### PR TITLE
fix: backport upbit ticker batching to production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,8 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
+          build-args: |
+            GITHUB_SHA=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ matrix.image }}

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -26,10 +26,13 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # ==============================================================================
 FROM python:3.13-slim AS final
 
+ARG GITHUB_SHA=unknown
+
 # 환경 변수 설정
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1
+    PIP_NO_CACHE_DIR=1 \
+    GITHUB_SHA=$GITHUB_SHA
 
 # 필수 OS 패키지 설치
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/app/services/brokers/upbit/client.py
+++ b/app/services/brokers/upbit/client.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 UPBIT_REST = "https://api.upbit.com/v1"
 UPBIT_CANDLES_RATE_LIMIT_KEY = "GET /v1/candles/*"
+_UPBIT_TICKER_BATCH_SIZE = 50
 _INTERVAL_TO_ENDPOINT = {
     "day": "days",
     "week": "weeks",
@@ -583,17 +584,22 @@ async def fetch_multiple_tickers(market_codes: list[str]) -> list[dict]:
         - acc_trade_volume_24h: 24시간 누적 거래량
         - acc_trade_price_24h: 24시간 누적 거래대금
     """
-    if not market_codes:
+    normalized_codes = _normalize_market_codes(market_codes)
+    if not normalized_codes:
         return []
 
-    query = urlencode(
-        {"markets": ",".join(market_codes)},
-        quote_via=quote,
-        safe=",",
-    )
-    url = f"{UPBIT_REST}/ticker?{query}"
+    tickers: list[dict] = []
+    for offset in range(0, len(normalized_codes), _UPBIT_TICKER_BATCH_SIZE):
+        batch_codes = normalized_codes[offset : offset + _UPBIT_TICKER_BATCH_SIZE]
+        query = urlencode(
+            {"markets": ",".join(batch_codes)},
+            quote_via=quote,
+            safe=",",
+        )
+        url = f"{UPBIT_REST}/ticker?{query}"
+        tickers.extend(await _request_json(url))
 
-    return await _request_json(url)
+    return tickers
 
 
 async def fetch_multiple_current_prices(

--- a/tests/test_mcp_screen_stocks_crypto.py
+++ b/tests/test_mcp_screen_stocks_crypto.py
@@ -1,4 +1,5 @@
 import asyncio
+from urllib.parse import parse_qs, urlparse
 from unittest.mock import AsyncMock, MagicMock
 
 import pandas as pd
@@ -1802,6 +1803,119 @@ class TestScreenStocksCrypto:
         assert first["market_cap_rank"] == 1
         assert result["meta"]["coingecko_cached"] is True
         assert result["meta"]["coingecko_age_seconds"] == pytest.approx(2.0)
+
+    @pytest.mark.asyncio
+    async def test_crypto_large_ticker_enrichment_uses_real_batched_client_path(
+        self,
+        fake_crypto_tvscreener_module,
+        monkeypatch,
+    ) -> None:
+        requested_batches: list[list[str]] = []
+        candidate_count = 120
+        tv_service = AsyncMock()
+        tv_service.query_crypto_screener.return_value = pd.DataFrame(
+            {
+                "symbol": [
+                    f"UPBIT:COIN{index:03d}KRW" for index in range(candidate_count)
+                ],
+                "name": [f"COIN{index:03d}KRW" for index in range(candidate_count)],
+                "description": [
+                    f"Coin {index:03d}" for index in range(candidate_count)
+                ],
+                "price": [1_000.0 + index for index in range(candidate_count)],
+                "change_percent": [-0.01 for _ in range(candidate_count)],
+                "relative_strength_index_14": [40.0 for _ in range(candidate_count)],
+                "average_directional_index_14": [20.0 for _ in range(candidate_count)],
+                "volume_24h_in_usd": [10_000.0 for _ in range(candidate_count)],
+                "value_traded": [
+                    1_000_000_000.0 - index for index in range(candidate_count)
+                ],
+                "market_cap": [100_000_000_000.0 for _ in range(candidate_count)],
+                "exchange": ["UPBIT" for _ in range(candidate_count)],
+            }
+        )
+
+        async def fake_request_json(url: str, params=None):
+            assert params is None
+            batch_codes = parse_qs(urlparse(url).query)["markets"][0].split(",")
+            requested_batches.append(batch_codes)
+            return [
+                {
+                    "market": market_code,
+                    "acc_trade_volume_24h": float(index + 1),
+                }
+                for index, market_code in enumerate(batch_codes)
+            ]
+
+        async def mock_fetch_ohlcv(
+            symbol: str, market_type: str, count: int
+        ) -> pd.DataFrame:
+            assert symbol.startswith("KRW-COIN")
+            assert market_type == "crypto"
+            assert count == 50
+            close = [100.0 + i for i in range(50)]
+            return pd.DataFrame(
+                {
+                    "open": close,
+                    "high": [value + 10.0 for value in close],
+                    "low": [value - 10.0 for value in close],
+                    "close": close,
+                    "volume": [1_000.0] * 49 + [1_500.0],
+                }
+            )
+
+        monkeypatch.setattr(
+            analysis_screen_core,
+            "_import_tvscreener",
+            lambda: fake_crypto_tvscreener_module,
+        )
+        monkeypatch.setattr(
+            analysis_screen_core,
+            "TvScreenerService",
+            lambda timeout=30.0: tv_service,
+        )
+        monkeypatch.setattr(
+            analysis_screen_core,
+            "_fetch_ohlcv_for_indicators",
+            mock_fetch_ohlcv,
+        )
+        monkeypatch.setattr(upbit_service, "_request_json", fake_request_json)
+        monkeypatch.setattr(
+            analysis_screen_core._CRYPTO_MARKET_CAP_CACHE,
+            "get",
+            AsyncMock(
+                return_value={
+                    "data": {},
+                    "cached": False,
+                    "age_seconds": None,
+                    "stale": False,
+                    "error": None,
+                }
+            ),
+        )
+
+        tools = build_tools()
+        result = await tools["screen_stocks"](
+            market="crypto",
+            asset_type=None,
+            category=None,
+            min_market_cap=None,
+            max_per=None,
+            min_dividend_yield=None,
+            max_rsi=None,
+            sort_by="trade_amount",
+            sort_order="desc",
+            limit=25,
+        )
+
+        query_kwargs = tv_service.query_crypto_screener.await_args.kwargs
+        assert query_kwargs["limit"] == 125
+        assert [len(batch) for batch in requested_batches] == [50, 50, 20]
+        assert len(result["results"]) == 25
+        assert all(item["volume_24h"] > 0.0 for item in result["results"])
+        assert not any(
+            "volume_24h defaulted to 0.0" in warning for warning in result["warnings"]
+        )
 
     @pytest.mark.asyncio
     async def test_crypto_coingecko_stale_fallback_adds_warning(self, monkeypatch):

--- a/tests/test_upbit_service.py
+++ b/tests/test_upbit_service.py
@@ -1,4 +1,5 @@
 import asyncio
+from urllib.parse import parse_qs, urlparse
 from unittest.mock import AsyncMock
 
 import pytest
@@ -277,3 +278,85 @@ async def test_fetch_top_traded_coins_fail_fast_when_universe_missing(monkeypatc
         await upbit.fetch_top_traded_coins("KRW")
 
     fetch_tickers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fetch_multiple_tickers_batches_large_requests(monkeypatch):
+    requested_batches: list[list[str]] = []
+    normalized_codes = [f"KRW-COIN{index:03d}" for index in range(120)]
+    market_codes = normalized_codes + [normalized_codes[0], normalized_codes[1]]
+
+    async def fake_request_json(url: str, params=None):
+        assert params is None
+        batch_codes = parse_qs(urlparse(url).query)["markets"][0].split(",")
+        requested_batches.append(batch_codes)
+        return [
+            {
+                "market": market_code,
+                "trade_price": float(index),
+                "acc_trade_price_24h": float(index),
+            }
+            for index, market_code in enumerate(batch_codes)
+        ]
+
+    monkeypatch.setattr(upbit, "_request_json", fake_request_json)
+
+    result = await upbit.fetch_multiple_tickers(market_codes)
+
+    assert [len(batch) for batch in requested_batches] == [50, 50, 20]
+    assert requested_batches[0] == normalized_codes[:50]
+    assert requested_batches[1] == normalized_codes[50:100]
+    assert requested_batches[2] == normalized_codes[100:120]
+    assert [item["market"] for item in result] == normalized_codes
+
+
+@pytest.mark.asyncio
+async def test_fetch_top_traded_coins_sorts_across_batched_ticker_results(monkeypatch):
+    requested_batches: list[list[str]] = []
+    active_markets = [f"KRW-COIN{index:03d}" for index in range(119, -1, -1)]
+
+    async def fake_request_json(url: str, params=None):
+        assert params is None
+        batch_codes = parse_qs(urlparse(url).query)["markets"][0].split(",")
+        requested_batches.append(batch_codes)
+        return [
+            {
+                "market": market_code,
+                "acc_trade_price_24h": float(market_code.removeprefix("KRW-COIN")),
+            }
+            for market_code in batch_codes
+        ]
+
+    get_active_markets = AsyncMock(return_value=active_markets)
+
+    monkeypatch.setattr(upbit, "get_active_upbit_markets", get_active_markets)
+    monkeypatch.setattr(upbit, "_request_json", fake_request_json)
+
+    result = await upbit.fetch_top_traded_coins("KRW")
+
+    get_active_markets.assert_awaited_once_with(quote_currency="KRW")
+    assert [len(batch) for batch in requested_batches] == [50, 50, 20]
+    assert len(result) == 120
+    assert result[0]["market"] == "KRW-COIN119"
+    assert result[-1]["market"] == "KRW-COIN000"
+
+
+@pytest.mark.asyncio
+async def test_fetch_multiple_tickers_propagates_later_batch_errors(monkeypatch):
+    requested_batches: list[list[str]] = []
+    market_codes = [f"KRW-COIN{index:03d}" for index in range(120)]
+
+    async def fake_request_json(url: str, params=None):
+        assert params is None
+        batch_codes = parse_qs(urlparse(url).query)["markets"][0].split(",")
+        requested_batches.append(batch_codes)
+        if len(requested_batches) == 2:
+            raise RuntimeError("second batch failed")
+        return [{"market": market_code} for market_code in batch_codes]
+
+    monkeypatch.setattr(upbit, "_request_json", fake_request_json)
+
+    with pytest.raises(RuntimeError, match="second batch failed"):
+        await upbit.fetch_multiple_tickers(market_codes)
+
+    assert [len(batch) for batch in requested_batches] == [50, 50]


### PR DESCRIPTION
## Summary
- backport the Upbit ticker batching fix to the production release line
- add regression coverage for large crypto ticker enrichment and batched ticker lookups
- pass GITHUB_SHA into the runtime image so Sentry can tag releases with the deployed commit

## Test Plan
- [x] uv run pytest tests/test_upbit_service.py -q
- [x] uv run pytest tests/test_mcp_screen_stocks_crypto.py -q -k large_ticker_enrichment_uses_real_batched_client_path
- [x] uv run pytest tests/test_daily_scan.py -q -k check_price_crash