### PR TITLE
[codex] Add portfolio decision desk v1

### DIFF
--- a/.omx/plans/portfolio-decision-desk-v1.md
+++ b/.omx/plans/portfolio-decision-desk-v1.md
@@ -1,0 +1,472 @@
+# Portfolio Decision Desk V1 Plan
+
+## 1. Recommended V1 product definition
+
+Build an analysis-only "Decision Desk" page inside the existing portfolio UI. The V1 route should present one generated decision slate for the current portfolio and make each proposed action explainable by price distance, support/resistance context, journal context, position weight, and execution boundary.
+
+Grounding in the current repo:
+- `app/routers/portfolio.py:51` already owns the `/portfolio` router.
+- `app/routers/portfolio.py:66` renders the existing portfolio dashboard HTML page.
+- `app/routers/portfolio.py:99` exposes the existing overview API, which already merges journal snapshots into positions.
+- `app/routers/portfolio.py:373` renders position detail pages under `/portfolio/positions/{market_type}/{symbol}`.
+- `app/services/portfolio_overview_service.py:82` returns holdings grouped by market/account/symbol with prices, position values, facets, exchange rate, and warnings.
+- `app/services/portfolio_dashboard_service.py:81` and `app/services/portfolio_dashboard_service.py:104` expose latest active/draft journal snapshots for one symbol or a batch.
+- `app/mcp_server/tooling/fundamentals/_support_resistance.py:29` exposes internal support/resistance analysis without needing a new MCP tool.
+
+V1 should include only held positions unless product explicitly asks for non-held opportunities. The prompt says the main unit is `Decision Item`, with symbols as grouping context; that maps naturally to a service response with `decision_run`, `summary`, `symbol_groups[]`, and each group containing `items[]`.
+
+Acceptance criteria:
+- `/portfolio/decision` renders an authenticated HTML page in the existing portfolio router.
+- `/portfolio/api/decision-slate` returns a deterministic JSON payload for the authenticated user's current portfolio.
+- Each symbol group can contain multiple action items, not just one row per symbol.
+- Each item states current price, suggested/action price when known, current-to-action delta, nearest support/resistance context, rationale, and execution boundary.
+- Missing support/resistance, journal, indicators, or price data produces warnings/unknown fields without failing the whole page.
+- No live execution, dry-run execution button, Discord flow, Paperclip flow, n8n change, schema migration, new dependency, or new MCP tool is included in Phase 1.
+
+## 2. Route and page structure
+
+Recommendation: create a separate page at `/portfolio/decision`, linked from the existing portfolio dashboard. Do not make it a tab inside `portfolio_dashboard.html` for V1.
+
+Reasoning:
+- The existing dashboard template is already large and owns overview filtering, cash, rotation, AI advice, and responsive table/card rendering.
+- The detail page pattern already supports a separate portfolio page with an HTML shell plus JSON-backed data sections.
+- A separate route keeps V1 additive and reversible while still staying inside the `/portfolio` IA.
+
+Route/API additions:
+- Add `get_portfolio_decision_service(...)` dependency in `app/routers/portfolio.py`, mirroring `get_portfolio_position_detail_service(...)`.
+- Add `@router.get("/decision", response_class=HTMLResponse)` that renders `portfolio_decision_desk.html`.
+- Add `@router.get("/api/decision-slate", response_model=PortfolioDecisionSlateResponse)` with filters:
+  - `market: Literal["ALL", "KR", "US", "CRYPTO"] = "ALL"`
+  - `account_keys: Annotated[list[str] | None, Query()] = None`
+  - `q: Annotated[str | None, Query(min_length=1)] = None`
+  - optional `include_held_only: bool = True`, default true. Keep true-only behavior if non-held candidates are out of scope.
+
+Template structure for `app/templates/portfolio_decision_desk.html`:
+- Header:
+  - title: `Decision Desk`
+  - subtitle: analysis-only generated slate
+  - badges: `analysis_only`, generated time, warning count
+  - link back to `/portfolio/`
+- Summary cards:
+  - total positions evaluated
+  - actionable item count
+  - manual-review item count
+  - auto-executable candidate count
+  - missing-context count
+- Filters:
+  - market selector
+  - account selector, reusing account facet data from the slate payload
+  - symbol/name search
+  - action filter: `all`, `buy_candidate`, `trim_candidate`, `sell_watch`, `hold`, `manual_review`
+  - execution boundary filter: `all`, `auto_candidate`, `manual_only`, `analysis_only`
+- Symbol-grouped sections:
+  - symbol, name, market, current price, quantity, avg price, P/L, portfolio weight, detail-page link
+  - compact support/resistance strip: nearest support, nearest resistance, data status
+  - decision item rows/cards below the symbol header
+- Decision item row:
+  - action badge
+  - suggested/action price and delta from current
+  - price anchor: support, resistance, target, stop, avg price, current price
+  - rationale bullets
+  - confidence/source badges
+  - execution boundary badge
+  - warnings for missing journal/SR/price
+  - link to `/portfolio/positions/{market}/{symbol}`
+- Empty/fallback states:
+  - no holdings match filters
+  - holdings exist but all classify as hold
+  - support/resistance unavailable
+  - journal unavailable
+  - current price unavailable
+
+Dashboard integration:
+- Add a single navigation affordance in `app/templates/portfolio_dashboard.html`, such as a header button/link to `/portfolio/decision`.
+- Do not embed the decision desk into the dashboard table or rotation panel in V1.
+
+## 3. Backend service / API design
+
+Create `app/services/portfolio_decision_service.py`.
+
+Constructor:
+```python
+class PortfolioDecisionService:
+    def __init__(self, *, overview_service, dashboard_service) -> None:
+        self.overview_service = overview_service
+        self.dashboard_service = dashboard_service
+```
+
+Primary method:
+```python
+async def build_decision_slate(
+    self,
+    *,
+    user_id: int,
+    market: str = "ALL",
+    account_keys: list[str] | None = None,
+    q: str | None = None,
+) -> dict[str, Any]:
+    ...
+```
+
+Inputs to reuse:
+- `PortfolioOverviewService.get_overview(...)` for current portfolio positions and filters.
+- `PortfolioDashboardService.get_journals_batch(...)` for active/draft journal snapshots with `target_distance_pct` and `stop_distance_pct`.
+- Internal `_get_support_resistance_impl(symbol, market=...)` from `app.mcp_server.tooling.fundamentals._support_resistance` for nearest support/resistance.
+- Optional `_get_indicators_impl` from the existing position-detail pattern for RSI only, if needed for conservative buy/hold heuristics.
+
+Keep deterministic logic in the service:
+- action classification
+- price delta calculations
+- nearest support/resistance selection
+- execution boundary classification
+- missing-context warnings
+
+Keep optional AI text out of V1:
+- `AiAdvisorService` is useful for user-triggered Q&A, but V1 decision item rationales should be deterministic and inspectable.
+- Later phases can add an optional "ask why" action that uses the existing AI advice provider surface; V1 should not generate core action labels via LLM.
+
+Support/resistance fetching strategy:
+- Fetch SR concurrently for positions with valid `current_price`.
+- Cap concurrent SR calls with an internal semaphore to avoid creating a slow page for large portfolios.
+- Treat any returned payload containing `error` or missing `supports`/`resistances` as `support_resistance.status = "unavailable"` and add a warning to the item/group.
+- Use the current overview price as the source of truth for current-vs-action deltas; SR's `current_price` can be included as `source_current_price` for diagnostics only.
+
+Market mapping:
+- Overview market types are `KR`, `US`, `CRYPTO`.
+- Support/resistance helper accepts market aliases through existing resolution; pass lower-case `kr`, `us`, `crypto` or normalize through a small private helper in the decision service.
+- Position detail URLs should use the existing `/portfolio/positions/{market_type.lower()}/{symbol}` path contract already tested in dashboard/router tests.
+
+Do not reuse `PortfolioRotationService` as the main service:
+- It is crypto-only and uses `_collect_portfolio_positions` plus separate screener buy candidates.
+- It can inspire response-shape tests and conservative classifier organization, but a cross-market Decision Desk needs overview-position inputs and symbol grouping.
+
+## 4. Data contract proposal
+
+Add `app/schemas/portfolio_decision.py` with Pydantic models. Keep fields explicit enough for tests and UI, while allowing nested `dict[str, Any]` for raw context snapshots where volatility is high.
+
+Proposed response:
+```json
+{
+  "success": true,
+  "decision_run": {
+    "id": "runtime-2026-04-20T10:15:00+09:00",
+    "generated_at": "2026-04-20T10:15:00+09:00",
+    "mode": "analysis_only",
+    "persisted": false,
+    "source": "portfolio_decision_service_v1"
+  },
+  "filters": {
+    "market": "ALL",
+    "account_keys": [],
+    "q": null
+  },
+  "summary": {
+    "symbols": 3,
+    "decision_items": 5,
+    "actionable_items": 2,
+    "manual_review_items": 1,
+    "auto_candidate_items": 1,
+    "missing_context_items": 1,
+    "by_action": {
+      "buy_candidate": 1,
+      "trim_candidate": 1,
+      "sell_watch": 0,
+      "hold": 2,
+      "manual_review": 1
+    },
+    "by_market": {
+      "KR": 1,
+      "US": 1,
+      "CRYPTO": 1
+    }
+  },
+  "facets": {
+    "accounts": []
+  },
+  "symbol_groups": [
+    {
+      "market_type": "US",
+      "symbol": "NVDA",
+      "name": "NVIDIA Corp.",
+      "detail_url": "/portfolio/positions/us/NVDA",
+      "position": {
+        "quantity": 3.0,
+        "avg_price": 120.0,
+        "current_price": 132.0,
+        "evaluation": 396.0,
+        "evaluation_krw": 540000.0,
+        "profit_loss": 36.0,
+        "profit_loss_krw": 49000.0,
+        "profit_rate": 0.1,
+        "portfolio_weight_pct": 9.8,
+        "market_weight_pct": 24.5,
+        "components": []
+      },
+      "journal": {
+        "status": "active",
+        "strategy": "trend",
+        "target_price": 145.0,
+        "stop_loss": 118.0,
+        "target_distance_pct": 9.85,
+        "stop_distance_pct": -10.61
+      },
+      "support_resistance": {
+        "status": "available",
+        "nearest_support": {
+          "price": 128.5,
+          "distance_pct": -2.65,
+          "strength": "moderate",
+          "sources": ["volume_poc", "bb_middle"]
+        },
+        "nearest_resistance": {
+          "price": 145.0,
+          "distance_pct": 9.85,
+          "strength": "strong",
+          "sources": ["fib_0.618", "bb_upper"]
+        },
+        "supports": [],
+        "resistances": []
+      },
+      "items": [
+        {
+          "id": "US:NVDA:trim_candidate:target",
+          "action": "trim_candidate",
+          "label": "Trim candidate",
+          "priority": "medium",
+          "current_price": 132.0,
+          "action_price": 145.0,
+          "action_price_source": "journal_target",
+          "delta_from_current_pct": 9.85,
+          "anchor": {
+            "type": "resistance",
+            "price": 145.0,
+            "distance_pct": 9.85,
+            "strength": "strong"
+          },
+          "rationale": [
+            "Journal target is within the next resistance zone.",
+            "Position is profitable and near planned exit context."
+          ],
+          "execution_boundary": {
+            "mode": "analysis_only",
+            "broker": "kis",
+            "auto_executable": false,
+            "manual_only": false,
+            "reason": "Phase 1 does not expose execution."
+          },
+          "badges": ["analysis_only", "near_resistance"],
+          "warnings": []
+        }
+      ],
+      "warnings": []
+    }
+  ],
+  "warnings": []
+}
+```
+
+Recommended model classes:
+- `DecisionRunResponse`
+- `DecisionSummaryResponse`
+- `DecisionPositionContextResponse`
+- `DecisionJournalContextResponse`
+- `SupportResistanceLevelResponse`
+- `SupportResistanceContextResponse`
+- `ExecutionBoundaryResponse`
+- `DecisionAnchorResponse`
+- `DecisionItemResponse`
+- `DecisionSymbolGroupResponse`
+- `PortfolioDecisionSlateResponse`
+
+State badges:
+- Always include `analysis_only` in V1.
+- Use `manual_only` when source/account/broker is not auto-executable through KIS or when market/source is manual-only.
+- Use `dry_run_ready` only as a capability label for future readiness, not as a button or action in Phase 1. Prefer `execution_boundary.future_capability = "dry_run_ready"` if needed to avoid implying current execution.
+
+## 5. V1 decision heuristics
+
+All thresholds should be constants at the top of `portfolio_decision_service.py`, with tests naming expected behavior. Initial conservative constants:
+- `NEAR_SUPPORT_PCT = 3.0`
+- `NEAR_RESISTANCE_PCT = 3.0`
+- `TARGET_NEAR_PCT = 5.0`
+- `STOP_NEAR_PCT = 5.0`
+- `HIGH_WEIGHT_PCT = 15.0`
+- `PROFIT_TRIM_PCT = 8.0`
+- `LOSS_WATCH_PCT = -6.0`
+- `RSI_OVERSOLD = 30.0`
+- `RSI_OVERBOUGHT = 70.0`
+
+Classification should produce one or more decision items per symbol, in priority order:
+
+1. `manual_review`
+- Trigger when current price is missing, quantity is zero/invalid, avg price is invalid, or both journal and support/resistance context are unavailable.
+- Also trigger if journal has no target/stop and no thesis/notes, matching the existing detail service's "저널 보강 필요" idea.
+- `action_price = null`.
+- Rationale should name the missing context.
+
+2. `sell_watch`
+- Trigger when journal stop is near: `stop_distance_pct >= -STOP_NEAR_PCT`.
+- Trigger when unrealized loss is at or below `LOSS_WATCH_PCT` and no active journal exists.
+- Anchor to `journal_stop` if present; otherwise nearest support below current.
+- Keep this as watch/manual-review language, not an execution instruction.
+
+3. `trim_candidate`
+- Trigger when position weight is high: `portfolio_weight_pct >= HIGH_WEIGHT_PCT`.
+- Trigger when journal target is near: `0 <= target_distance_pct <= TARGET_NEAR_PCT`.
+- Trigger when nearest resistance is near: `0 <= nearest_resistance.distance_pct <= NEAR_RESISTANCE_PCT` and profit is positive.
+- Suggested `action_price` preference: journal target, then nearest resistance, then current price.
+- Reduce quantity/percent should be omitted or labeled `suggested_size = null` in V1 unless explicitly configured later. Do not import the crypto rotation service's `PARTIAL_REDUCE_PCT` as cross-market policy.
+
+4. `buy_candidate`
+- For held positions only in V1: trigger only when the user already holds the symbol, the position is not high weight, current price is near support, and either RSI <= 30 or journal thesis/strategy supports accumulation.
+- Suggested `action_price` preference: nearest support, then journal entry/avg price context, never arbitrary "market now".
+- If broker/source is manual-only, mark `execution_boundary.mode = "manual_only"` even if action is buy candidate.
+
+5. `hold`
+- Default when no stronger rule triggers.
+- Include rationale from current weight, target/stop distance, and support/resistance spacing.
+- Hold is still a decision item, because the product goal asks "why not trim/buy".
+
+Execution boundary:
+- Phase 1: every item has `execution_boundary.mode = "analysis_only"` as the dominant badge.
+- Add `execution_boundary.channel = "kis_candidate"` only for KIS-backed KR/US components with broker/source data indicating KIS, but keep `auto_executable = false`.
+- Add `execution_boundary.channel = "manual_review"` for Toss/manual components, crypto, missing account context, or mixed-account symbols.
+- If a symbol has mixed KIS and manual components, prefer `manual_review` unless the item can specify component-level broker scope. V1 should avoid implicit partial-account execution assumptions.
+
+## 6. Test plan
+
+Add service tests:
+- New file: `tests/test_portfolio_decision_service.py`.
+- Test `build_decision_slate` returns top-level run/summary/groups/items shape from fake overview and fake journal data.
+- Test `trim_candidate` when target or nearest resistance is near.
+- Test `sell_watch` when stop loss is near.
+- Test held-only `buy_candidate` when current price is near support and RSI is oversold.
+- Test `hold` default when no action trigger fires.
+- Test `manual_review` when current price or all context is missing.
+- Test support/resistance helper errors degrade into warnings instead of exceptions.
+- Test mixed KIS/manual components become manual-review or analysis-only boundary, not auto-executable.
+
+Extend router tests:
+- Extend `tests/test_portfolio_dashboard_router.py` to assert the dashboard links to `/portfolio/decision`.
+- Add `tests/test_portfolio_decision_router.py` or extend dashboard router tests if keeping portfolio page tests together.
+- Test `/portfolio/decision` renders HTML with `id="portfolio-decision-desk-page"`.
+- Test `/portfolio/api/decision-slate` calls the injected service with `user_id`, `market`, repeated `account_keys`, and `q`.
+- Test API response validates through the response model.
+
+Template tests:
+- Assert the new template includes:
+  - `fetch("/portfolio/api/decision-slate`
+  - `function escapeHtml(value)`
+  - detail URL rendering
+  - empty state text
+  - badges for `analysis_only`, `manual_only`, and action types
+
+Regression/fallback tests:
+- No support/resistance: group still renders with `support_resistance.status = "unavailable"`.
+- No journal: item contains a `journal_missing` warning but still classifies based on price/SR if possible.
+- No current price: item is `manual_review`, not a 500.
+- Unsupported market from SR helper: item/group warning, not response failure.
+
+Suggested verification commands after implementation:
+```bash
+uv run pytest tests/test_portfolio_decision_service.py -q
+uv run pytest tests/test_portfolio_decision_router.py tests/test_portfolio_dashboard_router.py -q
+uv run pytest tests/test_portfolio_position_detail_router.py tests/test_portfolio_position_detail_service.py -q
+make lint
+```
+
+## 7. Phase breakdown
+
+Phase 1: analysis-only Decision Desk
+- Add route, API, schema, service, template, and dashboard link.
+- Use held portfolio positions only.
+- Use deterministic heuristics only.
+- No persistence. `decision_run.id` is runtime-generated from timestamp.
+- No execution, no dry-run button, no workflow integrations.
+
+Phase 2: dry-run / execution handoff integration
+- Add explicit dry-run handoff only after Phase 1 is stable.
+- Introduce component/account-scoped action sizing and broker-specific eligibility.
+- Add stronger guardrails for live-vs-paper separation.
+- Treat this as `high_risk_change` because it touches order approval boundaries.
+
+Phase 3: Discord / Paperclip / approval workflow integration
+- Persist decision runs if approvals/comments need stable references.
+- Add approval states and audit trail.
+- Integrate Discord/Paperclip/n8n only after approval and persistence requirements are explicit.
+- Treat this as `high_risk_change + needs_stronger_model_review + hold_for_final_review` before merge/deploy.
+
+## 8. Step-by-step implementation checklist
+
+1. Add schema models.
+- Create `app/schemas/portfolio_decision.py`.
+- Export models from `app/schemas/__init__.py` only if this repo's schema exports are expected by local convention.
+- Include `PortfolioDecisionSlateResponse` as the router response model.
+
+2. Add service tests first.
+- Create `tests/test_portfolio_decision_service.py`.
+- Use `MagicMock`/`AsyncMock` patterns from `tests/test_portfolio_position_detail_service.py`.
+- Patch support/resistance and indicator helpers at the service module import path.
+- Cover response shape, each action classifier, and fallback paths.
+
+3. Implement `PortfolioDecisionService`.
+- Create `app/services/portfolio_decision_service.py`.
+- Inject `overview_service` and `dashboard_service`.
+- Fetch overview with the same filter parameters as `/portfolio/api/overview`.
+- Fetch batch journals with current prices.
+- Build portfolio/market weights using logic equivalent to `PortfolioPositionDetailService._build_weights`; consider extracting later, but duplicate narrowly in V1 to avoid broad refactor.
+- Fetch support/resistance per symbol with graceful error handling.
+- Build `symbol_groups[]` and `items[]`.
+- Return warnings at item, group, and top-level scopes.
+
+4. Add router dependency and endpoints.
+- Modify `app/routers/portfolio.py`.
+- Import `PortfolioDecisionSlateResponse` and `PortfolioDecisionService`.
+- Add `get_portfolio_decision_service(...)`.
+- Add HTML route `/decision`.
+- Add JSON route `/api/decision-slate`.
+- Keep `HTTPException(500)` handling consistent with existing overview endpoints only for unexpected service failures; service-level missing SR/journal should not raise.
+
+5. Add the template.
+- Create `app/templates/portfolio_decision_desk.html`.
+- Reuse the visual language of portfolio templates: Bootstrap, bootstrap-icons, page shell/header, cards, responsive mobile layout, escape helpers.
+- Fetch `/portfolio/api/decision-slate` on load and on filter changes.
+- Render symbol sections from groups, not flat rows.
+- Use guarded HTML escaping and URL handling like existing templates.
+
+6. Link from the dashboard.
+- Modify `app/templates/portfolio_dashboard.html`.
+- Add a header/sidebar action link to `/portfolio/decision`.
+- Keep this to one additive navigation link; do not restructure the dashboard.
+
+7. Add router/template tests.
+- Create `tests/test_portfolio_decision_router.py`.
+- Extend `tests/test_portfolio_dashboard_router.py` for the new link.
+- Reuse `FastAPI()`, `TestClient`, dependency override patterns from existing portfolio tests.
+
+8. Run focused verification.
+- Run the new service and router tests.
+- Run existing portfolio dashboard/detail tests to catch template/router regressions.
+- Run lint after tests pass.
+
+9. Keep Phase 1 scoped.
+- Do not add migrations.
+- Do not persist decision runs.
+- Do not wire MCP, Paperclip, Discord, n8n, or execution endpoints.
+- Do not add dependencies.
+
+## 9. Risks / open questions
+
+Open questions:
+- Should V1 include only held positions, or also non-held buy candidates? Recommendation: held-only for V1, because overview service already owns current portfolio context and non-held candidates introduce screener scope and ranking policy.
+- Should decision runs be persisted? Recommendation: no for V1. Persist only when approval workflow, audit trail, or shareable run URLs become requirements.
+- Should KIS/Toss separation be exposed on day one? Recommendation: yes as badges/context, but not as executable controls.
+- Should component-level decisions be allowed for mixed-account symbols? Recommendation: no for V1 unless account scoping is explicit. Classify mixed symbols as manual-review or analysis-only to avoid hidden partial-execution assumptions.
+- Should `PortfolioPositionDetailService._build_weights` be extracted to a shared helper? Recommendation: not in first pass unless duplication becomes awkward. A focused duplicate keeps the diff safer.
+
+Risks and mitigations:
+- Support/resistance calls can make the page slow for large portfolios. Mitigate with concurrency limits, warnings, and progressive frontend loading if needed.
+- SR current price can differ from overview current price. Mitigate by calculating deltas from overview current price and keeping SR source price diagnostic-only.
+- Deterministic heuristics can be misread as advice. Mitigate with strong `analysis_only` copy, no execution controls, and rationale that names data sources/uncertainty.
+- Journal data may be stale or missing. Mitigate with item-level warnings and `manual_review` fallback.
+- Future execution phases are high risk. Mitigate by requiring explicit design review and no live execution paths in V1.

--- a/app/routers/portfolio.py
+++ b/app/routers/portfolio.py
@@ -51,6 +51,7 @@ from app.services.portfolio_position_detail_service import (
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/portfolio", tags=["Portfolio"])
+DECISION_SLATE_ERROR_DETAIL = "Unable to build portfolio decision slate."
 
 
 def get_portfolio_overview_service(
@@ -66,12 +67,12 @@ def get_portfolio_dashboard_service(
 
 
 def get_portfolio_decision_service(
-    overview_service: PortfolioOverviewService = Depends(
-        get_portfolio_overview_service
-    ),
-    dashboard_service: PortfolioDashboardService = Depends(
-        get_portfolio_dashboard_service
-    ),
+    overview_service: Annotated[
+        PortfolioOverviewService, Depends(get_portfolio_overview_service)
+    ],
+    dashboard_service: Annotated[
+        PortfolioDashboardService, Depends(get_portfolio_dashboard_service)
+    ],
 ) -> PortfolioDecisionService:
     return PortfolioDecisionService(
         overview_service=overview_service,
@@ -92,15 +93,19 @@ async def portfolio_decision_page(request: Request):
     )
 
 
-@router.get("/api/decision-slate", response_model=PortfolioDecisionSlateResponse)
+@router.get(
+    "/api/decision-slate",
+    response_model=PortfolioDecisionSlateResponse,
+    responses={500: {"description": "Failed to build portfolio decision slate"}},
+)
 async def get_portfolio_decision_slate(
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+    decision_service: Annotated[
+        PortfolioDecisionService, Depends(get_portfolio_decision_service)
+    ],
     market: Literal["ALL", "KR", "US", "CRYPTO"] = "ALL",
     account_keys: Annotated[list[str] | None, Query()] = None,
     q: Annotated[str | None, Query(min_length=1)] = None,
-    current_user: User = Depends(get_authenticated_user),
-    decision_service: PortfolioDecisionService = Depends(
-        get_portfolio_decision_service
-    ),
 ):
     try:
         return await decision_service.build_decision_slate(
@@ -111,7 +116,10 @@ async def get_portfolio_decision_slate(
         )
     except Exception as e:
         logger.error("Error building decision slate: %s", e, exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e)) from e
+        raise HTTPException(
+            status_code=500,
+            detail=DECISION_SLATE_ERROR_DETAIL,
+        ) from e
 
 
 @router.get("/", response_class=HTMLResponse)

--- a/app/routers/portfolio.py
+++ b/app/routers/portfolio.py
@@ -28,6 +28,7 @@ from app.schemas.manual_holdings import (
     MergedPortfolioResponse,
     ReferencePricesResponse,
 )
+from app.schemas.portfolio_decision import PortfolioDecisionSlateResponse
 from app.schemas.portfolio_position_detail import (
     PositionIndicatorsResponse,
     PositionNewsResponse,
@@ -41,6 +42,7 @@ from app.services.brokers.kis.client import KISClient
 from app.services.kis_holdings_service import get_kis_holding_for_ticker
 from app.services.merged_portfolio_service import MergedPortfolioService
 from app.services.portfolio_dashboard_service import PortfolioDashboardService
+from app.services.portfolio_decision_service import PortfolioDecisionService
 from app.services.portfolio_overview_service import PortfolioOverviewService
 from app.services.portfolio_position_detail_service import (
     PortfolioPositionDetailNotFoundError,
@@ -61,6 +63,55 @@ def get_portfolio_dashboard_service(
     db: AsyncSession = Depends(get_db),
 ) -> PortfolioDashboardService:
     return PortfolioDashboardService(db)
+
+
+def get_portfolio_decision_service(
+    overview_service: PortfolioOverviewService = Depends(
+        get_portfolio_overview_service
+    ),
+    dashboard_service: PortfolioDashboardService = Depends(
+        get_portfolio_dashboard_service
+    ),
+) -> PortfolioDecisionService:
+    return PortfolioDecisionService(
+        overview_service=overview_service,
+        dashboard_service=dashboard_service,
+    )
+
+
+@router.get("/decision", response_class=HTMLResponse)
+async def portfolio_decision_page(request: Request):
+    user = getattr(request.state, "user", None)
+    return templates.TemplateResponse(
+        request,
+        "portfolio_decision_desk.html",
+        {
+            "request": request,
+            "user": user,
+        },
+    )
+
+
+@router.get("/api/decision-slate", response_model=PortfolioDecisionSlateResponse)
+async def get_portfolio_decision_slate(
+    market: Literal["ALL", "KR", "US", "CRYPTO"] = "ALL",
+    account_keys: Annotated[list[str] | None, Query()] = None,
+    q: Annotated[str | None, Query(min_length=1)] = None,
+    current_user: User = Depends(get_authenticated_user),
+    decision_service: PortfolioDecisionService = Depends(
+        get_portfolio_decision_service
+    ),
+):
+    try:
+        return await decision_service.build_decision_slate(
+            user_id=current_user.id,
+            market=market,
+            account_keys=account_keys,
+            q=q,
+        )
+    except Exception as e:
+        logger.error("Error building decision slate: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 @router.get("/", response_class=HTMLResponse)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -29,6 +29,7 @@ from .n8n.pending_orders import (
     N8nPendingOrdersResponse,
     N8nPendingOrderSummary,
 )
+from .portfolio_decision import PortfolioDecisionSlateResponse
 from .portfolio_position_detail import (
     PositionDetailComponentResponse,
     PositionDetailPageResponse,
@@ -61,6 +62,8 @@ __all__ = [
     "ReferencePricesResponse",
     "MergedHoldingResponse",
     "MergedPortfolioResponse",
+    # Portfolio Decision
+    "PortfolioDecisionSlateResponse",
     # Portfolio Position Detail
     "PositionDetailComponentResponse",
     "PositionDetailSummaryResponse",

--- a/app/schemas/portfolio_decision.py
+++ b/app/schemas/portfolio_decision.py
@@ -1,0 +1,127 @@
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class DecisionRunResponse(BaseModel):
+    id: str
+    generated_at: datetime
+    mode: Literal["analysis_only", "dry_run", "live"] = "analysis_only"
+    persisted: bool = False
+    source: str = "portfolio_decision_service_v1"
+
+
+class DecisionFiltersResponse(BaseModel):
+    market: str = "ALL"
+    account_keys: list[str] = Field(default_factory=list)
+    q: str | None = None
+
+
+class DecisionSummaryResponse(BaseModel):
+    symbols: int = 0
+    decision_items: int = 0
+    actionable_items: int = 0
+    manual_review_items: int = 0
+    auto_candidate_items: int = 0
+    missing_context_items: int = 0
+    by_action: dict[str, int] = Field(default_factory=dict)
+    by_market: dict[str, int] = Field(default_factory=dict)
+
+
+class DecisionFacetsResponse(BaseModel):
+    accounts: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class DecisionPositionContextResponse(BaseModel):
+    quantity: float | None = None
+    avg_price: float | None = None
+    current_price: float | None = None
+    evaluation: float | None = None
+    evaluation_krw: float | None = None
+    profit_loss: float | None = None
+    profit_loss_krw: float | None = None
+    profit_rate: float | None = None
+    portfolio_weight_pct: float | None = None
+    market_weight_pct: float | None = None
+    components: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class DecisionJournalContextResponse(BaseModel):
+    status: str | None = None
+    strategy: str | None = None
+    target_price: float | None = None
+    stop_loss: float | None = None
+    target_distance_pct: float | None = None
+    stop_distance_pct: float | None = None
+
+
+class SupportResistanceLevelResponse(BaseModel):
+    price: float
+    distance_pct: float
+    strength: str
+    sources: list[str] = Field(default_factory=list)
+
+
+class SupportResistanceContextResponse(BaseModel):
+    status: Literal["available", "unavailable", "pending"]
+    nearest_support: SupportResistanceLevelResponse | None = None
+    nearest_resistance: SupportResistanceLevelResponse | None = None
+    supports: list[SupportResistanceLevelResponse] = Field(default_factory=list)
+    resistances: list[SupportResistanceLevelResponse] = Field(default_factory=list)
+
+
+class ExecutionBoundaryResponse(BaseModel):
+    mode: Literal["analysis_only", "manual_only", "dry_run_ready", "live_ready"]
+    channel: str | None = None
+    auto_executable: bool = False
+    manual_only: bool = False
+    reason: str | None = None
+    future_capability: str | None = None
+
+
+class DecisionAnchorResponse(BaseModel):
+    type: str
+    price: float | None = None
+    distance_pct: float | None = None
+    strength: str | None = None
+
+
+class DecisionItemResponse(BaseModel):
+    id: str
+    action: Literal[
+        "buy_candidate", "trim_candidate", "sell_watch", "hold", "manual_review"
+    ]
+    label: str
+    priority: Literal["low", "medium", "high"] = "low"
+    current_price: float | None = None
+    action_price: float | None = None
+    action_price_source: str | None = None
+    delta_from_current_pct: float | None = None
+    anchor: DecisionAnchorResponse | None = None
+    rationale: list[str] = Field(default_factory=list)
+    execution_boundary: ExecutionBoundaryResponse
+    badges: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class DecisionSymbolGroupResponse(BaseModel):
+    market_type: str
+    symbol: str
+    name: str
+    detail_url: str
+    position: DecisionPositionContextResponse
+    journal: DecisionJournalContextResponse | None = None
+    support_resistance: SupportResistanceContextResponse
+    items: list[DecisionItemResponse] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class PortfolioDecisionSlateResponse(BaseModel):
+    success: bool = True
+    decision_run: DecisionRunResponse
+    filters: DecisionFiltersResponse
+    summary: DecisionSummaryResponse
+    facets: DecisionFacetsResponse
+    symbol_groups: list[DecisionSymbolGroupResponse]
+    warnings: list[str] = Field(default_factory=list)

--- a/app/services/portfolio_decision_service.py
+++ b/app/services/portfolio_decision_service.py
@@ -1,0 +1,585 @@
+import asyncio
+import logging
+from datetime import datetime
+from typing import Any
+
+from app.mcp_server.tooling.fundamentals._support_resistance import (
+    get_support_resistance_impl as _get_support_resistance_impl,
+)
+from app.mcp_server.tooling.market_data_quotes import _get_indicators_impl
+
+logger = logging.getLogger(__name__)
+
+# Heuristic constants
+NEAR_SUPPORT_PCT = 3.0
+NEAR_RESISTANCE_PCT = 3.0
+TARGET_NEAR_PCT = 5.0
+STOP_NEAR_PCT = 5.0
+HIGH_WEIGHT_PCT = 15.0
+PROFIT_TRIM_PCT = 8.0
+LOSS_WATCH_PCT = -6.0
+RSI_OVERSOLD = 30.0
+RSI_OVERBOUGHT = 70.0
+
+
+def _to_optional_float(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+class PortfolioDecisionService:
+    def __init__(self, *, overview_service, dashboard_service) -> None:
+        self.overview_service = overview_service
+        self.dashboard_service = dashboard_service
+
+    async def build_decision_slate(
+        self,
+        *,
+        user_id: int,
+        market: str = "ALL",
+        account_keys: list[str] | None = None,
+        q: str | None = None,
+    ) -> dict[str, Any]:
+        """Build a deterministic decision slate for the user's current portfolio."""
+        # 1. Fetch overview
+        overview = await self.overview_service.get_overview(
+            user_id=user_id,
+            market=market,
+            account_keys=account_keys,
+            q=q,
+            skip_missing_prices=False,
+        )
+        positions = overview.get("positions") or []
+        facets = overview.get("facets") or {}
+
+        # 2. Fetch journals in batch
+        current_prices = {
+            p["symbol"]: p.get("current_price") for p in positions if p.get("symbol")
+        }
+        journals = await self.dashboard_service.get_journals_batch(
+            list(current_prices.keys()),
+            current_prices=current_prices,
+        )
+
+        # 3. Fetch support/resistance and indicators concurrently
+        # We cap concurrency to avoid overloading external APIs
+        semaphore = asyncio.Semaphore(10)
+
+        async def fetch_context(p: dict[str, Any]) -> dict[str, Any]:
+            symbol = p["symbol"]
+            market_type = p["market_type"]
+            async with semaphore:
+                sr_task = _get_support_resistance_impl(symbol, market=market_type)
+                ind_task = _get_indicators_impl(symbol, ["rsi"], market=market_type)
+                sr, ind = await asyncio.gather(
+                    sr_task, ind_task, return_exceptions=True
+                )
+                return {
+                    "symbol": symbol,
+                    "sr": sr
+                    if not isinstance(sr, Exception)
+                    else {"status": "unavailable", "error": str(sr)},
+                    "ind": ind
+                    if not isinstance(ind, Exception)
+                    else {"indicators": {}},
+                }
+
+        contexts_list = await asyncio.gather(*[fetch_context(p) for p in positions])
+        contexts = {c["symbol"]: c for c in contexts_list}
+
+        # 4. Build symbol groups and items
+        symbol_groups = []
+        summary_counts = {
+            "symbols": 0,
+            "decision_items": 0,
+            "actionable_items": 0,
+            "manual_review_items": 0,
+            "auto_candidate_items": 0,
+            "missing_context_items": 0,
+            "by_action": {
+                "buy_candidate": 0,
+                "trim_candidate": 0,
+                "sell_watch": 0,
+                "hold": 0,
+                "manual_review": 0,
+            },
+            "by_market": {},
+        }
+
+        for p in positions:
+            symbol = p["symbol"]
+            market_type = p["market_type"]
+            journal = journals.get(symbol)
+            context = contexts.get(symbol) or {
+                "sr": {"status": "unavailable"},
+                "ind": {"indicators": {}},
+            }
+
+            weights = self._build_weights(positions, p)
+            group = self._build_symbol_group(p, journal, context, weights)
+            symbol_groups.append(group)
+
+            # Update summary
+            summary_counts["symbols"] += 1
+            summary_counts["by_market"][market_type] = (
+                summary_counts["by_market"].get(market_type, 0) + 1
+            )
+            for item in group["items"]:
+                summary_counts["decision_items"] += 1
+                action = item["action"]
+                summary_counts["by_action"][action] = (
+                    summary_counts["by_action"].get(action, 0) + 1
+                )
+
+                if action in ("buy_candidate", "trim_candidate", "sell_watch"):
+                    summary_counts["actionable_items"] += 1
+                if action == "manual_review":
+                    summary_counts["manual_review_items"] += 1
+                if "missing_context" in item.get("badges", []):
+                    summary_counts["missing_context_items"] += 1
+
+                # Phase 1: auto_executable is always false
+                if item["execution_boundary"].get("auto_executable"):
+                    summary_counts["auto_candidate_items"] += 1
+
+        run_id = f"runtime-{datetime.now().isoformat()}"
+
+        return {
+            "success": True,
+            "decision_run": {
+                "id": run_id,
+                "generated_at": datetime.now(),
+                "mode": "analysis_only",
+                "persisted": False,
+                "source": "portfolio_decision_service_v1",
+            },
+            "filters": {
+                "market": market,
+                "account_keys": account_keys or [],
+                "q": q,
+            },
+            "summary": summary_counts,
+            "facets": facets,
+            "symbol_groups": symbol_groups,
+            "warnings": [],
+        }
+
+    def _build_symbol_group(
+        self,
+        position: dict[str, Any],
+        journal: dict[str, Any] | None,
+        context: dict[str, Any],
+        weights: dict[str, float | None],
+    ) -> dict[str, Any]:
+        symbol = position["symbol"]
+        market_type = position["market_type"]
+        sr_raw = context.get("sr") or {"status": "unavailable"}
+        ind_raw = context.get("ind") or {"indicators": {}}
+        rsi = _to_optional_float(
+            (ind_raw.get("indicators") or {}).get("rsi", {}).get("14")
+        )
+
+        # Map SR
+        sr_context = self._map_sr_context(sr_raw)
+        group_warnings = []
+        if sr_context["status"] == "unavailable":
+            group_warnings.append("support_resistance_unavailable")
+        if journal is None:
+            group_warnings.append("journal_missing")
+
+        # Build items
+        execution_boundary = self._build_execution_boundary(position)
+        items = self._classify_actions(
+            position, journal, sr_context, weights, rsi, execution_boundary
+        )
+
+        return {
+            "market_type": market_type,
+            "symbol": symbol,
+            "name": position.get("name", symbol),
+            "detail_url": f"/portfolio/positions/{market_type.lower()}/{symbol}",
+            "position": {
+                "quantity": _to_optional_float(position.get("quantity")),
+                "avg_price": _to_optional_float(position.get("avg_price")),
+                "current_price": _to_optional_float(position.get("current_price")),
+                "evaluation": _to_optional_float(position.get("evaluation")),
+                "evaluation_krw": _to_optional_float(position.get("evaluation_krw")),
+                "profit_loss": _to_optional_float(position.get("profit_loss")),
+                "profit_loss_krw": _to_optional_float(position.get("profit_loss_krw")),
+                "profit_rate": _to_optional_float(position.get("profit_rate")),
+                "portfolio_weight_pct": weights.get("portfolio_weight_pct"),
+                "market_weight_pct": weights.get("market_weight_pct"),
+                "components": position.get("components", []),
+            },
+            "journal": journal,
+            "support_resistance": sr_context,
+            "items": items,
+            "warnings": group_warnings,
+        }
+
+    def _map_sr_context(self, sr_raw: dict[str, Any]) -> dict[str, Any]:
+        status = sr_raw.get("status", "available")
+        if "error" in sr_raw:
+            status = "unavailable"
+
+        def map_level(level: Any) -> dict[str, Any] | None:
+            if isinstance(level, dict):
+                price = _to_optional_float(level.get("price"))
+                distance_pct = _to_optional_float(level.get("distance_pct"))
+                if price is None or distance_pct is None:
+                    return None
+                return {
+                    "price": price,
+                    "distance_pct": distance_pct,
+                    "strength": level.get("strength", "weak"),
+                    "sources": level.get("sources", []),
+                }
+            return None
+
+        supports = [
+            mapped
+            for mapped in (map_level(level) for level in (sr_raw.get("supports") or []))
+            if mapped is not None
+        ]
+        resistances = [
+            mapped
+            for mapped in (
+                map_level(level) for level in (sr_raw.get("resistances") or [])
+            )
+            if mapped is not None
+        ]
+        nearest_support = map_level(sr_raw.get("nearest_support")) or (
+            supports[0] if supports else None
+        )
+        nearest_resistance = map_level(sr_raw.get("nearest_resistance")) or (
+            resistances[0] if resistances else None
+        )
+
+        if status == "unavailable":
+            nearest_support = None
+            nearest_resistance = None
+            supports = []
+            resistances = []
+
+        return {
+            "status": status,
+            "nearest_support": nearest_support,
+            "nearest_resistance": nearest_resistance,
+            "supports": supports,
+            "resistances": resistances,
+        }
+
+    def _build_execution_boundary(self, position: dict[str, Any]) -> dict[str, Any]:
+        components = position.get("components") or []
+        brokers = {
+            str(component.get("broker") or "").lower()
+            for component in components
+            if component.get("broker")
+        }
+        sources = {
+            str(component.get("source") or "").lower()
+            for component in components
+            if component.get("source")
+        }
+        market_type = str(position.get("market_type") or "").upper()
+        is_kis_only = bool(brokers) and brokers <= {"kis"} and "manual" not in sources
+        channel = (
+            "kis_candidate"
+            if is_kis_only and market_type in {"KR", "US"}
+            else "manual_review"
+        )
+        manual_only = channel == "manual_review"
+        return {
+            "mode": "analysis_only",
+            "channel": channel,
+            "auto_executable": False,
+            "manual_only": manual_only,
+            "reason": "Phase 1 does not expose execution.",
+        }
+
+    def _classify_actions(
+        self,
+        position: dict[str, Any],
+        journal: dict[str, Any] | None,
+        sr: dict[str, Any],
+        weights: dict[str, float | None],
+        rsi: float | None,
+        execution_boundary: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        items = []
+        symbol = position["symbol"]
+        current_price = _to_optional_float(position.get("current_price"))
+        profit_rate = _to_optional_float(position.get("profit_rate")) or 0
+        portfolio_weight_pct = weights.get("portfolio_weight_pct") or 0
+
+        # 1. Manual Review
+        if (
+            current_price is None
+            or current_price <= 0
+            or (not journal and sr["status"] == "unavailable")
+        ):
+            items.append(
+                self._build_decision_item(
+                    id=f"{symbol}:manual_review:missing_context",
+                    action="manual_review",
+                    label="Manual review required",
+                    priority="high",
+                    current_price=current_price,
+                    rationale=[
+                        "Current price or market context (journal, S/R) is missing."
+                    ],
+                    execution_boundary=execution_boundary,
+                    badges=["analysis_only", "missing_context"],
+                    warnings=["missing_context"],
+                )
+            )
+            return items
+
+        # 2. Sell Watch
+        stop_dist = (journal or {}).get("stop_distance_pct")
+        if stop_dist is not None and stop_dist >= -STOP_NEAR_PCT:
+            items.append(
+                self._build_decision_item(
+                    id=f"{symbol}:sell_watch:stop_near",
+                    action="sell_watch",
+                    label="Sell watch (Stop near)",
+                    priority="high",
+                    current_price=current_price,
+                    action_price=(journal or {}).get("stop_loss"),
+                    action_price_source="journal_stop",
+                    delta_from_current_pct=stop_dist,
+                    anchor={
+                        "type": "stop_loss",
+                        "price": (journal or {}).get("stop_loss"),
+                        "distance_pct": stop_dist,
+                    },
+                    rationale=["Price is approaching the journal stop-loss level."],
+                    execution_boundary=execution_boundary,
+                )
+            )
+        elif profit_rate * 100 <= LOSS_WATCH_PCT and not journal:
+            items.append(
+                self._build_decision_item(
+                    id=f"{symbol}:sell_watch:loss_threshold",
+                    action="sell_watch",
+                    label="Sell watch (Loss threshold)",
+                    priority="medium",
+                    current_price=current_price,
+                    rationale=[
+                        f"Unrealized loss exceeded {LOSS_WATCH_PCT}% without an active journal."
+                    ],
+                    execution_boundary=execution_boundary,
+                )
+            )
+
+        # 3. Trim Candidate
+        target_dist = (journal or {}).get("target_distance_pct")
+        res_dist = (sr.get("nearest_resistance") or {}).get("distance_pct")
+
+        if portfolio_weight_pct >= HIGH_WEIGHT_PCT:
+            items.append(
+                self._build_decision_item(
+                    id=f"{symbol}:trim_candidate:high_weight",
+                    action="trim_candidate",
+                    label="Trim candidate (High weight)",
+                    priority="medium",
+                    current_price=current_price,
+                    rationale=[
+                        f"Position weight ({portfolio_weight_pct:.1f}%) exceeds the high-weight threshold ({HIGH_WEIGHT_PCT}%)."
+                    ],
+                    execution_boundary=execution_boundary,
+                )
+            )
+        elif target_dist is not None and 0 <= target_dist <= TARGET_NEAR_PCT:
+            items.append(
+                self._build_decision_item(
+                    id=f"{symbol}:trim_candidate:target_near",
+                    action="trim_candidate",
+                    label="Trim candidate (Target near)",
+                    priority="medium",
+                    current_price=current_price,
+                    action_price=(journal or {}).get("target_price"),
+                    action_price_source="journal_target",
+                    delta_from_current_pct=target_dist,
+                    anchor={
+                        "type": "target",
+                        "price": (journal or {}).get("target_price"),
+                        "distance_pct": target_dist,
+                    },
+                    rationale=["Price is approaching the journal target price."],
+                    execution_boundary=execution_boundary,
+                )
+            )
+        elif (
+            res_dist is not None
+            and 0 <= res_dist <= NEAR_RESISTANCE_PCT
+            and profit_rate > 0
+        ):
+            items.append(
+                self._build_decision_item(
+                    id=f"{symbol}:trim_candidate:resistance_near",
+                    action="trim_candidate",
+                    label="Trim candidate (Resistance near)",
+                    priority="low",
+                    current_price=current_price,
+                    action_price=(sr.get("nearest_resistance") or {}).get("price"),
+                    action_price_source="nearest_resistance",
+                    delta_from_current_pct=res_dist,
+                    anchor={
+                        "type": "resistance",
+                        "price": (sr.get("nearest_resistance") or {}).get("price"),
+                        "distance_pct": res_dist,
+                    },
+                    rationale=[
+                        "Price is near a major resistance level while in profit."
+                    ],
+                    execution_boundary=execution_boundary,
+                )
+            )
+
+        # 4. Buy Candidate (held only)
+        sup_dist = (sr.get("nearest_support") or {}).get("distance_pct")
+        if (
+            sup_dist is not None
+            and abs(sup_dist) <= NEAR_SUPPORT_PCT
+            and portfolio_weight_pct < HIGH_WEIGHT_PCT
+        ):
+            if rsi is not None and rsi <= RSI_OVERSOLD:
+                items.append(
+                    self._build_decision_item(
+                        id=f"{symbol}:buy_candidate:support_rsi",
+                        action="buy_candidate",
+                        label="Buy candidate (Support + RSI)",
+                        priority="medium",
+                        current_price=current_price,
+                        action_price=(sr.get("nearest_support") or {}).get("price"),
+                        action_price_source="nearest_support",
+                        delta_from_current_pct=sup_dist,
+                        anchor={
+                            "type": "support",
+                            "price": (sr.get("nearest_support") or {}).get("price"),
+                            "distance_pct": sup_dist,
+                        },
+                        rationale=[
+                            "Price is near support and RSI is in oversold territory."
+                        ],
+                        execution_boundary=execution_boundary,
+                    )
+                )
+
+        # 5. Hold
+        if not items:
+            items.append(
+                self._build_decision_item(
+                    id=f"{symbol}:hold:default",
+                    action="hold",
+                    label="Hold",
+                    priority="low",
+                    current_price=current_price,
+                    rationale=[
+                        "No strong buy/sell/trim triggers identified. Maintaining current position."
+                    ],
+                    execution_boundary=execution_boundary,
+                )
+            )
+
+        return items
+
+    def _build_decision_item(
+        self,
+        id: str,
+        action: str,
+        label: str,
+        current_price: float,
+        priority: str = "low",
+        action_price: float | None = None,
+        action_price_source: str | None = None,
+        delta_from_current_pct: float | None = None,
+        anchor: dict[str, Any] | None = None,
+        rationale: list[str] | None = None,
+        execution_boundary: dict[str, Any] | None = None,
+        badges: list[str] | None = None,
+        warnings: list[str] | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "id": id,
+            "action": action,
+            "label": label,
+            "priority": priority,
+            "current_price": current_price,
+            "action_price": action_price,
+            "action_price_source": action_price_source,
+            "delta_from_current_pct": delta_from_current_pct,
+            "anchor": anchor,
+            "rationale": rationale or [],
+            "execution_boundary": execution_boundary
+            or {
+                "mode": "analysis_only",
+                "channel": None,
+                "auto_executable": False,
+                "manual_only": False,
+                "reason": "Phase 1 does not expose execution.",
+            },
+            "badges": badges or ["analysis_only"],
+            "warnings": warnings or [],
+        }
+
+    def _round_pct(self, value: float | None) -> float | None:
+        if value is None:
+            return None
+        return round(value, 1)
+
+    def _build_weights(
+        self,
+        positions: list[dict[str, Any]],
+        base: dict[str, Any],
+    ) -> dict[str, float | None]:
+        def get_eval_krw(p: dict) -> float | None:
+            market_type = str(p.get("market_type") or "").upper()
+            val = p.get("evaluation_krw")
+            if val is not None:
+                return float(val)
+            if market_type == "US":
+                return None
+            return float(p.get("evaluation", 0) or 0)
+
+        base_evaluation_krw = get_eval_krw(base)
+        if base_evaluation_krw in (None, 0):
+            return {"portfolio_weight_pct": None, "market_weight_pct": None}
+
+        portfolio_values = [get_eval_krw(p) for p in positions]
+        total_portfolio_eval_krw = (
+            sum(value for value in portfolio_values if value is not None)
+            if all(value is not None for value in portfolio_values)
+            else None
+        )
+
+        market_type = base.get("market_type")
+        same_market_values = [
+            get_eval_krw(p) for p in positions if p.get("market_type") == market_type
+        ]
+        total_same_market_eval_krw = (
+            sum(value for value in same_market_values if value is not None)
+            if all(value is not None for value in same_market_values)
+            else None
+        )
+
+        portfolio_weight = (
+            (base_evaluation_krw / total_portfolio_eval_krw) * 100
+            if total_portfolio_eval_krw not in (None, 0)
+            else None
+        )
+        market_weight = (
+            (base_evaluation_krw / total_same_market_eval_krw) * 100
+            if total_same_market_eval_krw not in (None, 0)
+            else None
+        )
+
+        return {
+            "portfolio_weight_pct": self._round_pct(portfolio_weight),
+            "market_weight_pct": self._round_pct(market_weight),
+        }

--- a/app/services/portfolio_decision_service.py
+++ b/app/services/portfolio_decision_service.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from app.mcp_server.tooling.fundamentals._support_resistance import (
@@ -20,6 +20,18 @@ PROFIT_TRIM_PCT = 8.0
 LOSS_WATCH_PCT = -6.0
 RSI_OVERSOLD = 30.0
 RSI_OVERBOUGHT = 70.0
+ACTIONABLE_ACTIONS = frozenset({"buy_candidate", "trim_candidate", "sell_watch"})
+CONTEXT_TIMEOUT_SECONDS = 3.0
+EXECUTION_DISABLED_REASON = "Phase 1 does not expose execution."
+DEFAULT_EXECUTION_BOUNDARY = {
+    "mode": "analysis_only",
+    "channel": None,
+    "auto_executable": False,
+    "manual_only": False,
+    "reason": EXECUTION_DISABLED_REASON,
+}
+
+type PositionKey = tuple[str, str]
 
 
 def _to_optional_float(value: Any) -> float | None:
@@ -32,9 +44,16 @@ def _to_optional_float(value: Any) -> float | None:
 
 
 class PortfolioDecisionService:
-    def __init__(self, *, overview_service, dashboard_service) -> None:
+    def __init__(
+        self,
+        *,
+        overview_service,
+        dashboard_service,
+        context_timeout_seconds: float = CONTEXT_TIMEOUT_SECONDS,
+    ) -> None:
         self.overview_service = overview_service
         self.dashboard_service = dashboard_service
+        self.context_timeout_seconds = context_timeout_seconds
 
     async def build_decision_slate(
         self,
@@ -56,44 +75,145 @@ class PortfolioDecisionService:
         positions = overview.get("positions") or []
         facets = overview.get("facets") or {}
 
-        # 2. Fetch journals in batch
-        current_prices = {
-            p["symbol"]: p.get("current_price") for p in positions if p.get("symbol")
+        current_prices_by_position = self._current_prices_by_position(positions)
+        current_prices = self._current_prices_by_symbol(current_prices_by_position)
+        journals = await self._fetch_journals(current_prices)
+        contexts = await self._fetch_market_contexts(positions)
+
+        symbol_groups = []
+        summary_counts = self._initial_summary_counts()
+
+        for p in positions:
+            symbol = p["symbol"]
+            market_type = p["market_type"]
+            position_key = self._position_key(p)
+            journal = journals.get(symbol)
+            context = contexts.get(position_key) or self._empty_market_context()
+
+            weights = self._build_weights(positions, p)
+            group = self._build_symbol_group(p, journal, context, weights)
+            symbol_groups.append(group)
+            self._add_group_to_summary(summary_counts, market_type, group)
+
+        generated_at = datetime.now(UTC)
+        run_id = f"runtime-{generated_at.isoformat()}"
+
+        return {
+            "success": True,
+            "decision_run": {
+                "id": run_id,
+                "generated_at": generated_at,
+                "mode": "analysis_only",
+                "persisted": False,
+                "source": "portfolio_decision_service_v1",
+            },
+            "filters": {
+                "market": market,
+                "account_keys": account_keys or [],
+                "q": q,
+            },
+            "summary": summary_counts,
+            "facets": facets,
+            "symbol_groups": symbol_groups,
+            "warnings": [],
         }
-        journals = await self.dashboard_service.get_journals_batch(
+
+    def _position_key(self, position: dict[str, Any]) -> PositionKey:
+        return (str(position["market_type"]).upper(), str(position["symbol"]))
+
+    def _current_prices_by_position(
+        self, positions: list[dict[str, Any]]
+    ) -> dict[PositionKey, Any]:
+        return {
+            self._position_key(p): p.get("current_price")
+            for p in positions
+            if p.get("symbol") and p.get("market_type")
+        }
+
+    def _current_prices_by_symbol(
+        self, current_prices_by_position: dict[PositionKey, Any]
+    ) -> dict[str, Any]:
+        return {
+            symbol: current_price
+            for (_, symbol), current_price in current_prices_by_position.items()
+        }
+
+    async def _fetch_journals(self, current_prices: dict[str, Any]) -> dict[str, Any]:
+        return await self.dashboard_service.get_journals_batch(
             list(current_prices.keys()),
             current_prices=current_prices,
         )
 
-        # 3. Fetch support/resistance and indicators concurrently
-        # We cap concurrency to avoid overloading external APIs
+    async def _fetch_market_contexts(
+        self, positions: list[dict[str, Any]]
+    ) -> dict[PositionKey, dict[str, Any]]:
         semaphore = asyncio.Semaphore(10)
+        contexts_list = await asyncio.gather(
+            *[self._fetch_position_context(p, semaphore) for p in positions]
+        )
+        return {context["key"]: context for context in contexts_list}
 
-        async def fetch_context(p: dict[str, Any]) -> dict[str, Any]:
-            symbol = p["symbol"]
-            market_type = p["market_type"]
-            async with semaphore:
-                sr_task = _get_support_resistance_impl(symbol, market=market_type)
-                ind_task = _get_indicators_impl(symbol, ["rsi"], market=market_type)
-                sr, ind = await asyncio.gather(
-                    sr_task, ind_task, return_exceptions=True
-                )
-                return {
-                    "symbol": symbol,
-                    "sr": sr
-                    if not isinstance(sr, Exception)
-                    else {"status": "unavailable", "error": str(sr)},
-                    "ind": ind
-                    if not isinstance(ind, Exception)
-                    else {"indicators": {}},
-                }
+    async def _fetch_position_context(
+        self, position: dict[str, Any], semaphore: asyncio.Semaphore
+    ) -> dict[str, Any]:
+        symbol = position["symbol"]
+        market_type = position["market_type"]
+        key = self._position_key(position)
+        async with semaphore:
+            sr_task = self._fetch_context_call(
+                _get_support_resistance_impl(symbol, market=market_type),
+                symbol=symbol,
+                market_type=market_type,
+                call="support_resistance",
+                fallback={"status": "unavailable"},
+            )
+            ind_task = self._fetch_context_call(
+                _get_indicators_impl(symbol, ["rsi"], market=market_type),
+                symbol=symbol,
+                market_type=market_type,
+                call="indicators",
+                fallback={"indicators": {}},
+            )
+            sr, ind = await asyncio.gather(sr_task, ind_task)
 
-        contexts_list = await asyncio.gather(*[fetch_context(p) for p in positions])
-        contexts = {c["symbol"]: c for c in contexts_list}
+        return {
+            "key": key,
+            "symbol": symbol,
+            "sr": sr,
+            "ind": ind,
+        }
 
-        # 4. Build symbol groups and items
-        symbol_groups = []
-        summary_counts = {
+    async def _fetch_context_call(
+        self,
+        awaitable,
+        *,
+        symbol: str,
+        market_type: str,
+        call: str,
+        fallback: dict[str, Any],
+    ) -> dict[str, Any]:
+        try:
+            return await asyncio.wait_for(
+                awaitable,
+                timeout=self.context_timeout_seconds,
+            )
+        except Exception as exc:
+            logger.warning(
+                "portfolio decision context fetch failed "
+                "symbol=%s market=%s call=%s error=%s",
+                symbol,
+                market_type,
+                call,
+                exc,
+                exc_info=True,
+            )
+            return fallback
+
+    def _empty_market_context(self) -> dict[str, Any]:
+        return {"sr": {"status": "unavailable"}, "ind": {"indicators": {}}}
+
+    def _initial_summary_counts(self) -> dict[str, Any]:
+        return {
             "symbols": 0,
             "decision_items": 0,
             "actionable_items": 0,
@@ -110,63 +230,35 @@ class PortfolioDecisionService:
             "by_market": {},
         }
 
-        for p in positions:
-            symbol = p["symbol"]
-            market_type = p["market_type"]
-            journal = journals.get(symbol)
-            context = contexts.get(symbol) or {
-                "sr": {"status": "unavailable"},
-                "ind": {"indicators": {}},
-            }
+    def _add_group_to_summary(
+        self,
+        summary_counts: dict[str, Any],
+        market_type: str,
+        group: dict[str, Any],
+    ) -> None:
+        summary_counts["symbols"] += 1
+        summary_counts["by_market"][market_type] = (
+            summary_counts["by_market"].get(market_type, 0) + 1
+        )
+        for item in group["items"]:
+            self._add_item_to_summary(summary_counts, item)
 
-            weights = self._build_weights(positions, p)
-            group = self._build_symbol_group(p, journal, context, weights)
-            symbol_groups.append(group)
-
-            # Update summary
-            summary_counts["symbols"] += 1
-            summary_counts["by_market"][market_type] = (
-                summary_counts["by_market"].get(market_type, 0) + 1
-            )
-            for item in group["items"]:
-                summary_counts["decision_items"] += 1
-                action = item["action"]
-                summary_counts["by_action"][action] = (
-                    summary_counts["by_action"].get(action, 0) + 1
-                )
-
-                if action in ("buy_candidate", "trim_candidate", "sell_watch"):
-                    summary_counts["actionable_items"] += 1
-                if action == "manual_review":
-                    summary_counts["manual_review_items"] += 1
-                if "missing_context" in item.get("badges", []):
-                    summary_counts["missing_context_items"] += 1
-
-                # Phase 1: auto_executable is always false
-                if item["execution_boundary"].get("auto_executable"):
-                    summary_counts["auto_candidate_items"] += 1
-
-        run_id = f"runtime-{datetime.now().isoformat()}"
-
-        return {
-            "success": True,
-            "decision_run": {
-                "id": run_id,
-                "generated_at": datetime.now(),
-                "mode": "analysis_only",
-                "persisted": False,
-                "source": "portfolio_decision_service_v1",
-            },
-            "filters": {
-                "market": market,
-                "account_keys": account_keys or [],
-                "q": q,
-            },
-            "summary": summary_counts,
-            "facets": facets,
-            "symbol_groups": symbol_groups,
-            "warnings": [],
-        }
+    def _add_item_to_summary(
+        self, summary_counts: dict[str, Any], item: dict[str, Any]
+    ) -> None:
+        action = item["action"]
+        summary_counts["decision_items"] += 1
+        summary_counts["by_action"][action] = (
+            summary_counts["by_action"].get(action, 0) + 1
+        )
+        if action in ACTIONABLE_ACTIONS:
+            summary_counts["actionable_items"] += 1
+        if action == "manual_review":
+            summary_counts["manual_review_items"] += 1
+        if "missing_context" in item.get("badges", []):
+            summary_counts["missing_context_items"] += 1
+        if item["execution_boundary"].get("auto_executable"):
+            summary_counts["auto_candidate_items"] += 1
 
     def _build_symbol_group(
         self,
@@ -298,7 +390,7 @@ class PortfolioDecisionService:
             "channel": channel,
             "auto_executable": False,
             "manual_only": manual_only,
-            "reason": "Phase 1 does not expose execution.",
+            "reason": EXECUTION_DISABLED_REASON,
         }
 
     def _classify_actions(
@@ -310,191 +402,274 @@ class PortfolioDecisionService:
         rsi: float | None,
         execution_boundary: dict[str, Any],
     ) -> list[dict[str, Any]]:
-        items = []
         symbol = position["symbol"]
         current_price = _to_optional_float(position.get("current_price"))
-        profit_rate = _to_optional_float(position.get("profit_rate")) or 0
-        portfolio_weight_pct = weights.get("portfolio_weight_pct") or 0
+        if self._needs_manual_review(current_price, journal, sr):
+            return [
+                self._missing_context_item(symbol, current_price, execution_boundary)
+            ]
 
-        # 1. Manual Review
-        if (
-            current_price is None
-            or current_price <= 0
-            or (not journal and sr["status"] == "unavailable")
-        ):
-            items.append(
-                self._build_decision_item(
-                    id=f"{symbol}:manual_review:missing_context",
-                    action="manual_review",
-                    label="Manual review required",
-                    priority="high",
-                    current_price=current_price,
-                    rationale=[
-                        "Current price or market context (journal, S/R) is missing."
-                    ],
-                    execution_boundary=execution_boundary,
-                    badges=["analysis_only", "missing_context"],
-                    warnings=["missing_context"],
-                )
+        items = [
+            item
+            for item in (
+                self._sell_watch_item(
+                    symbol, current_price, position, journal, execution_boundary
+                ),
+                self._trim_candidate_item(
+                    symbol,
+                    current_price,
+                    position,
+                    journal,
+                    sr,
+                    weights,
+                    execution_boundary,
+                ),
+                self._buy_candidate_item(
+                    symbol, current_price, sr, weights, rsi, execution_boundary
+                ),
             )
-            return items
+            if item is not None
+        ]
+        if not items:
+            items.append(self._hold_item(symbol, current_price, execution_boundary))
+        return items
 
-        # 2. Sell Watch
+    def _sell_watch_item(
+        self,
+        symbol: str,
+        current_price: float | None,
+        position: dict[str, Any],
+        journal: dict[str, Any] | None,
+        execution_boundary: dict[str, Any],
+    ) -> dict[str, Any] | None:
         stop_dist = (journal or {}).get("stop_distance_pct")
         if stop_dist is not None and stop_dist >= -STOP_NEAR_PCT:
-            items.append(
-                self._build_decision_item(
-                    id=f"{symbol}:sell_watch:stop_near",
-                    action="sell_watch",
-                    label="Sell watch (Stop near)",
-                    priority="high",
-                    current_price=current_price,
-                    action_price=(journal or {}).get("stop_loss"),
-                    action_price_source="journal_stop",
-                    delta_from_current_pct=stop_dist,
-                    anchor={
-                        "type": "stop_loss",
-                        "price": (journal or {}).get("stop_loss"),
-                        "distance_pct": stop_dist,
-                    },
-                    rationale=["Price is approaching the journal stop-loss level."],
-                    execution_boundary=execution_boundary,
-                )
-            )
-        elif profit_rate * 100 <= LOSS_WATCH_PCT and not journal:
-            items.append(
-                self._build_decision_item(
-                    id=f"{symbol}:sell_watch:loss_threshold",
-                    action="sell_watch",
-                    label="Sell watch (Loss threshold)",
-                    priority="medium",
-                    current_price=current_price,
-                    rationale=[
-                        f"Unrealized loss exceeded {LOSS_WATCH_PCT}% without an active journal."
-                    ],
-                    execution_boundary=execution_boundary,
-                )
+            return self._build_decision_item(
+                id=f"{symbol}:sell_watch:stop_near",
+                action="sell_watch",
+                label="Sell watch (Stop near)",
+                priority="high",
+                current_price=current_price,
+                action_price=(journal or {}).get("stop_loss"),
+                action_price_source="journal_stop",
+                delta_from_current_pct=stop_dist,
+                anchor={
+                    "type": "stop_loss",
+                    "price": (journal or {}).get("stop_loss"),
+                    "distance_pct": stop_dist,
+                },
+                rationale=["Price is approaching the journal stop-loss level."],
+                execution_boundary=execution_boundary,
             )
 
-        # 3. Trim Candidate
+        profit_rate = _to_optional_float(position.get("profit_rate")) or 0
+        if profit_rate * 100 > LOSS_WATCH_PCT or journal:
+            return None
+
+        return self._build_decision_item(
+            id=f"{symbol}:sell_watch:loss_threshold",
+            action="sell_watch",
+            label="Sell watch (Loss threshold)",
+            priority="medium",
+            current_price=current_price,
+            rationale=[
+                f"Unrealized loss exceeded {LOSS_WATCH_PCT}% without an active journal."
+            ],
+            execution_boundary=execution_boundary,
+        )
+
+    def _trim_candidate_item(
+        self,
+        symbol: str,
+        current_price: float | None,
+        position: dict[str, Any],
+        journal: dict[str, Any] | None,
+        sr: dict[str, Any],
+        weights: dict[str, float | None],
+        execution_boundary: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        portfolio_weight_pct = weights.get("portfolio_weight_pct") or 0
         target_dist = (journal or {}).get("target_distance_pct")
         res_dist = (sr.get("nearest_resistance") or {}).get("distance_pct")
+        profit_rate = _to_optional_float(position.get("profit_rate")) or 0
 
         if portfolio_weight_pct >= HIGH_WEIGHT_PCT:
-            items.append(
-                self._build_decision_item(
-                    id=f"{symbol}:trim_candidate:high_weight",
-                    action="trim_candidate",
-                    label="Trim candidate (High weight)",
-                    priority="medium",
-                    current_price=current_price,
-                    rationale=[
-                        f"Position weight ({portfolio_weight_pct:.1f}%) exceeds the high-weight threshold ({HIGH_WEIGHT_PCT}%)."
-                    ],
-                    execution_boundary=execution_boundary,
-                )
+            return self._high_weight_item(
+                symbol, current_price, portfolio_weight_pct, execution_boundary
             )
-        elif target_dist is not None and 0 <= target_dist <= TARGET_NEAR_PCT:
-            items.append(
-                self._build_decision_item(
-                    id=f"{symbol}:trim_candidate:target_near",
-                    action="trim_candidate",
-                    label="Trim candidate (Target near)",
-                    priority="medium",
-                    current_price=current_price,
-                    action_price=(journal or {}).get("target_price"),
-                    action_price_source="journal_target",
-                    delta_from_current_pct=target_dist,
-                    anchor={
-                        "type": "target",
-                        "price": (journal or {}).get("target_price"),
-                        "distance_pct": target_dist,
-                    },
-                    rationale=["Price is approaching the journal target price."],
-                    execution_boundary=execution_boundary,
-                )
+        if target_dist is not None and 0 <= target_dist <= TARGET_NEAR_PCT:
+            return self._target_near_item(
+                symbol, current_price, journal, target_dist, execution_boundary
             )
-        elif (
+        if (
             res_dist is not None
             and 0 <= res_dist <= NEAR_RESISTANCE_PCT
             and profit_rate > 0
         ):
-            items.append(
-                self._build_decision_item(
-                    id=f"{symbol}:trim_candidate:resistance_near",
-                    action="trim_candidate",
-                    label="Trim candidate (Resistance near)",
-                    priority="low",
-                    current_price=current_price,
-                    action_price=(sr.get("nearest_resistance") or {}).get("price"),
-                    action_price_source="nearest_resistance",
-                    delta_from_current_pct=res_dist,
-                    anchor={
-                        "type": "resistance",
-                        "price": (sr.get("nearest_resistance") or {}).get("price"),
-                        "distance_pct": res_dist,
-                    },
-                    rationale=[
-                        "Price is near a major resistance level while in profit."
-                    ],
-                    execution_boundary=execution_boundary,
-                )
+            return self._resistance_near_item(
+                symbol, current_price, sr, res_dist, execution_boundary
             )
+        return None
 
-        # 4. Buy Candidate (held only)
+    def _high_weight_item(
+        self,
+        symbol: str,
+        current_price: float | None,
+        portfolio_weight_pct: float,
+        execution_boundary: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self._build_decision_item(
+            id=f"{symbol}:trim_candidate:high_weight",
+            action="trim_candidate",
+            label="Trim candidate (High weight)",
+            priority="medium",
+            current_price=current_price,
+            rationale=[
+                f"Position weight ({portfolio_weight_pct:.1f}%) exceeds the high-weight threshold ({HIGH_WEIGHT_PCT})."
+            ],
+            execution_boundary=execution_boundary,
+        )
+
+    def _target_near_item(
+        self,
+        symbol: str,
+        current_price: float | None,
+        journal: dict[str, Any] | None,
+        target_dist: float,
+        execution_boundary: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self._build_decision_item(
+            id=f"{symbol}:trim_candidate:target_near",
+            action="trim_candidate",
+            label="Trim candidate (Target near)",
+            priority="medium",
+            current_price=current_price,
+            action_price=(journal or {}).get("target_price"),
+            action_price_source="journal_target",
+            delta_from_current_pct=target_dist,
+            anchor={
+                "type": "target",
+                "price": (journal or {}).get("target_price"),
+                "distance_pct": target_dist,
+            },
+            rationale=["Price is approaching the journal target price."],
+            execution_boundary=execution_boundary,
+        )
+
+    def _resistance_near_item(
+        self,
+        symbol: str,
+        current_price: float | None,
+        sr: dict[str, Any],
+        res_dist: float,
+        execution_boundary: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self._build_decision_item(
+            id=f"{symbol}:trim_candidate:resistance_near",
+            action="trim_candidate",
+            label="Trim candidate (Resistance near)",
+            priority="low",
+            current_price=current_price,
+            action_price=(sr.get("nearest_resistance") or {}).get("price"),
+            action_price_source="nearest_resistance",
+            delta_from_current_pct=res_dist,
+            anchor={
+                "type": "resistance",
+                "price": (sr.get("nearest_resistance") or {}).get("price"),
+                "distance_pct": res_dist,
+            },
+            rationale=["Price is near a major resistance level while in profit."],
+            execution_boundary=execution_boundary,
+        )
+
+    def _buy_candidate_item(
+        self,
+        symbol: str,
+        current_price: float | None,
+        sr: dict[str, Any],
+        weights: dict[str, float | None],
+        rsi: float | None,
+        execution_boundary: dict[str, Any],
+    ) -> dict[str, Any] | None:
         sup_dist = (sr.get("nearest_support") or {}).get("distance_pct")
-        if (
-            sup_dist is not None
-            and abs(sup_dist) <= NEAR_SUPPORT_PCT
-            and portfolio_weight_pct < HIGH_WEIGHT_PCT
-        ):
-            if rsi is not None and rsi <= RSI_OVERSOLD:
-                items.append(
-                    self._build_decision_item(
-                        id=f"{symbol}:buy_candidate:support_rsi",
-                        action="buy_candidate",
-                        label="Buy candidate (Support + RSI)",
-                        priority="medium",
-                        current_price=current_price,
-                        action_price=(sr.get("nearest_support") or {}).get("price"),
-                        action_price_source="nearest_support",
-                        delta_from_current_pct=sup_dist,
-                        anchor={
-                            "type": "support",
-                            "price": (sr.get("nearest_support") or {}).get("price"),
-                            "distance_pct": sup_dist,
-                        },
-                        rationale=[
-                            "Price is near support and RSI is in oversold territory."
-                        ],
-                        execution_boundary=execution_boundary,
-                    )
-                )
+        portfolio_weight_pct = weights.get("portfolio_weight_pct") or 0
+        if sup_dist is None or abs(sup_dist) > NEAR_SUPPORT_PCT:
+            return None
+        if portfolio_weight_pct >= HIGH_WEIGHT_PCT or rsi is None or rsi > RSI_OVERSOLD:
+            return None
 
-        # 5. Hold
-        if not items:
-            items.append(
-                self._build_decision_item(
-                    id=f"{symbol}:hold:default",
-                    action="hold",
-                    label="Hold",
-                    priority="low",
-                    current_price=current_price,
-                    rationale=[
-                        "No strong buy/sell/trim triggers identified. Maintaining current position."
-                    ],
-                    execution_boundary=execution_boundary,
-                )
-            )
+        return self._build_decision_item(
+            id=f"{symbol}:buy_candidate:support_rsi",
+            action="buy_candidate",
+            label="Buy candidate (Support + RSI)",
+            priority="medium",
+            current_price=current_price,
+            action_price=(sr.get("nearest_support") or {}).get("price"),
+            action_price_source="nearest_support",
+            delta_from_current_pct=sup_dist,
+            anchor={
+                "type": "support",
+                "price": (sr.get("nearest_support") or {}).get("price"),
+                "distance_pct": sup_dist,
+            },
+            rationale=["Price is near support and RSI is in oversold territory."],
+            execution_boundary=execution_boundary,
+        )
 
-        return items
+    def _hold_item(
+        self,
+        symbol: str,
+        current_price: float | None,
+        execution_boundary: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self._build_decision_item(
+            id=f"{symbol}:hold:default",
+            action="hold",
+            label="Hold",
+            priority="low",
+            current_price=current_price,
+            rationale=[
+                "No strong buy/sell/trim triggers identified. Maintaining current position."
+            ],
+            execution_boundary=execution_boundary,
+        )
+
+    def _needs_manual_review(
+        self,
+        current_price: float | None,
+        journal: dict[str, Any] | None,
+        sr: dict[str, Any],
+    ) -> bool:
+        return (
+            current_price is None
+            or current_price <= 0
+            or (not journal and sr["status"] == "unavailable")
+        )
+
+    def _missing_context_item(
+        self,
+        symbol: str,
+        current_price: float | None,
+        execution_boundary: dict[str, Any],
+    ) -> dict[str, Any]:
+        return self._build_decision_item(
+            id=f"{symbol}:manual_review:missing_context",
+            action="manual_review",
+            label="Manual review required",
+            priority="high",
+            current_price=current_price,
+            rationale=["Current price or market context (journal, S/R) is missing."],
+            execution_boundary=execution_boundary,
+            badges=["analysis_only", "missing_context"],
+            warnings=["missing_context"],
+        )
 
     def _build_decision_item(
         self,
         id: str,
         action: str,
         label: str,
-        current_price: float,
+        current_price: float | None,
         priority: str = "low",
         action_price: float | None = None,
         action_price_source: str | None = None,
@@ -517,16 +692,13 @@ class PortfolioDecisionService:
             "anchor": anchor,
             "rationale": rationale or [],
             "execution_boundary": execution_boundary
-            or {
-                "mode": "analysis_only",
-                "channel": None,
-                "auto_executable": False,
-                "manual_only": False,
-                "reason": "Phase 1 does not expose execution.",
-            },
+            or self._default_execution_boundary(),
             "badges": badges or ["analysis_only"],
             "warnings": warnings or [],
         }
+
+    def _default_execution_boundary(self) -> dict[str, Any]:
+        return dict(DEFAULT_EXECUTION_BOUNDARY)
 
     def _round_pct(self, value: float | None) -> float | None:
         if value is None:

--- a/app/templates/portfolio_dashboard.html
+++ b/app/templates/portfolio_dashboard.html
@@ -508,9 +508,16 @@
 <body>
     {% include 'nav.html' %}
     <main class="shell" id="portfolio-main-page">
-        <header class="header">
-            <h1>Unified Portfolio Dashboard</h1>
-            <p>KR / US / CRYPTO 통합 보유현황을 계좌별 토글로 조회합니다.</p>
+        <header class="header" style="display: flex; justify-content: space-between; align-items: center;">
+            <div>
+                <h1>Unified Portfolio Dashboard</h1>
+                <p>KR / US / CRYPTO 통합 보유현황을 계좌별 토글로 조회합니다.</p>
+            </div>
+            <div>
+                <a href="/portfolio/decision" class="btn-primary-soft" style="text-decoration: none; background: #f3ede5; color: #1a1a1a; border-color: #d1ccc4;">
+                    <i class="bi bi-cpu"></i> Decision Desk
+                </a>
+            </div>
         </header>
 
         <!-- AI Markdown Export Section -->

--- a/app/templates/portfolio_decision_desk.html
+++ b/app/templates/portfolio_decision_desk.html
@@ -1,0 +1,389 @@
+{% extends "base.html" %}
+
+{% block title %}Decision Desk - Auto Trader{% endblock %}
+
+{% block content %}
+<div id="portfolio-decision-desk-page" class="container-fluid py-4">
+    <!-- Header -->
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+            <h1 class="h3 mb-1">Decision Desk <span class="badge bg-secondary fs-6">V1 Analysis</span></h1>
+            <p class="text-muted mb-0">Analysis-only generated action slate for your current portfolio.</p>
+        </div>
+        <div class="d-flex gap-2">
+            <a href="/portfolio/" class="btn btn-outline-primary">
+                <i class="bi bi-arrow-left"></i> Portfolio Dashboard
+            </a>
+            <button id="refresh-btn" class="btn btn-primary">
+                <i class="bi bi-arrow-clockwise"></i> Refresh Analysis
+            </button>
+        </div>
+    </div>
+
+    <!-- Summary Cards -->
+    <div id="summary-section" class="row g-3 mb-4">
+        <!-- Summary will be injected here -->
+        <div class="col-12">
+            <div class="card border-0 shadow-sm">
+                <div class="card-body py-5 text-center">
+                    <div class="spinner-border text-primary" role="status">
+                        <span class="visually-hidden">Loading...</span>
+                    </div>
+                    <p class="mt-3 mb-0">Building decision slate...</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Filters -->
+    <div class="card border-0 shadow-sm mb-4">
+        <div class="card-body">
+            <form id="filter-form" class="row g-3 align-items-end">
+                <div class="col-md-3">
+                    <label class="form-label small text-uppercase fw-bold text-muted">Market</label>
+                    <select name="market" class="form-select">
+                        <option value="ALL">All Markets</option>
+                        <option value="KR">Korea Equity</option>
+                        <option value="US">US Equity</option>
+                        <option value="CRYPTO">Crypto</option>
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label small text-uppercase fw-bold text-muted">Search Symbol/Name</label>
+                    <div class="input-group">
+                        <span class="input-group-text bg-white border-end-0"><i class="bi bi-search"></i></span>
+                        <input type="text" name="q" class="form-control border-start-0" placeholder="NVDA, 삼성전자...">
+                    </div>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label small text-uppercase fw-bold text-muted">Action Filter</label>
+                    <select id="action-filter" class="form-select">
+                        <option value="all">All Actions</option>
+                        <option value="actionable">Actionable Only</option>
+                        <option value="buy_candidate">Buy Candidates</option>
+                        <option value="trim_candidate">Trim Candidates</option>
+                        <option value="sell_watch">Sell Watch</option>
+                        <option value="hold">Hold Only</option>
+                        <option value="manual_review">Manual Review</option>
+                    </select>
+                </div>
+                <div class="col-md-2">
+                    <button type="submit" class="btn btn-secondary w-100">Apply</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Symbol Groups -->
+    <div id="groups-container">
+        <!-- Symbol groups will be injected here -->
+    </div>
+</div>
+
+<template id="summary-template">
+    <div class="col-md-2">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body text-center">
+                <div class="text-muted small text-uppercase mb-1">Symbols</div>
+                <div class="h4 mb-0 fw-bold" id="sum-symbols">0</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-2">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body text-center">
+                <div class="text-muted small text-uppercase mb-1">Actionable</div>
+                <div class="h4 mb-0 fw-bold text-primary" id="sum-actionable">0</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-2">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body text-center">
+                <div class="text-muted small text-uppercase mb-1">Trim/Sell</div>
+                <div class="h4 mb-0 fw-bold text-danger" id="sum-trim-sell">0</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-2">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body text-center">
+                <div class="text-muted small text-uppercase mb-1">Buy</div>
+                <div class="h4 mb-0 fw-bold text-success" id="sum-buy">0</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-2">
+        <div class="card border-0 shadow-sm h-100 border-start border-warning border-4">
+            <div class="card-body text-center">
+                <div class="text-muted small text-uppercase mb-1">Manual</div>
+                <div class="h4 mb-0 fw-bold text-warning" id="sum-manual">0</div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-2">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body text-center">
+                <div class="text-muted small text-uppercase mb-1">Missing Info</div>
+                <div class="h4 mb-0 fw-bold" id="sum-missing">0</div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<template id="group-template">
+    <div class="symbol-group mb-5">
+        <div class="d-flex align-items-center mb-3 group-header">
+            <div class="market-badge me-2"></div>
+            <h2 class="h5 mb-0 fw-bold symbol-name">SYMBOL NAME</h2>
+            <div class="ms-auto d-flex align-items-center gap-3">
+                <div class="text-muted small">
+                    <span class="qty">0</span> qty @ <span class="current-price">0</span>
+                    (<span class="pl-rate">0%</span>)
+                </div>
+                <a href="#" class="btn btn-sm btn-link detail-link">Detail <i class="bi bi-chevron-right"></i></a>
+            </div>
+        </div>
+        
+        <div class="row g-3 items-container">
+            <!-- Decision items will be injected here -->
+        </div>
+    </div>
+</template>
+
+<template id="item-template">
+    <div class="col-12 decision-item-card">
+        <div class="card border-0 shadow-sm">
+            <div class="card-body p-0">
+                <div class="row g-0">
+                    <div class="col-md-1 d-flex align-items-center justify-content-center item-action-sidebar border-end">
+                        <div class="action-icon h4 mb-0"></div>
+                    </div>
+                    <div class="col-md-11 p-3">
+                        <div class="d-flex justify-content-between align-items-start mb-2">
+                            <div>
+                                <span class="badge action-badge mb-1">ACTION</span>
+                                <h3 class="h6 fw-bold mb-0 label-text">Label</h3>
+                            </div>
+                            <div class="text-end">
+                                <div class="action-price-container mb-1">
+                                    <span class="text-muted small">Action Price:</span>
+                                    <span class="fw-bold action-price">-</span>
+                                </div>
+                                <div class="badge boundary-badge">Analysis Only</div>
+                            </div>
+                        </div>
+                        
+                        <div class="rationale-list mt-3">
+                            <ul class="mb-0 small text-muted"></ul>
+                        </div>
+                        
+                        <div class="anchor-info mt-2 pt-2 border-top d-flex gap-3 small text-muted">
+                            <span class="anchor-type"></span>
+                            <span class="anchor-price"></span>
+                            <span class="anchor-dist"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<style>
+    .market-badge-KR { background-color: #0d6efd; width: 4px; height: 24px; border-radius: 2px; }
+    .market-badge-US { background-color: #198754; width: 4px; height: 24px; border-radius: 2px; }
+    .market-badge-CRYPTO { background-color: #f7931a; width: 4px; height: 24px; border-radius: 2px; }
+    
+    .item-action-sidebar.action-buy_candidate { background-color: #f0fdf4; border-color: #bbf7d0 !important; color: #16a34a; }
+    .item-action-sidebar.action-trim_candidate { background-color: #fff7ed; border-color: #fed7aa !important; color: #ea580c; }
+    .item-action-sidebar.action-sell_watch { background-color: #fef2f2; border-color: #fecaca !important; color: #dc2626; }
+    .item-action-sidebar.action-hold { background-color: #f8fafc; border-color: #e2e8f0 !important; color: #475569; }
+    .item-action-sidebar.action-manual_review { background-color: #fefce8; border-color: #fef08a !important; color: #ca8a04; }
+    
+    .badge.action-buy_candidate { background-color: #16a34a; }
+    .badge.action-trim_candidate { background-color: #ea580c; }
+    .badge.action-sell_watch { background-color: #dc2626; }
+    .badge.action-hold { background-color: #475569; }
+    .badge.action-manual_review { background-color: #ca8a04; }
+</style>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const groupsContainer = document.getElementById('groups-container');
+        const summarySection = document.getElementById('summary-section');
+        const filterForm = document.getElementById('filter-form');
+        const refreshBtn = document.getElementById('refresh-btn');
+        const actionFilter = document.getElementById('action-filter');
+
+        let currentSlate = null;
+
+        function setStatusMessage(message, className = 'text-muted') {
+            groupsContainer.innerHTML = '';
+            const div = document.createElement('div');
+            div.className = `text-center py-5 ${className}`;
+            div.textContent = message;
+            groupsContainer.appendChild(div);
+        }
+
+        function setAlertMessage(message, className = 'alert-danger') {
+            groupsContainer.innerHTML = '';
+            const div = document.createElement('div');
+            div.className = `alert ${className}`;
+            div.textContent = message;
+            groupsContainer.appendChild(div);
+        }
+
+        function formatNumber(value) {
+            if (value === null || value === undefined || Number.isNaN(Number(value))) return '-';
+            return Number(value).toLocaleString();
+        }
+
+        function formatPercent(value) {
+            if (value === null || value === undefined || Number.isNaN(Number(value))) return '-';
+            return `${(Number(value) * 100).toFixed(2)}%`;
+        }
+
+        async function fetchSlate() {
+            setStatusMessage('Fetching latest analysis...');
+            
+            const formData = new FormData(filterForm);
+            const params = new URLSearchParams();
+            if (formData.get('market') !== 'ALL') params.append('market', formData.get('market'));
+            if (formData.get('q')) params.append('q', formData.get('q'));
+            
+            try {
+                const response = await fetch('/portfolio/api/decision-slate?' + params.toString());
+                const data = await response.json();
+                if (data.success) {
+                    currentSlate = data;
+                    renderSlate();
+                } else {
+                    setAlertMessage(`Failed to fetch data: ${data.detail || 'Unknown error'}`);
+                }
+            } catch (error) {
+                setAlertMessage(`Error: ${error.message}`);
+            }
+        }
+
+        function renderSlate() {
+            if (!currentSlate) return;
+
+            // Render Summary
+            const sum = currentSlate.summary;
+            summarySection.innerHTML = '';
+            const sumTemplate = document.getElementById('summary-template');
+            const sumNode = sumTemplate.content.cloneNode(true);
+            sumNode.getElementById('sum-symbols').textContent = sum.symbols;
+            sumNode.getElementById('sum-actionable').textContent = sum.actionable_items;
+            sumNode.getElementById('sum-trim-sell').textContent = (sum.by_action.trim_candidate || 0) + (sum.by_action.sell_watch || 0);
+            sumNode.getElementById('sum-buy').textContent = sum.by_action.buy_candidate || 0;
+            sumNode.getElementById('sum-manual').textContent = sum.manual_review_items;
+            sumNode.getElementById('sum-missing').textContent = sum.missing_context_items;
+            summarySection.appendChild(sumNode);
+
+            // Render Groups
+            groupsContainer.innerHTML = '';
+            const groupTemplate = document.getElementById('group-template');
+            const itemTemplate = document.getElementById('item-template');
+            
+            const selectedAction = actionFilter.value;
+
+            currentSlate.symbol_groups.forEach(group => {
+                // Filter items in group
+                const filteredItems = group.items.filter(item => {
+                    if (selectedAction === 'all') return true;
+                    if (selectedAction === 'actionable') return ['buy_candidate', 'trim_candidate', 'sell_watch'].includes(item.action);
+                    return item.action === selectedAction;
+                });
+
+                if (filteredItems.length === 0) return;
+
+                const gNode = groupTemplate.content.cloneNode(true);
+                const header = gNode.querySelector('.group-header');
+                const badge = header.querySelector('.market-badge');
+                badge.classList.add(`market-badge-${group.market_type}`);
+                
+                header.querySelector('.symbol-name').textContent = `${group.symbol} - ${group.name}`;
+                header.querySelector('.qty').textContent = formatNumber(group.position.quantity);
+                header.querySelector('.current-price').textContent = formatNumber(group.position.current_price);
+                const pl = header.querySelector('.pl-rate');
+                pl.textContent = formatPercent(group.position.profit_rate);
+                pl.className = group.position.profit_rate === null || group.position.profit_rate === undefined
+                    ? 'text-muted'
+                    : (group.position.profit_rate >= 0 ? 'text-success' : 'text-danger');
+                
+                const link = header.querySelector('.detail-link');
+                link.href = group.detail_url;
+
+                const itemsContainer = gNode.querySelector('.items-container');
+                filteredItems.forEach(item => {
+                    const iNode = itemTemplate.content.cloneNode(true);
+                    const sidebar = iNode.querySelector('.item-action-sidebar');
+                    sidebar.classList.add(`action-${item.action}`);
+                    
+                    const icon = iNode.querySelector('.action-icon');
+                    if (item.action === 'buy_candidate') icon.innerHTML = '<i class="bi bi-plus-circle-fill"></i>';
+                    else if (item.action === 'trim_candidate') icon.innerHTML = '<i class="bi bi-dash-circle-fill"></i>';
+                    else if (item.action === 'sell_watch') icon.innerHTML = '<i class="bi bi-exclamation-triangle-fill"></i>';
+                    else if (item.action === 'manual_review') icon.innerHTML = '<i class="bi bi-question-circle-fill"></i>';
+                    else icon.innerHTML = '<i class="bi bi-info-circle-fill"></i>';
+
+                    const badge = iNode.querySelector('.action-badge');
+                    badge.textContent = item.label;
+                    badge.classList.add(`action-${item.action}`);
+                    
+                    iNode.querySelector('.label-text').textContent = item.label;
+                    
+                    if (item.action_price !== null && item.action_price !== undefined) {
+                        iNode.querySelector('.action-price').textContent = formatNumber(item.action_price);
+                    } else {
+                        iNode.querySelector('.action-price-container').style.display = 'none';
+                    }
+
+                    const rationale = iNode.querySelector('.rationale-list ul');
+                    item.rationale.forEach(r => {
+                        const li = document.createElement('li');
+                        li.textContent = r;
+                        rationale.appendChild(li);
+                    });
+
+                    if (item.anchor) {
+                        iNode.querySelector('.anchor-type').textContent = `Ref: ${item.anchor.type.toUpperCase()}`;
+                        iNode.querySelector('.anchor-price').textContent = `@ ${formatNumber(item.anchor.price)}`;
+                        if (item.anchor.distance_pct !== null && item.anchor.distance_pct !== undefined) {
+                            iNode.querySelector('.anchor-dist').textContent = `(${item.anchor.distance_pct > 0 ? '+' : ''}${item.anchor.distance_pct.toFixed(2)}%)`;
+                        }
+                    } else {
+                        iNode.querySelector('.anchor-info').style.display = 'none';
+                    }
+
+                    itemsContainer.appendChild(iNode);
+                });
+
+                groupsContainer.appendChild(gNode);
+            });
+
+            if (groupsContainer.innerHTML === '') {
+                setStatusMessage('No positions match the current filters.');
+            }
+        }
+
+        filterForm.addEventListener('submit', function(e) {
+            e.preventDefault();
+            fetchSlate();
+        });
+
+        refreshBtn.addEventListener('click', function() {
+            fetchSlate();
+        });
+        
+        actionFilter.addEventListener('change', function() {
+            renderSlate();
+        });
+
+        // Initial fetch
+        fetchSlate();
+    });
+</script>
+{% endblock %}

--- a/app/templates/portfolio_decision_desk.html
+++ b/app/templates/portfolio_decision_desk.html
@@ -11,7 +11,7 @@
             <p class="text-muted mb-0">Analysis-only generated action slate for your current portfolio.</p>
         </div>
         <div class="d-flex gap-2">
-            <a href="/portfolio/" class="btn btn-outline-primary">
+            <a href="/portfolio/" class="btn btn-outline-secondary">
                 <i class="bi bi-arrow-left"></i> Portfolio Dashboard
             </a>
             <button id="refresh-btn" class="btn btn-primary">
@@ -26,9 +26,9 @@
         <div class="col-12">
             <div class="card border-0 shadow-sm">
                 <div class="card-body py-5 text-center">
-                    <div class="spinner-border text-primary" role="status">
+                    <output class="spinner-border text-primary" aria-live="polite">
                         <span class="visually-hidden">Loading...</span>
-                    </div>
+                    </output>
                     <p class="mt-3 mb-0">Building decision slate...</p>
                 </div>
             </div>
@@ -40,8 +40,8 @@
         <div class="card-body">
             <form id="filter-form" class="row g-3 align-items-end">
                 <div class="col-md-3">
-                    <label class="form-label small text-uppercase fw-bold text-muted">Market</label>
-                    <select name="market" class="form-select">
+                    <label for="decision-market-filter" class="form-label small text-uppercase fw-bold text-muted">Market</label>
+                    <select id="decision-market-filter" name="market" class="form-select">
                         <option value="ALL">All Markets</option>
                         <option value="KR">Korea Equity</option>
                         <option value="US">US Equity</option>
@@ -49,14 +49,14 @@
                     </select>
                 </div>
                 <div class="col-md-4">
-                    <label class="form-label small text-uppercase fw-bold text-muted">Search Symbol/Name</label>
+                    <label for="decision-symbol-search" class="form-label small text-uppercase fw-bold text-muted">Search Symbol/Name</label>
                     <div class="input-group">
                         <span class="input-group-text bg-white border-end-0"><i class="bi bi-search"></i></span>
-                        <input type="text" name="q" class="form-control border-start-0" placeholder="NVDA, 삼성전자...">
+                        <input id="decision-symbol-search" type="text" name="q" class="form-control border-start-0" placeholder="NVDA, 삼성전자...">
                     </div>
                 </div>
                 <div class="col-md-3">
-                    <label class="form-label small text-uppercase fw-bold text-muted">Action Filter</label>
+                    <label for="action-filter" class="form-label small text-uppercase fw-bold text-muted">Action Filter</label>
                     <select id="action-filter" class="form-select">
                         <option value="all">All Actions</option>
                         <option value="actionable">Actionable Only</option>
@@ -195,11 +195,11 @@
     .market-badge-US { background-color: #198754; width: 4px; height: 24px; border-radius: 2px; }
     .market-badge-CRYPTO { background-color: #f7931a; width: 4px; height: 24px; border-radius: 2px; }
     
-    .item-action-sidebar.action-buy_candidate { background-color: #f0fdf4; border-color: #bbf7d0 !important; color: #16a34a; }
-    .item-action-sidebar.action-trim_candidate { background-color: #fff7ed; border-color: #fed7aa !important; color: #ea580c; }
-    .item-action-sidebar.action-sell_watch { background-color: #fef2f2; border-color: #fecaca !important; color: #dc2626; }
-    .item-action-sidebar.action-hold { background-color: #f8fafc; border-color: #e2e8f0 !important; color: #475569; }
-    .item-action-sidebar.action-manual_review { background-color: #fefce8; border-color: #fef08a !important; color: #ca8a04; }
+    .item-action-sidebar.action-buy_candidate { background-color: #f0fdf4; border-color: #bbf7d0 !important; color: #0f7a35; }
+    .item-action-sidebar.action-trim_candidate { background-color: #fff7ed; border-color: #fed7aa !important; color: #9a3412; }
+    .item-action-sidebar.action-sell_watch { background-color: #fef2f2; border-color: #fecaca !important; color: #991b1b; }
+    .item-action-sidebar.action-hold { background-color: #f8fafc; border-color: #e2e8f0 !important; color: #334155; }
+    .item-action-sidebar.action-manual_review { background-color: #fefce8; border-color: #fef08a !important; color: #854d0e; }
     
     .badge.action-buy_candidate { background-color: #16a34a; }
     .badge.action-trim_candidate { background-color: #ea580c; }
@@ -208,7 +208,86 @@
     .badge.action-manual_review { background-color: #ca8a04; }
 </style>
 
-<script>
+    <script>
+    const ACTIONABLE_ACTIONS = new Set(['buy_candidate', 'trim_candidate', 'sell_watch']);
+    const ACTION_ICON_CLASSES = {
+        buy_candidate: 'bi-plus-circle-fill',
+        trim_candidate: 'bi-dash-circle-fill',
+        sell_watch: 'bi-exclamation-triangle-fill',
+        manual_review: 'bi-question-circle-fill',
+        hold: 'bi-info-circle-fill',
+    };
+
+    function formatNumber(value) {
+        if (value === null || value === undefined || Number.isNaN(Number(value))) return '-';
+        return Number(value).toLocaleString();
+    }
+
+    function formatPercent(value) {
+        if (value === null || value === undefined || Number.isNaN(Number(value))) return '-';
+        return `${(Number(value) * 100).toFixed(2)}%`;
+    }
+
+    function profitRateClass(profitRate) {
+        if (profitRate === null || profitRate === undefined) return 'text-muted';
+        return profitRate >= 0 ? 'text-success' : 'text-danger';
+    }
+
+    function itemMatchesActionFilter(item, selectedAction) {
+        if (selectedAction === 'all') return true;
+        if (selectedAction === 'actionable') return ACTIONABLE_ACTIONS.has(item.action);
+        return item.action === selectedAction;
+    }
+
+    function setActionIcon(iconContainer, action) {
+        const icon = document.createElement('i');
+        icon.className = `bi ${ACTION_ICON_CLASSES[action] || ACTION_ICON_CLASSES.hold}`;
+        iconContainer.replaceChildren(icon);
+    }
+
+    function renderDecisionItem(item, itemTemplate) {
+        const iNode = itemTemplate.content.cloneNode(true);
+        const sidebar = iNode.querySelector('.item-action-sidebar');
+        sidebar.classList.add(`action-${item.action}`);
+
+        setActionIcon(iNode.querySelector('.action-icon'), item.action);
+
+        const badge = iNode.querySelector('.action-badge');
+        badge.textContent = item.label;
+        badge.classList.add(`action-${item.action}`);
+        iNode.querySelector('.label-text').textContent = item.label;
+
+        if (item.action_price !== null && item.action_price !== undefined) {
+            iNode.querySelector('.action-price').textContent = formatNumber(item.action_price);
+        } else {
+            iNode.querySelector('.action-price-container').style.display = 'none';
+        }
+
+        const rationale = iNode.querySelector('.rationale-list ul');
+        item.rationale.forEach(r => {
+            const li = document.createElement('li');
+            li.textContent = r;
+            rationale.appendChild(li);
+        });
+
+        updateAnchorInfo(iNode, item.anchor);
+        return iNode;
+    }
+
+    function updateAnchorInfo(iNode, anchor) {
+        if (!anchor) {
+            iNode.querySelector('.anchor-info').style.display = 'none';
+            return;
+        }
+
+        iNode.querySelector('.anchor-type').textContent = `Ref: ${anchor.type.toUpperCase()}`;
+        iNode.querySelector('.anchor-price').textContent = `@ ${formatNumber(anchor.price)}`;
+        if (anchor.distance_pct !== null && anchor.distance_pct !== undefined) {
+            const sign = anchor.distance_pct > 0 ? '+' : '';
+            iNode.querySelector('.anchor-dist').textContent = `(${sign}${anchor.distance_pct.toFixed(2)}%)`;
+        }
+    }
+
     document.addEventListener('DOMContentLoaded', function() {
         const groupsContainer = document.getElementById('groups-container');
         const summarySection = document.getElementById('summary-section');
@@ -234,16 +313,6 @@
             groupsContainer.appendChild(div);
         }
 
-        function formatNumber(value) {
-            if (value === null || value === undefined || Number.isNaN(Number(value))) return '-';
-            return Number(value).toLocaleString();
-        }
-
-        function formatPercent(value) {
-            if (value === null || value === undefined || Number.isNaN(Number(value))) return '-';
-            return `${(Number(value) * 100).toFixed(2)}%`;
-        }
-
         async function fetchSlate() {
             setStatusMessage('Fetching latest analysis...');
             
@@ -254,6 +323,12 @@
             
             try {
                 const response = await fetch('/portfolio/api/decision-slate?' + params.toString());
+                const contentType = response.headers.get('content-type') || '';
+                if (!contentType.includes('application/json')) {
+                    setAlertMessage('Failed to fetch data: unexpected response format.');
+                    return;
+                }
+
                 const data = await response.json();
                 if (data.success) {
                     currentSlate = data;
@@ -291,11 +366,9 @@
 
             currentSlate.symbol_groups.forEach(group => {
                 // Filter items in group
-                const filteredItems = group.items.filter(item => {
-                    if (selectedAction === 'all') return true;
-                    if (selectedAction === 'actionable') return ['buy_candidate', 'trim_candidate', 'sell_watch'].includes(item.action);
-                    return item.action === selectedAction;
-                });
+                const filteredItems = group.items.filter(
+                    item => itemMatchesActionFilter(item, selectedAction)
+                );
 
                 if (filteredItems.length === 0) return;
 
@@ -309,56 +382,14 @@
                 header.querySelector('.current-price').textContent = formatNumber(group.position.current_price);
                 const pl = header.querySelector('.pl-rate');
                 pl.textContent = formatPercent(group.position.profit_rate);
-                pl.className = group.position.profit_rate === null || group.position.profit_rate === undefined
-                    ? 'text-muted'
-                    : (group.position.profit_rate >= 0 ? 'text-success' : 'text-danger');
+                pl.className = profitRateClass(group.position.profit_rate);
                 
                 const link = header.querySelector('.detail-link');
                 link.href = group.detail_url;
 
                 const itemsContainer = gNode.querySelector('.items-container');
                 filteredItems.forEach(item => {
-                    const iNode = itemTemplate.content.cloneNode(true);
-                    const sidebar = iNode.querySelector('.item-action-sidebar');
-                    sidebar.classList.add(`action-${item.action}`);
-                    
-                    const icon = iNode.querySelector('.action-icon');
-                    if (item.action === 'buy_candidate') icon.innerHTML = '<i class="bi bi-plus-circle-fill"></i>';
-                    else if (item.action === 'trim_candidate') icon.innerHTML = '<i class="bi bi-dash-circle-fill"></i>';
-                    else if (item.action === 'sell_watch') icon.innerHTML = '<i class="bi bi-exclamation-triangle-fill"></i>';
-                    else if (item.action === 'manual_review') icon.innerHTML = '<i class="bi bi-question-circle-fill"></i>';
-                    else icon.innerHTML = '<i class="bi bi-info-circle-fill"></i>';
-
-                    const badge = iNode.querySelector('.action-badge');
-                    badge.textContent = item.label;
-                    badge.classList.add(`action-${item.action}`);
-                    
-                    iNode.querySelector('.label-text').textContent = item.label;
-                    
-                    if (item.action_price !== null && item.action_price !== undefined) {
-                        iNode.querySelector('.action-price').textContent = formatNumber(item.action_price);
-                    } else {
-                        iNode.querySelector('.action-price-container').style.display = 'none';
-                    }
-
-                    const rationale = iNode.querySelector('.rationale-list ul');
-                    item.rationale.forEach(r => {
-                        const li = document.createElement('li');
-                        li.textContent = r;
-                        rationale.appendChild(li);
-                    });
-
-                    if (item.anchor) {
-                        iNode.querySelector('.anchor-type').textContent = `Ref: ${item.anchor.type.toUpperCase()}`;
-                        iNode.querySelector('.anchor-price').textContent = `@ ${formatNumber(item.anchor.price)}`;
-                        if (item.anchor.distance_pct !== null && item.anchor.distance_pct !== undefined) {
-                            iNode.querySelector('.anchor-dist').textContent = `(${item.anchor.distance_pct > 0 ? '+' : ''}${item.anchor.distance_pct.toFixed(2)}%)`;
-                        }
-                    } else {
-                        iNode.querySelector('.anchor-info').style.display = 'none';
-                    }
-
-                    itemsContainer.appendChild(iNode);
+                    itemsContainer.appendChild(renderDecisionItem(item, itemTemplate));
                 });
 
                 groupsContainer.appendChild(gNode);

--- a/tests/test_portfolio_decision_router.py
+++ b/tests/test_portfolio_decision_router.py
@@ -62,8 +62,7 @@ def test_portfolio_decision_page_renders_html() -> None:
 
 
 @pytest.mark.unit
-@pytest.mark.asyncio
-async def test_get_portfolio_decision_slate_api() -> None:
+def test_get_portfolio_decision_slate_api() -> None:
     client, fake_service = _create_client()
     response = client.get("/portfolio/api/decision-slate")
 
@@ -73,3 +72,17 @@ async def test_get_portfolio_decision_slate_api() -> None:
     assert data["decision_run"]["id"] == "test-run"
 
     fake_service.build_decision_slate.assert_awaited_once()
+
+
+@pytest.mark.unit
+def test_get_portfolio_decision_slate_uses_safe_error_detail() -> None:
+    client, fake_service = _create_client()
+    fake_service.build_decision_slate.side_effect = RuntimeError(
+        "upstream token secret leaked"
+    )
+
+    response = client.get("/portfolio/api/decision-slate")
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Unable to build portfolio decision slate."}
+    assert "secret" not in response.text

--- a/tests/test_portfolio_decision_router.py
+++ b/tests/test_portfolio_decision_router.py
@@ -1,0 +1,75 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import portfolio
+
+
+class _FakeDecisionService:
+    def __init__(self) -> None:
+        self.build_decision_slate = AsyncMock(
+            return_value={
+                "success": True,
+                "decision_run": {
+                    "id": "test-run",
+                    "generated_at": "2026-04-20T10:00:00",
+                    "mode": "analysis_only",
+                    "persisted": False,
+                    "source": "test",
+                },
+                "filters": {"market": "ALL", "account_keys": [], "q": None},
+                "summary": {
+                    "symbols": 0,
+                    "decision_items": 0,
+                    "actionable_items": 0,
+                    "manual_review_items": 0,
+                    "auto_candidate_items": 0,
+                    "missing_context_items": 0,
+                    "by_action": {},
+                    "by_market": {},
+                },
+                "facets": {"accounts": []},
+                "symbol_groups": [],
+                "warnings": [],
+            }
+        )
+
+
+def _create_client() -> tuple[TestClient, _FakeDecisionService]:
+    app = FastAPI()
+    fake_service = _FakeDecisionService()
+    app.include_router(portfolio.router)
+    app.dependency_overrides[portfolio.get_authenticated_user] = lambda: (
+        SimpleNamespace(id=7)
+    )
+    app.dependency_overrides[portfolio.get_portfolio_decision_service] = lambda: (
+        fake_service
+    )
+    return TestClient(app), fake_service
+
+
+@pytest.mark.unit
+def test_portfolio_decision_page_renders_html() -> None:
+    client, _ = _create_client()
+    response = client.get("/portfolio/decision")
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+    assert 'id="portfolio-decision-desk-page"' in response.text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_portfolio_decision_slate_api() -> None:
+    client, fake_service = _create_client()
+    response = client.get("/portfolio/api/decision-slate")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["success"] is True
+    assert data["decision_run"]["id"] == "test-run"
+
+    fake_service.build_decision_slate.assert_awaited_once()

--- a/tests/test_portfolio_decision_service.py
+++ b/tests/test_portfolio_decision_service.py
@@ -1,0 +1,531 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.schemas.portfolio_decision import PortfolioDecisionSlateResponse
+from app.services.portfolio_decision_service import PortfolioDecisionService
+
+
+def _make_overview_position(**overrides):
+    position = {
+        "market_type": "US",
+        "symbol": "AAPL",
+        "name": "Apple",
+        "quantity": 10.0,
+        "avg_price": 100.0,
+        "current_price": 110.0,
+        "evaluation": 1100.0,
+        "evaluation_krw": 1_500_000.0,
+        "profit_loss": 100.0,
+        "profit_loss_krw": 136_000.0,
+        "profit_rate": 0.10,
+        "components": [
+            {"broker": "kis", "account_name": "Main", "source": "live"},
+        ],
+    }
+    position.update(overrides)
+    return position
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_decision_slate_returns_valid_structure() -> None:
+    overview_service = MagicMock()
+    overview_service.get_overview = AsyncMock(
+        return_value={
+            "success": True,
+            "positions": [
+                {
+                    "market_type": "US",
+                    "symbol": "NVDA",
+                    "name": "NVIDIA Corp.",
+                    "quantity": 3.0,
+                    "avg_price": 120.0,
+                    "current_price": 132.0,
+                    "evaluation": 396.0,
+                    "evaluation_krw": 540000.0,
+                    "profit_loss": 36.0,
+                    "profit_loss_krw": 49000.0,
+                    "profit_rate": 0.1,
+                    "components": [
+                        {"broker": "kis", "account_name": "Main", "source": "live"}
+                    ],
+                }
+            ],
+            "facets": {"accounts": []},
+        }
+    )
+    dashboard_service = MagicMock()
+    dashboard_service.get_journals_batch = AsyncMock(
+        return_value={
+            "NVDA": {
+                "status": "active",
+                "strategy": "trend",
+                "target_price": 145.0,
+                "stop_loss": 118.0,
+                "target_distance_pct": 9.85,
+                "stop_distance_pct": -10.61,
+            }
+        }
+    )
+
+    service = PortfolioDecisionService(
+        overview_service=overview_service,
+        dashboard_service=dashboard_service,
+    )
+
+    # Patch support/resistance and indicator helpers
+    with (
+        patch(
+            "app.services.portfolio_decision_service._get_support_resistance_impl",
+            AsyncMock(
+                return_value={
+                    "status": "available",
+                    "nearest_support": {
+                        "price": 128.5,
+                        "distance_pct": -2.65,
+                        "strength": "moderate",
+                    },
+                    "nearest_resistance": {
+                        "price": 145.0,
+                        "distance_pct": 9.85,
+                        "strength": "strong",
+                    },
+                    "supports": [],
+                    "resistances": [],
+                }
+            ),
+        ),
+        patch(
+            "app.services.portfolio_decision_service._get_indicators_impl",
+            AsyncMock(return_value={"indicators": {"rsi": {"14": 45.0}}}),
+        ),
+    ):
+        slate = await service.build_decision_slate(user_id=1)
+
+    assert slate["success"] is True
+    assert "decision_run" in slate
+    assert len(slate["symbol_groups"]) == 1
+    group = slate["symbol_groups"][0]
+    assert group["symbol"] == "NVDA"
+    assert len(group["items"]) > 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_trim_candidate_when_target_near() -> None:
+    overview_service = MagicMock()
+    overview_service.get_overview = AsyncMock(
+        return_value={
+            "success": True,
+            "positions": [
+                {
+                    "market_type": "US",
+                    "symbol": "AAPL",
+                    "name": "Apple",
+                    "quantity": 10.0,
+                    "avg_price": 150.0,
+                    "current_price": 178.0,
+                    "evaluation": 1780.0,
+                    "evaluation_krw": 2400000.0,
+                    "profit_loss": 280.0,
+                    "profit_loss_krw": 380000.0,
+                    "profit_rate": 0.18,
+                    "components": [],
+                },
+                {
+                    "market_type": "KR",
+                    "symbol": "005930",
+                    "evaluation": 50000000.0,
+                    "evaluation_krw": 50000000.0,
+                    "components": [],
+                },
+            ],
+            "facets": {"accounts": []},
+        }
+    )
+    dashboard_service = MagicMock()
+    dashboard_service.get_journals_batch = AsyncMock(
+        return_value={
+            "AAPL": {
+                "target_price": 180.0,
+                "target_distance_pct": 1.12,  # Near target
+                "stop_loss": 140.0,
+                "stop_distance_pct": -21.35,
+            }
+        }
+    )
+
+    service = PortfolioDecisionService(
+        overview_service=overview_service,
+        dashboard_service=dashboard_service,
+    )
+
+    with (
+        patch(
+            "app.services.portfolio_decision_service._get_support_resistance_impl",
+            AsyncMock(return_value={"status": "unavailable"}),
+        ),
+        patch(
+            "app.services.portfolio_decision_service._get_indicators_impl",
+            AsyncMock(return_value={"indicators": {"rsi": {"14": 65.0}}}),
+        ),
+    ):
+        slate = await service.build_decision_slate(user_id=1)
+
+    group = slate["symbol_groups"][0]
+    trim_items = [item for item in group["items"] if item["action"] == "trim_candidate"]
+    assert len(trim_items) > 0
+    assert "target" in trim_items[0]["id"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sell_watch_when_stop_near() -> None:
+    overview_service = MagicMock()
+    overview_service.get_overview = AsyncMock(
+        return_value={
+            "success": True,
+            "positions": [
+                {
+                    "market_type": "KR",
+                    "symbol": "005930",
+                    "name": "삼성전자",
+                    "quantity": 100.0,
+                    "avg_price": 75000.0,
+                    "current_price": 71000.0,
+                    "evaluation": 7100000.0,
+                    "evaluation_krw": 7100000.0,
+                    "profit_loss": -400000.0,
+                    "profit_loss_krw": -400000.0,
+                    "profit_rate": -0.0533,
+                    "components": [],
+                }
+            ],
+            "facets": {"accounts": []},
+        }
+    )
+    dashboard_service = MagicMock()
+    dashboard_service.get_journals_batch = AsyncMock(
+        return_value={
+            "005930": {
+                "stop_loss": 70000.0,
+                "stop_distance_pct": -1.41,  # Near stop
+            }
+        }
+    )
+
+    service = PortfolioDecisionService(
+        overview_service=overview_service,
+        dashboard_service=dashboard_service,
+    )
+
+    with (
+        patch(
+            "app.services.portfolio_decision_service._get_support_resistance_impl",
+            AsyncMock(return_value={"status": "unavailable"}),
+        ),
+        patch(
+            "app.services.portfolio_decision_service._get_indicators_impl",
+            AsyncMock(return_value={"indicators": {"rsi": {"14": 35.0}}}),
+        ),
+    ):
+        slate = await service.build_decision_slate(user_id=1)
+
+    group = slate["symbol_groups"][0]
+    sell_watch_items = [
+        item for item in group["items"] if item["action"] == "sell_watch"
+    ]
+    assert len(sell_watch_items) > 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_manual_review_when_context_missing() -> None:
+    overview_service = MagicMock()
+    overview_service.get_overview = AsyncMock(
+        return_value={
+            "success": True,
+            "positions": [
+                {
+                    "market_type": "US",
+                    "symbol": "UNKNOWN",
+                    "name": "Unknown Stock",
+                    "quantity": 1.0,
+                    "avg_price": 100.0,
+                    "current_price": 0.0,  # Missing price
+                    "evaluation": 0.0,
+                    "evaluation_krw": 0.0,
+                    "profit_loss": 0.0,
+                    "profit_loss_krw": 0.0,
+                    "profit_rate": 0.0,
+                    "components": [],
+                }
+            ],
+            "facets": {"accounts": []},
+        }
+    )
+    dashboard_service = MagicMock()
+    dashboard_service.get_journals_batch = AsyncMock(return_value={})
+
+    service = PortfolioDecisionService(
+        overview_service=overview_service,
+        dashboard_service=dashboard_service,
+    )
+
+    with (
+        patch(
+            "app.services.portfolio_decision_service._get_support_resistance_impl",
+            AsyncMock(return_value={"status": "unavailable"}),
+        ),
+        patch(
+            "app.services.portfolio_decision_service._get_indicators_impl",
+            AsyncMock(return_value={"indicators": {}}),
+        ),
+    ):
+        slate = await service.build_decision_slate(user_id=1)
+
+    group = slate["symbol_groups"][0]
+    manual_review_items = [
+        item for item in group["items"] if item["action"] == "manual_review"
+    ]
+    assert len(manual_review_items) > 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_support_resistance_levels_supply_nearest_anchor() -> None:
+    overview_service = MagicMock()
+    overview_service.get_overview = AsyncMock(
+        return_value={
+            "success": True,
+            "positions": [
+                _make_overview_position(),
+                _make_overview_position(
+                    market_type="KR",
+                    symbol="005930",
+                    name="삼성전자",
+                    evaluation=50_000_000.0,
+                    evaluation_krw=50_000_000.0,
+                    current_price=70_000.0,
+                    profit_rate=0.0,
+                ),
+            ],
+            "facets": {"accounts": []},
+        }
+    )
+    dashboard_service = MagicMock()
+    dashboard_service.get_journals_batch = AsyncMock(
+        return_value={
+            "AAPL": {
+                "target_price": 130.0,
+                "target_distance_pct": 18.18,
+                "stop_loss": 90.0,
+                "stop_distance_pct": -18.18,
+            }
+        }
+    )
+
+    service = PortfolioDecisionService(
+        overview_service=overview_service,
+        dashboard_service=dashboard_service,
+    )
+
+    with (
+        patch(
+            "app.services.portfolio_decision_service._get_support_resistance_impl",
+            AsyncMock(
+                return_value={
+                    "supports": [
+                        {
+                            "price": 108.0,
+                            "distance_pct": -1.82,
+                            "strength": "moderate",
+                            "sources": ["volume_poc"],
+                        }
+                    ],
+                    "resistances": [
+                        {
+                            "price": 112.0,
+                            "distance_pct": 1.82,
+                            "strength": "strong",
+                            "sources": ["bb_upper"],
+                        }
+                    ],
+                }
+            ),
+        ),
+        patch(
+            "app.services.portfolio_decision_service._get_indicators_impl",
+            AsyncMock(return_value={"indicators": {"rsi": {"14": 65.0}}}),
+        ),
+    ):
+        slate = await service.build_decision_slate(user_id=1)
+
+    group = slate["symbol_groups"][0]
+    item = next(item for item in group["items"] if item["action"] == "trim_candidate")
+    assert item["action_price"] == 112.0
+    assert item["anchor"]["price"] == 112.0
+    assert group["support_resistance"]["nearest_support"]["price"] == 108.0
+    assert group["support_resistance"]["nearest_resistance"]["price"] == 112.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_unavailable_support_resistance_does_not_create_zero_price_action() -> (
+    None
+):
+    overview_service = MagicMock()
+    overview_service.get_overview = AsyncMock(
+        return_value={
+            "success": True,
+            "positions": [
+                _make_overview_position(),
+                _make_overview_position(
+                    market_type="KR",
+                    symbol="005930",
+                    name="삼성전자",
+                    evaluation=50_000_000.0,
+                    evaluation_krw=50_000_000.0,
+                    current_price=70_000.0,
+                    profit_rate=0.0,
+                ),
+            ],
+            "facets": {"accounts": []},
+        }
+    )
+    dashboard_service = MagicMock()
+    dashboard_service.get_journals_batch = AsyncMock(
+        return_value={
+            "AAPL": {
+                "target_price": 130.0,
+                "target_distance_pct": 18.18,
+                "stop_loss": 90.0,
+                "stop_distance_pct": -18.18,
+            }
+        }
+    )
+
+    service = PortfolioDecisionService(
+        overview_service=overview_service,
+        dashboard_service=dashboard_service,
+    )
+
+    with (
+        patch(
+            "app.services.portfolio_decision_service._get_support_resistance_impl",
+            AsyncMock(return_value={"status": "unavailable"}),
+        ),
+        patch(
+            "app.services.portfolio_decision_service._get_indicators_impl",
+            AsyncMock(return_value={"indicators": {"rsi": {"14": 65.0}}}),
+        ),
+    ):
+        slate = await service.build_decision_slate(user_id=1)
+
+    actions = [item["action"] for item in slate["symbol_groups"][0]["items"]]
+    assert actions == ["hold"]
+    assert slate["symbol_groups"][0]["support_resistance"]["nearest_resistance"] is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_missing_price_payload_still_validates_and_counts_missing_context() -> (
+    None
+):
+    overview_service = MagicMock()
+    overview_service.get_overview = AsyncMock(
+        return_value={
+            "success": True,
+            "positions": [
+                _make_overview_position(
+                    symbol="UNKNOWN",
+                    name="Unknown Stock",
+                    current_price=None,
+                    evaluation=None,
+                    evaluation_krw=None,
+                    profit_loss=None,
+                    profit_loss_krw=None,
+                    profit_rate=None,
+                )
+            ],
+            "facets": {"accounts": []},
+        }
+    )
+    dashboard_service = MagicMock()
+    dashboard_service.get_journals_batch = AsyncMock(return_value={})
+
+    service = PortfolioDecisionService(
+        overview_service=overview_service,
+        dashboard_service=dashboard_service,
+    )
+
+    with (
+        patch(
+            "app.services.portfolio_decision_service._get_support_resistance_impl",
+            AsyncMock(return_value={"status": "unavailable"}),
+        ),
+        patch(
+            "app.services.portfolio_decision_service._get_indicators_impl",
+            AsyncMock(return_value={"indicators": {}}),
+        ),
+    ):
+        slate = await service.build_decision_slate(user_id=1)
+
+    PortfolioDecisionSlateResponse.model_validate(slate)
+    group = slate["symbol_groups"][0]
+    assert group["position"]["current_price"] is None
+    assert group["items"][0]["action"] == "manual_review"
+    assert slate["summary"]["missing_context_items"] == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_execution_boundary_marks_manual_or_mixed_accounts_for_review() -> None:
+    overview_service = MagicMock()
+    overview_service.get_overview = AsyncMock(
+        return_value={
+            "success": True,
+            "positions": [
+                _make_overview_position(
+                    components=[
+                        {"broker": "kis", "account_name": "Main", "source": "live"},
+                        {"broker": "toss", "account_name": "Toss", "source": "manual"},
+                    ]
+                )
+            ],
+            "facets": {"accounts": []},
+        }
+    )
+    dashboard_service = MagicMock()
+    dashboard_service.get_journals_batch = AsyncMock(
+        return_value={
+            "AAPL": {
+                "target_price": 112.0,
+                "target_distance_pct": 1.82,
+                "stop_loss": 90.0,
+                "stop_distance_pct": -18.18,
+            }
+        }
+    )
+
+    service = PortfolioDecisionService(
+        overview_service=overview_service,
+        dashboard_service=dashboard_service,
+    )
+
+    with (
+        patch(
+            "app.services.portfolio_decision_service._get_support_resistance_impl",
+            AsyncMock(return_value={"status": "unavailable"}),
+        ),
+        patch(
+            "app.services.portfolio_decision_service._get_indicators_impl",
+            AsyncMock(return_value={"indicators": {"rsi": {"14": 65.0}}}),
+        ),
+    ):
+        slate = await service.build_decision_slate(user_id=1)
+
+    boundary = slate["symbol_groups"][0]["items"][0]["execution_boundary"]
+    assert boundary["channel"] == "manual_review"
+    assert boundary["manual_only"] is True

--- a/tests/test_portfolio_decision_service.py
+++ b/tests/test_portfolio_decision_service.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -25,6 +26,52 @@ def _make_overview_position(**overrides):
     }
     position.update(overrides)
     return position
+
+
+def _make_service_for_positions(
+    positions: list[dict],
+    journals: dict[str, dict] | None = None,
+) -> PortfolioDecisionService:
+    overview_service = MagicMock()
+    overview_service.get_overview = AsyncMock(
+        return_value={
+            "success": True,
+            "positions": positions,
+            "facets": {"accounts": []},
+        }
+    )
+    dashboard_service = MagicMock()
+    dashboard_service.get_journals_batch = AsyncMock(return_value=journals or {})
+    return PortfolioDecisionService(
+        overview_service=overview_service,
+        dashboard_service=dashboard_service,
+    )
+
+
+def _aapl_and_samsung_positions() -> list[dict]:
+    return [
+        _make_overview_position(),
+        _make_overview_position(
+            market_type="KR",
+            symbol="005930",
+            name="삼성전자",
+            evaluation=50_000_000.0,
+            evaluation_krw=50_000_000.0,
+            current_price=70_000.0,
+            profit_rate=0.0,
+        ),
+    ]
+
+
+def _aapl_journal_far_from_triggers() -> dict[str, dict]:
+    return {
+        "AAPL": {
+            "target_price": 130.0,
+            "target_distance_pct": 18.18,
+            "stop_loss": 90.0,
+            "stop_distance_pct": -18.18,
+        }
+    }
 
 
 @pytest.mark.unit
@@ -109,6 +156,99 @@ async def test_build_decision_slate_returns_valid_structure() -> None:
     group = slate["symbol_groups"][0]
     assert group["symbol"] == "NVDA"
     assert len(group["items"]) > 0
+    assert slate["decision_run"]["generated_at"].tzinfo is not None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_same_symbol_different_markets_keep_separate_contexts() -> None:
+    service = _make_service_for_positions(
+        [
+            _make_overview_position(
+                market_type="US",
+                symbol="ABC",
+                name="US ABC",
+                profit_rate=0.2,
+            ),
+            _make_overview_position(
+                market_type="KR",
+                symbol="ABC",
+                name="KR ABC",
+                current_price=70_000.0,
+                profit_rate=0.2,
+                evaluation=7_000_000.0,
+                evaluation_krw=7_000_000.0,
+            ),
+        ],
+        journals={},
+    )
+
+    async def support_resistance(symbol: str, *, market: str):
+        if market == "US":
+            return {
+                "nearest_resistance": {"price": 112.0, "distance_pct": 1.2},
+                "supports": [],
+                "resistances": [],
+            }
+        return {
+            "nearest_resistance": {"price": 71_000.0, "distance_pct": 1.4},
+            "supports": [],
+            "resistances": [],
+        }
+
+    with (
+        patch(
+            "app.services.portfolio_decision_service._get_support_resistance_impl",
+            support_resistance,
+        ),
+        patch(
+            "app.services.portfolio_decision_service._get_indicators_impl",
+            AsyncMock(return_value={"indicators": {"rsi": {"14": 65.0}}}),
+        ),
+    ):
+        slate = await service.build_decision_slate(user_id=1)
+
+    groups = {
+        (group["market_type"], group["symbol"]): group
+        for group in slate["symbol_groups"]
+    }
+    assert groups[("US", "ABC")]["support_resistance"]["nearest_resistance"][
+        "price"
+    ] == pytest.approx(112.0)
+    assert groups[("KR", "ABC")]["support_resistance"]["nearest_resistance"][
+        "price"
+    ] == pytest.approx(71_000.0)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_context_fetch_timeout_logs_warning_and_degrades(caplog) -> None:
+    service = _make_service_for_positions([_make_overview_position()], journals={})
+    service.context_timeout_seconds = 0.01
+
+    async def slow_support_resistance(symbol: str, *, market: str):
+        await asyncio.sleep(0.05)
+        return {"status": "available"}
+
+    with (
+        patch(
+            "app.services.portfolio_decision_service._get_support_resistance_impl",
+            slow_support_resistance,
+        ),
+        patch(
+            "app.services.portfolio_decision_service._get_indicators_impl",
+            AsyncMock(return_value={"indicators": {"rsi": {"14": 65.0}}}),
+        ),
+        caplog.at_level("WARNING"),
+    ):
+        slate = await service.build_decision_slate(user_id=1)
+
+    group = slate["symbol_groups"][0]
+    assert group["support_resistance"]["status"] == "unavailable"
+    assert "portfolio decision context fetch failed" in caplog.text
+    assert "symbol=AAPL" in caplog.text
+    assert "market=US" in caplog.text
+    assert "call=support_resistance" in caplog.text
 
 
 @pytest.mark.unit
@@ -295,40 +435,9 @@ async def test_manual_review_when_context_missing() -> None:
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_support_resistance_levels_supply_nearest_anchor() -> None:
-    overview_service = MagicMock()
-    overview_service.get_overview = AsyncMock(
-        return_value={
-            "success": True,
-            "positions": [
-                _make_overview_position(),
-                _make_overview_position(
-                    market_type="KR",
-                    symbol="005930",
-                    name="삼성전자",
-                    evaluation=50_000_000.0,
-                    evaluation_krw=50_000_000.0,
-                    current_price=70_000.0,
-                    profit_rate=0.0,
-                ),
-            ],
-            "facets": {"accounts": []},
-        }
-    )
-    dashboard_service = MagicMock()
-    dashboard_service.get_journals_batch = AsyncMock(
-        return_value={
-            "AAPL": {
-                "target_price": 130.0,
-                "target_distance_pct": 18.18,
-                "stop_loss": 90.0,
-                "stop_distance_pct": -18.18,
-            }
-        }
-    )
-
-    service = PortfolioDecisionService(
-        overview_service=overview_service,
-        dashboard_service=dashboard_service,
+    service = _make_service_for_positions(
+        _aapl_and_samsung_positions(),
+        _aapl_journal_far_from_triggers(),
     )
 
     with (
@@ -364,10 +473,14 @@ async def test_support_resistance_levels_supply_nearest_anchor() -> None:
 
     group = slate["symbol_groups"][0]
     item = next(item for item in group["items"] if item["action"] == "trim_candidate")
-    assert item["action_price"] == 112.0
-    assert item["anchor"]["price"] == 112.0
-    assert group["support_resistance"]["nearest_support"]["price"] == 108.0
-    assert group["support_resistance"]["nearest_resistance"]["price"] == 112.0
+    assert item["action_price"] == pytest.approx(112.0)
+    assert item["anchor"]["price"] == pytest.approx(112.0)
+    assert group["support_resistance"]["nearest_support"]["price"] == pytest.approx(
+        108.0
+    )
+    assert group["support_resistance"]["nearest_resistance"]["price"] == pytest.approx(
+        112.0
+    )
 
 
 @pytest.mark.unit
@@ -375,40 +488,9 @@ async def test_support_resistance_levels_supply_nearest_anchor() -> None:
 async def test_unavailable_support_resistance_does_not_create_zero_price_action() -> (
     None
 ):
-    overview_service = MagicMock()
-    overview_service.get_overview = AsyncMock(
-        return_value={
-            "success": True,
-            "positions": [
-                _make_overview_position(),
-                _make_overview_position(
-                    market_type="KR",
-                    symbol="005930",
-                    name="삼성전자",
-                    evaluation=50_000_000.0,
-                    evaluation_krw=50_000_000.0,
-                    current_price=70_000.0,
-                    profit_rate=0.0,
-                ),
-            ],
-            "facets": {"accounts": []},
-        }
-    )
-    dashboard_service = MagicMock()
-    dashboard_service.get_journals_batch = AsyncMock(
-        return_value={
-            "AAPL": {
-                "target_price": 130.0,
-                "target_distance_pct": 18.18,
-                "stop_loss": 90.0,
-                "stop_distance_pct": -18.18,
-            }
-        }
-    )
-
-    service = PortfolioDecisionService(
-        overview_service=overview_service,
-        dashboard_service=dashboard_service,
+    service = _make_service_for_positions(
+        _aapl_and_samsung_positions(),
+        _aapl_journal_far_from_triggers(),
     )
 
     with (


### PR DESCRIPTION
## Summary

Adds the Portfolio Decision Desk V1 as an analysis-only page under the existing `/portfolio` UI.

- Adds `/portfolio/decision` and `/portfolio/api/decision-slate` in the portfolio router.
- Adds `PortfolioDecisionService` with deterministic action-item classification for held positions.
- Adds response schemas and a Decision Desk template with grouped symbol/action rendering.
- Adds regression coverage for support/resistance mapping, missing-price graceful fallback, missing-context counts, and account execution-boundary labels.

## Review Fixes Included

This includes the follow-up fixes from review:

- Uses real `supports` / `resistances` arrays as nearest anchors instead of inventing zero-price levels.
- Keeps missing numeric portfolio fields nullable so unavailable price context does not break response validation or get hidden as zero.
- Counts missing-context manual-review items in the summary.
- Marks mixed/manual account symbols as manual-review boundary while keeping Phase 1 analysis-only.
- Avoids direct `innerHTML` interpolation for dynamic error messages on the Decision Desk page.

## Validation

- `uv run pytest tests/test_portfolio_decision_service.py tests/test_portfolio_decision_router.py tests/test_portfolio_dashboard_router.py tests/test_portfolio_position_detail_router.py tests/test_portfolio_position_detail_service.py -q`  
  Result: 86 passed, 2 existing Pydantic deprecation warnings.
- `make lint`  
  Result: Ruff check, Ruff format check, and ty all passed.

## Notes

Phase 1 intentionally does not include live execution, dry-run actions, Discord, Paperclip, n8n, schema migrations, new dependencies, or a new MCP tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Portfolio Decision Desk V1 — a new analysis interface displaying portfolio decision recommendations with intelligent classification heuristics.
  * Introduced decision analysis API endpoint with market filtering and search capabilities.
  * Added navigation link from the portfolio dashboard to access the new decision desk.

* **Documentation**
  * Added comprehensive specification for Portfolio Decision Desk V1 covering service architecture, response schema, and decision-classification rules.

* **Tests**
  * Added test coverage for portfolio decision router and service logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->