### PR TITLE
fix-mcp-test-network-slowdown

### DIFF
--- a/tests/test_mcp_server_tools.py
+++ b/tests/test_mcp_server_tools.py
@@ -138,6 +138,7 @@ _PATCH_MODULES = (
     fundamentals_sources_finnhub,
     fundamentals_sources_indices,
     fundamentals_sources_naver,
+    market_data_indicators,
     market_data_quotes,
     order_execution,
     orders_history,
@@ -8763,8 +8764,8 @@ async def test_analyze_stock_us_reuses_yfinance_info(monkeypatch):
             }
         )
 
-    monkeypatch.setattr(
-        market_data_indicators,
+    _patch_runtime_attr(
+        monkeypatch,
         "_fetch_ohlcv_for_indicators",
         mock_fetch_ohlcv,
     )


### PR DESCRIPTION
Fix GitHub Actions CI slowdown caused by unintended network access in MCP test file. The `test_analyze_stock_us_reuses_yfinance_info` test has unintended Yahoo network access via `yf.download()` in `client.py`, and the runtime patch helper is missing `market_data_indicators` in `_PATCH_MODULES`, causing `AttributeError` when patching `_fetch_ohlcv_for_volume_profile`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Simplified notification delivery for trade automation and market alerts; notifications now send via Telegram only. Discord notification support has been removed.

* **Tests**
  * Updated test suite to reflect the current notification flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->