### PR TITLE
Add MCP caller identity middleware

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -309,6 +309,12 @@ class Settings(BaseSettings):
     # N8N Watch Alert webhook (replaces OpenClaw watch alert route)
     N8N_WATCH_ALERT_WEBHOOK_URL: str = ""
 
+    # MCP caller identity fallback for non-HTTP/manual runs
+    mcp_caller_agent_id_fallback: str | None = Field(
+        default=None,
+        validation_alias="MCP_CALLER_AGENT_ID",
+    )
+
     DAILY_SCAN_ENABLED: bool = False
     DAILY_SCAN_CRASH_THRESHOLD: float = 0.05
     DAILY_SCAN_CRASH_HOLDING_THRESHOLD: float = 0.04

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -859,6 +859,7 @@ Environment variables:
 - `MCP_PATH` : `/mcp`
 - `MCP_GRACEFUL_SHUTDOWN_TIMEOUT` : `10` (seconds, HTTP transports only: `sse` / `streamable-http`)
 - `MCP_USER_ID` : `1` (manual holdings 조회에 사용할 기본 사용자 ID)
+- `MCP_CALLER_AGENT_ID` : optional caller agent id fallback when no `x-paperclip-agent-id` HTTP header is present
 
 Example:
 ```bash

--- a/app/mcp_server/caller_identity.py
+++ b/app/mcp_server/caller_identity.py
@@ -1,0 +1,27 @@
+"""Request-scoped MCP caller identity helpers."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Literal
+
+CallerSource = Literal["http_header", "env_fallback", "none"]
+
+caller_agent_id_var: ContextVar[str | None] = ContextVar(
+    "mcp_caller_agent_id",
+    default=None,
+)
+caller_source_var: ContextVar[CallerSource] = ContextVar(
+    "mcp_caller_source",
+    default="none",
+)
+
+
+def get_caller_agent_id() -> str | None:
+    """Return the current MCP caller agent id, if one was provided."""
+    return caller_agent_id_var.get()
+
+
+def get_caller_source() -> CallerSource:
+    """Return the source used to resolve the current MCP caller identity."""
+    return caller_source_var.get()

--- a/app/mcp_server/caller_identity_middleware.py
+++ b/app/mcp_server/caller_identity_middleware.py
@@ -1,0 +1,68 @@
+"""FastMCP middleware for exposing caller identity via contextvars."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastmcp.server.dependencies import get_http_request
+from fastmcp.server.middleware import Middleware
+
+from app.core.config import settings
+from app.mcp_server.caller_identity import (
+    CallerSource,
+    caller_agent_id_var,
+    caller_source_var,
+)
+
+if TYPE_CHECKING:
+    import mcp.types as mt
+    from fastmcp.server.middleware import CallNext, MiddlewareContext
+    from fastmcp.tools.tool import ToolResult
+
+
+CALLER_AGENT_ID_HEADER = "x-paperclip-agent-id"
+
+
+def _clean_agent_id(value: str | None) -> str | None:
+    if value is None:
+        return None
+    value = value.strip()
+    return value or None
+
+
+def _caller_from_http_header() -> str | None:
+    try:
+        request = get_http_request()
+    except RuntimeError:
+        return None
+    return _clean_agent_id(request.headers.get(CALLER_AGENT_ID_HEADER))
+
+
+def _resolve_caller_identity() -> tuple[str | None, CallerSource]:
+    header_agent_id = _caller_from_http_header()
+    if header_agent_id is not None:
+        return header_agent_id, "http_header"
+
+    fallback_agent_id = _clean_agent_id(settings.mcp_caller_agent_id_fallback)
+    if fallback_agent_id is not None:
+        return fallback_agent_id, "env_fallback"
+
+    return None, "none"
+
+
+class CallerIdentityMiddleware(Middleware):
+    """Resolve MCP caller identity once per tool call."""
+
+    async def on_call_tool(
+        self,
+        context: MiddlewareContext[mt.CallToolRequestParams],
+        call_next: CallNext[mt.CallToolRequestParams, ToolResult],
+    ) -> ToolResult:
+        caller_agent_id, caller_source = _resolve_caller_identity()
+        agent_id_token = caller_agent_id_var.set(caller_agent_id)
+        source_token = caller_source_var.set(caller_source)
+        try:
+            return await call_next(context)
+        finally:
+            caller_source_var.reset(source_token)
+            caller_agent_id_var.reset(agent_id_token)

--- a/app/mcp_server/main.py
+++ b/app/mcp_server/main.py
@@ -28,6 +28,9 @@ init_sentry(
 from fastmcp import FastMCP  # noqa: E402
 
 from app.mcp_server.auth import build_auth_provider  # noqa: E402
+from app.mcp_server.caller_identity_middleware import (  # noqa: E402
+    CallerIdentityMiddleware,
+)
 from app.mcp_server.sentry_middleware import McpToolCallSentryMiddleware  # noqa: E402
 from app.mcp_server.tooling import register_all_tools  # noqa: E402
 
@@ -44,6 +47,7 @@ mcp = FastMCP(
 )
 
 mcp.add_middleware(McpToolCallSentryMiddleware())
+mcp.add_middleware(CallerIdentityMiddleware())
 register_all_tools(mcp)
 
 

--- a/env.example
+++ b/env.example
@@ -137,6 +137,8 @@ MCP_PORT=8765
 MCP_PATH=/mcp
 # MCP 보유종목 조회용 사용자 ID (기본: 1)
 MCP_USER_ID=1
+# MCP caller identity fallback for local/manual calls when no HTTP header is present
+MCP_CALLER_AGENT_ID=
 # MCP 서버 Bearer Token 인증 (비워두면 인증 비활성)
 # 라즈베리파이 배포 시 Tailscale 없이 HTTPS 보안을 위한 토큰 인증
 # 생성 방법: openssl rand -hex 32

--- a/tests/test_mcp_server_main.py
+++ b/tests/test_mcp_server_main.py
@@ -51,6 +51,13 @@ def _load_main_module(
         return_value="middleware"
     )
 
+    fake_caller_identity_middleware = ModuleType(
+        "app.mcp_server.caller_identity_middleware"
+    )
+    fake_caller_identity_middleware.__dict__["CallerIdentityMiddleware"] = MagicMock(
+        return_value="caller-identity-middleware"
+    )
+
     fake_tooling = ModuleType("app.mcp_server.tooling")
     register_all_tools = MagicMock()
     fake_tooling.__dict__["register_all_tools"] = register_all_tools
@@ -69,6 +76,11 @@ def _load_main_module(
     monkeypatch.setitem(
         sys.modules, "app.mcp_server.sentry_middleware", fake_sentry_middleware
     )
+    monkeypatch.setitem(
+        sys.modules,
+        "app.mcp_server.caller_identity_middleware",
+        fake_caller_identity_middleware,
+    )
     monkeypatch.setitem(sys.modules, "app.mcp_server.tooling", fake_tooling)
     monkeypatch.setitem(sys.modules, "app.monitoring.sentry", fake_monitoring)
     monkeypatch.delitem(sys.modules, "app.mcp_server.main", raising=False)
@@ -84,6 +96,16 @@ def _load_main_module(
 
 @pytest.mark.unit
 class TestMcpServerMain:
+    def test_registers_caller_identity_middleware_after_sentry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _, mcp, _ = _load_main_module(monkeypatch)
+
+        assert [call.args[0] for call in mcp.add_middleware.call_args_list] == [
+            "middleware",
+            "caller-identity-middleware",
+        ]
+
     def test_streamable_http_uses_default_shutdown_timeout(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

- Add request-scoped MCP caller identity contextvars and helpers.
- Add FastMCP tool-call middleware that resolves caller identity from `x-paperclip-agent-id`, then `MCP_CALLER_AGENT_ID`, then `None`.
- Register the middleware after Sentry middleware and document the fallback env var.
- Keep existing tool signatures unchanged for the follow-up ST-3.2 work.

## Manual verification

- Header path: patched `get_http_request()` with `x-paperclip-agent-id: agent-from-header`; `get_caller_agent_id()` returned `agent-from-header` and source `http_header` inside the tool call, then reset to `(None, none)` afterward.
- Env fallback path: no header plus fallback `agent-from-env`; helper returned `agent-from-env` and source `env_fallback`, then reset afterward.
- Empty path: no header and no fallback; helper returned `None` and source `none`, then reset afterward.
- Config alias check: `MCP_CALLER_AGENT_ID=alias-agent` loads into `settings.mcp_caller_agent_id_fallback`.

## Checks

- `uv run ruff check app/mcp_server/caller_identity.py app/mcp_server/caller_identity_middleware.py app/mcp_server/main.py app/core/config.py tests/test_mcp_server_main.py`
- `uv run python -m pytest tests/test_mcp_server_main.py -q`
- `uv run python - <<'PY' ... import app.mcp_server.main ... PY`