### PR TITLE
fix: harden KIS overseas fill parsing (#283)

### DIFF
--- a/app/services/fill_notification.py
+++ b/app/services/fill_notification.py
@@ -4,12 +4,24 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+_US_SYMBOL_RESERVED_TOKENS = {
+    "PROD",
+    "RESERVED",
+    "ENV",
+    "HTS",
+    "NASD",
+    "NASDAQ",
+    "NYSE",
+    "AMEX",
+    "KRX",
+}
 
 
 @dataclass
@@ -26,6 +38,7 @@ class FillOrder:
     order_type: str | None = None
     fill_status: str | None = None
     market_type: str | None = None
+    currency: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -112,6 +125,48 @@ def _normalize_market_type(value: Any) -> str | None:
     return aliases.get(normalized)
 
 
+def _normalize_currency(value: Any) -> str | None:
+    text = _safe_text_or_none(value)
+    if text is None:
+        return None
+
+    normalized = text.upper()
+    aliases = {
+        "USD": "USD",
+        "$": "USD",
+        "US DOLLAR": "USD",
+        "KRW": "KRW",
+        "WON": "KRW",
+        "원": "KRW",
+        "KRW원": "KRW",
+    }
+    return aliases.get(normalized, normalized if normalized in {"USD", "KRW"} else None)
+
+
+def _default_currency_for_market(
+    market_type: str | None, *, account: str | None = None
+) -> str | None:
+    if market_type == "us":
+        return "USD"
+    if market_type in {"kr", "crypto"}:
+        return "KRW"
+    normalized_account = _safe_text_or_none(account)
+    if normalized_account is not None and normalized_account.lower() == "upbit":
+        return "KRW"
+    return None
+
+
+def _resolve_fill_currency(
+    raw: Mapping[str, Any], *, market_type: str | None, account: str | None = None
+) -> str | None:
+    explicit_currency = _normalize_currency(
+        _pick_first(raw, ["currency", "currency_code", "settlement_currency"])
+    )
+    if explicit_currency is not None:
+        return explicit_currency
+    return _default_currency_for_market(market_type, account=account)
+
+
 def _looks_like_kr_symbol(symbol: str) -> bool:
     return symbol.isdigit() and len(symbol) == 6
 
@@ -130,12 +185,15 @@ def _looks_like_us_symbol(symbol: str) -> bool:
     if _looks_like_crypto_symbol(normalized):
         return False
     cleaned = normalized.replace(".", "").replace("-", "").replace("/", "")
-    return (
-        bool(cleaned)
-        and cleaned[0].isalpha()
-        and cleaned.isalnum()
-        and 1 <= len(cleaned) <= 10
-    )
+    if not cleaned or not cleaned[0].isalpha():
+        return False
+    if cleaned in _US_SYMBOL_RESERVED_TOKENS:
+        return False
+    if cleaned.startswith(("ORDER", "ACNT", "ACCOUNT", "CUST", "USER")):
+        return False
+    if any(ch.isdigit() for ch in cleaned) and len(cleaned) >= 8:
+        return False
+    return bool(cleaned) and cleaned.isalnum() and 1 <= len(cleaned) <= 10
 
 
 def _resolve_fill_market_type(
@@ -200,10 +258,20 @@ def _parse_timestamp(value: Any) -> str:
 
 def coerce_fill_order(order: FillOrderLike) -> FillOrder:
     if isinstance(order, FillOrder):
-        return order
+        market_type = order.market_type or _resolve_fill_market_type(
+            order.to_dict(), symbol=order.symbol, account=order.account
+        )
+        currency = _normalize_currency(order.currency) or _resolve_fill_currency(
+            order.to_dict(), market_type=market_type, account=order.account
+        )
+        if market_type == order.market_type and currency == order.currency:
+            return order
+        return replace(order, market_type=market_type, currency=currency)
 
     symbol = str(order.get("symbol") or "UNKNOWN")
     account = str(order.get("account") or "unknown")
+    market_type = _resolve_fill_market_type(order, symbol=symbol, account=account)
+    currency = _resolve_fill_currency(order, market_type=market_type, account=account)
 
     return FillOrder(
         symbol=symbol,
@@ -219,7 +287,8 @@ def coerce_fill_order(order: FillOrderLike) -> FillOrder:
         fill_status=_normalize_fill_status(
             _pick_first(order, ["fill_status", "execution_status"])
         ),
-        market_type=_resolve_fill_market_type(order, symbol=symbol, account=account),
+        market_type=market_type,
+        currency=currency,
     )
 
 
@@ -258,6 +327,7 @@ def normalize_upbit_fill(raw: Mapping[str, Any]) -> FillOrder:
         order_type=_safe_text_or_none(_pick_first(raw, ["order_type", "ord_type"])),
         fill_status="filled",
         market_type="crypto",
+        currency="KRW",
     )
 
 
@@ -282,6 +352,9 @@ def normalize_kis_fill(raw: Mapping[str, Any]) -> FillOrder:
     if filled_price == 0 or filled_qty == 0:
         logger.debug("KIS best-effort fill normalization fallback: raw=%s", raw)
 
+    market_type = _resolve_fill_market_type(raw, symbol=symbol, account=account)
+    currency = _resolve_fill_currency(raw, market_type=market_type, account=account)
+
     return FillOrder(
         symbol=symbol,
         side=side,
@@ -304,7 +377,8 @@ def normalize_kis_fill(raw: Mapping[str, Any]) -> FillOrder:
         fill_status=_normalize_fill_status(
             _pick_first(raw, ["fill_status", "execution_status"])
         ),
-        market_type=_resolve_fill_market_type(raw, symbol=symbol, account=account),
+        market_type=market_type,
+        currency=currency,
     )
 
 
@@ -332,6 +406,16 @@ def _format_krw(value: float) -> str:
     return f"{text}원"
 
 
+def _format_usd(value: float) -> str:
+    return f"${value:,.2f}"
+
+
+def _format_money(value: float, currency: str | None) -> str:
+    if currency == "USD":
+        return _format_usd(value)
+    return _format_krw(value)
+
+
 def _format_quantity(value: float) -> str:
     rounded = round(value)
     if abs(value - rounded) < 1e-12:
@@ -357,9 +441,9 @@ def format_fill_message(order: FillOrderLike) -> str:
         f"{side_emoji} 체결 알림\n\n"
         f"종목: {normalized.symbol}\n"
         f"구분: {side_text} {fill_label}\n"
-        f"체결가: {_format_krw(normalized.filled_price)}{price_diff}\n"
+        f"체결가: {_format_money(normalized.filled_price, normalized.currency)}{price_diff}\n"
         f"수량: {_format_quantity(normalized.filled_qty)}\n"
-        f"금액: {_format_krw(normalized.filled_amount)}\n"
+        f"금액: {_format_money(normalized.filled_amount, normalized.currency)}\n"
         f"시간: {normalized.filled_at}\n\n"
         f"계좌: {normalized.account}"
     )

--- a/app/services/kis_websocket.py
+++ b/app/services/kis_websocket.py
@@ -123,6 +123,18 @@ _SIDE_MAP = {
     "매수": "bid",
 }
 
+_US_SYMBOL_RESERVED_TOKENS = {
+    "PROD",
+    "RESERVED",
+    "ENV",
+    "HTS",
+    "NASD",
+    "NASDAQ",
+    "NYSE",
+    "AMEX",
+    "KRX",
+}
+
 OVERSEAS_FILL_FIELDS = {
     "side": 4,
     "rctf_cls": 5,
@@ -810,9 +822,16 @@ class KISExecutionWebSocket:
             )
 
         if not parsed.get("symbol"):
-            parsed["symbol"] = (
-                self._extract_symbol(payload_fields, parsed["market"]) or ""
+            allow_symbol_fallback = not (
+                parsed["tr_code"] in OVERSEAS_EXECUTION_TR_CODES
+                and len(payload_fields) > OVERSEAS_FILL_FIELDS["symbol"]
             )
+            if allow_symbol_fallback:
+                parsed["symbol"] = (
+                    self._extract_symbol(payload_fields, parsed["market"]) or ""
+                )
+            else:
+                parsed["symbol"] = ""
 
         if parsed["tr_code"] in EXECUTION_TR_CODES and (
             not parsed.get("filled_price") or not parsed.get("filled_qty")
@@ -1086,6 +1105,7 @@ class KISExecutionWebSocket:
             "filled_qty": filled_qty,
             "filled_amount": filled_amount,
             "filled_at": filled_at,
+            "currency": "USD",
             "order_qty": order_qty,
             "rctf_cls": rctf_cls,
             "acpt_yn": acpt_yn,
@@ -1230,14 +1250,24 @@ class KISExecutionWebSocket:
             stripped = token.strip()
             if market == "kr" and stripped.isdigit() and len(stripped) == 6:
                 return stripped
-            if (
-                market == "us"
-                and stripped.replace(".", "").replace("-", "").isalnum()
-                and not stripped.replace(".", "").replace("-", "").isdigit()
-                and stripped.upper() == stripped
-                and 1 <= len(stripped) <= 10
-            ):
-                return stripped
+            if market != "us":
+                continue
+
+            normalized = stripped.upper()
+            cleaned = normalized.replace(".", "").replace("-", "").replace("/", "")
+            if not cleaned or not cleaned.isalnum() or not (1 <= len(cleaned) <= 10):
+                continue
+            if not cleaned[0].isalpha() or cleaned.isdigit():
+                continue
+            if normalized != stripped:
+                continue
+            if cleaned in _US_SYMBOL_RESERVED_TOKENS:
+                continue
+            if cleaned.startswith(("ORDER", "ACNT", "ACCOUNT", "CUST", "USER")):
+                continue
+            if any(ch.isdigit() for ch in cleaned) and len(cleaned) >= 8:
+                continue
+            return stripped
         return None
 
     def _extract_timestamp(self, value: str | None) -> str:

--- a/tests/test_fill_notification.py
+++ b/tests/test_fill_notification.py
@@ -97,6 +97,41 @@ class TestNormalizeKisFill:
         assert order.account == "kis"
         assert order.market_type == "us"
 
+    def test_normalize_overseas_fields_preserve_explicit_currency(self) -> None:
+        raw = {
+            "symbol": "BAC",
+            "side": "02",
+            "filled_price": "47.9",
+            "filled_qty": "23",
+            "filled_amount": "1101.7",
+            "filled_at": "2026-02-14T09:30:00-05:00",
+            "market": "us",
+            "currency": "USD",
+        }
+
+        order = normalize_kis_fill(raw)
+
+        assert order.market_type == "us"
+        assert order.currency == "USD"
+
+    def test_normalize_overseas_fields_defaults_currency_to_usd_for_us_market(
+        self,
+    ) -> None:
+        raw = {
+            "symbol": "BAC",
+            "side": "02",
+            "filled_price": "47.9",
+            "filled_qty": "23",
+            "filled_amount": "1101.7",
+            "filled_at": "2026-02-14T09:30:00-05:00",
+            "market_type": "us",
+        }
+
+        order = normalize_kis_fill(raw)
+
+        assert order.market_type == "us"
+        assert order.currency == "USD"
+
     def test_normalize_kis_fill_prefers_explicit_market_field_over_symbol_inference(
         self,
     ) -> None:
@@ -160,6 +195,23 @@ class TestNormalizeKisFill:
         )
 
         assert order.market_type == "kr"
+
+    def test_coerce_fill_order_preserves_explicit_currency(self) -> None:
+        order = coerce_fill_order(
+            {
+                "symbol": "BAC",
+                "side": "02",
+                "filled_price": 47.9,
+                "filled_qty": 23,
+                "filled_amount": 1101.7,
+                "filled_at": "2026-02-14T09:30:00",
+                "account": "kis",
+                "market_type": "us",
+                "currency": "USD",
+            }
+        )
+
+        assert order.currency == "USD"
 
     @pytest.mark.parametrize(
         ("market", "expected_market_type"),
@@ -250,6 +302,25 @@ class TestNormalizeKisFill:
 
         assert order.symbol == "UNKNOWN"
         assert order.market_type is None
+
+    @pytest.mark.parametrize("symbol", ["PROD", "ENV", "ORDER123"])
+    def test_coerce_fill_order_does_not_infer_us_market_from_reserved_tokens(
+        self, symbol: str
+    ) -> None:
+        order = coerce_fill_order(
+            {
+                "symbol": symbol,
+                "side": "02",
+                "filled_price": 100,
+                "filled_qty": 1,
+                "filled_amount": 100,
+                "filled_at": "2026-02-14T09:30:00",
+                "account": "kis",
+            }
+        )
+
+        assert order.market_type is None
+        assert order.currency is None
 
     def test_normalize_missing_fields_best_effort(self) -> None:
         order = normalize_kis_fill({})
@@ -361,3 +432,41 @@ class TestFormatFillMessage:
 
         assert "🟢 체결 알림" in message
         assert "구분: 매수 부분체결" in message
+
+    def test_format_us_fill_uses_usd_currency_output(self) -> None:
+        order = FillOrder(
+            symbol="BAC",
+            side="bid",
+            filled_price=47.9,
+            filled_qty=23,
+            filled_amount=1101.7,
+            filled_at="2026-02-14T09:30:00-05:00",
+            account="kis",
+            market_type="us",
+            currency="USD",
+        )
+
+        message = format_fill_message(order)
+
+        assert "체결가: $47.90" in message
+        assert "금액: $1,101.70" in message
+
+    def test_format_us_fill_normalizes_lowercase_currency_on_fill_order_input(
+        self,
+    ) -> None:
+        order = FillOrder(
+            symbol="BAC",
+            side="bid",
+            filled_price=47.9,
+            filled_qty=23,
+            filled_amount=1101.7,
+            filled_at="2026-02-14T09:30:00-05:00",
+            account="kis",
+            market_type="us",
+            currency="usd",
+        )
+
+        message = format_fill_message(order)
+
+        assert "체결가: $47.90" in message
+        assert "금액: $1,101.70" in message

--- a/tests/test_kis_websocket.py
+++ b/tests/test_kis_websocket.py
@@ -51,6 +51,14 @@ def _build_overseas_message(
     return f"0|H0GSCNI0|1|{payload}"
 
 
+def _build_synthetic_overseas_bac_message(*, symbol: str = "BAC") -> str:
+    payload = (
+        "mgh3326^1234567890^0030145286^PROD^02^0^RESERVED^"
+        f"{symbol}^23^47.90^093001^0^2^00^ENV^0000000023"
+    )
+    return f"0|H0GSCNI0|1|{payload}"
+
+
 @pytest.mark.unit
 class TestKISWebSocketApprovalKey:
     """Tests for Approval Key issuance"""
@@ -565,6 +573,21 @@ class TestKISWebSocketClient:
         assert result["order_qty"] == 10
         assert result["execution_status"] == "partial"
         assert "T09:30:01" in result["filled_at"]
+
+    @pytest.mark.asyncio
+    async def test_parse_message_keeps_synthetic_overseas_bac_fill_in_usd(
+        self, execution_callback
+    ) -> None:
+        client = KISExecutionWebSocket(on_execution=execution_callback, mock_mode=True)
+
+        result = client._parse_message(_build_synthetic_overseas_bac_message())
+
+        assert result is not None
+        assert result["symbol"] == "BAC"
+        assert result["filled_qty"] == 23
+        assert result["filled_price"] == 47.9
+        assert result["filled_amount"] == 1101.7
+        assert result["currency"] == "USD"
 
     @pytest.mark.asyncio
     async def test_parse_message_marks_overseas_order_notice_when_cntg_yn_not_two(
@@ -1144,6 +1167,22 @@ class TestKISWebSocketClient:
 
         assert client._extract_symbol(fields, "us") == "AAPL"
 
+    def test_extract_symbol_rejects_reserved_and_account_like_us_tokens(
+        self, execution_callback
+    ) -> None:
+        client = KISExecutionWebSocket(on_execution=execution_callback, mock_mode=True)
+
+        fields = [
+            "1234567890",
+            "PROD",
+            "RESERVED",
+            "ENV",
+            "BAC",
+            "093001",
+        ]
+
+        assert client._extract_symbol(fields, "us") == "BAC"
+
     def test_parse_overseas_execution_logs_error_on_insufficient_fields(
         self, execution_callback, caplog
     ):
@@ -1166,6 +1205,24 @@ class TestKISWebSocketClient:
         client = KISExecutionWebSocket(on_execution=execution_callback, mock_mode=True)
 
         payload = "mgh3326^6762259301^0030145286^prod^02^0^^^3^201.5^093001^0^2^00^^10"
+        message = f"0|H0GSCNI0|1|{payload}"
+
+        with caplog.at_level("ERROR"):
+            result = client._parse_message(message)
+
+        assert result is not None
+        assert result.get("symbol") == ""
+        assert not result.get("filled_price")
+        assert not result.get("filled_qty")
+        assert client._is_execution_event(result) is False
+        assert "missing symbol" in caplog.text.lower()
+
+    def test_parse_overseas_execution_with_empty_symbol_slot_does_not_revive_bac_fallback(
+        self, execution_callback, caplog
+    ) -> None:
+        client = KISExecutionWebSocket(on_execution=execution_callback, mock_mode=True)
+
+        payload = "mgh3326^1234567890^0030145286^PROD^02^0^^^23^47.90^093001^0^2^00^BAC^0000000023"
         message = f"0|H0GSCNI0|1|{payload}"
 
         with caplog.at_level("ERROR"):
@@ -1551,3 +1608,214 @@ class TestCloseApprovalKeyRedis:
         assert mock_redis.close.call_count == 1  # Not called again
 
         assert mod._redis_client is None
+
+
+
+
+
+# =============================================================================
+# H0GSCNI0 Synthetic Contract Tests
+# =============================================================================
+# These tests verify the current parser contract for overseas execution
+# (H0GSCNI0) message parsing. They use synthetic payloads that match the
+# documented KIS WebSocket API structure but are NOT based on actual decrypted
+# evidence captures.
+#
+# WARNING: These are synthetic tests only. Real evidence-backed regression
+# requires sanitized decrypted ^ payload from live trading captures.
+# See issue #283 for evidence requirements.
+# =============================================================================
+
+
+def _build_synthetic_h0gscni0_message(
+    *,
+    symbol: str = "TSLA",
+    filled_qty: str = "10",
+    filled_price: str = "248.50",
+    order_qty: str = "0000000010",
+    rctf_cls: str = "0",
+    acpt_yn: str = "00",
+    rfus_yn: str = "0",
+    cntg_yn: str = "2",
+    side: str = "02",
+) -> str:
+    """
+    Build a synthetic H0GSCNI0 message for parser contract testing.
+
+    SYNTHETIC ONLY - Not based on actual decrypted evidence.
+    Payload structure follows KIS API documentation conventions.
+    """
+    payload = (
+        f"ACCT0001^ORDER00001^TRX0000001^PROD^{side}^{rctf_cls}^RESERVED^"
+        f"{symbol}^{filled_qty}^{filled_price}^153045^{rfus_yn}^{cntg_yn}^{acpt_yn}^NASDAQ^{order_qty}"
+    )
+    return f"0|H0GSCNI0|1|{payload}"
+
+
+@pytest.mark.unit
+class TestH0GSCNI0SyntheticContract:
+    """
+    Synthetic contract tests for H0GSCNI0 (overseas execution) parsing.
+
+    These tests verify the current parser behavior against synthetic payloads.
+    They do NOT constitute evidence-backed regression (see issue #283).
+    """
+
+    @pytest.mark.asyncio
+    async def test_synthetic_h0gscni0_full_fill_parsing(self) -> None:
+        """
+        Test synthetic H0GSCNI0 full fill message parsing.
+
+        Synthetic case: Full fill (cntg_yn=2, filled_qty == order_qty)
+        Verifies: Parser extracts expected fields with USD currency
+        """
+        client = KISExecutionWebSocket(on_execution=AsyncMock(), mock_mode=True)
+
+        message = _build_synthetic_h0gscni0_message(
+            symbol="TSLA",
+            filled_qty="10",
+            filled_price="248.50",
+            order_qty="0000000010",
+            cntg_yn="2",
+            side="02",  # bid (buy)
+        )
+
+        result = client._parse_message(message)
+
+        assert result is not None
+        assert result["tr_code"] == "H0GSCNI0"
+        assert result["market"] == "us"
+        assert result["symbol"] == "TSLA"
+        assert result["side"] == "bid"
+        assert result["filled_qty"] == 10.0
+        assert result["filled_price"] == 248.50
+        assert result["filled_amount"] == 2485.0
+        assert result["order_qty"] == 10.0
+        assert result["currency"] == "USD"
+        assert result["execution_status"] == "filled"
+        assert client._is_execution_event(result) is True
+
+    @pytest.mark.asyncio
+    async def test_synthetic_h0gscni0_partial_fill_parsing(self) -> None:
+        """
+        Test synthetic H0GSCNI0 partial fill message parsing.
+
+        Synthetic case: Partial fill (cntg_yn=2, filled_qty < order_qty)
+        Verifies: Parser returns partial status
+        """
+        client = KISExecutionWebSocket(on_execution=AsyncMock(), mock_mode=True)
+
+        message = _build_synthetic_h0gscni0_message(
+            symbol="AAPL",
+            filled_qty="5",
+            filled_price="175.25",
+            order_qty="0000000010",
+            cntg_yn="2",
+            side="01",  # ask (sell)
+        )
+
+        result = client._parse_message(message)
+
+        assert result is not None
+        assert result["symbol"] == "AAPL"
+        assert result["side"] == "ask"
+        assert result["filled_qty"] == 5.0
+        assert result["filled_price"] == 175.25
+        assert result["order_qty"] == 10.0
+        assert result["currency"] == "USD"
+        assert result["execution_status"] == "partial"
+        assert client._is_execution_event(result) is True
+
+    @pytest.mark.asyncio
+    async def test_synthetic_h0gscni0_sell_side_parsing(self) -> None:
+        """
+        Test synthetic H0GSCNI0 sell-side (ask) message parsing.
+
+        Synthetic case: Sell order with side=01 (ask)
+        Verifies: Side correctly normalized to 'ask'
+        """
+        client = KISExecutionWebSocket(on_execution=AsyncMock(), mock_mode=True)
+
+        message = _build_synthetic_h0gscni0_message(
+            symbol="NVDA",
+            filled_qty="3",
+            filled_price="875.00",
+            side="01",  # ask (sell)
+        )
+
+        result = client._parse_message(message)
+
+        assert result is not None
+        assert result["symbol"] == "NVDA"
+        assert result["side"] == "ask"
+        assert result["filled_qty"] == 3.0
+        assert result["filled_price"] == 875.00
+        assert result["currency"] == "USD"
+
+    @pytest.mark.asyncio
+    async def test_synthetic_h0gscni0_rejected_status(self) -> None:
+        """
+        Test synthetic H0GSCNI0 rejected order status parsing.
+
+        Synthetic case: Rejected order (rfus_yn=1)
+        Verifies: execution_status='rejected', not an execution event
+        """
+        client = KISExecutionWebSocket(on_execution=AsyncMock(), mock_mode=True)
+
+        message = _build_synthetic_h0gscni0_message(
+            symbol="GOOGL",
+            filled_qty="0",
+            filled_price="0",
+            rfus_yn="1",  # rejected
+            cntg_yn="0",
+        )
+
+        result = client._parse_message(message)
+
+        assert result is not None
+        assert result["symbol"] == "GOOGL"
+        assert result["rfus_yn"] == "1"
+        assert result["execution_status"] == "rejected"
+        assert client._is_execution_event(result) is False
+
+    @pytest.mark.asyncio
+    async def test_synthetic_h0gscni0_field_slot_positions(self) -> None:
+        """
+        Test that H0GSCNI0 fields are extracted from documented slot positions.
+
+        Uses unique values at each position to verify slot mapping.
+        """
+        client = KISExecutionWebSocket(on_execution=AsyncMock(), mock_mode=True)
+
+        payload = (
+            "ACCT0001^"      # 0: account
+            "ORDER00001^"    # 1: order_id
+            "TRX0000001^"    # 2: tr_code placeholder
+            "PROD^"          # 3: reserved
+            "02^"            # 4: side (bid)
+            "9^"             # 5: rctf_cls (unique value)
+            "RESERVED^"      # 6: reserved
+            "META^"          # 7: symbol (unique)
+            "42^"            # 8: filled_qty (unique)
+            "999.99^"        # 9: filled_price (unique)
+            "093001^"        # 10: filled_at
+            "8^"             # 11: rfus_yn (unique)
+            "7^"             # 12: cntg_yn (unique)
+            "77^"            # 13: acpt_yn (unique)
+            "NYSE^"          # 14: exchange
+            "0000000042"     # 15: order_qty (unique)
+        )
+        message = f"0|H0GSCNI0|1|{payload}"
+
+        result = client._parse_message(message)
+
+        assert result is not None
+        assert result["symbol"] == "META"
+        assert result["filled_qty"] == 42.0
+        assert result["filled_price"] == 999.99
+        assert result["rctf_cls"] == "9"
+        assert result["acpt_yn"] == "77"
+        assert result["rfus_yn"] == "8"
+        assert result["cntg_yn"] == "7"
+        assert result["order_qty"] == 42.0
+        assert result["currency"] == "USD"

--- a/tests/test_websocket_monitor.py
+++ b/tests/test_websocket_monitor.py
@@ -96,6 +96,39 @@ class TestUnifiedWebSocketMonitor:
         assert send_mock.await_args.kwargs["correlation_id"] == "corr-kis-1"
 
     @pytest.mark.asyncio
+    async def test_on_kis_execution_forwards_us_currency_for_overseas_fill(
+        self, mock_settings: None
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor()
+        send_mock = AsyncMock(return_value="req-789")
+        monitor.openclaw_client.send_fill_notification = send_mock
+
+        await monitor._on_kis_execution(
+            {
+                "symbol": "BAC",
+                "side": "buy",
+                "execution_status": "filled",
+                "filled_price": 47.9,
+                "filled_qty": 23,
+                "filled_amount": 1101.7,
+                "market": "us",
+                "currency": "USD",
+                "correlation_id": "corr-kis-us-1",
+            }
+        )
+
+        send_mock.assert_awaited_once()
+        fill_order = send_mock.call_args.args[0]
+        assert isinstance(fill_order, FillOrder)
+        assert fill_order.symbol == "BAC"
+        assert fill_order.market_type == "us"
+        assert fill_order.currency == "USD"
+        assert send_mock.await_args is not None
+        assert send_mock.await_args.kwargs["correlation_id"] == "corr-kis-us-1"
+
+    @pytest.mark.asyncio
     async def test_on_kis_execution_skips_domestic_without_fill_yn(
         self, mock_settings: None
     ) -> None:


### PR DESCRIPTION
## Summary
- add USD propagation and formatting for overseas KIS fill notifications
- harden H0GSCNI0 symbol handling so empty overseas symbol slots are not revived from fallback tokens
- keep new H0GSCNI0 coverage explicitly synthetic until real decrypted evidence is captured

## Test Plan
- [x] uv run pytest tests/test_kis_websocket.py tests/test_fill_notification.py tests/test_websocket_monitor.py tests/test_openclaw_client.py -q
- [x] uv run ty check app/services/kis_websocket.py app/services/fill_notification.py websocket_monitor.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added currency tracking for fill orders with intelligent market-based defaults.
  * Implemented currency-aware formatting for transaction amounts displayed in notifications.
  * Enhanced US market symbol validation with stricter detection rules.

* **Bug Fixes**
  * Improved robustness of overseas execution message parsing and symbol handling in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->