### PR TITLE
feat: harden KIS US OHLCV cache behavior and source mapping

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -40,6 +40,12 @@ class Settings(BaseSettings):
     upbit_ohlcv_cache_max_days: int = 400
     upbit_ohlcv_cache_lock_ttl_seconds: int = 10
 
+    kis_ohlcv_cache_enabled: bool = True
+    kis_ohlcv_cache_ttl_seconds: int = 300
+    kis_ohlcv_cache_max_days: int = 400
+    kis_ohlcv_cache_lock_ttl_seconds: int = 10
+    kis_ohlcv_cache_probe_retry_seconds: int = 1800
+
     # API Rate Limit Retry Settings (429 handling)
     api_rate_limit_retry_429_max: int = 2  # 429 에러 시 최대 재시도 횟수
     api_rate_limit_retry_429_base_delay: float = 0.2  # 지수 백오프 기본 대기 시간 (초)

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -53,6 +53,11 @@ Market-specific behavior:
 - **US market**: Uses yfinance screener with EquityQuery
   - Maps: `min_market_cap` → `intradaymarketcap`, `max_per` → `peratio.lasttwelvemonths`, `min_dividend_yield` → `forward_dividend_yield`
   - Sort maps: `volume` → `dayvolume`, `market_cap` → `intradaymarketcap`, `change_rate` → `percentchange`
+  - `get_ohlcv`/`get_indicators`/`get_support_resistance`/`get_correlation` use KIS overseas daily price data
+  - US `get_ohlcv` max `count` is capped at 200
+  - US daily OHLCV Redis cache (`KIS_OHLCV_CACHE_*`) is used only when `period="day"` and `end_date` is not provided
+  - US daily cache as-of is based on ET 16:00 close, with weekend rollback to the last trading day
+  - `get_quote` for US remains Yahoo (`yfinance`)
 
 - **Crypto market**: Uses Upbit `fetch_top_traded_coins`
   - `sort_by="trade_amount"` uses `acc_trade_price_24h` (24h traded value in KRW)

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -82,7 +82,7 @@ def register_analysis_tools(mcp: FastMCP) -> None:
         name="get_correlation",
         description=(
             "Calculate Pearson correlation matrix between multiple assets. "
-            "Supports Korean stocks (KIS), US stocks (yfinance), and crypto (Upbit). "
+            "Supports Korean stocks (KIS), US stocks (KIS), and crypto (Upbit). "
             "Uses daily closing prices over specified period."
         ),
     )

--- a/app/mcp_server/tooling/analysis_screening.py
+++ b/app/mcp_server/tooling/analysis_screening.py
@@ -238,7 +238,7 @@ async def _analyze_stock_impl(
         raise ValueError("symbol is required")
 
     market_type, normalized_symbol = _resolve_market_type(symbol, market)
-    source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "yahoo"}
+    source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "kis"}
     source = source_map[market_type]
 
     errors: list[str] = []

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -263,7 +263,7 @@ async def get_correlation_impl(
     if period > 365:
         raise ValueError("period must be between 30 and 365 days")
 
-    source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "yahoo"}
+    source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "kis"}
     errors: list[str] = []
     price_data: dict[str, list[float]] = {}
     market_types: dict[str, str] = {}

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -112,7 +112,7 @@ async def _get_support_resistance_impl(
         raise ValueError("symbol is required")
 
     market_type, normalized_symbol = _resolve_market_type(symbol, market)
-    source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "yahoo"}
+    source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "kis"}
     source = source_map[market_type]
 
     try:

--- a/app/mcp_server/tooling/market_data_indicators.py
+++ b/app/mcp_server/tooling/market_data_indicators.py
@@ -15,9 +15,10 @@ from app.mcp_server.tooling.shared import (
 from app.mcp_server.tooling.shared import (
     to_optional_float as _to_optional_float,
 )
+from app.services import kis_ohlcv_cache
 from app.services import upbit as upbit_service
-from app.services import yahoo as yahoo_service
 from app.services.kis import KISClient
+from data.stocks_info import get_exchange_by_symbol
 
 IndicatorType = Literal[
     "sma", "ema", "rsi", "macd", "bollinger", "atr", "pivot", "adx", "stoch_rsi", "obv"
@@ -95,8 +96,35 @@ async def _fetch_ohlcv_for_indicators(
             code=symbol, market="J", n=capped_count, period="D"
         )
     capped_count = min(count, 250)
-    return await yahoo_service.fetch_ohlcv(
-        ticker=symbol, days=capped_count, period="day"
+    kis = KISClient()
+    exchange_code = get_exchange_by_symbol(symbol.upper()) or "NASD"
+
+    async def _raw_fetcher(
+        *, symbol: str, exchange_code: str, n: int, end_date: datetime.date | None
+    ) -> pd.DataFrame:
+        return await kis.inquire_overseas_daily_price(
+            symbol=symbol,
+            exchange_code=exchange_code,
+            n=n,
+            period="D",
+            end_date=end_date,
+        )
+
+    cached = await kis_ohlcv_cache.get_closed_daily_candles(
+        symbol=symbol,
+        exchange_code=exchange_code,
+        count=capped_count,
+        instrument_type="equity_us",
+        raw_fetcher=_raw_fetcher,
+    )
+    if cached is not None:
+        return cached
+
+    return await kis.inquire_overseas_daily_price(
+        symbol=symbol,
+        exchange_code=exchange_code,
+        n=capped_count,
+        period="D",
     )
 
 
@@ -112,8 +140,35 @@ async def _fetch_ohlcv_for_volume_profile(
         return await kis.inquire_daily_itemchartprice(
             code=symbol, market="J", n=period_days, period="D"
         )
-    return await yahoo_service.fetch_ohlcv(
-        ticker=symbol, days=period_days, period="day"
+    kis = KISClient()
+    exchange_code = get_exchange_by_symbol(symbol.upper()) or "NASD"
+
+    async def _raw_fetcher(
+        *, symbol: str, exchange_code: str, n: int, end_date: datetime.date | None
+    ) -> pd.DataFrame:
+        return await kis.inquire_overseas_daily_price(
+            symbol=symbol,
+            exchange_code=exchange_code,
+            n=n,
+            period="D",
+            end_date=end_date,
+        )
+
+    cached = await kis_ohlcv_cache.get_closed_daily_candles(
+        symbol=symbol,
+        exchange_code=exchange_code,
+        count=period_days,
+        instrument_type="equity_us",
+        raw_fetcher=_raw_fetcher,
+    )
+    if cached is not None:
+        return cached
+
+    return await kis.inquire_overseas_daily_price(
+        symbol=symbol,
+        exchange_code=exchange_code,
+        n=period_days,
+        period="D",
     )
 
 

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -32,11 +32,12 @@ from app.mcp_server.tooling.shared import (
     resolve_market_type as _resolve_market_type,
 )
 from app.monitoring import build_yfinance_tracing_session
+from app.services import kis_ohlcv_cache
 from app.services import upbit as upbit_service
-from app.services import yahoo as yahoo_service
 from app.services.kis import KISClient
 from data.coins_info import get_or_refresh_maps
 from data.stocks_info import (
+    get_exchange_by_symbol,
     get_kosdaq_name_to_code,
     get_kospi_name_to_code,
     get_us_stocks_data,
@@ -275,15 +276,53 @@ async def _fetch_ohlcv_equity_kr(
 async def _fetch_ohlcv_equity_us(
     symbol: str, count: int, period: str, end_date: datetime.datetime | None
 ) -> dict[str, Any]:
-    """Fetch US equity OHLCV from Yahoo Finance."""
-    capped_count = min(count, 100)
-    df = await yahoo_service.fetch_ohlcv(
-        ticker=symbol, days=capped_count, period=period, end_date=end_date
-    )
+    capped_count = min(count, 200)
+    kis = KISClient()
+    exchange_code = get_exchange_by_symbol(symbol.upper()) or "NASD"
+
+    if period == "day" and end_date is None:
+
+        async def _raw_fetcher(
+            *, symbol: str, exchange_code: str, n: int, end_date: datetime.date | None
+        ):
+            return await kis.inquire_overseas_daily_price(
+                symbol=symbol,
+                exchange_code=exchange_code,
+                n=n,
+                period="D",
+                end_date=end_date,
+            )
+
+        cached = await kis_ohlcv_cache.get_closed_daily_candles(
+            symbol=symbol,
+            exchange_code=exchange_code,
+            count=capped_count,
+            instrument_type="equity_us",
+            raw_fetcher=_raw_fetcher,
+        )
+        if cached is not None:
+            df = cached
+        else:
+            df = await kis.inquire_overseas_daily_price(
+                symbol=symbol,
+                exchange_code=exchange_code,
+                n=capped_count,
+                period="D",
+            )
+    else:
+        kis_period_map = {"day": "D", "week": "W", "month": "M"}
+        df = await kis.inquire_overseas_daily_price(
+            symbol=symbol,
+            exchange_code=exchange_code,
+            n=capped_count,
+            period=kis_period_map.get(period, "D"),
+            end_date=end_date.date() if end_date else None,
+        )
+
     return {
         "symbol": symbol,
         "instrument_type": "equity_us",
-        "source": "yahoo",
+        "source": "kis",
         "period": period,
         "count": capped_count,
         "rows": _normalize_rows(df),
@@ -389,7 +428,7 @@ def _register_market_data_tools_impl(mcp: FastMCP) -> None:
 
         market_type, symbol = _resolve_market_type(symbol, market)
 
-        source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "yahoo"}
+        source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "kis"}
         source = source_map[market_type]
 
         try:
@@ -448,7 +487,7 @@ def _register_market_data_tools_impl(mcp: FastMCP) -> None:
 
         market_type, symbol = _resolve_market_type(symbol, market)
 
-        source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "yahoo"}
+        source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "kis"}
         source = source_map[market_type]
 
         try:

--- a/app/mcp_server/tooling/portfolio_dca_core.py
+++ b/app/mcp_server/tooling/portfolio_dca_core.py
@@ -180,7 +180,7 @@ def _validate_create_dca_input(
             )
 
     market_type, normalized_symbol = resolve_market_type(symbol, market)
-    source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "yahoo"}
+    source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "kis"}
     return market_type, normalized_symbol, source_map[market_type]
 
 

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -536,7 +536,7 @@ async def _get_indicators_impl(
         raise ValueError("indicators list is required and cannot be empty")
 
     market_type, symbol = _resolve_market_type(symbol, market)
-    source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "yahoo"}
+    source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "kis"}
     source = source_map[market_type]
 
     try:

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,4 +1,5 @@
 from . import kis as kis
+from . import kis_ohlcv_cache as kis_ohlcv_cache
 from . import order_service as order_service
 from . import upbit as upbit
 from . import upbit_orderbook as upbit_orderbook

--- a/app/services/kis.py
+++ b/app/services/kis.py
@@ -1820,6 +1820,7 @@ class KISClient:
         exchange_code: str = "NASD",
         n: int = 200,
         period: str = "D",  # D/W/M
+        end_date: datetime.date | None = None,
     ) -> pd.DataFrame:
         """
         해외주식 일봉/주봉/월봉 조회 (국내주식처럼 충분한 데이터 확보)
@@ -1847,6 +1848,8 @@ class KISClient:
         rows: list[dict] = []
         max_iterations = 5  # 최대 5번 반복 (충분한 데이터 확보)
         iteration = 0
+        anchor_end_date = end_date
+        end_date_ymd = anchor_end_date.strftime("%Y%m%d") if anchor_end_date else None
 
         # 국내주식처럼 충분한 데이터를 확보할 때까지 반복 조회
         while len(rows) < n and iteration < max_iterations:
@@ -1861,7 +1864,7 @@ class KISClient:
                 except Exception:
                     bymd = ""
             else:
-                bymd = ""  # 첫 요청은 최신 데이터부터
+                bymd = end_date_ymd or ""
 
             params = {
                 "AUTH": "",
@@ -1894,6 +1897,10 @@ class KISClient:
                 raise RuntimeError(f"{js.get('msg_cd')} {js.get('msg1')}")
 
             chunk = js.get("output2") or js.get("output") or []
+            if end_date_ymd:
+                chunk = [
+                    row for row in chunk if str(row.get("xymd", "")) <= end_date_ymd
+                ]
             if not chunk:
                 logging.info(
                     f"더 이상 과거 데이터가 없음. 현재까지 수집: {len(rows)}개"
@@ -1935,9 +1942,11 @@ class KISClient:
             .assign(date=lambda d: pd.to_datetime(d["date"], format="%Y%m%d"))
             .drop_duplicates(subset=["date"], keep="first")
             .sort_values("date")
-            .tail(n)
             .reset_index(drop=True)
         )
+        if anchor_end_date is not None:
+            df = df[df["date"] <= pd.Timestamp(anchor_end_date)].reset_index(drop=True)
+        df = df.tail(n).reset_index(drop=True)
         logging.info(f"해외주식 일봉 조회 완료: {len(df)}개 데이터 반환")
         return df
 

--- a/app/services/kis_ohlcv_cache.py
+++ b/app/services/kis_ohlcv_cache.py
@@ -1,0 +1,531 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from datetime import UTC, date, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import redis.asyncio as redis
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_ET = ZoneInfo("America/New_York")
+_EMPTY_COLUMNS = ["date", "open", "high", "low", "close", "volume", "value"]
+
+_REDIS_CLIENT: redis.Redis | None = None
+
+
+def expected_asof_et(now_utc: datetime) -> date:
+    base = now_utc
+    if base.tzinfo is None:
+        base = base.replace(tzinfo=UTC)
+    et_now = base.astimezone(_ET)
+
+    anchor = (
+        et_now.date()
+        if et_now.time() >= time(16, 0)
+        else et_now.date() - timedelta(days=1)
+    )
+
+    while anchor.weekday() >= 5:
+        anchor -= timedelta(days=1)
+    return anchor
+
+
+def _epoch_day(value: date) -> int:
+    return int(
+        datetime(value.year, value.month, value.day, tzinfo=UTC).timestamp() // 86400
+    )
+
+
+def _empty_dataframe() -> pd.DataFrame:
+    return pd.DataFrame(columns=_EMPTY_COLUMNS)
+
+
+def _to_json_value(value: object) -> object:
+    if pd.isna(value):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return value
+
+
+def _keys(
+    symbol: str, exchange_code: str, instrument_type: str
+) -> tuple[str, str, str, str]:
+    base = (
+        "kis:ohlcv:day:v1:"
+        f"{instrument_type.lower()}:{exchange_code.upper()}:{symbol.upper()}"
+    )
+    return f"{base}:dates", f"{base}:rows", f"{base}:meta", f"{base}:lock"
+
+
+def _legacy_keys(
+    symbol: str, exchange_code: str, instrument_type: str
+) -> tuple[str, str, str, str]:
+    base = (
+        f"kis:ohlcv:{instrument_type.lower()}:day:v1:"
+        f"{exchange_code.upper()}:{symbol.upper()}"
+    )
+    return f"{base}:dates", f"{base}:rows", f"{base}:meta", f"{base}:lock"
+
+
+async def _get_redis_client() -> redis.Redis:
+    global _REDIS_CLIENT
+    if _REDIS_CLIENT is None:
+        _REDIS_CLIENT = redis.from_url(
+            settings.get_redis_url(),
+            max_connections=settings.redis_max_connections,
+            socket_timeout=settings.redis_socket_timeout,
+            socket_connect_timeout=settings.redis_socket_connect_timeout,
+            decode_responses=True,
+        )
+    return _REDIS_CLIENT
+
+
+async def close_kis_ohlcv_cache_redis() -> None:
+    global _REDIS_CLIENT
+    if _REDIS_CLIENT is not None:
+        await _REDIS_CLIENT.close()
+        _REDIS_CLIENT = None
+
+
+async def _read_cached_rows(
+    redis_client: redis.Redis,
+    dates_key: str,
+    rows_key: str,
+    target_asof: date,
+    count: int,
+) -> pd.DataFrame:
+    if count <= 0:
+        return _empty_dataframe()
+
+    fields = await redis_client.zrevrangebyscore(
+        dates_key,
+        _epoch_day(target_asof),
+        "-inf",
+        start=0,
+        num=count,
+    )
+    if not fields:
+        return _empty_dataframe()
+
+    payloads = await redis_client.hmget(rows_key, fields)
+    rows: list[dict[str, object]] = []
+    for field, payload in zip(fields, payloads, strict=False):
+        if not payload:
+            continue
+        try:
+            parsed = json.loads(payload)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        row_date = parsed.get("date", field)
+        try:
+            parsed["date"] = date.fromisoformat(str(row_date))
+        except ValueError:
+            continue
+        rows.append(parsed)
+
+    if not rows:
+        return _empty_dataframe()
+
+    frame = pd.DataFrame(rows)
+    for column in _EMPTY_COLUMNS:
+        if column not in frame.columns:
+            frame[column] = None
+    return frame.loc[:, _EMPTY_COLUMNS].sort_values("date").reset_index(drop=True)
+
+
+async def _read_latest_date(redis_client: redis.Redis, dates_key: str) -> date | None:
+    latest = await redis_client.zrevrangebyscore(
+        dates_key, "+inf", "-inf", start=0, num=1
+    )
+    if not latest:
+        return None
+    try:
+        return date.fromisoformat(latest[0])
+    except ValueError:
+        return None
+
+
+async def _acquire_lock(
+    redis_client: redis.Redis,
+    lock_key: str,
+    ttl_seconds: int,
+) -> str | None:
+    token = str(uuid.uuid4())
+    acquired = await redis_client.set(
+        lock_key, token, nx=True, ex=max(int(ttl_seconds), 1)
+    )
+    return token if acquired else None
+
+
+async def _release_lock(redis_client: redis.Redis, lock_key: str, token: str) -> None:
+    script = """
+    if redis.call('GET', KEYS[1]) == ARGV[1] then
+        return redis.call('DEL', KEYS[1])
+    else
+        return 0
+    end
+    """
+    try:
+        await redis_client.eval(script, 1, lock_key, token)
+    except Exception:
+        return
+
+
+async def _trim_retention(
+    redis_client: redis.Redis,
+    dates_key: str,
+    rows_key: str,
+    max_days: int,
+) -> None:
+    if max_days <= 0:
+        return
+    total = int(await redis_client.zcard(dates_key))
+    overflow = total - max_days
+    if overflow <= 0:
+        return
+
+    stale_dates = await redis_client.zrange(dates_key, 0, overflow - 1)
+    if not stale_dates:
+        return
+
+    pipe = redis_client.pipeline(transaction=True)
+    pipe.zremrangebyrank(dates_key, 0, overflow - 1)
+    pipe.hdel(rows_key, *stale_dates)
+    await pipe.execute()
+
+
+def _normalize_daily_frame(frame: pd.DataFrame, target_asof: date) -> pd.DataFrame:
+    if frame.empty:
+        return _empty_dataframe()
+
+    normalized = frame.copy()
+    if "date" not in normalized.columns:
+        return _empty_dataframe()
+
+    normalized["date"] = pd.to_datetime(normalized["date"], errors="coerce").dt.date
+    normalized = normalized.dropna(subset=["date"])  # type: ignore[arg-type]
+    if normalized.empty:
+        return _empty_dataframe()
+
+    normalized = normalized[normalized["date"] <= target_asof]
+    if normalized.empty:
+        return _empty_dataframe()
+
+    for column in _EMPTY_COLUMNS:
+        if column not in normalized.columns:
+            normalized[column] = None
+
+    return (
+        normalized.loc[:, _EMPTY_COLUMNS]
+        .drop_duplicates(subset=["date"], keep="first")
+        .sort_values("date")
+        .reset_index(drop=True)
+    )
+
+
+async def _upsert_rows(
+    redis_client: redis.Redis,
+    dates_key: str,
+    rows_key: str,
+    frame: pd.DataFrame,
+) -> int:
+    if frame.empty:
+        return 0
+
+    zadd_mapping: dict[str, int] = {}
+    hset_mapping: dict[str, str] = {}
+
+    for row in frame.itertuples(index=False):
+        row_date = getattr(row, "date", None)
+        if not isinstance(row_date, date):
+            continue
+
+        field = row_date.isoformat()
+        zadd_mapping[field] = _epoch_day(row_date)
+        hset_mapping[field] = json.dumps(
+            {
+                "date": field,
+                "open": _to_json_value(getattr(row, "open", None)),
+                "high": _to_json_value(getattr(row, "high", None)),
+                "low": _to_json_value(getattr(row, "low", None)),
+                "close": _to_json_value(getattr(row, "close", None)),
+                "volume": _to_json_value(getattr(row, "volume", None)),
+                "value": _to_json_value(getattr(row, "value", None)),
+            }
+        )
+
+    if not zadd_mapping:
+        return 0
+
+    pipe = redis_client.pipeline(transaction=True)
+    pipe.zadd(dates_key, zadd_mapping)
+    pipe.hset(rows_key, mapping=hset_mapping)
+    await pipe.execute()
+    return len(zadd_mapping)
+
+
+def _cache_hit_sufficient(
+    cached: pd.DataFrame,
+    latest_cached_date: date | None,
+    target_asof: date,
+    requested_count: int,
+) -> bool:
+    if latest_cached_date is None or latest_cached_date < target_asof:
+        return False
+    return len(cached) >= requested_count
+
+
+async def _set_probe_meta(
+    redis_client: redis.Redis,
+    meta_key: str,
+    target_asof: date,
+    now_utc: datetime,
+) -> None:
+    retry_seconds = max(int(settings.kis_ohlcv_cache_probe_retry_seconds), 1)
+    until_ts = int(now_utc.timestamp()) + retry_seconds
+    await redis_client.hset(
+        meta_key,
+        mapping={
+            "last_probe_target_asof": target_asof.isoformat(),
+            # Backward compatibility for one release window.
+            "last_probe_asof": target_asof.isoformat(),
+            "probe_until_ts": str(until_ts),
+            "last_probe_ts": str(int(now_utc.timestamp())),
+        },
+    )
+    await redis_client.expire(meta_key, max(int(settings.kis_ohlcv_cache_ttl_seconds), 1))
+
+
+def _probe_target_from_meta(meta: dict[str, str]) -> str | None:
+    return meta.get("last_probe_target_asof") or meta.get("last_probe_asof")
+
+
+def _is_probe_active(meta: dict[str, str], target_asof: date, now_utc: datetime) -> bool:
+    if not meta:
+        return False
+    if _probe_target_from_meta(meta) != target_asof.isoformat():
+        return False
+    try:
+        return int(meta.get("probe_until_ts", "0")) > int(now_utc.timestamp())
+    except ValueError:
+        return False
+
+
+async def _should_skip_probe(
+    redis_client: redis.Redis,
+    primary_meta_key: str,
+    legacy_meta_key: str,
+    target_asof: date,
+    now_utc: datetime,
+) -> bool:
+    primary_meta = await redis_client.hgetall(primary_meta_key)
+    if _is_probe_active(primary_meta, target_asof, now_utc):
+        return True
+
+    legacy_meta = await redis_client.hgetall(legacy_meta_key)
+    return _is_probe_active(legacy_meta, target_asof, now_utc)
+
+
+async def get_closed_daily_candles(
+    *,
+    symbol: str,
+    exchange_code: str,
+    count: int,
+    instrument_type: str,
+    raw_fetcher: Callable[..., Awaitable[pd.DataFrame]],
+    now_utc: datetime | None = None,
+) -> pd.DataFrame | None:
+    if not settings.kis_ohlcv_cache_enabled:
+        return None
+
+    normalized_symbol = str(symbol or "").strip().upper()
+    normalized_exchange = str(exchange_code or "").strip().upper()
+    if not normalized_symbol or not normalized_exchange:
+        return _empty_dataframe()
+
+    requested_count = int(count)
+    if requested_count <= 0:
+        return _empty_dataframe()
+
+    max_days = max(int(settings.kis_ohlcv_cache_max_days), 1)
+    requested_count = min(requested_count, max_days)
+
+    base_now_utc = now_utc or datetime.now(UTC)
+    if base_now_utc.tzinfo is None:
+        base_now_utc = base_now_utc.replace(tzinfo=UTC)
+
+    target_asof = expected_asof_et(base_now_utc)
+
+    try:
+        redis_client = await _get_redis_client()
+    except Exception as exc:
+        logger.warning("kis_ohlcv_cache redis unavailable: %s", exc)
+        return None
+
+    try:
+        dates_key, rows_key, meta_key, lock_key = _keys(
+            normalized_symbol,
+            normalized_exchange,
+            instrument_type,
+        )
+        legacy_dates_key, legacy_rows_key, legacy_meta_key, _ = _legacy_keys(
+            normalized_symbol,
+            normalized_exchange,
+            instrument_type,
+        )
+
+        await _trim_retention(redis_client, dates_key, rows_key, max_days)
+        await _trim_retention(redis_client, legacy_dates_key, legacy_rows_key, max_days)
+
+        cached_primary = await _read_cached_rows(
+            redis_client,
+            dates_key,
+            rows_key,
+            target_asof,
+            requested_count,
+        )
+        latest_cached_primary = await _read_latest_date(redis_client, dates_key)
+        if _cache_hit_sufficient(
+            cached_primary,
+            latest_cached_primary,
+            target_asof,
+            requested_count,
+        ):
+            return cached_primary.tail(requested_count).reset_index(drop=True)
+
+        cached_legacy = await _read_cached_rows(
+            redis_client,
+            legacy_dates_key,
+            legacy_rows_key,
+            target_asof,
+            requested_count,
+        )
+        latest_cached_legacy = await _read_latest_date(redis_client, legacy_dates_key)
+        if _cache_hit_sufficient(
+            cached_legacy,
+            latest_cached_legacy,
+            target_asof,
+            requested_count,
+        ):
+            return cached_legacy.tail(requested_count).reset_index(drop=True)
+
+        fallback_cached = (
+            cached_primary if len(cached_primary) >= len(cached_legacy) else cached_legacy
+        )
+
+        if await _should_skip_probe(
+            redis_client,
+            meta_key,
+            legacy_meta_key,
+            target_asof,
+            base_now_utc,
+        ):
+            return fallback_cached.tail(requested_count).reset_index(drop=True)
+
+        lock_token = await _acquire_lock(
+            redis_client,
+            lock_key,
+            settings.kis_ohlcv_cache_lock_ttl_seconds,
+        )
+
+        if lock_token is None:
+            for _ in range(6):
+                await asyncio.sleep(0.05)
+                refreshed = await _read_cached_rows(
+                    redis_client,
+                    dates_key,
+                    rows_key,
+                    target_asof,
+                    requested_count,
+                )
+                refreshed_latest = await _read_latest_date(redis_client, dates_key)
+                if _cache_hit_sufficient(
+                    refreshed,
+                    refreshed_latest,
+                    target_asof,
+                    requested_count,
+                ):
+                    return refreshed.tail(requested_count).reset_index(drop=True)
+            return fallback_cached.tail(requested_count).reset_index(drop=True)
+
+        try:
+            fetched = await raw_fetcher(
+                symbol=normalized_symbol,
+                exchange_code=normalized_exchange,
+                n=requested_count,
+                end_date=target_asof,
+            )
+            normalized = _normalize_daily_frame(fetched, target_asof)
+
+            if normalized.empty:
+                await _set_probe_meta(redis_client, meta_key, target_asof, base_now_utc)
+            else:
+                await _upsert_rows(redis_client, dates_key, rows_key, normalized)
+                await _trim_retention(redis_client, dates_key, rows_key, max_days)
+                synced_latest = await _read_latest_date(redis_client, dates_key)
+                if synced_latest is None or synced_latest < target_asof:
+                    await _set_probe_meta(
+                        redis_client,
+                        meta_key,
+                        target_asof,
+                        base_now_utc,
+                    )
+                else:
+                    latest_asof = synced_latest.isoformat()
+                    await redis_client.hset(
+                        meta_key,
+                        mapping={
+                            "latest_asof": latest_asof,
+                            # Backward compatibility for one release window.
+                            "last_sync_asof": latest_asof,
+                            "last_sync_ts": str(int(base_now_utc.timestamp())),
+                            "probe_until_ts": "0",
+                            "last_probe_target_asof": "",
+                            "last_probe_asof": "",
+                        },
+                    )
+                    await redis_client.expire(
+                        meta_key, max(int(settings.kis_ohlcv_cache_ttl_seconds), 1)
+                    )
+                    await redis_client.expire(
+                        dates_key, max(int(settings.kis_ohlcv_cache_ttl_seconds), 1)
+                    )
+                    await redis_client.expire(
+                        rows_key, max(int(settings.kis_ohlcv_cache_ttl_seconds), 1)
+                    )
+        finally:
+            await _release_lock(redis_client, lock_key, lock_token)
+
+        final_rows = await _read_cached_rows(
+            redis_client,
+            dates_key,
+            rows_key,
+            target_asof,
+            requested_count,
+        )
+        if final_rows.empty and not fallback_cached.empty:
+            return fallback_cached.tail(requested_count).reset_index(drop=True)
+        return final_rows.tail(requested_count).reset_index(drop=True)
+    except Exception as exc:
+        logger.warning(
+            "kis_ohlcv_cache error symbol=%s error=%s", normalized_symbol, exc
+        )
+        return None
+
+
+__all__ = [
+    "close_kis_ohlcv_cache_redis",
+    "expected_asof_et",
+    "get_closed_daily_candles",
+]

--- a/env.example
+++ b/env.example
@@ -40,6 +40,19 @@ KIS_RATE_LIMIT_PERIOD=1.0
 # 예시: {"FHKST03010100|/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice": {"rate": 10, "period": 1.0}}
 KIS_API_RATE_LIMITS={}
 
+# KIS US 일봉 캐시 설정 (Redis)
+# ========================================
+# KIS US 일봉 캐시 활성화 여부
+KIS_OHLCV_CACHE_ENABLED=true
+# 캐시 TTL (초)
+KIS_OHLCV_CACHE_TTL_SECONDS=300
+# 심볼당 최대 보관 일수
+KIS_OHLCV_CACHE_MAX_DAYS=400
+# 캐시 채우기 락 TTL (초)
+KIS_OHLCV_CACHE_LOCK_TTL_SECONDS=10
+# 데이터 미확정 시 재조회 억제 시간 (초)
+KIS_OHLCV_CACHE_PROBE_RETRY_SECONDS=1800
+
 # ========================================
 # Telegram 설정
 # ========================================

--- a/tests/test_kis_ohlcv_cache.py
+++ b/tests/test_kis_ohlcv_cache.py
@@ -1,0 +1,580 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, date, datetime, timedelta
+from unittest.mock import AsyncMock
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pytest
+
+from app.services import kis_ohlcv_cache
+
+
+class _FakePipeline:
+    def __init__(self, redis_client):
+        self.redis_client = redis_client
+        self.commands: list[tuple[str, tuple, dict]] = []
+
+    def zremrangebyrank(self, *args, **kwargs):
+        self.commands.append(("zremrangebyrank", args, kwargs))
+        return self
+
+    def hdel(self, *args, **kwargs):
+        self.commands.append(("hdel", args, kwargs))
+        return self
+
+    def zadd(self, *args, **kwargs):
+        self.commands.append(("zadd", args, kwargs))
+        return self
+
+    def hset(self, *args, **kwargs):
+        self.commands.append(("hset", args, kwargs))
+        return self
+
+    def expire(self, *args, **kwargs):
+        self.commands.append(("expire", args, kwargs))
+        return self
+
+    async def execute(self):
+        results = []
+        for method_name, args, kwargs in self.commands:
+            method = getattr(self.redis_client, method_name)
+            results.append(await method(*args, **kwargs))
+        self.commands.clear()
+        return results
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.zsets: dict[str, dict[str, float]] = {}
+        self.hashes: dict[str, dict[str, str]] = {}
+        self.strings: dict[str, str] = {}
+
+    def pipeline(self, transaction: bool = True):
+        return _FakePipeline(self)
+
+    async def set(self, key: str, value: str, nx: bool = False, ex: int | None = None):
+        if nx and key in self.strings:
+            return False
+        self.strings[key] = value
+        return True
+
+    async def get(self, key: str):
+        return self.strings.get(key)
+
+    async def eval(self, script: str, key_count: int, key: str, token: str):
+        if self.strings.get(key) == token:
+            self.strings.pop(key, None)
+            return 1
+        return 0
+
+    async def expire(self, key: str, ttl: int):
+        return True
+
+    async def zadd(self, key: str, mapping: dict[str, int | float]):
+        zset = self.zsets.setdefault(key, {})
+        inserted = 0
+        for member, score in mapping.items():
+            if member not in zset:
+                inserted += 1
+            zset[member] = float(score)
+        return inserted
+
+    async def zcard(self, key: str):
+        return len(self.zsets.get(key, {}))
+
+    async def zrange(self, key: str, start: int, end: int):
+        items = sorted(
+            self.zsets.get(key, {}).items(), key=lambda item: (item[1], item[0])
+        )
+        members = [member for member, _ in items]
+        if not members:
+            return []
+        if end < 0:
+            end = len(members) + end
+        if end < start:
+            return []
+        return members[start : end + 1]
+
+    async def zrevrangebyscore(
+        self,
+        key: str,
+        maximum: str | int | float,
+        minimum: str | int | float,
+        start: int = 0,
+        num: int | None = None,
+    ):
+        zset = self.zsets.get(key, {})
+        min_score = self._normalize_score(minimum)
+        max_score = self._normalize_score(maximum)
+        items = [
+            (member, score)
+            for member, score in zset.items()
+            if min_score <= score <= max_score
+        ]
+        items.sort(key=lambda item: (item[1], item[0]), reverse=True)
+        members = [member for member, _ in items]
+        if num is None:
+            return members[start:]
+        return members[start : start + num]
+
+    async def zremrangebyrank(self, key: str, start: int, end: int):
+        members = await self.zrange(key, 0, -1)
+        if not members:
+            return 0
+        if end < 0:
+            end = len(members) + end
+        if end < start:
+            return 0
+        removable = members[start : end + 1]
+        zset = self.zsets.get(key, {})
+        for member in removable:
+            zset.pop(member, None)
+        return len(removable)
+
+    async def hset(self, key: str, mapping: dict[str, str]):
+        target = self.hashes.setdefault(key, {})
+        inserted = 0
+        for field, value in mapping.items():
+            if field not in target:
+                inserted += 1
+            target[field] = value
+        return inserted
+
+    async def hmget(self, key: str, fields: list[str]):
+        target = self.hashes.get(key, {})
+        return [target.get(field) for field in fields]
+
+    async def hgetall(self, key: str):
+        return dict(self.hashes.get(key, {}))
+
+    async def hdel(self, key: str, *fields: str):
+        target = self.hashes.get(key, {})
+        removed = 0
+        for field in fields:
+            if field in target:
+                removed += 1
+                target.pop(field, None)
+        return removed
+
+    @staticmethod
+    def _normalize_score(value: str | int | float) -> float:
+        if isinstance(value, str):
+            if value == "-inf":
+                return float("-inf")
+            if value == "+inf":
+                return float("inf")
+        return float(value)
+
+
+def _build_daily_frame(end_date: date, rows: int) -> pd.DataFrame:
+    dates = [end_date - timedelta(days=index) for index in range(rows)]
+    dates.sort()
+    return pd.DataFrame(
+        {
+            "date": dates,
+            "open": [100.0 + idx for idx in range(rows)],
+            "high": [101.0 + idx for idx in range(rows)],
+            "low": [99.0 + idx for idx in range(rows)],
+            "close": [100.5 + idx for idx in range(rows)],
+            "volume": [1000.0 + idx for idx in range(rows)],
+            "value": [100000.0 + idx for idx in range(rows)],
+        }
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache_state():
+    kis_ohlcv_cache._REDIS_CLIENT = None
+    yield
+    kis_ohlcv_cache._REDIS_CLIENT = None
+
+
+def test_expected_asof_et_handles_est_edt_and_weekend_rollbacks():
+    assert kis_ohlcv_cache.expected_asof_et(
+        datetime(2026, 1, 15, 20, 30, tzinfo=UTC)
+    ) == date(2026, 1, 14)
+    assert kis_ohlcv_cache.expected_asof_et(
+        datetime(2026, 1, 15, 21, 30, tzinfo=UTC)
+    ) == date(2026, 1, 15)
+
+    assert kis_ohlcv_cache.expected_asof_et(
+        datetime(2026, 7, 15, 19, 30, tzinfo=UTC)
+    ) == date(2026, 7, 14)
+
+    assert kis_ohlcv_cache.expected_asof_et(
+        datetime(2026, 7, 18, 18, 0, tzinfo=UTC)
+    ) == date(2026, 7, 17)
+
+
+def test_expected_asof_et_same_for_2330_and_0130_kst():
+    kst = ZoneInfo("Asia/Seoul")
+    first = datetime(2026, 2, 17, 23, 30, tzinfo=kst).astimezone(UTC)
+    second = datetime(2026, 2, 18, 1, 30, tzinfo=kst).astimezone(UTC)
+
+    assert kis_ohlcv_cache.expected_asof_et(first) == date(2026, 2, 16)
+    assert kis_ohlcv_cache.expected_asof_et(first) == kis_ohlcv_cache.expected_asof_et(
+        second
+    )
+
+
+def test_expected_asof_et_uses_1600_close_boundary_for_est_and_edt():
+    # EST: 20:59 UTC = 15:59 ET, 21:00 UTC = 16:00 ET
+    assert kis_ohlcv_cache.expected_asof_et(
+        datetime(2026, 1, 15, 20, 59, tzinfo=UTC)
+    ) == date(2026, 1, 14)
+    assert kis_ohlcv_cache.expected_asof_et(
+        datetime(2026, 1, 15, 21, 0, tzinfo=UTC)
+    ) == date(2026, 1, 15)
+
+    # EDT: 19:59 UTC = 15:59 ET, 20:00 UTC = 16:00 ET
+    assert kis_ohlcv_cache.expected_asof_et(
+        datetime(2026, 7, 15, 19, 59, tzinfo=UTC)
+    ) == date(2026, 7, 14)
+    assert kis_ohlcv_cache.expected_asof_et(
+        datetime(2026, 7, 15, 20, 0, tzinfo=UTC)
+    ) == date(2026, 7, 15)
+
+
+def test_kis_cache_key_format_and_legacy_key_format():
+    dates_key, rows_key, meta_key, lock_key = kis_ohlcv_cache._keys(
+        "AAPL", "NASD", "equity_us"
+    )
+    assert dates_key == "kis:ohlcv:day:v1:equity_us:NASD:AAPL:dates"
+    assert rows_key == "kis:ohlcv:day:v1:equity_us:NASD:AAPL:rows"
+    assert meta_key == "kis:ohlcv:day:v1:equity_us:NASD:AAPL:meta"
+    assert lock_key == "kis:ohlcv:day:v1:equity_us:NASD:AAPL:lock"
+
+    legacy_dates_key, _, _, _ = kis_ohlcv_cache._legacy_keys("AAPL", "NASD", "equity_us")
+    assert legacy_dates_key == "kis:ohlcv:equity_us:day:v1:NASD:AAPL:dates"
+
+
+@pytest.mark.asyncio
+async def test_get_closed_daily_candles_miss_fetch_store_then_hit(monkeypatch):
+    fake_redis = _FakeRedis()
+    target_asof = date(2026, 2, 16)
+
+    async def mock_get_redis_client():
+        return fake_redis
+
+    fetch_mock = AsyncMock(return_value=_build_daily_frame(target_asof, 3))
+
+    monkeypatch.setattr(kis_ohlcv_cache, "_get_redis_client", mock_get_redis_client)
+    monkeypatch.setattr(
+        kis_ohlcv_cache, "expected_asof_et", lambda now_utc: target_asof
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_enabled", True, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_ttl_seconds", 300, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_max_days", 400, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings,
+        "kis_ohlcv_cache_lock_ttl_seconds",
+        10,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings,
+        "kis_ohlcv_cache_probe_retry_seconds",
+        1800,
+        raising=False,
+    )
+
+    first = await kis_ohlcv_cache.get_closed_daily_candles(
+        symbol="AAPL",
+        exchange_code="NASD",
+        count=3,
+        instrument_type="equity_us",
+        raw_fetcher=fetch_mock,
+        now_utc=datetime(2026, 2, 17, 15, 0, tzinfo=UTC),
+    )
+    second = await kis_ohlcv_cache.get_closed_daily_candles(
+        symbol="AAPL",
+        exchange_code="NASD",
+        count=3,
+        instrument_type="equity_us",
+        raw_fetcher=fetch_mock,
+        now_utc=datetime(2026, 2, 17, 15, 30, tzinfo=UTC),
+    )
+
+    assert first is not None
+    assert second is not None
+    assert len(first) == 3
+    assert len(second) == 3
+    assert fetch_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_closed_daily_candles_reads_legacy_cache_for_compat(monkeypatch):
+    fake_redis = _FakeRedis()
+    target_asof = date(2026, 2, 16)
+
+    async def mock_get_redis_client():
+        return fake_redis
+
+    monkeypatch.setattr(kis_ohlcv_cache, "_get_redis_client", mock_get_redis_client)
+    monkeypatch.setattr(
+        kis_ohlcv_cache, "expected_asof_et", lambda now_utc: target_asof
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_enabled", True, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_ttl_seconds", 300, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_max_days", 400, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings,
+        "kis_ohlcv_cache_lock_ttl_seconds",
+        10,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings,
+        "kis_ohlcv_cache_probe_retry_seconds",
+        1800,
+        raising=False,
+    )
+
+    legacy_dates_key, legacy_rows_key, _, _ = kis_ohlcv_cache._legacy_keys(
+        "AAPL", "NASD", "equity_us"
+    )
+    await kis_ohlcv_cache._upsert_rows(
+        fake_redis,
+        legacy_dates_key,
+        legacy_rows_key,
+        _build_daily_frame(target_asof, 3),
+    )
+
+    fetch_mock = AsyncMock()
+    result = await kis_ohlcv_cache.get_closed_daily_candles(
+        symbol="AAPL",
+        exchange_code="NASD",
+        count=3,
+        instrument_type="equity_us",
+        raw_fetcher=fetch_mock,
+        now_utc=datetime(2026, 2, 17, 15, 0, tzinfo=UTC),
+    )
+
+    assert result is not None
+    assert len(result) == 3
+    fetch_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_closed_daily_candles_single_fetch_under_lock_contention(monkeypatch):
+    fake_redis = _FakeRedis()
+    target_asof = date(2026, 2, 16)
+
+    async def mock_get_redis_client():
+        return fake_redis
+
+    async def slow_fetch(
+        *, symbol: str, exchange_code: str, n: int, end_date: date | None
+    ):
+        await asyncio.sleep(0.05)
+        return _build_daily_frame(target_asof, 3)
+
+    fetch_mock = AsyncMock(side_effect=slow_fetch)
+
+    monkeypatch.setattr(kis_ohlcv_cache, "_get_redis_client", mock_get_redis_client)
+    monkeypatch.setattr(
+        kis_ohlcv_cache, "expected_asof_et", lambda now_utc: target_asof
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_enabled", True, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_ttl_seconds", 300, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_max_days", 400, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings,
+        "kis_ohlcv_cache_lock_ttl_seconds",
+        10,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings,
+        "kis_ohlcv_cache_probe_retry_seconds",
+        1800,
+        raising=False,
+    )
+
+    async def _load_once():
+        return await kis_ohlcv_cache.get_closed_daily_candles(
+            symbol="AAPL",
+            exchange_code="NASD",
+            count=3,
+            instrument_type="equity_us",
+            raw_fetcher=fetch_mock,
+            now_utc=datetime(2026, 2, 17, 15, 0, tzinfo=UTC),
+        )
+
+    first, second = await asyncio.gather(_load_once(), _load_once())
+    assert first is not None
+    assert second is not None
+    assert len(first) == 3
+    assert len(second) == 3
+    assert fetch_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_closed_daily_candles_returns_none_on_redis_error(monkeypatch):
+    async def mock_get_redis_client():
+        raise RuntimeError("redis unavailable")
+
+    fetch_mock = AsyncMock()
+
+    monkeypatch.setattr(kis_ohlcv_cache, "_get_redis_client", mock_get_redis_client)
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_enabled", True, raising=False
+    )
+
+    result = await kis_ohlcv_cache.get_closed_daily_candles(
+        symbol="AAPL",
+        exchange_code="NASD",
+        count=3,
+        instrument_type="equity_us",
+        raw_fetcher=fetch_mock,
+        now_utc=datetime(2026, 2, 17, 15, 0, tzinfo=UTC),
+    )
+
+    assert result is None
+    fetch_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_get_closed_daily_candles_sets_probe_suppression_on_partial_latest(
+    monkeypatch,
+):
+    fake_redis = _FakeRedis()
+    target_asof = date(2026, 2, 17)
+    partial_latest = date(2026, 2, 14)
+
+    async def mock_get_redis_client():
+        return fake_redis
+
+    fetch_mock = AsyncMock(return_value=_build_daily_frame(partial_latest, 3))
+
+    monkeypatch.setattr(kis_ohlcv_cache, "_get_redis_client", mock_get_redis_client)
+    monkeypatch.setattr(
+        kis_ohlcv_cache, "expected_asof_et", lambda now_utc: target_asof
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_enabled", True, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_ttl_seconds", 300, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_max_days", 400, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings,
+        "kis_ohlcv_cache_lock_ttl_seconds",
+        10,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings,
+        "kis_ohlcv_cache_probe_retry_seconds",
+        1800,
+        raising=False,
+    )
+
+    first = await kis_ohlcv_cache.get_closed_daily_candles(
+        symbol="AAPL",
+        exchange_code="NASD",
+        count=3,
+        instrument_type="equity_us",
+        raw_fetcher=fetch_mock,
+        now_utc=datetime(2026, 2, 17, 15, 0, tzinfo=UTC),
+    )
+    second = await kis_ohlcv_cache.get_closed_daily_candles(
+        symbol="AAPL",
+        exchange_code="NASD",
+        count=3,
+        instrument_type="equity_us",
+        raw_fetcher=fetch_mock,
+        now_utc=datetime(2026, 2, 17, 15, 5, tzinfo=UTC),
+    )
+
+    assert first is not None
+    assert second is not None
+    assert len(first) == 3
+    assert len(second) == 3
+    assert fetch_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_closed_daily_candles_same_asof_hit_for_2330_and_0130_kst(
+    monkeypatch,
+):
+    fake_redis = _FakeRedis()
+    target_asof = date(2026, 2, 16)
+    kst = ZoneInfo("Asia/Seoul")
+
+    async def mock_get_redis_client():
+        return fake_redis
+
+    fetch_mock = AsyncMock(return_value=_build_daily_frame(target_asof, 5))
+
+    monkeypatch.setattr(kis_ohlcv_cache, "_get_redis_client", mock_get_redis_client)
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_enabled", True, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_ttl_seconds", 300, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings, "kis_ohlcv_cache_max_days", 400, raising=False
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings,
+        "kis_ohlcv_cache_lock_ttl_seconds",
+        10,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        kis_ohlcv_cache.settings,
+        "kis_ohlcv_cache_probe_retry_seconds",
+        1800,
+        raising=False,
+    )
+
+    first_now = datetime(2026, 2, 17, 23, 30, tzinfo=kst).astimezone(UTC)
+    second_now = datetime(2026, 2, 18, 1, 30, tzinfo=kst).astimezone(UTC)
+
+    first = await kis_ohlcv_cache.get_closed_daily_candles(
+        symbol="AAPL",
+        exchange_code="NASD",
+        count=3,
+        instrument_type="equity_us",
+        raw_fetcher=fetch_mock,
+        now_utc=first_now,
+    )
+    second = await kis_ohlcv_cache.get_closed_daily_candles(
+        symbol="AAPL",
+        exchange_code="NASD",
+        count=3,
+        instrument_type="equity_us",
+        raw_fetcher=fetch_mock,
+        now_utc=second_now,
+    )
+
+    assert first is not None
+    assert second is not None
+    assert len(first) == 3
+    assert len(second) == 3
+    assert fetch_mock.await_count == 1

--- a/tests/test_mcp_server_tools.py
+++ b/tests/test_mcp_server_tools.py
@@ -35,7 +35,6 @@ from app.mcp_server.tooling.registry import register_all_tools
 from app.models.dca_plan import DcaPlan, DcaPlanStatus, DcaPlanStep, DcaStepStatus
 from app.services import naver_finance
 from app.services import upbit as upbit_service
-from app.services import yahoo as yahoo_service
 from app.services.dca_service import DcaService
 
 # from app.mcp_server.tick_size import adjust_tick_size_kr  # TODO: Remove if not needed
@@ -1226,14 +1225,17 @@ async def test_get_ohlcv_korean_etf_with_explicit_market(monkeypatch):
 @pytest.mark.asyncio
 async def test_get_ohlcv_us_equity_returns_error_payload(monkeypatch):
     tools = build_tools()
-    mock_fetch = AsyncMock(side_effect=RuntimeError("yahoo timeout"))
-    monkeypatch.setattr(yahoo_service, "fetch_ohlcv", mock_fetch)
+    monkeypatch.setattr(
+        market_data_quotes.kis_ohlcv_cache,
+        "get_closed_daily_candles",
+        AsyncMock(side_effect=RuntimeError("kis timeout")),
+    )
 
     result = await tools["get_ohlcv"]("AAPL", count=5)
 
     assert result == {
-        "error": "yahoo timeout",
-        "source": "yahoo",
+        "error": "kis timeout",
+        "source": "kis",
         "symbol": "AAPL",
         "instrument_type": "equity_us",
     }
@@ -1243,18 +1245,83 @@ async def test_get_ohlcv_us_equity_returns_error_payload(monkeypatch):
 async def test_get_ohlcv_us_equity(monkeypatch):
     tools = build_tools()
     df = _single_row_df()
-    mock_fetch = AsyncMock(return_value=df)
-    monkeypatch.setattr(yahoo_service, "fetch_ohlcv", mock_fetch)
+    cache_mock = AsyncMock(return_value=df)
+    monkeypatch.setattr(
+        market_data_quotes.kis_ohlcv_cache,
+        "get_closed_daily_candles",
+        cache_mock,
+    )
 
     result = await tools["get_ohlcv"]("AAPL", count=5)
 
-    mock_fetch.assert_awaited_once_with(
-        ticker="AAPL", days=5, period="day", end_date=None
-    )
+    cache_mock.assert_awaited_once()
+    assert cache_mock.call_args is not None
+    call_kwargs = cache_mock.call_args.kwargs
+    assert call_kwargs["symbol"] == "AAPL"
+    assert call_kwargs["count"] == 5
     assert result["instrument_type"] == "equity_us"
-    assert result["source"] == "yahoo"
+    assert result["source"] == "kis"
     assert result["count"] == 5
     assert len(result["rows"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_ohlcv_us_equity_caps_count_to_200(monkeypatch):
+    tools = build_tools()
+    df = _single_row_df()
+    cache_mock = AsyncMock(return_value=df)
+    monkeypatch.setattr(
+        market_data_quotes.kis_ohlcv_cache,
+        "get_closed_daily_candles",
+        cache_mock,
+    )
+
+    result = await tools["get_ohlcv"]("AAPL", count=999)
+
+    cache_mock.assert_awaited_once()
+    assert cache_mock.call_args is not None
+    assert cache_mock.call_args.kwargs["count"] == 200
+    assert result["count"] == 200
+    assert result["source"] == "kis"
+
+
+@pytest.mark.asyncio
+async def test_get_ohlcv_us_equity_day_with_end_date_bypasses_cache(monkeypatch):
+    tools = build_tools()
+    df = _single_row_df()
+    cache_mock = AsyncMock(side_effect=AssertionError("cache should be bypassed"))
+    monkeypatch.setattr(
+        market_data_quotes.kis_ohlcv_cache,
+        "get_closed_daily_candles",
+        cache_mock,
+    )
+    called: dict[str, object] = {}
+
+    class DummyKISClient:
+        async def inquire_overseas_daily_price(
+            self,
+            symbol: str,
+            exchange_code: str = "NASD",
+            n: int = 200,
+            period: str = "D",
+            end_date: date | None = None,
+        ):
+            called["symbol"] = symbol
+            called["exchange_code"] = exchange_code
+            called["n"] = n
+            called["period"] = period
+            called["end_date"] = end_date
+            return df
+
+    _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
+
+    result = await tools["get_ohlcv"]("AAPL", count=5, period="day", end_date="2026-01-15")
+
+    cache_mock.assert_not_awaited()
+    assert called["symbol"] == "AAPL"
+    assert called["period"] == "D"
+    assert called["end_date"] == date(2026, 1, 15)
+    assert result["source"] == "kis"
 
 
 @pytest.mark.asyncio
@@ -1374,7 +1441,7 @@ async def test_get_indicators_obv_returns_error_when_volume_column_missing(monke
 
     result = await tools["get_indicators"]("AAPL", indicators=["obv"])
 
-    assert result["source"] == "yahoo"
+    assert result["source"] == "kis"
     assert "error" in result
     assert "Missing required columns" in result["error"]
     assert "volume" in result["error"]
@@ -5669,6 +5736,41 @@ async def test_get_support_resistance_clusters_levels(monkeypatch):
         expected = round((r["price"] - 100.0) / 100.0 * 100, 2)
         assert r["distance_pct"] == expected
         assert r["distance_pct"] > 0  # resistances are above current price
+
+
+@pytest.mark.asyncio
+async def test_get_support_resistance_us_error_payload_source_is_kis(monkeypatch):
+    tools = build_tools()
+    _patch_runtime_attr(
+        monkeypatch,
+        "_fetch_ohlcv_for_indicators",
+        AsyncMock(side_effect=RuntimeError("fetch failed")),
+    )
+
+    result = await tools["get_support_resistance"]("AAPL", market="us")
+
+    assert result["source"] == "kis"
+    assert result["instrument_type"] == "equity_us"
+    assert result["symbol"] == "AAPL"
+    assert "fetch failed" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_correlation_us_metadata_source_is_kis(monkeypatch):
+    tools = build_tools()
+    frame = pd.DataFrame({"close": [100.0, 101.0, 102.0, 103.0]})
+
+    _patch_runtime_attr(
+        monkeypatch,
+        "_fetch_ohlcv_for_indicators",
+        AsyncMock(return_value=frame),
+    )
+
+    result = await tools["get_correlation"](["AAPL", "MSFT"], period=30)
+
+    assert result["success"] is True
+    assert result["metadata"]["sources"]["AAPL"] == "kis"
+    assert result["metadata"]["sources"]["MSFT"] == "kis"
 
 
 @pytest.mark.asyncio

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1059,6 +1059,52 @@ class TestKISOverseasDailyPrice:
         assert mock_client.get.call_count == 2
         client._token_manager.clear_token.assert_awaited_once()
 
+    @pytest.mark.asyncio
+    @patch("app.services.kis.httpx.AsyncClient")
+    @patch("app.services.kis.settings")
+    async def test_inquire_overseas_daily_price_uses_end_date_as_bymd(
+        self, mock_settings, mock_client_class
+    ):
+        from datetime import date
+
+        from app.services.kis import KISClient
+
+        mock_settings.kis_account_no = "1234567890"
+        mock_settings.kis_access_token = "test_token"
+
+        mock_client = AsyncMock()
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "rt_cd": "0",
+            "output2": [
+                {
+                    "xymd": "20260115",
+                    "open": "190.0",
+                    "high": "191.0",
+                    "low": "189.0",
+                    "clos": "190.5",
+                    "tvol": "100",
+                }
+            ],
+        }
+        mock_client.get.return_value = mock_response
+
+        client = KISClient()
+        client._ensure_token = AsyncMock(return_value=None)
+        client._token_manager = AsyncMock()
+
+        end_date = date(2026, 1, 15)
+        result = await client.inquire_overseas_daily_price(
+            symbol="AAPL", n=1, end_date=end_date
+        )
+
+        assert len(result) == 1
+        params = mock_client.get.call_args.kwargs["params"]
+        assert params["BYMD"] == "20260115"
+
 
 class TestKISRequestWithRateLimit:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- switch US daily OHLCV cache usage to apply only when end_date is not provided
- align ET as-of boundary to 16:00 and harden probe suppression for non-trading or partial-latest days
- normalize KIS OHLCV cache key/meta schema with one-release legacy-key fallback
- keep US quote path on Yahoo while unifying OHLCV/indicator-derived source metadata to KIS
- update MCP docs and correlation description for KIS-based US correlation path

## Test
- uv run pytest tests/test_kis_ohlcv_cache.py -q --no-cov
- uv run pytest tests/test_services.py -k "inquire_overseas_daily_price" -q --no-cov
- uv run pytest tests/test_mcp_server_tools.py -k "get_ohlcv or get_indicators or correlation or support_resistance or get_quote_us_equity or get_holdings_preserves_kis_values_on_yahoo_failure" -q --no-cov
- make test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redis-backed caching for US daily market data with configurable TTL and retention limits.
  * Switched US market data source to KIS with 200-entry maximum per request.
  * Cache automatically handles market close times (ET 16:00) with weekend rollback adjustments.

* **Documentation**
  * Updated documentation to reflect new US data source and cache behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->