### PR TITLE
Enforce role-based access for KIS endpoints

### DIFF
--- a/app/routers/dependencies.py
+++ b/app/routers/dependencies.py
@@ -2,13 +2,16 @@
 Common router dependencies and constants.
 """
 
+from collections.abc import Callable
+
 from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.constants import AUTH_REQUIRED_MESSAGE
+from app.auth.role_hierarchy import has_min_role
 from app.auth.web_router import get_current_user_from_session
 from app.core.db import get_db
-from app.models.trading import User
+from app.models.trading import User, UserRole
 
 
 async def get_authenticated_user(
@@ -27,3 +30,35 @@ async def get_authenticated_user(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail=AUTH_REQUIRED_MESSAGE,
     )
+
+
+def require_min_role_user(min_role: UserRole) -> Callable:
+    """Factory that creates a dependency requiring a minimum role.
+
+    Returns a dependency that:
+    1. Gets the authenticated user
+    2. Checks if the user has at least the required role
+    3. Returns the user if authorized, raises HTTPException(403) otherwise
+
+    Usage:
+        require_trader_user = require_min_role_user(UserRole.trader)
+
+        @router.get("/protected")
+        async def protected_route(user: User = Depends(require_trader_user)):
+            ...
+    """
+
+    async def _dependency(request: Request, db: AsyncSession = Depends(get_db)) -> User:
+        user = await get_authenticated_user(request, db)
+        if not has_min_role(user.role, min_role):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"이 기능에 접근하려면 '{min_role.value}' 이상의 권한이 필요합니다.",
+            )
+        return user
+
+    return _dependency
+
+
+# Pre-configured dependencies for common role requirements
+require_trader_user = require_min_role_user(UserRole.trader)

--- a/app/routers/kis_domestic_trading.py
+++ b/app/routers/kis_domestic_trading.py
@@ -3,6 +3,8 @@ KIS 국내주식 자동 매매 웹 인터페이스 라우터
 - 보유 주식 조회 (KIS + 수동 잔고 통합)
 - AI 분석 실행
 - 자동 매수/매도 주문 (Placeholder)
+
+접근 정책: trader, admin만 접근 가능 (viewer 차단)
 """
 
 import logging
@@ -14,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.db import get_db
 from app.core.templates import templates
 from app.models.trading import User
-from app.routers.dependencies import get_authenticated_user
+from app.routers.dependencies import require_trader_user
 from app.services.kis import KISClient
 from app.services.merged_portfolio_service import MergedPortfolioService
 
@@ -23,14 +25,15 @@ router = APIRouter(prefix="/kis-domestic-trading", tags=["KIS Domestic Trading"]
 
 
 @router.get("/", response_class=HTMLResponse)
-async def kis_domestic_trading_dashboard(request: Request):
-    """KIS 국내주식 자동 매매 대시보드 페이지"""
-    user = getattr(request.state, "user", None)
+async def kis_domestic_trading_dashboard(
+    request: Request, current_user: User = Depends(require_trader_user)
+):
+    """KIS 국내주식 자동 매매 대시보드 페이지 (trader/admin 전용)"""
     return templates.TemplateResponse(
         "kis_domestic_trading_dashboard.html",
         {
             "request": request,
-            "user": user,
+            "user": current_user,
         },
     )
 
@@ -38,7 +41,7 @@ async def kis_domestic_trading_dashboard(request: Request):
 @router.get("/api/my-stocks")
 async def get_my_domestic_stocks(
     db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(get_authenticated_user),
+    current_user: User = Depends(require_trader_user),
 ):
     try:
         kis = KISClient()
@@ -109,10 +112,12 @@ from app.core.celery_app import celery_app
 
 
 @router.post("/api/analyze-stocks")
-async def analyze_my_domestic_stocks():
+async def analyze_my_domestic_stocks(current_user: User = Depends(require_trader_user)):
     """보유 국내 주식 AI 분석 실행 (Celery)"""
     try:
-        async_result = celery_app.send_task("kis.run_analysis_for_my_domestic_stocks")
+        async_result = celery_app.send_task(
+            "kis.run_analysis_for_my_domestic_stocks", args=[current_user.id]
+        )
 
         return {
             "success": True,
@@ -124,7 +129,9 @@ async def analyze_my_domestic_stocks():
 
 
 @router.get("/api/analyze-task/{task_id}")
-async def get_analyze_task_status(task_id: str):
+async def get_analyze_task_status(
+    task_id: str, current_user: User = Depends(require_trader_user)
+):
     """Celery 작업 상태 조회 API"""
 
     result = celery_app.AsyncResult(task_id)
@@ -149,10 +156,12 @@ async def get_analyze_task_status(task_id: str):
 
 
 @router.post("/api/buy-orders")
-async def execute_buy_orders():
+async def execute_buy_orders(current_user: User = Depends(require_trader_user)):
     """보유 국내 주식 자동 매수 주문 실행 (Celery)"""
     try:
-        async_result = celery_app.send_task("kis.execute_domestic_buy_orders")
+        async_result = celery_app.send_task(
+            "kis.execute_domestic_buy_orders", args=[current_user.id]
+        )
         return {
             "success": True,
             "message": "매수 주문이 시작되었습니다.",
@@ -163,10 +172,12 @@ async def execute_buy_orders():
 
 
 @router.post("/api/sell-orders")
-async def execute_sell_orders():
+async def execute_sell_orders(current_user: User = Depends(require_trader_user)):
     """보유 국내 주식 자동 매도 주문 실행 (Celery)"""
     try:
-        async_result = celery_app.send_task("kis.execute_domestic_sell_orders")
+        async_result = celery_app.send_task(
+            "kis.execute_domestic_sell_orders", args=[current_user.id]
+        )
         return {
             "success": True,
             "message": "매도 주문이 시작되었습니다.",
@@ -177,9 +188,11 @@ async def execute_sell_orders():
 
 
 @router.post("/api/automation/per-stock")
-async def run_per_stock_automation():
+async def run_per_stock_automation(current_user: User = Depends(require_trader_user)):
     """보유 종목별 자동 실행 (분석 -> 매수 -> 매도)"""
-    task = celery_app.send_task("kis.run_per_domestic_stock_automation")
+    task = celery_app.send_task(
+        "kis.run_per_domestic_stock_automation", args=[current_user.id]
+    )
     return {
         "success": True,
         "message": "종목별 자동 실행이 시작되었습니다.",
@@ -188,21 +201,27 @@ async def run_per_stock_automation():
 
 
 @router.post("/api/analyze-stock/{symbol}")
-async def analyze_stock(symbol: str):
+async def analyze_stock(symbol: str, current_user: User = Depends(require_trader_user)):
     """단일 종목 분석 요청"""
-    task = celery_app.send_task("kis.analyze_domestic_stock_task", args=[symbol])
+    task = celery_app.send_task(
+        "kis.analyze_domestic_stock_task", args=[symbol, current_user.id]
+    )
     return {"success": True, "message": f"{symbol} 분석 요청 완료", "task_id": task.id}
 
 
 @router.post("/api/buy-order/{symbol}")
-async def buy_order(symbol: str):
+async def buy_order(symbol: str, current_user: User = Depends(require_trader_user)):
     """단일 종목 매수 요청"""
-    task = celery_app.send_task("kis.execute_domestic_buy_order_task", args=[symbol])
+    task = celery_app.send_task(
+        "kis.execute_domestic_buy_order_task", args=[symbol, current_user.id]
+    )
     return {"success": True, "message": f"{symbol} 매수 요청 완료", "task_id": task.id}
 
 
 @router.post("/api/sell-order/{symbol}")
-async def sell_order(symbol: str):
+async def sell_order(symbol: str, current_user: User = Depends(require_trader_user)):
     """단일 종목 매도 요청"""
-    task = celery_app.send_task("kis.execute_domestic_sell_order_task", args=[symbol])
+    task = celery_app.send_task(
+        "kis.execute_domestic_sell_order_task", args=[symbol, current_user.id]
+    )
     return {"success": True, "message": f"{symbol} 매도 요청 완료", "task_id": task.id}

--- a/app/templates/nav.html
+++ b/app/templates/nav.html
@@ -25,6 +25,7 @@
                         <i class="bi bi-currency-bitcoin"></i> Upbit 거래
                     </a>
                 </li>
+                {% if user and user.role and user.role.value in ('trader', 'admin') %}
                 <li class="nav-item">
                     <a class="nav-link" href="/kis-domestic-trading/">
                         <i class="bi bi-graph-up-arrow"></i> KIS 국내
@@ -35,6 +36,7 @@
                         <i class="bi bi-globe"></i> KIS 해외
                     </a>
                 </li>
+                {% endif %}
                 <li class="nav-item">
                     <a class="nav-link" href="/orderbook/">
                         <i class="bi bi-bookmark-check"></i> 실시간 호가

--- a/tests/test_kis_tasks.py
+++ b/tests/test_kis_tasks.py
@@ -2298,3 +2298,205 @@ class TestOverseasManualHoldings:
 
         # 결과에도 AAPL은 한 번만 포함
         assert len(result["results"]) == 1
+
+
+def test_run_per_domestic_stock_automation_uses_passed_user_id(monkeypatch):
+    """run_per_domestic_stock_automation는 전달받은 user_id를 사용해야 한다."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from app.tasks import kis as kis_tasks
+
+    captured = {"user_id": None}
+
+    class DummyAnalyzer:
+        async def close(self):
+            return None
+
+    class DummyKIS:
+        async def fetch_my_stocks(self):
+            return []
+
+    class MockManualService:
+        def __init__(self, db):
+            pass
+
+        async def get_holdings_by_user(self, user_id, market_type):
+            captured["user_id"] = user_id
+            return []
+
+    mock_db_session = MagicMock()
+    mock_db_session.__aenter__ = AsyncMock(return_value=MagicMock())
+    mock_db_session.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("app.core.db.AsyncSessionLocal", return_value=mock_db_session),
+        patch(
+            "app.services.manual_holdings_service.ManualHoldingsService",
+            MockManualService,
+        ),
+    ):
+        monkeypatch.setattr(kis_tasks, "KISClient", DummyKIS)
+        monkeypatch.setattr(kis_tasks, "KISAnalyzer", DummyAnalyzer)
+        monkeypatch.setattr(
+            kis_tasks.run_per_domestic_stock_automation,
+            "update_state",
+            lambda *_, **__: None,
+            raising=False,
+        )
+
+        result = kis_tasks.run_per_domestic_stock_automation.apply(args=(777,)).result
+
+    assert result["status"] == "completed"
+    assert captured["user_id"] == 777
+
+
+def test_run_per_domestic_stock_automation_defaults_to_user_id_1(monkeypatch):
+    """run_per_domestic_stock_automation는 user_id 미전달 시 1을 사용해야 한다."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from app.tasks import kis as kis_tasks
+
+    captured = {"user_id": None}
+
+    class DummyAnalyzer:
+        async def close(self):
+            return None
+
+    class DummyKIS:
+        async def fetch_my_stocks(self):
+            return []
+
+    class MockManualService:
+        def __init__(self, db):
+            pass
+
+        async def get_holdings_by_user(self, user_id, market_type):
+            captured["user_id"] = user_id
+            return []
+
+    mock_db_session = MagicMock()
+    mock_db_session.__aenter__ = AsyncMock(return_value=MagicMock())
+    mock_db_session.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("app.core.db.AsyncSessionLocal", return_value=mock_db_session),
+        patch(
+            "app.services.manual_holdings_service.ManualHoldingsService",
+            MockManualService,
+        ),
+    ):
+        monkeypatch.setattr(kis_tasks, "KISClient", DummyKIS)
+        monkeypatch.setattr(kis_tasks, "KISAnalyzer", DummyAnalyzer)
+        monkeypatch.setattr(
+            kis_tasks.run_per_domestic_stock_automation,
+            "update_state",
+            lambda *_, **__: None,
+            raising=False,
+        )
+
+        result = kis_tasks.run_per_domestic_stock_automation.apply().result
+
+    assert result["status"] == "completed"
+    assert captured["user_id"] == 1
+
+
+def test_run_per_overseas_stock_automation_uses_passed_user_id(monkeypatch):
+    """run_per_overseas_stock_automation는 전달받은 user_id를 사용해야 한다."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from app.analysis import service_analyzers
+    from app.tasks import kis as kis_tasks
+
+    captured = {"user_id": None}
+
+    class DummyAnalyzer:
+        async def close(self):
+            return None
+
+    class DummyKIS:
+        async def fetch_my_overseas_stocks(self):
+            return []
+
+    class MockManualService:
+        def __init__(self, db):
+            pass
+
+        async def get_holdings_by_user(self, user_id, market_type):
+            captured["user_id"] = user_id
+            return []
+
+    mock_db_session = MagicMock()
+    mock_db_session.__aenter__ = AsyncMock(return_value=MagicMock())
+    mock_db_session.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("app.core.db.AsyncSessionLocal", return_value=mock_db_session),
+        patch(
+            "app.services.manual_holdings_service.ManualHoldingsService",
+            MockManualService,
+        ),
+    ):
+        monkeypatch.setattr(kis_tasks, "KISClient", DummyKIS)
+        monkeypatch.setattr(service_analyzers, "YahooAnalyzer", DummyAnalyzer)
+        monkeypatch.setattr(
+            kis_tasks.run_per_overseas_stock_automation,
+            "update_state",
+            lambda *_, **__: None,
+            raising=False,
+        )
+
+        result = kis_tasks.run_per_overseas_stock_automation.apply(args=(888,)).result
+
+    assert result["status"] == "completed"
+    assert captured["user_id"] == 888
+
+
+def test_run_per_overseas_stock_automation_defaults_to_user_id_1(monkeypatch):
+    """run_per_overseas_stock_automation는 user_id 미전달 시 1을 사용해야 한다."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from app.analysis import service_analyzers
+    from app.tasks import kis as kis_tasks
+
+    captured = {"user_id": None}
+
+    class DummyAnalyzer:
+        async def close(self):
+            return None
+
+    class DummyKIS:
+        async def fetch_my_overseas_stocks(self):
+            return []
+
+    class MockManualService:
+        def __init__(self, db):
+            pass
+
+        async def get_holdings_by_user(self, user_id, market_type):
+            captured["user_id"] = user_id
+            return []
+
+    mock_db_session = MagicMock()
+    mock_db_session.__aenter__ = AsyncMock(return_value=MagicMock())
+    mock_db_session.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("app.core.db.AsyncSessionLocal", return_value=mock_db_session),
+        patch(
+            "app.services.manual_holdings_service.ManualHoldingsService",
+            MockManualService,
+        ),
+    ):
+        monkeypatch.setattr(kis_tasks, "KISClient", DummyKIS)
+        monkeypatch.setattr(service_analyzers, "YahooAnalyzer", DummyAnalyzer)
+        monkeypatch.setattr(
+            kis_tasks.run_per_overseas_stock_automation,
+            "update_state",
+            lambda *_, **__: None,
+            raising=False,
+        )
+
+        result = kis_tasks.run_per_overseas_stock_automation.apply().result
+
+    assert result["status"] == "completed"
+    assert captured["user_id"] == 1

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -185,3 +185,217 @@ class TestKISOverseasTradingRouter:
         assert result["success"] is True
         assert result["usd_balance"] == 321.5
         assert call_state["integrated_called"] is False
+
+
+class TestKISRoleBasedAccess:
+    """Test role-based access control for KIS endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_require_min_role_user_blocks_viewer(self, monkeypatch):
+        """viewer role should get 403 on trader-required dependency."""
+        from app.models.trading import UserRole
+        from app.routers import dependencies as router_dependencies
+
+        viewer_user = MagicMock()
+        viewer_user.role = UserRole.viewer
+
+        async def fake_get_authenticated_user(request, db):
+            return viewer_user
+
+        monkeypatch.setattr(
+            router_dependencies,
+            "get_authenticated_user",
+            fake_get_authenticated_user,
+        )
+
+        dep = router_dependencies.require_min_role_user(UserRole.trader)
+        with pytest.raises(HTTPException) as exc_info:
+            await dep(request=MagicMock(), db=AsyncMock())
+
+        assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("role", ["trader", "admin"])
+    async def test_require_min_role_user_allows_trader_and_admin(
+        self, role, monkeypatch
+    ):
+        """trader/admin should pass trader-required dependency."""
+        from app.models.trading import UserRole
+        from app.routers import dependencies as router_dependencies
+
+        allowed_user = MagicMock()
+        allowed_user.role = UserRole(role)
+
+        async def fake_get_authenticated_user(request, db):
+            return allowed_user
+
+        monkeypatch.setattr(
+            router_dependencies,
+            "get_authenticated_user",
+            fake_get_authenticated_user,
+        )
+
+        dep = router_dependencies.require_min_role_user(UserRole.trader)
+        result = await dep(request=MagicMock(), db=AsyncMock())
+
+        assert result is allowed_user
+
+    @pytest.mark.asyncio
+    async def test_require_min_role_user_propagates_unauthenticated(
+        self, monkeypatch
+    ):
+        """Unauthenticated user should get 401 from auth dependency."""
+        from app.models.trading import UserRole
+        from app.routers import dependencies as router_dependencies
+
+        async def fake_get_authenticated_user(request, db):
+            raise HTTPException(status_code=401, detail="로그인이 필요합니다.")
+
+        monkeypatch.setattr(
+            router_dependencies,
+            "get_authenticated_user",
+            fake_get_authenticated_user,
+        )
+
+        dep = router_dependencies.require_min_role_user(UserRole.trader)
+        with pytest.raises(HTTPException) as exc_info:
+            await dep(request=MagicMock(), db=AsyncMock())
+
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_trader_can_access_kis_endpoints(self, monkeypatch):
+        """trader role should be able to access KIS endpoints."""
+        from app.models.trading import User, UserRole
+        from app.routers import kis_domestic_trading
+
+        trader_user = MagicMock(spec=User)
+        trader_user.id = 1
+        trader_user.role = UserRole.trader
+
+        class FakeKISClient:
+            async def inquire_domestic_cash_balance(self):
+                return {"dnca_tot_amt": "1000000"}
+
+        class FakeMergedPortfolioService:
+            def __init__(self, db):
+                self.db = db
+
+            async def get_merged_portfolio_domestic(self, user_id, kis):
+                return []
+
+        monkeypatch.setattr(kis_domestic_trading, "KISClient", FakeKISClient)
+        monkeypatch.setattr(
+            kis_domestic_trading,
+            "MergedPortfolioService",
+            FakeMergedPortfolioService,
+        )
+
+        result = await kis_domestic_trading.get_my_domestic_stocks(
+            db=AsyncMock(), current_user=trader_user
+        )
+
+        assert result["success"] is True
+        assert result["krw_balance"] == 1000000.0
+
+    @pytest.mark.asyncio
+    async def test_admin_can_access_kis_endpoints(self, monkeypatch):
+        """admin role should be able to access KIS endpoints."""
+        from app.models.trading import User, UserRole
+        from app.routers import kis_overseas_trading
+
+        admin_user = MagicMock(spec=User)
+        admin_user.id = 1
+        admin_user.role = UserRole.admin
+
+        class FakeKISClient:
+            async def inquire_overseas_margin(self):
+                return [
+                    {
+                        "natn_name": "미국",
+                        "crcy_cd": "USD",
+                        "frcr_dncl_amt1": "500.0",
+                        "frcr_gnrl_ord_psbl_amt": "400.0",
+                    }
+                ]
+
+        class FakeMergedPortfolioService:
+            def __init__(self, db):
+                self.db = db
+
+            async def get_merged_portfolio_overseas(self, user_id, kis):
+                return []
+
+        monkeypatch.setattr(kis_overseas_trading, "KISClient", FakeKISClient)
+        monkeypatch.setattr(
+            kis_overseas_trading,
+            "MergedPortfolioService",
+            FakeMergedPortfolioService,
+        )
+
+        result = await kis_overseas_trading.get_my_overseas_stocks(
+            db=AsyncMock(), current_user=admin_user
+        )
+
+        assert result["success"] is True
+        assert result["usd_balance"] == 500.0
+
+    @pytest.mark.asyncio
+    async def test_task_trigger_passes_user_id_domestic(self, monkeypatch):
+        """Domestic task trigger should pass current_user.id to Celery."""
+        from app.models.trading import User, UserRole
+        from app.routers import kis_domestic_trading
+
+        trader_user = MagicMock(spec=User)
+        trader_user.id = 42
+        trader_user.role = UserRole.trader
+
+        captured_args = {}
+
+        class FakeAsyncResult:
+            id = "test-task-id"
+
+        def fake_send_task(task_name, args=None):
+            captured_args["task_name"] = task_name
+            captured_args["args"] = args
+            return FakeAsyncResult()
+
+        monkeypatch.setattr(
+            kis_domestic_trading.celery_app, "send_task", fake_send_task
+        )
+
+        await kis_domestic_trading.analyze_my_domestic_stocks(current_user=trader_user)
+
+        assert captured_args["task_name"] == "kis.run_analysis_for_my_domestic_stocks"
+        assert captured_args["args"] == [42]
+
+    @pytest.mark.asyncio
+    async def test_task_trigger_passes_user_id_overseas(self, monkeypatch):
+        """Overseas task trigger should pass current_user.id to Celery."""
+        from app.models.trading import User, UserRole
+        from app.routers import kis_overseas_trading
+
+        trader_user = MagicMock(spec=User)
+        trader_user.id = 99
+        trader_user.role = UserRole.trader
+
+        captured_args = {}
+
+        class FakeAsyncResult:
+            id = "test-task-id"
+
+        def fake_send_task(task_name, args=None):
+            captured_args["task_name"] = task_name
+            captured_args["args"] = args
+            return FakeAsyncResult()
+
+        monkeypatch.setattr(
+            kis_overseas_trading.celery_app, "send_task", fake_send_task
+        )
+
+        await kis_overseas_trading.analyze_stock(
+            symbol="AAPL", current_user=trader_user
+        )
+
+        assert captured_args["task_name"] == "kis.analyze_overseas_stock_task"
+        assert captured_args["args"] == ["AAPL", 99]


### PR DESCRIPTION
Summary
- tighten viewer/trader/admin gating across the KIS domestic/overseas routers and dependency helpers
- verify Celery triggers and tasks propagate the authenticated `current_user.id` while preserving the MCP fallback
- clean up unused `_effective_user_id` helpers, keep the nav menu split by role, and expand router/task tests to cover new scenarios

Testing
- Not run (not requested)