### PR TITLE
fix(ci): propagate SSH exit code in deploy workflow (ROB-211)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,7 +120,9 @@ jobs:
 
       - name: Deploy via SSH
         timeout-minutes: 10
+        shell: bash
         run: |
+          set -eo pipefail
           ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
             ${{ secrets.DEPLOY_SSH_HOST }} \
             "cd /home/mgh3326/auto_trader && ./scripts/deploy.sh" 2>&1 | tee /tmp/deploy-output.txt


### PR DESCRIPTION
## Summary

- Deploy via SSH step was masking the remote exit code with `| tee`, so `./scripts/deploy.sh` failures (e.g. `.env.prod` missing → `exit 1`) silently passed the step and Discord reported "✅ 배포 완료" while the production container kept the stale image.
- Add `shell: bash` + `set -eo pipefail` so the pipeline exits with ssh's non-zero code; `if: failure()` Discord branch now fires on real deploy failures.
- No change to `scripts/deploy.sh` — it already uses `set -e` + explicit `exit 1`.

Resolves [ROB-211](/ROB/issues/ROB-211). Regression surfaced on [ROB-171](/ROB/issues/ROB-171) rollout: Deploy run [24558446773](https://github.com/mgh3326/auto_trader/actions/runs/24558446773) reported success while the remote container was unchanged for ~35h.

## Test plan

- [ ] Merge to `main`, then cut a `production` merge and let deploy run normally → expect success + "✅ 배포 완료" Discord notification.
- [ ] Regression probe (one-time): temporarily rename `.env.prod` on the deploy host, trigger a production deploy, confirm:
  - [ ] Workflow step `Deploy via SSH` reports **failure**
  - [ ] `Discord notification (failure)` fires with tail of `/tmp/deploy-output.txt` showing the `.env.prod not found` message
  - [ ] Restore `.env.prod` after verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment reliability by strengthening error detection during SSH deployment, ensuring deployment failures are caught and reported promptly rather than silently continuing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->