### PR TITLE
fix: align get_correlation symbol validation

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -114,20 +114,6 @@ Response format:
 - Upbit prerequisite: run `make sync-upbit-symbol-universe` (or `uv run python scripts/sync_upbit_symbol_universe.py`) right after migrations.
 - Scheduled sync task `symbols.upbit.universe.sync` runs daily at `06:15` KST (`cron: 15 6 * * *`, `cron_offset: Asia/Seoul`).
 
-### Company-name inputs
-- Read-only symbol tools support company-name inputs only when `market` is supplied explicitly.
-- `get_correlation` is the current exception: it has no `market` parameter, so it accepts ticker/code inputs only and rejects company-name inputs under the current API.
-- Supported explicit-market name resolution uses DB-backed universes only:
-  - `market="kr"` -> `kr_symbol_universe`
-  - `market="us"` -> `us_symbol_universe`
-- When a company name is missing, inactive, or ambiguous in the relevant universe, the tool returns the underlying lookup error with the existing sync hint.
-- When `market` is omitted for a company-name input (for example `삼성전자` or `Apple Inc.`), tools fail fast with:
-  - `"market is required for company-name inputs. Provide market='kr' or market='us', or use a ticker/code directly."`
-- For `get_correlation`, company-name inputs fail with:
-  - `"get_correlation does not support company-name inputs because it has no market parameter. Use ticker/code inputs directly."`
-- Runtime never infers `equity_us` from non-ASCII letters alone.
-- Order-entry tools do not use this company-name resolution path; they still require explicit tradable ticker/code inputs.
-
 ### `get_indicators` spec
 Parameters:
 - `symbol`: Asset symbol/ticker

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -37,10 +37,10 @@ from app.mcp_server.tooling.market_data_indicators import (
     _fetch_ohlcv_for_indicators,
 )
 from app.mcp_server.tooling.shared import (
-    COMPANY_NAME_MARKET_REQUIRED_MESSAGE,
-)
-from app.mcp_server.tooling.shared import (
-    resolve_readonly_symbol_input as _resolve_readonly_symbol_input,
+    is_crypto_market as _is_crypto_market,
+    is_korean_equity_code as _is_korean_equity_code,
+    is_us_equity_symbol as _is_us_equity_symbol,
+    resolve_market_type as _resolve_market_type,
 )
 from app.monitoring import build_yfinance_tracing_session
 from app.services.brokers.kis.client import KISClient
@@ -51,6 +51,28 @@ _CORRELATION_COMPANY_NAME_ERROR = (
     "get_correlation does not support company-name inputs because it has no "
     "market parameter. Use ticker/code inputs directly."
 )
+
+
+def _looks_like_correlation_company_name(symbol: str) -> bool:
+    normalized_symbol = _normalize_symbol_input(symbol, None)
+    if not normalized_symbol:
+        return False
+    if _is_crypto_market(normalized_symbol):
+        return False
+    if _is_korean_equity_code(normalized_symbol):
+        return False
+    if _is_us_equity_symbol(normalized_symbol):
+        return False
+    return any(ch.isalpha() for ch in normalized_symbol)
+
+
+def _resolve_correlation_symbol_input(symbol: str | int) -> tuple[str, str]:
+    normalized_symbol = _normalize_symbol_input(symbol, None)
+    if not normalized_symbol:
+        raise ValueError("symbol is required")
+    if _looks_like_correlation_company_name(normalized_symbol):
+        raise ValueError(_CORRELATION_COMPANY_NAME_ERROR)
+    return _resolve_market_type(normalized_symbol, None)
 
 name_to_corp_map: dict[str, Any]
 prime_index: Any | None
@@ -292,16 +314,14 @@ async def get_correlation_impl(
         symbol: str,
     ) -> tuple[str | None, str | None, list[float] | None, str | None, bool]:
         try:
-            market_type, normalized_symbol = await _resolve_readonly_symbol_input(
-                symbol, None
-            )
+            market_type, normalized_symbol = _resolve_correlation_symbol_input(symbol)
         except Exception as exc:
             return (
                 None,
                 None,
                 None,
                 f"{symbol}: {str(exc)}",
-                str(exc) == COMPANY_NAME_MARKET_REQUIRED_MESSAGE,
+                str(exc) == _CORRELATION_COMPANY_NAME_ERROR,
             )
 
         try:

--- a/tests/test_mcp_correlation_tools.py
+++ b/tests/test_mcp_correlation_tools.py
@@ -6,7 +6,6 @@ from unittest.mock import AsyncMock
 import pandas as pd
 import pytest
 
-from app.mcp_server.tooling.shared import COMPANY_NAME_MARKET_REQUIRED_MESSAGE
 from tests._mcp_tooling_support import _patch_runtime_attr, build_tools
 
 _CORRELATION_COMPANY_NAME_ERROR = (
@@ -80,7 +79,7 @@ async def test_get_correlation_rejects_korean_company_name_with_validation_error
         "success": False,
         "error": _CORRELATION_COMPANY_NAME_ERROR,
         "errors": [
-            f"삼성전자: {COMPANY_NAME_MARKET_REQUIRED_MESSAGE}",
+            f"삼성전자: {_CORRELATION_COMPANY_NAME_ERROR}",
         ],
     }
     fetch_mock.assert_awaited_once()
@@ -102,7 +101,7 @@ async def test_get_correlation_rejects_us_company_name_with_validation_error(
         "success": False,
         "error": _CORRELATION_COMPANY_NAME_ERROR,
         "errors": [
-            f"Apple Inc.: {COMPANY_NAME_MARKET_REQUIRED_MESSAGE}",
+            f"Apple Inc.: {_CORRELATION_COMPANY_NAME_ERROR}",
         ],
     }
     fetch_mock.assert_awaited_once()
@@ -126,7 +125,7 @@ async def test_get_correlation_keeps_partial_success_with_invalid_company_name(
     assert result["success"] is True
     assert result["symbols"] == ["005930", "AAPL"]
     assert result["errors"] == [
-        f"삼성전자: {COMPANY_NAME_MARKET_REQUIRED_MESSAGE}",
+        f"삼성전자: {_CORRELATION_COMPANY_NAME_ERROR}",
     ]
     assert result["correlation_matrix"] == [[1.0, 1.0], [1.0, 1.0]]
 


### PR DESCRIPTION
## Summary
- route `get_correlation` through the shared read-only symbol resolver so ticker/code inference stays intact while company-name inputs fail explicitly
- keep partial success when at least two symbols fetch successfully, and keep malformed-symbol or downstream fetch shortfalls on the generic insufficient-data path
- add dedicated correlation MCP tests and document that `get_correlation` remains ticker/code-only because it has no `market` parameter

## Test Plan
- [x] `uv run pytest tests/test_mcp_correlation_tools.py tests/test_mcp_shared_utils.py::TestResolveReadonlySymbolInput -q`
- [x] `uv run ruff check app/mcp_server/tooling/analysis_tool_handlers.py tests/test_mcp_correlation_tools.py`