### PR TITLE
refactor: Order broker-split fixup - re-export cleanup & function extraction

### DIFF
--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -289,8 +289,7 @@ async def _build_preview(
     market_type: str,
 ) -> dict[str, Any]:
     """Run preview and enrich result with defaults."""
-    preview_fn = globals().get("_preview_order", _preview_order)
-    dry_run_result = await preview_fn(
+    dry_run_result = await _preview_order(
         symbol=normalized_symbol,
         side=side,
         order_type=order_type,
@@ -668,6 +667,21 @@ async def _execute_and_record(
     }
 
 
+def _build_order_error(
+    message: str,
+    source: str,
+    symbol: str,
+    market_type: str,
+) -> dict[str, Any]:
+    return {
+        "success": False,
+        "error": message,
+        "source": source,
+        "symbol": symbol,
+        "instrument_type": market_type,
+    }
+
+
 async def _place_order_impl(
     symbol: str,
     side: Literal["buy", "sell"],
@@ -719,13 +733,7 @@ async def _place_order_impl(
     source = source_map[market_type]
 
     def _order_error(message: str) -> dict[str, Any]:
-        return {
-            "success": False,
-            "error": message,
-            "source": source,
-            "symbol": normalized_symbol,
-            "instrument_type": market_type,
-        }
+        return _build_order_error(message, source, normalized_symbol, market_type)
 
     # Check stop-loss cooldown for crypto buys
     if side_lower == "buy" and market_type == "crypto":

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -458,6 +458,115 @@ async def _record_fill_and_journals(
 # ---------------------------------------------------------------------------
 
 
+def _build_dry_run_response(
+    dry_run_result: dict[str, Any],
+    balance_warning: str | None,
+) -> dict[str, Any]:
+    """Build the dry-run preview response."""
+    result = {
+        "success": True,
+        "dry_run": True,
+        **dry_run_result,
+        "message": "Order preview (dry_run=True)",
+    }
+    if balance_warning:
+        result["warning"] = balance_warning
+    return result
+
+
+async def _execute_and_record(
+    *,
+    normalized_symbol: str,
+    side: str,
+    order_type: str,
+    order_quantity: float | None,
+    price: float | None,
+    market_type: str,
+    current_price: float,
+    avg_price: float,
+    dry_run_result: dict[str, Any],
+    order_amount: float,
+    reason: str,
+    exit_reason: str | None,
+    thesis: str | None,
+    strategy: str | None,
+    target_price: float | None,
+    stop_loss: float | None,
+    min_hold_days: int | None,
+    notes: str | None,
+    indicators_snapshot: dict[str, Any] | None,
+    order_error_fn: Any,
+) -> dict[str, Any]:
+    """Execute a live order, record history, fills, and journals."""
+    if not await _check_daily_order_limit(_MAX_ORDERS_PER_DAY):
+        return order_error_fn(
+            f"Daily order limit ({_MAX_ORDERS_PER_DAY}) exceeded"
+        )
+
+    try:
+        execution_result = await _execute_order(
+            symbol=normalized_symbol,
+            side=side,
+            order_type=order_type,
+            quantity=order_quantity,
+            price=price,
+            market_type=market_type,
+        )
+    except Exception as exec_exc:
+        logger.error(
+            "execute_order 실패: stage=execute_order, market_type=%s, "
+            "symbol=%s, side=%s, error=%s",
+            market_type,
+            normalized_symbol,
+            side,
+            exec_exc,
+        )
+        raise
+
+    await _record_order_history(
+        symbol=normalized_symbol,
+        side=side,
+        order_type=order_type,
+        quantity=order_quantity,
+        price=price,
+        amount=order_amount,
+        reason=reason,
+        dry_run=False,
+    )
+
+    # Record phase: fills + journals
+    record_result = await _record_fill_and_journals(
+        side=side,
+        normalized_symbol=normalized_symbol,
+        market_type=market_type,
+        execution_result=execution_result,
+        dry_run_result=dry_run_result,
+        order_quantity=order_quantity,
+        current_price=current_price,
+        avg_price=avg_price,
+        reason=reason,
+        exit_reason=exit_reason,
+        thesis=thesis,
+        strategy=strategy,
+        target_price=target_price,
+        stop_loss=stop_loss,
+        min_hold_days=min_hold_days,
+        notes=notes,
+        indicators_snapshot=indicators_snapshot,
+    )
+
+    return {
+        "success": True,
+        "dry_run": False,
+        "preview": dry_run_result,
+        "execution": execution_result,
+        **record_result,
+        "message": "Order placed and fill recorded successfully"
+        if record_result["fill_recorded"]
+        else "Order placed successfully",
+    }
+
+
 async def _place_order_impl(
     symbol: str,
     side: Literal["buy", "sell"],
@@ -568,7 +677,9 @@ async def _place_order_impl(
         except ValueError as preview_exc:
             return _order_error(str(preview_exc))
 
-        order_amount = _to_float(dry_run_result.get("estimated_value"), default=0.0)
+        order_amount = _to_float(
+            dry_run_result.get("estimated_value"), default=0.0
+        )
 
         # Balance pre-check for buy orders
         balance_warning: str | None = None
@@ -586,60 +697,20 @@ async def _place_order_impl(
 
         # Dry-run exit
         if dry_run:
-            result = {
-                "success": True,
-                "dry_run": True,
-                **dry_run_result,
-                "message": "Order preview (dry_run=True)",
-            }
-            if balance_warning:
-                result["warning"] = balance_warning
-            return result
+            return _build_dry_run_response(dry_run_result, balance_warning)
 
         # Real execution
-        if not await _check_daily_order_limit(_MAX_ORDERS_PER_DAY):
-            return _order_error(f"Daily order limit ({_MAX_ORDERS_PER_DAY}) exceeded")
-
-        try:
-            execution_result = await _execute_order(
-                symbol=normalized_symbol,
-                side=side_lower,
-                order_type=order_type_lower,
-                quantity=order_quantity,
-                price=price,
-                market_type=market_type,
-            )
-        except Exception as exec_exc:
-            logger.error(
-                "execute_order 실패: stage=execute_order, market_type=%s, symbol=%s, side=%s, error=%s",
-                market_type,
-                normalized_symbol,
-                side_lower,
-                exec_exc,
-            )
-            raise
-
-        await _record_order_history(
-            symbol=normalized_symbol,
+        return await _execute_and_record(
+            normalized_symbol=normalized_symbol,
             side=side_lower,
             order_type=order_type_lower,
-            quantity=order_quantity,
-            price=price,
-            amount=order_amount,
-            reason=reason,
-            dry_run=False,
-        )
-
-        # Record phase: fills + journals
-        record_result = await _record_fill_and_journals(
-            side=side_lower,
-            normalized_symbol=normalized_symbol,
-            market_type=market_type,
-            execution_result=execution_result,
-            dry_run_result=dry_run_result,
             order_quantity=order_quantity,
+            price=price,
+            market_type=market_type,
             current_price=current_price,
             avg_price=avg_price,
+            dry_run_result=dry_run_result,
+            order_amount=order_amount,
             reason=reason,
             exit_reason=exit_reason,
             thesis=thesis,
@@ -649,19 +720,8 @@ async def _place_order_impl(
             min_hold_days=min_hold_days,
             notes=notes,
             indicators_snapshot=indicators_snapshot,
+            order_error_fn=_order_error,
         )
-
-        response: dict[str, Any] = {
-            "success": True,
-            "dry_run": False,
-            "preview": dry_run_result,
-            "execution": execution_result,
-            **record_result,
-            "message": "Order placed and fill recorded successfully"
-            if record_result["fill_recorded"]
-            else "Order placed successfully",
-        }
-        return response
     except Exception as exc:
         await _record_order_history(
             symbol=normalized_symbol,
@@ -675,6 +735,7 @@ async def _place_order_impl(
             error=str(exc),
         )
         return _order_error(str(exc))
+
 
 
 __all__ = [

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -123,9 +123,7 @@ async def _execute_crypto_order(
         return await upbit_service.place_market_sell_order(symbol, volume_str)
 
     adjusted_price = upbit_service.adjust_price_to_upbit_unit(price)
-    return await upbit_service.place_sell_order(
-        symbol, volume_str, f"{adjusted_price}"
-    )
+    return await upbit_service.place_sell_order(symbol, volume_str, f"{adjusted_price}")
 
 
 async def _execute_kr_order(
@@ -217,8 +215,12 @@ _MAX_ORDERS_PER_DAY = 20
 
 
 def _validate_inputs(
-    symbol: str, side: str, order_type: str, price: float | None,
-    amount: float | None, quantity: float | None,
+    symbol: str,
+    side: str,
+    order_type: str,
+    price: float | None,
+    amount: float | None,
+    quantity: float | None,
 ) -> tuple[str, str, str]:
     """Validate and normalize basic inputs. Returns (symbol, side, order_type)."""
     symbol = (symbol or "").strip()
@@ -251,7 +253,10 @@ def _validate_inputs(
 
 
 async def _fetch_current_price(
-    normalized_symbol: str, market_type: str, order_type: str, price: float | None,
+    normalized_symbol: str,
+    market_type: str,
+    order_type: str,
+    price: float | None,
 ) -> float:
     """Fetch current price, falling back to limit price when available."""
     try:
@@ -310,10 +315,145 @@ async def _build_preview(
     dry_run_result.setdefault("side", side)
     dry_run_result.setdefault("order_type", order_type)
     if dry_run_result.get("price") is None:
-        dry_run_result["price"] = (
-            current_price if order_type == "market" else price
-        )
+        dry_run_result["price"] = current_price if order_type == "market" else price
     return dry_run_result
+
+
+async def _handle_buy_journal(
+    *,
+    normalized_symbol: str,
+    market_type: str,
+    dry_run_result: dict[str, Any],
+    thesis: str | None,
+    strategy: str | None,
+    target_price: float | None,
+    stop_loss: float | None,
+    min_hold_days: int | None,
+    notes: str | None,
+    indicators_snapshot: dict[str, Any] | None,
+) -> tuple[bool, int | None, str | None, str | None]:
+    """Create trade journal for buy orders.
+
+    Returns:
+        (journal_created, journal_id, journal_status, journal_warning)
+    """
+    try:
+        journal_result = await _create_trade_journal_for_buy(
+            symbol=normalized_symbol,
+            market_type=market_type,
+            preview=dry_run_result,
+            thesis=typing_cast(str, thesis),
+            strategy=typing_cast(str, strategy),
+            target_price=target_price,
+            stop_loss=stop_loss,
+            min_hold_days=min_hold_days,
+            notes=notes,
+            indicators_snapshot=indicators_snapshot,
+        )
+        return (
+            journal_result["journal_created"],
+            journal_result["journal_id"],
+            journal_result["journal_status"],
+            None,
+        )
+    except Exception as journal_exc:
+        warning = f"trade journal creation failed after order execution: {journal_exc}"
+        logger.warning(warning)
+        return False, None, None, warning
+
+
+async def _handle_sell_journal(
+    *,
+    normalized_symbol: str,
+    dry_run_result: dict[str, Any],
+    order_quantity: float | None,
+    current_price: float,
+    exit_reason: str | None,
+    reason: str,
+    journal_warning: str | None,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Close journals for sell orders.
+
+    Returns:
+        (journal_close_result, updated_journal_warning)
+    """
+    try:
+        preview_qty = _to_float(dry_run_result.get("quantity"), default=0.0)
+        preview_price = _to_float(dry_run_result.get("price"), default=0.0)
+        resolved_sell_qty = (
+            preview_qty if preview_qty > 0 else _to_float(order_quantity, default=0.0)
+        )
+        resolved_sell_price = (
+            preview_price
+            if preview_price > 0
+            else _to_float(current_price, default=0.0)
+        )
+        journal_close_result = await _close_journals_on_sell(
+            symbol=normalized_symbol,
+            sell_quantity=resolved_sell_qty,
+            sell_price=resolved_sell_price,
+            exit_reason=exit_reason or reason,
+        )
+        return journal_close_result, journal_warning
+    except Exception as journal_exc:
+        updated_warning = _append_journal_warning(
+            journal_warning, f"journal close failed after sell: {journal_exc}"
+        )
+        logger.warning("Failed to close journals on sell: %s", journal_exc)
+        return None, updated_warning
+
+
+async def _save_and_link_fill(
+    *,
+    normalized_symbol: str,
+    market_type: str,
+    side: str,
+    execution_result: dict[str, Any],
+    dry_run_result: dict[str, Any],
+    journal_created: bool,
+) -> tuple[bool, str | None, str | None]:
+    """Save order fill to DB and link to journal.
+
+    Returns:
+        (fill_recorded, journal_status, journal_warning)
+    """
+    order_id = execution_result.get("uuid") or execution_result.get("odno")
+    price_val = _to_float(dry_run_result.get("price"), default=0.0)
+    qty_val = _to_float(dry_run_result.get("quantity"), default=0.0)
+    amt_val = _to_float(dry_run_result.get("estimated_value"), default=0.0)
+    fee_val = _to_float(dry_run_result.get("fee"), default=0.0)
+    currency = "KRW" if market_type != "equity_us" else "USD"
+    account_name = "upbit" if market_type == "crypto" else "kis"
+
+    try:
+        trade_id = await _save_order_fill(
+            symbol=normalized_symbol,
+            instrument_type=market_type,
+            side=side,
+            price=price_val,
+            quantity=qty_val,
+            total_amount=amt_val,
+            fee=fee_val,
+            currency=currency,
+            account=account_name,
+            order_id=str(order_id) if order_id else None,
+        )
+
+        if trade_id:
+            await _link_journal_to_fill(normalized_symbol, trade_id)
+            if journal_created:
+                return True, "active", None
+            return True, None, None
+        elif journal_created:
+            return (
+                False,
+                None,
+                "trade journal created but fill was not recorded; journal remains draft",
+            )
+        return False, None, None
+    except Exception as db_exc:
+        logger.warning("Failed to record fill to DB: %s", db_exc)
+        return False, None, None
 
 
 async def _record_fill_and_journals(
@@ -343,25 +483,23 @@ async def _record_fill_and_journals(
     journal_warning: str | None = None
 
     if side == "buy":
-        try:
-            journal_result = await _create_trade_journal_for_buy(
-                symbol=normalized_symbol,
-                market_type=market_type,
-                preview=dry_run_result,
-                thesis=typing_cast(str, thesis),
-                strategy=typing_cast(str, strategy),
-                target_price=target_price,
-                stop_loss=stop_loss,
-                min_hold_days=min_hold_days,
-                notes=notes,
-                indicators_snapshot=indicators_snapshot,
-            )
-            journal_created = journal_result["journal_created"]
-            journal_id = journal_result["journal_id"]
-            journal_status = journal_result["journal_status"]
-        except Exception as journal_exc:
-            journal_warning = f"trade journal creation failed after order execution: {journal_exc}"
-            logger.warning(journal_warning)
+        (
+            journal_created,
+            journal_id,
+            journal_status,
+            journal_warning,
+        ) = await _handle_buy_journal(
+            normalized_symbol=normalized_symbol,
+            market_type=market_type,
+            dry_run_result=dry_run_result,
+            thesis=thesis,
+            strategy=strategy,
+            target_price=target_price,
+            stop_loss=stop_loss,
+            min_hold_days=min_hold_days,
+            notes=notes,
+            indicators_snapshot=indicators_snapshot,
+        )
 
     # Record stop-loss cooldown for crypto sells below threshold
     if (
@@ -377,66 +515,31 @@ async def _record_fill_and_journals(
             logger.warning("Failed to record stop-loss cooldown: %s", cooldown_exc)
 
     # Save fill to DB
-    fill_recorded = False
-    order_id = execution_result.get("uuid") or execution_result.get("odno")
-    price_val = _to_float(dry_run_result.get("price"), default=0.0)
-    qty_val = _to_float(dry_run_result.get("quantity"), default=0.0)
-    amt_val = _to_float(dry_run_result.get("estimated_value"), default=0.0)
-    fee_val = _to_float(dry_run_result.get("fee"), default=0.0)
-    currency = "KRW" if market_type != "equity_us" else "USD"
-    account_name = "upbit" if market_type == "crypto" else "kis"
-
-    try:
-        trade_id = await _save_order_fill(
-            symbol=normalized_symbol,
-            instrument_type=market_type,
-            side=side,
-            price=price_val,
-            quantity=qty_val,
-            total_amount=amt_val,
-            fee=fee_val,
-            currency=currency,
-            account=account_name,
-            order_id=str(order_id) if order_id else None,
-        )
-
-        if trade_id:
-            fill_recorded = True
-            await _link_journal_to_fill(normalized_symbol, trade_id)
-            if journal_created:
-                journal_status = "active"
-        elif journal_created:
-            journal_warning = "trade journal created but fill was not recorded; journal remains draft"
-    except Exception as db_exc:
-        logger.warning("Failed to record fill to DB: %s", db_exc)
+    fill_recorded, fill_journal_status, fill_warning = await _save_and_link_fill(
+        normalized_symbol=normalized_symbol,
+        market_type=market_type,
+        side=side,
+        execution_result=execution_result,
+        dry_run_result=dry_run_result,
+        journal_created=journal_created,
+    )
+    if fill_journal_status:
+        journal_status = fill_journal_status
+    if fill_warning:
+        journal_warning = _append_journal_warning(journal_warning, fill_warning)
 
     # Close journals for sell orders
     journal_close_result: dict[str, Any] | None = None
     if side == "sell":
-        try:
-            preview_qty = _to_float(dry_run_result.get("quantity"), default=0.0)
-            preview_price = _to_float(dry_run_result.get("price"), default=0.0)
-            resolved_sell_qty = (
-                preview_qty
-                if preview_qty > 0
-                else _to_float(order_quantity, default=0.0)
-            )
-            resolved_sell_price = (
-                preview_price
-                if preview_price > 0
-                else _to_float(current_price, default=0.0)
-            )
-            journal_close_result = await _close_journals_on_sell(
-                symbol=normalized_symbol,
-                sell_quantity=resolved_sell_qty,
-                sell_price=resolved_sell_price,
-                exit_reason=exit_reason or reason,
-            )
-        except Exception as journal_exc:
-            journal_warning = _append_journal_warning(
-                journal_warning, f"journal close failed after sell: {journal_exc}"
-            )
-            logger.warning("Failed to close journals on sell: %s", journal_exc)
+        journal_close_result, journal_warning = await _handle_sell_journal(
+            normalized_symbol=normalized_symbol,
+            dry_run_result=dry_run_result,
+            order_quantity=order_quantity,
+            current_price=current_price,
+            exit_reason=exit_reason,
+            reason=reason,
+            journal_warning=journal_warning,
+        )
 
     result: dict[str, Any] = {
         "fill_recorded": fill_recorded,
@@ -499,9 +602,7 @@ async def _execute_and_record(
 ) -> dict[str, Any]:
     """Execute a live order, record history, fills, and journals."""
     if not await _check_daily_order_limit(_MAX_ORDERS_PER_DAY):
-        return order_error_fn(
-            f"Daily order limit ({_MAX_ORDERS_PER_DAY}) exceeded"
-        )
+        return order_error_fn(f"Daily order limit ({_MAX_ORDERS_PER_DAY}) exceeded")
 
     try:
         execution_result = await _execute_order(
@@ -587,7 +688,12 @@ async def _place_order_impl(
     indicators_snapshot: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     symbol, side_lower, order_type_lower = _validate_inputs(
-        symbol, side, order_type, price, amount, quantity,
+        symbol,
+        side,
+        order_type,
+        price,
+        amount,
+        quantity,
     )
 
     market_type, normalized_symbol = _resolve_market_type(symbol, market)
@@ -631,7 +737,10 @@ async def _place_order_impl(
 
     try:
         current_price = await _fetch_current_price(
-            normalized_symbol, market_type, order_type_lower, price,
+            normalized_symbol,
+            market_type,
+            order_type_lower,
+            price,
         )
 
         # Resolve amount -> quantity for buy orders
@@ -677,9 +786,7 @@ async def _place_order_impl(
         except ValueError as preview_exc:
             return _order_error(str(preview_exc))
 
-        order_amount = _to_float(
-            dry_run_result.get("estimated_value"), default=0.0
-        )
+        order_amount = _to_float(dry_run_result.get("estimated_value"), default=0.0)
 
         # Balance pre-check for buy orders
         balance_warning: str | None = None
@@ -735,7 +842,6 @@ async def _place_order_impl(
             error=str(exc),
         )
         return _order_error(str(exc))
-
 
 
 __all__ = [

--- a/app/mcp_server/tooling/orders_history.py
+++ b/app/mcp_server/tooling/orders_history.py
@@ -53,19 +53,35 @@ def _calculate_order_summary(orders: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-async def get_order_history_impl(
-    symbol: str | None = None,
-    status: Literal["all", "pending", "filled", "cancelled"] = "all",
-    order_id: str | None = None,
-    market: str | None = None,
-    side: str | None = None,
-    days: int | None = None,
-    limit: int | None = 50,
-) -> dict[str, Any]:
+def _validate_history_inputs(
+    symbol: str | None,
+    status: str,
+    order_id: str | None,
+    market: str | None,
+    side: str | None,
+    days: int | None,
+    limit: int | None,
+) -> tuple[
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+    int | None,
+    float,
+    list[str],
+    str | None,
+]:
+    """Validate and normalize history query inputs.
+
+    Returns:
+        (symbol, order_id, market_hint, side, effective_days,
+         limit_val, market_types, normalized_symbol)
+    """
     if status != "pending" and not symbol:
         raise ValueError(
             f"symbol is required when status='{status}'. "
-            "Use status='pending' for symbol-free queries, or provide a symbol (e.g. symbol='KRW-BTC')."
+            "Use status='pending' for symbol-free queries, "
+            "or provide a symbol (e.g. symbol='KRW-BTC')."
         )
 
     symbol = (symbol or "").strip() or None
@@ -88,7 +104,9 @@ async def get_order_history_impl(
     normalized_symbol: str | None = None
 
     if symbol:
-        market_type, normalized_symbol = _resolve_market_type(symbol, market_hint)
+        market_type, normalized_symbol = _resolve_market_type(
+            symbol, market_hint
+        )
         market_types = [market_type]
     elif market_hint:
         norm = _normalize_market(market_hint)
@@ -104,108 +122,152 @@ async def get_order_history_impl(
         else:
             market_types = ["crypto", "equity_kr", "equity_us"]
 
-    orders: list[dict[str, Any]] = []
-    errors: list[dict[str, Any]] = []
+    return (
+        symbol,
+        order_id,
+        market_hint,
+        side,
+        effective_days,
+        limit_val,
+        market_types,
+        normalized_symbol,
+    )
 
-    for m_type in market_types:
-        try:
-            fetched: list[dict[str, Any]] = []
 
-            if m_type == "crypto":
-                if status in ("all", "pending"):
-                    open_ops = await upbit_service.fetch_open_orders(
-                        market=normalized_symbol
-                    )
-                    fetched.extend([_normalize_upbit_order(o) for o in open_ops])
+async def _fetch_crypto_orders(
+    normalized_symbol: str | None,
+    status: str,
+    limit_val: float,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Fetch and normalize Upbit (crypto) orders."""
+    fetched: list[dict[str, Any]] = []
 
-                if status in ("all", "filled", "cancelled") and normalized_symbol:
-                    fetch_limit = 100 if limit_val == float("inf") else max(limit, 20)
-                    closed_ops = await upbit_service.fetch_closed_orders(
-                        market=normalized_symbol,
-                        limit=fetch_limit,
-                    )
-                    fetched.extend([_normalize_upbit_order(o) for o in closed_ops])
+    if status in ("all", "pending"):
+        open_ops = await upbit_service.fetch_open_orders(
+            market=normalized_symbol
+        )
+        fetched.extend([_normalize_upbit_order(o) for o in open_ops])
 
-            elif m_type == "equity_kr":
-                kis = KISClient()
-                if status in ("all", "pending"):
-                    logger.debug(
-                        "Fetching KR pending orders, symbol=%s", normalized_symbol
-                    )
-                    open_ops = await kis.inquire_korea_orders()
-                    if open_ops:
-                        logger.debug(
-                            "Raw API response keys: %s", list(open_ops[0].keys())
-                        )
-                    for o in open_ops:
-                        o_sym = str(_get_kis_field(o, "pdno", "PDNO"))
-                        if normalized_symbol and o_sym != normalized_symbol:
-                            continue
-                        fetched.append(_normalize_kis_domestic_order(o))
+    if status in ("all", "filled", "cancelled") and normalized_symbol:
+        fetch_limit = (
+            100 if limit_val == float("inf") else max(limit, 20)
+        )
+        closed_ops = await upbit_service.fetch_closed_orders(
+            market=normalized_symbol,
+            limit=fetch_limit,
+        )
+        fetched.extend([_normalize_upbit_order(o) for o in closed_ops])
 
-                if status in ("all", "filled", "cancelled") and normalized_symbol:
-                    lookup_days = effective_days if effective_days is not None else 30
-                    start_dt, end_dt = _calculate_date_range(lookup_days)
-                    hist_ops = await kis.inquire_daily_order_domestic(
-                        start_date=start_dt,
-                        end_date=end_dt,
-                        stock_code=normalized_symbol,
-                        side="00",
-                    )
-                    fetched.extend([_normalize_kis_domestic_order(o) for o in hist_ops])
+    return fetched
 
-            elif m_type == "equity_us":
-                kis = KISClient()
-                if status in ("all", "pending"):
-                    target_exchanges = ["NASD", "NYSE", "AMEX"]
-                    if normalized_symbol:
-                        target_exchanges = [
-                            await get_us_exchange_by_symbol(normalized_symbol)
-                        ]
 
-                    seen_oids = set()
-                    for ex in target_exchanges:
-                        try:
-                            ops = await kis.inquire_overseas_orders(ex)
-                            for o in ops:
-                                oid = _extract_kis_order_number(o)
-                                if oid in seen_oids:
-                                    continue
-                                seen_oids.add(oid)
+async def _fetch_kr_orders(
+    normalized_symbol: str | None,
+    status: str,
+    effective_days: int | None,
+) -> list[dict[str, Any]]:
+    """Fetch and normalize KIS domestic (Korean equity) orders."""
+    fetched: list[dict[str, Any]] = []
+    kis = KISClient()
 
-                                o_sym = str(_get_kis_field(o, "pdno", "PDNO"))
-                                if normalized_symbol and o_sym != normalized_symbol:
-                                    continue
-                                fetched.append(_normalize_kis_overseas_order(o))
-                        except Exception:
-                            pass
+    if status in ("all", "pending"):
+        logger.debug(
+            "Fetching KR pending orders, symbol=%s", normalized_symbol
+        )
+        open_ops = await kis.inquire_korea_orders()
+        if open_ops:
+            logger.debug(
+                "Raw API response keys: %s", list(open_ops[0].keys())
+            )
+        for o in open_ops:
+            o_sym = str(_get_kis_field(o, "pdno", "PDNO"))
+            if normalized_symbol and o_sym != normalized_symbol:
+                continue
+            fetched.append(_normalize_kis_domestic_order(o))
 
-                if status in ("all", "filled", "cancelled") and normalized_symbol:
-                    lookup_days = effective_days if effective_days is not None else 30
-                    start_dt, end_dt = _calculate_date_range(lookup_days)
-                    ex = await get_us_exchange_by_symbol(normalized_symbol)
-                    hist_ops = await kis.inquire_daily_order_overseas(
-                        start_date=start_dt,
-                        end_date=end_dt,
-                        symbol=normalized_symbol,
-                        exchange_code=ex,
-                        side="00",
-                    )
-                    fetched.extend([_normalize_kis_overseas_order(o) for o in hist_ops])
+    if status in ("all", "filled", "cancelled") and normalized_symbol:
+        lookup_days = (
+            effective_days if effective_days is not None else 30
+        )
+        start_dt, end_dt = _calculate_date_range(lookup_days)
+        hist_ops = await kis.inquire_daily_order_domestic(
+            start_date=start_dt,
+            end_date=end_dt,
+            stock_code=normalized_symbol,
+            side="00",
+        )
+        fetched.extend(
+            [_normalize_kis_domestic_order(o) for o in hist_ops]
+        )
 
-            source_market = _normalize_market_type_to_external(m_type)
-            for f in fetched:
-                f["_source_market"] = source_market
-            orders.extend(fetched)
+    return fetched
 
-        except Exception as e:
-            errors.append({"market": m_type, "error": str(e)})
 
-    original_order_count = len(orders)
+async def _fetch_us_orders(
+    normalized_symbol: str | None,
+    status: str,
+    effective_days: int | None,
+) -> list[dict[str, Any]]:
+    """Fetch and normalize KIS overseas (US equity) orders."""
+    fetched: list[dict[str, Any]] = []
+    kis = KISClient()
+
+    if status in ("all", "pending"):
+        target_exchanges = ["NASD", "NYSE", "AMEX"]
+        if normalized_symbol:
+            target_exchanges = [
+                await get_us_exchange_by_symbol(normalized_symbol)
+            ]
+
+        seen_oids: set[str] = set()
+        for ex in target_exchanges:
+            try:
+                ops = await kis.inquire_overseas_orders(ex)
+                for o in ops:
+                    oid = _extract_kis_order_number(o)
+                    if oid in seen_oids:
+                        continue
+                    seen_oids.add(oid)
+
+                    o_sym = str(_get_kis_field(o, "pdno", "PDNO"))
+                    if normalized_symbol and o_sym != normalized_symbol:
+                        continue
+                    fetched.append(_normalize_kis_overseas_order(o))
+            except Exception:
+                pass
+
+    if status in ("all", "filled", "cancelled") and normalized_symbol:
+        lookup_days = (
+            effective_days if effective_days is not None else 30
+        )
+        start_dt, end_dt = _calculate_date_range(lookup_days)
+        ex = await get_us_exchange_by_symbol(normalized_symbol)
+        hist_ops = await kis.inquire_daily_order_overseas(
+            start_date=start_dt,
+            end_date=end_dt,
+            symbol=normalized_symbol,
+            exchange_code=ex,
+            side="00",
+        )
+        fetched.extend(
+            [_normalize_kis_overseas_order(o) for o in hist_ops]
+        )
+
+    return fetched
+
+
+def _dedupe_orders(
+    orders: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Remove duplicate orders, preserving last occurrence."""
+    original_count = len(orders)
     unique_orders: dict[tuple[Any, ...], dict[str, Any]] = {}
     for o in orders:
         oid = str(o.get("order_id") or "").strip()
-        source_market = o.get("_source_market") or o.get("market") or "unknown"
+        source_market = (
+            o.get("_source_market") or o.get("market") or "unknown"
+        )
         if oid:
             key = (source_market, oid)
             unique_orders[key] = o
@@ -222,12 +284,26 @@ async def get_order_history_impl(
             )
             unique_orders[key] = o
 
-    orders = list(unique_orders.values())
-    removed_duplicates = original_order_count - len(orders)
-    if removed_duplicates > 0:
-        logger.info("Removed %s duplicate orders", removed_duplicates)
+    result = list(unique_orders.values())
+    removed = original_count - len(result)
+    if removed > 0:
+        logger.info("Removed %s duplicate orders", removed)
+    return result
 
-    filtered_orders: list[dict[str, Any]] = []
+
+def _filter_and_sort_orders(
+    orders: list[dict[str, Any]],
+    status: str,
+    order_id: str | None,
+    side: str | None,
+    limit_val: float,
+) -> tuple[list[dict[str, Any]], int, bool]:
+    """Filter, sort, and truncate orders.
+
+    Returns:
+        (response_orders, total_available, truncated)
+    """
+    filtered: list[dict[str, Any]] = []
     for o in orders:
         o_status = o.get("status")
         if status == "pending":
@@ -246,26 +322,46 @@ async def get_order_history_impl(
         if side and o.get("side") != side:
             continue
 
-        filtered_orders.append(o)
+        filtered.append(o)
 
     def _get_sort_key(o: dict[str, Any]) -> str:
         val = o.get("ordered_at") or o.get("created_at") or ""
         return str(val)
 
-    filtered_orders.sort(key=_get_sort_key, reverse=True)
+    filtered.sort(key=_get_sort_key, reverse=True)
 
-    total_available = len(filtered_orders)
+    total_available = len(filtered)
     truncated = False
     if limit_val != float("inf") and total_available > limit_val:
-        filtered_orders = filtered_orders[: int(limit_val)]
+        filtered = filtered[: int(limit_val)]
         truncated = True
 
     response_orders: list[dict[str, Any]] = []
-    for o in filtered_orders:
+    for o in filtered:
         cleaned = dict(o)
         cleaned.pop("_source_market", None)
         response_orders.append(cleaned)
 
+    return response_orders, total_available, truncated
+
+
+def _build_history_response(
+    *,
+    response_orders: list[dict[str, Any]],
+    errors: list[dict[str, Any]],
+    market_types: list[str],
+    normalized_symbol: str | None,
+    symbol: str | None,
+    status: str,
+    order_id: str | None,
+    market_hint: str | None,
+    side: str | None,
+    days: int | None,
+    limit: int | None,
+    truncated: bool,
+    total_available: int,
+) -> dict[str, Any]:
+    """Build the final order history response dict."""
     summary = _calculate_order_summary(response_orders)
 
     ret_market = "mixed"
@@ -295,6 +391,79 @@ async def get_order_history_impl(
         "total_available": total_available,
         "errors": errors,
     }
+
+
+async def get_order_history_impl(
+    symbol: str | None = None,
+    status: Literal["all", "pending", "filled", "cancelled"] = "all",
+    order_id: str | None = None,
+    market: str | None = None,
+    side: str | None = None,
+    days: int | None = None,
+    limit: int | None = 50,
+) -> dict[str, Any]:
+    (
+        symbol,
+        order_id,
+        market_hint,
+        side,
+        effective_days,
+        limit_val,
+        market_types,
+        normalized_symbol,
+    ) = _validate_history_inputs(
+        symbol, status, order_id, market, side, days, limit
+    )
+
+    _broker_fetchers = {
+        "crypto": lambda: _fetch_crypto_orders(
+            normalized_symbol, status, limit_val, limit or 50
+        ),
+        "equity_kr": lambda: _fetch_kr_orders(
+            normalized_symbol, status, effective_days
+        ),
+        "equity_us": lambda: _fetch_us_orders(
+            normalized_symbol, status, effective_days
+        ),
+    }
+
+    orders: list[dict[str, Any]] = []
+    errors: list[dict[str, Any]] = []
+
+    for m_type in market_types:
+        try:
+            fetcher = _broker_fetchers.get(m_type)
+            if fetcher is None:
+                continue
+            fetched = await fetcher()
+            source_market = _normalize_market_type_to_external(m_type)
+            for f in fetched:
+                f["_source_market"] = source_market
+            orders.extend(fetched)
+        except Exception as e:
+            errors.append({"market": m_type, "error": str(e)})
+
+    orders = _dedupe_orders(orders)
+    response_orders, total_available, truncated = _filter_and_sort_orders(
+        orders, status, order_id, side, limit_val,
+    )
+
+    return _build_history_response(
+        response_orders=response_orders,
+        errors=errors,
+        market_types=market_types,
+        normalized_symbol=normalized_symbol,
+        symbol=symbol,
+        status=status,
+        order_id=order_id,
+        market_hint=market_hint,
+        side=side,
+        days=days,
+        limit=limit,
+        truncated=truncated,
+        total_available=total_available,
+    )
+
 
 
 __all__ = [

--- a/app/mcp_server/tooling/orders_history.py
+++ b/app/mcp_server/tooling/orders_history.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from typing import Any, Literal
 
 import app.services.brokers.upbit.client as upbit_service
-from app.mcp_server.tooling import order_execution as _order_execution
+from app.mcp_server.tooling.order_execution import (
+    _calculate_date_range,
+    _normalize_market_type_to_external,
+)
 from app.mcp_server.tooling.orders_modify_cancel import (
     _extract_kis_order_number,
     _get_kis_field,
@@ -24,17 +27,6 @@ from app.mcp_server.tooling.shared import (
 )
 from app.services.brokers.kis.client import KISClient
 from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
-
-_calculate_date_range = _order_execution._calculate_date_range
-_normalize_market_type_to_external = _order_execution._normalize_market_type_to_external
-_get_current_price_for_order = _order_execution._get_current_price_for_order
-_get_holdings_for_order = _order_execution._get_holdings_for_order
-_get_balance_for_order = _order_execution._get_balance_for_order
-_check_daily_order_limit = _order_execution._check_daily_order_limit
-_record_order_history = _order_execution._record_order_history
-_preview_order = _order_execution._preview_order
-_execute_order = _order_execution._execute_order
-_place_order_impl = _order_execution._place_order_impl
 
 
 def _calculate_order_summary(orders: list[dict[str, Any]]) -> dict[str, Any]:
@@ -104,9 +96,7 @@ def _validate_history_inputs(
     normalized_symbol: str | None = None
 
     if symbol:
-        market_type, normalized_symbol = _resolve_market_type(
-            symbol, market_hint
-        )
+        market_type, normalized_symbol = _resolve_market_type(symbol, market_hint)
         market_types = [market_type]
     elif market_hint:
         norm = _normalize_market(market_hint)
@@ -144,15 +134,11 @@ async def _fetch_crypto_orders(
     fetched: list[dict[str, Any]] = []
 
     if status in ("all", "pending"):
-        open_ops = await upbit_service.fetch_open_orders(
-            market=normalized_symbol
-        )
+        open_ops = await upbit_service.fetch_open_orders(market=normalized_symbol)
         fetched.extend([_normalize_upbit_order(o) for o in open_ops])
 
     if status in ("all", "filled", "cancelled") and normalized_symbol:
-        fetch_limit = (
-            100 if limit_val == float("inf") else max(limit, 20)
-        )
+        fetch_limit = 100 if limit_val == float("inf") else max(limit, 20)
         closed_ops = await upbit_service.fetch_closed_orders(
             market=normalized_symbol,
             limit=fetch_limit,
@@ -172,14 +158,10 @@ async def _fetch_kr_orders(
     kis = KISClient()
 
     if status in ("all", "pending"):
-        logger.debug(
-            "Fetching KR pending orders, symbol=%s", normalized_symbol
-        )
+        logger.debug("Fetching KR pending orders, symbol=%s", normalized_symbol)
         open_ops = await kis.inquire_korea_orders()
         if open_ops:
-            logger.debug(
-                "Raw API response keys: %s", list(open_ops[0].keys())
-            )
+            logger.debug("Raw API response keys: %s", list(open_ops[0].keys()))
         for o in open_ops:
             o_sym = str(_get_kis_field(o, "pdno", "PDNO"))
             if normalized_symbol and o_sym != normalized_symbol:
@@ -187,9 +169,7 @@ async def _fetch_kr_orders(
             fetched.append(_normalize_kis_domestic_order(o))
 
     if status in ("all", "filled", "cancelled") and normalized_symbol:
-        lookup_days = (
-            effective_days if effective_days is not None else 30
-        )
+        lookup_days = effective_days if effective_days is not None else 30
         start_dt, end_dt = _calculate_date_range(lookup_days)
         hist_ops = await kis.inquire_daily_order_domestic(
             start_date=start_dt,
@@ -197,9 +177,7 @@ async def _fetch_kr_orders(
             stock_code=normalized_symbol,
             side="00",
         )
-        fetched.extend(
-            [_normalize_kis_domestic_order(o) for o in hist_ops]
-        )
+        fetched.extend([_normalize_kis_domestic_order(o) for o in hist_ops])
 
     return fetched
 
@@ -216,9 +194,7 @@ async def _fetch_us_orders(
     if status in ("all", "pending"):
         target_exchanges = ["NASD", "NYSE", "AMEX"]
         if normalized_symbol:
-            target_exchanges = [
-                await get_us_exchange_by_symbol(normalized_symbol)
-            ]
+            target_exchanges = [await get_us_exchange_by_symbol(normalized_symbol)]
 
         seen_oids: set[str] = set()
         for ex in target_exchanges:
@@ -238,9 +214,7 @@ async def _fetch_us_orders(
                 pass
 
     if status in ("all", "filled", "cancelled") and normalized_symbol:
-        lookup_days = (
-            effective_days if effective_days is not None else 30
-        )
+        lookup_days = effective_days if effective_days is not None else 30
         start_dt, end_dt = _calculate_date_range(lookup_days)
         ex = await get_us_exchange_by_symbol(normalized_symbol)
         hist_ops = await kis.inquire_daily_order_overseas(
@@ -250,9 +224,7 @@ async def _fetch_us_orders(
             exchange_code=ex,
             side="00",
         )
-        fetched.extend(
-            [_normalize_kis_overseas_order(o) for o in hist_ops]
-        )
+        fetched.extend([_normalize_kis_overseas_order(o) for o in hist_ops])
 
     return fetched
 
@@ -265,9 +237,7 @@ def _dedupe_orders(
     unique_orders: dict[tuple[Any, ...], dict[str, Any]] = {}
     for o in orders:
         oid = str(o.get("order_id") or "").strip()
-        source_market = (
-            o.get("_source_market") or o.get("market") or "unknown"
-        )
+        source_market = o.get("_source_market") or o.get("market") or "unknown"
         if oid:
             key = (source_market, oid)
             unique_orders[key] = o
@@ -411,9 +381,7 @@ async def get_order_history_impl(
         limit_val,
         market_types,
         normalized_symbol,
-    ) = _validate_history_inputs(
-        symbol, status, order_id, market, side, days, limit
-    )
+    ) = _validate_history_inputs(symbol, status, order_id, market, side, days, limit)
 
     _broker_fetchers = {
         "crypto": lambda: _fetch_crypto_orders(
@@ -445,7 +413,11 @@ async def get_order_history_impl(
 
     orders = _dedupe_orders(orders)
     response_orders, total_available, truncated = _filter_and_sort_orders(
-        orders, status, order_id, side, limit_val,
+        orders,
+        status,
+        order_id,
+        side,
+        limit_val,
     )
 
     return _build_history_response(
@@ -465,17 +437,6 @@ async def get_order_history_impl(
     )
 
 
-
 __all__ = [
     "get_order_history_impl",
-    "_place_order_impl",
-    "_calculate_date_range",
-    "_normalize_market_type_to_external",
-    "_get_current_price_for_order",
-    "_get_holdings_for_order",
-    "_get_balance_for_order",
-    "_check_daily_order_limit",
-    "_record_order_history",
-    "_preview_order",
-    "_execute_order",
 ]

--- a/app/mcp_server/tooling/orders_modify_cancel.py
+++ b/app/mcp_server/tooling/orders_modify_cancel.py
@@ -383,11 +383,16 @@ def _normalize_kis_overseas_order(order: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-async def cancel_order_impl(
+def _validate_cancel_inputs(
     order_id: str,
-    symbol: str | None = None,
-    market: str | None = None,
-) -> dict[str, Any]:
+    symbol: str | None,
+    market: str | None,
+) -> tuple[str, str | None, str]:
+    """Validate and resolve cancel order inputs.
+
+    Returns:
+        (order_id, symbol, market_type)
+    """
     order_id = (order_id or "").strip()
     if not order_id:
         raise ValueError("order_id is required")
@@ -402,255 +407,280 @@ async def cancel_order_impl(
             market_type = "crypto"
         else:
             raise ValueError(
-                "market must be specified when symbol is not provided and order_id is not a UUID"
+                "market must be specified when symbol is not provided "
+                "and order_id is not a UUID"
             )
 
-    try:
-        if market_type == "crypto":
-            results = await upbit_service.cancel_orders([order_id])
-            if results and len(results) > 0:
-                result = results[0]
-                if "error" in result:
-                    return {
-                        "success": False,
-                        "order_id": order_id,
-                        "error": result.get("error"),
-                    }
-                return {
-                    "success": True,
-                    "order_id": order_id,
-                    "cancelled_at": result.get("created_at", ""),
-                }
+    return order_id, symbol, market_type
+
+
+async def _cancel_upbit(order_id: str) -> dict[str, Any]:
+    """Cancel an Upbit (crypto) order."""
+    results = await upbit_service.cancel_orders([order_id])
+    if results and len(results) > 0:
+        result = results[0]
+        if "error" in result:
             return {
                 "success": False,
                 "order_id": order_id,
-                "error": "No result from Upbit",
+                "error": result.get("error"),
+            }
+        return {
+            "success": True,
+            "order_id": order_id,
+            "cancelled_at": result.get("created_at", ""),
+        }
+    return {
+        "success": False,
+        "order_id": order_id,
+        "error": "No result from Upbit",
+    }
+
+
+async def _cancel_kis_domestic(
+    order_id: str,
+    symbol: str | None,
+) -> dict[str, Any]:
+    """Cancel a KIS domestic (Korean equity) order."""
+    if not symbol:
+        try:
+            kis = KISClient()
+            open_orders = await kis.inquire_korea_orders()
+            for order in open_orders:
+                if (
+                    str(
+                        _get_kis_field(order, "odno", "ODNO", "ord_no", "ORD_NO")
+                    )
+                    == order_id
+                ):
+                    symbol = str(_get_kis_field(order, "pdno", "PDNO"))
+                    break
+        except Exception as exc:
+            return {
+                "success": False,
+                "order_id": order_id,
+                "error": f"Failed to auto-retrieve order details: {exc}",
             }
 
-        if market_type == "equity_kr":
-            if not symbol:
-                try:
-                    kis = KISClient()
-                    open_orders = await kis.inquire_korea_orders()
-                    for order in open_orders:
-                        if (
-                            str(
-                                _get_kis_field(
-                                    order, "odno", "ODNO", "ord_no", "ORD_NO"
-                                )
-                            )
-                            == order_id
-                        ):
-                            symbol = str(_get_kis_field(order, "pdno", "PDNO"))
-                            break
-                except Exception as exc:
-                    return {
-                        "success": False,
-                        "order_id": order_id,
-                        "error": f"Failed to auto-retrieve order details: {exc}",
-                    }
+    if not symbol:
+        return {
+            "success": False,
+            "order_id": order_id,
+            "error": "symbol not found in order",
+        }
 
-            if not symbol:
-                return {
-                    "success": False,
-                    "order_id": order_id,
-                    "error": "symbol not found in order",
-                }
+    try:
+        kis = KISClient()
+        side_code = "02"
+        price = 0
+        quantity = 1
+        krx_fwdg_ord_orgno = None
 
-            try:
-                kis = KISClient()
-                side_code = "02"
-                price = 0
-                quantity = 1
-                krx_fwdg_ord_orgno = None
-
-                open_orders = await kis.inquire_korea_orders()
-                for order in open_orders:
-                    if (
-                        str(_get_kis_field(order, "odno", "ODNO", "ord_no", "ORD_NO"))
-                        == order_id
-                    ):
-                        side_code = _get_kis_field(
-                            order,
-                            "sll_buy_dvsn_cd",
-                            "SLL_BUY_DVSN_CD",
-                            default="02",
-                        )
-                        price = int(
-                            float(
-                                _get_kis_field(order, "ord_unpr", "ORD_UNPR", default=0)
-                                or 0
-                            )
-                        )
-                        quantity = int(
-                            float(
-                                _get_kis_field(order, "ord_qty", "ORD_QTY", default=0)
-                                or 0
-                            )
-                        )
-                        orgno_value = _get_kis_field(
-                            order,
-                            "ord_gno_brno",
-                            "ORD_GNO_BRNO",
-                            default="",
-                        )
-                        if orgno_value:
-                            krx_fwdg_ord_orgno = str(orgno_value).strip()
-                        break
-
-                order_type_str = "buy" if side_code == "02" else "sell"
-                result = await kis.cancel_korea_order(
-                    order_number=order_id,
-                    stock_code=symbol,
-                    quantity=quantity,
-                    price=price,
-                    order_type=order_type_str,
-                    krx_fwdg_ord_orgno=krx_fwdg_ord_orgno,
+        open_orders = await kis.inquire_korea_orders()
+        for order in open_orders:
+            if (
+                str(_get_kis_field(order, "odno", "ODNO", "ord_no", "ORD_NO"))
+                == order_id
+            ):
+                side_code = _get_kis_field(
+                    order,
+                    "sll_buy_dvsn_cd",
+                    "SLL_BUY_DVSN_CD",
+                    default="02",
                 )
-                return {
-                    "success": True,
-                    "order_id": order_id,
-                    "symbol": symbol,
-                    "cancelled_at": result.get("ord_tmd", ""),
-                }
-            except Exception as exc:
-                return {
-                    "success": False,
-                    "order_id": order_id,
-                    "symbol": symbol,
-                    "error": str(exc),
-                }
-
-        if market_type == "equity_us":
-            try:
-                kis = KISClient()
-                (
-                    target_order,
-                    target_exchange,
-                    exchange_candidates,
-                ) = await _find_us_open_order_by_id(kis, order_id, symbol)
-                logger.debug(
-                    "US cancel lookup: order_id=%s symbol=%s checked_exchanges=%s",
-                    order_id,
-                    symbol,
-                    ", ".join(exchange_candidates),
-                )
-
-                # If not in open orders, try recent history
-                if target_order is None and symbol:
-                    (
-                        target_order,
-                        target_exchange,
-                    ) = await _find_us_order_in_recent_history(
-                        kis, order_id, symbol, exchange_candidates
-                    )
-
-                if target_order is None:
-                    return {
-                        "success": False,
-                        "order_id": order_id,
-                        "error": (
-                            "Order not found in open orders or recent history "
-                            f"(checked exchanges: {','.join(exchange_candidates)})"
-                        ),
-                        "market": _normalize_market_type_to_external(market_type),
-                    }
-
-                if not symbol:
-                    symbol = str(_get_kis_field(target_order, "pdno", "PDNO")) or None
-
-                if not symbol:
-                    return {
-                        "success": False,
-                        "order_id": order_id,
-                        "error": "symbol not found in order",
-                        "market": _normalize_market_type_to_external(market_type),
-                    }
-
-                # Try to get remaining quantity from open order fields first
-                remaining_quantity = int(
+                price = int(
                     float(
-                        _get_kis_field(target_order, "nccs_qty", "NCCS_QTY", default=0)
+                        _get_kis_field(order, "ord_unpr", "ORD_UNPR", default=0)
                         or 0
                     )
                 )
-
-                # If remaining_quantity is available (>0), use it directly
-                if remaining_quantity > 0:
-                    quantity = remaining_quantity
-                else:
-                    # Calculate remaining from ordered - filled (for history or open orders without nccs_qty)
-                    ordered = int(
-                        float(
-                            _get_kis_field(
-                                target_order, "ft_ord_qty", "FT_ORD_QTY", default=0
-                            )
-                            or 0
-                        )
+                quantity = int(
+                    float(
+                        _get_kis_field(order, "ord_qty", "ORD_QTY", default=0)
+                        or 0
                     )
-                    filled = int(
-                        float(
-                            _get_kis_field(
-                                target_order, "ft_ccld_qty", "FT_CCLD_QTY", default=0
-                            )
-                            or 0
-                        )
+                )
+                orgno_value = _get_kis_field(
+                    order,
+                    "ord_gno_brno",
+                    "ORD_GNO_BRNO",
+                    default="",
+                )
+                if orgno_value:
+                    krx_fwdg_ord_orgno = str(orgno_value).strip()
+                break
+
+        order_type_str = "buy" if side_code == "02" else "sell"
+        result = await kis.cancel_korea_order(
+            order_number=order_id,
+            stock_code=symbol,
+            quantity=quantity,
+            price=price,
+            order_type=order_type_str,
+            krx_fwdg_ord_orgno=krx_fwdg_ord_orgno,
+        )
+        return {
+            "success": True,
+            "order_id": order_id,
+            "symbol": symbol,
+            "cancelled_at": result.get("ord_tmd", ""),
+        }
+    except Exception as exc:
+        return {
+            "success": False,
+            "order_id": order_id,
+            "symbol": symbol,
+            "error": str(exc),
+        }
+
+
+async def _cancel_kis_overseas(
+    order_id: str,
+    symbol: str | None,
+) -> dict[str, Any]:
+    """Cancel a KIS overseas (US equity) order."""
+    try:
+        kis = KISClient()
+        (
+            target_order,
+            target_exchange,
+            exchange_candidates,
+        ) = await _find_us_open_order_by_id(kis, order_id, symbol)
+        logger.debug(
+            "US cancel lookup: order_id=%s symbol=%s checked_exchanges=%s",
+            order_id,
+            symbol,
+            ", ".join(exchange_candidates),
+        )
+
+        # If not in open orders, try recent history
+        if target_order is None and symbol:
+            (
+                target_order,
+                target_exchange,
+            ) = await _find_us_order_in_recent_history(
+                kis, order_id, symbol, exchange_candidates
+            )
+
+        if target_order is None:
+            return {
+                "success": False,
+                "order_id": order_id,
+                "error": (
+                    "Order not found in open orders or recent history "
+                    f"(checked exchanges: {','.join(exchange_candidates)})"
+                ),
+                "market": _normalize_market_type_to_external("equity_us"),
+            }
+
+        if not symbol:
+            symbol = str(_get_kis_field(target_order, "pdno", "PDNO")) or None
+
+        if not symbol:
+            return {
+                "success": False,
+                "order_id": order_id,
+                "error": "symbol not found in order",
+                "market": _normalize_market_type_to_external("equity_us"),
+            }
+
+        # Try to get remaining quantity from open order fields first
+        remaining_quantity = int(
+            float(
+                _get_kis_field(target_order, "nccs_qty", "NCCS_QTY", default=0)
+                or 0
+            )
+        )
+
+        if remaining_quantity > 0:
+            quantity = remaining_quantity
+        else:
+            # Calculate remaining from ordered - filled
+            ordered = int(
+                float(
+                    _get_kis_field(
+                        target_order, "ft_ord_qty", "FT_ORD_QTY", default=0
                     )
-                    quantity = max(ordered - filled, 0)
-
-                    # KIS cancel requires a concrete order quantity in current client usage.
-                    # Fail closed if neither open orders nor recent history can reconstruct it.
-                    if quantity <= 0:
-                        return {
-                            "success": False,
-                            "order_id": order_id,
-                            "symbol": symbol,
-                            "error": "Unable to resolve remaining quantity from open orders or recent history",
-                            "market": _normalize_market_type_to_external(market_type),
-                        }
-
-                if quantity <= 0:
-                    return {
-                        "success": False,
-                        "order_id": order_id,
-                        "symbol": symbol,
-                        "error": "Unable to resolve cancel quantity from open order",
-                        "market": _normalize_market_type_to_external(market_type),
-                    }
-
-                # Normalize exchange from order payload or fallback to candidate
-                exchange_code = _normalize_kis_exchange_code(
-                    target_exchange or exchange_candidates[0]
+                    or 0
                 )
-                logger.info(
-                    "US cancel resolved: order_id=%s symbol=%s checked_exchanges=%s selected_exchange=%s resolved_quantity=%s",
-                    order_id,
-                    symbol,
-                    ", ".join(exchange_candidates),
-                    exchange_code,
-                    quantity,
+            )
+            filled = int(
+                float(
+                    _get_kis_field(
+                        target_order, "ft_ccld_qty", "FT_CCLD_QTY", default=0
+                    )
+                    or 0
                 )
+            )
+            quantity = max(ordered - filled, 0)
 
-                result = await kis.cancel_overseas_order(
-                    order_number=order_id,
-                    symbol=symbol,
-                    exchange_code=exchange_code,
-                    quantity=quantity,
-                )
-                return {
-                    "success": True,
-                    "order_id": order_id,
-                    "symbol": symbol,
-                    "cancelled_at": result.get("ord_tmd", ""),
-                }
-            except Exception as exc:
+            if quantity <= 0:
                 return {
                     "success": False,
                     "order_id": order_id,
                     "symbol": symbol,
-                    "error": str(exc),
+                    "error": "Unable to resolve remaining quantity from open orders or recent history",
+                    "market": _normalize_market_type_to_external("equity_us"),
                 }
 
+        if quantity <= 0:
+            return {
+                "success": False,
+                "order_id": order_id,
+                "symbol": symbol,
+                "error": "Unable to resolve cancel quantity from open order",
+                "market": _normalize_market_type_to_external("equity_us"),
+            }
+
+        # Normalize exchange from order payload or fallback to candidate
+        exchange_code = _normalize_kis_exchange_code(
+            target_exchange or exchange_candidates[0]
+        )
+        logger.info(
+            "US cancel resolved: order_id=%s symbol=%s checked_exchanges=%s "
+            "selected_exchange=%s resolved_quantity=%s",
+            order_id,
+            symbol,
+            ", ".join(exchange_candidates),
+            exchange_code,
+            quantity,
+        )
+
+        result = await kis.cancel_overseas_order(
+            order_number=order_id,
+            symbol=symbol,
+            exchange_code=exchange_code,
+            quantity=quantity,
+        )
+        return {
+            "success": True,
+            "order_id": order_id,
+            "symbol": symbol,
+            "cancelled_at": result.get("ord_tmd", ""),
+        }
+    except Exception as exc:
+        return {
+            "success": False,
+            "order_id": order_id,
+            "symbol": symbol,
+            "error": str(exc),
+        }
+
+
+async def cancel_order_impl(
+    order_id: str,
+    symbol: str | None = None,
+    market: str | None = None,
+) -> dict[str, Any]:
+    order_id, symbol, market_type = _validate_cancel_inputs(order_id, symbol, market)
+
+    try:
+        if market_type == "crypto":
+            return await _cancel_upbit(order_id)
+        if market_type == "equity_kr":
+            return await _cancel_kis_domestic(order_id, symbol)
+        if market_type == "equity_us":
+            return await _cancel_kis_overseas(order_id, symbol)
         return {
             "success": False,
             "order_id": order_id,
@@ -662,6 +692,7 @@ async def cancel_order_impl(
             "order_id": order_id,
             "error": str(exc),
         }
+
 
 
 async def modify_order_impl(

--- a/app/mcp_server/tooling/orders_modify_cancel.py
+++ b/app/mcp_server/tooling/orders_modify_cancel.py
@@ -695,16 +695,22 @@ async def cancel_order_impl(
 
 
 
-async def modify_order_impl(
+def _validate_modify_inputs(
     order_id: str,
     symbol: str,
-    market: str | None = None,
-    new_price: float | None = None,
-    new_quantity: float | None = None,
-    dry_run: bool = True,
-) -> dict[str, Any]:
+    market: str | None,
+    new_price: float | None,
+    new_quantity: float | None,
+) -> tuple[str, str, str, str]:
+    """Validate modify order inputs.
+
+    Returns:
+        (order_id, symbol, market_type, normalized_symbol)
+    """
     if new_price is None and new_quantity is None:
-        raise ValueError("At least one of new_price or new_quantity must be specified")
+        raise ValueError(
+            "At least one of new_price or new_quantity must be specified"
+        )
     if new_price is not None and new_price <= 0:
         raise ValueError("new_price must be a positive number")
     if new_quantity is not None and new_quantity <= 0:
@@ -713,320 +719,437 @@ async def modify_order_impl(
     order_id = order_id.strip()
     symbol = symbol.strip()
     market_type, normalized_symbol = _resolve_market_type(symbol, market)
+    return order_id, symbol, market_type, normalized_symbol
 
-    if dry_run:
-        changes: dict[str, Any] = {
-            "price": {"from": None, "to": new_price} if new_price else None,
-            "quantity": {"from": None, "to": new_quantity} if new_quantity else None,
+
+def _build_modify_dry_run_response(
+    order_id: str,
+    normalized_symbol: str,
+    market_type: str,
+    new_price: float | None,
+    new_quantity: float | None,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Build dry-run preview response for modify order."""
+    changes: dict[str, Any] = {
+        "price": {"from": None, "to": new_price} if new_price else None,
+        "quantity": (
+            {"from": None, "to": new_quantity} if new_quantity else None
+        ),
+    }
+    return {
+        "success": True,
+        "status": "simulated",
+        "order_id": order_id,
+        "symbol": normalized_symbol,
+        "market": _normalize_market_type_to_external(market_type),
+        "changes": changes,
+        "method": "dry_run",
+        "dry_run": dry_run,
+        "message": f"Dry run - Preview changes for order {order_id}",
+    }
+
+
+async def _modify_upbit(
+    order_id: str,
+    normalized_symbol: str,
+    market_type: str,
+    new_price: float | None,
+    new_quantity: float | None,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Modify an Upbit (crypto) order via cancel-and-reorder."""
+    try:
+        original_order = await upbit_service.fetch_order_detail(order_id)
+
+        if original_order.get("state") != "wait":
+            return {
+                "success": False,
+                "status": "failed",
+                "order_id": order_id,
+                "symbol": normalized_symbol,
+                "market": _normalize_market_type_to_external(market_type),
+                "error": "Order not in wait state (cannot modify non-pending orders)",
+                "dry_run": dry_run,
+            }
+        if original_order.get("ord_type") != "limit":
+            return {
+                "success": False,
+                "status": "failed",
+                "order_id": order_id,
+                "symbol": normalized_symbol,
+                "market": _normalize_market_type_to_external(market_type),
+                "error": "Only limit orders can be modified (not market orders)",
+                "dry_run": dry_run,
+            }
+
+        original_price = float(original_order.get("price", 0) or 0)
+        original_quantity = float(
+            original_order.get("remaining_volume", 0) or 0
+        )
+        final_price = new_price if new_price is not None else original_price
+        final_quantity = (
+            new_quantity if new_quantity is not None else original_quantity
+        )
+
+        result = await upbit_service.cancel_and_reorder(
+            order_id, final_price, final_quantity
+        )
+        changes = {
+            "price": {"from": original_price, "to": final_price}
+            if final_price != original_price
+            else None,
+            "quantity": {"from": original_quantity, "to": final_quantity}
+            if final_quantity != original_quantity
+            else None,
         }
+
+        if result.get("new_order") and "uuid" in result["new_order"]:
+            return {
+                "success": True,
+                "status": "modified",
+                "order_id": order_id,
+                "new_order_id": result["new_order"]["uuid"],
+                "symbol": normalized_symbol,
+                "market": _normalize_market_type_to_external(market_type),
+                "changes": changes,
+                "method": "cancel_reorder",
+                "dry_run": dry_run,
+                "message": "Order modified via cancel and reorder",
+            }
         return {
-            "success": True,
-            "status": "simulated",
+            "success": False,
+            "status": "failed",
             "order_id": order_id,
             "symbol": normalized_symbol,
             "market": _normalize_market_type_to_external(market_type),
+            "error": result.get("cancel_result", {}).get(
+                "error", "Unknown error"
+            ),
             "changes": changes,
-            "method": "dry_run",
+            "method": "cancel_reorder",
             "dry_run": dry_run,
-            "message": f"Dry run - Preview changes for order {order_id}",
+        }
+    except Exception as exc:
+        return {
+            "success": False,
+            "status": "failed",
+            "order_id": order_id,
+            "symbol": normalized_symbol,
+            "market": _normalize_market_type_to_external(market_type),
+            "error": str(exc),
+            "changes": None,
+            "method": "cancel_reorder",
+            "dry_run": dry_run,
         }
 
-    if market_type == "crypto":
-        try:
-            original_order = await upbit_service.fetch_order_detail(order_id)
 
-            if original_order.get("state") != "wait":
-                return {
-                    "success": False,
-                    "status": "failed",
-                    "order_id": order_id,
-                    "symbol": normalized_symbol,
-                    "market": _normalize_market_type_to_external(market_type),
-                    "error": "Order not in wait state (cannot modify non-pending orders)",
-                    "dry_run": dry_run,
-                }
-            if original_order.get("ord_type") != "limit":
-                return {
-                    "success": False,
-                    "status": "failed",
-                    "order_id": order_id,
-                    "symbol": normalized_symbol,
-                    "market": _normalize_market_type_to_external(market_type),
-                    "error": "Only limit orders can be modified (not market orders)",
-                    "dry_run": dry_run,
-                }
-
-            original_price = float(original_order.get("price", 0) or 0)
-            original_quantity = float(original_order.get("remaining_volume", 0) or 0)
-            final_price = new_price if new_price is not None else original_price
-            final_quantity = (
-                new_quantity if new_quantity is not None else original_quantity
-            )
-
-            result = await upbit_service.cancel_and_reorder(
-                order_id, final_price, final_quantity
-            )
-            changes = {
-                "price": {"from": original_price, "to": final_price}
-                if final_price != original_price
-                else None,
-                "quantity": {"from": original_quantity, "to": final_quantity}
-                if final_quantity != original_quantity
-                else None,
-            }
-
-            if result.get("new_order") and "uuid" in result["new_order"]:
-                return {
-                    "success": True,
-                    "status": "modified",
-                    "order_id": order_id,
-                    "new_order_id": result["new_order"]["uuid"],
-                    "symbol": normalized_symbol,
-                    "market": _normalize_market_type_to_external(market_type),
-                    "changes": changes,
-                    "method": "cancel_reorder",
-                    "dry_run": dry_run,
-                    "message": "Order modified via cancel and reorder",
-                }
-            return {
-                "success": False,
-                "status": "failed",
-                "order_id": order_id,
-                "symbol": normalized_symbol,
-                "market": _normalize_market_type_to_external(market_type),
-                "error": result.get("cancel_result", {}).get("error", "Unknown error"),
-                "changes": changes,
-                "method": "cancel_reorder",
-                "dry_run": dry_run,
-            }
-        except Exception as exc:
-            return {
-                "success": False,
-                "status": "failed",
-                "order_id": order_id,
-                "symbol": normalized_symbol,
-                "market": _normalize_market_type_to_external(market_type),
-                "error": str(exc),
-                "changes": None,
-                "method": "cancel_reorder",
-                "dry_run": dry_run,
-            }
-
-    if market_type == "equity_kr":
-        try:
-            kis = KISClient()
-            open_orders = await kis.inquire_korea_orders()
-            target_order = None
-            for order in open_orders:
-                if (
-                    str(_get_kis_field(order, "odno", "ODNO", "ord_no", "ORD_NO"))
-                    == order_id
-                ):
-                    target_order = order
-                    break
-
-            if not target_order:
-                return {
-                    "success": False,
-                    "status": "failed",
-                    "order_id": order_id,
-                    "symbol": normalized_symbol,
-                    "market": _normalize_market_type_to_external(market_type),
-                    "error": "Order not found in open orders",
-                    "dry_run": dry_run,
-                }
-
-            original_price = int(
-                float(
-                    _get_kis_field(target_order, "ord_unpr", "ORD_UNPR", default=0) or 0
+async def _modify_kis_domestic(
+    order_id: str,
+    normalized_symbol: str,
+    market_type: str,
+    new_price: float | None,
+    new_quantity: float | None,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Modify a KIS domestic (Korean equity) order."""
+    try:
+        kis = KISClient()
+        open_orders = await kis.inquire_korea_orders()
+        target_order = None
+        for order in open_orders:
+            if (
+                str(
+                    _get_kis_field(
+                        order, "odno", "ODNO", "ord_no", "ORD_NO"
+                    )
                 )
-            )
-            original_quantity = int(
-                float(
-                    _get_kis_field(target_order, "ord_qty", "ORD_QTY", default=0) or 0
+                == order_id
+            ):
+                target_order = order
+                break
+
+        if not target_order:
+            return {
+                "success": False,
+                "status": "failed",
+                "order_id": order_id,
+                "symbol": normalized_symbol,
+                "market": _normalize_market_type_to_external(market_type),
+                "error": "Order not found in open orders",
+                "dry_run": dry_run,
+            }
+
+        original_price = int(
+            float(
+                _get_kis_field(
+                    target_order, "ord_unpr", "ORD_UNPR", default=0
                 )
-            )
-            side_code = _get_kis_field(
-                target_order, "sll_buy_dvsn_cd", "SLL_BUY_DVSN_CD"
-            )
-            side = "buy" if side_code == "02" else "sell"
-
-            final_price_raw = (
-                int(new_price) if new_price is not None else original_price
-            )
-            final_price = int(adjust_tick_size_kr(float(final_price_raw), side))
-            final_quantity = (
-                int(new_quantity) if new_quantity is not None else original_quantity
-            )
-
-            krx_fwdg_ord_orgno = _get_kis_field(
-                target_order,
-                "ord_gno_brno",
-                "ORD_GNO_BRNO",
-                default="",
-            )
-            if krx_fwdg_ord_orgno:
-                krx_fwdg_ord_orgno = str(krx_fwdg_ord_orgno).strip()
-            else:
-                krx_fwdg_ord_orgno = None
-
-            result = await kis.modify_korea_order(
-                order_id,
-                normalized_symbol,
-                final_quantity,
-                final_price,
-                krx_fwdg_ord_orgno=krx_fwdg_ord_orgno,
-            )
-            changes = {
-                "price": {"from": original_price, "to": final_price}
-                if final_price != original_price
-                else None,
-                "quantity": {"from": original_quantity, "to": final_quantity}
-                if final_quantity != original_quantity
-                else None,
-            }
-
-            if result.get("odno"):
-                return {
-                    "success": True,
-                    "status": "modified",
-                    "order_id": order_id,
-                    "new_order_id": result["odno"],
-                    "symbol": normalized_symbol,
-                    "market": _normalize_market_type_to_external(market_type),
-                    "changes": changes,
-                    "method": "api_modify",
-                    "dry_run": dry_run,
-                    "message": "Order modified via KIS API",
-                }
-            return {
-                "success": False,
-                "status": "failed",
-                "order_id": order_id,
-                "symbol": normalized_symbol,
-                "market": _normalize_market_type_to_external(market_type),
-                "error": result.get("msg", "Unknown error"),
-                "changes": changes,
-                "method": "api_modify",
-                "dry_run": dry_run,
-            }
-        except Exception as exc:
-            return {
-                "success": False,
-                "status": "failed",
-                "order_id": order_id,
-                "symbol": normalized_symbol,
-                "market": _normalize_market_type_to_external(market_type),
-                "error": str(exc),
-                "changes": None,
-                "method": "api_modify",
-                "dry_run": dry_run,
-            }
-
-    if market_type == "equity_us":
-        try:
-            kis = KISClient()
-            (
-                target_order,
-                target_exchange,
-                exchange_candidates,
-            ) = await _find_us_open_order_by_id(kis, order_id, normalized_symbol)
-            logger.debug(
-                "US modify lookup: order_id=%s symbol=%s checked_exchanges=%s",
-                order_id,
-                normalized_symbol,
-                ", ".join(exchange_candidates),
-            )
-
-            if not target_order:
-                return {
-                    "success": False,
-                    "status": "failed",
-                    "order_id": order_id,
-                    "symbol": normalized_symbol,
-                    "market": _normalize_market_type_to_external(market_type),
-                    "error": f"Order not found in open orders (checked: {','.join(exchange_candidates)})",
-                    "dry_run": dry_run,
-                }
-
-            original_price = float(
-                _get_kis_field(target_order, "ft_ord_unpr3", "FT_ORD_UNPR3", default=0)
                 or 0
             )
-            original_quantity = int(
-                float(
-                    _get_kis_field(target_order, "ft_ord_qty", "FT_ORD_QTY", default=0)
-                    or 0
+        )
+        original_quantity = int(
+            float(
+                _get_kis_field(
+                    target_order, "ord_qty", "ORD_QTY", default=0
                 )
+                or 0
             )
+        )
+        side_code = _get_kis_field(
+            target_order, "sll_buy_dvsn_cd", "SLL_BUY_DVSN_CD"
+        )
+        side = "buy" if side_code == "02" else "sell"
 
-            exchange_code = target_exchange or exchange_candidates[0]
-            logger.info(
-                "US modify resolved: order_id=%s symbol=%s checked_exchanges=%s selected_exchange=%s",
-                order_id,
-                normalized_symbol,
-                ", ".join(exchange_candidates),
-                exchange_code,
-            )
-            final_price = float(new_price) if new_price is not None else original_price
-            final_quantity = (
-                int(new_quantity) if new_quantity is not None else original_quantity
-            )
+        final_price_raw = (
+            int(new_price) if new_price is not None else original_price
+        )
+        final_price = int(adjust_tick_size_kr(float(final_price_raw), side))
+        final_quantity = (
+            int(new_quantity) if new_quantity is not None else original_quantity
+        )
 
-            result = await kis.modify_overseas_order(
-                order_id,
-                normalized_symbol,
-                exchange_code,
-                final_quantity,
-                final_price,
-            )
-            changes = {
-                "price": {"from": original_price, "to": final_price}
-                if final_price != original_price
-                else None,
-                "quantity": {"from": original_quantity, "to": final_quantity}
-                if final_quantity != original_quantity
-                else None,
+        krx_fwdg_ord_orgno = _get_kis_field(
+            target_order,
+            "ord_gno_brno",
+            "ORD_GNO_BRNO",
+            default="",
+        )
+        if krx_fwdg_ord_orgno:
+            krx_fwdg_ord_orgno = str(krx_fwdg_ord_orgno).strip()
+        else:
+            krx_fwdg_ord_orgno = None
+
+        result = await kis.modify_korea_order(
+            order_id,
+            normalized_symbol,
+            final_quantity,
+            final_price,
+            krx_fwdg_ord_orgno=krx_fwdg_ord_orgno,
+        )
+        changes = {
+            "price": {"from": original_price, "to": final_price}
+            if final_price != original_price
+            else None,
+            "quantity": {"from": original_quantity, "to": final_quantity}
+            if final_quantity != original_quantity
+            else None,
+        }
+
+        if result.get("odno"):
+            return {
+                "success": True,
+                "status": "modified",
+                "order_id": order_id,
+                "new_order_id": result["odno"],
+                "symbol": normalized_symbol,
+                "market": _normalize_market_type_to_external(market_type),
+                "changes": changes,
+                "method": "api_modify",
+                "dry_run": dry_run,
+                "message": "Order modified via KIS API",
             }
+        return {
+            "success": False,
+            "status": "failed",
+            "order_id": order_id,
+            "symbol": normalized_symbol,
+            "market": _normalize_market_type_to_external(market_type),
+            "error": result.get("msg", "Unknown error"),
+            "changes": changes,
+            "method": "api_modify",
+            "dry_run": dry_run,
+        }
+    except Exception as exc:
+        return {
+            "success": False,
+            "status": "failed",
+            "order_id": order_id,
+            "symbol": normalized_symbol,
+            "market": _normalize_market_type_to_external(market_type),
+            "error": str(exc),
+            "changes": None,
+            "method": "api_modify",
+            "dry_run": dry_run,
+        }
 
-            if result.get("odno"):
-                return {
-                    "success": True,
-                    "status": "modified",
-                    "order_id": order_id,
-                    "new_order_id": result["odno"],
-                    "symbol": normalized_symbol,
-                    "market": _normalize_market_type_to_external(market_type),
-                    "exchange": exchange_code,
-                    "changes": changes,
-                    "method": "api_modify",
-                    "dry_run": dry_run,
-                    "message": "Order modified via KIS API",
-                }
+
+async def _modify_kis_overseas(
+    order_id: str,
+    normalized_symbol: str,
+    market_type: str,
+    new_price: float | None,
+    new_quantity: float | None,
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Modify a KIS overseas (US equity) order."""
+    try:
+        kis = KISClient()
+        (
+            target_order,
+            target_exchange,
+            exchange_candidates,
+        ) = await _find_us_open_order_by_id(
+            kis, order_id, normalized_symbol
+        )
+        logger.debug(
+            "US modify lookup: order_id=%s symbol=%s checked_exchanges=%s",
+            order_id,
+            normalized_symbol,
+            ", ".join(exchange_candidates),
+        )
+
+        if not target_order:
             return {
                 "success": False,
                 "status": "failed",
                 "order_id": order_id,
+                "symbol": normalized_symbol,
+                "market": _normalize_market_type_to_external(market_type),
+                "error": f"Order not found in open orders (checked: {','.join(exchange_candidates)})",
+                "dry_run": dry_run,
+            }
+
+        original_price = float(
+            _get_kis_field(
+                target_order, "ft_ord_unpr3", "FT_ORD_UNPR3", default=0
+            )
+            or 0
+        )
+        original_quantity = int(
+            float(
+                _get_kis_field(
+                    target_order, "ft_ord_qty", "FT_ORD_QTY", default=0
+                )
+                or 0
+            )
+        )
+
+        exchange_code = target_exchange or exchange_candidates[0]
+        logger.info(
+            "US modify resolved: order_id=%s symbol=%s "
+            "checked_exchanges=%s selected_exchange=%s",
+            order_id,
+            normalized_symbol,
+            ", ".join(exchange_candidates),
+            exchange_code,
+        )
+        final_price = (
+            float(new_price) if new_price is not None else original_price
+        )
+        final_quantity = (
+            int(new_quantity)
+            if new_quantity is not None
+            else original_quantity
+        )
+
+        result = await kis.modify_overseas_order(
+            order_id,
+            normalized_symbol,
+            exchange_code,
+            final_quantity,
+            final_price,
+        )
+        changes = {
+            "price": {"from": original_price, "to": final_price}
+            if final_price != original_price
+            else None,
+            "quantity": {"from": original_quantity, "to": final_quantity}
+            if final_quantity != original_quantity
+            else None,
+        }
+
+        if result.get("odno"):
+            return {
+                "success": True,
+                "status": "modified",
+                "order_id": order_id,
+                "new_order_id": result["odno"],
                 "symbol": normalized_symbol,
                 "market": _normalize_market_type_to_external(market_type),
                 "exchange": exchange_code,
-                "error": result.get("msg", "Unknown error"),
                 "changes": changes,
                 "method": "api_modify",
                 "dry_run": dry_run,
+                "message": "Order modified via KIS API",
             }
-        except Exception as exc:
-            return {
-                "success": False,
-                "status": "failed",
-                "order_id": order_id,
-                "symbol": normalized_symbol,
-                "market": _normalize_market_type_to_external(market_type),
-                "error": str(exc),
-                "changes": None,
-                "method": "api_modify",
-                "dry_run": dry_run,
-            }
+        return {
+            "success": False,
+            "status": "failed",
+            "order_id": order_id,
+            "symbol": normalized_symbol,
+            "market": _normalize_market_type_to_external(market_type),
+            "exchange": exchange_code,
+            "error": result.get("msg", "Unknown error"),
+            "changes": changes,
+            "method": "api_modify",
+            "dry_run": dry_run,
+        }
+    except Exception as exc:
+        return {
+            "success": False,
+            "status": "failed",
+            "order_id": order_id,
+            "symbol": normalized_symbol,
+            "market": _normalize_market_type_to_external(market_type),
+            "error": str(exc),
+            "changes": None,
+            "method": "api_modify",
+            "dry_run": dry_run,
+        }
+
+
+async def modify_order_impl(
+    order_id: str,
+    symbol: str,
+    market: str | None = None,
+    new_price: float | None = None,
+    new_quantity: float | None = None,
+    dry_run: bool = True,
+) -> dict[str, Any]:
+    order_id, symbol, market_type, normalized_symbol = (
+        _validate_modify_inputs(
+            order_id, symbol, market, new_price, new_quantity
+        )
+    )
+
+    if dry_run:
+        return _build_modify_dry_run_response(
+            order_id,
+            normalized_symbol,
+            market_type,
+            new_price,
+            new_quantity,
+            dry_run,
+        )
+
+    if market_type == "crypto":
+        return await _modify_upbit(
+            order_id,
+            normalized_symbol,
+            market_type,
+            new_price,
+            new_quantity,
+            dry_run,
+        )
+    if market_type == "equity_kr":
+        return await _modify_kis_domestic(
+            order_id,
+            normalized_symbol,
+            market_type,
+            new_price,
+            new_quantity,
+            dry_run,
+        )
+    if market_type == "equity_us":
+        return await _modify_kis_overseas(
+            order_id,
+            normalized_symbol,
+            market_type,
+            new_price,
+            new_quantity,
+            dry_run,
+        )
 
     return {
         "success": False,
@@ -1037,6 +1160,7 @@ async def modify_order_impl(
         "error": f"modify_order is not supported for market '{market_type}'",
         "dry_run": dry_run,
     }
+
 
 
 __all__ = [

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
-from app.mcp_server.tooling import orders_history
+from app.mcp_server.tooling import order_execution, orders_history
 from app.mcp_server.tooling.orders_modify_cancel import (
     cancel_order_impl,
     modify_order_impl,
@@ -79,9 +79,9 @@ def register_order_tools(mcp: FastMCP) -> None:
         stop_loss: float | None = None,
         min_hold_days: int | None = None,
         notes: str | None = None,
-        indicators_snapshot: dict | None = None,
+        indicators_snapshot: dict[str, Any] | None = None,
     ):
-        return await orders_history._place_order_impl(
+        return await order_execution._place_order_impl(
             symbol=symbol,
             side=side,
             order_type=order_type,


### PR DESCRIPTION
## Summary
This PR addresses 3 MEDIUM issues identified during code review of the order broker-split refactor:

1. **Remove re-export aliases** (`orders_history.py`)
   - Removed 10 module-level alias re-exports from `orders_history.py`
   - `orders_registration.py` now imports `_place_order_impl` directly from `order_execution`
   - Cleaned up `__all__` to only export `get_order_history_impl`

2. **Split `_record_fill_and_journals`** (`order_execution.py`)
   - Extracted 3 focused helper functions:
     - `_handle_buy_journal`: Trade journal creation for buy orders (41 lines)
     - `_handle_sell_journal`: Journal closing for sell orders (39 lines)
     - `_save_and_link_fill`: Fill recording and journal linking (51 lines)
   - Main function reduced from 139 to ~98 lines

3. **Remove `globals()` indirection** (`order_execution.py`)
   - `_build_preview` now calls `_preview_order` directly
   - Added `_build_order_error` module function for standardized error responses
   - Simplified `_order_error` closure to delegate to helper

## Test Plan
- [x] `tests/test_mcp_order_tools.py` - 32 tests passing
- [x] `tests/test_mcp_place_order.py` - 66 tests passing  
- [x] `tests/test_portfolio_position_detail_service.py` - 32 tests passing
- [x] Lint check: `ruff check` - All checks passed

## Commits
- `63b16418` - refactor: remove re-export aliases from orders_history
- `1815e66f` - refactor: split _record_fill_and_journals into focused helpers
- `cfe34020` - refactor: remove globals() indirection + add _build_order_error helper