### PR TITLE
fix: restore alternate US symbol search separators

### DIFF
--- a/app/services/us_symbol_universe_service.py
+++ b/app/services/us_symbol_universe_service.py
@@ -11,8 +11,10 @@ from typing import Any
 import httpx
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
 
 from app.core.db import AsyncSessionLocal
+from app.core.symbol import to_db_symbol
 from app.models.us_symbol_universe import USSymbolUniverse
 
 logger = logging.getLogger(__name__)
@@ -96,7 +98,7 @@ def _parse_cod_rows(lines: list[str], exchange: str) -> tuple[list[_UniverseRow]
             skipped += 1
             continue
 
-        symbol = _normalize_symbol(columns[4])
+        symbol = to_db_symbol(_normalize_symbol(columns[4]))
         if not symbol:
             skipped += 1
             continue
@@ -233,7 +235,7 @@ async def _has_any_rows(db: AsyncSession) -> bool:
 
 
 async def _resolve_active_symbol_row(db: AsyncSession, symbol: str) -> USSymbolUniverse:
-    normalized_symbol = _normalize_symbol(symbol)
+    normalized_symbol = to_db_symbol(_normalize_symbol(symbol))
     if not normalized_symbol:
         raise ValueError("symbol is required")
 
@@ -335,15 +337,26 @@ async def _search_us_symbols_impl(
     if not normalized_query:
         return []
 
-    pattern = f"%{normalized_query}%"
+    raw_symbol_query = _normalize_symbol(query)
+    canonical_symbol_query = to_db_symbol(raw_symbol_query)
+    symbol_predicates: list[ColumnElement[bool]] = []
+    seen_symbol_queries: set[str] = set()
+
+    for symbol_query in (raw_symbol_query, canonical_symbol_query):
+        if symbol_query in seen_symbol_queries:
+            continue
+        seen_symbol_queries.add(symbol_query)
+        symbol_predicates.append(USSymbolUniverse.symbol.ilike(f"%{symbol_query}%"))
+
+    name_pattern = f"%{normalized_query}%"
     stmt = (
         select(USSymbolUniverse)
         .where(
             USSymbolUniverse.is_active.is_(True),
             or_(
-                USSymbolUniverse.symbol.ilike(pattern),
-                USSymbolUniverse.name_kr.ilike(pattern),
-                USSymbolUniverse.name_en.ilike(pattern),
+                *symbol_predicates,
+                USSymbolUniverse.name_kr.ilike(name_pattern),
+                USSymbolUniverse.name_en.ilike(name_pattern),
             ),
         )
         .order_by(USSymbolUniverse.symbol.asc())

--- a/tests/test_us_symbol_universe_sync.py
+++ b/tests/test_us_symbol_universe_sync.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.models.us_symbol_universe import USSymbolUniverse
 from app.services import us_symbol_universe_service
@@ -79,6 +83,45 @@ class _FakeSession:
 
     async def flush(self):
         self.flushed = True
+
+
+class _ScalarOneResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _LookupSession:
+    def __init__(self, rows: dict[str, USSymbolUniverse]):
+        self._rows = rows
+
+    async def execute(self, stmt):
+        wc = getattr(stmt, "whereclause", None)
+        if wc is not None:
+            symbol: str = getattr(wc.right, "value", "")
+            return _ScalarOneResult(self._rows.get(symbol))
+        first = next(iter(self._rows), None)
+        return _ScalarOneResult(first)
+
+
+@asynccontextmanager
+async def _search_session(
+    db_path: Path,
+    rows: list[USSymbolUniverse],
+) -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(USSymbolUniverse.__table__.create)
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as session:
+        session.add_all(rows)
+        await session.commit()
+        yield session
+
+    await engine.dispose()
 
 
 @pytest.mark.asyncio
@@ -238,3 +281,169 @@ async def test_script_main_returns_nonzero_on_exception(monkeypatch):
 
     assert code == 1
     capture_mock.assert_called_once()
+
+
+@pytest.mark.parametrize("raw_symbol", ["BRK/B", "BRK-B"])
+def test_parse_cod_rows_canonicalizes_symbol_separators(raw_symbol):
+    lines = [_cod_line(raw_symbol, "버크셔B", "Berkshire B")]
+    rows, skipped = us_symbol_universe_service._parse_cod_rows(lines, "NYSE")
+    assert len(rows) == 1
+    assert rows[0].symbol == "BRK.B"
+    assert skipped == 0
+
+
+@pytest.mark.asyncio
+async def test_build_snapshot_canonicalizes_symbol_keys(monkeypatch):
+    async def fake_download(zip_name: str) -> list[str]:
+        if zip_name == "nasmst.cod.zip":
+            return [_cod_line("AAPL", "애플", "Apple Inc.")]
+        if zip_name == "nysmst.cod.zip":
+            return [_cod_line("BRK/B", "버크셔B", "Berkshire Hathaway B")]
+        if zip_name == "amsmst.cod.zip":
+            return [_cod_line("SPY", "SPDR", "SPDR S&P 500 ETF")]
+        raise AssertionError(zip_name)
+
+    monkeypatch.setattr(
+        us_symbol_universe_service, "_download_cod_lines", fake_download
+    )
+
+    snapshot = await us_symbol_universe_service.build_us_symbol_universe_snapshot()
+
+    assert "BRK.B" in snapshot
+    assert "BRK/B" not in snapshot
+    assert snapshot["BRK.B"].exchange == "NYSE"
+    assert snapshot["BRK.B"].symbol == "BRK.B"
+
+
+@pytest.mark.asyncio
+async def test_sync_deactivates_legacy_non_canonical_symbol(monkeypatch):
+    snapshot = {
+        "BRK.B": us_symbol_universe_service._UniverseRow(
+            symbol="BRK.B",
+            exchange="NYSE",
+            name_kr="버크셔B",
+            name_en="Berkshire B",
+        ),
+    }
+    monkeypatch.setattr(
+        us_symbol_universe_service,
+        "build_us_symbol_universe_snapshot",
+        AsyncMock(return_value=snapshot),
+    )
+
+    db = _FakeSession(
+        [
+            USSymbolUniverse(
+                symbol="BRK/B",
+                exchange="NYSE",
+                name_kr="버크셔B",
+                name_en="Berkshire B",
+                is_active=True,
+            ),
+        ]
+    )
+
+    result = await us_symbol_universe_service.sync_us_symbol_universe(db=db)
+
+    assert result["inserted"] == 1
+    assert result["deactivated"] == 1
+    assert db.rows["BRK.B"].is_active is True
+    assert db.rows["BRK/B"].is_active is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("input_symbol", ["BRK.B", "BRK/B", "BRK-B"])
+async def test_get_exchange_lookup_accepts_all_symbol_formats(input_symbol):
+    row = USSymbolUniverse(
+        symbol="BRK.B",
+        exchange="NYSE",
+        name_kr="버크셔B",
+        name_en="Berkshire B",
+        is_active=True,
+    )
+    db = _LookupSession({"BRK.B": row})
+
+    exchange = await us_symbol_universe_service.get_us_exchange_by_symbol(
+        input_symbol, db=db
+    )
+    assert exchange == "NYSE"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query", ["BRK.B", "BRK/B", "BRK-B"])
+async def test_search_us_symbols_accepts_all_separator_variants_for_canonical_row(
+    tmp_path: Path,
+    query: str,
+):
+    row = USSymbolUniverse(
+        symbol="BRK.B",
+        exchange="NYSE",
+        name_kr="버크셔B",
+        name_en="Berkshire Hathaway B",
+        is_active=True,
+    )
+
+    async with _search_session(tmp_path / "canonical-search.db", [row]) as db:
+        results = await us_symbol_universe_service.search_us_symbols(
+            query, limit=10, db=db
+        )
+
+    assert results == [
+        {
+            "symbol": "BRK.B",
+            "name": "버크셔B",
+            "instrument_type": "equity_us",
+            "exchange": "NYSE",
+            "is_active": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_search_us_symbols_matches_legacy_separator_row_during_transition(
+    tmp_path: Path,
+):
+    row = USSymbolUniverse(
+        symbol="BRK/B",
+        exchange="NYSE",
+        name_kr="버크셔B",
+        name_en="Berkshire Hathaway B",
+        is_active=True,
+    )
+
+    async with _search_session(tmp_path / "legacy-search.db", [row]) as db:
+        results = await us_symbol_universe_service.search_us_symbols(
+            "BRK/B", limit=10, db=db
+        )
+
+    assert results == [
+        {
+            "symbol": "BRK/B",
+            "name": "버크셔B",
+            "instrument_type": "equity_us",
+            "exchange": "NYSE",
+            "is_active": True,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query", ["버크셔", "Berkshire"])
+async def test_search_us_symbols_keeps_name_search_behavior(
+    tmp_path: Path,
+    query: str,
+):
+    row = USSymbolUniverse(
+        symbol="BRK.B",
+        exchange="NYSE",
+        name_kr="버크셔 해서웨이 B",
+        name_en="Berkshire Hathaway B",
+        is_active=True,
+    )
+
+    async with _search_session(tmp_path / "name-search.db", [row]) as db:
+        results = await us_symbol_universe_service.search_us_symbols(
+            query, limit=10, db=db
+        )
+
+    assert [result["symbol"] for result in results] == ["BRK.B"]


### PR DESCRIPTION
## Summary
- normalize US symbol search queries using both raw and canonical separator variants
- keep direct lookup canonicalization for US symbol universe rows synced to dot notation
- add regression tests for canonical, legacy, and name-based US symbol search behavior

## Test Plan
- [x] make test
- [x] uv run pytest tests/test_us_symbol_universe_sync.py tests/test_symbol_conversion.py tests/test_mcp_quotes_tools.py -q --no-cov

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symbol format handling to ensure consistent lookups and searches across multiple notation styles (e.g., BRK.B, BRK/B).

* **Tests**
  * Added comprehensive test coverage for symbol canonicalization, legacy format transitions, and various search scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->