### PR TITLE
fix: use orderable balance for crypto sell orders instead of total (balance + locked)

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -130,6 +130,12 @@ Derived fields:
 - `spread_pct` is `(spread / bids[0].price) * 100`, rounded to 3 decimal places, and becomes `null` when the best bid is missing or `<= 0`
 - `bid_walls` / `ask_walls` are MCP-only convenience fields. They are calculated only for crypto orderbooks by taking each side's `value_krw = round(price * quantity)`, using the side median as the baseline, selecting levels where `value_krw >= baseline * 2`, sorting by `value_krw` descending, and returning up to 3 entries shaped as `{price, size, value_krw}`
 
+### Crypto sell orderable validation
+- Crypto `place_order(..., side="sell")` uses **orderable balance only** (`balance` from Upbit `/v1/accounts`), not total holdings (`balance + locked`).
+- `locked` coins are already committed to pending orders and cannot be sold.
+- `quantity=None` (full sell) defaults to the orderable balance.
+- If `quantity > orderable balance`, the tool returns `success: false` with an error containing `requested`, `orderable`, and `locked` values instead of forwarding to Upbit.
+
 ### KR order routing
 - Domestic order tools (`place_order`, `modify_order`, `cancel_order` with `market="kr"`) use the new KIS TR IDs (`TTTC0012U/TTTC0011U/TTTC0013U`, mock: `VTTC0012U/VTTC0011U/VTTC0013U`).
 - Domestic order requests (`order-cash`, `order-rvsecncl`) route with `EXCG_ID_DVSN_CD="SOR"`.

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -7,6 +7,9 @@ import json
 from typing import Any, Literal
 
 import app.services.brokers.upbit.client as upbit_service
+from app.services.brokers.upbit.client import (
+    parse_upbit_account_row as _parse_upbit_account_row,
+)
 from app.core.config import settings
 from app.mcp_server.tick_size import adjust_tick_size_kr, get_tick_size_kr
 from app.mcp_server.tooling.market_data_quotes import (
@@ -73,12 +76,12 @@ async def _get_holdings_for_order(
         currency = symbol.replace("KRW-", "")
         for coin in coins:
             if coin.get("currency") == currency:
-                balance = float(coin.get("balance", 0))
-                locked = float(coin.get("locked", 0))
-                avg_buy_price = float(coin.get("avg_buy_price", 0) or 0)
+                parsed = _parse_upbit_account_row(coin)
                 return {
-                    "quantity": balance + locked,
-                    "avg_price": avg_buy_price,
+                    "quantity": parsed["orderable_quantity"],
+                    "total_quantity": parsed["total_quantity"],
+                    "locked": parsed["locked"],
+                    "avg_price": parsed["avg_buy_price"],
                 }
         return None
 
@@ -509,11 +512,15 @@ async def _place_order_impl(
                 return _order_error(f"No holdings found for {symbol}")
 
             available_quantity = _to_float(holdings.get("quantity"), default=0.0)
-            order_quantity = (
-                available_quantity
-                if quantity is None
-                else min(quantity, available_quantity)
-            )
+            locked_quantity = _to_float(holdings.get("locked"), default=0.0)
+
+            if quantity is not None and quantity > available_quantity:
+                return _order_error(
+                    f"Requested sell quantity {quantity} exceeds orderable balance {available_quantity}. "
+                    f"locked={locked_quantity} (in open orders, not sellable)."
+                )
+
+            order_quantity = available_quantity if quantity is None else quantity
 
             if order_type_lower == "limit" and price is not None:
                 avg_price = _to_float(holdings.get("avg_price"), default=0.0)

--- a/app/services/brokers/upbit/client.py
+++ b/app/services/brokers/upbit/client.py
@@ -176,14 +176,30 @@ async def fetch_my_coins() -> list[dict[str, Any]]:
     return await _request_with_auth("GET", f"{UPBIT_REST}/accounts")
 
 
+def parse_upbit_account_row(account: dict[str, Any]) -> dict[str, float]:
+    """Parse a single ``/v1/accounts`` row → ``balance, locked, total_quantity, orderable_quantity, avg_buy_price``."""
+    balance = float(account.get("balance", 0) or 0)
+    locked = float(account.get("locked", 0) or 0)
+    avg_buy_price = float(account.get("avg_buy_price", 0) or 0)
+    return {
+        "balance": balance,
+        "locked": locked,
+        "total_quantity": balance + locked,
+        "orderable_quantity": balance,
+        "avg_buy_price": avg_buy_price,
+    }
+
+
 async def fetch_krw_cash_summary() -> dict[str, float]:
     accounts = await fetch_my_coins()
 
     for account in accounts:
         if account.get("currency") == "KRW":
-            orderable = float(account.get("balance", 0) or 0)
-            locked = float(account.get("locked", 0) or 0)
-            return {"balance": orderable + locked, "orderable": orderable}
+            parsed = parse_upbit_account_row(account)
+            return {
+                "balance": parsed["total_quantity"],
+                "orderable": parsed["orderable_quantity"],
+            }
 
     return {"balance": 0.0, "orderable": 0.0}
 

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -1371,3 +1371,126 @@ async def test_place_order_kr_equity_balance_lookup_failure_blocks_real_order(
     assert "dry_run" not in result
     assert "OPSQ2001 CMA_EVLU_AMT_ICLD_YN error" in result["error"]
     assert len(order_calls) == 0
+
+
+# ----------------------------------------------------------------------
+# Crypto sell orderable vs locked regression tests
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_place_order_crypto_sell_exceeds_orderable_with_locked(monkeypatch):
+    tools = build_tools()
+
+    class DummyUpbit:
+        async def fetch_multiple_current_prices(self, symbols, use_cache=True):
+            return {"KRW-BTC": 50000000.0}
+
+        async def fetch_my_coins(self):
+            return [
+                {
+                    "currency": "BTC",
+                    "balance": 0.03,
+                    "locked": 0.02,
+                    "avg_buy_price": 50000000.0,
+                }
+            ]
+
+    _patch_runtime_attr(monkeypatch, "upbit_service", DummyUpbit())
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="market",
+        quantity=0.05,
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert "orderable balance 0.03" in result["error"]
+    assert "locked=0.02" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_place_order_crypto_market_sell_uses_orderable_only(monkeypatch):
+    tools = build_tools()
+
+    class DummyUpbit:
+        async def fetch_multiple_current_prices(self, symbols, use_cache=True):
+            return {"KRW-BTC": 50000000.0}
+
+        async def fetch_my_coins(self):
+            return [
+                {
+                    "currency": "BTC",
+                    "balance": 0.03,
+                    "locked": 0.02,
+                    "avg_buy_price": 50000000.0,
+                }
+            ]
+
+    _patch_runtime_attr(monkeypatch, "upbit_service", DummyUpbit())
+    _patch_runtime_attr(
+        monkeypatch,
+        "_preview_order",
+        AsyncMock(
+            return_value={
+                "estimated_value": 1500000.0,
+                "realized_pnl": 0.0,
+                "avg_buy_price": 50000000.0,
+            }
+        ),
+    )
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="market",
+        dry_run=True,
+    )
+
+    assert result["success"] is True
+    assert result["dry_run"] is True
+    assert result["quantity"] == 0.03
+
+
+@pytest.mark.asyncio
+async def test_place_order_crypto_sell_locked_zero_still_works(monkeypatch):
+    tools = build_tools()
+
+    class DummyUpbit:
+        async def fetch_multiple_current_prices(self, symbols, use_cache=True):
+            return {"KRW-BTC": 50000000.0}
+
+        async def fetch_my_coins(self):
+            return [
+                {
+                    "currency": "BTC",
+                    "balance": 0.5,
+                    "locked": 0,
+                    "avg_buy_price": 40000000.0,
+                }
+            ]
+
+    _patch_runtime_attr(monkeypatch, "upbit_service", DummyUpbit())
+    _patch_runtime_attr(
+        monkeypatch,
+        "_preview_order",
+        AsyncMock(
+            return_value={
+                "estimated_value": 25000000.0,
+                "realized_pnl": 5000000.0,
+                "avg_buy_price": 40000000.0,
+            }
+        ),
+    )
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="market",
+        dry_run=True,
+    )
+
+    assert result["success"] is True
+    assert result["quantity"] == 0.5


### PR DESCRIPTION
## Summary
- Crypto sell path incorrectly used `balance + locked` as sellable quantity; only `balance` is orderable on Upbit
- Added `parse_upbit_account_row()` shared helper in `upbit/client.py` to standardize total vs orderable semantics
- Changed sell validation from silent quantity clamp to fail-fast error with `requested`, `orderable`, and `locked` details
- Added 3 regression tests covering locked-coin scenarios

## Test Plan
- [x] `uv run pytest tests/test_mcp_place_order.py` — 36 passed
- [x] Broader order/portfolio suite (149 tests) — all passed
- [x] Existing sell tests (locked=0) unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved crypto sell order validation with detailed error messages showing breakdown of orderable vs. locked balances when orders exceed available quantity.

* **Documentation**
  * Added documentation for crypto sell order validation behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->