### PR TITLE
fix: allow all /api/n8n/ endpoints without auth

### DIFF
--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -46,8 +46,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
     PUBLIC_API_PATHS: ClassVar[list[str]] = [
         "/api/v1/openclaw/callback",
         "/api/screener/callback",
-        "/api/n8n/pending-orders",
-        "/api/n8n/market-context",
+        "/api/n8n/",  # n8n 내부 전용 API (전체 prefix 허용)
     ]
     LEGACY_DEPRECATED_PREFIXES: ClassVar[list[str]] = [
         "/manual-holdings",


### PR DESCRIPTION
## 문제
`/api/n8n/daily-brief` 호출 시 `Authentication required` 에러.
`PUBLIC_API_PATHS`에 `pending-orders`, `market-context`만 개별 등록되어 있고 `daily-brief`가 누락.

## 해결
개별 경로 대신 `/api/n8n/` prefix 전체를 허용.
새 n8n 엔드포인트 추가 시 auth 수정 불필요.

## 보안
내부 전용 (localhost only, `network_mode: host`). 외부 노출 없음.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API access configuration to allow broader N8N service endpoint accessibility without authentication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->