### PR TITLE
fix: block market orders via MCP place_order

### DIFF
--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -72,8 +72,10 @@ def register_order_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="place_order",
         description=(
-            "Place buy/sell orders for stocks or crypto. "
+            "Place buy/sell LIMIT orders for stocks or crypto. "
             "Supports Upbit (crypto) and KIS (KR/US equities). "
+            "Only limit orders are supported via MCP — market orders are not allowed. "
+            "`order_type` must be 'limit' and `price` is required. "
             "Always returns dry_run preview unless explicitly set to False. "
             "For buy orders (dry_run=False), thesis and strategy are required "
             "so a trade journal can be created automatically. "
@@ -91,7 +93,7 @@ def register_order_tools(mcp: FastMCP) -> None:
     async def place_order(
         symbol: str,
         side: Literal["buy", "sell"],
-        order_type: Literal["limit", "market"] = "limit",
+        order_type: Literal["limit"] = "limit",
         quantity: float | None = None,
         price: float | None = None,
         amount: float | None = None,
@@ -108,6 +110,19 @@ def register_order_tools(mcp: FastMCP) -> None:
         account_type: Literal["real", "paper"] = "real",
         paper_account: str | None = None,
     ):
+        # Defense in depth: reject market orders even if a stale client
+        # bypasses the tightened schema and still sends order_type="market".
+        if str(order_type).lower().strip() != "limit":
+            return {
+                "success": False,
+                "error": (
+                    "MCP place_order only supports limit orders; "
+                    "market orders are not allowed."
+                ),
+                "source": "mcp",
+                "symbol": symbol,
+                "order_type": order_type,
+            }
         if account_type == "paper":
             return await _place_paper_order(
                 symbol=symbol,

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -18,6 +18,19 @@ from tests._mcp_tooling_support import (
     build_tools,
 )
 
+EXPECTED_MARKET_ERROR = (
+    "MCP place_order only supports limit orders; market orders are not allowed."
+)
+
+
+def _assert_market_rejected(result):
+    assert result["success"] is False, result
+    assert result.get("error") == EXPECTED_MARKET_ERROR, result
+    # must NOT look like a successful preview or execution
+    assert result.get("dry_run") is not True
+    assert "execution" not in result
+
+
 # ----------------------------------------------------------------------
 # Amount-based order tests
 # ----------------------------------------------------------------------
@@ -25,51 +38,18 @@ from tests._mcp_tooling_support import (
 
 @pytest.mark.asyncio
 async def test_place_order_with_amount_crypto_market_buy(monkeypatch):
+    """MCP place_order must reject crypto market buy."""
     tools = build_tools()
-
-    mock = AsyncMock()
-    mock.fetch_multiple_current_prices = AsyncMock(return_value={"KRW-BTC": 50000000.0})
-    mock.fetch_my_coins = AsyncMock(
-        return_value=[{"currency": "KRW", "balance": "500000", "locked": "0"}]
-    )
-    mock.place_market_buy_order = AsyncMock(
-        return_value={
-            "uuid": "test-uuid",
-            "side": "bid",
-            "market": "KRW-BTC",
-            "ord_type": "price",
-            "price": "100000",
-            "volume": "0.002",
-        }
-    )
-
-    monkeypatch.setattr(
-        upbit_service,
-        "fetch_multiple_current_prices",
-        mock.fetch_multiple_current_prices,
-    )
-    monkeypatch.setattr(
-        upbit_service,
-        "fetch_my_coins",
-        mock.fetch_my_coins,
-    )
-    monkeypatch.setattr(
-        upbit_service,
-        "place_market_buy_order",
-        mock.place_market_buy_order,
-    )
-
     result = await tools["place_order"](
         symbol="KRW-BTC",
         side="buy",
         order_type="market",
-        amount=100000.0,
-        dry_run=True,
+        amount=5_000_000,
+        dry_run=False,
+        thesis="t",
+        strategy="s",
     )
-
-    assert result["success"] is True
-    assert result["dry_run"] is True
-    assert result["quantity"] > 0
+    _assert_market_rejected(result)
 
 
 @pytest.mark.asyncio
@@ -110,36 +90,18 @@ async def test_place_order_with_amount_limit_order(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_place_order_with_amount_stock_market_buy(monkeypatch):
+    """MCP place_order must reject KR stock market buy."""
     tools = build_tools()
-
-    class MockKISClient:
-        async def order_korea_stock(self, stock_code, order_type, quantity, price):
-            return {"odno": "12345", "ord_qty": quantity}
-
-        async def inquire_integrated_margin(self):
-            return {
-                "dnca_tot_amt": "5000000",
-                "stck_cash_objt_amt": "5000000",
-                "stck_itgr_cash100_ord_psbl_amt": "5000000",
-            }
-
-    async def fetch_quote(symbol):
-        return {"price": 100000.0}
-
-    _patch_runtime_attr(monkeypatch, "KISClient", MockKISClient)
-    _patch_runtime_attr(monkeypatch, "_fetch_quote_equity_kr", fetch_quote)
-
     result = await tools["place_order"](
         symbol="005930",
         side="buy",
         order_type="market",
-        amount=1000000.0,
-        dry_run=True,
+        amount=1_000_000,
+        dry_run=False,
+        thesis="t",
+        strategy="s",
     )
-
-    assert result["success"] is True
-    assert result["dry_run"] is True
-    assert result["quantity"] == 10
+    _assert_market_rejected(result)
 
 
 @pytest.mark.asyncio
@@ -229,45 +191,18 @@ async def test_place_order_upbit_buy_limit_dry_run(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_place_order_upbit_buy_market_dry_run(monkeypatch):
-    """Test Upbit buy market order in dry_run mode."""
+    """MCP place_order must reject crypto market buy even in dry_run."""
     tools = build_tools()
-
-    class DummyUpbit:
-        async def fetch_multiple_current_prices(self, symbols, use_cache=True):
-            return {"KRW-BTC": 50000000.0}
-
-        async def fetch_my_coins(self):
-            return [{"currency": "KRW", "balance": 2000000.0}]
-
-    _patch_runtime_attr(monkeypatch, "upbit_service", DummyUpbit())
-    _patch_runtime_attr(
-        monkeypatch,
-        "_preview_order",
-        AsyncMock(
-            return_value={
-                "symbol": "KRW-BTC",
-                "side": "buy",
-                "order_type": "market",
-                "price": 50000000.0,
-                "quantity": 0.04,
-                "estimated_value": 2000000.0,
-                "fee": 10000.0,
-            }
-        ),
-    )
-
     result = await tools["place_order"](
         symbol="KRW-BTC",
         side="buy",
         order_type="market",
+        amount=1_000_000,
         dry_run=True,
+        thesis="t",
+        strategy="s",
     )
-
-    assert result["success"] is True
-    assert result["dry_run"] is True
-    assert result["order_type"] == "market"
-    assert result["price"] == 50000000.0
-    assert result["quantity"] == 0.04
+    _assert_market_rejected(result)
 
 
 @pytest.mark.asyncio
@@ -309,70 +244,31 @@ async def test_place_order_sell_limit_price_below_minimum(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_place_order_market_buy_calculates_quantity(monkeypatch):
-    """Test that market buy order calculates quantity correctly."""
+    """MCP place_order must reject crypto market buy (calculates quantity path)."""
     tools = build_tools()
-
-    class DummyUpbit:
-        async def fetch_multiple_current_prices(self, symbols, use_cache=True):
-            return {"KRW-BTC": 50000000.0}
-
-        async def fetch_my_coins(self):
-            return [{"currency": "KRW", "balance": 2000000.0}]
-
-    _patch_runtime_attr(monkeypatch, "upbit_service", DummyUpbit())
-
     result = await tools["place_order"](
         symbol="KRW-BTC",
         side="buy",
         order_type="market",
+        amount=2_000_000,
         dry_run=True,
+        thesis="t",
+        strategy="s",
     )
-
-    assert result["success"] is True
-    assert result["dry_run"] is True
-    assert result["order_type"] == "market"
-    assert result["quantity"] == 0.04
-    assert result["price"] == 50000000.0
-    assert result["estimated_value"] == 2000000.0
+    _assert_market_rejected(result)
 
 
 @pytest.mark.asyncio
 async def test_place_order_market_sell_uses_full_quantity(monkeypatch):
-    """Test that market sell order uses full holdings."""
+    """MCP place_order must reject KR stock market sell."""
     tools = build_tools()
-
-    class DummyUpbit:
-        async def fetch_multiple_current_prices(self, symbols, use_cache=True):
-            return {"KRW-BTC": 50000000.0}
-
-        async def fetch_my_coins(self):
-            return [{"currency": "BTC", "balance": 0.5, "avg_buy_price": 40000000.0}]
-
-    _patch_runtime_attr(monkeypatch, "upbit_service", DummyUpbit())
-    _patch_runtime_attr(
-        monkeypatch,
-        "_preview_order",
-        AsyncMock(
-            return_value={
-                "estimated_value": 25000000.0,
-                "realized_pnl": 5000000.0,
-                "avg_buy_price": 40000000.0,
-            }
-        ),
-    )
-
     result = await tools["place_order"](
-        symbol="KRW-BTC",
+        symbol="005930",
         side="sell",
         order_type="market",
-        dry_run=True,
+        dry_run=False,
     )
-
-    assert result["success"] is True
-    assert result["dry_run"] is True
-    assert result["order_type"] == "market"
-    assert result["quantity"] == 0.5
-    assert result["realized_pnl"] == 5000000.0
+    _assert_market_rejected(result)
 
 
 # ----------------------------------------------------------------------
@@ -1431,45 +1327,15 @@ async def test_place_order_crypto_sell_exceeds_orderable_with_locked(monkeypatch
 
 @pytest.mark.asyncio
 async def test_place_order_crypto_market_sell_uses_orderable_only(monkeypatch):
+    """MCP place_order must reject crypto market sell."""
     tools = build_tools()
-
-    class DummyUpbit:
-        async def fetch_multiple_current_prices(self, symbols, use_cache=True):
-            return {"KRW-BTC": 50000000.0}
-
-        async def fetch_my_coins(self):
-            return [
-                {
-                    "currency": "BTC",
-                    "balance": 0.03,
-                    "locked": 0.02,
-                    "avg_buy_price": 50000000.0,
-                }
-            ]
-
-    _patch_runtime_attr(monkeypatch, "upbit_service", DummyUpbit())
-    _patch_runtime_attr(
-        monkeypatch,
-        "_preview_order",
-        AsyncMock(
-            return_value={
-                "estimated_value": 1500000.0,
-                "realized_pnl": 0.0,
-                "avg_buy_price": 50000000.0,
-            }
-        ),
-    )
-
     result = await tools["place_order"](
         symbol="KRW-BTC",
         side="sell",
         order_type="market",
-        dry_run=True,
+        dry_run=False,
     )
-
-    assert result["success"] is True
-    assert result["dry_run"] is True
-    assert result["quantity"] == 0.03
+    _assert_market_rejected(result)
 
 
 @pytest.mark.asyncio
@@ -2251,3 +2117,57 @@ class TestOrderFillRecording:
         assert result["success"] is True
         assert result["journal_created"] is False
         assert "journal_warning" in result
+
+
+# ----------------------------------------------------------------------
+# Market order rejection tests (policy change)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_place_order_paper_market_rejected():
+    """MCP place_order must reject market orders even in paper mode."""
+    tools = build_tools()
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="buy",
+        order_type="market",
+        amount=1_000_000,
+        dry_run=False,
+        account_type="paper",
+        thesis="t",
+        strategy="s",
+    )
+    _assert_market_rejected(result)
+
+
+@pytest.mark.asyncio
+async def test_place_order_paper_market_sell_rejected():
+    """MCP place_order must reject market sell orders in paper mode."""
+    tools = build_tools()
+    result = await tools["place_order"](
+        symbol="005930",
+        side="sell",
+        order_type="market",
+        dry_run=False,
+        account_type="paper",
+    )
+    _assert_market_rejected(result)
+
+
+@pytest.mark.asyncio
+async def test_place_order_limit_still_works_after_market_block(monkeypatch):
+    """Policy change must not regress the limit path."""
+    tools = build_tools()
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="buy",
+        order_type="limit",
+        price=50_000_000,
+        quantity=0.01,
+        dry_run=True,
+        thesis="t",
+        strategy="s",
+    )
+    # limit dry-run should succeed (or at least not be the market-rejection error)
+    assert result.get("error") != EXPECTED_MARKET_ERROR

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -114,9 +114,10 @@ async def test_place_order_amount_and_quantity_both_error():
         await tools["place_order"](
             symbol="KRW-BTC",
             side="buy",
-            order_type="market",
+            order_type="limit",
             amount=100000.0,
             quantity=0.001,
+            price=50000000.0,
             dry_run=True,
         )
 
@@ -129,7 +130,8 @@ async def test_place_order_sell_with_amount_error():
         await tools["place_order"](
             symbol="KRW-BTC",
             side="sell",
-            order_type="market",
+            order_type="limit",
+            price=50000000.0,
             amount=100000.0,
             dry_run=True,
         )
@@ -406,6 +408,9 @@ async def test_place_order_insufficient_balance_kis_overseas(monkeypatch):
                     "frcr_gnrl_ord_psbl_amt": "100.0",
                 }
             ]
+
+        def adjust_price_to_upbit_unit(self, price):
+            return price
 
     _patch_runtime_attr(monkeypatch, "KISClient", DummyKISClient)
     _patch_runtime_attr(
@@ -689,8 +694,9 @@ class TestPlaceOrderHighAmount:
         result = await tools["place_order"](
             symbol="005930",
             side="buy",
-            order_type="market",
+            order_type="limit",
             amount=5_000_000.0,
+            price=100000.0,
             dry_run=True,
         )
 
@@ -730,8 +736,9 @@ class TestPlaceOrderHighAmount:
         result = await tools["place_order"](
             symbol="AAPL",
             side="buy",
-            order_type="market",
+            order_type="limit",
             amount=2_600_000.0,
+            price=200.0,
             dry_run=True,
         )
 
@@ -765,8 +772,9 @@ class TestPlaceOrderHighAmount:
         result = await tools["place_order"](
             symbol="KRW-BTC",
             side="buy",
-            order_type="market",
+            order_type="limit",
             amount=5_000_000.0,
+            price=50000000.0,
             dry_run=True,
         )
 
@@ -903,7 +911,7 @@ class TestPlaceOrderHighAmount:
         mock.fetch_my_coins = AsyncMock(
             return_value=[{"currency": "KRW", "balance": "10000000", "locked": "0"}]
         )
-        mock.place_market_buy_order = AsyncMock(
+        mock.place_buy_order = AsyncMock(
             return_value={"uuid": "crypto-12345", "side": "bid"}
         )
 
@@ -919,15 +927,21 @@ class TestPlaceOrderHighAmount:
         )
         monkeypatch.setattr(
             upbit_service,
-            "place_market_buy_order",
-            mock.place_market_buy_order,
+            "place_buy_order",
+            mock.place_buy_order,
+        )
+        monkeypatch.setattr(
+            upbit_service,
+            "adjust_price_to_upbit_unit",
+            lambda price: price,
         )
 
         result = await tools["place_order"](
             symbol="KRW-BTC",
             side="buy",
-            order_type="market",
+            order_type="limit",
             amount=5_000_000.0,
+            price=50000000.0,
             dry_run=False,
             thesis="Test thesis for BTC",
             strategy="test-strategy",
@@ -936,7 +950,9 @@ class TestPlaceOrderHighAmount:
         assert result["success"] is True
         assert result["dry_run"] is False
         assert result["preview"]["quantity"] == pytest.approx(0.1, rel=1e-6)
-        mock.place_market_buy_order.assert_awaited_once_with("KRW-BTC", "5000000")
+        mock.place_buy_order.assert_awaited_once_with(
+            "KRW-BTC", 50000000.0, "0.10000000", "limit"
+        )
 
     @pytest.mark.asyncio
     async def test_place_order_daily_limit_blocks_high_amount_order(self, monkeypatch):
@@ -984,8 +1000,9 @@ class TestPlaceOrderHighAmount:
         result = await tools["place_order"](
             symbol="KRW-BTC",
             side="buy",
-            order_type="market",
+            order_type="limit",
             amount=5_000_000.0,
+            price=50000000.0,
             dry_run=False,
             thesis="Test thesis for BTC",
             strategy="test-strategy",
@@ -1153,8 +1170,9 @@ async def test_place_order_kr_equity_calls_integrated_margin(monkeypatch):
     result = await tools["place_order"](
         symbol="005930",
         side="buy",
-        order_type="market",
+        order_type="limit",
         amount=1_000_000.0,
+        price=80000.0,
         dry_run=True,
     )
 
@@ -1230,8 +1248,9 @@ async def test_place_order_kr_equity_balance_lookup_failure_returns_query_error(
         result = await tools["place_order"](
             symbol="005930",
             side="buy",
-            order_type="market",
+            order_type="limit",
             amount=500_000.0,
+            price=60000.0,
             dry_run=True,
         )
 
@@ -1315,8 +1334,9 @@ async def test_place_order_crypto_sell_exceeds_orderable_with_locked(monkeypatch
     result = await tools["place_order"](
         symbol="KRW-BTC",
         side="sell",
-        order_type="market",
+        order_type="limit",
         quantity=0.05,
+        price=50000000.0,
         dry_run=True,
     )
 
@@ -1356,6 +1376,9 @@ async def test_place_order_crypto_sell_locked_zero_still_works(monkeypatch):
                 }
             ]
 
+        def adjust_price_to_upbit_unit(self, price):
+            return price
+
     _patch_runtime_attr(monkeypatch, "upbit_service", DummyUpbit())
     _patch_runtime_attr(
         monkeypatch,
@@ -1372,7 +1395,9 @@ async def test_place_order_crypto_sell_locked_zero_still_works(monkeypatch):
     result = await tools["place_order"](
         symbol="KRW-BTC",
         side="sell",
-        order_type="market",
+        order_type="limit",
+        quantity=0.5,
+        price=50000000.0,
         dry_run=True,
     )
 
@@ -1416,8 +1441,9 @@ async def test_place_order_crypto_buy_blocked_by_stop_loss_cooldown(monkeypatch)
     result = await tools["place_order"](
         symbol="KRW-BTC",
         side="buy",
-        order_type="market",
+        order_type="limit",
         amount=100000.0,
+        price=50000000.0,
         dry_run=True,
     )
 
@@ -1447,12 +1473,16 @@ async def test_place_order_crypto_sell_records_stop_loss_cooldown(monkeypatch):
                 {"currency": "BTC", "balance": "0.5", "avg_buy_price": "50000000.0"}
             ]
 
-        async def place_market_sell_order(self, symbol, volume):
+        def adjust_price_to_upbit_unit(self, price):
+            return price
+
+        async def place_sell_order(self, symbol, volume, price):
             return {
                 "uuid": "test-uuid",
                 "side": "ask",
                 "market": symbol,
                 "volume": volume,
+                "price": price,
             }
 
     _patch_runtime_attr(monkeypatch, "upbit_service", DummyUpbit())
@@ -1460,8 +1490,9 @@ async def test_place_order_crypto_sell_records_stop_loss_cooldown(monkeypatch):
     result = await tools["place_order"](
         symbol="KRW-BTC",
         side="sell",
-        order_type="market",
+        order_type="limit",
         quantity=0.5,
+        price=51000000.0,
         dry_run=False,
     )
 
@@ -1514,8 +1545,9 @@ async def test_place_order_crypto_dry_run_stop_loss_does_not_record_cooldown(
     result = await tools["place_order"](
         symbol="KRW-BTC",
         side="sell",
-        order_type="market",
+        order_type="limit",
         quantity=0.5,
+        price=51000000.0,
         dry_run=True,
     )
 
@@ -1545,12 +1577,16 @@ async def test_place_order_crypto_profitable_sell_does_not_record_cooldown(monke
                 {"currency": "BTC", "balance": "0.5", "avg_buy_price": "50000000.0"}
             ]
 
-        async def place_market_sell_order(self, symbol, volume):
+        def adjust_price_to_upbit_unit(self, price):
+            return price
+
+        async def place_sell_order(self, symbol, volume, price):
             return {
                 "uuid": "test-uuid",
                 "side": "ask",
                 "market": symbol,
                 "volume": volume,
+                "price": price,
             }
 
     _patch_runtime_attr(monkeypatch, "upbit_service", DummyUpbit())
@@ -1580,8 +1616,9 @@ async def test_place_order_crypto_profitable_sell_does_not_record_cooldown(monke
     result = await tools["place_order"](
         symbol="KRW-BTC",
         side="sell",
-        order_type="market",
+        order_type="limit",
         quantity=0.5,
+        price=55000000.0,
         dry_run=False,
     )
 
@@ -1615,9 +1652,15 @@ async def test_real_sell_closes_journals_and_returns_summary(monkeypatch) -> Non
     )
     monkeypatch.setattr(
         upbit_service,
-        "place_market_sell_order",
+        "place_sell_order",
         AsyncMock(
-            return_value={"uuid": "sell-uuid", "side": "ask", "market": "KRW-BTC"}
+            return_value={
+                "uuid": "sell-uuid",
+                "side": "ask",
+                "market": "KRW-BTC",
+                "price": "95000000",
+                "volume": "0.01",
+            }
         ),
     )
     monkeypatch.setattr(
@@ -1638,8 +1681,9 @@ async def test_real_sell_closes_journals_and_returns_summary(monkeypatch) -> Non
     result = await tools["place_order"](
         symbol="KRW-BTC",
         side="sell",
-        order_type="market",
+        order_type="limit",
         quantity=0.01,
+        price=95000000.0,
         dry_run=False,
         reason="rebalance",
         exit_reason="take_profit",
@@ -1678,9 +1722,15 @@ async def test_sell_journal_close_failure_keeps_order_success(monkeypatch) -> No
     )
     monkeypatch.setattr(
         upbit_service,
-        "place_market_sell_order",
+        "place_sell_order",
         AsyncMock(
-            return_value={"uuid": "sell-uuid", "side": "ask", "market": "KRW-BTC"}
+            return_value={
+                "uuid": "sell-uuid",
+                "side": "ask",
+                "market": "KRW-BTC",
+                "price": "95000000",
+                "volume": "0.01",
+            }
         ),
     )
     monkeypatch.setattr(
@@ -1696,8 +1746,9 @@ async def test_sell_journal_close_failure_keeps_order_success(monkeypatch) -> No
     result = await tools["place_order"](
         symbol="KRW-BTC",
         side="sell",
-        order_type="market",
+        order_type="limit",
         quantity=0.01,
+        price=95000000.0,
         dry_run=False,
     )
 
@@ -1737,8 +1788,9 @@ async def test_sell_dry_run_does_not_close_journals(monkeypatch) -> None:
     result = await tools["place_order"](
         symbol="KRW-BTC",
         side="sell",
-        order_type="market",
+        order_type="limit",
         quantity=0.01,
+        price=95000000.0,
         dry_run=True,
     )
 


### PR DESCRIPTION
## Summary

This PR prevents the MCP `place_order` tool from executing market orders while leaving broker-level market-order capabilities intact for non-MCP callers.

### Changes

- **Schema change:** `order_type` parameter changed from `Literal["limit", "market"]` to `Literal["limit"]`
- **Runtime guard:** Added defense-in-depth check that rejects market orders with error: `MCP place_order only supports limit orders; market orders are not allowed.`
- **Tool description:** Updated to clarify that only limit orders are supported via MCP
- **Tests:** Updated 6 existing market tests to assert rejection, added 2 new paper-mode rejection tests + 1 limit regression test

### Architecture

The block is implemented at the MCP boundary only (`orders_registration.py`):
- `place_order` tool (MCP-facing) - blocks market orders
- `_place_order_impl` (internal) - unchanged, still accepts market orders for screener/router
- Paper trading engine - unchanged, remains market-capable
- Broker clients (KIS, Upbit) - unchanged

### Verification

- All 54 tests in `test_mcp_place_order.py` pass
- All screener tests pass (no non-MCP regression)
- Non-MCP paths verified to still support market orders

## Test Plan

- [ ] Run `uv run pytest tests/test_mcp_place_order.py -q` (54 tests pass)
- [ ] Verify screener still supports market orders via `order_type` parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order placement tool now restricted to limit orders only. Market orders are no longer supported and will be rejected with error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->