### PR TITLE
test(ROB-196): CIO quality gate e2e fixtures + reopen flow verification

### DIFF
--- a/tests/fixtures/scout_reports/all_gates_pass.md
+++ b/tests/fixtures/scout_reports/all_gates_pass.md
@@ -1,0 +1,25 @@
+# Scout Report — all-gates-pass fixture (ROB-196)
+
+### 요약
+- 탐색 범위: KR momentum / oversold
+- 신규 후보: 1건 / 기존 재검증: 1건
+- **same-depth status**: `PASS`
+- 결론: NAVER DCA 저가 보강 + Krafton watch 유지
+
+### 보유 + 신규 후보 동일 깊이 비교
+
+| 종목 | 시장가 | 지표 | BB/EMA | S/R | 뉴스 | 컨센서스/목표가 | DCA 대비 비교 | 실행경로 |
+|---|---|---|---|---|---|---|---|---|
+| **NAVER 035420** holdings/DCA | 216,000 | RSI 53, ADX 26 | BB 191K/206K/221K, EMA 5≈20<cur | 지지 206K (bb_mid) / 193K (bb_lower) | 뉴스 1건 (Naver: AI 검색 β launch) | 컨센서스 목표가 230K, PER 22 | 기존 보유 대비 우위 — 저가 진입 | KIS 즉시 |
+| **[신규]** Krafton 259960 | 266,500 | RSI 64, ADX 18 | BB 223K/244K/265K, EMA 5>20<120 | 지지 244K (bb_mid) / 231K (bb_lower) | 뉴스 2건 (Reuters: PUBG 모바일 / Bloomberg: 게임 규제) | 컨센서스 목표가 290K, PER 18 | NAVER 대비 열위 — 신규 중복 섹터 | KIS 즉시 |
+
+### 주문안 합계
+- 총 ~₩1.4M (NAVER DCA 3주 × 206K · 예수금 ~₩1.67M 대비 84%)
+
+### 제한사항
+- 없음
+
+### 권고
+- 조치: NAVER DCA limit 206K / Krafton watch
+- 긴급도: 다음 매매일
+- **same-depth status**: `PASS`

--- a/tests/fixtures/scout_reports/g1_depth_fail.md
+++ b/tests/fixtures/scout_reports/g1_depth_fail.md
@@ -1,0 +1,25 @@
+# Scout Report — G1 depth-fail fixture (ROB-196)
+
+### 요약
+- 탐색 범위: KR momentum / oversold
+- 신규 후보: 1건 / 기존 재검증: 1건
+- **same-depth status**: `FAIL`
+- 결론: 삼성바이오로직스 재분석 필요 — 보드 액션 보류
+
+### 보유 + 신규 후보 동일 깊이 비교
+
+| 종목 | 시장가 | 지표 | BB/EMA | S/R | 뉴스 | 컨센서스/목표가 | DCA 대비 비교 | 실행경로 |
+|---|---|---|---|---|---|---|---|---|
+| **NAVER 035420** holdings/DCA | 216,000 | RSI 53, ADX 26 | BB 191K/206K/221K, EMA 5≈20<cur | 지지 206K (bb_mid) / 193K (bb_lower) | 뉴스 1건 (Naver: AI 검색 β) | 컨센서스 목표가 230K, PER 22 | 기존 보유 대비 우위 | KIS 즉시 |
+| **[신규]** 삼성바이오로직스 207940 | 978,000 | RSI 71 | EMA 5>20 | 920K 근처 | — | — | — | KIS 즉시 |
+
+### 주문안 합계
+- 총 ~₩0.6M (NAVER DCA 3주 · 예수금 ~₩1.67M)
+
+### 제한사항
+- 없음
+
+### 권고
+- 조치: 삼성바이오로직스 deep-dive 재요청, NAVER DCA 유지
+- 긴급도: 참고
+- **same-depth status**: `FAIL` (삼성바이오로직스 news/consensus/S-R 누락)

--- a/tests/fixtures/scout_reports/g3_tool_failure.md
+++ b/tests/fixtures/scout_reports/g3_tool_failure.md
@@ -1,0 +1,25 @@
+# Scout Report — G3 tool-failure fixture (ROB-196)
+
+### 요약
+- 탐색 범위: KR momentum / oversold
+- 신규 후보: 1건 / 기존 재검증: 1건
+- **same-depth status**: `PASS`
+- 결론: NAVER DCA 저가 보강 + Krafton watch
+
+### 보유 + 신규 후보 동일 깊이 비교
+
+| 종목 | 시장가 | 지표 | BB/EMA | S/R | 뉴스 | 컨센서스/목표가 | DCA 대비 비교 | 실행경로 |
+|---|---|---|---|---|---|---|---|---|
+| **NAVER 035420** holdings/DCA | 216,000 | RSI 53, ADX 26 | BB 191K/206K/221K, EMA 5≈20<cur | 지지 206K (bb_mid) / 193K (bb_lower) | 뉴스 1건 (Naver: AI 검색 β) | 컨센서스 목표가 230K, PER 22 | 기존 보유 대비 우위 | KIS 즉시 |
+| **[신규]** Krafton 259960 | 266,500 | RSI 64, ADX 18 | BB 223K/244K/265K, EMA 5>20<120 | 지지 244K (bb_mid) / 231K (bb_lower) | 뉴스 2건 (Reuters: PUBG / Bloomberg: 규제) | 컨센서스 목표가 290K, PER 18 | NAVER 대비 열위 | KIS 즉시 |
+
+### 주문안 합계
+- 총 ~₩0.6M (NAVER DCA 3주 · 예수금 ~₩1.67M)
+
+### 권고
+- 조치: NAVER DCA limit, Krafton watch
+- 긴급도: 다음 매매일
+- **same-depth status**: `PASS`
+
+<!-- 이 픽스처: screen_stocks tool failure 발생 가정 (caller 가 tool_failures arg 로 주입).
+     본문에 `### 제한사항` 섹션이 없음 → G3 hard-gate 위반. -->

--- a/tests/fixtures/scout_reports/g4_execution_path.md
+++ b/tests/fixtures/scout_reports/g4_execution_path.md
@@ -1,0 +1,29 @@
+# Scout Report — G4 execution-path-missing fixture (ROB-196)
+
+### 요약
+- 탐색 범위: KR momentum / value
+- 신규 후보: 1건 / 기존 재검증: 1건
+- **same-depth status**: `PASS`
+- 결론: LG이노텍 신규 진입 검토
+
+### 보유 + 신규 후보 동일 깊이 비교
+
+| 종목 | 시장가 | 지표 | BB/EMA | S/R | 뉴스 | 컨센서스/목표가 | DCA 대비 비교 | 실행경로 |
+|---|---|---|---|---|---|---|---|---|
+| **NAVER 035420** holdings/DCA | 216,000 | RSI 53, ADX 26 | BB 191K/206K/221K, EMA 5≈20<cur | 지지 206K (bb_mid) / 193K (bb_lower) | 뉴스 1건 (Naver: AI 검색 β) | 컨센서스 목표가 230K, PER 22 | 기존 보유 대비 우위 | KIS 즉시 |
+| **[신규]** LG이노텍 011070 | 212,500 | RSI 58, ADX 24 | BB 194K/202K/222K, EMA 5>20>60<120 | 지지 202K (bb_mid) / 194K (bb_lower) | 뉴스 3건 (Naver: Apple 공급 / Reuters: 전장 매출 / Bloomberg: 컨센서스 상향) | 컨센서스 목표가 250K, PER 16 | NAVER 대비 우위 — 신규 카테고리 | KIS |
+
+### 주문안 합계
+- 총 ~₩0.6M (NAVER DCA · 예수금 ~₩1.67M)
+
+### 제한사항
+- 없음
+
+### 권고
+- 조치: LG이노텍 buy 검토
+- 긴급도: 다음 매매일
+- **same-depth status**: `PASS`
+
+<!-- 이 픽스처: LG이노텍 신규 후보 실행경로 셀이 bare "KIS" — EXEC_QUALIFIER_RE
+     (즉시/manual/mixed/KIS+Toss/KIS 일부/Toss 일부/해외/미지원/수동/자동) 미매치.
+     G4 hard-gate 위반. -->

--- a/tests/fixtures/scout_reports/g6_budget_reality.md
+++ b/tests/fixtures/scout_reports/g6_budget_reality.md
@@ -1,0 +1,30 @@
+# Scout Report — G6 budget-reality fixture (ROB-196)
+
+### 요약
+- 탐색 범위: KR momentum / oversold
+- 신규 후보: 1건 / 기존 재검증: 1건
+- **same-depth status**: `PASS`
+- 결론: NAVER + LG이노텍 Tier 1 분할 체결
+
+### 보유 + 신규 후보 동일 깊이 비교
+
+| 종목 | 시장가 | 지표 | BB/EMA | S/R | 뉴스 | 컨센서스/목표가 | DCA 대비 비교 | 실행경로 |
+|---|---|---|---|---|---|---|---|---|
+| **NAVER 035420** holdings/DCA | 216,000 | RSI 53, ADX 26 | BB 191K/206K/221K, EMA 5≈20<cur | 지지 206K (bb_mid) / 193K (bb_lower) | 뉴스 1건 (Naver: AI 검색 β) | 컨센서스 목표가 230K, PER 22 | 기존 보유 대비 우위 | KIS 즉시 |
+| **[신규]** LG이노텍 011070 | 212,500 | RSI 58, ADX 24 | BB 194K/202K/222K, EMA 5>20>60<120 | 지지 202K (bb_mid) / 194K (bb_lower) | 뉴스 3건 (Naver: Apple / Reuters: 전장 / Bloomberg: 컨센서스) | 컨센서스 목표가 250K, PER 16 | NAVER 대비 우위 | KIS 즉시 |
+
+### 주문안 합계
+- NAVER DCA 10주 × 206K + LG이노텍 buy 15주 × 202K
+- 총 ~₩5.0M
+
+### 제한사항
+- 없음
+
+### 권고
+- 조치: 위 주문안 분할 체결
+- 긴급도: 다음 매매일
+- **same-depth status**: `PASS`
+
+<!-- 이 픽스처: 주문안 총액 5.0M vs 예수금 1.67M (caller-supplied) = 배수 2.99x > 1.5x.
+     본문에 get_cash_balance 호출 흔적 없음 + BUDGET_DISCLOSURE_RE 매치 문구 없음
+     → G6 hard-gate 위반. -->

--- a/tests/test_cio_quality_gate_e2e.py
+++ b/tests/test_cio_quality_gate_e2e.py
@@ -1,0 +1,140 @@
+"""CIO quality gate e2e 테스트 — Scout Report shallow 감지 + reopen trigger.
+
+ROB-196 / ROB-170 §7 · 4개 hard-gate (G1/G3/G4/G6) 각각이 의도적으로 shallow 한
+Scout Report 를 수신했을 때 `evaluate_scout_report()` 가 해당 gate 를 탐지하고
+§7.2 reopen 코멘트를 생성하는지 검증한다.
+
+의존:
+- `app.services.cio_quality_gate_service` (ROB-197 deliverable)
+- `tests/fixtures/scout_reports/` markdown fixtures
+
+테스트 대상 모듈이 import 안 되는 환경에서는 `importorskip` 으로 전체 skip
+(ROB-197 이 merge 되기 전 ROB-196 branch 단독 CI 에서 green 유지).
+
+모든 테스트는 `cash_balance=1_670_000` 을 주입해 대상 gate 외 G6 이 노이즈로
+같이 터지는 것을 피한다. 개별 fixture 는 targeted gate 외 hard-gate 가 clean
+하도록 설계돼 있으며, assertion 은 `_hard_violation_ids(result)` 로 정확한
+hit set 을 검증한다.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+cio_gate = pytest.importorskip(
+    "app.services.cio_quality_gate_service",
+    reason="ROB-197 CIO quality gate service not merged yet",
+)
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "scout_reports"
+CIO_CASH = 1_670_000  # ROB-158 실제 예수금 (raw KRW)
+
+
+def _load(name: str) -> str:
+    return (FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+def _hard_violation_ids(result) -> set[str]:
+    return {v.gate_id for v in result.violations if v.severity == "hard"}
+
+
+def test_g1_depth_fail_triggers_reopen() -> None:
+    """신규 후보 1건에 news/fundamental/S/R 누락 → G1 hit → reopen 생성."""
+    report = _load("g1_depth_fail.md")
+
+    result = cio_gate.evaluate_scout_report(markdown=report, cash_balance=CIO_CASH)
+
+    assert result.overall_status == "FAIL"
+    assert _hard_violation_ids(result) == {"G1"}
+    assert result.reopen_comment is not None
+    assert "G1 Depth" in result.reopen_comment
+    g1 = next(v for v in result.violations if v.gate_id == "G1")
+    assert "삼성바이오로직스" in g1.detail or "207940" in g1.detail
+
+
+def test_g3_tool_failure_without_limitation_section_triggers_reopen() -> None:
+    """tool_failures 주입되고 `### 제한사항` 섹션 없음 → G3 hit."""
+    report = _load("g3_tool_failure.md")
+
+    result = cio_gate.evaluate_scout_report(
+        markdown=report,
+        cash_balance=CIO_CASH,
+        tool_failures=["screen_stocks: schema mismatch, retry 1회 실패"],
+    )
+
+    assert result.overall_status == "FAIL"
+    assert _hard_violation_ids(result) == {"G3"}
+    assert result.reopen_comment is not None
+    assert "G3" in result.reopen_comment
+
+
+def test_g4_execution_path_missing_triggers_reopen() -> None:
+    """신규 후보 실행경로 셀이 bare 'KIS' (qualifier 없음) → G4 hit."""
+    report = _load("g4_execution_path.md")
+
+    result = cio_gate.evaluate_scout_report(markdown=report, cash_balance=CIO_CASH)
+
+    assert result.overall_status == "FAIL"
+    assert _hard_violation_ids(result) == {"G4"}
+    assert result.reopen_comment is not None
+    assert "G4 Execution path" in result.reopen_comment
+    g4 = next(v for v in result.violations if v.gate_id == "G4")
+    assert "LG이노텍" in g4.detail or "011070" in g4.detail
+
+
+def test_g6_budget_over_cash_without_disclosure_triggers_reopen() -> None:
+    """주문안 총액 5.0M vs 예수금 1.67M (배수 2.99x) + disclosure 없음 → G6 hit.
+
+    `cash_balance` 주입은 get_cash_balance 호출 증거로 인정되지만,
+    over-budget + no-disclosure 조건에서는 G6 여전히 fail 이어야 함.
+    """
+    report = _load("g6_budget_reality.md")
+
+    result = cio_gate.evaluate_scout_report(markdown=report, cash_balance=CIO_CASH)
+
+    assert result.overall_status == "FAIL"
+    assert _hard_violation_ids(result) == {"G6"}
+    assert result.reopen_comment is not None
+    assert "G6 Budget reality" in result.reopen_comment
+
+
+def test_all_gates_pass_does_not_reopen() -> None:
+    """모든 gate pass → overall PASS, reopen 없음 (regression guard)."""
+    report = _load("all_gates_pass.md")
+
+    result = cio_gate.evaluate_scout_report(
+        markdown=report,
+        cash_balance=CIO_CASH,
+        tool_failures=[],
+    )
+
+    assert result.overall_status == "PASS"
+    assert _hard_violation_ids(result) == set()
+    assert result.reopen_comment is None
+
+
+@pytest.mark.parametrize(
+    "fixture_name,expected_hard_gate,label",
+    [
+        ("g1_depth_fail.md", "G1", "G1 Depth"),
+        ("g3_tool_failure.md", "G3", "G3"),
+        ("g4_execution_path.md", "G4", "G4 Execution path"),
+        ("g6_budget_reality.md", "G6", "G6 Budget reality"),
+    ],
+)
+def test_reopen_comment_cites_violated_gate(
+    fixture_name: str, expected_hard_gate: str, label: str
+) -> None:
+    """§7.2 reopen 템플릿의 `위반 gate` 라인이 실제 위반된 gate label 을 포함해야 한다."""
+    kwargs: dict = {"markdown": _load(fixture_name), "cash_balance": CIO_CASH}
+    if fixture_name == "g3_tool_failure.md":
+        kwargs["tool_failures"] = ["screen_stocks: schema mismatch"]
+
+    result = cio_gate.evaluate_scout_report(**kwargs)
+
+    assert result.reopen_comment is not None
+    assert expected_hard_gate in result.reopen_comment
+    assert label in result.reopen_comment
+    assert "Scout reopen" in result.reopen_comment


### PR DESCRIPTION
## Summary

- Add 4 single-gate-fail + 1 all-pass Scout Report fixtures under `tests/fixtures/scout_reports/`
- Add `tests/test_cio_quality_gate_e2e.py` with 9 cases (5 gate triggers + 4-way parametrized reopen-label check)
- Exercises `evaluate_scout_report()` (shipped in #546 / ROB-197) against intentionally-shallow Scout markdown to confirm G1 / G3 / G4 / G6 hard-gates each fire reopen
- Every case passes `cash_balance=1_670_000` for clean single-gate isolation (prevents G6 noise bleeding into G1/G3/G4 fixtures)

Related: [ROB-196](/ROB/issues/ROB-196), [ROB-170 plan §7](/ROB/issues/ROB-170#document-plan), follows [ROB-197](/ROB/issues/ROB-197).

## Test plan

- [x] `uv run pytest tests/test_cio_quality_gate_e2e.py -v` → 9 passed (run against merged main incl. ROB-197 service)
- [x] `uv run ruff check tests/test_cio_quality_gate_e2e.py`
- [x] `uv run ruff format --check tests/test_cio_quality_gate_e2e.py`
- [ ] CI: full pytest + lint on PR

## Coverage per fixture

| Fixture | Gate targeted | Trigger |
|---|---|---|
| `g1_depth_fail.md` | G1 Depth | 삼성바이오로직스 news/consensus/S-R 누락 |
| `g3_tool_failure.md` | G3 Tool failure | `tool_failures` arg + 제한사항 섹션 부재 |
| `g4_execution_path.md` | G4 Execution path | 신규 후보 실행경로 셀 bare `KIS` |
| `g6_budget_reality.md` | G6 Budget reality | 주문안 ₩5.0M / 예수금 ₩1.67M (2.99x) + disclosure 부재 |
| `all_gates_pass.md` | none | overall=PASS regression guard |

🤖 Generated with [Claude Code](https://claude.com/claude-code)