### PR TITLE
feat(paper): MCP 성과 분석 도구 (performance, trade log, comparison)

### DIFF
--- a/alembic/versions/1666768ca8ff_add_paper_daily_snapshots.py
+++ b/alembic/versions/1666768ca8ff_add_paper_daily_snapshots.py
@@ -1,0 +1,65 @@
+"""add paper daily snapshots
+
+Revision ID: 1666768ca8ff
+Revises: 0a610ecdbacf
+Create Date: 2026-04-13 16:18:56.616222
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = '1666768ca8ff'
+down_revision: Union[str, Sequence[str], None] = '0a610ecdbacf'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create paper.paper_daily_snapshots table."""
+    op.create_table(
+        'paper_daily_snapshots',
+        sa.Column('id', sa.BigInteger(), nullable=False),
+        sa.Column('account_id', sa.BigInteger(), nullable=False),
+        sa.Column('snapshot_date', sa.Date(), nullable=False),
+        sa.Column('cash_krw', sa.Numeric(precision=20, scale=4), nullable=False),
+        sa.Column('cash_usd', sa.Numeric(precision=20, scale=4), nullable=False),
+        sa.Column('positions_value', sa.Numeric(precision=20, scale=4), nullable=False),
+        sa.Column('total_equity', sa.Numeric(precision=20, scale=4), nullable=False),
+        sa.Column('daily_return_pct', sa.Numeric(precision=10, scale=4), nullable=True),
+        sa.Column(
+            'created_at',
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text('now()'),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ['account_id'],
+            ['paper.paper_accounts.id'],
+            ondelete='CASCADE',
+        ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint(
+            'account_id', 'snapshot_date',
+            name='uq_paper_daily_snapshots_account_date',
+        ),
+        schema='paper',
+    )
+    op.create_index(
+        'ix_paper_daily_snapshots_account_date',
+        'paper_daily_snapshots',
+        ['account_id', 'snapshot_date'],
+        schema='paper',
+    )
+
+
+def downgrade() -> None:
+    """Drop paper.paper_daily_snapshots table."""
+    op.drop_index(
+        'ix_paper_daily_snapshots_account_date',
+        table_name='paper_daily_snapshots',
+        schema='paper',
+    )
+    op.drop_table('paper_daily_snapshots', schema='paper')

--- a/app/mcp_server/tooling/paper_analytics_registration.py
+++ b/app/mcp_server/tooling/paper_analytics_registration.py
@@ -46,7 +46,47 @@ def _to_float(v: Any) -> float | None:
 
 
 def register_paper_analytics_tools(mcp: FastMCP) -> None:
-    pass  # Tools added in subsequent steps
+    @mcp.tool(
+        name="get_paper_performance",
+        description=(
+            "Return paper trading account performance: total_return_pct, realized/unrealized PnL, "
+            "total_trades (closed round trips), win_rate, avg_holding_days, max_drawdown_pct, "
+            "sharpe_ratio (annualised, 252 trading days), best_trade, worst_trade. "
+            "period ∈ {1d, 1w, 1m, 3m, all}. "
+            "Drawdown/Sharpe require PaperDailySnapshot rows in the period; otherwise null."
+        ),
+    )
+    async def get_paper_performance(
+        name: str,
+        period: str = "all",
+    ) -> dict[str, Any]:
+        try:
+            today = now_kst().date()
+            start = _parse_period(period, today)
+            end = None if period == "all" else today
+        except ValueError as exc:
+            return {"success": False, "error": str(exc)}
+
+        async with _session_factory()() as db:
+            service = PaperTradingService(db)
+            account = await service.get_account_by_name(name)
+            if account is None:
+                return {
+                    "success": False,
+                    "error": f"Paper account '{name}' not found",
+                }
+            try:
+                perf = await service.calculate_performance(
+                    account_id=account.id, start_date=start, end_date=end
+                )
+            except ValueError as exc:
+                return {"success": False, "error": str(exc)}
+            return {
+                "success": True,
+                "account_name": name,
+                "period": period,
+                "performance": perf,
+            }
 
 
 __all__ = [

--- a/app/mcp_server/tooling/paper_analytics_registration.py
+++ b/app/mcp_server/tooling/paper_analytics_registration.py
@@ -88,6 +88,56 @@ def register_paper_analytics_tools(mcp: FastMCP) -> None:
                 "performance": perf,
             }
 
+    @mcp.tool(
+        name="get_paper_trade_log",
+        description=(
+            "Return paper trading execution history (most recent first) for a given account. "
+            "Optional filters: symbol, days (look-back window), limit (default 50). "
+            "Each row includes symbol, side, quantity, price, fee, realized_pnl, executed_at."
+        ),
+    )
+    async def get_paper_trade_log(
+        name: str,
+        symbol: str | None = None,
+        days: int | None = None,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        async with _session_factory()() as db:
+            service = PaperTradingService(db)
+            account = await service.get_account_by_name(name)
+            if account is None:
+                return {
+                    "success": False,
+                    "error": f"Paper account '{name}' not found",
+                }
+
+            rows = await service.get_trade_history(
+                account_id=account.id, symbol=symbol, days=days, limit=limit
+            )
+            trades = [
+                {
+                    "id": r["id"],
+                    "symbol": r["symbol"],
+                    "instrument_type": r["instrument_type"],
+                    "side": r["side"],
+                    "order_type": r["order_type"],
+                    "quantity": _to_float(r.get("quantity")),
+                    "price": _to_float(r.get("price")),
+                    "total_amount": _to_float(r.get("total_amount")),
+                    "fee": _to_float(r.get("fee")),
+                    "currency": r["currency"],
+                    "reason": r.get("reason"),
+                    "realized_pnl": _to_float(r.get("realized_pnl")),
+                    "executed_at": (
+                        r["executed_at"].isoformat()
+                        if r.get("executed_at") is not None
+                        else None
+                    ),
+                }
+                for r in rows
+            ]
+            return {"success": True, "account_name": name, "trades": trades}
+
 
 __all__ = [
     "PAPER_ANALYTICS_TOOL_NAMES",

--- a/app/mcp_server/tooling/paper_analytics_registration.py
+++ b/app/mcp_server/tooling/paper_analytics_registration.py
@@ -138,6 +138,62 @@ def register_paper_analytics_tools(mcp: FastMCP) -> None:
             ]
             return {"success": True, "account_name": name, "trades": trades}
 
+    @mcp.tool(
+        name="compare_paper_accounts",
+        description=(
+            "Side-by-side performance comparison for multiple paper accounts. "
+            "Runs calculate_performance against each name and returns a list. "
+            "Missing accounts appear with performance=null and an error message. "
+            "period ∈ {1d, 1w, 1m, 3m, all}, defaults to 'all'."
+        ),
+    )
+    async def compare_paper_accounts(
+        names: list[str],
+        period: str = "all",
+    ) -> dict[str, Any]:
+        if not names:
+            return {
+                "success": False,
+                "error": "Provide at least one account name",
+            }
+
+        try:
+            today = now_kst().date()
+            start = _parse_period(period, today)
+            end = None if period == "all" else today
+        except ValueError as exc:
+            return {"success": False, "error": str(exc)}
+
+        comparison: list[dict[str, Any]] = []
+        async with _session_factory()() as db:
+            service = PaperTradingService(db)
+            for account_name in names:
+                account = await service.get_account_by_name(account_name)
+                if account is None:
+                    comparison.append({
+                        "account_name": account_name,
+                        "performance": None,
+                        "error": f"Paper account '{account_name}' not found",
+                    })
+                    continue
+                try:
+                    perf = await service.calculate_performance(
+                        account_id=account.id, start_date=start, end_date=end
+                    )
+                    comparison.append({
+                        "account_name": account_name,
+                        "performance": perf,
+                        "error": None,
+                    })
+                except ValueError as exc:
+                    comparison.append({
+                        "account_name": account_name,
+                        "performance": None,
+                        "error": str(exc),
+                    })
+
+        return {"success": True, "period": period, "comparison": comparison}
+
 
 __all__ = [
     "PAPER_ANALYTICS_TOOL_NAMES",

--- a/app/mcp_server/tooling/paper_analytics_registration.py
+++ b/app/mcp_server/tooling/paper_analytics_registration.py
@@ -1,0 +1,58 @@
+"""Paper Trading analytics MCP tool registration."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.core.timezone import now_kst
+from app.services.paper_trading_service import PaperTradingService
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+PAPER_ANALYTICS_TOOL_NAMES: set[str] = {
+    "get_paper_performance",
+    "get_paper_trade_log",
+    "compare_paper_accounts",
+}
+
+PeriodLiteral = Literal["1d", "1w", "1m", "3m", "all"]
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+def _parse_period(period: str, today: date) -> date | None:
+    if period == "all":
+        return None
+    deltas = {"1d": 1, "1w": 7, "1m": 30, "3m": 90}
+    if period not in deltas:
+        raise ValueError(f"Unsupported period: {period}")
+    return today - timedelta(days=deltas[period])
+
+
+def _to_float(v: Any) -> float | None:
+    if v is None:
+        return None
+    return float(v)
+
+
+def register_paper_analytics_tools(mcp: FastMCP) -> None:
+    pass  # Tools added in subsequent steps
+
+
+__all__ = [
+    "PAPER_ANALYTICS_TOOL_NAMES",
+    "register_paper_analytics_tools",
+    "_parse_period",
+    "_session_factory",
+    "_to_float",
+]

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -12,6 +12,9 @@ from app.mcp_server.tooling.orders_registration import register_order_tools
 from app.mcp_server.tooling.paper_account_registration import (
     register_paper_account_tools,
 )
+from app.mcp_server.tooling.paper_analytics_registration import (
+    register_paper_analytics_tools,
+)
 from app.mcp_server.tooling.portfolio_registration import register_portfolio_tools
 from app.mcp_server.tooling.trade_journal_registration import (
     register_trade_journal_tools,
@@ -42,6 +45,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_news_tools(mcp)
     register_trade_journal_tools(mcp)
     register_paper_account_tools(mcp)
+    register_paper_analytics_tools(mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/app/models/paper_trading.py
+++ b/app/models/paper_trading.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 
 from sqlalchemy import (
@@ -10,6 +10,7 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
+    Date,
     Enum,
     ForeignKey,
     Index,
@@ -134,5 +135,36 @@ class PaperTrade(Base):
     reason: Mapped[str | None] = mapped_column(Text)
     realized_pnl: Mapped[Decimal | None] = mapped_column(Numeric(20, 4))
     executed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+# ---------------------------------------------------------------------------
+# paper.paper_daily_snapshots — daily portfolio equity snapshots
+# ---------------------------------------------------------------------------
+class PaperDailySnapshot(Base):
+    __tablename__ = "paper_daily_snapshots"
+    __table_args__ = (
+        UniqueConstraint(
+            "account_id", "snapshot_date",
+            name="uq_paper_daily_snapshots_account_date",
+        ),
+        Index("ix_paper_daily_snapshots_account_date", "account_id", "snapshot_date"),
+        {"schema": "paper"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    account_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("paper.paper_accounts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    snapshot_date: Mapped[date] = mapped_column(Date, nullable=False)
+    cash_krw: Mapped[Decimal] = mapped_column(Numeric(20, 4), nullable=False)
+    cash_usd: Mapped[Decimal] = mapped_column(Numeric(20, 4), nullable=False)
+    positions_value: Mapped[Decimal] = mapped_column(Numeric(20, 4), nullable=False)
+    total_equity: Mapped[Decimal] = mapped_column(Numeric(20, 4), nullable=False)
+    daily_return_pct: Mapped[Decimal | None] = mapped_column(Numeric(10, 4))
+    created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
     )

--- a/app/services/paper_trading_service.py
+++ b/app/services/paper_trading_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Any
 
@@ -11,7 +11,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.timezone import now_kst
-from app.models.paper_trading import PaperAccount, PaperDailySnapshot, PaperPosition, PaperTrade
+from app.models.paper_trading import (
+    PaperAccount,
+    PaperDailySnapshot,
+    PaperPosition,
+    PaperTrade,
+)
 from app.models.trading import InstrumentType
 from app.services.brokers.upbit.client import fetch_multiple_current_prices
 
@@ -796,14 +801,12 @@ class PaperTradingService:
         # Trades in period
         trade_stmt = select(PaperTrade).where(PaperTrade.account_id == account_id)
         if start_date is not None:
-            from datetime import timezone as _tz
             trade_stmt = trade_stmt.where(
-                PaperTrade.executed_at >= datetime.combine(start_date, datetime.min.time(), tzinfo=_tz.utc)
+                PaperTrade.executed_at >= datetime.combine(start_date, datetime.min.time(), tzinfo=UTC)
             )
         if end_date is not None:
-            from datetime import timezone as _tz
             trade_stmt = trade_stmt.where(
-                PaperTrade.executed_at <= datetime.combine(end_date, datetime.max.time(), tzinfo=_tz.utc)
+                PaperTrade.executed_at <= datetime.combine(end_date, datetime.max.time(), tzinfo=UTC)
             )
         trade_stmt = trade_stmt.order_by(PaperTrade.executed_at.asc())
         trades = list((await self.db.execute(trade_stmt)).scalars().all())

--- a/app/services/paper_trading_service.py
+++ b/app/services/paper_trading_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
+from datetime import date, datetime, timedelta
 from decimal import ROUND_HALF_UP, Decimal
 from typing import Any
 
@@ -11,12 +11,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.timezone import now_kst
-from app.mcp_server.tooling.market_data_quotes import (
-    _fetch_quote_equity_kr,
-    _fetch_quote_equity_us,
-)
-from app.mcp_server.tooling.shared import resolve_market_type
-from app.models.paper_trading import PaperAccount, PaperPosition, PaperTrade
+from app.models.paper_trading import PaperAccount, PaperDailySnapshot, PaperPosition, PaperTrade
 from app.models.trading import InstrumentType
 from app.services.brokers.upbit.client import fetch_multiple_current_prices
 
@@ -172,9 +167,11 @@ class PaperTradingService:
     # ------------------------------------------------------------------ #
     async def _fetch_current_price(self, symbol: str, instrument_type: str) -> Decimal:
         if instrument_type == "equity_kr":
+            from app.mcp_server.tooling.market_data_quotes import _fetch_quote_equity_kr
             quote = await _fetch_quote_equity_kr(symbol)
             price = quote.get("price")
         elif instrument_type == "equity_us":
+            from app.mcp_server.tooling.market_data_quotes import _fetch_quote_equity_us
             quote = await _fetch_quote_equity_us(symbol)
             price = quote.get("price")
         elif instrument_type == "crypto":
@@ -216,6 +213,7 @@ class PaperTradingService:
         if not account.is_active:
             raise ValueError(f"Account {account_id} is inactive")
 
+        from app.mcp_server.tooling.shared import resolve_market_type
         instrument_type, resolved_symbol = resolve_market_type(symbol, None)
         currency = "USD" if instrument_type == "equity_us" else "KRW"
 
@@ -480,6 +478,7 @@ class PaperTradingService:
         return output
 
     async def get_position(self, account_id: int, symbol: str) -> dict[str, Any] | None:
+        from app.mcp_server.tooling.shared import resolve_market_type
         resolved_symbol = resolve_market_type(symbol, None)[1]
         pos = await self._get_position(account_id, resolved_symbol)
         if pos is None:
@@ -569,6 +568,201 @@ class PaperTradingService:
             "cash_usd": account.cash_usd,
             "positions_count": len(positions),
         }
+
+
+    # ------------------------------------------------------------------ #
+    # Daily snapshot
+    # ------------------------------------------------------------------ #
+    async def _evaluate_positions_value(self, account_id: int) -> Decimal:
+        """Sum evaluation_amount across live positions (raw KRW+USD)."""
+        positions = await self.get_positions(account_id=account_id)
+        total = Decimal("0")
+        for p in positions:
+            eval_amt = p.get("evaluation_amount")
+            if eval_amt is not None:
+                total += Decimal(str(eval_amt))
+        return _q_money(total)
+
+    async def record_daily_snapshot(self, account_id: int) -> PaperDailySnapshot:
+        account = await self.get_account(account_id)
+        if account is None:
+            raise ValueError(f"Account {account_id} not found")
+
+        today = now_kst().date()
+
+        existing_today = (
+            await self.db.execute(
+                select(PaperDailySnapshot).where(
+                    PaperDailySnapshot.account_id == account_id,
+                    PaperDailySnapshot.snapshot_date == today,
+                )
+            )
+        ).scalar_one_or_none()
+
+        positions_value = await self._evaluate_positions_value(account_id)
+        total_equity = _q_money(account.cash_krw + account.cash_usd + positions_value)
+
+        prior = (
+            await self.db.execute(
+                select(PaperDailySnapshot)
+                .where(
+                    PaperDailySnapshot.account_id == account_id,
+                    PaperDailySnapshot.snapshot_date < today,
+                )
+                .order_by(PaperDailySnapshot.snapshot_date.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+
+        daily_return_pct: Decimal | None = None
+        if prior is not None and prior.total_equity > 0:
+            daily_return_pct = (
+                (total_equity / prior.total_equity - Decimal("1")) * Decimal("100")
+            ).quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
+
+        if existing_today is None:
+            snapshot = PaperDailySnapshot(
+                account_id=account_id,
+                snapshot_date=today,
+                cash_krw=account.cash_krw,
+                cash_usd=account.cash_usd,
+                positions_value=positions_value,
+                total_equity=total_equity,
+                daily_return_pct=daily_return_pct,
+            )
+            self.db.add(snapshot)
+        else:
+            existing_today.cash_krw = account.cash_krw
+            existing_today.cash_usd = account.cash_usd
+            existing_today.positions_value = positions_value
+            existing_today.total_equity = total_equity
+            existing_today.daily_return_pct = daily_return_pct
+            snapshot = existing_today
+
+        await self.db.commit()
+        return snapshot
+
+    async def calculate_daily_returns(
+        self,
+        account_id: int,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> list[dict[str, Any]]:
+        stmt = select(PaperDailySnapshot).where(
+            PaperDailySnapshot.account_id == account_id
+        )
+        if start_date is not None:
+            stmt = stmt.where(PaperDailySnapshot.snapshot_date >= start_date)
+        if end_date is not None:
+            stmt = stmt.where(PaperDailySnapshot.snapshot_date <= end_date)
+        stmt = stmt.order_by(PaperDailySnapshot.snapshot_date.asc())
+
+        result = await self.db.execute(stmt)
+        snaps = list(result.scalars().all())
+        return [
+            {
+                "date": s.snapshot_date.isoformat(),
+                "total_equity": s.total_equity,
+                "daily_return_pct": s.daily_return_pct,
+            }
+            for s in snaps
+        ]
+
+    # ------------------------------------------------------------------ #
+    # Performance analytics helpers
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _build_round_trips(trades: list[PaperTrade]) -> list[dict[str, Any]]:
+        """Group raw trades into round trips per symbol until position is flat.
+        Excludes open (unclosed) trips."""
+        from collections import defaultdict
+
+        grouped: dict[str, list[tuple[int, PaperTrade]]] = defaultdict(list)
+        for idx, t in enumerate(trades):
+            grouped[t.symbol].append((idx, t))
+
+        round_trips: list[dict[str, Any]] = []
+        for symbol, indexed in grouped.items():
+            indexed.sort(key=lambda item: (item[1].executed_at, item[0]))
+            position_qty = Decimal("0")
+            buy_cost = Decimal("0")
+            total_pnl = Decimal("0")
+            entry_date: datetime | None = None
+            entry_reason = ""
+            last_exit_date: datetime | None = None
+            last_sell_reason = ""
+
+            for _, t in indexed:
+                qty = Decimal(t.quantity)
+                if t.side == "buy":
+                    if position_qty <= 0:
+                        entry_date = t.executed_at
+                        entry_reason = t.reason or ""
+                        buy_cost = Decimal("0")
+                        total_pnl = Decimal("0")
+                    position_qty += qty
+                    buy_cost += qty * Decimal(t.price) + Decimal(t.fee)
+                elif t.side == "sell" and position_qty > 0:
+                    position_qty -= qty
+                    total_pnl += Decimal(t.realized_pnl or 0)
+                    last_exit_date = t.executed_at
+                    last_sell_reason = t.reason or ""
+
+                    if position_qty <= 0 and entry_date is not None and last_exit_date is not None:
+                        holding_days = (last_exit_date.date() - entry_date.date()).days
+                        return_pct = (
+                            float(total_pnl / buy_cost * Decimal("100"))
+                            if buy_cost > 0 else 0.0
+                        )
+                        round_trips.append({
+                            "symbol": symbol,
+                            "entry_date": entry_date.isoformat(),
+                            "exit_date": last_exit_date.isoformat(),
+                            "holding_days": max(holding_days, 0),
+                            "pnl": float(total_pnl),
+                            "return_pct": return_pct,
+                            "entry_reason": entry_reason,
+                            "exit_reason": last_sell_reason,
+                        })
+                        position_qty = Decimal("0")
+                        buy_cost = Decimal("0")
+                        total_pnl = Decimal("0")
+                        entry_date = None
+                        entry_reason = ""
+                        last_exit_date = None
+                        last_sell_reason = ""
+
+        round_trips.sort(key=lambda trip: (trip["exit_date"], trip["symbol"]))
+        return round_trips
+
+    @staticmethod
+    def _calc_max_drawdown_pct(equity_curve: list[Decimal]) -> float | None:
+        if not equity_curve:
+            return None
+        peak = equity_curve[0]
+        max_dd = Decimal("0")
+        for v in equity_curve:
+            if v > peak:
+                peak = v
+            if peak > 0:
+                dd = (peak - v) / peak
+                if dd > max_dd:
+                    max_dd = dd
+        return float(max_dd * Decimal("100"))
+
+    @staticmethod
+    def _calc_sharpe_ratio(daily_returns_pct: list[Decimal]) -> float | None:
+        """Annualised Sharpe ratio (252 trading days). Assumes 0% risk-free rate."""
+        import math
+        values = [float(r) for r in daily_returns_pct if r is not None]
+        if len(values) < 2:
+            return None
+        mean = sum(values) / len(values)
+        variance = sum((v - mean) ** 2 for v in values) / (len(values) - 1)
+        stdev = math.sqrt(variance)
+        if stdev == 0:
+            return None
+        return (mean / stdev) * math.sqrt(252)
 
 
 __all__ = [

--- a/app/services/paper_trading_service.py
+++ b/app/services/paper_trading_service.py
@@ -765,6 +765,95 @@ class PaperTradingService:
         return (mean / stdev) * math.sqrt(252)
 
 
+    async def calculate_performance(
+        self,
+        account_id: int,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> dict[str, Any]:
+        account = await self.get_account(account_id)
+        if account is None:
+            raise ValueError(f"Account {account_id} not found")
+
+        # Current equity (always "now")
+        positions_value = await self._evaluate_positions_value(account_id)
+        total_equity = account.cash_krw + account.cash_usd + positions_value
+        initial = Decimal(account.initial_capital)
+        total_return_pct = (
+            float((total_equity - initial) / initial * Decimal("100"))
+            if initial > 0
+            else 0.0
+        )
+
+        # Unrealized pnl — sum across live positions
+        positions = await self.get_positions(account_id=account_id)
+        unrealized = Decimal("0")
+        for p in positions:
+            val = p.get("unrealized_pnl")
+            if val is not None:
+                unrealized += Decimal(str(val))
+
+        # Trades in period
+        trade_stmt = select(PaperTrade).where(PaperTrade.account_id == account_id)
+        if start_date is not None:
+            from datetime import timezone as _tz
+            trade_stmt = trade_stmt.where(
+                PaperTrade.executed_at >= datetime.combine(start_date, datetime.min.time(), tzinfo=_tz.utc)
+            )
+        if end_date is not None:
+            from datetime import timezone as _tz
+            trade_stmt = trade_stmt.where(
+                PaperTrade.executed_at <= datetime.combine(end_date, datetime.max.time(), tzinfo=_tz.utc)
+            )
+        trade_stmt = trade_stmt.order_by(PaperTrade.executed_at.asc())
+        trades = list((await self.db.execute(trade_stmt)).scalars().all())
+
+        realized = sum(
+            (Decimal(t.realized_pnl) for t in trades if t.realized_pnl is not None),
+            Decimal("0"),
+        )
+
+        round_trips = self._build_round_trips(trades)
+        total_trips = len(round_trips)
+        wins = sum(1 for trip in round_trips if trip["pnl"] > 0)
+        win_rate = (wins / total_trips * 100.0) if total_trips > 0 else 0.0
+        avg_holding_days = (
+            sum(trip["holding_days"] for trip in round_trips) / total_trips
+            if total_trips > 0 else 0.0
+        )
+        best_trip = max(round_trips, key=lambda t: t["return_pct"]) if round_trips else None
+        worst_trip = min(round_trips, key=lambda t: t["return_pct"]) if round_trips else None
+
+        # Snapshots in period → sharpe + max drawdown
+        snap_stmt = select(PaperDailySnapshot).where(
+            PaperDailySnapshot.account_id == account_id
+        )
+        if start_date is not None:
+            snap_stmt = snap_stmt.where(PaperDailySnapshot.snapshot_date >= start_date)
+        if end_date is not None:
+            snap_stmt = snap_stmt.where(PaperDailySnapshot.snapshot_date <= end_date)
+        snap_stmt = snap_stmt.order_by(PaperDailySnapshot.snapshot_date.asc())
+        snaps = list((await self.db.execute(snap_stmt)).scalars().all())
+
+        equity_curve = [s.total_equity for s in snaps]
+        daily_returns = [s.daily_return_pct for s in snaps if s.daily_return_pct is not None]
+        max_dd = self._calc_max_drawdown_pct(equity_curve) if equity_curve else None
+        sharpe = self._calc_sharpe_ratio(daily_returns) if daily_returns else None
+
+        return {
+            "total_return_pct": round(total_return_pct, 4),
+            "realized_pnl": float(realized),
+            "unrealized_pnl": float(unrealized),
+            "total_trades": total_trips,
+            "win_rate": round(win_rate, 2),
+            "avg_holding_days": round(avg_holding_days, 2),
+            "max_drawdown_pct": round(max_dd, 4) if max_dd is not None else None,
+            "sharpe_ratio": round(sharpe, 4) if sharpe is not None else None,
+            "best_trade": best_trip,
+            "worst_trade": worst_trip,
+        }
+
+
 __all__ = [
     "FEE_RATES",
     "calculate_fee",

--- a/tests/test_paper_analytics_tools.py
+++ b/tests/test_paper_analytics_tools.py
@@ -1,0 +1,376 @@
+"""Tests for paper trading analytics MCP tools."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests._mcp_tooling_support import build_tools
+
+
+@pytest.mark.asyncio
+async def test_paper_analytics_tools_registered() -> None:
+    tools = build_tools()
+    assert "get_paper_performance" in tools
+    assert "get_paper_trade_log" in tools
+    assert "compare_paper_accounts" in tools
+
+
+def test_parse_period_maps_to_start_date() -> None:
+    from app.mcp_server.tooling.paper_analytics_registration import _parse_period
+
+    today = date(2026, 4, 13)
+    assert _parse_period("all", today) is None
+    assert _parse_period("1d", today) == today - timedelta(days=1)
+    assert _parse_period("1w", today) == today - timedelta(days=7)
+    assert _parse_period("1m", today) == today - timedelta(days=30)
+    assert _parse_period("3m", today) == today - timedelta(days=90)
+
+
+def test_parse_period_rejects_unknown() -> None:
+    from app.mcp_server.tooling.paper_analytics_registration import _parse_period
+
+    with pytest.raises(ValueError, match="Unsupported period"):
+        _parse_period("2y", date(2026, 4, 13))
+
+
+class _SessionCtx:
+    def __init__(self, db):
+        self.db = db
+
+    async def __aenter__(self):
+        return self.db
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+
+def _patch_session(monkeypatch, db) -> None:
+    factory = MagicMock()
+    factory.return_value = _SessionCtx(db)
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.paper_analytics_registration._session_factory",
+        lambda: factory,
+    )
+
+
+def _perf_payload() -> dict:
+    return {
+        "total_return_pct": 10.0,
+        "realized_pnl": 98635.0,
+        "unrealized_pnl": 400000.0,
+        "total_trades": 1,
+        "win_rate": 100.0,
+        "avg_holding_days": 5.0,
+        "max_drawdown_pct": 1.49,
+        "sharpe_ratio": 0.5,
+        "best_trade": {
+            "symbol": "005930",
+            "entry_date": "2026-04-01T00:00:00+00:00",
+            "exit_date": "2026-04-06T00:00:00+00:00",
+            "holding_days": 5, "pnl": 98635.0, "return_pct": 16.44,
+            "entry_reason": "", "exit_reason": "",
+        },
+        "worst_trade": {
+            "symbol": "005930",
+            "entry_date": "2026-04-01T00:00:00+00:00",
+            "exit_date": "2026-04-06T00:00:00+00:00",
+            "holding_days": 5, "pnl": 98635.0, "return_pct": 16.44,
+            "entry_reason": "", "exit_reason": "",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_paper_performance_all_period(monkeypatch):
+    from app.models.paper_trading import PaperAccount
+
+    db = AsyncMock()
+    _patch_session(monkeypatch, db)
+
+    account = PaperAccount(
+        id=1, name="bot",
+        initial_capital=Decimal("10000000"),
+        cash_krw=Decimal("5000000"), cash_usd=Decimal("0"),
+        is_active=True,
+    )
+
+    with patch(
+        "app.mcp_server.tooling.paper_analytics_registration.PaperTradingService"
+    ) as svc_cls:
+        svc = svc_cls.return_value
+        svc.get_account_by_name = AsyncMock(return_value=account)
+        svc.calculate_performance = AsyncMock(return_value=_perf_payload())
+
+        tools = build_tools()
+        result = await tools["get_paper_performance"](name="bot", period="all")
+
+    svc.calculate_performance.assert_awaited_once_with(
+        account_id=1, start_date=None, end_date=None
+    )
+    assert result["success"] is True
+    assert result["account_name"] == "bot"
+    assert result["period"] == "all"
+    assert result["performance"]["total_return_pct"] == 10.0
+    assert result["performance"]["best_trade"]["symbol"] == "005930"
+
+
+@pytest.mark.asyncio
+async def test_get_paper_performance_unknown_account(monkeypatch):
+    db = AsyncMock()
+    _patch_session(monkeypatch, db)
+
+    with patch(
+        "app.mcp_server.tooling.paper_analytics_registration.PaperTradingService"
+    ) as svc_cls:
+        svc = svc_cls.return_value
+        svc.get_account_by_name = AsyncMock(return_value=None)
+
+        tools = build_tools()
+        result = await tools["get_paper_performance"](name="ghost", period="all")
+
+    assert result == {"success": False, "error": "Paper account 'ghost' not found"}
+
+
+@pytest.mark.asyncio
+async def test_get_paper_performance_invalid_period(monkeypatch):
+    from app.models.paper_trading import PaperAccount
+
+    db = AsyncMock()
+    _patch_session(monkeypatch, db)
+
+    account = PaperAccount(
+        id=1, name="bot",
+        initial_capital=Decimal("10000000"),
+        cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+        is_active=True,
+    )
+
+    with patch(
+        "app.mcp_server.tooling.paper_analytics_registration.PaperTradingService"
+    ) as svc_cls:
+        svc = svc_cls.return_value
+        svc.get_account_by_name = AsyncMock(return_value=account)
+
+        tools = build_tools()
+        result = await tools["get_paper_performance"](name="bot", period="2y")
+
+    assert result["success"] is False
+    assert "Unsupported period" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_get_paper_trade_log_basic(monkeypatch):
+    from app.models.paper_trading import PaperAccount
+
+    db = AsyncMock()
+    _patch_session(monkeypatch, db)
+
+    account = PaperAccount(
+        id=1, name="bot",
+        initial_capital=Decimal("10000000"),
+        cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+        is_active=True,
+    )
+
+    trade_rows = [
+        {
+            "id": 1, "symbol": "005930", "instrument_type": "equity_kr",
+            "side": "buy", "order_type": "market",
+            "quantity": Decimal("10"), "price": Decimal("60000"),
+            "total_amount": Decimal("600000"), "fee": Decimal("90"),
+            "currency": "KRW", "reason": "entry", "realized_pnl": None,
+            "executed_at": datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc),
+        },
+    ]
+
+    with patch(
+        "app.mcp_server.tooling.paper_analytics_registration.PaperTradingService"
+    ) as svc_cls:
+        svc = svc_cls.return_value
+        svc.get_account_by_name = AsyncMock(return_value=account)
+        svc.get_trade_history = AsyncMock(return_value=trade_rows)
+
+        tools = build_tools()
+        result = await tools["get_paper_trade_log"](name="bot")
+
+    svc.get_trade_history.assert_awaited_once_with(
+        account_id=1, symbol=None, days=None, limit=50
+    )
+    assert result["success"] is True
+    assert len(result["trades"]) == 1
+    t = result["trades"][0]
+    assert t["symbol"] == "005930"
+    assert t["quantity"] == 10.0
+    assert t["price"] == 60000.0
+    assert t["fee"] == 90.0
+    assert t["realized_pnl"] is None
+    assert t["executed_at"] == "2026-04-01T09:00:00+00:00"
+
+
+@pytest.mark.asyncio
+async def test_get_paper_trade_log_filters_forwarded(monkeypatch):
+    from app.models.paper_trading import PaperAccount
+
+    db = AsyncMock()
+    _patch_session(monkeypatch, db)
+
+    account = PaperAccount(
+        id=1, name="bot",
+        initial_capital=Decimal("0"),
+        cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+        is_active=True,
+    )
+
+    with patch(
+        "app.mcp_server.tooling.paper_analytics_registration.PaperTradingService"
+    ) as svc_cls:
+        svc = svc_cls.return_value
+        svc.get_account_by_name = AsyncMock(return_value=account)
+        svc.get_trade_history = AsyncMock(return_value=[])
+
+        tools = build_tools()
+        result = await tools["get_paper_trade_log"](
+            name="bot", symbol="AAPL", days=7, limit=10
+        )
+
+    svc.get_trade_history.assert_awaited_once_with(
+        account_id=1, symbol="AAPL", days=7, limit=10
+    )
+    assert result == {"success": True, "account_name": "bot", "trades": []}
+
+
+@pytest.mark.asyncio
+async def test_get_paper_trade_log_account_not_found(monkeypatch):
+    db = AsyncMock()
+    _patch_session(monkeypatch, db)
+
+    with patch(
+        "app.mcp_server.tooling.paper_analytics_registration.PaperTradingService"
+    ) as svc_cls:
+        svc = svc_cls.return_value
+        svc.get_account_by_name = AsyncMock(return_value=None)
+
+        tools = build_tools()
+        result = await tools["get_paper_trade_log"](name="ghost")
+
+    assert result["success"] is False
+    assert "not found" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_compare_paper_accounts_all_found(monkeypatch):
+    from app.models.paper_trading import PaperAccount
+
+    db = AsyncMock()
+    _patch_session(monkeypatch, db)
+
+    acc1 = PaperAccount(
+        id=1, name="bot-a",
+        initial_capital=Decimal("10000000"),
+        cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+        is_active=True,
+    )
+    acc2 = PaperAccount(
+        id=2, name="bot-b",
+        initial_capital=Decimal("10000000"),
+        cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+        is_active=True,
+    )
+
+    name_to_account = {"bot-a": acc1, "bot-b": acc2}
+    perf_by_id = {
+        1: {
+            "total_return_pct": 5.0, "realized_pnl": 100.0, "unrealized_pnl": 50.0,
+            "total_trades": 3, "win_rate": 66.67, "avg_holding_days": 4.0,
+            "max_drawdown_pct": 2.0, "sharpe_ratio": 1.0,
+            "best_trade": None, "worst_trade": None,
+        },
+        2: {
+            "total_return_pct": -2.0, "realized_pnl": -200.0, "unrealized_pnl": 0.0,
+            "total_trades": 1, "win_rate": 0.0, "avg_holding_days": 2.0,
+            "max_drawdown_pct": 5.0, "sharpe_ratio": -0.5,
+            "best_trade": None, "worst_trade": None,
+        },
+    }
+
+    async def _lookup(name):
+        return name_to_account.get(name)
+
+    async def _perf(account_id, start_date=None, end_date=None):
+        return perf_by_id[account_id]
+
+    with patch(
+        "app.mcp_server.tooling.paper_analytics_registration.PaperTradingService"
+    ) as svc_cls:
+        svc = svc_cls.return_value
+        svc.get_account_by_name = AsyncMock(side_effect=_lookup)
+        svc.calculate_performance = AsyncMock(side_effect=_perf)
+
+        tools = build_tools()
+        result = await tools["compare_paper_accounts"](names=["bot-a", "bot-b"])
+
+    assert result["success"] is True
+    rows = result["comparison"]
+    assert [r["account_name"] for r in rows] == ["bot-a", "bot-b"]
+    assert rows[0]["performance"]["total_return_pct"] == 5.0
+    assert rows[1]["performance"]["total_return_pct"] == -2.0
+
+
+@pytest.mark.asyncio
+async def test_compare_paper_accounts_skips_missing(monkeypatch):
+    from app.models.paper_trading import PaperAccount
+
+    db = AsyncMock()
+    _patch_session(monkeypatch, db)
+
+    acc1 = PaperAccount(
+        id=1, name="bot-a",
+        initial_capital=Decimal("10000000"),
+        cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+        is_active=True,
+    )
+
+    async def _lookup(name):
+        return acc1 if name == "bot-a" else None
+
+    with patch(
+        "app.mcp_server.tooling.paper_analytics_registration.PaperTradingService"
+    ) as svc_cls:
+        svc = svc_cls.return_value
+        svc.get_account_by_name = AsyncMock(side_effect=_lookup)
+        svc.calculate_performance = AsyncMock(return_value={
+            "total_return_pct": 0.0, "realized_pnl": 0.0, "unrealized_pnl": 0.0,
+            "total_trades": 0, "win_rate": 0.0, "avg_holding_days": 0.0,
+            "max_drawdown_pct": None, "sharpe_ratio": None,
+            "best_trade": None, "worst_trade": None,
+        })
+
+        tools = build_tools()
+        result = await tools["compare_paper_accounts"](names=["bot-a", "ghost"])
+
+    assert result["success"] is True
+    assert len(result["comparison"]) == 2
+    first, second = result["comparison"]
+    assert first["account_name"] == "bot-a"
+    assert first["performance"]["total_return_pct"] == 0.0
+    assert first.get("error") is None
+    assert second == {
+        "account_name": "ghost",
+        "performance": None,
+        "error": "Paper account 'ghost' not found",
+    }
+
+
+@pytest.mark.asyncio
+async def test_compare_paper_accounts_empty_names(monkeypatch):
+    db = AsyncMock()
+    _patch_session(monkeypatch, db)
+
+    tools = build_tools()
+    result = await tools["compare_paper_accounts"](names=[])
+    assert result["success"] is False
+    assert "at least one" in result["error"].lower()

--- a/tests/test_paper_analytics_tools.py
+++ b/tests/test_paper_analytics_tools.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -183,7 +183,7 @@ async def test_get_paper_trade_log_basic(monkeypatch):
             "quantity": Decimal("10"), "price": Decimal("60000"),
             "total_amount": Decimal("600000"), "fee": Decimal("90"),
             "currency": "KRW", "reason": "entry", "realized_pnl": None,
-            "executed_at": datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc),
+            "executed_at": datetime(2026, 4, 1, 9, 0, tzinfo=UTC),
         },
     ]
 

--- a/tests/test_paper_trading_model.py
+++ b/tests/test_paper_trading_model.py
@@ -100,3 +100,23 @@ class TestPaperTradeModel:
     def test_table_args(self) -> None:
         assert PaperTrade.__table_args__[-1] == {"schema": "paper"}
         assert PaperTrade.__tablename__ == "paper_trades"
+
+
+def test_paper_daily_snapshot_constructor() -> None:
+    from datetime import date
+    from decimal import Decimal
+
+    from app.models.paper_trading import PaperDailySnapshot
+
+    snap = PaperDailySnapshot(
+        account_id=1,
+        snapshot_date=date(2026, 4, 13),
+        cash_krw=Decimal("1000000"),
+        cash_usd=Decimal("0"),
+        positions_value=Decimal("500000"),
+        total_equity=Decimal("1500000"),
+        daily_return_pct=Decimal("0.25"),
+    )
+    assert snap.account_id == 1
+    assert snap.total_equity == Decimal("1500000")
+    assert snap.daily_return_pct == Decimal("0.25")

--- a/tests/test_paper_trading_service.py
+++ b/tests/test_paper_trading_service.py
@@ -2,13 +2,18 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from app.models.paper_trading import PaperAccount, PaperDailySnapshot, PaperPosition, PaperTrade
+from app.models.paper_trading import (
+    PaperAccount,
+    PaperDailySnapshot,
+    PaperPosition,
+    PaperTrade,
+)
 from app.models.trading import InstrumentType
 from app.services.paper_trading_service import (
     FEE_RATES,
@@ -869,7 +874,7 @@ class TestRoundTrips:
         return PaperTradingService(mock_db)
 
     def _trade(self, **kw):
-        from datetime import datetime, timezone
+        from datetime import datetime
         defaults = {
             "id": 0, "account_id": 1, "symbol": "005930",
             "instrument_type": InstrumentType.equity_kr,
@@ -877,25 +882,25 @@ class TestRoundTrips:
             "quantity": Decimal("10"), "price": Decimal("60000"),
             "total_amount": Decimal("600000"), "fee": Decimal("0"),
             "currency": "KRW", "reason": None, "realized_pnl": None,
-            "executed_at": datetime(2026, 4, 1, tzinfo=timezone.utc),
+            "executed_at": datetime(2026, 4, 1, tzinfo=UTC),
         }
         defaults.update(kw)
         return PaperTrade(**defaults)
 
     def test_closed_round_trip_computes_holding_days_and_pnl(self, service):
-        from datetime import datetime, timezone
+        from datetime import datetime
         trades = [
             self._trade(
                 id=1, side="buy", quantity=Decimal("10"),
                 price=Decimal("60000"), fee=Decimal("90"),
-                executed_at=datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc),
+                executed_at=datetime(2026, 4, 1, 9, 0, tzinfo=UTC),
                 reason="entry",
             ),
             self._trade(
                 id=2, side="sell", quantity=Decimal("10"),
                 price=Decimal("70000"), fee=Decimal("1365"),
                 realized_pnl=Decimal("98635"),
-                executed_at=datetime(2026, 4, 6, 9, 0, tzinfo=timezone.utc),
+                executed_at=datetime(2026, 4, 6, 9, 0, tzinfo=UTC),
                 reason="exit",
             ),
         ]
@@ -910,29 +915,29 @@ class TestRoundTrips:
         assert trip["exit_reason"] == "exit"
 
     def test_unclosed_position_excluded(self, service):
-        from datetime import datetime, timezone
+        from datetime import datetime
         trades = [
             self._trade(id=1, side="buy", quantity=Decimal("10"),
-                        executed_at=datetime(2026, 4, 1, tzinfo=timezone.utc)),
+                        executed_at=datetime(2026, 4, 1, tzinfo=UTC)),
             self._trade(id=2, side="sell", quantity=Decimal("4"),
                         realized_pnl=Decimal("40000"),
-                        executed_at=datetime(2026, 4, 3, tzinfo=timezone.utc)),
+                        executed_at=datetime(2026, 4, 3, tzinfo=UTC)),
         ]
         assert service._build_round_trips(trades) == []
 
     def test_multiple_symbols_grouped_independently(self, service):
-        from datetime import datetime, timezone
+        from datetime import datetime
         trades = [
             self._trade(id=1, symbol="A", side="buy",
-                        executed_at=datetime(2026, 4, 1, tzinfo=timezone.utc)),
+                        executed_at=datetime(2026, 4, 1, tzinfo=UTC)),
             self._trade(id=2, symbol="B", side="buy",
-                        executed_at=datetime(2026, 4, 1, tzinfo=timezone.utc)),
+                        executed_at=datetime(2026, 4, 1, tzinfo=UTC)),
             self._trade(id=3, symbol="A", side="sell",
                         realized_pnl=Decimal("100"),
-                        executed_at=datetime(2026, 4, 2, tzinfo=timezone.utc)),
+                        executed_at=datetime(2026, 4, 2, tzinfo=UTC)),
             self._trade(id=4, symbol="B", side="sell",
                         realized_pnl=Decimal("-50"),
-                        executed_at=datetime(2026, 4, 3, tzinfo=timezone.utc)),
+                        executed_at=datetime(2026, 4, 3, tzinfo=UTC)),
         ]
         trips = service._build_round_trips(trades)
         assert {t["symbol"] for t in trips} == {"A", "B"}
@@ -971,7 +976,6 @@ class TestCalculatePerformance:
 
     @pytest.mark.asyncio
     async def test_full_performance_all_period(self, service, mock_db, monkeypatch):
-        from datetime import timezone
         account = PaperAccount(
             id=1, name="A",
             initial_capital=Decimal("10000000"),
@@ -999,7 +1003,7 @@ class TestCalculatePerformance:
                 quantity=Decimal("10"), price=Decimal("60000"),
                 total_amount=Decimal("600000"), fee=Decimal("90"),
                 currency="KRW", reason=None, realized_pnl=None,
-                executed_at=datetime(2026, 4, 1, tzinfo=timezone.utc),
+                executed_at=datetime(2026, 4, 1, tzinfo=UTC),
             ),
             PaperTrade(
                 id=2, account_id=1, symbol="A",
@@ -1009,7 +1013,7 @@ class TestCalculatePerformance:
                 total_amount=Decimal("700000"), fee=Decimal("1365"),
                 currency="KRW", reason=None,
                 realized_pnl=Decimal("98635"),
-                executed_at=datetime(2026, 4, 6, tzinfo=timezone.utc),
+                executed_at=datetime(2026, 4, 6, tzinfo=UTC),
             ),
         ]
         scalars_trades = MagicMock()

--- a/tests/test_paper_trading_service.py
+++ b/tests/test_paper_trading_service.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import date, timedelta
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from app.models.paper_trading import PaperAccount, PaperPosition, PaperTrade
+from app.models.paper_trading import PaperAccount, PaperDailySnapshot, PaperPosition, PaperTrade
 from app.models.trading import InstrumentType
 from app.services.paper_trading_service import (
     FEE_RATES,
@@ -162,7 +163,7 @@ class TestFetchCurrentPrice:
     @pytest.mark.asyncio
     async def test_fetch_equity_kr_uses_kis_quote(self, service, monkeypatch):
         monkeypatch.setattr(
-            "app.services.paper_trading_service._fetch_quote_equity_kr",
+            "app.mcp_server.tooling.market_data_quotes._fetch_quote_equity_kr",
             AsyncMock(return_value={"price": 70000.0}),
         )
         price = await service._fetch_current_price("005930", "equity_kr")
@@ -171,7 +172,7 @@ class TestFetchCurrentPrice:
     @pytest.mark.asyncio
     async def test_fetch_equity_us_uses_yahoo_quote(self, service, monkeypatch):
         monkeypatch.setattr(
-            "app.services.paper_trading_service._fetch_quote_equity_us",
+            "app.mcp_server.tooling.market_data_quotes._fetch_quote_equity_us",
             AsyncMock(return_value={"price": 190.5}),
         )
         price = await service._fetch_current_price("AAPL", "equity_us")
@@ -756,3 +757,209 @@ class TestPortfolioSummary:
         assert summary["total_pnl"] == Decimal("0")
         assert summary["total_pnl_pct"] is None
         assert summary["positions_count"] == 0
+
+
+class TestDailySnapshots:
+    @pytest.fixture
+    def service(self, mock_db):
+        return PaperTradingService(mock_db)
+
+    @pytest.mark.asyncio
+    async def test_record_snapshot_creates_row_with_return_from_prior(
+        self, service, mock_db, monkeypatch
+    ):
+        account = PaperAccount(
+            id=1, name="A",
+            initial_capital=Decimal("10000000"),
+            cash_krw=Decimal("5000000"),
+            cash_usd=Decimal("0"),
+            is_active=True,
+        )
+        monkeypatch.setattr(service, "get_account", AsyncMock(return_value=account))
+        monkeypatch.setattr(
+            service, "get_positions",
+            AsyncMock(return_value=[{"evaluation_amount": Decimal("6000000")}]),
+        )
+
+        prior = PaperDailySnapshot(
+            id=10, account_id=1,
+            snapshot_date=date(2026, 4, 12),
+            cash_krw=Decimal("5000000"), cash_usd=Decimal("0"),
+            positions_value=Decimal("5000000"),
+            total_equity=Decimal("10000000"),
+            daily_return_pct=None,
+        )
+
+        scalars_none = MagicMock()
+        scalars_none.scalar_one_or_none = MagicMock(return_value=None)
+        scalars_prior = MagicMock()
+        scalars_prior.scalar_one_or_none = MagicMock(return_value=prior)
+        mock_db.execute = AsyncMock(side_effect=[scalars_none, scalars_prior])
+
+        snapshot = await service.record_daily_snapshot(account_id=1)
+
+        assert snapshot.cash_krw == Decimal("5000000")
+        assert snapshot.positions_value == Decimal("6000000")
+        assert snapshot.total_equity == Decimal("11000000")
+        assert snapshot.daily_return_pct == Decimal("10.0000")
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_record_snapshot_first_ever_has_null_return(
+        self, service, mock_db, monkeypatch
+    ):
+        account = PaperAccount(
+            id=1, name="A",
+            initial_capital=Decimal("10000000"),
+            cash_krw=Decimal("10000000"),
+            cash_usd=Decimal("0"),
+            is_active=True,
+        )
+        monkeypatch.setattr(service, "get_account", AsyncMock(return_value=account))
+        monkeypatch.setattr(service, "get_positions", AsyncMock(return_value=[]))
+
+        scalars_none1 = MagicMock()
+        scalars_none1.scalar_one_or_none = MagicMock(return_value=None)
+        scalars_none2 = MagicMock()
+        scalars_none2.scalar_one_or_none = MagicMock(return_value=None)
+        mock_db.execute = AsyncMock(side_effect=[scalars_none1, scalars_none2])
+
+        snapshot = await service.record_daily_snapshot(account_id=1)
+        assert snapshot.daily_return_pct is None
+        assert snapshot.total_equity == Decimal("10000000")
+
+    @pytest.mark.asyncio
+    async def test_calculate_daily_returns_filters_by_date_range(
+        self, service, mock_db
+    ):
+        snaps = [
+            PaperDailySnapshot(
+                id=1, account_id=1, snapshot_date=date(2026, 4, 10),
+                cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+                positions_value=Decimal("0"),
+                total_equity=Decimal("10000000"), daily_return_pct=None,
+            ),
+            PaperDailySnapshot(
+                id=2, account_id=1, snapshot_date=date(2026, 4, 11),
+                cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+                positions_value=Decimal("0"),
+                total_equity=Decimal("10100000"),
+                daily_return_pct=Decimal("1.0000"),
+            ),
+        ]
+        scalars = MagicMock()
+        scalars.all.return_value = snaps
+        result = MagicMock()
+        result.scalars.return_value = scalars
+        mock_db.execute = AsyncMock(return_value=result)
+
+        rows = await service.calculate_daily_returns(
+            account_id=1, start_date=date(2026, 4, 10), end_date=date(2026, 4, 11),
+        )
+        assert rows == [
+            {"date": "2026-04-10", "total_equity": Decimal("10000000"), "daily_return_pct": None},
+            {"date": "2026-04-11", "total_equity": Decimal("10100000"), "daily_return_pct": Decimal("1.0000")},
+        ]
+
+
+class TestRoundTrips:
+    @pytest.fixture
+    def service(self, mock_db):
+        return PaperTradingService(mock_db)
+
+    def _trade(self, **kw):
+        from datetime import datetime, timezone
+        defaults = {
+            "id": 0, "account_id": 1, "symbol": "005930",
+            "instrument_type": InstrumentType.equity_kr,
+            "side": "buy", "order_type": "market",
+            "quantity": Decimal("10"), "price": Decimal("60000"),
+            "total_amount": Decimal("600000"), "fee": Decimal("0"),
+            "currency": "KRW", "reason": None, "realized_pnl": None,
+            "executed_at": datetime(2026, 4, 1, tzinfo=timezone.utc),
+        }
+        defaults.update(kw)
+        return PaperTrade(**defaults)
+
+    def test_closed_round_trip_computes_holding_days_and_pnl(self, service):
+        from datetime import datetime, timezone
+        trades = [
+            self._trade(
+                id=1, side="buy", quantity=Decimal("10"),
+                price=Decimal("60000"), fee=Decimal("90"),
+                executed_at=datetime(2026, 4, 1, 9, 0, tzinfo=timezone.utc),
+                reason="entry",
+            ),
+            self._trade(
+                id=2, side="sell", quantity=Decimal("10"),
+                price=Decimal("70000"), fee=Decimal("1365"),
+                realized_pnl=Decimal("98635"),
+                executed_at=datetime(2026, 4, 6, 9, 0, tzinfo=timezone.utc),
+                reason="exit",
+            ),
+        ]
+        trips = service._build_round_trips(trades)
+        assert len(trips) == 1
+        trip = trips[0]
+        assert trip["symbol"] == "005930"
+        assert trip["holding_days"] == 5
+        assert trip["pnl"] == 98635.0
+        assert round(trip["return_pct"], 2) == 16.44
+        assert trip["entry_reason"] == "entry"
+        assert trip["exit_reason"] == "exit"
+
+    def test_unclosed_position_excluded(self, service):
+        from datetime import datetime, timezone
+        trades = [
+            self._trade(id=1, side="buy", quantity=Decimal("10"),
+                        executed_at=datetime(2026, 4, 1, tzinfo=timezone.utc)),
+            self._trade(id=2, side="sell", quantity=Decimal("4"),
+                        realized_pnl=Decimal("40000"),
+                        executed_at=datetime(2026, 4, 3, tzinfo=timezone.utc)),
+        ]
+        assert service._build_round_trips(trades) == []
+
+    def test_multiple_symbols_grouped_independently(self, service):
+        from datetime import datetime, timezone
+        trades = [
+            self._trade(id=1, symbol="A", side="buy",
+                        executed_at=datetime(2026, 4, 1, tzinfo=timezone.utc)),
+            self._trade(id=2, symbol="B", side="buy",
+                        executed_at=datetime(2026, 4, 1, tzinfo=timezone.utc)),
+            self._trade(id=3, symbol="A", side="sell",
+                        realized_pnl=Decimal("100"),
+                        executed_at=datetime(2026, 4, 2, tzinfo=timezone.utc)),
+            self._trade(id=4, symbol="B", side="sell",
+                        realized_pnl=Decimal("-50"),
+                        executed_at=datetime(2026, 4, 3, tzinfo=timezone.utc)),
+        ]
+        trips = service._build_round_trips(trades)
+        assert {t["symbol"] for t in trips} == {"A", "B"}
+
+
+class TestRiskMetrics:
+    def test_max_drawdown_pct_basic(self):
+        equities = [Decimal("100"), Decimal("120"), Decimal("90"), Decimal("110"), Decimal("80")]
+        dd = PaperTradingService._calc_max_drawdown_pct(equities)
+        assert round(dd, 2) == 33.33
+
+    def test_max_drawdown_empty_returns_none(self):
+        assert PaperTradingService._calc_max_drawdown_pct([]) is None
+
+    def test_max_drawdown_monotonic_returns_zero(self):
+        equities = [Decimal("100"), Decimal("110"), Decimal("120")]
+        assert PaperTradingService._calc_max_drawdown_pct(equities) == 0.0
+
+    def test_sharpe_ratio_with_uniform_returns(self):
+        rets = [Decimal("1.0"), Decimal("1.0"), Decimal("1.0")]
+        assert PaperTradingService._calc_sharpe_ratio(rets) is None
+
+    def test_sharpe_ratio_mixed(self):
+        rets = [Decimal("1.0"), Decimal("-0.5"), Decimal("2.0"), Decimal("0.5")]
+        sharpe = PaperTradingService._calc_sharpe_ratio(rets)
+        assert sharpe is not None and sharpe > 0
+
+    def test_sharpe_requires_at_least_two(self):
+        assert PaperTradingService._calc_sharpe_ratio([Decimal("1.0")]) is None
+        assert PaperTradingService._calc_sharpe_ratio([]) is None

--- a/tests/test_paper_trading_service.py
+++ b/tests/test_paper_trading_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
@@ -962,4 +962,141 @@ class TestRiskMetrics:
 
     def test_sharpe_requires_at_least_two(self):
         assert PaperTradingService._calc_sharpe_ratio([Decimal("1.0")]) is None
+
+
+class TestCalculatePerformance:
+    @pytest.fixture
+    def service(self, mock_db):
+        return PaperTradingService(mock_db)
+
+    @pytest.mark.asyncio
+    async def test_full_performance_all_period(self, service, mock_db, monkeypatch):
+        from datetime import timezone
+        account = PaperAccount(
+            id=1, name="A",
+            initial_capital=Decimal("10000000"),
+            cash_krw=Decimal("5000000"),
+            cash_usd=Decimal("0"),
+            is_active=True,
+        )
+        monkeypatch.setattr(service, "get_account", AsyncMock(return_value=account))
+        monkeypatch.setattr(
+            service, "_evaluate_positions_value", AsyncMock(return_value=Decimal("6000000"))
+        )
+        monkeypatch.setattr(
+            service, "get_positions",
+            AsyncMock(return_value=[
+                {"unrealized_pnl": Decimal("500000")},
+                {"unrealized_pnl": Decimal("-100000")},
+            ]),
+        )
+
+        trades = [
+            PaperTrade(
+                id=1, account_id=1, symbol="A",
+                instrument_type=InstrumentType.equity_kr,
+                side="buy", order_type="market",
+                quantity=Decimal("10"), price=Decimal("60000"),
+                total_amount=Decimal("600000"), fee=Decimal("90"),
+                currency="KRW", reason=None, realized_pnl=None,
+                executed_at=datetime(2026, 4, 1, tzinfo=timezone.utc),
+            ),
+            PaperTrade(
+                id=2, account_id=1, symbol="A",
+                instrument_type=InstrumentType.equity_kr,
+                side="sell", order_type="market",
+                quantity=Decimal("10"), price=Decimal("70000"),
+                total_amount=Decimal("700000"), fee=Decimal("1365"),
+                currency="KRW", reason=None,
+                realized_pnl=Decimal("98635"),
+                executed_at=datetime(2026, 4, 6, tzinfo=timezone.utc),
+            ),
+        ]
+        scalars_trades = MagicMock()
+        scalars_trades.all.return_value = trades
+        trade_result = MagicMock()
+        trade_result.scalars.return_value = scalars_trades
+
+        snaps = [
+            PaperDailySnapshot(
+                id=1, account_id=1, snapshot_date=date(2026, 4, 1),
+                cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+                positions_value=Decimal("0"),
+                total_equity=Decimal("10000000"), daily_return_pct=None,
+            ),
+            PaperDailySnapshot(
+                id=2, account_id=1, snapshot_date=date(2026, 4, 2),
+                cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+                positions_value=Decimal("0"),
+                total_equity=Decimal("10100000"),
+                daily_return_pct=Decimal("1.0"),
+            ),
+            PaperDailySnapshot(
+                id=3, account_id=1, snapshot_date=date(2026, 4, 3),
+                cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+                positions_value=Decimal("0"),
+                total_equity=Decimal("9950000"),
+                daily_return_pct=Decimal("-1.49"),
+            ),
+        ]
+        snap_scalars = MagicMock()
+        snap_scalars.all.return_value = snaps
+        snap_result = MagicMock()
+        snap_result.scalars.return_value = snap_scalars
+
+        mock_db.execute = AsyncMock(side_effect=[trade_result, snap_result])
+
+        perf = await service.calculate_performance(account_id=1)
+
+        assert perf["total_return_pct"] == 10.0
+        assert perf["realized_pnl"] == 98635.0
+        assert perf["unrealized_pnl"] == 400000.0
+        assert perf["total_trades"] == 1
+        assert perf["win_rate"] == 100.0
+        assert perf["avg_holding_days"] == 5.0
+        assert perf["max_drawdown_pct"] is not None
+        assert round(perf["max_drawdown_pct"], 2) == 1.49
+        assert perf["sharpe_ratio"] is not None
+        assert perf["best_trade"] is not None
+        assert perf["best_trade"]["symbol"] == "A"
+        assert perf["worst_trade"] is not None
+
+    @pytest.mark.asyncio
+    async def test_performance_no_trades_returns_zero_rates(
+        self, service, mock_db, monkeypatch
+    ):
+        account = PaperAccount(
+            id=1, name="A",
+            initial_capital=Decimal("10000000"),
+            cash_krw=Decimal("10000000"),
+            cash_usd=Decimal("0"),
+            is_active=True,
+        )
+        monkeypatch.setattr(service, "get_account", AsyncMock(return_value=account))
+        monkeypatch.setattr(
+            service, "_evaluate_positions_value", AsyncMock(return_value=Decimal("0"))
+        )
+        monkeypatch.setattr(service, "get_positions", AsyncMock(return_value=[]))
+
+        empty = MagicMock()
+        empty.scalars.return_value = MagicMock(all=MagicMock(return_value=[]))
+        mock_db.execute = AsyncMock(return_value=empty)
+
+        perf = await service.calculate_performance(account_id=1)
+        assert perf["total_return_pct"] == 0.0
+        assert perf["realized_pnl"] == 0.0
+        assert perf["unrealized_pnl"] == 0.0
+        assert perf["total_trades"] == 0
+        assert perf["win_rate"] == 0.0
+        assert perf["avg_holding_days"] == 0.0
+        assert perf["max_drawdown_pct"] is None
+        assert perf["sharpe_ratio"] is None
+        assert perf["best_trade"] is None
+        assert perf["worst_trade"] is None
+
+    @pytest.mark.asyncio
+    async def test_performance_missing_account_raises(self, service, monkeypatch):
+        monkeypatch.setattr(service, "get_account", AsyncMock(return_value=None))
+        with pytest.raises(ValueError, match="Account 99 not found"):
+            await service.calculate_performance(account_id=99)
         assert PaperTradingService._calc_sharpe_ratio([]) is None


### PR DESCRIPTION
## Summary
- Paper trading 성과 분석을 위한 MCP 도구 3개 추가: `get_paper_performance`, `get_paper_trade_log`, `compare_paper_accounts`
- `PaperDailySnapshot` 모델 + Alembic 마이그레이션 추가 (일별 포트폴리오 가치 추적)
- `PaperTradingService`에 분석 메서드 추가: `calculate_performance`, `record_daily_snapshot`, `calculate_daily_returns`, `_build_round_trips`, `_calc_max_drawdown_pct`, `_calc_sharpe_ratio`

### MCP 도구
| 도구 | 기능 |
|------|------|
| `get_paper_performance` | 총 수익률, 실현/미실현 손익, 승률, 평균 보유일, MDD, 샤프 비율, 최고/최악 거래 |
| `get_paper_trade_log` | 거래 내역 리스트 (symbol/days/limit 필터) |
| `compare_paper_accounts` | 여러 계좌 성과 비교표 (period 필터 지원) |

## Test plan
- [x] `PaperDailySnapshot` 모델 생성 테스트
- [x] `record_daily_snapshot` — 일별 수익률 계산 + 첫 스냅샷 null 반환
- [x] `calculate_daily_returns` — 날짜 범위 필터링
- [x] `_build_round_trips` — 라운드트립 페어링, 미체결 제외, 다중 심볼
- [x] `_calc_max_drawdown_pct` — 기본/빈 배열/단조증가
- [x] `_calc_sharpe_ratio` — 균일 수익률/혼합/최소 2개
- [x] `calculate_performance` — 전체 기간/빈 계좌/계좌 없음
- [x] `get_paper_performance` — 기간별/존재하지 않는 계좌/잘못된 기간
- [x] `get_paper_trade_log` — 기본/필터 전달/계좌 없음
- [x] `compare_paper_accounts` — 전체 비교/누락 계좌/빈 목록
- [x] 전체 87개 테스트 통과, ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paper trading analytics tools: calculate performance metrics, view trade history, and compare multiple accounts.
  * Introduced daily account snapshots with metrics including returns, max drawdown, and Sharpe ratio calculations.
  * New analytics queries support custom date ranges for detailed performance analysis.

* **Tests**
  * Added comprehensive test coverage for paper trading analytics functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->