### PR TITLE
refactor: extract symbol universe common module

### DIFF
--- a/app/services/kr_symbol_universe_service.py
+++ b/app/services/kr_symbol_universe_service.py
@@ -4,7 +4,7 @@ import io
 import logging
 import zipfile
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import httpx
 from sqlalchemy import case, func, or_, select
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import AsyncSessionLocal
 from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.services.symbol_universe_common import has_any_rows, normalize_name, sync_hint
 
 logger = logging.getLogger(__name__)
 
@@ -68,14 +69,6 @@ def _normalize_symbol_or_none(value: str) -> str | None:
     if len(symbol) == 6 and symbol.isalnum():
         return symbol
     return None
-
-
-def _normalize_name(value: str) -> str:
-    return str(value or "").strip()
-
-
-def _sync_hint() -> str:
-    return f"Sync required: {_KR_UNIVERSE_SYNC_COMMAND}"
 
 
 async def _download_mst_lines(zip_name: str) -> list[str]:
@@ -303,13 +296,8 @@ async def _apply_snapshot(
     }
 
 
-async def _has_any_rows(db: AsyncSession) -> bool:
-    result = await db.execute(select(KRSymbolUniverse.symbol).limit(1))
-    return result.scalar_one_or_none() is not None
-
-
 async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
-    normalized_name = _normalize_name(name)
+    normalized_name = normalize_name(name)
     if not normalized_name:
         raise ValueError("name is required")
 
@@ -319,13 +307,13 @@ async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
     rows = list((await db.execute(stmt)).scalars().all())
 
     if not rows:
-        if not await _has_any_rows(db):
+        if not await has_any_rows(db, KRSymbolUniverse.symbol):
             raise KRSymbolUniverseEmptyError(
-                f"kr_symbol_universe is empty. {_sync_hint()}"
+                f"kr_symbol_universe is empty. {sync_hint(_KR_UNIVERSE_SYNC_COMMAND)}"
             )
         raise KRSymbolNotRegisteredError(
             f"KR name '{normalized_name}' is not registered in kr_symbol_universe. "
-            f"{_sync_hint()}"
+            f"{sync_hint(_KR_UNIVERSE_SYNC_COMMAND)}"
         )
 
     active_rows = [row for row in rows if row.is_active]
@@ -334,7 +322,7 @@ async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
         preview = ", ".join(symbols[:10])
         raise KRSymbolInactiveError(
             f"KR name '{normalized_name}' is inactive in kr_symbol_universe. "
-            f"matched_symbols=[{preview}]. {_sync_hint()}"
+            f"matched_symbols=[{preview}]. {sync_hint(_KR_UNIVERSE_SYNC_COMMAND)}"
         )
 
     unique_symbols = sorted({row.symbol for row in active_rows})
@@ -342,7 +330,7 @@ async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
         preview = ", ".join(unique_symbols[:10])
         raise KRSymbolNameAmbiguousError(
             f"KR name '{normalized_name}' is ambiguous in kr_symbol_universe. "
-            f"matched_symbols=[{preview}] count={len(unique_symbols)}. {_sync_hint()}"
+            f"matched_symbols=[{preview}] count={len(unique_symbols)}. {sync_hint(_KR_UNIVERSE_SYNC_COMMAND)}"
         )
 
     return unique_symbols[0]
@@ -355,8 +343,11 @@ async def get_kr_symbol_by_name(
     if db is not None:
         return await _resolve_active_symbol_by_name(db, name)
 
-    async with AsyncSessionLocal() as session:
+    session = cast(AsyncSession, cast(object, AsyncSessionLocal()))
+    try:
         return await _resolve_active_symbol_by_name(session, name)
+    finally:
+        await session.close()
 
 
 async def _check_nxt_eligible(db: AsyncSession, symbol: str) -> bool:
@@ -381,8 +372,11 @@ async def is_nxt_eligible(
     if db is not None:
         return await _check_nxt_eligible(db, symbol)
 
-    async with AsyncSessionLocal() as session:
+    session = cast(AsyncSession, cast(object, AsyncSessionLocal()))
+    try:
         return await _check_nxt_eligible(session, symbol)
+    finally:
+        await session.close()
 
 
 async def _search_kr_symbols_impl(
@@ -390,7 +384,7 @@ async def _search_kr_symbols_impl(
     query: str,
     limit: int,
 ) -> list[dict[str, Any]]:
-    normalized_query = _normalize_name(query)
+    normalized_query = normalize_name(query)
     if not normalized_query:
         return []
 
@@ -418,8 +412,10 @@ async def _search_kr_symbols_impl(
     )
 
     rows = list((await db.execute(stmt)).scalars().all())
-    if not rows and not await _has_any_rows(db):
-        raise KRSymbolUniverseEmptyError(f"kr_symbol_universe is empty. {_sync_hint()}")
+    if not rows and not await has_any_rows(db, KRSymbolUniverse.symbol):
+        raise KRSymbolUniverseEmptyError(
+            f"kr_symbol_universe is empty. {sync_hint(_KR_UNIVERSE_SYNC_COMMAND)}"
+        )
 
     return [
         {
@@ -442,8 +438,11 @@ async def search_kr_symbols(
     if db is not None:
         return await _search_kr_symbols_impl(db, query, capped_limit)
 
-    async with AsyncSessionLocal() as session:
+    session = cast(AsyncSession, cast(object, AsyncSessionLocal()))
+    try:
         return await _search_kr_symbols_impl(session, query, capped_limit)
+    finally:
+        await session.close()
 
 
 async def sync_kr_symbol_universe(db: AsyncSession | None = None) -> dict[str, int]:
@@ -451,9 +450,12 @@ async def sync_kr_symbol_universe(db: AsyncSession | None = None) -> dict[str, i
     if db is not None:
         return await _apply_snapshot(db, snapshot)
 
-    async with AsyncSessionLocal() as session:
+    session = cast(AsyncSession, cast(object, AsyncSessionLocal()))
+    try:
         async with session.begin():
             result = await _apply_snapshot(session, snapshot)
+    finally:
+        await session.close()
     logger.info(
         "KR symbol universe synced total=%d inserted=%d updated=%d deactivated=%d",
         result["total"],
@@ -491,8 +493,11 @@ async def get_kr_names_by_symbols(
         return {}
     if db is not None:
         return await _get_kr_names_impl(db, symbols)
-    async with AsyncSessionLocal() as session:
+    session = cast(AsyncSession, cast(object, AsyncSessionLocal()))
+    try:
         return await _get_kr_names_impl(session, symbols)
+    finally:
+        await session.close()
 
 
 __all__ = [

--- a/app/services/symbol_universe_common.py
+++ b/app/services/symbol_universe_common.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def normalize_name(value: str) -> str:
+    return str(value or "").strip()
+
+
+def sync_hint(command: str) -> str:
+    return f"Sync required: {command}"
+
+
+async def has_any_rows(db: AsyncSession, column: Any) -> bool:
+    result = await db.execute(select(column).limit(1))
+    return result.scalar_one_or_none() is not None

--- a/app/services/upbit_symbol_universe_service.py
+++ b/app/services/upbit_symbol_universe_service.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import AsyncSessionLocal
 from app.models.upbit_symbol_universe import UpbitSymbolUniverse
+from app.services.symbol_universe_common import has_any_rows, normalize_name, sync_hint
 
 logger = logging.getLogger(__name__)
 
@@ -47,14 +48,6 @@ class _UniverseRow:
     korean_name: str
     english_name: str
     market_warning: str
-
-
-def _sync_hint() -> str:
-    return f"Sync required: {_UPBIT_UNIVERSE_SYNC_COMMAND}"
-
-
-def _normalize_name(value: str) -> str:
-    return str(value or "").strip()
 
 
 def _normalize_symbol(value: str) -> str:
@@ -101,8 +94,8 @@ async def build_upbit_symbol_universe_snapshot() -> dict[str, _UniverseRow]:
             continue
 
         quote_currency, base_currency = split
-        korean_name = _normalize_name(item.get("korean_name", ""))
-        english_name = _normalize_name(item.get("english_name", ""))
+        korean_name = normalize_name(item.get("korean_name", ""))
+        english_name = normalize_name(item.get("english_name", ""))
         if not korean_name or not english_name:
             skipped += 1
             continue
@@ -119,7 +112,9 @@ async def build_upbit_symbol_universe_snapshot() -> dict[str, _UniverseRow]:
         )
 
     if not snapshot:
-        raise ValueError(f"upbit_symbol_universe source is empty. {_sync_hint()}")
+        raise ValueError(
+            f"upbit_symbol_universe source is empty. {sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
+        )
 
     if skipped > 0:
         logger.warning("Upbit symbol universe parse skipped invalid rows=%d", skipped)
@@ -213,11 +208,6 @@ async def sync_upbit_symbol_universe(db: AsyncSession | None = None) -> dict[str
     return result
 
 
-async def _has_any_rows(db: AsyncSession) -> bool:
-    result = await db.execute(select(UpbitSymbolUniverse.market).limit(1))
-    return result.scalar_one_or_none() is not None
-
-
 @asynccontextmanager
 async def _internal_session() -> AsyncIterator[AsyncSession]:
     session = cast(AsyncSession, cast(object, AsyncSessionLocal()))
@@ -248,19 +238,19 @@ async def _resolve_active_row_by_market(
     row = (await db.execute(stmt)).scalar_one_or_none()
 
     if row is None:
-        if not await _has_any_rows(db):
+        if not await has_any_rows(db, UpbitSymbolUniverse.market):
             raise UpbitSymbolUniverseEmptyError(
-                f"upbit_symbol_universe is empty. {_sync_hint()}"
+                f"upbit_symbol_universe is empty. {sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
             )
         raise UpbitSymbolNotRegisteredError(
             f"Upbit market '{normalized_market}' is not registered in upbit_symbol_universe. "
-            f"{_sync_hint()}"
+            f"{sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
         )
 
     if not row.is_active:
         raise UpbitSymbolInactiveError(
             f"Upbit market '{normalized_market}' is inactive in upbit_symbol_universe. "
-            f"{_sync_hint()}"
+            f"{sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
         )
 
     return row
@@ -287,13 +277,13 @@ async def _resolve_active_row_by_coin(
     rows = list((await db.execute(stmt)).scalars().all())
 
     if not rows:
-        if not await _has_any_rows(db):
+        if not await has_any_rows(db, UpbitSymbolUniverse.market):
             raise UpbitSymbolUniverseEmptyError(
-                f"upbit_symbol_universe is empty. {_sync_hint()}"
+                f"upbit_symbol_universe is empty. {sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
             )
         raise UpbitSymbolNotRegisteredError(
             f"Upbit coin '{normalized_currency}' is not registered for quote '{normalized_quote_currency}' "
-            f"in upbit_symbol_universe. {_sync_hint()}"
+            f"in upbit_symbol_universe. {sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
         )
 
     active_rows = [row for row in rows if row.is_active]
@@ -302,14 +292,14 @@ async def _resolve_active_row_by_coin(
         preview = ", ".join(markets[:10])
         raise UpbitSymbolInactiveError(
             f"Upbit coin '{normalized_currency}' for quote '{normalized_quote_currency}' is inactive "
-            f"in upbit_symbol_universe. matched_symbols=[{preview}]. {_sync_hint()}"
+            f"in upbit_symbol_universe. matched_symbols=[{preview}]. {sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
         )
 
     return active_rows[0]
 
 
 async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
-    normalized_name = _normalize_name(name)
+    normalized_name = normalize_name(name)
     if not normalized_name:
         raise ValueError("name is required")
 
@@ -322,13 +312,13 @@ async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
     rows = list((await db.execute(stmt)).scalars().all())
 
     if not rows:
-        if not await _has_any_rows(db):
+        if not await has_any_rows(db, UpbitSymbolUniverse.market):
             raise UpbitSymbolUniverseEmptyError(
-                f"upbit_symbol_universe is empty. {_sync_hint()}"
+                f"upbit_symbol_universe is empty. {sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
             )
         raise UpbitSymbolNotRegisteredError(
             f"Upbit name '{normalized_name}' is not registered in upbit_symbol_universe. "
-            f"{_sync_hint()}"
+            f"{sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
         )
 
     active_rows = [row for row in rows if row.is_active]
@@ -337,7 +327,7 @@ async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
         preview = ", ".join(markets[:10])
         raise UpbitSymbolInactiveError(
             f"Upbit name '{normalized_name}' is inactive in upbit_symbol_universe. "
-            f"matched_symbols=[{preview}]. {_sync_hint()}"
+            f"matched_symbols=[{preview}]. {sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
         )
 
     unique_symbols = sorted({row.market for row in active_rows})
@@ -345,7 +335,7 @@ async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
         preview = ", ".join(unique_symbols[:10])
         raise UpbitSymbolNameAmbiguousError(
             f"Upbit name '{normalized_name}' is ambiguous in upbit_symbol_universe. "
-            f"matched_symbols=[{preview}] count={len(unique_symbols)}. {_sync_hint()}"
+            f"matched_symbols=[{preview}] count={len(unique_symbols)}. {sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
         )
 
     return unique_symbols[0]
@@ -420,9 +410,9 @@ async def _get_upbit_market_display_names_impl(
         UpbitSymbolUniverse.is_active.is_(True),
     )
     rows = list((await db.execute(stmt)).scalars().all())
-    if not rows and not await _has_any_rows(db):
+    if not rows and not await has_any_rows(db, UpbitSymbolUniverse.market):
         raise UpbitSymbolUniverseEmptyError(
-            f"upbit_symbol_universe is empty. {_sync_hint()}"
+            f"upbit_symbol_universe is empty. {sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
         )
 
     return {
@@ -463,7 +453,7 @@ async def _search_upbit_symbols_impl(
     query: str,
     limit: int,
 ) -> list[dict[str, Any]]:
-    normalized_query = _normalize_name(query)
+    normalized_query = normalize_name(query)
     if not normalized_query:
         return []
 
@@ -483,9 +473,9 @@ async def _search_upbit_symbols_impl(
     )
     rows = list((await db.execute(stmt)).scalars().all())
 
-    if not rows and not await _has_any_rows(db):
+    if not rows and not await has_any_rows(db, UpbitSymbolUniverse.market):
         raise UpbitSymbolUniverseEmptyError(
-            f"upbit_symbol_universe is empty. {_sync_hint()}"
+            f"upbit_symbol_universe is empty. {sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
         )
 
     return [
@@ -533,9 +523,9 @@ async def _get_active_upbit_markets_impl(
         if str(market).strip()
     }
 
-    if not markets and not await _has_any_rows(db):
+    if not markets and not await has_any_rows(db, UpbitSymbolUniverse.market):
         raise UpbitSymbolUniverseEmptyError(
-            f"upbit_symbol_universe is empty. {_sync_hint()}"
+            f"upbit_symbol_universe is empty. {sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
         )
     return markets
 
@@ -560,9 +550,9 @@ async def _get_upbit_warning_markets_impl(
         if str(symbol).strip()
     }
 
-    if not warning_markets and not await _has_any_rows(db):
+    if not warning_markets and not await has_any_rows(db, UpbitSymbolUniverse.market):
         raise UpbitSymbolUniverseEmptyError(
-            f"upbit_symbol_universe is empty. {_sync_hint()}"
+            f"upbit_symbol_universe is empty. {sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
         )
     return warning_markets
 
@@ -604,9 +594,11 @@ async def get_active_upbit_base_currencies(
             for base_currency in (await session.execute(stmt)).scalars().all()
             if str(base_currency).strip()
         }
-        if not base_currencies and not await _has_any_rows(session):
+        if not base_currencies and not await has_any_rows(
+            session, UpbitSymbolUniverse.market
+        ):
             raise UpbitSymbolUniverseEmptyError(
-                f"upbit_symbol_universe is empty. {_sync_hint()}"
+                f"upbit_symbol_universe is empty. {sync_hint(_UPBIT_UNIVERSE_SYNC_COMMAND)}"
             )
         return base_currencies
 

--- a/app/services/us_symbol_universe_service.py
+++ b/app/services/us_symbol_universe_service.py
@@ -16,6 +16,7 @@ from sqlalchemy.sql.elements import ColumnElement
 from app.core.db import AsyncSessionLocal
 from app.core.symbol import to_db_symbol
 from app.models.us_symbol_universe import USSymbolUniverse
+from app.services.symbol_universe_common import has_any_rows, normalize_name, sync_hint
 
 logger = logging.getLogger(__name__)
 
@@ -56,16 +57,8 @@ class _UniverseRow:
     name_en: str
 
 
-def _sync_hint() -> str:
-    return f"Sync required: {_US_UNIVERSE_SYNC_COMMAND}"
-
-
 def _normalize_symbol(value: str) -> str:
     return str(value or "").strip().upper()
-
-
-def _normalize_name(value: str) -> str:
-    return str(value or "").strip()
 
 
 async def _download_cod_lines(zip_name: str) -> list[str]:
@@ -107,8 +100,8 @@ def _parse_cod_rows(lines: list[str], exchange: str) -> tuple[list[_UniverseRow]
             _UniverseRow(
                 symbol=symbol,
                 exchange=exchange,
-                name_kr=_normalize_name(columns[6]),
-                name_en=_normalize_name(columns[7]),
+                name_kr=normalize_name(columns[6]),
+                name_en=normalize_name(columns[7]),
             )
         )
 
@@ -140,7 +133,9 @@ async def build_us_symbol_universe_snapshot() -> dict[str, _UniverseRow]:
             snapshot[row.symbol] = row
 
     if not snapshot:
-        raise ValueError(f"us_symbol_universe source is empty. {_sync_hint()}")
+        raise ValueError(
+            f"us_symbol_universe source is empty. {sync_hint(_US_UNIVERSE_SYNC_COMMAND)}"
+        )
 
     if duplicate_overwrites > 0:
         logger.warning(
@@ -215,7 +210,7 @@ async def sync_us_symbol_universe(db: AsyncSession | None = None) -> dict[str, i
     if db is not None:
         return await _apply_snapshot(db, snapshot)
 
-    async with AsyncSessionLocal() as session:
+    async with AsyncSessionLocal() as session:  # pyright: ignore[reportGeneralTypeIssues]
         async with session.begin():
             result = await _apply_snapshot(session, snapshot)
 
@@ -229,11 +224,6 @@ async def sync_us_symbol_universe(db: AsyncSession | None = None) -> dict[str, i
     return result
 
 
-async def _has_any_rows(db: AsyncSession) -> bool:
-    result = await db.execute(select(USSymbolUniverse.symbol).limit(1))
-    return result.scalar_one_or_none() is not None
-
-
 async def _resolve_active_symbol_row(db: AsyncSession, symbol: str) -> USSymbolUniverse:
     normalized_symbol = to_db_symbol(_normalize_symbol(symbol))
     if not normalized_symbol:
@@ -244,18 +234,18 @@ async def _resolve_active_symbol_row(db: AsyncSession, symbol: str) -> USSymbolU
     )
     row = result.scalar_one_or_none()
     if row is None:
-        if not await _has_any_rows(db):
+        if not await has_any_rows(db, USSymbolUniverse.symbol):
             raise USSymbolUniverseEmptyError(
-                f"us_symbol_universe is empty. {_sync_hint()}"
+                f"us_symbol_universe is empty. {sync_hint(_US_UNIVERSE_SYNC_COMMAND)}"
             )
         raise USSymbolNotRegisteredError(
             f"US symbol '{normalized_symbol}' is not registered in us_symbol_universe. "
-            f"{_sync_hint()}"
+            f"{sync_hint(_US_UNIVERSE_SYNC_COMMAND)}"
         )
     if not row.is_active:
         raise USSymbolInactiveError(
             f"US symbol '{normalized_symbol}' is inactive in us_symbol_universe. "
-            f"{_sync_hint()}"
+            f"{sync_hint(_US_UNIVERSE_SYNC_COMMAND)}"
         )
 
     return row
@@ -269,13 +259,13 @@ async def get_us_exchange_by_symbol(
         row = await _resolve_active_symbol_row(db, symbol)
         return row.exchange
 
-    async with AsyncSessionLocal() as session:
+    async with AsyncSessionLocal() as session:  # pyright: ignore[reportGeneralTypeIssues]
         row = await _resolve_active_symbol_row(session, symbol)
         return row.exchange
 
 
 async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
-    normalized_name = _normalize_name(name)
+    normalized_name = normalize_name(name)
     if not normalized_name:
         raise ValueError("name is required")
 
@@ -288,13 +278,13 @@ async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
     rows = list((await db.execute(stmt)).scalars().all())
 
     if not rows:
-        if not await _has_any_rows(db):
+        if not await has_any_rows(db, USSymbolUniverse.symbol):
             raise USSymbolUniverseEmptyError(
-                f"us_symbol_universe is empty. {_sync_hint()}"
+                f"us_symbol_universe is empty. {sync_hint(_US_UNIVERSE_SYNC_COMMAND)}"
             )
         raise USSymbolNotRegisteredError(
             f"US name '{normalized_name}' is not registered in us_symbol_universe. "
-            f"{_sync_hint()}"
+            f"{sync_hint(_US_UNIVERSE_SYNC_COMMAND)}"
         )
 
     active_rows = [row for row in rows if row.is_active]
@@ -303,7 +293,7 @@ async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
         preview = ", ".join(symbols[:10])
         raise USSymbolInactiveError(
             f"US name '{normalized_name}' is inactive in us_symbol_universe. "
-            f"matched_symbols=[{preview}]. {_sync_hint()}"
+            f"matched_symbols=[{preview}]. {sync_hint(_US_UNIVERSE_SYNC_COMMAND)}"
         )
 
     unique_symbols = sorted({row.symbol for row in active_rows})
@@ -311,7 +301,7 @@ async def _resolve_active_symbol_by_name(db: AsyncSession, name: str) -> str:
         preview = ", ".join(unique_symbols[:10])
         raise USSymbolNameAmbiguousError(
             f"US name '{normalized_name}' is ambiguous in us_symbol_universe. "
-            f"matched_symbols=[{preview}] count={len(unique_symbols)}. {_sync_hint()}"
+            f"matched_symbols=[{preview}] count={len(unique_symbols)}. {sync_hint(_US_UNIVERSE_SYNC_COMMAND)}"
         )
 
     return unique_symbols[0]
@@ -324,7 +314,7 @@ async def get_us_symbol_by_name(
     if db is not None:
         return await _resolve_active_symbol_by_name(db, name)
 
-    async with AsyncSessionLocal() as session:
+    async with AsyncSessionLocal() as session:  # pyright: ignore[reportGeneralTypeIssues]
         return await _resolve_active_symbol_by_name(session, name)
 
 
@@ -333,7 +323,7 @@ async def _search_us_symbols_impl(
     query: str,
     limit: int,
 ) -> list[dict[str, Any]]:
-    normalized_query = _normalize_name(query)
+    normalized_query = normalize_name(query)
     if not normalized_query:
         return []
 
@@ -364,8 +354,10 @@ async def _search_us_symbols_impl(
     )
     rows = list((await db.execute(stmt)).scalars().all())
 
-    if not rows and not await _has_any_rows(db):
-        raise USSymbolUniverseEmptyError(f"us_symbol_universe is empty. {_sync_hint()}")
+    if not rows and not await has_any_rows(db, USSymbolUniverse.symbol):
+        raise USSymbolUniverseEmptyError(
+            f"us_symbol_universe is empty. {sync_hint(_US_UNIVERSE_SYNC_COMMAND)}"
+        )
 
     return [
         {
@@ -388,7 +380,7 @@ async def search_us_symbols(
     if db is not None:
         return await _search_us_symbols_impl(db, query, capped_limit)
 
-    async with AsyncSessionLocal() as session:
+    async with AsyncSessionLocal() as session:  # pyright: ignore[reportGeneralTypeIssues]
         return await _search_us_symbols_impl(session, query, capped_limit)
 
 

--- a/tests/test_symbol_universe_common.py
+++ b/tests/test_symbol_universe_common.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.kr_symbol_universe import KRSymbolUniverse
+
+
+class TestNormalizeName:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("  삼성전자  ", "삼성전자"),
+            ("Apple Inc.", "Apple Inc."),
+            ("", ""),
+            ("  ", ""),
+        ],
+    )
+    def test_strips_whitespace(self, value: str, expected: str):
+        from app.services.symbol_universe_common import normalize_name
+
+        assert normalize_name(value) == expected
+
+
+class TestSyncHint:
+    def test_returns_formatted_hint(self):
+        from app.services.symbol_universe_common import sync_hint
+
+        result = sync_hint("uv run python scripts/sync_kr_symbol_universe.py")
+        assert (
+            result == "Sync required: uv run python scripts/sync_kr_symbol_universe.py"
+        )
+
+
+class TestHasAnyRows:
+    @pytest.mark.asyncio
+    async def test_returns_true_when_row_exists(self):
+        from app.services.symbol_universe_common import has_any_rows
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = "005930"
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        assert await has_any_rows(db, KRSymbolUniverse.symbol) is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_table_empty(self):
+        from app.services.symbol_universe_common import has_any_rows
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        db = AsyncMock()
+        db.execute.return_value = mock_result
+
+        assert await has_any_rows(db, KRSymbolUniverse.symbol) is False


### PR DESCRIPTION
## Summary
Extract 3 identical/constant-diff private functions from kr/us/upbit symbol universe services into a shared `symbol_universe_common.py` module.

## Changes
- **Create** `app/services/symbol_universe_common.py` with:
  - `normalize_name(value: str) -> str` - 문자열 정규화 (trim)
  - `sync_hint(command: str) -> str` - 동기화 힌트 메시지 생성
  - `has_any_rows(db: AsyncSession, column: Any) -> bool` - 테이블 데이터 존재 여부 확인
- **Create** `tests/test_symbol_universe_common.py` - 단위 테스트 (7개 테스트 케이스)
- **Migrate** KR/US/Upbit services to use common module:
  - Remove local `_normalize_name`, `_sync_hint`, `_has_any_rows` definitions
  - Update all call sites to use common module functions

## Verification
- ✅ All universe-related tests: 90 passed
- ✅ Lint (ruff check): passed
- ✅ Typecheck (ty): passed
- ✅ No local definitions remain in any service file

## Commits
- `94172f00` feat: add symbol_universe_common module with normalize_name, sync_hint, has_any_rows
- `e07e8f96` refactor(kr-universe): use symbol_universe_common for normalize_name, sync_hint, has_any_rows
- `4df9ee1f` refactor(us-universe): use symbol_universe_common for normalize_name, sync_hint, has_any_rows
- `569613ed` refactor(upbit-universe): use symbol_universe_common for normalize_name, sync_hint, has_any_rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal utility functions across symbol universe services to reduce code duplication and improve maintainability.

* **Tests**
  * Added comprehensive test coverage for newly shared utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->