### PR TITLE
feat(n8n): add GET /trade-reviews endpoint and API reference documentation (#341)

### DIFF
--- a/app/routers/n8n.py
+++ b/app/routers/n8n.py
@@ -26,6 +26,7 @@ from app.schemas.n8n import (
     N8nPendingReviewResponse,
     N8nPendingSnapshotsRequest,
     N8nPendingSnapshotsResponse,
+    N8nTradeReviewListResponse,
     N8nTradeReviewsRequest,
     N8nTradeReviewsResponse,
     N8nTradeReviewStats,
@@ -43,6 +44,7 @@ from app.services.n8n_pending_snapshot_service import (
 )
 from app.services.n8n_trade_review_service import (
     get_trade_review_stats,
+    get_trade_reviews,
     save_trade_reviews,
 )
 
@@ -289,6 +291,40 @@ async def post_trade_reviews(
         success=True,
         saved_count=result["saved_count"],
         skipped_count=result["skipped_count"],
+        errors=result["errors"],
+    )
+
+
+@router.get("/trade-reviews", response_model=N8nTradeReviewListResponse)
+async def get_trade_reviews_endpoint(
+    period: str = Query("7d", description="Duration format: 7d, 30d, 90d"),
+    market: str | None = Query(None, description="Filter by market: crypto, kr, us"),
+    symbol: str | None = Query(None, description="Filter by symbol (e.g. BTC, 005930)"),
+    limit: int = Query(100, ge=1, le=500, description="Maximum results to return"),
+    db: AsyncSession = Depends(get_db),
+) -> N8nTradeReviewListResponse | JSONResponse:
+    try:
+        result = await get_trade_reviews(
+            db, period=period, market=market, symbol=symbol, limit=limit
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Failed to get trade reviews")
+        return JSONResponse(
+            status_code=500,
+            content=N8nTradeReviewListResponse(
+                success=False,
+                period="error",
+                total_count=0,
+                reviews=[],
+                errors=[{"error": str(exc)}],
+            ).model_dump(),
+        )
+
+    return N8nTradeReviewListResponse(
+        success=True,
+        period=result["period"],
+        total_count=result["total_count"],
+        reviews=result["reviews"],
         errors=result["errors"],
     )
 

--- a/app/schemas/n8n.py
+++ b/app/schemas/n8n.py
@@ -839,3 +839,43 @@ class N8nCryptoScanResponse(BaseModel):
     coins: list[N8nCryptoScanCoin] = Field(default_factory=list)
     summary: N8nCryptoScanSummary = Field(...)
     errors: list[dict[str, object]] = Field(default_factory=list)
+
+
+# -----------------------------------------------------------------------------
+# Trade Reviews (GET list)
+# -----------------------------------------------------------------------------
+class N8nTradeReviewListItem(BaseModel):
+    """Single trade review entry for list response."""
+
+    order_id: str = Field(..., description="Broker order ID")
+    symbol: str = Field(..., description="Normalized symbol (BTC, 005930, NVDA)")
+    market: str = Field(..., description="Market: crypto, kr, us")
+    side: str = Field(..., description="buy or sell")
+    price: float = Field(..., description="Execution price")
+    quantity: float = Field(..., description="Filled quantity")
+    total_amount: float = Field(..., description="Total amount (price * quantity)")
+    fee: float = Field(0, description="Trading fee")
+    currency: str = Field("KRW", description="KRW or USD")
+    filled_at: str = Field(..., description="Trade date in ISO8601")
+    # review
+    verdict: str = Field(..., description="good, neutral, or bad")
+    pnl_pct: float | None = Field(None, description="P&L percentage at review")
+    comment: str | None = Field(None, description="Review commentary")
+    review_type: str = Field("daily", description="daily, weekly, monthly, manual")
+    review_date: str = Field(..., description="Review date in ISO8601")
+    # snapshot
+    indicators: N8nTradeReviewIndicators | None = Field(
+        None, description="Technical indicator snapshot at execution time"
+    )
+
+
+class N8nTradeReviewListResponse(BaseModel):
+    """Response for GET /api/n8n/trade-reviews."""
+
+    success: bool = Field(...)
+    period: str = Field(..., description="Period label, e.g. '2026-03-11 ~ 2026-03-18'")
+    total_count: int = Field(..., description="Number of reviews returned")
+    reviews: list[N8nTradeReviewListItem] = Field(
+        default_factory=list, description="Trade review items"
+    )
+    errors: list[dict[str, object]] = Field(default_factory=list)

--- a/app/services/n8n_trade_review_service.py
+++ b/app/services/n8n_trade_review_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import timedelta
 from typing import Any
 
@@ -22,6 +23,21 @@ _INSTRUMENT_MAP = {
     "kr": "equity_kr",
     "us": "equity_us",
 }
+
+# Instrument type reverse mapping for response
+_REVERSE_INSTRUMENT_MAP = {
+    "crypto": "crypto",
+    "equity_kr": "kr",
+    "equity_us": "us",
+}
+
+
+def parse_period(period: str) -> timedelta:
+    """Parse duration string like '7d', '30d' into timedelta. Defaults to 7d."""
+    match = re.match(r"^(\d+)d$", period.strip())
+    if match:
+        return timedelta(days=int(match.group(1)))
+    return timedelta(days=7)
 
 
 async def save_trade_reviews(
@@ -280,4 +296,110 @@ async def get_trade_review_stats(
         "worst_trade": {"symbol": worst["symbol"], "pnl_pct": worst.get("pnl_pct")},
         "by_verdict": by_verdict,
         "by_rsi_zone": by_rsi_zone,
+    }
+
+
+async def get_trade_reviews(
+    session: AsyncSession,
+    period: str = "7d",
+    market: str | None = None,
+    symbol: str | None = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Query saved trade reviews with optional filters."""
+    delta = parse_period(period)
+    now = now_kst()
+    start = now - delta
+
+    period_label = f"{start.strftime('%Y-%m-%d')} ~ {now.strftime('%Y-%m-%d')}"
+
+    # Build filters
+    filters = [Trade.trade_date >= start, Trade.trade_date <= now]
+
+    if market:
+        itype = _INSTRUMENT_MAP.get(market, market)
+        filters.append(Trade.instrument_type == itype)
+
+    if symbol:
+        filters.append(Trade.symbol == symbol.upper())
+
+    # Query: Trade JOIN TradeReview LEFT JOIN TradeSnapshot
+    stmt = (
+        select(Trade, TradeReview, TradeSnapshot)
+        .join(TradeReview, Trade.id == TradeReview.trade_id)
+        .outerjoin(TradeSnapshot, Trade.id == TradeSnapshot.trade_id)
+        .where(*filters)
+        .order_by(Trade.trade_date.desc())
+        .limit(limit)
+    )
+
+    result = await session.execute(stmt)
+    rows = result.all()
+
+    reviews = []
+    for trade, review, snapshot in rows:
+        market_code = _REVERSE_INSTRUMENT_MAP.get(
+            trade.instrument_type.value
+            if hasattr(trade.instrument_type, "value")
+            else str(trade.instrument_type),
+            "crypto",
+        )
+
+        indicators = None
+        if snapshot:
+            indicators = {
+                "rsi_14": float(snapshot.rsi_14)
+                if snapshot.rsi_14 is not None
+                else None,
+                "rsi_7": float(snapshot.rsi_7) if snapshot.rsi_7 is not None else None,
+                "ema_20": float(snapshot.ema_20)
+                if snapshot.ema_20 is not None
+                else None,
+                "ema_200": float(snapshot.ema_200)
+                if snapshot.ema_200 is not None
+                else None,
+                "macd": float(snapshot.macd) if snapshot.macd is not None else None,
+                "macd_signal": float(snapshot.macd_signal)
+                if snapshot.macd_signal is not None
+                else None,
+                "adx": float(snapshot.adx) if snapshot.adx is not None else None,
+                "stoch_rsi_k": float(snapshot.stoch_rsi_k)
+                if snapshot.stoch_rsi_k is not None
+                else None,
+                "volume_ratio": float(snapshot.volume_ratio)
+                if snapshot.volume_ratio is not None
+                else None,
+                "fear_greed": int(snapshot.fear_greed)
+                if snapshot.fear_greed is not None
+                else None,
+            }
+
+        reviews.append(
+            {
+                "order_id": trade.order_id or "",
+                "symbol": trade.symbol,
+                "market": market_code,
+                "side": trade.side,
+                "price": float(trade.price),
+                "quantity": float(trade.quantity),
+                "total_amount": float(trade.total_amount),
+                "fee": float(trade.fee),
+                "currency": trade.currency,
+                "filled_at": trade.trade_date.isoformat(),
+                "verdict": review.verdict,
+                "pnl_pct": float(review.pnl_pct)
+                if review.pnl_pct is not None
+                else None,
+                "comment": review.comment,
+                "review_type": review.review_type,
+                "review_date": review.review_date.isoformat(),
+                "indicators": indicators,
+            }
+        )
+
+    return {
+        "period": period_label,
+        "total_count": len(reviews),
+        "reviews": reviews,
+        "errors": [],
     }

--- a/docs/n8n-api-reference.md
+++ b/docs/n8n-api-reference.md
@@ -1,0 +1,215 @@
+# n8n API Reference
+
+This document provides a comprehensive reference for all n8n-specific API endpoints available in the Auto Trader system. These endpoints are designed for integration with n8n workflows, Discord notifications, and automated trading reports.
+
+## Authentication
+
+All endpoints require an API key passed in the `X-N8N-API-Key` header.
+
+- **Header:** `X-N8N-API-Key: <your_api_key>`
+- **Environment Variable:** `N8N_API_KEY`
+
+---
+
+## Endpoints Summary
+
+| Category | Method | Path | Description |
+| :--- | :--- | :--- | :--- |
+| **Market Data** | GET | `/api/n8n/pending-orders` | List current pending orders across markets |
+| | GET | `/api/n8n/market-context` | Technical indicators for specific symbols |
+| | GET | `/api/n8n/daily-brief` | Unified report for daily Discord updates |
+| | GET | `/api/n8n/filled-orders` | List recently filled orders |
+| **Crypto Scan** | GET | `/api/n8n/crypto-scan` | Advanced coin scanner (RSI, SMA, Crash) |
+| | GET | `/api/n8n/scan/strategy` | Run strategy-based signal detection |
+| | GET | `/api/n8n/scan/crash` | Run rapid price movement detection |
+| **Trade Reviews**| POST | `/api/n8n/trade-reviews` | Save execution reviews from n8n |
+| | GET | `/api/n8n/trade-reviews` | List saved trade reviews with filters |
+| | GET | `/api/n8n/trade-reviews/stats` | Aggregate performance statistics |
+| **Snapshots** | GET | `/api/n8n/pending-review` | List pending orders for manual review |
+| | POST | `/api/n8n/pending-snapshots` | Save snapshots of pending orders |
+| | PATCH| `/api/n8n/pending-snapshots/resolve` | Mark snapshots as filled/cancelled |
+
+---
+
+## Market Data
+
+### GET `/api/n8n/pending-orders`
+List all current pending (unfilled) orders with optional technical indicator enrichment.
+
+**Query Parameters:**
+- `market`: (optional) `crypto`, `kr`, `us`, or `all` (default)
+- `min_amount`: (optional) Minimum KRW amount filter (default: 0)
+- `include_current_price`: (optional) Boolean, compute gap from current price (default: true)
+- `side`: (optional) `buy` or `sell`
+- `include_indicators`: (optional) Boolean, include RSI/ADX/EMA data (default: true)
+
+**Example:**
+```bash
+curl -H "X-N8N-API-Key: secret" "http://localhost:8000/api/n8n/pending-orders?market=crypto"
+```
+
+### GET `/api/n8n/market-context`
+Fetch technical context (RSI, trend, ADX) for specific symbols or current holdings.
+
+**Query Parameters:**
+- `market`: (optional) `crypto` (default), `kr`, `us`, or `all`
+- `symbols`: (optional) Comma-separated list (e.g., `BTC,ETH,005930`)
+- `include_fear_greed`: (optional) Boolean (default: true)
+- `include_economic_calendar`: (optional) Boolean (default: true)
+
+**Example:**
+```bash
+curl -H "X-N8N-API-Key: secret" "http://localhost:8000/api/n8n/market-context?symbols=BTC,ETH"
+```
+
+### GET `/api/n8n/daily-brief`
+Unified endpoint providing pending orders, portfolio summary, and yesterday's fills for a daily Discord report.
+
+**Query Parameters:**
+- `markets`: (optional) Comma-separated list, e.g., `crypto,kr,us`
+- `min_amount`: (optional) Minimum KRW amount filter (default: 50,000)
+
+**Example:**
+```bash
+curl -H "X-N8N-API-Key: secret" "http://localhost:8000/api/n8n/daily-brief"
+```
+
+### GET `/api/n8n/filled-orders`
+List recently executed orders.
+
+**Query Parameters:**
+- `days`: (optional) Lookback period in days (default: 1)
+- `markets`: (optional) Comma-separated list (default: `crypto,kr,us`)
+- `min_amount`: (optional) Minimum filled amount filter
+
+**Example:**
+```bash
+curl -H "X-N8N-API-Key: secret" "http://localhost:8000/api/n8n/filled-orders?days=7"
+```
+
+---
+
+## Crypto Scan
+
+### GET `/api/n8n/crypto-scan`
+Advanced scan for crypto markets, filtering by trade volume and detecting technical signals.
+
+**Query Parameters:**
+- `top_n`: (optional) Number of coins by 24h trade volume (default: 30)
+- `include_holdings`: (optional) Include current holding coins (default: true)
+- `include_crash`: (optional) Run crash detection (default: true)
+- `include_sma_cross`: (optional) Run SMA cross detection (default: true)
+- `ohlcv_days`: (optional) Lookback for indicators (default: 50)
+
+**Example:**
+```bash
+curl -H "X-N8N-API-Key: secret" "http://localhost:8000/api/n8n/crypto-scan?top_n=50"
+```
+
+### GET `/api/n8n/scan/strategy`
+Trigger a strategy-based scan and return text-based signal summaries.
+
+**Example:**
+```bash
+curl -H "X-N8N-API-Key: secret" "http://localhost:8000/api/n8n/scan/strategy"
+```
+
+### GET `/api/n8n/scan/crash`
+Trigger a rapid price movement (crash) detection scan.
+
+**Example:**
+```bash
+curl -H "X-N8N-API-Key: secret" "http://localhost:8000/api/n8n/scan/crash"
+```
+
+---
+
+## Trade Reviews
+
+### POST `/api/n8n/trade-reviews`
+Save trade reviews and snapshots sent from n8n.
+
+**Request Body:**
+```json
+{
+  "reviews": [
+    {
+      "order_id": "abc-123",
+      "account": "upbit",
+      "symbol": "BTC",
+      "instrument_type": "crypto",
+      "side": "buy",
+      "price": 98000000,
+      "quantity": 0.015,
+      "total_amount": 1470000,
+      "verdict": "good",
+      "comment": "RSI oversold entry",
+      "review_type": "daily",
+      "filled_at": "2026-03-17T14:30:00+09:00",
+      "indicators": { "rsi_14": 31.2 }
+    }
+  ]
+}
+```
+
+**Example:**
+```bash
+curl -X POST -H "Content-Type: application/json" -H "X-N8N-API-Key: secret" \
+  -d '{"reviews": [...]}' "http://localhost:8000/api/n8n/trade-reviews"
+```
+
+### GET `/api/n8n/trade-reviews`
+Query saved trade reviews with optional filters.
+
+**Query Parameters:**
+- `period`: (optional) `7d`, `30d`, `90d` (default: `7d`)
+- `market`: (optional) `crypto`, `kr`, `us`
+- `symbol`: (optional) Normalized symbol (e.g., `BTC`)
+- `limit`: (optional) Max results to return (default: 100)
+
+**Example:**
+```bash
+curl -H "X-N8N-API-Key: secret" "http://localhost:8000/api/n8n/trade-reviews?period=30d&market=crypto"
+```
+
+### GET `/api/n8n/trade-reviews/stats`
+Get aggregate performance stats for a specific period.
+
+**Query Parameters:**
+- `period`: (optional) `week`, `month`, `quarter` (default: `week`)
+- `market`: (optional) Filter by market type
+
+**Example:**
+```bash
+curl -H "X-N8N-API-Key: secret" "http://localhost:8000/api/n8n/trade-reviews/stats?period=month"
+```
+
+---
+
+## Snapshots & Resolutions
+
+### GET `/api/n8n/pending-review`
+List pending orders with "Fill Probability" and suggestions for manual review.
+
+**Example:**
+```bash
+curl -H "X-N8N-API-Key: secret" "http://localhost:8000/api/n8n/pending-review"
+```
+
+### POST `/api/n8n/pending-snapshots`
+Save snapshots of current pending orders to track their lifecycle.
+
+**Example:**
+```bash
+curl -X POST -H "Content-Type: application/json" -H "X-N8N-API-Key: secret" \
+  -d '{"snapshots": [...]}' "http://localhost:8000/api/n8n/pending-snapshots"
+```
+
+### PATCH `/api/n8n/pending-snapshots/resolve`
+Update the status of saved snapshots (filled, cancelled, or expired).
+
+**Example:**
+```bash
+curl -X PATCH -H "Content-Type: application/json" -H "X-N8N-API-Key: secret" \
+  -d '{"resolutions": [...]}' "http://localhost:8000/api/n8n/pending-snapshots/resolve"
+```

--- a/docs/plans/2026-03-18-n8n-trade-reviews-get-endpoint-design.md
+++ b/docs/plans/2026-03-18-n8n-trade-reviews-get-endpoint-design.md
@@ -1,0 +1,118 @@
+# n8n Trade Reviews: GET 조회 엔드포인트 추가 및 API 문서화
+
+> **Issue**: [#341](https://github.com/mgh3326/auto_trader/issues/341)
+> **Priority**: Low
+> **Date**: 2026-03-18
+
+## 목표
+
+1. `GET /api/n8n/trade-reviews` 엔드포인트 추가 — 저장된 리뷰를 날짜/종목별로 조회
+2. n8n 엔드포인트 전체 API 레퍼런스 문서 작성
+
+## 현재 상태
+
+### 기존 n8n 엔드포인트 (12개)
+
+| # | Method | Path | 용도 |
+|---|--------|------|------|
+| 1 | `GET` | `/api/n8n/pending-orders` | 미체결 주문 조회 |
+| 2 | `GET` | `/api/n8n/market-context` | 시장 기술적 지표 |
+| 3 | `GET` | `/api/n8n/daily-brief` | 일일 트레이딩 브리프 |
+| 4 | `GET` | `/api/n8n/filled-orders` | 체결 주문 이력 |
+| 5 | `POST` | `/api/n8n/trade-reviews` | 리뷰 저장 |
+| 6 | `GET` | `/api/n8n/trade-reviews/stats` | 리뷰 통계 |
+| 7 | `GET` | `/api/n8n/pending-review` | 리뷰 대기 주문 |
+| 8 | `POST` | `/api/n8n/pending-snapshots` | 스냅샷 저장 |
+| 9 | `PATCH` | `/api/n8n/pending-snapshots/resolve` | 스냅샷 해결 |
+| 10 | `GET` | `/api/n8n/crypto-scan` | 암호화폐 스캔 |
+| 11 | `GET` | `/api/n8n/scan/strategy` | 전략 스캔 |
+| 12 | `GET` | `/api/n8n/scan/crash` | 급락 감지 |
+
+### 관련 코드
+
+- **Router**: `app/routers/n8n.py`, `app/routers/n8n_scan.py`
+- **Models**: `app/models/review.py` — `Trade`, `TradeReview`, `TradeSnapshot`
+- **Schemas**: `app/schemas/n8n.py`
+- **Service**: `app/services/n8n_trade_review_service.py`
+- **Tests**: `tests/test_n8n_trade_review.py`
+
+## 설계
+
+### 1. GET `/api/n8n/trade-reviews` 엔드포인트
+
+**Query Parameters:**
+
+| Param | Type | Default | Validation | Description |
+|-------|------|---------|------------|-------------|
+| `period` | `str` | `"7d"` | regex `^\d+d$` | Duration 포맷 (7d, 30d, 90d 등) |
+| `market` | `str \| None` | `None` | `crypto`, `kr`, `us` | 마켓 필터 |
+| `symbol` | `str \| None` | `None` | — | 종목 필터 (BTC, 005930 등) |
+| `limit` | `int` | `100` | `ge=1, le=500` | 최대 반환 건수 |
+
+**Period 파싱 로직:**
+- `"7d"` → `timedelta(days=7)`
+- `now_kst() - delta`를 start로 사용
+- 기존 stats 엔드포인트의 `week/month/quarter`와 다른 포맷이지만, n8n 워크플로우에서 동적 기간 설정이 가능하도록 duration 포맷 채택
+
+**DB 쿼리:**
+- `Trade` JOIN `TradeReview` JOIN `TradeSnapshot` (LEFT JOIN for snapshot)
+- `Trade.trade_date >= start` AND `Trade.trade_date <= now`
+- market 필터: `Trade.instrument_type` 매핑 (crypto→crypto, kr→equity_kr, us→equity_us)
+- symbol 필터: `Trade.symbol == symbol`
+- ORDER BY `Trade.trade_date DESC`
+- LIMIT 적용
+
+**응답 스키마:**
+
+```python
+class N8nTradeReviewListItem(BaseModel):
+    # trade 정보
+    order_id: str
+    symbol: str
+    market: str               # crypto, kr, us (instrument_type에서 역매핑)
+    side: str                 # buy, sell
+    price: float
+    quantity: float
+    total_amount: float
+    fee: float
+    currency: str
+    filled_at: str            # trade_date ISO8601
+    # review 정보
+    verdict: str              # good, neutral, bad
+    pnl_pct: float | None
+    comment: str | None
+    review_type: str          # daily, weekly, monthly, manual
+    review_date: str          # ISO8601
+    # snapshot 지표 (nullable)
+    indicators: N8nTradeReviewIndicators | None
+
+class N8nTradeReviewListResponse(BaseModel):
+    success: bool
+    period: str               # "2026-03-11 ~ 2026-03-18"
+    total_count: int
+    reviews: list[N8nTradeReviewListItem]
+    errors: list[dict[str, object]]
+```
+
+기존 `N8nTradeReviewIndicators` 스키마를 그대로 재사용.
+
+**에러 처리:** 기존 n8n 엔드포인트 패턴과 동일 — try/except에서 500 JSONResponse 반환.
+
+### 2. API 문서화
+
+**파일:** `docs/n8n-api-reference.md`
+
+기존 `n8n/README.md`는 인프라/배포 문서이므로 분리. 내용:
+- 인증 방식 (N8N_API_KEY 헤더)
+- 전체 13개 엔드포인트 레퍼런스 테이블
+- 각 엔드포인트: method, path, params, response 요약, curl 예시
+
+## 변경 범위
+
+| 파일 | 변경 | 설명 |
+|------|------|------|
+| `app/schemas/n8n.py` | 추가 | `N8nTradeReviewListItem`, `N8nTradeReviewListResponse` |
+| `app/services/n8n_trade_review_service.py` | 추가 | `get_trade_reviews()` 함수 |
+| `app/routers/n8n.py` | 추가 | GET `/trade-reviews` 핸들러 |
+| `tests/test_n8n_trade_review.py` | 추가 | GET 엔드포인트 단위 테스트 |
+| `docs/n8n-api-reference.md` | 생성 | API 레퍼런스 문서 |

--- a/tests/test_daily_scan.py
+++ b/tests/test_daily_scan.py
@@ -1072,7 +1072,9 @@ async def test_run_strategy_scan_returns_message_and_details(scanner_env, monkey
 
 
 @pytest.mark.asyncio
-async def test_run_crash_detection_returns_message_and_details(scanner_env, monkeypatch):
+async def test_run_crash_detection_returns_message_and_details(
+    scanner_env, monkeypatch
+):
     """run_crash_detection should return message and structured details."""
     scanner, openclaw, fake_redis, ds_mod = scanner_env
 

--- a/tests/test_kis_domestic_orders_nxt.py
+++ b/tests/test_kis_domestic_orders_nxt.py
@@ -72,8 +72,11 @@ class TestCancelKoreaOrderNxtRouting:
 
         with patch(_NXT_ELIGIBLE_PATH, AsyncMock(return_value=True)):
             await instance.cancel_korea_order(
-                order_number="00001", stock_code="005930",
-                quantity=10, price=70000, order_type="buy",
+                order_number="00001",
+                stock_code="005930",
+                quantity=10,
+                price=70000,
+                order_type="buy",
                 krx_fwdg_ord_orgno="00091",
             )
 
@@ -89,8 +92,11 @@ class TestCancelKoreaOrderNxtRouting:
 
         with patch(_NXT_ELIGIBLE_PATH, AsyncMock(return_value=False)):
             await instance.cancel_korea_order(
-                order_number="00001", stock_code="034220",
-                quantity=10, price=5000, order_type="sell",
+                order_number="00001",
+                stock_code="034220",
+                quantity=10,
+                price=5000,
+                order_type="sell",
                 krx_fwdg_ord_orgno="00091",
             )
 
@@ -111,8 +117,10 @@ class TestModifyKoreaOrderNxtRouting:
 
         with patch(_NXT_ELIGIBLE_PATH, AsyncMock(return_value=True)):
             await instance.modify_korea_order(
-                order_number="00001", stock_code="005930",
-                quantity=10, new_price=71000,
+                order_number="00001",
+                stock_code="005930",
+                quantity=10,
+                new_price=71000,
                 krx_fwdg_ord_orgno="00091",
             )
 
@@ -128,8 +136,10 @@ class TestModifyKoreaOrderNxtRouting:
 
         with patch(_NXT_ELIGIBLE_PATH, AsyncMock(return_value=False)):
             await instance.modify_korea_order(
-                order_number="00001", stock_code="034220",
-                quantity=10, new_price=5500,
+                order_number="00001",
+                stock_code="034220",
+                quantity=10,
+                new_price=5500,
                 krx_fwdg_ord_orgno="00091",
             )
 

--- a/tests/test_n8n_scan_api.py
+++ b/tests/test_n8n_scan_api.py
@@ -13,6 +13,7 @@ def client(monkeypatch):
     """Build test client with auth middleware bypassed."""
     # Monkeypatch settings before importing/creating app
     import app.middleware.auth
+
     monkeypatch.setattr(app.middleware.auth.settings, "N8N_API_KEY", "test-key")
     monkeypatch.setattr(app.middleware.auth.settings, "DOCS_ENABLED", False)
     monkeypatch.setattr(app.middleware.auth.settings, "PUBLIC_API_PATHS", [])
@@ -38,9 +39,7 @@ class TestStrategyScanEndpoint:
                 "btc_context": "📌 BTC 컨텍스트: RSI14 63.5",
             },
         }
-        with patch(
-            "app.routers.n8n_scan.DailyScanner"
-        ) as MockScanner:
+        with patch("app.routers.n8n_scan.DailyScanner") as MockScanner:
             instance = MockScanner.return_value
             instance.run_strategy_scan = AsyncMock(return_value=mock_result)
             instance.close = AsyncMock()
@@ -66,9 +65,7 @@ class TestStrategyScanEndpoint:
                 "btc_context": "📌 BTC 컨텍스트: RSI14 63.5",
             },
         }
-        with patch(
-            "app.routers.n8n_scan.DailyScanner"
-        ) as MockScanner:
+        with patch("app.routers.n8n_scan.DailyScanner") as MockScanner:
             instance = MockScanner.return_value
             instance.run_strategy_scan = AsyncMock(return_value=mock_result)
             instance.close = AsyncMock()
@@ -80,9 +77,7 @@ class TestStrategyScanEndpoint:
         assert body["alerts_sent"] == 0
 
     def test_strategy_scan_exception_returns_500(self, client):
-        with patch(
-            "app.routers.n8n_scan.DailyScanner"
-        ) as MockScanner:
+        with patch("app.routers.n8n_scan.DailyScanner") as MockScanner:
             instance = MockScanner.return_value
             instance.run_strategy_scan = AsyncMock(
                 side_effect=RuntimeError("upstream failure")
@@ -107,9 +102,7 @@ class TestCrashScanEndpoint:
                 "crash_signals": ["TEST 24h +11.00% — 급등 감지"],
             },
         }
-        with patch(
-            "app.routers.n8n_scan.DailyScanner"
-        ) as MockScanner:
+        with patch("app.routers.n8n_scan.DailyScanner") as MockScanner:
             instance = MockScanner.return_value
             instance.run_crash_detection = AsyncMock(return_value=mock_result)
             instance.close = AsyncMock()
@@ -129,9 +122,7 @@ class TestCrashScanEndpoint:
             "message": "",
             "details": {"crash_signals": []},
         }
-        with patch(
-            "app.routers.n8n_scan.DailyScanner"
-        ) as MockScanner:
+        with patch("app.routers.n8n_scan.DailyScanner") as MockScanner:
             instance = MockScanner.return_value
             instance.run_crash_detection = AsyncMock(return_value=mock_result)
             instance.close = AsyncMock()
@@ -143,9 +134,7 @@ class TestCrashScanEndpoint:
         assert body["alerts_sent"] == 0
 
     def test_crash_scan_exception_returns_500(self, client):
-        with patch(
-            "app.routers.n8n_scan.DailyScanner"
-        ) as MockScanner:
+        with patch("app.routers.n8n_scan.DailyScanner") as MockScanner:
             instance = MockScanner.return_value
             instance.run_crash_detection = AsyncMock(
                 side_effect=RuntimeError("upstream failure")

--- a/tests/test_n8n_trade_review.py
+++ b/tests/test_n8n_trade_review.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 
 @pytest.mark.unit
@@ -286,3 +288,170 @@ class TestPendingSnapshotService:
 
         assert result["resolved_count"] == 0
         assert len(result["errors"]) == 1
+
+
+@pytest.mark.unit
+class TestTradeReviewListSchema:
+    def test_list_item_schema_accepts_valid_data(self):
+        from app.schemas.n8n import N8nTradeReviewListItem
+
+        item = N8nTradeReviewListItem(
+            order_id="test-001",
+            symbol="BTC",
+            market="crypto",
+            side="buy",
+            price=98000000,
+            quantity=0.015,
+            total_amount=1470000,
+            fee=735,
+            currency="KRW",
+            filled_at="2026-03-17T14:30:00+09:00",
+            verdict="good",
+            pnl_pct=3.27,
+            comment="RSI oversold entry",
+            review_type="daily",
+            review_date="2026-03-18T09:00:00+09:00",
+            indicators=None,
+        )
+        assert item.order_id == "test-001"
+        assert item.market == "crypto"
+
+    def test_list_response_schema(self):
+        from app.schemas.n8n import N8nTradeReviewListResponse
+
+        resp = N8nTradeReviewListResponse(
+            success=True,
+            period="2026-03-11 ~ 2026-03-18",
+            total_count=0,
+            reviews=[],
+            errors=[],
+        )
+        assert resp.success is True
+        assert resp.total_count == 0
+
+
+@pytest.mark.unit
+class TestGetTradeReviews:
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_no_data(self):
+        from app.services.n8n_trade_review_service import get_trade_reviews
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.all.return_value = []
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        result = await get_trade_reviews(mock_session, period="7d")
+
+        assert result["total_count"] == 0
+        assert result["reviews"] == []
+        assert "period" in result
+
+    @pytest.mark.unit
+    def test_parses_period_format(self):
+        from app.services.n8n_trade_review_service import parse_period
+
+        delta = parse_period("7d")
+        assert delta.days == 7
+
+        delta = parse_period("30d")
+        assert delta.days == 30
+
+    @pytest.mark.unit
+    def test_invalid_period_defaults_to_7d(self):
+        from app.services.n8n_trade_review_service import parse_period
+
+        delta = parse_period("invalid")
+        assert delta.days == 7
+
+        delta = parse_period("")
+        assert delta.days == 7
+
+
+@pytest.mark.unit
+class TestGetTradeReviewsEndpoint:
+    @pytest.fixture
+    def client(self):
+        """Create test client with n8n router."""
+        from app.routers.n8n import router
+
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    def test_get_trade_reviews_default_params(self, client):
+        mock_result = {
+            "period": "2026-03-11 ~ 2026-03-18",
+            "total_count": 0,
+            "reviews": [],
+            "errors": [],
+        }
+        with patch(
+            "app.routers.n8n.get_trade_reviews",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            resp = client.get("/api/n8n/trade-reviews")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["total_count"] == 0
+
+    def test_get_trade_reviews_with_filters(self, client):
+        mock_result = {
+            "period": "2026-03-11 ~ 2026-03-18",
+            "total_count": 1,
+            "reviews": [
+                {
+                    "order_id": "test-001",
+                    "symbol": "BTC",
+                    "market": "crypto",
+                    "side": "buy",
+                    "price": 98000000,
+                    "quantity": 0.015,
+                    "total_amount": 1470000,
+                    "fee": 735,
+                    "currency": "KRW",
+                    "filled_at": "2026-03-17T14:30:00+09:00",
+                    "verdict": "good",
+                    "pnl_pct": 3.27,
+                    "comment": "RSI entry",
+                    "review_type": "daily",
+                    "review_date": "2026-03-18T09:00:00+09:00",
+                    "indicators": None,
+                }
+            ],
+            "errors": [],
+        }
+        with patch(
+            "app.routers.n8n.get_trade_reviews",
+            new_callable=AsyncMock,
+            return_value=mock_result,
+        ):
+            resp = client.get(
+                "/api/n8n/trade-reviews",
+                params={
+                    "period": "30d",
+                    "market": "crypto",
+                    "symbol": "BTC",
+                    "limit": 50,
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_count"] == 1
+        assert data["reviews"][0]["symbol"] == "BTC"
+
+    def test_get_trade_reviews_500_on_error(self, client):
+        with patch(
+            "app.routers.n8n.get_trade_reviews",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB down"),
+        ):
+            resp = client.get("/api/n8n/trade-reviews")
+
+        assert resp.status_code == 500
+        data = resp.json()
+        assert data["success"] is False


### PR DESCRIPTION
This PR adds the GET /api/n8n/trade-reviews endpoint and provides a comprehensive API reference for n8n integrations.

### Key Changes
- Added N8nTradeReviewListItem and N8nTradeReviewListResponse schemas.
- Implemented get_trade_reviews() in the service layer.
- Added GET /api/n8n/trade-reviews endpoint to the n8n router.
- Created docs/n8n-api-reference.md documenting all 13 n8n endpoints.
- Added unit tests for schemas, services, and endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GET endpoint to fetch trade reviews with optional filtering by period, market, symbol, and limit parameters.
  * Returns aggregated trade review data with period, total count, and error information.

* **Documentation**
  * Added comprehensive API reference documentation covering all n8n endpoints and authentication requirements.

* **Tests**
  * Added unit tests for the new trade review endpoint and schema validation.

* **Style**
  * Reformatted test function signatures and arguments for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->