### PR TITLE
Fix KR tick adjustment logic and metadata

### DIFF
--- a/app/mcp_server/tick_size.py
+++ b/app/mcp_server/tick_size.py
@@ -3,28 +3,31 @@
 This module provides tick size adjustment logic following KRX's standard
 tick size table, which is required for placing limit orders on Korean stocks.
 
-Based on KRX market rules:
+Based on KRX market rules (2023+):
 - Buy orders: Round DOWN (floor) to nearest tick
 - Sell orders: Round UP (ceil) to nearest tick
 
-KRX Tick Size Table (KRW):
-| Price Range      | Tick Size |
-|------------------|------------|
-| ~2,000           | 1          |
-| 2,000-5,000      | 5          |
-| 5,000-20,000     | 10         |
-| 20,000-50,000     | 50         |
-| 50,000-200,000    | 100        |
-| 200,000-500,000   | 500        |
-| 500,000-1,000,000 | 1,000      |
-| 1,000,000~        | 5,000      |
+References:
+- KRX 유가증권시장 매매거래제도 일반: https://regulation.krx.co.kr/contents/RGL/03/03010100/RGL03010100.jsp
+- KRX 코스닥시장 매매거래제도 일반: https://regulation.krx.co.kr/contents/RGL/03/03020100/RGL03020100.jsp
+
+KRX Tick Size Table (KRW, 2023+):
+| Price Range       | Tick Size |
+|-------------------|-----------|
+| ~2,000            | 1         |
+| 2,000-5,000       | 5         |
+| 5,000-20,000      | 10        |
+| 20,000-50,000     | 50        |
+| 50,000-200,000    | 100       |
+| 200,000-500,000   | 500       |
+| 500,000~          | 1,000     |
 """
 
 import math
 
 
-def _get_tick_size(price: float) -> int:
-    """Return the tick size for a given price based on KRX rules.
+def get_tick_size_kr(price: float) -> int:
+    """Return the tick size for a given price based on KRX rules (2023+).
 
     Args:
         price: Stock price in KRW
@@ -44,10 +47,22 @@ def _get_tick_size(price: float) -> int:
         return 100
     elif price < 500000:
         return 500
-    elif price < 1000000:
-        return 1000
     else:
-        return 5000
+        return 1000
+
+
+def _get_tick_size(price: float) -> int:
+    """Return the tick size for a given price based on KRX rules.
+
+    DEPRECATED: Use get_tick_size_kr() instead.
+
+    Args:
+        price: Stock price in KRW
+
+    Returns:
+        Tick size in KRW
+    """
+    return get_tick_size_kr(price)
 
 
 def adjust_tick_size_kr(price: float, side: str = "buy") -> int:
@@ -69,8 +84,8 @@ def adjust_tick_size_kr(price: float, side: str = "buy") -> int:
         327000
         >>> adjust_tick_size_kr(327272, "sell")
         327500
-        >>> adjust_tick_size_kr(2392500, "buy")
-        2390000
+        >>> adjust_tick_size_kr(1098000, "buy")
+        1098000
         >>> adjust_tick_size_kr(15723, "buy")
         15720
     """

--- a/tests/test_tick_size.py
+++ b/tests/test_tick_size.py
@@ -2,32 +2,58 @@
 
 import pytest
 
-from app.mcp_server.tick_size import adjust_tick_size_kr
+from app.mcp_server.tick_size import adjust_tick_size_kr, get_tick_size_kr
+
+
+class TestGetTickSizeKR:
+    """Test cases for get_tick_size_kr function (KRX 2023+ rules)."""
+
+    def test_tick_size_below_2000(self):
+        assert get_tick_size_kr(1000) == 1
+        assert get_tick_size_kr(1999) == 1
+
+    def test_tick_size_2000_to_5000(self):
+        assert get_tick_size_kr(2000) == 5
+        assert get_tick_size_kr(3000) == 5
+        assert get_tick_size_kr(4999) == 5
+
+    def test_tick_size_5000_to_20000(self):
+        assert get_tick_size_kr(5000) == 10
+        assert get_tick_size_kr(10000) == 10
+        assert get_tick_size_kr(19999) == 10
+
+    def test_tick_size_20000_to_50000(self):
+        assert get_tick_size_kr(20000) == 50
+        assert get_tick_size_kr(35000) == 50
+        assert get_tick_size_kr(49999) == 50
+
+    def test_tick_size_50000_to_200000(self):
+        assert get_tick_size_kr(50000) == 100
+        assert get_tick_size_kr(100000) == 100
+        assert get_tick_size_kr(199999) == 100
+
+    def test_tick_size_200000_to_500000(self):
+        assert get_tick_size_kr(200000) == 500
+        assert get_tick_size_kr(350000) == 500
+        assert get_tick_size_kr(499999) == 500
+
+    def test_tick_size_500000_and_above(self):
+        assert get_tick_size_kr(500000) == 1000
+        assert get_tick_size_kr(1000000) == 1000
+        assert get_tick_size_kr(10000000) == 1000
 
 
 class TestKRXTickSizeAdjustment:
     """Test cases for KRX tick size adjustment function."""
 
     def test_buy_order_rounds_down(self):
-        """Buy orders should round DOWN to nearest tick."""
-        # Example from task: 327,272원 매수 → 327,000원
         assert adjust_tick_size_kr(327272, "buy") == 327000
-
-        # 2,392,500원 매수 → 2,390,000원
-        assert adjust_tick_size_kr(2392500, "buy") == 2390000
-
-        # 15,723원 매수 → 15,720원
+        assert adjust_tick_size_kr(2392500, "buy") == 2392000
         assert adjust_tick_size_kr(15723, "buy") == 15720
-
-        # 49,980원 매수 → 49,950원
         assert adjust_tick_size_kr(49980, "buy") == 49950
 
     def test_sell_order_rounds_up(self):
-        """Sell orders should round UP to nearest tick."""
-        # Example from task: 327,272원 매도 → 327,500원
         assert adjust_tick_size_kr(327272, "sell") == 327500
-
-        # Boundary value test - exactly at boundary should round up
         assert adjust_tick_size_kr(2000, "sell") == 2000
         assert adjust_tick_size_kr(5000, "sell") == 5000
         assert adjust_tick_size_kr(20000, "sell") == 20000
@@ -37,86 +63,67 @@ class TestKRXTickSizeAdjustment:
         assert adjust_tick_size_kr(1000000, "sell") == 1000000
 
     def test_boundary_values(self):
-        """Test exact boundary values for different price ranges."""
-        # ~2,000원 tick size 1
         assert adjust_tick_size_kr(1999, "buy") == 1999
         assert adjust_tick_size_kr(2000, "buy") == 2000
         assert adjust_tick_size_kr(2001, "buy") == 2000
         assert adjust_tick_size_kr(2000, "sell") == 2000
 
-        # 2,000-5,000원 tick size 5
         assert adjust_tick_size_kr(5000, "buy") == 5000
         assert adjust_tick_size_kr(5001, "buy") == 5000
         assert adjust_tick_size_kr(4999, "buy") == 4995
 
-        # 5,000-20,000원 tick size 10
         assert adjust_tick_size_kr(20000, "buy") == 20000
         assert adjust_tick_size_kr(20001, "buy") == 20000
         assert adjust_tick_size_kr(19999, "buy") == 19990
 
-        # 20,000-50,000원 tick size 50
         assert adjust_tick_size_kr(50000, "buy") == 50000
         assert adjust_tick_size_kr(50001, "buy") == 50000
         assert adjust_tick_size_kr(49999, "buy") == 49950
 
-        # 50,000-200,000원 tick size 100
         assert adjust_tick_size_kr(200000, "buy") == 200000
         assert adjust_tick_size_kr(200001, "buy") == 200000
         assert adjust_tick_size_kr(199999, "buy") == 199900
 
-        # 200,000-500,000원 tick size 500
         assert adjust_tick_size_kr(500000, "buy") == 500000
         assert adjust_tick_size_kr(500001, "buy") == 500000
         assert adjust_tick_size_kr(499999, "buy") == 499500
 
-        # 500,000-1,000,000원 tick size 1,000
         assert adjust_tick_size_kr(1000000, "buy") == 1000000
         assert adjust_tick_size_kr(1000001, "buy") == 1000000
         assert adjust_tick_size_kr(999999, "buy") == 999000
 
-        # 1,000,000원~ tick size 5,000
         assert adjust_tick_size_kr(1000000, "sell") == 1000000
-        assert adjust_tick_size_kr(1000001, "sell") == 1005000
+        assert adjust_tick_size_kr(1000001, "sell") == 1001000
         assert adjust_tick_size_kr(1500000, "sell") == 1500000
-        assert adjust_tick_size_kr(1500001, "sell") == 1505000
+        assert adjust_tick_size_kr(1500001, "sell") == 1501000
 
     def test_tick_sizes_by_range(self):
-        """Verify correct tick size for each price range."""
-        # ~2,000원: tick size 1
         assert adjust_tick_size_kr(1000, "buy") == 1000
         assert adjust_tick_size_kr(1500, "buy") == 1500
 
-        # 2,000-5,000원: tick size 5
         assert adjust_tick_size_kr(2500, "buy") == 2500
         assert adjust_tick_size_kr(3000, "buy") == 3000
 
-        # 5,000-20,000원: tick size 10
         assert adjust_tick_size_kr(7500, "buy") == 7500
         assert adjust_tick_size_kr(10000, "buy") == 10000
 
-        # 20,000-50,000원: tick size 50
         assert adjust_tick_size_kr(30000, "buy") == 30000
         assert adjust_tick_size_kr(40000, "buy") == 40000
 
-        # 50,000-200,000원: tick size 100
         assert adjust_tick_size_kr(75000, "buy") == 75000
         assert adjust_tick_size_kr(100000, "buy") == 100000
         assert adjust_tick_size_kr(150000, "buy") == 150000
 
-        # 200,000-500,000원: tick size 500
         assert adjust_tick_size_kr(250000, "buy") == 250000
         assert adjust_tick_size_kr(350000, "buy") == 350000
 
-        # 500,000-1,000,000원: tick size 1,000
         assert adjust_tick_size_kr(750000, "buy") == 750000
         assert adjust_tick_size_kr(900000, "buy") == 900000
 
-        # 1,000,000원~: tick size 5,000
         assert adjust_tick_size_kr(1200000, "buy") == 1200000
         assert adjust_tick_size_kr(2000000, "buy") == 2000000
 
     def test_invalid_side_raises_error(self):
-        """Invalid side parameter should raise ValueError."""
         with pytest.raises(ValueError, match="side must be 'buy' or 'sell'"):
             adjust_tick_size_kr(1000, "invalid")
 
@@ -124,7 +131,6 @@ class TestKRXTickSizeAdjustment:
             adjust_tick_size_kr(1000, "")
 
     def test_negative_price_raises_error(self):
-        """Negative price should raise ValueError."""
         with pytest.raises(ValueError, match="Price must be non-negative"):
             adjust_tick_size_kr(-100, "buy")
 
@@ -132,15 +138,47 @@ class TestKRXTickSizeAdjustment:
             adjust_tick_size_kr(-1000, "sell")
 
     def test_minimum_price(self):
-        """Price adjustment should ensure minimum of 1 KRW."""
         assert adjust_tick_size_kr(0.5, "buy") == 1
         assert adjust_tick_size_kr(0.1, "sell") == 1
 
     def test_high_value_prices(self):
-        """Test very high prices use largest tick size."""
-        # 10 million KRW
         assert adjust_tick_size_kr(10000000, "buy") == 10000000
-        # 10.5 million KRW
         assert adjust_tick_size_kr(10500000, "sell") == 10500000
-        # 50 million KRW
         assert adjust_tick_size_kr(50000000, "buy") == 50000000
+
+
+class TestPR139Regression:
+    """Test cases for PR #139 regression fix (KRX 2023+ rules).
+
+    Verify that prices >= 500,000 use 1,000 tick size (not 5,000).
+    """
+
+    def test_no_adjustment_valid_prices(self):
+        assert adjust_tick_size_kr(1_098_000, "buy") == 1_098_000
+        assert adjust_tick_size_kr(312_000, "buy") == 312_000
+        assert adjust_tick_size_kr(352_000, "buy") == 352_000
+        assert adjust_tick_size_kr(50_100, "buy") == 50_100
+
+    def test_adjustment_required_buy(self):
+        assert adjust_tick_size_kr(1_098_500, "buy") == 1_098_000
+        assert adjust_tick_size_kr(312_300, "buy") == 312_000
+
+    def test_adjustment_required_sell(self):
+        assert adjust_tick_size_kr(312_300, "sell") == 312_500
+
+    def test_boundary_500000(self):
+        assert adjust_tick_size_kr(500_000, "buy") == 500_000
+        assert adjust_tick_size_kr(499_999, "buy") == 499_500
+        assert adjust_tick_size_kr(200_000, "buy") == 200_000
+
+    def test_million_plus_prices_use_1000_tick(self):
+        assert get_tick_size_kr(1_000_000) == 1000
+        assert get_tick_size_kr(1_098_000) == 1000
+        assert get_tick_size_kr(2_392_500) == 1000
+        assert get_tick_size_kr(10_000_000) == 1000
+
+    def test_million_plus_adjustment(self):
+        assert adjust_tick_size_kr(1_098_500, "buy") == 1_098_000
+        assert adjust_tick_size_kr(1_098_500, "sell") == 1_099_000
+        assert adjust_tick_size_kr(2_392_500, "buy") == 2_392_000
+        assert adjust_tick_size_kr(2_392_500, "sell") == 2_393_000


### PR DESCRIPTION
Summary
- align `get_tick_size_kr`/`adjust_tick_size_kr` with the 2023+ KRX tick table so prices ≥500K use 1,000 KRW steps and no longer auto-adjust valid ticks
- log only when a limit order price changes, flag tick metadata only when adjustments occur, and keep DCA/order previews lean when ticks already match
- expand tests to cover tick sizes, PR #139 regression cases, and metadata behavior in KR orders

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated tick-size calculation to match KRX 2023+ pricing tiers.

* **Bug Fixes**
  * More accurate tick-adjustment behavior and logging for Korean equity orders and plans.
  * DCA plan/execute records only include tick-adjustment metadata when prices were actually adjusted.

* **Documentation**
  * Tick-size docs updated to reference 2023+ rules and revised tier table.

* **Tests**
  * Added comprehensive tests covering tick sizing, adjustments, boundaries, and regression cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->