### PR TITLE
feat(n8n): TC 브리핑 Discord 엔드포인트 (ROB-94)

### DIFF
--- a/app/routers/n8n.py
+++ b/app/routers/n8n.py
@@ -37,6 +37,7 @@ from app.schemas.n8n.pending_snapshot import (
     N8nPendingSnapshotsResponse,
 )
 from app.schemas.n8n.sell_signal import N8nSellSignalResponse
+from app.schemas.n8n.tc_briefing import N8nTcBriefingRequest, N8nTcBriefingResponse
 from app.schemas.n8n.trade_review import (
     N8nTradeReviewListResponse,
     N8nTradeReviewsRequest,
@@ -62,6 +63,7 @@ from app.services.n8n_pending_snapshot_service import (
     resolve_pending_snapshots,
     save_pending_snapshots,
 )
+from app.services.n8n_tc_briefing_service import send_tc_briefing
 from app.services.n8n_trade_review_service import (
     get_trade_review_stats,
     get_trade_reviews,
@@ -644,4 +646,38 @@ async def get_sell_signal(
         success=True,
         as_of=as_of,
         **result,
+    )
+
+
+@router.post("/tc-briefing", response_model=N8nTcBriefingResponse)
+async def post_tc_briefing(
+    body: N8nTcBriefingRequest,
+) -> N8nTcBriefingResponse | JSONResponse:
+    """Send TC briefing to Discord channel.
+
+    Formats briefing items into Discord embeds grouped by category
+    (매도/매수/홀드/추가매수) and sends via Channel Messages API.
+    """
+    try:
+        result = await send_tc_briefing(body)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Failed to send TC briefing to Discord")
+        payload = N8nTcBriefingResponse(
+            success=False,
+            message_id=None,
+            errors=[{"error": str(exc)}],
+        )
+        return JSONResponse(status_code=500, content=payload.model_dump())
+
+    if "error" in result:
+        return N8nTcBriefingResponse(
+            success=False,
+            message_id=result.get("message_id"),
+            errors=[{"error": result["error"]}],
+        )
+
+    return N8nTcBriefingResponse(
+        success=True,
+        message_id=result.get("message_id"),
+        errors=[],
     )

--- a/app/schemas/n8n/tc_briefing.py
+++ b/app/schemas/n8n/tc_briefing.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class N8nTcBriefingItem(BaseModel):
+    """Single briefing item within a category."""
+
+    symbol: str = Field(..., description="종목 심볼 (e.g. BTC, 005930)")
+    name: str = Field(..., description="종목명 (e.g. 비트코인, SK하이닉스)")
+    action: str = Field(..., description="액션 (e.g. 매도, 매수, 홀드, 추가매수)")
+    reason_summary: str = Field(..., description="근거 요약 (1-2문장)")
+
+
+class N8nTcBriefingCategory(BaseModel):
+    """Category grouping for briefing items."""
+
+    category: str = Field(..., description="카테고리 (매도/매수/홀드/추가매수)")
+    items: list[N8nTcBriefingItem] = Field(default_factory=list)
+
+
+class N8nTcBriefingRequest(BaseModel):
+    """Request body for POST /api/n8n/tc-briefing."""
+
+    issue_identifier: str = Field(
+        ..., description="Paperclip issue identifier (e.g. ROB-94)"
+    )
+    title: str = Field(..., description="브리핑 제목")
+    briefing_items: list[N8nTcBriefingCategory] = Field(
+        ..., description="카테고리별 브리핑 항목"
+    )
+    paperclip_issue_url: str | None = Field(
+        None, description="Paperclip issue deep link URL"
+    )
+
+
+class N8nTcBriefingResponse(BaseModel):
+    """Response for POST /api/n8n/tc-briefing."""
+
+    success: bool
+    message_id: str | None = Field(None, description="Discord message ID if sent")
+    errors: list[dict] = Field(default_factory=list)

--- a/app/services/n8n_tc_briefing_service.py
+++ b/app/services/n8n_tc_briefing_service.py
@@ -1,0 +1,164 @@
+"""TC Briefing Discord delivery service.
+
+Sends structured briefing embeds to a Discord channel via the
+Discord Channel Messages API (Bot token auth), matching the pattern
+used in the Boss Action Queue n8n workflow.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+
+from app.schemas.n8n.tc_briefing import (
+    N8nTcBriefingCategory,
+    N8nTcBriefingRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+DISCORD_API_BASE = "https://discord.com/api/v10"
+
+# Embed colour per category (decimal)
+CATEGORY_COLOURS = {
+    "매도": 0xE74C3C,  # red
+    "매수": 0x2ECC71,  # green
+    "홀드": 0x3498DB,  # blue
+    "추가매수": 0xF1C40F,  # yellow
+}
+
+CATEGORY_EMOJI = {
+    "매도": "\U0001f534",  # red circle
+    "매수": "\U0001f7e2",  # green circle
+    "홀드": "\U0001f535",  # blue circle
+    "추가매수": "\U0001f7e1",  # yellow circle
+}
+
+
+def _build_embeds(request: N8nTcBriefingRequest) -> list[dict]:
+    """Build Discord embed objects from briefing categories."""
+    embeds: list[dict] = []
+
+    # Title embed
+    embeds.append(
+        {
+            "title": request.title,
+            "description": f"`{request.issue_identifier}`",
+            "color": 0x9B59B6,  # purple
+        }
+    )
+
+    for cat in request.briefing_items:
+        embed = _build_category_embed(cat, request.paperclip_issue_url)
+        if embed:
+            embeds.append(embed)
+
+    return embeds
+
+
+def _build_category_embed(
+    cat: N8nTcBriefingCategory,
+    paperclip_url: str | None,
+) -> dict | None:
+    if not cat.items:
+        return None
+
+    emoji = CATEGORY_EMOJI.get(cat.category, "\u2022")
+    colour = CATEGORY_COLOURS.get(cat.category, 0x95A5A6)
+
+    lines: list[str] = []
+    for item in cat.items:
+        lines.append(f"**{item.name}** (`{item.symbol}`)")
+        lines.append(f"> {item.reason_summary}")
+        lines.append("")
+
+    embed: dict = {
+        "title": f"{emoji} {cat.category} ({len(cat.items)}건)",
+        "description": "\n".join(lines).rstrip(),
+        "color": colour,
+    }
+
+    if paperclip_url:
+        embed["footer"] = {"text": "Paperclip에서 결정하기"}
+        embed["url"] = paperclip_url
+
+    return embed
+
+
+def _build_components(paperclip_url: str | None) -> list[dict] | None:
+    """Build Discord message components (button row)."""
+    if not paperclip_url:
+        return None
+
+    return [
+        {
+            "type": 1,  # Action Row
+            "components": [
+                {
+                    "type": 2,  # Button
+                    "style": 5,  # Link
+                    "label": "Paperclip에서 결정하기",
+                    "url": paperclip_url,
+                }
+            ],
+        }
+    ]
+
+
+async def send_tc_briefing(
+    request: N8nTcBriefingRequest,
+) -> dict:
+    """Send TC briefing to Discord channel.
+
+    Returns dict with ``message_id`` on success, or ``error`` on failure.
+    Uses Discord Channel Messages API with Bot token authentication.
+    """
+    bot_token = os.getenv("DISCORD_TC_BRIEFING_BOT_TOKEN", "")
+    channel_id = os.getenv("DISCORD_TC_BRIEFING_CHANNEL_ID", "")
+
+    if not bot_token or not channel_id:
+        missing = []
+        if not bot_token:
+            missing.append("DISCORD_TC_BRIEFING_BOT_TOKEN")
+        if not channel_id:
+            missing.append("DISCORD_TC_BRIEFING_CHANNEL_ID")
+        logger.warning("TC briefing skipped — missing env: %s", ", ".join(missing))
+        return {"message_id": None, "error": f"Missing env: {', '.join(missing)}"}
+
+    embeds = _build_embeds(request)
+    components = _build_components(request.paperclip_issue_url)
+
+    # Discord allows max 10 embeds per message
+    if len(embeds) > 10:
+        embeds = embeds[:10]
+
+    payload: dict = {"embeds": embeds}
+    if components:
+        payload["components"] = components
+
+    url = f"{DISCORD_API_BASE}/channels/{channel_id}/messages"
+    headers = {
+        "Authorization": f"Bot {bot_token}",
+        "Content-Type": "application/json",
+    }
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        try:
+            resp = await client.post(url, json=payload, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+            message_id = data.get("id")
+            logger.info("TC briefing sent to Discord — message_id=%s", message_id)
+            return {"message_id": message_id}
+        except httpx.HTTPStatusError as exc:
+            body = exc.response.text[:500] if exc.response else ""
+            logger.error("Discord API error %s: %s", exc.response.status_code, body)
+            return {
+                "message_id": None,
+                "error": f"Discord API {exc.response.status_code}: {body}",
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Failed to send TC briefing to Discord: %s", exc)
+            return {"message_id": None, "error": str(exc)}

--- a/env.example
+++ b/env.example
@@ -65,6 +65,11 @@ DISCORD_WEBHOOK_CRYPTO=
 # 예시: https://discord.com/api/webhooks/1234567890/AbCdEfGhIjKlMnOpQrStUvWxYz
 DISCORD_WEBHOOK_ALERTS=
 
+# Discord TC 브리핑 Bot Token (Channel Messages API 인증, 선택사항)
+DISCORD_TC_BRIEFING_BOT_TOKEN=
+# Discord TC 브리핑 채널 ID (브리핑 전송 대상 채널, 선택사항)
+DISCORD_TC_BRIEFING_CHANNEL_ID=
+
 # ========================================
 # 전략 설정
 # ========================================

--- a/tests/test_sell_signal_service.py
+++ b/tests/test_sell_signal_service.py
@@ -1,0 +1,804 @@
+"""Tests for sell signal evaluation service."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from app.schemas.n8n.sell_signal import N8nSellCondition, N8nSellSignalResponse
+from app.services.sell_signal_service import (
+    REDIS_RSI_PREFIX,
+    TRIGGER_THRESHOLD,
+    _check_bollinger_reentry,
+    _check_foreign_selling,
+    _check_rsi_momentum,
+    _check_stoch_rsi,
+    _check_trailing_stop,
+    _fetch_current_price,
+    _fetch_stock_name,
+    evaluate_sell_signal,
+)
+
+
+def _make_ohlcv_df(closes: list[float], n: int | None = None) -> pd.DataFrame:
+    if n is None:
+        n = len(closes)
+    return pd.DataFrame(
+        {
+            "open": closes[:n],
+            "high": [c * 1.01 for c in closes[:n]],
+            "low": [c * 0.99 for c in closes[:n]],
+            "close": closes[:n],
+            "volume": [1000.0] * n,
+        }
+    )
+
+
+def _make_large_ohlcv(n: int = 200, base: float = 100.0, seed: int = 42) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    changes = rng.normal(0, 1, n)
+    closes = [base]
+    for c in changes[1:]:
+        closes.append(max(closes[-1] + c, 1.0))
+    return _make_ohlcv_df(closes, n)
+
+
+# ---------------------------------------------------------------------------
+# _fetch_current_price
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCurrentPrice:
+    @pytest.mark.asyncio
+    async def test_returns_price_on_success(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame({"close": [1_150_000.0]})
+        price, err = await _fetch_current_price(kis, "000660")
+        assert price == 1_150_000.0
+        assert err is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_empty_df(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame()
+        price, err = await _fetch_current_price(kis, "000660")
+        assert price is None
+        assert err is None
+
+    @pytest.mark.asyncio
+    async def test_returns_error_on_exception(self):
+        kis = AsyncMock()
+        kis.inquire_price.side_effect = RuntimeError("API down")
+        price, err = await _fetch_current_price(kis, "000660")
+        assert price is None
+        assert err == "API down"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_stock_name
+# ---------------------------------------------------------------------------
+
+
+class TestFetchStockName:
+    @pytest.mark.asyncio
+    async def test_returns_name(self):
+        kis = AsyncMock()
+        kis.fetch_fundamental_info.return_value = {"종목명": "SK하이닉스"}
+        name = await _fetch_stock_name(kis, "000660")
+        assert name == "SK하이닉스"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_symbol(self):
+        kis = AsyncMock()
+        kis.fetch_fundamental_info.side_effect = RuntimeError("fail")
+        name = await _fetch_stock_name(kis, "000660")
+        assert name == "000660"
+
+
+# ---------------------------------------------------------------------------
+# _check_trailing_stop
+# ---------------------------------------------------------------------------
+
+
+class TestCheckTrailingStop:
+    @pytest.mark.asyncio
+    async def test_met_when_price_below_threshold(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame({"close": [1_100_000.0]})
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.name == "trailing_stop"
+        assert cond.met is True
+        assert price == 1_100_000.0
+        assert not errors
+
+    @pytest.mark.asyncio
+    async def test_met_when_price_equals_threshold(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame({"close": [1_150_000.0]})
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.met is True
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_price_above_threshold(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame({"close": [1_200_000.0]})
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.met is False
+        assert price == 1_200_000.0
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_price_unavailable(self):
+        kis = AsyncMock()
+        kis.inquire_price.return_value = pd.DataFrame()
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.met is False
+        assert price is None
+
+    @pytest.mark.asyncio
+    async def test_error_recorded_on_api_failure(self):
+        kis = AsyncMock()
+        kis.inquire_price.side_effect = RuntimeError("timeout")
+        cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
+        assert cond.met is False
+        assert len(errors) == 1
+        assert errors[0]["condition"] == "trailing_stop"
+
+
+# ---------------------------------------------------------------------------
+# _check_stoch_rsi
+# ---------------------------------------------------------------------------
+
+
+class TestCheckStochRsi:
+    @pytest.mark.asyncio
+    async def test_met_when_k_below_threshold(self):
+        df = _make_large_ohlcv(200, base=100)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_stoch_rsi",
+            return_value={"k": 25.0, "d": 30.0},
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.name == "stoch_rsi"
+            assert cond.met is True
+            assert cond.value == 25.0
+            assert not errors
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_k_above_threshold(self):
+        df = _make_large_ohlcv(200, base=100)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_stoch_rsi",
+            return_value={"k": 85.0, "d": 82.0},
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_insufficient_data(self):
+        df = _make_ohlcv_df([100.0] * 10)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.met is False
+            assert "부족" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_empty_dataframe(self):
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=pd.DataFrame(),
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_error(self):
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            side_effect=RuntimeError("network"),
+        ):
+            cond, errors = await _check_stoch_rsi("000660", 80)
+            assert cond.met is False
+            assert len(errors) == 1
+            assert errors[0]["condition"] == "stoch_rsi"
+
+
+# ---------------------------------------------------------------------------
+# _check_foreign_selling
+# ---------------------------------------------------------------------------
+
+
+class TestCheckForeignSelling:
+    @pytest.mark.asyncio
+    async def test_met_with_consecutive_sell_days(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [
+            {"frgn_ntby_qty": "-5000"},
+            {"frgn_ntby_qty": "-3000"},
+        ]
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.name == "foreign_selling"
+        assert cond.met is True
+        assert "2일 연속 순매도" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_not_met_with_mixed_days(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [
+            {"frgn_ntby_qty": "-5000"},
+            {"frgn_ntby_qty": "3000"},
+        ]
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_not_met_with_buy_days(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [
+            {"frgn_ntby_qty": "5000"},
+            {"frgn_ntby_qty": "3000"},
+        ]
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_insufficient_data(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [{"frgn_ntby_qty": "-5000"}]
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+        assert "부족" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_empty_rows(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = []
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_error(self):
+        kis = AsyncMock()
+        kis.inquire_investor.side_effect = RuntimeError("API error")
+        cond, errors = await _check_foreign_selling(kis, "000660", 2)
+        assert cond.met is False
+        assert len(errors) == 1
+        assert errors[0]["condition"] == "foreign_selling"
+
+    @pytest.mark.asyncio
+    async def test_single_day_consecutive(self):
+        kis = AsyncMock()
+        kis.inquire_investor.return_value = [{"frgn_ntby_qty": "-1000"}]
+        cond, errors = await _check_foreign_selling(kis, "000660", 1)
+        assert cond.met is True
+
+
+# ---------------------------------------------------------------------------
+# _check_rsi_momentum
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRsiMomentum:
+    def _mock_redis(self, stored_state: dict | None = None):
+        mock_r = AsyncMock()
+        if stored_state:
+            mock_r.get.return_value = json.dumps(stored_state)
+        else:
+            mock_r.get.return_value = None
+        mock_r.set.return_value = True
+        mock_r.aclose.return_value = None
+        return mock_r
+
+    @pytest.mark.asyncio
+    async def test_met_when_rsi_drops_below_low_mark_after_high(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis({"was_above_high": True, "rsi": 72.0})
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 63.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is True
+            assert "하락" in cond.detail
+            # After trigger, was_above_high resets to False
+            set_call = mock_r.set.call_args
+            saved = json.loads(set_call[0][1])
+            assert saved["was_above_high"] is False
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_rsi_above_low_mark(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis({"was_above_high": True, "rsi": 72.0})
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 68.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert "돌파 이력 있음" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_never_reached_high(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis()
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 50.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert "미돌파" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_sets_was_above_high_when_rsi_reaches_high_mark(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis()
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 75.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            set_call = mock_r.set.call_args
+            saved = json.loads(set_call[0][1])
+            assert saved["was_above_high"] is True
+
+    @pytest.mark.asyncio
+    async def test_insufficient_data(self):
+        df = _make_ohlcv_df([100.0] * 10)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert "부족" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_rsi_none_returns_not_met(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis()
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": None},
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert "계산 불가" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_redis_state_ttl_is_7_days(self):
+        df = _make_large_ohlcv(200)
+        mock_r = self._mock_redis()
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_rsi",
+            return_value={"14": 50.0},
+        ), patch(
+            "app.services.sell_signal_service._get_redis",
+            return_value=mock_r,
+        ):
+            await _check_rsi_momentum("000660", 70, 65)
+            set_call = mock_r.set.call_args
+            assert set_call[1]["ex"] == 86400 * 7
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_error(self):
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            side_effect=RuntimeError("redis down"),
+        ):
+            cond, errors = await _check_rsi_momentum("000660", 70, 65)
+            assert cond.met is False
+            assert len(errors) == 1
+
+
+# ---------------------------------------------------------------------------
+# _check_bollinger_reentry
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBollingerReentry:
+    @pytest.mark.asyncio
+    async def test_met_on_reentry_failure(self):
+        # Build prices: above ref, then drop below ref (re-entry), current below bb_upper
+        prices_above = [1_200_000.0] * 5
+        prices_below = [1_100_000.0] * 5
+        closes = [1_000_000.0] * 190 + prices_above + prices_below
+        df = _make_ohlcv_df(closes)
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 1_100_000.0, 1_142_000.0)
+            assert cond.name == "bollinger_reentry"
+            assert cond.met is True
+            assert "재진입" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_still_above_ref(self):
+        closes = [1_200_000.0] * 200
+        df = _make_ohlcv_df(closes)
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 1_200_000.0, 1_142_000.0)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_never_above_ref(self):
+        closes = [1_000_000.0] * 200
+        df = _make_ohlcv_df(closes)
+
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 1_000_000.0, 1_142_000.0)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_not_met_when_current_price_none(self):
+        df = _make_large_ohlcv(200)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": 1_150_000.0, "middle": 1_100_000.0, "lower": 1_050_000.0},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", None, 1_142_000.0)
+            assert cond.met is False
+            assert "계산 불가" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_insufficient_data(self):
+        df = _make_ohlcv_df([100.0] * 10)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 100.0, 95.0)
+            assert cond.met is False
+            assert "부족" in cond.detail
+
+    @pytest.mark.asyncio
+    async def test_bb_upper_none(self):
+        df = _make_large_ohlcv(200)
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            return_value=df,
+        ), patch(
+            "app.services.sell_signal_service._calculate_bollinger",
+            return_value={"upper": None, "middle": None, "lower": None},
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 100.0, 95.0)
+            assert cond.met is False
+
+    @pytest.mark.asyncio
+    async def test_exception_returns_error(self):
+        with patch(
+            "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+            side_effect=RuntimeError("fail"),
+        ):
+            cond, errors = await _check_bollinger_reentry("000660", 100.0, 95.0)
+            assert cond.met is False
+            assert len(errors) == 1
+            assert errors[0]["condition"] == "bollinger_reentry"
+
+
+# ---------------------------------------------------------------------------
+# evaluate_sell_signal — Integration
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateSellSignal:
+    def _patch_all(
+        self,
+        price: float | None = 1_100_000.0,
+        stoch_k: float = 25.0,
+        foreign_rows: list | None = None,
+        rsi_val: float = 63.0,
+        rsi_state: dict | None = None,
+        bb_upper: float = 1_150_000.0,
+        stock_name: str = "SK하이닉스",
+    ):
+        if foreign_rows is None:
+            foreign_rows = [
+                {"frgn_ntby_qty": "-5000"},
+                {"frgn_ntby_qty": "-3000"},
+            ]
+        if rsi_state is None:
+            rsi_state = {"was_above_high": True, "rsi": 72.0}
+
+        kis_mock = AsyncMock()
+        if price is not None:
+            kis_mock.inquire_price.return_value = pd.DataFrame({"close": [price]})
+        else:
+            kis_mock.inquire_price.return_value = pd.DataFrame()
+        kis_mock.fetch_fundamental_info.return_value = {"종목명": stock_name}
+        kis_mock.inquire_investor.return_value = foreign_rows
+
+        df = _make_large_ohlcv(200)
+
+        mock_r = AsyncMock()
+        mock_r.get.return_value = json.dumps(rsi_state)
+        mock_r.set.return_value = True
+        mock_r.aclose.return_value = None
+
+        return (
+            patch("app.services.sell_signal_service.KISClient", return_value=kis_mock),
+            patch("app.services.sell_signal_service._fetch_ohlcv_for_indicators", return_value=df),
+            patch("app.services.sell_signal_service._calculate_stoch_rsi", return_value={"k": stoch_k, "d": 30.0}),
+            patch("app.services.sell_signal_service._calculate_rsi", return_value={"14": rsi_val}),
+            patch("app.services.sell_signal_service._calculate_bollinger", return_value={"upper": bb_upper, "middle": 1_100_000.0, "lower": 1_050_000.0}),
+            patch("app.services.sell_signal_service._get_redis", return_value=mock_r),
+        )
+
+    @pytest.mark.asyncio
+    async def test_triggered_when_two_or_more_conditions_met(self):
+        # trailing_stop met (price 1.1M <= threshold 1.152M)
+        # stoch_rsi met (k=25 < 80)
+        # foreign met (2 consecutive sell days)
+        # rsi_momentum met (was_above_high + rsi 63 <= 65)
+        patches = self._patch_all(price=1_100_000.0, stoch_k=25.0, rsi_val=63.0)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await evaluate_sell_signal("000660")
+            assert result["triggered"] is True
+            assert result["conditions_met"] >= TRIGGER_THRESHOLD
+            assert "매도 검토" in result["message"]
+            assert result["symbol"] == "000660"
+            assert result["name"] == "SK하이닉스"
+
+    @pytest.mark.asyncio
+    async def test_not_triggered_when_one_condition_met(self):
+        # Only trailing_stop met (price below threshold)
+        # stoch_rsi not met (k=85 >= 80)
+        # foreign not met (buy days)
+        # rsi not met (never above high)
+        patches = self._patch_all(
+            price=1_100_000.0,
+            stoch_k=85.0,
+            foreign_rows=[
+                {"frgn_ntby_qty": "5000"},
+                {"frgn_ntby_qty": "3000"},
+            ],
+            rsi_val=50.0,
+            rsi_state={},
+        )
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await evaluate_sell_signal("000660")
+            assert result["triggered"] is False
+            assert result["conditions_met"] < TRIGGER_THRESHOLD
+            assert "매도 대기" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_zero_conditions_met(self):
+        patches = self._patch_all(
+            price=1_200_000.0,  # above threshold
+            stoch_k=85.0,  # above threshold
+            foreign_rows=[
+                {"frgn_ntby_qty": "5000"},
+                {"frgn_ntby_qty": "3000"},
+            ],
+            rsi_val=50.0,
+            rsi_state={},
+        )
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await evaluate_sell_signal("000660")
+            assert result["triggered"] is False
+            assert result["conditions_met"] == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_all_five_conditions(self):
+        patches = self._patch_all()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
+            result = await evaluate_sell_signal("000660")
+            assert len(result["conditions"]) == 5
+            names = {c.name for c in result["conditions"]}
+            assert names == {
+                "trailing_stop",
+                "stoch_rsi",
+                "foreign_selling",
+                "rsi_momentum",
+                "bollinger_reentry",
+            }
+
+    @pytest.mark.asyncio
+    async def test_errors_collected_from_evaluators(self):
+        kis_mock = AsyncMock()
+        kis_mock.inquire_price.side_effect = RuntimeError("price fail")
+        kis_mock.fetch_fundamental_info.return_value = {"종목명": "테스트"}
+        kis_mock.inquire_investor.side_effect = RuntimeError("investor fail")
+
+        with (
+            patch("app.services.sell_signal_service.KISClient", return_value=kis_mock),
+            patch(
+                "app.services.sell_signal_service._fetch_ohlcv_for_indicators",
+                side_effect=RuntimeError("ohlcv fail"),
+            ),
+        ):
+            result = await evaluate_sell_signal("000660")
+            assert result["triggered"] is False
+            assert len(result["errors"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# API Endpoint Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSellSignalEndpoint:
+    @pytest.fixture
+    def client(self):
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from app.routers.n8n import router
+
+        app = FastAPI()
+        app.include_router(router)
+        return TestClient(app)
+
+    @pytest.mark.asyncio
+    async def test_success_response_schema(self, client):
+        mock_result = {
+            "symbol": "000660",
+            "name": "SK하이닉스",
+            "triggered": False,
+            "conditions_met": 0,
+            "conditions": [],
+            "message": "[매도 대기] SK하이닉스 0/5 조건 충족",
+            "errors": [],
+        }
+        with patch(
+            "app.routers.n8n.evaluate_sell_signal",
+            return_value=mock_result,
+        ):
+            resp = client.get("/api/n8n/sell-signal/000660")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["success"] is True
+            assert data["symbol"] == "000660"
+            assert "as_of" in data
+            assert "triggered" in data
+            assert "conditions_met" in data
+            assert "conditions" in data
+            assert "message" in data
+            assert "errors" in data
+
+    @pytest.mark.asyncio
+    async def test_custom_query_params_forwarded(self, client):
+        mock_result = {
+            "symbol": "005930",
+            "name": "삼성전자",
+            "triggered": False,
+            "conditions_met": 0,
+            "conditions": [],
+            "message": "",
+            "errors": [],
+        }
+        with patch(
+            "app.routers.n8n.evaluate_sell_signal",
+            return_value=mock_result,
+        ) as mock_eval:
+            resp = client.get(
+                "/api/n8n/sell-signal/005930",
+                params={
+                    "price_threshold": 80000,
+                    "stoch_rsi_threshold": 70,
+                    "foreign_days": 3,
+                    "rsi_high": 75,
+                    "rsi_low": 60,
+                    "bb_upper_ref": 78000,
+                },
+            )
+            assert resp.status_code == 200
+            call_kwargs = mock_eval.call_args[1]
+            assert call_kwargs["symbol"] == "005930"
+            assert call_kwargs["price_threshold"] == 80000
+            assert call_kwargs["stoch_rsi_threshold"] == 70
+            assert call_kwargs["foreign_consecutive_days"] == 3
+            assert call_kwargs["rsi_high_mark"] == 75
+            assert call_kwargs["rsi_low_mark"] == 60
+            assert call_kwargs["bb_upper_ref"] == 78000
+
+    @pytest.mark.asyncio
+    async def test_500_on_evaluate_exception(self, client):
+        with patch(
+            "app.routers.n8n.evaluate_sell_signal",
+            side_effect=RuntimeError("catastrophic"),
+        ):
+            resp = client.get("/api/n8n/sell-signal/000660")
+            assert resp.status_code == 500
+            data = resp.json()
+            assert data["success"] is False
+            assert data["triggered"] is False
+            assert len(data["errors"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_response_validates_as_model(self, client):
+        mock_result = {
+            "symbol": "000660",
+            "name": "SK하이닉스",
+            "triggered": True,
+            "conditions_met": 3,
+            "conditions": [
+                N8nSellCondition(name="trailing_stop", met=True, value=1_100_000, threshold=1_152_000, detail="현재가 ₩1,100,000"),
+                N8nSellCondition(name="stoch_rsi", met=True, value=25.0, threshold=80, detail="StochRSI K=25.0"),
+                N8nSellCondition(name="foreign_selling", met=True, value=None, detail="2일 연속 순매도"),
+                N8nSellCondition(name="rsi_momentum", met=False, value=68.0, detail="RSI 68.0"),
+                N8nSellCondition(name="bollinger_reentry", met=False, value=1_150_000, detail="밴드 상단 ₩1,150,000"),
+            ],
+            "message": "[매도 검토] SK하이닉스 3/5 조건 충족 (trailing_stop, stoch_rsi, foreign_selling)",
+            "errors": [],
+        }
+        with patch(
+            "app.routers.n8n.evaluate_sell_signal",
+            return_value=mock_result,
+        ):
+            resp = client.get("/api/n8n/sell-signal/000660")
+            assert resp.status_code == 200
+            validated = N8nSellSignalResponse(**resp.json())
+            assert validated.triggered is True
+            assert validated.conditions_met == 3
+            assert len(validated.conditions) == 5


### PR DESCRIPTION
## Summary
- `POST /api/n8n/tc-briefing` 엔드포인트 추가 — Discord Channel Messages API로 TC 브리핑 전송
- 카테고리별(매도/매수/홀드/추가매수) embed 포맷 + Paperclip deep link 버튼
- `DISCORD_TC_BRIEFING_BOT_TOKEN` / `DISCORD_TC_BRIEFING_CHANNEL_ID` 환경변수 (미설정 시 graceful error)

## Test plan
- [ ] Bot token/channel ID 미설정 상태에서 엔드포인트 호출 → success=false, 명확한 에러 메시지 반환 확인
- [ ] 실제 Discord bot token + channel ID 설정 후 embed 전송 확인
- [ ] 빈 카테고리 항목 처리 확인
- [ ] ruff lint + format 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new API endpoint for sending TC briefings to Discord with formatted category-based items.
  * Supports optional reference links to external issues in briefing messages.

* **Tests**
  * Added comprehensive test suite for sell-signal evaluation logic and endpoints.

* **Chores**
  * Added required environment variables for Discord TC briefing bot configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->