### PR TITLE
Fix KR daily OHLCV cache freshness for analyze_stock

### DIFF
--- a/app/mcp_server/tooling/analysis_analyze.py
+++ b/app/mcp_server/tooling/analysis_analyze.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 
 import pandas as pd
+import sentry_sdk
 import yfinance as yf
+
+logger = logging.getLogger(__name__)
 
 from app.mcp_server.tooling.fundamentals_sources_finnhub import (
     _fetch_company_profile_finnhub,
@@ -389,9 +393,14 @@ async def analyze_stock_impl(
     market_type, normalized_symbol = _resolve_market_type(symbol, market)
     analysis = _build_analysis_payload(normalized_symbol, market_type)
     loop = asyncio.get_running_loop()
-    ohlcv_df = await _fetch_ohlcv_for_indicators(
-        normalized_symbol, market_type, count=250
-    )
+
+    with sentry_sdk.start_span(
+        op="analyze_stock.ohlcv_fetch",
+        name=f"OHLCV fetch {market_type} {normalized_symbol}",
+    ):
+        ohlcv_df = await _fetch_ohlcv_for_indicators(
+            normalized_symbol, market_type, count=250
+        )
     ohlcv_60d = ohlcv_df.tail(60) if len(ohlcv_df) >= 60 else ohlcv_df
 
     preloaded_quote, named_tasks = _prepare_quote_tasks(
@@ -407,12 +416,21 @@ async def analyze_stock_impl(
         named_tasks, normalized_symbol, market_type, include_peers
     )
 
-    task_results = await _gather_task_results(named_tasks)
-    _apply_common_results(analysis, task_results, preloaded_quote)
-    _apply_market_specific_results(analysis, task_results, market_type)
-    _apply_sector_peers_result(analysis, task_results, market_type, include_peers)
-    analysis["errors"] = []
-    _apply_recommendation(analysis, market_type)
+    with sentry_sdk.start_span(
+        op="analyze_stock.gather_tasks",
+        name=f"gather tasks {market_type} {normalized_symbol}",
+    ):
+        task_results = await _gather_task_results(named_tasks)
+
+    with sentry_sdk.start_span(
+        op="analyze_stock.assemble_response",
+        name=f"assemble response {market_type} {normalized_symbol}",
+    ):
+        _apply_common_results(analysis, task_results, preloaded_quote)
+        _apply_market_specific_results(analysis, task_results, market_type)
+        _apply_sector_peers_result(analysis, task_results, market_type, include_peers)
+        analysis["errors"] = []
+        _apply_recommendation(analysis, market_type)
 
     return analysis
 

--- a/app/mcp_server/tooling/market_data_indicators.py
+++ b/app/mcp_server/tooling/market_data_indicators.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 import app.services.brokers.upbit.client as upbit_service
 import app.services.brokers.yahoo.client as yahoo_service
+import app.services.kis_ohlcv_cache as kis_ohlcv_cache
 from app.mcp_server.tooling.shared import (
     to_float as _to_float,
 )
@@ -91,8 +92,17 @@ async def _fetch_ohlcv_for_indicators(
     if market_type == "equity_kr":
         capped_count = min(count, 250)
         kis = KISClient()
-        return await kis.inquire_daily_itemchartprice(
-            code=symbol, market="UN", n=capped_count, period="D"
+
+        async def _raw_fetch_kr_daily(n: int) -> pd.DataFrame:
+            return await kis.inquire_daily_itemchartprice(
+                code=symbol, market="UN", n=n, period="D"
+            )
+
+        return await kis_ohlcv_cache.get_candles(
+            symbol=symbol,
+            count=capped_count,
+            period="day",
+            raw_fetcher=_raw_fetch_kr_daily,
         )
     capped_count = min(count, 250)
     return await yahoo_service.fetch_ohlcv(
@@ -109,8 +119,17 @@ async def _fetch_ohlcv_for_volume_profile(
         )
     if market_type == "equity_kr":
         kis = KISClient()
-        return await kis.inquire_daily_itemchartprice(
-            code=symbol, market="UN", n=period_days, period="D"
+
+        async def _raw_fetch_kr_daily_vp(n: int) -> pd.DataFrame:
+            return await kis.inquire_daily_itemchartprice(
+                code=symbol, market="UN", n=n, period="D"
+            )
+
+        return await kis_ohlcv_cache.get_candles(
+            symbol=symbol,
+            count=period_days,
+            period="day",
+            raw_fetcher=_raw_fetch_kr_daily_vp,
         )
     return await yahoo_service.fetch_ohlcv(
         ticker=symbol, days=period_days, period="day"

--- a/app/services/kis_ohlcv_cache.py
+++ b/app/services/kis_ohlcv_cache.py
@@ -3,17 +3,21 @@ import json
 import logging
 import uuid
 from collections.abc import Awaitable, Callable
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime, time, timedelta
+from functools import lru_cache
 
+import exchange_calendars as xcals
 import pandas as pd
 import redis.asyncio as redis
 
 from app.core.config import settings
+from app.core.timezone import KST, now_kst
 
 logger = logging.getLogger(__name__)
 
 _SUPPORTED_PERIODS = {"day", "1h"}
 _DAY_COLUMNS = ["date", "open", "high", "low", "close", "volume", "value"]
+_KRX_DAILY_CACHE_CUTOFF = time(15, 35)
 _HOURLY_COLUMNS = [
     "datetime",
     "date",
@@ -81,6 +85,37 @@ def _coerce_datetime(value: object) -> pd.Timestamp | None:
     return parsed
 
 
+def _coerce_kst_datetime(now: datetime | None = None) -> datetime:
+    current = now or now_kst()
+    if current.tzinfo is None:
+        return current.replace(tzinfo=KST)
+    return current.astimezone(KST)
+
+
+@lru_cache(maxsize=1)
+def _get_xkrx_calendar():
+    return xcals.get_calendar("XKRX")
+
+
+def _is_session_day_kst(target_day: date) -> bool:
+    calendar = _get_xkrx_calendar()
+    return bool(calendar.is_session(pd.Timestamp(target_day)))
+
+
+def _latest_session_day_on_or_before(target_day: date) -> date | None:
+    calendar = _get_xkrx_calendar()
+    start = pd.Timestamp(target_day - timedelta(days=30))
+    end = pd.Timestamp(target_day)
+    sessions = calendar.sessions_in_range(start, end)
+    if len(sessions) == 0:
+        return None
+    return pd.Timestamp(sessions[-1]).date()
+
+
+def _latest_session_day_before(target_day: date) -> date | None:
+    return _latest_session_day_on_or_before(target_day - timedelta(days=1))
+
+
 def _canonicalize_frame(period: str, frame: pd.DataFrame) -> pd.DataFrame:
     if frame.empty:
         return _empty_dataframe(period)
@@ -128,15 +163,33 @@ def _is_cache_fresh(
     if frame.empty:
         return False
 
-    current = pd.Timestamp(now or datetime.now())
-    if pd.isna(current):
-        return False
-
     if period == "day":
+        current_kst = _coerce_kst_datetime(now)
         latest = pd.to_datetime(frame.get("date"), errors="coerce").max()
         if pd.isna(latest):
             return False
-        return latest.date() >= current.date()
+        latest_date = latest.date()
+        current_date = current_kst.date()
+        if latest_date > current_date:
+            return True
+
+        current_time = current_kst.time()
+        is_session_day = _is_session_day_kst(current_date)
+        if not is_session_day:
+            return latest_date == _latest_session_day_on_or_before(current_date)
+
+        if current_time < time(9, 0):
+            previous_session_day = _latest_session_day_before(current_date)
+            return latest_date == current_date or latest_date == previous_session_day
+
+        if current_time < _KRX_DAILY_CACHE_CUTOFF:
+            return False
+
+        return latest_date == current_date
+
+    current = pd.Timestamp(now or datetime.now())
+    if pd.isna(current):
+        return False
 
     latest = pd.to_datetime(frame.get("datetime"), errors="coerce").max()
     if pd.isna(latest):

--- a/tests/test_kis_ohlcv_cache.py
+++ b/tests/test_kis_ohlcv_cache.py
@@ -1,16 +1,18 @@
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
+from typing import Any, cast
 from unittest.mock import AsyncMock
 
 import pandas as pd
 import pytest
 
+from app.core.timezone import KST
 from app.services import kis_ohlcv_cache
 
 
 class _FakePipeline:
     def __init__(self, redis_client):
         self.redis_client = redis_client
-        self.commands: list[tuple[str, tuple, dict]] = []
+        self.commands: list[tuple[str, tuple[Any, ...], dict[str, Any]]] = []
 
     def zremrangebyrank(self, *args, **kwargs):
         self.commands.append(("zremrangebyrank", args, kwargs))
@@ -142,6 +144,11 @@ def _build_daily_frame(rows: int = 2) -> pd.DataFrame:
     base_date = datetime.now().date()
     dates = [base_date - timedelta(days=idx) for idx in range(rows)]
     dates.sort()
+    return _build_daily_frame_for_dates(dates)
+
+
+def _build_daily_frame_for_dates(dates: list[date]) -> pd.DataFrame:
+    rows = len(dates)
     return pd.DataFrame(
         {
             "date": dates,
@@ -155,39 +162,52 @@ def _build_daily_frame(rows: int = 2) -> pd.DataFrame:
     )
 
 
+def _kst_datetime(year: int, month: int, day: int, hour: int, minute: int) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=KST)
+
+
 @pytest.fixture(autouse=True)
 def _reset_cache_state():
     kis_ohlcv_cache._REDIS_CLIENT = None
     kis_ohlcv_cache._FALLBACK_COUNT = 0
 
 
-def test_keys_include_route_segment_for_same_symbol_period():
-    default_keys = kis_ohlcv_cache._keys("005930", "1h")
-    routed_keys = kis_ohlcv_cache._keys("005930", "1h", "j")
+@pytest.mark.parametrize(
+    ("latest_date", "now", "expected"),
+    [
+        (datetime(2026, 3, 13).date(), _kst_datetime(2026, 3, 13, 15, 0), False),
+        (datetime(2026, 3, 13).date(), _kst_datetime(2026, 3, 13, 8, 59), True),
+        (datetime(2026, 3, 13).date(), _kst_datetime(2026, 3, 13, 15, 35), True),
+        (datetime(2026, 3, 12).date(), _kst_datetime(2026, 3, 13, 15, 0), False),
+        (datetime(2026, 3, 12).date(), _kst_datetime(2026, 3, 13, 8, 59), True),
+        (datetime(2026, 3, 11).date(), _kst_datetime(2026, 3, 13, 8, 59), False),
+        (datetime(2026, 3, 12).date(), _kst_datetime(2026, 3, 13, 15, 35), False),
+        (datetime(2026, 3, 13).date(), _kst_datetime(2026, 3, 14, 12, 0), True),
+        (datetime(2026, 3, 12).date(), _kst_datetime(2026, 3, 14, 12, 0), False),
+        (datetime(2026, 3, 14).date(), _kst_datetime(2026, 3, 13, 15, 0), True),
+    ],
+)
+def test_is_cache_fresh_for_day_respects_xkrx_session_policy(
+    latest_date, now: datetime, expected: bool
+):
+    frame = _build_daily_frame_for_dates([latest_date])
 
-    assert default_keys != routed_keys
-    assert ":J:" in routed_keys[0]
+    assert kis_ohlcv_cache._is_cache_fresh("day", frame, now=now) is expected
 
 
-@pytest.mark.asyncio
-async def test_get_candles_returns_cached_when_sufficient(monkeypatch):
-    fake_redis = _FakeRedis()
-    symbol = "005930"
-    dates_key, rows_key, _, _ = kis_ohlcv_cache._keys(symbol, "day")
+def test_is_session_day_kst_uses_xkrx_calendar() -> None:
+    assert kis_ohlcv_cache._is_session_day_kst(date(2026, 1, 1)) is False
+    assert kis_ohlcv_cache._is_session_day_kst(date(2026, 1, 2)) is True
 
-    await kis_ohlcv_cache._upsert_rows(
-        fake_redis,
-        dates_key,
-        rows_key,
-        _build_daily_frame(2),
-        "day",
-    )
 
+def _configure_cache_runtime(
+    monkeypatch, fake_redis: _FakeRedis, now: datetime
+) -> None:
     async def mock_get_redis_client():
         return fake_redis
 
-    raw_fetcher = AsyncMock(return_value=_build_daily_frame(2))
     monkeypatch.setattr(kis_ohlcv_cache, "_get_redis_client", mock_get_redis_client)
+    monkeypatch.setattr(kis_ohlcv_cache, "now_kst", lambda: now)
     monkeypatch.setattr(
         kis_ohlcv_cache.settings,
         "kis_ohlcv_cache_enabled",
@@ -206,6 +226,36 @@ async def test_get_candles_returns_cached_when_sufficient(monkeypatch):
         10,
         raising=False,
     )
+
+
+def test_keys_include_route_segment_for_same_symbol_period():
+    default_keys = kis_ohlcv_cache._keys("005930", "1h")
+    routed_keys = kis_ohlcv_cache._keys("005930", "1h", "j")
+
+    assert default_keys != routed_keys
+    assert ":J:" in routed_keys[0]
+
+
+@pytest.mark.asyncio
+async def test_get_candles_returns_cached_when_sufficient(monkeypatch):
+    fake_redis = _FakeRedis()
+    symbol = "005930"
+    dates_key, rows_key, _, _ = kis_ohlcv_cache._keys(symbol, "day")
+    now = _kst_datetime(2026, 3, 13, 15, 35)
+    cached = _build_daily_frame_for_dates(
+        [datetime(2026, 3, 12).date(), datetime(2026, 3, 13).date()]
+    )
+
+    await kis_ohlcv_cache._upsert_rows(
+        cast(Any, fake_redis),
+        dates_key,
+        rows_key,
+        cached,
+        "day",
+    )
+
+    raw_fetcher = AsyncMock(return_value=_build_daily_frame_for_dates([now.date()]))
+    _configure_cache_runtime(monkeypatch, fake_redis, now)
 
     result = await kis_ohlcv_cache.get_candles(
         symbol=symbol,
@@ -223,43 +273,25 @@ async def test_get_candles_refreshes_when_cached_rows_are_stale(monkeypatch):
     fake_redis = _FakeRedis()
     symbol = "005930"
     dates_key, rows_key, _, _ = kis_ohlcv_cache._keys(symbol, "day")
+    now = _kst_datetime(2026, 3, 13, 15, 0)
 
-    stale = _build_daily_frame(2).assign(
-        date=[datetime(2020, 1, 1).date(), datetime(2020, 1, 2).date()]
-    )
+    stale = _build_daily_frame_for_dates(
+        [datetime(2026, 3, 12).date(), datetime(2026, 3, 13).date()]
+    ).assign(close=[100.5, 101.5])
     await kis_ohlcv_cache._upsert_rows(
-        fake_redis,
+        cast(Any, fake_redis),
         dates_key,
         rows_key,
         stale,
         "day",
     )
 
-    fresh = _build_daily_frame(2)
+    fresh = _build_daily_frame_for_dates(
+        [datetime(2026, 3, 12).date(), datetime(2026, 3, 13).date()]
+    ).assign(close=[200.5, 201.5])
     raw_fetcher = AsyncMock(return_value=fresh)
 
-    async def mock_get_redis_client():
-        return fake_redis
-
-    monkeypatch.setattr(kis_ohlcv_cache, "_get_redis_client", mock_get_redis_client)
-    monkeypatch.setattr(
-        kis_ohlcv_cache.settings,
-        "kis_ohlcv_cache_enabled",
-        True,
-        raising=False,
-    )
-    monkeypatch.setattr(
-        kis_ohlcv_cache.settings,
-        "kis_ohlcv_cache_max_days",
-        400,
-        raising=False,
-    )
-    monkeypatch.setattr(
-        kis_ohlcv_cache.settings,
-        "kis_ohlcv_cache_lock_ttl_seconds",
-        10,
-        raising=False,
-    )
+    _configure_cache_runtime(monkeypatch, fake_redis, now)
 
     result = await kis_ohlcv_cache.get_candles(
         symbol=symbol,
@@ -271,6 +303,174 @@ async def test_get_candles_refreshes_when_cached_rows_are_stale(monkeypatch):
     raw_fetcher.assert_awaited_once_with(2)
     assert len(result) == 2
     assert result["date"].max() == fresh["date"].max()
+    assert result.iloc[-1]["close"] == 201.5
+
+
+@pytest.mark.asyncio
+async def test_get_candles_refreshes_intraday_when_only_yesterday_is_cached(
+    monkeypatch,
+):
+    fake_redis = _FakeRedis()
+    symbol = "005930"
+    dates_key, rows_key, _, _ = kis_ohlcv_cache._keys(symbol, "day")
+    now = _kst_datetime(2026, 3, 13, 15, 0)
+
+    await kis_ohlcv_cache._upsert_rows(
+        cast(Any, fake_redis),
+        dates_key,
+        rows_key,
+        _build_daily_frame_for_dates([datetime(2026, 3, 12).date()]),
+        "day",
+    )
+
+    fresh = _build_daily_frame_for_dates(
+        [datetime(2026, 3, 12).date(), datetime(2026, 3, 13).date()]
+    )
+    raw_fetcher = AsyncMock(return_value=fresh)
+
+    _configure_cache_runtime(monkeypatch, fake_redis, now)
+
+    result = await kis_ohlcv_cache.get_candles(
+        symbol=symbol,
+        count=1,
+        period="day",
+        raw_fetcher=raw_fetcher,
+    )
+
+    raw_fetcher.assert_awaited_once_with(1)
+    assert result.iloc[-1]["date"] == datetime(2026, 3, 13).date()
+
+
+@pytest.mark.asyncio
+async def test_get_candles_reuses_yesterday_before_open(monkeypatch):
+    fake_redis = _FakeRedis()
+    symbol = "005930"
+    dates_key, rows_key, _, _ = kis_ohlcv_cache._keys(symbol, "day")
+    now = _kst_datetime(2026, 3, 13, 8, 59)
+
+    cached = _build_daily_frame_for_dates([datetime(2026, 3, 12).date()])
+    await kis_ohlcv_cache._upsert_rows(
+        cast(Any, fake_redis),
+        dates_key,
+        rows_key,
+        cached,
+        "day",
+    )
+
+    raw_fetcher = AsyncMock(
+        return_value=_build_daily_frame_for_dates([datetime(2026, 3, 13).date()])
+    )
+
+    _configure_cache_runtime(monkeypatch, fake_redis, now)
+
+    result = await kis_ohlcv_cache.get_candles(
+        symbol=symbol,
+        count=1,
+        period="day",
+        raw_fetcher=raw_fetcher,
+    )
+
+    raw_fetcher.assert_not_awaited()
+    assert result.iloc[-1]["date"] == datetime(2026, 3, 12).date()
+
+
+@pytest.mark.asyncio
+async def test_get_candles_refreshes_before_open_when_previous_session_missing(
+    monkeypatch,
+):
+    fake_redis = _FakeRedis()
+    symbol = "005930"
+    dates_key, rows_key, _, _ = kis_ohlcv_cache._keys(symbol, "day")
+    now = _kst_datetime(2026, 3, 13, 8, 59)
+
+    cached = _build_daily_frame_for_dates([datetime(2026, 3, 11).date()])
+    await kis_ohlcv_cache._upsert_rows(
+        cast(Any, fake_redis),
+        dates_key,
+        rows_key,
+        cached,
+        "day",
+    )
+
+    fresh = _build_daily_frame_for_dates([datetime(2026, 3, 12).date()])
+    raw_fetcher = AsyncMock(return_value=fresh)
+
+    _configure_cache_runtime(monkeypatch, fake_redis, now)
+
+    result = await kis_ohlcv_cache.get_candles(
+        symbol=symbol,
+        count=1,
+        period="day",
+        raw_fetcher=raw_fetcher,
+    )
+
+    raw_fetcher.assert_awaited_once_with(1)
+    assert result.iloc[-1]["date"] == datetime(2026, 3, 12).date()
+
+
+@pytest.mark.asyncio
+async def test_get_candles_reuses_today_after_cutoff(monkeypatch):
+    fake_redis = _FakeRedis()
+    symbol = "005930"
+    dates_key, rows_key, _, _ = kis_ohlcv_cache._keys(symbol, "day")
+    now = _kst_datetime(2026, 3, 13, 15, 35)
+
+    cached = _build_daily_frame_for_dates([datetime(2026, 3, 13).date()])
+    await kis_ohlcv_cache._upsert_rows(
+        cast(Any, fake_redis),
+        dates_key,
+        rows_key,
+        cached,
+        "day",
+    )
+
+    raw_fetcher = AsyncMock(
+        return_value=_build_daily_frame_for_dates([datetime(2026, 3, 14).date()])
+    )
+
+    _configure_cache_runtime(monkeypatch, fake_redis, now)
+
+    result = await kis_ohlcv_cache.get_candles(
+        symbol=symbol,
+        count=1,
+        period="day",
+        raw_fetcher=raw_fetcher,
+    )
+
+    raw_fetcher.assert_not_awaited()
+    assert result.iloc[-1]["date"] == datetime(2026, 3, 13).date()
+
+
+@pytest.mark.asyncio
+async def test_get_candles_refreshes_after_cutoff_when_today_row_missing(monkeypatch):
+    fake_redis = _FakeRedis()
+    symbol = "005930"
+    dates_key, rows_key, _, _ = kis_ohlcv_cache._keys(symbol, "day")
+    now = _kst_datetime(2026, 3, 13, 15, 35)
+
+    cached = _build_daily_frame_for_dates([datetime(2026, 3, 12).date()])
+    await kis_ohlcv_cache._upsert_rows(
+        cast(Any, fake_redis),
+        dates_key,
+        rows_key,
+        cached,
+        "day",
+    )
+
+    fresh = _build_daily_frame_for_dates([datetime(2026, 3, 13).date()])
+    raw_fetcher = AsyncMock(return_value=fresh)
+
+    _configure_cache_runtime(monkeypatch, fake_redis, now)
+
+    result = await kis_ohlcv_cache.get_candles(
+        symbol=symbol,
+        count=1,
+        period="day",
+        raw_fetcher=raw_fetcher,
+    )
+
+    raw_fetcher.assert_awaited_once_with(1)
+    assert result.iloc[-1]["date"] == datetime(2026, 3, 13).date()
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_indicator_tools.py
+++ b/tests/test_mcp_indicator_tools.py
@@ -343,6 +343,7 @@ async def test_fetch_ohlcv_for_indicators_crypto_uses_upbit_service_boundary(
 async def test_fetch_ohlcv_for_indicators_kr_uses_un_market(monkeypatch):
     service_df = _single_row_df()
     called: dict[str, object] = {}
+    cache_called: dict[str, object] = {}
 
     class DummyKISClient:
         async def inquire_daily_itemchartprice(self, code, market, n, period):
@@ -352,13 +353,25 @@ async def test_fetch_ohlcv_for_indicators_kr_uses_un_market(monkeypatch):
             called["period"] = period
             return service_df
 
+    async def mock_get_candles(symbol, count, period, raw_fetcher, route=None):
+        cache_called["symbol"] = symbol
+        cache_called["count"] = count
+        cache_called["period"] = period
+        return await raw_fetcher(count)
+
     monkeypatch.setattr(market_data_indicators, "KISClient", DummyKISClient)
+    monkeypatch.setattr(
+        market_data_indicators.kis_ohlcv_cache, "get_candles", mock_get_candles
+    )
 
     result = await market_data_indicators._fetch_ohlcv_for_indicators(
         "005930", "equity_kr", count=300
     )
 
     assert len(result) == 1
+    assert cache_called["symbol"] == "005930"
+    assert cache_called["count"] == 250
+    assert cache_called["period"] == "day"
     assert called["code"] == "005930"
     assert called["market"] == "UN"
     assert called["n"] == 250
@@ -369,6 +382,7 @@ async def test_fetch_ohlcv_for_indicators_kr_uses_un_market(monkeypatch):
 async def test_fetch_ohlcv_for_volume_profile_kr_uses_un_market(monkeypatch):
     service_df = _single_row_df()
     called: dict[str, object] = {}
+    cache_called: dict[str, object] = {}
 
     class DummyKISClient:
         async def inquire_daily_itemchartprice(self, code, market, n, period):
@@ -378,13 +392,25 @@ async def test_fetch_ohlcv_for_volume_profile_kr_uses_un_market(monkeypatch):
             called["period"] = period
             return service_df
 
+    async def mock_get_candles(symbol, count, period, raw_fetcher, route=None):
+        cache_called["symbol"] = symbol
+        cache_called["count"] = count
+        cache_called["period"] = period
+        return await raw_fetcher(count)
+
     monkeypatch.setattr(market_data_indicators, "KISClient", DummyKISClient)
+    monkeypatch.setattr(
+        market_data_indicators.kis_ohlcv_cache, "get_candles", mock_get_candles
+    )
 
     result = await market_data_indicators._fetch_ohlcv_for_volume_profile(
         "005930", "equity_kr", period_days=60
     )
 
     assert len(result) == 1
+    assert cache_called["symbol"] == "005930"
+    assert cache_called["count"] == 60
+    assert cache_called["period"] == "day"
     assert called["code"] == "005930"
     assert called["market"] == "UN"
     assert called["n"] == 60
@@ -670,3 +696,105 @@ async def test_get_support_resistance_uses_single_ohlcv_fetch(monkeypatch):
     assert len(fetch_calls) == 1
     assert fetch_calls[0][0] == "AAPL"
     assert result["symbol"] == "AAPL"
+
+
+# ---------------------------------------------------------------------------
+# KR OHLCV cache integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_ohlcv_for_indicators_kr_warm_cache_avoids_kis_call(monkeypatch):
+    """When cache returns data, KIS raw fetcher should NOT be called."""
+    service_df = _single_row_df()
+    kis_called = False
+
+    class DummyKISClient:
+        async def inquire_daily_itemchartprice(self, **kwargs):
+            nonlocal kis_called
+            kis_called = True
+            return service_df
+
+    async def mock_get_candles_warm(symbol, count, period, raw_fetcher, route=None):
+        return service_df
+
+    monkeypatch.setattr(market_data_indicators, "KISClient", DummyKISClient)
+    monkeypatch.setattr(
+        market_data_indicators.kis_ohlcv_cache, "get_candles", mock_get_candles_warm
+    )
+
+    result = await market_data_indicators._fetch_ohlcv_for_indicators(
+        "005930", "equity_kr", count=250
+    )
+
+    assert len(result) == 1
+    assert not kis_called, "KIS should not be called when cache is warm"
+
+
+@pytest.mark.asyncio
+async def test_fetch_ohlcv_for_indicators_crypto_unaffected_by_cache(monkeypatch):
+    """Crypto path should NOT use kis_ohlcv_cache at all."""
+    cache_called = False
+
+    async def mock_get_candles(**kwargs):
+        nonlocal cache_called
+        cache_called = True
+        return pd.DataFrame()
+
+    monkeypatch.setattr(
+        market_data_indicators.kis_ohlcv_cache, "get_candles", mock_get_candles
+    )
+
+    rows = 50
+    dates = pd.date_range("2024-01-01", periods=rows, freq="D")
+
+    async def mock_upbit_fetch(market, days, period, end_date=None):
+        return pd.DataFrame(
+            {
+                "date": dates[:days],
+                "open": [100.0] * min(days, rows),
+                "high": [110.0] * min(days, rows),
+                "low": [90.0] * min(days, rows),
+                "close": [105.0] * min(days, rows),
+                "volume": [1000] * min(days, rows),
+            }
+        )
+
+    monkeypatch.setattr(upbit_service, "fetch_ohlcv", mock_upbit_fetch)
+
+    result = await market_data_indicators._fetch_ohlcv_for_indicators(
+        "KRW-BTC", "crypto", count=50
+    )
+
+    assert not cache_called, "Crypto path should not use kis_ohlcv_cache"
+    assert len(result) == rows
+
+
+@pytest.mark.asyncio
+async def test_fetch_ohlcv_for_volume_profile_kr_warm_cache_avoids_kis_call(
+    monkeypatch,
+):
+    """Volume profile warm cache path should NOT call KIS."""
+    service_df = _single_row_df()
+    kis_called = False
+
+    class DummyKISClient:
+        async def inquire_daily_itemchartprice(self, **kwargs):
+            nonlocal kis_called
+            kis_called = True
+            return service_df
+
+    async def mock_get_candles(symbol, count, period, raw_fetcher, route=None):
+        return service_df
+
+    monkeypatch.setattr(market_data_indicators, "KISClient", DummyKISClient)
+    monkeypatch.setattr(
+        market_data_indicators.kis_ohlcv_cache, "get_candles", mock_get_candles
+    )
+
+    result = await market_data_indicators._fetch_ohlcv_for_volume_profile(
+        "005930", "equity_kr", period_days=60
+    )
+
+    assert len(result) == 1
+    assert not kis_called, "KIS should not be called when cache is warm"


### PR DESCRIPTION
## Summary
- fix KR daily OHLCV cache freshness to respect XKRX session state, pre-open behavior, intraday invalidation, and post-close cutoff
- add regression coverage for same-day, previous-day, pre-open, post-cutoff, and holiday cache behavior
- add Sentry spans around analyze_stock OHLCV fetch, task gathering, and response assembly

## Test Plan
- [x] uv run pytest tests/test_kis_ohlcv_cache.py -q
- [x] uv run pytest tests/test_mcp_indicator_tools.py -q
- [x] uv run pytest tests/test_mcp_fundamentals_tools.py -q -k 'analyze_stock_kr_reuses_preloaded_ohlcv_and_bundled_naver or analyze_stock_kr_falls_back_to_quote_helper_when_ohlcv_empty'
