### PR TITLE
ROB-74: add MCP execution journal tools

### DIFF
--- a/alembic/versions/b8c4d2e0f1a9_create_trade_journals.py
+++ b/alembic/versions/b8c4d2e0f1a9_create_trade_journals.py
@@ -1,0 +1,144 @@
+"""Create trade journals.
+
+Revision ID: b8c4d2e0f1a9
+Revises: 672f39265fed
+Create Date: 2026-04-15 18:05:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "b8c4d2e0f1a9"
+down_revision: str | Sequence[str] | None = "672f39265fed"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+instrument_type_enum = sa.Enum(
+    "equity_kr",
+    "equity_us",
+    "crypto",
+    "forex",
+    "index",
+    name="instrument_type",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "trade_journals",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column("instrument_type", instrument_type_enum, nullable=False),
+        sa.Column("side", sa.Text(), nullable=False, server_default="buy"),
+        sa.Column("entry_price", sa.Numeric(20, 4), nullable=True),
+        sa.Column("quantity", sa.Numeric(20, 8), nullable=True),
+        sa.Column("amount", sa.Numeric(20, 4), nullable=True),
+        sa.Column("thesis", sa.Text(), nullable=False),
+        sa.Column("strategy", sa.Text(), nullable=True),
+        sa.Column("target_price", sa.Numeric(20, 4), nullable=True),
+        sa.Column("stop_loss", sa.Numeric(20, 4), nullable=True),
+        sa.Column("min_hold_days", sa.SmallInteger(), nullable=True),
+        sa.Column("hold_until", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "indicators_snapshot",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("status", sa.Text(), nullable=False, server_default="draft"),
+        sa.Column("trade_id", sa.BigInteger(), nullable=True),
+        sa.Column("exit_price", sa.Numeric(20, 4), nullable=True),
+        sa.Column("exit_date", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("exit_reason", sa.Text(), nullable=True),
+        sa.Column("pnl_pct", sa.Numeric(8, 4), nullable=True),
+        sa.Column("account", sa.Text(), nullable=True),
+        sa.Column("account_type", sa.Text(), nullable=False, server_default="live"),
+        sa.Column("paper_trade_id", sa.BigInteger(), nullable=True),
+        sa.Column("paperclip_issue_id", sa.Text(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.ForeignKeyConstraint(
+            ["trade_id"],
+            ["review.trades.id"],
+            ondelete="SET NULL",
+            name="fk_trade_journals_trade_id",
+        ),
+        sa.CheckConstraint(
+            "status IN ('draft','active','closed','stopped','expired')",
+            name="trade_journals_status_allowed",
+        ),
+        sa.CheckConstraint("side IN ('buy','sell')", name="trade_journals_side"),
+        sa.CheckConstraint(
+            "account_type IN ('live','paper')",
+            name="trade_journals_account_type",
+        ),
+        sa.CheckConstraint(
+            "NOT (account_type = 'live' AND paper_trade_id IS NOT NULL)",
+            name="trade_journals_no_paper_trade_on_live",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_trade_journals_symbol_status",
+        "trade_journals",
+        ["symbol", "status"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_trade_journals_created",
+        "trade_journals",
+        ["created_at"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_trade_journals_account_type",
+        "trade_journals",
+        ["account_type"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_trade_journals_paperclip_issue_id",
+        "trade_journals",
+        ["paperclip_issue_id"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_trade_journals_paperclip_issue_id",
+        table_name="trade_journals",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_trade_journals_account_type",
+        table_name="trade_journals",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_trade_journals_created",
+        table_name="trade_journals",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_trade_journals_symbol_status",
+        table_name="trade_journals",
+        schema="review",
+    )
+    op.drop_table("trade_journals", schema="review")

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -67,6 +67,12 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - `status="pending"` 만 symbol 없이 호출 가능
   - `status in {"all", "filled", "cancelled"}` 는 symbol 필요
   - filled/cancelled 조회는 시장별 historical endpoint 제약 때문에 symbol fan-out을 자동 수행하지 않음
+- `save_trade_journal(symbol, thesis, ..., paperclip_issue_id=None)` - Save the thesis, strategy, account context, and optional Paperclip issue link for a trade.
+- `get_trade_journal(symbol=None, status=None, ..., paperclip_issue_id=None)` - Query active journal entries by symbol/account or reverse-lookup a journal from a Paperclip issue ID.
+- `update_trade_journal(journal_id=None, symbol=None, ...)` - Activate, close, stop, or adjust the latest matching journal entry.
+- `format_execution_comment(stage, symbol, side, filled_qty, filled_price, ...)` - Format Discord/Paperclip-ready Markdown for `fill` and `follow_up` execution stages.
+- `get_latest_market_brief(symbols=None, market=None, limit=10)` - Return concise latest AI analysis context for recent or selected symbols.
+- `get_market_reports(symbol, days=7, limit=10)` - Return detailed AI analysis report history and decision trend for one symbol.
 - `place_order(symbol, side, order_type="limit", quantity=None, price=None, amount=None)`
 - `modify_order(order_id, symbol, new_price=None, new_quantity=None)`
 - `cancel_order(order_id)`

--- a/app/mcp_server/tooling/execution_comment_registration.py
+++ b/app/mcp_server/tooling/execution_comment_registration.py
@@ -1,0 +1,32 @@
+"""MCP registration for execution comment tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.mcp_server.tooling.execution_comment_tools import format_execution_comment
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+EXECUTION_COMMENT_TOOL_NAMES: set[str] = {
+    "format_execution_comment",
+}
+
+
+def register_execution_comment_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="format_execution_comment",
+        description=(
+            "Format a structured Markdown comment for trade execution events. "
+            "stage='fill' for immediate fill notification with price/qty/thesis. "
+            "stage='follow_up' for post-fill analysis with next_action recommendation. "
+            "Output is usable in both Discord and Paperclip comments."
+        ),
+    )(format_execution_comment)
+
+
+__all__ = [
+    "EXECUTION_COMMENT_TOOL_NAMES",
+    "register_execution_comment_tools",
+]

--- a/app/mcp_server/tooling/execution_comment_tools.py
+++ b/app/mcp_server/tooling/execution_comment_tools.py
@@ -1,0 +1,162 @@
+"""Execution comment formatting MCP tool implementations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+
+def _format_fill_comment(
+    symbol: str,
+    side: str,
+    filled_qty: float,
+    filled_price: float,
+    currency: str,
+    journal_context: dict[str, Any] | None,
+    market_brief: str | None,
+) -> str:
+    side_label = "매수" if side == "buy" else "매도"
+    side_emoji = "\U0001f7e2" if side == "buy" else "\U0001f534"
+
+    lines = [
+        f"## {side_emoji} {symbol} {side_label} 체결",
+        "",
+        f"- **수량**: {filled_qty:,.4g}",
+        f"- **체결가**: {currency}{filled_price:,.2f}",
+        f"- **체결금액**: {currency}{filled_qty * filled_price:,.0f}",
+        f"- **시각**: {datetime.now().strftime('%Y-%m-%d %H:%M:%S KST')}",
+    ]
+
+    if journal_context:
+        lines.append("")
+        lines.append("### 투자 논거")
+        if journal_context.get("thesis"):
+            lines.append(f"- **논거**: {journal_context['thesis']}")
+        if journal_context.get("strategy"):
+            lines.append(f"- **전략**: {journal_context['strategy']}")
+        if journal_context.get("target_price") is not None:
+            lines.append(
+                f"- **목표가**: {currency}{journal_context['target_price']:,.2f}"
+            )
+        if journal_context.get("stop_loss") is not None:
+            lines.append(f"- **손절가**: {currency}{journal_context['stop_loss']:,.2f}")
+        if journal_context.get("min_hold_days") is not None:
+            lines.append(f"- **최소 보유**: {journal_context['min_hold_days']}일")
+
+    if market_brief:
+        lines.append("")
+        lines.append("### 시장 컨텍스트")
+        lines.append(market_brief)
+
+    return "\n".join(lines)
+
+
+def _format_follow_up_comment(
+    symbol: str,
+    side: str,
+    filled_qty: float,
+    filled_price: float,
+    currency: str,
+    journal_context: dict[str, Any] | None,
+    market_brief: str | None,
+    next_action: str | None,
+    analysis_summary: str | None,
+) -> str:
+    side_label = "매수" if side == "buy" else "매도"
+
+    lines = [
+        f"## 후속 판단: {symbol} {side_label} 체결 후",
+        "",
+        f"- **체결**: {filled_qty:,.4g} @ {currency}{filled_price:,.2f}",
+    ]
+
+    if journal_context:
+        entry_price = journal_context.get("entry_price")
+        if entry_price and side == "sell":
+            pnl_pct = (filled_price / entry_price - 1) * 100
+            pnl_sign = "+" if pnl_pct >= 0 else ""
+            lines.append(f"- **수익률**: {pnl_sign}{pnl_pct:.2f}%")
+
+    if analysis_summary:
+        lines.append("")
+        lines.append("### 분석 요약")
+        lines.append(analysis_summary)
+
+    if market_brief:
+        lines.append("")
+        lines.append("### 시장 컨텍스트")
+        lines.append(market_brief)
+
+    if next_action:
+        lines.append("")
+        lines.append("### 다음 행동")
+        lines.append(f"**{next_action}**")
+
+    return "\n".join(lines)
+
+
+async def format_execution_comment(
+    stage: str,
+    symbol: str,
+    side: str,
+    filled_qty: float,
+    filled_price: float,
+    currency: str = "₩",
+    journal_context: dict[str, Any] | None = None,
+    market_brief: str | None = None,
+    next_action: str | None = None,
+    analysis_summary: str | None = None,
+) -> dict[str, Any]:
+    """Format a structured Markdown comment for trade execution events.
+
+    stage: 'fill' for immediate fill notification, 'follow_up' for post-fill analysis.
+    symbol: the traded symbol.
+    side: 'buy' or 'sell'.
+    filled_qty: quantity filled.
+    filled_price: price at which the fill occurred.
+    currency: currency symbol (default ₩).
+    journal_context: dict with thesis, strategy, target_price, stop_loss, etc.
+    market_brief: short market context string.
+    next_action: recommended next action (hold / 추가매수 / 익절 / 손절).
+    analysis_summary: post-fill analysis summary text.
+    """
+    if stage not in ("fill", "follow_up"):
+        return {"success": False, "error": "stage must be 'fill' or 'follow_up'"}
+    if side not in ("buy", "sell"):
+        return {"success": False, "error": "side must be 'buy' or 'sell'"}
+    if filled_qty <= 0:
+        return {"success": False, "error": "filled_qty must be positive"}
+    if filled_price <= 0:
+        return {"success": False, "error": "filled_price must be positive"}
+
+    try:
+        if stage == "fill":
+            text = _format_fill_comment(
+                symbol=symbol,
+                side=side,
+                filled_qty=filled_qty,
+                filled_price=filled_price,
+                currency=currency,
+                journal_context=journal_context,
+                market_brief=market_brief,
+            )
+        else:
+            text = _format_follow_up_comment(
+                symbol=symbol,
+                side=side,
+                filled_qty=filled_qty,
+                filled_price=filled_price,
+                currency=currency,
+                journal_context=journal_context,
+                market_brief=market_brief,
+                next_action=next_action,
+                analysis_summary=analysis_summary,
+            )
+
+        return {
+            "success": True,
+            "stage": stage,
+            "markdown": text,
+        }
+    except Exception as exc:
+        return {"success": False, "error": f"format_execution_comment failed: {exc}"}

--- a/app/mcp_server/tooling/market_brief_registration.py
+++ b/app/mcp_server/tooling/market_brief_registration.py
@@ -1,0 +1,43 @@
+"""MCP registration for market brief and reports tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.mcp_server.tooling.market_brief_tools import (
+    get_latest_market_brief,
+    get_market_reports,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+MARKET_BRIEF_TOOL_NAMES: set[str] = {
+    "get_latest_market_brief",
+    "get_market_reports",
+}
+
+
+def register_market_brief_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="get_latest_market_brief",
+        description=(
+            "Get a concise market summary from recent AI analysis results. "
+            "Returns decision (buy/hold/sell), confidence, and key price levels "
+            "for each symbol. Use for quick market context during trade execution."
+        ),
+    )(get_latest_market_brief)
+    _ = mcp.tool(
+        name="get_market_reports",
+        description=(
+            "Get detailed analysis report history for a specific symbol. "
+            "Returns full analysis including reasons, price ranges, detailed text, "
+            "and decision trend over time. Use for deep-dive on a single symbol."
+        ),
+    )(get_market_reports)
+
+
+__all__ = [
+    "MARKET_BRIEF_TOOL_NAMES",
+    "register_market_brief_tools",
+]

--- a/app/mcp_server/tooling/market_brief_tools.py
+++ b/app/mcp_server/tooling/market_brief_tools.py
@@ -1,0 +1,220 @@
+"""Market brief and reports MCP tool implementations."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.models.analysis import StockAnalysisResult, StockInfo
+
+logger = logging.getLogger(__name__)
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+async def get_latest_market_brief(
+    symbols: list[str] | None = None,
+    market: str | None = None,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Get a concise market summary for recent analysis results.
+
+    Returns current decision, confidence, and key price levels for each symbol.
+    symbols: optional list of symbols to filter (e.g. ['005930', 'AAPL']).
+    market: optional filter by instrument_type ('equity_kr', 'equity_us', 'crypto').
+    limit: max number of symbols to return (default 10).
+    """
+    try:
+        async with _session_factory()() as db:
+            from sqlalchemy import func
+
+            latest_subq = (
+                select(
+                    StockAnalysisResult.stock_info_id,
+                    func.max(StockAnalysisResult.created_at).label("max_created"),
+                )
+                .group_by(StockAnalysisResult.stock_info_id)
+                .subquery()
+            )
+
+            stmt = (
+                select(StockAnalysisResult, StockInfo)
+                .join(StockInfo, StockAnalysisResult.stock_info_id == StockInfo.id)
+                .join(
+                    latest_subq,
+                    (StockAnalysisResult.stock_info_id == latest_subq.c.stock_info_id)
+                    & (StockAnalysisResult.created_at == latest_subq.c.max_created),
+                )
+                .order_by(desc(StockAnalysisResult.created_at))
+            )
+
+            if symbols:
+                normalized = [s.strip().upper() for s in symbols]
+                stmt = stmt.where(StockInfo.symbol.in_(normalized))
+
+            if market:
+                stmt = stmt.where(StockInfo.instrument_type == market)
+
+            stmt = stmt.limit(limit)
+
+            result = await db.execute(stmt)
+            rows = result.all()
+
+            briefs = []
+            for analysis, info in rows:
+                brief = {
+                    "symbol": info.symbol,
+                    "name": info.name,
+                    "instrument_type": info.instrument_type,
+                    "decision": analysis.decision,
+                    "confidence": analysis.confidence,
+                    "buy_range": _price_range(
+                        analysis.appropriate_buy_min,
+                        analysis.appropriate_buy_max,
+                    ),
+                    "sell_range": _price_range(
+                        analysis.appropriate_sell_min,
+                        analysis.appropriate_sell_max,
+                    ),
+                    "analyzed_at": (
+                        analysis.created_at.isoformat() if analysis.created_at else None
+                    ),
+                }
+                briefs.append(brief)
+
+            summary = {
+                "total": len(briefs),
+                "buy_count": sum(1 for b in briefs if b["decision"] == "buy"),
+                "hold_count": sum(1 for b in briefs if b["decision"] == "hold"),
+                "sell_count": sum(1 for b in briefs if b["decision"] == "sell"),
+                "avg_confidence": (
+                    round(sum(b["confidence"] for b in briefs) / len(briefs), 1)
+                    if briefs
+                    else 0
+                ),
+            }
+
+            return {
+                "success": True,
+                "briefs": briefs,
+                "summary": summary,
+            }
+
+    except Exception as exc:
+        logger.exception("get_latest_market_brief failed")
+        return {"success": False, "error": f"get_latest_market_brief failed: {exc}"}
+
+
+async def get_market_reports(
+    symbol: str,
+    days: int = 7,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Get detailed analysis reports for a specific symbol.
+
+    Returns full analysis history including reasons, price ranges, and detailed text.
+    symbol: the symbol to query (e.g. '005930', 'AAPL', 'KRW-BTC').
+    days: how many days of history to include (default 7).
+    limit: max number of reports to return (default 10).
+    """
+    symbol = (symbol or "").strip().upper()
+    if not symbol:
+        return {"success": False, "error": "symbol is required"}
+
+    try:
+        async with _session_factory()() as db:
+            from datetime import timedelta
+
+            from app.core.timezone import now_kst
+
+            cutoff = now_kst() - timedelta(days=days)
+
+            stmt = (
+                select(StockAnalysisResult, StockInfo)
+                .join(StockInfo, StockAnalysisResult.stock_info_id == StockInfo.id)
+                .where(
+                    StockInfo.symbol == symbol,
+                    StockAnalysisResult.created_at >= cutoff,
+                )
+                .order_by(desc(StockAnalysisResult.created_at))
+                .limit(limit)
+            )
+
+            result = await db.execute(stmt)
+            rows = result.all()
+
+            if not rows:
+                return {
+                    "success": True,
+                    "symbol": symbol,
+                    "reports": [],
+                    "message": f"No analysis reports found for {symbol} in the last {days} days",
+                }
+
+            reports = []
+            for analysis, info in rows:
+                report = {
+                    "id": analysis.id,
+                    "symbol": info.symbol,
+                    "name": info.name,
+                    "model_name": analysis.model_name,
+                    "decision": analysis.decision,
+                    "confidence": analysis.confidence,
+                    "price_analysis": {
+                        "appropriate_buy": _price_range(
+                            analysis.appropriate_buy_min,
+                            analysis.appropriate_buy_max,
+                        ),
+                        "appropriate_sell": _price_range(
+                            analysis.appropriate_sell_min,
+                            analysis.appropriate_sell_max,
+                        ),
+                        "buy_hope": _price_range(
+                            analysis.buy_hope_min,
+                            analysis.buy_hope_max,
+                        ),
+                        "sell_target": _price_range(
+                            analysis.sell_target_min,
+                            analysis.sell_target_max,
+                        ),
+                    },
+                    "reasons": analysis.reasons,
+                    "detailed_text": analysis.detailed_text,
+                    "analyzed_at": (
+                        analysis.created_at.isoformat() if analysis.created_at else None
+                    ),
+                }
+                reports.append(report)
+
+            decision_trend = [r["decision"] for r in reports]
+
+            return {
+                "success": True,
+                "symbol": symbol,
+                "name": rows[0][1].name,
+                "reports": reports,
+                "trend": {
+                    "total_reports": len(reports),
+                    "decision_sequence": decision_trend,
+                    "latest_decision": decision_trend[0] if decision_trend else None,
+                    "latest_confidence": (
+                        reports[0]["confidence"] if reports else None
+                    ),
+                },
+            }
+
+    except Exception as exc:
+        logger.exception("get_market_reports failed")
+        return {"success": False, "error": f"get_market_reports failed: {exc}"}
+
+
+def _price_range(
+    min_val: float | None, max_val: float | None
+) -> dict[str, float | None]:
+    return {"min": min_val, "max": max_val}

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -5,10 +5,19 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from app.mcp_server.tooling.analysis_registration import register_analysis_tools
+from app.mcp_server.tooling.execution_comment_registration import (
+    register_execution_comment_tools,
+)
 from app.mcp_server.tooling.fundamentals_registration import register_fundamentals_tools
+from app.mcp_server.tooling.market_brief_registration import (
+    register_market_brief_tools,
+)
 from app.mcp_server.tooling.market_data_registration import register_market_data_tools
 from app.mcp_server.tooling.orders_registration import register_order_tools
 from app.mcp_server.tooling.portfolio_registration import register_portfolio_tools
+from app.mcp_server.tooling.trade_journal_registration import (
+    register_trade_journal_tools,
+)
 from app.mcp_server.tooling.trade_profile_registration import (
     register_trade_profile_tools,
 )
@@ -28,6 +37,9 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_analysis_tools(mcp)
     register_watch_alert_tools(mcp)
     register_trade_profile_tools(mcp)
+    register_trade_journal_tools(mcp)
+    register_execution_comment_tools(mcp)
+    register_market_brief_tools(mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/app/mcp_server/tooling/trade_journal_registration.py
+++ b/app/mcp_server/tooling/trade_journal_registration.py
@@ -1,0 +1,66 @@
+# app/mcp_server/tooling/trade_journal_registration.py
+"""MCP registration for trade journal tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.mcp_server.tooling.trade_journal_tools import (
+    get_trade_journal,
+    save_trade_journal,
+    update_trade_journal,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+TRADE_JOURNAL_TOOL_NAMES: set[str] = {
+    "save_trade_journal",
+    "get_trade_journal",
+    "update_trade_journal",
+}
+
+
+def register_trade_journal_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="save_trade_journal",
+        description=(
+            "Save a trade journal entry with investment thesis and strategy metadata. "
+            "Call this when recommending a buy/sell to record WHY. "
+            "symbol auto-detects instrument_type. min_hold_days sets hold_until. "
+            "status defaults to 'draft' — set to 'active' after fill confirmation. "
+            "account_type='paper' for paper trading journals (requires account name). "
+            "paper_trade_id links to the paper trade record. "
+            "paperclip_issue_id links to the Paperclip issue tracking this trade. "
+            "metadata is an optional JSON dict for extensible fields."
+        ),
+    )(save_trade_journal)
+    _ = mcp.tool(
+        name="get_trade_journal",
+        description=(
+            "Query trade journals. MUST call before any sell recommendation to check "
+            "thesis, hold period, target/stop prices. "
+            "Returns active journals by default. "
+            "Each entry includes hold_remaining_days and hold_expired. "
+            "account_type defaults to 'live'; set to 'paper' for paper journals, "
+            "or None to query both. "
+            "account (optional) filters to a specific account name. "
+            "paperclip_issue_id (optional) reverse lookup by Paperclip issue ID."
+        ),
+    )(get_trade_journal)
+    _ = mcp.tool(
+        name="update_trade_journal",
+        description=(
+            "Update a trade journal. Use for: "
+            "draft->active (after fill), close (target reached), stop (stop-loss hit), "
+            "or adjust target/stop/notes. "
+            "Find by journal_id or symbol (latest active). "
+            "Auto-calculates pnl_pct on close."
+        ),
+    )(update_trade_journal)
+
+
+__all__ = [
+    "TRADE_JOURNAL_TOOL_NAMES",
+    "register_trade_journal_tools",
+]

--- a/app/mcp_server/tooling/trade_journal_tools.py
+++ b/app/mcp_server/tooling/trade_journal_tools.py
@@ -1,0 +1,438 @@
+# app/mcp_server/tooling/trade_journal_tools.py
+"""Trade journal MCP tool implementations."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+from decimal import Decimal
+from typing import Any, cast
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.core.timezone import now_kst
+from app.mcp_server.tooling.shared import (
+    resolve_market_type as _resolve_market_type,
+)
+from app.models.trade_journal import JournalStatus, TradeJournal
+from app.models.trading import InstrumentType
+
+logger = logging.getLogger(__name__)
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+def _serialize_journal(j: TradeJournal) -> dict[str, Any]:
+    """Convert a TradeJournal row to a JSON-safe dict."""
+    return {
+        "id": j.id,
+        "symbol": j.symbol,
+        "instrument_type": j.instrument_type.value
+        if hasattr(j.instrument_type, "value")
+        else str(j.instrument_type),
+        "side": j.side,
+        "entry_price": float(j.entry_price) if j.entry_price is not None else None,
+        "quantity": float(j.quantity) if j.quantity is not None else None,
+        "amount": float(j.amount) if j.amount is not None else None,
+        "thesis": j.thesis,
+        "strategy": j.strategy,
+        "target_price": float(j.target_price) if j.target_price is not None else None,
+        "stop_loss": float(j.stop_loss) if j.stop_loss is not None else None,
+        "min_hold_days": j.min_hold_days,
+        "hold_until": j.hold_until.isoformat() if j.hold_until else None,
+        "indicators_snapshot": j.indicators_snapshot,
+        "metadata": j.extra_metadata,
+        "status": j.status,
+        "trade_id": j.trade_id,
+        "exit_price": float(j.exit_price) if j.exit_price is not None else None,
+        "exit_date": j.exit_date.isoformat() if j.exit_date else None,
+        "exit_reason": j.exit_reason,
+        "pnl_pct": float(j.pnl_pct) if j.pnl_pct is not None else None,
+        "account": j.account,
+        "account_type": j.account_type,
+        "paper_trade_id": j.paper_trade_id,
+        "paperclip_issue_id": j.paperclip_issue_id,
+        "notes": j.notes,
+        "created_at": j.created_at.isoformat() if j.created_at else None,
+        "updated_at": j.updated_at.isoformat() if j.updated_at else None,
+    }
+
+
+async def save_trade_journal(
+    symbol: str,
+    thesis: str,
+    side: str = "buy",
+    entry_price: float | None = None,
+    quantity: float | None = None,
+    amount: float | None = None,
+    strategy: str | None = None,
+    target_price: float | None = None,
+    stop_loss: float | None = None,
+    min_hold_days: int | None = None,
+    indicators_snapshot: dict | None = None,
+    account: str | None = None,
+    notes: str | None = None,
+    status: str = "draft",
+    account_type: str = "live",
+    paper_trade_id: int | None = None,
+    paperclip_issue_id: str | None = None,
+    metadata: dict | None = None,
+) -> dict[str, Any]:
+    """Save a trade journal entry with investment thesis and strategy metadata.
+
+    symbol is auto-detected for instrument_type (KRW-BTC -> crypto, AAPL -> equity_us, 005930 -> equity_kr).
+    min_hold_days auto-calculates hold_until from now.
+    Warns if an active journal already exists for the same symbol.
+    account_type='paper' for paper trading journals (requires account name).
+    paper_trade_id links to the paper trade record.
+    paperclip_issue_id links to the Paperclip issue tracking this trade.
+    metadata is an optional JSON dict for extensible fields.
+    """
+    symbol = (symbol or "").strip()
+    thesis = (thesis or "").strip()
+
+    if not symbol:
+        return {"success": False, "error": "symbol is required"}
+    if not thesis:
+        return {"success": False, "error": "thesis is required"}
+    if side not in ("buy", "sell"):
+        return {"success": False, "error": "side must be 'buy' or 'sell'"}
+    if status not in {s.value for s in JournalStatus}:
+        return {"success": False, "error": f"Invalid status: {status}"}
+
+    # account_type 검증
+    if account_type not in ("live", "paper"):
+        return {"success": False, "error": f"Invalid account_type: {account_type}"}
+    if account_type == "live" and paper_trade_id is not None:
+        return {
+            "success": False,
+            "error": "paper_trade_id cannot be set for live account_type",
+        }
+    if account_type == "paper" and not account:
+        return {
+            "success": False,
+            "error": "account is required for paper account_type",
+        }
+
+    try:
+        market_type, normalized_symbol = _resolve_market_type(symbol, None)
+    except ValueError as exc:
+        return {"success": False, "error": f"Cannot detect market type: {exc}"}
+
+    instrument = InstrumentType(market_type)
+
+    hold_until = None
+    if min_hold_days is not None and min_hold_days > 0:
+        hold_until = now_kst() + timedelta(days=min_hold_days)
+
+    try:
+        async with _session_factory()() as db:
+            # Check for existing active journal
+            warning = None
+            existing_stmt = (
+                select(TradeJournal)
+                .where(
+                    TradeJournal.symbol == normalized_symbol,
+                    TradeJournal.status == JournalStatus.active,
+                    TradeJournal.account_type == account_type,
+                )
+                .order_by(desc(TradeJournal.created_at))
+                .limit(1)
+            )
+            existing_result = await db.execute(existing_stmt)
+            existing = existing_result.scalars().first()
+            if existing:
+                warning = (
+                    f"Active journal already exists for {normalized_symbol} "
+                    f"(id={existing.id}, thesis='{existing.thesis[:50]}...', "
+                    f"account_type={account_type}). "
+                    "Creating new journal anyway."
+                )
+
+            journal = TradeJournal(
+                symbol=normalized_symbol,
+                instrument_type=instrument,
+                side=side,
+                entry_price=Decimal(str(entry_price))
+                if entry_price is not None
+                else None,
+                quantity=Decimal(str(quantity)) if quantity is not None else None,
+                amount=Decimal(str(amount)) if amount is not None else None,
+                thesis=thesis,
+                strategy=strategy,
+                target_price=Decimal(str(target_price))
+                if target_price is not None
+                else None,
+                stop_loss=Decimal(str(stop_loss)) if stop_loss is not None else None,
+                min_hold_days=min_hold_days,
+                hold_until=hold_until,
+                indicators_snapshot=indicators_snapshot,
+                status=status,
+                account=account,
+                account_type=account_type,
+                paper_trade_id=paper_trade_id,
+                paperclip_issue_id=paperclip_issue_id,
+                notes=notes,
+                extra_metadata=metadata,
+            )
+            db.add(journal)
+            await db.commit()
+            await db.refresh(journal)
+
+            result: dict[str, Any] = {
+                "success": True,
+                "action": "created",
+                "data": _serialize_journal(journal),
+            }
+            if warning:
+                result["warning"] = warning
+            return result
+
+    except Exception as exc:
+        logger.exception("save_trade_journal failed")
+        return {"success": False, "error": f"save_trade_journal failed: {exc}"}
+
+
+async def get_trade_journal(
+    symbol: str | None = None,
+    status: str | None = None,
+    market: str | None = None,
+    strategy: str | None = None,
+    days: int | None = None,
+    include_closed: bool = False,
+    limit: int = 50,
+    account_type: str | None = "live",
+    account: str | None = None,
+    paperclip_issue_id: str | None = None,
+) -> dict[str, Any]:
+    """Query trade journals. Call before any sell decision to check thesis and hold periods.
+
+    Returns active journals by default. Set include_closed=True for closed/stopped.
+    Each entry includes hold_remaining_days, hold_expired for hold period checks.
+    account_type defaults to 'live'; set to 'paper' for paper journals, or None to query both.
+    account (optional) filters to a specific account name.
+    paperclip_issue_id (optional) filters by Paperclip issue ID for reverse lookup.
+    """
+    try:
+        async with _session_factory()() as db:
+            filters = []
+
+            if symbol:
+                symbol = symbol.strip()
+                try:
+                    _, normalized = _resolve_market_type(symbol, None)
+                    filters.append(TradeJournal.symbol == normalized)
+                except ValueError:
+                    filters.append(TradeJournal.symbol == symbol)
+
+            if status:
+                if status not in {s.value for s in JournalStatus}:
+                    return {"success": False, "error": f"Invalid status: {status}"}
+                filters.append(TradeJournal.status == status)
+            elif not include_closed:
+                filters.append(
+                    TradeJournal.status.in_(
+                        [
+                            JournalStatus.draft,
+                            JournalStatus.active,
+                        ]
+                    )
+                )
+
+            if account_type is not None:
+                filters.append(TradeJournal.account_type == account_type)
+
+            if account is not None:
+                filters.append(TradeJournal.account == account)
+
+            if paperclip_issue_id is not None:
+                filters.append(TradeJournal.paperclip_issue_id == paperclip_issue_id)
+
+            if market:
+                market_map = {
+                    "crypto": InstrumentType.crypto,
+                    "kr": InstrumentType.equity_kr,
+                    "us": InstrumentType.equity_us,
+                }
+                itype = market_map.get(market)
+                if itype:
+                    filters.append(TradeJournal.instrument_type == itype)
+
+            if strategy:
+                filters.append(TradeJournal.strategy == strategy)
+
+            if days is not None and days > 0:
+                cutoff = now_kst() - timedelta(days=days)
+                filters.append(TradeJournal.created_at >= cutoff)
+
+            stmt = (
+                select(TradeJournal)
+                .where(*filters)
+                .order_by(desc(TradeJournal.created_at))
+                .limit(limit)
+            )
+            result = await db.execute(stmt)
+            journals = result.scalars().all()
+
+            now = now_kst()
+            entries = []
+            total_active = 0
+            hold_locked = 0
+            near_target = 0
+            near_stop = 0
+
+            for j in journals:
+                entry = _serialize_journal(j)
+
+                # Hold period calculations
+                if j.hold_until:
+                    remaining = (j.hold_until - now).days
+                    entry["hold_remaining_days"] = remaining
+                    entry["hold_expired"] = remaining < 0
+                    if remaining >= 0 and j.status == JournalStatus.active:
+                        hold_locked += 1
+                else:
+                    entry["hold_remaining_days"] = None
+                    entry["hold_expired"] = None
+
+                # Current price not fetched here (too slow for bulk queries)
+                # Caller can use get_quote separately
+                entry["current_price"] = None
+                entry["pnl_pct_live"] = None
+                entry["target_reached"] = None
+                entry["stop_reached"] = None
+
+                if j.status == JournalStatus.active:
+                    total_active += 1
+
+                entries.append(entry)
+
+            return {
+                "success": True,
+                "entries": entries,
+                "summary": {
+                    "total_active": total_active,
+                    "hold_locked": hold_locked,
+                    "near_target": near_target,
+                    "near_stop": near_stop,
+                    "total_returned": len(entries),
+                },
+            }
+
+    except Exception as exc:
+        logger.exception("get_trade_journal failed")
+        return {"success": False, "error": f"get_trade_journal failed: {exc}"}
+
+
+async def update_trade_journal(
+    journal_id: int | None = None,
+    symbol: str | None = None,
+    status: str | None = None,
+    exit_price: float | None = None,
+    exit_reason: str | None = None,
+    target_price: float | None = None,
+    stop_loss: float | None = None,
+    min_hold_days: int | None = None,
+    trade_id: int | None = None,
+    notes: str | None = None,
+) -> dict[str, Any]:
+    """Update a trade journal entry.
+
+    Find by journal_id, or by symbol (most recent active).
+    On close/stop: auto-calculates pnl_pct from entry_price and exit_price.
+    On activate: recalculates hold_until from now if min_hold_days is set.
+    """
+    if journal_id is None and not symbol:
+        return {"success": False, "error": "Either journal_id or symbol is required"}
+
+    try:
+        async with _session_factory()() as db:
+            journal: TradeJournal | None = None
+
+            if journal_id is not None:
+                journal = await db.get(TradeJournal, journal_id)
+
+            if journal is None and symbol:
+                symbol = symbol.strip()
+                try:
+                    _, normalized = _resolve_market_type(symbol, None)
+                except ValueError:
+                    normalized = symbol
+
+                stmt = (
+                    select(TradeJournal)
+                    .where(
+                        TradeJournal.symbol == normalized,
+                        TradeJournal.status.in_(
+                            [
+                                JournalStatus.draft,
+                                JournalStatus.active,
+                            ]
+                        ),
+                    )
+                    .order_by(desc(TradeJournal.created_at))
+                    .limit(1)
+                )
+                result = await db.execute(stmt)
+                journal = result.scalars().first()
+
+            if journal is None:
+                target = f"id={journal_id}" if journal_id else f"symbol={symbol}"
+                return {"success": False, "error": f"Journal not found: {target}"}
+
+            # Apply updates
+            if status is not None:
+                if status not in {s.value for s in JournalStatus}:
+                    return {"success": False, "error": f"Invalid status: {status}"}
+                journal.status = status
+
+                # On activation: recalculate hold_until from now
+                if status == JournalStatus.active and journal.min_hold_days:
+                    journal.hold_until = now_kst() + timedelta(
+                        days=journal.min_hold_days
+                    )
+
+            if trade_id is not None:
+                journal.trade_id = trade_id
+
+            if target_price is not None:
+                journal.target_price = Decimal(str(target_price))
+
+            if stop_loss is not None:
+                journal.stop_loss = Decimal(str(stop_loss))
+
+            if min_hold_days is not None:
+                journal.min_hold_days = min_hold_days
+                journal.hold_until = now_kst() + timedelta(days=min_hold_days)
+
+            if notes is not None:
+                journal.notes = notes
+
+            if exit_price is not None:
+                journal.exit_price = Decimal(str(exit_price))
+                journal.exit_date = now_kst()
+
+                # Auto-calculate pnl_pct
+                if journal.entry_price and journal.entry_price > 0:
+                    pnl = (Decimal(str(exit_price)) / journal.entry_price - 1) * 100
+                    journal.pnl_pct = round(pnl, 4)
+
+            if exit_reason is not None:
+                journal.exit_reason = exit_reason
+
+            await db.commit()
+            await db.refresh(journal)
+
+            return {
+                "success": True,
+                "action": "updated",
+                "data": _serialize_journal(journal),
+            }
+
+    except Exception as exc:
+        logger.exception("update_trade_journal failed")
+        return {"success": False, "error": f"update_trade_journal failed: {exc}"}

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -19,6 +19,7 @@ from .research_backtest import (
 )
 from .review import PendingSnapshot, Trade, TradeReview, TradeSnapshot
 from .symbol_trade_settings import SymbolTradeSettings
+from .trade_journal import JournalStatus, TradeJournal
 from .trade_profile import (
     AssetProfile,
     FilterName,
@@ -58,6 +59,8 @@ __all__ = [
     "SellMode",
     "TierParamType",
     "FilterName",
+    "JournalStatus",
+    "TradeJournal",
     "StockInfo",
     "StockAnalysisResult",
     "KRSymbolUniverse",

--- a/app/models/trade_journal.py
+++ b/app/models/trade_journal.py
@@ -1,0 +1,133 @@
+# app/models/trade_journal.py
+"""Trade journal — investment thesis and strategy metadata."""
+
+from __future__ import annotations
+
+import enum
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    CheckConstraint,
+    Enum,
+    ForeignKey,
+    Index,
+    Numeric,
+    SmallInteger,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+from app.models.trading import InstrumentType
+
+
+class JournalStatus(enum.StrEnum):
+    draft = "draft"
+    active = "active"
+    closed = "closed"
+    stopped = "stopped"
+    expired = "expired"
+
+
+class TradeJournal(Base):
+    __tablename__ = "trade_journals"
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('draft','active','closed','stopped','expired')",
+            name="trade_journals_status_allowed",
+        ),
+        CheckConstraint(
+            "side IN ('buy','sell')",
+            name="trade_journals_side",
+        ),
+        CheckConstraint(
+            "account_type IN ('live','paper')",
+            name="trade_journals_account_type",
+        ),
+        CheckConstraint(
+            "NOT (account_type = 'live' AND paper_trade_id IS NOT NULL)",
+            name="trade_journals_no_paper_trade_on_live",
+        ),
+        Index("ix_trade_journals_symbol_status", "symbol", "status"),
+        Index("ix_trade_journals_created", "created_at"),
+        Index("ix_trade_journals_account_type", "account_type"),
+        Index("ix_trade_journals_paperclip_issue_id", "paperclip_issue_id"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+
+    # Symbol info
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    instrument_type: Mapped[InstrumentType] = mapped_column(
+        Enum(InstrumentType, name="instrument_type", create_type=False),
+        nullable=False,
+    )
+    side: Mapped[str] = mapped_column(Text, nullable=False, default="buy")
+
+    # Price/quantity at recommendation time
+    entry_price: Mapped[Decimal | None] = mapped_column(Numeric(20, 4))
+    quantity: Mapped[Decimal | None] = mapped_column(Numeric(20, 8))
+    amount: Mapped[Decimal | None] = mapped_column(Numeric(20, 4))
+
+    # Strategy metadata (the core value!)
+    thesis: Mapped[str] = mapped_column(Text, nullable=False)
+    strategy: Mapped[str | None] = mapped_column(Text)
+    target_price: Mapped[Decimal | None] = mapped_column(Numeric(20, 4))
+    stop_loss: Mapped[Decimal | None] = mapped_column(Numeric(20, 4))
+    min_hold_days: Mapped[int | None] = mapped_column(SmallInteger)
+    hold_until: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+
+    # Indicator snapshot at entry
+    indicators_snapshot: Mapped[dict | None] = mapped_column(JSONB)
+
+    # Extensible metadata (e.g. paperclip_issue_id linkage)
+    extra_metadata: Mapped[dict | None] = mapped_column(
+        "metadata", JSONB, nullable=True
+    )
+
+    # Status
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="draft")
+
+    # Link to review.trades (optional)
+    trade_id: Mapped[int | None] = mapped_column(
+        ForeignKey("review.trades.id", ondelete="SET NULL"),
+    )
+
+    # Exit info
+    exit_price: Mapped[Decimal | None] = mapped_column(Numeric(20, 4))
+    exit_date: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    exit_reason: Mapped[str | None] = mapped_column(Text)
+    pnl_pct: Mapped[Decimal | None] = mapped_column(Numeric(8, 4))
+
+    # Meta
+    account: Mapped[str | None] = mapped_column(Text)
+    account_type: Mapped[str] = mapped_column(
+        Text, nullable=False, default="live", server_default="live"
+    )
+    paper_trade_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    paperclip_issue_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs.setdefault("side", "buy")
+        kwargs.setdefault("status", "draft")
+        kwargs.setdefault("account_type", "live")
+        super().__init__(**kwargs)

--- a/tests/test_mcp_execution_tools.py
+++ b/tests/test_mcp_execution_tools.py
@@ -1,0 +1,266 @@
+"""MCP execution support tools."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.core.timezone import now_kst
+from tests._mcp_tooling_support import build_tools
+
+
+class _ScalarRows:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+    def first(self) -> Any | None:
+        return self._rows[0] if self._rows else None
+
+
+class _ExecuteResult:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+    def scalars(self) -> _ScalarRows:
+        return _ScalarRows(self._rows)
+
+
+class _DummyDb:
+    def __init__(self, rows: list[Any]) -> None:
+        self.rows = rows
+        self.statements: list[Any] = []
+
+    async def execute(self, stmt: Any) -> _ExecuteResult:
+        self.statements.append(stmt)
+        return _ExecuteResult(self.rows)
+
+
+class _DummySessionFactory:
+    def __init__(self, db: _DummyDb) -> None:
+        self.db = db
+
+    def __call__(self) -> _DummySessionFactory:
+        return self
+
+    async def __aenter__(self) -> _DummyDb:
+        return self.db
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+
+def _analysis(
+    *,
+    id: int = 1,
+    decision: str = "buy",
+    confidence: int = 82,
+    created_at=None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=id,
+        model_name="test-model",
+        decision=decision,
+        confidence=confidence,
+        appropriate_buy_min=70000.0,
+        appropriate_buy_max=72000.0,
+        appropriate_sell_min=82000.0,
+        appropriate_sell_max=84000.0,
+        buy_hope_min=69000.0,
+        buy_hope_max=70500.0,
+        sell_target_min=83000.0,
+        sell_target_max=85000.0,
+        reasons=["earnings momentum"],
+        detailed_text="Strong demand and improving margins.",
+        created_at=created_at or now_kst(),
+    )
+
+
+def _stock_info() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=7,
+        symbol="005930",
+        name="Samsung Electronics",
+        instrument_type="equity_kr",
+    )
+
+
+@pytest.mark.asyncio
+async def test_execution_tools_are_registered() -> None:
+    tools = build_tools()
+
+    assert "get_trade_journal" in tools
+    assert "format_execution_comment" in tools
+    assert "get_latest_market_brief" in tools
+    assert "get_market_reports" in tools
+
+
+@pytest.mark.asyncio
+async def test_format_execution_comment_fill_markdown() -> None:
+    tools = build_tools()
+
+    result = await tools["format_execution_comment"](
+        stage="fill",
+        symbol="005930",
+        side="buy",
+        filled_qty=3,
+        filled_price=71200,
+        currency="KRW ",
+        journal_context={
+            "thesis": "Memory cycle recovery",
+            "strategy": "swing",
+            "target_price": 84000,
+            "stop_loss": 68000,
+            "min_hold_days": 5,
+        },
+        market_brief="Latest brief: buy, confidence 82.",
+    )
+
+    assert result["success"] is True
+    assert result["stage"] == "fill"
+    markdown = result["markdown"]
+    assert "005930" in markdown
+    assert "Memory cycle recovery" in markdown
+    assert "KRW 71,200.00" in markdown
+    assert "Latest brief: buy, confidence 82." in markdown
+
+
+@pytest.mark.asyncio
+async def test_format_execution_comment_follow_up_markdown() -> None:
+    tools = build_tools()
+
+    result = await tools["format_execution_comment"](
+        stage="follow_up",
+        symbol="005930",
+        side="sell",
+        filled_qty=3,
+        filled_price=80000,
+        currency="KRW ",
+        journal_context={"entry_price": 70000},
+        analysis_summary="Momentum is fading near resistance.",
+        next_action="hold",
+    )
+
+    assert result["success"] is True
+    assert result["stage"] == "follow_up"
+    markdown = result["markdown"]
+    assert "후속 판단" in markdown
+    assert "+14.29%" in markdown
+    assert "Momentum is fading near resistance." in markdown
+    assert "**hold**" in markdown
+
+
+@pytest.mark.asyncio
+async def test_get_latest_market_brief_returns_latest_analysis(monkeypatch) -> None:
+    from app.mcp_server.tooling import market_brief_tools
+
+    db = _DummyDb(rows=[(_analysis(), _stock_info())])
+    monkeypatch.setattr(
+        market_brief_tools,
+        "_session_factory",
+        lambda: _DummySessionFactory(db),
+    )
+    tools = build_tools()
+
+    result = await tools["get_latest_market_brief"](symbols=["005930"], limit=5)
+
+    assert result["success"] is True
+    assert result["briefs"] == [
+        {
+            "symbol": "005930",
+            "name": "Samsung Electronics",
+            "instrument_type": "equity_kr",
+            "decision": "buy",
+            "confidence": 82,
+            "buy_range": {"min": 70000.0, "max": 72000.0},
+            "sell_range": {"min": 82000.0, "max": 84000.0},
+            "analyzed_at": result["briefs"][0]["analyzed_at"],
+        }
+    ]
+    assert result["summary"]["buy_count"] == 1
+    assert db.statements
+
+
+@pytest.mark.asyncio
+async def test_get_market_reports_returns_symbol_history(monkeypatch) -> None:
+    from app.mcp_server.tooling import market_brief_tools
+
+    db = _DummyDb(rows=[(_analysis(id=9, decision="hold"), _stock_info())])
+    monkeypatch.setattr(
+        market_brief_tools,
+        "_session_factory",
+        lambda: _DummySessionFactory(db),
+    )
+    tools = build_tools()
+
+    result = await tools["get_market_reports"](symbol="005930", days=3)
+
+    assert result["success"] is True
+    assert result["symbol"] == "005930"
+    assert result["reports"][0]["id"] == 9
+    assert result["reports"][0]["price_analysis"]["sell_target"] == {
+        "min": 83000.0,
+        "max": 85000.0,
+    }
+    assert result["trend"]["latest_decision"] == "hold"
+
+
+@pytest.mark.asyncio
+async def test_get_trade_journal_filters_by_paperclip_issue_id(monkeypatch) -> None:
+    from app.mcp_server.tooling import trade_journal_tools
+
+    created_at = now_kst() - timedelta(hours=1)
+    journal = SimpleNamespace(
+        id=11,
+        symbol="005930",
+        instrument_type=SimpleNamespace(value="equity_kr"),
+        side="buy",
+        entry_price=Decimal("70000"),
+        quantity=Decimal("3"),
+        amount=Decimal("210000"),
+        thesis="Memory cycle recovery",
+        strategy="swing",
+        target_price=Decimal("84000"),
+        stop_loss=Decimal("68000"),
+        min_hold_days=5,
+        hold_until=now_kst() + timedelta(days=4),
+        indicators_snapshot={"rsi": 55},
+        extra_metadata={"source": "paperclip"},
+        status="active",
+        trade_id=None,
+        exit_price=None,
+        exit_date=None,
+        exit_reason=None,
+        pnl_pct=None,
+        account="main",
+        account_type="live",
+        paper_trade_id=None,
+        paperclip_issue_id="ROB-74",
+        notes="tracking fill",
+        created_at=created_at,
+        updated_at=created_at,
+    )
+    db = _DummyDb(rows=[journal])
+    monkeypatch.setattr(
+        trade_journal_tools,
+        "_session_factory",
+        lambda: _DummySessionFactory(db),
+    )
+    tools = build_tools()
+
+    result = await tools["get_trade_journal"](paperclip_issue_id="ROB-74")
+
+    assert result["success"] is True
+    assert result["entries"][0]["paperclip_issue_id"] == "ROB-74"
+    assert result["entries"][0]["thesis"] == "Memory cycle recovery"
+    assert result["summary"]["total_active"] == 1
+    assert db.statements


### PR DESCRIPTION
## Summary

- Add `review.trade_journals` model and Alembic revision with `paperclip_issue_id` indexed for reverse lookup.
- Register trade journal MCP tools plus `format_execution_comment`, `get_latest_market_brief`, and `get_market_reports`.
- Add focused MCP tests for registration, fill/follow-up Markdown formatting, market brief/report payloads, and `paperclip_issue_id` journal lookup.
- Update MCP README with the new public tool entries.

## Verification

- `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/test_db uv run --group test pytest tests/test_mcp_execution_tools.py tests/test_mcp_tool_registration.py tests/test_mcp_order_tools.py -q` -> 48 passed
- `uv run ruff check app/mcp_server/tooling app/models/trade_journal.py app/models/__init__.py tests/test_mcp_execution_tools.py alembic/versions/b8c4d2e0f1a9_create_trade_journals.py` -> passed
- `uv run ruff format --check app/mcp_server/tooling/execution_comment_registration.py app/mcp_server/tooling/execution_comment_tools.py app/mcp_server/tooling/market_brief_registration.py app/mcp_server/tooling/market_brief_tools.py app/mcp_server/tooling/registry.py app/mcp_server/tooling/trade_journal_registration.py app/mcp_server/tooling/trade_journal_tools.py app/models/trade_journal.py app/models/__init__.py tests/test_mcp_execution_tools.py alembic/versions/b8c4d2e0f1a9_create_trade_journals.py` -> passed
- `DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/test_db uv run alembic heads` -> `b8c4d2e0f1a9 (head)`

## Notes

- I did not use `alembic upgrade head --sql` as a success gate because an existing older migration (`a135dbde152e`) calls `bind.execute(...).fetchall()` and fails in offline SQL generation before reaching this new revision.