### PR TITLE
feat(paper): add paper trading DB models and migration

### DIFF
--- a/alembic/versions/0a610ecdbacf_add_paper_trading_tables.py
+++ b/alembic/versions/0a610ecdbacf_add_paper_trading_tables.py
@@ -1,0 +1,201 @@
+"""add paper trading tables
+
+Revision ID: 0a610ecdbacf
+Revises: 3e1f0c7a9b2d
+Create Date: 2026-04-13 13:43:27.916878
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "0a610ecdbacf"
+down_revision: str | Sequence[str] | None = "3e1f0c7a9b2d"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Existing instrument_type enum — reuse, do not create
+instrument_type_enum = postgresql.ENUM(
+    "equity_kr", "equity_us", "crypto", "forex", "index",
+    name="instrument_type",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. Create paper schema
+    # ------------------------------------------------------------------
+    op.execute("CREATE SCHEMA IF NOT EXISTS paper")
+
+    # ------------------------------------------------------------------
+    # 2. paper.paper_accounts
+    # ------------------------------------------------------------------
+    op.create_table(
+        "paper_accounts",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("initial_capital", sa.Numeric(20, 4), nullable=False),
+        sa.Column("cash_krw", sa.Numeric(20, 4), nullable=False),
+        sa.Column(
+            "cash_usd",
+            sa.Numeric(20, 4),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("strategy_name", sa.String(length=128), nullable=True),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("name", name="uq_paper_accounts_name"),
+        schema="paper",
+    )
+
+    # ------------------------------------------------------------------
+    # 3. paper.paper_positions
+    # ------------------------------------------------------------------
+    op.create_table(
+        "paper_positions",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("account_id", sa.BigInteger(), nullable=False),
+        sa.Column("symbol", sa.String(length=32), nullable=False),
+        sa.Column("instrument_type", instrument_type_enum, nullable=False),
+        sa.Column("quantity", sa.Numeric(20, 8), nullable=False),
+        sa.Column("avg_price", sa.Numeric(20, 8), nullable=False),
+        sa.Column("total_invested", sa.Numeric(20, 4), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["account_id"],
+            ["paper.paper_accounts.id"],
+            ondelete="CASCADE",
+            name="fk_paper_positions_account_id",
+        ),
+        sa.UniqueConstraint(
+            "account_id", "symbol", name="uq_paper_positions_account_symbol"
+        ),
+        schema="paper",
+    )
+    op.create_index(
+        "ix_paper_positions_account_id",
+        "paper_positions",
+        ["account_id"],
+        schema="paper",
+    )
+    op.create_index(
+        "ix_paper_positions_symbol",
+        "paper_positions",
+        ["symbol"],
+        schema="paper",
+    )
+
+    # ------------------------------------------------------------------
+    # 4. paper.paper_trades
+    # ------------------------------------------------------------------
+    op.create_table(
+        "paper_trades",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("account_id", sa.BigInteger(), nullable=False),
+        sa.Column("symbol", sa.String(length=32), nullable=False),
+        sa.Column("instrument_type", instrument_type_enum, nullable=False),
+        sa.Column("side", sa.String(length=4), nullable=False),
+        sa.Column("order_type", sa.String(length=8), nullable=False),
+        sa.Column("quantity", sa.Numeric(20, 8), nullable=False),
+        sa.Column("price", sa.Numeric(20, 8), nullable=False),
+        sa.Column("total_amount", sa.Numeric(20, 4), nullable=False),
+        sa.Column("fee", sa.Numeric(20, 4), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("realized_pnl", sa.Numeric(20, 4), nullable=True),
+        sa.Column(
+            "executed_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["account_id"],
+            ["paper.paper_accounts.id"],
+            ondelete="CASCADE",
+            name="fk_paper_trades_account_id",
+        ),
+        sa.CheckConstraint("side IN ('buy','sell')", name="paper_trades_side"),
+        sa.CheckConstraint(
+            "order_type IN ('limit','market')", name="paper_trades_order_type"
+        ),
+        sa.CheckConstraint(
+            "currency IN ('KRW','USD')", name="paper_trades_currency"
+        ),
+        schema="paper",
+    )
+    op.create_index(
+        "ix_paper_trades_account_symbol",
+        "paper_trades",
+        ["account_id", "symbol"],
+        schema="paper",
+    )
+    op.create_index(
+        "ix_paper_trades_account_executed_at",
+        "paper_trades",
+        ["account_id", "executed_at"],
+        schema="paper",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_paper_trades_account_executed_at",
+        table_name="paper_trades",
+        schema="paper",
+    )
+    op.drop_index(
+        "ix_paper_trades_account_symbol",
+        table_name="paper_trades",
+        schema="paper",
+    )
+    op.drop_table("paper_trades", schema="paper")
+
+    op.drop_index(
+        "ix_paper_positions_symbol",
+        table_name="paper_positions",
+        schema="paper",
+    )
+    op.drop_index(
+        "ix_paper_positions_account_id",
+        table_name="paper_positions",
+        schema="paper",
+    )
+    op.drop_table("paper_positions", schema="paper")
+
+    op.drop_table("paper_accounts", schema="paper")
+
+    op.execute("DROP SCHEMA IF EXISTS paper")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -10,6 +10,7 @@ from .manual_holdings import (
     StockAlias,
 )
 from .news import NewsAnalysisResult, NewsArticle, Sentiment
+from .paper_trading import PaperAccount, PaperPosition, PaperTrade
 from .prompt import PromptResult
 from .research_backtest import (
     ResearchBacktestPair,
@@ -81,6 +82,9 @@ __all__ = [
     "TradeJournal",
     "JournalStatus",
     "PendingSnapshot",
+    "PaperAccount",
+    "PaperPosition",
+    "PaperTrade",
     # "AlertRule", "AlertEvent",
     # "PricesLatest", "PricesOHLCV", "FxRate",
 ]

--- a/app/models/paper_trading.py
+++ b/app/models/paper_trading.py
@@ -1,0 +1,138 @@
+"""Paper trading (모의투자) models — paper schema."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    Enum,
+    ForeignKey,
+    Index,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.models.base import Base
+from app.models.trading import InstrumentType
+
+
+# ---------------------------------------------------------------------------
+# paper.paper_accounts — virtual accounts with cash balances
+# ---------------------------------------------------------------------------
+class PaperAccount(Base):
+    __tablename__ = "paper_accounts"
+    __table_args__ = (
+        UniqueConstraint("name", name="uq_paper_accounts_name"),
+        {"schema": "paper"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    name: Mapped[str] = mapped_column(String(128), nullable=False)
+    initial_capital: Mapped[Decimal] = mapped_column(Numeric(20, 4), nullable=False)
+    cash_krw: Mapped[Decimal] = mapped_column(Numeric(20, 4), nullable=False)
+    cash_usd: Mapped[Decimal] = mapped_column(
+        Numeric(20, 4), nullable=False, default=Decimal("0"), server_default="0"
+    )
+    description: Mapped[str | None] = mapped_column(Text)
+    strategy_name: Mapped[str | None] = mapped_column(String(128))
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# paper.paper_positions — current holdings per account+symbol
+# ---------------------------------------------------------------------------
+class PaperPosition(Base):
+    __tablename__ = "paper_positions"
+    __table_args__ = (
+        UniqueConstraint(
+            "account_id", "symbol", name="uq_paper_positions_account_symbol"
+        ),
+        Index("ix_paper_positions_account_id", "account_id"),
+        Index("ix_paper_positions_symbol", "symbol"),
+        {"schema": "paper"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    account_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("paper.paper_accounts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    symbol: Mapped[str] = mapped_column(String(32), nullable=False)
+    instrument_type: Mapped[InstrumentType] = mapped_column(
+        Enum(InstrumentType, name="instrument_type", create_type=False), nullable=False
+    )
+    quantity: Mapped[Decimal] = mapped_column(Numeric(20, 8), nullable=False)
+    avg_price: Mapped[Decimal] = mapped_column(Numeric(20, 8), nullable=False)
+    total_invested: Mapped[Decimal] = mapped_column(Numeric(20, 4), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# paper.paper_trades — executed (simulated) trade records
+# ---------------------------------------------------------------------------
+class PaperTrade(Base):
+    __tablename__ = "paper_trades"
+    __table_args__ = (
+        CheckConstraint("side IN ('buy','sell')", name="paper_trades_side"),
+        CheckConstraint(
+            "order_type IN ('limit','market')", name="paper_trades_order_type"
+        ),
+        CheckConstraint(
+            "currency IN ('KRW','USD')", name="paper_trades_currency"
+        ),
+        Index("ix_paper_trades_account_symbol", "account_id", "symbol"),
+        Index("ix_paper_trades_account_executed_at", "account_id", "executed_at"),
+        {"schema": "paper"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    account_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("paper.paper_accounts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    symbol: Mapped[str] = mapped_column(String(32), nullable=False)
+    instrument_type: Mapped[InstrumentType] = mapped_column(
+        Enum(InstrumentType, name="instrument_type", create_type=False), nullable=False
+    )
+    side: Mapped[str] = mapped_column(String(4), nullable=False)
+    order_type: Mapped[str] = mapped_column(String(8), nullable=False)
+    quantity: Mapped[Decimal] = mapped_column(Numeric(20, 8), nullable=False)
+    price: Mapped[Decimal] = mapped_column(Numeric(20, 8), nullable=False)
+    total_amount: Mapped[Decimal] = mapped_column(Numeric(20, 4), nullable=False)
+    fee: Mapped[Decimal] = mapped_column(Numeric(20, 4), nullable=False)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    reason: Mapped[str | None] = mapped_column(Text)
+    realized_pnl: Mapped[Decimal | None] = mapped_column(Numeric(20, 4))
+    executed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/tests/test_paper_trading_model.py
+++ b/tests/test_paper_trading_model.py
@@ -1,0 +1,102 @@
+"""Unit tests for paper trading models (PaperAccount / PaperPosition / PaperTrade)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from app.models.paper_trading import PaperAccount, PaperPosition, PaperTrade
+from app.models.trading import InstrumentType
+
+
+class TestPaperAccountModel:
+    def test_create_minimal_account(self) -> None:
+        account = PaperAccount(
+            name="기본 모의계좌",
+            initial_capital=Decimal("10000000"),
+            cash_krw=Decimal("10000000"),
+        )
+        assert account.name == "기본 모의계좌"
+        assert account.initial_capital == Decimal("10000000")
+        assert account.cash_krw == Decimal("10000000")
+
+    def test_create_full_account(self) -> None:
+        account = PaperAccount(
+            name="데이트레이딩",
+            initial_capital=Decimal("5000000"),
+            cash_krw=Decimal("4500000"),
+            cash_usd=Decimal("100.50"),
+            description="단타 전략 전용",
+            strategy_name="rsi_mean_reversion",
+            is_active=True,
+        )
+        assert account.description == "단타 전략 전용"
+        assert account.strategy_name == "rsi_mean_reversion"
+        assert account.is_active is True
+
+    def test_table_args(self) -> None:
+        # schema dict is always the last element of __table_args__
+        assert PaperAccount.__table_args__[-1] == {"schema": "paper"}
+        assert PaperAccount.__tablename__ == "paper_accounts"
+
+
+class TestPaperPositionModel:
+    def test_create_position(self) -> None:
+        position = PaperPosition(
+            account_id=1,
+            symbol="KRW-BTC",
+            instrument_type=InstrumentType.crypto,
+            quantity=Decimal("0.00123456"),
+            avg_price=Decimal("85000000"),
+            total_invested=Decimal("104987.76"),
+        )
+        assert position.account_id == 1
+        assert position.symbol == "KRW-BTC"
+        assert position.instrument_type == InstrumentType.crypto
+        assert position.quantity == Decimal("0.00123456")
+
+    def test_table_args(self) -> None:
+        assert PaperPosition.__table_args__[-1] == {"schema": "paper"}
+        assert PaperPosition.__tablename__ == "paper_positions"
+
+
+class TestPaperTradeModel:
+    def test_create_buy_trade(self) -> None:
+        trade = PaperTrade(
+            account_id=1,
+            symbol="AAPL",
+            instrument_type=InstrumentType.equity_us,
+            side="buy",
+            order_type="limit",
+            quantity=Decimal("10"),
+            price=Decimal("175.50"),
+            total_amount=Decimal("1755.00"),
+            fee=Decimal("0.88"),
+            currency="USD",
+            reason="momentum entry",
+        )
+        assert trade.side == "buy"
+        assert trade.order_type == "limit"
+        assert trade.currency == "USD"
+        assert trade.realized_pnl is None
+
+    def test_create_sell_trade_with_pnl(self) -> None:
+        trade = PaperTrade(
+            account_id=1,
+            symbol="AAPL",
+            instrument_type=InstrumentType.equity_us,
+            side="sell",
+            order_type="market",
+            quantity=Decimal("10"),
+            price=Decimal("200.00"),
+            total_amount=Decimal("2000.00"),
+            fee=Decimal("1.00"),
+            currency="USD",
+            realized_pnl=Decimal("244.12"),
+            executed_at=datetime.now(UTC),
+        )
+        assert trade.realized_pnl == Decimal("244.12")
+
+    def test_table_args(self) -> None:
+        assert PaperTrade.__table_args__[-1] == {"schema": "paper"}
+        assert PaperTrade.__tablename__ == "paper_trades"


### PR DESCRIPTION
## Summary
- `paper` 스키마 + 3개 테이블(`paper_accounts`, `paper_positions`, `paper_trades`) 추가 — 모의투자(paper trading) Phase 1A
- `PaperAccount` / `PaperPosition` / `PaperTrade` SQLAlchemy 모델 추가 (`app/models/paper_trading.py`)
- 기존 `instrument_type` enum 재사용(`create_type=False`) — 중복 타입 생성 방지
- Alembic 마이그레이션 `0a610ecdbacf` (down_revision=`3e1f0c7a9b2d`), `upgrade`/`downgrade` 모두 구현
- 단위 테스트 8개 (`tests/test_paper_trading_model.py`) — 모델 생성/`__table_args__`/스키마 검증

## Test plan
- [x] `uv run pytest tests/test_paper_trading_model.py -v` — 8 passed
- [x] `uv run alembic upgrade head` — `paper.paper_accounts`, `paper.paper_positions`, `paper.paper_trades` 생성 확인
- [x] `instrument_type` enum 개수 = 1 (중복 없음)
- [x] FK / unique / check / index 제약 DB에서 실제 확인 (CASCADE 포함)
- [ ] CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paper trading functionality, enabling users to create virtual trading accounts, simulate trades, and track positions across multiple instruments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->