### PR TITLE
[ROB-216] Add MCP caller identity header injection template

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -884,7 +884,9 @@ export MCP_SESSION_ID="<MCP session id>"
 export PAPERCLIP_AGENT_ID="<calling agent's Paperclip agent id>"
 envsubst '$MCP_ENDPOINT $MCP_AUTH_TOKEN $MCP_SESSION_ID $PAPERCLIP_AGENT_ID' \
   < scripts/templates/mcp_call.sh.tmpl > /tmp/mcp_call.sh
-chmod +x /tmp/mcp_call.sh
+# 0700 — owner-only. The rendered script bakes MCP_AUTH_TOKEN in plaintext,
+# so group/other read bits must be stripped.
+chmod 700 /tmp/mcp_call.sh
 
 # Smoke test — should return a tool payload, not 401/403/reject:
 /tmp/mcp_call.sh get_quote '{"symbol":"005930","market":"kr"}'

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -851,6 +851,50 @@ Behavior:
 - `updated_at` is automatically set to the current timestamp
 - The (user_id, key) pair is unique; attempting to create a duplicate key for the same user will update the existing entry
 
+## Caller Identity Header (required)
+
+All MCP callers (Scout, Trader, CIO bridges, and any future client) MUST send
+`x-paperclip-agent-id: <calling agent's Paperclip agent id>` on every
+`tools/call` request. The value is the caller's Paperclip agent id, not the
+target trader agent id.
+
+- The `CallerIdentityMiddleware` added in ROB-214 (ST-3.1) reads this header,
+  stores it in a request-scoped contextvar, and records the extraction source
+  (`http_header` | `env_fallback` | `none`) on each call.
+- Caller-identity-gated tools (e.g. `place_order(..., defensive_trim=True)`
+  after ST-3.2) reject calls where the contextvar is `None`, so a missing
+  header in a production path is an outage, not a soft warning.
+- Local dev / stdio transports that cannot send HTTP headers may export
+  `MCP_CALLER_AGENT_ID` as an env fallback. This is a dev convenience only —
+  production callers must send the header explicitly.
+
+### Scout / Trader curl bridge
+
+When an agent runs under a harness that does not register the auto_trader MCP
+server in-process (current state for Scout and Trader on `claude_local`),
+they use a JSON-RPC curl bridge at `/tmp/mcp_call.sh`. The canonical template
+lives at `scripts/templates/mcp_call.sh.tmpl`; both agents MUST regenerate
+their local `/tmp/mcp_call.sh` from that template so the header is present.
+
+```bash
+# From the repo root, per operator host/session:
+export MCP_ENDPOINT="http://127.0.0.1:8765/mcp"
+export MCP_AUTH_TOKEN="<value from env.MCP_AUTH_TOKEN>"
+export MCP_SESSION_ID="<MCP session id>"
+export PAPERCLIP_AGENT_ID="<calling agent's Paperclip agent id>"
+envsubst '$MCP_ENDPOINT $MCP_AUTH_TOKEN $MCP_SESSION_ID $PAPERCLIP_AGENT_ID' \
+  < scripts/templates/mcp_call.sh.tmpl > /tmp/mcp_call.sh
+chmod +x /tmp/mcp_call.sh
+
+# Smoke test — should return a tool payload, not 401/403/reject:
+/tmp/mcp_call.sh get_quote '{"symbol":"005930","market":"kr"}'
+```
+
+If the Trader adapter is later migrated to an in-process MCP client (for
+example a Claude Code `.mcp.json` entry or an SDK-level `default_headers`
+config), that client must also set `x-paperclip-agent-id`; do not rely on
+the shell bridge as the long-term header injection point.
+
 ## Run (docker-compose.prod)
 Environment variables:
 - `MCP_TYPE` : `streamable-http` (default) | `sse` | `stdio`

--- a/scripts/templates/mcp_call.sh.tmpl
+++ b/scripts/templates/mcp_call.sh.tmpl
@@ -24,7 +24,9 @@
 #      like $1 / $2 or the $PAYLOAD / $TOOL_NAME / $ARGS runtime vars):
 #        envsubst '$MCP_ENDPOINT $MCP_AUTH_TOKEN $MCP_SESSION_ID $PAPERCLIP_AGENT_ID' \
 #          < scripts/templates/mcp_call.sh.tmpl > /tmp/mcp_call.sh
-#        chmod +x /tmp/mcp_call.sh
+#        chmod 700 /tmp/mcp_call.sh
+#      (0700 — owner-only; the rendered file contains MCP_AUTH_TOKEN in
+#       plaintext, so group/other read bits must be stripped.)
 #   3. Smoke test (should return a tool payload, not a 401/403):
 #        /tmp/mcp_call.sh get_quote '{"symbol":"005930","market":"kr"}'
 #
@@ -37,6 +39,10 @@
 
 set -euo pipefail
 
+# envsubst substitution anchors — these `${VAR}` references are replaced with
+# literal values when the template is rendered into `/tmp/mcp_call.sh` (see
+# the regeneration procedure above). They look like self-assignments here,
+# but at runtime the rendered file holds the baked-in values.
 MCP_ENDPOINT="${MCP_ENDPOINT}"
 MCP_AUTH_TOKEN="${MCP_AUTH_TOKEN}"
 MCP_SESSION_ID="${MCP_SESSION_ID}"
@@ -48,11 +54,16 @@ ARGS="$2"
 PAYLOAD=$(jq -n --arg tool "$TOOL_NAME" --argjson args "$ARGS" \
   '{jsonrpc:"2.0",id:100,method:"tools/call",params:{name:$tool,arguments:$args}}')
 
-curl -s -X POST "$MCP_ENDPOINT" \
+# `-f` makes curl exit non-zero on HTTP 4xx/5xx (so auth/header-gate failures
+# surface instead of falling through as an empty SSE stream); `-S` keeps the
+# stderr error message visible even with `-s`. Combined with `set -euo
+# pipefail` above, a failed request aborts the script rather than silently
+# emitting an empty payload.
+curl -fsS -X POST "$MCP_ENDPOINT" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
   -H "Authorization: Bearer $MCP_AUTH_TOKEN" \
   -H "Mcp-Session-Id: $MCP_SESSION_ID" \
   -H "x-paperclip-agent-id: $PAPERCLIP_AGENT_ID" \
-  -d "$PAYLOAD" 2>/dev/null \
+  -d "$PAYLOAD" \
   | grep "^data:" | head -1 | sed 's/^data: //'

--- a/scripts/templates/mcp_call.sh.tmpl
+++ b/scripts/templates/mcp_call.sh.tmpl
@@ -1,0 +1,58 @@
+#!/bin/bash
+# auto_trader MCP JSON-RPC bridge — canonical template.
+#
+# Purpose:
+#   Reference implementation of the `/tmp/mcp_call.sh` curl bridge that Scout
+#   (read-only) and Trader (read/write) use to call the auto_trader MCP HTTP
+#   server when no in-process MCP client is registered with the agent runtime.
+#
+# Why this template exists:
+#   ST-3 (ROB-212) switches MCP caller identity from tool-arg self-assertion
+#   to middleware-extracted HTTP header. Every caller MUST send the
+#   `x-paperclip-agent-id` header; otherwise defensive_trim and future
+#   caller-identity-gated tools reject the call.
+#
+# Operator regeneration procedure (CIO / Scout / Trader operators):
+#   1. Export the three env vars below (values differ per host / session):
+#        export MCP_ENDPOINT="http://127.0.0.1:8765/mcp"
+#        export MCP_AUTH_TOKEN="<bearer token from env.MCP_AUTH_TOKEN>"
+#        export PAPERCLIP_AGENT_ID="<calling agent's Paperclip agent id>"
+#      Optional:
+#        export MCP_SESSION_ID="<MCP session id from session/init handshake>"
+#   2. Regenerate `/tmp/mcp_call.sh` from this template (pass an explicit
+#      variable allow-list so envsubst does NOT expand shell positional args
+#      like $1 / $2 or the $PAYLOAD / $TOOL_NAME / $ARGS runtime vars):
+#        envsubst '$MCP_ENDPOINT $MCP_AUTH_TOKEN $MCP_SESSION_ID $PAPERCLIP_AGENT_ID' \
+#          < scripts/templates/mcp_call.sh.tmpl > /tmp/mcp_call.sh
+#        chmod +x /tmp/mcp_call.sh
+#   3. Smoke test (should return a tool payload, not a 401/403):
+#        /tmp/mcp_call.sh get_quote '{"symbol":"005930","market":"kr"}'
+#
+# Runtime behaviour:
+#   - Values of MCP_ENDPOINT / MCP_AUTH_TOKEN / MCP_SESSION_ID / PAPERCLIP_AGENT_ID
+#     are baked in by `envsubst` at regeneration time. Changing them later
+#     requires re-running step 2.
+#   - PAPERCLIP_AGENT_ID is emitted as the `x-paperclip-agent-id` request
+#     header; the MCP middleware reads it into a contextvar for gated tools.
+
+set -euo pipefail
+
+MCP_ENDPOINT="${MCP_ENDPOINT}"
+MCP_AUTH_TOKEN="${MCP_AUTH_TOKEN}"
+MCP_SESSION_ID="${MCP_SESSION_ID}"
+PAPERCLIP_AGENT_ID="${PAPERCLIP_AGENT_ID}"
+
+TOOL_NAME="$1"
+ARGS="$2"
+
+PAYLOAD=$(jq -n --arg tool "$TOOL_NAME" --argjson args "$ARGS" \
+  '{jsonrpc:"2.0",id:100,method:"tools/call",params:{name:$tool,arguments:$args}}')
+
+curl -s -X POST "$MCP_ENDPOINT" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -H "Authorization: Bearer $MCP_AUTH_TOKEN" \
+  -H "Mcp-Session-Id: $MCP_SESSION_ID" \
+  -H "x-paperclip-agent-id: $PAPERCLIP_AGENT_ID" \
+  -d "$PAYLOAD" 2>/dev/null \
+  | grep "^data:" | head -1 | sed 's/^data: //'


### PR DESCRIPTION
## Summary
- Add `scripts/templates/mcp_call.sh.tmpl` as the canonical reference bridge that Scout (read-only) and Trader (read/write) agents regenerate into `/tmp/mcp_call.sh`; the template injects `x-paperclip-agent-id` built from `${PAPERCLIP_AGENT_ID}` so the ROB-214 `CallerIdentityMiddleware` can extract the caller from a trusted HTTP header instead of a tool-arg self-assertion.
- Document the caller identity header contract in `app/mcp_server/README.md`, including the operator regeneration procedure (envsubst with an explicit variable allow-list so runtime shell vars `$PAYLOAD`/`$TOOL_NAME`/`$ARGS` survive) and a forward-looking note about migrating Trader to an in-process MCP client.

## Context
- Parent plan: [ROB-212 plan document](/ROB/issues/ROB-212#document-plan) — §ST-3.3.
- Ticket: [ROB-216](/ROB/issues/ROB-216).
- Blocker: [ROB-214](/ROB/issues/ROB-214) owns the middleware that reads this header; header name `x-paperclip-agent-id` is finalized in that ticket's description.
- Companion tickets: [ROB-215](/ROB/issues/ROB-215) (ST-3.2 gate switch), [ROB-217](/ROB/issues/ROB-217) (ST-3.4 tests).

## Trader MCP client path
Both Scout and Trader run under `claude_local` with empty `adapterConfig` and no `.mcp.json` MCP servers registered at the agent level, so both agents invoke the auto_trader MCP server through the same `/tmp/mcp_call.sh` curl bridge. The minimal header-injection surface is therefore the shared template, not a per-agent adapter config change; the README calls out that a future in-process MCP client must carry the same header.

## Manual validation
Rendered `/tmp/mcp_call.sh` from the template via `envsubst '$MCP_ENDPOINT $MCP_AUTH_TOKEN $MCP_SESSION_ID $PAPERCLIP_AGENT_ID' < scripts/templates/mcp_call.sh.tmpl` and confirmed the header is on the wire:

```
> POST /mcp HTTP/1.1
> Authorization: Bearer <redacted>
> Mcp-Session-Id: <redacted>
> x-paperclip-agent-id: 19cb1efc-5fbf-4e97-ab41-223c23bb57d2
< HTTP/1.1 200 OK
```

Tool result for `get_quote {"symbol":"005930","market":"kr"}` returned a valid KRX equity quote (`price: 216000.0`, `source: "kis"`).

ROB-214's middleware is still pre-merge, so this PR only proves caller-side injection is correct; end-to-end contextvar extraction verification lives with ROB-214's validation.

## Test plan
- [x] `envsubst` template renders cleanly with positional-arg preservation
- [x] Rendered bridge successfully calls live MCP server (`get_quote` 200 OK)
- [x] `x-paperclip-agent-id` header visible in `curl -v` output
- [ ] Code Reviewer pre-review pass
- [ ] Staff Engineer handoff
- [ ] CTO human review

Co-Authored-By: Paperclip <noreply@paperclip.ing>