### PR TITLE
ROB-227 BoardBriefContext schema v2 fields

### DIFF
--- a/app/routers/n8n.py
+++ b/app/routers/n8n.py
@@ -144,6 +144,13 @@ def _evaluate_g2_gate(payload: CIOFollowupRequest) -> N8nG2GatePayload:
 
 def _followup_context_from_tc(payload: TCFollowupRequest) -> BoardBriefContext:
     return BoardBriefContext(
+        exchange_krw=payload.exchange_krw,
+        unverified_cap=payload.unverified_cap,
+        next_obligation=payload.next_obligation,
+        tier_scenarios=payload.tier_scenarios,
+        hard_gate_candidates=payload.hard_gate_candidates,
+        data_sufficient_by_symbol=payload.data_sufficient_by_symbol,
+        btc_regime=payload.btc_regime,
         manual_cash_krw=payload.manual_cash_krw,
         daily_burn_krw=payload.daily_burn_krw,
         manual_cash_runway_days=payload.manual_cash_runway_days,
@@ -156,6 +163,13 @@ def _followup_context_from_tc(payload: TCFollowupRequest) -> BoardBriefContext:
 
 def _followup_context_from_cio(payload: CIOFollowupRequest) -> BoardBriefContext:
     return BoardBriefContext(
+        exchange_krw=payload.exchange_krw,
+        unverified_cap=payload.unverified_cap,
+        next_obligation=payload.next_obligation,
+        tier_scenarios=payload.tier_scenarios,
+        hard_gate_candidates=payload.hard_gate_candidates,
+        data_sufficient_by_symbol=payload.data_sufficient_by_symbol,
+        btc_regime=payload.btc_regime,
         manual_cash_krw=payload.manual_cash_krw,
         daily_burn_krw=payload.daily_burn_krw,
         manual_cash_runway_days=payload.manual_cash_runway_days,

--- a/app/schemas/n8n/board_brief.py
+++ b/app/schemas/n8n/board_brief.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
@@ -10,6 +10,9 @@ from pydantic import BaseModel, Field
 FundingIntent = Literal["runway_recovery", "new_buy", "partial", "other"]
 BoardBriefPhase = Literal["tc_preliminary", "cio_pending"]
 GateStatus = Literal["pass", "fail", "pending", "tbd"]
+BtcCloseVs20dMa = Literal["above", "below"]
+BtcMa20Slope = Literal["up", "flat", "down"]
+TierLabel = Literal["T1", "T2", "T3"]
 
 
 class GateResult(BaseModel):
@@ -61,7 +64,62 @@ class BoardFundingResponse(BaseModel):
     manual_cash_verified: bool = False
 
 
-class BoardBriefContext(BaseModel):
+class UnverifiedCapPayload(BaseModel):
+    """Manual funding cap that is not counted as verified exchange cash."""
+
+    amount: float = Field(0, ge=0)
+    confirmed_at: datetime | None = None
+    verified_by_boss_today: bool = False
+    stale_warning: bool = False
+
+
+class NextObligationPayload(BaseModel):
+    """Next cash obligation used for runway and funding-path decisions."""
+
+    date: date
+    days_remaining: int = Field(..., ge=0)
+    cash_needed_until: float = Field(..., ge=0)
+
+
+class TierScenario(BaseModel):
+    """Funding tier scenario for board-facing path A comparison."""
+
+    label: TierLabel
+    target_exchange_krw: float = Field(..., ge=0)
+    deposit_amount: float = Field(..., ge=0)
+    buffer_days: int = Field(..., ge=0)
+    cushion_after_obligation: float
+
+
+class HardGateCandidate(BaseModel):
+    """Candidate action that still requires a separate hard-gate critique."""
+
+    symbol: str = Field(..., min_length=1)
+    proposal: str = Field(..., min_length=1)
+    amount_range: str = Field(..., min_length=1)
+
+
+class BtcRegimePayload(BaseModel):
+    """BTC regime metrics used by G4."""
+
+    close_vs_20d_ma: BtcCloseVs20dMa
+    ma20_slope: BtcMa20Slope
+    drawdown_14d_pct: float
+
+
+class BoardBriefV2Fields(BaseModel):
+    """Prompt v2 fields shared by context and n8n follow-up request bodies."""
+
+    exchange_krw: float = Field(0, ge=0)
+    unverified_cap: UnverifiedCapPayload | None = None
+    next_obligation: NextObligationPayload | None = None
+    tier_scenarios: list[TierScenario] = Field(default_factory=list)
+    hard_gate_candidates: list[HardGateCandidate] = Field(default_factory=list)
+    data_sufficient_by_symbol: dict[str, bool] = Field(default_factory=dict)
+    btc_regime: BtcRegimePayload | None = None
+
+
+class BoardBriefContext(BoardBriefV2Fields):
     """Internal render context shared by TC preliminary and CIO pending builders."""
 
     manual_cash_krw: float = Field(0, ge=0)
@@ -87,7 +145,7 @@ class BoardBriefRender(BaseModel):
     generated_at: datetime
 
 
-class TCFollowupRequest(BaseModel):
+class TCFollowupRequest(BoardBriefV2Fields):
     """Request payload for /api/n8n/tc-followup."""
 
     manual_cash_krw: float = Field(0, ge=0)
@@ -112,11 +170,16 @@ __all__ = [
     "BoardBriefPhase",
     "BoardBriefRender",
     "BoardFundingResponse",
+    "BtcRegimePayload",
     "CIOFollowupRequest",
     "DustItem",
     "FundingIntent",
     "GateResult",
+    "HardGateCandidate",
     "N8nG2GatePayload",
+    "NextObligationPayload",
     "TCFollowupRequest",
+    "TierScenario",
+    "UnverifiedCapPayload",
     "WeightItem",
 ]

--- a/tests/test_board_brief_schema_v2.py
+++ b/tests/test_board_brief_schema_v2.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.n8n.board_brief import (
+    BoardBriefContext,
+    BtcRegimePayload,
+    CIOFollowupRequest,
+    HardGateCandidate,
+    NextObligationPayload,
+    TCFollowupRequest,
+    TierScenario,
+    UnverifiedCapPayload,
+)
+
+
+def _full_v2_payload() -> dict:
+    return {
+        "exchange_krw": 1_500_000,
+        "unverified_cap": {
+            "amount": 10_000_000,
+            "confirmed_at": "2026-04-17T09:30:00+09:00",
+            "verified_by_boss_today": True,
+            "stale_warning": False,
+        },
+        "next_obligation": {
+            "date": "2026-04-24",
+            "days_remaining": 7,
+            "cash_needed_until": 700_000,
+        },
+        "tier_scenarios": [
+            {
+                "label": "T1",
+                "target_exchange_krw": 2_000_000,
+                "deposit_amount": 500_000,
+                "buffer_days": 7,
+                "cushion_after_obligation": 1_300_000,
+            },
+            {
+                "label": "T2",
+                "target_exchange_krw": 5_000_000,
+                "deposit_amount": 3_500_000,
+                "buffer_days": 14,
+                "cushion_after_obligation": 4_300_000,
+            },
+        ],
+        "hard_gate_candidates": [
+            {
+                "symbol": "SOL",
+                "proposal": "부분매도",
+                "amount_range": "8~10 SOL",
+            }
+        ],
+        "data_sufficient_by_symbol": {"SOL": True, "BTC": False},
+        "btc_regime": {
+            "close_vs_20d_ma": "above",
+            "ma20_slope": "up",
+            "drawdown_14d_pct": 4.2,
+        },
+    }
+
+
+def test_board_brief_context_round_trips_full_v2_payload() -> None:
+    context = BoardBriefContext.model_validate(_full_v2_payload())
+
+    assert context.exchange_krw == 1_500_000
+    assert context.unverified_cap == UnverifiedCapPayload(
+        amount=10_000_000,
+        confirmed_at=datetime.fromisoformat("2026-04-17T09:30:00+09:00"),
+        verified_by_boss_today=True,
+        stale_warning=False,
+    )
+    assert context.next_obligation == NextObligationPayload(
+        date=date(2026, 4, 24),
+        days_remaining=7,
+        cash_needed_until=700_000,
+    )
+    assert context.tier_scenarios[0] == TierScenario(
+        label="T1",
+        target_exchange_krw=2_000_000,
+        deposit_amount=500_000,
+        buffer_days=7,
+        cushion_after_obligation=1_300_000,
+    )
+    assert context.hard_gate_candidates == [
+        HardGateCandidate(symbol="SOL", proposal="부분매도", amount_range="8~10 SOL")
+    ]
+    assert context.btc_regime == BtcRegimePayload(
+        close_vs_20d_ma="above",
+        ma20_slope="up",
+        drawdown_14d_pct=4.2,
+    )
+
+    dumped = context.model_dump(mode="json")
+    assert BoardBriefContext.model_validate(dumped) == context
+
+
+def test_board_brief_context_defaults_optional_v2_sections_cleanly() -> None:
+    context = BoardBriefContext()
+
+    assert context.exchange_krw == 0
+    assert context.unverified_cap is None
+    assert context.next_obligation is None
+    assert context.tier_scenarios == []
+    assert context.hard_gate_candidates == []
+    assert context.data_sufficient_by_symbol == {}
+    assert context.btc_regime is None
+    assert context.manual_cash_krw == 0
+
+
+@pytest.mark.parametrize(
+    ("model", "payload"),
+    [
+        (UnverifiedCapPayload, {"amount": -1}),
+        (
+            NextObligationPayload,
+            {"date": "2026-04-24", "days_remaining": -1, "cash_needed_until": 0},
+        ),
+        (
+            NextObligationPayload,
+            {"date": "2026-04-24", "days_remaining": 0, "cash_needed_until": -1},
+        ),
+        (
+            TierScenario,
+            {
+                "label": "T4",
+                "target_exchange_krw": 0,
+                "deposit_amount": 0,
+                "buffer_days": 0,
+                "cushion_after_obligation": 0,
+            },
+        ),
+        (
+            BtcRegimePayload,
+            {
+                "close_vs_20d_ma": "sideways",
+                "ma20_slope": "up",
+                "drawdown_14d_pct": 0,
+            },
+        ),
+    ],
+)
+def test_board_brief_v2_payloads_reject_invalid_values(
+    model: type, payload: dict
+) -> None:
+    with pytest.raises(ValidationError):
+        model.model_validate(payload)
+
+
+def test_followup_requests_accept_v2_fields_and_keep_manual_cash_compat() -> None:
+    payload = _full_v2_payload() | {"manual_cash_krw": 9_000_000}
+
+    tc_request = TCFollowupRequest.model_validate(payload)
+    cio_request = CIOFollowupRequest.model_validate(payload)
+
+    assert tc_request.manual_cash_krw == 9_000_000
+    assert tc_request.unverified_cap is not None
+    assert tc_request.unverified_cap.amount == 10_000_000
+    assert cio_request.tier_scenarios[1].label == "T2"
+    assert cio_request.btc_regime is not None
+    assert cio_request.btc_regime.ma20_slope == "up"


### PR DESCRIPTION
## Summary
- Add prompt v2 BoardBriefContext models and shared request fields for exchange cash, unverified cap, next obligation, tier scenarios, hard-gate candidates, data sufficiency, and BTC regime.
- Preserve manual_cash_krw compatibility while allowing TC/CIO follow-up requests to carry v2 payload sections into render context.
- Add focused schema tests for full payload round-trip, optional defaults, and negative validation.

## Validation
- uv run pytest tests/test_n8n_tc_briefing_discord.py tests/test_board_brief_schema_v2.py -v
- make lint
- make typecheck