### PR TITLE
feat: add watch alerts scheduler and mcp management

### DIFF
--- a/app/jobs/watch_scanner.py
+++ b/app/jobs/watch_scanner.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+
+import exchange_calendars as xcals
+import pandas as pd
+from pandas import Timestamp
+
+from app.mcp_server.tooling.market_data_indicators import _calculate_rsi
+from app.services import upbit as upbit_service
+from app.services import yahoo as yahoo_service
+from app.services.kis import KISClient
+from app.services.openclaw_client import OpenClawClient
+from app.services.watch_alerts import WatchAlertService
+
+logger = logging.getLogger(__name__)
+_CRYPTO_RSI_LOOKBACK_DAYS = 200
+
+
+class WatchScanner:
+    def __init__(self) -> None:
+        self._watch_service = WatchAlertService()
+        self._openclaw = OpenClawClient()
+        self._kis = KISClient()
+
+    @staticmethod
+    @lru_cache(maxsize=2)
+    def _get_calendar(market: str):
+        if market == "kr":
+            return xcals.get_calendar("XKRX")
+        if market == "us":
+            return xcals.get_calendar("XNYS")
+        return None
+
+    def _is_market_open(self, market: str) -> bool:
+        if market == "crypto":
+            return True
+
+        calendar = self._get_calendar(market)
+        if calendar is None:
+            return False
+
+        now_utc = Timestamp.now("UTC").floor("min")
+        if now_utc.tz is None:
+            now_utc = now_utc.tz_localize("UTC")
+        now_in_market_tz = now_utc.tz_convert(calendar.tz)
+        return bool(calendar.is_trading_minute(now_in_market_tz))
+
+    @staticmethod
+    def _to_float(value: object) -> float | None:
+        try:
+            if value is None:
+                return None
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _extract_close(frame: pd.DataFrame) -> float | None:
+        if frame.empty or "close" not in frame.columns:
+            return None
+        value = frame["close"].iloc[-1]
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _is_triggered(current: float | None, operator: str, threshold: float) -> bool:
+        if current is None:
+            return False
+        if operator == "above":
+            return current > threshold
+        if operator == "below":
+            return current < threshold
+        return False
+
+    @staticmethod
+    def _normalize_crypto_symbol(symbol: str) -> str:
+        upper_symbol = symbol.strip().upper()
+        if "-" in upper_symbol:
+            return upper_symbol
+        return f"KRW-{upper_symbol}"
+
+    async def _get_price(self, symbol: str, market: str) -> float | None:
+        if market == "crypto":
+            frame = await upbit_service.fetch_price(
+                self._normalize_crypto_symbol(symbol)
+            )
+            return self._extract_close(frame)
+        if market == "kr":
+            frame = await self._kis.inquire_price(symbol)
+            return self._extract_close(frame)
+        if market == "us":
+            frame = await yahoo_service.fetch_price(symbol)
+            return self._extract_close(frame)
+        return None
+
+    async def _get_rsi(self, symbol: str, market: str) -> float | None:
+        frame: pd.DataFrame
+        if market == "crypto":
+            frame = await upbit_service.fetch_ohlcv(
+                market=self._normalize_crypto_symbol(symbol),
+                days=_CRYPTO_RSI_LOOKBACK_DAYS,
+                period="day",
+            )
+        elif market == "kr":
+            frame = await self._kis.inquire_daily_itemchartprice(
+                code=symbol,
+                market="J",
+                n=250,
+                period="D",
+            )
+        elif market == "us":
+            frame = await yahoo_service.fetch_ohlcv(
+                ticker=symbol,
+                days=250,
+                period="day",
+            )
+        else:
+            return None
+
+        if frame.empty or "close" not in frame.columns:
+            return None
+
+        close = pd.to_numeric(frame["close"], errors="coerce").dropna()
+        if close.empty:
+            return None
+
+        return self._to_float(_calculate_rsi(close).get("14"))
+
+    @staticmethod
+    def _build_batched_message(
+        market: str,
+        triggered: list[dict[str, object]],
+    ) -> str:
+        lines = [f"Watch alerts ({market})"]
+        for row in triggered:
+            symbol = str(row["symbol"])
+            condition_type = str(row["condition_type"])
+            threshold = float(row["threshold"])
+            current = float(row["current"])
+            lines.append(
+                f"- {symbol} {condition_type}: current={current:.4f}, threshold={threshold:.4f}"
+            )
+        return "\n".join(lines)
+
+    async def _send_alert(self, message: str) -> str | None:
+        try:
+            return await self._openclaw.send_watch_alert(message)
+        except Exception as exc:
+            logger.error("Failed to send watch scan alert: %s", exc)
+            return None
+
+    async def scan_market(self, market: str) -> dict[str, object]:
+        normalized_market = str(market).strip().lower()
+        if not self._is_market_open(normalized_market):
+            return {
+                "market": normalized_market,
+                "skipped": True,
+                "reason": "market_closed",
+            }
+
+        watches = await self._watch_service.get_watches_for_market(normalized_market)
+        if not watches:
+            return {"market": normalized_market, "alerts_sent": 0, "details": []}
+
+        triggered: list[dict[str, object]] = []
+        triggered_fields: list[str] = []
+
+        for watch in watches:
+            symbol = str(watch.get("symbol") or "").strip().upper()
+            condition_type = str(watch.get("condition_type") or "").strip().lower()
+            field = str(watch.get("field") or "")
+            threshold = self._to_float(watch.get("threshold"))
+
+            if not symbol or not condition_type or not field or threshold is None:
+                continue
+
+            try:
+                metric, operator = condition_type.split("_", 1)
+            except ValueError:
+                continue
+
+            current: float | None
+            if metric == "price":
+                current = await self._get_price(symbol, normalized_market)
+            elif metric == "rsi":
+                current = await self._get_rsi(symbol, normalized_market)
+            else:
+                continue
+
+            if not self._is_triggered(current, operator, threshold):
+                continue
+
+            triggered.append(
+                {
+                    "symbol": symbol,
+                    "condition_type": condition_type,
+                    "threshold": threshold,
+                    "current": current,
+                }
+            )
+            triggered_fields.append(field)
+
+        if not triggered:
+            return {"market": normalized_market, "alerts_sent": 0, "details": []}
+
+        message = self._build_batched_message(normalized_market, triggered)
+        request_id = await self._send_alert(message)
+        if not request_id:
+            return {"market": normalized_market, "alerts_sent": 0, "details": []}
+
+        for field in triggered_fields:
+            await self._watch_service.trigger_and_remove(normalized_market, field)
+
+        return {
+            "market": normalized_market,
+            "alerts_sent": len(triggered_fields),
+            "details": [message],
+        }
+
+    async def run(self) -> dict[str, dict[str, object]]:
+        results: dict[str, dict[str, object]] = {}
+        for market in ("crypto", "kr", "us"):
+            market_result = await self.scan_market(market)
+            results[market] = dict(market_result)
+        return results
+
+    async def close(self) -> None:
+        await self._watch_service.close()

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -27,8 +27,63 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - `place_order(symbol, side, order_type="limit", quantity=None, price=None, amount=None)`
 - `modify_order(order_id, symbol, new_price=None, new_quantity=None)`
 - `cancel_order(order_id)`
+- `manage_watch_alerts(action, market=None, symbol=None, metric=None, operator=None, threshold=None)`
 - `screen_stocks(...)` - Screen stocks across different markets (KR/US/Crypto) with various filters.
 - `recommend_stocks(...)` - Recommend stocks based on budget and strategy.
+
+### `manage_watch_alerts` spec
+Parameters:
+- `action`: Required action - `"add"`, `"remove"`, `"list"`
+- `market`: Market - `"crypto"`, `"kr"`, `"us"` (required for `add`/`remove`, optional for `list`)
+- `symbol`: Asset symbol/ticker (required for `add`/`remove`)
+- `metric`: Condition metric - `"price"` or `"rsi"` (required for `add`/`remove`)
+- `operator`: Condition operator - `"above"` or `"below"` (required for `add`/`remove`)
+- `threshold`: Numeric threshold value (required for `add`/`remove`)
+
+Behavior:
+- `action="add"`: Creates a watch condition in Redis; repeated same condition is idempotent.
+- `action="remove"`: Removes one matching watch condition.
+- `action="list"`: Returns all watches, optionally filtered by market.
+- Triggered watches are removed only after successful outbound alert delivery by the scheduler path.
+
+Response examples:
+```json
+{
+  "success": true,
+  "action": "add",
+  "market": "crypto",
+  "symbol": "BTC",
+  "condition_type": "price_below",
+  "threshold": 90000000.0,
+  "created": true,
+  "already_exists": false
+}
+```
+
+```json
+{
+  "success": true,
+  "action": "list",
+  "watches": {
+    "crypto": [
+      {
+        "symbol": "BTC",
+        "condition_type": "price_below",
+        "threshold": 90000000.0,
+        "created_at": "2026-02-17T13:40:00+09:00"
+      }
+    ]
+  }
+}
+```
+
+Error examples:
+```json
+{
+  "success": false,
+  "error": "Unknown action: foo"
+}
+```
 
 ### `screen_stocks` spec
 Parameters:

--- a/app/mcp_server/__init__.py
+++ b/app/mcp_server/__init__.py
@@ -42,4 +42,5 @@ AVAILABLE_TOOL_NAMES = [
     "modify_order",
     "screen_stocks",
     "recommend_stocks",
+    "manage_watch_alerts",
 ]

--- a/app/mcp_server/tooling/__init__.py
+++ b/app/mcp_server/tooling/__init__.py
@@ -15,5 +15,13 @@ This package contains the refactored MCP tools split by domain:
 """
 
 from app.mcp_server.tooling.registry import register_all_tools
+from app.mcp_server.tooling.watch_alerts_registration import (
+    WATCH_ALERT_TOOL_NAMES,
+    register_watch_alert_tools,
+)
 
-__all__ = ["register_all_tools"]
+__all__ = [
+    "WATCH_ALERT_TOOL_NAMES",
+    "register_all_tools",
+    "register_watch_alert_tools",
+]

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -9,6 +9,9 @@ from app.mcp_server.tooling.fundamentals_registration import register_fundamenta
 from app.mcp_server.tooling.market_data_registration import register_market_data_tools
 from app.mcp_server.tooling.orders_registration import register_order_tools
 from app.mcp_server.tooling.portfolio_registration import register_portfolio_tools
+from app.mcp_server.tooling.watch_alerts_registration import (
+    register_watch_alert_tools,
+)
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -20,6 +23,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_order_tools(mcp)
     register_fundamentals_tools(mcp)
     register_analysis_tools(mcp)
+    register_watch_alert_tools(mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/app/mcp_server/tooling/watch_alerts_registration.py
+++ b/app/mcp_server/tooling/watch_alerts_registration.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.services.watch_alerts import WatchAlertService
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+WATCH_ALERT_TOOL_NAMES: set[str] = {"manage_watch_alerts"}
+
+
+async def manage_watch_alerts_impl(
+    action: str,
+    market: str | None = None,
+    symbol: str | None = None,
+    metric: str | None = None,
+    operator: str | None = None,
+    threshold: float | None = None,
+) -> dict:
+    service = WatchAlertService()
+    try:
+        normalized_action = str(action or "").strip().lower()
+        if normalized_action not in {"add", "remove", "list"}:
+            return {
+                "success": False,
+                "error": f"Unknown action: {action}",
+            }
+
+        if normalized_action == "list":
+            listed = await service.list_watches(market=market)
+            return {
+                "success": True,
+                "action": "list",
+                "watches": listed,
+            }
+
+        if not market or not symbol:
+            return {
+                "success": False,
+                "error": "market and symbol are required for add/remove",
+            }
+
+        normalized_metric = str(metric or "").strip().lower()
+        normalized_operator = str(operator or "").strip().lower()
+        if normalized_metric not in {"price", "rsi"}:
+            return {
+                "success": False,
+                "error": f"Invalid metric: {metric}",
+            }
+        if normalized_operator not in {"above", "below"}:
+            return {
+                "success": False,
+                "error": f"Invalid operator: {operator}",
+            }
+        if threshold is None:
+            return {
+                "success": False,
+                "error": "threshold is required for add/remove",
+            }
+
+        normalized_market = str(market).strip().lower()
+        normalized_symbol = str(symbol).strip().upper()
+        condition_type = f"{normalized_metric}_{normalized_operator}"
+        normalized_threshold = float(threshold)
+
+        if normalized_action == "add":
+            result = await service.add_watch(
+                market=market,
+                symbol=symbol,
+                condition_type=condition_type,
+                threshold=normalized_threshold,
+            )
+            return {
+                "success": True,
+                "action": "add",
+                **result,
+                "market": normalized_market,
+                "symbol": normalized_symbol,
+                "condition_type": condition_type,
+                "threshold": normalized_threshold,
+            }
+
+        result = await service.remove_watch(
+            market=market,
+            symbol=symbol,
+            condition_type=condition_type,
+            threshold=normalized_threshold,
+        )
+        return {
+            "success": True,
+            "action": "remove",
+            **result,
+            "market": normalized_market,
+            "symbol": normalized_symbol,
+            "condition_type": condition_type,
+            "threshold": normalized_threshold,
+        }
+    except ValueError as exc:
+        return {
+            "success": False,
+            "error": str(exc),
+        }
+    except Exception as exc:
+        return {
+            "success": False,
+            "error": f"manage_watch_alerts failed: {exc}",
+        }
+    finally:
+        await service.close()
+
+
+def register_watch_alert_tools(mcp: FastMCP) -> None:
+    mcp.tool(
+        name="manage_watch_alerts",
+        description=(
+            "Manage watch alerts by action=add/remove/list. "
+            "add/remove require market,symbol,metric,operator,threshold. "
+            "list optionally accepts market."
+        ),
+    )(manage_watch_alerts_impl)
+
+
+__all__ = [
+    "WATCH_ALERT_TOOL_NAMES",
+    "manage_watch_alerts_impl",
+    "register_watch_alert_tools",
+]

--- a/app/services/openclaw_client.py
+++ b/app/services/openclaw_client.py
@@ -177,16 +177,16 @@ class OpenClawClient:
             )
             return None
 
-    async def send_scan_alert(self, message: str) -> str | None:
+    async def _send_market_alert(self, message: str, category: str) -> str | None:
         if not settings.OPENCLAW_ENABLED:
-            logger.debug("OpenClaw disabled, skipping scan alert")
+            logger.debug("OpenClaw disabled, skipping %s alert", category)
             return None
 
         request_id = str(uuid4())
         payload = {
             "message": message,
-            "name": "auto-trader:scan",
-            "sessionKey": f"auto-trader:scan:{request_id}",
+            "name": f"auto-trader:{category}",
+            "sessionKey": f"auto-trader:{category}:{request_id}",
             "wakeMode": "now",
         }
 
@@ -206,24 +206,36 @@ class OpenClawClient:
                             self._webhook_url, json=payload, headers=headers
                         )
                         res.raise_for_status()
-                    logger.info("OpenClaw scan alert sent: request_id=%s", request_id)
-                    await self._forward_to_telegram(message, alert_type="scan")
+                    logger.info(
+                        "OpenClaw %s alert sent: request_id=%s",
+                        category,
+                        request_id,
+                    )
+                    await self._forward_to_telegram(message, alert_type=category)
                     return request_id
 
         except RetryError as e:
             logger.error(
-                "OpenClaw scan alert failed after retries: request_id=%s error=%s",
+                "OpenClaw %s alert failed after retries: request_id=%s error=%s",
+                category,
                 request_id,
                 e,
             )
             return None
         except Exception as e:
             logger.error(
-                "OpenClaw scan alert error: request_id=%s error=%s",
+                "OpenClaw %s alert error: request_id=%s error=%s",
+                category,
                 request_id,
                 e,
             )
             return None
+
+    async def send_scan_alert(self, message: str) -> str | None:
+        return await self._send_market_alert(message, category="scan")
+
+    async def send_watch_alert(self, message: str) -> str | None:
+        return await self._send_market_alert(message, category="watch")
 
 
 def _build_openclaw_message(

--- a/app/services/watch_alerts.py
+++ b/app/services/watch_alerts.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+
+import redis.asyncio as redis
+
+from app.core.config import settings
+from app.core.timezone import now_kst
+
+_SUPPORTED_MARKETS = {"crypto", "kr", "us"}
+_SUPPORTED_CONDITIONS = {
+    "price_above",
+    "price_below",
+    "rsi_above",
+    "rsi_below",
+}
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_threshold(threshold: float) -> tuple[float, str]:
+    threshold_float = float(threshold)
+    canonical = format(threshold_float, ".15g")
+    if "." in canonical:
+        canonical = canonical.rstrip("0").rstrip(".")
+    if canonical == "":
+        canonical = "0"
+    return threshold_float, canonical
+
+
+@dataclass(slots=True)
+class _WatchKey:
+    symbol: str
+    condition_type: str
+    threshold: float
+    threshold_key: str
+
+    @property
+    def field(self) -> str:
+        return f"{self.symbol}:{self.condition_type}:{self.threshold_key}"
+
+
+class WatchAlertService:
+    def __init__(self) -> None:
+        self._redis: redis.Redis | None = None
+
+    @staticmethod
+    def _normalize_market(market: str) -> str:
+        normalized = str(market or "").strip().lower()
+        if normalized not in _SUPPORTED_MARKETS:
+            raise ValueError("market must be one of: crypto, kr, us")
+        return normalized
+
+    @staticmethod
+    def _normalize_symbol(symbol: str) -> str:
+        normalized = str(symbol or "").strip().upper()
+        if not normalized:
+            raise ValueError("symbol is required")
+        return normalized
+
+    @staticmethod
+    def _normalize_condition_type(condition_type: str) -> str:
+        normalized = str(condition_type or "").strip().lower()
+        if normalized not in _SUPPORTED_CONDITIONS:
+            raise ValueError(
+                "condition_type must be one of: price_above, price_below, "
+                "rsi_above, rsi_below"
+            )
+        return normalized
+
+    @staticmethod
+    def _split_condition(condition_type: str) -> tuple[str, str]:
+        metric, operator = condition_type.split("_", 1)
+        return metric, operator
+
+    @staticmethod
+    def _key_for_market(market: str) -> str:
+        return f"watch:alerts:{market}"
+
+    async def _get_redis(self) -> redis.Redis:
+        if self._redis is None:
+            self._redis = redis.from_url(
+                settings.get_redis_url(),
+                max_connections=settings.redis_max_connections,
+                socket_timeout=settings.redis_socket_timeout,
+                socket_connect_timeout=settings.redis_socket_connect_timeout,
+                decode_responses=True,
+            )
+        return self._redis
+
+    async def close(self) -> None:
+        if self._redis is not None:
+            await self._redis.close()
+            self._redis = None
+
+    def validate_watch_inputs(
+        self,
+        market: str,
+        symbol: str,
+        condition_type: str,
+        threshold: float,
+    ) -> _WatchKey:
+        normalized_market = self._normalize_market(market)
+        _ = normalized_market
+
+        normalized_symbol = self._normalize_symbol(symbol)
+        normalized_condition = self._normalize_condition_type(condition_type)
+        threshold_float, threshold_key = _normalize_threshold(threshold)
+
+        if normalized_condition.startswith("rsi_") and not (
+            0.0 <= threshold_float <= 100.0
+        ):
+            raise ValueError("RSI threshold must be between 0 and 100")
+
+        return _WatchKey(
+            symbol=normalized_symbol,
+            condition_type=normalized_condition,
+            threshold=threshold_float,
+            threshold_key=threshold_key,
+        )
+
+    async def add_watch(
+        self,
+        market: str,
+        symbol: str,
+        condition_type: str,
+        threshold: float,
+    ) -> dict[str, object]:
+        normalized_market = self._normalize_market(market)
+        watch_key = self.validate_watch_inputs(
+            market=normalized_market,
+            symbol=symbol,
+            condition_type=condition_type,
+            threshold=threshold,
+        )
+        redis_client = await self._get_redis()
+        redis_key = self._key_for_market(normalized_market)
+
+        already_exists = await redis_client.hexists(redis_key, watch_key.field)
+        if already_exists:
+            return {
+                "market": normalized_market,
+                "symbol": watch_key.symbol,
+                "condition_type": watch_key.condition_type,
+                "threshold": watch_key.threshold,
+                "field": watch_key.field,
+                "created": False,
+                "already_exists": True,
+            }
+
+        payload = {"created_at": now_kst().isoformat()}
+        await redis_client.hset(redis_key, watch_key.field, json.dumps(payload))
+
+        return {
+            "market": normalized_market,
+            "symbol": watch_key.symbol,
+            "condition_type": watch_key.condition_type,
+            "threshold": watch_key.threshold,
+            "field": watch_key.field,
+            "created": True,
+            "already_exists": False,
+        }
+
+    async def remove_watch(
+        self,
+        market: str,
+        symbol: str,
+        condition_type: str,
+        threshold: float,
+    ) -> dict[str, object]:
+        normalized_market = self._normalize_market(market)
+        watch_key = self.validate_watch_inputs(
+            market=normalized_market,
+            symbol=symbol,
+            condition_type=condition_type,
+            threshold=threshold,
+        )
+        removed = await self.trigger_and_remove(normalized_market, watch_key.field)
+        return {
+            "market": normalized_market,
+            "symbol": watch_key.symbol,
+            "condition_type": watch_key.condition_type,
+            "threshold": watch_key.threshold,
+            "field": watch_key.field,
+            "removed": removed,
+        }
+
+    async def trigger_and_remove(self, market: str, field: str) -> bool:
+        normalized_market = self._normalize_market(market)
+        redis_client = await self._get_redis()
+        removed = await redis_client.hdel(
+            self._key_for_market(normalized_market), field
+        )
+        return bool(removed)
+
+    async def get_watches_for_market(self, market: str) -> list[dict[str, object]]:
+        normalized_market = self._normalize_market(market)
+        listed = await self.list_watches(normalized_market)
+        return listed[normalized_market]
+
+    async def list_watches(
+        self,
+        market: str | None = None,
+    ) -> dict[str, list[dict[str, object]]]:
+        markets: list[str]
+        if market is None:
+            markets = ["crypto", "kr", "us"]
+        else:
+            markets = [self._normalize_market(market)]
+
+        redis_client = await self._get_redis()
+        results: dict[str, list[dict[str, object]]] = {}
+
+        for market_name in markets:
+            redis_key = self._key_for_market(market_name)
+            payloads = await redis_client.hgetall(redis_key)
+            rows: list[dict[str, object]] = []
+            for field, raw_payload in payloads.items():
+                try:
+                    symbol, condition_type, threshold_key = field.split(":", 2)
+                except ValueError:
+                    logger.warning(
+                        "Skipping malformed watch field: market=%s field=%s",
+                        market_name,
+                        field,
+                    )
+                    continue
+
+                try:
+                    normalized_condition = self._normalize_condition_type(condition_type)
+                except ValueError:
+                    logger.warning(
+                        "Skipping unsupported condition type: market=%s field=%s",
+                        market_name,
+                        field,
+                    )
+                    continue
+
+                try:
+                    threshold_value = float(threshold_key)
+                except (TypeError, ValueError):
+                    logger.warning(
+                        "Skipping malformed threshold: market=%s field=%s",
+                        market_name,
+                        field,
+                    )
+                    continue
+
+                metric, operator = self._split_condition(normalized_condition)
+
+                created_at: str | None = None
+                if raw_payload:
+                    try:
+                        parsed = json.loads(raw_payload)
+                    except json.JSONDecodeError:
+                        parsed = {}
+                    if isinstance(parsed, dict):
+                        value = parsed.get("created_at")
+                        if isinstance(value, str):
+                            created_at = value
+
+                rows.append(
+                    {
+                        "market": market_name,
+                        "symbol": symbol,
+                        "condition_type": normalized_condition,
+                        "metric": metric,
+                        "operator": operator,
+                        "threshold": threshold_value,
+                        "field": field,
+                        "created_at": created_at,
+                    }
+                )
+
+            rows.sort(key=lambda row: str(row["field"]))
+            results[market_name] = rows
+
+        return results

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -1,3 +1,3 @@
-from app.tasks import daily_scan_tasks
+from app.tasks import daily_scan_tasks, watch_scan_tasks
 
-TASKIQ_TASK_MODULES = (daily_scan_tasks,)
+TASKIQ_TASK_MODULES = (daily_scan_tasks, watch_scan_tasks)

--- a/app/tasks/watch_scan_tasks.py
+++ b/app/tasks/watch_scan_tasks.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from app.core.taskiq_broker import broker
+from app.jobs.watch_scanner import WatchScanner
+
+
+@broker.task(
+    task_name="scan.watch_alerts",
+    schedule=[{"cron": "*/5 * * * *", "cron_offset": "Asia/Seoul"}],
+)
+async def run_watch_scan_task() -> dict:
+    scanner = WatchScanner()
+    try:
+        return await scanner.run()
+    finally:
+        await scanner.close()

--- a/docs/plans/2026-02-17-watch-alerts-design.md
+++ b/docs/plans/2026-02-17-watch-alerts-design.md
@@ -13,7 +13,7 @@
 
 - Redis hash 기반 사용자 지정 조건 알림을 도입한다.
 - cron(TaskIQ) 주기 스캔으로 조건 충족을 평가한다.
-- 알림은 OpenClaw + Telegram 미러링 경로(`send_scan_alert`)를 사용한다.
+- 알림은 OpenClaw + Telegram 미러링 경로(`send_watch_alert`, 내부 `_send_market_alert` 공유)를 사용한다.
 - 조건 충족 알림 발송 성공 시 해당 조건을 자동 삭제한다.
 
 ## 2. 확정 요구사항
@@ -68,9 +68,8 @@
 
 ## 4.3 알림 채널
 
-- watch 스캐너는 `/Users/robin/PycharmProjects/auto_trader/app/services/openclaw_client.py`의 `send_scan_alert()` 경로를 사용한다.
-- 이 경로는 OpenClaw 전송 성공 시 Telegram으로 미러링된다.
-- 네이밍은 하위 호환을 위해 `send_scan_alert`를 유지하고, 필요 시 내부 공통 메서드(`send_market_alert`)로 확장한다.
+- watch 스캐너는 `/Users/robin/PycharmProjects/auto_trader/app/services/openclaw_client.py`의 `send_watch_alert()`를 사용한다.
+- `send_watch_alert()`와 `send_scan_alert()`는 내부 공통 경로(`_send_market_alert`)를 공유하며, OpenClaw 전송 성공 시 Telegram으로 미러링된다.
 
 ## 5. 데이터 모델 및 계약
 
@@ -214,4 +213,3 @@
 - 조건 충족 후 자동 재등록/복구 로직
 - 사용자별 멀티테넌트 watch 분리
 - watch 메시지 분할 발송
-

--- a/tests/test_mcp_tool_registration.py
+++ b/tests/test_mcp_tool_registration.py
@@ -1,6 +1,10 @@
 import pytest
 
 from app.mcp_server import AVAILABLE_TOOL_NAMES, register_all_tools
+from app.mcp_server.tooling import (
+    WATCH_ALERT_TOOL_NAMES,
+    register_watch_alert_tools,
+)
 from app.mcp_server.tooling.analysis_registration import (
     ANALYSIS_TOOL_NAMES,
     register_analysis_tools,
@@ -76,6 +80,16 @@ def test_domain_registration_is_incremental_and_recoverable() -> None:
         | ANALYSIS_TOOL_NAMES
     )
 
+    register_watch_alert_tools(mcp)
+    assert set(mcp.tools) == (
+        MARKET_DATA_TOOL_NAMES
+        | PORTFOLIO_TOOL_NAMES
+        | ORDER_TOOL_NAMES
+        | FUNDAMENTALS_TOOL_NAMES
+        | ANALYSIS_TOOL_NAMES
+        | WATCH_ALERT_TOOL_NAMES
+    )
+
     assert set(mcp.tools) == set(AVAILABLE_TOOL_NAMES)
 
 
@@ -87,6 +101,7 @@ def test_domain_registration_is_incremental_and_recoverable() -> None:
         register_order_tools,
         register_fundamentals_tools,
         register_analysis_tools,
+        register_watch_alert_tools,
     ],
 )
 def test_domain_registration_is_idempotent(registrar: object) -> None:

--- a/tests/test_mcp_watch_alerts.py
+++ b/tests/test_mcp_watch_alerts.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling import (
+    watch_alerts_registration as watch_alerts_registration,
+)
+from app.mcp_server.tooling.registry import register_all_tools
+
+
+class DummyMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, object] = {}
+
+    def tool(self, name: str, description: str):
+        _ = description
+
+        def decorator(func):
+            self.tools[name] = func
+            return func
+
+        return decorator
+
+
+def build_tools() -> dict[str, object]:
+    mcp = DummyMCP()
+    register_all_tools(mcp)
+    return mcp.tools
+
+
+class _FakeWatchAlertService:
+    def __init__(self) -> None:
+        self.add_calls: list[tuple[str, str, str, float]] = []
+        self.remove_calls: list[tuple[str, str, str, float]] = []
+        self.list_calls: list[str | None] = []
+        self.closed = False
+
+    async def add_watch(
+        self,
+        market: str,
+        symbol: str,
+        condition_type: str,
+        threshold: float,
+    ) -> dict[str, object]:
+        self.add_calls.append((market, symbol, condition_type, threshold))
+        return {"created": True, "already_exists": False}
+
+    async def remove_watch(
+        self,
+        market: str,
+        symbol: str,
+        condition_type: str,
+        threshold: float,
+    ) -> dict[str, object]:
+        self.remove_calls.append((market, symbol, condition_type, threshold))
+        return {"removed": True}
+
+    async def list_watches(
+        self,
+        market: str | None = None,
+    ) -> dict[str, list[dict[str, object]]]:
+        self.list_calls.append(market)
+        return {"crypto": []}
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_manage_watch_alerts_add_maps_metric_operator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tools = build_tools()
+
+    fake_service = _FakeWatchAlertService()
+    monkeypatch.setattr(
+        watch_alerts_registration, "WatchAlertService", lambda: fake_service
+    )
+
+    result = await tools["manage_watch_alerts"](
+        action="add",
+        market="crypto",
+        symbol="btc",
+        metric="price",
+        operator="below",
+        threshold=90000000,
+    )
+
+    assert result["success"] is True
+    assert result["symbol"] == "BTC"
+    assert fake_service.add_calls[0][2] == "price_below"
+    assert result["condition_type"] == "price_below"
+    assert result["threshold"] == 90000000.0
+    assert fake_service.closed is True
+
+
+@pytest.mark.asyncio
+async def test_manage_watch_alerts_rejects_unknown_action() -> None:
+    tools = build_tools()
+
+    result = await tools["manage_watch_alerts"](action="unknown")
+
+    assert result["success"] is False
+    assert "unknown action" in str(result["error"]).lower()

--- a/tests/test_openclaw_client.py
+++ b/tests/test_openclaw_client.py
@@ -319,6 +319,45 @@ async def test_send_scan_alert_success(
 
 @pytest.mark.asyncio
 @patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_watch_alert_success(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
+    monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
+    monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+
+    mock_cli = AsyncMock()
+    mock_res = MagicMock(status_code=200)
+    mock_res.raise_for_status.return_value = None
+    mock_cli.post.return_value = mock_res
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    mock_notifier = MagicMock()
+    mock_notifier.notify_openclaw_message = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.services.openclaw_client.get_trade_notifier",
+        lambda: mock_notifier,
+    )
+
+    result = await OpenClawClient().send_watch_alert("watch message")
+
+    assert result is not None
+    mock_cli.post.assert_awaited_once()
+    called_json = mock_cli.post.call_args.kwargs["json"]
+    assert called_json["name"] == "auto-trader:watch"
+    assert called_json["wakeMode"] == "now"
+    assert called_json["sessionKey"].startswith("auto-trader:watch:")
+    assert called_json["message"] == "watch message"
+    mock_notifier.notify_openclaw_message.assert_awaited_once_with("watch message")
+
+
+@pytest.mark.asyncio
+@patch("app.services.openclaw_client.httpx.AsyncClient")
 async def test_send_scan_alert_returns_none_after_all_retries_fail(
     mock_httpx_client_cls: MagicMock,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_watch_alerts.py
+++ b/tests/test_watch_alerts.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.watch_alerts import WatchAlertService
+
+
+class _FakeRedisHash:
+    def __init__(self) -> None:
+        self._hashes: dict[str, dict[str, str]] = {}
+
+    async def hexists(self, key: str, field: str) -> bool:
+        return field in self._hashes.get(key, {})
+
+    async def hset(self, key: str, field: str, value: str) -> int:
+        target = self._hashes.setdefault(key, {})
+        is_new = field not in target
+        target[field] = value
+        return 1 if is_new else 0
+
+    async def hgetall(self, key: str) -> dict[str, str]:
+        return dict(self._hashes.get(key, {}))
+
+    async def hdel(self, key: str, field: str) -> int:
+        target = self._hashes.get(key, {})
+        if field in target:
+            target.pop(field, None)
+            return 1
+        return 0
+
+
+@pytest.mark.asyncio
+async def test_add_watch_is_idempotent_and_preserves_created_at() -> None:
+    service = WatchAlertService()
+    fake_redis = _FakeRedisHash()
+    service._get_redis = AsyncMock(return_value=fake_redis)  # type: ignore[method-assign]
+
+    first = await service.add_watch("crypto", "btc", "price_below", 90000000)
+    second = await service.add_watch("crypto", "BTC", "price_below", 90000000)
+
+    assert first["created"] is True
+    assert second["created"] is False
+    assert second["already_exists"] is True
+
+    all_rows = await service.list_watches("crypto")
+    watch = all_rows["crypto"][0]
+    assert watch["symbol"] == "BTC"
+    assert watch["condition_type"] == "price_below"
+    assert watch["metric"] == "price"
+    assert watch["operator"] == "below"
+
+
+@pytest.mark.asyncio
+async def test_rsi_threshold_out_of_range_raises_value_error() -> None:
+    service = WatchAlertService()
+
+    with pytest.raises(ValueError, match="RSI threshold"):
+        service.validate_watch_inputs(
+            market="crypto",
+            symbol="BTC",
+            condition_type="rsi_below",
+            threshold=101,
+        )
+
+
+@pytest.mark.asyncio
+async def test_list_watches_skips_malformed_entries() -> None:
+    service = WatchAlertService()
+    fake_redis = _FakeRedisHash()
+    service._get_redis = AsyncMock(return_value=fake_redis)  # type: ignore[method-assign]
+
+    fake_redis._hashes["watch:alerts:crypto"] = {
+        "BTC:price_below:90000000": '{"created_at":"2026-02-17T13:00:00+09:00"}',
+        "BROKEN_FIELD": '{"created_at":"2026-02-17T13:01:00+09:00"}',
+        "ETH:price_above:not-a-number": '{"created_at":"2026-02-17T13:02:00+09:00"}',
+    }
+
+    rows = await service.list_watches("crypto")
+    assert len(rows["crypto"]) == 1
+    assert rows["crypto"][0]["symbol"] == "BTC"

--- a/tests/test_watch_scan_tasks.py
+++ b/tests/test_watch_scan_tasks.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+
+class _FakeScanner:
+    def __init__(self, result: dict[str, object]) -> None:
+        self._result = result
+        self.closed = False
+
+    async def run(self) -> dict[str, object]:
+        return self._result
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_run_watch_scan_task_uses_scanner_and_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.tasks.watch_scan_tasks import run_watch_scan_task
+
+    scanner = _FakeScanner(result={"crypto": {"alerts_sent": 1}})
+    monkeypatch.setattr("app.tasks.watch_scan_tasks.WatchScanner", lambda: scanner)
+
+    result = await run_watch_scan_task()
+
+    assert result == {"crypto": {"alerts_sent": 1}}
+    assert scanner.closed is True

--- a/tests/test_watch_scanner.py
+++ b/tests/test_watch_scanner.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pandas as pd
+import pytest
+
+from app.jobs.watch_scanner import WatchScanner
+
+
+class _FakeWatchService:
+    def __init__(self, rows: list[dict[str, object]] | None = None) -> None:
+        self._rows_by_market: dict[str, list[dict[str, object]]] = {
+            "crypto": list(rows or []),
+            "kr": [],
+            "us": [],
+        }
+        self.removed_fields: list[tuple[str, str]] = []
+        self.closed = False
+
+    async def get_watches_for_market(self, market: str) -> list[dict[str, object]]:
+        return list(self._rows_by_market.get(market, []))
+
+    async def trigger_and_remove(self, market: str, field: str) -> bool:
+        self.removed_fields.append((market, field))
+        return True
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeOpenClawClient:
+    def __init__(self, success: bool = True) -> None:
+        self._success = success
+        self.messages: list[str] = []
+
+    async def send_scan_alert(self, message: str) -> str | None:
+        self.messages.append(message)
+        return "scan-1" if self._success else None
+
+    async def send_watch_alert(self, message: str) -> str | None:
+        self.messages.append(message)
+        return "watch-1" if self._success else None
+
+
+def _make_ohlcv(closes: list[float]) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "date": pd.date_range("2026-01-01", periods=len(closes), freq="D"),
+            "open": closes,
+            "high": closes,
+            "low": closes,
+            "close": closes,
+            "volume": [100.0] * len(closes),
+            "value": [1000.0] * len(closes),
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_scan_market_sends_single_batched_message_and_removes_only_triggered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = WatchScanner()
+    scanner._watch_service = _FakeWatchService(
+        rows=[
+            {
+                "symbol": "BTC",
+                "condition_type": "price_below",
+                "threshold": 100.0,
+                "field": "BTC:price_below:100",
+            },
+            {
+                "symbol": "ETH",
+                "condition_type": "rsi_above",
+                "threshold": 70.0,
+                "field": "ETH:rsi_above:70",
+            },
+        ]
+    )
+    scanner._openclaw = _FakeOpenClawClient(success=True)
+
+    monkeypatch.setattr(scanner, "_is_market_open", lambda market: True)
+    monkeypatch.setattr(scanner, "_get_price", AsyncMock(return_value=90.0))
+    monkeypatch.setattr(scanner, "_get_rsi", AsyncMock(return_value=72.5))
+
+    result = await scanner.scan_market("crypto")
+
+    assert result["alerts_sent"] == 2
+    assert len(scanner._openclaw.messages) == 1
+    assert scanner._watch_service.removed_fields == [
+        ("crypto", "BTC:price_below:100"),
+        ("crypto", "ETH:rsi_above:70"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_scans_all_markets_and_skips_closed_market(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = WatchScanner()
+    scanner._watch_service = _FakeWatchService(rows=[])
+    scanner._openclaw = _FakeOpenClawClient(success=True)
+
+    monkeypatch.setattr(scanner, "_is_market_open", lambda market: market != "us")
+    monkeypatch.setattr(scanner, "_get_price", AsyncMock(return_value=None))
+    monkeypatch.setattr(scanner, "_get_rsi", AsyncMock(return_value=None))
+
+    result = await scanner.run()
+
+    assert set(result.keys()) == {"crypto", "kr", "us"}
+    assert result["us"] == {
+        "market": "us",
+        "skipped": True,
+        "reason": "market_closed",
+    }
+    assert result["crypto"]["alerts_sent"] == 0
+    assert result["kr"]["alerts_sent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_price_and_rsi_use_market_specific_sources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.jobs import watch_scanner as watch_scanner_module
+
+    scanner = WatchScanner()
+
+    mock_kis = AsyncMock()
+    mock_kis.inquire_price.return_value = pd.DataFrame(
+        [{"code": "005930", "close": 55000.0}]
+    ).set_index("code")
+    mock_kis.inquire_daily_itemchartprice.return_value = _make_ohlcv(
+        [1, 2, 3, 4, 5] * 20
+    )
+    scanner._kis = mock_kis
+
+    mock_us_price = AsyncMock(return_value=pd.DataFrame([{"close": 190.0}]))
+    mock_us_ohlcv = AsyncMock(return_value=_make_ohlcv([1, 2, 3, 4, 5] * 20))
+    monkeypatch.setattr(
+        watch_scanner_module.yahoo_service, "fetch_price", mock_us_price
+    )
+    monkeypatch.setattr(
+        watch_scanner_module.yahoo_service, "fetch_ohlcv", mock_us_ohlcv
+    )
+
+    mock_crypto_price = AsyncMock(return_value=pd.DataFrame([{"close": 91000000.0}]))
+    mock_crypto_ohlcv = AsyncMock(return_value=_make_ohlcv([1, 2, 3, 4, 5] * 20))
+    monkeypatch.setattr(
+        watch_scanner_module.upbit_service,
+        "fetch_price",
+        mock_crypto_price,
+    )
+    monkeypatch.setattr(
+        watch_scanner_module.upbit_service,
+        "fetch_ohlcv",
+        mock_crypto_ohlcv,
+    )
+
+    assert await scanner._get_price("005930", "kr") == 55000.0
+    assert await scanner._get_price("AMZN", "us") == 190.0
+    assert await scanner._get_price("BTC", "crypto") == 91000000.0
+
+    kr_rsi = await scanner._get_rsi("005930", "kr")
+    us_rsi = await scanner._get_rsi("AMZN", "us")
+    crypto_rsi = await scanner._get_rsi("BTC", "crypto")
+    assert kr_rsi is not None
+    assert us_rsi is not None
+    assert crypto_rsi is not None
+
+    mock_kis.inquire_price.assert_awaited_once_with("005930")
+    mock_us_price.assert_awaited_once_with("AMZN")
+    mock_crypto_price.assert_awaited_once_with("KRW-BTC")
+
+
+@pytest.mark.asyncio
+async def test_get_rsi_crypto_uses_supported_ohlcv_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.jobs import watch_scanner as watch_scanner_module
+
+    scanner = WatchScanner()
+    mock_crypto_ohlcv = AsyncMock(return_value=_make_ohlcv([1, 2, 3, 4, 5] * 20))
+    monkeypatch.setattr(
+        watch_scanner_module.upbit_service,
+        "fetch_ohlcv",
+        mock_crypto_ohlcv,
+    )
+
+    rsi = await scanner._get_rsi("BTC", "crypto")
+
+    assert rsi is not None
+    assert mock_crypto_ohlcv.await_args.kwargs["days"] <= 200


### PR DESCRIPTION
## Summary
- add Redis-backed watch alert domain (`WatchAlertService`) with idempotent add and resilient malformed-entry handling
- add multi-market `WatchScanner` + TaskIQ schedule (`scan.watch_alerts`) with market-hour gating and batched alert delivery/removal flow
- add MCP tool `manage_watch_alerts` (`metric` + `operator` input contract), registry wiring, README contract docs, and watch-specific OpenClaw sender
- add focused tests for service/scanner/task/MCP registration and review follow-up fixes

## Test Plan
- [x] `uv run pytest --no-cov tests/test_watch_alerts.py tests/test_watch_scanner.py tests/test_watch_scan_tasks.py tests/test_mcp_watch_alerts.py tests/test_mcp_tool_registration.py tests/test_openclaw_client.py -q`
- [x] `uv run ruff check app/services/watch_alerts.py app/jobs/watch_scanner.py app/mcp_server/tooling/watch_alerts_registration.py tests/test_watch_alerts.py tests/test_watch_scanner.py tests/test_mcp_watch_alerts.py`
- [x] `uv run pyright app/services/watch_alerts.py app/jobs/watch_scanner.py app/mcp_server/tooling/watch_alerts_registration.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Market watch alerts: Set custom price and RSI triggers for crypto, Korean, and US markets
  * Automatic alert scanning every 5 minutes with real-time condition evaluation
  * Complete watch management: Add, remove, and list alerts via API
  * Alerts sent via existing notification channels when conditions trigger

<!-- end of auto-generated comment: release notes by coderabbit.ai -->