### PR TITLE
docs: add ROB-275 model-lane review guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,16 @@ auto_trader/
 - Keep task declarations in `app/tasks/`; job orchestration stays in `app/jobs/`.
 - Keep MCP behavior changes synchronized with `app/mcp_server/README.md` and tests.
 
+## MODEL-LANE REVIEW GUARDRAILS
+- Default engineering execution stays on `gpt-5.4` and should be tagged `keep_on_gpt54` when the task is routine implementation, focused bug fixing, test work, documentation, triage, or a narrow refactor with local blast radius.
+- Tag `candidate_for_sonnet` when the task needs steadier design or review judgment than routine execution but does not carry final high-risk approval authority.
+- Tag `candidate_for_opus` when the task needs reserved-lane review for high-cost decisions: architecture direction final decisions, auth / permission / security-sensitive changes, DB schema / migration, broad refactors, live order final approval, strategy policy changes, or deployment / operational automation boundary changes.
+- Tag `high_risk_change` on any issue or PR touching those high-risk categories, even when implementation is straightforward.
+- Tag `needs_stronger_model_review` when a `high_risk_change` needs Sonnet/Opus review before merge, approval, or operational use.
+- Tag `hold_for_final_review` when work is implemented but must not be merged, deployed, or used for live trading until the named stronger-model reviewer or CTO clears it.
+- Example issue comment: `Applying high_risk_change + needs_stronger_model_review: this touches DB migration behavior. Holding merge until CTO/Opus review confirms rollback and data-safety assumptions.`
+- Example hold comment: `Implementation is ready, but I am applying hold_for_final_review because this changes live order approval boundaries. No deploy or live execution until final review clears it.`
+
 ## ANTI-PATTERNS (THIS PROJECT)
 - Do not hardcode credentials/secrets in code or scripts.
 - Do not keep default/example secrets in production environments.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,8 @@ auto_trader/
 - Tag `high_risk_change` on any issue or PR touching those high-risk categories, even when implementation is straightforward.
 - Tag `needs_stronger_model_review` when a `high_risk_change` needs Sonnet/Opus review before merge, approval, or operational use.
 - Tag `hold_for_final_review` when work is implemented but must not be merged, deployed, or used for live trading until the named stronger-model reviewer or CTO clears it.
-- Example issue comment: `Applying high_risk_change + needs_stronger_model_review: this touches DB migration behavior. Holding merge until CTO/Opus review confirms rollback and data-safety assumptions.`
-- Example hold comment: `Implementation is ready, but I am applying hold_for_final_review because this changes live order approval boundaries. No deploy or live execution until final review clears it.`
+- Example issue comment: `Applying high_risk_change + needs_stronger_model_review for [ROB-275](/ROB/issues/ROB-275): this touches DB migration behavior. Holding merge until CTO/Opus review confirms rollback and data-safety assumptions.`
+- Example hold comment: `Implementation is ready for [ROB-275](/ROB/issues/ROB-275), but I am applying hold_for_final_review because this changes live order approval boundaries. No deploy or live execution until final review clears it.`
 
 ## ANTI-PATTERNS (THIS PROJECT)
 - Do not hardcode credentials/secrets in code or scripts.


### PR DESCRIPTION
## Summary

- Adds auto_trader project guidance for model-lane review tags and high-risk escalation.
- Mirrors the ROB-275/ROB-281 guardrail rules into active Paperclip agent instruction files for CTO, Staff Engineer, Release Engineer, QA Engineer, and Code Reviewer.
- Clarifies when to use `keep_on_gpt54`, `candidate_for_sonnet`, `candidate_for_opus`, `high_risk_change`, `needs_stronger_model_review`, and `hold_for_final_review`.

## Validation

- Verified all required tags are present across the touched policy files.
- Verified all required high-risk categories are present.
- Ran `git diff --check`.

## Notes

The Paperclip agent instruction files live outside this Git repository and were updated in place. This PR contains the repo-tracked project guidance change in `AGENTS.md`.