### PR TITLE
feat(paper): 다중 전략 계좌 + Trade Journal 연동

### DIFF
--- a/alembic/versions/db555723284f_add_account_type_and_paper_trade_id_to_.py
+++ b/alembic/versions/db555723284f_add_account_type_and_paper_trade_id_to_.py
@@ -1,0 +1,74 @@
+"""add account_type and paper_trade_id to trade_journals
+
+Revision ID: db555723284f
+Revises: 0a610ecdbacf
+Create Date: 2026-04-13 18:28:11.653257
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'db555723284f'
+down_revision: Union[str, Sequence[str], None] = '0a610ecdbacf'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "trade_journals",
+        sa.Column(
+            "account_type",
+            sa.Text(),
+            nullable=False,
+            server_default="live",
+        ),
+        schema="review",
+    )
+    op.add_column(
+        "trade_journals",
+        sa.Column("paper_trade_id", sa.BigInteger(), nullable=True),
+        schema="review",
+    )
+    op.create_check_constraint(
+        "trade_journals_account_type",
+        "trade_journals",
+        "account_type IN ('live','paper')",
+        schema="review",
+    )
+    op.create_check_constraint(
+        "trade_journals_no_paper_trade_on_live",
+        "trade_journals",
+        "NOT (account_type = 'live' AND paper_trade_id IS NOT NULL)",
+        schema="review",
+    )
+    op.create_index(
+        "ix_trade_journals_account_type",
+        "trade_journals",
+        ["account_type"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_trade_journals_account_type",
+        table_name="trade_journals",
+        schema="review",
+    )
+    op.drop_constraint(
+        "trade_journals_no_paper_trade_on_live",
+        "trade_journals",
+        schema="review",
+    )
+    op.drop_constraint(
+        "trade_journals_account_type",
+        "trade_journals",
+        schema="review",
+    )
+    op.drop_column("trade_journals", "paper_trade_id", schema="review")
+    op.drop_column("trade_journals", "account_type", schema="review")

--- a/app/mcp_server/tooling/order_journal.py
+++ b/app/mcp_server/tooling/order_journal.py
@@ -74,7 +74,12 @@ async def _save_order_fill(
         return None
 
 
-async def _link_journal_to_fill(symbol: str, trade_id: int) -> None:
+async def _link_journal_to_fill(
+    symbol: str,
+    trade_id: int,
+    account_type: str = "live",
+    account: str | None = None,
+) -> None:
     """Link a draft journal to a fill: draft -> active, set trade_id, recalculate hold_until."""
     try:
         async with _order_session_factory()() as db:
@@ -83,10 +88,13 @@ async def _link_journal_to_fill(symbol: str, trade_id: int) -> None:
                 .where(
                     TradeJournal.symbol == symbol,
                     TradeJournal.status == JournalStatus.draft,
+                    TradeJournal.account_type == account_type,
                 )
-                .order_by(desc(TradeJournal.created_at))
-                .limit(1)
             )
+            if account:
+                stmt = stmt.where(TradeJournal.account == account)
+
+            stmt = stmt.order_by(desc(TradeJournal.created_at)).limit(1)
             result = await db.execute(stmt)
             journal = result.scalars().first()
 
@@ -102,10 +110,12 @@ async def _link_journal_to_fill(symbol: str, trade_id: int) -> None:
 
             await db.commit()
             logger.info(
-                "Linked journal id=%s to trade id=%s for %s",
+                "Linked journal id=%s to trade id=%s for %s (account_type=%s, account=%s)",
                 journal.id,
                 trade_id,
                 symbol,
+                account_type,
+                account,
             )
     except Exception as exc:
         logger.warning("Failed to link journal to fill: %s", exc)
@@ -139,6 +149,8 @@ async def _create_trade_journal_for_buy(
     min_hold_days: int | None,
     notes: str | None,
     indicators_snapshot: dict[str, Any] | None,
+    account_type: str = "live",
+    account: str | None = None,
 ) -> dict[str, Any]:
     """Create a draft trade journal entry for a buy order.
 
@@ -150,7 +162,11 @@ async def _create_trade_journal_for_buy(
         if min_hold_days and min_hold_days > 0
         else None
     )
-    account_name = "upbit" if market_type == "crypto" else "kis"
+
+    if account:
+        account_name = account
+    else:
+        account_name = "upbit" if market_type == "crypto" else "kis"
 
     journal = TradeJournal(
         symbol=symbol,
@@ -168,6 +184,7 @@ async def _create_trade_journal_for_buy(
         indicators_snapshot=indicators_snapshot,
         notes=notes,
         account=account_name,
+        account_type=account_type,
         status=JournalStatus.draft,
     )
 
@@ -189,6 +206,8 @@ async def _close_journals_on_sell(
     sell_quantity: float,
     sell_price: float,
     exit_reason: str | None = None,
+    account_type: str = "live",
+    account: str | None = None,
 ) -> dict[str, Any]:
     """Close active trade journals in FIFO order when a sell order succeeds.
 
@@ -209,9 +228,13 @@ async def _close_journals_on_sell(
             .where(
                 TradeJournal.symbol == symbol,
                 TradeJournal.status == JournalStatus.active,
+                TradeJournal.account_type == account_type,
             )
-            .order_by(TradeJournal.created_at.asc())
         )
+        if account:
+            stmt = stmt.where(TradeJournal.account == account)
+
+        stmt = stmt.order_by(TradeJournal.created_at.asc())
         result = await db.execute(stmt)
         journals = list(result.scalars().all())
 

--- a/app/mcp_server/tooling/order_journal.py
+++ b/app/mcp_server/tooling/order_journal.py
@@ -83,13 +83,10 @@ async def _link_journal_to_fill(
     """Link a draft journal to a fill: draft -> active, set trade_id, recalculate hold_until."""
     try:
         async with _order_session_factory()() as db:
-            stmt = (
-                select(TradeJournal)
-                .where(
-                    TradeJournal.symbol == symbol,
-                    TradeJournal.status == JournalStatus.draft,
-                    TradeJournal.account_type == account_type,
-                )
+            stmt = select(TradeJournal).where(
+                TradeJournal.symbol == symbol,
+                TradeJournal.status == JournalStatus.draft,
+                TradeJournal.account_type == account_type,
             )
             if account:
                 stmt = stmt.where(TradeJournal.account == account)
@@ -223,13 +220,10 @@ async def _close_journals_on_sell(
     resolved_reason = (exit_reason or "").strip() or "sold_via_place_order"
 
     async with _order_session_factory()() as db:
-        stmt = (
-            select(TradeJournal)
-            .where(
-                TradeJournal.symbol == symbol,
-                TradeJournal.status == JournalStatus.active,
-                TradeJournal.account_type == account_type,
-            )
+        stmt = select(TradeJournal).where(
+            TradeJournal.symbol == symbol,
+            TradeJournal.status == JournalStatus.active,
+            TradeJournal.account_type == account_type,
         )
         if account:
             stmt = stmt.where(TradeJournal.account == account)

--- a/app/mcp_server/tooling/orders_modify_cancel.py
+++ b/app/mcp_server/tooling/orders_modify_cancel.py
@@ -448,9 +448,7 @@ async def _cancel_kis_domestic(
             open_orders = await kis.inquire_korea_orders()
             for order in open_orders:
                 if (
-                    str(
-                        _get_kis_field(order, "odno", "ODNO", "ord_no", "ORD_NO")
-                    )
+                    str(_get_kis_field(order, "odno", "ODNO", "ord_no", "ORD_NO"))
                     == order_id
                 ):
                     symbol = str(_get_kis_field(order, "pdno", "PDNO"))
@@ -489,16 +487,10 @@ async def _cancel_kis_domestic(
                     default="02",
                 )
                 price = int(
-                    float(
-                        _get_kis_field(order, "ord_unpr", "ORD_UNPR", default=0)
-                        or 0
-                    )
+                    float(_get_kis_field(order, "ord_unpr", "ORD_UNPR", default=0) or 0)
                 )
                 quantity = int(
-                    float(
-                        _get_kis_field(order, "ord_qty", "ORD_QTY", default=0)
-                        or 0
-                    )
+                    float(_get_kis_field(order, "ord_qty", "ORD_QTY", default=0) or 0)
                 )
                 orgno_value = _get_kis_field(
                     order,
@@ -586,10 +578,7 @@ async def _cancel_kis_overseas(
 
         # Try to get remaining quantity from open order fields first
         remaining_quantity = int(
-            float(
-                _get_kis_field(target_order, "nccs_qty", "NCCS_QTY", default=0)
-                or 0
-            )
+            float(_get_kis_field(target_order, "nccs_qty", "NCCS_QTY", default=0) or 0)
         )
 
         if remaining_quantity > 0:
@@ -598,9 +587,7 @@ async def _cancel_kis_overseas(
             # Calculate remaining from ordered - filled
             ordered = int(
                 float(
-                    _get_kis_field(
-                        target_order, "ft_ord_qty", "FT_ORD_QTY", default=0
-                    )
+                    _get_kis_field(target_order, "ft_ord_qty", "FT_ORD_QTY", default=0)
                     or 0
                 )
             )
@@ -694,7 +681,6 @@ async def cancel_order_impl(
         }
 
 
-
 def _validate_modify_inputs(
     order_id: str,
     symbol: str,
@@ -708,9 +694,7 @@ def _validate_modify_inputs(
         (order_id, symbol, market_type, normalized_symbol)
     """
     if new_price is None and new_quantity is None:
-        raise ValueError(
-            "At least one of new_price or new_quantity must be specified"
-        )
+        raise ValueError("At least one of new_price or new_quantity must be specified")
     if new_price is not None and new_price <= 0:
         raise ValueError("new_price must be a positive number")
     if new_quantity is not None and new_quantity <= 0:
@@ -733,9 +717,7 @@ def _build_modify_dry_run_response(
     """Build dry-run preview response for modify order."""
     changes: dict[str, Any] = {
         "price": {"from": None, "to": new_price} if new_price else None,
-        "quantity": (
-            {"from": None, "to": new_quantity} if new_quantity else None
-        ),
+        "quantity": ({"from": None, "to": new_quantity} if new_quantity else None),
     }
     return {
         "success": True,
@@ -784,13 +766,9 @@ async def _modify_upbit(
             }
 
         original_price = float(original_order.get("price", 0) or 0)
-        original_quantity = float(
-            original_order.get("remaining_volume", 0) or 0
-        )
+        original_quantity = float(original_order.get("remaining_volume", 0) or 0)
         final_price = new_price if new_price is not None else original_price
-        final_quantity = (
-            new_quantity if new_quantity is not None else original_quantity
-        )
+        final_quantity = new_quantity if new_quantity is not None else original_quantity
 
         result = await upbit_service.cancel_and_reorder(
             order_id, final_price, final_quantity
@@ -823,9 +801,7 @@ async def _modify_upbit(
             "order_id": order_id,
             "symbol": normalized_symbol,
             "market": _normalize_market_type_to_external(market_type),
-            "error": result.get("cancel_result", {}).get(
-                "error", "Unknown error"
-            ),
+            "error": result.get("cancel_result", {}).get("error", "Unknown error"),
             "changes": changes,
             "method": "cancel_reorder",
             "dry_run": dry_run,
@@ -859,11 +835,7 @@ async def _modify_kis_domestic(
         target_order = None
         for order in open_orders:
             if (
-                str(
-                    _get_kis_field(
-                        order, "odno", "ODNO", "ord_no", "ORD_NO"
-                    )
-                )
+                str(_get_kis_field(order, "odno", "ODNO", "ord_no", "ORD_NO"))
                 == order_id
             ):
                 target_order = order
@@ -881,29 +853,15 @@ async def _modify_kis_domestic(
             }
 
         original_price = int(
-            float(
-                _get_kis_field(
-                    target_order, "ord_unpr", "ORD_UNPR", default=0
-                )
-                or 0
-            )
+            float(_get_kis_field(target_order, "ord_unpr", "ORD_UNPR", default=0) or 0)
         )
         original_quantity = int(
-            float(
-                _get_kis_field(
-                    target_order, "ord_qty", "ORD_QTY", default=0
-                )
-                or 0
-            )
+            float(_get_kis_field(target_order, "ord_qty", "ORD_QTY", default=0) or 0)
         )
-        side_code = _get_kis_field(
-            target_order, "sll_buy_dvsn_cd", "SLL_BUY_DVSN_CD"
-        )
+        side_code = _get_kis_field(target_order, "sll_buy_dvsn_cd", "SLL_BUY_DVSN_CD")
         side = "buy" if side_code == "02" else "sell"
 
-        final_price_raw = (
-            int(new_price) if new_price is not None else original_price
-        )
+        final_price_raw = int(new_price) if new_price is not None else original_price
         final_price = int(adjust_tick_size_kr(float(final_price_raw), side))
         final_quantity = (
             int(new_quantity) if new_quantity is not None else original_quantity
@@ -989,9 +947,7 @@ async def _modify_kis_overseas(
             target_order,
             target_exchange,
             exchange_candidates,
-        ) = await _find_us_open_order_by_id(
-            kis, order_id, normalized_symbol
-        )
+        ) = await _find_us_open_order_by_id(kis, order_id, normalized_symbol)
         logger.debug(
             "US modify lookup: order_id=%s symbol=%s checked_exchanges=%s",
             order_id,
@@ -1011,17 +967,11 @@ async def _modify_kis_overseas(
             }
 
         original_price = float(
-            _get_kis_field(
-                target_order, "ft_ord_unpr3", "FT_ORD_UNPR3", default=0
-            )
-            or 0
+            _get_kis_field(target_order, "ft_ord_unpr3", "FT_ORD_UNPR3", default=0) or 0
         )
         original_quantity = int(
             float(
-                _get_kis_field(
-                    target_order, "ft_ord_qty", "FT_ORD_QTY", default=0
-                )
-                or 0
+                _get_kis_field(target_order, "ft_ord_qty", "FT_ORD_QTY", default=0) or 0
             )
         )
 
@@ -1034,13 +984,9 @@ async def _modify_kis_overseas(
             ", ".join(exchange_candidates),
             exchange_code,
         )
-        final_price = (
-            float(new_price) if new_price is not None else original_price
-        )
+        final_price = float(new_price) if new_price is not None else original_price
         final_quantity = (
-            int(new_quantity)
-            if new_quantity is not None
-            else original_quantity
+            int(new_quantity) if new_quantity is not None else original_quantity
         )
 
         result = await kis.modify_overseas_order(
@@ -1107,10 +1053,8 @@ async def modify_order_impl(
     new_quantity: float | None = None,
     dry_run: bool = True,
 ) -> dict[str, Any]:
-    order_id, symbol, market_type, normalized_symbol = (
-        _validate_modify_inputs(
-            order_id, symbol, market, new_price, new_quantity
-        )
+    order_id, symbol, market_type, normalized_symbol = _validate_modify_inputs(
+        order_id, symbol, market, new_price, new_quantity
     )
 
     if dry_run:
@@ -1160,7 +1104,6 @@ async def modify_order_impl(
         "error": f"modify_order is not supported for market '{market_type}'",
         "dry_run": dry_run,
     }
-
 
 
 __all__ = [

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -75,9 +75,9 @@ def register_order_tools(mcp: FastMCP) -> None:
             "Place buy/sell orders for stocks or crypto. "
             "Supports Upbit (crypto) and KIS (KR/US equities). "
             "Always returns dry_run preview unless explicitly set to False. "
-            "For real buy orders (dry_run=False), thesis and strategy are required "
+            "For buy orders (dry_run=False), thesis and strategy are required "
             "so a trade journal can be created automatically. "
-            "For real sell orders, active trade journals are auto-closed in FIFO order. "
+            "For sell orders, active trade journals are auto-closed in FIFO order. "
             "Use exit_reason to record the sell thesis in the journal. "
             "Safety limit: max 20 orders/day. "
             "dry_run=True by default for safety. "
@@ -85,7 +85,7 @@ def register_order_tools(mcp: FastMCP) -> None:
             "(no real broker calls, uses PaperTradingService). In paper mode, the "
             "default account is auto-created with 100,000,000 KRW on first use; "
             "pass paper_account to target a named paper account. "
-            "In paper mode, thesis/strategy/journal parameters are ignored."
+            "Journal features (thesis/strategy/FIFO close) ARE supported in paper mode."
         ),
     )
     async def place_order(
@@ -118,6 +118,14 @@ def register_order_tools(mcp: FastMCP) -> None:
                 amount=amount,
                 dry_run=dry_run,
                 reason=reason,
+                exit_reason=exit_reason,
+                thesis=thesis,
+                strategy=strategy,
+                target_price=target_price,
+                stop_loss=stop_loss,
+                min_hold_days=min_hold_days,
+                notes=notes,
+                indicators_snapshot=indicators_snapshot,
                 paper_account_name=paper_account,
             )
         return await order_execution._place_order_impl(

--- a/app/mcp_server/tooling/paper_account_registration.py
+++ b/app/mcp_server/tooling/paper_account_registration.py
@@ -67,6 +67,7 @@ def register_paper_account_tools(mcp: FastMCP) -> None:
             "Create a new paper trading (모의투자) account. "
             "initial_capital is the KRW opening balance (default 100,000,000 KRW = 1억). "
             "initial_capital_usd adds a separate USD cash balance for US equity simulation. "
+            "strategy_name (optional) tags the account with a strategy slug (e.g. 'momentum'). "
             "Account name must be unique."
         ),
     )
@@ -75,6 +76,7 @@ def register_paper_account_tools(mcp: FastMCP) -> None:
         initial_capital: float = 100_000_000.0,
         initial_capital_usd: float = 0.0,
         description: str | None = None,
+        strategy_name: str | None = None,
     ) -> dict[str, Any]:
         try:
             async with _session_factory()() as db:
@@ -84,6 +86,7 @@ def register_paper_account_tools(mcp: FastMCP) -> None:
                     initial_capital_krw=Decimal(str(initial_capital)),
                     initial_capital_usd=Decimal(str(initial_capital_usd)),
                     description=description,
+                    strategy_name=strategy_name,
                 )
                 return {"success": True, "account": _serialize_account(account)}
         except IntegrityError:
@@ -101,13 +104,20 @@ def register_paper_account_tools(mcp: FastMCP) -> None:
             "(positions_count, total_evaluated_krw, total_pnl_pct). "
             "Note: total_evaluated_krw sums KRW and USD position values verbatim "
             "— it does not convert USD to KRW. "
-            "is_active=True (default) filters to active accounts only."
+            "is_active=True (default) filters to active accounts only. "
+            "strategy_name (optional) filters to accounts with a matching strategy slug."
         ),
     )
-    async def list_paper_accounts(is_active: bool = True) -> dict[str, Any]:
+    async def list_paper_accounts(
+        is_active: bool = True,
+        strategy_name: str | None = None,
+    ) -> dict[str, Any]:
         async with _session_factory()() as db:
             service = PaperTradingService(db)
-            accounts = await service.list_accounts(is_active=is_active)
+            accounts = await service.list_accounts(
+                is_active=is_active,
+                strategy_name=strategy_name,
+            )
 
             out: list[dict[str, Any]] = []
             for account in accounts:

--- a/app/mcp_server/tooling/paper_journal_bridge.py
+++ b/app/mcp_server/tooling/paper_journal_bridge.py
@@ -1,0 +1,175 @@
+"""Paper Journal Bridge — 전략 비교 및 실전 전환 추천.
+
+Paper 주문→journal 연동(create/close)은 order_journal.py가 담당한다.
+이 모듈은 journal 데이터를 기반으로 한 분석/추천 기능만 책임진다.
+
+집계 규칙 (고정):
+- 모든 지표(win_rate, total_return_pct, avg_pnl_pct, best/worst_trade)는
+  **closed** journal 기준으로만 계산 (realized performance).
+- active journal은 집계에서 제외.
+- total_return_pct는 closed journal들의 pnl_pct 합산 (realized 기준).
+- 집계 단위는 paper account 기준. strategy_name은 필터/표시 역할.
+- strategy_name 필터는 TradeJournal.strategy 기준 (PaperAccount.strategy_name 아님).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import timedelta
+from decimal import Decimal
+from typing import Any, cast
+
+from sqlalchemy import desc, func as sa_func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.core.timezone import now_kst
+from app.models.paper_trading import PaperAccount
+from app.models.trade_journal import JournalStatus, TradeJournal
+
+logger = logging.getLogger(__name__)
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+async def compare_strategies(
+    days: int = 30,
+    strategy_name: str | None = None,
+    include_live_comparison: bool = True,
+) -> dict[str, Any]:
+    """Compare paper trading strategy performance over a given period.
+
+    Shows per-account/per-strategy metrics such as win rate, realized return,
+    and best/worst trade. All metrics are based on closed journals only.
+    If include_live_comparison=True, also compares same-symbol live vs paper
+    journal outcomes within the same period.
+    """
+    cutoff = now_kst() - timedelta(days=days)
+
+    try:
+        async with _session_factory()() as db:
+            # 1. Paper accounts for metadata
+            acct_stmt = select(PaperAccount).where(PaperAccount.is_active.is_(True))
+            acct_result = await db.execute(acct_stmt)
+            accounts = {a.name: a for a in acct_result.scalars().all()}
+
+            # 2. Paper journals in period
+            paper_filters: list = [
+                TradeJournal.account_type == "paper",
+                TradeJournal.created_at >= cutoff,
+            ]
+            if strategy_name is not None:
+                paper_filters.append(TradeJournal.strategy == strategy_name)
+
+            paper_stmt = (
+                select(TradeJournal)
+                .where(*paper_filters)
+                .order_by(desc(TradeJournal.created_at))
+            )
+            paper_result = await db.execute(paper_stmt)
+            paper_journals = list(paper_result.scalars().all())
+
+            # 3. Aggregate by account (closed only)
+            by_account: dict[str, list[TradeJournal]] = defaultdict(list)
+            for j in paper_journals:
+                if j.status == JournalStatus.closed and j.account:
+                    by_account[j.account].append(j)
+
+            strategies_out: list[dict[str, Any]] = []
+            for account_name, journals in by_account.items():
+                acct = accounts.get(account_name)
+                total = len(journals)
+                pnl_values = [
+                    float(j.pnl_pct) for j in journals if j.pnl_pct is not None
+                ]
+                win_count = sum(1 for v in pnl_values if v > 0)
+                loss_count = total - win_count
+                total_return_pct = round(sum(pnl_values), 2) if pnl_values else 0.0
+                avg_pnl_pct = (
+                    round(total_return_pct / len(pnl_values), 2) if pnl_values else 0.0
+                )
+                win_rate = round(win_count / total * 100, 1) if total > 0 else 0.0
+
+                best = max(journals, key=lambda j: float(j.pnl_pct or 0))
+                worst = min(journals, key=lambda j: float(j.pnl_pct or 0))
+
+                strategies_out.append({
+                    "strategy_name": acct.strategy_name if acct else None,
+                    "account_name": account_name,
+                    "account_id": acct.id if acct else None,
+                    "total_trades": total,
+                    "win_count": win_count,
+                    "loss_count": loss_count,
+                    "win_rate": win_rate,
+                    "total_return_pct": total_return_pct,
+                    "avg_pnl_pct": avg_pnl_pct,
+                    "best_trade": {
+                        "symbol": best.symbol,
+                        "pnl_pct": float(best.pnl_pct) if best.pnl_pct else 0.0,
+                    },
+                    "worst_trade": {
+                        "symbol": worst.symbol,
+                        "pnl_pct": float(worst.pnl_pct) if worst.pnl_pct else 0.0,
+                    },
+                })
+
+            # 4. Live vs paper comparison (most recent closed per symbol)
+            live_vs_paper: list[dict[str, Any]] = []
+            if include_live_comparison:
+                live_stmt = (
+                    select(TradeJournal)
+                    .where(
+                        TradeJournal.account_type == "live",
+                        TradeJournal.status == JournalStatus.closed,
+                        TradeJournal.created_at >= cutoff,
+                    )
+                    .order_by(desc(TradeJournal.created_at))
+                )
+                live_result = await db.execute(live_stmt)
+                live_journals = list(live_result.scalars().all())
+
+                # Most recent closed per symbol
+                live_by_symbol: dict[str, TradeJournal] = {}
+                for j in live_journals:
+                    if j.symbol not in live_by_symbol:
+                        live_by_symbol[j.symbol] = j
+
+                paper_closed = [
+                    j for j in paper_journals if j.status == JournalStatus.closed
+                ]
+                paper_by_symbol: dict[str, TradeJournal] = {}
+                for j in paper_closed:
+                    if j.symbol not in paper_by_symbol:
+                        paper_by_symbol[j.symbol] = j
+
+                for sym in sorted(set(live_by_symbol) & set(paper_by_symbol)):
+                    lj = live_by_symbol[sym]
+                    pj = paper_by_symbol[sym]
+                    l_pnl = float(lj.pnl_pct) if lj.pnl_pct is not None else 0.0
+                    p_pnl = float(pj.pnl_pct) if pj.pnl_pct is not None else 0.0
+                    live_vs_paper.append({
+                        "symbol": sym,
+                        "live_entry_price": (
+                            float(lj.entry_price) if lj.entry_price else None
+                        ),
+                        "live_pnl_pct": l_pnl,
+                        "paper_entry_price": (
+                            float(pj.entry_price) if pj.entry_price else None
+                        ),
+                        "paper_pnl_pct": p_pnl,
+                        "paper_strategy": pj.strategy,
+                        "delta_pnl_pct": round(p_pnl - l_pnl, 4),
+                    })
+
+            return {
+                "success": True,
+                "period_days": days,
+                "strategies": strategies_out,
+                "live_vs_paper": live_vs_paper,
+            }
+    except Exception as exc:
+        logger.exception("compare_strategies failed")
+        return {"success": False, "error": f"compare_strategies failed: {exc}"}

--- a/app/mcp_server/tooling/paper_journal_bridge.py
+++ b/app/mcp_server/tooling/paper_journal_bridge.py
@@ -173,3 +173,131 @@ async def compare_strategies(
     except Exception as exc:
         logger.exception("compare_strategies failed")
         return {"success": False, "error": f"compare_strategies failed: {exc}"}
+
+
+async def recommend_go_live(
+    account_name: str,
+    min_trades: int = 20,
+    min_win_rate: float = 50.0,
+    min_return_pct: float = 0.0,
+) -> dict[str, Any]:
+    """Evaluate whether a paper trading account meets go-live criteria.
+
+    All metrics are based on **closed** journals only (realized performance).
+    Active positions are shown in summary for reference but excluded from judgment.
+    """
+    try:
+        async with _session_factory()() as db:
+            # 1. Account lookup
+            acct_stmt = select(PaperAccount).where(
+                PaperAccount.name == account_name
+            )
+            acct_result = await db.execute(acct_stmt)
+            account = acct_result.scalars().one_or_none()
+            if account is None:
+                return {
+                    "success": False,
+                    "error": f"Paper account '{account_name}' not found",
+                }
+
+            # 2. Closed journals
+            closed_stmt = (
+                select(TradeJournal)
+                .where(
+                    TradeJournal.account_type == "paper",
+                    TradeJournal.account == account_name,
+                    TradeJournal.status == JournalStatus.closed,
+                )
+                .order_by(desc(TradeJournal.created_at))
+            )
+            closed_result = await db.execute(closed_stmt)
+            closed_journals = list(closed_result.scalars().all())
+
+            # 3. Active positions count (reference only)
+            active_stmt = (
+                select(sa_func.count())
+                .select_from(TradeJournal)
+                .where(
+                    TradeJournal.account_type == "paper",
+                    TradeJournal.account == account_name,
+                    TradeJournal.status == JournalStatus.active,
+                )
+            )
+            active_result = await db.execute(active_stmt)
+            active_positions = active_result.scalar_one()
+
+            # 4. Calculate metrics
+            total_trades = len(closed_journals)
+            pnl_values = [
+                float(j.pnl_pct)
+                for j in closed_journals
+                if j.pnl_pct is not None
+            ]
+            win_count = sum(1 for v in pnl_values if v > 0)
+            loss_count = total_trades - win_count
+            total_return_pct = round(sum(pnl_values), 2) if pnl_values else 0.0
+            win_rate = (
+                round(win_count / total_trades * 100, 1) if total_trades > 0 else 0.0
+            )
+            avg_pnl_pct = (
+                round(total_return_pct / len(pnl_values), 2) if pnl_values else 0.0
+            )
+
+            best_trade = None
+            worst_trade = None
+            if closed_journals:
+                best = max(closed_journals, key=lambda j: float(j.pnl_pct or 0))
+                worst = min(closed_journals, key=lambda j: float(j.pnl_pct or 0))
+                best_trade = {
+                    "symbol": best.symbol,
+                    "pnl_pct": float(best.pnl_pct) if best.pnl_pct else 0.0,
+                }
+                worst_trade = {
+                    "symbol": worst.symbol,
+                    "pnl_pct": float(worst.pnl_pct) if worst.pnl_pct else 0.0,
+                }
+
+            # 5. Criteria check
+            trades_passed = total_trades >= min_trades
+            wr_passed = win_rate >= min_win_rate
+            return_passed = total_return_pct >= min_return_pct
+            all_passed = trades_passed and wr_passed and return_passed
+
+            return {
+                "success": True,
+                "account_name": account_name,
+                "strategy_name": account.strategy_name,
+                "recommendation": "go_live" if all_passed else "not_ready",
+                "criteria": {
+                    "min_trades": {
+                        "required": min_trades,
+                        "actual": total_trades,
+                        "passed": trades_passed,
+                    },
+                    "min_win_rate": {
+                        "required": min_win_rate,
+                        "actual": win_rate,
+                        "passed": wr_passed,
+                    },
+                    "min_return_pct": {
+                        "required": min_return_pct,
+                        "actual": total_return_pct,
+                        "passed": return_passed,
+                    },
+                },
+                "all_passed": all_passed,
+                "summary": {
+                    "total_trades": total_trades,
+                    "win_count": win_count,
+                    "loss_count": loss_count,
+                    "win_rate": win_rate,
+                    "total_return_pct": total_return_pct,
+                    "avg_pnl_pct": avg_pnl_pct,
+                    "best_trade": best_trade,
+                    "worst_trade": worst_trade,
+                    "active_positions": active_positions,
+                },
+            }
+    except Exception as exc:
+        logger.exception("recommend_go_live failed")
+        return {"success": False, "error": f"recommend_go_live failed: {exc}"}

--- a/app/mcp_server/tooling/paper_journal_bridge.py
+++ b/app/mcp_server/tooling/paper_journal_bridge.py
@@ -17,10 +17,10 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from datetime import timedelta
-from decimal import Decimal
 from typing import Any, cast
 
-from sqlalchemy import desc, func as sa_func, select
+from sqlalchemy import desc, select
+from sqlalchemy import func as sa_func
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.db import AsyncSessionLocal
@@ -96,25 +96,27 @@ async def compare_strategies(
                 best = max(journals, key=lambda j: float(j.pnl_pct or 0))
                 worst = min(journals, key=lambda j: float(j.pnl_pct or 0))
 
-                strategies_out.append({
-                    "strategy_name": acct.strategy_name if acct else None,
-                    "account_name": account_name,
-                    "account_id": acct.id if acct else None,
-                    "total_trades": total,
-                    "win_count": win_count,
-                    "loss_count": loss_count,
-                    "win_rate": win_rate,
-                    "total_return_pct": total_return_pct,
-                    "avg_pnl_pct": avg_pnl_pct,
-                    "best_trade": {
-                        "symbol": best.symbol,
-                        "pnl_pct": float(best.pnl_pct) if best.pnl_pct else 0.0,
-                    },
-                    "worst_trade": {
-                        "symbol": worst.symbol,
-                        "pnl_pct": float(worst.pnl_pct) if worst.pnl_pct else 0.0,
-                    },
-                })
+                strategies_out.append(
+                    {
+                        "strategy_name": acct.strategy_name if acct else None,
+                        "account_name": account_name,
+                        "account_id": acct.id if acct else None,
+                        "total_trades": total,
+                        "win_count": win_count,
+                        "loss_count": loss_count,
+                        "win_rate": win_rate,
+                        "total_return_pct": total_return_pct,
+                        "avg_pnl_pct": avg_pnl_pct,
+                        "best_trade": {
+                            "symbol": best.symbol,
+                            "pnl_pct": float(best.pnl_pct) if best.pnl_pct else 0.0,
+                        },
+                        "worst_trade": {
+                            "symbol": worst.symbol,
+                            "pnl_pct": float(worst.pnl_pct) if worst.pnl_pct else 0.0,
+                        },
+                    }
+                )
 
             # 4. Live vs paper comparison (most recent closed per symbol)
             live_vs_paper: list[dict[str, Any]] = []
@@ -150,19 +152,21 @@ async def compare_strategies(
                     pj = paper_by_symbol[sym]
                     l_pnl = float(lj.pnl_pct) if lj.pnl_pct is not None else 0.0
                     p_pnl = float(pj.pnl_pct) if pj.pnl_pct is not None else 0.0
-                    live_vs_paper.append({
-                        "symbol": sym,
-                        "live_entry_price": (
-                            float(lj.entry_price) if lj.entry_price else None
-                        ),
-                        "live_pnl_pct": l_pnl,
-                        "paper_entry_price": (
-                            float(pj.entry_price) if pj.entry_price else None
-                        ),
-                        "paper_pnl_pct": p_pnl,
-                        "paper_strategy": pj.strategy,
-                        "delta_pnl_pct": round(p_pnl - l_pnl, 4),
-                    })
+                    live_vs_paper.append(
+                        {
+                            "symbol": sym,
+                            "live_entry_price": (
+                                float(lj.entry_price) if lj.entry_price else None
+                            ),
+                            "live_pnl_pct": l_pnl,
+                            "paper_entry_price": (
+                                float(pj.entry_price) if pj.entry_price else None
+                            ),
+                            "paper_pnl_pct": p_pnl,
+                            "paper_strategy": pj.strategy,
+                            "delta_pnl_pct": round(p_pnl - l_pnl, 4),
+                        }
+                    )
 
             return {
                 "success": True,
@@ -189,9 +193,7 @@ async def recommend_go_live(
     try:
         async with _session_factory()() as db:
             # 1. Account lookup
-            acct_stmt = select(PaperAccount).where(
-                PaperAccount.name == account_name
-            )
+            acct_stmt = select(PaperAccount).where(PaperAccount.name == account_name)
             acct_result = await db.execute(acct_stmt)
             account = acct_result.scalars().one_or_none()
             if account is None:
@@ -229,9 +231,7 @@ async def recommend_go_live(
             # 4. Calculate metrics
             total_trades = len(closed_journals)
             pnl_values = [
-                float(j.pnl_pct)
-                for j in closed_journals
-                if j.pnl_pct is not None
+                float(j.pnl_pct) for j in closed_journals if j.pnl_pct is not None
             ]
             win_count = sum(1 for v in pnl_values if v > 0)
             loss_count = total_trades - win_count

--- a/app/mcp_server/tooling/paper_journal_registration.py
+++ b/app/mcp_server/tooling/paper_journal_registration.py
@@ -1,0 +1,44 @@
+"""Paper Journal MCP tool registration — compare_strategies, recommend_go_live."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.mcp_server.tooling.paper_journal_bridge import (
+    compare_strategies,
+    recommend_go_live,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+PAPER_JOURNAL_TOOL_NAMES: set[str] = {
+    "compare_strategies",
+    "recommend_go_live",
+}
+
+
+def register_paper_journal_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="compare_strategies",
+        description=(
+            "Compare paper trading strategy performance over a given period. "
+            "Shows per-account/per-strategy metrics such as win rate, realized return, "
+            "and best/worst trade. All metrics are based on closed journals only. "
+            "If include_live_comparison=True, also compares same-symbol live vs paper "
+            "journal outcomes within the same period."
+        ),
+    )(compare_strategies)
+
+    _ = mcp.tool(
+        name="recommend_go_live",
+        description=(
+            "Evaluate whether a paper trading account meets criteria for live trading. "
+            "Checks total trades, win rate, and realized return against thresholds "
+            "(default: 20 trades, 50% win rate, positive return). "
+            "All metrics are based on closed journals only."
+        ),
+    )(recommend_go_live)
+
+
+__all__ = ["PAPER_JOURNAL_TOOL_NAMES", "register_paper_journal_tools"]

--- a/app/mcp_server/tooling/paper_order_handler.py
+++ b/app/mcp_server/tooling/paper_order_handler.py
@@ -9,6 +9,13 @@ from decimal import Decimal
 from typing import Any
 
 from app.core.db import AsyncSessionLocal
+from app.mcp_server.tooling.order_journal import (
+    _append_journal_warning,
+    _close_journals_on_sell,
+    _create_trade_journal_for_buy,
+    _link_journal_to_fill,
+    _validate_buy_journal_requirements,
+)
 from app.mcp_server.tooling.shared import logger
 from app.models.paper_trading import PaperAccount
 from app.services.paper_trading_service import PaperTradingService
@@ -64,10 +71,26 @@ async def _place_paper_order(
     amount: float | None,
     dry_run: bool,
     reason: str,
-    paper_account_name: str | None,
+    exit_reason: str | None = None,
+    thesis: str | None = None,
+    strategy: str | None = None,
+    target_price: float | None = None,
+    stop_loss: float | None = None,
+    min_hold_days: int | None = None,
+    notes: str | None = None,
+    indicators_snapshot: dict[str, Any] | None = None,
+    paper_account_name: str | None = None,
 ) -> dict[str, Any]:
     """Route a `place_order` call to the paper trading engine."""
     try:
+        # 1. Validate journal requirements for buy orders
+        _validate_buy_journal_requirements(
+            side=side,
+            dry_run=dry_run,
+            thesis=thesis,
+            strategy=strategy,
+        )
+
         async with AsyncSessionLocal() as db:
             service = PaperTradingService(db)
             try:
@@ -95,6 +118,7 @@ async def _place_paper_order(
                     "message": "[Paper] Order preview (dry_run=True)",
                 }
 
+            # 2. Execution
             execution = await service.execute_order(
                 account_id=account.id,
                 symbol=symbol,
@@ -105,16 +129,84 @@ async def _place_paper_order(
                 amount=amount,
                 reason=reason or "",
             )
-            return {
+
+            p = execution["preview"]
+            exec_data = execution["execution"]
+            normalized_symbol = p["symbol"]
+            market_type = p["instrument_type"]
+
+            journal_id: int | None = None
+            journal_status: str | None = None
+            journal_warning: str | None = None
+
+            # 3. Journal Integration (Buy)
+            if side == "buy":
+                try:
+                    journal_res = await _create_trade_journal_for_buy(
+                        symbol=normalized_symbol,
+                        market_type=market_type,
+                        preview=p,
+                        thesis=thesis or "",
+                        strategy=strategy or "",
+                        target_price=target_price,
+                        stop_loss=stop_loss,
+                        min_hold_days=min_hold_days,
+                        notes=notes,
+                        indicators_snapshot=indicators_snapshot,
+                        account_type="paper",
+                        account=account.name,
+                    )
+                    journal_id = journal_res["journal_id"]
+                    journal_status = journal_res["journal_status"]
+
+                    # Paper trades fill immediately, link right away
+                    await _link_journal_to_fill(
+                        symbol=normalized_symbol,
+                        trade_id=0,  # placeholder for paper
+                        account_type="paper",
+                        account=account.name,
+                    )
+                    journal_status = "active"
+                except Exception as exc:
+                    journal_warning = _append_journal_warning(
+                        journal_warning, f"Journal creation failed: {exc}"
+                    )
+
+            # 4. Journal Integration (Sell)
+            elif side == "sell":
+                try:
+                    close_res = await _close_journals_on_sell(
+                        symbol=normalized_symbol,
+                        sell_quantity=float(p["quantity"]),
+                        sell_price=float(p["price"]),
+                        exit_reason=exit_reason,
+                        account_type="paper",
+                        account=account.name,
+                    )
+                    if close_res["journals_closed"] > 0:
+                        exec_data["journals_closed"] = close_res["journals_closed"]
+                        exec_data["closed_journal_ids"] = close_res["closed_ids"]
+                except Exception as exc:
+                    journal_warning = _append_journal_warning(
+                        journal_warning, f"Journal closing failed: {exc}"
+                    )
+
+            result = {
                 "success": True,
                 "dry_run": False,
                 "account_type": "paper",
                 "paper_account": account.name,
                 "account_id": account.id,
-                "preview": execution["preview"],
-                "execution": execution["execution"],
+                "preview": p,
+                "execution": exec_data,
+                "journal_id": journal_id,
+                "journal_status": journal_status,
                 "message": "[Paper] Order placed successfully",
             }
+            if journal_warning:
+                result["journal_warning"] = journal_warning
+
+            return result
     except ValueError as exc:
         return _paper_error(str(exc), symbol=symbol)
     except Exception as exc:  # pragma: no cover — unexpected failure

--- a/app/mcp_server/tooling/paper_order_handler.py
+++ b/app/mcp_server/tooling/paper_order_handler.py
@@ -5,19 +5,23 @@ Keeps paper-only code isolated from the live order execution path.
 
 from __future__ import annotations
 
+from datetime import timedelta
 from decimal import Decimal
 from typing import Any
 
+from sqlalchemy import desc, select
+
 from app.core.db import AsyncSessionLocal
+from app.core.timezone import now_kst
 from app.mcp_server.tooling.order_journal import (
     _append_journal_warning,
     _close_journals_on_sell,
     _create_trade_journal_for_buy,
-    _link_journal_to_fill,
-    _validate_buy_journal_requirements,
+    _order_session_factory,
 )
 from app.mcp_server.tooling.shared import logger
 from app.models.paper_trading import PaperAccount
+from app.models.trade_journal import JournalStatus, TradeJournal
 from app.services.paper_trading_service import PaperTradingService
 
 DEFAULT_PAPER_ACCOUNT_NAME = "default"
@@ -61,6 +65,52 @@ async def _resolve_paper_account(
     )
 
 
+async def _activate_paper_journal(
+    *,
+    symbol: str,
+    account_name: str,
+) -> None:
+    """Activate the most recent draft paper journal for a symbol.
+
+    Paper trades fill immediately, so draft→active happens right after creation.
+    Unlike live orders, paper journals do NOT set trade_id (no real trade exists).
+    hold_until is recalculated from now if min_hold_days is set.
+    """
+    try:
+        async with _order_session_factory()() as db:
+            stmt = (
+                select(TradeJournal)
+                .where(
+                    TradeJournal.symbol == symbol,
+                    TradeJournal.status == JournalStatus.draft,
+                    TradeJournal.account_type == "paper",
+                    TradeJournal.account == account_name,
+                )
+                .order_by(desc(TradeJournal.created_at))
+                .limit(1)
+            )
+            result = await db.execute(stmt)
+            journal = result.scalars().first()
+
+            if journal is None:
+                return
+
+            journal.status = JournalStatus.active
+            # trade_id stays None — no real trade to link
+            if journal.min_hold_days:
+                journal.hold_until = now_kst() + timedelta(days=journal.min_hold_days)
+
+            await db.commit()
+            logger.info(
+                "Activated paper journal id=%s for %s (account=%s)",
+                journal.id,
+                symbol,
+                account_name,
+            )
+    except Exception as exc:
+        logger.warning("Failed to activate paper journal: %s", exc)
+
+
 async def _place_paper_order(
     *,
     symbol: str,
@@ -81,16 +131,13 @@ async def _place_paper_order(
     indicators_snapshot: dict[str, Any] | None = None,
     paper_account_name: str | None = None,
 ) -> dict[str, Any]:
-    """Route a `place_order` call to the paper trading engine."""
-    try:
-        # 1. Validate journal requirements for buy orders
-        _validate_buy_journal_requirements(
-            side=side,
-            dry_run=dry_run,
-            thesis=thesis,
-            strategy=strategy,
-        )
+    """Route a `place_order` call to the paper trading engine.
 
+    Unlike live orders, thesis/strategy are optional for paper buys.
+    If provided, a trade journal is auto-created; if omitted, the order
+    executes without journal creation.
+    """
+    try:
         async with AsyncSessionLocal() as db:
             service = PaperTradingService(db)
             try:
@@ -139,14 +186,14 @@ async def _place_paper_order(
             journal_status: str | None = None
             journal_warning: str | None = None
 
-            # 3. Journal Integration (Buy)
-            if side == "buy":
+            # 3. Journal Integration (Buy) — only if thesis provided
+            if side == "buy" and thesis:
                 try:
                     journal_res = await _create_trade_journal_for_buy(
                         symbol=normalized_symbol,
                         market_type=market_type,
                         preview=p,
-                        thesis=thesis or "",
+                        thesis=thesis,
                         strategy=strategy or "",
                         target_price=target_price,
                         stop_loss=stop_loss,
@@ -159,12 +206,10 @@ async def _place_paper_order(
                     journal_id = journal_res["journal_id"]
                     journal_status = journal_res["journal_status"]
 
-                    # Paper trades fill immediately, link right away
-                    await _link_journal_to_fill(
+                    # Paper trades fill immediately — activate directly
+                    await _activate_paper_journal(
                         symbol=normalized_symbol,
-                        trade_id=0,  # placeholder for paper
-                        account_type="paper",
-                        account=account.name,
+                        account_name=account.name,
                     )
                     journal_status = "active"
                 except Exception as exc:

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -12,6 +12,9 @@ from app.mcp_server.tooling.orders_registration import register_order_tools
 from app.mcp_server.tooling.paper_account_registration import (
     register_paper_account_tools,
 )
+from app.mcp_server.tooling.paper_journal_registration import (
+    register_paper_journal_tools,
+)
 from app.mcp_server.tooling.portfolio_registration import register_portfolio_tools
 from app.mcp_server.tooling.trade_journal_registration import (
     register_trade_journal_tools,
@@ -42,6 +45,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_news_tools(mcp)
     register_trade_journal_tools(mcp)
     register_paper_account_tools(mcp)
+    register_paper_journal_tools(mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/app/mcp_server/tooling/trade_journal_registration.py
+++ b/app/mcp_server/tooling/trade_journal_registration.py
@@ -41,7 +41,8 @@ def register_trade_journal_tools(mcp: FastMCP) -> None:
             "Returns active journals by default. "
             "Each entry includes hold_remaining_days and hold_expired. "
             "account_type defaults to 'live'; set to 'paper' for paper journals, "
-            "or None to query both."
+            "or None to query both. "
+            "account (optional) filters to a specific account name."
         ),
     )(get_trade_journal)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/trade_journal_registration.py
+++ b/app/mcp_server/tooling/trade_journal_registration.py
@@ -28,7 +28,9 @@ def register_trade_journal_tools(mcp: FastMCP) -> None:
             "Save a trade journal entry with investment thesis and strategy metadata. "
             "Call this when recommending a buy/sell to record WHY. "
             "symbol auto-detects instrument_type. min_hold_days sets hold_until. "
-            "status defaults to 'draft' — set to 'active' after fill confirmation."
+            "status defaults to 'draft' — set to 'active' after fill confirmation. "
+            "account_type='paper' for paper trading journals (requires account name). "
+            "paper_trade_id links to the paper trade record."
         ),
     )(save_trade_journal)
     _ = mcp.tool(
@@ -37,7 +39,9 @@ def register_trade_journal_tools(mcp: FastMCP) -> None:
             "Query trade journals. MUST call before any sell recommendation to check "
             "thesis, hold period, target/stop prices. "
             "Returns active journals by default. "
-            "Each entry includes hold_remaining_days and hold_expired."
+            "Each entry includes hold_remaining_days and hold_expired. "
+            "account_type defaults to 'live'; set to 'paper' for paper journals, "
+            "or None to query both."
         ),
     )(get_trade_journal)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/trade_journal_tools.py
+++ b/app/mcp_server/tooling/trade_journal_tools.py
@@ -52,6 +52,8 @@ def _serialize_journal(j: TradeJournal) -> dict[str, Any]:
         "exit_reason": j.exit_reason,
         "pnl_pct": float(j.pnl_pct) if j.pnl_pct is not None else None,
         "account": j.account,
+        "account_type": j.account_type,
+        "paper_trade_id": j.paper_trade_id,
         "notes": j.notes,
         "created_at": j.created_at.isoformat() if j.created_at else None,
         "updated_at": j.updated_at.isoformat() if j.updated_at else None,
@@ -73,12 +75,16 @@ async def save_trade_journal(
     account: str | None = None,
     notes: str | None = None,
     status: str = "draft",
+    account_type: str = "live",
+    paper_trade_id: int | None = None,
 ) -> dict[str, Any]:
     """Save a trade journal entry with investment thesis and strategy metadata.
 
     symbol is auto-detected for instrument_type (KRW-BTC -> crypto, AAPL -> equity_us, 005930 -> equity_kr).
     min_hold_days auto-calculates hold_until from now.
     Warns if an active journal already exists for the same symbol.
+    account_type='paper' for paper trading journals (requires account name).
+    paper_trade_id links to the paper trade record.
     """
     symbol = (symbol or "").strip()
     thesis = (thesis or "").strip()
@@ -91,6 +97,20 @@ async def save_trade_journal(
         return {"success": False, "error": "side must be 'buy' or 'sell'"}
     if status not in {s.value for s in JournalStatus}:
         return {"success": False, "error": f"Invalid status: {status}"}
+
+    # account_type 검증
+    if account_type not in ("live", "paper"):
+        return {"success": False, "error": f"Invalid account_type: {account_type}"}
+    if account_type == "live" and paper_trade_id is not None:
+        return {
+            "success": False,
+            "error": "paper_trade_id cannot be set for live account_type",
+        }
+    if account_type == "paper" and not account:
+        return {
+            "success": False,
+            "error": "account is required for paper account_type",
+        }
 
     try:
         market_type, normalized_symbol = _resolve_market_type(symbol, None)
@@ -112,6 +132,7 @@ async def save_trade_journal(
                 .where(
                     TradeJournal.symbol == normalized_symbol,
                     TradeJournal.status == JournalStatus.active,
+                    TradeJournal.account_type == account_type,
                 )
                 .order_by(desc(TradeJournal.created_at))
                 .limit(1)
@@ -121,7 +142,8 @@ async def save_trade_journal(
             if existing:
                 warning = (
                     f"Active journal already exists for {normalized_symbol} "
-                    f"(id={existing.id}, thesis='{existing.thesis[:50]}...'). "
+                    f"(id={existing.id}, thesis='{existing.thesis[:50]}...', "
+                    f"account_type={account_type}). "
                     "Creating new journal anyway."
                 )
 
@@ -145,6 +167,8 @@ async def save_trade_journal(
                 indicators_snapshot=indicators_snapshot,
                 status=status,
                 account=account,
+                account_type=account_type,
+                paper_trade_id=paper_trade_id,
                 notes=notes,
             )
             db.add(journal)
@@ -173,11 +197,13 @@ async def get_trade_journal(
     days: int | None = None,
     include_closed: bool = False,
     limit: int = 50,
+    account_type: str | None = "live",
 ) -> dict[str, Any]:
     """Query trade journals. Call before any sell decision to check thesis and hold periods.
 
     Returns active journals by default. Set include_closed=True for closed/stopped.
     Each entry includes hold_remaining_days, hold_expired for hold period checks.
+    account_type defaults to 'live'; set to 'paper' for paper journals, or None to query both.
     """
     try:
         async with _session_factory()() as db:
@@ -204,6 +230,9 @@ async def get_trade_journal(
                         ]
                     )
                 )
+
+            if account_type is not None:
+                filters.append(TradeJournal.account_type == account_type)
 
             if market:
                 market_map = {

--- a/app/mcp_server/tooling/trade_journal_tools.py
+++ b/app/mcp_server/tooling/trade_journal_tools.py
@@ -198,12 +198,14 @@ async def get_trade_journal(
     include_closed: bool = False,
     limit: int = 50,
     account_type: str | None = "live",
+    account: str | None = None,
 ) -> dict[str, Any]:
     """Query trade journals. Call before any sell decision to check thesis and hold periods.
 
     Returns active journals by default. Set include_closed=True for closed/stopped.
     Each entry includes hold_remaining_days, hold_expired for hold period checks.
     account_type defaults to 'live'; set to 'paper' for paper journals, or None to query both.
+    account (optional) filters to a specific account name.
     """
     try:
         async with _session_factory()() as db:
@@ -233,6 +235,9 @@ async def get_trade_journal(
 
             if account_type is not None:
                 filters.append(TradeJournal.account_type == account_type)
+
+            if account is not None:
+                filters.append(TradeJournal.account == account)
 
             if market:
                 market_map = {

--- a/app/models/paper_trading.py
+++ b/app/models/paper_trading.py
@@ -106,9 +106,7 @@ class PaperTrade(Base):
         CheckConstraint(
             "order_type IN ('limit','market')", name="paper_trades_order_type"
         ),
-        CheckConstraint(
-            "currency IN ('KRW','USD')", name="paper_trades_currency"
-        ),
+        CheckConstraint("currency IN ('KRW','USD')", name="paper_trades_currency"),
         Index("ix_paper_trades_account_symbol", "account_id", "symbol"),
         Index("ix_paper_trades_account_executed_at", "account_id", "executed_at"),
         {"schema": "paper"},

--- a/app/models/trade_journal.py
+++ b/app/models/trade_journal.py
@@ -46,8 +46,17 @@ class TradeJournal(Base):
             "side IN ('buy','sell')",
             name="trade_journals_side",
         ),
+        CheckConstraint(
+            "account_type IN ('live','paper')",
+            name="trade_journals_account_type",
+        ),
+        CheckConstraint(
+            "NOT (account_type = 'live' AND paper_trade_id IS NOT NULL)",
+            name="trade_journals_no_paper_trade_on_live",
+        ),
         Index("ix_trade_journals_symbol_status", "symbol", "status"),
         Index("ix_trade_journals_created", "created_at"),
+        Index("ix_trade_journals_account_type", "account_type"),
         {"schema": "review"},
     )
 
@@ -93,6 +102,10 @@ class TradeJournal(Base):
 
     # Meta
     account: Mapped[str | None] = mapped_column(Text)
+    account_type: Mapped[str] = mapped_column(
+        Text, nullable=False, default="live", server_default="live"
+    )
+    paper_trade_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
     notes: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True),
@@ -109,4 +122,5 @@ class TradeJournal(Base):
     def __init__(self, **kwargs: Any) -> None:
         kwargs.setdefault("side", "buy")
         kwargs.setdefault("status", "draft")
+        kwargs.setdefault("account_type", "live")
         super().__init__(**kwargs)

--- a/app/services/paper_trading_service.py
+++ b/app/services/paper_trading_service.py
@@ -11,11 +11,6 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.timezone import now_kst
-from app.mcp_server.tooling.market_data_quotes import (
-    _fetch_quote_equity_kr,
-    _fetch_quote_equity_us,
-)
-from app.mcp_server.tooling.shared import resolve_market_type
 from app.models.paper_trading import PaperAccount, PaperPosition, PaperTrade
 from app.models.trading import InstrumentType
 from app.services.brokers.upbit.client import fetch_multiple_current_prices
@@ -32,60 +27,52 @@ FEE_RATES: dict[str, dict[str, float]] = {
     "crypto": {"buy": 0.0005, "sell": 0.0005},
 }
 
-# Quantize targets matching Numeric(20, 4) for money fields
-_MONEY_Q = Decimal("0.0001")
-# Numeric(20, 8) for crypto quantity; equity quantities are whole shares
-_CRYPTO_QTY_Q = Decimal("0.00000001")
 
-
-def _q_money(value: Decimal) -> Decimal:
-    return value.quantize(_MONEY_Q, rounding=ROUND_HALF_UP)
-
-
-def _q_crypto_qty(value: Decimal) -> Decimal:
-    return value.quantize(_CRYPTO_QTY_Q, rounding=ROUND_HALF_UP)
-
-
-def calculate_fee(
-    instrument_type: str,
-    side: str,
-    gross_amount: Decimal,
-) -> Decimal:
-    """Calculate commission + tax for a simulated fill.
-
-    Parameters
-    ----------
-    instrument_type : "equity_kr" | "equity_us" | "crypto"
-    side : "buy" | "sell"
-    gross_amount : quantity * price (in the instrument's currency)
-    """
+def calculate_fee(instrument_type: str, side: str, amount: Decimal) -> Decimal:
+    """Calculate paper trading fee based on instrument type and amount."""
     rates = FEE_RATES.get(instrument_type)
-    if rates is None:
+    if not rates:
         raise ValueError(f"Unsupported instrument_type: {instrument_type}")
 
-    gross = Decimal(gross_amount)
-
     if instrument_type == "equity_kr":
-        commission = gross * Decimal(str(rates["buy" if side == "buy" else "sell"]))
+        fee_rate = rates["buy"] if side == "buy" else rates["sell"]
+        fee = amount * Decimal(str(fee_rate))
         if side == "sell":
-            commission += gross * Decimal(str(rates["tax_sell"]))
-        return _q_money(commission)
+            fee += amount * Decimal(str(rates["tax_sell"]))
+        return _q_money(fee)
 
     if instrument_type == "equity_us":
-        commission = gross * Decimal(str(rates["buy" if side == "buy" else "sell"]))
+        fee = amount * Decimal(str(rates["buy"]))
         min_fee = Decimal(str(rates["min_fee_usd"]))
-        return _q_money(max(commission, min_fee))
+        return _q_money(max(fee, min_fee))
 
-    # crypto
-    commission = gross * Decimal(str(rates["buy" if side == "buy" else "sell"]))
-    return _q_money(commission)
+    if instrument_type == "crypto":
+        fee_rate = rates["buy"] if side == "buy" else rates["sell"]
+        return _q_money(amount * Decimal(str(fee_rate)))
+
+    raise ValueError(f"Unsupported instrument_type: {instrument_type}")
 
 
 # ---------------------------------------------------------------------------
-# Service
+# Formatting helpers
+# ---------------------------------------------------------------------------
+def _q_money(val: Decimal | float) -> Decimal:
+    return Decimal(str(val)).quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
+
+
+def _q_crypto_qty(val: Decimal | float) -> Decimal:
+    return Decimal(str(val)).quantize(Decimal("0.00000001"), rounding=ROUND_HALF_UP)
+
+
+def _q_pct(val: Decimal | float) -> Decimal:
+    return Decimal(str(val)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+# ---------------------------------------------------------------------------
+# Paper Trading Service
 # ---------------------------------------------------------------------------
 class PaperTradingService:
-    """모의투자 계좌/주문/포지션 관리 서비스."""
+    """Manage paper trading accounts, orders, and positions."""
 
     def __init__(self, db: AsyncSession) -> None:
         self.db = db
@@ -95,19 +82,17 @@ class PaperTradingService:
     # ------------------------------------------------------------------ #
     async def create_account(
         self,
-        *,
         name: str,
-        initial_capital_krw: Decimal,
+        initial_capital_krw: Decimal = Decimal("100000000"),
         initial_capital_usd: Decimal = Decimal("0"),
         description: str | None = None,
         strategy_name: str | None = None,
     ) -> PaperAccount:
-        initial_total = Decimal(initial_capital_krw) + Decimal(initial_capital_usd)
         account = PaperAccount(
             name=name,
-            initial_capital=initial_total,
-            cash_krw=Decimal(initial_capital_krw),
-            cash_usd=Decimal(initial_capital_usd),
+            initial_capital=initial_capital_krw,
+            cash_krw=initial_capital_krw,
+            cash_usd=initial_capital_usd,
             description=description,
             strategy_name=strategy_name,
             is_active=True,
@@ -129,10 +114,16 @@ class PaperTradingService:
         )
         return result.scalar_one_or_none()
 
-    async def list_accounts(self, is_active: bool | None = True) -> list[PaperAccount]:
+    async def list_accounts(
+        self,
+        is_active: bool | None = True,
+        strategy_name: str | None = None,
+    ) -> list[PaperAccount]:
         stmt = select(PaperAccount)
         if is_active is not None:
             stmt = stmt.where(PaperAccount.is_active == is_active)
+        if strategy_name is not None:
+            stmt = stmt.where(PaperAccount.strategy_name == strategy_name)
         stmt = stmt.order_by(PaperAccount.created_at.desc())
         result = await self.db.execute(stmt)
         return list(result.scalars().all())
@@ -148,13 +139,9 @@ class PaperTradingService:
         await self.db.execute(
             sa_delete(PaperPosition).where(PaperPosition.account_id == account_id)
         )
-
-        # Restore cash balances. The model only stores a combined
-        # ``initial_capital``, so reset puts everything back into KRW and zeroes
-        # USD.
+        # Reset cash to initial.
         account.cash_krw = account.initial_capital
         account.cash_usd = Decimal("0")
-
         await self.db.commit()
         await self.db.refresh(account)
         return account
@@ -172,9 +159,17 @@ class PaperTradingService:
     # ------------------------------------------------------------------ #
     async def _fetch_current_price(self, symbol: str, instrument_type: str) -> Decimal:
         if instrument_type == "equity_kr":
+            from app.mcp_server.tooling.market_data_quotes import (
+                _fetch_quote_equity_kr,
+            )
+
             quote = await _fetch_quote_equity_kr(symbol)
             price = quote.get("price")
         elif instrument_type == "equity_us":
+            from app.mcp_server.tooling.market_data_quotes import (
+                _fetch_quote_equity_us,
+            )
+
             quote = await _fetch_quote_equity_us(symbol)
             price = quote.get("price")
         elif instrument_type == "crypto":
@@ -186,11 +181,11 @@ class PaperTradingService:
             raise ValueError(f"Unsupported instrument_type: {instrument_type}")
 
         if price is None:
-            raise ValueError(f"Failed to fetch price for {symbol}")
+            raise ValueError(f"Could not fetch current price for {symbol}")
         return Decimal(str(price))
 
     # ------------------------------------------------------------------ #
-    # Order preview (shared with execute_order)
+    # Preview order
     # ------------------------------------------------------------------ #
     async def preview_order(
         self,
@@ -210,36 +205,39 @@ class PaperTradingService:
         if order_type not in ("limit", "market"):
             raise ValueError("order_type must be 'limit' or 'market'")
 
+        from app.mcp_server.tooling.shared import resolve_market_type
+
         account = await self.get_account(account_id)
         if account is None:
             raise ValueError(f"Account {account_id} not found")
         if not account.is_active:
             raise ValueError(f"Account {account_id} is inactive")
 
+        # Resolve market type and normalized symbol
         instrument_type, resolved_symbol = resolve_market_type(symbol, None)
-        currency = "USD" if instrument_type == "equity_us" else "KRW"
 
-        # Resolve fill price
-        if order_type == "market":
-            fill_price = await self._fetch_current_price(
-                resolved_symbol, instrument_type
-            )
-        else:
+        # Currency detection
+        currency = "KRW"
+        if instrument_type == "equity_us":
+            currency = "USD"
+        elif instrument_type == "crypto" and resolved_symbol.startswith("USDT-"):
+            currency = "USDT"
+
+        # Determine price
+        if order_type == "limit":
             if price is None:
                 raise ValueError("price is required for limit orders")
             fill_price = Decimal(str(price))
+        else:
+            fill_price = await self._fetch_current_price(resolved_symbol, instrument_type)
 
-        if fill_price <= 0:
-            raise ValueError(f"Invalid fill price: {fill_price}")
-
-        # Resolve quantity
-        if quantity is None and amount is None:
-            raise ValueError("quantity or amount must be provided")
-
+        # Determine quantity
         if quantity is not None:
             qty = Decimal(str(quantity))
-        else:
+        elif amount is not None:
             qty = Decimal(str(amount)) / fill_price
+        else:
+            raise ValueError("Either quantity or amount must be provided")
 
         if instrument_type == "crypto":
             qty = _q_crypto_qty(qty)
@@ -299,6 +297,7 @@ class PaperTradingService:
         amount: Decimal | float | int | None = None,
         reason: str = "",
     ) -> dict[str, Any]:
+        # 1. Preview order to get finalized quantity/price/costs
         preview = await self.preview_order(
             account_id=account_id,
             symbol=symbol,
@@ -340,9 +339,18 @@ class PaperTradingService:
                     )
                 account.cash_krw = _q_money(account.cash_krw - total_cost)
 
-            # Upsert position with weighted-average cost (fee excluded from avg)
+            # Update/Create position
             position = await self._get_position(account_id, resolved_symbol)
-            if position is None:
+            if position:
+                # Weighted average calculation
+                old_total = position.total_invested
+                new_total = old_total + gross
+                new_qty = position.quantity + qty
+                position.avg_price = _q_money(new_total / new_qty)
+                position.quantity = new_qty
+                position.total_invested = new_total
+                position.updated_at = now_kst()
+            else:
                 position = PaperPosition(
                     account_id=account_id,
                     symbol=resolved_symbol,
@@ -352,143 +360,113 @@ class PaperTradingService:
                     total_invested=gross,
                 )
                 self.db.add(position)
-            else:
-                new_qty = position.quantity + qty
-                new_invested = position.total_invested + gross
-                position.avg_price = (
-                    (new_invested / new_qty) if new_qty > 0 else Decimal("0")
-                )
-                position.quantity = new_qty
-                position.total_invested = _q_money(new_invested)
+
         else:  # sell
             position = await self._get_position(account_id, resolved_symbol)
-            if position is None:
-                raise ValueError(
-                    f"No position to sell for account {account_id} symbol {resolved_symbol}"
-                )
+            if not position:
+                raise ValueError(f"No position to sell for {resolved_symbol}")
             if position.quantity < qty:
                 raise ValueError(
-                    f"Insufficient quantity: have {position.quantity}, sell {qty}"
+                    f"Insufficient quantity to sell: have {position.quantity}, "
+                    f"need {qty}"
                 )
 
-            avg_price = position.avg_price
-            proceeds_net = total_cost  # gross - fee (from preview)
-            realized_pnl = _q_money(((fill_price - avg_price) * qty) - fee)
-
-            # Credit cash
+            # Proceeds credit
             if currency == "USD":
-                account.cash_usd = _q_money(account.cash_usd + proceeds_net)
+                account.cash_usd = _q_money(account.cash_usd + total_cost)
             else:
-                account.cash_krw = _q_money(account.cash_krw + proceeds_net)
+                account.cash_krw = _q_money(account.cash_krw + total_cost)
 
-            # Update or delete position
-            new_qty = position.quantity - qty
-            if new_qty == 0:
+            # Realized PnL calculation
+            # PnL = (sell_price - avg_buy_price) * quantity - fee
+            cost_basis = position.avg_price * qty
+            realized_pnl = _q_money(gross - cost_basis - fee)
+
+            # Update/Delete position
+            if position.quantity == qty:
                 await self.db.delete(position)
             else:
-                # Keep avg_price fixed on sell; reduce total_invested proportionally
-                position.quantity = new_qty
-                position.total_invested = _q_money(avg_price * new_qty)
+                position.quantity -= qty
+                position.total_invested = _q_money(
+                    position.total_invested - cost_basis
+                )
+                position.updated_at = now_kst()
 
+        # 3. Create Trade record
         trade = PaperTrade(
             account_id=account_id,
             symbol=resolved_symbol,
             instrument_type=InstrumentType(instrument_type),
-            side=side.lower(),
-            order_type=order_type.lower(),
+            side=side,
+            order_type=order_type,
             quantity=qty,
             price=fill_price,
             total_amount=gross,
             fee=fee,
             currency=currency,
-            reason=reason or None,
+            reason=reason,
             realized_pnl=realized_pnl,
-            executed_at=now_kst(),
         )
         self.db.add(trade)
 
         await self.db.commit()
 
-        return {
+        # 4. Prepare result
+        res = {
             "success": True,
             "dry_run": False,
             "account_id": account_id,
-            "preview": preview["preview"],
+            "preview": p,
             "execution": {
-                "symbol": resolved_symbol,
-                "instrument_type": instrument_type,
-                "side": side.lower(),
-                "order_type": order_type.lower(),
-                "quantity": qty,
-                "price": fill_price,
-                "gross": gross,
-                "fee": fee,
-                "total_cost": total_cost,
-                "currency": currency,
+                **p,
                 "realized_pnl": realized_pnl,
-                "executed_at": trade.executed_at,
+                "executed_at": now_kst(),
             },
         }
+        return res
 
     # ------------------------------------------------------------------ #
-    # Queries
+    # Query tools
     # ------------------------------------------------------------------ #
-    async def get_positions(
-        self,
-        account_id: int,
-        market: str | None = None,
-    ) -> list[dict[str, Any]]:
+    async def get_positions(self, account_id: int) -> list[dict[str, Any]]:
         stmt = select(PaperPosition).where(PaperPosition.account_id == account_id)
-        if market is not None:
-            stmt = stmt.where(PaperPosition.instrument_type == InstrumentType(market))
-        stmt = stmt.order_by(PaperPosition.symbol)
         result = await self.db.execute(stmt)
-        rows = list(result.scalars().all())
+        positions = result.scalars().all()
 
-        output: list[dict[str, Any]] = []
-        for pos in rows:
-            item: dict[str, Any] = {
-                "symbol": pos.symbol,
-                "instrument_type": pos.instrument_type.value,
-                "quantity": pos.quantity,
-                "avg_price": pos.avg_price,
-                "total_invested": pos.total_invested,
+        out = []
+        for p in positions:
+            item = {
+                "symbol": p.symbol,
+                "instrument_type": p.instrument_type.value,
+                "quantity": p.quantity,
+                "avg_price": p.avg_price,
+                "total_invested": p.total_invested,
                 "current_price": None,
                 "evaluation_amount": None,
                 "unrealized_pnl": None,
                 "pnl_pct": None,
             }
             try:
-                current_price = await self._fetch_current_price(
-                    pos.symbol, pos.instrument_type.value
+                cur_price = await self._fetch_current_price(
+                    p.symbol, p.instrument_type.value
                 )
-                item["current_price"] = current_price
-                evaluation = _q_money(current_price * pos.quantity)
-                item["evaluation_amount"] = evaluation
-                pnl = _q_money(evaluation - pos.total_invested)
-                item["unrealized_pnl"] = pnl
-                if pos.avg_price > 0:
-                    pnl_pct = (
-                        (current_price - pos.avg_price) / pos.avg_price * Decimal("100")
-                    )
-                    item["pnl_pct"] = pnl_pct.quantize(
-                        Decimal("0.01"), rounding=ROUND_HALF_UP
-                    )
+                eval_amt = _q_money(cur_price * p.quantity)
+                pnl = _q_money(eval_amt - p.total_invested)
+                pnl_pct = _q_pct((eval_amt / p.total_invested - 1) * 100)
+
+                item.update(
+                    {
+                        "current_price": cur_price,
+                        "evaluation_amount": eval_amt,
+                        "unrealized_pnl": pnl,
+                        "pnl_pct": pnl_pct,
+                    }
+                )
             except Exception as exc:
                 item["price_error"] = str(exc)
-            output.append(item)
-        return output
 
-    async def get_position(self, account_id: int, symbol: str) -> dict[str, Any] | None:
-        resolved_symbol = resolve_market_type(symbol, None)[1]
-        pos = await self._get_position(account_id, resolved_symbol)
-        if pos is None:
-            return None
-        positions = await self.get_positions(account_id=account_id)
-        for item in positions:
-            if item["symbol"] == resolved_symbol:
-                return item
-        return None
+            out.append(item)
+        return out
 
     async def get_cash_balance(self, account_id: int) -> dict[str, Decimal]:
         account = await self.get_account(account_id)
@@ -505,17 +483,18 @@ class PaperTradingService:
         limit: int = 50,
     ) -> list[dict[str, Any]]:
         stmt = select(PaperTrade).where(PaperTrade.account_id == account_id)
-        if symbol is not None:
+        if symbol:
             stmt = stmt.where(PaperTrade.symbol == symbol)
-        if side is not None:
-            stmt = stmt.where(PaperTrade.side == side.lower())
-        if days is not None:
+        if side:
+            stmt = stmt.where(PaperTrade.side == side)
+        if days:
             cutoff = now_kst() - timedelta(days=days)
             stmt = stmt.where(PaperTrade.executed_at >= cutoff)
-        stmt = stmt.order_by(PaperTrade.executed_at.desc()).limit(limit)
 
+        stmt = stmt.order_by(PaperTrade.executed_at.desc()).limit(limit)
         result = await self.db.execute(stmt)
-        rows = list(result.scalars().all())
+        trades = result.scalars().all()
+
         return [
             {
                 "id": t.id,
@@ -528,51 +507,42 @@ class PaperTradingService:
                 "total_amount": t.total_amount,
                 "fee": t.fee,
                 "currency": t.currency,
-                "reason": t.reason,
                 "realized_pnl": t.realized_pnl,
+                "reason": t.reason,
                 "executed_at": t.executed_at,
             }
-            for t in rows
+            for t in trades
         ]
 
     async def get_portfolio_summary(self, account_id: int) -> dict[str, Any]:
+        """Summarize entire portfolio performance."""
         account = await self.get_account(account_id)
         if account is None:
             raise ValueError(f"Account {account_id} not found")
 
-        positions = await self.get_positions(account_id=account_id)
+        positions = await self.get_positions(account_id)
 
         total_invested = Decimal("0")
         total_evaluated = Decimal("0")
         total_pnl = Decimal("0")
-        for p in positions:
-            total_invested += Decimal(str(p.get("total_invested") or "0"))
-            eval_amt = p.get("evaluation_amount")
-            pnl = p.get("unrealized_pnl")
-            if eval_amt is not None:
-                total_evaluated += Decimal(str(eval_amt))
-            if pnl is not None:
-                total_pnl += Decimal(str(pnl))
 
-        total_pnl_pct: Decimal | None = None
+        for p in positions:
+            if p["evaluation_amount"] is not None:
+                total_invested += p["total_invested"]
+                total_evaluated += p["evaluation_amount"]
+                total_pnl += p["unrealized_pnl"]
+
+        total_pnl_pct = None
         if total_invested > 0:
-            total_pnl_pct = (total_pnl / total_invested * Decimal("100")).quantize(
-                Decimal("0.01"), rounding=ROUND_HALF_UP
-            )
+            total_pnl_pct = _q_pct((total_evaluated / total_invested - 1) * 100)
 
         return {
+            "account_name": account.name,
+            "cash_krw": account.cash_krw,
+            "cash_usd": account.cash_usd,
             "total_invested": total_invested,
             "total_evaluated": total_evaluated,
             "total_pnl": total_pnl,
             "total_pnl_pct": total_pnl_pct,
-            "cash_krw": account.cash_krw,
-            "cash_usd": account.cash_usd,
             "positions_count": len(positions),
         }
-
-
-__all__ = [
-    "FEE_RATES",
-    "calculate_fee",
-    "PaperTradingService",
-]

--- a/app/services/paper_trading_service.py
+++ b/app/services/paper_trading_service.py
@@ -229,7 +229,9 @@ class PaperTradingService:
                 raise ValueError("price is required for limit orders")
             fill_price = Decimal(str(price))
         else:
-            fill_price = await self._fetch_current_price(resolved_symbol, instrument_type)
+            fill_price = await self._fetch_current_price(
+                resolved_symbol, instrument_type
+            )
 
         # Determine quantity
         if quantity is not None:
@@ -387,9 +389,7 @@ class PaperTradingService:
                 await self.db.delete(position)
             else:
                 position.quantity -= qty
-                position.total_invested = _q_money(
-                    position.total_invested - cost_basis
-                )
+                position.total_invested = _q_money(position.total_invested - cost_basis)
                 position.updated_at = now_kst()
 
         # 3. Create Trade record

--- a/docs/superpowers/plans/2026-04-13-paper-strategy-journal-integration.md
+++ b/docs/superpowers/plans/2026-04-13-paper-strategy-journal-integration.md
@@ -1,0 +1,2524 @@
+# Paper Trading 다중 전략 + Trade Journal 연동 구현 플랜
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Paper 매매 시 투자 논거(thesis)를 Trade Journal에 자동 기록하고, 전략 간 성과 비교 및 실전 전환 추천 도구를 제공한다.
+
+**Architecture:** 기존 `review.trade_journals` 테이블에 `account_type`/`paper_trade_id` 컬럼을 추가하여 paper journal을 통합 저장한다. 새 `paper_journal_bridge.py` 모듈이 paper 주문↔journal 연동, 전략 비교, 실전 전환 추천을 담당한다. 기존 MCP 도구 이름은 유지하고 파라미터만 확장한다.
+
+**Tech Stack:** Python 3.13, SQLAlchemy (async), Alembic, FastMCP, pytest + pytest-asyncio
+
+**Spec:** `docs/superpowers/specs/2026-04-13-paper-strategy-journal-integration-design.md`
+
+---
+
+## 파일 구조
+
+| 파일 | 유형 | 책임 |
+|------|------|------|
+| `app/models/trade_journal.py` | 수정 | `account_type`, `paper_trade_id` 컬럼, constraints |
+| `alembic/versions/xxxx_add_paper_journal_fields.py` | 신규 | 마이그레이션 |
+| `app/mcp_server/tooling/paper_journal_bridge.py` | 신규 | create/close/compare/recommend 4개 함수 |
+| `app/mcp_server/tooling/paper_journal_registration.py` | 신규 | compare_strategies, recommend_go_live MCP 등록 |
+| `app/mcp_server/tooling/paper_account_registration.py` | 수정 | strategy_name 파라미터 노출 |
+| `app/services/paper_trading_service.py` | 수정 | list_accounts에 strategy_name 필터 |
+| `app/mcp_server/tooling/paper_order_handler.py` | 수정 | thesis/strategy 파라미터 + bridge 호출 |
+| `app/mcp_server/tooling/orders_registration.py` | 수정 | paper 경로에 journal 파라미터 전달 |
+| `app/mcp_server/tooling/trade_journal_tools.py` | 수정 | account_type, paper_trade_id 지원 |
+| `app/mcp_server/tooling/trade_journal_registration.py` | 수정 | MCP description 업데이트 |
+| `app/mcp_server/tooling/registry.py` | 수정 | paper_journal 등록 추가 |
+| `tests/test_paper_journal_bridge.py` | 신규 | bridge 단위 테스트 |
+| `tests/test_paper_strategy_mcp.py` | 신규 | MCP 도구 변경 테스트 |
+
+---
+
+## Task 1: TradeJournal 모델에 account_type, paper_trade_id 추가
+
+**Files:**
+- Modify: `app/models/trade_journal.py`
+- Test: `tests/test_trade_journal_model.py`
+
+- [ ] **Step 1: 기존 모델 테스트 읽기**
+
+Run: `uv run pytest tests/test_trade_journal_model.py -v`
+Expected: 기존 테스트 모두 PASS (baseline)
+
+- [ ] **Step 2: account_type/paper_trade_id 모델 테스트 작성**
+
+`tests/test_trade_journal_model.py`에 추가:
+
+```python
+class TestAccountTypeField:
+    """account_type 및 paper_trade_id 필드 테스트."""
+
+    def test_default_account_type_is_live(self):
+        journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Test thesis",
+        )
+        assert journal.account_type == "live"
+
+    def test_paper_account_type(self):
+        journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Test thesis",
+            account_type="paper",
+            paper_trade_id=42,
+            account="paper-momentum",
+        )
+        assert journal.account_type == "paper"
+        assert journal.paper_trade_id == 42
+
+    def test_live_journal_paper_trade_id_is_none(self):
+        journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Test thesis",
+        )
+        assert journal.paper_trade_id is None
+```
+
+- [ ] **Step 3: 테스트 실패 확인**
+
+Run: `uv run pytest tests/test_trade_journal_model.py::TestAccountTypeField -v`
+Expected: FAIL — `account_type` attribute 없음
+
+- [ ] **Step 4: TradeJournal 모델에 컬럼 추가**
+
+`app/models/trade_journal.py` 수정 — `__table_args__`에 constraints 추가, 클래스 body에 컬럼 추가:
+
+```python
+# __table_args__에 추가:
+CheckConstraint(
+    "account_type IN ('live','paper')",
+    name="trade_journals_account_type",
+),
+CheckConstraint(
+    "NOT (account_type = 'live' AND paper_trade_id IS NOT NULL)",
+    name="trade_journals_no_paper_trade_on_live",
+),
+Index("ix_trade_journals_account_type", "account_type"),
+
+# 클래스 body에 추가 (account 필드 아래):
+account_type: Mapped[str] = mapped_column(
+    Text, nullable=False, default="live", server_default="live"
+)
+paper_trade_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+```
+
+`__init__`에 기본값 추가:
+
+```python
+def __init__(self, **kwargs: Any) -> None:
+    kwargs.setdefault("side", "buy")
+    kwargs.setdefault("status", "draft")
+    kwargs.setdefault("account_type", "live")
+    super().__init__(**kwargs)
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_trade_journal_model.py -v`
+Expected: 기존 테스트 + 새 테스트 모두 PASS
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app/models/trade_journal.py tests/test_trade_journal_model.py
+git commit -m "feat(journal): add account_type and paper_trade_id columns to TradeJournal model"
+```
+
+---
+
+## Task 2: Alembic 마이그레이션 생성 및 적용
+
+**Files:**
+- Create: `alembic/versions/xxxx_add_paper_journal_fields.py`
+
+- [ ] **Step 1: 마이그레이션 자동 생성**
+
+Run: `uv run alembic revision --autogenerate -m "add account_type and paper_trade_id to trade_journals"`
+
+- [ ] **Step 2: 생성된 마이그레이션 파일 검토**
+
+생성된 파일에 아래 내용이 포함되어야 함:
+
+```python
+def upgrade() -> None:
+    op.add_column(
+        "trade_journals",
+        sa.Column(
+            "account_type",
+            sa.Text(),
+            nullable=False,
+            server_default="live",
+        ),
+        schema="review",
+    )
+    op.add_column(
+        "trade_journals",
+        sa.Column("paper_trade_id", sa.BigInteger(), nullable=True),
+        schema="review",
+    )
+    op.create_check_constraint(
+        "trade_journals_account_type",
+        "trade_journals",
+        "account_type IN ('live','paper')",
+        schema="review",
+    )
+    op.create_check_constraint(
+        "trade_journals_no_paper_trade_on_live",
+        "trade_journals",
+        "NOT (account_type = 'live' AND paper_trade_id IS NOT NULL)",
+        schema="review",
+    )
+    op.create_index(
+        "ix_trade_journals_account_type",
+        "trade_journals",
+        ["account_type"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_trade_journals_account_type",
+        table_name="trade_journals",
+        schema="review",
+    )
+    op.drop_constraint(
+        "trade_journals_no_paper_trade_on_live",
+        "trade_journals",
+        schema="review",
+    )
+    op.drop_constraint(
+        "trade_journals_account_type",
+        "trade_journals",
+        schema="review",
+    )
+    op.drop_column("trade_journals", "paper_trade_id", schema="review")
+    op.drop_column("trade_journals", "account_type", schema="review")
+```
+
+autogenerate가 constraint/index를 누락하면 수동으로 추가한다.
+
+- [ ] **Step 3: 마이그레이션 적용 (로컬)**
+
+Run: `uv run alembic upgrade head`
+Expected: 성공, 새 revision이 current로 표시
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add alembic/versions/
+git commit -m "migration: add account_type and paper_trade_id to trade_journals"
+```
+
+---
+
+## Task 3: _serialize_journal 및 trade_journal_tools에 account_type 지원 추가
+
+**Files:**
+- Modify: `app/mcp_server/tooling/trade_journal_tools.py`
+- Test: `tests/test_mcp_trade_journal.py`
+
+- [ ] **Step 1: serialize 테스트 작성**
+
+`tests/test_mcp_trade_journal.py`에 추가:
+
+```python
+class TestSerializeJournalNewFields:
+    """account_type, paper_trade_id 직렬화 테스트."""
+
+    def test_serialize_live_journal(self):
+        journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Test",
+            account_type="live",
+        )
+        journal.id = 1
+        journal.created_at = now_kst()
+        journal.updated_at = now_kst()
+        result = _serialize_journal(journal)
+        assert result["account_type"] == "live"
+        assert result["paper_trade_id"] is None
+
+    def test_serialize_paper_journal(self):
+        journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Test",
+            account_type="paper",
+            paper_trade_id=42,
+            account="paper-momentum",
+        )
+        journal.id = 2
+        journal.created_at = now_kst()
+        journal.updated_at = now_kst()
+        result = _serialize_journal(journal)
+        assert result["account_type"] == "paper"
+        assert result["paper_trade_id"] == 42
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `uv run pytest tests/test_mcp_trade_journal.py::TestSerializeJournalNewFields -v`
+Expected: FAIL — `account_type` key 없음
+
+- [ ] **Step 3: _serialize_journal에 새 필드 추가**
+
+`app/mcp_server/tooling/trade_journal_tools.py`의 `_serialize_journal()` 함수에 추가:
+
+```python
+"account_type": j.account_type,
+"paper_trade_id": j.paper_trade_id,
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_mcp_trade_journal.py::TestSerializeJournalNewFields -v`
+Expected: PASS
+
+- [ ] **Step 5: save_trade_journal 검증 테스트 작성**
+
+`tests/test_mcp_trade_journal.py`에 추가:
+
+```python
+class TestSaveTradeJournalAccountType:
+    """save_trade_journal account_type 검증 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_save_with_default_account_type(self, monkeypatch):
+        """기본 account_type은 'live'."""
+        saved_journal = None
+
+        async def _capture_add(session):
+            nonlocal saved_journal
+            original_add = session.add
+
+            def capturing_add(obj):
+                nonlocal saved_journal
+                if isinstance(obj, TradeJournal):
+                    saved_journal = obj
+                return original_add(obj)
+
+            session.add = capturing_add
+            return session
+
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.refresh = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.first.return_value = None
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.trade_journal_tools._session_factory",
+            lambda: factory,
+        )
+
+        result = await save_trade_journal(
+            symbol="005930",
+            thesis="Test thesis",
+        )
+        assert result["success"] is True
+        added_obj = mock_session.add.call_args[0][0]
+        assert added_obj.account_type == "live"
+
+    @pytest.mark.asyncio
+    async def test_save_live_with_paper_trade_id_errors(self, monkeypatch):
+        """account_type='live' + paper_trade_id 지정 시 오류."""
+        result = await save_trade_journal(
+            symbol="005930",
+            thesis="Test thesis",
+            account_type="live",
+            paper_trade_id=42,
+        )
+        assert result["success"] is False
+        assert "paper_trade_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_save_paper_without_account_errors(self, monkeypatch):
+        """account_type='paper' + account 비어있으면 오류."""
+        result = await save_trade_journal(
+            symbol="005930",
+            thesis="Test thesis",
+            account_type="paper",
+        )
+        assert result["success"] is False
+        assert "account" in result["error"]
+```
+
+- [ ] **Step 6: 테스트 실패 확인**
+
+Run: `uv run pytest tests/test_mcp_trade_journal.py::TestSaveTradeJournalAccountType -v`
+Expected: FAIL
+
+- [ ] **Step 7: save_trade_journal에 account_type/paper_trade_id 파라미터 및 검증 추가**
+
+`app/mcp_server/tooling/trade_journal_tools.py`의 `save_trade_journal()` 시그니처에 추가:
+
+```python
+async def save_trade_journal(
+    symbol: str,
+    thesis: str,
+    side: str = "buy",
+    entry_price: float | None = None,
+    quantity: float | None = None,
+    amount: float | None = None,
+    strategy: str | None = None,
+    target_price: float | None = None,
+    stop_loss: float | None = None,
+    min_hold_days: int | None = None,
+    indicators_snapshot: dict | None = None,
+    account: str | None = None,
+    notes: str | None = None,
+    status: str = "draft",
+    account_type: str = "live",           # 추가
+    paper_trade_id: int | None = None,    # 추가
+) -> dict[str, Any]:
+```
+
+함수 body 시작 부분에 검증 추가:
+
+```python
+# account_type 검증
+if account_type not in ("live", "paper"):
+    return {"success": False, "error": f"Invalid account_type: {account_type}"}
+if account_type == "live" and paper_trade_id is not None:
+    return {
+        "success": False,
+        "error": "paper_trade_id cannot be set for live account_type",
+    }
+if account_type == "paper" and not account:
+    return {
+        "success": False,
+        "error": "account is required for paper account_type",
+    }
+```
+
+TradeJournal 생성 시 새 필드 전달:
+
+```python
+journal = TradeJournal(
+    # ... 기존 필드 ...
+    account=account,
+    account_type=account_type,
+    paper_trade_id=paper_trade_id,
+    notes=notes,
+)
+```
+
+- [ ] **Step 8: get_trade_journal 테스트 작성**
+
+`tests/test_mcp_trade_journal.py`에 추가:
+
+```python
+class TestGetTradeJournalAccountType:
+    """get_trade_journal account_type 필터 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_default_returns_live_only(self, monkeypatch):
+        """기본 account_type='live' — 기존 동작 유지."""
+        live_journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Live",
+            account_type="live",
+            status="active",
+        )
+        live_journal.id = 1
+        live_journal.created_at = now_kst()
+        live_journal.updated_at = now_kst()
+
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [live_journal]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.trade_journal_tools._session_factory",
+            lambda: factory,
+        )
+
+        result = await get_trade_journal()
+        assert result["success"] is True
+        assert len(result["entries"]) == 1
+        assert result["entries"][0]["account_type"] == "live"
+```
+
+- [ ] **Step 9: get_trade_journal에 account_type 필터 추가**
+
+`app/mcp_server/tooling/trade_journal_tools.py`의 `get_trade_journal()` 시그니처에 추가:
+
+```python
+async def get_trade_journal(
+    symbol: str | None = None,
+    status: str | None = None,
+    market: str | None = None,
+    strategy: str | None = None,
+    days: int | None = None,
+    include_closed: bool = False,
+    limit: int = 50,
+    account_type: str | None = "live",    # 추가: 기본 live만 반환
+) -> dict[str, Any]:
+```
+
+filters 구성 부분에 추가:
+
+```python
+if account_type is not None:
+    filters.append(TradeJournal.account_type == account_type)
+```
+
+- [ ] **Step 10: 전체 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_mcp_trade_journal.py -v`
+Expected: 기존 + 새 테스트 모두 PASS
+
+- [ ] **Step 11: 커밋**
+
+```bash
+git add app/mcp_server/tooling/trade_journal_tools.py tests/test_mcp_trade_journal.py
+git commit -m "feat(journal): add account_type/paper_trade_id to save/get_trade_journal"
+```
+
+---
+
+## Task 4: trade_journal_registration MCP description 업데이트
+
+**Files:**
+- Modify: `app/mcp_server/tooling/trade_journal_registration.py`
+
+- [ ] **Step 1: MCP description 업데이트**
+
+`app/mcp_server/tooling/trade_journal_registration.py` 수정:
+
+`save_trade_journal` description에 추가:
+```python
+description=(
+    "Save a trade journal entry with investment thesis and strategy metadata. "
+    "Call this when recommending a buy/sell to record WHY. "
+    "symbol auto-detects instrument_type. min_hold_days sets hold_until. "
+    "status defaults to 'draft' — set to 'active' after fill confirmation. "
+    "account_type='paper' for paper trading journals (requires account name). "
+    "paper_trade_id links to the paper trade record."
+),
+```
+
+`get_trade_journal` description에 추가:
+```python
+description=(
+    "Query trade journals. MUST call before any sell recommendation to check "
+    "thesis, hold period, target/stop prices. "
+    "Returns active journals by default. "
+    "Each entry includes hold_remaining_days and hold_expired. "
+    "account_type defaults to 'live'; set to 'paper' for paper journals, "
+    "or None to query both."
+),
+```
+
+- [ ] **Step 2: 커밋**
+
+```bash
+git add app/mcp_server/tooling/trade_journal_registration.py
+git commit -m "docs(journal): update MCP descriptions for account_type support"
+```
+
+---
+
+## Task 5: PaperTradingService — strategy_name 필터 추가
+
+**Files:**
+- Modify: `app/services/paper_trading_service.py`
+- Test: `tests/test_paper_trading_service.py`
+
+- [ ] **Step 1: strategy_name 필터 테스트 작성**
+
+`tests/test_paper_trading_service.py`에 추가:
+
+```python
+class TestListAccountsStrategyFilter:
+    """list_accounts strategy_name 필터 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_filter_by_strategy_name(self, mock_db):
+        service = PaperTradingService(mock_db)
+        momentum_account = PaperAccount(
+            name="paper-momentum",
+            initial_capital=Decimal("100000000"),
+            cash_krw=Decimal("100000000"),
+            strategy_name="momentum",
+            is_active=True,
+        )
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [momentum_account]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        accounts = await service.list_accounts(
+            is_active=True, strategy_name="momentum"
+        )
+        assert len(accounts) == 1
+        assert accounts[0].strategy_name == "momentum"
+
+    @pytest.mark.asyncio
+    async def test_no_filter_returns_all(self, mock_db):
+        service = PaperTradingService(mock_db)
+        accounts_data = [
+            PaperAccount(
+                name="a",
+                initial_capital=Decimal("100000000"),
+                cash_krw=Decimal("100000000"),
+                strategy_name="momentum",
+                is_active=True,
+            ),
+            PaperAccount(
+                name="b",
+                initial_capital=Decimal("100000000"),
+                cash_krw=Decimal("100000000"),
+                strategy_name=None,
+                is_active=True,
+            ),
+        ]
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = accounts_data
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        accounts = await service.list_accounts(is_active=True)
+        assert len(accounts) == 2
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `uv run pytest tests/test_paper_trading_service.py::TestListAccountsStrategyFilter -v`
+Expected: FAIL — `list_accounts()` got unexpected keyword argument `strategy_name`
+
+- [ ] **Step 3: list_accounts에 strategy_name 파라미터 추가**
+
+`app/services/paper_trading_service.py`의 `list_accounts()` 수정:
+
+```python
+async def list_accounts(
+    self,
+    is_active: bool | None = True,
+    strategy_name: str | None = None,
+) -> list[PaperAccount]:
+    stmt = select(PaperAccount)
+    if is_active is not None:
+        stmt = stmt.where(PaperAccount.is_active == is_active)
+    if strategy_name is not None:
+        stmt = stmt.where(PaperAccount.strategy_name == strategy_name)
+    stmt = stmt.order_by(PaperAccount.created_at.desc())
+    result = await self.db.execute(stmt)
+    return list(result.scalars().all())
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_paper_trading_service.py -v`
+Expected: 모두 PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/services/paper_trading_service.py tests/test_paper_trading_service.py
+git commit -m "feat(paper): add strategy_name filter to list_accounts"
+```
+
+---
+
+## Task 6: create_paper_account에 strategy_name 노출 + list_paper_accounts 필터
+
+**Files:**
+- Modify: `app/mcp_server/tooling/paper_account_registration.py`
+- Test: `tests/test_paper_account_tools.py`
+
+- [ ] **Step 1: strategy_name 파라미터 테스트 작성**
+
+`tests/test_paper_account_tools.py`에 추가:
+
+```python
+class TestCreatePaperAccountStrategy:
+    """create_paper_account strategy_name 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_create_with_strategy_name(self, monkeypatch):
+        account = PaperAccount(
+            name="paper-momentum",
+            initial_capital=Decimal("100000000"),
+            cash_krw=Decimal("100000000"),
+            strategy_name="momentum",
+            is_active=True,
+        )
+        account.id = 1
+        account.created_at = now_kst()
+        account.updated_at = now_kst()
+
+        mock_service = AsyncMock()
+        mock_service.create_account = AsyncMock(return_value=account)
+
+        mock_session = AsyncMock()
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.paper_account_registration._session_factory",
+            lambda: factory,
+        )
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.paper_account_registration.PaperTradingService",
+            lambda db: mock_service,
+        )
+
+        result = await create_paper_account(
+            name="paper-momentum",
+            strategy_name="momentum",
+        )
+        assert result["success"] is True
+        assert result["account"]["strategy_name"] == "momentum"
+        mock_service.create_account.assert_awaited_once()
+        call_kwargs = mock_service.create_account.call_args.kwargs
+        assert call_kwargs["strategy_name"] == "momentum"
+
+
+class TestListPaperAccountsStrategyFilter:
+    """list_paper_accounts strategy_name 필터 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_filter_by_strategy(self, monkeypatch):
+        account = PaperAccount(
+            name="paper-momentum",
+            initial_capital=Decimal("100000000"),
+            cash_krw=Decimal("100000000"),
+            strategy_name="momentum",
+            is_active=True,
+        )
+        account.id = 1
+        account.created_at = now_kst()
+        account.updated_at = now_kst()
+
+        mock_service = AsyncMock()
+        mock_service.list_accounts = AsyncMock(return_value=[account])
+        mock_service.get_portfolio_summary = AsyncMock(
+            return_value={
+                "positions_count": 0,
+                "total_evaluated": Decimal("0"),
+                "total_pnl_pct": None,
+            }
+        )
+
+        mock_session = AsyncMock()
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.paper_account_registration._session_factory",
+            lambda: factory,
+        )
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.paper_account_registration.PaperTradingService",
+            lambda db: mock_service,
+        )
+
+        result = await list_paper_accounts(strategy_name="momentum")
+        assert result["success"] is True
+        mock_service.list_accounts.assert_awaited_once()
+        call_kwargs = mock_service.list_accounts.call_args.kwargs
+        assert call_kwargs["strategy_name"] == "momentum"
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `uv run pytest tests/test_paper_account_tools.py::TestCreatePaperAccountStrategy -v`
+Expected: FAIL
+
+- [ ] **Step 3: create_paper_account에 strategy_name 추가**
+
+`app/mcp_server/tooling/paper_account_registration.py` 수정:
+
+`create_paper_account` 함수:
+```python
+@mcp.tool(
+    name="create_paper_account",
+    description=(
+        "Create a new paper trading (모의투자) account. "
+        "initial_capital is the KRW opening balance (default 100,000,000 KRW = 1억). "
+        "initial_capital_usd adds a separate USD cash balance for US equity simulation. "
+        "Account name must be unique. "
+        "strategy_name tags the account with a strategy (e.g. daytrading, swing, ai-signal)."
+    ),
+)
+async def create_paper_account(
+    name: str,
+    initial_capital: float = 100_000_000.0,
+    initial_capital_usd: float = 0.0,
+    description: str | None = None,
+    strategy_name: str | None = None,
+) -> dict[str, Any]:
+    try:
+        async with _session_factory()() as db:
+            service = PaperTradingService(db)
+            account = await service.create_account(
+                name=name,
+                initial_capital_krw=Decimal(str(initial_capital)),
+                initial_capital_usd=Decimal(str(initial_capital_usd)),
+                description=description,
+                strategy_name=strategy_name,
+            )
+            return {"success": True, "account": _serialize_account(account)}
+    except IntegrityError:
+        return {
+            "success": False,
+            "error": f"Paper account '{name}' already exists",
+        }
+    except ValueError as exc:
+        return {"success": False, "error": str(exc)}
+```
+
+`list_paper_accounts` 함수:
+```python
+@mcp.tool(
+    name="list_paper_accounts",
+    description=(
+        "List paper trading accounts with per-account summary "
+        "(positions_count, total_evaluated_krw, total_pnl_pct). "
+        "Note: total_evaluated_krw sums KRW and USD position values verbatim "
+        "— it does not convert USD to KRW. "
+        "is_active=True (default) filters to active accounts only. "
+        "strategy_name filters by strategy tag."
+    ),
+)
+async def list_paper_accounts(
+    is_active: bool = True,
+    strategy_name: str | None = None,
+) -> dict[str, Any]:
+    async with _session_factory()() as db:
+        service = PaperTradingService(db)
+        accounts = await service.list_accounts(
+            is_active=is_active,
+            strategy_name=strategy_name,
+        )
+        # ... rest unchanged
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_paper_account_tools.py -v`
+Expected: 모두 PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/mcp_server/tooling/paper_account_registration.py tests/test_paper_account_tools.py
+git commit -m "feat(paper): expose strategy_name in create/list paper account MCP tools"
+```
+
+---
+
+## Task 7: paper_journal_bridge — create_paper_journal 구현
+
+**Files:**
+- Create: `app/mcp_server/tooling/paper_journal_bridge.py`
+- Create: `tests/test_paper_journal_bridge.py`
+
+- [ ] **Step 1: create_paper_journal 테스트 작성**
+
+`tests/test_paper_journal_bridge.py` 생성:
+
+```python
+"""Paper Journal Bridge unit tests."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.timezone import now_kst
+from app.models.trade_journal import TradeJournal
+from app.models.trading import InstrumentType
+
+
+class TestCreatePaperJournal:
+    """create_paper_journal 단위 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_creates_journal_with_paper_fields(self, monkeypatch):
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.refresh = AsyncMock()
+        # No existing active journal
+        mock_scalars = MagicMock()
+        mock_scalars.first.return_value = None
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            paper_journal_bridge, "_session_factory", lambda: factory
+        )
+
+        result = await paper_journal_bridge.create_paper_journal(
+            symbol="005930",
+            instrument_type="equity_kr",
+            entry_price=Decimal("72000"),
+            quantity=Decimal("10"),
+            amount=Decimal("720000"),
+            paper_trade_id=42,
+            paper_account_name="paper-momentum",
+            thesis="AI signal buy",
+            strategy="momentum",
+            target_price=Decimal("80000"),
+            stop_loss=Decimal("65000"),
+            min_hold_days=7,
+            notes="Test note",
+        )
+
+        assert result["success"] is True
+        added_obj = mock_session.add.call_args[0][0]
+        assert isinstance(added_obj, TradeJournal)
+        assert added_obj.account_type == "paper"
+        assert added_obj.paper_trade_id == 42
+        assert added_obj.account == "paper-momentum"
+        assert added_obj.status == "active"
+        assert added_obj.side == "buy"
+        assert added_obj.thesis == "AI signal buy"
+        assert added_obj.strategy == "momentum"
+        assert added_obj.notes == "Test note"
+        assert added_obj.hold_until is not None
+
+    @pytest.mark.asyncio
+    async def test_thesis_required(self, monkeypatch):
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        result = await paper_journal_bridge.create_paper_journal(
+            symbol="005930",
+            instrument_type="equity_kr",
+            entry_price=Decimal("72000"),
+            quantity=Decimal("10"),
+            amount=Decimal("720000"),
+            paper_trade_id=42,
+            paper_account_name="paper-momentum",
+            thesis="",
+        )
+        assert result["success"] is False
+        assert "thesis" in result["error"]
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py::TestCreatePaperJournal -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: paper_journal_bridge.py 생성 — create_paper_journal 구현**
+
+`app/mcp_server/tooling/paper_journal_bridge.py` 생성:
+
+```python
+"""Paper Journal Bridge — paper trading ↔ trade journal 연동.
+
+Paper 주문 결과를 journal 도메인에 반영하는 어댑터 계층.
+주문 체결은 order handler/service가 담당하고,
+이 모듈은 journal create/close/compare/recommend만 책임진다.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from decimal import Decimal
+from typing import Any, cast
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.core.timezone import now_kst
+from app.models.trade_journal import JournalStatus, TradeJournal
+from app.models.trading import InstrumentType
+
+logger = logging.getLogger(__name__)
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+async def create_paper_journal(
+    *,
+    symbol: str,
+    instrument_type: str,
+    entry_price: Decimal,
+    quantity: Decimal,
+    amount: Decimal,
+    paper_trade_id: int,
+    paper_account_name: str,
+    thesis: str,
+    strategy: str | None = None,
+    target_price: Decimal | None = None,
+    stop_loss: Decimal | None = None,
+    min_hold_days: int | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
+    """Create a TradeJournal entry for a paper buy execution.
+
+    Called automatically after a paper buy order with thesis.
+    Status is set to 'active' (paper orders are instant fills — skip draft).
+    """
+    thesis = (thesis or "").strip()
+    if not thesis:
+        return {"success": False, "error": "thesis is required"}
+
+    hold_until = None
+    if min_hold_days is not None and min_hold_days > 0:
+        hold_until = now_kst() + timedelta(days=min_hold_days)
+
+    try:
+        async with _session_factory()() as db:
+            journal = TradeJournal(
+                symbol=symbol,
+                instrument_type=InstrumentType(instrument_type),
+                side="buy",
+                entry_price=entry_price,
+                quantity=quantity,
+                amount=amount,
+                thesis=thesis,
+                strategy=strategy,
+                target_price=target_price,
+                stop_loss=stop_loss,
+                min_hold_days=min_hold_days,
+                hold_until=hold_until,
+                status=JournalStatus.active,
+                account_type="paper",
+                paper_trade_id=paper_trade_id,
+                account=paper_account_name,
+                notes=notes,
+            )
+            db.add(journal)
+            await db.commit()
+            await db.refresh(journal)
+
+            return {
+                "success": True,
+                "action": "created",
+                "journal_id": journal.id,
+            }
+    except Exception as exc:
+        logger.exception("create_paper_journal failed")
+        return {"success": False, "error": f"create_paper_journal failed: {exc}"}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py::TestCreatePaperJournal -v`
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/mcp_server/tooling/paper_journal_bridge.py tests/test_paper_journal_bridge.py
+git commit -m "feat(paper): implement create_paper_journal in paper_journal_bridge"
+```
+
+---
+
+## Task 8: paper_journal_bridge — close_paper_journal (FIFO) 구현
+
+**Files:**
+- Modify: `app/mcp_server/tooling/paper_journal_bridge.py`
+- Modify: `tests/test_paper_journal_bridge.py`
+
+- [ ] **Step 1: close_paper_journal 테스트 작성**
+
+`tests/test_paper_journal_bridge.py`에 추가:
+
+```python
+class TestClosePaperJournal:
+    """close_paper_journal FIFO 정책 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_closes_active_journal(self, monkeypatch):
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Test",
+            entry_price=Decimal("72000"),
+            account_type="paper",
+            account="paper-momentum",
+            status="active",
+        )
+        journal.id = 1
+        journal.created_at = now_kst()
+        journal.updated_at = now_kst()
+
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.first.return_value = journal
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.commit = AsyncMock()
+        mock_session.refresh = AsyncMock()
+
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            paper_journal_bridge, "_session_factory", lambda: factory
+        )
+
+        result = await paper_journal_bridge.close_paper_journal(
+            symbol="005930",
+            exit_price=Decimal("80000"),
+            exit_reason="Target reached",
+            paper_account_name="paper-momentum",
+        )
+
+        assert result is not None
+        assert result["success"] is True
+        assert journal.status == "closed"
+        assert journal.exit_price == Decimal("80000")
+        assert journal.exit_reason == "Target reached"
+        assert journal.exit_date is not None
+        # pnl_pct: (80000/72000 - 1) * 100 ≈ 11.11%
+        assert journal.pnl_pct is not None
+        assert float(journal.pnl_pct) > 11.0
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_journal(self, monkeypatch):
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.first.return_value = None
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            paper_journal_bridge, "_session_factory", lambda: factory
+        )
+
+        result = await paper_journal_bridge.close_paper_journal(
+            symbol="005930",
+            exit_price=Decimal("80000"),
+            paper_account_name="paper-momentum",
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_fifo_closes_oldest_first(self, monkeypatch):
+        """FIFO: created_at ASC 기준 가장 오래된 journal을 close."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        old_journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="First buy",
+            entry_price=Decimal("70000"),
+            account_type="paper",
+            account="paper-momentum",
+            status="active",
+        )
+        old_journal.id = 1
+        old_journal.created_at = now_kst()
+        old_journal.updated_at = now_kst()
+
+        # Query returns oldest first (order_by created_at ASC, limit 1)
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.first.return_value = old_journal
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session.commit = AsyncMock()
+        mock_session.refresh = AsyncMock()
+
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            paper_journal_bridge, "_session_factory", lambda: factory
+        )
+
+        result = await paper_journal_bridge.close_paper_journal(
+            symbol="005930",
+            exit_price=Decimal("75000"),
+            paper_account_name="paper-momentum",
+        )
+
+        assert result is not None
+        assert old_journal.status == "closed"
+        assert old_journal.id == 1  # oldest was closed
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py::TestClosePaperJournal -v`
+Expected: FAIL — `close_paper_journal` not defined
+
+- [ ] **Step 3: close_paper_journal 구현**
+
+`app/mcp_server/tooling/paper_journal_bridge.py`에 추가:
+
+```python
+async def close_paper_journal(
+    *,
+    symbol: str,
+    exit_price: Decimal,
+    exit_reason: str | None = None,
+    paper_account_name: str,
+) -> dict[str, Any] | None:
+    """Close the oldest active paper journal for a symbol (FIFO policy).
+
+    Called automatically after a paper sell order.
+    Returns None if no active paper journal exists (not an error —
+    the position may have been opened without thesis).
+    """
+    try:
+        async with _session_factory()() as db:
+            # FIFO: oldest active journal first (created_at ASC)
+            stmt = (
+                select(TradeJournal)
+                .where(
+                    TradeJournal.symbol == symbol,
+                    TradeJournal.account_type == "paper",
+                    TradeJournal.account == paper_account_name,
+                    TradeJournal.status == JournalStatus.active,
+                )
+                .order_by(TradeJournal.created_at.asc())
+                .limit(1)
+            )
+            result = await db.execute(stmt)
+            journal = result.scalars().first()
+
+            if journal is None:
+                return None
+
+            journal.status = JournalStatus.closed
+            journal.exit_price = exit_price
+            journal.exit_date = now_kst()
+            journal.exit_reason = exit_reason
+
+            if journal.entry_price and journal.entry_price > 0:
+                pnl = (exit_price / journal.entry_price - 1) * Decimal("100")
+                journal.pnl_pct = round(pnl, 4)
+
+            await db.commit()
+            await db.refresh(journal)
+
+            return {
+                "success": True,
+                "action": "closed",
+                "journal_id": journal.id,
+                "pnl_pct": float(journal.pnl_pct) if journal.pnl_pct else None,
+            }
+    except Exception as exc:
+        logger.exception("close_paper_journal failed")
+        return {"success": False, "error": f"close_paper_journal failed: {exc}"}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py -v`
+Expected: 모두 PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/mcp_server/tooling/paper_journal_bridge.py tests/test_paper_journal_bridge.py
+git commit -m "feat(paper): implement close_paper_journal with FIFO policy"
+```
+
+---
+
+## Task 9: paper_order_handler에 journal 연동 통합
+
+**Files:**
+- Modify: `app/mcp_server/tooling/paper_order_handler.py`
+- Modify: `app/mcp_server/tooling/orders_registration.py`
+- Test: `tests/test_paper_order_handler.py`
+
+- [ ] **Step 1: paper_order_handler journal 연동 테스트 작성**
+
+`tests/test_paper_order_handler.py`에 추가:
+
+```python
+class TestPaperOrderJournalIntegration:
+    """place_paper_order → journal 자동 생성/close 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_buy_with_thesis_creates_journal(self, monkeypatch):
+        from app.mcp_server.tooling import paper_order_handler
+
+        # Mock service.execute_order
+        mock_execution = {
+            "success": True,
+            "dry_run": False,
+            "account_id": 1,
+            "preview": {
+                "symbol": "005930",
+                "instrument_type": "equity_kr",
+                "side": "buy",
+                "order_type": "market",
+                "quantity": Decimal("10"),
+                "price": Decimal("72000"),
+                "gross": Decimal("720000"),
+                "fee": Decimal("108"),
+                "total_cost": Decimal("720108"),
+                "currency": "KRW",
+            },
+            "execution": {
+                "symbol": "005930",
+                "instrument_type": "equity_kr",
+                "side": "buy",
+                "order_type": "market",
+                "quantity": Decimal("10"),
+                "price": Decimal("72000"),
+                "gross": Decimal("720000"),
+                "fee": Decimal("108"),
+                "total_cost": Decimal("720108"),
+                "currency": "KRW",
+                "realized_pnl": None,
+                "executed_at": now_kst(),
+            },
+        }
+        mock_account = MagicMock()
+        mock_account.name = "default"
+        mock_account.id = 1
+
+        mock_service = AsyncMock()
+        mock_service.execute_order = AsyncMock(return_value=mock_execution)
+        mock_service.get_account_by_name = AsyncMock(return_value=mock_account)
+
+        monkeypatch.setattr(
+            paper_order_handler, "PaperTradingService", lambda db: mock_service
+        )
+        mock_session = AsyncMock()
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        monkeypatch.setattr(
+            paper_order_handler, "AsyncSessionLocal", lambda: cm
+        )
+
+        mock_create_journal = AsyncMock(
+            return_value={"success": True, "journal_id": 1}
+        )
+        monkeypatch.setattr(
+            paper_order_handler, "create_paper_journal", mock_create_journal
+        )
+
+        result = await paper_order_handler._place_paper_order(
+            symbol="005930",
+            side="buy",
+            order_type="market",
+            quantity=10.0,
+            price=None,
+            amount=None,
+            dry_run=False,
+            reason="AI signal",
+            paper_account_name=None,
+            thesis="AI signal buy thesis",
+            strategy="momentum",
+            target_price=80000.0,
+            stop_loss=65000.0,
+            min_hold_days=7,
+            notes="Test note",
+        )
+
+        assert result["success"] is True
+        mock_create_journal.assert_awaited_once()
+        call_kwargs = mock_create_journal.call_args.kwargs
+        assert call_kwargs["thesis"] == "AI signal buy thesis"
+        assert call_kwargs["strategy"] == "momentum"
+        assert call_kwargs["paper_account_name"] == "default"
+
+    @pytest.mark.asyncio
+    async def test_buy_without_thesis_skips_journal(self, monkeypatch):
+        from app.mcp_server.tooling import paper_order_handler
+
+        mock_execution = {
+            "success": True,
+            "dry_run": False,
+            "account_id": 1,
+            "preview": {
+                "symbol": "005930",
+                "instrument_type": "equity_kr",
+                "side": "buy",
+                "order_type": "market",
+                "quantity": Decimal("10"),
+                "price": Decimal("72000"),
+                "gross": Decimal("720000"),
+                "fee": Decimal("108"),
+                "total_cost": Decimal("720108"),
+                "currency": "KRW",
+            },
+            "execution": {
+                "symbol": "005930",
+                "instrument_type": "equity_kr",
+                "side": "buy",
+                "order_type": "market",
+                "quantity": Decimal("10"),
+                "price": Decimal("72000"),
+                "gross": Decimal("720000"),
+                "fee": Decimal("108"),
+                "total_cost": Decimal("720108"),
+                "currency": "KRW",
+                "realized_pnl": None,
+                "executed_at": now_kst(),
+            },
+        }
+        mock_account = MagicMock()
+        mock_account.name = "default"
+        mock_account.id = 1
+
+        mock_service = AsyncMock()
+        mock_service.execute_order = AsyncMock(return_value=mock_execution)
+        mock_service.get_account_by_name = AsyncMock(return_value=mock_account)
+
+        monkeypatch.setattr(
+            paper_order_handler, "PaperTradingService", lambda db: mock_service
+        )
+        mock_session = AsyncMock()
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        monkeypatch.setattr(
+            paper_order_handler, "AsyncSessionLocal", lambda: cm
+        )
+
+        mock_create_journal = AsyncMock()
+        monkeypatch.setattr(
+            paper_order_handler, "create_paper_journal", mock_create_journal
+        )
+
+        result = await paper_order_handler._place_paper_order(
+            symbol="005930",
+            side="buy",
+            order_type="market",
+            quantity=10.0,
+            price=None,
+            amount=None,
+            dry_run=False,
+            reason="Quick buy",
+            paper_account_name=None,
+        )
+
+        assert result["success"] is True
+        mock_create_journal.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_sell_calls_close_journal(self, monkeypatch):
+        from app.mcp_server.tooling import paper_order_handler
+
+        mock_execution = {
+            "success": True,
+            "dry_run": False,
+            "account_id": 1,
+            "preview": {
+                "symbol": "005930",
+                "instrument_type": "equity_kr",
+                "side": "sell",
+                "order_type": "market",
+                "quantity": Decimal("10"),
+                "price": Decimal("80000"),
+                "gross": Decimal("800000"),
+                "fee": Decimal("1560"),
+                "total_cost": Decimal("798440"),
+                "currency": "KRW",
+            },
+            "execution": {
+                "symbol": "005930",
+                "instrument_type": "equity_kr",
+                "side": "sell",
+                "order_type": "market",
+                "quantity": Decimal("10"),
+                "price": Decimal("80000"),
+                "gross": Decimal("800000"),
+                "fee": Decimal("1560"),
+                "total_cost": Decimal("798440"),
+                "currency": "KRW",
+                "realized_pnl": Decimal("78440"),
+                "executed_at": now_kst(),
+            },
+        }
+        mock_account = MagicMock()
+        mock_account.name = "default"
+        mock_account.id = 1
+
+        mock_service = AsyncMock()
+        mock_service.execute_order = AsyncMock(return_value=mock_execution)
+        mock_service.get_account_by_name = AsyncMock(return_value=mock_account)
+
+        monkeypatch.setattr(
+            paper_order_handler, "PaperTradingService", lambda db: mock_service
+        )
+        mock_session = AsyncMock()
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        monkeypatch.setattr(
+            paper_order_handler, "AsyncSessionLocal", lambda: cm
+        )
+
+        mock_close_journal = AsyncMock(
+            return_value={"success": True, "journal_id": 1, "pnl_pct": 11.11}
+        )
+        monkeypatch.setattr(
+            paper_order_handler, "close_paper_journal", mock_close_journal
+        )
+
+        result = await paper_order_handler._place_paper_order(
+            symbol="005930",
+            side="sell",
+            order_type="market",
+            quantity=10.0,
+            price=None,
+            amount=None,
+            dry_run=False,
+            reason="Target reached",
+            paper_account_name=None,
+        )
+
+        assert result["success"] is True
+        mock_close_journal.assert_awaited_once()
+        call_kwargs = mock_close_journal.call_args.kwargs
+        assert call_kwargs["symbol"] == "005930"
+        assert call_kwargs["paper_account_name"] == "default"
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `uv run pytest tests/test_paper_order_handler.py::TestPaperOrderJournalIntegration -v`
+Expected: FAIL
+
+- [ ] **Step 3: _place_paper_order 시그니처 확장 및 journal 연동 구현**
+
+`app/mcp_server/tooling/paper_order_handler.py` 수정:
+
+import 추가:
+```python
+from app.mcp_server.tooling.paper_journal_bridge import (
+    close_paper_journal,
+    create_paper_journal,
+)
+```
+
+`_place_paper_order` 시그니처 확장:
+```python
+async def _place_paper_order(
+    *,
+    symbol: str,
+    side: str,
+    order_type: str,
+    quantity: float | None,
+    price: float | None,
+    amount: float | None,
+    dry_run: bool,
+    reason: str,
+    paper_account_name: str | None,
+    # Journal 연동 파라미터
+    thesis: str | None = None,
+    strategy: str | None = None,
+    target_price: float | None = None,
+    stop_loss: float | None = None,
+    min_hold_days: int | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
+```
+
+실행 성공 후 journal 연동 로직 추가 (기존 return 직전):
+```python
+        # --- Journal 연동 ---
+        exec_data = execution["execution"]
+        account_name = account.name
+
+        if side.lower() == "buy" and thesis:
+            try:
+                journal_result = await create_paper_journal(
+                    symbol=exec_data["symbol"],
+                    instrument_type=exec_data["instrument_type"],
+                    entry_price=Decimal(str(exec_data["price"])),
+                    quantity=Decimal(str(exec_data["quantity"])),
+                    amount=Decimal(str(exec_data["gross"])),
+                    paper_trade_id=exec_data.get("trade_id", 0),
+                    paper_account_name=account_name,
+                    thesis=thesis,
+                    strategy=strategy,
+                    target_price=Decimal(str(target_price)) if target_price else None,
+                    stop_loss=Decimal(str(stop_loss)) if stop_loss else None,
+                    min_hold_days=min_hold_days,
+                    notes=notes,
+                )
+            except Exception as exc:
+                logger.warning("Paper journal creation failed: %s", exc)
+                journal_result = None
+        elif side.lower() == "sell":
+            try:
+                journal_result = await close_paper_journal(
+                    symbol=exec_data["symbol"],
+                    exit_price=Decimal(str(exec_data["price"])),
+                    exit_reason=reason or None,
+                    paper_account_name=account_name,
+                )
+            except Exception as exc:
+                logger.warning("Paper journal close failed: %s", exc)
+                journal_result = None
+        else:
+            journal_result = None
+
+        response = {
+            "success": True,
+            "dry_run": False,
+            "account_type": "paper",
+            "paper_account": account_name,
+            "account_id": account.id,
+            "preview": execution["preview"],
+            "execution": execution["execution"],
+            "message": "[Paper] Order placed successfully",
+        }
+        if journal_result is not None:
+            response["journal"] = journal_result
+        return response
+```
+
+- [ ] **Step 4: orders_registration.py에서 paper 경로에 journal 파라미터 전달**
+
+`app/mcp_server/tooling/orders_registration.py` 수정:
+
+`place_order` 함수의 paper 분기 (line 111-122) 변경:
+```python
+        if account_type == "paper":
+            return await _place_paper_order(
+                symbol=symbol,
+                side=side,
+                order_type=order_type,
+                quantity=quantity,
+                price=price,
+                amount=amount,
+                dry_run=dry_run,
+                reason=reason,
+                paper_account_name=paper_account,
+                thesis=thesis,
+                strategy=strategy,
+                target_price=target_price,
+                stop_loss=stop_loss,
+                min_hold_days=min_hold_days,
+                notes=notes,
+            )
+```
+
+`place_order` MCP description 업데이트 — "In paper mode, thesis/strategy/journal parameters are ignored." 문구 제거, 대체:
+```python
+"In paper mode, if thesis is provided on buy, a trade journal is auto-created; "
+"on sell, active paper journals are auto-closed in FIFO order. "
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_paper_order_handler.py -v`
+Expected: 모두 PASS
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app/mcp_server/tooling/paper_order_handler.py app/mcp_server/tooling/orders_registration.py tests/test_paper_order_handler.py
+git commit -m "feat(paper): integrate journal create/close into paper order flow"
+```
+
+---
+
+## Task 10: compare_strategies 구현
+
+**Files:**
+- Modify: `app/mcp_server/tooling/paper_journal_bridge.py`
+- Modify: `tests/test_paper_journal_bridge.py`
+
+- [ ] **Step 1: compare_strategies 테스트 작성**
+
+`tests/test_paper_journal_bridge.py`에 추가:
+
+```python
+class TestCompareStrategies:
+    """compare_strategies 단위 테스트."""
+
+    def _make_closed_journal(
+        self,
+        *,
+        symbol: str,
+        account: str,
+        strategy: str | None,
+        account_type: str = "paper",
+        entry_price: float,
+        pnl_pct: float,
+        journal_id: int,
+    ) -> TradeJournal:
+        j = TradeJournal(
+            symbol=symbol,
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Test",
+            entry_price=Decimal(str(entry_price)),
+            account_type=account_type,
+            account=account,
+            strategy=strategy,
+            status="closed",
+            pnl_pct=Decimal(str(pnl_pct)),
+        )
+        j.id = journal_id
+        j.created_at = now_kst()
+        j.updated_at = now_kst()
+        j.exit_date = now_kst()
+        j.exit_price = Decimal(str(entry_price * (1 + pnl_pct / 100)))
+        return j
+
+    @pytest.mark.asyncio
+    async def test_strategies_aggregation_closed_only(self, monkeypatch):
+        """closed journal 기준으로만 집계."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        closed_win = self._make_closed_journal(
+            symbol="005930", account="paper-m", strategy="momentum",
+            entry_price=72000, pnl_pct=5.0, journal_id=1,
+        )
+        closed_loss = self._make_closed_journal(
+            symbol="AAPL", account="paper-m", strategy="momentum",
+            entry_price=150, pnl_pct=-3.0, journal_id=2,
+        )
+        active_journal = TradeJournal(
+            symbol="TSLA",
+            instrument_type=InstrumentType.equity_us,
+            thesis="Test",
+            account_type="paper",
+            account="paper-m",
+            strategy="momentum",
+            status="active",
+        )
+        active_journal.id = 3
+        active_journal.created_at = now_kst()
+        active_journal.updated_at = now_kst()
+
+        # Mock: paper journals query returns closed + active
+        mock_session = AsyncMock()
+
+        # First call: paper closed journals for strategies
+        paper_scalars = MagicMock()
+        paper_scalars.all.return_value = [closed_win, closed_loss, active_journal]
+        paper_result = MagicMock()
+        paper_result.scalars.return_value = paper_scalars
+
+        # Second call: live journals (empty for this test)
+        live_scalars = MagicMock()
+        live_scalars.all.return_value = []
+        live_result = MagicMock()
+        live_result.scalars.return_value = live_scalars
+
+        # Third call: paper account lookup
+        account_scalars = MagicMock()
+        mock_paper_account = MagicMock()
+        mock_paper_account.id = 1
+        mock_paper_account.name = "paper-m"
+        mock_paper_account.strategy_name = "momentum"
+        account_scalars.all.return_value = [mock_paper_account]
+        account_result = MagicMock()
+        account_result.scalars.return_value = account_scalars
+
+        mock_session.execute = AsyncMock(
+            side_effect=[account_result, paper_result, live_result]
+        )
+
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            paper_journal_bridge, "_session_factory", lambda: factory
+        )
+
+        result = await paper_journal_bridge.compare_strategies(days=30)
+
+        assert result["success"] is True
+        strategies = result["strategies"]
+        assert len(strategies) == 1
+        s = strategies[0]
+        # Only closed journals counted
+        assert s["total_trades"] == 2
+        assert s["win_count"] == 1
+        assert s["loss_count"] == 1
+        assert s["win_rate"] == 50.0
+
+    @pytest.mark.asyncio
+    async def test_include_live_comparison_false(self, monkeypatch):
+        """include_live_comparison=False → live_vs_paper 빈 배열."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_session = AsyncMock()
+        account_scalars = MagicMock()
+        account_scalars.all.return_value = []
+        account_result = MagicMock()
+        account_result.scalars.return_value = account_scalars
+
+        paper_scalars = MagicMock()
+        paper_scalars.all.return_value = []
+        paper_result = MagicMock()
+        paper_result.scalars.return_value = paper_scalars
+
+        mock_session.execute = AsyncMock(
+            side_effect=[account_result, paper_result]
+        )
+
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            paper_journal_bridge, "_session_factory", lambda: factory
+        )
+
+        result = await paper_journal_bridge.compare_strategies(
+            days=30, include_live_comparison=False
+        )
+        assert result["success"] is True
+        assert result["live_vs_paper"] == []
+
+    @pytest.mark.asyncio
+    async def test_live_vs_paper_same_symbol(self, monkeypatch):
+        """같은 종목 live/paper journal → 비교 결과 생성."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        paper_j = self._make_closed_journal(
+            symbol="005930", account="paper-m", strategy="momentum",
+            account_type="paper", entry_price=72000, pnl_pct=5.0, journal_id=1,
+        )
+        live_j = self._make_closed_journal(
+            symbol="005930", account="kis-main", strategy=None,
+            account_type="live", entry_price=71000, pnl_pct=3.0, journal_id=2,
+        )
+
+        mock_session = AsyncMock()
+
+        account_scalars = MagicMock()
+        mock_paper_account = MagicMock()
+        mock_paper_account.id = 1
+        mock_paper_account.name = "paper-m"
+        mock_paper_account.strategy_name = "momentum"
+        account_scalars.all.return_value = [mock_paper_account]
+        account_result = MagicMock()
+        account_result.scalars.return_value = account_scalars
+
+        paper_scalars = MagicMock()
+        paper_scalars.all.return_value = [paper_j]
+        paper_result = MagicMock()
+        paper_result.scalars.return_value = paper_scalars
+
+        live_scalars = MagicMock()
+        live_scalars.all.return_value = [live_j]
+        live_result = MagicMock()
+        live_result.scalars.return_value = live_scalars
+
+        mock_session.execute = AsyncMock(
+            side_effect=[account_result, paper_result, live_result]
+        )
+
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            paper_journal_bridge, "_session_factory", lambda: factory
+        )
+
+        result = await paper_journal_bridge.compare_strategies(
+            days=30, include_live_comparison=True
+        )
+
+        assert result["success"] is True
+        assert len(result["live_vs_paper"]) == 1
+        comp = result["live_vs_paper"][0]
+        assert comp["symbol"] == "005930"
+        assert comp["paper_pnl_pct"] == 5.0
+        assert comp["live_pnl_pct"] == 3.0
+        assert comp["delta_pnl_pct"] == pytest.approx(2.0)
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py::TestCompareStrategies -v`
+Expected: FAIL
+
+- [ ] **Step 3: compare_strategies 구현**
+
+`app/mcp_server/tooling/paper_journal_bridge.py`에 추가:
+
+```python
+from app.models.paper_trading import PaperAccount
+
+
+async def compare_strategies(
+    days: int = 30,
+    strategy_name: str | None = None,
+    include_live_comparison: bool = True,
+) -> dict[str, Any]:
+    """Compare paper trading strategy performance over a given period.
+
+    All metrics (win_rate, total_return_pct, avg_pnl_pct, best/worst_trade)
+    are based on **closed** journals only (realized performance).
+
+    Aggregation unit is paper account. strategy_name is a filter on
+    TradeJournal.strategy (not PaperAccount.strategy_name).
+    """
+    cutoff = now_kst() - timedelta(days=days)
+
+    try:
+        async with _session_factory()() as db:
+            # 1. Get paper accounts for metadata
+            acct_stmt = select(PaperAccount).where(PaperAccount.is_active.is_(True))
+            acct_result = await db.execute(acct_stmt)
+            accounts = {a.name: a for a in acct_result.scalars().all()}
+
+            # 2. Fetch paper journals in period
+            paper_filters = [
+                TradeJournal.account_type == "paper",
+                TradeJournal.created_at >= cutoff,
+            ]
+            if strategy_name is not None:
+                paper_filters.append(TradeJournal.strategy == strategy_name)
+
+            paper_stmt = (
+                select(TradeJournal)
+                .where(*paper_filters)
+                .order_by(desc(TradeJournal.created_at))
+            )
+            paper_result = await db.execute(paper_stmt)
+            paper_journals = list(paper_result.scalars().all())
+
+            # 3. Aggregate by account (closed only)
+            from collections import defaultdict
+
+            by_account: dict[str, list[TradeJournal]] = defaultdict(list)
+            for j in paper_journals:
+                if j.status == JournalStatus.closed and j.account:
+                    by_account[j.account].append(j)
+
+            strategies_out: list[dict[str, Any]] = []
+            for account_name, journals in by_account.items():
+                acct = accounts.get(account_name)
+                wins = [j for j in journals if j.pnl_pct is not None and j.pnl_pct > 0]
+                losses = [j for j in journals if j.pnl_pct is not None and j.pnl_pct <= 0]
+                total = len(journals)
+                win_count = len(wins)
+                loss_count = len(losses)
+
+                pnl_values = [
+                    float(j.pnl_pct) for j in journals if j.pnl_pct is not None
+                ]
+                total_return_pct = sum(pnl_values) if pnl_values else 0.0
+                avg_pnl_pct = (
+                    round(total_return_pct / len(pnl_values), 2) if pnl_values else 0.0
+                )
+                win_rate = round(win_count / total * 100, 1) if total > 0 else 0.0
+
+                best = max(journals, key=lambda j: float(j.pnl_pct or 0))
+                worst = min(journals, key=lambda j: float(j.pnl_pct or 0))
+
+                strategies_out.append({
+                    "strategy_name": acct.strategy_name if acct else None,
+                    "account_name": account_name,
+                    "account_id": acct.id if acct else None,
+                    "total_trades": total,
+                    "win_count": win_count,
+                    "loss_count": loss_count,
+                    "win_rate": win_rate,
+                    "total_return_pct": round(total_return_pct, 2),
+                    "avg_pnl_pct": avg_pnl_pct,
+                    "best_trade": {
+                        "symbol": best.symbol,
+                        "pnl_pct": float(best.pnl_pct) if best.pnl_pct else 0.0,
+                    },
+                    "worst_trade": {
+                        "symbol": worst.symbol,
+                        "pnl_pct": float(worst.pnl_pct) if worst.pnl_pct else 0.0,
+                    },
+                })
+
+            # 4. Live vs paper comparison
+            live_vs_paper: list[dict[str, Any]] = []
+            if include_live_comparison:
+                live_stmt = (
+                    select(TradeJournal)
+                    .where(
+                        TradeJournal.account_type == "live",
+                        TradeJournal.status == JournalStatus.closed,
+                        TradeJournal.created_at >= cutoff,
+                    )
+                    .order_by(desc(TradeJournal.created_at))
+                )
+                live_result = await db.execute(live_stmt)
+                live_journals = list(live_result.scalars().all())
+
+                # Most recent closed journal per symbol (live)
+                live_by_symbol: dict[str, TradeJournal] = {}
+                for j in live_journals:
+                    if j.symbol not in live_by_symbol:
+                        live_by_symbol[j.symbol] = j
+
+                # Most recent closed journal per symbol (paper)
+                paper_closed = [
+                    j for j in paper_journals if j.status == JournalStatus.closed
+                ]
+                paper_by_symbol: dict[str, TradeJournal] = {}
+                for j in paper_closed:
+                    if j.symbol not in paper_by_symbol:
+                        paper_by_symbol[j.symbol] = j
+
+                # Match
+                common_symbols = set(live_by_symbol) & set(paper_by_symbol)
+                for sym in sorted(common_symbols):
+                    lj = live_by_symbol[sym]
+                    pj = paper_by_symbol[sym]
+                    l_pnl = float(lj.pnl_pct) if lj.pnl_pct is not None else 0.0
+                    p_pnl = float(pj.pnl_pct) if pj.pnl_pct is not None else 0.0
+                    live_vs_paper.append({
+                        "symbol": sym,
+                        "live_entry_price": float(lj.entry_price) if lj.entry_price else None,
+                        "live_pnl_pct": l_pnl,
+                        "paper_entry_price": float(pj.entry_price) if pj.entry_price else None,
+                        "paper_pnl_pct": p_pnl,
+                        "paper_strategy": pj.strategy,
+                        "delta_pnl_pct": round(p_pnl - l_pnl, 4),
+                    })
+
+            return {
+                "success": True,
+                "period_days": days,
+                "strategies": strategies_out,
+                "live_vs_paper": live_vs_paper,
+            }
+    except Exception as exc:
+        logger.exception("compare_strategies failed")
+        return {"success": False, "error": f"compare_strategies failed: {exc}"}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py::TestCompareStrategies -v`
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/mcp_server/tooling/paper_journal_bridge.py tests/test_paper_journal_bridge.py
+git commit -m "feat(paper): implement compare_strategies in paper_journal_bridge"
+```
+
+---
+
+## Task 11: recommend_go_live 구현
+
+**Files:**
+- Modify: `app/mcp_server/tooling/paper_journal_bridge.py`
+- Modify: `tests/test_paper_journal_bridge.py`
+
+- [ ] **Step 1: recommend_go_live 테스트 작성**
+
+`tests/test_paper_journal_bridge.py`에 추가:
+
+```python
+class TestRecommendGoLive:
+    """recommend_go_live 판정 테스트."""
+
+    def _make_closed_journal(
+        self, *, pnl_pct: float, journal_id: int
+    ) -> TradeJournal:
+        j = TradeJournal(
+            symbol=f"SYM{journal_id}",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Test",
+            entry_price=Decimal("10000"),
+            account_type="paper",
+            account="paper-test",
+            status="closed",
+            pnl_pct=Decimal(str(pnl_pct)),
+        )
+        j.id = journal_id
+        j.created_at = now_kst()
+        j.updated_at = now_kst()
+        return j
+
+    def _mock_session_for_recommend(
+        self, monkeypatch, account, closed_journals, active_count=0
+    ):
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_session = AsyncMock()
+
+        # First query: account lookup
+        acct_scalars = MagicMock()
+        acct_scalars.one_or_none.return_value = account
+        acct_result = MagicMock()
+        acct_result.scalars.return_value = acct_scalars
+
+        # Second query: closed journals
+        closed_scalars = MagicMock()
+        closed_scalars.all.return_value = closed_journals
+        closed_result = MagicMock()
+        closed_result.scalars.return_value = closed_scalars
+
+        # Third query: active count
+        active_scalar_result = MagicMock()
+        active_scalar_result.scalar_one.return_value = active_count
+        
+        mock_session.execute = AsyncMock(
+            side_effect=[acct_result, closed_result, active_scalar_result]
+        )
+
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            paper_journal_bridge, "_session_factory", lambda: factory
+        )
+
+    @pytest.mark.asyncio
+    async def test_all_criteria_met_go_live(self, monkeypatch):
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        account = MagicMock()
+        account.name = "paper-test"
+        account.strategy_name = "momentum"
+
+        # 25 trades, 16 wins, 9 losses → win_rate=64%, total_return positive
+        journals = []
+        for i in range(16):
+            journals.append(self._make_closed_journal(pnl_pct=3.0, journal_id=i + 1))
+        for i in range(9):
+            journals.append(
+                self._make_closed_journal(pnl_pct=-2.0, journal_id=i + 17)
+            )
+
+        self._mock_session_for_recommend(monkeypatch, account, journals)
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test"
+        )
+        assert result["success"] is True
+        assert result["recommendation"] == "go_live"
+        assert result["all_passed"] is True
+        assert result["criteria"]["min_trades"]["passed"] is True
+        assert result["criteria"]["min_win_rate"]["passed"] is True
+        assert result["criteria"]["min_return_pct"]["passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_insufficient_trades_not_ready(self, monkeypatch):
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        account = MagicMock()
+        account.name = "paper-test"
+        account.strategy_name = "test"
+
+        journals = [
+            self._make_closed_journal(pnl_pct=5.0, journal_id=i + 1)
+            for i in range(10)
+        ]
+        self._mock_session_for_recommend(monkeypatch, account, journals)
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test"
+        )
+        assert result["recommendation"] == "not_ready"
+        assert result["criteria"]["min_trades"]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_low_win_rate_not_ready(self, monkeypatch):
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        account = MagicMock()
+        account.name = "paper-test"
+        account.strategy_name = "test"
+
+        # 20 trades, only 5 wins → 25%
+        journals = []
+        for i in range(5):
+            journals.append(self._make_closed_journal(pnl_pct=2.0, journal_id=i + 1))
+        for i in range(15):
+            journals.append(
+                self._make_closed_journal(pnl_pct=-1.0, journal_id=i + 6)
+            )
+        self._mock_session_for_recommend(monkeypatch, account, journals)
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test"
+        )
+        assert result["recommendation"] == "not_ready"
+        assert result["criteria"]["min_win_rate"]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_custom_thresholds(self, monkeypatch):
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        account = MagicMock()
+        account.name = "paper-test"
+        account.strategy_name = "test"
+
+        journals = [
+            self._make_closed_journal(pnl_pct=1.0, journal_id=i + 1)
+            for i in range(10)
+        ]
+        self._mock_session_for_recommend(monkeypatch, account, journals)
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test",
+            min_trades=5,
+            min_win_rate=80.0,
+            min_return_pct=5.0,
+        )
+        assert result["recommendation"] == "go_live"
+        assert result["criteria"]["min_trades"]["required"] == 5
+
+    @pytest.mark.asyncio
+    async def test_account_not_found(self, monkeypatch):
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        self._mock_session_for_recommend(monkeypatch, None, [])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="nonexistent"
+        )
+        assert result["success"] is False
+        assert "not found" in result["error"]
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py::TestRecommendGoLive -v`
+Expected: FAIL
+
+- [ ] **Step 3: recommend_go_live 구현**
+
+`app/mcp_server/tooling/paper_journal_bridge.py`에 추가:
+
+```python
+from sqlalchemy import func as sa_func
+
+
+async def recommend_go_live(
+    account_name: str,
+    min_trades: int = 20,
+    min_win_rate: float = 50.0,
+    min_return_pct: float = 0.0,
+) -> dict[str, Any]:
+    """Evaluate whether a paper trading account meets go-live criteria.
+
+    All metrics are based on **closed** journals only (realized performance).
+    Active positions are shown in summary for reference but excluded from judgment.
+    """
+    try:
+        async with _session_factory()() as db:
+            # 1. Account lookup
+            acct_stmt = select(PaperAccount).where(
+                PaperAccount.name == account_name
+            )
+            acct_result = await db.execute(acct_stmt)
+            account = acct_result.scalars().one_or_none()
+            if account is None:
+                return {
+                    "success": False,
+                    "error": f"Paper account '{account_name}' not found",
+                }
+
+            # 2. Closed journals
+            closed_stmt = (
+                select(TradeJournal)
+                .where(
+                    TradeJournal.account_type == "paper",
+                    TradeJournal.account == account_name,
+                    TradeJournal.status == JournalStatus.closed,
+                )
+                .order_by(desc(TradeJournal.created_at))
+            )
+            closed_result = await db.execute(closed_stmt)
+            closed_journals = list(closed_result.scalars().all())
+
+            # 3. Active positions count (reference only)
+            active_stmt = (
+                select(sa_func.count())
+                .select_from(TradeJournal)
+                .where(
+                    TradeJournal.account_type == "paper",
+                    TradeJournal.account == account_name,
+                    TradeJournal.status == JournalStatus.active,
+                )
+            )
+            active_result = await db.execute(active_stmt)
+            active_positions = active_result.scalar_one()
+
+            # 4. Calculate metrics
+            total_trades = len(closed_journals)
+            pnl_values = [
+                float(j.pnl_pct) for j in closed_journals if j.pnl_pct is not None
+            ]
+            win_count = sum(1 for v in pnl_values if v > 0)
+            loss_count = total_trades - win_count
+            total_return_pct = round(sum(pnl_values), 2) if pnl_values else 0.0
+            win_rate = round(win_count / total_trades * 100, 1) if total_trades > 0 else 0.0
+            avg_pnl_pct = (
+                round(total_return_pct / len(pnl_values), 2) if pnl_values else 0.0
+            )
+
+            best_trade = None
+            worst_trade = None
+            if closed_journals:
+                best = max(closed_journals, key=lambda j: float(j.pnl_pct or 0))
+                worst = min(closed_journals, key=lambda j: float(j.pnl_pct or 0))
+                best_trade = {
+                    "symbol": best.symbol,
+                    "pnl_pct": float(best.pnl_pct) if best.pnl_pct else 0.0,
+                }
+                worst_trade = {
+                    "symbol": worst.symbol,
+                    "pnl_pct": float(worst.pnl_pct) if worst.pnl_pct else 0.0,
+                }
+
+            # 5. Criteria check
+            trades_passed = total_trades >= min_trades
+            wr_passed = win_rate >= min_win_rate
+            return_passed = total_return_pct >= min_return_pct
+            all_passed = trades_passed and wr_passed and return_passed
+
+            return {
+                "success": True,
+                "account_name": account_name,
+                "strategy_name": account.strategy_name,
+                "recommendation": "go_live" if all_passed else "not_ready",
+                "criteria": {
+                    "min_trades": {
+                        "required": min_trades,
+                        "actual": total_trades,
+                        "passed": trades_passed,
+                    },
+                    "min_win_rate": {
+                        "required": min_win_rate,
+                        "actual": win_rate,
+                        "passed": wr_passed,
+                    },
+                    "min_return_pct": {
+                        "required": min_return_pct,
+                        "actual": total_return_pct,
+                        "passed": return_passed,
+                    },
+                },
+                "all_passed": all_passed,
+                "summary": {
+                    "total_trades": total_trades,
+                    "win_count": win_count,
+                    "loss_count": loss_count,
+                    "win_rate": win_rate,
+                    "total_return_pct": total_return_pct,
+                    "avg_pnl_pct": avg_pnl_pct,
+                    "best_trade": best_trade,
+                    "worst_trade": worst_trade,
+                    "active_positions": active_positions,
+                },
+            }
+    except Exception as exc:
+        logger.exception("recommend_go_live failed")
+        return {"success": False, "error": f"recommend_go_live failed: {exc}"}
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py::TestRecommendGoLive -v`
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/mcp_server/tooling/paper_journal_bridge.py tests/test_paper_journal_bridge.py
+git commit -m "feat(paper): implement recommend_go_live in paper_journal_bridge"
+```
+
+---
+
+## Task 12: MCP 등록 — compare_strategies, recommend_go_live
+
+**Files:**
+- Create: `app/mcp_server/tooling/paper_journal_registration.py`
+- Modify: `app/mcp_server/tooling/registry.py`
+
+- [ ] **Step 1: registration 파일 생성**
+
+`app/mcp_server/tooling/paper_journal_registration.py` 생성:
+
+```python
+"""Paper Journal MCP tool registration — compare_strategies, recommend_go_live."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.mcp_server.tooling.paper_journal_bridge import (
+    compare_strategies,
+    recommend_go_live,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+PAPER_JOURNAL_TOOL_NAMES: set[str] = {
+    "compare_strategies",
+    "recommend_go_live",
+}
+
+
+def register_paper_journal_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="compare_strategies",
+        description=(
+            "Compare paper trading strategy performance over a given period. "
+            "Shows per-account/per-strategy metrics such as win rate, realized return, "
+            "and best/worst trade. All metrics are based on closed journals only. "
+            "If include_live_comparison=True, also compares same-symbol live vs paper "
+            "journal outcomes within the same period."
+        ),
+    )(compare_strategies)
+
+    _ = mcp.tool(
+        name="recommend_go_live",
+        description=(
+            "Evaluate whether a paper trading account meets criteria for live trading. "
+            "Checks total trades, win rate, and realized return against thresholds "
+            "(default: 20 trades, 50% win rate, positive return). "
+            "All metrics are based on closed journals only."
+        ),
+    )(recommend_go_live)
+
+
+__all__ = ["PAPER_JOURNAL_TOOL_NAMES", "register_paper_journal_tools"]
+```
+
+- [ ] **Step 2: registry.py에 등록 추가**
+
+`app/mcp_server/tooling/registry.py` 수정:
+
+import 추가:
+```python
+from app.mcp_server.tooling.paper_journal_registration import (
+    register_paper_journal_tools,
+)
+```
+
+`register_all_tools` 함수에 추가:
+```python
+register_paper_journal_tools(mcp)
+```
+
+- [ ] **Step 3: 등록 테스트**
+
+`tests/test_paper_journal_bridge.py`에 추가:
+
+```python
+class TestPaperJournalRegistration:
+    """MCP 도구 등록 확인."""
+
+    def test_tool_names_defined(self):
+        from app.mcp_server.tooling.paper_journal_registration import (
+            PAPER_JOURNAL_TOOL_NAMES,
+        )
+
+        assert "compare_strategies" in PAPER_JOURNAL_TOOL_NAMES
+        assert "recommend_go_live" in PAPER_JOURNAL_TOOL_NAMES
+
+    def test_register_does_not_raise(self):
+        from unittest.mock import MagicMock
+
+        from app.mcp_server.tooling.paper_journal_registration import (
+            register_paper_journal_tools,
+        )
+
+        mock_mcp = MagicMock()
+        mock_mcp.tool.return_value = lambda fn: fn
+        register_paper_journal_tools(mock_mcp)
+        assert mock_mcp.tool.call_count == 2
+```
+
+- [ ] **Step 4: 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py::TestPaperJournalRegistration -v`
+Expected: PASS
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add app/mcp_server/tooling/paper_journal_registration.py app/mcp_server/tooling/registry.py tests/test_paper_journal_bridge.py
+git commit -m "feat(paper): register compare_strategies and recommend_go_live MCP tools"
+```
+
+---
+
+## Task 13: 전체 테스트 스위트 실행 및 lint
+
+- [ ] **Step 1: 전체 테스트 실행**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py tests/test_mcp_trade_journal.py tests/test_paper_trading_service.py tests/test_paper_account_tools.py tests/test_paper_order_handler.py tests/test_trade_journal_model.py -v`
+Expected: 모두 PASS
+
+- [ ] **Step 2: lint 실행**
+
+Run: `make lint`
+Expected: 오류 없음
+
+- [ ] **Step 3: format 실행**
+
+Run: `make format`
+
+- [ ] **Step 4: lint 재확인 후 커밋**
+
+Run: `make lint`
+
+```bash
+git add -A
+git commit -m "style: fix formatting from lint"
+```
+
+(변경사항 없으면 커밋 생략)

--- a/docs/superpowers/plans/2026-04-13-paper-strategy-remaining-tasks.md
+++ b/docs/superpowers/plans/2026-04-13-paper-strategy-remaining-tasks.md
@@ -1,0 +1,1093 @@
+# Paper Trading 다중 전략 — 잔여 작업 구현 플랜
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 미커밋 코드 정리, `compare_strategies`/`recommend_go_live` MCP 도구 구현, MCP 등록, 전체 검증을 완료한다.
+
+**Architecture:** `paper_journal_bridge.py` 모듈에 `compare_strategies`와 `recommend_go_live`를 구현한다. 기존 구현에서 journal create/close는 `order_journal.py`를 재사용하는 방식으로 이미 완료되었으므로, bridge 모듈에는 분석/추천 함수만 포함한다. `paper_journal_registration.py`에서 MCP 도구로 등록한다.
+
+**Tech Stack:** Python 3.13, SQLAlchemy (async), FastMCP, pytest + pytest-asyncio
+
+**Spec:** `docs/superpowers/specs/2026-04-13-paper-strategy-journal-integration-design.md`
+
+**선행 작업 상태:**
+- Tasks 1-5, 9 커밋 완료 (모델, 마이그레이션, journal account_type, MCP description, strategy 필터, order→journal 연동)
+- Task 6 코드 존재하나 미커밋 (`paper_account_registration.py`)
+- Tasks 7-8은 `order_journal.py` 재사용으로 대체 (별도 bridge 불필요)
+- Tasks 10-12 미구현 (compare_strategies, recommend_go_live, MCP 등록)
+- Task 13 미실행 (전체 테스트/lint)
+
+---
+
+## 파일 구조
+
+| 파일 | 유형 | 책임 |
+|------|------|------|
+| `app/mcp_server/tooling/paper_account_registration.py` | 미커밋 변경 | strategy_name 파라미터 노출 (이미 코드 존재) |
+| `app/mcp_server/tooling/paper_journal_bridge.py` | 신규 | compare_strategies, recommend_go_live 구현 |
+| `app/mcp_server/tooling/paper_journal_registration.py` | 신규 | MCP 도구 등록 |
+| `app/mcp_server/tooling/registry.py` | 수정 | paper_journal 등록 추가 |
+| `tests/test_paper_journal_bridge.py` | 신규 | bridge 단위 테스트 |
+
+---
+
+## Task 1: 미커밋 코드 커밋 (paper_account_registration strategy_name)
+
+**Files:**
+- Commit: `app/mcp_server/tooling/paper_account_registration.py` (이미 변경됨)
+
+- [ ] **Step 1: 변경 내용 확인**
+
+Run: `git diff app/mcp_server/tooling/paper_account_registration.py`
+
+확인할 내용:
+- `create_paper_account`에 `strategy_name: str | None = None` 파라미터 추가
+- `service.create_account()`에 `strategy_name=strategy_name` 전달
+- `list_paper_accounts`에 `strategy_name: str | None = None` 파라미터 추가
+- `service.list_accounts()`에 `strategy_name=strategy_name` 전달
+- MCP description에 strategy_name 설명 추가
+
+- [ ] **Step 2: 관련 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_paper_account_tools.py -v`
+Expected: 모두 PASS
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add app/mcp_server/tooling/paper_account_registration.py
+git commit -m "feat(paper): expose strategy_name in create/list paper account MCP tools"
+```
+
+---
+
+## Task 2: compare_strategies 테스트 작성
+
+**Files:**
+- Create: `tests/test_paper_journal_bridge.py`
+
+- [ ] **Step 1: 테스트 파일 생성**
+
+`tests/test_paper_journal_bridge.py` 생성:
+
+```python
+"""Paper Journal Bridge unit tests — compare_strategies, recommend_go_live."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.timezone import now_kst
+from app.models.trade_journal import TradeJournal
+from app.models.trading import InstrumentType
+
+
+def _make_closed_journal(
+    *,
+    symbol: str,
+    account: str,
+    strategy: str | None,
+    account_type: str = "paper",
+    entry_price: float,
+    pnl_pct: float,
+    journal_id: int,
+) -> TradeJournal:
+    j = TradeJournal(
+        symbol=symbol,
+        instrument_type=InstrumentType.equity_kr,
+        thesis="Test thesis",
+        entry_price=Decimal(str(entry_price)),
+        account_type=account_type,
+        account=account,
+        strategy=strategy,
+        status="closed",
+        pnl_pct=Decimal(str(pnl_pct)),
+    )
+    j.id = journal_id
+    j.created_at = now_kst()
+    j.updated_at = now_kst()
+    j.exit_date = now_kst()
+    j.exit_price = Decimal(str(entry_price * (1 + pnl_pct / 100)))
+    return j
+
+
+def _mock_bridge_session(monkeypatch, execute_side_effects: list):
+    """Set up mock session factory for paper_journal_bridge."""
+    from app.mcp_server.tooling import paper_journal_bridge
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(side_effect=execute_side_effects)
+
+    cm = AsyncMock()
+    cm.__aenter__.return_value = mock_session
+    cm.__aexit__.return_value = None
+    factory = MagicMock(return_value=cm)
+    monkeypatch.setattr(paper_journal_bridge, "_session_factory", lambda: factory)
+    return mock_session
+
+
+def _scalars_result(items: list) -> MagicMock:
+    """Build a mock SQLAlchemy result with .scalars().all()."""
+    scalars = MagicMock()
+    scalars.all.return_value = items
+    result = MagicMock()
+    result.scalars.return_value = scalars
+    return result
+
+
+def _scalar_one_result(value) -> MagicMock:
+    """Build a mock SQLAlchemy result with .scalar_one()."""
+    result = MagicMock()
+    result.scalar_one.return_value = value
+    return result
+
+
+class TestCompareStrategies:
+    """compare_strategies 단위 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_closed_only_aggregation(self, monkeypatch):
+        """closed journal 기준으로만 집계. active는 제외."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        closed_win = _make_closed_journal(
+            symbol="005930", account="paper-m", strategy="momentum",
+            entry_price=72000, pnl_pct=5.0, journal_id=1,
+        )
+        closed_loss = _make_closed_journal(
+            symbol="AAPL", account="paper-m", strategy="momentum",
+            entry_price=150, pnl_pct=-3.0, journal_id=2,
+        )
+        # active journal — must be excluded from aggregation
+        active_journal = TradeJournal(
+            symbol="TSLA",
+            instrument_type=InstrumentType.equity_us,
+            thesis="Test",
+            account_type="paper",
+            account="paper-m",
+            strategy="momentum",
+            status="active",
+        )
+        active_journal.id = 3
+        active_journal.created_at = now_kst()
+        active_journal.updated_at = now_kst()
+
+        mock_account = MagicMock()
+        mock_account.id = 1
+        mock_account.name = "paper-m"
+        mock_account.strategy_name = "momentum"
+
+        _mock_bridge_session(monkeypatch, [
+            _scalars_result([mock_account]),                          # accounts
+            _scalars_result([closed_win, closed_loss, active_journal]),  # paper journals
+            _scalars_result([]),                                      # live journals
+        ])
+
+        result = await paper_journal_bridge.compare_strategies(days=30)
+
+        assert result["success"] is True
+        assert len(result["strategies"]) == 1
+        s = result["strategies"][0]
+        assert s["total_trades"] == 2  # active excluded
+        assert s["win_count"] == 1
+        assert s["loss_count"] == 1
+        assert s["win_rate"] == 50.0
+        assert s["total_return_pct"] == 2.0  # 5.0 + (-3.0)
+        assert s["best_trade"]["symbol"] == "005930"
+        assert s["worst_trade"]["symbol"] == "AAPL"
+
+    @pytest.mark.asyncio
+    async def test_strategy_name_filter(self, monkeypatch):
+        """strategy_name 필터가 TradeJournal.strategy 기준으로 적용."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        # Only momentum journals returned (filtered by query)
+        momentum_j = _make_closed_journal(
+            symbol="005930", account="paper-m", strategy="momentum",
+            entry_price=72000, pnl_pct=5.0, journal_id=1,
+        )
+        mock_account = MagicMock()
+        mock_account.id = 1
+        mock_account.name = "paper-m"
+        mock_account.strategy_name = "momentum"
+
+        _mock_bridge_session(monkeypatch, [
+            _scalars_result([mock_account]),
+            _scalars_result([momentum_j]),
+            _scalars_result([]),
+        ])
+
+        result = await paper_journal_bridge.compare_strategies(
+            days=30, strategy_name="momentum"
+        )
+        assert result["success"] is True
+        assert len(result["strategies"]) == 1
+        assert result["strategies"][0]["strategy_name"] == "momentum"
+
+    @pytest.mark.asyncio
+    async def test_include_live_comparison_false(self, monkeypatch):
+        """include_live_comparison=False → live_vs_paper 빈 배열."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        _mock_bridge_session(monkeypatch, [
+            _scalars_result([]),  # accounts
+            _scalars_result([]),  # paper journals
+            # no live query issued
+        ])
+
+        result = await paper_journal_bridge.compare_strategies(
+            days=30, include_live_comparison=False
+        )
+        assert result["success"] is True
+        assert result["live_vs_paper"] == []
+
+    @pytest.mark.asyncio
+    async def test_live_vs_paper_same_symbol(self, monkeypatch):
+        """같은 종목 live/paper closed journal → 비교 결과 생성."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        paper_j = _make_closed_journal(
+            symbol="005930", account="paper-m", strategy="momentum",
+            account_type="paper", entry_price=72000, pnl_pct=5.0, journal_id=1,
+        )
+        live_j = _make_closed_journal(
+            symbol="005930", account="kis-main", strategy=None,
+            account_type="live", entry_price=71000, pnl_pct=3.0, journal_id=2,
+        )
+
+        mock_account = MagicMock()
+        mock_account.id = 1
+        mock_account.name = "paper-m"
+        mock_account.strategy_name = "momentum"
+
+        _mock_bridge_session(monkeypatch, [
+            _scalars_result([mock_account]),
+            _scalars_result([paper_j]),
+            _scalars_result([live_j]),
+        ])
+
+        result = await paper_journal_bridge.compare_strategies(
+            days=30, include_live_comparison=True
+        )
+        assert result["success"] is True
+        assert len(result["live_vs_paper"]) == 1
+        comp = result["live_vs_paper"][0]
+        assert comp["symbol"] == "005930"
+        assert comp["paper_pnl_pct"] == 5.0
+        assert comp["live_pnl_pct"] == 3.0
+        assert comp["delta_pnl_pct"] == pytest.approx(2.0)
+
+    @pytest.mark.asyncio
+    async def test_live_only_symbol_not_in_comparison(self, monkeypatch):
+        """live만 있고 paper 없는 종목은 live_vs_paper에 미포함."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        live_j = _make_closed_journal(
+            symbol="TSLA", account="kis-main", strategy=None,
+            account_type="live", entry_price=200, pnl_pct=10.0, journal_id=1,
+        )
+
+        _mock_bridge_session(monkeypatch, [
+            _scalars_result([]),
+            _scalars_result([]),
+            _scalars_result([live_j]),
+        ])
+
+        result = await paper_journal_bridge.compare_strategies(days=30)
+        assert result["live_vs_paper"] == []
+
+    @pytest.mark.asyncio
+    async def test_empty_strategies_no_error(self, monkeypatch):
+        """paper journal 없으면 빈 strategies 반환."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        _mock_bridge_session(monkeypatch, [
+            _scalars_result([]),
+            _scalars_result([]),
+            _scalars_result([]),
+        ])
+
+        result = await paper_journal_bridge.compare_strategies(days=30)
+        assert result["success"] is True
+        assert result["strategies"] == []
+        assert result["live_vs_paper"] == []
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py::TestCompareStrategies -v`
+Expected: FAIL — `paper_journal_bridge` module not found
+
+---
+
+## Task 3: compare_strategies 구현
+
+**Files:**
+- Create: `app/mcp_server/tooling/paper_journal_bridge.py`
+
+- [ ] **Step 1: paper_journal_bridge.py 생성**
+
+```python
+"""Paper Journal Bridge — 전략 비교 및 실전 전환 추천.
+
+Paper 주문→journal 연동(create/close)은 order_journal.py가 담당한다.
+이 모듈은 journal 데이터를 기반으로 한 분석/추천 기능만 책임진다.
+
+집계 규칙 (고정):
+- 모든 지표(win_rate, total_return_pct, avg_pnl_pct, best/worst_trade)는
+  **closed** journal 기준으로만 계산 (realized performance).
+- active journal은 집계에서 제외.
+- total_return_pct는 closed journal들의 pnl_pct 합산 (realized 기준).
+- 집계 단위는 paper account 기준. strategy_name은 필터/표시 역할.
+- strategy_name 필터는 TradeJournal.strategy 기준 (PaperAccount.strategy_name 아님).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import timedelta
+from decimal import Decimal
+from typing import Any, cast
+
+from sqlalchemy import desc, func as sa_func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.core.timezone import now_kst
+from app.models.paper_trading import PaperAccount
+from app.models.trade_journal import JournalStatus, TradeJournal
+
+logger = logging.getLogger(__name__)
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+async def compare_strategies(
+    days: int = 30,
+    strategy_name: str | None = None,
+    include_live_comparison: bool = True,
+) -> dict[str, Any]:
+    """Compare paper trading strategy performance over a given period.
+
+    Shows per-account/per-strategy metrics such as win rate, realized return,
+    and best/worst trade. All metrics are based on closed journals only.
+    If include_live_comparison=True, also compares same-symbol live vs paper
+    journal outcomes within the same period.
+    """
+    cutoff = now_kst() - timedelta(days=days)
+
+    try:
+        async with _session_factory()() as db:
+            # 1. Paper accounts for metadata
+            acct_stmt = select(PaperAccount).where(PaperAccount.is_active.is_(True))
+            acct_result = await db.execute(acct_stmt)
+            accounts = {a.name: a for a in acct_result.scalars().all()}
+
+            # 2. Paper journals in period
+            paper_filters: list = [
+                TradeJournal.account_type == "paper",
+                TradeJournal.created_at >= cutoff,
+            ]
+            if strategy_name is not None:
+                paper_filters.append(TradeJournal.strategy == strategy_name)
+
+            paper_stmt = (
+                select(TradeJournal)
+                .where(*paper_filters)
+                .order_by(desc(TradeJournal.created_at))
+            )
+            paper_result = await db.execute(paper_stmt)
+            paper_journals = list(paper_result.scalars().all())
+
+            # 3. Aggregate by account (closed only)
+            by_account: dict[str, list[TradeJournal]] = defaultdict(list)
+            for j in paper_journals:
+                if j.status == JournalStatus.closed and j.account:
+                    by_account[j.account].append(j)
+
+            strategies_out: list[dict[str, Any]] = []
+            for account_name, journals in by_account.items():
+                acct = accounts.get(account_name)
+                total = len(journals)
+                pnl_values = [
+                    float(j.pnl_pct) for j in journals if j.pnl_pct is not None
+                ]
+                win_count = sum(1 for v in pnl_values if v > 0)
+                loss_count = total - win_count
+                total_return_pct = round(sum(pnl_values), 2) if pnl_values else 0.0
+                avg_pnl_pct = (
+                    round(total_return_pct / len(pnl_values), 2) if pnl_values else 0.0
+                )
+                win_rate = round(win_count / total * 100, 1) if total > 0 else 0.0
+
+                best = max(journals, key=lambda j: float(j.pnl_pct or 0))
+                worst = min(journals, key=lambda j: float(j.pnl_pct or 0))
+
+                strategies_out.append({
+                    "strategy_name": acct.strategy_name if acct else None,
+                    "account_name": account_name,
+                    "account_id": acct.id if acct else None,
+                    "total_trades": total,
+                    "win_count": win_count,
+                    "loss_count": loss_count,
+                    "win_rate": win_rate,
+                    "total_return_pct": total_return_pct,
+                    "avg_pnl_pct": avg_pnl_pct,
+                    "best_trade": {
+                        "symbol": best.symbol,
+                        "pnl_pct": float(best.pnl_pct) if best.pnl_pct else 0.0,
+                    },
+                    "worst_trade": {
+                        "symbol": worst.symbol,
+                        "pnl_pct": float(worst.pnl_pct) if worst.pnl_pct else 0.0,
+                    },
+                })
+
+            # 4. Live vs paper comparison (most recent closed per symbol)
+            live_vs_paper: list[dict[str, Any]] = []
+            if include_live_comparison:
+                live_stmt = (
+                    select(TradeJournal)
+                    .where(
+                        TradeJournal.account_type == "live",
+                        TradeJournal.status == JournalStatus.closed,
+                        TradeJournal.created_at >= cutoff,
+                    )
+                    .order_by(desc(TradeJournal.created_at))
+                )
+                live_result = await db.execute(live_stmt)
+                live_journals = list(live_result.scalars().all())
+
+                # Most recent closed per symbol
+                live_by_symbol: dict[str, TradeJournal] = {}
+                for j in live_journals:
+                    if j.symbol not in live_by_symbol:
+                        live_by_symbol[j.symbol] = j
+
+                paper_closed = [
+                    j for j in paper_journals if j.status == JournalStatus.closed
+                ]
+                paper_by_symbol: dict[str, TradeJournal] = {}
+                for j in paper_closed:
+                    if j.symbol not in paper_by_symbol:
+                        paper_by_symbol[j.symbol] = j
+
+                for sym in sorted(set(live_by_symbol) & set(paper_by_symbol)):
+                    lj = live_by_symbol[sym]
+                    pj = paper_by_symbol[sym]
+                    l_pnl = float(lj.pnl_pct) if lj.pnl_pct is not None else 0.0
+                    p_pnl = float(pj.pnl_pct) if pj.pnl_pct is not None else 0.0
+                    live_vs_paper.append({
+                        "symbol": sym,
+                        "live_entry_price": (
+                            float(lj.entry_price) if lj.entry_price else None
+                        ),
+                        "live_pnl_pct": l_pnl,
+                        "paper_entry_price": (
+                            float(pj.entry_price) if pj.entry_price else None
+                        ),
+                        "paper_pnl_pct": p_pnl,
+                        "paper_strategy": pj.strategy,
+                        "delta_pnl_pct": round(p_pnl - l_pnl, 4),
+                    })
+
+            return {
+                "success": True,
+                "period_days": days,
+                "strategies": strategies_out,
+                "live_vs_paper": live_vs_paper,
+            }
+    except Exception as exc:
+        logger.exception("compare_strategies failed")
+        return {"success": False, "error": f"compare_strategies failed: {exc}"}
+```
+
+- [ ] **Step 2: 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py::TestCompareStrategies -v`
+Expected: 6 tests PASS
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add app/mcp_server/tooling/paper_journal_bridge.py tests/test_paper_journal_bridge.py
+git commit -m "feat(paper): implement compare_strategies in paper_journal_bridge"
+```
+
+---
+
+## Task 4: recommend_go_live 테스트 작성
+
+**Files:**
+- Modify: `tests/test_paper_journal_bridge.py`
+
+- [ ] **Step 1: recommend_go_live 테스트 추가**
+
+`tests/test_paper_journal_bridge.py`에 추가:
+
+```python
+def _make_simple_closed_journal(*, pnl_pct: float, journal_id: int) -> TradeJournal:
+    j = TradeJournal(
+        symbol=f"SYM{journal_id:03d}",
+        instrument_type=InstrumentType.equity_kr,
+        thesis="Test",
+        entry_price=Decimal("10000"),
+        account_type="paper",
+        account="paper-test",
+        status="closed",
+        pnl_pct=Decimal(str(pnl_pct)),
+    )
+    j.id = journal_id
+    j.created_at = now_kst()
+    j.updated_at = now_kst()
+    return j
+
+
+class TestRecommendGoLive:
+    """recommend_go_live 판정 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_all_criteria_met_go_live(self, monkeypatch):
+        """세 기준 모두 충족 → go_live."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_account = MagicMock()
+        mock_account.name = "paper-test"
+        mock_account.strategy_name = "momentum"
+
+        # 25 trades: 16 wins (3.0%), 9 losses (-2.0%)
+        # win_rate = 64%, total_return = 16*3 + 9*(-2) = 30.0
+        journals = [
+            _make_simple_closed_journal(pnl_pct=3.0, journal_id=i + 1)
+            for i in range(16)
+        ] + [
+            _make_simple_closed_journal(pnl_pct=-2.0, journal_id=i + 17)
+            for i in range(9)
+        ]
+
+        mock_scalars_account = MagicMock()
+        mock_scalars_account.one_or_none.return_value = mock_account
+        account_result = MagicMock()
+        account_result.scalars.return_value = mock_scalars_account
+
+        _mock_bridge_session(monkeypatch, [
+            account_result,
+            _scalars_result(journals),
+            _scalar_one_result(2),  # active_positions count
+        ])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test"
+        )
+        assert result["success"] is True
+        assert result["recommendation"] == "go_live"
+        assert result["all_passed"] is True
+        assert result["criteria"]["min_trades"]["passed"] is True
+        assert result["criteria"]["min_win_rate"]["passed"] is True
+        assert result["criteria"]["min_return_pct"]["passed"] is True
+        assert result["summary"]["total_trades"] == 25
+        assert result["summary"]["active_positions"] == 2
+
+    @pytest.mark.asyncio
+    async def test_insufficient_trades_not_ready(self, monkeypatch):
+        """거래 수 미달 → not_ready."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_account = MagicMock()
+        mock_account.name = "paper-test"
+        mock_account.strategy_name = "test"
+
+        journals = [
+            _make_simple_closed_journal(pnl_pct=5.0, journal_id=i + 1)
+            for i in range(10)
+        ]
+
+        mock_scalars_account = MagicMock()
+        mock_scalars_account.one_or_none.return_value = mock_account
+        account_result = MagicMock()
+        account_result.scalars.return_value = mock_scalars_account
+
+        _mock_bridge_session(monkeypatch, [
+            account_result,
+            _scalars_result(journals),
+            _scalar_one_result(0),
+        ])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test"
+        )
+        assert result["recommendation"] == "not_ready"
+        assert result["criteria"]["min_trades"]["passed"] is False
+        assert result["criteria"]["min_trades"]["actual"] == 10
+        assert result["criteria"]["min_trades"]["required"] == 20
+
+    @pytest.mark.asyncio
+    async def test_low_win_rate_not_ready(self, monkeypatch):
+        """승률 미달 → not_ready."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_account = MagicMock()
+        mock_account.name = "paper-test"
+        mock_account.strategy_name = "test"
+
+        # 20 trades, 5 wins → 25%
+        journals = [
+            _make_simple_closed_journal(pnl_pct=2.0, journal_id=i + 1)
+            for i in range(5)
+        ] + [
+            _make_simple_closed_journal(pnl_pct=-1.0, journal_id=i + 6)
+            for i in range(15)
+        ]
+
+        mock_scalars_account = MagicMock()
+        mock_scalars_account.one_or_none.return_value = mock_account
+        account_result = MagicMock()
+        account_result.scalars.return_value = mock_scalars_account
+
+        _mock_bridge_session(monkeypatch, [
+            account_result,
+            _scalars_result(journals),
+            _scalar_one_result(0),
+        ])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test"
+        )
+        assert result["recommendation"] == "not_ready"
+        assert result["criteria"]["min_win_rate"]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_negative_return_not_ready(self, monkeypatch):
+        """수익률 미달 → not_ready."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_account = MagicMock()
+        mock_account.name = "paper-test"
+        mock_account.strategy_name = "test"
+
+        # 20 trades, 11 wins at 1%, 9 losses at -3% → total = 11 - 27 = -16
+        journals = [
+            _make_simple_closed_journal(pnl_pct=1.0, journal_id=i + 1)
+            for i in range(11)
+        ] + [
+            _make_simple_closed_journal(pnl_pct=-3.0, journal_id=i + 12)
+            for i in range(9)
+        ]
+
+        mock_scalars_account = MagicMock()
+        mock_scalars_account.one_or_none.return_value = mock_account
+        account_result = MagicMock()
+        account_result.scalars.return_value = mock_scalars_account
+
+        _mock_bridge_session(monkeypatch, [
+            account_result,
+            _scalars_result(journals),
+            _scalar_one_result(0),
+        ])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test"
+        )
+        assert result["recommendation"] == "not_ready"
+        assert result["criteria"]["min_return_pct"]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_custom_thresholds(self, monkeypatch):
+        """커스텀 기준값 override."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_account = MagicMock()
+        mock_account.name = "paper-test"
+        mock_account.strategy_name = "test"
+
+        journals = [
+            _make_simple_closed_journal(pnl_pct=1.0, journal_id=i + 1)
+            for i in range(10)
+        ]
+
+        mock_scalars_account = MagicMock()
+        mock_scalars_account.one_or_none.return_value = mock_account
+        account_result = MagicMock()
+        account_result.scalars.return_value = mock_scalars_account
+
+        _mock_bridge_session(monkeypatch, [
+            account_result,
+            _scalars_result(journals),
+            _scalar_one_result(0),
+        ])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test",
+            min_trades=5,
+            min_win_rate=80.0,
+            min_return_pct=5.0,
+        )
+        assert result["recommendation"] == "go_live"
+        assert result["criteria"]["min_trades"]["required"] == 5
+
+    @pytest.mark.asyncio
+    async def test_account_not_found(self, monkeypatch):
+        """존재하지 않는 account → 에러."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_scalars_account = MagicMock()
+        mock_scalars_account.one_or_none.return_value = None
+        account_result = MagicMock()
+        account_result.scalars.return_value = mock_scalars_account
+
+        _mock_bridge_session(monkeypatch, [account_result])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="nonexistent"
+        )
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_active_journals_excluded_from_metrics(self, monkeypatch):
+        """active journal은 집계에서 제외 — closed만 계산."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_account = MagicMock()
+        mock_account.name = "paper-test"
+        mock_account.strategy_name = "test"
+
+        # Query returns closed only (the function queries closed only)
+        # but we verify the count is correct
+        journals = [
+            _make_simple_closed_journal(pnl_pct=5.0, journal_id=i + 1)
+            for i in range(20)
+        ]
+
+        mock_scalars_account = MagicMock()
+        mock_scalars_account.one_or_none.return_value = mock_account
+        account_result = MagicMock()
+        account_result.scalars.return_value = mock_scalars_account
+
+        _mock_bridge_session(monkeypatch, [
+            account_result,
+            _scalars_result(journals),
+            _scalar_one_result(5),  # 5 active positions
+        ])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test"
+        )
+        assert result["summary"]["total_trades"] == 20
+        assert result["summary"]["active_positions"] == 5
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py::TestRecommendGoLive -v`
+Expected: FAIL — `recommend_go_live` not defined
+
+---
+
+## Task 5: recommend_go_live 구현
+
+**Files:**
+- Modify: `app/mcp_server/tooling/paper_journal_bridge.py`
+
+- [ ] **Step 1: recommend_go_live 함수 추가**
+
+`app/mcp_server/tooling/paper_journal_bridge.py`에 추가:
+
+```python
+async def recommend_go_live(
+    account_name: str,
+    min_trades: int = 20,
+    min_win_rate: float = 50.0,
+    min_return_pct: float = 0.0,
+) -> dict[str, Any]:
+    """Evaluate whether a paper trading account meets go-live criteria.
+
+    All metrics are based on **closed** journals only (realized performance).
+    Active positions are shown in summary for reference but excluded from judgment.
+    """
+    try:
+        async with _session_factory()() as db:
+            # 1. Account lookup
+            acct_stmt = select(PaperAccount).where(
+                PaperAccount.name == account_name
+            )
+            acct_result = await db.execute(acct_stmt)
+            account = acct_result.scalars().one_or_none()
+            if account is None:
+                return {
+                    "success": False,
+                    "error": f"Paper account '{account_name}' not found",
+                }
+
+            # 2. Closed journals
+            closed_stmt = (
+                select(TradeJournal)
+                .where(
+                    TradeJournal.account_type == "paper",
+                    TradeJournal.account == account_name,
+                    TradeJournal.status == JournalStatus.closed,
+                )
+                .order_by(desc(TradeJournal.created_at))
+            )
+            closed_result = await db.execute(closed_stmt)
+            closed_journals = list(closed_result.scalars().all())
+
+            # 3. Active positions count (reference only)
+            active_stmt = (
+                select(sa_func.count())
+                .select_from(TradeJournal)
+                .where(
+                    TradeJournal.account_type == "paper",
+                    TradeJournal.account == account_name,
+                    TradeJournal.status == JournalStatus.active,
+                )
+            )
+            active_result = await db.execute(active_stmt)
+            active_positions = active_result.scalar_one()
+
+            # 4. Calculate metrics
+            total_trades = len(closed_journals)
+            pnl_values = [
+                float(j.pnl_pct)
+                for j in closed_journals
+                if j.pnl_pct is not None
+            ]
+            win_count = sum(1 for v in pnl_values if v > 0)
+            loss_count = total_trades - win_count
+            total_return_pct = round(sum(pnl_values), 2) if pnl_values else 0.0
+            win_rate = (
+                round(win_count / total_trades * 100, 1) if total_trades > 0 else 0.0
+            )
+            avg_pnl_pct = (
+                round(total_return_pct / len(pnl_values), 2) if pnl_values else 0.0
+            )
+
+            best_trade = None
+            worst_trade = None
+            if closed_journals:
+                best = max(closed_journals, key=lambda j: float(j.pnl_pct or 0))
+                worst = min(closed_journals, key=lambda j: float(j.pnl_pct or 0))
+                best_trade = {
+                    "symbol": best.symbol,
+                    "pnl_pct": float(best.pnl_pct) if best.pnl_pct else 0.0,
+                }
+                worst_trade = {
+                    "symbol": worst.symbol,
+                    "pnl_pct": float(worst.pnl_pct) if worst.pnl_pct else 0.0,
+                }
+
+            # 5. Criteria check
+            trades_passed = total_trades >= min_trades
+            wr_passed = win_rate >= min_win_rate
+            return_passed = total_return_pct >= min_return_pct
+            all_passed = trades_passed and wr_passed and return_passed
+
+            return {
+                "success": True,
+                "account_name": account_name,
+                "strategy_name": account.strategy_name,
+                "recommendation": "go_live" if all_passed else "not_ready",
+                "criteria": {
+                    "min_trades": {
+                        "required": min_trades,
+                        "actual": total_trades,
+                        "passed": trades_passed,
+                    },
+                    "min_win_rate": {
+                        "required": min_win_rate,
+                        "actual": win_rate,
+                        "passed": wr_passed,
+                    },
+                    "min_return_pct": {
+                        "required": min_return_pct,
+                        "actual": total_return_pct,
+                        "passed": return_passed,
+                    },
+                },
+                "all_passed": all_passed,
+                "summary": {
+                    "total_trades": total_trades,
+                    "win_count": win_count,
+                    "loss_count": loss_count,
+                    "win_rate": win_rate,
+                    "total_return_pct": total_return_pct,
+                    "avg_pnl_pct": avg_pnl_pct,
+                    "best_trade": best_trade,
+                    "worst_trade": worst_trade,
+                    "active_positions": active_positions,
+                },
+            }
+    except Exception as exc:
+        logger.exception("recommend_go_live failed")
+        return {"success": False, "error": f"recommend_go_live failed: {exc}"}
+```
+
+- [ ] **Step 2: 전체 bridge 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py -v`
+Expected: 모두 PASS (TestCompareStrategies 6건 + TestRecommendGoLive 7건)
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add app/mcp_server/tooling/paper_journal_bridge.py tests/test_paper_journal_bridge.py
+git commit -m "feat(paper): implement recommend_go_live in paper_journal_bridge"
+```
+
+---
+
+## Task 6: MCP 등록 — compare_strategies, recommend_go_live
+
+**Files:**
+- Create: `app/mcp_server/tooling/paper_journal_registration.py`
+- Modify: `app/mcp_server/tooling/registry.py`
+- Modify: `tests/test_paper_journal_bridge.py`
+
+- [ ] **Step 1: registration 테스트 작성**
+
+`tests/test_paper_journal_bridge.py`에 추가:
+
+```python
+class TestPaperJournalRegistration:
+    """MCP 도구 등록 확인."""
+
+    def test_tool_names_defined(self):
+        from app.mcp_server.tooling.paper_journal_registration import (
+            PAPER_JOURNAL_TOOL_NAMES,
+        )
+
+        assert "compare_strategies" in PAPER_JOURNAL_TOOL_NAMES
+        assert "recommend_go_live" in PAPER_JOURNAL_TOOL_NAMES
+
+    def test_register_does_not_raise(self):
+        from app.mcp_server.tooling.paper_journal_registration import (
+            register_paper_journal_tools,
+        )
+
+        mock_mcp = MagicMock()
+        mock_mcp.tool.return_value = lambda fn: fn
+        register_paper_journal_tools(mock_mcp)
+        assert mock_mcp.tool.call_count == 2
+```
+
+- [ ] **Step 2: 테스트 실패 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py::TestPaperJournalRegistration -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: paper_journal_registration.py 생성**
+
+`app/mcp_server/tooling/paper_journal_registration.py` 생성:
+
+```python
+"""Paper Journal MCP tool registration — compare_strategies, recommend_go_live."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.mcp_server.tooling.paper_journal_bridge import (
+    compare_strategies,
+    recommend_go_live,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+PAPER_JOURNAL_TOOL_NAMES: set[str] = {
+    "compare_strategies",
+    "recommend_go_live",
+}
+
+
+def register_paper_journal_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="compare_strategies",
+        description=(
+            "Compare paper trading strategy performance over a given period. "
+            "Shows per-account/per-strategy metrics such as win rate, realized return, "
+            "and best/worst trade. All metrics are based on closed journals only. "
+            "If include_live_comparison=True, also compares same-symbol live vs paper "
+            "journal outcomes within the same period."
+        ),
+    )(compare_strategies)
+
+    _ = mcp.tool(
+        name="recommend_go_live",
+        description=(
+            "Evaluate whether a paper trading account meets criteria for live trading. "
+            "Checks total trades, win rate, and realized return against thresholds "
+            "(default: 20 trades, 50% win rate, positive return). "
+            "All metrics are based on closed journals only."
+        ),
+    )(recommend_go_live)
+
+
+__all__ = ["PAPER_JOURNAL_TOOL_NAMES", "register_paper_journal_tools"]
+```
+
+- [ ] **Step 4: registry.py에 등록 추가**
+
+`app/mcp_server/tooling/registry.py` 수정:
+
+import 추가 (paper_account_registration import 아래):
+```python
+from app.mcp_server.tooling.paper_journal_registration import (
+    register_paper_journal_tools,
+)
+```
+
+`register_all_tools` 함수 마지막에 추가:
+```python
+    register_paper_journal_tools(mcp)
+```
+
+- [ ] **Step 5: 테스트 통과 확인**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py::TestPaperJournalRegistration -v`
+Expected: PASS
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add app/mcp_server/tooling/paper_journal_registration.py app/mcp_server/tooling/registry.py tests/test_paper_journal_bridge.py
+git commit -m "feat(paper): register compare_strategies and recommend_go_live MCP tools"
+```
+
+---
+
+## Task 7: 전체 테스트 스위트 + lint
+
+- [ ] **Step 1: 신규 + 기존 관련 테스트 전체 실행**
+
+Run: `uv run pytest tests/test_paper_journal_bridge.py tests/test_mcp_trade_journal.py tests/test_paper_trading_service.py tests/test_paper_account_tools.py tests/test_paper_order_handler.py tests/test_trade_journal_model.py -v`
+Expected: 모두 PASS (기존 106건 + 신규 ~15건)
+
+- [ ] **Step 2: lint 실행**
+
+Run: `make lint`
+Expected: 오류 없음
+
+- [ ] **Step 3: format 실행**
+
+Run: `make format`
+
+- [ ] **Step 4: lint 재확인**
+
+Run: `make lint`
+Expected: 오류 없음
+
+- [ ] **Step 5: 포맷 변경사항 있으면 커밋**
+
+```bash
+git add -A
+git commit -m "style: fix formatting"
+```
+
+(변경사항 없으면 생략)

--- a/docs/superpowers/specs/2026-04-13-paper-strategy-journal-integration-design.md
+++ b/docs/superpowers/specs/2026-04-13-paper-strategy-journal-integration-design.md
@@ -1,0 +1,442 @@
+# Paper Trading 다중 전략 + Trade Journal 연동 설계
+
+## 목표
+
+모의투자 계좌에 전략 태깅을 강화하고, 기존 Trade Journal 시스템과 연동하여
+paper 매매 시 투자 논거(thesis)를 자동 기록하고, 전략 간 성과를 비교하며,
+실전 전환 추천 기준을 제공한다.
+
+## 컨텍스트
+
+- Trade Journal 모델: `app/models/trade_journal.py` (review 스키마)
+- Trade Journal MCP 도구: `app/mcp_server/tooling/trade_journal_tools.py`
+- Paper Trading 서비스: `app/services/paper_trading_service.py`
+- Paper Trading 모델: `app/models/paper_trading.py` (paper 스키마)
+- Paper MCP 도구: `app/mcp_server/tooling/paper_account_registration.py`, `paper_order_handler.py`, `paper_portfolio_handler.py`
+
+## 설계 결정 요약
+
+| 결정 항목 | 선택 | 이유 |
+|-----------|------|------|
+| Journal 저장 방식 | 기존 TradeJournal에 `account_type` 컬럼 추가 | 중복 최소화, 실전/모의 비교 JOIN 용이 |
+| 주문-Journal 연동 | 자동 생성 + paper_trade_id 링크 | 원스텝 기록, 데이터 일관성 |
+| 매도 시 Journal close | FIFO 정책 | 같은 종목 여러 active journal 허용, 오래된 것부터 close |
+| 전략 비교 범위 | 계좌 단위 + 실전 vs 모의 동일 종목 비교 | 원 요구사항 충족 |
+| 실전 전환 기준 | 파라미터로 override 가능한 기본값 | 유연성 확보, 최소 복잡도 |
+| list_paper_accounts | strategy_name 필터만 (그룹핑 없음) | 반환 스키마 변경 없음 |
+| 구현 접근법 | paper_journal_bridge.py 모듈 분리 | SRP 유지, 테스트 용이 |
+
+---
+
+## 1. DB 변경: TradeJournal 모델
+
+### 컬럼 추가
+
+`app/models/trade_journal.py`의 `TradeJournal` 클래스에 2개 컬럼 추가:
+
+```python
+# 실전/모의 구분
+account_type: Mapped[str] = mapped_column(
+    Text, nullable=False, default="live", server_default="live"
+)
+
+# paper.paper_trades 소프트 참조 (스키마가 달라 DB FK 미사용)
+paper_trade_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+```
+
+### 제약 조건 추가
+
+```python
+CheckConstraint(
+    "account_type IN ('live','paper')",
+    name="trade_journals_account_type",
+)
+CheckConstraint(
+    "NOT (account_type = 'live' AND paper_trade_id IS NOT NULL)",
+    name="trade_journals_no_paper_trade_on_live",
+)
+```
+
+### 인덱스 추가
+
+```python
+Index("ix_trade_journals_account_type", "account_type")
+```
+
+### 마이그레이션
+
+- `account_type TEXT NOT NULL DEFAULT 'live'` — 기존 row 전부 `'live'`
+- `paper_trade_id BIGINT NULL`
+- 인덱스 1개, CheckConstraint 2개
+
+---
+
+## 2. Paper Journal Bridge 모듈
+
+### 새 파일: `app/mcp_server/tooling/paper_journal_bridge.py`
+
+paper 주문 결과를 journal 도메인에 반영하는 어댑터 계층.
+주문 체결은 order handler/service가 책임지고, journal create/close/compare/recommend만 담당.
+
+### 2-1. `create_paper_journal()`
+
+paper 매수 주문 체결 후 호출. TradeJournal 레코드 생성.
+
+```python
+async def create_paper_journal(
+    *,
+    symbol: str,
+    instrument_type: str,
+    entry_price: Decimal,
+    quantity: Decimal,
+    amount: Decimal,
+    paper_trade_id: int,
+    paper_account_name: str,
+    thesis: str,
+    strategy: str | None = None,
+    target_price: Decimal | None = None,
+    stop_loss: Decimal | None = None,
+    min_hold_days: int | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
+```
+
+- buy 전용 함수 (side 파라미터 없음)
+- `account_type="paper"`, `account=paper_account_name`
+- `status="active"` (paper는 즉시 체결 — draft 건너뜀)
+- `trade_id=None` (live용), `paper_trade_id=paper_trade_id`
+
+### 2-2. `close_paper_journal()`
+
+paper 매도 주문 체결 후 호출. 해당 종목의 active paper journal을 FIFO로 close.
+
+```python
+async def close_paper_journal(
+    *,
+    symbol: str,
+    exit_price: Decimal,
+    exit_reason: str | None = None,
+    paper_account_name: str,
+) -> dict[str, Any] | None:
+```
+
+- 조회 조건: `symbol + account_type="paper" + account=paper_account_name + status="active"`
+- **FIFO 정책**: 같은 종목에 active journal이 여러 개면 `created_at` 가장 오래된 것부터 close
+- `pnl_pct` 자동 계산, `status="closed"`, `exit_date=now_kst()`
+- journal 없으면 `None` 반환 (에러 아님 — thesis 없이 주문한 경우)
+
+### 2-3. `compare_strategies()`
+
+섹션 4에서 상세 기술.
+
+### 2-4. `recommend_go_live()`
+
+섹션 5에서 상세 기술.
+
+### 호출 흐름
+
+```
+_place_paper_order()
+  ├─ service.execute_order()          # 주문 체결
+  ├─ if thesis and side=="buy":
+  │    create_paper_journal()         # journal 자동 생성
+  └─ if side=="sell":
+       close_paper_journal()          # active journal 자동 close (FIFO)
+```
+
+---
+
+## 3. MCP 도구 변경 (기존 도구 수정)
+
+### 3-1. `create_paper_account` — strategy_name 노출
+
+```python
+async def create_paper_account(
+    name: str,
+    initial_capital: float = 100_000_000.0,
+    initial_capital_usd: float = 0.0,
+    description: str | None = None,
+    strategy_name: str | None = None,    # 추가
+) -> dict[str, Any]:
+```
+
+- 서비스 `create_account()`는 이미 `strategy_name`을 받으므로 pass-through
+- MCP description에 strategy 예시값(daytrading, swing, ai-signal) 포함
+
+### 3-2. `list_paper_accounts` — strategy_name 필터
+
+```python
+async def list_paper_accounts(
+    is_active: bool = True,
+    strategy_name: str | None = None,    # 추가
+) -> dict[str, Any]:
+```
+
+- 반환 형태는 기존 flat list 유지
+- **서비스 레이어**에서 `strategy_name` 필터 처리 (MCP 후처리가 아님)
+
+### 3-3. `place_order` — paper 경로에 thesis/strategy 전달
+
+`_place_paper_order()` 시그니처 확장:
+
+```python
+async def _place_paper_order(
+    *,
+    symbol: str,
+    side: str,
+    order_type: str,
+    quantity: float | None,
+    price: float | None,
+    amount: float | None,
+    dry_run: bool,
+    reason: str,
+    paper_account_name: str | None,
+    # 추가 — journal 연동용 (live/paper 공통 파라미터)
+    thesis: str | None = None,
+    strategy: str | None = None,
+    target_price: float | None = None,
+    stop_loss: float | None = None,
+    min_hold_days: int | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
+```
+
+- 상위 `place_order` MCP 도구에서 위 파라미터를 받음
+- live/paper 공통 파라미터로 취급 (paper만의 예외가 아님)
+- live 경로는 기존 처리 유지, paper 경로에서 bridge 호출
+
+### 3-4. `get_trade_journal` / `save_trade_journal` — account_type 반영
+
+```python
+# get_trade_journal
+account_type: str | None = "live"   # 기본 live만 반환, None이면 전체, "paper"면 paper만
+
+# save_trade_journal
+account_type: str = "live"
+paper_trade_id: int | None = None
+```
+
+**애플리케이션 레벨 검증 (DB constraint와 별도로):**
+- `account_type="live"` + `paper_trade_id` 제공 → 명시적 오류
+- `account_type="paper"` + `trade_id` 제공 → 명시적 오류
+- `account_type="paper"` + `account` 비어있음 → 명시적 오류
+
+### 3-5. `_serialize_journal` 확장
+
+반환 dict에 `account_type`, `paper_trade_id` 추가:
+- live journal: `account_type="live"`, `trade_id=<id>`, `paper_trade_id=None`
+- paper journal: `account_type="paper"`, `trade_id=None`, `paper_trade_id=<id>`
+
+---
+
+## 4. `compare_strategies` MCP 도구
+
+### 시그니처
+
+```python
+async def compare_strategies(
+    days: int = 30,
+    strategy_name: str | None = None,
+    include_live_comparison: bool = True,
+) -> dict[str, Any]:
+```
+
+### 반환 구조
+
+```python
+{
+    "success": True,
+    "period_days": 30,
+    "strategies": [
+        {
+            "strategy_name": "momentum",
+            "account_name": "paper-momentum",
+            "account_id": 1,
+            "total_trades": 15,
+            "win_count": 9,
+            "loss_count": 6,
+            "win_rate": 60.0,
+            "total_return_pct": 5.2,
+            "avg_pnl_pct": 1.8,
+            "best_trade": {"symbol": "005930", "pnl_pct": 8.5},
+            "worst_trade": {"symbol": "AAPL", "pnl_pct": -3.2},
+        },
+    ],
+    "live_vs_paper": [
+        {
+            "symbol": "005930",
+            "live_entry_price": 72000,
+            "live_pnl_pct": 3.5,
+            "paper_entry_price": 71500,
+            "paper_pnl_pct": 5.2,
+            "paper_strategy": "momentum",
+            "delta_pnl_pct": 1.7,
+        },
+    ],
+}
+```
+
+### 집계 기준 (고정 규칙)
+
+1. **strategies 섹션의 모든 지표(total_trades, win_rate, avg_pnl_pct, best/worst_trade)는 closed journal 기준으로만 계산.** active journal은 집계에서 제외.
+2. **`total_return_pct`는 realized 기준.** closed journal들의 `pnl_pct` 합산. 코드 주석과 MCP description에 realized 기준임을 명시.
+3. **집계 단위는 paper account 기준.** `strategy_name`은 필터/표시 역할. 같은 전략명을 여러 계좌가 공유해도 각각 별도 항목.
+4. **`strategy_name` 필터는 `TradeJournal.strategy` 기준.** `PaperAccount.strategy_name`이 아닌 journal의 strategy 필드 사용.
+
+### live_vs_paper 비교 규칙
+
+- 같은 `symbol`에 대해 `account_type="live"`와 `account_type="paper"` closed journal이 모두 존재
+- 지정 기간 내 `created_at` 기준
+- **종목별 최근 1건 비교로 단순화** (정밀 timestamp 매칭 안 함)
+- `include_live_comparison=False`일 때 `live_vs_paper`는 빈 배열 유지 (필드 생략하지 않음)
+
+### MCP description
+
+```
+"Compare paper trading strategy performance over a given period. "
+"Shows per-account/per-strategy metrics such as win rate, realized return, "
+"and best/worst trade. If include_live_comparison=True, also compares "
+"same-symbol live vs paper journal outcomes within the same period."
+```
+
+---
+
+## 5. `recommend_go_live` MCP 도구
+
+### 시그니처
+
+```python
+async def recommend_go_live(
+    account_name: str,
+    min_trades: int = 20,
+    min_win_rate: float = 50.0,
+    min_return_pct: float = 0.0,
+) -> dict[str, Any]:
+```
+
+### 반환 구조
+
+```python
+{
+    "success": True,
+    "account_name": "paper-momentum",
+    "strategy_name": "momentum",
+    "recommendation": "go_live" | "not_ready",
+    "criteria": {
+        "min_trades": {"required": 20, "actual": 25, "passed": True},
+        "min_win_rate": {"required": 50.0, "actual": 64.0, "passed": True},
+        "min_return_pct": {"required": 0.0, "actual": 3.8, "passed": True},
+    },
+    "all_passed": True,
+    "summary": {
+        "total_trades": 25,
+        "win_count": 16,
+        "loss_count": 9,
+        "win_rate": 64.0,
+        "total_return_pct": 3.8,
+        "avg_pnl_pct": 1.2,
+        "best_trade": {"symbol": "005930", "pnl_pct": 8.5},
+        "worst_trade": {"symbol": "AAPL", "pnl_pct": -3.2},
+        "active_positions": 3,
+    },
+}
+```
+
+### 판정 로직
+
+1. `account_name`으로 PaperAccount 조회 → `strategy_name` 가져옴
+2. 해당 계좌의 **closed** journal만 조회 (`account_type="paper"`, `account=account_name`, `status="closed"`)
+3. 세 기준 각각 판정:
+   - `total_trades >= min_trades`
+   - `win_rate >= min_win_rate` (win = `pnl_pct > 0`)
+   - `total_return_pct >= min_return_pct` (closed journal들의 realized pnl_pct 합산)
+4. 세 기준 모두 통과 → `"go_live"`, 아니면 `"not_ready"`
+
+### 설계 원칙
+
+- `compare_strategies`와 동일한 집계 기준: closed journal, realized pnl 기준
+- active position 수는 `summary`에 참고용으로 포함하되 판정에는 미포함
+- `total_return_pct` 계산은 `compare_strategies`와 동일 정의
+
+### MCP description
+
+```
+"Evaluate whether a paper trading account meets criteria for live trading. "
+"Checks total trades, win rate, and realized return against thresholds "
+"(default: 20 trades, 50% win rate, positive return). "
+"All metrics are based on closed journals only."
+```
+
+---
+
+## 6. MCP 등록
+
+새 파일 `app/mcp_server/tooling/paper_journal_registration.py` 생성:
+
+- `compare_strategies` 도구 등록
+- `recommend_go_live` 도구 등록
+
+기존 파일 수정:
+- `paper_account_registration.py`: `create_paper_account`에 `strategy_name`, `list_paper_accounts`에 `strategy_name` 파라미터
+- `paper_order_handler.py`: `_place_paper_order`에 thesis/strategy 파라미터 + bridge 호출
+- `trade_journal_tools.py`: `account_type`, `paper_trade_id` 지원
+- `trade_journal_registration.py`: MCP description 업데이트
+
+---
+
+## 7. 파일 변경 요약
+
+| 파일 | 변경 유형 | 내용 |
+|------|----------|------|
+| `app/models/trade_journal.py` | 수정 | `account_type`, `paper_trade_id` 컬럼, constraints |
+| `alembic/versions/xxx_add_paper_journal_fields.py` | 신규 | 마이그레이션 |
+| `app/mcp_server/tooling/paper_journal_bridge.py` | 신규 | create/close/compare/recommend |
+| `app/mcp_server/tooling/paper_journal_registration.py` | 신규 | compare_strategies, recommend_go_live 등록 |
+| `app/mcp_server/tooling/paper_account_registration.py` | 수정 | strategy_name 파라미터 |
+| `app/mcp_server/tooling/paper_order_handler.py` | 수정 | thesis/strategy 파라미터, bridge 호출 |
+| `app/mcp_server/tooling/trade_journal_tools.py` | 수정 | account_type, paper_trade_id, 검증 |
+| `app/mcp_server/tooling/trade_journal_registration.py` | 수정 | MCP description 업데이트 |
+| `app/services/paper_trading_service.py` | 수정 | list_accounts에 strategy_name 필터 |
+| `tests/test_paper_journal_bridge.py` | 신규 | bridge 단위 테스트 |
+| `tests/test_paper_strategy_integration.py` | 신규 | 전략 계좌 생성→거래→저널→비교 통합 테스트 |
+
+---
+
+## 8. 테스트 계획
+
+### 단위 테스트 (`tests/test_paper_journal_bridge.py`)
+
+**create_paper_journal:**
+- 매수 체결 후 journal 생성, account_type="paper" 확인
+- paper_trade_id 연결 확인
+- thesis 필수값 검증
+
+**close_paper_journal:**
+- 매도 시 active journal close, pnl_pct 자동 계산
+- FIFO 정책: 같은 종목 여러 active journal 중 오래된 것 close
+- journal 없으면 None 반환 (에러 아님)
+
+**compare_strategies:**
+- closed journals만으로 집계 계산
+- active journals가 win_rate/avg_pnl_pct/best/worst_trade에서 제외
+- strategy_name 필터가 TradeJournal.strategy 기준으로 적용
+- include_live_comparison=False → live_vs_paper 빈 배열
+- 같은 기간 내 동일 종목 live/paper journal → 비교 결과 생성
+- live 또는 paper 한쪽만 → live_vs_paper에 미포함
+
+**recommend_go_live:**
+- 세 기준 모두 충족 → "go_live"
+- 거래 수/승률/수익률 각각 미달 → "not_ready"
+- active journal은 집계에서 제외
+- 커스텀 기준값 override 동작
+- 존재하지 않는 account_name → 에러
+
+### MCP 도구 테스트
+
+- `create_paper_account(strategy_name=...)` 정상 동작
+- `list_paper_accounts(strategy_name=...)` 필터 동작
+- `get_trade_journal(account_type="live")` 기본 동작 유지
+- `get_trade_journal(account_type="paper")` paper journal만 반환
+- `save_trade_journal(account_type="live", paper_trade_id=123)` → 오류
+- `save_trade_journal(account_type="paper", account=None)` → 오류
+- `_serialize_journal()`에 account_type, paper_trade_id 포함

--- a/tests/test_mcp_trade_journal.py
+++ b/tests/test_mcp_trade_journal.py
@@ -376,6 +376,44 @@ class TestGetTradeJournalAccountType:
         assert len(result["entries"]) == 1
         assert result["entries"][0]["account_type"] == "live"
 
+    @pytest.mark.asyncio
+    async def test_filter_by_account_name(self, monkeypatch) -> None:
+        """account 필터 검증."""
+        acc_journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Paper",
+            account_type="paper",
+            account="paper-momentum",
+            status="active",
+        )
+        acc_journal.id = 1
+        acc_journal.created_at = now_kst()
+        acc_journal.updated_at = now_kst()
+
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [acc_journal]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.trade_journal_tools._session_factory",
+            lambda: factory,
+        )
+
+        result = await get_trade_journal(
+            account_type="paper", account="paper-momentum"
+        )
+        assert result["success"] is True
+        assert len(result["entries"]) == 1
+        assert result["entries"][0]["account"] == "paper-momentum"
+
 
 class TestUpdateTradeJournal:
     @pytest.mark.asyncio

--- a/tests/test_mcp_trade_journal.py
+++ b/tests/test_mcp_trade_journal.py
@@ -407,9 +407,7 @@ class TestGetTradeJournalAccountType:
             lambda: factory,
         )
 
-        result = await get_trade_journal(
-            account_type="paper", account="paper-momentum"
-        )
+        result = await get_trade_journal(account_type="paper", account="paper-momentum")
         assert result["success"] is True
         assert len(result["entries"]) == 1
         assert result["entries"][0]["account"] == "paper-momentum"
@@ -418,7 +416,6 @@ class TestGetTradeJournalAccountType:
 class TestUpdateTradeJournal:
     @pytest.mark.asyncio
     async def test_update_draft_to_active(self) -> None:
-        from app.mcp_server.tooling.trade_journal_tools import update_trade_journal
 
         now = datetime.now(UTC)
         journal = TradeJournal(
@@ -453,7 +450,6 @@ class TestUpdateTradeJournal:
 
     @pytest.mark.asyncio
     async def test_update_close_with_pnl(self) -> None:
-        from app.mcp_server.tooling.trade_journal_tools import update_trade_journal
 
         now = datetime.now(UTC)
         journal = TradeJournal(
@@ -493,7 +489,6 @@ class TestUpdateTradeJournal:
 
     @pytest.mark.asyncio
     async def test_update_by_symbol_finds_latest_active(self) -> None:
-        from app.mcp_server.tooling.trade_journal_tools import update_trade_journal
 
         now = datetime.now(UTC)
         journal = TradeJournal(
@@ -530,7 +525,6 @@ class TestUpdateTradeJournal:
 
     @pytest.mark.asyncio
     async def test_update_not_found(self) -> None:
-        from app.mcp_server.tooling.trade_journal_tools import update_trade_journal
 
         mock_session = AsyncMock()
         mock_session.get.return_value = None

--- a/tests/test_mcp_trade_journal.py
+++ b/tests/test_mcp_trade_journal.py
@@ -9,6 +9,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.core.timezone import now_kst
+from app.mcp_server.tooling.trade_journal_tools import (
+    _serialize_journal,
+    get_trade_journal,
+    save_trade_journal,
+    update_trade_journal,
+)
 from app.models.trade_journal import TradeJournal
 from app.models.trading import InstrumentType
 
@@ -238,6 +245,136 @@ class TestGetTradeJournal:
         assert result["success"] is True
         assert result["entries"] == []
         assert result["summary"]["total_active"] == 0
+
+
+class TestSerializeJournalNewFields:
+    """account_type, paper_trade_id 직렬화 테스트."""
+
+    def test_serialize_live_journal(self) -> None:
+        journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Test",
+            account_type="live",
+        )
+        journal.id = 1
+        journal.created_at = now_kst()
+        journal.updated_at = now_kst()
+        result = _serialize_journal(journal)
+        assert result["account_type"] == "live"
+        assert result["paper_trade_id"] is None
+
+    def test_serialize_paper_journal(self) -> None:
+        journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Test",
+            account_type="paper",
+            paper_trade_id=42,
+            account="paper-momentum",
+        )
+        journal.id = 2
+        journal.created_at = now_kst()
+        journal.updated_at = now_kst()
+        result = _serialize_journal(journal)
+        assert result["account_type"] == "paper"
+        assert result["paper_trade_id"] == 42
+
+
+class TestSaveTradeJournalAccountType:
+    """save_trade_journal account_type 검증 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_save_with_default_account_type(self, monkeypatch) -> None:
+        """기본 account_type은 'live'."""
+        mock_session = AsyncMock()
+        mock_session.add = MagicMock()
+        mock_session.commit = AsyncMock()
+        mock_session.refresh = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.first.return_value = None
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.trade_journal_tools._session_factory",
+            lambda: factory,
+        )
+
+        result = await save_trade_journal(
+            symbol="005930",
+            thesis="Test thesis",
+        )
+        assert result["success"] is True
+        added_obj = mock_session.add.call_args[0][0]
+        assert added_obj.account_type == "live"
+
+    @pytest.mark.asyncio
+    async def test_save_live_with_paper_trade_id_errors(self, monkeypatch) -> None:
+        """account_type='live' + paper_trade_id 지정 시 오류."""
+        result = await save_trade_journal(
+            symbol="005930",
+            thesis="Test thesis",
+            account_type="live",
+            paper_trade_id=42,
+        )
+        assert result["success"] is False
+        assert "paper_trade_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_save_paper_without_account_errors(self, monkeypatch) -> None:
+        """account_type='paper' + account 비어있으면 오류."""
+        result = await save_trade_journal(
+            symbol="005930",
+            thesis="Test thesis",
+            account_type="paper",
+        )
+        assert result["success"] is False
+        assert "account" in result["error"]
+
+
+class TestGetTradeJournalAccountType:
+    """get_trade_journal account_type 필터 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_default_returns_live_only(self, monkeypatch) -> None:
+        """기본 account_type='live' — 기존 동작 유지."""
+        live_journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Live",
+            account_type="live",
+            status="active",
+        )
+        live_journal.id = 1
+        live_journal.created_at = now_kst()
+        live_journal.updated_at = now_kst()
+
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [live_journal]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute = AsyncMock(return_value=mock_result)
+
+        cm = AsyncMock()
+        cm.__aenter__.return_value = mock_session
+        cm.__aexit__.return_value = None
+        factory = MagicMock(return_value=cm)
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.trade_journal_tools._session_factory",
+            lambda: factory,
+        )
+
+        result = await get_trade_journal()
+        assert result["success"] is True
+        assert len(result["entries"]) == 1
+        assert result["entries"][0]["account_type"] == "live"
 
 
 class TestUpdateTradeJournal:

--- a/tests/test_paper_account_tools.py
+++ b/tests/test_paper_account_tools.py
@@ -135,6 +135,65 @@ async def test_create_paper_account_success(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_paper_account_with_strategy_name(monkeypatch) -> None:
+    db = AsyncMock()
+    db.add = MagicMock()
+
+    async def _refresh(instance):
+        instance.id = 55
+        instance.created_at = None
+        instance.updated_at = None
+
+    db.refresh = AsyncMock(side_effect=_refresh)
+    _patch_session(monkeypatch, db)
+
+    tools = build_tools()
+    result = await tools["create_paper_account"](
+        name="momentum-bot",
+        strategy_name="momentum",
+    )
+
+    assert result["success"] is True
+    assert result["account"]["strategy_name"] == "momentum"
+
+
+@pytest.mark.asyncio
+async def test_list_paper_accounts_with_strategy_filter(monkeypatch) -> None:
+    db = AsyncMock()
+    _patch_session(monkeypatch, db)
+
+    acc = _make_account(id=1, name="momentum-bot", strategy_name="momentum")
+
+    async def _list(is_active, strategy_name):
+        assert strategy_name == "momentum"
+        return [acc]
+
+    with patch(
+        "app.mcp_server.tooling.paper_account_registration.PaperTradingService"
+    ) as svc_cls:
+        svc = svc_cls.return_value
+        svc.list_accounts = AsyncMock(side_effect=_list)
+        svc.get_portfolio_summary = AsyncMock(
+            return_value={
+                "total_invested": Decimal("0"),
+                "total_evaluated": Decimal("100000000"),
+                "total_pnl": Decimal("0"),
+                "total_pnl_pct": Decimal("0.00"),
+                "cash_krw": acc.cash_krw,
+                "cash_usd": acc.cash_usd,
+                "positions_count": 0,
+            }
+        )
+
+        tools = build_tools()
+        result = await tools["list_paper_accounts"](strategy_name="momentum")
+
+    assert result["success"] is True
+    assert len(result["accounts"]) == 1
+    assert result["accounts"][0]["strategy_name"] == "momentum"
+
+
+@pytest.mark.asyncio
 async def test_create_paper_account_duplicate_name(monkeypatch) -> None:
     db = AsyncMock()
     db.add = MagicMock()
@@ -161,7 +220,7 @@ async def test_list_paper_accounts_returns_enriched(monkeypatch) -> None:
         id=2, name="us-bot", cash_krw=Decimal("0"), cash_usd=Decimal("5000")
     )
 
-    async def _list(is_active):
+    async def _list(is_active, strategy_name=None):
         assert is_active is True
         return [acc1, acc2]
 
@@ -218,7 +277,7 @@ async def test_list_paper_accounts_is_active_false(monkeypatch) -> None:
 
     captured: dict[str, object] = {}
 
-    async def _list(is_active):
+    async def _list(is_active, strategy_name=None):
         captured["is_active"] = is_active
         return []
 

--- a/tests/test_paper_journal_bridge.py
+++ b/tests/test_paper_journal_bridge.py
@@ -492,3 +492,25 @@ class TestRecommendGoLive:
         )
         assert result["summary"]["total_trades"] == 20
         assert result["summary"]["active_positions"] == 5
+
+
+class TestPaperJournalRegistration:
+    """MCP 도구 등록 확인."""
+
+    def test_tool_names_defined(self):
+        from app.mcp_server.tooling.paper_journal_registration import (
+            PAPER_JOURNAL_TOOL_NAMES,
+        )
+
+        assert "compare_strategies" in PAPER_JOURNAL_TOOL_NAMES
+        assert "recommend_go_live" in PAPER_JOURNAL_TOOL_NAMES
+
+    def test_register_does_not_raise(self):
+        from app.mcp_server.tooling.paper_journal_registration import (
+            register_paper_journal_tools,
+        )
+
+        mock_mcp = MagicMock()
+        mock_mcp.tool.return_value = lambda fn: fn
+        register_paper_journal_tools(mock_mcp)
+        assert mock_mcp.tool.call_count == 2

--- a/tests/test_paper_journal_bridge.py
+++ b/tests/test_paper_journal_bridge.py
@@ -1,0 +1,243 @@
+"""Paper Journal Bridge unit tests — compare_strategies, recommend_go_live."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.timezone import now_kst
+from app.models.trade_journal import TradeJournal
+from app.models.trading import InstrumentType
+
+
+def _make_closed_journal(
+    *,
+    symbol: str,
+    account: str,
+    strategy: str | None,
+    account_type: str = "paper",
+    entry_price: float,
+    pnl_pct: float,
+    journal_id: int,
+) -> TradeJournal:
+    j = TradeJournal(
+        symbol=symbol,
+        instrument_type=InstrumentType.equity_kr,
+        thesis="Test thesis",
+        entry_price=Decimal(str(entry_price)),
+        account_type=account_type,
+        account=account,
+        strategy=strategy,
+        status="closed",
+        pnl_pct=Decimal(str(pnl_pct)),
+    )
+    j.id = journal_id
+    j.created_at = now_kst()
+    j.updated_at = now_kst()
+    j.exit_date = now_kst()
+    j.exit_price = Decimal(str(entry_price * (1 + pnl_pct / 100)))
+    return j
+
+
+def _mock_bridge_session(monkeypatch, execute_side_effects: list):
+    """Set up mock session factory for paper_journal_bridge."""
+    from app.mcp_server.tooling import paper_journal_bridge
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(side_effect=execute_side_effects)
+
+    cm = AsyncMock()
+    cm.__aenter__.return_value = mock_session
+    cm.__aexit__.return_value = None
+    factory = MagicMock(return_value=cm)
+    monkeypatch.setattr(paper_journal_bridge, "_session_factory", lambda: factory)
+    return mock_session
+
+
+def _scalars_result(items: list) -> MagicMock:
+    """Build a mock SQLAlchemy result with .scalars().all()."""
+    scalars = MagicMock()
+    scalars.all.return_value = items
+    result = MagicMock()
+    result.scalars.return_value = scalars
+    return result
+
+
+def _scalar_one_result(value) -> MagicMock:
+    """Build a mock SQLAlchemy result with .scalar_one()."""
+    result = MagicMock()
+    result.scalar_one.return_value = value
+    return result
+
+
+class TestCompareStrategies:
+    """compare_strategies 단위 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_closed_only_aggregation(self, monkeypatch):
+        """closed journal 기준으로만 집계. active는 제외."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        closed_win = _make_closed_journal(
+            symbol="005930", account="paper-m", strategy="momentum",
+            entry_price=72000, pnl_pct=5.0, journal_id=1,
+        )
+        closed_loss = _make_closed_journal(
+            symbol="AAPL", account="paper-m", strategy="momentum",
+            entry_price=150, pnl_pct=-3.0, journal_id=2,
+        )
+        # active journal — must be excluded from aggregation
+        active_journal = TradeJournal(
+            symbol="TSLA",
+            instrument_type=InstrumentType.equity_us,
+            thesis="Test",
+            account_type="paper",
+            account="paper-m",
+            strategy="momentum",
+            status="active",
+        )
+        active_journal.id = 3
+        active_journal.created_at = now_kst()
+        active_journal.updated_at = now_kst()
+
+        mock_account = MagicMock()
+        mock_account.id = 1
+        mock_account.name = "paper-m"
+        mock_account.strategy_name = "momentum"
+
+        _mock_bridge_session(monkeypatch, [
+            _scalars_result([mock_account]),                          # accounts
+            _scalars_result([closed_win, closed_loss, active_journal]),  # paper journals
+            _scalars_result([]),                                      # live journals
+        ])
+
+        result = await paper_journal_bridge.compare_strategies(days=30)
+
+        assert result["success"] is True
+        assert len(result["strategies"]) == 1
+        s = result["strategies"][0]
+        assert s["total_trades"] == 2  # active excluded
+        assert s["win_count"] == 1
+        assert s["loss_count"] == 1
+        assert s["win_rate"] == 50.0
+        assert s["total_return_pct"] == 2.0  # 5.0 + (-3.0)
+        assert s["best_trade"]["symbol"] == "005930"
+        assert s["worst_trade"]["symbol"] == "AAPL"
+
+    @pytest.mark.asyncio
+    async def test_strategy_name_filter(self, monkeypatch):
+        """strategy_name 필터가 TradeJournal.strategy 기준으로 적용."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        # Only momentum journals returned (filtered by query)
+        momentum_j = _make_closed_journal(
+            symbol="005930", account="paper-m", strategy="momentum",
+            entry_price=72000, pnl_pct=5.0, journal_id=1,
+        )
+        mock_account = MagicMock()
+        mock_account.id = 1
+        mock_account.name = "paper-m"
+        mock_account.strategy_name = "momentum"
+
+        _mock_bridge_session(monkeypatch, [
+            _scalars_result([mock_account]),
+            _scalars_result([momentum_j]),
+            _scalars_result([]),
+        ])
+
+        result = await paper_journal_bridge.compare_strategies(
+            days=30, strategy_name="momentum"
+        )
+        assert result["success"] is True
+        assert len(result["strategies"]) == 1
+        assert result["strategies"][0]["strategy_name"] == "momentum"
+
+    @pytest.mark.asyncio
+    async def test_include_live_comparison_false(self, monkeypatch):
+        """include_live_comparison=False → live_vs_paper 빈 배열."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        _mock_bridge_session(monkeypatch, [
+            _scalars_result([]),  # accounts
+            _scalars_result([]),  # paper journals
+            # no live query issued
+        ])
+
+        result = await paper_journal_bridge.compare_strategies(
+            days=30, include_live_comparison=False
+        )
+        assert result["success"] is True
+        assert result["live_vs_paper"] == []
+
+    @pytest.mark.asyncio
+    async def test_live_vs_paper_same_symbol(self, monkeypatch):
+        """같은 종목 live/paper closed journal → 비교 결과 생성."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        paper_j = _make_closed_journal(
+            symbol="005930", account="paper-m", strategy="momentum",
+            account_type="paper", entry_price=72000, pnl_pct=5.0, journal_id=1,
+        )
+        live_j = _make_closed_journal(
+            symbol="005930", account="kis-main", strategy=None,
+            account_type="live", entry_price=71000, pnl_pct=3.0, journal_id=2,
+        )
+
+        mock_account = MagicMock()
+        mock_account.id = 1
+        mock_account.name = "paper-m"
+        mock_account.strategy_name = "momentum"
+
+        _mock_bridge_session(monkeypatch, [
+            _scalars_result([mock_account]),
+            _scalars_result([paper_j]),
+            _scalars_result([live_j]),
+        ])
+
+        result = await paper_journal_bridge.compare_strategies(
+            days=30, include_live_comparison=True
+        )
+        assert result["success"] is True
+        assert len(result["live_vs_paper"]) == 1
+        comp = result["live_vs_paper"][0]
+        assert comp["symbol"] == "005930"
+        assert comp["paper_pnl_pct"] == 5.0
+        assert comp["live_pnl_pct"] == 3.0
+        assert comp["delta_pnl_pct"] == pytest.approx(2.0)
+
+    @pytest.mark.asyncio
+    async def test_live_only_symbol_not_in_comparison(self, monkeypatch):
+        """live만 있고 paper 없는 종목은 live_vs_paper에 미포함."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        live_j = _make_closed_journal(
+            symbol="TSLA", account="kis-main", strategy=None,
+            account_type="live", entry_price=200, pnl_pct=10.0, journal_id=1,
+        )
+
+        _mock_bridge_session(monkeypatch, [
+            _scalars_result([]),
+            _scalars_result([]),
+            _scalars_result([live_j]),
+        ])
+
+        result = await paper_journal_bridge.compare_strategies(days=30)
+        assert result["live_vs_paper"] == []
+
+    @pytest.mark.asyncio
+    async def test_empty_strategies_no_error(self, monkeypatch):
+        """paper journal 없으면 빈 strategies 반환."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        _mock_bridge_session(monkeypatch, [
+            _scalars_result([]),
+            _scalars_result([]),
+            _scalars_result([]),
+        ])
+
+        result = await paper_journal_bridge.compare_strategies(days=30)
+        assert result["success"] is True
+        assert result["strategies"] == []
+        assert result["live_vs_paper"] == []

--- a/tests/test_paper_journal_bridge.py
+++ b/tests/test_paper_journal_bridge.py
@@ -241,3 +241,254 @@ class TestCompareStrategies:
         assert result["success"] is True
         assert result["strategies"] == []
         assert result["live_vs_paper"] == []
+
+
+def _make_simple_closed_journal(*, pnl_pct: float, journal_id: int) -> TradeJournal:
+    j = TradeJournal(
+        symbol=f"SYM{journal_id:03d}",
+        instrument_type=InstrumentType.equity_kr,
+        thesis="Test",
+        entry_price=Decimal("10000"),
+        account_type="paper",
+        account="paper-test",
+        status="closed",
+        pnl_pct=Decimal(str(pnl_pct)),
+    )
+    j.id = journal_id
+    j.created_at = now_kst()
+    j.updated_at = now_kst()
+    return j
+
+
+class TestRecommendGoLive:
+    """recommend_go_live 판정 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_all_criteria_met_go_live(self, monkeypatch):
+        """세 기준 모두 충족 → go_live."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_account = MagicMock()
+        mock_account.name = "paper-test"
+        mock_account.strategy_name = "momentum"
+
+        # 25 trades: 16 wins (3.0%), 9 losses (-2.0%)
+        # win_rate = 64%, total_return = 16*3 + 9*(-2) = 30.0
+        journals = [
+            _make_simple_closed_journal(pnl_pct=3.0, journal_id=i + 1)
+            for i in range(16)
+        ] + [
+            _make_simple_closed_journal(pnl_pct=-2.0, journal_id=i + 17)
+            for i in range(9)
+        ]
+
+        mock_scalars_account = MagicMock()
+        mock_scalars_account.one_or_none.return_value = mock_account
+        account_result = MagicMock()
+        account_result.scalars.return_value = mock_scalars_account
+
+        _mock_bridge_session(monkeypatch, [
+            account_result,
+            _scalars_result(journals),
+            _scalar_one_result(2),  # active_positions count
+        ])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test"
+        )
+        assert result["success"] is True
+        assert result["recommendation"] == "go_live"
+        assert result["all_passed"] is True
+        assert result["criteria"]["min_trades"]["passed"] is True
+        assert result["criteria"]["min_win_rate"]["passed"] is True
+        assert result["criteria"]["min_return_pct"]["passed"] is True
+        assert result["summary"]["total_trades"] == 25
+        assert result["summary"]["active_positions"] == 2
+
+    @pytest.mark.asyncio
+    async def test_insufficient_trades_not_ready(self, monkeypatch):
+        """거래 수 미달 → not_ready."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_account = MagicMock()
+        mock_account.name = "paper-test"
+        mock_account.strategy_name = "test"
+
+        journals = [
+            _make_simple_closed_journal(pnl_pct=5.0, journal_id=i + 1)
+            for i in range(10)
+        ]
+
+        mock_scalars_account = MagicMock()
+        mock_scalars_account.one_or_none.return_value = mock_account
+        account_result = MagicMock()
+        account_result.scalars.return_value = mock_scalars_account
+
+        _mock_bridge_session(monkeypatch, [
+            account_result,
+            _scalars_result(journals),
+            _scalar_one_result(0),
+        ])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test"
+        )
+        assert result["recommendation"] == "not_ready"
+        assert result["criteria"]["min_trades"]["passed"] is False
+        assert result["criteria"]["min_trades"]["actual"] == 10
+        assert result["criteria"]["min_trades"]["required"] == 20
+
+    @pytest.mark.asyncio
+    async def test_low_win_rate_not_ready(self, monkeypatch):
+        """승률 미달 → not_ready."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_account = MagicMock()
+        mock_account.name = "paper-test"
+        mock_account.strategy_name = "test"
+
+        # 20 trades, 5 wins → 25%
+        journals = [
+            _make_simple_closed_journal(pnl_pct=2.0, journal_id=i + 1)
+            for i in range(5)
+        ] + [
+            _make_simple_closed_journal(pnl_pct=-1.0, journal_id=i + 6)
+            for i in range(15)
+        ]
+
+        mock_scalars_account = MagicMock()
+        mock_scalars_account.one_or_none.return_value = mock_account
+        account_result = MagicMock()
+        account_result.scalars.return_value = mock_scalars_account
+
+        _mock_bridge_session(monkeypatch, [
+            account_result,
+            _scalars_result(journals),
+            _scalar_one_result(0),
+        ])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test"
+        )
+        assert result["recommendation"] == "not_ready"
+        assert result["criteria"]["min_win_rate"]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_negative_return_not_ready(self, monkeypatch):
+        """수익률 미달 → not_ready."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_account = MagicMock()
+        mock_account.name = "paper-test"
+        mock_account.strategy_name = "test"
+
+        # 20 trades, 11 wins at 1%, 9 losses at -3% → total = 11 - 27 = -16
+        journals = [
+            _make_simple_closed_journal(pnl_pct=1.0, journal_id=i + 1)
+            for i in range(11)
+        ] + [
+            _make_simple_closed_journal(pnl_pct=-3.0, journal_id=i + 12)
+            for i in range(9)
+        ]
+
+        mock_scalars_account = MagicMock()
+        mock_scalars_account.one_or_none.return_value = mock_account
+        account_result = MagicMock()
+        account_result.scalars.return_value = mock_scalars_account
+
+        _mock_bridge_session(monkeypatch, [
+            account_result,
+            _scalars_result(journals),
+            _scalar_one_result(0),
+        ])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test"
+        )
+        assert result["recommendation"] == "not_ready"
+        assert result["criteria"]["min_return_pct"]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_custom_thresholds(self, monkeypatch):
+        """커스텀 기준값 override."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_account = MagicMock()
+        mock_account.name = "paper-test"
+        mock_account.strategy_name = "test"
+
+        journals = [
+            _make_simple_closed_journal(pnl_pct=1.0, journal_id=i + 1)
+            for i in range(10)
+        ]
+
+        mock_scalars_account = MagicMock()
+        mock_scalars_account.one_or_none.return_value = mock_account
+        account_result = MagicMock()
+        account_result.scalars.return_value = mock_scalars_account
+
+        _mock_bridge_session(monkeypatch, [
+            account_result,
+            _scalars_result(journals),
+            _scalar_one_result(0),
+        ])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test",
+            min_trades=5,
+            min_win_rate=80.0,
+            min_return_pct=5.0,
+        )
+        assert result["recommendation"] == "go_live"
+        assert result["criteria"]["min_trades"]["required"] == 5
+
+    @pytest.mark.asyncio
+    async def test_account_not_found(self, monkeypatch):
+        """존재하지 않는 account → 에러."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_scalars_account = MagicMock()
+        mock_scalars_account.one_or_none.return_value = None
+        account_result = MagicMock()
+        account_result.scalars.return_value = mock_scalars_account
+
+        _mock_bridge_session(monkeypatch, [account_result])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="nonexistent"
+        )
+        assert result["success"] is False
+        assert "not found" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_active_journals_excluded_from_metrics(self, monkeypatch):
+        """active journal은 집계에서 제외 — closed만 계산."""
+        from app.mcp_server.tooling import paper_journal_bridge
+
+        mock_account = MagicMock()
+        mock_account.name = "paper-test"
+        mock_account.strategy_name = "test"
+
+        # Query returns closed only (the function queries closed only)
+        # but we verify the count is correct
+        journals = [
+            _make_simple_closed_journal(pnl_pct=5.0, journal_id=i + 1)
+            for i in range(20)
+        ]
+
+        mock_scalars_account = MagicMock()
+        mock_scalars_account.one_or_none.return_value = mock_account
+        account_result = MagicMock()
+        account_result.scalars.return_value = mock_scalars_account
+
+        _mock_bridge_session(monkeypatch, [
+            account_result,
+            _scalars_result(journals),
+            _scalar_one_result(5),  # 5 active positions
+        ])
+
+        result = await paper_journal_bridge.recommend_go_live(
+            account_name="paper-test"
+        )
+        assert result["summary"]["total_trades"] == 20
+        assert result["summary"]["active_positions"] == 5

--- a/tests/test_paper_journal_bridge.py
+++ b/tests/test_paper_journal_bridge.py
@@ -81,12 +81,20 @@ class TestCompareStrategies:
         from app.mcp_server.tooling import paper_journal_bridge
 
         closed_win = _make_closed_journal(
-            symbol="005930", account="paper-m", strategy="momentum",
-            entry_price=72000, pnl_pct=5.0, journal_id=1,
+            symbol="005930",
+            account="paper-m",
+            strategy="momentum",
+            entry_price=72000,
+            pnl_pct=5.0,
+            journal_id=1,
         )
         closed_loss = _make_closed_journal(
-            symbol="AAPL", account="paper-m", strategy="momentum",
-            entry_price=150, pnl_pct=-3.0, journal_id=2,
+            symbol="AAPL",
+            account="paper-m",
+            strategy="momentum",
+            entry_price=150,
+            pnl_pct=-3.0,
+            journal_id=2,
         )
         # active journal — must be excluded from aggregation
         active_journal = TradeJournal(
@@ -107,11 +115,16 @@ class TestCompareStrategies:
         mock_account.name = "paper-m"
         mock_account.strategy_name = "momentum"
 
-        _mock_bridge_session(monkeypatch, [
-            _scalars_result([mock_account]),                          # accounts
-            _scalars_result([closed_win, closed_loss, active_journal]),  # paper journals
-            _scalars_result([]),                                      # live journals
-        ])
+        _mock_bridge_session(
+            monkeypatch,
+            [
+                _scalars_result([mock_account]),  # accounts
+                _scalars_result(
+                    [closed_win, closed_loss, active_journal]
+                ),  # paper journals
+                _scalars_result([]),  # live journals
+            ],
+        )
 
         result = await paper_journal_bridge.compare_strategies(days=30)
 
@@ -133,19 +146,26 @@ class TestCompareStrategies:
 
         # Only momentum journals returned (filtered by query)
         momentum_j = _make_closed_journal(
-            symbol="005930", account="paper-m", strategy="momentum",
-            entry_price=72000, pnl_pct=5.0, journal_id=1,
+            symbol="005930",
+            account="paper-m",
+            strategy="momentum",
+            entry_price=72000,
+            pnl_pct=5.0,
+            journal_id=1,
         )
         mock_account = MagicMock()
         mock_account.id = 1
         mock_account.name = "paper-m"
         mock_account.strategy_name = "momentum"
 
-        _mock_bridge_session(monkeypatch, [
-            _scalars_result([mock_account]),
-            _scalars_result([momentum_j]),
-            _scalars_result([]),
-        ])
+        _mock_bridge_session(
+            monkeypatch,
+            [
+                _scalars_result([mock_account]),
+                _scalars_result([momentum_j]),
+                _scalars_result([]),
+            ],
+        )
 
         result = await paper_journal_bridge.compare_strategies(
             days=30, strategy_name="momentum"
@@ -159,11 +179,14 @@ class TestCompareStrategies:
         """include_live_comparison=False → live_vs_paper 빈 배열."""
         from app.mcp_server.tooling import paper_journal_bridge
 
-        _mock_bridge_session(monkeypatch, [
-            _scalars_result([]),  # accounts
-            _scalars_result([]),  # paper journals
-            # no live query issued
-        ])
+        _mock_bridge_session(
+            monkeypatch,
+            [
+                _scalars_result([]),  # accounts
+                _scalars_result([]),  # paper journals
+                # no live query issued
+            ],
+        )
 
         result = await paper_journal_bridge.compare_strategies(
             days=30, include_live_comparison=False
@@ -177,12 +200,22 @@ class TestCompareStrategies:
         from app.mcp_server.tooling import paper_journal_bridge
 
         paper_j = _make_closed_journal(
-            symbol="005930", account="paper-m", strategy="momentum",
-            account_type="paper", entry_price=72000, pnl_pct=5.0, journal_id=1,
+            symbol="005930",
+            account="paper-m",
+            strategy="momentum",
+            account_type="paper",
+            entry_price=72000,
+            pnl_pct=5.0,
+            journal_id=1,
         )
         live_j = _make_closed_journal(
-            symbol="005930", account="kis-main", strategy=None,
-            account_type="live", entry_price=71000, pnl_pct=3.0, journal_id=2,
+            symbol="005930",
+            account="kis-main",
+            strategy=None,
+            account_type="live",
+            entry_price=71000,
+            pnl_pct=3.0,
+            journal_id=2,
         )
 
         mock_account = MagicMock()
@@ -190,11 +223,14 @@ class TestCompareStrategies:
         mock_account.name = "paper-m"
         mock_account.strategy_name = "momentum"
 
-        _mock_bridge_session(monkeypatch, [
-            _scalars_result([mock_account]),
-            _scalars_result([paper_j]),
-            _scalars_result([live_j]),
-        ])
+        _mock_bridge_session(
+            monkeypatch,
+            [
+                _scalars_result([mock_account]),
+                _scalars_result([paper_j]),
+                _scalars_result([live_j]),
+            ],
+        )
 
         result = await paper_journal_bridge.compare_strategies(
             days=30, include_live_comparison=True
@@ -213,15 +249,23 @@ class TestCompareStrategies:
         from app.mcp_server.tooling import paper_journal_bridge
 
         live_j = _make_closed_journal(
-            symbol="TSLA", account="kis-main", strategy=None,
-            account_type="live", entry_price=200, pnl_pct=10.0, journal_id=1,
+            symbol="TSLA",
+            account="kis-main",
+            strategy=None,
+            account_type="live",
+            entry_price=200,
+            pnl_pct=10.0,
+            journal_id=1,
         )
 
-        _mock_bridge_session(monkeypatch, [
-            _scalars_result([]),
-            _scalars_result([]),
-            _scalars_result([live_j]),
-        ])
+        _mock_bridge_session(
+            monkeypatch,
+            [
+                _scalars_result([]),
+                _scalars_result([]),
+                _scalars_result([live_j]),
+            ],
+        )
 
         result = await paper_journal_bridge.compare_strategies(days=30)
         assert result["live_vs_paper"] == []
@@ -231,11 +275,14 @@ class TestCompareStrategies:
         """paper journal 없으면 빈 strategies 반환."""
         from app.mcp_server.tooling import paper_journal_bridge
 
-        _mock_bridge_session(monkeypatch, [
-            _scalars_result([]),
-            _scalars_result([]),
-            _scalars_result([]),
-        ])
+        _mock_bridge_session(
+            monkeypatch,
+            [
+                _scalars_result([]),
+                _scalars_result([]),
+                _scalars_result([]),
+            ],
+        )
 
         result = await paper_journal_bridge.compare_strategies(days=30)
         assert result["success"] is True
@@ -287,15 +334,16 @@ class TestRecommendGoLive:
         account_result = MagicMock()
         account_result.scalars.return_value = mock_scalars_account
 
-        _mock_bridge_session(monkeypatch, [
-            account_result,
-            _scalars_result(journals),
-            _scalar_one_result(2),  # active_positions count
-        ])
-
-        result = await paper_journal_bridge.recommend_go_live(
-            account_name="paper-test"
+        _mock_bridge_session(
+            monkeypatch,
+            [
+                account_result,
+                _scalars_result(journals),
+                _scalar_one_result(2),  # active_positions count
+            ],
         )
+
+        result = await paper_journal_bridge.recommend_go_live(account_name="paper-test")
         assert result["success"] is True
         assert result["recommendation"] == "go_live"
         assert result["all_passed"] is True
@@ -324,15 +372,16 @@ class TestRecommendGoLive:
         account_result = MagicMock()
         account_result.scalars.return_value = mock_scalars_account
 
-        _mock_bridge_session(monkeypatch, [
-            account_result,
-            _scalars_result(journals),
-            _scalar_one_result(0),
-        ])
-
-        result = await paper_journal_bridge.recommend_go_live(
-            account_name="paper-test"
+        _mock_bridge_session(
+            monkeypatch,
+            [
+                account_result,
+                _scalars_result(journals),
+                _scalar_one_result(0),
+            ],
         )
+
+        result = await paper_journal_bridge.recommend_go_live(account_name="paper-test")
         assert result["recommendation"] == "not_ready"
         assert result["criteria"]["min_trades"]["passed"] is False
         assert result["criteria"]["min_trades"]["actual"] == 10
@@ -349,8 +398,7 @@ class TestRecommendGoLive:
 
         # 20 trades, 5 wins → 25%
         journals = [
-            _make_simple_closed_journal(pnl_pct=2.0, journal_id=i + 1)
-            for i in range(5)
+            _make_simple_closed_journal(pnl_pct=2.0, journal_id=i + 1) for i in range(5)
         ] + [
             _make_simple_closed_journal(pnl_pct=-1.0, journal_id=i + 6)
             for i in range(15)
@@ -361,15 +409,16 @@ class TestRecommendGoLive:
         account_result = MagicMock()
         account_result.scalars.return_value = mock_scalars_account
 
-        _mock_bridge_session(monkeypatch, [
-            account_result,
-            _scalars_result(journals),
-            _scalar_one_result(0),
-        ])
-
-        result = await paper_journal_bridge.recommend_go_live(
-            account_name="paper-test"
+        _mock_bridge_session(
+            monkeypatch,
+            [
+                account_result,
+                _scalars_result(journals),
+                _scalar_one_result(0),
+            ],
         )
+
+        result = await paper_journal_bridge.recommend_go_live(account_name="paper-test")
         assert result["recommendation"] == "not_ready"
         assert result["criteria"]["min_win_rate"]["passed"] is False
 
@@ -396,15 +445,16 @@ class TestRecommendGoLive:
         account_result = MagicMock()
         account_result.scalars.return_value = mock_scalars_account
 
-        _mock_bridge_session(monkeypatch, [
-            account_result,
-            _scalars_result(journals),
-            _scalar_one_result(0),
-        ])
-
-        result = await paper_journal_bridge.recommend_go_live(
-            account_name="paper-test"
+        _mock_bridge_session(
+            monkeypatch,
+            [
+                account_result,
+                _scalars_result(journals),
+                _scalar_one_result(0),
+            ],
         )
+
+        result = await paper_journal_bridge.recommend_go_live(account_name="paper-test")
         assert result["recommendation"] == "not_ready"
         assert result["criteria"]["min_return_pct"]["passed"] is False
 
@@ -427,11 +477,14 @@ class TestRecommendGoLive:
         account_result = MagicMock()
         account_result.scalars.return_value = mock_scalars_account
 
-        _mock_bridge_session(monkeypatch, [
-            account_result,
-            _scalars_result(journals),
-            _scalar_one_result(0),
-        ])
+        _mock_bridge_session(
+            monkeypatch,
+            [
+                account_result,
+                _scalars_result(journals),
+                _scalar_one_result(0),
+            ],
+        )
 
         result = await paper_journal_bridge.recommend_go_live(
             account_name="paper-test",
@@ -481,15 +534,16 @@ class TestRecommendGoLive:
         account_result = MagicMock()
         account_result.scalars.return_value = mock_scalars_account
 
-        _mock_bridge_session(monkeypatch, [
-            account_result,
-            _scalars_result(journals),
-            _scalar_one_result(5),  # 5 active positions
-        ])
-
-        result = await paper_journal_bridge.recommend_go_live(
-            account_name="paper-test"
+        _mock_bridge_session(
+            monkeypatch,
+            [
+                account_result,
+                _scalars_result(journals),
+                _scalar_one_result(5),  # 5 active positions
+            ],
         )
+
+        result = await paper_journal_bridge.recommend_go_live(account_name="paper-test")
         assert result["summary"]["total_trades"] == 20
         assert result["summary"]["active_positions"] == 5
 

--- a/tests/test_paper_order_handler.py
+++ b/tests/test_paper_order_handler.py
@@ -253,6 +253,8 @@ class TestPlacePaperOrderExecute:
                 amount=None,
                 dry_run=False,
                 reason="demo",
+                thesis="Test thesis",
+                strategy="Test strategy",
                 paper_account_name=None,
             )
 
@@ -302,6 +304,8 @@ class TestPlacePaperOrderExecute:
                 amount=None,
                 dry_run=False,
                 reason="",
+                thesis="Test thesis",
+                strategy="Test strategy",
                 paper_account_name=None,
             )
 

--- a/tests/test_paper_trading_service.py
+++ b/tests/test_paper_trading_service.py
@@ -756,3 +756,59 @@ class TestPortfolioSummary:
         assert summary["total_pnl"] == Decimal("0")
         assert summary["total_pnl_pct"] is None
         assert summary["positions_count"] == 0
+
+
+class TestListAccountsStrategyFilter:
+    """list_accounts strategy_name 필터 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_filter_by_strategy_name(self, mock_db) -> None:
+        service = PaperTradingService(mock_db)
+        momentum_account = PaperAccount(
+            name="paper-momentum",
+            initial_capital=Decimal("100000000"),
+            cash_krw=Decimal("100000000"),
+            strategy_name="momentum",
+            is_active=True,
+        )
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [momentum_account]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        accounts = await service.list_accounts(
+            is_active=True, strategy_name="momentum"
+        )
+        assert len(accounts) == 1
+        assert accounts[0].strategy_name == "momentum"
+
+    @pytest.mark.asyncio
+    async def test_no_filter_returns_all(self, mock_db) -> None:
+        service = PaperTradingService(mock_db)
+        accounts_data = [
+            PaperAccount(
+                name="a",
+                initial_capital=Decimal("100000000"),
+                cash_krw=Decimal("100000000"),
+                strategy_name="momentum",
+                is_active=True,
+            ),
+            PaperAccount(
+                name="b",
+                initial_capital=Decimal("100000000"),
+                cash_krw=Decimal("100000000"),
+                strategy_name=None,
+                is_active=True,
+            ),
+        ]
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = accounts_data
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        accounts = await service.list_accounts(is_active=True)
+        assert len(accounts) == 2

--- a/tests/test_paper_trading_service.py
+++ b/tests/test_paper_trading_service.py
@@ -162,7 +162,7 @@ class TestFetchCurrentPrice:
     @pytest.mark.asyncio
     async def test_fetch_equity_kr_uses_kis_quote(self, service, monkeypatch):
         monkeypatch.setattr(
-            "app.services.paper_trading_service._fetch_quote_equity_kr",
+            "app.mcp_server.tooling.market_data_quotes._fetch_quote_equity_kr",
             AsyncMock(return_value={"price": 70000.0}),
         )
         price = await service._fetch_current_price("005930", "equity_kr")
@@ -171,7 +171,7 @@ class TestFetchCurrentPrice:
     @pytest.mark.asyncio
     async def test_fetch_equity_us_uses_yahoo_quote(self, service, monkeypatch):
         monkeypatch.setattr(
-            "app.services.paper_trading_service._fetch_quote_equity_us",
+            "app.mcp_server.tooling.market_data_quotes._fetch_quote_equity_us",
             AsyncMock(return_value={"price": 190.5}),
         )
         price = await service._fetch_current_price("AAPL", "equity_us")

--- a/tests/test_paper_trading_service.py
+++ b/tests/test_paper_trading_service.py
@@ -778,9 +778,7 @@ class TestListAccountsStrategyFilter:
         mock_result.scalars.return_value = mock_scalars
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        accounts = await service.list_accounts(
-            is_active=True, strategy_name="momentum"
-        )
+        accounts = await service.list_accounts(is_active=True, strategy_name="momentum")
         assert len(accounts) == 1
         assert accounts[0].strategy_name == "momentum"
 

--- a/tests/test_trade_journal_model.py
+++ b/tests/test_trade_journal_model.py
@@ -71,3 +71,35 @@ class TestTradeJournalModel:
     def test_table_args(self) -> None:
         assert TradeJournal.__table_args__[-1] == {"schema": "review"}
         assert TradeJournal.__tablename__ == "trade_journals"
+
+
+class TestAccountTypeField:
+    """account_type 및 paper_trade_id 필드 테스트."""
+
+    def test_default_account_type_is_live(self) -> None:
+        journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Test thesis",
+        )
+        assert journal.account_type == "live"
+
+    def test_paper_account_type(self) -> None:
+        journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Test thesis",
+            account_type="paper",
+            paper_trade_id=42,
+            account="paper-momentum",
+        )
+        assert journal.account_type == "paper"
+        assert journal.paper_trade_id == 42
+
+    def test_live_journal_paper_trade_id_is_none(self) -> None:
+        journal = TradeJournal(
+            symbol="005930",
+            instrument_type=InstrumentType.equity_kr,
+            thesis="Test thesis",
+        )
+        assert journal.paper_trade_id is None


### PR DESCRIPTION
## Summary
- TradeJournal 모델에 `account_type`/`paper_trade_id` 컬럼 추가 — 실전/모의 journal 통합 저장, DB 레벨 cross-type 제약
- Paper 매수 시 thesis 제공하면 trade journal 자동 생성 (status=active), 매도 시 FIFO 자동 close
- `compare_strategies` MCP 도구 — paper 전략 간 성과 비교 + 실전 vs 모의 동일 종목 비교
- `recommend_go_live` MCP 도구 — 모의 성과 기준 실전 전환 추천 (거래 수/승률/수익률)
- `create_paper_account`/`list_paper_accounts`에 strategy_name 파라미터 노출

## Key Design Decisions
- 별도 PaperTradeJournal 모델 대신 기존 `review.trade_journals`에 `account_type` 컬럼 추가 (통합 저장 + 비교 용이)
- Journal create/close는 기존 `order_journal.py` 재사용, compare/recommend만 새 `paper_journal_bridge.py`에 구현
- Paper 매수 시 thesis는 optional — 없으면 journal 생성 건너뛰고 주문만 실행
- 모든 집계 지표(win_rate, return, best/worst)는 closed journal 기준 (realized only)
- `strategy_name` 필터는 서비스 레이어에서 처리

## Test plan
- [ ] 121 unit tests passing (paper journal bridge, trade journal, paper trading service, paper account tools, paper order handler, trade journal model)
- [ ] `make lint` 통과 (ruff check, ruff format, ty check)
- [ ] Paper 매수 thesis 없이 주문 → journal 미생성, 주문 정상 실행 확인
- [ ] Paper 매수 thesis 포함 → journal 자동 생성 (status=active, trade_id=None) 확인
- [ ] Paper 매도 → FIFO journal close + pnl_pct 자동 계산 확인
- [ ] `compare_strategies` — closed only 집계, live vs paper 비교 확인
- [ ] `recommend_go_live` — 기준 판정 go_live/not_ready 확인
- [ ] DB migration: `uv run alembic upgrade head` 정상 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Paper trading journals now integrated with strategy tracking; journals support live and paper account types.
  * New analysis tools: compare strategy performance across paper accounts and receive go-live recommendations based on trading metrics.
  * Paper accounts can be tagged with strategy names for organized tracking and filtering.

* **Enhancements**
  * Trade journals now filterable by account type and account name, improving organization and querying.
  * Paper order execution now captures and links journal metadata (thesis, strategy, targets, holds).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->