### PR TITLE
fix-tradenotifier-discord-paths

### DIFF
--- a/app/monitoring/trade_notifier.py
+++ b/app/monitoring/trade_notifier.py
@@ -433,6 +433,48 @@ class TradeNotifier:
             "fields": fields,
         }
 
+    def _format_automation_summary_telegram(
+        self,
+        total_coins: int,
+        analyzed: int,
+        bought: int,
+        sold: int,
+        errors: int,
+        duration_seconds: float,
+    ) -> str:
+        """
+        Format automation execution summary as Telegram markdown message.
+
+        Args:
+            total_coins: Total number of coins processed
+            analyzed: Number of coins analyzed
+            bought: Number of buy orders placed
+            sold: Number of sell orders placed
+            errors: Number of errors occurred
+            duration_seconds: Total execution time
+
+        Returns:
+            Telegram markdown formatted message
+        """
+        timestamp = format_datetime()
+
+        lines = [
+            "*🤖 자동 거래 실행 완료*",
+            "",
+            f"🕒 {timestamp}",
+            "",
+            f"*처리 종목:* {total_coins}개",
+            f"*분석 완료:* {analyzed}개",
+            f"*매수 주문:* {bought}건",
+            f"*매도 주문:* {sold}건",
+            f"*실행 시간:* {duration_seconds:.1f}초",
+        ]
+
+        if errors > 0:
+            lines.append(f"*오류 발생:* {errors}건")
+
+        return "\n".join(lines)
+
     async def _send_to_telegram(
         self, message: str, parse_mode: str = "Markdown"
     ) -> bool:
@@ -572,6 +614,40 @@ class TradeNotifier:
 
         except Exception as e:
             logger.error(f"Failed to send embed to Discord webhook: {e}")
+            return False
+
+    async def _send_to_discord_content_single(
+        self, content: str, webhook_url: str
+    ) -> bool:
+        """
+        Send plain text content to a specific Discord webhook URL.
+
+        Args:
+            content: Plain text content to send
+            webhook_url: Specific Discord webhook URL to send to
+
+        Returns:
+            True if message was sent successfully
+        """
+        if not self._enabled or not self._http_client:
+            return False
+
+        if not webhook_url:
+            logger.warning("No Discord webhook URL provided")
+            return False
+
+        try:
+            response = await self._http_client.post(
+                webhook_url,
+                json={"content": content},
+                headers={"Content-Type": "application/json"},
+            )
+            response.raise_for_status()
+            logger.info("Content sent to Discord webhook")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to send content to Discord webhook: {e}")
             return False
 
     def _format_buy_notification_telegram(
@@ -1053,15 +1129,44 @@ class TradeNotifier:
         errors: int,
         duration_seconds: float,
     ) -> bool:
-        """Send automation execution summary notification."""
+        """
+        Send automation execution summary notification.
+
+        Sends to Discord alerts webhook first, falls back to Telegram
+        if Discord is not configured or fails.
+
+        Args:
+            total_coins: Total number of coins processed
+            analyzed: Number of coins analyzed
+            bought: Number of buy orders placed
+            sold: Number of sell orders placed
+            errors: Number of errors occurred
+            duration_seconds: Total execution time
+
+        Returns:
+            True if notification sent successfully
+        """
         if not self._enabled:
             return False
 
         try:
-            message = self._format_automation_summary(
+            # Try Discord first
+            if self._discord_webhook_alerts:
+                embed = self._format_automation_summary(
+                    total_coins, analyzed, bought, sold, errors, duration_seconds
+                )
+                discord_success = await self._send_to_discord_embed_single(
+                    embed, self._discord_webhook_alerts
+                )
+                if discord_success:
+                    return True
+                logger.info("Discord send failed, falling back to Telegram")
+
+            # Fall back to Telegram
+            telegram_message = self._format_automation_summary_telegram(
                 total_coins, analyzed, bought, sold, errors, duration_seconds
             )
-            return await self._send_to_telegram(message)
+            return await self._send_to_telegram(telegram_message)
         except Exception as e:
             logger.error(f"Failed to send summary notification: {e}")
             return False
@@ -1634,11 +1739,14 @@ class TradeNotifier:
         parse_mode: str = "Markdown",
     ) -> bool:
         """
-        Forward an OpenClaw outbound message to Telegram.
+        Forward an OpenClaw outbound message to Discord or Telegram.
+
+        Sends plain text to Discord alerts webhook first, falls back to Telegram
+        if Discord is not configured or fails.
 
         Args:
             message: Original message payload sent to OpenClaw
-            parse_mode: Telegram parse mode ("Markdown" or "HTML")
+            parse_mode: Telegram parse mode ("Markdown" or "HTML") for fallback
 
         Returns:
             True if notification sent successfully
@@ -1647,6 +1755,16 @@ class TradeNotifier:
             return False
 
         try:
+            # Try Discord first
+            if self._discord_webhook_alerts:
+                discord_success = await self._send_to_discord_content_single(
+                    message, self._discord_webhook_alerts
+                )
+                if discord_success:
+                    return True
+                logger.info("Discord send failed, falling back to Telegram")
+
+            # Fall back to Telegram
             return await self._send_to_telegram(message, parse_mode=parse_mode)
         except Exception as e:
             logger.error(f"Failed to forward OpenClaw message: {e}")

--- a/tests/test_trade_notifier.py
+++ b/tests/test_trade_notifier.py
@@ -943,3 +943,350 @@ async def test_telegram_fallback(trade_notifier):
     assert json_data["parse_mode"] == "Markdown"
     assert "💰 매수 주문 접수" in json_data["text"]
     assert "비트코인 \\(BTC\\)" in json_data["text"]
+
+
+# =============================================================================
+# Discord-first tests for notify_openclaw_message and notify_automation_summary
+# =============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notify_openclaw_message_discord_first(trade_notifier):
+    """Test OpenClaw message sends to Discord alerts webhook first."""
+    webhook_url = "https://discord.com/api/webhooks/alerts"
+    trade_notifier.configure(
+        bot_token="test_token",
+        chat_ids=["123456"],
+        enabled=True,
+        discord_webhook_alerts=webhook_url,
+    )
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(
+        trade_notifier._http_client,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_post:
+        result = await trade_notifier.notify_openclaw_message("OpenClaw message")
+
+        assert result is True
+        mock_post.assert_called_once()
+
+        # Verify Discord webhook was called with content (not embeds)
+        call_args = mock_post.call_args
+        assert call_args.args[0] == webhook_url
+        assert call_args.kwargs["json"]["content"] == "OpenClaw message"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notify_openclaw_message_discord_fallback_to_telegram(trade_notifier):
+    """Test OpenClaw message falls back to Telegram when Discord fails."""
+    webhook_url = "https://discord.com/api/webhooks/alerts"
+    trade_notifier.configure(
+        bot_token="test_token",
+        chat_ids=["123456"],
+        enabled=True,
+        discord_webhook_alerts=webhook_url,
+    )
+
+    # Discord failure, Telegram success
+    mock_discord_response = MagicMock()
+    mock_discord_response.raise_for_status = MagicMock(
+        side_effect=Exception("Discord error")
+    )
+    mock_telegram_response = MagicMock()
+    mock_telegram_response.raise_for_status = MagicMock()
+
+    with patch.object(
+        trade_notifier._http_client,
+        "post",
+        new_callable=AsyncMock,
+        side_effect=[mock_discord_response, mock_telegram_response],
+    ) as mock_post:
+        result = await trade_notifier.notify_openclaw_message(
+            "OpenClaw message", parse_mode="HTML"
+        )
+
+        assert result is True
+        assert mock_post.call_count == 2
+
+        # First call was to Discord
+        discord_call = mock_post.call_args_list[0]
+        assert discord_call.args[0] == webhook_url
+        assert "content" in discord_call.kwargs["json"]
+
+        # Second call was to Telegram
+        telegram_call = mock_post.call_args_list[1]
+        assert "api.telegram.org" in telegram_call.args[0]
+        assert telegram_call.kwargs["json"]["text"] == "OpenClaw message"
+        assert telegram_call.kwargs["json"]["parse_mode"] == "HTML"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notify_openclaw_message_telegram_only(trade_notifier):
+    """Test OpenClaw message uses Telegram when no Discord webhook configured."""
+    trade_notifier.configure(
+        bot_token="test_token",
+        chat_ids=["123456"],
+        enabled=True,
+        # No discord_webhook_alerts configured
+    )
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(
+        trade_notifier._http_client,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_post:
+        result = await trade_notifier.notify_openclaw_message("OpenClaw message")
+
+        assert result is True
+        mock_post.assert_called_once()
+
+        # Verify Telegram was called directly
+        call_args = mock_post.call_args
+        assert "api.telegram.org" in call_args.args[0]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notify_automation_summary_discord_first(trade_notifier):
+    """Test automation summary sends to Discord alerts webhook first."""
+    webhook_url = "https://discord.com/api/webhooks/alerts"
+    trade_notifier.configure(
+        bot_token="test_token",
+        chat_ids=["123456"],
+        enabled=True,
+        discord_webhook_alerts=webhook_url,
+    )
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(
+        trade_notifier._http_client,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_post:
+        result = await trade_notifier.notify_automation_summary(
+            total_coins=10,
+            analyzed=10,
+            bought=3,
+            sold=2,
+            errors=0,
+            duration_seconds=45.5,
+        )
+
+        assert result is True
+        mock_post.assert_called_once()
+
+        # Verify Discord webhook was called with embeds
+        call_args = mock_post.call_args
+        assert call_args.args[0] == webhook_url
+        json_data = call_args.kwargs["json"]
+        assert "embeds" in json_data
+        embed = json_data["embeds"][0]
+        assert embed["title"] == "🤖 자동 거래 실행 완료"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notify_automation_summary_discord_fallback_to_telegram(trade_notifier):
+    """Test automation summary falls back to Telegram when Discord fails."""
+    webhook_url = "https://discord.com/api/webhooks/alerts"
+    trade_notifier.configure(
+        bot_token="test_token",
+        chat_ids=["123456"],
+        enabled=True,
+        discord_webhook_alerts=webhook_url,
+    )
+
+    # Discord failure, Telegram success
+    mock_discord_response = MagicMock()
+    mock_discord_response.raise_for_status = MagicMock(
+        side_effect=Exception("Discord error")
+    )
+    mock_telegram_response = MagicMock()
+    mock_telegram_response.raise_for_status = MagicMock()
+
+    with patch.object(
+        trade_notifier._http_client,
+        "post",
+        new_callable=AsyncMock,
+        side_effect=[mock_discord_response, mock_telegram_response],
+    ) as mock_post:
+        result = await trade_notifier.notify_automation_summary(
+            total_coins=10,
+            analyzed=10,
+            bought=3,
+            sold=2,
+            errors=1,
+            duration_seconds=45.5,
+        )
+
+        assert result is True
+        assert mock_post.call_count == 2
+
+        # First call was to Discord with embeds
+        discord_call = mock_post.call_args_list[0]
+        assert discord_call.args[0] == webhook_url
+        assert "embeds" in discord_call.kwargs["json"]
+
+        # Second call was to Telegram with markdown text
+        telegram_call = mock_post.call_args_list[1]
+        assert "api.telegram.org" in telegram_call.args[0]
+        text = telegram_call.kwargs["json"]["text"]
+        assert "*🤖 자동 거래 실행 완료*" in text
+        assert "*오류 발생:* 1건" in text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notify_automation_summary_telegram_only(trade_notifier):
+    """Test automation summary uses Telegram when no Discord webhook configured."""
+    trade_notifier.configure(
+        bot_token="test_token",
+        chat_ids=["123456"],
+        enabled=True,
+        # No discord_webhook_alerts configured
+    )
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(
+        trade_notifier._http_client,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_post:
+        result = await trade_notifier.notify_automation_summary(
+            total_coins=10,
+            analyzed=10,
+            bought=3,
+            sold=2,
+            errors=0,
+            duration_seconds=45.5,
+        )
+
+        assert result is True
+        mock_post.assert_called_once()
+
+        # Verify Telegram was called directly
+        call_args = mock_post.call_args
+        assert "api.telegram.org" in call_args.args[0]
+        text = call_args.kwargs["json"]["text"]
+        assert "*🤖 자동 거래 실행 완료*" in text
+
+
+@pytest.mark.unit
+def test_format_automation_summary_telegram(trade_notifier):
+    """Test automation summary formatting for Telegram."""
+    message = trade_notifier._format_automation_summary_telegram(
+        total_coins=10,
+        analyzed=10,
+        bought=3,
+        sold=2,
+        errors=0,
+        duration_seconds=45.5,
+    )
+
+    # Verify markdown formatting
+    assert "*🤖 자동 거래 실행 완료*" in message
+    assert "*처리 종목:* 10개" in message
+    assert "*분석 완료:* 10개" in message
+    assert "*매수 주문:* 3건" in message
+    assert "*매도 주문:* 2건" in message
+    assert "*실행 시간:* 45.5초" in message
+    assert "오류" not in message  # No errors section when errors=0
+
+
+@pytest.mark.unit
+def test_format_automation_summary_telegram_with_errors(trade_notifier):
+    """Test automation summary formatting for Telegram with errors."""
+    message = trade_notifier._format_automation_summary_telegram(
+        total_coins=5,
+        analyzed=5,
+        bought=1,
+        sold=1,
+        errors=2,
+        duration_seconds=30.0,
+    )
+
+    # Verify markdown formatting including errors
+    assert "*🤖 자동 거래 실행 완료*" in message
+    assert "*오류 발생:* 2건" in message
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_to_discord_content_single_success(trade_notifier):
+    """Test sending plain text content to a specific Discord webhook."""
+    webhook_url = "https://discord.com/api/webhooks/alerts"
+    trade_notifier.configure(
+        bot_token="test_token",
+        chat_ids=["123456"],
+        enabled=True,
+        discord_webhook_alerts=webhook_url,
+    )
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+
+    with patch.object(
+        trade_notifier._http_client,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_post:
+        result = await trade_notifier._send_to_discord_content_single(
+            "Plain text message", webhook_url
+        )
+
+        assert result is True
+        mock_post.assert_called_once()
+
+        # Verify content format (not embeds)
+        call_args = mock_post.call_args
+        assert call_args.args[0] == webhook_url
+        assert call_args.kwargs["json"]["content"] == "Plain text message"
+        assert "embeds" not in call_args.kwargs["json"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_send_to_discord_content_single_failure(trade_notifier):
+    """Test Discord content send failure."""
+    webhook_url = "https://discord.com/api/webhooks/alerts"
+    trade_notifier.configure(
+        bot_token="test_token",
+        chat_ids=["123456"],
+        enabled=True,
+        discord_webhook_alerts=webhook_url,
+    )
+
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock(side_effect=Exception("Network error"))
+
+    with patch.object(
+        trade_notifier._http_client,
+        "post",
+        new_callable=AsyncMock,
+        return_value=mock_response,
+    ) as mock_post:
+        result = await trade_notifier._send_to_discord_content_single(
+            "Plain text message", webhook_url
+        )
+
+        assert result is False
+        mock_post.assert_called_once()


### PR DESCRIPTION
Fix two notification methods in `TradeNotifier` to follow Discord-first migration from #204. The `notify_openclaw_message()` and `notify_automation_summary()` methods currently bypass Discord and send Telegram-only, which is inconsistent with the Discord-first migration completed in issue #204.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Discord webhook integration for trade notifications with automatic Telegram fallback.
  * Implemented market-type-based notification routing (US, KR, crypto markets).

* **Tests**
  * Added comprehensive test coverage for notification delivery pathways, including Discord-first logic and Telegram fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->