### PR TITLE
refactor(mcp): yfinance 동일 path 중복 호출 제거 (무캐시, 구조 개선)

### DIFF
--- a/app/mcp_server/tooling/analysis_screening.py
+++ b/app/mcp_server/tooling/analysis_screening.py
@@ -25,7 +25,11 @@ from app.mcp_server.tooling.fundamentals_sources_finnhub import (
     _fetch_company_profile_finnhub,
     _fetch_news_finnhub,
 )
+import pandas as pd
+import yfinance as yf
+
 from app.mcp_server.tooling.fundamentals_sources_naver import (
+    _YFinanceSnapshot,
     _fetch_investment_opinions_naver,
     _fetch_investment_opinions_yfinance,
     _fetch_news_naver,
@@ -34,6 +38,10 @@ from app.mcp_server.tooling.fundamentals_sources_naver import (
     _fetch_valuation_naver,
     _fetch_valuation_yfinance,
 )
+from app.mcp_server.tooling.market_data_indicators import (
+    _fetch_ohlcv_for_indicators,
+)
+from app.monitoring import build_yfinance_tracing_session
 from app.mcp_server.tooling.market_data_quotes import (
     _fetch_quote_crypto,
     _fetch_quote_equity_kr,
@@ -211,21 +219,23 @@ async def _get_indicators_impl(
     symbol: str,
     indicators: list[str],
     market: str | None = None,
+    preloaded_df: pd.DataFrame | None = None,
 ) -> dict[str, Any]:
     from app.mcp_server.tooling.portfolio_holdings import _get_indicators_impl as _impl
 
-    return await _impl(symbol, indicators, market)
+    return await _impl(symbol, indicators, market, preloaded_df=preloaded_df)
 
 
 async def _get_support_resistance_impl(
     symbol: str,
     market: str | None = None,
+    preloaded_df: pd.DataFrame | None = None,
 ) -> dict[str, Any]:
     from app.mcp_server.tooling.fundamentals_handlers import (
         _get_support_resistance_impl as _impl,
     )
 
-    return await _impl(symbol, market)
+    return await _impl(symbol, market, preloaded_df=preloaded_df)
 
 
 async def _analyze_stock_impl(
@@ -250,18 +260,25 @@ async def _analyze_stock_impl(
 
     tasks: list[asyncio.Task[Any]] = []
 
+    # Fetch OHLCV once for indicators and support/resistance (avoid duplicate fetch)
+    loop = asyncio.get_running_loop()
+    ohlcv_df = await _fetch_ohlcv_for_indicators(normalized_symbol, market_type, count=250)
+    # Use last 60 days for support/resistance (slice from the 250-day df)
+    ohlcv_60d = ohlcv_df.tail(60) if len(ohlcv_df) >= 60 else ohlcv_df
+
     quote_task = asyncio.create_task(_get_quote_impl(normalized_symbol, market_type))
     tasks.append(quote_task)
 
     indicators_task = asyncio.create_task(
         _get_indicators_impl(
-            normalized_symbol, ["rsi", "macd", "bollinger", "sma"], None
+            normalized_symbol, ["rsi", "macd", "bollinger", "sma"], None,
+            preloaded_df=ohlcv_df,
         ),
     )
     tasks.append(indicators_task)
 
     sr_task = asyncio.create_task(
-        _get_support_resistance_impl(normalized_symbol, None),
+        _get_support_resistance_impl(normalized_symbol, None, preloaded_df=ohlcv_60d),
     )
     tasks.append(sr_task)
 
@@ -282,8 +299,32 @@ async def _analyze_stock_impl(
         tasks.append(opinions_task)
 
     elif market_type == "equity_us":
+        # Collect yfinance snapshot once to avoid duplicate ticker.info calls
+        yf_session = build_yfinance_tracing_session()
+        yf_ticker = yf.Ticker(normalized_symbol, session=yf_session)
+
+        def _collect_yf_snapshot() -> _YFinanceSnapshot:
+            info = None
+            targets = None
+            ud = None
+            try:
+                info = yf_ticker.info
+            except Exception:
+                pass
+            try:
+                targets = yf_ticker.analyst_price_targets
+            except Exception:
+                pass
+            try:
+                ud = yf_ticker.upgrades_downgrades
+            except Exception:
+                pass
+            return _YFinanceSnapshot(info=info, analyst_price_targets=targets, upgrades_downgrades=ud)
+
+        yf_snapshot = await loop.run_in_executor(None, _collect_yf_snapshot)
+
         valuation_task = asyncio.create_task(
-            _fetch_valuation_yfinance(normalized_symbol),
+            _fetch_valuation_yfinance(normalized_symbol, snapshot=yf_snapshot, session=yf_session),
         )
         tasks.append(valuation_task)
 
@@ -298,7 +339,7 @@ async def _analyze_stock_impl(
         tasks.append(news_task)
 
         opinions_task = asyncio.create_task(
-            _fetch_investment_opinions_yfinance(normalized_symbol, 10),
+            _fetch_investment_opinions_yfinance(normalized_symbol, 10, snapshot=yf_snapshot, session=yf_session),
         )
         tasks.append(opinions_task)
 

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+
+import pandas as pd
 from typing import TYPE_CHECKING, Any
 
 from app.mcp_server.tooling.fundamentals_sources_binance import (
@@ -104,6 +106,7 @@ FUNDAMENTALS_TOOL_NAMES: set[str] = {
 async def _get_support_resistance_impl(
     symbol: str,
     market: str | None = None,
+    preloaded_df: pd.DataFrame | None = None,
 ) -> dict[str, Any]:
     """Get support/resistance zones from multi-indicator clustering."""
 
@@ -116,7 +119,11 @@ async def _get_support_resistance_impl(
     source = source_map[market_type]
 
     try:
-        df = await _fetch_ohlcv_for_indicators(normalized_symbol, market_type, count=60)
+        # Use preloaded OHLCV data if provided, otherwise fetch
+        if preloaded_df is not None and not preloaded_df.empty:
+            df = preloaded_df
+        else:
+            df = await _fetch_ohlcv_for_indicators(normalized_symbol, market_type, count=60)
         if df.empty:
             raise ValueError(f"No data available for symbol '{normalized_symbol}'")
 
@@ -128,10 +135,8 @@ async def _get_support_resistance_impl(
         fib_result = _calculate_fibonacci(df, current_price)
         fib_result["symbol"] = normalized_symbol
 
-        volume_profile_df = await _fetch_ohlcv_for_volume_profile(
-            normalized_symbol, market_type, 60
-        )
-        volume_result = _calculate_volume_profile(volume_profile_df, bins=20)
+        # Reuse the same OHLCV dataframe for volume profile (avoid duplicate fetch)
+        volume_result = _calculate_volume_profile(df, bins=20)
         volume_result["symbol"] = normalized_symbol
         volume_result["period_days"] = 60
 

--- a/app/mcp_server/tooling/fundamentals_sources_naver.py
+++ b/app/mcp_server/tooling/fundamentals_sources_naver.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import json
+from dataclasses import dataclass
 from typing import Any
 
 try:
@@ -27,6 +28,20 @@ from app.services.analyst_normalizer import (
     rating_to_bucket,
 )
 
+
+
+# ---------------------------------------------------------------------------
+# YFinance Snapshot (internal dedupe helper)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _YFinanceSnapshot:
+    """Internal container for yfinance data to avoid duplicate ticker.info calls."""
+
+    info: dict[str, Any] | None = None
+    analyst_price_targets: dict[str, Any] | None = None
+    upgrades_downgrades: Any = None  # DataFrame or None
 # ---------------------------------------------------------------------------
 # Local Parse/Normalize Helpers (kept here to avoid circular imports)
 # ---------------------------------------------------------------------------
@@ -425,10 +440,14 @@ async def _fetch_investment_opinions_naver(symbol: str, limit: int) -> dict[str,
 
 
 async def _fetch_investment_opinions_yfinance(
-    symbol: str, limit: int
+    symbol: str,
+    limit: int,
+    snapshot: _YFinanceSnapshot | None = None,
+    session: Any | None = None,
 ) -> dict[str, Any]:
     loop = asyncio.get_running_loop()
-    session = build_yfinance_tracing_session()
+    if session is None:
+        session = build_yfinance_tracing_session()
     ticker = yf.Ticker(symbol, session=session)
 
     def _collect() -> tuple[dict | None, Any, dict | None]:
@@ -451,7 +470,13 @@ async def _fetch_investment_opinions_yfinance(
             pass
         return targets, ud, info
 
-    targets, ud, info = await loop.run_in_executor(None, _collect)
+    # Use pre-fetched snapshot if available
+    if snapshot is not None:
+        targets = snapshot.analyst_price_targets
+        ud = snapshot.upgrades_downgrades
+        info = snapshot.info
+    else:
+        targets, ud, info = await loop.run_in_executor(None, _collect)
     current_price = (info or {}).get("currentPrice")
 
     if isinstance(targets, dict) and current_price is None:
@@ -525,11 +550,19 @@ async def _fetch_valuation_naver(symbol: str) -> dict[str, Any]:
     }
 
 
-async def _fetch_valuation_yfinance(symbol: str) -> dict[str, Any]:
+async def _fetch_valuation_yfinance(
+    symbol: str,
+    snapshot: _YFinanceSnapshot | None = None,
+    session: Any | None = None,
+) -> dict[str, Any]:
     loop = asyncio.get_running_loop()
-    session = build_yfinance_tracing_session()
+    if session is None:
+        session = build_yfinance_tracing_session()
     ticker = yf.Ticker(symbol, session=session)
-    info: dict[str, Any] = await loop.run_in_executor(None, lambda: ticker.info)
+    if snapshot is not None and snapshot.info is not None:
+        info = snapshot.info
+    else:
+        info: dict[str, Any] = await loop.run_in_executor(None, lambda: ticker.info)
 
     current_price = info.get("currentPrice")
     high_52w = info.get("fiftyTwoWeekHigh")
@@ -621,15 +654,38 @@ async def _fetch_sector_peers_us(
     client = _get_finnhub_client()
     upper_symbol = symbol.upper()
 
+    def get_base_ticker(ticker: str) -> str:
+        if "." in ticker:
+            return ticker.split(".")[0]
+        return ticker
+
     if manual_peers:
         peer_tickers = [t.upper() for t in manual_peers if t.upper() != upper_symbol]
-        peer_tickers = peer_tickers[:limit]
+        # Dedupe by base ticker BEFORE network call
+        target_base = get_base_ticker(upper_symbol)
+        seen_bases = {target_base}
+        deduped_peer_tickers = []
+        for ticker in peer_tickers:
+            peer_base = get_base_ticker(ticker)
+            if peer_base not in seen_bases:
+                seen_bases.add(peer_base)
+                deduped_peer_tickers.append(ticker)
+        peer_tickers = deduped_peer_tickers[:limit]
     else:
         peer_tickers: list[str] = await asyncio.to_thread(
             client.company_peers, upper_symbol
         )
         peer_tickers = [t for t in peer_tickers if t.upper() != upper_symbol]
-        peer_tickers = peer_tickers[: limit + 5]
+        # Dedupe by base ticker BEFORE network call
+        target_base = get_base_ticker(upper_symbol)
+        seen_bases = {target_base}
+        deduped_peer_tickers = []
+        for ticker in peer_tickers:
+            peer_base = get_base_ticker(ticker)
+            if peer_base not in seen_bases:
+                seen_bases.add(peer_base)
+                deduped_peer_tickers.append(ticker)
+        peer_tickers = deduped_peer_tickers[: limit + 5]
 
     all_tickers = [upper_symbol] + peer_tickers
 
@@ -671,16 +727,9 @@ async def _fetch_sector_peers_us(
         return ticker
 
     target_base = get_base_ticker(upper_symbol)
-    seen_bases = {target_base}
-    filtered_tickers = []
-    for ticker in peer_tickers:
-        peer_base = get_base_ticker(ticker)
-        if peer_base not in seen_bases:
-            seen_bases.add(peer_base)
-            filtered_tickers.append(ticker)
-
+    # Dedupe already applied before network call, use peer_tickers directly
     peers: list[dict[str, Any]] = []
-    for ticker in filtered_tickers:
+    for ticker in peer_tickers:
         info = info_map.get(ticker)
         if info is None:
             continue
@@ -855,4 +904,5 @@ __all__ = [
     "_fetch_valuation_yfinance",
     "_parse_naver_int",
     "_parse_naver_num",
+    "_YFinanceSnapshot",
 ]

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+
+import pandas as pd
 from typing import TYPE_CHECKING, Any, cast
 
 import app.services.brokers.upbit.client as upbit_service
@@ -526,6 +528,7 @@ async def _get_indicators_impl(
     symbol: str,
     indicators: list[str],
     market: str | None = None,
+    preloaded_df: pd.DataFrame | None = None,
 ) -> dict[str, Any]:
     symbol = (symbol or "").strip()
     if not symbol:
@@ -538,7 +541,11 @@ async def _get_indicators_impl(
     source = source_map[market_type]
 
     try:
-        df = await _fetch_ohlcv_for_indicators(symbol, market_type, count=250)
+        # Use preloaded OHLCV data if provided, otherwise fetch
+        if preloaded_df is not None and not preloaded_df.empty:
+            df = preloaded_df
+        else:
+            df = await _fetch_ohlcv_for_indicators(symbol, market_type, count=250)
         if df.empty:
             raise ValueError(f"No data available for symbol '{symbol}'")
 

--- a/tests/test_mcp_server_tools.py
+++ b/tests/test_mcp_server_tools.py
@@ -8718,3 +8718,186 @@ async def test_recommend_stocks_registration():
     """Test recommend_stocks tool is registered."""
     tools = build_tools()
     assert "recommend_stocks" in tools
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for yfinance dedupe (GH-8160)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_support_resistance_uses_single_ohlcv_fetch(monkeypatch):
+    """Verify get_support_resistance fetches OHLCV only once (not twice)."""
+    from app.mcp_server.tooling import fundamentals_handlers
+
+    tools = build_tools()
+    fetch_calls = []
+
+    async def mock_fetch_ohlcv(symbol, market_type, count):
+        fetch_calls.append((symbol, market_type, count))
+        return pd.DataFrame(
+            {
+                "date": pd.date_range("2024-01-01", periods=60, freq="D"),
+                "open": [100.0] * 60,
+                "high": [105.0] * 60,
+                "low": [95.0] * 60,
+                "close": [102.0] * 60,
+                "volume": [1000] * 60,
+            }
+        )
+
+    # Patch in fundamentals_handlers since that's where the import happens
+    monkeypatch.setattr(
+        fundamentals_handlers,
+        "_fetch_ohlcv_for_indicators",
+        mock_fetch_ohlcv,
+    )
+
+    result = await tools["get_support_resistance"]("AAPL", market="us")
+
+    # Should only fetch once, not twice
+    assert len(fetch_calls) == 1
+    assert fetch_calls[0][0] == "AAPL"
+    assert result["symbol"] == "AAPL"
+
+
+@pytest.mark.asyncio
+async def test_sector_peers_us_dedupes_before_network_call(monkeypatch):
+    """Verify sector_peers_us dedupes base tickers before fetching yfinance info."""
+    from app.mcp_server.tooling import fundamentals_sources_naver
+
+    tools = build_tools()
+    yf_info_calls = []
+
+    # Mock Finnhub client to return peers with duplicates
+    class MockFinnhubClient:
+        def company_peers(self, symbol):
+            # Return peers with same base ticker (e.g., BRK.B and BRK.A)
+            return ["AAPL", "BRK.B", "BRK.A", "MSFT"]
+
+    monkeypatch.setattr(
+        fundamentals_sources_naver,
+        "_get_finnhub_client",
+        MockFinnhubClient,
+    )
+
+    def mock_yf_ticker(symbol, session=None):
+        calls = {"symbol": symbol}
+
+        class MockTicker:
+            @property
+            def info(self):
+                yf_info_calls.append(symbol)
+                return {
+                    "shortName": f"{symbol} Inc",
+                    "currentPrice": 100.0,
+                    "previousClose": 99.0,
+                    "trailingPE": 15.0,
+                    "priceToBook": 2.0,
+                    "marketCap": 1000000000,
+                    "industry": "Tech",
+                }
+
+        return MockTicker()
+
+    monkeypatch.setattr(fundamentals_sources_naver.yf, "Ticker", mock_yf_ticker)
+
+    result = await tools["get_sector_peers"]("TEST", market="us", limit=5)
+
+    # BRK.B and BRK.A share base ticker "BRK", so only one should be fetched
+    # Total calls: 1 for target (TEST) + deduped peers (AAPL, BRK.B or BRK.A, MSFT)
+    assert len(yf_info_calls) <= 4  # TEST + AAPL + (BRK.B or BRK.A) + MSFT
+    assert "BRK.B" not in yf_info_calls or "BRK.A" not in yf_info_calls
+
+
+@pytest.mark.asyncio
+async def test_analyze_stock_us_reuses_yfinance_info(monkeypatch):
+    """Verify analyze_stock(US) fetches ticker.info only once for valuation+opinions."""
+    from app.mcp_server.tooling import fundamentals_sources_naver
+
+    tools = build_tools()
+    yf_info_calls = []
+
+    # Mock OHLCV fetch for indicators and support/resistance
+    async def mock_fetch_ohlcv(symbol, market_type, count):
+        return pd.DataFrame(
+            {
+                "date": pd.date_range("2024-01-01", periods=250, freq="D"),
+                "open": [100.0] * 250,
+                "high": [105.0] * 250,
+                "low": [95.0] * 250,
+                "close": [102.0] * 250,
+                "volume": [1000] * 250,
+            }
+        )
+
+    monkeypatch.setattr(
+        market_data_indicators,
+        "_fetch_ohlcv_for_indicators",
+        mock_fetch_ohlcv,
+    )
+
+    # Mock KIS client
+    class MockKISClient:
+        pass
+
+    _patch_runtime_attr(monkeypatch, "KISClient", MockKISClient)
+
+    # Mock yfinance to count info calls
+    original_ticker = fundamentals_sources_naver.yf.Ticker
+
+    def mock_yf_ticker(symbol, session=None):
+        class MockTicker:
+            @property
+            def info(self):
+                yf_info_calls.append(f"info:{symbol}")
+                return {
+                    "shortName": f"{symbol} Inc",
+                    "currentPrice": 150.0,
+                    "fiftyTwoWeekHigh": 200.0,
+                    "fiftyTwoWeekLow": 100.0,
+                    "trailingPE": 25.0,
+                    "priceToBook": 5.0,
+                    "returnOnEquity": 0.15,
+                    "dividendYield": 0.01,
+                }
+
+            @property
+            def analyst_price_targets(self):
+                return {"mean": 180.0, "median": 175.0, "low": 150.0, "high": 200.0}
+
+            @property
+            def upgrades_downgrades(self):
+                return pd.DataFrame()
+
+        return MockTicker()
+
+    monkeypatch.setattr(fundamentals_sources_naver.yf, "Ticker", mock_yf_ticker)
+
+    # Mock Finnhub for profile and news
+    class MockFinnhubClient:
+        def company_profile2(self, symbol):
+            return {"name": f"{symbol} Inc", "ticker": symbol}
+
+        def general_news(self, category, min_id=0):
+            return []
+
+        def company_news(self, symbol, _from, to):
+            return []
+
+    monkeypatch.setattr(
+        fundamentals_sources_naver,
+        "_get_finnhub_client",
+        MockFinnhubClient,
+    )
+
+    # Run analyze_stock for US market
+    result = await tools["analyze_stock"]("AAPL", market="us")
+
+    # ticker.info should be called only once (via snapshot) for both valuation and opinions
+    info_calls = [c for c in yf_info_calls if c.startswith("info:")]
+    assert len(info_calls) == 1, f"Expected 1 info call, got {len(info_calls)}: {info_calls}"
+
+    assert result["symbol"] == "AAPL"
+    assert "valuation" in result
+    assert "opinions" in result


### PR DESCRIPTION
## 요약
`yfinance` 경로에서 **동일 요청 내 중복 네트워크 호출**을 구조적으로 제거합니다. 캐시 없이 구조 개선만 수행합니다.

## 확인된 중복 근거
1. `analyze_stock(us)` 1회에서 `ticker.info` 2회 호출
2. `analyze_stock(us)` 1회에서 OHLCV fetch 3회 호출
3. `get_support_resistance` 내부에서 동일 60일 OHLCV를 2회 fetch
4. `sector_peers_us`는 dedupe 이전에 `info` fetch를 수행해 불필요 호출 가능

## 변경 사항

### 1단계 (핵심 중복 제거)
- ✅ **YFinanceSnapshot 데이터클래스 추가** (`fundamentals_sources_naver.py`)
- ✅ **_fetch_valuation_yfinance에 snapshot/session optional 인자 추가**
- ✅ **_fetch_investment_opinions_yfinance에 snapshot/session optional 인자 추가**
- ✅ **_analyze_stock_impl(US)에서 snapshot 1회 수집 후 전달** (`analysis_screening.py`)
- ✅ **_get_support_resistance_impl에서 OHLCV 중복 fetch 제거** (`fundamentals_handlers.py`)

### 2단계 (전체 yfinance 경로 확장)
- ✅ **_get_indicators_impl에 preloaded_df optional 인자 추가** (`portfolio_holdings.py`)
- ✅ **_get_support_resistance_impl에 preloaded_df optional 인자 추가** (`fundamentals_handlers.py`)
- ✅ **_analyze_stock_impl에서 OHLCV 1회 fetch 후 지표/지지저항 공유**
- ✅ **_fetch_sector_peers_us dedupe를 네트워크 호출 이전으로 이동**

## 성능 개선
| 경로 | 변경 전 | 변경 후 |
|------|---------|---------|
| analyze_stock(US) ticker.info 호출 | 2회 | 1회 |
| get_support_resistance OHLCV fetch | 2회 | 1회 |
| analyze_stock OHLCV fetch | 3회 | 1회 |

## 공개 API/인터페이스 변경 사항
- MCP public tool 이름/파라미터/응답 필드: **변경 없음**
- 내부 함수 시그니처(비공개)만 optional 인자 추가

## 테스트
### 추가된 회귀 테스트
1. ✅ `test_get_support_resistance_uses_single_ohlcv_fetch` - OHLCV 1회만 fetch 검증
2. ✅ `test_sector_peers_us_dedupes_before_network_call` - dedupe 선적용 검증
3. ✅ `test_analyze_stock_us_reuses_yfinance_info` - ticker.info 1회만 호출 검증

### 검증 결과
```
342 passed, 4 warnings in 17.21s
```

## 제약 사항
- 캐시(TTL/전역/요청간) 도입 없음, 구조 개선만 수행
- Sentry `search_events` 불가/로그인 제한 때문에 trace 세부 path 집계는 코드+로컬 계측 근거로 진행

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized data fetching by reusing market data across multiple analysis operations, reducing redundant network calls.
  * Implemented intelligent deduplication of related ticker symbols to minimize duplicate lookups.
  * Enhanced support/resistance and indicator calculations to leverage preloaded historical data for faster processing.

* **Tests**
  * Added regression tests verifying single-fetch optimization and data deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->