### PR TITLE
feat(n8n): watch-alert webhook + Discord 라우팅 + dedupe (ROB-174)

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -93,6 +93,39 @@ docker exec auto_trader_n8n_prod n8n import:workflow \
 - **주기**: 15분 간격
 - **동작**: Upbit/KIS WebSocket heartbeat 파일을 읽어 비정상 상태 시 Discord 알림
 
+### Paperclip Watch Alert
+- **Export file**: `n8n/workflows/paperclip-watch-alert.json`
+- **Trigger**: Webhook `POST /webhook/watch-alert`
+- **동작**: auto_trader `OpenClawClient.send_watch_alert_to_n8n` ([ROB-173](/ROB/issues/ROB-173) / PR #540) 이 보내는 watch alert 페이로드를 받아 market (`crypto` / `kr` / `us`) 별 Discord 채널로 라우팅. `{market}:{symbol}:{condition_type}:{threshold}` fingerprint 를 workflow static data 에 저장해 **6시간 쿨다운** dedupe, 24시간 초과 엔트리는 GC.
+- **응답 계약**:
+  - 전송 성공 → `200 {"status":"sent","market":"...","sent_count":N,"deduped_count":M,...}`
+  - 전 항목 dedupe hit → `200 {"status":"deduped","sent_count":0,"deduped_count":N,...}`
+  - 잘못된 payload (unknown market, missing `triggered`, item 필드 누락) → `400 {"status":"error","error":"..."}`
+  - Discord 노드 실패 (5xx / 타임아웃) → `500 {"status":"error","error":"discord_send_failed",...}` — auto_trader 가 재시도 후 record 보존
+- **필수 credential (n8n UI 에서 수동 등록 후 import 된 workflow 에 매핑)**:
+
+  | market  | credential 이름                        | 소스 env 값                |
+  |---------|----------------------------------------|----------------------------|
+  | crypto  | `Discord Webhook - Watch Alert Crypto` | `DISCORD_WEBHOOK_CRYPTO`   |
+  | kr      | `Discord Webhook - Watch Alert KR`     | `DISCORD_WEBHOOK_KR`       |
+  | us      | `Discord Webhook - Watch Alert US`     | `DISCORD_WEBHOOK_US`       |
+
+  각 credential 은 n8n 의 `Discord Webhook account` 타입이며 `.env.prod` 에 저장된 URL 을 그대로 등록한다. Export 된 JSON 은 `REPLACE_WITH_DISCORD_WEBHOOK_*` placeholder id 를 가지므로 import 후 반드시 UI 에서 credential 을 재매핑할 것.
+- **auto_trader 연동**: `.env.prod` 의 `N8N_WATCH_ALERT_WEBHOOK_URL=http://localhost:5678/webhook/watch-alert` 세팅 후 API 재시작. webhook URL 은 PR #540 / [ROB-173](/ROB/issues/ROB-173) 에서 서버측 수신 경로에 이미 연결되어 있다.
+- **검증 (import 후 로컬)**:
+  ```bash
+  # 정상 전송 (crypto) → 200 sent
+  curl -sS -X POST http://127.0.0.1:5678/webhook/watch-alert \
+    -H 'content-type: application/json' \
+    -d '{"alert_type":"watch","correlation_id":"00000000-0000-0000-0000-000000000001","as_of":"2026-04-17T00:00:00Z","market":"crypto","triggered":[{"symbol":"AAVE","condition_type":"rsi_above","threshold":70.0,"current":73.12}],"message":"Watch alerts (crypto)\n- AAVE rsi_above: current=73.1200, threshold=70.0000"}'
+
+  # 동일 fingerprint 재전송 → 200 deduped
+  # market 오타 → 400
+  curl -sS -o /dev/null -w '%{http_code}\n' -X POST http://127.0.0.1:5678/webhook/watch-alert \
+    -H 'content-type: application/json' \
+    -d '{"alert_type":"watch","correlation_id":"x","as_of":"2026-04-17T00:00:00Z","market":"nyse","triggered":[{"symbol":"AAPL","condition_type":"rsi_above","threshold":70,"current":80}],"message":"x"}'
+  ```
+
 ## 런타임 계약
 
 n8n은 낮부 전용으로 `127.0.0.1:5678`에 고정 바인딩됩니다.

--- a/n8n/workflows/paperclip-watch-alert.json
+++ b/n8n/workflows/paperclip-watch-alert.json
@@ -1,0 +1,432 @@
+{
+  "id": "paperclip-watch-alert",
+  "name": "Paperclip Watch Alert",
+  "nodes": [
+    {
+      "parameters": {
+        "httpMethod": "POST",
+        "path": "watch-alert",
+        "responseMode": "responseNode",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [
+        0,
+        0
+      ],
+      "id": "wa-webhook",
+      "name": "Watch Alert Webhook",
+      "webhookId": "watch-alert"
+    },
+    {
+      "parameters": {
+        "jsCode": "// Validate + dedupe + build message for Paperclip Watch Alert workflow.\n//\n// Input: webhook JSON body with shape\n//   { alert_type, correlation_id, as_of, market, triggered:[{symbol,condition_type,threshold,current}], message }\n// Output (single item) with `route` keyed by the Switch node:\n//   route = 'invalid' | 'deduped' | 'crypto' | 'kr' | 'us'\nconst input = $input.first().json || {};\nconst body = (input.body && typeof input.body === 'object') ? input.body : input;\n\nconst staticData = $getWorkflowStaticData('global');\nif (!staticData.sentMap || typeof staticData.sentMap !== 'object') staticData.sentMap = {};\nconst sentMap = staticData.sentMap;\n\nconst nowMs = Date.now();\nconst COOLDOWN_MS = 6 * 60 * 60 * 1000;\nconst GC_AGE_MS = 24 * 60 * 60 * 1000;\nconst ALLOWED_MARKETS = ['crypto', 'kr', 'us'];\n\n// GC entries older than 24h so the static map does not grow unbounded.\nfor (const key of Object.keys(sentMap)) {\n  const entry = sentMap[key];\n  if (!entry || typeof entry !== 'object') {\n    delete sentMap[key];\n    continue;\n  }\n  const lastSentAt = Number(entry.lastSentAt || 0);\n  if (!lastSentAt || (nowMs - lastSentAt) > GC_AGE_MS) delete sentMap[key];\n}\n\nconst correlationId = typeof body.correlation_id === 'string' ? body.correlation_id : null;\nconst asOf = typeof body.as_of === 'string' ? body.as_of : null;\nconst market = String(body.market || '').trim().toLowerCase();\nconst triggered = Array.isArray(body.triggered) ? body.triggered : null;\nconst rawMessage = typeof body.message === 'string' ? body.message : '';\n\nfunction invalid(errorCode, detail) {\n  return [{\n    json: {\n      route: 'invalid',\n      errorCode,\n      detail: detail || null,\n      market: market || null,\n      correlationId,\n      asOf,\n      responseStatusCode: 400,\n      responseBody: JSON.stringify({\n        status: 'error',\n        error: errorCode,\n        detail: detail || null,\n        correlation_id: correlationId,\n      }),\n    },\n  }];\n}\n\nif (!ALLOWED_MARKETS.includes(market)) {\n  return invalid('unknown_market', `market must be one of ${ALLOWED_MARKETS.join(', ')}`);\n}\nif (!triggered || triggered.length === 0) {\n  return invalid('missing_triggered', 'triggered array is required and must be non-empty');\n}\n\nfor (const item of triggered) {\n  if (!item || typeof item !== 'object') {\n    return invalid('invalid_triggered_item', 'each triggered entry must be an object');\n  }\n  if (!item.symbol || !item.condition_type || item.threshold === undefined || item.threshold === null) {\n    return invalid('invalid_triggered_item', 'symbol/condition_type/threshold are required per item');\n  }\n}\n\nlet newItemCount = 0;\nconst fingerprints = triggered.map((item) => {\n  const symbol = String(item.symbol).trim();\n  const conditionType = String(item.condition_type).trim();\n  const threshold = item.threshold;\n  const fp = `${market}:${symbol}:${conditionType}:${threshold}`;\n  const previous = sentMap[fp];\n  const lastSentAt = previous && typeof previous === 'object' ? Number(previous.lastSentAt || 0) : 0;\n  const isNew = !lastSentAt || (nowMs - lastSentAt) > COOLDOWN_MS;\n  if (isNew) newItemCount += 1;\n  return { fp, isNew };\n});\n\nconst dedupedCount = fingerprints.length - newItemCount;\n\nif (newItemCount === 0) {\n  // Every triggered item is inside the 6h cooldown — noop but still 200.\n  return [{\n    json: {\n      route: 'deduped',\n      market,\n      correlationId,\n      asOf,\n      sentCount: 0,\n      dedupedCount,\n      responseStatusCode: 200,\n      responseBody: JSON.stringify({\n        status: 'deduped',\n        market,\n        sent_count: 0,\n        deduped_count: dedupedCount,\n        correlation_id: correlationId,\n      }),\n    },\n  }];\n}\n\n// Record send time for every fingerprint in this payload (including re-mentioned ones)\n// so the user does not re-receive them inside the cooldown window.\nfor (const { fp } of fingerprints) {\n  sentMap[fp] = { lastSentAt: nowMs };\n}\n\nconst footer = `\\n\\ncorrelation_id=${correlationId || 'unknown'}  as_of=${asOf || 'unknown'}`;\nconst discordContent = rawMessage ? `${rawMessage}${footer}` : `Watch alert (${market})${footer}`;\n\nreturn [{\n  json: {\n    route: market,\n    market,\n    correlationId,\n    asOf,\n    sentCount: newItemCount,\n    dedupedCount,\n    discordContent,\n    responseStatusCode: 200,\n    responseBody: JSON.stringify({\n      status: 'sent',\n      market,\n      sent_count: newItemCount,\n      deduped_count: dedupedCount,\n      correlation_id: correlationId,\n    }),\n  },\n}];\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        240,
+        0
+      ],
+      "id": "wa-process",
+      "name": "Validate & Dedupe"
+    },
+    {
+      "parameters": {
+        "rules": {
+          "values": [
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
+                },
+                "conditions": [
+                  {
+                    "id": "wa-rule-invalid",
+                    "leftValue": "={{ $json.route }}",
+                    "rightValue": "invalid",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "invalid"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
+                },
+                "conditions": [
+                  {
+                    "id": "wa-rule-deduped",
+                    "leftValue": "={{ $json.route }}",
+                    "rightValue": "deduped",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "deduped"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
+                },
+                "conditions": [
+                  {
+                    "id": "wa-rule-crypto",
+                    "leftValue": "={{ $json.route }}",
+                    "rightValue": "crypto",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "crypto"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
+                },
+                "conditions": [
+                  {
+                    "id": "wa-rule-kr",
+                    "leftValue": "={{ $json.route }}",
+                    "rightValue": "kr",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "kr"
+            },
+            {
+              "conditions": {
+                "options": {
+                  "caseSensitive": true,
+                  "leftValue": "",
+                  "typeValidation": "strict",
+                  "version": 3
+                },
+                "conditions": [
+                  {
+                    "id": "wa-rule-us",
+                    "leftValue": "={{ $json.route }}",
+                    "rightValue": "us",
+                    "operator": {
+                      "type": "string",
+                      "operation": "equals"
+                    }
+                  }
+                ],
+                "combinator": "and"
+              },
+              "renameOutput": true,
+              "outputKey": "us"
+            }
+          ]
+        },
+        "options": {
+          "fallbackOutput": "none"
+        }
+      },
+      "type": "n8n-nodes-base.switch",
+      "typeVersion": 3.2,
+      "position": [
+        500,
+        0
+      ],
+      "id": "wa-router",
+      "name": "Route by market"
+    },
+    {
+      "parameters": {
+        "authentication": "webhook",
+        "content": "={{ $json.discordContent }}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.discord",
+      "typeVersion": 2,
+      "position": [
+        780,
+        -80
+      ],
+      "id": "wa-discord-crypto",
+      "name": "Discord — Crypto",
+      "credentials": {
+        "discordWebhookApi": {
+          "id": "REPLACE_WITH_DISCORD_WEBHOOK_CRYPTO",
+          "name": "Discord Webhook - Watch Alert Crypto"
+        }
+      },
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "authentication": "webhook",
+        "content": "={{ $json.discordContent }}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.discord",
+      "typeVersion": 2,
+      "position": [
+        780,
+        80
+      ],
+      "id": "wa-discord-kr",
+      "name": "Discord — KR",
+      "credentials": {
+        "discordWebhookApi": {
+          "id": "REPLACE_WITH_DISCORD_WEBHOOK_KR",
+          "name": "Discord Webhook - Watch Alert KR"
+        }
+      },
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "authentication": "webhook",
+        "content": "={{ $json.discordContent }}",
+        "options": {}
+      },
+      "type": "n8n-nodes-base.discord",
+      "typeVersion": 2,
+      "position": [
+        780,
+        240
+      ],
+      "id": "wa-discord-us",
+      "name": "Discord — US",
+      "credentials": {
+        "discordWebhookApi": {
+          "id": "REPLACE_WITH_DISCORD_WEBHOOK_US",
+          "name": "Discord Webhook - Watch Alert US"
+        }
+      },
+      "onError": "continueErrorOutput"
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $('Validate & Dedupe').item.json.responseBody }}",
+        "options": {
+          "responseCode": 400
+        }
+      },
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        780,
+        -240
+      ],
+      "id": "wa-respond-400",
+      "name": "Respond 400"
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $('Validate & Dedupe').item.json.responseBody }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        780,
+        -160
+      ],
+      "id": "wa-respond-200-deduped",
+      "name": "Respond 200 (deduped)"
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ $('Validate & Dedupe').item.json.responseBody }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        1060,
+        -80
+      ],
+      "id": "wa-respond-200-sent",
+      "name": "Respond 200 (sent)"
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ status: 'error', error: 'discord_send_failed', detail: ($json.error && $json.error.message) || $json.message || 'discord node failure', market: $('Validate & Dedupe').item.json.market, correlation_id: $('Validate & Dedupe').item.json.correlationId }) }}",
+        "options": {
+          "responseCode": 500
+        }
+      },
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [
+        1060,
+        240
+      ],
+      "id": "wa-respond-500",
+      "name": "Respond 500"
+    }
+  ],
+  "connections": {
+    "Watch Alert Webhook": {
+      "main": [
+        [
+          {
+            "node": "Validate & Dedupe",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Validate & Dedupe": {
+      "main": [
+        [
+          {
+            "node": "Route by market",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Route by market": {
+      "main": [
+        [
+          {
+            "node": "Respond 400",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond 200 (deduped)",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Discord — Crypto",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Discord — KR",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Discord — US",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord — Crypto": {
+      "main": [
+        [
+          {
+            "node": "Respond 200 (sent)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ],
+      "error": [
+        [
+          {
+            "node": "Respond 500",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord — KR": {
+      "main": [
+        [
+          {
+            "node": "Respond 200 (sent)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ],
+      "error": [
+        [
+          {
+            "node": "Respond 500",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord — US": {
+      "main": [
+        [
+          {
+            "node": "Respond 200 (sent)",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ],
+      "error": [
+        [
+          {
+            "node": "Respond 500",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  }
+}

--- a/n8n/workflows/paperclip-watch-alert.json
+++ b/n8n/workflows/paperclip-watch-alert.json
@@ -21,7 +21,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Validate + dedupe + build message for Paperclip Watch Alert workflow.\n//\n// Input: webhook JSON body with shape\n//   { alert_type, correlation_id, as_of, market, triggered:[{symbol,condition_type,threshold,current}], message }\n// Output (single item) with `route` keyed by the Switch node:\n//   route = 'invalid' | 'deduped' | 'crypto' | 'kr' | 'us'\nconst input = $input.first().json || {};\nconst body = (input.body && typeof input.body === 'object') ? input.body : input;\n\nconst staticData = $getWorkflowStaticData('global');\nif (!staticData.sentMap || typeof staticData.sentMap !== 'object') staticData.sentMap = {};\nconst sentMap = staticData.sentMap;\n\nconst nowMs = Date.now();\nconst COOLDOWN_MS = 6 * 60 * 60 * 1000;\nconst GC_AGE_MS = 24 * 60 * 60 * 1000;\nconst ALLOWED_MARKETS = ['crypto', 'kr', 'us'];\n\n// GC entries older than 24h so the static map does not grow unbounded.\nfor (const key of Object.keys(sentMap)) {\n  const entry = sentMap[key];\n  if (!entry || typeof entry !== 'object') {\n    delete sentMap[key];\n    continue;\n  }\n  const lastSentAt = Number(entry.lastSentAt || 0);\n  if (!lastSentAt || (nowMs - lastSentAt) > GC_AGE_MS) delete sentMap[key];\n}\n\nconst correlationId = typeof body.correlation_id === 'string' ? body.correlation_id : null;\nconst asOf = typeof body.as_of === 'string' ? body.as_of : null;\nconst market = String(body.market || '').trim().toLowerCase();\nconst triggered = Array.isArray(body.triggered) ? body.triggered : null;\nconst rawMessage = typeof body.message === 'string' ? body.message : '';\n\nfunction invalid(errorCode, detail) {\n  return [{\n    json: {\n      route: 'invalid',\n      errorCode,\n      detail: detail || null,\n      market: market || null,\n      correlationId,\n      asOf,\n      responseStatusCode: 400,\n      responseBody: JSON.stringify({\n        status: 'error',\n        error: errorCode,\n        detail: detail || null,\n        correlation_id: correlationId,\n      }),\n    },\n  }];\n}\n\nif (!ALLOWED_MARKETS.includes(market)) {\n  return invalid('unknown_market', `market must be one of ${ALLOWED_MARKETS.join(', ')}`);\n}\nif (!triggered || triggered.length === 0) {\n  return invalid('missing_triggered', 'triggered array is required and must be non-empty');\n}\n\nfor (const item of triggered) {\n  if (!item || typeof item !== 'object') {\n    return invalid('invalid_triggered_item', 'each triggered entry must be an object');\n  }\n  if (!item.symbol || !item.condition_type || item.threshold === undefined || item.threshold === null) {\n    return invalid('invalid_triggered_item', 'symbol/condition_type/threshold are required per item');\n  }\n}\n\nlet newItemCount = 0;\nconst fingerprints = triggered.map((item) => {\n  const symbol = String(item.symbol).trim();\n  const conditionType = String(item.condition_type).trim();\n  const threshold = item.threshold;\n  const fp = `${market}:${symbol}:${conditionType}:${threshold}`;\n  const previous = sentMap[fp];\n  const lastSentAt = previous && typeof previous === 'object' ? Number(previous.lastSentAt || 0) : 0;\n  const isNew = !lastSentAt || (nowMs - lastSentAt) > COOLDOWN_MS;\n  if (isNew) newItemCount += 1;\n  return { fp, isNew };\n});\n\nconst dedupedCount = fingerprints.length - newItemCount;\n\nif (newItemCount === 0) {\n  // Every triggered item is inside the 6h cooldown — noop but still 200.\n  return [{\n    json: {\n      route: 'deduped',\n      market,\n      correlationId,\n      asOf,\n      sentCount: 0,\n      dedupedCount,\n      responseStatusCode: 200,\n      responseBody: JSON.stringify({\n        status: 'deduped',\n        market,\n        sent_count: 0,\n        deduped_count: dedupedCount,\n        correlation_id: correlationId,\n      }),\n    },\n  }];\n}\n\n// Record send time for every fingerprint in this payload (including re-mentioned ones)\n// so the user does not re-receive them inside the cooldown window.\nfor (const { fp } of fingerprints) {\n  sentMap[fp] = { lastSentAt: nowMs };\n}\n\nconst footer = `\\n\\ncorrelation_id=${correlationId || 'unknown'}  as_of=${asOf || 'unknown'}`;\nconst discordContent = rawMessage ? `${rawMessage}${footer}` : `Watch alert (${market})${footer}`;\n\nreturn [{\n  json: {\n    route: market,\n    market,\n    correlationId,\n    asOf,\n    sentCount: newItemCount,\n    dedupedCount,\n    discordContent,\n    responseStatusCode: 200,\n    responseBody: JSON.stringify({\n      status: 'sent',\n      market,\n      sent_count: newItemCount,\n      deduped_count: dedupedCount,\n      correlation_id: correlationId,\n    }),\n  },\n}];\n"
+        "jsCode": "// Validate + dedupe + build message for Paperclip Watch Alert workflow.\n//\n// Input: webhook JSON body with shape\n//   { alert_type, correlation_id, as_of, market, triggered:[{symbol,condition_type,threshold,current}], message }\n// Output (single item) with `route` keyed by the Switch node:\n//   route = 'invalid' | 'deduped' | 'crypto' | 'kr' | 'us'\n//\n// IMPORTANT: sentMap is only READ here. The actual write happens in the `Mark Sent`\n// code node AFTER Discord delivery succeeds, so a Discord 5xx → auto_trader retry\n// can re-evaluate the payload and re-deliver instead of silently deduping.\nconst input = $input.first().json || {};\nconst body = (input.body && typeof input.body === 'object') ? input.body : input;\n\nconst staticData = $getWorkflowStaticData('global');\nif (!staticData.sentMap || typeof staticData.sentMap !== 'object') staticData.sentMap = {};\nconst sentMap = staticData.sentMap;\n\nconst nowMs = Date.now();\nconst COOLDOWN_MS = 6 * 60 * 60 * 1000;\nconst GC_AGE_MS = 24 * 60 * 60 * 1000;\nconst ALLOWED_MARKETS = ['crypto', 'kr', 'us'];\n\n// GC entries older than 24h so the static map does not grow unbounded.\nfor (const key of Object.keys(sentMap)) {\n  const entry = sentMap[key];\n  if (!entry || typeof entry !== 'object') {\n    delete sentMap[key];\n    continue;\n  }\n  const lastSentAt = Number(entry.lastSentAt || 0);\n  if (!lastSentAt || (nowMs - lastSentAt) > GC_AGE_MS) delete sentMap[key];\n}\n\nconst correlationId = typeof body.correlation_id === 'string' ? body.correlation_id : null;\nconst asOf = typeof body.as_of === 'string' ? body.as_of : null;\nconst market = String(body.market || '').trim().toLowerCase();\nconst triggered = Array.isArray(body.triggered) ? body.triggered : null;\nconst rawMessage = typeof body.message === 'string' ? body.message : '';\n\nfunction invalid(errorCode, detail) {\n  return [{\n    json: {\n      route: 'invalid',\n      errorCode,\n      detail: detail || null,\n      market: market || null,\n      correlationId,\n      asOf,\n      responseStatusCode: 400,\n      responseBody: JSON.stringify({\n        status: 'error',\n        error: errorCode,\n        detail: detail || null,\n        correlation_id: correlationId,\n      }),\n    },\n  }];\n}\n\nif (!ALLOWED_MARKETS.includes(market)) {\n  return invalid('unknown_market', `market must be one of ${ALLOWED_MARKETS.join(', ')}`);\n}\nif (!triggered || triggered.length === 0) {\n  return invalid('missing_triggered', 'triggered array is required and must be non-empty');\n}\n\nfor (const item of triggered) {\n  if (!item || typeof item !== 'object') {\n    return invalid('invalid_triggered_item', 'each triggered entry must be an object');\n  }\n  if (!item.symbol || !item.condition_type || item.threshold === undefined || item.threshold === null) {\n    return invalid('invalid_triggered_item', 'symbol/condition_type/threshold are required per item');\n  }\n  const thresholdType = typeof item.threshold;\n  if (thresholdType !== 'number' && thresholdType !== 'string') {\n    return invalid('invalid_triggered_item', 'threshold must be a number or string');\n  }\n}\n\nlet newItemCount = 0;\nconst fingerprints = triggered.map((item) => {\n  const symbol = String(item.symbol).trim();\n  const conditionType = String(item.condition_type).trim();\n  const threshold = item.threshold;\n  const fp = `${market}:${symbol}:${conditionType}:${threshold}`;\n  const previous = sentMap[fp];\n  const lastSentAt = previous && typeof previous === 'object' ? Number(previous.lastSentAt || 0) : 0;\n  const isNew = !lastSentAt || (nowMs - lastSentAt) > COOLDOWN_MS;\n  if (isNew) newItemCount += 1;\n  return { fp, isNew };\n});\n\nconst dedupedCount = fingerprints.length - newItemCount;\n\nif (newItemCount === 0) {\n  // Every triggered item is inside the 6h cooldown — noop but still 200.\n  // No sentMap write here: entries already have lastSentAt recorded from the\n  // prior successful delivery.\n  return [{\n    json: {\n      route: 'deduped',\n      market,\n      correlationId,\n      asOf,\n      sentCount: 0,\n      dedupedCount,\n      fingerprints,\n      responseStatusCode: 200,\n      responseBody: JSON.stringify({\n        status: 'deduped',\n        market,\n        sent_count: 0,\n        deduped_count: dedupedCount,\n        correlation_id: correlationId,\n      }),\n    },\n  }];\n}\n\nconst footer = `\\n\\ncorrelation_id=${correlationId || 'unknown'}  as_of=${asOf || 'unknown'}`;\nconst discordContent = rawMessage ? `${rawMessage}${footer}` : `Watch alert (${market})${footer}`;\n\nreturn [{\n  json: {\n    route: market,\n    market,\n    correlationId,\n    asOf,\n    sentCount: newItemCount,\n    dedupedCount,\n    discordContent,\n    fingerprints,\n    responseStatusCode: 200,\n    responseBody: JSON.stringify({\n      status: 'sent',\n      market,\n      sent_count: newItemCount,\n      deduped_count: dedupedCount,\n      correlation_id: correlationId,\n    }),\n  },\n}];\n"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
@@ -273,6 +273,19 @@
     },
     {
       "parameters": {
+        "jsCode": "// Record fingerprint send times AFTER Discord delivery succeeds.\n// This runs only on the Discord main (success) output path, so a Discord 5xx\n// routes around this node into `Respond 500` and leaves sentMap untouched,\n// letting auto_trader retry re-deliver the alert.\nconst upstream = $('Validate & Dedupe').item.json || {};\nconst fingerprints = Array.isArray(upstream.fingerprints) ? upstream.fingerprints : [];\nconst nowMs = Date.now();\n\nconst staticData = $getWorkflowStaticData('global');\nif (!staticData.sentMap || typeof staticData.sentMap !== 'object') staticData.sentMap = {};\nconst sentMap = staticData.sentMap;\n\n// Refresh every fingerprint in the payload (new + re-mentioned) so the user\n// does not re-receive the same alert inside the 6h cooldown.\nfor (const entry of fingerprints) {\n  if (!entry || typeof entry !== 'object' || !entry.fp) continue;\n  sentMap[entry.fp] = { lastSentAt: nowMs };\n}\n\nreturn $input.all();\n"
+      },
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [
+        920,
+        80
+      ],
+      "id": "wa-mark-sent",
+      "name": "Mark Sent"
+    },
+    {
+      "parameters": {
         "respondWith": "json",
         "responseBody": "={{ $('Validate & Dedupe').item.json.responseBody }}",
         "options": {
@@ -372,7 +385,7 @@
       "main": [
         [
           {
-            "node": "Respond 200 (sent)",
+            "node": "Mark Sent",
             "type": "main",
             "index": 0
           }
@@ -392,7 +405,7 @@
       "main": [
         [
           {
-            "node": "Respond 200 (sent)",
+            "node": "Mark Sent",
             "type": "main",
             "index": 0
           }
@@ -412,7 +425,7 @@
       "main": [
         [
           {
-            "node": "Respond 200 (sent)",
+            "node": "Mark Sent",
             "type": "main",
             "index": 0
           }
@@ -422,6 +435,17 @@
         [
           {
             "node": "Respond 500",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Mark Sent": {
+      "main": [
+        [
+          {
+            "node": "Respond 200 (sent)",
             "type": "main",
             "index": 0
           }

--- a/tests/test_n8n_watch_alert_workflow.py
+++ b/tests/test_n8n_watch_alert_workflow.py
@@ -1,0 +1,253 @@
+"""Regression tests for the `paperclip-watch-alert.json` n8n workflow.
+
+Reason this file exists: when the reviewer caught ROB-178 PR #541 v1, the Validate
+& Dedupe node wrote `sentMap` before Discord actually sent. A Discord 5xx combined
+with auto_trader retry therefore silently deduped the second attempt and the alert
+was lost. The fix defers the `sentMap` write into a new `Mark Sent` code node that
+runs only on the Discord success branch.
+
+These tests shell out to `node` (following the existing
+`tests/test_n8n_tc_briefing_discord.py` pattern) to execute the embedded jsCode
+against a fake `$getWorkflowStaticData` / `$input` harness.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+WORKFLOW_PATH = Path("n8n/workflows/paperclip-watch-alert.json")
+
+NODE_REQUIRED = shutil.which("node") is not None
+pytestmark = pytest.mark.skipif(
+    not NODE_REQUIRED, reason="node runtime required to execute embedded jsCode"
+)
+
+
+def _node_for(workflow: dict, node_id: str) -> dict:
+    return next(node for node in workflow["nodes"] if node["id"] == node_id)
+
+
+def _run_js_pipeline(static_data: dict, payload: dict) -> dict:
+    """Runs Validate & Dedupe then (conditionally) Mark Sent against `payload`.
+
+    Returns a dict:
+        {
+            "validate_output": <json from Validate & Dedupe>,
+            "static_data_after_validate": <sentMap snapshot before Mark Sent>,
+            "mark_sent_ran": <bool>,
+            "static_data_after_mark": <sentMap snapshot after Mark Sent — same as
+                                        after_validate when mark_sent_ran=False>,
+        }
+    """
+    workflow = json.loads(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    validate_code = _node_for(workflow, "wa-process")["parameters"]["jsCode"]
+    mark_sent_code = _node_for(workflow, "wa-mark-sent")["parameters"]["jsCode"]
+
+    runner = r"""
+const fs = require('node:fs');
+const input = JSON.parse(fs.readFileSync(0, 'utf8'));
+
+function makeStaticAccessor(scope) {
+  return () => scope;
+}
+
+// Stage 1: Validate & Dedupe
+const staticScope = input.staticData;
+const getStatic = makeStaticAccessor(staticScope);
+const body = input.payload;
+const fn1 = new Function(
+  '$input', '$getWorkflowStaticData',
+  input.validateCode + '\n//# run; will return via `return [...]` inside the body'
+);
+// The embedded script uses top-level `return`. Wrap in IIFE via Function body.
+const validateFn = new Function(
+  '$input', '$getWorkflowStaticData',
+  '"use strict";\n' + input.validateCode
+);
+const validateOutput = validateFn(
+  { first: () => ({ json: body }) },
+  getStatic,
+);
+const validateJson = validateOutput[0].json;
+const staticAfterValidate = JSON.parse(JSON.stringify(staticScope));
+
+let markSentRan = false;
+let staticAfterMark = staticAfterValidate;
+if (['crypto', 'kr', 'us'].includes(validateJson.route)) {
+  markSentRan = true;
+  const markSentFn = new Function(
+    '$input', '$getWorkflowStaticData', '$',
+    '"use strict";\n' + input.markSentCode
+  );
+  const accessor = (name) => {
+    if (name === 'Validate & Dedupe') {
+      return { item: { json: validateJson } };
+    }
+    throw new Error(`unexpected \${name}`);
+  };
+  markSentFn(
+    { all: () => [{ json: validateJson }] },
+    getStatic,
+    accessor,
+  );
+  staticAfterMark = JSON.parse(JSON.stringify(staticScope));
+}
+
+process.stdout.write(JSON.stringify({
+  validate_output: validateJson,
+  static_data_after_validate: staticAfterValidate,
+  mark_sent_ran: markSentRan,
+  static_data_after_mark: staticAfterMark,
+}));
+"""
+
+    completed = subprocess.run(
+        ["node", "-e", runner],
+        input=json.dumps(
+            {
+                "staticData": static_data,
+                "payload": payload,
+                "validateCode": validate_code,
+                "markSentCode": mark_sent_code,
+            }
+        ),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(completed.stdout)
+
+
+def _base_payload(**overrides) -> dict:
+    payload = {
+        "correlation_id": "corr-123",
+        "as_of": "2026-04-17T03:47:00Z",
+        "market": "crypto",
+        "triggered": [
+            {
+                "symbol": "BTC/KRW",
+                "condition_type": "price_above",
+                "threshold": 100000000,
+                "current": 100500000,
+            }
+        ],
+        "message": "BTC breached 100M KRW",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_validate_dedupe_does_not_write_sentmap_on_sent_path() -> None:
+    """Blocking regression: sentMap must stay untouched until Mark Sent runs.
+
+    Otherwise a Discord 5xx causes auto_trader's retry to hit the deduped path
+    and the alert is lost.
+    """
+    result = _run_js_pipeline({"sentMap": {}}, _base_payload())
+
+    assert result["validate_output"]["route"] == "crypto"
+    assert result["static_data_after_validate"] == {"sentMap": {}}, (
+        "Validate & Dedupe must not write sentMap on the sent path"
+    )
+    # Fingerprints must be exposed for Mark Sent to consume.
+    fingerprints = result["validate_output"]["fingerprints"]
+    assert isinstance(fingerprints, list) and len(fingerprints) == 1
+    assert fingerprints[0]["fp"] == "crypto:BTC/KRW:price_above:100000000"
+    assert fingerprints[0]["isNew"] is True
+
+
+def test_mark_sent_records_fingerprints_after_discord_success() -> None:
+    """Mark Sent runs on the Discord success branch and writes sentMap."""
+    result = _run_js_pipeline({"sentMap": {}}, _base_payload())
+    assert result["mark_sent_ran"] is True
+    sent_map = result["static_data_after_mark"]["sentMap"]
+    assert "crypto:BTC/KRW:price_above:100000000" in sent_map
+    entry = sent_map["crypto:BTC/KRW:price_above:100000000"]
+    assert isinstance(entry["lastSentAt"], int) and entry["lastSentAt"] > 0
+
+
+def test_discord_failure_retry_redelivers_instead_of_deduping() -> None:
+    """Simulates the exact scenario the reviewer flagged:
+
+    1. Request 1 runs Validate & Dedupe, Discord fails — Mark Sent never runs.
+    2. auto_trader retries with the same payload.
+    3. Request 2 must still route to `crypto` (sent) — not `deduped`.
+    """
+    static_data: dict = {"sentMap": {}}
+
+    first = _run_js_pipeline(static_data, _base_payload())
+    assert first["validate_output"]["route"] == "crypto"
+    # Simulate Discord failure: we keep the sentMap from *before* Mark Sent.
+    static_after_failure = first["static_data_after_validate"]
+    assert static_after_failure == {"sentMap": {}}
+
+    second = _run_js_pipeline(static_after_failure, _base_payload())
+    assert second["validate_output"]["route"] == "crypto", (
+        "retry after Discord failure must still be routed as sent, not deduped"
+    )
+    assert second["validate_output"]["sentCount"] == 1
+
+
+def test_second_delivery_within_cooldown_dedupes() -> None:
+    """After a successful delivery + Mark Sent, an identical payload dedupes."""
+    first = _run_js_pipeline({"sentMap": {}}, _base_payload())
+    assert first["mark_sent_ran"] is True
+
+    static_after_success = first["static_data_after_mark"]
+    second = _run_js_pipeline(static_after_success, _base_payload())
+
+    assert second["validate_output"]["route"] == "deduped"
+    assert second["validate_output"]["sentCount"] == 0
+    assert second["validate_output"]["dedupedCount"] == 1
+    assert second["mark_sent_ran"] is False
+
+
+def test_invalid_payloads_return_400_without_touching_sentmap() -> None:
+    result = _run_js_pipeline(
+        {"sentMap": {}},
+        _base_payload(market="forex"),
+    )
+    assert result["validate_output"]["route"] == "invalid"
+    assert result["validate_output"]["responseStatusCode"] == 400
+    assert result["static_data_after_validate"] == {"sentMap": {}}
+    assert result["mark_sent_ran"] is False
+
+
+def test_threshold_type_guard_rejects_non_scalar() -> None:
+    result = _run_js_pipeline(
+        {"sentMap": {}},
+        _base_payload(
+            triggered=[
+                {
+                    "symbol": "BTC/KRW",
+                    "condition_type": "price_above",
+                    "threshold": {"value": 1},
+                }
+            ]
+        ),
+    )
+    assert result["validate_output"]["route"] == "invalid"
+    assert result["validate_output"]["errorCode"] == "invalid_triggered_item"
+
+
+def test_discord_success_outputs_route_through_mark_sent_node() -> None:
+    """Structural guard: every Discord main output must funnel into Mark Sent.
+
+    Catches a future refactor that accidentally re-wires a Discord node straight
+    back to `Respond 200 (sent)` and reintroduces the bug.
+    """
+    workflow = json.loads(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    for discord_id in ("Discord — Crypto", "Discord — KR", "Discord — US"):
+        main = workflow["connections"][discord_id]["main"][0]
+        assert len(main) == 1
+        assert main[0]["node"] == "Mark Sent", (
+            f"{discord_id} main output must go through Mark Sent, not {main[0]['node']}"
+        )
+    mark_main = workflow["connections"]["Mark Sent"]["main"][0]
+    assert len(mark_main) == 1
+    assert mark_main[0]["node"] == "Respond 200 (sent)"


### PR DESCRIPTION
## Summary
- Adds `n8n/workflows/paperclip-watch-alert.json` implementing the watch-alert webhook receiver: `POST /webhook/watch-alert` → validate → 6h fingerprint dedupe (workflow static data) → Switch(`market`) → `crypto` / `kr` / `us` Discord channels.
- Pairs with PR #540 / [ROB-173](/ROB/issues/ROB-173) — auto_trader already posts to this webhook (once `N8N_WATCH_ALERT_WEBHOOK_URL` is set).
- Response contract (matches auto_trader retry behavior in PR #540):
  - `200 {"status":"sent",...}` on success
  - `200 {"status":"deduped",...}` when every triggered fingerprint is in 6h cooldown (no-op)
  - `400` on unknown `market` / missing `triggered` / malformed item
  - `500 {"error":"discord_send_failed",...}` on Discord 5xx / timeout so auto_trader retries and preserves the record
- Fingerprint key: `{market}:{symbol}:{condition_type}:{threshold}`. Entries older than 24h GC'd on next run.
- README updated with workflow description, Discord credential mapping, env wiring, and local curl verification recipes.

## Files
- `n8n/workflows/paperclip-watch-alert.json` (new)
- `n8n/README.md` — "Paperclip Watch Alert" section added under workflow list.

## Credential mapping (done manually in n8n UI after import)
| market  | credential name                        | source env              |
|---------|----------------------------------------|-------------------------|
| crypto  | `Discord Webhook - Watch Alert Crypto` | `DISCORD_WEBHOOK_CRYPTO` |
| kr      | `Discord Webhook - Watch Alert KR`     | `DISCORD_WEBHOOK_KR`     |
| us      | `Discord Webhook - Watch Alert US`     | `DISCORD_WEBHOOK_US`     |

Exported JSON carries `REPLACE_WITH_DISCORD_WEBHOOK_*` placeholder credential IDs. Re-map them in the n8n UI after import (both `id` and `name` resolve through the n8n credentials store).

## Test plan
Local curl verification is documented in the README; intended to be run after import into the n8n container by whoever operates the import step:

- [ ] `docker exec auto_trader_n8n_prod n8n import:workflow --input=/home/node/.n8n/workflows/paperclip-watch-alert.json`
- [ ] Create/attach 3 Discord webhook credentials (crypto/kr/us) in the n8n UI and re-map the Discord nodes.
- [ ] `POST /webhook/watch-alert` with a valid crypto payload → Discord message delivered, response `200 {status:sent,...}`.
- [ ] Re-send the same payload → response `200 {status:deduped,...}` and **no** Discord message.
- [ ] `POST` with `market:"nyse"` → response `400 {error:unknown_market,...}`.
- [ ] `POST` with empty `triggered:[]` → response `400 {error:missing_triggered,...}`.
- [ ] Temporarily swap a Discord credential to an invalid webhook URL → response `500 {error:discord_send_failed,...}` and confirm auto_trader's n8n-first retry path (PR #540) records the failure without swallowing the alert.

## Out of scope
- `.env.prod` wiring of `N8N_WATCH_ALERT_WEBHOOK_URL` (follow-up after PR #540 merges)
- Hermes follow-up fan-out
- Any changes to `fill-webhook` / `daily-scan` workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)