### PR TITLE
Add OpenClaw execution notification flow

### DIFF
--- a/env.example
+++ b/env.example
@@ -62,6 +62,7 @@ GOOGLE_API_KEYS=key1,key2,key3
 # ========================================
 # OpenClaw (Gateway Webhook) 설정
 # ========================================
+# 분석 요청 + 체결 알림 모두 아래 OpenClaw Gateway 설정을 공용으로 사용
 # OpenClaw 연동 활성화 여부
 OPENCLAW_ENABLED=false
 # OpenClaw webhook URL (Gateway)

--- a/env.prod.example
+++ b/env.prod.example
@@ -50,6 +50,7 @@ GOOGLE_API_KEY=your_google_api_key
 GOOGLE_API_KEYS=["your_google_api_key_1","your_google_api_key_2"]
 
 # OpenClaw (Gateway Webhook)
+# 분석 요청 + 체결 알림 모두 아래 OpenClaw Gateway 설정을 공용으로 사용
 OPENCLAW_ENABLED=false
 OPENCLAW_WEBHOOK_URL=http://localhost:18789/hooks/agent
 OPENCLAW_TOKEN=

--- a/tests/test_openclaw_client.py
+++ b/tests/test_openclaw_client.py
@@ -6,6 +6,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
+import httpx
 import pytest
 
 from app.core.config import settings
@@ -107,3 +108,121 @@ async def test_request_analysis_posts_payload_and_returns_request_id(
     assert "USER_PROMPT:\nP" in called_json["message"]
     assert "POST http://example.test/api/v1/openclaw/callback" in called_json["message"]
     assert "Authorization: Bearer cb-token" in called_json["message"]
+
+
+def test_build_execution_message_with_fallback() -> None:
+    msg = OpenClawClient()._build_execution_message(
+        {
+            "symbol": "005930",
+            "market": "kr",
+        }
+    )
+    assert "005930" in msg
+    assert "상세 체결 정보가 부족" in msg
+
+
+def test_build_execution_message_with_dca_quantity_fallback() -> None:
+    msg = OpenClawClient()._build_execution_message(
+        {
+            "symbol": "AMZN",
+            "name": "Amazon.com",
+            "market": "us",
+            "side": "buy",
+            "filled_price": 207.0,
+            "filled_qty": 2,
+            "dca_next_step": {
+                "step_number": 2,
+                "target_price": 195.0,
+                "quantity": 2,
+            },
+        }
+    )
+    assert "DCA 2차" in msg
+    assert "$195.00" in msg
+    assert "2주" in msg
+
+
+@pytest.mark.asyncio
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_execution_notification_skips_when_disabled(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "OPENCLAW_ENABLED", False)
+    sent = await OpenClawClient().send_execution_notification({"symbol": "AAPL"})
+    assert sent is False
+    mock_httpx_client_cls.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_execution_notification_posts_gateway_payload(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
+    monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
+    monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+
+    mock_cli = AsyncMock()
+    mock_res = MagicMock(status_code=202)
+    mock_res.raise_for_status.return_value = None
+    mock_cli.post.return_value = mock_res
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    event = {
+        "symbol": "AMZN",
+        "name": "Amazon.com",
+        "market": "us",
+        "side": "buy",
+        "filled_price": 207.0,
+        "filled_qty": 2,
+        "dca_next_step": {
+            "step_number": 2,
+            "target_price": 195.0,
+            "target_quantity": 2,
+        },
+    }
+
+    sent = await OpenClawClient().send_execution_notification(event)
+
+    assert sent is True
+    mock_httpx_client_cls.assert_called_once_with(timeout=10)
+    mock_cli.post.assert_awaited_once()
+
+    called_url = mock_cli.post.call_args.args[0]
+    called_json = mock_cli.post.call_args.kwargs["json"]
+    called_headers = mock_cli.post.call_args.kwargs["headers"]
+
+    assert called_url == "http://openclaw/hooks/agent"
+    assert called_headers["Authorization"] == "Bearer test-token"
+    assert called_json["name"] == "auto-trader:execution"
+    assert called_json["wakeMode"] == "now"
+    assert called_json["sessionKey"] == "auto-trader:execution:us:AMZN"
+    assert "Amazon.com(AMZN)" in called_json["message"]
+    assert "DCA 2차" in called_json["message"]
+
+
+@pytest.mark.asyncio
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_execution_notification_returns_false_on_http_error(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
+    monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
+
+    mock_cli = AsyncMock()
+    mock_cli.post.side_effect = httpx.ConnectError("boom")
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    sent = await OpenClawClient().send_execution_notification({"symbol": "AAPL"})
+    assert sent is False


### PR DESCRIPTION
Summary
- extend `OpenClawClient` with execution notification payload construction, formatting helpers, and delivery logic guarded by feature flags
- update KIS monitor to call new client after DCA bookkeeping and keep tests aligned with the extra call
- document and configure the OpenClaw webhook settings in env examples

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time trade execution notifications to OpenClaw Gateway (when enabled). The system sends detailed alerts for every trade including symbol, market, side, price, quantity, and timestamp to your configured webhook endpoint, enabling seamless integration with external monitoring services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->