### PR TITLE
feat(n8n): accept amount=0 as "자금 지원 안 함" board response (ROB-219)

### DIFF
--- a/app/routers/n8n.py
+++ b/app/routers/n8n.py
@@ -119,6 +119,13 @@ def _evaluate_g1_gate(g1_gate: dict | None) -> GateResult:
 
 
 def _evaluate_g2_gate(payload: CIOFollowupRequest) -> N8nG2GatePayload:
+    if payload.board_response is not None and payload.board_response.amount == 0:
+        return N8nG2GatePayload(
+            passed=True,
+            status="pass",
+            detail="보드 응답: 자금 지원 없음 (0 KRW)",
+        )
+
     intent = payload.board_response.funding_intent if payload.board_response else None
     intent = intent or payload.funding_intent
     if intent is None:
@@ -147,6 +154,7 @@ def _followup_context_from_tc(payload: TCFollowupRequest) -> BoardBriefContext:
         manual_cash_krw=payload.manual_cash_krw,
         daily_burn_krw=payload.daily_burn_krw,
         manual_cash_runway_days=payload.manual_cash_runway_days,
+        board_response=payload.board_response,
         weights_top_n=payload.weights_top_n,
         holdings=payload.holdings,
         dust_items=payload.dust_items,

--- a/app/schemas/n8n/board_brief.py
+++ b/app/schemas/n8n/board_brief.py
@@ -53,11 +53,15 @@ class DustItem(BaseModel):
 
 
 class BoardFundingResponse(BaseModel):
-    """Board funding response captured between TC preliminary and CIO pending."""
+    """Board funding response captured between TC preliminary and CIO pending.
 
-    amount: float = Field(..., gt=0, le=100_000_000_000)
+    `amount == 0` is a valid "자금 지원 안 함" signal from the board; in that
+    case `funding_intent` may be omitted since no funding path is selected.
+    """
+
+    amount: float = Field(..., ge=0, le=100_000_000_000)
     target: str | None = Field(None, max_length=80)
-    funding_intent: FundingIntent
+    funding_intent: FundingIntent | None = None
     manual_cash_verified: bool = False
 
 
@@ -93,6 +97,7 @@ class TCFollowupRequest(BaseModel):
     manual_cash_krw: float = Field(0, ge=0)
     daily_burn_krw: float = Field(0, ge=0)
     manual_cash_runway_days: float | None = Field(None, ge=0)
+    board_response: BoardFundingResponse | None = None
     weights_top_n: list[WeightItem] = Field(default_factory=list)
     holdings: list[HoldingSnapshot] = Field(default_factory=list)
     dust_items: list[DustItem] = Field(default_factory=list)
@@ -103,7 +108,6 @@ class CIOFollowupRequest(TCFollowupRequest):
     """Request payload for /api/n8n/cio-followup."""
 
     funding_intent: FundingIntent | None = None
-    board_response: BoardFundingResponse | None = None
     g1_gate: dict[str, Any] | None = None
 
 

--- a/app/services/n8n_daily_brief_service.py
+++ b/app/services/n8n_daily_brief_service.py
@@ -531,6 +531,34 @@ def _build_dust_lines(ctx: BoardBriefContext) -> list[str]:
     ]
 
 
+def _build_board_response_lines(ctx: BoardBriefContext) -> list[str]:
+    """Render the board funding response section when one is available.
+
+    `amount == 0` means the board explicitly responded with "자금 지원 안 함";
+    funding_intent in that case is optional since no funding path is selected.
+    """
+    response = ctx.board_response
+    if response is None:
+        return []
+    if response.amount == 0:
+        detail_parts = ["자금 지원 안 함 (0 KRW)"]
+        if response.funding_intent:
+            detail_parts.append(f"intent: {response.funding_intent}")
+        if response.manual_cash_verified:
+            detail_parts.append("manual_cash_verified")
+        return [
+            "🗳️ 보드 응답",
+            f"- {' · '.join(detail_parts)} — 경로 A 지속, 신규 매수 차단",
+        ]
+    target = response.target or "-"
+    intent = response.funding_intent or "-"
+    verified = " · manual_cash_verified" if response.manual_cash_verified else ""
+    return [
+        "🗳️ 보드 응답",
+        f"- {_fmt_krw(response.amount)} → {target} (intent: {intent}){verified}",
+    ]
+
+
 def _build_tc_preliminary_text(ctx: BoardBriefContext) -> str:
     """Build TC preliminary text without recommendation or gate sections."""
     runway_days = _cash_runway_days(ctx)
@@ -553,6 +581,9 @@ def _build_tc_preliminary_text(ctx: BoardBriefContext) -> str:
     dust_lines = _build_dust_lines(ctx)
     if dust_lines:
         lines.extend(["", *dust_lines])
+    board_lines = _build_board_response_lines(ctx)
+    if board_lines:
+        lines.extend(["", *board_lines])
     lines.extend(
         [
             "",
@@ -580,15 +611,18 @@ def _build_cio_pending_text(ctx: BoardBriefContext) -> str:
     gates = _build_gate_results(ctx)
     g2 = gates["G2"]
     g2_failed = isinstance(g2, N8nG2GatePayload) and not g2.passed
+    no_funding = ctx.board_response is not None and ctx.board_response.amount == 0
+    if no_funding:
+        recommendation = "🚫 신규 매수 차단 — 보드 응답: 자금 지원 없음 (0 KRW)"
+    elif g2_failed:
+        recommendation = "🚫 신규 매수 차단 — G2 fail"
+    else:
+        recommendation = "CIO 의견 대기 중 — gate 결과 확인 후 action 확정"
     lines = [
         _build_tc_preliminary_text(ctx),
         "",
         "🎯 권고",
-        (
-            "🚫 신규 매수 차단 — G2 fail"
-            if g2_failed
-            else "CIO 의견 대기 중 — gate 결과 확인 후 action 확정"
-        ),
+        recommendation,
         "",
         "📊 Gate 판정 결과",
     ]

--- a/tests/test_n8n_followup_endpoints.py
+++ b/tests/test_n8n_followup_endpoints.py
@@ -138,3 +138,60 @@ class TestN8nFollowupEndpoints:
 
         assert resp.status_code == 422
         assert field in resp.text
+
+    def test_cio_followup_accepts_zero_amount_as_no_funding(self) -> None:
+        """Board amount=0 with no funding_intent is a valid "자금 지원 안 함" response."""
+        client = self._get_client()
+
+        resp = client.post(
+            "/api/n8n/cio-followup",
+            json={
+                "manual_cash_krw": 700_000,
+                "daily_burn_krw": 100_000,
+                "manual_cash_runway_days": 7,
+                "board_response": {
+                    "amount": 0,
+                    "manual_cash_verified": True,
+                },
+                "weights_top_n": [{"symbol": "BTC", "weight_pct": 42.5}],
+                "holdings": [
+                    {"symbol": "BTC", "current_krw_value": 1_000_000, "dust": False}
+                ],
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["phase"] == "cio_pending"
+        assert body["gate_results"]["G2"]["passed"] is True
+        assert "자금 지원 없음" in body["gate_results"]["G2"]["detail"]
+        assert "🗳️ 보드 응답" in body["text"]
+        assert "자금 지원 안 함 (0 KRW)" in body["text"]
+        assert "보드 응답: 자금 지원 없음" in body["text"]
+
+    def test_tc_followup_renders_board_response_when_provided(self) -> None:
+        """TC preliminary should render the 0 KRW no-funding framing when
+        the board response carries over into the TC recomputation."""
+        client = self._get_client()
+
+        resp = client.post(
+            "/api/n8n/tc-followup",
+            json={
+                "manual_cash_krw": 700_000,
+                "daily_burn_krw": 100_000,
+                "board_response": {
+                    "amount": 0,
+                    "manual_cash_verified": True,
+                },
+                "weights_top_n": [{"symbol": "BTC", "weight_pct": 42.5}],
+                "holdings": [
+                    {"symbol": "BTC", "current_krw_value": 1_000_000, "dust": False}
+                ],
+            },
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["phase"] == "tc_preliminary"
+        assert "🗳️ 보드 응답" in body["text"]
+        assert "자금 지원 안 함 (0 KRW)" in body["text"]


### PR DESCRIPTION
## Summary
- Relax `BoardFundingResponse.amount` from `gt=0` → `ge=0`; make `funding_intent` optional so the board can explicitly respond "자금 지원 안 함" (0 KRW)
- Move `board_response` up to `TCFollowupRequest` so TC preliminary and CIO pending share the same input shape
- Add 🗳️ 보드 응답 rendering branch; 0 KRW shows explicit "자금 지원 안 함" framing
- G2 gate short-circuits to `pass` with "자금 지원 없음" detail when amount=0; CIO 권고 switches to "🚫 신규 매수 차단 — 보드 응답: 자금 지원 없음"
- `amount < 0` still returns 422; existing preliminary/cio_pending and daily brief regression tests stay green

## Context
Follow-up to [ROB-149](/ROB/issues/ROB-149) / [#551](https://github.com/mgh3326/auto_trader/pull/551). Boss feedback: 0 KRW should be a first-class board response meaning "자금 지원 안 함" rather than a 422.

## Test plan
- [x] `uv run pytest tests/test_n8n_followup_endpoints.py tests/test_n8n_daily_brief_formatting.py -v` (22 passed)
- [x] `uv run ruff check` on touched files (clean)
- [x] n8n tc-briefing discord regression suite passes (`-k "followup or board_brief or tc_briefing"` → 19 passed)

## Linked
- [ROB-219](/ROB/issues/ROB-219)
- Parent: [ROB-149](/ROB/issues/ROB-149)

🤖 Generated with [Claude Code](https://claude.com/claude-code)