### PR TITLE
fix: correct KIS fill parsing and OpenClaw Telegram mirroring

### DIFF
--- a/app/services/kis_websocket.py
+++ b/app/services/kis_websocket.py
@@ -121,6 +121,33 @@ _SIDE_MAP = {
     "매수": "bid",
 }
 
+OVERSEAS_FILL_FIELDS = {
+    "side": 4,
+    "symbol": 7,
+    "filled_qty": 8,
+    "filled_price": 9,
+    "filled_at": 10,
+    "fill_yn": 12,
+}
+
+OVERSEAS_SIDE_MAP = {
+    "01": "ask",
+    "1": "ask",
+    "S": "ask",
+    "02": "bid",
+    "2": "bid",
+    "B": "bid",
+}
+
+DOMESTIC_FILL_FIELDS = {
+    "symbol": 0,
+    "side": 1,
+    "order_id": 2,
+    "filled_price": 3,
+    "filled_qty": 4,
+    "filled_at": 5,
+}
+
 
 class KISSubscriptionAckError(RuntimeError):
     """Structured ACK failure for KIS subscription."""
@@ -529,9 +556,12 @@ class KISExecutionWebSocket:
     def _is_execution_event(self, data: dict[str, Any]) -> bool:
         if data.get("type") in {"error", "ack"}:
             return False
+        tr_code = str(data.get("tr_code", ""))
+        if tr_code in OVERSEAS_EXECUTION_TR_CODES:
+            return str(data.get("fill_yn", "")).strip() == "2"
         if data.get("execution_type") == 1:
             return True
-        return str(data.get("tr_code", "")) in EXECUTION_TR_CODES
+        return tr_code in EXECUTION_TR_CODES
 
     def _parse_message(self, message: str | bytes) -> dict | None:
         """
@@ -729,6 +759,16 @@ class KISExecutionWebSocket:
         if not fields:
             return {}
 
+        if market == "us":
+            parsed_overseas = self._parse_overseas_execution(fields)
+            if parsed_overseas is not None:
+                return parsed_overseas
+
+        if market == "kr":
+            parsed_domestic = self._parse_domestic_execution(fields)
+            if parsed_domestic is not None:
+                return parsed_domestic
+
         kv: dict[str, str] = {}
         for token in fields:
             if "=" in token:
@@ -818,6 +858,66 @@ class KISExecutionWebSocket:
             "filled_price": filled_price,
             "filled_qty": filled_qty,
             "filled_amount": filled_amount,
+            "filled_at": filled_at,
+        }
+
+    def _parse_overseas_execution(self, fields: list[str]) -> dict[str, Any] | None:
+        if len(fields) <= max(OVERSEAS_FILL_FIELDS.values()):
+            return None
+
+        symbol = fields[OVERSEAS_FILL_FIELDS["symbol"]].strip()
+        if not symbol:
+            return None
+
+        side_token = fields[OVERSEAS_FILL_FIELDS["side"]].strip().upper()
+        side = OVERSEAS_SIDE_MAP.get(side_token, "unknown")
+
+        filled_qty = self._to_float(fields[OVERSEAS_FILL_FIELDS["filled_qty"]])
+        filled_price = self._to_float(fields[OVERSEAS_FILL_FIELDS["filled_price"]])
+        if filled_qty <= 0 or filled_price <= 0:
+            return None
+
+        order_id = fields[2].strip() if len(fields) > 2 else ""
+        if not order_id:
+            order_id = None
+
+        filled_at = self._extract_timestamp(fields[OVERSEAS_FILL_FIELDS["filled_at"]])
+        fill_yn = fields[OVERSEAS_FILL_FIELDS["fill_yn"]].strip()
+
+        return {
+            "symbol": symbol,
+            "side": side,
+            "order_id": order_id,
+            "filled_price": filled_price,
+            "filled_qty": filled_qty,
+            "filled_amount": filled_price * filled_qty,
+            "filled_at": filled_at,
+            "fill_yn": fill_yn,
+        }
+
+    def _parse_domestic_execution(self, fields: list[str]) -> dict[str, Any] | None:
+        if len(fields) <= max(DOMESTIC_FILL_FIELDS.values()):
+            return None
+
+        symbol = fields[DOMESTIC_FILL_FIELDS["symbol"]].strip()
+        side_token = fields[DOMESTIC_FILL_FIELDS["side"]].strip().upper()
+        order_id = fields[DOMESTIC_FILL_FIELDS["order_id"]].strip() or None
+        filled_price = self._to_float(fields[DOMESTIC_FILL_FIELDS["filled_price"]])
+        filled_qty = self._to_float(fields[DOMESTIC_FILL_FIELDS["filled_qty"]])
+
+        if not symbol or filled_price <= 0 or filled_qty <= 0:
+            return None
+
+        side = _SIDE_MAP.get(side_token, "unknown")
+        filled_at = self._extract_timestamp(fields[DOMESTIC_FILL_FIELDS["filled_at"]])
+
+        return {
+            "symbol": symbol,
+            "side": side,
+            "order_id": order_id,
+            "filled_price": filled_price,
+            "filled_qty": filled_qty,
+            "filled_amount": filled_price * filled_qty,
             "filled_at": filled_at,
         }
 

--- a/app/services/openclaw_client.py
+++ b/app/services/openclaw_client.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from uuid import uuid4
 
@@ -28,11 +27,9 @@ class OpenClawClient:
         self,
         webhook_url: str | None = None,
         token: str | None = None,
-        callback_url: str | None = None,
     ) -> None:
         self._webhook_url = webhook_url or settings.OPENCLAW_WEBHOOK_URL
         self._token = token if token is not None else settings.OPENCLAW_TOKEN
-        self._callback_url = callback_url or settings.OPENCLAW_CALLBACK_URL
 
     async def _forward_to_telegram(self, message: str, alert_type: str) -> None:
         try:
@@ -49,61 +46,6 @@ class OpenClawClient:
                 alert_type,
                 exc,
             )
-
-    async def request_analysis(
-        self,
-        prompt: str,
-        symbol: str,
-        name: str,
-        instrument_type: str,
-    ) -> str:
-        """Send an analysis request to OpenClaw.
-
-        Returns
-        -------
-        str
-            request_id to correlate the callback payload.
-        """
-        if not settings.OPENCLAW_ENABLED:
-            raise RuntimeError(
-                "OpenClaw integration is disabled (OPENCLAW_ENABLED=false)"
-            )
-
-        request_id = str(uuid4())
-
-        message = _build_openclaw_message(
-            request_id=request_id,
-            prompt=prompt,
-            symbol=symbol,
-            name=name,
-            instrument_type=instrument_type,
-            callback_url=self._callback_url,
-            callback_token=settings.OPENCLAW_CALLBACK_TOKEN,
-        )
-
-        payload = {
-            "message": message,
-            "name": "auto-trader:analysis",
-            "sessionKey": f"auto-trader:openclaw:{request_id}",
-            "wakeMode": "now",
-        }
-
-        headers = {"Content-Type": "application/json"}
-        if self._token:
-            headers["Authorization"] = f"Bearer {self._token}"
-
-        async with httpx.AsyncClient(timeout=10) as cli:
-            res = await cli.post(self._webhook_url, json=payload, headers=headers)
-            res.raise_for_status()
-
-        logger.info(
-            "OpenClaw analysis requested: request_id=%s symbol=%s instrument_type=%s status=%s",
-            request_id,
-            symbol,
-            instrument_type,
-            res.status_code,
-        )
-        return request_id
 
     async def send_fill_notification(self, order: FillOrderLike) -> str | None:
         """
@@ -141,6 +83,7 @@ class OpenClawClient:
         if self._token:
             headers["Authorization"] = f"Bearer {self._token}"
 
+        delivered_to_openclaw = False
         try:
             async for attempt in AsyncRetrying(
                 stop=stop_after_attempt(4),
@@ -159,8 +102,8 @@ class OpenClawClient:
                         normalized_order.symbol,
                         normalized_order.account,
                     )
-                    await self._forward_to_telegram(message, alert_type="fill")
-                    return request_id
+                    delivered_to_openclaw = True
+                    break
 
         except RetryError as e:
             logger.error(
@@ -168,14 +111,18 @@ class OpenClawClient:
                 request_id,
                 e,
             )
-            return None
         except Exception as e:
             logger.error(
                 "OpenClaw fill notification error: request_id=%s error=%s",
                 request_id,
                 e,
             )
-            return None
+        finally:
+            await self._forward_to_telegram(message, alert_type="fill")
+
+        if delivered_to_openclaw:
+            return request_id
+        return None
 
     async def _send_market_alert(self, message: str, category: str) -> str | None:
         if not settings.OPENCLAW_ENABLED:
@@ -194,6 +141,7 @@ class OpenClawClient:
         if self._token:
             headers["Authorization"] = f"Bearer {self._token}"
 
+        delivered_to_openclaw = False
         try:
             async for attempt in AsyncRetrying(
                 stop=stop_after_attempt(4),
@@ -211,8 +159,8 @@ class OpenClawClient:
                         category,
                         request_id,
                     )
-                    await self._forward_to_telegram(message, alert_type=category)
-                    return request_id
+                    delivered_to_openclaw = True
+                    break
 
         except RetryError as e:
             logger.error(
@@ -221,7 +169,6 @@ class OpenClawClient:
                 request_id,
                 e,
             )
-            return None
         except Exception as e:
             logger.error(
                 "OpenClaw %s alert error: request_id=%s error=%s",
@@ -229,61 +176,15 @@ class OpenClawClient:
                 request_id,
                 e,
             )
-            return None
+        finally:
+            await self._forward_to_telegram(message, alert_type=category)
+
+        if delivered_to_openclaw:
+            return request_id
+        return None
 
     async def send_scan_alert(self, message: str) -> str | None:
         return await self._send_market_alert(message, category="scan")
 
     async def send_watch_alert(self, message: str) -> str | None:
         return await self._send_market_alert(message, category="watch")
-
-
-def _build_openclaw_message(
-    *,
-    request_id: str,
-    prompt: str,
-    symbol: str,
-    name: str,
-    instrument_type: str,
-    callback_url: str,
-    callback_token: str | None,
-) -> str:
-    callback_schema = {
-        "request_id": request_id,
-        "symbol": symbol,
-        "name": name,
-        "instrument_type": instrument_type,
-        "decision": "buy|hold|sell",
-        "confidence": 0,
-        "reasons": ["..."],
-        "price_analysis": {
-            "appropriate_buy_range": {"min": 0, "max": 0},
-            "appropriate_sell_range": {"min": 0, "max": 0},
-            "buy_hope_range": {"min": 0, "max": 0},
-            "sell_target_range": {"min": 0, "max": 0},
-        },
-        "detailed_text": "...",
-        "model_name": "...",
-    }
-
-    schema_json = json.dumps(callback_schema, ensure_ascii=True)
-
-    callback_headers = "Content-Type: application/json\n"
-    token = callback_token.strip() if callback_token else ""
-    if token:
-        callback_headers += f"Authorization: Bearer {token}\n"
-
-    return (
-        "Analyze the following trading instrument and return a JSON result via HTTP callback.\n\n"
-        f"request_id: {request_id}\n"
-        f"symbol: {symbol}\n"
-        f"name: {name}\n"
-        f"instrument_type: {instrument_type}\n\n"
-        "USER_PROMPT:\n"
-        f"{prompt}\n\n"
-        "CALLBACK:\n"
-        f"POST {callback_url}\n"
-        f"{callback_headers}\n"
-        "RESPONSE_JSON_SCHEMA (example):\n"
-        f"{schema_json}\n"
-    )

--- a/tests/test_kis_websocket.py
+++ b/tests/test_kis_websocket.py
@@ -512,7 +512,63 @@ class TestKISWebSocketClient:
         assert result["order_id"] == "A123456789"
         assert result["filled_price"] == 70000
         assert result["filled_qty"] == 10
-        assert "filled_at" in result
+        assert result["filled_amount"] == 700000
+        assert "T09:30:01" in result["filled_at"]
+
+    @pytest.mark.asyncio
+    async def test_parse_message_extracts_overseas_fill_fields_by_index(
+        self, execution_callback
+    ):
+        client = KISExecutionWebSocket(on_execution=execution_callback, mock_mode=True)
+
+        message = (
+            "0|H0GSCNI0|1|"
+            "mgh3326^6762259301^0030145286^0000000000^02^0^00^AMZN^3^201.5^093001^N^2"
+        )
+        result = client._parse_message(message)
+
+        assert result is not None
+        assert result["tr_code"] == "H0GSCNI0"
+        assert result["market"] == "us"
+        assert result["symbol"] == "AMZN"
+        assert result["side"] == "bid"
+        assert result["filled_qty"] == 3
+        assert result["filled_price"] == 201.5
+        assert result["filled_amount"] == 604.5
+        assert result["fill_yn"] == "2"
+        assert "T09:30:01" in result["filled_at"]
+
+    def test_is_execution_event_rejects_overseas_when_fill_yn_not_two(
+        self, execution_callback
+    ) -> None:
+        client = KISExecutionWebSocket(on_execution=execution_callback, mock_mode=True)
+
+        assert (
+            client._is_execution_event(
+                {
+                    "tr_code": OVERSEAS_EXECUTION_TR_REAL,
+                    "execution_type": 1,
+                    "fill_yn": "1",
+                }
+            )
+            is False
+        )
+
+    def test_is_execution_event_accepts_overseas_when_fill_yn_two(
+        self, execution_callback
+    ) -> None:
+        client = KISExecutionWebSocket(on_execution=execution_callback, mock_mode=True)
+
+        assert (
+            client._is_execution_event(
+                {
+                    "tr_code": OVERSEAS_EXECUTION_TR_REAL,
+                    "execution_type": 1,
+                    "fill_yn": "2",
+                }
+            )
+            is True
+        )
 
     @pytest.mark.asyncio
     async def test_parse_message_json_response(self, execution_callback):

--- a/tests/test_openclaw_client.py
+++ b/tests/test_openclaw_client.py
@@ -2,111 +2,12 @@
 
 from __future__ import annotations
 
-import json
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import UUID
 
 import pytest
 
 from app.core.config import settings
-from app.services.openclaw_client import OpenClawClient, _build_openclaw_message
-
-
-def test_build_openclaw_message_includes_callback_and_schema() -> None:
-    message = _build_openclaw_message(
-        request_id="rid-123",
-        prompt="PROMPT",
-        symbol="AAPL",
-        name="Apple Inc.",
-        instrument_type="equity_us",
-        callback_url="http://example.test/api/v1/openclaw/callback",
-        callback_token="cb-token",
-    )
-
-    assert "USER_PROMPT:\nPROMPT" in message
-    assert "POST http://example.test/api/v1/openclaw/callback" in message
-    assert "Authorization: Bearer cb-token" in message
-    assert "RESPONSE_JSON_SCHEMA (example):" in message
-
-    schema_json = message.split("RESPONSE_JSON_SCHEMA (example):\n", 1)[1].strip()
-    schema = json.loads(schema_json)
-    assert schema["request_id"] == "rid-123"
-    assert schema["symbol"] == "AAPL"
-    assert schema["name"] == "Apple Inc."
-    assert schema["instrument_type"] == "equity_us"
-
-
-@pytest.mark.asyncio
-async def test_request_analysis_raises_when_disabled(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(settings, "OPENCLAW_ENABLED", False)
-
-    with pytest.raises(RuntimeError, match="OpenClaw integration is disabled"):
-        await OpenClawClient().request_analysis(
-            prompt="P",
-            symbol="AAPL",
-            name="Apple Inc.",
-            instrument_type="equity_us",
-        )
-
-
-@pytest.mark.asyncio
-@patch(
-    "app.services.openclaw_client.uuid4",
-    return_value=UUID("00000000-0000-0000-0000-000000000000"),
-)
-@patch("app.services.openclaw_client.httpx.AsyncClient")
-async def test_request_analysis_posts_payload_and_returns_request_id(
-    mock_httpx_client_cls: MagicMock,
-    _mock_uuid4: MagicMock,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
-    monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
-    monkeypatch.setattr(
-        settings,
-        "OPENCLAW_CALLBACK_URL",
-        "http://example.test/api/v1/openclaw/callback",
-    )
-    monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
-    monkeypatch.setattr(settings, "OPENCLAW_CALLBACK_TOKEN", "cb-token")
-
-    mock_cli = AsyncMock()
-    mock_res = MagicMock(status_code=202)
-    mock_res.raise_for_status.return_value = None
-    mock_cli.post.return_value = mock_res
-
-    mock_client_instance = AsyncMock()
-    mock_client_instance.__aenter__.return_value = mock_cli
-    mock_client_instance.__aexit__.return_value = None
-    mock_httpx_client_cls.return_value = mock_client_instance
-
-    request_id = await OpenClawClient().request_analysis(
-        prompt="P",
-        symbol="AAPL",
-        name="Apple Inc.",
-        instrument_type="equity_us",
-    )
-
-    assert request_id == "00000000-0000-0000-0000-000000000000"
-    mock_httpx_client_cls.assert_called_once_with(timeout=10)
-
-    mock_cli.post.assert_awaited_once()
-    called_url = mock_cli.post.call_args.args[0]
-    called_json = mock_cli.post.call_args.kwargs["json"]
-    called_headers = mock_cli.post.call_args.kwargs["headers"]
-
-    assert called_url == "http://openclaw/hooks/agent"
-    assert called_headers["Content-Type"] == "application/json"
-    assert called_headers["Authorization"] == "Bearer test-token"
-
-    assert called_json["name"] == "auto-trader:analysis"
-    assert called_json["wakeMode"] == "now"
-    assert called_json["sessionKey"] == f"auto-trader:openclaw:{request_id}"
-    assert "USER_PROMPT:\nP" in called_json["message"]
-    assert "POST http://example.test/api/v1/openclaw/callback" in called_json["message"]
-    assert "Authorization: Bearer cb-token" in called_json["message"]
+from app.services.openclaw_client import OpenClawClient
 
 
 @pytest.mark.asyncio
@@ -269,6 +170,54 @@ async def test_send_fill_notification_returns_none_after_all_retries_fail(
 
 
 @pytest.mark.asyncio
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_fill_notification_forwards_telegram_when_openclaw_fails(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
+    monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
+    monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+
+    from app.services.fill_notification import FillOrder
+
+    order = FillOrder(
+        symbol="KRW-BTC",
+        side="bid",
+        filled_price=50000000,
+        filled_qty=0.1,
+        filled_amount=5000000,
+        filled_at="2024-01-01T00:00:00Z",
+        account="upbit",
+    )
+
+    mock_cli = AsyncMock()
+    mock_res_fail = MagicMock()
+    mock_res_fail.raise_for_status.side_effect = Exception("Network error")
+    mock_cli.post.return_value = mock_res_fail
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    mock_notifier = MagicMock()
+    mock_notifier.notify_openclaw_message = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.services.openclaw_client.get_trade_notifier",
+        lambda: mock_notifier,
+    )
+
+    result = await OpenClawClient().send_fill_notification(order)
+
+    assert result is None
+    assert mock_cli.post.call_count == 4
+    mock_notifier.notify_openclaw_message.assert_awaited_once()
+    forwarded_message = mock_notifier.notify_openclaw_message.await_args.args[0]
+    assert "체결 알림" in forwarded_message
+
+
+@pytest.mark.asyncio
 async def test_send_scan_alert_returns_none_when_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -380,3 +329,71 @@ async def test_send_scan_alert_returns_none_after_all_retries_fail(
 
     assert result is None
     assert mock_cli.post.call_count == 4
+
+
+@pytest.mark.asyncio
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_scan_alert_forwards_telegram_when_openclaw_fails(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
+    monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
+    monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+
+    mock_cli = AsyncMock()
+    mock_res_fail = MagicMock()
+    mock_res_fail.raise_for_status.side_effect = Exception("Network error")
+    mock_cli.post.return_value = mock_res_fail
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    mock_notifier = MagicMock()
+    mock_notifier.notify_openclaw_message = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.services.openclaw_client.get_trade_notifier",
+        lambda: mock_notifier,
+    )
+
+    result = await OpenClawClient().send_scan_alert("scan message")
+
+    assert result is None
+    assert mock_cli.post.call_count == 4
+    mock_notifier.notify_openclaw_message.assert_awaited_once_with("scan message")
+
+
+@pytest.mark.asyncio
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_watch_alert_forwards_telegram_when_openclaw_fails(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
+    monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
+    monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+
+    mock_cli = AsyncMock()
+    mock_res_fail = MagicMock()
+    mock_res_fail.raise_for_status.side_effect = Exception("Network error")
+    mock_cli.post.return_value = mock_res_fail
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    mock_notifier = MagicMock()
+    mock_notifier.notify_openclaw_message = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.services.openclaw_client.get_trade_notifier",
+        lambda: mock_notifier,
+    )
+
+    result = await OpenClawClient().send_watch_alert("watch message")
+
+    assert result is None
+    assert mock_cli.post.call_count == 4
+    mock_notifier.notify_openclaw_message.assert_awaited_once_with("watch message")

--- a/tests/test_websocket_monitor.py
+++ b/tests/test_websocket_monitor.py
@@ -279,3 +279,43 @@ class TestUnifiedWebSocketMonitor:
         )
 
         send_mock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_main_configures_and_shuts_down_trade_notifier(
+        self, mock_settings: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import websocket_monitor
+
+        monitor = MagicMock()
+        monitor.start = AsyncMock(return_value=None)
+        monitor.stop = AsyncMock(return_value=None)
+
+        notifier = MagicMock()
+        notifier.configure = MagicMock()
+        notifier.shutdown = AsyncMock(return_value=None)
+
+        monkeypatch.setattr(settings, "telegram_token", "telegram-token")
+        monkeypatch.setattr(settings, "telegram_chat_id", "123456")
+        monkeypatch.setattr(websocket_monitor, "init_sentry", lambda **_: None)
+        monkeypatch.setattr(
+            websocket_monitor,
+            "UnifiedWebSocketMonitor",
+            lambda mode="both": monitor,
+        )
+        monkeypatch.setattr(
+            websocket_monitor,
+            "get_trade_notifier",
+            lambda: notifier,
+            raising=False,
+        )
+
+        await websocket_monitor.main(mode="both")
+
+        notifier.configure.assert_called_once_with(
+            bot_token="telegram-token",
+            chat_ids=["123456"],
+            enabled=True,
+        )
+        notifier.shutdown.assert_awaited_once()
+        monitor.start.assert_awaited_once()
+        monitor.stop.assert_awaited_once()

--- a/websocket_monitor.py
+++ b/websocket_monitor.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from app.core.config import settings
 from app.monitoring.sentry import capture_exception, init_sentry
+from app.monitoring.trade_notifier import get_trade_notifier
 from app.services.fill_notification import (
     FillOrder,
     normalize_kis_fill,
@@ -279,6 +280,17 @@ async def main(mode: str = "both") -> None:
     }[mode]
     init_sentry(service_name=service_name)
 
+    if settings.telegram_token and settings.telegram_chat_id:
+        try:
+            trade_notifier = get_trade_notifier()
+            trade_notifier.configure(
+                bot_token=settings.telegram_token,
+                chat_ids=settings.telegram_chat_ids,
+                enabled=True,
+            )
+        except Exception as e:
+            logger.warning("Failed to configure trade notifier: %s", e, exc_info=True)
+
     monitor = UnifiedWebSocketMonitor(mode=mode)
 
     try:
@@ -291,6 +303,11 @@ async def main(mode: str = "both") -> None:
         sys.exit(1)
     finally:
         await monitor.stop()
+        try:
+            trade_notifier = get_trade_notifier()
+            await trade_notifier.shutdown()
+        except Exception as e:
+            logger.warning("Failed to shutdown trade notifier: %s", e, exc_info=True)
         logger.info("Unified WebSocket Monitor exited gracefully")
 
 


### PR DESCRIPTION
## Summary
- fix KIS websocket execution parsing with market-specific handlers (KR/US)
- correct overseas H0GSCNI0 side index mapping (SELN_BYOV_CLS at index 4) and filter US execution events by `fill_yn == "2"`
- fix domestic compact payload amount parsing by deriving `filled_amount = price * qty`
- remove unused OpenClaw `request_analysis` path and keep alert-style senders (`fill/scan/watch`)
- mirror OpenClaw outbound alert messages to Telegram even when OpenClaw delivery fails
- initialize/shutdown TradeNotifier in websocket monitor runtime

## Verification
- `uv run pytest --no-cov tests/test_kis_websocket.py -q -k "overseas or domestic or fill_event"`
- `uv run pytest --no-cov tests/test_openclaw_client.py -q`
- `uv run pytest --no-cov tests/test_websocket_monitor.py -q`
- `uv run ruff check app/services/kis_websocket.py app/services/openclaw_client.py websocket_monitor.py tests/test_kis_websocket.py tests/test_openclaw_client.py tests/test_websocket_monitor.py`
- `uv run pyright app/services/kis_websocket.py app/services/openclaw_client.py websocket_monitor.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Telegram notification integration to the websocket monitor
  * Enhanced execution event parsing for domestic and overseas market orders

* **Improvements**
  * Streamlined client initialization and configuration
  * Notifications now reliably forward to Telegram even if primary delivery fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->