### PR TITLE
ROB-143: S3 daily burn 실시간 산출 + n8n brief 반영

### DIFF
--- a/app/mcp_server/tooling/trade_journal_tools.py
+++ b/app/mcp_server/tooling/trade_journal_tools.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta
+from datetime import timedelta, timezone
 from decimal import Decimal
 from typing import Any, cast
 
@@ -12,7 +12,7 @@ from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.db import AsyncSessionLocal
-from app.core.timezone import now_kst
+from app.core.timezone import KST, now_kst
 from app.mcp_server.tooling.shared import (
     resolve_market_type as _resolve_market_type,
 )
@@ -509,7 +509,14 @@ async def compute_active_dca_daily_burn() -> dict[str, Any]:
         daily_burn += allocation
 
         if journal.hold_until is not None:
-            days_to_obligation = (journal.hold_until.date() - today).days
+            hold_until = journal.hold_until
+            hold_until_with_tz = (
+                hold_until
+                if hold_until.tzinfo is not None
+                else hold_until.replace(tzinfo=timezone.utc)
+            )
+            hold_until_kst_date = hold_until_with_tz.astimezone(KST).date()
+            days_to_obligation = (hold_until_kst_date - today).days
             if days_to_obligation > 0:
                 obligation_days.append(days_to_obligation)
 

--- a/app/mcp_server/tooling/trade_journal_tools.py
+++ b/app/mcp_server/tooling/trade_journal_tools.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import timedelta, timezone
+from datetime import UTC, timedelta
 from decimal import Decimal
 from typing import Any, cast
 
@@ -513,7 +513,7 @@ async def compute_active_dca_daily_burn() -> dict[str, Any]:
             hold_until_with_tz = (
                 hold_until
                 if hold_until.tzinfo is not None
-                else hold_until.replace(tzinfo=timezone.utc)
+                else hold_until.replace(tzinfo=UTC)
             )
             hold_until_kst_date = hold_until_with_tz.astimezone(KST).date()
             days_to_obligation = (hold_until_kst_date - today).days

--- a/app/mcp_server/tooling/trade_journal_tools.py
+++ b/app/mcp_server/tooling/trade_journal_tools.py
@@ -436,3 +436,94 @@ async def update_trade_journal(
     except Exception as exc:
         logger.exception("update_trade_journal failed")
         return {"success": False, "error": f"update_trade_journal failed: {exc}"}
+
+
+def _extract_daily_allocation_krw(journal: TradeJournal) -> float:
+    """Extract per-day KRW allocation from metadata or model columns."""
+    metadata = (
+        journal.extra_metadata if isinstance(journal.extra_metadata, dict) else {}
+    )
+
+    amount_krw = metadata.get("amount_krw")
+    hold_days = metadata.get("hold_days")
+
+    if amount_krw is None:
+        amount_krw = journal.amount
+    if hold_days is None:
+        hold_days = journal.min_hold_days
+
+    if amount_krw is None or hold_days is None:
+        return 0.0
+
+    try:
+        total_amount = float(amount_krw)
+        total_hold_days = int(hold_days)
+    except (TypeError, ValueError):
+        return 0.0
+
+    if total_amount <= 0 or total_hold_days <= 0:
+        return 0.0
+
+    return total_amount / total_hold_days
+
+
+async def compute_active_dca_daily_burn() -> dict[str, Any]:
+    """Compute current daily burn from active DCA journal records."""
+    try:
+        async with _session_factory()() as db:
+            stmt = (
+                select(TradeJournal)
+                .where(
+                    TradeJournal.status == JournalStatus.active,
+                    TradeJournal.strategy.in_(("dca_oversold", "coinmoogi")),
+                )
+                .order_by(desc(TradeJournal.created_at))
+            )
+            result = await db.execute(stmt)
+            journals = result.scalars().all()
+    except Exception as exc:
+        logger.exception("compute_active_dca_daily_burn failed")
+        return {
+            "daily_burn_krw": 0.0,
+            "active_count": 0,
+            "per_record": [],
+            "days_to_next_obligation": None,
+            "cash_needed_until_obligation": 0.0,
+            "error": f"compute_active_dca_daily_burn failed: {exc}",
+        }
+
+    today = now_kst().date()
+    per_record: list[dict[str, Any]] = []
+    daily_burn = 0.0
+    obligation_days: list[int] = []
+
+    for journal in journals:
+        allocation = _extract_daily_allocation_krw(journal)
+        per_record.append(
+            {
+                "symbol": journal.symbol,
+                "allocation_krw": allocation,
+                "hold_until": journal.hold_until,
+            }
+        )
+        daily_burn += allocation
+
+        if journal.hold_until is not None:
+            days_to_obligation = (journal.hold_until.date() - today).days
+            if days_to_obligation > 0:
+                obligation_days.append(days_to_obligation)
+
+    days_to_next_obligation = min(obligation_days) if obligation_days else None
+    cash_needed_until_obligation = (
+        daily_burn * days_to_next_obligation
+        if days_to_next_obligation is not None
+        else 0.0
+    )
+
+    return {
+        "daily_burn_krw": round(daily_burn, 6),
+        "active_count": len(journals),
+        "per_record": per_record,
+        "days_to_next_obligation": days_to_next_obligation,
+        "cash_needed_until_obligation": round(cash_needed_until_obligation, 6),
+    }

--- a/app/schemas/n8n/daily_brief.py
+++ b/app/schemas/n8n/daily_brief.py
@@ -17,6 +17,7 @@ __all__ = [
     "N8nDailyBriefPortfolio",
     "N8nFillItem",
     "N8nYesterdayFills",
+    "N8nDailyBurnStatus",
     "N8nDailyBriefResponse",
 ]
 
@@ -81,6 +82,23 @@ class N8nYesterdayFills(BaseModel):
     fills: list[N8nFillItem] = Field(default_factory=list)
 
 
+class N8nDailyBurnStatus(BaseModel):
+    """Recomputed active DCA daily-burn summary."""
+
+    daily_burn_krw: float = Field(0, description="Recomputed daily burn in KRW")
+    active_count: int = Field(0, description="Active DCA journal count")
+    per_record: list[dict[str, object]] = Field(default_factory=list)
+    days_to_next_obligation: int | None = Field(
+        None, description="Days until the next active DCA obligation"
+    )
+    cash_needed_until_obligation: float = Field(
+        0, description="Projected cash needed until next obligation"
+    )
+    error: str | None = Field(
+        None, description="Failure detail when daily-burn recomputation degraded"
+    )
+
+
 class N8nDailyBriefResponse(BaseModel):
     """Daily trading brief response."""
 
@@ -97,6 +115,9 @@ class N8nDailyBriefResponse(BaseModel):
     )
     yesterday_fills: N8nYesterdayFills = Field(
         ..., description="Yesterday's filled orders"
+    )
+    daily_burn: N8nDailyBurnStatus | None = Field(
+        None, description="Recomputed active DCA daily-burn status"
     )
 
     brief_text: str = Field(..., description="Pre-formatted briefing text for Discord")

--- a/app/services/n8n_daily_brief_service.py
+++ b/app/services/n8n_daily_brief_service.py
@@ -481,12 +481,15 @@ def _build_brief_text(
 
     # Funding
     burn_data = daily_burn or {}
-    burn_krw = float(burn_data.get("daily_burn_krw") or 0)
-    active_dca_count = int(burn_data.get("active_count") or 0)
     lines.append("💰 자금 현황")
-    lines.append(
-        f"daily_burn: {burn_krw:,.0f} KRW (active DCA {active_dca_count}종 · 재산출)"
-    )
+    if burn_data.get("error"):
+        lines.append("daily_burn: unavailable (active DCA 재산출 실패)")
+    else:
+        burn_krw = float(burn_data.get("daily_burn_krw") or 0)
+        active_dca_count = int(burn_data.get("active_count") or 0)
+        lines.append(
+            f"daily_burn: {burn_krw:,.0f} KRW (active DCA {active_dca_count}종 · 재산출)"
+        )
     lines.append("")
 
     # Yesterday fills
@@ -1296,7 +1299,10 @@ async def fetch_daily_brief(
     if isinstance(results_s1[2], dict):
         daily_burn_result = results_s1[2]
     elif isinstance(results_s1[2], Exception):
-        errors.append({"source": "daily_burn", "error": str(results_s1[2])})
+        daily_burn_result["error"] = str(results_s1[2])
+
+    if daily_burn_result.get("error"):
+        errors.append({"source": "daily_burn", "error": daily_burn_result["error"]})
 
     # Derive shared symbol context for Stage 2
     symbols_by_market = _collect_symbols_by_market(pending_result, portfolio_result)

--- a/app/services/n8n_daily_brief_service.py
+++ b/app/services/n8n_daily_brief_service.py
@@ -19,6 +19,7 @@ import httpx
 
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst
+from app.mcp_server.tooling.trade_journal_tools import compute_active_dca_daily_burn
 from app.schemas.n8n.board_brief import (
     BoardBriefContext,
     BoardBriefPhase,
@@ -370,6 +371,7 @@ def _build_brief_text(
     pending_by_market: dict[str, dict[str, Any]],
     portfolio_by_market: dict[str, dict[str, Any]],
     yesterday_fills: dict[str, Any],
+    daily_burn: dict[str, Any] | None = None,
 ) -> str:
     """Build the full brief text for Discord delivery."""
     lines: list[str] = []
@@ -476,6 +478,16 @@ def _build_brief_text(
             f"{', '.join(dust_lines)} — Upbit 최소 주문 금액 미만, execution-actionable 제외, journal 유지. cleanup backlog."
         )
         lines.append("")
+
+    # Funding
+    burn_data = daily_burn or {}
+    burn_krw = float(burn_data.get("daily_burn_krw") or 0)
+    active_dca_count = int(burn_data.get("active_count") or 0)
+    lines.append("💰 자금 현황")
+    lines.append(
+        f"daily_burn: {burn_krw:,.0f} KRW (active DCA {active_dca_count}종 · 재산출)"
+    )
+    lines.append("")
 
     # Yesterday fills
     fills_data = yesterday_fills or {}
@@ -1252,10 +1264,12 @@ async def fetch_daily_brief(
         as_of=effective_as_of,
     )
     portfolio_task = _get_portfolio_overview(effective_markets)
+    daily_burn_task = compute_active_dca_daily_burn()
 
     results_s1 = await asyncio.gather(
         pending_task,
         portfolio_task,
+        daily_burn_task,
         return_exceptions=True,
     )
 
@@ -1271,6 +1285,18 @@ async def fetch_daily_brief(
         portfolio_result = results_s1[1]
     elif isinstance(results_s1[1], Exception):
         errors.append({"source": "portfolio", "error": str(results_s1[1])})
+
+    daily_burn_result: dict[str, Any] = {
+        "daily_burn_krw": 0.0,
+        "active_count": 0,
+        "per_record": [],
+        "days_to_next_obligation": None,
+        "cash_needed_until_obligation": 0.0,
+    }
+    if isinstance(results_s1[2], dict):
+        daily_burn_result = results_s1[2]
+    elif isinstance(results_s1[2], Exception):
+        errors.append({"source": "daily_burn", "error": str(results_s1[2])})
 
     # Derive shared symbol context for Stage 2
     symbols_by_market = _collect_symbols_by_market(pending_result, portfolio_result)
@@ -1335,6 +1361,7 @@ async def fetch_daily_brief(
         pending_by_market=pending_by_market,
         portfolio_by_market=portfolio_by_market,
         yesterday_fills=fills_result,
+        daily_burn=daily_burn_result,
     )
 
     # Collect sub-errors
@@ -1354,6 +1381,7 @@ async def fetch_daily_brief(
             market: portfolio_by_market.get(market) for market in effective_markets
         },
         "yesterday_fills": fills_result,
+        "daily_burn": daily_burn_result,
         "brief_text": brief_text,
         "errors": errors,
     }

--- a/tests/test_daily_burn.py
+++ b/tests/test_daily_burn.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import pytest
@@ -201,7 +201,7 @@ async def test_compute_active_dca_daily_burn_uses_kst_date_for_utc_hold_until(
 ) -> None:
     fixed_now = datetime(2026, 4, 17, 0, 0, tzinfo=KST)
     # 2026-04-17 15:30 UTC == 2026-04-18 00:30 KST
-    hold_until_utc = datetime(2026, 4, 17, 15, 30, tzinfo=timezone.utc)
+    hold_until_utc = datetime(2026, 4, 17, 15, 30, tzinfo=UTC)
 
     await _insert_journals(
         sqlite_session_factory,

--- a/tests/test_daily_burn.py
+++ b/tests/test_daily_burn.py
@@ -54,7 +54,7 @@ async def test_compute_active_dca_daily_burn_sums_mixed_strategies(
     sqlite_session_factory: async_sessionmaker[AsyncSession],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    now = now_kst()
+    now = datetime(2026, 4, 17, 12, 0, tzinfo=KST)
     await _insert_journals(
         sqlite_session_factory,
         [
@@ -98,6 +98,10 @@ async def test_compute_active_dca_daily_burn_sums_mixed_strategies(
     monkeypatch.setattr(
         "app.mcp_server.tooling.trade_journal_tools._session_factory",
         lambda: sqlite_session_factory,
+    )
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.trade_journal_tools.now_kst",
+        lambda: now,
     )
 
     result = await compute_active_dca_daily_burn()
@@ -287,3 +291,86 @@ def test_brief_text_renders_recomputed_daily_burn_line() -> None:
     )
 
     assert "daily_burn: 60,000 KRW (active DCA 3종 · 재산출)" in text
+
+
+@pytest.mark.unit
+def test_brief_text_marks_daily_burn_unavailable_when_recompute_failed() -> None:
+    text = _build_brief_text(
+        date_fmt="03/17 (화)",
+        market_overview={
+            "fear_greed": None,
+            "btc_dominance": None,
+            "total_market_cap_change_24h": None,
+            "economic_events_today": [],
+        },
+        pending_by_market={},
+        portfolio_by_market={},
+        yesterday_fills={"total": 0, "fills": []},
+        daily_burn={
+            "daily_burn_krw": 0.0,
+            "active_count": 0,
+            "error": "compute_active_dca_daily_burn failed: db unavailable",
+        },
+    )
+
+    assert "daily_burn: unavailable" in text
+    assert "daily_burn: 0 KRW" not in text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_daily_brief_marks_daily_burn_unavailable_when_task_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _raise_daily_burn() -> dict[str, object]:
+        raise RuntimeError("db unavailable")
+
+    async def _fetch_pending_orders(**_kwargs: object) -> dict[str, object]:
+        return {"orders": [], "errors": []}
+
+    async def _get_portfolio_overview(_markets: list[str]) -> dict[str, object]:
+        return {"positions": [], "warnings": []}
+
+    async def _fetch_market_context(**_kwargs: object) -> dict[str, object]:
+        return {
+            "market_overview": {
+                "fear_greed": None,
+                "btc_dominance": None,
+                "total_market_cap_change_24h": None,
+                "economic_events_today": [],
+            },
+            "errors": [],
+        }
+
+    async def _fetch_yesterday_fills(**_kwargs: object) -> dict[str, object]:
+        return {"total": 0, "fills": []}
+
+    monkeypatch.setattr(
+        "app.services.n8n_daily_brief_service.compute_active_dca_daily_burn",
+        _raise_daily_burn,
+    )
+    monkeypatch.setattr(
+        "app.services.n8n_daily_brief_service.fetch_pending_orders",
+        _fetch_pending_orders,
+    )
+    monkeypatch.setattr(
+        "app.services.n8n_daily_brief_service._get_portfolio_overview",
+        _get_portfolio_overview,
+    )
+    monkeypatch.setattr(
+        "app.services.n8n_daily_brief_service.fetch_market_context",
+        _fetch_market_context,
+    )
+    monkeypatch.setattr(
+        "app.services.n8n_daily_brief_service._fetch_yesterday_fills",
+        _fetch_yesterday_fills,
+    )
+
+    from app.services.n8n_daily_brief_service import fetch_daily_brief
+
+    result = await fetch_daily_brief(markets=["crypto"])
+
+    assert result["daily_burn"]["error"] == "db unavailable"
+    assert {"source": "daily_burn", "error": "db unavailable"} in result["errors"]
+    assert "daily_burn: unavailable" in result["brief_text"]
+    assert "daily_burn: 0 KRW" not in result["brief_text"]

--- a/tests/test_daily_burn.py
+++ b/tests/test_daily_burn.py
@@ -186,10 +186,10 @@ async def test_compute_active_dca_daily_burn_returns_zero_when_no_active(
 
     result = await compute_active_dca_daily_burn()
 
-    assert result["daily_burn_krw"] == 0.0
+    assert result["daily_burn_krw"] == pytest.approx(0.0)
     assert result["active_count"] == 0
     assert result["days_to_next_obligation"] is None
-    assert result["cash_needed_until_obligation"] == 0.0
+    assert result["cash_needed_until_obligation"] == pytest.approx(0.0)
     assert result["per_record"] == []
 
 

--- a/tests/test_daily_burn.py
+++ b/tests/test_daily_burn.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.compiler import compiles
+
+from app.core.timezone import now_kst
+from app.mcp_server.tooling.trade_journal_tools import compute_active_dca_daily_burn
+from app.models.trade_journal import JournalStatus, TradeJournal
+from app.models.trading import InstrumentType
+from app.services.n8n_daily_brief_service import _build_brief_text
+
+
+@compiles(JSONB, "sqlite")
+def _compile_jsonb_sqlite(_type: JSONB, _compiler, **_kwargs) -> str:
+    return "JSON"
+
+
+@pytest_asyncio.fixture
+async def sqlite_session_factory() -> async_sessionmaker[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql("ATTACH DATABASE ':memory:' AS review")
+        await conn.run_sync(TradeJournal.__table__.create)
+
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield factory
+    finally:
+        await engine.dispose()
+
+
+async def _insert_journals(
+    factory: async_sessionmaker[AsyncSession],
+    journals: list[TradeJournal],
+) -> None:
+    async with factory() as session:
+        session.add_all(journals)
+        await session.commit()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_compute_active_dca_daily_burn_sums_mixed_strategies(
+    sqlite_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = now_kst()
+    await _insert_journals(
+        sqlite_session_factory,
+        [
+            TradeJournal(
+                id=1,
+                symbol="KRW-BTC",
+                instrument_type=InstrumentType.crypto,
+                side="buy",
+                thesis="dca",
+                status=JournalStatus.active,
+                strategy="dca_oversold",
+                amount=Decimal("90000"),
+                min_hold_days=9,
+                hold_until=now + timedelta(days=7),
+            ),
+            TradeJournal(
+                id=2,
+                symbol="KRW-ETH",
+                instrument_type=InstrumentType.crypto,
+                side="buy",
+                thesis="dca",
+                status=JournalStatus.active,
+                strategy="coinmoogi",
+                extra_metadata={"amount_krw": 200000, "hold_days": 10},
+                hold_until=now + timedelta(days=3),
+            ),
+            TradeJournal(
+                id=3,
+                symbol="KRW-XRP",
+                instrument_type=InstrumentType.crypto,
+                side="buy",
+                thesis="dca",
+                status=JournalStatus.active,
+                strategy="dca_oversold",
+                extra_metadata={"amount_krw": 600000, "hold_days": 20},
+                hold_until=now + timedelta(days=10),
+            ),
+        ],
+    )
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.trade_journal_tools._session_factory",
+        lambda: sqlite_session_factory,
+    )
+
+    result = await compute_active_dca_daily_burn()
+
+    assert result["active_count"] == 3
+    assert result["daily_burn_krw"] == pytest.approx(60000.0)
+    assert result["days_to_next_obligation"] == 3
+    assert result["cash_needed_until_obligation"] == pytest.approx(180000.0)
+    assert len(result["per_record"]) == 3
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_compute_active_dca_daily_burn_excludes_closed_status(
+    sqlite_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = now_kst()
+    await _insert_journals(
+        sqlite_session_factory,
+        [
+            TradeJournal(
+                id=11,
+                symbol="KRW-BTC",
+                instrument_type=InstrumentType.crypto,
+                side="buy",
+                thesis="dca",
+                status=JournalStatus.active,
+                strategy="dca_oversold",
+                amount=Decimal("90000"),
+                min_hold_days=9,
+                hold_until=now + timedelta(days=4),
+            ),
+            TradeJournal(
+                id=12,
+                symbol="KRW-ETH",
+                instrument_type=InstrumentType.crypto,
+                side="buy",
+                thesis="dca",
+                status=JournalStatus.closed,
+                strategy="coinmoogi",
+                extra_metadata={"amount_krw": 200000, "hold_days": 10},
+                hold_until=now + timedelta(days=3),
+            ),
+        ],
+    )
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.trade_journal_tools._session_factory",
+        lambda: sqlite_session_factory,
+    )
+
+    result = await compute_active_dca_daily_burn()
+
+    assert result["active_count"] == 1
+    assert result["daily_burn_krw"] == pytest.approx(10000.0)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_compute_active_dca_daily_burn_returns_zero_when_no_active(
+    sqlite_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _insert_journals(
+        sqlite_session_factory,
+        [
+            TradeJournal(
+                id=21,
+                symbol="KRW-BTC",
+                instrument_type=InstrumentType.crypto,
+                side="buy",
+                thesis="dca",
+                status=JournalStatus.closed,
+                strategy="dca_oversold",
+                amount=Decimal("90000"),
+                min_hold_days=9,
+            )
+        ],
+    )
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.trade_journal_tools._session_factory",
+        lambda: sqlite_session_factory,
+    )
+
+    result = await compute_active_dca_daily_burn()
+
+    assert result["daily_burn_krw"] == 0.0
+    assert result["active_count"] == 0
+    assert result["days_to_next_obligation"] is None
+    assert result["cash_needed_until_obligation"] == 0.0
+    assert result["per_record"] == []
+
+
+@pytest.mark.unit
+def test_brief_text_renders_recomputed_daily_burn_line() -> None:
+    text = _build_brief_text(
+        date_fmt="03/17 (화)",
+        market_overview={
+            "fear_greed": None,
+            "btc_dominance": None,
+            "total_market_cap_change_24h": None,
+            "economic_events_today": [],
+        },
+        pending_by_market={},
+        portfolio_by_market={},
+        yesterday_fills={"total": 0, "fills": []},
+        daily_burn={"daily_burn_krw": 60000.0, "active_count": 3},
+    )
+
+    assert "daily_burn: 60,000 KRW (active DCA 3종 · 재산출)" in text

--- a/tests/test_daily_burn.py
+++ b/tests/test_daily_burn.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -9,8 +9,11 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.ext.compiler import compiles
 
-from app.core.timezone import now_kst
-from app.mcp_server.tooling.trade_journal_tools import compute_active_dca_daily_burn
+from app.core.timezone import KST, now_kst
+from app.mcp_server.tooling.trade_journal_tools import (
+    _extract_daily_allocation_krw,
+    compute_active_dca_daily_burn,
+)
 from app.models.trade_journal import JournalStatus, TradeJournal
 from app.models.trading import InstrumentType
 from app.services.n8n_daily_brief_service import _build_brief_text
@@ -188,6 +191,83 @@ async def test_compute_active_dca_daily_burn_returns_zero_when_no_active(
     assert result["days_to_next_obligation"] is None
     assert result["cash_needed_until_obligation"] == 0.0
     assert result["per_record"] == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_compute_active_dca_daily_burn_uses_kst_date_for_utc_hold_until(
+    sqlite_session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixed_now = datetime(2026, 4, 17, 0, 0, tzinfo=KST)
+    # 2026-04-17 15:30 UTC == 2026-04-18 00:30 KST
+    hold_until_utc = datetime(2026, 4, 17, 15, 30, tzinfo=timezone.utc)
+
+    await _insert_journals(
+        sqlite_session_factory,
+        [
+            TradeJournal(
+                id=31,
+                symbol="KRW-BTC",
+                instrument_type=InstrumentType.crypto,
+                side="buy",
+                thesis="dca",
+                status=JournalStatus.active,
+                strategy="dca_oversold",
+                amount=Decimal("90000"),
+                min_hold_days=9,
+                hold_until=hold_until_utc,
+            )
+        ],
+    )
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.trade_journal_tools._session_factory",
+        lambda: sqlite_session_factory,
+    )
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.trade_journal_tools.now_kst",
+        lambda: fixed_now,
+    )
+
+    result = await compute_active_dca_daily_burn()
+
+    assert result["days_to_next_obligation"] == 1
+    assert result["cash_needed_until_obligation"] == pytest.approx(10000.0)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("extra_metadata", "amount", "min_hold_days", "expected"),
+    [
+        ({"amount_krw": 100000, "hold_days": 10}, None, None, 10000.0),
+        ({"amount_krw": 120000}, Decimal("60000"), 6, 20000.0),
+        ({}, Decimal("60000"), 6, 10000.0),
+        ({"amount_krw": "abc", "hold_days": 10}, None, None, 0.0),
+        ({"amount_krw": 100000, "hold_days": 0}, None, None, 0.0),
+        ({"amount_krw": -100000, "hold_days": 10}, None, None, 0.0),
+    ],
+)
+def test_extract_daily_allocation_krw_edge_cases(
+    extra_metadata: dict[str, int | str],
+    amount: Decimal | None,
+    min_hold_days: int | None,
+    expected: float,
+) -> None:
+    journal = TradeJournal(
+        id=41,
+        symbol="KRW-BTC",
+        instrument_type=InstrumentType.crypto,
+        side="buy",
+        thesis="dca",
+        status=JournalStatus.active,
+        strategy="dca_oversold",
+        extra_metadata=extra_metadata,
+        amount=amount,
+        min_hold_days=min_hold_days,
+    )
+
+    assert _extract_daily_allocation_krw(journal) == pytest.approx(expected)
 
 
 @pytest.mark.unit

--- a/tests/test_n8n_daily_brief_api.py
+++ b/tests/test_n8n_daily_brief_api.py
@@ -51,6 +51,30 @@ class TestDailyBriefEndpoint:
         assert "brief_text" in body
         assert "market_overview" in body
 
+    def test_daily_brief_preserves_daily_burn_error_payload(self):
+        client = self._get_client()
+        result = _make_brief_result()
+        result["daily_burn"] = {
+            "daily_burn_krw": 0.0,
+            "active_count": 0,
+            "error": "db unavailable",
+        }
+        result["errors"] = [{"source": "daily_burn", "error": "db unavailable"}]
+        result["brief_text"] = "daily_burn: unavailable (active DCA 재산출 실패)"
+
+        with patch(
+            "app.routers.n8n.fetch_daily_brief",
+            new_callable=AsyncMock,
+            return_value=result,
+        ):
+            resp = client.get("/api/n8n/daily-brief")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["daily_burn"]["error"] == "db unavailable"
+        assert {"source": "daily_burn", "error": "db unavailable"} in body["errors"]
+        assert "daily_burn: unavailable" in body["brief_text"]
+
     def test_daily_brief_custom_markets(self):
         client = self._get_client()
         with patch(


### PR DESCRIPTION
## Summary
- add `compute_active_dca_daily_burn()` to compute active DCA daily obligation from trade journals
- remove hardcoded daily-burn policy path from n8n brief and inject recomputed value
- add `tests/test_daily_burn.py` for active/closed/empty cases and brief render assertion

## Validation
- `uv run pytest tests/test_daily_burn.py -v`
- `uv run ruff check app tests`
- `uv run ruff format --check app tests`
- `grep -n "80000" app/services/n8n_daily_brief_service.py`

## Notes
- repository-wide lint gate required fixing pre-existing lint issues in `tests/test_sell_signal_service.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "자금 현황" (Funding Status) section to daily brief, displaying active DCA positions, daily burn rate in KRW, and days until next obligation.

* **Tests**
  * Introduced comprehensive test suite covering daily burn calculations, funding status rendering, and edge cases across various journal configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->