### PR TITLE
fix: harden websocket monitor health and reconnect behavior

### DIFF
--- a/app/services/upbit_websocket.py
+++ b/app/services/upbit_websocket.py
@@ -5,7 +5,8 @@ import json
 import logging
 import ssl
 import uuid
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 import jwt
 from websockets.exceptions import ConnectionClosed, WebSocketException
@@ -24,7 +25,9 @@ class UpbitMyOrderWebSocket:
     """업비트 내 주문 및 체결 WebSocket 클라이언트"""
 
     def __init__(
-        self, on_order_callback: Callable | None = None, verify_ssl: bool = False
+        self,
+        on_order_callback: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+        verify_ssl: bool = False,
     ):
         """
         Args:
@@ -40,6 +43,7 @@ class UpbitMyOrderWebSocket:
         self.reconnect_delay = 5  # 재연결 대기 시간 (초)
         self.max_reconnect_attempts = 10
         self.current_attempt = 0
+        self.auth_token: str | None = None
 
     def _create_ssl_context(self):
         """SSL 컨텍스트 생성"""
@@ -72,7 +76,7 @@ class UpbitMyOrderWebSocket:
             logger.error(f"JWT 토큰 생성 실패: {e}")
             return None
 
-    async def connect_and_subscribe(self, coin_pairs: list | None = None):
+    async def connect_and_subscribe(self, coin_pairs: list[str] | None = None):
         """
         WebSocket 연결 및 구독 시작
 
@@ -83,6 +87,8 @@ class UpbitMyOrderWebSocket:
         while self.current_attempt < self.max_reconnect_attempts:
             try:
                 await self._connect_and_subscribe_internal(coin_pairs)
+                if not self.is_connected:
+                    raise RuntimeError("Upbit WebSocket connection not established")
                 # 성공적으로 연결된 경우 재시도 카운터 초기화
                 self.current_attempt = 0
                 break
@@ -101,7 +107,15 @@ class UpbitMyOrderWebSocket:
                 logger.info(f"{self.reconnect_delay}초 후 재연결을 시도합니다...")
                 await asyncio.sleep(self.reconnect_delay)
 
-    async def _connect_and_subscribe_internal(self, coin_pairs: list | None = None):
+        if not self.is_connected:
+            raise RuntimeError(
+                "Upbit WebSocket connection not established "
+                f"({self.current_attempt}/{self.max_reconnect_attempts})"
+            )
+
+    async def _connect_and_subscribe_internal(
+        self, coin_pairs: list[str] | None = None
+    ):
         """내부 연결 및 구독 로직"""
         logger.info("업비트 MyOrder WebSocket 연결을 시작합니다...")
 
@@ -143,10 +157,12 @@ class UpbitMyOrderWebSocket:
         # 메시지 수신 루프 시작
         await self._listen_for_messages()
 
-    def _create_subscribe_message(self, coin_pairs: list | None = None) -> list:
+    def _create_subscribe_message(
+        self, coin_pairs: list[str] | None = None
+    ) -> list[dict[str, Any]]:
         """구독 메시지 생성"""
         # 기본 메시지 구조
-        message = [
+        message: list[dict[str, Any]] = [
             {
                 "ticket": str(uuid.uuid4())  # 고유 티켓 ID
             },
@@ -238,7 +254,9 @@ class UpbitOrderAnalysisService:
     """업비트 주문/체결 데이터 기반 자동 분석 서비스"""
 
     def __init__(
-        self, analyzer_callback: Callable | None = None, verify_ssl: bool = False
+        self,
+        analyzer_callback: Callable[[str], Awaitable[None]] | None = None,
+        verify_ssl: bool = False,
     ):
         """
         Args:
@@ -251,7 +269,7 @@ class UpbitOrderAnalysisService:
         self.websocket_client = None
         self.is_running = False
 
-    async def start_monitoring(self, coin_pairs: list | None = None):
+    async def start_monitoring(self, coin_pairs: list[str] | None = None):
         """모니터링 시작"""
         if self.is_running:
             logger.warning("이미 모니터링이 실행 중입니다.")
@@ -286,7 +304,7 @@ class UpbitOrderAnalysisService:
             await self.websocket_client.disconnect()
             self.websocket_client = None
 
-    async def _handle_order_data(self, order_data: dict):
+    async def _handle_order_data(self, order_data: dict[str, Any]):
         """주문/체결 데이터 처리"""
         try:
             # 체결 상태인 경우에만 분석 수행

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -116,12 +116,17 @@ services:
     command: [ "python", "websocket_monitor.py", "--mode", "upbit" ]
     env_file:
       - .env.prod
+    environment:
+      WS_MONITOR_HEARTBEAT_PATH: ${WS_MONITOR_HEARTBEAT_PATH:-/tmp/websocket_monitor_heartbeat.json}
+      WS_MONITOR_HEARTBEAT_INTERVAL_SECONDS: ${WS_MONITOR_HEARTBEAT_INTERVAL_SECONDS:-5}
+      WS_MONITOR_RECONNECT_DELAY_SECONDS: ${WS_MONITOR_RECONNECT_DELAY_SECONDS:-5}
+      WS_MONITOR_EXPECT_MODE: upbit
     depends_on:
       - api
     restart: unless-stopped
     network_mode: host # Host 네트워크 사용으로 localhost DB/Redis 접근
     healthcheck:
-      test: [ "CMD", "pgrep", "-f", "websocket_monitor.py --mode upbit" ]
+      test: [ "CMD", "python", "scripts/websocket_healthcheck.py" ]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -134,19 +139,23 @@ services:
         reservations:
           memory: 128M
           cpus: '0.125'
-
   kis_websocket:
     image: ghcr.io/${GITHUB_REPOSITORY}:production
     container_name: auto_trader_kis_ws_prod
     command: [ "python", "websocket_monitor.py", "--mode", "kis" ]
     env_file:
       - .env.prod
+    environment:
+      WS_MONITOR_HEARTBEAT_PATH: ${WS_MONITOR_HEARTBEAT_PATH:-/tmp/websocket_monitor_heartbeat.json}
+      WS_MONITOR_HEARTBEAT_INTERVAL_SECONDS: ${WS_MONITOR_HEARTBEAT_INTERVAL_SECONDS:-5}
+      WS_MONITOR_RECONNECT_DELAY_SECONDS: ${WS_MONITOR_RECONNECT_DELAY_SECONDS:-5}
+      WS_MONITOR_EXPECT_MODE: kis
     depends_on:
       - api
     restart: unless-stopped
     network_mode: host # Host 네트워크 사용으로 localhost DB/Redis 접근
     healthcheck:
-      test: [ "CMD", "pgrep", "-f", "websocket_monitor.py --mode kis" ]
+      test: [ "CMD", "python", "scripts/websocket_healthcheck.py" ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/scripts/websocket_healthcheck.py
+++ b/scripts/websocket_healthcheck.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+WebSocket Monitor Healthcheck Script.
+
+Checks heartbeat file for websocket monitor health status.
+Used by Docker healthcheck to determine container health.
+
+Exit codes:
+  0: Healthy (heartbeat fresh, running, connected)
+  1: Unhealthy (missing/stale heartbeat, not running, not connected)
+
+Environment variables:
+  WS_MONITOR_HEARTBEAT_PATH: Path to heartbeat JSON file
+    (default: /tmp/websocket_monitor_heartbeat.json)
+  WS_MONITOR_EXPECT_MODE: Expected mode ("upbit", "kis", or "both")
+    (default: both)
+  WS_MONITOR_HEARTBEAT_STALE_SECONDS: Seconds before heartbeat considered stale
+    (default: 90)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+# Default configuration
+DEFAULT_HEARTBEAT_PATH = "/tmp/websocket_monitor_heartbeat.json"
+DEFAULT_STALE_SECONDS = 90.0
+FUTURE_SKEW_TOLERANCE_SECONDS = 1.0
+
+
+def get_config() -> tuple[str, str, float]:
+    """Get configuration from environment variables."""
+    heartbeat_path = os.environ.get("WS_MONITOR_HEARTBEAT_PATH", DEFAULT_HEARTBEAT_PATH)
+    expect_mode = os.environ.get("WS_MONITOR_EXPECT_MODE", "both")
+    stale_seconds = float(
+        os.environ.get("WS_MONITOR_HEARTBEAT_STALE_SECONDS", str(DEFAULT_STALE_SECONDS))
+    )
+    return heartbeat_path, expect_mode, stale_seconds
+
+
+def check_health() -> tuple[bool, str]:
+    """
+    Check websocket monitor health based on heartbeat file.
+
+    Returns:
+        Tuple of (is_healthy, error_message)
+    """
+    heartbeat_path, expect_mode, stale_seconds = get_config()
+    path = Path(heartbeat_path)
+
+    # Check file exists
+    if not path.exists():
+        return False, f"Heartbeat file not found: {heartbeat_path}"
+
+    # Read and parse JSON
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        return False, f"Failed to parse heartbeat JSON: {e}"
+    except OSError as e:
+        return False, f"Failed to read heartbeat file: {e}"
+
+    # Check required fields
+    required_fields = ["updated_at_unix", "mode", "is_running"]
+    for field in required_fields:
+        if field not in data:
+            return False, f"Missing required field in heartbeat: {field}"
+
+    # Check staleness
+    updated_at = float(data["updated_at_unix"])
+    age_seconds = time.time() - updated_at
+    if age_seconds < -FUTURE_SKEW_TOLERANCE_SECONDS:
+        return False, f"Heartbeat timestamp is in the future (age={age_seconds:.1f}s)"
+    if age_seconds > stale_seconds:
+        return False, (
+            f"Heartbeat is stale (age={age_seconds:.1f}s, threshold={stale_seconds}s)"
+        )
+
+    # Check is_running
+    if not data["is_running"]:
+        return False, "Monitor is not running (is_running=false)"
+
+    # Check mode match
+    actual_mode = data["mode"]
+    if expect_mode != "both" and actual_mode != expect_mode:
+        return False, f"Mode mismatch: expected={expect_mode}, actual={actual_mode}"
+
+    # Check connection status based on expected mode
+    if expect_mode in ("kis", "both"):
+        kis_connected = data.get("kis_connected", "n/a")
+        if kis_connected is not True:
+            return False, f"KIS not connected: {kis_connected}"
+
+    if expect_mode in ("upbit", "both"):
+        upbit_connected = data.get("upbit_connected", "n/a")
+        if upbit_connected is not True:
+            return False, f"Upbit not connected: {upbit_connected}"
+
+    return True, f"Healthy (mode={actual_mode}, age={age_seconds:.1f}s)"
+
+
+def main() -> int:
+    """Main entry point."""
+    is_healthy, message = check_health()
+
+    if is_healthy:
+        print(f"OK: {message}")
+        return 0
+    else:
+        print(f"FAIL: {message}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_upbit_websocket_service.py
+++ b/tests/test_upbit_websocket_service.py
@@ -31,6 +31,7 @@ class TestUpbitMyOrderWebSocket:
         ):
             await client._connect_and_subscribe_internal()
 
+        assert mock_connect.await_args is not None
         kwargs = mock_connect.await_args.kwargs
         assert kwargs["additional_headers"] == {
             "Authorization": "Bearer token-123",
@@ -54,3 +55,27 @@ class TestUpbitMyOrderWebSocket:
                 await client._connect_and_subscribe_internal()
 
         mock_connect.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_connect_and_subscribe_raises_after_max_attempts(self):
+        client = UpbitMyOrderWebSocket()
+        client.max_reconnect_attempts = 3
+        client.reconnect_delay = 0
+
+        failure = RuntimeError("simulated connection failure")
+
+        with patch.object(
+            client,
+            "_connect_and_subscribe_internal",
+            new=AsyncMock(side_effect=failure),
+        ) as connect_mock:
+            with pytest.raises(
+                RuntimeError,
+                match="Upbit WebSocket connection not established",
+            ) as exc_info:
+                await client.connect_and_subscribe()
+
+        assert connect_mock.await_count == 3
+        assert client.current_attempt == client.max_reconnect_attempts
+        assert client.is_connected is False
+        assert "3/3" in str(exc_info.value)

--- a/tests/test_websocket_healthcheck.py
+++ b/tests/test_websocket_healthcheck.py
@@ -1,0 +1,269 @@
+"""Tests for websocket healthcheck script."""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def run_healthcheck(
+    heartbeat_path: str,
+    expect_mode: str | None = "kis",
+    stale_seconds: float = 90,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run healthcheck script with given parameters."""
+    script_path = Path(__file__).parent.parent / "scripts" / "websocket_healthcheck.py"
+    full_env = os.environ.copy()
+    full_env.update(
+        {
+            "WS_MONITOR_HEARTBEAT_PATH": heartbeat_path,
+            "WS_MONITOR_HEARTBEAT_STALE_SECONDS": str(stale_seconds),
+        }
+    )
+    if expect_mode is not None:
+        full_env["WS_MONITOR_EXPECT_MODE"] = expect_mode
+    else:
+        full_env.pop("WS_MONITOR_EXPECT_MODE", None)
+    if env:
+        full_env.update(env)
+
+    return subprocess.run(
+        [sys.executable, str(script_path)],
+        capture_output=True,
+        text=True,
+        env=full_env,
+    )
+
+
+def write_heartbeat(
+    path: str,
+    *,
+    updated_at_unix: float | None = None,
+    mode: str = "kis",
+    is_running: bool = True,
+    upbit_connected: bool | str = "n/a",
+    kis_connected: bool | str = True,
+) -> None:
+    """Write a heartbeat file with given values."""
+    if updated_at_unix is None:
+        updated_at_unix = time.time()
+
+    data = {
+        "updated_at_unix": updated_at_unix,
+        "mode": mode,
+        "is_running": is_running,
+        "upbit_connected": upbit_connected,
+        "kis_connected": kis_connected,
+    }
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f)
+
+
+class TestWebsocketHealthcheck:
+    """Healthcheck script behavior tests."""
+
+    def test_pass_fresh_heartbeat_kis_connected(self, tmp_path: Path) -> None:
+        """Should pass with fresh heartbeat and KIS connected."""
+        heartbeat_path = str(tmp_path / "heartbeat.json")
+        write_heartbeat(
+            heartbeat_path,
+            mode="kis",
+            is_running=True,
+            kis_connected=True,
+        )
+
+        result = run_healthcheck(heartbeat_path, expect_mode="kis")
+
+        assert result.returncode == 0, f"Expected pass, got: {result.stderr}"
+
+    def test_pass_fresh_heartbeat_upbit_connected(self, tmp_path: Path) -> None:
+        """Should pass with fresh heartbeat and Upbit connected."""
+        heartbeat_path = str(tmp_path / "heartbeat.json")
+        write_heartbeat(
+            heartbeat_path,
+            mode="upbit",
+            is_running=True,
+            upbit_connected=True,
+            kis_connected="n/a",
+        )
+
+        result = run_healthcheck(heartbeat_path, expect_mode="upbit")
+
+        assert result.returncode == 0, f"Expected pass, got: {result.stderr}"
+
+    def test_fail_missing_heartbeat_file(self, tmp_path: Path) -> None:
+        """Should fail when heartbeat file doesn't exist."""
+        heartbeat_path = str(tmp_path / "nonexistent.json")
+
+        result = run_healthcheck(heartbeat_path, expect_mode="kis")
+
+        assert result.returncode == 1
+        assert "not found" in result.stderr.lower()
+
+    def test_fail_stale_heartbeat(self, tmp_path: Path) -> None:
+        """Should fail when heartbeat is too old."""
+        heartbeat_path = str(tmp_path / "heartbeat.json")
+        # Write heartbeat that's 120 seconds old (stale by default 90s)
+        write_heartbeat(
+            heartbeat_path,
+            updated_at_unix=time.time() - 120,
+            mode="kis",
+            is_running=True,
+            kis_connected=True,
+        )
+
+        result = run_healthcheck(heartbeat_path, expect_mode="kis", stale_seconds=90)
+
+        assert result.returncode == 1
+        assert "stale" in result.stderr.lower()
+
+    def test_fail_future_heartbeat_timestamp(self, tmp_path: Path) -> None:
+        heartbeat_path = str(tmp_path / "heartbeat.json")
+        write_heartbeat(
+            heartbeat_path,
+            updated_at_unix=time.time() + 120,
+            mode="kis",
+            is_running=True,
+            kis_connected=True,
+        )
+
+        result = run_healthcheck(heartbeat_path, expect_mode="kis")
+
+        assert result.returncode == 1
+        assert "future" in result.stderr.lower()
+
+    def test_pass_small_future_skew_within_tolerance(self, tmp_path: Path) -> None:
+        heartbeat_path = str(tmp_path / "heartbeat.json")
+        write_heartbeat(
+            heartbeat_path,
+            updated_at_unix=time.time() + 0.5,
+            mode="kis",
+            is_running=True,
+            kis_connected=True,
+        )
+
+        result = run_healthcheck(heartbeat_path, expect_mode="kis")
+
+        assert result.returncode == 0
+
+    def test_fail_not_running(self, tmp_path: Path) -> None:
+        """Should fail when is_running is False."""
+        heartbeat_path = str(tmp_path / "heartbeat.json")
+        write_heartbeat(
+            heartbeat_path,
+            mode="kis",
+            is_running=False,
+            kis_connected=True,
+        )
+
+        result = run_healthcheck(heartbeat_path, expect_mode="kis")
+
+        assert result.returncode == 1
+        assert "not running" in result.stderr.lower()
+
+    def test_fail_mode_mismatch(self, tmp_path: Path) -> None:
+        """Should fail when mode doesn't match expected."""
+        heartbeat_path = str(tmp_path / "heartbeat.json")
+        write_heartbeat(
+            heartbeat_path,
+            mode="upbit",
+            is_running=True,
+            upbit_connected=True,
+            kis_connected="n/a",
+        )
+
+        result = run_healthcheck(heartbeat_path, expect_mode="kis")
+
+        assert result.returncode == 1
+        assert "mode" in result.stderr.lower()
+
+    def test_fail_not_connected(self, tmp_path: Path) -> None:
+        """Should fail when expected connection is not established."""
+        heartbeat_path = str(tmp_path / "heartbeat.json")
+        write_heartbeat(
+            heartbeat_path,
+            mode="kis",
+            is_running=True,
+            kis_connected=False,
+        )
+
+        result = run_healthcheck(heartbeat_path, expect_mode="kis")
+
+        assert result.returncode == 1
+        assert "not connected" in result.stderr.lower()
+
+    def test_fail_invalid_json(self, tmp_path: Path) -> None:
+        """Should fail when heartbeat file has invalid JSON."""
+        heartbeat_path = str(tmp_path / "heartbeat.json")
+        Path(heartbeat_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(heartbeat_path, "w") as f:
+            f.write("{ invalid json }")
+
+        result = run_healthcheck(heartbeat_path, expect_mode="kis")
+
+        assert result.returncode == 1
+        assert "parse" in result.stderr.lower() or "json" in result.stderr.lower()
+
+    def test_pass_custom_stale_threshold(self, tmp_path: Path) -> None:
+        """Should pass with custom stale threshold."""
+        heartbeat_path = str(tmp_path / "heartbeat.json")
+        # 50 seconds old, stale threshold 60
+        write_heartbeat(
+            heartbeat_path,
+            updated_at_unix=time.time() - 50,
+            mode="kis",
+            is_running=True,
+            kis_connected=True,
+        )
+
+        result = run_healthcheck(heartbeat_path, expect_mode="kis", stale_seconds=60)
+
+        assert result.returncode == 0
+
+    def test_pass_both_mode_checks_relevant_connection(self, tmp_path: Path) -> None:
+        """For mode=both, should check both connections."""
+        heartbeat_path = str(tmp_path / "heartbeat.json")
+        write_heartbeat(
+            heartbeat_path,
+            mode="both",
+            is_running=True,
+            upbit_connected=True,
+            kis_connected=True,
+        )
+
+        # When expecting both, both should be connected
+        result = run_healthcheck(heartbeat_path, expect_mode="both")
+        assert result.returncode == 0
+
+    def test_fail_both_mode_one_disconnected(self, tmp_path: Path) -> None:
+        """For mode=both, should fail if either is disconnected."""
+        heartbeat_path = str(tmp_path / "heartbeat.json")
+        write_heartbeat(
+            heartbeat_path,
+            mode="both",
+            is_running=True,
+            upbit_connected=True,
+            kis_connected=False,
+        )
+
+        result = run_healthcheck(heartbeat_path, expect_mode="both")
+        assert result.returncode == 1
+
+    def test_pass_default_expect_mode_when_heartbeat_mode_is_both(
+        self, tmp_path: Path
+    ) -> None:
+        heartbeat_path = str(tmp_path / "heartbeat.json")
+        write_heartbeat(
+            heartbeat_path,
+            mode="both",
+            is_running=True,
+            upbit_connected=True,
+            kis_connected=True,
+        )
+
+        result = run_healthcheck(heartbeat_path, expect_mode=None)
+        assert result.returncode == 0, f"Expected pass, got: {result.stderr}"

--- a/tests/test_websocket_monitor.py
+++ b/tests/test_websocket_monitor.py
@@ -365,3 +365,176 @@ class TestUnifiedWebSocketMonitor:
         notifier.shutdown.assert_awaited_once()
         monitor.start.assert_awaited_once()
         monitor.stop.assert_awaited_once()
+
+
+class TestHeartbeat:
+    """Tests for heartbeat file writing."""
+
+    def test_write_heartbeat_creates_file(self, mock_settings: None, tmp_path) -> None:
+        """Test that _write_heartbeat creates heartbeat file."""
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        heartbeat_file = tmp_path / "heartbeat.json"
+        monitor = UnifiedWebSocketMonitor()
+        monitor._heartbeat_path = str(heartbeat_file)
+        monitor._write_heartbeat()
+
+        assert heartbeat_file.exists()
+
+    def test_write_heartbeat_content(self, mock_settings: None, tmp_path) -> None:
+        """Test that _write_heartbeat writes correct content."""
+        import json
+        import time
+
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        heartbeat_file = tmp_path / "heartbeat.json"
+        monitor = UnifiedWebSocketMonitor(mode="both")
+        monitor._heartbeat_path = str(heartbeat_file)
+        monitor._write_heartbeat()
+
+        with open(heartbeat_file) as f:
+            data = json.load(f)
+
+        assert "updated_at_unix" in data
+        assert data["mode"] == "both"
+        assert data["is_running"] is False  # Default
+        assert data["upbit_connected"] is False
+        assert data["kis_connected"] is False
+        # Verify timestamp is recent
+        assert time.time() - data["updated_at_unix"] < 2
+
+    def test_write_heartbeat_with_override(self, mock_settings: None, tmp_path) -> None:
+        """Test that _write_heartbeat respects is_running override."""
+        import json
+
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        heartbeat_file = tmp_path / "heartbeat.json"
+        monitor = UnifiedWebSocketMonitor()
+        monitor._heartbeat_path = str(heartbeat_file)
+        monitor._write_heartbeat(is_running=True)
+
+        with open(heartbeat_file) as f:
+            data = json.load(f)
+
+        assert data["is_running"] is True
+
+    def test_write_heartbeat_mode_upbit(self, mock_settings: None, tmp_path) -> None:
+        """Test heartbeat shows correct connection status for upbit mode."""
+        import json
+
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        heartbeat_file = tmp_path / "heartbeat.json"
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+        monitor._heartbeat_path = str(heartbeat_file)
+        monitor._write_heartbeat()
+
+        with open(heartbeat_file) as f:
+            data = json.load(f)
+
+        assert data["mode"] == "upbit"
+        assert data["upbit_connected"] is False
+        assert data["kis_connected"] == "n/a"
+
+    def test_write_heartbeat_creates_parent_dir(
+        self, mock_settings: None, tmp_path
+    ) -> None:
+        """Test that _write_heartbeat creates parent directories."""
+        import json
+
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        heartbeat_file = tmp_path / "nested" / "dir" / "heartbeat.json"
+        monitor = UnifiedWebSocketMonitor()
+        monitor._heartbeat_path = str(heartbeat_file)
+        monitor._write_heartbeat()
+
+        assert heartbeat_file.exists()
+        with open(heartbeat_file) as f:
+            data = json.load(f)
+        assert "updated_at_unix" in data
+
+
+class TestAutoReconnect:
+    """Tests for auto-reconnect supervisor behavior."""
+
+    def test_reconnect_delay_configurable(self, mock_settings: None) -> None:
+        """Test that reconnect delay is configurable."""
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+        monitor._reconnect_delay_seconds = 5.0
+
+        assert monitor._reconnect_delay_seconds == 5.0
+
+    def test_heartbeat_path_configurable(
+        self, mock_settings: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that heartbeat path is configurable via environment."""
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monkeypatch.setenv("WS_MONITOR_HEARTBEAT_PATH", "/custom/heartbeat.json")
+        monitor = UnifiedWebSocketMonitor()
+        assert monitor._heartbeat_path == "/custom/heartbeat.json"
+
+    def test_heartbeat_interval_configurable(
+        self, mock_settings: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that heartbeat interval is configurable via environment."""
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monkeypatch.setenv("WS_MONITOR_HEARTBEAT_INTERVAL_SECONDS", "30")
+        monitor = UnifiedWebSocketMonitor()
+        assert monitor._heartbeat_interval_seconds == 30.0
+
+    @pytest.mark.asyncio
+    async def test_supervisor_exits_on_stop_before_start(
+        self, mock_settings: None
+    ) -> None:
+        """Test that supervisor exits immediately when is_running is False."""
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+        monitor.is_running = False
+
+        # Should exit immediately without attempting connection
+        await monitor._start_upbit_supervisor()
+        # No assertion needed - just verify it returns cleanly
+
+    @pytest.mark.asyncio
+    async def test_upbit_supervisor_reconnects_when_connection_not_established(
+        self,
+        mock_settings: None,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        import websocket_monitor
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor(mode="upbit")
+        monitor.is_running = True
+
+        class FakeUpbitWs:
+            def __init__(self, *args, **kwargs):
+                self.is_connected = False
+                self.connect_and_subscribe = AsyncMock(return_value=None)
+
+        fake_ws = FakeUpbitWs()
+
+        def fake_factory(*args, **kwargs):
+            return fake_ws
+
+        async def stop_after_first_sleep(_: float) -> None:
+            monitor.is_running = False
+
+        monkeypatch.setattr(websocket_monitor, "UpbitMyOrderWebSocket", fake_factory)
+        monkeypatch.setattr(websocket_monitor.asyncio, "sleep", stop_after_first_sleep)
+        caplog.set_level("INFO")
+
+        await monitor._start_upbit_supervisor()
+
+        fake_ws.connect_and_subscribe.assert_awaited_once()
+        assert "Upbit WebSocket connected" not in caplog.text
+        assert "Reconnecting Upbit" in caplog.text

--- a/websocket_monitor.py
+++ b/websocket_monitor.py
@@ -7,10 +7,14 @@ Upbit/KIS 체결 WebSocket을 통합하여 OpenClaw Gateway로 체결 알림을 
 
 import argparse
 import asyncio
+import json
 import logging
+import os
 import signal
 import sys
-from typing import Any
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
 
 from app.core.config import settings
 from app.monitoring.sentry import capture_exception, init_sentry
@@ -27,6 +31,11 @@ from app.services.upbit_websocket import UpbitMyOrderWebSocket
 logger = logging.getLogger(__name__)
 VALID_MONITOR_MODES = {"upbit", "kis", "both"}
 MIN_FILL_NOTIFY_AMOUNT = 50_000
+
+# Default heartbeat configuration
+DEFAULT_HEARTBEAT_PATH = "/tmp/websocket_monitor_heartbeat.json"
+DEFAULT_HEARTBEAT_INTERVAL_SECONDS = 5.0
+DEFAULT_RECONNECT_DELAY_SECONDS = 5.0
 
 
 class UnifiedWebSocketMonitor:
@@ -51,6 +60,24 @@ class UnifiedWebSocketMonitor:
         self._next_health_log_at = 0.0
         self._setup_signal_handlers()
 
+        # Heartbeat configuration from environment
+        self._heartbeat_path = os.environ.get(
+            "WS_MONITOR_HEARTBEAT_PATH", DEFAULT_HEARTBEAT_PATH
+        )
+        self._heartbeat_interval_seconds = float(
+            os.environ.get(
+                "WS_MONITOR_HEARTBEAT_INTERVAL_SECONDS",
+                str(DEFAULT_HEARTBEAT_INTERVAL_SECONDS),
+            )
+        )
+        self._reconnect_delay_seconds = float(
+            os.environ.get(
+                "WS_MONITOR_RECONNECT_DELAY_SECONDS",
+                str(DEFAULT_RECONNECT_DELAY_SECONDS),
+            )
+        )
+        self._last_heartbeat_at = 0.0
+
     def _setup_signal_handlers(self):
         """SIGINT/SIGTERM 시그널 핸들러 설정"""
         signal.signal(signal.SIGINT, self._handle_signal)
@@ -63,7 +90,51 @@ class UnifiedWebSocketMonitor:
         logger.info(f"Received signal {sig_name} ({signum}), initiating shutdown...")
         self.is_running = False
 
-    async def _on_upbit_order(self, order_data: dict) -> None:
+    def _write_heartbeat(self, is_running: bool | None = None) -> None:
+        """
+        Write heartbeat file atomically.
+
+        Args:
+            is_running: Override for is_running status. If None, uses self.is_running.
+        """
+        import time
+
+        if is_running is None:
+            is_running = self.is_running
+
+        upbit_enabled = self.mode in {"upbit", "both"}
+        kis_enabled = self.mode in {"kis", "both"}
+
+        upbit_connected: bool | str = (
+            bool(self.upbit_ws and self.upbit_ws.is_connected)
+            if upbit_enabled
+            else "n/a"
+        )
+        kis_connected: bool | str = (
+            bool(self.kis_ws and self.kis_ws.is_connected) if kis_enabled else "n/a"
+        )
+
+        data = {
+            "updated_at_unix": time.time(),
+            "mode": self.mode,
+            "is_running": is_running,
+            "upbit_connected": upbit_connected,
+            "kis_connected": kis_connected,
+        }
+
+        # Atomic write: write to temp file, then rename
+        heartbeat_path = Path(self._heartbeat_path)
+        heartbeat_path.parent.mkdir(parents=True, exist_ok=True)
+        temp_path = heartbeat_path.with_suffix(".tmp")
+
+        try:
+            with open(temp_path, "w") as f:
+                json.dump(data, f)
+            temp_path.replace(heartbeat_path)
+        except OSError as e:
+            logger.warning("Failed to write heartbeat file: %s", e)
+
+    async def _on_upbit_order(self, order_data: dict[str, Any]) -> None:
         """
         Upbit 주문/체결 이벤트 처리
 
@@ -157,31 +228,93 @@ class UnifiedWebSocketMonitor:
         except Exception as e:
             logger.error(f"Fill notification error: {e}", exc_info=True)
 
-    async def _start_upbit(self) -> None:
-        """Upbit WebSocket 시작"""
-        self.upbit_ws = UpbitMyOrderWebSocket(
-            on_order_callback=self._on_upbit_order,
-            verify_ssl=False,
-        )
-        logger.info("Starting Upbit WebSocket...")
-        await self.upbit_ws.connect_and_subscribe()
+    async def _start_upbit_supervisor(self) -> None:
+        """
+        Upbit WebSocket supervisor loop with auto-reconnect.
 
-        if self.is_running:
-            raise RuntimeError("Upbit WebSocket task exited unexpectedly")
+        When connection closes and is_running=True, reconnects after delay.
+        Only exits when is_running=False (stop signal).
+        """
+        while self.is_running:
+            try:
+                self.upbit_ws = UpbitMyOrderWebSocket(
+                    on_order_callback=self._on_upbit_order,
+                    verify_ssl=False,
+                )
+                logger.info("Connecting to Upbit WebSocket...")
+                await self.upbit_ws.connect_and_subscribe()
+                if self.upbit_ws.is_connected is not True:
+                    raise RuntimeError("Upbit WebSocket connection not established")
+                logger.info("Upbit WebSocket connected")
+
+                # Connection closed normally - check if we should reconnect
+                if self.is_running:
+                    logger.warning(
+                        "Upbit WebSocket connection closed, reconnecting in %.1fs...",
+                        self._reconnect_delay_seconds,
+                    )
+                    await asyncio.sleep(self._reconnect_delay_seconds)
+                else:
+                    logger.info("Upbit WebSocket exiting (stop signal)")
+                    break
+            except Exception as e:
+                logger.error("Upbit WebSocket error: %s", e, exc_info=True)
+                if self.is_running:
+                    logger.info(
+                        "Reconnecting Upbit in %.1fs...", self._reconnect_delay_seconds
+                    )
+                    await asyncio.sleep(self._reconnect_delay_seconds)
+                else:
+                    raise
+
+    async def _start_kis_supervisor(self) -> None:
+        """
+        KIS WebSocket supervisor loop with auto-reconnect.
+
+        When connection closes and is_running=True, reconnects after delay.
+        Only exits when is_running=False (stop signal).
+        """
+        while self.is_running:
+            try:
+                self.kis_ws = KISExecutionWebSocket(
+                    on_execution=cast(
+                        Callable[[dict[str, Any]], None],
+                        self._on_kis_execution,
+                    ),
+                    mock_mode=settings.kis_ws_is_mock,
+                )
+                self.kis_ws.is_running = True
+                logger.info("Connecting to KIS WebSocket...")
+                await self.kis_ws.connect_and_subscribe()
+                await self.kis_ws.listen()
+
+                # listen() returned - connection closed
+                if self.is_running:
+                    logger.warning(
+                        "KIS WebSocket connection closed, reconnecting in %.1fs...",
+                        self._reconnect_delay_seconds,
+                    )
+                    await asyncio.sleep(self._reconnect_delay_seconds)
+                else:
+                    logger.info("KIS WebSocket exiting (stop signal)")
+                    break
+            except Exception as e:
+                logger.error("KIS WebSocket error: %s", e, exc_info=True)
+                if self.is_running:
+                    logger.info(
+                        "Reconnecting KIS in %.1fs...", self._reconnect_delay_seconds
+                    )
+                    await asyncio.sleep(self._reconnect_delay_seconds)
+                else:
+                    raise
+
+    async def _start_upbit(self) -> None:
+        """Upbit WebSocket 시작 (supervisor wrapper)."""
+        await self._start_upbit_supervisor()
 
     async def _start_kis(self) -> None:
-        """KIS WebSocket 시작"""
-        self.kis_ws = KISExecutionWebSocket(
-            on_execution=self._on_kis_execution,
-            mock_mode=settings.kis_ws_is_mock,
-        )
-        self.kis_ws.is_running = True
-        logger.info("Starting KIS WebSocket...")
-        await self.kis_ws.connect_and_subscribe()
-        await self.kis_ws.listen()
-
-        if self.is_running:
-            raise RuntimeError("KIS WebSocket task exited unexpectedly")
+        """KIS WebSocket 시작 (supervisor wrapper)."""
+        await self._start_kis_supervisor()
 
     def _log_health_status(self, *, force: bool = False) -> None:
         now = asyncio.get_running_loop().time()
@@ -212,6 +345,9 @@ class UnifiedWebSocketMonitor:
         logger.info("Starting Unified WebSocket Monitor (mode=%s)...", self.mode)
         self.is_running = True
 
+        # Write initial heartbeat
+        self._write_heartbeat()
+
         task_map: dict[str, asyncio.Task[Any]] = {}
         if self.mode in {"upbit", "both"}:
             task_map["upbit"] = asyncio.create_task(
@@ -231,9 +367,13 @@ class UnifiedWebSocketMonitor:
             while self.is_running:
                 done, _ = await asyncio.wait(
                     set(task_map.values()),
-                    timeout=5,
+                    timeout=self._heartbeat_interval_seconds,
                     return_when=asyncio.FIRST_COMPLETED,
                 )
+
+                # Update heartbeat periodically
+                self._write_heartbeat()
+
                 if not done:
                     self._log_health_status()
                     continue
@@ -253,15 +393,17 @@ class UnifiedWebSocketMonitor:
                             failure = RuntimeError(f"{name} task failed: {exc}")
                             logger.error("%s task failed: %s", name, exc, exc_info=exc)
                         else:
-                            failure = RuntimeError(
-                                f"{name} task exited unexpectedly without exception"
-                            )
-                            logger.error(
-                                "%s task exited unexpectedly without exception", name
-                            )
+                            # Task completed normally - supervisor exited
+                            # This means stop was requested, which is fine
+                            if self.is_running:
+                                failure = RuntimeError(
+                                    f"{name} supervisor exited unexpectedly"
+                                )
+                                logger.error("%s supervisor exited unexpectedly", name)
 
-                    self.is_running = False
-                    break
+                    if failure:
+                        self.is_running = False
+                        break
         except asyncio.CancelledError:
             logger.info("Main loop cancelled")
             raise
@@ -276,6 +418,7 @@ class UnifiedWebSocketMonitor:
                     logger.debug("Child task cleanup ignored error: %s", exc)
 
             self._log_health_status(force=True)
+            self._write_heartbeat(is_running=False)
 
         if failure is not None:
             raise failure
@@ -284,6 +427,9 @@ class UnifiedWebSocketMonitor:
         """통합 모니터링 정지"""
         logger.info("Stopping Unified WebSocket Monitor...")
         self.is_running = False
+
+        # Write heartbeat to indicate stopped
+        self._write_heartbeat(is_running=False)
 
         if self.upbit_ws:
             try:


### PR DESCRIPTION
## Summary
- add websocket heartbeat-based healthcheck script for prod websocket containers
- improve websocket monitor supervisors with reconnect loops and heartbeat emission
- harden Upbit connection establishment semantics to avoid false connected logs
- add regression tests for reconnect behavior and heartbeat healthcheck (including future timestamp skew handling)

## Test Plan
- [x] uv run pytest tests/test_upbit_websocket_service.py tests/test_websocket_monitor.py tests/test_websocket_healthcheck.py --no-cov -q
- [x] uv run ruff check app/services/upbit_websocket.py websocket_monitor.py scripts/websocket_healthcheck.py tests/test_upbit_websocket_service.py tests/test_websocket_monitor.py tests/test_websocket_healthcheck.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auto-reconnect capability for WebSocket connections with configurable reconnection delay
  * Introduced heartbeat-based health monitoring for connection status

* **Chores**
  * Enhanced type safety and validation in WebSocket services
  * Implemented health check script for Docker deployments
  * Added environment-based configuration for heartbeat monitoring and reconnection settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->