### PR TITLE
chore: remove TaskIQ schedules for scan tasks (moved to n8n)

### DIFF
--- a/app/tasks/daily_scan_tasks.py
+++ b/app/tasks/daily_scan_tasks.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from app.core.taskiq_broker import broker
 from app.jobs.daily_scan import DailyScanner
 
+# NOTE: TaskIQ schedules removed — scanning is now driven by n8n workflows:
+#   - Crypto Strategy Scan (every :30) → GET /api/n8n/scan/strategy
+#   - Crash Detection Scan (every :00) → GET /api/n8n/scan/crash
+# Tasks are kept as manual entry points (e.g. taskiq kick) but no longer auto-scheduled.
 
-@broker.task(
-    task_name="scan.strategy",
-    schedule=[
-        {"cron": "30 * * * *", "cron_offset": "Asia/Seoul"},
-    ],
-)
+
+@broker.task(task_name="scan.strategy")
 async def run_strategy_scan_task() -> dict:
     scanner = DailyScanner(alert_mode="telegram_only")
     try:
@@ -18,10 +18,7 @@ async def run_strategy_scan_task() -> dict:
         await scanner.close()
 
 
-@broker.task(
-    task_name="scan.crash_detection",
-    schedule=[{"cron": "0 * * * *", "cron_offset": "Asia/Seoul"}],
-)
+@broker.task(task_name="scan.crash_detection")
 async def run_crash_detection_task() -> dict:
     scanner = DailyScanner(alert_mode="telegram_only")
     try:


### PR DESCRIPTION
## 변경 사항

TaskIQ의 자동 스케줄을 제거하고, n8n 워크플로우가 스캔을 트리거하도록 전환.

### 제거
- `scan.strategy`: `schedule=[{"cron": "30 * * * *"}]` 제거
- `scan.crash_detection`: `schedule=[{"cron": "0 * * * *"}]` 제거

### 유지
- TaskIQ task 정의는 그대로 (수동 실행 가능)
- `DailyScanner` 로직 변경 없음

### n8n 워크플로우 (이미 활성화)
| 워크플로우 | 스케줄 | 엔드포인트 |
|-----------|--------|-----------|
| Crypto Strategy Scan | 매시 30분 | `GET /api/n8n/scan/strategy` |
| Crash Detection Scan | 매시 정각 | `GET /api/n8n/scan/crash` |

### 배포 후
TaskIQ worker 재시작하면 자동 스케줄 비활성화됨.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored task scheduling architecture to use external workflow orchestration. Strategy scan and crash detection tasks are now driven by external workflows rather than internal scheduling. Tasks remain available as manual entry points. Enhanced resource cleanup during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->