### PR TITLE
fix: enable executeCommand node in n8n v2

### DIFF
--- a/docker-compose.n8n.yml
+++ b/docker-compose.n8n.yml
@@ -14,6 +14,7 @@ services:
       - N8N_DIAGNOSTICS_ENABLED=false
       - N8N_VERSION_NOTIFICATIONS_ENABLED=false
       - QUEUE_HEALTH_CHECK_ACTIVE=true
+      - NODES_EXCLUDE=[]  # n8n v2는 executeCommand를 기본 비활성화. 내부 전용이므로 허용
     volumes:
       - ./n8n/data:/home/node/.n8n
     healthcheck:


### PR DESCRIPTION
## 개요
n8n v2의 기본 비활성화된 `executeCommand` 노드를 허용합니다.

## 배경
n8n v2는 보안 강화로 Execute Command 노드를 기본 `NODES_EXCLUDE`에 포함시켜 비활성화합니다.
워크플로우 생성은 가능하나 **활성화(activate) 시** `Unrecognized node type` 에러가 발생합니다.

## 변경
- `docker-compose.n8n.yml`: `NODES_EXCLUDE=[]` 환경변수 추가

## 필요 워크플로우
- **WebSocket Container Monitor**: `docker inspect`로 Upbit/KIS WS 컨테이너 상태 확인
- **RPi5 Resource Monitor**: `free`, `df`, thermal zone으로 리소스 모니터링

## 보안
- n8n은 `127.0.0.1`에만 바인딩 (내부 전용)
- SSH 터널로만 접근 가능
- owner 인증 필수

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated n8n service configuration in docker-compose setup to include node exclusion settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->