### PR TITLE
fix(tests): correct mock patch paths in kis_trading tests

### DIFF
--- a/tests/test_kis_manual_holdings_integration.py
+++ b/tests/test_kis_manual_holdings_integration.py
@@ -102,14 +102,16 @@ class TestManualHoldingsIntegration:
                 "app.services.manual_holdings_service.ManualHoldingsService",
                 MockManualService,
             ),
+            patch(
+                "app.services.kis_trading_service.process_kis_domestic_buy_orders_with_analysis",
+                fake_buy,
+            ),
+            patch(
+                "app.services.kis_trading_service.process_kis_domestic_sell_orders_with_analysis",
+                fake_sell,
+            ),
         ):
             monkeypatch.setattr(kis_tasks, "KISClient", DummyKIS)
-            monkeypatch.setattr(
-                kis_tasks, "process_kis_domestic_buy_orders_with_analysis", fake_buy
-            )
-            monkeypatch.setattr(
-                kis_tasks, "process_kis_domestic_sell_orders_with_analysis", fake_sell
-            )
 
             result = asyncio.run(kis_tasks.run_per_domestic_stock_automation())
 
@@ -198,14 +200,16 @@ class TestManualHoldingsIntegration:
                 "app.services.manual_holdings_service.ManualHoldingsService",
                 MockManualService,
             ),
+            patch(
+                "app.services.kis_trading_service.process_kis_domestic_buy_orders_with_analysis",
+                fake_buy,
+            ),
+            patch(
+                "app.services.kis_trading_service.process_kis_domestic_sell_orders_with_analysis",
+                fake_sell,
+            ),
         ):
             monkeypatch.setattr(kis_tasks, "KISClient", DummyKIS)
-            monkeypatch.setattr(
-                kis_tasks, "process_kis_domestic_buy_orders_with_analysis", fake_buy
-            )
-            monkeypatch.setattr(
-                kis_tasks, "process_kis_domestic_sell_orders_with_analysis", fake_sell
-            )
 
             result = asyncio.run(kis_tasks.run_per_domestic_stock_automation())
 
@@ -281,14 +285,16 @@ class TestManualHoldingsIntegration:
                 "app.services.manual_holdings_service.ManualHoldingsService",
                 MockManualService,
             ),
+            patch(
+                "app.services.kis_trading_service.process_kis_domestic_buy_orders_with_analysis",
+                fake_buy,
+            ),
+            patch(
+                "app.services.kis_trading_service.process_kis_domestic_sell_orders_with_analysis",
+                fake_sell,
+            ),
         ):
             monkeypatch.setattr(kis_tasks, "KISClient", DummyKIS)
-            monkeypatch.setattr(
-                kis_tasks, "process_kis_domestic_buy_orders_with_analysis", fake_buy
-            )
-            monkeypatch.setattr(
-                kis_tasks, "process_kis_domestic_sell_orders_with_analysis", fake_sell
-            )
 
             result = asyncio.run(kis_tasks.run_per_domestic_stock_automation())
 
@@ -361,14 +367,16 @@ class TestManualHoldingsIntegration:
                 "app.services.manual_holdings_service.ManualHoldingsService",
                 MockManualService,
             ),
+            patch(
+                "app.services.kis_trading_service.process_kis_domestic_buy_orders_with_analysis",
+                fake_buy,
+            ),
+            patch(
+                "app.services.kis_trading_service.process_kis_domestic_sell_orders_with_analysis",
+                fake_sell,
+            ),
         ):
             monkeypatch.setattr(kis_tasks, "KISClient", DummyKIS)
-            monkeypatch.setattr(
-                kis_tasks, "process_kis_domestic_buy_orders_with_analysis", fake_buy
-            )
-            monkeypatch.setattr(
-                kis_tasks, "process_kis_domestic_sell_orders_with_analysis", fake_sell
-            )
 
             result = asyncio.run(kis_tasks.run_per_domestic_stock_automation())
 
@@ -441,7 +449,7 @@ class TestManualHoldingsIntegration:
         # Mock DB session
         mock_db_session = MagicMock()
         mock_db_session.__aenter__ = AsyncMock(return_value=MagicMock())
-        mock_db_session.__aexit__ = AsyncMock(return_value=None)
+        mock_db_session.__aexit__ = AsyncMock()
 
         with (
             patch("app.core.db.AsyncSessionLocal", return_value=mock_db_session),
@@ -449,14 +457,16 @@ class TestManualHoldingsIntegration:
                 "app.services.manual_holdings_service.ManualHoldingsService",
                 MockManualService,
             ),
+            patch(
+                "app.services.kis_trading_service.process_kis_domestic_buy_orders_with_analysis",
+                fake_buy,
+            ),
+            patch(
+                "app.services.kis_trading_service.process_kis_domestic_sell_orders_with_analysis",
+                fake_sell,
+            ),
         ):
             monkeypatch.setattr(kis_tasks, "KISClient", DummyKIS)
-            monkeypatch.setattr(
-                kis_tasks, "process_kis_domestic_buy_orders_with_analysis", fake_buy
-            )
-            monkeypatch.setattr(
-                kis_tasks, "process_kis_domestic_sell_orders_with_analysis", fake_sell
-            )
 
             result = asyncio.run(kis_tasks.run_per_domestic_stock_automation())
 
@@ -542,14 +552,16 @@ class TestManualHoldingsIntegration:
                 "app.services.manual_holdings_service.ManualHoldingsService",
                 MockManualService,
             ),
+            patch(
+                "app.services.kis_trading_service.process_kis_domestic_buy_orders_with_analysis",
+                fake_buy,
+            ),
+            patch(
+                "app.services.kis_trading_service.process_kis_domestic_sell_orders_with_analysis",
+                fake_sell,
+            ),
         ):
             monkeypatch.setattr(kis_tasks, "KISClient", DummyKIS)
-            monkeypatch.setattr(
-                kis_tasks, "process_kis_domestic_buy_orders_with_analysis", fake_buy
-            )
-            monkeypatch.setattr(
-                kis_tasks, "process_kis_domestic_sell_orders_with_analysis", fake_sell
-            )
 
             result = asyncio.run(kis_tasks.run_per_domestic_stock_automation())
 

--- a/tests/test_kis_toss_notification.py
+++ b/tests/test_kis_toss_notification.py
@@ -29,7 +29,7 @@ class TestDomesticStockTossNotification:
         with patch(
             "app.services.toss_notification_service.send_toss_notification_if_needed"
         ) as mock_send_toss:
-            result = await kis_tasks._analyze_domestic_stock_async("005930")
+            result = await kis_tasks.analyze_domestic_stock_task("005930")
 
             assert result["status"] == "ignored"
             assert result["symbol"] == "005930"
@@ -45,20 +45,20 @@ class TestDomesticStockTossNotification:
         with patch(
             "app.services.toss_notification_service.send_toss_notification_if_needed"
         ) as mock_send_toss:
-            result = await kis_tasks._analyze_domestic_stock_async("035720")
+            result = await kis_tasks.analyze_domestic_stock_task("035720")
 
             assert result["status"] == "ignored"
             mock_send_toss.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_analyze_domestic_stock_no_toss_notification_on_hold(self, mock_db):
-        """국내 주식 분석 함수는 no-op이므로 토스 알림을 보내지 않아야 함"""
+        """국내 주식 분석 함수는 no-op이므로 토스 알림을 별내지 않아야 함"""
         from app.jobs import kis_trading as kis_tasks
 
         with patch(
             "app.services.toss_notification_service.send_toss_notification_if_needed"
         ) as mock_send_toss:
-            result = await kis_tasks._analyze_domestic_stock_async("035420")
+            result = await kis_tasks.analyze_domestic_stock_task("035420")
 
             assert result["status"] == "ignored"
             mock_send_toss.assert_not_called()
@@ -77,7 +77,7 @@ class TestOverseasStockTossNotification:
         with patch(
             "app.services.toss_notification_service.send_toss_notification_if_needed"
         ) as mock_send_toss:
-            result = await kis_tasks._analyze_overseas_stock_async("AAPL")
+            result = await kis_tasks.analyze_overseas_stock_task("AAPL")
 
             assert result["status"] == "ignored"
             assert result["symbol"] == "AAPL"
@@ -93,7 +93,7 @@ class TestOverseasStockTossNotification:
         with patch(
             "app.services.toss_notification_service.send_toss_notification_if_needed"
         ) as mock_send_toss:
-            result = await kis_tasks._analyze_overseas_stock_async("TSLA")
+            result = await kis_tasks.analyze_overseas_stock_task("TSLA")
 
             assert result["status"] == "ignored"
             mock_send_toss.assert_not_called()
@@ -110,7 +110,7 @@ class TestTossNotificationIntegration:
         with patch(
             "app.services.toss_notification_service.send_toss_notification_if_needed"
         ) as mock_send_toss:
-            analysis_result = await kis_tasks._analyze_domestic_stock_async("005930")
+            analysis_result = await kis_tasks.analyze_domestic_stock_task("005930")
 
             assert analysis_result["status"] == "ignored"
             mock_send_toss.assert_not_called()


### PR DESCRIPTION
GitHub Actions test failures fix

- Fixed test_kis_manual_holdings_integration.py to patch functions at correct location
- Fixed test_kis_toss_notification.py to use correct function names

All 18 tests in both files now pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cases with improved mocking approaches for order processing and analysis task verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->