### PR TITLE
feat(cio): coin board briefing v2 wiring (ROB-142 S2-S5)

### DIFF
--- a/app/routers/n8n.py
+++ b/app/routers/n8n.py
@@ -144,6 +144,13 @@ def _evaluate_g2_gate(payload: CIOFollowupRequest) -> N8nG2GatePayload:
 
 def _followup_context_from_tc(payload: TCFollowupRequest) -> BoardBriefContext:
     return BoardBriefContext(
+        exchange_krw=payload.exchange_krw,
+        unverified_cap=payload.unverified_cap,
+        next_obligation=payload.next_obligation,
+        tier_scenarios=payload.tier_scenarios,
+        hard_gate_candidates=payload.hard_gate_candidates,
+        data_sufficient_by_symbol=payload.data_sufficient_by_symbol,
+        btc_regime=payload.btc_regime,
         manual_cash_krw=payload.manual_cash_krw,
         daily_burn_krw=payload.daily_burn_krw,
         manual_cash_runway_days=payload.manual_cash_runway_days,
@@ -156,6 +163,13 @@ def _followup_context_from_tc(payload: TCFollowupRequest) -> BoardBriefContext:
 
 def _followup_context_from_cio(payload: CIOFollowupRequest) -> BoardBriefContext:
     return BoardBriefContext(
+        exchange_krw=payload.exchange_krw,
+        unverified_cap=payload.unverified_cap,
+        next_obligation=payload.next_obligation,
+        tier_scenarios=payload.tier_scenarios,
+        hard_gate_candidates=payload.hard_gate_candidates,
+        data_sufficient_by_symbol=payload.data_sufficient_by_symbol,
+        btc_regime=payload.btc_regime,
         manual_cash_krw=payload.manual_cash_krw,
         daily_burn_krw=payload.daily_burn_krw,
         manual_cash_runway_days=payload.manual_cash_runway_days,

--- a/app/schemas/n8n/board_brief.py
+++ b/app/schemas/n8n/board_brief.py
@@ -141,6 +141,7 @@ class BoardBriefRender(BaseModel):
     phase: BoardBriefPhase
     embed: dict[str, Any]
     text: str
+    funding_intent: FundingIntent | None = None
     gate_results: dict[str, GateResult | N8nG2GatePayload] | None = None
     generated_at: datetime
 

--- a/app/schemas/n8n/board_brief.py
+++ b/app/schemas/n8n/board_brief.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
@@ -10,6 +10,9 @@ from pydantic import BaseModel, Field
 FundingIntent = Literal["runway_recovery", "new_buy", "partial", "other"]
 BoardBriefPhase = Literal["tc_preliminary", "cio_pending"]
 GateStatus = Literal["pass", "fail", "pending", "tbd"]
+BtcCloseVs20dMa = Literal["above", "below"]
+BtcMa20Slope = Literal["up", "flat", "down"]
+TierLabel = Literal["T1", "T2", "T3"]
 
 
 class GateResult(BaseModel):
@@ -61,7 +64,62 @@ class BoardFundingResponse(BaseModel):
     manual_cash_verified: bool = False
 
 
-class BoardBriefContext(BaseModel):
+class UnverifiedCapPayload(BaseModel):
+    """Manual funding cap that is not counted as verified exchange cash."""
+
+    amount: float = Field(0, ge=0)
+    confirmed_at: datetime | None = None
+    verified_by_boss_today: bool = False
+    stale_warning: bool = False
+
+
+class NextObligationPayload(BaseModel):
+    """Next cash obligation used for runway and funding-path decisions."""
+
+    date: date
+    days_remaining: int = Field(..., ge=0)
+    cash_needed_until: float = Field(..., ge=0)
+
+
+class TierScenario(BaseModel):
+    """Funding tier scenario for board-facing path A comparison."""
+
+    label: TierLabel
+    target_exchange_krw: float = Field(..., ge=0)
+    deposit_amount: float = Field(..., ge=0)
+    buffer_days: int = Field(..., ge=0)
+    cushion_after_obligation: float
+
+
+class HardGateCandidate(BaseModel):
+    """Candidate action that still requires a separate hard-gate critique."""
+
+    symbol: str = Field(..., min_length=1)
+    proposal: str = Field(..., min_length=1)
+    amount_range: str = Field(..., min_length=1)
+
+
+class BtcRegimePayload(BaseModel):
+    """BTC regime metrics used by G4."""
+
+    close_vs_20d_ma: BtcCloseVs20dMa
+    ma20_slope: BtcMa20Slope
+    drawdown_14d_pct: float
+
+
+class BoardBriefV2Fields(BaseModel):
+    """Prompt v2 fields shared by context and n8n follow-up request bodies."""
+
+    exchange_krw: float = Field(0, ge=0)
+    unverified_cap: UnverifiedCapPayload | None = None
+    next_obligation: NextObligationPayload | None = None
+    tier_scenarios: list[TierScenario] = Field(default_factory=list)
+    hard_gate_candidates: list[HardGateCandidate] = Field(default_factory=list)
+    data_sufficient_by_symbol: dict[str, bool] = Field(default_factory=dict)
+    btc_regime: BtcRegimePayload | None = None
+
+
+class BoardBriefContext(BoardBriefV2Fields):
     """Internal render context shared by TC preliminary and CIO pending builders."""
 
     manual_cash_krw: float = Field(0, ge=0)
@@ -87,7 +145,7 @@ class BoardBriefRender(BaseModel):
     generated_at: datetime
 
 
-class TCFollowupRequest(BaseModel):
+class TCFollowupRequest(BoardBriefV2Fields):
     """Request payload for /api/n8n/tc-followup."""
 
     manual_cash_krw: float = Field(0, ge=0)
@@ -112,11 +170,16 @@ __all__ = [
     "BoardBriefPhase",
     "BoardBriefRender",
     "BoardFundingResponse",
+    "BtcRegimePayload",
     "CIOFollowupRequest",
     "DustItem",
     "FundingIntent",
     "GateResult",
+    "HardGateCandidate",
     "N8nG2GatePayload",
+    "NextObligationPayload",
     "TCFollowupRequest",
+    "TierScenario",
+    "UnverifiedCapPayload",
     "WeightItem",
 ]

--- a/app/services/cio_coin_briefing/prompts/gate_phrases.py
+++ b/app/services/cio_coin_briefing/prompts/gate_phrases.py
@@ -1,5 +1,7 @@
 """Prompt v2 phrase constants used by board brief renderers."""
 
+import re
+
 G2_RUNWAY_FUEL_LINES = [
     "- 이번 {amount} 원은 **운영 연료** 로 귀속 — coinmoogi DCA {days} 일 지속분 + 만기 cushion.",
     "- 신규 매수 여력으로 전용 금지. G2 에서 차단.",
@@ -19,3 +21,19 @@ PATH_SECTION_AB_REPEAT = "**A 와 B 는 상호배타 아님 — 병행 가능.**
 BOARD_QUESTIONS_TEMPLATE = """질문 (Step 1 답변 반영 — 재질문 아님)
 1) **[funding-confirmation]** manual_cash 중 오늘 실제 입금 가능액이 있습니까? 있다면 얼마, 언제까지?
 2) **[action]** 부분매도를 Hard Gate critique 에 올려 실행하시겠습니까?"""
+
+FORBIDDEN_PATTERN_STRINGS = [
+    r"\[funding\].*\[action\]",
+    r"가용\s*현금[^(]*\d",
+    r"Planning\s*cash",
+    r"\b유휴\s*자금\b",
+    r"\b예비\s*자금\b",
+    r"\b대기\s*자금\b",
+    r"\b대기\s*cash\b",
+    r"\b입금\s*여력\b",
+    r"\b천만\s*원\s*(현금|cash|가용)",
+    r"A\s*(또는|혹은|or)\s*B\s*(중|에서)\s*택1?",
+    r"입금\s*(또는|혹은)\s*매도\s*(중|에서)\s*택1?",
+]
+
+FORBIDDEN_PATTERNS = [re.compile(pattern) for pattern in FORBIDDEN_PATTERN_STRINGS]

--- a/app/services/cio_coin_briefing/prompts/gate_phrases.py
+++ b/app/services/cio_coin_briefing/prompts/gate_phrases.py
@@ -1,0 +1,21 @@
+"""Prompt v2 phrase constants used by board brief renderers."""
+
+G2_RUNWAY_FUEL_LINES = [
+    "- 이번 {amount} 원은 **운영 연료** 로 귀속 — coinmoogi DCA {days} 일 지속분 + 만기 cushion.",
+    "- 신규 매수 여력으로 전용 금지. G2 에서 차단.",
+]
+
+G2_NEW_BUDGET_LINES = [
+    "- 이번 {amount} 원은 G3 (runway/obligation) 통과 후 신규 risk budget 후보.",
+    "- 이 경우에도 G4 시장 regime → G5 volatility halt → G6 보조지표 통과 여부 추가 판정 필요.",
+]
+
+FRAMING_AB_PATH_NON_EXCLUSIVE = (
+    "경로 A (입금) 와 경로 B (현물 부분매도) 는 **상호배타 아님**. 병행 가능합니다."
+)
+
+PATH_SECTION_AB_REPEAT = "**A 와 B 는 상호배타 아님 — 병행 가능.**"
+
+BOARD_QUESTIONS_TEMPLATE = """질문 (Step 1 답변 반영 — 재질문 아님)
+1) **[funding-confirmation]** manual_cash 중 오늘 실제 입금 가능액이 있습니까? 있다면 얼마, 언제까지?
+2) **[action]** 부분매도를 Hard Gate critique 에 올려 실행하시겠습니까?"""

--- a/app/services/n8n_daily_brief_service.py
+++ b/app/services/n8n_daily_brief_service.py
@@ -8,13 +8,20 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
+
+import httpx
 
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst
 from app.schemas.n8n.board_brief import (
     BoardBriefContext,
+    BoardBriefPhase,
     BoardBriefRender,
     BoardFundingResponse,
     FundingIntent,
@@ -24,6 +31,7 @@ from app.schemas.n8n.board_brief import (
 from app.schemas.n8n.common import N8nMarketOverview
 from app.services.cio_coin_briefing.prompts.gate_phrases import (
     BOARD_QUESTIONS_TEMPLATE,
+    FORBIDDEN_PATTERNS,
     FRAMING_AB_PATH_NON_EXCLUSIVE,
     G2_NEW_BUDGET_LINES,
     G2_RUNWAY_FUEL_LINES,
@@ -42,6 +50,47 @@ from app.services.n8n_pending_orders_service import fetch_pending_orders
 logger = logging.getLogger(__name__)
 
 _DEFAULT_MARKETS = ("crypto", "kr", "us")
+_FAIL_CLOSED_ANCHOR_RE = re.compile(r"^⚠️ .+ 누락 — .+$")
+_DUST_AGGREGATE_RE = re.compile(
+    r"^🧹 Dust \d+종목 · 합계 .+ · 포트폴리오 \d+(?:\.\d+)?%$"
+)
+
+
+@dataclass(frozen=True)
+class InvariantViolation:
+    """One render invariant violation."""
+
+    code: str
+    detail: str
+
+
+class RenderInvariantError(RuntimeError):
+    """Raised when final markdown violates render safety invariants."""
+
+    def __init__(self, violations: list[InvariantViolation]) -> None:
+        self.violations = violations
+        details = ", ".join(f"{item.code}: {item.detail}" for item in violations)
+        super().__init__(f"Board brief render invariant failed: {details}")
+
+
+class RenderRouter:
+    """Route render output to board or ops channels.
+
+    The default implementation only performs ops escalation when
+    N8N_OPS_ESCALATION_WEBHOOK is configured. Tests can inject a subclass to
+    assert fail-closed routing without making network calls.
+    """
+
+    def route_ops_escalation(self, message: str) -> None:
+        webhook_url = os.getenv("N8N_OPS_ESCALATION_WEBHOOK", "").strip()
+        if not webhook_url:
+            logger.warning("Ops escalation webhook not configured: %s", message)
+            return
+        try:
+            with httpx.Client(timeout=5) as client:
+                client.post(webhook_url, json={"content": message})
+        except httpx.HTTPError:
+            logger.exception("Failed to send ops escalation webhook")
 
 
 async def _get_portfolio_overview(
@@ -481,6 +530,253 @@ def _extract_followup_context(
     return BoardBriefContext.model_validate(payload)
 
 
+def _missing_required_context(ctx: BoardBriefContext) -> tuple[str, str] | None:
+    required_checks: list[tuple[str, bool, str]] = [
+        (
+            "exchange_krw",
+            ctx.exchange_krw > 0,
+            "거래소 주문가능 KRW 미수신, 브리핑 생성 불가",
+        ),
+        (
+            "unverified_cap",
+            ctx.unverified_cap is not None,
+            "manual_cash 관련 권고/문구 생성 금지",
+        ),
+        (
+            "next_obligation",
+            ctx.next_obligation is not None,
+            "obligation 행과 경로 A 평가 보류",
+        ),
+        (
+            "tier_scenarios",
+            bool(ctx.tier_scenarios),
+            "입금 시나리오 산출 보류",
+        ),
+        (
+            "data_sufficient_by_symbol",
+            bool(ctx.data_sufficient_by_symbol),
+            "심볼별 G1 데이터 충분성 평가 불가",
+        ),
+        (
+            "btc_regime",
+            ctx.btc_regime is not None,
+            "G4 regime 통과 판정 금지",
+        ),
+        (
+            "holdings",
+            bool(ctx.holdings),
+            "포트폴리오 쏠림 및 dust 평가 불가",
+        ),
+    ]
+    for field, present, reason in required_checks:
+        if not present:
+            return field, reason
+    return None
+
+
+def _route_fail_closed(
+    *,
+    ctx: BoardBriefContext,
+    phase: BoardBriefPhase,
+    field: str,
+    reason: str,
+    router: RenderRouter,
+) -> BoardBriefRender:
+    generated_at = ctx.generated_at or now_kst().replace(microsecond=0)
+    text = f"⚠️ {field} 누락 — {reason}"
+    router.route_ops_escalation(text)
+    logger.error(
+        "Board brief fail-closed render routed to ops",
+        extra={"phase": phase, "missing_field": field},
+    )
+    return BoardBriefRender(
+        phase=phase,
+        embed={},
+        text=text,
+        gate_results=None,
+        generated_at=generated_at,
+    )
+
+
+def _format_unverified_amounts(ctx: BoardBriefContext) -> set[str]:
+    if not ctx.unverified_cap:
+        return set()
+    amount = ctx.unverified_cap.amount
+    return {
+        f"{amount:,.0f}",
+        f"{amount:.0f}",
+        _fmt_krw(amount),
+    }
+
+
+def _gate_passed(gate: GateResult | N8nG2GatePayload | None) -> bool:
+    if isinstance(gate, N8nG2GatePayload):
+        return gate.passed and gate.status == "pass"
+    if isinstance(gate, GateResult):
+        return gate.status == "pass"
+    return False
+
+
+def _line_count(text: str, needle: str) -> int:
+    return sum(1 for line in text.splitlines() if needle in line)
+
+
+def _contains_fail_closed_anchor(text: str) -> bool:
+    return any(_FAIL_CLOSED_ANCHOR_RE.match(line) for line in text.splitlines())
+
+
+def validate_render_invariants(
+    text: str,
+    ctx: BoardBriefContext,
+    *,
+    phase: BoardBriefPhase,
+) -> list[InvariantViolation]:
+    """Return structural render invariant violations for final markdown."""
+    violations: list[InvariantViolation] = []
+
+    exchange_rows = _line_count(text, "거래소 KRW:")
+    unverified_rows = _line_count(text, "미확인 cap")
+    if exchange_rows != 1 or unverified_rows != 1:
+        violations.append(
+            InvariantViolation(
+                code="funding_rows",
+                detail=(
+                    "expected 거래소 KRW and 미확인 cap rows exactly once "
+                    f"(got {exchange_rows}/{unverified_rows})"
+                ),
+            )
+        )
+
+    runway_lines = [line for line in text.splitlines() if "runway" in line.lower()]
+    unverified_amounts = _format_unverified_amounts(ctx)
+    if any(
+        amount and amount in line
+        for line in runway_lines
+        for amount in unverified_amounts
+    ):
+        violations.append(
+            InvariantViolation(
+                code="runway_excludes_unverified_cap",
+                detail="runway line includes unverified_cap amount",
+            )
+        )
+
+    framing_count = text.count(FRAMING_AB_PATH_NON_EXCLUSIVE)
+    path_repeat_count = text.count(PATH_SECTION_AB_REPEAT)
+    funding_question_count = text.count("[funding-confirmation]") + text.count(
+        "[funding]"
+    )
+    action_question_count = text.count("[action]")
+    if phase == "cio_pending":
+        ab_ok = (
+            framing_count == 1
+            and path_repeat_count == 1
+            and funding_question_count == 1
+            and action_question_count == 1
+        )
+    else:
+        ab_ok = framing_count == 1 and path_repeat_count == 1
+    if not ab_ok:
+        violations.append(
+            InvariantViolation(
+                code="ab_anchor_triple",
+                detail=(
+                    "expected A/B framing, repeat, and CIO question anchors exactly once "
+                    f"(got {framing_count}/{path_repeat_count}/"
+                    f"{funding_question_count}/{action_question_count})"
+                ),
+            )
+        )
+
+    if phase == "cio_pending":
+        runway_phrase_count = text.count("**운영 연료**")
+        new_budget_phrase_count = text.count("신규 risk budget 후보")
+        if runway_phrase_count + new_budget_phrase_count != 1:
+            violations.append(
+                InvariantViolation(
+                    code="g2_phrase_exactly_one",
+                    detail=(
+                        "expected exactly one G2 phrase head "
+                        f"(got {runway_phrase_count}/{new_budget_phrase_count})"
+                    ),
+                )
+            )
+
+        if "CIO 권고 (1) 즉시 매수" in text:
+            gates = _build_gate_results(ctx)
+            missing = [
+                name
+                for name in ("G2", "G3", "G4", "G5")
+                if not _gate_passed(gates.get(name))
+            ]
+            if missing:
+                violations.append(
+                    InvariantViolation(
+                        code="immediate_buy_requires_g2_g5_pass",
+                        detail=f"immediate buy rendered while {', '.join(missing)} not pass",
+                    )
+                )
+
+    dust_count = sum(1 for line in text.splitlines() if _DUST_AGGREGATE_RE.match(line))
+    if dust_count != 1:
+        violations.append(
+            InvariantViolation(
+                code="dust_aggregate",
+                detail=f"expected exactly one dust aggregate line (got {dust_count})",
+            )
+        )
+
+    if _contains_fail_closed_anchor(text):
+        violations.append(
+            InvariantViolation(
+                code="fail_closed_anchor",
+                detail="fail-closed anchors must bypass normal board render validation",
+            )
+        )
+
+    return violations
+
+
+def _check_forbidden_patterns(text: str) -> list[InvariantViolation]:
+    violations: list[InvariantViolation] = []
+    for pattern in FORBIDDEN_PATTERNS:
+        if pattern.search(text):
+            violations.append(
+                InvariantViolation(
+                    code="forbidden_pattern",
+                    detail=pattern.pattern,
+                )
+            )
+    return violations
+
+
+def _postprocess_and_validate_render(
+    *,
+    text: str,
+    ctx: BoardBriefContext,
+    phase: BoardBriefPhase,
+    router: RenderRouter,
+    text_postprocessor: Callable[[str], str] | None,
+) -> str:
+    if text_postprocessor:
+        text = text_postprocessor(text)
+
+    violations = _check_forbidden_patterns(text)
+    violations.extend(validate_render_invariants(text, ctx, phase=phase))
+    if violations:
+        message = "; ".join(f"{item.code}: {item.detail}" for item in violations)
+        logger.error(
+            "Board brief render invariant violation",
+            extra={
+                "phase": phase,
+                "violations": [item.__dict__ for item in violations],
+            },
+        )
+        router.route_ops_escalation(message)
+        raise RenderInvariantError(violations)
+    return text
+
+
 def _default_gate_results() -> dict[str, GateResult | N8nG2GatePayload]:
     return {
         "G1": GateResult(status="pending", detail="G1 데이터 충분성 평가 대기"),
@@ -766,11 +1062,30 @@ def _build_board_embed(*, title: str, text: str, color: int) -> dict[str, Any]:
 
 def build_tc_preliminary(
     payload: BoardBriefContext | dict[str, Any],
+    *,
+    router: RenderRouter | None = None,
+    text_postprocessor: Callable[[str], str] | None = None,
 ) -> BoardBriefRender:
     """Render the first TC follow-up phase."""
     ctx = _extract_followup_context(payload)
+    router = router or RenderRouter()
+    if missing := _missing_required_context(ctx):
+        return _route_fail_closed(
+            ctx=ctx,
+            phase="tc_preliminary",
+            field=missing[0],
+            reason=missing[1],
+            router=router,
+        )
     generated_at = ctx.generated_at or now_kst().replace(microsecond=0)
     text = _build_tc_preliminary_text(ctx)
+    text = _postprocess_and_validate_render(
+        text=text,
+        ctx=ctx,
+        phase="tc_preliminary",
+        router=router,
+        text_postprocessor=text_postprocessor,
+    )
     return BoardBriefRender(
         phase="tc_preliminary",
         embed=_build_board_embed(
@@ -786,9 +1101,21 @@ def build_tc_preliminary(
 
 def build_cio_pending_decision(
     payload: BoardBriefContext | dict[str, Any],
+    *,
+    router: RenderRouter | None = None,
+    text_postprocessor: Callable[[str], str] | None = None,
 ) -> BoardBriefRender:
     """Render the second CIO follow-up phase."""
     ctx = _extract_followup_context(payload)
+    router = router or RenderRouter()
+    if missing := _missing_required_context(ctx):
+        return _route_fail_closed(
+            ctx=ctx,
+            phase="cio_pending",
+            field=missing[0],
+            reason=missing[1],
+            router=router,
+        )
     generated_at = ctx.generated_at or now_kst().replace(microsecond=0)
     gate_results = _build_gate_results(ctx)
     funding_intent, _ = resolve_funding_intent(ctx, ctx.board_response)
@@ -796,6 +1123,13 @@ def build_cio_pending_decision(
         update={"funding_intent": funding_intent, "gate_results": gate_results}
     )
     text = _build_cio_pending_text(ctx)
+    text = _postprocess_and_validate_render(
+        text=text,
+        ctx=ctx,
+        phase="cio_pending",
+        router=router,
+        text_postprocessor=text_postprocessor,
+    )
     return BoardBriefRender(
         phase="cio_pending",
         embed=_build_board_embed(
@@ -948,7 +1282,11 @@ async def fetch_daily_brief(
 
 
 __all__ = [
+    "InvariantViolation",
+    "RenderInvariantError",
+    "RenderRouter",
     "build_cio_pending_decision",
     "build_tc_preliminary",
     "fetch_daily_brief",
+    "validate_render_invariants",
 ]

--- a/app/services/n8n_daily_brief_service.py
+++ b/app/services/n8n_daily_brief_service.py
@@ -16,10 +16,19 @@ from app.core.timezone import now_kst
 from app.schemas.n8n.board_brief import (
     BoardBriefContext,
     BoardBriefRender,
+    BoardFundingResponse,
+    FundingIntent,
     GateResult,
     N8nG2GatePayload,
 )
 from app.schemas.n8n.common import N8nMarketOverview
+from app.services.cio_coin_briefing.prompts.gate_phrases import (
+    BOARD_QUESTIONS_TEMPLATE,
+    FRAMING_AB_PATH_NON_EXCLUSIVE,
+    G2_NEW_BUDGET_LINES,
+    G2_RUNWAY_FUEL_LINES,
+    PATH_SECTION_AB_REPEAT,
+)
 from app.services.n8n_formatting import (
     fmt_amount,
     fmt_date_with_weekday,
@@ -457,6 +466,12 @@ def _fmt_pct(value: float | int | None) -> str:
     return f"{float(value):.1f}%"
 
 
+def _fmt_days(value: float | int | None) -> str:
+    if value is None:
+        return "-"
+    return f"{float(value):.2f}일"
+
+
 def _extract_followup_context(
     payload: BoardBriefContext | dict[str, Any],
 ) -> BoardBriefContext:
@@ -490,12 +505,89 @@ def _build_gate_results(
     return gates
 
 
+def _has_v2_funding_context(ctx: BoardBriefContext) -> bool:
+    return bool(
+        ctx.exchange_krw
+        or ctx.unverified_cap
+        or ctx.next_obligation
+        or ctx.tier_scenarios
+    )
+
+
 def _cash_runway_days(ctx: BoardBriefContext) -> float | None:
     if ctx.manual_cash_runway_days is not None:
         return ctx.manual_cash_runway_days
+    if _has_v2_funding_context(ctx) and ctx.daily_burn_krw > 0:
+        return ctx.exchange_krw / ctx.daily_burn_krw
     if ctx.daily_burn_krw > 0:
         return ctx.manual_cash_krw / ctx.daily_burn_krw
     return None
+
+
+def _funding_amount(board_response: BoardFundingResponse | None) -> float:
+    return board_response.amount if board_response else 0
+
+
+def _funding_verified(
+    ctx: BoardBriefContext, board_response: BoardFundingResponse | None
+) -> bool:
+    return bool(
+        (board_response and board_response.manual_cash_verified)
+        or (ctx.unverified_cap and ctx.unverified_cap.verified_by_boss_today)
+    )
+
+
+def _format_g2_lines(lines: list[str], *, amount: float, days: int) -> list[str]:
+    return [line.format(amount=f"{amount:,.0f}", days=days) for line in lines]
+
+
+def resolve_funding_intent(
+    ctx: BoardBriefContext,
+    board_response: BoardFundingResponse | None,
+) -> tuple[FundingIntent, list[str]]:
+    """Resolve G2 funding intent and the exact phrase set to render.
+
+    >>> ctx = BoardBriefContext(exchange_krw=100, daily_burn_krw=10)
+    >>> resolve_funding_intent(ctx, None)[0]
+    'runway_recovery'
+    >>> response = BoardFundingResponse(
+    ...     amount=100, target="BTC", funding_intent="new_buy", manual_cash_verified=True
+    ... )
+    >>> ctx = BoardBriefContext(
+    ...     exchange_krw=100, daily_burn_krw=10,
+    ...     next_obligation={"date": "2026-04-24", "days_remaining": 7, "cash_needed_until": 50}
+    ... )
+    >>> resolve_funding_intent(ctx, response)[0]
+    'new_buy'
+    """
+    amount = _funding_amount(board_response)
+    days = ctx.next_obligation.days_remaining if ctx.next_obligation else 0
+    runway_lines = _format_g2_lines(
+        G2_RUNWAY_FUEL_LINES,
+        amount=amount,
+        days=days,
+    )
+    new_budget_lines = _format_g2_lines(
+        G2_NEW_BUDGET_LINES,
+        amount=amount,
+        days=days,
+    )
+
+    verified_amount = amount if _funding_verified(ctx, board_response) else 0
+    if (
+        ctx.next_obligation
+        and ctx.next_obligation.cash_needed_until > ctx.exchange_krw + verified_amount
+    ):
+        return "runway_recovery", runway_lines
+
+    if (
+        board_response
+        and board_response.target
+        and _funding_verified(ctx, board_response)
+    ):
+        return "new_buy", new_budget_lines
+
+    return "runway_recovery", runway_lines
 
 
 def _build_concentration_lines(ctx: BoardBriefContext) -> list[str]:
@@ -519,30 +611,79 @@ def _build_candidate_lines(ctx: BoardBriefContext) -> list[str]:
 
 def _build_dust_lines(ctx: BoardBriefContext) -> list[str]:
     dust_items = ctx.dust_items or [holding for holding in ctx.holdings if holding.dust]
-    if not dust_items:
-        return []
-    joined = ", ".join(
-        f"{item.symbol} (~{float(item.current_krw_value):,.0f} KRW)"
-        for item in dust_items[:8]
+    dust_total = sum(float(item.current_krw_value) for item in dust_items)
+    portfolio_total = sum(float(holding.current_krw_value) for holding in ctx.holdings)
+    dust_pct = (dust_total / portfolio_total * 100) if portfolio_total > 0 else 0
+    return [
+        f"🧹 Dust {len(dust_items)}종목 · 합계 {_fmt_krw(dust_total)} · 포트폴리오 {dust_pct:.2f}%"
+    ]
+
+
+def _build_funding_lines(ctx: BoardBriefContext) -> list[str]:
+    runway_days = _cash_runway_days(ctx)
+    unverified_cap = ctx.unverified_cap.amount if ctx.unverified_cap else None
+    unverified_badges = []
+    if ctx.unverified_cap and ctx.unverified_cap.stale_warning:
+        unverified_badges.append("stale_warning")
+    if ctx.unverified_cap and ctx.unverified_cap.verified_by_boss_today:
+        unverified_badges.append("verified_by_boss_today")
+    badge_text = f" ({' / '.join(unverified_badges)})" if unverified_badges else ""
+    obligation = (
+        f"{ctx.next_obligation.date.isoformat()} / D-{ctx.next_obligation.days_remaining} / "
+        f"{_fmt_krw(ctx.next_obligation.cash_needed_until)}"
+        if ctx.next_obligation
+        else "-"
+    )
+    runway_formula = (
+        f"{_fmt_krw(ctx.exchange_krw)} / {_fmt_krw(ctx.daily_burn_krw)} = "
+        f"{_fmt_days(runway_days)}"
+        if runway_days is not None and ctx.daily_burn_krw > 0
+        else "-"
     )
     return [
-        "🧹 Dust",
-        f"{joined} — Upbit 최소 주문 금액 미만, execution-actionable 제외, journal 유지. cleanup backlog.",
+        f"- 거래소 KRW: {_fmt_krw(ctx.exchange_krw)}",
+        f"- 미확인 cap (보스 확인 전): {_fmt_krw(unverified_cap)}{badge_text}",
+        f"- 일일 소진 (daily_burn): {_fmt_krw(ctx.daily_burn_krw)}",
+        f"- 다음 의무 (date / days_remaining / cash_needed_until): {obligation}",
+        f"- runway 산식: {runway_formula}",
     ]
+
+
+def _build_tier_lines(ctx: BoardBriefContext) -> list[str]:
+    if not ctx.tier_scenarios:
+        return ["tier_scenarios 미수신, 입금 시나리오 산출 보류"]
+    obligation = (
+        f"{ctx.next_obligation.date.isoformat()} / D-{ctx.next_obligation.days_remaining}"
+        if ctx.next_obligation
+        else "-"
+    )
+    lines = [
+        (
+            "deposit_amount | next_obligation | cash_needed_until | "
+            "cushion_after_obligation | target_exchange_krw | buffer_days (보조)"
+        )
+    ]
+    for scenario in ctx.tier_scenarios:
+        cash_needed = (
+            ctx.next_obligation.cash_needed_until if ctx.next_obligation else None
+        )
+        lines.append(
+            f"{_fmt_krw(scenario.deposit_amount)} | {obligation} | "
+            f"{_fmt_krw(cash_needed)} | {_fmt_krw(scenario.cushion_after_obligation)} | "
+            f"{_fmt_krw(scenario.target_exchange_krw)} | {scenario.buffer_days}"
+        )
+    return lines
 
 
 def _build_tc_preliminary_text(ctx: BoardBriefContext) -> str:
     """Build TC preliminary text without recommendation or gate sections."""
-    runway_days = _cash_runway_days(ctx)
     lines = [
-        "📊 TC Preliminary — 자금 현황 재계산",
+        "📊 TC Preliminary — 입금 약속 반영 시나리오 (pledged, 거래소 미반영)",
         "",
-        "요약: 경로 A·B 병행 가능. 현금 runway와 포지션 쏠림을 먼저 재계산한다.",
+        f"요약: 경로 A·B 병행 가능. {FRAMING_AB_PATH_NON_EXCLUSIVE}",
         "",
         "💵 자금 현황",
-        f"- 수동 현금: {_fmt_krw(ctx.manual_cash_krw)}",
-        f"- 일 burn: {_fmt_krw(ctx.daily_burn_krw)}",
-        f"- runway: {_fmt_pct(runway_days).replace('%', '일') if runway_days is not None else '-'}",
+        *_build_funding_lines(ctx),
         "",
         "📌 쏠림/편중",
         *_build_concentration_lines(ctx),
@@ -558,6 +699,10 @@ def _build_tc_preliminary_text(ctx: BoardBriefContext) -> str:
             "",
             "경로 A: 신규 매수 없이 현금 runway 회복 우선.",
             "경로 B: board funding 확인 후 CIO pending decision에서 gate 재평가.",
+            "",
+            "§7 Tier table",
+            *_build_tier_lines(ctx),
+            PATH_SECTION_AB_REPEAT,
         ]
     )
     return "\n".join(lines)
@@ -580,6 +725,7 @@ def _build_cio_pending_text(ctx: BoardBriefContext) -> str:
     gates = _build_gate_results(ctx)
     g2 = gates["G2"]
     g2_failed = isinstance(g2, N8nG2GatePayload) and not g2.passed
+    _, g2_lines = resolve_funding_intent(ctx, ctx.board_response)
     lines = [
         _build_tc_preliminary_text(ctx),
         "",
@@ -589,6 +735,7 @@ def _build_cio_pending_text(ctx: BoardBriefContext) -> str:
             if g2_failed
             else "CIO 의견 대기 중 — gate 결과 확인 후 action 확정"
         ),
+        *g2_lines,
         "",
         "📊 Gate 판정 결과",
     ]
@@ -603,9 +750,7 @@ def _build_cio_pending_text(ctx: BoardBriefContext) -> str:
     lines.extend(
         [
             "",
-            "질문",
-            "[funding] 경로 A·B 병행 가능 기준으로 board funding 금액/목적을 확정할 것.",
-            "[action] 경로 A·B 병행 가능 조건에서 신규 매수, 현금 회복, 축소 중 하나를 선택할 것.",
+            BOARD_QUESTIONS_TEMPLATE,
         ]
     )
     return "\n".join(lines)
@@ -629,7 +774,7 @@ def build_tc_preliminary(
     return BoardBriefRender(
         phase="tc_preliminary",
         embed=_build_board_embed(
-            title="📊 TC Preliminary — 자금 현황 재계산",
+            title="📊 TC Preliminary — 입금 약속 반영 시나리오 (pledged, 거래소 미반영)",
             text=text,
             color=0x3498DB,
         ),
@@ -646,7 +791,10 @@ def build_cio_pending_decision(
     ctx = _extract_followup_context(payload)
     generated_at = ctx.generated_at or now_kst().replace(microsecond=0)
     gate_results = _build_gate_results(ctx)
-    ctx = ctx.model_copy(update={"gate_results": gate_results})
+    funding_intent, _ = resolve_funding_intent(ctx, ctx.board_response)
+    ctx = ctx.model_copy(
+        update={"funding_intent": funding_intent, "gate_results": gate_results}
+    )
     text = _build_cio_pending_text(ctx)
     return BoardBriefRender(
         phase="cio_pending",
@@ -656,6 +804,7 @@ def build_cio_pending_decision(
             color=0xF1C40F,
         ),
         text=text,
+        funding_intent=funding_intent,
         gate_results=gate_results,
         generated_at=generated_at,
     )

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Shared pytest fixture helpers."""

--- a/tests/fixtures/cio_briefing.py
+++ b/tests/fixtures/cio_briefing.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from copy import deepcopy
+from typing import Any
+
+from app.schemas.n8n.board_brief import BoardBriefContext, GateResult, N8nG2GatePayload
+from app.services.n8n_daily_brief_service import RenderRouter
+
+
+def plan_v2_section_f_dataset(**updates: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "exchange_krw": 83_318,
+        "unverified_cap": {
+            "amount": 10_000_000,
+            "confirmed_at": None,
+            "verified_by_boss_today": False,
+            "stale_warning": True,
+        },
+        "manual_cash_krw": 10_000_000,
+        "daily_burn_krw": 80_000,
+        "next_obligation": {
+            "date": "2026-04-29",
+            "days_remaining": 12,
+            "cash_needed_until": 960_000,
+        },
+        "tier_scenarios": [
+            {
+                "label": "T1",
+                "deposit_amount": 516_682,
+                "target_exchange_krw": 600_000,
+                "buffer_days": 7,
+                "cushion_after_obligation": -360_000,
+            },
+            {
+                "label": "T2",
+                "deposit_amount": 1_116_682,
+                "target_exchange_krw": 1_200_000,
+                "buffer_days": 15,
+                "cushion_after_obligation": 240_000,
+            },
+            {
+                "label": "T3",
+                "deposit_amount": 2_316_682,
+                "target_exchange_krw": 2_400_000,
+                "buffer_days": 30,
+                "cushion_after_obligation": 1_440_000,
+            },
+        ],
+        "hard_gate_candidates": [
+            {
+                "symbol": "SOL",
+                "proposal": "SOL 현물 8~10개 부분매도",
+                "amount_range": "1.13~1.40M KRW",
+            }
+        ],
+        "data_sufficient_by_symbol": {"BTC": True, "SOL": True},
+        "btc_regime": {
+            "close_vs_20d_ma": "above",
+            "ma20_slope": "flat",
+            "drawdown_14d_pct": -3.2,
+        },
+        "weights_top_n": [
+            {"symbol": "SOL", "weight_pct": 32},
+            {"symbol": "ETH", "weight_pct": 28},
+            {"symbol": "BTC", "weight_pct": 11},
+            {"symbol": "XRP", "weight_pct": 11},
+            {"symbol": "LINK", "weight_pct": 10},
+        ],
+        "holdings": [
+            {"symbol": "SOL", "current_krw_value": 3_200_000, "dust": False},
+            {"symbol": "ETH", "current_krw_value": 2_800_000, "dust": False},
+            {"symbol": "BTC", "current_krw_value": 1_100_000, "dust": False},
+            {"symbol": "XRP", "current_krw_value": 1_100_000, "dust": False},
+            {"symbol": "LINK", "current_krw_value": 1_000_000, "dust": False},
+            {"symbol": "APT", "current_krw_value": 654, "dust": True},
+        ],
+        "dust_items": [{"symbol": "APT", "current_krw_value": 654}],
+        "gate_results": {
+            "G1": GateResult(status="pass", detail="데이터 충분"),
+            "G2": N8nG2GatePayload(
+                passed=True,
+                status="pass",
+                detail="운영 runway 복구",
+            ),
+            "G3": GateResult(status="pass", detail="cushion 충족"),
+            "G4": GateResult(status="pass", detail="BTC regime 통과"),
+            "G5": GateResult(status="pass", detail="volatility halt 없음"),
+            "G6": GateResult(status="pass", detail="RSI=45 보조지표 통과"),
+        },
+    }
+    payload.update(updates)
+    return payload
+
+
+def plan_v2_section_f_context(**updates: Any) -> BoardBriefContext:
+    return BoardBriefContext.model_validate(plan_v2_section_f_dataset(**updates))
+
+
+def drop_required_field(field: str) -> dict[str, Any]:
+    payload = deepcopy(plan_v2_section_f_dataset())
+    if field in {
+        "exchange_krw",
+        "unverified_cap",
+        "next_obligation",
+        "tier_scenarios",
+        "data_sufficient_by_symbol",
+        "btc_regime",
+        "holdings",
+    }:
+        payload.pop(field)
+    else:
+        raise ValueError(f"Unknown required field: {field}")
+    return payload
+
+
+def replace_once(old: str, new: str) -> Callable[[str], str]:
+    def _postprocess(text: str) -> str:
+        assert old in text
+        return text.replace(old, new, 1)
+
+    return _postprocess
+
+
+class RecordingRouter(RenderRouter):
+    def __init__(self) -> None:
+        self.board_messages: list[str] = []
+        self.ops_messages: list[str] = []
+
+    def route_board(self, message: str) -> None:
+        self.board_messages.append(message)
+
+    def route_ops_escalation(self, message: str) -> None:
+        self.ops_messages.append(message)

--- a/tests/test_board_brief_render_v2.py
+++ b/tests/test_board_brief_render_v2.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from app.schemas.n8n.board_brief import BoardBriefContext, BoardFundingResponse
+from app.services.n8n_daily_brief_service import (
+    build_cio_pending_decision,
+    build_tc_preliminary,
+    resolve_funding_intent,
+)
+
+
+def _v2_context() -> BoardBriefContext:
+    return BoardBriefContext.model_validate(
+        {
+            "exchange_krw": 1_000_000,
+            "unverified_cap": {
+                "amount": 5_000_000,
+                "verified_by_boss_today": False,
+                "stale_warning": True,
+            },
+            "daily_burn_krw": 100_000,
+            "next_obligation": {
+                "date": "2026-04-24",
+                "days_remaining": 7,
+                "cash_needed_until": 2_500_000,
+            },
+            "tier_scenarios": [
+                {
+                    "label": "T1",
+                    "deposit_amount": 1_500_000,
+                    "target_exchange_krw": 2_500_000,
+                    "buffer_days": 25,
+                    "cushion_after_obligation": 0,
+                },
+                {
+                    "label": "T2",
+                    "deposit_amount": 3_500_000,
+                    "target_exchange_krw": 4_500_000,
+                    "buffer_days": 45,
+                    "cushion_after_obligation": 2_000_000,
+                },
+            ],
+            "holdings": [
+                {"symbol": "BTC", "current_krw_value": 7_000_000, "dust": False},
+                {"symbol": "DOGE", "current_krw_value": 3_000, "dust": True},
+                {"symbol": "XRP", "current_krw_value": 2_000, "dust": True},
+            ],
+            "dust_items": [
+                {"symbol": "DOGE", "current_krw_value": 3_000},
+                {"symbol": "XRP", "current_krw_value": 2_000},
+            ],
+        }
+    )
+
+
+def _context_with_updates(**updates: object) -> BoardBriefContext:
+    return BoardBriefContext.model_validate(
+        _v2_context().model_dump(mode="json") | updates
+    )
+
+
+def test_resolve_funding_intent_prefers_runway_when_obligation_dominates() -> None:
+    ctx = _v2_context()
+    board_response = BoardFundingResponse(
+        amount=1_000_000,
+        target="BTC",
+        funding_intent="new_buy",
+        manual_cash_verified=True,
+    )
+
+    intent, lines = resolve_funding_intent(ctx, board_response)
+
+    assert intent == "runway_recovery"
+    assert lines == [
+        "- 이번 1,000,000 원은 **운영 연료** 로 귀속 — coinmoogi DCA 7 일 지속분 + 만기 cushion.",
+        "- 신규 매수 여력으로 전용 금지. G2 에서 차단.",
+    ]
+
+
+def test_resolve_funding_intent_allows_verified_target_as_new_buy() -> None:
+    ctx = _context_with_updates(
+        next_obligation={
+            "date": "2026-04-24",
+            "days_remaining": 7,
+            "cash_needed_until": 1_500_000,
+        }
+    )
+    board_response = BoardFundingResponse(
+        amount=1_000_000,
+        target="BTC",
+        funding_intent="runway_recovery",
+        manual_cash_verified=True,
+    )
+
+    intent, lines = resolve_funding_intent(ctx, board_response)
+
+    assert intent == "new_buy"
+    assert lines == [
+        "- 이번 1,000,000 원은 G3 (runway/obligation) 통과 후 신규 risk budget 후보.",
+        "- 이 경우에도 G4 시장 regime → G5 volatility halt → G6 보조지표 통과 여부 추가 판정 필요.",
+    ]
+
+
+def test_resolve_funding_intent_defaults_unverified_target_to_runway() -> None:
+    ctx = _context_with_updates(
+        next_obligation={
+            "date": "2026-04-24",
+            "days_remaining": 7,
+            "cash_needed_until": 1_500_000,
+        }
+    )
+    board_response = BoardFundingResponse(
+        amount=1_000_000,
+        target="BTC",
+        funding_intent="new_buy",
+        manual_cash_verified=False,
+    )
+
+    intent, lines = resolve_funding_intent(ctx, board_response)
+
+    assert intent == "runway_recovery"
+    assert lines == [
+        "- 이번 1,000,000 원은 **운영 연료** 로 귀속 — coinmoogi DCA 7 일 지속분 + 만기 cushion.",
+        "- 신규 매수 여력으로 전용 금지. G2 에서 차단.",
+    ]
+
+
+def test_tc_preliminary_renders_v2_cash_dust_and_tier_sections() -> None:
+    render = build_tc_preliminary(_v2_context())
+    text = render.text
+
+    assert text.startswith(
+        "📊 TC Preliminary — 입금 약속 반영 시나리오 (pledged, 거래소 미반영)"
+    )
+    assert text.index("거래소 KRW") < text.index("미확인 cap (보스 확인 전)")
+    assert text.index("미확인 cap (보스 확인 전)") < text.index(
+        "일일 소진 (daily_burn)"
+    )
+    assert text.index("일일 소진 (daily_burn)") < text.index("다음 의무")
+    assert text.index("다음 의무") < text.index("runway 산식")
+    assert "runway 산식: 1,000,000 KRW / 100,000 KRW = 10.00일" in text
+    assert "🧹 Dust 2종목 · 합계 5,000 KRW · 포트폴리오 0.07%" in text
+    assert (
+        "deposit_amount | next_obligation | cash_needed_until | "
+        "cushion_after_obligation | target_exchange_krw | buffer_days (보조)"
+    ) in text
+    assert "1,500,000 KRW | 2026-04-24 / D-7 | 2,500,000 KRW" in text
+    assert "**A 와 B 는 상호배타 아님 — 병행 가능.**" in text
+
+
+def test_cio_pending_injects_one_g2_phrase_set_and_question_tags() -> None:
+    ctx = _context_with_updates(
+        next_obligation={
+            "date": "2026-04-24",
+            "days_remaining": 7,
+            "cash_needed_until": 1_500_000,
+        },
+        board_response={
+            "amount": 1_000_000,
+            "target": "BTC",
+            "funding_intent": "new_buy",
+            "manual_cash_verified": True,
+        },
+    )
+
+    render = build_cio_pending_decision(ctx)
+    text = render.text
+
+    assert render.funding_intent == "new_buy"
+    assert text.count("신규 risk budget 후보") == 1
+    assert "운영 연료" not in text
+    assert "질문 (Step 1 답변 반영 — 재질문 아님)" in text
+    assert "[funding-confirmation]" in text
+    assert "[action]" in text

--- a/tests/test_board_brief_render_v2.py
+++ b/tests/test_board_brief_render_v2.py
@@ -39,6 +39,12 @@ def _v2_context() -> BoardBriefContext:
                     "cushion_after_obligation": 2_000_000,
                 },
             ],
+            "data_sufficient_by_symbol": {"BTC": True},
+            "btc_regime": {
+                "close_vs_20d_ma": "above",
+                "ma20_slope": "up",
+                "drawdown_14d_pct": -3.2,
+            },
             "holdings": [
                 {"symbol": "BTC", "current_krw_value": 7_000_000, "dust": False},
                 {"symbol": "DOGE", "current_krw_value": 3_000, "dust": True},

--- a/tests/test_board_brief_schema_v2.py
+++ b/tests/test_board_brief_schema_v2.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.n8n.board_brief import (
+    BoardBriefContext,
+    BtcRegimePayload,
+    CIOFollowupRequest,
+    HardGateCandidate,
+    NextObligationPayload,
+    TCFollowupRequest,
+    TierScenario,
+    UnverifiedCapPayload,
+)
+
+
+def _full_v2_payload() -> dict:
+    return {
+        "exchange_krw": 1_500_000,
+        "unverified_cap": {
+            "amount": 10_000_000,
+            "confirmed_at": "2026-04-17T09:30:00+09:00",
+            "verified_by_boss_today": True,
+            "stale_warning": False,
+        },
+        "next_obligation": {
+            "date": "2026-04-24",
+            "days_remaining": 7,
+            "cash_needed_until": 700_000,
+        },
+        "tier_scenarios": [
+            {
+                "label": "T1",
+                "target_exchange_krw": 2_000_000,
+                "deposit_amount": 500_000,
+                "buffer_days": 7,
+                "cushion_after_obligation": 1_300_000,
+            },
+            {
+                "label": "T2",
+                "target_exchange_krw": 5_000_000,
+                "deposit_amount": 3_500_000,
+                "buffer_days": 14,
+                "cushion_after_obligation": 4_300_000,
+            },
+        ],
+        "hard_gate_candidates": [
+            {
+                "symbol": "SOL",
+                "proposal": "부분매도",
+                "amount_range": "8~10 SOL",
+            }
+        ],
+        "data_sufficient_by_symbol": {"SOL": True, "BTC": False},
+        "btc_regime": {
+            "close_vs_20d_ma": "above",
+            "ma20_slope": "up",
+            "drawdown_14d_pct": 4.2,
+        },
+    }
+
+
+def test_board_brief_context_round_trips_full_v2_payload() -> None:
+    context = BoardBriefContext.model_validate(_full_v2_payload())
+
+    assert context.exchange_krw == 1_500_000
+    assert context.unverified_cap == UnverifiedCapPayload(
+        amount=10_000_000,
+        confirmed_at=datetime.fromisoformat("2026-04-17T09:30:00+09:00"),
+        verified_by_boss_today=True,
+        stale_warning=False,
+    )
+    assert context.next_obligation == NextObligationPayload(
+        date=date(2026, 4, 24),
+        days_remaining=7,
+        cash_needed_until=700_000,
+    )
+    assert context.tier_scenarios[0] == TierScenario(
+        label="T1",
+        target_exchange_krw=2_000_000,
+        deposit_amount=500_000,
+        buffer_days=7,
+        cushion_after_obligation=1_300_000,
+    )
+    assert context.hard_gate_candidates == [
+        HardGateCandidate(symbol="SOL", proposal="부분매도", amount_range="8~10 SOL")
+    ]
+    assert context.btc_regime == BtcRegimePayload(
+        close_vs_20d_ma="above",
+        ma20_slope="up",
+        drawdown_14d_pct=4.2,
+    )
+
+    dumped = context.model_dump(mode="json")
+    assert BoardBriefContext.model_validate(dumped) == context
+
+
+def test_board_brief_context_defaults_optional_v2_sections_cleanly() -> None:
+    context = BoardBriefContext()
+
+    assert context.exchange_krw == 0
+    assert context.unverified_cap is None
+    assert context.next_obligation is None
+    assert context.tier_scenarios == []
+    assert context.hard_gate_candidates == []
+    assert context.data_sufficient_by_symbol == {}
+    assert context.btc_regime is None
+    assert context.manual_cash_krw == 0
+
+
+@pytest.mark.parametrize(
+    ("model", "payload"),
+    [
+        (UnverifiedCapPayload, {"amount": -1}),
+        (
+            NextObligationPayload,
+            {"date": "2026-04-24", "days_remaining": -1, "cash_needed_until": 0},
+        ),
+        (
+            NextObligationPayload,
+            {"date": "2026-04-24", "days_remaining": 0, "cash_needed_until": -1},
+        ),
+        (
+            TierScenario,
+            {
+                "label": "T4",
+                "target_exchange_krw": 0,
+                "deposit_amount": 0,
+                "buffer_days": 0,
+                "cushion_after_obligation": 0,
+            },
+        ),
+        (
+            BtcRegimePayload,
+            {
+                "close_vs_20d_ma": "sideways",
+                "ma20_slope": "up",
+                "drawdown_14d_pct": 0,
+            },
+        ),
+    ],
+)
+def test_board_brief_v2_payloads_reject_invalid_values(
+    model: type, payload: dict
+) -> None:
+    with pytest.raises(ValidationError):
+        model.model_validate(payload)
+
+
+def test_followup_requests_accept_v2_fields_and_keep_manual_cash_compat() -> None:
+    payload = _full_v2_payload() | {"manual_cash_krw": 9_000_000}
+
+    tc_request = TCFollowupRequest.model_validate(payload)
+    cio_request = CIOFollowupRequest.model_validate(payload)
+
+    assert tc_request.manual_cash_krw == 9_000_000
+    assert tc_request.unverified_cap is not None
+    assert tc_request.unverified_cap.amount == 10_000_000
+    assert cio_request.tier_scenarios[1].label == "T2"
+    assert cio_request.btc_regime is not None
+    assert cio_request.btc_regime.ma20_slope == "up"

--- a/tests/test_cio_briefing_fail_closed.py
+++ b/tests/test_cio_briefing_fail_closed.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.n8n_daily_brief_service import build_cio_pending_decision
+from tests.fixtures.cio_briefing import RecordingRouter, drop_required_field
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "exchange_krw",
+        "unverified_cap",
+        "next_obligation",
+        "tier_scenarios",
+        "data_sufficient_by_symbol",
+        "btc_regime",
+        "holdings",
+    ],
+)
+def test_missing_required_context_fails_closed_and_routes_ops(field: str) -> None:
+    router = RecordingRouter()
+
+    render = build_cio_pending_decision(drop_required_field(field), router=router)
+
+    assert render.text.startswith(f"⚠️ {field} 누락")
+    assert render.embed == {}
+    assert router.board_messages == []
+    assert router.ops_messages == [render.text]

--- a/tests/test_cio_briefing_g2_precedence.py
+++ b/tests/test_cio_briefing_g2_precedence.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from app.services.n8n_daily_brief_service import build_cio_pending_decision
+from tests.fixtures.cio_briefing import plan_v2_section_f_context
+
+
+def test_target_is_ignored_when_runway_deficit_dominates() -> None:
+    ctx = plan_v2_section_f_context(
+        exchange_krw=83_318,
+        next_obligation={
+            "date": "2026-04-29",
+            "days_remaining": 12,
+            "cash_needed_until": 2_500_000,
+        },
+        board_response={
+            "amount": 1_200_000,
+            "target": "BTC",
+            "funding_intent": "new_buy",
+            "manual_cash_verified": True,
+        },
+    )
+
+    render = build_cio_pending_decision(ctx)
+
+    assert render.funding_intent == "runway_recovery"
+    assert "운영 연료" in render.text
+    assert "신규 risk budget 후보" not in render.text
+
+
+def test_verified_target_with_sufficient_runway_enters_new_buy() -> None:
+    ctx = plan_v2_section_f_context(
+        exchange_krw=1_200_000,
+        unverified_cap={
+            "amount": 10_000_000,
+            "verified_by_boss_today": True,
+            "stale_warning": False,
+        },
+        next_obligation={
+            "date": "2026-04-29",
+            "days_remaining": 12,
+            "cash_needed_until": 1_200_000,
+        },
+        board_response={
+            "amount": 1_200_000,
+            "target": "BTC",
+            "funding_intent": "runway_recovery",
+            "manual_cash_verified": True,
+        },
+    )
+
+    render = build_cio_pending_decision(ctx)
+
+    assert render.funding_intent == "new_buy"
+    assert "신규 risk budget 후보" in render.text
+    assert "운영 연료" not in render.text

--- a/tests/test_cio_briefing_g6_only_trigger.py
+++ b/tests/test_cio_briefing_g6_only_trigger.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from app.schemas.n8n.board_brief import GateResult, N8nG2GatePayload
+from app.services.n8n_daily_brief_service import (
+    RenderInvariantError,
+    build_cio_pending_decision,
+)
+from tests.fixtures.cio_briefing import plan_v2_section_f_context
+
+
+def test_g6_rsi_trigger_cannot_emit_immediate_buy_when_upper_gate_fails() -> None:
+    ctx = plan_v2_section_f_context(
+        gate_results={
+            "G1": GateResult(status="fail", detail="target OHLCV missing"),
+            "G2": N8nG2GatePayload(
+                passed=False,
+                status="fail",
+                blocking_reason="runway recovery only",
+            ),
+            "G3": GateResult(status="fail", detail="obligation cushion negative"),
+            "G4": GateResult(status="fail", detail="target below 20D MA"),
+            "G5": GateResult(status="fail", detail="24h volatility halt"),
+            "G6": GateResult(status="pass", detail="RSI=30 oversold trigger"),
+        }
+    )
+
+    with pytest.raises(RenderInvariantError) as exc_info:
+        build_cio_pending_decision(
+            ctx,
+            text_postprocessor=lambda text: text + "\nCIO 권고 (1) 즉시 매수",
+        )
+
+    assert [violation.code for violation in exc_info.value.violations] == [
+        "immediate_buy_requires_g2_g5_pass"
+    ]
+    assert exc_info.value.violations[0].detail == (
+        "immediate buy rendered while G2, G3, G4, G5 not pass"
+    )

--- a/tests/test_cio_briefing_render_invariants.py
+++ b/tests/test_cio_briefing_render_invariants.py
@@ -1,112 +1,107 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 
-from app.schemas.n8n.board_brief import BoardBriefContext
+from app.schemas.n8n.board_brief import GateResult
 from app.services.n8n_daily_brief_service import (
-    InvariantViolation,
     RenderInvariantError,
-    RenderRouter,
     build_cio_pending_decision,
-    build_tc_preliminary,
     validate_render_invariants,
 )
+from tests.fixtures.cio_briefing import plan_v2_section_f_context, replace_once
 
 
-def _v2_context(**updates: object) -> BoardBriefContext:
-    payload = {
-        "exchange_krw": 1_000_000,
-        "unverified_cap": {
-            "amount": 5_000_000,
-            "verified_by_boss_today": False,
-        },
-        "daily_burn_krw": 100_000,
-        "next_obligation": {
-            "date": "2026-04-24",
-            "days_remaining": 7,
-            "cash_needed_until": 2_500_000,
-        },
-        "tier_scenarios": [
-            {
-                "label": "T1",
-                "deposit_amount": 1_500_000,
-                "target_exchange_krw": 2_500_000,
-                "buffer_days": 25,
-                "cushion_after_obligation": 0,
-            },
-        ],
-        "data_sufficient_by_symbol": {"BTC": True},
-        "btc_regime": {
-            "close_vs_20d_ma": "above",
-            "ma20_slope": "up",
-            "drawdown_14d_pct": -3.2,
-        },
-        "holdings": [
-            {"symbol": "BTC", "current_krw_value": 1_000_000, "dust": False},
-            {"symbol": "DOGE", "current_krw_value": 3_000, "dust": True},
-        ],
-        "dust_items": [{"symbol": "DOGE", "current_krw_value": 3_000}],
-    }
-    payload.update(updates)
-    return BoardBriefContext.model_validate(payload)
+def _append_immediate_buy(text: str) -> str:
+    return text + "\nCIO 권고 (1) 즉시 매수"
 
 
-class RecordingRouter(RenderRouter):
-    def __init__(self) -> None:
-        self.ops_messages: list[str] = []
-
-    def route_ops_escalation(self, message: str) -> None:
-        self.ops_messages.append(message)
+def _append_fail_closed_anchor(text: str) -> str:
+    return text + "\n⚠️ synthetic 누락 — 테스트 anchor"
 
 
-def test_missing_required_context_returns_anchor_only_and_routes_ops() -> None:
-    router = RecordingRouter()
-    ctx = _v2_context(unverified_cap=None)
-
-    render = build_tc_preliminary(ctx, router=router)
-
-    assert render.text == "⚠️ unverified_cap 누락 — manual_cash 관련 권고/문구 생성 금지"
-    assert render.embed == {}
-    assert router.ops_messages == [render.text]
+def _duplicate_dust_line(text: str) -> str:
+    dust_line = next(line for line in text.splitlines() if line.startswith("🧹 Dust"))
+    return text + f"\n{dust_line}"
 
 
-def test_forbidden_pattern_blocks_partial_render_and_routes_ops() -> None:
-    router = RecordingRouter()
-    ctx = _v2_context()
+INVARIANT_CASES: list[tuple[str, Callable[[str], str], str]] = [
+    (
+        "funding_rows",
+        replace_once("- 거래소 KRW:", "- 거래소 원화:"),
+        "funding_rows",
+    ),
+    (
+        "runway_excludes_unverified_cap",
+        replace_once(
+            "runway 산식: 83,318 KRW / 80,000 KRW = 1.04일",
+            "runway 산식: 83,318 KRW + 10,000,000 KRW / 80,000 KRW = 126.04일",
+        ),
+        "runway_excludes_unverified_cap",
+    ),
+    (
+        "ab_anchor_triple",
+        replace_once(
+            "경로 A (입금) 와 경로 B (현물 부분매도) 는 **상호배타 아님**. 병행 가능합니다.",
+            "경로 A와 경로 B를 검토합니다.",
+        ),
+        "ab_anchor_triple",
+    ),
+    (
+        "g2_phrase_exactly_one",
+        lambda text: (
+            text
+            + "\n- 이번 1,200,000 원은 G3 (runway/obligation) 통과 후 신규 risk budget 후보."
+        ),
+        "g2_phrase_exactly_one",
+    ),
+    (
+        "immediate_buy_requires_g2_g5_pass",
+        _append_immediate_buy,
+        "immediate_buy_requires_g2_g5_pass",
+    ),
+    ("dust_aggregate", _duplicate_dust_line, "dust_aggregate"),
+    ("fail_closed_anchor", _append_fail_closed_anchor, "fail_closed_anchor"),
+]
+
+
+@pytest.mark.parametrize(
+    ("case_name", "mutate", "violation_code"),
+    INVARIANT_CASES,
+    ids=[case[0] for case in INVARIANT_CASES],
+)
+def test_render_invariant_positive_and_negative_fixtures(
+    case_name: str,
+    mutate: Callable[[str], str],
+    violation_code: str,
+) -> None:
+    ctx = plan_v2_section_f_context()
+    positive = build_cio_pending_decision(ctx).text
+    if case_name == "immediate_buy_requires_g2_g5_pass":
+        positive = _append_immediate_buy(positive)
+        assert validate_render_invariants(positive, ctx, phase="cio_pending") == []
+        negative_ctx = ctx.model_copy(
+            update={
+                "gate_results": ctx.gate_results
+                | {"G4": GateResult(status="fail", detail="target below MA20")}
+            }
+        )
+    else:
+        assert validate_render_invariants(positive, ctx, phase="cio_pending") == []
+        negative_ctx = ctx
 
     with pytest.raises(RenderInvariantError) as exc_info:
-        build_cio_pending_decision(
-            ctx,
-            router=router,
-            text_postprocessor=lambda text: text + "\n가용 현금 1000000",
-        )
+        build_cio_pending_decision(negative_ctx, text_postprocessor=mutate)
 
-    assert exc_info.value.violations == [
-        InvariantViolation(
-            code="forbidden_pattern",
-            detail=r"가용\s*현금[^(]*\d",
-        )
+    assert [violation.code for violation in exc_info.value.violations] == [
+        violation_code
     ]
-    assert router.ops_messages
-    assert "forbidden_pattern" in router.ops_messages[0]
 
 
-def test_validate_render_invariants_reports_structural_violations() -> None:
-    ctx = _v2_context()
-    text = "\n".join(
-        [
-            "💵 자금 현황",
-            "- 거래소 KRW: 1,000,000 KRW",
-            "- runway 산식: 1,000,000 KRW + 5,000,000 KRW / 100,000 KRW = 60.00일",
-            "경로 A: 신규 매수 없이 현금 runway 회복 우선.",
-            "🧹 Dust 1종목 · 합계 3,000 KRW · 포트폴리오 0.30%",
-        ]
-    )
+def test_full_suite_pass_plan_v2_section_f_sample() -> None:
+    ctx = plan_v2_section_f_context()
 
-    violations = validate_render_invariants(text, ctx, phase="cio_pending")
+    render = build_cio_pending_decision(ctx)
 
-    codes = {violation.code for violation in violations}
-    assert "funding_rows" in codes
-    assert "runway_excludes_unverified_cap" in codes
-    assert "ab_anchor_triple" in codes
-    assert "g2_phrase_exactly_one" in codes
+    assert validate_render_invariants(render.text, ctx, phase="cio_pending") == []

--- a/tests/test_cio_briefing_render_invariants.py
+++ b/tests/test_cio_briefing_render_invariants.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import pytest
+
+from app.schemas.n8n.board_brief import BoardBriefContext
+from app.services.n8n_daily_brief_service import (
+    InvariantViolation,
+    RenderInvariantError,
+    RenderRouter,
+    build_cio_pending_decision,
+    build_tc_preliminary,
+    validate_render_invariants,
+)
+
+
+def _v2_context(**updates: object) -> BoardBriefContext:
+    payload = {
+        "exchange_krw": 1_000_000,
+        "unverified_cap": {
+            "amount": 5_000_000,
+            "verified_by_boss_today": False,
+        },
+        "daily_burn_krw": 100_000,
+        "next_obligation": {
+            "date": "2026-04-24",
+            "days_remaining": 7,
+            "cash_needed_until": 2_500_000,
+        },
+        "tier_scenarios": [
+            {
+                "label": "T1",
+                "deposit_amount": 1_500_000,
+                "target_exchange_krw": 2_500_000,
+                "buffer_days": 25,
+                "cushion_after_obligation": 0,
+            },
+        ],
+        "data_sufficient_by_symbol": {"BTC": True},
+        "btc_regime": {
+            "close_vs_20d_ma": "above",
+            "ma20_slope": "up",
+            "drawdown_14d_pct": -3.2,
+        },
+        "holdings": [
+            {"symbol": "BTC", "current_krw_value": 1_000_000, "dust": False},
+            {"symbol": "DOGE", "current_krw_value": 3_000, "dust": True},
+        ],
+        "dust_items": [{"symbol": "DOGE", "current_krw_value": 3_000}],
+    }
+    payload.update(updates)
+    return BoardBriefContext.model_validate(payload)
+
+
+class RecordingRouter(RenderRouter):
+    def __init__(self) -> None:
+        self.ops_messages: list[str] = []
+
+    def route_ops_escalation(self, message: str) -> None:
+        self.ops_messages.append(message)
+
+
+def test_missing_required_context_returns_anchor_only_and_routes_ops() -> None:
+    router = RecordingRouter()
+    ctx = _v2_context(unverified_cap=None)
+
+    render = build_tc_preliminary(ctx, router=router)
+
+    assert render.text == "⚠️ unverified_cap 누락 — manual_cash 관련 권고/문구 생성 금지"
+    assert render.embed == {}
+    assert router.ops_messages == [render.text]
+
+
+def test_forbidden_pattern_blocks_partial_render_and_routes_ops() -> None:
+    router = RecordingRouter()
+    ctx = _v2_context()
+
+    with pytest.raises(RenderInvariantError) as exc_info:
+        build_cio_pending_decision(
+            ctx,
+            router=router,
+            text_postprocessor=lambda text: text + "\n가용 현금 1000000",
+        )
+
+    assert exc_info.value.violations == [
+        InvariantViolation(
+            code="forbidden_pattern",
+            detail=r"가용\s*현금[^(]*\d",
+        )
+    ]
+    assert router.ops_messages
+    assert "forbidden_pattern" in router.ops_messages[0]
+
+
+def test_validate_render_invariants_reports_structural_violations() -> None:
+    ctx = _v2_context()
+    text = "\n".join(
+        [
+            "💵 자금 현황",
+            "- 거래소 KRW: 1,000,000 KRW",
+            "- runway 산식: 1,000,000 KRW + 5,000,000 KRW / 100,000 KRW = 60.00일",
+            "경로 A: 신규 매수 없이 현금 runway 회복 우선.",
+            "🧹 Dust 1종목 · 합계 3,000 KRW · 포트폴리오 0.30%",
+        ]
+    )
+
+    violations = validate_render_invariants(text, ctx, phase="cio_pending")
+
+    codes = {violation.code for violation in violations}
+    assert "funding_rows" in codes
+    assert "runway_excludes_unverified_cap" in codes
+    assert "ab_anchor_triple" in codes
+    assert "g2_phrase_exactly_one" in codes

--- a/tests/test_cio_briefing_service_branch_coverage.py
+++ b/tests/test_cio_briefing_service_branch_coverage.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.schemas.n8n.board_brief import BoardBriefContext
+from app.services.n8n_daily_brief_service import (
+    RenderInvariantError,
+    RenderRouter,
+    _build_candidate_lines,
+    _build_concentration_lines,
+    _build_tier_lines,
+    _cash_runway_days,
+    _collect_symbols_by_market,
+    _format_unverified_amounts,
+    _gate_passed,
+    build_cio_pending_decision,
+    build_tc_preliminary,
+    resolve_funding_intent,
+)
+from tests.fixtures.cio_briefing import drop_required_field, plan_v2_section_f_context
+
+
+def test_renderer_helper_fallback_branches() -> None:
+    assert (
+        _format_unverified_amounts(plan_v2_section_f_context(unverified_cap=None))
+        == set()
+    )
+    assert _gate_passed(None) is False
+    assert (
+        _cash_runway_days(plan_v2_section_f_context(manual_cash_runway_days=7.5)) == 7.5
+    )
+    assert (
+        _cash_runway_days(BoardBriefContext(manual_cash_krw=1_000, daily_burn_krw=100))
+        == 10
+    )
+    assert _cash_runway_days(BoardBriefContext(manual_cash_krw=1_000)) is None
+    assert _build_concentration_lines(plan_v2_section_f_context(weights_top_n=[])) == [
+        "- 상위 비중 데이터 없음"
+    ]
+    assert _build_candidate_lines(
+        plan_v2_section_f_context(
+            holdings=[{"symbol": "APT", "current_krw_value": 654, "dust": True}]
+        )
+    ) == ["- execution-actionable 매도/축소 후보 없음"]
+    assert _build_tier_lines(plan_v2_section_f_context(tier_scenarios=[])) == [
+        "tier_scenarios 미수신, 입금 시나리오 산출 보류"
+    ]
+    assert (
+        resolve_funding_intent(plan_v2_section_f_context(next_obligation=None), None)[0]
+        == "runway_recovery"
+    )
+
+
+def test_collect_symbols_normalizes_crypto_and_skips_incomplete_rows() -> None:
+    symbols_by_market = _collect_symbols_by_market(
+        {
+            "orders": [
+                {"market": "crypto", "symbol": "KRW-ETH"},
+                {"market": "", "symbol": "IGNORED"},
+            ]
+        },
+        {
+            "positions": [
+                {"market_type": "CRYPTO", "symbol": "btc"},
+                {"market_type": "KR", "symbol": ""},
+            ]
+        },
+    )
+
+    assert symbols_by_market == {"crypto": {"KRW-ETH", "KRW-BTC"}}
+
+
+def test_tc_preliminary_missing_context_fails_closed() -> None:
+    render = build_tc_preliminary(drop_required_field("exchange_krw"))
+
+    assert render.text.startswith("⚠️ exchange_krw 누락")
+    assert render.embed == {}
+
+
+def test_forbidden_pattern_routes_ops_and_raises() -> None:
+    with pytest.raises(RenderInvariantError) as exc_info:
+        build_cio_pending_decision(
+            plan_v2_section_f_context(),
+            text_postprocessor=lambda text: text + "\nPlanning cash 100",
+        )
+
+    assert [violation.code for violation in exc_info.value.violations] == [
+        "forbidden_pattern"
+    ]
+
+
+def test_default_router_posts_ops_escalation(monkeypatch: pytest.MonkeyPatch) -> None:
+    posted: list[tuple[str, dict[str, str]]] = []
+
+    class FakeClient:
+        def __init__(self, timeout: int) -> None:
+            self.timeout = timeout
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def post(self, url: str, json: dict[str, str]) -> None:
+            posted.append((url, json))
+
+    monkeypatch.setenv("N8N_OPS_ESCALATION_WEBHOOK", "https://ops.example/hook")
+    monkeypatch.setattr(httpx, "Client", FakeClient)
+
+    RenderRouter().route_ops_escalation("blocked")
+
+    assert posted == [("https://ops.example/hook", {"content": "blocked"})]

--- a/tests/test_n8n_daily_brief_formatting.py
+++ b/tests/test_n8n_daily_brief_formatting.py
@@ -136,6 +136,28 @@ class TestBoardBriefBuilders:
         from app.schemas.n8n.board_brief import BoardBriefContext
 
         return BoardBriefContext(
+            exchange_krw=1_000_000,
+            unverified_cap={"amount": 5_000_000},
+            next_obligation={
+                "date": "2026-04-24",
+                "days_remaining": 7,
+                "cash_needed_until": 2_500_000,
+            },
+            tier_scenarios=[
+                {
+                    "label": "T1",
+                    "deposit_amount": 1_500_000,
+                    "target_exchange_krw": 2_500_000,
+                    "buffer_days": 25,
+                    "cushion_after_obligation": 0,
+                }
+            ],
+            data_sufficient_by_symbol={"BTC": True},
+            btc_regime={
+                "close_vs_20d_ma": "above",
+                "ma20_slope": "up",
+                "drawdown_14d_pct": -3.2,
+            },
             manual_cash_krw=1_250_000,
             daily_burn_krw=50_000,
             weights_top_n=[{"symbol": "BTC", "weight_pct": 42.5}],

--- a/tests/test_n8n_daily_brief_formatting.py
+++ b/tests/test_n8n_daily_brief_formatting.py
@@ -155,7 +155,7 @@ class TestBoardBriefBuilders:
         assert render.phase == "tc_preliminary"
         assert "경로 A·B 병행 가능" in text
         assert "BTC" in text
-        assert "DOGE" in text
+        assert "🧹 Dust 1종목" in text
         assert "🎯 권고" not in text
         assert "📊 Gate 판정 결과" not in text
         assert "[funding]" not in text
@@ -189,6 +189,7 @@ class TestBoardBriefBuilders:
         assert "📊 Gate 판정 결과" in text
         assert "🚫 신규 매수 차단 — G2 fail" in text
         assert "(3) 현금 우선 정책 적용" in text
-        assert "[funding]" in text
+        assert "[funding-confirmation]" in text
         assert "[action]" in text
-        assert text.count("경로 A·B 병행 가능") >= 2
+        assert "경로 A·B 병행 가능" in text
+        assert "**A 와 B 는 상호배타 아님 — 병행 가능.**" in text

--- a/tests/test_n8n_followup_endpoints.py
+++ b/tests/test_n8n_followup_endpoints.py
@@ -36,10 +36,13 @@ class TestN8nFollowupEndpoints:
         body = resp.json()
         assert body["phase"] == "tc_preliminary"
         assert body["generated_at"]
-        assert body["embed"]["title"] == "📊 TC Preliminary — 자금 현황 재계산"
+        assert (
+            body["embed"]["title"]
+            == "📊 TC Preliminary — 입금 약속 반영 시나리오 (pledged, 거래소 미반영)"
+        )
         assert "경로 A·B 병행 가능" in body["text"]
         assert "BTC" in body["text"]
-        assert "DOGE" in body["text"]
+        assert "🧹 Dust 1종목" in body["text"]
         assert "🎯 권고" not in body["text"]
         assert "📊 Gate 판정 결과" not in body["text"]
 
@@ -84,7 +87,7 @@ class TestN8nFollowupEndpoints:
         assert "🚫 신규 매수 차단 — G2 fail" in body["text"]
         assert "(3) 현금 우선 정책 적용" in body["text"]
         assert "📊 Gate 판정 결과" in body["text"]
-        assert "[funding]" in body["text"]
+        assert "[funding-confirmation]" in body["text"]
         assert "[action]" in body["text"]
 
     def test_evaluate_g1_gate_pass_ignores_force_cash_policy_note(self) -> None:

--- a/tests/test_n8n_followup_endpoints.py
+++ b/tests/test_n8n_followup_endpoints.py
@@ -14,12 +14,46 @@ class TestN8nFollowupEndpoints:
         app.include_router(router)
         return TestClient(app)
 
+    def _required_v2_payload(self) -> dict:
+        return {
+            "exchange_krw": 1_000_000,
+            "unverified_cap": {"amount": 5_000_000},
+            "next_obligation": {
+                "date": "2026-04-24",
+                "days_remaining": 7,
+                "cash_needed_until": 2_500_000,
+            },
+            "tier_scenarios": [
+                {
+                    "label": "T1",
+                    "deposit_amount": 1_500_000,
+                    "target_exchange_krw": 2_500_000,
+                    "buffer_days": 25,
+                    "cushion_after_obligation": 0,
+                }
+            ],
+            "data_sufficient_by_symbol": {"BTC": True},
+            "btc_regime": {
+                "close_vs_20d_ma": "above",
+                "ma20_slope": "up",
+                "drawdown_14d_pct": -3.2,
+            },
+            "holdings": [
+                {"symbol": "BTC", "current_krw_value": 1_000_000, "dust": False},
+                {"symbol": "DOGE", "current_krw_value": 3_000, "dust": True},
+            ],
+            "dust_items": [
+                {"symbol": "DOGE", "current_krw_value": 3_000, "dust": True}
+            ],
+        }
+
     def test_tc_followup_returns_preliminary_render(self) -> None:
         client = self._get_client()
 
         resp = client.post(
             "/api/n8n/tc-followup",
             json={
+                **self._required_v2_payload(),
                 "manual_cash_krw": 1_250_000,
                 "daily_burn_krw": 50_000,
                 "weights_top_n": [{"symbol": "BTC", "weight_pct": 42.5}],
@@ -52,6 +86,7 @@ class TestN8nFollowupEndpoints:
         resp = client.post(
             "/api/n8n/cio-followup",
             json={
+                **self._required_v2_payload(),
                 "manual_cash_krw": 700_000,
                 "daily_burn_krw": 100_000,
                 "manual_cash_runway_days": 7,
@@ -96,6 +131,7 @@ class TestN8nFollowupEndpoints:
         resp = client.post(
             "/api/n8n/cio-followup",
             json={
+                **self._required_v2_payload(),
                 "manual_cash_krw": 1_500_000,
                 "daily_burn_krw": 100_000,
                 "manual_cash_runway_days": 15,

--- a/tests/test_plan_v2_section_g_checklist.py
+++ b/tests/test_plan_v2_section_g_checklist.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from app.services.n8n_daily_brief_service import (
+    build_cio_pending_decision,
+    build_tc_preliminary,
+    validate_render_invariants,
+)
+from tests.fixtures.cio_briefing import plan_v2_section_f_context
+
+
+def test_plan_v2_section_g_checklist() -> None:
+    ctx = plan_v2_section_f_context()
+
+    tc_render = build_tc_preliminary(ctx)
+    cio_render = build_cio_pending_decision(ctx)
+    combined_text = tc_render.text + "\n" + cio_render.text
+
+    checks = {
+        "framing_box_top": tc_render.text.splitlines()[2].startswith(
+            "요약: 경로 A·B 병행 가능."
+        ),
+        "cash_rows_separate": "거래소 KRW:" in tc_render.text
+        and "미확인 cap (보스 확인 전):" in tc_render.text,
+        "unverified_flags": all(
+            flag in tc_render.text
+            for flag in [
+                "미확인 cap (보스 확인 전): 10,000,000 KRW",
+                "stale_warning",
+            ]
+        ),
+        "daily_burn_rendered": "일일 소진 (daily_burn): 80,000 KRW" in tc_render.text,
+        "dust_excluded_from_actionable_table": "APT: 654 KRW" not in combined_text,
+        "dust_footnote_one_line": sum(
+            1 for line in tc_render.text.splitlines() if line.startswith("🧹 Dust")
+        )
+        == 1,
+        "three_tier_obligation_table": all(
+            item in tc_render.text
+            for item in ["516,682 KRW", "1,116,682 KRW", "2,316,682 KRW"]
+        )
+        and "cushion_after_obligation" in tc_render.text,
+        "default_rule_matches_sample": cio_render.funding_intent == "runway_recovery"
+        and "운영 연료" in cio_render.text,
+        "path_a_b_split": "경로 A:" in tc_render.text and "경로 B:" in tc_render.text,
+        "two_block_followup": "TC Preliminary" in tc_render.text
+        and "CIO Pending Decision" in cio_render.embed["title"],
+        "g1_g6_order": all(f"- G{idx}:" in cio_render.text for idx in range(1, 7))
+        and cio_render.text.index("- G1:") < cio_render.text.index("- G6:"),
+        "board_questions_split": "[funding-confirmation]" in cio_render.text
+        and "[action]" in cio_render.text
+        and cio_render.text.index("[funding-confirmation]")
+        < cio_render.text.index("[action]"),
+    }
+
+    assert validate_render_invariants(tc_render.text, ctx, phase="tc_preliminary") == []
+    assert validate_render_invariants(cio_render.text, ctx, phase="cio_pending") == []
+    failed_checks = {name: value for name, value in checks.items() if not value}
+    assert failed_checks == {}


### PR DESCRIPTION
## Summary

Stacked on top of #562 (ROB-142 S1 prompt). Wires the S2-S5 integration layer so the coin board briefing v2 is end-to-end functional with fail-closed render semantics.

Merge order: #562 → this PR. After #562 merges, this PR will auto-retarget to `main`.

## Scope (S2–S5)

- **S2 — schema v2 fields** ([ROB-228](/ROB/issues/ROB-228))
  - Commit: `7a38007 feat: add board brief schema v2 fields`
- **S3 — render wiring (funding intent)** ([ROB-230](/ROB/issues/ROB-230))
  - Commit: `e8e16d3 feat: wire board brief render v2 funding intent`
- **S4 — fail-closed render invariants** ([ROB-232](/ROB/issues/ROB-232))
  - Commit: `23e8a16 feat: add board brief fail-closed render invariants`
- **S5 — integration checklist coverage** ([ROB-234](/ROB/issues/ROB-234))
  - Commit: `51031fa test: add CIO briefing integration checklist coverage`

## CR signoff

- [ROB-228](/ROB/issues/ROB-228) — S2 schema v2 fields
- [ROB-230](/ROB/issues/ROB-230) — S3 render v2 funding intent
- [ROB-232](/ROB/issues/ROB-232) — S4 fail-closed render invariants
- [ROB-234](/ROB/issues/ROB-234) — S5 integration checklist coverage

Parent issue: [ROB-142](/ROB/issues/ROB-142) · Integration tracker: [ROB-221](/ROB/issues/ROB-221)

## Test plan

- [ ] S2 schema tests pass
- [ ] S3 render wiring tests pass
- [ ] S4 fail-closed invariants tests pass
- [ ] S5 integration checklist suite passes
- [ ] `git merge-base --is-ancestor origin/feature/ROB-142-cio-briefing-prompt-v2 origin/feature/ROB-233-integration-tests` confirms stack
