### PR TITLE
fix(ci): add PostgreSQL service and fix test configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,21 @@ jobs:
       matrix:
         python-version: ["3.13"]
 
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_db
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
     steps:
     - uses: actions/checkout@v5
     

--- a/alembic/versions/f29d2ab2ca96_merge_duplicate_heads.py
+++ b/alembic/versions/f29d2ab2ca96_merge_duplicate_heads.py
@@ -1,0 +1,28 @@
+"""merge duplicate heads
+
+Revision ID: f29d2ab2ca96
+Revises: 142f11db8fc3, 2bbc1aab9f3e
+Create Date: 2026-04-15 11:33:01.917380
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f29d2ab2ca96'
+down_revision: Union[str, Sequence[str], None] = ('142f11db8fc3', '2bbc1aab9f3e')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,12 @@ def _ensure_test_env() -> None:
     # regardless of what's in env.example or .env
     os.environ["SECRET_KEY"] = "Test_Secret_Key_12345_Test_Secret_Key_12345"
 
+    # Force overwrite DATABASE_URL to ensure tests use the correct test database
+    # regardless of what's in env.example (which may contain placeholder values)
+    os.environ["DATABASE_URL"] = (
+        "postgresql+asyncpg://postgres:postgres@localhost:5432/test_db"
+    )
+
     # Force disable Sentry during tests — prevent test-originated errors
     # from leaking to the real Sentry project (developer shell may have SENTRY_DSN set)
     os.environ["SENTRY_DSN"] = ""


### PR DESCRIPTION
## 문제

GitHub Actions에서 테스트가 실패했습니다:
1. PostgreSQL 서비스가 없어 데이터베이스 연결 테스트 실패
2. env.example의 placeholder DATABASE_URL이 테스트에 사용됨
3. Alembic 마이그레이션에 duplicate heads 존재

## 해결

- GitHub Actions workflow에 PostgreSQL 서비스 추가
- conftest.py에서 DATABASE_URL을 force overwrite하도록 수정
- Alembic merge migration 생성하여 duplicate heads 해결

## 테스트

- test_us_candles_sync.py 통과 확인 (이전에는 duplicate heads로 실패)
- 전체 테스트 스위트 통과 확인 (3,669 passed)