### PR TITLE
deploy: main → production for screen_stocks filters (PR #548, ROB-210)

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -352,10 +352,15 @@ Error examples:
 
 ### `screen_stocks` spec
 Parameters:
-- `market`: Market to screen - "kr", "us", "crypto" (default: "kr")
+- `market`: Market to screen - "kr", "kospi", "kosdaq", "konex", "all", "us", "crypto" (default: "kr")
 - `asset_type`: Asset type - "stock", "etf", "etn" (only applicable to KR, default: None)
 - `category`: Category filter - ETF categories for KR, sector for US (default: None)
 - `sector`: Sector filter for KR/US stocks (default: None). Not supported for crypto or KR ETF/ETN requests
+- `exclude_sectors`: Sector exclusion list for KR/US stocks (default: None). Values are de-duplicated case-insensitively for ASCII labels
+- `instrument_types`: Instrument taxonomy filter list - "common", "preferred", "etf", "reit", "spac", "unknown" (default: None)
+- `adv_krw_min`: Minimum 30-day average daily value in KRW. Use 1,000,000,000 for a conservative liquidity floor or 5,000,000,000 for an aggressive liquidity floor
+- `market_cap_min_krw`: Minimum market capitalization in KRW (default: None)
+- `market_cap_max_krw`: Maximum market capitalization in KRW (default: None)
 - `sort_by`: Sort criteria - "volume", "trade_amount", "market_cap", "change_rate", "dividend_yield", "rsi" (default: crypto="rsi", KR/US="volume")
 - `sort_order`: Sort order - "asc" or "desc" (default: "desc")
 - `min_market_cap`: Minimum market cap (억원 for KR, USD for US; not supported for crypto)
@@ -368,8 +373,11 @@ Parameters:
 
 Market-specific behavior:
 - **KR market**:
+  - `market="konex"` screens KONEX only; `market="all"` screens KOSPI, KOSDAQ, and KONEX
   - Default `asset_type in {None, "stock"}` + `category=None` requests use tvscreener only when verified KR stock-query capabilities cover the request; otherwise they fall back to the legacy KRX/Naver path before entering tvscreener
-  - Successful stock responses expose `meta.source = "tvscreener"` and include `adx` in each result row
+  - Successful stock responses expose `meta.source = "tvscreener"` and include `adx`, `instrument_type`, and 30-day ADV fields when TradingView provides them
+  - `adv_krw_min` uses TradingView 30-day average volume multiplied by price; responses set `meta.adv_window_days = 30` when this filter is requested
+  - Legacy KRX fallback cannot compute `adv_krw_min`; it returns a warning and skips only that filter
   - `sort_by="rsi"` is supported via tvscreener RSI data; legacy path falls back to OHLCV-based RSI enrichment
   - ETF/category requests stay on the legacy KRX/Naver path
   - KRX data cached with 300s TTL (Redis) + in-memory fallback
@@ -381,7 +389,9 @@ Market-specific behavior:
   - Default `asset_type in {None, "stock"}` requests use tvscreener only when verified US stock-query capabilities cover the request
   - US `category`/`sector` alias requests stay on the tvscreener path only when the TradingView sector filter capability is verified; otherwise they fall back to legacy before running the tv query
   - `sort_by="rsi"` is supported via tvscreener RSI data; legacy yfinance path falls back to OHLCV-based RSI enrichment
-  - Successful stock responses expose `meta.source = "tvscreener"`, include `adx`, and preserve public enrichment fields (`sector`, `analyst_buy`, `analyst_hold`, `analyst_sell`, `avg_target`, `upside_pct`) from tvscreener when available
+  - Successful stock responses expose `meta.source = "tvscreener"`, include `adx`, `instrument_type`, 30-day ADV fields, and preserve public enrichment fields (`sector`, `analyst_buy`, `analyst_hold`, `analyst_sell`, `avg_target`, `upside_pct`) from tvscreener when available
+  - `adv_krw_min` uses TradingView 30-day average volume multiplied by price; responses set `meta.adv_window_days = 30` when this filter is requested
+  - Legacy yfinance fallback cannot compute `adv_krw_min`; it returns a warning and skips only that filter
   - Post-screen enrichment skips per-row Finnhub/yfinance fan-out when those public fields are already populated; missing fields fall back to lightweight yfinance/Finnhub enrichment
   - Unsupported or unverified tvscreener request-critical capabilities fall back to the legacy yfinance path
   - Legacy yfinance maps: `min_market_cap` → `intradaymarketcap`, `max_per` → `peratio.lasttwelvemonths`, `min_dividend_yield` → `forward_dividend_yield`
@@ -404,10 +414,13 @@ Market-specific behavior:
   - `market_cap` sorting is supported; public `market_cap` prefers CoinGecko cache values and falls back to TradingView `MARKET_CAP`, and final ordering uses that public value without silently falling back to `trade_amount_24h`
   - `max_per`, `min_dividend_yield`, `sort_by="dividend_yield"` not supported - returns error
   - `min_market_cap` filter is not supported; crypto responses return a warning that it was ignored
-  - `sector` and `min_analyst_buy` filters are not supported for crypto - returns error
+  - `sector`, `exclude_sectors`, `instrument_types`, `adv_krw_min`, `market_cap_min_krw`, `market_cap_max_krw`, and `min_analyst_buy` filters are not supported for crypto - returns error
 
 Filter compatibility and error semantics:
 - `sector` filter: Supported for KR/US stocks only. Returns error for crypto or KR ETF/ETN requests
+- `exclude_sectors`: Supported for KR/US stocks only. Cannot overlap with `sector`
+- `instrument_types`: Supported for KR/US only. `asset_type="etf"` conflicts with `instrument_types=["common"]`
+- `adv_krw_min`, `market_cap_min_krw`, `market_cap_max_krw`: Non-negative integers only. `market_cap_min_krw` must be less than or equal to `market_cap_max_krw`
 - `min_analyst_buy` filter: Supported for KR/US stocks only (not ETF/ETN). Returns error for crypto or non-stock asset types
 - `min_dividend` / `min_dividend_yield`: These are aliases. Accepts decimal (0.03) or percentage (3.0) formats. If both are specified with different values, returns error. Not supported for crypto
 - `category` and `sector`: These are aliases for US market. If both are specified with different values, returns error

--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -156,14 +156,22 @@ def register_analysis_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="screen_stocks",
         description=(
-            "Screen stocks across markets (KR/US/Crypto) with various filters."
+            "Screen stocks across markets (KR/US/Crypto) with filters. "
+            "KR supports kospi/kosdaq/konex/all, 30-day ADV via adv_krw_min "
+            "(1B KRW conservative, 5B KRW aggressive), instrument_types, "
+            "and exclude_sectors."
         ),
     )
     async def screen_stocks(
-        market: Literal["kr", "kospi", "kosdaq", "us", "crypto"] = "kr",
+        market: Literal["kr", "kospi", "kosdaq", "konex", "all", "us", "crypto"] = "kr",
         asset_type: Literal["stock", "etf", "etn"] | None = None,
         category: str | None = None,
         sector: str | None = None,
+        exclude_sectors: list[str] | None = None,
+        instrument_types: list[
+            Literal["common", "preferred", "etf", "reit", "spac", "unknown"]
+        ]
+        | None = None,
         strategy: str | None = None,
         sort_by: Literal[
             "volume",
@@ -182,6 +190,9 @@ def register_analysis_tools(mcp: FastMCP) -> None:
         min_dividend: float | None = None,
         min_analyst_buy: float | None = None,
         max_rsi: float | None = None,
+        adv_krw_min: int | None = None,
+        market_cap_min_krw: int | None = None,
+        market_cap_max_krw: int | None = None,
         limit: int = 50,
     ) -> dict[str, Any]:
         return await screen_stocks_impl(
@@ -189,6 +200,8 @@ def register_analysis_tools(mcp: FastMCP) -> None:
             asset_type=asset_type,
             category=category,
             sector=sector,
+            exclude_sectors=exclude_sectors,
+            instrument_types=instrument_types,
             strategy=strategy,
             sort_by=sort_by,
             sort_order=sort_order,
@@ -199,6 +212,9 @@ def register_analysis_tools(mcp: FastMCP) -> None:
             min_dividend=min_dividend,
             min_analyst_buy=min_analyst_buy,
             max_rsi=max_rsi,
+            adv_krw_min=adv_krw_min,
+            market_cap_min_krw=market_cap_min_krw,
+            market_cap_max_krw=market_cap_max_krw,
             limit=limit,
         )
 

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -528,7 +528,7 @@ async def analyze_portfolio_impl(
 
 
 async def screen_stocks_impl(
-    market: Literal["kr", "kospi", "kosdaq", "us", "crypto"] = "kr",
+    market: Literal["kr", "kospi", "kosdaq", "konex", "all", "us", "crypto"] = "kr",
     asset_type: Literal["stock", "etf", "etn"] | None = None,
     category: str | None = None,
     sector: str | None = None,
@@ -550,6 +550,11 @@ async def screen_stocks_impl(
     min_dividend: float | None = None,
     min_analyst_buy: float | None = None,
     max_rsi: float | None = None,
+    exclude_sectors: list[str] | None = None,
+    instrument_types: list[str] | None = None,
+    adv_krw_min: int | None = None,
+    market_cap_min_krw: int | None = None,
+    market_cap_max_krw: int | None = None,
     limit: int = 50,
 ) -> dict[str, Any]:
     sort_by_specified = sort_by is not None
@@ -588,6 +593,11 @@ async def screen_stocks_impl(
         min_analyst_buy=min_analyst_buy,
         max_rsi=max_rsi,
         limit=limit,
+        exclude_sectors=exclude_sectors,
+        instrument_types=instrument_types,
+        adv_krw_min=adv_krw_min,
+        market_cap_min_krw=market_cap_min_krw,
+        market_cap_max_krw=market_cap_max_krw,
     )
 
     normalized_market = analysis_screening._normalize_screen_market(market)
@@ -616,6 +626,11 @@ async def screen_stocks_impl(
         min_dividend_yield=normalized_request["min_dividend_yield"],
         max_rsi=max_rsi,
         sort_by=normalized_sort_by,
+        adv_krw_min=normalized_request["adv_krw_min"],
+        market_cap_min_krw=normalized_request["market_cap_min_krw"],
+        market_cap_max_krw=normalized_request["market_cap_max_krw"],
+        instrument_types=normalized_request["instrument_types"],
+        exclude_sectors=normalized_request["exclude_sectors"],
     )
     # Use unified screening with automatic data source selection
     return await analysis_screening.screen_stocks_unified(
@@ -633,6 +648,11 @@ async def screen_stocks_impl(
         sort_by=normalized_sort_by,
         sort_order=normalized_sort_order,
         limit=limit,
+        exclude_sectors=exclude_sectors,
+        instrument_types=instrument_types,
+        adv_krw_min=adv_krw_min,
+        market_cap_min_krw=market_cap_min_krw,
+        market_cap_max_krw=market_cap_max_krw,
     )
 
 

--- a/app/mcp_server/tooling/screening/common.py
+++ b/app/mcp_server/tooling/screening/common.py
@@ -21,6 +21,7 @@ DROP_THRESHOLD = -0.30
 MARKET_PANIC = -0.10
 CRYPTO_TOP_BY_VOLUME = 100
 COINGECKO_MARKETS_URL = "https://api.coingecko.com/api/v3/coins/markets"
+SUPPORTED_INSTRUMENT_TYPES = {"common", "preferred", "etf", "reit", "spac", "unknown"}
 
 # ---------------------------------------------------------------------------
 # Timeout Policy Configuration
@@ -199,6 +200,10 @@ def _kr_market_codes(market: str) -> tuple[list[str], str]:
         return ["STK"], "STK"
     if market == "kosdaq":
         return ["KSQ"], "KSQ"
+    if market == "konex":
+        return ["KNX"], "KNX"
+    if market == "all":
+        return ["STK", "KSQ", "KNX"], "ALL"
     return ["STK", "KSQ"], "ALL"
 
 
@@ -380,6 +385,45 @@ def _normalize_sector_compare_key(sector: str | None) -> str | None:
     return normalized
 
 
+def _normalize_string_list(values: list[str] | None) -> list[str] | None:
+    if values is None:
+        return None
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = _normalize_optional_text(value)
+        if text is None:
+            continue
+        key = text.casefold() if text.isascii() else text
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(text)
+    return normalized or None
+
+
+def _normalize_instrument_types(values: list[str] | None) -> list[str] | None:
+    normalized = _normalize_string_list(values)
+    if normalized is None:
+        return None
+    lowered = [value.casefold() for value in normalized]
+    invalid = sorted(set(lowered) - SUPPORTED_INSTRUMENT_TYPES)
+    if invalid:
+        raise ValueError(
+            "instrument_types must contain only: "
+            + ", ".join(sorted(SUPPORTED_INSTRUMENT_TYPES))
+        )
+    return lowered
+
+
+def _normalize_non_negative_int(value: int | None, name: str) -> int | None:
+    if value is None:
+        return None
+    if value < 0:
+        raise ValueError(f"{name} must be >= 0")
+    return int(value)
+
+
 def _canonicalize_us_sector_label(sector: str) -> str:
     """Canonicalize a US sector label for the TradingView tvscreener provider.
 
@@ -451,11 +495,51 @@ def normalize_screen_request(
     min_analyst_buy: float | None,
     max_rsi: float | None,
     limit: int,
+    exclude_sectors: list[str] | None = None,
+    instrument_types: list[str] | None = None,
+    adv_krw_min: int | None = None,
+    market_cap_min_krw: int | None = None,
+    market_cap_max_krw: int | None = None,
 ) -> dict[str, Any]:
     normalized_market = _normalize_screen_market(market)
+    if normalized_market not in {
+        "kr",
+        "kospi",
+        "kosdaq",
+        "konex",
+        "all",
+        "us",
+        "crypto",
+    }:
+        raise ValueError(
+            "market must be one of: kr, kospi, kosdaq, konex, all, us, crypto"
+        )
     normalized_asset_type = _normalize_asset_type(asset_type)
     normalized_category = _normalize_optional_text(category)
     normalized_sector = _normalize_sector_value(sector)
+    normalized_exclude_sectors = _normalize_string_list(exclude_sectors)
+    exclude_sector_keys = {
+        key
+        for key in (
+            _normalize_sector_compare_key(sector)
+            for sector in (normalized_exclude_sectors or [])
+        )
+        if key is not None
+    }
+    normalized_instrument_types = _normalize_instrument_types(instrument_types)
+    normalized_adv_krw_min = _normalize_non_negative_int(adv_krw_min, "adv_krw_min")
+    normalized_market_cap_min_krw = _normalize_non_negative_int(
+        market_cap_min_krw, "market_cap_min_krw"
+    )
+    normalized_market_cap_max_krw = _normalize_non_negative_int(
+        market_cap_max_krw, "market_cap_max_krw"
+    )
+    if (
+        normalized_market_cap_min_krw is not None
+        and normalized_market_cap_max_krw is not None
+        and normalized_market_cap_min_krw > normalized_market_cap_max_krw
+    ):
+        raise ValueError("market_cap_min_krw must be <= market_cap_max_krw")
     normalized_strategy = _normalize_optional_text(strategy)
     normalized_sort_by = _normalize_sort_by(sort_by)
     normalized_sort_order = _normalize_sort_order(sort_order)
@@ -485,13 +569,22 @@ def normalize_screen_request(
         effective_sector = _canonicalize_us_sector_label(effective_sector)
 
     if effective_sector is not None:
+        sector_key = _normalize_sector_compare_key(effective_sector)
+        if sector_key is not None and sector_key in exclude_sector_keys:
+            raise ValueError("sector and exclude_sectors cannot overlap")
         if normalized_market == "crypto":
             raise ValueError("crypto market does not support sector filter")
-        if normalized_market in {"kr", "kospi", "kosdaq"} and normalized_asset_type in {
-            "etf",
-            "etn",
-        }:
+        if normalized_market in {
+            "kr",
+            "kospi",
+            "kosdaq",
+            "konex",
+            "all",
+        } and normalized_asset_type in {"etf", "etn"}:
             raise ValueError("sector filter is only supported for stock requests")
+
+    if normalized_asset_type == "etf" and normalized_instrument_types == ["common"]:
+        raise ValueError("asset_type='etf' conflicts with instrument_types=['common']")
 
     if normalized_min_analyst_buy is not None:
         if normalized_market == "crypto":
@@ -527,6 +620,12 @@ def normalize_screen_request(
         "min_analyst_buy": normalized_min_analyst_buy,
         "max_rsi": max_rsi,
         "limit": limit,
+        "exclude_sectors": normalized_exclude_sectors,
+        "exclude_sector_keys": exclude_sector_keys,
+        "instrument_types": normalized_instrument_types,
+        "adv_krw_min": normalized_adv_krw_min,
+        "market_cap_min_krw": normalized_market_cap_min_krw,
+        "market_cap_max_krw": normalized_market_cap_max_krw,
     }
 
 
@@ -543,12 +642,27 @@ def _validate_screen_filters(
     min_dividend_yield: float | None,
     max_rsi: float | None,
     sort_by: str | None,
+    adv_krw_min: int | None = None,
+    market_cap_min_krw: int | None = None,
+    market_cap_max_krw: int | None = None,
+    instrument_types: list[str] | None = None,
+    exclude_sectors: list[str] | None = None,
 ) -> None:
     """Validate screening filters and raise ValueError for unsupported combinations."""
     _ = min_market_cap
     _ = max_rsi
 
     if market == "crypto":
+        if adv_krw_min is not None:
+            raise ValueError("crypto market does not support adv_krw_min filter")
+        if market_cap_min_krw is not None:
+            raise ValueError("crypto market does not support market_cap_min_krw filter")
+        if market_cap_max_krw is not None:
+            raise ValueError("crypto market does not support market_cap_max_krw filter")
+        if instrument_types is not None:
+            raise ValueError("crypto market does not support instrument_types filter")
+        if exclude_sectors is not None:
+            raise ValueError("crypto market does not support exclude_sectors filter")
         if max_per is not None:
             raise ValueError(
                 "Crypto market does not support 'max_per' filter (no P/E ratio)"
@@ -571,7 +685,7 @@ def _validate_screen_filters(
                 "'trade_amount' sorting is only supported for crypto market"
             )
 
-    if market in ("kr", "kospi", "kosdaq") and asset_type == "etn":
+    if market in ("kr", "kospi", "kosdaq", "konex", "all") and asset_type == "etn":
         raise ValueError(
             "Korean market (KR/KOSPI/KOSDAQ) does not support ETN (Exchange Traded Notes) asset_type"
         )
@@ -584,9 +698,15 @@ def _apply_basic_filters(
     max_pbr: float | None,
     min_dividend_yield: float | None,
     max_rsi: float | None,
+    adv_krw_min: int | None = None,
+    market_cap_min_krw: int | None = None,
+    market_cap_max_krw: int | None = None,
+    instrument_types: list[str] | None = None,
+    exclude_sector_keys: set[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Apply basic numeric filters to candidate stocks."""
     filtered = []
+    instrument_type_set = set(instrument_types or [])
 
     for item in candidates:
         skip = False
@@ -595,6 +715,24 @@ def _apply_basic_filters(
             if item.get("market_cap") is None:
                 skip = True
             elif item["market_cap"] < min_market_cap:
+                skip = True
+
+        if not skip and adv_krw_min is not None:
+            if item.get("adv_krw") is None:
+                skip = True
+            elif item["adv_krw"] < adv_krw_min:
+                skip = True
+
+        if not skip and market_cap_min_krw is not None:
+            if item.get("market_cap_krw") is None:
+                skip = True
+            elif item["market_cap_krw"] < market_cap_min_krw:
+                skip = True
+
+        if not skip and market_cap_max_krw is not None:
+            if item.get("market_cap_krw") is None:
+                skip = True
+            elif item["market_cap_krw"] > market_cap_max_krw:
                 skip = True
 
         if not skip and max_per is not None:
@@ -619,6 +757,18 @@ def _apply_basic_filters(
             if item.get("rsi") is None:
                 skip = True
             elif item["rsi"] > max_rsi:
+                skip = True
+
+        if not skip and instrument_types is not None:
+            if (
+                str(item.get("instrument_type") or "").casefold()
+                not in instrument_type_set
+            ):
+                skip = True
+
+        if not skip and exclude_sector_keys:
+            sector_key = _normalize_sector_compare_key(item.get("sector"))
+            if sector_key is not None and sector_key in exclude_sector_keys:
                 skip = True
 
         if not skip:

--- a/app/mcp_server/tooling/screening/entrypoint.py
+++ b/app/mcp_server/tooling/screening/entrypoint.py
@@ -45,6 +45,12 @@ async def _dispatch_kr_screen(
         sort_by=normalized_request["sort_by"],
         sort_order=normalized_request["sort_order"],
         limit=query_limit,
+        adv_krw_min=normalized_request["adv_krw_min"],
+        market_cap_min_krw=normalized_request["market_cap_min_krw"],
+        market_cap_max_krw=normalized_request["market_cap_max_krw"],
+        instrument_types=normalized_request["instrument_types"],
+        exclude_sectors=normalized_request["exclude_sectors"],
+        exclude_sector_keys=normalized_request["exclude_sector_keys"],
     )
 
 
@@ -70,6 +76,12 @@ async def _dispatch_us_screen(
         sort_by=normalized_request["sort_by"],
         sort_order=normalized_request["sort_order"],
         limit=query_limit,
+        adv_krw_min=normalized_request["adv_krw_min"],
+        market_cap_min_krw=normalized_request["market_cap_min_krw"],
+        market_cap_max_krw=normalized_request["market_cap_max_krw"],
+        instrument_types=normalized_request["instrument_types"],
+        exclude_sectors=normalized_request["exclude_sectors"],
+        exclude_sector_keys=normalized_request["exclude_sector_keys"],
     )
 
 
@@ -109,6 +121,11 @@ def _dispatch_unsupported_market(
             "asset_type": normalized_request["asset_type"],
             "category": normalized_request["category_for_filters"],
             "sector": normalized_request["sector"],
+            "exclude_sectors": normalized_request["exclude_sectors"],
+            "instrument_types": normalized_request["instrument_types"],
+            "adv_krw_min": normalized_request["adv_krw_min"],
+            "market_cap_min_krw": normalized_request["market_cap_min_krw"],
+            "market_cap_max_krw": normalized_request["market_cap_max_krw"],
         },
         market=normalized_request["market"],
         warnings=[f"Unsupported market: {normalized_request['market']}"],
@@ -130,6 +147,11 @@ async def screen_stocks_unified(
     sector: str | None = None,
     min_dividend: float | None = None,
     min_analyst_buy: float | None = None,
+    exclude_sectors: list[str] | None = None,
+    instrument_types: list[str] | None = None,
+    adv_krw_min: int | None = None,
+    market_cap_min_krw: int | None = None,
+    market_cap_max_krw: int | None = None,
 ) -> dict[str, Any]:
     """Unified stock screening entry point with automatic data source selection.
 
@@ -171,6 +193,11 @@ async def screen_stocks_unified(
         min_analyst_buy=min_analyst_buy,
         max_rsi=max_rsi,
         limit=limit,
+        exclude_sectors=exclude_sectors,
+        instrument_types=instrument_types,
+        adv_krw_min=adv_krw_min,
+        market_cap_min_krw=market_cap_min_krw,
+        market_cap_max_krw=market_cap_max_krw,
     )
     normalized_market = normalized_request["market"]
     normalized_asset_type = normalized_request["asset_type"]
@@ -178,7 +205,7 @@ async def screen_stocks_unified(
     normalized_sort_order = normalized_request["sort_order"]
     normalized_min_dividend_yield = normalized_request["min_dividend_yield"]
     apply_post_enrichment_filters = (
-        normalized_market in {"kr", "kospi", "kosdaq", "us"}
+        normalized_market in {"kr", "kospi", "kosdaq", "konex", "all", "us"}
         and normalized_asset_type in {None, "stock"}
         and (
             normalized_request["sector"] is not None
@@ -188,7 +215,7 @@ async def screen_stocks_unified(
     can_avoid_overfetch = normalized_asset_type in {None, "stock"} and (
         normalized_market == "us"
         or (
-            normalized_market in {"kr", "kospi", "kosdaq"}
+            normalized_market in {"kr", "kospi", "kosdaq", "konex", "all"}
             and normalized_request["sector"] is None
             and normalized_request["min_analyst_buy"] is not None
         )
@@ -208,10 +235,15 @@ async def screen_stocks_unified(
         min_dividend_yield=normalized_min_dividend_yield,
         max_rsi=max_rsi,
         sort_by=normalized_sort_by,
+        adv_krw_min=normalized_request["adv_krw_min"],
+        market_cap_min_krw=normalized_request["market_cap_min_krw"],
+        market_cap_max_krw=normalized_request["market_cap_max_krw"],
+        instrument_types=normalized_request["instrument_types"],
+        exclude_sectors=normalized_request["exclude_sectors"],
     )
 
     # Route to appropriate implementation based on market
-    if normalized_market in ("kr", "kospi", "kosdaq"):
+    if normalized_market in ("kr", "kospi", "kosdaq", "konex", "all"):
         response = await _dispatch_kr_screen(
             normalized_request,
             min_market_cap=min_market_cap,
@@ -276,6 +308,25 @@ async def screen_stocks_unified(
         "min_analyst_buy", normalized_request["min_analyst_buy"]
     )
     normalized_filters_applied.setdefault("max_rsi", max_rsi)
+    normalized_filters_applied.setdefault(
+        "exclude_sectors", normalized_request["exclude_sectors"]
+    )
+    normalized_filters_applied.setdefault(
+        "instrument_types", normalized_request["instrument_types"]
+    )
+    normalized_filters_applied.setdefault(
+        "adv_krw_min", normalized_request["adv_krw_min"]
+    )
+    normalized_filters_applied.setdefault(
+        "market_cap_min_krw", normalized_request["market_cap_min_krw"]
+    )
+    normalized_filters_applied.setdefault(
+        "market_cap_max_krw", normalized_request["market_cap_max_krw"]
+    )
+    if normalized_request["adv_krw_min"] is not None:
+        meta = response.get("meta")
+        if isinstance(meta, dict):
+            meta.setdefault("adv_window_days", 30)
     if normalized_request["min_dividend_input"] is not None:
         normalized_filters_applied["min_dividend_input"] = normalized_request[
             "min_dividend_input"

--- a/app/mcp_server/tooling/screening/instrument_type.py
+++ b/app/mcp_server/tooling/screening/instrument_type.py
@@ -1,0 +1,93 @@
+"""Instrument-type classification helpers for stock screening."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+InstrumentType = Literal["common", "preferred", "etf", "reit", "spac", "unknown"]
+
+_PREFERRED_KR_NAME_RE = re.compile(r"(?:\d우B?|\d우|우B?|우선주)$")
+_PREFERRED_KR_CODE_SUFFIXES = ("5", "7", "9")
+_PREFERRED_US_SYMBOL_RE = re.compile(r"(?:[.-]P[A-Z]?|[.-]PR[.-]?[A-Z]?)$")
+
+
+def _normalize_compare_key(value: object) -> str:
+    return re.sub(r"\s+", "", str(value or "").strip()).casefold()
+
+
+def _has_any_token(value: object, tokens: tuple[str, ...]) -> bool:
+    key = _normalize_compare_key(value)
+    return any(token in key for token in tokens)
+
+
+def classify_kr_instrument(
+    symbol: object,
+    name: object,
+    tvscreener_subtype: object,
+) -> InstrumentType:
+    """Classify Korean instruments into the public screen_stocks taxonomy."""
+    symbol_text = str(symbol or "").strip().upper()
+    name_text = str(name or "").strip()
+    subtype_text = str(tvscreener_subtype or "").strip()
+
+    if _has_any_token(subtype_text, ("etf", "exchangetradedfund")) or _has_any_token(
+        name_text, ("etf", "상장지수", "kodex", "tiger", "ace", "kbstar", "hanaro")
+    ):
+        return "etf"
+    if _has_any_token(name_text, ("reit", "리츠")) or _has_any_token(
+        subtype_text, ("reit",)
+    ):
+        return "reit"
+    if _has_any_token(name_text, ("spac", "스팩")) or _has_any_token(
+        subtype_text, ("spac",)
+    ):
+        return "spac"
+    if name_text and _PREFERRED_KR_NAME_RE.search(name_text):
+        return "preferred"
+    if name_text and symbol_text and symbol_text[-1:] in _PREFERRED_KR_CODE_SUFFIXES:
+        return "preferred"
+    if name_text or subtype_text:
+        return "common"
+    return "unknown"
+
+
+def classify_us_instrument(
+    symbol: object,
+    name: object,
+    tvscreener_type: object,
+    tvscreener_subtype: object,
+) -> InstrumentType:
+    """Classify US instruments into the public screen_stocks taxonomy."""
+    symbol_text = str(symbol or "").strip().upper()
+    name_text = str(name or "").strip()
+    type_text = str(tvscreener_type or "").strip()
+    subtype_text = str(tvscreener_subtype or "").strip()
+    combined = " ".join((name_text, type_text, subtype_text))
+
+    if _has_any_token(combined, ("etf", "exchangetradedfund")):
+        return "etf"
+    if _has_any_token(combined, ("reit", "realestateinvestmenttrust")):
+        return "reit"
+    if _has_any_token(combined, ("spac", "specialpurposeacquisition")) or (
+        "acquisitioncorp" in _normalize_compare_key(name_text)
+        and _has_any_token(name_text, ("unit", "warrant"))
+    ):
+        return "spac"
+    if _has_any_token(combined, ("preferred", "preference")) or (
+        symbol_text and _PREFERRED_US_SYMBOL_RE.search(symbol_text)
+    ):
+        return "preferred"
+    if _has_any_token(combined, ("commonstock", "stock", "equity")) or (
+        symbol_text and name_text
+    ):
+        return "common"
+    return "unknown"
+
+
+__all__ = [
+    "InstrumentType",
+    "_normalize_compare_key",
+    "classify_kr_instrument",
+    "classify_us_instrument",
+]

--- a/app/mcp_server/tooling/screening/kr.py
+++ b/app/mcp_server/tooling/screening/kr.py
@@ -24,6 +24,7 @@ from app.mcp_server.tooling.screening.common import (
     _to_optional_float,
 )
 from app.mcp_server.tooling.screening.enrichment import _pick_display_name
+from app.mcp_server.tooling.screening.instrument_type import classify_kr_instrument
 from app.mcp_server.tooling.screening.tvscreener_support import (
     _adapt_tvscreener_stock_response,
     _can_use_tvscreener_stock_path,
@@ -56,6 +57,12 @@ async def _screen_kr(
     sort_by: str,
     sort_order: str,
     limit: int,
+    adv_krw_min: int | None = None,
+    market_cap_min_krw: int | None = None,
+    market_cap_max_krw: int | None = None,
+    instrument_types: list[str] | None = None,
+    exclude_sectors: list[str] | None = None,
+    exclude_sector_keys: set[str] | None = None,
 ) -> dict[str, Any]:
     """Screen Korean market stocks/ETFs."""
     (
@@ -67,6 +74,11 @@ async def _screen_kr(
         "market": market,
         "asset_type": asset_type,
         "category": category,
+        "adv_krw_min": adv_krw_min,
+        "market_cap_min_krw": market_cap_min_krw,
+        "market_cap_max_krw": market_cap_max_krw,
+        "instrument_types": instrument_types,
+        "exclude_sectors": exclude_sectors,
     }
 
     if category is not None and asset_type is None:
@@ -118,6 +130,19 @@ async def _screen_kr(
 
         if "asset_type" not in item:
             item["asset_type"] = "stock"
+        item["instrument_type"] = (
+            "etf"
+            if item.get("asset_type") == "etf"
+            else classify_kr_instrument(
+                item.get("short_code") or item.get("code"),
+                item.get("name"),
+                item.get("subtype"),
+            )
+        )
+        if item.get("market_cap_krw") is None:
+            market_cap = _to_optional_float(item.get("market_cap"))
+            if market_cap is not None:
+                item["market_cap_krw"] = market_cap * 100_000_000
 
     valuation_market = {"kospi": "STK", "kosdaq": "KSQ"}.get(market, "ALL")
     try:
@@ -149,6 +174,11 @@ async def _screen_kr(
         max_pbr=max_pbr,
         min_dividend_yield=min_dividend_yield_normalized,
         max_rsi=max_rsi,
+        adv_krw_min=None,
+        market_cap_min_krw=market_cap_min_krw,
+        market_cap_max_krw=market_cap_max_krw,
+        instrument_types=instrument_types,
+        exclude_sector_keys=exclude_sector_keys,
     )
     results = _sort_and_limit(
         filtered,
@@ -165,11 +195,19 @@ async def _screen_kr(
     if min_dividend_yield_normalized is not None:
         filters_applied["min_dividend_yield_normalized"] = min_dividend_yield_normalized
 
+    warnings = []
+    if adv_krw_min is not None:
+        warnings.append(
+            "adv_krw_min requires 30-day average-volume data and is not available "
+            "on the KR legacy fallback path; filter was skipped."
+        )
+
     return _build_screen_response(
         results,
         len(filtered),
         filters_applied,
         market,
+        warnings=warnings or None,
     )
 
 
@@ -217,6 +255,11 @@ def _build_kr_filters(
     )
     price_target_field = _get_tvscreener_attr(StockField, "PRICE_TARGET_1Y")
     price_target_delta_field = _get_tvscreener_attr(StockField, "PRICE_TARGET_1Y_DELTA")
+    average_volume_30_day_field = _get_tvscreener_attr(
+        StockField, "AVERAGE_VOLUME_30_DAY", "AVERAGE_VOLUME_30D", "AVERAGE_VOLUME_30"
+    )
+    type_field = _get_tvscreener_attr(StockField, "TYPE")
+    subtype_field = _get_tvscreener_attr(StockField, "SUBTYPE")
 
     columns = [
         StockField.ACTIVE_SYMBOL,
@@ -242,6 +285,9 @@ def _build_kr_filters(
         recommendation_under_field,
         price_target_field,
         price_target_delta_field,
+        average_volume_30_day_field,
+        type_field,
+        subtype_field,
     ):
         if optional_field is not None:
             columns.append(optional_field)
@@ -351,6 +397,14 @@ async def _normalize_kr_results(
             "rsi": _to_optional_float(row.get("relative_strength_index_14")),
             "adx": _to_optional_float(row.get("average_directional_index_14")),
             "volume": _to_optional_float(row.get("volume")),
+            "average_volume_30_day": _to_optional_float(
+                _get_first_present(
+                    row,
+                    "average_volume_30_day",
+                    "average_volume_30d",
+                    "average_volume_30",
+                )
+            ),
             "change_percent": _to_optional_float(row.get("change_percent")),
             "market_cap": _to_optional_float(
                 _get_first_present(
@@ -381,6 +435,18 @@ async def _normalize_kr_results(
             else "South Korea",
         }
         stock["change_rate"] = stock["change_percent"]
+        avg_volume = _to_optional_float(stock.get("average_volume_30_day"))
+        price = _to_optional_float(stock.get("price"))
+        if avg_volume is not None and price is not None:
+            stock["adv_krw"] = avg_volume * price
+        market_cap = _to_optional_float(stock.get("market_cap"))
+        if market_cap is not None:
+            stock["market_cap_krw"] = market_cap * 100_000_000
+        stock["instrument_type"] = classify_kr_instrument(
+            code,
+            stock.get("name") or base.get("name"),
+            _get_first_present(row, "subtype", "type"),
+        )
 
         # Fallback to KRX data for missing fields
         if stock["market_cap"] is None:
@@ -427,6 +493,12 @@ async def _screen_kr_via_tvscreener(
     sort_by: str = "rsi",
     sort_order: str = "desc",
     limit: int = 50,
+    adv_krw_min: int | None = None,
+    market_cap_min_krw: int | None = None,
+    market_cap_max_krw: int | None = None,
+    instrument_types: list[str] | None = None,
+    exclude_sectors: list[str] | None = None,
+    exclude_sector_keys: set[str] | None = None,
 ) -> dict[str, Any]:
     """Screen Korean stocks using TradingView StockScreener API."""
     (
@@ -450,6 +522,11 @@ async def _screen_kr_via_tvscreener(
         "sort_by": sort_by,
         "sort_order": sort_order,
         "limit": limit,
+        "adv_krw_min": adv_krw_min,
+        "market_cap_min_krw": market_cap_min_krw,
+        "market_cap_max_krw": market_cap_max_krw,
+        "instrument_types": instrument_types,
+        "exclude_sectors": exclude_sectors,
     }
     if min_dividend_yield_input is not None:
         filters_applied["min_dividend_yield_input"] = min_dividend_yield_input
@@ -499,11 +576,18 @@ async def _screen_kr_via_tvscreener(
             max_pbr=max_pbr,
             min_dividend_yield=min_dividend_yield_normalized,
             max_rsi=max_rsi,
+            adv_krw_min=adv_krw_min,
+            market_cap_min_krw=market_cap_min_krw,
+            market_cap_max_krw=market_cap_max_krw,
+            instrument_types=instrument_types,
+            exclude_sector_keys=exclude_sector_keys,
         )
         ordered = _sort_and_limit(filtered, sort_by, sort_order, limit)
 
         result["count"] = len(filtered)
         result["stocks"] = ordered
+        if adv_krw_min is not None:
+            result["meta_fields"] = {"adv_window_days": 30}
 
         logger.info(
             "[Screen-KR-TV] Returning %d Korean stocks sorted by %s",
@@ -547,6 +631,12 @@ async def _screen_kr_with_fallback(
     sort_by: str,
     sort_order: str,
     limit: int,
+    adv_krw_min: int | None = None,
+    market_cap_min_krw: int | None = None,
+    market_cap_max_krw: int | None = None,
+    instrument_types: list[str] | None = None,
+    exclude_sectors: list[str] | None = None,
+    exclude_sector_keys: set[str] | None = None,
 ) -> dict[str, Any]:
     """Screen Korean market with tvscreener fallback to legacy."""
     capability_snapshot = await _get_tvscreener_stock_capability_snapshot(
@@ -585,6 +675,12 @@ async def _screen_kr_with_fallback(
                 sort_by=sort_by,
                 sort_order=sort_order,
                 limit=limit,
+                adv_krw_min=adv_krw_min,
+                market_cap_min_krw=market_cap_min_krw,
+                market_cap_max_krw=market_cap_max_krw,
+                instrument_types=instrument_types,
+                exclude_sectors=exclude_sectors,
+                exclude_sector_keys=exclude_sector_keys,
             )
             if tvscreener_result and not tvscreener_result.get("error"):
                 logger.info(
@@ -614,4 +710,10 @@ async def _screen_kr_with_fallback(
         sort_by=sort_by,
         sort_order=sort_order,
         limit=limit,
+        adv_krw_min=adv_krw_min,
+        market_cap_min_krw=market_cap_min_krw,
+        market_cap_max_krw=market_cap_max_krw,
+        instrument_types=instrument_types,
+        exclude_sectors=exclude_sectors,
+        exclude_sector_keys=exclude_sector_keys,
     )

--- a/app/mcp_server/tooling/screening/tvscreener_support.py
+++ b/app/mcp_server/tooling/screening/tvscreener_support.py
@@ -168,6 +168,18 @@ def _map_tvscreener_stock_row(
         "adx": row.get("adx"),
         "market": row.get("market") or market,
     }
+    adv_krw = _to_optional_float(row.get("adv_krw"))
+    if adv_krw is not None:
+        mapped["adv_krw"] = adv_krw
+    average_volume_30_day = _to_optional_float(row.get("average_volume_30_day"))
+    if average_volume_30_day is not None:
+        mapped["average_volume_30_day"] = average_volume_30_day
+    market_cap_krw = _to_optional_float(row.get("market_cap_krw"))
+    if market_cap_krw is not None:
+        mapped["market_cap_krw"] = market_cap_krw
+    instrument_type = row.get("instrument_type")
+    if instrument_type is not None:
+        mapped["instrument_type"] = instrument_type
     pbr = _to_optional_float(
         _get_first_present(
             row,
@@ -252,10 +264,14 @@ def _adapt_tvscreener_stock_response(
     normalized_filters.setdefault("sort_by", None)
     normalized_filters.setdefault("sort_order", "desc")
     total_count = int(tvscreener_result.get("count", len(rows)) or 0)
+    meta_fields = {"source": "tvscreener"}
+    extra_meta = tvscreener_result.get("meta_fields")
+    if isinstance(extra_meta, dict):
+        meta_fields.update(extra_meta)
     return _build_screen_response(
         rows,
         total_count,
         normalized_filters,
         market,
-        meta_fields={"source": "tvscreener"},
+        meta_fields=meta_fields,
     )

--- a/app/mcp_server/tooling/screening/us.py
+++ b/app/mcp_server/tooling/screening/us.py
@@ -29,6 +29,7 @@ from app.mcp_server.tooling.screening.common import (
 from app.mcp_server.tooling.screening.enrichment import (
     _pick_display_name,
 )
+from app.mcp_server.tooling.screening.instrument_type import classify_us_instrument
 from app.mcp_server.tooling.screening.tvscreener_support import (
     _adapt_tvscreener_stock_response,
     _can_use_tvscreener_stock_path,
@@ -36,6 +37,7 @@ from app.mcp_server.tooling.screening.tvscreener_support import (
 )
 from app.mcp_server.tooling.shared import error_payload as _error_payload
 from app.monitoring import build_yfinance_tracing_session
+from app.services.exchange_rate_service import get_usd_krw_rate
 from app.services.tvscreener_service import (
     TvScreenerError,
     TvScreenerService,
@@ -43,6 +45,34 @@ from app.services.tvscreener_service import (
 )
 
 logger = logging.getLogger(__name__)
+
+_US_SCREENING_USD_KRW_FALLBACK_RATE = 1300.0
+
+
+def _has_krw_valuation_filter(
+    *,
+    adv_krw_min: int | None = None,
+    market_cap_min_krw: int | None = None,
+    market_cap_max_krw: int | None = None,
+) -> bool:
+    return any(
+        value is not None
+        for value in (adv_krw_min, market_cap_min_krw, market_cap_max_krw)
+    )
+
+
+async def _resolve_us_screening_usd_krw_rate(*, prefer_live_rate: bool) -> float:
+    if not prefer_live_rate:
+        return _US_SCREENING_USD_KRW_FALLBACK_RATE
+    try:
+        return await get_usd_krw_rate()
+    except Exception as exc:
+        logger.warning(
+            "US screening USD/KRW lookup failed; using fallback rate %s: %s",
+            _US_SCREENING_USD_KRW_FALLBACK_RATE,
+            exc,
+        )
+        return _US_SCREENING_USD_KRW_FALLBACK_RATE
 
 
 async def _screen_us(
@@ -56,6 +86,12 @@ async def _screen_us(
     sort_by: str,
     sort_order: str,
     limit: int,
+    adv_krw_min: int | None = None,
+    market_cap_min_krw: int | None = None,
+    market_cap_max_krw: int | None = None,
+    instrument_types: list[str] | None = None,
+    exclude_sectors: list[str] | None = None,
+    exclude_sector_keys: set[str] | None = None,
 ) -> dict[str, Any]:
     """Screen US market stocks using yfinance screener."""
     (
@@ -73,6 +109,11 @@ async def _screen_us(
         filters_applied.update(
             {
                 "min_market_cap": min_market_cap,
+                "adv_krw_min": adv_krw_min,
+                "market_cap_min_krw": market_cap_min_krw,
+                "market_cap_max_krw": market_cap_max_krw,
+                "instrument_types": instrument_types,
+                "exclude_sectors": exclude_sectors,
                 "max_per": max_per,
                 "min_dividend_yield": min_dividend_yield_normalized,
                 "max_rsi": max_rsi,
@@ -154,6 +195,13 @@ async def _screen_us(
             _complete_filters_applied()
             return _build_screen_response([], 0, filters_applied, market)
 
+        usd_krw_rate = await _resolve_us_screening_usd_krw_rate(
+            prefer_live_rate=_has_krw_valuation_filter(
+                market_cap_min_krw=market_cap_min_krw,
+                market_cap_max_krw=market_cap_max_krw,
+            )
+        )
+
         def _first_value(quote: dict[str, Any], *keys: str) -> Any:
             for key in keys:
                 value = quote.get(key)
@@ -200,6 +248,18 @@ async def _screen_us(
                 ),
                 "market": "us",
             }
+            sector = _first_value(quote, "sector", "sectorDisp")
+            if sector:
+                mapped["sector"] = sector
+            mapped["instrument_type"] = classify_us_instrument(
+                mapped.get("code"),
+                mapped.get("name"),
+                _first_value(quote, "quoteType", "type"),
+                _first_value(quote, "typeDisp", "subtype"),
+            )
+            market_cap = _to_optional_float(mapped.get("market_cap"))
+            if market_cap is not None:
+                mapped["market_cap_krw"] = market_cap * usd_krw_rate
             # Drop rows without usable price; these often come from stale/partial screener rows.
             if mapped["close"] in (None, 0):
                 continue
@@ -213,12 +273,43 @@ async def _screen_us(
                 max_pbr=None,
                 min_dividend_yield=None,
                 max_rsi=max_rsi,
+                adv_krw_min=None,
+                market_cap_min_krw=market_cap_min_krw,
+                market_cap_max_krw=market_cap_max_krw,
+                instrument_types=instrument_types,
+                exclude_sector_keys=exclude_sector_keys,
+            )
+        else:
+            results = _apply_basic_filters(
+                results,
+                min_market_cap=None,
+                max_per=None,
+                max_pbr=None,
+                min_dividend_yield=None,
+                max_rsi=None,
+                adv_krw_min=None,
+                market_cap_min_krw=market_cap_min_krw,
+                market_cap_max_krw=market_cap_max_krw,
+                instrument_types=instrument_types,
+                exclude_sector_keys=exclude_sector_keys,
             )
 
         _complete_filters_applied()
         pre_limit_count = len(results)
         results = _sort_and_limit(results, sort_by, sort_order, limit)
-        return _build_screen_response(results, pre_limit_count, filters_applied, market)
+        warnings = []
+        if adv_krw_min is not None:
+            warnings.append(
+                "adv_krw_min requires 30-day average-volume data and is not "
+                "available on the US yfinance fallback path; filter was skipped."
+            )
+        return _build_screen_response(
+            results,
+            pre_limit_count,
+            filters_applied,
+            market,
+            warnings=warnings or None,
+        )
     except ImportError:
         return _error_payload(
             source="yfinance",
@@ -281,6 +372,11 @@ def _build_us_filters(
     )
     price_target_field = _get_tvscreener_attr(StockField, "PRICE_TARGET_1Y")
     price_target_delta_field = _get_tvscreener_attr(StockField, "PRICE_TARGET_1Y_DELTA")
+    average_volume_30_day_field = _get_tvscreener_attr(
+        StockField, "AVERAGE_VOLUME_30_DAY", "AVERAGE_VOLUME_30D", "AVERAGE_VOLUME_30"
+    )
+    type_field = _get_tvscreener_attr(StockField, "TYPE")
+    subtype_field = _get_tvscreener_attr(StockField, "SUBTYPE")
 
     # Validate that required fields are available
     if sort_by == "market_cap" and market_cap_field is None:
@@ -324,6 +420,9 @@ def _build_us_filters(
         price_target_average_field,
         price_target_field,
         price_target_delta_field,
+        average_volume_30_day_field,
+        type_field,
+        subtype_field,
     ):
         if optional_field is not None:
             columns.append(optional_field)
@@ -393,6 +492,7 @@ def _normalize_us_results(
     df: Any,
     *,
     market: str,
+    usd_krw_rate: float,
 ) -> list[dict[str, Any]]:
     """Map tvscreener DataFrame rows to normalized US stock dicts."""
     stocks: list[dict[str, Any]] = []
@@ -408,6 +508,14 @@ def _normalize_us_results(
             "rsi": _to_optional_float(row.get("relative_strength_index_14")),
             "adx": _to_optional_float(row.get("average_directional_index_14")),
             "volume": _to_optional_float(row.get("volume")),
+            "average_volume_30_day": _to_optional_float(
+                _get_first_present(
+                    row,
+                    "average_volume_30_day",
+                    "average_volume_30d",
+                    "average_volume_30",
+                )
+            ),
             "change_percent": _to_optional_float(row.get("change_percent")),
             "market_cap": _to_optional_float(
                 _get_first_present(row, "market_capitalization", "market_cap_basic")
@@ -458,6 +566,18 @@ def _normalize_us_results(
         sector = _clean_text(_get_first_present(row, "sector.tr", "sector"))
         if sector:
             stock["sector"] = sector
+        avg_volume = _to_optional_float(stock.get("average_volume_30_day"))
+        if avg_volume is not None:
+            stock["adv_krw"] = avg_volume * price * usd_krw_rate
+        market_cap = _to_optional_float(stock.get("market_cap"))
+        if market_cap is not None:
+            stock["market_cap_krw"] = market_cap * usd_krw_rate
+        stock["instrument_type"] = classify_us_instrument(
+            stock.get("symbol"),
+            stock.get("name"),
+            _get_first_present(row, "type"),
+            _get_first_present(row, "subtype"),
+        )
 
         stock.update(_aggregate_analyst_recommendations(row))
 
@@ -489,6 +609,12 @@ async def _screen_us_via_tvscreener(
     sort_by: str = "rsi",
     sort_order: str = "desc",
     limit: int = 50,
+    adv_krw_min: int | None = None,
+    market_cap_min_krw: int | None = None,
+    market_cap_max_krw: int | None = None,
+    instrument_types: list[str] | None = None,
+    exclude_sectors: list[str] | None = None,
+    exclude_sector_keys: set[str] | None = None,
 ) -> dict[str, Any]:
     """Screen US stocks using TradingView StockScreener API."""
     (
@@ -510,6 +636,11 @@ async def _screen_us_via_tvscreener(
         "sort_by": sort_by,
         "sort_order": sort_order,
         "limit": limit,
+        "adv_krw_min": adv_krw_min,
+        "market_cap_min_krw": market_cap_min_krw,
+        "market_cap_max_krw": market_cap_max_krw,
+        "instrument_types": instrument_types,
+        "exclude_sectors": exclude_sectors,
     }
     if min_dividend_yield_input is not None:
         filters_applied["min_dividend_yield_input"] = min_dividend_yield_input
@@ -554,7 +685,18 @@ async def _screen_us_via_tvscreener(
         logger.info("[Screen-US-TV] StockScreener returned %d US stocks", len(df))
 
         # Phase 3: Normalize results
-        stocks = _normalize_us_results(df, market=market)
+        usd_krw_rate = await _resolve_us_screening_usd_krw_rate(
+            prefer_live_rate=_has_krw_valuation_filter(
+                adv_krw_min=adv_krw_min,
+                market_cap_min_krw=market_cap_min_krw,
+                market_cap_max_krw=market_cap_max_krw,
+            )
+        )
+        stocks = _normalize_us_results(
+            df,
+            market=market,
+            usd_krw_rate=usd_krw_rate,
+        )
 
         stocks = _filter_by_min_analyst_buy(stocks, min_analyst_buy)
 
@@ -565,11 +707,18 @@ async def _screen_us_via_tvscreener(
             max_pbr=None,
             min_dividend_yield=min_dividend_yield_normalized,
             max_rsi=max_rsi,
+            adv_krw_min=adv_krw_min,
+            market_cap_min_krw=market_cap_min_krw,
+            market_cap_max_krw=market_cap_max_krw,
+            instrument_types=instrument_types,
+            exclude_sector_keys=exclude_sector_keys,
         )
         ordered = _sort_and_limit(filtered, sort_by, sort_order, limit)
 
         result["count"] = len(filtered)
         result["stocks"] = ordered
+        if adv_krw_min is not None:
+            result["meta_fields"] = {"adv_window_days": 30}
 
         logger.info(
             "[Screen-US-TV] Returning %d US stocks sorted by %s",
@@ -611,6 +760,12 @@ async def _screen_us_with_fallback(
     sort_by: str,
     sort_order: str,
     limit: int,
+    adv_krw_min: int | None = None,
+    market_cap_min_krw: int | None = None,
+    market_cap_max_krw: int | None = None,
+    instrument_types: list[str] | None = None,
+    exclude_sectors: list[str] | None = None,
+    exclude_sector_keys: set[str] | None = None,
 ) -> dict[str, Any]:
     """Screen US market with tvscreener fallback to legacy."""
     capability_snapshot = await _get_tvscreener_stock_capability_snapshot(
@@ -647,6 +802,12 @@ async def _screen_us_with_fallback(
                 sort_by=sort_by,
                 sort_order=sort_order,
                 limit=limit,
+                adv_krw_min=adv_krw_min,
+                market_cap_min_krw=market_cap_min_krw,
+                market_cap_max_krw=market_cap_max_krw,
+                instrument_types=instrument_types,
+                exclude_sectors=exclude_sectors,
+                exclude_sector_keys=exclude_sector_keys,
             )
             if tvscreener_result and not tvscreener_result.get("error"):
                 logger.info(
@@ -675,4 +836,10 @@ async def _screen_us_with_fallback(
         sort_by=sort_by,
         sort_order=sort_order,
         limit=limit,
+        adv_krw_min=adv_krw_min,
+        market_cap_min_krw=market_cap_min_krw,
+        market_cap_max_krw=market_cap_max_krw,
+        instrument_types=instrument_types,
+        exclude_sectors=exclude_sectors,
+        exclude_sector_keys=exclude_sector_keys,
     )

--- a/tests/test_mcp_screen_stocks_filters_and_rsi.py
+++ b/tests/test_mcp_screen_stocks_filters_and_rsi.py
@@ -6,6 +6,7 @@ import pytest
 import app.services.naver_finance as naver_finance
 from app.mcp_server.tooling.screening import crypto as screening_crypto
 from app.mcp_server.tooling.screening import kr as screening_kr
+from app.mcp_server.tooling.screening import us as screening_us
 from tests._mcp_tooling_support import build_tools
 
 pytest_plugins = ("tests._mcp_tooling_support",)
@@ -600,6 +601,78 @@ class TestScreenStocksPhase2Spec:
         assert result["results"][0]["market_cap"] == 4800000
 
     @pytest.mark.asyncio
+    async def test_kr_new_filters_pass_through_and_echo(self, monkeypatch):
+        async def mock_screen_kr_via_tvscreener(**kwargs):
+            assert kwargs["market"] == "kospi"
+            assert kwargs["adv_krw_min"] == 5_000_000_000
+            assert kwargs["market_cap_min_krw"] == 10_000_000_000
+            assert kwargs["market_cap_max_krw"] == 1_000_000_000_000
+            assert kwargs["instrument_types"] == ["common"]
+            assert kwargs["exclude_sectors"] == ["Finance"]
+            assert kwargs["exclude_sector_keys"] == {"finance"}
+            return {
+                "stocks": [
+                    {
+                        "symbol": "005930",
+                        "name": "Samsung Electronics Co., Ltd.",
+                        "price": 80000.0,
+                        "change_percent": 2.5,
+                        "volume": 1000.0,
+                        "market_cap": 4_800_000,
+                        "market_cap_krw": 480_000_000_000_000,
+                        "adv_krw": 8_000_000_000,
+                        "instrument_type": "common",
+                        "sector": "Technology",
+                        "rsi": 35.0,
+                        "adx": 20.0,
+                        "market": "KOSPI",
+                    }
+                ],
+                "count": 1,
+                "filters_applied": {
+                    "market": "kospi",
+                    "adv_krw_min": 5_000_000_000,
+                    "market_cap_min_krw": 10_000_000_000,
+                    "market_cap_max_krw": 1_000_000_000_000,
+                    "instrument_types": ["common"],
+                    "exclude_sectors": ["Finance"],
+                    "sort_by": "volume",
+                    "sort_order": "desc",
+                },
+                "meta_fields": {"adv_window_days": 30},
+                "source": "tvscreener",
+                "error": None,
+            }
+
+        monkeypatch.setattr(
+            "app.mcp_server.tooling.screening.kr._screen_kr_via_tvscreener",
+            mock_screen_kr_via_tvscreener,
+        )
+
+        tools = build_tools()
+        result = await tools["screen_stocks"](
+            market="kospi",
+            asset_type="stock",
+            adv_krw_min=5_000_000_000,
+            market_cap_min_krw=10_000_000_000,
+            market_cap_max_krw=1_000_000_000_000,
+            instrument_types=["common"],
+            exclude_sectors=["Finance"],
+            sort_by="volume",
+            sort_order="desc",
+            limit=20,
+        )
+
+        assert result["filters_applied"]["adv_krw_min"] == 5_000_000_000
+        assert result["filters_applied"]["market_cap_min_krw"] == 10_000_000_000
+        assert result["filters_applied"]["market_cap_max_krw"] == 1_000_000_000_000
+        assert result["filters_applied"]["instrument_types"] == ["common"]
+        assert result["filters_applied"]["exclude_sectors"] == ["Finance"]
+        assert result["meta"]["adv_window_days"] == 30
+        assert result["results"][0]["adv_krw"] == 8_000_000_000
+        assert result["results"][0]["instrument_type"] == "common"
+
+    @pytest.mark.asyncio
     async def test_us_early_return_filters_applied_complete(self, monkeypatch):
         def mock_screen_none(query, size, sortField, sortAsc, session=None):
             assert session is not None
@@ -629,6 +702,63 @@ class TestScreenStocksPhase2Spec:
         assert "max_rsi" in result["filters_applied"]
         assert "sort_by" in result["filters_applied"]
         assert "sort_order" in result["filters_applied"]
+
+    @pytest.mark.asyncio
+    async def test_us_yfinance_fallback_converts_market_cap_filter_to_krw(
+        self, monkeypatch
+    ):
+        def mock_screen(query, size, sortField, sortAsc, session=None):
+            assert session is not None
+            return {
+                "quotes": [
+                    {
+                        "symbol": "PASS",
+                        "shortName": "Pass Corp",
+                        "regularMarketPrice": 100.0,
+                        "regularMarketChangePercent": 1.0,
+                        "regularMarketVolume": 1_000_000,
+                        "marketCap": 10_000_000,
+                    },
+                    {
+                        "symbol": "FAIL",
+                        "shortName": "Fail Corp",
+                        "regularMarketPrice": 100.0,
+                        "regularMarketChangePercent": 1.0,
+                        "regularMarketVolume": 1_000_000,
+                        "marketCap": 1_000_000,
+                    },
+                ]
+            }
+
+        import yfinance as yf
+
+        monkeypatch.setattr(yf, "screen", mock_screen)
+        monkeypatch.setattr(
+            screening_us,
+            "get_usd_krw_rate",
+            AsyncMock(return_value=1_300.0),
+            raising=False,
+        )
+
+        result = await screening_us._screen_us(
+            market="us",
+            asset_type=None,
+            category=None,
+            min_market_cap=None,
+            max_per=None,
+            min_dividend_yield=None,
+            max_rsi=None,
+            sort_by="market_cap",
+            sort_order="desc",
+            limit=20,
+            adv_krw_min=5_000_000_000,
+            market_cap_min_krw=10_000_000_000,
+        )
+
+        assert result["returned_count"] == 1
+        assert result["results"][0]["code"] == "PASS"
+        assert result["results"][0]["market_cap_krw"] == 13_000_000_000
+        assert any("adv_krw_min" in warning for warning in result["warnings"])
 
     @pytest.mark.asyncio
     async def test_us_max_rsi_filter_applied(self, mock_yfinance_screen, monkeypatch):

--- a/tests/test_screening_filter_extensions.py
+++ b/tests/test_screening_filter_extensions.py
@@ -1,0 +1,158 @@
+import pytest
+
+from app.mcp_server.tooling.screening.common import (
+    _apply_basic_filters,
+    _kr_market_codes,
+    _validate_screen_filters,
+    normalize_screen_request,
+)
+
+
+def _request(**overrides):
+    params = {
+        "market": "kr",
+        "asset_type": None,
+        "category": None,
+        "sector": None,
+        "strategy": None,
+        "sort_by": "volume",
+        "sort_order": "desc",
+        "min_market_cap": None,
+        "max_per": None,
+        "max_pbr": None,
+        "min_dividend_yield": None,
+        "min_dividend": None,
+        "min_analyst_buy": None,
+        "max_rsi": None,
+        "limit": 10,
+        "exclude_sectors": None,
+        "instrument_types": None,
+        "adv_krw_min": None,
+        "market_cap_min_krw": None,
+        "market_cap_max_krw": None,
+    }
+    params.update(overrides)
+    return normalize_screen_request(**params)
+
+
+def test_kr_market_codes_include_konex_and_all():
+    assert _kr_market_codes("konex") == (["KNX"], "KNX")
+    assert _kr_market_codes("all") == (["STK", "KSQ", "KNX"], "ALL")
+
+
+def test_normalize_screen_request_new_filter_contract():
+    request = _request(
+        market="all",
+        exclude_sectors=[" 반도체 ", "반도체", "Finance"],
+        instrument_types=["common", "reit"],
+        adv_krw_min=1_000_000_000,
+        market_cap_min_krw=10_000_000_000,
+        market_cap_max_krw=50_000_000_000,
+    )
+
+    assert request["market"] == "all"
+    assert request["exclude_sectors"] == ["반도체", "Finance"]
+    assert request["exclude_sector_keys"] == {"반도체", "finance"}
+    assert request["instrument_types"] == ["common", "reit"]
+    assert request["adv_krw_min"] == 1_000_000_000
+    assert request["market_cap_min_krw"] == 10_000_000_000
+    assert request["market_cap_max_krw"] == 50_000_000_000
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"instrument_types": ["common", "warrant"]}, "instrument_types"),
+        ({"adv_krw_min": -1}, "adv_krw_min"),
+        ({"market_cap_min_krw": -1}, "market_cap_min_krw"),
+        ({"market_cap_max_krw": -1}, "market_cap_max_krw"),
+        (
+            {"sector": "Technology", "exclude_sectors": ["technology"]},
+            "sector and exclude_sectors",
+        ),
+        (
+            {"asset_type": "etf", "instrument_types": ["common"]},
+            "asset_type='etf'",
+        ),
+        (
+            {"market_cap_min_krw": 20, "market_cap_max_krw": 10},
+            "market_cap_min_krw",
+        ),
+    ],
+)
+def test_normalize_screen_request_rejects_invalid_new_filters(overrides, match):
+    with pytest.raises(ValueError, match=match):
+        _request(**overrides)
+
+
+def test_apply_basic_filters_supports_adv_instrument_sector_and_krw_market_cap():
+    candidates = [
+        {
+            "symbol": "005930",
+            "sector": "Technology",
+            "instrument_type": "common",
+            "adv_krw": 6_000_000_000,
+            "market_cap_krw": 500_000_000_000,
+        },
+        {
+            "symbol": "005935",
+            "sector": "Technology",
+            "instrument_type": "preferred",
+            "adv_krw": 6_000_000_000,
+            "market_cap_krw": 500_000_000_000,
+        },
+        {
+            "symbol": "357120",
+            "sector": "Real Estate",
+            "instrument_type": "reit",
+            "adv_krw": 7_000_000_000,
+            "market_cap_krw": 300_000_000_000,
+        },
+        {
+            "symbol": "000660",
+            "sector": "Semiconductors",
+            "instrument_type": "common",
+            "adv_krw": 500_000_000,
+            "market_cap_krw": 200_000_000_000,
+        },
+    ]
+
+    filtered = _apply_basic_filters(
+        candidates,
+        min_market_cap=None,
+        max_per=None,
+        max_pbr=None,
+        min_dividend_yield=None,
+        max_rsi=None,
+        adv_krw_min=1_000_000_000,
+        market_cap_min_krw=250_000_000_000,
+        market_cap_max_krw=600_000_000_000,
+        instrument_types=["common"],
+        exclude_sector_keys={"real estate"},
+    )
+
+    assert [item["symbol"] for item in filtered] == ["005930"]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"adv_krw_min": 1},
+        {"market_cap_min_krw": 1},
+        {"market_cap_max_krw": 1},
+        {"instrument_types": ["common"]},
+        {"exclude_sectors": ["Technology"]},
+    ],
+)
+def test_validate_screen_filters_rejects_new_filters_for_crypto(kwargs):
+    with pytest.raises(ValueError, match="crypto"):
+        _validate_screen_filters(
+            market="crypto",
+            asset_type=None,
+            min_market_cap=None,
+            max_per=None,
+            min_dividend_yield=None,
+            max_rsi=None,
+            sort_by="rsi",
+            **kwargs,
+        )

--- a/tests/test_screening_instrument_type.py
+++ b/tests/test_screening_instrument_type.py
@@ -1,0 +1,66 @@
+import pytest
+
+from app.mcp_server.tooling.screening.instrument_type import (
+    classify_kr_instrument,
+    classify_us_instrument,
+)
+
+
+@pytest.mark.parametrize(
+    ("symbol", "name", "subtype", "expected"),
+    [
+        ("005930", "삼성전자", None, "common"),
+        ("000660", "SK하이닉스", None, "common"),
+        ("950170", "JTC", None, "common"),
+        ("005935", "삼성전자우", None, "preferred"),
+        ("005387", "현대차2우B", None, "preferred"),
+        ("005389", "현대차3우B", None, "preferred"),
+        ("003545", "대신증권우", None, "preferred"),
+        ("001527", "동양2우B", None, "preferred"),
+        ("001529", "동양3우B", None, "preferred"),
+        ("000995", "DB하이텍1우", None, "preferred"),
+        ("000547", "흥국화재2우B", None, "preferred"),
+        ("000545", "흥국화재우", None, "preferred"),
+        ("33626K", "두산퓨얼셀1우", None, "preferred"),
+        ("33626L", "두산퓨얼셀2우B", None, "preferred"),
+        ("123450", "이지스밸류리츠", None, "reit"),
+        ("357120", "코람코라이프인프라리츠", None, "reit"),
+        ("330590", "롯데리츠", None, "reit"),
+        ("451800", "한화리츠", None, "reit"),
+        ("950210", "프레스티지바이오파마", None, "common"),
+        ("451060", "KODEX CD금리액티브", "ETF", "etf"),
+        ("069500", "KODEX 200", "exchange traded fund", "etf"),
+        ("114800", "KODEX 반도체", "ETF", "etf"),
+        ("458730", "TIGER 미국배당다우존스", "ETF", "etf"),
+        ("457480", "ACE 테슬라밸류체인액티브", "ETF", "etf"),
+        ("430220", "IBKS제17호스팩", None, "spac"),
+        ("469480", "하나32호스팩", None, "spac"),
+        ("477380", "미래에셋비전스팩7호", None, "spac"),
+        ("477760", "KB제30호스팩", None, "spac"),
+        ("475240", "유안타제16호스팩", None, "spac"),
+        ("999999", "", None, "unknown"),
+        ("", "", None, "unknown"),
+    ],
+)
+def test_classify_kr_instrument_cases(symbol, name, subtype, expected):
+    assert classify_kr_instrument(symbol, name, subtype) == expected
+
+
+@pytest.mark.parametrize(
+    ("symbol", "name", "type_", "subtype", "expected"),
+    [
+        ("AAPL", "Apple Inc.", "stock", "common stock", "common"),
+        ("BRK.B", "Berkshire Hathaway Inc.", "stock", "common stock", "common"),
+        ("SPY", "SPDR S&P 500 ETF Trust", "fund", "ETF", "etf"),
+        ("QQQ", "Invesco QQQ Trust", "fund", "exchange traded fund", "etf"),
+        ("O", "Realty Income Corporation", "stock", "reit", "reit"),
+        ("PLD", "Prologis, Inc.", "stock", "equity reit", "reit"),
+        ("DWAC", "Digital World Acquisition Corp.", "stock", "spac", "spac"),
+        ("XYZ.U", "Example Acquisition Corp Unit", "stock", "unit", "spac"),
+        ("BAC.PR.K", "Bank of America Preferred Series K", "stock", "", "preferred"),
+        ("WFC-PD", "Wells Fargo Preferred", "stock", "", "preferred"),
+        ("UNKNOWN", "", None, None, "unknown"),
+    ],
+)
+def test_classify_us_instrument_cases(symbol, name, type_, subtype, expected):
+    assert classify_us_instrument(symbol, name, type_, subtype) == expected

--- a/tests/test_tvscreener_stocks.py
+++ b/tests/test_tvscreener_stocks.py
@@ -12,6 +12,7 @@ from app.mcp_server.tooling.analysis_screen_core import (
     _screen_us_via_tvscreener,
     normalize_screen_request,
 )
+from app.mcp_server.tooling.screening import us as screening_us
 
 
 class _Condition:
@@ -56,6 +57,9 @@ def fake_tvscreener_module() -> SimpleNamespace:
             PRICE_TO_EARNINGS_RATIO_TTM=_Field("pe_ttm"),
             PRICE_TO_BOOK_FQ=_Field("pbr_fq"),
             DIVIDEND_YIELD_FORWARD=_Field("dividend_yield_forward"),
+            AVERAGE_VOLUME_30_DAY=_Field("average_volume_30_day"),
+            TYPE=_Field("type"),
+            SUBTYPE=_Field("subtype"),
             COUNTRY=_Field("country"),
         ),
     )
@@ -179,6 +183,57 @@ async def test_screen_us_uses_market_america_and_country_filter(
     assert kwargs["country"] == "United States"
     assert [stock["symbol"] for stock in result["stocks"]] == ["AAPL", "NVDA"]
     assert result["stocks"][0]["name"] == "Apple Inc."
+
+
+@pytest.mark.asyncio
+async def test_screen_us_converts_usd_adv_and_market_cap_to_krw_before_filtering(
+    fake_tvscreener_module: SimpleNamespace,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    service = AsyncMock()
+    service.query_stock_screener.return_value = pd.DataFrame(
+        {
+            "symbol": ["NASDAQ:PASS", "NASDAQ:FAIL"],
+            "description": ["Pass Corp", "Fail Corp"],
+            "name": ["PASS", "FAIL"],
+            "price": [100.0, 100.0],
+            "relative_strength_index_14": [35.0, 35.0],
+            "average_directional_index_14": [25.0, 25.0],
+            "volume": [1_000_000.0, 1_000_000.0],
+            "average_volume_30_day": [50_000.0, 1_000.0],
+            "change_percent": [1.0, 1.0],
+            "market_capitalization": [10_000_000.0, 10_000_000.0],
+            "country": ["United States", "United States"],
+        }
+    )
+    monkeypatch.setattr(
+        screening_us,
+        "get_usd_krw_rate",
+        AsyncMock(return_value=1_300.0),
+        raising=False,
+    )
+
+    with (
+        patch(
+            "app.mcp_server.tooling.screening.us._import_tvscreener",
+            return_value=fake_tvscreener_module,
+        ),
+        patch(
+            "app.mcp_server.tooling.screening.us.TvScreenerService",
+            return_value=service,
+        ),
+    ):
+        result = await _screen_us_via_tvscreener(
+            adv_krw_min=5_000_000_000,
+            market_cap_min_krw=10_000_000_000,
+            limit=5,
+        )
+
+    assert result["error"] is None
+    assert [stock["symbol"] for stock in result["stocks"]] == ["PASS"]
+    assert result["stocks"][0]["adv_krw"] == 6_500_000_000
+    assert result["stocks"][0]["market_cap_krw"] == 13_000_000_000
+    assert result["meta_fields"]["adv_window_days"] == 30
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 목적
[ROB-210](/ROB/issues/ROB-210) 배포: `main` → `production` 머지하여 `ghcr.io/mgh3326/auto_trader:production` 이미지 재빌드 유발.

## 포함 변경
- `a7e9643` [ROB-201] Expand screen_stocks filters (#548)
  - `screen_stocks` MCP 툴에 `market / ADV / instrument_types` 필터 확장
  - prod MCP schema에 `adv_krw_min` 파라미터 노출
  - [ROB-209](/ROB/issues/ROB-209) / [ROB-193](/ROB/issues/ROB-193) dry-run 회귀 가드 선결 조건

## 배경
- `production` head = `af23242` (직전 머지)에서 멈춰 PR #548 미반영
- Scout canonical 1-call이 prod schema에서 `adv_krw_min: Unexpected keyword argument`로 차단되는 증상 확인

## 배포 후 확인
- [ ] GHCR `auto_trader:production` 이미지 rebuild 완료
- [ ] `auto_trader_mcp_prod` 컨테이너 재기동 (새 digest)
- [ ] smoke: MCP `screen_stocks` schema에 `adv_krw_min` 파라미터 노출

Co-Authored-By: Paperclip <noreply@paperclip.ing>