### PR TITLE
chore(ROB-248): sync .gitignore graphify block with production drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,10 +277,7 @@ blog/images/screenshot_*.png
 backtest/data/
 backtest/output/
 .omc/.env.prod
-# graphify cache only
-graphify-out/cache/
-app/graphify-out/cache/
-
-# optional heavy visualization artifacts
-graphify-out/graph.html
-app/graphify-out/graph.html
+# graphify: all generated artifacts (graph, report, cache, interpreter path, chunk inputs)
+graphify-out/
+app/graphify-out/
+/.air/worktree.json


### PR DESCRIPTION
## Why

[ROB-248](/ROB/issues/ROB-248) release PR [#577](https://github.com/mgh3326/auto_trader/pull/577) (`main → production`) 가 `.gitignore` 에서 conflict. 원인: production 에 직접 반영돼 있던 commit `5034781 chore: update .git` ([robin@watcha.com](mailto:robin@watcha.com), 2026-04-15) 가 main 에 backport 되지 않아 3-way merge 시 graphify 블록 hunk 가 충돌.

## What

main 쪽 `.gitignore` 의 graphify 블록을 production 의 superset 버전으로 교체.

```
- # graphify cache only
- graphify-out/cache/
- app/graphify-out/cache/
-
- # optional heavy visualization artifacts
- graphify-out/graph.html
- app/graphify-out/graph.html
+ # graphify: all generated artifacts (graph, report, cache, interpreter path, chunk inputs)
+ graphify-out/
+ app/graphify-out/
+ /.air/worktree.json
```

- `graphify-out/` 는 `graphify-out/cache/` + `graphify-out/graph.html` 모두 커버 → 기능적 superset.
- `/.air/worktree.json` 은 worktree 메타데이터.
- main 의 `.env.prod` / `.env.prod.*` / `.omc/.env.prod` 라인은 그대로 유지.

## Verification

`git merge-tree $(git merge-base HEAD origin/production) HEAD origin/production` → **conflict markers 없음**. 이 PR 머지 후 [#577](https://github.com/mgh3326/auto_trader/pull/577) 가 clean merge 로 전환.

## Follow-up

[#577](https://github.com/mgh3326/auto_trader/pull/577) main → production release PR merge → GHCR 이미지 빌드 + auto-deploy observation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git ignore patterns to exclude additional output directories and temporary files from version control.

**Note:** This release contains only internal configuration updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->