### PR TITLE
[ROB-244] Guard MCP caller env fallback

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -866,7 +866,9 @@ target trader agent id.
   header in a production path is an outage, not a soft warning.
 - Local dev / stdio transports that cannot send HTTP headers may export
   `MCP_CALLER_AGENT_ID` as an env fallback. This is a dev convenience only —
-  production callers must send the header explicitly.
+  production callers must send the header explicitly. `MCP_CALLER_AGENT_ID`
+  MUST NOT be set in production HTTP deployments because it re-opens a caller
+  spoofing vector for requests that omit `x-paperclip-agent-id`.
 
 ### Scout / Trader curl bridge
 
@@ -905,7 +907,7 @@ Environment variables:
 - `MCP_PATH` : `/mcp`
 - `MCP_GRACEFUL_SHUTDOWN_TIMEOUT` : `10` (seconds, HTTP transports only: `sse` / `streamable-http`)
 - `MCP_USER_ID` : `1` (manual holdings 조회에 사용할 기본 사용자 ID)
-- `MCP_CALLER_AGENT_ID` : optional caller agent id fallback when no `x-paperclip-agent-id` HTTP header is present
+- `MCP_CALLER_AGENT_ID` : DEV/stdio only — MUST NOT be set in production HTTP deployments (re-opens caller spoofing vector)
 
 Example:
 ```bash

--- a/app/mcp_server/main.py
+++ b/app/mcp_server/main.py
@@ -51,6 +51,16 @@ mcp.add_middleware(CallerIdentityMiddleware())
 register_all_tools(mcp)
 
 
+def _validate_caller_agent_id_fallback(mcp_type: str) -> None:
+    fallback_agent_id = settings.mcp_caller_agent_id_fallback
+    if mcp_type in {"streamable-http", "sse"} and fallback_agent_id:
+        raise RuntimeError(
+            "MCP_CALLER_AGENT_ID is only allowed for stdio/local dev transports; "
+            "unset it for production HTTP deployments and send "
+            "x-paperclip-agent-id explicitly."
+        )
+
+
 def main() -> None:
     log_level_name = str(getattr(settings, "LOG_LEVEL", "INFO") or "INFO").upper()
     log_level = getattr(logging, log_level_name, logging.INFO)
@@ -73,6 +83,8 @@ def main() -> None:
     )
 
     try:
+        _validate_caller_agent_id_fallback(mcp_type)
+
         if mcp_type == "stdio":
             mcp.run(transport="stdio")
         elif mcp_type == "sse":

--- a/env.example
+++ b/env.example
@@ -137,7 +137,8 @@ MCP_PORT=8765
 MCP_PATH=/mcp
 # MCP 보유종목 조회용 사용자 ID (기본: 1)
 MCP_USER_ID=1
-# MCP caller identity fallback for local/manual calls when no HTTP header is present
+# MCP caller identity fallback: DEV/stdio only.
+# MUST NOT be set in production HTTP deployments because it re-opens caller spoofing.
 MCP_CALLER_AGENT_ID=
 # MCP 서버 Bearer Token 인증 (비워두면 인증 비활성)
 # 라즈베리파이 배포 시 Tailscale 없이 HTTPS 보안을 위한 토큰 인증

--- a/scripts/templates/mcp_call.sh.tmpl
+++ b/scripts/templates/mcp_call.sh.tmpl
@@ -11,6 +11,8 @@
 #   to middleware-extracted HTTP header. Every caller MUST send the
 #   `x-paperclip-agent-id` header; otherwise defensive_trim and future
 #   caller-identity-gated tools reject the call.
+#   Do NOT set MCP_CALLER_AGENT_ID for this HTTP bridge. That env fallback is
+#   DEV/stdio only and MUST NOT be used in production HTTP deployments.
 #
 # Operator regeneration procedure (CIO / Scout / Trader operators):
 #   1. Export the three env vars below (values differ per host / session):

--- a/tests/test_mcp_server_main.py
+++ b/tests/test_mcp_server_main.py
@@ -109,6 +109,22 @@ class TestMcpServerMain:
             "caller-identity-middleware",
         ]
 
+    def test_non_integer_log_level_falls_back_to_info(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        module, mcp, _ = _load_main_module(monkeypatch)
+        module.settings.LOG_LEVEL = "BASIC_FORMAT"
+
+        module.main()
+
+        mcp.run.assert_called_once_with(
+            transport="streamable-http",
+            host="0.0.0.0",
+            port=8765,
+            path="/mcp",
+            uvicorn_config={"timeout_graceful_shutdown": 10},
+        )
+
     def test_streamable_http_uses_default_shutdown_timeout(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/test_mcp_server_main.py
+++ b/tests/test_mcp_server_main.py
@@ -179,10 +179,11 @@ class TestMcpServerMain:
 
         capture_exception.assert_called_once()
 
+    @pytest.mark.parametrize("transport", ["streamable-http", "sse"])
     def test_refuses_to_boot_when_env_fallback_set_on_http_transport(
-        self, monkeypatch: pytest.MonkeyPatch
+        self, monkeypatch: pytest.MonkeyPatch, transport: str
     ) -> None:
-        monkeypatch.setenv("MCP_TYPE", "streamable-http")
+        monkeypatch.setenv("MCP_TYPE", transport)
 
         module, mcp, capture_exception = _load_main_module(monkeypatch)
         module.settings.mcp_caller_agent_id_fallback = "trader-agent-id"
@@ -190,8 +191,7 @@ class TestMcpServerMain:
         with pytest.raises(
             RuntimeError,
             match=(
-                "MCP_CALLER_AGENT_ID is only allowed for stdio/local dev "
-                "transports"
+                "MCP_CALLER_AGENT_ID is only allowed for stdio/local dev transports"
             ),
         ):
             module.main()

--- a/tests/test_mcp_server_main.py
+++ b/tests/test_mcp_server_main.py
@@ -41,7 +41,10 @@ def _load_main_module(
     fake_mcp_package.__path__ = []
 
     fake_config = ModuleType("app.core.config")
-    fake_config.__dict__["settings"] = SimpleNamespace(LOG_LEVEL="INFO")
+    fake_config.__dict__["settings"] = SimpleNamespace(
+        LOG_LEVEL="INFO",
+        mcp_caller_agent_id_fallback=None,
+    )
 
     fake_auth = ModuleType("app.mcp_server.auth")
     fake_auth.__dict__["build_auth_provider"] = MagicMock(return_value="auth-provider")
@@ -175,3 +178,55 @@ class TestMcpServerMain:
             module.main()
 
         capture_exception.assert_called_once()
+
+    def test_refuses_to_boot_when_env_fallback_set_on_http_transport(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MCP_TYPE", "streamable-http")
+
+        module, mcp, capture_exception = _load_main_module(monkeypatch)
+        module.settings.mcp_caller_agent_id_fallback = "trader-agent-id"
+
+        with pytest.raises(
+            RuntimeError,
+            match=(
+                "MCP_CALLER_AGENT_ID is only allowed for stdio/local dev "
+                "transports"
+            ),
+        ):
+            module.main()
+
+        mcp.run.assert_not_called()
+        capture_exception.assert_called_once()
+
+    def test_boot_ok_when_env_fallback_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MCP_TYPE", "sse")
+
+        module, mcp, capture_exception = _load_main_module(monkeypatch)
+        module.settings.mcp_caller_agent_id_fallback = None
+
+        module.main()
+
+        mcp.run.assert_called_once_with(
+            transport="sse",
+            host="0.0.0.0",
+            port=8765,
+            path="/mcp",
+            uvicorn_config={"timeout_graceful_shutdown": 10},
+        )
+        capture_exception.assert_not_called()
+
+    def test_boot_ok_when_stdio_and_env_fallback_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MCP_TYPE", "stdio")
+
+        module, mcp, capture_exception = _load_main_module(monkeypatch)
+        module.settings.mcp_caller_agent_id_fallback = "trader-agent-id"
+
+        module.main()
+
+        mcp.run.assert_called_once_with(transport="stdio")
+        capture_exception.assert_not_called()


### PR DESCRIPTION
## Summary

- Refuse MCP startup for HTTP transports when `MCP_CALLER_AGENT_ID` is configured.
- Keep stdio/local-dev fallback behavior unchanged.
- Tighten README, `env.example`, and bridge-template policy text to mark the fallback as DEV/stdio only.

## Validation

- `uv run pytest tests/test_mcp_server_main.py`
- `uv run ruff check app/mcp_server/main.py tests/test_mcp_server_main.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a caller spoofing vulnerability by restricting the caller agent ID fallback to development deployments. Production HTTP deployments will now fail to start if misconfigured.

* **Documentation**
  * Clarified that the caller agent ID fallback is for development/stdio use only and must not be configured for production HTTP deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->