### PR TITLE
feat: add clickable GitHub Actions link to Discord CI notification

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,7 +206,7 @@ jobs:
             -d "{
               \"embeds\": [{
                 \"title\": \"❌ Test CI 실패\",
-                \"description\": \"**Branch:** \`${{ github.ref_name }}\`\n**Commit:** \`${GITHUB_SHA::7}\`\n**Author:** ${{ github.actor }}\n**Trigger:** ${{ github.event_name }}\",
+                \"description\": \"**Branch:** \`${{ github.ref_name }}\`\n**Commit:** \`${GITHUB_SHA::7}\`\n**Author:** ${{ github.actor }}\n**Trigger:** ${{ github.event_name }}\n\n🔗 [GitHub Actions에서 보기](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\",
                 \"url\": \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\",
                 \"color\": 16711680,
                 \"footer\": {\"text\": \"${{ github.repository }}\"},


### PR DESCRIPTION
Discord CI 실패 알림 embed에 🔗 **GitHub Actions에서 보기** 클릭 링크 추가

**변경 사항:**
- `test.yml` notify job의 embed description에 명시적 링크 추가
- 기존: 제목 클릭으로만 Actions 페이지 이동 가능
- 변경: description 내 클릭 가능한 마크다운 링크 표시

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced failure notifications with a direct link to view run details on GitHub Actions, improving troubleshooting accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->