### PR TITLE
fix(kis): handle output1 field differences in domestic order normalization

### DIFF
--- a/app/mcp_server/tooling/orders_modify_cancel.py
+++ b/app/mcp_server/tooling/orders_modify_cancel.py
@@ -112,6 +112,12 @@ def _map_kis_status(filled: int, remaining: int, status_name: str) -> str:
         if remaining > 0:
             return "partial"
         return "filled"
+    # output1 (inquire-daily-ccld) may not have prcs_stat_name;
+    # fall back to quantity-based detection.
+    if filled > 0 and remaining <= 0:
+        return "filled"
+    if filled > 0 and remaining > 0:
+        return "partial"
     return "pending"
 
 
@@ -120,15 +126,23 @@ def _normalize_kis_domestic_order(order: dict[str, Any]) -> dict[str, Any]:
     side = "buy" if side_code == "02" else "sell"
 
     ordered = int(float(_get_kis_field(order, "ord_qty", "ORD_QTY", default=0) or 0))
-    filled = int(float(_get_kis_field(order, "ccld_qty", "CCLD_QTY", default=0) or 0))
+    # output1 uses tot_ccld_qty instead of ccld_qty
+    filled = int(float(
+        _get_kis_field(order, "ccld_qty", "CCLD_QTY", default=0)
+        or _get_kis_field(order, "tot_ccld_qty", "TOT_CCLD_QTY", default=0)
+        or 0
+    ))
     remaining = ordered - filled
 
     ordered_price = int(
         float(_get_kis_field(order, "ord_unpr", "ORD_UNPR", default=0) or 0)
     )
-    filled_price = int(
-        float(_get_kis_field(order, "ccld_unpr", "CCLD_UNPR", default=0) or 0)
-    )
+    # output1 uses avg_prvs instead of ccld_unpr
+    filled_price = int(float(
+        _get_kis_field(order, "ccld_unpr", "CCLD_UNPR", default=0)
+        or _get_kis_field(order, "avg_prvs", "AVG_PRVS", default=0)
+        or 0
+    ))
 
     status = _map_kis_status(
         filled,


### PR DESCRIPTION
## 문제
PR #450 (output1 키 수정) + PR #452 (EXCG_ID_DVSN_CD=ALL) 이후에도 상세페이지에서 주문/체결 내역이 비어 있음.

## 원인
`inquire-daily-ccld`의 `output1` 응답 필드명이 미체결 조회(`output`)와 다름:

| 미체결 조회 (output) | 체결 조회 (output1) | 용도 |
|---|---|---|
| `ccld_qty` | `tot_ccld_qty` | 체결 수량 |
| `ccld_unpr` | `avg_prvs` | 체결 단가 |
| `prcs_stat_name` | (없음) | 상태명 |

`_normalize_kis_domestic_order()`가 `ccld_qty`만 읽어서 filled=0 → status=pending으로 분류.
`_map_kis_status()`도 `prcs_stat_name`이 None이면 기본값 pending 반환.

## 수정
1. **필드 fallback**: `ccld_qty` → `tot_ccld_qty`, `ccld_unpr` → `avg_prvs`
2. **수량 기반 상태 판정**: `prcs_stat_name`이 없으면 filled/remaining 기준으로 판정

## 검증
수정 후 로컬 테스트:
- 카카오(035720): **4건** (4/1 10주, 3/23 10주, 3/16 30주+50주)
- NAVER(035420): **6건** (4/2 5주, 4/1 3주 등)