### PR TITLE
feat(intent-preview): use public base URL for Discord links

### DIFF
--- a/app/routers/portfolio.py
+++ b/app/routers/portfolio.py
@@ -12,6 +12,7 @@ from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.db import get_db
 from app.core.templates import templates
 from app.models.manual_holdings import MarketType
@@ -48,7 +49,10 @@ from app.services.ai_providers.base import AiProviderError
 from app.services.brokers.kis.client import KISClient
 from app.services.kis_holdings_service import get_kis_holding_for_ticker
 from app.services.merged_portfolio_service import MergedPortfolioService
-from app.services.order_intent_discord_brief import build_decision_desk_url
+from app.services.order_intent_discord_brief import (
+    build_decision_desk_url,
+    resolve_decision_desk_base_url,
+)
 from app.services.order_intent_preview_service import OrderIntentPreviewService
 from app.services.portfolio_dashboard_service import PortfolioDashboardService
 from app.services.portfolio_decision_service import (
@@ -224,10 +228,11 @@ async def preview_order_intents_for_decision_run(
         OrderIntentPreviewService, Depends(get_order_intent_preview_service)
     ],
 ) -> OrderIntentPreviewResponse:
-    # TODO(follow-up): respect PUBLIC_BASE_URL / X-Forwarded-* origin once
-    # the public Decision Desk URL diverges from request.base_url under
-    # proxies. For now request.base_url works for direct + standard setups.
-    decision_desk_url = build_decision_desk_url(str(request.base_url), run_id)
+    base_url = resolve_decision_desk_base_url(
+        configured=settings.public_base_url,
+        request_base_url=str(request.base_url),
+    )
+    decision_desk_url = build_decision_desk_url(base_url, run_id)
     try:
         return await preview_service.build_preview(
             user_id=current_user.id,

--- a/app/services/order_intent_discord_brief.py
+++ b/app/services/order_intent_discord_brief.py
@@ -36,6 +36,21 @@ def build_decision_desk_url(base_url: str, run_id: str) -> str:
     return f"{base}/portfolio/decision?run_id={quote(run_id, safe='')}"
 
 
+def resolve_decision_desk_base_url(
+    *, configured: str | None, request_base_url: str
+) -> str:
+    """Pick the configured public base URL when set, else fall back.
+
+    Pure function — no settings/env access. The caller (router) supplies
+    `configured` from `settings.public_base_url` and `request_base_url`
+    from `request.base_url`. Whitespace-only or empty configured values
+    are treated as unset so the request origin remains the fallback.
+    """
+    if configured is not None and configured.strip():
+        return configured.strip()
+    return request_base_url
+
+
 def format_discord_brief(
     *,
     preview: OrderIntentPreviewResponse,

--- a/tests/test_order_intent_discord_brief.py
+++ b/tests/test_order_intent_discord_brief.py
@@ -12,12 +12,68 @@ from app.services import order_intent_discord_brief as brief_module
 from app.services.order_intent_discord_brief import (
     build_decision_desk_url,
     format_discord_brief,
+    resolve_decision_desk_base_url,
 )
 
 
 @pytest.mark.unit
 def test_build_decision_desk_url_strips_trailing_slash() -> None:
     url = build_decision_desk_url("https://trader.robinco.dev/", "decision-r1")
+    assert url == "https://trader.robinco.dev/portfolio/decision?run_id=decision-r1"
+
+
+@pytest.mark.unit
+def test_resolve_base_url_uses_configured_when_set() -> None:
+    resolved = resolve_decision_desk_base_url(
+        configured="https://trader.robinco.dev",
+        request_base_url="http://127.0.0.1:8000/",
+    )
+    assert resolved == "https://trader.robinco.dev"
+
+
+@pytest.mark.unit
+def test_resolve_base_url_strips_surrounding_whitespace_in_configured() -> None:
+    resolved = resolve_decision_desk_base_url(
+        configured="  https://trader.robinco.dev/  ",
+        request_base_url="http://127.0.0.1:8000/",
+    )
+    assert resolved == "https://trader.robinco.dev/"
+
+
+@pytest.mark.unit
+def test_resolve_base_url_falls_back_when_configured_is_none() -> None:
+    resolved = resolve_decision_desk_base_url(
+        configured=None,
+        request_base_url="http://127.0.0.1:8000/",
+    )
+    assert resolved == "http://127.0.0.1:8000/"
+
+
+@pytest.mark.unit
+def test_resolve_base_url_falls_back_when_configured_is_empty() -> None:
+    resolved = resolve_decision_desk_base_url(
+        configured="",
+        request_base_url="http://127.0.0.1:8000/",
+    )
+    assert resolved == "http://127.0.0.1:8000/"
+
+
+@pytest.mark.unit
+def test_resolve_base_url_falls_back_when_configured_is_whitespace() -> None:
+    resolved = resolve_decision_desk_base_url(
+        configured="   ",
+        request_base_url="http://127.0.0.1:8000/",
+    )
+    assert resolved == "http://127.0.0.1:8000/"
+
+
+@pytest.mark.unit
+def test_resolve_then_build_normalises_trailing_slash() -> None:
+    base = resolve_decision_desk_base_url(
+        configured="https://trader.robinco.dev/",
+        request_base_url="http://127.0.0.1:8000/",
+    )
+    url = build_decision_desk_url(base, "decision-r1")
     assert url == "https://trader.robinco.dev/portfolio/decision?run_id=decision-r1"
 
 

--- a/tests/test_order_intent_preview_router.py
+++ b/tests/test_order_intent_preview_router.py
@@ -136,3 +136,65 @@ def test_preview_endpoint_response_includes_discord_brief_with_run_path() -> Non
     assert "/portfolio/decision?run_id=decision-r1" in body["discord_brief"]
     assert "Mode: `preview_only`" in body["discord_brief"]
     assert "This is preview-only." in body["discord_brief"]
+
+
+@pytest.mark.unit
+def test_preview_endpoint_uses_public_base_url_when_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        portfolio.settings, "public_base_url", "https://trader.robinco.dev/"
+    )
+    client = _make_client_with_real_preview_service()
+
+    response = client.post(
+        "/portfolio/api/decision-runs/decision-r1/intent-preview",
+        json={
+            "budget": {"default_buy_budget_krw": 100000},
+            "selections": [],
+            "execution_mode": "requires_final_approval",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    brief = body["discord_brief"]
+    assert brief is not None
+    assert (
+        "Decision Desk: https://trader.robinco.dev/portfolio/decision?"
+        "run_id=decision-r1"
+    ) in brief
+    # Safety lines must remain intact.
+    for needle in (
+        "This is preview-only.",
+        "No orders were placed.",
+        "No watch alerts were registered.",
+        "Final approval is still required before any execution.",
+    ):
+        assert needle in brief
+
+
+@pytest.mark.unit
+def test_preview_endpoint_falls_back_to_request_base_url_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(portfolio.settings, "public_base_url", "")
+    client = _make_client_with_real_preview_service()
+
+    response = client.post(
+        "/portfolio/api/decision-runs/decision-r1/intent-preview",
+        json={
+            "budget": {"default_buy_budget_krw": 100000},
+            "selections": [],
+            "execution_mode": "requires_final_approval",
+        },
+    )
+
+    assert response.status_code == 200
+    brief = response.json()["discord_brief"]
+    assert brief is not None
+    # TestClient's default base URL is http://testserver/.
+    assert (
+        "Decision Desk: http://testserver/portfolio/decision?run_id=decision-r1"
+    ) in brief
+    assert "https://trader.robinco.dev" not in brief


### PR DESCRIPTION
## Summary
- Use configured `PUBLIC_BASE_URL` when generating Discord brief / intent-preview links
- Preserve safe fallback behavior when the setting is empty or malformed
- Add router and Discord brief tests covering `https://trader.robinco.dev` URL generation

## Environment note
Production native launchd services read:

```text
/Users/mgh3326/services/auto_trader/shared/.env.prod.native
```

This file already contains:

```text
PUBLIC_BASE_URL=https://trader.robinco.dev
```

So after this PR is merged and deployed, generated links should use the intended public trader URL. If the API process was already running before env changes, restart `com.robinco.auto-trader.api` after deployment.

## Test Plan
- [x] `uv run pytest tests/test_order_intent_discord_brief.py tests/test_order_intent_preview_router.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Decision Desk link generation in order previews to intelligently resolve base URLs using configured settings. Links now behave consistently across different deployment configurations and access domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->