### PR TITLE
fix(test): n8n workflow 파일 경로 수정

### DIFF
--- a/tests/test_n8n_tc_briefing_discord.py
+++ b/tests/test_n8n_tc_briefing_discord.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 from pathlib import Path
 
-WORKFLOW_PATH = Path("n8n/data/export-check/tc-briefing-discord.json")
+WORKFLOW_PATH = Path("n8n/workflows/tc-briefing-discord.json")
 COMPOSE_PATH = Path("docker-compose.n8n.yml")
 
 


### PR DESCRIPTION
GitHub Actions 테스트 실패를 수정합니다.

## 변경사항
- test_n8n_tc_briefing_discord.py에서 존재하지 않는 경로 
  
8n/data/export-check/ 대신 실제 파일 위치인 n8n/workflows/를 사용하도록 수정

## 문제
테스트가 존재하지 않는 경로를 참조하여 FileNotFoundError가 발생했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to reference updated workflow file location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->