### PR TITLE
test(mcp): fix runtime patching for ohlcv helper mocks

### DIFF
--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -16,7 +16,6 @@ This module contains tests for:
 
 import dataclasses
 import json
-from collections.abc import Callable
 from unittest.mock import AsyncMock
 
 import httpx
@@ -26,8 +25,6 @@ import yfinance as yf
 
 import app.services.brokers.upbit.client as upbit_service
 from app.mcp_server.tooling import (
-    analysis_screening,
-    fundamentals_sources_binance,
     fundamentals_sources_coingecko,
     fundamentals_sources_indices,
     fundamentals_sources_naver,
@@ -35,16 +32,12 @@ from app.mcp_server.tooling import (
     shared,
 )
 from app.services import naver_finance
-
 from tests._mcp_tooling_support import (
-    DummyMCP,
-    DummySessionManager,
-    build_tools,
-    _patch_runtime_attr,
     _patch_httpx_async_client,
+    _patch_runtime_attr,
     _patch_yf_ticker,
+    build_tools,
 )
-
 
 # ---------------------------------------------------------------------------
 # analyze_stock Tool
@@ -2529,6 +2522,7 @@ class TestIndexMeta:
 def _fib_df_uptrend(n: int = 60) -> pd.DataFrame:
     """Create OHLCV DataFrame where low comes first, then high (uptrend)."""
     import datetime as dt
+
     import numpy as np
 
     dates = [dt.date.today() - dt.timedelta(days=n - 1 - i) for i in range(n)]
@@ -2549,6 +2543,7 @@ def _fib_df_uptrend(n: int = 60) -> pd.DataFrame:
 def _fib_df_downtrend(n: int = 60) -> pd.DataFrame:
     """Create OHLCV DataFrame where high comes first, then low (downtrend)."""
     import datetime as dt
+
     import numpy as np
 
     dates = [dt.date.today() - dt.timedelta(days=n - 1 - i) for i in range(n)]


### PR DESCRIPTION
## Summary
- add `market_data_indicators` to the MCP runtime patch helper so helper-based mocks can resolve `_fetch_ohlcv_for_volume_profile`
- patch `test_analyze_stock_us_reuses_yfinance_info` through `_patch_runtime_attr(...)` so the test hits the bound runtime symbol used by MCP tooling instead of the source module import
- keep production MCP code unchanged while removing the unintended Yahoo network path from the affected regression tests

## Test Plan
- `uv run pytest tests/test_mcp_server_tools.py -q --no-cov -k 'analyze_stock_us_reuses_yfinance_info or get_support_resistance_clusters_levels or sector_peers_us_dedupes_before_network_call' --durations=10`
- `uv run pytest tests/test_taskiq_broker.py tests/test_kr_hourly_candles_read_service.py -q --no-cov --durations=10`
- `uv run pytest tests/ -v --cov=app --cov-report=xml --cov-report=html` *(repository has unrelated pre-existing failures/hang outside this change; targeted regressions above pass)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-facing changes in this release. This update includes internal test infrastructure improvements to enhance testing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->