### PR TITLE
fix: set n8n compose project name to avoid orphan removal

### DIFF
--- a/docker-compose.n8n.yml
+++ b/docker-compose.n8n.yml
@@ -1,5 +1,6 @@
 # n8n 워크플로우 자동화 (별도 compose — caddy와 동일 패턴)
 # 배포: docker compose -f docker-compose.n8n.yml up -d
+name: n8n-automation
 services:
   n8n:
     image: n8nio/n8n:2.11.4


### PR DESCRIPTION
## 문제
`docker compose -f docker-compose.prod.yml up -d --remove-orphans` 실행 시 n8n 컨테이너가 orphan으로 제거됨.

## 원인
같은 디렉토리에서 실행하면 Docker가 디렉토리명(`auto_trader`)을 프로젝트명으로 사용 → n8n과 prod가 같은 프로젝트로 인식 → orphan 처리.

caddy는 `docker-compose.monitoring-rpi.yml`에 별도 프로젝트명(`caddy-edge`)이 있어서 안 날아감.

## 해결
`docker-compose.n8n.yml`에 `name: n8n-automation` 추가.

| compose | project name |
|---------|-------------|
| docker-compose.prod.yml | auto_trader |
| docker-compose.n8n.yml | n8n-automation ← 추가 |
| docker-compose.monitoring-rpi.yml | caddy-edge |

## 확인
```bash
docker ps --format '{{.Names}} {{.Label "com.docker.compose.project"}}'
# auto_trader_n8n_prod n8n-automation ← 분리됨
# auto_trader_api_prod auto_trader
# caddy caddy-edge
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced n8n automation service configuration with improved stability features including automatic restart policies, health monitoring, and resource allocation management to ensure reliable service operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->