### PR TITLE
feat: add market_reports DB pipeline + MCP tools (ROB-37)

### DIFF
--- a/alembic/versions/142f11db8fc3_add_market_reports_table.py
+++ b/alembic/versions/142f11db8fc3_add_market_reports_table.py
@@ -1,7 +1,7 @@
 """add market_reports table
 
 Revision ID: 142f11db8fc3
-Revises: 2bbc1aab9f3e
+Revises: 1666768ca8ff, db555723284f
 Create Date: 2026-04-15 09:10:36.996075
 
 """
@@ -13,7 +13,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = '142f11db8fc3'
-down_revision: Union[str, Sequence[str], None] = '2bbc1aab9f3e'
+down_revision: Union[str, Sequence[str], None] = ('1666768ca8ff', 'db555723284f')
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/142f11db8fc3_add_market_reports_table.py
+++ b/alembic/versions/142f11db8fc3_add_market_reports_table.py
@@ -1,0 +1,49 @@
+"""add market_reports table
+
+Revision ID: 142f11db8fc3
+Revises: 2bbc1aab9f3e
+Create Date: 2026-04-15 09:10:36.996075
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '142f11db8fc3'
+down_revision: Union[str, Sequence[str], None] = '2bbc1aab9f3e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table('market_reports',
+    sa.Column('id', sa.BigInteger(), nullable=False),
+    sa.Column('report_type', sa.String(length=50), nullable=False, comment='리포트 타입 (daily_brief, kr_morning, crypto_scan)'),
+    sa.Column('report_date', sa.Date(), nullable=False, comment='리포트 대상 날짜'),
+    sa.Column('market', sa.String(length=20), nullable=False, comment='시장 (kr, us, crypto, all)'),
+    sa.Column('title', sa.String(length=500), nullable=True, comment='리포트 제목'),
+    sa.Column('content', postgresql.JSONB(astext_type=sa.Text()), nullable=False, comment='구조화된 리포트 데이터'),
+    sa.Column('summary', sa.Text(), nullable=True, comment='사람이 읽을 수 있는 요약'),
+    sa.Column('metadata', postgresql.JSONB(astext_type=sa.Text()), nullable=True, comment='추가 메타데이터 (소스, 지표 등)'),
+    sa.Column('user_id', sa.BigInteger(), nullable=True),
+    sa.Column('created_at', sa.DateTime(), nullable=False, comment='데이터 생성일시'),
+    sa.Column('updated_at', sa.DateTime(), nullable=True, comment='데이터 수정일시'),
+    sa.ForeignKeyConstraint(['user_id'], ['users.id'], name=op.f('fk_market_reports_user_id_users'), ondelete='SET NULL'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_market_reports')),
+    sa.UniqueConstraint('report_type', 'report_date', 'market', 'user_id', name='uq_market_reports_type_date_market_user'),
+    )
+    op.create_index('ix_market_reports_market', 'market_reports', ['market'], unique=False)
+    op.create_index('ix_market_reports_type_date', 'market_reports', ['report_type', 'report_date'], unique=False)
+    op.create_index(op.f('ix_market_reports_user_id'), 'market_reports', ['user_id'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_market_reports_user_id'), table_name='market_reports')
+    op.drop_index('ix_market_reports_type_date', table_name='market_reports')
+    op.drop_index('ix_market_reports_market', table_name='market_reports')
+    op.drop_table('market_reports')

--- a/app/mcp_server/tooling/__init__.py
+++ b/app/mcp_server/tooling/__init__.py
@@ -16,6 +16,10 @@ This package contains the refactored MCP tools split by domain:
 
 from __future__ import annotations
 
+from app.mcp_server.tooling.market_report_registration import (
+    MARKET_REPORT_TOOL_NAMES,
+    register_market_report_tools,
+)
 from app.mcp_server.tooling.news_registration import (
     NEWS_TOOL_NAMES,
     register_news_tools,
@@ -35,11 +39,13 @@ from app.mcp_server.tooling.watch_alerts_registration import (
 )
 
 __all__ = [
+    "MARKET_REPORT_TOOL_NAMES",
     "WATCH_ALERT_TOOL_NAMES",
     "TRADE_PROFILE_TOOL_NAMES",
     "NEWS_TOOL_NAMES",
     "TRADE_JOURNAL_TOOL_NAMES",
     "register_all_tools",
+    "register_market_report_tools",
     "register_trade_journal_tools",
     "register_trade_profile_tools",
     "register_watch_alert_tools",

--- a/app/mcp_server/tooling/market_report_handlers.py
+++ b/app/mcp_server/tooling/market_report_handlers.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from app.services.market_report_service import (
+    get_latest_market_brief,
+    get_market_reports,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+MARKET_REPORT_TOOL_NAMES = ["get_market_reports", "get_latest_market_brief"]
+
+
+async def _get_market_reports_impl(
+    report_type: str | None = None,
+    market: str | None = None,
+    days: int | None = 7,
+    limit: int | None = 10,
+) -> dict[str, Any]:
+    days = days or 7
+    limit = limit or 10
+
+    reports = await get_market_reports(
+        report_type=report_type,
+        market=market,
+        days=days,
+        limit=limit,
+    )
+
+    return {
+        "count": len(reports),
+        "reports": reports,
+    }
+
+
+async def _get_latest_market_brief_impl(
+    market: str | None = "all",
+) -> dict[str, Any]:
+    market = market or "all"
+    report = await get_latest_market_brief(market=market)
+
+    if not report:
+        return {"found": False, "report": None}
+
+    return {"found": True, "report": report}
+
+
+def _register_market_report_tools_impl(mcp: FastMCP) -> None:
+    @mcp.tool(
+        name="get_market_reports",
+        description=(
+            "과거 마켓 리포트 조회. report_type으로 필터 가능: "
+            "'daily_brief' (일일 종합 브리프), 'kr_morning' (한국 주식 모닝 리포트), "
+            "'crypto_scan' (크립토 스캔). market으로 필터 가능: 'kr', 'us', 'crypto', 'all'. "
+            "days로 조회 기간 설정 (기본 7일)."
+        ),
+    )
+    async def get_market_reports_tool(
+        report_type: str | None = None,
+        market: str | None = None,
+        days: int = 7,
+        limit: int = 10,
+    ) -> dict[str, Any]:
+        return await _get_market_reports_impl(
+            report_type=report_type,
+            market=market,
+            days=days,
+            limit=limit,
+        )
+
+    @mcp.tool(
+        name="get_latest_market_brief",
+        description=(
+            "최신 daily_brief 마켓 브리프 조회. "
+            "market='all'이면 전체 시장 브리프, 'kr'/'us'/'crypto'로 필터 가능."
+        ),
+    )
+    async def get_latest_market_brief_tool(
+        market: str = "all",
+    ) -> dict[str, Any]:
+        return await _get_latest_market_brief_impl(market=market)

--- a/app/mcp_server/tooling/market_report_registration.py
+++ b/app/mcp_server/tooling/market_report_registration.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.mcp_server.tooling.market_report_handlers import (
+    MARKET_REPORT_TOOL_NAMES,
+    _register_market_report_tools_impl,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+def register_market_report_tools(mcp: FastMCP) -> None:
+    _register_market_report_tools_impl(mcp)
+
+
+__all__ = ["MARKET_REPORT_TOOL_NAMES", "register_market_report_tools"]

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -7,6 +7,9 @@ from typing import TYPE_CHECKING
 from app.mcp_server.tooling.analysis_registration import register_analysis_tools
 from app.mcp_server.tooling.fundamentals_registration import register_fundamentals_tools
 from app.mcp_server.tooling.market_data_registration import register_market_data_tools
+from app.mcp_server.tooling.market_report_registration import (
+    register_market_report_tools,
+)
 from app.mcp_server.tooling.news_registration import register_news_tools
 from app.mcp_server.tooling.orders_registration import register_order_tools
 from app.mcp_server.tooling.paper_account_registration import (
@@ -44,6 +47,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_analysis_tools(mcp)
     register_watch_alert_tools(mcp)
     register_trade_profile_tools(mcp)
+    register_market_report_tools(mcp)
     register_user_settings_tools(mcp)
     register_news_tools(mcp)
     register_trade_journal_tools(mcp)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -9,6 +9,7 @@ from .manual_holdings import (
     MarketType,
     StockAlias,
 )
+from .market_report import MarketReport
 from .news import NewsAnalysisResult, NewsArticle, Sentiment
 from .paper_trading import PaperAccount, PaperPosition, PaperTrade
 from .prompt import PromptResult
@@ -76,6 +77,7 @@ __all__ = [
     "BrokerAccount",
     "StockAlias",
     "ManualHolding",
+    "MarketReport",
     "Trade",
     "TradeSnapshot",
     "TradeReview",

--- a/app/models/market_report.py
+++ b/app/models/market_report.py
@@ -1,0 +1,96 @@
+"""Database model for market reports (daily brief, kr morning, crypto scan)."""
+
+from datetime import date, datetime
+
+from sqlalchemy import (
+    BigInteger,
+    Date,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+
+class MarketReport(Base):
+    __tablename__ = "market_reports"
+
+    __table_args__ = (
+        UniqueConstraint(
+            "report_type",
+            "report_date",
+            "market",
+            "user_id",
+            name="uq_market_reports_type_date_market_user",
+        ),
+        Index("ix_market_reports_type_date", "report_type", "report_date"),
+        Index("ix_market_reports_market", "market"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+
+    report_type: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        comment="리포트 타입 (daily_brief, kr_morning, crypto_scan)",
+    )
+    report_date: Mapped[date] = mapped_column(
+        Date,
+        nullable=False,
+        comment="리포트 대상 날짜",
+    )
+    market: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        comment="시장 (kr, us, crypto, all)",
+    )
+    title: Mapped[str | None] = mapped_column(
+        String(500),
+        nullable=True,
+        comment="리포트 제목",
+    )
+    content: Mapped[dict] = mapped_column(
+        JSONB,
+        nullable=False,
+        comment="구조화된 리포트 데이터",
+    )
+    summary: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        comment="사람이 읽을 수 있는 요약",
+    )
+    metadata_: Mapped[dict | None] = mapped_column(
+        "metadata",
+        JSONB,
+        nullable=True,
+        comment="추가 메타데이터 (소스, 지표 등)",
+    )
+
+    user_id: Mapped[int | None] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        nullable=False,
+        comment="데이터 생성일시",
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        nullable=True,
+        comment="데이터 수정일시",
+    )
+
+    user = relationship("User", backref="market_reports")
+
+    def __repr__(self) -> str:
+        return (
+            f"<MarketReport(id={self.id}, type='{self.report_type}', "
+            f"date={self.report_date}, market='{self.market}')>"
+        )

--- a/app/routers/n8n.py
+++ b/app/routers/n8n.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Literal
 
@@ -41,6 +42,11 @@ from app.schemas.n8n.trade_review import (
     N8nTradeReviewsResponse,
     N8nTradeReviewStats,
     N8nTradeReviewStatsResponse,
+)
+from app.services.market_report_service import (
+    save_crypto_scan_report,
+    save_daily_brief_report,
+    save_kr_morning_report,
 )
 from app.services.n8n_crypto_scan_service import fetch_crypto_scan
 from app.services.n8n_daily_brief_service import fetch_daily_brief
@@ -250,6 +256,7 @@ async def get_daily_brief(
         )
         return JSONResponse(status_code=500, content=payload.model_dump())
 
+    asyncio.ensure_future(save_daily_brief_report(result))
     return N8nDailyBriefResponse(**result)
 
 
@@ -501,6 +508,7 @@ async def get_crypto_scan(
         )
         return JSONResponse(status_code=500, content=payload.model_dump())
 
+    asyncio.ensure_future(save_crypto_scan_report(result))
     return N8nCryptoScanResponse(
         success=result.get("success", True),
         as_of=as_of,
@@ -543,6 +551,7 @@ async def get_kr_morning_report(
         )
         return JSONResponse(status_code=500, content=payload.model_dump())
 
+    asyncio.ensure_future(save_kr_morning_report(result))
     return N8nKrMorningReportResponse(**result)
 
 

--- a/app/services/market_report_service.py
+++ b/app/services/market_report_service.py
@@ -1,0 +1,213 @@
+"""Market report persistence service — UPSERT reports to market_reports table."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from app.core.db import AsyncSessionLocal
+from app.core.timezone import now_kst
+from app.models.market_report import MarketReport
+
+logger = logging.getLogger(__name__)
+
+
+async def upsert_market_report(
+    *,
+    report_type: str,
+    report_date: date,
+    market: str,
+    content: dict[str, Any],
+    title: str | None = None,
+    summary: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    user_id: int | None = 1,
+) -> int | None:
+    now = now_kst().replace(tzinfo=None)
+
+    async with AsyncSessionLocal() as session:
+        stmt = (
+            pg_insert(MarketReport.__table__)
+            .values(
+                report_type=report_type,
+                report_date=report_date,
+                market=market,
+                title=title,
+                content=content,
+                summary=summary,
+                metadata=metadata,
+                user_id=user_id,
+                created_at=now,
+                updated_at=now,
+            )
+            .on_conflict_do_update(
+                constraint="uq_market_reports_type_date_market_user",
+                set_={
+                    "content": content,
+                    "title": title,
+                    "summary": summary,
+                    "metadata": metadata,
+                    "updated_at": now,
+                },
+            )
+        )
+        result = await session.execute(stmt)
+        await session.commit()
+
+        if result.inserted_primary_key:
+            return result.inserted_primary_key[0]
+        return None
+
+
+async def save_daily_brief_report(result: dict[str, Any]) -> None:
+    try:
+        as_of_str = result.get("as_of", "")
+        try:
+            report_date = datetime.fromisoformat(as_of_str).date()
+        except (ValueError, AttributeError):
+            report_date = now_kst().date()
+
+        await upsert_market_report(
+            report_type="daily_brief",
+            report_date=report_date,
+            market="all",
+            content=_serialize_result(result),
+            title=f"Daily Brief — {result.get('date_fmt', '')}",
+            summary=result.get("brief_text"),
+        )
+        logger.info("Saved daily_brief report for %s", report_date)
+    except Exception:
+        logger.exception("Failed to save daily_brief report to DB")
+
+
+async def save_kr_morning_report(result: dict[str, Any]) -> None:
+    try:
+        as_of_str = result.get("as_of", "")
+        try:
+            report_date = datetime.fromisoformat(as_of_str).date()
+        except (ValueError, AttributeError):
+            report_date = now_kst().date()
+
+        await upsert_market_report(
+            report_type="kr_morning",
+            report_date=report_date,
+            market="kr",
+            content=_serialize_result(result),
+            title=f"KR Morning Report — {result.get('date_fmt', '')}",
+            summary=result.get("brief_text"),
+        )
+        logger.info("Saved kr_morning report for %s", report_date)
+    except Exception:
+        logger.exception("Failed to save kr_morning report to DB")
+
+
+async def save_crypto_scan_report(result: dict[str, Any]) -> None:
+    try:
+        report_date = now_kst().date()
+
+        await upsert_market_report(
+            report_type="crypto_scan",
+            report_date=report_date,
+            market="crypto",
+            content=_serialize_result(result),
+            title=f"Crypto Scan — {report_date.isoformat()}",
+            summary=None,
+        )
+        logger.info("Saved crypto_scan report for %s", report_date)
+    except Exception:
+        logger.exception("Failed to save crypto_scan report to DB")
+
+
+async def get_market_reports(
+    *,
+    report_type: str | None = None,
+    market: str | None = None,
+    days: int = 7,
+    limit: int = 10,
+) -> list[dict[str, Any]]:
+    cutoff = now_kst().date() - timedelta(days=days)
+
+    async with AsyncSessionLocal() as session:
+        q = select(MarketReport).where(MarketReport.report_date >= cutoff)
+
+        if report_type:
+            q = q.where(MarketReport.report_type == report_type)
+        if market:
+            q = q.where(MarketReport.market == market)
+
+        q = q.order_by(MarketReport.report_date.desc(), MarketReport.created_at.desc())
+        q = q.limit(limit)
+
+        result = await session.execute(q)
+        reports = list(result.scalars().all())
+
+    return [_report_to_dict(r) for r in reports]
+
+
+async def get_latest_market_brief(
+    *,
+    market: str = "all",
+) -> dict[str, Any] | None:
+    async with AsyncSessionLocal() as session:
+        q = select(MarketReport).where(MarketReport.report_type == "daily_brief")
+        if market != "all":
+            q = q.where(MarketReport.market == market)
+
+        q = q.order_by(MarketReport.report_date.desc()).limit(1)
+
+        result = await session.execute(q)
+        report = result.scalars().first()
+
+    if not report:
+        return None
+    return _report_to_dict(report)
+
+
+def _report_to_dict(report: MarketReport) -> dict[str, Any]:
+    return {
+        "id": report.id,
+        "report_type": report.report_type,
+        "report_date": report.report_date.isoformat(),
+        "market": report.market,
+        "title": report.title,
+        "content": report.content,
+        "summary": report.summary,
+        "metadata": report.metadata_,
+        "created_at": report.created_at.isoformat() if report.created_at else None,
+        "updated_at": report.updated_at.isoformat() if report.updated_at else None,
+    }
+
+
+def _serialize_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Recursively convert non-JSON-serializable values in a result dict."""
+    import dataclasses
+
+    cleaned: dict[str, Any] = {}
+    for key, value in result.items():
+        if key == "errors":
+            cleaned[key] = [
+                {k: str(v) for k, v in e.items()} if isinstance(e, dict) else str(e)
+                for e in (value or [])
+            ]
+        elif hasattr(value, "model_dump"):
+            cleaned[key] = value.model_dump()
+        elif dataclasses.is_dataclass(value) and not isinstance(value, type):
+            cleaned[key] = dataclasses.asdict(value)
+        elif isinstance(value, dict):
+            cleaned[key] = _serialize_result(value)
+        elif isinstance(value, list):
+            cleaned[key] = [
+                v.model_dump()
+                if hasattr(v, "model_dump")
+                else dataclasses.asdict(v)
+                if (dataclasses.is_dataclass(v) and not isinstance(v, type))
+                else v
+                for v in value
+            ]
+        else:
+            cleaned[key] = value
+    return cleaned


### PR DESCRIPTION
## Summary
- Added `MarketReport` SQLAlchemy model with `market_reports` table (report_type, report_date, market, content JSONB, summary, metadata JSONB)
- Created Alembic migration with proper indexes and UNIQUE constraint for UPSERT
- Added `market_report_service.py` with UPSERT logic for daily_brief, kr_morning, and crypto_scan reports
- n8n endpoints (`/daily-brief`, `/kr-morning-report`, `/crypto-scan`) now save reports to DB asynchronously after successful responses (no impact on existing Discord output)
- Created MCP tools `get_market_reports` and `get_latest_market_brief` for agent querying of historical market data

## Test plan
- [ ] Run `alembic upgrade head` to create the `market_reports` table
- [ ] Call `/api/n8n/daily-brief` and verify a row is inserted in `market_reports` with `report_type='daily_brief'`
- [ ] Call `/api/n8n/kr-morning-report` and verify `report_type='kr_morning'` row
- [ ] Call `/api/n8n/crypto-scan` and verify `report_type='crypto_scan'` row
- [ ] Verify existing Discord output is unchanged
- [ ] Test MCP tool `get_market_reports` returns saved reports
- [ ] Test MCP tool `get_latest_market_brief` returns latest daily_brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Market reports are now automatically saved and stored when daily briefs, crypto scans, and morning reports are generated.
  * Added ability to retrieve and filter stored market reports by type, market, and date range.
  * Added ability to fetch the latest market brief for a specified market.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->