### PR TITLE
Fix: correct import path for format_execution_comment

### DIFF
--- a/app/mcp_server/tooling/execution_comment_registration.py
+++ b/app/mcp_server/tooling/execution_comment_registration.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from app.mcp_server.tooling.execution_comment import format_execution_comment
+from app.mcp_server.tooling.execution_comment_tools import format_execution_comment
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP


### PR DESCRIPTION
Fixes GitHub Actions test failure in run #24479987659

## Problem
The `execution_comment_registration.py` was importing from `execution_comment.py` instead of `execution_comment_tools.py`. 

- The old module (`execution_comment.py`) returns a plain markdown string
- The new module (`execution_comment_tools.py` from ROB-74) returns a dict with `success`, `stage`, and `markdown` keys that the tests expect

## Fix
Changed the import path from:
```python
from app.mcp_server.tooling.execution_comment import format_execution_comment
```
to:
```python
from app.mcp_server.tooling.execution_comment_tools import format_execution_comment
```

## Verification
All 6 MCP execution tools tests pass after this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal module reorganization to improve code structure. No changes to user-facing functionality or tool behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->