### PR TITLE
Fix get_disclosures symbol handling and index loading

### DIFF
--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -59,9 +59,9 @@ def register_analysis_tools(mcp: FastMCP) -> None:
         name="get_disclosures",
         description=(
             "Get DART (OPENDART) disclosure filings for Korean corporations. "
-            "Supports both 6-digit corp codes (e.g., '005930') and Korean company names "
-            "(e.g., '삼성전자'). Returns filing date, report name, report number, and "
-            "corporation name."
+            "Supports Korean company names (삼성전자), 6-digit stock codes (005930), "
+            "and 8-digit DART corp codes. Returns filing date, report name, report number, "
+            "and corporation name."
         ),
     )
     async def get_disclosures(

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -180,8 +180,9 @@ async def get_disclosures_impl(
             "success": False,
             "error": "DART functionality not available (dart_fss package not installed)",
         }
+    normalized_symbol = (symbol or "").strip().strip("'\"")
     try:
-        result = await list_filings(symbol, days, limit, report_type)
+        result = await list_filings(normalized_symbol, days, limit, report_type)
         if isinstance(result, list):
             return {"success": True, "filings": result}
         return result
@@ -189,7 +190,7 @@ async def get_disclosures_impl(
         return {
             "success": False,
             "error": str(exc),
-            "symbol": symbol,
+            "symbol": normalized_symbol,
         }
 
 
@@ -337,7 +338,9 @@ async def analyze_portfolio_impl(
                 errors.append(f"{sym}: {str(exc)}")
                 return {"symbol": sym, "error": str(exc)}
 
-    analyze_results = await asyncio.gather(*[_analyze_one(s) for s in normalized_symbols])
+    analyze_results = await asyncio.gather(
+        *[_analyze_one(s) for s in normalized_symbols]
+    )
 
     success_count = 0
     fail_count = 0
@@ -363,7 +366,9 @@ async def screen_stocks_impl(
     market: Literal["kr", "kospi", "kosdaq", "us", "crypto"] = "kr",
     asset_type: Literal["stock", "etf", "etn"] | None = None,
     category: str | None = None,
-    sort_by: Literal["volume", "market_cap", "change_rate", "dividend_yield"] = "volume",
+    sort_by: Literal[
+        "volume", "market_cap", "change_rate", "dividend_yield"
+    ] = "volume",
     sort_order: Literal["asc", "desc"] = "desc",
     min_market_cap: float | None = None,
     max_per: float | None = None,

--- a/app/services/disclosures/dart.py
+++ b/app/services/disclosures/dart.py
@@ -7,18 +7,15 @@ import enum
 import dart_fss
 
 from app.core.config import settings
-from data.disclosures.dart_corp_index import NAME_TO_CORP, prime_index
+from data.disclosures.dart_corp_index import (
+    NAME_TO_CORP,
+    prime_index,
+    resolve_symbol,
+)
 
 
 class ReportType(str, enum.Enum):
-    """DART 공시 유형 (Report Type).
-
-    - periodic: 정기 (반기/사업/분기보고서)
-    - major_events: 주요사항 (주요사항보고)
-    - issuance: 발행 (증권발행실적보고)
-    - shareholding: 지분 (지분공시)
-    - other: 기타 (기타공시)
-    """
+    """DART 공시 유형 (Report Type)."""
 
     periodic = "A"
     major_events = "B"
@@ -37,28 +34,51 @@ KOREAN_REPORT_TYPE_MAP: dict[str, ReportType] = {
 
 
 async def list_filings(
-    korean_name: str,
-    days: int = 3,
+    symbol: str,
+    days: int = 30,
     limit: int = 20,
     report_type: str | None = None,
 ) -> list[dict] | dict:
     """Query DART API for corporation filings.
 
     Args:
-        korean_name: Korean company name (e.g., "삼성전자")
-        days: Number of days to look back (default: 3, max: 365)
+        symbol: Korean company name (삼성전자), 6-digit stock code (005930),
+                or 8-digit DART corp code.
+        days: Number of days to look back (default: 30, max: 365)
         limit: Maximum number of filings to return (default: 20, max: 100)
         report_type: Filter by report type ("정기", "주요사항", "발행", "지분", "기타")
 
     Returns:
-        List of filing records with date, report name, report number, corp name.
+        List of filing records with date, report name, report number, corp name,
+        or dict with success=False and error message on failure.
     """
-    if not NAME_TO_CORP:
-        await prime_index()
+    if not settings.opendart_api_key:
+        return {
+            "success": False,
+            "error_code": "missing_api_key",
+            "error": "OPENDART_API_KEY not set. Please set environment variable.",
+            "filings": [],
+        }
 
-    corp_code = NAME_TO_CORP.get(korean_name)
+    if not NAME_TO_CORP:
+        try:
+            await prime_index()
+        except Exception as exc:
+            return {
+                "success": False,
+                "error_code": "index_load_failed",
+                "error": f"DART index loading failed: {exc}",
+                "filings": [],
+            }
+
+    corp_code, corp_name = resolve_symbol(symbol)
     if not corp_code:
-        return []
+        return {
+            "success": False,
+            "error_code": "symbol_not_resolved",
+            "error": f"Cannot resolve symbol '{symbol}'. Use Korean name (삼성전자), 6-digit stock code (005930), or 8-digit DART corp code.",
+            "filings": [],
+        }
 
     bgn = (dt.date.today() - dt.timedelta(days=days)).strftime("%Y%m%d")
     end = dt.date.today().strftime("%Y%m%d")
@@ -80,29 +100,27 @@ async def list_filings(
             page_count=min(limit, 100),
         )
         return [
-            (r.rcept_dt, r.report_nm, r.rcept_no, korean_name) for r in reports[:limit]
+            (r.rcept_dt, r.report_nm, r.rcept_no, corp_name) for r in reports[:limit]
         ]
-
-    if not settings.opendart_api_key:
-        return {
-            "success": False,
-            "error": "OPENDART_API_KEY not set. Please set environment variable.",
-            "filings": [],
-        }
 
     try:
         results = await asyncio.to_thread(fetch_sync)
     except Exception as exc:
-        return {"success": False, "error": str(exc), "filings": []}
+        return {
+            "success": False,
+            "error_code": "dart_api_failed",
+            "error": str(exc),
+            "filings": [],
+        }
 
     filings = []
-    for filing_date, report_nm, rcept_no, korean_name in results:
+    for filing_date, report_nm, rcept_no, name in results:
         filings.append(
             {
                 "date": f"{filing_date[:4]}-{filing_date[4:6]}-{filing_date[6:8]}",
                 "report_nm": report_nm,
                 "rcp_no": rcept_no,
-                "corp_name": korean_name,
+                "corp_name": name,
             }
         )
 

--- a/data/disclosures/dart_corp_index.py
+++ b/data/disclosures/dart_corp_index.py
@@ -17,8 +17,15 @@ CACHE_DIR = Path(os.getenv("AUTO_TRADER_CACHE_DIR", "/tmp/auto_trader"))
 CACHE_DIR.mkdir(parents=True, exist_ok=True)
 CACHE_FILE = CACHE_DIR / "dart_corp_index.json"
 
+# Global indices
 NAME_TO_CORP: dict[str, str] = {}  # "삼성전자" -> corp_code
+STOCK_TO_CORP: dict[str, str] = {}  # "005930" -> corp_code (6-digit stock code)
+CORP_TO_NAME: dict[str, str] = {}  # corp_code -> "삼성전자"
+
 _t = 0.0
+
+# Cache schema version - increment when structure changes
+CACHE_SCHEMA_VERSION = 2
 
 
 def _atomic_write(p: Path, obj: dict):
@@ -28,28 +35,63 @@ def _atomic_write(p: Path, obj: dict):
 
 
 def _load_cache() -> dict | None:
-    if not CACHE_FILE.exists(): return None
-    data = json.loads(CACHE_FILE.read_text("utf-8"))
+    """Load cache if valid. Returns None if missing, expired, or schema mismatch."""
+    if not CACHE_FILE.exists():
+        return None
+    try:
+        data = json.loads(CACHE_FILE.read_text("utf-8"))
+    except json.JSONDecodeError:
+        return None
+
+    # Check schema version - old cache without version is incomplete
+    if data.get("schema_version") != CACHE_SCHEMA_VERSION:
+        return None
+
     if time.time() - data.get("cached_at", 0) < TTL:
-        return data["name_to_corp"]
+        return {
+            "name_to_corp": data.get("name_to_corp", {}),
+            "stock_to_corp": data.get("stock_to_corp", {}),
+            "corp_to_name": data.get("corp_to_name", {}),
+        }
     return None
 
 
-def _apply(mapping: dict[str, str]):
+def _apply(indices: dict):
+    """Apply loaded indices to global variables."""
     NAME_TO_CORP.clear()
-    NAME_TO_CORP.update(mapping)
+    STOCK_TO_CORP.clear()
+    CORP_TO_NAME.clear()
+
+    NAME_TO_CORP.update(indices.get("name_to_corp", {}))
+    STOCK_TO_CORP.update(indices.get("stock_to_corp", {}))
+    CORP_TO_NAME.update(indices.get("corp_to_name", {}))
 
 
 async def refresh_index() -> None:
-    # 공식 corpCode 다운로드/파싱 (간단화를 위해 공개 REST 예시 생략)
-    # dart-fss 사용 시: dart_fss.get_corp_code() 등 활용
-    # 여기선 이미 파싱된 dict를 얻었다고 가정
-    mapping = await fetch_and_parse_corp_code()  # api_key 파라미터 제거
-    _apply(mapping)
-    _atomic_write(CACHE_FILE, {"cached_at": time.time(), "name_to_corp": mapping})
+    """Refresh the corp index from DART and update cache."""
+    indices = await fetch_and_parse_corp_code()
+
+    # Validate indices are non-empty
+    if not indices.get("name_to_corp"):
+        raise ValueError("DART corp index is empty - API may have failed")
+    if not indices.get("stock_to_corp"):
+        raise ValueError("DART stock index is empty - corp stock mapping failed")
+
+    _apply(indices)
+    _atomic_write(
+        CACHE_FILE,
+        {
+            "schema_version": CACHE_SCHEMA_VERSION,
+            "cached_at": time.time(),
+            "name_to_corp": indices["name_to_corp"],
+            "stock_to_corp": indices["stock_to_corp"],
+            "corp_to_name": indices["corp_to_name"],
+        },
+    )
 
 
 async def prime_index() -> None:
+    """Load index from cache if valid, otherwise refresh."""
     cached = _load_cache()
     if cached:
         _apply(cached)
@@ -57,36 +99,51 @@ async def prime_index() -> None:
     await refresh_index()
 
 
-
-def _fetch_corp_index_sync() -> dict[str, str]:
+def _fetch_corp_index_sync() -> dict[str, dict[str, str]]:
     """
-    dart_fss.get_corp_code()로 전체 회사 목록을 받아
-    '한글회사명 -> corp_code' 매핑을 만든다.
+    dart_fss.get_corp_code()로 전체 회사 목록을 받아 3개 인덱스를 구성:
+    - name_to_corp: 한글회사명 -> corp_code (상장사 우선)
+    - stock_to_corp: 6자리 종목코드 -> corp_code
+    - corp_to_name: corp_code -> 한글회사명
+
     동일 회사명이 여러 번 나오면 '상장사(stock_code 존재)'를 우선 채택.
     """
-    api_key = settings.opendart_api_key  # settings에서 api_key 가져오기
+    api_key = settings.opendart_api_key
     if not api_key:
         raise ValueError("OpenDART API Key 가 비어 있습니다.")
 
     dart_fss.set_api_key(api_key=api_key)
 
-    # CorpList 객체 반환 (공식 문서)
     corp_list = dart_fss.get_corp_list()
 
     name_to_corp: dict[str, str] = {}
+    stock_to_corp: dict[str, str] = {}
+    corp_to_name: dict[str, str] = {}
     listed_flag: dict[str, bool] = {}
 
-    # corp_list.corps 는 Corp 객체 리스트
-    for corp in corp_list.corps:
+    corps = getattr(corp_list, "corps", None) or []
+    for corp in corps:
         name = (corp.corp_name or "").strip()
-        code = (corp.corp_code or "").strip()  # ← 우리가 필요한 corp_code
-        stock = (corp.stock_code or "").strip()  # 상장 여부 판단용
+        code = (corp.corp_code or "").strip()  # 8-digit corp_code
+        stock = (
+            getattr(corp, "stock_code", None) or getattr(corp, "stock_id", "")
+        ).strip()  # 6-digit stock code (상장 여부 판단용)
+
         if not name or not code:
             continue
 
         listed = bool(stock)
 
-        # 동일 이름 여러개면 상장사 우선 교체
+        # Build stock_to_corp mapping (for listed companies)
+        if stock and len(stock) == 6:
+            # Only keep first occurrence (avoid duplicates)
+            if stock not in stock_to_corp:
+                stock_to_corp[stock] = code
+
+        # Build corp_to_name mapping
+        corp_to_name[code] = name
+
+        # Build name_to_corp with listed company priority
         if name in name_to_corp:
             if listed and not listed_flag.get(name, False):
                 name_to_corp[name] = code
@@ -96,8 +153,51 @@ def _fetch_corp_index_sync() -> dict[str, str]:
         name_to_corp[name] = code
         listed_flag[name] = listed
 
-    return name_to_corp
+    return {
+        "name_to_corp": name_to_corp,
+        "stock_to_corp": stock_to_corp,
+        "corp_to_name": corp_to_name,
+    }
 
-async def fetch_and_parse_corp_code() -> dict[str, str]:
-    """OpenDART corpCode를 dart-fss로 받아 회사명→corp_code 매핑 반환 (async 래퍼)."""
+
+async def fetch_and_parse_corp_code() -> dict[str, dict[str, str]]:
+    """OpenDART corpCode를 dart-fss로 받아 3개 인덱스 반환 (async 래퍼)."""
     return await asyncio.to_thread(_fetch_corp_index_sync)
+
+
+def resolve_symbol(symbol: str) -> tuple[str | None, str | None]:
+    """
+    Resolve a symbol to (corp_code, corp_name).
+
+    Args:
+        symbol: Korean name (삼성전자), 6-digit stock code (005930), or 8-digit corp code
+
+    Returns:
+        (corp_code, corp_name) tuple, or (None, None) if not found
+    """
+    if not symbol:
+        return None, None
+
+    # Strip whitespace and surrounding quotes
+    s = symbol.strip().strip("'\"")
+
+    # Try as 6-digit stock code first
+    if len(s) == 6 and s.isdigit():
+        corp_code = STOCK_TO_CORP.get(s)
+        if corp_code:
+            return corp_code, CORP_TO_NAME.get(corp_code, s)
+        return None, None
+
+    # Try as 8-digit corp code
+    if len(s) == 8 and s.isdigit():
+        corp_name = CORP_TO_NAME.get(s)
+        if corp_name:
+            return s, corp_name
+        return None, None
+
+    # Try as Korean company name
+    corp_code = NAME_TO_CORP.get(s)
+    if corp_code:
+        return corp_code, CORP_TO_NAME.get(corp_code, s)
+
+    return None, None

--- a/tests/test_dart_corp_index.py
+++ b/tests/test_dart_corp_index.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+
+import pytest
+
+import data.disclosures.dart_corp_index as corp_index
+
+
+@pytest.fixture
+def restore_indices():
+    prev_name = dict(corp_index.NAME_TO_CORP)
+    prev_stock = dict(corp_index.STOCK_TO_CORP)
+    prev_corp = dict(corp_index.CORP_TO_NAME)
+    try:
+        yield
+    finally:
+        corp_index.NAME_TO_CORP.clear()
+        corp_index.NAME_TO_CORP.update(prev_name)
+        corp_index.STOCK_TO_CORP.clear()
+        corp_index.STOCK_TO_CORP.update(prev_stock)
+        corp_index.CORP_TO_NAME.clear()
+        corp_index.CORP_TO_NAME.update(prev_corp)
+
+
+def test_fetch_corp_index_uses_stock_code_and_stock_id(monkeypatch):
+    monkeypatch.setattr(corp_index.settings, "opendart_api_key", "dummy-key")
+    monkeypatch.setattr(corp_index.dart_fss, "set_api_key", lambda api_key=None: None)
+
+    corps = [
+        SimpleNamespace(
+            corp_name="삼성전자",
+            corp_code="00126380",
+            stock_code="005930",
+        ),
+        SimpleNamespace(
+            corp_name="NAVER",
+            corp_code="00266961",
+            stock_id="035420",
+        ),
+    ]
+    monkeypatch.setattr(
+        corp_index.dart_fss,
+        "get_corp_list",
+        lambda: SimpleNamespace(corps=corps),
+    )
+
+    result = corp_index._fetch_corp_index_sync()
+
+    assert result["name_to_corp"]["삼성전자"] == "00126380"
+    assert result["name_to_corp"]["NAVER"] == "00266961"
+    assert result["stock_to_corp"]["005930"] == "00126380"
+    assert result["stock_to_corp"]["035420"] == "00266961"
+    assert result["corp_to_name"]["00126380"] == "삼성전자"
+    assert result["corp_to_name"]["00266961"] == "NAVER"
+
+
+def test_resolve_symbol_supports_stock_code(restore_indices):
+    corp_index.NAME_TO_CORP.clear()
+    corp_index.STOCK_TO_CORP.clear()
+    corp_index.CORP_TO_NAME.clear()
+
+    corp_index.NAME_TO_CORP["삼성전자"] = "00126380"
+    corp_index.STOCK_TO_CORP["005930"] = "00126380"
+    corp_index.CORP_TO_NAME["00126380"] = "삼성전자"
+
+    corp_code, corp_name = corp_index.resolve_symbol("005930")
+
+    assert corp_code == "00126380"
+    assert corp_name == "삼성전자"

--- a/tests/test_disclosures_dart.py
+++ b/tests/test_disclosures_dart.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.core.config import settings
+from app.services.disclosures import dart
+
+
+@pytest.fixture
+def restore_dart_indices():
+    prev_name = dict(dart.NAME_TO_CORP)
+    try:
+        yield
+    finally:
+        dart.NAME_TO_CORP.clear()
+        dart.NAME_TO_CORP.update(prev_name)
+
+
+@pytest.mark.asyncio
+async def test_list_filings_missing_api_key_returns_explicit_error(monkeypatch):
+    monkeypatch.setattr(settings, "opendart_api_key", "")
+    prime_mock = AsyncMock(side_effect=AssertionError("prime_index should not run"))
+    monkeypatch.setattr(dart, "prime_index", prime_mock)
+
+    result = await dart.list_filings("삼성전자", days=30, limit=5)
+
+    assert result["success"] is False
+    assert result["error_code"] == "missing_api_key"
+    assert result["filings"] == []
+    prime_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_list_filings_unresolved_symbol_returns_failure(
+    monkeypatch, restore_dart_indices
+):
+    monkeypatch.setattr(settings, "opendart_api_key", "dummy-key")
+    dart.NAME_TO_CORP.clear()
+    monkeypatch.setattr(dart, "prime_index", AsyncMock(return_value=None))
+    monkeypatch.setattr(dart, "resolve_symbol", lambda symbol: (None, None))
+
+    result = await dart.list_filings("없는회사", days=30, limit=5)
+
+    assert result["success"] is False
+    assert result["error_code"] == "symbol_not_resolved"
+    assert result["filings"] == []
+
+
+@pytest.mark.asyncio
+async def test_list_filings_returns_list_on_success(monkeypatch, restore_dart_indices):
+    monkeypatch.setattr(settings, "opendart_api_key", "dummy-key")
+    dart.NAME_TO_CORP["삼성전자"] = "00126380"
+    monkeypatch.setattr(
+        dart,
+        "resolve_symbol",
+        lambda symbol: ("00126380", "삼성전자"),
+    )
+    monkeypatch.setattr(dart.dart_fss, "set_api_key", lambda *args, **kwargs: None)
+
+    class FakeCorp:
+        def __init__(self, corp_code):
+            self.corp_code = corp_code
+
+        def search_filings(self, **kwargs):
+            _ = kwargs
+            return [
+                SimpleNamespace(
+                    rcept_dt="20260213",
+                    report_nm="기타경영사항(자율공시)",
+                    rcept_no="20260213000123",
+                )
+            ]
+
+    monkeypatch.setattr(dart.dart_fss.corp, "Corp", FakeCorp)
+
+    async def run_sync(sync_fn):
+        return sync_fn()
+
+    monkeypatch.setattr(dart.asyncio, "to_thread", run_sync)
+
+    result = await dart.list_filings("삼성전자", days=30, limit=5)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["corp_name"] == "삼성전자"
+    assert result[0]["report_nm"] == "기타경영사항(자율공시)"
+    assert result[0]["rcp_no"] == "20260213000123"

--- a/tests/test_mcp_disclosures.py
+++ b/tests/test_mcp_disclosures.py
@@ -1,0 +1,70 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.mcp_server.tooling import analysis_tool_handlers
+from app.mcp_server.tooling.registry import register_all_tools
+
+
+class DummyMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, object] = {}
+
+    def tool(self, name: str, description: str):
+        _ = description
+
+        def decorator(func):
+            self.tools[name] = func
+            return func
+
+        return decorator
+
+
+def build_tools() -> dict[str, object]:
+    mcp = DummyMCP()
+    register_all_tools(mcp)
+    return mcp.tools
+
+
+@pytest.mark.asyncio
+async def test_get_disclosures_strips_wrapping_quotes(monkeypatch):
+    tools = build_tools()
+    list_filings_mock = AsyncMock(return_value=[])
+    monkeypatch.setattr(analysis_tool_handlers, "list_filings", list_filings_mock)
+
+    result = await tools["get_disclosures"](symbol="'005930'", days=30, limit=5)
+
+    assert result["success"] is True
+    assert result["filings"] == []
+    list_filings_mock.assert_awaited_once_with("005930", 30, 5, None)
+
+
+@pytest.mark.asyncio
+async def test_get_disclosures_wraps_list_result(monkeypatch):
+    tools = build_tools()
+    list_filings_mock = AsyncMock(
+        return_value=[{"date": "2026-02-13", "report_nm": "기타경영사항(자율공시)"}]
+    )
+    monkeypatch.setattr(analysis_tool_handlers, "list_filings", list_filings_mock)
+
+    result = await tools["get_disclosures"](symbol="삼성전자", days=30, limit=5)
+
+    assert result["success"] is True
+    assert len(result["filings"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_disclosures_passes_through_error_dict(monkeypatch):
+    tools = build_tools()
+    expected = {
+        "success": False,
+        "error_code": "symbol_not_resolved",
+        "error": "Cannot resolve symbol",
+        "filings": [],
+    }
+    list_filings_mock = AsyncMock(return_value=expected)
+    monkeypatch.setattr(analysis_tool_handlers, "list_filings", list_filings_mock)
+
+    result = await tools["get_disclosures"](symbol="없는회사", days=30, limit=5)
+
+    assert result == expected


### PR DESCRIPTION
Summary:
- ensure DART tool strips quotes/whitespace before calling into the shared service
- have list_filings guard API key, prime the corp index, and return structured errors for missing keys or unresolved symbols
- expand corp index to include stock codes, cache schema versioning, resolver helpers, and relevant unit/MCP tests

Testing:
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Company disclosure lookups now support Korean names, 6-digit stock codes, and 8-digit corporate identification codes.
  * Expanded available disclosure report types.

* **Bug Fixes**
  * Enhanced input handling to better process symbols with extra whitespace and formatting variations.
  * Improved error reporting for unsuccessful disclosure searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->