### PR TITLE
[codex] Guarantee watch-alert Discord failures return 500 before mark-sent

### DIFF
--- a/n8n/README.md
+++ b/n8n/README.md
@@ -96,7 +96,7 @@ docker exec auto_trader_n8n_prod n8n import:workflow \
 ### Paperclip Watch Alert
 - **Export file**: `n8n/workflows/paperclip-watch-alert.json`
 - **Trigger**: Webhook `POST /webhook/watch-alert`
-- **동작**: auto_trader `OpenClawClient.send_watch_alert_to_n8n` ([ROB-173](/ROB/issues/ROB-173) / PR #540) 이 보내는 watch alert 페이로드를 받아 market (`crypto` / `kr` / `us`) 별 Discord 채널로 라우팅. `{market}:{symbol}:{condition_type}:{threshold}` fingerprint 를 workflow static data 에 저장해 **6시간 쿨다운** dedupe, 24시간 초과 엔트리는 GC.
+- **동작**: auto_trader `OpenClawClient.send_watch_alert_to_n8n` ([ROB-173](/ROB/issues/ROB-173) / PR #540) 이 보내는 watch alert 페이로드를 받아 market (`crypto` / `kr` / `us`) 별 Discord 채널로 라우팅. Discord 결과는 market별 `Discord OK?` IF 노드에서 성공/실패를 먼저 분기하고, 성공 branch에서만 `Mark Sent` 가 static data 를 갱신한다. `{market}:{symbol}:{condition_type}:{threshold}` fingerprint 를 workflow static data 에 저장해 **6시간 쿨다운** dedupe, 24시간 초과 엔트리는 GC.
 - **응답 계약**:
   - 전송 성공 → `200 {"status":"sent","market":"...","sent_count":N,"deduped_count":M,...}`
   - 전 항목 dedupe hit → `200 {"status":"deduped","sent_count":0,"deduped_count":N,...}`

--- a/n8n/workflows/paperclip-watch-alert.json
+++ b/n8n/workflows/paperclip-watch-alert.json
@@ -191,7 +191,7 @@
           "name": "Discord Webhook - Watch Alert Crypto"
         }
       },
-      "onError": "continueErrorOutput"
+      "onError": "continueRegularOutput"
     },
     {
       "parameters": {
@@ -213,7 +213,7 @@
           "name": "Discord Webhook - Watch Alert KR"
         }
       },
-      "onError": "continueErrorOutput"
+      "onError": "continueRegularOutput"
     },
     {
       "parameters": {
@@ -235,7 +235,7 @@
           "name": "Discord Webhook - Watch Alert US"
         }
       },
-      "onError": "continueErrorOutput"
+      "onError": "continueRegularOutput"
     },
     {
       "parameters": {
@@ -249,7 +249,7 @@
           "conditions": [
             {
               "id": "wa-discord-ok-crypto",
-              "leftValue": "={{ !($json.error && $json.error.message) }}",
+            "leftValue": "={{ !$json.error }}",
               "rightValue": true,
               "operator": {
                 "type": "boolean",
@@ -282,7 +282,7 @@
           "conditions": [
             {
               "id": "wa-discord-ok-kr",
-              "leftValue": "={{ !($json.error && $json.error.message) }}",
+            "leftValue": "={{ !$json.error }}",
               "rightValue": true,
               "operator": {
                 "type": "boolean",
@@ -315,7 +315,7 @@
           "conditions": [
             {
               "id": "wa-discord-ok-us",
-              "leftValue": "={{ !($json.error && $json.error.message) }}",
+            "leftValue": "={{ !$json.error }}",
               "rightValue": true,
               "operator": {
                 "type": "boolean",

--- a/n8n/workflows/paperclip-watch-alert.json
+++ b/n8n/workflows/paperclip-watch-alert.json
@@ -239,6 +239,105 @@
     },
     {
       "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose",
+            "version": 3
+          },
+          "conditions": [
+            {
+              "id": "wa-discord-ok-crypto",
+              "leftValue": "={{ !($json.error && $json.error.message) }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.3,
+      "position": [
+        940,
+        -80
+      ],
+      "id": "wa-if-discord-ok-crypto",
+      "name": "Discord OK? — Crypto"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose",
+            "version": 3
+          },
+          "conditions": [
+            {
+              "id": "wa-discord-ok-kr",
+              "leftValue": "={{ !($json.error && $json.error.message) }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.3,
+      "position": [
+        940,
+        80
+      ],
+      "id": "wa-if-discord-ok-kr",
+      "name": "Discord OK? — KR"
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "loose",
+            "version": 3
+          },
+          "conditions": [
+            {
+              "id": "wa-discord-ok-us",
+              "leftValue": "={{ !($json.error && $json.error.message) }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.3,
+      "position": [
+        940,
+        240
+      ],
+      "id": "wa-if-discord-ok-us",
+      "name": "Discord OK? — US"
+    },
+    {
+      "parameters": {
         "respondWith": "json",
         "responseBody": "={{ $('Validate & Dedupe').item.json.responseBody }}",
         "options": {
@@ -385,16 +484,7 @@
       "main": [
         [
           {
-            "node": "Mark Sent",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ],
-      "error": [
-        [
-          {
-            "node": "Respond 500",
+            "node": "Discord OK? — Crypto",
             "type": "main",
             "index": 0
           }
@@ -405,16 +495,7 @@
       "main": [
         [
           {
-            "node": "Mark Sent",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ],
-      "error": [
-        [
-          {
-            "node": "Respond 500",
+            "node": "Discord OK? — KR",
             "type": "main",
             "index": 0
           }
@@ -425,13 +506,58 @@
       "main": [
         [
           {
-            "node": "Mark Sent",
+            "node": "Discord OK? — US",
             "type": "main",
             "index": 0
           }
         ]
-      ],
-      "error": [
+      ]
+    },
+    "Discord OK? — Crypto": {
+      "main": [
+        [
+          {
+            "node": "Mark Sent",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond 500",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord OK? — KR": {
+      "main": [
+        [
+          {
+            "node": "Mark Sent",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Respond 500",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Discord OK? — US": {
+      "main": [
+        [
+          {
+            "node": "Mark Sent",
+            "type": "main",
+            "index": 0
+          }
+        ],
         [
           {
             "node": "Respond 500",

--- a/tests/test_n8n_watch_alert_workflow.py
+++ b/tests/test_n8n_watch_alert_workflow.py
@@ -235,19 +235,32 @@ def test_threshold_type_guard_rejects_non_scalar() -> None:
     assert result["validate_output"]["errorCode"] == "invalid_triggered_item"
 
 
-def test_discord_success_outputs_route_through_mark_sent_node() -> None:
-    """Structural guard: every Discord main output must funnel into Mark Sent.
+def test_discord_outputs_are_guarded_before_mark_sent() -> None:
+    """Structural guard: Discord output must be branched by explicit success IF.
 
-    Catches a future refactor that accidentally re-wires a Discord node straight
-    back to `Respond 200 (sent)` and reintroduces the bug.
+    n8n's `continueErrorOutput` can still emit errored items on main output, so
+    wiring Discord main directly into Mark Sent can incorrectly produce 200/sent.
     """
     workflow = json.loads(WORKFLOW_PATH.read_text(encoding="utf-8"))
-    for discord_id in ("Discord — Crypto", "Discord — KR", "Discord — US"):
-        main = workflow["connections"][discord_id]["main"][0]
+    expected_if_nodes = {
+        "Discord — Crypto": "Discord OK? — Crypto",
+        "Discord — KR": "Discord OK? — KR",
+        "Discord — US": "Discord OK? — US",
+    }
+
+    for discord_name, if_name in expected_if_nodes.items():
+        main = workflow["connections"][discord_name]["main"][0]
         assert len(main) == 1
-        assert main[0]["node"] == "Mark Sent", (
-            f"{discord_id} main output must go through Mark Sent, not {main[0]['node']}"
-        )
+        assert main[0]["node"] == if_name
+        assert "error" not in workflow["connections"][discord_name]
+
+        if_main = workflow["connections"][if_name]["main"]
+        assert len(if_main) == 2
+        ok_branch = if_main[0]
+        fail_branch = if_main[1]
+        assert len(ok_branch) == 1 and ok_branch[0]["node"] == "Mark Sent"
+        assert len(fail_branch) == 1 and fail_branch[0]["node"] == "Respond 500"
+
     mark_main = workflow["connections"]["Mark Sent"]["main"][0]
     assert len(mark_main) == 1
     assert mark_main[0]["node"] == "Respond 200 (sent)"

--- a/tests/test_n8n_watch_alert_workflow.py
+++ b/tests/test_n8n_watch_alert_workflow.py
@@ -261,6 +261,17 @@ def test_discord_outputs_are_guarded_before_mark_sent() -> None:
         assert len(ok_branch) == 1 and ok_branch[0]["node"] == "Mark Sent"
         assert len(fail_branch) == 1 and fail_branch[0]["node"] == "Respond 500"
 
+        if_node = next(node for node in workflow["nodes"] if node["name"] == if_name)
+        condition = if_node["parameters"]["conditions"]["conditions"][0]
+        assert condition["leftValue"] == "={{ !$json.error }}"
+
+    for node in workflow["nodes"]:
+        if node["type"] == "n8n-nodes-base.discord":
+            assert node.get("onError") == "continueRegularOutput", (
+                f"{node['name']} must use continueRegularOutput so errors flow to main "
+                "with $json.error populated (required by the Discord OK? IF guard)."
+            )
+
     mark_main = workflow["connections"]["Mark Sent"]["main"][0]
     assert len(mark_main) == 1
     assert mark_main[0]["node"] == "Respond 200 (sent)"


### PR DESCRIPTION
## Summary
- set all watch-alert Discord nodes (`Discord — Crypto/KR/US`) `onError` to `continueRegularOutput` (Option A)
- keep the `Discord OK?` guard architecture before `Mark Sent`, and harden each IF condition to check `{{$json.error}}` presence directly (`={{ !$json.error }}`)
- keep success path as `Mark Sent -> Respond 200 (sent)` and failure path as `Respond 500`
- add structural regression assertions to enforce both:
  - Discord nodes must use `continueRegularOutput`
  - `Discord OK?` conditions must use `={{ !$json.error }}`

## Root Cause
With `continueErrorOutput`, Discord failures do not flow through the main pin, so the `Discord OK?` guard cannot reliably gate the response path.

After switching to Option A, failed Discord deliveries in our runtime emit `$json.error` as a string (not always as an object with `.message`). The previous IF expression checked `error.message` only, which could still pass failures into `Mark Sent` and return `200 sent`. The guard now checks `$json.error` directly.

## Validation
- `uv run pytest tests/test_n8n_watch_alert_workflow.py -q` -> `7 passed`
- local repro (US credential forced to `http://127.0.0.1:1/...`, n8n restarted):
  - `POST /webhook/watch-alert` returns `500 {"status":"error","error":"discord_send_failed",...}`
  - execution runData shows `Respond 500` executed, `Mark Sent` not executed

## Impact
- Discord failure path now deterministically returns 500 and skips sentMap write, so auto_trader retries can re-deliver.
- Existing 400 / 200(deduped) / 200(sent) contracts remain intact.