### PR TITLE
fix: expose analyze_stock recommendation rsi14

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -158,6 +158,17 @@ Examples:
 - Allowed: `symbol="KRW-ETC"` (market omitted)
 - Rejected: `symbol="ETC"` (market omitted)
 
+### `analyze_stock` spec
+
+Parameters:
+- `symbol`: Asset symbol/ticker/code (required; string or int accepted)
+- `market`: Market - `"kr"`, `"us"`, `"crypto"` (optional, inferred from symbol if omitted)
+- `include_peers`: Whether to include sector peer analysis for KR/US equities (default: false; ignored for crypto)
+
+Response notes:
+- Equity responses (KR/US markets) include `recommendation.rsi14` when RSI(14) is available from the indicator payload
+- This field provides a convenient summary; callers should continue to use `get_indicators` when they need the full indicator set rather than the summarized recommendation field
+
 ### `get_correlation` spec
 Parameters:
 - `symbols`: List of asset ticker/code inputs (required, 2-10 entries)

--- a/app/mcp_server/tooling/shared.py
+++ b/app/mcp_server/tooling/shared.py
@@ -533,6 +533,38 @@ def recalculate_profit_fields(position: dict[str, Any]) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _extract_rsi14(indicators: dict[str, Any] | None) -> float | None:
+    """Extract RSI(14) value from various indicator payload shapes.
+
+    Handles:
+    - {"indicators": {"rsi": {"14": 45.8}}}
+    - {"rsi": {"14": 45.8}}
+    - {"rsi": 45.8} (scalar RSI)
+
+    Returns None only when RSI value is actually absent.
+    """
+    if not indicators:
+        return None
+
+    # Handle {"indicators": {...}} wrapper
+    indicators_dict = indicators.get("indicators", indicators)
+
+    rsi_data = indicators_dict.get("rsi")
+    if rsi_data is None:
+        return None
+
+    if isinstance(rsi_data, dict):
+        # Try "14" string key first, then 14 int key
+        rsi = rsi_data.get("14")
+        if rsi is None:
+            rsi = rsi_data.get(14)
+        return rsi
+    elif isinstance(rsi_data, (int, float)):
+        return float(rsi_data)
+
+    return None
+
+
 def build_recommendation_for_equity(
     analysis: dict[str, Any],
     market_type: str,
@@ -554,6 +586,7 @@ def build_recommendation_for_equity(
     recommendation: dict[str, Any] = {
         "action": "hold",
         "confidence": "low",
+        "rsi14": None,
         "buy_zones": [],
         "sell_targets": [],
         "stop_loss": None,
@@ -564,29 +597,23 @@ def build_recommendation_for_equity(
     score = 0
     max_score = 0
 
-    if indicators:
-        indicators_dict = indicators.get("indicators", indicators)
-        rsi_data = indicators_dict.get("rsi")
-        rsi = None
-        if isinstance(rsi_data, dict):
-            rsi = rsi_data.get("14") or rsi_data.get(14)
-        elif isinstance(rsi_data, (int, float)):
-            rsi = rsi_data
-
-        if rsi:
-            max_score += 2
-            if rsi < 30:
-                score += 2
-                reasoning_parts.append(f"RSI {rsi:.1f} (oversold)")
-            elif rsi < 40:
-                score += 1
-                reasoning_parts.append(f"RSI {rsi:.1f} (bearish)")
-            elif rsi > 70:
-                score -= 2
-                reasoning_parts.append(f"RSI {rsi:.1f} (overbought)")
-            elif rsi > 60:
-                score -= 1
-                reasoning_parts.append(f"RSI {rsi:.1f} (bullish)")
+    # Use helper for RSI extraction
+    rsi = _extract_rsi14(indicators)
+    if rsi is not None:  # FIX: use "is not None" to keep 0.0
+        recommendation["rsi14"] = rsi  # NEW: store rsi14 in recommendation
+        max_score += 2
+        if rsi < 30:
+            score += 2
+            reasoning_parts.append(f"RSI {rsi:.1f} (oversold)")
+        elif rsi < 40:
+            score += 1
+            reasoning_parts.append(f"RSI {rsi:.1f} (bearish)")
+        elif rsi > 70:
+            score -= 2
+            reasoning_parts.append(f"RSI {rsi:.1f} (overbought)")
+        elif rsi > 60:
+            score -= 1
+            reasoning_parts.append(f"RSI {rsi:.1f} (bullish)")
 
     if consensus:
         buy_count = consensus.get("buy_count", 0)

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -168,6 +168,68 @@ class TestAnalyzeStock:
         assert "stop_loss" in rec
         assert "reasoning" in rec
 
+    async def test_build_recommendation_for_equity_exposes_rsi14(self):
+        """Test that rsi14 value is exposed in recommendation payload."""
+        analysis = {
+            "quote": {"price": 150.0},
+            "indicators": {"indicators": {"rsi": {"14": 45.8}}},
+            "support_resistance": {"supports": [], "resistances": []},
+        }
+        rec = shared.build_recommendation_for_equity(analysis, "equity_us")
+        assert rec is not None
+        assert rec["rsi14"] == 45.8
+
+    async def test_build_recommendation_for_equity_keeps_zero_rsi(self):
+        """Test that rsi14=0.0 is NOT treated as missing."""
+        analysis = {
+            "quote": {"price": 150.0},
+            "indicators": {"indicators": {"rsi": {"14": 0.0}}},
+            "support_resistance": {"supports": [], "resistances": []},
+        }
+        rec = shared.build_recommendation_for_equity(analysis, "equity_us")
+        assert rec is not None
+        assert rec["rsi14"] == 0.0
+
+    async def test_analyze_stock_us_includes_recommendation_rsi14(self, monkeypatch):
+        """Test that rsi14 is surfaced in recommendation payload for US market."""
+        tools = build_tools()
+
+        async def mock_fetch_ohlcv(symbol, market_type, count):
+            return pd.DataFrame(
+                {
+                    "date": ["2024-01-01"],
+                    "open": [150.0],
+                    "high": [155.0],
+                    "low": [148.0],
+                    "close": [150.0],
+                    "volume": [1000000],
+                }
+            )
+
+        async def mock_get_indicators(
+            symbol, indicators, market=None, preloaded_df=None
+        ):
+            return {"indicators": {"rsi": {"14": 45.8}, "bollinger": {"lower": 145.0}}}
+
+        async def mock_get_support_resistance(symbol, market=None, preloaded_df=None):
+            return {"supports": [{"price": 140.0}], "resistances": [{"price": 160.0}]}
+
+        async def mock_get_quote(symbol, market_type):
+            return {"symbol": symbol, "price": 150.0, "instrument_type": "equity_us"}
+
+        _patch_runtime_attr(
+            monkeypatch, "_fetch_ohlcv_for_indicators", mock_fetch_ohlcv
+        )
+        _patch_runtime_attr(monkeypatch, "_get_indicators_impl", mock_get_indicators)
+        _patch_runtime_attr(
+            monkeypatch, "_get_support_resistance_impl", mock_get_support_resistance
+        )
+        _patch_runtime_attr(monkeypatch, "_get_quote_impl", mock_get_quote)
+
+        result = await tools["analyze_stock"]("AAPL", market="us")
+
+        assert result["recommendation"]["rsi14"] == 45.8
+
     async def test_recommendation_not_included_crypto(self, monkeypatch):
         tools = build_tools()
 


### PR DESCRIPTION
## Summary
- expose recommendation.rsi14 from the existing analyze_stock indicator payload for equity responses
- preserve 0.0 RSI values instead of dropping them through falsy checks
- document the actual analyze_stock parameters and add regression coverage for the new response field

## Test Plan
- [x] uv run pytest tests/test_mcp_fundamentals_tools.py -v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RSI(14) indicator now included in equity recommendation results
  * Configurable period parameter added to get_correlation (range: 30-365 days)

* **Documentation**
  * Updated analyze_stock specification with detailed parameters and response guidance
  * Enhanced get_correlation specification with period parameter documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->