### PR TITLE
ci: add macOS native production deploy

### DIFF
--- a/.github/workflows/deploy-macos-native.yml
+++ b/.github/workflows/deploy-macos-native.yml
@@ -28,22 +28,27 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Tailscale
-        uses: tailscale/github-action@v3
+        uses: tailscale/github-action@v4
         with:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 
-      - name: Configure SSH key
+      - name: Configure SSH key and known host
         shell: bash
         env:
+          MACBOOK_DEPLOY_SSH_HOST: ${{ secrets.MACBOOK_DEPLOY_SSH_HOST }}
+          MACBOOK_DEPLOY_SSH_HOST_KEY: ${{ secrets.MACBOOK_DEPLOY_SSH_HOST_KEY }}
           MACBOOK_DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.MACBOOK_DEPLOY_SSH_PRIVATE_KEY }}
         run: |
           set -euo pipefail
           install -d -m 700 ~/.ssh
           printf '%s\n' "$MACBOOK_DEPLOY_SSH_PRIVATE_KEY" > ~/.ssh/auto_trader_deploy_key
           chmod 600 ~/.ssh/auto_trader_deploy_key
+          deploy_host="${MACBOOK_DEPLOY_SSH_HOST#*@}"
+          printf '%s %s\n' "$deploy_host" "$MACBOOK_DEPLOY_SSH_HOST_KEY" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
 
       - name: Deploy via SSH
         id: deploy
@@ -59,12 +64,15 @@ jobs:
           ssh_opts=(
             -i ~/.ssh/auto_trader_deploy_key
             -o IdentitiesOnly=yes
-            -o StrictHostKeyChecking=accept-new
+            -o StrictHostKeyChecking=yes
+            -o UserKnownHostsFile=~/.ssh/known_hosts
             -o ConnectTimeout=30
           )
 
+          deploy_sha_q=$(printf '%q' "$DEPLOY_SHA")
+          deploy_branch_q=$(printf '%q' "$DEPLOY_BRANCH")
           ssh "${ssh_opts[@]}" "$MACBOOK_DEPLOY_SSH_HOST" \
-            "tmp=\$(mktemp /tmp/auto-trader-deploy-native.XXXXXX) && cat > \$tmp && chmod +x \$tmp && \$tmp '$DEPLOY_SHA' '$DEPLOY_BRANCH'; rc=\$?; rm -f \$tmp; exit \$rc" \
+            "tmp=\$(mktemp /tmp/auto-trader-deploy-native.XXXXXX) && cat > \$tmp && chmod +x \$tmp && \$tmp $deploy_sha_q $deploy_branch_q; rc=\$?; rm -f \$tmp; exit \$rc" \
             < scripts/deploy-native.sh 2>&1 | tee /tmp/deploy-output.txt
 
       - name: Discord notification (success)

--- a/.github/workflows/deploy-macos-native.yml
+++ b/.github/workflows/deploy-macos-native.yml
@@ -1,0 +1,131 @@
+name: Deploy MacBook Native Production
+
+on:
+  push:
+    branches: [production]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Commit SHA to deploy (defaults to the workflow commit)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: auto-trader-macos-native-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to MacBook native launchd
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: production
+    env:
+      DISCORD_DEPLOY_WEBHOOK_URL: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+
+      - name: Configure SSH key
+        shell: bash
+        env:
+          MACBOOK_DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.MACBOOK_DEPLOY_SSH_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          install -d -m 700 ~/.ssh
+          printf '%s\n' "$MACBOOK_DEPLOY_SSH_PRIVATE_KEY" > ~/.ssh/auto_trader_deploy_key
+          chmod 600 ~/.ssh/auto_trader_deploy_key
+
+      - name: Deploy via SSH
+        id: deploy
+        shell: bash
+        env:
+          MACBOOK_DEPLOY_SSH_HOST: ${{ secrets.MACBOOK_DEPLOY_SSH_HOST }}
+          DEPLOY_SHA: ${{ github.event.inputs.sha || github.sha }}
+          DEPLOY_BRANCH: production
+        run: |
+          set -euo pipefail
+          test -s scripts/deploy-native.sh
+
+          ssh_opts=(
+            -i ~/.ssh/auto_trader_deploy_key
+            -o IdentitiesOnly=yes
+            -o StrictHostKeyChecking=accept-new
+            -o ConnectTimeout=30
+          )
+
+          ssh "${ssh_opts[@]}" "$MACBOOK_DEPLOY_SSH_HOST" \
+            "tmp=\$(mktemp /tmp/auto-trader-deploy-native.XXXXXX) && cat > \$tmp && chmod +x \$tmp && \$tmp '$DEPLOY_SHA' '$DEPLOY_BRANCH'; rc=\$?; rm -f \$tmp; exit \$rc" \
+            < scripts/deploy-native.sh 2>&1 | tee /tmp/deploy-output.txt
+
+      - name: Discord notification (success)
+        if: success() && env.DISCORD_DEPLOY_WEBHOOK_URL != ''
+        env:
+          DISCORD_WEBHOOK: ${{ env.DISCORD_DEPLOY_WEBHOOK_URL }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 - <<'PY' >/tmp/discord-payload.json
+          import json, os
+          sha = os.environ["COMMIT_SHA"]
+          payload = {
+              "embeds": [{
+                  "title": "✅ Auto Trader MacBook native 배포 완료",
+                  "description": (
+                      f"**Branch:** `{os.environ['BRANCH_NAME']}`\n"
+                      f"**Commit:** [`{sha[:7]}`]({os.environ['COMMIT_URL']})\n"
+                      f"**Run:** [#{os.environ['RUN_NUMBER']}]({os.environ['RUN_URL']})"
+                  ),
+                  "color": 5763719,
+                  "footer": {"text": "auto_trader macOS native production"},
+              }]
+          }
+          print(json.dumps(payload, ensure_ascii=False))
+          PY
+          curl -s -H "Content-Type: application/json" --data @/tmp/discord-payload.json "$DISCORD_WEBHOOK"
+
+      - name: Discord notification (failure)
+        if: failure() && env.DISCORD_DEPLOY_WEBHOOK_URL != ''
+        env:
+          DISCORD_WEBHOOK: ${{ env.DISCORD_DEPLOY_WEBHOOK_URL }}
+          BRANCH_NAME: ${{ github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 - <<'PY' >/tmp/discord-payload.json
+          import json, os, pathlib
+          sha = os.environ["COMMIT_SHA"]
+          log_path = pathlib.Path("/tmp/deploy-output.txt")
+          deploy_log = "No deploy log available"
+          if log_path.exists():
+              deploy_log = "\n".join(log_path.read_text(errors="replace").splitlines()[-20:])[:1500]
+          payload = {
+              "embeds": [{
+                  "title": "❌ Auto Trader MacBook native 배포 실패",
+                  "description": (
+                      f"**Branch:** `{os.environ['BRANCH_NAME']}`\n"
+                      f"**Commit:** [`{sha[:7]}`]({os.environ['COMMIT_URL']})\n"
+                      f"**Run:** [#{os.environ['RUN_NUMBER']}]({os.environ['RUN_URL']})\n\n"
+                      f"**Log:**\n```\n{deploy_log}\n```"
+                  ),
+                  "color": 15548997,
+                  "footer": {"text": "auto_trader macOS native production"},
+              }]
+          }
+          print(json.dumps(payload, ensure_ascii=False))
+          PY
+          curl -s -H "Content-Type: application/json" --data @/tmp/discord-payload.json "$DISCORD_WEBHOOK"

--- a/.github/workflows/deploy-macos-native.yml
+++ b/.github/workflows/deploy-macos-native.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Tailscale
-        uses: tailscale/github-action@v4
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4
         with:
           authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
 

--- a/scripts/deploy-native.sh
+++ b/scripts/deploy-native.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env bash
 set -euo pipefail
 
 usage() {
@@ -87,14 +87,12 @@ restart_services() {
   done
 }
 
-run_healthcheck() {
+run_healthcheck_once() {
   if [[ -x "$SERVER_HEALTHCHECK" ]]; then
-    log "Running server native healthcheck: $SERVER_HEALTHCHECK"
     "$SERVER_HEALTHCHECK"
     return $?
   fi
 
-  log "Running built-in native healthcheck fallback"
   local rc=0 code
 
   curl -fsS http://127.0.0.1:8000/healthz >/dev/null || {
@@ -120,6 +118,33 @@ run_healthcheck() {
   fi
 
   return $rc
+}
+
+run_healthcheck() {
+  local attempts="${AUTO_TRADER_HEALTHCHECK_ATTEMPTS:-6}"
+  local interval="${AUTO_TRADER_HEALTHCHECK_INTERVAL_SECONDS:-5}"
+  local attempt
+
+  if [[ -x "$SERVER_HEALTHCHECK" ]]; then
+    log "Running server native healthcheck with retries: $SERVER_HEALTHCHECK"
+  else
+    log "Running built-in native healthcheck fallback with retries"
+  fi
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    log "Healthcheck attempt $attempt/$attempts"
+    if run_healthcheck_once; then
+      log "Healthcheck passed"
+      return 0
+    fi
+
+    if (( attempt < attempts )); then
+      sleep "$interval"
+    fi
+  done
+
+  echo "Healthcheck failed after $attempts attempts" >&2
+  return 1
 }
 
 rollback() {
@@ -154,6 +179,11 @@ log "New release: $NEW_RELEASE"
 
 log "Fetching source repository"
 git -C "$SOURCE_REPO" fetch origin "$BRANCH" --tags
+if ! git -C "$SOURCE_REPO" cat-file -e "$SHA^{commit}" 2>/dev/null; then
+  log "Commit not found after branch fetch; trying explicit SHA fetch"
+  git -C "$SOURCE_REPO" fetch origin "$SHA" --tags || \
+    git -C "$SOURCE_REPO" fetch origin '+refs/heads/*:refs/remotes/origin/*' --tags
+fi
 git -C "$SOURCE_REPO" cat-file -e "$SHA^{commit}"
 
 if [[ ! -d "$NEW_RELEASE/.git" ]]; then
@@ -165,12 +195,15 @@ cd "$NEW_RELEASE"
 log "Preparing release checkout"
 git fetch origin "$BRANCH" --tags
 git checkout --detach "$SHA"
-git clean -fdx
+git clean -fdx -e .venv
 
 log "Installing dependencies with uv"
 uv sync --frozen
 
 log "Running Alembic migrations"
+# Online deploy rollback only reverts code/services. Production migrations must be
+# expansion-only/backwards-compatible with the previous release; do not merge
+# destructive downgrades into this path without a separate data rollback runbook.
 ENV_FILE="$SHARED_ENV" uv run alembic upgrade head
 
 log "Switching current symlink"

--- a/scripts/deploy-native.sh
+++ b/scripts/deploy-native.sh
@@ -1,0 +1,187 @@
+#!/bin/zsh
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE' >&2
+Usage: scripts/deploy-native.sh <commit-sha> [branch]
+
+Deploys auto_trader to a macOS native launchd production layout:
+  $AUTO_TRADER_BASE/releases/<sha>
+  $AUTO_TRADER_BASE/current -> releases/<sha>
+
+Expected server-side layout defaults:
+  AUTO_TRADER_BASE=/Users/mgh3326/services/auto_trader
+  AUTO_TRADER_SOURCE_REPO=/Users/mgh3326/work/auto_trader
+  AUTO_TRADER_ENV_FILE=$AUTO_TRADER_BASE/shared/.env.prod.native
+USAGE
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 64
+fi
+
+SHA="$1"
+BRANCH="${2:-production}"
+
+if ! printf '%s' "$SHA" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+  echo "Expected a full 40-character git commit SHA, got: $SHA" >&2
+  exit 64
+fi
+
+export HOME="${HOME:-/Users/mgh3326}"
+export PATH="$HOME/.local/bin:$HOME/.hermes/node/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+BASE="${AUTO_TRADER_BASE:-$HOME/services/auto_trader}"
+RELEASES="$BASE/releases"
+CURRENT="$BASE/current"
+SOURCE_REPO="${AUTO_TRADER_SOURCE_REPO:-$HOME/work/auto_trader}"
+SHARED_ENV="${AUTO_TRADER_ENV_FILE:-$BASE/shared/.env.prod.native}"
+LOG_DIR="$BASE/logs"
+PLIST_DIR="${AUTO_TRADER_PLIST_DIR:-$BASE/plists}"
+SERVER_HEALTHCHECK="$BASE/scripts/healthcheck-native.sh"
+
+LABELS=(
+  "com.robinco.auto-trader.api"
+  "com.robinco.auto-trader.mcp"
+  "com.robinco.auto-trader.worker"
+  "com.robinco.auto-trader.scheduler"
+  "com.robinco.auto-trader.kis-websocket"
+  "com.robinco.auto-trader.upbit-websocket"
+)
+
+NEW_RELEASE="$RELEASES/$SHA"
+PREVIOUS_RELEASE="$(readlink "$CURRENT" 2>/dev/null || true)"
+SWITCHED=0
+
+log() {
+  printf '[%s] %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*"
+}
+
+require_file() {
+  local path="$1"
+  if [[ ! -f "$path" ]]; then
+    echo "Missing required file: $path" >&2
+    exit 78
+  fi
+}
+
+restart_services() {
+  local uid_num label plist target
+  uid_num="$(id -u)"
+
+  for label in "${LABELS[@]}"; do
+    plist="$PLIST_DIR/$label.plist"
+    target="$HOME/Library/LaunchAgents/$label.plist"
+
+    if [[ ! -f "$plist" ]]; then
+      echo "Missing launchd plist: $plist" >&2
+      return 78
+    fi
+
+    install -m 0644 "$plist" "$target"
+    launchctl bootout "gui/$uid_num/$label" 2>/dev/null || true
+    launchctl bootstrap "gui/$uid_num" "$target"
+    launchctl enable "gui/$uid_num/$label"
+    launchctl kickstart -k "gui/$uid_num/$label"
+  done
+}
+
+run_healthcheck() {
+  if [[ -x "$SERVER_HEALTHCHECK" ]]; then
+    log "Running server native healthcheck: $SERVER_HEALTHCHECK"
+    "$SERVER_HEALTHCHECK"
+    return $?
+  fi
+
+  log "Running built-in native healthcheck fallback"
+  local rc=0 code
+
+  curl -fsS http://127.0.0.1:8000/healthz >/dev/null || {
+    echo "API healthz failed" >&2
+    rc=1
+  }
+
+  code="$(curl -sS -o /dev/null -w '%{http_code}' -H 'Accept: text/event-stream' http://127.0.0.1:8765/mcp || true)"
+  if [[ "$code" != "401" && "$code" != "400" ]]; then
+    echo "MCP unexpected status: $code" >&2
+    rc=1
+  fi
+
+  if [[ -f "$CURRENT/scripts/websocket_healthcheck.py" ]]; then
+    WS_MONITOR_HEARTBEAT_PATH="$BASE/state/heartbeat/kis.json" \
+      WS_MONITOR_EXPECT_MODE=kis \
+      uv run python scripts/websocket_healthcheck.py || rc=1
+    WS_MONITOR_HEARTBEAT_PATH="$BASE/state/heartbeat/upbit.json" \
+      WS_MONITOR_EXPECT_MODE=upbit \
+      uv run python scripts/websocket_healthcheck.py || rc=1
+  else
+    echo "websocket_healthcheck.py not found; skipping websocket heartbeat checks" >&2
+  fi
+
+  return $rc
+}
+
+rollback() {
+  local exit_code=$?
+  echo "Deploy failed with exit code $exit_code" >&2
+
+  if [[ "$SWITCHED" == "1" && -n "${PREVIOUS_RELEASE:-}" && -d "$PREVIOUS_RELEASE" ]]; then
+    echo "Rolling back current symlink to: $PREVIOUS_RELEASE" >&2
+    ln -sfn "$PREVIOUS_RELEASE" "$CURRENT"
+    restart_services || true
+  else
+    echo "No symlink switch happened, or previous release is unavailable; skipping rollback restart" >&2
+  fi
+
+  exit "$exit_code"
+}
+
+trap rollback ERR
+
+require_file "$SHARED_ENV"
+mkdir -p "$RELEASES" "$LOG_DIR" "$BASE/state/heartbeat"
+
+if [[ ! -d "$SOURCE_REPO/.git" ]]; then
+  echo "Missing source git repository: $SOURCE_REPO" >&2
+  exit 78
+fi
+
+log "Deploying auto_trader commit $SHA from $BRANCH"
+log "Base: $BASE"
+log "Source repo: $SOURCE_REPO"
+log "New release: $NEW_RELEASE"
+
+log "Fetching source repository"
+git -C "$SOURCE_REPO" fetch origin "$BRANCH" --tags
+git -C "$SOURCE_REPO" cat-file -e "$SHA^{commit}"
+
+if [[ ! -d "$NEW_RELEASE/.git" ]]; then
+  log "Creating release checkout"
+  git clone --local "$SOURCE_REPO" "$NEW_RELEASE"
+fi
+
+cd "$NEW_RELEASE"
+log "Preparing release checkout"
+git fetch origin "$BRANCH" --tags
+git checkout --detach "$SHA"
+git clean -fdx
+
+log "Installing dependencies with uv"
+uv sync --frozen
+
+log "Running Alembic migrations"
+ENV_FILE="$SHARED_ENV" uv run alembic upgrade head
+
+log "Switching current symlink"
+ln -sfn "$NEW_RELEASE" "$CURRENT"
+SWITCHED=1
+
+log "Restarting launchd services"
+restart_services
+
+log "Running healthcheck"
+run_healthcheck
+
+trap - ERR
+log "Deploy complete: $SHA"


### PR DESCRIPTION
## Summary
- Add `scripts/deploy-native.sh` for MacBook native launchd production releases under `/Users/mgh3326/services/auto_trader`.
- Add `.github/workflows/deploy-macos-native.yml` to deploy `production` pushes over Tailscale SSH.
- Deploy flow creates `releases/<sha>`, runs `uv sync --frozen`, applies Alembic migrations, atomically switches `current`, restarts launchd services, runs bounded health checks, and rolls back code/services on post-switch failure.

## GitHub Environment / Secrets required
Create or update the `production` environment with:
- `TAILSCALE_AUTHKEY` — ephemeral/reusable Tailscale auth key for GitHub Actions to join the tailnet.
- `MACBOOK_DEPLOY_SSH_HOST` — SSH target for the MacBook server, e.g. `mgh3326@<tailscale-hostname-or-ip>`.
- `MACBOOK_DEPLOY_SSH_HOST_KEY` — pinned SSH host public key for the MacBook target, e.g. the `ssh-ed25519 ...` value from `ssh-keyscan`/`~/.ssh/known_hosts` without the hostname prefix.
- `MACBOOK_DEPLOY_SSH_PRIVATE_KEY` — private key whose public key is authorized on the MacBook deploy account.
- `DISCORD_DEPLOY_WEBHOOK_URL` — optional webhook for success/failure deploy notifications.

## Test Plan
- [x] `bash -n scripts/deploy-native.sh`
- [x] `scripts/deploy-native.sh bad-sha` exits with usage validation code
- [x] Workflow YAML parses with Ruby YAML loader
- [x] `git diff --check -- .github/workflows/deploy-macos-native.yml scripts/deploy-native.sh`

## Risk / Review
This touches deployment automation for production, so please treat as `high_risk_change` and review rollback, secret scope, and server-side path assumptions before merging to production.

Rollback note: automated rollback reverts the code symlink and launchd services. Alembic migrations in this path must remain expansion-only/backwards-compatible; destructive DB rollback requires a separate operator runbook.
