### PR TITLE
ci: remove deploy key fingerprint logging

### DIFF
--- a/.github/workflows/deploy-macos-native.yml
+++ b/.github/workflows/deploy-macos-native.yml
@@ -46,8 +46,6 @@ jobs:
           install -d -m 700 ~/.ssh
           printf '%s\n' "$MACBOOK_DEPLOY_SSH_PRIVATE_KEY" > ~/.ssh/auto_trader_deploy_key
           chmod 600 ~/.ssh/auto_trader_deploy_key
-          echo "Deploy SSH public key fingerprint:"
-          ssh-keygen -y -f ~/.ssh/auto_trader_deploy_key | ssh-keygen -lf -
           deploy_host="${MACBOOK_DEPLOY_SSH_HOST#*@}"
           printf '%s %s\n' "$deploy_host" "$MACBOOK_DEPLOY_SSH_HOST_KEY" > ~/.ssh/known_hosts
           chmod 600 ~/.ssh/known_hosts


### PR DESCRIPTION
## Summary
- Remove deploy SSH public key fingerprint logging from the MacBook native production deploy workflow.
- Keeps strict host key checking and SSH key setup unchanged.

## Why
The production deploy succeeded, but the workflow file still contained diagnostic fingerprint logging. A public key fingerprint is not private key material, but the repository is public and the value is unnecessary infrastructure metadata, so avoid printing it in future runs.

## Validation
- `git diff --check -- .github/workflows/deploy-macos-native.yml`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy-macos-native.yml'); puts 'YAML parsed with ruby'"`