### PR TITLE
feat: add BTC dominance to n8n market context

### DIFF
--- a/app/services/external/btc_dominance.py
+++ b/app/services/external/btc_dominance.py
@@ -1,0 +1,90 @@
+"""BTC dominance service using CoinGecko API."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+
+import httpx
+
+from app.core.timezone import now_kst
+
+logger = logging.getLogger(__name__)
+
+_btc_dominance_cache: dict[str, Any] = {}
+_btc_dominance_cache_expires: datetime | None = None
+_cache_lock = asyncio.Lock()
+
+COIN_GECKO_GLOBAL_URL = "https://api.coingecko.com/api/v3/global"
+
+
+def _clear_btc_dominance_cache() -> None:
+    """Clear in-memory BTC dominance cache (for tests)."""
+    global _btc_dominance_cache, _btc_dominance_cache_expires
+    _btc_dominance_cache = {}
+    _btc_dominance_cache_expires = None
+
+
+async def fetch_btc_dominance() -> dict[str, Any] | None:
+    """
+    Fetch BTC dominance and global market data from CoinGecko.
+
+    Returns:
+        {
+            "btc_dominance": float,  # BTC market cap percentage
+            "total_market_cap_change_24h": float  # 24h change %
+        }
+        or None if fetch fails
+    """
+    global _btc_dominance_cache, _btc_dominance_cache_expires
+
+    async with _cache_lock:
+        if _btc_dominance_cache_expires and now_kst() < _btc_dominance_cache_expires:
+            logger.debug("Returning cached BTC dominance data")
+            return _btc_dominance_cache.copy()
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.get(COIN_GECKO_GLOBAL_URL)
+            response.raise_for_status()
+            data = response.json()
+    except Exception as exc:
+        logger.warning(f"Failed to fetch BTC dominance: {exc}")
+        async with _cache_lock:
+            _btc_dominance_cache = {}
+            _btc_dominance_cache_expires = None
+        return None
+
+    try:
+        market_data = data.get("data", {})
+        market_cap_pct = market_data.get("market_cap_percentage", {})
+        btc_dominance = market_cap_pct.get("btc")
+        market_cap_change = market_data.get(
+            "market_cap_change_percentage_24h_usd",
+        )
+
+        if btc_dominance is None:
+            logger.warning("BTC dominance not found in CoinGecko response")
+            return None
+
+        result = {
+            "btc_dominance": round(float(btc_dominance), 2),
+            "total_market_cap_change_24h": (
+                round(float(market_cap_change), 2)
+                if market_cap_change is not None
+                else None
+            ),
+        }
+
+        async with _cache_lock:
+            _btc_dominance_cache = result.copy()
+            _btc_dominance_cache_expires = now_kst() + timedelta(minutes=30)
+
+        return result
+
+    except Exception as exc:
+        logger.warning(f"Failed to parse BTC dominance response: {exc}")
+        return None
+

--- a/app/services/n8n_market_context_service.py
+++ b/app/services/n8n_market_context_service.py
@@ -25,6 +25,7 @@ from app.schemas.n8n import (
 from app.services.brokers.upbit.client import fetch_multiple_tickers
 from app.services.external.economic_calendar import fetch_economic_events_today
 from app.services.external.fear_greed import fetch_fear_greed
+from app.services.external.btc_dominance import fetch_btc_dominance
 from app.services.n8n_formatting import fmt_gap, fmt_price
 from app.services.n8n_pending_orders_service import fetch_pending_orders
 
@@ -137,14 +138,18 @@ async def _compute_symbol_indicators(symbol: str) -> dict[str, Any] | None:
 async def _fetch_crypto_market_overview() -> dict[str, Any]:
     """Fetch crypto market overview data (BTC dominance, market cap change)."""
     try:
-        await fetch_multiple_tickers(["KRW-BTC", "KRW-ETH"])
+        dominance_data = await fetch_btc_dominance()
 
-        btc_dominance = None
-        total_market_cap_change = None
-
+        if dominance_data:
+            return {
+                "btc_dominance": dominance_data.get("btc_dominance"),
+                "total_market_cap_change_24h": dominance_data.get(
+                    "total_market_cap_change_24h",
+                ),
+            }
         return {
-            "btc_dominance": btc_dominance,
-            "total_market_cap_change_24h": total_market_cap_change,
+            "btc_dominance": None,
+            "total_market_cap_change_24h": None,
         }
     except Exception as exc:
         logger.warning(f"Failed to fetch market overview: {exc}")

--- a/tests/test_n8n_market_context.py
+++ b/tests/test_n8n_market_context.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
@@ -114,6 +114,43 @@ class TestMarketContextEndpoint:
             call_kwargs = mock_fetch.call_args.kwargs
             assert call_kwargs["include_fear_greed"] is False
 
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_market_context_with_btc_dominance(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Test that market context endpoint returns BTC dominance data."""
+        with patch(
+            "app.services.n8n_market_context_service.fetch_btc_dominance",
+        ) as mock_btc, patch(
+            "app.services.n8n_market_context_service.fetch_fear_greed",
+        ) as mock_fg, patch(
+            "app.services.n8n_market_context_service.fetch_economic_events_today",
+        ) as mock_econ:
+            mock_btc.return_value = {
+                "btc_dominance": 61.5,
+                "total_market_cap_change_24h": 2.3,
+            }
+            mock_fg.return_value = {
+                "value": 45,
+                "label": "Neutral",
+                "previous": 42,
+                "trend": "improving",
+            }
+            mock_econ.return_value = []
+
+            response = client.get("/api/n8n/market-context")
+            assert response.status_code == 200
+            data = response.json()
+
+            assert (
+                data["market_overview"]["btc_dominance"] == 61.5
+            )
+            assert (
+                data["market_overview"]["total_market_cap_change_24h"] == 2.3
+            )
+
     def test_endpoint_handles_service_error(self, client: TestClient) -> None:
         """Test that endpoint returns 500 on service error."""
         with patch("app.routers.n8n.fetch_market_context") as mock_fetch:
@@ -200,6 +237,57 @@ class TestFearGreedService:
         ):
             result = await fetch_fear_greed()
 
+            assert result is None
+
+
+@pytest.mark.unit
+class TestBtcDominanceService:
+    """Tests for BTC dominance service."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_btc_dominance_success(self) -> None:
+        """Test successful BTC dominance fetch."""
+        from app.services.external.btc_dominance import (
+            _clear_btc_dominance_cache,
+            fetch_btc_dominance,
+        )
+
+        _clear_btc_dominance_cache()
+
+        mock_response = {
+            "data": {
+                "market_cap_percentage": {"btc": 61.2, "eth": 12.5},
+                "market_cap_change_percentage_24h_usd": 2.3,
+            }
+        }
+
+        with patch(
+            "app.services.external.btc_dominance.httpx.AsyncClient.get",
+            return_value=MagicMock(
+                raise_for_status=lambda: None,
+                json=lambda: mock_response,
+            ),
+        ):
+            result = await fetch_btc_dominance()
+            assert result is not None
+            assert result["btc_dominance"] == 61.2
+            assert result["total_market_cap_change_24h"] == 2.3
+
+    @pytest.mark.asyncio
+    async def test_fetch_btc_dominance_handles_error(self) -> None:
+        """Test BTC dominance fetch handles API errors."""
+        from app.services.external.btc_dominance import (
+            _clear_btc_dominance_cache,
+            fetch_btc_dominance,
+        )
+
+        _clear_btc_dominance_cache()
+
+        with patch(
+            "app.services.external.btc_dominance.httpx.AsyncClient.get",
+            side_effect=Exception("Network error"),
+        ):
+            result = await fetch_btc_dominance()
             assert result is None
 
 


### PR DESCRIPTION
## Summary
- Add CoinGecko-based BTC dominance service with async caching
- Integrate BTC dominance into n8n market context service
- Add unit and integration tests for BTC dominance and market-context endpoint

## Test Plan
- [x] uv run pytest tests/test_n8n_market_context.py -v -m \"not live\"

Made with [Cursor](https://cursor.com)