### PR TITLE
feat: deployment pipeline docs & MCP health check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,30 @@ DB Tables:
 - Upbit 심볼/마켓 해석도 DB 테이블(`upbit_symbol_universe`)을 단일 소스로 사용
 - 배포/마이그레이션 직후 심볼 유니버스 sync 스크립트 실행이 필요
 
+## 브랜치 & PR 워크플로우
+
+### 브랜치 보호
+- **main**, **production** 브랜치는 보호됨 — 직접 push 금지
+- 모든 코드 변경은 Pull Request를 통해 머지
+
+### 브랜치 역할
+- **main**: 개발 브랜치 (모든 PR의 base)
+- **production**: 배포 브랜치 (GHCR 이미지 빌드 트리거)
+
+### 브랜치 네이밍
+```
+feature/<task-id>-<설명>     # 새 기능 (예: feature/ROB-16-branch-protection)
+fix/<task-id>-<설명>         # 버그 수정
+chore/<설명>                 # 유지보수
+```
+
+### 워크플로우
+1. `main` 브랜치에서 feature branch 생성
+2. 코드 변경 후 커밋 (`Co-Authored-By: Paperclip <noreply@paperclip.ing>`)
+3. PR 생성 (base: `main`)
+4. 리뷰 후 머지
+5. 배포 시 `main` → `production` 머지
+
 ## 주요 워크플로우
 
 ### 1. 새로운 서비스 분석기 추가

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -2,6 +2,44 @@
 
 이 문서는 `docker-compose.prod.yml` 기반 프로덕션 배포 절차를 설명합니다.
 
+## 배포 파이프라인 개요
+
+```
+feature branch → (PR) → main → (merge) → production → (CI: deploy.yml) → GHCR → (서버) → deploy.sh
+```
+
+- **main**: 개발 브랜치 (모든 PR의 base)
+- **production**: 배포 브랜치 (GHCR 이미지 빌드 트리거)
+
+| 단계 | 트리거 | 자동화 |
+|------|--------|--------|
+| feature → main | PR 머지 | 수동 (리뷰 필수) |
+| main → production | 브랜치 머지 | 수동 (`git merge main`) |
+| production → GHCR | push to `production` | **자동** (GitHub Actions `deploy.yml`) |
+| GHCR → 서버 배포 | 이미지 pull + restart | 수동 (`scripts/deploy.sh`) |
+
+### 전체 배포 절차 (main 머지 후)
+
+```bash
+# 1. production 브랜치에 main 머지
+git checkout production
+git pull origin production
+git merge main
+git push origin production
+
+# 2. GitHub Actions 빌드 완료 대기 (약 5-10분)
+#    확인: https://github.com/<repo>/actions/workflows/deploy.yml
+
+# 3. 서버에서 배포 실행
+cd /home/mgh3326/auto_trader
+scripts/deploy.sh --auto-migrate
+
+# 4. 서비스 상태 확인
+docker compose --env-file .env.prod -f docker-compose.prod.yml ps
+curl http://localhost:8000/healthz
+curl http://localhost:8765/mcp
+```
+
 ## 1. 사전 준비
 
 - Docker / Docker Compose 설치
@@ -91,7 +129,12 @@ docker compose -f docker-compose.n8n.yml logs -f  # n8n
 ## 6. 업데이트 절차
 
 ```bash
-git pull origin production
+# 권장: 배포 스크립트 사용
+scripts/deploy.sh                    # 마이그레이션 없이 빠른 배포
+scripts/deploy.sh --auto-migrate     # 마이그레이션 포함
+scripts/deploy.sh --auto-migrate --backup  # 백업 + 마이그레이션
+
+# 수동 실행
 docker compose --env-file .env.prod -f docker-compose.prod.yml pull
 docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
 ```

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,6 +17,7 @@ NC='\033[0m'
 COMPOSE_FILE="docker-compose.prod.yml"
 ENV_FILE=".env.prod"
 HEALTH_URL="http://localhost:8000/healthz"
+MCP_URL="http://localhost:${MCP_PORT:-8765}/mcp"
 HEALTH_RETRIES=15
 HEALTH_INTERVAL=3
 
@@ -165,9 +166,27 @@ if [ "$HEALTH_CHECK" = true ]; then
     echo -e "${YELLOW}🏥 Running health check...${NC}"
     for i in $(seq 1 $HEALTH_RETRIES); do
         if curl -sf "$HEALTH_URL" > /dev/null 2>&1; then
+            echo -e "${GREEN}✅ API health check passed!${NC}"
+
+            # MCP 서버 헬스체크
+            MCP_OK=false
+            for j in $(seq 1 5); do
+                if curl -sf "$MCP_URL" > /dev/null 2>&1 || curl -s "$MCP_URL" 2>/dev/null | grep -q 'error\|method\|session'; then
+                    MCP_OK=true
+                    break
+                fi
+                echo -e "  ⏳ Waiting for MCP server... ($j/5)"
+                sleep 2
+            done
+
+            if [ "$MCP_OK" = true ]; then
+                echo -e "${GREEN}✅ MCP server health check passed!${NC}"
+            else
+                echo -e "${YELLOW}⚠️  MCP server not responding on $MCP_URL (non-fatal)${NC}"
+            fi
+
             DEPLOY_END=$(date +%s)
             DEPLOY_DURATION=$((DEPLOY_END - DEPLOY_START))
-            echo -e "${GREEN}✅ API health check passed!${NC}"
             echo ""
             echo -e "${GREEN}🎉 Deployment completed in ${DEPLOY_DURATION}s${NC}"
             echo ""

--- a/tests/integration/test_paper_positions_market_filter.py
+++ b/tests/integration/test_paper_positions_market_filter.py
@@ -29,6 +29,7 @@ async def async_db():
         execution_options={"schema_translate_map": {"paper": None}},
     )
     from sqlalchemy import Integer
+
     for table in [PaperAccount.__table__, PaperPosition.__table__]:
         for column in table.columns:
             if column.primary_key:
@@ -82,7 +83,9 @@ async def test_get_positions_no_market_returns_all(async_db: AsyncSession):
     account_id = await _seed_positions(async_db)
     service = PaperTradingService(async_db)
 
-    with patch.object(service, "_fetch_current_price", new_callable=AsyncMock) as mock_price:
+    with patch.object(
+        service, "_fetch_current_price", new_callable=AsyncMock
+    ) as mock_price:
         mock_price.side_effect = Exception("skip price")
         positions = await service.get_positions(account_id)
 
@@ -94,7 +97,9 @@ async def test_get_positions_market_equity_kr(async_db: AsyncSession):
     account_id = await _seed_positions(async_db)
     service = PaperTradingService(async_db)
 
-    with patch.object(service, "_fetch_current_price", new_callable=AsyncMock) as mock_price:
+    with patch.object(
+        service, "_fetch_current_price", new_callable=AsyncMock
+    ) as mock_price:
         mock_price.side_effect = Exception("skip price")
         positions = await service.get_positions(account_id, market="equity_kr")
 
@@ -108,7 +113,9 @@ async def test_get_positions_market_equity_us(async_db: AsyncSession):
     account_id = await _seed_positions(async_db)
     service = PaperTradingService(async_db)
 
-    with patch.object(service, "_fetch_current_price", new_callable=AsyncMock) as mock_price:
+    with patch.object(
+        service, "_fetch_current_price", new_callable=AsyncMock
+    ) as mock_price:
         mock_price.side_effect = Exception("skip price")
         positions = await service.get_positions(account_id, market="equity_us")
 
@@ -121,7 +128,9 @@ async def test_get_positions_market_crypto(async_db: AsyncSession):
     account_id = await _seed_positions(async_db)
     service = PaperTradingService(async_db)
 
-    with patch.object(service, "_fetch_current_price", new_callable=AsyncMock) as mock_price:
+    with patch.object(
+        service, "_fetch_current_price", new_callable=AsyncMock
+    ) as mock_price:
         mock_price.side_effect = Exception("skip price")
         positions = await service.get_positions(account_id, market="crypto")
 


### PR DESCRIPTION
## Summary

- Add branch & PR workflow section to `CLAUDE.md` (main = dev branch, production = deploy branch)
- Add end-to-end deployment pipeline overview to `DEPLOYMENT.md` with step-by-step procedure
- Add MCP server health check (port 8765) to `scripts/deploy.sh`
- Recommend `scripts/deploy.sh` in the update procedure section

## Context

ROB-17: Document and implement deployment process so code merged to `main` can be deployed to the MCP server via `production` branch → GHCR → `scripts/deploy.sh`.

Replaces #505 (was based on stale `develop` branch, causing 200K-line diff).

## Test plan

- [ ] Verify `scripts/deploy.sh` MCP health check works (non-fatal if MCP not running)
- [ ] Verify `DEPLOYMENT.md` renders correctly with pipeline overview table
- [ ] Verify `CLAUDE.md` branch workflow section is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Branch & PR workflow guidelines documenting branch protection, roles, and naming conventions.
  * Enhanced deployment documentation with end-to-end pipeline overview and detailed step-by-step procedures.

* **Chores**
  * Strengthened deployment script with MCP server readiness verification during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->