### PR TITLE
feat(probe): parent_unblocked 신호 + blockedBy snapshot 추가 (ROB-184)

### DIFF
--- a/scripts/paperclip_cli_probe.py
+++ b/scripts/paperclip_cli_probe.py
@@ -329,6 +329,34 @@ def fetch_heartbeat_runs(
     return [row for row in data if isinstance(row, dict)]
 
 
+def fetch_issue_blockers(
+    *,
+    api_base: str,
+    issue_id: str,
+    api_key: str,
+    timeout: float = DEFAULT_HTTP_TIMEOUT,
+) -> list[dict[str, Any]]:
+    url = f"{normalize_api_base(api_base)}/api/issues/{issue_id}"
+    headers = {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+    with httpx.Client() as client:
+        response = client.get(url, headers=headers, timeout=timeout)
+        response.raise_for_status()
+        data = response.json()
+    if not isinstance(data, dict):
+        raise CliProbeError(
+            code="api_invalid_json",
+            message="Issue detail endpoint returned non-object JSON",
+            debug={"url": url, "body": data},
+        )
+    blocked_by = data.get("blockedBy")
+    if not isinstance(blocked_by, list):
+        return []
+    return [row for row in blocked_by if isinstance(row, dict)]
+
+
 def collect_raw_snapshot(
     launcher: CliLauncher,
     runtime: RuntimeConfig,
@@ -360,6 +388,31 @@ def collect_raw_snapshot(
             except Exception as exc:  # noqa: BLE001
                 warnings.append(
                     f"heartbeat API fallback unavailable for agent {agent_id}: {exc}"
+                )
+
+    # Enrich `blocked` issues with their `blockedBy` relation so the derive
+    # stage can detect parent_unblocked signals. The CLI `issue list` response
+    # does not include blockers, so we fetch per-issue details via HTTP.
+    if runtime.api_key and isinstance(issues, list):
+        for issue in issues:
+            if not isinstance(issue, dict):
+                continue
+            if str(issue.get("status") or "").strip().lower() != "blocked":
+                continue
+            issue_id = issue.get("id")
+            if not isinstance(issue_id, str) or not issue_id:
+                continue
+            if isinstance(issue.get("blockedBy"), list):
+                continue
+            try:
+                issue["blockedBy"] = fetch_issue_blockers(
+                    api_base=runtime.api_base or "",
+                    issue_id=issue_id,
+                    api_key=runtime.api_key,
+                )
+            except Exception as exc:  # noqa: BLE001
+                warnings.append(
+                    f"blockers fetch unavailable for issue {issue_id}: {exc}"
                 )
 
     return (
@@ -526,6 +579,66 @@ def derive_boss_queue_items(
                                 else None,
                             },
                             "recommended_action": f"{owner} 재실행 또는 parent issue 확인",
+                        }
+                    )
+
+        # parent_unblocked
+        # A `blocked` issue whose entire blockedBy set has reached `done` is
+        # ready to resume. Paperclip's backend fires an `issue_blockers_resolved`
+        # wake for this case — the probe emits the same signal independently so
+        # the Boss Action Queue surfaces it even when a wake is missed.
+        if (
+            isinstance(issue_id, str)
+            and status.strip().lower() == "blocked"
+            and isinstance(assignee_agent_id, str)
+            and assignee_agent_id in agents
+        ):
+            blocked_by = issue.get("blockedBy")
+            if isinstance(blocked_by, list) and blocked_by:
+                blocker_dicts = [b for b in blocked_by if isinstance(b, dict)]
+                all_done = bool(blocker_dicts) and all(
+                    str(b.get("status") or "").strip().lower() == "done"
+                    for b in blocker_dicts
+                )
+                if all_done:
+                    agent = agents[assignee_agent_id]
+                    owner = str(agent.get("name") or assignee_agent_id)
+                    blocker_timestamps = [
+                        ts
+                        for ts in (
+                            parse_timestamp(b.get("updatedAt")) for b in blocker_dicts
+                        )
+                        if ts is not None
+                    ]
+                    latest_blocker_update = (
+                        max(blocker_timestamps) if blocker_timestamps else None
+                    )
+                    blocker_identifiers = [
+                        str(b.get("identifier") or b.get("id") or "")
+                        for b in blocker_dicts
+                    ]
+                    items.append(
+                        {
+                            "fingerprint": fingerprint_for_item(
+                                "parent_unblocked",
+                                identifier or issue_id,
+                                latest_blocker_update.isoformat()
+                                if latest_blocker_update
+                                else "",
+                            ),
+                            "kind": "parent_unblocked",
+                            "severity": "high",
+                            "owner": owner,
+                            "issue_identifier": identifier,
+                            "title": title,
+                            "summary": "blocked 이슈의 모든 blocker가 done — 재실행 가능",
+                            "evidence": {
+                                "blocker_identifiers": blocker_identifiers,
+                                "latest_blocker_update": latest_blocker_update.isoformat()
+                                if latest_blocker_update
+                                else None,
+                            },
+                            "recommended_action": f"{owner} 재실행 또는 blocker 해소 후 후속 작업 시작",
                         }
                     )
 

--- a/tests/test_paperclip_cli_probe.py
+++ b/tests/test_paperclip_cli_probe.py
@@ -642,3 +642,163 @@ def test_in_review_with_no_assignee_falls_to_active_issue_unassigned() -> None:
         in ("issue_review_needed", "formal_approval_pending", "misrouted_review")
     ]
     assert review_items == []
+
+
+def _parent_unblocked_snapshot(
+    *,
+    blocker_statuses: list[str],
+    parent_status: str = "blocked",
+    blocker_updated_at: str = "2026-04-15T10:30:00+09:00",
+) -> dict:
+    blockers = [
+        {
+            "id": f"blk{index}",
+            "identifier": f"ROB-9{index}",
+            "status": blocker_status,
+            "updatedAt": blocker_updated_at,
+        }
+        for index, blocker_status in enumerate(blocker_statuses, start=1)
+    ]
+    return {
+        "issues": [
+            {
+                "id": "p1",
+                "identifier": "ROB-111",
+                "title": "Boss Action Queue",
+                "status": parent_status,
+                "parentId": None,
+                "assigneeAgentId": "a1",
+                "updatedAt": "2026-04-15T09:00:00+09:00",
+                "blockedBy": blockers,
+            }
+        ],
+        "approvals": [],
+        "agents": [
+            {
+                "id": "a1",
+                "name": "Staff",
+                "runtimeConfig": {"heartbeat": {"enabled": True, "intervalSec": 3600}},
+                "lastHeartbeatAt": "2026-04-15T10:00:00+09:00",
+            }
+        ],
+        "heartbeat_runs": {},
+    }
+
+
+def test_parent_unblocked_emitted_when_all_blockers_done() -> None:
+    # ROB-184: blocked parent whose entire blockedBy set reached `done` must
+    # emit `parent_unblocked` so the Boss Action Queue can wake the owner.
+    snapshot = _parent_unblocked_snapshot(blocker_statuses=["done", "done"])
+
+    items, warnings = probe.derive_boss_queue_items(
+        snapshot,
+        now=probe.parse_timestamp("2026-04-15T11:00:00+09:00"),
+    )
+
+    unblocked = [item for item in items if item["kind"] == "parent_unblocked"]
+    assert warnings == []
+    assert len(unblocked) == 1
+    assert unblocked[0]["severity"] == "high"
+    assert unblocked[0]["owner"] == "Staff"
+    assert unblocked[0]["issue_identifier"] == "ROB-111"
+    assert unblocked[0]["evidence"]["blocker_identifiers"] == ["ROB-91", "ROB-92"]
+
+
+def test_parent_unblocked_skipped_when_any_blocker_not_done() -> None:
+    # Partial blocker completion must NOT emit parent_unblocked — at least one
+    # blocker still needs to reach `done` (cancelled/in_progress/in_review all
+    # count as unresolved per the Paperclip backend wake semantics).
+    snapshot = _parent_unblocked_snapshot(blocker_statuses=["done", "in_progress"])
+
+    items, _warnings = probe.derive_boss_queue_items(
+        snapshot,
+        now=probe.parse_timestamp("2026-04-15T11:00:00+09:00"),
+    )
+
+    assert all(item["kind"] != "parent_unblocked" for item in items)
+
+
+def test_parent_unblocked_skipped_when_blockers_cancelled() -> None:
+    # Cancelled blockers do not count as resolved (matches Paperclip's
+    # issue_blockers_resolved wake behavior).
+    snapshot = _parent_unblocked_snapshot(blocker_statuses=["done", "cancelled"])
+
+    items, _warnings = probe.derive_boss_queue_items(
+        snapshot,
+        now=probe.parse_timestamp("2026-04-15T11:00:00+09:00"),
+    )
+
+    assert all(item["kind"] != "parent_unblocked" for item in items)
+
+
+def test_parent_unblocked_skipped_when_blocked_by_empty() -> None:
+    # A `blocked` issue with no declared blockers must not emit parent_unblocked
+    # because we cannot assert that any dependency has been resolved.
+    snapshot = _parent_unblocked_snapshot(blocker_statuses=[])
+
+    items, _warnings = probe.derive_boss_queue_items(
+        snapshot,
+        now=probe.parse_timestamp("2026-04-15T11:00:00+09:00"),
+    )
+
+    assert all(item["kind"] != "parent_unblocked" for item in items)
+
+
+def test_parent_unblocked_skipped_when_parent_not_blocked() -> None:
+    # Non-blocked parents are out of scope for this signal even if their
+    # blockedBy snapshot happens to show done blockers.
+    snapshot = _parent_unblocked_snapshot(
+        blocker_statuses=["done"],
+        parent_status="in_progress",
+    )
+
+    items, _warnings = probe.derive_boss_queue_items(
+        snapshot,
+        now=probe.parse_timestamp("2026-04-15T11:00:00+09:00"),
+    )
+
+    assert all(item["kind"] != "parent_unblocked" for item in items)
+
+
+def test_fetch_issue_blockers_returns_blocked_by_relation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called: dict[str, object] = {}
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {
+                "id": "i1",
+                "blockedBy": [
+                    {"id": "b1", "identifier": "ROB-90", "status": "done"},
+                    "not-a-dict",
+                ],
+            }
+
+    class FakeClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def get(self, url: str, headers=None, timeout=None):
+            called["url"] = url
+            called["headers"] = headers
+            return FakeResponse()
+
+    monkeypatch.setattr(probe.httpx, "Client", lambda: FakeClient())
+
+    rows = probe.fetch_issue_blockers(
+        api_base="http://127.0.0.1:3100",
+        issue_id="i1",
+        api_key="token-1",
+    )
+
+    assert called["url"] == "http://127.0.0.1:3100/api/issues/i1"
+    assert called["headers"]["Authorization"] == "Bearer token-1"
+    assert len(rows) == 1
+    assert rows[0]["identifier"] == "ROB-90"


### PR DESCRIPTION
## Summary

- `scripts/paperclip_cli_probe.py`의 `collect_raw_snapshot`이 `blocked` 이슈마다 `/api/issues/:id` 호출로 `blockedBy` 관계를 보충한다 (CLI `issue list`는 blockers를 포함하지 않음).
- `derive_boss_queue_items`에서 `blocked` 이슈 + 전체 blocker `done` 조건을 감지해 **`parent_unblocked`** signal을 emit한다 (severity=`high`, owner=parent assignee).
- cancelled blocker는 resolved로 간주하지 않아 Paperclip의 자동 `issue_blockers_resolved` wake semantics와 일치한다.
- 회귀 테스트 6개 추가 (all-done / partial / cancelled / empty / non-blocked parent / fetch helper).

## Context

- Phase 1 [ROB-181](/ROB/issues/ROB-181) (PR [#542](https://github.com/mgh3326/auto_trader/pull/542), merged): `blocked` parent를 `manager_followup_needed`에서 제외해 false-positive 제거.
- Phase 2 이 PR: blocker가 모두 해소된 순간 parent owner에게 독립 신호를 emit해 백엔드 wake 누락 시에도 Boss Action Queue가 재실행을 푸시하도록 한다.

## Test plan

- [x] `uv run pytest tests/test_paperclip_cli_probe.py -v` → 29 passed (기존 23 + 신규 6)
- [x] `uv run ruff check scripts/paperclip_cli_probe.py tests/test_paperclip_cli_probe.py` → All checks passed
- [x] `uv run ruff format --check ...` → 2 files already formatted
- [ ] Code Reviewer 검토 후 프로덕션 n8n probe 실행에서 실데이터 blocker 감지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issue blockers are now automatically fetched and tracked from the Paperclip API.
  * The system detects when all blockers for a blocked issue are resolved and generates a notification.

* **Tests**
  * Added comprehensive test coverage for blocker detection and resolution functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->