### PR TITLE
feat(dust): S4 dust 회계 분리 (ROB-145)

### DIFF
--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -63,6 +63,9 @@ from app.mcp_server.tooling.shared import (
     match_account_filter as _match_account_filter,
 )
 from app.mcp_server.tooling.shared import (
+    min_order_krw as _min_order_krw,
+)
+from app.mcp_server.tooling.shared import (
     normalize_account_filter as _normalize_account_filter,
 )
 from app.mcp_server.tooling.shared import (
@@ -829,6 +832,24 @@ async def _get_holdings_impl(
 
     filtered_count = 0
     filter_reason: str | None = None
+
+    for position in positions:
+        position["dust"] = False
+
+    if include_current_price:
+        for position in positions:
+            if position.get("instrument_type") != "crypto":
+                continue
+            symbol = str(position.get("symbol") or "").strip().upper()
+            if not symbol:
+                continue
+            value = _value_for_minimum_filter(position)
+            if value <= 0:
+                # Price/evaluation unavailable → keep conservative default (not dust).
+                position["dust"] = False
+                continue
+            threshold = _min_order_krw(symbol)
+            position["dust"] = value < threshold
 
     if include_current_price and minimum_value is not None:
         threshold = float(minimum_value)

--- a/app/mcp_server/tooling/shared.py
+++ b/app/mcp_server/tooling/shared.py
@@ -428,6 +428,7 @@ def position_to_output(position: dict[str, Any]) -> dict[str, Any]:
         "evaluation_amount": position["evaluation_amount"],
         "profit_loss": position["profit_loss"],
         "profit_rate": position["profit_rate"],
+        "dust": bool(position.get("dust", False)),
     }
     if "price_error" in position:
         output["price_error"] = position["price_error"]
@@ -446,6 +447,17 @@ def value_for_minimum_filter(position: dict[str, Any]) -> float:
     if current_price <= 0:
         return 0.0
     return quantity * current_price
+
+
+def min_order_krw(symbol: str) -> float:
+    """Return KRW minimum order threshold for crypto positions.
+
+    Upbit KRW markets share a fixed minimum order amount in current policy.
+    The ``symbol`` parameter is intentionally retained for future per-market
+    extensions without changing the public function signature.
+    """
+    _ = symbol
+    return DEFAULT_MINIMUM_VALUES["crypto"]
 
 
 def format_filter_threshold(value: float) -> str:
@@ -903,6 +915,7 @@ __all__ = [
     "normalize_position_symbol",
     "position_to_output",
     "value_for_minimum_filter",
+    "min_order_krw",
     "format_filter_threshold",
     "build_holdings_summary",
     "is_position_symbol_match",

--- a/app/services/n8n_daily_brief_service.py
+++ b/app/services/n8n_daily_brief_service.py
@@ -8,70 +8,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass, field, replace
 from datetime import datetime
 from typing import Any
 
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst
-
-try:
-    from app.mcp_server.tooling.trade_journal_tools import compute_active_dca_daily_burn
-except ImportError:
-
-    async def compute_active_dca_daily_burn() -> dict[str, Any]:
-        return {
-            "daily_burn_krw": 0.0,
-            "active_count": 0,
-            "per_record": [],
-            "days_to_next_obligation": None,
-            "cash_needed_until_obligation": 0.0,
-        }
-
-
-try:
-    from app.schemas.n8n.board_brief import (
-        BoardBriefContext,
-        BoardBriefRender,
-        GateResult,
-        N8nG2GatePayload,
-    )
-except ModuleNotFoundError:
-
-    @dataclass
-    class GateResult:
-        id: str
-        label: str
-        status: str
-        detail: str
-
-    @dataclass
-    class N8nG2GatePayload:
-        pass_: bool = True
-
-    @dataclass
-    class BoardBriefContext:
-        date_fmt: str = ""
-        market_overview: Any = None
-        pending_by_market: dict[str, Any] = field(default_factory=dict)
-        portfolio_by_market: dict[str, Any] = field(default_factory=dict)
-        yesterday_fills: dict[str, Any] = field(default_factory=dict)
-        daily_burn: dict[str, Any] = field(default_factory=dict)
-        gate_results: dict[str, Any] = field(default_factory=dict)
-        generated_at: datetime = field(default_factory=now_kst)
-        cio_recommendation: str | None = None
-
-        def model_copy(self, update: dict[str, Any]) -> BoardBriefContext:
-            return replace(self, **update)
-
-    @dataclass
-    class BoardBriefRender:
-        phase: str
-        brief_text: str
-        generated_at: datetime
-        gate_results: dict[str, Any] | None = None
-
-
 from app.schemas.n8n.common import N8nMarketOverview
 from app.services.n8n_formatting import (
     fmt_amount,
@@ -364,7 +305,6 @@ def _build_brief_text(
     pending_by_market: dict[str, dict[str, Any]],
     portfolio_by_market: dict[str, dict[str, Any]],
     yesterday_fills: dict[str, Any],
-    daily_burn: dict[str, Any] | None = None,
 ) -> str:
     """Build the full brief text for Discord delivery."""
     lines: list[str] = []
@@ -472,16 +412,6 @@ def _build_brief_text(
         )
         lines.append("")
 
-    # Funding
-    burn_data = daily_burn or {}
-    burn_krw = float(burn_data.get("daily_burn_krw") or 0)
-    active_dca_count = int(burn_data.get("active_count") or 0)
-    lines.append("💰 자금 현황")
-    lines.append(
-        f"daily_burn: {burn_krw:,.0f} KRW (active DCA {active_dca_count}종 · 재산출)"
-    )
-    lines.append("")
-
     # Yesterday fills
     fills_data = yesterday_fills or {}
     total_fills = fills_data.get("total", 0)
@@ -507,119 +437,6 @@ def _build_brief_text(
     lines.append("각 시장별 미체결 상세는 스레드에서 확인 후 리뷰해줘.")
 
     return "\n".join(lines)
-
-
-def _build_tc_preliminary_text(ctx: BoardBriefContext) -> str:
-    lines: list[str] = []
-    lines.append("📊 TC Preliminary — 자금 현황 재계산")
-    lines.append("")
-    lines.append("🧭 Framing")
-    lines.append("경로 A·B 병행 가능. 경로 A/B는 상호배타가 아니다.")
-    lines.append("")
-    lines.append("💰 자금 현황")
-    lines.append(f"- manual_cash: {fmt_amount(float(ctx.manual_cash))}")
-    lines.append(
-        f"- daily_burn: {fmt_amount(float(ctx.daily_burn)) if ctx.daily_burn is not None else '-'}"
-    )
-    lines.append(
-        f"- days_to_next_obligation: {ctx.days_to_next_obligation}일"
-        if ctx.days_to_next_obligation is not None
-        else "- days_to_next_obligation: -"
-    )
-    lines.append("")
-    lines.append("📈 쏠림/편중")
-    if ctx.weights_top_n:
-        for item in ctx.weights_top_n:
-            lines.append(f"- {item.symbol} {item.weight_pct:.1f}% ({item.market})")
-    else:
-        lines.append("- 상위 비중 데이터 없음")
-    lines.append("")
-    lines.append("📉 매도/축소 후보")
-    if ctx.holdings:
-        for item in ctx.holdings[:5]:
-            lines.append(f"- {item.symbol} ({item.market})")
-    else:
-        lines.append("- 후보 없음")
-    if ctx.dust_items:
-        dust_line = ", ".join(
-            f"{item.symbol} (~{int(item.value_krw):,} KRW)" for item in ctx.dust_items
-        )
-        lines.append(f"- Dust footnote: {dust_line}")
-    lines.append("")
-    lines.append("🛣️ 경로 A / 경로 B")
-    lines.append("- A: 즉시 재배치")
-    lines.append("- B: 분할 대응")
-    lines.append("- 경로 A·B 병행 가능")
-    return "\n".join(lines)
-
-
-def _normalize_gate_results(
-    gate_results: dict[str, GateResult | N8nG2GatePayload],
-) -> dict[str, GateResult]:
-    defaults = {
-        "G1": ("G1 Runway", "tbd", "TBD (S7)"),
-        "G2": ("G2 Diversification", "pending", "S5 engineering 중"),
-        "G3": ("G3", "tbd", "TBD (Sx)"),
-        "G4": ("G4", "tbd", "TBD (Sx)"),
-        "G5": ("G5", "tbd", "TBD (Sx)"),
-        "G6": ("G6", "tbd", "TBD (Sx)"),
-    }
-    normalized: dict[str, GateResult] = {}
-    for gate_id, (label, status, detail) in defaults.items():
-        item = gate_results.get(gate_id)
-        if item is None or not isinstance(item, GateResult):
-            normalized[gate_id] = GateResult(
-                id=gate_id, label=label, status=status, detail=detail
-            )
-        else:
-            normalized[gate_id] = item
-    return normalized
-
-
-def _build_cio_pending_text(ctx: BoardBriefContext) -> str:
-    lines: list[str] = [_build_tc_preliminary_text(ctx), ""]
-    lines.append("🎯 권고")
-    lines.append(ctx.cio_recommendation or "(CIO 의견 대기 중)")
-    lines.append("")
-    lines.append("📊 Gate 판정 결과")
-    gate_status_results = _normalize_gate_results(ctx.gate_results)
-    for gate_id in ("G1", "G2", "G3", "G4", "G5", "G6"):
-        gate = gate_status_results[gate_id]
-        lines.append(f"- {gate.id} {gate.label}: {gate.status} ({gate.detail})")
-    g2_payload = ctx.gate_results.get("G2")
-    if isinstance(g2_payload, N8nG2GatePayload) and not g2_payload.pass_:
-        lines.append("🚫 신규 매수 차단 — G2 fail")
-    lines.append("")
-    lines.append("[funding] 자금 의도/제약 확인. (경로 A·B 병행 가능)")
-    lines.append("[action] 실행 우선순위 확인. (경로 A·B 병행 가능)")
-    return "\n".join(lines)
-
-
-def build_tc_preliminary(ctx: BoardBriefContext) -> BoardBriefRender:
-    brief_text = _build_tc_preliminary_text(ctx)
-    return BoardBriefRender(
-        phase="tc_preliminary",
-        brief_text=brief_text,
-        generated_at=ctx.generated_at,
-    )
-
-
-def build_cio_pending_decision(ctx: BoardBriefContext) -> BoardBriefRender:
-    gate_status_results = _normalize_gate_results(ctx.gate_results)
-    merged_gate_results: dict[str, GateResult | N8nG2GatePayload] = {
-        **gate_status_results
-    }
-    if isinstance(ctx.gate_results.get("G2"), N8nG2GatePayload):
-        merged_gate_results["G2"] = ctx.gate_results["G2"]
-
-    pending_ctx = ctx.model_copy(update={"gate_results": merged_gate_results})
-    brief_text = _build_cio_pending_text(pending_ctx)
-    return BoardBriefRender(
-        phase="cio_pending",
-        brief_text=brief_text,
-        gate_results=merged_gate_results,
-        generated_at=ctx.generated_at,
-    )
 
 
 async def fetch_daily_brief(
@@ -652,13 +469,9 @@ async def fetch_daily_brief(
         as_of=effective_as_of,
     )
     portfolio_task = _get_portfolio_overview(effective_markets)
-    daily_burn_task = compute_active_dca_daily_burn()
 
     results_s1 = await asyncio.gather(
-        pending_task,
-        portfolio_task,
-        daily_burn_task,
-        return_exceptions=True,
+        pending_task, portfolio_task, return_exceptions=True
     )
 
     # Unpack Stage 1 results with fallbacks
@@ -673,18 +486,6 @@ async def fetch_daily_brief(
         portfolio_result = results_s1[1]
     elif isinstance(results_s1[1], Exception):
         errors.append({"source": "portfolio", "error": str(results_s1[1])})
-
-    daily_burn_result: dict[str, Any] = {
-        "daily_burn_krw": 0.0,
-        "active_count": 0,
-        "per_record": [],
-        "days_to_next_obligation": None,
-        "cash_needed_until_obligation": 0.0,
-    }
-    if isinstance(results_s1[2], dict):
-        daily_burn_result = results_s1[2]
-    elif isinstance(results_s1[2], Exception):
-        errors.append({"source": "daily_burn", "error": str(results_s1[2])})
 
     # Derive shared symbol context for Stage 2
     symbols_by_market = _collect_symbols_by_market(pending_result, portfolio_result)
@@ -749,7 +550,6 @@ async def fetch_daily_brief(
         pending_by_market=pending_by_market,
         portfolio_by_market=portfolio_by_market,
         yesterday_fills=fills_result,
-        daily_burn=daily_burn_result,
     )
 
     # Collect sub-errors
@@ -769,10 +569,6 @@ async def fetch_daily_brief(
             market: portfolio_by_market.get(market) for market in effective_markets
         },
         "yesterday_fills": fills_result,
-        "daily_burn": daily_burn_result,
         "brief_text": brief_text,
         "errors": errors,
     }
-
-
-__all__ = ["build_cio_pending_decision", "build_tc_preliminary", "fetch_daily_brief"]

--- a/app/services/n8n_daily_brief_service.py
+++ b/app/services/n8n_daily_brief_service.py
@@ -8,11 +8,70 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from typing import Any
 
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst
+
+try:
+    from app.mcp_server.tooling.trade_journal_tools import compute_active_dca_daily_burn
+except ImportError:
+
+    async def compute_active_dca_daily_burn() -> dict[str, Any]:
+        return {
+            "daily_burn_krw": 0.0,
+            "active_count": 0,
+            "per_record": [],
+            "days_to_next_obligation": None,
+            "cash_needed_until_obligation": 0.0,
+        }
+
+
+try:
+    from app.schemas.n8n.board_brief import (
+        BoardBriefContext,
+        BoardBriefRender,
+        GateResult,
+        N8nG2GatePayload,
+    )
+except ModuleNotFoundError:
+
+    @dataclass
+    class GateResult:
+        id: str
+        label: str
+        status: str
+        detail: str
+
+    @dataclass
+    class N8nG2GatePayload:
+        pass_: bool = True
+
+    @dataclass
+    class BoardBriefContext:
+        date_fmt: str = ""
+        market_overview: Any = None
+        pending_by_market: dict[str, Any] = field(default_factory=dict)
+        portfolio_by_market: dict[str, Any] = field(default_factory=dict)
+        yesterday_fills: dict[str, Any] = field(default_factory=dict)
+        daily_burn: dict[str, Any] = field(default_factory=dict)
+        gate_results: dict[str, Any] = field(default_factory=dict)
+        generated_at: datetime = field(default_factory=now_kst)
+        cio_recommendation: str | None = None
+
+        def model_copy(self, update: dict[str, Any]) -> BoardBriefContext:
+            return replace(self, **update)
+
+    @dataclass
+    class BoardBriefRender:
+        phase: str
+        brief_text: str
+        generated_at: datetime
+        gate_results: dict[str, Any] | None = None
+
+
 from app.schemas.n8n.common import N8nMarketOverview
 from app.services.n8n_formatting import (
     fmt_amount,
@@ -242,7 +301,11 @@ def _build_portfolio_summary(
 
         # Top gainers/losers by profit_rate
         sorted_positions = sorted(
-            [p for p in market_positions if p.get("profit_rate") is not None],
+            [
+                p
+                for p in market_positions
+                if p.get("profit_rate") is not None and not p.get("dust")
+            ],
             key=lambda p: float(p.get("profit_rate") or 0),
             reverse=True,
         )
@@ -271,6 +334,15 @@ def _build_portfolio_summary(
             "position_count": len(market_positions),
             "top_gainers": top_gainers,
             "top_losers": top_losers,
+            "dust_positions": [
+                {
+                    "symbol": p.get("symbol"),
+                    "quantity": p.get("quantity"),
+                    "current_krw_value": float(p.get("evaluation") or 0),
+                }
+                for p in market_positions
+                if p.get("dust")
+            ],
         }
 
         if market == "us":
@@ -292,6 +364,7 @@ def _build_brief_text(
     pending_by_market: dict[str, dict[str, Any]],
     portfolio_by_market: dict[str, dict[str, Any]],
     yesterday_fills: dict[str, Any],
+    daily_burn: dict[str, Any] | None = None,
 ) -> str:
     """Build the full brief text for Discord delivery."""
     lines: list[str] = []
@@ -378,6 +451,37 @@ def _build_brief_text(
             lines.append(line)
     lines.append("")
 
+    dust_lines: list[str] = []
+    for market_key in ("crypto", "kr", "us"):
+        market_data = portfolio_by_market.get(market_key) or {}
+        for dust_pos in market_data.get("dust_positions") or []:
+            symbol = str(dust_pos.get("symbol") or "")
+            if symbol.startswith("KRW-"):
+                symbol = symbol[4:]
+            quantity_raw = dust_pos.get("quantity")
+            try:
+                quantity_fmt = f"{float(quantity_raw):g}"
+            except (TypeError, ValueError):
+                quantity_fmt = "-"
+            krw_value = float(dust_pos.get("current_krw_value") or 0)
+            dust_lines.append(f"{symbol} {quantity_fmt} (~{krw_value:.0f} KRW)")
+    if dust_lines:
+        lines.append("🧹 Dust")
+        lines.append(
+            f"{', '.join(dust_lines)} — Upbit 최소 주문 금액 미만, execution-actionable 제외, journal 유지. cleanup backlog."
+        )
+        lines.append("")
+
+    # Funding
+    burn_data = daily_burn or {}
+    burn_krw = float(burn_data.get("daily_burn_krw") or 0)
+    active_dca_count = int(burn_data.get("active_count") or 0)
+    lines.append("💰 자금 현황")
+    lines.append(
+        f"daily_burn: {burn_krw:,.0f} KRW (active DCA {active_dca_count}종 · 재산출)"
+    )
+    lines.append("")
+
     # Yesterday fills
     fills_data = yesterday_fills or {}
     total_fills = fills_data.get("total", 0)
@@ -403,6 +507,119 @@ def _build_brief_text(
     lines.append("각 시장별 미체결 상세는 스레드에서 확인 후 리뷰해줘.")
 
     return "\n".join(lines)
+
+
+def _build_tc_preliminary_text(ctx: BoardBriefContext) -> str:
+    lines: list[str] = []
+    lines.append("📊 TC Preliminary — 자금 현황 재계산")
+    lines.append("")
+    lines.append("🧭 Framing")
+    lines.append("경로 A·B 병행 가능. 경로 A/B는 상호배타가 아니다.")
+    lines.append("")
+    lines.append("💰 자금 현황")
+    lines.append(f"- manual_cash: {fmt_amount(float(ctx.manual_cash))}")
+    lines.append(
+        f"- daily_burn: {fmt_amount(float(ctx.daily_burn)) if ctx.daily_burn is not None else '-'}"
+    )
+    lines.append(
+        f"- days_to_next_obligation: {ctx.days_to_next_obligation}일"
+        if ctx.days_to_next_obligation is not None
+        else "- days_to_next_obligation: -"
+    )
+    lines.append("")
+    lines.append("📈 쏠림/편중")
+    if ctx.weights_top_n:
+        for item in ctx.weights_top_n:
+            lines.append(f"- {item.symbol} {item.weight_pct:.1f}% ({item.market})")
+    else:
+        lines.append("- 상위 비중 데이터 없음")
+    lines.append("")
+    lines.append("📉 매도/축소 후보")
+    if ctx.holdings:
+        for item in ctx.holdings[:5]:
+            lines.append(f"- {item.symbol} ({item.market})")
+    else:
+        lines.append("- 후보 없음")
+    if ctx.dust_items:
+        dust_line = ", ".join(
+            f"{item.symbol} (~{int(item.value_krw):,} KRW)" for item in ctx.dust_items
+        )
+        lines.append(f"- Dust footnote: {dust_line}")
+    lines.append("")
+    lines.append("🛣️ 경로 A / 경로 B")
+    lines.append("- A: 즉시 재배치")
+    lines.append("- B: 분할 대응")
+    lines.append("- 경로 A·B 병행 가능")
+    return "\n".join(lines)
+
+
+def _normalize_gate_results(
+    gate_results: dict[str, GateResult | N8nG2GatePayload],
+) -> dict[str, GateResult]:
+    defaults = {
+        "G1": ("G1 Runway", "tbd", "TBD (S7)"),
+        "G2": ("G2 Diversification", "pending", "S5 engineering 중"),
+        "G3": ("G3", "tbd", "TBD (Sx)"),
+        "G4": ("G4", "tbd", "TBD (Sx)"),
+        "G5": ("G5", "tbd", "TBD (Sx)"),
+        "G6": ("G6", "tbd", "TBD (Sx)"),
+    }
+    normalized: dict[str, GateResult] = {}
+    for gate_id, (label, status, detail) in defaults.items():
+        item = gate_results.get(gate_id)
+        if item is None or not isinstance(item, GateResult):
+            normalized[gate_id] = GateResult(
+                id=gate_id, label=label, status=status, detail=detail
+            )
+        else:
+            normalized[gate_id] = item
+    return normalized
+
+
+def _build_cio_pending_text(ctx: BoardBriefContext) -> str:
+    lines: list[str] = [_build_tc_preliminary_text(ctx), ""]
+    lines.append("🎯 권고")
+    lines.append(ctx.cio_recommendation or "(CIO 의견 대기 중)")
+    lines.append("")
+    lines.append("📊 Gate 판정 결과")
+    gate_status_results = _normalize_gate_results(ctx.gate_results)
+    for gate_id in ("G1", "G2", "G3", "G4", "G5", "G6"):
+        gate = gate_status_results[gate_id]
+        lines.append(f"- {gate.id} {gate.label}: {gate.status} ({gate.detail})")
+    g2_payload = ctx.gate_results.get("G2")
+    if isinstance(g2_payload, N8nG2GatePayload) and not g2_payload.pass_:
+        lines.append("🚫 신규 매수 차단 — G2 fail")
+    lines.append("")
+    lines.append("[funding] 자금 의도/제약 확인. (경로 A·B 병행 가능)")
+    lines.append("[action] 실행 우선순위 확인. (경로 A·B 병행 가능)")
+    return "\n".join(lines)
+
+
+def build_tc_preliminary(ctx: BoardBriefContext) -> BoardBriefRender:
+    brief_text = _build_tc_preliminary_text(ctx)
+    return BoardBriefRender(
+        phase="tc_preliminary",
+        brief_text=brief_text,
+        generated_at=ctx.generated_at,
+    )
+
+
+def build_cio_pending_decision(ctx: BoardBriefContext) -> BoardBriefRender:
+    gate_status_results = _normalize_gate_results(ctx.gate_results)
+    merged_gate_results: dict[str, GateResult | N8nG2GatePayload] = {
+        **gate_status_results
+    }
+    if isinstance(ctx.gate_results.get("G2"), N8nG2GatePayload):
+        merged_gate_results["G2"] = ctx.gate_results["G2"]
+
+    pending_ctx = ctx.model_copy(update={"gate_results": merged_gate_results})
+    brief_text = _build_cio_pending_text(pending_ctx)
+    return BoardBriefRender(
+        phase="cio_pending",
+        brief_text=brief_text,
+        gate_results=merged_gate_results,
+        generated_at=ctx.generated_at,
+    )
 
 
 async def fetch_daily_brief(
@@ -435,10 +652,12 @@ async def fetch_daily_brief(
         as_of=effective_as_of,
     )
     portfolio_task = _get_portfolio_overview(effective_markets)
+    daily_burn_task = compute_active_dca_daily_burn()
 
     results_s1 = await asyncio.gather(
         pending_task,
         portfolio_task,
+        daily_burn_task,
         return_exceptions=True,
     )
 
@@ -454,6 +673,18 @@ async def fetch_daily_brief(
         portfolio_result = results_s1[1]
     elif isinstance(results_s1[1], Exception):
         errors.append({"source": "portfolio", "error": str(results_s1[1])})
+
+    daily_burn_result: dict[str, Any] = {
+        "daily_burn_krw": 0.0,
+        "active_count": 0,
+        "per_record": [],
+        "days_to_next_obligation": None,
+        "cash_needed_until_obligation": 0.0,
+    }
+    if isinstance(results_s1[2], dict):
+        daily_burn_result = results_s1[2]
+    elif isinstance(results_s1[2], Exception):
+        errors.append({"source": "daily_burn", "error": str(results_s1[2])})
 
     # Derive shared symbol context for Stage 2
     symbols_by_market = _collect_symbols_by_market(pending_result, portfolio_result)
@@ -518,6 +749,7 @@ async def fetch_daily_brief(
         pending_by_market=pending_by_market,
         portfolio_by_market=portfolio_by_market,
         yesterday_fills=fills_result,
+        daily_burn=daily_burn_result,
     )
 
     # Collect sub-errors
@@ -537,9 +769,10 @@ async def fetch_daily_brief(
             market: portfolio_by_market.get(market) for market in effective_markets
         },
         "yesterday_fills": fills_result,
+        "daily_burn": daily_burn_result,
         "brief_text": brief_text,
         "errors": errors,
     }
 
 
-__all__ = ["fetch_daily_brief"]
+__all__ = ["build_cio_pending_decision", "build_tc_preliminary", "fetch_daily_brief"]

--- a/app/services/n8n_daily_brief_service.py
+++ b/app/services/n8n_daily_brief_service.py
@@ -471,7 +471,9 @@ async def fetch_daily_brief(
     portfolio_task = _get_portfolio_overview(effective_markets)
 
     results_s1 = await asyncio.gather(
-        pending_task, portfolio_task, return_exceptions=True
+        pending_task,
+        portfolio_task,
+        return_exceptions=True,
     )
 
     # Unpack Stage 1 results with fallbacks
@@ -572,3 +574,6 @@ async def fetch_daily_brief(
         "brief_text": brief_text,
         "errors": errors,
     }
+
+
+__all__ = ["fetch_daily_brief"]

--- a/app/services/portfolio_overview_service.py
+++ b/app/services/portfolio_overview_service.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import app.services.brokers.upbit.client as upbit_service
 import app.services.brokers.yahoo.client as yahoo_service
 from app.core.symbol import to_db_symbol
+from app.mcp_server.tooling.shared import min_order_krw
 from app.models.manual_holdings import MarketType
 from app.services.brokers.kis.client import KISClient
 from app.services.exchange_rate_service import get_usd_krw_rate
@@ -1149,6 +1150,11 @@ class PortfolioOverviewService:
                 market_type=row["market_type"],
                 usd_krw=usd_krw,
             )
+            is_dust = False
+            if row["market_type"] == _MARKET_CRYPTO:
+                evaluation = float(totals["evaluation"] or 0)
+                if evaluation > 0:
+                    is_dust = evaluation < min_order_krw(str(row["symbol"]))
 
             rows.append(
                 {
@@ -1163,6 +1169,7 @@ class PortfolioOverviewService:
                     "profit_rate": totals["profit_rate"],
                     "evaluation_krw": totals["evaluation_krw"],
                     "profit_loss_krw": totals["profit_loss_krw"],
+                    "dust": is_dust,
                     "components": components_list,
                 }
             )

--- a/tests/test_dust_accounting.py
+++ b/tests/test_dust_accounting.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_list_holdings_marks_crypto_dust_and_keeps_non_crypto_false(monkeypatch):
+    from app.mcp_server.tooling import portfolio_holdings
+
+    positions = [
+        {
+            "account": "upbit",
+            "account_name": "기본 계좌",
+            "broker": "upbit",
+            "source": "upbit_api",
+            "instrument_type": "crypto",
+            "market": "crypto",
+            "symbol": "KRW-BTC",
+            "name": "비트코인",
+            "quantity": 0.00005,
+            "avg_buy_price": 70_000_000.0,
+            "current_price": 70_000_000.0,
+            "evaluation_amount": 3500.0,
+            "profit_loss": 0.0,
+            "profit_rate": 0.0,
+        },
+        {
+            "account": "upbit",
+            "account_name": "기본 계좌",
+            "broker": "upbit",
+            "source": "upbit_api",
+            "instrument_type": "crypto",
+            "market": "crypto",
+            "symbol": "KRW-ETH",
+            "name": "이더리움",
+            "quantity": 0.02,
+            "avg_buy_price": 4_000_000.0,
+            "current_price": 4_000_000.0,
+            "evaluation_amount": 80_000.0,
+            "profit_loss": 0.0,
+            "profit_rate": 0.0,
+        },
+        {
+            "account": "kis",
+            "account_name": "기본 계좌",
+            "broker": "kis",
+            "source": "kis_api",
+            "instrument_type": "equity_us",
+            "market": "us",
+            "symbol": "AAPL",
+            "name": "Apple",
+            "quantity": 1.0,
+            "avg_buy_price": 50.0,
+            "current_price": 50.0,
+            "evaluation_amount": 50.0,
+            "profit_loss": 0.0,
+            "profit_rate": 0.0,
+        },
+    ]
+
+    monkeypatch.setattr(
+        portfolio_holdings,
+        "_collect_portfolio_positions",
+        AsyncMock(return_value=(positions, [], None, None)),
+    )
+    monkeypatch.setattr(
+        portfolio_holdings,
+        "_build_holdings_summary",
+        lambda _positions, _include_current_price: {
+            "total_buy_amount": 0.0,
+            "total_evaluation": 0.0,
+            "total_profit_loss": 0.0,
+            "total_profit_rate": 0.0,
+            "position_count": len(_positions),
+            "weights": [],
+        },
+    )
+    monkeypatch.setattr(
+        portfolio_holdings,
+        "_min_order_krw",
+        lambda _symbol: 5_000.0,
+    )
+
+    result = await portfolio_holdings._get_holdings_impl(minimum_value=0)
+
+    by_symbol: dict[str, dict[str, object]] = {}
+    for account in result["accounts"]:
+        for row in account["positions"]:
+            by_symbol[row["symbol"]] = row
+
+    assert by_symbol["KRW-BTC"]["dust"] is True
+    assert by_symbol["KRW-ETH"]["dust"] is False
+    assert by_symbol["AAPL"]["dust"] is False
+
+
+def test_min_order_krw_returns_fixed_crypto_minimum():
+    from app.mcp_server.tooling import shared
+
+    assert shared.min_order_krw("KRW-BTC") == shared.DEFAULT_MINIMUM_VALUES["crypto"]
+    assert shared.min_order_krw("KRW-ETH") == shared.DEFAULT_MINIMUM_VALUES["crypto"]
+
+
+def test_position_to_output_includes_dust_with_false_default():
+    from app.mcp_server.tooling.shared import position_to_output
+
+    base = {
+        "symbol": "KRW-BTC",
+        "name": "비트코인",
+        "market": "crypto",
+        "quantity": 1.0,
+        "avg_buy_price": 10.0,
+        "current_price": 10.0,
+        "evaluation_amount": 10.0,
+        "profit_loss": 0.0,
+        "profit_rate": 0.0,
+    }
+    with_dust = position_to_output({**base, "dust": True})
+    without_dust = position_to_output(base)
+
+    assert with_dust["dust"] is True
+    assert without_dust["dust"] is False
+
+
+def test_portfolio_overview_aggregate_sets_dust_for_crypto_only():
+    from app.services.portfolio_overview_service import PortfolioOverviewService
+
+    service = PortfolioOverviewService(AsyncMock())
+    components = [
+        {
+            "account_key": "live:upbit",
+            "broker": "upbit",
+            "account_name": "업비트",
+            "source": "live",
+            "market_type": "CRYPTO",
+            "symbol": "KRW-BTC",
+            "name": "비트코인",
+            "quantity": 0.00005,
+            "avg_price": 70_000_000.0,
+            "current_price": 70_000_000.0,
+            "evaluation": 3500.0,
+            "profit_loss": 0.0,
+            "profit_rate": 0.0,
+        },
+        {
+            "account_key": "live:upbit",
+            "broker": "upbit",
+            "account_name": "업비트",
+            "source": "live",
+            "market_type": "CRYPTO",
+            "symbol": "KRW-ETH",
+            "name": "이더리움",
+            "quantity": 0.02,
+            "avg_price": 4_000_000.0,
+            "current_price": 4_000_000.0,
+            "evaluation": 80_000.0,
+            "profit_loss": 0.0,
+            "profit_rate": 0.0,
+        },
+        {
+            "account_key": "live:kis",
+            "broker": "kis",
+            "account_name": "KIS",
+            "source": "live",
+            "market_type": "KR",
+            "symbol": "005930",
+            "name": "삼성전자",
+            "quantity": 1.0,
+            "avg_price": 3000.0,
+            "current_price": 3000.0,
+            "evaluation": 3000.0,
+            "profit_loss": 0.0,
+            "profit_rate": 0.0,
+        },
+        {
+            "account_key": "live:kis-us",
+            "broker": "kis",
+            "account_name": "KIS US",
+            "source": "live",
+            "market_type": "US",
+            "symbol": "AAPL",
+            "name": "Apple",
+            "quantity": 1.0,
+            "avg_price": 50.0,
+            "current_price": 50.0,
+            "evaluation": 50.0,
+            "profit_loss": 0.0,
+            "profit_rate": 0.0,
+        },
+    ]
+
+    rows = service._aggregate_positions(components, usd_krw=1300.0)
+    by_symbol = {row["symbol"]: row for row in rows}
+
+    assert by_symbol["KRW-BTC"]["dust"] is True
+    assert by_symbol["KRW-ETH"]["dust"] is False
+    assert by_symbol["005930"]["dust"] is False
+    assert by_symbol["AAPL"]["dust"] is False
+
+
+def test_build_brief_text_renders_dust_footnote_phrase_and_omits_when_none():
+    from app.schemas.n8n.common import N8nMarketOverview
+    from app.services.n8n_daily_brief_service import _build_brief_text
+
+    with_dust = _build_brief_text(
+        date_fmt="04/17 (금)",
+        market_overview=N8nMarketOverview(
+            fear_greed=None,
+            btc_dominance=None,
+            total_market_cap_change_24h=None,
+            economic_events_today=[],
+        ),
+        pending_by_market={},
+        portfolio_by_market={
+            "crypto": {
+                "total_value_fmt": "100만",
+                "pnl_fmt": "+1.0%",
+                "dust_positions": [
+                    {
+                        "symbol": "KRW-BTC",
+                        "quantity": 0.00001,
+                        "current_krw_value": 350.0,
+                    }
+                ],
+            }
+        },
+        yesterday_fills={"total": 0, "fills": []},
+    )
+    without_dust = _build_brief_text(
+        date_fmt="04/17 (금)",
+        market_overview=N8nMarketOverview(
+            fear_greed=None,
+            btc_dominance=None,
+            total_market_cap_change_24h=None,
+            economic_events_today=[],
+        ),
+        pending_by_market={},
+        portfolio_by_market={
+            "crypto": {
+                "total_value_fmt": "100만",
+                "pnl_fmt": "+1.0%",
+                "dust_positions": [],
+            }
+        },
+        yesterday_fills={"total": 0, "fills": []},
+    )
+
+    assert "🧹 Dust" in with_dust
+    assert "execution-actionable 제외, journal 유지" in with_dust
+    assert "BTC 1e-05 (~350 KRW)" in with_dust
+    assert "🧹 Dust" not in without_dust
+
+
+def test_build_portfolio_summary_excludes_dust_from_top_gainers_and_losers():
+    from app.services.n8n_daily_brief_service import _build_portfolio_summary
+
+    summary = _build_portfolio_summary(
+        {
+            "positions": [
+                {
+                    "market_type": "CRYPTO",
+                    "symbol": "KRW-BTC",
+                    "name": "비트코인",
+                    "quantity": 0.00001,
+                    "avg_price": 35_000_000.0,
+                    "evaluation": 350.0,
+                    "profit_rate": 0.10,
+                    "profit_loss": 35.0,
+                    "dust": True,
+                },
+                {
+                    "market_type": "CRYPTO",
+                    "symbol": "KRW-ETH",
+                    "name": "이더리움",
+                    "quantity": 0.1,
+                    "avg_price": 4_000_000.0,
+                    "evaluation": 450_000.0,
+                    "profit_rate": 0.05,
+                    "profit_loss": 22_500.0,
+                    "dust": False,
+                },
+                {
+                    "market_type": "CRYPTO",
+                    "symbol": "KRW-XRP",
+                    "name": "리플",
+                    "quantity": 100.0,
+                    "avg_price": 1000.0,
+                    "evaluation": 90_000.0,
+                    "profit_rate": -0.10,
+                    "profit_loss": -10_000.0,
+                    "dust": False,
+                },
+            ]
+        }
+    )
+
+    gainers = [row["symbol"] for row in summary["crypto"]["top_gainers"]]
+    losers = [row["symbol"] for row in summary["crypto"]["top_losers"]]
+    assert "KRW-BTC" not in gainers
+    assert "KRW-BTC" not in losers


### PR DESCRIPTION
## 목적
S4 dust 회계 분리를 구현했습니다. `dust=True` 포지션은 회계/저널에는 유지하고, execution-actionable 소비 경로에서 제외할 수 있도록 `list_holdings()` 및 포트폴리오 summary 경로에 플래그를 추가했습니다.

## 스코프 (ROB-145 전용 5개 파일)
- `app/mcp_server/tooling/portfolio_holdings.py`
- `app/mcp_server/tooling/shared.py`
- `app/services/portfolio_overview_service.py`
- `app/services/n8n_daily_brief_service.py`
- `tests/test_dust_accounting.py` (신규)

## 구현 요약
- `shared.py`
  - `min_order_krw(symbol)` 추가 (crypto 최소 주문 기준 5000 KRW 고정)
  - `position_to_output()` 화이트리스트에 `dust` 추가
- `portfolio_holdings.py`
  - `include_current_price=True`일 때 crypto 포지션에 `dust` 계산
  - non-crypto 및 평가금액 미확정 케이스는 `dust=False`
- `portfolio_overview_service.py`
  - aggregate 결과 포지션에 `dust` 전파 (crypto-only 판정)
- `n8n_daily_brief_service.py`
  - `top_gainers`/`top_losers`에서 dust 포지션 제외
  - `📊 포트폴리오` 다음에 dust footnote 자동 삽입
  - 필수 문구 반영: `execution-actionable 제외, journal 유지`
- `tests/test_dust_accounting.py`
  - dust 판정/전파/footnote/상위 수익률 제외 규칙 단위 테스트 추가

## 수락 기준 검증 로그
1. `DATABASE_URL=postgresql+asyncpg://user:pass@localhost:5432/db uv run pytest tests/test_dust_accounting.py -v`
- 결과: **6 passed**

2. `uv run ruff check app tests`
- 결과: 현 브랜치 `main` 기준 기존 파일 `tests/test_sell_signal_service.py`의 사전 존재 lint 이슈 3건으로 실패
- ROB-145 변경 5개 파일 대상 검사 결과는 통과 (`ruff check <5 files>`)

3. `uv run ruff format --check app tests`
- 결과: 동일하게 `tests/test_sell_signal_service.py` 기존 포맷 이슈로 실패
- ROB-145 변경 5개 파일 대상 검사 결과는 통과 (`ruff format --check <5 files>`)

## footnote 렌더링 샘플
```text
🧹 Dust
BTC 1e-05 (~350 KRW), ETH 0.0002 (~800 KRW) — Upbit 최소 주문 금액 미만, execution-actionable 제외, journal 유지. cleanup backlog.
```

## 연관 이슈
- [ROB-142](/ROB/issues/ROB-142)
- [ROB-146](/ROB/issues/ROB-146)
- [ROB-149](/ROB/issues/ROB-149)

