### PR TITLE
feat(n8n): add API key authentication for /api/n8n/ endpoints

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -363,6 +363,9 @@ class Settings(BaseSettings):
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7
     SESSION_BLACKLIST_FAIL_SAFE: bool = True
     SESSION_BLACKLIST_DB_FALLBACK: bool = True
+
+    # N8N API Key Authentication
+    N8N_API_KEY: str = ""
     PUBLIC_API_PATHS: list[str] = []
 
     @field_validator("SECRET_KEY")

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -1,5 +1,6 @@
 """Authentication middleware for protecting web routes."""
 
+import hmac
 from contextlib import AbstractAsyncContextManager
 from typing import ClassVar, cast
 
@@ -46,8 +47,6 @@ class AuthMiddleware(BaseHTTPMiddleware):
     PUBLIC_API_PATHS: ClassVar[list[str]] = [
         "/api/v1/openclaw/callback",
         "/api/screener/callback",
-        "/api/n8n/pending-orders",
-        "/api/n8n/market-context",
     ]
     LEGACY_DEPRECATED_PREFIXES: ClassVar[list[str]] = [
         "/manual-holdings",
@@ -107,6 +106,21 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         # Legacy paths must always pass through to deprecated router handlers.
         if self._is_legacy_deprecated_path(path):
+            return await call_next(request)
+
+        # n8n API: dedicated API key authentication
+        if path.startswith("/api/n8n/"):
+            if not settings.N8N_API_KEY:
+                return JSONResponse(
+                    status_code=403,
+                    content={"detail": "N8N_API_KEY not configured"},
+                )
+            api_key = request.headers.get("X-N8N-API-KEY", "")
+            if not hmac.compare_digest(api_key, settings.N8N_API_KEY):
+                return JSONResponse(
+                    status_code=401,
+                    content={"detail": "Invalid N8N API key"},
+                )
             return await call_next(request)
 
         # Allow public paths

--- a/env.prod.example
+++ b/env.prod.example
@@ -112,6 +112,10 @@ ACCESS_TOKEN_EXPIRE_MINUTES=30
 REFRESH_TOKEN_EXPIRE_DAYS=7
 # Comma-separated list of public API paths that do not require auth
 PUBLIC_API_PATHS=
+
+# N8N API Key (for /api/n8n/* endpoints)
+# Generate with: openssl rand -hex 32
+N8N_API_KEY=
 # Keep inactive users blocked when Redis is unavailable
 SESSION_BLACKLIST_FAIL_SAFE=true
 # Fallback to the database to verify user status when Redis is down

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,7 @@ def _ensure_test_env() -> None:
         "ENVIRONMENT": "test",
         "SECRET_KEY": "Test_Secret_Key_12345_Test_Secret_Key_12345",  # Valid complex key for tests
         "MCP_AUTH_TOKEN": "",  # Empty to disable auth for tests
+        "N8N_API_KEY": "",  # Empty = n8n auth disabled in tests by default
     }
 
     for key, value in default_env_values.items():

--- a/tests/test_n8n_api_key_auth.py
+++ b/tests/test_n8n_api_key_auth.py
@@ -1,0 +1,122 @@
+"""Tests for /api/n8n/* API key authentication in AuthMiddleware."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.middleware.auth import AuthMiddleware
+
+
+def _build_app() -> FastAPI:
+    """Build a minimal FastAPI app with AuthMiddleware and a dummy n8n route."""
+    app = FastAPI()
+    app.add_middleware(AuthMiddleware)
+
+    @app.get("/api/n8n/daily-brief")
+    async def daily_brief():
+        return {"success": True}
+
+    @app.get("/api/n8n/pending-orders")
+    async def pending_orders():
+        return {"success": True}
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.get("/api/v1/openclaw/callback")
+    async def openclaw_callback():
+        return {"ok": True}
+
+    return app
+
+
+class TestN8nApiKeyAuth:
+    """N8N API key authentication via AuthMiddleware."""
+
+    @pytest.fixture
+    def client_with_key(self) -> TestClient:
+        """Client where N8N_API_KEY is configured."""
+        with patch("app.middleware.auth.settings") as mock_settings:
+            mock_settings.N8N_API_KEY = "test-secret-key-123"
+            mock_settings.DOCS_ENABLED = False
+            mock_settings.PUBLIC_API_PATHS = []
+            app = _build_app()
+            yield TestClient(app)
+
+    @pytest.fixture
+    def client_without_key(self) -> TestClient:
+        """Client where N8N_API_KEY is empty (not configured)."""
+        with patch("app.middleware.auth.settings") as mock_settings:
+            mock_settings.N8N_API_KEY = ""
+            mock_settings.DOCS_ENABLED = False
+            mock_settings.PUBLIC_API_PATHS = []
+            app = _build_app()
+            yield TestClient(app)
+
+    def test_no_api_key_returns_401(self, client_with_key: TestClient) -> None:
+        """Request without X-N8N-API-KEY header → 401."""
+        response = client_with_key.get("/api/n8n/daily-brief")
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid N8N API key"
+
+    def test_wrong_api_key_returns_401(self, client_with_key: TestClient) -> None:
+        """Request with wrong API key → 401."""
+        response = client_with_key.get(
+            "/api/n8n/daily-brief",
+            headers={"X-N8N-API-KEY": "wrong-key"},
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Invalid N8N API key"
+
+    def test_correct_api_key_returns_200(self, client_with_key: TestClient) -> None:
+        """Request with correct API key → 200."""
+        response = client_with_key.get(
+            "/api/n8n/daily-brief",
+            headers={"X-N8N-API-KEY": "test-secret-key-123"},
+        )
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+    def test_correct_key_works_for_all_n8n_paths(
+        self, client_with_key: TestClient
+    ) -> None:
+        """All /api/n8n/* paths accept valid key."""
+        response = client_with_key.get(
+            "/api/n8n/pending-orders",
+            headers={"X-N8N-API-KEY": "test-secret-key-123"},
+        )
+        assert response.status_code == 200
+
+    def test_unconfigured_key_returns_403(
+        self, client_without_key: TestClient
+    ) -> None:
+        """When N8N_API_KEY is empty → 403 regardless of header."""
+        response = client_without_key.get(
+            "/api/n8n/daily-brief",
+            headers={"X-N8N-API-KEY": "anything"},
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"] == "N8N_API_KEY not configured"
+
+    def test_unconfigured_key_no_header_returns_403(
+        self, client_without_key: TestClient
+    ) -> None:
+        """When N8N_API_KEY is empty and no header → 403."""
+        response = client_without_key.get("/api/n8n/daily-brief")
+        assert response.status_code == 403
+
+    def test_health_endpoint_unaffected(self, client_with_key: TestClient) -> None:
+        """Health endpoint still works without n8n key."""
+        response = client_with_key.get("/health")
+        assert response.status_code == 200
+
+    def test_other_public_api_unaffected(self, client_with_key: TestClient) -> None:
+        """Other public API paths are not affected by n8n auth."""
+        response = client_with_key.get("/api/v1/openclaw/callback")
+        assert response.status_code == 200
+


### PR DESCRIPTION
## Summary
- `/api/n8n/*` 엔드포인트에 `X-N8N-API-KEY` 헤더 기반 전용 API Key 인증 추가
- `PUBLIC_API_PATHS`에서 n8n 경로 제거, `AuthMiddleware`에서 별도 인증 처리
- `hmac.compare_digest` 사용으로 타이밍 공격 방지

## Changes
| File | Description |
|------|-------------|
| `app/core/config.py` | `N8N_API_KEY` 설정 추가 (default `""`) |
| `app/middleware/auth.py` | n8n 전용 API key 인증 로직 + PUBLIC_API_PATHS에서 n8n 제거 |
| `env.prod.example` | `N8N_API_KEY` placeholder 추가 |
| `tests/conftest.py` | 테스트 환경 기본값 추가 |
| `tests/test_n8n_api_key_auth.py` | 인증 테스트 8개 (401/403/200 시나리오) |

## Auth Priority
```
요청 → 경로 확인
├─ /api/n8n/*       → X-N8N-API-KEY 헤더 체크
├─ PUBLIC_API_PATHS → 통과
├─ /health          → 통과
└─ 나머지            → 기존 세션/토큰 인증
```

## Test plan
- [x] 키 없이 호출 → 401
- [x] 잘못된 키 → 401
- [x] 올바른 키 → 200
- [x] N8N_API_KEY 미설정 → 403
- [x] /health, /api/v1/openclaw/callback 등 기존 경로 영향 없음
- [x] 기존 n8n 테스트 70개 리그레션 없음

## 배포 후 TODO
- [ ] 프로덕션 `.env.prod`에 `N8N_API_KEY` 설정 (`openssl rand -hex 32`)
- [ ] n8n 워크플로우에 `X-N8N-API-KEY` 헤더 추가 (Header Auth credential 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API key authentication for n8n endpoints. Requests to `/api/n8n/*` now require the `X-N8N-API-KEY` header to match the configured `N8N_API_KEY`.
  * Previously public n8n endpoints (`/api/n8n/pending-orders`, `/api/n8n/market-context`) are now protected.

* **Tests**
  * Added comprehensive test coverage for N8N API key authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->