### PR TITLE
[ROB-168] Gate defensive trim order bypass

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -333,6 +333,9 @@ class Settings(BaseSettings):
     # N8N API Key Authentication
     N8N_API_KEY: str = ""
     PUBLIC_API_PATHS: list[str] = []
+    trader_agent_id: str = "6b2192cc-14fa-4335-b572-2fe1e0cb54a7"
+    paperclip_api_url: str | None = None
+    paperclip_api_key: str | None = None
 
     public_base_url: str = "https://mgh3326.duckdns.org"
 

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -94,12 +94,13 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - `format_execution_comment(stage, symbol, side, filled_qty, filled_price, ...)` - Format Discord/Paperclip-ready Markdown for `fill` and `follow_up` execution stages.
 - `get_latest_market_brief(symbols=None, market=None, limit=10)` - Return concise latest AI analysis context for recent or selected symbols.
 - `get_market_reports(symbol, days=7, limit=10)` - Return detailed AI analysis report history and decision trend for one symbol.
-- `place_order(symbol, side, order_type="limit", quantity=None, price=None, amount=None, dry_run=True, reason="", exit_reason=None, thesis=None, strategy=None, target_price=None, stop_loss=None, min_hold_days=None, notes=None, indicators_snapshot=None)`
+- `place_order(symbol, side, order_type="limit", quantity=None, price=None, amount=None, dry_run=True, reason="", exit_reason=None, thesis=None, strategy=None, target_price=None, stop_loss=None, min_hold_days=None, notes=None, indicators_snapshot=None, defensive_trim=False, approval_issue_id=None, requester_agent_id=None)`
   - `side="buy"` 이고 `dry_run=False` 인 경우 `thesis` 와 `strategy` 가 필수
   - 실매수 성공 시 trade journal draft를 자동 생성하고 fill 저장 후 active로 연결 시도
   - 실매도 성공 시 동일 symbol의 active journal을 FIFO 기준으로 auto-close 시도
   - 부분 매도는 quantity를 수정하지 않고, fully-consumed journal만 close한다
   - journal close 실패는 주문 성공을 되돌리지 않고 `journal_warning` 으로 응답한다
+  - `defensive_trim=True` 는 ROB-164/ROB-166 승인 기반 제한 경로이며 `(a) side="sell"`, `(b) order_type="limit"`, `(c) `approval_issue_id` 가 Paperclip `done` 상태, `(d) `requester_agent_id` 가 Trader agent 와 일치할 때만 평균단가 1% 매도 floor 를 우회한다
 - `modify_order(order_id, symbol, market=None, new_price=None, new_quantity=None, dry_run=True)`
 - `cancel_order(order_id, symbol=None, market=None)`
   - US equities: resolves exchange from symbol DB, open orders, and recent history before cancel

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -22,6 +22,7 @@ from app.mcp_server.tooling.order_journal import (
     _validate_buy_journal_requirements,
 )
 from app.mcp_server.tooling.order_validation import (
+    DefensiveTrimContext,
     _check_balance_and_warn,
     _check_daily_order_limit,
     _get_balance_for_order,
@@ -30,6 +31,7 @@ from app.mcp_server.tooling.order_validation import (
     _preview_order,
     _record_order_history,
     _resolve_buy_quantity,
+    _validate_defensive_trim_preconditions,
     _validate_sell_side,
 )
 from app.mcp_server.tooling.shared import logger
@@ -287,6 +289,7 @@ async def _build_preview(
     price: float | None,
     current_price: float,
     market_type: str,
+    defensive_trim_ctx: DefensiveTrimContext | None,
 ) -> dict[str, Any]:
     """Run preview and enrich result with defaults."""
     dry_run_result = await _preview_order(
@@ -297,6 +300,7 @@ async def _build_preview(
         price=price,
         current_price=current_price,
         market_type=market_type,
+        defensive_trim_ctx=defensive_trim_ctx,
     )
     if not isinstance(dry_run_result, dict):
         raise ValueError("Order preview returned invalid result")
@@ -597,6 +601,7 @@ async def _execute_and_record(
     min_hold_days: int | None,
     notes: str | None,
     indicators_snapshot: dict[str, Any] | None,
+    defensive_trim_ctx: DefensiveTrimContext | None,
     order_error_fn: Any,
 ) -> dict[str, Any]:
     """Execute a live order, record history, fills, and journals."""
@@ -632,6 +637,13 @@ async def _execute_and_record(
         amount=order_amount,
         reason=reason,
         dry_run=False,
+        defensive_trim=defensive_trim_ctx is not None,
+        approval_issue_id=(
+            defensive_trim_ctx.approval_issue_id if defensive_trim_ctx else None
+        ),
+        requester_agent_id=(
+            defensive_trim_ctx.requester_agent_id if defensive_trim_ctx else None
+        ),
     )
 
     # Record phase: fills + journals
@@ -700,6 +712,9 @@ async def _place_order_impl(
     min_hold_days: int | None = None,
     notes: str | None = None,
     indicators_snapshot: dict[str, Any] | None = None,
+    defensive_trim: bool = False,
+    approval_issue_id: str | None = None,
+    requester_agent_id: str | None = None,
 ) -> dict[str, Any]:
     symbol, side_lower, order_type_lower = _validate_inputs(
         symbol,
@@ -734,6 +749,17 @@ async def _place_order_impl(
 
     def _order_error(message: str) -> dict[str, Any]:
         return _build_order_error(message, source, normalized_symbol, market_type)
+
+    try:
+        defensive_trim_ctx = await _validate_defensive_trim_preconditions(
+            defensive_trim=defensive_trim,
+            approval_issue_id=approval_issue_id,
+            requester_agent_id=requester_agent_id,
+            side=side_lower,
+            order_type=order_type_lower,
+        )
+    except ValueError as e:
+        return _order_error(str(e))
 
     # Check stop-loss cooldown for crypto buys
     if side_lower == "buy" and market_type == "crypto":
@@ -776,6 +802,7 @@ async def _place_order_impl(
                 price=price,
                 current_price=current_price,
                 order_error_fn=_order_error,
+                defensive_trim_ctx=defensive_trim_ctx,
             )
             if sell_error is not None:
                 return sell_error
@@ -790,6 +817,7 @@ async def _place_order_impl(
                 price=price,
                 current_price=current_price,
                 market_type=market_type,
+                defensive_trim_ctx=defensive_trim_ctx,
             )
         except ValueError as preview_exc:
             return _order_error(str(preview_exc))
@@ -835,6 +863,7 @@ async def _place_order_impl(
             min_hold_days=min_hold_days,
             notes=notes,
             indicators_snapshot=indicators_snapshot,
+            defensive_trim_ctx=defensive_trim_ctx,
             order_error_fn=_order_error,
         )
     except Exception as exc:
@@ -848,6 +877,13 @@ async def _place_order_impl(
             reason=reason,
             dry_run=True,
             error=str(exc),
+            defensive_trim=defensive_trim_ctx is not None,
+            approval_issue_id=(
+                defensive_trim_ctx.approval_issue_id if defensive_trim_ctx else None
+            ),
+            requester_agent_id=(
+                defensive_trim_ctx.requester_agent_id if defensive_trim_ctx else None
+            ),
         )
         return _order_error(str(exc))
 

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import datetime
 import json
+import re
+import time
+from dataclasses import dataclass
 from typing import Any
+
+import httpx
 
 import app.services.brokers.upbit.client as upbit_service
 from app.core.config import settings
@@ -27,6 +32,147 @@ from app.services.brokers.kis import (
 from app.services.brokers.upbit.client import (
     parse_upbit_account_row as _parse_upbit_account_row,
 )
+
+_DEFENSIVE_TRIM_APPROVAL_REGEX = re.compile(r"^[A-Z]+-\d+$")
+_DEFENSIVE_TRIM_CACHE_TTL_SECONDS = 60.0
+_defensive_trim_success_cache: dict[str, float] = {}
+_TRADER_AGENT_ID_DEFAULT = "6b2192cc-14fa-4335-b572-2fe1e0cb54a7"
+
+
+@dataclass(frozen=True)
+class DefensiveTrimContext:
+    approval_issue_id: str
+    requester_agent_id: str
+    approval_verified_at: datetime.datetime
+
+
+def _is_cached_approved(approval_issue_id: str) -> bool:
+    expires_at = _defensive_trim_success_cache.get(approval_issue_id)
+    if expires_at is None:
+        return False
+    if expires_at <= time.time():
+        _defensive_trim_success_cache.pop(approval_issue_id, None)
+        return False
+    return True
+
+
+def _cache_approved(approval_issue_id: str) -> None:
+    _defensive_trim_success_cache[approval_issue_id] = (
+        time.time() + _DEFENSIVE_TRIM_CACHE_TTL_SECONDS
+    )
+
+
+def _log_defensive_trim_bypass(
+    *,
+    symbol: str,
+    market_type: str,
+    price: float,
+    current_price: float,
+    avg_price: float,
+    min_sell_price: float,
+    defensive_trim_ctx: DefensiveTrimContext,
+    phase: str,
+) -> None:
+    logger.warning(
+        "defensive_trim_bypass_active: sell floor bypassed",
+        extra={
+            "symbol": symbol,
+            "market_type": market_type,
+            "price": price,
+            "current_price": current_price,
+            "avg_price": avg_price,
+            "min_sell_price": min_sell_price,
+            "approval_issue_id": defensive_trim_ctx.approval_issue_id,
+            "requester_agent_id": defensive_trim_ctx.requester_agent_id,
+            "phase": phase,
+        },
+    )
+
+
+async def _fetch_approval_issue_status(approval_issue_id: str) -> str | None:
+    api_url = getattr(settings, "paperclip_api_url", None)
+    api_key = getattr(settings, "paperclip_api_key", None)
+    if not api_url or not api_key:
+        logger.warning(
+            "defensive_trim disabled: missing PAPERCLIP_API_URL or PAPERCLIP_API_KEY"
+        )
+        return None
+
+    issue_api_url = f"{api_url.rstrip('/')}/api/issues/{approval_issue_id}"
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    try:
+        async with httpx.AsyncClient(timeout=2.0) as client:
+            response = await client.get(issue_api_url, headers=headers)
+    except Exception:
+        return None
+
+    if response.status_code != 200:
+        return None
+
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+
+    status = payload.get("status")
+    return str(status) if status is not None else None
+
+
+async def _validate_defensive_trim_preconditions(
+    *,
+    defensive_trim: bool,
+    approval_issue_id: str | None,
+    requester_agent_id: str | None,
+    side: str,
+    order_type: str,
+) -> DefensiveTrimContext | None:
+    if not defensive_trim:
+        return None
+
+    if side != "sell":
+        raise ValueError(
+            "defensive_trim requires side='sell' (buy orders always use existing path)"
+        )
+    if order_type != "limit":
+        raise ValueError(
+            "defensive_trim requires order_type='limit' (market orders are blocked)"
+        )
+    if not approval_issue_id:
+        raise ValueError("defensive_trim=True requires approval_issue_id")
+    if not _DEFENSIVE_TRIM_APPROVAL_REGEX.match(approval_issue_id):
+        raise ValueError("approval_issue_id format invalid (expected e.g. 'ROB-164')")
+    if not requester_agent_id:
+        raise ValueError("requester_agent_id is required for defensive_trim")
+
+    trader_agent_id = getattr(settings, "trader_agent_id", _TRADER_AGENT_ID_DEFAULT)
+    if requester_agent_id != trader_agent_id:
+        raise ValueError(
+            "defensive_trim requires Trader agent caller "
+            f"(got requester_agent_id={requester_agent_id})"
+        )
+
+    approval_status: str | None
+    if _is_cached_approved(approval_issue_id):
+        approval_status = "done"
+    else:
+        try:
+            approval_status = await _fetch_approval_issue_status(approval_issue_id)
+        except Exception:
+            approval_status = None
+        if approval_status == "done":
+            _cache_approved(approval_issue_id)
+
+    if approval_status != "done":
+        raise ValueError(
+            f"approval_issue_id {approval_issue_id} not found or not in 'done' status"
+        )
+
+    return DefensiveTrimContext(
+        approval_issue_id=approval_issue_id,
+        requester_agent_id=requester_agent_id,
+        approval_verified_at=datetime.datetime.now(datetime.UTC),
+    )
 
 
 async def _get_current_price_for_order(symbol: str, market_type: str) -> float | None:
@@ -145,6 +291,9 @@ async def _record_order_history(
     reason: str,
     dry_run: bool,
     error: str | None = None,
+    defensive_trim: bool = False,
+    approval_issue_id: str | None = None,
+    requester_agent_id: str | None = None,
 ) -> None:
     try:
         import redis.asyncio as redis_async
@@ -169,6 +318,9 @@ async def _record_order_history(
             "reason": reason,
             "dry_run": dry_run,
             "error": error,
+            "defensive_trim": defensive_trim,
+            "approval_issue_id": approval_issue_id,
+            "requester_agent_id": requester_agent_id,
         }
 
         await redis.rpush(key, json.dumps(record))
@@ -253,6 +405,7 @@ async def _preview_sell(
     price: float | None,
     current_price: float,
     market_type: str,
+    defensive_trim_ctx: DefensiveTrimContext | None = None,
 ) -> dict[str, Any]:
     """Build a dry-run preview dict for a sell order."""
     result: dict[str, Any] = {
@@ -277,18 +430,33 @@ async def _preview_sell(
             result["error"] = "price is required for limit sell orders"
             return result
         min_sell_price = avg_price * 1.01
-        if price < min_sell_price:
+        if price < min_sell_price and defensive_trim_ctx is None:
             result["error"] = (
                 f"Sell price {price} below minimum "
                 f"(avg_buy_price * 1.01 = {min_sell_price:.0f})"
             )
             return result
+        if price < min_sell_price and defensive_trim_ctx is not None:
+            _log_defensive_trim_bypass(
+                symbol=symbol,
+                market_type=market_type,
+                price=price,
+                current_price=current_price,
+                avg_price=avg_price,
+                min_sell_price=min_sell_price,
+                defensive_trim_ctx=defensive_trim_ctx,
+                phase="preview",
+            )
         if price < current_price:
             result["error"] = f"Sell price {price} below current price {current_price}"
             return result
         order_quantity = holdings["quantity"] if quantity is None else quantity
         execution_price = price
         result["price"] = execution_price
+
+    if defensive_trim_ctx is not None:
+        result["defensive_trim"] = True
+        result["approval_issue_id"] = defensive_trim_ctx.approval_issue_id
 
     estimated_value = execution_price * order_quantity
     realized_pnl = (execution_price - avg_price) * order_quantity
@@ -309,6 +477,7 @@ async def _preview_order(
     price: float | None,
     current_price: float,
     market_type: str,
+    defensive_trim_ctx: DefensiveTrimContext | None = None,
 ) -> dict[str, Any]:
     """Validate order and return a dry-run simulation dict.
 
@@ -330,6 +499,7 @@ async def _preview_order(
         price=price,
         current_price=current_price,
         market_type=market_type,
+        defensive_trim_ctx=defensive_trim_ctx,
     )
 
 
@@ -392,6 +562,7 @@ async def _validate_sell_side(
     price: float | None,
     current_price: float,
     order_error_fn: Any,
+    defensive_trim_ctx: DefensiveTrimContext | None = None,
 ) -> tuple[float, float, dict[str, Any] | None]:
     """Validate sell-side: check holdings, locked, price constraints.
 
@@ -419,7 +590,7 @@ async def _validate_sell_side(
 
     if order_type == "limit" and price is not None:
         min_sell_price = avg_price * 1.01
-        if price < min_sell_price:
+        if price < min_sell_price and defensive_trim_ctx is None:
             return (
                 0.0,
                 0.0,
@@ -427,6 +598,17 @@ async def _validate_sell_side(
                     f"Sell price {price} below minimum "
                     f"(avg_buy_price * 1.01 = {min_sell_price:.0f})"
                 ),
+            )
+        if price < min_sell_price and defensive_trim_ctx is not None:
+            _log_defensive_trim_bypass(
+                symbol=normalized_symbol,
+                market_type=market_type,
+                price=price,
+                current_price=current_price,
+                avg_price=avg_price,
+                min_sell_price=min_sell_price,
+                defensive_trim_ctx=defensive_trim_ctx,
+                phase="execution",
             )
         if price < current_price:
             return (

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -87,7 +87,11 @@ def register_order_tools(mcp: FastMCP) -> None:
             "(no real broker calls, uses PaperTradingService). In paper mode, the "
             "default account is auto-created with 100,000,000 KRW on first use; "
             "pass paper_account to target a named paper account. "
-            "Journal features (thesis/strategy/FIFO close) ARE supported in paper mode."
+            "Journal features (thesis/strategy/FIFO close) ARE supported in paper mode. "
+            "defensive_trim=True enables a sell/limit-only floor bypass path. "
+            "ROB-164/ROB-166 defensive_trim requires ALL of: (a) side='sell', "
+            "(b) order_type='limit', (c) valid approval_issue_id with approval issue "
+            "status=done in Paperclip, and (d) requester_agent_id matching Trader."
         ),
     )
     async def place_order(
@@ -107,12 +111,26 @@ def register_order_tools(mcp: FastMCP) -> None:
         min_hold_days: int | None = None,
         notes: str | None = None,
         indicators_snapshot: dict[str, Any] | None = None,
+        defensive_trim: bool = False,
+        approval_issue_id: str | None = None,
+        requester_agent_id: str | None = None,
         account_type: Literal["real", "paper"] = "real",
         paper_account: str | None = None,
     ):
         # Defense in depth: reject market orders even if a stale client
         # bypasses the tightened schema and still sends order_type="market".
         if str(order_type).lower().strip() != "limit":
+            if defensive_trim:
+                return {
+                    "success": False,
+                    "error": (
+                        "defensive_trim requires order_type='limit' "
+                        "(market orders are blocked)"
+                    ),
+                    "source": "mcp",
+                    "symbol": symbol,
+                    "order_type": order_type,
+                }
             return {
                 "success": False,
                 "error": (
@@ -160,6 +178,9 @@ def register_order_tools(mcp: FastMCP) -> None:
             min_hold_days=min_hold_days,
             notes=notes,
             indicators_snapshot=indicators_snapshot,
+            defensive_trim=defensive_trim,
+            approval_issue_id=approval_issue_id,
+            requester_agent_id=requester_agent_id,
         )
 
     @mcp.tool(

--- a/tests/test_mcp_place_order_defensive_trim.py
+++ b/tests/test_mcp_place_order_defensive_trim.py
@@ -1,0 +1,453 @@
+"""Unit tests for defensive_trim gating in place_order."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+import app.services.brokers.upbit.client as upbit_service
+from app.core.config import settings
+from app.mcp_server.tooling import order_execution, order_validation
+from app.mcp_server.tooling.orders_registration import register_order_tools
+from tests._mcp_tooling_support import build_tools
+
+TRADER_AGENT_ID = "6b2192cc-14fa-4335-b572-2fe1e0cb54a7"
+
+
+def _mock_crypto_sell_context(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    current_price: float = 1000.0,
+    balance: str = "2.0",
+    avg_buy_price: str = "1000.0",
+) -> None:
+    monkeypatch.setattr(
+        upbit_service,
+        "fetch_multiple_current_prices",
+        AsyncMock(return_value={"KRW-BTC": current_price}),
+    )
+    monkeypatch.setattr(
+        upbit_service,
+        "fetch_my_coins",
+        AsyncMock(
+            return_value=[
+                {
+                    "currency": "BTC",
+                    "balance": balance,
+                    "locked": "0",
+                    "avg_buy_price": avg_buy_price,
+                }
+            ]
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _set_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "trader_agent_id", TRADER_AGENT_ID, raising=False)
+    monkeypatch.setattr(
+        settings,
+        "paperclip_api_url",
+        "https://paperclip.local",
+        raising=False,
+    )
+    monkeypatch.setattr(settings, "paperclip_api_key", "test-token", raising=False)
+    order_validation._defensive_trim_success_cache.clear()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_defensive_trim_schema_blocks_market_even_with_flag() -> None:
+    """defensive_trim path rejects market orders."""
+    tools = build_tools()
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="market",
+        defensive_trim=True,
+        approval_issue_id="ROB-164",
+        requester_agent_id=TRADER_AGENT_ID,
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert (
+        result["error"]
+        == "defensive_trim requires order_type='limit' (market orders are blocked)"
+    )
+
+
+@pytest.mark.unit
+def test_place_order_description_documents_four_and_defensive_trim_gate() -> None:
+    """Public tool description documents every defensive_trim gate."""
+
+    class CapturingMCP:
+        def __init__(self) -> None:
+            self.descriptions: dict[str, str] = {}
+
+        def tool(self, name: str, description: str):
+            self.descriptions[name] = description
+
+            def decorator(func):
+                return func
+
+            return decorator
+
+    mcp = CapturingMCP()
+    register_order_tools(mcp)  # type: ignore[arg-type]
+
+    description = mcp.descriptions["place_order"]
+    assert "defensive_trim=True" in description
+    assert "(a) side='sell'" in description
+    assert "(b) order_type='limit'" in description
+    assert "(c) valid approval_issue_id" in description
+    assert "(d) requester_agent_id matching Trader" in description
+    assert "approval issue status=done" in description
+    assert "ROB-164/ROB-166" in description
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_flag_off_limit_below_floor_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """defensive_trim=False keeps avg*1.01 floor enforcement."""
+    tools = build_tools()
+    _mock_crypto_sell_context(monkeypatch, current_price=1000.0, avg_buy_price="1000.0")
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=1005.0,
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert "below minimum" in result["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_flag_on_with_valid_approval_and_trader_caller_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Valid 4-gate combination allows floor bypass in preview."""
+    tools = build_tools()
+    _mock_crypto_sell_context(monkeypatch, current_price=1000.0, avg_buy_price="1000.0")
+    monkeypatch.setattr(
+        order_validation,
+        "_fetch_approval_issue_status",
+        AsyncMock(return_value="done"),
+    )
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=1005.0,
+        defensive_trim=True,
+        approval_issue_id="ROB-164",
+        requester_agent_id=TRADER_AGENT_ID,
+        dry_run=True,
+    )
+
+    assert result["success"] is True
+    assert result["dry_run"] is True
+    assert result["defensive_trim"] is True
+    assert result["approval_issue_id"] == "ROB-164"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_flag_on_floor_bypass_logs_structured_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """defensive_trim floor bypass emits the ST-2 audit warning fields."""
+    tools = build_tools()
+    _mock_crypto_sell_context(monkeypatch, current_price=1000.0, avg_buy_price="1000.0")
+    monkeypatch.setattr(
+        order_validation,
+        "_fetch_approval_issue_status",
+        AsyncMock(return_value="done"),
+    )
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=1005.0,
+        defensive_trim=True,
+        approval_issue_id="ROB-164",
+        requester_agent_id=TRADER_AGENT_ID,
+        dry_run=True,
+    )
+
+    assert result["success"] is True
+    warning_records = [
+        record
+        for record in caplog.records
+        if record.message.startswith("defensive_trim_bypass_active")
+    ]
+    assert {record.phase for record in warning_records} == {"execution", "preview"}
+    for record in warning_records:
+        assert record.approval_issue_id == "ROB-164"
+        assert record.requester_agent_id == TRADER_AGENT_ID
+        assert record.symbol == "KRW-BTC"
+        assert record.price == pytest.approx(1005.0)
+        assert record.min_sell_price == pytest.approx(1010.0)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_flag_on_missing_approval_id_rejected() -> None:
+    """defensive_trim requires approval_issue_id."""
+    tools = build_tools()
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=1005.0,
+        defensive_trim=True,
+        requester_agent_id=TRADER_AGENT_ID,
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "defensive_trim=True requires approval_issue_id"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_flag_on_malformed_approval_id_rejected() -> None:
+    """approval_issue_id must match ticket-like format."""
+    tools = build_tools()
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=1005.0,
+        defensive_trim=True,
+        approval_issue_id="bad-format",
+        requester_agent_id=TRADER_AGENT_ID,
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert (
+        result["error"] == "approval_issue_id format invalid (expected e.g. 'ROB-164')"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_flag_on_approval_not_done_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Approval must exist and be in done status."""
+    tools = build_tools()
+    monkeypatch.setattr(
+        order_validation,
+        "_fetch_approval_issue_status",
+        AsyncMock(return_value="in_progress"),
+    )
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=1005.0,
+        defensive_trim=True,
+        approval_issue_id="ROB-164",
+        requester_agent_id=TRADER_AGENT_ID,
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert (
+        result["error"] == "approval_issue_id ROB-164 not found or not in 'done' status"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_flag_on_paperclip_api_timeout_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Paperclip API timeout fails closed."""
+    tools = build_tools()
+    monkeypatch.setattr(
+        order_validation,
+        "_fetch_approval_issue_status",
+        AsyncMock(side_effect=TimeoutError("timeout")),
+    )
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=1005.0,
+        defensive_trim=True,
+        approval_issue_id="ROB-164",
+        requester_agent_id=TRADER_AGENT_ID,
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert (
+        result["error"] == "approval_issue_id ROB-164 not found or not in 'done' status"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_flag_on_non_trader_caller_rejected() -> None:
+    """Only trader agent can use defensive_trim."""
+    tools = build_tools()
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=1005.0,
+        defensive_trim=True,
+        approval_issue_id="ROB-164",
+        requester_agent_id="other-agent",
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert (
+        result["error"]
+        == "defensive_trim requires Trader agent caller (got requester_agent_id=other-agent)"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_flag_on_missing_caller_id_rejected() -> None:
+    """defensive_trim requires caller identity."""
+    tools = build_tools()
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=1005.0,
+        defensive_trim=True,
+        approval_issue_id="ROB-164",
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert result["error"] == "requester_agent_id is required for defensive_trim"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_flag_on_still_rejects_below_current_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """defensive_trim bypasses floor only, not current-price guard."""
+    tools = build_tools()
+    _mock_crypto_sell_context(monkeypatch, current_price=1000.0, avg_buy_price="900.0")
+    monkeypatch.setattr(
+        order_validation,
+        "_fetch_approval_issue_status",
+        AsyncMock(return_value="done"),
+    )
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=990.0,
+        defensive_trim=True,
+        approval_issue_id="ROB-164",
+        requester_agent_id=TRADER_AGENT_ID,
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert "below current price" in result["error"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_journal_and_redis_record_defensive_trim_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Error-path order history records defensive trim audit fields."""
+    tools = build_tools()
+    monkeypatch.setattr(
+        order_validation,
+        "_fetch_approval_issue_status",
+        AsyncMock(return_value="done"),
+    )
+
+    record_mock = AsyncMock()
+    monkeypatch.setattr(order_execution, "_record_order_history", record_mock)
+    monkeypatch.setattr(
+        order_execution,
+        "_fetch_current_price",
+        AsyncMock(side_effect=RuntimeError("boom")),
+    )
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=1005.0,
+        defensive_trim=True,
+        approval_issue_id="ROB-164",
+        requester_agent_id=TRADER_AGENT_ID,
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    record_mock.assert_awaited_once()
+    kwargs = record_mock.await_args.kwargs
+    assert kwargs["defensive_trim"] is True
+    assert kwargs["approval_issue_id"] == "ROB-164"
+    assert kwargs["requester_agent_id"] == TRADER_AGENT_ID
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_flag_on_buy_side_rejected() -> None:
+    """defensive_trim is sell-only."""
+    tools = build_tools()
+
+    result = await tools["place_order"](
+        symbol="KRW-BTC",
+        side="buy",
+        order_type="limit",
+        quantity=1.0,
+        price=1000.0,
+        defensive_trim=True,
+        approval_issue_id="ROB-164",
+        requester_agent_id=TRADER_AGENT_ID,
+        dry_run=True,
+    )
+
+    assert result["success"] is False
+    assert (
+        result["error"]
+        == "defensive_trim requires side='sell' (buy orders always use existing path)"
+    )


### PR DESCRIPTION
## Summary
- Adds the `defensive_trim` gated `place_order` path for ROB-164/ROB-166, requiring sell + limit + valid done Paperclip approval + Trader caller identity before bypassing the sell floor.
- Keeps the current-price sell guard intact, records defensive-trim audit fields in order history, and emits structured `defensive_trim_bypass_active` warnings in both sell validation and preview branches.
- Updates MCP docs and public tool description with the explicit 4-AND gate.
- Rebased the branch onto current `origin/main`; the unrelated `tests/test_sell_signal_service.py` Ruff cleanup is not part of this PR.

## Verification
- `uv run pytest -m unit tests/test_mcp_place_order_defensive_trim.py -q` -> 14 passed
- `make lint` -> passed
- `make typecheck` -> passed

## Notes
- Existing unrelated untracked files remain unstaged in the worktree and are not part of this PR.
- Reviewer-observed baseline failures in `tests/test_mcp_place_order.py` and `tests/test_kr_hourly_candles_read_service.py` were not re-run in this heartbeat because the pre-review already confirmed they reproduce on clean `HEAD` and are outside ROB-168 scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "defensive trim" feature enabling restricted sell limit orders to bypass standard price floors when approval conditions are met.
  * Added new configuration fields for trader agent identification and optional Paperclip API integration settings.

* **Tests**
  * Added comprehensive test suite validating defensive trim approval workflow, rejection paths, and audit logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->