### PR TITLE
fix: distinguish skipped OpenClaw fill notifications

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -338,6 +338,9 @@ class Settings(BaseSettings):
     OPENCLAW_CALLBACK_URL: str = "http://localhost:8000/api/v1/openclaw/callback"
     OPENCLAW_SCREENER_CALLBACK_URL: str = "http://localhost:8000/api/screener/callback"
     OPENCLAW_ENABLED: bool = False
+    OPENCLAW_THREAD_KR: str | None = None
+    OPENCLAW_THREAD_US: str | None = None
+    OPENCLAW_THREAD_CRYPTO: str | None = None
 
     DAILY_SCAN_ENABLED: bool = False
     DAILY_SCAN_CRASH_THRESHOLD: float = 0.05

--- a/app/services/openclaw_client.py
+++ b/app/services/openclaw_client.py
@@ -1,5 +1,7 @@
 import json
 import logging
+from dataclasses import dataclass
+from typing import Literal
 from uuid import uuid4
 
 import httpx
@@ -22,6 +24,36 @@ logger = logging.getLogger(__name__)
 
 OPENCLAW_RETRY_STOP = stop_after_attempt(4)
 OPENCLAW_RETRY_WAIT = wait_exponential(multiplier=1, min=1, max=4)
+OPENCLAW_FILL_AGENT_NAME = "TradeAlert"
+OPENCLAW_FILL_AGENT_CHANNEL = "discord"
+OPENCLAW_FILL_AGENT_MODEL = "gpt"
+OPENCLAW_FILL_AGENT_TIMEOUT_SECONDS = 60
+OPENCLAW_FILL_MARKET_LABELS = {
+    "kr": "equity_kr",
+    "us": "equity_us",
+    "crypto": "crypto",
+}
+OPENCLAW_FILL_AGENT_INSTRUCTIONS = (
+    "반드시 `get_holdings`와 `analyze_stock`를 실행하세요.\n"
+    "최종 판단은 `buy`, `hold`, `sell` 중 정확히 하나만 선택하세요.\n"
+    "Discord 댓글 첫 줄은 반드시 `판단: buy`, `판단: hold`, `판단: sell` 중 하나로 시작하고, "
+    "그 다음 줄부터 현재 보유 상태, 이번 체결의 의미, 핵심 근거를 한국어로 간결하게 정리하세요."
+)
+
+FillNotificationDeliveryStatus = Literal["success", "skipped", "failed"]
+
+
+@dataclass(slots=True, frozen=True)
+class FillNotificationDeliveryResult:
+    status: FillNotificationDeliveryStatus
+    reason: str | None = None
+    request_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status == "success" and self.request_id is None:
+            raise ValueError("success results require a request_id")
+        if self.status != "success" and self.request_id is not None:
+            raise ValueError("request_id is only allowed for success results")
 
 
 def _build_openclaw_retrying() -> AsyncRetrying:
@@ -29,6 +61,66 @@ def _build_openclaw_retrying() -> AsyncRetrying:
         stop=OPENCLAW_RETRY_STOP,
         wait=OPENCLAW_RETRY_WAIT,
         reraise=False,
+    )
+
+
+def _normalize_optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _format_fill_side_text(side: str, fill_status: str | None) -> str:
+    side_text = {
+        "bid": "매수",
+        "ask": "매도",
+    }.get(side, "미확인")
+    fill_label = "부분체결" if fill_status == "partial" else "체결"
+    return f"{side_text} {fill_label}"
+
+
+def _format_fill_value(value: float) -> str:
+    rounded = round(value)
+    if abs(value - rounded) < 1e-12:
+        return f"{int(rounded):,}"
+    return f"{value:,.12f}".rstrip("0").rstrip(".")
+
+
+def _resolve_fill_agent_market(market_type: str | None) -> str | None:
+    if market_type is None:
+        return None
+    return OPENCLAW_FILL_MARKET_LABELS.get(market_type)
+
+
+def _resolve_fill_analysis_thread_id(market_type: str | None) -> str | None:
+    if market_type == "kr":
+        return _normalize_optional_text(settings.OPENCLAW_THREAD_KR)
+    if market_type == "us":
+        return _normalize_optional_text(settings.OPENCLAW_THREAD_US)
+    if market_type == "crypto":
+        return _normalize_optional_text(settings.OPENCLAW_THREAD_CRYPTO)
+    return None
+
+
+def _build_fill_agent_message(
+    normalized_order: FillOrderLike,
+    *,
+    agent_market: str,
+) -> str:
+    order = coerce_fill_order(normalized_order)
+    return (
+        "다음 체결 내역을 분석하고 Discord 판단 스레드에 전달할 메시지를 작성하세요.\n\n"
+        f"종목: {order.symbol}\n"
+        f"구분: {_format_fill_side_text(order.side, order.fill_status)}\n"
+        f"수량: {_format_fill_value(order.filled_qty)}\n"
+        f"체결가: {_format_fill_value(order.filled_price)}\n"
+        f"금액: {_format_fill_value(order.filled_amount)}\n"
+        f"시간: {order.filled_at}\n"
+        f"계좌: {order.account}\n"
+        f"마켓: {agent_market}\n\n"
+        "출력 규칙:\n"
+        f"{OPENCLAW_FILL_AGENT_INSTRUCTIONS}"
     )
 
 
@@ -40,9 +132,9 @@ class OpenClawClient:
         webhook_url: str | None = None,
         token: str | None = None,
     ) -> None:
-        self._webhook_url = webhook_url or settings.OPENCLAW_WEBHOOK_URL
-        self._token = token if token is not None else settings.OPENCLAW_TOKEN
-        self._callback_url = settings.OPENCLAW_CALLBACK_URL
+        self._webhook_url: str = webhook_url or settings.OPENCLAW_WEBHOOK_URL
+        self._token: str = token if token is not None else settings.OPENCLAW_TOKEN
+        self._callback_url: str = settings.OPENCLAW_CALLBACK_URL
 
     async def _forward_to_telegram(
         self,
@@ -134,7 +226,7 @@ class OpenClawClient:
 
         async with httpx.AsyncClient(timeout=10) as cli:
             res = await cli.post(self._webhook_url, json=payload, headers=headers)
-            res.raise_for_status()
+            _ = res.raise_for_status()
 
         logger.info(
             "OpenClaw analysis requested: request_id=%s symbol=%s instrument_type=%s status=%s",
@@ -147,118 +239,166 @@ class OpenClawClient:
 
     async def send_fill_notification(
         self, order: FillOrderLike, *, correlation_id: str | None = None
-    ) -> str | None:
+    ) -> FillNotificationDeliveryResult:
         """
         체결 알림을 OpenClaw Gateway로 전송
 
         Fire-and-forget 텍스트 알림으로 전송하며, 최대 4회 시도합니다
         (초기 1회 + 재시도 3회, 1s -> 2s -> 4s 백오프).
-        모든 재시도 실패 시 None을 반환하고 예외를 삼킵니다.
+        모든 재시도 실패 시 failed 결과를 반환하고 예외를 삼킵니다.
 
         Args:
             order: 정규화된 체결 데이터
 
         Returns:
-            str | None: 성공 시 request_id, 실패 시 None
+            FillNotificationDeliveryResult: 성공/스킵/실패 결과
         """
-        if not settings.OPENCLAW_ENABLED:
-            logger.debug("OpenClaw disabled, skipping fill notification")
-            return None
-
         normalized_order = coerce_fill_order(order)
         request_id = str(uuid4())
-        message = format_fill_message(normalized_order)
-        session_suffix = normalized_order.order_id or request_id
-
-        payload = {
-            "message": message,
-            "name": "auto-trader:fill",
-            "sessionKey": (
-                f"auto-trader:fill:{normalized_order.account}:{session_suffix}"
-            ),
-            "wakeMode": "now",
-        }
-
         headers = {"Content-Type": "application/json"}
         if self._token:
             headers["Authorization"] = f"Bearer {self._token}"
 
-        delivered_to_openclaw = False
+        result = FillNotificationDeliveryResult(
+            status="failed",
+            reason="request_failed",
+        )
+        discord_fill_message = format_fill_message(normalized_order)
         try:
-            async for attempt in _build_openclaw_retrying():
-                attempt_number = attempt.retry_state.attempt_number
-                with attempt:
-                    logger.info(
-                        "OpenClaw fill notification send start: correlation_id=%s "
-                        "request_id=%s symbol=%s account=%s attempt=%s",
-                        correlation_id,
-                        request_id,
-                        normalized_order.symbol,
-                        normalized_order.account,
-                        attempt_number,
-                    )
-                    try:
-                        async with httpx.AsyncClient(timeout=10) as cli:
-                            res = await cli.post(
-                                self._webhook_url, json=payload, headers=headers
-                            )
-                            res.raise_for_status()
-                    except Exception as exc:
-                        logger.warning(
-                            "OpenClaw fill notification attempt failed: correlation_id=%s "
-                            "request_id=%s symbol=%s account=%s attempt=%s error=%s",
+            agent_market = _resolve_fill_agent_market(normalized_order.market_type)
+            analysis_thread_id = _resolve_fill_analysis_thread_id(
+                normalized_order.market_type
+            )
+
+            if not settings.OPENCLAW_ENABLED:
+                logger.debug(
+                    "OpenClaw fill agent skipped: correlation_id=%s symbol=%s account=%s reason=openclaw_disabled",
+                    correlation_id,
+                    normalized_order.symbol,
+                    normalized_order.account,
+                )
+                result = FillNotificationDeliveryResult(
+                    status="skipped",
+                    reason="openclaw_disabled",
+                )
+            elif agent_market is None:
+                logger.debug(
+                    "OpenClaw fill agent skipped: correlation_id=%s symbol=%s account=%s reason=unsupported_market market_type=%s",
+                    correlation_id,
+                    normalized_order.symbol,
+                    normalized_order.account,
+                    normalized_order.market_type,
+                )
+                result = FillNotificationDeliveryResult(
+                    status="skipped",
+                    reason="unsupported_market",
+                )
+            elif analysis_thread_id is None:
+                logger.debug(
+                    "OpenClaw fill agent skipped: correlation_id=%s symbol=%s account=%s reason=missing_analysis_thread market_type=%s",
+                    correlation_id,
+                    normalized_order.symbol,
+                    normalized_order.account,
+                    normalized_order.market_type,
+                )
+                result = FillNotificationDeliveryResult(
+                    status="skipped",
+                    reason="missing_analysis_thread",
+                )
+            else:
+                payload = {
+                    "message": _build_fill_agent_message(
+                        normalized_order,
+                        agent_market=agent_market,
+                    ),
+                    "name": OPENCLAW_FILL_AGENT_NAME,
+                    "deliver": True,
+                    "channel": OPENCLAW_FILL_AGENT_CHANNEL,
+                    "to": analysis_thread_id,
+                    "model": OPENCLAW_FILL_AGENT_MODEL,
+                    "timeoutSeconds": OPENCLAW_FILL_AGENT_TIMEOUT_SECONDS,
+                }
+                async for attempt in _build_openclaw_retrying():
+                    attempt_number = attempt.retry_state.attempt_number
+                    with attempt:
+                        logger.info(
+                            "OpenClaw fill notification send start: correlation_id=%s request_id=%s symbol=%s account=%s attempt=%s thread_id=%s",
                             correlation_id,
                             request_id,
                             normalized_order.symbol,
                             normalized_order.account,
                             attempt_number,
-                            exc,
+                            analysis_thread_id,
                         )
-                        raise
-                    logger.info(
-                        "OpenClaw fill notification sent: correlation_id=%s request_id=%s "
-                        "symbol=%s account=%s attempt=%s status=%s",
-                        correlation_id,
-                        request_id,
-                        normalized_order.symbol,
-                        normalized_order.account,
-                        attempt_number,
-                        res.status_code,
-                    )
-                    delivered_to_openclaw = True
-                    break
+                        try:
+                            async with httpx.AsyncClient(timeout=10) as cli:
+                                res = await cli.post(
+                                    self._webhook_url,
+                                    json=payload,
+                                    headers=headers,
+                                )
+                                _ = res.raise_for_status()
+                        except Exception as exc:
+                            logger.warning(
+                                "OpenClaw fill notification attempt failed: correlation_id=%s request_id=%s symbol=%s account=%s attempt=%s error=%s",
+                                correlation_id,
+                                request_id,
+                                normalized_order.symbol,
+                                normalized_order.account,
+                                attempt_number,
+                                exc,
+                            )
+                            raise
+                        logger.info(
+                            "OpenClaw fill notification sent: correlation_id=%s request_id=%s symbol=%s account=%s attempt=%s status=%s",
+                            correlation_id,
+                            request_id,
+                            normalized_order.symbol,
+                            normalized_order.account,
+                            attempt_number,
+                            res.status_code,
+                        )
+                        result = FillNotificationDeliveryResult(
+                            status="success",
+                            request_id=request_id,
+                        )
+                        break
 
         except RetryError as e:
             logger.error(
-                "OpenClaw fill notification failed after retries: correlation_id=%s "
-                "request_id=%s symbol=%s account=%s error=%s",
+                "OpenClaw fill notification failed after retries: correlation_id=%s request_id=%s symbol=%s account=%s error=%s",
                 correlation_id,
                 request_id,
                 normalized_order.symbol,
                 normalized_order.account,
                 e,
+            )
+            result = FillNotificationDeliveryResult(
+                status="failed",
+                reason="request_failed",
             )
         except Exception as e:
             logger.error(
-                "OpenClaw fill notification error: correlation_id=%s request_id=%s "
-                "symbol=%s account=%s error=%s",
+                "OpenClaw fill notification error: correlation_id=%s request_id=%s symbol=%s account=%s error=%s",
                 correlation_id,
                 request_id,
                 normalized_order.symbol,
                 normalized_order.account,
                 e,
             )
+            result = FillNotificationDeliveryResult(
+                status="failed",
+                reason="request_failed",
+            )
         finally:
             await self._forward_to_telegram(
-                message,
+                discord_fill_message,
                 alert_type="fill",
                 correlation_id=correlation_id,
                 market_type=normalized_order.market_type,
             )
 
-        if delivered_to_openclaw:
-            return request_id
-        return None
+        return result
 
     async def _send_market_alert(
         self,
@@ -291,7 +431,7 @@ class OpenClawClient:
                         res = await cli.post(
                             self._webhook_url, json=payload, headers=headers
                         )
-                        res.raise_for_status()
+                        _ = res.raise_for_status()
                     logger.info(
                         "OpenClaw %s alert sent: request_id=%s",
                         category,

--- a/tests/test_openclaw_client.py
+++ b/tests/test_openclaw_client.py
@@ -13,7 +13,12 @@ from tenacity import wait_fixed
 import app.services.openclaw_client as openclaw_client
 from app.core.config import settings
 from app.monitoring.trade_notifier import TradeNotifier, get_trade_notifier
-from app.services.openclaw_client import OpenClawClient, _build_openclaw_message
+from app.services.openclaw_client import (
+    FillNotificationDeliveryResult,
+    OpenClawClient,
+    _build_openclaw_message,
+)
+from app.services.fill_notification import FillOrder, format_fill_message
 
 
 def test_build_openclaw_message_includes_callback_and_schema() -> None:
@@ -65,6 +70,56 @@ def zero_delay_openclaw_retry_wait(monkeypatch: pytest.MonkeyPatch) -> None:
         wait_fixed(0),
         raising=False,
     )
+
+
+def _set_openclaw_threads(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    kr: str | None = None,
+    us: str | None = None,
+    crypto: str | None = None,
+) -> None:
+    monkeypatch.setitem(settings.__dict__, "OPENCLAW_THREAD_KR", kr)
+    monkeypatch.setitem(settings.__dict__, "OPENCLAW_THREAD_US", us)
+    monkeypatch.setitem(settings.__dict__, "OPENCLAW_THREAD_CRYPTO", crypto)
+
+
+def _build_fill_order(
+    *,
+    symbol: str,
+    market_type: str,
+    account: str,
+    side: str = "bid",
+    filled_price: float = 50_000_000,
+    filled_qty: float = 0.1,
+    filled_amount: float = 5_000_000,
+    filled_at: str = "2024-01-01T00:00:00Z",
+    order_id: str | None = "order-123",
+    fill_status: str | None = None,
+) -> FillOrder:
+    return FillOrder(
+        symbol=symbol,
+        side=side,
+        filled_price=filled_price,
+        filled_qty=filled_qty,
+        filled_amount=filled_amount,
+        filled_at=filled_at,
+        account=account,
+        order_id=order_id,
+        fill_status=fill_status,
+        market_type=market_type,
+    )
+
+
+def test_fill_notification_delivery_result_enforces_request_id_contract() -> None:
+    with pytest.raises(ValueError, match="success results require a request_id"):
+        FillNotificationDeliveryResult(status="success")
+
+    with pytest.raises(
+        ValueError,
+        match="request_id is only allowed for success results",
+    ):
+        FillNotificationDeliveryResult(status="failed", request_id="req-123")
 
 
 @pytest.mark.asyncio
@@ -190,52 +245,83 @@ async def test_request_analysis_supports_screener_callback_schema(
 
 
 @pytest.mark.asyncio
-async def test_send_fill_notification_returns_none_when_disabled(
+async def test_send_fill_notification_returns_skipped_when_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(settings, "OPENCLAW_ENABLED", False)
 
-    from app.services.fill_notification import FillOrder
-
-    order = FillOrder(
+    order = _build_fill_order(
         symbol="KRW-BTC",
-        side="bid",
-        filled_price=50000000,
-        filled_qty=0.1,
-        filled_amount=5000000,
-        filled_at="2024-01-01T00:00:00Z",
-        account="upbit",
         market_type="crypto",
+        account="upbit",
+    )
+    plain_fill_message = format_fill_message(order)
+    mock_notifier = MagicMock()
+    mock_notifier.notify_openclaw_message = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.services.openclaw_client.get_trade_notifier",
+        lambda: mock_notifier,
     )
 
     result = await OpenClawClient().send_fill_notification(order)
-    assert result is None
+
+    assert result.status == "skipped"
+    assert result.reason == "openclaw_disabled"
+    assert result.request_id is None
+
+    mock_notifier.notify_openclaw_message.assert_awaited_once_with(
+        plain_fill_message,
+        market_type="crypto",
+    )
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("order", "thread_kwargs", "expected_thread", "expected_market_label"),
+    [
+        (
+            _build_fill_order(symbol="005930", market_type="kr", account="kis"),
+            {"kr": "discord-thread-kr"},
+            "discord-thread-kr",
+            "equity_kr",
+        ),
+        (
+            _build_fill_order(
+                symbol="AAPL",
+                market_type="us",
+                account="kis",
+                filled_price=195.5,
+                filled_qty=2,
+                filled_amount=391,
+                filled_at="2026-02-14T09:30:00-05:00",
+            ),
+            {"us": "discord-thread-us"},
+            "discord-thread-us",
+            "equity_us",
+        ),
+        (
+            _build_fill_order(symbol="KRW-BTC", market_type="crypto", account="upbit"),
+            {"crypto": "discord-thread-crypto"},
+            "discord-thread-crypto",
+            "crypto",
+        ),
+    ],
+)
 @patch("app.services.openclaw_client.httpx.AsyncClient")
-async def test_send_fill_notification_success(
+async def test_send_fill_notification_posts_tradealert_payload_to_market_thread(
     mock_httpx_client_cls: MagicMock,
+    order: FillOrder,
+    thread_kwargs: dict[str, str],
+    expected_thread: str,
+    expected_market_label: str,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
     monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
     monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
-
-    from app.services.fill_notification import FillOrder
-
-    order = FillOrder(
-        symbol="KRW-BTC",
-        side="bid",
-        filled_price=50000000,
-        filled_qty=0.1,
-        filled_amount=5000000,
-        filled_at="2024-01-01T00:00:00Z",
-        account="upbit",
-        order_id="order-123",
-        market_type="crypto",
-    )
+    _set_openclaw_threads(monkeypatch, **thread_kwargs)
+    plain_fill_message = format_fill_message(order)
 
     mock_cli = AsyncMock()
     mock_res = MagicMock(status_code=200)
@@ -256,22 +342,40 @@ async def test_send_fill_notification_success(
 
     with caplog.at_level("INFO"):
         result = await OpenClawClient().send_fill_notification(
-            order, correlation_id="corr-fill-success"
+            order, correlation_id=f"corr-fill-{order.market_type}"
         )
 
-    assert result is not None
     mock_cli.post.assert_awaited_once()
     called_json = mock_cli.post.call_args.kwargs["json"]
-    assert called_json["name"] == "auto-trader:fill"
-    assert called_json["wakeMode"] == "now"
-    assert "🟢 체결 알림" in called_json["message"]
-    mock_notifier.notify_openclaw_message.assert_awaited_once_with(
-        called_json["message"],
-        correlation_id="corr-fill-success",
-        market_type="crypto",
+    assert called_json["name"] == "TradeAlert"
+    assert called_json["deliver"] is True
+    assert called_json["channel"] == "discord"
+    assert called_json["to"] == expected_thread
+    assert called_json["model"] == "gpt"
+    assert called_json["timeoutSeconds"] == 60
+    assert "sessionKey" not in called_json
+    assert "wakeMode" not in called_json
+    assert called_json["message"] != plain_fill_message
+    assert f"마켓: {expected_market_label}" in called_json["message"]
+    assert "get_holdings" in called_json["message"]
+    assert "analyze_stock" in called_json["message"]
+    assert "판단: buy" in called_json["message"]
+    assert "판단: hold" in called_json["message"]
+    assert "판단: sell" in called_json["message"]
+    assert (
+        "Discord 댓글 첫 줄은 반드시 `판단: buy`, `판단: hold`, `판단: sell` 중 하나로 시작하고, "
+        "그 다음 줄부터 현재 보유 상태, 이번 체결의 의미, 핵심 근거를 한국어로 간결하게 정리하세요."
+        in called_json["message"]
     )
-    assert "correlation_id=corr-fill-success" in caplog.text
-    assert f"request_id={result}" in caplog.text
+    mock_notifier.notify_openclaw_message.assert_awaited_once_with(
+        plain_fill_message,
+        correlation_id=f"corr-fill-{order.market_type}",
+        market_type=order.market_type,
+    )
+    assert f"correlation_id=corr-fill-{order.market_type}" in caplog.text
+    assert result.status == "success"
+    assert result.request_id is not None
+    assert f"request_id={result.request_id}" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -283,6 +387,7 @@ async def test_send_fill_notification_raw_mapping_forwards_canonical_market_type
     monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
     monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
     monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+    _set_openclaw_threads(monkeypatch, us="discord-thread-us")
 
     order = {
         "symbol": "AAPL",
@@ -316,7 +421,8 @@ async def test_send_fill_notification_raw_mapping_forwards_canonical_market_type
         order, correlation_id="corr-fill-raw-market"
     )
 
-    assert result is not None
+    assert result.status == "success"
+    assert result.request_id is not None
     mock_notifier.notify_openclaw_message.assert_awaited_once_with(
         mock_notifier.notify_openclaw_message.await_args.args[0],
         correlation_id="corr-fill-raw-market",
@@ -326,7 +432,50 @@ async def test_send_fill_notification_raw_mapping_forwards_canonical_market_type
 
 @pytest.mark.asyncio
 @patch("app.services.openclaw_client.httpx.AsyncClient")
-async def test_send_fill_notification_partial_event_uses_partial_message_and_order_id_session(
+async def test_send_fill_notification_skips_openclaw_post_when_thread_missing_and_still_mirrors_plain_fill_message(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
+    monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
+    monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+    _set_openclaw_threads(monkeypatch)
+
+    order = _build_fill_order(
+        symbol="AAPL",
+        market_type="us",
+        account="kis",
+        filled_price=195.5,
+        filled_qty=2,
+        filled_amount=391,
+        filled_at="2026-02-14T09:30:00-05:00",
+        order_id="us-order-12345",
+        fill_status="partial",
+    )
+    plain_fill_message = format_fill_message(order)
+
+    mock_notifier = MagicMock()
+    mock_notifier.notify_openclaw_message = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.services.openclaw_client.get_trade_notifier",
+        lambda: mock_notifier,
+    )
+
+    result = await OpenClawClient().send_fill_notification(order)
+
+    assert result.status == "skipped"
+    assert result.reason == "missing_analysis_thread"
+    assert result.request_id is None
+    mock_httpx_client_cls.assert_not_called()
+    mock_notifier.notify_openclaw_message.assert_awaited_once_with(
+        plain_fill_message,
+        market_type="us",
+    )
+
+
+@pytest.mark.asyncio
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_fill_notification_skips_unsupported_market_and_still_mirrors_plain_fill_message(
     mock_httpx_client_cls: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -334,36 +483,33 @@ async def test_send_fill_notification_partial_event_uses_partial_message_and_ord
     monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
     monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
 
-    from app.services.fill_notification import FillOrder
-
-    order = FillOrder(
-        symbol="AAPL",
-        side="bid",
-        filled_price=195.5,
-        filled_qty=2,
-        filled_amount=391,
-        filled_at="2026-02-14T09:30:00-05:00",
+    order = _build_fill_order(
+        symbol="7203.T",
+        market_type="jp",
         account="kis",
-        order_id="us-order-12345",
-        fill_status="partial",
+        filled_price=2800,
+        filled_qty=3,
+        filled_amount=8400,
     )
+    plain_fill_message = format_fill_message(order)
 
-    mock_cli = AsyncMock()
-    mock_res = MagicMock(status_code=200)
-    mock_res.raise_for_status.return_value = None
-    mock_cli.post.return_value = mock_res
-
-    mock_client_instance = AsyncMock()
-    mock_client_instance.__aenter__.return_value = mock_cli
-    mock_client_instance.__aexit__.return_value = None
-    mock_httpx_client_cls.return_value = mock_client_instance
+    mock_notifier = MagicMock()
+    mock_notifier.notify_openclaw_message = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.services.openclaw_client.get_trade_notifier",
+        lambda: mock_notifier,
+    )
 
     result = await OpenClawClient().send_fill_notification(order)
 
-    assert result is not None
-    called_json = mock_cli.post.call_args.kwargs["json"]
-    assert "구분: 매수 부분체결" in called_json["message"]
-    assert called_json["sessionKey"] == "auto-trader:fill:kis:us-order-12345"
+    assert result.status == "skipped"
+    assert result.reason == "unsupported_market"
+    assert result.request_id is None
+    mock_httpx_client_cls.assert_not_called()
+    mock_notifier.notify_openclaw_message.assert_awaited_once_with(
+        plain_fill_message,
+        market_type="jp",
+    )
 
 
 @pytest.mark.asyncio
@@ -377,6 +523,7 @@ async def test_send_fill_notification_retries_on_failure_then_succeeds(
     monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
     monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
     monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+    _set_openclaw_threads(monkeypatch, crypto="discord-thread-crypto")
 
     from app.services.fill_notification import FillOrder
 
@@ -388,6 +535,7 @@ async def test_send_fill_notification_retries_on_failure_then_succeeds(
         filled_amount=5000000,
         filled_at="2024-01-01T00:00:00Z",
         account="upbit",
+        market_type="crypto",
     )
 
     mock_cli = AsyncMock()
@@ -415,7 +563,8 @@ async def test_send_fill_notification_retries_on_failure_then_succeeds(
         )
     elapsed = time.monotonic() - start
 
-    assert result is not None
+    assert result.status == "success"
+    assert result.request_id is not None
     assert mock_cli.post.call_count == 4
     assert elapsed < 2.0
     assert "correlation_id=corr-fill-retry" in caplog.text
@@ -426,7 +575,7 @@ async def test_send_fill_notification_retries_on_failure_then_succeeds(
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("zero_delay_openclaw_retry_wait")
 @patch("app.services.openclaw_client.httpx.AsyncClient")
-async def test_send_fill_notification_returns_none_after_all_retries_fail(
+async def test_send_fill_notification_returns_failed_after_all_retries_fail(
     mock_httpx_client_cls: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
@@ -434,6 +583,7 @@ async def test_send_fill_notification_returns_none_after_all_retries_fail(
     monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
     monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
     monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+    _set_openclaw_threads(monkeypatch, crypto="discord-thread-crypto")
 
     from app.services.fill_notification import FillOrder
 
@@ -465,7 +615,9 @@ async def test_send_fill_notification_returns_none_after_all_retries_fail(
         )
     elapsed = time.monotonic() - start
 
-    assert result is None
+    assert result.status == "failed"
+    assert result.reason == "request_failed"
+    assert result.request_id is None
     assert mock_cli.post.call_count == 4
     assert elapsed < 2.0
     assert "correlation_id=corr-fill-failed" in caplog.text
@@ -483,19 +635,14 @@ async def test_send_fill_notification_forwards_telegram_when_openclaw_fails(
     monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
     monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
     monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+    _set_openclaw_threads(monkeypatch, crypto="discord-thread-crypto")
 
-    from app.services.fill_notification import FillOrder
-
-    order = FillOrder(
+    order = _build_fill_order(
         symbol="KRW-BTC",
-        side="bid",
-        filled_price=50000000,
-        filled_qty=0.1,
-        filled_amount=5000000,
-        filled_at="2024-01-01T00:00:00Z",
-        account="upbit",
         market_type="crypto",
+        account="upbit",
     )
+    plain_fill_message = format_fill_message(order)
 
     mock_cli = AsyncMock()
     mock_res_fail = MagicMock()
@@ -521,16 +668,19 @@ async def test_send_fill_notification_forwards_telegram_when_openclaw_fails(
         )
     elapsed = time.monotonic() - start
 
-    assert result is None
+    assert result.status == "failed"
+    assert result.reason == "request_failed"
+    assert result.request_id is None
     assert mock_cli.post.call_count == 4
     assert elapsed < 2.0
-    forwarded_message = mock_notifier.notify_openclaw_message.await_args.args[0]
+    posted_message = mock_cli.post.call_args.kwargs["json"]["message"]
     mock_notifier.notify_openclaw_message.assert_awaited_once_with(
-        forwarded_message,
+        plain_fill_message,
         correlation_id="corr-openclaw-fail-mirror-success",
         market_type="crypto",
     )
-    assert "체결 알림" in forwarded_message
+    assert posted_message != plain_fill_message
+    assert "get_holdings" in posted_message
     assert "corr-openclaw-fail-mirror-success" in caplog.text
 
 
@@ -544,6 +694,7 @@ async def test_send_fill_notification_logs_mirror_failure_when_openclaw_succeeds
     monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
     monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
     monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+    _set_openclaw_threads(monkeypatch, crypto="discord-thread-crypto")
 
     from app.services.fill_notification import FillOrder
 
@@ -555,6 +706,7 @@ async def test_send_fill_notification_logs_mirror_failure_when_openclaw_succeeds
         filled_amount=5000000,
         filled_at="2024-01-01T00:00:00Z",
         account="upbit",
+        market_type="crypto",
     )
 
     mock_cli = AsyncMock()
@@ -579,7 +731,8 @@ async def test_send_fill_notification_logs_mirror_failure_when_openclaw_succeeds
             order, correlation_id="corr-openclaw-success-mirror-fail"
         )
 
-    assert result is not None
+    assert result.status == "success"
+    assert result.request_id is not None
     mock_notifier.notify_openclaw_message.assert_awaited_once()
 
 
@@ -593,6 +746,7 @@ async def test_send_fill_notification_disabled_notifier_emits_single_summary_log
     monkeypatch.setattr(settings, "OPENCLAW_ENABLED", True)
     monkeypatch.setattr(settings, "OPENCLAW_WEBHOOK_URL", "http://openclaw/hooks/agent")
     monkeypatch.setattr(settings, "OPENCLAW_TOKEN", "test-token")
+    _set_openclaw_threads(monkeypatch, crypto="discord-thread-crypto")
 
     from app.services.fill_notification import FillOrder
 
@@ -604,6 +758,7 @@ async def test_send_fill_notification_disabled_notifier_emits_single_summary_log
         filled_amount=5000000,
         filled_at="2024-01-01T00:00:00Z",
         account="upbit",
+        market_type="crypto",
     )
 
     mock_cli = AsyncMock()
@@ -634,7 +789,8 @@ async def test_send_fill_notification_disabled_notifier_emits_single_summary_log
         TradeNotifier._instance = None
         TradeNotifier._initialized = False
 
-    assert result is not None
+    assert result.status == "success"
+    assert result.request_id is not None
     summary_lines = [
         record.getMessage()
         for record in caplog.records

--- a/tests/test_websocket_monitor.py
+++ b/tests/test_websocket_monitor.py
@@ -7,6 +7,19 @@ import pytest
 
 from app.core.config import settings
 from app.services.fill_notification import FillOrder
+from app.services.openclaw_client import FillNotificationDeliveryResult
+
+
+def _success_result(request_id: str = "req-123") -> FillNotificationDeliveryResult:
+    return FillNotificationDeliveryResult(status="success", request_id=request_id)
+
+
+def _skipped_result(reason: str) -> FillNotificationDeliveryResult:
+    return FillNotificationDeliveryResult(status="skipped", reason=reason)
+
+
+def _failed_result(reason: str = "request_failed") -> FillNotificationDeliveryResult:
+    return FillNotificationDeliveryResult(status="failed", reason=reason)
 
 
 @pytest.fixture
@@ -25,7 +38,7 @@ class TestUnifiedWebSocketMonitor:
         from websocket_monitor import UnifiedWebSocketMonitor
 
         monitor = UnifiedWebSocketMonitor()
-        send_mock = AsyncMock(return_value="req-123")
+        send_mock = AsyncMock(return_value=_success_result())
         monitor.openclaw_client.send_fill_notification = send_mock
 
         await monitor._on_upbit_order(
@@ -50,7 +63,7 @@ class TestUnifiedWebSocketMonitor:
         from websocket_monitor import UnifiedWebSocketMonitor
 
         monitor = UnifiedWebSocketMonitor()
-        send_mock = AsyncMock(return_value="req-123")
+        send_mock = AsyncMock(return_value=_success_result())
         monitor.openclaw_client.send_fill_notification = send_mock
 
         await monitor._on_upbit_order(
@@ -72,7 +85,7 @@ class TestUnifiedWebSocketMonitor:
         from websocket_monitor import UnifiedWebSocketMonitor
 
         monitor = UnifiedWebSocketMonitor()
-        send_mock = AsyncMock(return_value="req-456")
+        send_mock = AsyncMock(return_value=_success_result("req-456"))
         monitor.openclaw_client.send_fill_notification = send_mock
 
         await monitor._on_kis_execution(
@@ -102,7 +115,7 @@ class TestUnifiedWebSocketMonitor:
         from websocket_monitor import UnifiedWebSocketMonitor
 
         monitor = UnifiedWebSocketMonitor()
-        send_mock = AsyncMock(return_value="req-456")
+        send_mock = AsyncMock(return_value=_success_result("req-456"))
         monitor.openclaw_client.send_fill_notification = send_mock
 
         await monitor._on_kis_execution(
@@ -124,7 +137,7 @@ class TestUnifiedWebSocketMonitor:
         from websocket_monitor import UnifiedWebSocketMonitor
 
         monitor = UnifiedWebSocketMonitor()
-        send_mock = AsyncMock(return_value="req-456")
+        send_mock = AsyncMock(return_value=_success_result("req-456"))
         monitor.openclaw_client.send_fill_notification = send_mock
 
         await monitor._on_kis_execution(
@@ -252,7 +265,7 @@ class TestUnifiedWebSocketMonitor:
         assert monitor.is_running is False
 
     @pytest.mark.asyncio
-    async def test_send_fill_notification_disabled(
+    async def test_send_fill_notification_disabled_still_routes_through_client(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setattr(settings, "OPENCLAW_ENABLED", False)
@@ -260,7 +273,7 @@ class TestUnifiedWebSocketMonitor:
 
         monitor = UnifiedWebSocketMonitor()
         monitor.openclaw_client.send_fill_notification = AsyncMock(
-            return_value="req-123"
+            return_value=_success_result()
         )
 
         await monitor._send_fill_notification(
@@ -275,7 +288,7 @@ class TestUnifiedWebSocketMonitor:
             )
         )
 
-        monitor.openclaw_client.send_fill_notification.assert_not_awaited()
+        monitor.openclaw_client.send_fill_notification.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_send_fill_notification_skips_upbit_below_minimum(
@@ -284,7 +297,7 @@ class TestUnifiedWebSocketMonitor:
         from websocket_monitor import MIN_FILL_NOTIFY_AMOUNT, UnifiedWebSocketMonitor
 
         monitor = UnifiedWebSocketMonitor()
-        send_mock = AsyncMock(return_value="req-123")
+        send_mock = AsyncMock(return_value=_success_result())
         monitor.openclaw_client.send_fill_notification = send_mock
 
         caplog.set_level("DEBUG")
@@ -311,7 +324,7 @@ class TestUnifiedWebSocketMonitor:
         from websocket_monitor import UnifiedWebSocketMonitor
 
         monitor = UnifiedWebSocketMonitor()
-        send_mock = AsyncMock(return_value="req-123")
+        send_mock = AsyncMock(return_value=_success_result())
         monitor.openclaw_client.send_fill_notification = send_mock
 
         await monitor._send_fill_notification(
@@ -335,7 +348,7 @@ class TestUnifiedWebSocketMonitor:
         from websocket_monitor import UnifiedWebSocketMonitor
 
         monitor = UnifiedWebSocketMonitor()
-        send_mock = AsyncMock(return_value=None)
+        send_mock = AsyncMock(return_value=_failed_result())
         monitor.openclaw_client.send_fill_notification = send_mock
 
         await monitor._send_fill_notification(
@@ -372,11 +385,12 @@ class TestUnifiedWebSocketMonitor:
         caplog.set_level("INFO")
 
         monitor.openclaw_client.send_fill_notification = AsyncMock(
-            return_value="req-123"
+            return_value=_success_result()
         )
         await monitor._send_fill_notification(order, correlation_id="corr-success")
         assert monitor.fills_forwarded == 1
         assert monitor.last_openclaw_success_at is not None
+        success_timestamp = monitor.last_openclaw_success_at
         assert "correlation_id=corr-success" in caplog.text
         assert "OpenClaw send start" in caplog.text
         assert "OpenClaw send result" in caplog.text
@@ -384,15 +398,20 @@ class TestUnifiedWebSocketMonitor:
         assert "Notification pipeline result" not in caplog.text
 
         caplog.clear()
-        monitor.openclaw_client.send_fill_notification = AsyncMock(return_value=None)
+        monitor.openclaw_client.send_fill_notification = AsyncMock(
+            return_value=_failed_result()
+        )
         await monitor._send_fill_notification(order, correlation_id="corr-failed")
         assert "correlation_id=corr-failed" in caplog.text
         assert "OpenClaw send result" in caplog.text
         assert "result=failed" in caplog.text
+        assert "reason=request_failed" in caplog.text
+        assert monitor.fills_forwarded == 1
+        assert monitor.last_openclaw_success_at == success_timestamp
 
         caplog.clear()
         monitor.openclaw_client.send_fill_notification = AsyncMock(
-            return_value="req-skip"
+            return_value=_success_result("req-skip")
         )
         monitor.mode = "upbit"
         await monitor._send_fill_notification(
@@ -410,6 +429,42 @@ class TestUnifiedWebSocketMonitor:
         assert "correlation_id=corr-skipped" in caplog.text
         assert "OpenClaw send result" in caplog.text
         assert "result=skipped" in caplog.text
+        assert monitor.fills_forwarded == 1
+        assert monitor.last_openclaw_success_at == success_timestamp
+
+    @pytest.mark.asyncio
+    async def test_send_fill_notification_logs_client_skip_reason(
+        self, mock_settings: None, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor(mode="kis")
+        order = FillOrder(
+            symbol="AAPL",
+            side="bid",
+            filled_price=195.5,
+            filled_qty=2,
+            filled_amount=391,
+            filled_at="2024-01-01T00:00:00Z",
+            account="kis",
+            market_type="us",
+        )
+
+        caplog.set_level("INFO")
+        monitor.openclaw_client.send_fill_notification = AsyncMock(
+            return_value=_skipped_result("missing_analysis_thread")
+        )
+
+        await monitor._send_fill_notification(
+            order, correlation_id="corr-missing-thread"
+        )
+
+        assert "correlation_id=corr-missing-thread" in caplog.text
+        assert "result=skipped" in caplog.text
+        assert "reason=missing_analysis_thread" in caplog.text
+        assert "result=failed" not in caplog.text
+        assert monitor.fills_forwarded == 0
+        assert monitor.last_openclaw_success_at is None
 
     @pytest.mark.asyncio
     async def test_log_health_status_uses_kis_state_fields(

--- a/websocket_monitor.py
+++ b/websocket_monitor.py
@@ -238,16 +238,6 @@ class UnifiedWebSocketMonitor:
         self, order: FillOrder, *, correlation_id: str | None = None
     ) -> None:
         """OpenClaw로 체결 알림 전송 (fire-and-forget)"""
-        if not settings.OPENCLAW_ENABLED:
-            logger.info(
-                "OpenClaw send result: correlation_id=%s symbol=%s account=%s "
-                "result=skipped reason=openclaw_disabled",
-                correlation_id,
-                order.symbol,
-                order.account,
-            )
-            return
-
         if order.account == "upbit" and order.filled_amount < MIN_FILL_NOTIFY_AMOUNT:
             logger.debug(
                 "Fill below minimum notify amount (%s < %s), skipping: %s",
@@ -274,10 +264,10 @@ class UnifiedWebSocketMonitor:
             order.filled_amount,
         )
         try:
-            request_id = await self.openclaw_client.send_fill_notification(
+            result = await self.openclaw_client.send_fill_notification(
                 order, correlation_id=correlation_id
             )
-            if request_id:
+            if result.status == "success":
                 self.fills_forwarded += 1
                 self.last_openclaw_success_at = datetime.now(UTC).isoformat()
                 logger.info(
@@ -286,15 +276,26 @@ class UnifiedWebSocketMonitor:
                     correlation_id,
                     order.symbol,
                     order.account,
-                    request_id,
+                    result.request_id,
+                )
+            elif result.status == "skipped":
+                logger.info(
+                    "OpenClaw send result: correlation_id=%s symbol=%s account=%s "
+                    "result=skipped reason=%s",
+                    correlation_id,
+                    order.symbol,
+                    order.account,
+                    result.reason,
                 )
             else:
                 logger.warning(
                     "OpenClaw send result: correlation_id=%s symbol=%s account=%s "
-                    "result=failed request_id=<none>",
+                    "result=failed reason=%s request_id=%s",
                     correlation_id,
                     order.symbol,
                     order.account,
+                    result.reason,
+                    result.request_id or "<none>",
                 )
         except Exception as e:
             logger.error(


### PR DESCRIPTION
## Summary
- require explicit buy/hold/sell judgments in OpenClaw fill-agent prompts
- return structured fill-delivery results so skips and failures log separately
- add regression coverage for fill delivery and websocket monitor logging

## Test Plan
- uv run pytest tests/test_openclaw_client.py tests/test_websocket_monitor.py tests/test_fill_notification.py -q --no-cov
- uv run ty check app/services/openclaw_client.py websocket_monitor.py app/core/config.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable OpenClaw thread identifiers for Korea, US, and Crypto markets.
  * Enhanced fill notification system with structured delivery status tracking (success, skipped, failed), including reason and request ID.
  * Improved multi-market support with market-specific labeling and thread resolution.

* **Bug Fixes**
  * Enhanced error handling and retry logic for fill notifications with better logging of skip reasons and failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->