### PR TITLE
ci: disable legacy production deploy trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,7 @@
 name: Deploy to GHCR
 
 on:
-  push:
-    branches: [ production ]
+  workflow_dispatch:
   release:
     types: [ published ]
 


### PR DESCRIPTION
## Summary
- Remove the automatic `push` trigger for `production` from the legacy `Deploy to GHCR` workflow.
- Keep the legacy workflow available via `workflow_dispatch` and published releases.
- This prevents the old Raspberry Pi/Docker SSH deploy path from running when `production` is updated for the MacBook native launchd deploy workflow.

## Test Plan
- [x] Workflow YAML parses with Ruby YAML loader
- [x] `git diff --check -- .github/workflows/deploy.yml`

## Risk / Review
This changes production deployment routing. After this lands, `production` pushes should trigger the new MacBook native workflow, while the legacy GHCR workflow should no longer auto-run on branch pushes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated deployment workflow to require manual trigger instead of automatic deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->