### PR TITLE
fix(probe): manager_followup_needed false-positive 제거 (ROB-181)

### DIFF
--- a/scripts/paperclip_cli_probe.py
+++ b/scripts/paperclip_cli_probe.py
@@ -19,6 +19,10 @@ import httpx
 
 ACTIVE_ISSUE_STATUSES = {"in_progress", "blocked"}
 OPTIONAL_PENDING_STATUSES = {"backlog", "todo"}
+# Child statuses that warrant a manager_followup_needed signal on the parent.
+# Lane handoffs (in_review) and in-lane work (in_progress) are excluded
+# because they do not require the parent owner to rerun or intervene.
+MANAGER_FOLLOWUP_CHILD_STATUSES = {"done", "blocked"}
 NON_FATAL_ERROR_CODES = {"auth_bootstrap_required"}
 REVIEW_GRACE_PERIOD = timedelta(minutes=30)
 DEFAULT_HEARTBEAT_RUN_LIMIT = 50
@@ -468,49 +472,62 @@ def derive_boss_queue_items(
         assignee_agent_id = issue.get("assigneeAgentId")
 
         # manager_followup_needed
+        # Only in_progress parents are eligible. A `blocked` parent is waiting
+        # on an external blocker to resolve, so child updates alone should not
+        # wake the parent owner (see ROB-181 / ROB-166 false-positive).
         if (
             isinstance(issue_id, str)
-            and is_active_issue_status(status, include_backlog=False)
+            and status.strip().lower() == "in_progress"
             and isinstance(assignee_agent_id, str)
             and assignee_agent_id in agents
             and child_issues.get(issue_id)
         ):
-            agent = agents[assignee_agent_id]
-            last_heartbeat_at = parse_timestamp(agent.get("lastHeartbeatAt"))
-            latest_child_update = max(
-                (
-                    parse_timestamp(child.get("updatedAt"))
-                    for child in child_issues[issue_id]
-                    if parse_timestamp(child.get("updatedAt")) is not None
-                ),
-                default=None,
-            )
-            if latest_child_update and (
-                last_heartbeat_at is None or latest_child_update > last_heartbeat_at
-            ):
-                owner = str(agent.get("name") or assignee_agent_id)
-                items.append(
-                    {
-                        "fingerprint": fingerprint_for_item(
-                            "manager_followup_needed",
-                            identifier or issue_id,
-                            latest_child_update.isoformat(),
-                        ),
-                        "kind": "manager_followup_needed",
-                        "severity": "critical",
-                        "owner": owner,
-                        "issue_identifier": identifier,
-                        "title": title,
-                        "summary": "자식 이슈 업데이트가 assignee 마지막 heartbeat보다 최신",
-                        "evidence": {
-                            "latest_child_update": latest_child_update.isoformat(),
-                            "last_heartbeat_at": last_heartbeat_at.isoformat()
-                            if last_heartbeat_at
-                            else None,
-                        },
-                        "recommended_action": f"{owner} 재실행 또는 parent issue 확인",
-                    }
+            # Only count children in states that require parent follow-up.
+            # `in_review` and `in_progress` children represent lane handoff or
+            # in-lane work and must not trigger a rerun signal.
+            actionable_children = [
+                child
+                for child in child_issues[issue_id]
+                if str(child.get("status") or "").strip().lower()
+                in MANAGER_FOLLOWUP_CHILD_STATUSES
+            ]
+            if actionable_children:
+                agent = agents[assignee_agent_id]
+                last_heartbeat_at = parse_timestamp(agent.get("lastHeartbeatAt"))
+                latest_child_update = max(
+                    (
+                        parse_timestamp(child.get("updatedAt"))
+                        for child in actionable_children
+                        if parse_timestamp(child.get("updatedAt")) is not None
+                    ),
+                    default=None,
                 )
+                if latest_child_update and (
+                    last_heartbeat_at is None or latest_child_update > last_heartbeat_at
+                ):
+                    owner = str(agent.get("name") or assignee_agent_id)
+                    items.append(
+                        {
+                            "fingerprint": fingerprint_for_item(
+                                "manager_followup_needed",
+                                identifier or issue_id,
+                                latest_child_update.isoformat(),
+                            ),
+                            "kind": "manager_followup_needed",
+                            "severity": "critical",
+                            "owner": owner,
+                            "issue_identifier": identifier,
+                            "title": title,
+                            "summary": "자식 이슈 업데이트가 assignee 마지막 heartbeat보다 최신",
+                            "evidence": {
+                                "latest_child_update": latest_child_update.isoformat(),
+                                "last_heartbeat_at": last_heartbeat_at.isoformat()
+                                if last_heartbeat_at
+                                else None,
+                            },
+                            "recommended_action": f"{owner} 재실행 또는 parent issue 확인",
+                        }
+                    )
 
         # active_issue_unassigned
         if (

--- a/tests/test_paperclip_cli_probe.py
+++ b/tests/test_paperclip_cli_probe.py
@@ -184,7 +184,7 @@ def test_derive_manager_followup_needed_when_child_newer_than_assignee_heartbeat
                 "id": "c1",
                 "identifier": "ROB-52",
                 "title": "Child",
-                "status": "in_progress",
+                "status": "done",
                 "parentId": "p1",
                 "assigneeAgentId": None,
                 "updatedAt": "2026-04-15T10:58:24+09:00",
@@ -208,6 +208,109 @@ def test_derive_manager_followup_needed_when_child_newer_than_assignee_heartbeat
     )
 
     assert warnings == []
+    assert any(item["kind"] == "manager_followup_needed" for item in items)
+
+
+def _manager_followup_snapshot(
+    *,
+    parent_status: str,
+    child_status: str,
+    parent_updated_at: str = "2026-04-15T10:57:47+09:00",
+    child_updated_at: str = "2026-04-15T10:58:24+09:00",
+    last_heartbeat_at: str = "2026-04-15T10:54:16+09:00",
+) -> dict:
+    return {
+        "issues": [
+            {
+                "id": "p1",
+                "identifier": "ROB-111",
+                "title": "Parent",
+                "status": parent_status,
+                "parentId": None,
+                "assigneeAgentId": "a1",
+                "updatedAt": parent_updated_at,
+            },
+            {
+                "id": "c1",
+                "identifier": "ROB-181c",
+                "title": "Child",
+                "status": child_status,
+                "parentId": "p1",
+                "assigneeAgentId": None,
+                "updatedAt": child_updated_at,
+            },
+        ],
+        "approvals": [],
+        "agents": [
+            {
+                "id": "a1",
+                "name": "CEO",
+                "runtimeConfig": {"heartbeat": {"enabled": True, "intervalSec": 3600}},
+                "lastHeartbeatAt": last_heartbeat_at,
+            }
+        ],
+        "heartbeat_runs": {},
+    }
+
+
+def test_manager_followup_skipped_when_parent_blocked_and_child_in_review() -> None:
+    # ROB-166 regression: blocked parent waiting on external blocker +
+    # child moved to in_review (lane handoff) must NOT emit manager_followup.
+    snapshot = _manager_followup_snapshot(
+        parent_status="blocked",
+        child_status="in_review",
+    )
+
+    items, _warnings = probe.derive_boss_queue_items(
+        snapshot,
+        now=probe.parse_timestamp("2026-04-15T11:00:00+09:00"),
+    )
+
+    assert all(item["kind"] != "manager_followup_needed" for item in items)
+
+
+def test_manager_followup_skipped_when_child_in_progress_only() -> None:
+    # In-lane child work (in_progress) is not a parent-owner signal.
+    snapshot = _manager_followup_snapshot(
+        parent_status="in_progress",
+        child_status="in_progress",
+    )
+
+    items, _warnings = probe.derive_boss_queue_items(
+        snapshot,
+        now=probe.parse_timestamp("2026-04-15T11:00:00+09:00"),
+    )
+
+    assert all(item["kind"] != "manager_followup_needed" for item in items)
+
+
+def test_manager_followup_skipped_when_child_in_review() -> None:
+    # Code Reviewer lane handoff must not trigger parent rerun signal.
+    snapshot = _manager_followup_snapshot(
+        parent_status="in_progress",
+        child_status="in_review",
+    )
+
+    items, _warnings = probe.derive_boss_queue_items(
+        snapshot,
+        now=probe.parse_timestamp("2026-04-15T11:00:00+09:00"),
+    )
+
+    assert all(item["kind"] != "manager_followup_needed" for item in items)
+
+
+def test_manager_followup_emitted_when_child_blocked() -> None:
+    # Child blocked on something the parent owner may need to resolve.
+    snapshot = _manager_followup_snapshot(
+        parent_status="in_progress",
+        child_status="blocked",
+    )
+
+    items, _warnings = probe.derive_boss_queue_items(
+        snapshot,
+        now=probe.parse_timestamp("2026-04-15T11:00:00+09:00"),
+    )
+
     assert any(item["kind"] == "manager_followup_needed" for item in items)
 
 


### PR DESCRIPTION
## Summary

- `blocked` parent + child `in_review` 조합에서 발생하던 `manager_followup_needed` false-positive를 제거 (ROB-166 재현)
- parent는 `in_progress`일 때만 신호 대상, child는 `done`/`blocked`일 때만 emit (lane handoff 상태는 skip)
- 회귀 테스트 4건 추가 (+ 기존 happy-path 테스트는 child `done` 기준으로 갱신)

## Context

Linked issue: [ROB-181](/ROB/issues/ROB-181) (parent: [ROB-111](/ROB/issues/ROB-111))

기존 로직은 parent가 `in_progress` 또는 `blocked`이면서 자식 업데이트가 assignee heartbeat 이후이면 무조건 `manager_followup_needed`를 emit 했다. 그 결과:
1. 외부 blocker를 기다리는 `blocked` parent에서 child가 `in_review`로 lane handoff만 해도 parent owner rerun 신호 오탐 (ROB-166 사례)
2. child가 단순히 `in_progress` 상태로 업데이트만 되어도 오탐

## Change

`scripts/paperclip_cli_probe.py`:
- `MANAGER_FOLLOWUP_CHILD_STATUSES = {"done", "blocked"}` 상수 추가
- parent 조건을 `status == "in_progress"`로 좁힘 (blocked 제외)
- child 중 status가 done/blocked인 것만 `latest_child_update` 산정에 포함

Phase 2(`blockedBy` 해소 감지, `parent_unblocked` 신호)는 별도 이슈로 분리 권장.

## Test plan

- [x] `uv run pytest tests/test_paperclip_cli_probe.py -v` — 23 passed
- [x] `uv run ruff check scripts/paperclip_cli_probe.py tests/test_paperclip_cli_probe.py`
- [x] `uv run ruff format --check` (worktree에서 자동 포맷 적용 후 재검증)
- [ ] Code Reviewer / QA: ROB-166 류 snapshot에서 실제 probe 실행 시 `manager_followup_needed`가 사라지는지 확인