### PR TITLE
[codex] Add experiment history guardrails to orchestrator

### DIFF
--- a/backtest/orchestrator.py
+++ b/backtest/orchestrator.py
@@ -32,6 +32,13 @@ class ExperimentResult:
 
 
 @dataclass(slots=True)
+class RecentExperiment:
+    experiment: str
+    status: str
+    description: str
+
+
+@dataclass(slots=True)
 class Stats:
     initial_best_score: float
     current_best_score: float
@@ -189,6 +196,33 @@ def read_best_result_row(results_path: Path = RESULTS_TSV) -> ExperimentResult |
         if best_result is None or candidate.cv_score > best_result.cv_score:
             best_result = candidate
     return best_result
+
+
+def get_recent_experiments(
+    results_path: Path = RESULTS_TSV,
+    n: int = 20,
+) -> list[RecentExperiment]:
+    """Read the latest experiment rows from results.tsv in reverse chronological order."""
+    if not results_path.exists() or n <= 0:
+        return []
+
+    experiments: list[RecentExperiment] = []
+    for raw_line in reversed(results_path.read_text().splitlines()[1:]):
+        if not raw_line.strip():
+            continue
+        parts = raw_line.split("\t", 7)
+        if len(parts) < 8:
+            continue
+        experiments.append(
+            RecentExperiment(
+                experiment=parts[0].strip(),
+                status=parts[6].strip().lower(),
+                description=parts[7].strip(),
+            )
+        )
+        if len(experiments) >= n:
+            break
+    return experiments
 
 
 def resolve_description(
@@ -349,12 +383,33 @@ def build_ai_prompt(round_number: int, total_rounds: int, best_score: float) -> 
     """Build the prompt passed to the AI CLI in auto mode."""
     next_experiment = get_next_experiment_id(RESULTS_TSV)
     best_text = display_score(best_score)
+    recent_experiments = get_recent_experiments(RESULTS_TSV, n=20)
+    recent_lines = ["Recent experiments (DO NOT repeat these):"]
+    if recent_experiments:
+        for result in recent_experiments:
+            if result.status in {"revert", "reverted"}:
+                status_label = "REVERTED"
+            elif result.status == "crash":
+                status_label = "CRASHED"
+            elif result.status in {"keep", "kept"}:
+                status_label = "KEPT"
+            else:
+                status_label = result.status.upper()
+            recent_lines.append(
+                f"- {result.experiment} | {status_label} | {result.description}"
+            )
+    else:
+        recent_lines.append("- none recorded yet")
+    recent_history = "\n".join(recent_lines)
+
     return (
-        f"Read {PROGRAM_MD.relative_to(REPO_ROOT)}. "
-        f"Current best cv_score is {best_text}. "
-        f"You are on round {round_number}/{total_rounds}. "
-        "Modify backtest/strategy.py with exactly ONE experimental idea to improve the score. "
-        "Do not modify any other file. "
+        f"Read {PROGRAM_MD.relative_to(REPO_ROOT)}.\n"
+        f"Current best cv_score is {best_text}.\n"
+        f"You are on round {round_number}/{total_rounds}.\n"
+        f"{recent_history}\n"
+        "Reverted experiments already failed; do not retry the same idea with nearby values.\n"
+        "Modify backtest/strategy.py with exactly ONE experimental idea to improve the score.\n"
+        "Do not modify any other file.\n"
         f"Then run: git add backtest/strategy.py && git commit -m '{next_experiment}: <description>'"
     )
 

--- a/backtest/program.md
+++ b/backtest/program.md
@@ -246,6 +246,22 @@ Most zero-weight positions were turned off individually. Try:
 - **Cross-coin signals** — BTC momentum as filter for altcoin entries
 - **Dynamic MAX_POSITIONS** — increase in low-vol, decrease in high-vol environments
 
+## Plateau Escape
+
+If you hit 5 consecutive `revert`/`reverted` results, stop tweaking nearby parameter values and change direction.
+
+1. First inspect recent history: `tail -30 results.tsv`
+2. Read the recent `experiment`, `status`, and `description` entries
+3. Choose a direction that does NOT appear in the recent failed attempts
+4. Prefer structural changes over micro-tuning:
+   - add a new signal function
+   - change exit logic (for example trailing exits, regime-aware exits, or partial exits)
+   - introduce vote weighting or signal-family weighting
+   - change how regime filters gate entries/exits
+
+Forbidden pattern: repeatedly adjusting the same parameter to nearby values after repeated reverts.
+Examples: `stop_loss_pct 2.0 -> 2.5 -> 3.0`, halving the same AVAX weight again, or retesting the same threshold family with tiny increments.
+
 ## Data Available
 
 - 8 coins: BTC, ETH, SOL, XRP, LINK, ADA, DOT, AVAX (Upbit KRW market)

--- a/tests/backtest/test_orchestrator.py
+++ b/tests/backtest/test_orchestrator.py
@@ -70,6 +70,27 @@ def test_read_best_result_row_returns_top_kept_entry(tmp_path: Path) -> None:
     assert result.description == "gamma"
 
 
+def test_get_recent_experiments_returns_latest_rows_in_reverse_chronological_order(
+    tmp_path: Path,
+) -> None:
+    results_path = tmp_path / "results.tsv"
+    _write_results(
+        results_path,
+        [
+            "exp1\t4.100000\t4.1\t0.1\t3.9\tNA\tkeep\tfirst",
+            "exp2\t4.200000\t4.2\t0.1\t4.0\tNA\treverted\tsecond",
+            "exp3\t4.300000\t4.3\t0.1\t4.1\tNA\tcrash\tthird",
+        ],
+    )
+
+    results = orchestrator.get_recent_experiments(results_path, n=2)
+
+    assert [(result.experiment, result.status, result.description) for result in results] == [
+        ("exp3", "crash", "third"),
+        ("exp2", "reverted", "second"),
+    ]
+
+
 def test_resolve_description_prefers_cli_value() -> None:
     assert (
         orchestrator.resolve_description(


### PR DESCRIPTION
## Summary
- add recent experiment history loading to the orchestrator and inject the last 20 experiment outcomes into the auto-mode AI prompt
- highlight reverted experiments in the prompt so the AI avoids repeating failed ideas with nearby parameter tweaks
- add a Plateau Escape section to the backtest program and cover the history helper with a new unit test

## Why
The orchestrator prompt only exposed the current best score, so repeated failed experiments were not visible to the AI. That caused the same stop-loss and allocation changes to be retried multiple times.

## Validation
- `uv run pytest tests/backtest/test_orchestrator.py -q`
- `uv run ruff check backtest/orchestrator.py tests/backtest/test_orchestrator.py`

## Notes
- Repo-wide `uv run ruff check` still has unrelated pre-existing failures outside this diff (`backtest/rsi/*`, `blog/*`, `scripts/*`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Recent experiment history is now tracked and referenced to prevent the AI from suggesting repeated failed configurations, improving exploration efficiency.

* **Documentation**
  * Added "Plateau Escape" guidance for escaping tuning plateaus: after 5 consecutive reversions, switch modification direction and prioritize structural changes over parameter adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->