### PR TITLE
feat: Hermes fill-analysis wiring — post_paperclip_comment MCP tool (ROB-81)

### DIFF
--- a/app/mcp_server/tooling/paperclip_comment.py
+++ b/app/mcp_server/tooling/paperclip_comment.py
@@ -1,0 +1,113 @@
+"""Post comments to Paperclip issues via the Paperclip API."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+
+async def post_paperclip_comment(
+    issue_identifier: str,
+    body: str,
+) -> dict[str, Any]:
+    """Post a markdown comment to a Paperclip issue.
+
+    Args:
+        issue_identifier: Paperclip issue identifier (e.g. "ROB-73").
+        body: Markdown comment body.
+
+    Returns:
+        Dict with success status and comment ID or error message.
+    """
+    api_url = os.environ.get("PAPERCLIP_API_URL", "").rstrip("/")
+    api_key = os.environ.get("PAPERCLIP_API_KEY", "")
+
+    if not api_url or not api_key:
+        return {
+            "success": False,
+            "error": "PAPERCLIP_API_URL and PAPERCLIP_API_KEY must be set",
+        }
+
+    if not issue_identifier or not body:
+        return {
+            "success": False,
+            "error": "issue_identifier and body are required",
+        }
+
+    company_id = os.environ.get("PAPERCLIP_COMPANY_ID", "")
+
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            if company_id:
+                search_resp = await client.get(
+                    f"{api_url}/api/companies/{company_id}/issues",
+                    params={
+                        "q": issue_identifier,
+                        "status": "todo,in_progress,in_review,blocked",
+                    },
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+            else:
+                search_resp = await client.get(
+                    f"{api_url}/api/issues/by-identifier/{issue_identifier}",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+
+            if search_resp.status_code != 200:
+                return {
+                    "success": False,
+                    "error": f"Failed to find issue {issue_identifier}: HTTP {search_resp.status_code}",
+                }
+
+            data = search_resp.json()
+
+            if company_id and isinstance(data, list):
+                issue = next(
+                    (i for i in data if i.get("identifier") == issue_identifier),
+                    None,
+                )
+                if not issue:
+                    return {
+                        "success": False,
+                        "error": f"Issue {issue_identifier} not found",
+                    }
+                issue_id = issue["id"]
+            elif isinstance(data, dict) and data.get("id"):
+                issue_id = data["id"]
+            else:
+                return {
+                    "success": False,
+                    "error": f"Issue {issue_identifier} not found",
+                }
+
+            comment_resp = await client.post(
+                f"{api_url}/api/issues/{issue_id}/comments",
+                json={"body": body},
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+            )
+
+            if comment_resp.status_code not in (200, 201):
+                return {
+                    "success": False,
+                    "error": f"Failed to post comment: HTTP {comment_resp.status_code}",
+                }
+
+            result = comment_resp.json()
+            return {
+                "success": True,
+                "comment_id": result.get("id"),
+                "issue_identifier": issue_identifier,
+            }
+
+    except httpx.TimeoutException:
+        return {"success": False, "error": "Request timed out"}
+    except Exception as exc:
+        return {"success": False, "error": str(exc)}
+
+
+__all__ = ["post_paperclip_comment"]

--- a/app/mcp_server/tooling/paperclip_comment_registration.py
+++ b/app/mcp_server/tooling/paperclip_comment_registration.py
@@ -1,0 +1,31 @@
+"""MCP registration for Paperclip comment posting tool."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.mcp_server.tooling.paperclip_comment import post_paperclip_comment
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+PAPERCLIP_COMMENT_TOOL_NAMES: set[str] = {
+    "post_paperclip_comment",
+}
+
+
+def register_paperclip_comment_tools(mcp: FastMCP) -> None:
+    _ = mcp.tool(
+        name="post_paperclip_comment",
+        description=(
+            "Post a markdown comment to a Paperclip issue. "
+            "Requires PAPERCLIP_API_URL and PAPERCLIP_API_KEY environment variables. "
+            "Pass issue_identifier (e.g. 'ROB-73') and body (markdown text)."
+        ),
+    )(post_paperclip_comment)
+
+
+__all__ = [
+    "PAPERCLIP_COMMENT_TOOL_NAMES",
+    "register_paperclip_comment_tools",
+]

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -27,6 +27,9 @@ from app.mcp_server.tooling.paper_analytics_registration import (
 from app.mcp_server.tooling.paper_journal_registration import (
     register_paper_journal_tools,
 )
+from app.mcp_server.tooling.paperclip_comment_registration import (
+    register_paperclip_comment_tools,
+)
 from app.mcp_server.tooling.portfolio_registration import register_portfolio_tools
 from app.mcp_server.tooling.trade_journal_registration import (
     register_trade_journal_tools,
@@ -62,6 +65,7 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_paper_journal_tools(mcp)
     register_execution_comment_tools(mcp)
     register_market_brief_tools(mcp)
+    register_paperclip_comment_tools(mcp)
 
 
 __all__ = ["register_all_tools"]

--- a/tests/test_paperclip_comment.py
+++ b/tests/test_paperclip_comment.py
@@ -1,0 +1,265 @@
+"""Tests for Paperclip comment posting MCP tool."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+from app.mcp_server.tooling.paperclip_comment import post_paperclip_comment
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_missing_env_vars():
+    with patch.dict("os.environ", {}, clear=True):
+        result = await post_paperclip_comment("ROB-73", "test comment")
+    assert result["success"] is False
+    assert "PAPERCLIP_API_URL" in result["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_empty_identifier():
+    env = {"PAPERCLIP_API_URL": "http://localhost:3000", "PAPERCLIP_API_KEY": "key"}
+    with patch.dict("os.environ", env, clear=True):
+        result = await post_paperclip_comment("", "test comment")
+    assert result["success"] is False
+    assert "required" in result["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_empty_body():
+    env = {"PAPERCLIP_API_URL": "http://localhost:3000", "PAPERCLIP_API_KEY": "key"}
+    with patch.dict("os.environ", env, clear=True):
+        result = await post_paperclip_comment("ROB-73", "")
+    assert result["success"] is False
+    assert "required" in result["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_successful_comment_with_company_id():
+    env = {
+        "PAPERCLIP_API_URL": "http://localhost:3000",
+        "PAPERCLIP_API_KEY": "test-key",
+        "PAPERCLIP_COMPANY_ID": "company-123",
+    }
+
+    search_response = httpx.Response(
+        200,
+        json=[{"id": "issue-uuid", "identifier": "ROB-73"}],
+        request=httpx.Request(
+            "GET", "http://localhost:3000/api/companies/company-123/issues"
+        ),
+    )
+    comment_response = httpx.Response(
+        201,
+        json={"id": "comment-uuid"},
+        request=httpx.Request(
+            "POST", "http://localhost:3000/api/issues/issue-uuid/comments"
+        ),
+    )
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(return_value=search_response)
+    mock_client.post = AsyncMock(return_value=comment_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.dict("os.environ", env, clear=True),
+        patch(
+            "app.mcp_server.tooling.paperclip_comment.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+    ):
+        result = await post_paperclip_comment(
+            "ROB-73", "## Fill Record\nBought 10 shares"
+        )
+
+    assert result["success"] is True
+    assert result["comment_id"] == "comment-uuid"
+    assert result["issue_identifier"] == "ROB-73"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_successful_comment_without_company_id():
+    env = {
+        "PAPERCLIP_API_URL": "http://localhost:3000",
+        "PAPERCLIP_API_KEY": "test-key",
+    }
+
+    search_response = httpx.Response(
+        200,
+        json={"id": "issue-uuid", "identifier": "ROB-73"},
+        request=httpx.Request(
+            "GET", "http://localhost:3000/api/issues/by-identifier/ROB-73"
+        ),
+    )
+    comment_response = httpx.Response(
+        201,
+        json={"id": "comment-uuid"},
+        request=httpx.Request(
+            "POST", "http://localhost:3000/api/issues/issue-uuid/comments"
+        ),
+    )
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(return_value=search_response)
+    mock_client.post = AsyncMock(return_value=comment_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.dict("os.environ", env, clear=True),
+        patch(
+            "app.mcp_server.tooling.paperclip_comment.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+    ):
+        result = await post_paperclip_comment("ROB-73", "test comment")
+
+    assert result["success"] is True
+    assert result["comment_id"] == "comment-uuid"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_issue_not_found():
+    env = {
+        "PAPERCLIP_API_URL": "http://localhost:3000",
+        "PAPERCLIP_API_KEY": "test-key",
+        "PAPERCLIP_COMPANY_ID": "company-123",
+    }
+
+    search_response = httpx.Response(
+        200,
+        json=[{"id": "other-uuid", "identifier": "ROB-99"}],
+        request=httpx.Request(
+            "GET", "http://localhost:3000/api/companies/company-123/issues"
+        ),
+    )
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(return_value=search_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.dict("os.environ", env, clear=True),
+        patch(
+            "app.mcp_server.tooling.paperclip_comment.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+    ):
+        result = await post_paperclip_comment("ROB-73", "test comment")
+
+    assert result["success"] is False
+    assert "not found" in result["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_search_api_error():
+    env = {
+        "PAPERCLIP_API_URL": "http://localhost:3000",
+        "PAPERCLIP_API_KEY": "test-key",
+        "PAPERCLIP_COMPANY_ID": "company-123",
+    }
+
+    search_response = httpx.Response(
+        500,
+        json={"error": "Internal server error"},
+        request=httpx.Request(
+            "GET", "http://localhost:3000/api/companies/company-123/issues"
+        ),
+    )
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(return_value=search_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.dict("os.environ", env, clear=True),
+        patch(
+            "app.mcp_server.tooling.paperclip_comment.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+    ):
+        result = await post_paperclip_comment("ROB-73", "test comment")
+
+    assert result["success"] is False
+    assert "HTTP 500" in result["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_comment_post_failure():
+    env = {
+        "PAPERCLIP_API_URL": "http://localhost:3000",
+        "PAPERCLIP_API_KEY": "test-key",
+        "PAPERCLIP_COMPANY_ID": "company-123",
+    }
+
+    search_response = httpx.Response(
+        200,
+        json=[{"id": "issue-uuid", "identifier": "ROB-73"}],
+        request=httpx.Request(
+            "GET", "http://localhost:3000/api/companies/company-123/issues"
+        ),
+    )
+    comment_response = httpx.Response(
+        403,
+        json={"error": "Forbidden"},
+        request=httpx.Request(
+            "POST", "http://localhost:3000/api/issues/issue-uuid/comments"
+        ),
+    )
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(return_value=search_response)
+    mock_client.post = AsyncMock(return_value=comment_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.dict("os.environ", env, clear=True),
+        patch(
+            "app.mcp_server.tooling.paperclip_comment.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+    ):
+        result = await post_paperclip_comment("ROB-73", "test comment")
+
+    assert result["success"] is False
+    assert "HTTP 403" in result["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_timeout_handling():
+    env = {
+        "PAPERCLIP_API_URL": "http://localhost:3000",
+        "PAPERCLIP_API_KEY": "test-key",
+        "PAPERCLIP_COMPANY_ID": "company-123",
+    }
+
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.dict("os.environ", env, clear=True),
+        patch(
+            "app.mcp_server.tooling.paperclip_comment.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+    ):
+        result = await post_paperclip_comment("ROB-73", "test comment")
+
+    assert result["success"] is False
+    assert "timed out" in result["error"]


### PR DESCRIPTION
## Summary

- Add `post_paperclip_comment` MCP tool enabling Hermes to post structured comments to Paperclip issues via the auto_trader MCP server (no direct API key needed in Hermes)
- Register tool in `registry.py` alongside existing execution comment tools
- Create Hermes `trading` skill (`SKILL.md`) with fill event handling workflow: journal lookup → order history → market brief → format comments → post to Paperclip + Discord
- Add 9 unit tests covering success paths, error handling, and edge cases

## Context

Phase 2 of [ROB-73]: wires the existing `fill-analysis` webhook in Hermes to MCP tools for automated post-fill judgment and Paperclip issue recording. Phase 1 (MCP tools: `format_execution_comment`, `get_latest_market_brief`) was delivered in PRs #523/#524.

## Test plan

- [x] All 9 `test_paperclip_comment.py` tests pass
- [x] Ruff lint + format clean
- [ ] End-to-end: send sample fill payload to webhook, verify Discord thread + Paperclip comment
- [ ] Verify idempotency: re-send same fill, confirm no duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Paperclip issue tracker with the ability to post comments directly to issues.

* **Tests**
  * Added comprehensive test suites for Paperclip comment posting and sell signal evaluation, covering successful operations, failure scenarios, timeout handling, and various edge cases to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->