### PR TITLE
chore: ignore production env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,6 +205,7 @@ celerybeat.pid
 .env
 .env.test
 .env.mcp
+.env.prod
 .venv
 env/
 venv/


### PR DESCRIPTION
## Summary

- Add `.env.prod` to `.gitignore` so local production environment files are not accidentally tracked.

## Validation

- Inspected the commit diff: one `.gitignore` insertion only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git ignore configuration to exclude additional environment files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->