### PR TITLE
feat(paper): MCP place_order/get_order_history paper trading 통합

### DIFF
--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -31,7 +31,10 @@ def register_order_tools(mcp: FastMCP) -> None:
         description=(
             "Get order history for a symbol. Supports Upbit (crypto) and KIS "
             "(KR/US equities). Pending orders can be queried without a symbol, "
-            "but filled/cancelled/all queries require symbol."
+            "but filled/cancelled/all queries require symbol. "
+            "Set account_type='paper' to query the virtual paper-trading "
+            "account's trade history instead; pass paper_account to target a "
+            "named paper account (defaults to 'default')."
         ),
     )
     async def get_order_history(
@@ -42,7 +45,20 @@ def register_order_tools(mcp: FastMCP) -> None:
         side: str | None = None,
         days: int | None = None,
         limit: int | None = 50,
+        account_type: Literal["real", "paper"] = "real",
+        paper_account: str | None = None,
     ):
+        if account_type == "paper":
+            return await _get_paper_order_history(
+                symbol=symbol,
+                status=status,
+                order_id=order_id,
+                market=market,
+                side=side,
+                days=days,
+                limit=limit,
+                paper_account_name=paper_account,
+            )
         return await orders_history.get_order_history_impl(
             symbol=symbol,
             status=status,

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -9,6 +9,10 @@ from app.mcp_server.tooling.orders_modify_cancel import (
     cancel_order_impl,
     modify_order_impl,
 )
+from app.mcp_server.tooling.paper_order_handler import (
+    _get_paper_order_history,
+    _place_paper_order,
+)
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -60,7 +64,12 @@ def register_order_tools(mcp: FastMCP) -> None:
             "For real sell orders, active trade journals are auto-closed in FIFO order. "
             "Use exit_reason to record the sell thesis in the journal. "
             "Safety limit: max 20 orders/day. "
-            "dry_run=True by default for safety."
+            "dry_run=True by default for safety. "
+            "Set account_type='paper' to route to the virtual paper-trading engine "
+            "(no real broker calls, uses PaperTradingService). In paper mode, the "
+            "default account is auto-created with 100,000,000 KRW on first use; "
+            "pass paper_account to target a named paper account. "
+            "In paper mode, thesis/strategy/journal parameters are ignored."
         ),
     )
     async def place_order(
@@ -80,7 +89,21 @@ def register_order_tools(mcp: FastMCP) -> None:
         min_hold_days: int | None = None,
         notes: str | None = None,
         indicators_snapshot: dict[str, Any] | None = None,
+        account_type: Literal["real", "paper"] = "real",
+        paper_account: str | None = None,
     ):
+        if account_type == "paper":
+            return await _place_paper_order(
+                symbol=symbol,
+                side=side,
+                order_type=order_type,
+                quantity=quantity,
+                price=price,
+                amount=amount,
+                dry_run=dry_run,
+                reason=reason,
+                paper_account_name=paper_account,
+            )
         return await order_execution._place_order_impl(
             symbol=symbol,
             side=side,

--- a/app/mcp_server/tooling/paper_order_handler.py
+++ b/app/mcp_server/tooling/paper_order_handler.py
@@ -1,0 +1,111 @@
+"""MCP shim that routes `place_order` / `get_order_history` to paper trading.
+
+Keeps paper-only code isolated from the live order execution path.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from app.core.db import AsyncSessionLocal
+from app.mcp_server.tooling.shared import logger
+from app.models.paper_trading import PaperAccount
+from app.services.paper_trading_service import PaperTradingService
+
+DEFAULT_PAPER_ACCOUNT_NAME = "default"
+DEFAULT_PAPER_INITIAL_CAPITAL_KRW = Decimal("100000000")  # 1억 KRW
+
+
+def _paper_error(message: str, *, symbol: str | None = None) -> dict[str, Any]:
+    """Build a paper-trading error response with the `[Paper]` prefix."""
+    result: dict[str, Any] = {
+        "success": False,
+        "account_type": "paper",
+        "error": f"[Paper] {message}",
+        "source": "paper",
+    }
+    if symbol is not None:
+        result["symbol"] = symbol
+    return result
+
+
+async def _resolve_paper_account(
+    service: PaperTradingService,
+    name: str | None,
+) -> PaperAccount:
+    """Return the named paper account, auto-creating the default one if missing.
+
+    Only the default account is auto-created; an explicit name that does not
+    exist raises ValueError so users don't create typo'd ghost accounts.
+    """
+    account_name = name or DEFAULT_PAPER_ACCOUNT_NAME
+    account = await service.get_account_by_name(account_name)
+    if account is not None:
+        return account
+
+    if name is not None and name != DEFAULT_PAPER_ACCOUNT_NAME:
+        raise ValueError(f"Paper account '{name}' not found")
+
+    return await service.create_account(
+        name=DEFAULT_PAPER_ACCOUNT_NAME,
+        initial_capital_krw=DEFAULT_PAPER_INITIAL_CAPITAL_KRW,
+        description="Auto-created default paper account",
+    )
+
+
+async def _place_paper_order(
+    *,
+    symbol: str,
+    side: str,
+    order_type: str,
+    quantity: float | None,
+    price: float | None,
+    amount: float | None,
+    dry_run: bool,
+    reason: str,
+    paper_account_name: str | None,
+) -> dict[str, Any]:
+    """Route a `place_order` call to the paper trading engine."""
+    try:
+        async with AsyncSessionLocal() as db:
+            service = PaperTradingService(db)
+            try:
+                account = await _resolve_paper_account(service, paper_account_name)
+            except ValueError as exc:
+                return _paper_error(str(exc), symbol=symbol)
+
+            if dry_run:
+                preview = await service.preview_order(
+                    account_id=account.id,
+                    symbol=symbol,
+                    side=side,
+                    order_type=order_type,
+                    quantity=quantity,
+                    price=price,
+                    amount=amount,
+                )
+                return {
+                    "success": True,
+                    "dry_run": True,
+                    "account_type": "paper",
+                    "paper_account": account.name,
+                    "account_id": account.id,
+                    "preview": preview["preview"],
+                    "message": "[Paper] Order preview (dry_run=True)",
+                }
+
+            # Real execution wired up in a later task.
+            raise NotImplementedError("paper execute path not yet implemented")
+    except ValueError as exc:
+        return _paper_error(str(exc), symbol=symbol)
+    except Exception as exc:  # pragma: no cover — unexpected failure
+        logger.exception("Paper order failed: %s", exc)
+        return _paper_error(f"unexpected error: {exc}", symbol=symbol)
+
+
+__all__ = [
+    "DEFAULT_PAPER_ACCOUNT_NAME",
+    "DEFAULT_PAPER_INITIAL_CAPITAL_KRW",
+    "_place_paper_order",
+]

--- a/app/mcp_server/tooling/paper_order_handler.py
+++ b/app/mcp_server/tooling/paper_order_handler.py
@@ -122,8 +122,61 @@ async def _place_paper_order(
         return _paper_error(f"unexpected error: {exc}", symbol=symbol)
 
 
+async def _get_paper_order_history(
+    *,
+    symbol: str | None,
+    status: str,
+    order_id: str | None,
+    market: str | None,
+    side: str | None,
+    days: int | None,
+    limit: int | None,
+    paper_account_name: str | None,
+) -> dict[str, Any]:
+    """Return paper trade history in a shape compatible with the live tool.
+
+    `status`, `order_id`, and `market` are accepted for signature parity with
+    the live tool but are not meaningful for paper trades (all paper trades
+    are immediate fills). They are echoed back in the response for tracing.
+    """
+    del order_id, market  # signature parity only
+    limit_val = limit if limit is not None else 50
+
+    try:
+        async with AsyncSessionLocal() as db:
+            service = PaperTradingService(db)
+            try:
+                account = await _resolve_paper_account(service, paper_account_name)
+            except ValueError as exc:
+                return _paper_error(str(exc), symbol=symbol)
+
+            rows = await service.get_trade_history(
+                account_id=account.id,
+                symbol=symbol,
+                side=side,
+                days=days,
+                limit=limit_val,
+            )
+
+            return {
+                "success": True,
+                "account_type": "paper",
+                "paper_account": account.name,
+                "account_id": account.id,
+                "orders": rows,
+                "total_available": len(rows),
+                "truncated": False,
+                "status": status,
+                "errors": [],
+            }
+    except Exception as exc:  # pragma: no cover — unexpected failure
+        logger.exception("Paper history failed: %s", exc)
+        return _paper_error(f"unexpected error: {exc}", symbol=symbol)
+
+
 __all__ = [
     "DEFAULT_PAPER_ACCOUNT_NAME",
     "DEFAULT_PAPER_INITIAL_CAPITAL_KRW",
     "_place_paper_order",
+    "_get_paper_order_history",
 ]

--- a/app/mcp_server/tooling/paper_order_handler.py
+++ b/app/mcp_server/tooling/paper_order_handler.py
@@ -95,8 +95,26 @@ async def _place_paper_order(
                     "message": "[Paper] Order preview (dry_run=True)",
                 }
 
-            # Real execution wired up in a later task.
-            raise NotImplementedError("paper execute path not yet implemented")
+            execution = await service.execute_order(
+                account_id=account.id,
+                symbol=symbol,
+                side=side,
+                order_type=order_type,
+                quantity=quantity,
+                price=price,
+                amount=amount,
+                reason=reason or "",
+            )
+            return {
+                "success": True,
+                "dry_run": False,
+                "account_type": "paper",
+                "paper_account": account.name,
+                "account_id": account.id,
+                "preview": execution["preview"],
+                "execution": execution["execution"],
+                "message": "[Paper] Order placed successfully",
+            }
     except ValueError as exc:
         return _paper_error(str(exc), symbol=symbol)
     except Exception as exc:  # pragma: no cover — unexpected failure

--- a/tests/test_paper_order_handler.py
+++ b/tests/test_paper_order_handler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -439,9 +440,7 @@ class TestPlaceOrderRegistration:
         live_stub = AsyncMock(return_value={"success": True, "dry_run": True})
 
         with (
-            patch.object(
-                orders_registration, "_place_paper_order", paper_stub
-            ),
+            patch.object(orders_registration, "_place_paper_order", paper_stub),
             patch.object(
                 orders_registration.order_execution,
                 "_place_order_impl",
@@ -488,9 +487,7 @@ class TestPlaceOrderRegistration:
         live_stub = AsyncMock(return_value={"success": True, "dry_run": True})
 
         with (
-            patch.object(
-                orders_registration, "_place_paper_order", paper_stub
-            ),
+            patch.object(orders_registration, "_place_paper_order", paper_stub),
             patch.object(
                 orders_registration.order_execution,
                 "_place_order_impl",
@@ -534,9 +531,7 @@ class TestGetOrderHistoryRegistration:
         live_stub = AsyncMock(return_value={"success": True, "orders": []})
 
         with (
-            patch.object(
-                orders_registration, "_get_paper_order_history", paper_stub
-            ),
+            patch.object(orders_registration, "_get_paper_order_history", paper_stub),
             patch.object(
                 orders_registration.orders_history,
                 "get_order_history_impl",
@@ -577,9 +572,7 @@ class TestGetOrderHistoryRegistration:
         live_stub = AsyncMock(return_value={"success": True, "orders": []})
 
         with (
-            patch.object(
-                orders_registration, "_get_paper_order_history", paper_stub
-            ),
+            patch.object(orders_registration, "_get_paper_order_history", paper_stub),
             patch.object(
                 orders_registration.orders_history,
                 "get_order_history_impl",

--- a/tests/test_paper_order_handler.py
+++ b/tests/test_paper_order_handler.py
@@ -412,3 +412,99 @@ class TestGetPaperOrderHistory:
         assert result["success"] is False
         assert result["error"].startswith("[Paper] ")
         assert "ghost" in result["error"]
+
+
+class TestPlaceOrderRegistration:
+    @pytest.mark.asyncio
+    async def test_account_type_paper_routes_to_paper_handler(self):
+        """register_order_tools must expose account_type and route paper calls."""
+        from app.mcp_server.tooling import orders_registration
+
+        registered: dict[str, Any] = {}
+
+        class DummyMCP:
+            def tool(self, name: str, description: str):
+                def _wrap(fn):
+                    registered[name] = fn
+                    return fn
+
+                return _wrap
+
+        orders_registration.register_order_tools(DummyMCP())
+        place_order = registered["place_order"]
+
+        paper_stub = AsyncMock(
+            return_value={"success": True, "account_type": "paper", "dry_run": True}
+        )
+        live_stub = AsyncMock(return_value={"success": True, "dry_run": True})
+
+        with (
+            patch.object(
+                orders_registration, "_place_paper_order", paper_stub
+            ),
+            patch.object(
+                orders_registration.order_execution,
+                "_place_order_impl",
+                live_stub,
+            ),
+        ):
+            result = await place_order(
+                symbol="005930",
+                side="buy",
+                order_type="limit",
+                quantity=10,
+                price=70000,
+                account_type="paper",
+                paper_account="swing",
+            )
+
+        assert result["account_type"] == "paper"
+        paper_stub.assert_awaited_once()
+        kwargs = paper_stub.await_args.kwargs
+        assert kwargs["symbol"] == "005930"
+        assert kwargs["side"] == "buy"
+        assert kwargs["paper_account_name"] == "swing"
+        assert kwargs["dry_run"] is True
+        live_stub.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_account_type_real_still_calls_live_impl(self):
+        from app.mcp_server.tooling import orders_registration
+
+        registered: dict[str, Any] = {}
+
+        class DummyMCP:
+            def tool(self, name: str, description: str):
+                def _wrap(fn):
+                    registered[name] = fn
+                    return fn
+
+                return _wrap
+
+        orders_registration.register_order_tools(DummyMCP())
+        place_order = registered["place_order"]
+
+        paper_stub = AsyncMock()
+        live_stub = AsyncMock(return_value={"success": True, "dry_run": True})
+
+        with (
+            patch.object(
+                orders_registration, "_place_paper_order", paper_stub
+            ),
+            patch.object(
+                orders_registration.order_execution,
+                "_place_order_impl",
+                live_stub,
+            ),
+        ):
+            result = await place_order(
+                symbol="005930",
+                side="buy",
+                order_type="limit",
+                quantity=10,
+                price=70000,
+            )
+
+        assert result["success"] is True
+        live_stub.assert_awaited_once()
+        paper_stub.assert_not_called()

--- a/tests/test_paper_order_handler.py
+++ b/tests/test_paper_order_handler.py
@@ -508,3 +508,86 @@ class TestPlaceOrderRegistration:
         assert result["success"] is True
         live_stub.assert_awaited_once()
         paper_stub.assert_not_called()
+
+
+class TestGetOrderHistoryRegistration:
+    @pytest.mark.asyncio
+    async def test_account_type_paper_routes_to_paper_history(self):
+        from app.mcp_server.tooling import orders_registration
+
+        registered: dict[str, Any] = {}
+
+        class DummyMCP:
+            def tool(self, name: str, description: str):
+                def _wrap(fn):
+                    registered[name] = fn
+                    return fn
+
+                return _wrap
+
+        orders_registration.register_order_tools(DummyMCP())
+        get_order_history = registered["get_order_history"]
+
+        paper_stub = AsyncMock(
+            return_value={"success": True, "account_type": "paper", "orders": []}
+        )
+        live_stub = AsyncMock(return_value={"success": True, "orders": []})
+
+        with (
+            patch.object(
+                orders_registration, "_get_paper_order_history", paper_stub
+            ),
+            patch.object(
+                orders_registration.orders_history,
+                "get_order_history_impl",
+                live_stub,
+            ),
+        ):
+            result = await get_order_history(
+                symbol="005930",
+                account_type="paper",
+                paper_account="swing",
+            )
+
+        assert result["account_type"] == "paper"
+        paper_stub.assert_awaited_once()
+        kwargs = paper_stub.await_args.kwargs
+        assert kwargs["symbol"] == "005930"
+        assert kwargs["paper_account_name"] == "swing"
+        live_stub.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_account_type_real_still_calls_live_history(self):
+        from app.mcp_server.tooling import orders_registration
+
+        registered: dict[str, Any] = {}
+
+        class DummyMCP:
+            def tool(self, name: str, description: str):
+                def _wrap(fn):
+                    registered[name] = fn
+                    return fn
+
+                return _wrap
+
+        orders_registration.register_order_tools(DummyMCP())
+        get_order_history = registered["get_order_history"]
+
+        paper_stub = AsyncMock()
+        live_stub = AsyncMock(return_value={"success": True, "orders": []})
+
+        with (
+            patch.object(
+                orders_registration, "_get_paper_order_history", paper_stub
+            ),
+            patch.object(
+                orders_registration.orders_history,
+                "get_order_history_impl",
+                live_stub,
+            ),
+        ):
+            result = await get_order_history(symbol="005930")
+
+        assert result["success"] is True
+        live_stub.assert_awaited_once()
+        paper_stub.assert_not_called()

--- a/tests/test_paper_order_handler.py
+++ b/tests/test_paper_order_handler.py
@@ -308,3 +308,107 @@ class TestPlacePaperOrderExecute:
         assert result["account_type"] == "paper"
         assert result["error"].startswith("[Paper] ")
         assert "Insufficient KRW balance" in result["error"]
+
+
+class TestGetPaperOrderHistory:
+    @pytest.mark.asyncio
+    async def test_history_returns_service_rows(self):
+        account = _make_account()
+        service = MagicMock()
+        service.get_account_by_name = AsyncMock(return_value=account)
+        service.get_trade_history = AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "symbol": "005930",
+                    "instrument_type": "equity_kr",
+                    "side": "buy",
+                    "order_type": "limit",
+                    "quantity": Decimal("10"),
+                    "price": Decimal("70000"),
+                    "total_amount": Decimal("700000"),
+                    "fee": Decimal("105"),
+                    "currency": "KRW",
+                    "reason": None,
+                    "realized_pnl": None,
+                    "executed_at": None,
+                }
+            ]
+        )
+
+        fake_session_cm = AsyncMock()
+        fake_session_cm.__aenter__.return_value = MagicMock()
+        fake_session_cm.__aexit__.return_value = None
+
+        with (
+            patch.object(
+                paper_order_handler,
+                "AsyncSessionLocal",
+                return_value=fake_session_cm,
+            ),
+            patch.object(
+                paper_order_handler,
+                "PaperTradingService",
+                return_value=service,
+            ),
+        ):
+            result = await paper_order_handler._get_paper_order_history(
+                symbol="005930",
+                status="all",
+                order_id=None,
+                market=None,
+                side=None,
+                days=None,
+                limit=50,
+                paper_account_name=None,
+            )
+
+        assert result["success"] is True
+        assert result["account_type"] == "paper"
+        assert result["paper_account"] == "default"
+        assert result["total_available"] == 1
+        assert result["truncated"] is False
+        assert result["orders"][0]["symbol"] == "005930"
+        service.get_trade_history.assert_awaited_once_with(
+            account_id=1,
+            symbol="005930",
+            side=None,
+            days=None,
+            limit=50,
+        )
+
+    @pytest.mark.asyncio
+    async def test_history_unknown_named_account_errors(self):
+        service = MagicMock()
+        service.get_account_by_name = AsyncMock(return_value=None)
+
+        fake_session_cm = AsyncMock()
+        fake_session_cm.__aenter__.return_value = MagicMock()
+        fake_session_cm.__aexit__.return_value = None
+
+        with (
+            patch.object(
+                paper_order_handler,
+                "AsyncSessionLocal",
+                return_value=fake_session_cm,
+            ),
+            patch.object(
+                paper_order_handler,
+                "PaperTradingService",
+                return_value=service,
+            ),
+        ):
+            result = await paper_order_handler._get_paper_order_history(
+                symbol=None,
+                status="all",
+                order_id=None,
+                market=None,
+                side=None,
+                days=None,
+                limit=50,
+                paper_account_name="ghost",
+            )
+
+        assert result["success"] is False
+        assert result["error"].startswith("[Paper] ")
+        assert "ghost" in result["error"]

--- a/tests/test_paper_order_handler.py
+++ b/tests/test_paper_order_handler.py
@@ -184,3 +184,127 @@ class TestPlacePaperOrderDryRun:
         assert result["error"].startswith("[Paper]")
         assert "ghost" in result["error"]
         service.create_account.assert_not_called()
+
+
+class TestPlacePaperOrderExecute:
+    @pytest.mark.asyncio
+    async def test_execute_returns_preview_and_execution(self):
+        account = _make_account()
+        service = MagicMock()
+        service.get_account_by_name = AsyncMock(return_value=account)
+        service.create_account = AsyncMock()
+        service.execute_order = AsyncMock(
+            return_value={
+                "success": True,
+                "dry_run": False,
+                "account_id": 1,
+                "preview": {
+                    "symbol": "005930",
+                    "instrument_type": "equity_kr",
+                    "side": "buy",
+                    "order_type": "limit",
+                    "quantity": Decimal("10"),
+                    "price": Decimal("70000"),
+                    "gross": Decimal("700000"),
+                    "fee": Decimal("105"),
+                    "total_cost": Decimal("700105"),
+                    "currency": "KRW",
+                },
+                "execution": {
+                    "symbol": "005930",
+                    "instrument_type": "equity_kr",
+                    "side": "buy",
+                    "order_type": "limit",
+                    "quantity": Decimal("10"),
+                    "price": Decimal("70000"),
+                    "gross": Decimal("700000"),
+                    "fee": Decimal("105"),
+                    "total_cost": Decimal("700105"),
+                    "currency": "KRW",
+                    "realized_pnl": None,
+                    "executed_at": None,
+                },
+            }
+        )
+
+        fake_session_cm = AsyncMock()
+        fake_session_cm.__aenter__.return_value = MagicMock()
+        fake_session_cm.__aexit__.return_value = None
+
+        with (
+            patch.object(
+                paper_order_handler,
+                "AsyncSessionLocal",
+                return_value=fake_session_cm,
+            ),
+            patch.object(
+                paper_order_handler,
+                "PaperTradingService",
+                return_value=service,
+            ),
+        ):
+            result = await paper_order_handler._place_paper_order(
+                symbol="005930",
+                side="buy",
+                order_type="limit",
+                quantity=10,
+                price=70000,
+                amount=None,
+                dry_run=False,
+                reason="demo",
+                paper_account_name=None,
+            )
+
+        assert result["success"] is True
+        assert result["dry_run"] is False
+        assert result["account_type"] == "paper"
+        assert result["paper_account"] == "default"
+        assert result["preview"]["symbol"] == "005930"
+        assert result["execution"]["quantity"] == Decimal("10")
+        assert result["message"] == "[Paper] Order placed successfully"
+        service.execute_order.assert_awaited_once()
+        kwargs = service.execute_order.await_args.kwargs
+        assert kwargs["account_id"] == 1
+        assert kwargs["reason"] == "demo"
+
+    @pytest.mark.asyncio
+    async def test_execute_insufficient_balance_returns_prefixed_error(self):
+        account = _make_account()
+        service = MagicMock()
+        service.get_account_by_name = AsyncMock(return_value=account)
+        service.execute_order = AsyncMock(
+            side_effect=ValueError("Insufficient KRW balance: have 0, need 700105")
+        )
+
+        fake_session_cm = AsyncMock()
+        fake_session_cm.__aenter__.return_value = MagicMock()
+        fake_session_cm.__aexit__.return_value = None
+
+        with (
+            patch.object(
+                paper_order_handler,
+                "AsyncSessionLocal",
+                return_value=fake_session_cm,
+            ),
+            patch.object(
+                paper_order_handler,
+                "PaperTradingService",
+                return_value=service,
+            ),
+        ):
+            result = await paper_order_handler._place_paper_order(
+                symbol="005930",
+                side="buy",
+                order_type="limit",
+                quantity=10,
+                price=70000,
+                amount=None,
+                dry_run=False,
+                reason="",
+                paper_account_name=None,
+            )
+
+        assert result["success"] is False
+        assert result["account_type"] == "paper"
+        assert result["error"].startswith("[Paper] ")
+        assert "Insufficient KRW balance" in result["error"]

--- a/tests/test_paper_order_handler.py
+++ b/tests/test_paper_order_handler.py
@@ -1,0 +1,186 @@
+"""Unit tests for the paper order handler MCP shim."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.mcp_server.tooling import paper_order_handler
+from app.models.paper_trading import PaperAccount
+
+
+def _make_account(account_id: int = 1, name: str = "default") -> PaperAccount:
+    return PaperAccount(
+        id=account_id,
+        name=name,
+        initial_capital=Decimal("100000000"),
+        cash_krw=Decimal("100000000"),
+        cash_usd=Decimal("0"),
+        is_active=True,
+    )
+
+
+class TestPlacePaperOrderDryRun:
+    @pytest.mark.asyncio
+    async def test_dry_run_creates_default_account_when_missing(self):
+        service = MagicMock()
+        service.get_account_by_name = AsyncMock(return_value=None)
+        service.create_account = AsyncMock(return_value=_make_account())
+        service.preview_order = AsyncMock(
+            return_value={
+                "success": True,
+                "dry_run": True,
+                "account_id": 1,
+                "preview": {
+                    "symbol": "005930",
+                    "instrument_type": "equity_kr",
+                    "side": "buy",
+                    "order_type": "limit",
+                    "quantity": Decimal("10"),
+                    "price": Decimal("70000"),
+                    "gross": Decimal("700000"),
+                    "fee": Decimal("105"),
+                    "total_cost": Decimal("700105"),
+                    "currency": "KRW",
+                },
+            }
+        )
+
+        fake_session_cm = AsyncMock()
+        fake_session_cm.__aenter__.return_value = MagicMock()
+        fake_session_cm.__aexit__.return_value = None
+
+        with (
+            patch.object(
+                paper_order_handler,
+                "AsyncSessionLocal",
+                return_value=fake_session_cm,
+            ),
+            patch.object(
+                paper_order_handler,
+                "PaperTradingService",
+                return_value=service,
+            ),
+        ):
+            result = await paper_order_handler._place_paper_order(
+                symbol="005930",
+                side="buy",
+                order_type="limit",
+                quantity=10,
+                price=70000,
+                amount=None,
+                dry_run=True,
+                reason="",
+                paper_account_name=None,
+            )
+
+        assert result["success"] is True
+        assert result["dry_run"] is True
+        assert result["account_type"] == "paper"
+        assert result["paper_account"] == "default"
+        assert result["preview"]["symbol"] == "005930"
+        service.create_account.assert_awaited_once()
+        call_kwargs = service.create_account.await_args.kwargs
+        assert call_kwargs["name"] == "default"
+        assert call_kwargs["initial_capital_krw"] == Decimal("100000000")
+        service.preview_order.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_dry_run_uses_named_account(self):
+        account = _make_account(account_id=7, name="swing")
+        service = MagicMock()
+        service.get_account_by_name = AsyncMock(return_value=account)
+        service.create_account = AsyncMock()
+        service.preview_order = AsyncMock(
+            return_value={
+                "success": True,
+                "dry_run": True,
+                "account_id": 7,
+                "preview": {
+                    "symbol": "AAPL",
+                    "instrument_type": "equity_us",
+                    "side": "buy",
+                    "order_type": "market",
+                    "quantity": Decimal("1"),
+                    "price": Decimal("190"),
+                    "gross": Decimal("190"),
+                    "fee": Decimal("1"),
+                    "total_cost": Decimal("191"),
+                    "currency": "USD",
+                },
+            }
+        )
+
+        fake_session_cm = AsyncMock()
+        fake_session_cm.__aenter__.return_value = MagicMock()
+        fake_session_cm.__aexit__.return_value = None
+
+        with (
+            patch.object(
+                paper_order_handler,
+                "AsyncSessionLocal",
+                return_value=fake_session_cm,
+            ),
+            patch.object(
+                paper_order_handler,
+                "PaperTradingService",
+                return_value=service,
+            ),
+        ):
+            result = await paper_order_handler._place_paper_order(
+                symbol="AAPL",
+                side="buy",
+                order_type="market",
+                quantity=1,
+                price=None,
+                amount=None,
+                dry_run=True,
+                reason="",
+                paper_account_name="swing",
+            )
+
+        assert result["paper_account"] == "swing"
+        assert result["account_id"] == 7
+        service.create_account.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unknown_named_account_errors(self):
+        service = MagicMock()
+        service.get_account_by_name = AsyncMock(return_value=None)
+        service.create_account = AsyncMock()
+
+        fake_session_cm = AsyncMock()
+        fake_session_cm.__aenter__.return_value = MagicMock()
+        fake_session_cm.__aexit__.return_value = None
+
+        with (
+            patch.object(
+                paper_order_handler,
+                "AsyncSessionLocal",
+                return_value=fake_session_cm,
+            ),
+            patch.object(
+                paper_order_handler,
+                "PaperTradingService",
+                return_value=service,
+            ),
+        ):
+            result = await paper_order_handler._place_paper_order(
+                symbol="005930",
+                side="buy",
+                order_type="limit",
+                quantity=1,
+                price=70000,
+                amount=None,
+                dry_run=True,
+                reason="",
+                paper_account_name="ghost",
+            )
+
+        assert result["success"] is False
+        assert result["account_type"] == "paper"
+        assert result["error"].startswith("[Paper]")
+        assert "ghost" in result["error"]
+        service.create_account.assert_not_called()


### PR DESCRIPTION
## Summary
- `place_order` / `get_order_history` MCP 도구에 `account_type` (`real`|`paper`) 와 `paper_account` 파라미터 추가. `paper` 모드에서는 `PaperTradingService` 가상 엔진으로 라우팅되어 실제 브로커 호출 없이 시뮬레이션 주문을 수행한다.
- Paper 전용 경로는 신규 `app/mcp_server/tooling/paper_order_handler.py`로 격리 — 실전(`real`) 경로 코드는 전혀 수정하지 않음.
- 기본 계좌 `"default"`는 최초 사용 시 1억 KRW로 자동 생성. 이름을 명시한 계좌가 존재하지 않으면 `[Paper]` 프리픽스 에러 반환(오타 방지).

## 설계 포인트
- **실전 코드 불변**: `account_type="real"`이 기본값이며, `_place_order_impl` / `get_order_history_impl` 호출 경로는 그대로.
- **Paper 모드 제약**: `thesis` / `strategy` / trade journal 관련 파라미터는 MCP 시그니처에는 유지하되 paper 핸들러에 **전달하지 않음** (Phase 3에서 별도 연동 예정).
- **Out of scope (의도적)**: `modify_order`/`cancel_order` paper 라우팅(paper 체결은 즉시), 일일 주문 수 제한, crypto 손절 쿨다운, 심볼 유니버스 sync, KR tick-size 조정 — 모두 실전 전용 로직.
- 6개 커밋, TDD 순서대로 작성됨 (test → fail → implement → pass → commit).

## Test plan
- [x] `uv run pytest tests/test_paper_order_handler.py -v` — 11/11 passed
- [x] `uv run pytest tests/ -k "order" -m "not integration and not slow"` — 440 passed (unrelated 2 pre-existing failures in `test_kis_manual_holdings_integration.py`, main 에서도 동일하게 실패)
- [x] `uv run ruff check` on touched files — passed
- [x] `uv run ty check` on touched files — passed
- [ ] Staging 환경에서 `place_order(..., account_type="paper", dry_run=True)` 수동 호출로 end-to-end preview 응답 확인
- [ ] `place_order(..., account_type="paper", dry_run=False)` → `get_order_history(account_type="paper")`로 체결 기록 조회 확인
- [ ] 기존 실전 `place_order` / `get_order_history` 호출 동작이 바뀌지 않았는지 스모크 확인

## Plan
`docs/superpowers/plans/2026-04-13-mcp-place-order-paper-trading.md` 참조 (6 tasks, TDD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)