### PR TITLE
[ROB-224] Extract CIO briefing gate phrase constants

### DIFF
--- a/app/services/cio_coin_briefing/__init__.py
+++ b/app/services/cio_coin_briefing/__init__.py
@@ -1,0 +1,1 @@
+"""CIO coin briefing services."""

--- a/app/services/cio_coin_briefing/prompts/__init__.py
+++ b/app/services/cio_coin_briefing/prompts/__init__.py
@@ -1,0 +1,1 @@
+"""Prompt constants for CIO coin briefing renderers."""

--- a/app/services/cio_coin_briefing/prompts/gate_phrases.py
+++ b/app/services/cio_coin_briefing/prompts/gate_phrases.py
@@ -1,0 +1,52 @@
+"""Gate phrase constants extracted from board_briefing_v2.md."""
+
+from __future__ import annotations
+
+import re
+
+G2_LINE_RUNWAY = "- G2 입금 목적: **운영 runway 복구** (신규 risk budget 아님)"
+G2_LINE_NEW_BUDGET = "- G2 입금 목적: **신규 risk budget** (운영 runway 는 이미 충족)"
+
+G2_RECOMMENDATION_FIXED = "CIO 권고: **(3) 현금 비중 유지**"
+
+G2_RUNWAY_FUEL_LINES = [
+    "- 이번 {amount} 원은 **운영 연료** 로 귀속 — coinmoogi DCA {days} 일 지속분 + 만기 cushion.",
+    "- 신규 매수 여력으로 전용 금지. G2 에서 차단.",
+]
+
+G2_NEW_BUDGET_LINES = [
+    "- 이번 {amount} 원은 G3 (runway/obligation) 통과 후 신규 risk budget 후보.",
+    "- 이 경우에도 G4 시장 regime → G5 volatility halt → G6 보조지표 통과 여부 추가 판정 필요.",
+]
+
+HARD_GATE_REMINDER = (
+    "- {symbol} 부분매도는 별도 Hard Gate critique 으로 계속 진행 "
+    "(경로 B 는 concentration 문제를 여전히 해결해야 함)."
+)
+
+FRAMING_AB_PATH_NON_EXCLUSIVE = (
+    "경로 A (입금) 와 경로 B (현물 부분매도) 는 **상호배타 아님**. 병행 가능합니다."
+)
+
+PATH_SECTION_AB_REPEAT = "**A 와 B 는 상호배타 아님 — 병행 가능.**"
+
+BOARD_QUESTIONS_TEMPLATE = """### 보드에게 질문 (응답 요청, 분리)
+1) **[funding]** manual_cash 중 오늘 실제 입금 가능액이 있습니까? 있다면 얼마, 언제까지?
+2) **[action]** {hard_gate_symbol} 현물 {quantity_range} 부분매도를 Hard Gate critique 에 올려 실행하시겠습니까?"""
+
+FORBIDDEN_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(pattern)
+    for pattern in [
+        r"\[funding\].*\[action\]",
+        r"가용\s*현금[^(]*\d",
+        r"Planning\s*cash",
+        r"\b유휴\s*자금\b",
+        r"\b예비\s*자금\b",
+        r"\b대기\s*자금\b",
+        r"\b대기\s*cash\b",
+        r"\b입금\s*여력\b",
+        r"\b천만\s*원\s*(현금|cash|가용)",
+        r"A\s*(또는|혹은|or)\s*B\s*(중|에서)\s*택1?",
+        r"입금\s*(또는|혹은)\s*매도\s*(중|에서)\s*택1?",
+    ]
+]

--- a/app/services/cio_coin_briefing/prompts/render_invariants.py
+++ b/app/services/cio_coin_briefing/prompts/render_invariants.py
@@ -1,0 +1,56 @@
+"""Render invariant declarations for CIO coin briefing markdown."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Invariant:
+    name: str
+    description: str
+    check: Callable[[str], bool]
+
+
+def _parser_not_implemented(_: str) -> bool:
+    raise NotImplementedError("Render invariant parser lands in ROB-221 E-4.")
+
+
+RENDER_INVARIANTS: list[Invariant] = [
+    Invariant(
+        name="funding_rows_split",
+        description="exchange_krw 행과 unverified_cap 행이 §3 자금 현황 안에서 각 1회씩 등장",
+        check=_parser_not_implemented,
+    ),
+    Invariant(
+        name="runway_excludes_unverified_cap",
+        description="runway 산식 (현재 runway / TC preliminary 의 runway) 에 unverified_cap.amount 가 포함되지 않음",
+        check=_parser_not_implemented,
+    ),
+    Invariant(
+        name="framing_ab_anchor",
+        description="FRAMING_AB_PATH_NON_EXCLUSIVE anchor 가 Framing 에 존재",
+        check=_parser_not_implemented,
+    ),
+    Invariant(
+        name="path_section_ab_anchor",
+        description="PATH_SECTION_AB_REPEAT anchor 가 §7 말미에 존재",
+        check=_parser_not_implemented,
+    ),
+    Invariant(
+        name="board_questions_split",
+        description="§10 보드 질문이 [funding] (또는 [funding-confirmation]) 1 행 + [action] 1 행, 총 2 행 분리",
+        check=_parser_not_implemented,
+    ),
+    Invariant(
+        name="g2_phrase_mutual_exclusivity",
+        description="G2_RUNWAY_FUEL_LINES 와 G2_NEW_BUDGET_LINES 중 정확히 하나만 삽입 (둘 다 불가, 둘 다 없음 불가)",
+        check=_parser_not_implemented,
+    ),
+    Invariant(
+        name="immediate_buy_requires_g2_to_g5_pass",
+        description="CIO 권고가 '(1) 즉시 매수' 이면 G2~G5 모두 pass — 하나라도 fail/대기/차단이면 assertion fail",
+        check=_parser_not_implemented,
+    ),
+]

--- a/app/services/cio_coin_briefing/prompts/render_invariants.py
+++ b/app/services/cio_coin_briefing/prompts/render_invariants.py
@@ -53,4 +53,14 @@ RENDER_INVARIANTS: list[Invariant] = [
         description="CIO 권고가 '(1) 즉시 매수' 이면 G2~G5 모두 pass — 하나라도 fail/대기/차단이면 assertion fail",
         check=_parser_not_implemented,
     ),
+    Invariant(
+        name="dust_aggregate_line",
+        description="§4 통합 포트폴리오 쏠림 말미에 'Dust aggregate: N symbols / total KRW / portfolio pct' 한 줄 존재",
+        check=_parser_not_implemented,
+    ),
+    Invariant(
+        name="fail_closed_anchor_routing",
+        description="Missing-field fail-closed anchor (⚠️ ... 누락 ...) 가 등장하면 보드 채널 전송 금지, 운영팀 에스컬레이션 라우팅",
+        check=_parser_not_implemented,
+    ),
 ]

--- a/tests/test_cio_briefing_gate_phrases.py
+++ b/tests/test_cio_briefing_gate_phrases.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from app.services.cio_coin_briefing.prompts import gate_phrases, render_invariants
+
+EXPECTED_STRINGS = [
+    "G2_LINE_RUNWAY",
+    "G2_LINE_NEW_BUDGET",
+    "G2_RECOMMENDATION_FIXED",
+    "HARD_GATE_REMINDER",
+    "FRAMING_AB_PATH_NON_EXCLUSIVE",
+    "PATH_SECTION_AB_REPEAT",
+    "BOARD_QUESTIONS_TEMPLATE",
+]
+
+EXPECTED_LINE_LISTS = [
+    "G2_RUNWAY_FUEL_LINES",
+    "G2_NEW_BUDGET_LINES",
+]
+
+
+@pytest.mark.unit
+def test_gate_phrase_string_constants_exist_and_are_non_empty():
+    for name in EXPECTED_STRINGS:
+        value = getattr(gate_phrases, name)
+        assert isinstance(value, str), name
+        assert value.strip(), name
+
+
+@pytest.mark.unit
+def test_gate_phrase_line_lists_exist_and_are_non_empty():
+    for name in EXPECTED_LINE_LISTS:
+        value = getattr(gate_phrases, name)
+        assert isinstance(value, list), name
+        assert value, name
+        assert all(isinstance(line, str) and line.strip() for line in value), name
+
+
+@pytest.mark.unit
+def test_gate_phrase_placeholders_survive_copy():
+    assert "{hard_gate_symbol}" in gate_phrases.BOARD_QUESTIONS_TEMPLATE
+    assert "{quantity_range}" in gate_phrases.BOARD_QUESTIONS_TEMPLATE
+    assert "{amount}" in "\n".join(gate_phrases.G2_RUNWAY_FUEL_LINES)
+    assert "{days}" in "\n".join(gate_phrases.G2_RUNWAY_FUEL_LINES)
+    assert "{amount}" in "\n".join(gate_phrases.G2_NEW_BUDGET_LINES)
+
+
+@pytest.mark.unit
+def test_forbidden_patterns_are_compiled_regexes():
+    assert isinstance(gate_phrases.FORBIDDEN_PATTERNS, list)
+    assert len(gate_phrases.FORBIDDEN_PATTERNS) == 11
+    assert all(
+        isinstance(pattern, re.Pattern) for pattern in gate_phrases.FORBIDDEN_PATTERNS
+    )
+
+
+@pytest.mark.unit
+def test_render_invariants_exist_with_callable_stubs():
+    invariants = render_invariants.RENDER_INVARIANTS
+    assert isinstance(invariants, list)
+    assert len(invariants) == 7
+
+    for invariant in invariants:
+        assert isinstance(invariant, render_invariants.Invariant)
+        assert invariant.name.strip()
+        assert invariant.description.strip()
+        assert callable(invariant.check)
+        with pytest.raises(NotImplementedError):
+            invariant.check("rendered briefing markdown")

--- a/tests/test_cio_briefing_gate_phrases.py
+++ b/tests/test_cio_briefing_gate_phrases.py
@@ -61,7 +61,17 @@ def test_forbidden_patterns_are_compiled_regexes():
 def test_render_invariants_exist_with_callable_stubs():
     invariants = render_invariants.RENDER_INVARIANTS
     assert isinstance(invariants, list)
-    assert len(invariants) == 7
+    assert len(invariants) == 9
+
+    invariant_by_name = {invariant.name: invariant for invariant in invariants}
+    assert (
+        invariant_by_name["dust_aggregate_line"].description
+        == "§4 통합 포트폴리오 쏠림 말미에 'Dust aggregate: N symbols / total KRW / portfolio pct' 한 줄 존재"
+    )
+    assert (
+        invariant_by_name["fail_closed_anchor_routing"].description
+        == "Missing-field fail-closed anchor (⚠️ ... 누락 ...) 가 등장하면 보드 채널 전송 금지, 운영팀 에스컬레이션 라우팅"
+    )
 
     for invariant in invariants:
         assert isinstance(invariant, render_invariants.Invariant)


### PR DESCRIPTION
## Summary
- Add `app.services.cio_coin_briefing.prompts.gate_phrases` with the G2 phrase constants, A/B framing anchors, board-question template, and 11 compiled forbidden regex patterns copied from `board_briefing_v2.md`.
- Add `render_invariants.py` with nine `Invariant` declarations and parser stubs that raise `NotImplementedError` until the render parser lands in the later task.
- Add focused unit coverage for constant presence, types, non-empty values, placeholder preservation, regex compilation, and invariant stub behavior.

## Validation
- `uv run pytest tests/test_cio_briefing_gate_phrases.py -v`
- `make lint`

## Review Follow-up
- ROB-225 requested reconciling `RENDER_INVARIANTS` with the full source prompt. This PR now mirrors all 9 prompt invariant strings, including dust aggregate and fail-closed anchor routing.
