### PR TITLE
Update place_order limits and docs

### DIFF
--- a/tests/test_mcp_server_tools_part1.txt
+++ b/tests/test_mcp_server_tools_part1.txt
@@ -7742,7 +7742,7 @@ class TestCreateDcaPlan:
             assert "DCA plan step" in call["kwargs"]["reason"]
 
     async def test_dry_run_false_max_amount_check(self, monkeypatch):
-        """dry_run=False validates max 1M KRW per step."""
+        """dry_run=False executes high-amount steps (> 1M KRW per step)."""
         tools = build_tools()
 
         # Create plan with each step > 1M KRW


### PR DESCRIPTION
Summary
- remove the hard 1M KRW cap in `place_order`/DCA steps while keeping dry_run safety and daily limit guardrails
- clarify `amount`/`total_amount` docstrings to note the market currency instead of KRW-only wording
- reinforce regression tests so high-value orders and daily-limit behavior stay predictable (including the legacy text doc update)

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Removed per-order amount limit (previously capped at 1,000,000 KRW)
  * Updated currency support to be market-agnostic rather than KRW-specific

* **Documentation**
  * Clarified parameter descriptions and safety limits to reflect multi-currency support
  * Updated references from KRW-only to market currency (e.g., KRW for Korean markets, USD for US equities)

* **Tests**
  * Expanded test coverage for high-amount orders across multiple asset classes (KR equities, US equities, crypto)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->