### PR TITLE
fix: tighten is_us_equity_symbol and add input validation to analyze_stock_impl

### DIFF
--- a/app/mcp_server/tooling/analysis_analyze.py
+++ b/app/mcp_server/tooling/analysis_analyze.py
@@ -390,7 +390,13 @@ async def analyze_stock_impl(
     if not symbol:
         raise ValueError("symbol is required")
 
-    market_type, normalized_symbol = _resolve_market_type(symbol, market)
+    try:
+        market_type, normalized_symbol = _resolve_market_type(symbol, market)
+    except ValueError:
+        raise ValueError(
+            f"Unsupported symbol format: '{symbol}'. "
+            "Use ticker codes (e.g., AAPL, 005930, KRW-BTC)."
+        )
     analysis = _build_analysis_payload(normalized_symbol, market_type)
     loop = asyncio.get_running_loop()
 

--- a/app/mcp_server/tooling/shared.py
+++ b/app/mcp_server/tooling/shared.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import re
 from typing import Any
 
 import pandas as pd
@@ -46,6 +47,10 @@ DEFAULT_MINIMUM_VALUES: dict[str, float] = {
 # ---------------------------------------------------------------------------
 
 
+# US equity symbol pattern: 1-20 alphanumeric chars, optional dots for share classes (BRK.B)
+_US_EQUITY_PATTERN = re.compile(r"^[A-Z][A-Z0-9.]{0,19}$")
+
+
 def is_korean_equity_code(symbol: str) -> bool:
     s = symbol.strip().upper()
     return len(s) == 6 and s.isalnum()
@@ -58,7 +63,11 @@ def is_crypto_market(symbol: str) -> bool:
 
 def is_us_equity_symbol(symbol: str) -> bool:
     s = symbol.strip().upper()
-    return (not is_crypto_market(s)) and any(c.isalpha() for c in s)
+    if not s:
+        return False
+    if is_crypto_market(s):
+        return False
+    return bool(_US_EQUITY_PATTERN.match(s))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -4095,3 +4095,64 @@ class TestComputeRsiWeights:
         # All weights equal
         expected_weight = 1.0 / 3
         assert all(abs(w - expected_weight) < 0.001 for w in result)
+
+
+# ---------------------------------------------------------------------------
+# AUTO_TRADER-3S: Invalid Symbol Input Validation Fix Tests
+# ---------------------------------------------------------------------------
+
+
+class TestIsUsEquitySymbol:
+    """is_us_equity_symbol rejects obviously invalid inputs."""
+
+    @pytest.mark.parametrize(
+        "symbol",
+        [
+            "--symbol",
+            "-AAPL",
+            "!!abc",
+            "@test",
+            "",
+            "   ",
+            "a" * 21,  # too long
+        ],
+    )
+    def test_rejects_invalid_symbols(self, symbol: str) -> None:
+        from app.mcp_server.tooling.shared import is_us_equity_symbol
+
+        assert is_us_equity_symbol(symbol) is False
+
+    @pytest.mark.parametrize(
+        "symbol",
+        [
+            "AAPL",
+            "MSFT",
+            "BRK.B",
+            "NVDA",
+            "A",
+            "META",
+        ],
+    )
+    def test_accepts_valid_us_symbols(self, symbol: str) -> None:
+        from app.mcp_server.tooling.shared import is_us_equity_symbol
+
+        assert is_us_equity_symbol(symbol) is True
+
+
+class TestAnalyzeStockInvalidInput:
+    """analyze_stock rejects invalid symbol inputs gracefully."""
+
+    @pytest.mark.asyncio
+    async def test_rejects_cli_flag_symbol(self, monkeypatch) -> None:
+        """Symbols like '--symbol' should raise ValueError, not reach yfinance."""
+        from app.mcp_server.tooling.analysis_analyze import analyze_stock_impl
+
+        with pytest.raises(ValueError, match="(?i)invalid.*symbol|unsupported.*symbol"):
+            await analyze_stock_impl(symbol="--symbol", market="KRW-BTC")
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_symbol(self, monkeypatch) -> None:
+        from app.mcp_server.tooling.analysis_analyze import analyze_stock_impl
+
+        with pytest.raises(ValueError, match="symbol is required"):
+            await analyze_stock_impl(symbol="", market=None)


### PR DESCRIPTION
## Description
This PR addresses the issue where invalid symbols (like `--symbol`) passed to the `analyze_stock` tool were causing yfinance HTTP 404 errors and propagating to Sentry.

### Changes
- **app/mcp_server/tooling/shared.py**: Tightened `is_us_equity_symbol` validation using a regex pattern to reject obviously invalid formats.
- **app/mcp_server/tooling/analysis_analyze.py**: Added an explicit input validation layer in `analyze_stock_impl` to catch `Unsupported symbol format` errors early and return a user-friendly message.
- **tests/test_mcp_fundamentals_tools.py**: Added regression tests for `is_us_equity_symbol` and `analyze_stock_impl` validation.

### Verification
- Ran new test cases: `uv run pytest tests/test_mcp_fundamentals_tools.py::TestIsUsEquitySymbol tests/test_mcp_fundamentals_tools.py::TestAnalyzeStockInvalidInput -v` -> PASS
- Ran full MCP test suite: `uv run pytest tests/test_mcp_fundamentals_tools.py tests/test_mcp_quotes_tools.py -v` -> PASS
- Ran full unit test suite: `make test-unit` -> PASS
- Ran linting: `make lint` -> PASS

Fixes AUTO_TRADER-3S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stock symbol validation now delivers standardized error messages for unsupported formats, helping users understand correct usage (ticker codes like AAPL, market formats).
  * Enhanced pattern-based validation for US equity symbols to robustly reject invalid inputs and edge cases before processing.

* **Tests**
  * Added comprehensive unit tests for symbol validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->