### PR TITLE
chore(ci): bump Deploy via SSH timeout 10→20min (ROB-248)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,7 +119,7 @@ jobs:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 
       - name: Deploy via SSH
-        timeout-minutes: 10
+        timeout-minutes: 20
         shell: bash
         run: |
           set -eo pipefail


### PR DESCRIPTION
## Why

[ROB-248](/ROB/issues/ROB-248) main → production rollout 의 자연 deploy run [#24591551334](https://github.com/mgh3326/auto_trader/actions/runs/24591551334) 이 `Deploy via SSH` step 10분 timeout 으로 실패. Image pull 이 ~9분 소요되면서 container recreate 가 시작되자마자 timeout 이 터짐.

> 로그 일부
> ```
> 23:49:06  📦 Pulling latest Docker images...
> 23:57:57  ✅ Images pulled
> 23:58:52  Container auto_trader_{api,worker,...}_prod  Recreate  ← 시작
> 23:59:16  ##[error]The action 'Deploy via SSH' has timed out after 10 minutes.
> ```

## What

`.github/workflows/deploy.yml` `Deploy via SSH` step `timeout-minutes: 10` → `20`.

- mechanical, infra-only 변경.
- 안전 여유 ~2배. 일반 deploy 는 여전히 3–5분 이내 완료 예상.
- 근본 해결은 아님. image pull 경로 최적화 / pre-pull step 분리는 별도 tracker 가능.

## Verification

- 이 PR 머지 후 production 에도 반영돼야 다음 rollout 부터 효력 발생.
- 단기적으론 지금 진행 중인 ROB-248 후속 재배포/수동 정리에 안전 여유 제공.

## Follow-up

- image pull 지연 원인 조사 (네트워크, 디스크 I/O, layer 중복)
- 필요 시 별도 `Pull images` step 분리로 timeout 를 step 별로 관리