### PR TITLE
[ROB-245] Fix MCP helper SSE buffering

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -892,6 +892,11 @@ chmod 700 /tmp/mcp_call.sh
 /tmp/mcp_call.sh get_quote '{"symbol":"005930","market":"kr"}'
 ```
 
+The rendered bridge intentionally calls curl with `-N --max-time 15` and sends
+`Connection: close`. It only consumes the first SSE `data:` line, so no-buffer
+mode and the timeout keep the helper from holding a completed Paperclip run open
+if the server keeps the stream alive.
+
 If the Trader adapter is later migrated to an in-process MCP client (for
 example a Claude Code `.mcp.json` entry or an SDK-level `default_headers`
 config), that client must also set `x-paperclip-agent-id`; do not rely on

--- a/scripts/templates/mcp_call.sh.tmpl
+++ b/scripts/templates/mcp_call.sh.tmpl
@@ -84,6 +84,8 @@ coproc CURL_STREAM {
 }
 
 RESPONSE=""
+# Bash may unset CURL_STREAM_PID after a fast-exiting coproc; keep a stable copy.
+CURL_PID="$CURL_STREAM_PID"
 CURL_FD=${CURL_STREAM[0]}
 while IFS= read -r line <&"$CURL_FD"; do
   if [[ "$line" == data:* ]]; then
@@ -95,15 +97,15 @@ exec {CURL_FD}<&-
 
 if [[ -z "$RESPONSE" ]]; then
   CURL_STATUS=1
-  wait "$CURL_STREAM_PID" || CURL_STATUS=$?
+  wait "$CURL_PID" || CURL_STATUS=$?
   cat "$CURL_ERR" >&2
   exit "$CURL_STATUS"
 fi
 
-if kill "$CURL_STREAM_PID" 2>/dev/null; then
-  wait "$CURL_STREAM_PID" 2>/dev/null || true
+if kill "$CURL_PID" 2>/dev/null; then
+  wait "$CURL_PID" 2>/dev/null || true
 else
-  wait "$CURL_STREAM_PID" 2>/dev/null || true
+  wait "$CURL_PID" 2>/dev/null || true
 fi
 
 printf '%s\n' "$RESPONSE"

--- a/scripts/templates/mcp_call.sh.tmpl
+++ b/scripts/templates/mcp_call.sh.tmpl
@@ -56,14 +56,54 @@ PAYLOAD=$(jq -n --arg tool "$TOOL_NAME" --argjson args "$ARGS" \
 
 # `-f` makes curl exit non-zero on HTTP 4xx/5xx (so auth/header-gate failures
 # surface instead of falling through as an empty SSE stream); `-S` keeps the
-# stderr error message visible even with `-s`. Combined with `set -euo
-# pipefail` above, a failed request aborts the script rather than silently
-# emitting an empty payload.
-curl -fsS -X POST "$MCP_ENDPOINT" \
-  -H "Content-Type: application/json" \
-  -H "Accept: application/json, text/event-stream" \
-  -H "Authorization: Bearer $MCP_AUTH_TOKEN" \
-  -H "Mcp-Session-Id: $MCP_SESSION_ID" \
-  -H "x-paperclip-agent-id: $PAPERCLIP_AGENT_ID" \
-  -d "$PAYLOAD" \
-  | grep "^data:" | head -1 | sed 's/^data: //'
+# stderr error message visible even with `-s`.
+#
+# The MCP endpoint may answer with an SSE stream while this bridge only needs
+# the first `data:` line. `-N` flushes that line immediately, `--max-time`
+# prevents stuck helper processes, and `Connection: close` avoids keep-alive
+# ambiguity. Run curl as a coprocess so the helper can stop it after the first
+# payload; a plain pipeline can still wait forever if the server keeps the
+# stream open without writing again. Non-zero curl waits after a successful
+# read are expected because the helper intentionally closes the stream early
+# (SIGPIPE/SIGTERM depending on timing).
+CURL_ERR=$(mktemp)
+cleanup() {
+  rm -f "$CURL_ERR"
+}
+trap cleanup EXIT
+
+coproc CURL_STREAM {
+  curl -fsS -N --max-time 15 -X POST "$MCP_ENDPOINT" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -H "Authorization: Bearer $MCP_AUTH_TOKEN" \
+    -H "Mcp-Session-Id: $MCP_SESSION_ID" \
+    -H "x-paperclip-agent-id: $PAPERCLIP_AGENT_ID" \
+    -H "Connection: close" \
+    -d "$PAYLOAD" 2>"$CURL_ERR"
+}
+
+RESPONSE=""
+CURL_FD=${CURL_STREAM[0]}
+while IFS= read -r line <&"$CURL_FD"; do
+  if [[ "$line" == data:* ]]; then
+    RESPONSE="${line#data: }"
+    break
+  fi
+done
+exec {CURL_FD}<&-
+
+if [[ -z "$RESPONSE" ]]; then
+  CURL_STATUS=1
+  wait "$CURL_STREAM_PID" || CURL_STATUS=$?
+  cat "$CURL_ERR" >&2
+  exit "$CURL_STATUS"
+fi
+
+if kill "$CURL_STREAM_PID" 2>/dev/null; then
+  wait "$CURL_STREAM_PID" 2>/dev/null || true
+else
+  wait "$CURL_STREAM_PID" 2>/dev/null || true
+fi
+
+printf '%s\n' "$RESPONSE"

--- a/tests/test_mcp_call_template.py
+++ b/tests/test_mcp_call_template.py
@@ -1,0 +1,81 @@
+import json
+import subprocess
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from threading import Thread
+
+TEMPLATE_PATH = Path("scripts/templates/mcp_call.sh.tmpl")
+
+
+def test_mcp_call_template_disables_sse_buffering_and_has_timeout() -> None:
+    template = TEMPLATE_PATH.read_text()
+
+    assert "curl -fsS -N --max-time 15 -X POST" in template
+    assert '-H "Connection: close"' in template
+    assert "SSE" in template
+    assert "SIGPIPE" in template
+
+
+def test_mcp_call_template_exits_after_first_sse_data_line(tmp_path: Path) -> None:
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            content_length = int(self.headers.get("content-length", "0"))
+            if content_length:
+                self.rfile.read(content_length)
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            self.wfile.write(
+                b'data: {"jsonrpc":"2.0","id":100,"result":{"content":[]}}\n\n'
+            )
+            self.wfile.flush()
+            time.sleep(30)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    server.daemon_threads = True
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        template = TEMPLATE_PATH.read_text()
+        endpoint = f"http://127.0.0.1:{server.server_port}/mcp"
+        rendered = (
+            template.replace("${MCP_ENDPOINT}", endpoint)
+            .replace("${MCP_AUTH_TOKEN}", "dummy-token")
+            .replace("${MCP_SESSION_ID}", "dummy-session")
+            .replace("${PAPERCLIP_AGENT_ID}", "dummy-agent")
+        )
+        helper = tmp_path / "mcp_call.sh"
+        helper.write_text(rendered)
+        helper.chmod(0o700)
+
+        start = time.monotonic()
+        result = subprocess.run(
+            [
+                "bash",
+                str(helper),
+                "get_sector_peers",
+                json.dumps({"symbol": "HSY", "market": "us"}),
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=5,
+        )
+        elapsed = time.monotonic() - start
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout) == {
+        "jsonrpc": "2.0",
+        "id": 100,
+        "result": {"content": []},
+    }
+    assert elapsed < 5

--- a/tests/test_mcp_call_template.py
+++ b/tests/test_mcp_call_template.py
@@ -1,4 +1,5 @@
 import json
+import socket
 import subprocess
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -79,3 +80,41 @@ def test_mcp_call_template_exits_after_first_sse_data_line(tmp_path: Path) -> No
         "result": {"content": []},
     }
     assert elapsed < 5
+
+
+def test_mcp_call_template_fast_fail_does_not_use_unbound_coproc_pid(
+    tmp_path: Path,
+) -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        closed_port = sock.getsockname()[1]
+
+    template = TEMPLATE_PATH.read_text()
+    rendered = (
+        template.replace("${MCP_ENDPOINT}", f"http://127.0.0.1:{closed_port}/mcp")
+        .replace("${MCP_AUTH_TOKEN}", "dummy-token")
+        .replace("${MCP_SESSION_ID}", "dummy-session")
+        .replace("${PAPERCLIP_AGENT_ID}", "dummy-agent")
+    )
+    helper = tmp_path / "mcp_call.sh"
+    helper.write_text(rendered)
+    helper.chmod(0o700)
+
+    start = time.monotonic()
+    result = subprocess.run(
+        [
+            "bash",
+            str(helper),
+            "get_sector_peers",
+            json.dumps({"symbol": "HSY", "market": "us"}),
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=5,
+    )
+    elapsed = time.monotonic() - start
+
+    assert result.returncode != 0
+    assert elapsed < 5
+    assert "CURL_STREAM_PID: unbound variable" not in result.stderr


### PR DESCRIPTION
## Summary

Fixes the `/tmp/mcp_call.sh` template used by Paperclip MCP callers when the MCP server returns an SSE stream that stays open after the first `data:` payload.

- Adds `curl -N --max-time 15` and `Connection: close` to the rendered helper request.
- Replaces the old `curl | grep | head | sed` pipeline with a bash coprocess so the helper reads the first SSE `data:` line and then terminates curl explicitly.
- Documents why the rendered bridge uses no-buffer mode and a timeout.
- Adds regression coverage for both the template flags and a fake SSE server that sends one `data:` line and keeps the stream open.

## Root Cause

The helper only needs the first SSE `data:` line, but the old shell pipeline could keep waiting after that line if curl or downstream buffering did not close promptly. That left child processes attached to a completed Paperclip run.

## Verification

- `uv run pytest tests/test_mcp_call_template.py` passed.
- `uv run ruff check tests/test_mcp_call_template.py` passed.
- Rendered `/tmp/mcp_call.sh` from the template and ran `bash -n /tmp/mcp_call.sh` successfully.
- Synthetic SSE smoke test: rendered `/tmp/mcp_call.sh`, called a local server that emitted one `data:` line and then slept for 30s, and verified the helper returned JSON with `elapsed_seconds=0` under `timeout 15`.

## Notes

I could not run the exact live `get_sector_peers` HSY MCP smoke test in this heartbeat because the environment only provided `PAPERCLIP_AGENT_ID`; it did not include `MCP_ENDPOINT`, `MCP_AUTH_TOKEN`, or `MCP_SESSION_ID`. The synthetic SSE test exercises the buffering/hanging behavior directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on MCP server bridge behavior, including stream handling and connection lifecycle management.

* **Improvements**
  * Enhanced connection handling with improved timeout management (15-second maximum) to prevent indefinite waits.
  * Optimized stream processing to terminate promptly after receiving the first response.
  * Strengthened error handling for failed connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->