### PR TITLE
Fix US screener fields and add recommend_stocks exclude_held toggle

### DIFF
--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -137,6 +137,7 @@ def register_analysis_tools(mcp: FastMCP) -> None:
         market: str = "kr",
         asset_type: str | None = None,
         category: str | None = None,
+        strategy: str | None = None,
         sort_by: str = "volume",
         sort_order: str = "desc",
         min_market_cap: float | None = None,
@@ -150,6 +151,7 @@ def register_analysis_tools(mcp: FastMCP) -> None:
             market=market,  # type: ignore[arg-type]
             asset_type=asset_type,  # type: ignore[arg-type]
             category=category,
+            strategy=strategy,
             sort_by=sort_by,  # type: ignore[arg-type]
             sort_order=sort_order,  # type: ignore[arg-type]
             min_market_cap=min_market_cap,
@@ -173,6 +175,7 @@ def register_analysis_tools(mcp: FastMCP) -> None:
         exclude_symbols: list[str] | None = None,
         sectors: list[str] | None = None,
         max_positions: int = 5,
+        exclude_held: bool = True,
     ) -> dict:
         return await recommend_stocks_impl(
             budget=budget,
@@ -181,6 +184,7 @@ def register_analysis_tools(mcp: FastMCP) -> None:
             exclude_symbols=exclude_symbols,
             sectors=sectors,
             max_positions=max_positions,
+            exclude_held=exclude_held,
         )
 
     @mcp.tool(

--- a/app/mcp_server/tooling/analysis_screening.py
+++ b/app/mcp_server/tooling/analysis_screening.py
@@ -407,6 +407,7 @@ async def _recommend_stocks_impl(
     exclude_symbols: list[str] | None,
     sectors: list[str] | None,
     max_positions: int,
+    exclude_held: bool = True,
     top_stocks_fallback: Any,
 ) -> dict[str, Any]:
     return await _recommend_stocks_impl_core(
@@ -416,6 +417,7 @@ async def _recommend_stocks_impl(
         exclude_symbols=exclude_symbols,
         sectors=sectors,
         max_positions=max_positions,
+        exclude_held=exclude_held,
         top_stocks_fallback=top_stocks_fallback,
         screen_kr_fn=_screen_kr,
         screen_crypto_fn=_screen_crypto,


### PR DESCRIPTION
Summary
- update `_screen_us` to map yfinance screener fields correctly, reject rows lacking valid prices, and keep RSI enrichment on top candidates
- ensure crypto, KR, and US screeners always calculate RSI and expose 24h trade amount/margin-aware market cap fallbacks
- add `exclude_held` plumbing to `recommend_stocks`, populate crypto liquidity scores, and expose strategy presets for `screen_stocks`

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added strategy presets for stock screening: oversold, momentum, and high_volume options
  * New parameter to include or exclude already-held stocks from recommendation results
  * Enhanced crypto asset valuation now uses liquidity metrics as the primary valuation indicator

* **Improvements**
  * Better data normalization and mapping across crypto, US, and Korean markets
  * Improved handling of trade volume data for crypto assets during analysis and sorting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->