### PR TITLE
feat(mcp): Phase 1 MCP 도구 보강 — execution comment, market brief

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_add_paperclip_issue_id_to_trade_journals.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_paperclip_issue_id_to_trade_journals.py
@@ -1,0 +1,41 @@
+"""add paperclip_issue_id to trade_journals
+
+Revision ID: a1b2c3d4e5f6
+Revises: 00227d1d2890
+Create Date: 2026-04-15 15:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | None = "00227d1d2890"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "trade_journals",
+        sa.Column("paperclip_issue_id", sa.Text(), nullable=True),
+        schema="review",
+    )
+    op.create_index(
+        "ix_trade_journals_paperclip_issue_id",
+        "trade_journals",
+        ["paperclip_issue_id"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_trade_journals_paperclip_issue_id",
+        table_name="trade_journals",
+        schema="review",
+    )
+    op.drop_column("trade_journals", "paperclip_issue_id", schema="review")

--- a/app/mcp_server/tooling/execution_comment_registration.py
+++ b/app/mcp_server/tooling/execution_comment_registration.py
@@ -1,10 +1,10 @@
-"""MCP registration for execution comment formatter tool."""
+"""MCP registration for execution comment tools."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from app.mcp_server.tooling.execution_comment import format_execution_comment
+from app.mcp_server.tooling.execution_comment_tools import format_execution_comment
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -18,15 +18,10 @@ def register_execution_comment_tools(mcp: FastMCP) -> None:
     _ = mcp.tool(
         name="format_execution_comment",
         description=(
-            "Format trade execution data into a structured markdown comment. "
-            "stage controls which fields appear: "
-            "'strategy' (symbol, side, thesis), "
-            "'dry_run' (symbol, side, qty, price), "
-            "'live' (all fields, fill_status=pending), "
-            "'fill' (all fields incl. filled_qty/fee), "
-            "'follow_up' (symbol, journal_id, next_action, market_context). "
-            "Missing optional fields are omitted. "
-            "Set currency ('$', '₩') to prepend to price/fee."
+            "Format a structured Markdown comment for trade execution events. "
+            "stage='fill' for immediate fill notification with price/qty/thesis. "
+            "stage='follow_up' for post-fill analysis with next_action recommendation. "
+            "Output is usable in both Discord and Paperclip comments."
         ),
     )(format_execution_comment)
 

--- a/app/mcp_server/tooling/execution_comment_tools.py
+++ b/app/mcp_server/tooling/execution_comment_tools.py
@@ -1,0 +1,162 @@
+"""Execution comment formatting MCP tool implementations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+
+def _format_fill_comment(
+    symbol: str,
+    side: str,
+    filled_qty: float,
+    filled_price: float,
+    currency: str,
+    journal_context: dict[str, Any] | None,
+    market_brief: str | None,
+) -> str:
+    side_label = "매수" if side == "buy" else "매도"
+    side_emoji = "\U0001f7e2" if side == "buy" else "\U0001f534"
+
+    lines = [
+        f"## {side_emoji} {symbol} {side_label} 체결",
+        "",
+        f"- **수량**: {filled_qty:,.4g}",
+        f"- **체결가**: {currency}{filled_price:,.2f}",
+        f"- **체결금액**: {currency}{filled_qty * filled_price:,.0f}",
+        f"- **시각**: {datetime.now().strftime('%Y-%m-%d %H:%M:%S KST')}",
+    ]
+
+    if journal_context:
+        lines.append("")
+        lines.append("### 투자 논거")
+        if journal_context.get("thesis"):
+            lines.append(f"- **논거**: {journal_context['thesis']}")
+        if journal_context.get("strategy"):
+            lines.append(f"- **전략**: {journal_context['strategy']}")
+        if journal_context.get("target_price") is not None:
+            lines.append(
+                f"- **목표가**: {currency}{journal_context['target_price']:,.2f}"
+            )
+        if journal_context.get("stop_loss") is not None:
+            lines.append(f"- **손절가**: {currency}{journal_context['stop_loss']:,.2f}")
+        if journal_context.get("min_hold_days") is not None:
+            lines.append(f"- **최소 보유**: {journal_context['min_hold_days']}일")
+
+    if market_brief:
+        lines.append("")
+        lines.append("### 시장 컨텍스트")
+        lines.append(market_brief)
+
+    return "\n".join(lines)
+
+
+def _format_follow_up_comment(
+    symbol: str,
+    side: str,
+    filled_qty: float,
+    filled_price: float,
+    currency: str,
+    journal_context: dict[str, Any] | None,
+    market_brief: str | None,
+    next_action: str | None,
+    analysis_summary: str | None,
+) -> str:
+    side_label = "매수" if side == "buy" else "매도"
+
+    lines = [
+        f"## 후속 판단: {symbol} {side_label} 체결 후",
+        "",
+        f"- **체결**: {filled_qty:,.4g} @ {currency}{filled_price:,.2f}",
+    ]
+
+    if journal_context:
+        entry_price = journal_context.get("entry_price")
+        if entry_price and side == "sell":
+            pnl_pct = (filled_price / entry_price - 1) * 100
+            pnl_sign = "+" if pnl_pct >= 0 else ""
+            lines.append(f"- **수익률**: {pnl_sign}{pnl_pct:.2f}%")
+
+    if analysis_summary:
+        lines.append("")
+        lines.append("### 분석 요약")
+        lines.append(analysis_summary)
+
+    if market_brief:
+        lines.append("")
+        lines.append("### 시장 컨텍스트")
+        lines.append(market_brief)
+
+    if next_action:
+        lines.append("")
+        lines.append("### 다음 행동")
+        lines.append(f"**{next_action}**")
+
+    return "\n".join(lines)
+
+
+async def format_execution_comment(
+    stage: str,
+    symbol: str,
+    side: str,
+    filled_qty: float,
+    filled_price: float,
+    currency: str = "₩",
+    journal_context: dict[str, Any] | None = None,
+    market_brief: str | None = None,
+    next_action: str | None = None,
+    analysis_summary: str | None = None,
+) -> dict[str, Any]:
+    """Format a structured Markdown comment for trade execution events.
+
+    stage: 'fill' for immediate fill notification, 'follow_up' for post-fill analysis.
+    symbol: the traded symbol.
+    side: 'buy' or 'sell'.
+    filled_qty: quantity filled.
+    filled_price: price at which the fill occurred.
+    currency: currency symbol (default ₩).
+    journal_context: dict with thesis, strategy, target_price, stop_loss, etc.
+    market_brief: short market context string.
+    next_action: recommended next action (hold / 추가매수 / 익절 / 손절).
+    analysis_summary: post-fill analysis summary text.
+    """
+    if stage not in ("fill", "follow_up"):
+        return {"success": False, "error": "stage must be 'fill' or 'follow_up'"}
+    if side not in ("buy", "sell"):
+        return {"success": False, "error": "side must be 'buy' or 'sell'"}
+    if filled_qty <= 0:
+        return {"success": False, "error": "filled_qty must be positive"}
+    if filled_price <= 0:
+        return {"success": False, "error": "filled_price must be positive"}
+
+    try:
+        if stage == "fill":
+            text = _format_fill_comment(
+                symbol=symbol,
+                side=side,
+                filled_qty=filled_qty,
+                filled_price=filled_price,
+                currency=currency,
+                journal_context=journal_context,
+                market_brief=market_brief,
+            )
+        else:
+            text = _format_follow_up_comment(
+                symbol=symbol,
+                side=side,
+                filled_qty=filled_qty,
+                filled_price=filled_price,
+                currency=currency,
+                journal_context=journal_context,
+                market_brief=market_brief,
+                next_action=next_action,
+                analysis_summary=analysis_summary,
+            )
+
+        return {
+            "success": True,
+            "stage": stage,
+            "markdown": text,
+        }
+    except Exception as exc:
+        return {"success": False, "error": f"format_execution_comment failed: {exc}"}

--- a/app/mcp_server/tooling/market_brief_registration.py
+++ b/app/mcp_server/tooling/market_brief_registration.py
@@ -1,0 +1,43 @@
+"""MCP registration for market brief and reports tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.mcp_server.tooling.market_brief_tools import (
+    get_latest_market_brief,
+    get_market_reports,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+MARKET_BRIEF_TOOL_NAMES: set[str] = {
+    "get_latest_market_brief",
+    "get_market_reports",
+}
+
+
+def register_market_brief_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="get_latest_market_brief",
+        description=(
+            "Get a concise market summary from recent AI analysis results. "
+            "Returns decision (buy/hold/sell), confidence, and key price levels "
+            "for each symbol. Use for quick market context during trade execution."
+        ),
+    )(get_latest_market_brief)
+    _ = mcp.tool(
+        name="get_market_reports",
+        description=(
+            "Get detailed analysis report history for a specific symbol. "
+            "Returns full analysis including reasons, price ranges, detailed text, "
+            "and decision trend over time. Use for deep-dive on a single symbol."
+        ),
+    )(get_market_reports)
+
+
+__all__ = [
+    "MARKET_BRIEF_TOOL_NAMES",
+    "register_market_brief_tools",
+]

--- a/app/mcp_server/tooling/market_brief_tools.py
+++ b/app/mcp_server/tooling/market_brief_tools.py
@@ -1,0 +1,220 @@
+"""Market brief and reports MCP tool implementations."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.models.analysis import StockAnalysisResult, StockInfo
+
+logger = logging.getLogger(__name__)
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+async def get_latest_market_brief(
+    symbols: list[str] | None = None,
+    market: str | None = None,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Get a concise market summary for recent analysis results.
+
+    Returns current decision, confidence, and key price levels for each symbol.
+    symbols: optional list of symbols to filter (e.g. ['005930', 'AAPL']).
+    market: optional filter by instrument_type ('equity_kr', 'equity_us', 'crypto').
+    limit: max number of symbols to return (default 10).
+    """
+    try:
+        async with _session_factory()() as db:
+            from sqlalchemy import func
+
+            latest_subq = (
+                select(
+                    StockAnalysisResult.stock_info_id,
+                    func.max(StockAnalysisResult.created_at).label("max_created"),
+                )
+                .group_by(StockAnalysisResult.stock_info_id)
+                .subquery()
+            )
+
+            stmt = (
+                select(StockAnalysisResult, StockInfo)
+                .join(StockInfo, StockAnalysisResult.stock_info_id == StockInfo.id)
+                .join(
+                    latest_subq,
+                    (StockAnalysisResult.stock_info_id == latest_subq.c.stock_info_id)
+                    & (StockAnalysisResult.created_at == latest_subq.c.max_created),
+                )
+                .order_by(desc(StockAnalysisResult.created_at))
+            )
+
+            if symbols:
+                normalized = [s.strip().upper() for s in symbols]
+                stmt = stmt.where(StockInfo.symbol.in_(normalized))
+
+            if market:
+                stmt = stmt.where(StockInfo.instrument_type == market)
+
+            stmt = stmt.limit(limit)
+
+            result = await db.execute(stmt)
+            rows = result.all()
+
+            briefs = []
+            for analysis, info in rows:
+                brief = {
+                    "symbol": info.symbol,
+                    "name": info.name,
+                    "instrument_type": info.instrument_type,
+                    "decision": analysis.decision,
+                    "confidence": analysis.confidence,
+                    "buy_range": _price_range(
+                        analysis.appropriate_buy_min,
+                        analysis.appropriate_buy_max,
+                    ),
+                    "sell_range": _price_range(
+                        analysis.appropriate_sell_min,
+                        analysis.appropriate_sell_max,
+                    ),
+                    "analyzed_at": (
+                        analysis.created_at.isoformat() if analysis.created_at else None
+                    ),
+                }
+                briefs.append(brief)
+
+            summary = {
+                "total": len(briefs),
+                "buy_count": sum(1 for b in briefs if b["decision"] == "buy"),
+                "hold_count": sum(1 for b in briefs if b["decision"] == "hold"),
+                "sell_count": sum(1 for b in briefs if b["decision"] == "sell"),
+                "avg_confidence": (
+                    round(sum(b["confidence"] for b in briefs) / len(briefs), 1)
+                    if briefs
+                    else 0
+                ),
+            }
+
+            return {
+                "success": True,
+                "briefs": briefs,
+                "summary": summary,
+            }
+
+    except Exception as exc:
+        logger.exception("get_latest_market_brief failed")
+        return {"success": False, "error": f"get_latest_market_brief failed: {exc}"}
+
+
+async def get_market_reports(
+    symbol: str,
+    days: int = 7,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Get detailed analysis reports for a specific symbol.
+
+    Returns full analysis history including reasons, price ranges, and detailed text.
+    symbol: the symbol to query (e.g. '005930', 'AAPL', 'KRW-BTC').
+    days: how many days of history to include (default 7).
+    limit: max number of reports to return (default 10).
+    """
+    symbol = (symbol or "").strip().upper()
+    if not symbol:
+        return {"success": False, "error": "symbol is required"}
+
+    try:
+        async with _session_factory()() as db:
+            from datetime import timedelta
+
+            from app.core.timezone import now_kst
+
+            cutoff = now_kst() - timedelta(days=days)
+
+            stmt = (
+                select(StockAnalysisResult, StockInfo)
+                .join(StockInfo, StockAnalysisResult.stock_info_id == StockInfo.id)
+                .where(
+                    StockInfo.symbol == symbol,
+                    StockAnalysisResult.created_at >= cutoff,
+                )
+                .order_by(desc(StockAnalysisResult.created_at))
+                .limit(limit)
+            )
+
+            result = await db.execute(stmt)
+            rows = result.all()
+
+            if not rows:
+                return {
+                    "success": True,
+                    "symbol": symbol,
+                    "reports": [],
+                    "message": f"No analysis reports found for {symbol} in the last {days} days",
+                }
+
+            reports = []
+            for analysis, info in rows:
+                report = {
+                    "id": analysis.id,
+                    "symbol": info.symbol,
+                    "name": info.name,
+                    "model_name": analysis.model_name,
+                    "decision": analysis.decision,
+                    "confidence": analysis.confidence,
+                    "price_analysis": {
+                        "appropriate_buy": _price_range(
+                            analysis.appropriate_buy_min,
+                            analysis.appropriate_buy_max,
+                        ),
+                        "appropriate_sell": _price_range(
+                            analysis.appropriate_sell_min,
+                            analysis.appropriate_sell_max,
+                        ),
+                        "buy_hope": _price_range(
+                            analysis.buy_hope_min,
+                            analysis.buy_hope_max,
+                        ),
+                        "sell_target": _price_range(
+                            analysis.sell_target_min,
+                            analysis.sell_target_max,
+                        ),
+                    },
+                    "reasons": analysis.reasons,
+                    "detailed_text": analysis.detailed_text,
+                    "analyzed_at": (
+                        analysis.created_at.isoformat() if analysis.created_at else None
+                    ),
+                }
+                reports.append(report)
+
+            decision_trend = [r["decision"] for r in reports]
+
+            return {
+                "success": True,
+                "symbol": symbol,
+                "name": rows[0][1].name,
+                "reports": reports,
+                "trend": {
+                    "total_reports": len(reports),
+                    "decision_sequence": decision_trend,
+                    "latest_decision": decision_trend[0] if decision_trend else None,
+                    "latest_confidence": (
+                        reports[0]["confidence"] if reports else None
+                    ),
+                },
+            }
+
+    except Exception as exc:
+        logger.exception("get_market_reports failed")
+        return {"success": False, "error": f"get_market_reports failed: {exc}"}
+
+
+def _price_range(
+    min_val: float | None, max_val: float | None
+) -> dict[str, float | None]:
+    return {"min": min_val, "max": max_val}

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -9,6 +9,9 @@ from app.mcp_server.tooling.execution_comment_registration import (
     register_execution_comment_tools,
 )
 from app.mcp_server.tooling.fundamentals_registration import register_fundamentals_tools
+from app.mcp_server.tooling.market_brief_registration import (
+    register_market_brief_tools,
+)
 from app.mcp_server.tooling.market_data_registration import register_market_data_tools
 from app.mcp_server.tooling.market_report_registration import (
     register_market_report_tools,
@@ -58,6 +61,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_paper_analytics_tools(mcp)
     register_paper_journal_tools(mcp)
     register_execution_comment_tools(mcp)
+    register_market_brief_tools(mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/app/mcp_server/tooling/trade_journal_registration.py
+++ b/app/mcp_server/tooling/trade_journal_registration.py
@@ -31,8 +31,8 @@ def register_trade_journal_tools(mcp: FastMCP) -> None:
             "status defaults to 'draft' — set to 'active' after fill confirmation. "
             "account_type='paper' for paper trading journals (requires account name). "
             "paper_trade_id links to the paper trade record. "
-            "metadata is an optional JSON dict for extensible fields "
-            '(e.g. {"paperclip_issue_id": "ROB-XX"} for Paperclip linkage).'
+            "paperclip_issue_id links to the Paperclip issue tracking this trade. "
+            "metadata is an optional JSON dict for extensible fields."
         ),
     )(save_trade_journal)
     _ = mcp.tool(
@@ -45,8 +45,7 @@ def register_trade_journal_tools(mcp: FastMCP) -> None:
             "account_type defaults to 'live'; set to 'paper' for paper journals, "
             "or None to query both. "
             "account (optional) filters to a specific account name. "
-            "paperclip_issue_id (optional) filters by metadata.paperclip_issue_id "
-            "for reverse lookup from Paperclip issue to trade journal."
+            "paperclip_issue_id (optional) reverse lookup by Paperclip issue ID."
         ),
     )(get_trade_journal)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/trade_journal_tools.py
+++ b/app/mcp_server/tooling/trade_journal_tools.py
@@ -55,6 +55,7 @@ def _serialize_journal(j: TradeJournal) -> dict[str, Any]:
         "account": j.account,
         "account_type": j.account_type,
         "paper_trade_id": j.paper_trade_id,
+        "paperclip_issue_id": j.paperclip_issue_id,
         "notes": j.notes,
         "created_at": j.created_at.isoformat() if j.created_at else None,
         "updated_at": j.updated_at.isoformat() if j.updated_at else None,
@@ -78,6 +79,7 @@ async def save_trade_journal(
     status: str = "draft",
     account_type: str = "live",
     paper_trade_id: int | None = None,
+    paperclip_issue_id: str | None = None,
     metadata: dict | None = None,
 ) -> dict[str, Any]:
     """Save a trade journal entry with investment thesis and strategy metadata.
@@ -87,7 +89,8 @@ async def save_trade_journal(
     Warns if an active journal already exists for the same symbol.
     account_type='paper' for paper trading journals (requires account name).
     paper_trade_id links to the paper trade record.
-    metadata is an optional JSON dict for extensible fields (e.g. {"paperclip_issue_id": "ROB-XX"}).
+    paperclip_issue_id links to the Paperclip issue tracking this trade.
+    metadata is an optional JSON dict for extensible fields.
     """
     symbol = (symbol or "").strip()
     thesis = (thesis or "").strip()
@@ -172,6 +175,7 @@ async def save_trade_journal(
                 account=account,
                 account_type=account_type,
                 paper_trade_id=paper_trade_id,
+                paperclip_issue_id=paperclip_issue_id,
                 notes=notes,
                 extra_metadata=metadata,
             )
@@ -211,7 +215,7 @@ async def get_trade_journal(
     Each entry includes hold_remaining_days, hold_expired for hold period checks.
     account_type defaults to 'live'; set to 'paper' for paper journals, or None to query both.
     account (optional) filters to a specific account name.
-    paperclip_issue_id (optional) filters by metadata.paperclip_issue_id for reverse lookup.
+    paperclip_issue_id (optional) filters by Paperclip issue ID for reverse lookup.
     """
     try:
         async with _session_factory()() as db:
@@ -246,10 +250,7 @@ async def get_trade_journal(
                 filters.append(TradeJournal.account == account)
 
             if paperclip_issue_id is not None:
-                filters.append(
-                    TradeJournal.extra_metadata["paperclip_issue_id"].astext
-                    == paperclip_issue_id
-                )
+                filters.append(TradeJournal.paperclip_issue_id == paperclip_issue_id)
 
             if market:
                 market_map = {

--- a/app/models/trade_journal.py
+++ b/app/models/trade_journal.py
@@ -57,6 +57,7 @@ class TradeJournal(Base):
         Index("ix_trade_journals_symbol_status", "symbol", "status"),
         Index("ix_trade_journals_created", "created_at"),
         Index("ix_trade_journals_account_type", "account_type"),
+        Index("ix_trade_journals_paperclip_issue_id", "paperclip_issue_id"),
         {"schema": "review"},
     )
 
@@ -111,6 +112,7 @@ class TradeJournal(Base):
         Text, nullable=False, default="live", server_default="live"
     )
     paper_trade_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    paperclip_issue_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     notes: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True),

--- a/tests/test_sell_signal_service.py
+++ b/tests/test_sell_signal_service.py
@@ -1,0 +1,804 @@
+"""Tests for sell signal evaluation service."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.schemas.n8n.sell_signal import N8nSellCondition, N8nSellSignalResponse
+from app.services.sell_signal_service import (
+    REDIS_RSI_PREFIX,
+    TRIGGER_THRESHOLD,
+    _check_bollinger_reentry,
+    _check_foreign_selling,
+    _check_rsi_momentum,
+    _check_stoch_rsi,
+    _check_trailing_stop,
+    _fetch_current_price,
+    _fetch_stock_name,
+    evaluate_sell_signal,
+)
+
+
+def _make_ohlcv_df(closes: list[float], n: int | None = None) -> pd.DataFrame:
+    if n is None:
+        n = len(closes)
+    return pd.DataFrame(
+        {
+            "open": closes[:n],
+            "high": [c * 1.01 for c in closes[:n]],
+            "low": [c * 0.99 for c in closes[:n]],
+            "close": closes[:n],
+            "volume": [1000.0] * n,
+        }
+    )
+
+
+def _make_large_ohlcv(n: int = 200, base: float = 100.0, seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    changes = rng.normal(0, 1, n)
+    closes = [base]
+    for c in changes[1:]:
+        closes.append(max(closes[-1] + c, 1.0))
+    return _make_ohlcv_df(closes, n)
+
+
+# ---------------------------------------------------------------------------
+# _fetch_current_price
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCurrentPrice:
+    @pytest.mark.asyncio
+    async def test_returns_price_on_success(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame({"close": [1_150_000.0]})
+        price, err = await _fetch_current_price(kis, "000660")
+        assert price == 1_150_000.0
+        assert err is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_empty_df(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame()
+        price, err = await _fetch_current_price(kis, "000660")
+        assert price is None
+        assert err is None
+
+    @pytest.mark.asyncio
+    async def test_returns_error_on_exception(self):
+        kis = AsyncMock()
+        kis.inquire_price.side_effect = RuntimeError("API down")
+        price, err = await _fetch_current_price(kis, "000660")
+        assert price is None
+        assert err == "API down"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_stock_name
+# ---------------------------------------------------------------------------
+
+
+class TestFetchStockName:
+    @pytest.mark.asyncio
+    async def test_returns_name(self):
+        kis = AsyncMock()
+        kis.fetch_fundamental_info.return_value = {"종목명": "SK하이닉스"}
+        name = await _fetch_stock_name(kis, "000660")
+        assert name == "SK하이닉스"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_symbol(self):
+        kis = AsyncMock()
+        kis.fetch_fundamental_info.side_effect = RuntimeError("fail")
+        name = await _fetch_stock_name(kis, "000660")
+        assert name == "000660"
+
+
+# ---------------------------------------------------------------------------
+# _check_trailing_stop
+# ---------------------------------------------------------------------------
+
+
+class TestCheckTrailingStop:
+    @pytest.mark.asyncio
+    async def test_met_when_price_below_threshold(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame({"close": [1_100_000.0]})
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.name == "trailing_stop"
+        assert cond.met is True
+        assert price == 1_100_000.0
+        assert not errors
+
+    @pytest.mark.asyncio
+    async def test_met_when_price_equals_threshold(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame({"close": [1_150_000.0]})
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.met is True
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_price_above_threshold(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame({"close": [1_200_000.0]})
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.met is False
+        assert price == 1_200_000.0
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_price_unavailable(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame()
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.met is False
+        assert price is None
+
+    @pytest.mark.asyncio
+    async def test_error_recorded_on_api_failure(self):
+        kis = AsyncMock()
+        kis.inquire_price.side_effect = RuntimeError("timeout")
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.met is False
+        assert len(errors) == 1
+        assert errors[0]["condition"] == "trailing_stop"
+
+
+# ---------------------------------------------------------------------------
+# _check_stoch_rsi
+# ---------------------------------------------------------------------------
+
+
+class TestCheckStochRsi:
+    @pytest.mark.asyncio
+    async def test_met_when_k_below_threshold(self):
+        df = _make_large_ohlcv(200, base=100)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_stoch_rsi",
+            return_value={"k": 25.0, "d": 30.0},
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.name == "stoch_rsi"
+            assert cond.met is True
+            assert cond.value == 25.0
+            assert not errors
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_k_above_threshold(self):
+        df = _make_large_ohlcv(200, base=100)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_stoch_rsi",
+            return_value={"k": 85.0, "d": 82.0},
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_insufficient_data(self):
+        df = _make_ohlcv_df([100.0] * 10)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.met is False
+            assert "부족" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_empty_dataframe(self):
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=pd.DataFrame(),
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_error(self):
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            side_effect=RuntimeError("network"),
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.met is False
+            assert len(errors) == 1
+            assert errors[0]["condition"] == "stoch_rsi"
+
+
+# ---------------------------------------------------------------------------
+# _check_foreign_selling
+# ---------------------------------------------------------------------------
+
+
+class TestCheckForeignSelling:
+    @pytest.mark.asyncio
+    async def test_met_with_consecutive_sell_days(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [
+            {"frgn_ntby_qty": "-5000"},
+            {"frgn_ntby_qty": "-3000"},
+        ]
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.name == "foreign_selling"
+        assert cond.met is True
+        assert "2일 연속 순매도" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_not_met_with_mixed_days(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [
+            {"frgn_ntby_qty": "-5000"},
+            {"frgn_ntby_qty": "3000"},
+        ]
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_not_met_with_buy_days(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [
+            {"frgn_ntby_qty": "5000"},
+            {"frgn_ntby_qty": "3000"},
+        ]
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_insufficient_data(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [{"frgn_ntby_qty": "-5000"}]
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+        assert "부족" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_empty_rows(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = []
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_error(self):
+        kis = AsyncMock()
+        kis.inquire_investor.side_effect = RuntimeError("API error")
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+        assert len(errors) == 1
+        assert errors[0]["condition"] == "foreign_selling"
+
+    @pytest.mark.asyncio
+    async def test_single_day_consecutive(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [{"frgn_ntby_qty": "-1000"}]
+        cond, errors = await _check_foreign_selling(kis, "000660", 1)
+        assert cond.met is True
+
+
+# ---------------------------------------------------------------------------
+# _check_rsi_momentum
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRsiMomentum:
+    def _mock_redis(self, stored_state: dict | None = None):
+        mock_r = AsyncMock()
+        if stored_state:
+            mock_r.get.return_value = json.dumps(stored_state)
+        else:
+            mock_r.get.return_value = None
+        mock_r.set.return_value = True
+        mock_r.aclose.return_value = None
+        return mock_r
+
+    @pytest.mark.asyncio
+    async def test_met_when_rsi_drops_below_low_mark_after_high(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis({"was_above_high": True, "rsi": 72.0})
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 63.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is True
+            assert "하락" in cond.detail
+            # After trigger, was_above_high resets to False
+            set_call = mock_r.set.call_args
+            saved = json.loads(set_call[0][1])
+            assert saved["was_above_high"] is False
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_rsi_above_low_mark(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis({"was_above_high": True, "rsi": 72.0})
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 68.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert "돌파 이력 있음" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_never_reached_high(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis()
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 50.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert "미돌파" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_sets_was_above_high_when_rsi_reaches_high_mark(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis()
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 75.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            set_call = mock_r.set.call_args
+            saved = json.loads(set_call[0][1])
+            assert saved["was_above_high"] is True
+
+    @pytest.mark.asyncio
+    async def test_insufficient_data(self):
+        df = _make_ohlcv_df([100.0] * 10)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert "부족" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_rsi_none_returns_not_met(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis()
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": None},
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert "계산 불가" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_redis_state_ttl_is_7_days(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis()
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 50.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            await _check_rsi_momentum("000660", 70, 65)
+            set_call = mock_r.set.call_args
+            assert set_call[1]["ex"] == 86400 * 7
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_error(self):
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            side_effect=RuntimeError("redis down"),
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert len(errors) == 1
+
+
+# ---------------------------------------------------------------------------
+# _check_bollinger_reentry
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBollingerReentry:
+    @pytest.mark.asyncio
+    async def test_met_on_reentry_failure(self):
+        # Build prices: above ref, then drop below ref (re-entry), current below bb_upper
+        prices_above = [1_200_000.0] * 5
+        prices_below = [1_100_000.0] * 5
+        closes = [1_000_000.0] * 190 + prices_above + prices_below
+        df = _make_ohlcv_df(closes)
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 1_100_000.0, 1_142_000.0)
+            assert cond.name == "bollinger_reentry"
+            assert cond.met is True
+            assert "재진입" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_still_above_ref(self):
+        closes = [1_200_000.0] * 200
+        df = _make_ohlcv_df(closes)
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 1_200_000.0, 1_142_000.0)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_never_above_ref(self):
+        closes = [1_000_000.0] * 200
+        df = _make_ohlcv_df(closes)
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 1_000_000.0, 1_142_000.0)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_current_price_none(self):
+        df = _make_large_ohlcv(200)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", None, 1_142_000.0)
+            assert cond.met is False
+            assert "계산 불가" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_insufficient_data(self):
+        df = _make_ohlcv_df([100.0] * 10)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 100.0, 95.0)
+            assert cond.met is False
+            assert "부족" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_bb_upper_none(self):
+        df = _make_large_ohlcv(200)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": None, "middle": None, "lower": None},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 100.0, 95.0)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_error(self):
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            side_effect=RuntimeError("fail"),
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 100.0, 95.0)
+            assert cond.met is False
+            assert len(errors) == 1
+            assert errors[0]["condition"] == "bollinger_reentry"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_sell_signal — Integration
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSellSignal:
+    def _patch_all(
+        self,
+        price: float | None = 1_100_000.0,
+        stoch_k: float = 25.0,
+        foreign_rows: list | None = None,
+        rsi_val: float = 63.0,
+        rsi_state: dict | None = None,
+        bb_upper: float = 1_150_000.0,
+        stock_name: str = "SK하이닉스",
+    ):
+        if foreign_rows is None:
+            foreign_rows = [
+                {"frgn_ntby_qty": "-5000"},
+                {"frgn_ntby_qty": "-3000"},
+            ]
+        if rsi_state is None:
+            rsi_state = {"was_above_high": True, "rsi": 72.0}
+
+        kis_mock = AsyncMock()
+        if price is not None:
+            kis_mock.inquire_price.return_value = pd.DataFrame({"close": [price]})
+        else:
+            kis_mock.inquire_price.return_value = pd.DataFrame()
+        kis_mock.fetch_fundamental_info.return_value = {"종목명": stock_name}
+        kis_mock.inquire_investor.return_value = foreign_rows
+
+        df = _make_large_ohlcv(200)
+
+        mock_r = AsyncMock()
+        mock_r.get.return_value = json.dumps(rsi_state)
+        mock_r.set.return_value = True
+        mock_r.aclose.return_value = None
+
+        return (
+            patch("app.services.sell_signal_service.KISClient", return_value=kis_mock),
+            patch("app.services.sell_signal_service._fetch_ohlcv_for_indicators", return_value=df),
+            patch("app.services.sell_signal_service._calculate_stoch_rsi", return_value={"k": stoch_k, "d": 30.0}),
+            patch("app.services.sell_signal_service._calculate_rsi", return_value={"14": rsi_val}),
+            patch("app.services.sell_signal_service._calculate_bollinger", return_value={"upper": bb_upper, "middle": 1_100_000.0, "lower": 1_050_000.0}),
+            patch("app.services.sell_signal_service._get_redis", return_value=mock_r),
+        )
+
+    @pytest.mark.asyncio
+    async def test_triggered_when_two_or_more_conditions_met(self):
+        # trailing_stop met (price 1.1M <= threshold 1.152M)
+        # stoch_rsi met (k=25 < 80)
+        # foreign met (2 consecutive sell days)
+        # rsi_momentum met (was_above_high + rsi 63 <= 65)
+        patches = self._patch_all(price=1_100_000.0, stoch_k=25.0, rsi_val=63.0)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await evaluate_sell_signal("000660")
+            assert result["triggered"] is True
+            assert result["conditions_met"] >= TRIGGER_THRESHOLD
+            assert "매도 검토" in result["message"]
+            assert result["symbol"] == "000660"
+            assert result["name"] == "SK하이닉스"
+
+    @pytest.mark.asyncio
+    async def test_not_triggered_when_one_condition_met(self):
+        # Only trailing_stop met (price below threshold)
+        # stoch_rsi not met (k=85 >= 80)
+        # foreign not met (buy days)
+        # rsi not met (never above high)
+        patches = self._patch_all(
+            price=1_100_000.0,
+            stoch_k=85.0,
+            foreign_rows=[
+                {"frgn_ntby_qty": "5000"},
+                {"frgn_ntby_qty": "3000"},
+            ],
+            rsi_val=50.0,
+            rsi_state={},
+        )
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await evaluate_sell_signal("000660")
+            assert result["triggered"] is False
+            assert result["conditions_met"] < TRIGGER_THRESHOLD
+            assert "매도 대기" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_zero_conditions_met(self):
+        patches = self._patch_all(
+            price=1_200_000.0,  # above threshold
+            stoch_k=85.0,  # above threshold
+            foreign_rows=[
+                {"frgn_ntby_qty": "5000"},
+                {"frgn_ntby_qty": "3000"},
+            ],
+            rsi_val=50.0,
+            rsi_state={},
+        )
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await evaluate_sell_signal("000660")
+            assert result["triggered"] is False
+            assert result["conditions_met"] == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_all_five_conditions(self):
+        patches = self._patch_all()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await evaluate_sell_signal("000660")
+            assert len(result["conditions"]) == 5
+            names = {c.name for c in result["conditions"]}
+            assert names == {
+                "trailing_stop",
+                "stoch_rsi",
+                "foreign_selling",
+                "rsi_momentum",
+                "bollinger_reentry",
+            }
+
+    @pytest.mark.asyncio
+    async def test_errors_collected_from_evaluators(self):
+        kis_mock = AsyncMock()
+        kis_mock.inquire_price.side_effect = RuntimeError("price fail")
+        kis_mock.fetch_fundamental_info.return_value = {"종목명": "테스트"}
+        kis_mock.inquire_investor.side_effect = RuntimeError("investor fail")
+
+        with (
+            patch("app.services.sell_signal_service.KISClient", return_value=kis_mock),
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                side_effect=RuntimeError("ohlcv fail"),
+            ),
+        ):
+            result = await evaluate_sell_signal("000660")
+            assert result["triggered"] is False
+            assert len(result["errors"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# API Endpoint Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSellSignalEndpoint:
+    @pytest.fixture
+    def client(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from app.routers.n8n import router
+
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    @pytest.mark.asyncio
+    async def test_success_response_schema(self, client):
+        mock_result = {
+            "symbol": "000660",
+            "name": "SK하이닉스",
+            "triggered": False,
+            "conditions_met": 0,
+            "conditions": [],
+            "message": "[매도 대기] SK하이닉스 0/5 조건 충족",
+            "errors": [],
+        }
+        with patch(
+            "app.routers.n8n.evaluate_sell_signal",
+            return_value=mock_result,
+        ):
+            resp = client.get("/api/n8n/sell-signal/000660")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["success"] is True
+            assert data["symbol"] == "000660"
+            assert "as_of" in data
+            assert "triggered" in data
+            assert "conditions_met" in data
+            assert "conditions" in data
+            assert "message" in data
+            assert "errors" in data
+
+    @pytest.mark.asyncio
+    async def test_custom_query_params_forwarded(self, client):
+        mock_result = {
+            "symbol": "005930",
+            "name": "삼성전자",
+            "triggered": False,
+            "conditions_met": 0,
+            "conditions": [],
+            "message": "",
+            "errors": [],
+        }
+        with patch(
+            "app.routers.n8n.evaluate_sell_signal",
+            return_value=mock_result,
+        ) as mock_eval:
+            resp = client.get(
+                "/api/n8n/sell-signal/005930",
+                params={
+                    "price_threshold": 80000,
+                    "stoch_rsi_threshold": 70,
+                    "foreign_days": 3,
+                    "rsi_high": 75,
+                    "rsi_low": 60,
+                    "bb_upper_ref": 78000,
+                },
+            )
+            assert resp.status_code == 200
+            call_kwargs = mock_eval.call_args[1]
+            assert call_kwargs["symbol"] == "005930"
+            assert call_kwargs["price_threshold"] == 80000
+            assert call_kwargs["stoch_rsi_threshold"] == 70
+            assert call_kwargs["foreign_consecutive_days"] == 3
+            assert call_kwargs["rsi_high_mark"] == 75
+            assert call_kwargs["rsi_low_mark"] == 60
+            assert call_kwargs["bb_upper_ref"] == 78000
+
+    @pytest.mark.asyncio
+    async def test_500_on_evaluate_exception(self, client):
+        with patch(
+            "app.routers.n8n.evaluate_sell_signal",
+            side_effect=RuntimeError("catastrophic"),
+        ):
+            resp = client.get("/api/n8n/sell-signal/000660")
+            assert resp.status_code == 500
+            data = resp.json()
+            assert data["success"] is False
+            assert data["triggered"] is False
+            assert len(data["errors"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_response_validates_as_model(self, client):
+        mock_result = {
+            "symbol": "000660",
+            "name": "SK하이닉스",
+            "triggered": True,
+            "conditions_met": 3,
+            "conditions": [
+                N8nSellCondition(name="trailing_stop", met=True, value=1_100_000, threshold=1_152_000, detail="현재가 ₩1,100,000"),
+                N8nSellCondition(name="stoch_rsi", met=True, value=25.0, threshold=80, detail="StochRSI K=25.0"),
+                N8nSellCondition(name="foreign_selling", met=True, value=None, detail="2일 연속 순매도"),
+                N8nSellCondition(name="rsi_momentum", met=False, value=68.0, detail="RSI 68.0"),
+                N8nSellCondition(name="bollinger_reentry", met=False, value=1_150_000, detail="밴드 상단 ₩1,150,000"),
+            ],
+            "message": "[매도 검토] SK하이닉스 3/5 조건 충족 (trailing_stop, stoch_rsi, foreign_selling)",
+            "errors": [],
+        }
+        with patch(
+            "app.routers.n8n.evaluate_sell_signal",
+            return_value=mock_result,
+        ):
+            resp = client.get("/api/n8n/sell-signal/000660")
+            assert resp.status_code == 200
+            validated = N8nSellSignalResponse(**resp.json())
+            assert validated.triggered is True
+            assert validated.conditions_met == 3
+            assert len(validated.conditions) == 5


### PR DESCRIPTION
## Summary

Phase 1 of [ROB-73](/ROB/issues/ROB-73) — auto_trader MCP 도구 보강.

- **`paperclip_issue_id` column** added to `trade_journals` table with index + Alembic migration for reverse lookup from Paperclip issues to trade journals
- **`get_trade_journal`/`save_trade_journal` extended** with `paperclip_issue_id` parameter (dedicated column, not JSONB)
- **`format_execution_comment`** new MCP tool — generates structured Markdown for `fill` (체결 알림) and `follow_up` (후속 판단) stages
- **`get_latest_market_brief`** new MCP tool — concise market summary from latest AI analysis results (decision, confidence, price levels)
- **`get_market_reports`** new MCP tool — detailed analysis report history for a specific symbol with decision trend

## Test plan

- [x] `ruff check` passes on all changed files
- [x] `ruff format` applied
- [x] 967 existing unit tests pass (1 pre-existing failure unrelated to this PR)
- [ ] Run `alembic upgrade head` to apply migration
- [ ] Verify `format_execution_comment(stage="fill")` via MCP
- [ ] Verify `format_execution_comment(stage="follow_up")` via MCP
- [ ] Verify `get_latest_market_brief` returns analysis summaries
- [ ] Verify `get_market_reports` returns detailed reports
- [ ] Verify `get_trade_journal(paperclip_issue_id="ROB-XX")` reverse lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added market brief and stock report retrieval with filtering by symbol and timeframe
  * Added execution comment generation for trade notifications with market context and stage-based formatting
  * Introduced direct Paperclip issue ID support for trade journals

* **Database**
  * Added Paperclip issue ID column to trade journals with optimized indexing

* **Tests**
  * Added comprehensive test suite for sell signal evaluation service

<!-- end of auto-generated comment: release notes by coderabbit.ai -->