### PR TITLE
refactor(ohlcv-cache): consolidate duplicated logic into common module

### DIFF
--- a/app/services/kis_ohlcv_cache.py
+++ b/app/services/kis_ohlcv_cache.py
@@ -16,6 +16,10 @@ from app.services.ohlcv_cache_common import (
     _enforce_retention_limit,
     _release_lock,
     _to_json_value,
+    acquire_lock_with_retry,
+    create_redis_client,
+    make_keys,
+    normalize_period,
 )
 
 logger = logging.getLogger(__name__)
@@ -39,26 +43,20 @@ _REDIS_CLIENT: redis.Redis | None = None
 _FALLBACK_COUNT = 0
 
 
-def _normalize_period(period: str) -> str:
-    normalized = str(period or "").strip().lower()
-    if normalized not in _SUPPORTED_PERIODS:
-        raise ValueError(f"period must be one of {sorted(_SUPPORTED_PERIODS)}")
-    return normalized
+def _normalize_period_local(period: str) -> str:
+    return normalize_period(period, _SUPPORTED_PERIODS)
 
 
 def _base_key(symbol: str, period: str, route: str | None = None) -> str:
-    normalized_symbol = str(symbol or "").strip().upper()
-    normalized_route = str(route or "").strip().upper()
-    if normalized_route:
-        return f"kis:ohlcv:{period}:v1:{normalized_symbol}:{normalized_route}"
-    return f"kis:ohlcv:{period}:v1:{normalized_symbol}"
+    from app.services.ohlcv_cache_common import make_base_key
+
+    return make_base_key("kis", symbol, period, route)
 
 
 def _keys(
     symbol: str, period: str, route: str | None = None
 ) -> tuple[str, str, str, str]:
-    base = _base_key(symbol, period, route)
-    return f"{base}:dates", f"{base}:rows", f"{base}:meta", f"{base}:lock"
+    return make_keys("kis", symbol, period, route)
 
 
 def _empty_dataframe(period: str) -> pd.DataFrame:
@@ -259,13 +257,7 @@ def _parse_cached_row(
 async def _get_redis_client() -> redis.Redis:
     global _REDIS_CLIENT
     if _REDIS_CLIENT is None:
-        _REDIS_CLIENT = redis.from_url(
-            settings.get_redis_url(),
-            max_connections=settings.redis_max_connections,
-            socket_timeout=settings.redis_socket_timeout,
-            socket_connect_timeout=settings.redis_socket_connect_timeout,
-            decode_responses=True,
-        )
+        _REDIS_CLIENT = await create_redis_client()
     return _REDIS_CLIENT
 
 
@@ -380,7 +372,7 @@ async def get_candles(
     raw_fetcher: Callable[[int], Awaitable[pd.DataFrame]],
     route: str | None = None,
 ) -> pd.DataFrame:
-    normalized_period = _normalize_period(period)
+    normalized_period = _normalize_period_local(period)
     requested_count = int(count)
     if requested_count <= 0:
         return _empty_dataframe(normalized_period)
@@ -423,40 +415,31 @@ async def get_candles(
         ):
             return cached.tail(requested_count).reset_index(drop=True)
 
-        lock_token = await _acquire_lock(
+        lock_token = await acquire_lock_with_retry(
             redis_client,
             lock_key,
             settings.kis_ohlcv_cache_lock_ttl_seconds,
+            _acquire_lock,
+            asyncio.sleep,
         )
         if lock_token is None:
-            for _ in range(2):
-                await asyncio.sleep(0.1)
-                lock_token = await _acquire_lock(
-                    redis_client,
-                    lock_key,
-                    settings.kis_ohlcv_cache_lock_ttl_seconds,
-                )
-                if lock_token is not None:
-                    break
-
-            if lock_token is None:
-                refreshed = await _read_cached_rows(
-                    redis_client,
-                    dates_key,
-                    rows_key,
-                    requested_count,
-                    normalized_period,
-                )
-                if len(refreshed) >= requested_count and _is_cache_fresh(
-                    normalized_period, refreshed
-                ):
-                    return refreshed.tail(requested_count).reset_index(drop=True)
-                raw_fallback = await raw_fetcher(requested_count)
-                return (
-                    _canonicalize_frame(normalized_period, raw_fallback)
-                    .tail(requested_count)
-                    .reset_index(drop=True)
-                )
+            refreshed = await _read_cached_rows(
+                redis_client,
+                dates_key,
+                rows_key,
+                requested_count,
+                normalized_period,
+            )
+            if len(refreshed) >= requested_count and _is_cache_fresh(
+                normalized_period, refreshed
+            ):
+                return refreshed.tail(requested_count).reset_index(drop=True)
+            raw_fallback = await raw_fetcher(requested_count)
+            return (
+                _canonicalize_frame(normalized_period, raw_fallback)
+                .tail(requested_count)
+                .reset_index(drop=True)
+            )
 
         raw_frame = _empty_dataframe(normalized_period)
         try:

--- a/app/services/ohlcv_cache_common.py
+++ b/app/services/ohlcv_cache_common.py
@@ -361,3 +361,307 @@ async def _refresh_meta(
         "last_sync_ts": str(int(datetime.now(UTC).timestamp())),
     }
     await redis_client.hset(meta_key, mapping=mapping)
+
+
+# ---------------------------------------------------------------------------
+# Closed-candle orchestration (upbit / yahoo shared)
+# ---------------------------------------------------------------------------
+
+
+async def backfill_loop(
+    *,
+    redis_client: redis.Redis,
+    symbol: str,
+    period: str,
+    raw_fetcher: Callable,
+    fetcher_symbol_kwarg: str,
+    requested_count: int,
+    target_closed_date: date,
+    dates_key: str,
+    rows_key: str,
+    meta_key: str,
+    max_days: int,
+    is_latest_fresh_fn: Callable[[date | None, date], bool],
+    bucket_gap_fn: Callable[[str, date, date], int],
+    is_sufficient_fn: Callable[[int, date | None, bool, int, date], bool],
+    log_prefix: str,
+    meta_date_field: str = "last_closed_date",
+) -> None:
+    """Two-stage backfill: Stage A fills newest closed candles, Stage B fills depth."""
+    meta = await redis_client.hgetall(meta_key)
+    oldest_confirmed = _normalize_bool(meta.get("oldest_confirmed"))
+
+    # Stage A: keep cache fresh — fill newest closed candles first
+    while True:
+        latest_cached = await _read_latest_date(redis_client, dates_key)
+        if is_latest_fresh_fn(latest_cached, target_closed_date):
+            break
+
+        if latest_cached is None:
+            batch_size = min(max(requested_count, 1), 200)
+        else:
+            gap = bucket_gap_fn(period, latest_cached, target_closed_date)
+            batch_size = min(max(gap, 1), 200)
+
+        fetched = await raw_fetcher(
+            **{fetcher_symbol_kwarg: symbol},
+            days=batch_size,
+            period=period,
+            end_date=datetime.combine(target_closed_date, time(23, 59, 59)),
+        )
+        if fetched.empty or "date" not in fetched.columns:
+            break
+
+        fetched = fetched[fetched["date"] <= target_closed_date]
+        if fetched.empty:
+            break
+
+        inserted = await _upsert_rows(redis_client, dates_key, rows_key, fetched)
+        logger.info(
+            "%s forward_fill symbol=%s rows=%d requested=%d",
+            log_prefix,
+            symbol,
+            inserted,
+            batch_size,
+        )
+
+        trimmed = await _enforce_retention_limit(
+            redis_client, dates_key, rows_key, max_days
+        )
+        if trimmed > 0:
+            logger.info("%s trimmed symbol=%s removed=%d", log_prefix, symbol, trimmed)
+
+        latest_after = await _read_latest_date(redis_client, dates_key)
+        if latest_cached is not None and (
+            latest_after is None or latest_after <= latest_cached
+        ):
+            break
+
+        if len(fetched) < batch_size:
+            break
+
+    # Stage B: fetch older candles only when depth is insufficient
+    while True:
+        cached_count, latest_cached, oldest_confirmed = await _read_cache_status(
+            redis_client, dates_key, meta_key, target_closed_date
+        )
+        if is_sufficient_fn(
+            cached_count,
+            latest_cached,
+            oldest_confirmed,
+            requested_count,
+            target_closed_date,
+        ):
+            await _refresh_meta(
+                redis_client,
+                dates_key,
+                meta_key,
+                target_closed_date,
+                oldest_confirmed,
+                meta_date_field=meta_date_field,
+            )
+            return
+        if oldest_confirmed:
+            break
+
+        earliest = await _read_oldest_date(redis_client, dates_key)
+        batch_end = (
+            earliest - timedelta(days=1) if earliest is not None else target_closed_date
+        )
+        if batch_end > target_closed_date:
+            batch_end = target_closed_date
+
+        remaining = requested_count - cached_count
+        batch_size = min(max(remaining, 1), 200)
+
+        fetched = await raw_fetcher(
+            **{fetcher_symbol_kwarg: symbol},
+            days=batch_size,
+            period=period,
+            end_date=datetime.combine(batch_end, time(23, 59, 59)),
+        )
+        if fetched.empty or "date" not in fetched.columns:
+            if not oldest_confirmed:
+                logger.info(
+                    "%s oldest_confirmed symbol=%s reason=empty_batch",
+                    log_prefix,
+                    symbol,
+                )
+            oldest_confirmed = True
+            break
+
+        fetched = fetched[fetched["date"] <= batch_end]
+        if fetched.empty:
+            if not oldest_confirmed:
+                logger.info(
+                    "%s oldest_confirmed symbol=%s reason=no_closed_rows",
+                    log_prefix,
+                    symbol,
+                )
+            oldest_confirmed = True
+            break
+
+        inserted = await _upsert_rows(redis_client, dates_key, rows_key, fetched)
+        logger.info(
+            "%s backfill symbol=%s rows=%d requested=%d",
+            log_prefix,
+            symbol,
+            inserted,
+            batch_size,
+        )
+
+        trimmed = await _enforce_retention_limit(
+            redis_client, dates_key, rows_key, max_days
+        )
+        if trimmed > 0:
+            logger.info("%s trimmed symbol=%s removed=%d", log_prefix, symbol, trimmed)
+
+        if inserted <= 0:
+            oldest_confirmed = True
+            break
+
+        if len(fetched) < batch_size:
+            if not oldest_confirmed:
+                logger.info(
+                    "%s oldest_confirmed symbol=%s reason=short_batch returned=%d requested=%d",
+                    log_prefix,
+                    symbol,
+                    len(fetched),
+                    batch_size,
+                )
+            oldest_confirmed = True
+            break
+
+    await _refresh_meta(
+        redis_client,
+        dates_key,
+        meta_key,
+        target_closed_date,
+        oldest_confirmed,
+        meta_date_field=meta_date_field,
+    )
+
+
+async def get_closed_candles_flow(
+    *,
+    redis_client: redis.Redis,
+    dates_key: str,
+    rows_key: str,
+    meta_key: str,
+    lock_key: str,
+    symbol: str,
+    period: str,
+    requested_count: int,
+    max_days: int,
+    lock_ttl: int,
+    target_closed_date: date,
+    raw_fetcher: Callable,
+    fetcher_symbol_kwarg: str,
+    is_latest_fresh_fn: Callable[[date | None, date], bool],
+    bucket_gap_fn: Callable[[str, date, date], int],
+    is_sufficient_fn: Callable[[int, date | None, bool, int, date], bool],
+    acquire_lock_fn: Callable,
+    release_lock_fn: Callable,
+    sleep_fn: Callable,
+    log_prefix: str,
+    meta_date_field: str = "last_closed_date",
+) -> pd.DataFrame | None:
+    """Closed-candle cache read-through orchestration.
+
+    Checks cache → acquires lock → backfills → returns result.
+    Service-specific behavior is injected via callbacks.
+    """
+    trimmed = await _enforce_retention_limit(
+        redis_client, dates_key, rows_key, max_days
+    )
+    if trimmed > 0:
+        logger.info(
+            "%s trimmed symbol=%s period=%s removed=%d",
+            log_prefix,
+            symbol,
+            period,
+            trimmed,
+        )
+
+    cached = await _read_cached_rows(
+        redis_client, dates_key, rows_key, target_closed_date, requested_count
+    )
+    cached_count, latest_date, oldest_confirmed = await _read_cache_status(
+        redis_client, dates_key, meta_key, target_closed_date
+    )
+    if is_sufficient_fn(
+        cached_count,
+        latest_date,
+        oldest_confirmed,
+        requested_count,
+        target_closed_date,
+    ):
+        await _refresh_meta(
+            redis_client,
+            dates_key,
+            meta_key,
+            target_closed_date,
+            oldest_confirmed,
+            meta_date_field=meta_date_field,
+        )
+        logger.info(
+            "%s hit symbol=%s period=%s cached=%d requested=%d",
+            log_prefix,
+            symbol,
+            period,
+            len(cached),
+            requested_count,
+        )
+        return cached.tail(requested_count).reset_index(drop=True)
+
+    logger.info(
+        "%s miss symbol=%s period=%s cached=%d requested=%d",
+        log_prefix,
+        symbol,
+        period,
+        len(cached),
+        requested_count,
+    )
+
+    lock_token = await acquire_lock_with_retry(
+        redis_client, lock_key, lock_ttl, acquire_lock_fn, sleep_fn
+    )
+    if lock_token is None:
+        refreshed = await _read_cached_rows(
+            redis_client, dates_key, rows_key, target_closed_date, requested_count
+        )
+        r_count, r_latest, r_oldest = await _read_cache_status(
+            redis_client, dates_key, meta_key, target_closed_date
+        )
+        if is_sufficient_fn(
+            r_count, r_latest, r_oldest, requested_count, target_closed_date
+        ):
+            return refreshed.tail(requested_count).reset_index(drop=True)
+        return None
+
+    try:
+        await backfill_loop(
+            redis_client=redis_client,
+            symbol=symbol,
+            period=period,
+            raw_fetcher=raw_fetcher,
+            fetcher_symbol_kwarg=fetcher_symbol_kwarg,
+            requested_count=requested_count,
+            target_closed_date=target_closed_date,
+            dates_key=dates_key,
+            rows_key=rows_key,
+            meta_key=meta_key,
+            max_days=max_days,
+            is_latest_fresh_fn=is_latest_fresh_fn,
+            bucket_gap_fn=bucket_gap_fn,
+            is_sufficient_fn=is_sufficient_fn,
+            log_prefix=log_prefix,
+            meta_date_field=meta_date_field,
+        )
+    finally:
+        await release_lock_fn(redis_client, lock_key, lock_token)
+
+    final = await _read_cached_rows(
+        redis_client, dates_key, rows_key, target_closed_date, requested_count
+    )
+    return final.tail(requested_count).reset_index(drop=True)

--- a/app/services/ohlcv_cache_common.py
+++ b/app/services/ohlcv_cache_common.py
@@ -5,12 +5,19 @@ Upbit, Yahoo, KIS 캐시 모듈이 공유하는 순수 함수 모음.
 각 서비스 모듈에서 `from app.services.ohlcv_cache_common import ...` 로 사용.
 """
 
+import asyncio
 import json
+import logging
 import uuid
-from datetime import UTC, date, datetime
+from collections.abc import Awaitable, Callable
+from datetime import UTC, date, datetime, time, timedelta
 
 import pandas as pd
 import redis.asyncio as redis
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
 
 _EMPTY_COLUMNS = ["date", "open", "high", "low", "close", "volume", "value"]
 
@@ -44,6 +51,57 @@ def _epoch_day(value: date) -> int:
 
 def _empty_dataframe() -> pd.DataFrame:
     return pd.DataFrame(columns=_EMPTY_COLUMNS)
+
+
+# ---------------------------------------------------------------------------
+# Generic parameterized utilities
+# ---------------------------------------------------------------------------
+
+
+def normalize_period(period: str, supported: set[str]) -> str:
+    """Validate and normalize a period string against a set of supported values."""
+    normalized = str(period or "").strip().lower()
+    if normalized not in supported:
+        raise ValueError(f"period must be one of {sorted(supported)}")
+    return normalized
+
+
+def make_base_key(
+    prefix: str,
+    identifier: str,
+    period: str,
+    extra: str | None = None,
+) -> str:
+    """Build a Redis base key: '{prefix}:ohlcv:{period}:v1:{ID}[:EXTRA]'."""
+    norm_id = str(identifier or "").strip().upper()
+    norm_period = str(period or "").strip().lower()
+    base = f"{prefix}:ohlcv:{norm_period}:v1:{norm_id}"
+    norm_extra = str(extra or "").strip().upper()
+    if norm_extra:
+        return f"{base}:{norm_extra}"
+    return base
+
+
+def make_keys(
+    prefix: str,
+    identifier: str,
+    period: str,
+    extra: str | None = None,
+) -> tuple[str, str, str, str]:
+    """Return (dates_key, rows_key, meta_key, lock_key) for a cache entry."""
+    base = make_base_key(prefix, identifier, period, extra)
+    return f"{base}:dates", f"{base}:rows", f"{base}:meta", f"{base}:lock"
+
+
+async def create_redis_client() -> redis.Redis:
+    """Create an async Redis client using application settings."""
+    return redis.from_url(
+        settings.get_redis_url(),
+        max_connections=settings.redis_max_connections,
+        socket_timeout=settings.redis_socket_timeout,
+        socket_connect_timeout=settings.redis_socket_connect_timeout,
+        decode_responses=True,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -84,6 +142,27 @@ async def _release_lock(
         await redis_client.eval(release_script, 1, lock_key, lock_token)
     except Exception:
         return
+
+
+async def acquire_lock_with_retry(
+    redis_client: redis.Redis,
+    lock_key: str,
+    ttl_seconds: int,
+    acquire_fn: Callable[..., Awaitable[str | None]],
+    sleep_fn: Callable[..., Awaitable[None]],
+    retries: int = 2,
+    delay: float = 0.1,
+) -> str | None:
+    """Try to acquire a distributed lock, retrying up to *retries* times."""
+    token = await acquire_fn(redis_client, lock_key, ttl_seconds)
+    if token is not None:
+        return token
+    for _ in range(retries):
+        await sleep_fn(delay)
+        token = await acquire_fn(redis_client, lock_key, ttl_seconds)
+        if token is not None:
+            return token
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/ohlcv_cache_common.py
+++ b/app/services/ohlcv_cache_common.py
@@ -5,7 +5,6 @@ Upbit, Yahoo, KIS 캐시 모듈이 공유하는 순수 함수 모음.
 각 서비스 모듈에서 `from app.services.ohlcv_cache_common import ...` 로 사용.
 """
 
-import asyncio
 import json
 import logging
 import uuid

--- a/app/services/upbit_ohlcv_cache.py
+++ b/app/services/upbit_ohlcv_cache.py
@@ -11,15 +11,13 @@ from app.core.config import settings
 from app.services.ohlcv_cache_common import (
     _acquire_lock,
     _empty_dataframe,
-    _enforce_retention_limit,
-    _normalize_bool,
-    _read_cache_status,
-    _read_cached_rows,
-    _read_latest_date,
-    _read_oldest_date,
-    _refresh_meta,
     _release_lock,
     _upsert_rows,
+    acquire_lock_with_retry,
+    create_redis_client,
+    get_closed_candles_flow,
+    make_keys,
+    normalize_period,
 )
 
 logger = logging.getLogger(__name__)
@@ -31,12 +29,31 @@ _REDIS_CLIENT: redis.Redis | None = None
 _FALLBACK_COUNT = 0
 
 
+# ---------------------------------------------------------------------------
+# Service-specific helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_period_local(period: str) -> str:
+    return normalize_period(period, _SUPPORTED_PERIODS)
+
+
+def _base_key(market: str, period: str = "day") -> str:
+    from app.services.ohlcv_cache_common import make_base_key
+
+    return make_base_key("upbit", market, period)
+
+
+def _keys(market: str, period: str = "day") -> tuple[str, str, str, str]:
+    return make_keys("upbit", market, period)
+
+
 def get_target_closed_date_kst(now: datetime | None = None) -> date:
     return get_last_closed_bucket_kst("day", now)
 
 
 def get_last_closed_bucket_kst(period: str, now: datetime | None = None) -> date:
-    normalized_period = _normalize_period(period)
+    normalized_period = _normalize_period_local(period)
 
     base_now = now or datetime.now(UTC)
     if base_now.tzinfo is None:
@@ -59,25 +76,8 @@ def get_last_closed_bucket_kst(period: str, now: datetime | None = None) -> date
     return previous_month_last_day.replace(day=1)
 
 
-def _base_key(market: str, period: str = "day") -> str:
-    normalized_period = str(period or "day").strip().lower()
-    return f"upbit:ohlcv:{normalized_period}:v1:{market}"
-
-
-def _keys(market: str, period: str = "day") -> tuple[str, str, str, str]:
-    base = _base_key(market, period)
-    return f"{base}:dates", f"{base}:rows", f"{base}:meta", f"{base}:lock"
-
-
-def _normalize_period(period: str) -> str:
-    normalized = str(period or "").strip().lower()
-    if normalized not in _SUPPORTED_PERIODS:
-        raise ValueError(f"period must be one of {sorted(_SUPPORTED_PERIODS)}")
-    return normalized
-
-
 def _bucket_gap_count(period: str, earlier: date, later: date) -> int:
-    normalized_period = _normalize_period(period)
+    normalized_period = _normalize_period_local(period)
     if later <= earlier:
         return 0
 
@@ -89,26 +89,6 @@ def _bucket_gap_count(period: str, earlier: date, later: date) -> int:
 
     month_gap = (later.year - earlier.year) * 12 + (later.month - earlier.month)
     return max(month_gap, 0)
-
-
-async def _get_redis_client() -> redis.Redis:
-    global _REDIS_CLIENT
-    if _REDIS_CLIENT is None:
-        _REDIS_CLIENT = redis.from_url(
-            settings.get_redis_url(),
-            max_connections=settings.redis_max_connections,
-            socket_timeout=settings.redis_socket_timeout,
-            socket_connect_timeout=settings.redis_socket_connect_timeout,
-            decode_responses=True,
-        )
-    return _REDIS_CLIENT
-
-
-async def close_ohlcv_cache_redis() -> None:
-    global _REDIS_CLIENT
-    if _REDIS_CLIENT is not None:
-        await _REDIS_CLIENT.close()
-        _REDIS_CLIENT = None
 
 
 def _is_cache_sufficient(
@@ -128,185 +108,32 @@ def _is_cache_sufficient(
     return oldest_confirmed
 
 
-async def _backfill_until_satisfied(
-    redis_client: redis.Redis,
-    market: str,
-    period: str,
-    raw_fetcher: Callable[
-        [str, int, str, datetime | None],
-        Awaitable[pd.DataFrame],
-    ],
-    requested_count: int,
-    target_closed_date: date,
-    dates_key: str,
-    rows_key: str,
-    meta_key: str,
-    max_days: int,
-) -> None:
-    meta = await redis_client.hgetall(meta_key)
-    oldest_confirmed = _normalize_bool(meta.get("oldest_confirmed"))
+def _is_latest_fresh(latest: date | None, target: date) -> bool:
+    return latest is not None and latest >= target
 
-    # Stage A: keep cache fresh by filling newest closed candles first.
-    while True:
-        latest_cached_date = await _read_latest_date(redis_client, dates_key)
-        if latest_cached_date is not None and latest_cached_date >= target_closed_date:
-            break
 
-        if latest_cached_date is None:
-            batch_size = min(max(requested_count, 1), 200)
-        else:
-            missing_latest_buckets = _bucket_gap_count(
-                period,
-                latest_cached_date,
-                target_closed_date,
-            )
-            batch_size = min(max(missing_latest_buckets, 1), 200)
+# ---------------------------------------------------------------------------
+# Redis client management
+# ---------------------------------------------------------------------------
 
-        fetched = await raw_fetcher(
-            market=market,
-            days=batch_size,
-            period=period,
-            end_date=datetime.combine(target_closed_date, time(23, 59, 59)),
-        )
-        if fetched.empty or "date" not in fetched.columns:
-            break
 
-        fetched = fetched[fetched["date"] <= target_closed_date]
-        if fetched.empty:
-            break
+async def _get_redis_client() -> redis.Redis:
+    global _REDIS_CLIENT
+    if _REDIS_CLIENT is None:
+        _REDIS_CLIENT = await create_redis_client()
+    return _REDIS_CLIENT
 
-        inserted_count = await _upsert_rows(redis_client, dates_key, rows_key, fetched)
-        logger.info(
-            "upbit_ohlcv_cache forward_fill market=%s rows=%d requested=%d",
-            market,
-            inserted_count,
-            batch_size,
-        )
 
-        trimmed_count = await _enforce_retention_limit(
-            redis_client,
-            dates_key,
-            rows_key,
-            max_days,
-        )
-        if trimmed_count > 0:
-            logger.info(
-                "upbit_ohlcv_cache trimmed market=%s removed=%d",
-                market,
-                trimmed_count,
-            )
+async def close_ohlcv_cache_redis() -> None:
+    global _REDIS_CLIENT
+    if _REDIS_CLIENT is not None:
+        await _REDIS_CLIENT.close()
+        _REDIS_CLIENT = None
 
-        latest_after = await _read_latest_date(redis_client, dates_key)
-        if latest_cached_date is not None and (
-            latest_after is None or latest_after <= latest_cached_date
-        ):
-            break
 
-        if len(fetched) < batch_size:
-            break
-
-    # Stage B: fetch older candles only when depth is insufficient.
-    while True:
-        cached_count, latest_cached_date, oldest_confirmed = await _read_cache_status(
-            redis_client,
-            dates_key,
-            meta_key,
-            target_closed_date,
-        )
-        if _is_cache_sufficient(
-            cached_count,
-            latest_cached_date,
-            oldest_confirmed,
-            requested_count,
-            target_closed_date,
-        ):
-            await _refresh_meta(
-                redis_client,
-                dates_key,
-                meta_key,
-                target_closed_date,
-                oldest_confirmed,
-            )
-            return
-        if oldest_confirmed:
-            break
-
-        earliest_cached_date = await _read_oldest_date(redis_client, dates_key)
-        batch_end_date = (
-            earliest_cached_date - timedelta(days=1)
-            if earliest_cached_date is not None
-            else target_closed_date
-        )
-        if batch_end_date > target_closed_date:
-            batch_end_date = target_closed_date
-
-        remaining = requested_count - cached_count
-        batch_size = min(max(remaining, 1), 200)
-
-        fetched = await raw_fetcher(
-            market=market,
-            days=batch_size,
-            period=period,
-            end_date=datetime.combine(batch_end_date, time(23, 59, 59)),
-        )
-        if fetched.empty or "date" not in fetched.columns:
-            if not oldest_confirmed:
-                logger.info(
-                    "upbit_ohlcv_cache oldest_confirmed enabled market=%s reason=empty_batch",
-                    market,
-                )
-            oldest_confirmed = True
-            break
-
-        fetched = fetched[fetched["date"] <= target_closed_date]
-        if fetched.empty:
-            if not oldest_confirmed:
-                logger.info(
-                    "upbit_ohlcv_cache oldest_confirmed enabled market=%s reason=no_closed_rows",
-                    market,
-                )
-            oldest_confirmed = True
-            break
-
-        inserted_count = await _upsert_rows(redis_client, dates_key, rows_key, fetched)
-        logger.info(
-            "upbit_ohlcv_cache backfill market=%s rows=%d requested=%d",
-            market,
-            inserted_count,
-            batch_size,
-        )
-
-        trimmed_count = await _enforce_retention_limit(
-            redis_client,
-            dates_key,
-            rows_key,
-            max_days,
-        )
-        if trimmed_count > 0:
-            logger.info(
-                "upbit_ohlcv_cache trimmed market=%s removed=%d",
-                market,
-                trimmed_count,
-            )
-
-        if len(fetched) < batch_size:
-            if not oldest_confirmed:
-                logger.info(
-                    "upbit_ohlcv_cache oldest_confirmed enabled market=%s reason=short_batch returned=%d requested=%d",
-                    market,
-                    len(fetched),
-                    batch_size,
-                )
-            oldest_confirmed = True
-            break
-
-    await _refresh_meta(
-        redis_client,
-        dates_key,
-        meta_key,
-        target_closed_date,
-        oldest_confirmed,
-    )
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
 async def get_closed_candles(
@@ -319,7 +146,7 @@ async def get_closed_candles(
     ]
     | None = None,
 ) -> pd.DataFrame | None:
-    normalized_period = _normalize_period(period)
+    normalized_period = _normalize_period_local(period)
     if not settings.upbit_ohlcv_cache_enabled:
         return None
 
@@ -345,136 +172,28 @@ async def get_closed_candles(
         else:
             target_closed_date = get_last_closed_bucket_kst(normalized_period)
 
-        trimmed_count = await _enforce_retention_limit(
-            redis_client,
-            dates_key,
-            rows_key,
-            max_days,
+        return await get_closed_candles_flow(
+            redis_client=redis_client,
+            dates_key=dates_key,
+            rows_key=rows_key,
+            meta_key=meta_key,
+            lock_key=lock_key,
+            symbol=normalized_market,
+            period=normalized_period,
+            requested_count=requested_count,
+            max_days=max_days,
+            lock_ttl=settings.upbit_ohlcv_cache_lock_ttl_seconds,
+            target_closed_date=target_closed_date,
+            raw_fetcher=fetcher,
+            fetcher_symbol_kwarg="market",
+            is_latest_fresh_fn=_is_latest_fresh,
+            bucket_gap_fn=_bucket_gap_count,
+            is_sufficient_fn=_is_cache_sufficient,
+            acquire_lock_fn=_acquire_lock,
+            release_lock_fn=_release_lock,
+            sleep_fn=asyncio.sleep,
+            log_prefix="upbit_ohlcv_cache",
         )
-        if trimmed_count > 0:
-            logger.info(
-                "upbit_ohlcv_cache trimmed market=%s period=%s removed=%d",
-                normalized_market,
-                normalized_period,
-                trimmed_count,
-            )
-
-        cached = await _read_cached_rows(
-            redis_client,
-            dates_key,
-            rows_key,
-            target_closed_date,
-            requested_count,
-        )
-        (
-            cached_count,
-            latest_cached_date,
-            oldest_confirmed,
-        ) = await _read_cache_status(
-            redis_client,
-            dates_key,
-            meta_key,
-            target_closed_date,
-        )
-        if _is_cache_sufficient(
-            cached_count,
-            latest_cached_date,
-            oldest_confirmed,
-            requested_count,
-            target_closed_date,
-        ):
-            await _refresh_meta(
-                redis_client,
-                dates_key,
-                meta_key,
-                target_closed_date,
-                oldest_confirmed,
-            )
-            logger.info(
-                "upbit_ohlcv_cache hit market=%s period=%s cached=%d requested=%d",
-                normalized_market,
-                normalized_period,
-                len(cached),
-                requested_count,
-            )
-            return cached.tail(requested_count).reset_index(drop=True)
-
-        logger.info(
-            "upbit_ohlcv_cache miss market=%s period=%s cached=%d requested=%d",
-            normalized_market,
-            normalized_period,
-            len(cached),
-            requested_count,
-        )
-
-        lock_token = await _acquire_lock(
-            redis_client,
-            lock_key,
-            settings.upbit_ohlcv_cache_lock_ttl_seconds,
-        )
-        if lock_token is None:
-            for _ in range(2):
-                await asyncio.sleep(0.1)
-                lock_token = await _acquire_lock(
-                    redis_client,
-                    lock_key,
-                    settings.upbit_ohlcv_cache_lock_ttl_seconds,
-                )
-                if lock_token is not None:
-                    break
-            if lock_token is None:
-                refreshed_cached = await _read_cached_rows(
-                    redis_client,
-                    dates_key,
-                    rows_key,
-                    target_closed_date,
-                    requested_count,
-                )
-                (
-                    refreshed_count,
-                    refreshed_latest_date,
-                    refreshed_oldest_confirmed,
-                ) = await _read_cache_status(
-                    redis_client,
-                    dates_key,
-                    meta_key,
-                    target_closed_date,
-                )
-                if _is_cache_sufficient(
-                    refreshed_count,
-                    refreshed_latest_date,
-                    refreshed_oldest_confirmed,
-                    requested_count,
-                    target_closed_date,
-                ):
-                    return refreshed_cached.tail(requested_count).reset_index(drop=True)
-                return None
-
-        try:
-            await _backfill_until_satisfied(
-                redis_client,
-                normalized_market,
-                normalized_period,
-                fetcher,
-                requested_count,
-                target_closed_date,
-                dates_key,
-                rows_key,
-                meta_key,
-                max_days,
-            )
-        finally:
-            await _release_lock(redis_client, lock_key, lock_token)
-
-        final_rows = await _read_cached_rows(
-            redis_client,
-            dates_key,
-            rows_key,
-            target_closed_date,
-            requested_count,
-        )
-        return final_rows.tail(requested_count).reset_index(drop=True)
-
     except Exception as exc:
         global _FALLBACK_COUNT
         _FALLBACK_COUNT += 1

--- a/app/services/upbit_ohlcv_cache.py
+++ b/app/services/upbit_ohlcv_cache.py
@@ -12,8 +12,8 @@ from app.services.ohlcv_cache_common import (
     _acquire_lock,
     _empty_dataframe,
     _release_lock,
-    _upsert_rows,
-    acquire_lock_with_retry,
+    _upsert_rows,  # noqa: F401
+    acquire_lock_with_retry,  # noqa: F401
     create_redis_client,
     get_closed_candles_flow,
     make_keys,

--- a/app/services/yahoo_ohlcv_cache.py
+++ b/app/services/yahoo_ohlcv_cache.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
-from datetime import UTC, date, datetime, time, timedelta
+from datetime import UTC, date, datetime, timedelta
 
 import exchange_calendars as xcals
 import pandas as pd
@@ -12,7 +12,7 @@ from app.services.ohlcv_cache_common import (
     _acquire_lock,
     _empty_dataframe,
     _release_lock,
-    _upsert_rows,
+    _upsert_rows,  # noqa: F401
     create_redis_client,
     get_closed_candles_flow,
     make_keys,

--- a/app/services/yahoo_ohlcv_cache.py
+++ b/app/services/yahoo_ohlcv_cache.py
@@ -11,15 +11,12 @@ from app.core.config import settings
 from app.services.ohlcv_cache_common import (
     _acquire_lock,
     _empty_dataframe,
-    _enforce_retention_limit,
-    _normalize_bool,
-    _read_cache_status,
-    _read_cached_rows,
-    _read_latest_date,
-    _read_oldest_date,
-    _refresh_meta,
     _release_lock,
     _upsert_rows,
+    create_redis_client,
+    get_closed_candles_flow,
+    make_keys,
+    normalize_period,
 )
 
 logger = logging.getLogger(__name__)
@@ -30,11 +27,13 @@ _REDIS_CLIENT: redis.Redis | None = None
 _FALLBACK_COUNT = 0
 
 
-def _normalize_period(period: str) -> str:
-    normalized = str(period or "").strip().lower()
-    if normalized not in _SUPPORTED_PERIODS:
-        raise ValueError(f"period must be one of {sorted(_SUPPORTED_PERIODS)}")
-    return normalized
+# ---------------------------------------------------------------------------
+# Service-specific helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_period_local(period: str) -> str:
+    return normalize_period(period, _SUPPORTED_PERIODS)
 
 
 def _normalize_now_utc(now: datetime | None) -> datetime:
@@ -107,7 +106,7 @@ def _resolve_bucket_date(
 
 
 def get_last_closed_bucket_nyse(period: str, now: datetime | None = None) -> date:
-    normalized = _normalize_period(period)
+    normalized = _normalize_period_local(period)
     now_utc = _normalize_now_utc(now)
     sessions = _recent_sessions(now_utc, lookback_days=120)
     if not sessions:
@@ -116,7 +115,7 @@ def get_last_closed_bucket_nyse(period: str, now: datetime | None = None) -> dat
 
 
 def _bucket_key(period: str, bucket_date: date) -> tuple[int, int, int]:
-    normalized_period = _normalize_period(period)
+    normalized_period = _normalize_period_local(period)
     if normalized_period == "day":
         return (bucket_date.year, bucket_date.month, bucket_date.day)
     if normalized_period == "week":
@@ -126,7 +125,7 @@ def _bucket_key(period: str, bucket_date: date) -> tuple[int, int, int]:
 
 
 def _bucket_gap_count(period: str, earlier: date, later: date) -> int:
-    normalized_period = _normalize_period(period)
+    normalized_period = _normalize_period_local(period)
     if later <= earlier:
         return 0
 
@@ -144,27 +143,52 @@ def _bucket_gap_count(period: str, earlier: date, later: date) -> int:
     return max(month_gap, 0)
 
 
-def _base_key(ticker: str, period: str = "day") -> str:
-    normalized_period = str(period or "day").strip().lower()
-    normalized_ticker = str(ticker or "").strip().upper()
-    return f"yahoo:ohlcv:{normalized_period}:v1:{normalized_ticker}"
+def _make_is_cache_sufficient(period: str):
+    """Create a period-aware cache-sufficiency checker (captures period via closure)."""
+
+    def _is_cache_sufficient(
+        cached_count: int,
+        latest_cached_date: date | None,
+        oldest_confirmed: bool,
+        requested_count: int,
+        target_closed_date: date,
+    ) -> bool:
+        has_latest_closed = latest_cached_date is not None and _bucket_key(
+            period, latest_cached_date
+        ) >= _bucket_key(period, target_closed_date)
+        if not has_latest_closed:
+            return False
+        if cached_count >= requested_count:
+            return True
+        return oldest_confirmed
+
+    return _is_cache_sufficient
+
+
+def _make_is_latest_fresh(period: str):
+    """Create a period-aware freshness checker (captures period via closure)."""
+
+    def _is_latest_fresh(latest: date | None, target: date) -> bool:
+        if latest is None:
+            return False
+        return _bucket_key(period, latest) >= _bucket_key(period, target)
+
+    return _is_latest_fresh
 
 
 def _keys(ticker: str, period: str = "day") -> tuple[str, str, str, str]:
-    base = _base_key(ticker, period)
-    return f"{base}:dates", f"{base}:rows", f"{base}:meta", f"{base}:lock"
+    return make_keys("yahoo", ticker, period)
+
+
+# ---------------------------------------------------------------------------
+# Redis client management
+# ---------------------------------------------------------------------------
 
 
 async def _get_redis_client() -> redis.Redis:
     global _REDIS_CLIENT
     if _REDIS_CLIENT is None:
-        _REDIS_CLIENT = redis.from_url(
-            settings.get_redis_url(),
-            max_connections=settings.redis_max_connections,
-            socket_timeout=settings.redis_socket_timeout,
-            socket_connect_timeout=settings.redis_socket_connect_timeout,
-            decode_responses=True,
-        )
+        _REDIS_CLIENT = await create_redis_client()
     return _REDIS_CLIENT
 
 
@@ -175,158 +199,9 @@ async def close_ohlcv_cache_redis() -> None:
         _REDIS_CLIENT = None
 
 
-def _is_cache_sufficient(
-    period: str,
-    cached_count: int,
-    latest_cached_date: date | None,
-    oldest_confirmed: bool,
-    requested_count: int,
-    target_closed_date: date,
-) -> bool:
-    has_latest_closed = latest_cached_date is not None and _bucket_key(
-        period, latest_cached_date
-    ) >= _bucket_key(period, target_closed_date)
-    if not has_latest_closed:
-        return False
-    if cached_count >= requested_count:
-        return True
-    return oldest_confirmed
-
-
-async def _backfill_until_satisfied(
-    redis_client: redis.Redis,
-    ticker: str,
-    period: str,
-    raw_fetcher: Callable[
-        [str, int, str, datetime | None],
-        Awaitable[pd.DataFrame],
-    ],
-    requested_count: int,
-    target_closed_date: date,
-    dates_key: str,
-    rows_key: str,
-    meta_key: str,
-    max_days: int,
-) -> None:
-    meta = await redis_client.hgetall(meta_key)
-    oldest_confirmed = _normalize_bool(meta.get("oldest_confirmed"))
-
-    while True:
-        latest_cached_date = await _read_latest_date(redis_client, dates_key)
-        if latest_cached_date is not None and _bucket_key(
-            period,
-            latest_cached_date,
-        ) >= _bucket_key(period, target_closed_date):
-            break
-
-        if latest_cached_date is None:
-            batch_size = min(max(requested_count, 1), 200)
-        else:
-            missing_latest_buckets = _bucket_gap_count(
-                period,
-                latest_cached_date,
-                target_closed_date,
-            )
-            batch_size = min(max(missing_latest_buckets, 1), 200)
-
-        fetched = await raw_fetcher(
-            ticker=ticker,
-            days=batch_size,
-            period=period,
-            end_date=datetime.combine(target_closed_date, time(23, 59, 59)),
-        )
-        if fetched.empty or "date" not in fetched.columns:
-            break
-
-        fetched = fetched[fetched["date"] <= target_closed_date]
-        if fetched.empty:
-            break
-
-        await _upsert_rows(redis_client, dates_key, rows_key, fetched)
-        await _enforce_retention_limit(redis_client, dates_key, rows_key, max_days)
-
-        latest_after = await _read_latest_date(redis_client, dates_key)
-        if latest_cached_date is not None and (
-            latest_after is None or latest_after <= latest_cached_date
-        ):
-            break
-
-        if len(fetched) < batch_size:
-            break
-
-    while True:
-        cached_count, latest_cached_date, oldest_confirmed = await _read_cache_status(
-            redis_client,
-            dates_key,
-            meta_key,
-            target_closed_date,
-        )
-        if _is_cache_sufficient(
-            period,
-            cached_count,
-            latest_cached_date,
-            oldest_confirmed,
-            requested_count,
-            target_closed_date,
-        ):
-            await _refresh_meta(
-                redis_client,
-                dates_key,
-                meta_key,
-                target_closed_date,
-                oldest_confirmed,
-                meta_date_field="last_closed_bucket",
-            )
-            return
-        if oldest_confirmed:
-            break
-
-        earliest_cached_date = await _read_oldest_date(redis_client, dates_key)
-        batch_end_date = (
-            earliest_cached_date - timedelta(days=1)
-            if earliest_cached_date is not None
-            else target_closed_date
-        )
-        if batch_end_date > target_closed_date:
-            batch_end_date = target_closed_date
-
-        remaining = requested_count - cached_count
-        batch_size = min(max(remaining, 1), 200)
-
-        fetched = await raw_fetcher(
-            ticker=ticker,
-            days=batch_size,
-            period=period,
-            end_date=datetime.combine(batch_end_date, time(23, 59, 59)),
-        )
-        if fetched.empty or "date" not in fetched.columns:
-            oldest_confirmed = True
-            break
-
-        fetched = fetched[fetched["date"] <= batch_end_date]
-        if fetched.empty:
-            oldest_confirmed = True
-            break
-
-        inserted_count = await _upsert_rows(redis_client, dates_key, rows_key, fetched)
-        await _enforce_retention_limit(redis_client, dates_key, rows_key, max_days)
-
-        if inserted_count <= 0:
-            oldest_confirmed = True
-            break
-
-        if len(fetched) < batch_size:
-            oldest_confirmed = True
-            break
-
-    await _refresh_meta(
-        redis_client,
-        dates_key,
-        meta_key,
-        target_closed_date,
-        oldest_confirmed,
-        meta_date_field="last_closed_bucket",
-    )
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
 async def get_closed_candles(
@@ -335,7 +210,7 @@ async def get_closed_candles(
     period: str,
     raw_fetcher: Callable[[str, int, str, datetime | None], Awaitable[pd.DataFrame]],
 ) -> pd.DataFrame | None:
-    normalized_period = _normalize_period(period)
+    normalized_period = _normalize_period_local(period)
     if not settings.yahoo_ohlcv_cache_enabled:
         return None
 
@@ -353,119 +228,33 @@ async def get_closed_candles(
     try:
         redis_client = await _get_redis_client()
         dates_key, rows_key, meta_key, lock_key = _keys(
-            normalized_ticker,
-            normalized_period,
+            normalized_ticker, normalized_period
         )
         target_closed_date = get_last_closed_bucket_nyse(normalized_period)
 
-        await _enforce_retention_limit(
-            redis_client,
-            dates_key,
-            rows_key,
-            max_days,
+        return await get_closed_candles_flow(
+            redis_client=redis_client,
+            dates_key=dates_key,
+            rows_key=rows_key,
+            meta_key=meta_key,
+            lock_key=lock_key,
+            symbol=normalized_ticker,
+            period=normalized_period,
+            requested_count=requested_count,
+            max_days=max_days,
+            lock_ttl=settings.yahoo_ohlcv_cache_lock_ttl_seconds,
+            target_closed_date=target_closed_date,
+            raw_fetcher=raw_fetcher,
+            fetcher_symbol_kwarg="ticker",
+            is_latest_fresh_fn=_make_is_latest_fresh(normalized_period),
+            bucket_gap_fn=_bucket_gap_count,
+            is_sufficient_fn=_make_is_cache_sufficient(normalized_period),
+            acquire_lock_fn=_acquire_lock,
+            release_lock_fn=_release_lock,
+            sleep_fn=asyncio.sleep,
+            log_prefix="yahoo_ohlcv_cache",
+            meta_date_field="last_closed_bucket",
         )
-
-        cached = await _read_cached_rows(
-            redis_client,
-            dates_key,
-            rows_key,
-            target_closed_date,
-            requested_count,
-        )
-        cached_count, latest_cached_date, oldest_confirmed = await _read_cache_status(
-            redis_client,
-            dates_key,
-            meta_key,
-            target_closed_date,
-        )
-        if _is_cache_sufficient(
-            normalized_period,
-            cached_count,
-            latest_cached_date,
-            oldest_confirmed,
-            requested_count,
-            target_closed_date,
-        ):
-            await _refresh_meta(
-                redis_client,
-                dates_key,
-                meta_key,
-                target_closed_date,
-                oldest_confirmed,
-                meta_date_field="last_closed_bucket",
-            )
-            return cached.tail(requested_count).reset_index(drop=True)
-
-        lock_token = await _acquire_lock(
-            redis_client,
-            lock_key,
-            settings.yahoo_ohlcv_cache_lock_ttl_seconds,
-        )
-        if lock_token is None:
-            for _ in range(2):
-                await asyncio.sleep(0.1)
-                lock_token = await _acquire_lock(
-                    redis_client,
-                    lock_key,
-                    settings.yahoo_ohlcv_cache_lock_ttl_seconds,
-                )
-                if lock_token is not None:
-                    break
-
-            if lock_token is None:
-                refreshed_cached = await _read_cached_rows(
-                    redis_client,
-                    dates_key,
-                    rows_key,
-                    target_closed_date,
-                    requested_count,
-                )
-                (
-                    refreshed_count,
-                    refreshed_latest_date,
-                    refreshed_oldest_confirmed,
-                ) = await _read_cache_status(
-                    redis_client,
-                    dates_key,
-                    meta_key,
-                    target_closed_date,
-                )
-                if _is_cache_sufficient(
-                    normalized_period,
-                    refreshed_count,
-                    refreshed_latest_date,
-                    refreshed_oldest_confirmed,
-                    requested_count,
-                    target_closed_date,
-                ):
-                    return refreshed_cached.tail(requested_count).reset_index(drop=True)
-                return None
-
-        try:
-            await _backfill_until_satisfied(
-                redis_client,
-                normalized_ticker,
-                normalized_period,
-                raw_fetcher,
-                requested_count,
-                target_closed_date,
-                dates_key,
-                rows_key,
-                meta_key,
-                max_days,
-            )
-        finally:
-            await _release_lock(redis_client, lock_key, lock_token)
-
-        final_rows = await _read_cached_rows(
-            redis_client,
-            dates_key,
-            rows_key,
-            target_closed_date,
-            requested_count,
-        )
-        return final_rows.tail(requested_count).reset_index(drop=True)
-
     except Exception as exc:
         global _FALLBACK_COUNT
         _FALLBACK_COUNT += 1


### PR DESCRIPTION
## Summary
- Extract duplicated logic from 3 OHLCV cache service files into `ohlcv_cache_common.py`
- Add generic utilities: `normalize_period`, `make_base_key`, `make_keys`, `create_redis_client`, `acquire_lock_with_retry`
- Add closed-candle orchestration: `backfill_loop` and `get_closed_candles_flow`
- Slim down service modules using common orchestration (upbit: 514→233 lines, yahoo: 500→289 lines)
- KIS uses common utilities but keeps its own orchestration (different caching model)

## Test Plan
- [x] All 74 OHLCV cache tests pass
- [x] Linter passes
- [x] Line count reduced: 1,813 → 1,685 lines (-128 net)