### PR TITLE
improve: Caddy 배포 순단 완화 설정

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -63,6 +63,10 @@
 			# Headers for proper subpath handling
 			header_up Host {host}
 			header_up X-Real-IP {remote_host}
+
+			# Retry on deploy (backend restart tolerance)
+			lb_try_duration 10s
+			lb_try_interval 500ms
 		}
 	}
 
@@ -80,6 +84,15 @@
 			# Headers
 			header_up Host {host}
 			header_up X-Real-IP {remote_host}
+
+			# Retry on deploy (backend restart tolerance)
+			lb_try_duration 10s
+			lb_try_interval 500ms
+
+			# Active health check
+			health_uri /healthz
+			health_interval 5s
+			health_timeout 3s
 		}
 	}
 


### PR DESCRIPTION
## Phase 2: Caddy 순단 완화

배포 시 컨테이너 재생성(2~3초) 동안 Caddy가 자동 재시도하여 클라이언트에 502 에러가 노출되지 않도록 개선.

### 변경 사항

**API (`host.docker.internal:8000`)**
- `lb_try_duration 10s` — 백엔드 연결 실패 시 10초간 재시도
- `lb_try_interval 500ms` — 0.5초 간격으로 재시도
- `health_uri /healthz` — 5초 간격 active health check

**MCP (`host.docker.internal:8765`)**
- `lb_try_duration 10s` + `lb_try_interval 500ms` — 동일 재시도 설정

### 효과
| | Before | After |
|---|---|---|
| 배포 중 클라이언트 경험 | 502 Bad Gateway (2~3초) | 응답 지연 (502 없음) |

### 적용 방법
머지 후 Caddy 컨테이너 재시작:
```bash
docker compose -f docker-compose.caddy.yml restart caddy
```
(또는 Caddy가 자동 reload 설정이면 자동 적용)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured automatic retry mechanisms with 10-second duration and 500ms intervals for improved reliability during service disruptions.
  * Added active health checks with 5-second monitoring intervals to verify backend service availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->