### PR TITLE
refactor: migrate upbit symbol lookups to strict DB queries

### DIFF
--- a/app/analysis/service_analyzers.py
+++ b/app/analysis/service_analyzers.py
@@ -3,8 +3,11 @@ import pandas as pd
 import app.services.brokers.kis.client as kis
 import app.services.brokers.upbit.client as upbit
 import app.services.brokers.yahoo.client as yahoo
-from app.services import upbit_symbol_universe_service as upbit_pairs
 from app.services.kr_symbol_universe_service import get_kr_symbol_by_name
+from app.services.upbit_symbol_universe_service import (
+    get_active_upbit_base_currencies,
+    get_upbit_symbol_by_name,
+)
 from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
 
 from .analyzer import Analyzer, DataProcessor
@@ -18,7 +21,8 @@ class UpbitAnalyzer(Analyzer):
 
     def __init__(self, api_key=None):
         super().__init__(api_key)
-        self._tradable_coins_map = None  # 캐시용 인스턴스 변수
+        self._tradable_coins_map: dict[str, dict] | None = None
+        self._tradable_base_currencies: set[str] | None = None
 
     @staticmethod
     def is_tradable(coin: dict) -> bool:
@@ -47,21 +51,29 @@ class UpbitAnalyzer(Analyzer):
             심볼별 코인 정보 딕셔너리
         """
         if self._tradable_coins_map is None or force_refresh:
-            try:
-                my_coins = await upbit.fetch_my_coins()
-                self._tradable_coins_map = {
-                    f"KRW-{coin['currency']}": coin
-                    for coin in my_coins
-                    if coin.get("currency") != "KRW"  # 원화 제외
-                    and self.is_tradable(coin)  # 최소 평가액 이상
-                    and coin.get("currency")
-                    in upbit_pairs.KRW_TRADABLE_COINS  # KRW 마켓에서 거래 가능
-                }
-            except Exception as e:
-                print(f"보유 자산 정보를 가져오는 데 실패했습니다: {e}")
-                self._tradable_coins_map = {}
+            my_coins = await upbit.fetch_my_coins()
+            tradable_base_currencies = await self._get_tradable_base_currencies(
+                force_refresh=force_refresh
+            )
+            self._tradable_coins_map = {
+                f"KRW-{coin['currency']}": coin
+                for coin in my_coins
+                if coin.get("currency") != "KRW"  # 원화 제외
+                and self.is_tradable(coin)  # 최소 평가액 이상
+                and str(coin.get("currency") or "").upper() in tradable_base_currencies
+            }
 
         return self._tradable_coins_map
+
+    async def _get_tradable_base_currencies(
+        self,
+        force_refresh: bool = False,
+    ) -> set[str]:
+        if self._tradable_base_currencies is None or force_refresh:
+            self._tradable_base_currencies = await get_active_upbit_base_currencies(
+                quote_currency="KRW"
+            )
+        return self._tradable_base_currencies
 
     def _create_position_info(self, my_coin: dict | None) -> dict | None:
         """
@@ -130,16 +142,11 @@ class UpbitAnalyzer(Analyzer):
 
     async def analyze_coins(self, coin_names: list[str]) -> None:
         """여러 코인을 순차적으로 분석"""
-        await upbit_pairs.prime_upbit_constants()
-
         # 보유 코인 정보를 한 번만 가져와서 캐시
         tradable_coins_map = await self._get_tradable_coins_map()
 
         for coin_name in coin_names:
-            stock_symbol = upbit_pairs.NAME_TO_PAIR_KR.get(coin_name)
-            if not stock_symbol:
-                print(f"코인명을 찾을 수 없음: {coin_name}")
-                continue
+            stock_symbol = await get_upbit_symbol_by_name(coin_name)
 
             # 캐시된 정보에서 코인 조회
             my_coin = tradable_coins_map.get(stock_symbol)
@@ -170,16 +177,11 @@ class UpbitAnalyzer(Analyzer):
 
     async def analyze_coins_json(self, coin_names: list[str]) -> None:
         """여러 코인을 순차적으로 JSON 형식으로 분석"""
-        await upbit_pairs.prime_upbit_constants()
-
         # 보유 코인 정보를 한 번만 가져와서 캐시
         tradable_coins_map = await self._get_tradable_coins_map()
 
         for coin_name in coin_names:
-            stock_symbol = upbit_pairs.NAME_TO_PAIR_KR.get(coin_name)
-            if not stock_symbol:
-                print(f"코인명을 찾을 수 없음: {coin_name}")
-                continue
+            stock_symbol = await get_upbit_symbol_by_name(coin_name)
 
             # 캐시된 정보에서 코인 조회
             my_coin = tradable_coins_map.get(stock_symbol)
@@ -217,12 +219,7 @@ class UpbitAnalyzer(Analyzer):
     async def analyze_coin_json(self, coin_name: str) -> tuple[object | None, str]:
         """단일 코인을 JSON 형식으로 분석"""
         try:
-            await upbit_pairs.prime_upbit_constants()
-
-            stock_symbol = upbit_pairs.NAME_TO_PAIR_KR.get(coin_name)
-            if not stock_symbol:
-                print(f"코인명을 찾을 수 없음: {coin_name}")
-                return None, ""
+            stock_symbol = await get_upbit_symbol_by_name(coin_name)
 
             # 보유 코인 정보 가져오기 (캐시 사용)
             tradable_coins_map = await self._get_tradable_coins_map()

--- a/app/jobs/analyze.py
+++ b/app/jobs/analyze.py
@@ -1,32 +1,54 @@
 import asyncio
+from typing import Any
 
 import app.services.brokers.upbit.client as upbit
 from app.analysis.service_analyzers import KISAnalyzer, UpbitAnalyzer, YahooAnalyzer
 from app.monitoring.trade_notifier import get_trade_notifier
-from app.services import upbit_symbol_universe_service as upbit_pairs
 from app.services.order_service import (
     cancel_existing_buy_orders,
     cancel_existing_sell_orders,
     get_sell_prices_for_coin,
     place_multiple_sell_orders,
 )
+from app.services.upbit_symbol_universe_service import (
+    UpbitSymbolUniverseLookupError,
+    get_upbit_korean_name_by_coin,
+    get_upbit_market_by_coin,
+)
 
 
-async def _fetch_tradable_coins() -> tuple[list[dict], list[dict]]:
+def _normalize_currency(value: object) -> str:
+    return str(value or "").upper().strip()
+
+
+async def _resolve_tradable_coins(
+    my_coins: list[dict[str, Any]],
+    analyzer: UpbitAnalyzer,
+) -> list[dict[str, Any]]:
+    tradable_coins: list[dict[str, Any]] = []
+    for coin in my_coins:
+        currency = _normalize_currency(coin.get("currency"))
+        if not currency or currency == "KRW" or not analyzer.is_tradable(coin):
+            continue
+
+        market = await get_upbit_market_by_coin(currency)
+        korean_name = await get_upbit_korean_name_by_coin(currency)
+        enriched_coin = dict(coin)
+        enriched_coin["currency"] = currency
+        enriched_coin["market"] = market
+        enriched_coin["korean_name"] = korean_name
+        tradable_coins.append(enriched_coin)
+
+    return tradable_coins
+
+
+async def _fetch_tradable_coins() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """보유 중인 코인과 거래 가능한 코인을 동시에 조회."""
-    await upbit_pairs.prime_upbit_constants()
-
     my_coins = await upbit.fetch_my_coins()
 
     analyzer = UpbitAnalyzer()
     try:
-        tradable_coins = [
-            coin
-            for coin in my_coins
-            if coin.get("currency") != "KRW"
-            and analyzer.is_tradable(coin)
-            and coin.get("currency") in upbit_pairs.KRW_TRADABLE_COINS
-        ]
+        tradable_coins = await _resolve_tradable_coins(my_coins, analyzer)
     finally:
         await analyzer.close()
 
@@ -38,17 +60,9 @@ async def _analyze_coin_async(currency: str) -> dict[str, object]:
     if not currency:
         return {"status": "failed", "error": "코인 코드가 필요합니다."}
 
-    await upbit_pairs.prime_upbit_constants()
     currency_code = currency.upper()
-
-    if currency_code not in upbit_pairs.KRW_TRADABLE_COINS:
-        return {
-            "status": "failed",
-            "currency": currency_code,
-            "message": f"{currency_code}는 KRW 마켓 거래 대상이 아닙니다.",
-        }
-
-    korean_name = upbit_pairs.COIN_TO_NAME_KR.get(currency_code, currency_code)
+    korean_name = await get_upbit_korean_name_by_coin(currency_code)
+    await get_upbit_market_by_coin(currency_code)
 
     analyzer = UpbitAnalyzer()
     try:
@@ -67,14 +81,15 @@ async def _analyze_coin_async(currency: str) -> dict[str, object]:
         if hasattr(result, "decision"):
             try:
                 notifier = get_trade_notifier()
+                result_decision = getattr(result, "decision", None)
+                result_confidence = getattr(result, "confidence", None)
+                result_reasons = getattr(result, "reasons", None)
                 await notifier.notify_analysis_complete(
                     symbol=currency_code,
                     korean_name=korean_name,
-                    decision=result.decision,
-                    confidence=float(result.confidence) if result.confidence else 0.0,
-                    reasons=result.reasons
-                    if hasattr(result, "reasons") and result.reasons
-                    else [],
+                    decision=str(result_decision),
+                    confidence=float(result_confidence) if result_confidence else 0.0,
+                    reasons=result_reasons if result_reasons else [],
                     market_type="암호화폐",
                 )
             except Exception as notify_error:  # pragma: no cover
@@ -86,6 +101,8 @@ async def _analyze_coin_async(currency: str) -> dict[str, object]:
             "korean_name": korean_name,
             "message": f"{korean_name} 분석이 완료되었습니다.",
         }
+    except UpbitSymbolUniverseLookupError:
+        raise
     except Exception as exc:  # pragma: no cover - defensive logging
         return {
             "status": "failed",
@@ -105,17 +122,8 @@ async def _execute_buy_order_for_coin_async(currency: str) -> dict[str, object]:
     from app.services.stock_info_service import process_buy_orders_with_analysis
 
     currency_code = currency.upper()
-
-    await upbit_pairs.prime_upbit_constants()
-
-    if currency_code not in upbit_pairs.KRW_TRADABLE_COINS:
-        return {
-            "status": "failed",
-            "currency": currency_code,
-            "message": f"{currency_code}는 KRW 마켓에서 거래할 수 없습니다.",
-        }
-
-    market = f"KRW-{currency_code}"
+    market = await get_upbit_market_by_coin(currency_code)
+    korean_name = await get_upbit_korean_name_by_coin(currency_code)
 
     try:
         my_coins = await upbit.fetch_my_coins()
@@ -161,9 +169,6 @@ async def _execute_buy_order_for_coin_async(currency: str) -> dict[str, object]:
         if result.get("success") and result.get("orders_placed", 0) > 0:
             try:
                 notifier = get_trade_notifier()
-                korean_name = upbit_pairs.COIN_TO_NAME_KR.get(
-                    currency_code, currency_code
-                )
 
                 # Extract order details from result if available
                 orders_placed = result.get("orders_placed", 0)
@@ -187,9 +192,6 @@ async def _execute_buy_order_for_coin_async(currency: str) -> dict[str, object]:
         elif not result.get("success") and has_insufficient_balance:
             try:
                 notifier = get_trade_notifier()
-                korean_name = upbit_pairs.COIN_TO_NAME_KR.get(
-                    currency_code, currency_code
-                )
                 reason = message or (
                     failure_reasons[0] if failure_reasons else "잔고 부족으로 매수 실패"
                 )
@@ -209,6 +211,8 @@ async def _execute_buy_order_for_coin_async(currency: str) -> dict[str, object]:
             "message": result.get("message"),
             "result": result,
         }
+    except UpbitSymbolUniverseLookupError:
+        raise
     except Exception as exc:  # pragma: no cover - defensive logging
         return {
             "status": "failed",
@@ -223,17 +227,8 @@ async def _execute_sell_order_for_coin_async(currency: str) -> dict[str, object]
         return {"status": "failed", "error": "코인 코드가 필요합니다."}
 
     currency_code = currency.upper()
-
-    await upbit_pairs.prime_upbit_constants()
-
-    if currency_code not in upbit_pairs.KRW_TRADABLE_COINS:
-        return {
-            "status": "failed",
-            "currency": currency_code,
-            "message": f"{currency_code}는 KRW 마켓에서 거래할 수 없습니다.",
-        }
-
-    market = f"KRW-{currency_code}"
+    market = await get_upbit_market_by_coin(currency_code)
+    korean_name = await get_upbit_korean_name_by_coin(currency_code)
 
     try:
         my_coins = await upbit.fetch_my_coins()
@@ -301,9 +296,6 @@ async def _execute_sell_order_for_coin_async(currency: str) -> dict[str, object]
             if result.get("orders_placed", 0) > 0:
                 try:
                     notifier = get_trade_notifier()
-                    korean_name = upbit_pairs.COIN_TO_NAME_KR.get(
-                        currency_code, currency_code
-                    )
 
                     orders_placed = result.get("orders_placed", 0)
                     # Estimate expected amount from sell_prices and balance
@@ -334,6 +326,8 @@ async def _execute_sell_order_for_coin_async(currency: str) -> dict[str, object]
             "message": result.get("message"),
             "result": result,
         }
+    except UpbitSymbolUniverseLookupError:
+        raise
     except Exception as exc:  # pragma: no cover - defensive logging
         return {
             "status": "failed",
@@ -342,7 +336,11 @@ async def _execute_sell_order_for_coin_async(currency: str) -> dict[str, object]
         }
 
 
-async def run_analysis_for_stock(symbol: str, name: str, instrument_type: str) -> dict:
+async def run_analysis_for_stock(
+    symbol: str,
+    name: str,
+    instrument_type: str,
+) -> dict[str, object]:
     analyzer = None
     try:
         if instrument_type == "equity_kr":
@@ -379,19 +377,12 @@ async def run_analysis_for_stock(symbol: str, name: str, instrument_type: str) -
             await analyzer.close()
 
 
-async def run_analysis_for_my_coins() -> dict:
-    await upbit_pairs.prime_upbit_constants()
+async def run_analysis_for_my_coins() -> dict[str, object]:
     analyzer = UpbitAnalyzer()
 
     try:
         my_coins = await upbit.fetch_my_coins()
-        tradable_coins = [
-            coin
-            for coin in my_coins
-            if coin.get("currency") != "KRW"
-            and analyzer.is_tradable(coin)
-            and coin.get("currency") in upbit_pairs.KRW_TRADABLE_COINS
-        ]
+        tradable_coins = await _resolve_tradable_coins(my_coins, analyzer)
 
         if not tradable_coins:
             return {
@@ -402,19 +393,14 @@ async def run_analysis_for_my_coins() -> dict:
                 "results": [],
             }
 
-        coin_names = []
-        for coin in tradable_coins:
-            currency = coin.get("currency")
-            korean_name = upbit_pairs.COIN_TO_NAME_KR.get(currency)
-            if korean_name:
-                coin_names.append(korean_name)
+        coin_names = [str(coin["korean_name"]) for coin in tradable_coins]
 
         total_count = len(coin_names)
         results = []
 
         for coin_name in coin_names:
             try:
-                _, model = await analyzer.analyze_coins_json([coin_name])
+                _, model = await analyzer.analyze_coin_json(coin_name)
                 results.append(
                     {"coin_name": coin_name, "success": True, "model": model}
                 )
@@ -431,6 +417,8 @@ async def run_analysis_for_my_coins() -> dict:
             "message": f"{success_count}/{total_count}개 코인 분석 완료",
             "results": results,
         }
+    except UpbitSymbolUniverseLookupError:
+        raise
     except Exception as exc:
         return {
             "status": "failed",
@@ -443,21 +431,14 @@ async def run_analysis_for_my_coins() -> dict:
         await analyzer.close()
 
 
-async def execute_buy_orders_task() -> dict:
+async def execute_buy_orders_task() -> dict[str, object]:
     from app.services.stock_info_service import process_buy_orders_with_analysis
 
-    await upbit_pairs.prime_upbit_constants()
     analyzer = UpbitAnalyzer()
 
     try:
         my_coins = await upbit.fetch_my_coins()
-        tradable_coins = [
-            coin
-            for coin in my_coins
-            if coin.get("currency") != "KRW"
-            and analyzer.is_tradable(coin)
-            and coin.get("currency") in upbit_pairs.KRW_TRADABLE_COINS
-        ]
+        tradable_coins = await _resolve_tradable_coins(my_coins, analyzer)
 
         if not tradable_coins:
             return {
@@ -468,12 +449,12 @@ async def execute_buy_orders_task() -> dict:
                 "results": [],
             }
 
-        market_codes = [f"KRW-{coin['currency']}" for coin in tradable_coins]
+        market_codes = [str(coin["market"]) for coin in tradable_coins]
         current_prices = await upbit.fetch_multiple_current_prices(market_codes)
 
         for coin in tradable_coins:
             currency = coin["currency"]
-            market = f"KRW-{currency}"
+            market = str(coin["market"])
             avg_buy_price = float(coin.get("avg_buy_price", 0))
 
             if avg_buy_price > 0 and market in current_prices:
@@ -490,7 +471,7 @@ async def execute_buy_orders_task() -> dict:
 
         for coin in tradable_coins:
             currency = coin["currency"]
-            market = f"KRW-{currency}"
+            market = str(coin["market"])
             avg_buy_price = float(coin["avg_buy_price"])
 
             try:
@@ -534,6 +515,8 @@ async def execute_buy_orders_task() -> dict:
             "message": f"{success_count}/{total_count}개 코인 매수 주문 완료",
             "results": order_results,
         }
+    except UpbitSymbolUniverseLookupError:
+        raise
     except Exception as exc:
         return {
             "status": "failed",
@@ -546,19 +529,12 @@ async def execute_buy_orders_task() -> dict:
         await analyzer.close()
 
 
-async def execute_sell_orders_task() -> dict:
-    await upbit_pairs.prime_upbit_constants()
+async def execute_sell_orders_task() -> dict[str, object]:
     analyzer = UpbitAnalyzer()
 
     try:
         my_coins = await upbit.fetch_my_coins()
-        tradable_coins = [
-            coin
-            for coin in my_coins
-            if coin.get("currency") != "KRW"
-            and analyzer.is_tradable(coin)
-            and coin.get("currency") in upbit_pairs.KRW_TRADABLE_COINS
-        ]
+        tradable_coins = await _resolve_tradable_coins(my_coins, analyzer)
 
         if not tradable_coins:
             return {
@@ -574,7 +550,7 @@ async def execute_sell_orders_task() -> dict:
 
         for coin in tradable_coins:
             currency = coin["currency"]
-            market = f"KRW-{currency}"
+            market = str(coin["market"])
             balance = float(coin["balance"])
             avg_buy_price = float(coin["avg_buy_price"])
 
@@ -648,6 +624,8 @@ async def execute_sell_orders_task() -> dict:
             "message": f"{success_count}/{total_count}개 코인 매도 주문 완료",
             "results": order_results,
         }
+    except UpbitSymbolUniverseLookupError:
+        raise
     except Exception as exc:
         return {
             "status": "failed",
@@ -660,25 +638,25 @@ async def execute_sell_orders_task() -> dict:
         await analyzer.close()
 
 
-async def execute_buy_order_for_coin_task(currency: str) -> dict:
+async def execute_buy_order_for_coin_task(currency: str) -> dict[str, object]:
     """특정 코인에 대한 분할 매수 주문 실행."""
 
     return await _execute_buy_order_for_coin_async(currency)
 
 
-async def execute_sell_order_for_coin_task(currency: str) -> dict:
+async def execute_sell_order_for_coin_task(currency: str) -> dict[str, object]:
     """특정 코인에 대한 분할 매도 주문 실행."""
 
     return await _execute_sell_order_for_coin_async(currency)
 
 
-async def run_analysis_for_coin_task(currency: str) -> dict:
+async def run_analysis_for_coin_task(currency: str) -> dict[str, object]:
     """단일 코인에 대한 AI 분석 실행."""
 
     return await _analyze_coin_async(currency)
 
 
-async def run_per_coin_automation_task() -> dict:
+async def run_per_coin_automation_task() -> dict[str, object]:
     """보유 코인 각각에 대해 분석 → 분할 매수 → 분할 매도를 순차 실행."""
 
     _, tradable_coins = await _fetch_tradable_coins()
@@ -696,14 +674,14 @@ async def run_per_coin_automation_task() -> dict:
 
     for coin in tradable_coins:
         currency = (coin.get("currency") or "").upper()
-        korean_name = coin.get("korean_name") or upbit_pairs.COIN_TO_NAME_KR.get(
-            currency, currency
-        )
-        coin_summary = {
+        korean_name = coin.get("korean_name")
+        if not korean_name:
+            korean_name = await get_upbit_korean_name_by_coin(currency)
+        coin_summary: dict[str, object] = {
             "currency": currency,
-            "korean_name": korean_name,
-            "steps": [],
+            "korean_name": str(korean_name),
         }
+        step_results: list[dict[str, object]] = []
 
         step_definitions = [
             ("analysis", lambda c=currency: _analyze_coin_async(c)),
@@ -718,7 +696,7 @@ async def run_per_coin_automation_task() -> dict:
                 break
 
             result = await step_fn()
-            coin_summary["steps"].append(
+            step_results.append(
                 {
                     "step": step_name,
                     "result": result,
@@ -730,13 +708,21 @@ async def run_per_coin_automation_task() -> dict:
 
             await asyncio.sleep(0.5)
 
+        coin_summary["steps"] = step_results
         results.append(coin_summary)
 
-    success_coins = sum(
-        1
-        for item in results
-        if all(step["result"].get("status") == "completed" for step in item["steps"])
-    )
+    success_coins = 0
+    for item in results:
+        steps_obj = item.get("steps")
+        if not isinstance(steps_obj, list):
+            continue
+        if all(
+            isinstance(step, dict)
+            and isinstance(step.get("result"), dict)
+            and step["result"].get("status") == "completed"
+            for step in steps_obj
+        ):
+            success_coins += 1
 
     return {
         "status": "completed",

--- a/app/jobs/daily_scan.py
+++ b/app/jobs/daily_scan.py
@@ -10,7 +10,6 @@ from app.core.timezone import now_kst
 from app.mcp_server.tooling.analysis_tool_handlers import get_fear_greed_index_impl
 from app.mcp_server.tooling.market_data_indicators import _calculate_rsi, _calculate_sma
 from app.monitoring.trade_notifier import get_trade_notifier
-from app.services import upbit_symbol_universe_service as upbit_pairs
 from app.services.brokers.upbit.client import (
     fetch_multiple_tickers,
     fetch_my_coins,
@@ -18,6 +17,7 @@ from app.services.brokers.upbit.client import (
     fetch_top_traded_coins,
 )
 from app.services.openclaw_client import OpenClawClient
+from app.services.upbit_symbol_universe_service import get_upbit_korean_name_by_coin
 
 logger = logging.getLogger(__name__)
 
@@ -114,15 +114,8 @@ class DailyScanner:
 
         return sorted(market_codes), sorted(skipped_markets)
 
-    @staticmethod
-    def _coin_name(currency: str) -> str:
-        try:
-            name = upbit_pairs.COIN_TO_NAME_KR.get(currency, currency)
-            if isinstance(name, str) and name:
-                return name
-            return currency
-        except Exception:
-            return currency
+    async def _coin_name(self, currency: str) -> str:
+        return await get_upbit_korean_name_by_coin(currency, quote_currency="KRW")
 
     @staticmethod
     def _build_rank_by_market(top_coins: list[dict]) -> dict[str, int]:
@@ -303,7 +296,7 @@ class DailyScanner:
             if not await self._should_alert(currency, "overbought"):
                 continue
 
-            name = self._coin_name(currency)
+            name = await self._coin_name(currency)
             base_message = f"⚠️ {name}({currency}) RSI {rsi:.1f} — 과매수 구간"
             if send_immediately:
                 message = f"{base_message}\n{btc_ctx}"
@@ -350,7 +343,7 @@ class DailyScanner:
             if not await self._should_alert(currency, "oversold"):
                 continue
 
-            name = self._coin_name(currency)
+            name = await self._coin_name(currency)
             base_message = f"📉 {name}({currency}) RSI {rsi:.1f} — 과매도 구간"
             if send_immediately:
                 message = f"{base_message}\n{btc_ctx}"
@@ -455,7 +448,7 @@ class DailyScanner:
                 )
                 continue
 
-            name = self._coin_name(currency)
+            name = await self._coin_name(currency)
             direction = "급등" if change_rate > 0 else "급락"
             message = f"{name}({currency}) 24h {change_rate:+.2%} — {direction} 감지"
             logger.info(
@@ -599,7 +592,7 @@ class DailyScanner:
             if not await self._should_alert(symbol, "sma_cross"):
                 continue
 
-            name = self._coin_name(currency)
+            name = await self._coin_name(currency)
             message = (
                 f"{emoji} {name}({currency}) SMA20 {crossing_label} — "
                 f"종가 {curr_close:,.0f} / SMA20 {curr_sma20:,.0f}"
@@ -663,7 +656,6 @@ class DailyScanner:
         if not settings.DAILY_SCAN_ENABLED:
             return {"skipped": True, "reason": "disabled"}
 
-        await upbit_pairs.prime_upbit_constants()
         btc_ctx = await self._get_btc_context()
         pending_cooldowns: list[tuple[str, str]] = []
 
@@ -716,7 +708,6 @@ class DailyScanner:
         if not settings.DAILY_SCAN_ENABLED:
             return {"skipped": True, "reason": "disabled"}
 
-        await upbit_pairs.prime_upbit_constants()
         pending_cooldowns: list[tuple[str, str]] = []
         alerts = await self.check_price_crash(
             send_immediately=False,

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -67,6 +67,8 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - Upbit crypto symbol/market resolution uses DB table `upbit_symbol_universe` only.
 - Runtime does not call Upbit `/v1/market/all`; that endpoint is sync-path only.
 - If `upbit_symbol_universe` is empty/unavailable, tools fail fast with explicit sync hint.
+- If a coin/market lookup is missing or inactive in `upbit_symbol_universe`, MCP tools propagate explicit lookup errors (no silent fallback/default ticker).
+- `search_symbol` (crypto) uses DB-backed `search_upbit_symbols` only; in-memory map-based search is removed.
 - Upbit prerequisite: run `make sync-upbit-symbol-universe` (or `uv run python scripts/sync_upbit_symbol_universe.py`) right after migrations.
 - Scheduled sync task `symbols.upbit.universe.sync` runs daily at `06:15` KST (`cron: 15 6 * * *`, `cron_offset: Asia/Seoul`).
 

--- a/app/mcp_server/tooling/fundamentals_sources_coingecko.py
+++ b/app/mcp_server/tooling/fundamentals_sources_coingecko.py
@@ -23,7 +23,7 @@ from app.mcp_server.tooling.shared import (
 from app.mcp_server.tooling.shared import (
     to_optional_int as _to_optional_int,
 )
-from app.services.upbit_symbol_universe_service import get_or_refresh_maps
+from app.services.upbit_symbol_universe_service import get_active_upbit_base_currencies
 
 DEFAULT_BATCH_CRYPTO_SYMBOLS = [
     "BTC",
@@ -396,34 +396,29 @@ async def _fetch_coingecko_coin_profile(coin_id: str) -> dict[str, Any]:
 async def _resolve_batch_crypto_symbols() -> list[str]:
     try:
         coins = await upbit_service.fetch_my_coins()
-        held_symbols: list[str] = []
-        for coin in coins:
-            currency = str(coin.get("currency", "")).upper().strip()
-            if not currency or currency == "KRW":
-                continue
-            quantity = _to_float(coin.get("balance")) + _to_float(coin.get("locked"))
-            if quantity <= 0:
-                continue
-            held_symbols.append(currency)
-
-        if held_symbols:
-            try:
-                crypto_maps = await get_or_refresh_maps()
-                tradable_set = {
-                    str(symbol).upper()
-                    for symbol in crypto_maps.get("COIN_TO_PAIR", {}).keys()
-                    if str(symbol).strip()
-                }
-                held_symbols = [
-                    symbol for symbol in held_symbols if symbol.upper() in tradable_set
-                ]
-            except Exception:
-                pass
-
-            if held_symbols:
-                return sorted(set(held_symbols))
     except Exception:
-        pass
+        return list(DEFAULT_BATCH_CRYPTO_SYMBOLS)
+
+    held_symbols: list[str] = []
+    for coin in coins:
+        currency = str(coin.get("currency", "")).upper().strip()
+        if not currency or currency == "KRW":
+            continue
+        quantity = _to_float(coin.get("balance")) + _to_float(coin.get("locked"))
+        if quantity <= 0:
+            continue
+        held_symbols.append(currency)
+
+    if not held_symbols:
+        return list(DEFAULT_BATCH_CRYPTO_SYMBOLS)
+
+    tradable_set = await get_active_upbit_base_currencies(quote_currency="KRW")
+    tradable_held_symbols = [
+        symbol for symbol in held_symbols if symbol.upper() in tradable_set
+    ]
+
+    if tradable_held_symbols:
+        return sorted(set(tradable_held_symbols))
 
     return list(DEFAULT_BATCH_CRYPTO_SYMBOLS)
 

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -46,7 +46,7 @@ from app.models.kr_symbol_universe import KRSymbolUniverse
 from app.services import kis_ohlcv_cache
 from app.services.brokers.kis.client import KISClient
 from app.services.kr_symbol_universe_service import search_kr_symbols
-from app.services.upbit_symbol_universe_service import get_or_refresh_maps
+from app.services.upbit_symbol_universe_service import search_upbit_symbols
 from app.services.us_symbol_universe_service import search_us_symbols
 
 if TYPE_CHECKING:
@@ -62,8 +62,6 @@ async def _search_master_data(
 ) -> list[dict[str, Any]]:
     """Search symbols across KRX, US, and Upbit master datasets."""
     results: list[dict[str, Any]] = []
-    query_lower = query.lower()
-    query_upper = query.upper()
 
     if instrument_type is None or instrument_type == "equity_kr":
         kr_results = await search_kr_symbols(query, limit)
@@ -80,24 +78,12 @@ async def _search_master_data(
                 return results
 
     if instrument_type is None or instrument_type == "crypto":
-        try:
-            crypto_maps = await get_or_refresh_maps()
-            name_to_pair = crypto_maps.get("NAME_TO_PAIR_KR", {})
-            for name, pair in name_to_pair.items():
-                if query_lower in name.lower() or query_upper in pair.upper():
-                    results.append(
-                        {
-                            "symbol": pair,
-                            "name": name,
-                            "instrument_type": "crypto",
-                            "exchange": "Upbit",
-                            "is_active": True,
-                        }
-                    )
-                    if len(results) >= limit:
-                        return results
-        except Exception:
-            pass
+        remaining = limit - len(results)
+        if remaining > 0:
+            crypto_results = await search_upbit_symbols(query, remaining)
+            results.extend(crypto_results)
+            if len(results) >= limit:
+                return results
 
     return results
 

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import app.services.brokers.upbit.client as upbit_service
 from app.core.db import AsyncSessionLocal
@@ -85,8 +85,9 @@ from app.services.brokers.kis.client import KISClient
 from app.services.manual_holdings_service import ManualHoldingsService
 from app.services.screenshot_holdings_service import ScreenshotHoldingsService
 from app.services.upbit_symbol_universe_service import (
+    UpbitSymbolUniverseLookupError,
     get_active_upbit_markets,
-    get_or_refresh_maps,
+    get_upbit_korean_name_by_coin,
 )
 
 if TYPE_CHECKING:
@@ -190,13 +191,6 @@ async def _collect_upbit_positions(
     errors: list[dict[str, Any]] = []
 
     try:
-        coin_name_map: dict[str, str] = {}
-        try:
-            crypto_maps = await get_or_refresh_maps()
-            coin_name_map = crypto_maps.get("COIN_TO_NAME_KR", {}) or {}
-        except Exception:
-            coin_name_map = {}
-
         coins = await upbit_service.fetch_my_coins()
         for coin in coins:
             currency = str(coin.get("currency", "")).upper().strip()
@@ -208,9 +202,14 @@ async def _collect_upbit_positions(
                 continue
 
             unit_currency = str(coin.get("unit_currency", "KRW")).upper().strip()
+            quote_currency = unit_currency or "KRW"
             symbol = _normalize_position_symbol(
-                f"{unit_currency or 'KRW'}-{currency}",
+                f"{quote_currency}-{currency}",
                 "crypto",
+            )
+            korean_name = await get_upbit_korean_name_by_coin(
+                currency,
+                quote_currency=quote_currency,
             )
 
             positions.append(
@@ -222,7 +221,7 @@ async def _collect_upbit_positions(
                     "instrument_type": "crypto",
                     "market": "crypto",
                     "symbol": symbol,
-                    "name": coin_name_map.get(currency, symbol),
+                    "name": korean_name,
                     "quantity": quantity,
                     "avg_buy_price": _to_float(coin.get("avg_buy_price")),
                     "current_price": None,
@@ -231,6 +230,8 @@ async def _collect_upbit_positions(
                     "profit_rate": None,
                 }
             )
+    except UpbitSymbolUniverseLookupError:
+        raise
     except Exception as exc:
         errors.append({"source": "upbit", "market": "crypto", "error": str(exc)})
 
@@ -313,6 +314,8 @@ async def _fetch_price_map_for_positions(
             valid_symbols = [
                 symbol for symbol in crypto_symbols if symbol.upper() in tradable_set
             ]
+        except UpbitSymbolUniverseLookupError:
+            raise
         except Exception as exc:
             price_errors.append(
                 {
@@ -453,10 +456,15 @@ async def _collect_portfolio_positions(
     errors: list[dict[str, Any]] = []
 
     for result in results:
-        if isinstance(result, Exception):
+        if isinstance(result, BaseException):
+            if isinstance(result, UpbitSymbolUniverseLookupError):
+                raise result
             errors.append({"source": "holdings", "error": str(result)})
             continue
-        source_positions, source_errors = result
+        source_positions, source_errors = cast(
+            tuple[list[dict[str, Any]], list[dict[str, Any]]],
+            result,
+        )
         positions.extend(source_positions)
         errors.extend(source_errors)
 

--- a/app/routers/orderbook.py
+++ b/app/routers/orderbook.py
@@ -14,7 +14,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.db import get_db
 from app.core.templates import templates
 from app.services import upbit_orderbook
-from app.services import upbit_symbol_universe_service as upbit_pairs
+from app.services.upbit_symbol_universe_service import (
+    UpbitSymbolUniverseLookupError,
+    get_active_upbit_markets,
+)
 from app.services.websocket_connection_manager import manager
 
 logger = logging.getLogger(__name__)
@@ -42,9 +45,10 @@ async def get_available_markets(db: AsyncSession = Depends(get_db)):
         - markets: list of market codes (e.g. ["KRW-BTC", "KRW-ETH"])
     """
     try:
-        await upbit_pairs.prime_upbit_constants()
-        markets = sorted(upbit_pairs.COIN_TO_PAIR.values())
+        markets = sorted(await get_active_upbit_markets(db=db, quote_currency="KRW"))
         return {"markets": markets}
+    except UpbitSymbolUniverseLookupError:
+        raise
     except Exception as e:
         logger.error(f"Failed to get markets: {e}")
         return {"markets": []}
@@ -111,8 +115,7 @@ async def fetch_all_orderbooks():
         dict: orderbook data per market
     """
     try:
-        await upbit_pairs.prime_upbit_constants()
-        markets = list(upbit_pairs.COIN_TO_PAIR.values())
+        markets = list(await get_active_upbit_markets(quote_currency="KRW"))
 
         orderbooks = await upbit_orderbook.fetch_multiple_orderbooks(markets)
 
@@ -121,6 +124,8 @@ async def fetch_all_orderbooks():
             "timestamp": int(asyncio.get_event_loop().time()),
             "data": orderbooks,
         }
+    except UpbitSymbolUniverseLookupError:
+        raise
     except Exception as e:
         logger.error(f"Failed to fetch orderbook data: {e}")
         return {

--- a/app/routers/symbol_settings.py
+++ b/app/routers/symbol_settings.py
@@ -18,6 +18,7 @@ from app.services.symbol_trade_settings_service import (
     UserTradeDefaultsService,
     calculate_estimated_order_cost,
 )
+from app.services.upbit_symbol_universe_service import get_active_upbit_base_currencies
 from app.services.us_symbol_universe_service import (
     USSymbolUniverseLookupError,
     get_us_exchange_by_symbol,
@@ -598,7 +599,6 @@ async def get_crypto_estimated_costs(
 
     import app.services.brokers.upbit.client as upbit
     from app.analysis.service_analyzers import UpbitAnalyzer
-    from app.services import upbit_symbol_universe_service as upbit_pairs
 
     user = await get_user_from_request(request, db)
     settings_service = SymbolTradeSettingsService(db)
@@ -612,17 +612,19 @@ async def get_crypto_estimated_costs(
     )
 
     # 보유 코인 조회
-    await upbit_pairs.prime_upbit_constants()
     my_coins = await upbit.fetch_my_coins()
-    analyzer = UpbitAnalyzer()
+    tradable_currencies = await get_active_upbit_base_currencies(
+        quote_currency="KRW",
+        db=db,
+    )
 
     # 거래 가능한 코인만 필터링
     tradable_coins = [
         coin
         for coin in my_coins
-        if coin.get("currency") != "KRW"
-        and analyzer.is_tradable(coin)
-        and coin.get("currency") in upbit_pairs.KRW_TRADABLE_COINS
+        if str(coin.get("currency") or "").upper() != "KRW"
+        and UpbitAnalyzer.is_tradable(coin)
+        and str(coin.get("currency") or "").upper() in tradable_currencies
     ]
 
     # 종목별 설정 조회

--- a/app/routers/upbit_trading.py
+++ b/app/routers/upbit_trading.py
@@ -27,11 +27,16 @@ from app.jobs.analyze import (
     run_analysis_for_my_coins,
     run_per_coin_automation_task,
 )
-from app.services import upbit_symbol_universe_service as upbit_pairs
 from app.services.stock_info_service import (
     StockAnalysisService,
 )
 from app.services.symbol_trade_settings_service import SymbolTradeSettingsService
+from app.services.upbit_symbol_universe_service import (
+    UpbitSymbolInactiveError,
+    UpbitSymbolNotRegisteredError,
+    get_upbit_korean_name_by_coin,
+    get_upbit_market_by_coin,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/upbit-trading", tags=["Upbit Trading"])
@@ -77,23 +82,23 @@ async def get_my_coins(
     tradable_coins: list[dict] = []
     try:
         logger.info("Starting get_my_coins request")
-        await upbit_pairs.prime_upbit_constants()
-        logger.info("Upbit constants primed successfully")
 
         my_coins = await upbit.fetch_my_coins()
         logger.info(f"Fetched {len(my_coins)} coins from Upbit")
 
         analyzer = UpbitAnalyzer()
-        tradable_coins = [
-            coin
-            for coin in my_coins
-            if coin.get("currency") != "KRW"
-            and analyzer.is_tradable(coin)
-            and coin.get("currency") in upbit_pairs.KRW_TRADABLE_COINS
-        ]
+        tradable_coins = []
+        for coin in my_coins:
+            currency = str(coin.get("currency") or "").upper()
+            if not currency or currency == "KRW" or not analyzer.is_tradable(coin):
+                continue
+            resolved_market = await get_upbit_market_by_coin(currency, db=db)
+            coin["currency"] = currency
+            coin["_resolved_market"] = resolved_market
+            tradable_coins.append(coin)
 
         if tradable_coins:
-            market_codes = [f"KRW-{coin['currency']}" for coin in tradable_coins]
+            market_codes = [str(coin["_resolved_market"]) for coin in tradable_coins]
             current_prices = await upbit.fetch_multiple_current_prices(market_codes)
             analysis_service = StockAnalysisService(db)
             settings_service = SymbolTradeSettingsService(db)
@@ -112,7 +117,7 @@ async def get_my_coins(
 
             for coin in tradable_coins:
                 currency = coin["currency"]
-                market = f"KRW-{currency}"
+                market = str(coin["_resolved_market"])
                 balance_raw = coin.get("balance", "0")
                 locked_raw = coin.get("locked", "0")
                 balance_decimal = _to_decimal(balance_raw)
@@ -121,7 +126,7 @@ async def get_my_coins(
                 locked = float(locked_decimal)
                 avg_buy_price = float(coin.get("avg_buy_price", 0))
 
-                korean_name = upbit_pairs.COIN_TO_NAME_KR.get(currency, currency)
+                korean_name = await get_upbit_korean_name_by_coin(currency, db=db)
                 coin["korean_name"] = korean_name
                 coin["balance_raw"] = str(balance_raw)
                 coin["locked_raw"] = str(locked_raw)
@@ -315,16 +320,15 @@ async def analyze_coin(currency: str):
     currency_code = currency.upper()
 
     try:
-        await upbit_pairs.prime_upbit_constants()
-
-        if currency_code not in upbit_pairs.KRW_TRADABLE_COINS:
-            raise HTTPException(
-                status_code=400,
-                detail=f"{currency_code}는 KRW 마켓 거래 대상이 아닙니다.",
-            )
+        await get_upbit_market_by_coin(currency_code)
 
         result = await run_analysis_for_coin_task(currency_code)
         return {"success": True, **result}
+    except (UpbitSymbolNotRegisteredError, UpbitSymbolInactiveError):
+        raise HTTPException(
+            status_code=400,
+            detail=f"{currency_code}는 KRW 마켓 거래 대상이 아닙니다.",
+        ) from None
     except HTTPException:
         raise
     except Exception as e:
@@ -355,8 +359,6 @@ async def execute_coin_sell_orders(currency: str):
 async def get_open_orders():
     """체결 대기 중인 모든 주문 조회"""
     try:
-        await upbit_pairs.prime_upbit_constants()
-
         # 현재 보유 자산 정보는 보조 메타데이터로 활용
         my_coins = await upbit.fetch_my_coins()
         holdings = {
@@ -375,7 +377,7 @@ async def get_open_orders():
                 currency = market
 
             korean_name = (
-                upbit_pairs.COIN_TO_NAME_KR.get(currency, currency) if currency else ""
+                await get_upbit_korean_name_by_coin(currency) if currency else ""
             )
             holding = holdings.get(currency)
 
@@ -410,8 +412,6 @@ async def get_open_orders():
 async def cancel_all_orders():
     """모든 미체결 주문 취소"""
     try:
-        await upbit_pairs.prime_upbit_constants()
-
         open_orders = await upbit.fetch_open_orders()
 
         if not open_orders:

--- a/app/services/screenshot_holdings_service.py
+++ b/app/services/screenshot_holdings_service.py
@@ -19,7 +19,11 @@ from app.services.kr_symbol_universe_service import (
 )
 from app.services.manual_holdings_service import ManualHoldingsService
 from app.services.stock_alias_service import StockAliasService
-from app.services.upbit_symbol_universe_service import get_or_refresh_maps
+from app.services.upbit_symbol_universe_service import (
+    UpbitSymbolUniverseLookupError,
+    get_upbit_market_by_coin,
+    get_upbit_symbol_by_name,
+)
 from app.services.us_symbol_universe_service import (
     USSymbolUniverseLookupError,
     get_us_symbol_by_name,
@@ -45,15 +49,6 @@ class ScreenshotHoldingsService:
         market_section: str,
         broker: str,
     ) -> tuple[str, str, str]:
-        """종목명 → 티커 해석 (3단계 fallback)
-
-        Returns:
-            (ticker, market_type, resolution_method)
-            - ticker: 해석된 티커
-            - market_type: "KR" | "US" | "CRYPTO"
-            - resolution_method:
-              "alias" | "krx_master" | "us_master" | "crypto_name_kr" | "fallback"
-        """
         market_section = market_section.lower()
         if market_section == "kr":
             market_type = MarketType.KR
@@ -96,27 +91,23 @@ class ScreenshotHoldingsService:
                 )
                 raise
         elif market_type == MarketType.CRYPTO:
+            normalized_name = stock_name.strip()
+            if not normalized_name:
+                raise ValueError("crypto stock_name is required when symbol is missing")
+
             try:
-                crypto_maps = await get_or_refresh_maps()
-                name_to_pair = crypto_maps.get("NAME_TO_PAIR_KR", {})
-                ticker = name_to_pair.get(stock_name)
-                if ticker:
-                    return ticker, market_type.value, "crypto_name_kr"
+                ticker = await get_upbit_symbol_by_name(normalized_name, self.db)
+                return ticker, market_type.value, "crypto_master_name"
+            except UpbitSymbolUniverseLookupError:
+                candidate_coin = normalized_name.upper()
+                if candidate_coin.isalnum():
+                    ticker = await get_upbit_market_by_coin(candidate_coin, db=self.db)
+                    return ticker, market_type.value, "crypto_master_coin"
+                raise
 
-                coin_to_name = crypto_maps.get("COIN_TO_NAME_KR", {})
-                for coin_symbol, kr_name in coin_to_name.items():
-                    if kr_name == stock_name:
-                        pair = f"KRW-{coin_symbol}"
-                        return pair, market_type.value, "crypto_name_kr"
-            except Exception as e:
-                logger.warning(f"Crypto map lookup failed: {e}")
-
-        # 3단계: Fallback - 이름 그대로 대문자로 반환
-        logger.warning(
-            f"Symbol not found in alias/master data: {stock_name} ({broker}), "
-            "using uppercase name as ticker"
+        raise ValueError(
+            f"Unsupported market section '{market_section}' for broker '{broker}'"
         )
-        return stock_name.upper(), market_type.value, "fallback"
 
     async def _calculate_avg_buy_price(
         self,

--- a/app/services/upbit_orderbook.py
+++ b/app/services/upbit_orderbook.py
@@ -10,7 +10,7 @@ from typing import Any
 import httpx
 from httpx import HTTPStatusError
 
-from app.services import upbit_symbol_universe_service as upbit_pairs
+from app.services.upbit_symbol_universe_service import get_upbit_market_by_coin
 
 logger = logging.getLogger(__name__)
 
@@ -34,8 +34,7 @@ async def _normalize_market_code(market: str) -> str | None:
     if market_code.startswith("KRW-"):
         return market_code
 
-    await upbit_pairs.prime_upbit_constants()
-    return upbit_pairs.COIN_TO_PAIR.get(market_code)
+    return await get_upbit_market_by_coin(market_code)
 
 
 def _build_orderbook_result(rows: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:

--- a/app/services/upbit_symbol_universe_service.py
+++ b/app/services/upbit_symbol_universe_service.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import httpx
 from sqlalchemy import func, or_, select
@@ -15,8 +17,6 @@ logger = logging.getLogger(__name__)
 
 _UPBIT_MARKET_ALL_URL = "https://api.upbit.com/v1/market/all"
 _UPBIT_UNIVERSE_SYNC_COMMAND = "uv run python scripts/sync_upbit_symbol_universe.py"
-
-_upbit_maps: dict[str, dict[str, str]] | None = None
 
 
 class UpbitSymbolUniverseLookupError(ValueError):
@@ -199,7 +199,7 @@ async def sync_upbit_symbol_universe(db: AsyncSession | None = None) -> dict[str
     if db is not None:
         return await _apply_snapshot(db, snapshot)
 
-    async with AsyncSessionLocal() as session:
+    async with _internal_session() as session:
         async with session.begin():
             result = await _apply_snapshot(session, snapshot)
 
@@ -218,103 +218,94 @@ async def _has_any_rows(db: AsyncSession) -> bool:
     return result.scalar_one_or_none() is not None
 
 
-def _build_maps(rows: list[UpbitSymbolUniverse]) -> dict[str, dict[str, str]]:
-    pair_to_name_kr: dict[str, str] = {}
-    name_to_pair_kr: dict[str, str] = {}
-    coin_to_name_kr: dict[str, str] = {}
-    coin_to_name_en: dict[str, str] = {}
-    coin_to_pair: dict[str, str] = {}
-
-    for row in rows:
-        coin = row.base_currency
-        pair = row.market
-        if not coin or not pair:
-            continue
-
-        pair_to_name_kr[pair] = row.korean_name
-        name_to_pair_kr[row.korean_name] = pair
-        coin_to_name_kr[coin] = row.korean_name
-        coin_to_name_en[coin] = row.english_name
-        coin_to_pair[coin] = pair
-
-    return {
-        "NAME_TO_PAIR_KR": name_to_pair_kr,
-        "PAIR_TO_NAME_KR": pair_to_name_kr,
-        "COIN_TO_PAIR": coin_to_pair,
-        "COIN_TO_NAME_KR": coin_to_name_kr,
-        "COIN_TO_NAME_EN": coin_to_name_en,
-    }
+@asynccontextmanager
+async def _internal_session() -> AsyncIterator[AsyncSession]:
+    session = cast(AsyncSession, cast(object, AsyncSessionLocal()))
+    try:
+        yield session
+    finally:
+        await session.close()
 
 
-async def _load_active_krw_rows(db: AsyncSession) -> list[UpbitSymbolUniverse]:
+def _normalize_quote_currency(value: str | None, *, default: str = "KRW") -> str:
+    quote_currency = _normalize_symbol(value or default)
+    if not quote_currency:
+        raise ValueError("quote_currency is required")
+    return quote_currency
+
+
+async def _resolve_active_row_by_market(
+    db: AsyncSession,
+    market: str,
+) -> UpbitSymbolUniverse:
+    normalized_market = _normalize_symbol(market)
+    if not normalized_market:
+        raise ValueError("market is required")
+
+    stmt = select(UpbitSymbolUniverse).where(
+        UpbitSymbolUniverse.market == normalized_market
+    )
+    row = (await db.execute(stmt)).scalar_one_or_none()
+
+    if row is None:
+        if not await _has_any_rows(db):
+            raise UpbitSymbolUniverseEmptyError(
+                f"upbit_symbol_universe is empty. {_sync_hint()}"
+            )
+        raise UpbitSymbolNotRegisteredError(
+            f"Upbit market '{normalized_market}' is not registered in upbit_symbol_universe. "
+            f"{_sync_hint()}"
+        )
+
+    if not row.is_active:
+        raise UpbitSymbolInactiveError(
+            f"Upbit market '{normalized_market}' is inactive in upbit_symbol_universe. "
+            f"{_sync_hint()}"
+        )
+
+    return row
+
+
+async def _resolve_active_row_by_coin(
+    db: AsyncSession,
+    currency: str,
+    quote_currency: str,
+) -> UpbitSymbolUniverse:
+    normalized_currency = _normalize_symbol(currency)
+    if not normalized_currency:
+        raise ValueError("currency is required")
+
+    normalized_quote_currency = _normalize_quote_currency(quote_currency)
     stmt = (
         select(UpbitSymbolUniverse)
         .where(
-            UpbitSymbolUniverse.is_active.is_(True),
-            UpbitSymbolUniverse.quote_currency == "KRW",
+            UpbitSymbolUniverse.base_currency == normalized_currency,
+            UpbitSymbolUniverse.quote_currency == normalized_quote_currency,
         )
         .order_by(UpbitSymbolUniverse.market.asc())
     )
-    return list((await db.execute(stmt)).scalars().all())
+    rows = list((await db.execute(stmt)).scalars().all())
 
-
-async def _load_maps_from_db(db: AsyncSession) -> dict[str, dict[str, str]]:
-    rows = await _load_active_krw_rows(db)
     if not rows:
         if not await _has_any_rows(db):
             raise UpbitSymbolUniverseEmptyError(
                 f"upbit_symbol_universe is empty. {_sync_hint()}"
             )
-        raise UpbitSymbolUniverseEmptyError(
-            f"upbit_symbol_universe has no active KRW symbols. {_sync_hint()}"
+        raise UpbitSymbolNotRegisteredError(
+            f"Upbit coin '{normalized_currency}' is not registered for quote '{normalized_quote_currency}' "
+            f"in upbit_symbol_universe. {_sync_hint()}"
         )
 
-    maps = _build_maps(rows)
-    if not maps["COIN_TO_PAIR"]:
-        raise UpbitSymbolUniverseEmptyError(
-            f"upbit_symbol_universe has no active KRW symbols. {_sync_hint()}"
+    active_rows = [row for row in rows if row.is_active]
+    if not active_rows:
+        markets = sorted({row.market for row in rows})
+        preview = ", ".join(markets[:10])
+        raise UpbitSymbolInactiveError(
+            f"Upbit coin '{normalized_currency}' for quote '{normalized_quote_currency}' is inactive "
+            f"in upbit_symbol_universe. matched_symbols=[{preview}]. {_sync_hint()}"
         )
-    return maps
 
-
-async def get_upbit_maps(db: AsyncSession | None = None) -> dict[str, dict[str, str]]:
-    global _upbit_maps
-
-    if _upbit_maps is not None and db is None:
-        return _upbit_maps
-
-    if db is not None:
-        maps = await _load_maps_from_db(db)
-        if _upbit_maps is None:
-            _upbit_maps = maps
-        return maps
-
-    async with AsyncSessionLocal() as session:
-        maps = await _load_maps_from_db(session)
-    _upbit_maps = maps
-    return maps
-
-
-async def get_or_refresh_maps(
-    force: bool = False,
-    db: AsyncSession | None = None,
-) -> dict[str, dict[str, str]]:
-    global _upbit_maps
-    if force:
-        if db is not None:
-            maps = await _load_maps_from_db(db)
-            _upbit_maps = maps
-            return maps
-        async with AsyncSessionLocal() as session:
-            maps = await _load_maps_from_db(session)
-        _upbit_maps = maps
-        return maps
-
-    return await get_upbit_maps(db=db)
-
-
-async def prime_upbit_constants() -> None:
-    await get_upbit_maps()
+    return active_rows[0]
 
 
 async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
@@ -367,8 +358,62 @@ async def get_upbit_symbol_by_name(
     if db is not None:
         return await _resolve_active_symbol_by_name(db, name)
 
-    async with AsyncSessionLocal() as session:
+    async with _internal_session() as session:
         return await _resolve_active_symbol_by_name(session, name)
+
+
+async def get_upbit_market_by_coin(
+    currency: str,
+    quote_currency: str = "KRW",
+    db: AsyncSession | None = None,
+) -> str:
+    if db is not None:
+        row = await _resolve_active_row_by_coin(db, currency, quote_currency)
+        return row.market
+
+    async with _internal_session() as session:
+        row = await _resolve_active_row_by_coin(session, currency, quote_currency)
+    return row.market
+
+
+async def get_upbit_korean_name_by_coin(
+    currency: str,
+    quote_currency: str = "KRW",
+    db: AsyncSession | None = None,
+) -> str:
+    if db is not None:
+        row = await _resolve_active_row_by_coin(db, currency, quote_currency)
+        return row.korean_name
+
+    async with _internal_session() as session:
+        row = await _resolve_active_row_by_coin(session, currency, quote_currency)
+    return row.korean_name
+
+
+async def get_upbit_korean_name_by_market(
+    market: str,
+    db: AsyncSession | None = None,
+) -> str:
+    if db is not None:
+        row = await _resolve_active_row_by_market(db, market)
+        return row.korean_name
+
+    async with _internal_session() as session:
+        row = await _resolve_active_row_by_market(session, market)
+    return row.korean_name
+
+
+async def get_upbit_coin_by_market(
+    market: str,
+    db: AsyncSession | None = None,
+) -> str:
+    if db is not None:
+        row = await _resolve_active_row_by_market(db, market)
+        return row.base_currency
+
+    async with _internal_session() as session:
+        row = await _resolve_active_row_by_market(session, market)
+    return row.base_currency
 
 
 async def _search_upbit_symbols_impl(
@@ -423,7 +468,7 @@ async def search_upbit_symbols(
     if db is not None:
         return await _search_upbit_symbols_impl(db, query, capped_limit)
 
-    async with AsyncSessionLocal() as session:
+    async with _internal_session() as session:
         return await _search_upbit_symbols_impl(session, query, capped_limit)
 
 
@@ -489,11 +534,45 @@ async def get_active_upbit_markets(
     if db is not None:
         return await _get_active_upbit_markets_impl(db, effective_quote_currency)
 
-    async with AsyncSessionLocal() as session:
+    async with _internal_session() as session:
         return await _get_active_upbit_markets_impl(
             session,
             effective_quote_currency,
         )
+
+
+async def get_active_upbit_base_currencies(
+    quote_currency: str = "KRW",
+    db: AsyncSession | None = None,
+) -> set[str]:
+    normalized_quote_currency = _normalize_quote_currency(quote_currency)
+
+    stmt = (
+        select(UpbitSymbolUniverse.base_currency)
+        .where(
+            UpbitSymbolUniverse.is_active.is_(True),
+            UpbitSymbolUniverse.quote_currency == normalized_quote_currency,
+        )
+        .order_by(UpbitSymbolUniverse.base_currency.asc())
+    )
+
+    async def _load(session: AsyncSession) -> set[str]:
+        base_currencies = {
+            str(base_currency).strip().upper()
+            for base_currency in (await session.execute(stmt)).scalars().all()
+            if str(base_currency).strip()
+        }
+        if not base_currencies and not await _has_any_rows(session):
+            raise UpbitSymbolUniverseEmptyError(
+                f"upbit_symbol_universe is empty. {_sync_hint()}"
+            )
+        return base_currencies
+
+    if db is not None:
+        return await _load(db)
+
+    async with _internal_session() as session:
+        return await _load(session)
 
 
 async def get_upbit_warning_markets(
@@ -505,83 +584,11 @@ async def get_upbit_warning_markets(
     if db is not None:
         return await _get_upbit_warning_markets_impl(db, effective_quote_currency)
 
-    async with AsyncSessionLocal() as session:
+    async with _internal_session() as session:
         return await _get_upbit_warning_markets_impl(
             session,
             effective_quote_currency,
         )
-
-
-class _LazyUpbitDict:
-    def __init__(self, key: str):
-        self._key = key
-
-    def _get_data(self) -> dict[str, str]:
-        global _upbit_maps
-        if _upbit_maps is None:
-            raise RuntimeError(
-                "Upbit symbol universe maps are not initialized. "
-                "Call 'await prime_upbit_constants()' first."
-            )
-        return _upbit_maps[self._key]
-
-    def __getitem__(self, key: str) -> str:
-        return self._get_data()[key]
-
-    def __contains__(self, key: object) -> bool:
-        return key in self._get_data()
-
-    def get(self, key: str, default: str | None = None) -> str | None:
-        return self._get_data().get(key, default)
-
-    def keys(self):
-        return self._get_data().keys()
-
-    def values(self):
-        return self._get_data().values()
-
-    def items(self):
-        return self._get_data().items()
-
-    def __iter__(self):
-        return iter(self._get_data())
-
-    def __len__(self) -> int:
-        return len(self._get_data())
-
-    def __repr__(self) -> str:
-        return repr(self._get_data())
-
-
-class _LazyUpbitSet:
-    def _get_data(self) -> set[str]:
-        global _upbit_maps
-        if _upbit_maps is None:
-            raise RuntimeError(
-                "Upbit symbol universe maps are not initialized. "
-                "Call 'await prime_upbit_constants()' first."
-            )
-        return set(_upbit_maps["COIN_TO_NAME_KR"].keys())
-
-    def __contains__(self, item: object) -> bool:
-        return item in self._get_data()
-
-    def __iter__(self):
-        return iter(self._get_data())
-
-    def __len__(self) -> int:
-        return len(self._get_data())
-
-    def __repr__(self) -> str:
-        return repr(self._get_data())
-
-
-NAME_TO_PAIR_KR = _LazyUpbitDict("NAME_TO_PAIR_KR")
-PAIR_TO_NAME_KR = _LazyUpbitDict("PAIR_TO_NAME_KR")
-COIN_TO_PAIR = _LazyUpbitDict("COIN_TO_PAIR")
-COIN_TO_NAME_KR = _LazyUpbitDict("COIN_TO_NAME_KR")
-COIN_TO_NAME_EN = _LazyUpbitDict("COIN_TO_NAME_EN")
-KRW_TRADABLE_COINS = _LazyUpbitSet()
 
 
 __all__ = [
@@ -590,19 +597,15 @@ __all__ = [
     "UpbitSymbolNotRegisteredError",
     "UpbitSymbolInactiveError",
     "UpbitSymbolNameAmbiguousError",
-    "NAME_TO_PAIR_KR",
-    "PAIR_TO_NAME_KR",
-    "COIN_TO_PAIR",
-    "COIN_TO_NAME_KR",
-    "COIN_TO_NAME_EN",
-    "KRW_TRADABLE_COINS",
     "build_upbit_symbol_universe_snapshot",
     "get_active_upbit_markets",
-    "get_or_refresh_maps",
+    "get_active_upbit_base_currencies",
+    "get_upbit_coin_by_market",
+    "get_upbit_korean_name_by_coin",
+    "get_upbit_korean_name_by_market",
+    "get_upbit_market_by_coin",
     "get_upbit_warning_markets",
-    "get_upbit_maps",
     "get_upbit_symbol_by_name",
-    "prime_upbit_constants",
     "search_upbit_symbols",
     "sync_upbit_symbol_universe",
 ]

--- a/app/services/upbit_websocket.py
+++ b/app/services/upbit_websocket.py
@@ -11,7 +11,10 @@ import jwt
 from websockets.exceptions import ConnectionClosed, WebSocketException
 
 from app.core.config import settings
-from app.services import upbit_symbol_universe_service as upbit_pairs
+from app.services.upbit_symbol_universe_service import (
+    UpbitSymbolUniverseLookupError,
+    get_upbit_korean_name_by_market,
+)
 
 # 로깅 설정
 logger = logging.getLogger(__name__)
@@ -299,12 +302,7 @@ class UpbitOrderAnalysisService:
                 return
 
             # 페어를 한국 이름으로 변환
-            await upbit_pairs.prime_upbit_constants()
-            coin_name = upbit_pairs.PAIR_TO_NAME_KR.get(code)
-
-            if not coin_name:
-                logger.warning(f"코인명을 찾을 수 없음: {code}")
-                return
+            coin_name = await get_upbit_korean_name_by_market(code)
 
             # 매수/매도 구분
             ask_bid = order_data.get("ask_bid")  # "ASK"(매도) 또는 "BID"(매수)
@@ -323,6 +321,9 @@ class UpbitOrderAnalysisService:
             else:
                 logger.warning("분석 콜백이 설정되지 않았습니다.")
 
+        except UpbitSymbolUniverseLookupError:
+            logger.error(f"주문 데이터 심볼 해석 오류: {order_data}", exc_info=True)
+            raise
         except Exception as e:
             logger.error(f"주문 데이터 처리 오류: {e}")
             logger.error(f"문제가 된 데이터: {order_data}")

--- a/blog/test_upbit_blog.py
+++ b/blog/test_upbit_blog.py
@@ -10,7 +10,6 @@ from google import genai
 
 from app.analysis.analyzer import DataProcessor
 import app.services.brokers.upbit.client as upbit
-from app.services import upbit_symbol_universe_service as upbit_pairs
 
 
 def add_indicators(df):
@@ -54,7 +53,7 @@ def build_prompt(df, ticker: str, coin_name: str, fundamental_info: dict = None)
     # 1. 기술적 지표 계산
     df = add_indicators(df).sort_values("date").reset_index(drop=True)
 
-    latest = df.iloc[-1]     # 오늘
+    latest = df.iloc[-1]  # 오늘
     yesterday = df.iloc[-2]  # 어제
 
     # 2. 전일 대비 계산
@@ -117,9 +116,6 @@ def build_prompt(df, ticker: str, coin_name: str, fundamental_info: dict = None)
 
 
 async def main():
-    # Upbit 상수 초기화
-    await upbit_pairs.prime_upbit_constants()
-
     # 비트코인 데이터 수집
     coin_name = "비트코인"
     ticker = "KRW-BTC"
@@ -152,10 +148,7 @@ async def main():
 
     # GOOGLE_API_KEY 환경 변수에서 자동으로 가져옴
     client = genai.Client()
-    response = client.models.generate_content(
-        model="gemini-2.5-flash",
-        contents=prompt
-    )
+    response = client.models.generate_content(model="gemini-2.5-flash", contents=prompt)
 
     print("\nGemini AI 분석 결과:")
     print("=" * 80)

--- a/docs/plans/2026-02-23-upbit-db-lookup-migration-design.md
+++ b/docs/plans/2026-02-23-upbit-db-lookup-migration-design.md
@@ -1,0 +1,164 @@
+# Upbit Symbol Lookup 전역 맵 제거 및 Strict DB 조회 전환 설계
+
+## Summary
+
+- 목표: Upbit 심볼 해석 경로에서 전역 맵/캐시(`_upbit_maps` + lazy proxy)를 제거하고 DB 직접 조회 API로 일원화한다.
+- 범위: 런타임(`app/`), MCP tooling(`app/mcp_server/tooling/`), screenshot holdings 서비스, 관련 테스트/문서.
+- 정책: fallback 없이 strict 예외 전파. 미등록/비활성/빈 테이블은 즉시 실패한다.
+
+## Problem Statement
+
+현재 Upbit 심볼 해석은 `upbit_symbol_universe_service`의 전역 맵과 lazy proxy(`COIN_TO_PAIR`, `COIN_TO_NAME_KR`, `NAME_TO_PAIR_KR` 등)에 의존한다. 이 구조는 다음 문제를 만든다.
+
+1. 조회 타이밍과 초기화 순서(`prime_upbit_constants`)가 결합되어 런타임 에러 포인트가 분산된다.
+2. 일부 경로에서 broad exception과 결합되며 오류가 silent fallback으로 숨겨진다.
+3. MCP/screenshot 경로에서 map iterate 기반 해석이 남아 DB 계약(등록/활성 상태 기반)과 분리된다.
+
+## Locked Decisions
+
+- DB 스키마 변경 없음(마이그레이션 없음)
+- 전역 캐시/TTL 캐시 도입 금지
+- 루프 처리 중 미등록/비활성 발견 시 항목 skip 금지, 즉시 실패
+- `db: AsyncSession | None` 시그니처 유지, `db is None`이면 내부 `AsyncSessionLocal` one-shot 조회
+- 공개 계약 유지/변경은 아래 명시값만 허용
+
+## Public Interface Changes
+
+### Remove
+
+- `prime_upbit_constants`
+- `get_upbit_maps`
+- `get_or_refresh_maps`
+- `NAME_TO_PAIR_KR`
+- `PAIR_TO_NAME_KR`
+- `COIN_TO_PAIR`
+- `COIN_TO_NAME_KR`
+- `COIN_TO_NAME_EN`
+- `KRW_TRADABLE_COINS`
+
+### Keep
+
+- `get_upbit_symbol_by_name`
+- `get_active_upbit_markets`
+- `get_upbit_warning_markets`
+- `UpbitSymbolUniverseEmptyError`
+- `UpbitSymbolNotRegisteredError`
+- `UpbitSymbolInactiveError`
+- `UpbitSymbolNameAmbiguousError`
+
+### Add
+
+- `get_upbit_market_by_coin(currency: str, quote_currency: str = "KRW", db: AsyncSession | None = None) -> str`
+- `get_upbit_korean_name_by_coin(currency: str, quote_currency: str = "KRW", db: AsyncSession | None = None) -> str`
+- `get_upbit_korean_name_by_market(market: str, db: AsyncSession | None = None) -> str`
+- `get_upbit_coin_by_market(market: str, db: AsyncSession | None = None) -> str`
+- `get_active_upbit_base_currencies(quote_currency: str = "KRW", db: AsyncSession | None = None) -> set[str]`
+
+## Exception Contract
+
+- 빈 테이블/조회 가능한 universe 부재: `UpbitSymbolUniverseEmptyError`
+- 대상이 등록되지 않음: `UpbitSymbolNotRegisteredError`
+- 대상이 등록되어 있으나 비활성: `UpbitSymbolInactiveError`
+- 이름 기반 다중 활성 심볼 충돌: `UpbitSymbolNameAmbiguousError` (기존 계약 유지)
+- 기본값 반환 금지(`dict.get(..., default)` 대체)
+
+## Approaches Considered
+
+1. **현행 유지 + 예외만 강화**
+   - 장점: 변경량 작음
+   - 단점: 전역 상태/초기화 순서 결합 지속, map 경로와 DB 계약 이원화
+2. **전역 맵 유지 + 내부 캐시 무효화 개선**
+   - 장점: 성능 유지
+   - 단점: strict 계약과 충돌 가능성 높고 fallback 관성 유지
+3. **선택안: 전역 맵 완전 제거 + DB strict lookup 단일화**
+   - 장점: 계약 명확성, 오류 전파 일관성, 테스트 가능성 향상
+   - 단점: 호출부 async lookup 전환 비용 증가
+
+선택: 3번.
+
+## Design Details
+
+### 1) 서비스 코어 리팩터링
+
+- 제거 대상: `_upbit_maps`, map builder(`_build_maps`), map loader(`_load_maps_from_db`), lazy proxy class/instance, map API.
+- 신규 lookup helper는 모두 다음 공통 규칙을 따른다.
+  - 입력 정규화 후 active row 우선 조회
+  - 미조회 시 inactive 여부 확인 쿼리로 예외 유형 결정
+  - `db is None`이면 내부 session 생성 후 one-shot 조회
+
+### 2) 런타임 호출부 치환
+
+- `upbit_websocket.py`: market code -> korean name은 `get_upbit_korean_name_by_market`로 치환
+- `upbit_orderbook.py`: coin code 정규화는 `get_upbit_market_by_coin` 사용
+- `routers/orderbook.py`: 전체 KRW 마켓 목록은 `get_active_upbit_markets(quote_currency="KRW")`
+- `routers/upbit_trading.py`/`jobs/analyze.py`/`analysis/service_analyzers.py`/`routers/symbol_settings.py`
+  - tradable membership 체크(`KRW_TRADABLE_COINS`) 제거
+  - coin 검증은 `get_upbit_market_by_coin` 호출로 대체
+  - coin 이름 해석은 `get_upbit_korean_name_by_coin`
+- `jobs/daily_scan.py`: `_coin_name`을 async 조회로 전환하고 실패 시 전파
+
+### 3) MCP/tooling 및 screenshot 경로
+
+- `screenshot_holdings_service.py`: `get_or_refresh_maps` 제거, crypto name -> symbol 해석은 strict DB lookup(`get_upbit_symbol_by_name` 등) 사용
+- `market_data_quotes.py`: crypto search map iterate 제거, `search_upbit_symbols` 사용
+- `fundamentals_sources_coingecko.py`: 보유 코인 필터링 시 coin별 strict DB 검증 사용
+- `portfolio_holdings.py`: `COIN_TO_NAME_KR` 제거, coin별 이름 조회 함수 사용
+
+### 4) broad exception 정리
+
+- symbol lookup 관련 `except Exception: pass` 구간은 제거 또는 domain-aware 재throw로 축소
+- 예외를 payload로 변환해야 하는 MCP 경로는 silent suppress 대신 명시적 에러 메시지/오류 목록 반환
+
+## Callsite Migration Matrix
+
+- Runtime: `app/services/upbit_websocket.py`, `app/services/upbit_orderbook.py`, `app/routers/orderbook.py`, `app/routers/upbit_trading.py`, `app/jobs/analyze.py`, `app/jobs/daily_scan.py`, `app/analysis/service_analyzers.py`, `app/routers/symbol_settings.py`
+- MCP/Tooling: `app/mcp_server/tooling/market_data_quotes.py`, `app/mcp_server/tooling/fundamentals_sources_coingecko.py`, `app/mcp_server/tooling/portfolio_holdings.py`
+- Screenshot: `app/services/screenshot_holdings_service.py`
+- 추가 동기화 대상(전역 API 삭제 영향): `websocket_monitor.py`, `upbit_websocket_monitor.py`, 관련 테스트
+
+## Testing Strategy
+
+### Unit (Service API)
+
+- 신규 API 성공/미등록/비활성/빈 테이블 케이스 모두 검증
+- 예외 타입별 메시지에 sync hint 포함 여부 검증
+
+### Runtime Integration
+
+- websocket 체결 이벤트의 code -> korean_name strict 조회
+- orderbook coin 정규화(strict coin->market)
+- analyze/upbit_trading에서 미등록 코인 즉시 실패
+
+### MCP/Screenshot
+
+- map 없이 crypto symbol/name 해석 동작
+- 해석 실패 시 silent fallback 제거(명시적 에러)
+
+### Regression
+
+- map API 제거 후 import/monkeypatch 경로 정리
+- 기존 `get_active_upbit_markets`, `get_upbit_warning_markets`, `search_upbit_symbols` 동작 유지
+
+## Verification Commands
+
+```bash
+uv run pytest tests/test_upbit_symbol_universe_sync.py
+uv run pytest tests/test_upbit_trading.py tests/test_tasks.py tests/test_daily_scan.py tests/test_upbit_orderbook_service.py tests/test_screenshot_holdings_service_resolution.py
+uv run pytest tests/test_mcp_server_tools.py -k "get_or_refresh_maps or COIN_TO_NAME_KR or NAME_TO_PAIR_KR"
+make lint
+```
+
+## Risks and Mitigations
+
+- 리스크: async lookup 증가로 루프 경로 I/O 빈도 증가
+  - 대응: 동작 정확성 우선 적용 후 병목이 확인될 때 명시적 배치 API 별도 설계
+- 리스크: broad catch 제거로 기존 "조용한 성공" 경로가 실패로 전환
+  - 대응: MCP README/테스트를 함께 업데이트하여 계약을 명문화
+- 리스크: 제거 API를 참조하는 주변 스크립트 누락
+  - 대응: `rg` 기반 전역 스캔과 관련 테스트 동시 수정
+
+## Out of Scope
+
+- DB schema 변경
+- 캐시 재도입/TTL 정책 변경
+- Upbit sync 스케줄/잡 정책 변경

--- a/tests/test_daily_scan.py
+++ b/tests/test_daily_scan.py
@@ -74,17 +74,22 @@ def scanner_env(monkeypatch: pytest.MonkeyPatch):
     fake_redis = _FakeRedis()
     scanner._get_redis = AsyncMock(return_value=fake_redis)  # type: ignore[method-assign]
 
+    async def fake_get_upbit_korean_name_by_coin(
+        currency: str,
+        quote_currency: str = "KRW",
+        db=None,
+    ) -> str:
+        _ = quote_currency, db
+        return {
+            "BTC": "비트코인",
+            "ETH": "이더리움",
+            "XRP": "리플",
+        }.get(currency, currency)
+
     monkeypatch.setattr(
-        daily_scan.upbit_pairs,
-        "COIN_TO_NAME_KR",
-        {"BTC": "비트코인", "ETH": "이더리움", "XRP": "리플"},
-        raising=False,
-    )
-    monkeypatch.setattr(
-        daily_scan.upbit_pairs,
-        "prime_upbit_constants",
-        AsyncMock(return_value=None),
-        raising=False,
+        daily_scan,
+        "get_upbit_korean_name_by_coin",
+        fake_get_upbit_korean_name_by_coin,
     )
 
     monkeypatch.setattr(

--- a/tests/test_mcp_server_tools.py
+++ b/tests/test_mcp_server_tools.py
@@ -149,6 +149,15 @@ def _patch_runtime_attr(
         raise AttributeError(f"No runtime module exposes attribute '{attr_name}'")
 
 
+def _upbit_name_lookup_mock(name_map: dict[str, str]) -> AsyncMock:
+    async def _lookup(currency: str, quote_currency: str = "KRW", db=None) -> str:
+        _ = quote_currency, db
+        key = str(currency).upper()
+        return name_map.get(key, key)
+
+    return AsyncMock(side_effect=_lookup)
+
+
 def _patch_httpx_async_client(
     monkeypatch: pytest.MonkeyPatch, async_client_class: type
 ) -> None:
@@ -1043,6 +1052,11 @@ async def test_search_symbol_clamps_limit_and_shapes(monkeypatch):
     _patch_runtime_attr(
         monkeypatch,
         "search_us_symbols",
+        AsyncMock(return_value=[]),
+    )
+    _patch_runtime_attr(
+        monkeypatch,
+        "search_upbit_symbols",
         AsyncMock(return_value=[]),
     )
 
@@ -5672,8 +5686,8 @@ async def test_get_holdings_groups_by_account_and_calculates_pnl(monkeypatch):
     )
     _patch_runtime_attr(
         monkeypatch,
-        "get_or_refresh_maps",
-        AsyncMock(return_value={"COIN_TO_NAME_KR": {"BTC": "비트코인"}}),
+        "get_upbit_korean_name_by_coin",
+        _upbit_name_lookup_mock({"BTC": "비트코인"}),
     )
     _patch_runtime_attr(
         monkeypatch,
@@ -5783,10 +5797,8 @@ async def test_get_holdings_crypto_prices_batch_fetch(monkeypatch):
     )
     _patch_runtime_attr(
         monkeypatch,
-        "get_or_refresh_maps",
-        AsyncMock(
-            return_value={"COIN_TO_NAME_KR": {"BTC": "비트코인", "ETH": "이더리움"}}
-        ),
+        "get_upbit_korean_name_by_coin",
+        _upbit_name_lookup_mock({"BTC": "비트코인", "ETH": "이더리움"}),
     )
     _patch_runtime_attr(
         monkeypatch,
@@ -5860,10 +5872,8 @@ async def test_get_holdings_includes_crypto_price_errors(monkeypatch):
     )
     _patch_runtime_attr(
         monkeypatch,
-        "get_or_refresh_maps",
-        AsyncMock(
-            return_value={"COIN_TO_NAME_KR": {"BTC": "비트코인", "DOGE": "도지"}}
-        ),
+        "get_upbit_korean_name_by_coin",
+        _upbit_name_lookup_mock({"BTC": "비트코인", "DOGE": "도지"}),
     )
     _patch_runtime_attr(
         monkeypatch,
@@ -5960,15 +5970,13 @@ async def test_get_holdings_applies_minimum_value_filter(monkeypatch):
     )
     _patch_runtime_attr(
         monkeypatch,
-        "get_or_refresh_maps",
-        AsyncMock(
-            return_value={
-                "COIN_TO_NAME_KR": {
-                    "BTC": "비트코인",
-                    "ONG": "온톨로지가스",
-                    "XYM": "심볼",
-                    "PCI": "페이코인",
-                }
+        "get_upbit_korean_name_by_coin",
+        _upbit_name_lookup_mock(
+            {
+                "BTC": "비트코인",
+                "ONG": "온톨로지가스",
+                "XYM": "심볼",
+                "PCI": "페이코인",
             }
         ),
     )
@@ -6054,10 +6062,8 @@ async def test_get_holdings_filters_delisted_markets_before_batch_fetch(monkeypa
     )
     _patch_runtime_attr(
         monkeypatch,
-        "get_or_refresh_maps",
-        AsyncMock(
-            return_value={"COIN_TO_NAME_KR": {"BTC": "비트코인", "PCI": "페이코인"}}
-        ),
+        "get_upbit_korean_name_by_coin",
+        _upbit_name_lookup_mock({"BTC": "비트코인", "PCI": "페이코인"}),
     )
     _patch_runtime_attr(
         monkeypatch,
@@ -6128,8 +6134,8 @@ async def test_get_holdings_filters_account_market_and_disables_prices(monkeypat
     )
     _patch_runtime_attr(
         monkeypatch,
-        "get_or_refresh_maps",
-        AsyncMock(return_value={"COIN_TO_NAME_KR": {"ETH": "이더리움"}}),
+        "get_upbit_korean_name_by_coin",
+        _upbit_name_lookup_mock({"ETH": "이더리움"}),
     )
     _patch_runtime_attr(
         monkeypatch,

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -3,6 +3,7 @@ Tests for API routers.
 """
 
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -70,9 +71,6 @@ class TestUpbitTradingRouter:
         """get_my_coins는 내부 오류 시 HTTPException을 일관되게 전달해야 한다."""
         from app.routers import upbit_trading
 
-        async def fake_prime():
-            return None
-
         async def fake_fetch_my_coins():
             raise RuntimeError("boom")
 
@@ -87,10 +85,6 @@ class TestUpbitTradingRouter:
                 return None
 
         monkeypatch.setattr(
-            "app.services.upbit_symbol_universe_service.prime_upbit_constants",
-            fake_prime,
-        )
-        monkeypatch.setattr(
             "app.services.brokers.upbit.client.fetch_my_coins",
             fake_fetch_my_coins,
         )
@@ -101,7 +95,7 @@ class TestUpbitTradingRouter:
         )
 
         with pytest.raises(HTTPException) as exc_info:
-            await upbit_trading.get_my_coins(db=object())
+            await upbit_trading.get_my_coins(db=cast(Any, object()))
 
         assert exc_info.value.status_code == 500
         assert "boom" in exc_info.value.detail
@@ -232,7 +226,7 @@ class TestManualHoldingsRouter:
         with pytest.raises(HTTPException) as exc_info:
             await manual_holdings.create_holding(
                 data=data,
-                current_user=SimpleNamespace(id=1),
+                current_user=cast(Any, SimpleNamespace(id=1)),
                 db=AsyncMock(),
             )
 
@@ -272,26 +266,29 @@ class TestManualHoldingsRouter:
         data = ManualHoldingBulkCreate(
             broker_type=BrokerType.TOSS,
             account_name="기본 계좌",
-            holdings=[
-                {
-                    "ticker": "AAPL",
-                    "market_type": MarketType.US,
-                    "quantity": 1,
-                    "avg_price": 100,
-                },
-                {
-                    "ticker": "솔라나",
-                    "market_type": MarketType.US,
-                    "quantity": 1,
-                    "avg_price": 100,
-                },
-            ],
+            holdings=cast(
+                Any,
+                [
+                    {
+                        "ticker": "AAPL",
+                        "market_type": MarketType.US,
+                        "quantity": 1,
+                        "avg_price": 100,
+                    },
+                    {
+                        "ticker": "솔라나",
+                        "market_type": MarketType.US,
+                        "quantity": 1,
+                        "avg_price": 100,
+                    },
+                ],
+            ),
         )
 
         with pytest.raises(HTTPException) as exc_info:
             await manual_holdings.create_holdings_bulk(
                 data=data,
-                current_user=SimpleNamespace(id=1),
+                current_user=cast(Any, SimpleNamespace(id=1)),
                 db=AsyncMock(),
             )
 

--- a/tests/test_screenshot_holdings_service_resolution.py
+++ b/tests/test_screenshot_holdings_service_resolution.py
@@ -13,6 +13,7 @@ import pytest
 from app.services.kr_symbol_universe_service import KRSymbolUniverseLookupError
 from app.services.screenshot_holdings_service import ScreenshotHoldingsService
 from app.services.stock_alias_service import StockAliasService
+from app.services.upbit_symbol_universe_service import UpbitSymbolNotRegisteredError
 from app.services.us_symbol_universe_service import USSymbolUniverseLookupError
 
 
@@ -43,14 +44,16 @@ def _setup_mocks(
     mock_db,
     mock_broker_account,
     existing_holdings=None,
-    crypto_maps=None,
+    crypto_name_to_market=None,
+    crypto_coin_to_market=None,
     kr_name_to_symbol=None,
     us_name_to_symbol=None,
     alias_ticker=None,
 ):
     """Helper to set up all required mocks."""
     existing_holdings = existing_holdings or []
-    crypto_maps = crypto_maps or {"NAME_TO_PAIR_KR": {}, "COIN_TO_NAME_KR": {}}
+    crypto_name_to_market = crypto_name_to_market or {}
+    crypto_coin_to_market = crypto_coin_to_market or {}
     kr_name_to_symbol = kr_name_to_symbol or {}
     us_name_to_symbol = us_name_to_symbol or {}
 
@@ -59,9 +62,27 @@ def _setup_mocks(
         existing_holdings
     )
 
+    async def mock_get_upbit_symbol_by_name(name, _db=None):
+        market = crypto_name_to_market.get(name)
+        if market is None:
+            raise UpbitSymbolNotRegisteredError("not found")
+        return market
+
     monkeypatch.setattr(
-        "app.services.screenshot_holdings_service.get_or_refresh_maps",
-        AsyncMock(return_value=crypto_maps),
+        "app.services.screenshot_holdings_service.get_upbit_symbol_by_name",
+        mock_get_upbit_symbol_by_name,
+    )
+
+    async def mock_get_upbit_market_by_coin(currency, quote_currency="KRW", db=None):
+        _ = quote_currency, db
+        market = crypto_coin_to_market.get(str(currency).upper())
+        if market is None:
+            raise UpbitSymbolNotRegisteredError("not found")
+        return market
+
+    monkeypatch.setattr(
+        "app.services.screenshot_holdings_service.get_upbit_market_by_coin",
+        mock_get_upbit_market_by_coin,
     )
 
     async def mock_get_kr_symbol_by_name(name, _db=None):
@@ -136,12 +157,12 @@ def _setup_mocks(
 async def test_crypto_korean_name_ethereum(
     service, mock_db, mock_broker_account, monkeypatch
 ):
-    """Scenario 1: '이더리움' + market_section='crypto' -> KRW-ETH, CRYPTO, crypto_name_kr"""
-    crypto_maps = {
-        "NAME_TO_PAIR_KR": {"이더리움": "KRW-ETH", "비트코인": "KRW-BTC"},
-        "COIN_TO_NAME_KR": {"ETH": "이더리움", "BTC": "비트코인"},
-    }
-    _setup_mocks(monkeypatch, mock_db, mock_broker_account, crypto_maps=crypto_maps)
+    _setup_mocks(
+        monkeypatch,
+        mock_db,
+        mock_broker_account,
+        crypto_name_to_market={"이더리움": "KRW-ETH", "비트코인": "KRW-BTC"},
+    )
 
     result = await service.resolve_and_update(
         user_id=1,
@@ -162,7 +183,7 @@ async def test_crypto_korean_name_ethereum(
     holding = result["holdings"][0]
     assert holding["resolved_ticker"] == "KRW-ETH"
     assert holding["market_type"] == "CRYPTO"
-    assert holding["resolution_method"] == "crypto_name_kr"
+    assert holding["resolution_method"] == "crypto_master_name"
 
 
 @pytest.mark.asyncio
@@ -170,11 +191,12 @@ async def test_crypto_korean_name_solana(
     service, mock_db, mock_broker_account, monkeypatch
 ):
     """Scenario 2: '솔라나' -> KRW-SOL"""
-    crypto_maps = {
-        "NAME_TO_PAIR_KR": {"솔라나": "KRW-SOL"},
-        "COIN_TO_NAME_KR": {"SOL": "솔라나"},
-    }
-    _setup_mocks(monkeypatch, mock_db, mock_broker_account, crypto_maps=crypto_maps)
+    _setup_mocks(
+        monkeypatch,
+        mock_db,
+        mock_broker_account,
+        crypto_name_to_market={"솔라나": "KRW-SOL"},
+    )
 
     result = await service.resolve_and_update(
         user_id=1,
@@ -194,7 +216,7 @@ async def test_crypto_korean_name_solana(
     holding = result["holdings"][0]
     assert holding["resolved_ticker"] == "KRW-SOL"
     assert holding["market_type"] == "CRYPTO"
-    assert holding["resolution_method"] == "crypto_name_kr"
+    assert holding["resolution_method"] == "crypto_master_name"
 
 
 @pytest.mark.asyncio
@@ -415,13 +437,12 @@ async def test_stock_name_remove_resolves_and_deletes(
     existing.quantity = Decimal("1")
     existing.avg_price = Decimal("3000000")
 
-    crypto_maps = {"NAME_TO_PAIR_KR": {"이더리움": "KRW-ETH"}, "COIN_TO_NAME_KR": {}}
     _setup_mocks(
         monkeypatch,
         mock_db,
         mock_broker_account,
         existing_holdings=[existing],
-        crypto_maps=crypto_maps,
+        crypto_name_to_market={"이더리움": "KRW-ETH"},
     )
 
     delete_calls = []
@@ -460,16 +481,11 @@ async def test_stock_name_remove_resolves_and_deletes(
 async def test_alias_precedence_over_crypto_map(
     service, mock_db, mock_broker_account, monkeypatch
 ):
-    """alias가 crypto map보다 우선되어 ticker를 결정한다."""
-    crypto_maps = {
-        "NAME_TO_PAIR_KR": {"이더리움": "KRW-ETH"},
-        "COIN_TO_NAME_KR": {"ETH": "이더리움"},
-    }
     _setup_mocks(
         monkeypatch,
         mock_db,
         mock_broker_account,
-        crypto_maps=crypto_maps,
+        crypto_name_to_market={"이더리움": "KRW-ETH"},
         alias_ticker="KRW-ETH-ALIAS",
     )
 
@@ -578,8 +594,12 @@ async def test_dry_run_response_contract(
     service, mock_db, mock_broker_account, monkeypatch
 ):
     """Scenario 10: dry_run=True에서 diff/count 미포함, dry_run=False에서 포함 검증"""
-    crypto_maps = {"NAME_TO_PAIR_KR": {"이더리움": "KRW-ETH"}, "COIN_TO_NAME_KR": {}}
-    _setup_mocks(monkeypatch, mock_db, mock_broker_account, crypto_maps=crypto_maps)
+    _setup_mocks(
+        monkeypatch,
+        mock_db,
+        mock_broker_account,
+        crypto_name_to_market={"이더리움": "KRW-ETH"},
+    )
 
     result_dry = await service.resolve_and_update(
         user_id=1,
@@ -647,30 +667,24 @@ async def test_calculate_avg_buy_price_normal(service):
 
 
 @pytest.mark.asyncio
-async def test_crypto_unknown_coin_fallback(
+async def test_crypto_unknown_coin_raises_explicit_error(
     service, mock_db, mock_broker_account, monkeypatch
 ):
-    """Unknown crypto name falls back to uppercase name as ticker."""
-    crypto_maps = {"NAME_TO_PAIR_KR": {}, "COIN_TO_NAME_KR": {}}
-    _setup_mocks(monkeypatch, mock_db, mock_broker_account, crypto_maps=crypto_maps)
+    _setup_mocks(monkeypatch, mock_db, mock_broker_account)
 
-    result = await service.resolve_and_update(
-        user_id=1,
-        holdings_data=[
-            {
-                "stock_name": "존재안하는코인",
-                "quantity": 1,
-                "market_section": "crypto",
-            }
-        ],
-        broker="upbit",
-        dry_run=True,
-    )
-
-    assert result["success"] is True
-    holding = result["holdings"][0]
-    assert holding["resolved_ticker"] == "존재안하는코인"
-    assert holding["resolution_method"] == "fallback"
+    with pytest.raises(UpbitSymbolNotRegisteredError, match="not found"):
+        await service.resolve_and_update(
+            user_id=1,
+            holdings_data=[
+                {
+                    "stock_name": "존재안하는코인",
+                    "quantity": 1,
+                    "market_section": "crypto",
+                }
+            ],
+            broker="upbit",
+            dry_run=True,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,6 +1,8 @@
 """Tests for TaskIQ tasks defined in app.jobs.analyze."""
 
 import asyncio
+from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -36,29 +38,12 @@ def test_run_analysis_for_my_coins_no_tradable(monkeypatch):
     """거래 가능한 코인이 없을 때 완료 상태로 즉시 반환하는지 확인."""
     from app.jobs import analyze
 
-    async def fake_prime():
-        return None
-
     async def fake_fetch_my_coins():
         return [{"currency": "KRW", "balance": "100000"}]
 
     monkeypatch.setattr(
-        "app.services.upbit_symbol_universe_service.prime_upbit_constants",
-        fake_prime,
-    )
-    monkeypatch.setattr(
         "app.services.brokers.upbit.client.fetch_my_coins",
         fake_fetch_my_coins,
-    )
-    monkeypatch.setattr(
-        "app.services.upbit_symbol_universe_service.KRW_TRADABLE_COINS",
-        {"BTC"},
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "app.services.upbit_symbol_universe_service.COIN_TO_NAME_KR",
-        {"BTC": "비트코인"},
-        raising=False,
     )
     analyzers = _patch_upbit_analyzer(monkeypatch, tradable=False)
 
@@ -75,29 +60,12 @@ def test_execute_buy_orders_task_no_tradable(monkeypatch):
     """매수 태스크가 거래 가능한 코인이 없으면 즉시 종료하는지 확인."""
     from app.jobs import analyze
 
-    async def fake_prime():
-        return None
-
     async def fake_fetch_my_coins():
         return [{"currency": "KRW", "balance": "100000"}]
 
     monkeypatch.setattr(
-        "app.services.upbit_symbol_universe_service.prime_upbit_constants",
-        fake_prime,
-    )
-    monkeypatch.setattr(
         "app.services.brokers.upbit.client.fetch_my_coins",
         fake_fetch_my_coins,
-    )
-    monkeypatch.setattr(
-        "app.services.upbit_symbol_universe_service.KRW_TRADABLE_COINS",
-        {"BTC"},
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "app.services.upbit_symbol_universe_service.COIN_TO_NAME_KR",
-        {"BTC": "비트코인"},
-        raising=False,
     )
     analyzers = _patch_upbit_analyzer(monkeypatch, tradable=False)
 
@@ -115,22 +83,15 @@ async def test_execute_buy_order_notifies_on_insufficient_balance(monkeypatch):
     """잔고 부족으로 매수 실패 시 텔레그램 알림을 보내는지 확인."""
     from app.jobs import analyze
 
-    async def fake_prime():
-        return None
-
     monkeypatch.setattr(
-        "app.services.upbit_symbol_universe_service.prime_upbit_constants",
-        fake_prime,
+        analyze,
+        "get_upbit_market_by_coin",
+        AsyncMock(return_value="KRW-BTC"),
     )
     monkeypatch.setattr(
-        "app.services.upbit_symbol_universe_service.KRW_TRADABLE_COINS",
-        {"BTC"},
-        raising=False,
-    )
-    monkeypatch.setattr(
-        "app.services.upbit_symbol_universe_service.COIN_TO_NAME_KR",
-        {"BTC": "비트코인"},
-        raising=False,
+        analyze,
+        "get_upbit_korean_name_by_coin",
+        AsyncMock(return_value="비트코인"),
     )
 
     async def fake_fetch_my_coins():
@@ -271,8 +232,9 @@ def test_run_per_coin_automation_success(monkeypatch):
     assert result["status"] == "completed"
     assert result["total_coins"] == 1
     assert result["success_coins"] == 1
-    assert len(result["results"]) == 1
-    coin_steps = result["results"][0]["steps"]
+    coin_results = cast(list[dict[str, Any]], result["results"])
+    assert len(coin_results) == 1
+    coin_steps = cast(list[dict[str, Any]], coin_results[0]["steps"])
     assert [step["step"] for step in coin_steps] == ["analysis", "buy", "sell"]
     assert all(step["result"]["status"] == "completed" for step in coin_steps)
     assert len(coin_steps) == 3

--- a/tests/test_upbit_orderbook_service.py
+++ b/tests/test_upbit_orderbook_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import httpx
@@ -75,11 +74,8 @@ async def test_fetch_orderbook_normalizes_symbol(monkeypatch):
 
     monkeypatch.setattr(
         upbit_orderbook,
-        "upbit_pairs",
-        SimpleNamespace(
-            prime_upbit_constants=AsyncMock(),
-            COIN_TO_PAIR={"BTC": "KRW-BTC"},
-        ),
+        "get_upbit_market_by_coin",
+        AsyncMock(return_value="KRW-BTC"),
     )
     monkeypatch.setattr(
         upbit_orderbook.httpx,
@@ -112,13 +108,17 @@ async def test_fetch_multiple_orderbooks_batches_and_deduplicates(monkeypatch):
         ),
     ]
 
+    async def fake_get_upbit_market_by_coin(currency: str) -> str:
+        return {
+            "BTC": "KRW-BTC",
+            "ETH": "KRW-ETH",
+            "XRP": "KRW-XRP",
+        }[currency]
+
     monkeypatch.setattr(
         upbit_orderbook,
-        "upbit_pairs",
-        SimpleNamespace(
-            prime_upbit_constants=AsyncMock(),
-            COIN_TO_PAIR={"BTC": "KRW-BTC", "ETH": "KRW-ETH", "XRP": "KRW-XRP"},
-        ),
+        "get_upbit_market_by_coin",
+        fake_get_upbit_market_by_coin,
     )
     monkeypatch.setattr(upbit_orderbook, "MAX_MARKETS_PER_REQUEST", 2)
     monkeypatch.setattr(
@@ -128,7 +128,7 @@ async def test_fetch_multiple_orderbooks_batches_and_deduplicates(monkeypatch):
     )
 
     result = await upbit_orderbook.fetch_multiple_orderbooks(
-        ["btc", "KRW-ETH", "xrp", "BTC", "NOT-A-MARKET"]
+        ["btc", "KRW-ETH", "xrp", "BTC"]
     )
 
     assert len(calls) == 2
@@ -151,13 +151,17 @@ async def test_fetch_multiple_orderbooks_returns_partial_on_429(monkeypatch):
         DummyResponse(429, []),
     ]
 
+    async def fake_get_upbit_market_by_coin(currency: str) -> str:
+        return {
+            "BTC": "KRW-BTC",
+            "ETH": "KRW-ETH",
+            "XRP": "KRW-XRP",
+        }[currency]
+
     monkeypatch.setattr(
         upbit_orderbook,
-        "upbit_pairs",
-        SimpleNamespace(
-            prime_upbit_constants=AsyncMock(),
-            COIN_TO_PAIR={"BTC": "KRW-BTC", "ETH": "KRW-ETH", "XRP": "KRW-XRP"},
-        ),
+        "get_upbit_market_by_coin",
+        fake_get_upbit_market_by_coin,
     )
     monkeypatch.setattr(upbit_orderbook, "MAX_MARKETS_PER_REQUEST", 2)
     monkeypatch.setattr(

--- a/tests/test_upbit_trading.py
+++ b/tests/test_upbit_trading.py
@@ -3,6 +3,8 @@ Tests covering the Upbit trading router endpoints.
 """
 
 from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -11,9 +13,6 @@ import pytest
 async def test_get_my_coins_success(monkeypatch):
     """보유 코인 조회가 정상 구조로 응답하는지 확인."""
     from app.routers import upbit_trading
-
-    async def fake_prime():
-        return None
 
     sample_coins = [
         {
@@ -63,10 +62,6 @@ async def test_get_my_coins_success(monkeypatch):
             return None  # No settings configured
 
     monkeypatch.setattr(
-        "app.services.upbit_symbol_universe_service.prime_upbit_constants",
-        fake_prime,
-    )
-    monkeypatch.setattr(
         "app.services.brokers.upbit.client.fetch_my_coins",
         fake_fetch_my_coins,
     )
@@ -75,14 +70,12 @@ async def test_get_my_coins_success(monkeypatch):
         fake_fetch_prices,
     )
     monkeypatch.setattr(
-        "app.services.upbit_symbol_universe_service.KRW_TRADABLE_COINS",
-        {"BTC"},
-        raising=False,
+        upbit_trading, "get_upbit_market_by_coin", AsyncMock(return_value="KRW-BTC")
     )
     monkeypatch.setattr(
-        "app.services.upbit_symbol_universe_service.COIN_TO_NAME_KR",
-        {"BTC": "비트코인"},
-        raising=False,
+        upbit_trading,
+        "get_upbit_korean_name_by_coin",
+        AsyncMock(return_value="비트코인"),
     )
     monkeypatch.setattr(
         upbit_trading,
@@ -100,7 +93,7 @@ async def test_get_my_coins_success(monkeypatch):
         DummySettingsService,
     )
 
-    response = await upbit_trading.get_my_coins(db=object())
+    response = await upbit_trading.get_my_coins(db=cast(Any, object()))
 
     assert response["success"] is True
     assert response["tradable_coins_count"] == 1

--- a/tests/test_upbit_websocket_monitor.py
+++ b/tests/test_upbit_websocket_monitor.py
@@ -22,10 +22,6 @@ async def test_main_captures_fatal_exception():
     with (
         patch("upbit_websocket_monitor.init_sentry") as mock_init_sentry,
         patch("upbit_websocket_monitor.capture_exception") as mock_capture_exception,
-        patch(
-            "upbit_websocket_monitor.upbit_pairs.prime_upbit_constants",
-            new=AsyncMock(),
-        ),
         patch("upbit_websocket_monitor.UpbitAnalyzer", return_value=mock_analyzer),
         patch(
             "upbit_websocket_monitor.UpbitOrderAnalysisService",

--- a/upbit_websocket_monitor.py
+++ b/upbit_websocket_monitor.py
@@ -9,7 +9,6 @@ import logging
 
 from app.analysis.service_analyzers import UpbitAnalyzer
 from app.monitoring.sentry import capture_exception, init_sentry
-from app.services import upbit_symbol_universe_service as upbit_pairs
 from app.services.upbit_websocket import UpbitOrderAnalysisService
 
 # 로깅 설정
@@ -22,9 +21,6 @@ logger = logging.getLogger(__name__)
 async def main():
     """메인 실행 함수"""
     init_sentry(service_name="auto-trader-upbit-ws")
-
-    # Upbit 상수 초기화
-    await upbit_pairs.prime_upbit_constants()
 
     # 분석기 초기화
     analyzer = UpbitAnalyzer()

--- a/websocket_monitor.py
+++ b/websocket_monitor.py
@@ -15,7 +15,6 @@ from typing import Any
 from app.core.config import settings
 from app.monitoring.sentry import capture_exception, init_sentry
 from app.monitoring.trade_notifier import get_trade_notifier
-from app.services import upbit_symbol_universe_service as upbit_pairs
 from app.services.fill_notification import (
     FillOrder,
     normalize_kis_fill,
@@ -160,7 +159,6 @@ class UnifiedWebSocketMonitor:
 
     async def _start_upbit(self) -> None:
         """Upbit WebSocket 시작"""
-        await upbit_pairs.prime_upbit_constants()
         self.upbit_ws = UpbitMyOrderWebSocket(
             on_order_callback=self._on_upbit_order,
             verify_ssl=False,


### PR DESCRIPTION
## Summary
- remove global Upbit lazy maps/constants and migrate to strict DB lookup APIs
- update runtime paths (routers/jobs/services/websocket) to use explicit lookup helpers
- migrate MCP/screenshot paths and tests to DB-backed symbol/name resolution
- add design doc for the migration plan

## Validation
- uv run pytest tests/test_upbit_symbol_universe_sync.py tests/test_upbit_orderbook_service.py tests/test_upbit_trading.py tests/test_tasks.py tests/test_daily_scan.py tests/test_screenshot_holdings_service_resolution.py tests/test_routers.py tests/test_upbit_websocket_monitor.py tests/test_mcp_server_tools.py -k "search_symbol or get_holdings or upbit or symbol_universe or daily_scan or tasks or routers" --no-cov -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Improvements**
  * Migrated symbol and market data resolution from cached maps to real-time database lookups, ensuring currency information is always current.
  
* **Reliability Enhancements**
  * Implemented stricter validation for cryptocurrency symbols and markets, with clearer error handling when symbols are inactive or unregistered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->