### PR TITLE
Mark zero-priced holdings below minimum value filter

### DIFF
--- a/app/mcp_server/tooling/shared.py
+++ b/app/mcp_server/tooling/shared.py
@@ -381,11 +381,10 @@ def value_for_minimum_filter(position: dict[str, Any]) -> float:
     if evaluation_amount is not None:
         return to_float(evaluation_amount, default=0.0)
 
-    if position.get("current_price") is None:
-        return float("inf")
-
     quantity = to_float(position.get("quantity"))
     current_price = to_float(position.get("current_price"))
+    if current_price <= 0:
+        return 0.0
     return quantity * current_price
 
 


### PR DESCRIPTION
Summary
- ensure the minimum-value filter treats positions with zero or missing current prices as insufficient value instead of skipping them
- update tests that cover the holding filters to expect the new behavior and verify delisted coins are filtered out

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of positions with unavailable price data—assets without current pricing are now properly excluded from holdings lists rather than retained with error states, affecting minimum filter threshold evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->