### PR TITLE
fix: add missing internal exports to kr_hourly_candles_read_service shim

### DIFF
--- a/app/services/kr_hourly_candles_read_service.py
+++ b/app/services/kr_hourly_candles_read_service.py
@@ -8,12 +8,16 @@ from app.services.kr_intraday import (  # noqa: F401
     _VENUE_CONFIGS,
     _aggregate_minutes_to_hourly,
     _empty_intraday_frame,
+    _fetch_historical_minutes_via_kis,
+    _merge_overlay_into_intraday_frame,
     _normalize_intraday_rows,
+    _schedule_background_minute_storage,
     _store_minute_candles_background,
     read_kr_hourly_candles_1h,
     read_kr_intraday_candles,
 )
 from app.services.kr_intraday._repository import _log_task_exception  # noqa: F401
+from app.services.kr_intraday._types import _MinuteRow  # noqa: F401
 
 __all__ = [
     "read_kr_hourly_candles_1h",
@@ -22,4 +26,8 @@ __all__ = [
     "_log_task_exception",
     "AsyncSessionLocal",
     "KISClient",
+    "_MinuteRow",
+    "_merge_overlay_into_intraday_frame",
+    "_schedule_background_minute_storage",
+    "_fetch_historical_minutes_via_kis",
 ]


### PR DESCRIPTION
The compatibility shim was missing internal attributes that tests depend on:
- _MinuteRow (from _types)
- _merge_overlay_into_intraday_frame
- _schedule_background_minute_storage
- _fetch_historical_minutes_via_kis

These are needed by tests/test_kr_hourly_candles_read_service.py to access internal implementation details for testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded internal module exports to improve backward compatibility and code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->