### PR TITLE
feat(sell): DB 기반 매도 조건 + batch 엔드포인트 + n8n 워크플로우

### DIFF
--- a/alembic/versions/b3f8a1c2d4e5_add_sell_conditions_table.py
+++ b/alembic/versions/b3f8a1c2d4e5_add_sell_conditions_table.py
@@ -1,0 +1,67 @@
+"""add sell_conditions table
+
+Revision ID: b3f8a1c2d4e5
+Revises: 00227d1d2890
+Create Date: 2026-04-15 14:30:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b3f8a1c2d4e5"
+down_revision: str = "00227d1d2890"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "sell_conditions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("symbol", sa.String(20), nullable=False),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("price_threshold", sa.Numeric(18, 2), nullable=False),
+        sa.Column(
+            "stoch_rsi_threshold",
+            sa.Numeric(6, 2),
+            nullable=False,
+            server_default="80.0",
+        ),
+        sa.Column("foreign_days", sa.Integer(), nullable=False, server_default="2"),
+        sa.Column("rsi_high", sa.Numeric(6, 2), nullable=False, server_default="70.0"),
+        sa.Column("rsi_low", sa.Numeric(6, 2), nullable=False, server_default="65.0"),
+        sa.Column("bb_upper_ref", sa.Numeric(18, 2), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.PrimaryKeyConstraint("id", name="pk_sell_conditions"),
+        sa.UniqueConstraint("symbol", name="uq_sell_conditions_symbol"),
+    )
+    op.create_index("ix_sell_conditions_symbol", "sell_conditions", ["symbol"])
+
+    op.execute(
+        """
+        INSERT INTO sell_conditions (symbol, name, is_active, price_threshold,
+            stoch_rsi_threshold, foreign_days, rsi_high, rsi_low, bb_upper_ref)
+        VALUES ('000660', 'SK하이닉스', true, 1152000, 80.0, 2, 70.0, 65.0, 1142000)
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_sell_conditions_symbol", table_name="sell_conditions")
+    op.drop_table("sell_conditions")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -20,6 +20,7 @@ from .research_backtest import (
     ResearchSyncJob,
 )
 from .review import PendingSnapshot, Trade, TradeReview, TradeSnapshot
+from .sell_condition import SellCondition
 from .symbol_trade_settings import SymbolTradeSettings
 from .trade_journal import JournalStatus, TradeJournal
 from .trade_profile import (
@@ -87,6 +88,7 @@ __all__ = [
     "PaperAccount",
     "PaperPosition",
     "PaperTrade",
+    "SellCondition",
     # "AlertRule", "AlertEvent",
     # "PricesLatest", "PricesOHLCV", "FxRate",
 ]

--- a/app/models/sell_condition.py
+++ b/app/models/sell_condition.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+
+from sqlalchemy import TIMESTAMP, Boolean, Integer, Numeric, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class SellCondition(Base):
+    __tablename__ = "sell_conditions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    symbol: Mapped[str] = mapped_column(String(20), unique=True, index=True)
+    name: Mapped[str] = mapped_column(String(100))
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    price_threshold: Mapped[float] = mapped_column(Numeric(18, 2))
+    stoch_rsi_threshold: Mapped[float] = mapped_column(Numeric(6, 2), default=80.0)
+    foreign_days: Mapped[int] = mapped_column(Integer, default=2)
+    rsi_high: Mapped[float] = mapped_column(Numeric(6, 2), default=70.0)
+    rsi_low: Mapped[float] = mapped_column(Numeric(6, 2), default=65.0)
+    bb_upper_ref: Mapped[float] = mapped_column(Numeric(18, 2))
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    def __repr__(self) -> str:
+        return f"<SellCondition(symbol={self.symbol}, name={self.name}, active={self.is_active})>"

--- a/app/routers/n8n.py
+++ b/app/routers/n8n.py
@@ -36,7 +36,10 @@ from app.schemas.n8n.pending_snapshot import (
     N8nPendingSnapshotsRequest,
     N8nPendingSnapshotsResponse,
 )
-from app.schemas.n8n.sell_signal import N8nSellSignalResponse
+from app.schemas.n8n.sell_signal import (
+    N8nSellSignalBatchResponse,
+    N8nSellSignalResponse,
+)
 from app.schemas.n8n.trade_review import (
     N8nTradeReviewListResponse,
     N8nTradeReviewsRequest,
@@ -66,6 +69,10 @@ from app.services.n8n_trade_review_service import (
     get_trade_review_stats,
     get_trade_reviews,
     save_trade_reviews,
+)
+from app.services.sell_conditions_service import (
+    get_active_sell_conditions,
+    get_sell_condition,
 )
 from app.services.sell_signal_service import evaluate_sell_signal
 
@@ -599,31 +606,121 @@ async def get_n8n_news(
     return result
 
 
+@router.get("/sell-signal/batch", response_model=N8nSellSignalBatchResponse)
+async def get_sell_signal_batch(
+    db: AsyncSession = Depends(get_db),
+) -> N8nSellSignalBatchResponse | JSONResponse:
+    as_of = now_kst().replace(microsecond=0).isoformat()
+
+    try:
+        conditions = await get_active_sell_conditions(db)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Failed to load active sell conditions")
+        payload = N8nSellSignalBatchResponse(
+            success=False,
+            as_of=as_of,
+            total=0,
+            triggered_count=0,
+            results=[],
+            errors=[{"error": str(exc)}],
+        )
+        return JSONResponse(status_code=500, content=payload.model_dump())
+
+    results: list[N8nSellSignalResponse] = []
+    top_errors: list[dict[str, object]] = []
+
+    for cond in conditions:
+        try:
+            result = await evaluate_sell_signal(
+                symbol=cond.symbol,
+                price_threshold=float(cond.price_threshold),
+                stoch_rsi_threshold=float(cond.stoch_rsi_threshold),
+                foreign_consecutive_days=cond.foreign_days,
+                rsi_high_mark=float(cond.rsi_high),
+                rsi_low_mark=float(cond.rsi_low),
+                bb_upper_ref=float(cond.bb_upper_ref),
+            )
+            results.append(N8nSellSignalResponse(success=True, as_of=as_of, **result))
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Batch sell signal failed for %s", cond.symbol)
+            top_errors.append({"symbol": cond.symbol, "error": str(exc)})
+
+    triggered_count = sum(1 for r in results if r.triggered)
+    return N8nSellSignalBatchResponse(
+        success=True,
+        as_of=as_of,
+        total=len(results),
+        triggered_count=triggered_count,
+        results=results,
+        errors=top_errors,
+    )
+
+
 @router.get("/sell-signal/{symbol}", response_model=N8nSellSignalResponse)
 async def get_sell_signal(
     symbol: str,
-    price_threshold: float = Query(1_152_000, description="Trailing stop price (KRW)"),
-    stoch_rsi_threshold: float = Query(80, description="StochRSI K threshold"),
-    foreign_days: int = Query(
-        2, ge=1, le=5, description="Foreign consecutive sell days"
+    price_threshold: float | None = Query(
+        None, description="Trailing stop price (KRW). Loaded from DB if omitted."
     ),
-    rsi_high: float = Query(70, description="RSI high watermark"),
-    rsi_low: float = Query(65, description="RSI low trigger"),
-    bb_upper_ref: float = Query(
-        1_142_000, description="Bollinger upper reference (KRW)"
+    stoch_rsi_threshold: float | None = Query(
+        None, description="StochRSI K threshold. Loaded from DB if omitted."
     ),
+    foreign_days: int | None = Query(
+        None, ge=1, le=5, description="Foreign consecutive sell days"
+    ),
+    rsi_high: float | None = Query(
+        None, description="RSI high watermark. Loaded from DB if omitted."
+    ),
+    rsi_low: float | None = Query(
+        None, description="RSI low trigger. Loaded from DB if omitted."
+    ),
+    bb_upper_ref: float | None = Query(
+        None, description="Bollinger upper reference (KRW). Loaded from DB if omitted."
+    ),
+    db: AsyncSession = Depends(get_db),
 ) -> N8nSellSignalResponse | JSONResponse:
     as_of = now_kst().replace(microsecond=0).isoformat()
+
+    db_cond = await get_sell_condition(db, symbol)
+
+    final_price_threshold = (
+        price_threshold
+        if price_threshold is not None
+        else (float(db_cond.price_threshold) if db_cond else 1_152_000)
+    )
+    final_stoch_rsi = (
+        stoch_rsi_threshold
+        if stoch_rsi_threshold is not None
+        else (float(db_cond.stoch_rsi_threshold) if db_cond else 80)
+    )
+    final_foreign_days = (
+        foreign_days
+        if foreign_days is not None
+        else (db_cond.foreign_days if db_cond else 2)
+    )
+    final_rsi_high = (
+        rsi_high
+        if rsi_high is not None
+        else (float(db_cond.rsi_high) if db_cond else 70)
+    )
+    final_rsi_low = (
+        rsi_low if rsi_low is not None else (float(db_cond.rsi_low) if db_cond else 65)
+    )
+    final_bb_upper_ref = (
+        bb_upper_ref
+        if bb_upper_ref is not None
+        else (float(db_cond.bb_upper_ref) if db_cond else 1_142_000)
+    )
 
     try:
         result = await evaluate_sell_signal(
             symbol=symbol,
-            price_threshold=price_threshold,
-            stoch_rsi_threshold=stoch_rsi_threshold,
-            foreign_consecutive_days=foreign_days,
-            rsi_high_mark=rsi_high,
-            rsi_low_mark=rsi_low,
-            bb_upper_ref=bb_upper_ref,
+            price_threshold=final_price_threshold,
+            stoch_rsi_threshold=final_stoch_rsi,
+            foreign_consecutive_days=final_foreign_days,
+            rsi_high_mark=final_rsi_high,
+            rsi_low_mark=final_rsi_low,
+            bb_upper_ref=final_bb_upper_ref,
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Failed to evaluate sell signal for %s", symbol)

--- a/app/schemas/n8n/sell_signal.py
+++ b/app/schemas/n8n/sell_signal.py
@@ -25,3 +25,18 @@ class N8nSellSignalResponse(BaseModel):
     errors: list[dict[str, object]] = Field(
         default_factory=list, description="Non-fatal errors during evaluation"
     )
+
+
+class N8nSellSignalBatchResponse(BaseModel):
+    success: bool = Field(..., description="Whether batch request completed")
+    as_of: str = Field(..., description="Response timestamp in KST ISO8601")
+    total: int = Field(..., description="Total active symbols evaluated")
+    triggered_count: int = Field(
+        ..., description="Number of symbols with sell signal triggered"
+    )
+    results: list[N8nSellSignalResponse] = Field(
+        default_factory=list, description="Per-symbol evaluation results"
+    )
+    errors: list[dict[str, object]] = Field(
+        default_factory=list, description="Top-level errors"
+    )

--- a/app/services/sell_conditions_service.py
+++ b/app/services/sell_conditions_service.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.sell_condition import SellCondition
+
+logger = logging.getLogger(__name__)
+
+
+async def get_sell_condition(db: AsyncSession, symbol: str) -> SellCondition | None:
+    result = await db.execute(
+        select(SellCondition).where(SellCondition.symbol == symbol)
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_active_sell_conditions(
+    db: AsyncSession,
+) -> list[SellCondition]:
+    result = await db.execute(
+        select(SellCondition).where(SellCondition.is_active.is_(True))
+    )
+    return list(result.scalars().all())

--- a/n8n/workflows/sell-alert.json
+++ b/n8n/workflows/sell-alert.json
@@ -1,0 +1,129 @@
+{
+  "id": "sell-alert",
+  "name": "Sell Signal Alert (Generic)",
+  "nodes": [
+    {
+      "parameters": {
+        "rule": {
+          "interval": [{ "field": "minutes", "minutesInterval": 5 }]
+        }
+      },
+      "type": "n8n-nodes-base.scheduleTrigger",
+      "typeVersion": 1.3,
+      "position": [0, 0],
+      "id": "sell-trigger",
+      "name": "Schedule Trigger"
+    },
+    {
+      "parameters": {
+        "method": "GET",
+        "url": "={{ $env.AUTO_TRADER_API_URL }}/api/n8n/sell-signal/batch",
+        "authentication": "genericCredentialType",
+        "genericAuthType": "httpHeaderAuth",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [240, 0],
+      "id": "sell-fetch",
+      "name": "Fetch Batch Sell Signals",
+      "credentials": {
+        "httpHeaderAuth": {
+          "id": "auto_trader_api_token",
+          "name": "Auto Trader API Token"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const body = $input.first().json;\nif (!body.success || !body.results) {\n  return [{ json: { hasTriggered: false, items: [], message: 'batch request failed' } }];\n}\n\nconst triggered = body.results.filter(r => r.triggered);\nif (triggered.length === 0) {\n  return [{ json: { hasTriggered: false, items: [], message: 'no sell signals' } }];\n}\n\nconst items = triggered.map(r => {\n  const metConditions = r.conditions.filter(c => c.met).map(c => c.name).join(', ');\n  return {\n    symbol: r.symbol,\n    name: r.name,\n    conditions_met: r.conditions_met,\n    met_names: metConditions,\n    message: r.message,\n    details: r.conditions.filter(c => c.met).map(c => `${c.name}: ${c.detail}`).join('\\n')\n  };\n});\n\nreturn [{ json: { hasTriggered: true, items, message: `${triggered.length}개 종목 매도 신호` } }];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [480, 0],
+      "id": "sell-filter",
+      "name": "Filter Triggered"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": true, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "triggered-check",
+              "leftValue": "={{ $json.hasTriggered }}",
+              "rightValue": true,
+              "operator": { "type": "boolean", "operation": "equals" }
+            }
+          ],
+          "combinator": "and"
+        }
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [720, 0],
+      "id": "sell-if",
+      "name": "Has Triggered?"
+    },
+    {
+      "parameters": {
+        "mode": "runOnceForAllItems",
+        "jsCode": "const data = $input.first().json;\nconst items = data.items || [];\n\nlet text = `\\uD83D\\uDEA8 **매도 신호 알림** (${items.length}개 종목)\\n\\n`;\n\nfor (const item of items) {\n  text += `**${item.name} (${item.symbol})**\\n`;\n  text += `\\u2022 조건 충족: ${item.conditions_met}/5 (${item.met_names})\\n`;\n  text += `${item.details}\\n\\n`;\n}\n\nreturn [{ json: { text } }];"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [960, 0],
+      "id": "sell-format",
+      "name": "Format Message"
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "={{ $env.HERMES_WEBHOOK_URL }}",
+        "sendBody": true,
+        "bodyParameters": {
+          "parameters": [
+            { "name": "text", "value": "={{ $json.text }}" }
+          ]
+        },
+        "options": {
+          "timeout": 10000
+        }
+      },
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1200, 0],
+      "id": "sell-notify",
+      "name": "Send to Hermes"
+    }
+  ],
+  "connections": {
+    "Schedule Trigger": {
+      "main": [[{ "node": "Fetch Batch Sell Signals", "type": "main", "index": 0 }]]
+    },
+    "Fetch Batch Sell Signals": {
+      "main": [[{ "node": "Filter Triggered", "type": "main", "index": 0 }]]
+    },
+    "Filter Triggered": {
+      "main": [[{ "node": "Has Triggered?", "type": "main", "index": 0 }]]
+    },
+    "Has Triggered?": {
+      "main": [
+        [{ "node": "Format Message", "type": "main", "index": 0 }],
+        []
+      ]
+    },
+    "Format Message": {
+      "main": [[{ "node": "Send to Hermes", "type": "main", "index": 0 }]]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateCredsSetupCompleted": true
+  }
+}

--- a/tests/test_sell_signal_service.py
+++ b/tests/test_sell_signal_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import numpy as np
 import pandas as pd
@@ -11,7 +11,6 @@ import pytest
 
 from app.schemas.n8n.sell_signal import N8nSellCondition, N8nSellSignalResponse
 from app.services.sell_signal_service import (
-    REDIS_RSI_PREFIX,
     TRIGGER_THRESHOLD,
     _check_bollinger_reentry,
     _check_foreign_selling,
@@ -421,7 +420,7 @@ class TestCheckRsiMomentum:
     @pytest.mark.asyncio
     async def test_rsi_none_returns_not_met(self):
         df = _make_large_ohlcv(200)
-        mock_r = self._mock_redis()
+        self._mock_redis()
 
         with (
             patch(

--- a/tests/test_sell_signal_service.py
+++ b/tests/test_sell_signal_service.py
@@ -38,7 +38,9 @@ def _make_ohlcv_df(closes: list[float], n: int | None = None) -> pd.DataFrame:
     )
 
 
-def _make_large_ohlcv(n: int = 200, base: float = 100.0, seed: int = 42) -> pd.DataFrame:
+def _make_large_ohlcv(
+    n: int = 200, base: float = 100.0, seed: int = 42
+) -> pd.DataFrame:
     rng = np.random.default_rng(seed)
     changes = rng.normal(0, 1, n)
     closes = [base]
@@ -157,12 +159,15 @@ class TestCheckStochRsi:
     @pytest.mark.asyncio
     async def test_met_when_k_below_threshold(self):
         df = _make_large_ohlcv(200, base=100)
-        with patch(
-            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
-            return_value=df,
-        ), patch(
-            "app.services.sell_signal_service._calculate_stoch_rsi",
-            return_value={"k": 25.0, "d": 30.0},
+        with (
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                return_value=df,
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_stoch_rsi",
+                return_value={"k": 25.0, "d": 30.0},
+            ),
         ):
             cond, errors = await _check_stoch_rsi("000660", 80)
             assert cond.name == "stoch_rsi"
@@ -173,12 +178,15 @@ class TestCheckStochRsi:
     @pytest.mark.asyncio
     async def test_not_met_when_k_above_threshold(self):
         df = _make_large_ohlcv(200, base=100)
-        with patch(
-            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
-            return_value=df,
-        ), patch(
-            "app.services.sell_signal_service._calculate_stoch_rsi",
-            return_value={"k": 85.0, "d": 82.0},
+        with (
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                return_value=df,
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_stoch_rsi",
+                return_value={"k": 85.0, "d": 82.0},
+            ),
         ):
             cond, errors = await _check_stoch_rsi("000660", 80)
             assert cond.met is False
@@ -306,15 +314,19 @@ class TestCheckRsiMomentum:
         df = _make_large_ohlcv(200)
         mock_r = self._mock_redis({"was_above_high": True, "rsi": 72.0})
 
-        with patch(
-            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
-            return_value=df,
-        ), patch(
-            "app.services.sell_signal_service._calculate_rsi",
-            return_value={"14": 63.0},
-        ), patch(
-            "app.services.sell_signal_service._get_redis",
-            return_value=mock_r,
+        with (
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                return_value=df,
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_rsi",
+                return_value={"14": 63.0},
+            ),
+            patch(
+                "app.services.sell_signal_service._get_redis",
+                return_value=mock_r,
+            ),
         ):
             cond, errors = await _check_rsi_momentum("000660", 70, 65)
             assert cond.met is True
@@ -329,15 +341,19 @@ class TestCheckRsiMomentum:
         df = _make_large_ohlcv(200)
         mock_r = self._mock_redis({"was_above_high": True, "rsi": 72.0})
 
-        with patch(
-            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
-            return_value=df,
-        ), patch(
-            "app.services.sell_signal_service._calculate_rsi",
-            return_value={"14": 68.0},
-        ), patch(
-            "app.services.sell_signal_service._get_redis",
-            return_value=mock_r,
+        with (
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                return_value=df,
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_rsi",
+                return_value={"14": 68.0},
+            ),
+            patch(
+                "app.services.sell_signal_service._get_redis",
+                return_value=mock_r,
+            ),
         ):
             cond, errors = await _check_rsi_momentum("000660", 70, 65)
             assert cond.met is False
@@ -348,15 +364,19 @@ class TestCheckRsiMomentum:
         df = _make_large_ohlcv(200)
         mock_r = self._mock_redis()
 
-        with patch(
-            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
-            return_value=df,
-        ), patch(
-            "app.services.sell_signal_service._calculate_rsi",
-            return_value={"14": 50.0},
-        ), patch(
-            "app.services.sell_signal_service._get_redis",
-            return_value=mock_r,
+        with (
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                return_value=df,
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_rsi",
+                return_value={"14": 50.0},
+            ),
+            patch(
+                "app.services.sell_signal_service._get_redis",
+                return_value=mock_r,
+            ),
         ):
             cond, errors = await _check_rsi_momentum("000660", 70, 65)
             assert cond.met is False
@@ -367,15 +387,19 @@ class TestCheckRsiMomentum:
         df = _make_large_ohlcv(200)
         mock_r = self._mock_redis()
 
-        with patch(
-            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
-            return_value=df,
-        ), patch(
-            "app.services.sell_signal_service._calculate_rsi",
-            return_value={"14": 75.0},
-        ), patch(
-            "app.services.sell_signal_service._get_redis",
-            return_value=mock_r,
+        with (
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                return_value=df,
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_rsi",
+                return_value={"14": 75.0},
+            ),
+            patch(
+                "app.services.sell_signal_service._get_redis",
+                return_value=mock_r,
+            ),
         ):
             cond, errors = await _check_rsi_momentum("000660", 70, 65)
             assert cond.met is False
@@ -399,12 +423,15 @@ class TestCheckRsiMomentum:
         df = _make_large_ohlcv(200)
         mock_r = self._mock_redis()
 
-        with patch(
-            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
-            return_value=df,
-        ), patch(
-            "app.services.sell_signal_service._calculate_rsi",
-            return_value={"14": None},
+        with (
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                return_value=df,
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_rsi",
+                return_value={"14": None},
+            ),
         ):
             cond, errors = await _check_rsi_momentum("000660", 70, 65)
             assert cond.met is False
@@ -415,15 +442,19 @@ class TestCheckRsiMomentum:
         df = _make_large_ohlcv(200)
         mock_r = self._mock_redis()
 
-        with patch(
-            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
-            return_value=df,
-        ), patch(
-            "app.services.sell_signal_service._calculate_rsi",
-            return_value={"14": 50.0},
-        ), patch(
-            "app.services.sell_signal_service._get_redis",
-            return_value=mock_r,
+        with (
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                return_value=df,
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_rsi",
+                return_value={"14": 50.0},
+            ),
+            patch(
+                "app.services.sell_signal_service._get_redis",
+                return_value=mock_r,
+            ),
         ):
             await _check_rsi_momentum("000660", 70, 65)
             set_call = mock_r.set.call_args
@@ -454,14 +485,23 @@ class TestCheckBollingerReentry:
         closes = [1_000_000.0] * 190 + prices_above + prices_below
         df = _make_ohlcv_df(closes)
 
-        with patch(
-            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
-            return_value=df,
-        ), patch(
-            "app.services.sell_signal_service._calculate_bollinger",
-            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        with (
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                return_value=df,
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_bollinger",
+                return_value={
+                    "upper": 1_150_000.0,
+                    "middle": 1_100_000.0,
+                    "lower": 1_050_000.0,
+                },
+            ),
         ):
-            cond, errors = await _check_bollinger_reentry("000660", 1_100_000.0, 1_142_000.0)
+            cond, errors = await _check_bollinger_reentry(
+                "000660", 1_100_000.0, 1_142_000.0
+            )
             assert cond.name == "bollinger_reentry"
             assert cond.met is True
             assert "재진입" in cond.detail
@@ -471,14 +511,23 @@ class TestCheckBollingerReentry:
         closes = [1_200_000.0] * 200
         df = _make_ohlcv_df(closes)
 
-        with patch(
-            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
-            return_value=df,
-        ), patch(
-            "app.services.sell_signal_service._calculate_bollinger",
-            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        with (
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                return_value=df,
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_bollinger",
+                return_value={
+                    "upper": 1_150_000.0,
+                    "middle": 1_100_000.0,
+                    "lower": 1_050_000.0,
+                },
+            ),
         ):
-            cond, errors = await _check_bollinger_reentry("000660", 1_200_000.0, 1_142_000.0)
+            cond, errors = await _check_bollinger_reentry(
+                "000660", 1_200_000.0, 1_142_000.0
+            )
             assert cond.met is False
 
     @pytest.mark.asyncio
@@ -486,25 +535,41 @@ class TestCheckBollingerReentry:
         closes = [1_000_000.0] * 200
         df = _make_ohlcv_df(closes)
 
-        with patch(
-            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
-            return_value=df,
-        ), patch(
-            "app.services.sell_signal_service._calculate_bollinger",
-            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        with (
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                return_value=df,
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_bollinger",
+                return_value={
+                    "upper": 1_150_000.0,
+                    "middle": 1_100_000.0,
+                    "lower": 1_050_000.0,
+                },
+            ),
         ):
-            cond, errors = await _check_bollinger_reentry("000660", 1_000_000.0, 1_142_000.0)
+            cond, errors = await _check_bollinger_reentry(
+                "000660", 1_000_000.0, 1_142_000.0
+            )
             assert cond.met is False
 
     @pytest.mark.asyncio
     async def test_not_met_when_current_price_none(self):
         df = _make_large_ohlcv(200)
-        with patch(
-            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
-            return_value=df,
-        ), patch(
-            "app.services.sell_signal_service._calculate_bollinger",
-            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        with (
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                return_value=df,
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_bollinger",
+                return_value={
+                    "upper": 1_150_000.0,
+                    "middle": 1_100_000.0,
+                    "lower": 1_050_000.0,
+                },
+            ),
         ):
             cond, errors = await _check_bollinger_reentry("000660", None, 1_142_000.0)
             assert cond.met is False
@@ -524,12 +589,15 @@ class TestCheckBollingerReentry:
     @pytest.mark.asyncio
     async def test_bb_upper_none(self):
         df = _make_large_ohlcv(200)
-        with patch(
-            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
-            return_value=df,
-        ), patch(
-            "app.services.sell_signal_service._calculate_bollinger",
-            return_value={"upper": None, "middle": None, "lower": None},
+        with (
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                return_value=df,
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_bollinger",
+                return_value={"upper": None, "middle": None, "lower": None},
+            ),
         ):
             cond, errors = await _check_bollinger_reentry("000660", 100.0, 95.0)
             assert cond.met is False
@@ -587,10 +655,26 @@ class TestEvaluateSellSignal:
 
         return (
             patch("app.services.sell_signal_service.KISClient", return_value=kis_mock),
-            patch("app.services.sell_signal_service._fetch_ohlcv_for_indicators", return_value=df),
-            patch("app.services.sell_signal_service._calculate_stoch_rsi", return_value={"k": stoch_k, "d": 30.0}),
-            patch("app.services.sell_signal_service._calculate_rsi", return_value={"14": rsi_val}),
-            patch("app.services.sell_signal_service._calculate_bollinger", return_value={"upper": bb_upper, "middle": 1_100_000.0, "lower": 1_050_000.0}),
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                return_value=df,
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_stoch_rsi",
+                return_value={"k": stoch_k, "d": 30.0},
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_rsi",
+                return_value={"14": rsi_val},
+            ),
+            patch(
+                "app.services.sell_signal_service._calculate_bollinger",
+                return_value={
+                    "upper": bb_upper,
+                    "middle": 1_100_000.0,
+                    "lower": 1_050_000.0,
+                },
+            ),
             patch("app.services.sell_signal_service._get_redis", return_value=mock_r),
         )
 
@@ -690,13 +774,21 @@ class TestEvaluateSellSignal:
 class TestSellSignalEndpoint:
     @pytest.fixture
     def client(self):
+        from unittest.mock import AsyncMock
+
         from fastapi import FastAPI
         from fastapi.testclient import TestClient
 
+        from app.core.db import get_db
         from app.routers.n8n import router
 
         app = FastAPI()
         app.include_router(router)
+
+        async def override_get_db():
+            yield AsyncMock()
+
+        app.dependency_overrides[get_db] = override_get_db
         return TestClient(app)
 
     @pytest.mark.asyncio
@@ -710,9 +802,15 @@ class TestSellSignalEndpoint:
             "message": "[매도 대기] SK하이닉스 0/5 조건 충족",
             "errors": [],
         }
-        with patch(
-            "app.routers.n8n.evaluate_sell_signal",
-            return_value=mock_result,
+        with (
+            patch(
+                "app.routers.n8n.evaluate_sell_signal",
+                return_value=mock_result,
+            ),
+            patch(
+                "app.routers.n8n.get_sell_condition",
+                return_value=None,
+            ),
         ):
             resp = client.get("/api/n8n/sell-signal/000660")
             assert resp.status_code == 200
@@ -737,10 +835,16 @@ class TestSellSignalEndpoint:
             "message": "",
             "errors": [],
         }
-        with patch(
-            "app.routers.n8n.evaluate_sell_signal",
-            return_value=mock_result,
-        ) as mock_eval:
+        with (
+            patch(
+                "app.routers.n8n.evaluate_sell_signal",
+                return_value=mock_result,
+            ) as mock_eval,
+            patch(
+                "app.routers.n8n.get_sell_condition",
+                return_value=None,
+            ),
+        ):
             resp = client.get(
                 "/api/n8n/sell-signal/005930",
                 params={
@@ -764,9 +868,15 @@ class TestSellSignalEndpoint:
 
     @pytest.mark.asyncio
     async def test_500_on_evaluate_exception(self, client):
-        with patch(
-            "app.routers.n8n.evaluate_sell_signal",
-            side_effect=RuntimeError("catastrophic"),
+        with (
+            patch(
+                "app.routers.n8n.evaluate_sell_signal",
+                side_effect=RuntimeError("catastrophic"),
+            ),
+            patch(
+                "app.routers.n8n.get_sell_condition",
+                return_value=None,
+            ),
         ):
             resp = client.get("/api/n8n/sell-signal/000660")
             assert resp.status_code == 500
@@ -783,18 +893,48 @@ class TestSellSignalEndpoint:
             "triggered": True,
             "conditions_met": 3,
             "conditions": [
-                N8nSellCondition(name="trailing_stop", met=True, value=1_100_000, threshold=1_152_000, detail="현재가 ₩1,100,000"),
-                N8nSellCondition(name="stoch_rsi", met=True, value=25.0, threshold=80, detail="StochRSI K=25.0"),
-                N8nSellCondition(name="foreign_selling", met=True, value=None, detail="2일 연속 순매도"),
-                N8nSellCondition(name="rsi_momentum", met=False, value=68.0, detail="RSI 68.0"),
-                N8nSellCondition(name="bollinger_reentry", met=False, value=1_150_000, detail="밴드 상단 ₩1,150,000"),
+                N8nSellCondition(
+                    name="trailing_stop",
+                    met=True,
+                    value=1_100_000,
+                    threshold=1_152_000,
+                    detail="현재가 ₩1,100,000",
+                ),
+                N8nSellCondition(
+                    name="stoch_rsi",
+                    met=True,
+                    value=25.0,
+                    threshold=80,
+                    detail="StochRSI K=25.0",
+                ),
+                N8nSellCondition(
+                    name="foreign_selling",
+                    met=True,
+                    value=None,
+                    detail="2일 연속 순매도",
+                ),
+                N8nSellCondition(
+                    name="rsi_momentum", met=False, value=68.0, detail="RSI 68.0"
+                ),
+                N8nSellCondition(
+                    name="bollinger_reentry",
+                    met=False,
+                    value=1_150_000,
+                    detail="밴드 상단 ₩1,150,000",
+                ),
             ],
             "message": "[매도 검토] SK하이닉스 3/5 조건 충족 (trailing_stop, stoch_rsi, foreign_selling)",
             "errors": [],
         }
-        with patch(
-            "app.routers.n8n.evaluate_sell_signal",
-            return_value=mock_result,
+        with (
+            patch(
+                "app.routers.n8n.evaluate_sell_signal",
+                return_value=mock_result,
+            ),
+            patch(
+                "app.routers.n8n.get_sell_condition",
+                return_value=None,
+            ),
         ):
             resp = client.get("/api/n8n/sell-signal/000660")
             assert resp.status_code == 200

--- a/tests/test_sell_signal_service.py
+++ b/tests/test_sell_signal_service.py
@@ -1,0 +1,804 @@
+"""Tests for sell signal evaluation service."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.schemas.n8n.sell_signal import N8nSellCondition, N8nSellSignalResponse
+from app.services.sell_signal_service import (
+    REDIS_RSI_PREFIX,
+    TRIGGER_THRESHOLD,
+    _check_bollinger_reentry,
+    _check_foreign_selling,
+    _check_rsi_momentum,
+    _check_stoch_rsi,
+    _check_trailing_stop,
+    _fetch_current_price,
+    _fetch_stock_name,
+    evaluate_sell_signal,
+)
+
+
+def _make_ohlcv_df(closes: list[float], n: int | None = None) -> pd.DataFrame:
+    if n is None:
+        n = len(closes)
+    return pd.DataFrame(
+        {
+            "open": closes[:n],
+            "high": [c * 1.01 for c in closes[:n]],
+            "low": [c * 0.99 for c in closes[:n]],
+            "close": closes[:n],
+            "volume": [1000.0] * n,
+        }
+    )
+
+
+def _make_large_ohlcv(n: int = 200, base: float = 100.0, seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    changes = rng.normal(0, 1, n)
+    closes = [base]
+    for c in changes[1:]:
+        closes.append(max(closes[-1] + c, 1.0))
+    return _make_ohlcv_df(closes, n)
+
+
+# ---------------------------------------------------------------------------
+# _fetch_current_price
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCurrentPrice:
+    @pytest.mark.asyncio
+    async def test_returns_price_on_success(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame({"close": [1_150_000.0]})
+        price, err = await _fetch_current_price(kis, "000660")
+        assert price == 1_150_000.0
+        assert err is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_empty_df(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame()
+        price, err = await _fetch_current_price(kis, "000660")
+        assert price is None
+        assert err is None
+
+    @pytest.mark.asyncio
+    async def test_returns_error_on_exception(self):
+        kis = AsyncMock()
+        kis.inquire_price.side_effect = RuntimeError("API down")
+        price, err = await _fetch_current_price(kis, "000660")
+        assert price is None
+        assert err == "API down"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_stock_name
+# ---------------------------------------------------------------------------
+
+
+class TestFetchStockName:
+    @pytest.mark.asyncio
+    async def test_returns_name(self):
+        kis = AsyncMock()
+        kis.fetch_fundamental_info.return_value = {"종목명": "SK하이닉스"}
+        name = await _fetch_stock_name(kis, "000660")
+        assert name == "SK하이닉스"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_symbol(self):
+        kis = AsyncMock()
+        kis.fetch_fundamental_info.side_effect = RuntimeError("fail")
+        name = await _fetch_stock_name(kis, "000660")
+        assert name == "000660"
+
+
+# ---------------------------------------------------------------------------
+# _check_trailing_stop
+# ---------------------------------------------------------------------------
+
+
+class TestCheckTrailingStop:
+    @pytest.mark.asyncio
+    async def test_met_when_price_below_threshold(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame({"close": [1_100_000.0]})
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.name == "trailing_stop"
+        assert cond.met is True
+        assert price == 1_100_000.0
+        assert not errors
+
+    @pytest.mark.asyncio
+    async def test_met_when_price_equals_threshold(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame({"close": [1_150_000.0]})
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.met is True
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_price_above_threshold(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame({"close": [1_200_000.0]})
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.met is False
+        assert price == 1_200_000.0
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_price_unavailable(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame()
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.met is False
+        assert price is None
+
+    @pytest.mark.asyncio
+    async def test_error_recorded_on_api_failure(self):
+        kis = AsyncMock()
+        kis.inquire_price.side_effect = RuntimeError("timeout")
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.met is False
+        assert len(errors) == 1
+        assert errors[0]["condition"] == "trailing_stop"
+
+
+# ---------------------------------------------------------------------------
+# _check_stoch_rsi
+# ---------------------------------------------------------------------------
+
+
+class TestCheckStochRsi:
+    @pytest.mark.asyncio
+    async def test_met_when_k_below_threshold(self):
+        df = _make_large_ohlcv(200, base=100)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_stoch_rsi",
+            return_value={"k": 25.0, "d": 30.0},
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.name == "stoch_rsi"
+            assert cond.met is True
+            assert cond.value == 25.0
+            assert not errors
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_k_above_threshold(self):
+        df = _make_large_ohlcv(200, base=100)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_stoch_rsi",
+            return_value={"k": 85.0, "d": 82.0},
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_insufficient_data(self):
+        df = _make_ohlcv_df([100.0] * 10)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.met is False
+            assert "부족" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_empty_dataframe(self):
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=pd.DataFrame(),
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_error(self):
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            side_effect=RuntimeError("network"),
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.met is False
+            assert len(errors) == 1
+            assert errors[0]["condition"] == "stoch_rsi"
+
+
+# ---------------------------------------------------------------------------
+# _check_foreign_selling
+# ---------------------------------------------------------------------------
+
+
+class TestCheckForeignSelling:
+    @pytest.mark.asyncio
+    async def test_met_with_consecutive_sell_days(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [
+            {"frgn_ntby_qty": "-5000"},
+            {"frgn_ntby_qty": "-3000"},
+        ]
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.name == "foreign_selling"
+        assert cond.met is True
+        assert "2일 연속 순매도" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_not_met_with_mixed_days(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [
+            {"frgn_ntby_qty": "-5000"},
+            {"frgn_ntby_qty": "3000"},
+        ]
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_not_met_with_buy_days(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [
+            {"frgn_ntby_qty": "5000"},
+            {"frgn_ntby_qty": "3000"},
+        ]
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_insufficient_data(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [{"frgn_ntby_qty": "-5000"}]
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+        assert "부족" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_empty_rows(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = []
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_error(self):
+        kis = AsyncMock()
+        kis.inquire_investor.side_effect = RuntimeError("API error")
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+        assert len(errors) == 1
+        assert errors[0]["condition"] == "foreign_selling"
+
+    @pytest.mark.asyncio
+    async def test_single_day_consecutive(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [{"frgn_ntby_qty": "-1000"}]
+        cond, errors = await _check_foreign_selling(kis, "000660", 1)
+        assert cond.met is True
+
+
+# ---------------------------------------------------------------------------
+# _check_rsi_momentum
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRsiMomentum:
+    def _mock_redis(self, stored_state: dict | None = None):
+        mock_r = AsyncMock()
+        if stored_state:
+            mock_r.get.return_value = json.dumps(stored_state)
+        else:
+            mock_r.get.return_value = None
+        mock_r.set.return_value = True
+        mock_r.aclose.return_value = None
+        return mock_r
+
+    @pytest.mark.asyncio
+    async def test_met_when_rsi_drops_below_low_mark_after_high(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis({"was_above_high": True, "rsi": 72.0})
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 63.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is True
+            assert "하락" in cond.detail
+            # After trigger, was_above_high resets to False
+            set_call = mock_r.set.call_args
+            saved = json.loads(set_call[0][1])
+            assert saved["was_above_high"] is False
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_rsi_above_low_mark(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis({"was_above_high": True, "rsi": 72.0})
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 68.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert "돌파 이력 있음" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_never_reached_high(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis()
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 50.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert "미돌파" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_sets_was_above_high_when_rsi_reaches_high_mark(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis()
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 75.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            set_call = mock_r.set.call_args
+            saved = json.loads(set_call[0][1])
+            assert saved["was_above_high"] is True
+
+    @pytest.mark.asyncio
+    async def test_insufficient_data(self):
+        df = _make_ohlcv_df([100.0] * 10)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert "부족" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_rsi_none_returns_not_met(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis()
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": None},
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert "계산 불가" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_redis_state_ttl_is_7_days(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis()
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 50.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            await _check_rsi_momentum("000660", 70, 65)
+            set_call = mock_r.set.call_args
+            assert set_call[1]["ex"] == 86400 * 7
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_error(self):
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            side_effect=RuntimeError("redis down"),
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert len(errors) == 1
+
+
+# ---------------------------------------------------------------------------
+# _check_bollinger_reentry
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBollingerReentry:
+    @pytest.mark.asyncio
+    async def test_met_on_reentry_failure(self):
+        # Build prices: above ref, then drop below ref (re-entry), current below bb_upper
+        prices_above = [1_200_000.0] * 5
+        prices_below = [1_100_000.0] * 5
+        closes = [1_000_000.0] * 190 + prices_above + prices_below
+        df = _make_ohlcv_df(closes)
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 1_100_000.0, 1_142_000.0)
+            assert cond.name == "bollinger_reentry"
+            assert cond.met is True
+            assert "재진입" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_still_above_ref(self):
+        closes = [1_200_000.0] * 200
+        df = _make_ohlcv_df(closes)
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 1_200_000.0, 1_142_000.0)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_never_above_ref(self):
+        closes = [1_000_000.0] * 200
+        df = _make_ohlcv_df(closes)
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 1_000_000.0, 1_142_000.0)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_current_price_none(self):
+        df = _make_large_ohlcv(200)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", None, 1_142_000.0)
+            assert cond.met is False
+            assert "계산 불가" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_insufficient_data(self):
+        df = _make_ohlcv_df([100.0] * 10)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 100.0, 95.0)
+            assert cond.met is False
+            assert "부족" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_bb_upper_none(self):
+        df = _make_large_ohlcv(200)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": None, "middle": None, "lower": None},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 100.0, 95.0)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_error(self):
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            side_effect=RuntimeError("fail"),
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 100.0, 95.0)
+            assert cond.met is False
+            assert len(errors) == 1
+            assert errors[0]["condition"] == "bollinger_reentry"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_sell_signal — Integration
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSellSignal:
+    def _patch_all(
+        self,
+        price: float | None = 1_100_000.0,
+        stoch_k: float = 25.0,
+        foreign_rows: list | None = None,
+        rsi_val: float = 63.0,
+        rsi_state: dict | None = None,
+        bb_upper: float = 1_150_000.0,
+        stock_name: str = "SK하이닉스",
+    ):
+        if foreign_rows is None:
+            foreign_rows = [
+                {"frgn_ntby_qty": "-5000"},
+                {"frgn_ntby_qty": "-3000"},
+            ]
+        if rsi_state is None:
+            rsi_state = {"was_above_high": True, "rsi": 72.0}
+
+        kis_mock = AsyncMock()
+        if price is not None:
+            kis_mock.inquire_price.return_value = pd.DataFrame({"close": [price]})
+        else:
+            kis_mock.inquire_price.return_value = pd.DataFrame()
+        kis_mock.fetch_fundamental_info.return_value = {"종목명": stock_name}
+        kis_mock.inquire_investor.return_value = foreign_rows
+
+        df = _make_large_ohlcv(200)
+
+        mock_r = AsyncMock()
+        mock_r.get.return_value = json.dumps(rsi_state)
+        mock_r.set.return_value = True
+        mock_r.aclose.return_value = None
+
+        return (
+            patch("app.services.sell_signal_service.KISClient", return_value=kis_mock),
+            patch("app.services.sell_signal_service._fetch_ohlcv_for_indicators", return_value=df),
+            patch("app.services.sell_signal_service._calculate_stoch_rsi", return_value={"k": stoch_k, "d": 30.0}),
+            patch("app.services.sell_signal_service._calculate_rsi", return_value={"14": rsi_val}),
+            patch("app.services.sell_signal_service._calculate_bollinger", return_value={"upper": bb_upper, "middle": 1_100_000.0, "lower": 1_050_000.0}),
+            patch("app.services.sell_signal_service._get_redis", return_value=mock_r),
+        )
+
+    @pytest.mark.asyncio
+    async def test_triggered_when_two_or_more_conditions_met(self):
+        # trailing_stop met (price 1.1M <= threshold 1.152M)
+        # stoch_rsi met (k=25 < 80)
+        # foreign met (2 consecutive sell days)
+        # rsi_momentum met (was_above_high + rsi 63 <= 65)
+        patches = self._patch_all(price=1_100_000.0, stoch_k=25.0, rsi_val=63.0)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await evaluate_sell_signal("000660")
+            assert result["triggered"] is True
+            assert result["conditions_met"] >= TRIGGER_THRESHOLD
+            assert "매도 검토" in result["message"]
+            assert result["symbol"] == "000660"
+            assert result["name"] == "SK하이닉스"
+
+    @pytest.mark.asyncio
+    async def test_not_triggered_when_one_condition_met(self):
+        # Only trailing_stop met (price below threshold)
+        # stoch_rsi not met (k=85 >= 80)
+        # foreign not met (buy days)
+        # rsi not met (never above high)
+        patches = self._patch_all(
+            price=1_100_000.0,
+            stoch_k=85.0,
+            foreign_rows=[
+                {"frgn_ntby_qty": "5000"},
+                {"frgn_ntby_qty": "3000"},
+            ],
+            rsi_val=50.0,
+            rsi_state={},
+        )
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await evaluate_sell_signal("000660")
+            assert result["triggered"] is False
+            assert result["conditions_met"] < TRIGGER_THRESHOLD
+            assert "매도 대기" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_zero_conditions_met(self):
+        patches = self._patch_all(
+            price=1_200_000.0,  # above threshold
+            stoch_k=85.0,  # above threshold
+            foreign_rows=[
+                {"frgn_ntby_qty": "5000"},
+                {"frgn_ntby_qty": "3000"},
+            ],
+            rsi_val=50.0,
+            rsi_state={},
+        )
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await evaluate_sell_signal("000660")
+            assert result["triggered"] is False
+            assert result["conditions_met"] == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_all_five_conditions(self):
+        patches = self._patch_all()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await evaluate_sell_signal("000660")
+            assert len(result["conditions"]) == 5
+            names = {c.name for c in result["conditions"]}
+            assert names == {
+                "trailing_stop",
+                "stoch_rsi",
+                "foreign_selling",
+                "rsi_momentum",
+                "bollinger_reentry",
+            }
+
+    @pytest.mark.asyncio
+    async def test_errors_collected_from_evaluators(self):
+        kis_mock = AsyncMock()
+        kis_mock.inquire_price.side_effect = RuntimeError("price fail")
+        kis_mock.fetch_fundamental_info.return_value = {"종목명": "테스트"}
+        kis_mock.inquire_investor.side_effect = RuntimeError("investor fail")
+
+        with (
+            patch("app.services.sell_signal_service.KISClient", return_value=kis_mock),
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                side_effect=RuntimeError("ohlcv fail"),
+            ),
+        ):
+            result = await evaluate_sell_signal("000660")
+            assert result["triggered"] is False
+            assert len(result["errors"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# API Endpoint Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSellSignalEndpoint:
+    @pytest.fixture
+    def client(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from app.routers.n8n import router
+
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    @pytest.mark.asyncio
+    async def test_success_response_schema(self, client):
+        mock_result = {
+            "symbol": "000660",
+            "name": "SK하이닉스",
+            "triggered": False,
+            "conditions_met": 0,
+            "conditions": [],
+            "message": "[매도 대기] SK하이닉스 0/5 조건 충족",
+            "errors": [],
+        }
+        with patch(
+            "app.routers.n8n.evaluate_sell_signal",
+            return_value=mock_result,
+        ):
+            resp = client.get("/api/n8n/sell-signal/000660")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["success"] is True
+            assert data["symbol"] == "000660"
+            assert "as_of" in data
+            assert "triggered" in data
+            assert "conditions_met" in data
+            assert "conditions" in data
+            assert "message" in data
+            assert "errors" in data
+
+    @pytest.mark.asyncio
+    async def test_custom_query_params_forwarded(self, client):
+        mock_result = {
+            "symbol": "005930",
+            "name": "삼성전자",
+            "triggered": False,
+            "conditions_met": 0,
+            "conditions": [],
+            "message": "",
+            "errors": [],
+        }
+        with patch(
+            "app.routers.n8n.evaluate_sell_signal",
+            return_value=mock_result,
+        ) as mock_eval:
+            resp = client.get(
+                "/api/n8n/sell-signal/005930",
+                params={
+                    "price_threshold": 80000,
+                    "stoch_rsi_threshold": 70,
+                    "foreign_days": 3,
+                    "rsi_high": 75,
+                    "rsi_low": 60,
+                    "bb_upper_ref": 78000,
+                },
+            )
+            assert resp.status_code == 200
+            call_kwargs = mock_eval.call_args[1]
+            assert call_kwargs["symbol"] == "005930"
+            assert call_kwargs["price_threshold"] == 80000
+            assert call_kwargs["stoch_rsi_threshold"] == 70
+            assert call_kwargs["foreign_consecutive_days"] == 3
+            assert call_kwargs["rsi_high_mark"] == 75
+            assert call_kwargs["rsi_low_mark"] == 60
+            assert call_kwargs["bb_upper_ref"] == 78000
+
+    @pytest.mark.asyncio
+    async def test_500_on_evaluate_exception(self, client):
+        with patch(
+            "app.routers.n8n.evaluate_sell_signal",
+            side_effect=RuntimeError("catastrophic"),
+        ):
+            resp = client.get("/api/n8n/sell-signal/000660")
+            assert resp.status_code == 500
+            data = resp.json()
+            assert data["success"] is False
+            assert data["triggered"] is False
+            assert len(data["errors"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_response_validates_as_model(self, client):
+        mock_result = {
+            "symbol": "000660",
+            "name": "SK하이닉스",
+            "triggered": True,
+            "conditions_met": 3,
+            "conditions": [
+                N8nSellCondition(name="trailing_stop", met=True, value=1_100_000, threshold=1_152_000, detail="현재가 ₩1,100,000"),
+                N8nSellCondition(name="stoch_rsi", met=True, value=25.0, threshold=80, detail="StochRSI K=25.0"),
+                N8nSellCondition(name="foreign_selling", met=True, value=None, detail="2일 연속 순매도"),
+                N8nSellCondition(name="rsi_momentum", met=False, value=68.0, detail="RSI 68.0"),
+                N8nSellCondition(name="bollinger_reentry", met=False, value=1_150_000, detail="밴드 상단 ₩1,150,000"),
+            ],
+            "message": "[매도 검토] SK하이닉스 3/5 조건 충족 (trailing_stop, stoch_rsi, foreign_selling)",
+            "errors": [],
+        }
+        with patch(
+            "app.routers.n8n.evaluate_sell_signal",
+            return_value=mock_result,
+        ):
+            resp = client.get("/api/n8n/sell-signal/000660")
+            assert resp.status_code == 200
+            validated = N8nSellSignalResponse(**resp.json())
+            assert validated.triggered is True
+            assert validated.conditions_met == 3
+            assert len(validated.conditions) == 5


### PR DESCRIPTION
## Summary

- **SellCondition** DB 모델 + Alembic 마이그레이션 (SK하이닉스 000660 시드 데이터 포함)
- `sell_conditions_service.py`: 종목별 조건 조회 + 활성 종목 목록 조회
- `GET /api/n8n/sell-signal/{symbol}`: 기본값을 DB에서 로드 (DB에 없는 종목은 기존 하드코딩값 유지)
- `GET /api/n8n/sell-signal/batch`: 활성 종목 전체를 일괄 평가하여 배열로 반환
- `N8nSellSignalBatchResponse` 스키마 추가
- `sell-alert.json`: Schedule Trigger → batch API → triggered 필터 → hermes 알림 워크플로우
- 기존 테스트에 DB 의존성 모킹 추가하여 46건 모두 통과

## Test plan

- [x] `uv run pytest tests/test_sell_signal_service.py -v` — 46 passed
- [x] `uv run ruff check` — no errors on changed files
- [ ] Alembic 마이그레이션 적용 후 sell_conditions 테이블 확인
- [ ] `/api/n8n/sell-signal/000660` DB 기본값 반영 확인
- [ ] `/api/n8n/sell-signal/batch` 활성 종목 일괄 평가 확인
- [ ] n8n sell-alert.json import 후 워크플로우 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)