### PR TITLE
[codex] Preserve exact Decision Desk artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -281,3 +281,4 @@ backtest/output/
 graphify-out/
 app/graphify-out/
 /.air/worktree.json
+.omx/

--- a/alembic/versions/0f4a7c9d3e21_add_portfolio_decision_runs.py
+++ b/alembic/versions/0f4a7c9d3e21_add_portfolio_decision_runs.py
@@ -1,0 +1,98 @@
+"""add portfolio decision run snapshots
+
+Revision ID: 0f4a7c9d3e21
+Revises: c0e7a9d8f6b1
+Create Date: 2026-04-21 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0f4a7c9d3e21"
+down_revision: str | Sequence[str] | None = "c0e7a9d8f6b1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "portfolio_decision_runs",
+        sa.Column("run_id", sa.String(length=80), nullable=False),
+        sa.Column("user_id", sa.BigInteger(), nullable=False),
+        sa.Column("generated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("market_scope", sa.String(length=20), nullable=False),
+        sa.Column("mode", sa.String(length=40), nullable=False),
+        sa.Column("source", sa.String(length=100), nullable=False),
+        sa.Column("filters", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("summary", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("facets", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "symbol_groups", postgresql.JSONB(astext_type=sa.Text()), nullable=False
+        ),
+        sa.Column("warnings", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name=op.f("fk_portfolio_decision_runs_user_id_users"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("run_id", name=op.f("pk_portfolio_decision_runs")),
+    )
+    op.create_index(
+        op.f("ix_portfolio_decision_runs_user_id"),
+        "portfolio_decision_runs",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_portfolio_decision_runs_generated_at"),
+        "portfolio_decision_runs",
+        ["generated_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_portfolio_decision_runs_user_generated_at",
+        "portfolio_decision_runs",
+        ["user_id", "generated_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_portfolio_decision_runs_market_scope",
+        "portfolio_decision_runs",
+        ["market_scope"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_portfolio_decision_runs_market_scope",
+        table_name="portfolio_decision_runs",
+    )
+    op.drop_index(
+        "ix_portfolio_decision_runs_user_generated_at",
+        table_name="portfolio_decision_runs",
+    )
+    op.drop_index(
+        op.f("ix_portfolio_decision_runs_generated_at"),
+        table_name="portfolio_decision_runs",
+    )
+    op.drop_index(
+        op.f("ix_portfolio_decision_runs_user_id"),
+        table_name="portfolio_decision_runs",
+    )
+    op.drop_table("portfolio_decision_runs")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -12,6 +12,7 @@ from .manual_holdings import (
 from .market_report import MarketReport
 from .news import NewsAnalysisResult, NewsArticle, Sentiment
 from .paper_trading import PaperAccount, PaperPosition, PaperTrade
+from .portfolio_decision_run import PortfolioDecisionRun
 from .prompt import PromptResult
 from .research_backtest import (
     ResearchBacktestPair,
@@ -90,6 +91,7 @@ __all__ = [
     "PaperAccount",
     "PaperPosition",
     "PaperTrade",
+    "PortfolioDecisionRun",
     "SellCondition",
     # "AlertRule", "AlertEvent",
     # "PricesLatest", "PricesOHLCV", "FxRate",

--- a/app/models/portfolio_decision_run.py
+++ b/app/models/portfolio_decision_run.py
@@ -1,0 +1,70 @@
+"""Persisted Decision Desk run snapshots."""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+class PortfolioDecisionRun(Base):
+    """Immutable JSONB snapshot for a generated Decision Desk slate."""
+
+    __tablename__ = "portfolio_decision_runs"
+
+    __table_args__ = (
+        Index(
+            "ix_portfolio_decision_runs_user_generated_at",
+            "user_id",
+            "generated_at",
+        ),
+        Index("ix_portfolio_decision_runs_market_scope", "market_scope"),
+    )
+
+    run_id: Mapped[str] = mapped_column(String(80), primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    generated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=_utcnow,
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        onupdate=_utcnow,
+    )
+    market_scope: Mapped[str] = mapped_column(String(20), nullable=False)
+    mode: Mapped[str] = mapped_column(String(40), nullable=False)
+    source: Mapped[str] = mapped_column(String(100), nullable=False)
+    filters: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    summary: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    facets: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    symbol_groups: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False)
+    warnings: Mapped[list[str]] = mapped_column(JSONB, nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+
+    user = relationship("User", backref="portfolio_decision_runs")
+
+    def __repr__(self) -> str:
+        return (
+            "<PortfolioDecisionRun("
+            f"run_id='{self.run_id}', user_id={self.user_id}, "
+            f"market_scope='{self.market_scope}')>"
+        )

--- a/app/routers/portfolio.py
+++ b/app/routers/portfolio.py
@@ -28,7 +28,10 @@ from app.schemas.manual_holdings import (
     MergedPortfolioResponse,
     ReferencePricesResponse,
 )
-from app.schemas.portfolio_decision import PortfolioDecisionSlateResponse
+from app.schemas.portfolio_decision import (
+    DecisionRunCreateRequest,
+    PortfolioDecisionSlateResponse,
+)
 from app.schemas.portfolio_position_detail import (
     PositionIndicatorsResponse,
     PositionNewsResponse,
@@ -42,7 +45,10 @@ from app.services.brokers.kis.client import KISClient
 from app.services.kis_holdings_service import get_kis_holding_for_ticker
 from app.services.merged_portfolio_service import MergedPortfolioService
 from app.services.portfolio_dashboard_service import PortfolioDashboardService
-from app.services.portfolio_decision_service import PortfolioDecisionService
+from app.services.portfolio_decision_service import (
+    PortfolioDecisionRunNotFoundError,
+    PortfolioDecisionService,
+)
 from app.services.portfolio_overview_service import PortfolioOverviewService
 from app.services.portfolio_position_detail_service import (
     PortfolioPositionDetailNotFoundError,
@@ -52,6 +58,9 @@ from app.services.portfolio_position_detail_service import (
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/portfolio", tags=["Portfolio"])
 DECISION_SLATE_ERROR_DETAIL = "Unable to build portfolio decision slate."
+DECISION_RUN_CREATE_ERROR_DETAIL = "Unable to create portfolio decision run."
+DECISION_RUN_LOOKUP_ERROR_DETAIL = "Unable to load portfolio decision run."
+DECISION_RUN_NOT_FOUND_DETAIL = "Decision run not found."
 
 
 def get_portfolio_overview_service(
@@ -67,6 +76,7 @@ def get_portfolio_dashboard_service(
 
 
 def get_portfolio_decision_service(
+    db: Annotated[AsyncSession, Depends(get_db)],
     overview_service: Annotated[
         PortfolioOverviewService, Depends(get_portfolio_overview_service)
     ],
@@ -77,6 +87,7 @@ def get_portfolio_decision_service(
     return PortfolioDecisionService(
         overview_service=overview_service,
         dashboard_service=dashboard_service,
+        db=db,
     )
 
 
@@ -119,6 +130,66 @@ async def get_portfolio_decision_slate(
         raise HTTPException(
             status_code=500,
             detail=DECISION_SLATE_ERROR_DETAIL,
+        ) from e
+
+
+@router.post(
+    "/api/decision-runs",
+    response_model=PortfolioDecisionSlateResponse,
+    responses={500: {"description": "Failed to create portfolio decision run"}},
+)
+async def create_portfolio_decision_run(
+    request: DecisionRunCreateRequest,
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+    decision_service: Annotated[
+        PortfolioDecisionService, Depends(get_portfolio_decision_service)
+    ],
+):
+    try:
+        return await decision_service.create_decision_run(
+            user_id=current_user.id,
+            market=request.market,
+            account_keys=request.account_keys,
+            q=request.q,
+        )
+    except Exception as e:
+        logger.error("Error creating decision run: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=DECISION_RUN_CREATE_ERROR_DETAIL,
+        ) from e
+
+
+@router.get(
+    "/api/decision-runs/{run_id}",
+    response_model=PortfolioDecisionSlateResponse,
+    responses={
+        404: {"description": "Decision run not found"},
+        500: {"description": "Failed to load portfolio decision run"},
+    },
+)
+async def get_portfolio_decision_run(
+    run_id: str,
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+    decision_service: Annotated[
+        PortfolioDecisionService, Depends(get_portfolio_decision_service)
+    ],
+):
+    try:
+        return await decision_service.get_decision_run(
+            user_id=current_user.id,
+            run_id=run_id,
+        )
+    except PortfolioDecisionRunNotFoundError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=DECISION_RUN_NOT_FOUND_DETAIL,
+        ) from e
+    except Exception as e:
+        logger.error("Error loading decision run: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=DECISION_RUN_LOOKUP_ERROR_DETAIL,
         ) from e
 
 

--- a/app/schemas/portfolio_decision.py
+++ b/app/schemas/portfolio_decision.py
@@ -7,9 +7,17 @@ from pydantic import BaseModel, Field
 class DecisionRunResponse(BaseModel):
     id: str
     generated_at: datetime
+    market_scope: str | None = None
     mode: Literal["analysis_only", "dry_run", "live"] = "analysis_only"
     persisted: bool = False
     source: str = "portfolio_decision_service_v1"
+    share_url: str | None = None
+
+
+class DecisionRunCreateRequest(BaseModel):
+    market: Literal["ALL", "KR", "US", "CRYPTO"] = "ALL"
+    account_keys: list[str] = Field(default_factory=list)
+    q: str | None = Field(default=None, min_length=1)
 
 
 class DecisionFiltersResponse(BaseModel):

--- a/app/services/portfolio_decision_service.py
+++ b/app/services/portfolio_decision_service.py
@@ -1,12 +1,18 @@
 import asyncio
 import logging
+import secrets
 from datetime import UTC, datetime
 from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.mcp_server.tooling.fundamentals._support_resistance import (
     get_support_resistance_impl as _get_support_resistance_impl,
 )
 from app.mcp_server.tooling.market_data_quotes import _get_indicators_impl
+from app.models.portfolio_decision_run import PortfolioDecisionRun
+from app.schemas.portfolio_decision import PortfolioDecisionSlateResponse
 
 logger = logging.getLogger(__name__)
 
@@ -43,17 +49,95 @@ def _to_optional_float(value: Any) -> float | None:
         return None
 
 
+class PortfolioDecisionRunNotFoundError(Exception):
+    """Raised when a persisted Decision Desk snapshot is missing or not owned."""
+
+
 class PortfolioDecisionService:
     def __init__(
         self,
         *,
         overview_service,
         dashboard_service,
+        db: AsyncSession | None = None,
         context_timeout_seconds: float = CONTEXT_TIMEOUT_SECONDS,
     ) -> None:
         self.overview_service = overview_service
         self.dashboard_service = dashboard_service
+        self.db = db
         self.context_timeout_seconds = context_timeout_seconds
+
+    async def create_decision_run(
+        self,
+        *,
+        user_id: int,
+        market: str = "ALL",
+        account_keys: list[str] | None = None,
+        q: str | None = None,
+    ) -> dict[str, Any]:
+        """Persist one immutable snapshot; live generation remains separate."""
+        db = self._require_db()
+        live_slate = await self.build_decision_slate(
+            user_id=user_id,
+            market=market,
+            account_keys=account_keys,
+            q=q,
+        )
+        validated_live_slate = PortfolioDecisionSlateResponse.model_validate(live_slate)
+        generated_at = validated_live_slate.decision_run.generated_at
+        run_id = self._new_run_id(generated_at)
+        share_url = f"/portfolio/decision?run_id={run_id}"
+
+        snapshot = validated_live_slate.model_dump()
+        snapshot["decision_run"] = {
+            **snapshot["decision_run"],
+            "id": run_id,
+            "market_scope": market,
+            "persisted": True,
+            "share_url": share_url,
+        }
+        payload = PortfolioDecisionSlateResponse.model_validate(snapshot).model_dump(
+            mode="json"
+        )
+
+        run = PortfolioDecisionRun(
+            run_id=run_id,
+            user_id=user_id,
+            generated_at=generated_at,
+            market_scope=market,
+            mode=payload["decision_run"]["mode"],
+            source=payload["decision_run"]["source"],
+            filters=payload["filters"],
+            summary=payload["summary"],
+            facets=payload["facets"],
+            symbol_groups=payload["symbol_groups"],
+            warnings=payload["warnings"],
+            payload=payload,
+            created_at=datetime.now(UTC),
+        )
+        db.add(run)
+        await db.commit()
+        return payload
+
+    async def get_decision_run(
+        self,
+        *,
+        user_id: int,
+        run_id: str,
+    ) -> dict[str, Any]:
+        """Return a stored snapshot only; this path never recalculates context."""
+        db = self._require_db()
+        result = await db.execute(
+            select(PortfolioDecisionRun).where(
+                PortfolioDecisionRun.run_id == run_id,
+                PortfolioDecisionRun.user_id == user_id,
+            )
+        )
+        run = result.scalar_one_or_none()
+        if run is None:
+            raise PortfolioDecisionRunNotFoundError(run_id)
+        PortfolioDecisionSlateResponse.model_validate(run.payload)
+        return run.payload
 
     async def build_decision_slate(
         self,
@@ -117,6 +201,15 @@ class PortfolioDecisionService:
             "symbol_groups": symbol_groups,
             "warnings": [],
         }
+
+    def _require_db(self) -> AsyncSession:
+        if self.db is None:
+            raise RuntimeError("PortfolioDecisionService persistence requires a db.")
+        return self.db
+
+    def _new_run_id(self, generated_at: datetime) -> str:
+        timestamp = generated_at.astimezone(UTC).strftime("%Y%m%dT%H%M%S%fZ")
+        return f"decision-{timestamp}-{secrets.token_hex(4)}"
 
     def _position_key(self, position: dict[str, Any]) -> PositionKey:
         return (str(position["market_type"]).upper(), str(position["symbol"]))

--- a/app/templates/portfolio_decision_desk.html
+++ b/app/templates/portfolio_decision_desk.html
@@ -7,13 +7,17 @@
     <!-- Header -->
     <div class="d-flex justify-content-between align-items-center mb-4">
         <div>
-            <h1 class="h3 mb-1">Decision Desk <span class="badge bg-secondary fs-6">V1 Analysis</span></h1>
-            <p class="text-muted mb-0">Analysis-only generated action slate for your current portfolio.</p>
+            <h1 class="h3 mb-1">Decision Desk <span id="decision-mode-badge" class="badge bg-secondary fs-6">V1 Analysis</span></h1>
+            <p id="decision-run-status" class="text-muted mb-0">Analysis-only generated action slate for your current portfolio.</p>
+            <p id="decision-share-url" class="small text-muted mb-0 d-none"></p>
         </div>
         <div class="d-flex gap-2">
             <a href="/portfolio/" class="btn btn-outline-secondary">
                 <i class="bi bi-arrow-left"></i> Portfolio Dashboard
             </a>
+            <button id="create-share-link-btn" class="btn btn-outline-primary">
+                <i class="bi bi-link-45deg"></i> Create Share Link
+            </button>
             <button id="refresh-btn" class="btn btn-primary">
                 <i class="bi bi-arrow-clockwise"></i> Refresh Analysis
             </button>
@@ -293,9 +297,50 @@
         const summarySection = document.getElementById('summary-section');
         const filterForm = document.getElementById('filter-form');
         const refreshBtn = document.getElementById('refresh-btn');
+        const createShareLinkBtn = document.getElementById('create-share-link-btn');
         const actionFilter = document.getElementById('action-filter');
+        const modeBadge = document.getElementById('decision-mode-badge');
+        const runStatus = document.getElementById('decision-run-status');
+        const shareUrlEl = document.getElementById('decision-share-url');
 
+        const initialParams = new URLSearchParams(window.location.search);
+        const snapshotRunId = initialParams.get('run_id');
+        const isSnapshotMode = Boolean(snapshotRunId);
         let currentSlate = null;
+
+        initializeLiveFiltersFromUrl(initialParams);
+        updateModeChrome();
+
+        function initializeLiveFiltersFromUrl(params) {
+            if (isSnapshotMode) return;
+            const market = params.get('market');
+            if (market) {
+                const marketSelect = document.getElementById('decision-market-filter');
+                if ([...marketSelect.options].some(option => option.value === market)) {
+                    marketSelect.value = market;
+                }
+            }
+            const q = params.get('q');
+            if (q) document.getElementById('decision-symbol-search').value = q;
+        }
+
+        function updateModeChrome() {
+            if (isSnapshotMode) {
+                modeBadge.textContent = 'Snapshot';
+                modeBadge.className = 'badge bg-success fs-6';
+                runStatus.textContent = `Loading persisted decision snapshot ${snapshotRunId}...`;
+                refreshBtn.classList.add('d-none');
+                createShareLinkBtn.classList.add('d-none');
+                filterForm.querySelectorAll('input, select, button').forEach(el => {
+                    if (el.id !== 'action-filter') el.disabled = true;
+                });
+                return;
+            }
+            modeBadge.textContent = 'V1 Analysis';
+            modeBadge.className = 'badge bg-secondary fs-6';
+            runStatus.textContent = 'Analysis-only generated action slate for your current portfolio.';
+            shareUrlEl.classList.add('d-none');
+        }
 
         function setStatusMessage(message, className = 'text-muted') {
             groupsContainer.innerHTML = '';
@@ -313,31 +358,120 @@
             groupsContainer.appendChild(div);
         }
 
-        async function fetchSlate() {
-            setStatusMessage('Fetching latest analysis...');
-            
+        function buildLiveParams() {
             const formData = new FormData(filterForm);
             const params = new URLSearchParams();
-            if (formData.get('market') !== 'ALL') params.append('market', formData.get('market'));
-            if (formData.get('q')) params.append('q', formData.get('q'));
-            
-            try {
-                const response = await fetch('/portfolio/api/decision-slate?' + params.toString());
-                const contentType = response.headers.get('content-type') || '';
-                if (!contentType.includes('application/json')) {
-                    setAlertMessage('Failed to fetch data: unexpected response format.');
-                    return;
-                }
+            const market = formData.get('market') || 'ALL';
+            params.set('market', market);
+            if (formData.get('q')) params.set('q', formData.get('q'));
+            initialParams.getAll('account_keys').forEach(accountKey => {
+                if (accountKey) params.append('account_keys', accountKey);
+            });
+            return params;
+        }
 
-                const data = await response.json();
+        function updateLiveUrl(params) {
+            if (isSnapshotMode) return;
+            const nextUrl = `${window.location.pathname}?${params.toString()}`;
+            window.history.replaceState({}, '', nextUrl);
+        }
+
+        async function fetchSlate(options = {}) {
+            if (isSnapshotMode) {
+                await fetchPersistedSnapshot();
+                return;
+            }
+
+            setStatusMessage('Fetching latest analysis...');
+            const params = buildLiveParams();
+            if (options.updateUrl) updateLiveUrl(params);
+
+            try {
+                const response = await fetch(`/portfolio/api/decision-slate?${params.toString()}`);
+                const data = await parseJsonResponse(response);
                 if (data.success) {
                     currentSlate = data;
+                    updateLiveRunStatus();
                     renderSlate();
                 } else {
                     setAlertMessage(`Failed to fetch data: ${data.detail || 'Unknown error'}`);
                 }
             } catch (error) {
                 setAlertMessage(`Error: ${error.message}`);
+            }
+        }
+
+        async function fetchPersistedSnapshot() {
+            setStatusMessage('Fetching persisted snapshot...');
+            try {
+                const response = await fetch(`/portfolio/api/decision-runs/${encodeURIComponent(snapshotRunId)}`);
+                const data = await parseJsonResponse(response);
+                if (data.success) {
+                    currentSlate = data;
+                    updateSnapshotRunStatus(data);
+                    renderSlate();
+                } else {
+                    setAlertMessage(`Failed to fetch snapshot: ${data.detail || 'Unknown error'}`);
+                }
+            } catch (error) {
+                setAlertMessage(`Error: ${error.message}`);
+            }
+        }
+
+        async function parseJsonResponse(response) {
+            const contentType = response.headers.get('content-type') || '';
+            if (!contentType.includes('application/json')) {
+                throw new Error('unexpected response format');
+            }
+            const data = await response.json();
+            if (!response.ok) {
+                throw new Error(data.detail || `request failed (${response.status})`);
+            }
+            return data;
+        }
+
+        function updateLiveRunStatus() {
+            if (!currentSlate) return;
+            const generatedAt = new Date(currentSlate.decision_run.generated_at).toLocaleString();
+            runStatus.textContent = `Live operator view generated ${generatedAt}. Filters are preserved in this URL.`;
+            shareUrlEl.classList.add('d-none');
+        }
+
+        function updateSnapshotRunStatus(data) {
+            const run = data.decision_run;
+            const generatedAt = new Date(run.generated_at).toLocaleString();
+            runStatus.textContent = `Persisted snapshot ${run.id} generated ${generatedAt} for ${run.market_scope || data.filters.market || 'ALL'}.`;
+            if (run.share_url) {
+                const absoluteUrl = new URL(run.share_url, window.location.origin).toString();
+                shareUrlEl.textContent = `Share URL: ${absoluteUrl}`;
+                shareUrlEl.classList.remove('d-none');
+            }
+        }
+
+        async function createShareLink() {
+            if (isSnapshotMode) return;
+            createShareLinkBtn.disabled = true;
+            createShareLinkBtn.textContent = 'Creating...';
+            try {
+                const formData = new FormData(filterForm);
+                const params = buildLiveParams();
+                const response = await fetch('/portfolio/api/decision-runs', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        market: formData.get('market') || 'ALL',
+                        account_keys: params.getAll('account_keys'),
+                        q: formData.get('q') || null,
+                    }),
+                });
+                const data = await parseJsonResponse(response);
+                const shareUrl = data.decision_run.share_url || `/portfolio/decision?run_id=${encodeURIComponent(data.decision_run.id)}`;
+                window.location.assign(shareUrl);
+            } catch (error) {
+                setAlertMessage(`Error creating share link: ${error.message}`);
+            } finally {
+                createShareLinkBtn.disabled = false;
+                createShareLinkBtn.innerHTML = '<i class="bi bi-link-45deg"></i> Create Share Link';
             }
         }
 
@@ -402,11 +536,15 @@
 
         filterForm.addEventListener('submit', function(e) {
             e.preventDefault();
-            fetchSlate();
+            fetchSlate({updateUrl: true});
         });
 
         refreshBtn.addEventListener('click', function() {
-            fetchSlate();
+            fetchSlate({updateUrl: true});
+        });
+
+        createShareLinkBtn.addEventListener('click', function() {
+            createShareLink();
         });
         
         actionFilter.addEventListener('change', function() {
@@ -414,7 +552,7 @@
         });
 
         // Initial fetch
-        fetchSlate();
+        fetchSlate({updateUrl: false});
     });
 </script>
 {% endblock %}

--- a/tests/test_portfolio_decision_router.py
+++ b/tests/test_portfolio_decision_router.py
@@ -10,30 +10,58 @@ from app.routers import portfolio
 
 class _FakeDecisionService:
     def __init__(self) -> None:
-        self.build_decision_slate = AsyncMock(
+        self.slate = {
+            "success": True,
+            "decision_run": {
+                "id": "test-run",
+                "generated_at": "2026-04-20T10:00:00",
+                "mode": "analysis_only",
+                "persisted": False,
+                "source": "test",
+            },
+            "filters": {"market": "ALL", "account_keys": [], "q": None},
+            "summary": {
+                "symbols": 0,
+                "decision_items": 0,
+                "actionable_items": 0,
+                "manual_review_items": 0,
+                "auto_candidate_items": 0,
+                "missing_context_items": 0,
+                "by_action": {},
+                "by_market": {},
+            },
+            "facets": {"accounts": []},
+            "symbol_groups": [],
+            "warnings": [],
+        }
+        self.build_decision_slate = AsyncMock(return_value=self.slate)
+        self.create_decision_run = AsyncMock(
             return_value={
-                "success": True,
+                **self.slate,
                 "decision_run": {
-                    "id": "test-run",
-                    "generated_at": "2026-04-20T10:00:00",
-                    "mode": "analysis_only",
-                    "persisted": False,
-                    "source": "test",
+                    **self.slate["decision_run"],
+                    "id": "decision-created",
+                    "persisted": True,
+                    "market_scope": "CRYPTO",
+                    "share_url": "/portfolio/decision?run_id=decision-created",
                 },
-                "filters": {"market": "ALL", "account_keys": [], "q": None},
-                "summary": {
-                    "symbols": 0,
-                    "decision_items": 0,
-                    "actionable_items": 0,
-                    "manual_review_items": 0,
-                    "auto_candidate_items": 0,
-                    "missing_context_items": 0,
-                    "by_action": {},
-                    "by_market": {},
+                "filters": {
+                    "market": "CRYPTO",
+                    "account_keys": ["upbit:main"],
+                    "q": "BTC",
                 },
-                "facets": {"accounts": []},
-                "symbol_groups": [],
-                "warnings": [],
+            }
+        )
+        self.get_decision_run = AsyncMock(
+            return_value={
+                **self.slate,
+                "decision_run": {
+                    **self.slate["decision_run"],
+                    "id": "decision-stored",
+                    "persisted": True,
+                    "market_scope": "CRYPTO",
+                    "share_url": "/portfolio/decision?run_id=decision-stored",
+                },
             }
         )
 
@@ -86,3 +114,71 @@ def test_get_portfolio_decision_slate_uses_safe_error_detail() -> None:
     assert response.status_code == 500
     assert response.json() == {"detail": "Unable to build portfolio decision slate."}
     assert "secret" not in response.text
+
+
+@pytest.mark.unit
+def test_create_portfolio_decision_run_api_delegates_filters() -> None:
+    client, fake_service = _create_client()
+
+    response = client.post(
+        "/portfolio/api/decision-runs",
+        json={"market": "CRYPTO", "account_keys": ["upbit:main"], "q": "BTC"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["decision_run"]["id"] == "decision-created"
+    assert data["decision_run"]["persisted"] is True
+    assert data["decision_run"]["market_scope"] == "CRYPTO"
+    assert (
+        data["decision_run"]["share_url"]
+        == "/portfolio/decision?run_id=decision-created"
+    )
+    fake_service.create_decision_run.assert_awaited_once_with(
+        user_id=7,
+        market="CRYPTO",
+        account_keys=["upbit:main"],
+        q="BTC",
+    )
+
+
+@pytest.mark.unit
+def test_get_portfolio_decision_run_api_delegates_lookup() -> None:
+    client, fake_service = _create_client()
+
+    response = client.get("/portfolio/api/decision-runs/decision-stored")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["decision_run"]["id"] == "decision-stored"
+    fake_service.get_decision_run.assert_awaited_once_with(
+        user_id=7,
+        run_id="decision-stored",
+    )
+
+
+@pytest.mark.unit
+def test_get_portfolio_decision_run_unknown_maps_to_404() -> None:
+    from app.services.portfolio_decision_service import (
+        PortfolioDecisionRunNotFoundError,
+    )
+
+    client, fake_service = _create_client()
+    fake_service.get_decision_run.side_effect = PortfolioDecisionRunNotFoundError(
+        "unknown"
+    )
+
+    response = client.get("/portfolio/api/decision-runs/unknown")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Decision run not found."}
+
+
+@pytest.mark.unit
+def test_portfolio_decision_page_with_run_id_renders_html_shell() -> None:
+    client, _ = _create_client()
+    response = client.get("/portfolio/decision?run_id=test-run")
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+    assert 'id="portfolio-decision-desk-page"' in response.text

--- a/tests/test_portfolio_decision_run_model.py
+++ b/tests/test_portfolio_decision_run_model.py
@@ -1,0 +1,44 @@
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.dialects.postgresql import JSONB
+
+from app.models.portfolio_decision_run import PortfolioDecisionRun
+
+
+@pytest.mark.unit
+def test_portfolio_decision_run_model_shape() -> None:
+    assert PortfolioDecisionRun.__tablename__ == "portfolio_decision_runs"
+    columns = PortfolioDecisionRun.__table__.columns
+    assert columns["run_id"].primary_key is True
+    assert columns["user_id"].index is True
+    assert columns["market_scope"].type.length == 20
+    assert isinstance(columns["payload"].type, JSONB)
+    for field in ("filters", "summary", "facets", "symbol_groups", "warnings"):
+        assert isinstance(columns[field].type, JSONB)
+
+    index_names = {index.name for index in PortfolioDecisionRun.__table__.indexes}
+    assert "ix_portfolio_decision_runs_user_generated_at" in index_names
+    assert "ix_portfolio_decision_runs_market_scope" in index_names
+
+
+@pytest.mark.unit
+def test_portfolio_decision_run_repr_mentions_run_id_and_market() -> None:
+    run = PortfolioDecisionRun(
+        run_id="decision-test",
+        user_id=7,
+        generated_at=datetime(2026, 4, 20, 10, 0, tzinfo=UTC),
+        market_scope="CRYPTO",
+        mode="analysis_only",
+        source="portfolio_decision_service_v1",
+        filters={},
+        summary={},
+        facets={},
+        symbol_groups=[],
+        warnings=[],
+        payload={},
+        created_at=datetime(2026, 4, 20, 10, 0, tzinfo=UTC),
+    )
+
+    assert "decision-test" in repr(run)
+    assert "CRYPTO" in repr(run)

--- a/tests/test_portfolio_decision_service.py
+++ b/tests/test_portfolio_decision_service.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.models.portfolio_decision_run import PortfolioDecisionRun
 from app.schemas.portfolio_decision import PortfolioDecisionSlateResponse
 from app.services.portfolio_decision_service import PortfolioDecisionService
 
@@ -31,6 +32,7 @@ def _make_overview_position(**overrides):
 def _make_service_for_positions(
     positions: list[dict],
     journals: dict[str, dict] | None = None,
+    db=None,
 ) -> PortfolioDecisionService:
     overview_service = MagicMock()
     overview_service.get_overview = AsyncMock(
@@ -42,9 +44,50 @@ def _make_service_for_positions(
     )
     dashboard_service = MagicMock()
     dashboard_service.get_journals_batch = AsyncMock(return_value=journals or {})
-    return PortfolioDecisionService(
-        overview_service=overview_service,
-        dashboard_service=dashboard_service,
+    kwargs = {
+        "overview_service": overview_service,
+        "dashboard_service": dashboard_service,
+    }
+    if db is not None:
+        kwargs["db"] = db
+    return PortfolioDecisionService(**kwargs)
+
+
+class _FakePortfolioDecisionDb:
+    def __init__(self, stored_run: PortfolioDecisionRun | None = None) -> None:
+        self.add = MagicMock()
+        self.commit = AsyncMock()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = stored_run
+        self.execute = AsyncMock(return_value=result)
+
+
+def _available_context_patches():
+    return (
+        patch(
+            "app.services.portfolio_decision_service._get_support_resistance_impl",
+            AsyncMock(
+                return_value={
+                    "status": "available",
+                    "nearest_support": {
+                        "price": 100.0,
+                        "distance_pct": -1.5,
+                        "strength": "moderate",
+                    },
+                    "nearest_resistance": {
+                        "price": 115.0,
+                        "distance_pct": 3.0,
+                        "strength": "strong",
+                    },
+                    "supports": [],
+                    "resistances": [],
+                }
+            ),
+        ),
+        patch(
+            "app.services.portfolio_decision_service._get_indicators_impl",
+            AsyncMock(return_value={"indicators": {"rsi": {"14": 45.0}}}),
+        ),
     )
 
 
@@ -611,3 +654,132 @@ async def test_execution_boundary_marks_manual_or_mixed_accounts_for_review() ->
     boundary = slate["symbol_groups"][0]["items"][0]["execution_boundary"]
     assert boundary["channel"] == "manual_review"
     assert boundary["manual_only"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_create_decision_run_persists_crypto_snapshot_with_share_url() -> None:
+    db = _FakePortfolioDecisionDb()
+    service = _make_service_for_positions(
+        [
+            _make_overview_position(
+                market_type="CRYPTO",
+                symbol="KRW-BTC",
+                name="Bitcoin",
+                current_price=100.0,
+                evaluation=1_000_000.0,
+                evaluation_krw=1_000_000.0,
+            )
+        ],
+        journals={"KRW-BTC": {"status": "active", "target_price": 120.0}},
+        db=db,
+    )
+
+    with _available_context_patches()[0], _available_context_patches()[1]:
+        slate = await service.create_decision_run(
+            user_id=42,
+            market="CRYPTO",
+            account_keys=["upbit:main"],
+            q="BTC",
+        )
+
+    PortfolioDecisionSlateResponse.model_validate(slate)
+    run = slate["decision_run"]
+    assert run["id"].startswith("decision-")
+    assert run["persisted"] is True
+    assert run["market_scope"] == "CRYPTO"
+    assert run["share_url"] == f"/portfolio/decision?run_id={run['id']}"
+    assert slate["filters"] == {
+        "market": "CRYPTO",
+        "account_keys": ["upbit:main"],
+        "q": "BTC",
+    }
+    assert slate["symbol_groups"][0]["symbol"] == "KRW-BTC"
+
+    db.add.assert_called_once()
+    stored = db.add.call_args.args[0]
+    assert isinstance(stored, PortfolioDecisionRun)
+    assert stored.run_id == run["id"]
+    assert stored.user_id == 42
+    assert stored.market_scope == "CRYPTO"
+    assert stored.mode == "analysis_only"
+    assert stored.source == "portfolio_decision_service_v1"
+    assert stored.filters == slate["filters"]
+    assert stored.summary == slate["summary"]
+    assert stored.symbol_groups == slate["symbol_groups"]
+    assert stored.warnings == slate["warnings"]
+    assert stored.payload == slate
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_decision_run_returns_stored_payload_without_recalculating() -> None:
+    payload = {
+        "success": True,
+        "decision_run": {
+            "id": "decision-stored",
+            "generated_at": "2026-04-20T10:00:00+00:00",
+            "market_scope": "CRYPTO",
+            "mode": "analysis_only",
+            "persisted": True,
+            "source": "portfolio_decision_service_v1",
+            "share_url": "/portfolio/decision?run_id=decision-stored",
+        },
+        "filters": {"market": "CRYPTO", "account_keys": [], "q": None},
+        "summary": {
+            "symbols": 0,
+            "decision_items": 0,
+            "actionable_items": 0,
+            "manual_review_items": 0,
+            "auto_candidate_items": 0,
+            "missing_context_items": 0,
+            "by_action": {},
+            "by_market": {},
+        },
+        "facets": {"accounts": []},
+        "symbol_groups": [],
+        "warnings": [],
+    }
+    stored_run = PortfolioDecisionRun(
+        run_id="decision-stored",
+        user_id=42,
+        generated_at="2026-04-20T10:00:00+00:00",
+        market_scope="CRYPTO",
+        mode="analysis_only",
+        source="portfolio_decision_service_v1",
+        filters=payload["filters"],
+        summary=payload["summary"],
+        facets=payload["facets"],
+        symbol_groups=payload["symbol_groups"],
+        warnings=payload["warnings"],
+        payload=payload,
+        created_at="2026-04-20T10:00:00+00:00",
+    )
+    db = _FakePortfolioDecisionDb(stored_run)
+    service = _make_service_for_positions([_make_overview_position()], db=db)
+
+    result = await service.get_decision_run(user_id=42, run_id="decision-stored")
+
+    assert result == payload
+    PortfolioDecisionSlateResponse.model_validate(result)
+    service.overview_service.get_overview.assert_not_awaited()
+    db.execute.assert_awaited_once()
+    statement = db.execute.call_args.args[0]
+    assert str(statement.compile(compile_kwargs={"literal_binds": True})).count(
+        "portfolio_decision_runs"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_decision_run_rejects_missing_run() -> None:
+    from app.services.portfolio_decision_service import (
+        PortfolioDecisionRunNotFoundError,
+    )
+
+    db = _FakePortfolioDecisionDb(None)
+    service = _make_service_for_positions([_make_overview_position()], db=db)
+
+    with pytest.raises(PortfolioDecisionRunNotFoundError):
+        await service.get_decision_run(user_id=42, run_id="missing-run")


### PR DESCRIPTION
## Summary

Adds persisted Decision Desk run snapshots so shared links can reopen the exact decision artifact instead of the moving latest dashboard.

## Changes

- Add `portfolio_decision_runs` persistence model and Alembic migration for immutable JSONB slate snapshots.
- Add `POST /portfolio/api/decision-runs` to generate and store a run-specific artifact.
- Add `GET /portfolio/api/decision-runs/{run_id}` to return stored snapshots without recalculating live holdings, prices, journals, or market context.
- Extend Decision Desk response metadata with `market_scope` and `share_url`.
- Update the Decision Desk page to support live mode, snapshot mode via `?run_id=...`, URL-preserved live filters, and share-link creation.
- Add service, router, and model tests for snapshot persistence and lookup behavior.
- Ignore local `.omx/` state.

## Why

`/portfolio/decision` previously behaved as a live dashboard. Sharing it did not preserve the specific portfolio decision that existed at the time of review. This separates live operator mode from persisted run-specific artifacts.

## Validation

- `uv run pytest tests/test_portfolio_decision_service.py tests/test_portfolio_decision_router.py tests/test_portfolio_decision_run_model.py -q`
- `make lint`

## Not Tested

- `uv run alembic upgrade head` against local Postgres; the local DB was unavailable on `127.0.0.1:5434`.
- Browser smoke for create-share-link and snapshot page rendering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to create and save portfolio decision runs
  * Decision runs can be shared via generated share links
  * Snapshots preserve all decision data, filters, and recommendations for later retrieval
  * Implemented URL-driven viewing of persisted portfolio decisions
  * Market scope and account filtering are applied to saved decisions

* **Tests**
  * Added comprehensive unit tests for decision run endpoints and service layer
  * Added database model validation tests for portfolio decision persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->