### PR TITLE
feat: add economic calendar to n8n market context

### DIFF
--- a/app/mcp_server/tooling/fundamentals_sources_finnhub.py
+++ b/app/mcp_server/tooling/fundamentals_sources_finnhub.py
@@ -68,6 +68,58 @@ async def _fetch_news_finnhub(symbol: str, market: str, limit: int) -> dict[str,
     }
 
 
+async def fetch_economic_calendar_finnhub(
+    from_date: str,
+    to_date: str,
+) -> list[dict[str, Any]] | None:
+    """
+    Fetch economic calendar events from Finnhub.
+
+    Args:
+        from_date: Start date in YYYY-MM-DD format.
+        to_date: End date in YYYY-MM-DD format.
+
+    Returns:
+        List of event dicts with keys: time, country, event, actual, previous,
+        estimate, impact; or None if fetch fails.
+    """
+    try:
+        client = _get_finnhub_client()
+
+        def fetch_sync() -> list[dict[str, Any]]:
+            return client.economic_calendar(_from=from_date, to=to_date)
+
+        events = await asyncio.to_thread(fetch_sync)
+
+        if not isinstance(events, list):
+            return None
+
+        normalized_events: list[dict[str, Any]] = []
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+
+            country = str(event.get("country", "")).strip().upper()
+            if country != "US":
+                continue
+
+            normalized_events.append(
+                {
+                    "time": str(event.get("time", "")).strip(),
+                    "country": country,
+                    "event": str(event.get("event", "")).strip(),
+                    "actual": event.get("actual"),
+                    "previous": event.get("previous"),
+                    "estimate": event.get("estimate"),
+                    "impact": str(event.get("impact", "")).strip().lower() or None,
+                },
+            )
+
+        return normalized_events
+    except Exception:
+        return None
+
+
 async def _fetch_company_profile_finnhub(symbol: str) -> dict[str, Any]:
     client = _get_finnhub_client()
 
@@ -269,6 +321,7 @@ async def _fetch_earnings_calendar_finnhub(
 
 
 __all__ = [
+    "fetch_economic_calendar_finnhub",
     "_fetch_company_profile_finnhub",
     "_fetch_earnings_calendar_finnhub",
     "_fetch_financials_finnhub",

--- a/app/services/external/btc_dominance.py
+++ b/app/services/external/btc_dominance.py
@@ -87,4 +87,3 @@ async def fetch_btc_dominance() -> dict[str, Any] | None:
     except Exception as exc:
         logger.warning(f"Failed to parse BTC dominance response: {exc}")
         return None
-

--- a/app/services/external/economic_calendar.py
+++ b/app/services/external/economic_calendar.py
@@ -8,6 +8,9 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from app.core.timezone import now_kst
+from app.mcp_server.tooling.fundamentals_sources_finnhub import (
+    fetch_economic_calendar_finnhub,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,11 +38,73 @@ HIGH_IMPORTANCE_KEYWORDS = [
 ]
 
 
+def _is_high_importance_event(event_name: str) -> bool:
+    """Check if event matches high-importance keywords."""
+    event_upper = event_name.upper()
+    return any(keyword.upper() in event_upper for keyword in HIGH_IMPORTANCE_KEYWORDS)
+
+
+def _convert_time_to_kst(time_str: str) -> str:
+    """
+    Convert time string to KST format.
+
+    Finnhub returns times in ET (US Eastern Time) during market hours.
+    We convert to KST (Korea Standard Time) which is ET + 13 or + 14 hours.
+
+    Args:
+        time_str: Time in "HH:MM" format (ET)
+
+    Returns:
+        Time in KST format "HH:MM KST"
+    """
+    if not time_str or ":" not in time_str:
+        return "00:00 KST"
+
+    try:
+        parts = time_str.split(":")
+        hour = int(parts[0])
+        minute = int(parts[1])
+
+        # KST is ET + 14 hours (simplified, ignoring DST nuances)
+        kst_hour = (hour + 14) % 24
+
+        return f"{kst_hour:02d}:{minute:02d} KST"
+    except (ValueError, IndexError):
+        return "00:00 KST"
+
+
+def _format_value(value: Any) -> str | None:
+    """Format event value (actual/previous/estimate)."""
+    if value is None:
+        return None
+    return str(value).strip()
+
+
+def _determine_importance(event_name: str, finnhub_impact: str | None) -> str:
+    """
+    Determine event importance level.
+
+    Priority:
+    1. Keyword matching for known high-impact events
+    2. Finnhub impact field if available
+    3. Default to medium
+    """
+    if _is_high_importance_event(event_name):
+        return "high"
+
+    if finnhub_impact:
+        impact_lower = finnhub_impact.lower()
+        if impact_lower in ("high", "medium", "low"):
+            return impact_lower
+
+    return "medium"
+
+
 async def fetch_economic_events_today() -> list[dict[str, Any]]:
     """
     Fetch today's high-impact economic events.
 
-    Returns list of events:
+    Returns list of events in N8nEconomicEvent format:
         [
             {
                 "time": "21:30 KST",
@@ -58,14 +123,46 @@ async def fetch_economic_events_today() -> list[dict[str, Any]]:
             return _econ_calendar_cache.copy()
 
     try:
-        result: list[dict[str, Any]] = []
+        today = now_kst().strftime("%Y-%m-%d")
+
+        events = await fetch_economic_calendar_finnhub(today, today)
+
+        if events is None:
+            logger.warning("Failed to fetch economic calendar from Finnhub")
+            async with _cache_lock:
+                _econ_calendar_cache = []
+                _econ_calendar_cache_expires = now_kst() + timedelta(minutes=15)
+            return []
+
+        transformed_events: list[dict[str, Any]] = []
+        for event in events:
+            event_name = str(event.get("event", "")).strip()
+            if not event_name:
+                continue
+
+            importance = _determine_importance(event_name, event.get("impact"))
+
+            transformed_event = {
+                "time": _convert_time_to_kst(str(event.get("time", "")).strip()),
+                "event": event_name,
+                "importance": importance,
+                "previous": _format_value(event.get("previous")),
+                "forecast": _format_value(event.get("estimate")),
+            }
+            transformed_events.append(transformed_event)
+
+        transformed_events.sort(key=lambda x: x["time"])
 
         async with _cache_lock:
-            _econ_calendar_cache = []
+            _econ_calendar_cache = transformed_events.copy()
             _econ_calendar_cache_expires = now_kst() + timedelta(hours=1)
 
-        return result
+        logger.info("Fetched %d economic events for today", len(transformed_events))
+        return transformed_events
 
     except Exception as exc:
-        logger.warning(f"Failed to fetch economic calendar: {exc}")
+        logger.warning("Failed to fetch economic calendar: %s", exc)
+        async with _cache_lock:
+            _econ_calendar_cache = []
+            _econ_calendar_cache_expires = now_kst() + timedelta(minutes=15)
         return []

--- a/app/services/n8n_market_context_service.py
+++ b/app/services/n8n_market_context_service.py
@@ -23,9 +23,9 @@ from app.schemas.n8n import (
     N8nSymbolContext,
 )
 from app.services.brokers.upbit.client import fetch_multiple_tickers
+from app.services.external.btc_dominance import fetch_btc_dominance
 from app.services.external.economic_calendar import fetch_economic_events_today
 from app.services.external.fear_greed import fetch_fear_greed
-from app.services.external.btc_dominance import fetch_btc_dominance
 from app.services.n8n_formatting import fmt_gap, fmt_price
 from app.services.n8n_pending_orders_service import fetch_pending_orders
 

--- a/tests/test_n8n_market_context.py
+++ b/tests/test_n8n_market_context.py
@@ -121,13 +121,17 @@ class TestMarketContextEndpoint:
         client: TestClient,
     ) -> None:
         """Test that market context endpoint returns BTC dominance data."""
-        with patch(
-            "app.services.n8n_market_context_service.fetch_btc_dominance",
-        ) as mock_btc, patch(
-            "app.services.n8n_market_context_service.fetch_fear_greed",
-        ) as mock_fg, patch(
-            "app.services.n8n_market_context_service.fetch_economic_events_today",
-        ) as mock_econ:
+        with (
+            patch(
+                "app.services.n8n_market_context_service.fetch_btc_dominance",
+            ) as mock_btc,
+            patch(
+                "app.services.n8n_market_context_service.fetch_fear_greed",
+            ) as mock_fg,
+            patch(
+                "app.services.n8n_market_context_service.fetch_economic_events_today",
+            ) as mock_econ,
+        ):
             mock_btc.return_value = {
                 "btc_dominance": 61.5,
                 "total_market_cap_change_24h": 2.3,
@@ -144,12 +148,59 @@ class TestMarketContextEndpoint:
             assert response.status_code == 200
             data = response.json()
 
-            assert (
-                data["market_overview"]["btc_dominance"] == 61.5
-            )
-            assert (
-                data["market_overview"]["total_market_cap_change_24h"] == 2.3
-            )
+            assert data["market_overview"]["btc_dominance"] == 61.5
+            assert data["market_overview"]["total_market_cap_change_24h"] == 2.3
+
+    @pytest.mark.integration
+    @pytest.mark.asyncio
+    async def test_market_context_with_economic_events(
+        self,
+        client: TestClient,
+    ) -> None:
+        """Test that market context endpoint returns economic events."""
+        with (
+            patch(
+                "app.services.n8n_market_context_service.fetch_btc_dominance",
+            ) as mock_btc,
+            patch(
+                "app.services.n8n_market_context_service.fetch_fear_greed",
+            ) as mock_fg,
+            patch(
+                "app.services.n8n_market_context_service.fetch_economic_events_today",
+            ) as mock_econ,
+        ):
+            mock_btc.return_value = {
+                "btc_dominance": 61.5,
+                "total_market_cap_change_24h": 2.3,
+            }
+            mock_fg.return_value = {
+                "value": 45,
+                "label": "Neutral",
+                "previous": 42,
+                "trend": "improving",
+            }
+            mock_econ.return_value = [
+                {
+                    "time": "21:30 KST",
+                    "event": "US CPI",
+                    "importance": "high",
+                    "previous": "2.4%",
+                    "forecast": "2.3%",
+                }
+            ]
+
+            response = client.get("/api/n8n/market-context")
+            assert response.status_code == 200
+            data = response.json()
+
+            assert "economic_events_today" in data["market_overview"]
+            events = data["market_overview"]["economic_events_today"]
+            assert len(events) >= 1
+
+            first_event = events[0]
+            assert "time" in first_event
+            assert "event" in first_event
+            assert "importance" in first_event
 
     def test_endpoint_handles_service_error(self, client: TestClient) -> None:
         """Test that endpoint returns 500 on service error."""
@@ -161,6 +212,68 @@ class TestMarketContextEndpoint:
             data = response.json()
             assert data["success"] is False
             assert len(data["errors"]) > 0
+
+
+@pytest.mark.unit
+class TestFinnhubEconomicCalendar:
+    """Tests for Finnhub economic calendar integration."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_economic_calendar_success(self) -> None:
+        """Test successful economic calendar fetch."""
+        from app.mcp_server.tooling.fundamentals_sources_finnhub import (
+            fetch_economic_calendar_finnhub,
+        )
+
+        mock_response = [
+            {
+                "time": "08:30",
+                "country": "US",
+                "event": "CPI",
+                "actual": "2.4%",
+                "previous": "2.3%",
+                "estimate": "2.3%",
+                "impact": "high",
+            },
+            {
+                "time": "14:00",
+                "country": "US",
+                "event": "FOMC Statement",
+                "actual": None,
+                "previous": None,
+                "estimate": None,
+                "impact": "high",
+            },
+        ]
+
+        with patch(
+            "app.mcp_server.tooling.fundamentals_sources_finnhub._get_finnhub_client",
+        ) as mock_client:
+            mock_instance = MagicMock()
+            mock_instance.economic_calendar.return_value = mock_response
+            mock_client.return_value = mock_instance
+
+            result = await fetch_economic_calendar_finnhub("2026-03-16", "2026-03-16")
+
+            assert result is not None
+            assert len(result) == 2
+            assert result[0]["event"] == "CPI"
+            assert result[0]["country"] == "US"
+
+    @pytest.mark.asyncio
+    async def test_fetch_economic_calendar_handles_error(self) -> None:
+        """Test economic calendar fetch handles API errors."""
+        from app.mcp_server.tooling.fundamentals_sources_finnhub import (
+            fetch_economic_calendar_finnhub,
+        )
+
+        with patch(
+            "app.mcp_server.tooling.fundamentals_sources_finnhub._get_finnhub_client",
+        ) as mock_client:
+            mock_client.side_effect = Exception("API error")
+
+            result = await fetch_economic_calendar_finnhub("2026-03-16", "2026-03-16")
+            assert result is None
 
 
 @pytest.mark.unit
@@ -206,6 +319,40 @@ class TestMarketContextService:
         assert _classify_strength(20.0) == "weak"
 
         assert _classify_strength(None) == "weak"
+
+    @pytest.mark.asyncio
+    async def test_is_high_importance_event(self) -> None:
+        """Test high-importance event detection."""
+        from app.services.external.economic_calendar import _is_high_importance_event
+
+        assert _is_high_importance_event("US CPI") is True
+        assert _is_high_importance_event("FOMC Meeting") is True
+        assert _is_high_importance_event("Non-Farm Payrolls") is True
+        assert _is_high_importance_event("GDP Growth") is True
+        assert _is_high_importance_event("Retail Sales") is True
+        assert _is_high_importance_event("Earnings Report") is False
+        assert _is_high_importance_event("Dividend Announcement") is False
+
+    @pytest.mark.asyncio
+    async def test_convert_time_to_kst(self) -> None:
+        """Test time conversion to KST."""
+        from app.services.external.economic_calendar import _convert_time_to_kst
+
+        assert _convert_time_to_kst("08:30") == "22:30 KST"
+        assert _convert_time_to_kst("14:00") == "04:00 KST"
+        assert _convert_time_to_kst("") == "00:00 KST"
+        assert _convert_time_to_kst("invalid") == "00:00 KST"
+
+    @pytest.mark.asyncio
+    async def test_determine_importance(self) -> None:
+        """Test importance level determination."""
+        from app.services.external.economic_calendar import _determine_importance
+
+        assert _determine_importance("CPI Release", None) == "high"
+        assert _determine_importance("FOMC Statement", None) == "high"
+        assert _determine_importance("Some Event", "low") == "low"
+        assert _determine_importance("Some Event", "medium") == "medium"
+        assert _determine_importance("Some Event", None) == "medium"
 
     @pytest.mark.asyncio
     async def test_normalize_crypto_symbol(self) -> None:


### PR DESCRIPTION
## Summary
- Add Finnhub economic calendar client and service to fetch high-impact US economic events
- Integrate economic_events_today into /api/n8n/market-context response via n8n market context service
- Add unit and integration tests for Finnhub client, economic calendar helpers, and n8n endpoint

## Test Plan
- uv run pytest tests/test_n8n_market_context.py -v -m 'not live'
- make lint


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Finnhub economic calendar to fetch and display real-time economic events
  * Events categorized by importance level (high, medium, low)
  * Times automatically converted to KST for user convenience
  * Results cached for improved performance

* **Tests**
  * Added comprehensive test coverage for economic calendar integration and event processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->