### PR TITLE
feat: Discord webhook notifications on CI/CD failure

### DIFF
--- a/.github/workflows/build-caddy.yml
+++ b/.github/workflows/build-caddy.yml
@@ -73,3 +73,21 @@ jobs:
           else
             echo "- **Image pushed**: ❌" >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Discord failure notification
+        if: failure()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          curl -s -H "Content-Type: application/json" \
+            -d "{
+              \"embeds\": [{
+                \"title\": \"❌ Caddy Build 실패\",
+                \"description\": \"**Branch:** \`${{ github.ref_name }}\`\n**Commit:** \`${GITHUB_SHA::7}\`\n**Author:** ${{ github.actor }}\",
+                \"url\": \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\",
+                \"color\": 16711680,
+                \"footer\": {\"text\": \"${{ github.repository }}\"},
+                \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+              }]
+            }" \
+            "$DISCORD_WEBHOOK"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,3 +101,25 @@ jobs:
           else
             echo "- **Image pushed**: ❌" >> $GITHUB_STEP_SUMMARY
           fi
+
+  notify:
+    if: failure()
+    needs: [build-and-push]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discord failure notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          curl -s -H "Content-Type: application/json" \
+            -d "{
+              \"embeds\": [{
+                \"title\": \"❌ Deploy 실패\",
+                \"description\": \"**Branch:** \`${{ github.ref_name }}\`\n**Commit:** \`${GITHUB_SHA::7}\`\n**Author:** ${{ github.actor }}\n**Image:** GHCR push failed\",
+                \"url\": \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\",
+                \"color\": 16711680,
+                \"footer\": {\"text\": \"${{ github.repository }}\"},
+                \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+              }]
+            }" \
+            "$DISCORD_WEBHOOK"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,3 +193,25 @@ jobs:
         path: |
           bandit-report.json
           safety-report.json
+
+  notify:
+    if: failure()
+    needs: [lint, test, security]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discord failure notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          curl -s -H "Content-Type: application/json" \
+            -d "{
+              \"embeds\": [{
+                \"title\": \"❌ Test CI 실패\",
+                \"description\": \"**Branch:** \`${{ github.ref_name }}\`\n**Commit:** \`${GITHUB_SHA::7}\`\n**Author:** ${{ github.actor }}\n**Trigger:** ${{ github.event_name }}\",
+                \"url\": \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\",
+                \"color\": 16711680,
+                \"footer\": {\"text\": \"${{ github.repository }}\"},
+                \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
+              }]
+            }" \
+            "$DISCORD_WEBHOOK"


### PR DESCRIPTION
## 변경사항

GitHub Actions 워크플로우 실패 시 Discord 웹훅으로 알림을 보내는 기능 추가.

### 적용 워크플로우
- **test.yml**: lint/test/security 중 하나라도 실패 → `notify` job 실행
- **deploy.yml**: GHCR 이미지 빌드/푸시 실패 → `notify` job 실행
- **build-caddy.yml**: Caddy 이미지 빌드 실패 → 인라인 step 실행

### 알림 내용
- 실패한 워크플로우 이름
- 브랜치, 커밋 해시, 작성자
- Actions run 링크 (클릭하면 바로 이동)

### 필요한 설정
`DISCORD_WEBHOOK_URL` Secret을 repo Settings → Secrets → Actions에 등록해야 합니다.

> Discord 서버 설정 → 연동 → 웹훅 → 새 웹훅 → URL 복사 → Secret에 붙여넣기

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline monitoring with automated failure notifications across build, deployment, and testing workflows for faster incident awareness and improved operational response times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->