### PR TITLE
[ROB-217] Add CallerIdentityMiddleware unit tests

### DIFF
--- a/tests/test_mcp_caller_identity_middleware.py
+++ b/tests/test_mcp_caller_identity_middleware.py
@@ -1,0 +1,178 @@
+"""Unit tests for CallerIdentityMiddleware.on_call_tool."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from app.core.config import settings
+from app.mcp_server import caller_identity_middleware
+from app.mcp_server.caller_identity import (
+    caller_agent_id_var,
+    caller_source_var,
+)
+from app.mcp_server.caller_identity_middleware import (
+    CALLER_AGENT_ID_HEADER,
+    CallerIdentityMiddleware,
+)
+
+
+def _make_http_request(headers: dict[str, str]) -> Mock:
+    request = Mock()
+    request.headers = headers
+    return request
+
+
+def _capturing_call_next() -> tuple[AsyncMock, dict[str, Any]]:
+    """Return a call_next mock that records contextvar state at the time of invocation."""
+    observed: dict[str, Any] = {}
+
+    async def _record(ctx: Any) -> str:
+        observed["caller_agent_id"] = caller_agent_id_var.get()
+        observed["caller_source"] = caller_source_var.get()
+        return "tool-result"
+
+    return AsyncMock(side_effect=_record), observed
+
+
+@pytest.fixture(autouse=True)
+def _clear_fallback_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep env fallback empty unless a test opts in."""
+    monkeypatch.setattr(
+        settings,
+        "mcp_caller_agent_id_fallback",
+        None,
+        raising=False,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestCallerIdentityMiddleware:
+    async def test_http_header_resolves_caller_identity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Header `x-paperclip-agent-id` populates contextvar with source=http_header."""
+        monkeypatch.setattr(
+            caller_identity_middleware,
+            "get_http_request",
+            lambda: _make_http_request({CALLER_AGENT_ID_HEADER: "agent-xyz"}),
+        )
+        call_next, observed = _capturing_call_next()
+
+        result = await CallerIdentityMiddleware().on_call_tool(Mock(), call_next)
+
+        assert result == "tool-result"
+        assert observed == {
+            "caller_agent_id": "agent-xyz",
+            "caller_source": "http_header",
+        }
+
+    async def test_env_fallback_used_when_header_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing HTTP request + env fallback set → source=env_fallback."""
+
+        def _raise_no_http() -> None:
+            raise RuntimeError("no HTTP request in context")
+
+        monkeypatch.setattr(
+            caller_identity_middleware, "get_http_request", _raise_no_http
+        )
+        monkeypatch.setattr(
+            settings, "mcp_caller_agent_id_fallback", "env-agent", raising=False
+        )
+        call_next, observed = _capturing_call_next()
+
+        await CallerIdentityMiddleware().on_call_tool(Mock(), call_next)
+
+        assert observed == {
+            "caller_agent_id": "env-agent",
+            "caller_source": "env_fallback",
+        }
+
+    async def test_caller_none_when_neither_header_nor_env_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing HTTP request + no env fallback → caller=None, source=none."""
+
+        def _raise_no_http() -> None:
+            raise RuntimeError("no HTTP request in context")
+
+        monkeypatch.setattr(
+            caller_identity_middleware, "get_http_request", _raise_no_http
+        )
+        call_next, observed = _capturing_call_next()
+
+        await CallerIdentityMiddleware().on_call_tool(Mock(), call_next)
+
+        assert observed == {"caller_agent_id": None, "caller_source": "none"}
+
+    async def test_contextvars_restored_after_call_next(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Middleware restores contextvar state via reset(token) after call_next."""
+        monkeypatch.setattr(
+            caller_identity_middleware,
+            "get_http_request",
+            lambda: _make_http_request({CALLER_AGENT_ID_HEADER: "agent-xyz"}),
+        )
+
+        pre_agent_token = caller_agent_id_var.set("pre-existing-agent")
+        pre_source_token = caller_source_var.set("env_fallback")
+        try:
+            await CallerIdentityMiddleware().on_call_tool(
+                Mock(), AsyncMock(return_value="ok")
+            )
+            assert caller_agent_id_var.get() == "pre-existing-agent"
+            assert caller_source_var.get() == "env_fallback"
+        finally:
+            caller_source_var.reset(pre_source_token)
+            caller_agent_id_var.reset(pre_agent_token)
+
+    async def test_contextvars_restored_even_when_call_next_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """reset tokens fire in `finally` so exceptions don't leak contextvar state."""
+        monkeypatch.setattr(
+            caller_identity_middleware,
+            "get_http_request",
+            lambda: _make_http_request({CALLER_AGENT_ID_HEADER: "agent-xyz"}),
+        )
+
+        pre_agent_token = caller_agent_id_var.set("pre-existing-agent")
+        pre_source_token = caller_source_var.set("env_fallback")
+        try:
+            with pytest.raises(RuntimeError, match="tool exploded"):
+                await CallerIdentityMiddleware().on_call_tool(
+                    Mock(),
+                    AsyncMock(side_effect=RuntimeError("tool exploded")),
+                )
+            assert caller_agent_id_var.get() == "pre-existing-agent"
+            assert caller_source_var.get() == "env_fallback"
+        finally:
+            caller_source_var.reset(pre_source_token)
+            caller_agent_id_var.reset(pre_agent_token)
+
+    async def test_blank_header_falls_back_to_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Whitespace-only header treated as missing, env fallback used."""
+        monkeypatch.setattr(
+            caller_identity_middleware,
+            "get_http_request",
+            lambda: _make_http_request({CALLER_AGENT_ID_HEADER: "   "}),
+        )
+        monkeypatch.setattr(
+            settings, "mcp_caller_agent_id_fallback", "env-agent", raising=False
+        )
+        call_next, observed = _capturing_call_next()
+
+        await CallerIdentityMiddleware().on_call_tool(Mock(), call_next)
+
+        assert observed == {
+            "caller_agent_id": "env-agent",
+            "caller_source": "env_fallback",
+        }


### PR DESCRIPTION
## Summary

- Add `tests/test_mcp_caller_identity_middleware.py` covering `CallerIdentityMiddleware.on_call_tool` for all three identity sources (`http_header`, `env_fallback`, `none`) plus contextvar teardown semantics.
- Completes [ROB-217](https://paperclip.local/ROB/issues/ROB-217) (ST-3.4). The defensive_trim test rewrite portion of ST-3.4 (kwarg removal, contextvar fixture, new error messages, `caller_source` order_history verification) already landed in [ROB-215 PR #565](https://github.com/mgh3326/auto_trader/pull/565), so this PR is scoped to the new middleware test file only.

## Scenarios covered

1. `x-paperclip-agent-id` header present → contextvar = agent id, source = `http_header`
2. No HTTP request + `settings.mcp_caller_agent_id_fallback` set → contextvar = env agent, source = `env_fallback`
3. No HTTP request + no env fallback → contextvar = `None`, source = `none`
4. Contextvar state restored via `reset(token)` after successful `call_next`
5. Contextvar state restored via `reset(token)` even when `call_next` raises
6. Whitespace-only header treated as missing (env fallback used)

## Acceptance criteria (ST-3.4)

- [x] `test_mcp_place_order_defensive_trim.py` passes (unchanged on this branch; ROB-215 already did the rewrite)
- [x] `test_mcp_caller_identity_middleware.py` 4+ scenarios pass (6 total)
- [x] `caller_source` field recorded in order history — existing `test_record_order_history_persists_caller_source` covers this
- [x] New error-message assertions intact (`defensive_trim requires Trader agent caller`, `caller identity unavailable — defensive_trim requires authenticated MCP caller`)
- [x] `make lint` passes (ruff check + format + ty)
- [x] PR base = `main`

## Test plan

- [x] `uv run pytest tests/test_mcp_caller_identity_middleware.py tests/test_mcp_place_order_defensive_trim.py tests/test_mcp_server_main.py -v` → 28 passed
- [x] `make lint` → all checks passed (ruff + format + ty)

## Review handoff

Following the review chain from the issue description: this PR is ready for Code Reviewer pre-review → Staff Engineer handoff → CTO human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)