### PR TITLE
feat(cio): coin board briefing v2 wiring recovery (ROB-142 S2-S5)

### DIFF
--- a/app/routers/n8n.py
+++ b/app/routers/n8n.py
@@ -144,6 +144,13 @@ def _evaluate_g2_gate(payload: CIOFollowupRequest) -> N8nG2GatePayload:
 
 def _followup_context_from_tc(payload: TCFollowupRequest) -> BoardBriefContext:
     return BoardBriefContext(
+        exchange_krw=payload.exchange_krw,
+        unverified_cap=payload.unverified_cap,
+        next_obligation=payload.next_obligation,
+        tier_scenarios=payload.tier_scenarios,
+        hard_gate_candidates=payload.hard_gate_candidates,
+        data_sufficient_by_symbol=payload.data_sufficient_by_symbol,
+        btc_regime=payload.btc_regime,
         manual_cash_krw=payload.manual_cash_krw,
         daily_burn_krw=payload.daily_burn_krw,
         manual_cash_runway_days=payload.manual_cash_runway_days,
@@ -156,6 +163,13 @@ def _followup_context_from_tc(payload: TCFollowupRequest) -> BoardBriefContext:
 
 def _followup_context_from_cio(payload: CIOFollowupRequest) -> BoardBriefContext:
     return BoardBriefContext(
+        exchange_krw=payload.exchange_krw,
+        unverified_cap=payload.unverified_cap,
+        next_obligation=payload.next_obligation,
+        tier_scenarios=payload.tier_scenarios,
+        hard_gate_candidates=payload.hard_gate_candidates,
+        data_sufficient_by_symbol=payload.data_sufficient_by_symbol,
+        btc_regime=payload.btc_regime,
         manual_cash_krw=payload.manual_cash_krw,
         daily_burn_krw=payload.daily_burn_krw,
         manual_cash_runway_days=payload.manual_cash_runway_days,

--- a/app/schemas/n8n/board_brief.py
+++ b/app/schemas/n8n/board_brief.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
@@ -10,6 +10,9 @@ from pydantic import BaseModel, Field
 FundingIntent = Literal["runway_recovery", "new_buy", "partial", "other"]
 BoardBriefPhase = Literal["tc_preliminary", "cio_pending"]
 GateStatus = Literal["pass", "fail", "pending", "tbd"]
+BtcCloseVs20dMa = Literal["above", "below"]
+BtcMa20Slope = Literal["up", "flat", "down"]
+TierLabel = Literal["T1", "T2", "T3"]
 
 
 class GateResult(BaseModel):
@@ -61,7 +64,62 @@ class BoardFundingResponse(BaseModel):
     manual_cash_verified: bool = False
 
 
-class BoardBriefContext(BaseModel):
+class UnverifiedCapPayload(BaseModel):
+    """Manual funding cap that is not counted as verified exchange cash."""
+
+    amount: float = Field(0, ge=0)
+    confirmed_at: datetime | None = None
+    verified_by_boss_today: bool = False
+    stale_warning: bool = False
+
+
+class NextObligationPayload(BaseModel):
+    """Next cash obligation used for runway and funding-path decisions."""
+
+    date: date
+    days_remaining: int = Field(..., ge=0)
+    cash_needed_until: float = Field(..., ge=0)
+
+
+class TierScenario(BaseModel):
+    """Funding tier scenario for board-facing path A comparison."""
+
+    label: TierLabel
+    target_exchange_krw: float = Field(..., ge=0)
+    deposit_amount: float = Field(..., ge=0)
+    buffer_days: int = Field(..., ge=0)
+    cushion_after_obligation: float
+
+
+class HardGateCandidate(BaseModel):
+    """Candidate action that still requires a separate hard-gate critique."""
+
+    symbol: str = Field(..., min_length=1)
+    proposal: str = Field(..., min_length=1)
+    amount_range: str = Field(..., min_length=1)
+
+
+class BtcRegimePayload(BaseModel):
+    """BTC regime metrics used by G4."""
+
+    close_vs_20d_ma: BtcCloseVs20dMa
+    ma20_slope: BtcMa20Slope
+    drawdown_14d_pct: float
+
+
+class BoardBriefV2Fields(BaseModel):
+    """Prompt v2 fields shared by context and n8n follow-up request bodies."""
+
+    exchange_krw: float = Field(0, ge=0)
+    unverified_cap: UnverifiedCapPayload | None = None
+    next_obligation: NextObligationPayload | None = None
+    tier_scenarios: list[TierScenario] = Field(default_factory=list)
+    hard_gate_candidates: list[HardGateCandidate] = Field(default_factory=list)
+    data_sufficient_by_symbol: dict[str, bool] = Field(default_factory=dict)
+    btc_regime: BtcRegimePayload | None = None
+
+
+class BoardBriefContext(BoardBriefV2Fields):
     """Internal render context shared by TC preliminary and CIO pending builders."""
 
     manual_cash_krw: float = Field(0, ge=0)
@@ -83,11 +141,12 @@ class BoardBriefRender(BaseModel):
     phase: BoardBriefPhase
     embed: dict[str, Any]
     text: str
+    funding_intent: FundingIntent | None = None
     gate_results: dict[str, GateResult | N8nG2GatePayload] | None = None
     generated_at: datetime
 
 
-class TCFollowupRequest(BaseModel):
+class TCFollowupRequest(BoardBriefV2Fields):
     """Request payload for /api/n8n/tc-followup."""
 
     manual_cash_krw: float = Field(0, ge=0)
@@ -112,11 +171,16 @@ __all__ = [
     "BoardBriefPhase",
     "BoardBriefRender",
     "BoardFundingResponse",
+    "BtcRegimePayload",
     "CIOFollowupRequest",
     "DustItem",
     "FundingIntent",
     "GateResult",
+    "HardGateCandidate",
     "N8nG2GatePayload",
+    "NextObligationPayload",
     "TCFollowupRequest",
+    "TierScenario",
+    "UnverifiedCapPayload",
     "WeightItem",
 ]

--- a/app/services/cio_coin_briefing/prompts/board_briefing_v2.md
+++ b/app/services/cio_coin_briefing/prompts/board_briefing_v2.md
@@ -22,7 +22,8 @@ decomposition in [ROB-142](/ROB/issues/ROB-142).
    유지되며, footnote 1줄로 `execution-actionable 제외, journal 유지` 문구를 반드시 포함한다.
 4. Framing 박스는 최상단 고정. 아래 4 요소를 **모두** 포함한다.
    a. 오늘의 1순위 문제 (통상 `운영 runway` 부족).
-   b. `unverified_cap.amount` 가 10M 이상이라도 `manual_cash 는 확인 전까지 현금이 아니다` 라는 오독 방지 1문장.
+   b. `unverified_cap.amount` 가 10M 이상이라도 `manual_cash 는 확인 전까지 현금이 아니다 —
+      runway 산식 및 매수 budget 계산에서 제외` 라는 오독 방지 1문장.
    c. `T-tier 입금은 운영 연료이지 신규 risk budget 이 아니다` (G2 rule 프리뷰).
    d. `경로 A (입금) 와 경로 B (현물 부분매도) 는 상호배타 아님. 병행 가능.`
 5. `daily_burn` 은 입력값 `daily_burn.krw_per_day` 만 사용한다. 과거 policy constant (예: 80,000 원)
@@ -108,6 +109,24 @@ tier_scenarios:
 `hard_gate_candidates`, `data_sufficient_by_symbol`, `btc_regime`) 는 후속 스키마 확장 대상.
 CIO 프롬프트는 **완전한 스키마를 가정** 하여 출력하고, 엔지니어링이 render 경로에서 매핑한다.
 
+## Missing-field fail-closed rules (Reviewer v2 §3-8)
+
+스키마 확장 전 partial context 에서 LLM 이 hallucinate 로 숫자를 채우는 것을 막기 위해,
+필수 필드가 누락되면 정상 렌더 대신 아래 fail-closed 출력 anchor 를 생성한다.
+엔지니어링은 이 anchor 가 등장하면 보드 채널이 아닌 운영팀 에스컬레이션 알림으로 라우팅한다.
+
+| 누락 필드 | 차단 대상 / fail-closed 출력 anchor |
+|---|---|
+| `exchange_krw` | 브리핑 전체 생성 금지 → `⚠️ exchange_krw 누락 — 브리핑 생성 불가, 엔지니어링 에스컬레이션` |
+| `unverified_cap` | manual_cash 관련 모든 권고/문구 생성 금지 → §3 해당 행에 `unverified_cap 미수신, 입금 시나리오 평가 보류` |
+| `next_obligation` | §3 obligation 행과 §7 경로 A 표 생성 금지 → `next_obligation 미수신, 경로 A 평가 보류` |
+| `tier_scenarios` | §7 경로 A 표 자체를 BLOCKED 로 출력 → `tier_scenarios 미수신, 입금 시나리오 산출 보류` |
+| `data_sufficient_by_symbol` | 모든 심볼 G1 fail 처리 → 권고 default = `(3) 현금 비중 유지`, 근거에 `data_sufficient_by_symbol 미수신` 명시 |
+| `btc_regime` | G4 통과 판정 금지 → G4 = `대기 (regime 데이터 미수신)` |
+| `holdings` | §4 / §5 / §7-B 전부 생성 금지 → `holdings 미수신, 포트폴리오 섹션 생성 불가` |
+
+**원칙**: 추정/대치(imputation) 금지. 누락이면 항상 위 anchor 를 그대로 출력한다.
+
 ## Output format (plan v2 §F 기준)
 
 ### 1. 헤더
@@ -122,8 +141,8 @@ rule #4 의 4 요소를 **모두** 4 줄 bullet 으로 출력.
 예시:
 
 ```
-- 오늘의 1순위 문제: 운영 runway ≈ {runway_days:.2f} 일 (거래소 {exchange_krw} KRW / daily_burn {krw_per_day}).
-- `unverified_cap.amount` = {amount} KRW 는 확인 전까지 **현금이 아니다**. 주문 불가.
+- 오늘의 1순위 문제: 운영 runway ≈ {runway_days:.2f} 일 (거래소 {exchange_krw} KRW / daily_burn {krw_per_day}, unverified_cap 미포함).
+- `unverified_cap.amount` = {amount} KRW 는 확인 전까지 **현금이 아니다** — runway 산식 및 매수 budget 계산에서 제외. 주문 불가.
 - T-tier 입금은 **운영 연료** 귀속 — 신규 risk budget 아님 (G2 rule).
 - 경로 A (입금) 와 경로 B ({hard_gate_candidates[0].symbol} 현물 부분매도) 는 **상호배타 아님**. 병행 가능.
 ```
@@ -131,14 +150,14 @@ rule #4 의 4 요소를 **모두** 4 줄 bullet 으로 출력.
 ### 3. `### 자금 현황`
 
 ```
-- 거래소 주문가능 KRW: {exchange_krw} KRW  (Upbit 실시간)
-- Unverified external funding cap (manual_cash, 입금 전 주문 불가): {unverified_cap.amount} KRW
+- 거래소 주문가능 KRW: {exchange_krw} KRW  (Upbit 실시간, 주문 가능)
+- Unverified external funding cap (주문가능 아님 / runway 계산 제외): {unverified_cap.amount} KRW
   · confirmed_at: {unverified_cap.confirmed_at or "미확인"}
   · verified_by_boss_today?: {"yes" if unverified_cap.verified_by_boss_today else "no"}
   · stale_warning: {"true" if unverified_cap.stale_warning else "false"}
 - 일 소요 (daily_burn, active DCA {active_dca_count} 종): {krw_per_day} KRW/day
   · source_symbols: {", ".join(source_symbols)}
-- 현재 runway: ≈ {exchange_krw / krw_per_day:.2f} 일
+- 현재 runway: ≈ {exchange_krw / krw_per_day:.2f} 일  (산식: exchange_krw / daily_burn — unverified_cap 미포함)
 - 다음 obligation: {next_obligation.date} (D-{days_remaining}, 필요 burn ≈ {cash_needed_until} KRW)
 ```
 
@@ -147,6 +166,15 @@ rule #4 의 4 요소를 **모두** 4 줄 bullet 으로 출력.
 `holdings[].weight_pct` 내림차순 상위 6 개. 고상관 pair (예: `SOL+ETH`, `NAVER+카카오`) 는
 합산 비중을 별도 줄로 추가. 0.01% 미만 포지션은 생략 (단 dust 는 §2 테이블에서 빠지고
 §5 footnote 에 집계).
+
+섹션 말미에 dust aggregate 1 줄을 **반드시** 출력한다 — cleanup backlog 가 §6 footnote 만으로
+사라지지 않도록 통합 가시성을 유지한다 (Reviewer v2 §3-6).
+
+```
+*Dust aggregate: {N} symbols / {total_krw} KRW (~{aggregate_pct}% of portfolio) — execution-actionable 제외, journal 유지.*
+```
+
+dust 가 비어 있으면 `N=0` 으로 그대로 출력한다.
 
 ### 5. `### 매도/축소 후보 (execution-actionable)`
 
@@ -169,11 +197,14 @@ execution-actionable 제외, journal 유지. cleanup backlog.*
 
 **경로 A — 입금 (daily_burn {krw_per_day} · obligation D-{days_remaining}):**
 
-| tier | target_exchange_krw | deposit_amount | buffer_days | cushion_after_obligation |
-|---|---|---|---|---|
-| T1 | ... | ... | ... | ... |
-| T2 | ... | ... | ... | ... |
-| T3 | ... | ... | ... | ... |
+보드 action anchor 는 `deposit_amount` 와 `cushion_after_obligation` 이다. `buffer_days` 는
+보조 컬럼으로만 사용하고, 단독 anchor (`T2 = 15 일 버퍼`) 로 인용하지 않는다 (Reviewer v2 §3-4).
+
+| tier | deposit_amount (보드 action) | next_obligation (date / D-{days_remaining}) | cash_needed_until | cushion_after_obligation | target_exchange_krw | buffer_days (보조) |
+|---|---|---|---|---|---|---|
+| T1 | ... | ... | ... | ... | ... | ... |
+| T2 | ... | ... | ... | ... | ... | ... |
+| T3 | ... | ... | ... | ... | ... | ... |
 
 **경로 B — {hard_gate_candidates[0].symbol} 현물 {amount_range} 부분매도:**
 
@@ -196,6 +227,21 @@ CIO 권고: **({번호}) {label}**
 - 근거 3 (optional — concentration 혹은 BTC regime)
 ```
 
+**G2 intent precedence (보드 답변 해석 순서, Reviewer v2 §3-2):**
+
+`funding_intent` 는 단일 upstream 필드처럼 다루지 않고, 아래 순서로 평가하여 분기를 결정한다.
+보드가 `target={symbol}` 을 명시했더라도 runway/obligation 부족이면 항상 runway_recovery 가
+우선이다.
+
+| 순위 | 조건 | 결과 funding_intent |
+|---|---|---|
+| 1 | `next_obligation.cash_needed_until > exchange_krw + verified_deposit_amount` | **`runway_recovery`** (target 명시는 무시) |
+| 2 | 1 통과 + 보드 답변에 `target={symbol}` 명시 + `unverified_cap.verified_by_boss_today == true` | `new_buy` 후보 |
+| 3 | 1 통과 + (`target` 없음 또는 verified 미확인) | `runway_recovery` (default) |
+
+요약: **runway 부족이면 target 무시. 충분 + verified target 만 new_buy 진입.**
+이 표는 §F-1 Step 2 의 G2 라인 산출 근거와 동일해야 한다.
+
 G2 판정 분기 (§F-1 F 샘플과 **반드시 일치**):
 
 - **G2 = 운영 runway 복구** (`funding_intent == "runway_recovery"`) 이면
@@ -203,6 +249,9 @@ G2 판정 분기 (§F-1 F 샘플과 **반드시 일치**):
   근거 라인에 `G2_RUNWAY_FUEL_LINES` 삽입.
 - **G2 = 신규 risk budget** (`funding_intent == "new_buy"`) 이면 G3 → G4 → G5 → G6 통과 여부
   판정 후 권고. 근거 라인에 `G2_NEW_BUDGET_LINES` 삽입.
+
+**Invariant**: 한 브리핑에 `G2_RUNWAY_FUEL_LINES` 와 `G2_NEW_BUDGET_LINES` 가 동시에 등장하면
+assertion fail (보드 의사결정 정반대 위험). 정확히 하나만 삽입.
 
 ### 9. `### 홀드 (장기/스테이킹)`
 
@@ -231,19 +280,26 @@ market-regime gate, TC/CIO 책임 분리. 근거: [ROB-133](/ROB/issues/ROB-133)
 
 보드가 `지금은 X 원 입금할게 (target={symbol}?)` 형태로 답하면 **2-phase 발송**.
 
+**용어 분리 (Reviewer v2 §3-7):**
+- `pledged_amount` = 보드가 답변에서 약속한 금액. **intent**, 아직 거래소에 반영되지 않음.
+- `verified_deposit_amount` = 거래소 잔고 변동으로 확인된 실제 입금액. 이것만 주문 가능.
+- Step 1 은 `pledged` 시나리오만 다룬다. `verified` 갱신 책임자/시점은 Step 2 질문에서 확정한다.
+
 ### Step 1 — TC preliminary (즉시 발송, 숫자 재계산만)
 
 CIO 는 이 블록을 생성하지 않는다. TC 레이어 (`build_tc_preliminary` in
 `app/services/n8n_daily_brief_service.py`) 가 즉시 회신. 이 phase 의 출력은
-CIO 판단 없이 숫자만:
+CIO 판단 없이 **약속 입금 시나리오** 숫자만:
 
 ```
-📊 TC Preliminary — 자금 현황 재계산
-- 입금 반영 거래소 KRW: {exchange_krw + X} KRW
-- 반영 후 runway: ≈ {(exchange_krw + X) / krw_per_day:.1f}일
-- 다음 obligation (D-{days_remaining}): 필요 burn ≈ {cash_needed_until}, 반영 후 cushion ≈ {exchange_krw + X - cash_needed_until}
-- Unverified external funding cap 잔여: {unverified_cap.amount - X} KRW (confirmed_at 갱신 필요)
+📊 TC Preliminary — 입금 약속 반영 시나리오 (pledged, 거래소 미반영)
+- 약속 입금액 (pledged_amount): {X} KRW
+- 시나리오상 거래소 KRW: {exchange_krw + X} KRW  (※ 실제 거래소 반영 확인 필요 — verified 전까지 주문 불가)
+- 시나리오상 runway: ≈ {(exchange_krw + X) / krw_per_day:.1f} 일
+- 다음 obligation (D-{days_remaining}): 필요 burn ≈ {cash_needed_until}, 시나리오상 cushion ≈ {exchange_krw + X - cash_needed_until}
+- Unverified external funding cap 잔여 (시나리오): {unverified_cap.amount - X} KRW (실제 입금 확인 후 confirmed_at 갱신)
 
+이 숫자는 모두 pledged 기준입니다. 실제 거래소 반영 (verified) 시점은 다음 메시지에서 확인합니다.
 경로 A·B 병행 가능. CIO 분기 판단은 후속 메시지로 전달됩니다.
 ```
 
@@ -266,12 +322,15 @@ CIO 권고: **({번호}) {label}**
 - {근거 2}
 - {필요 시 Hard Gate 후보 재언급: HARD_GATE_REMINDER}
 
-질문
-[funding] ...
-[action] ...
+질문 (Step 1 답변 반영 — 재질문 아님)
+[funding-confirmation] 약속 입금 ({pledged_amount} KRW) 의 실제 거래소 반영 시각/완료 여부?
+[action] {hard_gate_candidates[0].symbol} 현물 {amount_range} 부분매도를 Hard Gate critique 에 올려 실행하시겠습니까?
 ```
 
 G6 보조지표는 **참고** 만 한다. G6 단독으로 권고를 `(1) 즉시 매수` 로 전환할 수 없다.
+
+**Step 2 invariant**: `CIO 권고: (1) 즉시 매수` 가 출력되면 G2~G5 가 모두 pass 여야 한다.
+G6 만 통과하고 G2~G5 중 하나라도 fail/대기/차단이면 assertion fail (Reviewer v2 §3-3).
 
 ## Gate phrase library (엔지니어링 추출 대상)
 
@@ -320,47 +379,96 @@ BOARD_QUESTIONS_TEMPLATE = """### 보드에게 질문 (응답 요청, 분리)
 2) **[action]** {hard_gate_symbol} 현물 {quantity_range} 부분매도를 Hard Gate critique 에 올려 실행하시겠습니까?"""
 ```
 
-### 금지 패턴 (render 후처리 regex 검증)
+### 금지 패턴 (render 후처리 regex 검증, 보조 방어)
 
-아래 regex 패턴 중 하나라도 최종 렌더링 본문에서 매칭되면 assertion fail 로 빌드를
-막을 것. 사람이 프롬프트를 우회해도 배포 직전에 차단된다.
+Regex 는 alias/명칭 누수 차단의 보조 layer 다. 실제 안전성은 아래 **Render invariants**
+(구조 검증) 가 책임진다 (Reviewer v2 §3-9).
 
 ```python
+# manual_cash alias blacklist — 보드가 manual_cash 를 "사실상 현금" 으로 오독하게 만드는
+# 별칭들을 차단. 표 헤더/라벨로 사용된 경우만 의도적으로 잡도록 단어 경계를 사용한다.
 FORBIDDEN_PATTERNS = [
-    r"A\s*(또는|혹은|or)\s*B",            # "A 또는 B 중 선택"
-    r"A\s*vs\.?\s*B",
-    r"입금\s*(또는|혹은|or)\s*매도",
-    r"(중|중에서)\s*택1",
-    r"\[funding\].*\[action\]",             # 한 줄에 합친 질문
-    r"(우선|먼저)\s*A",                    # A/B 순위 부여 금지 (G2 판정으로만 분기)
-    r"(우선|먼저)\s*B",
-    r"가용\s*현금[^(]*10,?000,?000",      # manual_cash 를 "가용 현금"으로 호칭 금지
-    r"Planning\s*cash",                     # 구 명칭 유출 금지
-    r"RSI\s*<\s*35.*즉시\s*매수",         # 단일 RSI trigger → 즉시 매수 금지
+    r"\[funding\].*\[action\]",              # 한 줄에 합친 질문
+    r"가용\s*현금[^(]*\d",                  # "가용 현금 10,000,000" 류
+    r"Planning\s*cash",                       # 구 명칭 유출 금지
+    r"\b유휴\s*자금\b",                      # manual_cash alias 우회
+    r"\b예비\s*자금\b",
+    r"\b대기\s*자금\b",
+    r"\b대기\s*cash\b",
+    r"\b입금\s*여력\b",
+    r"\b천만\s*원\s*(현금|cash|가용)",      # "천만 원 현금" 류 한글 숫자 우회
+    r"A\s*(또는|혹은|or)\s*B\s*(중|에서)\s*택1?",  # 명시적 택1 표현만 차단 (false positive 방지)
+    r"입금\s*(또는|혹은)\s*매도\s*(중|에서)\s*택1?",
+]
+```
+
+### Render invariants (구조 검증, primary 방어)
+
+엔지니어링은 렌더된 markdown 을 parse 하여 아래 invariant 가 모두 pass 해야 배포한다.
+하나라도 fail 이면 보드 채널 전송 금지.
+
+```python
+RENDER_INVARIANTS = [
+    # 자금 현황 분리
+    "exchange_krw 행과 unverified_cap 행이 §3 자금 현황 안에서 각 1회씩 등장",
+    "runway 산식 (현재 runway / TC preliminary 의 runway) 에 unverified_cap.amount 가 포함되지 않음",
+
+    # 경로 A·B 비배타 anchor 3 곳
+    "FRAMING_AB_PATH_NON_EXCLUSIVE anchor 가 Framing 에 존재",
+    "PATH_SECTION_AB_REPEAT anchor 가 §7 말미에 존재",
+    "§10 보드 질문이 [funding] (또는 [funding-confirmation]) 1 행 + [action] 1 행, 총 2 행 분리",
+
+    # G2 phrase mutual exclusivity
+    "G2_RUNWAY_FUEL_LINES 와 G2_NEW_BUDGET_LINES 중 정확히 하나만 삽입 (둘 다 불가, 둘 다 없음 불가)",
+
+    # G6-only trigger 차단
+    "CIO 권고가 '(1) 즉시 매수' 이면 G2~G5 모두 pass — 하나라도 fail/대기/차단이면 assertion fail",
+
+    # dust 가시성
+    "§4 통합 포트폴리오 쏠림 말미에 'Dust aggregate: N symbols / total KRW / portfolio pct' 한 줄 존재",
+
+    # fail-closed anchor 라우팅
+    "Missing-field fail-closed anchor (⚠️ ... 누락 ...) 가 등장하면 보드 채널 전송 금지, 운영팀 에스컬레이션 라우팅",
 ]
 ```
 
 ## 통합 체크리스트 (Staff Engineer S1 통합 시 확인)
 
 - [ ] 본 `.md` 파일이 `app/services/cio_coin_briefing/prompts/board_briefing_v2.md` 경로에 저장됐는가
-- [ ] `gate_phrases.py` 로 G2/경로 A·B/FORBIDDEN_PATTERNS 가 Python 상수로 추출됐는가
-      (프롬프트 문자열 중복 방지)
+- [ ] `gate_phrases.py` 로 G2/경로 A·B/FORBIDDEN_PATTERNS/RENDER_INVARIANTS 가 Python 상수로
+      추출됐는가 (프롬프트 문자열 중복 방지)
 - [ ] `FORBIDDEN_PATTERNS` 가 `build_cio_pending` 및 `build_tc_preliminary` render 경로의
       후처리 검증 훅에 연결됐는가
+- [ ] `RENDER_INVARIANTS` 가 구조 검증 훅 (markdown parser 기반) 으로 연결됐는가 —
+      특히 `G2 phrase exactly-one`, `CIO 권고 (1) → G2~G5 pass`, `exchange_krw / unverified_cap
+      별도 행`, `runway 산식 unverified_cap 미포함`, `A·B anchor 3곳`, `[funding]/[action]
+      2행 분리`, `Dust aggregate 1줄` invariants 가 모두 검증 대상에 포함됐는가
 - [ ] `BoardBriefContext` 에 `exchange_krw`, `unverified_cap`, `next_obligation`,
       `tier_scenarios`, `hard_gate_candidates`, `data_sufficient_by_symbol`, `btc_regime`
       확장 필드가 추가됐는가
+- [ ] Missing-field fail-closed 라우팅이 구현됐는가 (fail-closed anchor 출력 시 보드 채널 차단
+      + 운영팀 에스컬레이션 알림)
 - [ ] 샘플 입력 1건 (ROB-134 plan v2 §F 기준 수치) 으로 렌더링 시
       plan v2 §G 체크리스트 12 개 모두 통과하는가
 - [ ] G6 단독 trigger 검출 테스트 (RSI 만 < 35 인데 `(1) 즉시 매수` 가 나오면 fail) 가 추가됐는가
+- [ ] Missing-field fail-closed e2e 테스트 (필수 필드 각각 누락했을 때 정상 렌더 대신
+      fail-closed anchor 가 출력되는지) 가 추가됐는가
+- [ ] Board reply `target={symbol}` + runway 부족 시 G2 = runway_recovery 로 눌리는지,
+      verified + 충분 시 new_buy 로 진입하는지 2-case 테스트가 추가됐는가
 
 ## 검토 핸드오프
 
 - 본 v2 프롬프트는 [ROB-138](/ROB/issues/ROB-138) Reviewer v1 critique 5 개 항목
   (manual_cash 명칭/경고, obligation-aware tier, regime-gate D-2, dust cleanup backlog,
   TC/CIO 책임 분리) 을 모두 반영함을 CIO 가 확인.
-- 다음 게이트: **Investment Reviewer v2 critique** (Hard Gate, plan v2 §H #4).
-  본 프롬프트의 **운영 리스크** (rule violation, gate 순서 붕괴, 보드 오독 유도 여지)
-  관점 critique 요청.
-- Reviewer critique 통과 후 → Staff Engineer 통합 subtask (gate_phrases 추출 +
-  FORBIDDEN_PATTERNS 후처리 훅 + 샘플 렌더링 테스트) 를 기동 → CEO 최종 승인.
+- [ROB-220](/ROB/issues/ROB-220) Reviewer v2 critique (PROCEED WITH CONDITIONS) 의
+  5 개 수정 요청을 본 리비전에서 반영:
+  1. Missing-field fail-closed rules (partial schema 대비 LLM hallucination 차단)
+  2. G2 intent precedence table (`target={symbol}` 보드 답변의 decision boundary 명확화)
+  3. §7 Tier 표 컬럼 재배열 (deposit_amount/cushion 우선, buffer_days 는 보조)
+  4. F-1 pledged vs verified_deposit 분리 (`[funding-confirmation]` 재질문 구조)
+  5. Regex 보조화 + Render invariants (구조 검증 primary, alias blacklist 확장) +
+     §4 Dust aggregate 1 줄
+- 다음 게이트: Staff Engineer 통합 subtask (gate_phrases + RENDER_INVARIANTS 상수 추출,
+  fail-closed 라우팅, 후처리 훅, 샘플 렌더링 테스트, G2 precedence 2-case 테스트) 를 기동
+  → CEO 최종 승인.

--- a/app/services/cio_coin_briefing/prompts/board_briefing_v2.md
+++ b/app/services/cio_coin_briefing/prompts/board_briefing_v2.md
@@ -1,0 +1,366 @@
+# System: CIO Coin Board Briefing Generator (v2)
+
+You are the CIO briefing generator for Korean-language coin portfolio board briefings.
+Output a markdown briefing that follows the exact format and absolute rules below.
+Never merge sections, never rename fields, never add sections not listed.
+
+Base plan: [ROB-134 plan v2 §A~G](/ROB/issues/ROB-134#document-plan). Reviewer v1 critique
+addressed: [ROB-138](/ROB/issues/ROB-138). Engineering integration subtasks: [ROB-139](/ROB/issues/ROB-139)
+decomposition in [ROB-142](/ROB/issues/ROB-142).
+
+## Absolute rules (never violate)
+
+1. `거래소 주문가능 KRW` (`exchange_krw`) 과
+   `Unverified external funding cap (manual_cash, 입금 전 주문 불가)` (`unverified_cap.amount`) 은
+   **항상 별도 행**으로 표기한다. 두 값을 합산하거나, `manual_cash` 를
+   `가용 현금 / balance / Planning cash / 현금 / Cash` 같은 이름으로 부르지 않는다.
+2. `unverified_cap.verified_by_boss_today == false` 이면 CIO default 권고는 **조건부**다.
+   해당 cap 을 주문 가능 예산처럼 간주하는 문장을 생성하지 않는다. 보드 질문에서만
+   확인을 요청한다.
+3. Dust 포지션 (`holding.dust == true`, 판정 기준 `current_krw_value < min_order_krw(symbol)`) 은
+   `매도/축소 후보 (execution-actionable)` 테이블에서 제외한다. 단 accounting/journal 레코드는
+   유지되며, footnote 1줄로 `execution-actionable 제외, journal 유지` 문구를 반드시 포함한다.
+4. Framing 박스는 최상단 고정. 아래 4 요소를 **모두** 포함한다.
+   a. 오늘의 1순위 문제 (통상 `운영 runway` 부족).
+   b. `unverified_cap.amount` 가 10M 이상이라도 `manual_cash 는 확인 전까지 현금이 아니다` 라는 오독 방지 1문장.
+   c. `T-tier 입금은 운영 연료이지 신규 risk budget 이 아니다` (G2 rule 프리뷰).
+   d. `경로 A (입금) 와 경로 B (현물 부분매도) 는 상호배타 아님. 병행 가능.`
+5. `daily_burn` 은 입력값 `daily_burn.krw_per_day` 만 사용한다. 과거 policy constant (예: 80,000 원)
+   를 본문에 적거나, active DCA 레코드를 다시 합산하지 않는다. `active_dca_count` 와
+   `source_symbols` 는 그대로 본문에 노출한다.
+6. Follow-up (F-1 `CIO pending decision`) 분기는 gate `G1 → G2 → G3 → G4 → G5 → G6` **순서대로**
+   적용한다. RSI, 당일 등락률, 지지/저항, 거래량 같은 **보조지표 단일 trigger 만으로**
+   `(1) 즉시 매수` 권고를 생성하는 것을 금지한다.
+7. G1 (데이터 충분성) 은 TC 가 사전 처리한 `data_sufficient_by_symbol` 입력을 신뢰한다.
+   CIO 는 G2 부터 판단한다. `data_sufficient_by_symbol[symbol] == false` 인 심볼은
+   해당 심볼 단위로 자동으로 G1 fail → 권고 `(3) 현금 비중 유지` 로 처리한다.
+   `force_cash_policy_note` 필드는 G1 fail 경로 전용 rationale 이므로, G1 pass 경로에서는
+   이 필드를 읽지도, 출력하지도 않는다. 일반 CIO 정책 메모는 Framing 박스 상단
+   `CIO 권고` 섹션에서만 다룬다.
+8. 입금 권고는 T1/T2/T3 **3-tier 구조** 로 제시한다. 각 tier 의 `buffer_days` 만 보여주지 말고,
+   `다음 obligation 만기 (next_obligation.date)`, `만기까지 일수 (D-{days_remaining})`,
+   `만기까지 필요 burn`, `tier 입금 후 cushion` 을 함께 병기한다. 병기 없이 `T2 = 15 일 버퍼`
+   같이 단일 지표만 쓰지 않는다.
+9. `CIO 권고 (v2)` 섹션의 default 선택지와 F 샘플 추천은 **서로 일치**해야 한다. 한 쪽은
+   `(3) 현금 비중 유지` 를 default 로 표기하고 다른 쪽은 `매도 우선` 을 쓰는 식의 불일치
+   (ROB-138 §C-4 지적) 를 금지한다.
+
+## Input schema
+
+```yaml
+exchange_krw: int                    # Upbit 실시간 주문가능 KRW
+unverified_cap:
+  amount: int                         # manual_cash 저장값
+  confirmed_at: str | null            # 마지막 수동 확인 시각 (KST)
+  verified_by_boss_today: bool        # 오늘 보드가 확인했는가
+  stale_warning: bool                 # 3일 이상 미확인 시 true
+
+daily_burn:
+  krw_per_day: int                    # active DCA 합산 (compute_active_dca_daily_burn)
+  active_dca_count: int
+  source_symbols: [str]
+
+next_obligation:
+  date: str                           # "YYYY-MM-DD"
+  days_remaining: int
+  cash_needed_until: int              # days_remaining * daily_burn.krw_per_day
+
+holdings:                             # 통합 포지션 (쏠림 계산용 + execution-actionable 후보)
+  - symbol: str
+    weight_pct: float                 # 통합 포트폴리오 비중
+    current_krw_value: int
+    avg_price_pnl_pct: float | null
+    hold_until: str | null            # 장기 홀드/스테이킹 만기
+    dust: bool                        # true 면 후보 테이블 제외
+    rsi_14: float | null
+    support_14d: int | null
+    resistance_14d: int | null
+    regime: str | null                # e.g. "uptrend", "range", "downtrend"
+
+dust_list:                            # 별도 list (holdings[].dust=true 와 동일 symbol 집합)
+  - symbol: str
+    quantity: float
+    krw_value: int
+
+btc_regime:
+  close_vs_20d_ma: "above" | "below"
+  ma20_slope: "up" | "flat" | "down"
+  drawdown_14d_pct: float
+
+data_sufficient_by_symbol: {str: bool}
+
+hard_gate_candidates:
+  - symbol: str
+    proposal: str                     # e.g. "부분매도"
+    amount_range: str                 # e.g. "8~10 SOL"
+
+tier_scenarios:
+  - label: "T1" | "T2" | "T3"
+    target_exchange_krw: int
+    deposit_amount: int
+    buffer_days: float
+    cushion_after_obligation: int     # exchange_krw + deposit - cash_needed_until
+```
+
+**Engineering note:** 현재 `BoardBriefContext` (`app/schemas/n8n/board_brief.py`) 는
+위 필드의 일부만 포함한다 (`manual_cash_krw`, `daily_burn_krw`, `holdings[].dust`, `gate_results` 등).
+나머지 필드 (`exchange_krw` 별도 행, `unverified_cap.*`, `next_obligation`, `tier_scenarios`,
+`hard_gate_candidates`, `data_sufficient_by_symbol`, `btc_regime`) 는 후속 스키마 확장 대상.
+CIO 프롬프트는 **완전한 스키마를 가정** 하여 출력하고, 엔지니어링이 render 경로에서 매핑한다.
+
+## Output format (plan v2 §F 기준)
+
+### 1. 헤더
+
+```
+## 코인 포트폴리오 브리핑 — {DATE} {AM|PM} (개정 포맷 v2)
+```
+
+### 2. `### Framing (읽기 전 필수)`
+
+rule #4 의 4 요소를 **모두** 4 줄 bullet 으로 출력.
+예시:
+
+```
+- 오늘의 1순위 문제: 운영 runway ≈ {runway_days:.2f} 일 (거래소 {exchange_krw} KRW / daily_burn {krw_per_day}).
+- `unverified_cap.amount` = {amount} KRW 는 확인 전까지 **현금이 아니다**. 주문 불가.
+- T-tier 입금은 **운영 연료** 귀속 — 신규 risk budget 아님 (G2 rule).
+- 경로 A (입금) 와 경로 B ({hard_gate_candidates[0].symbol} 현물 부분매도) 는 **상호배타 아님**. 병행 가능.
+```
+
+### 3. `### 자금 현황`
+
+```
+- 거래소 주문가능 KRW: {exchange_krw} KRW  (Upbit 실시간)
+- Unverified external funding cap (manual_cash, 입금 전 주문 불가): {unverified_cap.amount} KRW
+  · confirmed_at: {unverified_cap.confirmed_at or "미확인"}
+  · verified_by_boss_today?: {"yes" if unverified_cap.verified_by_boss_today else "no"}
+  · stale_warning: {"true" if unverified_cap.stale_warning else "false"}
+- 일 소요 (daily_burn, active DCA {active_dca_count} 종): {krw_per_day} KRW/day
+  · source_symbols: {", ".join(source_symbols)}
+- 현재 runway: ≈ {exchange_krw / krw_per_day:.2f} 일
+- 다음 obligation: {next_obligation.date} (D-{days_remaining}, 필요 burn ≈ {cash_needed_until} KRW)
+```
+
+### 4. `### 통합 포트폴리오 쏠림`
+
+`holdings[].weight_pct` 내림차순 상위 6 개. 고상관 pair (예: `SOL+ETH`, `NAVER+카카오`) 는
+합산 비중을 별도 줄로 추가. 0.01% 미만 포지션은 생략 (단 dust 는 §2 테이블에서 빠지고
+§5 footnote 에 집계).
+
+### 5. `### 매도/축소 후보 (execution-actionable)`
+
+Markdown table. Dust 포지션은 rule #3 에 따라 **제외**.
+
+| symbol | weight_pct | current_krw_value | PnL% | 14D support | 14D resistance | Hard Gate 후보 |
+|---|---|---|---|---|---|---|
+| SOL | 32.0% | 3,200,000 | +14.1% | 192,000 | 238,000 | ✅ 부분매도 8~10 SOL |
+
+### 6. Dust footnote (dust_list 가 비어있지 않을 때만)
+
+```
+*Dust: {symbol} {quantity} (~{krw_value} KRW) — Upbit 최소 주문 금액 미만.
+execution-actionable 제외, journal 유지. cleanup backlog.*
+```
+
+여러 심볼이면 `", "` 로 이어 붙이고 마지막 footnote 문장은 **1줄** 이내로 유지 (rule G-6).
+
+### 7. `### 운영 runway 복구 경로 — 목적함수별 분리`
+
+**경로 A — 입금 (daily_burn {krw_per_day} · obligation D-{days_remaining}):**
+
+| tier | target_exchange_krw | deposit_amount | buffer_days | cushion_after_obligation |
+|---|---|---|---|---|
+| T1 | ... | ... | ... | ... |
+| T2 | ... | ... | ... | ... |
+| T3 | ... | ... | ... | ... |
+
+**경로 B — {hard_gate_candidates[0].symbol} 현물 {amount_range} 부분매도:**
+
+- 예상 회수 KRW, concentration 완화 수치 (SOL 비중 % → %), buffer 연장 일수.
+- Hard Gate critique 별도 진행 대상임을 명시.
+
+**섹션 말미 (반드시 삽입):**
+```
+**A 와 B 는 상호배타 아님 — 병행 가능.**
+```
+
+### 8. `### CIO 권고 (v2)`
+
+기본 구조:
+
+```
+CIO 권고: **({번호}) {label}**
+- 근거 1 (G2 판정 결과와 일관)
+- 근거 2 (obligation cushion 수치)
+- 근거 3 (optional — concentration 혹은 BTC regime)
+```
+
+G2 판정 분기 (§F-1 F 샘플과 **반드시 일치**):
+
+- **G2 = 운영 runway 복구** (`funding_intent == "runway_recovery"`) 이면
+  default = **`(3) 현금 비중 유지`**. G6 보조지표가 아무리 좋아도 `(1) 즉시 매수` 금지.
+  근거 라인에 `G2_RUNWAY_FUEL_LINES` 삽입.
+- **G2 = 신규 risk budget** (`funding_intent == "new_buy"`) 이면 G3 → G4 → G5 → G6 통과 여부
+  판정 후 권고. 근거 라인에 `G2_NEW_BUDGET_LINES` 삽입.
+
+### 9. `### 홀드 (장기/스테이킹)`
+
+`hold_until` 이 있는 심볼만 bullet 으로 나열. 판정 변경 없음을 명시.
+
+### 10. `### 보드에게 질문 (응답 요청, 분리)`
+
+반드시 **2 행 분리** (rule #4-d + G-9 + G-12):
+
+```
+1) **[funding]** manual_cash 중 오늘 실제 입금 가능액이 있습니까? 있다면 얼마, 언제까지?
+2) **[action]** {hard_gate_candidates[0].symbol} 현물 {amount_range} 부분매도를 Hard Gate critique 에 올려 실행하시겠습니까?
+```
+
+한 줄 합성 (예: `[funding] ... [action] ...`) 금지.
+
+### 11. Footer
+
+```
+*개정 포맷 v2 — dust non-actionable, unverified cap 명시, obligation-aware tier,
+market-regime gate, TC/CIO 책임 분리. 근거: [ROB-133](/ROB/issues/ROB-133) /
+[ROB-134](/ROB/issues/ROB-134) / [ROB-138](/ROB/issues/ROB-138).*
+```
+
+## F-1. Follow-up answer format
+
+보드가 `지금은 X 원 입금할게 (target={symbol}?)` 형태로 답하면 **2-phase 발송**.
+
+### Step 1 — TC preliminary (즉시 발송, 숫자 재계산만)
+
+CIO 는 이 블록을 생성하지 않는다. TC 레이어 (`build_tc_preliminary` in
+`app/services/n8n_daily_brief_service.py`) 가 즉시 회신. 이 phase 의 출력은
+CIO 판단 없이 숫자만:
+
+```
+📊 TC Preliminary — 자금 현황 재계산
+- 입금 반영 거래소 KRW: {exchange_krw + X} KRW
+- 반영 후 runway: ≈ {(exchange_krw + X) / krw_per_day:.1f}일
+- 다음 obligation (D-{days_remaining}): 필요 burn ≈ {cash_needed_until}, 반영 후 cushion ≈ {exchange_krw + X - cash_needed_until}
+- Unverified external funding cap 잔여: {unverified_cap.amount - X} KRW (confirmed_at 갱신 필요)
+
+경로 A·B 병행 가능. CIO 분기 판단은 후속 메시지로 전달됩니다.
+```
+
+### Step 2 — CIO pending decision (gate 판정 후 이어지는 메시지)
+
+CIO 프롬프트가 생성한다. 반드시 G1~G6 6 줄을 **정확한 순서** 로 출력.
+
+```
+🎯 CIO pending decision — Gate 판정 결과
+
+- G1 데이터 충분성: {pass|fail} — {fail 시 결측 필드 또는 force_cash_policy_note}
+- G2 입금 목적: **{운영 runway 복구 | 신규 risk budget}**
+- G3 Runway/Obligation: cushion {value} KRW — {통과|부족}
+- G4 BTC regime: close vs 20D MA={above|below}, ma20_slope={up|flat|down}, drawdown_14d_pct={value} — {통과|대기|차단}
+- G5 Volatility halt: {해당 없음 | 24h drawdown >10% → 유예}
+- G6 보조지표 (참고): RSI={rsi_14}, 당일 등락률={...}, 지지/저항={support_14d}/{resistance_14d}, 거래량={...}
+
+CIO 권고: **({번호}) {label}**
+- {근거 1}
+- {근거 2}
+- {필요 시 Hard Gate 후보 재언급: HARD_GATE_REMINDER}
+
+질문
+[funding] ...
+[action] ...
+```
+
+G6 보조지표는 **참고** 만 한다. G6 단독으로 권고를 `(1) 즉시 매수` 로 전환할 수 없다.
+
+## Gate phrase library (엔지니어링 추출 대상)
+
+엔지니어링 측에서 별도 파일 `app/services/cio_coin_briefing/prompts/gate_phrases.py`
+에 Python 상수로 추출해 `BoardBriefContext` render 경로와 연결할 것을 권장한다.
+(본 프롬프트 안에서도 동일 문자열을 사용해야 일관성이 유지된다.)
+
+### G2 (funding intent)
+
+```python
+G2_LINE_RUNWAY      = "- G2 입금 목적: **운영 runway 복구** (신규 risk budget 아님)"
+G2_LINE_NEW_BUDGET  = "- G2 입금 목적: **신규 risk budget** (운영 runway 는 이미 충족)"
+
+# G2 == runway 복구 일 때 CIO 권고 default (fixed)
+G2_RECOMMENDATION_FIXED = "CIO 권고: **(3) 현금 비중 유지**"
+
+# G2 == runway 일 때만 삽입하는 근거 라인
+G2_RUNWAY_FUEL_LINES = [
+    "- 이번 {amount} 원은 **운영 연료** 로 귀속 — coinmoogi DCA {days} 일 지속분 + 만기 cushion.",
+    "- 신규 매수 여력으로 전용 금지. G2 에서 차단.",
+]
+
+# G2 == new_buy 일 때만 삽입하는 근거 라인
+G2_NEW_BUDGET_LINES = [
+    "- 이번 {amount} 원은 G3 (runway/obligation) 통과 후 신규 risk budget 후보.",
+    "- 이 경우에도 G4 시장 regime → G5 volatility halt → G6 보조지표 통과 여부 추가 판정 필요.",
+]
+
+HARD_GATE_REMINDER = (
+    "- {symbol} 부분매도는 별도 Hard Gate critique 으로 계속 진행 "
+    "(경로 B 는 concentration 문제를 여전히 해결해야 함)."
+)
+```
+
+### 경로 A·B (비배타)
+
+```python
+FRAMING_AB_PATH_NON_EXCLUSIVE = (
+    "경로 A (입금) 와 경로 B (현물 부분매도) 는 **상호배타 아님**. 병행 가능합니다."
+)
+
+PATH_SECTION_AB_REPEAT = "**A 와 B 는 상호배타 아님 — 병행 가능.**"
+
+BOARD_QUESTIONS_TEMPLATE = """### 보드에게 질문 (응답 요청, 분리)
+1) **[funding]** manual_cash 중 오늘 실제 입금 가능액이 있습니까? 있다면 얼마, 언제까지?
+2) **[action]** {hard_gate_symbol} 현물 {quantity_range} 부분매도를 Hard Gate critique 에 올려 실행하시겠습니까?"""
+```
+
+### 금지 패턴 (render 후처리 regex 검증)
+
+아래 regex 패턴 중 하나라도 최종 렌더링 본문에서 매칭되면 assertion fail 로 빌드를
+막을 것. 사람이 프롬프트를 우회해도 배포 직전에 차단된다.
+
+```python
+FORBIDDEN_PATTERNS = [
+    r"A\s*(또는|혹은|or)\s*B",            # "A 또는 B 중 선택"
+    r"A\s*vs\.?\s*B",
+    r"입금\s*(또는|혹은|or)\s*매도",
+    r"(중|중에서)\s*택1",
+    r"\[funding\].*\[action\]",             # 한 줄에 합친 질문
+    r"(우선|먼저)\s*A",                    # A/B 순위 부여 금지 (G2 판정으로만 분기)
+    r"(우선|먼저)\s*B",
+    r"가용\s*현금[^(]*10,?000,?000",      # manual_cash 를 "가용 현금"으로 호칭 금지
+    r"Planning\s*cash",                     # 구 명칭 유출 금지
+    r"RSI\s*<\s*35.*즉시\s*매수",         # 단일 RSI trigger → 즉시 매수 금지
+]
+```
+
+## 통합 체크리스트 (Staff Engineer S1 통합 시 확인)
+
+- [ ] 본 `.md` 파일이 `app/services/cio_coin_briefing/prompts/board_briefing_v2.md` 경로에 저장됐는가
+- [ ] `gate_phrases.py` 로 G2/경로 A·B/FORBIDDEN_PATTERNS 가 Python 상수로 추출됐는가
+      (프롬프트 문자열 중복 방지)
+- [ ] `FORBIDDEN_PATTERNS` 가 `build_cio_pending` 및 `build_tc_preliminary` render 경로의
+      후처리 검증 훅에 연결됐는가
+- [ ] `BoardBriefContext` 에 `exchange_krw`, `unverified_cap`, `next_obligation`,
+      `tier_scenarios`, `hard_gate_candidates`, `data_sufficient_by_symbol`, `btc_regime`
+      확장 필드가 추가됐는가
+- [ ] 샘플 입력 1건 (ROB-134 plan v2 §F 기준 수치) 으로 렌더링 시
+      plan v2 §G 체크리스트 12 개 모두 통과하는가
+- [ ] G6 단독 trigger 검출 테스트 (RSI 만 < 35 인데 `(1) 즉시 매수` 가 나오면 fail) 가 추가됐는가
+
+## 검토 핸드오프
+
+- 본 v2 프롬프트는 [ROB-138](/ROB/issues/ROB-138) Reviewer v1 critique 5 개 항목
+  (manual_cash 명칭/경고, obligation-aware tier, regime-gate D-2, dust cleanup backlog,
+  TC/CIO 책임 분리) 을 모두 반영함을 CIO 가 확인.
+- 다음 게이트: **Investment Reviewer v2 critique** (Hard Gate, plan v2 §H #4).
+  본 프롬프트의 **운영 리스크** (rule violation, gate 순서 붕괴, 보드 오독 유도 여지)
+  관점 critique 요청.
+- Reviewer critique 통과 후 → Staff Engineer 통합 subtask (gate_phrases 추출 +
+  FORBIDDEN_PATTERNS 후처리 훅 + 샘플 렌더링 테스트) 를 기동 → CEO 최종 승인.

--- a/app/services/cio_coin_briefing/prompts/gate_phrases.py
+++ b/app/services/cio_coin_briefing/prompts/gate_phrases.py
@@ -1,0 +1,39 @@
+"""Prompt v2 phrase constants used by board brief renderers."""
+
+import re
+
+G2_RUNWAY_FUEL_LINES = [
+    "- 이번 {amount} 원은 **운영 연료** 로 귀속 — coinmoogi DCA {days} 일 지속분 + 만기 cushion.",
+    "- 신규 매수 여력으로 전용 금지. G2 에서 차단.",
+]
+
+G2_NEW_BUDGET_LINES = [
+    "- 이번 {amount} 원은 G3 (runway/obligation) 통과 후 신규 risk budget 후보.",
+    "- 이 경우에도 G4 시장 regime → G5 volatility halt → G6 보조지표 통과 여부 추가 판정 필요.",
+]
+
+FRAMING_AB_PATH_NON_EXCLUSIVE = (
+    "경로 A (입금) 와 경로 B (현물 부분매도) 는 **상호배타 아님**. 병행 가능합니다."
+)
+
+PATH_SECTION_AB_REPEAT = "**A 와 B 는 상호배타 아님 — 병행 가능.**"
+
+BOARD_QUESTIONS_TEMPLATE = """질문 (Step 1 답변 반영 — 재질문 아님)
+1) **[funding-confirmation]** manual_cash 중 오늘 실제 입금 가능액이 있습니까? 있다면 얼마, 언제까지?
+2) **[action]** 부분매도를 Hard Gate critique 에 올려 실행하시겠습니까?"""
+
+FORBIDDEN_PATTERN_STRINGS = [
+    r"\[funding\].*\[action\]",
+    r"가용\s*현금[^(]*\d",
+    r"Planning\s*cash",
+    r"\b유휴\s*자금\b",
+    r"\b예비\s*자금\b",
+    r"\b대기\s*자금\b",
+    r"\b대기\s*cash\b",
+    r"\b입금\s*여력\b",
+    r"\b천만\s*원\s*(현금|cash|가용)",
+    r"A\s*(또는|혹은|or)\s*B\s*(중|에서)\s*택1?",
+    r"입금\s*(또는|혹은)\s*매도\s*(중|에서)\s*택1?",
+]
+
+FORBIDDEN_PATTERNS = [re.compile(pattern) for pattern in FORBIDDEN_PATTERN_STRINGS]

--- a/app/services/n8n_daily_brief_service.py
+++ b/app/services/n8n_daily_brief_service.py
@@ -715,9 +715,7 @@ def _validate_immediate_buy_gates(
         return []
     gates = _build_gate_results(ctx)
     missing = [
-        name
-        for name in ("G2", "G3", "G4", "G5")
-        if not _gate_passed(gates.get(name))
+        name for name in ("G2", "G3", "G4", "G5") if not _gate_passed(gates.get(name))
     ]
     if not missing:
         return []

--- a/app/services/n8n_daily_brief_service.py
+++ b/app/services/n8n_daily_brief_service.py
@@ -625,42 +625,44 @@ def _contains_fail_closed_anchor(text: str) -> bool:
     return any(_FAIL_CLOSED_ANCHOR_RE.match(line) for line in text.splitlines())
 
 
-def validate_render_invariants(
-    text: str,
-    ctx: BoardBriefContext,
-    *,
-    phase: BoardBriefPhase,
-) -> list[InvariantViolation]:
-    """Return structural render invariant violations for final markdown."""
-    violations: list[InvariantViolation] = []
-
+def _validate_funding_rows(text: str) -> list[InvariantViolation]:
     exchange_rows = _line_count(text, "거래소 KRW:")
     unverified_rows = _line_count(text, "미확인 cap")
-    if exchange_rows != 1 or unverified_rows != 1:
-        violations.append(
-            InvariantViolation(
-                code="funding_rows",
-                detail=(
-                    "expected 거래소 KRW and 미확인 cap rows exactly once "
-                    f"(got {exchange_rows}/{unverified_rows})"
-                ),
-            )
+    if exchange_rows == 1 and unverified_rows == 1:
+        return []
+    return [
+        InvariantViolation(
+            code="funding_rows",
+            detail=(
+                "expected 거래소 KRW and 미확인 cap rows exactly once "
+                f"(got {exchange_rows}/{unverified_rows})"
+            ),
         )
+    ]
 
+
+def _validate_runway_excludes_unverified_cap(
+    text: str, ctx: BoardBriefContext
+) -> list[InvariantViolation]:
     runway_lines = [line for line in text.splitlines() if "runway" in line.lower()]
     unverified_amounts = _format_unverified_amounts(ctx)
-    if any(
+    if not any(
         amount and amount in line
         for line in runway_lines
         for amount in unverified_amounts
     ):
-        violations.append(
-            InvariantViolation(
-                code="runway_excludes_unverified_cap",
-                detail="runway line includes unverified_cap amount",
-            )
+        return []
+    return [
+        InvariantViolation(
+            code="runway_excludes_unverified_cap",
+            detail="runway line includes unverified_cap amount",
         )
+    ]
 
+
+def _validate_ab_anchors(
+    text: str, *, phase: BoardBriefPhase
+) -> list[InvariantViolation]:
     framing_count = text.count(FRAMING_AB_PATH_NON_EXCLUSIVE)
     path_repeat_count = text.count(PATH_SECTION_AB_REPEAT)
     funding_question_count = text.count("[funding-confirmation]") + text.count(
@@ -676,64 +678,104 @@ def validate_render_invariants(
         )
     else:
         ab_ok = framing_count == 1 and path_repeat_count == 1
-    if not ab_ok:
-        violations.append(
-            InvariantViolation(
-                code="ab_anchor_triple",
-                detail=(
-                    "expected A/B framing, repeat, and CIO question anchors exactly once "
-                    f"(got {framing_count}/{path_repeat_count}/"
-                    f"{funding_question_count}/{action_question_count})"
-                ),
-            )
+    if ab_ok:
+        return []
+    return [
+        InvariantViolation(
+            code="ab_anchor_triple",
+            detail=(
+                "expected A/B framing, repeat, and CIO question anchors exactly once "
+                f"(got {framing_count}/{path_repeat_count}/"
+                f"{funding_question_count}/{action_question_count})"
+            ),
         )
+    ]
 
-    if phase == "cio_pending":
-        runway_phrase_count = text.count("**운영 연료**")
-        new_budget_phrase_count = text.count("신규 risk budget 후보")
-        if runway_phrase_count + new_budget_phrase_count != 1:
-            violations.append(
-                InvariantViolation(
-                    code="g2_phrase_exactly_one",
-                    detail=(
-                        "expected exactly one G2 phrase head "
-                        f"(got {runway_phrase_count}/{new_budget_phrase_count})"
-                    ),
-                )
-            )
 
-        if "CIO 권고 (1) 즉시 매수" in text:
-            gates = _build_gate_results(ctx)
-            missing = [
-                name
-                for name in ("G2", "G3", "G4", "G5")
-                if not _gate_passed(gates.get(name))
-            ]
-            if missing:
-                violations.append(
-                    InvariantViolation(
-                        code="immediate_buy_requires_g2_g5_pass",
-                        detail=f"immediate buy rendered while {', '.join(missing)} not pass",
-                    )
-                )
+def _validate_g2_phrase(text: str) -> list[InvariantViolation]:
+    runway_phrase_count = text.count("**운영 연료**")
+    new_budget_phrase_count = text.count("신규 risk budget 후보")
+    if runway_phrase_count + new_budget_phrase_count == 1:
+        return []
+    return [
+        InvariantViolation(
+            code="g2_phrase_exactly_one",
+            detail=(
+                "expected exactly one G2 phrase head "
+                f"(got {runway_phrase_count}/{new_budget_phrase_count})"
+            ),
+        )
+    ]
 
+
+def _validate_immediate_buy_gates(
+    text: str, ctx: BoardBriefContext
+) -> list[InvariantViolation]:
+    if "CIO 권고 (1) 즉시 매수" not in text:
+        return []
+    gates = _build_gate_results(ctx)
+    missing = [
+        name
+        for name in ("G2", "G3", "G4", "G5")
+        if not _gate_passed(gates.get(name))
+    ]
+    if not missing:
+        return []
+    return [
+        InvariantViolation(
+            code="immediate_buy_requires_g2_g5_pass",
+            detail=f"immediate buy rendered while {', '.join(missing)} not pass",
+        )
+    ]
+
+
+def _validate_cio_pending_invariants(
+    text: str, ctx: BoardBriefContext
+) -> list[InvariantViolation]:
+    return [
+        *_validate_g2_phrase(text),
+        *_validate_immediate_buy_gates(text, ctx),
+    ]
+
+
+def _validate_dust_aggregate(text: str) -> list[InvariantViolation]:
     dust_count = sum(1 for line in text.splitlines() if _DUST_AGGREGATE_RE.match(line))
-    if dust_count != 1:
-        violations.append(
-            InvariantViolation(
-                code="dust_aggregate",
-                detail=f"expected exactly one dust aggregate line (got {dust_count})",
-            )
+    if dust_count == 1:
+        return []
+    return [
+        InvariantViolation(
+            code="dust_aggregate",
+            detail=f"expected exactly one dust aggregate line (got {dust_count})",
         )
+    ]
 
-    if _contains_fail_closed_anchor(text):
-        violations.append(
-            InvariantViolation(
-                code="fail_closed_anchor",
-                detail="fail-closed anchors must bypass normal board render validation",
-            )
+
+def _validate_fail_closed_anchor(text: str) -> list[InvariantViolation]:
+    if not _contains_fail_closed_anchor(text):
+        return []
+    return [
+        InvariantViolation(
+            code="fail_closed_anchor",
+            detail="fail-closed anchors must bypass normal board render validation",
         )
+    ]
 
+
+def validate_render_invariants(
+    text: str,
+    ctx: BoardBriefContext,
+    *,
+    phase: BoardBriefPhase,
+) -> list[InvariantViolation]:
+    """Return structural render invariant violations for final markdown."""
+    violations: list[InvariantViolation] = []
+    violations.extend(_validate_funding_rows(text))
+    violations.extend(_validate_runway_excludes_unverified_cap(text, ctx))
+    violations.extend(_validate_ab_anchors(text, phase=phase))
+    if phase == "cio_pending":
+        violations.extend(_validate_cio_pending_invariants(text, ctx))
+    violations.extend(_validate_dust_aggregate(text))
+    violations.extend(_validate_fail_closed_anchor(text))
     return violations
 
 

--- a/app/services/n8n_daily_brief_service.py
+++ b/app/services/n8n_daily_brief_service.py
@@ -8,18 +8,35 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
+
+import httpx
 
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst
 from app.schemas.n8n.board_brief import (
     BoardBriefContext,
+    BoardBriefPhase,
     BoardBriefRender,
+    BoardFundingResponse,
+    FundingIntent,
     GateResult,
     N8nG2GatePayload,
 )
 from app.schemas.n8n.common import N8nMarketOverview
+from app.services.cio_coin_briefing.prompts.gate_phrases import (
+    BOARD_QUESTIONS_TEMPLATE,
+    FORBIDDEN_PATTERNS,
+    FRAMING_AB_PATH_NON_EXCLUSIVE,
+    G2_NEW_BUDGET_LINES,
+    G2_RUNWAY_FUEL_LINES,
+    PATH_SECTION_AB_REPEAT,
+)
 from app.services.n8n_formatting import (
     fmt_amount,
     fmt_date_with_weekday,
@@ -33,6 +50,47 @@ from app.services.n8n_pending_orders_service import fetch_pending_orders
 logger = logging.getLogger(__name__)
 
 _DEFAULT_MARKETS = ("crypto", "kr", "us")
+_FAIL_CLOSED_ANCHOR_RE = re.compile(r"^⚠️ .+ 누락 — .+$")
+_DUST_AGGREGATE_RE = re.compile(
+    r"^🧹 Dust \d+종목 · 합계 .+ · 포트폴리오 \d+(?:\.\d+)?%$"
+)
+
+
+@dataclass(frozen=True)
+class InvariantViolation:
+    """One render invariant violation."""
+
+    code: str
+    detail: str
+
+
+class RenderInvariantError(RuntimeError):
+    """Raised when final markdown violates render safety invariants."""
+
+    def __init__(self, violations: list[InvariantViolation]) -> None:
+        self.violations = violations
+        details = ", ".join(f"{item.code}: {item.detail}" for item in violations)
+        super().__init__(f"Board brief render invariant failed: {details}")
+
+
+class RenderRouter:
+    """Route render output to board or ops channels.
+
+    The default implementation only performs ops escalation when
+    N8N_OPS_ESCALATION_WEBHOOK is configured. Tests can inject a subclass to
+    assert fail-closed routing without making network calls.
+    """
+
+    def route_ops_escalation(self, message: str) -> None:
+        webhook_url = os.getenv("N8N_OPS_ESCALATION_WEBHOOK", "").strip()
+        if not webhook_url:
+            logger.warning("Ops escalation webhook not configured: %s", message)
+            return
+        try:
+            with httpx.Client(timeout=5) as client:
+                client.post(webhook_url, json={"content": message})
+        except httpx.HTTPError:
+            logger.exception("Failed to send ops escalation webhook")
 
 
 async def _get_portfolio_overview(
@@ -457,6 +515,12 @@ def _fmt_pct(value: float | int | None) -> str:
     return f"{float(value):.1f}%"
 
 
+def _fmt_days(value: float | int | None) -> str:
+    if value is None:
+        return "-"
+    return f"{float(value):.2f}일"
+
+
 def _extract_followup_context(
     payload: BoardBriefContext | dict[str, Any],
 ) -> BoardBriefContext:
@@ -464,6 +528,253 @@ def _extract_followup_context(
     if isinstance(payload, BoardBriefContext):
         return payload
     return BoardBriefContext.model_validate(payload)
+
+
+def _missing_required_context(ctx: BoardBriefContext) -> tuple[str, str] | None:
+    required_checks: list[tuple[str, bool, str]] = [
+        (
+            "exchange_krw",
+            ctx.exchange_krw > 0,
+            "거래소 주문가능 KRW 미수신, 브리핑 생성 불가",
+        ),
+        (
+            "unverified_cap",
+            ctx.unverified_cap is not None,
+            "manual_cash 관련 권고/문구 생성 금지",
+        ),
+        (
+            "next_obligation",
+            ctx.next_obligation is not None,
+            "obligation 행과 경로 A 평가 보류",
+        ),
+        (
+            "tier_scenarios",
+            bool(ctx.tier_scenarios),
+            "입금 시나리오 산출 보류",
+        ),
+        (
+            "data_sufficient_by_symbol",
+            bool(ctx.data_sufficient_by_symbol),
+            "심볼별 G1 데이터 충분성 평가 불가",
+        ),
+        (
+            "btc_regime",
+            ctx.btc_regime is not None,
+            "G4 regime 통과 판정 금지",
+        ),
+        (
+            "holdings",
+            bool(ctx.holdings),
+            "포트폴리오 쏠림 및 dust 평가 불가",
+        ),
+    ]
+    for field, present, reason in required_checks:
+        if not present:
+            return field, reason
+    return None
+
+
+def _route_fail_closed(
+    *,
+    ctx: BoardBriefContext,
+    phase: BoardBriefPhase,
+    field: str,
+    reason: str,
+    router: RenderRouter,
+) -> BoardBriefRender:
+    generated_at = ctx.generated_at or now_kst().replace(microsecond=0)
+    text = f"⚠️ {field} 누락 — {reason}"
+    router.route_ops_escalation(text)
+    logger.error(
+        "Board brief fail-closed render routed to ops",
+        extra={"phase": phase, "missing_field": field},
+    )
+    return BoardBriefRender(
+        phase=phase,
+        embed={},
+        text=text,
+        gate_results=None,
+        generated_at=generated_at,
+    )
+
+
+def _format_unverified_amounts(ctx: BoardBriefContext) -> set[str]:
+    if not ctx.unverified_cap:
+        return set()
+    amount = ctx.unverified_cap.amount
+    return {
+        f"{amount:,.0f}",
+        f"{amount:.0f}",
+        _fmt_krw(amount),
+    }
+
+
+def _gate_passed(gate: GateResult | N8nG2GatePayload | None) -> bool:
+    if isinstance(gate, N8nG2GatePayload):
+        return gate.passed and gate.status == "pass"
+    if isinstance(gate, GateResult):
+        return gate.status == "pass"
+    return False
+
+
+def _line_count(text: str, needle: str) -> int:
+    return sum(1 for line in text.splitlines() if needle in line)
+
+
+def _contains_fail_closed_anchor(text: str) -> bool:
+    return any(_FAIL_CLOSED_ANCHOR_RE.match(line) for line in text.splitlines())
+
+
+def validate_render_invariants(
+    text: str,
+    ctx: BoardBriefContext,
+    *,
+    phase: BoardBriefPhase,
+) -> list[InvariantViolation]:
+    """Return structural render invariant violations for final markdown."""
+    violations: list[InvariantViolation] = []
+
+    exchange_rows = _line_count(text, "거래소 KRW:")
+    unverified_rows = _line_count(text, "미확인 cap")
+    if exchange_rows != 1 or unverified_rows != 1:
+        violations.append(
+            InvariantViolation(
+                code="funding_rows",
+                detail=(
+                    "expected 거래소 KRW and 미확인 cap rows exactly once "
+                    f"(got {exchange_rows}/{unverified_rows})"
+                ),
+            )
+        )
+
+    runway_lines = [line for line in text.splitlines() if "runway" in line.lower()]
+    unverified_amounts = _format_unverified_amounts(ctx)
+    if any(
+        amount and amount in line
+        for line in runway_lines
+        for amount in unverified_amounts
+    ):
+        violations.append(
+            InvariantViolation(
+                code="runway_excludes_unverified_cap",
+                detail="runway line includes unverified_cap amount",
+            )
+        )
+
+    framing_count = text.count(FRAMING_AB_PATH_NON_EXCLUSIVE)
+    path_repeat_count = text.count(PATH_SECTION_AB_REPEAT)
+    funding_question_count = text.count("[funding-confirmation]") + text.count(
+        "[funding]"
+    )
+    action_question_count = text.count("[action]")
+    if phase == "cio_pending":
+        ab_ok = (
+            framing_count == 1
+            and path_repeat_count == 1
+            and funding_question_count == 1
+            and action_question_count == 1
+        )
+    else:
+        ab_ok = framing_count == 1 and path_repeat_count == 1
+    if not ab_ok:
+        violations.append(
+            InvariantViolation(
+                code="ab_anchor_triple",
+                detail=(
+                    "expected A/B framing, repeat, and CIO question anchors exactly once "
+                    f"(got {framing_count}/{path_repeat_count}/"
+                    f"{funding_question_count}/{action_question_count})"
+                ),
+            )
+        )
+
+    if phase == "cio_pending":
+        runway_phrase_count = text.count("**운영 연료**")
+        new_budget_phrase_count = text.count("신규 risk budget 후보")
+        if runway_phrase_count + new_budget_phrase_count != 1:
+            violations.append(
+                InvariantViolation(
+                    code="g2_phrase_exactly_one",
+                    detail=(
+                        "expected exactly one G2 phrase head "
+                        f"(got {runway_phrase_count}/{new_budget_phrase_count})"
+                    ),
+                )
+            )
+
+        if "CIO 권고 (1) 즉시 매수" in text:
+            gates = _build_gate_results(ctx)
+            missing = [
+                name
+                for name in ("G2", "G3", "G4", "G5")
+                if not _gate_passed(gates.get(name))
+            ]
+            if missing:
+                violations.append(
+                    InvariantViolation(
+                        code="immediate_buy_requires_g2_g5_pass",
+                        detail=f"immediate buy rendered while {', '.join(missing)} not pass",
+                    )
+                )
+
+    dust_count = sum(1 for line in text.splitlines() if _DUST_AGGREGATE_RE.match(line))
+    if dust_count != 1:
+        violations.append(
+            InvariantViolation(
+                code="dust_aggregate",
+                detail=f"expected exactly one dust aggregate line (got {dust_count})",
+            )
+        )
+
+    if _contains_fail_closed_anchor(text):
+        violations.append(
+            InvariantViolation(
+                code="fail_closed_anchor",
+                detail="fail-closed anchors must bypass normal board render validation",
+            )
+        )
+
+    return violations
+
+
+def _check_forbidden_patterns(text: str) -> list[InvariantViolation]:
+    violations: list[InvariantViolation] = []
+    for pattern in FORBIDDEN_PATTERNS:
+        if pattern.search(text):
+            violations.append(
+                InvariantViolation(
+                    code="forbidden_pattern",
+                    detail=pattern.pattern,
+                )
+            )
+    return violations
+
+
+def _postprocess_and_validate_render(
+    *,
+    text: str,
+    ctx: BoardBriefContext,
+    phase: BoardBriefPhase,
+    router: RenderRouter,
+    text_postprocessor: Callable[[str], str] | None,
+) -> str:
+    if text_postprocessor:
+        text = text_postprocessor(text)
+
+    violations = _check_forbidden_patterns(text)
+    violations.extend(validate_render_invariants(text, ctx, phase=phase))
+    if violations:
+        message = "; ".join(f"{item.code}: {item.detail}" for item in violations)
+        logger.error(
+            "Board brief render invariant violation",
+            extra={
+                "phase": phase,
+                "violations": [item.__dict__ for item in violations],
+            },
+        )
+        router.route_ops_escalation(message)
+        raise RenderInvariantError(violations)
+    return text
 
 
 def _default_gate_results() -> dict[str, GateResult | N8nG2GatePayload]:
@@ -490,12 +801,89 @@ def _build_gate_results(
     return gates
 
 
+def _has_v2_funding_context(ctx: BoardBriefContext) -> bool:
+    return bool(
+        ctx.exchange_krw
+        or ctx.unverified_cap
+        or ctx.next_obligation
+        or ctx.tier_scenarios
+    )
+
+
 def _cash_runway_days(ctx: BoardBriefContext) -> float | None:
     if ctx.manual_cash_runway_days is not None:
         return ctx.manual_cash_runway_days
+    if _has_v2_funding_context(ctx) and ctx.daily_burn_krw > 0:
+        return ctx.exchange_krw / ctx.daily_burn_krw
     if ctx.daily_burn_krw > 0:
         return ctx.manual_cash_krw / ctx.daily_burn_krw
     return None
+
+
+def _funding_amount(board_response: BoardFundingResponse | None) -> float:
+    return board_response.amount if board_response else 0
+
+
+def _funding_verified(
+    ctx: BoardBriefContext, board_response: BoardFundingResponse | None
+) -> bool:
+    return bool(
+        (board_response and board_response.manual_cash_verified)
+        or (ctx.unverified_cap and ctx.unverified_cap.verified_by_boss_today)
+    )
+
+
+def _format_g2_lines(lines: list[str], *, amount: float, days: int) -> list[str]:
+    return [line.format(amount=f"{amount:,.0f}", days=days) for line in lines]
+
+
+def resolve_funding_intent(
+    ctx: BoardBriefContext,
+    board_response: BoardFundingResponse | None,
+) -> tuple[FundingIntent, list[str]]:
+    """Resolve G2 funding intent and the exact phrase set to render.
+
+    >>> ctx = BoardBriefContext(exchange_krw=100, daily_burn_krw=10)
+    >>> resolve_funding_intent(ctx, None)[0]
+    'runway_recovery'
+    >>> response = BoardFundingResponse(
+    ...     amount=100, target="BTC", funding_intent="new_buy", manual_cash_verified=True
+    ... )
+    >>> ctx = BoardBriefContext(
+    ...     exchange_krw=100, daily_burn_krw=10,
+    ...     next_obligation={"date": "2026-04-24", "days_remaining": 7, "cash_needed_until": 50}
+    ... )
+    >>> resolve_funding_intent(ctx, response)[0]
+    'new_buy'
+    """
+    amount = _funding_amount(board_response)
+    days = ctx.next_obligation.days_remaining if ctx.next_obligation else 0
+    runway_lines = _format_g2_lines(
+        G2_RUNWAY_FUEL_LINES,
+        amount=amount,
+        days=days,
+    )
+    new_budget_lines = _format_g2_lines(
+        G2_NEW_BUDGET_LINES,
+        amount=amount,
+        days=days,
+    )
+
+    verified_amount = amount if _funding_verified(ctx, board_response) else 0
+    if (
+        ctx.next_obligation
+        and ctx.next_obligation.cash_needed_until > ctx.exchange_krw + verified_amount
+    ):
+        return "runway_recovery", runway_lines
+
+    if (
+        board_response
+        and board_response.target
+        and _funding_verified(ctx, board_response)
+    ):
+        return "new_buy", new_budget_lines
+
+    return "runway_recovery", runway_lines
 
 
 def _build_concentration_lines(ctx: BoardBriefContext) -> list[str]:
@@ -519,30 +907,79 @@ def _build_candidate_lines(ctx: BoardBriefContext) -> list[str]:
 
 def _build_dust_lines(ctx: BoardBriefContext) -> list[str]:
     dust_items = ctx.dust_items or [holding for holding in ctx.holdings if holding.dust]
-    if not dust_items:
-        return []
-    joined = ", ".join(
-        f"{item.symbol} (~{float(item.current_krw_value):,.0f} KRW)"
-        for item in dust_items[:8]
+    dust_total = sum(float(item.current_krw_value) for item in dust_items)
+    portfolio_total = sum(float(holding.current_krw_value) for holding in ctx.holdings)
+    dust_pct = (dust_total / portfolio_total * 100) if portfolio_total > 0 else 0
+    return [
+        f"🧹 Dust {len(dust_items)}종목 · 합계 {_fmt_krw(dust_total)} · 포트폴리오 {dust_pct:.2f}%"
+    ]
+
+
+def _build_funding_lines(ctx: BoardBriefContext) -> list[str]:
+    runway_days = _cash_runway_days(ctx)
+    unverified_cap = ctx.unverified_cap.amount if ctx.unverified_cap else None
+    unverified_badges = []
+    if ctx.unverified_cap and ctx.unverified_cap.stale_warning:
+        unverified_badges.append("stale_warning")
+    if ctx.unverified_cap and ctx.unverified_cap.verified_by_boss_today:
+        unverified_badges.append("verified_by_boss_today")
+    badge_text = f" ({' / '.join(unverified_badges)})" if unverified_badges else ""
+    obligation = (
+        f"{ctx.next_obligation.date.isoformat()} / D-{ctx.next_obligation.days_remaining} / "
+        f"{_fmt_krw(ctx.next_obligation.cash_needed_until)}"
+        if ctx.next_obligation
+        else "-"
+    )
+    runway_formula = (
+        f"{_fmt_krw(ctx.exchange_krw)} / {_fmt_krw(ctx.daily_burn_krw)} = "
+        f"{_fmt_days(runway_days)}"
+        if runway_days is not None and ctx.daily_burn_krw > 0
+        else "-"
     )
     return [
-        "🧹 Dust",
-        f"{joined} — Upbit 최소 주문 금액 미만, execution-actionable 제외, journal 유지. cleanup backlog.",
+        f"- 거래소 KRW: {_fmt_krw(ctx.exchange_krw)}",
+        f"- 미확인 cap (보스 확인 전): {_fmt_krw(unverified_cap)}{badge_text}",
+        f"- 일일 소진 (daily_burn): {_fmt_krw(ctx.daily_burn_krw)}",
+        f"- 다음 의무 (date / days_remaining / cash_needed_until): {obligation}",
+        f"- runway 산식: {runway_formula}",
     ]
+
+
+def _build_tier_lines(ctx: BoardBriefContext) -> list[str]:
+    if not ctx.tier_scenarios:
+        return ["tier_scenarios 미수신, 입금 시나리오 산출 보류"]
+    obligation = (
+        f"{ctx.next_obligation.date.isoformat()} / D-{ctx.next_obligation.days_remaining}"
+        if ctx.next_obligation
+        else "-"
+    )
+    lines = [
+        (
+            "deposit_amount | next_obligation | cash_needed_until | "
+            "cushion_after_obligation | target_exchange_krw | buffer_days (보조)"
+        )
+    ]
+    for scenario in ctx.tier_scenarios:
+        cash_needed = (
+            ctx.next_obligation.cash_needed_until if ctx.next_obligation else None
+        )
+        lines.append(
+            f"{_fmt_krw(scenario.deposit_amount)} | {obligation} | "
+            f"{_fmt_krw(cash_needed)} | {_fmt_krw(scenario.cushion_after_obligation)} | "
+            f"{_fmt_krw(scenario.target_exchange_krw)} | {scenario.buffer_days}"
+        )
+    return lines
 
 
 def _build_tc_preliminary_text(ctx: BoardBriefContext) -> str:
     """Build TC preliminary text without recommendation or gate sections."""
-    runway_days = _cash_runway_days(ctx)
     lines = [
-        "📊 TC Preliminary — 자금 현황 재계산",
+        "📊 TC Preliminary — 입금 약속 반영 시나리오 (pledged, 거래소 미반영)",
         "",
-        "요약: 경로 A·B 병행 가능. 현금 runway와 포지션 쏠림을 먼저 재계산한다.",
+        f"요약: 경로 A·B 병행 가능. {FRAMING_AB_PATH_NON_EXCLUSIVE}",
         "",
         "💵 자금 현황",
-        f"- 수동 현금: {_fmt_krw(ctx.manual_cash_krw)}",
-        f"- 일 burn: {_fmt_krw(ctx.daily_burn_krw)}",
-        f"- runway: {_fmt_pct(runway_days).replace('%', '일') if runway_days is not None else '-'}",
+        *_build_funding_lines(ctx),
         "",
         "📌 쏠림/편중",
         *_build_concentration_lines(ctx),
@@ -558,6 +995,10 @@ def _build_tc_preliminary_text(ctx: BoardBriefContext) -> str:
             "",
             "경로 A: 신규 매수 없이 현금 runway 회복 우선.",
             "경로 B: board funding 확인 후 CIO pending decision에서 gate 재평가.",
+            "",
+            "§7 Tier table",
+            *_build_tier_lines(ctx),
+            PATH_SECTION_AB_REPEAT,
         ]
     )
     return "\n".join(lines)
@@ -580,6 +1021,7 @@ def _build_cio_pending_text(ctx: BoardBriefContext) -> str:
     gates = _build_gate_results(ctx)
     g2 = gates["G2"]
     g2_failed = isinstance(g2, N8nG2GatePayload) and not g2.passed
+    _, g2_lines = resolve_funding_intent(ctx, ctx.board_response)
     lines = [
         _build_tc_preliminary_text(ctx),
         "",
@@ -589,6 +1031,7 @@ def _build_cio_pending_text(ctx: BoardBriefContext) -> str:
             if g2_failed
             else "CIO 의견 대기 중 — gate 결과 확인 후 action 확정"
         ),
+        *g2_lines,
         "",
         "📊 Gate 판정 결과",
     ]
@@ -603,9 +1046,7 @@ def _build_cio_pending_text(ctx: BoardBriefContext) -> str:
     lines.extend(
         [
             "",
-            "질문",
-            "[funding] 경로 A·B 병행 가능 기준으로 board funding 금액/목적을 확정할 것.",
-            "[action] 경로 A·B 병행 가능 조건에서 신규 매수, 현금 회복, 축소 중 하나를 선택할 것.",
+            BOARD_QUESTIONS_TEMPLATE,
         ]
     )
     return "\n".join(lines)
@@ -621,15 +1062,34 @@ def _build_board_embed(*, title: str, text: str, color: int) -> dict[str, Any]:
 
 def build_tc_preliminary(
     payload: BoardBriefContext | dict[str, Any],
+    *,
+    router: RenderRouter | None = None,
+    text_postprocessor: Callable[[str], str] | None = None,
 ) -> BoardBriefRender:
     """Render the first TC follow-up phase."""
     ctx = _extract_followup_context(payload)
+    router = router or RenderRouter()
+    if missing := _missing_required_context(ctx):
+        return _route_fail_closed(
+            ctx=ctx,
+            phase="tc_preliminary",
+            field=missing[0],
+            reason=missing[1],
+            router=router,
+        )
     generated_at = ctx.generated_at or now_kst().replace(microsecond=0)
     text = _build_tc_preliminary_text(ctx)
+    text = _postprocess_and_validate_render(
+        text=text,
+        ctx=ctx,
+        phase="tc_preliminary",
+        router=router,
+        text_postprocessor=text_postprocessor,
+    )
     return BoardBriefRender(
         phase="tc_preliminary",
         embed=_build_board_embed(
-            title="📊 TC Preliminary — 자금 현황 재계산",
+            title="📊 TC Preliminary — 입금 약속 반영 시나리오 (pledged, 거래소 미반영)",
             text=text,
             color=0x3498DB,
         ),
@@ -641,13 +1101,35 @@ def build_tc_preliminary(
 
 def build_cio_pending_decision(
     payload: BoardBriefContext | dict[str, Any],
+    *,
+    router: RenderRouter | None = None,
+    text_postprocessor: Callable[[str], str] | None = None,
 ) -> BoardBriefRender:
     """Render the second CIO follow-up phase."""
     ctx = _extract_followup_context(payload)
+    router = router or RenderRouter()
+    if missing := _missing_required_context(ctx):
+        return _route_fail_closed(
+            ctx=ctx,
+            phase="cio_pending",
+            field=missing[0],
+            reason=missing[1],
+            router=router,
+        )
     generated_at = ctx.generated_at or now_kst().replace(microsecond=0)
     gate_results = _build_gate_results(ctx)
-    ctx = ctx.model_copy(update={"gate_results": gate_results})
+    funding_intent, _ = resolve_funding_intent(ctx, ctx.board_response)
+    ctx = ctx.model_copy(
+        update={"funding_intent": funding_intent, "gate_results": gate_results}
+    )
     text = _build_cio_pending_text(ctx)
+    text = _postprocess_and_validate_render(
+        text=text,
+        ctx=ctx,
+        phase="cio_pending",
+        router=router,
+        text_postprocessor=text_postprocessor,
+    )
     return BoardBriefRender(
         phase="cio_pending",
         embed=_build_board_embed(
@@ -656,6 +1138,7 @@ def build_cio_pending_decision(
             color=0xF1C40F,
         ),
         text=text,
+        funding_intent=funding_intent,
         gate_results=gate_results,
         generated_at=generated_at,
     )
@@ -799,7 +1282,11 @@ async def fetch_daily_brief(
 
 
 __all__ = [
+    "InvariantViolation",
+    "RenderInvariantError",
+    "RenderRouter",
     "build_cio_pending_decision",
     "build_tc_preliminary",
     "fetch_daily_brief",
+    "validate_render_invariants",
 ]

--- a/app/services/n8n_daily_brief_service.py
+++ b/app/services/n8n_daily_brief_service.py
@@ -50,7 +50,8 @@ from app.services.n8n_pending_orders_service import fetch_pending_orders
 logger = logging.getLogger(__name__)
 
 _DEFAULT_MARKETS = ("crypto", "kr", "us")
-_FAIL_CLOSED_ANCHOR_RE = re.compile(r"^⚠️ .+ 누락 — .+$")
+_FAIL_CLOSED_PREFIX = "⚠️ "
+_FAIL_CLOSED_SEPARATOR = " 누락 — "
 _DUST_AGGREGATE_RE = re.compile(
     r"^🧹 Dust \d+종목 · 합계 .+ · 포트폴리오 \d+(?:\.\d+)?%$"
 )
@@ -622,7 +623,10 @@ def _line_count(text: str, needle: str) -> int:
 
 
 def _contains_fail_closed_anchor(text: str) -> bool:
-    return any(_FAIL_CLOSED_ANCHOR_RE.match(line) for line in text.splitlines())
+    return any(
+        line.startswith(_FAIL_CLOSED_PREFIX) and _FAIL_CLOSED_SEPARATOR in line
+        for line in text.splitlines()
+    )
 
 
 def _validate_funding_rows(text: str) -> list[InvariantViolation]:

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Shared pytest fixture helpers."""

--- a/tests/fixtures/cio_briefing.py
+++ b/tests/fixtures/cio_briefing.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from copy import deepcopy
+from typing import Any
+
+from app.schemas.n8n.board_brief import BoardBriefContext, GateResult, N8nG2GatePayload
+from app.services.n8n_daily_brief_service import RenderRouter
+
+
+def plan_v2_section_f_dataset(**updates: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "exchange_krw": 83_318,
+        "unverified_cap": {
+            "amount": 10_000_000,
+            "confirmed_at": None,
+            "verified_by_boss_today": False,
+            "stale_warning": True,
+        },
+        "manual_cash_krw": 10_000_000,
+        "daily_burn_krw": 80_000,
+        "next_obligation": {
+            "date": "2026-04-29",
+            "days_remaining": 12,
+            "cash_needed_until": 960_000,
+        },
+        "tier_scenarios": [
+            {
+                "label": "T1",
+                "deposit_amount": 516_682,
+                "target_exchange_krw": 600_000,
+                "buffer_days": 7,
+                "cushion_after_obligation": -360_000,
+            },
+            {
+                "label": "T2",
+                "deposit_amount": 1_116_682,
+                "target_exchange_krw": 1_200_000,
+                "buffer_days": 15,
+                "cushion_after_obligation": 240_000,
+            },
+            {
+                "label": "T3",
+                "deposit_amount": 2_316_682,
+                "target_exchange_krw": 2_400_000,
+                "buffer_days": 30,
+                "cushion_after_obligation": 1_440_000,
+            },
+        ],
+        "hard_gate_candidates": [
+            {
+                "symbol": "SOL",
+                "proposal": "SOL 현물 8~10개 부분매도",
+                "amount_range": "1.13~1.40M KRW",
+            }
+        ],
+        "data_sufficient_by_symbol": {"BTC": True, "SOL": True},
+        "btc_regime": {
+            "close_vs_20d_ma": "above",
+            "ma20_slope": "flat",
+            "drawdown_14d_pct": -3.2,
+        },
+        "weights_top_n": [
+            {"symbol": "SOL", "weight_pct": 32},
+            {"symbol": "ETH", "weight_pct": 28},
+            {"symbol": "BTC", "weight_pct": 11},
+            {"symbol": "XRP", "weight_pct": 11},
+            {"symbol": "LINK", "weight_pct": 10},
+        ],
+        "holdings": [
+            {"symbol": "SOL", "current_krw_value": 3_200_000, "dust": False},
+            {"symbol": "ETH", "current_krw_value": 2_800_000, "dust": False},
+            {"symbol": "BTC", "current_krw_value": 1_100_000, "dust": False},
+            {"symbol": "XRP", "current_krw_value": 1_100_000, "dust": False},
+            {"symbol": "LINK", "current_krw_value": 1_000_000, "dust": False},
+            {"symbol": "APT", "current_krw_value": 654, "dust": True},
+        ],
+        "dust_items": [{"symbol": "APT", "current_krw_value": 654}],
+        "gate_results": {
+            "G1": GateResult(status="pass", detail="데이터 충분"),
+            "G2": N8nG2GatePayload(
+                passed=True,
+                status="pass",
+                detail="운영 runway 복구",
+            ),
+            "G3": GateResult(status="pass", detail="cushion 충족"),
+            "G4": GateResult(status="pass", detail="BTC regime 통과"),
+            "G5": GateResult(status="pass", detail="volatility halt 없음"),
+            "G6": GateResult(status="pass", detail="RSI=45 보조지표 통과"),
+        },
+    }
+    payload.update(updates)
+    return payload
+
+
+def plan_v2_section_f_context(**updates: Any) -> BoardBriefContext:
+    return BoardBriefContext.model_validate(plan_v2_section_f_dataset(**updates))
+
+
+def drop_required_field(field: str) -> dict[str, Any]:
+    payload = deepcopy(plan_v2_section_f_dataset())
+    if field in {
+        "exchange_krw",
+        "unverified_cap",
+        "next_obligation",
+        "tier_scenarios",
+        "data_sufficient_by_symbol",
+        "btc_regime",
+        "holdings",
+    }:
+        payload.pop(field)
+    else:
+        raise ValueError(f"Unknown required field: {field}")
+    return payload
+
+
+def replace_once(old: str, new: str) -> Callable[[str], str]:
+    def _postprocess(text: str) -> str:
+        assert old in text
+        return text.replace(old, new, 1)
+
+    return _postprocess
+
+
+class RecordingRouter(RenderRouter):
+    def __init__(self) -> None:
+        self.board_messages: list[str] = []
+        self.ops_messages: list[str] = []
+
+    def route_board(self, message: str) -> None:
+        self.board_messages.append(message)
+
+    def route_ops_escalation(self, message: str) -> None:
+        self.ops_messages.append(message)

--- a/tests/test_board_brief_render_v2.py
+++ b/tests/test_board_brief_render_v2.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from app.schemas.n8n.board_brief import BoardBriefContext, BoardFundingResponse
+from app.services.n8n_daily_brief_service import (
+    build_cio_pending_decision,
+    build_tc_preliminary,
+    resolve_funding_intent,
+)
+
+
+def _v2_context() -> BoardBriefContext:
+    return BoardBriefContext.model_validate(
+        {
+            "exchange_krw": 1_000_000,
+            "unverified_cap": {
+                "amount": 5_000_000,
+                "verified_by_boss_today": False,
+                "stale_warning": True,
+            },
+            "daily_burn_krw": 100_000,
+            "next_obligation": {
+                "date": "2026-04-24",
+                "days_remaining": 7,
+                "cash_needed_until": 2_500_000,
+            },
+            "tier_scenarios": [
+                {
+                    "label": "T1",
+                    "deposit_amount": 1_500_000,
+                    "target_exchange_krw": 2_500_000,
+                    "buffer_days": 25,
+                    "cushion_after_obligation": 0,
+                },
+                {
+                    "label": "T2",
+                    "deposit_amount": 3_500_000,
+                    "target_exchange_krw": 4_500_000,
+                    "buffer_days": 45,
+                    "cushion_after_obligation": 2_000_000,
+                },
+            ],
+            "data_sufficient_by_symbol": {"BTC": True},
+            "btc_regime": {
+                "close_vs_20d_ma": "above",
+                "ma20_slope": "up",
+                "drawdown_14d_pct": -3.2,
+            },
+            "holdings": [
+                {"symbol": "BTC", "current_krw_value": 7_000_000, "dust": False},
+                {"symbol": "DOGE", "current_krw_value": 3_000, "dust": True},
+                {"symbol": "XRP", "current_krw_value": 2_000, "dust": True},
+            ],
+            "dust_items": [
+                {"symbol": "DOGE", "current_krw_value": 3_000},
+                {"symbol": "XRP", "current_krw_value": 2_000},
+            ],
+        }
+    )
+
+
+def _context_with_updates(**updates: object) -> BoardBriefContext:
+    return BoardBriefContext.model_validate(
+        _v2_context().model_dump(mode="json") | updates
+    )
+
+
+def test_resolve_funding_intent_prefers_runway_when_obligation_dominates() -> None:
+    ctx = _v2_context()
+    board_response = BoardFundingResponse(
+        amount=1_000_000,
+        target="BTC",
+        funding_intent="new_buy",
+        manual_cash_verified=True,
+    )
+
+    intent, lines = resolve_funding_intent(ctx, board_response)
+
+    assert intent == "runway_recovery"
+    assert lines == [
+        "- 이번 1,000,000 원은 **운영 연료** 로 귀속 — coinmoogi DCA 7 일 지속분 + 만기 cushion.",
+        "- 신규 매수 여력으로 전용 금지. G2 에서 차단.",
+    ]
+
+
+def test_resolve_funding_intent_allows_verified_target_as_new_buy() -> None:
+    ctx = _context_with_updates(
+        next_obligation={
+            "date": "2026-04-24",
+            "days_remaining": 7,
+            "cash_needed_until": 1_500_000,
+        }
+    )
+    board_response = BoardFundingResponse(
+        amount=1_000_000,
+        target="BTC",
+        funding_intent="runway_recovery",
+        manual_cash_verified=True,
+    )
+
+    intent, lines = resolve_funding_intent(ctx, board_response)
+
+    assert intent == "new_buy"
+    assert lines == [
+        "- 이번 1,000,000 원은 G3 (runway/obligation) 통과 후 신규 risk budget 후보.",
+        "- 이 경우에도 G4 시장 regime → G5 volatility halt → G6 보조지표 통과 여부 추가 판정 필요.",
+    ]
+
+
+def test_resolve_funding_intent_defaults_unverified_target_to_runway() -> None:
+    ctx = _context_with_updates(
+        next_obligation={
+            "date": "2026-04-24",
+            "days_remaining": 7,
+            "cash_needed_until": 1_500_000,
+        }
+    )
+    board_response = BoardFundingResponse(
+        amount=1_000_000,
+        target="BTC",
+        funding_intent="new_buy",
+        manual_cash_verified=False,
+    )
+
+    intent, lines = resolve_funding_intent(ctx, board_response)
+
+    assert intent == "runway_recovery"
+    assert lines == [
+        "- 이번 1,000,000 원은 **운영 연료** 로 귀속 — coinmoogi DCA 7 일 지속분 + 만기 cushion.",
+        "- 신규 매수 여력으로 전용 금지. G2 에서 차단.",
+    ]
+
+
+def test_tc_preliminary_renders_v2_cash_dust_and_tier_sections() -> None:
+    render = build_tc_preliminary(_v2_context())
+    text = render.text
+
+    assert text.startswith(
+        "📊 TC Preliminary — 입금 약속 반영 시나리오 (pledged, 거래소 미반영)"
+    )
+    assert text.index("거래소 KRW") < text.index("미확인 cap (보스 확인 전)")
+    assert text.index("미확인 cap (보스 확인 전)") < text.index(
+        "일일 소진 (daily_burn)"
+    )
+    assert text.index("일일 소진 (daily_burn)") < text.index("다음 의무")
+    assert text.index("다음 의무") < text.index("runway 산식")
+    assert "runway 산식: 1,000,000 KRW / 100,000 KRW = 10.00일" in text
+    assert "🧹 Dust 2종목 · 합계 5,000 KRW · 포트폴리오 0.07%" in text
+    assert (
+        "deposit_amount | next_obligation | cash_needed_until | "
+        "cushion_after_obligation | target_exchange_krw | buffer_days (보조)"
+    ) in text
+    assert "1,500,000 KRW | 2026-04-24 / D-7 | 2,500,000 KRW" in text
+    assert "**A 와 B 는 상호배타 아님 — 병행 가능.**" in text
+
+
+def test_cio_pending_injects_one_g2_phrase_set_and_question_tags() -> None:
+    ctx = _context_with_updates(
+        next_obligation={
+            "date": "2026-04-24",
+            "days_remaining": 7,
+            "cash_needed_until": 1_500_000,
+        },
+        board_response={
+            "amount": 1_000_000,
+            "target": "BTC",
+            "funding_intent": "new_buy",
+            "manual_cash_verified": True,
+        },
+    )
+
+    render = build_cio_pending_decision(ctx)
+    text = render.text
+
+    assert render.funding_intent == "new_buy"
+    assert text.count("신규 risk budget 후보") == 1
+    assert "운영 연료" not in text
+    assert "질문 (Step 1 답변 반영 — 재질문 아님)" in text
+    assert "[funding-confirmation]" in text
+    assert "[action]" in text

--- a/tests/test_board_brief_schema_v2.py
+++ b/tests/test_board_brief_schema_v2.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.n8n.board_brief import (
+    BoardBriefContext,
+    BtcRegimePayload,
+    CIOFollowupRequest,
+    HardGateCandidate,
+    NextObligationPayload,
+    TCFollowupRequest,
+    TierScenario,
+    UnverifiedCapPayload,
+)
+
+
+def _full_v2_payload() -> dict:
+    return {
+        "exchange_krw": 1_500_000,
+        "unverified_cap": {
+            "amount": 10_000_000,
+            "confirmed_at": "2026-04-17T09:30:00+09:00",
+            "verified_by_boss_today": True,
+            "stale_warning": False,
+        },
+        "next_obligation": {
+            "date": "2026-04-24",
+            "days_remaining": 7,
+            "cash_needed_until": 700_000,
+        },
+        "tier_scenarios": [
+            {
+                "label": "T1",
+                "target_exchange_krw": 2_000_000,
+                "deposit_amount": 500_000,
+                "buffer_days": 7,
+                "cushion_after_obligation": 1_300_000,
+            },
+            {
+                "label": "T2",
+                "target_exchange_krw": 5_000_000,
+                "deposit_amount": 3_500_000,
+                "buffer_days": 14,
+                "cushion_after_obligation": 4_300_000,
+            },
+        ],
+        "hard_gate_candidates": [
+            {
+                "symbol": "SOL",
+                "proposal": "부분매도",
+                "amount_range": "8~10 SOL",
+            }
+        ],
+        "data_sufficient_by_symbol": {"SOL": True, "BTC": False},
+        "btc_regime": {
+            "close_vs_20d_ma": "above",
+            "ma20_slope": "up",
+            "drawdown_14d_pct": 4.2,
+        },
+    }
+
+
+def test_board_brief_context_round_trips_full_v2_payload() -> None:
+    context = BoardBriefContext.model_validate(_full_v2_payload())
+
+    assert context.exchange_krw == 1_500_000
+    assert context.unverified_cap == UnverifiedCapPayload(
+        amount=10_000_000,
+        confirmed_at=datetime.fromisoformat("2026-04-17T09:30:00+09:00"),
+        verified_by_boss_today=True,
+        stale_warning=False,
+    )
+    assert context.next_obligation == NextObligationPayload(
+        date=date(2026, 4, 24),
+        days_remaining=7,
+        cash_needed_until=700_000,
+    )
+    assert context.tier_scenarios[0] == TierScenario(
+        label="T1",
+        target_exchange_krw=2_000_000,
+        deposit_amount=500_000,
+        buffer_days=7,
+        cushion_after_obligation=1_300_000,
+    )
+    assert context.hard_gate_candidates == [
+        HardGateCandidate(symbol="SOL", proposal="부분매도", amount_range="8~10 SOL")
+    ]
+    assert context.btc_regime == BtcRegimePayload(
+        close_vs_20d_ma="above",
+        ma20_slope="up",
+        drawdown_14d_pct=4.2,
+    )
+
+    dumped = context.model_dump(mode="json")
+    assert BoardBriefContext.model_validate(dumped) == context
+
+
+def test_board_brief_context_defaults_optional_v2_sections_cleanly() -> None:
+    context = BoardBriefContext()
+
+    assert context.exchange_krw == 0
+    assert context.unverified_cap is None
+    assert context.next_obligation is None
+    assert context.tier_scenarios == []
+    assert context.hard_gate_candidates == []
+    assert context.data_sufficient_by_symbol == {}
+    assert context.btc_regime is None
+    assert context.manual_cash_krw == 0
+
+
+@pytest.mark.parametrize(
+    ("model", "payload"),
+    [
+        (UnverifiedCapPayload, {"amount": -1}),
+        (
+            NextObligationPayload,
+            {"date": "2026-04-24", "days_remaining": -1, "cash_needed_until": 0},
+        ),
+        (
+            NextObligationPayload,
+            {"date": "2026-04-24", "days_remaining": 0, "cash_needed_until": -1},
+        ),
+        (
+            TierScenario,
+            {
+                "label": "T4",
+                "target_exchange_krw": 0,
+                "deposit_amount": 0,
+                "buffer_days": 0,
+                "cushion_after_obligation": 0,
+            },
+        ),
+        (
+            BtcRegimePayload,
+            {
+                "close_vs_20d_ma": "sideways",
+                "ma20_slope": "up",
+                "drawdown_14d_pct": 0,
+            },
+        ),
+    ],
+)
+def test_board_brief_v2_payloads_reject_invalid_values(
+    model: type, payload: dict
+) -> None:
+    with pytest.raises(ValidationError):
+        model.model_validate(payload)
+
+
+def test_followup_requests_accept_v2_fields_and_keep_manual_cash_compat() -> None:
+    payload = _full_v2_payload() | {"manual_cash_krw": 9_000_000}
+
+    tc_request = TCFollowupRequest.model_validate(payload)
+    cio_request = CIOFollowupRequest.model_validate(payload)
+
+    assert tc_request.manual_cash_krw == 9_000_000
+    assert tc_request.unverified_cap is not None
+    assert tc_request.unverified_cap.amount == 10_000_000
+    assert cio_request.tier_scenarios[1].label == "T2"
+    assert cio_request.btc_regime is not None
+    assert cio_request.btc_regime.ma20_slope == "up"

--- a/tests/test_cio_briefing_fail_closed.py
+++ b/tests/test_cio_briefing_fail_closed.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.n8n_daily_brief_service import build_cio_pending_decision
+from tests.fixtures.cio_briefing import RecordingRouter, drop_required_field
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "exchange_krw",
+        "unverified_cap",
+        "next_obligation",
+        "tier_scenarios",
+        "data_sufficient_by_symbol",
+        "btc_regime",
+        "holdings",
+    ],
+)
+def test_missing_required_context_fails_closed_and_routes_ops(field: str) -> None:
+    router = RecordingRouter()
+
+    render = build_cio_pending_decision(drop_required_field(field), router=router)
+
+    assert render.text.startswith(f"⚠️ {field} 누락")
+    assert render.embed == {}
+    assert router.board_messages == []
+    assert router.ops_messages == [render.text]

--- a/tests/test_cio_briefing_g2_precedence.py
+++ b/tests/test_cio_briefing_g2_precedence.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from app.services.n8n_daily_brief_service import build_cio_pending_decision
+from tests.fixtures.cio_briefing import plan_v2_section_f_context
+
+
+def test_target_is_ignored_when_runway_deficit_dominates() -> None:
+    ctx = plan_v2_section_f_context(
+        exchange_krw=83_318,
+        next_obligation={
+            "date": "2026-04-29",
+            "days_remaining": 12,
+            "cash_needed_until": 2_500_000,
+        },
+        board_response={
+            "amount": 1_200_000,
+            "target": "BTC",
+            "funding_intent": "new_buy",
+            "manual_cash_verified": True,
+        },
+    )
+
+    render = build_cio_pending_decision(ctx)
+
+    assert render.funding_intent == "runway_recovery"
+    assert "운영 연료" in render.text
+    assert "신규 risk budget 후보" not in render.text
+
+
+def test_verified_target_with_sufficient_runway_enters_new_buy() -> None:
+    ctx = plan_v2_section_f_context(
+        exchange_krw=1_200_000,
+        unverified_cap={
+            "amount": 10_000_000,
+            "verified_by_boss_today": True,
+            "stale_warning": False,
+        },
+        next_obligation={
+            "date": "2026-04-29",
+            "days_remaining": 12,
+            "cash_needed_until": 1_200_000,
+        },
+        board_response={
+            "amount": 1_200_000,
+            "target": "BTC",
+            "funding_intent": "runway_recovery",
+            "manual_cash_verified": True,
+        },
+    )
+
+    render = build_cio_pending_decision(ctx)
+
+    assert render.funding_intent == "new_buy"
+    assert "신규 risk budget 후보" in render.text
+    assert "운영 연료" not in render.text

--- a/tests/test_cio_briefing_g6_only_trigger.py
+++ b/tests/test_cio_briefing_g6_only_trigger.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pytest
+
+from app.schemas.n8n.board_brief import GateResult, N8nG2GatePayload
+from app.services.n8n_daily_brief_service import (
+    RenderInvariantError,
+    build_cio_pending_decision,
+)
+from tests.fixtures.cio_briefing import plan_v2_section_f_context
+
+
+def test_g6_rsi_trigger_cannot_emit_immediate_buy_when_upper_gate_fails() -> None:
+    ctx = plan_v2_section_f_context(
+        gate_results={
+            "G1": GateResult(status="fail", detail="target OHLCV missing"),
+            "G2": N8nG2GatePayload(
+                passed=False,
+                status="fail",
+                blocking_reason="runway recovery only",
+            ),
+            "G3": GateResult(status="fail", detail="obligation cushion negative"),
+            "G4": GateResult(status="fail", detail="target below 20D MA"),
+            "G5": GateResult(status="fail", detail="24h volatility halt"),
+            "G6": GateResult(status="pass", detail="RSI=30 oversold trigger"),
+        }
+    )
+
+    with pytest.raises(RenderInvariantError) as exc_info:
+        build_cio_pending_decision(
+            ctx,
+            text_postprocessor=lambda text: text + "\nCIO 권고 (1) 즉시 매수",
+        )
+
+    assert [violation.code for violation in exc_info.value.violations] == [
+        "immediate_buy_requires_g2_g5_pass"
+    ]
+    assert exc_info.value.violations[0].detail == (
+        "immediate buy rendered while G2, G3, G4, G5 not pass"
+    )

--- a/tests/test_cio_briefing_render_invariants.py
+++ b/tests/test_cio_briefing_render_invariants.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from app.schemas.n8n.board_brief import GateResult
+from app.services.n8n_daily_brief_service import (
+    RenderInvariantError,
+    build_cio_pending_decision,
+    validate_render_invariants,
+)
+from tests.fixtures.cio_briefing import plan_v2_section_f_context, replace_once
+
+
+def _append_immediate_buy(text: str) -> str:
+    return text + "\nCIO 권고 (1) 즉시 매수"
+
+
+def _append_fail_closed_anchor(text: str) -> str:
+    return text + "\n⚠️ synthetic 누락 — 테스트 anchor"
+
+
+def _duplicate_dust_line(text: str) -> str:
+    dust_line = next(line for line in text.splitlines() if line.startswith("🧹 Dust"))
+    return text + f"\n{dust_line}"
+
+
+INVARIANT_CASES: list[tuple[str, Callable[[str], str], str]] = [
+    (
+        "funding_rows",
+        replace_once("- 거래소 KRW:", "- 거래소 원화:"),
+        "funding_rows",
+    ),
+    (
+        "runway_excludes_unverified_cap",
+        replace_once(
+            "runway 산식: 83,318 KRW / 80,000 KRW = 1.04일",
+            "runway 산식: 83,318 KRW + 10,000,000 KRW / 80,000 KRW = 126.04일",
+        ),
+        "runway_excludes_unverified_cap",
+    ),
+    (
+        "ab_anchor_triple",
+        replace_once(
+            "경로 A (입금) 와 경로 B (현물 부분매도) 는 **상호배타 아님**. 병행 가능합니다.",
+            "경로 A와 경로 B를 검토합니다.",
+        ),
+        "ab_anchor_triple",
+    ),
+    (
+        "g2_phrase_exactly_one",
+        lambda text: (
+            text
+            + "\n- 이번 1,200,000 원은 G3 (runway/obligation) 통과 후 신규 risk budget 후보."
+        ),
+        "g2_phrase_exactly_one",
+    ),
+    (
+        "immediate_buy_requires_g2_g5_pass",
+        _append_immediate_buy,
+        "immediate_buy_requires_g2_g5_pass",
+    ),
+    ("dust_aggregate", _duplicate_dust_line, "dust_aggregate"),
+    ("fail_closed_anchor", _append_fail_closed_anchor, "fail_closed_anchor"),
+]
+
+
+@pytest.mark.parametrize(
+    ("case_name", "mutate", "violation_code"),
+    INVARIANT_CASES,
+    ids=[case[0] for case in INVARIANT_CASES],
+)
+def test_render_invariant_positive_and_negative_fixtures(
+    case_name: str,
+    mutate: Callable[[str], str],
+    violation_code: str,
+) -> None:
+    ctx = plan_v2_section_f_context()
+    positive = build_cio_pending_decision(ctx).text
+    if case_name == "immediate_buy_requires_g2_g5_pass":
+        positive = _append_immediate_buy(positive)
+        assert validate_render_invariants(positive, ctx, phase="cio_pending") == []
+        negative_ctx = ctx.model_copy(
+            update={
+                "gate_results": ctx.gate_results
+                | {"G4": GateResult(status="fail", detail="target below MA20")}
+            }
+        )
+    else:
+        assert validate_render_invariants(positive, ctx, phase="cio_pending") == []
+        negative_ctx = ctx
+
+    with pytest.raises(RenderInvariantError) as exc_info:
+        build_cio_pending_decision(negative_ctx, text_postprocessor=mutate)
+
+    assert [violation.code for violation in exc_info.value.violations] == [
+        violation_code
+    ]
+
+
+def test_full_suite_pass_plan_v2_section_f_sample() -> None:
+    ctx = plan_v2_section_f_context()
+
+    render = build_cio_pending_decision(ctx)
+
+    assert validate_render_invariants(render.text, ctx, phase="cio_pending") == []

--- a/tests/test_cio_briefing_service_branch_coverage.py
+++ b/tests/test_cio_briefing_service_branch_coverage.py
@@ -27,10 +27,9 @@ def test_renderer_helper_fallback_branches() -> None:
         == set()
     )
     assert _gate_passed(None) is False
-    assert (
-        _cash_runway_days(plan_v2_section_f_context(manual_cash_runway_days=7.5))
-        == pytest.approx(7.5)
-    )
+    assert _cash_runway_days(
+        plan_v2_section_f_context(manual_cash_runway_days=7.5)
+    ) == pytest.approx(7.5)
     assert (
         _cash_runway_days(BoardBriefContext(manual_cash_krw=1_000, daily_burn_krw=100))
         == 10

--- a/tests/test_cio_briefing_service_branch_coverage.py
+++ b/tests/test_cio_briefing_service_branch_coverage.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.schemas.n8n.board_brief import BoardBriefContext
+from app.services.n8n_daily_brief_service import (
+    RenderInvariantError,
+    RenderRouter,
+    _build_candidate_lines,
+    _build_concentration_lines,
+    _build_tier_lines,
+    _cash_runway_days,
+    _collect_symbols_by_market,
+    _format_unverified_amounts,
+    _gate_passed,
+    build_cio_pending_decision,
+    build_tc_preliminary,
+    resolve_funding_intent,
+)
+from tests.fixtures.cio_briefing import drop_required_field, plan_v2_section_f_context
+
+
+def test_renderer_helper_fallback_branches() -> None:
+    assert (
+        _format_unverified_amounts(plan_v2_section_f_context(unverified_cap=None))
+        == set()
+    )
+    assert _gate_passed(None) is False
+    assert (
+        _cash_runway_days(plan_v2_section_f_context(manual_cash_runway_days=7.5)) == 7.5
+    )
+    assert (
+        _cash_runway_days(BoardBriefContext(manual_cash_krw=1_000, daily_burn_krw=100))
+        == 10
+    )
+    assert _cash_runway_days(BoardBriefContext(manual_cash_krw=1_000)) is None
+    assert _build_concentration_lines(plan_v2_section_f_context(weights_top_n=[])) == [
+        "- 상위 비중 데이터 없음"
+    ]
+    assert _build_candidate_lines(
+        plan_v2_section_f_context(
+            holdings=[{"symbol": "APT", "current_krw_value": 654, "dust": True}]
+        )
+    ) == ["- execution-actionable 매도/축소 후보 없음"]
+    assert _build_tier_lines(plan_v2_section_f_context(tier_scenarios=[])) == [
+        "tier_scenarios 미수신, 입금 시나리오 산출 보류"
+    ]
+    assert (
+        resolve_funding_intent(plan_v2_section_f_context(next_obligation=None), None)[0]
+        == "runway_recovery"
+    )
+
+
+def test_collect_symbols_normalizes_crypto_and_skips_incomplete_rows() -> None:
+    symbols_by_market = _collect_symbols_by_market(
+        {
+            "orders": [
+                {"market": "crypto", "symbol": "KRW-ETH"},
+                {"market": "", "symbol": "IGNORED"},
+            ]
+        },
+        {
+            "positions": [
+                {"market_type": "CRYPTO", "symbol": "btc"},
+                {"market_type": "KR", "symbol": ""},
+            ]
+        },
+    )
+
+    assert symbols_by_market == {"crypto": {"KRW-ETH", "KRW-BTC"}}
+
+
+def test_tc_preliminary_missing_context_fails_closed() -> None:
+    render = build_tc_preliminary(drop_required_field("exchange_krw"))
+
+    assert render.text.startswith("⚠️ exchange_krw 누락")
+    assert render.embed == {}
+
+
+def test_forbidden_pattern_routes_ops_and_raises() -> None:
+    with pytest.raises(RenderInvariantError) as exc_info:
+        build_cio_pending_decision(
+            plan_v2_section_f_context(),
+            text_postprocessor=lambda text: text + "\nPlanning cash 100",
+        )
+
+    assert [violation.code for violation in exc_info.value.violations] == [
+        "forbidden_pattern"
+    ]
+
+
+def test_default_router_posts_ops_escalation(monkeypatch: pytest.MonkeyPatch) -> None:
+    posted: list[tuple[str, dict[str, str]]] = []
+
+    class FakeClient:
+        def __init__(self, timeout: int) -> None:
+            self.timeout = timeout
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def post(self, url: str, json: dict[str, str]) -> None:
+            posted.append((url, json))
+
+    monkeypatch.setenv("N8N_OPS_ESCALATION_WEBHOOK", "https://ops.example/hook")
+    monkeypatch.setattr(httpx, "Client", FakeClient)
+
+    RenderRouter().route_ops_escalation("blocked")
+
+    assert posted == [("https://ops.example/hook", {"content": "blocked"})]

--- a/tests/test_cio_briefing_service_branch_coverage.py
+++ b/tests/test_cio_briefing_service_branch_coverage.py
@@ -28,7 +28,8 @@ def test_renderer_helper_fallback_branches() -> None:
     )
     assert _gate_passed(None) is False
     assert (
-        _cash_runway_days(plan_v2_section_f_context(manual_cash_runway_days=7.5)) == 7.5
+        _cash_runway_days(plan_v2_section_f_context(manual_cash_runway_days=7.5))
+        == pytest.approx(7.5)
     )
     assert (
         _cash_runway_days(BoardBriefContext(manual_cash_krw=1_000, daily_burn_krw=100))

--- a/tests/test_n8n_daily_brief_formatting.py
+++ b/tests/test_n8n_daily_brief_formatting.py
@@ -136,6 +136,28 @@ class TestBoardBriefBuilders:
         from app.schemas.n8n.board_brief import BoardBriefContext
 
         return BoardBriefContext(
+            exchange_krw=1_000_000,
+            unverified_cap={"amount": 5_000_000},
+            next_obligation={
+                "date": "2026-04-24",
+                "days_remaining": 7,
+                "cash_needed_until": 2_500_000,
+            },
+            tier_scenarios=[
+                {
+                    "label": "T1",
+                    "deposit_amount": 1_500_000,
+                    "target_exchange_krw": 2_500_000,
+                    "buffer_days": 25,
+                    "cushion_after_obligation": 0,
+                }
+            ],
+            data_sufficient_by_symbol={"BTC": True},
+            btc_regime={
+                "close_vs_20d_ma": "above",
+                "ma20_slope": "up",
+                "drawdown_14d_pct": -3.2,
+            },
             manual_cash_krw=1_250_000,
             daily_burn_krw=50_000,
             weights_top_n=[{"symbol": "BTC", "weight_pct": 42.5}],
@@ -155,7 +177,7 @@ class TestBoardBriefBuilders:
         assert render.phase == "tc_preliminary"
         assert "경로 A·B 병행 가능" in text
         assert "BTC" in text
-        assert "DOGE" in text
+        assert "🧹 Dust 1종목" in text
         assert "🎯 권고" not in text
         assert "📊 Gate 판정 결과" not in text
         assert "[funding]" not in text
@@ -189,6 +211,7 @@ class TestBoardBriefBuilders:
         assert "📊 Gate 판정 결과" in text
         assert "🚫 신규 매수 차단 — G2 fail" in text
         assert "(3) 현금 우선 정책 적용" in text
-        assert "[funding]" in text
+        assert "[funding-confirmation]" in text
         assert "[action]" in text
-        assert text.count("경로 A·B 병행 가능") >= 2
+        assert "경로 A·B 병행 가능" in text
+        assert "**A 와 B 는 상호배타 아님 — 병행 가능.**" in text

--- a/tests/test_n8n_followup_endpoints.py
+++ b/tests/test_n8n_followup_endpoints.py
@@ -14,12 +14,46 @@ class TestN8nFollowupEndpoints:
         app.include_router(router)
         return TestClient(app)
 
+    def _required_v2_payload(self) -> dict:
+        return {
+            "exchange_krw": 1_000_000,
+            "unverified_cap": {"amount": 5_000_000},
+            "next_obligation": {
+                "date": "2026-04-24",
+                "days_remaining": 7,
+                "cash_needed_until": 2_500_000,
+            },
+            "tier_scenarios": [
+                {
+                    "label": "T1",
+                    "deposit_amount": 1_500_000,
+                    "target_exchange_krw": 2_500_000,
+                    "buffer_days": 25,
+                    "cushion_after_obligation": 0,
+                }
+            ],
+            "data_sufficient_by_symbol": {"BTC": True},
+            "btc_regime": {
+                "close_vs_20d_ma": "above",
+                "ma20_slope": "up",
+                "drawdown_14d_pct": -3.2,
+            },
+            "holdings": [
+                {"symbol": "BTC", "current_krw_value": 1_000_000, "dust": False},
+                {"symbol": "DOGE", "current_krw_value": 3_000, "dust": True},
+            ],
+            "dust_items": [
+                {"symbol": "DOGE", "current_krw_value": 3_000, "dust": True}
+            ],
+        }
+
     def test_tc_followup_returns_preliminary_render(self) -> None:
         client = self._get_client()
 
         resp = client.post(
             "/api/n8n/tc-followup",
             json={
+                **self._required_v2_payload(),
                 "manual_cash_krw": 1_250_000,
                 "daily_burn_krw": 50_000,
                 "weights_top_n": [{"symbol": "BTC", "weight_pct": 42.5}],
@@ -36,10 +70,13 @@ class TestN8nFollowupEndpoints:
         body = resp.json()
         assert body["phase"] == "tc_preliminary"
         assert body["generated_at"]
-        assert body["embed"]["title"] == "📊 TC Preliminary — 자금 현황 재계산"
+        assert (
+            body["embed"]["title"]
+            == "📊 TC Preliminary — 입금 약속 반영 시나리오 (pledged, 거래소 미반영)"
+        )
         assert "경로 A·B 병행 가능" in body["text"]
         assert "BTC" in body["text"]
-        assert "DOGE" in body["text"]
+        assert "🧹 Dust 1종목" in body["text"]
         assert "🎯 권고" not in body["text"]
         assert "📊 Gate 판정 결과" not in body["text"]
 
@@ -49,6 +86,7 @@ class TestN8nFollowupEndpoints:
         resp = client.post(
             "/api/n8n/cio-followup",
             json={
+                **self._required_v2_payload(),
                 "manual_cash_krw": 700_000,
                 "daily_burn_krw": 100_000,
                 "manual_cash_runway_days": 7,
@@ -84,7 +122,7 @@ class TestN8nFollowupEndpoints:
         assert "🚫 신규 매수 차단 — G2 fail" in body["text"]
         assert "(3) 현금 우선 정책 적용" in body["text"]
         assert "📊 Gate 판정 결과" in body["text"]
-        assert "[funding]" in body["text"]
+        assert "[funding-confirmation]" in body["text"]
         assert "[action]" in body["text"]
 
     def test_evaluate_g1_gate_pass_ignores_force_cash_policy_note(self) -> None:
@@ -93,6 +131,7 @@ class TestN8nFollowupEndpoints:
         resp = client.post(
             "/api/n8n/cio-followup",
             json={
+                **self._required_v2_payload(),
                 "manual_cash_krw": 1_500_000,
                 "daily_burn_krw": 100_000,
                 "manual_cash_runway_days": 15,

--- a/tests/test_plan_v2_section_g_checklist.py
+++ b/tests/test_plan_v2_section_g_checklist.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from app.services.n8n_daily_brief_service import (
+    build_cio_pending_decision,
+    build_tc_preliminary,
+    validate_render_invariants,
+)
+from tests.fixtures.cio_briefing import plan_v2_section_f_context
+
+
+def test_plan_v2_section_g_checklist() -> None:
+    ctx = plan_v2_section_f_context()
+
+    tc_render = build_tc_preliminary(ctx)
+    cio_render = build_cio_pending_decision(ctx)
+    combined_text = tc_render.text + "\n" + cio_render.text
+
+    checks = {
+        "framing_box_top": tc_render.text.splitlines()[2].startswith(
+            "요약: 경로 A·B 병행 가능."
+        ),
+        "cash_rows_separate": "거래소 KRW:" in tc_render.text
+        and "미확인 cap (보스 확인 전):" in tc_render.text,
+        "unverified_flags": all(
+            flag in tc_render.text
+            for flag in [
+                "미확인 cap (보스 확인 전): 10,000,000 KRW",
+                "stale_warning",
+            ]
+        ),
+        "daily_burn_rendered": "일일 소진 (daily_burn): 80,000 KRW" in tc_render.text,
+        "dust_excluded_from_actionable_table": "APT: 654 KRW" not in combined_text,
+        "dust_footnote_one_line": sum(
+            1 for line in tc_render.text.splitlines() if line.startswith("🧹 Dust")
+        )
+        == 1,
+        "three_tier_obligation_table": all(
+            item in tc_render.text
+            for item in ["516,682 KRW", "1,116,682 KRW", "2,316,682 KRW"]
+        )
+        and "cushion_after_obligation" in tc_render.text,
+        "default_rule_matches_sample": cio_render.funding_intent == "runway_recovery"
+        and "운영 연료" in cio_render.text,
+        "path_a_b_split": "경로 A:" in tc_render.text and "경로 B:" in tc_render.text,
+        "two_block_followup": "TC Preliminary" in tc_render.text
+        and "CIO Pending Decision" in cio_render.embed["title"],
+        "g1_g6_order": all(f"- G{idx}:" in cio_render.text for idx in range(1, 7))
+        and cio_render.text.index("- G1:") < cio_render.text.index("- G6:"),
+        "board_questions_split": "[funding-confirmation]" in cio_render.text
+        and "[action]" in cio_render.text
+        and cio_render.text.index("[funding-confirmation]")
+        < cio_render.text.index("[action]"),
+    }
+
+    assert validate_render_invariants(tc_render.text, ctx, phase="tc_preliminary") == []
+    assert validate_render_invariants(cio_render.text, ctx, phase="cio_pending") == []
+    failed_checks = {name: value for name, value in checks.items() if not value}
+    assert failed_checks == {}


### PR DESCRIPTION
## S2-S5 wiring is absent from main because of merge topology

[#562](https://github.com/mgh3326/auto_trader/pull/562) was squash-merged into `main` at 2026-04-17T20:52:14Z as merge commit `2a4d980`. That squash preserved the S1 prompt content on `main`, but it did not make `feature/ROB-142-cio-briefing-prompt-v2` an ancestor of `main`.

[#567](https://github.com/mgh3326/auto_trader/pull/567) merged 76 seconds later at 2026-04-17T20:53:30Z while its base was still `feature/ROB-142-cio-briefing-prompt-v2`. GitHub did not auto-retarget it to `main`, so merge commit `9750855c` landed only on the intermediate branch.

Result: S1 prompt is already on `main` through `2a4d980`; S2-S5 wiring remains only on `feature/ROB-142-cio-briefing-prompt-v2` until this PR lands.

## Scope in this PR

Commit range from `git log origin/main..origin/feature/ROB-142-cio-briefing-prompt-v2 --oneline`:

```text
9750855 feat(cio): coin board briefing v2 wiring (ROB-142 S2-S5) (#567)
4b58ff5 feat(cio): apply ROB-220 reviewer v2 critique (5 changes requested)
329dbbb feat(cio): add coin board briefing v2 prompt (ROB-142 S1)
```

Actual file list from `gh pr diff 573 --name-only`:

```text
app/routers/n8n.py
app/schemas/n8n/board_brief.py
app/services/cio_coin_briefing/prompts/board_briefing_v2.md
app/services/cio_coin_briefing/prompts/gate_phrases.py
app/services/n8n_daily_brief_service.py
tests/fixtures/__init__.py
tests/fixtures/cio_briefing.py
tests/test_board_brief_render_v2.py
tests/test_board_brief_schema_v2.py
tests/test_cio_briefing_fail_closed.py
tests/test_cio_briefing_g2_precedence.py
tests/test_cio_briefing_g6_only_trigger.py
tests/test_cio_briefing_render_invariants.py
tests/test_cio_briefing_service_branch_coverage.py
tests/test_n8n_daily_brief_formatting.py
tests/test_n8n_followup_endpoints.py
tests/test_plan_v2_section_g_checklist.py
```

Measured stat from `gh pr diff 573 --patch --color never | git apply --stat` because installed GitHub CLI 2.86.0 does not support `gh pr diff --stat`:

```text
 .../cio_coin_briefing/prompts/board_briefing_v2.md |  366 ++++++++++++++
 .../cio_coin_briefing/prompts/board_briefing_v2.md |  190 ++++++-
 app/routers/n8n.py                                 |   14 +
 app/schemas/n8n/board_brief.py                     |   70 +++
 .../cio_coin_briefing/prompts/gate_phrases.py      |   39 +
 app/services/n8n_daily_brief_service.py            |  523 +++++++++++++++++++-
 tests/fixtures/__init__.py                         |    1 
 tests/fixtures/cio_briefing.py                     |  134 +++++
 tests/test_board_brief_render_v2.py                |  179 +++++++
 tests/test_board_brief_schema_v2.py                |  164 ++++++
 tests/test_cio_briefing_fail_closed.py             |   29 +
 tests/test_cio_briefing_g2_precedence.py           |   55 ++
 tests/test_cio_briefing_g6_only_trigger.py         |   40 ++
 tests/test_cio_briefing_render_invariants.py       |  107 ++++
 tests/test_cio_briefing_service_branch_coverage.py |  114 ++++
 tests/test_n8n_daily_brief_formatting.py           |   29 +
 tests/test_n8n_followup_endpoints.py               |   45 ++
 tests/test_plan_v2_section_g_checklist.py          |   58 ++
 18 files changed, 2089 insertions(+), 68 deletions(-)
```

The actual GitHub PR diff includes files beyond the expected ticket list, including `app/services/cio_coin_briefing/prompts/board_briefing_v2.md` and additional CIO briefing test files. The body uses the measured PR diff rather than the expected list.

## Relationship to existing PRs and review signoff

This PR is a re-target PR that brings [#567](https://github.com/mgh3326/auto_trader/pull/567) from the intermediate branch into `main`.

[#562](https://github.com/mgh3326/auto_trader/pull/562), covering S1 prompt content, is already squash-merged into `main` as `2a4d980`. [#567](https://github.com/mgh3326/auto_trader/pull/567) is merged into `feature/ROB-142-cio-briefing-prompt-v2` as `9750855c`; this PR applies that branch tip to `main`.

CR signoff links: [ROB-228](/ROB/issues/ROB-228) · [ROB-230](/ROB/issues/ROB-230) · [ROB-232](/ROB/issues/ROB-232) · [ROB-234](/ROB/issues/ROB-234)

Tracker links: [ROB-221](/ROB/issues/ROB-221) · [ROB-142](/ROB/issues/ROB-142)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Enhanced cash runway and funding analysis with additional financial context fields
  - Implemented render validation to ensure output consistency and prevent invalid states
  - Added fail-closed rendering with automated escalation notifications for missing critical data

* **Tests**
  - Added comprehensive test coverage for funding decision logic, output validation, and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->