### PR TITLE
fix(mcp): optimize US screen_stocks tvscreener enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,11 @@ Market-specific behavior:
   - Category filter auto-limits to ETFs if `asset_type=None`
   - ETN (`asset_type="etn"`) not supported - returns error
 
-- **US market**: Uses yfinance screener.
-  - Filters: `min_market_cap` → `intradaymarketcap`, `max_per` → `peratio_lasttwelvemonths`, `min_dividend_yield` → `forward_dividend_yield`
-  - Sort maps: `volume` → `dayvolume`, `market_cap` → `intradaymarketcap`, `change_rate` → `percentchange`
+- **US market**: Uses tvscreener first for stock requests, then falls back to yfinance when TradingView fields are unavailable or the request needs an unsupported sort.
+  - US `category`/`sector` filters stay on the tvscreener path when TradingView sector metadata is available
+  - Public enrichment fields (`sector`, `analyst_buy`, `analyst_hold`, `analyst_sell`, `avg_target`, `upside_pct`) are filled directly from tvscreener when possible; missing values use lightweight Finnhub/yfinance fallback
+  - Legacy yfinance filters: `min_market_cap` → `intradaymarketcap`, `max_per` → `peratio_lasttwelvemonths`, `min_dividend_yield` → `forward_dividend_yield`
+  - Legacy yfinance sort maps: `volume` → `dayvolume`, `market_cap` → `intradaymarketcap`, `change_rate` → `percentchange`
 
 - **Crypto market**: Uses Upbit top traded coins.
   - Default sort is `trade_amount` and maps to `acc_trade_price_24h` (24h traded value in KRW)

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -319,11 +319,13 @@ Market-specific behavior:
   - ETN (`asset_type="etn"`) not supported - returns error
 
 - **US market**:
-  - Default `asset_type in {None, "stock"}` + `category=None` requests use tvscreener first
-  - Successful stock responses expose `meta.source = "tvscreener"` and include `adx` in each result row
-  - Category/unsupported requests fall back to the legacy yfinance path
+  - Default `asset_type in {None, "stock"}` requests use tvscreener first, including US `category`/`sector` alias filters when the TradingView sector field is available
+  - Successful stock responses expose `meta.source = "tvscreener"`, include `adx`, and preserve public enrichment fields (`sector`, `analyst_buy`, `analyst_hold`, `analyst_sell`, `avg_target`, `upside_pct`) from tvscreener when available
+  - Post-screen enrichment skips per-row Finnhub/yfinance fan-out when those public fields are already populated; missing fields fall back to lightweight yfinance/Finnhub enrichment
+  - Unsupported sorts or missing tvscreener sector metadata fall back to the legacy yfinance path
   - Legacy yfinance maps: `min_market_cap` → `intradaymarketcap`, `max_per` → `peratio.lasttwelvemonths`, `min_dividend_yield` → `forward_dividend_yield`
   - Legacy yfinance sort maps: `volume` → `dayvolume`, `market_cap` → `intradaymarketcap`, `change_rate` → `percentchange`
+  - Legacy yfinance screen enrichment reuses a request-scoped session for repeated analyst-target lookups
   - Yahoo OHLCV (`day/week/month`) requests use Redis closed-candle cache at the service boundary
   - Closed-bucket cutoff uses NYSE session close via `exchange_calendars` (`XNYS`), including DST/holidays/early close
 

--- a/app/mcp_server/tooling/analysis_screen_core.py
+++ b/app/mcp_server/tooling/analysis_screen_core.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import inspect
 import logging
 import time
 from typing import Any, cast
@@ -253,7 +254,65 @@ def _apply_equity_enrichment_defaults(row: dict[str, Any]) -> dict[str, Any]:
     normalized = dict(row)
     for field in _SCREEN_ENRICHMENT_FIELDS:
         normalized.setdefault(field, None)
+    sector = _clean_text(normalized.get("sector"))
+    normalized["sector"] = sector or None
+    for field in ("analyst_buy", "analyst_hold", "analyst_sell"):
+        normalized[field] = _to_optional_int(normalized.get(field))
+    avg_target = _to_optional_float(normalized.get("avg_target"))
+    normalized["avg_target"] = avg_target
+    upside_pct = _to_optional_float(normalized.get("upside_pct"))
+    if upside_pct is None:
+        upside_pct = _compute_target_upside_pct(
+            avg_target=avg_target,
+            current_price=_to_optional_float(
+                _get_first_present(normalized, "close", "price")
+            ),
+        )
+    normalized["upside_pct"] = upside_pct
     return normalized
+
+
+def _compute_target_upside_pct(
+    *, avg_target: float | None, current_price: float | None
+) -> float | None:
+    if avg_target is None or current_price is None or current_price <= 0:
+        return None
+    return round((avg_target - current_price) / current_price * 100, 2)
+
+
+def _row_has_complete_screen_enrichment(row: dict[str, Any]) -> bool:
+    if row.get("sector") is None:
+        return False
+    if any(
+        row.get(field) is None
+        for field in ("analyst_buy", "analyst_hold", "analyst_sell")
+    ):
+        return False
+    return row.get("avg_target") is not None and row.get("upside_pct") is not None
+
+
+def _filter_supported_keyword_args(
+    func: Any,
+    kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    try:
+        parameters = inspect.signature(func).parameters.values()
+    except (TypeError, ValueError):
+        return kwargs
+
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in parameters):
+        return kwargs
+
+    accepted_names = {
+        param.name
+        for param in parameters
+        if param.kind
+        in {
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }
+    }
+    return {name: value for name, value in kwargs.items() if name in accepted_names}
 
 
 def _screen_row_symbol(row: dict[str, Any]) -> str | None:
@@ -286,6 +345,14 @@ async def _decorate_screen_rows_with_equity_enrichment(
     normalized_rows = [_apply_equity_enrichment_defaults(row) for row in rows]
     semaphore = asyncio.Semaphore(max(1, concurrency))
     warnings: list[str] = []
+    yfinance_session: Any | None = None
+    if any(
+        str(row.get("market") or "").strip().lower() == "us"
+        and _is_equity_stock_row(row)
+        and not _row_has_complete_screen_enrichment(row)
+        for row in normalized_rows
+    ):
+        yfinance_session = build_yfinance_tracing_session()
 
     async def enrich_row(index: int, row: dict[str, Any]) -> None:
         if not _is_equity_stock_row(row):
@@ -296,15 +363,28 @@ async def _decorate_screen_rows_with_equity_enrichment(
         if not symbol:
             warnings.append(f"{market or 'unknown'}:<missing-symbol>: missing symbol")
             return
+        if market == "us" and _row_has_complete_screen_enrichment(row):
+            return
 
-        fetcher = (
-            _fetch_screen_enrichment_us
-            if market == "us"
-            else _fetch_screen_enrichment_kr
-        )
         async with semaphore:
             try:
-                enrichment = await fetcher(symbol)
+                if market == "us":
+                    enrichment_kwargs = _filter_supported_keyword_args(
+                        _fetch_screen_enrichment_us,
+                        {
+                            "current_price": _to_optional_float(
+                                _get_first_present(row, "close", "price")
+                            ),
+                            "session": yfinance_session,
+                            "include_opinion_history": False,
+                        },
+                    )
+                    enrichment = await _fetch_screen_enrichment_us(
+                        symbol,
+                        **enrichment_kwargs,
+                    )
+                else:
+                    enrichment = await _fetch_screen_enrichment_kr(symbol)
             except Exception as exc:
                 warnings.append(f"{market}:{symbol}: {type(exc).__name__}: {exc}")
                 return
@@ -314,11 +394,20 @@ async def _decorate_screen_rows_with_equity_enrichment(
             return
 
         for field in _SCREEN_ENRICHMENT_FIELDS:
-            normalized_rows[index][field] = enrichment.get(field)
+            current_value = normalized_rows[index].get(field)
+            incoming_value = enrichment.get(field)
+            if current_value is None and incoming_value is not None:
+                normalized_rows[index][field] = incoming_value
 
-    await asyncio.gather(
-        *(enrich_row(index, row) for index, row in enumerate(normalized_rows))
-    )
+    try:
+        await asyncio.gather(
+            *(enrich_row(index, row) for index, row in enumerate(normalized_rows))
+        )
+    finally:
+        if yfinance_session is not None:
+            close = getattr(yfinance_session, "close", None)
+            if callable(close):
+                close()
     return normalized_rows, warnings
 
 
@@ -385,11 +474,11 @@ def _apply_post_enrichment_filters(
     min_dividend_yield: float | None,
 ) -> list[dict[str, Any]]:
     filtered: list[dict[str, Any]] = []
-    normalized_sector = _normalize_sector_value(sector)
+    normalized_sector = _normalize_sector_compare_key(sector)
 
     for row in rows:
         if normalized_sector is not None:
-            row_sector = _normalize_sector_value(_clean_text(row.get("sector")))
+            row_sector = _normalize_sector_compare_key(_clean_text(row.get("sector")))
             if row_sector != normalized_sector:
                 continue
 
@@ -600,13 +689,30 @@ def _normalize_optional_text(value: str | None) -> str | None:
 
 
 def _normalize_sector_value(sector: str | None) -> str | None:
+    return _normalize_optional_text(sector)
+
+
+def _normalize_sector_compare_key(sector: str | None) -> str | None:
     normalized = _normalize_optional_text(sector)
     if normalized is None:
         return None
     if normalized.isascii():
-        return normalized.title()
+        return normalized.casefold()
     return normalized
 
+
+def _canonicalize_us_sector_label(sector: str) -> str:
+    """Canonicalize a US sector label for the TradingView tvscreener provider.
+
+    General ASCII strings → title case (``"technology"`` → ``"Technology"``).
+    Short ASCII tokens (≤3 chars) → upper case (``"ai"`` → ``"AI"``).
+    Non-ASCII values → whitespace cleanup only (unchanged).
+    """
+    if not sector.isascii():
+        return sector
+    if len(sector) <= 3:
+        return sector.upper()
+    return sector.title()
 
 def _normalize_min_analyst_buy(value: float | None) -> float | None:
     if value is None:
@@ -671,11 +777,11 @@ def normalize_screen_request(
 
     if normalized_category is not None and normalized_sector is not None:
         category_alias = (
-            _normalize_sector_value(normalized_category)
+            _normalize_sector_compare_key(normalized_category)
             if normalized_market == "us"
-            else normalized_category
+            else _normalize_optional_text(normalized_category)
         )
-        if category_alias != normalized_sector:
+        if category_alias != _normalize_sector_compare_key(normalized_sector):
             raise ValueError("category and sector cannot specify different values")
 
     effective_sector = normalized_sector
@@ -685,6 +791,8 @@ def normalize_screen_request(
         and normalized_category is not None
     ):
         effective_sector = _normalize_sector_value(normalized_category)
+    if normalized_market == "us" and effective_sector is not None:
+        effective_sector = _canonicalize_us_sector_label(effective_sector)
 
     if effective_sector is not None:
         if normalized_market == "crypto":
@@ -763,7 +871,7 @@ def _can_use_tvscreener_stock_path(
         return asset_type in {None, "stock"} and category is None
 
     if market == "us":
-        return asset_type in {None, "stock"} and category is None
+        return asset_type in {None, "stock"}
 
     return False
 
@@ -789,6 +897,55 @@ def _map_tvscreener_stock_row(
     }
     if row.get("pbr") is not None or market in {"kr", "kospi", "kosdaq"}:
         mapped["pbr"] = row.get("pbr")
+    if market == "us":
+        sector = _clean_text(_get_first_present(row, "sector.tr", "sector"))
+        if sector:
+            mapped["sector"] = sector
+        recommendation_buy = _to_optional_int(
+            _get_first_present(row, "recommendation_buy", "analyst_buy")
+        )
+        recommendation_over = _to_optional_int(
+            _get_first_present(row, "recommendation_over")
+        )
+        recommendation_hold = _to_optional_int(
+            _get_first_present(row, "recommendation_hold", "analyst_hold")
+        )
+        recommendation_sell = _to_optional_int(
+            _get_first_present(row, "recommendation_sell", "analyst_sell")
+        )
+        recommendation_under = _to_optional_int(
+            _get_first_present(row, "recommendation_under")
+        )
+        if recommendation_buy is not None or recommendation_over is not None:
+            mapped["analyst_buy"] = (recommendation_buy or 0) + (
+                recommendation_over or 0
+            )
+        if recommendation_hold is not None:
+            mapped["analyst_hold"] = recommendation_hold
+        if recommendation_sell is not None or recommendation_under is not None:
+            mapped["analyst_sell"] = (recommendation_sell or 0) + (
+                recommendation_under or 0
+            )
+        avg_target = _to_optional_float(
+            _get_first_present(
+                row,
+                "price_target_average",
+                "price_target_1y",
+                "avg_target",
+            )
+        )
+        if avg_target is not None:
+            mapped["avg_target"] = avg_target
+        upside_pct = _to_optional_float(
+            _get_first_present(row, "price_target_1y_delta", "upside_pct")
+        )
+        if upside_pct is None:
+            upside_pct = _compute_target_upside_pct(
+                avg_target=avg_target,
+                current_price=_to_optional_float(mapped.get("close")),
+            )
+        if upside_pct is not None:
+            mapped["upside_pct"] = upside_pct
     return mapped
 
 
@@ -2186,6 +2343,40 @@ async def _screen_us_via_tvscreener(
             "DIVIDEND_YIELD_FORWARD",
             "DIVIDEND_YIELD_RECENT",
         )
+        sector_field = _get_tvscreener_attr(StockField, "SECTOR")
+        sector_display_field = _get_tvscreener_attr(StockField, "SECTOR_TR")
+        recommendation_buy_field = _get_tvscreener_attr(
+            StockField,
+            "RECOMMENDATION_BUY",
+        )
+        recommendation_over_field = _get_tvscreener_attr(
+            StockField,
+            "RECOMMENDATION_OVER",
+        )
+        recommendation_hold_field = _get_tvscreener_attr(
+            StockField,
+            "RECOMMENDATION_HOLD",
+        )
+        recommendation_sell_field = _get_tvscreener_attr(
+            StockField,
+            "RECOMMENDATION_SELL",
+        )
+        recommendation_under_field = _get_tvscreener_attr(
+            StockField,
+            "RECOMMENDATION_UNDER",
+        )
+        price_target_average_field = _get_tvscreener_attr(
+            StockField,
+            "PRICE_TARGET_AVERAGE",
+        )
+        price_target_field = _get_tvscreener_attr(
+            StockField,
+            "PRICE_TARGET_1Y",
+        )
+        price_target_delta_field = _get_tvscreener_attr(
+            StockField,
+            "PRICE_TARGET_1Y_DELTA",
+        )
 
         if sort_by == "market_cap" and market_cap_field is None:
             result["error"] = "tvscreener market-cap field unavailable"
@@ -2201,6 +2392,9 @@ async def _screen_us_via_tvscreener(
             return result
         if min_dividend_yield is not None and dividend_field is None:
             result["error"] = "tvscreener dividend-yield field unavailable"
+            return result
+        if category is not None and sector_field is None:
+            result["error"] = "tvscreener sector field unavailable"
             return result
 
         columns = [
@@ -2219,6 +2413,20 @@ async def _screen_us_via_tvscreener(
             columns.append(pe_field)
         if dividend_field is not None:
             columns.append(dividend_field)
+        for optional_field in (
+            sector_display_field,
+            sector_field,
+            recommendation_buy_field,
+            recommendation_over_field,
+            recommendation_hold_field,
+            recommendation_sell_field,
+            recommendation_under_field,
+            price_target_average_field,
+            price_target_field,
+            price_target_delta_field,
+        ):
+            if optional_field is not None:
+                columns.append(optional_field)
 
         try:
             columns.append(StockField.COUNTRY)
@@ -2240,6 +2448,8 @@ async def _screen_us_via_tvscreener(
             where_conditions.append(pe_field <= max_per)
         if min_dividend_yield_normalized is not None and dividend_field is not None:
             where_conditions.append(dividend_field >= min_dividend_yield_normalized)
+        if category is not None and sector_field is not None:
+            where_conditions.append(sector_field == category)
 
         logger.info(
             "[Screen-US-TV] Querying StockScreener for US stocks "
@@ -2295,11 +2505,79 @@ async def _screen_us_via_tvscreener(
                         "dividend_yield_recent",
                     )
                 ),
+                "sector": _get_first_present(row, "sector.tr", "sector"),
+                "recommendation_buy": _to_optional_int(
+                    _get_first_present(row, "recommendation_buy")
+                ),
+                "recommendation_over": _to_optional_int(
+                    _get_first_present(row, "recommendation_over")
+                ),
+                "recommendation_hold": _to_optional_int(
+                    _get_first_present(row, "recommendation_hold")
+                ),
+                "recommendation_sell": _to_optional_int(
+                    _get_first_present(row, "recommendation_sell")
+                ),
+                "recommendation_under": _to_optional_int(
+                    _get_first_present(row, "recommendation_under")
+                ),
+                "price_target_average": _to_optional_float(
+                    _get_first_present(row, "price_target_average")
+                ),
+                "price_target_1y": _to_optional_float(
+                    _get_first_present(row, "price_target_1y")
+                ),
+                "price_target_1y_delta": _to_optional_float(
+                    _get_first_present(row, "price_target_1y_delta")
+                ),
                 "market": market,
                 "country": str(row.get("country", "")).strip()
                 if "country" in row
                 else "United States",
             }
+            sector = _clean_text(_get_first_present(row, "sector.tr", "sector"))
+            if sector:
+                stock["sector"] = sector
+            recommendation_buy = _to_optional_int(
+                _get_first_present(row, "recommendation_buy")
+            )
+            recommendation_over = _to_optional_int(
+                _get_first_present(row, "recommendation_over")
+            )
+            recommendation_hold = _to_optional_int(
+                _get_first_present(row, "recommendation_hold")
+            )
+            recommendation_sell = _to_optional_int(
+                _get_first_present(row, "recommendation_sell")
+            )
+            recommendation_under = _to_optional_int(
+                _get_first_present(row, "recommendation_under")
+            )
+            if recommendation_buy is not None or recommendation_over is not None:
+                stock["analyst_buy"] = (recommendation_buy or 0) + (
+                    recommendation_over or 0
+                )
+            if recommendation_hold is not None:
+                stock["analyst_hold"] = recommendation_hold
+            if recommendation_sell is not None or recommendation_under is not None:
+                stock["analyst_sell"] = (recommendation_sell or 0) + (
+                    recommendation_under or 0
+                )
+            avg_target = _to_optional_float(
+                _get_first_present(row, "price_target_average", "price_target_1y")
+            )
+            if avg_target is not None:
+                stock["avg_target"] = avg_target
+            upside_pct = _to_optional_float(
+                _get_first_present(row, "price_target_1y_delta")
+            )
+            if upside_pct is None:
+                upside_pct = _compute_target_upside_pct(
+                    avg_target=avg_target,
+                    current_price=price,
+                )
+            if upside_pct is not None:
+                stock["upside_pct"] = upside_pct
             stock["change_rate"] = stock["change_percent"]
             stocks.append(stock)
 

--- a/app/mcp_server/tooling/fundamentals_sources_naver.py
+++ b/app/mcp_server/tooling/fundamentals_sources_naver.py
@@ -816,6 +816,69 @@ async def _fetch_investment_opinions_yfinance(
     return result
 
 
+async def _fetch_investment_opinions_yfinance_screen(
+    symbol: str,
+    *,
+    current_price: float | None = None,
+    session: Any | None = None,
+) -> dict[str, Any]:
+    loop = asyncio.get_running_loop()
+    if session is None:
+        session = build_yfinance_tracing_session()
+    ticker = yf.Ticker(symbol, session=session)
+
+    def _collect() -> tuple[dict[str, Any] | None, Any]:
+        targets = None
+        try:
+            targets = ticker.analyst_price_targets
+        except Exception:
+            pass
+
+        recommendations = None
+        try:
+            recommendations = ticker.recommendations
+        except Exception:
+            pass
+
+        return targets, recommendations
+
+    targets, trend = await loop.run_in_executor(None, _collect)
+
+    target_consensus = _build_yahoo_target_consensus(
+        targets,
+        fallback_current_price=current_price,
+    )
+    usable_target_available = False
+    if isinstance(targets, dict):
+        usable_target_available = any(
+            _normalize_yahoo_numeric(targets.get(key)) is not None
+            for key in ("mean", "median", "low", "high", "current")
+        )
+
+    consensus = _empty_analyst_consensus(
+        current_price=(target_consensus or {}).get("current_price", current_price)
+    )
+    count_consensus = _build_yahoo_count_consensus(trend)
+    if count_consensus is not None:
+        consensus.update(count_consensus)
+    if target_consensus is not None:
+        consensus.update(target_consensus)
+
+    result = {
+        "instrument_type": "equity_us",
+        "source": "yfinance",
+        "symbol": symbol.upper(),
+        "count": 0,
+        "opinions": [],
+        "consensus": consensus,
+    }
+    if count_consensus is None and not usable_target_available:
+        result["warning"] = (
+            f"Yahoo analyst consensus data unavailable for {symbol.upper()}."
+        )
+    return result
+
+
 async def _fetch_screen_enrichment_kr(symbol: str) -> dict[str, Any]:
     return await _fetch_screen_enrichment_payload(
         symbol=symbol,
@@ -826,13 +889,47 @@ async def _fetch_screen_enrichment_kr(symbol: str) -> dict[str, Any]:
     )
 
 
-async def _fetch_screen_enrichment_us(symbol: str) -> dict[str, Any]:
+async def _fetch_screen_enrichment_us(
+    symbol: str,
+    *,
+    current_price: float | None = None,
+    session: Any | None = None,
+    include_opinion_history: bool = True,
+) -> dict[str, Any]:
+    opinions_request: Any
+    opinions_provider: str
+    if include_opinion_history:
+        if session is None:
+            opinions_request = _fetch_investment_opinions_yfinance(symbol, 10)
+        else:
+            opinions_request = _fetch_investment_opinions_yfinance(
+                symbol,
+                10,
+                session=session,
+            )
+        opinions_provider = "yfinance"
+    else:
+        if current_price is None and session is None:
+            opinions_request = _fetch_investment_opinions_yfinance_screen(symbol)
+        elif session is None:
+            opinions_request = _fetch_investment_opinions_yfinance_screen(
+                symbol,
+                current_price=current_price,
+            )
+        else:
+            opinions_request = _fetch_investment_opinions_yfinance_screen(
+                symbol,
+                current_price=current_price,
+                session=session,
+            )
+        opinions_provider = "yfinance_screen"
+
     return await _fetch_screen_enrichment_payload(
         symbol=symbol,
         profile_request=_fetch_company_profile_finnhub(symbol),
-        opinions_request=_fetch_investment_opinions_yfinance(symbol, 10),
+        opinions_request=opinions_request,
         profile_provider="finnhub",
-        opinions_provider="yfinance",
+        opinions_provider=opinions_provider,
     )
 
 

--- a/tests/_mcp_screen_stocks_support.py
+++ b/tests/_mcp_screen_stocks_support.py
@@ -911,6 +911,378 @@ class TestScreenStocksTvScreenerContract:
         assert result["results"][0]["adx"] == 31.4
 
     @pytest.mark.asyncio
+    async def test_us_category_and_analyst_filter_stay_on_tvscreener_without_network_enrichment(
+        self, monkeypatch
+    ):
+        async def mock_screen_us_via_tvscreener(**kwargs):
+            assert kwargs["market"] == "us"
+            assert kwargs["asset_type"] is None
+            assert kwargs["category"] == "Technology"
+            assert kwargs["limit"] == 5
+            return {
+                "stocks": [
+                    {
+                        "symbol": "AAPL",
+                        "name": "Apple Inc.",
+                        "price": 175.5,
+                        "change_percent": 1.2,
+                        "volume": 75000000.0,
+                        "market_cap": 2800000000000,
+                        "rsi": 35.2,
+                        "adx": 31.4,
+                        "market": "us",
+                        "sector": "Technology",
+                        "analyst_buy": 18,
+                        "analyst_hold": 4,
+                        "analyst_sell": 1,
+                        "avg_target": 210.0,
+                        "upside_pct": 19.66,
+                    },
+                    {
+                        "symbol": "IBM",
+                        "name": "IBM",
+                        "price": 190.0,
+                        "change_percent": 0.4,
+                        "volume": 12000000.0,
+                        "market_cap": 170000000000,
+                        "rsi": 42.0,
+                        "adx": 22.0,
+                        "market": "us",
+                        "sector": "Technology",
+                        "analyst_buy": 7,
+                        "analyst_hold": 8,
+                        "analyst_sell": 2,
+                        "avg_target": 195.0,
+                        "upside_pct": 2.63,
+                    },
+                ],
+                "count": 2,
+                "filters_applied": {
+                    "market": "us",
+                    "asset_type": None,
+                    "category": "Technology",
+                    "sort_by": "volume",
+                    "sort_order": "desc",
+                },
+                "source": "tvscreener",
+                "error": None,
+            }
+
+        async def fail_legacy_us(**kwargs):
+            raise AssertionError(
+                "legacy US path should not run for category/analyst tvscreener requests"
+            )
+
+        async def fail_enrichment(symbol: str, **kwargs):
+            raise AssertionError(
+                f"network enrichment should not run for pre-enriched tvscreener row {symbol}"
+            )
+
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core._screen_us_via_tvscreener",
+            mock_screen_us_via_tvscreener,
+        )
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core._screen_us",
+            fail_legacy_us,
+        )
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core._fetch_screen_enrichment_us",
+            fail_enrichment,
+        )
+
+        tools = build_tools()
+        result = await tools["screen_stocks"](
+            market="us",
+            asset_type=None,
+            category="Technology",
+            min_market_cap=None,
+            max_per=None,
+            min_dividend_yield=None,
+            min_analyst_buy=10,
+            max_rsi=None,
+            sort_by="volume",
+            sort_order="desc",
+            limit=1,
+        )
+
+        assert result["meta"]["source"] == "tvscreener"
+        assert result["total_count"] == 1
+        assert result["returned_count"] == 1
+        assert result["filters_applied"]["category"] == "Technology"
+        assert result["filters_applied"]["min_analyst_buy"] == 10
+        first = result["results"][0]
+        assert first["code"] == "AAPL"
+        assert first["sector"] == "Technology"
+        assert first["analyst_buy"] == 18
+        assert first["analyst_hold"] == 4
+        assert first["analyst_sell"] == 1
+        assert first["avg_target"] == 210.0
+        assert first["upside_pct"] == 19.66
+
+    @pytest.mark.asyncio
+    async def test_us_enrichment_fallback_only_runs_for_rows_missing_tvscreener_fields(
+        self, monkeypatch
+    ):
+        fetch_enrichment = AsyncMock(
+            return_value={
+                "sector": "Software",
+                "analyst_buy": 16,
+                "analyst_hold": 5,
+                "analyst_sell": 1,
+                "avg_target": 470.0,
+                "upside_pct": 14.63,
+            }
+        )
+        monkeypatch.setattr(
+            analysis_screen_core,
+            "_fetch_screen_enrichment_us",
+            fetch_enrichment,
+        )
+
+        (
+            rows,
+            warnings,
+        ) = await analysis_screen_core._decorate_screen_rows_with_equity_enrichment(
+            [
+                {
+                    "code": "AAPL",
+                    "market": "us",
+                    "sector": "Technology",
+                    "analyst_buy": 20,
+                    "analyst_hold": 3,
+                    "analyst_sell": 1,
+                    "avg_target": 225.0,
+                    "upside_pct": 11.8,
+                },
+                {
+                    "code": "MSFT",
+                    "market": "us",
+                    "sector": None,
+                    "analyst_buy": None,
+                    "analyst_hold": None,
+                    "analyst_sell": None,
+                    "avg_target": None,
+                    "upside_pct": None,
+                },
+            ]
+        )
+
+        assert warnings == []
+        assert fetch_enrichment.await_count == 1
+        assert fetch_enrichment.await_args is not None
+        assert fetch_enrichment.await_args.args[0] == "MSFT"
+        assert rows[0]["sector"] == "Technology"
+        assert rows[0]["analyst_buy"] == 20
+        assert rows[0]["avg_target"] == 225.0
+        assert rows[1]["sector"] == "Software"
+        assert rows[1]["analyst_buy"] == 16
+        assert rows[1]["analyst_hold"] == 5
+        assert rows[1]["analyst_sell"] == 1
+        assert rows[1]["avg_target"] == 470.0
+        assert rows[1]["upside_pct"] == 14.63
+
+    @pytest.mark.asyncio
+    async def test_us_enrichment_fallback_preserves_existing_tvscreener_values(
+        self, monkeypatch
+    ):
+        fetch_enrichment = AsyncMock(
+            return_value={
+                "sector": None,
+                "analyst_buy": 0,
+                "analyst_hold": 0,
+                "analyst_sell": 0,
+                "avg_target": 220.0,
+                "upside_pct": 10.0,
+            }
+        )
+        monkeypatch.setattr(
+            analysis_screen_core,
+            "_fetch_screen_enrichment_us",
+            fetch_enrichment,
+        )
+
+        (
+            rows,
+            warnings,
+        ) = await analysis_screen_core._decorate_screen_rows_with_equity_enrichment(
+            [
+                {
+                    "code": "AAPL",
+                    "market": "us",
+                    "sector": "Technology",
+                    "analyst_buy": 18,
+                    "analyst_hold": 4,
+                    "analyst_sell": 1,
+                    "avg_target": None,
+                    "upside_pct": None,
+                    "close": 200.0,
+                }
+            ]
+        )
+
+        assert warnings == []
+        assert fetch_enrichment.await_count == 1
+        assert rows[0]["sector"] == "Technology"
+        assert rows[0]["analyst_buy"] == 18
+        assert rows[0]["analyst_hold"] == 4
+        assert rows[0]["analyst_sell"] == 1
+        assert rows[0]["avg_target"] == 220.0
+        assert rows[0]["upside_pct"] == 10.0
+
+    @pytest.mark.asyncio
+    async def test_us_category_preserves_acronym_case_for_tvscreener_filter(
+        self, monkeypatch
+    ):
+        captured: dict[str, Any] = {}
+
+        async def mock_screen_us_via_tvscreener(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {
+                "stocks": [
+                    {
+                        "symbol": "AI",
+                        "name": "C3.ai, Inc.",
+                        "price": 30.0,
+                        "change_percent": 1.5,
+                        "volume": 1000.0,
+                        "market_cap": 4_000_000_000.0,
+                        "market": "us",
+                        "sector": "AI",
+                        "analyst_buy": 9,
+                        "analyst_hold": 4,
+                        "analyst_sell": 1,
+                        "avg_target": 36.0,
+                        "upside_pct": 20.0,
+                    }
+                ],
+                "count": 1,
+                "filters_applied": {
+                    "market": "us",
+                    "asset_type": None,
+                    "category": "AI",
+                    "sort_by": "volume",
+                    "sort_order": "desc",
+                },
+                "source": "tvscreener",
+                "error": None,
+            }
+
+        async def fail_legacy_us(**kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("legacy US path should not run for AI category")
+
+        async def fail_enrichment(symbol: str, **kwargs: Any) -> dict[str, Any]:
+            raise AssertionError(
+                f"network enrichment should not run for pre-enriched tvscreener row {symbol}"
+            )
+
+        monkeypatch.setattr(
+            analysis_screen_core,
+            "_screen_us_via_tvscreener",
+            mock_screen_us_via_tvscreener,
+        )
+        monkeypatch.setattr(analysis_screen_core, "_screen_us", fail_legacy_us)
+        monkeypatch.setattr(
+            analysis_screen_core,
+            "_fetch_screen_enrichment_us",
+            fail_enrichment,
+        )
+
+        tools = build_tools()
+        result = await tools["screen_stocks"](
+            market="us",
+            asset_type=None,
+            category="AI",
+            min_market_cap=None,
+            max_per=None,
+            min_dividend_yield=None,
+            max_rsi=None,
+            sort_by="volume",
+            sort_order="desc",
+            limit=1,
+        )
+
+        assert captured["category"] == "AI"
+        assert result["filters_applied"]["category"] == "AI"
+        assert result["filters_applied"]["sector"] == "AI"
+        assert result["results"][0]["sector"] == "AI"
+
+    @pytest.mark.asyncio
+    async def test_us_category_lowercase_technology_canonicalized_for_tvscreener(
+        self, monkeypatch
+    ):
+        captured: dict[str, Any] = {}
+
+        async def mock_screen_us_via_tvscreener(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {
+                "stocks": [
+                    {
+                        "symbol": "AAPL",
+                        "name": "Apple Inc.",
+                        "price": 200.0,
+                        "change_percent": 0.5,
+                        "volume": 50_000.0,
+                        "market_cap": 3_000_000_000_000.0,
+                        "market": "us",
+                        "sector": "Technology",
+                        "analyst_buy": 30,
+                        "analyst_hold": 5,
+                        "analyst_sell": 1,
+                        "avg_target": 250.0,
+                        "upside_pct": 25.0,
+                    }
+                ],
+                "count": 1,
+                "filters_applied": {
+                    "market": "us",
+                    "asset_type": None,
+                    "category": "Technology",
+                    "sort_by": "volume",
+                    "sort_order": "desc",
+                },
+                "source": "tvscreener",
+                "error": None,
+            }
+
+        async def fail_legacy_us(**kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("legacy US path should not run for technology category")
+
+        async def fail_enrichment(symbol: str, **kwargs: Any) -> dict[str, Any]:
+            raise AssertionError(
+                f"network enrichment should not run for pre-enriched tvscreener row {symbol}"
+            )
+
+        monkeypatch.setattr(
+            analysis_screen_core,
+            "_screen_us_via_tvscreener",
+            mock_screen_us_via_tvscreener,
+        )
+        monkeypatch.setattr(analysis_screen_core, "_screen_us", fail_legacy_us)
+        monkeypatch.setattr(
+            analysis_screen_core,
+            "_fetch_screen_enrichment_us",
+            fail_enrichment,
+        )
+
+        tools = build_tools()
+        result = await tools["screen_stocks"](
+            market="us",
+            asset_type=None,
+            category="technology",
+            min_market_cap=None,
+            max_per=None,
+            min_dividend_yield=None,
+            max_rsi=None,
+            sort_by="volume",
+            sort_order="desc",
+            limit=1,
+        )
+
+        assert captured["category"] == "Technology"
+        assert result["filters_applied"]["sector"] == "Technology"
+        assert result["results"][0]["sector"] == "Technology"
+    @pytest.mark.asyncio
     async def test_kr_stock_request_with_max_rsi_still_uses_tvscreener(
         self, monkeypatch
     ):
@@ -1679,7 +2051,9 @@ class TestScreenStocksFundamentalsExpansion:
                 "legacy US path should not run for plain stock requests"
             )
 
-        async def mock_fetch_screen_enrichment_us(symbol: str) -> dict[str, Any]:
+        async def mock_fetch_screen_enrichment_us(
+            symbol: str, **kwargs: Any
+        ) -> dict[str, Any]:
             enriched_symbols.append(symbol)
             return {
                 "sector": "Technology",

--- a/tests/test_tvscreener_stocks.py
+++ b/tests/test_tvscreener_stocks.py
@@ -10,6 +10,7 @@ import pytest
 from app.mcp_server.tooling.analysis_screen_core import (
     _screen_kr_via_tvscreener,
     _screen_us_via_tvscreener,
+    normalize_screen_request,
 )
 
 
@@ -206,6 +207,75 @@ async def test_screen_us_passes_combined_filters_without_bitwise_and(
         fake_tvscreener_module.StockField.AVERAGE_DIRECTIONAL_INDEX_14 >= 25.0,
     ]
     assert result["error"] is None
+
+
+@pytest.mark.asyncio
+async def test_screen_us_queries_and_maps_optional_analyst_fields(
+    fake_tvscreener_module: SimpleNamespace,
+) -> None:
+    fake_tvscreener_module.StockField.SECTOR = _Field("sector")
+    fake_tvscreener_module.StockField.RECOMMENDATION_BUY = _Field("recommendation_buy")
+    fake_tvscreener_module.StockField.RECOMMENDATION_HOLD = _Field(
+        "recommendation_hold"
+    )
+    fake_tvscreener_module.StockField.RECOMMENDATION_SELL = _Field(
+        "recommendation_sell"
+    )
+    fake_tvscreener_module.StockField.PRICE_TARGET_AVERAGE = _Field(
+        "price_target_average"
+    )
+
+    service = AsyncMock()
+    service.query_stock_screener.return_value = pd.DataFrame(
+        {
+            "symbol": ["NASDAQ:AAPL"],
+            "description": ["Apple Inc."],
+            "name": ["AAPL"],
+            "price": [175.5],
+            "relative_strength_index_14": [35.2],
+            "average_directional_index_14": [25.6],
+            "volume": [75_000_000.0],
+            "change_percent": [1.2],
+            "market_capitalization": [2_800_000_000_000.0],
+            "price_to_earnings_ratio_ttm": [28.5],
+            "dividend_yield_forward": [0.005],
+            "sector": ["Technology"],
+            "recommendation_buy": [22],
+            "recommendation_hold": [14],
+            "recommendation_sell": [2],
+            "price_target_average": [205.0],
+            "country": ["United States"],
+        }
+    )
+
+    with (
+        patch(
+            "app.mcp_server.tooling.analysis_screen_core._import_tvscreener",
+            return_value=fake_tvscreener_module,
+        ),
+        patch(
+            "app.mcp_server.tooling.analysis_screen_core.TvScreenerService",
+            return_value=service,
+        ),
+    ):
+        result = await _screen_us_via_tvscreener(category="Technology", limit=5)
+
+    kwargs = service.query_stock_screener.await_args.kwargs
+    assert fake_tvscreener_module.StockField.SECTOR in kwargs["columns"]
+    assert fake_tvscreener_module.StockField.RECOMMENDATION_BUY in kwargs["columns"]
+    assert fake_tvscreener_module.StockField.RECOMMENDATION_HOLD in kwargs["columns"]
+    assert fake_tvscreener_module.StockField.RECOMMENDATION_SELL in kwargs["columns"]
+    assert fake_tvscreener_module.StockField.PRICE_TARGET_AVERAGE in kwargs["columns"]
+    assert kwargs["where_clause"] == [
+        fake_tvscreener_module.StockField.SECTOR == "Technology"
+    ]
+    assert result["error"] is None
+    assert result["stocks"][0]["sector"] == "Technology"
+    assert result["stocks"][0]["analyst_buy"] == 22
+    assert result["stocks"][0]["analyst_hold"] == 14
+    assert result["stocks"][0]["analyst_sell"] == 2
+    assert result["stocks"][0]["avg_target"] == 205.0
+    assert result["stocks"][0]["upside_pct"] == 16.81
 
 
 @pytest.mark.asyncio
@@ -500,3 +570,47 @@ class TestStockScreeningIntegration:
             first = result["stocks"][0]
             assert ":" not in first["symbol"]
             assert first["name"]
+
+
+class TestNormalizeScreenRequestUsSectorCanonicalization:
+    """normalize_screen_request must title-case US sector labels."""
+
+    def test_us_category_lowercase_technology_becomes_title_case(self) -> None:
+        result = normalize_screen_request(
+            market="us",
+            asset_type=None,
+            category="technology",
+            sector=None,
+            strategy=None,
+            sort_by=None,
+            sort_order=None,
+            min_market_cap=None,
+            max_per=None,
+            max_pbr=None,
+            min_dividend_yield=None,
+            min_dividend=None,
+            min_analyst_buy=None,
+            max_rsi=None,
+            limit=10,
+        )
+        assert result["sector"] == "Technology"
+
+    def test_us_category_lowercase_acronym_ai_becomes_uppercase(self) -> None:
+        result = normalize_screen_request(
+            market="us",
+            asset_type=None,
+            category="ai",
+            sector=None,
+            strategy=None,
+            sort_by=None,
+            sort_order=None,
+            min_market_cap=None,
+            max_per=None,
+            max_pbr=None,
+            min_dividend_yield=None,
+            min_dividend=None,
+            min_analyst_buy=None,
+            max_rsi=None,
+            limit=10,
+        )
+        assert result["sector"] == "AI"


### PR DESCRIPTION
## Summary
- keep US stock `screen_stocks` requests on the tvscreener path for sector/category and analyst-target enrichment when TradingView fields are available
- reduce per-row yfinance/Finnhub fan-out by reusing lightweight fallback enrichment only for rows still missing public fields
- add docs and regression coverage for tvscreener mapping, lowercase sector normalization, and enrichment compatibility

## Test Plan
- [x] make test