### PR TITLE
ROB-171: switch watch alert delivery path to n8n-first

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -306,6 +306,8 @@ class Settings(BaseSettings):
 
     # N8N Fill Notification webhook (replaces OPENCLAW_THREAD_* for fills)
     N8N_FILL_WEBHOOK_URL: str = ""
+    # N8N Watch Alert webhook (replaces OpenClaw watch alert route)
+    N8N_WATCH_ALERT_WEBHOOK_URL: str = ""
 
     DAILY_SCAN_ENABLED: bool = False
     DAILY_SCAN_CRASH_THRESHOLD: float = 0.05

--- a/app/jobs/watch_scanner.py
+++ b/app/jobs/watch_scanner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from functools import lru_cache
+from uuid import uuid4
 
 import exchange_calendars as xcals
 import pandas as pd
@@ -9,7 +10,7 @@ from pandas import Timestamp
 
 from app.mcp_server.tooling.market_data_indicators import _calculate_rsi
 from app.services import market_data as market_data_service
-from app.services.openclaw_client import OpenClawClient
+from app.services.openclaw_client import OpenClawClient, WatchAlertDeliveryResult
 from app.services.watch_alerts import WatchAlertService
 
 logger = logging.getLogger(__name__)
@@ -169,25 +170,46 @@ class WatchScanner:
             )
         return "\n".join(lines)
 
-    async def _send_alert(self, message: str) -> str | None:
+    async def _send_alert(
+        self,
+        *,
+        market: str,
+        triggered: list[dict[str, object]],
+        message: str,
+    ) -> WatchAlertDeliveryResult:
+        correlation_id = str(uuid4())
+        as_of = Timestamp.now("UTC").isoformat()
         try:
-            return await self._openclaw.send_watch_alert(message)
+            return await self._openclaw.send_watch_alert_to_n8n(
+                message=message,
+                market=market,
+                triggered=triggered,
+                as_of=as_of,
+                correlation_id=correlation_id,
+            )
         except Exception as exc:
             logger.error("Failed to send watch scan alert: %s", exc)
-            return None
+            return WatchAlertDeliveryResult(status="failed", reason="request_failed")
 
     async def scan_market(self, market: str) -> dict[str, object]:
         normalized_market = str(market).strip().lower()
         if not self._is_market_open(normalized_market):
             return {
                 "market": normalized_market,
+                "status": "skipped",
                 "skipped": True,
                 "reason": "market_closed",
             }
 
         watches = await self._watch_service.get_watches_for_market(normalized_market)
         if not watches:
-            return {"market": normalized_market, "alerts_sent": 0, "details": []}
+            return {
+                "market": normalized_market,
+                "status": "skipped",
+                "reason": "no_watch_records",
+                "alerts_sent": 0,
+                "details": [],
+            }
 
         triggered: list[dict[str, object]] = []
         triggered_fields: list[str] = []
@@ -228,18 +250,42 @@ class WatchScanner:
             triggered_fields.append(field)
 
         if not triggered:
-            return {"market": normalized_market, "alerts_sent": 0, "details": []}
+            return {
+                "market": normalized_market,
+                "status": "skipped",
+                "reason": "no_triggered_alerts",
+                "alerts_sent": 0,
+                "details": [],
+            }
 
         message = self._build_batched_message(normalized_market, triggered)
-        request_id = await self._send_alert(message)
-        if not request_id:
-            return {"market": normalized_market, "alerts_sent": 0, "details": []}
+        result = await self._send_alert(
+            market=normalized_market,
+            triggered=triggered,
+            message=message,
+        )
+        if result.status != "success":
+            logger.warning(
+                "Watch alert delivery was not successful: market=%s status=%s reason=%s",
+                normalized_market,
+                result.status,
+                result.reason,
+            )
+            return {
+                "market": normalized_market,
+                "status": result.status,
+                "reason": result.reason,
+                "alerts_sent": 0,
+                "details": [message],
+            }
 
         for field in triggered_fields:
             await self._watch_service.trigger_and_remove(normalized_market, field)
 
         return {
             "market": normalized_market,
+            "status": "success",
+            "request_id": result.request_id,
             "alerts_sent": len(triggered_fields),
             "details": [message],
         }

--- a/app/services/openclaw_client.py
+++ b/app/services/openclaw_client.py
@@ -32,11 +32,25 @@ OPENCLAW_RETRY_WAIT = wait_exponential(multiplier=1, min=1, max=4)
 _KR_SYMBOLS_REVERSE: dict[str, str] | None = None
 
 FillNotificationDeliveryStatus = Literal["success", "skipped", "failed"]
+WatchAlertDeliveryStatus = Literal["success", "skipped", "failed"]
 
 
 @dataclass(slots=True, frozen=True)
 class FillNotificationDeliveryResult:
     status: FillNotificationDeliveryStatus
+    reason: str | None = None
+    request_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status == "success" and self.request_id is None:
+            raise ValueError("success results require a request_id")
+        if self.status != "success" and self.request_id is not None:
+            raise ValueError("request_id is only allowed for success results")
+
+
+@dataclass(slots=True, frozen=True)
+class WatchAlertDeliveryResult:
+    status: WatchAlertDeliveryStatus
     reason: str | None = None
     request_id: str | None = None
 
@@ -364,6 +378,99 @@ class OpenClawClient:
 
         return result
 
+    async def send_watch_alert_to_n8n(
+        self,
+        *,
+        message: str,
+        market: str,
+        triggered: list[dict[str, Any]],
+        as_of: str,
+        correlation_id: str | None = None,
+    ) -> WatchAlertDeliveryResult:
+        request_id = str(uuid4())
+        n8n_webhook_url = settings.N8N_WATCH_ALERT_WEBHOOK_URL.strip()
+
+        if not n8n_webhook_url:
+            logger.debug(
+                "N8N watch alert skipped: correlation_id=%s market=%s reason=n8n_webhook_not_configured",
+                correlation_id,
+                market,
+            )
+            return WatchAlertDeliveryResult(
+                status="skipped",
+                reason="n8n_webhook_not_configured",
+            )
+
+        payload = {
+            "alert_type": "watch",
+            "correlation_id": correlation_id,
+            "as_of": as_of,
+            "market": market,
+            "triggered": triggered,
+            "message": message,
+        }
+        headers = {"Content-Type": "application/json"}
+
+        try:
+            async for attempt in _build_openclaw_retrying():
+                attempt_number = attempt.retry_state.attempt_number
+                with attempt:
+                    logger.info(
+                        "N8N watch alert send start: correlation_id=%s request_id=%s market=%s attempt=%s",
+                        correlation_id,
+                        request_id,
+                        market,
+                        attempt_number,
+                    )
+                    try:
+                        async with httpx.AsyncClient(timeout=10) as cli:
+                            res = await cli.post(
+                                n8n_webhook_url,
+                                json=payload,
+                                headers=headers,
+                            )
+                            _ = res.raise_for_status()
+                    except Exception as exc:
+                        logger.warning(
+                            "N8N watch alert attempt failed: correlation_id=%s request_id=%s market=%s attempt=%s error=%s",
+                            correlation_id,
+                            request_id,
+                            market,
+                            attempt_number,
+                            exc,
+                        )
+                        raise
+                    logger.info(
+                        "N8N watch alert sent: correlation_id=%s request_id=%s market=%s attempt=%s status=%s",
+                        correlation_id,
+                        request_id,
+                        market,
+                        attempt_number,
+                        res.status_code,
+                    )
+                    return WatchAlertDeliveryResult(
+                        status="success",
+                        request_id=request_id,
+                    )
+        except RetryError as exc:
+            logger.error(
+                "N8N watch alert failed after retries: correlation_id=%s request_id=%s market=%s error=%s",
+                correlation_id,
+                request_id,
+                market,
+                exc,
+            )
+        except Exception as exc:
+            logger.error(
+                "N8N watch alert error: correlation_id=%s request_id=%s market=%s error=%s",
+                correlation_id,
+                request_id,
+                market,
+                exc,
+            )
+
+        return WatchAlertDeliveryResult(status="failed", reason="request_failed")
+
     async def _send_market_alert(
         self,
         message: str,
@@ -371,6 +478,7 @@ class OpenClawClient:
         *,
         mirror_to_telegram: bool = True,
     ) -> str | None:
+        # Deprecated: watch category is replaced by send_watch_alert_to_n8n (ROB-171)
         if not settings.OPENCLAW_ENABLED:
             logger.debug("OpenClaw disabled, skipping %s alert", category)
             return None
@@ -439,6 +547,7 @@ class OpenClawClient:
         )
 
     async def send_watch_alert(self, message: str) -> str | None:
+        # Deprecated: replaced by send_watch_alert_to_n8n (ROB-171)
         return await self._send_market_alert(message, category="watch")
 
 

--- a/env.example
+++ b/env.example
@@ -106,6 +106,9 @@ OPENCLAW_SCREENER_CALLBACK_URL=http://localhost:8000/api/screener/callback
 # n8n에 "Fill Notification" 워크플로우를 생성하면 자동으로 생성되는 URL
 # 예시: http://localhost:5678/webhook/fill-notification
 N8N_FILL_WEBHOOK_URL=
+# n8n Watch Alert Webhook URL (watch alert → n8n-first route)
+# 예시: http://localhost:5678/webhook/watch-alert
+N8N_WATCH_ALERT_WEBHOOK_URL=
 
 # ========================================
 # KRX (한국거래소) 정보데이터시스템 설정

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,7 @@ def _ensure_test_env() -> None:
         "MCP_AUTH_TOKEN": "",  # Empty to disable auth for tests
         "N8N_API_KEY": "",  # Empty = n8n auth disabled in tests by default
         "N8N_FILL_WEBHOOK_URL": "",  # Empty = n8n fill webhook disabled in tests by default
+        "N8N_WATCH_ALERT_WEBHOOK_URL": "",  # Empty = n8n watch webhook disabled in tests
         "OPENAI_API_KEY": "",
         "GEMINI_ADVISOR_API_KEY": "",
         "GROK_API_KEY": "",

--- a/tests/test_openclaw_client.py
+++ b/tests/test_openclaw_client.py
@@ -17,6 +17,7 @@ from app.services.fill_notification import FillOrder, format_fill_message
 from app.services.openclaw_client import (
     FillNotificationDeliveryResult,
     OpenClawClient,
+    WatchAlertDeliveryResult,
     _build_n8n_fill_payload,
     _build_openclaw_message,
 )
@@ -1212,6 +1213,131 @@ async def test_send_watch_alert_success(
     assert called_json["sessionKey"].startswith("auto-trader:watch:")
     assert called_json["message"] == "watch message"
     mock_notifier.notify_openclaw_message.assert_awaited_once_with("watch message")
+
+
+@pytest.mark.asyncio
+async def test_send_watch_alert_to_n8n_skips_when_webhook_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "N8N_WATCH_ALERT_WEBHOOK_URL", "")
+
+    result = await OpenClawClient().send_watch_alert_to_n8n(
+        message="watch message",
+        market="crypto",
+        triggered=[{"symbol": "BTC", "condition_type": "price_above"}],
+        as_of="2026-04-17T00:00:00+09:00",
+        correlation_id="corr-watch-skip",
+    )
+
+    assert result.status == "skipped"
+    assert result.reason == "n8n_webhook_not_configured"
+    assert result.request_id is None
+
+
+@pytest.mark.asyncio
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_watch_alert_to_n8n_posts_payload(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        settings,
+        "N8N_WATCH_ALERT_WEBHOOK_URL",
+        "http://127.0.0.1:5678/webhook/watch-alert",
+    )
+
+    mock_cli = AsyncMock()
+    mock_res = MagicMock(status_code=200)
+    mock_res.raise_for_status.return_value = None
+    mock_cli.post.return_value = mock_res
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    result = await OpenClawClient().send_watch_alert_to_n8n(
+        message="watch summary",
+        market="kr",
+        triggered=[
+            {
+                "symbol": "005930",
+                "condition_type": "price_below",
+                "threshold": 70000,
+                "current": 69000,
+            }
+        ],
+        as_of="2026-04-17T09:30:00+09:00",
+        correlation_id="corr-watch-ok",
+    )
+
+    assert result.status == "success"
+    assert result.reason is None
+    assert result.request_id is not None
+    called_url = mock_cli.post.call_args.args[0]
+    called_json = mock_cli.post.call_args.kwargs["json"]
+    assert called_url == "http://127.0.0.1:5678/webhook/watch-alert"
+    assert called_json["alert_type"] == "watch"
+    assert called_json["correlation_id"] == "corr-watch-ok"
+    assert called_json["as_of"] == "2026-04-17T09:30:00+09:00"
+    assert called_json["market"] == "kr"
+    assert called_json["triggered"] == [
+        {
+            "symbol": "005930",
+            "condition_type": "price_below",
+            "threshold": 70000,
+            "current": 69000,
+        }
+    ]
+    assert called_json["message"] == "watch summary"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("zero_delay_openclaw_retry_wait")
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_watch_alert_to_n8n_returns_failed_on_retries_exhausted(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        settings,
+        "N8N_WATCH_ALERT_WEBHOOK_URL",
+        "http://127.0.0.1:5678/webhook/watch-alert",
+    )
+
+    mock_cli = AsyncMock()
+    mock_res_fail = MagicMock()
+    mock_res_fail.raise_for_status.side_effect = Exception("watch 5xx")
+    mock_cli.post.return_value = mock_res_fail
+
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    result = await OpenClawClient().send_watch_alert_to_n8n(
+        message="watch summary",
+        market="crypto",
+        triggered=[{"symbol": "BTC", "condition_type": "price_above"}],
+        as_of="2026-04-17T00:00:00+09:00",
+        correlation_id="corr-watch-fail",
+    )
+
+    assert result.status == "failed"
+    assert result.reason == "request_failed"
+    assert result.request_id is None
+    assert mock_cli.post.call_count == 4
+
+
+def test_watch_alert_delivery_result_enforces_request_id_contract() -> None:
+    with pytest.raises(ValueError, match="success results require a request_id"):
+        WatchAlertDeliveryResult(status="success")
+
+    with pytest.raises(
+        ValueError,
+        match="request_id is only allowed for success results",
+    ):
+        WatchAlertDeliveryResult(status="failed", request_id="req-123")
 
 
 @pytest.mark.asyncio

--- a/tests/test_watch_scanner.py
+++ b/tests/test_watch_scanner.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from app.jobs.watch_scanner import WatchScanner
+from app.services.openclaw_client import WatchAlertDeliveryResult
 
 
 class _FakeWatchService:
@@ -30,17 +31,37 @@ class _FakeWatchService:
 
 
 class _FakeOpenClawClient:
-    def __init__(self, success: bool = True) -> None:
-        self._success = success
+    def __init__(self, status: str = "success") -> None:
+        self._status = status
         self.messages: list[str] = []
 
     async def send_scan_alert(self, message: str) -> str | None:
         self.messages.append(message)
-        return "scan-1" if self._success else None
+        return "scan-1" if self._status == "success" else None
 
     async def send_watch_alert(self, message: str) -> str | None:
         self.messages.append(message)
-        return "watch-1" if self._success else None
+        return "watch-1" if self._status == "success" else None
+
+    async def send_watch_alert_to_n8n(
+        self,
+        *,
+        message: str,
+        market: str,
+        triggered: list[dict[str, object]],
+        as_of: str,
+        correlation_id: str | None = None,
+    ) -> WatchAlertDeliveryResult:
+        _ = market, triggered, as_of, correlation_id
+        self.messages.append(message)
+        if self._status == "success":
+            return WatchAlertDeliveryResult(status="success", request_id="watch-1")
+        if self._status == "skipped":
+            return WatchAlertDeliveryResult(
+                status="skipped",
+                reason="n8n_webhook_not_configured",
+            )
+        return WatchAlertDeliveryResult(status="failed", reason="request_failed")
 
 
 @pytest.mark.asyncio
@@ -64,7 +85,7 @@ async def test_scan_market_sends_single_batched_message_and_removes_only_trigger
             },
         ]
     )
-    scanner._openclaw = _FakeOpenClawClient(success=True)
+    scanner._openclaw = _FakeOpenClawClient(status="success")
 
     monkeypatch.setattr(scanner, "_is_market_open", lambda market: True)
     monkeypatch.setattr(scanner, "_get_price", AsyncMock(return_value=90.0))
@@ -86,7 +107,7 @@ async def test_run_scans_all_markets_and_skips_closed_market(
 ) -> None:
     scanner = WatchScanner()
     scanner._watch_service = _FakeWatchService(rows=[])
-    scanner._openclaw = _FakeOpenClawClient(success=True)
+    scanner._openclaw = _FakeOpenClawClient(status="success")
 
     monkeypatch.setattr(scanner, "_is_market_open", lambda market: market != "us")
     monkeypatch.setattr(scanner, "_get_price", AsyncMock(return_value=None))
@@ -97,6 +118,7 @@ async def test_run_scans_all_markets_and_skips_closed_market(
     assert set(result.keys()) == {"crypto", "kr", "us"}
     assert result["us"] == {
         "market": "us",
+        "status": "skipped",
         "skipped": True,
         "reason": "market_closed",
     }
@@ -238,3 +260,58 @@ async def test_watch_scanner_uses_market_data_domain_service(
         period="day",
         count=200,
     )
+
+
+@pytest.mark.asyncio
+async def test_scan_market_keeps_watch_records_when_n8n_delivery_failed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = WatchScanner()
+    scanner._watch_service = _FakeWatchService(
+        rows=[
+            {
+                "symbol": "BTC",
+                "condition_type": "price_below",
+                "threshold": 100.0,
+                "field": "BTC:price_below:100",
+            }
+        ]
+    )
+    scanner._openclaw = _FakeOpenClawClient(status="failed")
+
+    monkeypatch.setattr(scanner, "_is_market_open", lambda market: True)
+    monkeypatch.setattr(scanner, "_get_price", AsyncMock(return_value=90.0))
+
+    result = await scanner.scan_market("crypto")
+
+    assert result["alerts_sent"] == 0
+    assert result["status"] == "failed"
+    assert scanner._watch_service.removed_fields == []
+
+
+@pytest.mark.asyncio
+async def test_scan_market_keeps_watch_records_when_n8n_delivery_skipped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = WatchScanner()
+    scanner._watch_service = _FakeWatchService(
+        rows=[
+            {
+                "symbol": "BTC",
+                "condition_type": "price_below",
+                "threshold": 100.0,
+                "field": "BTC:price_below:100",
+            }
+        ]
+    )
+    scanner._openclaw = _FakeOpenClawClient(status="skipped")
+
+    monkeypatch.setattr(scanner, "_is_market_open", lambda market: True)
+    monkeypatch.setattr(scanner, "_get_price", AsyncMock(return_value=90.0))
+
+    result = await scanner.scan_market("crypto")
+
+    assert result["alerts_sent"] == 0
+    assert result["status"] == "skipped"
+    assert result["reason"] == "n8n_webhook_not_configured"
+    assert scanner._watch_service.removed_fields == []


### PR DESCRIPTION
## Summary
- add `N8N_WATCH_ALERT_WEBHOOK_URL` config/env wiring
- implement `OpenClawClient.send_watch_alert_to_n8n()` with retry + structured result (`success|skipped|failed`)
- switch watch scanner delivery to n8n-first route with correlation metadata and explicit status/reason outputs
- keep watch records when n8n delivery is skipped/failed; only remove on success
- add/adjust tests for watch n8n delivery and scanner behavior

## Rollout (ROB-171 plan §8)
- follow plan sequence in [ROB-171 plan §8 rollout](/ROB/issues/ROB-171#document-plan)
- set `N8N_WATCH_ALERT_WEBHOOK_URL` first, validate webhook workflow, then enable operationally

## Verification
- `uv run pytest tests/test_openclaw_client.py tests/test_watch_scanner.py -v` (passed)
- `make lint` (fails on pre-existing unrelated `tests/test_sell_signal_service.py` Ruff errors)
- `make test` (large suite; observed pre-existing unrelated failure in `tests/test_crypto_composite_score.py::TestCryptoScreenStocksTvScreenerContract::test_screen_stocks_keeps_composite_fields_on_tvscreener_success`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable webhook URL for watch alert notifications separate from existing fill webhooks
  * Implemented watch alert delivery with retry logic and detailed status tracking (success/skipped/failed)
  * Enhanced watch scanner with structured outcome reporting and improved error messaging

* **Tests**
  * Added comprehensive test coverage for watch alert delivery and sell signal evaluation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->