### PR TITLE
fix: route fill alerts by market webhook

### DIFF
--- a/app/monitoring/trade_notifier.py
+++ b/app/monitoring/trade_notifier.py
@@ -144,15 +144,32 @@ class TradeNotifier:
         Returns:
             Discord webhook URL for the market type, or None if not configured
         """
-        # Normalize market type - handle both English and Korean
-        market_type_normalized = market_type.strip()
+        market_type_normalized = market_type.strip().lower()
 
-        # Map market types to webhooks
-        if market_type_normalized in ("US", "해외주식"):
+        if market_type_normalized in {
+            "us",
+            "usa",
+            "overseas",
+            "equity_us",
+            "해외주식",
+            "nas",
+            "nasd",
+            "nasdaq",
+            "nys",
+            "nyse",
+            "ams",
+            "amex",
+        }:
             return self._discord_webhook_us
-        elif market_type_normalized == "국내주식":
+        elif market_type_normalized in {
+            "kr",
+            "krx",
+            "domestic",
+            "equity_kr",
+            "국내주식",
+        }:
             return self._discord_webhook_kr
-        elif market_type_normalized == "암호화폐":
+        elif market_type_normalized in {"crypto", "cryptocurrency", "coin", "암호화폐"}:
             return self._discord_webhook_crypto
         else:
             logger.warning(f"Unknown market type: {market_type}")
@@ -1709,6 +1726,7 @@ class TradeNotifier:
         parse_mode: str = "Markdown",
         *,
         correlation_id: str | None = None,
+        market_type: str | None = None,
     ) -> bool:
         """
         Forward an OpenClaw outbound message to Discord or Telegram.
@@ -1738,10 +1756,17 @@ class TradeNotifier:
                 )
                 return False
 
-            # Try Discord first
-            if self._discord_webhook_alerts:
+            webhook_url: str | None = None
+            if market_type is not None:
+                webhook_url = self._get_webhook_for_market_type(market_type)
+                if webhook_url is None:
+                    discord_result = "skipped(no_market_webhook)"
+            else:
+                webhook_url = self._discord_webhook_alerts
+
+            if webhook_url:
                 discord_success = await self._send_to_discord_content_single(
-                    message, self._discord_webhook_alerts
+                    message, webhook_url
                 )
                 if discord_success:
                     discord_result = "success"

--- a/app/services/fill_notification.py
+++ b/app/services/fill_notification.py
@@ -25,6 +25,7 @@ class FillOrder:
     order_id: str | None = None
     order_type: str | None = None
     fill_status: str | None = None
+    market_type: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -70,6 +71,88 @@ def _normalize_fill_status(value: Any) -> str | None:
     normalized = text.lower()
     if normalized in {"filled", "partial"}:
         return normalized
+    return None
+
+
+def _normalize_market_type(value: Any) -> str | None:
+    text = _safe_text_or_none(value)
+    if text is None:
+        return None
+
+    normalized = text.lower()
+    aliases = {
+        "kr": "kr",
+        "krx": "kr",
+        "korea": "kr",
+        "korean": "kr",
+        "domestic": "kr",
+        "equity_kr": "kr",
+        "국내주식": "kr",
+        "300": "kr",
+        "us": "us",
+        "usa": "us",
+        "overseas": "us",
+        "equity_us": "us",
+        "해외주식": "us",
+        "nas": "us",
+        "nasd": "us",
+        "nasdaq": "us",
+        "nys": "us",
+        "nyse": "us",
+        "ams": "us",
+        "amex": "us",
+        "512": "us",
+        "513": "us",
+        "529": "us",
+        "crypto": "crypto",
+        "cryptocurrency": "crypto",
+        "coin": "crypto",
+        "암호화폐": "crypto",
+    }
+    return aliases.get(normalized)
+
+
+def _looks_like_kr_symbol(symbol: str) -> bool:
+    return symbol.isdigit() and len(symbol) == 6
+
+
+def _looks_like_crypto_symbol(symbol: str) -> bool:
+    normalized = symbol.strip().upper()
+    return normalized.startswith("KRW-") or normalized.startswith("USDT-")
+
+
+def _looks_like_us_symbol(symbol: str) -> bool:
+    normalized = symbol.strip()
+    if not normalized or normalized != normalized.upper():
+        return False
+    if normalized == "UNKNOWN":
+        return False
+    if _looks_like_crypto_symbol(normalized):
+        return False
+    cleaned = normalized.replace(".", "").replace("-", "").replace("/", "")
+    return (
+        bool(cleaned)
+        and cleaned[0].isalpha()
+        and cleaned.isalnum()
+        and 1 <= len(cleaned) <= 10
+    )
+
+
+def _resolve_fill_market_type(
+    raw: Mapping[str, Any], *, symbol: str, account: str | None = None
+) -> str | None:
+    explicit_market = _normalize_market_type(
+        _pick_first(raw, ["market_type", "market", "ovrs_excg_cd", "prdt_type_cd"])
+    )
+    if explicit_market is not None:
+        return explicit_market
+    normalized_account = _safe_text_or_none(account or raw.get("account"))
+    if normalized_account is not None and normalized_account.lower() == "upbit":
+        return "crypto"
+    if _looks_like_kr_symbol(symbol):
+        return "kr"
+    if _looks_like_us_symbol(symbol):
+        return "us"
     return None
 
 
@@ -119,20 +202,24 @@ def coerce_fill_order(order: FillOrderLike) -> FillOrder:
     if isinstance(order, FillOrder):
         return order
 
+    symbol = str(order.get("symbol") or "UNKNOWN")
+    account = str(order.get("account") or "unknown")
+
     return FillOrder(
-        symbol=str(order.get("symbol") or "UNKNOWN"),
+        symbol=symbol,
         side=_normalize_side(str(order.get("side") or "")),
         filled_price=_safe_float(order.get("filled_price")),
         filled_qty=_safe_float(order.get("filled_qty")),
         filled_amount=_safe_float(order.get("filled_amount")),
         filled_at=_parse_timestamp(order.get("filled_at")),
-        account=str(order.get("account") or "unknown"),
+        account=account,
         order_price=_safe_float_or_none(order.get("order_price")),
         order_id=_safe_text_or_none(order.get("order_id")),
         order_type=_safe_text_or_none(order.get("order_type")),
         fill_status=_normalize_fill_status(
             _pick_first(order, ["fill_status", "execution_status"])
         ),
+        market_type=_resolve_fill_market_type(order, symbol=symbol, account=account),
     )
 
 
@@ -170,11 +257,13 @@ def normalize_upbit_fill(raw: Mapping[str, Any]) -> FillOrder:
         order_id=_safe_text_or_none(_pick_first(raw, ["uuid", "order_id"])),
         order_type=_safe_text_or_none(_pick_first(raw, ["order_type", "ord_type"])),
         fill_status="filled",
+        market_type="crypto",
     )
 
 
 def normalize_kis_fill(raw: Mapping[str, Any]) -> FillOrder:
     symbol = str(_pick_first(raw, ["symbol", "pdno", "mksc_shrn_iscd"]) or "UNKNOWN")
+    account = str(_pick_first(raw, ["account"]) or "kis")
     side = _normalize_side(
         str(_pick_first(raw, ["side", "sll_buy_dvsn_cd", "buy_sell", "bsop_gb"]) or "")
     )
@@ -204,7 +293,7 @@ def normalize_kis_fill(raw: Mapping[str, Any]) -> FillOrder:
                 raw, ["filled_at", "timestamp", "exec_time", "ord_tmd", "ccld_time"]
             )
         ),
-        account=str(_pick_first(raw, ["account"]) or "kis"),
+        account=account,
         order_price=_safe_float_or_none(
             _pick_first(raw, ["order_price", "ord_unpr", "ft_ord_unpr3"])
         ),
@@ -215,6 +304,7 @@ def normalize_kis_fill(raw: Mapping[str, Any]) -> FillOrder:
         fill_status=_normalize_fill_status(
             _pick_first(raw, ["fill_status", "execution_status"])
         ),
+        market_type=_resolve_fill_market_type(raw, symbol=symbol, account=account),
     )
 
 

--- a/app/services/openclaw_client.py
+++ b/app/services/openclaw_client.py
@@ -50,14 +50,21 @@ class OpenClawClient:
         alert_type: str,
         *,
         correlation_id: str | None = None,
+        market_type: str | None = None,
     ) -> None:
         try:
             notifier = get_trade_notifier()
-            if correlation_id is None:
+            notifier_kwargs: dict[str, str] = {}
+            if correlation_id is not None:
+                notifier_kwargs["correlation_id"] = correlation_id
+            if market_type is not None:
+                notifier_kwargs["market_type"] = market_type
+
+            if not notifier_kwargs:
                 sent = await notifier.notify_openclaw_message(message)
             else:
                 sent = await notifier.notify_openclaw_message(
-                    message, correlation_id=correlation_id
+                    message, **notifier_kwargs
                 )
             if sent:
                 logger.debug(
@@ -246,6 +253,7 @@ class OpenClawClient:
                 message,
                 alert_type="fill",
                 correlation_id=correlation_id,
+                market_type=normalized_order.market_type,
             )
 
         if delivered_to_openclaw:

--- a/tests/test_fill_notification.py
+++ b/tests/test_fill_notification.py
@@ -1,5 +1,7 @@
 """Tests for fill notification normalization and formatting."""
 
+import pytest
+
 from app.services.fill_notification import (
     FillOrder,
     coerce_fill_order,
@@ -28,6 +30,7 @@ class TestNormalizeUpbitFill:
         assert order.filled_qty == 0.1
         assert order.filled_amount == 5_000_000
         assert order.account == "upbit"
+        assert order.market_type == "crypto"
 
     def test_normalize_with_order_metadata(self) -> None:
         raw = {
@@ -71,6 +74,7 @@ class TestNormalizeKisFill:
         assert order.filled_amount == 700_000
         assert order.order_id == "A123456789"
         assert order.account == "kis"
+        assert order.market_type == "kr"
 
     def test_normalize_overseas_fields(self) -> None:
         raw = {
@@ -91,6 +95,22 @@ class TestNormalizeKisFill:
         assert order.filled_amount == 391.0
         assert order.order_id == "US-ORDER-1234"
         assert order.account == "kis"
+        assert order.market_type == "us"
+
+    def test_normalize_kis_fill_prefers_explicit_market_field_over_symbol_inference(
+        self,
+    ) -> None:
+        raw = {
+            "pdno": "005930",
+            "market": "NASDAQ",
+            "sll_buy_dvsn_cd": "02",
+            "ccld_unpr": "70000",
+            "ccld_qty": "1",
+        }
+
+        order = normalize_kis_fill(raw)
+
+        assert order.market_type == "us"
 
     def test_normalize_kis_fill_propagates_execution_status_to_fill_status(
         self,
@@ -124,6 +144,113 @@ class TestNormalizeKisFill:
 
         assert order.fill_status == "partial"
 
+    def test_coerce_fill_order_prefers_market_type_over_market_alias(self) -> None:
+        order = coerce_fill_order(
+            {
+                "symbol": "005930",
+                "side": "02",
+                "filled_price": 100,
+                "filled_qty": 1,
+                "filled_amount": 100,
+                "filled_at": "2026-02-14T09:30:00",
+                "account": "kis",
+                "market_type": "kr",
+                "market": "NASDAQ",
+            }
+        )
+
+        assert order.market_type == "kr"
+
+    @pytest.mark.parametrize(
+        ("market", "expected_market_type"),
+        [("kr", "kr"), ("us", "us"), ("NASDAQ", "us")],
+    )
+    def test_coerce_fill_order_normalizes_raw_market_aliases(
+        self, market: str, expected_market_type: str
+    ) -> None:
+        order = coerce_fill_order(
+            {
+                "symbol": "005930" if expected_market_type == "kr" else "AAPL",
+                "side": "02",
+                "filled_price": 100,
+                "filled_qty": 1,
+                "filled_amount": 100,
+                "filled_at": "2026-02-14T09:30:00",
+                "account": "kis",
+                "market": market,
+            }
+        )
+
+        assert order.market_type == expected_market_type
+
+    def test_coerce_fill_order_uses_upbit_account_market_fallback(self) -> None:
+        order = coerce_fill_order(
+            {
+                "symbol": "KRW-BTC",
+                "side": "BID",
+                "filled_price": 100,
+                "filled_qty": 1,
+                "filled_amount": 100,
+                "filled_at": "2026-02-14T09:30:00",
+                "account": "upbit",
+            }
+        )
+
+        assert order.market_type == "crypto"
+
+    @pytest.mark.parametrize(
+        ("symbol", "expected_market_type"),
+        [("005930", "kr"), ("AAPL", "us")],
+    )
+    def test_coerce_fill_order_infers_safe_kis_market_from_symbol_shape(
+        self, symbol: str, expected_market_type: str
+    ) -> None:
+        order = coerce_fill_order(
+            {
+                "symbol": symbol,
+                "side": "02",
+                "filled_price": 100,
+                "filled_qty": 1,
+                "filled_amount": 100,
+                "filled_at": "2026-02-14T09:30:00",
+                "account": "kis",
+            }
+        )
+
+        assert order.market_type == expected_market_type
+
+    def test_coerce_fill_order_keeps_unknown_market_for_crypto_like_symbol_without_hint(
+        self,
+    ) -> None:
+        order = coerce_fill_order(
+            {
+                "symbol": "KRW-BTC",
+                "side": "BID",
+                "filled_price": 100,
+                "filled_qty": 1,
+                "filled_amount": 100,
+                "filled_at": "2026-02-14T09:30:00",
+                "account": "unknown",
+            }
+        )
+
+        assert order.market_type is None
+
+    def test_coerce_fill_order_missing_symbol_does_not_infer_us_market(self) -> None:
+        order = coerce_fill_order(
+            {
+                "side": "02",
+                "filled_price": 100,
+                "filled_qty": 1,
+                "filled_amount": 100,
+                "filled_at": "2026-02-14T09:30:00",
+                "account": "kis",
+            }
+        )
+
+        assert order.symbol == "UNKNOWN"
+        assert order.market_type is None
+
     def test_normalize_missing_fields_best_effort(self) -> None:
         order = normalize_kis_fill({})
 
@@ -133,6 +260,7 @@ class TestNormalizeKisFill:
         assert order.filled_qty == 0
         assert order.filled_amount == 0
         assert order.account == "kis"
+        assert order.market_type is None
         assert order.filled_at
 
 

--- a/tests/test_openclaw_client.py
+++ b/tests/test_openclaw_client.py
@@ -205,6 +205,7 @@ async def test_send_fill_notification_returns_none_when_disabled(
         filled_amount=5000000,
         filled_at="2024-01-01T00:00:00Z",
         account="upbit",
+        market_type="crypto",
     )
 
     result = await OpenClawClient().send_fill_notification(order)
@@ -233,6 +234,7 @@ async def test_send_fill_notification_success(
         filled_at="2024-01-01T00:00:00Z",
         account="upbit",
         order_id="order-123",
+        market_type="crypto",
     )
 
     mock_cli = AsyncMock()
@@ -264,10 +266,62 @@ async def test_send_fill_notification_success(
     assert called_json["wakeMode"] == "now"
     assert "🟢 체결 알림" in called_json["message"]
     mock_notifier.notify_openclaw_message.assert_awaited_once_with(
-        called_json["message"], correlation_id="corr-fill-success"
+        called_json["message"],
+        correlation_id="corr-fill-success",
+        market_type="crypto",
     )
     assert "correlation_id=corr-fill-success" in caplog.text
     assert f"request_id={result}" in caplog.text
+
+
+@pytest.mark.asyncio
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_fill_notification_raw_mapping_forwards_canonical_market_type(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
+    monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
+    monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+
+    order = {
+        "symbol": "AAPL",
+        "side": "02",
+        "filled_price": 195.5,
+        "filled_qty": 2,
+        "filled_amount": 391,
+        "filled_at": "2026-02-14T09:30:00-05:00",
+        "account": "kis",
+        "market": "NASDAQ",
+    }
+
+    mock_cli = AsyncMock()
+    mock_res = MagicMock(status_code=200)
+    mock_res.raise_for_status.return_value = None
+    mock_cli.post.return_value = mock_res
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    mock_notifier = MagicMock()
+    mock_notifier.notify_openclaw_message = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.services.openclaw_client.get_trade_notifier",
+        lambda: mock_notifier,
+    )
+
+    result = await OpenClawClient().send_fill_notification(
+        order, correlation_id="corr-fill-raw-market"
+    )
+
+    assert result is not None
+    mock_notifier.notify_openclaw_message.assert_awaited_once_with(
+        mock_notifier.notify_openclaw_message.await_args.args[0],
+        correlation_id="corr-fill-raw-market",
+        market_type="us",
+    )
 
 
 @pytest.mark.asyncio
@@ -391,6 +445,7 @@ async def test_send_fill_notification_returns_none_after_all_retries_fail(
         filled_amount=5000000,
         filled_at="2024-01-01T00:00:00Z",
         account="upbit",
+        market_type="crypto",
     )
 
     mock_cli = AsyncMock()
@@ -439,6 +494,7 @@ async def test_send_fill_notification_forwards_telegram_when_openclaw_fails(
         filled_amount=5000000,
         filled_at="2024-01-01T00:00:00Z",
         account="upbit",
+        market_type="crypto",
     )
 
     mock_cli = AsyncMock()
@@ -468,8 +524,11 @@ async def test_send_fill_notification_forwards_telegram_when_openclaw_fails(
     assert result is None
     assert mock_cli.post.call_count == 4
     assert elapsed < 2.0
-    mock_notifier.notify_openclaw_message.assert_awaited_once()
-    forwarded_message = mock_notifier.notify_openclaw_message.await_args.args[0]
+    mock_notifier.notify_openclaw_message.assert_awaited_once_with(
+        forwarded_message := mock_notifier.notify_openclaw_message.await_args.args[0],
+        correlation_id="corr-openclaw-fail-mirror-success",
+        market_type="crypto",
+    )
     assert "체결 알림" in forwarded_message
     assert "corr-openclaw-fail-mirror-success" in caplog.text
 

--- a/tests/test_trade_notifier.py
+++ b/tests/test_trade_notifier.py
@@ -715,6 +715,127 @@ async def test_notify_sell_order_disabled(trade_notifier):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("market_type", "expected_webhook"),
+    [
+        ("kr", "https://discord.com/api/webhooks/kr"),
+        ("us", "https://discord.com/api/webhooks/us"),
+        ("crypto", "https://discord.com/api/webhooks/crypto"),
+    ],
+)
+async def test_notify_openclaw_message_fill_uses_market_specific_webhook(
+    trade_notifier,
+    market_type: str,
+    expected_webhook: str,
+):
+    trade_notifier.configure(
+        bot_token="test_token",
+        chat_ids=["123456"],
+        enabled=True,
+        discord_webhook_us="https://discord.com/api/webhooks/us",
+        discord_webhook_kr="https://discord.com/api/webhooks/kr",
+        discord_webhook_crypto="https://discord.com/api/webhooks/crypto",
+        discord_webhook_alerts="https://discord.com/api/webhooks/alerts",
+    )
+
+    with (
+        patch.object(
+            trade_notifier,
+            "_send_to_discord_content_single",
+            new=AsyncMock(return_value=True),
+        ) as mock_discord,
+        patch.object(
+            trade_notifier,
+            "_send_to_telegram",
+            new=AsyncMock(return_value=True),
+        ) as mock_telegram,
+    ):
+        result = await trade_notifier.notify_openclaw_message(
+            "fill message",
+            correlation_id=f"corr-fill-{market_type}",
+            market_type=market_type,
+        )
+
+    assert result is True
+    mock_discord.assert_awaited_once_with("fill message", expected_webhook)
+    mock_telegram.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notify_openclaw_message_fill_skips_alerts_when_market_webhook_missing(
+    trade_notifier,
+):
+    trade_notifier.configure(
+        bot_token="test_token",
+        chat_ids=["123456"],
+        enabled=True,
+        discord_webhook_alerts="https://discord.com/api/webhooks/alerts",
+    )
+
+    with (
+        patch.object(
+            trade_notifier,
+            "_send_to_discord_content_single",
+            new=AsyncMock(return_value=True),
+        ) as mock_discord,
+        patch.object(
+            trade_notifier,
+            "_send_to_telegram",
+            new=AsyncMock(return_value=True),
+        ) as mock_telegram,
+    ):
+        result = await trade_notifier.notify_openclaw_message(
+            "fill message",
+            correlation_id="corr-fill-no-market-webhook",
+            market_type="kr",
+        )
+
+    assert result is True
+    mock_discord.assert_not_awaited()
+    mock_telegram.assert_awaited_once_with("fill message", parse_mode="Markdown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notify_openclaw_message_fill_discord_failure_falls_back_to_telegram(
+    trade_notifier,
+):
+    trade_notifier.configure(
+        bot_token="test_token",
+        chat_ids=["123456"],
+        enabled=True,
+        discord_webhook_kr="https://discord.com/api/webhooks/kr",
+        discord_webhook_alerts="https://discord.com/api/webhooks/alerts",
+    )
+
+    with (
+        patch.object(
+            trade_notifier,
+            "_send_to_discord_content_single",
+            new=AsyncMock(return_value=False),
+        ) as mock_discord,
+        patch.object(
+            trade_notifier,
+            "_send_to_telegram",
+            new=AsyncMock(return_value=True),
+        ) as mock_telegram,
+    ):
+        result = await trade_notifier.notify_openclaw_message(
+            "fill message",
+            correlation_id="corr-fill-discord-failed",
+            market_type="kr",
+        )
+
+    assert result is True
+    mock_discord.assert_awaited_once_with(
+        "fill message", "https://discord.com/api/webhooks/kr"
+    )
+    mock_telegram.assert_awaited_once_with("fill message", parse_mode="Markdown")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_notify_openclaw_message_success(trade_notifier):
     """Test successful OpenClaw message forwarding."""
     trade_notifier.configure(
@@ -738,6 +859,40 @@ async def test_notify_openclaw_message_success(trade_notifier):
         mock_post.assert_called_once()
         call_args = mock_post.call_args
         assert call_args.kwargs["json"]["text"] == "scan message"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_notify_openclaw_message_generic_scan_uses_alerts_webhook(trade_notifier):
+    trade_notifier.configure(
+        bot_token="test_token",
+        chat_ids=["123456"],
+        enabled=True,
+        discord_webhook_us="https://discord.com/api/webhooks/us",
+        discord_webhook_kr="https://discord.com/api/webhooks/kr",
+        discord_webhook_crypto="https://discord.com/api/webhooks/crypto",
+        discord_webhook_alerts="https://discord.com/api/webhooks/alerts",
+    )
+
+    with (
+        patch.object(
+            trade_notifier,
+            "_send_to_discord_content_single",
+            new=AsyncMock(return_value=True),
+        ) as mock_discord,
+        patch.object(
+            trade_notifier,
+            "_send_to_telegram",
+            new=AsyncMock(return_value=True),
+        ) as mock_telegram,
+    ):
+        result = await trade_notifier.notify_openclaw_message("scan message")
+
+    assert result is True
+    mock_discord.assert_awaited_once_with(
+        "scan message", "https://discord.com/api/webhooks/alerts"
+    )
+    mock_telegram.assert_not_awaited()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- route OpenClaw fill mirrors to KR/US/crypto Discord webhooks
- preserve generic OpenClaw alerts on DISCORD_WEBHOOK_ALERTS
- add raw FillOrderLike market coercion and regression coverage

## Test Plan
- [x] make test
- [x] uv run pytest tests/test_fill_notification.py tests/test_openclaw_client.py tests/test_trade_notifier.py tests/test_websocket_monitor.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Market-type-aware notification routing: Trading notifications now intelligently route to market-specific channels based on asset type (US equities, Korean equities, crypto) with automatic fallback mechanisms when primary channels are unavailable.
  * Automatic market detection: The system now infers market classification from trading data and symbols for improved notification categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->