### PR TITLE
Use tvscreener capabilities for screen_stocks routing

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -310,7 +310,7 @@ Parameters:
 
 Market-specific behavior:
 - **KR market**:
-  - Default `asset_type in {None, "stock"}` + `category=None` requests use tvscreener first
+  - Default `asset_type in {None, "stock"}` + `category=None` requests use tvscreener only when verified KR stock-query capabilities cover the request; otherwise they fall back to the legacy KRX/Naver path before entering tvscreener
   - Successful stock responses expose `meta.source = "tvscreener"` and include `adx` in each result row
   - ETF/category requests stay on the legacy KRX/Naver path
   - KRX data cached with 300s TTL (Redis) + in-memory fallback
@@ -319,10 +319,11 @@ Market-specific behavior:
   - ETN (`asset_type="etn"`) not supported - returns error
 
 - **US market**:
-  - Default `asset_type in {None, "stock"}` requests use tvscreener first, including US `category`/`sector` alias filters when the TradingView sector field is available
+  - Default `asset_type in {None, "stock"}` requests use tvscreener only when verified US stock-query capabilities cover the request
+  - US `category`/`sector` alias requests stay on the tvscreener path only when the TradingView sector filter capability is verified; otherwise they fall back to legacy before running the tv query
   - Successful stock responses expose `meta.source = "tvscreener"`, include `adx`, and preserve public enrichment fields (`sector`, `analyst_buy`, `analyst_hold`, `analyst_sell`, `avg_target`, `upside_pct`) from tvscreener when available
   - Post-screen enrichment skips per-row Finnhub/yfinance fan-out when those public fields are already populated; missing fields fall back to lightweight yfinance/Finnhub enrichment
-  - Unsupported sorts or missing tvscreener sector metadata fall back to the legacy yfinance path
+  - Unsupported or unverified tvscreener request-critical capabilities fall back to the legacy yfinance path
   - Legacy yfinance maps: `min_market_cap` → `intradaymarketcap`, `max_per` → `peratio.lasttwelvemonths`, `min_dividend_yield` → `forward_dividend_yield`
   - Legacy yfinance sort maps: `volume` → `dayvolume`, `market_cap` → `intradaymarketcap`, `change_rate` → `percentchange`
   - Legacy yfinance screen enrichment reuses a request-scoped session for repeated analyst-target lookups

--- a/app/mcp_server/tooling/analysis_screen_core.py
+++ b/app/mcp_server/tooling/analysis_screen_core.py
@@ -6,17 +6,16 @@ import asyncio
 import datetime
 import inspect
 import logging
-import sentry_sdk
 import math
 import time
 from typing import Any, cast
 
 import httpx
+import sentry_sdk
 import yfinance as yf
-
-import app.services.brokers.upbit.client as upbit_service
 from sqlalchemy.ext.asyncio import AsyncSession
 
+import app.services.brokers.upbit.client as upbit_service
 from app.core.async_rate_limiter import RateLimitExceededError
 from app.core.db import AsyncSessionLocal
 from app.mcp_server.tooling.analysis_crypto_score import (
@@ -42,6 +41,7 @@ from app.services.krx import (
     fetch_valuation_all_cached,
 )
 from app.services.tvscreener_service import (
+    TvScreenerCapabilitySnapshot,
     TvScreenerError,
     TvScreenerRateLimitError,
     TvScreenerService,
@@ -72,10 +72,6 @@ _SCREEN_ENRICHMENT_FIELDS = (
     "avg_target",
     "upside_pct",
 )
-
-# TvScreener supported sort fields for stock screening
-# TvScreener supported sort fields for stock screening
-_TVSCREENER_STOCK_SORTS = {"volume", "change_rate", "market_cap", "dividend_yield"}
 
 # ---------------------------------------------------------------------------
 # Timeout Policy Configuration
@@ -730,6 +726,7 @@ def _canonicalize_us_sector_label(sector: str) -> str:
         return sector.upper()
     return sector.title()
 
+
 def _normalize_min_analyst_buy(value: float | None) -> float | None:
     if value is None:
         return None
@@ -866,30 +863,107 @@ def _normalize_dividend_yield_threshold(
     return value, normalized_value
 
 
+def _required_tvscreener_stock_capabilities(
+    *,
+    market: str,
+    asset_type: str | None,
+    category: str | None,
+    sort_by: str,
+    min_market_cap: float | None,
+    max_per: float | None,
+    min_dividend_yield: float | None,
+) -> set[str]:
+    if market in {"kr", "kospi", "kosdaq"}:
+        if asset_type not in {None, "stock"} or category is not None:
+            return set()
+        return {"volume", "change_rate", "rsi", "adx"}
+
+    if market == "us":
+        if asset_type not in {None, "stock"}:
+            return set()
+
+        required = {"volume", "change_rate", "rsi", "adx"}
+        if sort_by == "market_cap" or min_market_cap is not None:
+            required.add("market_cap")
+        if max_per is not None:
+            required.add("pe")
+        if sort_by == "dividend_yield" or min_dividend_yield is not None:
+            required.add("dividend_yield")
+        if category is not None:
+            required.add("sector")
+        return required
+
+    return set()
+
+
+async def _get_tvscreener_stock_capability_snapshot(
+    *,
+    market: str,
+    asset_type: str | None,
+    category: str | None,
+    sort_by: str,
+    min_market_cap: float | None,
+    max_per: float | None,
+    min_dividend_yield: float | None,
+) -> TvScreenerCapabilitySnapshot | None:
+    required_capabilities = _required_tvscreener_stock_capabilities(
+        market=market,
+        asset_type=asset_type,
+        category=category,
+        sort_by=sort_by,
+        min_market_cap=min_market_cap,
+        max_per=max_per,
+        min_dividend_yield=min_dividend_yield,
+    )
+    if not required_capabilities:
+        return None
+
+    try:
+        tvscreener_service = TvScreenerService(timeout=_timeout_seconds("tvscreener"))
+        return await tvscreener_service.get_stock_capabilities(
+            market=market,
+            capability_names=required_capabilities,
+        )
+    except Exception as exc:
+        logger.debug(
+            "tvscreener stock capability snapshot failed for %s: %s: %s",
+            market,
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+
 def _can_use_tvscreener_stock_path(
     *,
     market: str,
     asset_type: str | None,
     category: str | None,
     sort_by: str,
-    max_rsi: float | None,
+    min_market_cap: float | None,
+    max_per: float | None,
+    min_dividend_yield: float | None,
+    capability_snapshot: TvScreenerCapabilitySnapshot | None,
 ) -> bool:
-    """Determine if tvscreener path can be used for the given parameters.
-
-    TvScreener supports specific sort fields and simple stock queries only.
-    ETF, category filters, and unsupported sorts require legacy path.
-    """
-    _ = max_rsi  # Reserved for future compatibility
-    if sort_by not in _TVSCREENER_STOCK_SORTS:
+    if capability_snapshot is None:
         return False
 
-    if market in {"kr", "kospi", "kosdaq"}:
-        return asset_type in {None, "stock"} and category is None
+    required_capabilities = _required_tvscreener_stock_capabilities(
+        market=market,
+        asset_type=asset_type,
+        category=category,
+        sort_by=sort_by,
+        min_market_cap=min_market_cap,
+        max_per=max_per,
+        min_dividend_yield=min_dividend_yield,
+    )
+    if not required_capabilities:
+        return False
 
-    if market == "us":
-        return asset_type in {None, "stock"}
-
-    return False
+    return all(
+        capability_snapshot.is_usable(capability_name)
+        for capability_name in required_capabilities
+    )
 
 
 def _map_tvscreener_stock_row(
@@ -3398,12 +3472,24 @@ async def _screen_kr_with_fallback(
     enrich_rsi: bool,
 ) -> dict[str, Any]:
     """Screen Korean market with tvscreener fallback to legacy."""
+    capability_snapshot = await _get_tvscreener_stock_capability_snapshot(
+        market=market,
+        asset_type=asset_type,
+        category=category,
+        sort_by=sort_by,
+        min_market_cap=min_market_cap,
+        max_per=max_per,
+        min_dividend_yield=min_dividend_yield,
+    )
     if _can_use_tvscreener_stock_path(
         market=market,
         asset_type=asset_type,
         category=category,
         sort_by=sort_by,
-        max_rsi=max_rsi,
+        min_market_cap=min_market_cap,
+        max_per=max_per,
+        min_dividend_yield=min_dividend_yield,
+        capability_snapshot=capability_snapshot,
     ):
         try:
             tvscreener_result = await _screen_kr_via_tvscreener(
@@ -3467,12 +3553,24 @@ async def _screen_us_with_fallback(
     enrich_rsi: bool,
 ) -> dict[str, Any]:
     """Screen US market with tvscreener fallback to legacy."""
+    capability_snapshot = await _get_tvscreener_stock_capability_snapshot(
+        market=market,
+        asset_type=asset_type,
+        category=category,
+        sort_by=sort_by,
+        min_market_cap=min_market_cap,
+        max_per=max_per,
+        min_dividend_yield=min_dividend_yield,
+    )
     if _can_use_tvscreener_stock_path(
         market=market,
         asset_type=asset_type,
         category=category,
         sort_by=sort_by,
-        max_rsi=max_rsi,
+        min_market_cap=min_market_cap,
+        max_per=max_per,
+        min_dividend_yield=min_dividend_yield,
+        capability_snapshot=capability_snapshot,
     ):
         try:
             tvscreener_result = await _screen_us_via_tvscreener(

--- a/app/services/tvscreener_service.py
+++ b/app/services/tvscreener_service.py
@@ -12,6 +12,8 @@ import logging
 import re
 import time
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any
 
 import pandas as pd
@@ -75,6 +77,51 @@ def _normalize_where_clauses(where_clause: Any | None) -> list[Any]:
     return [where_clause]
 
 
+def _has_probe_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    try:
+        return not bool(pd.isna(value))
+    except TypeError:
+        return True
+
+
+def _evaluate_stock_probe_result(
+    *,
+    capability_name: str,
+    field: object,
+    result: pd.DataFrame,
+) -> TvScreenerCapabilityState:
+    if result.empty:
+        return TvScreenerCapabilityState.UNKNOWN
+
+    expected_columns = {
+        _normalize_column_name(field),
+        *(
+            _normalize_column_name(alias)
+            for alias in _STOCK_CAPABILITY_ALIASES.get(capability_name, ())
+        ),
+    }
+    expected_columns.discard("")
+
+    matching_columns = [
+        column
+        for column in result.columns
+        if _normalize_column_name(column) in expected_columns
+    ]
+    if not matching_columns:
+        return TvScreenerCapabilityState.UNKNOWN
+
+    for column in matching_columns:
+        series = result[column]
+        if any(_has_probe_value(value) for value in series.tolist()):
+            return TvScreenerCapabilityState.USABLE
+
+    return TvScreenerCapabilityState.UNKNOWN
+
+
 class TvScreenerError(Exception):
     """Base exception for TvScreener service errors."""
 
@@ -97,6 +144,114 @@ class TvScreenerTimeoutError(TvScreenerError):
     """Raised when a TvScreener request times out."""
 
     pass
+
+
+class TvScreenerCapabilityState(StrEnum):
+    USABLE = "usable"
+    UNSUPPORTED = "unsupported"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class TvScreenerCapabilitySnapshot:
+    screener: str
+    market: str
+    statuses: dict[str, TvScreenerCapabilityState]
+    fields: dict[str, object | None]
+
+    def status(self, capability_name: str) -> TvScreenerCapabilityState:
+        return self.statuses.get(capability_name, TvScreenerCapabilityState.UNKNOWN)
+
+    def field(self, capability_name: str) -> object | None:
+        return self.fields.get(capability_name)
+
+    def is_usable(self, capability_name: str) -> bool:
+        return (
+            self.status(capability_name) is TvScreenerCapabilityState.USABLE
+            and self.field(capability_name) is not None
+        )
+
+
+_STOCK_CAPABILITY_ALIASES: dict[str, tuple[str, ...]] = {
+    "name": ("NAME",),
+    "price": ("PRICE",),
+    "rsi": ("RELATIVE_STRENGTH_INDEX_14",),
+    "adx": ("AVERAGE_DIRECTIONAL_INDEX_14",),
+    "volume": ("VOLUME",),
+    "change_rate": ("CHANGE_PERCENT",),
+    "market_cap": ("MARKET_CAPITALIZATION", "MARKET_CAP_BASIC"),
+    "pe": ("PRICE_TO_EARNINGS_RATIO_TTM", "PRICE_TO_EARNINGS_TTM"),
+    "pbr": ("PRICE_TO_BOOK_FQ",),
+    "dividend_yield": ("DIVIDEND_YIELD_FORWARD", "DIVIDEND_YIELD_RECENT"),
+    "sector": ("SECTOR",),
+}
+
+_CRYPTO_CAPABILITY_ALIASES: dict[str, tuple[str, ...]] = {
+    "name": ("NAME",),
+    "description": ("DESCRIPTION",),
+    "price": ("PRICE",),
+    "rsi": ("RELATIVE_STRENGTH_INDEX_14",),
+    "adx": ("AVERAGE_DIRECTIONAL_INDEX_14",),
+    "value_traded": ("VALUE_TRADED",),
+    "market_cap": ("MARKET_CAP",),
+}
+
+_CAPABILITY_CACHE_MISS = object()
+
+
+class _TvScreenerCapabilityRegistry:
+    def __init__(self) -> None:
+        self._field_cache: dict[tuple[str, str], object | None] = {}
+        self._status_cache: dict[tuple[str, str, str], TvScreenerCapabilityState] = {}
+        self._probe_locks: dict[tuple[str, str, str], asyncio.Lock] = {}
+
+    def get_field(self, screener: str, capability_name: str) -> object:
+        return self._field_cache.get(
+            (screener, capability_name),
+            _CAPABILITY_CACHE_MISS,
+        )
+
+    def set_field(
+        self,
+        screener: str,
+        capability_name: str,
+        field: object | None,
+    ) -> None:
+        self._field_cache[(screener, capability_name)] = field
+
+    def get_status(
+        self,
+        screener: str,
+        market: str,
+        capability_name: str,
+    ) -> TvScreenerCapabilityState | None:
+        return self._status_cache.get((screener, market, capability_name))
+
+    def set_status(
+        self,
+        screener: str,
+        market: str,
+        capability_name: str,
+        status: TvScreenerCapabilityState,
+    ) -> None:
+        self._status_cache[(screener, market, capability_name)] = status
+
+    def get_probe_lock(
+        self,
+        screener: str,
+        market: str,
+        capability_name: str,
+    ) -> asyncio.Lock:
+        cache_key = (screener, market, capability_name)
+        lock = self._probe_locks.get(cache_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._probe_locks[cache_key] = lock
+        return lock
+
+
+_shared_capability_registry = _TvScreenerCapabilityRegistry()
+_STOCK_CAPABILITY_PROBE_LIMIT = 3
 
 
 class TvScreenerService:
@@ -123,6 +278,7 @@ class TvScreenerService:
         max_retries: int = 3,
         base_delay: float = 1.0,
         timeout: float = 30.0,
+        capability_registry: _TvScreenerCapabilityRegistry | None = None,
     ) -> None:
         """Initialize TvScreener service.
 
@@ -139,6 +295,7 @@ class TvScreenerService:
         self.base_delay = base_delay
         self.timeout = timeout
         self._field_cache: dict[str, list[tuple[str, Any]]] = {}
+        self._capability_registry = capability_registry or _shared_capability_registry
         logger.info(
             "TvScreenerService initialized with max_retries=%d, base_delay=%.1fs, timeout=%.1fs",
             max_retries,
@@ -386,6 +543,273 @@ class TvScreenerService:
 
         return available_fields
 
+    @staticmethod
+    def _normalize_stock_market(market: str) -> str:
+        normalized = str(market or "").strip().lower()
+        if normalized in {"kr", "kospi", "kosdaq", "korea"}:
+            return "kr"
+        if normalized in {"us", "america", "united states"}:
+            return "us"
+        return normalized
+
+    async def _resolve_capability_fields(
+        self,
+        *,
+        screener: str,
+        screener_class: type,
+        field_enum: type,
+        capability_aliases: dict[str, tuple[str, ...]],
+        capability_names: set[str],
+    ) -> dict[str, object | None]:
+        available_fields = dict(await self.discover_fields(screener_class, field_enum))
+        resolved_fields: dict[str, object | None] = {}
+
+        for capability_name in capability_names:
+            cached_field = self._capability_registry.get_field(
+                screener, capability_name
+            )
+            if cached_field is _CAPABILITY_CACHE_MISS:
+                resolved_field: object | None = None
+                for alias in capability_aliases.get(capability_name, ()):
+                    if alias in available_fields:
+                        resolved_field = available_fields[alias]
+                        break
+                    field_value = getattr(field_enum, alias, None)
+                    if field_value is not None and not callable(field_value):
+                        resolved_field = field_value
+                        break
+                self._capability_registry.set_field(
+                    screener,
+                    capability_name,
+                    resolved_field,
+                )
+                cached_field = resolved_field
+
+            resolved_fields[capability_name] = (
+                None if cached_field is _CAPABILITY_CACHE_MISS else cached_field
+            )
+
+        return resolved_fields
+
+    async def _probe_stock_capability(
+        self,
+        *,
+        market: str,
+        capability_name: str,
+        field: object,
+    ) -> TvScreenerCapabilityState:
+        normalized_market = self._normalize_stock_market(market)
+        cached_status = self._capability_registry.get_status(
+            "stock",
+            normalized_market,
+            capability_name,
+        )
+        if cached_status is not None:
+            return cached_status
+
+        probe_lock = self._capability_registry.get_probe_lock(
+            "stock",
+            normalized_market,
+            capability_name,
+        )
+
+        async with probe_lock:
+            cached_status = self._capability_registry.get_status(
+                "stock",
+                normalized_market,
+                capability_name,
+            )
+            if cached_status is not None:
+                return cached_status
+
+            try:
+                tvscreener = _import_tvscreener()
+                StockField = tvscreener.StockField
+                Market = tvscreener.Market
+            except ImportError:
+                return TvScreenerCapabilityState.UNKNOWN
+
+            probe_columns = [StockField.NAME]
+            if field != StockField.NAME:
+                probe_columns.append(field)
+
+            probe_markets = None
+            probe_country = None
+            if normalized_market == "kr":
+                probe_markets = [Market.KOREA]
+            elif normalized_market == "us":
+                probe_markets = [Market.AMERICA]
+                probe_country = "United States"
+            else:
+                return TvScreenerCapabilityState.UNKNOWN
+
+            try:
+                probe_result = await self.query_stock_screener(
+                    columns=probe_columns,
+                    where_clause=None,
+                    country=probe_country,
+                    markets=probe_markets,
+                    limit=_STOCK_CAPABILITY_PROBE_LIMIT,
+                )
+            except TvScreenerMalformedRequestError:
+                status = TvScreenerCapabilityState.UNSUPPORTED
+            except (
+                TvScreenerError,
+                TvScreenerRateLimitError,
+                TvScreenerTimeoutError,
+            ):
+                return TvScreenerCapabilityState.UNKNOWN
+            else:
+                status = _evaluate_stock_probe_result(
+                    capability_name=capability_name,
+                    field=field,
+                    result=probe_result,
+                )
+
+            self._capability_registry.set_status(
+                "stock",
+                normalized_market,
+                capability_name,
+                status,
+            )
+            return status
+
+    async def get_stock_capabilities(
+        self,
+        *,
+        market: str,
+        capability_names: Iterable[str],
+    ) -> TvScreenerCapabilitySnapshot:
+        requested_capabilities = {
+            str(capability_name).strip()
+            for capability_name in capability_names
+            if str(capability_name).strip()
+        }
+        normalized_market = self._normalize_stock_market(market)
+
+        if not requested_capabilities:
+            return TvScreenerCapabilitySnapshot(
+                screener="stock",
+                market=normalized_market,
+                statuses={},
+                fields={},
+            )
+
+        try:
+            tvscreener = _import_tvscreener()
+        except ImportError:
+            return TvScreenerCapabilitySnapshot(
+                screener="stock",
+                market=normalized_market,
+                statuses=dict.fromkeys(
+                    requested_capabilities, TvScreenerCapabilityState.UNKNOWN
+                ),
+                fields=dict.fromkeys(requested_capabilities),
+            )
+
+        resolved_fields = await self._resolve_capability_fields(
+            screener="stock",
+            screener_class=tvscreener.StockScreener,
+            field_enum=tvscreener.StockField,
+            capability_aliases=_STOCK_CAPABILITY_ALIASES,
+            capability_names=requested_capabilities,
+        )
+
+        capability_fields: dict[str, object | None] = {}
+        capability_statuses: dict[str, TvScreenerCapabilityState] = {}
+
+        for capability_name in requested_capabilities:
+            resolved_field = resolved_fields.get(capability_name)
+            capability_fields[capability_name] = resolved_field
+
+            if resolved_field is None:
+                self._capability_registry.set_status(
+                    "stock",
+                    normalized_market,
+                    capability_name,
+                    TvScreenerCapabilityState.UNSUPPORTED,
+                )
+                capability_statuses[capability_name] = (
+                    TvScreenerCapabilityState.UNSUPPORTED
+                )
+                continue
+
+            cached_status = self._capability_registry.get_status(
+                "stock",
+                normalized_market,
+                capability_name,
+            )
+            if cached_status is not None:
+                capability_statuses[capability_name] = cached_status
+                continue
+
+            capability_statuses[capability_name] = await self._probe_stock_capability(
+                market=normalized_market,
+                capability_name=capability_name,
+                field=resolved_field,
+            )
+
+        return TvScreenerCapabilitySnapshot(
+            screener="stock",
+            market=normalized_market,
+            statuses=capability_statuses,
+            fields=capability_fields,
+        )
+
+    async def get_crypto_capabilities(
+        self,
+        capability_names: Iterable[str],
+    ) -> TvScreenerCapabilitySnapshot:
+        requested_capabilities = {
+            str(capability_name).strip()
+            for capability_name in capability_names
+            if str(capability_name).strip()
+        }
+
+        if not requested_capabilities:
+            return TvScreenerCapabilitySnapshot(
+                screener="crypto",
+                market="crypto",
+                statuses={},
+                fields={},
+            )
+
+        try:
+            tvscreener = _import_tvscreener()
+        except ImportError:
+            return TvScreenerCapabilitySnapshot(
+                screener="crypto",
+                market="crypto",
+                statuses=dict.fromkeys(
+                    requested_capabilities, TvScreenerCapabilityState.UNKNOWN
+                ),
+                fields=dict.fromkeys(requested_capabilities),
+            )
+
+        resolved_fields = await self._resolve_capability_fields(
+            screener="crypto",
+            screener_class=tvscreener.CryptoScreener,
+            field_enum=tvscreener.CryptoField,
+            capability_aliases=_CRYPTO_CAPABILITY_ALIASES,
+            capability_names=requested_capabilities,
+        )
+
+        capability_statuses = {
+            capability_name: (
+                TvScreenerCapabilityState.USABLE
+                if resolved_fields.get(capability_name) is not None
+                else TvScreenerCapabilityState.UNSUPPORTED
+            )
+            for capability_name in requested_capabilities
+        }
+
+        return TvScreenerCapabilitySnapshot(
+            screener="crypto",
+            market="crypto",
+            statuses=capability_statuses,
+            fields=resolved_fields,
+        )
+
     async def query_crypto_screener(
         self,
         columns: list[Any],
@@ -560,6 +984,8 @@ def get_tvscreener_service() -> TvScreenerService:
 
 
 __all__ = [
+    "TvScreenerCapabilitySnapshot",
+    "TvScreenerCapabilityState",
     "TvScreenerService",
     "TvScreenerError",
     "TvScreenerRateLimitError",

--- a/tests/test_mcp_screen_stocks_tvscreener_contract.py
+++ b/tests/test_mcp_screen_stocks_tvscreener_contract.py
@@ -1,8 +1,50 @@
 import pytest
 
+from app.services.tvscreener_service import (
+    TvScreenerCapabilitySnapshot,
+    TvScreenerCapabilityState,
+)
 from tests._mcp_tooling_support import build_tools
 
 pytest_plugins = ("tests._mcp_tooling_support",)
+
+
+def _stock_capability_snapshot(
+    market: str,
+    **statuses: TvScreenerCapabilityState,
+) -> TvScreenerCapabilitySnapshot:
+    return TvScreenerCapabilitySnapshot(
+        screener="stock",
+        market=market,
+        statuses=statuses,
+        fields={
+            name: name if state is TvScreenerCapabilityState.USABLE else None
+            for name, state in statuses.items()
+        },
+    )
+
+
+def _install_stock_capabilities(
+    monkeypatch,
+    *,
+    overrides: dict[str, TvScreenerCapabilityState] | None = None,
+) -> None:
+    capability_overrides = dict(overrides or {})
+
+    async def mock_get_stock_capabilities(self, *, market, capability_names):
+        del self
+        normalized_market = "kr" if market in {"kr", "kospi", "kosdaq"} else market
+        statuses = {
+            name: capability_overrides.get(name, TvScreenerCapabilityState.USABLE)
+            for name in capability_names
+        }
+        return _stock_capability_snapshot(normalized_market, **statuses)
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.analysis_screen_core.TvScreenerService.get_stock_capabilities",
+        mock_get_stock_capabilities,
+        raising=False,
+    )
 
 
 class TestScreenStocksTvScreenerContract:
@@ -52,6 +94,7 @@ class TestScreenStocksTvScreenerContract:
             "app.mcp_server.tooling.analysis_screen_core._screen_kr_via_tvscreener",
             mock_screen_kr_via_tvscreener,
         )
+        _install_stock_capabilities(monkeypatch)
 
         tools = build_tools()
         result = await tools["screen_stocks"](
@@ -138,6 +181,7 @@ class TestScreenStocksTvScreenerContract:
             "app.mcp_server.tooling.analysis_screen_core._screen_us_via_tvscreener",
             mock_screen_us_via_tvscreener,
         )
+        _install_stock_capabilities(monkeypatch)
 
         tools = build_tools()
         result = await tools["screen_stocks"](
@@ -211,6 +255,7 @@ class TestScreenStocksTvScreenerContract:
             "app.mcp_server.tooling.analysis_screen_core._screen_kr",
             fail_legacy_kr,
         )
+        _install_stock_capabilities(monkeypatch)
 
         tools = build_tools()
         result = await tools["screen_stocks"](
@@ -273,6 +318,7 @@ class TestScreenStocksTvScreenerContract:
             "app.mcp_server.tooling.analysis_screen_core._screen_us",
             fail_legacy_us,
         )
+        _install_stock_capabilities(monkeypatch)
 
         tools = build_tools()
         result = await tools["screen_stocks"](
@@ -336,6 +382,7 @@ class TestScreenStocksTvScreenerContract:
             "app.mcp_server.tooling.analysis_screen_core._screen_kr",
             fail_legacy_kr,
         )
+        _install_stock_capabilities(monkeypatch)
 
         tools = build_tools()
         result = await tools["screen_stocks"](
@@ -400,6 +447,7 @@ class TestScreenStocksTvScreenerContract:
             "app.mcp_server.tooling.analysis_screen_core._screen_us",
             fail_legacy_us,
         )
+        _install_stock_capabilities(monkeypatch)
 
         tools = build_tools()
         result = await tools["screen_stocks"](
@@ -474,6 +522,7 @@ class TestScreenStocksTvScreenerContract:
             "app.mcp_server.tooling.analysis_screen_core._screen_us",
             mock_screen_us,
         )
+        _install_stock_capabilities(monkeypatch)
 
         tools = build_tools()
         result = await tools["screen_stocks"](
@@ -523,6 +572,7 @@ class TestScreenStocksTvScreenerContract:
             "app.mcp_server.tooling.analysis_screen_core._screen_kr_via_tvscreener",
             mock_screen_kr_via_tvscreener,
         )
+        _install_stock_capabilities(monkeypatch)
 
         tools = build_tools()
         result = await tools["screen_stocks"](
@@ -543,20 +593,56 @@ class TestScreenStocksTvScreenerContract:
         assert result["filters_applied"]["market"] == market
 
     @pytest.mark.asyncio
-    async def test_us_category_with_max_rsi_falls_back_to_legacy_path(
-        self, mock_yfinance_screen, monkeypatch
+    @pytest.mark.asyncio
+    async def test_us_sector_request_uses_tvscreener_when_capability_verified(
+        self, monkeypatch
     ):
-        import yfinance as yf
-
-        async def fail_if_called(**kwargs):
-            raise AssertionError(
-                "tvscreener path should not run for market_cap sorting"
+        async def mock_get_stock_capabilities(self, *, market, capability_names):
+            assert market == "us"
+            assert "sector" in capability_names
+            return _stock_capability_snapshot(
+                market,
+                volume=TvScreenerCapabilityState.USABLE,
+                change_rate=TvScreenerCapabilityState.USABLE,
+                rsi=TvScreenerCapabilityState.USABLE,
+                adx=TvScreenerCapabilityState.USABLE,
+                sector=TvScreenerCapabilityState.USABLE,
             )
 
-        monkeypatch.setattr(yf, "screen", mock_yfinance_screen)
+        async def mock_screen_us_via_tvscreener(**kwargs):
+            assert kwargs["category"] == "Technology"
+            return {
+                "stocks": [
+                    {
+                        "symbol": "AAPL",
+                        "name": "Apple Inc.",
+                        "price": 175.5,
+                        "change_percent": 1.2,
+                        "volume": 75_000_000.0,
+                        "sector": "Technology",
+                    }
+                ],
+                "count": 1,
+                "filters_applied": {"sort_by": "volume", "sort_order": "desc"},
+                "source": "tvscreener",
+                "error": None,
+            }
+
+        async def fail_legacy_us(**kwargs):
+            raise AssertionError("legacy US path should not run when sector is usable")
+
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core.TvScreenerService.get_stock_capabilities",
+            mock_get_stock_capabilities,
+            raising=False,
+        )
         monkeypatch.setattr(
             "app.mcp_server.tooling.analysis_screen_core._screen_us_via_tvscreener",
-            fail_if_called,
+            mock_screen_us_via_tvscreener,
+        )
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core._screen_us",
+            fail_legacy_us,
         )
 
         tools = build_tools()
@@ -567,14 +653,170 @@ class TestScreenStocksTvScreenerContract:
             min_market_cap=None,
             max_per=None,
             min_dividend_yield=None,
-            max_rsi=40.0,
+            max_rsi=None,
             sort_by="volume",
             sort_order="desc",
-            limit=50,
+            limit=5,
         )
 
-        assert result["market"] == "us"
-        assert "results" in result
+        assert result["meta"]["source"] == "tvscreener"
+        assert result["results"][0]["sector"] == "Technology"
+
+    @pytest.mark.asyncio
+    async def test_us_sector_request_falls_back_to_legacy_when_capability_missing(
+        self, monkeypatch
+    ):
+        async def mock_get_stock_capabilities(self, *, market, capability_names):
+            assert market == "us"
+            assert "sector" in capability_names
+            return _stock_capability_snapshot(
+                market,
+                volume=TvScreenerCapabilityState.USABLE,
+                change_rate=TvScreenerCapabilityState.USABLE,
+                rsi=TvScreenerCapabilityState.USABLE,
+                adx=TvScreenerCapabilityState.USABLE,
+                sector=TvScreenerCapabilityState.UNSUPPORTED,
+            )
+
+        async def fail_tvscreener_us(**kwargs):
+            raise AssertionError(
+                "tvscreener US path should not run when sector capability is unsupported"
+            )
+
+        async def mock_screen_us(**kwargs):
+            return {
+                "results": [
+                    {
+                        "code": "AAPL",
+                        "name": "Apple Inc.",
+                        "close": 175.5,
+                        "change_rate": 1.2,
+                        "volume": 75_000_000.0,
+                        "sector": "Technology",
+                        "market": "us",
+                    }
+                ],
+                "total_count": 1,
+                "returned_count": 1,
+                "filters_applied": {
+                    "market": "us",
+                    "category": "Technology",
+                    "sort_by": "volume",
+                    "sort_order": "desc",
+                },
+                "market": "us",
+                "timestamp": "2026-03-07T00:00:00+00:00",
+                "meta": {"source": "legacy"},
+            }
+
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core.TvScreenerService.get_stock_capabilities",
+            mock_get_stock_capabilities,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core._screen_us_via_tvscreener",
+            fail_tvscreener_us,
+        )
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core._screen_us",
+            mock_screen_us,
+        )
+
+        tools = build_tools()
+        result = await tools["screen_stocks"](
+            market="us",
+            asset_type=None,
+            category="Technology",
+            min_market_cap=None,
+            max_per=None,
+            min_dividend_yield=None,
+            max_rsi=None,
+            sort_by="volume",
+            sort_order="desc",
+            limit=5,
+        )
+
+        assert result["meta"]["source"] == "legacy"
+        assert result["results"][0]["code"] == "AAPL"
+
+    @pytest.mark.asyncio
+    async def test_us_sector_request_falls_back_to_legacy_when_capability_unknown(
+        self, monkeypatch
+    ):
+        async def mock_get_stock_capabilities(self, *, market, capability_names):
+            assert market == "us"
+            assert "sector" in capability_names
+            return _stock_capability_snapshot(
+                market,
+                volume=TvScreenerCapabilityState.USABLE,
+                change_rate=TvScreenerCapabilityState.USABLE,
+                rsi=TvScreenerCapabilityState.USABLE,
+                adx=TvScreenerCapabilityState.USABLE,
+                sector=TvScreenerCapabilityState.UNKNOWN,
+            )
+
+        async def fail_tvscreener_us(**kwargs):
+            raise AssertionError(
+                "tvscreener US path should not run when sector capability is unknown"
+            )
+
+        async def mock_screen_us(**kwargs):
+            return {
+                "results": [
+                    {
+                        "code": "AAPL",
+                        "name": "Apple Inc.",
+                        "close": 175.5,
+                        "change_rate": 1.2,
+                        "volume": 75_000_000.0,
+                        "sector": "Technology",
+                        "market": "us",
+                    }
+                ],
+                "total_count": 1,
+                "returned_count": 1,
+                "filters_applied": {
+                    "market": "us",
+                    "category": "Technology",
+                    "sort_by": "volume",
+                    "sort_order": "desc",
+                },
+                "market": "us",
+                "timestamp": "2026-03-07T00:00:00+00:00",
+                "meta": {"source": "legacy"},
+            }
+
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core.TvScreenerService.get_stock_capabilities",
+            mock_get_stock_capabilities,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core._screen_us_via_tvscreener",
+            fail_tvscreener_us,
+        )
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core._screen_us",
+            mock_screen_us,
+        )
+
+        tools = build_tools()
+        result = await tools["screen_stocks"](
+            market="us",
+            asset_type=None,
+            category="Technology",
+            min_market_cap=None,
+            max_per=None,
+            min_dividend_yield=None,
+            max_rsi=None,
+            sort_by="volume",
+            sort_order="desc",
+            limit=5,
+        )
+
+        assert result["meta"]["source"] == "legacy"
+        assert result["results"][0]["code"] == "AAPL"
 
     @pytest.mark.asyncio
     async def test_kr_category_with_max_rsi_falls_back_to_legacy_path(
@@ -628,3 +870,149 @@ class TestScreenStocksTvScreenerContract:
 
         assert result["filters_applied"]["asset_type"] == "etf"
         assert result["filters_applied"]["category"] == "반도체"
+
+    @pytest.mark.asyncio
+    async def test_kr_default_stock_request_uses_tvscreener_when_capabilities_verified(
+        self, monkeypatch
+    ):
+        async def mock_get_stock_capabilities(self, *, market, capability_names):
+            assert market == "kr"
+            assert {"volume", "change_rate", "rsi", "adx"}.issubset(capability_names)
+            return _stock_capability_snapshot(
+                market,
+                volume=TvScreenerCapabilityState.USABLE,
+                change_rate=TvScreenerCapabilityState.USABLE,
+                rsi=TvScreenerCapabilityState.USABLE,
+                adx=TvScreenerCapabilityState.USABLE,
+            )
+
+        async def mock_screen_kr_via_tvscreener(**kwargs):
+            return {
+                "stocks": [
+                    {
+                        "symbol": "005930",
+                        "name": "Samsung Electronics Co., Ltd.",
+                        "price": 70000.0,
+                        "change_percent": 2.5,
+                        "volume": 15_000_000.0,
+                        "rsi": 41.2,
+                        "adx": 23.5,
+                        "market": "KOSPI",
+                    }
+                ],
+                "count": 1,
+                "filters_applied": {"sort_by": "volume", "sort_order": "desc"},
+                "source": "tvscreener",
+                "error": None,
+            }
+
+        async def fail_legacy_kr(**kwargs):
+            raise AssertionError("legacy KR path should not run when capabilities pass")
+
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core.TvScreenerService.get_stock_capabilities",
+            mock_get_stock_capabilities,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core._screen_kr_via_tvscreener",
+            mock_screen_kr_via_tvscreener,
+        )
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core._screen_kr",
+            fail_legacy_kr,
+        )
+
+        tools = build_tools()
+        result = await tools["screen_stocks"](
+            market="kr",
+            asset_type="stock",
+            category=None,
+            min_market_cap=None,
+            max_per=None,
+            max_pbr=None,
+            min_dividend_yield=None,
+            max_rsi=35.0,
+            sort_by="volume",
+            sort_order="desc",
+            limit=5,
+        )
+
+        assert result["meta"]["source"] == "tvscreener"
+        assert result["results"][0]["adx"] == 23.5
+
+    @pytest.mark.asyncio
+    async def test_kr_request_falls_back_to_legacy_when_capability_unverified(
+        self, monkeypatch
+    ):
+        async def mock_get_stock_capabilities(self, *, market, capability_names):
+            assert market == "kr"
+            return _stock_capability_snapshot(
+                market,
+                volume=TvScreenerCapabilityState.UNKNOWN,
+                change_rate=TvScreenerCapabilityState.USABLE,
+                rsi=TvScreenerCapabilityState.USABLE,
+                adx=TvScreenerCapabilityState.USABLE,
+            )
+
+        async def fail_tvscreener_kr(**kwargs):
+            raise AssertionError(
+                "tvscreener KR path should not run when a required capability is unknown"
+            )
+
+        async def mock_screen_kr(**kwargs):
+            return {
+                "results": [
+                    {
+                        "code": "005930",
+                        "name": "삼성전자",
+                        "close": 70000.0,
+                        "change_rate": 2.5,
+                        "volume": 15_000_000.0,
+                        "market": "KOSPI",
+                    }
+                ],
+                "total_count": 1,
+                "returned_count": 1,
+                "filters_applied": {
+                    "market": "kr",
+                    "asset_type": "stock",
+                    "sort_by": "volume",
+                    "sort_order": "desc",
+                },
+                "market": "kr",
+                "meta": {"source": "legacy", "rsi_enrichment": {"error_samples": []}},
+                "timestamp": "2026-03-07T00:00:00+00:00",
+            }
+
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core.TvScreenerService.get_stock_capabilities",
+            mock_get_stock_capabilities,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core._screen_kr_via_tvscreener",
+            fail_tvscreener_kr,
+        )
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.analysis_screen_core._screen_kr",
+            mock_screen_kr,
+        )
+
+        tools = build_tools()
+        result = await tools["screen_stocks"](
+            market="kr",
+            asset_type="stock",
+            category=None,
+            min_market_cap=None,
+            max_per=None,
+            max_pbr=None,
+            min_dividend_yield=None,
+            max_rsi=35.0,
+            sort_by="volume",
+            sort_order="desc",
+            limit=5,
+        )
+
+        assert result["meta"]["source"] == "legacy"
+        assert result["results"][0]["code"] == "005930"

--- a/tests/test_tvscreener_capabilities.py
+++ b/tests/test_tvscreener_capabilities.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pandas as pd
+import pytest
+
+import app.services.tvscreener_service as tvscreener_service
+from app.services.tvscreener_service import (
+    TvScreenerCapabilityState,
+    TvScreenerMalformedRequestError,
+    TvScreenerRateLimitError,
+    TvScreenerService,
+)
+
+
+def _fake_stock_module(**field_overrides: object) -> SimpleNamespace:
+    stock_field_attrs: dict[str, object] = {
+        "NAME": "name",
+        "VOLUME": "volume",
+        "CHANGE_PERCENT": "change_percent",
+        "RELATIVE_STRENGTH_INDEX_14": "rsi14",
+        "AVERAGE_DIRECTIONAL_INDEX_14": "adx14",
+    }
+    stock_field_attrs.update(field_overrides)
+    return SimpleNamespace(
+        Market=SimpleNamespace(KOREA="KOREA", AMERICA="AMERICA"),
+        StockScreener=type("FakeStockScreener", (), {}),
+        StockField=type("FakeStockField", (), stock_field_attrs),
+    )
+
+
+@pytest.mark.asyncio
+async def test_stock_capabilities_keep_empty_probe_results_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TvScreenerService(
+        capability_registry=tvscreener_service._TvScreenerCapabilityRegistry()
+    )
+    probe = AsyncMock(return_value=pd.DataFrame(columns=["name", "sector"]))
+
+    monkeypatch.setattr(
+        "app.services.tvscreener_service._import_tvscreener",
+        lambda: _fake_stock_module(SECTOR="sector"),
+    )
+    monkeypatch.setattr(service, "query_stock_screener", probe)
+
+    snapshot = await service.get_stock_capabilities(
+        market="us",
+        capability_names={"sector"},
+    )
+
+    assert snapshot.status("sector") is TvScreenerCapabilityState.UNKNOWN
+    assert snapshot.field("sector") == "sector"
+    await_args = probe.await_args
+    assert await_args is not None
+    assert await_args.kwargs["where_clause"] is None
+    assert await_args.kwargs["limit"] > 1
+
+
+@pytest.mark.asyncio
+async def test_stock_capabilities_keep_valueless_probe_samples_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TvScreenerService(
+        capability_registry=tvscreener_service._TvScreenerCapabilityRegistry()
+    )
+    probe = AsyncMock(
+        return_value=pd.DataFrame(
+            {
+                "name": ["AAPL", "MSFT", "NVDA"],
+                "sector": [None, "", "   "],
+            }
+        )
+    )
+
+    monkeypatch.setattr(
+        "app.services.tvscreener_service._import_tvscreener",
+        lambda: _fake_stock_module(SECTOR="sector"),
+    )
+    monkeypatch.setattr(service, "query_stock_screener", probe)
+
+    snapshot = await service.get_stock_capabilities(
+        market="us",
+        capability_names={"sector"},
+    )
+
+    assert snapshot.status("sector") is TvScreenerCapabilityState.UNKNOWN
+    assert snapshot.field("sector") == "sector"
+
+
+@pytest.mark.asyncio
+async def test_stock_capabilities_keep_missing_probe_column_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TvScreenerService(
+        capability_registry=tvscreener_service._TvScreenerCapabilityRegistry()
+    )
+    probe = AsyncMock(
+        return_value=pd.DataFrame(
+            {
+                "name": ["AAPL", "MSFT", "NVDA"],
+                "industry": ["Consumer Electronics", "Software", "Semiconductors"],
+            }
+        )
+    )
+
+    monkeypatch.setattr(
+        "app.services.tvscreener_service._import_tvscreener",
+        lambda: _fake_stock_module(SECTOR="sector"),
+    )
+    monkeypatch.setattr(service, "query_stock_screener", probe)
+
+    snapshot = await service.get_stock_capabilities(
+        market="us",
+        capability_names={"sector"},
+    )
+
+    assert snapshot.status("sector") is TvScreenerCapabilityState.UNKNOWN
+    assert snapshot.field("sector") == "sector"
+
+
+@pytest.mark.asyncio
+async def test_stock_capabilities_mark_missing_enum_field_unsupported_without_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TvScreenerService(
+        capability_registry=tvscreener_service._TvScreenerCapabilityRegistry()
+    )
+    probe = AsyncMock(return_value=pd.DataFrame({"name": ["AAPL"]}))
+
+    monkeypatch.setattr(
+        "app.services.tvscreener_service._import_tvscreener",
+        lambda: _fake_stock_module(),
+    )
+    monkeypatch.setattr(service, "query_stock_screener", probe)
+
+    snapshot = await service.get_stock_capabilities(
+        market="us",
+        capability_names={"sector"},
+    )
+
+    assert snapshot.status("sector") is TvScreenerCapabilityState.UNSUPPORTED
+    assert snapshot.field("sector") is None
+    probe.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stock_capabilities_cache_hard_unsupported_probe_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TvScreenerService(
+        capability_registry=tvscreener_service._TvScreenerCapabilityRegistry()
+    )
+    probe = AsyncMock(side_effect=TvScreenerMalformedRequestError("unknown field"))
+
+    monkeypatch.setattr(
+        "app.services.tvscreener_service._import_tvscreener",
+        lambda: _fake_stock_module(SECTOR="sector"),
+    )
+    monkeypatch.setattr(service, "query_stock_screener", probe)
+
+    first = await service.get_stock_capabilities(
+        market="us",
+        capability_names={"sector"},
+    )
+    second = await service.get_stock_capabilities(
+        market="us",
+        capability_names={"sector"},
+    )
+
+    assert first.status("sector") is TvScreenerCapabilityState.UNSUPPORTED
+    assert second.status("sector") is TvScreenerCapabilityState.UNSUPPORTED
+    assert probe.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stock_capabilities_retry_after_transient_probe_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TvScreenerService(
+        capability_registry=tvscreener_service._TvScreenerCapabilityRegistry()
+    )
+    probe = AsyncMock(
+        side_effect=[
+            TvScreenerRateLimitError("rate limit"),
+            pd.DataFrame({"name": ["AAPL"], "sector": ["Technology"]}),
+        ]
+    )
+
+    monkeypatch.setattr(
+        "app.services.tvscreener_service._import_tvscreener",
+        lambda: _fake_stock_module(SECTOR="sector"),
+    )
+    monkeypatch.setattr(service, "query_stock_screener", probe)
+
+    first = await service.get_stock_capabilities(
+        market="us",
+        capability_names={"sector"},
+    )
+    second = await service.get_stock_capabilities(
+        market="us",
+        capability_names={"sector"},
+    )
+
+    assert first.status("sector") is TvScreenerCapabilityState.UNKNOWN
+    assert second.status("sector") is TvScreenerCapabilityState.USABLE
+    assert second.field("sector") == "sector"
+    assert probe.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_stock_capabilities_reuse_cached_usable_probe_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = TvScreenerService(
+        capability_registry=tvscreener_service._TvScreenerCapabilityRegistry()
+    )
+    probe = AsyncMock(
+        return_value=pd.DataFrame({"name": ["005930"], "volume": [1_000.0]})
+    )
+
+    monkeypatch.setattr(
+        "app.services.tvscreener_service._import_tvscreener",
+        lambda: _fake_stock_module(VOLUME="volume"),
+    )
+    monkeypatch.setattr(service, "query_stock_screener", probe)
+
+    first = await service.get_stock_capabilities(
+        market="kr",
+        capability_names={"volume"},
+    )
+    second = await service.get_stock_capabilities(
+        market="kr",
+        capability_names={"volume"},
+    )
+
+    assert first.status("volume") is TvScreenerCapabilityState.USABLE
+    assert second.status("volume") is TvScreenerCapabilityState.USABLE
+    assert probe.await_count == 1


### PR DESCRIPTION
## Summary
- add lazy tvscreener capability discovery and probe validation for screen_stocks field routing
- route KR and US stock screening through tvscreener only when verified capabilities satisfy the requested filters and sorts
- cover the new routing and empty-probe fallback behavior with capability and contract tests, and document the gating in the MCP README

## Test Plan
- make test
- uv run pytest --no-cov tests/test_tvscreener_capabilities.py tests/test_mcp_screen_stocks_tvscreener_contract.py -q
- uv run pytest --no-cov tests/test_mcp_screen_stocks_*.py -q
- uv run ty check app/services/tvscreener_service.py app/mcp_server/tooling/analysis_screen_core.py --error-on-warning -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced stock screening reliability with market-specific fallback mechanisms for Korean and US markets.
  * Stock queries now verify required capabilities are available before executing and automatically fall back to alternative data sources when needed.
  * Improved handling of filtered stock requests, including sector-based filtering.
  * Better error handling ensures stock screening continues to work even when certain data sources are temporarily unavailable or unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->