### PR TITLE
feat: add analyze_stock_batch MCP tool

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -63,6 +63,11 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - `manage_watch_alerts(action, market=None, symbol=None, metric=None, operator=None, threshold=None)`
 - `screen_stocks(...)` - Screen stocks across different markets (KR/US/Crypto) with various filters.
 - `recommend_stocks(...)` - Recommend stocks based on budget and strategy.
+- `analyze_stock_batch(symbols, market=None, include_peers=False, quick=True)`
+  - Analyze multiple symbols in parallel and return compact per-symbol summaries
+  - Default `quick=True` returns compact summary with: symbol, current_price, rsi_14, consensus, recommendation, supports (top 3), resistances (top 3)
+  - Set `quick=False` for full analysis payload (like `analyze_portfolio`)
+  - Example: `analyze_stock_batch(symbols=["NVDA", "AMZN", "MSFT", "GOOGL"], market="us")`
 
 ### `get_orderbook` spec
 Parameters:
@@ -603,3 +608,4 @@ docker compose -f docker-compose.prod.yml up -d mcp
 ```
 
 > Note: current prod compose uses `network_mode: host`, so port publishing is handled by the host network.
+

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from app.mcp_server.tooling.analysis_tool_handlers import (
     analyze_portfolio_impl,
+    analyze_stock_batch_impl,
     analyze_stock_impl,
     get_correlation_impl,
     get_disclosures_impl,
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
 ANALYSIS_TOOL_NAMES: set[str] = {
     "analyze_stock",
     "analyze_portfolio",
+    "analyze_stock_batch",
     "screen_stocks",
     "recommend_stocks",
     "get_top_stocks",
@@ -127,6 +129,28 @@ def register_analysis_tools(mcp: FastMCP) -> None:
             market=market,
             include_peers=include_peers,
         )
+
+    @mcp.tool(
+        name="analyze_stock_batch",
+        description=(
+            "Analyze multiple stocks in parallel with compact summaries. "
+            "Returns per-symbol compact summary (symbol, price, RSI, consensus, supports/resistances) "
+            "by default, or full analysis when quick=False."
+        ),
+    )
+    async def analyze_stock_batch(
+        symbols: list[str | int],
+        market: str | None = None,
+        include_peers: bool = False,
+        quick: bool = True,
+    ) -> dict[str, Any]:
+        return await analyze_stock_batch_impl(
+            symbols=symbols,
+            market=market,
+            include_peers=include_peers,
+            quick=quick,
+        )
+
 
     @mcp.tool(
         name="screen_stocks",

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import datetime
 import logging
+from collections.abc import Callable
 from typing import Any, Literal
 
 import httpx
@@ -367,11 +368,27 @@ async def analyze_stock_impl(
     return result
 
 
-async def analyze_portfolio_impl(
+async def _run_batch_analysis(
     symbols: list[str | int],
-    market: str | None = None,
-    include_peers: bool = False,
+    *,
+    market: str | None,
+    include_peers: bool,
+    formatter: Callable[[str, dict[str, Any]], dict[str, Any]],
 ) -> dict[str, Any]:
+    """Shared batch analysis executor for portfolio and stock batch analysis.
+
+    Args:
+        symbols: List of symbol inputs (1-10 entries)
+        market: Optional market override
+        include_peers: Whether to include peer analysis
+        formatter: Callable that receives (normalized_symbol, analysis_result) and returns formatted result
+
+    Returns:
+        Dict with 'results' (symbol -> formatted_result) and 'summary' keys
+
+    Raises:
+        ValueError: If symbols list is empty or exceeds 10 entries
+    """
     if not symbols:
         raise ValueError("symbols must contain at least one entry")
 
@@ -405,7 +422,8 @@ async def analyze_portfolio_impl(
     success_count = 0
     fail_count = 0
     for sym, result in zip(normalized_symbols, analyze_results, strict=True):
-        results[sym] = result
+        formatted_result = formatter(sym, result)
+        results[sym] = formatted_result
         if "error" not in result:
             success_count += 1
         else:
@@ -420,6 +438,79 @@ async def analyze_portfolio_impl(
             "errors": errors,
         },
     }
+
+
+def _summarize_analysis_result(
+    symbol: str,
+    analysis: dict[str, Any],
+) -> dict[str, Any]:
+    """Convert full analysis into compact summary for batch responses."""
+    # If result is an error, pass through unchanged
+    if "error" in analysis:
+        return analysis
+
+    quote = analysis.get("quote") or {}
+    indicators = (analysis.get("indicators") or {}).get("indicators", {})
+    rsi = (indicators.get("rsi") or {}).get("14")
+    sr = analysis.get("support_resistance") or {}
+
+    return {
+        "symbol": symbol,
+        "market_type": analysis.get("market_type"),
+        "source": analysis.get("source"),
+        "current_price": quote.get("price") or quote.get("current_price"),
+        "rsi_14": rsi,
+        "consensus": ((analysis.get("opinions") or {}).get("consensus")),
+        "recommendation": analysis.get("recommendation"),
+        "supports": (sr.get("supports") or [])[:3],
+        "resistances": (sr.get("resistances") or [])[:3],
+    }
+
+
+async def analyze_stock_batch_impl(
+    symbols: list[str | int],
+    market: str | None = None,
+    include_peers: bool = False,
+    quick: bool = True,
+) -> dict[str, Any]:
+    """Analyze multiple symbols and return compact per-symbol summaries.
+    Args:
+        symbols: List of symbol inputs (1-10 entries)
+        market: Optional market override
+        include_peers: Whether to include peer analysis
+        quick: If True, return compact summary; if False, return full analysis
+    Returns:
+        Dict with 'results' (symbol -> summary) and 'summary' keys
+    """
+    formatter = _summarize_analysis_result if quick else (lambda _sym, result: result)
+    return await _run_batch_analysis(
+        symbols,
+        market=market,
+        include_peers=include_peers,
+        formatter=formatter,
+    )
+
+async def analyze_portfolio_impl(
+    symbols: list[str | int],
+    market: str | None = None,
+    include_peers: bool = False,
+) -> dict[str, Any]:
+    """Analyze a portfolio of symbols.
+
+    Args:
+        symbols: List of symbol inputs (1-10 entries)
+        market: Optional market override
+        include_peers: Whether to include peer analysis
+
+    Returns:
+        Dict with 'results' (symbol -> analysis_result) and 'summary' keys
+    """
+    return await _run_batch_analysis(
+        symbols,
+        market=market,
+        include_peers=include_peers,
+        formatter=lambda _sym, result: result,
+    )
 
 
 async def screen_stocks_impl(

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -14,6 +14,7 @@ This module contains tests for:
 - get_investment_opinions tool
 """
 
+import asyncio
 import dataclasses
 import json
 from unittest.mock import AsyncMock
@@ -288,6 +289,163 @@ class TestAnalyzeStock:
         # Both symbols should be normalized to 6-digit strings
         assert "012450" in result["results"]
         assert "005930" in result["results"]
+
+
+@pytest.mark.asyncio
+class TestAnalyzeStockBatch:
+    """Test analyze_stock_batch tool."""
+
+    async def test_analyze_stock_batch_registration(self):
+        """Test that analyze_stock_batch is registered as an MCP tool."""
+        tools = build_tools()
+
+        assert "analyze_stock_batch" in tools
+
+    async def test_analyze_stock_batch_quick_summary(self, monkeypatch):
+        """Test that analyze_stock_batch returns the compact summary contract."""
+        tools = build_tools()
+
+        mock_analysis = {
+            "symbol": "005930",
+            "market_type": "equity_kr",
+            "source": "kis",
+            "quote": {"price": 75000},
+            "indicators": {
+                "indicators": {
+                    "rsi": {"14": 45.0},
+                    "bollinger": {"lower": 74000},
+                }
+            },
+            "support_resistance": {
+                "supports": [{"price": 73000}],
+                "resistances": [{"price": 77000, "strength": "medium"}],
+            },
+            "opinions": {
+                "consensus": {
+                    "buy_count": 2,
+                    "avg_target_price": 85000,
+                    "current_price": 75000,
+                }
+            },
+            "recommendation": {
+                "action": "hold",
+                "confidence": "low",
+            },
+            "news": [{"title": "Some news"}],
+            "profile": {"description": "Company profile"},
+        }
+
+        async def fake_impl(symbol: str, market: str | None, include_peers: bool):
+            return mock_analysis
+
+        _patch_runtime_attr(monkeypatch, "_analyze_stock_impl", fake_impl)
+
+        result = await tools["analyze_stock_batch"](["005930"], market="kr")
+
+        assert result["summary"] == {
+            "total_symbols": 1,
+            "successful": 1,
+            "failed": 0,
+            "errors": [],
+        }
+        assert result["results"]["005930"] == {
+            "symbol": "005930",
+            "market_type": "equity_kr",
+            "source": "kis",
+            "current_price": 75000,
+            "rsi_14": 45.0,
+            "consensus": {
+                "buy_count": 2,
+                "avg_target_price": 85000,
+                "current_price": 75000,
+            },
+            "recommendation": {
+                "action": "hold",
+                "confidence": "low",
+            },
+            "supports": [{"price": 73000}],
+            "resistances": [{"price": 77000, "strength": "medium"}],
+        }
+
+    async def test_analyze_stock_batch_quick_false_returns_full_payload(
+        self, monkeypatch
+    ):
+        """Test that quick=False returns the unsummarized full analysis payload."""
+        tools = build_tools()
+
+        mock_analysis = {
+            "symbol": "AAPL",
+            "market_type": "equity_us",
+            "source": "yahoo",
+            "quote": {"price": 185.5},
+            "news": [{"title": "Full payload should keep news"}],
+            "profile": {"name": "Apple Inc."},
+        }
+
+        async def fake_impl(symbol: str, market: str | None, include_peers: bool):
+            return mock_analysis
+
+        _patch_runtime_attr(monkeypatch, "_analyze_stock_impl", fake_impl)
+
+        result = await tools["analyze_stock_batch"](
+            ["AAPL"], market="us", quick=False
+        )
+
+        assert result["summary"] == {
+            "total_symbols": 1,
+            "successful": 1,
+            "failed": 0,
+            "errors": [],
+        }
+        assert result["results"]["AAPL"] == mock_analysis
+
+    async def test_analyze_stock_batch_kr_symbol_normalization(self, monkeypatch):
+        """Test that analyze_stock_batch normalizes numeric KR symbols."""
+        tools = build_tools()
+
+        def mock_impl(symbol: str, market: str | None, include_peers: bool):
+            return {
+                "symbol": symbol,
+                "market_type": "equity_kr",
+                "source": "kis",
+                "quote": {"price": 75000},
+            }
+
+        _patch_runtime_attr(monkeypatch, "_analyze_stock_impl", mock_impl)
+
+        result = await tools["analyze_stock_batch"]([12450, "005930"], market="kr")
+
+        assert "results" in result
+        assert "012450" in result["results"]
+        assert "005930" in result["results"]
+
+    async def test_analyze_stock_batch_concurrency(self, monkeypatch):
+        """Test that analyze_stock_batch executes symbol analysis concurrently."""
+        tools = build_tools()
+        call_tracker = {"active": 0, "max_active": 0}
+
+        async def fake_impl(symbol: str, market: str | None, include_peers: bool):
+            call_tracker["active"] += 1
+            call_tracker["max_active"] = max(
+                call_tracker["max_active"], call_tracker["active"]
+            )
+            await asyncio.sleep(0.01)
+            call_tracker["active"] -= 1
+            return {
+                "symbol": symbol,
+                "market_type": "equity_kr",
+                "source": "kis",
+                "quote": {"price": 75000},
+            }
+
+        _patch_runtime_attr(monkeypatch, "_analyze_stock_impl", fake_impl)
+
+        result = await tools["analyze_stock_batch"](
+            ["005930", "000660", "035420"], market="kr"
+        )
+
+        assert "results" in result
+        assert call_tracker["max_active"] > 1, "Expected concurrent execution"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add `analyze_stock_batch` as an MCP analysis tool with compact batch summaries and `quick=False` full-payload support
- extract shared batch execution in analysis handlers so `analyze_portfolio` and `analyze_stock_batch` reuse the same concurrency path
- tighten MCP fundamentals tests to lock the compact response contract, full-payload mode, KR normalization, and concurrency behavior

## Test Plan
- [x] `uv run pytest tests/test_mcp_fundamentals_tools.py -v`
- [x] `uv run ruff check tests/test_mcp_fundamentals_tools.py`