### PR TITLE
feat(n8n): Paperclip review/blocked notification pipeline

### DIFF
--- a/docker-compose.n8n.yml
+++ b/docker-compose.n8n.yml
@@ -7,6 +7,8 @@ services:
     container_name: auto_trader_n8n_prod
     restart: unless-stopped
     network_mode: host # auto_trader API/MCP에 localhost로 직접 접근
+    env_file:
+      - .env
     environment:
       - N8N_HOST=localhost
       - N8N_LISTEN_ADDRESS=127.0.0.1
@@ -16,6 +18,10 @@ services:
       - N8N_VERSION_NOTIFICATIONS_ENABLED=false
       - QUEUE_HEALTH_CHECK_ACTIVE=true
       - NODES_EXCLUDE=[]  # executeCommand 노드 허용 (내부 전용)
+      # Paperclip Review Notify workflow
+      - PAPERCLIP_COMPANY_ID=${PAPERCLIP_COMPANY_ID:-6a41f388-ff8d-4b65-82dc-38a9b66fa69e}
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_TOKEN}
+      - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
     volumes:
       - ./n8n/data:/home/node/.n8n
       - ws-heartbeat:/shared/heartbeat:ro

--- a/docker-compose.n8n.yml
+++ b/docker-compose.n8n.yml
@@ -20,8 +20,7 @@ services:
       - NODES_EXCLUDE=[]  # executeCommand 노드 허용 (내부 전용)
       # Paperclip Review Notify workflow
       - PAPERCLIP_COMPANY_ID=${PAPERCLIP_COMPANY_ID:-6a41f388-ff8d-4b65-82dc-38a9b66fa69e}
-      - TELEGRAM_BOT_TOKEN=${TELEGRAM_TOKEN}
-      - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
+      - PAPERCLIP_DISCORD_WEBHOOK_URL=${PAPERCLIP_DISCORD_WEBHOOK_URL}
     volumes:
       - ./n8n/data:/home/node/.n8n
       - ws-heartbeat:/shared/heartbeat:ro

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,7 +16,7 @@ services:
         echo '🔄 Running migrations...' &&
         alembic upgrade head &&
         echo '🔁 Syncing kr_symbol_universe...' &&
-        python scripts/sync_kr_symbol_universe.py &&
+        PYTHONPATH=/app python scripts/sync_kr_symbol_universe.py &&
         echo '✅ kr_symbol_universe sync completed' &&
         echo '✅ Migrations completed successfully'
       "

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -63,9 +63,9 @@ docker exec auto_trader_n8n_prod n8n import:workflow \
 ### Paperclip Review/Blocked Notify
 - **ID**: `paperclip-review-notify`
 - **주기**: 3분 간격 polling
-- **동작**: Paperclip API에서 `in_review`, `blocked` 상태 태스크를 조회하고 새로운 상태 변경을 감지하면 Telegram으로 알림 전송
+- **동작**: Paperclip API에서 `in_review`, `blocked` 상태 태스크를 조회하고 새로운 상태 변경을 감지하면 Discord webhook으로 알림 전송 (embed 형식)
 - **중복 방지**: n8n static data로 이미 알린 태스크 ID+상태 추적. 상태 변경 시에만 재알림
-- **환경 변수**: `PAPERCLIP_COMPANY_ID`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`
+- **환경 변수**: `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_DISCORD_WEBHOOK_URL`
 
 ### WebSocket Container Monitor
 - **주기**: 15분 간격

--- a/n8n/README.md
+++ b/n8n/README.md
@@ -58,6 +58,19 @@ docker exec auto_trader_n8n_prod n8n import:workflow \
   --input=/home/node/.n8n/workflows/
 ```
 
+## 워크플로우 목록
+
+### Paperclip Review/Blocked Notify
+- **ID**: `paperclip-review-notify`
+- **주기**: 3분 간격 polling
+- **동작**: Paperclip API에서 `in_review`, `blocked` 상태 태스크를 조회하고 새로운 상태 변경을 감지하면 Telegram으로 알림 전송
+- **중복 방지**: n8n static data로 이미 알린 태스크 ID+상태 추적. 상태 변경 시에만 재알림
+- **환경 변수**: `PAPERCLIP_COMPANY_ID`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`
+
+### WebSocket Container Monitor
+- **주기**: 15분 간격
+- **동작**: Upbit/KIS WebSocket heartbeat 파일을 읽어 비정상 상태 시 Discord 알림
+
 ## 런타임 계약
 
 n8n은 낮부 전용으로 `127.0.0.1:5678`에 고정 바인딩됩니다.

--- a/n8n/workflows/paperclip-review-notify.json
+++ b/n8n/workflows/paperclip-review-notify.json
@@ -37,7 +37,7 @@
     {
       "parameters": {
         "mode": "runOnceForAllItems",
-        "jsCode": "// Dedup: track already-notified issue IDs + statuses using workflow static data.\n// Only notify when a task is NEWLY in_review or blocked (or changes status).\n\nconst staticData = $getWorkflowStaticData('global');\nif (!staticData.notifiedMap) staticData.notifiedMap = {};\n\nconst issues = $input.first()?.json ?? [];\nconst now = Date.now();\nconst newAlerts = [];\n\n// Build current set of issue IDs for cleanup\nconst currentIds = new Set();\n\nfor (const issue of issues) {\n  if (!issue?.id) continue;\n  currentIds.add(issue.id);\n\n  const key = issue.id;\n  const prevStatus = staticData.notifiedMap[key];\n\n  // Notify if: never seen before, or status changed\n  if (!prevStatus || prevStatus !== issue.status) {\n    const agentName = issue.assigneeAgentId ? (issue.executionAgentNameKey || 'agent') : 'unassigned';\n    const statusEmoji = issue.status === 'blocked' ? '🚫' : '👀';\n\n    newAlerts.push({\n      id: issue.id,\n      identifier: issue.identifier || 'unknown',\n      title: issue.title || 'Untitled',\n      status: issue.status,\n      statusEmoji,\n      agentName,\n      priority: issue.priority || 'medium',\n      updatedAt: issue.updatedAt || new Date().toISOString()\n    });\n\n    staticData.notifiedMap[key] = issue.status;\n  }\n}\n\n// Clean up stale entries (issues no longer in_review/blocked)\nfor (const id of Object.keys(staticData.notifiedMap)) {\n  if (!currentIds.has(id)) {\n    delete staticData.notifiedMap[id];\n  }\n}\n\nreturn [{ json: { hasAlerts: newAlerts.length > 0, alerts: newAlerts, totalActive: issues.length } }];"
+        "jsCode": "// Dedup: track already-notified issue IDs + statuses using workflow static data.\n// Only notify when a task is NEWLY in_review or blocked (or changes status).\n\nconst staticData = $getWorkflowStaticData('global');\nif (!staticData.notifiedMap) staticData.notifiedMap = {};\n\nconst issues = $input.first()?.json ?? [];\nconst now = Date.now();\nconst newAlerts = [];\n\n// Build current set of issue IDs for cleanup\nconst currentIds = new Set();\n\nfor (const issue of issues) {\n  if (!issue?.id) continue;\n  currentIds.add(issue.id);\n\n  const key = issue.id;\n  const prevStatus = staticData.notifiedMap[key];\n\n  // Notify if: never seen before, or status changed\n  if (!prevStatus || prevStatus !== issue.status) {\n    const agentName = issue.assigneeAgentId ? (issue.executionAgentNameKey || 'agent') : 'unassigned';\n    const statusEmoji = issue.status === 'blocked' ? '\\uD83D\\uDEAB' : '\\uD83D\\uDC40';\n\n    newAlerts.push({\n      id: issue.id,\n      identifier: issue.identifier || 'unknown',\n      title: issue.title || 'Untitled',\n      status: issue.status,\n      statusEmoji,\n      agentName,\n      priority: issue.priority || 'medium',\n      updatedAt: issue.updatedAt || new Date().toISOString()\n    });\n\n    staticData.notifiedMap[key] = issue.status;\n  }\n}\n\n// Clean up stale entries (issues no longer in_review/blocked)\nfor (const id of Object.keys(staticData.notifiedMap)) {\n  if (!currentIds.has(id)) {\n    delete staticData.notifiedMap[id];\n  }\n}\n\nreturn [{ json: { hasAlerts: newAlerts.length > 0, alerts: newAlerts, totalActive: issues.length } }];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
@@ -63,21 +63,21 @@
     {
       "parameters": {
         "mode": "runOnceForAllItems",
-        "jsCode": "// Build Telegram message from alerts\nconst data = $input.first().json;\nconst alerts = data.alerts;\n\nconst PAPERCLIP_UI = 'http://127.0.0.1:3100';\nconst PREFIX = 'ROB';\n\nlet lines = ['📋 *Paperclip 리뷰 알림*\\n'];\n\nfor (const a of alerts) {\n  const link = `${PAPERCLIP_UI}/${PREFIX}/issues/${a.identifier}`;\n  lines.push(`${a.statusEmoji} *${a.identifier}*: ${a.title}`);\n  lines.push(`   상태: \\`${a.status}\\` | 담당: \\`${a.agentName}\\` | 우선순위: \\`${a.priority}\\``);\n  lines.push(`   🔗 ${link}`);\n  lines.push('');\n}\n\nlines.push(`_총 ${data.totalActive}개 태스크가 리뷰/blocked 대기 중_`);\n\nconst text = lines.join('\\n');\n\nreturn [{ json: { text, chatId: $env.TELEGRAM_CHAT_ID || '' } }];"
+        "jsCode": "// Build Discord embed from alerts\nconst data = $input.first().json;\nconst alerts = data.alerts;\n\nconst PAPERCLIP_UI = 'http://127.0.0.1:3100';\nconst PREFIX = 'ROB';\n\nconst embeds = alerts.map(a => {\n  const link = `${PAPERCLIP_UI}/${PREFIX}/issues/${a.identifier}`;\n  const color = a.status === 'blocked' ? 0xFF0000 : 0xFFA500;\n  return {\n    title: `${a.statusEmoji} ${a.identifier}: ${a.title}`,\n    url: link,\n    color,\n    fields: [\n      { name: 'Status', value: `\\`${a.status}\\``, inline: true },\n      { name: 'Agent', value: `\\`${a.agentName}\\``, inline: true },\n      { name: 'Priority', value: `\\`${a.priority}\\``, inline: true }\n    ],\n    timestamp: a.updatedAt\n  };\n});\n\nconst payload = {\n  content: `**Paperclip Review Alert** - ${data.totalActive} task(s) awaiting review/unblock`,\n  embeds: embeds.slice(0, 10)\n};\n\nreturn [{ json: payload }];"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [960, 0],
       "id": "pc-msg",
-      "name": "Build Message"
+      "name": "Build Discord Message"
     },
     {
       "parameters": {
         "method": "POST",
-        "url": "=https://api.telegram.org/bot{{ $env.TELEGRAM_BOT_TOKEN }}/sendMessage",
+        "url": "={{ $env.PAPERCLIP_DISCORD_WEBHOOK_URL }}",
         "sendBody": true,
         "specifyBody": "json",
-        "jsonBody": "={\n  \"chat_id\": \"{{ $json.chatId }}\",\n  \"text\": {{ JSON.stringify($json.text) }},\n  \"parse_mode\": \"Markdown\"\n}",
+        "jsonBody": "={{ JSON.stringify($json) }}",
         "options": {
           "timeout": 10000
         }
@@ -85,8 +85,8 @@
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 4.2,
       "position": [1200, 0],
-      "id": "pc-telegram",
-      "name": "Send Telegram"
+      "id": "pc-discord",
+      "name": "Send Discord"
     }
   ],
   "connections": {
@@ -100,10 +100,10 @@
       "main": [[{ "node": "Has New Alerts?", "type": "main", "index": 0 }]]
     },
     "Has New Alerts?": {
-      "main": [[{ "node": "Build Message", "type": "main", "index": 0 }]]
+      "main": [[{ "node": "Build Discord Message", "type": "main", "index": 0 }]]
     },
-    "Build Message": {
-      "main": [[{ "node": "Send Telegram", "type": "main", "index": 0 }]]
+    "Build Discord Message": {
+      "main": [[{ "node": "Send Discord", "type": "main", "index": 0 }]]
     }
   }
 }

--- a/n8n/workflows/paperclip-review-notify.json
+++ b/n8n/workflows/paperclip-review-notify.json
@@ -1,0 +1,109 @@
+{
+  "id": "paperclip-review-notify",
+  "name": "Paperclip Review/Blocked Notify",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [{ "field": "minutes", "minutesInterval": 3 }]
+        }
+      },
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.3,
+      "position": [0, 0],
+      "id": "pc-trigger",
+      "name": "Schedule Trigger"
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "=http://127.0.0.1:3100/api/companies/{{ $env.PAPERCLIP_COMPANY_ID }}/issues",
+        "sendQuery": true,
+        "queryParameters": {
+          "parameters": [
+            { "name": "status", "value": "in_review,blocked" }
+          ]
+        },
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [240, 0],
+      "id": "pc-fetch",
+      "name": "Fetch Paperclip Issues"
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "// Dedup: track already-notified issue IDs + statuses using workflow static data.\n// Only notify when a task is NEWLY in_review or blocked (or changes status).\n\nconst staticData = $getWorkflowStaticData('global');\nif (!staticData.notifiedMap) staticData.notifiedMap = {};\n\nconst issues = $input.first()?.json ?? [];\nconst now = Date.now();\nconst newAlerts = [];\n\n// Build current set of issue IDs for cleanup\nconst currentIds = new Set();\n\nfor (const issue of issues) {\n  if (!issue?.id) continue;\n  currentIds.add(issue.id);\n\n  const key = issue.id;\n  const prevStatus = staticData.notifiedMap[key];\n\n  // Notify if: never seen before, or status changed\n  if (!prevStatus || prevStatus !== issue.status) {\n    const agentName = issue.assigneeAgentId ? (issue.executionAgentNameKey || 'agent') : 'unassigned';\n    const statusEmoji = issue.status === 'blocked' ? '🚫' : '👀';\n\n    newAlerts.push({\n      id: issue.id,\n      identifier: issue.identifier || 'unknown',\n      title: issue.title || 'Untitled',\n      status: issue.status,\n      statusEmoji,\n      agentName,\n      priority: issue.priority || 'medium',\n      updatedAt: issue.updatedAt || new Date().toISOString()\n    });\n\n    staticData.notifiedMap[key] = issue.status;\n  }\n}\n\n// Clean up stale entries (issues no longer in_review/blocked)\nfor (const id of Object.keys(staticData.notifiedMap)) {\n  if (!currentIds.has(id)) {\n    delete staticData.notifiedMap[id];\n  }\n}\n\nreturn [{ json: { hasAlerts: newAlerts.length > 0, alerts: newAlerts, totalActive: issues.length } }];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [480, 0],
+      "id": "pc-dedup",
+      "name": "Dedup & Format"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "loose", "version": 3 },
+          "conditions": [{ "id": "pc-check", "leftValue": "={{ $json.hasAlerts }}", "rightValue": true, "operator": { "type": "boolean", "operation": "true" } }],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.3,
+      "position": [720, 0],
+      "id": "pc-if",
+      "name": "Has New Alerts?"
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "// Build Telegram message from alerts\nconst data = $input.first().json;\nconst alerts = data.alerts;\n\nconst PAPERCLIP_UI = 'http://127.0.0.1:3100';\nconst PREFIX = 'ROB';\n\nlet lines = ['📋 *Paperclip 리뷰 알림*\\n'];\n\nfor (const a of alerts) {\n  const link = `${PAPERCLIP_UI}/${PREFIX}/issues/${a.identifier}`;\n  lines.push(`${a.statusEmoji} *${a.identifier}*: ${a.title}`);\n  lines.push(`   상태: \\`${a.status}\\` | 담당: \\`${a.agentName}\\` | 우선순위: \\`${a.priority}\\``);\n  lines.push(`   🔗 ${link}`);\n  lines.push('');\n}\n\nlines.push(`_총 ${data.totalActive}개 태스크가 리뷰/blocked 대기 중_`);\n\nconst text = lines.join('\\n');\n\nreturn [{ json: { text, chatId: $env.TELEGRAM_CHAT_ID || '' } }];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [960, 0],
+      "id": "pc-msg",
+      "name": "Build Message"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "=https://api.telegram.org/bot{{ $env.TELEGRAM_BOT_TOKEN }}/sendMessage",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={\n  \"chat_id\": \"{{ $json.chatId }}\",\n  \"text\": {{ JSON.stringify($json.text) }},\n  \"parse_mode\": \"Markdown\"\n}",
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1200, 0],
+      "id": "pc-telegram",
+      "name": "Send Telegram"
+    }
+  ],
+  "connections": {
+    "Schedule Trigger": {
+      "main": [[{ "node": "Fetch Paperclip Issues", "type": "main", "index": 0 }]]
+    },
+    "Fetch Paperclip Issues": {
+      "main": [[{ "node": "Dedup & Format", "type": "main", "index": 0 }]]
+    },
+    "Dedup & Format": {
+      "main": [[{ "node": "Has New Alerts?", "type": "main", "index": 0 }]]
+    },
+    "Has New Alerts?": {
+      "main": [[{ "node": "Build Message", "type": "main", "index": 0 }]]
+    },
+    "Build Message": {
+      "main": [[{ "node": "Send Telegram", "type": "main", "index": 0 }]]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds n8n workflow that polls Paperclip API every 3 minutes for `in_review`/`blocked` tasks
- Sends Telegram notification when new review/blocked tasks are detected
- Dedup via n8n static data (tracks task ID + status; only re-alerts on status change)
- Updates n8n docker compose with `env_file: .env` and Paperclip/Telegram env vars

## Details

**Workflow**: `n8n/workflows/paperclip-review-notify.json`
- Schedule Trigger (3min) → Fetch Paperclip Issues → Dedup & Format → Conditional → Build Message → Send Telegram

**Architecture decision**: Uses Telegram Bot API directly from n8n rather than routing through hermes webhook. The hermes webhook platform triggers full AI agent sessions for each message, which is excessive for simple status notifications. Direct Telegram delivery is faster, cheaper, and more reliable.

**Paperclip API auth**: Paperclip runs in `local_trusted` mode on localhost:3100, so no auth needed for n8n (host networking).

## Test plan

- [x] Verified n8n container can reach Paperclip API (`wget` from inside container)
- [x] Verified Paperclip API returns correct results for `?status=in_review,blocked`
- [x] Verified Telegram notification delivery with test message
- [x] Workflow imported, published, and activated in n8n
- [x] Created and cleaned up test task (ROB-23) to validate full pipeline
- [ ] Monitor first automated trigger after 3 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)