### PR TITLE
feat: add Order Intent Preview v0 endpoint (no side effects)

### DIFF
--- a/app/routers/portfolio.py
+++ b/app/routers/portfolio.py
@@ -48,8 +48,8 @@ from app.services.ai_providers.base import AiProviderError
 from app.services.brokers.kis.client import KISClient
 from app.services.kis_holdings_service import get_kis_holding_for_ticker
 from app.services.merged_portfolio_service import MergedPortfolioService
-from app.services.portfolio_dashboard_service import PortfolioDashboardService
 from app.services.order_intent_preview_service import OrderIntentPreviewService
+from app.services.portfolio_dashboard_service import PortfolioDashboardService
 from app.services.portfolio_decision_service import (
     PortfolioDecisionRunNotFoundError,
     PortfolioDecisionService,

--- a/app/routers/portfolio.py
+++ b/app/routers/portfolio.py
@@ -28,6 +28,10 @@ from app.schemas.manual_holdings import (
     MergedPortfolioResponse,
     ReferencePricesResponse,
 )
+from app.schemas.order_intent_preview import (
+    OrderIntentPreviewRequest,
+    OrderIntentPreviewResponse,
+)
 from app.schemas.portfolio_decision import (
     DecisionRunCreateRequest,
     PortfolioDecisionSlateResponse,
@@ -45,6 +49,7 @@ from app.services.brokers.kis.client import KISClient
 from app.services.kis_holdings_service import get_kis_holding_for_ticker
 from app.services.merged_portfolio_service import MergedPortfolioService
 from app.services.portfolio_dashboard_service import PortfolioDashboardService
+from app.services.order_intent_preview_service import OrderIntentPreviewService
 from app.services.portfolio_decision_service import (
     PortfolioDecisionRunNotFoundError,
     PortfolioDecisionService,
@@ -61,6 +66,7 @@ DECISION_SLATE_ERROR_DETAIL = "Unable to build portfolio decision slate."
 DECISION_RUN_CREATE_ERROR_DETAIL = "Unable to create portfolio decision run."
 DECISION_RUN_LOOKUP_ERROR_DETAIL = "Unable to load portfolio decision run."
 DECISION_RUN_NOT_FOUND_DETAIL = "Decision run not found."
+INTENT_PREVIEW_ERROR_DETAIL = "Unable to build order intent preview."
 
 
 def get_portfolio_overview_service(
@@ -89,6 +95,14 @@ def get_portfolio_decision_service(
         dashboard_service=dashboard_service,
         db=db,
     )
+
+
+def get_order_intent_preview_service(
+    decision_service: Annotated[
+        PortfolioDecisionService, Depends(get_portfolio_decision_service)
+    ],
+) -> OrderIntentPreviewService:
+    return OrderIntentPreviewService(decision_service=decision_service)
 
 
 @router.get("/decision", response_class=HTMLResponse)
@@ -190,6 +204,41 @@ async def get_portfolio_decision_run(
         raise HTTPException(
             status_code=500,
             detail=DECISION_RUN_LOOKUP_ERROR_DETAIL,
+        ) from e
+
+
+@router.post(
+    "/api/decision-runs/{run_id}/intent-preview",
+    response_model=OrderIntentPreviewResponse,
+    responses={
+        404: {"description": "Decision run not found"},
+        500: {"description": "Failed to build order intent preview"},
+    },
+)
+async def preview_order_intents_for_decision_run(
+    run_id: str,
+    payload: OrderIntentPreviewRequest,
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+    preview_service: Annotated[
+        OrderIntentPreviewService, Depends(get_order_intent_preview_service)
+    ],
+) -> OrderIntentPreviewResponse:
+    try:
+        return await preview_service.build_preview(
+            user_id=current_user.id,
+            run_id=run_id,
+            request=payload,
+        )
+    except PortfolioDecisionRunNotFoundError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=DECISION_RUN_NOT_FOUND_DETAIL,
+        ) from e
+    except Exception as e:
+        logger.error("Error building intent preview: %s", e, exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=INTENT_PREVIEW_ERROR_DETAIL,
         ) from e
 
 

--- a/app/routers/portfolio.py
+++ b/app/routers/portfolio.py
@@ -209,7 +209,6 @@ async def get_portfolio_decision_run(
 
 @router.post(
     "/api/decision-runs/{run_id}/intent-preview",
-    response_model=OrderIntentPreviewResponse,
     responses={
         404: {"description": "Decision run not found"},
         500: {"description": "Failed to build order intent preview"},

--- a/app/schemas/order_intent_preview.py
+++ b/app/schemas/order_intent_preview.py
@@ -1,0 +1,67 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class IntentBudgetInput(BaseModel):
+    total_krw: float | None = Field(default=None, ge=0)
+    per_symbol_budget_krw: dict[str, float] = Field(default_factory=dict)
+    default_buy_budget_krw: float | None = Field(default=None, ge=0)
+
+
+class IntentSelectionInput(BaseModel):
+    decision_item_id: str
+    enabled: bool = True
+    budget_krw: float | None = Field(default=None, ge=0)
+    quantity_pct: float | None = Field(default=None, ge=0, le=100)
+    override_threshold: float | None = Field(default=None, gt=0)
+
+
+class OrderIntentPreviewRequest(BaseModel):
+    budget: IntentBudgetInput = Field(default_factory=IntentBudgetInput)
+    selections: list[IntentSelectionInput] = Field(default_factory=list)
+    execution_mode: Literal[
+        "requires_final_approval",
+        "paper_only",
+        "dry_run_only",
+    ] = "requires_final_approval"
+
+
+class IntentTriggerPreview(BaseModel):
+    metric: Literal["price"]
+    operator: Literal["above", "below"]
+    threshold: float | None = None
+    source: str | None = None
+
+
+class OrderIntentPreviewItem(BaseModel):
+    decision_run_id: str
+    decision_item_id: str
+    symbol: str
+    market: str
+    side: Literal["buy", "sell"]
+    intent_type: str
+    status: Literal[
+        "invalid",
+        "watch_ready",
+        "execution_candidate",
+        "manual_review_required",
+    ]
+    execution_mode: Literal[
+        "requires_final_approval",
+        "paper_only",
+        "dry_run_only",
+    ]
+    budget_krw: float | None = None
+    quantity_pct: float | None = None
+    trigger: IntentTriggerPreview | None = None
+    rationale: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class OrderIntentPreviewResponse(BaseModel):
+    success: bool = True
+    decision_run_id: str
+    mode: Literal["preview_only"] = "preview_only"
+    intents: list[OrderIntentPreviewItem] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)

--- a/app/schemas/order_intent_preview.py
+++ b/app/schemas/order_intent_preview.py
@@ -42,7 +42,12 @@ class OrderIntentPreviewItem(BaseModel):
     symbol: str
     market: str
     side: Literal["buy", "sell"]
-    intent_type: str
+    intent_type: Literal[
+        "buy_candidate",
+        "trim_candidate",
+        "sell_watch",
+        "manual_review",
+    ]
     status: Literal[
         "invalid",
         "watch_ready",

--- a/app/schemas/order_intent_preview.py
+++ b/app/schemas/order_intent_preview.py
@@ -1,11 +1,13 @@
-from typing import Literal
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
+
+NonNegativeFloat = Annotated[float, Field(ge=0)]
 
 
 class IntentBudgetInput(BaseModel):
     total_krw: float | None = Field(default=None, ge=0)
-    per_symbol_budget_krw: dict[str, float] = Field(default_factory=dict)
+    per_symbol_budget_krw: dict[str, NonNegativeFloat] = Field(default_factory=dict)
     default_buy_budget_krw: float | None = Field(default=None, ge=0)
 
 

--- a/app/services/order_intent_preview_service.py
+++ b/app/services/order_intent_preview_service.py
@@ -77,6 +77,67 @@ class OrderIntentPreviewService:
         # by status="manual_review_required" and trigger=None.
         return "sell"
 
+    @staticmethod
+    def _resolve_buy_budget(
+        request: OrderIntentPreviewRequest,
+        group: dict[str, Any],
+        selection: IntentSelectionInput | None,
+    ) -> tuple[float | None, list[str]]:
+        if selection is not None and selection.budget_krw is not None:
+            return selection.budget_krw, []
+        per_symbol = request.budget.per_symbol_budget_krw
+        symbol = group["symbol"]
+        if symbol in per_symbol:
+            return per_symbol[symbol], []
+        if request.budget.default_buy_budget_krw is not None:
+            return request.budget.default_buy_budget_krw, []
+        return None, ["missing_buy_budget"]
+
+    @staticmethod
+    def _resolve_sell_quantity_pct(
+        action: str | None,
+        selection: IntentSelectionInput | None,
+    ) -> float | None:
+        if selection is not None and selection.quantity_pct is not None:
+            return selection.quantity_pct
+        return _DEFAULT_SELL_QTY_PCT.get(action) if action is not None else None
+
+    @staticmethod
+    def _resolve_threshold(
+        item: dict[str, Any],
+        selection: IntentSelectionInput | None,
+    ) -> tuple[float | None, str | None]:
+        if selection is not None and selection.override_threshold is not None:
+            return selection.override_threshold, "override"
+        raw = item.get("action_price")
+        if raw is None:
+            return None, None
+        return float(raw), item.get("action_price_source")
+
+    @staticmethod
+    def _build_trigger_and_status(
+        side: Literal["buy", "sell"],
+        action: str | None,
+        threshold: float | None,
+        threshold_source: str | None,
+        item: dict[str, Any],
+    ) -> tuple[IntentTriggerPreview | None, str]:
+        if action == "manual_review" or threshold is None:
+            return None, "manual_review_required"
+        operator = "below" if side == "buy" else "above"
+        trigger = IntentTriggerPreview(
+            metric="price",
+            operator=operator,
+            threshold=threshold,
+            source=threshold_source,
+        )
+        if side == "sell":
+            current_price = item.get("current_price")
+            if current_price is not None and float(current_price) >= threshold:
+                return trigger, "execution_candidate"
+            return trigger, "watch_ready"
+        return trigger, "watch_ready"
+
     def _build_intent_for_item(
         self,
         *,
@@ -89,7 +150,6 @@ class OrderIntentPreviewService:
         action = item.get("action")
         if action == "hold":
             return None
-
         if selection is not None and not selection.enabled:
             return None
 
@@ -98,52 +158,16 @@ class OrderIntentPreviewService:
         budget_krw: float | None = None
         warnings: list[str] = []
         if side == "buy":
-            if selection is not None and selection.budget_krw is not None:
-                budget_krw = selection.budget_krw
-            elif group["symbol"] in request.budget.per_symbol_budget_krw:
-                budget_krw = request.budget.per_symbol_budget_krw[group["symbol"]]
-            elif request.budget.default_buy_budget_krw is not None:
-                budget_krw = request.budget.default_buy_budget_krw
-            else:
-                warnings.append("missing_buy_budget")
+            budget_krw, warnings = self._resolve_buy_budget(request, group, selection)
 
         quantity_pct: float | None = None
         if side == "sell" and action != "manual_review":
-            if selection is not None and selection.quantity_pct is not None:
-                quantity_pct = selection.quantity_pct
-            else:
-                quantity_pct = _DEFAULT_SELL_QTY_PCT.get(action)
+            quantity_pct = self._resolve_sell_quantity_pct(action, selection)
 
-        threshold: float | None = None
-        threshold_source: str | None = None
-        if selection is not None and selection.override_threshold is not None:
-            threshold = selection.override_threshold
-            threshold_source = "override"
-        else:
-            threshold_raw = item.get("action_price")
-            if threshold_raw is not None:
-                threshold = float(threshold_raw)
-                threshold_source = item.get("action_price_source")
-
-        operator = "below" if side == "buy" else "above"
-        trigger: IntentTriggerPreview | None = None
-        status = "manual_review_required"
-        if action != "manual_review" and threshold is not None:
-            threshold_f = float(threshold)
-            trigger = IntentTriggerPreview(
-                metric="price",
-                operator=operator,
-                threshold=threshold_f,
-                source=threshold_source,
-            )
-            if side == "sell":
-                current_price = item.get("current_price")
-                if current_price is not None and float(current_price) >= threshold_f:
-                    status = "execution_candidate"
-                else:
-                    status = "watch_ready"
-            else:
-                status = "watch_ready"
+        threshold, threshold_source = self._resolve_threshold(item, selection)
+        trigger, status = self._build_trigger_and_status(
+            side, action, threshold, threshold_source, item
+        )
 
         return OrderIntentPreviewItem(
             decision_run_id=run_id,

--- a/app/services/order_intent_preview_service.py
+++ b/app/services/order_intent_preview_service.py
@@ -78,6 +78,9 @@ class OrderIntentPreviewService:
         if action == "hold":
             return None
 
+        if selection is not None and not selection.enabled:
+            return None
+
         if action in _BUY_ACTIONS:
             side = "buy"
         else:

--- a/app/services/order_intent_preview_service.py
+++ b/app/services/order_intent_preview_service.py
@@ -98,6 +98,13 @@ class OrderIntentPreviewService:
             else:
                 warnings.append("missing_buy_budget")
 
+        quantity_pct: float | None = None
+        if side == "sell" and action != "manual_review":
+            if selection is not None and selection.quantity_pct is not None:
+                quantity_pct = selection.quantity_pct
+            else:
+                quantity_pct = _DEFAULT_SELL_QTY_PCT.get(action)
+
         threshold: float | None = None
         threshold_source: str | None = None
         if selection is not None and selection.override_threshold is not None:
@@ -139,6 +146,7 @@ class OrderIntentPreviewService:
             status=status,
             execution_mode=request.execution_mode,
             budget_krw=budget_krw,
+            quantity_pct=quantity_pct,
             trigger=trigger,
             warnings=warnings,
         )

--- a/app/services/order_intent_preview_service.py
+++ b/app/services/order_intent_preview_service.py
@@ -1,0 +1,98 @@
+"""Order Intent Preview v0 — pure transformation, zero side effects."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.schemas.order_intent_preview import (
+    IntentTriggerPreview,
+    OrderIntentPreviewItem,
+    OrderIntentPreviewRequest,
+    OrderIntentPreviewResponse,
+)
+from app.services.portfolio_decision_service import (
+    PortfolioDecisionRunNotFoundError,  # noqa: F401  (re-exported for callers)
+    PortfolioDecisionService,
+)
+
+_BUY_ACTIONS = {"buy_candidate"}
+_SELL_ACTIONS = {"trim_candidate", "sell_watch"}
+_DEFAULT_SELL_QTY_PCT = {"trim_candidate": 30.0, "sell_watch": 100.0}
+
+
+class OrderIntentPreviewService:
+    def __init__(self, *, decision_service: PortfolioDecisionService) -> None:
+        self._decision_service = decision_service
+
+    async def build_preview(
+        self,
+        *,
+        user_id: int,
+        run_id: str,
+        request: OrderIntentPreviewRequest,
+    ) -> OrderIntentPreviewResponse:
+        payload = await self._decision_service.get_decision_run(
+            user_id=user_id,
+            run_id=run_id,
+        )
+        intents: list[OrderIntentPreviewItem] = []
+        warnings: list[str] = []
+
+        for group in payload.get("symbol_groups", []):
+            for item in group.get("items", []):
+                intent = self._build_intent_for_item(
+                    run_id=run_id,
+                    group=group,
+                    item=item,
+                    request=request,
+                )
+                if intent is not None:
+                    intents.append(intent)
+
+        return OrderIntentPreviewResponse(
+            decision_run_id=run_id,
+            intents=intents,
+            warnings=warnings,
+        )
+
+    def _build_intent_for_item(
+        self,
+        *,
+        run_id: str,
+        group: dict[str, Any],
+        item: dict[str, Any],
+        request: OrderIntentPreviewRequest,
+    ) -> OrderIntentPreviewItem | None:
+        action = item.get("action")
+        if action == "hold":
+            return None
+
+        if action in _BUY_ACTIONS:
+            side = "buy"
+        else:
+            side = "sell"
+
+        threshold = item.get("action_price")
+        operator = "below" if side == "buy" else "above"
+        trigger: IntentTriggerPreview | None = None
+        status = "manual_review_required"
+        if action != "manual_review" and threshold is not None:
+            trigger = IntentTriggerPreview(
+                metric="price",
+                operator=operator,
+                threshold=float(threshold),
+                source=item.get("action_price_source"),
+            )
+            status = "watch_ready"
+
+        return OrderIntentPreviewItem(
+            decision_run_id=run_id,
+            decision_item_id=item["id"],
+            symbol=group["symbol"],
+            market=group["market_type"],
+            side=side,
+            intent_type=action,
+            status=status,
+            execution_mode=request.execution_mode,
+            trigger=trigger,
+        )

--- a/app/services/order_intent_preview_service.py
+++ b/app/services/order_intent_preview_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from app.schemas.order_intent_preview import (
     IntentSelectionInput,
@@ -18,6 +18,7 @@ from app.services.portfolio_decision_service import (
 
 _BUY_ACTIONS = {"buy_candidate"}
 _SELL_ACTIONS = {"trim_candidate", "sell_watch"}
+_MANUAL_REVIEW_ACTIONS = {"manual_review"}
 _DEFAULT_SELL_QTY_PCT = {"trim_candidate": 30.0, "sell_watch": 100.0}
 
 
@@ -65,6 +66,15 @@ class OrderIntentPreviewService:
     ) -> dict[str, IntentSelectionInput]:
         return {s.decision_item_id: s for s in selections}
 
+    @staticmethod
+    def _side_for_action(action: str | None) -> Literal["buy", "sell"]:
+        if action in _BUY_ACTIONS:
+            return "buy"
+        # Explicit contract: sell-style actions and manual_review map to "sell"
+        # so they share the buy/sell schema. manual_review is gated separately
+        # by status="manual_review_required" and trigger=None.
+        return "sell"
+
     def _build_intent_for_item(
         self,
         *,
@@ -81,10 +91,7 @@ class OrderIntentPreviewService:
         if selection is not None and not selection.enabled:
             return None
 
-        if action in _BUY_ACTIONS:
-            side = "buy"
-        else:
-            side = "sell"
+        side = self._side_for_action(action)
 
         budget_krw: float | None = None
         warnings: list[str] = []

--- a/app/services/order_intent_preview_service.py
+++ b/app/services/order_intent_preview_service.py
@@ -44,12 +44,14 @@ class OrderIntentPreviewService:
 
         for group in payload.get("symbol_groups", []):
             for item in group.get("items", []):
+                item_id = item.get("id")
+                selection = selection_map.get(item_id) if item_id else None
                 intent = self._build_intent_for_item(
                     run_id=run_id,
                     group=group,
                     item=item,
                     request=request,
-                    selection=selection_map.get(item.get("id", "")),
+                    selection=selection,
                 )
                 if intent is not None:
                     intents.append(intent)

--- a/app/services/order_intent_preview_service.py
+++ b/app/services/order_intent_preview_service.py
@@ -77,13 +77,21 @@ class OrderIntentPreviewService:
         trigger: IntentTriggerPreview | None = None
         status = "manual_review_required"
         if action != "manual_review" and threshold is not None:
+            threshold_f = float(threshold)
             trigger = IntentTriggerPreview(
                 metric="price",
                 operator=operator,
-                threshold=float(threshold),
+                threshold=threshold_f,
                 source=item.get("action_price_source"),
             )
-            status = "watch_ready"
+            if side == "sell":
+                current_price = item.get("current_price")
+                if current_price is not None and float(current_price) >= threshold_f:
+                    status = "execution_candidate"
+                else:
+                    status = "watch_ready"
+            else:
+                status = "watch_ready"
 
         return OrderIntentPreviewItem(
             decision_run_id=run_id,

--- a/app/services/order_intent_preview_service.py
+++ b/app/services/order_intent_preview_service.py
@@ -86,6 +86,18 @@ class OrderIntentPreviewService:
         else:
             side = "sell"
 
+        budget_krw: float | None = None
+        warnings: list[str] = []
+        if side == "buy":
+            if selection is not None and selection.budget_krw is not None:
+                budget_krw = selection.budget_krw
+            elif group["symbol"] in request.budget.per_symbol_budget_krw:
+                budget_krw = request.budget.per_symbol_budget_krw[group["symbol"]]
+            elif request.budget.default_buy_budget_krw is not None:
+                budget_krw = request.budget.default_buy_budget_krw
+            else:
+                warnings.append("missing_buy_budget")
+
         threshold: float | None = None
         threshold_source: str | None = None
         if selection is not None and selection.override_threshold is not None:
@@ -126,5 +138,7 @@ class OrderIntentPreviewService:
             intent_type=action,
             status=status,
             execution_mode=request.execution_mode,
+            budget_krw=budget_krw,
             trigger=trigger,
+            warnings=warnings,
         )

--- a/app/services/order_intent_preview_service.py
+++ b/app/services/order_intent_preview_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from app.schemas.order_intent_preview import (
+    IntentSelectionInput,
     IntentTriggerPreview,
     OrderIntentPreviewItem,
     OrderIntentPreviewRequest,
@@ -38,6 +39,8 @@ class OrderIntentPreviewService:
         intents: list[OrderIntentPreviewItem] = []
         warnings: list[str] = []
 
+        selection_map = self._selections_by_id(request.selections)
+
         for group in payload.get("symbol_groups", []):
             for item in group.get("items", []):
                 intent = self._build_intent_for_item(
@@ -45,6 +48,7 @@ class OrderIntentPreviewService:
                     group=group,
                     item=item,
                     request=request,
+                    selection=selection_map.get(item.get("id", "")),
                 )
                 if intent is not None:
                     intents.append(intent)
@@ -55,6 +59,12 @@ class OrderIntentPreviewService:
             warnings=warnings,
         )
 
+    @staticmethod
+    def _selections_by_id(
+        selections: list[IntentSelectionInput],
+    ) -> dict[str, IntentSelectionInput]:
+        return {s.decision_item_id: s for s in selections}
+
     def _build_intent_for_item(
         self,
         *,
@@ -62,6 +72,7 @@ class OrderIntentPreviewService:
         group: dict[str, Any],
         item: dict[str, Any],
         request: OrderIntentPreviewRequest,
+        selection: IntentSelectionInput | None = None,
     ) -> OrderIntentPreviewItem | None:
         action = item.get("action")
         if action == "hold":
@@ -72,7 +83,17 @@ class OrderIntentPreviewService:
         else:
             side = "sell"
 
-        threshold = item.get("action_price")
+        threshold: float | None = None
+        threshold_source: str | None = None
+        if selection is not None and selection.override_threshold is not None:
+            threshold = selection.override_threshold
+            threshold_source = "override"
+        else:
+            threshold_raw = item.get("action_price")
+            if threshold_raw is not None:
+                threshold = float(threshold_raw)
+                threshold_source = item.get("action_price_source")
+
         operator = "below" if side == "buy" else "above"
         trigger: IntentTriggerPreview | None = None
         status = "manual_review_required"
@@ -82,7 +103,7 @@ class OrderIntentPreviewService:
                 metric="price",
                 operator=operator,
                 threshold=threshold_f,
-                source=item.get("action_price_source"),
+                source=threshold_source,
             )
             if side == "sell":
                 current_price = item.get("current_price")

--- a/tests/test_order_intent_preview_router.py
+++ b/tests/test_order_intent_preview_router.py
@@ -6,7 +6,10 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from app.routers import portfolio
-from app.schemas.order_intent_preview import OrderIntentPreviewResponse
+from app.schemas.order_intent_preview import (
+    OrderIntentPreviewRequest,
+    OrderIntentPreviewResponse,
+)
 from app.services.portfolio_decision_service import PortfolioDecisionRunNotFoundError
 
 
@@ -44,6 +47,8 @@ def test_preview_endpoint_returns_preview_only_response() -> None:
     kwargs = fake_preview.build_preview.await_args.kwargs
     assert kwargs["user_id"] == 7
     assert kwargs["run_id"] == "decision-stored"
+    assert isinstance(kwargs["request"], OrderIntentPreviewRequest)
+    assert kwargs["request"].execution_mode == "requires_final_approval"
 
 
 @pytest.mark.unit

--- a/tests/test_order_intent_preview_router.py
+++ b/tests/test_order_intent_preview_router.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import portfolio
+from app.schemas.order_intent_preview import OrderIntentPreviewResponse
+from app.services.portfolio_decision_service import PortfolioDecisionRunNotFoundError
+
+
+def _make_client():
+    app = FastAPI()
+    app.include_router(portfolio.router)
+    fake_preview = AsyncMock()
+    fake_preview.build_preview = AsyncMock(
+        return_value=OrderIntentPreviewResponse(
+            decision_run_id="decision-stored", intents=[]
+        )
+    )
+    app.dependency_overrides[portfolio.get_authenticated_user] = lambda: (
+        SimpleNamespace(id=7)
+    )
+    app.dependency_overrides[portfolio.get_order_intent_preview_service] = (
+        lambda: fake_preview
+    )
+    return TestClient(app), fake_preview
+
+
+@pytest.mark.unit
+def test_preview_endpoint_returns_preview_only_response() -> None:
+    client, fake_preview = _make_client()
+    response = client.post(
+        "/portfolio/api/decision-runs/decision-stored/intent-preview",
+        json={"budget": {}, "selections": [], "execution_mode": "requires_final_approval"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["mode"] == "preview_only"
+    assert body["decision_run_id"] == "decision-stored"
+    fake_preview.build_preview.assert_awaited_once()
+    kwargs = fake_preview.build_preview.await_args.kwargs
+    assert kwargs["user_id"] == 7
+    assert kwargs["run_id"] == "decision-stored"
+
+
+@pytest.mark.unit
+def test_preview_endpoint_returns_404_when_run_missing() -> None:
+    client, fake_preview = _make_client()
+    fake_preview.build_preview.side_effect = PortfolioDecisionRunNotFoundError("nope")
+    response = client.post(
+        "/portfolio/api/decision-runs/nope/intent-preview",
+        json={},
+    )
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Decision run not found."}

--- a/tests/test_order_intent_preview_router.py
+++ b/tests/test_order_intent_preview_router.py
@@ -25,8 +25,8 @@ def _make_client():
     app.dependency_overrides[portfolio.get_authenticated_user] = lambda: (
         SimpleNamespace(id=7)
     )
-    app.dependency_overrides[portfolio.get_order_intent_preview_service] = (
-        lambda: fake_preview
+    app.dependency_overrides[portfolio.get_order_intent_preview_service] = lambda: (
+        fake_preview
     )
     return TestClient(app), fake_preview
 
@@ -36,7 +36,11 @@ def test_preview_endpoint_returns_preview_only_response() -> None:
     client, fake_preview = _make_client()
     response = client.post(
         "/portfolio/api/decision-runs/decision-stored/intent-preview",
-        json={"budget": {}, "selections": [], "execution_mode": "requires_final_approval"},
+        json={
+            "budget": {},
+            "selections": [],
+            "execution_mode": "requires_final_approval",
+        },
     )
 
     assert response.status_code == 200

--- a/tests/test_order_intent_preview_service.py
+++ b/tests/test_order_intent_preview_service.py
@@ -83,7 +83,9 @@ def _service(payload: dict) -> OrderIntentPreviewService:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_buy_candidate_with_action_price_yields_watch_ready_below_trigger() -> None:
+async def test_buy_candidate_with_action_price_yields_watch_ready_below_trigger() -> (
+    None
+):
     service = _service(_payload_with_items([_item()]))
 
     response = await service.build_preview(
@@ -215,8 +217,6 @@ async def test_trim_candidate_without_action_price_is_manual_review_required() -
     assert intent.trigger is None
 
 
-
-
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_selection_override_threshold_replaces_action_price() -> None:
@@ -244,8 +244,11 @@ async def test_selection_override_threshold_replaces_action_price() -> None:
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_override_threshold_supplies_trigger_when_action_price_missing() -> None:
-    items = [_item(id="trim-3", action="trim_candidate", action_price=None,
-                   current_price=200.0)]
+    items = [
+        _item(
+            id="trim-3", action="trim_candidate", action_price=None, current_price=200.0
+        )
+    ]
     service = _service(_payload_with_items(items))
 
     request = OrderIntentPreviewRequest(
@@ -288,8 +291,6 @@ async def test_selection_enabled_false_excludes_item() -> None:
     )
 
     assert [i.decision_item_id for i in response.intents] == ["buy-2"]
-
-
 
 
 @pytest.mark.unit
@@ -357,10 +358,13 @@ async def test_buy_budget_missing_emits_warning_and_null_budget() -> None:
 @pytest.mark.asyncio
 async def test_sell_quantity_pct_defaults() -> None:
     items = [
-        _item(id="trim-1", action="trim_candidate", current_price=120.0,
-              action_price=110.0),
-        _item(id="sw-1", action="sell_watch", current_price=90.0,
-              action_price=110.0),
+        _item(
+            id="trim-1",
+            action="trim_candidate",
+            current_price=120.0,
+            action_price=110.0,
+        ),
+        _item(id="sw-1", action="sell_watch", current_price=90.0, action_price=110.0),
     ]
     service = _service(_payload_with_items(items))
     response = await service.build_preview(
@@ -375,8 +379,12 @@ async def test_sell_quantity_pct_defaults() -> None:
 @pytest.mark.asyncio
 async def test_sell_quantity_pct_selection_overrides_default() -> None:
     items = [
-        _item(id="trim-1", action="trim_candidate", current_price=120.0,
-              action_price=110.0),
+        _item(
+            id="trim-1",
+            action="trim_candidate",
+            current_price=120.0,
+            action_price=110.0,
+        ),
     ]
     service = _service(_payload_with_items(items))
     request = OrderIntentPreviewRequest(
@@ -388,8 +396,6 @@ async def test_sell_quantity_pct_selection_overrides_default() -> None:
         user_id=7, run_id="decision-test-run", request=request
     )
     assert response.intents[0].quantity_pct == pytest.approx(55.0)
-
-
 
 
 @pytest.mark.unit
@@ -405,7 +411,9 @@ def test_preview_service_does_not_import_order_or_redis_modules() -> None:
         "paperclip",
     )
     for needle in forbidden:
-        assert needle not in source, f"forbidden symbol '{needle}' present in preview service"
+        assert needle not in source, (
+            f"forbidden symbol '{needle}' present in preview service"
+        )
 
 
 @pytest.mark.unit

--- a/tests/test_order_intent_preview_service.py
+++ b/tests/test_order_intent_preview_service.py
@@ -279,3 +279,67 @@ async def test_selection_enabled_false_excludes_item() -> None:
     )
 
     assert [i.decision_item_id for i in response.intents] == ["buy-2"]
+
+
+from app.schemas.order_intent_preview import IntentBudgetInput
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_buy_budget_uses_selection_first() -> None:
+    items = [_item(id="buy-1", action="buy_candidate")]
+    service = _service(_payload_with_items(items))
+    request = OrderIntentPreviewRequest(
+        budget=IntentBudgetInput(
+            per_symbol_budget_krw={"KRW-BTC": 200_000.0},
+            default_buy_budget_krw=100_000.0,
+        ),
+        selections=[
+            IntentSelectionInput(decision_item_id="buy-1", budget_krw=500_000.0),
+        ],
+    )
+    response = await service.build_preview(
+        user_id=7, run_id="decision-test-run", request=request
+    )
+    assert response.intents[0].budget_krw == 500_000.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_buy_budget_falls_back_to_per_symbol_then_default() -> None:
+    items = [_item(id="buy-1", action="buy_candidate")]
+    service = _service(_payload_with_items(items))
+
+    per_symbol = OrderIntentPreviewRequest(
+        budget=IntentBudgetInput(
+            per_symbol_budget_krw={"KRW-BTC": 200_000.0},
+            default_buy_budget_krw=100_000.0,
+        ),
+    )
+    response = await service.build_preview(
+        user_id=7, run_id="decision-test-run", request=per_symbol
+    )
+    assert response.intents[0].budget_krw == 200_000.0
+
+    default_only = OrderIntentPreviewRequest(
+        budget=IntentBudgetInput(default_buy_budget_krw=100_000.0),
+    )
+    response = await service.build_preview(
+        user_id=7, run_id="decision-test-run", request=default_only
+    )
+    assert response.intents[0].budget_krw == 100_000.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_buy_budget_missing_emits_warning_and_null_budget() -> None:
+    items = [_item(id="buy-1", action="buy_candidate")]
+    service = _service(_payload_with_items(items))
+    response = await service.build_preview(
+        user_id=7,
+        run_id="decision-test-run",
+        request=OrderIntentPreviewRequest(),
+    )
+    intent = response.intents[0]
+    assert intent.budget_krw is None
+    assert "missing_buy_budget" in intent.warnings

--- a/tests/test_order_intent_preview_service.py
+++ b/tests/test_order_intent_preview_service.py
@@ -412,3 +412,24 @@ def test_per_symbol_budget_rejects_negative_values() -> None:
         OrderIntentPreviewRequest.model_validate(
             {"budget": {"per_symbol_budget_krw": {"KRW-BTC": -1.0}}}
         )
+
+
+@pytest.mark.unit
+def test_intent_type_rejects_unknown_value() -> None:
+    from pydantic import ValidationError
+
+    from app.schemas.order_intent_preview import OrderIntentPreviewItem
+
+    with pytest.raises(ValidationError):
+        OrderIntentPreviewItem.model_validate(
+            {
+                "decision_run_id": "r",
+                "decision_item_id": "i",
+                "symbol": "KRW-BTC",
+                "market": "CRYPTO",
+                "side": "buy",
+                "intent_type": "totally_invalid_action",
+                "status": "watch_ready",
+                "execution_mode": "requires_final_approval",
+            }
+        )

--- a/tests/test_order_intent_preview_service.py
+++ b/tests/test_order_intent_preview_service.py
@@ -138,8 +138,12 @@ async def test_manual_review_action_is_marked_manual_review_required() -> None:
     )
 
     assert len(response.intents) == 1
-    assert response.intents[0].status == "manual_review_required"
-    assert response.intents[0].trigger is None
+    intent = response.intents[0]
+    assert intent.status == "manual_review_required"
+    assert intent.trigger is None
+    # Explicit contract: manual_review is mapped to side="sell" so it surfaces
+    # in the existing buy/sell schema while remaining manual-only via status.
+    assert intent.side == "sell"
 
 
 @pytest.mark.unit

--- a/tests/test_order_intent_preview_service.py
+++ b/tests/test_order_intent_preview_service.py
@@ -343,3 +343,40 @@ async def test_buy_budget_missing_emits_warning_and_null_budget() -> None:
     intent = response.intents[0]
     assert intent.budget_krw is None
     assert "missing_buy_budget" in intent.warnings
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sell_quantity_pct_defaults() -> None:
+    items = [
+        _item(id="trim-1", action="trim_candidate", current_price=120.0,
+              action_price=110.0),
+        _item(id="sw-1", action="sell_watch", current_price=90.0,
+              action_price=110.0),
+    ]
+    service = _service(_payload_with_items(items))
+    response = await service.build_preview(
+        user_id=7, run_id="decision-test-run", request=OrderIntentPreviewRequest()
+    )
+    by_id = {i.decision_item_id: i for i in response.intents}
+    assert by_id["trim-1"].quantity_pct == 30.0
+    assert by_id["sw-1"].quantity_pct == 100.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sell_quantity_pct_selection_overrides_default() -> None:
+    items = [
+        _item(id="trim-1", action="trim_candidate", current_price=120.0,
+              action_price=110.0),
+    ]
+    service = _service(_payload_with_items(items))
+    request = OrderIntentPreviewRequest(
+        selections=[
+            IntentSelectionInput(decision_item_id="trim-1", quantity_pct=55.0),
+        ]
+    )
+    response = await service.build_preview(
+        user_id=7, run_id="decision-test-run", request=request
+    )
+    assert response.intents[0].quantity_pct == 55.0

--- a/tests/test_order_intent_preview_service.py
+++ b/tests/test_order_intent_preview_service.py
@@ -203,3 +203,55 @@ async def test_trim_candidate_without_action_price_is_manual_review_required() -
     intent = response.intents[0]
     assert intent.status == "manual_review_required"
     assert intent.trigger is None
+
+
+from app.schemas.order_intent_preview import IntentSelectionInput
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_selection_override_threshold_replaces_action_price() -> None:
+    items = [_item(id="buy-1", action="buy_candidate", action_price=140.0)]
+    service = _service(_payload_with_items(items))
+
+    request = OrderIntentPreviewRequest(
+        selections=[
+            IntentSelectionInput(decision_item_id="buy-1", override_threshold=125.0)
+        ]
+    )
+
+    response = await service.build_preview(
+        user_id=7,
+        run_id="decision-test-run",
+        request=request,
+    )
+
+    intent = response.intents[0]
+    assert intent.trigger is not None
+    assert intent.trigger.threshold == 125.0
+    assert intent.trigger.source == "override"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_override_threshold_supplies_trigger_when_action_price_missing() -> None:
+    items = [_item(id="trim-3", action="trim_candidate", action_price=None,
+                   current_price=200.0)]
+    service = _service(_payload_with_items(items))
+
+    request = OrderIntentPreviewRequest(
+        selections=[
+            IntentSelectionInput(decision_item_id="trim-3", override_threshold=180.0)
+        ]
+    )
+
+    response = await service.build_preview(
+        user_id=7,
+        run_id="decision-test-run",
+        request=request,
+    )
+
+    intent = response.intents[0]
+    assert intent.trigger is not None
+    assert intent.trigger.threshold == 180.0
+    assert intent.status == "execution_candidate"

--- a/tests/test_order_intent_preview_service.py
+++ b/tests/test_order_intent_preview_service.py
@@ -134,3 +134,72 @@ async def test_manual_review_action_is_marked_manual_review_required() -> None:
     assert len(response.intents) == 1
     assert response.intents[0].status == "manual_review_required"
     assert response.intents[0].trigger is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_trim_candidate_above_threshold_is_execution_candidate() -> None:
+    items = [
+        _item(
+            id="trim-1",
+            action="trim_candidate",
+            current_price=120.0,
+            action_price=110.0,
+        )
+    ]
+    service = _service(_payload_with_items(items))
+
+    response = await service.build_preview(
+        user_id=7,
+        run_id="decision-test-run",
+        request=OrderIntentPreviewRequest(),
+    )
+
+    intent = response.intents[0]
+    assert intent.side == "sell"
+    assert intent.intent_type == "trim_candidate"
+    assert intent.status == "execution_candidate"
+    assert intent.trigger is not None
+    assert intent.trigger.operator == "above"
+    assert intent.trigger.threshold == 110.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sell_watch_below_threshold_is_watch_ready() -> None:
+    items = [
+        _item(
+            id="sw-1",
+            action="sell_watch",
+            current_price=90.0,
+            action_price=110.0,
+        )
+    ]
+    service = _service(_payload_with_items(items))
+
+    response = await service.build_preview(
+        user_id=7,
+        run_id="decision-test-run",
+        request=OrderIntentPreviewRequest(),
+    )
+
+    intent = response.intents[0]
+    assert intent.side == "sell"
+    assert intent.status == "watch_ready"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_trim_candidate_without_action_price_is_manual_review_required() -> None:
+    items = [_item(id="trim-2", action="trim_candidate", action_price=None)]
+    service = _service(_payload_with_items(items))
+
+    response = await service.build_preview(
+        user_id=7,
+        run_id="decision-test-run",
+        request=OrderIntentPreviewRequest(),
+    )
+
+    intent = response.intents[0]
+    assert intent.status == "manual_review_required"
+    assert intent.trigger is None

--- a/tests/test_order_intent_preview_service.py
+++ b/tests/test_order_intent_preview_service.py
@@ -1,0 +1,101 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.schemas.order_intent_preview import OrderIntentPreviewRequest
+from app.services.order_intent_preview_service import OrderIntentPreviewService
+
+
+def _payload_with_items(items: list[dict]) -> dict:
+    return {
+        "success": True,
+        "decision_run": {
+            "id": "decision-test-run",
+            "generated_at": "2026-04-20T10:00:00+00:00",
+            "mode": "analysis_only",
+            "persisted": True,
+            "source": "portfolio_decision_service_v1",
+        },
+        "filters": {"market": "ALL", "account_keys": [], "q": None},
+        "summary": {
+            "symbols": 0,
+            "decision_items": 0,
+            "actionable_items": 0,
+            "manual_review_items": 0,
+            "auto_candidate_items": 0,
+            "missing_context_items": 0,
+            "by_action": {},
+            "by_market": {},
+        },
+        "facets": {"accounts": []},
+        "symbol_groups": [
+            {
+                "market_type": "CRYPTO",
+                "symbol": "KRW-BTC",
+                "name": "Bitcoin",
+                "detail_url": "/portfolio/positions/CRYPTO/KRW-BTC",
+                "position": {"components": []},
+                "journal": None,
+                "support_resistance": {"status": "unavailable"},
+                "items": items,
+                "warnings": [],
+            }
+        ],
+        "warnings": [],
+    }
+
+
+def _item(**overrides) -> dict:
+    item = {
+        "id": "item-1",
+        "action": "buy_candidate",
+        "label": "Buy candidate",
+        "priority": "medium",
+        "current_price": 150_000_000.0,
+        "action_price": 140_000_000.0,
+        "action_price_source": "support",
+        "delta_from_current_pct": -6.66,
+        "anchor": None,
+        "rationale": [],
+        "execution_boundary": {
+            "mode": "analysis_only",
+            "auto_executable": False,
+            "manual_only": True,
+        },
+        "badges": [],
+        "warnings": [],
+    }
+    item.update(overrides)
+    return item
+
+
+def _service(payload: dict) -> OrderIntentPreviewService:
+    decision_service = AsyncMock()
+    decision_service.get_decision_run = AsyncMock(return_value=payload)
+    return OrderIntentPreviewService(decision_service=decision_service)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_buy_candidate_with_action_price_yields_watch_ready_below_trigger() -> None:
+    service = _service(_payload_with_items([_item()]))
+
+    response = await service.build_preview(
+        user_id=7,
+        run_id="decision-test-run",
+        request=OrderIntentPreviewRequest(),
+    )
+
+    assert response.mode == "preview_only"
+    assert response.decision_run_id == "decision-test-run"
+    assert len(response.intents) == 1
+    intent = response.intents[0]
+    assert intent.side == "buy"
+    assert intent.intent_type == "buy_candidate"
+    assert intent.status == "watch_ready"
+    assert intent.symbol == "KRW-BTC"
+    assert intent.market == "CRYPTO"
+    assert intent.trigger is not None
+    assert intent.trigger.metric == "price"
+    assert intent.trigger.operator == "below"
+    assert intent.trigger.threshold == 140_000_000.0

--- a/tests/test_order_intent_preview_service.py
+++ b/tests/test_order_intent_preview_service.py
@@ -99,3 +99,38 @@ async def test_buy_candidate_with_action_price_yields_watch_ready_below_trigger(
     assert intent.trigger.metric == "price"
     assert intent.trigger.operator == "below"
     assert intent.trigger.threshold == 140_000_000.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_hold_items_are_excluded() -> None:
+    items = [
+        _item(id="hold-1", action="hold", action_price=None),
+        _item(id="buy-1", action="buy_candidate"),
+    ]
+    service = _service(_payload_with_items(items))
+
+    response = await service.build_preview(
+        user_id=7,
+        run_id="decision-test-run",
+        request=OrderIntentPreviewRequest(),
+    )
+
+    assert [i.decision_item_id for i in response.intents] == ["buy-1"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_manual_review_action_is_marked_manual_review_required() -> None:
+    items = [_item(id="mr-1", action="manual_review", action_price=None)]
+    service = _service(_payload_with_items(items))
+
+    response = await service.build_preview(
+        user_id=7,
+        run_id="decision-test-run",
+        request=OrderIntentPreviewRequest(),
+    )
+
+    assert len(response.intents) == 1
+    assert response.intents[0].status == "manual_review_required"
+    assert response.intents[0].trigger is None

--- a/tests/test_order_intent_preview_service.py
+++ b/tests/test_order_intent_preview_service.py
@@ -104,7 +104,7 @@ async def test_buy_candidate_with_action_price_yields_watch_ready_below_trigger(
     assert intent.trigger is not None
     assert intent.trigger.metric == "price"
     assert intent.trigger.operator == "below"
-    assert intent.trigger.threshold == 140_000_000.0
+    assert intent.trigger.threshold == pytest.approx(140_000_000.0)
 
 
 @pytest.mark.unit
@@ -167,7 +167,7 @@ async def test_trim_candidate_above_threshold_is_execution_candidate() -> None:
     assert intent.status == "execution_candidate"
     assert intent.trigger is not None
     assert intent.trigger.operator == "above"
-    assert intent.trigger.threshold == 110.0
+    assert intent.trigger.threshold == pytest.approx(110.0)
 
 
 @pytest.mark.unit
@@ -233,7 +233,7 @@ async def test_selection_override_threshold_replaces_action_price() -> None:
 
     intent = response.intents[0]
     assert intent.trigger is not None
-    assert intent.trigger.threshold == 125.0
+    assert intent.trigger.threshold == pytest.approx(125.0)
     assert intent.trigger.source == "override"
 
 
@@ -258,7 +258,7 @@ async def test_override_threshold_supplies_trigger_when_action_price_missing() -
 
     intent = response.intents[0]
     assert intent.trigger is not None
-    assert intent.trigger.threshold == 180.0
+    assert intent.trigger.threshold == pytest.approx(180.0)
     assert intent.status == "execution_candidate"
 
 
@@ -305,7 +305,7 @@ async def test_buy_budget_uses_selection_first() -> None:
     response = await service.build_preview(
         user_id=7, run_id="decision-test-run", request=request
     )
-    assert response.intents[0].budget_krw == 500_000.0
+    assert response.intents[0].budget_krw == pytest.approx(500_000.0)
 
 
 @pytest.mark.unit
@@ -323,7 +323,7 @@ async def test_buy_budget_falls_back_to_per_symbol_then_default() -> None:
     response = await service.build_preview(
         user_id=7, run_id="decision-test-run", request=per_symbol
     )
-    assert response.intents[0].budget_krw == 200_000.0
+    assert response.intents[0].budget_krw == pytest.approx(200_000.0)
 
     default_only = OrderIntentPreviewRequest(
         budget=IntentBudgetInput(default_buy_budget_krw=100_000.0),
@@ -331,7 +331,7 @@ async def test_buy_budget_falls_back_to_per_symbol_then_default() -> None:
     response = await service.build_preview(
         user_id=7, run_id="decision-test-run", request=default_only
     )
-    assert response.intents[0].budget_krw == 100_000.0
+    assert response.intents[0].budget_krw == pytest.approx(100_000.0)
 
 
 @pytest.mark.unit
@@ -363,8 +363,8 @@ async def test_sell_quantity_pct_defaults() -> None:
         user_id=7, run_id="decision-test-run", request=OrderIntentPreviewRequest()
     )
     by_id = {i.decision_item_id: i for i in response.intents}
-    assert by_id["trim-1"].quantity_pct == 30.0
-    assert by_id["sw-1"].quantity_pct == 100.0
+    assert by_id["trim-1"].quantity_pct == pytest.approx(30.0)
+    assert by_id["sw-1"].quantity_pct == pytest.approx(100.0)
 
 
 @pytest.mark.unit
@@ -383,7 +383,7 @@ async def test_sell_quantity_pct_selection_overrides_default() -> None:
     response = await service.build_preview(
         user_id=7, run_id="decision-test-run", request=request
     )
-    assert response.intents[0].quantity_pct == 55.0
+    assert response.intents[0].quantity_pct == pytest.approx(55.0)
 
 
 

--- a/tests/test_order_intent_preview_service.py
+++ b/tests/test_order_intent_preview_service.py
@@ -255,3 +255,27 @@ async def test_override_threshold_supplies_trigger_when_action_price_missing() -
     assert intent.trigger is not None
     assert intent.trigger.threshold == 180.0
     assert intent.status == "execution_candidate"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_selection_enabled_false_excludes_item() -> None:
+    items = [
+        _item(id="buy-1", action="buy_candidate"),
+        _item(id="buy-2", action="buy_candidate"),
+    ]
+    service = _service(_payload_with_items(items))
+
+    request = OrderIntentPreviewRequest(
+        selections=[
+            IntentSelectionInput(decision_item_id="buy-1", enabled=False),
+        ]
+    )
+
+    response = await service.build_preview(
+        user_id=7,
+        run_id="decision-test-run",
+        request=request,
+    )
+
+    assert [i.decision_item_id for i in response.intents] == ["buy-2"]

--- a/tests/test_order_intent_preview_service.py
+++ b/tests/test_order_intent_preview_service.py
@@ -380,3 +380,24 @@ async def test_sell_quantity_pct_selection_overrides_default() -> None:
         user_id=7, run_id="decision-test-run", request=request
     )
     assert response.intents[0].quantity_pct == 55.0
+
+
+import inspect
+
+from app.services import order_intent_preview_service as preview_module
+
+
+@pytest.mark.unit
+def test_preview_service_does_not_import_order_or_redis_modules() -> None:
+    source = inspect.getsource(preview_module)
+    forbidden = (
+        "place_order",
+        "manage_watch_alerts",
+        "redis",
+        "Redis",
+        "broker",
+        "trading_service",
+        "paperclip",
+    )
+    for needle in forbidden:
+        assert needle not in source, f"forbidden symbol '{needle}' present in preview service"

--- a/tests/test_order_intent_preview_service.py
+++ b/tests/test_order_intent_preview_service.py
@@ -402,3 +402,13 @@ def test_preview_service_does_not_import_order_or_redis_modules() -> None:
     )
     for needle in forbidden:
         assert needle not in source, f"forbidden symbol '{needle}' present in preview service"
+
+
+@pytest.mark.unit
+def test_per_symbol_budget_rejects_negative_values() -> None:
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        OrderIntentPreviewRequest.model_validate(
+            {"budget": {"per_symbol_budget_krw": {"KRW-BTC": -1.0}}}
+        )

--- a/tests/test_order_intent_preview_service.py
+++ b/tests/test_order_intent_preview_service.py
@@ -1,8 +1,14 @@
+import inspect
 from unittest.mock import AsyncMock
 
 import pytest
 
-from app.schemas.order_intent_preview import OrderIntentPreviewRequest
+from app.schemas.order_intent_preview import (
+    IntentBudgetInput,
+    IntentSelectionInput,
+    OrderIntentPreviewRequest,
+)
+from app.services import order_intent_preview_service as preview_module
 from app.services.order_intent_preview_service import OrderIntentPreviewService
 
 
@@ -205,7 +211,6 @@ async def test_trim_candidate_without_action_price_is_manual_review_required() -
     assert intent.trigger is None
 
 
-from app.schemas.order_intent_preview import IntentSelectionInput
 
 
 @pytest.mark.unit
@@ -281,7 +286,6 @@ async def test_selection_enabled_false_excludes_item() -> None:
     assert [i.decision_item_id for i in response.intents] == ["buy-2"]
 
 
-from app.schemas.order_intent_preview import IntentBudgetInput
 
 
 @pytest.mark.unit
@@ -382,9 +386,6 @@ async def test_sell_quantity_pct_selection_overrides_default() -> None:
     assert response.intents[0].quantity_pct == 55.0
 
 
-import inspect
-
-from app.services import order_intent_preview_service as preview_module
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- 신규 엔드포인트 `POST /portfolio/api/decision-runs/{run_id}/intent-preview` 추가 — 저장된 Decision Desk snapshot + 사용자가 입력한 budget/selections를 받아 **순수 변환**으로 Order Intent Preview JSON을 반환한다 (`mode: "preview_only"`).
- 어떠한 side effect도 없음: 주문 실행, Redis write, watch 등록, broker 호출, paperclip 호출 모두 하지 않는다 — 구조 가드 테스트(`test_preview_service_does_not_import_order_or_redis_modules`)로 보장.
- 기존 Decision Desk 엔드포인트(`/api/decision-runs/{run_id}` 등) 동작은 변경 없음.

## 구현 내용

**신규 파일:**
- `app/schemas/order_intent_preview.py` — `OrderIntentPreviewRequest/Response`, `IntentBudgetInput`, `IntentSelectionInput`, `IntentTriggerPreview`, `OrderIntentPreviewItem` Pydantic 모델.
- `app/services/order_intent_preview_service.py` — `OrderIntentPreviewService.build_preview()` 단일 진입점. `PortfolioDecisionService.get_decision_run`을 통해 payload를 읽고 item별로 trigger/budget/quantity/status를 계산.
- `tests/test_order_intent_preview_service.py` (15 cases) + `tests/test_order_intent_preview_router.py` (2 cases).

**수정:**
- `app/routers/portfolio.py` — `get_order_intent_preview_service` DI provider + endpoint 추가, 기존 `get_authenticated_user` 인증 + `PortfolioDecisionRunNotFoundError → 404` 패턴 그대로 사용.

## 핵심 규칙

- `hold` item, `selection.enabled=false` item은 제외.
- `buy_candidate → buy`, `trim_candidate/sell_watch → sell`, `manual_review → manual_review_required`(trigger=null).
- Trigger threshold 우선순위: `selection.override_threshold` → `item.action_price`. 없으면 `manual_review_required`.
- Buy budget 우선순위: `selection.budget_krw` → `budget.per_symbol_budget_krw[symbol]` → `budget.default_buy_budget_krw` → `null` + `"missing_buy_budget"` warning.
- Sell `quantity_pct`: `selection.quantity_pct` 없으면 기본값 `trim_candidate=30`, `sell_watch=100`.
- Sell status: `current_price >= threshold` → `execution_candidate`, 그 외 → `watch_ready`.

## Test plan

- [x] `uv run pytest tests/test_order_intent_preview_service.py tests/test_order_intent_preview_router.py -v` — 17 passed.
- [x] `uv run pytest tests/test_portfolio_decision_router.py tests/test_portfolio_decision_service.py tests/test_portfolio_decision_run_model.py -v` — 22 passed (회귀 영향 없음).
- [x] `uv run ruff check` 신규/수정 5개 파일 모두 통과.
- [ ] (수동) 실제 `run_id`로 curl 호출 후 응답에 `"mode": "preview_only"` 확인, Redis `watch_alerts:*` / `model_rate_limit:*` 키 변화 없음 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Order intent preview: submit budgets, per-item selections, and execution mode to preview how portfolio decisions would become orders—shows intents, execution status, price triggers, budgets/quantities, rationales, and warnings.
  * Input validation: budgets, percentages, thresholds, and execution modes are validated with sensible defaults.
* **Tests**
  * Added unit tests covering preview behavior, validation, and various decision-item scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->