### PR TITLE
Deploy: ROB-74 MCP execution tools + import fix

### DIFF
--- a/alembic/versions/b8c4d2e0f1a9_create_trade_journals.py
+++ b/alembic/versions/b8c4d2e0f1a9_create_trade_journals.py
@@ -1,0 +1,40 @@
+"""Add paperclip_issue_id to trade_journals.
+
+Revision ID: b8c4d2e0f1a9
+Revises: b3f8a1c2d4e5
+Create Date: 2026-04-15 18:05:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b8c4d2e0f1a9"
+down_revision: str | Sequence[str] | None = "b3f8a1c2d4e5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "trade_journals",
+        sa.Column("paperclip_issue_id", sa.Text(), nullable=True),
+        schema="review",
+    )
+    op.create_index(
+        "ix_trade_journals_paperclip_issue_id",
+        "trade_journals",
+        ["paperclip_issue_id"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_trade_journals_paperclip_issue_id",
+        table_name="trade_journals",
+        schema="review",
+    )
+    op.drop_column("trade_journals", "paperclip_issue_id", schema="review")

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -88,6 +88,12 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - `status="pending"` 만 symbol 없이 호출 가능
   - `status in {"all", "filled", "cancelled"}` 는 symbol 필요
   - filled/cancelled 조회는 시장별 historical endpoint 제약 때문에 symbol fan-out을 자동 수행하지 않음
+- `save_trade_journal(symbol, thesis, ..., paperclip_issue_id=None)` - Save the thesis, strategy, account context, and optional Paperclip issue link for a trade.
+- `get_trade_journal(symbol=None, status=None, ..., paperclip_issue_id=None)` - Query active journal entries by symbol/account or reverse-lookup a journal from a Paperclip issue ID.
+- `update_trade_journal(journal_id=None, symbol=None, ...)` - Activate, close, stop, or adjust the latest matching journal entry.
+- `format_execution_comment(stage, symbol, side, filled_qty, filled_price, ...)` - Format Discord/Paperclip-ready Markdown for `fill` and `follow_up` execution stages.
+- `get_latest_market_brief(symbols=None, market=None, limit=10)` - Return concise latest AI analysis context for recent or selected symbols.
+- `get_market_reports(symbol, days=7, limit=10)` - Return detailed AI analysis report history and decision trend for one symbol.
 - `place_order(symbol, side, order_type="limit", quantity=None, price=None, amount=None, dry_run=True, reason="", exit_reason=None, thesis=None, strategy=None, target_price=None, stop_loss=None, min_hold_days=None, notes=None, indicators_snapshot=None)`
   - `side="buy"` 이고 `dry_run=False` 인 경우 `thesis` 와 `strategy` 가 필수
   - 실매수 성공 시 trade journal draft를 자동 생성하고 fill 저장 후 active로 연결 시도

--- a/app/mcp_server/tooling/execution_comment_registration.py
+++ b/app/mcp_server/tooling/execution_comment_registration.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from app.mcp_server.tooling.execution_comment import format_execution_comment
+from app.mcp_server.tooling.execution_comment_tools import format_execution_comment
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP

--- a/app/mcp_server/tooling/execution_comment_tools.py
+++ b/app/mcp_server/tooling/execution_comment_tools.py
@@ -1,0 +1,162 @@
+"""Execution comment formatting MCP tool implementations."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+
+def _format_fill_comment(
+    symbol: str,
+    side: str,
+    filled_qty: float,
+    filled_price: float,
+    currency: str,
+    journal_context: dict[str, Any] | None,
+    market_brief: str | None,
+) -> str:
+    side_label = "매수" if side == "buy" else "매도"
+    side_emoji = "\U0001f7e2" if side == "buy" else "\U0001f534"
+
+    lines = [
+        f"## {side_emoji} {symbol} {side_label} 체결",
+        "",
+        f"- **수량**: {filled_qty:,.4g}",
+        f"- **체결가**: {currency}{filled_price:,.2f}",
+        f"- **체결금액**: {currency}{filled_qty * filled_price:,.0f}",
+        f"- **시각**: {datetime.now().strftime('%Y-%m-%d %H:%M:%S KST')}",
+    ]
+
+    if journal_context:
+        lines.append("")
+        lines.append("### 투자 논거")
+        if journal_context.get("thesis"):
+            lines.append(f"- **논거**: {journal_context['thesis']}")
+        if journal_context.get("strategy"):
+            lines.append(f"- **전략**: {journal_context['strategy']}")
+        if journal_context.get("target_price") is not None:
+            lines.append(
+                f"- **목표가**: {currency}{journal_context['target_price']:,.2f}"
+            )
+        if journal_context.get("stop_loss") is not None:
+            lines.append(f"- **손절가**: {currency}{journal_context['stop_loss']:,.2f}")
+        if journal_context.get("min_hold_days") is not None:
+            lines.append(f"- **최소 보유**: {journal_context['min_hold_days']}일")
+
+    if market_brief:
+        lines.append("")
+        lines.append("### 시장 컨텍스트")
+        lines.append(market_brief)
+
+    return "\n".join(lines)
+
+
+def _format_follow_up_comment(
+    symbol: str,
+    side: str,
+    filled_qty: float,
+    filled_price: float,
+    currency: str,
+    journal_context: dict[str, Any] | None,
+    market_brief: str | None,
+    next_action: str | None,
+    analysis_summary: str | None,
+) -> str:
+    side_label = "매수" if side == "buy" else "매도"
+
+    lines = [
+        f"## 후속 판단: {symbol} {side_label} 체결 후",
+        "",
+        f"- **체결**: {filled_qty:,.4g} @ {currency}{filled_price:,.2f}",
+    ]
+
+    if journal_context:
+        entry_price = journal_context.get("entry_price")
+        if entry_price and side == "sell":
+            pnl_pct = (filled_price / entry_price - 1) * 100
+            pnl_sign = "+" if pnl_pct >= 0 else ""
+            lines.append(f"- **수익률**: {pnl_sign}{pnl_pct:.2f}%")
+
+    if analysis_summary:
+        lines.append("")
+        lines.append("### 분석 요약")
+        lines.append(analysis_summary)
+
+    if market_brief:
+        lines.append("")
+        lines.append("### 시장 컨텍스트")
+        lines.append(market_brief)
+
+    if next_action:
+        lines.append("")
+        lines.append("### 다음 행동")
+        lines.append(f"**{next_action}**")
+
+    return "\n".join(lines)
+
+
+async def format_execution_comment(
+    stage: str,
+    symbol: str,
+    side: str,
+    filled_qty: float,
+    filled_price: float,
+    currency: str = "₩",
+    journal_context: dict[str, Any] | None = None,
+    market_brief: str | None = None,
+    next_action: str | None = None,
+    analysis_summary: str | None = None,
+) -> dict[str, Any]:
+    """Format a structured Markdown comment for trade execution events.
+
+    stage: 'fill' for immediate fill notification, 'follow_up' for post-fill analysis.
+    symbol: the traded symbol.
+    side: 'buy' or 'sell'.
+    filled_qty: quantity filled.
+    filled_price: price at which the fill occurred.
+    currency: currency symbol (default ₩).
+    journal_context: dict with thesis, strategy, target_price, stop_loss, etc.
+    market_brief: short market context string.
+    next_action: recommended next action (hold / 추가매수 / 익절 / 손절).
+    analysis_summary: post-fill analysis summary text.
+    """
+    if stage not in ("fill", "follow_up"):
+        return {"success": False, "error": "stage must be 'fill' or 'follow_up'"}
+    if side not in ("buy", "sell"):
+        return {"success": False, "error": "side must be 'buy' or 'sell'"}
+    if filled_qty <= 0:
+        return {"success": False, "error": "filled_qty must be positive"}
+    if filled_price <= 0:
+        return {"success": False, "error": "filled_price must be positive"}
+
+    try:
+        if stage == "fill":
+            text = _format_fill_comment(
+                symbol=symbol,
+                side=side,
+                filled_qty=filled_qty,
+                filled_price=filled_price,
+                currency=currency,
+                journal_context=journal_context,
+                market_brief=market_brief,
+            )
+        else:
+            text = _format_follow_up_comment(
+                symbol=symbol,
+                side=side,
+                filled_qty=filled_qty,
+                filled_price=filled_price,
+                currency=currency,
+                journal_context=journal_context,
+                market_brief=market_brief,
+                next_action=next_action,
+                analysis_summary=analysis_summary,
+            )
+
+        return {
+            "success": True,
+            "stage": stage,
+            "markdown": text,
+        }
+    except Exception as exc:
+        return {"success": False, "error": f"format_execution_comment failed: {exc}"}

--- a/app/mcp_server/tooling/market_brief_registration.py
+++ b/app/mcp_server/tooling/market_brief_registration.py
@@ -1,0 +1,43 @@
+"""MCP registration for market brief and reports tools."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.mcp_server.tooling.market_brief_tools import (
+    get_latest_market_brief,
+    get_market_reports,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+MARKET_BRIEF_TOOL_NAMES: set[str] = {
+    "get_latest_market_brief",
+    "get_market_reports",
+}
+
+
+def register_market_brief_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="get_latest_market_brief",
+        description=(
+            "Get a concise market summary from recent AI analysis results. "
+            "Returns decision (buy/hold/sell), confidence, and key price levels "
+            "for each symbol. Use for quick market context during trade execution."
+        ),
+    )(get_latest_market_brief)
+    _ = mcp.tool(
+        name="get_market_reports",
+        description=(
+            "Get detailed analysis report history for a specific symbol. "
+            "Returns full analysis including reasons, price ranges, detailed text, "
+            "and decision trend over time. Use for deep-dive on a single symbol."
+        ),
+    )(get_market_reports)
+
+
+__all__ = [
+    "MARKET_BRIEF_TOOL_NAMES",
+    "register_market_brief_tools",
+]

--- a/app/mcp_server/tooling/market_brief_tools.py
+++ b/app/mcp_server/tooling/market_brief_tools.py
@@ -1,0 +1,220 @@
+"""Market brief and reports MCP tool implementations."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.models.analysis import StockAnalysisResult, StockInfo
+
+logger = logging.getLogger(__name__)
+
+
+def _session_factory() -> async_sessionmaker[AsyncSession]:
+    return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
+
+
+async def get_latest_market_brief(
+    symbols: list[str] | None = None,
+    market: str | None = None,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Get a concise market summary for recent analysis results.
+
+    Returns current decision, confidence, and key price levels for each symbol.
+    symbols: optional list of symbols to filter (e.g. ['005930', 'AAPL']).
+    market: optional filter by instrument_type ('equity_kr', 'equity_us', 'crypto').
+    limit: max number of symbols to return (default 10).
+    """
+    try:
+        async with _session_factory()() as db:
+            from sqlalchemy import func
+
+            latest_subq = (
+                select(
+                    StockAnalysisResult.stock_info_id,
+                    func.max(StockAnalysisResult.created_at).label("max_created"),
+                )
+                .group_by(StockAnalysisResult.stock_info_id)
+                .subquery()
+            )
+
+            stmt = (
+                select(StockAnalysisResult, StockInfo)
+                .join(StockInfo, StockAnalysisResult.stock_info_id == StockInfo.id)
+                .join(
+                    latest_subq,
+                    (StockAnalysisResult.stock_info_id == latest_subq.c.stock_info_id)
+                    & (StockAnalysisResult.created_at == latest_subq.c.max_created),
+                )
+                .order_by(desc(StockAnalysisResult.created_at))
+            )
+
+            if symbols:
+                normalized = [s.strip().upper() for s in symbols]
+                stmt = stmt.where(StockInfo.symbol.in_(normalized))
+
+            if market:
+                stmt = stmt.where(StockInfo.instrument_type == market)
+
+            stmt = stmt.limit(limit)
+
+            result = await db.execute(stmt)
+            rows = result.all()
+
+            briefs = []
+            for analysis, info in rows:
+                brief = {
+                    "symbol": info.symbol,
+                    "name": info.name,
+                    "instrument_type": info.instrument_type,
+                    "decision": analysis.decision,
+                    "confidence": analysis.confidence,
+                    "buy_range": _price_range(
+                        analysis.appropriate_buy_min,
+                        analysis.appropriate_buy_max,
+                    ),
+                    "sell_range": _price_range(
+                        analysis.appropriate_sell_min,
+                        analysis.appropriate_sell_max,
+                    ),
+                    "analyzed_at": (
+                        analysis.created_at.isoformat() if analysis.created_at else None
+                    ),
+                }
+                briefs.append(brief)
+
+            summary = {
+                "total": len(briefs),
+                "buy_count": sum(1 for b in briefs if b["decision"] == "buy"),
+                "hold_count": sum(1 for b in briefs if b["decision"] == "hold"),
+                "sell_count": sum(1 for b in briefs if b["decision"] == "sell"),
+                "avg_confidence": (
+                    round(sum(b["confidence"] for b in briefs) / len(briefs), 1)
+                    if briefs
+                    else 0
+                ),
+            }
+
+            return {
+                "success": True,
+                "briefs": briefs,
+                "summary": summary,
+            }
+
+    except Exception as exc:
+        logger.exception("get_latest_market_brief failed")
+        return {"success": False, "error": f"get_latest_market_brief failed: {exc}"}
+
+
+async def get_market_reports(
+    symbol: str,
+    days: int = 7,
+    limit: int = 10,
+) -> dict[str, Any]:
+    """Get detailed analysis reports for a specific symbol.
+
+    Returns full analysis history including reasons, price ranges, and detailed text.
+    symbol: the symbol to query (e.g. '005930', 'AAPL', 'KRW-BTC').
+    days: how many days of history to include (default 7).
+    limit: max number of reports to return (default 10).
+    """
+    symbol = (symbol or "").strip().upper()
+    if not symbol:
+        return {"success": False, "error": "symbol is required"}
+
+    try:
+        async with _session_factory()() as db:
+            from datetime import timedelta
+
+            from app.core.timezone import now_kst
+
+            cutoff = now_kst() - timedelta(days=days)
+
+            stmt = (
+                select(StockAnalysisResult, StockInfo)
+                .join(StockInfo, StockAnalysisResult.stock_info_id == StockInfo.id)
+                .where(
+                    StockInfo.symbol == symbol,
+                    StockAnalysisResult.created_at >= cutoff,
+                )
+                .order_by(desc(StockAnalysisResult.created_at))
+                .limit(limit)
+            )
+
+            result = await db.execute(stmt)
+            rows = result.all()
+
+            if not rows:
+                return {
+                    "success": True,
+                    "symbol": symbol,
+                    "reports": [],
+                    "message": f"No analysis reports found for {symbol} in the last {days} days",
+                }
+
+            reports = []
+            for analysis, info in rows:
+                report = {
+                    "id": analysis.id,
+                    "symbol": info.symbol,
+                    "name": info.name,
+                    "model_name": analysis.model_name,
+                    "decision": analysis.decision,
+                    "confidence": analysis.confidence,
+                    "price_analysis": {
+                        "appropriate_buy": _price_range(
+                            analysis.appropriate_buy_min,
+                            analysis.appropriate_buy_max,
+                        ),
+                        "appropriate_sell": _price_range(
+                            analysis.appropriate_sell_min,
+                            analysis.appropriate_sell_max,
+                        ),
+                        "buy_hope": _price_range(
+                            analysis.buy_hope_min,
+                            analysis.buy_hope_max,
+                        ),
+                        "sell_target": _price_range(
+                            analysis.sell_target_min,
+                            analysis.sell_target_max,
+                        ),
+                    },
+                    "reasons": analysis.reasons,
+                    "detailed_text": analysis.detailed_text,
+                    "analyzed_at": (
+                        analysis.created_at.isoformat() if analysis.created_at else None
+                    ),
+                }
+                reports.append(report)
+
+            decision_trend = [r["decision"] for r in reports]
+
+            return {
+                "success": True,
+                "symbol": symbol,
+                "name": rows[0][1].name,
+                "reports": reports,
+                "trend": {
+                    "total_reports": len(reports),
+                    "decision_sequence": decision_trend,
+                    "latest_decision": decision_trend[0] if decision_trend else None,
+                    "latest_confidence": (
+                        reports[0]["confidence"] if reports else None
+                    ),
+                },
+            }
+
+    except Exception as exc:
+        logger.exception("get_market_reports failed")
+        return {"success": False, "error": f"get_market_reports failed: {exc}"}
+
+
+def _price_range(
+    min_val: float | None, max_val: float | None
+) -> dict[str, float | None]:
+    return {"min": min_val, "max": max_val}

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -9,6 +9,9 @@ from app.mcp_server.tooling.execution_comment_registration import (
     register_execution_comment_tools,
 )
 from app.mcp_server.tooling.fundamentals_registration import register_fundamentals_tools
+from app.mcp_server.tooling.market_brief_registration import (
+    register_market_brief_tools,
+)
 from app.mcp_server.tooling.market_data_registration import register_market_data_tools
 from app.mcp_server.tooling.market_report_registration import (
     register_market_report_tools,
@@ -58,6 +61,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_paper_analytics_tools(mcp)
     register_paper_journal_tools(mcp)
     register_execution_comment_tools(mcp)
+    register_market_brief_tools(mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/app/mcp_server/tooling/trade_journal_registration.py
+++ b/app/mcp_server/tooling/trade_journal_registration.py
@@ -31,8 +31,8 @@ def register_trade_journal_tools(mcp: FastMCP) -> None:
             "status defaults to 'draft' — set to 'active' after fill confirmation. "
             "account_type='paper' for paper trading journals (requires account name). "
             "paper_trade_id links to the paper trade record. "
-            "metadata is an optional JSON dict for extensible fields "
-            '(e.g. {"paperclip_issue_id": "ROB-XX"} for Paperclip linkage).'
+            "paperclip_issue_id links to the Paperclip issue tracking this trade. "
+            "metadata is an optional JSON dict for extensible fields."
         ),
     )(save_trade_journal)
     _ = mcp.tool(
@@ -45,8 +45,7 @@ def register_trade_journal_tools(mcp: FastMCP) -> None:
             "account_type defaults to 'live'; set to 'paper' for paper journals, "
             "or None to query both. "
             "account (optional) filters to a specific account name. "
-            "paperclip_issue_id (optional) filters by metadata.paperclip_issue_id "
-            "for reverse lookup from Paperclip issue to trade journal."
+            "paperclip_issue_id (optional) reverse lookup by Paperclip issue ID."
         ),
     )(get_trade_journal)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/trade_journal_tools.py
+++ b/app/mcp_server/tooling/trade_journal_tools.py
@@ -55,6 +55,7 @@ def _serialize_journal(j: TradeJournal) -> dict[str, Any]:
         "account": j.account,
         "account_type": j.account_type,
         "paper_trade_id": j.paper_trade_id,
+        "paperclip_issue_id": j.paperclip_issue_id,
         "notes": j.notes,
         "created_at": j.created_at.isoformat() if j.created_at else None,
         "updated_at": j.updated_at.isoformat() if j.updated_at else None,
@@ -78,6 +79,7 @@ async def save_trade_journal(
     status: str = "draft",
     account_type: str = "live",
     paper_trade_id: int | None = None,
+    paperclip_issue_id: str | None = None,
     metadata: dict | None = None,
 ) -> dict[str, Any]:
     """Save a trade journal entry with investment thesis and strategy metadata.
@@ -87,7 +89,8 @@ async def save_trade_journal(
     Warns if an active journal already exists for the same symbol.
     account_type='paper' for paper trading journals (requires account name).
     paper_trade_id links to the paper trade record.
-    metadata is an optional JSON dict for extensible fields (e.g. {"paperclip_issue_id": "ROB-XX"}).
+    paperclip_issue_id links to the Paperclip issue tracking this trade.
+    metadata is an optional JSON dict for extensible fields.
     """
     symbol = (symbol or "").strip()
     thesis = (thesis or "").strip()
@@ -172,6 +175,7 @@ async def save_trade_journal(
                 account=account,
                 account_type=account_type,
                 paper_trade_id=paper_trade_id,
+                paperclip_issue_id=paperclip_issue_id,
                 notes=notes,
                 extra_metadata=metadata,
             )
@@ -211,7 +215,7 @@ async def get_trade_journal(
     Each entry includes hold_remaining_days, hold_expired for hold period checks.
     account_type defaults to 'live'; set to 'paper' for paper journals, or None to query both.
     account (optional) filters to a specific account name.
-    paperclip_issue_id (optional) filters by metadata.paperclip_issue_id for reverse lookup.
+    paperclip_issue_id (optional) filters by Paperclip issue ID for reverse lookup.
     """
     try:
         async with _session_factory()() as db:
@@ -246,10 +250,7 @@ async def get_trade_journal(
                 filters.append(TradeJournal.account == account)
 
             if paperclip_issue_id is not None:
-                filters.append(
-                    TradeJournal.extra_metadata["paperclip_issue_id"].astext
-                    == paperclip_issue_id
-                )
+                filters.append(TradeJournal.paperclip_issue_id == paperclip_issue_id)
 
             if market:
                 market_map = {

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -63,6 +63,8 @@ __all__ = [
     "SellMode",
     "TierParamType",
     "FilterName",
+    "JournalStatus",
+    "TradeJournal",
     "StockInfo",
     "StockAnalysisResult",
     "KRSymbolUniverse",

--- a/app/models/trade_journal.py
+++ b/app/models/trade_journal.py
@@ -57,6 +57,7 @@ class TradeJournal(Base):
         Index("ix_trade_journals_symbol_status", "symbol", "status"),
         Index("ix_trade_journals_created", "created_at"),
         Index("ix_trade_journals_account_type", "account_type"),
+        Index("ix_trade_journals_paperclip_issue_id", "paperclip_issue_id"),
         {"schema": "review"},
     )
 
@@ -111,6 +112,7 @@ class TradeJournal(Base):
         Text, nullable=False, default="live", server_default="live"
     )
     paper_trade_id: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    paperclip_issue_id: Mapped[str | None] = mapped_column(Text, nullable=True)
     notes: Mapped[str | None] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True),

--- a/tests/test_mcp_execution_tools.py
+++ b/tests/test_mcp_execution_tools.py
@@ -1,0 +1,266 @@
+"""MCP execution support tools."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.core.timezone import now_kst
+from tests._mcp_tooling_support import build_tools
+
+
+class _ScalarRows:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+    def first(self) -> Any | None:
+        return self._rows[0] if self._rows else None
+
+
+class _ExecuteResult:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+    def scalars(self) -> _ScalarRows:
+        return _ScalarRows(self._rows)
+
+
+class _DummyDb:
+    def __init__(self, rows: list[Any]) -> None:
+        self.rows = rows
+        self.statements: list[Any] = []
+
+    async def execute(self, stmt: Any) -> _ExecuteResult:
+        self.statements.append(stmt)
+        return _ExecuteResult(self.rows)
+
+
+class _DummySessionFactory:
+    def __init__(self, db: _DummyDb) -> None:
+        self.db = db
+
+    def __call__(self) -> _DummySessionFactory:
+        return self
+
+    async def __aenter__(self) -> _DummyDb:
+        return self.db
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+
+def _analysis(
+    *,
+    id: int = 1,
+    decision: str = "buy",
+    confidence: int = 82,
+    created_at=None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=id,
+        model_name="test-model",
+        decision=decision,
+        confidence=confidence,
+        appropriate_buy_min=70000.0,
+        appropriate_buy_max=72000.0,
+        appropriate_sell_min=82000.0,
+        appropriate_sell_max=84000.0,
+        buy_hope_min=69000.0,
+        buy_hope_max=70500.0,
+        sell_target_min=83000.0,
+        sell_target_max=85000.0,
+        reasons=["earnings momentum"],
+        detailed_text="Strong demand and improving margins.",
+        created_at=created_at or now_kst(),
+    )
+
+
+def _stock_info() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=7,
+        symbol="005930",
+        name="Samsung Electronics",
+        instrument_type="equity_kr",
+    )
+
+
+@pytest.mark.asyncio
+async def test_execution_tools_are_registered() -> None:
+    tools = build_tools()
+
+    assert "get_trade_journal" in tools
+    assert "format_execution_comment" in tools
+    assert "get_latest_market_brief" in tools
+    assert "get_market_reports" in tools
+
+
+@pytest.mark.asyncio
+async def test_format_execution_comment_fill_markdown() -> None:
+    tools = build_tools()
+
+    result = await tools["format_execution_comment"](
+        stage="fill",
+        symbol="005930",
+        side="buy",
+        filled_qty=3,
+        filled_price=71200,
+        currency="KRW ",
+        journal_context={
+            "thesis": "Memory cycle recovery",
+            "strategy": "swing",
+            "target_price": 84000,
+            "stop_loss": 68000,
+            "min_hold_days": 5,
+        },
+        market_brief="Latest brief: buy, confidence 82.",
+    )
+
+    assert result["success"] is True
+    assert result["stage"] == "fill"
+    markdown = result["markdown"]
+    assert "005930" in markdown
+    assert "Memory cycle recovery" in markdown
+    assert "KRW 71,200.00" in markdown
+    assert "Latest brief: buy, confidence 82." in markdown
+
+
+@pytest.mark.asyncio
+async def test_format_execution_comment_follow_up_markdown() -> None:
+    tools = build_tools()
+
+    result = await tools["format_execution_comment"](
+        stage="follow_up",
+        symbol="005930",
+        side="sell",
+        filled_qty=3,
+        filled_price=80000,
+        currency="KRW ",
+        journal_context={"entry_price": 70000},
+        analysis_summary="Momentum is fading near resistance.",
+        next_action="hold",
+    )
+
+    assert result["success"] is True
+    assert result["stage"] == "follow_up"
+    markdown = result["markdown"]
+    assert "후속 판단" in markdown
+    assert "+14.29%" in markdown
+    assert "Momentum is fading near resistance." in markdown
+    assert "**hold**" in markdown
+
+
+@pytest.mark.asyncio
+async def test_get_latest_market_brief_returns_latest_analysis(monkeypatch) -> None:
+    from app.mcp_server.tooling import market_brief_tools
+
+    db = _DummyDb(rows=[(_analysis(), _stock_info())])
+    monkeypatch.setattr(
+        market_brief_tools,
+        "_session_factory",
+        lambda: _DummySessionFactory(db),
+    )
+    tools = build_tools()
+
+    result = await tools["get_latest_market_brief"](symbols=["005930"], limit=5)
+
+    assert result["success"] is True
+    assert result["briefs"] == [
+        {
+            "symbol": "005930",
+            "name": "Samsung Electronics",
+            "instrument_type": "equity_kr",
+            "decision": "buy",
+            "confidence": 82,
+            "buy_range": {"min": 70000.0, "max": 72000.0},
+            "sell_range": {"min": 82000.0, "max": 84000.0},
+            "analyzed_at": result["briefs"][0]["analyzed_at"],
+        }
+    ]
+    assert result["summary"]["buy_count"] == 1
+    assert db.statements
+
+
+@pytest.mark.asyncio
+async def test_get_market_reports_returns_symbol_history(monkeypatch) -> None:
+    from app.mcp_server.tooling import market_brief_tools
+
+    db = _DummyDb(rows=[(_analysis(id=9, decision="hold"), _stock_info())])
+    monkeypatch.setattr(
+        market_brief_tools,
+        "_session_factory",
+        lambda: _DummySessionFactory(db),
+    )
+    tools = build_tools()
+
+    result = await tools["get_market_reports"](symbol="005930", days=3)
+
+    assert result["success"] is True
+    assert result["symbol"] == "005930"
+    assert result["reports"][0]["id"] == 9
+    assert result["reports"][0]["price_analysis"]["sell_target"] == {
+        "min": 83000.0,
+        "max": 85000.0,
+    }
+    assert result["trend"]["latest_decision"] == "hold"
+
+
+@pytest.mark.asyncio
+async def test_get_trade_journal_filters_by_paperclip_issue_id(monkeypatch) -> None:
+    from app.mcp_server.tooling import trade_journal_tools
+
+    created_at = now_kst() - timedelta(hours=1)
+    journal = SimpleNamespace(
+        id=11,
+        symbol="005930",
+        instrument_type=SimpleNamespace(value="equity_kr"),
+        side="buy",
+        entry_price=Decimal("70000"),
+        quantity=Decimal("3"),
+        amount=Decimal("210000"),
+        thesis="Memory cycle recovery",
+        strategy="swing",
+        target_price=Decimal("84000"),
+        stop_loss=Decimal("68000"),
+        min_hold_days=5,
+        hold_until=now_kst() + timedelta(days=4),
+        indicators_snapshot={"rsi": 55},
+        extra_metadata={"source": "paperclip"},
+        status="active",
+        trade_id=None,
+        exit_price=None,
+        exit_date=None,
+        exit_reason=None,
+        pnl_pct=None,
+        account="main",
+        account_type="live",
+        paper_trade_id=None,
+        paperclip_issue_id="ROB-74",
+        notes="tracking fill",
+        created_at=created_at,
+        updated_at=created_at,
+    )
+    db = _DummyDb(rows=[journal])
+    monkeypatch.setattr(
+        trade_journal_tools,
+        "_session_factory",
+        lambda: _DummySessionFactory(db),
+    )
+    tools = build_tools()
+
+    result = await tools["get_trade_journal"](paperclip_issue_id="ROB-74")
+
+    assert result["success"] is True
+    assert result["entries"][0]["paperclip_issue_id"] == "ROB-74"
+    assert result["entries"][0]["thesis"] == "Memory cycle recovery"
+    assert result["summary"]["total_active"] == 1
+    assert db.statements


### PR DESCRIPTION
## Summary
- `paperclip_issue_id` column on `trade_journals` table + migration
- MCP tools: `format_execution_comment`, `get_latest_market_brief`, `get_market_reports`
- Import path fix for execution comment registration (#524)

## Commits
- `ee0a1a2` feat(mcp): add paperclip_issue_id to trade_journals + execution tools (ROB-74)
- `3f53d6e` fix: correct import path for format_execution_comment in MCP registration (#524)

## Deploy checklist
- [ ] Migration: `alembic upgrade head` (adds `paperclip_issue_id` column)
- [ ] MCP server restart for new tool registration
- [ ] Verify new tools via MCP health endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>