### PR TITLE
fix: preserve MCP tool args in sentry issues

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -15,6 +15,12 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - `service:auto-trader-api op:http.client span.description:"GET /v1/finance/screener"`
 - `profile` flamegraph and `trace` spans are different datasets, so some frames may appear only in profiling.
 - It is normal to see only high-level spans when a tool does not execute DB/HTTP operations.
+- MCP tool call arguments are attached as structured Sentry context (`mcp_tool_call`) via `McpToolCallSentryMiddleware`:
+  - Context fields: `tool_name` (string), `arguments` (dict, sanitized and truncated)
+  - Tag: `mcp.tool.name` for issue-level filtering
+  - Sensitive values (`token`, `secret`, `password`, `authorization`, `cookie`) are masked to `[Filtered]`
+  - Large arguments are truncated (strings: 1024 chars, lists/dicts: 25 items) with a visible `[truncated]` marker
+  - The middleware never calls `capture_exception` directly; exception capture is handled by Sentry's `MCPIntegration`
 
 ## Tools
 - `search_symbol(query, limit=20)`

--- a/app/mcp_server/main.py
+++ b/app/mcp_server/main.py
@@ -28,6 +28,7 @@ init_sentry(
 from fastmcp import FastMCP  # noqa: E402
 
 from app.mcp_server.auth import build_auth_provider  # noqa: E402
+from app.mcp_server.sentry_middleware import McpToolCallSentryMiddleware  # noqa: E402
 from app.mcp_server.tooling import register_all_tools  # noqa: E402
 
 _auth_token = _env("MCP_AUTH_TOKEN", "")
@@ -42,6 +43,7 @@ mcp = FastMCP(
     auth=auth_provider,
 )
 
+mcp.add_middleware(McpToolCallSentryMiddleware())
 register_all_tools(mcp)
 
 

--- a/app/mcp_server/sentry_middleware.py
+++ b/app/mcp_server/sentry_middleware.py
@@ -1,0 +1,45 @@
+"""Sentry scope enrichment middleware for MCP tool calls."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import sentry_sdk
+
+from app.monitoring.sentry import enrich_mcp_tool_call_scope, get_mcp_http_scopes
+
+if TYPE_CHECKING:
+    import mcp.types as mt
+    from fastmcp.server.middleware import CallNext, MiddlewareContext
+    from fastmcp.tools.tool import ToolResult
+
+from fastmcp.server.middleware import Middleware
+
+
+class McpToolCallSentryMiddleware(Middleware):
+    """Set ``mcp.tool.name`` tag and ``mcp_tool_call`` structured context
+    on the current Sentry scope for every ``tools/call`` request.
+
+    The middleware **never** calls ``capture_exception`` itself — the
+    existing ``sentry-sdk`` ``MCPIntegration`` captures within the same
+    scope, so the enriched context is automatically attached to the event.
+    """
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        tool_name: str = context.message.name
+        arguments: dict[str, Any] = context.message.arguments or {}
+
+        http_scopes = get_mcp_http_scopes()
+        if http_scopes is not None:
+            isolation_scope, _ = http_scopes
+            if isolation_scope is not None:
+                enrich_mcp_tool_call_scope(isolation_scope, tool_name, arguments)
+                return await call_next(context)
+
+        with sentry_sdk.isolation_scope() as isolation_scope:
+            enrich_mcp_tool_call_scope(isolation_scope, tool_name, arguments)
+            return await call_next(context)

--- a/app/monitoring/sentry.py
+++ b/app/monitoring/sentry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 import os
 from typing import Any
@@ -16,6 +17,11 @@ try:
     from sentry_sdk.integrations.mcp import MCPIntegration
 except ImportError:  # pragma: no cover - dependent on sentry-sdk version
     MCPIntegration = None
+
+try:
+    from mcp.server.lowlevel.server import request_ctx as _mcp_request_ctx
+except ImportError:  # pragma: no cover - dependent on MCP SDK availability
+    _mcp_request_ctx = None
 
 from app.core.config import settings
 
@@ -296,6 +302,107 @@ def init_sentry(
     except Exception:
         logger.exception("Failed to initialize Sentry for service=%s", service_name)
         return False
+
+
+_MAX_STRING_LENGTH = 1024
+_MAX_SEQUENCE_LENGTH = 25
+_MAX_DICT_KEYS = 25
+_TRUNCATED_MARKER = "...[truncated]"
+
+
+def _truncate_for_sentry(value: Any) -> Any:
+    """Truncate oversized values for Sentry structured context.
+
+    Limits:
+        * Strings – first 1 024 characters.
+        * Lists / tuples – first 25 elements.
+        * Dicts – first 25 keys.
+
+    A visible marker is appended whenever a value is truncated.
+    The function is pure – the original *value* is never mutated.
+    """
+    if isinstance(value, str):
+        if len(value) > _MAX_STRING_LENGTH:
+            return value[:_MAX_STRING_LENGTH] + _TRUNCATED_MARKER
+        return value
+
+    if isinstance(value, dict):
+        keys = list(value.keys())
+        if len(keys) > _MAX_DICT_KEYS:
+            result = {k: _truncate_for_sentry(value[k]) for k in keys[:_MAX_DICT_KEYS]}
+            result[_TRUNCATED_MARKER] = f"{len(keys) - _MAX_DICT_KEYS} more keys"
+            return result
+        return {k: _truncate_for_sentry(v) for k, v in value.items()}
+
+    if isinstance(value, (list, tuple)):
+        is_tuple = isinstance(value, tuple)
+        if len(value) > _MAX_SEQUENCE_LENGTH:
+            items: list[Any] = [
+                _truncate_for_sentry(item) for item in value[:_MAX_SEQUENCE_LENGTH]
+            ]
+            items.append(
+                f"...[truncated: {len(value) - _MAX_SEQUENCE_LENGTH} more items]"
+            )
+            return tuple(items) if is_tuple else items
+        items = [_truncate_for_sentry(item) for item in value]
+        return tuple(items) if is_tuple else items
+
+    return value
+
+
+def build_mcp_tool_call_context(
+    tool_name: str, arguments: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Build a sanitized, truncated structured context for an MCP tool call.
+
+    Reuses the project-wide sensitive-key filter and applies size limits
+    so the payload stays within Sentry's recommended context size.
+
+    Returns a dict with exactly two keys: ``tool_name`` and ``arguments``.
+    """
+    safe_args = _truncate_for_sentry(_sanitize_in_place(copy.deepcopy(arguments or {})))
+    return {
+        "tool_name": tool_name,
+        "arguments": safe_args,
+    }
+
+
+def get_mcp_http_scopes() -> (
+    tuple[sentry_sdk.Scope | None, sentry_sdk.Scope | None] | None
+):
+    if _mcp_request_ctx is None:
+        return None
+
+    try:
+        ctx = _mcp_request_ctx.get()
+    except LookupError:
+        return None
+
+    if ctx is None or not hasattr(ctx, "request") or ctx.request is None:
+        return None
+
+    request_scope = getattr(ctx.request, "scope", None)
+    if not isinstance(request_scope, dict) or request_scope.get("type") != "http":
+        return None
+
+    state = request_scope.get("state")
+    if not isinstance(state, dict):
+        return None
+
+    return (
+        state.get("sentry_sdk.isolation_scope"),
+        state.get("sentry_sdk.current_scope"),
+    )
+
+
+def enrich_mcp_tool_call_scope(
+    scope: sentry_sdk.Scope, tool_name: str, arguments: dict[str, Any] | None
+) -> None:
+    scope.set_tag("mcp.tool.name", tool_name)
+    scope.set_context(
+        "mcp_tool_call",
+        build_mcp_tool_call_context(tool_name, arguments),
+    )
 
 
 def capture_exception(exc: BaseException, **context: Any) -> None:

--- a/tests/test_mcp_sentry_middleware.py
+++ b/tests/test_mcp_sentry_middleware.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import copy
+from contextvars import ContextVar
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+import sentry_sdk
+import sentry_sdk.scope as sentry_scope
+
+import app.monitoring.sentry as sentry_module
+from app.monitoring.sentry import (
+    _truncate_for_sentry,
+    build_mcp_tool_call_context,
+)
+
+
+@pytest.mark.unit
+class TestTruncateForSentry:
+    def test_short_string_unchanged(self):
+        assert _truncate_for_sentry("hello") == "hello"
+
+    def test_long_string_truncated(self):
+        long = "a" * 2000
+        result = _truncate_for_sentry(long)
+        assert result.startswith("a" * 1024)
+        assert result.endswith("...[truncated]")
+        assert len(result) == 1024 + len("...[truncated]")
+
+    def test_small_list_unchanged(self):
+        items = list(range(10))
+        assert _truncate_for_sentry(items) == items
+
+    def test_large_list_truncated(self):
+        items = list(range(50))
+        result = _truncate_for_sentry(items)
+        assert len(result) == 26
+        assert result[:25] == list(range(25))
+        assert "truncated" in str(result[-1])
+        assert "25 more" in str(result[-1])
+
+    def test_large_tuple_truncated_keeps_type(self):
+        items = tuple(range(50))
+        result = _truncate_for_sentry(items)
+        assert isinstance(result, tuple)
+        assert len(result) == 26
+
+    def test_small_dict_unchanged(self):
+        d = {f"k{i}": i for i in range(5)}
+        assert _truncate_for_sentry(d) == d
+
+    def test_large_dict_truncated(self):
+        d = {f"k{i}": i for i in range(50)}
+        result = _truncate_for_sentry(d)
+        assert len(result) == 26
+        assert "...[truncated]" in result
+        assert "25 more keys" in str(result["...[truncated]"])
+
+    def test_nested_truncation(self):
+        d: dict[str, Any] = {"data": "a" * 2000, "items": list(range(50))}
+        result = _truncate_for_sentry(d)
+        assert result["data"].endswith("...[truncated]")
+        assert len(result["items"]) == 26
+
+    def test_non_container_passthrough(self):
+        assert _truncate_for_sentry(42) == 42
+        assert _truncate_for_sentry(3.14) == 3.14
+        assert _truncate_for_sentry(None) is None
+        assert _truncate_for_sentry(True) is True
+
+    def test_does_not_mutate_original(self):
+        original = {"data": "x" * 2000}
+        _truncate_for_sentry(original)
+        assert len(original["data"]) == 2000
+
+
+@pytest.mark.unit
+class TestBuildMcpToolCallContext:
+    def test_basic_context_shape(self):
+        ctx = build_mcp_tool_call_context(
+            "get_ohlcv", {"symbol": "005930", "period": "day"}
+        )
+        assert ctx["tool_name"] == "get_ohlcv"
+        assert ctx["arguments"]["symbol"] == "005930"
+        assert ctx["arguments"]["period"] == "day"
+
+    def test_sensitive_keys_masked(self):
+        ctx = build_mcp_tool_call_context(
+            "some_tool",
+            {
+                "authorization": "Bearer secret",
+                "token": "abc123",
+                "secret": "mysecret",
+                "password": "mypass",
+                "normal_key": "visible",
+            },
+        )
+        assert ctx["arguments"]["authorization"] == "[Filtered]"
+        assert ctx["arguments"]["token"] == "[Filtered]"
+        assert ctx["arguments"]["secret"] == "[Filtered]"
+        assert ctx["arguments"]["password"] == "[Filtered]"
+        assert ctx["arguments"]["normal_key"] == "visible"
+
+    def test_none_arguments_becomes_empty_dict(self):
+        ctx = build_mcp_tool_call_context("my_tool", None)
+        assert ctx["arguments"] == {}
+
+    def test_does_not_mutate_original(self):
+        original = {"key": "value", "token": "secret"}
+        original_copy = copy.deepcopy(original)
+        build_mcp_tool_call_context("my_tool", original)
+        assert original == original_copy
+
+    def test_large_argument_truncated(self):
+        ctx = build_mcp_tool_call_context("my_tool", {"data": "x" * 2000})
+        assert ctx["arguments"]["data"].endswith("...[truncated]")
+        assert len(ctx["arguments"]["data"]) == 1024 + len("...[truncated]")
+
+
+def _make_tool_context(tool_name: str, arguments: dict[str, Any] | None = None) -> Mock:
+    message = Mock()
+    message.name = tool_name
+    message.arguments = arguments
+    ctx = Mock()
+    ctx.message = message
+    return ctx
+
+
+class _ScopeRecorder:
+    def __init__(self) -> None:
+        self.tags: dict[str, str] = {}
+        self.contexts: dict[str, dict[str, Any]] = {}
+
+    def set_tag(self, key: str, value: str) -> None:
+        self.tags[key] = value
+
+    def set_context(self, key: str, value: dict[str, Any]) -> None:
+        self.contexts[key] = value
+
+
+def _make_scope_context_manager(scope: Any) -> Mock:
+    cm = Mock()
+    cm.__enter__ = Mock(return_value=scope)
+    cm.__exit__ = Mock(return_value=False)
+    return cm
+
+
+def _make_http_request_ctx(isolation_scope: Any, current_scope: Any) -> SimpleNamespace:
+    return SimpleNamespace(
+        request=SimpleNamespace(
+            scope={
+                "type": "http",
+                "state": {
+                    "sentry_sdk.isolation_scope": isolation_scope,
+                    "sentry_sdk.current_scope": current_scope,
+                },
+            }
+        )
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestMcpToolCallSentryMiddleware:
+    async def test_enriches_request_isolation_scope_for_http_calls(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from app.mcp_server.sentry_middleware import McpToolCallSentryMiddleware
+
+        middleware = McpToolCallSentryMiddleware()
+        ctx = _make_tool_context("get_ohlcv", {"symbol": "005930", "period": "day"})
+        request_ctx = ContextVar[Any]("request_ctx")
+        request_isolation_scope = _ScopeRecorder()
+        request_current_scope = _ScopeRecorder()
+        token = request_ctx.set(
+            _make_http_request_ctx(request_isolation_scope, request_current_scope)
+        )
+        monkeypatch.setattr(sentry_module, "_mcp_request_ctx", request_ctx)
+        call_next = AsyncMock(return_value={"success": True})
+
+        try:
+            with patch.object(
+                sentry_sdk,
+                "new_scope",
+                side_effect=AssertionError("new_scope should not be used"),
+            ):
+                with patch.object(
+                    sentry_sdk,
+                    "isolation_scope",
+                    side_effect=AssertionError(
+                        "isolation_scope should not be used for HTTP requests"
+                    ),
+                ):
+                    result = await middleware.on_call_tool(ctx, call_next)
+        finally:
+            request_ctx.reset(token)
+
+        assert result == {"success": True}
+        assert request_isolation_scope.tags["mcp.tool.name"] == "get_ohlcv"
+        assert (
+            request_isolation_scope.contexts["mcp_tool_call"]["tool_name"]
+            == "get_ohlcv"
+        )
+        assert (
+            request_isolation_scope.contexts["mcp_tool_call"]["arguments"]["symbol"]
+            == "005930"
+        )
+        assert (
+            request_isolation_scope.contexts["mcp_tool_call"]["arguments"]["period"]
+            == "day"
+        )
+        assert request_current_scope.tags == {}
+        assert request_current_scope.contexts == {}
+        call_next.assert_awaited_once_with(ctx)
+
+    async def test_does_not_capture_exception_directly(self):
+        from app.mcp_server.sentry_middleware import McpToolCallSentryMiddleware
+
+        middleware = McpToolCallSentryMiddleware()
+        ctx = _make_tool_context("get_ohlcv", {"period": "invalid"})
+        call_next = AsyncMock(side_effect=ValueError("Invalid period"))
+
+        non_http_scope = _ScopeRecorder()
+
+        with patch.object(
+            sentry_sdk,
+            "new_scope",
+            side_effect=AssertionError("new_scope should not be used"),
+        ):
+            with patch.object(
+                sentry_sdk,
+                "isolation_scope",
+                return_value=_make_scope_context_manager(non_http_scope),
+            ):
+                with patch.object(sentry_sdk, "capture_exception") as mock_capture:
+                    with pytest.raises(ValueError, match="Invalid period"):
+                        await middleware.on_call_tool(ctx, call_next)
+                    mock_capture.assert_not_called()
+
+    async def test_uses_per_call_isolation_scope_for_non_http_requests(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from app.mcp_server.sentry_middleware import McpToolCallSentryMiddleware
+
+        middleware = McpToolCallSentryMiddleware()
+        request_ctx = ContextVar[Any]("request_ctx")
+        monkeypatch.setattr(sentry_module, "_mcp_request_ctx", request_ctx)
+        scopes: list[_ScopeRecorder] = []
+
+        def make_scope() -> Mock:
+            scope = _ScopeRecorder()
+            scopes.append(scope)
+            return _make_scope_context_manager(scope)
+
+        call_next = AsyncMock(return_value={"ok": True})
+
+        with patch.object(
+            sentry_sdk,
+            "new_scope",
+            side_effect=AssertionError("new_scope should not be used"),
+        ):
+            with patch.object(sentry_sdk, "isolation_scope", side_effect=make_scope):
+                await middleware.on_call_tool(
+                    _make_tool_context("get_ohlcv", {"symbol": "005930"}),
+                    call_next,
+                )
+                await middleware.on_call_tool(
+                    _make_tool_context("get_quote", {"symbol": "AAPL"}),
+                    call_next,
+                )
+
+        assert len(scopes) == 2
+        assert scopes[0].tags["mcp.tool.name"] == "get_ohlcv"
+        assert scopes[1].tags["mcp.tool.name"] == "get_quote"
+        assert scopes[0].contexts["mcp_tool_call"]["arguments"]["symbol"] == "005930"
+        assert scopes[1].contexts["mcp_tool_call"]["arguments"]["symbol"] == "AAPL"
+        assert scopes[0].contexts["mcp_tool_call"]["arguments"] == {"symbol": "005930"}
+        assert scopes[1].contexts["mcp_tool_call"]["arguments"] == {"symbol": "AAPL"}
+
+    async def test_sensitive_args_masked_in_context(self):
+        from app.mcp_server.sentry_middleware import McpToolCallSentryMiddleware
+
+        middleware = McpToolCallSentryMiddleware()
+        ctx = _make_tool_context("some_tool", {"token": "secret123", "query": "hello"})
+        scope = _ScopeRecorder()
+        call_next = AsyncMock(return_value={})
+
+        with patch.object(
+            sentry_sdk,
+            "new_scope",
+            side_effect=AssertionError("new_scope should not be used"),
+        ):
+            with patch.object(
+                sentry_sdk,
+                "isolation_scope",
+                return_value=_make_scope_context_manager(scope),
+            ):
+                await middleware.on_call_tool(ctx, call_next)
+
+        args = scope.contexts["mcp_tool_call"]["arguments"]
+        assert args["token"] == "[Filtered]"
+        assert args["query"] == "hello"
+
+    async def test_http_scope_context_survives_when_sentry_wrapper_reuses_request_scope(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from app.mcp_server.sentry_middleware import McpToolCallSentryMiddleware
+
+        middleware = McpToolCallSentryMiddleware()
+        request_ctx = ContextVar[Any]("request_ctx")
+        request_isolation_scope = sentry_sdk.Scope()
+        request_current_scope = sentry_sdk.Scope()
+        token = request_ctx.set(
+            _make_http_request_ctx(request_isolation_scope, request_current_scope)
+        )
+        monkeypatch.setattr(sentry_module, "_mcp_request_ctx", request_ctx)
+        ctx = _make_tool_context(
+            "get_ohlcv",
+            {"symbol": "005930", "period": "invalid_period", "count": 100},
+        )
+        call_next = AsyncMock(side_effect=ValueError("Invalid period: invalid_period"))
+
+        try:
+            with patch.object(
+                sentry_sdk,
+                "new_scope",
+                side_effect=AssertionError("new_scope should not be used"),
+            ):
+                with patch.object(
+                    sentry_sdk,
+                    "isolation_scope",
+                    side_effect=AssertionError(
+                        "isolation_scope should not be used for HTTP requests"
+                    ),
+                ):
+                    with pytest.raises(ValueError):
+                        await middleware.on_call_tool(ctx, call_next)
+        finally:
+            request_ctx.reset(token)
+
+        with sentry_scope.use_isolation_scope(request_isolation_scope):
+            with sentry_scope.use_scope(request_current_scope):
+                preserved = sentry_sdk.get_isolation_scope()._contexts["mcp_tool_call"]
+                assert (
+                    sentry_sdk.get_isolation_scope()._tags["mcp.tool.name"]
+                    == "get_ohlcv"
+                )
+                assert preserved["arguments"]["period"] == "invalid_period"
+
+    async def test_none_arguments_handled(self):
+        from app.mcp_server.sentry_middleware import McpToolCallSentryMiddleware
+
+        middleware = McpToolCallSentryMiddleware()
+        ctx = _make_tool_context("list_tools", None)
+        scope = _ScopeRecorder()
+        call_next = AsyncMock(return_value={})
+
+        with patch.object(
+            sentry_sdk,
+            "new_scope",
+            side_effect=AssertionError("new_scope should not be used"),
+        ):
+            with patch.object(
+                sentry_sdk,
+                "isolation_scope",
+                return_value=_make_scope_context_manager(scope),
+            ):
+                await middleware.on_call_tool(ctx, call_next)
+
+        assert scope.tags["mcp.tool.name"] == "list_tools"
+        assert scope.contexts["mcp_tool_call"]["arguments"] == {}


### PR DESCRIPTION
## Summary
- attach MCP tool name and sanitized arguments to Sentry issue context for tool-call failures
- enrich HTTP MCP requests via request isolation scope and use per-call isolation scope for non-HTTP transports
- add middleware coverage for HTTP and non-HTTP paths, plus document the masking behavior

## Test Plan
- [x] make test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Sentry integration for improved error tracking and debugging of MCP tool calls with automatic context capture.

* **Documentation**
  * Updated observability documentation with details on MCP tool call context tracking.

* **Tests**
  * Added comprehensive test coverage for Sentry integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->