### PR TITLE
feat: add trade profile persistence foundation

### DIFF
--- a/alembic/versions/4d9f0b2c7a11_add_trade_profile_tables.py
+++ b/alembic/versions/4d9f0b2c7a11_add_trade_profile_tables.py
@@ -1,0 +1,336 @@
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "4d9f0b2c7a11"
+down_revision: str | Sequence[str] | None = "9f2c6db7a41e"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "asset_profiles",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("broker_account_id", sa.BigInteger(), nullable=True),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column(
+            "instrument_type",
+            postgresql.ENUM(
+                "equity_kr",
+                "equity_us",
+                "crypto",
+                "forex",
+                "index",
+                name="instrument_type",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("tier", sa.SmallInteger(), nullable=False),
+        sa.Column("profile", sa.String(length=24), nullable=False),
+        sa.Column("sector", sa.Text(), nullable=True),
+        sa.Column("tags", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("max_position_pct", sa.Numeric(precision=5, scale=2), nullable=True),
+        sa.Column(
+            "buy_allowed", sa.Boolean(), server_default=sa.text("true"), nullable=False
+        ),
+        sa.Column(
+            "sell_mode",
+            sa.String(length=20),
+            server_default=sa.text("'any'"),
+            nullable=False,
+        ),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("updated_by", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint("tier BETWEEN 1 AND 4", name="asset_profiles_tier_range"),
+        sa.CheckConstraint(
+            "profile IN ('aggressive','balanced','conservative','exit','hold_only')",
+            name="asset_profiles_profile_allowed",
+        ),
+        sa.CheckConstraint(
+            "sell_mode IN ('any','rebalance_only','none')",
+            name="asset_profiles_sell_mode_allowed",
+        ),
+        sa.CheckConstraint(
+            "profile <> 'exit' OR buy_allowed = FALSE",
+            name="asset_profiles_exit_buy_rule",
+        ),
+        sa.CheckConstraint(
+            "profile <> 'hold_only' OR sell_mode = 'rebalance_only'",
+            name="asset_profiles_hold_only_sell_mode_rule",
+        ),
+        sa.CheckConstraint(
+            "tags IS NULL OR jsonb_typeof(tags) = 'array'",
+            name="asset_profiles_tags_array_type",
+        ),
+        sa.ForeignKeyConstraint(
+            ["broker_account_id"],
+            ["broker_accounts.id"],
+            name=op.f("fk_asset_profiles_broker_account_id_broker_accounts"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name=op.f("fk_asset_profiles_user_id_users"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_asset_profiles")),
+    )
+    op.create_index(
+        "ix_asset_profiles_user_instrument_type",
+        "asset_profiles",
+        ["user_id", "instrument_type"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_asset_profiles_user_profile",
+        "asset_profiles",
+        ["user_id", "profile"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_asset_profiles_tags_gin",
+        "asset_profiles",
+        ["tags"],
+        unique=False,
+        postgresql_using="gin",
+    )
+
+    op.create_table(
+        "tier_rule_params",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column(
+            "instrument_type",
+            postgresql.ENUM(
+                "equity_kr",
+                "equity_us",
+                "crypto",
+                "forex",
+                "index",
+                name="instrument_type",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("tier", sa.SmallInteger(), nullable=False),
+        sa.Column("profile", sa.String(length=24), nullable=False),
+        sa.Column(
+            "param_type",
+            sa.String(length=16),
+            nullable=False,
+        ),
+        sa.Column("params", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("version", sa.Integer(), server_default=sa.text("1"), nullable=False),
+        sa.Column("updated_by", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint("tier BETWEEN 1 AND 4", name="tier_rule_params_tier_range"),
+        sa.CheckConstraint(
+            "profile IN ('aggressive','balanced','conservative','exit','hold_only')",
+            name="tier_rule_params_profile_allowed",
+        ),
+        sa.CheckConstraint(
+            "param_type IN ('buy','sell','stop','rebalance','common')",
+            name="tier_rule_params_param_type_allowed",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name=op.f("fk_tier_rule_params_user_id_users"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_tier_rule_params")),
+        sa.UniqueConstraint(
+            "user_id",
+            "instrument_type",
+            "tier",
+            "profile",
+            "param_type",
+            name="uq_tier_rule_params_key",
+        ),
+    )
+
+    op.create_table(
+        "market_filters",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("broker_account_id", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "instrument_type",
+            postgresql.ENUM(
+                "equity_kr",
+                "equity_us",
+                "crypto",
+                "forex",
+                "index",
+                name="instrument_type",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("filter_name", sa.String(length=32), nullable=False),
+        sa.Column("params", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "enabled", sa.Boolean(), server_default=sa.text("true"), nullable=False
+        ),
+        sa.Column("updated_by", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "filter_name ~ '^[a-z][a-z0-9_]{0,29}$'",
+            name="market_filters_filter_name_format",
+        ),
+        sa.ForeignKeyConstraint(
+            ["broker_account_id"],
+            ["broker_accounts.id"],
+            name=op.f("fk_market_filters_broker_account_id_broker_accounts"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name=op.f("fk_market_filters_user_id_users"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_market_filters")),
+    )
+    op.create_index(
+        "ix_market_filters_user_instrument_enabled",
+        "market_filters",
+        ["user_id", "instrument_type", "enabled"],
+        unique=False,
+    )
+
+    op.create_table(
+        "profile_change_log",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("change_type", sa.String(length=32), nullable=False),
+        sa.Column("target", sa.String(length=64), nullable=False),
+        sa.Column("old_value", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("new_value", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("changed_by", sa.Text(), nullable=False),
+        sa.Column(
+            "changed_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name=op.f("fk_profile_change_log_user_id_users"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_profile_change_log")),
+    )
+    op.create_index(
+        "ix_profile_change_log_user_changed_at",
+        "profile_change_log",
+        ["user_id", "changed_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_profile_change_log_target_changed_at",
+        "profile_change_log",
+        ["target", "changed_at"],
+        unique=False,
+    )
+
+    op.execute(
+        """
+        CREATE UNIQUE INDEX uq_asset_profiles_with_broker
+        ON asset_profiles (user_id, broker_account_id, symbol, instrument_type)
+        WHERE broker_account_id IS NOT NULL
+        """
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX uq_asset_profiles_without_broker
+        ON asset_profiles (user_id, symbol, instrument_type)
+        WHERE broker_account_id IS NULL
+        """
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX uq_market_filters_with_broker
+        ON market_filters (user_id, broker_account_id, instrument_type, filter_name)
+        WHERE broker_account_id IS NOT NULL
+        """
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX uq_market_filters_without_broker
+        ON market_filters (user_id, instrument_type, filter_name)
+        WHERE broker_account_id IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_market_filters_without_broker")
+    op.execute("DROP INDEX IF EXISTS uq_market_filters_with_broker")
+    op.execute("DROP INDEX IF EXISTS uq_asset_profiles_without_broker")
+    op.execute("DROP INDEX IF EXISTS uq_asset_profiles_with_broker")
+
+    op.execute("DROP INDEX IF EXISTS ix_profile_change_log_target_changed_at")
+    op.execute("DROP INDEX IF EXISTS ix_profile_change_log_user_changed_at")
+    op.execute("DROP INDEX IF EXISTS ix_profile_change_log_asset_profile_created_at")
+    op.execute("DROP INDEX IF EXISTS ix_profile_change_log_user_created_at")
+    op.drop_table("profile_change_log")
+
+    op.drop_index(
+        "ix_market_filters_user_instrument_enabled",
+        table_name="market_filters",
+    )
+    op.drop_table("market_filters")
+
+    op.drop_table("tier_rule_params")
+
+    op.drop_index("ix_asset_profiles_tags_gin", table_name="asset_profiles")
+    op.drop_index("ix_asset_profiles_user_profile", table_name="asset_profiles")
+    op.drop_index(
+        "ix_asset_profiles_user_instrument_type",
+        table_name="asset_profiles",
+    )
+    op.drop_table("asset_profiles")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -18,6 +18,16 @@ from .research_backtest import (
     ResearchSyncJob,
 )
 from .symbol_trade_settings import SymbolTradeSettings
+from .trade_profile import (
+    AssetProfile,
+    FilterName,
+    MarketFilter,
+    ProfileChangeLog,
+    ProfileName,
+    SellMode,
+    TierParamType,
+    TierRuleParam,
+)
 from .trading import Exchange, Instrument, User, UserChannel, UserRole, UserWatchItem
 from .upbit_symbol_universe import UpbitSymbolUniverse
 from .us_symbol_universe import USSymbolUniverse
@@ -39,6 +49,14 @@ __all__ = [
     "ResearchBacktestPair",
     "ResearchPromotionCandidate",
     "ResearchSyncJob",
+    "AssetProfile",
+    "TierRuleParam",
+    "MarketFilter",
+    "ProfileChangeLog",
+    "ProfileName",
+    "SellMode",
+    "TierParamType",
+    "FilterName",
     "StockInfo",
     "StockAnalysisResult",
     "KRSymbolUniverse",

--- a/app/models/trade_profile.py
+++ b/app/models/trade_profile.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    SmallInteger,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+from app.models.trading import InstrumentType
+
+
+class ProfileName(enum.StrEnum):
+    aggressive = "aggressive"
+    balanced = "balanced"
+    conservative = "conservative"
+    exit = "exit"
+    hold_only = "hold_only"
+
+
+class SellMode(enum.StrEnum):
+    any = "any"
+    rebalance_only = "rebalance_only"
+    none = "none"
+
+
+class TierParamType(enum.StrEnum):
+    buy = "buy"
+    sell = "sell"
+    stop = "stop"
+    rebalance = "rebalance"
+    common = "common"
+
+
+class FilterName(enum.StrEnum):
+    regime = "regime"
+    kill_switch = "kill_switch"
+    fear_greed = "fear_greed"
+    funding_rate = "funding_rate"
+    btc_filter = "btc_filter"
+    liquidity = "liquidity"
+
+
+class AssetProfile(Base):
+    __tablename__ = "asset_profiles"
+    __table_args__ = (
+        CheckConstraint("tier BETWEEN 1 AND 4", name="asset_profiles_tier_range"),
+        CheckConstraint(
+            "profile IN ('aggressive','balanced','conservative','exit','hold_only')",
+            name="asset_profiles_profile_allowed",
+        ),
+        CheckConstraint(
+            "sell_mode IN ('any','rebalance_only','none')",
+            name="asset_profiles_sell_mode_allowed",
+        ),
+        CheckConstraint(
+            "profile <> 'exit' OR buy_allowed = FALSE",
+            name="asset_profiles_exit_buy_rule",
+        ),
+        CheckConstraint(
+            "profile <> 'hold_only' OR sell_mode = 'rebalance_only'",
+            name="asset_profiles_hold_only_sell_mode_rule",
+        ),
+        CheckConstraint(
+            "tags IS NULL OR jsonb_typeof(tags) = 'array'",
+            name="asset_profiles_tags_array_type",
+        ),
+        Index("ix_asset_profiles_user_instrument_type", "user_id", "instrument_type"),
+        Index("ix_asset_profiles_user_profile", "user_id", "profile"),
+        Index("ix_asset_profiles_tags_gin", "tags", postgresql_using="gin"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    broker_account_id: Mapped[int | None] = mapped_column(
+        ForeignKey("broker_accounts.id", ondelete="CASCADE"), nullable=True
+    )
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    instrument_type: Mapped[InstrumentType] = mapped_column(
+        Enum(InstrumentType, name="instrument_type", create_type=False), nullable=False
+    )
+    tier: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    profile: Mapped[str] = mapped_column(String(24), nullable=False)
+    sector: Mapped[str | None] = mapped_column(Text, nullable=True)
+    tags: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
+    max_position_pct: Mapped[Decimal | None] = mapped_column(
+        Numeric(5, 2), nullable=True
+    )
+    buy_allowed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    sell_mode: Mapped[str] = mapped_column(
+        String(20), nullable=False, default=SellMode.any.value
+    )
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    updated_by: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+class TierRuleParam(Base):
+    __tablename__ = "tier_rule_params"
+    __table_args__ = (
+        CheckConstraint("tier BETWEEN 1 AND 4", name="tier_rule_params_tier_range"),
+        CheckConstraint(
+            "profile IN ('aggressive','balanced','conservative','exit','hold_only')",
+            name="tier_rule_params_profile_allowed",
+        ),
+        CheckConstraint(
+            "param_type IN ('buy','sell','stop','rebalance','common')",
+            name="tier_rule_params_param_type_allowed",
+        ),
+        Index(
+            "uq_tier_rule_params_key",
+            "user_id",
+            "instrument_type",
+            "tier",
+            "profile",
+            "param_type",
+            unique=True,
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    instrument_type: Mapped[InstrumentType] = mapped_column(
+        Enum(InstrumentType, name="instrument_type", create_type=False), nullable=False
+    )
+    tier: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    profile: Mapped[str] = mapped_column(String(24), nullable=False)
+    param_type: Mapped[str] = mapped_column(String(16), nullable=False)
+    params: Mapped[dict[str, object]] = mapped_column(JSONB, nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    updated_by: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+class MarketFilter(Base):
+    __tablename__ = "market_filters"
+    __table_args__ = (
+        CheckConstraint(
+            r"filter_name ~ '^[a-z][a-z0-9_]{0,29}$'",
+            name="market_filters_filter_name_format",
+        ),
+        Index(
+            "ix_market_filters_user_instrument_enabled",
+            "user_id",
+            "instrument_type",
+            "enabled",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    broker_account_id: Mapped[int | None] = mapped_column(
+        ForeignKey("broker_accounts.id", ondelete="CASCADE"), nullable=True
+    )
+    instrument_type: Mapped[InstrumentType] = mapped_column(
+        Enum(InstrumentType, name="instrument_type", create_type=False), nullable=False
+    )
+    filter_name: Mapped[str] = mapped_column(String(32), nullable=False)
+    params: Mapped[dict[str, object]] = mapped_column(JSONB, nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    updated_by: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+class ProfileChangeLog(Base):
+    __tablename__ = "profile_change_log"
+    __table_args__ = (
+        Index("ix_profile_change_log_user_changed_at", "user_id", "changed_at"),
+        Index("ix_profile_change_log_target_changed_at", "target", "changed_at"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    change_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    target: Mapped[str] = mapped_column(String(64), nullable=False)
+    old_value: Mapped[dict[str, object] | None] = mapped_column(JSONB, nullable=True)
+    new_value: Mapped[dict[str, object] | None] = mapped_column(JSONB, nullable=True)
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    changed_by: Mapped[str] = mapped_column(Text, nullable=False)
+    changed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/scripts/seed_trade_profiles.py
+++ b/scripts/seed_trade_profiles.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import select, text
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.config import settings
+from app.core.db import engine
+from app.models.manual_holdings import BrokerAccount
+from app.models.trade_profile import (
+    AssetProfile,
+    FilterName,
+    MarketFilter,
+    ProfileName,
+    SellMode,
+    TierParamType,
+    TierRuleParam,
+)
+from app.models.trading import InstrumentType
+from app.monitoring.sentry import capture_exception, init_sentry
+
+logger = logging.getLogger(__name__)
+SessionLocal = async_sessionmaker(
+    bind=engine, class_=AsyncSession, expire_on_commit=False
+)
+
+KR_SYMBOLS: dict[str, str] = {
+    "한화에어로": "012450",
+    "삼양식품": "003230",
+    "HD한국조선": "329180",
+    "크래프톤": "259960",
+    "NAVER": "035420",
+    "파마리서치": "214450",
+    "펩트론": "087010",
+    "알테오젠": "196170",
+}
+
+
+@dataclass(frozen=True)
+class AssetProfileSeed:
+    instrument_type: InstrumentType
+    symbol_input: str
+    tier: int
+    profile: ProfileName
+    broker_account_id: int | None
+    sector: str | None
+    tags: list[str] | None
+    max_position_pct: Decimal | None
+    buy_allowed: bool
+    sell_mode: SellMode
+    note: str | None
+    updated_by: str
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Seed trade profile tables")
+    parser.add_argument("--user-id", type=int, required=True)
+    parser.add_argument("--updated-by", default="seed_trade_profiles")
+    parser.add_argument("--kis-account-name", default=None)
+    parser.add_argument("--upbit-account-name", default=None)
+    return parser
+
+
+def _normalize_kr_symbol(symbol_input: str) -> str:
+    candidate = symbol_input.strip()
+    if candidate.isdigit() and len(candidate) <= 6:
+        return candidate.zfill(6)
+    mapped = KR_SYMBOLS.get(candidate)
+    if mapped is None:
+        raise ValueError(f"KR symbol mapping missing for input: {symbol_input}")
+    return mapped
+
+
+def _resolve_symbol(symbol_input: str, instrument_type: InstrumentType) -> str:
+    if instrument_type == InstrumentType.equity_kr:
+        return _normalize_kr_symbol(symbol_input)
+    if instrument_type == InstrumentType.crypto:
+        normalized = symbol_input.strip().upper()
+        if normalized.startswith("KRW-"):
+            return normalized
+        return f"KRW-{normalized}"
+    return symbol_input.strip().upper()
+
+
+async def _require_broker_account(
+    user_id: int,
+    broker_type: str,
+    account_name: str | None = None,
+) -> int:
+    async with SessionLocal() as session:
+        stmt = select(BrokerAccount.id, BrokerAccount.account_name).where(
+            BrokerAccount.user_id == user_id,
+            BrokerAccount.broker_type == broker_type,
+            BrokerAccount.is_active.is_(True),
+        )
+        if account_name is not None:
+            stmt = stmt.where(BrokerAccount.account_name == account_name)
+
+        rows = (await session.execute(stmt)).all()
+        if not rows:
+            if account_name is None:
+                raise ValueError(
+                    "Required broker account missing: "
+                    f"user_id={user_id}, broker_type={broker_type}"
+                )
+            raise ValueError(
+                "Required broker account missing: "
+                f"user_id={user_id}, broker_type={broker_type}, account_name={account_name}"
+            )
+        if len(rows) > 1:
+            account_names = sorted(str(row.account_name) for row in rows)
+            raise ValueError(
+                "Ambiguous broker account selection: "
+                f"user_id={user_id}, broker_type={broker_type}, "
+                f"account_name={account_name}, candidates={account_names}"
+            )
+        return int(rows[0].id)
+
+
+def _seed_sell_mode_for_profile(profile: ProfileName) -> SellMode:
+    if profile == ProfileName.hold_only:
+        return SellMode.rebalance_only
+    return SellMode.any
+
+
+async def seed_trade_profiles(
+    user_id: int,
+    updated_by: str,
+    kis_account_name: str | None = None,
+    upbit_account_name: str | None = None,
+) -> None:
+    kis_account_id = await _require_broker_account(
+        user_id,
+        "kis",
+        account_name=kis_account_name,
+    )
+    upbit_account_id = await _require_broker_account(
+        user_id,
+        "upbit",
+        account_name=upbit_account_name,
+    )
+
+    asset_profiles = [
+        AssetProfileSeed(
+            instrument_type=InstrumentType.equity_kr,
+            symbol_input="한화에어로",
+            tier=2,
+            profile=ProfileName.balanced,
+            broker_account_id=kis_account_id,
+            sector="semiconductor",
+            tags=["region:kr", "style:core"],
+            max_position_pct=Decimal("15.00"),
+            buy_allowed=True,
+            sell_mode=_seed_sell_mode_for_profile(ProfileName.balanced),
+            note="core kr equity",
+            updated_by=updated_by,
+        ),
+        AssetProfileSeed(
+            instrument_type=InstrumentType.crypto,
+            symbol_input="BTC",
+            tier=1,
+            profile=ProfileName.aggressive,
+            broker_account_id=upbit_account_id,
+            sector="crypto",
+            tags=["bucket:trend"],
+            max_position_pct=Decimal("20.00"),
+            buy_allowed=True,
+            sell_mode=_seed_sell_mode_for_profile(ProfileName.aggressive),
+            note="crypto trend",
+            updated_by=updated_by,
+        ),
+        AssetProfileSeed(
+            instrument_type=InstrumentType.crypto,
+            symbol_input="ETH",
+            tier=3,
+            profile=ProfileName.hold_only,
+            broker_account_id=upbit_account_id,
+            sector="crypto",
+            tags=["bucket:core"],
+            max_position_pct=Decimal("12.50"),
+            buy_allowed=True,
+            sell_mode=_seed_sell_mode_for_profile(ProfileName.hold_only),
+            note="hold-only rebalance",
+            updated_by=updated_by,
+        ),
+        AssetProfileSeed(
+            instrument_type=InstrumentType.crypto,
+            symbol_input="XRP",
+            tier=4,
+            profile=ProfileName.exit,
+            broker_account_id=upbit_account_id,
+            sector="crypto",
+            tags=["bucket:risk_off"],
+            max_position_pct=Decimal("5.00"),
+            buy_allowed=False,
+            sell_mode=_seed_sell_mode_for_profile(ProfileName.exit),
+            note="exit profile",
+            updated_by=updated_by,
+        ),
+    ]
+
+    market_filters: list[dict[str, Any]] = [
+        {
+            "instrument_type": InstrumentType.crypto,
+            "filter_name": FilterName.funding_rate.value,
+            "params": {"max_abs_funding_rate": 0.01},
+            "enabled": True,
+            "broker_account_id": upbit_account_id,
+            "updated_by": updated_by,
+        },
+        {
+            "instrument_type": InstrumentType.equity_kr,
+            "filter_name": FilterName.liquidity.value,
+            "params": {"min_volume": 300000},
+            "enabled": True,
+            "broker_account_id": kis_account_id,
+            "updated_by": updated_by,
+        },
+    ]
+
+    tier_rule_params: list[dict[str, Any]] = []
+    for tier in (1, 2, 3, 4):
+        for profile in (
+            ProfileName.aggressive,
+            ProfileName.balanced,
+            ProfileName.conservative,
+            ProfileName.exit,
+            ProfileName.hold_only,
+        ):
+            tier_rule_params.extend(
+                [
+                    {
+                        "user_id": user_id,
+                        "instrument_type": InstrumentType.crypto,
+                        "tier": tier,
+                        "profile": profile,
+                        "param_type": TierParamType.buy,
+                        "params": {"slice_count": max(1, 5 - tier)},
+                        "version": 1,
+                        "updated_by": updated_by,
+                    },
+                    {
+                        "user_id": user_id,
+                        "instrument_type": InstrumentType.crypto,
+                        "tier": tier,
+                        "profile": profile,
+                        "param_type": TierParamType.sell,
+                        "params": {"take_profit_pct": float(4 + tier)},
+                        "version": 1,
+                        "updated_by": updated_by,
+                    },
+                    {
+                        "user_id": user_id,
+                        "instrument_type": InstrumentType.crypto,
+                        "tier": tier,
+                        "profile": profile,
+                        "param_type": TierParamType.stop,
+                        "params": {"stop_loss_pct": float(2 + tier)},
+                        "version": 1,
+                        "updated_by": updated_by,
+                    },
+                    {
+                        "user_id": user_id,
+                        "instrument_type": InstrumentType.crypto,
+                        "tier": tier,
+                        "profile": profile,
+                        "param_type": TierParamType.rebalance,
+                        "params": {"window_days": 7 * tier},
+                        "version": 1,
+                        "updated_by": updated_by,
+                    },
+                    {
+                        "user_id": user_id,
+                        "instrument_type": InstrumentType.crypto,
+                        "tier": tier,
+                        "profile": profile,
+                        "param_type": TierParamType.common,
+                        "params": {
+                            "price_base": "close_1",
+                            "regime_ema": [60, 200],
+                            "max_concurrent_orders": max(1, 5 - tier),
+                        },
+                        "version": 1,
+                        "updated_by": updated_by,
+                    },
+                ]
+            )
+
+    async with SessionLocal() as session:
+        async with session.begin():
+            for profile in asset_profiles:
+                symbol = _resolve_symbol(profile.symbol_input, profile.instrument_type)
+                payload = {
+                    "user_id": user_id,
+                    "broker_account_id": profile.broker_account_id,
+                    "symbol": symbol,
+                    "instrument_type": profile.instrument_type,
+                    "tier": profile.tier,
+                    "profile": profile.profile,
+                    "sector": profile.sector,
+                    "tags": profile.tags,
+                    "max_position_pct": profile.max_position_pct,
+                    "buy_allowed": profile.buy_allowed,
+                    "sell_mode": profile.sell_mode,
+                    "note": profile.note,
+                    "updated_by": profile.updated_by,
+                }
+                stmt = insert(AssetProfile).values(**payload)
+                if profile.broker_account_id is None:
+                    stmt = stmt.on_conflict_do_update(
+                        index_elements=["user_id", "symbol", "instrument_type"],
+                        index_where=text("broker_account_id IS NULL"),
+                        set_={k: v for k, v in payload.items() if k != "user_id"},
+                    )
+                else:
+                    stmt = stmt.on_conflict_do_update(
+                        index_elements=[
+                            "user_id",
+                            "broker_account_id",
+                            "symbol",
+                            "instrument_type",
+                        ],
+                        index_where=text("broker_account_id IS NOT NULL"),
+                        set_={
+                            k: v
+                            for k, v in payload.items()
+                            if k not in {"user_id", "broker_account_id"}
+                        },
+                    )
+                await session.execute(stmt)
+
+            for item in market_filters:
+                payload = {
+                    "user_id": user_id,
+                    "broker_account_id": item["broker_account_id"],
+                    "instrument_type": item["instrument_type"],
+                    "filter_name": item["filter_name"],
+                    "params": item["params"],
+                    "enabled": item["enabled"],
+                    "updated_by": item["updated_by"],
+                }
+                stmt = insert(MarketFilter).values(**payload)
+                if payload["broker_account_id"] is None:
+                    stmt = stmt.on_conflict_do_update(
+                        index_elements=["user_id", "instrument_type", "filter_name"],
+                        index_where=text("broker_account_id IS NULL"),
+                        set_={
+                            "params": payload["params"],
+                            "enabled": payload["enabled"],
+                            "updated_by": payload["updated_by"],
+                        },
+                    )
+                else:
+                    stmt = stmt.on_conflict_do_update(
+                        index_elements=[
+                            "user_id",
+                            "broker_account_id",
+                            "instrument_type",
+                            "filter_name",
+                        ],
+                        index_where=text("broker_account_id IS NOT NULL"),
+                        set_={
+                            "params": payload["params"],
+                            "enabled": payload["enabled"],
+                            "updated_by": payload["updated_by"],
+                        },
+                    )
+                await session.execute(stmt)
+
+            for item in tier_rule_params:
+                stmt = (
+                    insert(TierRuleParam)
+                    .values(**item)
+                    .on_conflict_do_update(
+                        index_elements=[
+                            "user_id",
+                            "instrument_type",
+                            "tier",
+                            "profile",
+                            "param_type",
+                        ],
+                        set_={
+                            "params": item["params"],
+                            "version": item["version"],
+                            "updated_by": item["updated_by"],
+                        },
+                    )
+                )
+                await session.execute(stmt)
+
+        await session.commit()
+
+
+async def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    init_sentry(service_name="trade-profile-seed")
+    try:
+        await seed_trade_profiles(
+            user_id=args.user_id,
+            updated_by=args.updated_by,
+            kis_account_name=args.kis_account_name,
+            upbit_account_name=args.upbit_account_name,
+        )
+    except Exception as exc:
+        capture_exception(exc, process="seed_trade_profiles")
+        logger.error("Trade profile seed failed: %s", exc, exc_info=True)
+        return 1
+
+    logger.info("Trade profile seed completed for user_id=%s", args.user_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/integration/test_trade_profile_persistence.py
+++ b/tests/integration/test_trade_profile_persistence.py
@@ -1,0 +1,300 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import engine
+from app.models.trading import InstrumentType
+from scripts.seed_trade_profiles import seed_trade_profiles
+
+SessionLocal = async_sessionmaker(
+    bind=engine, class_=AsyncSession, expire_on_commit=False
+)
+
+
+async def _tables_ready() -> bool:
+    try:
+        async with SessionLocal() as session:
+            row = await session.execute(text("SELECT to_regclass('asset_profiles')"))
+            return row.scalar_one_or_none() is not None
+    except Exception:
+        return False
+
+
+async def _create_user_and_accounts() -> tuple[int, str, str]:
+    suffix = uuid.uuid4().hex[:8]
+    async with SessionLocal() as session:
+        user_id = (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO users (username, email, role, tz, base_currency, is_active)
+                    VALUES (:username, :email, 'viewer', 'Asia/Seoul', 'KRW', true)
+                    RETURNING id
+                    """
+                ),
+                {
+                    "username": f"seed_profile_user_{suffix}",
+                    "email": f"seed_profile_{suffix}@example.com",
+                },
+            )
+        ).scalar_one()
+        kis_name = f"kis_{suffix}"
+        upbit_name = f"upbit_{suffix}"
+
+        await session.execute(
+            text(
+                """
+                INSERT INTO broker_accounts
+                    (user_id, broker_type, account_name, is_mock, is_active)
+                VALUES
+                    (:user_id, 'kis', :kis_name, false, true),
+                    (:user_id, 'upbit', :upbit_name, false, true)
+                """
+            ),
+            {
+                "user_id": user_id,
+                "kis_name": kis_name,
+                "upbit_name": upbit_name,
+            },
+        )
+        await session.commit()
+        return user_id, kis_name, upbit_name
+
+
+async def _cleanup_user(user_id: int) -> None:
+    async with SessionLocal() as session:
+        await session.execute(
+            text("DELETE FROM users WHERE id = :user_id"), {"user_id": user_id}
+        )
+        await session.commit()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_trade_profile_seed_idempotency_and_crypto_common() -> None:
+    if not await _tables_ready():
+        pytest.skip("trade profile tables are not migrated")
+
+    user_id, kis_account_name, upbit_account_name = await _create_user_and_accounts()
+    try:
+        await seed_trade_profiles(
+            user_id=user_id,
+            updated_by="integration_test",
+            kis_account_name=kis_account_name,
+            upbit_account_name=upbit_account_name,
+        )
+        await seed_trade_profiles(
+            user_id=user_id,
+            updated_by="integration_test",
+            kis_account_name=kis_account_name,
+            upbit_account_name=upbit_account_name,
+        )
+
+        async with SessionLocal() as session:
+            profile_count = (
+                await session.execute(
+                    text(
+                        "SELECT COUNT(*) FROM asset_profiles WHERE user_id = :user_id"
+                    ),
+                    {"user_id": user_id},
+                )
+            ).scalar_one()
+            assert profile_count > 0
+
+            kr_row = (
+                await session.execute(
+                    text(
+                        """
+                        SELECT symbol FROM asset_profiles
+                        WHERE user_id = :user_id
+                          AND instrument_type = :instrument_type
+                        ORDER BY id ASC
+                        LIMIT 1
+                        """
+                    ),
+                    {
+                        "user_id": user_id,
+                        "instrument_type": InstrumentType.equity_kr.value,
+                    },
+                )
+            ).scalar_one_or_none()
+            assert kr_row is not None
+            assert isinstance(kr_row, str)
+            assert len(kr_row) == 6
+            assert kr_row.isdigit()
+
+            # Verify KR symbol is from agreed-upon mapping set
+            agreed_kr_codes = {
+                "012450",
+                "003230",
+                "329180",
+                "259960",
+                "035420",
+                "214450",
+                "087010",
+                "196170",
+            }
+            assert kr_row in agreed_kr_codes, (
+                f"KR symbol {kr_row} not in agreed mapping set"
+            )
+
+            common_count = (
+                await session.execute(
+                    text(
+                        """
+                        SELECT COUNT(*) FROM tier_rule_params
+                        WHERE user_id = :user_id
+                          AND instrument_type = :instrument_type
+                          AND param_type = 'common'
+                        """
+                    ),
+                    {
+                        "user_id": user_id,
+                        "instrument_type": InstrumentType.crypto.value,
+                    },
+                )
+            ).scalar_one()
+            assert common_count > 0
+
+            # Verify common params structure matches agreed spec
+            common_row = (
+                await session.execute(
+                    text(
+                        """
+                        SELECT params FROM tier_rule_params
+                        WHERE user_id = :user_id
+                          AND instrument_type = :instrument_type
+                          AND param_type = 'common'
+                        ORDER BY id ASC
+                        LIMIT 1
+                        """
+                    ),
+                    {
+                        "user_id": user_id,
+                        "instrument_type": InstrumentType.crypto.value,
+                    },
+                )
+            ).scalar_one()
+            assert common_row["price_base"] == "close_1"
+            assert isinstance(common_row["regime_ema"], list)
+            assert common_row["regime_ema"] == [60, 200]
+            assert isinstance(common_row["max_concurrent_orders"], int)
+
+            crypto_symbols = (
+                (
+                    await session.execute(
+                        text(
+                            """
+                        SELECT symbol FROM asset_profiles
+                        WHERE user_id = :user_id
+                          AND instrument_type = :instrument_type
+                        ORDER BY symbol ASC
+                        """
+                        ),
+                        {
+                            "user_id": user_id,
+                            "instrument_type": InstrumentType.crypto.value,
+                        },
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert crypto_symbols
+            assert all(symbol.startswith("KRW-") for symbol in crypto_symbols)
+
+            total_rows_after_second_seed = (
+                await session.execute(
+                    text(
+                        """
+                        SELECT COUNT(*) FROM tier_rule_params
+                        WHERE user_id = :user_id
+                        """
+                    ),
+                    {"user_id": user_id},
+                )
+            ).scalar_one()
+
+        await seed_trade_profiles(
+            user_id=user_id,
+            updated_by="integration_test",
+            kis_account_name=kis_account_name,
+            upbit_account_name=upbit_account_name,
+        )
+
+        async with SessionLocal() as session:
+            total_rows_after_third_seed = (
+                await session.execute(
+                    text(
+                        """
+                        SELECT COUNT(*) FROM tier_rule_params
+                        WHERE user_id = :user_id
+                        """
+                    ),
+                    {"user_id": user_id},
+                )
+            ).scalar_one()
+            assert total_rows_after_second_seed == total_rows_after_third_seed
+
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO profile_change_log
+                        (user_id, change_type, target, old_value, new_value, reason, changed_by)
+                    VALUES
+                        (:user_id, 'update', 'asset_profile', '{"old": true}'::jsonb, '{"new": true}'::jsonb, 'test', 'integration_test')
+                    """
+                ),
+                {"user_id": user_id},
+            )
+            await session.commit()
+
+            log_count = (
+                await session.execute(
+                    text(
+                        """
+                        SELECT COUNT(*) FROM profile_change_log
+                        WHERE user_id = :user_id
+                        """
+                    ),
+                    {"user_id": user_id},
+                )
+            ).scalar_one()
+            assert log_count == 1
+    finally:
+        await _cleanup_user(user_id)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_trade_profile_seed_fails_fast_on_ambiguous_accounts() -> None:
+    if not await _tables_ready():
+        pytest.skip("trade profile tables are not migrated")
+
+    user_id, _, _ = await _create_user_and_accounts()
+    try:
+        async with SessionLocal() as session:
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO broker_accounts
+                        (user_id, broker_type, account_name, is_mock, is_active)
+                    VALUES
+                        (:user_id, 'upbit', :account_name, false, true)
+                    """
+                ),
+                {
+                    "user_id": user_id,
+                    "account_name": f"upbit_extra_{uuid.uuid4().hex[:6]}",
+                },
+            )
+            await session.commit()
+
+        with pytest.raises(ValueError, match="Ambiguous broker account selection"):
+            await seed_trade_profiles(user_id=user_id, updated_by="integration_test")
+    finally:
+        await _cleanup_user(user_id)

--- a/tests/models/test_trade_profile.py
+++ b/tests/models/test_trade_profile.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import engine
+from app.models.trading import InstrumentType
+
+SessionLocal = async_sessionmaker(
+    bind=engine, class_=AsyncSession, expire_on_commit=False
+)
+
+
+async def _ensure_trade_profile_tables() -> None:
+    try:
+        async with SessionLocal() as session:
+            row = await session.execute(text("SELECT to_regclass('asset_profiles')"))
+            if row.scalar_one_or_none() is None:
+                pytest.skip("trade profile tables are not migrated")
+    except Exception:
+        pytest.skip("database is not available for integration persistence checks")
+
+
+async def _create_user_and_accounts() -> tuple[int, int, int]:
+    suffix = uuid.uuid4().hex[:8]
+    async with SessionLocal() as session:
+        user_id = (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO users (username, email, role, tz, base_currency, is_active)
+                    VALUES (:username, :email, 'viewer', 'Asia/Seoul', 'KRW', true)
+                    RETURNING id
+                    """
+                ),
+                {
+                    "username": f"trade_profile_user_{suffix}",
+                    "email": f"trade_profile_{suffix}@example.com",
+                },
+            )
+        ).scalar_one()
+        kis_id = (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO broker_accounts
+                        (user_id, broker_type, account_name, is_mock, is_active)
+                    VALUES (:user_id, 'kis', :name, false, true)
+                    RETURNING id
+                    """
+                ),
+                {"user_id": user_id, "name": f"kis_{suffix}"},
+            )
+        ).scalar_one()
+        upbit_id = (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO broker_accounts
+                        (user_id, broker_type, account_name, is_mock, is_active)
+                    VALUES (:user_id, 'upbit', :name, false, true)
+                    RETURNING id
+                    """
+                ),
+                {"user_id": user_id, "name": f"upbit_{suffix}"},
+            )
+        ).scalar_one()
+        await session.commit()
+        return user_id, kis_id, upbit_id
+
+
+async def _cleanup_user(user_id: int) -> None:
+    async with SessionLocal() as session:
+        await session.execute(
+            text("DELETE FROM users WHERE id = :user_id"), {"user_id": user_id}
+        )
+        await session.commit()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_sell_mode_and_hold_only_checks() -> None:
+    await _ensure_trade_profile_tables()
+    user_id, kis_id, _ = await _create_user_and_accounts()
+    try:
+        async with SessionLocal() as session:
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO asset_profiles
+                        (user_id, broker_account_id, symbol, instrument_type, tier, profile, buy_allowed, sell_mode)
+                    VALUES
+                        (:user_id, :broker_id, '005930', :instrument_type, 2, 'hold_only', true, 'rebalance_only')
+                    """
+                ),
+                {
+                    "user_id": user_id,
+                    "broker_id": kis_id,
+                    "instrument_type": InstrumentType.equity_kr.value,
+                },
+            )
+            await session.commit()
+
+        async with SessionLocal() as session:
+            with pytest.raises(DBAPIError):
+                await session.execute(
+                    text(
+                        """
+                        INSERT INTO asset_profiles
+                            (user_id, broker_account_id, symbol, instrument_type, tier, profile, buy_allowed, sell_mode)
+                        VALUES
+                            (:user_id, :broker_id, '000660', :instrument_type, 2, 'hold_only', true, 'any')
+                        """
+                    ),
+                    {
+                        "user_id": user_id,
+                        "broker_id": kis_id,
+                        "instrument_type": InstrumentType.equity_kr.value,
+                    },
+                )
+                await session.commit()
+
+        async with SessionLocal() as session:
+            with pytest.raises(DBAPIError):
+                await session.execute(
+                    text(
+                        """
+                        INSERT INTO asset_profiles
+                            (user_id, broker_account_id, symbol, instrument_type, tier, profile, buy_allowed, sell_mode)
+                        VALUES
+                            (:user_id, :broker_id, '035420', :instrument_type, 2, 'balanced', true, 'invalid_mode')
+                        """
+                    ),
+                    {
+                        "user_id": user_id,
+                        "broker_id": kis_id,
+                        "instrument_type": InstrumentType.equity_kr.value,
+                    },
+                )
+                await session.commit()
+
+        async with SessionLocal() as session:
+            with pytest.raises(DBAPIError):
+                await session.execute(
+                    text(
+                        """
+                        INSERT INTO asset_profiles
+                            (user_id, broker_account_id, symbol, instrument_type, tier, profile, buy_allowed, sell_mode, tags)
+                        VALUES
+                            (:user_id, :broker_id, '051910', :instrument_type, 2, 'balanced', true, 'any', '{"bad": "shape"}'::jsonb)
+                        """
+                    ),
+                    {
+                        "user_id": user_id,
+                        "broker_id": kis_id,
+                        "instrument_type": InstrumentType.equity_kr.value,
+                    },
+                )
+                await session.commit()
+    finally:
+        await _cleanup_user(user_id)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_param_type_common_and_filter_name_format_and_partial_unique() -> None:
+    await _ensure_trade_profile_tables()
+    user_id, kis_id, _ = await _create_user_and_accounts()
+    try:
+        async with SessionLocal() as session:
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO tier_rule_params
+                        (user_id, instrument_type, tier, profile, param_type, params, version)
+                    VALUES
+                        (:user_id, :instrument_type, 1, 'balanced', 'common', '{"max": 3}'::jsonb, 1)
+                    """
+                ),
+                {
+                    "user_id": user_id,
+                    "instrument_type": InstrumentType.crypto.value,
+                },
+            )
+            await session.execute(
+                text(
+                    """
+                        INSERT INTO market_filters
+                            (user_id, broker_account_id, instrument_type, filter_name, params, enabled)
+                        VALUES
+                            (:user_id, :broker_id, :instrument_type, 'liquidity', '{"min": 1}'::jsonb, true)
+                        """
+                ),
+                {
+                    "user_id": user_id,
+                    "broker_id": kis_id,
+                    "instrument_type": InstrumentType.equity_kr.value,
+                },
+            )
+            await session.commit()
+
+        async with SessionLocal() as session:
+            with pytest.raises(DBAPIError):
+                await session.execute(
+                    text(
+                        """
+                        INSERT INTO market_filters
+                            (user_id, broker_account_id, instrument_type, filter_name, params, enabled)
+                        VALUES
+                            (:user_id, :broker_id, :instrument_type, 'INVALID-NAME', '{"x": 1}'::jsonb, true)
+                        """
+                    ),
+                    {
+                        "user_id": user_id,
+                        "broker_id": kis_id,
+                        "instrument_type": InstrumentType.equity_kr.value,
+                    },
+                )
+                await session.commit()
+
+        async with SessionLocal() as session:
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO asset_profiles
+                        (user_id, broker_account_id, symbol, instrument_type, tier, profile, buy_allowed, sell_mode)
+                    VALUES
+                        (:user_id, NULL, 'BTC', :instrument_type, 1, 'aggressive', true, 'any')
+                    """
+                ),
+                {
+                    "user_id": user_id,
+                    "instrument_type": InstrumentType.crypto.value,
+                },
+            )
+            await session.commit()
+
+        async with SessionLocal() as session:
+            with pytest.raises(DBAPIError):
+                await session.execute(
+                    text(
+                        """
+                        INSERT INTO asset_profiles
+                            (user_id, broker_account_id, symbol, instrument_type, tier, profile, buy_allowed, sell_mode)
+                        VALUES
+                            (:user_id, NULL, 'BTC', :instrument_type, 2, 'balanced', true, 'any')
+                        """
+                    ),
+                    {
+                        "user_id": user_id,
+                        "instrument_type": InstrumentType.crypto.value,
+                    },
+                )
+                await session.commit()
+    finally:
+        await _cleanup_user(user_id)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_profile_change_log_generic_fields() -> None:
+    await _ensure_trade_profile_tables()
+    user_id, _, _ = await _create_user_and_accounts()
+    try:
+        async with SessionLocal() as session:
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO profile_change_log
+                        (user_id, change_type, target, old_value, new_value, reason, changed_by)
+                    VALUES
+                        (:user_id, 'update', 'asset_profile', '{"tier": 2}'::jsonb, '{"tier": 3}'::jsonb, 'rebalance tuning', 'test_runner')
+                    """
+                ),
+                {"user_id": user_id},
+            )
+            await session.commit()
+
+        async with SessionLocal() as session:
+            row = (
+                await session.execute(
+                    text(
+                        """
+                        SELECT change_type, target, reason
+                        FROM profile_change_log
+                        WHERE user_id = :user_id
+                        ORDER BY id DESC
+                        LIMIT 1
+                        """
+                    ),
+                    {"user_id": user_id},
+                )
+            ).one()
+
+        assert row.change_type == "update"
+        assert row.target == "asset_profile"
+        assert row.reason == "rebalance tuning"
+    finally:
+        await _cleanup_user(user_id)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_profile_change_log_changed_by_not_null() -> None:
+    """changed_by=NULL insert must be rejected by DB constraint."""
+    await _ensure_trade_profile_tables()
+    user_id, _, _ = await _create_user_and_accounts()
+    try:
+        async with SessionLocal() as session:
+            with pytest.raises(DBAPIError):
+                await session.execute(
+                    text(
+                        """
+                        INSERT INTO profile_change_log
+                            (user_id, change_type, target, old_value, new_value, reason, changed_by)
+                        VALUES
+                            (:user_id, 'update', 'asset_profile', '{}'::jsonb, '{}'::jsonb, 'test', NULL)
+                        """
+                    ),
+                    {"user_id": user_id},
+                )
+                await session.commit()
+    finally:
+        await _cleanup_user(user_id)


### PR DESCRIPTION
Summary: add trade profile models, Alembic migration, idempotent seed script, model exports, and tests. Validation: ruff passed; targeted pytest executed with skips in this environment due DB migration state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Introduced comprehensive trade profile management system enabling users to configure tiered asset profiles, market filters, and tier-based trading parameters with complete change audit logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->