### PR TITLE
fix(ci): GitHub Actions test.yml 수정 - lint 에러 및 redis-cli 문제 해결

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,19 +157,6 @@ jobs:
     - name: Install dependencies
       run: uv sync --group test
 
-    - name: Wait for Redis to be ready
-      run: |
-        for i in {1..30}; do
-          if redis-cli -h localhost -p 6379 ping | grep -q PONG; then
-            echo "Redis is ready!"
-            exit 0
-          fi
-          echo "Waiting for Redis... ($i/30)"
-          sleep 1
-        done
-        echo "Redis failed to start"
-        exit 1
-
     - name: Set environment variables from env.example
       run: |
         chmod +x scripts/setup-test-env.sh

--- a/tests/test_n8n_tc_briefing_discord.py
+++ b/tests/test_n8n_tc_briefing_discord.py
@@ -4,7 +4,6 @@ import json
 import subprocess
 from pathlib import Path
 
-
 WORKFLOW_PATH = Path("n8n/data/export-check/tc-briefing-discord.json")
 COMPOSE_PATH = Path("docker-compose.n8n.yml")
 
@@ -25,8 +24,7 @@ process.stdout.write(JSON.stringify(result[0].json));
         ["node", "-e", runner],
         input=json.dumps({"env": env, "payload": payload, "jsCode": js_code}),
         text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
         check=True,
     )
     return json.loads(completed.stdout)
@@ -55,7 +53,9 @@ def test_tc_briefing_buttons_use_paperclip_base_url_with_identifier() -> None:
     assert button["url"] == "http://raspberrypi:3100/ROB/issues/ROB-99"
 
 
-def test_tc_briefing_buttons_extract_identifier_from_url_when_identifier_missing() -> None:
+def test_tc_briefing_buttons_extract_identifier_from_url_when_identifier_missing() -> (
+    None
+):
     result = _run_build_embeds_node(
         {
             "DISCORD_TC_BRIEFING_BOT_TOKEN": "bot-token",


### PR DESCRIPTION
## 변경사항

1. **style: 테스트 파일 lint 에러 수정 (UP022, import 정렬)**
   - 
tests/test_n8n_tc_briefing_discord.py: subprocess.run에서 
capture_output=True 사용 (UP022)
   - import 블록 정렬 (I001)

2. **fix(ci): Redis 대기 스텝 제거 (redis-cli 미설치 문제)**
   - GitHub Actions runner에 redis-cli가 설치되어 있지 않아 taskiq-smoke job이 실패
   - services 설정의 health check가 이미 Redis 준비 상태를 확인하므로 별도 대기 스텝 불필요

## 관련 실행
- https://github.com/mgh3326/auto_trader/actions/runs/24510430433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow and test infrastructure for better reliability and code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->