### PR TITLE
feat: add screener web flow with OpenClaw callback

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -174,6 +174,7 @@ class Settings(BaseSettings):
     OPENCLAW_TOKEN: str = ""
     OPENCLAW_CALLBACK_TOKEN: str = ""  # shared secret for inbound callback auth
     OPENCLAW_CALLBACK_URL: str = "http://localhost:8000/api/v1/openclaw/callback"
+    OPENCLAW_SCREENER_CALLBACK_URL: str = "http://localhost:8000/api/screener/callback"
     OPENCLAW_ENABLED: bool = False
 
     DAILY_SCAN_ENABLED: bool = False

--- a/app/main.py
+++ b/app/main.py
@@ -29,6 +29,7 @@ from app.routers import (
     openclaw_callback,
     orderbook,
     portfolio,
+    screener,
     stock_latest,
     symbol_settings,
     test,
@@ -120,6 +121,7 @@ def create_app() -> FastAPI:
     app.include_router(web_auth_router)
     app.include_router(admin_router)
     app.include_router(dashboard.router)
+    app.include_router(screener.router)
     app.include_router(health.router)
     app.include_router(analysis_json.router)
     app.include_router(news_analysis.router)

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -408,6 +408,7 @@ async def _execute_order(
 async def _place_order_impl(
     symbol: str,
     side: Literal["buy", "sell"],
+    market: str | None = None,
     order_type: Literal["limit", "market"] = "limit",
     quantity: float | None = None,
     price: float | None = None,
@@ -442,7 +443,7 @@ async def _place_order_impl(
             "amount can only be used for buy orders. Use quantity for sell orders."
         )
 
-    market_type, normalized_symbol = _resolve_market_type(symbol, None)
+    market_type, normalized_symbol = _resolve_market_type(symbol, market)
     source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "kis"}
     source = source_map[market_type]
 

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -43,6 +43,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
     # Public API paths (explicit whitelist)
     PUBLIC_API_PATHS: ClassVar[list[str]] = [
         "/api/v1/openclaw/callback",
+        "/api/screener/callback",
     ]
 
     def __init__(self, app):

--- a/app/routers/screener.py
+++ b/app/routers/screener.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel, Field
+
+from app.analysis.models import PriceAnalysis
+from app.core.templates import templates
+from app.routers.openclaw_callback import _require_openclaw_callback_token
+from app.services.screener_service import ScreenerService
+
+router = APIRouter(tags=["Screener"])
+
+_SCREENER_SERVICE: ScreenerService | None = None
+
+
+def get_screener_service() -> ScreenerService:
+    global _SCREENER_SERVICE
+    if _SCREENER_SERVICE is None:
+        _SCREENER_SERVICE = ScreenerService()
+    return _SCREENER_SERVICE
+
+
+class ScreenerFilterRequest(BaseModel):
+    market: Literal["kr", "us", "crypto"] = "kr"
+    asset_type: Literal["stock", "etf", "etn"] | None = None
+    category: str | None = None
+    strategy: str | None = None
+    sort_by: str | None = None
+    sort_order: Literal["asc", "desc"] = "desc"
+    min_market_cap: float | None = None
+    max_per: float | None = None
+    max_pbr: float | None = None
+    min_dividend_yield: float | None = None
+    max_rsi: float | None = None
+    limit: int = Field(default=20, ge=1, le=50)
+
+
+class ScreenerReportRequest(BaseModel):
+    market: Literal["kr", "us", "crypto"]
+    symbol: str = Field(min_length=1)
+    name: str | None = None
+
+
+class ScreenerCallbackRequest(BaseModel):
+    request_id: str
+    symbol: str
+    name: str
+    instrument_type: str
+    decision: Literal["buy", "hold", "sell"]
+    confidence: int = Field(ge=0, le=100)
+    reasons: list[str] | None = None
+    price_analysis: PriceAnalysis
+    detailed_text: str | None = None
+
+
+class ScreenerOrderRequest(BaseModel):
+    market: Literal["kr", "us", "crypto"]
+    symbol: str
+    side: Literal["buy", "sell"]
+    order_type: Literal["limit", "market"] = "limit"
+    quantity: float | None = None
+    price: float | None = None
+    amount: float | None = None
+    confirm: bool = False
+    reason: str = ""
+
+
+@router.get("/screener", response_class=HTMLResponse)
+async def screener_dashboard(request: Request):
+    return templates.TemplateResponse(
+        request,
+        "screener_dashboard.html",
+        {
+            "request": request,
+            "poll_interval_seconds": 3,
+            "poll_timeout_seconds": 120,
+        },
+    )
+
+
+@router.get("/screener/report/{job_id}", response_class=HTMLResponse)
+async def screener_report_page(request: Request, job_id: str):
+    return templates.TemplateResponse(
+        request,
+        "screener_dashboard.html",
+        {
+            "request": request,
+            "poll_interval_seconds": 3,
+            "poll_timeout_seconds": 120,
+            "initial_job_id": job_id,
+        },
+    )
+
+
+@router.get("/api/screener/list")
+async def screener_list(
+    market: Literal["kr", "us", "crypto"] = "kr",
+    asset_type: Literal["stock", "etf", "etn"] | None = None,
+    category: str | None = None,
+    strategy: str | None = None,
+    sort_by: str | None = None,
+    sort_order: Literal["asc", "desc"] = "desc",
+    min_market_cap: float | None = Query(default=None),
+    max_per: float | None = Query(default=None),
+    max_pbr: float | None = Query(default=None),
+    min_dividend_yield: float | None = Query(default=None),
+    max_rsi: float | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=50),
+    service: ScreenerService = Depends(get_screener_service),
+):
+    return await service.list_screening(
+        market=market,
+        asset_type=asset_type,
+        category=category,
+        strategy=strategy,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        min_market_cap=min_market_cap,
+        max_per=max_per,
+        max_pbr=max_pbr,
+        min_dividend_yield=min_dividend_yield,
+        max_rsi=max_rsi,
+        limit=limit,
+    )
+
+
+@router.post("/api/screener/refresh")
+async def screener_refresh(
+    payload: ScreenerFilterRequest,
+    service: ScreenerService = Depends(get_screener_service),
+):
+    return await service.refresh_screening(**payload.model_dump())
+
+
+@router.post("/api/screener/report")
+async def screener_request_report(
+    payload: ScreenerReportRequest,
+    service: ScreenerService = Depends(get_screener_service),
+):
+    return await service.request_report(
+        market=payload.market,
+        symbol=payload.symbol,
+        name=payload.name,
+    )
+
+
+@router.get("/api/screener/report/{job_id}")
+async def screener_report_status(
+    job_id: str,
+    service: ScreenerService = Depends(get_screener_service),
+):
+    return await service.get_report_status(job_id)
+
+
+@router.post("/api/screener/callback")
+async def screener_callback(
+    payload: ScreenerCallbackRequest,
+    _: None = Depends(_require_openclaw_callback_token),
+    service: ScreenerService = Depends(get_screener_service),
+):
+    return await service.process_callback(payload.model_dump(exclude_none=True))
+
+
+@router.post("/api/screener/order")
+async def screener_order(
+    payload: ScreenerOrderRequest,
+    service: ScreenerService = Depends(get_screener_service),
+):
+    return await service.place_order(
+        market=payload.market,
+        symbol=payload.symbol,
+        side=payload.side,
+        order_type=payload.order_type,
+        quantity=payload.quantity,
+        price=payload.price,
+        amount=payload.amount,
+        confirm=payload.confirm,
+        reason=payload.reason,
+    )

--- a/app/services/openclaw_client.py
+++ b/app/services/openclaw_client.py
@@ -47,6 +47,65 @@ class OpenClawClient:
                 exc,
             )
 
+    async def request_analysis(
+        self,
+        prompt: str,
+        symbol: str,
+        name: str,
+        instrument_type: str,
+        callback_url: str | None = None,
+        include_model_name: bool = True,
+        request_id: str | None = None,
+    ) -> str:
+        """Send an analysis request to OpenClaw.
+
+        Returns
+        -------
+        str
+            request_id to correlate the callback payload.
+        """
+        if not settings.OPENCLAW_ENABLED:
+            raise RuntimeError(
+                "OpenClaw integration is disabled (OPENCLAW_ENABLED=false)"
+            )
+
+        request_id = request_id or str(uuid4())
+
+        message = _build_openclaw_message(
+            request_id=request_id,
+            prompt=prompt,
+            symbol=symbol,
+            name=name,
+            instrument_type=instrument_type,
+            callback_url=callback_url or self._callback_url,
+            callback_token=settings.OPENCLAW_CALLBACK_TOKEN,
+            include_model_name=include_model_name,
+        )
+
+        payload = {
+            "message": message,
+            "name": "auto-trader:analysis",
+            "sessionKey": f"auto-trader:openclaw:{request_id}",
+            "wakeMode": "now",
+        }
+
+        headers = {"Content-Type": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+
+        async with httpx.AsyncClient(timeout=10) as cli:
+            res = await cli.post(self._webhook_url, json=payload, headers=headers)
+            res.raise_for_status()
+
+        logger.info(
+            "OpenClaw analysis requested: request_id=%s symbol=%s instrument_type=%s status=%s",
+            request_id,
+            symbol,
+            instrument_type,
+            res.status_code,
+        )
+        return request_id
+
     async def send_fill_notification(self, order: FillOrderLike) -> str | None:
         """
         체결 알림을 OpenClaw Gateway로 전송
@@ -188,3 +247,56 @@ class OpenClawClient:
 
     async def send_watch_alert(self, message: str) -> str | None:
         return await self._send_market_alert(message, category="watch")
+
+
+def _build_openclaw_message(
+    *,
+    request_id: str,
+    prompt: str,
+    symbol: str,
+    name: str,
+    instrument_type: str,
+    callback_url: str,
+    callback_token: str | None,
+    include_model_name: bool = True,
+) -> str:
+    callback_schema = {
+        "request_id": request_id,
+        "symbol": symbol,
+        "name": name,
+        "instrument_type": instrument_type,
+        "decision": "buy|hold|sell",
+        "confidence": 0,
+        "reasons": ["..."],
+        "price_analysis": {
+            "appropriate_buy_range": {"min": 0, "max": 0},
+            "appropriate_sell_range": {"min": 0, "max": 0},
+            "buy_hope_range": {"min": 0, "max": 0},
+            "sell_target_range": {"min": 0, "max": 0},
+        },
+        "detailed_text": "...",
+    }
+    if include_model_name:
+        callback_schema["model_name"] = "..."
+
+    schema_json = json.dumps(callback_schema, ensure_ascii=True)
+
+    callback_headers = "Content-Type: application/json\n"
+    token = callback_token.strip() if callback_token else ""
+    if token:
+        callback_headers += f"Authorization: Bearer {token}\n"
+
+    return (
+        "Analyze the following trading instrument and return a JSON result via HTTP callback.\n\n"
+        f"request_id: {request_id}\n"
+        f"symbol: {symbol}\n"
+        f"name: {name}\n"
+        f"instrument_type: {instrument_type}\n\n"
+        "USER_PROMPT:\n"
+        f"{prompt}\n\n"
+        "CALLBACK:\n"
+        f"POST {callback_url}\n"
+        f"{callback_headers}\n"
+        "RESPONSE_JSON_SCHEMA (example):\n"
+        f"{schema_json}\n"
+    )

--- a/app/services/screener_service.py
+++ b/app/services/screener_service.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from hashlib import sha256
+from typing import Any, Literal
+from uuid import uuid4
+
+import redis.asyncio as redis
+
+from app.core.config import settings
+from app.mcp_server.tooling.analysis_tool_handlers import screen_stocks_impl
+from app.mcp_server.tooling.order_execution import _place_order_impl
+from app.services.openclaw_client import OpenClawClient
+
+ScreenMarket = Literal["kr", "us", "crypto"]
+
+
+@dataclass(slots=True)
+class _ReportKeys:
+    result_key: str
+    inflight_key: str
+    status_key: str
+    job_key: str
+
+
+class ScreenerService:
+    SCREENING_CACHE_TTL_SECONDS = 300
+    REPORT_CACHE_TTL_SECONDS = 3600
+    REPORT_INFLIGHT_TTL_SECONDS = 120
+
+    def __init__(
+        self,
+        redis_client: redis.Redis | None = None,
+        openclaw_client: OpenClawClient | None = None,
+    ) -> None:
+        self._redis = redis_client
+        self._openclaw = openclaw_client or OpenClawClient()
+
+    async def _get_redis(self) -> redis.Redis:
+        if self._redis is None:
+            self._redis = redis.from_url(
+                settings.get_redis_url(),
+                max_connections=settings.redis_max_connections,
+                socket_timeout=settings.redis_socket_timeout,
+                socket_connect_timeout=settings.redis_socket_connect_timeout,
+                decode_responses=True,
+            )
+        return self._redis
+
+    @staticmethod
+    def _normalize_market(market: str) -> ScreenMarket:
+        normalized = (market or "").strip().lower()
+        if normalized in {"kr", "kospi", "kosdaq"}:
+            return "kr"
+        if normalized in {"us", "nasdaq", "nyse"}:
+            return "us"
+        if normalized == "crypto":
+            return "crypto"
+        raise ValueError("market must be one of: kr, us, crypto")
+
+    @staticmethod
+    def _normalize_symbol(market: ScreenMarket, symbol: str) -> str:
+        raw = (symbol or "").strip()
+        if not raw:
+            raise ValueError("symbol is required")
+        if market == "kr":
+            return raw.upper()
+        if market == "us":
+            return raw.upper()
+        return raw.upper()
+
+    @staticmethod
+    def _instrument_type(market: ScreenMarket) -> str:
+        mapping = {
+            "kr": "equity_kr",
+            "us": "equity_us",
+            "crypto": "crypto",
+        }
+        return mapping[market]
+
+    @staticmethod
+    def _market_from_instrument_type(instrument_type: str | None) -> ScreenMarket:
+        normalized = (instrument_type or "").strip().lower()
+        mapping: dict[str, ScreenMarket] = {
+            "equity_kr": "kr",
+            "equity_us": "us",
+            "crypto": "crypto",
+        }
+        if normalized in mapping:
+            return mapping[normalized]
+        raise ValueError(
+            "instrument_type must be one of: equity_kr, equity_us, crypto"
+        )
+
+    @staticmethod
+    def _compact_json(data: dict[str, Any]) -> str:
+        return json.dumps(
+            data, ensure_ascii=True, separators=(",", ":"), sort_keys=True
+        )
+
+    def _screening_cache_key(self, filters: dict[str, Any]) -> str:
+        serialized = self._compact_json(filters)
+        digest = sha256(serialized.encode("utf-8")).hexdigest()
+        return f"screener:list:{digest}"
+
+    def _report_keys(
+        self, market: ScreenMarket, symbol: str, job_id: str
+    ) -> _ReportKeys:
+        return _ReportKeys(
+            result_key=f"screener:report:result:{market}:{symbol}",
+            inflight_key=f"screener:report:inflight:{market}:{symbol}",
+            status_key=f"screener:report:status:{job_id}",
+            job_key=f"screener:report:job:{job_id}",
+        )
+
+    async def _load_cached_json(self, key: str) -> dict[str, Any] | None:
+        redis_client = await self._get_redis()
+        raw = await redis_client.get(key)
+        if not raw:
+            return None
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict):
+            return parsed
+        return None
+
+    async def _store_json(self, key: str, ttl: int, data: dict[str, Any]) -> None:
+        redis_client = await self._get_redis()
+        await redis_client.setex(key, ttl, self._compact_json(data))
+
+    async def list_screening(
+        self,
+        market: str = "kr",
+        asset_type: str | None = None,
+        category: str | None = None,
+        strategy: str | None = None,
+        sort_by: str | None = None,
+        sort_order: str | None = "desc",
+        min_market_cap: float | None = None,
+        max_per: float | None = None,
+        max_pbr: float | None = None,
+        min_dividend_yield: float | None = None,
+        max_rsi: float | None = None,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        normalized_market = self._normalize_market(market)
+        filters = {
+            "market": normalized_market,
+            "asset_type": asset_type,
+            "category": category,
+            "strategy": strategy,
+            "sort_by": sort_by,
+            "sort_order": sort_order,
+            "min_market_cap": min_market_cap,
+            "max_per": max_per,
+            "max_pbr": max_pbr,
+            "min_dividend_yield": min_dividend_yield,
+            "max_rsi": max_rsi,
+            "limit": limit,
+        }
+        cache_key = self._screening_cache_key(filters)
+        cached = await self._load_cached_json(cache_key)
+        if cached:
+            return {**cached, "cache_hit": True}
+
+        call_kwargs = {k: v for k, v in filters.items() if v is not None}
+        result = await screen_stocks_impl(**call_kwargs)
+        await self._store_json(cache_key, self.SCREENING_CACHE_TTL_SECONDS, result)
+        return {**result, "cache_hit": False}
+
+    async def refresh_screening(
+        self,
+        market: str = "kr",
+        asset_type: str | None = None,
+        category: str | None = None,
+        strategy: str | None = None,
+        sort_by: str | None = None,
+        sort_order: str | None = "desc",
+        min_market_cap: float | None = None,
+        max_per: float | None = None,
+        max_pbr: float | None = None,
+        min_dividend_yield: float | None = None,
+        max_rsi: float | None = None,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        normalized_market = self._normalize_market(market)
+        filters = {
+            "market": normalized_market,
+            "asset_type": asset_type,
+            "category": category,
+            "strategy": strategy,
+            "sort_by": sort_by,
+            "sort_order": sort_order,
+            "min_market_cap": min_market_cap,
+            "max_per": max_per,
+            "max_pbr": max_pbr,
+            "min_dividend_yield": min_dividend_yield,
+            "max_rsi": max_rsi,
+            "limit": limit,
+        }
+        cache_key = self._screening_cache_key(filters)
+        redis_client = await self._get_redis()
+        await redis_client.delete(cache_key)
+        return await self.list_screening(**filters)
+
+    async def request_report(
+        self, market: str, symbol: str, name: str | None = None
+    ) -> dict[str, Any]:
+        normalized_market = self._normalize_market(market)
+        normalized_symbol = self._normalize_symbol(normalized_market, symbol)
+        report_key = f"screener:report:result:{normalized_market}:{normalized_symbol}"
+        inflight_key = (
+            f"screener:report:inflight:{normalized_market}:{normalized_symbol}"
+        )
+        redis_client = await self._get_redis()
+
+        existing_report = await self._load_cached_json(report_key)
+        if existing_report is not None:
+            return {
+                "job_id": existing_report.get("request_id"),
+                "status": "completed",
+                "is_reused": True,
+                "report": existing_report,
+            }
+
+        inflight_job_id = await redis_client.get(inflight_key)
+        if inflight_job_id:
+            status_key = f"screener:report:status:{inflight_job_id}"
+            status = await redis_client.get(status_key)
+            return {
+                "job_id": inflight_job_id,
+                "status": status or "queued",
+                "is_reused": True,
+            }
+
+        provisional_job_id = str(uuid4())
+        inflight_claimed = await redis_client.set(
+            inflight_key,
+            provisional_job_id,
+            ex=self.REPORT_INFLIGHT_TTL_SECONDS,
+            nx=True,
+        )
+        if not inflight_claimed:
+            reused_job_id = await redis_client.get(inflight_key)
+            if reused_job_id:
+                status_key = f"screener:report:status:{reused_job_id}"
+                status = await redis_client.get(status_key)
+                return {
+                    "job_id": reused_job_id,
+                    "status": status or "queued",
+                    "is_reused": True,
+                }
+            return {
+                "job_id": provisional_job_id,
+                "status": "queued",
+                "is_reused": True,
+            }
+
+        display_name = (name or normalized_symbol).strip() or normalized_symbol
+        prompt = (
+            "Produce a trading report for the instrument below using MCP tools and return a JSON callback.\n"
+            f"market={normalized_market}\n"
+            f"symbol={normalized_symbol}\n"
+            f"name={display_name}\n"
+            "Include decision, confidence, reasons, and price_analysis ranges."
+        )
+        instrument_type = self._instrument_type(normalized_market)
+        try:
+            job_id = await self._openclaw.request_analysis(
+                prompt=prompt,
+                symbol=normalized_symbol,
+                name=display_name,
+                instrument_type=instrument_type,
+                callback_url=settings.OPENCLAW_SCREENER_CALLBACK_URL,
+                include_model_name=False,
+                request_id=provisional_job_id,
+            )
+        except Exception as exc:
+            await redis_client.delete(inflight_key)
+            error_message = str(exc).strip() or exc.__class__.__name__
+            keys = self._report_keys(
+                normalized_market, normalized_symbol, provisional_job_id
+            )
+            await redis_client.setex(
+                keys.status_key, self.REPORT_CACHE_TTL_SECONDS, "failed"
+            )
+            await self._store_json(
+                keys.job_key,
+                self.REPORT_CACHE_TTL_SECONDS,
+                {
+                    "job_id": provisional_job_id,
+                    "market": normalized_market,
+                    "symbol": normalized_symbol,
+                    "result_key": keys.result_key,
+                    "status_key": keys.status_key,
+                    "inflight_key": keys.inflight_key,
+                    "updated_at": datetime.now(UTC).isoformat(),
+                    "error": error_message,
+                },
+            )
+            return {
+                "job_id": provisional_job_id,
+                "status": "failed",
+                "error": error_message,
+                "is_reused": False,
+            }
+
+        keys = self._report_keys(normalized_market, normalized_symbol, job_id)
+        metadata = {
+            "job_id": job_id,
+            "market": normalized_market,
+            "symbol": normalized_symbol,
+            "result_key": keys.result_key,
+            "status_key": keys.status_key,
+            "inflight_key": keys.inflight_key,
+            "updated_at": datetime.now(UTC).isoformat(),
+        }
+        await self._store_json(keys.job_key, self.REPORT_CACHE_TTL_SECONDS, metadata)
+        await redis_client.setex(
+            keys.status_key, self.REPORT_CACHE_TTL_SECONDS, "queued"
+        )
+        await redis_client.set(
+            keys.inflight_key,
+            job_id,
+            ex=self.REPORT_INFLIGHT_TTL_SECONDS,
+        )
+
+        return {"job_id": job_id, "status": "queued", "is_reused": False}
+
+    async def get_report_status(self, job_id: str) -> dict[str, Any]:
+        if not job_id:
+            raise ValueError("job_id is required")
+        redis_client = await self._get_redis()
+        status_key = f"screener:report:status:{job_id}"
+        status = await redis_client.get(status_key)
+        response: dict[str, Any] = {"job_id": job_id, "status": status or "queued"}
+        metadata = await self._load_cached_json(f"screener:report:job:{job_id}")
+        if status == "completed":
+            if metadata and isinstance(metadata.get("result_key"), str):
+                report = await self._load_cached_json(metadata["result_key"])
+                if report is not None:
+                    response["report"] = report
+        elif status == "failed":
+            if metadata and isinstance(metadata.get("error"), str):
+                response["error"] = metadata["error"]
+        return response
+
+    async def process_callback(self, payload: dict[str, Any]) -> dict[str, Any]:
+        job_id = str(payload.get("request_id") or "").strip()
+        if not job_id:
+            raise ValueError("request_id is required")
+
+        metadata = await self._load_cached_json(f"screener:report:job:{job_id}")
+        if metadata is None:
+            redis_client = await self._get_redis()
+            status_key = f"screener:report:status:{job_id}"
+            try:
+                market = self._market_from_instrument_type(payload.get("instrument_type"))
+                symbol = self._normalize_symbol(market, str(payload.get("symbol") or ""))
+            except ValueError as exc:
+                error_message = str(exc)
+                await redis_client.setex(
+                    status_key, self.REPORT_CACHE_TTL_SECONDS, "failed"
+                )
+                await self._store_json(
+                    f"screener:report:job:{job_id}",
+                    self.REPORT_CACHE_TTL_SECONDS,
+                    {
+                        "job_id": job_id,
+                        "status_key": status_key,
+                        "updated_at": datetime.now(UTC).isoformat(),
+                        "error": error_message,
+                    },
+                )
+                return {
+                    "status": "failed",
+                    "request_id": job_id,
+                    "job_id": job_id,
+                    "error": error_message,
+                }
+            keys = self._report_keys(market, symbol, job_id)
+            metadata = {
+                "job_id": job_id,
+                "market": market,
+                "symbol": symbol,
+                "result_key": keys.result_key,
+                "status_key": keys.status_key,
+                "inflight_key": keys.inflight_key,
+            }
+
+        result_key = str(metadata["result_key"])
+        status_key = str(metadata["status_key"])
+        inflight_key = str(metadata["inflight_key"])
+        payload_with_timestamp = {
+            **payload,
+            "received_at": datetime.now(UTC).isoformat(),
+        }
+
+        redis_client = await self._get_redis()
+        await self._store_json(
+            result_key, self.REPORT_CACHE_TTL_SECONDS, payload_with_timestamp
+        )
+        await redis_client.setex(status_key, self.REPORT_CACHE_TTL_SECONDS, "completed")
+        await self._store_json(
+            f"screener:report:job:{job_id}",
+            self.REPORT_CACHE_TTL_SECONDS,
+            {
+                **metadata,
+                "updated_at": datetime.now(UTC).isoformat(),
+            },
+        )
+        await redis_client.delete(inflight_key)
+
+        return {
+            "status": "ok",
+            "request_id": job_id,
+            "job_id": job_id,
+            "is_reused": False,
+        }
+
+    async def place_order(
+        self,
+        market: str,
+        symbol: str,
+        side: Literal["buy", "sell"],
+        order_type: Literal["limit", "market"] = "limit",
+        quantity: float | None = None,
+        price: float | None = None,
+        amount: float | None = None,
+        confirm: bool = False,
+        reason: str = "",
+    ) -> dict[str, Any]:
+        normalized_market = self._normalize_market(market)
+        normalized_symbol = self._normalize_symbol(normalized_market, symbol)
+        return await _place_order_impl(
+            symbol=normalized_symbol,
+            market=normalized_market,
+            side=side,
+            order_type=order_type,
+            quantity=quantity,
+            price=price,
+            amount=amount,
+            dry_run=not confirm,
+            reason=reason,
+        )

--- a/app/templates/screener_dashboard.html
+++ b/app/templates/screener_dashboard.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Screener Dashboard</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        :root {
+            --bg-page: #f5f3ef;
+            --bg-dark: #1a1a1a;
+            --accent: #c05a3c;
+            --success: #4a7c59;
+            --error: #b54a4a;
+            --border-light: #d1ccc4;
+            --text-primary: #242220;
+            --text-secondary: #4f4a44;
+        }
+
+        body {
+            background: radial-gradient(circle at top right, #f9f7f3 0%, var(--bg-page) 45%, #ece8df 100%);
+            color: var(--text-primary);
+            min-height: 100vh;
+        }
+
+        .shell {
+            max-width: 1120px;
+            margin: 2rem auto;
+            border: 1px solid var(--border-light);
+            background: #fff;
+            border-radius: 1rem;
+            box-shadow: 0 18px 40px rgba(24, 19, 16, 0.08);
+            overflow: hidden;
+        }
+
+        .header {
+            background: linear-gradient(120deg, var(--bg-dark) 0%, #2f2b28 50%, #45352e 100%);
+            color: #f3ede5;
+            padding: 1.2rem 1.5rem;
+        }
+
+        .header h1 {
+            font-size: 1.25rem;
+            margin: 0;
+            letter-spacing: 0.02em;
+        }
+
+        .header p {
+            color: #d9cec1;
+            margin: 0.35rem 0 0;
+            font-size: 0.9rem;
+        }
+
+        .content {
+            padding: 1.4rem;
+            display: grid;
+            gap: 1rem;
+        }
+
+        .status-panel {
+            border: 1px solid var(--border-light);
+            border-radius: 0.75rem;
+            padding: 0.9rem 1rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 1rem;
+            background: #fcfbf8;
+        }
+
+        .status-label {
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: var(--text-secondary);
+            margin: 0;
+        }
+
+        .status-value {
+            margin: 0.2rem 0 0;
+            font-weight: 600;
+        }
+
+        .badge-running {
+            color: var(--success);
+            border: 1px solid rgba(74, 124, 89, 0.35);
+            border-radius: 999px;
+            padding: 0.2rem 0.6rem;
+            font-size: 0.78rem;
+            background: rgba(74, 124, 89, 0.08);
+        }
+
+        .api-list {
+            border: 1px solid var(--border-light);
+            border-radius: 0.75rem;
+            overflow: hidden;
+        }
+
+        .api-list table {
+            margin: 0;
+        }
+
+        .api-list td,
+        .api-list th {
+            font-size: 0.88rem;
+            vertical-align: middle;
+        }
+
+        .api-list .method {
+            font-weight: 700;
+            color: var(--accent);
+            width: 6rem;
+        }
+
+        .note {
+            font-size: 0.82rem;
+            color: var(--text-secondary);
+            margin: 0;
+        }
+
+        @media (max-width: 720px) {
+            .shell {
+                margin: 0;
+                border-radius: 0;
+                min-height: 100vh;
+            }
+
+            .status-panel {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+        }
+    </style>
+</head>
+<body>
+<main class="shell">
+    <header class="header">
+        <h1>OpenClaw Screener</h1>
+        <p>API-first screening and report workflow with callback-secured completion path.</p>
+    </header>
+
+    <section class="content">
+        <article class="status-panel">
+            <div>
+                <p class="status-label">Initial Job</p>
+                <p class="status-value" id="job-id">{{ initial_job_id or "not-set" }}</p>
+            </div>
+            <div>
+                <p class="status-label">Polling Profile</p>
+                <p class="status-value">
+                    {{ poll_interval_seconds }}s interval / {{ poll_timeout_seconds }}s timeout
+                </p>
+            </div>
+            <span class="badge-running">ready</span>
+        </article>
+
+        <article class="api-list">
+            <table class="table table-sm table-striped mb-0">
+                <thead>
+                <tr>
+                    <th>Method</th>
+                    <th>Path</th>
+                    <th>Purpose</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td class="method">GET</td>
+                    <td>/api/screener/list</td>
+                    <td>Read cached screener candidates</td>
+                </tr>
+                <tr>
+                    <td class="method">POST</td>
+                    <td>/api/screener/refresh</td>
+                    <td>Invalidate filter cache and recompute</td>
+                </tr>
+                <tr>
+                    <td class="method">POST</td>
+                    <td>/api/screener/report</td>
+                    <td>Create or reuse OpenClaw report job</td>
+                </tr>
+                <tr>
+                    <td class="method">GET</td>
+                    <td>/api/screener/report/{job_id}</td>
+                    <td>Poll job status and report payload</td>
+                </tr>
+                <tr>
+                    <td class="method">POST</td>
+                    <td>/api/screener/callback</td>
+                    <td>Receive token-protected OpenClaw callback</td>
+                </tr>
+                <tr>
+                    <td class="method">POST</td>
+                    <td>/api/screener/order</td>
+                    <td>Place order with confirm-to-dry-run mapping</td>
+                </tr>
+                </tbody>
+            </table>
+        </article>
+
+        <p class="note">This template is API contract aware and intended for iteration-safe backend integration.</p>
+    </section>
+</main>
+</body>
+</html>

--- a/env.example
+++ b/env.example
@@ -83,6 +83,8 @@ OPENCLAW_TOKEN=
 OPENCLAW_CALLBACK_TOKEN=
 # OpenClaw 콜백 URL (Auto Trader가 수신)
 OPENCLAW_CALLBACK_URL=http://localhost:8000/api/v1/openclaw/callback
+# Screener 전용 OpenClaw 콜백 URL
+OPENCLAW_SCREENER_CALLBACK_URL=http://localhost:8000/api/screener/callback
 
 # ========================================
 # OpenDART 설정

--- a/env.prod.example
+++ b/env.prod.example
@@ -85,6 +85,7 @@ OPENCLAW_WEBHOOK_URL=http://localhost:18789/hooks/agent
 OPENCLAW_TOKEN=
 OPENCLAW_CALLBACK_TOKEN=
 OPENCLAW_CALLBACK_URL=http://localhost:8000/api/v1/openclaw/callback
+OPENCLAW_SCREENER_CALLBACK_URL=http://localhost:8000/api/screener/callback
 
 # OpenDART API
 OPENDART_API_KEY=your_opendart_api_key

--- a/tests/test_openclaw_client.py
+++ b/tests/test_openclaw_client.py
@@ -7,7 +7,171 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.core.config import settings
+from app.services.openclaw_client import _build_openclaw_message
+
+
+def test_build_openclaw_message_includes_callback_and_schema() -> None:
+    message = _build_openclaw_message(
+        request_id="rid-123",
+        prompt="PROMPT",
+        symbol="AAPL",
+        name="Apple Inc.",
+        instrument_type="equity_us",
+        callback_url="http://example.test/api/v1/openclaw/callback",
+        callback_token="cb-token",
+    )
+
+    assert "USER_PROMPT:\nPROMPT" in message
+    assert "POST http://example.test/api/v1/openclaw/callback" in message
+    assert "Authorization: Bearer cb-token" in message
+    assert "RESPONSE_JSON_SCHEMA (example):" in message
+
+    schema_json = message.split("RESPONSE_JSON_SCHEMA (example):\n", 1)[1].strip()
+    schema = json.loads(schema_json)
+    assert schema["request_id"] == "rid-123"
+    assert schema["symbol"] == "AAPL"
+    assert schema["name"] == "Apple Inc."
+    assert schema["instrument_type"] == "equity_us"
+
+
+def test_build_openclaw_message_can_omit_model_name() -> None:
+    message = _build_openclaw_message(
+        request_id="rid-456",
+        prompt="PROMPT",
+        symbol="AAPL",
+        name="Apple Inc.",
+        instrument_type="equity_us",
+        callback_url="http://example.test/api/screener/callback",
+        callback_token="cb-token",
+        include_model_name=False,
+    )
+
+    schema_json = message.split("RESPONSE_JSON_SCHEMA (example):\n", 1)[1].strip()
+    schema = json.loads(schema_json)
+    assert "model_name" not in schema
+
+
+@pytest.mark.asyncio
+async def test_request_analysis_raises_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "OPENCLAW_ENABLED", False)
+
+    with pytest.raises(RuntimeError, match="OpenClaw integration is disabled"):
+        await OpenClawClient().request_analysis(
+            prompt="P",
+            symbol="AAPL",
+            name="Apple Inc.",
+            instrument_type="equity_us",
+        )
+
+
+@pytest.mark.asyncio
+@patch(
+    "app.services.openclaw_client.uuid4",
+    return_value=UUID("00000000-0000-0000-0000-000000000000"),
+)
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_request_analysis_posts_payload_and_returns_request_id(
+    mock_httpx_client_cls: MagicMock,
+    _mock_uuid4: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
+    monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
+    monkeypatch.setattr(
+        settings,
+        "OPENCLAW_CALLBACK_URL",
+        "http://example.test/api/v1/openclaw/callback",
+    )
+    monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+    monkeypatch.setattr(settings, "OPENCLAW_CALLBACK_TOKEN", "cb-token")
+
+    mock_cli = AsyncMock()
+    mock_res = MagicMock(status_code=202)
+    mock_res.raise_for_status.return_value = None
+    mock_cli.post.return_value = mock_res
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    request_id = await OpenClawClient().request_analysis(
+        prompt="P",
+        symbol="AAPL",
+        name="Apple Inc.",
+        instrument_type="equity_us",
+    )
+
+    assert request_id == "00000000-0000-0000-0000-000000000000"
+    mock_httpx_client_cls.assert_called_once_with(timeout=10)
+
+    mock_cli.post.assert_awaited_once()
+    called_url = mock_cli.post.call_args.args[0]
+    called_json = mock_cli.post.call_args.kwargs["json"]
+    called_headers = mock_cli.post.call_args.kwargs["headers"]
+
+    assert called_url == "http://openclaw/hooks/agent"
+    assert called_headers["Content-Type"] == "application/json"
+    assert called_headers["Authorization"] == "Bearer test-token"
+
+    assert called_json["name"] == "auto-trader:analysis"
+    assert called_json["wakeMode"] == "now"
+    assert called_json["sessionKey"] == f"auto-trader:openclaw:{request_id}"
+    assert "USER_PROMPT:\nP" in called_json["message"]
+    assert "POST http://example.test/api/v1/openclaw/callback" in called_json["message"]
+    assert "Authorization: Bearer cb-token" in called_json["message"]
 from app.services.openclaw_client import OpenClawClient
+
+
+@pytest.mark.asyncio
+@patch(
+    "app.services.openclaw_client.uuid4",
+    return_value=UUID("00000000-0000-0000-0000-000000000001"),
+)
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_request_analysis_supports_screener_callback_schema(
+    mock_httpx_client_cls: MagicMock,
+    _mock_uuid4: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
+    monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
+    monkeypatch.setattr(
+        settings,
+        "OPENCLAW_CALLBACK_URL",
+        "http://example.test/api/v1/openclaw/callback",
+    )
+    monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+    monkeypatch.setattr(settings, "OPENCLAW_CALLBACK_TOKEN", "cb-token")
+
+    mock_cli = AsyncMock()
+    mock_res = MagicMock(status_code=202)
+    mock_res.raise_for_status.return_value = None
+    mock_cli.post.return_value = mock_res
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    await OpenClawClient().request_analysis(
+        prompt="P",
+        symbol="AAPL",
+        name="Apple Inc.",
+        instrument_type="equity_us",
+        callback_url="http://example.test/api/screener/callback",
+        include_model_name=False,
+    )
+
+    called_json = mock_cli.post.call_args.kwargs["json"]
+    assert "POST http://example.test/api/screener/callback" in called_json["message"]
+    schema_json = (
+        called_json["message"].split("RESPONSE_JSON_SCHEMA (example):\n", 1)[1].strip()
+    )
+    schema = json.loads(schema_json)
+    assert "model_name" not in schema
 
 
 @pytest.mark.asyncio

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -58,6 +58,7 @@ class TestRouterIntegration:
         assert any("/healthz" in route for route in routes)
         assert any("/dashboard" in route for route in routes)
         assert any("/analysis" in route for route in routes)
+        assert any("/screener" in route for route in routes)
 
 
 class TestUpbitTradingRouter:

--- a/tests/test_screener_callback_auth.py
+++ b/tests/test_screener_callback_auth.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.config import settings
+from app.middleware.auth import AuthMiddleware
+from app.routers import screener
+
+
+class _FakeScreenerService:
+    def __init__(self) -> None:
+        self.process_callback = AsyncMock(
+            return_value={"status": "ok", "request_id": "job-1", "job_id": "job-1"}
+        )
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(settings, "OPENCLAW_CALLBACK_TOKEN", "callback-secret")
+
+    app = FastAPI()
+    app.add_middleware(AuthMiddleware)
+    app.include_router(screener.router)
+    fake_service = _FakeScreenerService()
+    app.dependency_overrides[screener.get_screener_service] = lambda: fake_service
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def _payload() -> dict:
+    return {
+        "request_id": "job-1",
+        "symbol": "AAPL",
+        "name": "Apple",
+        "instrument_type": "equity_us",
+        "decision": "hold",
+        "confidence": 55,
+        "reasons": ["r1"],
+        "price_analysis": {
+            "appropriate_buy_range": {"min": 100, "max": 110},
+            "appropriate_sell_range": {"min": 120, "max": 130},
+            "buy_hope_range": {"min": 95, "max": 98},
+            "sell_target_range": {"min": 150, "max": 160},
+        },
+        "detailed_text": "report",
+    }
+
+
+def test_screener_callback_rejects_missing_token(client: TestClient) -> None:
+    response = client.post("/api/screener/callback", json=_payload())
+    assert response.status_code == 401
+
+
+def test_screener_callback_rejects_invalid_token(client: TestClient) -> None:
+    response = client.post(
+        "/api/screener/callback",
+        headers={"Authorization": "Bearer wrong"},
+        json=_payload(),
+    )
+    assert response.status_code == 401
+
+
+def test_screener_callback_accepts_valid_bearer_token(client: TestClient) -> None:
+    response = client.post(
+        "/api/screener/callback",
+        headers={"Authorization": "Bearer callback-secret"},
+        json=_payload(),
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_screener_callback_accepts_x_openclaw_token(client: TestClient) -> None:
+    response = client.post(
+        "/api/screener/callback",
+        headers={"X-OpenClaw-Token": "callback-secret"},
+        json=_payload(),
+    )
+    assert response.status_code == 200

--- a/tests/test_screener_router.py
+++ b/tests/test_screener_router.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import screener
+
+
+class _FakeScreenerService:
+    def __init__(self) -> None:
+        self.list_screening = AsyncMock(
+            return_value={
+                "results": [{"code": "AAPL"}],
+                "total_count": 1,
+                "returned_count": 1,
+                "market": "us",
+                "cache_hit": False,
+            }
+        )
+        self.refresh_screening = AsyncMock(
+            return_value={
+                "results": [{"code": "MSFT"}],
+                "total_count": 1,
+                "returned_count": 1,
+                "market": "us",
+                "cache_hit": False,
+            }
+        )
+        self.request_report = AsyncMock(
+            return_value={"job_id": "job-1", "status": "queued", "is_reused": False}
+        )
+        self.get_report_status = AsyncMock(
+            return_value={"job_id": "job-1", "status": "running"}
+        )
+        self.process_callback = AsyncMock(
+            return_value={"status": "ok", "request_id": "job-1", "job_id": "job-1"}
+        )
+        self.place_order = AsyncMock(return_value={"success": True, "dry_run": True})
+
+
+@pytest.fixture
+def client() -> Generator[tuple[TestClient, _FakeScreenerService]]:
+    app = FastAPI()
+    fake_service = _FakeScreenerService()
+    app.include_router(screener.router)
+    app.dependency_overrides[screener.get_screener_service] = lambda: fake_service
+
+    with TestClient(app) as test_client:
+        yield test_client, fake_service
+
+
+def test_screener_dashboard_page(
+    client: tuple[TestClient, _FakeScreenerService],
+) -> None:
+    test_client, _ = client
+    response = test_client.get("/screener")
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+
+
+def test_screener_report_page(client: tuple[TestClient, _FakeScreenerService]) -> None:
+    test_client, _ = client
+    response = test_client.get("/screener/report/job-1")
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+
+
+def test_list_endpoint_calls_service(
+    client: tuple[TestClient, _FakeScreenerService],
+) -> None:
+    test_client, fake_service = client
+
+    response = test_client.get(
+        "/api/screener/list",
+        params={"market": "us", "max_rsi": 40, "limit": 10},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["market"] == "us"
+    fake_service.list_screening.assert_awaited_once()
+
+
+def test_refresh_endpoint_calls_service(
+    client: tuple[TestClient, _FakeScreenerService],
+) -> None:
+    test_client, fake_service = client
+
+    response = test_client.post(
+        "/api/screener/refresh",
+        json={"market": "us", "max_rsi": 50, "limit": 5},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["results"][0]["code"] == "MSFT"
+    fake_service.refresh_screening.assert_awaited_once()
+
+
+def test_report_request_endpoint(
+    client: tuple[TestClient, _FakeScreenerService],
+) -> None:
+    test_client, fake_service = client
+
+    response = test_client.post(
+        "/api/screener/report",
+        json={"market": "us", "symbol": "AAPL", "name": "Apple"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["job_id"] == "job-1"
+    assert body["status"] == "queued"
+    fake_service.request_report.assert_awaited_once_with(
+        market="us", symbol="AAPL", name="Apple"
+    )
+
+
+def test_report_status_endpoint(
+    client: tuple[TestClient, _FakeScreenerService],
+) -> None:
+    test_client, fake_service = client
+
+    response = test_client.get("/api/screener/report/job-1")
+    assert response.status_code == 200
+    assert response.json()["status"] == "running"
+    fake_service.get_report_status.assert_awaited_once_with("job-1")
+
+
+def test_order_endpoint_calls_service(
+    client: tuple[TestClient, _FakeScreenerService],
+) -> None:
+    test_client, fake_service = client
+
+    response = test_client.post(
+        "/api/screener/order",
+        json={
+            "market": "us",
+            "symbol": "AAPL",
+            "side": "buy",
+            "order_type": "limit",
+            "quantity": 1,
+            "price": 100,
+            "confirm": False,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    fake_service.place_order.assert_awaited_once()

--- a/tests/test_screener_service.py
+++ b/tests/test_screener_service.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def get(self, key: str):
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str, ex: int | None = None, nx: bool = False):
+        if nx and key in self.store:
+            return False
+        _ = ex
+        self.store[key] = value
+        return True
+
+    async def setex(self, key: str, ttl: int, value: str):
+        _ = ttl
+        self.store[key] = value
+        return True
+
+    async def delete(self, key: str):
+        self.store.pop(key, None)
+        return 1
+
+
+@pytest.mark.asyncio
+async def test_list_screening_uses_5m_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.services.screener_service import ScreenerService
+
+    fake_redis = _FakeRedis()
+    mock_screen = AsyncMock(
+        return_value={
+            "results": [{"code": "AAPL", "name": "Apple"}],
+            "total_count": 1,
+            "returned_count": 1,
+            "market": "us",
+        }
+    )
+    monkeypatch.setattr("app.services.screener_service.screen_stocks_impl", mock_screen)
+
+    service = ScreenerService(redis_client=fake_redis)
+
+    first = await service.list_screening(market="us", limit=20)
+    second = await service.list_screening(market="us", limit=20)
+
+    assert first["cache_hit"] is False
+    assert second["cache_hit"] is True
+    assert mock_screen.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_screening_invalidates_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services.screener_service import ScreenerService
+
+    fake_redis = _FakeRedis()
+    mock_screen = AsyncMock(
+        side_effect=[
+            {
+                "results": [{"code": "AAPL"}],
+                "total_count": 1,
+                "returned_count": 1,
+                "market": "us",
+            },
+            {
+                "results": [{"code": "MSFT"}],
+                "total_count": 1,
+                "returned_count": 1,
+                "market": "us",
+            },
+        ]
+    )
+    monkeypatch.setattr("app.services.screener_service.screen_stocks_impl", mock_screen)
+
+    service = ScreenerService(redis_client=fake_redis)
+
+    first = await service.list_screening(market="us", limit=20)
+    refreshed = await service.refresh_screening(market="us", limit=20)
+
+    assert first["results"][0]["code"] == "AAPL"
+    assert refreshed["results"][0]["code"] == "MSFT"
+    assert refreshed["cache_hit"] is False
+    assert mock_screen.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_request_report_reuses_inflight_job() -> None:
+    from app.services.screener_service import ScreenerService
+
+    fake_redis = _FakeRedis()
+    openclaw = AsyncMock()
+    openclaw.request_analysis = AsyncMock(return_value="job-1")
+
+    service = ScreenerService(redis_client=fake_redis, openclaw_client=openclaw)
+
+    first = await service.request_report(market="us", symbol="AAPL", name="Apple")
+    second = await service.request_report(market="us", symbol="AAPL", name="Apple")
+
+    assert first["job_id"] == "job-1"
+    assert first["is_reused"] is False
+    assert second["job_id"] == "job-1"
+    assert second["is_reused"] is True
+    openclaw.request_analysis.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_callback_completes_job_and_reuses_report() -> None:
+    from app.services.screener_service import ScreenerService
+
+    fake_redis = _FakeRedis()
+    openclaw = AsyncMock()
+    openclaw.request_analysis = AsyncMock(return_value="job-2")
+
+    service = ScreenerService(redis_client=fake_redis, openclaw_client=openclaw)
+
+    queued = await service.request_report(market="us", symbol="AAPL", name="Apple")
+    assert queued["status"] == "queued"
+
+    callback_payload = {
+        "request_id": "job-2",
+        "symbol": "AAPL",
+        "name": "Apple",
+        "instrument_type": "equity_us",
+        "decision": "hold",
+        "confidence": 60,
+        "reasons": ["range"],
+        "price_analysis": {
+            "appropriate_buy_range": {"min": 100, "max": 110},
+            "appropriate_sell_range": {"min": 120, "max": 130},
+            "buy_hope_range": {"min": 95, "max": 98},
+            "sell_target_range": {"min": 150, "max": 160},
+        },
+        "detailed_text": "done",
+    }
+    callback_result = await service.process_callback(callback_payload)
+    status = await service.get_report_status("job-2")
+    reused = await service.request_report(market="us", symbol="AAPL", name="Apple")
+
+    assert callback_result["status"] == "ok"
+    assert status["status"] == "completed"
+    assert status["report"]["decision"] == "hold"
+    assert reused["status"] == "completed"
+    assert reused["is_reused"] is True
+    openclaw.request_analysis.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_request_report_marks_failed_when_openclaw_request_fails() -> None:
+    from app.services.screener_service import ScreenerService
+
+    fake_redis = _FakeRedis()
+    openclaw = AsyncMock()
+    openclaw.request_analysis = AsyncMock(side_effect=RuntimeError("openclaw down"))
+
+    service = ScreenerService(redis_client=fake_redis, openclaw_client=openclaw)
+
+    result = await service.request_report(market="us", symbol="AAPL", name="Apple")
+
+    assert result["status"] == "failed"
+    assert result["is_reused"] is False
+    assert "openclaw down" in result["error"]
+
+    status = await service.get_report_status(result["job_id"])
+    assert status["status"] == "failed"
+    assert "openclaw down" in status["error"]
+
+
+@pytest.mark.asyncio
+async def test_callback_with_unknown_instrument_type_marks_failed() -> None:
+    from app.services.screener_service import ScreenerService
+
+    fake_redis = _FakeRedis()
+    service = ScreenerService(redis_client=fake_redis)
+
+    result = await service.process_callback(
+        {
+            "request_id": "job-unknown-type",
+            "symbol": "AAPL",
+            "name": "Apple",
+            "instrument_type": "equity_jp",
+            "decision": "hold",
+            "confidence": 55,
+            "reasons": ["r1"],
+            "price_analysis": {
+                "appropriate_buy_range": {"min": 100, "max": 110},
+                "appropriate_sell_range": {"min": 120, "max": 130},
+                "buy_hope_range": {"min": 95, "max": 98},
+                "sell_target_range": {"min": 150, "max": 160},
+            },
+            "detailed_text": "report",
+        }
+    )
+
+    assert result["status"] == "failed"
+    assert "instrument_type must be one of" in result["error"]
+
+    status = await service.get_report_status("job-unknown-type")
+    assert status["status"] == "failed"
+    assert "instrument_type must be one of" in status["error"]
+
+
+@pytest.mark.asyncio
+async def test_place_order_confirm_maps_to_dry_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services.screener_service import ScreenerService
+
+    fake_redis = _FakeRedis()
+    mock_place = AsyncMock(return_value={"success": True})
+    monkeypatch.setattr("app.services.screener_service._place_order_impl", mock_place)
+
+    service = ScreenerService(redis_client=fake_redis)
+
+    await service.place_order(
+        market="us",
+        symbol="AAPL",
+        side="buy",
+        order_type="limit",
+        quantity=1,
+        price=100,
+        confirm=False,
+    )
+    await service.place_order(
+        market="us",
+        symbol="AAPL",
+        side="buy",
+        order_type="limit",
+        quantity=1,
+        price=100,
+        confirm=True,
+    )
+
+    first_kwargs = mock_place.await_args_list[0].kwargs
+    second_kwargs = mock_place.await_args_list[1].kwargs
+    assert first_kwargs["dry_run"] is True
+    assert second_kwargs["dry_run"] is False
+    assert first_kwargs["market"] == "us"
+    assert second_kwargs["market"] == "us"


### PR DESCRIPTION
Summary in commit history; includes screener API, OpenClaw callback integration, cache/reuse/failure handling, market propagation, and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new stock screener dashboard with filtering and listing capabilities
  * Added AI-powered stock analysis reports with real-time job status tracking
  * Enabled order execution directly from the screener interface
  * Added screener callback processing for external service integration
  * Created comprehensive stock screening API endpoints supporting multiple market types and filtering options

* **Configuration**
  * Added new screener callback URL configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->