### PR TITLE
Add configurable MCP graceful shutdown timeout

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -678,6 +678,7 @@ Environment variables:
 - `MCP_HOST` : `0.0.0.0`
 - `MCP_PORT` : `8765`
 - `MCP_PATH` : `/mcp`
+- `MCP_GRACEFUL_SHUTDOWN_TIMEOUT` : `10` (seconds, HTTP transports only: `sse` / `streamable-http`)
 - `MCP_USER_ID` : `1` (manual holdings 조회에 사용할 기본 사용자 ID)
 
 Example:

--- a/app/mcp_server/env_utils.py
+++ b/app/mcp_server/env_utils.py
@@ -27,3 +27,8 @@ def _env_int(name: str, default: int) -> int:
 def get_finnhub_api_key() -> str | None:
     """Get Finnhub API key from environment."""
     return _env("FINNHUB_API_KEY")
+
+
+def get_mcp_graceful_shutdown_timeout() -> int:
+    """Get MCP HTTP graceful shutdown timeout in seconds."""
+    return _env_int("MCP_GRACEFUL_SHUTDOWN_TIMEOUT", 10)

--- a/app/mcp_server/main.py
+++ b/app/mcp_server/main.py
@@ -1,7 +1,7 @@
 import logging
 
 from app.core.config import settings
-from app.mcp_server.env_utils import _env, _env_int
+from app.mcp_server.env_utils import _env, _env_int, get_mcp_graceful_shutdown_timeout
 from app.monitoring.sentry import capture_exception, init_sentry
 
 # ──────────────────────────────────────────────────────────────────────
@@ -72,10 +72,22 @@ def main() -> None:
         if mcp_type == "stdio":
             mcp.run(transport="stdio")
         elif mcp_type == "sse":
-            mcp.run(transport="sse", host=mcp_host, port=mcp_port, path=mcp_path)
-        elif mcp_type == "streamable-http":
+            graceful_shutdown_timeout = get_mcp_graceful_shutdown_timeout()
             mcp.run(
-                transport="streamable-http", host=mcp_host, port=mcp_port, path=mcp_path
+                transport="sse",
+                host=mcp_host,
+                port=mcp_port,
+                path=mcp_path,
+                uvicorn_config={"timeout_graceful_shutdown": graceful_shutdown_timeout},
+            )
+        elif mcp_type == "streamable-http":
+            graceful_shutdown_timeout = get_mcp_graceful_shutdown_timeout()
+            mcp.run(
+                transport="streamable-http",
+                host=mcp_host,
+                port=mcp_port,
+                path=mcp_path,
+                uvicorn_config={"timeout_graceful_shutdown": graceful_shutdown_timeout},
             )
         else:
             raise ValueError(f"Unsupported MCP_TYPE: {mcp_type}")

--- a/tests/test_mcp_server_env_utils.py
+++ b/tests/test_mcp_server_env_utils.py
@@ -1,6 +1,28 @@
+import importlib.util
+from pathlib import Path
+
 import pytest
 
-from app.mcp_server.env_utils import _env, _env_int, get_finnhub_api_key
+
+def _load_env_utils_module():
+    env_utils_path = (
+        Path(__file__).resolve().parents[1] / "app" / "mcp_server" / "env_utils.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "test_env_utils_module", env_utils_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_env_utils = _load_env_utils_module()
+_env = _env_utils._env
+_env_int = _env_utils._env_int
+get_finnhub_api_key = _env_utils.get_finnhub_api_key
+get_mcp_graceful_shutdown_timeout = _env_utils.get_mcp_graceful_shutdown_timeout
 
 
 @pytest.mark.unit
@@ -59,3 +81,28 @@ class TestGetFinnhubApiKey:
     def test_returns_none_when_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("FINNHUB_API_KEY", "")
         assert get_finnhub_api_key() is None
+
+
+@pytest.mark.unit
+class TestGetMcpGracefulShutdownTimeout:
+    def test_returns_timeout_when_valid(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_GRACEFUL_SHUTDOWN_TIMEOUT", "25")
+        assert get_mcp_graceful_shutdown_timeout() == 25
+
+    def test_returns_default_when_not_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("MCP_GRACEFUL_SHUTDOWN_TIMEOUT", raising=False)
+        assert get_mcp_graceful_shutdown_timeout() == 10
+
+    def test_returns_default_when_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MCP_GRACEFUL_SHUTDOWN_TIMEOUT", "")
+        assert get_mcp_graceful_shutdown_timeout() == 10
+
+    def test_returns_default_on_invalid_value(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.setenv("MCP_GRACEFUL_SHUTDOWN_TIMEOUT", "invalid")
+        assert get_mcp_graceful_shutdown_timeout() == 10
+        assert "Invalid integer" in caplog.text
+        assert "MCP_GRACEFUL_SHUTDOWN_TIMEOUT" in caplog.text

--- a/tests/test_mcp_server_main.py
+++ b/tests/test_mcp_server_main.py
@@ -1,0 +1,155 @@
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class _FakeFastMCP:
+    def __init__(self, **kwargs: object) -> None:
+        self.init_kwargs = kwargs
+        self.run = MagicMock()
+        self.add_middleware = MagicMock()
+
+
+def _load_env_utils_module() -> ModuleType:
+    env_utils_path = (
+        Path(__file__).resolve().parents[1] / "app" / "mcp_server" / "env_utils.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "app.mcp_server.env_utils", env_utils_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_main_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[ModuleType, _FakeFastMCP, MagicMock]:
+    main_path = Path(__file__).resolve().parents[1] / "app" / "mcp_server" / "main.py"
+
+    fake_fastmcp = ModuleType("fastmcp")
+    fake_fastmcp.__dict__["FastMCP"] = _FakeFastMCP
+
+    fake_mcp_package = ModuleType("app.mcp_server")
+    fake_mcp_package.__path__ = []
+
+    fake_config = ModuleType("app.core.config")
+    fake_config.__dict__["settings"] = SimpleNamespace(LOG_LEVEL="INFO")
+
+    fake_auth = ModuleType("app.mcp_server.auth")
+    fake_auth.__dict__["build_auth_provider"] = MagicMock(return_value="auth-provider")
+
+    fake_sentry_middleware = ModuleType("app.mcp_server.sentry_middleware")
+    fake_sentry_middleware.__dict__["McpToolCallSentryMiddleware"] = MagicMock(
+        return_value="middleware"
+    )
+
+    fake_tooling = ModuleType("app.mcp_server.tooling")
+    register_all_tools = MagicMock()
+    fake_tooling.__dict__["register_all_tools"] = register_all_tools
+
+    fake_monitoring = ModuleType("app.monitoring.sentry")
+    fake_monitoring.__dict__["capture_exception"] = MagicMock()
+    fake_monitoring.__dict__["init_sentry"] = MagicMock()
+
+    env_utils_module = _load_env_utils_module()
+
+    monkeypatch.setitem(sys.modules, "fastmcp", fake_fastmcp)
+    monkeypatch.setitem(sys.modules, "app.mcp_server", fake_mcp_package)
+    monkeypatch.setitem(sys.modules, "app.core.config", fake_config)
+    monkeypatch.setitem(sys.modules, "app.mcp_server.auth", fake_auth)
+    monkeypatch.setitem(sys.modules, "app.mcp_server.env_utils", env_utils_module)
+    monkeypatch.setitem(
+        sys.modules, "app.mcp_server.sentry_middleware", fake_sentry_middleware
+    )
+    monkeypatch.setitem(sys.modules, "app.mcp_server.tooling", fake_tooling)
+    monkeypatch.setitem(sys.modules, "app.monitoring.sentry", fake_monitoring)
+    monkeypatch.delitem(sys.modules, "app.mcp_server.main", raising=False)
+
+    spec = importlib.util.spec_from_file_location("app.mcp_server.main", main_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["app.mcp_server.main"] = module
+    spec.loader.exec_module(module)
+    return module, module.mcp, fake_monitoring.capture_exception
+
+
+@pytest.mark.unit
+class TestMcpServerMain:
+    def test_streamable_http_uses_default_shutdown_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MCP_TYPE", "streamable-http")
+        monkeypatch.delenv("MCP_GRACEFUL_SHUTDOWN_TIMEOUT", raising=False)
+
+        module, mcp, _ = _load_main_module(monkeypatch)
+
+        module.main()
+
+        mcp.run.assert_called_once_with(
+            transport="streamable-http",
+            host="0.0.0.0",
+            port=8765,
+            path="/mcp",
+            uvicorn_config={"timeout_graceful_shutdown": 10},
+        )
+
+    def test_sse_honors_explicit_shutdown_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MCP_TYPE", "sse")
+        monkeypatch.setenv("MCP_GRACEFUL_SHUTDOWN_TIMEOUT", "27")
+
+        module, mcp, _ = _load_main_module(monkeypatch)
+
+        module.main()
+
+        mcp.run.assert_called_once_with(
+            transport="sse",
+            host="0.0.0.0",
+            port=8765,
+            path="/mcp",
+            uvicorn_config={"timeout_graceful_shutdown": 27},
+        )
+
+    def test_stdio_does_not_pass_uvicorn_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MCP_TYPE", "stdio")
+        monkeypatch.setenv("MCP_GRACEFUL_SHUTDOWN_TIMEOUT", "33")
+
+        module, mcp, _ = _load_main_module(monkeypatch)
+
+        module.main()
+
+        mcp.run.assert_called_once_with(transport="stdio")
+
+    def test_stdio_does_not_parse_invalid_shutdown_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MCP_TYPE", "stdio")
+        monkeypatch.setenv("MCP_GRACEFUL_SHUTDOWN_TIMEOUT", "invalid")
+
+        module, _, _ = _load_main_module(monkeypatch)
+
+        module.main()
+
+    def test_unsupported_mcp_type_still_raises_and_captures(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MCP_TYPE", "invalid")
+
+        module, _, capture_exception = _load_main_module(monkeypatch)
+
+        with pytest.raises(ValueError, match="Unsupported MCP_TYPE: invalid"):
+            module.main()
+
+        capture_exception.assert_called_once()


### PR DESCRIPTION
## Summary
- add `MCP_GRACEFUL_SHUTDOWN_TIMEOUT` env parsing with a default of `10`
- pass Uvicorn graceful shutdown timeout only for MCP HTTP transports
- add MCP main/env coverage and document the new setting in the MCP README

## Testing
- `make test` (`2297 passed, 4 skipped, 3 deselected`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable graceful shutdown timeout for HTTP-based transports via the `MCP_GRACEFUL_SHUTDOWN_TIMEOUT` environment variable (default: 10 seconds).

* **Tests**
  * Added comprehensive test coverage for environment configuration utilities and graceful shutdown timeout handling across different transport types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->