### PR TITLE
feat(n8n): SK하이닉스 매도 신호 평가 서비스 + n8n 엔드포인트

### DIFF
--- a/app/mcp_server/tooling/fundamentals/_valuation.py
+++ b/app/mcp_server/tooling/fundamentals/_valuation.py
@@ -5,6 +5,8 @@ Includes: get_valuation, get_investment_opinions, get_investor_trends, get_short
 
 from __future__ import annotations
 
+import datetime
+from collections import defaultdict
 from typing import Any
 
 from app.mcp_server.tooling.fundamentals._helpers import normalize_equity_market
@@ -108,6 +110,7 @@ async def handle_get_investment_opinions(
 async def handle_get_investor_trends(
     symbol: str,
     days: int = 20,
+    period: str = "day",
 ) -> dict[str, Any]:
     symbol = (symbol or "").strip()
     if not symbol:
@@ -119,10 +122,21 @@ async def handle_get_investor_trends(
             "(6-digit codes like '005930')"
         )
 
-    capped_days = min(max(days, 1), 60)
+    period = (period or "day").lower()
+    if period not in ("day", "week", "month"):
+        raise ValueError("period must be 'day', 'week', or 'month'")
+
+    # Fetch more daily data when aggregating to week/month
+    if period == "month":
+        fetch_days = min(max(days, 1), 60) * 22  # ~22 trading days/month
+    elif period == "week":
+        fetch_days = min(max(days, 1), 60) * 5
+    else:
+        fetch_days = min(max(days, 1), 60)
+    fetch_days = min(fetch_days, 60)  # Naver caps at ~60 rows per page
 
     try:
-        return await _fetch_investor_trends_naver(symbol, capped_days)
+        result = await _fetch_investor_trends_naver(symbol, fetch_days)
     except Exception as exc:
         return _error_payload(
             source="naver",
@@ -130,6 +144,69 @@ async def handle_get_investor_trends(
             symbol=symbol,
             instrument_type="equity_kr",
         )
+
+    # Add individual_net (derived: negative of institutional + foreign)
+    for row in result.get("data", []):
+        inst = row.get("institutional_net") or 0
+        frgn = row.get("foreign_net") or 0
+        row["individual_net"] = -(inst + frgn)
+
+    if period != "day":
+        result["data"] = _aggregate_investor_data(result["data"], period)
+
+    result["period"] = period
+    capped_days = min(max(days, 1), 60)
+    result["data"] = result["data"][:capped_days]
+    result["days"] = len(result["data"])
+    return result
+
+
+def _aggregate_investor_data(
+    daily_data: list[dict[str, Any]], period: str
+) -> list[dict[str, Any]]:
+    """Aggregate daily investor flow data into weekly or monthly buckets."""
+    if not daily_data:
+        return []
+
+    buckets: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+    for row in daily_data:
+        date_str = row.get("date", "")
+        if not date_str:
+            continue
+        try:
+            dt = datetime.date.fromisoformat(date_str)
+        except (ValueError, TypeError):
+            continue
+
+        if period == "week":
+            # ISO week: Monday-based
+            iso = dt.isocalendar()
+            key = f"{iso[0]}-W{iso[1]:02d}"
+        else:  # month
+            key = f"{dt.year}-{dt.month:02d}"
+
+        buckets[key].append(row)
+
+    aggregated: list[dict[str, Any]] = []
+    for key in sorted(buckets, reverse=True):
+        rows = buckets[key]
+        # Use the most recent date in the bucket as representative
+        rows_sorted = sorted(rows, key=lambda r: r.get("date", ""), reverse=True)
+        agg: dict[str, Any] = {
+            "period_key": key,
+            "date_start": rows_sorted[-1].get("date", ""),
+            "date_end": rows_sorted[0].get("date", ""),
+            "trading_days": len(rows),
+            "close": rows_sorted[0].get("close"),
+            "volume": sum(r.get("volume") or 0 for r in rows),
+            "institutional_net": sum(r.get("institutional_net") or 0 for r in rows),
+            "foreign_net": sum(r.get("foreign_net") or 0 for r in rows),
+            "individual_net": sum(r.get("individual_net") or 0 for r in rows),
+        }
+        aggregated.append(agg)
+
+    return aggregated
 
 
 async def handle_get_short_interest(

--- a/app/mcp_server/tooling/fundamentals_handlers.py
+++ b/app/mcp_server/tooling/fundamentals_handlers.py
@@ -142,15 +142,17 @@ def _register_fundamentals_tools_impl(mcp: FastMCP) -> None:
     @mcp.tool(
         name="get_investor_trends",
         description=(
-            "Get foreign and institutional investor trading trends for a Korean "
-            "stock. Returns daily net buy/sell data. Korean stocks only."
+            "Get foreign, institutional, and individual investor trading trends "
+            "for a Korean stock. Returns net buy/sell data by investor type. "
+            "Supports daily/weekly/monthly aggregation. Korean stocks only."
         ),
     )
     async def get_investor_trends(
         symbol: str,
         days: int = 20,
+        period: str = "day",
     ) -> dict[str, Any]:
-        return await handle_get_investor_trends(symbol, days)
+        return await handle_get_investor_trends(symbol, days, period)
 
     @mcp.tool(
         name="get_investment_opinions",

--- a/app/mcp_server/tooling/paper_analytics_registration.py
+++ b/app/mcp_server/tooling/paper_analytics_registration.py
@@ -170,27 +170,33 @@ def register_paper_analytics_tools(mcp: FastMCP) -> None:
             for account_name in names:
                 account = await service.get_account_by_name(account_name)
                 if account is None:
-                    comparison.append({
-                        "account_name": account_name,
-                        "performance": None,
-                        "error": f"Paper account '{account_name}' not found",
-                    })
+                    comparison.append(
+                        {
+                            "account_name": account_name,
+                            "performance": None,
+                            "error": f"Paper account '{account_name}' not found",
+                        }
+                    )
                     continue
                 try:
                     perf = await service.calculate_performance(
                         account_id=account.id, start_date=start, end_date=end
                     )
-                    comparison.append({
-                        "account_name": account_name,
-                        "performance": perf,
-                        "error": None,
-                    })
+                    comparison.append(
+                        {
+                            "account_name": account_name,
+                            "performance": perf,
+                            "error": None,
+                        }
+                    )
                 except ValueError as exc:
-                    comparison.append({
-                        "account_name": account_name,
-                        "performance": None,
-                        "error": str(exc),
-                    })
+                    comparison.append(
+                        {
+                            "account_name": account_name,
+                            "performance": None,
+                            "error": str(exc),
+                        }
+                    )
 
         return {"success": True, "period": period, "comparison": comparison}
 

--- a/app/models/paper_trading.py
+++ b/app/models/paper_trading.py
@@ -144,7 +144,8 @@ class PaperDailySnapshot(Base):
     __tablename__ = "paper_daily_snapshots"
     __table_args__ = (
         UniqueConstraint(
-            "account_id", "snapshot_date",
+            "account_id",
+            "snapshot_date",
             name="uq_paper_daily_snapshots_account_date",
         ),
         Index("ix_paper_daily_snapshots_account_date", "account_id", "snapshot_date"),

--- a/app/routers/n8n.py
+++ b/app/routers/n8n.py
@@ -48,6 +48,7 @@ from app.services.n8n_filled_orders_service import fetch_filled_orders
 from app.services.n8n_formatting import fmt_date_with_weekday
 from app.services.n8n_kr_morning_report_service import fetch_kr_morning_report
 from app.services.n8n_market_context_service import fetch_market_context
+from app.schemas.n8n.sell_signal import N8nSellSignalResponse
 from app.services.n8n_news_service import fetch_n8n_news
 from app.services.n8n_pending_orders_service import fetch_pending_orders
 from app.services.n8n_pending_review_service import fetch_pending_review
@@ -60,6 +61,7 @@ from app.services.n8n_trade_review_service import (
     get_trade_reviews,
     save_trade_reviews,
 )
+from app.services.sell_signal_service import evaluate_sell_signal
 
 logger = logging.getLogger(__name__)
 
@@ -586,3 +588,47 @@ async def get_n8n_news(
         return JSONResponse(status_code=500, content=payload.model_dump())
 
     return result
+
+
+@router.get("/sell-signal/{symbol}", response_model=N8nSellSignalResponse)
+async def get_sell_signal(
+    symbol: str,
+    price_threshold: float = Query(1_152_000, description="Trailing stop price (KRW)"),
+    stoch_rsi_threshold: float = Query(80, description="StochRSI K threshold"),
+    foreign_days: int = Query(2, ge=1, le=5, description="Foreign consecutive sell days"),
+    rsi_high: float = Query(70, description="RSI high watermark"),
+    rsi_low: float = Query(65, description="RSI low trigger"),
+    bb_upper_ref: float = Query(1_142_000, description="Bollinger upper reference (KRW)"),
+) -> N8nSellSignalResponse | JSONResponse:
+    as_of = now_kst().replace(microsecond=0).isoformat()
+
+    try:
+        result = await evaluate_sell_signal(
+            symbol=symbol,
+            price_threshold=price_threshold,
+            stoch_rsi_threshold=stoch_rsi_threshold,
+            foreign_consecutive_days=foreign_days,
+            rsi_high_mark=rsi_high,
+            rsi_low_mark=rsi_low,
+            bb_upper_ref=bb_upper_ref,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Failed to evaluate sell signal for %s", symbol)
+        payload = N8nSellSignalResponse(
+            success=False,
+            as_of=as_of,
+            symbol=symbol,
+            name=symbol,
+            triggered=False,
+            conditions_met=0,
+            conditions=[],
+            message="",
+            errors=[{"error": str(exc)}],
+        )
+        return JSONResponse(status_code=500, content=payload.model_dump())
+
+    return N8nSellSignalResponse(
+        success=True,
+        as_of=as_of,
+        **result,
+    )

--- a/app/routers/n8n.py
+++ b/app/routers/n8n.py
@@ -35,6 +35,7 @@ from app.schemas.n8n.pending_snapshot import (
     N8nPendingSnapshotsRequest,
     N8nPendingSnapshotsResponse,
 )
+from app.schemas.n8n.sell_signal import N8nSellSignalResponse
 from app.schemas.n8n.trade_review import (
     N8nTradeReviewListResponse,
     N8nTradeReviewsRequest,
@@ -48,7 +49,6 @@ from app.services.n8n_filled_orders_service import fetch_filled_orders
 from app.services.n8n_formatting import fmt_date_with_weekday
 from app.services.n8n_kr_morning_report_service import fetch_kr_morning_report
 from app.services.n8n_market_context_service import fetch_market_context
-from app.schemas.n8n.sell_signal import N8nSellSignalResponse
 from app.services.n8n_news_service import fetch_n8n_news
 from app.services.n8n_pending_orders_service import fetch_pending_orders
 from app.services.n8n_pending_review_service import fetch_pending_review

--- a/app/routers/n8n.py
+++ b/app/routers/n8n.py
@@ -595,10 +595,14 @@ async def get_sell_signal(
     symbol: str,
     price_threshold: float = Query(1_152_000, description="Trailing stop price (KRW)"),
     stoch_rsi_threshold: float = Query(80, description="StochRSI K threshold"),
-    foreign_days: int = Query(2, ge=1, le=5, description="Foreign consecutive sell days"),
+    foreign_days: int = Query(
+        2, ge=1, le=5, description="Foreign consecutive sell days"
+    ),
     rsi_high: float = Query(70, description="RSI high watermark"),
     rsi_low: float = Query(65, description="RSI low trigger"),
-    bb_upper_ref: float = Query(1_142_000, description="Bollinger upper reference (KRW)"),
+    bb_upper_ref: float = Query(
+        1_142_000, description="Bollinger upper reference (KRW)"
+    ),
 ) -> N8nSellSignalResponse | JSONResponse:
     as_of = now_kst().replace(microsecond=0).isoformat()
 

--- a/app/schemas/n8n/sell_signal.py
+++ b/app/schemas/n8n/sell_signal.py
@@ -16,9 +16,7 @@ class N8nSellSignalResponse(BaseModel):
     as_of: str = Field(..., description="Response timestamp in KST ISO8601")
     symbol: str = Field(..., description="Stock code (e.g. 000660)")
     name: str = Field(..., description="Stock name")
-    triggered: bool = Field(
-        ..., description="True if 2+ conditions met simultaneously"
-    )
+    triggered: bool = Field(..., description="True if 2+ conditions met simultaneously")
     conditions_met: int = Field(..., description="Number of conditions currently met")
     conditions: list[N8nSellCondition] = Field(
         default_factory=list, description="Individual condition evaluations"

--- a/app/schemas/n8n/sell_signal.py
+++ b/app/schemas/n8n/sell_signal.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class N8nSellCondition(BaseModel):
+    name: str = Field(..., description="Condition identifier")
+    met: bool = Field(..., description="Whether condition is currently met")
+    value: float | None = Field(None, description="Current observed value")
+    threshold: float | None = Field(None, description="Threshold for trigger")
+    detail: str | None = Field(None, description="Human-readable detail")
+
+
+class N8nSellSignalResponse(BaseModel):
+    success: bool = Field(..., description="Whether request completed successfully")
+    as_of: str = Field(..., description="Response timestamp in KST ISO8601")
+    symbol: str = Field(..., description="Stock code (e.g. 000660)")
+    name: str = Field(..., description="Stock name")
+    triggered: bool = Field(
+        ..., description="True if 2+ conditions met simultaneously"
+    )
+    conditions_met: int = Field(..., description="Number of conditions currently met")
+    conditions: list[N8nSellCondition] = Field(
+        default_factory=list, description="Individual condition evaluations"
+    )
+    message: str = Field("", description="Summary message for notification")
+    errors: list[dict[str, object]] = Field(
+        default_factory=list, description="Non-fatal errors during evaluation"
+    )

--- a/app/services/brokers/kis/client.py
+++ b/app/services/brokers/kis/client.py
@@ -124,6 +124,11 @@ class KISClient(BaseKISClient):
             code, market, n, adj, period, end_date, per_call_days
         )
 
+    async def inquire_investor(
+        self, code: str, market: str = "J"
+    ) -> list[dict[str, Any]]:
+        return await self._market_data.inquire_investor(code, market)
+
     async def inquire_short_selling(
         self,
         code: str,

--- a/app/services/brokers/kis/constants.py
+++ b/app/services/brokers/kis/constants.py
@@ -50,6 +50,9 @@ FLUCTUATION_RANK_TR = "FHPST01700000"
 FOREIGN_BUYING_RANK_URL = "/uapi/domestic-stock/v1/quotations/foreign-institution-total"
 FOREIGN_BUYING_RANK_TR = "FHPTJ04400000"
 
+INVESTOR_TRADING_URL = "/uapi/domestic-stock/v1/quotations/inquire-investor"
+INVESTOR_TRADING_TR = "FHKST01010900"
+
 # Domestic Stock - Balance & Orders
 DOMESTIC_BALANCE_URL = "/uapi/domestic-stock/v1/trading/inquire-balance"
 DOMESTIC_BALANCE_TR = "TTTC8434R"  # 실전투자 주식잔고조회

--- a/app/services/brokers/kis/domestic_market_data.py
+++ b/app/services/brokers/kis/domestic_market_data.py
@@ -315,6 +315,25 @@ class DomesticMarketDataMixin(MarketDataBase):
 
         return output1, output2
 
+    async def inquire_investor(
+        self,
+        code: str,
+        market: str = "J",
+    ) -> list[dict[str, Any]]:
+        js = await self._request_with_token_retry(
+            tr_id=constants.INVESTOR_TRADING_TR,
+            url=f"{constants.BASE}{constants.INVESTOR_TRADING_URL}",
+            params={
+                "FID_COND_MRKT_DIV_CODE": market,
+                "FID_INPUT_ISCD": code.zfill(6),
+            },
+            api_name="inquire_investor",
+        )
+        output = js.get("output") or []
+        if not isinstance(output, list):
+            return []
+        return output
+
     async def fetch_fundamental_info(self, code: str, market: str = "J") -> dict:
         """
         종목의 기본 정보를 가져와 딕셔너리로 반환합니다.

--- a/app/services/paper_trading_service.py
+++ b/app/services/paper_trading_service.py
@@ -175,7 +175,6 @@ class PaperTradingService:
                 _fetch_quote_equity_us,
             )
 
-
             quote = await _fetch_quote_equity_us(symbol)
             price = quote.get("price")
         elif instrument_type == "crypto":
@@ -566,7 +565,6 @@ class PaperTradingService:
             "positions_count": len(positions),
         }
 
-
     # ------------------------------------------------------------------ #
     # Daily snapshot
     # ------------------------------------------------------------------ #
@@ -705,22 +703,29 @@ class PaperTradingService:
                     last_exit_date = t.executed_at
                     last_sell_reason = t.reason or ""
 
-                    if position_qty <= 0 and entry_date is not None and last_exit_date is not None:
+                    if (
+                        position_qty <= 0
+                        and entry_date is not None
+                        and last_exit_date is not None
+                    ):
                         holding_days = (last_exit_date.date() - entry_date.date()).days
                         return_pct = (
                             float(total_pnl / buy_cost * Decimal("100"))
-                            if buy_cost > 0 else 0.0
+                            if buy_cost > 0
+                            else 0.0
                         )
-                        round_trips.append({
-                            "symbol": symbol,
-                            "entry_date": entry_date.isoformat(),
-                            "exit_date": last_exit_date.isoformat(),
-                            "holding_days": max(holding_days, 0),
-                            "pnl": float(total_pnl),
-                            "return_pct": return_pct,
-                            "entry_reason": entry_reason,
-                            "exit_reason": last_sell_reason,
-                        })
+                        round_trips.append(
+                            {
+                                "symbol": symbol,
+                                "entry_date": entry_date.isoformat(),
+                                "exit_date": last_exit_date.isoformat(),
+                                "holding_days": max(holding_days, 0),
+                                "pnl": float(total_pnl),
+                                "return_pct": return_pct,
+                                "entry_reason": entry_reason,
+                                "exit_reason": last_sell_reason,
+                            }
+                        )
                         position_qty = Decimal("0")
                         buy_cost = Decimal("0")
                         total_pnl = Decimal("0")
@@ -751,6 +756,7 @@ class PaperTradingService:
     def _calc_sharpe_ratio(daily_returns_pct: list[Decimal]) -> float | None:
         """Annualised Sharpe ratio (252 trading days). Assumes 0% risk-free rate."""
         import math
+
         values = [float(r) for r in daily_returns_pct if r is not None]
         if len(values) < 2:
             return None
@@ -760,7 +766,6 @@ class PaperTradingService:
         if stdev == 0:
             return None
         return (mean / stdev) * math.sqrt(252)
-
 
     async def calculate_performance(
         self,
@@ -794,11 +799,13 @@ class PaperTradingService:
         trade_stmt = select(PaperTrade).where(PaperTrade.account_id == account_id)
         if start_date is not None:
             trade_stmt = trade_stmt.where(
-                PaperTrade.executed_at >= datetime.combine(start_date, datetime.min.time(), tzinfo=UTC)
+                PaperTrade.executed_at
+                >= datetime.combine(start_date, datetime.min.time(), tzinfo=UTC)
             )
         if end_date is not None:
             trade_stmt = trade_stmt.where(
-                PaperTrade.executed_at <= datetime.combine(end_date, datetime.max.time(), tzinfo=UTC)
+                PaperTrade.executed_at
+                <= datetime.combine(end_date, datetime.max.time(), tzinfo=UTC)
             )
         trade_stmt = trade_stmt.order_by(PaperTrade.executed_at.asc())
         trades = list((await self.db.execute(trade_stmt)).scalars().all())
@@ -814,10 +821,15 @@ class PaperTradingService:
         win_rate = (wins / total_trips * 100.0) if total_trips > 0 else 0.0
         avg_holding_days = (
             sum(trip["holding_days"] for trip in round_trips) / total_trips
-            if total_trips > 0 else 0.0
+            if total_trips > 0
+            else 0.0
         )
-        best_trip = max(round_trips, key=lambda t: t["return_pct"]) if round_trips else None
-        worst_trip = min(round_trips, key=lambda t: t["return_pct"]) if round_trips else None
+        best_trip = (
+            max(round_trips, key=lambda t: t["return_pct"]) if round_trips else None
+        )
+        worst_trip = (
+            min(round_trips, key=lambda t: t["return_pct"]) if round_trips else None
+        )
 
         # Snapshots in period → sharpe + max drawdown
         snap_stmt = select(PaperDailySnapshot).where(
@@ -831,7 +843,9 @@ class PaperTradingService:
         snaps = list((await self.db.execute(snap_stmt)).scalars().all())
 
         equity_curve = [s.total_equity for s in snaps]
-        daily_returns = [s.daily_return_pct for s in snaps if s.daily_return_pct is not None]
+        daily_returns = [
+            s.daily_return_pct for s in snaps if s.daily_return_pct is not None
+        ]
         max_dd = self._calc_max_drawdown_pct(equity_curve) if equity_curve else None
         sharpe = self._calc_sharpe_ratio(daily_returns) if daily_returns else None
 

--- a/app/services/sell_signal_service.py
+++ b/app/services/sell_signal_service.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import redis.asyncio as aioredis
+
+from app.core.config import settings
+from app.core.timezone import now_kst
+from app.mcp_server.tooling.market_data_indicators import (
+    _calculate_bollinger,
+    _calculate_rsi,
+    _calculate_stoch_rsi,
+    _fetch_ohlcv_for_indicators,
+)
+from app.schemas.n8n.sell_signal import N8nSellCondition
+from app.services.brokers.kis.client import KISClient
+
+logger = logging.getLogger(__name__)
+
+REDIS_RSI_PREFIX = "sell_signal:rsi_state"
+TRIGGER_THRESHOLD = 2
+
+
+async def _get_redis() -> aioredis.Redis:
+    return aioredis.from_url(
+        settings.get_redis_url(),
+        max_connections=settings.redis_max_connections,
+        socket_timeout=settings.redis_socket_timeout,
+        decode_responses=True,
+    )
+
+
+async def _fetch_current_price(
+    kis: KISClient, symbol: str
+) -> tuple[float | None, str | None]:
+    try:
+        df = await kis.inquire_price(symbol)
+        if df.empty:
+            return None, None
+        row = df.iloc[0]
+        return float(row["close"]), None
+    except Exception as exc:
+        return None, str(exc)
+
+
+async def _fetch_stock_name(kis: KISClient, symbol: str) -> str:
+    try:
+        info = await kis.fetch_fundamental_info(symbol)
+        return info.get("종목명", symbol)
+    except Exception:
+        return symbol
+
+
+async def _check_trailing_stop(
+    kis: KISClient, symbol: str, threshold: float
+) -> tuple[N8nSellCondition, float | None, list[dict[str, Any]]]:
+    errors: list[dict[str, Any]] = []
+    price, err = await _fetch_current_price(kis, symbol)
+    if err:
+        errors.append({"condition": "trailing_stop", "error": err})
+
+    met = price is not None and price <= threshold
+    return (
+        N8nSellCondition(
+            name="trailing_stop",
+            met=met,
+            value=price,
+            threshold=threshold,
+            detail=f"현재가 ₩{price:,.0f}" if price else "가격 조회 실패",
+        ),
+        price,
+        errors,
+    )
+
+
+async def _check_stoch_rsi(
+    symbol: str, threshold: float
+) -> tuple[N8nSellCondition, list[dict[str, Any]]]:
+    errors: list[dict[str, Any]] = []
+    try:
+        df = await _fetch_ohlcv_for_indicators(symbol, "equity_kr", count=200)
+        if df.empty or len(df) < 30:
+            return (
+                N8nSellCondition(
+                    name="stoch_rsi",
+                    met=False,
+                    value=None,
+                    threshold=threshold,
+                    detail="OHLCV 데이터 부족",
+                ),
+                errors,
+            )
+        close = df["close"].astype(float)
+        stoch = _calculate_stoch_rsi(close)
+        k_val = stoch.get("k")
+        met = k_val is not None and k_val < threshold
+        return (
+            N8nSellCondition(
+                name="stoch_rsi",
+                met=met,
+                value=round(k_val, 2) if k_val is not None else None,
+                threshold=threshold,
+                detail=f"StochRSI K={k_val:.1f}" if k_val is not None else "계산 불가",
+            ),
+            errors,
+        )
+    except Exception as exc:
+        errors.append({"condition": "stoch_rsi", "error": str(exc)})
+        return (
+            N8nSellCondition(
+                name="stoch_rsi",
+                met=False,
+                value=None,
+                threshold=threshold,
+                detail=str(exc),
+            ),
+            errors,
+        )
+
+
+async def _check_foreign_selling(
+    kis: KISClient, symbol: str, consecutive_days: int
+) -> tuple[N8nSellCondition, list[dict[str, Any]]]:
+    errors: list[dict[str, Any]] = []
+    try:
+        rows = await kis.inquire_investor(symbol)
+        if not rows or len(rows) < consecutive_days:
+            return (
+                N8nSellCondition(
+                    name="foreign_selling",
+                    met=False,
+                    value=None,
+                    detail="투자자 데이터 부족",
+                ),
+                errors,
+            )
+
+        net_sells = 0
+        for row in rows[:consecutive_days]:
+            frgn_ntby = float(row.get("frgn_ntby_qty", 0))
+            if frgn_ntby < 0:
+                net_sells += 1
+
+        met = net_sells >= consecutive_days
+        detail_parts = []
+        for i, row in enumerate(rows[:consecutive_days]):
+            qty = float(row.get("frgn_ntby_qty", 0))
+            label = "순매도" if qty < 0 else "순매수"
+            detail_parts.append(f"D-{i}: {label} {abs(qty):,.0f}주")
+
+        return (
+            N8nSellCondition(
+                name="foreign_selling",
+                met=met,
+                value=None,
+                detail=f"{net_sells}일 연속 순매도" if met else "; ".join(detail_parts),
+            ),
+            errors,
+        )
+    except Exception as exc:
+        errors.append({"condition": "foreign_selling", "error": str(exc)})
+        return (
+            N8nSellCondition(
+                name="foreign_selling",
+                met=False,
+                value=None,
+                detail=str(exc),
+            ),
+            errors,
+        )
+
+
+async def _check_rsi_momentum(
+    symbol: str, high_mark: float, low_mark: float
+) -> tuple[N8nSellCondition, list[dict[str, Any]]]:
+    errors: list[dict[str, Any]] = []
+    redis_key = f"{REDIS_RSI_PREFIX}:{symbol}"
+
+    try:
+        df = await _fetch_ohlcv_for_indicators(symbol, "equity_kr", count=200)
+        if df.empty or len(df) < 20:
+            return (
+                N8nSellCondition(
+                    name="rsi_momentum",
+                    met=False,
+                    value=None,
+                    detail="OHLCV 데이터 부족",
+                ),
+                errors,
+            )
+
+        close = df["close"].astype(float)
+        rsi_result = _calculate_rsi(close, 14)
+        current_rsi = rsi_result.get("14")
+        if current_rsi is None:
+            return (
+                N8nSellCondition(
+                    name="rsi_momentum",
+                    met=False,
+                    value=None,
+                    detail="RSI 계산 불가",
+                ),
+                errors,
+            )
+
+        r = await _get_redis()
+        try:
+            raw = await r.get(redis_key)
+            prev_state = json.loads(raw) if raw else {}
+        except Exception:
+            prev_state = {}
+
+        prev_rsi = prev_state.get("rsi")
+        was_above_high = prev_state.get("was_above_high", False)
+
+        if current_rsi >= high_mark:
+            was_above_high = True
+        met = was_above_high and current_rsi <= low_mark
+
+        new_state = {
+            "rsi": round(current_rsi, 2),
+            "was_above_high": was_above_high and not met,
+            "updated_at": now_kst().isoformat(),
+        }
+        await r.set(redis_key, json.dumps(new_state), ex=86400 * 7)
+        await r.aclose()
+
+        if met:
+            detail = f"{high_mark}→{current_rsi:.1f} 하락"
+        elif was_above_high:
+            detail = f"RSI {current_rsi:.1f} (고점 {high_mark} 돌파 이력 있음)"
+        else:
+            detail = f"RSI {current_rsi:.1f} (아직 {high_mark} 미돌파)"
+
+        return (
+            N8nSellCondition(
+                name="rsi_momentum",
+                met=met,
+                value=round(current_rsi, 2),
+                detail=detail,
+            ),
+            errors,
+        )
+    except Exception as exc:
+        errors.append({"condition": "rsi_momentum", "error": str(exc)})
+        return (
+            N8nSellCondition(
+                name="rsi_momentum",
+                met=False,
+                value=None,
+                detail=str(exc),
+            ),
+            errors,
+        )
+
+
+async def _check_bollinger_reentry(
+    symbol: str, current_price: float | None, bb_upper_ref: float
+) -> tuple[N8nSellCondition, list[dict[str, Any]]]:
+    errors: list[dict[str, Any]] = []
+    try:
+        df = await _fetch_ohlcv_for_indicators(symbol, "equity_kr", count=200)
+        if df.empty or len(df) < 25:
+            return (
+                N8nSellCondition(
+                    name="bollinger_reentry",
+                    met=False,
+                    value=None,
+                    detail="OHLCV 데이터 부족",
+                ),
+                errors,
+            )
+
+        close = df["close"].astype(float)
+        bb = _calculate_bollinger(close)
+        bb_upper = bb.get("upper")
+        if bb_upper is None or current_price is None:
+            return (
+                N8nSellCondition(
+                    name="bollinger_reentry",
+                    met=False,
+                    value=None,
+                    detail="볼린저밴드 계산 불가",
+                ),
+                errors,
+            )
+
+        prices = close.values
+        was_above = False
+        re_entered = False
+        for i in range(max(0, len(prices) - 10), len(prices) - 1):
+            if prices[i] > bb_upper_ref:
+                was_above = True
+            elif was_above and prices[i] <= bb_upper_ref:
+                re_entered = True
+                break
+
+        met = re_entered and current_price < bb_upper
+        if met:
+            detail = f"밴드 상단 ₩{bb_upper:,.0f} 아래 재진입 후 반등 실패"
+        elif was_above and not re_entered:
+            detail = f"밴드 상단 위 (현재가 > ₩{bb_upper_ref:,.0f})"
+        else:
+            detail = f"밴드 상단 ₩{bb_upper:,.0f}"
+
+        return (
+            N8nSellCondition(
+                name="bollinger_reentry",
+                met=met,
+                value=round(bb_upper, 0) if bb_upper else None,
+                detail=detail,
+            ),
+            errors,
+        )
+    except Exception as exc:
+        errors.append({"condition": "bollinger_reentry", "error": str(exc)})
+        return (
+            N8nSellCondition(
+                name="bollinger_reentry",
+                met=False,
+                value=None,
+                detail=str(exc),
+            ),
+            errors,
+        )
+
+
+async def evaluate_sell_signal(
+    symbol: str,
+    price_threshold: float = 1_152_000,
+    stoch_rsi_threshold: float = 80,
+    foreign_consecutive_days: int = 2,
+    rsi_high_mark: float = 70,
+    rsi_low_mark: float = 65,
+    bb_upper_ref: float = 1_142_000,
+) -> dict[str, Any]:
+    kis = KISClient()
+    all_errors: list[dict[str, Any]] = []
+
+    stock_name = await _fetch_stock_name(kis, symbol)
+
+    trailing_cond, current_price, errs = await _check_trailing_stop(
+        kis, symbol, price_threshold
+    )
+    all_errors.extend(errs)
+
+    stoch_cond, errs = await _check_stoch_rsi(symbol, stoch_rsi_threshold)
+    all_errors.extend(errs)
+
+    foreign_cond, errs = await _check_foreign_selling(
+        kis, symbol, foreign_consecutive_days
+    )
+    all_errors.extend(errs)
+
+    rsi_cond, errs = await _check_rsi_momentum(symbol, rsi_high_mark, rsi_low_mark)
+    all_errors.extend(errs)
+
+    bb_cond, errs = await _check_bollinger_reentry(
+        symbol, current_price, bb_upper_ref
+    )
+    all_errors.extend(errs)
+
+    conditions = [trailing_cond, stoch_cond, foreign_cond, rsi_cond, bb_cond]
+    conditions_met = sum(1 for c in conditions if c.met)
+    triggered = conditions_met >= TRIGGER_THRESHOLD
+
+    met_names = [c.name for c in conditions if c.met]
+    if triggered:
+        message = f"[매도 검토] {stock_name} {conditions_met}/5 조건 충족 ({', '.join(met_names)})"
+    else:
+        message = f"[매도 대기] {stock_name} {conditions_met}/5 조건 충족"
+
+    return {
+        "symbol": symbol,
+        "name": stock_name,
+        "triggered": triggered,
+        "conditions_met": conditions_met,
+        "conditions": conditions,
+        "message": message,
+        "errors": all_errors,
+    }

--- a/app/services/sell_signal_service.py
+++ b/app/services/sell_signal_service.py
@@ -212,7 +212,6 @@ async def _check_rsi_momentum(
         except Exception:
             prev_state = {}
 
-        prev_rsi = prev_state.get("rsi")
         was_above_high = prev_state.get("was_above_high", False)
 
         if current_rsi >= high_mark:

--- a/app/services/sell_signal_service.py
+++ b/app/services/sell_signal_service.py
@@ -356,9 +356,7 @@ async def evaluate_sell_signal(
     rsi_cond, errs = await _check_rsi_momentum(symbol, rsi_high_mark, rsi_low_mark)
     all_errors.extend(errs)
 
-    bb_cond, errs = await _check_bollinger_reentry(
-        symbol, current_price, bb_upper_ref
-    )
+    bb_cond, errs = await _check_bollinger_reentry(symbol, current_price, bb_upper_ref)
     all_errors.extend(errs)
 
     conditions = [trailing_cond, stoch_cond, foreign_cond, rsi_cond, bb_cond]

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -4295,3 +4295,152 @@ class TestAnalyzeStockInvalidInput:
 
         with pytest.raises(ValueError, match="symbol is required"):
             await analyze_stock_impl(symbol="", market=None)
+
+
+# ---------------------------------------------------------------------------
+# get_investor_trends Tool
+# ---------------------------------------------------------------------------
+
+
+def _make_daily_investor_data(days: int = 10) -> dict:
+    """Build mock daily investor trend data from Naver source."""
+    data = []
+    import datetime as _dt
+
+    base = _dt.date(2024, 3, 15)
+    for i in range(days):
+        d = base - _dt.timedelta(days=i)
+        # Skip weekends to simulate trading days
+        if d.weekday() >= 5:
+            continue
+        data.append(
+            {
+                "date": d.isoformat(),
+                "close": 75000 + i * 100,
+                "change": 100 * (1 if i % 2 == 0 else -1),
+                "change_pct": 0.13 * (1 if i % 2 == 0 else -1),
+                "volume": 10_000_000 + i * 500_000,
+                "institutional_net": 500_000 * (1 if i % 3 == 0 else -1),
+                "foreign_net": 300_000 * (1 if i % 2 == 0 else -1),
+            }
+        )
+    return {
+        "symbol": "005930",
+        "days": len(data),
+        "data": data,
+    }
+
+
+@pytest.mark.asyncio
+class TestGetInvestorTrends:
+    """Test get_investor_trends tool."""
+
+    async def test_daily_default(self, monkeypatch):
+        """Test daily investor trends returns data with individual_net added."""
+        tools = build_tools()
+        mock = _make_daily_investor_data(10)
+
+        async def mock_fetch(code, days):
+            return {
+                "instrument_type": "equity_kr",
+                "source": "naver",
+                **mock,
+            }
+
+        _patch_runtime_attr(
+            monkeypatch, "_fetch_investor_trends_naver", mock_fetch
+        )
+
+        result = await tools["get_investor_trends"]("005930")
+
+        assert result["source"] == "naver"
+        assert result["period"] == "day"
+        assert len(result["data"]) > 0
+        # Every row should have individual_net
+        for row in result["data"]:
+            assert "individual_net" in row
+            inst = row.get("institutional_net") or 0
+            frgn = row.get("foreign_net") or 0
+            assert row["individual_net"] == -(inst + frgn)
+
+    async def test_weekly_aggregation(self, monkeypatch):
+        """Test weekly aggregation sums investor flows."""
+        tools = build_tools()
+        mock = _make_daily_investor_data(20)
+
+        async def mock_fetch(code, days):
+            return {
+                "instrument_type": "equity_kr",
+                "source": "naver",
+                **mock,
+            }
+
+        _patch_runtime_attr(
+            monkeypatch, "_fetch_investor_trends_naver", mock_fetch
+        )
+
+        result = await tools["get_investor_trends"]("005930", period="week")
+
+        assert result["period"] == "week"
+        for row in result["data"]:
+            assert "period_key" in row
+            assert "date_start" in row
+            assert "date_end" in row
+            assert "trading_days" in row
+            assert "institutional_net" in row
+            assert "foreign_net" in row
+            assert "individual_net" in row
+
+    async def test_monthly_aggregation(self, monkeypatch):
+        """Test monthly aggregation sums investor flows."""
+        tools = build_tools()
+        mock = _make_daily_investor_data(30)
+
+        async def mock_fetch(code, days):
+            return {
+                "instrument_type": "equity_kr",
+                "source": "naver",
+                **mock,
+            }
+
+        _patch_runtime_attr(
+            monkeypatch, "_fetch_investor_trends_naver", mock_fetch
+        )
+
+        result = await tools["get_investor_trends"]("005930", period="month")
+
+        assert result["period"] == "month"
+        assert len(result["data"]) > 0
+        for row in result["data"]:
+            assert "period_key" in row
+            # Month key format: YYYY-MM
+            assert len(row["period_key"].split("-")) == 2
+
+    async def test_rejects_non_kr_symbol(self, monkeypatch):
+        """Test that non-Korean symbols raise ValueError."""
+        tools = build_tools()
+
+        with pytest.raises(ValueError, match="Korean stocks"):
+            await tools["get_investor_trends"]("AAPL")
+
+    async def test_rejects_invalid_period(self, monkeypatch):
+        """Test that invalid period raises ValueError."""
+        tools = build_tools()
+
+        with pytest.raises(ValueError, match="period must be"):
+            await tools["get_investor_trends"]("005930", period="quarter")
+
+    async def test_error_returns_error_payload(self, monkeypatch):
+        """Test that fetch errors return error payload instead of raising."""
+        tools = build_tools()
+
+        async def mock_fetch(code, days):
+            raise RuntimeError("Naver down")
+
+        _patch_runtime_attr(
+            monkeypatch, "_fetch_investor_trends_naver", mock_fetch
+        )
+
+        result = await tools["get_investor_trends"]("005930")
+
+        assert "error" in result or "message" in result

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -4347,9 +4347,7 @@ class TestGetInvestorTrends:
                 **mock,
             }
 
-        _patch_runtime_attr(
-            monkeypatch, "_fetch_investor_trends_naver", mock_fetch
-        )
+        _patch_runtime_attr(monkeypatch, "_fetch_investor_trends_naver", mock_fetch)
 
         result = await tools["get_investor_trends"]("005930")
 
@@ -4375,9 +4373,7 @@ class TestGetInvestorTrends:
                 **mock,
             }
 
-        _patch_runtime_attr(
-            monkeypatch, "_fetch_investor_trends_naver", mock_fetch
-        )
+        _patch_runtime_attr(monkeypatch, "_fetch_investor_trends_naver", mock_fetch)
 
         result = await tools["get_investor_trends"]("005930", period="week")
 
@@ -4403,9 +4399,7 @@ class TestGetInvestorTrends:
                 **mock,
             }
 
-        _patch_runtime_attr(
-            monkeypatch, "_fetch_investor_trends_naver", mock_fetch
-        )
+        _patch_runtime_attr(monkeypatch, "_fetch_investor_trends_naver", mock_fetch)
 
         result = await tools["get_investor_trends"]("005930", period="month")
 
@@ -4437,9 +4431,7 @@ class TestGetInvestorTrends:
         async def mock_fetch(code, days):
             raise RuntimeError("Naver down")
 
-        _patch_runtime_attr(
-            monkeypatch, "_fetch_investor_trends_naver", mock_fetch
-        )
+        _patch_runtime_attr(monkeypatch, "_fetch_investor_trends_naver", mock_fetch)
 
         result = await tools["get_investor_trends"]("005930")
 

--- a/tests/test_paper_analytics_tools.py
+++ b/tests/test_paper_analytics_tools.py
@@ -71,15 +71,21 @@ def _perf_payload() -> dict:
             "symbol": "005930",
             "entry_date": "2026-04-01T00:00:00+00:00",
             "exit_date": "2026-04-06T00:00:00+00:00",
-            "holding_days": 5, "pnl": 98635.0, "return_pct": 16.44,
-            "entry_reason": "", "exit_reason": "",
+            "holding_days": 5,
+            "pnl": 98635.0,
+            "return_pct": 16.44,
+            "entry_reason": "",
+            "exit_reason": "",
         },
         "worst_trade": {
             "symbol": "005930",
             "entry_date": "2026-04-01T00:00:00+00:00",
             "exit_date": "2026-04-06T00:00:00+00:00",
-            "holding_days": 5, "pnl": 98635.0, "return_pct": 16.44,
-            "entry_reason": "", "exit_reason": "",
+            "holding_days": 5,
+            "pnl": 98635.0,
+            "return_pct": 16.44,
+            "entry_reason": "",
+            "exit_reason": "",
         },
     }
 
@@ -92,9 +98,11 @@ async def test_get_paper_performance_all_period(monkeypatch):
     _patch_session(monkeypatch, db)
 
     account = PaperAccount(
-        id=1, name="bot",
+        id=1,
+        name="bot",
         initial_capital=Decimal("10000000"),
-        cash_krw=Decimal("5000000"), cash_usd=Decimal("0"),
+        cash_krw=Decimal("5000000"),
+        cash_usd=Decimal("0"),
         is_active=True,
     )
 
@@ -143,9 +151,11 @@ async def test_get_paper_performance_invalid_period(monkeypatch):
     _patch_session(monkeypatch, db)
 
     account = PaperAccount(
-        id=1, name="bot",
+        id=1,
+        name="bot",
         initial_capital=Decimal("10000000"),
-        cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+        cash_krw=Decimal("0"),
+        cash_usd=Decimal("0"),
         is_active=True,
     )
 
@@ -170,19 +180,28 @@ async def test_get_paper_trade_log_basic(monkeypatch):
     _patch_session(monkeypatch, db)
 
     account = PaperAccount(
-        id=1, name="bot",
+        id=1,
+        name="bot",
         initial_capital=Decimal("10000000"),
-        cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+        cash_krw=Decimal("0"),
+        cash_usd=Decimal("0"),
         is_active=True,
     )
 
     trade_rows = [
         {
-            "id": 1, "symbol": "005930", "instrument_type": "equity_kr",
-            "side": "buy", "order_type": "market",
-            "quantity": Decimal("10"), "price": Decimal("60000"),
-            "total_amount": Decimal("600000"), "fee": Decimal("90"),
-            "currency": "KRW", "reason": "entry", "realized_pnl": None,
+            "id": 1,
+            "symbol": "005930",
+            "instrument_type": "equity_kr",
+            "side": "buy",
+            "order_type": "market",
+            "quantity": Decimal("10"),
+            "price": Decimal("60000"),
+            "total_amount": Decimal("600000"),
+            "fee": Decimal("90"),
+            "currency": "KRW",
+            "reason": "entry",
+            "realized_pnl": None,
             "executed_at": datetime(2026, 4, 1, 9, 0, tzinfo=UTC),
         },
     ]
@@ -219,9 +238,11 @@ async def test_get_paper_trade_log_filters_forwarded(monkeypatch):
     _patch_session(monkeypatch, db)
 
     account = PaperAccount(
-        id=1, name="bot",
+        id=1,
+        name="bot",
         initial_capital=Decimal("0"),
-        cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+        cash_krw=Decimal("0"),
+        cash_usd=Decimal("0"),
         is_active=True,
     )
 
@@ -269,31 +290,47 @@ async def test_compare_paper_accounts_all_found(monkeypatch):
     _patch_session(monkeypatch, db)
 
     acc1 = PaperAccount(
-        id=1, name="bot-a",
+        id=1,
+        name="bot-a",
         initial_capital=Decimal("10000000"),
-        cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+        cash_krw=Decimal("0"),
+        cash_usd=Decimal("0"),
         is_active=True,
     )
     acc2 = PaperAccount(
-        id=2, name="bot-b",
+        id=2,
+        name="bot-b",
         initial_capital=Decimal("10000000"),
-        cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+        cash_krw=Decimal("0"),
+        cash_usd=Decimal("0"),
         is_active=True,
     )
 
     name_to_account = {"bot-a": acc1, "bot-b": acc2}
     perf_by_id = {
         1: {
-            "total_return_pct": 5.0, "realized_pnl": 100.0, "unrealized_pnl": 50.0,
-            "total_trades": 3, "win_rate": 66.67, "avg_holding_days": 4.0,
-            "max_drawdown_pct": 2.0, "sharpe_ratio": 1.0,
-            "best_trade": None, "worst_trade": None,
+            "total_return_pct": 5.0,
+            "realized_pnl": 100.0,
+            "unrealized_pnl": 50.0,
+            "total_trades": 3,
+            "win_rate": 66.67,
+            "avg_holding_days": 4.0,
+            "max_drawdown_pct": 2.0,
+            "sharpe_ratio": 1.0,
+            "best_trade": None,
+            "worst_trade": None,
         },
         2: {
-            "total_return_pct": -2.0, "realized_pnl": -200.0, "unrealized_pnl": 0.0,
-            "total_trades": 1, "win_rate": 0.0, "avg_holding_days": 2.0,
-            "max_drawdown_pct": 5.0, "sharpe_ratio": -0.5,
-            "best_trade": None, "worst_trade": None,
+            "total_return_pct": -2.0,
+            "realized_pnl": -200.0,
+            "unrealized_pnl": 0.0,
+            "total_trades": 1,
+            "win_rate": 0.0,
+            "avg_holding_days": 2.0,
+            "max_drawdown_pct": 5.0,
+            "sharpe_ratio": -0.5,
+            "best_trade": None,
+            "worst_trade": None,
         },
     }
 
@@ -328,9 +365,11 @@ async def test_compare_paper_accounts_skips_missing(monkeypatch):
     _patch_session(monkeypatch, db)
 
     acc1 = PaperAccount(
-        id=1, name="bot-a",
+        id=1,
+        name="bot-a",
         initial_capital=Decimal("10000000"),
-        cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+        cash_krw=Decimal("0"),
+        cash_usd=Decimal("0"),
         is_active=True,
     )
 
@@ -342,12 +381,20 @@ async def test_compare_paper_accounts_skips_missing(monkeypatch):
     ) as svc_cls:
         svc = svc_cls.return_value
         svc.get_account_by_name = AsyncMock(side_effect=_lookup)
-        svc.calculate_performance = AsyncMock(return_value={
-            "total_return_pct": 0.0, "realized_pnl": 0.0, "unrealized_pnl": 0.0,
-            "total_trades": 0, "win_rate": 0.0, "avg_holding_days": 0.0,
-            "max_drawdown_pct": None, "sharpe_ratio": None,
-            "best_trade": None, "worst_trade": None,
-        })
+        svc.calculate_performance = AsyncMock(
+            return_value={
+                "total_return_pct": 0.0,
+                "realized_pnl": 0.0,
+                "unrealized_pnl": 0.0,
+                "total_trades": 0,
+                "win_rate": 0.0,
+                "avg_holding_days": 0.0,
+                "max_drawdown_pct": None,
+                "sharpe_ratio": None,
+                "best_trade": None,
+                "worst_trade": None,
+            }
+        )
 
         tools = build_tools()
         result = await tools["compare_paper_accounts"](names=["bot-a", "ghost"])

--- a/tests/test_paper_trading_service.py
+++ b/tests/test_paper_trading_service.py
@@ -774,7 +774,8 @@ class TestDailySnapshots:
         self, service, mock_db, monkeypatch
     ):
         account = PaperAccount(
-            id=1, name="A",
+            id=1,
+            name="A",
             initial_capital=Decimal("10000000"),
             cash_krw=Decimal("5000000"),
             cash_usd=Decimal("0"),
@@ -782,14 +783,17 @@ class TestDailySnapshots:
         )
         monkeypatch.setattr(service, "get_account", AsyncMock(return_value=account))
         monkeypatch.setattr(
-            service, "get_positions",
+            service,
+            "get_positions",
             AsyncMock(return_value=[{"evaluation_amount": Decimal("6000000")}]),
         )
 
         prior = PaperDailySnapshot(
-            id=10, account_id=1,
+            id=10,
+            account_id=1,
             snapshot_date=date(2026, 4, 12),
-            cash_krw=Decimal("5000000"), cash_usd=Decimal("0"),
+            cash_krw=Decimal("5000000"),
+            cash_usd=Decimal("0"),
             positions_value=Decimal("5000000"),
             total_equity=Decimal("10000000"),
             daily_return_pct=None,
@@ -815,7 +819,8 @@ class TestDailySnapshots:
         self, service, mock_db, monkeypatch
     ):
         account = PaperAccount(
-            id=1, name="A",
+            id=1,
+            name="A",
             initial_capital=Decimal("10000000"),
             cash_krw=Decimal("10000000"),
             cash_usd=Decimal("0"),
@@ -840,14 +845,21 @@ class TestDailySnapshots:
     ):
         snaps = [
             PaperDailySnapshot(
-                id=1, account_id=1, snapshot_date=date(2026, 4, 10),
-                cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+                id=1,
+                account_id=1,
+                snapshot_date=date(2026, 4, 10),
+                cash_krw=Decimal("0"),
+                cash_usd=Decimal("0"),
                 positions_value=Decimal("0"),
-                total_equity=Decimal("10000000"), daily_return_pct=None,
+                total_equity=Decimal("10000000"),
+                daily_return_pct=None,
             ),
             PaperDailySnapshot(
-                id=2, account_id=1, snapshot_date=date(2026, 4, 11),
-                cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+                id=2,
+                account_id=1,
+                snapshot_date=date(2026, 4, 11),
+                cash_krw=Decimal("0"),
+                cash_usd=Decimal("0"),
                 positions_value=Decimal("0"),
                 total_equity=Decimal("10100000"),
                 daily_return_pct=Decimal("1.0000"),
@@ -860,11 +872,21 @@ class TestDailySnapshots:
         mock_db.execute = AsyncMock(return_value=result)
 
         rows = await service.calculate_daily_returns(
-            account_id=1, start_date=date(2026, 4, 10), end_date=date(2026, 4, 11),
+            account_id=1,
+            start_date=date(2026, 4, 10),
+            end_date=date(2026, 4, 11),
         )
         assert rows == [
-            {"date": "2026-04-10", "total_equity": Decimal("10000000"), "daily_return_pct": None},
-            {"date": "2026-04-11", "total_equity": Decimal("10100000"), "daily_return_pct": Decimal("1.0000")},
+            {
+                "date": "2026-04-10",
+                "total_equity": Decimal("10000000"),
+                "daily_return_pct": None,
+            },
+            {
+                "date": "2026-04-11",
+                "total_equity": Decimal("10100000"),
+                "daily_return_pct": Decimal("1.0000"),
+            },
         ]
 
 
@@ -875,13 +897,21 @@ class TestRoundTrips:
 
     def _trade(self, **kw):
         from datetime import datetime
+
         defaults = {
-            "id": 0, "account_id": 1, "symbol": "005930",
+            "id": 0,
+            "account_id": 1,
+            "symbol": "005930",
             "instrument_type": InstrumentType.equity_kr,
-            "side": "buy", "order_type": "market",
-            "quantity": Decimal("10"), "price": Decimal("60000"),
-            "total_amount": Decimal("600000"), "fee": Decimal("0"),
-            "currency": "KRW", "reason": None, "realized_pnl": None,
+            "side": "buy",
+            "order_type": "market",
+            "quantity": Decimal("10"),
+            "price": Decimal("60000"),
+            "total_amount": Decimal("600000"),
+            "fee": Decimal("0"),
+            "currency": "KRW",
+            "reason": None,
+            "realized_pnl": None,
             "executed_at": datetime(2026, 4, 1, tzinfo=UTC),
         }
         defaults.update(kw)
@@ -889,16 +919,23 @@ class TestRoundTrips:
 
     def test_closed_round_trip_computes_holding_days_and_pnl(self, service):
         from datetime import datetime
+
         trades = [
             self._trade(
-                id=1, side="buy", quantity=Decimal("10"),
-                price=Decimal("60000"), fee=Decimal("90"),
+                id=1,
+                side="buy",
+                quantity=Decimal("10"),
+                price=Decimal("60000"),
+                fee=Decimal("90"),
                 executed_at=datetime(2026, 4, 1, 9, 0, tzinfo=UTC),
                 reason="entry",
             ),
             self._trade(
-                id=2, side="sell", quantity=Decimal("10"),
-                price=Decimal("70000"), fee=Decimal("1365"),
+                id=2,
+                side="sell",
+                quantity=Decimal("10"),
+                price=Decimal("70000"),
+                fee=Decimal("1365"),
                 realized_pnl=Decimal("98635"),
                 executed_at=datetime(2026, 4, 6, 9, 0, tzinfo=UTC),
                 reason="exit",
@@ -916,28 +953,54 @@ class TestRoundTrips:
 
     def test_unclosed_position_excluded(self, service):
         from datetime import datetime
+
         trades = [
-            self._trade(id=1, side="buy", quantity=Decimal("10"),
-                        executed_at=datetime(2026, 4, 1, tzinfo=UTC)),
-            self._trade(id=2, side="sell", quantity=Decimal("4"),
-                        realized_pnl=Decimal("40000"),
-                        executed_at=datetime(2026, 4, 3, tzinfo=UTC)),
+            self._trade(
+                id=1,
+                side="buy",
+                quantity=Decimal("10"),
+                executed_at=datetime(2026, 4, 1, tzinfo=UTC),
+            ),
+            self._trade(
+                id=2,
+                side="sell",
+                quantity=Decimal("4"),
+                realized_pnl=Decimal("40000"),
+                executed_at=datetime(2026, 4, 3, tzinfo=UTC),
+            ),
         ]
         assert service._build_round_trips(trades) == []
 
     def test_multiple_symbols_grouped_independently(self, service):
         from datetime import datetime
+
         trades = [
-            self._trade(id=1, symbol="A", side="buy",
-                        executed_at=datetime(2026, 4, 1, tzinfo=UTC)),
-            self._trade(id=2, symbol="B", side="buy",
-                        executed_at=datetime(2026, 4, 1, tzinfo=UTC)),
-            self._trade(id=3, symbol="A", side="sell",
-                        realized_pnl=Decimal("100"),
-                        executed_at=datetime(2026, 4, 2, tzinfo=UTC)),
-            self._trade(id=4, symbol="B", side="sell",
-                        realized_pnl=Decimal("-50"),
-                        executed_at=datetime(2026, 4, 3, tzinfo=UTC)),
+            self._trade(
+                id=1,
+                symbol="A",
+                side="buy",
+                executed_at=datetime(2026, 4, 1, tzinfo=UTC),
+            ),
+            self._trade(
+                id=2,
+                symbol="B",
+                side="buy",
+                executed_at=datetime(2026, 4, 1, tzinfo=UTC),
+            ),
+            self._trade(
+                id=3,
+                symbol="A",
+                side="sell",
+                realized_pnl=Decimal("100"),
+                executed_at=datetime(2026, 4, 2, tzinfo=UTC),
+            ),
+            self._trade(
+                id=4,
+                symbol="B",
+                side="sell",
+                realized_pnl=Decimal("-50"),
+                executed_at=datetime(2026, 4, 3, tzinfo=UTC),
+            ),
         ]
         trips = service._build_round_trips(trades)
         assert {t["symbol"] for t in trips} == {"A", "B"}
@@ -945,7 +1008,13 @@ class TestRoundTrips:
 
 class TestRiskMetrics:
     def test_max_drawdown_pct_basic(self):
-        equities = [Decimal("100"), Decimal("120"), Decimal("90"), Decimal("110"), Decimal("80")]
+        equities = [
+            Decimal("100"),
+            Decimal("120"),
+            Decimal("90"),
+            Decimal("110"),
+            Decimal("80"),
+        ]
         dd = PaperTradingService._calc_max_drawdown_pct(equities)
         assert round(dd, 2) == 33.33
 
@@ -977,7 +1046,8 @@ class TestCalculatePerformance:
     @pytest.mark.asyncio
     async def test_full_performance_all_period(self, service, mock_db, monkeypatch):
         account = PaperAccount(
-            id=1, name="A",
+            id=1,
+            name="A",
             initial_capital=Decimal("10000000"),
             cash_krw=Decimal("5000000"),
             cash_usd=Decimal("0"),
@@ -985,33 +1055,51 @@ class TestCalculatePerformance:
         )
         monkeypatch.setattr(service, "get_account", AsyncMock(return_value=account))
         monkeypatch.setattr(
-            service, "_evaluate_positions_value", AsyncMock(return_value=Decimal("6000000"))
+            service,
+            "_evaluate_positions_value",
+            AsyncMock(return_value=Decimal("6000000")),
         )
         monkeypatch.setattr(
-            service, "get_positions",
-            AsyncMock(return_value=[
-                {"unrealized_pnl": Decimal("500000")},
-                {"unrealized_pnl": Decimal("-100000")},
-            ]),
+            service,
+            "get_positions",
+            AsyncMock(
+                return_value=[
+                    {"unrealized_pnl": Decimal("500000")},
+                    {"unrealized_pnl": Decimal("-100000")},
+                ]
+            ),
         )
 
         trades = [
             PaperTrade(
-                id=1, account_id=1, symbol="A",
+                id=1,
+                account_id=1,
+                symbol="A",
                 instrument_type=InstrumentType.equity_kr,
-                side="buy", order_type="market",
-                quantity=Decimal("10"), price=Decimal("60000"),
-                total_amount=Decimal("600000"), fee=Decimal("90"),
-                currency="KRW", reason=None, realized_pnl=None,
+                side="buy",
+                order_type="market",
+                quantity=Decimal("10"),
+                price=Decimal("60000"),
+                total_amount=Decimal("600000"),
+                fee=Decimal("90"),
+                currency="KRW",
+                reason=None,
+                realized_pnl=None,
                 executed_at=datetime(2026, 4, 1, tzinfo=UTC),
             ),
             PaperTrade(
-                id=2, account_id=1, symbol="A",
+                id=2,
+                account_id=1,
+                symbol="A",
                 instrument_type=InstrumentType.equity_kr,
-                side="sell", order_type="market",
-                quantity=Decimal("10"), price=Decimal("70000"),
-                total_amount=Decimal("700000"), fee=Decimal("1365"),
-                currency="KRW", reason=None,
+                side="sell",
+                order_type="market",
+                quantity=Decimal("10"),
+                price=Decimal("70000"),
+                total_amount=Decimal("700000"),
+                fee=Decimal("1365"),
+                currency="KRW",
+                reason=None,
                 realized_pnl=Decimal("98635"),
                 executed_at=datetime(2026, 4, 6, tzinfo=UTC),
             ),
@@ -1023,21 +1111,31 @@ class TestCalculatePerformance:
 
         snaps = [
             PaperDailySnapshot(
-                id=1, account_id=1, snapshot_date=date(2026, 4, 1),
-                cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+                id=1,
+                account_id=1,
+                snapshot_date=date(2026, 4, 1),
+                cash_krw=Decimal("0"),
+                cash_usd=Decimal("0"),
                 positions_value=Decimal("0"),
-                total_equity=Decimal("10000000"), daily_return_pct=None,
+                total_equity=Decimal("10000000"),
+                daily_return_pct=None,
             ),
             PaperDailySnapshot(
-                id=2, account_id=1, snapshot_date=date(2026, 4, 2),
-                cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+                id=2,
+                account_id=1,
+                snapshot_date=date(2026, 4, 2),
+                cash_krw=Decimal("0"),
+                cash_usd=Decimal("0"),
                 positions_value=Decimal("0"),
                 total_equity=Decimal("10100000"),
                 daily_return_pct=Decimal("1.0"),
             ),
             PaperDailySnapshot(
-                id=3, account_id=1, snapshot_date=date(2026, 4, 3),
-                cash_krw=Decimal("0"), cash_usd=Decimal("0"),
+                id=3,
+                account_id=1,
+                snapshot_date=date(2026, 4, 3),
+                cash_krw=Decimal("0"),
+                cash_usd=Decimal("0"),
                 positions_value=Decimal("0"),
                 total_equity=Decimal("9950000"),
                 daily_return_pct=Decimal("-1.49"),
@@ -1070,7 +1168,8 @@ class TestCalculatePerformance:
         self, service, mock_db, monkeypatch
     ):
         account = PaperAccount(
-            id=1, name="A",
+            id=1,
+            name="A",
             initial_capital=Decimal("10000000"),
             cash_krw=Decimal("10000000"),
             cash_usd=Decimal("0"),


### PR DESCRIPTION
## Summary

- SK하이닉스 매도 조건 5개를 평가하는 `sell_signal_service.py` 구현
  - trailing stop (가격 ≤ threshold)
  - StochRSI K < 80
  - 외국인 2일 연속 순매도 (KIS 투자자별 매매동향 API 추가)
  - RSI 70→65 하락 (Redis 기반 상태 전환 추적)
  - 볼린저밴드 상단 재진입 후 반등 실패
- `GET /api/n8n/sell-signal/{symbol}` 엔드포인트 추가 (모든 threshold 파라미터 커스터마이즈 가능)
- 2개 이상 조건 동시 충족 시 `triggered: true` 반환
- KIS `inquire_investor` API 메서드 추가 (constants, domestic_market_data, client)

## Test plan

- [ ] `GET /api/n8n/sell-signal/000660` 호출 시 5개 조건 평가 결과 확인
- [ ] Redis RSI 상태 저장/조회 동작 확인
- [ ] 외국인 투자자 데이터 API 응답 형식 검증
- [ ] threshold 파라미터 커스터마이즈 동작 확인
- [ ] n8n 폴링 연동 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)