### PR TITLE
chore: ignore production env variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,7 @@ celerybeat.pid
 .env.test
 .env.mcp
 .env.prod
+.env.prod.*
 .venv
 env/
 venv/


### PR DESCRIPTION
## Summary

- Add `.env.prod.*` to `.gitignore` alongside `.env.prod`.
- Normalize the trailing newline in `.gitignore` while touching the file.

## Validation

- `git diff --check`
- Inspected the `.gitignore` diff.