### PR TITLE
feat: add market reports, trade journal metadata, execution comment MCP tools (ROB-37/50/53)

### DIFF
--- a/alembic/versions/00227d1d2890_merge_rob_37_and_paper_trading_.py
+++ b/alembic/versions/00227d1d2890_merge_rob_37_and_paper_trading_.py
@@ -1,0 +1,25 @@
+"""merge ROB-37 and paper-trading migration heads
+
+Revision ID: 00227d1d2890
+Revises: 0f2f4afaf556, f29d2ab2ca96
+Create Date: 2026-04-15 12:14:04.303310
+
+"""
+
+from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "00227d1d2890"
+down_revision: str | Sequence[str] | None = ("0f2f4afaf556", "f29d2ab2ca96")
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/alembic/versions/0aa8b1405ef4_merge_market_reports_and_paper_trading_.py
+++ b/alembic/versions/0aa8b1405ef4_merge_market_reports_and_paper_trading_.py
@@ -1,0 +1,28 @@
+"""merge market_reports and paper_trading heads
+
+Revision ID: 0aa8b1405ef4
+Revises: 142f11db8fc3, 2bbc1aab9f3e
+Create Date: 2026-04-15 09:52:49.133733
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0aa8b1405ef4'
+down_revision: Union[str, Sequence[str], None] = ('142f11db8fc3', '2bbc1aab9f3e')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/alembic/versions/0f2f4afaf556_add_metadata_jsonb_to_trade_journals.py
+++ b/alembic/versions/0f2f4afaf556_add_metadata_jsonb_to_trade_journals.py
@@ -1,0 +1,31 @@
+"""add metadata jsonb to trade_journals
+
+Revision ID: 0f2f4afaf556
+Revises: 0aa8b1405ef4
+Create Date: 2026-04-15 09:52:58.258448
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0f2f4afaf556'
+down_revision: Union[str, Sequence[str], None] = '0aa8b1405ef4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "trade_journals",
+        sa.Column("metadata", JSONB, nullable=True),
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("trade_journals", "metadata", schema="review")

--- a/app/mcp_server/tooling/execution_comment.py
+++ b/app/mcp_server/tooling/execution_comment.py
@@ -1,0 +1,132 @@
+"""Format trade execution data into structured markdown comments."""
+
+from __future__ import annotations
+
+STAGE_FIELDS: dict[str, set[str]] = {
+    "strategy": {"symbol", "side", "thesis"},
+    "dry_run": {"symbol", "side", "qty", "price", "mode", "currency"},
+    "live": {
+        "symbol",
+        "side",
+        "qty",
+        "price",
+        "mode",
+        "order_id",
+        "journal_id",
+        "fill_status",
+        "account_type",
+        "currency",
+    },
+    "fill": {
+        "symbol",
+        "side",
+        "qty",
+        "price",
+        "mode",
+        "order_id",
+        "journal_id",
+        "fill_status",
+        "filled_qty",
+        "unfilled_qty",
+        "fee",
+        "account_type",
+        "currency",
+    },
+    "follow_up": {"symbol", "journal_id", "next_action", "market_context"},
+}
+
+VALID_STAGES = frozenset(STAGE_FIELDS.keys())
+
+
+def _format_value(key: str, value: object, currency: str | None) -> str:
+    if key == "price" and currency:
+        return f"{currency}{value}"
+    if key == "fee" and currency:
+        return f"{currency}{value}"
+    return str(value)
+
+
+async def format_execution_comment(
+    stage: str,
+    symbol: str,
+    side: str | None = None,
+    qty: float | None = None,
+    price: float | None = None,
+    mode: str | None = None,
+    order_id: str | None = None,
+    journal_id: int | None = None,
+    fill_status: str | None = None,
+    filled_qty: float | None = None,
+    unfilled_qty: float | None = None,
+    fee: float | None = None,
+    currency: str | None = None,
+    thesis: str | None = None,
+    next_action: str | None = None,
+    market_context: str | None = None,
+    account_type: str | None = None,
+) -> str:
+    """Format trade execution data into a structured markdown comment.
+
+    Args:
+        stage: Execution stage — one of "strategy", "dry_run", "live", "fill", "follow_up".
+        symbol: Trading symbol (e.g. "AAPL", "KRW-BTC").
+        side: Trade direction — "buy" or "sell".
+        qty: Order quantity.
+        price: Order or fill price.
+        mode: Execution mode — "dry_run", "live", or "paper".
+        order_id: Broker order identifier.
+        journal_id: Trade journal record ID.
+        fill_status: Fill state — "pending", "filled", "partial", or "cancelled".
+        filled_qty: Quantity filled so far.
+        unfilled_qty: Remaining unfilled quantity.
+        fee: Transaction fee.
+        currency: Currency symbol prepended to price/fee (e.g. "$", "₩").
+        thesis: Investment thesis text (strategy stage).
+        next_action: Follow-up action description.
+        market_context: Market context summary from market reports.
+        account_type: Account type — "kis_auto", "toss_manual", or "paper".
+
+    Returns:
+        Formatted markdown string.
+    """
+    if stage not in VALID_STAGES:
+        return f"Error: invalid stage '{stage}'. Must be one of: {', '.join(sorted(VALID_STAGES))}"
+
+    if stage == "dry_run":
+        mode = "dry_run"
+
+    allowed = STAGE_FIELDS[stage]
+
+    all_fields: list[tuple[str, object]] = [
+        ("symbol", symbol),
+        ("side", side),
+        ("qty", qty),
+        ("price", price),
+        ("mode", mode),
+        ("order_id", order_id),
+        ("journal_id", journal_id),
+        ("fill_status", fill_status),
+        ("filled_qty", filled_qty),
+        ("unfilled_qty", unfilled_qty),
+        ("fee", fee),
+        ("account_type", account_type),
+        ("thesis", thesis),
+        ("next_action", next_action),
+        ("market_context", market_context),
+    ]
+
+    rows: list[str] = []
+    for key, value in all_fields:
+        if key not in allowed or value is None:
+            continue
+        formatted = _format_value(key, value, currency)
+        rows.append(f"| {key} | {formatted} |")
+
+    if not rows:
+        return f"## 실행 기록\n\nNo data for stage '{stage}'."
+
+    header = "## 실행 기록\n| 필드 | 값 |\n|------|-----|"
+    return header + "\n" + "\n".join(rows)
+
+
+__all__ = ["format_execution_comment"]

--- a/app/mcp_server/tooling/execution_comment_registration.py
+++ b/app/mcp_server/tooling/execution_comment_registration.py
@@ -1,0 +1,37 @@
+"""MCP registration for execution comment formatter tool."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.mcp_server.tooling.execution_comment import format_execution_comment
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+EXECUTION_COMMENT_TOOL_NAMES: set[str] = {
+    "format_execution_comment",
+}
+
+
+def register_execution_comment_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="format_execution_comment",
+        description=(
+            "Format trade execution data into a structured markdown comment. "
+            "stage controls which fields appear: "
+            "'strategy' (symbol, side, thesis), "
+            "'dry_run' (symbol, side, qty, price), "
+            "'live' (all fields, fill_status=pending), "
+            "'fill' (all fields incl. filled_qty/fee), "
+            "'follow_up' (symbol, journal_id, next_action, market_context). "
+            "Missing optional fields are omitted. "
+            "Set currency ('$', '₩') to prepend to price/fee."
+        ),
+    )(format_execution_comment)
+
+
+__all__ = [
+    "EXECUTION_COMMENT_TOOL_NAMES",
+    "register_execution_comment_tools",
+]

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from app.mcp_server.tooling.analysis_registration import register_analysis_tools
+from app.mcp_server.tooling.execution_comment_registration import (
+    register_execution_comment_tools,
+)
 from app.mcp_server.tooling.fundamentals_registration import register_fundamentals_tools
 from app.mcp_server.tooling.market_data_registration import register_market_data_tools
 from app.mcp_server.tooling.market_report_registration import (
@@ -54,6 +57,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_paper_account_tools(mcp)
     register_paper_analytics_tools(mcp)
     register_paper_journal_tools(mcp)
+    register_execution_comment_tools(mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/app/mcp_server/tooling/trade_journal_registration.py
+++ b/app/mcp_server/tooling/trade_journal_registration.py
@@ -30,7 +30,9 @@ def register_trade_journal_tools(mcp: FastMCP) -> None:
             "symbol auto-detects instrument_type. min_hold_days sets hold_until. "
             "status defaults to 'draft' — set to 'active' after fill confirmation. "
             "account_type='paper' for paper trading journals (requires account name). "
-            "paper_trade_id links to the paper trade record."
+            "paper_trade_id links to the paper trade record. "
+            "metadata is an optional JSON dict for extensible fields "
+            "(e.g. {\"paperclip_issue_id\": \"ROB-XX\"} for Paperclip linkage)."
         ),
     )(save_trade_journal)
     _ = mcp.tool(
@@ -42,7 +44,9 @@ def register_trade_journal_tools(mcp: FastMCP) -> None:
             "Each entry includes hold_remaining_days and hold_expired. "
             "account_type defaults to 'live'; set to 'paper' for paper journals, "
             "or None to query both. "
-            "account (optional) filters to a specific account name."
+            "account (optional) filters to a specific account name. "
+            "paperclip_issue_id (optional) filters by metadata.paperclip_issue_id "
+            "for reverse lookup from Paperclip issue to trade journal."
         ),
     )(get_trade_journal)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/trade_journal_registration.py
+++ b/app/mcp_server/tooling/trade_journal_registration.py
@@ -32,7 +32,7 @@ def register_trade_journal_tools(mcp: FastMCP) -> None:
             "account_type='paper' for paper trading journals (requires account name). "
             "paper_trade_id links to the paper trade record. "
             "metadata is an optional JSON dict for extensible fields "
-            "(e.g. {\"paperclip_issue_id\": \"ROB-XX\"} for Paperclip linkage)."
+            '(e.g. {"paperclip_issue_id": "ROB-XX"} for Paperclip linkage).'
         ),
     )(save_trade_journal)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/trade_journal_tools.py
+++ b/app/mcp_server/tooling/trade_journal_tools.py
@@ -45,6 +45,7 @@ def _serialize_journal(j: TradeJournal) -> dict[str, Any]:
         "min_hold_days": j.min_hold_days,
         "hold_until": j.hold_until.isoformat() if j.hold_until else None,
         "indicators_snapshot": j.indicators_snapshot,
+        "metadata": j.extra_metadata,
         "status": j.status,
         "trade_id": j.trade_id,
         "exit_price": float(j.exit_price) if j.exit_price is not None else None,
@@ -77,6 +78,7 @@ async def save_trade_journal(
     status: str = "draft",
     account_type: str = "live",
     paper_trade_id: int | None = None,
+    metadata: dict | None = None,
 ) -> dict[str, Any]:
     """Save a trade journal entry with investment thesis and strategy metadata.
 
@@ -85,6 +87,7 @@ async def save_trade_journal(
     Warns if an active journal already exists for the same symbol.
     account_type='paper' for paper trading journals (requires account name).
     paper_trade_id links to the paper trade record.
+    metadata is an optional JSON dict for extensible fields (e.g. {"paperclip_issue_id": "ROB-XX"}).
     """
     symbol = (symbol or "").strip()
     thesis = (thesis or "").strip()
@@ -170,6 +173,7 @@ async def save_trade_journal(
                 account_type=account_type,
                 paper_trade_id=paper_trade_id,
                 notes=notes,
+                extra_metadata=metadata,
             )
             db.add(journal)
             await db.commit()
@@ -199,6 +203,7 @@ async def get_trade_journal(
     limit: int = 50,
     account_type: str | None = "live",
     account: str | None = None,
+    paperclip_issue_id: str | None = None,
 ) -> dict[str, Any]:
     """Query trade journals. Call before any sell decision to check thesis and hold periods.
 
@@ -206,6 +211,7 @@ async def get_trade_journal(
     Each entry includes hold_remaining_days, hold_expired for hold period checks.
     account_type defaults to 'live'; set to 'paper' for paper journals, or None to query both.
     account (optional) filters to a specific account name.
+    paperclip_issue_id (optional) filters by metadata.paperclip_issue_id for reverse lookup.
     """
     try:
         async with _session_factory()() as db:
@@ -238,6 +244,12 @@ async def get_trade_journal(
 
             if account is not None:
                 filters.append(TradeJournal.account == account)
+
+            if paperclip_issue_id is not None:
+                filters.append(
+                    TradeJournal.extra_metadata["paperclip_issue_id"].astext
+                    == paperclip_issue_id
+                )
 
             if market:
                 market_map = {

--- a/app/models/trade_journal.py
+++ b/app/models/trade_journal.py
@@ -86,6 +86,11 @@ class TradeJournal(Base):
     # Indicator snapshot at entry
     indicators_snapshot: Mapped[dict | None] = mapped_column(JSONB)
 
+    # Extensible metadata (e.g. paperclip_issue_id linkage)
+    extra_metadata: Mapped[dict | None] = mapped_column(
+        "metadata", JSONB, nullable=True
+    )
+
     # Status
     status: Mapped[str] = mapped_column(Text, nullable=False, default="draft")
 

--- a/docker-compose.n8n.yml
+++ b/docker-compose.n8n.yml
@@ -16,6 +16,8 @@ services:
       - TZ=Asia/Seoul
       - N8N_DIAGNOSTICS_ENABLED=false
       - N8N_VERSION_NOTIFICATIONS_ENABLED=false
+      - N8N_BLOCK_ENV_ACCESS_IN_NODE=false
+      - N8N_DISCORD_BOT_TOKEN_ALFRED=${N8N_DISCORD_BOT_TOKEN_ALFRED}
       - QUEUE_HEALTH_CHECK_ACTIVE=true
       - NODES_EXCLUDE=[]  # executeCommand 노드 허용 (내부 전용)
       # Paperclip Review Notify workflow

--- a/tests/test_execution_comment.py
+++ b/tests/test_execution_comment.py
@@ -1,0 +1,143 @@
+"""Tests for execution comment formatter MCP tool."""
+
+import pytest
+
+from app.mcp_server.tooling.execution_comment import format_execution_comment
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_strategy_stage():
+    result = await format_execution_comment(
+        stage="strategy",
+        symbol="AAPL",
+        side="buy",
+        thesis="Strong earnings momentum",
+    )
+    assert "## 실행 기록" in result
+    assert "| symbol | AAPL |" in result
+    assert "| side | buy |" in result
+    assert "| thesis | Strong earnings momentum |" in result
+    assert "order_id" not in result
+    assert "fill_status" not in result
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dry_run_stage():
+    result = await format_execution_comment(
+        stage="dry_run",
+        symbol="TSLA",
+        side="buy",
+        qty=5.0,
+        price=250.0,
+        currency="$",
+    )
+    assert "| symbol | TSLA |" in result
+    assert "| price | $250.0 |" in result
+    assert "| mode | dry_run |" in result
+    assert "order_id" not in result
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_live_stage():
+    result = await format_execution_comment(
+        stage="live",
+        symbol="AAPL",
+        side="buy",
+        qty=10.0,
+        price=185.50,
+        mode="live",
+        order_id="KIS-20260415-001",
+        journal_id=42,
+        fill_status="pending",
+        currency="$",
+        account_type="kis_auto",
+    )
+    assert "| order_id | KIS-20260415-001 |" in result
+    assert "| fill_status | pending |" in result
+    assert "| price | $185.5 |" in result
+    assert "| account_type | kis_auto |" in result
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fill_stage_with_fee():
+    result = await format_execution_comment(
+        stage="fill",
+        symbol="AAPL",
+        side="buy",
+        qty=10.0,
+        price=185.50,
+        mode="live",
+        order_id="KIS-20260415-001",
+        journal_id=42,
+        fill_status="filled",
+        filled_qty=10.0,
+        fee=1.5,
+        currency="$",
+    )
+    assert "| fill_status | filled |" in result
+    assert "| filled_qty | 10.0 |" in result
+    assert "| fee | $1.5 |" in result
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_follow_up_stage():
+    result = await format_execution_comment(
+        stage="follow_up",
+        symbol="AAPL",
+        journal_id=42,
+        next_action="hold_until 2026-05-15",
+        market_context="SPY up 1.2%, sector bullish",
+    )
+    assert "| symbol | AAPL |" in result
+    assert "| journal_id | 42 |" in result
+    assert "| next_action | hold_until 2026-05-15 |" in result
+    assert "| market_context | SPY up 1.2%, sector bullish |" in result
+    assert "side" not in result
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_missing_optional_fields_omitted():
+    result = await format_execution_comment(
+        stage="live",
+        symbol="AAPL",
+        side="buy",
+        qty=10.0,
+        price=185.50,
+        mode="live",
+        fill_status="pending",
+    )
+    assert "order_id" not in result
+    assert "journal_id" not in result
+    assert "account_type" not in result
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_invalid_stage():
+    result = await format_execution_comment(
+        stage="invalid",
+        symbol="AAPL",
+    )
+    assert "Error: invalid stage" in result
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_currency_prepended_to_price():
+    result = await format_execution_comment(
+        stage="live",
+        symbol="삼성전자",
+        side="buy",
+        qty=10.0,
+        price=72000,
+        mode="live",
+        fill_status="pending",
+        currency="₩",
+    )
+    assert "| price | ₩72000 |" in result

--- a/tests/test_market_report.py
+++ b/tests/test_market_report.py
@@ -1,0 +1,644 @@
+# tests/test_market_report.py
+"""Tests for market_reports pipeline — model, service, MCP tools."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.market_report import MarketReport
+
+
+class TestMarketReportModel:
+    """MarketReport 모델 기본 테스트."""
+
+    def test_create_minimal_report(self) -> None:
+        report = MarketReport(
+            report_type="daily_brief",
+            report_date=date(2026, 4, 15),
+            market="all",
+            content={"success": True, "brief_text": "hello"},
+            created_at=datetime(2026, 4, 15, 9, 0),
+        )
+        assert report.report_type == "daily_brief"
+        assert report.report_date == date(2026, 4, 15)
+        assert report.market == "all"
+        assert report.content == {"success": True, "brief_text": "hello"}
+        assert report.title is None
+        assert report.summary is None
+        assert report.metadata_ is None
+
+    def test_create_full_report(self) -> None:
+        report = MarketReport(
+            report_type="kr_morning",
+            report_date=date(2026, 4, 15),
+            market="kr",
+            content={"holdings": [], "screening": {}},
+            title="KR Morning Report — 04/15 (화)",
+            summary="오늘의 한국 주식 시장 요약",
+            metadata_={"source": "n8n", "version": 2},
+            user_id=1,
+            created_at=datetime(2026, 4, 15, 8, 0),
+            updated_at=datetime(2026, 4, 15, 8, 30),
+        )
+        assert report.title == "KR Morning Report — 04/15 (화)"
+        assert report.summary == "오늘의 한국 주식 시장 요약"
+        assert report.metadata_ == {"source": "n8n", "version": 2}
+        assert report.user_id == 1
+        assert report.updated_at is not None
+
+    def test_table_args(self) -> None:
+        assert MarketReport.__tablename__ == "market_reports"
+
+    def test_repr(self) -> None:
+        report = MarketReport(
+            id=1,
+            report_type="crypto_scan",
+            report_date=date(2026, 4, 15),
+            market="crypto",
+            content={},
+            created_at=datetime(2026, 4, 15, 9, 0),
+        )
+        assert "crypto_scan" in repr(report)
+        assert "crypto" in repr(report)
+
+
+class TestReportToDict:
+    """_report_to_dict 직렬화 테스트."""
+
+    def test_serializes_all_fields(self) -> None:
+        from app.services.market_report_service import _report_to_dict
+
+        report = MarketReport(
+            id=5,
+            report_type="daily_brief",
+            report_date=date(2026, 4, 15),
+            market="all",
+            content={"brief_text": "hello"},
+            title="Daily Brief — 04/15",
+            summary="Summary text",
+            metadata_={"source": "test"},
+            created_at=datetime(2026, 4, 15, 9, 0),
+            updated_at=datetime(2026, 4, 15, 9, 30),
+        )
+
+        d = _report_to_dict(report)
+        assert d["id"] == 5
+        assert d["report_type"] == "daily_brief"
+        assert d["report_date"] == "2026-04-15"
+        assert d["market"] == "all"
+        assert d["content"] == {"brief_text": "hello"}
+        assert d["title"] == "Daily Brief — 04/15"
+        assert d["summary"] == "Summary text"
+        assert d["metadata"] == {"source": "test"}
+        assert d["created_at"] == "2026-04-15T09:00:00"
+        assert d["updated_at"] == "2026-04-15T09:30:00"
+
+    def test_serializes_none_timestamps(self) -> None:
+        from app.services.market_report_service import _report_to_dict
+
+        report = MarketReport(
+            id=6,
+            report_type="crypto_scan",
+            report_date=date(2026, 4, 15),
+            market="crypto",
+            content={"coins": []},
+            created_at=datetime(2026, 4, 15, 9, 0),
+            updated_at=None,
+        )
+
+        d = _report_to_dict(report)
+        assert d["updated_at"] is None
+        assert d["metadata"] is None
+
+
+class TestSerializeResult:
+    """_serialize_result 재귀 변환 테스트."""
+
+    def test_plain_dict_passthrough(self) -> None:
+        from app.services.market_report_service import _serialize_result
+
+        inp = {"key": "value", "num": 42}
+        out = _serialize_result(inp)
+        assert out == {"key": "value", "num": 42}
+
+    def test_errors_field_stringified(self) -> None:
+        from app.services.market_report_service import _serialize_result
+
+        inp = {"errors": [{"code": 500, "msg": "fail"}, "raw error"]}
+        out = _serialize_result(inp)
+        assert out["errors"][0] == {"code": "500", "msg": "fail"}
+        assert out["errors"][1] == "raw error"
+
+    def test_pydantic_model_dump(self) -> None:
+        from app.services.market_report_service import _serialize_result
+
+        mock_model = MagicMock()
+        mock_model.model_dump.return_value = {"field": "val"}
+        inp = {"data": mock_model}
+        out = _serialize_result(inp)
+        assert out["data"] == {"field": "val"}
+
+    def test_nested_dict_recursion(self) -> None:
+        from app.services.market_report_service import _serialize_result
+
+        inp = {"outer": {"inner": "value"}}
+        out = _serialize_result(inp)
+        assert out["outer"]["inner"] == "value"
+
+    def test_list_with_pydantic(self) -> None:
+        from app.services.market_report_service import _serialize_result
+
+        mock_model = MagicMock()
+        mock_model.model_dump.return_value = {"a": 1}
+        inp = {"items": [mock_model, "plain"]}
+        out = _serialize_result(inp)
+        assert out["items"] == [{"a": 1}, "plain"]
+
+
+class TestSaveDailyBriefReport:
+    """save_daily_brief_report DB 저장 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_saves_with_valid_as_of(self) -> None:
+        from app.services.market_report_service import save_daily_brief_report
+
+        with patch(
+            "app.services.market_report_service.upsert_market_report",
+            new_callable=AsyncMock,
+            return_value=1,
+        ) as mock_upsert:
+            await save_daily_brief_report(
+                {
+                    "as_of": "2026-04-15T09:00:00+09:00",
+                    "date_fmt": "04/15 (화)",
+                    "brief_text": "Daily summary",
+                    "success": True,
+                }
+            )
+
+        mock_upsert.assert_called_once()
+        kwargs = mock_upsert.call_args.kwargs
+        assert kwargs["report_type"] == "daily_brief"
+        assert kwargs["report_date"] == date(2026, 4, 15)
+        assert kwargs["market"] == "all"
+        assert kwargs["title"] == "Daily Brief — 04/15 (화)"
+        assert kwargs["summary"] == "Daily summary"
+
+    @pytest.mark.asyncio
+    async def test_fallback_date_on_invalid_as_of(self) -> None:
+        from app.services.market_report_service import save_daily_brief_report
+
+        with patch(
+            "app.services.market_report_service.upsert_market_report",
+            new_callable=AsyncMock,
+            return_value=1,
+        ) as mock_upsert:
+            await save_daily_brief_report({"as_of": "INVALID", "brief_text": "test"})
+
+        kwargs = mock_upsert.call_args.kwargs
+        assert isinstance(kwargs["report_date"], date)
+
+    @pytest.mark.asyncio
+    async def test_exception_does_not_propagate(self) -> None:
+        from app.services.market_report_service import save_daily_brief_report
+
+        with patch(
+            "app.services.market_report_service.upsert_market_report",
+            new_callable=AsyncMock,
+            side_effect=Exception("DB error"),
+        ):
+            await save_daily_brief_report({"as_of": "2026-04-15T09:00:00+09:00"})
+
+
+class TestSaveKrMorningReport:
+    """save_kr_morning_report DB 저장 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_saves_kr_morning(self) -> None:
+        from app.services.market_report_service import save_kr_morning_report
+
+        with patch(
+            "app.services.market_report_service.upsert_market_report",
+            new_callable=AsyncMock,
+            return_value=2,
+        ) as mock_upsert:
+            await save_kr_morning_report(
+                {
+                    "as_of": "2026-04-15T08:30:00+09:00",
+                    "date_fmt": "04/15 (화)",
+                    "brief_text": "KR morning summary",
+                }
+            )
+
+        kwargs = mock_upsert.call_args.kwargs
+        assert kwargs["report_type"] == "kr_morning"
+        assert kwargs["market"] == "kr"
+        assert kwargs["title"] == "KR Morning Report — 04/15 (화)"
+        assert kwargs["summary"] == "KR morning summary"
+
+
+class TestSaveCryptoScanReport:
+    """save_crypto_scan_report DB 저장 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_saves_crypto_scan(self) -> None:
+        from app.services.market_report_service import save_crypto_scan_report
+
+        with patch(
+            "app.services.market_report_service.upsert_market_report",
+            new_callable=AsyncMock,
+            return_value=3,
+        ) as mock_upsert:
+            await save_crypto_scan_report({"coins": [], "summary": "no signals"})
+
+        kwargs = mock_upsert.call_args.kwargs
+        assert kwargs["report_type"] == "crypto_scan"
+        assert kwargs["market"] == "crypto"
+        assert kwargs["summary"] is None
+
+
+class TestGetMarketReports:
+    """get_market_reports 조회 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_returns_filtered_reports(self) -> None:
+        from app.services.market_report_service import get_market_reports
+
+        report = MarketReport(
+            id=1,
+            report_type="daily_brief",
+            report_date=date(2026, 4, 15),
+            market="all",
+            content={"brief_text": "hello"},
+            title="Daily Brief",
+            summary="summary",
+            created_at=datetime(2026, 4, 15, 9, 0),
+            updated_at=None,
+        )
+
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [report]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        session_cm = AsyncMock()
+        session_cm.__aenter__.return_value = mock_session
+        session_cm.__aexit__.return_value = None
+
+        with patch(
+            "app.services.market_report_service.AsyncSessionLocal",
+            return_value=session_cm,
+        ):
+            reports = await get_market_reports(report_type="daily_brief", days=7)
+
+        assert len(reports) == 1
+        assert reports[0]["report_type"] == "daily_brief"
+        assert reports[0]["market"] == "all"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list(self) -> None:
+        from app.services.market_report_service import get_market_reports
+
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        session_cm = AsyncMock()
+        session_cm.__aenter__.return_value = mock_session
+        session_cm.__aexit__.return_value = None
+
+        with patch(
+            "app.services.market_report_service.AsyncSessionLocal",
+            return_value=session_cm,
+        ):
+            reports = await get_market_reports(report_type="kr_morning", market="kr")
+
+        assert reports == []
+
+
+class TestGetLatestMarketBrief:
+    """get_latest_market_brief 조회 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_returns_latest_brief(self) -> None:
+        from app.services.market_report_service import get_latest_market_brief
+
+        report = MarketReport(
+            id=10,
+            report_type="daily_brief",
+            report_date=date(2026, 4, 15),
+            market="all",
+            content={"brief_text": "latest"},
+            created_at=datetime(2026, 4, 15, 9, 0),
+            updated_at=None,
+        )
+
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.first.return_value = report
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        session_cm = AsyncMock()
+        session_cm.__aenter__.return_value = mock_session
+        session_cm.__aexit__.return_value = None
+
+        with patch(
+            "app.services.market_report_service.AsyncSessionLocal",
+            return_value=session_cm,
+        ):
+            result = await get_latest_market_brief(market="all")
+
+        assert result is not None
+        assert result["report_type"] == "daily_brief"
+        assert result["content"] == {"brief_text": "latest"}
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_empty(self) -> None:
+        from app.services.market_report_service import get_latest_market_brief
+
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.first.return_value = None
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        session_cm = AsyncMock()
+        session_cm.__aenter__.return_value = mock_session
+        session_cm.__aexit__.return_value = None
+
+        with patch(
+            "app.services.market_report_service.AsyncSessionLocal",
+            return_value=session_cm,
+        ):
+            result = await get_latest_market_brief(market="us")
+
+        assert result is None
+
+
+class TestMCPGetMarketReports:
+    """MCP get_market_reports 도구 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_returns_count_and_reports(self) -> None:
+        from app.mcp_server.tooling.market_report_handlers import (
+            _get_market_reports_impl,
+        )
+
+        mock_reports = [
+            {"id": 1, "report_type": "daily_brief", "market": "all"},
+            {"id": 2, "report_type": "kr_morning", "market": "kr"},
+        ]
+
+        with patch(
+            "app.mcp_server.tooling.market_report_handlers.get_market_reports",
+            new_callable=AsyncMock,
+            return_value=mock_reports,
+        ):
+            result = await _get_market_reports_impl(report_type="daily_brief", days=7)
+
+        assert result["count"] == 2
+        assert result["reports"] == mock_reports
+
+    @pytest.mark.asyncio
+    async def test_defaults_days_and_limit(self) -> None:
+        from app.mcp_server.tooling.market_report_handlers import (
+            _get_market_reports_impl,
+        )
+
+        with patch(
+            "app.mcp_server.tooling.market_report_handlers.get_market_reports",
+            new_callable=AsyncMock,
+            return_value=[],
+        ) as mock_get:
+            await _get_market_reports_impl(days=None, limit=None)
+
+        kwargs = mock_get.call_args.kwargs
+        assert kwargs["days"] == 7
+        assert kwargs["limit"] == 10
+
+    @pytest.mark.asyncio
+    async def test_empty_results(self) -> None:
+        from app.mcp_server.tooling.market_report_handlers import (
+            _get_market_reports_impl,
+        )
+
+        with patch(
+            "app.mcp_server.tooling.market_report_handlers.get_market_reports",
+            new_callable=AsyncMock,
+            return_value=[],
+        ):
+            result = await _get_market_reports_impl()
+
+        assert result["count"] == 0
+        assert result["reports"] == []
+
+
+class TestMCPGetLatestMarketBrief:
+    """MCP get_latest_market_brief 도구 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_found_report(self) -> None:
+        from app.mcp_server.tooling.market_report_handlers import (
+            _get_latest_market_brief_impl,
+        )
+
+        mock_report = {"id": 1, "report_type": "daily_brief", "market": "all"}
+
+        with patch(
+            "app.mcp_server.tooling.market_report_handlers.get_latest_market_brief",
+            new_callable=AsyncMock,
+            return_value=mock_report,
+        ):
+            result = await _get_latest_market_brief_impl(market="all")
+
+        assert result["found"] is True
+        assert result["report"] == mock_report
+
+    @pytest.mark.asyncio
+    async def test_not_found(self) -> None:
+        from app.mcp_server.tooling.market_report_handlers import (
+            _get_latest_market_brief_impl,
+        )
+
+        with patch(
+            "app.mcp_server.tooling.market_report_handlers.get_latest_market_brief",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await _get_latest_market_brief_impl(market="us")
+
+        assert result["found"] is False
+        assert result["report"] is None
+
+    @pytest.mark.asyncio
+    async def test_defaults_market_to_all(self) -> None:
+        from app.mcp_server.tooling.market_report_handlers import (
+            _get_latest_market_brief_impl,
+        )
+
+        with patch(
+            "app.mcp_server.tooling.market_report_handlers.get_latest_market_brief",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_get:
+            await _get_latest_market_brief_impl(market=None)
+
+        kwargs = mock_get.call_args.kwargs
+        assert kwargs["market"] == "all"
+
+
+class TestMCPToolRegistration:
+    """MCP 도구 등록 테스트."""
+
+    def test_market_report_tools_registered(self) -> None:
+        from tests._mcp_tooling_support import build_tools
+
+        tools = build_tools()
+        assert "get_market_reports" in tools
+        assert "get_latest_market_brief" in tools
+
+    def test_tool_names_constant(self) -> None:
+        from app.mcp_server.tooling.market_report_handlers import (
+            MARKET_REPORT_TOOL_NAMES,
+        )
+
+        assert "get_market_reports" in MARKET_REPORT_TOOL_NAMES
+        assert "get_latest_market_brief" in MARKET_REPORT_TOOL_NAMES
+
+
+class TestN8nEndpointDbSave:
+    """n8n 엔드포인트에서 DB 저장 호출 확인."""
+
+    @pytest.mark.integration
+    def test_daily_brief_triggers_save(self) -> None:
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from app.schemas.n8n.common import N8nMarketOverview
+
+        app = FastAPI()
+        from app.routers.n8n import router
+
+        app.include_router(router)
+        client = TestClient(app)
+
+        result = {
+            "success": True,
+            "as_of": "2026-04-15T09:00:00+09:00",
+            "date_fmt": "04/15 (화)",
+            "market_overview": N8nMarketOverview(
+                fear_greed=None,
+                btc_dominance=56.64,
+                total_market_cap_change_24h=3.86,
+                economic_events_today=[],
+            ),
+            "pending_orders": {"crypto": None, "kr": None, "us": None},
+            "portfolio_summary": {"crypto": None, "kr": None, "us": None},
+            "yesterday_fills": {"total": 0, "fills": []},
+            "brief_text": "Daily Brief text",
+            "errors": [],
+        }
+
+        with (
+            patch(
+                "app.routers.n8n.fetch_daily_brief",
+                new_callable=AsyncMock,
+                return_value=result,
+            ),
+            patch(
+                "app.routers.n8n.save_daily_brief_report",
+                new_callable=AsyncMock,
+            ) as mock_save,
+        ):
+            resp = client.get("/api/n8n/daily-brief")
+
+        assert resp.status_code == 200
+        mock_save.assert_called_once()
+
+    @pytest.mark.integration
+    def test_kr_morning_report_triggers_save(self) -> None:
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        app = FastAPI()
+        from app.routers.n8n import router
+
+        app.include_router(router)
+        client = TestClient(app)
+
+        result = {
+            "success": True,
+            "as_of": "2026-04-15T08:30:00+09:00",
+            "date_fmt": "04/15 (화)",
+            "holdings": {},
+            "cash_balance": {},
+            "screening": {},
+            "pending_orders": {},
+            "brief_text": "KR Morning text",
+            "errors": [],
+        }
+
+        with (
+            patch(
+                "app.routers.n8n.fetch_kr_morning_report",
+                new_callable=AsyncMock,
+                return_value=result,
+            ),
+            patch(
+                "app.routers.n8n.save_kr_morning_report",
+                new_callable=AsyncMock,
+            ) as mock_save,
+        ):
+            resp = client.get("/api/n8n/kr-morning-report")
+
+        assert resp.status_code == 200
+        mock_save.assert_called_once()
+
+    @pytest.mark.integration
+    def test_crypto_scan_triggers_save(self) -> None:
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        app = FastAPI()
+        from app.routers.n8n import router
+
+        app.include_router(router)
+        client = TestClient(app)
+
+        result = {
+            "success": True,
+            "as_of": "2026-04-15T09:00:00+09:00",
+            "scan_params": {},
+            "btc_context": None,
+            "fear_greed": None,
+            "coins": [],
+            "summary": {"total_scanned": 30, "top_n_count": 20, "holdings_added": 5},
+            "errors": [],
+        }
+
+        with (
+            patch(
+                "app.routers.n8n.fetch_crypto_scan",
+                new_callable=AsyncMock,
+                return_value=result,
+            ),
+            patch(
+                "app.routers.n8n.save_crypto_scan_report",
+                new_callable=AsyncMock,
+            ) as mock_save,
+        ):
+            resp = client.get("/api/n8n/crypto-scan")
+
+        assert resp.status_code == 200
+        mock_save.assert_called_once()

--- a/tests/test_mcp_trade_journal.py
+++ b/tests/test_mcp_trade_journal.py
@@ -247,6 +247,168 @@ class TestGetTradeJournal:
         assert result["summary"]["total_active"] == 0
 
 
+class TestSaveTradeJournalMetadata:
+    """save_trade_journal metadata 파라미터 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_save_with_metadata_stores_correctly(self) -> None:
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.first.return_value = None
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        factory = _mock_session_factory(mock_session)
+        with patch(
+            "app.mcp_server.tooling.trade_journal_tools._session_factory",
+            return_value=factory,
+        ):
+            result = await save_trade_journal(
+                symbol="KRW-BTC",
+                thesis="RSI oversold bounce play",
+                metadata={"paperclip_issue_id": "ROB-51", "source": "auto"},
+            )
+
+        assert result["success"] is True
+        added_obj = mock_session.add.call_args[0][0]
+        assert isinstance(added_obj, TradeJournal)
+        assert added_obj.extra_metadata == {
+            "paperclip_issue_id": "ROB-51",
+            "source": "auto",
+        }
+
+    @pytest.mark.asyncio
+    async def test_save_without_metadata_no_regression(self) -> None:
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.first.return_value = None
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        factory = _mock_session_factory(mock_session)
+        with patch(
+            "app.mcp_server.tooling.trade_journal_tools._session_factory",
+            return_value=factory,
+        ):
+            result = await save_trade_journal(
+                symbol="KRW-BTC",
+                thesis="RSI oversold bounce play",
+            )
+
+        assert result["success"] is True
+        added_obj = mock_session.add.call_args[0][0]
+        assert added_obj.extra_metadata is None
+
+
+class TestGetTradeJournalPaperclipIssueId:
+    """get_trade_journal paperclip_issue_id 필터 테스트."""
+
+    @pytest.mark.asyncio
+    async def test_filter_by_paperclip_issue_id_returns_matching(self) -> None:
+        now = datetime.now(UTC)
+        journal = TradeJournal(
+            id=10,
+            symbol="KRW-BTC",
+            instrument_type=InstrumentType.crypto,
+            thesis="RSI oversold",
+            status="active",
+            side="buy",
+            extra_metadata={"paperclip_issue_id": "ROB-51"},
+            created_at=now,
+            updated_at=now,
+        )
+
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [journal]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        factory = _mock_session_factory(mock_session)
+        with patch(
+            "app.mcp_server.tooling.trade_journal_tools._session_factory",
+            return_value=factory,
+        ):
+            result = await get_trade_journal(paperclip_issue_id="ROB-51")
+
+        assert result["success"] is True
+        assert len(result["entries"]) == 1
+        assert result["entries"][0]["metadata"] == {"paperclip_issue_id": "ROB-51"}
+
+    @pytest.mark.asyncio
+    async def test_filter_by_paperclip_issue_id_no_matches(self) -> None:
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        factory = _mock_session_factory(mock_session)
+        with patch(
+            "app.mcp_server.tooling.trade_journal_tools._session_factory",
+            return_value=factory,
+        ):
+            result = await get_trade_journal(paperclip_issue_id="ROB-999")
+
+        assert result["success"] is True
+        assert result["entries"] == []
+        assert result["summary"]["total_active"] == 0
+
+    @pytest.mark.asyncio
+    async def test_paperclip_issue_id_filter_builds_correct_query(self) -> None:
+        mock_session = AsyncMock()
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        mock_session.execute.return_value = mock_result
+
+        factory = _mock_session_factory(mock_session)
+        with patch(
+            "app.mcp_server.tooling.trade_journal_tools._session_factory",
+            return_value=factory,
+        ):
+            await get_trade_journal(paperclip_issue_id="ROB-51")
+
+        stmt = mock_session.execute.call_args[0][0]
+        compiled_sql = str(stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "metadata" in compiled_sql.lower()
+        assert "paperclip_issue_id" in compiled_sql
+
+
+class TestSerializeJournalMetadata:
+    """_serialize_journal metadata 필드 직렬화 테스트."""
+
+    def test_serialize_includes_metadata(self) -> None:
+        journal = TradeJournal(
+            symbol="KRW-BTC",
+            instrument_type=InstrumentType.crypto,
+            thesis="Test",
+            extra_metadata={"paperclip_issue_id": "ROB-51"},
+        )
+        journal.id = 1
+        journal.created_at = now_kst()
+        journal.updated_at = now_kst()
+        result = _serialize_journal(journal)
+        assert result["metadata"] == {"paperclip_issue_id": "ROB-51"}
+
+    def test_serialize_metadata_none(self) -> None:
+        journal = TradeJournal(
+            symbol="KRW-BTC",
+            instrument_type=InstrumentType.crypto,
+            thesis="Test",
+        )
+        journal.id = 2
+        journal.created_at = now_kst()
+        journal.updated_at = now_kst()
+        result = _serialize_journal(journal)
+        assert result["metadata"] is None
+
+
 class TestSerializeJournalNewFields:
     """account_type, paper_trade_id 직렬화 테스트."""
 

--- a/tests/test_trade_journal_model.py
+++ b/tests/test_trade_journal_model.py
@@ -103,3 +103,42 @@ class TestAccountTypeField:
             thesis="Test thesis",
         )
         assert journal.paper_trade_id is None
+
+
+class TestMetadataJSONBField:
+    """extra_metadata (JSONB 'metadata' column) 테스트."""
+
+    def test_create_with_metadata_dict(self) -> None:
+        journal = TradeJournal(
+            symbol="KRW-BTC",
+            instrument_type=InstrumentType.crypto,
+            thesis="RSI oversold",
+            extra_metadata={"paperclip_issue_id": "ROB-51"},
+        )
+        assert journal.extra_metadata == {"paperclip_issue_id": "ROB-51"}
+
+    def test_create_with_none_metadata(self) -> None:
+        journal = TradeJournal(
+            symbol="KRW-BTC",
+            instrument_type=InstrumentType.crypto,
+            thesis="RSI oversold",
+        )
+        assert journal.extra_metadata is None
+
+    def test_metadata_stores_complex_nested_json(self) -> None:
+        nested = {
+            "paperclip_issue_id": "ROB-51",
+            "tags": ["momentum", "oversold"],
+            "scores": {"technical": 85, "fundamental": 70},
+            "nested": {"deep": {"value": True}},
+        }
+        journal = TradeJournal(
+            symbol="AAPL",
+            instrument_type=InstrumentType.equity_us,
+            thesis="Earnings play",
+            extra_metadata=nested,
+        )
+        assert journal.extra_metadata == nested
+        assert journal.extra_metadata["tags"] == ["momentum", "oversold"]
+        assert journal.extra_metadata["scores"]["technical"] == 85
+        assert journal.extra_metadata["nested"]["deep"]["value"] is True


### PR DESCRIPTION
## Summary

- **ROB-37**: Add `market_reports` table, DB persistence via `market_report_service`, and MCP tools for saving/querying market reports
- **ROB-50**: Add `metadata` JSONB column to `trade_journals` table with MCP tool support for filtering by `paperclip_issue_id`
- **ROB-53**: Add `format_execution_comment` MCP tool for generating structured trade execution comments

## Changes

- 3 new Alembic migrations (market_reports table, trade_journal metadata column, merge head)
- New model: `MarketReport` with report types (daily_brief, weekly_summary, etc.)
- New service: `market_report_service.py` with save/query/latest/summary functions
- New MCP tools: `save_market_report`, `get_market_reports`, `format_execution_comment`
- Trade journal MCP tools updated with `metadata` parameter and `paperclip_issue_id` filter
- n8n router endpoint for daily brief DB persistence
- Docker compose: enable env access in n8n nodes, add Discord bot token passthrough

## Test plan

- [x] `tests/test_market_report.py` — 646 lines covering model, service, MCP tools, n8n endpoint
- [x] `tests/test_mcp_trade_journal.py` — metadata save/filter tests added
- [x] `tests/test_trade_journal_model.py` — JSONB field unit tests added
- [x] `tests/test_execution_comment.py` — execution comment formatting tests (already committed)
- [x] Ruff lint + format passing

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata support to trade journals for storing custom fields and filtering by linked issue IDs.
  * Introduced structured execution comment formatting tool for standardized trade execution documentation.

* **Tests**
  * Added comprehensive test coverage for trade journal metadata, market reports, and execution comment functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->