### PR TITLE
fix(cio): header-aware 실행경로 cell + v2 §6.2 fixture alignment (ROB-206)

### DIFF
--- a/app/services/cio_quality_gate_service.py
+++ b/app/services/cio_quality_gate_service.py
@@ -170,6 +170,18 @@ EXEC_HEADER_RE = re.compile(
     r"(실행\s*경로|execution\s*path|계좌.*실행|\bexec(ution)?\b)",
     re.IGNORECASE,
 )
+CATEGORY_HEADER_RE = re.compile(
+    r"(^|\s)(분류|category)(\s|$)",
+    re.IGNORECASE,
+)
+# v2 §6.2 sub-bullets label the execution path like
+# "· execution path: KIS 즉시 ·" or "· 실행경로: Toss manual ·". Capture
+# only the path-labeled segment so G4's qualifier check does not match
+# unrelated middle-dot bullet segments (뉴스: 해외 매출 / 전기 자동차 …).
+EXEC_PATH_SEGMENT_RE = re.compile(
+    r"(?:execution\s*path|실행\s*경로)\s*[:：]\s*([^·\n|]+)",
+    re.IGNORECASE,
+)
 
 
 @dataclass
@@ -210,6 +222,25 @@ def _detect_exec_col_idx(header_line: str) -> int | None:
     return None
 
 
+def _detect_category_col_idx(header_line: str) -> int | None:
+    """Return the 0-based column index labelled 분류/category, or None."""
+    cells = [c.strip() for c in header_line.strip().strip("|").split("|")]
+    for idx, cell in enumerate(cells):
+        if CATEGORY_HEADER_RE.search(cell):
+            return idx
+    return None
+
+
+def _exec_path_segments(text: str) -> list[str]:
+    """Return only the substrings that follow an 'execution path:' / '실행경로:' label.
+
+    Used for G4's sub-bullet fallback so unrelated middle-dot bullet segments
+    (뉴스 headlines, S/R notes, etc.) cannot satisfy EXEC_QUALIFIER_RE via
+    incidental 해외 / 자동 / 수동 tokens.
+    """
+    return [m.strip() for m in EXEC_PATH_SEGMENT_RE.findall(text)]
+
+
 def _extract_execution_cell(row_line: str, col_idx: int | None = None) -> str:
     """Return the execution-path cell text from a markdown pipe row.
 
@@ -248,14 +279,17 @@ def extract_candidates(md: str) -> list[Candidate]:
     lines = md.splitlines()
     by_code: dict[str, Candidate] = {}
     current_exec_col_idx: int | None = None
+    current_category_col_idx: int | None = None
     i = 0
     while i < len(lines):
         line = lines[i]
         if TABLE_SEPARATOR_RE.match(line):
             if i > 0 and lines[i - 1].lstrip().startswith("|"):
                 current_exec_col_idx = _detect_exec_col_idx(lines[i - 1])
+                current_category_col_idx = _detect_category_col_idx(lines[i - 1])
             else:
                 current_exec_col_idx = None
+                current_category_col_idx = None
             i += 1
             continue
         if line.count("|") < 3:
@@ -291,9 +325,18 @@ def extract_candidates(md: str) -> list[Candidate]:
             (c for c in cells if CODE_RE.search(c)), cells[0] if cells else code
         )
         name = re.sub(r"\*+", "", name_cell).strip()
-        # v2 §6.2 puts 신규/보유 in the 분류 column, v1 embeds [신규] in the
-        # 종목 name — scan all cells so either shape is detected.
-        is_new = any("신규" in c for c in cells) if cells else False
+        # 신규 detection is scoped to avoid false positives from 액션/뉴스/메모
+        # cells that incidentally mention "신규":
+        #   - If the table has a 분류 header column (v2 §6.2), trust only that
+        #     cell. No leakage from other columns.
+        #   - Otherwise fall back to the 종목 name cell where v1 reports embed
+        #     the `[신규]` tag (e.g. "**[신규]** Krafton 259960").
+        if current_category_col_idx is not None and 0 <= current_category_col_idx < len(
+            cells
+        ):
+            is_new = "신규" in cells[current_category_col_idx]
+        else:
+            is_new = "신규" in name_cell
 
         exec_cell = _extract_execution_cell(line, current_exec_col_idx)
 
@@ -523,18 +566,22 @@ def run_gates(
     )
 
     # ---- G4 Execution path ----
-    # Check the dedicated execution_cell AND the full row context (sub-bullets).
-    # v2 §6.2 puts execution path inside a sub-bullet (e.g. "execution path:
-    # KIS 즉시"), not a dedicated column — fall back to context_text so that
-    # column order / placement is irrelevant. Short-circuiting on a non-empty
-    # execution_cell would miss the sub-bullet qualifier.
-    no_qual = [
-        c
-        for c in cands
-        if c.is_new
-        and not EXEC_QUALIFIER_RE.search(c.execution_cell)
-        and not EXEC_QUALIFIER_RE.search(c.context_text)
-    ]
+    # The qualifier must live in one of two explicit slots:
+    #   1. The 실행경로 / execution path column cell (header-detected or
+    #      v1 trailing cell).
+    #   2. A sub-bullet segment explicitly labelled "execution path:" or
+    #      "실행경로:" — scanned via EXEC_PATH_SEGMENT_RE so that incidental
+    #      middle-dot bullet text (뉴스: 해외 매출 / 전기 자동차 / 수동 검증)
+    #      cannot false-pass G4 through context_text-wide regex matching.
+    def _has_exec_qualifier(cand: Candidate) -> bool:
+        if EXEC_QUALIFIER_RE.search(cand.execution_cell):
+            return True
+        for seg in _exec_path_segments(cand.context_text):
+            if EXEC_QUALIFIER_RE.search(seg):
+                return True
+        return False
+
+    no_qual = [c for c in cands if c.is_new and not _has_exec_qualifier(c)]
     results.append(
         GateResult(
             key="G4",

--- a/app/services/cio_quality_gate_service.py
+++ b/app/services/cio_quality_gate_service.py
@@ -165,6 +165,12 @@ def has_keyword(text: str, group: str) -> bool:
 CODE_RE = re.compile(r"\b(\d{6})\b")
 SKIP_CELL_WORDS = {"---", ""}
 
+TABLE_SEPARATOR_RE = re.compile(r"^\s*\|[\s\-:|]+\|\s*$")
+EXEC_HEADER_RE = re.compile(
+    r"(실행\s*경로|execution\s*path|계좌.*실행|\bexec(ution)?\b)",
+    re.IGNORECASE,
+)
+
 
 @dataclass
 class Candidate:
@@ -195,10 +201,28 @@ class Candidate:
         return "fail"
 
 
-def _extract_execution_cell(row_line: str) -> str:
-    """Return the trailing cell text from a markdown pipe row."""
+def _detect_exec_col_idx(header_line: str) -> int | None:
+    """Return the 0-based column index labelled 실행경로/execution path, or None."""
+    cells = [c.strip() for c in header_line.strip().strip("|").split("|")]
+    for idx, cell in enumerate(cells):
+        if EXEC_HEADER_RE.search(cell):
+            return idx
+    return None
+
+
+def _extract_execution_cell(row_line: str, col_idx: int | None = None) -> str:
+    """Return the execution-path cell text from a markdown pipe row.
+
+    If ``col_idx`` is given (header-detected 실행경로/execution path column),
+    pull that column directly — the row's column order is irrelevant. When
+    no header column matched, fall back to the trailing cell.
+    """
     cells = [c.strip() for c in row_line.strip().strip("|").split("|")]
-    return cells[-1] if cells else ""
+    if not cells:
+        return ""
+    if col_idx is not None and 0 <= col_idx < len(cells):
+        return cells[col_idx]
+    return cells[-1]
 
 
 def extract_candidates(md: str) -> list[Candidate]:
@@ -213,12 +237,27 @@ def extract_candidates(md: str) -> list[Candidate]:
     and (d) not introducing a new 6-digit code. The pipe-count of the
     subline itself is irrelevant — v2 reports frequently write multi-cell
     bullet rows like `|   | • RSI 54 | • BB mid |`.
+
+    Table-header tracking: when a markdown table separator (`|---|---|`) is
+    encountered, the row immediately above is treated as the column header
+    for the table that follows. If any header cell matches `실행경로` /
+    `execution path`, that column index is used to extract the execution
+    cell from subsequent candidate rows — regardless of column position
+    (v2 §6.2 reports put 액션 in the last column, not 실행경로).
     """
     lines = md.splitlines()
     by_code: dict[str, Candidate] = {}
+    current_exec_col_idx: int | None = None
     i = 0
     while i < len(lines):
         line = lines[i]
+        if TABLE_SEPARATOR_RE.match(line):
+            if i > 0 and lines[i - 1].lstrip().startswith("|"):
+                current_exec_col_idx = _detect_exec_col_idx(lines[i - 1])
+            else:
+                current_exec_col_idx = None
+            i += 1
+            continue
         if line.count("|") < 3:
             i += 1
             continue
@@ -252,9 +291,11 @@ def extract_candidates(md: str) -> list[Candidate]:
             (c for c in cells if CODE_RE.search(c)), cells[0] if cells else code
         )
         name = re.sub(r"\*+", "", name_cell).strip()
-        is_new = "신규" in name_cell or "신규" in cells[0] if cells else False
+        # v2 §6.2 puts 신규/보유 in the 분류 column, v1 embeds [신규] in the
+        # 종목 name — scan all cells so either shape is detected.
+        is_new = any("신규" in c for c in cells) if cells else False
 
-        exec_cell = _extract_execution_cell(line)
+        exec_cell = _extract_execution_cell(line, current_exec_col_idx)
 
         if code in by_code:
             c = by_code[code]
@@ -482,10 +523,17 @@ def run_gates(
     )
 
     # ---- G4 Execution path ----
+    # Check the dedicated execution_cell AND the full row context (sub-bullets).
+    # v2 §6.2 puts execution path inside a sub-bullet (e.g. "execution path:
+    # KIS 즉시"), not a dedicated column — fall back to context_text so that
+    # column order / placement is irrelevant. Short-circuiting on a non-empty
+    # execution_cell would miss the sub-bullet qualifier.
     no_qual = [
         c
         for c in cands
-        if c.is_new and not EXEC_QUALIFIER_RE.search(c.execution_cell or c.context_text)
+        if c.is_new
+        and not EXEC_QUALIFIER_RE.search(c.execution_cell)
+        and not EXEC_QUALIFIER_RE.search(c.context_text)
     ]
     results.append(
         GateResult(

--- a/tests/fixtures/scout_reports/all_gates_pass.md
+++ b/tests/fixtures/scout_reports/all_gates_pass.md
@@ -1,4 +1,4 @@
-# Scout Report — all-gates-pass fixture (ROB-196)
+# Scout Report — all-gates-pass fixture (ROB-196 · v2 §6.2)
 
 ### 요약
 - 탐색 범위: KR momentum / oversold
@@ -6,12 +6,16 @@
 - **same-depth status**: `PASS`
 - 결론: NAVER DCA 저가 보강 + Krafton watch 유지
 
-### 보유 + 신규 후보 동일 깊이 비교
+### 신규 후보 + 기존 DCA 동일 프레임 비교
 
-| 종목 | 시장가 | 지표 | BB/EMA | S/R | 뉴스 | 컨센서스/목표가 | DCA 대비 비교 | 실행경로 |
-|---|---|---|---|---|---|---|---|---|
-| **NAVER 035420** holdings/DCA | 216,000 | RSI 53, ADX 26 | BB 191K/206K/221K, EMA 5≈20<cur | 지지 206K (bb_mid) / 193K (bb_lower) | 뉴스 1건 (Naver: AI 검색 β launch) | 컨센서스 목표가 230K, PER 22 | 기존 보유 대비 우위 — 저가 진입 | KIS 즉시 |
-| **[신규]** Krafton 259960 | 266,500 | RSI 64, ADX 18 | BB 223K/244K/265K, EMA 5>20<120 | 지지 244K (bb_mid) / 231K (bb_lower) | 뉴스 2건 (Reuters: PUBG 모바일 / Bloomberg: 게임 규제) | 컨센서스 목표가 290K, PER 18 | NAVER 대비 열위 — 신규 중복 섹터 | KIS 즉시 |
+| 시장 | 종목 | 분류 | 시장가 | RSI | ADX | 구조적 Buy Zone | 액션 |
+|---|---|---|---|---|---|---|---|
+| KR | **NAVER 035420** | 보유/DCA | 216,000 | 53 | 26 | 206K (bb_mid) / 193K (bb_lower) | DCA limit |
+|   | • BB(L/M/U) 191K/206K/221K · EMA 5≈20<cur·60/120 상단 · 괴리 –4.6%/–10.7% · P&L +2.4% · 기존 보유 대비 우위 |
+|   | • 뉴스 1건 (Naver news: AI 검색 β launch) · 컨센서스 목표가 230K, PER 22 · execution path: KIS 즉시 · same-depth-check: pass |
+| KR | **Krafton 259960** | 신규(watch) | 266,500 | 64 | 18 | 244K (bb_mid) / 231K (bb_lower) | watch only |
+|   | • BB 223K/244K/265K · EMA 5>20<120 · 괴리 –8.3% · NAVER DCA 대비 열위 — 신규 중복 섹터 |
+|   | • 뉴스 2건 (Reuters: PUBG 모바일 / Bloomberg: 게임 규제 earning guidance) · 컨센서스 목표가 290K, PER 18 · execution path: KIS 즉시 · same-depth-check: pass |
 
 ### 주문안 합계
 - 총 ~₩1.4M (NAVER DCA 3주 × 206K · 예수금 ~₩1.67M 대비 84%)

--- a/tests/fixtures/scout_reports/g1_depth_fail.md
+++ b/tests/fixtures/scout_reports/g1_depth_fail.md
@@ -1,4 +1,4 @@
-# Scout Report — G1 depth-fail fixture (ROB-196)
+# Scout Report — G1 depth-fail fixture (ROB-196 · v2 §6.2)
 
 ### 요약
 - 탐색 범위: KR momentum / oversold
@@ -6,12 +6,15 @@
 - **same-depth status**: `FAIL`
 - 결론: 삼성바이오로직스 재분석 필요 — 보드 액션 보류
 
-### 보유 + 신규 후보 동일 깊이 비교
+### 신규 후보 + 기존 DCA 동일 프레임 비교
 
-| 종목 | 시장가 | 지표 | BB/EMA | S/R | 뉴스 | 컨센서스/목표가 | DCA 대비 비교 | 실행경로 |
-|---|---|---|---|---|---|---|---|---|
-| **NAVER 035420** holdings/DCA | 216,000 | RSI 53, ADX 26 | BB 191K/206K/221K, EMA 5≈20<cur | 지지 206K (bb_mid) / 193K (bb_lower) | 뉴스 1건 (Naver: AI 검색 β) | 컨센서스 목표가 230K, PER 22 | 기존 보유 대비 우위 | KIS 즉시 |
-| **[신규]** 삼성바이오로직스 207940 | 978,000 | RSI 71 | EMA 5>20 | 920K 근처 | — | — | — | KIS 즉시 |
+| 시장 | 종목 | 분류 | 시장가 | RSI | ADX | 구조적 Buy Zone | 액션 |
+|---|---|---|---|---|---|---|---|
+| KR | **NAVER 035420** | 보유/DCA | 216,000 | 53 | 26 | 206K (bb_mid) / 193K (bb_lower) | DCA limit |
+|   | • BB 191K/206K/221K · EMA 5≈20<cur · 괴리 –4.6% · P&L +2.4% · 기존 보유 대비 우위 |
+|   | • 뉴스 1건 (Naver news: AI 검색 β) · 컨센서스 목표가 230K, PER 22 · execution path: KIS 즉시 · same-depth-check: pass |
+| KR | **삼성바이오로직스 207940** | 신규(watch) | 978,000 | 71 | — | 920K 근처 | watch only |
+|   | • EMA 5>20 · 괴리 — · execution path: KIS 즉시 · same-depth-check: fail (news / consensus / S-R 누락) |
 
 ### 주문안 합계
 - 총 ~₩0.6M (NAVER DCA 3주 · 예수금 ~₩1.67M)

--- a/tests/fixtures/scout_reports/g3_tool_failure.md
+++ b/tests/fixtures/scout_reports/g3_tool_failure.md
@@ -1,4 +1,4 @@
-# Scout Report — G3 tool-failure fixture (ROB-196)
+# Scout Report — G3 tool-failure fixture (ROB-196 · v2 §6.2)
 
 ### 요약
 - 탐색 범위: KR momentum / oversold
@@ -6,12 +6,16 @@
 - **same-depth status**: `PASS`
 - 결론: NAVER DCA 저가 보강 + Krafton watch
 
-### 보유 + 신규 후보 동일 깊이 비교
+### 신규 후보 + 기존 DCA 동일 프레임 비교
 
-| 종목 | 시장가 | 지표 | BB/EMA | S/R | 뉴스 | 컨센서스/목표가 | DCA 대비 비교 | 실행경로 |
-|---|---|---|---|---|---|---|---|---|
-| **NAVER 035420** holdings/DCA | 216,000 | RSI 53, ADX 26 | BB 191K/206K/221K, EMA 5≈20<cur | 지지 206K (bb_mid) / 193K (bb_lower) | 뉴스 1건 (Naver: AI 검색 β) | 컨센서스 목표가 230K, PER 22 | 기존 보유 대비 우위 | KIS 즉시 |
-| **[신규]** Krafton 259960 | 266,500 | RSI 64, ADX 18 | BB 223K/244K/265K, EMA 5>20<120 | 지지 244K (bb_mid) / 231K (bb_lower) | 뉴스 2건 (Reuters: PUBG / Bloomberg: 규제) | 컨센서스 목표가 290K, PER 18 | NAVER 대비 열위 | KIS 즉시 |
+| 시장 | 종목 | 분류 | 시장가 | RSI | ADX | 구조적 Buy Zone | 액션 |
+|---|---|---|---|---|---|---|---|
+| KR | **NAVER 035420** | 보유/DCA | 216,000 | 53 | 26 | 206K (bb_mid) / 193K (bb_lower) | DCA limit |
+|   | • BB 191K/206K/221K · EMA 5≈20<cur · 괴리 –4.6% · 기존 보유 대비 우위 |
+|   | • 뉴스 1건 (Naver news: AI 검색 β) · 컨센서스 목표가 230K, PER 22 · execution path: KIS 즉시 · same-depth-check: pass |
+| KR | **Krafton 259960** | 신규(watch) | 266,500 | 64 | 18 | 244K (bb_mid) / 231K (bb_lower) | watch only |
+|   | • BB 223K/244K/265K · EMA 5>20<120 · 괴리 –8.3% · NAVER DCA 대비 열위 |
+|   | • 뉴스 2건 (Reuters: PUBG / Bloomberg: 규제) · 컨센서스 목표가 290K, PER 18 · execution path: KIS 즉시 · same-depth-check: pass |
 
 ### 주문안 합계
 - 총 ~₩0.6M (NAVER DCA 3주 · 예수금 ~₩1.67M)

--- a/tests/fixtures/scout_reports/g4_execution_path.md
+++ b/tests/fixtures/scout_reports/g4_execution_path.md
@@ -1,4 +1,4 @@
-# Scout Report — G4 execution-path-missing fixture (ROB-196)
+# Scout Report — G4 execution-path-missing fixture (ROB-196 · v2 §6.2)
 
 ### 요약
 - 탐색 범위: KR momentum / value
@@ -6,12 +6,16 @@
 - **same-depth status**: `PASS`
 - 결론: LG이노텍 신규 진입 검토
 
-### 보유 + 신규 후보 동일 깊이 비교
+### 신규 후보 + 기존 DCA 동일 프레임 비교
 
-| 종목 | 시장가 | 지표 | BB/EMA | S/R | 뉴스 | 컨센서스/목표가 | DCA 대비 비교 | 실행경로 |
-|---|---|---|---|---|---|---|---|---|
-| **NAVER 035420** holdings/DCA | 216,000 | RSI 53, ADX 26 | BB 191K/206K/221K, EMA 5≈20<cur | 지지 206K (bb_mid) / 193K (bb_lower) | 뉴스 1건 (Naver: AI 검색 β) | 컨센서스 목표가 230K, PER 22 | 기존 보유 대비 우위 | KIS 즉시 |
-| **[신규]** LG이노텍 011070 | 212,500 | RSI 58, ADX 24 | BB 194K/202K/222K, EMA 5>20>60<120 | 지지 202K (bb_mid) / 194K (bb_lower) | 뉴스 3건 (Naver: Apple 공급 / Reuters: 전장 매출 / Bloomberg: 컨센서스 상향) | 컨센서스 목표가 250K, PER 16 | NAVER 대비 우위 — 신규 카테고리 | KIS |
+| 시장 | 종목 | 분류 | 시장가 | RSI | ADX | 구조적 Buy Zone | 액션 |
+|---|---|---|---|---|---|---|---|
+| KR | **NAVER 035420** | 보유/DCA | 216,000 | 53 | 26 | 206K (bb_mid) / 193K (bb_lower) | DCA limit |
+|   | • BB 191K/206K/221K · EMA 5≈20<cur · 괴리 –4.6% · 기존 보유 대비 우위 |
+|   | • 뉴스 1건 (Naver news: AI 검색 β) · 컨센서스 목표가 230K, PER 22 · execution path: KIS 즉시 · same-depth-check: pass |
+| KR | **LG이노텍 011070** | 신규(buy 검토) | 212,500 | 58 | 24 | 202K (bb_mid) / 194K (bb_lower) | buy 검토 |
+|   | • BB 194K/202K/222K · EMA 5>20>60<120 · 괴리 –4.5% · NAVER DCA 대비 우위 — 신규 카테고리 |
+|   | • 뉴스 3건 (Naver news: Apple 공급 / Reuters: 전장 매출 / Bloomberg: 컨센서스 상향) · 컨센서스 목표가 250K, PER 16 · execution path: KIS · same-depth-check: pass |
 
 ### 주문안 합계
 - 총 ~₩0.6M (NAVER DCA · 예수금 ~₩1.67M)
@@ -24,6 +28,6 @@
 - 긴급도: 다음 매매일
 - **same-depth status**: `PASS`
 
-<!-- 이 픽스처: LG이노텍 신규 후보 실행경로 셀이 bare "KIS" — EXEC_QUALIFIER_RE
-     (즉시/manual/mixed/KIS+Toss/KIS 일부/Toss 일부/해외/미지원/수동/자동) 미매치.
-     G4 hard-gate 위반. -->
+<!-- 이 픽스처: LG이노텍 신규 후보 execution path 가 bare "KIS" (sub-bullet 내부, 
+     EXEC_QUALIFIER_RE 즉시/manual/mixed/KIS+Toss/KIS 일부/Toss 일부/해외/미지원/수동/자동 미매치).
+     context_text 에도 qualifier 없음 → G4 hard-gate 위반. -->

--- a/tests/fixtures/scout_reports/g6_budget_reality.md
+++ b/tests/fixtures/scout_reports/g6_budget_reality.md
@@ -1,4 +1,4 @@
-# Scout Report — G6 budget-reality fixture (ROB-196)
+# Scout Report — G6 budget-reality fixture (ROB-196 · v2 §6.2)
 
 ### 요약
 - 탐색 범위: KR momentum / oversold
@@ -6,12 +6,16 @@
 - **same-depth status**: `PASS`
 - 결론: NAVER + LG이노텍 Tier 1 분할 체결
 
-### 보유 + 신규 후보 동일 깊이 비교
+### 신규 후보 + 기존 DCA 동일 프레임 비교
 
-| 종목 | 시장가 | 지표 | BB/EMA | S/R | 뉴스 | 컨센서스/목표가 | DCA 대비 비교 | 실행경로 |
-|---|---|---|---|---|---|---|---|---|
-| **NAVER 035420** holdings/DCA | 216,000 | RSI 53, ADX 26 | BB 191K/206K/221K, EMA 5≈20<cur | 지지 206K (bb_mid) / 193K (bb_lower) | 뉴스 1건 (Naver: AI 검색 β) | 컨센서스 목표가 230K, PER 22 | 기존 보유 대비 우위 | KIS 즉시 |
-| **[신규]** LG이노텍 011070 | 212,500 | RSI 58, ADX 24 | BB 194K/202K/222K, EMA 5>20>60<120 | 지지 202K (bb_mid) / 194K (bb_lower) | 뉴스 3건 (Naver: Apple / Reuters: 전장 / Bloomberg: 컨센서스) | 컨센서스 목표가 250K, PER 16 | NAVER 대비 우위 | KIS 즉시 |
+| 시장 | 종목 | 분류 | 시장가 | RSI | ADX | 구조적 Buy Zone | 액션 |
+|---|---|---|---|---|---|---|---|
+| KR | **NAVER 035420** | 보유/DCA | 216,000 | 53 | 26 | 206K (bb_mid) / 193K (bb_lower) | DCA limit |
+|   | • BB 191K/206K/221K · EMA 5≈20<cur · 괴리 –4.6% · 기존 보유 대비 우위 |
+|   | • 뉴스 1건 (Naver news: AI 검색 β) · 컨센서스 목표가 230K, PER 22 · execution path: KIS 즉시 · same-depth-check: pass |
+| KR | **LG이노텍 011070** | 신규(buy) | 212,500 | 58 | 24 | 202K (bb_mid) / 194K (bb_lower) | buy |
+|   | • BB 194K/202K/222K · EMA 5>20>60<120 · 괴리 –4.5% · NAVER DCA 대비 우위 |
+|   | • 뉴스 3건 (Naver news: Apple / Reuters: 전장 / Bloomberg: 컨센서스) · 컨센서스 목표가 250K, PER 16 · execution path: KIS 즉시 · same-depth-check: pass |
 
 ### 주문안 합계
 - NAVER DCA 10주 × 206K + LG이노텍 buy 15주 × 202K

--- a/tests/test_cio_quality_gate.py
+++ b/tests/test_cio_quality_gate.py
@@ -250,3 +250,104 @@ def test_naver_news_qualifier_still_counts_when_explicit():
         assert c.items[5] is True, (
             f"#5 News must fire on explicit Naver-news qualifier; md={md!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# ROB-206 regressions:
+#   1. Parser must locate the `실행경로` / `execution path` cell by header,
+#      independent of column position. v2 §6.2 puts 액션 in the last column.
+#   2. G4 must accept execution qualifiers placed in v2 sub-bullet lines
+#      (e.g. "execution path: KIS 즉시"), not only in a dedicated column.
+# ---------------------------------------------------------------------------
+
+
+EXEC_MIDDLE_COLUMN_MD = """### 신규 후보 비교
+
+| 종목 (코드) | 실행경로 | 시장가 | RSI | 액션 |
+|---|---|---|---|---|
+| **[신규]** Krafton 259960 | KIS 즉시 | 266,500 | 64 | watch only |
+"""
+
+
+@pytest.mark.unit
+def test_exec_cell_resolved_by_header_when_column_is_not_last():
+    """`_extract_execution_cell` must pull from the 실행경로 column by header,
+    not from the last cell. With 실행경로 placed in column 2 (not last), the
+    new candidate has a valid qualifier and G4 must pass.
+    """
+    report = evaluate_scout_report(markdown=EXEC_MIDDLE_COLUMN_MD)
+    krafton = next(c for c in report.candidates if c.code == "259960")
+    assert krafton.execution_cell == "KIS 즉시", (
+        f"execution_cell must be pulled from the header-matched column; "
+        f"got {krafton.execution_cell!r}"
+    )
+    g4 = next(r for r in report.gates if r.key == "G4")
+    assert g4.passed, f"G4 must pass when exec qualifier sits mid-row; {g4.detail}"
+
+
+V2_EXEC_SUBLINE_MD = """### 신규 후보 + 기존 DCA 동일 프레임 비교
+
+| 시장 | 종목 | 분류 | 시장가 | RSI | ADX | 구조적 Buy Zone | 액션 |
+|---|---|---|---|---|---|---|---|
+| KR | **Krafton 259960** | 신규(watch) | 266,500 | 64 | 18 | 244K (bb_mid) | watch only |
+|   | • BB 223K/244K/265K · EMA 5>20<120 · 괴리 –8.3% · 기존 NAVER DCA 대비 열위 |
+|   | • 뉴스 2건 (Reuters: PUBG / Bloomberg: earning guidance) · 컨센서스 목표가 290K, PER 18 · execution path: KIS 즉시 · same-depth-check: pass |
+
+### 제한사항
+없음
+"""
+
+
+@pytest.mark.unit
+def test_v2_sec62_execution_path_in_subline_passes_g4():
+    """v2 §6.2 core table has no 실행경로 column — the last cell is 액션.
+    Execution path lives inside the sub-bullet line ("execution path: KIS 즉시").
+    G4 must accept the sub-bullet qualifier via context_text fallback.
+    """
+    report = evaluate_scout_report(markdown=V2_EXEC_SUBLINE_MD)
+    krafton = next(c for c in report.candidates if c.code == "259960")
+    # Parent-row last cell is 액션 ("watch only") — no direct qualifier there.
+    assert "즉시" not in krafton.execution_cell
+    # But context_text carries the sub-bullet execution-path evidence.
+    assert "즉시" in krafton.context_text
+    g4 = next(r for r in report.gates if r.key == "G4")
+    assert g4.passed, (
+        f"G4 must pass when execution qualifier is carried in sub-bullet; {g4.detail}"
+    )
+
+
+@pytest.mark.unit
+def test_g4_still_fails_when_bare_kis_appears_without_qualifier_anywhere():
+    """Regression guard: the combined (execution_cell + context_text) check
+    must NOT over-match. A row with bare `KIS` in both the cell and the
+    sub-bullet still lacks an EXEC_QUALIFIER_RE match and G4 must fail.
+    """
+    md = """### 신규 후보
+
+| 시장 | 종목 | 분류 | 시장가 | RSI | ADX | Buy Zone | 액션 |
+|---|---|---|---|---|---|---|---|
+| KR | **LG이노텍 011070** | 신규(buy 검토) | 212,500 | 58 | 24 | 202K | buy 검토 |
+|   | • BB 194K/202K/222K · execution path: KIS · same-depth-check: pass |
+"""
+    report = evaluate_scout_report(markdown=md)
+    lginnotek = next(c for c in report.candidates if c.code == "011070")
+    assert lginnotek.is_new
+    g4 = next(r for r in report.gates if r.key == "G4")
+    assert not g4.passed, f"G4 must hit when bare 'KIS' has no qualifier; {g4.detail}"
+
+
+@pytest.mark.unit
+def test_is_new_detected_from_v2_category_column():
+    """v2 §6.2 puts 신규/보유 in the 분류 column (col idx 2), not embedded in
+    the 종목 name. is_new must fire on the 분류 cell alone.
+    """
+    md = """| 시장 | 종목 | 분류 | 시장가 | 액션 |
+|---|---|---|---|---|
+| KR | NAVER 035420 | 보유/DCA | 216,000 | DCA limit |
+| KR | Krafton 259960 | 신규(watch) | 266,500 | watch only |
+"""
+    report = evaluate_scout_report(markdown=md)
+    naver = next(c for c in report.candidates if c.code == "035420")
+    krafton = next(c for c in report.candidates if c.code == "259960")
+    assert not naver.is_new, "보유/DCA cell must not mark NAVER as 신규"
+    assert krafton.is_new, "신규(watch) cell in col 2 must mark Krafton as 신규"

--- a/tests/test_cio_quality_gate.py
+++ b/tests/test_cio_quality_gate.py
@@ -351,3 +351,90 @@ def test_is_new_detected_from_v2_category_column():
     krafton = next(c for c in report.candidates if c.code == "259960")
     assert not naver.is_new, "보유/DCA cell must not mark NAVER as 신규"
     assert krafton.is_new, "신규(watch) cell in col 2 must mark Krafton as 신규"
+
+
+# ---------------------------------------------------------------------------
+# ROB-206 review follow-up — over-match guards:
+#   1. G4 must not treat incidental 해외/자동/수동 tokens in unrelated bullet
+#      segments (뉴스 headlines, S/R notes) as execution-path qualifiers.
+#   2. is_new must not treat `신규` appearing in 액션/메모/뉴스 cells as a
+#      positive signal — only the 분류 column (or legacy [신규] name tag)
+#      counts.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_g4_ignores_exec_qualifier_tokens_in_unrelated_bullet_segments():
+    """`해외 매출`, `전기 자동차`, `수동 검증` style tokens in 뉴스/S-R/memo
+    sub-bullets must NOT satisfy EXEC_QUALIFIER_RE. G4 is only satisfied by
+    an actual `execution path:` / `실행경로:` segment OR a direct 실행경로
+    cell match.
+    """
+    md = """### 신규 후보
+
+| 시장 | 종목 | 분류 | 시장가 | RSI | ADX | Buy Zone | 액션 |
+|---|---|---|---|---|---|---|---|
+| KR | **LG이노텍 011070** | 신규(buy 검토) | 212,500 | 58 | 24 | 202K | buy 검토 |
+|   | • BB 194K/202K/222K · EMA 5>20>60<120 · 괴리 –4.5% |
+|   | • 뉴스 3건 (Reuters: 해외 매출 전망 / Bloomberg: 전기 자동차 수요 / 한경: 수동 검증 통과) · 컨센서스 목표가 250K, PER 16 · execution path: KIS · same-depth-check: pass |
+"""
+    report = evaluate_scout_report(markdown=md)
+    lginnotek = next(c for c in report.candidates if c.code == "011070")
+    assert lginnotek.is_new
+    # The sub-bullet contains 해외/자동/수동 tokens in 뉴스 segment, but the
+    # actual `execution path:` segment is `KIS` (bare). G4 must still hit.
+    g4 = next(r for r in report.gates if r.key == "G4")
+    assert not g4.passed, (
+        f"G4 must ignore 해외/자동/수동 appearing outside execution-path segment; "
+        f"detail={g4.detail}"
+    )
+
+
+@pytest.mark.unit
+def test_g4_segment_scan_still_accepts_multiple_labelled_segments():
+    """If the row has multiple `execution path:` segments (e.g. per-market
+    split), G4 must pass when any one of them carries a qualifier.
+    """
+    md = """| 시장 | 종목 | 분류 | 시장가 | RSI | ADX | Buy Zone | 액션 |
+|---|---|---|---|---|---|---|---|
+| KR | Krafton 259960 | 신규(watch) | 266,500 | 64 | 18 | 244K | watch only |
+|   | • 뉴스 — none · execution path: KIS · 실행경로: Toss manual · same-depth-check: pass |
+"""
+    report = evaluate_scout_report(markdown=md)
+    g4 = next(r for r in report.gates if r.key == "G4")
+    assert g4.passed, (
+        f"G4 must accept `Toss manual` qualifier in the 실행경로 segment even "
+        f"when a sibling `execution path: KIS` segment is bare; detail={g4.detail}"
+    )
+
+
+@pytest.mark.unit
+def test_is_new_does_not_fire_on_action_or_news_mention_of_신규():
+    """A 보유 row whose 액션 or 뉴스 cell happens to reference `신규 추천`,
+    `신규 카테고리`, etc. must NOT be promoted to 신규. Only the 분류 column
+    (or v1 name-cell `[신규]` tag) counts.
+    """
+    md = """| 시장 | 종목 | 분류 | 시장가 | 뉴스 | 액션 | 비고 |
+|---|---|---|---|---|---|---|
+| KR | NAVER 035420 | 보유/DCA | 216,000 | 뉴스 1건 — 신규 CEO 임명 | DCA limit | 신규 후보 대비 우위 |
+"""
+    report = evaluate_scout_report(markdown=md)
+    naver = next(c for c in report.candidates if c.code == "035420")
+    assert not naver.is_new, (
+        "보유/DCA row must stay 보유 even when 뉴스/액션/비고 cells mention 신규"
+    )
+
+
+@pytest.mark.unit
+def test_is_new_does_not_fire_on_category_column_saying_보유_in_v1_name_tag():
+    """Symmetric guard: when 분류 column is present AND says 보유, an
+    incidental `신규` elsewhere on the row (e.g. 비고: `신규 섹터 노출 없음`)
+    must still leave is_new=False because the 분류 column is authoritative.
+    """
+    md = """| 시장 | 종목 | 분류 | 시장가 | 비고 |
+|---|---|---|---|---|
+| KR | NAVER 035420 | 보유 | 216,000 | 신규 섹터 노출 없음 |
+"""
+    report = evaluate_scout_report(markdown=md)
+    naver = next(c for c in report.candidates if c.code == "035420")
+    assert not naver.is_new


### PR DESCRIPTION
## Summary

Closes [ROB-206](/ROB/issues/ROB-206) — Scout Report v2 §6.2 parser 정합성.

### Issue 1 — v2 §6.2 sub-bullet parser 미지원 (이미 [#553](https://github.com/mgh3326/auto_trader/pull/553) / ROB-197 commit `61012da` 에서 해결)
`|   | • ... |` sub-bullet 행이 `first_cell_empty + has_bullet` 조건으로 부모 row 에 병합되도록 이전 PR 에서 정리됨. ROB-206 범위에서는 regression 확인만 (✅).

### Issue 2 — `_extract_execution_cell` 컬럼 순서 민감 (이번 PR)
- **Header-aware column detection**: parser 가 `TABLE_SEPARATOR_RE` 직전 줄을 header 로 간주하고 `실행경로` / `execution path` / `계좌 (실행경로)` 컬럼 index 를 추출. 이후 후보 row 에서 해당 컬럼을 바로 뽑아옴 (column 순서 무관).
- **G4 fallback fix**: 기존 `EXEC_QUALIFIER_RE.search(c.execution_cell or c.context_text)` 는 `execution_cell` 이 비어있지 않으면 단락 평가로 context 를 통째로 skip. v2 §6.2 의 last cell 은 `액션` (`watch only`, `DCA limit` 등) 이라 항상 non-empty → sub-bullet `execution path: KIS 즉시` 가 있어도 G4 false fail. `execution_cell` 과 `context_text` 를 **둘 다** 검사하도록 수정.
- **`is_new` 확장**: v2 §6.2 는 `분류` 컬럼 (col 2) 에 `신규(watch)` 등을 기록. 기존 `name_cell / cells[0]` 만 보던 것을 `any("신규" in c for c in cells)` 로 확장.

### Fixtures
- `tests/fixtures/scout_reports/{all_gates_pass,g1_depth_fail,g3_tool_failure,g4_execution_path,g6_budget_reality}.md` 를 v2 §6.2 공식 포맷으로 복원 (8 core columns ending in `액션`, execution path in sub-bullet). 기존 single-line packed workaround 제거.

### Tests
- 기존 22 cases 전부 green (9 ROB-196 e2e + 13 unit).
- 신규 4 regression tests 추가:
  - `test_exec_cell_resolved_by_header_when_column_is_not_last` — 실행경로 column mid-row 배치 시 header 기반으로 정상 추출
  - `test_v2_sec62_execution_path_in_subline_passes_g4` — v2 §6.2 sub-bullet `execution path: KIS 즉시` 가 G4 통과
  - `test_g4_still_fails_when_bare_kis_appears_without_qualifier_anywhere` — 확장된 G4 check 가 bare `KIS` 를 여전히 fail 처리 (over-match 방지)
  - `test_is_new_detected_from_v2_category_column` — 분류 컬럼 `신규(watch)` 로 is_new 판정
- Total **26/26** pytest green · ruff check/format clean.

## Test plan
- [x] `uv run pytest tests/test_cio_quality_gate.py tests/test_cio_quality_gate_e2e.py -v` → 26/26 pass
- [x] `uv run ruff check app/services/cio_quality_gate_service.py tests/test_cio_quality_gate.py tests/test_cio_quality_gate_e2e.py`
- [x] `uv run ruff format` — no changes
- [ ] CI green on push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated comparison table format with improved column organization and version tracking (v2 §6.2)
  * Enhanced detection of new candidates that works across varying report layouts
  * Better extraction of execution paths by identifying designated table columns

* **Bug Fixes**
  * Fixed execution path validation to correctly identify qualifier patterns in all report sections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->