### PR TITLE
feat: add KR OHLCV ingest pipeline with scheduled precompute

### DIFF
--- a/alembic/versions/c4d9e2a8f7b1_add_timescale_kr_ohlcv_tables.py
+++ b/alembic/versions/c4d9e2a8f7b1_add_timescale_kr_ohlcv_tables.py
@@ -1,0 +1,131 @@
+from alembic import op
+
+revision = "c4d9e2a8f7b1"
+down_revision = "b71d9dce2f34"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS timescaledb")
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS market_candles_1m (
+            market TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            ts TIMESTAMPTZ NOT NULL,
+            open NUMERIC(20, 6) NOT NULL,
+            high NUMERIC(20, 6) NOT NULL,
+            low NUMERIC(20, 6) NOT NULL,
+            close NUMERIC(20, 6) NOT NULL,
+            volume BIGINT NOT NULL DEFAULT 0,
+            value BIGINT NOT NULL DEFAULT 0,
+            source TEXT NOT NULL DEFAULT 'kis',
+            route TEXT NOT NULL,
+            fetched_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (market, symbol, ts)
+        )
+        """
+    )
+
+    op.execute(
+        """
+        SELECT create_hypertable(
+            'market_candles_1m',
+            by_range('ts', INTERVAL '7 days'),
+            if_not_exists => TRUE
+        )
+        """
+    )
+
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW IF NOT EXISTS market_candles_1h_kr
+        WITH (timescaledb.continuous) AS
+        SELECT
+            market,
+            symbol,
+            time_bucket('1 hour', ts, 'Asia/Seoul') AS bucket_start,
+            first(open, ts) AS open,
+            max(high) AS high,
+            min(low) AS low,
+            last(close, ts) AS close,
+            sum(volume) AS volume,
+            sum(value) AS value
+        FROM market_candles_1m
+        WHERE market = 'kr'
+        GROUP BY market, symbol, bucket_start
+        WITH NO DATA
+        """
+    )
+
+    op.execute(
+        """
+        ALTER MATERIALIZED VIEW market_candles_1h_kr
+        SET (timescaledb.materialized_only = false)
+        """
+    )
+
+    op.execute(
+        """
+        SELECT add_retention_policy(
+            'market_candles_1m',
+            INTERVAL '30 days',
+            if_not_exists => TRUE
+        )
+        """
+    )
+
+    op.execute(
+        """
+        SELECT add_retention_policy(
+            'market_candles_1h_kr',
+            INTERVAL '400 days',
+            if_not_exists => TRUE
+        )
+        """
+    )
+
+    op.execute(
+        """
+        SELECT add_continuous_aggregate_policy(
+            'market_candles_1h_kr',
+            start_offset => INTERVAL '8 days',
+            end_offset => INTERVAL '1 minute',
+            schedule_interval => INTERVAL '5 minutes',
+            if_not_exists => TRUE
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        SELECT remove_continuous_aggregate_policy(
+            'market_candles_1h_kr',
+            if_not_exists => TRUE
+        )
+        """
+    )
+    op.execute(
+        """
+        SELECT remove_retention_policy(
+            'market_candles_1h_kr',
+            if_not_exists => TRUE
+        )
+        """
+    )
+    op.execute(
+        """
+        SELECT remove_retention_policy(
+            'market_candles_1m',
+            if_not_exists => TRUE
+        )
+        """
+    )
+
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS market_candles_1h_kr")
+    op.execute("DROP TABLE IF EXISTS market_candles_1m")

--- a/alembic/versions/c9e4f5b8a2d1_rebuild_kr_hour_cagg_with_exchange_priority.py
+++ b/alembic/versions/c9e4f5b8a2d1_rebuild_kr_hour_cagg_with_exchange_priority.py
@@ -1,0 +1,240 @@
+from alembic import op
+
+revision = "c9e4f5b8a2d1"
+down_revision = "c4d9e2a8f7b1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS market_candles_1m_kr (
+            exchange TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            ts TIMESTAMPTZ NOT NULL,
+            open NUMERIC(20, 6) NOT NULL,
+            high NUMERIC(20, 6) NOT NULL,
+            low NUMERIC(20, 6) NOT NULL,
+            close NUMERIC(20, 6) NOT NULL,
+            volume BIGINT NOT NULL DEFAULT 0,
+            value BIGINT NOT NULL DEFAULT 0,
+            source TEXT NOT NULL DEFAULT 'kis',
+            fetched_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (exchange, symbol, ts)
+        )
+        """
+    )
+
+    op.execute(
+        """
+        SELECT create_hypertable(
+            'market_candles_1m_kr',
+            by_range('ts', INTERVAL '7 days'),
+            if_not_exists => TRUE
+        )
+        """
+    )
+
+    op.execute(
+        """
+        DO $$
+        DECLARE
+            invalid_route_count BIGINT;
+        BEGIN
+            SELECT COUNT(*)
+            INTO invalid_route_count
+            FROM market_candles_1m
+            WHERE lower(coalesce(market, '')) = 'kr'
+              AND upper(coalesce(route, '')) NOT IN ('J', 'NX', 'NXT');
+
+            IF invalid_route_count > 0 THEN
+                RAISE EXCEPTION
+                    'c9 KR backfill aborted: found % rows with unsupported route (allowed: J,NX,NXT)',
+                    invalid_route_count;
+            END IF;
+        END
+        $$;
+        """
+    )
+
+    op.execute(
+        """
+        INSERT INTO market_candles_1m_kr (
+            exchange,
+            symbol,
+            ts,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            value,
+            source,
+            fetched_at,
+            updated_at
+        )
+        SELECT
+            CASE
+                WHEN upper(coalesce(route, '')) = 'J' THEN 'KRX'
+                WHEN upper(coalesce(route, '')) IN ('NX', 'NXT') THEN 'NXT'
+            END AS exchange,
+            symbol,
+            ts,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            value,
+            source,
+            fetched_at,
+            updated_at
+        FROM market_candles_1m
+        WHERE lower(coalesce(market, '')) = 'kr'
+          AND upper(coalesce(route, '')) IN ('J', 'NX', 'NXT')
+        ON CONFLICT (exchange, symbol, ts) DO UPDATE SET
+            open = EXCLUDED.open,
+            high = EXCLUDED.high,
+            low = EXCLUDED.low,
+            close = EXCLUDED.close,
+            volume = EXCLUDED.volume,
+            value = EXCLUDED.value,
+            source = EXCLUDED.source,
+            fetched_at = EXCLUDED.fetched_at,
+            updated_at = EXCLUDED.updated_at
+        """
+    )
+
+    op.execute(
+        """
+        SELECT remove_continuous_aggregate_policy(
+            'market_candles_1h_kr',
+            if_not_exists => TRUE
+        )
+        """
+    )
+
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS market_candles_1h_kr")
+
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW market_candles_1h_kr
+        WITH (timescaledb.continuous) AS
+        SELECT
+            symbol,
+            time_bucket(INTERVAL '1 hour', ts, 'Asia/Seoul') AS bucket_start,
+
+            first(
+                open,
+                ts + CASE
+                    WHEN exchange = 'NXT' THEN INTERVAL '1 millisecond'
+                    ELSE INTERVAL '0'
+                END
+            ) AS open,
+
+            MAX(high) AS high,
+            MIN(low) AS low,
+
+            last(
+                close,
+                ts + CASE
+                    WHEN exchange = 'KRX' THEN INTERVAL '1 millisecond'
+                    ELSE INTERVAL '0'
+                END
+            ) AS close,
+
+            SUM(volume)::BIGINT AS volume,
+            SUM(value)::BIGINT AS value
+        FROM market_candles_1m_kr
+        WHERE exchange IN ('KRX', 'NXT')
+        GROUP BY symbol, bucket_start
+        WITH NO DATA
+        """
+    )
+
+    op.execute(
+        """
+        ALTER MATERIALIZED VIEW market_candles_1h_kr
+        SET (timescaledb.materialized_only = false)
+        """
+    )
+
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS ux_market_candles_1h_kr_symbol_bucket
+        ON market_candles_1h_kr (symbol, bucket_start)
+        """
+    )
+
+    op.execute(
+        """
+        SELECT add_continuous_aggregate_policy(
+            'market_candles_1h_kr',
+            start_offset => INTERVAL '8 days',
+            end_offset => INTERVAL '1 minute',
+            schedule_interval => INTERVAL '5 minutes',
+            if_not_exists => TRUE
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        SELECT remove_continuous_aggregate_policy(
+            'market_candles_1h_kr',
+            if_not_exists => TRUE
+        )
+        """
+    )
+
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS market_candles_1h_kr")
+
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW market_candles_1h_kr
+        WITH (timescaledb.continuous) AS
+        SELECT
+            symbol,
+            time_bucket(INTERVAL '1 hour', ts, 'Asia/Seoul') AS bucket_start,
+            first(open, ts) AS open,
+            MAX(high) AS high,
+            MIN(low) AS low,
+            last(close, ts) AS close,
+            SUM(volume)::BIGINT AS volume,
+            SUM(value)::BIGINT AS value
+        FROM market_candles_1m_kr
+        WHERE exchange IN ('KRX', 'NXT')
+        GROUP BY symbol, bucket_start
+        WITH NO DATA
+        """
+    )
+
+    op.execute(
+        """
+        ALTER MATERIALIZED VIEW market_candles_1h_kr
+        SET (timescaledb.materialized_only = false)
+        """
+    )
+
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS ux_market_candles_1h_kr_symbol_bucket
+        ON market_candles_1h_kr (symbol, bucket_start)
+        """
+    )
+
+    op.execute(
+        """
+        SELECT add_continuous_aggregate_policy(
+            'market_candles_1h_kr',
+            start_offset => INTERVAL '8 days',
+            end_offset => INTERVAL '1 minute',
+            schedule_interval => INTERVAL '5 minutes',
+            if_not_exists => TRUE
+        )
+        """
+    )

--- a/alembic/versions/d2f4a8c1b9e3_add_kr_quarantine_and_bigint_v2.py
+++ b/alembic/versions/d2f4a8c1b9e3_add_kr_quarantine_and_bigint_v2.py
@@ -1,0 +1,180 @@
+from alembic import op
+
+revision = "d2f4a8c1b9e3"
+down_revision = "c9e4f5b8a2d1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS market_candles_ingest_quarantine (
+            id BIGSERIAL PRIMARY KEY,
+            symbol TEXT NOT NULL,
+            route TEXT,
+            exchange_raw TEXT NOT NULL,
+            ts TIMESTAMPTZ NOT NULL,
+            payload JSONB NOT NULL,
+            reason TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS ix_market_candles_ingest_quarantine_created_at
+        ON market_candles_ingest_quarantine (created_at DESC)
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS market_candles_1m_kr_v2 (
+            exchange TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            ts TIMESTAMPTZ NOT NULL,
+            open BIGINT NOT NULL,
+            high BIGINT NOT NULL,
+            low BIGINT NOT NULL,
+            close BIGINT NOT NULL,
+            volume BIGINT NOT NULL DEFAULT 0,
+            value BIGINT NOT NULL DEFAULT 0,
+            source TEXT NOT NULL DEFAULT 'kis',
+            fetched_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            PRIMARY KEY (exchange, symbol, ts)
+        )
+        """
+    )
+
+    op.execute(
+        """
+        SELECT create_hypertable(
+            'market_candles_1m_kr_v2',
+            by_range('ts', INTERVAL '7 days'),
+            if_not_exists => TRUE
+        )
+        """
+    )
+
+    op.execute(
+        """
+        INSERT INTO market_candles_1m_kr_v2 (
+            exchange,
+            symbol,
+            ts,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            value,
+            source,
+            fetched_at,
+            updated_at
+        )
+        SELECT
+            exchange,
+            symbol,
+            ts,
+            ROUND(open)::BIGINT,
+            ROUND(high)::BIGINT,
+            ROUND(low)::BIGINT,
+            ROUND(close)::BIGINT,
+            volume,
+            value,
+            source,
+            fetched_at,
+            updated_at
+        FROM market_candles_1m_kr
+        ON CONFLICT (exchange, symbol, ts) DO UPDATE SET
+            open = EXCLUDED.open,
+            high = EXCLUDED.high,
+            low = EXCLUDED.low,
+            close = EXCLUDED.close,
+            volume = EXCLUDED.volume,
+            value = EXCLUDED.value,
+            source = EXCLUDED.source,
+            fetched_at = EXCLUDED.fetched_at,
+            updated_at = EXCLUDED.updated_at
+        """
+    )
+
+    op.execute(
+        """
+        CREATE MATERIALIZED VIEW IF NOT EXISTS market_candles_1h_kr_v2
+        WITH (timescaledb.continuous) AS
+        SELECT
+            symbol,
+            time_bucket(INTERVAL '1 hour', ts, 'Asia/Seoul') AS bucket_start,
+
+            first(
+                open,
+                ts + CASE
+                    WHEN exchange = 'NXT' THEN INTERVAL '1 millisecond'
+                    ELSE INTERVAL '0'
+                END
+            ) AS open,
+
+            MAX(high) AS high,
+            MIN(low) AS low,
+
+            last(
+                close,
+                ts + CASE
+                    WHEN exchange = 'KRX' THEN INTERVAL '1 millisecond'
+                    ELSE INTERVAL '0'
+                END
+            ) AS close,
+
+            SUM(volume)::BIGINT AS volume,
+            SUM(value)::BIGINT AS value
+        FROM market_candles_1m_kr_v2
+        WHERE exchange IN ('KRX', 'NXT')
+        GROUP BY symbol, bucket_start
+        WITH NO DATA
+        """
+    )
+
+    op.execute(
+        """
+        ALTER MATERIALIZED VIEW market_candles_1h_kr_v2
+        SET (timescaledb.materialized_only = false)
+        """
+    )
+
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS ux_market_candles_1h_kr_v2_symbol_bucket
+        ON market_candles_1h_kr_v2 (symbol, bucket_start)
+        """
+    )
+
+    op.execute(
+        """
+        SELECT add_continuous_aggregate_policy(
+            'market_candles_1h_kr_v2',
+            start_offset => INTERVAL '8 days',
+            end_offset => INTERVAL '1 minute',
+            schedule_interval => INTERVAL '5 minutes',
+            if_not_exists => TRUE
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        SELECT remove_continuous_aggregate_policy(
+            'market_candles_1h_kr_v2',
+            if_not_exists => TRUE
+        )
+        """
+    )
+
+    op.execute("DROP MATERIALIZED VIEW IF EXISTS market_candles_1h_kr_v2")
+    op.execute("DROP TABLE IF EXISTS market_candles_1m_kr_v2")
+    op.execute("DROP TABLE IF EXISTS market_candles_ingest_quarantine")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -46,6 +46,10 @@ class Settings(BaseSettings):
     kis_ohlcv_cache_max_days: int = 400
     kis_ohlcv_cache_max_hours: int = 400 * 24
     kis_ohlcv_cache_lock_ttl_seconds: int = 10
+    KR_OHLCV_DUAL_ROUTE_ENABLED: bool = False
+    KR_OHLCV_DUAL_ROUTE_CANARY_SYMBOLS: list[str] = []
+    KR_OHLCV_DUAL_ROUTE_CANARY_ALL: bool = False
+    KR_OHLCV_V2_DUAL_WRITE_ENABLED: bool = False
 
     # API Rate Limit Retry Settings (429 handling)
     api_rate_limit_retry_429_max: int = 2  # 429 에러 시 최대 재시도 횟수
@@ -94,6 +98,21 @@ class Settings(BaseSettings):
                 return []
             return [key.strip() for key in v.split(",") if key.strip()]
         return v
+
+    @field_validator("KR_OHLCV_DUAL_ROUTE_CANARY_SYMBOLS", mode="before")
+    @classmethod
+    def split_kr_ohlcv_canary_symbols(cls, value: Any) -> list[str]:
+        if isinstance(value, str):
+            if not value:
+                return []
+            return [
+                symbol.strip().upper() for symbol in value.split(",") if symbol.strip()
+            ]
+        if isinstance(value, list):
+            return [
+                str(symbol).strip().upper() for symbol in value if str(symbol).strip()
+            ]
+        return []
 
     def _ensure_key_index(self):
         """API 키 인덱스 초기화 (필요시에만)"""

--- a/app/core/taskiq_broker.py
+++ b/app/core/taskiq_broker.py
@@ -6,12 +6,14 @@ from taskiq_redis import ListQueueBroker, RedisAsyncResultBackend
 from app.core.config import settings
 from app.monitoring.sentry import init_sentry
 from app.monitoring.trade_notifier import get_trade_notifier
+from app.services.kr_ohlcv_timeseries_store import ensure_timescale_ready
 
 logger = logging.getLogger(__name__)
 
 
 class WorkerInitMiddleware(TaskiqMiddleware):
     async def startup(self) -> None:
+        await ensure_timescale_ready()
         if self.broker.is_worker_process:
             init_sentry(
                 service_name="auto-trader-worker",

--- a/app/jobs/kr_ohlcv_precompute.py
+++ b/app/jobs/kr_ohlcv_precompute.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+import datetime
+import logging
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.manual_holdings import BrokerAccount, ManualHolding, MarketType
+from app.models.symbol_trade_settings import SymbolTradeSettings
+from app.models.trading import InstrumentType, User
+from app.services import kr_ohlcv_timeseries_store
+from app.services.kis import KISClient
+from app.services.kr_ohlcv_metrics import record_fetch_success
+from app.services.kr_trading_calendar import exchange_for_route, get_session_bounds
+
+logger = logging.getLogger(__name__)
+
+_KST = ZoneInfo("Asia/Seoul")
+_KR_INTRADAY_MAX_PAGE_CALLS_PER_DAY = 10
+_BOOTSTRAP_DAYS = 7
+_NIGHTLY_DAYS = 30
+_INCREMENTAL_DAYS = 1
+
+
+def _normalize_symbol(value: str) -> str | None:
+    normalized = str(value or "").strip().upper()
+    if len(normalized) == 6 and normalized.isalnum():
+        return normalized
+    return None
+
+
+def _filter_kr_intraday_session(
+    frame: pd.DataFrame,
+    route_market: str,
+    target_day: datetime.date,
+) -> pd.DataFrame:
+    if frame.empty or "datetime" not in frame.columns:
+        return frame
+
+    session_bounds = get_session_bounds(route_market, target_day)
+    if session_bounds is None:
+        return frame.iloc[0:0].reset_index(drop=True)
+
+    out = frame.copy()
+    out["datetime"] = pd.to_datetime(out["datetime"], errors="coerce")
+    out = out.dropna(subset=["datetime"])
+    if out.empty:
+        return out
+
+    session_start, session_end = session_bounds
+    start_ts = pd.Timestamp(session_start)
+    end_ts = pd.Timestamp(session_end)
+    if out["datetime"].dt.tz is None:
+        out["_datetime_kst"] = out["datetime"].dt.tz_localize(_KST)
+    else:
+        out["_datetime_kst"] = out["datetime"].dt.tz_convert(_KST)
+
+    return (
+        out.loc[(out["_datetime_kst"] >= start_ts) & (out["_datetime_kst"] <= end_ts)]
+        .drop(columns=["_datetime_kst"])
+        .reset_index(drop=True)
+    )
+
+
+async def _page_kr_intraday_day(
+    *,
+    kis: KISClient,
+    symbol: str,
+    route_market: str,
+    target_day: datetime.date,
+) -> pd.DataFrame:
+    session_bounds = get_session_bounds(route_market, target_day)
+    if session_bounds is None:
+        return pd.DataFrame()
+    session_start = session_bounds[0].strftime("%H%M%S")
+    end_time = session_bounds[1].strftime("%H%M%S")
+    merged = pd.DataFrame()
+
+    for _ in range(_KR_INTRADAY_MAX_PAGE_CALLS_PER_DAY):
+        intraday = await kis.inquire_time_dailychartprice(
+            code=symbol,
+            market=route_market,
+            n=200,
+            end_date=target_day,
+            end_time=end_time,
+        )
+        intraday = _filter_kr_intraday_session(
+            intraday,
+            route_market,
+            target_day,
+        )
+        if intraday.empty:
+            break
+
+        merged = pd.concat([merged, intraday], ignore_index=True)
+        merged["datetime"] = pd.to_datetime(merged["datetime"], errors="coerce")
+        merged = (
+            merged.dropna(subset=["datetime"])
+            .drop_duplicates(subset=["datetime"], keep="last")
+            .sort_values("datetime")
+            .reset_index(drop=True)
+        )
+
+        intraday_datetimes = pd.to_datetime(intraday["datetime"], errors="coerce")
+        intraday_datetimes = intraday_datetimes.dropna()
+        if intraday_datetimes.empty:
+            break
+
+        oldest = intraday_datetimes.min()
+        next_end_time = (oldest - datetime.timedelta(minutes=1)).strftime("%H%M%S")
+        if next_end_time < session_start:
+            break
+        if next_end_time == end_time:
+            break
+        end_time = next_end_time
+
+    return merged
+
+
+def _is_dual_route_canary_symbol(symbol: str) -> bool:
+    if settings.KR_OHLCV_DUAL_ROUTE_CANARY_ALL:
+        return True
+    canary_symbols = {
+        str(item).strip().upper()
+        for item in settings.KR_OHLCV_DUAL_ROUTE_CANARY_SYMBOLS
+        if str(item).strip()
+    }
+    return str(symbol or "").strip().upper() in canary_symbols
+
+
+async def _resolve_route(symbol: str) -> list[str] | None:
+    async with AsyncSessionLocal() as session:
+        row = (
+            await session.execute(
+                select(KRSymbolUniverse).where(KRSymbolUniverse.symbol == symbol)
+            )
+        ).scalar_one_or_none()
+    if row is None or not row.is_active:
+        return None
+    normalized_symbol = str(symbol or "").strip().upper()
+    if not row.nxt_eligible:
+        return ["J"]
+    if settings.KR_OHLCV_DUAL_ROUTE_ENABLED and _is_dual_route_canary_symbol(
+        normalized_symbol
+    ):
+        return ["J", "NX"]
+    return ["J"]
+
+
+async def _collect_kr_symbols() -> set[str]:
+    async with AsyncSessionLocal() as session:
+        active_users = list(
+            (
+                await session.execute(
+                    select(User.id).where(User.is_active.is_(True)).order_by(User.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        setting_symbols = list(
+            (
+                await session.execute(
+                    select(SymbolTradeSettings.symbol)
+                    .join(User, User.id == SymbolTradeSettings.user_id)
+                    .where(User.is_active.is_(True))
+                    .where(SymbolTradeSettings.is_active.is_(True))
+                    .where(
+                        SymbolTradeSettings.instrument_type == InstrumentType.equity_kr
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        manual_symbols = list(
+            (
+                await session.execute(
+                    select(ManualHolding.ticker)
+                    .join(
+                        BrokerAccount,
+                        BrokerAccount.id == ManualHolding.broker_account_id,
+                    )
+                    .join(User, User.id == BrokerAccount.user_id)
+                    .where(User.is_active.is_(True))
+                    .where(BrokerAccount.is_active.is_(True))
+                    .where(ManualHolding.market_type == MarketType.KR)
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+    symbols: set[str] = set()
+    for symbol in [*setting_symbols, *manual_symbols]:
+        normalized = _normalize_symbol(str(symbol or ""))
+        if normalized is not None:
+            symbols.add(normalized)
+
+    if active_users:
+        try:
+            holdings = await KISClient().fetch_my_stocks()
+            for stock in holdings:
+                normalized = _normalize_symbol(str(stock.get("pdno") or ""))
+                if normalized is not None:
+                    symbols.add(normalized)
+        except Exception as exc:
+            logger.warning("Failed to collect KIS account symbols: %s", exc)
+
+    return symbols
+
+
+async def _sync_symbol_minutes(symbol: str, days: int) -> dict[str, int | str]:
+    normalized_days = max(int(days), 1)
+    route_markets = await _resolve_route(symbol)
+    if route_markets is None:
+        return {
+            "status": "skipped",
+            "symbol": symbol,
+            "reason": "route_not_found",
+            "rows": 0,
+        }
+
+    kis = KISClient()
+    today_kst = datetime.datetime.now(_KST).date()
+    start_day = today_kst - datetime.timedelta(days=normalized_days - 1)
+
+    total_rows = 0
+    refresh_min_ts: datetime.datetime | None = None
+    refresh_max_ts: datetime.datetime | None = None
+    for route_market in route_markets:
+        merged = pd.DataFrame()
+        current_day = today_kst
+        while current_day >= start_day:
+            daily = await _page_kr_intraday_day(
+                kis=kis,
+                symbol=symbol,
+                route_market=route_market,
+                target_day=current_day,
+            )
+            if not daily.empty:
+                merged = pd.concat([merged, daily], ignore_index=True)
+            current_day = current_day - datetime.timedelta(days=1)
+
+        record_fetch_success(route_market)
+        if merged.empty:
+            continue
+
+        merged["datetime"] = pd.to_datetime(merged["datetime"], errors="coerce")
+        merged = (
+            merged.dropna(subset=["datetime"])
+            .drop_duplicates(subset=["datetime"], keep="last")
+            .sort_values("datetime")
+            .reset_index(drop=True)
+        )
+
+        upsert_result = await kr_ohlcv_timeseries_store.upsert_market_candles_1m(
+            symbol=symbol,
+            exchange=exchange_for_route(route_market),
+            route=route_market,
+            frame=merged,
+            source="kis",
+        )
+        total_rows += int(upsert_result.get("rows", 0))
+        min_ts = upsert_result.get("min_ts")
+        max_ts = upsert_result.get("max_ts")
+        if isinstance(min_ts, datetime.datetime):
+            if refresh_min_ts is None or min_ts < refresh_min_ts:
+                refresh_min_ts = min_ts
+        if isinstance(max_ts, datetime.datetime):
+            if refresh_max_ts is None or max_ts > refresh_max_ts:
+                refresh_max_ts = max_ts
+
+    if refresh_min_ts is not None and refresh_max_ts is not None:
+        await kr_ohlcv_timeseries_store.refresh_market_candles_1h_kr(
+            start_ts=refresh_min_ts,
+            end_ts=refresh_max_ts + datetime.timedelta(hours=1),
+        )
+
+    return {
+        "status": "completed",
+        "symbol": symbol,
+        "rows": total_rows,
+        "route": ",".join(route_markets),
+    }
+
+
+async def run_kr_ohlcv_incremental_precompute() -> dict[str, int | str]:
+    try:
+        await kr_ohlcv_timeseries_store.ensure_timescale_ready()
+        symbols = await _collect_kr_symbols()
+
+        processed = 0
+        inserted_rows = 0
+        bootstrapped = 0
+        for symbol in sorted(symbols):
+            latest_bucket = await kr_ohlcv_timeseries_store.fetch_latest_hourly_bucket(
+                symbol=symbol
+            )
+            sync_days = _BOOTSTRAP_DAYS if latest_bucket is None else _INCREMENTAL_DAYS
+            if sync_days == _BOOTSTRAP_DAYS:
+                bootstrapped += 1
+
+            result = await _sync_symbol_minutes(symbol, sync_days)
+            if result.get("status") == "completed":
+                processed += 1
+                inserted_rows += int(result.get("rows", 0))
+
+        return {
+            "status": "completed",
+            "mode": "incremental",
+            "symbols": len(symbols),
+            "processed": processed,
+            "bootstrapped": bootstrapped,
+            "inserted_rows": inserted_rows,
+        }
+    except Exception as exc:
+        logger.error("KR OHLCV incremental precompute failed: %s", exc, exc_info=True)
+        return {
+            "status": "failed",
+            "mode": "incremental",
+            "error": str(exc),
+        }
+
+
+async def run_kr_ohlcv_nightly_precompute() -> dict[str, int | str]:
+    try:
+        await kr_ohlcv_timeseries_store.ensure_timescale_ready()
+        symbols = await _collect_kr_symbols()
+
+        processed = 0
+        inserted_rows = 0
+        bootstrapped = 0
+        expanded = 0
+        for symbol in sorted(symbols):
+            latest_bucket = await kr_ohlcv_timeseries_store.fetch_latest_hourly_bucket(
+                symbol=symbol
+            )
+            sync_days = _BOOTSTRAP_DAYS if latest_bucket is None else _NIGHTLY_DAYS
+            if sync_days == _BOOTSTRAP_DAYS:
+                bootstrapped += 1
+            else:
+                expanded += 1
+
+            result = await _sync_symbol_minutes(symbol, sync_days)
+            if result.get("status") == "completed":
+                processed += 1
+                inserted_rows += int(result.get("rows", 0))
+
+        return {
+            "status": "completed",
+            "mode": "nightly",
+            "symbols": len(symbols),
+            "processed": processed,
+            "bootstrapped": bootstrapped,
+            "expanded_to_30d": expanded,
+            "inserted_rows": inserted_rows,
+        }
+    except Exception as exc:
+        logger.error("KR OHLCV nightly precompute failed: %s", exc, exc_info=True)
+        return {
+            "status": "failed",
+            "mode": "nightly",
+            "error": str(exc),
+        }
+
+
+__all__ = [
+    "run_kr_ohlcv_incremental_precompute",
+    "run_kr_ohlcv_nightly_precompute",
+]

--- a/app/services/kr_ohlcv_metrics.py
+++ b/app/services/kr_ohlcv_metrics.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Final
+
+_METRIC_FETCH_SUCCESS: Final[str] = "kr_ohlcv_fetch_success"
+_METRIC_ROWS_UPSERTED: Final[str] = "kr_ohlcv_rows_upserted"
+_METRIC_QUARANTINE_COUNT: Final[str] = "kr_ohlcv_quarantine_count"
+
+_counters: Counter[tuple[str, str]] = Counter()
+
+
+def record_fetch_success(route: str) -> None:
+    _counters[(_METRIC_FETCH_SUCCESS, str(route).strip().upper())] += 1
+
+
+def record_rows_upserted(exchange: str, rows: int) -> None:
+    normalized_rows = max(int(rows), 0)
+    if normalized_rows <= 0:
+        return
+    _counters[(_METRIC_ROWS_UPSERTED, str(exchange).strip().upper())] += normalized_rows
+
+
+def record_quarantine(count: int = 1) -> None:
+    normalized_count = max(int(count), 0)
+    if normalized_count <= 0:
+        return
+    _counters[(_METRIC_QUARANTINE_COUNT, "total")] += normalized_count
+
+
+def snapshot() -> dict[str, dict[str, int]]:
+    out: dict[str, dict[str, int]] = {
+        _METRIC_FETCH_SUCCESS: {},
+        _METRIC_ROWS_UPSERTED: {},
+        _METRIC_QUARANTINE_COUNT: {},
+    }
+    for (metric, label), value in _counters.items():
+        out.setdefault(metric, {})[label] = int(value)
+    return out
+
+
+def reset() -> None:
+    _counters.clear()
+
+
+__all__ = [
+    "record_fetch_success",
+    "record_quarantine",
+    "record_rows_upserted",
+    "reset",
+    "snapshot",
+]

--- a/app/services/kr_ohlcv_timeseries_store.py
+++ b/app/services/kr_ohlcv_timeseries_store.py
@@ -1,0 +1,573 @@
+from __future__ import annotations
+
+import datetime
+import json
+from collections.abc import Sequence
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+from sqlalchemy import text
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.services.kr_ohlcv_metrics import record_quarantine, record_rows_upserted
+from app.services.kr_trading_calendar import route_for_exchange
+
+_KST = ZoneInfo("Asia/Seoul")
+_UTC = datetime.UTC
+_HOURLY_COLUMNS = [
+    "datetime",
+    "date",
+    "time",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "value",
+]
+_VALID_EXCHANGES = {"KRX", "NXT"}
+_VALID_ROUTES = {"J", "NX"}
+
+
+def _empty_hourly_frame() -> pd.DataFrame:
+    return pd.DataFrame(columns=_HOURLY_COLUMNS)
+
+
+def _to_kst_aware(value: datetime.datetime) -> datetime.datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=_KST)
+    return value.astimezone(_KST)
+
+
+def _normalize_minute_frame(frame: pd.DataFrame) -> pd.DataFrame:
+    if frame.empty:
+        return pd.DataFrame(
+            columns=[
+                "datetime",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "value",
+            ]
+        )
+
+    normalized = frame.copy()
+    if "datetime" not in normalized.columns:
+        if "date" in normalized.columns and "time" in normalized.columns:
+            normalized["datetime"] = pd.to_datetime(
+                normalized["date"].astype(str) + " " + normalized["time"].astype(str),
+                errors="coerce",
+            )
+        else:
+            return pd.DataFrame(
+                columns=[
+                    "datetime",
+                    "open",
+                    "high",
+                    "low",
+                    "close",
+                    "volume",
+                    "value",
+                ]
+            )
+
+    normalized["datetime"] = pd.to_datetime(normalized["datetime"], errors="coerce")
+    normalized = normalized.dropna(subset=["datetime"]).copy()
+    if normalized.empty:
+        return pd.DataFrame(
+            columns=[
+                "datetime",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "value",
+            ]
+        )
+
+    numeric_defaults: dict[str, float | int] = {
+        "open": 0.0,
+        "high": 0.0,
+        "low": 0.0,
+        "close": 0.0,
+        "volume": 0,
+        "value": 0,
+    }
+    for column, default in numeric_defaults.items():
+        if column not in normalized.columns:
+            normalized[column] = default
+        normalized[column] = pd.to_numeric(normalized[column], errors="coerce").fillna(
+            default
+        )
+
+    normalized["datetime"] = normalized["datetime"].dt.floor("min")
+    normalized = (
+        normalized.loc[
+            :,
+            [
+                "datetime",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+                "value",
+            ],
+        ]
+        .drop_duplicates(subset=["datetime"], keep="last")
+        .sort_values("datetime")
+        .reset_index(drop=True)
+    )
+    return normalized
+
+
+async def ensure_timescale_ready(*, allow_test_bypass: bool = True) -> None:
+    if allow_test_bypass and str(settings.ENVIRONMENT).lower() == "test":
+        return
+
+    async with AsyncSessionLocal() as session:
+        extension = (
+            await session.execute(
+                text("SELECT extname FROM pg_extension WHERE extname = 'timescaledb'")
+            )
+        ).scalar_one_or_none()
+        if extension != "timescaledb":
+            raise RuntimeError("TimescaleDB extension is not installed")
+
+        table_name = (
+            await session.execute(
+                text("SELECT to_regclass('public.market_candles_1m_kr')")
+            )
+        ).scalar_one_or_none()
+        if table_name is None:
+            raise RuntimeError("market_candles_1m_kr table is missing")
+
+        cagg_name = (
+            await session.execute(
+                text("SELECT to_regclass('public.market_candles_1h_kr')")
+            )
+        ).scalar_one_or_none()
+        if cagg_name is None:
+            raise RuntimeError("market_candles_1h_kr continuous aggregate is missing")
+
+
+async def upsert_market_candles_1m(
+    *,
+    symbol: str,
+    frame: pd.DataFrame,
+    exchange: str,
+    route: str | None = None,
+    source: str = "kis",
+) -> dict[str, Any]:
+    normalized = _normalize_minute_frame(frame)
+    if normalized.empty:
+        return {
+            "rows": 0,
+            "min_ts": None,
+            "max_ts": None,
+        }
+
+    symbol_value = str(symbol).strip().upper()
+    exchange_value = str(exchange or "").strip().upper()
+    route_value = str(route or "").strip().upper()
+    reason: str | None = None
+    if exchange_value not in _VALID_EXCHANGES:
+        reason = "invalid_exchange"
+    elif route_value and route_value not in _VALID_ROUTES:
+        reason = "invalid_route"
+    elif route_value and route_for_exchange(exchange_value) != route_value:
+        reason = "exchange_route_mismatch"
+
+    params: list[dict[str, Any]] = []
+    params_v2: list[dict[str, Any]] = []
+    quarantine_params: list[dict[str, Any]] = []
+    utc_datetimes: list[datetime.datetime] = []
+    fetched_at = datetime.datetime.now(_UTC)
+    for row in normalized.itertuples(index=False):
+        dt = pd.Timestamp(row.datetime)
+        if dt.tzinfo is None:
+            dt_kst = dt.tz_localize(_KST)
+        else:
+            dt_kst = dt.tz_convert(_KST)
+        dt_utc = dt_kst.tz_convert(_UTC).to_pydatetime()
+        utc_datetimes.append(dt_utc)
+
+        payload = {
+            "open": float(row.open),
+            "high": float(row.high),
+            "low": float(row.low),
+            "close": float(row.close),
+            "volume": int(row.volume),
+            "value": int(row.value),
+            "source": str(source).strip().lower() or "kis",
+        }
+
+        if reason is not None:
+            quarantine_params.append(
+                {
+                    "symbol": symbol_value,
+                    "route": route_value or None,
+                    "exchange_raw": exchange_value,
+                    "ts": dt_utc,
+                    "payload": json.dumps(payload, ensure_ascii=True),
+                    "reason": reason,
+                }
+            )
+            continue
+
+        params.append(
+            {
+                "exchange": exchange_value,
+                "symbol": symbol_value,
+                "ts": dt_utc,
+                "open": payload["open"],
+                "high": payload["high"],
+                "low": payload["low"],
+                "close": payload["close"],
+                "volume": payload["volume"],
+                "value": payload["value"],
+                "source": payload["source"],
+                "fetched_at": fetched_at,
+            }
+        )
+        if settings.KR_OHLCV_V2_DUAL_WRITE_ENABLED:
+            params_v2.append(
+                {
+                    "exchange": exchange_value,
+                    "symbol": symbol_value,
+                    "ts": dt_utc,
+                    "open": int(round(float(payload["open"]))),
+                    "high": int(round(float(payload["high"]))),
+                    "low": int(round(float(payload["low"]))),
+                    "close": int(round(float(payload["close"]))),
+                    "volume": payload["volume"],
+                    "value": payload["value"],
+                    "source": payload["source"],
+                    "fetched_at": fetched_at,
+                }
+            )
+
+    if quarantine_params:
+        quarantine_statement = text(
+            """
+            INSERT INTO market_candles_ingest_quarantine (
+                symbol,
+                route,
+                exchange_raw,
+                ts,
+                payload,
+                reason,
+                created_at
+            ) VALUES (
+                :symbol,
+                :route,
+                :exchange_raw,
+                :ts,
+                CAST(:payload AS jsonb),
+                :reason,
+                now()
+            )
+            """
+        )
+        async with AsyncSessionLocal() as session:
+            await session.execute(quarantine_statement, quarantine_params)
+            await session.commit()
+        record_quarantine(len(quarantine_params))
+        return {
+            "rows": 0,
+            "quarantined_rows": len(quarantine_params),
+            "min_ts": min(utc_datetimes),
+            "max_ts": max(utc_datetimes),
+        }
+
+    statement = text(
+        """
+        INSERT INTO market_candles_1m_kr (
+            exchange,
+            symbol,
+            ts,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            value,
+            source,
+            fetched_at,
+            updated_at
+        ) VALUES (
+            :exchange,
+            :symbol,
+            :ts,
+            :open,
+            :high,
+            :low,
+            :close,
+            :volume,
+            :value,
+            :source,
+            :fetched_at,
+            now()
+        )
+        ON CONFLICT (exchange, symbol, ts) DO UPDATE SET
+            open = EXCLUDED.open,
+            high = EXCLUDED.high,
+            low = EXCLUDED.low,
+            close = EXCLUDED.close,
+            volume = EXCLUDED.volume,
+            value = EXCLUDED.value,
+            source = EXCLUDED.source,
+            fetched_at = EXCLUDED.fetched_at,
+            updated_at = now()
+        """
+    )
+
+    statement_v2 = text(
+        """
+        INSERT INTO market_candles_1m_kr_v2 (
+            exchange,
+            symbol,
+            ts,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            value,
+            source,
+            fetched_at,
+            updated_at
+        ) VALUES (
+            :exchange,
+            :symbol,
+            :ts,
+            :open,
+            :high,
+            :low,
+            :close,
+            :volume,
+            :value,
+            :source,
+            :fetched_at,
+            now()
+        )
+        ON CONFLICT (exchange, symbol, ts) DO UPDATE SET
+            open = EXCLUDED.open,
+            high = EXCLUDED.high,
+            low = EXCLUDED.low,
+            close = EXCLUDED.close,
+            volume = EXCLUDED.volume,
+            value = EXCLUDED.value,
+            source = EXCLUDED.source,
+            fetched_at = EXCLUDED.fetched_at,
+            updated_at = now()
+        """
+    )
+
+    async with AsyncSessionLocal() as session:
+        await session.execute(statement, params)
+        if settings.KR_OHLCV_V2_DUAL_WRITE_ENABLED and params_v2:
+            await session.execute(statement_v2, params_v2)
+        await session.commit()
+
+    record_rows_upserted(exchange_value, len(params))
+
+    return {
+        "rows": len(params),
+        "min_ts": min(utc_datetimes),
+        "max_ts": max(utc_datetimes),
+    }
+
+
+async def refresh_market_candles_1h_kr(
+    *,
+    start_ts: datetime.datetime,
+    end_ts: datetime.datetime,
+) -> None:
+    start_utc = _to_kst_aware(start_ts).astimezone(_UTC)
+    end_utc = _to_kst_aware(end_ts).astimezone(_UTC)
+    if end_utc <= start_utc:
+        return
+
+    statement = text(
+        """
+        SELECT refresh_continuous_aggregate(
+            'market_candles_1h_kr',
+            :start_ts,
+            :end_ts
+        )
+        """
+    )
+    async with AsyncSessionLocal() as session:
+        await session.execute(statement, {"start_ts": start_utc, "end_ts": end_utc})
+        await session.commit()
+
+
+async def fetch_market_candles_1h_kr(
+    *,
+    symbol: str,
+    start_bucket: datetime.datetime,
+    end_bucket: datetime.datetime,
+) -> pd.DataFrame:
+    if end_bucket < start_bucket:
+        return _empty_hourly_frame()
+
+    start_utc = _to_kst_aware(start_bucket).astimezone(_UTC)
+    end_utc = _to_kst_aware(end_bucket).astimezone(_UTC)
+    statement = text(
+        """
+        SELECT
+            bucket_start,
+            open,
+            high,
+            low,
+            close,
+            volume,
+            value
+        FROM market_candles_1h_kr
+        WHERE symbol = :symbol
+          AND bucket_start >= :start_bucket
+          AND bucket_start <= :end_bucket
+        ORDER BY bucket_start ASC
+        """
+    )
+    async with AsyncSessionLocal() as session:
+        rows = list(
+            (
+                await session.execute(
+                    statement,
+                    {
+                        "symbol": str(symbol).strip().upper(),
+                        "start_bucket": start_utc,
+                        "end_bucket": end_utc,
+                    },
+                )
+            )
+            .mappings()
+            .all()
+        )
+
+    if not rows:
+        return _empty_hourly_frame()
+
+    frame = pd.DataFrame(rows)
+    frame["datetime"] = pd.to_datetime(frame["bucket_start"], utc=True).dt.tz_convert(
+        _KST
+    )
+    frame["date"] = frame["datetime"].dt.date
+    frame["time"] = frame["datetime"].dt.time
+    for column in ("open", "high", "low", "close"):
+        frame[column] = pd.to_numeric(frame[column], errors="coerce")
+    for column in ("volume", "value"):
+        frame[column] = (
+            pd.to_numeric(frame[column], errors="coerce").fillna(0).astype("int64")
+        )
+    frame = frame.loc[:, _HOURLY_COLUMNS].sort_values("datetime").reset_index(drop=True)
+    return frame
+
+
+async def fetch_previous_close_before_bucket(
+    *,
+    symbol: str,
+    before_bucket: datetime.datetime,
+) -> float | None:
+    before_utc = _to_kst_aware(before_bucket).astimezone(_UTC)
+    symbol_value = str(symbol).strip().upper()
+
+    cagg_statement = text(
+        """
+        SELECT close
+        FROM market_candles_1h_kr
+        WHERE symbol = :symbol
+          AND bucket_start < :before_bucket
+        ORDER BY bucket_start DESC
+        LIMIT 1
+        """
+    )
+    minute_statement = text(
+        """
+        SELECT close
+        FROM market_candles_1m_kr
+        WHERE symbol = :symbol
+          AND ts < :before_bucket
+          AND exchange IN ('KRX', 'NXT')
+        ORDER BY
+            ts DESC,
+            CASE WHEN exchange = 'KRX' THEN 1 ELSE 0 END DESC
+        LIMIT 1
+        """
+    )
+
+    async with AsyncSessionLocal() as session:
+        close_value = (
+            await session.execute(
+                cagg_statement,
+                {"symbol": symbol_value, "before_bucket": before_utc},
+            )
+        ).scalar_one_or_none()
+        if close_value is not None:
+            return float(close_value)
+
+        minute_close = (
+            await session.execute(
+                minute_statement,
+                {"symbol": symbol_value, "before_bucket": before_utc},
+            )
+        ).scalar_one_or_none()
+        if minute_close is not None:
+            return float(minute_close)
+    return None
+
+
+async def fetch_latest_hourly_bucket(
+    *,
+    symbol: str,
+) -> datetime.datetime | None:
+    statement = text(
+        """
+        SELECT bucket_start
+        FROM market_candles_1h_kr
+        WHERE symbol = :symbol
+        ORDER BY bucket_start DESC
+        LIMIT 1
+        """
+    )
+    async with AsyncSessionLocal() as session:
+        value = (
+            await session.execute(statement, {"symbol": str(symbol).strip().upper()})
+        ).scalar_one_or_none()
+
+    if value is None:
+        return None
+    parsed = pd.Timestamp(value)
+    if parsed.tzinfo is None:
+        parsed = parsed.tz_localize(_UTC)
+    else:
+        parsed = parsed.tz_convert(_UTC)
+    return parsed.tz_convert(_KST).to_pydatetime()
+
+
+def frame_from_hour_rows(rows: Sequence[dict[str, Any]]) -> pd.DataFrame:
+    if not rows:
+        return _empty_hourly_frame()
+    frame = pd.DataFrame(rows)
+    for column in _HOURLY_COLUMNS:
+        if column not in frame.columns:
+            frame[column] = None
+    return frame.loc[:, _HOURLY_COLUMNS].reset_index(drop=True)
+
+
+__all__ = [
+    "ensure_timescale_ready",
+    "fetch_latest_hourly_bucket",
+    "fetch_market_candles_1h_kr",
+    "fetch_previous_close_before_bucket",
+    "frame_from_hour_rows",
+    "refresh_market_candles_1h_kr",
+    "upsert_market_candles_1m",
+]

--- a/app/services/kr_trading_calendar.py
+++ b/app/services/kr_trading_calendar.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import datetime
+from functools import lru_cache
+from zoneinfo import ZoneInfo
+
+import exchange_calendars as xcals
+import pandas as pd
+
+_KST = ZoneInfo("Asia/Seoul")
+_KRX_PREOPEN_OFFSET = datetime.timedelta(hours=1)
+_KRX_POSTCLOSE_OFFSET = datetime.timedelta(hours=4, minutes=30)
+
+_ROUTE_TO_EXCHANGE = {
+    "J": "KRX",
+    "NX": "NXT",
+}
+_EXCHANGE_TO_ROUTE = {
+    "KRX": "J",
+    "NXT": "NX",
+}
+
+
+def normalize_route(route: str) -> str:
+    normalized = str(route or "").strip().upper()
+    if normalized not in _ROUTE_TO_EXCHANGE:
+        raise ValueError(f"Unsupported KR route: {route}")
+    return normalized
+
+
+def normalize_exchange(exchange: str) -> str:
+    normalized = str(exchange or "").strip().upper()
+    if normalized not in _EXCHANGE_TO_ROUTE:
+        raise ValueError(f"Unsupported KR exchange: {exchange}")
+    return normalized
+
+
+def exchange_for_route(route: str) -> str:
+    return _ROUTE_TO_EXCHANGE[normalize_route(route)]
+
+
+def route_for_exchange(exchange: str) -> str:
+    return _EXCHANGE_TO_ROUTE[normalize_exchange(exchange)]
+
+
+@lru_cache(maxsize=1)
+def get_xkrx_calendar():
+    return xcals.get_calendar("XKRX")
+
+
+def _to_kst_timestamp(value: object) -> pd.Timestamp:
+    ts = pd.Timestamp(value)
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    return ts.tz_convert(_KST)
+
+
+def get_session_bounds(
+    route: str,
+    day: datetime.date,
+) -> tuple[datetime.datetime, datetime.datetime] | None:
+    normalized_route = normalize_route(route)
+    calendar = get_xkrx_calendar()
+
+    session_label = pd.Timestamp(day).normalize().tz_localize(None)
+    schedule = calendar.schedule
+    if session_label not in schedule.index:
+        return None
+
+    row = schedule.loc[session_label]
+    if isinstance(row, pd.DataFrame):
+        row = row.iloc[0]
+
+    open_value = row.get("market_open", row.get("open"))
+    close_value = row.get("market_close", row.get("close"))
+    if open_value is None or close_value is None:
+        return None
+
+    open_kst = _to_kst_timestamp(open_value).to_pydatetime()
+    close_kst = _to_kst_timestamp(close_value).to_pydatetime()
+    if normalized_route == "NX":
+        return (
+            open_kst - _KRX_PREOPEN_OFFSET,
+            close_kst + _KRX_POSTCLOSE_OFFSET,
+        )
+    return open_kst, close_kst
+
+
+__all__ = [
+    "exchange_for_route",
+    "get_session_bounds",
+    "get_xkrx_calendar",
+    "normalize_exchange",
+    "normalize_route",
+    "route_for_exchange",
+]

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -1,5 +1,6 @@
 from app.tasks import (
     daily_scan_tasks,
+    kr_ohlcv_precompute_tasks,
     kr_symbol_universe_tasks,
     upbit_symbol_universe_tasks,
     us_symbol_universe_tasks,
@@ -9,6 +10,7 @@ from app.tasks import (
 TASKIQ_TASK_MODULES = (
     daily_scan_tasks,
     watch_scan_tasks,
+    kr_ohlcv_precompute_tasks,
     kr_symbol_universe_tasks,
     upbit_symbol_universe_tasks,
     us_symbol_universe_tasks,

--- a/app/tasks/kr_ohlcv_precompute_tasks.py
+++ b/app/tasks/kr_ohlcv_precompute_tasks.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import logging
+
+from app.core.taskiq_broker import broker
+from app.jobs.kr_ohlcv_precompute import (
+    run_kr_ohlcv_incremental_precompute,
+    run_kr_ohlcv_nightly_precompute,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@broker.task(
+    task_name="ohlcv.kr.precompute.incremental",
+    schedule=[{"cron": "*/5 8-20 * * 1-5", "cron_offset": "Asia/Seoul"}],
+)
+async def run_kr_ohlcv_incremental_precompute_task() -> dict[str, int | str]:
+    try:
+        return await run_kr_ohlcv_incremental_precompute()
+    except Exception as exc:
+        logger.error(
+            "TaskIQ KR OHLCV incremental precompute failed: %s",
+            exc,
+            exc_info=True,
+        )
+        return {
+            "status": "failed",
+            "mode": "incremental",
+            "error": str(exc),
+        }
+
+
+@broker.task(
+    task_name="ohlcv.kr.precompute.nightly",
+    schedule=[{"cron": "25 2 * * *", "cron_offset": "Asia/Seoul"}],
+)
+async def run_kr_ohlcv_nightly_precompute_task() -> dict[str, int | str]:
+    try:
+        return await run_kr_ohlcv_nightly_precompute()
+    except Exception as exc:
+        logger.error(
+            "TaskIQ KR OHLCV nightly precompute failed: %s",
+            exc,
+            exc_info=True,
+        )
+        return {
+            "status": "failed",
+            "mode": "nightly",
+            "error": str(exc),
+        }

--- a/tests/test_kr_cagg_migration.py
+++ b/tests/test_kr_cagg_migration.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from importlib import util as importlib_util
+from pathlib import Path
+
+
+def _load_migration_module(file_name: str):
+    migration_path = (
+        Path(__file__).resolve().parents[1] / "alembic" / "versions" / file_name
+    )
+    spec = importlib_util.spec_from_file_location(
+        file_name,
+        migration_path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Failed to load KR CAGG migration module")
+    module = importlib_util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_cagg_sql_policy_recreated(monkeypatch):
+    migration = _load_migration_module(
+        "c9e4f5b8a2d1_rebuild_kr_hour_cagg_with_exchange_priority.py"
+    )
+    statements: list[str] = []
+
+    def _record(statement):
+        statements.append(str(statement))
+
+    monkeypatch.setattr(migration.op, "execute", _record)
+
+    migration.upgrade()
+
+    assert any(
+        "remove_continuous_aggregate_policy" in stmt and "market_candles_1h_kr" in stmt
+        for stmt in statements
+    )
+    assert any(
+        "DROP MATERIALIZED VIEW IF EXISTS market_candles_1h_kr" in stmt
+        for stmt in statements
+    )
+
+    create_cagg_sql = next(
+        stmt
+        for stmt in statements
+        if "CREATE MATERIALIZED VIEW market_candles_1h_kr" in stmt
+    )
+    assert "FROM market_candles_1m_kr" in create_cagg_sql
+    assert "exchange IN ('KRX', 'NXT')" in create_cagg_sql
+    assert "WHEN exchange = 'NXT' THEN INTERVAL '1 millisecond'" in create_cagg_sql
+    assert "WHEN exchange = 'KRX' THEN INTERVAL '1 millisecond'" in create_cagg_sql
+
+    assert any(
+        "add_continuous_aggregate_policy" in stmt
+        and "start_offset => INTERVAL '8 days'" in stmt
+        and "end_offset => INTERVAL '1 minute'" in stmt
+        and "schedule_interval => INTERVAL '5 minutes'" in stmt
+        for stmt in statements
+    )
+
+    fail_fast_sql = next(stmt for stmt in statements if "RAISE EXCEPTION" in stmt)
+    assert "upper(coalesce(route, '')) NOT IN ('J', 'NX', 'NXT')" in fail_fast_sql
+    assert "unsupported route (allowed: J,NX,NXT)" in fail_fast_sql
+
+    route_remap_sql = next(
+        stmt for stmt in statements if "INSERT INTO market_candles_1m_kr" in stmt
+    )
+    assert "upper(coalesce(route, '')) = 'J' THEN 'KRX'" in route_remap_sql
+    assert "IN ('NX', 'NXT')" in route_remap_sql
+    assert "upper(coalesce(route, '')) IN ('J', 'NX', 'NXT')" in route_remap_sql
+    assert "ELSE 'KRX'" not in route_remap_sql
+    assert "'UN', 'NXT'" not in route_remap_sql
+
+
+def test_v2_migration_creates_bigint_tables_and_policy(monkeypatch):
+    migration = _load_migration_module(
+        "d2f4a8c1b9e3_add_kr_quarantine_and_bigint_v2.py"
+    )
+    statements: list[str] = []
+
+    def _record(statement):
+        statements.append(str(statement))
+
+    monkeypatch.setattr(migration.op, "execute", _record)
+
+    migration.upgrade()
+
+    assert any(
+        "CREATE TABLE IF NOT EXISTS market_candles_ingest_quarantine" in stmt
+        for stmt in statements
+    )
+    assert any(
+        "CREATE TABLE IF NOT EXISTS market_candles_1m_kr_v2" in stmt
+        for stmt in statements
+    )
+    assert any("ROUND(open)::BIGINT" in stmt for stmt in statements)
+    assert any(
+        "CREATE MATERIALIZED VIEW IF NOT EXISTS market_candles_1h_kr_v2" in stmt
+        for stmt in statements
+    )
+    assert any(
+        "add_continuous_aggregate_policy" in stmt and "market_candles_1h_kr_v2" in stmt
+        for stmt in statements
+    )

--- a/tests/test_kr_ohlcv_precompute.py
+++ b/tests/test_kr_ohlcv_precompute.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import datetime
+from unittest.mock import AsyncMock
+
+import pandas as pd
+import pytest
+
+from app.jobs import kr_ohlcv_precompute
+
+
+@pytest.mark.asyncio
+async def test_incremental_bootstraps_new_symbols_with_7_days(monkeypatch):
+    monkeypatch.setattr(
+        kr_ohlcv_precompute.kr_ohlcv_timeseries_store,
+        "ensure_timescale_ready",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        kr_ohlcv_precompute,
+        "_collect_kr_symbols",
+        AsyncMock(return_value={"005930", "000660"}),
+    )
+
+    latest_bucket_mock = AsyncMock(
+        side_effect=[None, datetime.datetime(2026, 2, 19, 9, 0)]
+    )
+    monkeypatch.setattr(
+        kr_ohlcv_precompute.kr_ohlcv_timeseries_store,
+        "fetch_latest_hourly_bucket",
+        latest_bucket_mock,
+    )
+
+    sync_mock = AsyncMock(return_value={"status": "completed", "rows": 12})
+    monkeypatch.setattr(kr_ohlcv_precompute, "_sync_symbol_minutes", sync_mock)
+
+    result = await kr_ohlcv_precompute.run_kr_ohlcv_incremental_precompute()
+
+    assert result["status"] == "completed"
+    assert result["mode"] == "incremental"
+    assert result["symbols"] == 2
+    assert result["bootstrapped"] == 1
+
+    called_days = [call.args[1] for call in sync_mock.await_args_list]
+    assert sorted(called_days) == [1, 7]
+
+
+@pytest.mark.asyncio
+async def test_nightly_expands_existing_symbols_to_30_days(monkeypatch):
+    monkeypatch.setattr(
+        kr_ohlcv_precompute.kr_ohlcv_timeseries_store,
+        "ensure_timescale_ready",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        kr_ohlcv_precompute,
+        "_collect_kr_symbols",
+        AsyncMock(return_value={"005930", "000660"}),
+    )
+
+    latest_bucket_mock = AsyncMock(
+        side_effect=[None, datetime.datetime(2026, 2, 19, 9, 0)]
+    )
+    monkeypatch.setattr(
+        kr_ohlcv_precompute.kr_ohlcv_timeseries_store,
+        "fetch_latest_hourly_bucket",
+        latest_bucket_mock,
+    )
+
+    sync_mock = AsyncMock(return_value={"status": "completed", "rows": 24})
+    monkeypatch.setattr(kr_ohlcv_precompute, "_sync_symbol_minutes", sync_mock)
+
+    result = await kr_ohlcv_precompute.run_kr_ohlcv_nightly_precompute()
+
+    assert result["status"] == "completed"
+    assert result["mode"] == "nightly"
+    assert result["symbols"] == 2
+    assert result["bootstrapped"] == 1
+    assert result["expanded_to_30d"] == 1
+
+    called_days = [call.args[1] for call in sync_mock.await_args_list]
+    assert sorted(called_days) == [7, 30]
+
+
+@pytest.mark.asyncio
+async def test_incremental_returns_failed_status_on_exception(monkeypatch):
+    monkeypatch.setattr(
+        kr_ohlcv_precompute.kr_ohlcv_timeseries_store,
+        "ensure_timescale_ready",
+        AsyncMock(side_effect=RuntimeError("timescale down")),
+    )
+
+    result = await kr_ohlcv_precompute.run_kr_ohlcv_incremental_precompute()
+
+    assert result["status"] == "failed"
+    assert result["mode"] == "incremental"
+    assert "timescale down" in str(result["error"])
+
+
+@pytest.mark.asyncio
+async def test_resolve_route_returns_dual_for_canary_symbol(monkeypatch):
+    class _ScalarResult:
+        def __init__(self, value):
+            self._value = value
+
+        def scalar_one_or_none(self):
+            return self._value
+
+    class _DummySession:
+        async def execute(self, _statement):
+            return _ScalarResult(
+                type("Row", (), {"is_active": True, "nxt_eligible": True})
+            )
+
+    class _DummySessionManager:
+        async def __aenter__(self):
+            return _DummySession()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            del exc_type, exc, tb
+            return None
+
+    monkeypatch.setattr(
+        kr_ohlcv_precompute,
+        "AsyncSessionLocal",
+        lambda: _DummySessionManager(),
+    )
+    monkeypatch.setattr(
+        kr_ohlcv_precompute.settings,
+        "KR_OHLCV_DUAL_ROUTE_ENABLED",
+        True,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        kr_ohlcv_precompute.settings,
+        "KR_OHLCV_DUAL_ROUTE_CANARY_SYMBOLS",
+        ["005930"],
+        raising=False,
+    )
+
+    routes = await kr_ohlcv_precompute._resolve_route("005930")
+
+    assert routes == ["J", "NX"]
+
+
+@pytest.mark.asyncio
+async def test_sync_symbol_minutes_skips_non_trading_day_and_upserts_split_routes(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        kr_ohlcv_precompute,
+        "_resolve_route",
+        AsyncMock(return_value=["J", "NX"]),
+    )
+
+    fixed_now = datetime.datetime(2026, 2, 23, 10, 0, tzinfo=kr_ohlcv_precompute._KST)
+    base_datetime = kr_ohlcv_precompute.datetime.datetime
+
+    class _FixedDateTime(base_datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return fixed_now.replace(tzinfo=None)
+            return fixed_now.astimezone(tz)
+
+    monkeypatch.setattr(kr_ohlcv_precompute.datetime, "datetime", _FixedDateTime)
+
+    def _session_bounds(_route: str, day: datetime.date):
+        if day.weekday() >= 5:
+            return None
+        return (
+            datetime.datetime.combine(
+                day, datetime.time(9, 0), tzinfo=kr_ohlcv_precompute._KST
+            ),
+            datetime.datetime.combine(
+                day, datetime.time(15, 30), tzinfo=kr_ohlcv_precompute._KST
+            ),
+        )
+
+    monkeypatch.setattr(kr_ohlcv_precompute, "get_session_bounds", _session_bounds)
+
+    called_days: list[tuple[str, datetime.date]] = []
+
+    class _DummyKISClient:
+        async def inquire_time_dailychartprice(
+            self, code, market, n, end_date=None, end_time=None
+        ):
+            del code, n, end_time
+            assert end_date is not None
+            called_days.append((market, end_date))
+            return pd.DataFrame(
+                [
+                    {
+                        "datetime": pd.Timestamp(f"{end_date} 09:00:00"),
+                        "open": 100.0,
+                        "high": 101.0,
+                        "low": 99.0,
+                        "close": 100.5,
+                        "volume": 100,
+                        "value": 10050,
+                    }
+                ]
+            )
+
+    monkeypatch.setattr(kr_ohlcv_precompute, "KISClient", _DummyKISClient)
+
+    upsert_mock = AsyncMock(
+        return_value={
+            "rows": 1,
+            "min_ts": _FixedDateTime(2026, 2, 20, 0, 0, tzinfo=datetime.UTC),
+            "max_ts": _FixedDateTime(2026, 2, 23, 6, 0, tzinfo=datetime.UTC),
+        }
+    )
+    refresh_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        kr_ohlcv_precompute.kr_ohlcv_timeseries_store,
+        "upsert_market_candles_1m",
+        upsert_mock,
+    )
+    monkeypatch.setattr(
+        kr_ohlcv_precompute.kr_ohlcv_timeseries_store,
+        "refresh_market_candles_1h_kr",
+        refresh_mock,
+    )
+
+    result = await kr_ohlcv_precompute._sync_symbol_minutes("005930", days=4)
+
+    assert result["status"] == "completed"
+    assert result["rows"] == 2
+    assert result["route"] == "J,NX"
+    assert upsert_mock.await_count == 2
+    called_exchanges = {call.kwargs["exchange"] for call in upsert_mock.await_args_list}
+    assert called_exchanges == {"KRX", "NXT"}
+    assert all(day.weekday() < 5 for _, day in called_days)
+    refresh_mock.assert_awaited_once()

--- a/tests/test_kr_ohlcv_timeseries_store.py
+++ b/tests/test_kr_ohlcv_timeseries_store.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import datetime
+
+import pandas as pd
+import pytest
+
+from app.core.config import settings
+from app.services import kr_ohlcv_timeseries_store
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _DummySession:
+    def __init__(self, values: list[object | None]):
+        self._values = list(values)
+        self._index = 0
+        self.committed = False
+
+    async def execute(self, statement, params=None):
+        del statement, params
+        if self._index < len(self._values):
+            value = self._values[self._index]
+        else:
+            value = None
+        self._index += 1
+        return _ScalarResult(value)
+
+    async def commit(self):
+        self.committed = True
+
+
+class _DummySessionManager:
+    def __init__(self, session):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        del exc_type, exc, tb
+        return None
+
+
+class _RecordingSession:
+    def __init__(self, *, cagg_value: object | None, minute_value: object | None):
+        self.cagg_value = cagg_value
+        self.minute_value = minute_value
+        self.statements: list[str] = []
+
+    async def execute(self, statement, params=None):
+        del params
+        sql = str(statement)
+        self.statements.append(sql)
+
+        if "FROM market_candles_1h_kr" in sql:
+            return _ScalarResult(self.cagg_value)
+        if "FROM market_candles_1m_kr" in sql:
+            return _ScalarResult(self.minute_value)
+        return _ScalarResult(None)
+
+    async def commit(self):
+        return None
+
+
+class _CaptureWriteSession:
+    def __init__(self):
+        self.statements: list[str] = []
+
+    async def execute(self, statement, params=None):
+        del params
+        self.statements.append(str(statement))
+        return _ScalarResult(None)
+
+    async def commit(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_ensure_timescale_ready_bypasses_in_test_env(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "test", raising=False)
+
+    def _should_not_open_session():
+        raise AssertionError("AsyncSessionLocal should not be called in test env")
+
+    monkeypatch.setattr(
+        kr_ohlcv_timeseries_store,
+        "AsyncSessionLocal",
+        _should_not_open_session,
+    )
+
+    await kr_ohlcv_timeseries_store.ensure_timescale_ready()
+
+
+@pytest.mark.asyncio
+async def test_ensure_timescale_ready_fails_when_extension_missing(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production", raising=False)
+    dummy = _DummySession(values=[None])
+    monkeypatch.setattr(
+        kr_ohlcv_timeseries_store,
+        "AsyncSessionLocal",
+        lambda: _DummySessionManager(dummy),
+    )
+
+    with pytest.raises(RuntimeError, match="TimescaleDB extension is not installed"):
+        await kr_ohlcv_timeseries_store.ensure_timescale_ready(allow_test_bypass=False)
+
+
+@pytest.mark.asyncio
+async def test_ensure_timescale_ready_fails_when_minute_table_missing(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production", raising=False)
+    dummy = _DummySession(values=["timescaledb", None])
+    monkeypatch.setattr(
+        kr_ohlcv_timeseries_store,
+        "AsyncSessionLocal",
+        lambda: _DummySessionManager(dummy),
+    )
+
+    with pytest.raises(RuntimeError, match="market_candles_1m_kr table is missing"):
+        await kr_ohlcv_timeseries_store.ensure_timescale_ready(allow_test_bypass=False)
+
+
+@pytest.mark.asyncio
+async def test_upsert_market_candles_1m_returns_zero_for_empty_frame():
+    result = await kr_ohlcv_timeseries_store.upsert_market_candles_1m(
+        symbol="005930",
+        exchange="KRX",
+        route="J",
+        frame=pd.DataFrame(),
+    )
+
+    assert result == {
+        "rows": 0,
+        "min_ts": None,
+        "max_ts": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_upsert_market_candles_1m_invalid_exchange_to_quarantine(monkeypatch):
+    session = _CaptureWriteSession()
+    monkeypatch.setattr(
+        kr_ohlcv_timeseries_store,
+        "AsyncSessionLocal",
+        lambda: _DummySessionManager(session),
+    )
+
+    frame = pd.DataFrame(
+        [
+            {
+                "datetime": pd.Timestamp("2026-02-19 09:01:00"),
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 100.5,
+                "volume": 100,
+                "value": 10050,
+            }
+        ]
+    )
+
+    result = await kr_ohlcv_timeseries_store.upsert_market_candles_1m(
+        symbol="005930",
+        exchange="BADX",
+        route="J",
+        frame=frame,
+    )
+
+    assert result["rows"] == 0
+    assert result["quarantined_rows"] == 1
+    assert any(
+        "INSERT INTO market_candles_ingest_quarantine" in stmt
+        for stmt in session.statements
+    )
+
+
+def test_frame_from_hour_rows_builds_dataframe():
+    frame = kr_ohlcv_timeseries_store.frame_from_hour_rows(
+        [
+            {
+                "datetime": pd.Timestamp("2026-02-19 09:00:00"),
+                "date": pd.Timestamp("2026-02-19").date(),
+                "time": pd.Timestamp("2026-02-19 09:00:00").time(),
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 100.5,
+                "volume": 100,
+                "value": 10050,
+            }
+        ]
+    )
+
+    assert len(frame) == 1
+    assert set(frame.columns) == {
+        "datetime",
+        "date",
+        "time",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+        "value",
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_market_candles_1h_kr_returns_empty_when_range_invalid():
+    start_bucket = pd.Timestamp("2026-02-19 12:00:00").to_pydatetime()
+    end_bucket = pd.Timestamp("2026-02-19 10:00:00").to_pydatetime()
+
+    frame = await kr_ohlcv_timeseries_store.fetch_market_candles_1h_kr(
+        symbol="005930",
+        start_bucket=start_bucket,
+        end_bucket=end_bucket,
+    )
+
+    assert frame.empty
+
+
+@pytest.mark.asyncio
+async def test_fetch_previous_close_before_bucket_prefers_hour_cagg(monkeypatch):
+    session = _RecordingSession(cagg_value=101.25, minute_value=88.0)
+    monkeypatch.setattr(
+        kr_ohlcv_timeseries_store,
+        "AsyncSessionLocal",
+        lambda: _DummySessionManager(session),
+    )
+
+    close = await kr_ohlcv_timeseries_store.fetch_previous_close_before_bucket(
+        symbol="005930",
+        before_bucket=datetime.datetime(2026, 2, 19, 10, 0),
+    )
+
+    assert close == 101.25
+    assert any("FROM market_candles_1h_kr" in sql for sql in session.statements)
+    assert not any("FROM market_candles_1m_kr" in sql for sql in session.statements)
+
+
+@pytest.mark.asyncio
+async def test_fetch_previous_close_before_bucket_uses_minute_fallback_tiebreak(
+    monkeypatch,
+):
+    session = _RecordingSession(cagg_value=None, minute_value=77.7)
+    monkeypatch.setattr(
+        kr_ohlcv_timeseries_store,
+        "AsyncSessionLocal",
+        lambda: _DummySessionManager(session),
+    )
+
+    close = await kr_ohlcv_timeseries_store.fetch_previous_close_before_bucket(
+        symbol="005930",
+        before_bucket=datetime.datetime(2026, 2, 19, 10, 0),
+    )
+
+    assert close == 77.7
+    minute_sql = next(
+        sql for sql in session.statements if "FROM market_candles_1m_kr" in sql
+    )
+    assert "CASE WHEN exchange = 'KRX' THEN 1 ELSE 0 END DESC" in minute_sql


### PR DESCRIPTION
## Summary
- add TimescaleDB KR OHLCV ingest foundation with 1m hypertable and 1h CAGG migrations
- add scheduled KR precompute jobs/tasks for incremental and nightly sync
- add ingestion services for exchange-aware upsert, quarantine handling, and trading-calendar session bounds
- wire scheduler/taskiq modules and config flags needed for ingest-only rollout
- add focused tests for migrations, precompute job flow, and timeseries store behavior

## Test Plan
- [x] `uv run pytest --no-cov tests/test_kr_cagg_migration.py tests/test_kr_ohlcv_precompute.py tests/test_kr_ohlcv_timeseries_store.py -q`
- [x] `uv run pytest --no-cov tests/test_mcp_server_tools.py::test_get_quote_korean_equity tests/test_routers.py::TestHealthRouter::test_health_check -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Korean market OHLCV time-series data infrastructure with TimescaleDB support.
  * Implemented automated data precomputation for Korean market candlestick data (1-minute and 1-hour intervals).
  * Added support for multiple Korean trading routes with dual-write capabilities.
  * Introduced configuration flags for canary testing and data validation modes.

* **Chores**
  * Enhanced data ingestion and storage with quarantine handling for invalid records.
  * Added periodic scheduled tasks for incremental and nightly data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->