### PR TITLE
[ROB-215] Remove place_order caller-asserted requester

### DIFF
--- a/alembic/versions/c0e7a9d8f6b1_add_caller_source_to_order_history.py
+++ b/alembic/versions/c0e7a9d8f6b1_add_caller_source_to_order_history.py
@@ -1,0 +1,49 @@
+"""add caller_source to order history
+
+Revision ID: c0e7a9d8f6b1
+Revises: b8c4d2e0f1a9
+Create Date: 2026-04-17 21:38:00.000000
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c0e7a9d8f6b1"
+down_revision: str | Sequence[str] | None = "b8c4d2e0f1a9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _has_table(table_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def _has_column(table_name: str, column_name: str) -> bool:
+    bind = op.get_bind()
+    inspector = inspect(bind)
+    return any(
+        column["name"] == column_name for column in inspector.get_columns(table_name)
+    )
+
+
+def upgrade() -> None:
+    if _has_table("order_history") and not _has_column("order_history", "caller_source"):
+        op.add_column(
+            "order_history",
+            sa.Column("caller_source", sa.String(length=16), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    if _has_table("order_history") and _has_column("order_history", "caller_source"):
+        op.drop_column("order_history", "caller_source")

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -94,13 +94,13 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - `format_execution_comment(stage, symbol, side, filled_qty, filled_price, ...)` - Format Discord/Paperclip-ready Markdown for `fill` and `follow_up` execution stages.
 - `get_latest_market_brief(symbols=None, market=None, limit=10)` - Return concise latest AI analysis context for recent or selected symbols.
 - `get_market_reports(symbol, days=7, limit=10)` - Return detailed AI analysis report history and decision trend for one symbol.
-- `place_order(symbol, side, order_type="limit", quantity=None, price=None, amount=None, dry_run=True, reason="", exit_reason=None, thesis=None, strategy=None, target_price=None, stop_loss=None, min_hold_days=None, notes=None, indicators_snapshot=None, defensive_trim=False, approval_issue_id=None, requester_agent_id=None)`
+- `place_order(symbol, side, order_type="limit", quantity=None, price=None, amount=None, dry_run=True, reason="", exit_reason=None, thesis=None, strategy=None, target_price=None, stop_loss=None, min_hold_days=None, notes=None, indicators_snapshot=None, defensive_trim=False, approval_issue_id=None)`
   - `side="buy"` 이고 `dry_run=False` 인 경우 `thesis` 와 `strategy` 가 필수
   - 실매수 성공 시 trade journal draft를 자동 생성하고 fill 저장 후 active로 연결 시도
   - 실매도 성공 시 동일 symbol의 active journal을 FIFO 기준으로 auto-close 시도
   - 부분 매도는 quantity를 수정하지 않고, fully-consumed journal만 close한다
   - journal close 실패는 주문 성공을 되돌리지 않고 `journal_warning` 으로 응답한다
-  - `defensive_trim=True` 는 ROB-164/ROB-166 승인 기반 제한 경로이며 `(a) side="sell"`, `(b) order_type="limit"`, `(c) `approval_issue_id` 가 Paperclip `done` 상태, `(d) `requester_agent_id` 가 Trader agent 와 일치할 때만 평균단가 1% 매도 floor 를 우회한다. `requester_agent_id` 는 caller-asserted 값이며, 실제 caller attestation 은 ST-3 에서 별도 추적한다
+  - `defensive_trim=True` 는 ROB-164/ROB-166 승인 기반 제한 경로이며 `(a) side="sell"`, `(b) order_type="limit"`, `(c) `approval_issue_id` 가 Paperclip `done` 상태, `(d) middleware-extracted caller identity 가 Trader agent 와 일치할 때만 평균단가 1% 매도 floor 를 우회한다
 - `modify_order(order_id, symbol, market=None, new_price=None, new_quantity=None, dry_run=True)`
 - `cancel_order(order_id, symbol=None, market=None)`
   - US equities: resolves exchange from symbol DB, open orders, and recent history before cancel

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -11,6 +11,7 @@ from typing import Any, Literal
 from typing import cast as typing_cast
 
 import app.services.brokers.upbit.client as upbit_service
+from app.mcp_server.caller_identity import get_caller_source
 from app.mcp_server.tick_size import adjust_tick_size_kr, get_tick_size_kr
 from app.mcp_server.tooling.order_journal import (
     _append_journal_warning,
@@ -648,6 +649,7 @@ async def _execute_and_record(
         requester_agent_id=(
             defensive_trim_ctx.requester_agent_id if defensive_trim_ctx else None
         ),
+        caller_source=get_caller_source() if defensive_trim_ctx else None,
     )
 
     # Record phase: fills + journals
@@ -719,7 +721,6 @@ async def _place_order_impl(
     indicators_snapshot: dict[str, Any] | None = None,
     defensive_trim: bool = False,
     approval_issue_id: str | None = None,
-    requester_agent_id: str | None = None,
 ) -> dict[str, Any]:
     symbol, side_lower, order_type_lower = _validate_inputs(
         symbol,
@@ -759,7 +760,6 @@ async def _place_order_impl(
         defensive_trim_ctx = await _validate_defensive_trim_preconditions(
             defensive_trim=defensive_trim,
             approval_issue_id=approval_issue_id,
-            requester_agent_id=requester_agent_id,
             side=side_lower,
             order_type=order_type_lower,
         )
@@ -889,6 +889,7 @@ async def _place_order_impl(
             requester_agent_id=(
                 defensive_trim_ctx.requester_agent_id if defensive_trim_ctx else None
             ),
+            caller_source=get_caller_source() if defensive_trim_ctx else None,
         )
         return _order_error(str(exc))
 

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -13,6 +13,7 @@ import httpx
 
 import app.services.brokers.upbit.client as upbit_service
 from app.core.config import settings
+from app.mcp_server.caller_identity import get_caller_agent_id, get_caller_source
 from app.mcp_server.tooling.market_data_quotes import (
     _fetch_quote_equity_kr,
     _fetch_quote_equity_us,
@@ -125,14 +126,10 @@ async def _validate_defensive_trim_preconditions(
     *,
     defensive_trim: bool,
     approval_issue_id: str | None,
-    requester_agent_id: str | None,
     side: str,
     order_type: str,
 ) -> DefensiveTrimContext | None:
-    """Validate defensive_trim gates.
-
-    requester_agent_id is caller-asserted; ST-3 tracks true caller attestation.
-    """
+    """Validate defensive_trim gates using middleware-extracted caller identity."""
     if not defensive_trim:
         return None
 
@@ -148,14 +145,18 @@ async def _validate_defensive_trim_preconditions(
         raise ValueError("defensive_trim=True requires approval_issue_id")
     if not _DEFENSIVE_TRIM_APPROVAL_REGEX.match(approval_issue_id):
         raise ValueError("approval_issue_id format invalid (expected e.g. 'ROB-164')")
-    if not requester_agent_id:
-        raise ValueError("requester_agent_id is required for defensive_trim")
+
+    caller_agent_id = get_caller_agent_id()
+    if not caller_agent_id:
+        raise ValueError(
+            "caller identity unavailable — defensive_trim requires authenticated MCP caller"
+        )
 
     trader_agent_id = getattr(settings, "trader_agent_id", _TRADER_AGENT_ID_DEFAULT)
-    if requester_agent_id != trader_agent_id:
+    if caller_agent_id != trader_agent_id:
         raise ValueError(
             "defensive_trim requires Trader agent caller "
-            f"(got requester_agent_id={requester_agent_id})"
+            f"(got caller_agent_id={caller_agent_id})"
         )
 
     approval_status: str | None
@@ -176,7 +177,7 @@ async def _validate_defensive_trim_preconditions(
 
     return DefensiveTrimContext(
         approval_issue_id=approval_issue_id,
-        requester_agent_id=requester_agent_id,
+        requester_agent_id=caller_agent_id,
         approval_verified_at=datetime.datetime.now(datetime.UTC),
     )
 
@@ -300,6 +301,7 @@ async def _record_order_history(
     defensive_trim: bool = False,
     approval_issue_id: str | None = None,
     requester_agent_id: str | None = None,
+    caller_source: str | None = None,
 ) -> None:
     try:
         import redis.asyncio as redis_async
@@ -327,6 +329,7 @@ async def _record_order_history(
             "defensive_trim": defensive_trim,
             "approval_issue_id": approval_issue_id,
             "requester_agent_id": requester_agent_id,
+            "caller_source": caller_source or get_caller_source(),
         }
 
         await redis.rpush(key, json.dumps(record))

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -91,9 +91,8 @@ def register_order_tools(mcp: FastMCP) -> None:
             "defensive_trim=True enables a sell/limit-only floor bypass path. "
             "ROB-164/ROB-166 defensive_trim requires ALL of: (a) side='sell', "
             "(b) order_type='limit', (c) valid approval_issue_id with approval issue "
-            "status=done in Paperclip, and (d) requester_agent_id matching Trader. "
-            "requester_agent_id is caller-asserted; ST-3 tracks true caller "
-            "attestation."
+            "status=done in Paperclip, and (d) middleware-extracted caller identity "
+            "matching Trader agent."
         ),
     )
     async def place_order(
@@ -115,7 +114,6 @@ def register_order_tools(mcp: FastMCP) -> None:
         indicators_snapshot: dict[str, Any] | None = None,
         defensive_trim: bool = False,
         approval_issue_id: str | None = None,
-        requester_agent_id: str | None = None,
         account_type: Literal["real", "paper"] = "real",
         paper_account: str | None = None,
     ):
@@ -182,7 +180,6 @@ def register_order_tools(mcp: FastMCP) -> None:
             indicators_snapshot=indicators_snapshot,
             defensive_trim=defensive_trim,
             approval_issue_id=approval_issue_id,
-            requester_agent_id=requester_agent_id,
         )
 
     @mcp.tool(

--- a/tests/test_mcp_place_order_defensive_trim.py
+++ b/tests/test_mcp_place_order_defensive_trim.py
@@ -112,7 +112,9 @@ def test_place_order_description_documents_four_and_defensive_trim_gate() -> Non
     assert "(a) side='sell'" in description
     assert "(b) order_type='limit'" in description
     assert "(c) valid approval_issue_id" in description
-    assert "(d) middleware-extracted caller identity matching Trader agent" in description
+    assert (
+        "(d) middleware-extracted caller identity matching Trader agent" in description
+    )
     assert "approval issue status=done" in description
     assert "requester_agent_id" not in description
     assert "ROB-164/ROB-166" in description

--- a/tests/test_mcp_place_order_defensive_trim.py
+++ b/tests/test_mcp_place_order_defensive_trim.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import inspect
+import json
 from unittest.mock import AsyncMock
 
 import pytest
 
 import app.services.brokers.upbit.client as upbit_service
 from app.core.config import settings
+from app.mcp_server.caller_identity import caller_agent_id_var, caller_source_var
 from app.mcp_server.tooling import order_execution, order_validation
 from app.mcp_server.tooling.orders_registration import register_order_tools
 from tests._mcp_tooling_support import build_tools
@@ -44,7 +47,7 @@ def _mock_crypto_sell_context(
 
 
 @pytest.fixture(autouse=True)
-def _set_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+def _set_defaults(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(settings, "trader_agent_id", TRADER_AGENT_ID, raising=False)
     monkeypatch.setattr(
         settings,
@@ -54,6 +57,13 @@ def _set_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     monkeypatch.setattr(settings, "paperclip_api_key", "test-token", raising=False)
     order_validation._defensive_trim_success_cache.clear()
+    agent_token = caller_agent_id_var.set(TRADER_AGENT_ID)
+    source_token = caller_source_var.set("http_header")
+    try:
+        yield
+    finally:
+        caller_source_var.reset(source_token)
+        caller_agent_id_var.reset(agent_token)
 
 
 @pytest.mark.unit
@@ -68,7 +78,6 @@ async def test_defensive_trim_schema_blocks_market_even_with_flag() -> None:
         order_type="market",
         defensive_trim=True,
         approval_issue_id="ROB-164",
-        requester_agent_id=TRADER_AGENT_ID,
         dry_run=True,
     )
 
@@ -103,11 +112,20 @@ def test_place_order_description_documents_four_and_defensive_trim_gate() -> Non
     assert "(a) side='sell'" in description
     assert "(b) order_type='limit'" in description
     assert "(c) valid approval_issue_id" in description
-    assert "(d) requester_agent_id matching Trader" in description
+    assert "(d) middleware-extracted caller identity matching Trader agent" in description
     assert "approval issue status=done" in description
-    assert "requester_agent_id is caller-asserted" in description
-    assert "ST-3" in description
+    assert "requester_agent_id" not in description
     assert "ROB-164/ROB-166" in description
+
+
+@pytest.mark.unit
+def test_place_order_signature_removes_requester_agent_id() -> None:
+    """Public MCP place_order signature no longer accepts caller-asserted identity."""
+    tools = build_tools()
+
+    signature = inspect.signature(tools["place_order"])
+
+    assert "requester_agent_id" not in signature.parameters
 
 
 @pytest.mark.unit
@@ -154,7 +172,6 @@ async def test_flag_on_with_valid_approval_and_trader_caller_allowed(
         price=1005.0,
         defensive_trim=True,
         approval_issue_id="ROB-164",
-        requester_agent_id=TRADER_AGENT_ID,
         dry_run=True,
     )
 
@@ -187,7 +204,6 @@ async def test_flag_on_floor_bypass_logs_structured_warning(
         price=1005.0,
         defensive_trim=True,
         approval_issue_id="ROB-164",
-        requester_agent_id=TRADER_AGENT_ID,
         dry_run=True,
     )
 
@@ -219,7 +235,6 @@ async def test_flag_on_missing_approval_id_rejected() -> None:
         quantity=1.0,
         price=1005.0,
         defensive_trim=True,
-        requester_agent_id=TRADER_AGENT_ID,
         dry_run=True,
     )
 
@@ -241,7 +256,6 @@ async def test_flag_on_malformed_approval_id_rejected() -> None:
         price=1005.0,
         defensive_trim=True,
         approval_issue_id="bad-format",
-        requester_agent_id=TRADER_AGENT_ID,
         dry_run=True,
     )
 
@@ -272,7 +286,6 @@ async def test_flag_on_approval_not_done_rejected(
         price=1005.0,
         defensive_trim=True,
         approval_issue_id="ROB-164",
-        requester_agent_id=TRADER_AGENT_ID,
         dry_run=True,
     )
 
@@ -303,7 +316,6 @@ async def test_flag_on_paperclip_api_timeout_fail_closed(
         price=1005.0,
         defensive_trim=True,
         approval_issue_id="ROB-164",
-        requester_agent_id=TRADER_AGENT_ID,
         dry_run=True,
     )
 
@@ -318,6 +330,7 @@ async def test_flag_on_paperclip_api_timeout_fail_closed(
 async def test_flag_on_non_trader_caller_rejected() -> None:
     """Only trader agent can use defensive_trim."""
     tools = build_tools()
+    caller_agent_id_var.set("other-agent")
 
     result = await tools["place_order"](
         symbol="KRW-BTC",
@@ -327,14 +340,13 @@ async def test_flag_on_non_trader_caller_rejected() -> None:
         price=1005.0,
         defensive_trim=True,
         approval_issue_id="ROB-164",
-        requester_agent_id="other-agent",
         dry_run=True,
     )
 
     assert result["success"] is False
     assert (
         result["error"]
-        == "defensive_trim requires Trader agent caller (got requester_agent_id=other-agent)"
+        == "defensive_trim requires Trader agent caller (got caller_agent_id=other-agent)"
     )
 
 
@@ -343,6 +355,7 @@ async def test_flag_on_non_trader_caller_rejected() -> None:
 async def test_flag_on_missing_caller_id_rejected() -> None:
     """defensive_trim requires caller identity."""
     tools = build_tools()
+    caller_agent_id_var.set(None)
 
     result = await tools["place_order"](
         symbol="KRW-BTC",
@@ -356,7 +369,10 @@ async def test_flag_on_missing_caller_id_rejected() -> None:
     )
 
     assert result["success"] is False
-    assert result["error"] == "requester_agent_id is required for defensive_trim"
+    assert (
+        result["error"]
+        == "caller identity unavailable — defensive_trim requires authenticated MCP caller"
+    )
 
 
 @pytest.mark.unit
@@ -381,7 +397,6 @@ async def test_flag_on_still_rejects_below_current_price(
         price=990.0,
         defensive_trim=True,
         approval_issue_id="ROB-164",
-        requester_agent_id=TRADER_AGENT_ID,
         dry_run=True,
     )
 
@@ -432,7 +447,6 @@ async def test_journal_and_redis_record_defensive_trim_fields(
         price=1005.0,
         defensive_trim=True,
         approval_issue_id="ROB-164",
-        requester_agent_id=TRADER_AGENT_ID,
         dry_run=False,
     )
 
@@ -444,11 +458,57 @@ async def test_journal_and_redis_record_defensive_trim_fields(
     assert kwargs["defensive_trim"] is True
     assert kwargs["approval_issue_id"] == "ROB-164"
     assert kwargs["requester_agent_id"] == TRADER_AGENT_ID
+    assert kwargs["caller_source"] == "http_header"
 
     close_mock.assert_awaited_once()
     close_kwargs = close_mock.await_args.kwargs
     assert close_kwargs["defensive_trim_ctx"].approval_issue_id == "ROB-164"
     assert close_kwargs["defensive_trim_ctx"].requester_agent_id == TRADER_AGENT_ID
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_record_order_history_persists_caller_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Redis order history audit records the middleware caller source."""
+
+    class FakeRedis:
+        def __init__(self) -> None:
+            self.pushed: list[tuple[str, str]] = []
+
+        async def rpush(self, key: str, value: str) -> None:
+            self.pushed.append((key, value))
+
+        async def expire(self, key: str, seconds: int) -> None:
+            del key, seconds
+
+    fake_redis = FakeRedis()
+    monkeypatch.setattr(settings, "redis_url", "redis://test", raising=False)
+    monkeypatch.setattr(
+        "redis.asyncio.from_url",
+        AsyncMock(return_value=fake_redis),
+    )
+
+    await order_validation._record_order_history(
+        symbol="KRW-BTC",
+        side="sell",
+        order_type="limit",
+        quantity=1.0,
+        price=1005.0,
+        amount=1005.0,
+        reason="defensive trim",
+        dry_run=False,
+        defensive_trim=True,
+        approval_issue_id="ROB-164",
+        requester_agent_id=TRADER_AGENT_ID,
+    )
+
+    assert len(fake_redis.pushed) == 1
+    _, raw_record = fake_redis.pushed[0]
+    record = json.loads(raw_record)
+    assert record["requester_agent_id"] == TRADER_AGENT_ID
+    assert record["caller_source"] == "http_header"
 
 
 @pytest.mark.unit
@@ -465,7 +525,6 @@ async def test_flag_on_buy_side_rejected() -> None:
         price=1000.0,
         defensive_trim=True,
         approval_issue_id="ROB-164",
-        requester_agent_id=TRADER_AGENT_ID,
         dry_run=True,
     )
 


### PR DESCRIPTION
## Summary

- Removes public `requester_agent_id` from `place_order` registration, signature, and MCP docs.
- Switches `defensive_trim` caller validation to the ROB-214 middleware contextvar identity via `get_caller_agent_id()`.
- Preserves audit `requester_agent_id` from trusted middleware identity and records `caller_source` in Redis order history.
- Adds a conditional Alembic migration for legacy SQL `order_history.caller_source` when that table exists.
- Updates defensive trim tests to set caller contextvars, verify the public arg is gone, cover missing/non-Trader caller failures, and assert `caller_source` audit persistence.

## Validation

- `uv run pytest --no-cov tests/test_mcp_place_order_defensive_trim.py tests/test_mcp_trade_journal.py tests/test_mcp_server_main.py -q` -> 62 passed, 9 warnings
- `uv run ruff check app/mcp_server/tooling/orders_registration.py app/mcp_server/tooling/order_validation.py app/mcp_server/tooling/order_execution.py tests/test_mcp_place_order_defensive_trim.py alembic/versions/c0e7a9d8f6b1_add_caller_source_to_order_history.py` -> passed
- `git diff --check` -> passed
- `uv run alembic heads` -> `c0e7a9d8f6b1 (head)`

## Full-suite note

`make test` completed with 12 failures / 3967 passed / 17 skipped / 3 deselected before publishing this PR. The failures are outside the ROB-215 focused path: existing crypto screening/tvscreener expectations and nearby non-defensive `test_mcp_place_order.py` cases that hit stop-loss cooldown state.

## Paperclip

ROB-215. Requesting Code Reviewer pre-review before Staff Engineer / CTO review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Order history now tracks caller source information.
  - Simplified `place_order` tool—caller identity is now automatically extracted from middleware instead of being provided as a parameter.

* **Documentation**
  - Updated `place_order` tool documentation to reflect the simplified signature.

* **Tests**
  - Enhanced test coverage for the new caller identity extraction and tracking mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->