### PR TITLE
feat(trading-decision): ROB-2 API contract endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -38,6 +38,7 @@ from app.routers import (
     symbol_settings,
     test,
     trading,
+    trading_decisions,
     user_defaults,
     websocket,
 )
@@ -160,6 +161,7 @@ def create_app() -> FastAPI:
     app.include_router(ai_markdown.router)
     app.include_router(deprecated_pages.router)
     app.include_router(trading.router)
+    app.include_router(trading_decisions.router)
     app.include_router(kospi200.router)
     app.include_router(websocket.router)
     if settings.EXPOSE_MONITORING_TEST_ROUTES:

--- a/app/routers/trading_decisions.py
+++ b/app/routers/trading_decisions.py
@@ -1,4 +1,5 @@
 """Trading decisions API router."""
+
 from datetime import UTC, datetime
 from typing import Annotated
 from uuid import UUID
@@ -102,12 +103,16 @@ def _to_proposal_detail(proposal) -> ProposalDetail:
         user_threshold_pct=proposal.user_threshold_pct,
         user_note=proposal.user_note,
         actions=[_to_action_detail(a) for a in proposal.actions],
-        counterfactuals=[_to_counterfactual_detail(c) for c in proposal.counterfactuals],
+        counterfactuals=[
+            _to_counterfactual_detail(c) for c in proposal.counterfactuals
+        ],
         outcomes=[_to_outcome_detail(o) for o in proposal.outcomes],
     )
 
 
-def _to_session_summary(session, proposals_count: int, pending_count: int) -> SessionSummary:
+def _to_session_summary(
+    session, proposals_count: int, pending_count: int
+) -> SessionSummary:
     return SessionSummary(
         session_uuid=session.session_uuid,
         source_profile=session.source_profile,
@@ -156,7 +161,9 @@ async def list_decisions(
         status=status,
     )
 
-    sessions = [_to_session_summary(session, count, pending) for session, count, pending in rows]
+    sessions = [
+        _to_session_summary(session, count, pending) for session, count, pending in rows
+    ]
 
     return SessionListResponse(
         sessions=sessions,
@@ -166,7 +173,9 @@ async def list_decisions(
     )
 
 
-@router.post("/api/decisions", response_model=SessionDetail, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/api/decisions", response_model=SessionDetail, status_code=status.HTTP_201_CREATED
+)
 async def create_decision(
     request: SessionCreateRequest,
     response: Response,

--- a/app/routers/trading_decisions.py
+++ b/app/routers/trading_decisions.py
@@ -1,0 +1,480 @@
+"""Trading decisions API router."""
+from datetime import UTC, datetime
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.models.trading import User
+from app.routers.dependencies import get_authenticated_user
+from app.schemas.trading_decisions import (
+    ActionCreateRequest,
+    ActionDetail,
+    CounterfactualCreateRequest,
+    CounterfactualDetail,
+    OutcomeCreateRequest,
+    OutcomeDetail,
+    ProposalCreateBulkRequest,
+    ProposalCreateBulkResponse,
+    ProposalDetail,
+    ProposalRespondRequest,
+    SessionCreateRequest,
+    SessionDetail,
+    SessionListResponse,
+    SessionStatusLiteral,
+    SessionSummary,
+)
+from app.services import trading_decision_service
+
+router = APIRouter(prefix="/trading", tags=["trading-decisions"])
+
+
+def _to_action_detail(action) -> ActionDetail:
+    return ActionDetail(
+        id=action.id,
+        action_kind=action.action_kind,
+        external_order_id=action.external_order_id,
+        external_paper_id=action.external_paper_id,
+        external_watch_id=action.external_watch_id,
+        external_source=action.external_source,
+        payload_snapshot=action.payload_snapshot,
+        recorded_at=action.recorded_at,
+        created_at=action.created_at,
+    )
+
+
+def _to_counterfactual_detail(cf) -> CounterfactualDetail:
+    return CounterfactualDetail(
+        id=cf.id,
+        track_kind=cf.track_kind,
+        baseline_price=cf.baseline_price,
+        baseline_at=cf.baseline_at,
+        quantity=cf.quantity,
+        payload=cf.payload,
+        notes=cf.notes,
+        created_at=cf.created_at,
+    )
+
+
+def _to_outcome_detail(outcome) -> OutcomeDetail:
+    return OutcomeDetail(
+        id=outcome.id,
+        counterfactual_id=outcome.counterfactual_id,
+        track_kind=outcome.track_kind,
+        horizon=outcome.horizon,
+        price_at_mark=outcome.price_at_mark,
+        pnl_pct=outcome.pnl_pct,
+        pnl_amount=outcome.pnl_amount,
+        marked_at=outcome.marked_at,
+        payload=outcome.payload,
+        created_at=outcome.created_at,
+    )
+
+
+def _to_proposal_detail(proposal) -> ProposalDetail:
+    return ProposalDetail(
+        proposal_uuid=proposal.proposal_uuid,
+        symbol=proposal.symbol,
+        instrument_type=proposal.instrument_type,
+        proposal_kind=proposal.proposal_kind,
+        side=proposal.side,
+        user_response=proposal.user_response,
+        responded_at=proposal.responded_at,
+        created_at=proposal.created_at,
+        updated_at=proposal.updated_at,
+        original_quantity=proposal.original_quantity,
+        original_quantity_pct=proposal.original_quantity_pct,
+        original_amount=proposal.original_amount,
+        original_price=proposal.original_price,
+        original_trigger_price=proposal.original_trigger_price,
+        original_threshold_pct=proposal.original_threshold_pct,
+        original_currency=proposal.original_currency,
+        original_rationale=proposal.original_rationale,
+        original_payload=proposal.original_payload,
+        user_quantity=proposal.user_quantity,
+        user_quantity_pct=proposal.user_quantity_pct,
+        user_amount=proposal.user_amount,
+        user_price=proposal.user_price,
+        user_trigger_price=proposal.user_trigger_price,
+        user_threshold_pct=proposal.user_threshold_pct,
+        user_note=proposal.user_note,
+        actions=[_to_action_detail(a) for a in proposal.actions],
+        counterfactuals=[_to_counterfactual_detail(c) for c in proposal.counterfactuals],
+        outcomes=[_to_outcome_detail(o) for o in proposal.outcomes],
+    )
+
+
+def _to_session_summary(session, proposals_count: int, pending_count: int) -> SessionSummary:
+    return SessionSummary(
+        session_uuid=session.session_uuid,
+        source_profile=session.source_profile,
+        strategy_name=session.strategy_name,
+        market_scope=session.market_scope,
+        status=session.status,
+        generated_at=session.generated_at,
+        created_at=session.created_at,
+        updated_at=session.updated_at,
+        proposals_count=proposals_count,
+        pending_count=pending_count,
+    )
+
+
+def _to_session_detail(session) -> SessionDetail:
+    return SessionDetail(
+        session_uuid=session.session_uuid,
+        source_profile=session.source_profile,
+        strategy_name=session.strategy_name,
+        market_scope=session.market_scope,
+        status=session.status,
+        generated_at=session.generated_at,
+        created_at=session.created_at,
+        updated_at=session.updated_at,
+        market_brief=session.market_brief,
+        notes=session.notes,
+        proposals_count=len(session.proposals),
+        pending_count=sum(1 for p in session.proposals if p.user_response == "pending"),
+        proposals=[_to_proposal_detail(p) for p in session.proposals],
+    )
+
+
+@router.get("/api/decisions", response_model=SessionListResponse)
+async def list_decisions(
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+    status: SessionStatusLiteral | None = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_authenticated_user),
+) -> SessionListResponse:
+    rows, total = await trading_decision_service.list_user_sessions(
+        db,
+        user_id=current_user.id,
+        limit=limit,
+        offset=offset,
+        status=status,
+    )
+
+    sessions = [_to_session_summary(session, count, pending) for session, count, pending in rows]
+
+    return SessionListResponse(
+        sessions=sessions,
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post("/api/decisions", response_model=SessionDetail, status_code=status.HTTP_201_CREATED)
+async def create_decision(
+    request: SessionCreateRequest,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_authenticated_user),
+) -> SessionDetail:
+    session_obj = await trading_decision_service.create_decision_session(
+        db,
+        user_id=current_user.id,
+        source_profile=request.source_profile,
+        strategy_name=request.strategy_name,
+        market_scope=request.market_scope,
+        market_brief=request.market_brief,
+        generated_at=request.generated_at,
+        notes=request.notes,
+    )
+    await db.commit()
+
+    session_obj = await trading_decision_service.get_session_by_uuid(
+        db, session_uuid=session_obj.session_uuid, user_id=current_user.id
+    )
+    if session_obj is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Decision session not found",
+        )
+    response.headers["Location"] = f"/trading/api/decisions/{session_obj.session_uuid}"
+
+    return _to_session_detail(session_obj)
+
+
+@router.get("/api/decisions/{session_uuid}", response_model=SessionDetail)
+async def get_decision(
+    session_uuid: UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_authenticated_user),
+) -> SessionDetail:
+    session_obj = await trading_decision_service.get_session_by_uuid(
+        db, session_uuid=session_uuid, user_id=current_user.id
+    )
+
+    if session_obj is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Decision session not found",
+        )
+
+    return _to_session_detail(session_obj)
+
+
+@router.post(
+    "/api/decisions/{session_uuid}/proposals",
+    response_model=ProposalCreateBulkResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_proposals(
+    session_uuid: UUID,
+    request: ProposalCreateBulkRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_authenticated_user),
+) -> ProposalCreateBulkResponse:
+    session_obj = await trading_decision_service.get_session_by_uuid(
+        db, session_uuid=session_uuid, user_id=current_user.id
+    )
+
+    if session_obj is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Decision session not found",
+        )
+
+    if session_obj.status != "open":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Session is not open",
+        )
+
+    from app.services.trading_decision_service import ProposalCreate
+
+    proposals_to_create = [
+        ProposalCreate(
+            symbol=p.symbol,
+            instrument_type=p.instrument_type,
+            proposal_kind=p.proposal_kind,
+            side=p.side,
+            original_quantity=p.original_quantity,
+            original_quantity_pct=p.original_quantity_pct,
+            original_amount=p.original_amount,
+            original_price=p.original_price,
+            original_trigger_price=p.original_trigger_price,
+            original_threshold_pct=p.original_threshold_pct,
+            original_currency=p.original_currency,
+            original_rationale=p.original_rationale,
+            original_payload=p.original_payload,
+        )
+        for p in request.proposals
+    ]
+
+    proposals = await trading_decision_service.add_decision_proposals(
+        db, session_id=session_obj.id, proposals=proposals_to_create
+    )
+    await db.commit()
+
+    # Refetch through the ownership-checked read helper so async SQLAlchemy never
+    # lazy-loads relationship collections while serializing the response.
+    proposal_details = []
+    for proposal in proposals:
+        refreshed = await trading_decision_service.get_proposal_by_uuid(
+            db,
+            proposal_uuid=proposal.proposal_uuid,
+            user_id=current_user.id,
+        )
+        if refreshed is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Proposal not found",
+            )
+        proposal_details.append(_to_proposal_detail(refreshed))
+
+    return ProposalCreateBulkResponse(proposals=proposal_details)
+
+
+@router.post("/api/proposals/{proposal_uuid}/respond", response_model=ProposalDetail)
+async def respond_to_proposal(
+    proposal_uuid: UUID,
+    request: ProposalRespondRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_authenticated_user),
+) -> ProposalDetail:
+    proposal = await trading_decision_service.get_proposal_by_uuid(
+        db, proposal_uuid=proposal_uuid, user_id=current_user.id
+    )
+
+    if proposal is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Proposal not found",
+        )
+
+    if proposal.session.status == "archived":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Session is archived",
+        )
+
+    from app.models.trading_decision import UserResponse
+
+    await trading_decision_service.record_user_response(
+        db,
+        proposal_id=proposal.id,
+        response=UserResponse(request.response),
+        user_quantity=request.user_quantity,
+        user_quantity_pct=request.user_quantity_pct,
+        user_amount=request.user_amount,
+        user_price=request.user_price,
+        user_trigger_price=request.user_trigger_price,
+        user_threshold_pct=request.user_threshold_pct,
+        user_note=request.user_note,
+        responded_at=datetime.now(UTC),
+    )
+    await db.commit()
+
+    refreshed = await trading_decision_service.get_proposal_by_uuid(
+        db, proposal_uuid=proposal_uuid, user_id=current_user.id
+    )
+
+    return _to_proposal_detail(refreshed)
+
+
+@router.post(
+    "/api/proposals/{proposal_uuid}/actions",
+    response_model=ActionDetail,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_action(
+    proposal_uuid: UUID,
+    request: ActionCreateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_authenticated_user),
+) -> ActionDetail:
+    proposal = await trading_decision_service.get_proposal_by_uuid(
+        db, proposal_uuid=proposal_uuid, user_id=current_user.id
+    )
+
+    if proposal is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Proposal not found",
+        )
+
+    from app.models.trading_decision import ActionKind
+
+    try:
+        action = await trading_decision_service.record_decision_action(
+            db,
+            proposal_id=proposal.id,
+            action_kind=ActionKind(request.action_kind),
+            external_order_id=request.external_order_id,
+            external_paper_id=request.external_paper_id,
+            external_watch_id=request.external_watch_id,
+            external_source=request.external_source,
+            payload_snapshot=request.payload_snapshot,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(e),
+        )
+
+    await db.commit()
+
+    return _to_action_detail(action)
+
+
+@router.post(
+    "/api/proposals/{proposal_uuid}/counterfactuals",
+    response_model=CounterfactualDetail,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_counterfactual(
+    proposal_uuid: UUID,
+    request: CounterfactualCreateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_authenticated_user),
+) -> CounterfactualDetail:
+    proposal = await trading_decision_service.get_proposal_by_uuid(
+        db, proposal_uuid=proposal_uuid, user_id=current_user.id
+    )
+
+    if proposal is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Proposal not found",
+        )
+
+    from app.models.trading_decision import TrackKind
+
+    cf = await trading_decision_service.create_counterfactual_track(
+        db,
+        proposal_id=proposal.id,
+        track_kind=TrackKind(request.track_kind),
+        baseline_price=request.baseline_price,
+        baseline_at=request.baseline_at,
+        quantity=request.quantity,
+        payload=request.payload,
+        notes=request.notes,
+    )
+    await db.commit()
+
+    return _to_counterfactual_detail(cf)
+
+
+@router.post(
+    "/api/proposals/{proposal_uuid}/outcomes",
+    response_model=OutcomeDetail,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_outcome(
+    proposal_uuid: UUID,
+    request: OutcomeCreateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_authenticated_user),
+) -> OutcomeDetail:
+    proposal = await trading_decision_service.get_proposal_by_uuid(
+        db, proposal_uuid=proposal_uuid, user_id=current_user.id
+    )
+
+    if proposal is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Proposal not found",
+        )
+
+    # Verify counterfactual belongs to this proposal if provided
+    if request.counterfactual_id is not None:
+        cf_ids = [cf.id for cf in proposal.counterfactuals]
+        if request.counterfactual_id not in cf_ids:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="counterfactual_id does not belong to this proposal",
+            )
+
+    from app.models.trading_decision import OutcomeHorizon, TrackKind
+
+    try:
+        outcome = await trading_decision_service.record_outcome_mark(
+            db,
+            proposal_id=proposal.id,
+            track_kind=TrackKind(request.track_kind),
+            horizon=OutcomeHorizon(request.horizon),
+            price_at_mark=request.price_at_mark,
+            counterfactual_id=request.counterfactual_id,
+            pnl_pct=request.pnl_pct,
+            pnl_amount=request.pnl_amount,
+            marked_at=request.marked_at,
+            payload=request.payload,
+        )
+        await db.commit()
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Outcome mark already exists for this horizon",
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(e),
+        )
+
+    return _to_outcome_detail(outcome)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,81 +1,63 @@
-# app/schemas/__init__.py
-from .manual_holdings import (
-    # Broker Account
-    BrokerAccountCreate,
-    BrokerAccountResponse,
-    BrokerAccountUpdate,
-    # Trading
-    BuyOrderRequest,
-    ExpectedProfitResponse,
-    # Portfolio
-    HoldingInfoResponse,
-    ManualHoldingBulkCreate,
-    # Manual Holding
-    ManualHoldingCreate,
-    ManualHoldingResponse,
-    ManualHoldingUpdate,
-    MergedHoldingResponse,
-    MergedPortfolioResponse,
-    OrderSimulationResponse,
-    ReferencePricesResponse,
-    SellOrderRequest,
-    # Stock Alias
-    StockAliasCreate,
-    StockAliasResponse,
-    StockAliasSearchResult,
-)
-from .n8n.pending_orders import (
-    N8nPendingOrderItem,
-    N8nPendingOrdersResponse,
-    N8nPendingOrderSummary,
-)
-from .portfolio_decision import PortfolioDecisionSlateResponse
-from .portfolio_position_detail import (
-    PositionDetailComponentResponse,
-    PositionDetailPageResponse,
-    PositionDetailSummaryResponse,
-    PositionIndicatorsResponse,
-    PositionNewsResponse,
-    PositionOpinionsResponse,
-)
-from .research_backtest import BacktestPairSummary, BacktestRunSummary
+"""Lazy schema package exports.
 
-__all__ = [
+Avoid importing all schema modules when a single submodule is requested. Some
+legacy schemas import pricing services at module import time; eager package
+exports would pull broker/Redis execution paths into unrelated routers.
+"""
+
+_EXPORT_MODULES = {
     # Broker Account
-    "BrokerAccountCreate",
-    "BrokerAccountUpdate",
-    "BrokerAccountResponse",
+    "BrokerAccountCreate": "app.schemas.manual_holdings",
+    "BrokerAccountUpdate": "app.schemas.manual_holdings",
+    "BrokerAccountResponse": "app.schemas.manual_holdings",
     # Manual Holding
-    "ManualHoldingCreate",
-    "ManualHoldingUpdate",
-    "ManualHoldingResponse",
-    "ManualHoldingBulkCreate",
+    "ManualHoldingCreate": "app.schemas.manual_holdings",
+    "ManualHoldingUpdate": "app.schemas.manual_holdings",
+    "ManualHoldingResponse": "app.schemas.manual_holdings",
+    "ManualHoldingBulkCreate": "app.schemas.manual_holdings",
     # Stock Alias
-    "StockAliasCreate",
-    "StockAliasResponse",
-    "StockAliasSearchResult",
-    "N8nPendingOrderItem",
-    "N8nPendingOrderSummary",
-    "N8nPendingOrdersResponse",
+    "StockAliasCreate": "app.schemas.manual_holdings",
+    "StockAliasResponse": "app.schemas.manual_holdings",
+    "StockAliasSearchResult": "app.schemas.manual_holdings",
+    # n8n pending orders
+    "N8nPendingOrderItem": "app.schemas.n8n.pending_orders",
+    "N8nPendingOrderSummary": "app.schemas.n8n.pending_orders",
+    "N8nPendingOrdersResponse": "app.schemas.n8n.pending_orders",
     # Portfolio
-    "HoldingInfoResponse",
-    "ReferencePricesResponse",
-    "MergedHoldingResponse",
-    "MergedPortfolioResponse",
+    "HoldingInfoResponse": "app.schemas.manual_holdings",
+    "ReferencePricesResponse": "app.schemas.manual_holdings",
+    "MergedHoldingResponse": "app.schemas.manual_holdings",
+    "MergedPortfolioResponse": "app.schemas.manual_holdings",
     # Portfolio Decision
-    "PortfolioDecisionSlateResponse",
+    "PortfolioDecisionSlateResponse": "app.schemas.portfolio_decision",
     # Portfolio Position Detail
-    "PositionDetailComponentResponse",
-    "PositionDetailSummaryResponse",
-    "PositionDetailPageResponse",
-    "PositionIndicatorsResponse",
-    "PositionNewsResponse",
-    "PositionOpinionsResponse",
+    "PositionDetailComponentResponse": "app.schemas.portfolio_position_detail",
+    "PositionDetailSummaryResponse": "app.schemas.portfolio_position_detail",
+    "PositionDetailPageResponse": "app.schemas.portfolio_position_detail",
+    "PositionIndicatorsResponse": "app.schemas.portfolio_position_detail",
+    "PositionNewsResponse": "app.schemas.portfolio_position_detail",
+    "PositionOpinionsResponse": "app.schemas.portfolio_position_detail",
     # Trading
-    "BuyOrderRequest",
-    "SellOrderRequest",
-    "OrderSimulationResponse",
-    "ExpectedProfitResponse",
-    "BacktestRunSummary",
-    "BacktestPairSummary",
-]
+    "BuyOrderRequest": "app.schemas.manual_holdings",
+    "SellOrderRequest": "app.schemas.manual_holdings",
+    "OrderSimulationResponse": "app.schemas.manual_holdings",
+    "ExpectedProfitResponse": "app.schemas.manual_holdings",
+    # Backtest
+    "BacktestRunSummary": "app.schemas.research_backtest",
+    "BacktestPairSummary": "app.schemas.research_backtest",
+}
+
+__all__ = list(_EXPORT_MODULES)
+
+
+def __getattr__(name: str):
+    module_name = _EXPORT_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    from importlib import import_module
+
+    module = import_module(module_name)
+    value = getattr(module, name)
+    globals()[name] = value
+    return value

--- a/app/schemas/trading_decisions.py
+++ b/app/schemas/trading_decisions.py
@@ -1,0 +1,285 @@
+"""Trading decisions API schemas."""
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal, Self
+from uuid import UUID
+
+from pydantic import BaseModel, Field, model_validator
+
+# Shared type literals per plan §6
+ProposalKindLiteral = Literal[
+    "trim",
+    "add",
+    "enter",
+    "exit",
+    "pullback_watch",
+    "breakout_watch",
+    "avoid",
+    "no_action",
+    "other",
+]
+
+SideLiteral = Literal["buy", "sell", "none"]
+
+UserResponseLiteral = Literal[
+    "pending",
+    "accept",
+    "reject",
+    "modify",
+    "partial_accept",
+    "defer",
+]
+
+ActionKindLiteral = Literal[
+    "live_order",
+    "paper_order",
+    "watch_alert",
+    "no_action",
+    "manual_note",
+]
+
+TrackKindLiteral = Literal[
+    "accepted_live",
+    "accepted_paper",
+    "rejected_counterfactual",
+    "analyst_alternative",
+    "user_alternative",
+]
+
+OutcomeHorizonLiteral = Literal["1h", "4h", "1d", "3d", "7d", "final"]
+
+SessionStatusLiteral = Literal["open", "closed", "archived"]
+
+InstrumentTypeLiteral = Literal[
+    "equity_kr",
+    "equity_us",
+    "crypto",
+    "forex",
+    "index",
+]
+
+
+# ========== Session Schemas ==========
+
+class SessionCreateRequest(BaseModel):
+    source_profile: str = Field(..., min_length=1, max_length=64)
+    strategy_name: str | None = Field(default=None, max_length=128)
+    market_scope: str | None = Field(default=None, max_length=32)
+    market_brief: dict | None = None
+    generated_at: datetime
+    notes: str | None = Field(default=None, max_length=4000)
+
+
+class SessionSummary(BaseModel):
+    session_uuid: UUID
+    source_profile: str
+    strategy_name: str | None
+    market_scope: str | None
+    status: SessionStatusLiteral
+    generated_at: datetime
+    created_at: datetime
+    updated_at: datetime
+    proposals_count: int
+    pending_count: int
+
+
+class SessionDetail(SessionSummary):
+    market_brief: dict | None
+    notes: str | None
+    proposals: list["ProposalDetail"]
+
+
+class SessionListResponse(BaseModel):
+    sessions: list[SessionSummary]
+    total: int
+    limit: int
+    offset: int
+
+
+# ========== Proposal Schemas ==========
+
+class ProposalCreateItem(BaseModel):
+    symbol: str = Field(..., min_length=1, max_length=64)
+    instrument_type: InstrumentTypeLiteral
+    proposal_kind: ProposalKindLiteral
+    side: SideLiteral = "none"
+    original_quantity: Decimal | None = None
+    original_quantity_pct: Decimal | None = Field(default=None, ge=0, le=100)
+    original_amount: Decimal | None = Field(default=None, ge=0)
+    original_price: Decimal | None = Field(default=None, ge=0)
+    original_trigger_price: Decimal | None = Field(default=None, ge=0)
+    original_threshold_pct: Decimal | None = Field(default=None, ge=0, le=100)
+    original_currency: str | None = Field(default=None, max_length=8)
+    original_rationale: str | None = Field(default=None, max_length=4000)
+    original_payload: dict
+
+
+class ProposalCreateBulkRequest(BaseModel):
+    proposals: list[ProposalCreateItem] = Field(..., min_length=1, max_length=100)
+
+
+class ProposalSummary(BaseModel):
+    proposal_uuid: UUID
+    symbol: str
+    instrument_type: InstrumentTypeLiteral
+    proposal_kind: ProposalKindLiteral
+    side: SideLiteral
+    user_response: UserResponseLiteral
+    responded_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProposalDetail(ProposalSummary):
+    original_quantity: Decimal | None
+    original_quantity_pct: Decimal | None
+    original_amount: Decimal | None
+    original_price: Decimal | None
+    original_trigger_price: Decimal | None
+    original_threshold_pct: Decimal | None
+    original_currency: str | None
+    original_rationale: str | None
+    original_payload: dict
+    user_quantity: Decimal | None
+    user_quantity_pct: Decimal | None
+    user_amount: Decimal | None
+    user_price: Decimal | None
+    user_trigger_price: Decimal | None
+    user_threshold_pct: Decimal | None
+    user_note: str | None
+    actions: list["ActionDetail"]
+    counterfactuals: list["CounterfactualDetail"]
+    outcomes: list["OutcomeDetail"]
+
+
+class ProposalCreateBulkResponse(BaseModel):
+    proposals: list[ProposalDetail]
+
+
+# ========== Response Schemas ==========
+
+class ProposalRespondRequest(BaseModel):
+    response: Literal["accept", "reject", "modify", "partial_accept", "defer"]
+    user_quantity: Decimal | None = None
+    user_quantity_pct: Decimal | None = Field(default=None, ge=0, le=100)
+    user_amount: Decimal | None = Field(default=None, ge=0)
+    user_price: Decimal | None = Field(default=None, ge=0)
+    user_trigger_price: Decimal | None = Field(default=None, ge=0)
+    user_threshold_pct: Decimal | None = Field(default=None, ge=0, le=100)
+    user_note: str | None = Field(default=None, max_length=4000)
+
+    @model_validator(mode="after")
+    def _modify_requires_some_user_field(self) -> Self:
+        if self.response in ("modify", "partial_accept") and not any(
+            v is not None
+            for v in (
+                self.user_quantity,
+                self.user_quantity_pct,
+                self.user_amount,
+                self.user_price,
+                self.user_trigger_price,
+                self.user_threshold_pct,
+            )
+        ):
+            raise ValueError(
+                "modify/partial_accept requires at least one user_* numeric field"
+            )
+        return self
+
+
+# ========== Action Schemas ==========
+
+class ActionCreateRequest(BaseModel):
+    action_kind: ActionKindLiteral
+    external_order_id: str | None = Field(default=None, max_length=128)
+    external_paper_id: str | None = Field(default=None, max_length=128)
+    external_watch_id: str | None = Field(default=None, max_length=128)
+    external_source: str | None = Field(default=None, max_length=64)
+    payload_snapshot: dict
+
+    @model_validator(mode="after")
+    def _kinds_requiring_external_id(self) -> Self:
+        needs_id = self.action_kind not in ("no_action", "manual_note")
+        has_id = any(
+            [self.external_order_id, self.external_paper_id, self.external_watch_id]
+        )
+        if needs_id and not has_id:
+            raise ValueError(
+                f"action_kind '{self.action_kind}' requires at least one external_* id"
+            )
+        return self
+
+
+class ActionDetail(BaseModel):
+    id: int
+    action_kind: ActionKindLiteral
+    external_order_id: str | None
+    external_paper_id: str | None
+    external_watch_id: str | None
+    external_source: str | None
+    payload_snapshot: dict
+    recorded_at: datetime
+    created_at: datetime
+
+
+# ========== Counterfactual Schemas ==========
+
+class CounterfactualCreateRequest(BaseModel):
+    track_kind: Literal[
+        "rejected_counterfactual",
+        "analyst_alternative",
+        "user_alternative",
+        "accepted_paper",
+    ]
+    baseline_price: Decimal = Field(..., ge=0)
+    baseline_at: datetime
+    quantity: Decimal | None = None
+    payload: dict
+    notes: str | None = Field(default=None, max_length=4000)
+
+
+class CounterfactualDetail(BaseModel):
+    id: int
+    track_kind: TrackKindLiteral
+    baseline_price: Decimal
+    baseline_at: datetime
+    quantity: Decimal | None
+    payload: dict
+    notes: str | None
+    created_at: datetime
+
+
+# ========== Outcome Schemas ==========
+
+class OutcomeCreateRequest(BaseModel):
+    track_kind: TrackKindLiteral
+    horizon: OutcomeHorizonLiteral
+    price_at_mark: Decimal = Field(..., ge=0)
+    counterfactual_id: int | None = None
+    pnl_pct: Decimal | None = None
+    pnl_amount: Decimal | None = None
+    marked_at: datetime
+    payload: dict | None = None
+
+    @model_validator(mode="after")
+    def _accepted_live_invariant(self) -> Self:
+        if self.track_kind == "accepted_live" and self.counterfactual_id is not None:
+            raise ValueError("accepted_live track must not include counterfactual_id")
+        if self.track_kind != "accepted_live" and self.counterfactual_id is None:
+            raise ValueError(
+                f"track_kind '{self.track_kind}' requires counterfactual_id"
+            )
+        return self
+
+
+class OutcomeDetail(BaseModel):
+    id: int
+    counterfactual_id: int | None
+    track_kind: TrackKindLiteral
+    horizon: OutcomeHorizonLiteral
+    price_at_mark: Decimal
+    pnl_pct: Decimal | None
+    pnl_amount: Decimal | None
+    marked_at: datetime
+    payload: dict | None
+    created_at: datetime

--- a/app/schemas/trading_decisions.py
+++ b/app/schemas/trading_decisions.py
@@ -1,4 +1,5 @@
 """Trading decisions API schemas."""
+
 from datetime import datetime
 from decimal import Decimal
 from typing import Literal, Self
@@ -61,6 +62,7 @@ InstrumentTypeLiteral = Literal[
 
 # ========== Session Schemas ==========
 
+
 class SessionCreateRequest(BaseModel):
     source_profile: str = Field(..., min_length=1, max_length=64)
     strategy_name: str | None = Field(default=None, max_length=128)
@@ -97,6 +99,7 @@ class SessionListResponse(BaseModel):
 
 
 # ========== Proposal Schemas ==========
+
 
 class ProposalCreateItem(BaseModel):
     symbol: str = Field(..., min_length=1, max_length=64)
@@ -158,6 +161,7 @@ class ProposalCreateBulkResponse(BaseModel):
 
 # ========== Response Schemas ==========
 
+
 class ProposalRespondRequest(BaseModel):
     response: Literal["accept", "reject", "modify", "partial_accept", "defer"]
     user_quantity: Decimal | None = None
@@ -188,6 +192,7 @@ class ProposalRespondRequest(BaseModel):
 
 
 # ========== Action Schemas ==========
+
 
 class ActionCreateRequest(BaseModel):
     action_kind: ActionKindLiteral
@@ -224,6 +229,7 @@ class ActionDetail(BaseModel):
 
 # ========== Counterfactual Schemas ==========
 
+
 class CounterfactualCreateRequest(BaseModel):
     track_kind: Literal[
         "rejected_counterfactual",
@@ -250,6 +256,7 @@ class CounterfactualDetail(BaseModel):
 
 
 # ========== Outcome Schemas ==========
+
 
 class OutcomeCreateRequest(BaseModel):
     track_kind: TrackKindLiteral

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,3 +1,6 @@
-from . import order_service as order_service
-from . import upbit_orderbook as upbit_orderbook
-from . import upbit_websocket as upbit_websocket
+"""Service package.
+
+Keep package import side-effect free. Import concrete service modules directly at
+call sites (for example, ``from app.services import order_service``) so safety
+checks can reason about which execution paths are actually loaded.
+"""

--- a/app/services/trading_decision_service.py
+++ b/app/services/trading_decision_service.py
@@ -2,9 +2,11 @@ from collections.abc import Sequence
 from datetime import datetime
 from decimal import Decimal
 from typing import TypedDict
+from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.models.trading import InstrumentType
 from app.models.trading_decision import (
@@ -233,3 +235,107 @@ async def record_outcome_mark(
     await session.flush()
     await session.refresh(db_outcome)
     return db_outcome
+
+
+async def get_session_by_uuid(
+    session: AsyncSession,
+    *,
+    session_uuid: UUID,
+    user_id: int,
+) -> TradingDecisionSession | None:
+    """Return session iff it exists AND belongs to user_id; eager-load proposals."""
+    result = await session.execute(
+        select(TradingDecisionSession)
+        .where(
+            TradingDecisionSession.session_uuid == session_uuid,
+            TradingDecisionSession.user_id == user_id,
+        )
+        .options(
+            selectinload(TradingDecisionSession.proposals).selectinload(
+                TradingDecisionProposal.actions
+            ),
+            selectinload(TradingDecisionSession.proposals).selectinload(
+                TradingDecisionProposal.counterfactuals
+            ),
+            selectinload(TradingDecisionSession.proposals).selectinload(
+                TradingDecisionProposal.outcomes
+            ),
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def list_user_sessions(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    limit: int = 50,
+    offset: int = 0,
+    status: str | None = None,
+) -> tuple[list[tuple[TradingDecisionSession, int, int]], int]:
+    """
+    Return (rows, total). Each row is (session, proposals_count, pending_count).
+    Single SQL query with grouped counts to avoid N+1.
+    """
+    # Build base filters
+    base_filters = [TradingDecisionSession.user_id == user_id]
+    if status:
+        base_filters.append(TradingDecisionSession.status == status)
+
+    # Get total count
+    total_result = await session.execute(
+        select(func.count(TradingDecisionSession.id)).where(*base_filters)
+    )
+    total = total_result.scalar() or 0
+
+    # Get sessions with counts
+    stmt = (
+        select(
+            TradingDecisionSession,
+            func.count(TradingDecisionProposal.id).label("proposals_count"),
+            func.count(TradingDecisionProposal.id)
+            .filter(TradingDecisionProposal.user_response == "pending")
+            .label("pending_count"),
+        )
+        .outerjoin(
+            TradingDecisionProposal,
+            TradingDecisionProposal.session_id == TradingDecisionSession.id,
+        )
+        .where(*base_filters)
+        .group_by(TradingDecisionSession.id)
+        .order_by(TradingDecisionSession.generated_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+
+    result = await session.execute(stmt)
+    rows = [
+        (row.TradingDecisionSession, row.proposals_count, row.pending_count)
+        for row in result.all()
+    ]
+
+    return rows, total
+
+
+async def get_proposal_by_uuid(
+    session: AsyncSession,
+    *,
+    proposal_uuid: UUID,
+    user_id: int,
+) -> TradingDecisionProposal | None:
+    """JOIN sessions to enforce ownership. Eager-load actions/counterfactuals/outcomes."""
+    result = await session.execute(
+        select(TradingDecisionProposal)
+        .join(TradingDecisionSession)
+        .where(
+            TradingDecisionProposal.proposal_uuid == proposal_uuid,
+            TradingDecisionSession.user_id == user_id,
+        )
+        .options(
+            selectinload(TradingDecisionProposal.session),
+            selectinload(TradingDecisionProposal.actions),
+            selectinload(TradingDecisionProposal.counterfactuals),
+            selectinload(TradingDecisionProposal.outcomes),
+        )
+    )
+    return result.scalar_one_or_none()

--- a/docs/plans/ROB-2-trading-decision-api-contract-plan.md
+++ b/docs/plans/ROB-2-trading-decision-api-contract-plan.md
@@ -1,0 +1,738 @@
+# ROB-2 — Trading Decision API Contract Plan
+
+- **PR scope:** Prompt 2 of `auto_trader_trading_decision_workspace_roadmap.md` only.
+- **Branch / worktree:** `feature/ROB-2-trading-decision-api-contract` (single PR).
+- **Status:** Plan only. No code yet.
+- **Depends on:** ROB-1 / PR #595 (DB schema + service) — already merged to `main`.
+
+> ⚠️ This PR ships **API endpoints only** over the ROB-1 persistence layer. React/Vite scaffold (ROB-3), decision workspace UI (ROB-4), outcome/analytics UI (ROB-5), Discord delivery, periodic reassessment, broker/watch live execution, and any KIS/Upbit/Redis side effect are **explicitly deferred**.
+
+---
+
+## 1. Goal
+
+Expose authenticated FastAPI endpoints that let a future UI (and other internal callers) **create / read decision sessions and proposals, record user responses, record action links, create counterfactual tracks, and record/read outcome marks** — entirely as record-only operations on top of the ROB-1 schema.
+
+Two non-negotiable invariants carry over from ROB-1 and are now contract-level guarantees:
+
+1. The **immutable** `original_*` fields on a proposal are never mutated by an API call — even when the user `modify`s a recommendation. The user’s adjustments live in `user_*` fields.
+2. The API performs **no broker, watch, or token-refresh side effect**. `record action` only persists external IDs the caller already obtained from a separate execution flow.
+
+---
+
+## 2. In-scope vs Out-of-scope
+
+| Area | In scope (this PR) | Deferred |
+|---|---|---|
+| FastAPI router module | ✅ `app/routers/trading_decisions.py` | — |
+| Pydantic request/response schemas | ✅ `app/schemas/trading_decisions.py` | — |
+| Auth via existing `get_authenticated_user` dependency | ✅ | — |
+| Session/proposal/action/counterfactual/outcome write endpoints | ✅ | — |
+| List + detail read endpoints (sessions, proposals, outcomes nested in detail) | ✅ | — |
+| Read helper additions in `trading_decision_service.py` | ✅ | — |
+| Router test file (`tests/test_trading_decisions_router.py`) using `TestClient` + dependency overrides | ✅ | — |
+| Side-effect safety test (no forbidden imports loaded by router module) | ✅ | — |
+| Router-level OpenAPI `tags`, summary, response models | ✅ | — |
+| React UI / Vite scaffold | ❌ | ROB-3 |
+| Outcome dashboard / analytics view | ❌ | ROB-5 |
+| Discord brief / push of new sessions | ❌ | future |
+| Periodic reassessment cron job | ❌ | future |
+| Live order placement, watch alert registration | ❌ (forbidden — see §9) | — |
+| Hermes ingestion adapter (writing proposals from analyst output) | ❌ | future PR |
+
+---
+
+## 3. Workflow the API must support
+
+The same scenario from ROB-1, now driven through HTTP:
+
+```text
+POST /trading/api/decisions                                    # create session
+POST /trading/api/decisions/{session_uuid}/proposals           # add BTC trim, ETH/SOL watch, ORCA/ZBT avoid
+POST /trading/api/proposals/{btc_uuid}/respond {accept}        # accept BTC exactly
+POST /trading/api/proposals/{btc_uuid}/respond {modify, ...}   # OR: modify BTC 20% → 10%
+POST /trading/api/proposals/{eth_uuid}/respond {accept}        # accept ETH only
+POST /trading/api/proposals/{sol_uuid}/respond {defer}         # defer SOL
+POST /trading/api/proposals/{btc_uuid}/actions {live_order,
+       external_order_id, external_source}                     # link to KIS/Upbit order id
+POST /trading/api/proposals/{sol_uuid}/counterfactuals {...}   # paper track for rejected SOL
+POST /trading/api/proposals/{btc_uuid}/outcomes {1h, ...}      # mark price at horizon
+GET  /trading/api/decisions                                    # list user’s sessions
+GET  /trading/api/decisions/{session_uuid}                     # detail incl. nested proposals/actions/outcomes
+```
+
+A future UI will read `GET /decisions` for the inbox and `GET /decisions/{uuid}` for the detail screen.
+
+---
+
+## 4. Module placement & router structure
+
+### 4.1 New files
+
+| File | Purpose |
+|---|---|
+| `app/routers/trading_decisions.py` | `APIRouter` with all 8 endpoints |
+| `app/schemas/trading_decisions.py` | Pydantic v2 request/response models |
+| `tests/test_trading_decisions_router.py` | Router unit tests with `TestClient` + dependency overrides |
+| `tests/test_trading_decisions_router_safety.py` | Subprocess import test enforcing §9 forbidden-import boundary |
+
+### 4.2 Files modified
+
+| File | Change |
+|---|---|
+| `app/main.py` | `from app.routers import trading_decisions` + `app.include_router(trading_decisions.router)` (next to `trading.router`) |
+| `app/services/trading_decision_service.py` | Add **read** helpers only (`get_session_by_uuid`, `list_user_sessions`, `get_proposal_by_uuid`). No new write helpers — existing ones already satisfy the 8 endpoints. |
+
+### 4.3 Router declaration
+
+```python
+# app/routers/trading_decisions.py
+router = APIRouter(prefix="/trading", tags=["trading-decisions"])
+```
+
+**Why prefix `/trading` (same as `app.routers.trading`)?** The roadmap mandates `/trading/api/decisions/...`. FastAPI allows multiple routers to share a prefix; the existing `trading.router` owns `/trading/api/buy|sell|v1/trading/...` and the new router owns `/trading/api/decisions|proposals/...` — no path collisions. Tests confirm registration order and route uniqueness.
+
+The middleware `TemplateFormCSRFMiddleware` already exempts `^/trading/` (see `app/main.py:190`), so JSON POSTs from internal clients won’t hit CSRF. Browser clients hit the same path through `AuthMiddleware` which populates `request.state.user`.
+
+---
+
+## 5. Authentication / authorization / dependency pattern
+
+### 5.1 Auth dependency (reuse existing pattern)
+
+Use `get_authenticated_user` from `app/routers/dependencies.py:14`:
+
+```python
+from app.routers.dependencies import get_authenticated_user
+from app.models.trading import User
+
+async def endpoint(
+    ...,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_authenticated_user),
+) -> SomeResponse: ...
+```
+
+Rationale: matches `app.routers.trading`, `app.routers.portfolio`, `app.routers.order_estimation`. Supports both JWT bearer (via `AuthMiddleware`) and web-session cookies. Unauthenticated requests get HTTP 401 from the dependency itself — no manual check needed in the handler.
+
+### 5.2 Authorization model
+
+Every endpoint that touches a `session_uuid` or `proposal_uuid` **must verify the current user owns the session**. The check must be done in the service layer (single source of truth), not duplicated in handlers.
+
+Rule:
+
+> If `session.user_id != current_user.id`, the API returns **HTTP 404**, **never 403**, to avoid leaking session existence.
+
+Implementation:
+
+- `get_session_by_uuid(db, *, session_uuid, user_id)` returns `None` if not found *or* not owned. Handler raises `HTTPException(404, "Decision session not found")`.
+- `get_proposal_by_uuid(db, *, proposal_uuid, user_id)` joins `trading_decision_proposals → trading_decision_sessions` and filters on `sessions.user_id`. Returns `None` if not found or not owned.
+- All proposal-scoped endpoints (`/proposals/{uuid}/respond|actions|counterfactuals|outcomes`) call `get_proposal_by_uuid` first; failure → 404.
+
+### 5.3 No anonymous read
+
+`GET /trading/api/decisions` returns the calling user’s sessions only. No admin/global view is added in this PR.
+
+---
+
+## 6. Pydantic request/response schemas
+
+All schemas live in `app/schemas/trading_decisions.py`. Pydantic v2 syntax (matches `app/schemas/order_intent_preview.py`).
+
+### 6.1 Shared types
+
+```python
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+from uuid import UUID
+from pydantic import BaseModel, Field, model_validator
+
+ProposalKindLiteral = Literal[
+    "trim", "add", "enter", "exit",
+    "pullback_watch", "breakout_watch",
+    "avoid", "no_action", "other",
+]
+SideLiteral = Literal["buy", "sell", "none"]
+UserResponseLiteral = Literal[
+    "pending", "accept", "reject", "modify", "partial_accept", "defer",
+]
+ActionKindLiteral = Literal[
+    "live_order", "paper_order", "watch_alert", "no_action", "manual_note",
+]
+TrackKindLiteral = Literal[
+    "accepted_live", "accepted_paper",
+    "rejected_counterfactual", "analyst_alternative", "user_alternative",
+]
+OutcomeHorizonLiteral = Literal["1h", "4h", "1d", "3d", "7d", "final"]
+SessionStatusLiteral = Literal["open", "closed", "archived"]
+InstrumentTypeLiteral = Literal[
+    "equity_kr", "equity_us", "crypto", "etf", "futures", "option", "other",
+]  # mirror app.models.trading.InstrumentType
+```
+
+> The Literal aliases must be kept in sync with the SQLAlchemy CHECK constraints in `app/models/trading_decision.py`. A test (see §10.6) imports both and asserts set equality.
+
+### 6.2 Session schemas
+
+```python
+class SessionCreateRequest(BaseModel):
+    source_profile: str = Field(..., min_length=1, max_length=64)
+    strategy_name: str | None = Field(default=None, max_length=128)
+    market_scope: str | None = Field(default=None, max_length=32)
+    market_brief: dict | None = None
+    generated_at: datetime
+    notes: str | None = Field(default=None, max_length=4000)
+
+class SessionSummary(BaseModel):
+    session_uuid: UUID
+    source_profile: str
+    strategy_name: str | None
+    market_scope: str | None
+    status: SessionStatusLiteral
+    generated_at: datetime
+    created_at: datetime
+    updated_at: datetime
+    proposals_count: int
+    pending_count: int
+
+class SessionDetail(SessionSummary):
+    market_brief: dict | None
+    notes: str | None
+    proposals: list["ProposalDetail"]
+
+class SessionListResponse(BaseModel):
+    sessions: list[SessionSummary]
+    total: int
+    limit: int
+    offset: int
+```
+
+### 6.3 Proposal schemas
+
+```python
+class ProposalCreateItem(BaseModel):
+    symbol: str = Field(..., min_length=1, max_length=64)
+    instrument_type: InstrumentTypeLiteral
+    proposal_kind: ProposalKindLiteral
+    side: SideLiteral = "none"
+    original_quantity: Decimal | None = None
+    original_quantity_pct: Decimal | None = Field(default=None, ge=0, le=100)
+    original_amount: Decimal | None = Field(default=None, ge=0)
+    original_price: Decimal | None = Field(default=None, ge=0)
+    original_trigger_price: Decimal | None = Field(default=None, ge=0)
+    original_threshold_pct: Decimal | None = Field(default=None, ge=0, le=100)
+    original_currency: str | None = Field(default=None, max_length=8)
+    original_rationale: str | None = Field(default=None, max_length=4000)
+    original_payload: dict  # required, lossless analyst snapshot
+
+class ProposalCreateBulkRequest(BaseModel):
+    proposals: list[ProposalCreateItem] = Field(..., min_length=1, max_length=100)
+
+class ProposalSummary(BaseModel):
+    proposal_uuid: UUID
+    symbol: str
+    instrument_type: InstrumentTypeLiteral
+    proposal_kind: ProposalKindLiteral
+    side: SideLiteral
+    user_response: UserResponseLiteral
+    responded_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+class ProposalDetail(ProposalSummary):
+    original_quantity: Decimal | None
+    original_quantity_pct: Decimal | None
+    original_amount: Decimal | None
+    original_price: Decimal | None
+    original_trigger_price: Decimal | None
+    original_threshold_pct: Decimal | None
+    original_currency: str | None
+    original_rationale: str | None
+    original_payload: dict
+    user_quantity: Decimal | None
+    user_quantity_pct: Decimal | None
+    user_amount: Decimal | None
+    user_price: Decimal | None
+    user_trigger_price: Decimal | None
+    user_threshold_pct: Decimal | None
+    user_note: str | None
+    actions: list["ActionDetail"]
+    counterfactuals: list["CounterfactualDetail"]
+    outcomes: list["OutcomeDetail"]
+
+class ProposalCreateBulkResponse(BaseModel):
+    proposals: list[ProposalDetail]
+```
+
+### 6.4 Response schemas
+
+```python
+class ProposalRespondRequest(BaseModel):
+    response: Literal["accept", "reject", "modify", "partial_accept", "defer"]
+    user_quantity: Decimal | None = None
+    user_quantity_pct: Decimal | None = Field(default=None, ge=0, le=100)
+    user_amount: Decimal | None = Field(default=None, ge=0)
+    user_price: Decimal | None = Field(default=None, ge=0)
+    user_trigger_price: Decimal | None = Field(default=None, ge=0)
+    user_threshold_pct: Decimal | None = Field(default=None, ge=0, le=100)
+    user_note: str | None = Field(default=None, max_length=4000)
+
+    @model_validator(mode="after")
+    def _modify_requires_some_user_field(self) -> "ProposalRespondRequest":
+        if self.response in ("modify", "partial_accept") and not any(
+            v is not None for v in (
+                self.user_quantity, self.user_quantity_pct,
+                self.user_amount, self.user_price,
+                self.user_trigger_price, self.user_threshold_pct,
+            )
+        ):
+            raise ValueError(
+                "modify/partial_accept requires at least one user_* numeric field"
+            )
+        return self
+```
+
+> Note: server stamps `responded_at = utcnow()` — clients **cannot** override it. Keeps the audit trail trustworthy.
+
+### 6.5 Action / counterfactual / outcome schemas
+
+```python
+class ActionCreateRequest(BaseModel):
+    action_kind: ActionKindLiteral
+    external_order_id: str | None = Field(default=None, max_length=128)
+    external_paper_id: str | None = Field(default=None, max_length=128)
+    external_watch_id: str | None = Field(default=None, max_length=128)
+    external_source: str | None = Field(default=None, max_length=64)
+    payload_snapshot: dict
+
+    @model_validator(mode="after")
+    def _kinds_requiring_external_id(self) -> "ActionCreateRequest":
+        needs_id = self.action_kind not in ("no_action", "manual_note")
+        has_id = any([self.external_order_id, self.external_paper_id, self.external_watch_id])
+        if needs_id and not has_id:
+            raise ValueError(
+                f"action_kind '{self.action_kind}' requires at least one external_* id"
+            )
+        return self
+
+class ActionDetail(BaseModel):
+    id: int
+    action_kind: ActionKindLiteral
+    external_order_id: str | None
+    external_paper_id: str | None
+    external_watch_id: str | None
+    external_source: str | None
+    payload_snapshot: dict
+    recorded_at: datetime
+    created_at: datetime
+
+class CounterfactualCreateRequest(BaseModel):
+    track_kind: Literal[
+        "rejected_counterfactual", "analyst_alternative",
+        "user_alternative", "accepted_paper",
+    ]
+    baseline_price: Decimal = Field(..., ge=0)
+    baseline_at: datetime
+    quantity: Decimal | None = None
+    payload: dict
+    notes: str | None = Field(default=None, max_length=4000)
+
+class CounterfactualDetail(BaseModel):
+    id: int
+    track_kind: TrackKindLiteral
+    baseline_price: Decimal
+    baseline_at: datetime
+    quantity: Decimal | None
+    payload: dict
+    notes: str | None
+    created_at: datetime
+
+class OutcomeCreateRequest(BaseModel):
+    track_kind: TrackKindLiteral
+    horizon: OutcomeHorizonLiteral
+    price_at_mark: Decimal = Field(..., ge=0)
+    counterfactual_id: int | None = None  # plain int FK; matches DB
+    pnl_pct: Decimal | None = None
+    pnl_amount: Decimal | None = None
+    marked_at: datetime
+    payload: dict | None = None
+
+    @model_validator(mode="after")
+    def _accepted_live_invariant(self) -> "OutcomeCreateRequest":
+        if self.track_kind == "accepted_live" and self.counterfactual_id is not None:
+            raise ValueError("accepted_live track must not include counterfactual_id")
+        if self.track_kind != "accepted_live" and self.counterfactual_id is None:
+            raise ValueError(
+                f"track_kind '{self.track_kind}' requires counterfactual_id"
+            )
+        return self
+
+class OutcomeDetail(BaseModel):
+    id: int
+    counterfactual_id: int | None
+    track_kind: TrackKindLiteral
+    horizon: OutcomeHorizonLiteral
+    price_at_mark: Decimal
+    pnl_pct: Decimal | None
+    pnl_amount: Decimal | None
+    marked_at: datetime
+    payload: dict | None
+    created_at: datetime
+```
+
+> All `Decimal` fields serialize as JSON strings (Pydantic v2 default for Decimal) to avoid float precision loss. Documented in the OpenAPI schema.
+
+---
+
+## 7. Endpoint behavior
+
+All endpoints are async, use `get_authenticated_user` and `get_db`, and return Pydantic response models.
+
+### 7.1 `GET /trading/api/decisions` → `SessionListResponse`
+
+**Query params:** `limit: int = 50` (max 200), `offset: int = 0`, `status: SessionStatusLiteral | None = None`.
+
+**Behavior:**
+1. `sessions, total = await list_user_sessions(db, user_id=current_user.id, limit=limit, offset=offset, status=status)`
+2. Each `SessionSummary` includes `proposals_count` (total) and `pending_count` (`user_response = 'pending'`) — computed in a single SQL query (subquery or grouped count) to avoid N+1.
+3. Response always includes echoed `limit`/`offset`/`total`.
+
+### 7.2 `POST /trading/api/decisions` → `SessionDetail`
+
+**Body:** `SessionCreateRequest`.
+
+**Behavior:**
+1. `session_obj = await create_decision_session(db, user_id=current_user.id, ...)`.
+2. `await db.commit()` (router commits — service flushes).
+3. Refetch via `get_session_by_uuid` to populate empty `proposals` list. Return `SessionDetail`.
+
+**Status:** 201 Created. `Location: /trading/api/decisions/{session_uuid}`.
+
+### 7.3 `GET /trading/api/decisions/{session_uuid}` → `SessionDetail`
+
+**Path:** `session_uuid: UUID`.
+
+**Behavior:**
+1. `session_obj = await get_session_by_uuid(db, session_uuid=session_uuid, user_id=current_user.id)`.
+2. If `None` → 404 `"Decision session not found"`.
+3. Eager-load (`selectinload`) proposals → actions / counterfactuals / outcomes. Build `SessionDetail` with full nesting.
+
+### 7.4 `POST /trading/api/decisions/{session_uuid}/proposals` → `ProposalCreateBulkResponse`
+
+**Body:** `ProposalCreateBulkRequest`.
+
+**Behavior:**
+1. Look up session via `get_session_by_uuid`. 404 if not owned.
+2. Refuse if `session.status != 'open'` → HTTP 409 `"Session is not open"`.
+3. Convert each `ProposalCreateItem` to the service’s `ProposalCreate` TypedDict and call `add_decision_proposals`. Commit. Return `ProposalCreateBulkResponse` with refetched proposals (so server-set fields populate).
+
+**Status:** 201 Created.
+
+### 7.5 `POST /trading/api/proposals/{proposal_uuid}/respond` → `ProposalDetail`
+
+**Path:** `proposal_uuid: UUID`. **Body:** `ProposalRespondRequest`.
+
+**Behavior:**
+1. `proposal = await get_proposal_by_uuid(db, proposal_uuid=proposal_uuid, user_id=current_user.id)`. 404 if missing/not owned.
+2. Refuse if proposal’s parent session is `'archived'` → 409.
+3. Call `record_user_response(db, proposal_id=proposal.id, response=UserResponse(req.response), user_quantity=..., responded_at=utcnow())`. Commit.
+4. Refetch with eager-loaded children → return `ProposalDetail`.
+
+**Idempotency note:** A second `respond` call overwrites the earlier user response. The DB CHECK `(user_response='pending') = (responded_at IS NULL)` is preserved because `responded_at` is always set when a non-pending response is written.
+
+### 7.6 `POST /trading/api/proposals/{proposal_uuid}/actions` → `ActionDetail`
+
+**Body:** `ActionCreateRequest`.
+
+**Behavior:**
+1. Look up proposal (404 if missing/not owned).
+2. Call `record_decision_action(db, proposal_id=proposal.id, action_kind=ActionKind(req.action_kind), external_order_id=..., payload_snapshot=...)`. The service raises `ValueError` if external-id invariant is violated → translate to **HTTP 422** with the message.
+3. Commit. Return `ActionDetail`.
+
+**Safety:** the handler does **not** import or call `app.services.kis*`, `app.services.upbit*`, `app.services.brokers.*`, `app.services.order_service`, `app.services.fill_notification`, watch-alert services, or any Redis token manager. External IDs are passed as opaque strings.
+
+**Status:** 201 Created.
+
+### 7.7 `POST /trading/api/proposals/{proposal_uuid}/counterfactuals` → `CounterfactualDetail`
+
+**Body:** `CounterfactualCreateRequest`.
+
+**Behavior:**
+1. Look up proposal (404 if missing/not owned).
+2. Call `create_counterfactual_track(db, proposal_id=proposal.id, track_kind=TrackKind(req.track_kind), baseline_price=..., payload=...)`. Commit. Return `CounterfactualDetail`.
+
+**Status:** 201 Created.
+
+### 7.8 `POST /trading/api/proposals/{proposal_uuid}/outcomes` → `OutcomeDetail`
+
+**Body:** `OutcomeCreateRequest`.
+
+**Behavior:**
+1. Look up proposal (404 if missing/not owned).
+2. If `counterfactual_id` is provided, verify it belongs to the same proposal — service-level helper or a single SELECT before insert. Mismatch → 422.
+3. Call `record_outcome_mark(...)`. Commit. Return `OutcomeDetail`.
+4. Service raises `ValueError` on `accepted_live` invariant violations → translate to 422.
+5. PostgreSQL `IntegrityError` on the unique `(proposal_id, counterfactual_id, track_kind, horizon)` index → 409 `"Outcome mark already exists for this horizon"`.
+
+**Status:** 201 Created.
+
+### 7.9 Error response shape
+
+All `HTTPException` instances use `detail: str`. No structured error envelope is introduced in this PR (matches `order_intent_preview` precedent). Validation errors come back as standard FastAPI 422 with `loc/msg/type`.
+
+---
+
+## 8. Service layer additions (read helpers)
+
+Add to `app/services/trading_decision_service.py`. Pure persistence — no new write functions.
+
+```python
+async def get_session_by_uuid(
+    session: AsyncSession,
+    *,
+    session_uuid: UUID,
+    user_id: int,
+) -> TradingDecisionSession | None:
+    """Return session iff it exists AND belongs to user_id; eager-load proposals."""
+
+async def list_user_sessions(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    limit: int = 50,
+    offset: int = 0,
+    status: str | None = None,
+) -> tuple[list[tuple[TradingDecisionSession, int, int]], int]:
+    """
+    Return (rows, total). Each row is (session, proposals_count, pending_count).
+    Single SQL query: `SELECT s.*, count(p.id) AS proposals_count,
+    count(p.id) FILTER (WHERE p.user_response='pending') AS pending_count
+    FROM trading_decision_sessions s LEFT JOIN trading_decision_proposals p ...
+    GROUP BY s.id ORDER BY s.generated_at DESC LIMIT :limit OFFSET :offset`.
+    `total` is a separate `SELECT count(*) WHERE user_id = :user_id [AND status=:status]`.
+    """
+
+async def get_proposal_by_uuid(
+    session: AsyncSession,
+    *,
+    proposal_uuid: UUID,
+    user_id: int,
+) -> TradingDecisionProposal | None:
+    """JOIN sessions to enforce ownership. Eager-load actions/counterfactuals/outcomes."""
+```
+
+These are **read-only**. None of them invoke broker, watch, or Redis paths. The §9 forbidden-import test covers them transitively.
+
+---
+
+## 9. Side-effect safety boundaries (forbidden imports)
+
+The router **must not** import (directly or transitively from `app.services.trading_decision_service` or `app.schemas.trading_decisions`) any of:
+
+```text
+app.services.kis
+app.services.kis_trading_service
+app.services.kis_trading_contracts
+app.services.upbit
+app.services.upbit_websocket
+app.services.brokers
+app.services.order_service
+app.services.fill_notification
+app.services.execution_event
+app.services.redis_token_manager
+app.services.kis_websocket
+app.services.kis_websocket_internal
+app.tasks
+```
+
+This is the **same list** ROB-1 enforces on the service module. ROB-2 extends the assertion to the router module.
+
+**Permitted imports** the router *does* need:
+
+- `app.routers.dependencies.get_authenticated_user`
+- `app.core.db.get_db`
+- `app.models.trading.User` (typing only)
+- `app.models.trading_decision.*` (enums + ORM classes)
+- `app.services.trading_decision_service.*` (existing + new read helpers)
+- `app.schemas.trading_decisions.*`
+- standard FastAPI / SQLAlchemy / Pydantic imports
+
+A dedicated test (`tests/test_trading_decisions_router_safety.py`, see §10.6) imports the router module in a clean subprocess and asserts no forbidden module name (exact or `prefix + "."`) ends up in `sys.modules`. Mirrors the ROB-1 service test pattern in `tests/models/test_trading_decision_service.py:576`.
+
+> If a future change pulls in one of these modules — even transitively — the test will fail. The fix is to isolate the import behind a function or move logic, not to weaken the test.
+
+---
+
+## 10. Tests
+
+All tests `pytest`-async. Router tests follow the `TestClient` + `app.dependency_overrides[get_authenticated_user] = lambda: user` pattern from `tests/test_order_intent_preview_router.py` (the canonical example in this repo). The DB layer is mocked via an `AsyncMock` for unit-level router tests; one integration test exercises the full stack against a real test DB (gated by the same `_ensure_trading_decision_tables` helper as ROB-1).
+
+### 10.1 `tests/test_trading_decisions_router.py` — request/response unit tests
+
+Each test creates a `TestClient` with:
+- `app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=7)`
+- `app.dependency_overrides[get_db] = lambda: AsyncMock(...)`
+- The trading_decision_service module is monkeypatched per test to return canned ORM-shaped objects (or `SimpleNamespace`).
+
+Cases (mirrors roadmap’s required test list):
+
+1. **`test_authenticated_create_session`** — POST /decisions returns 201, response includes `session_uuid`, `created_at`, `proposals=[]`.
+2. **`test_unauthenticated_request_returns_401`** — no auth override; assert 401.
+3. **`test_create_proposals_btc_eth_sol`** — POST /decisions/{uuid}/proposals with 3 items returns 201 with all 3 in payload, `user_response="pending"`.
+4. **`test_modify_btc_20_to_10_preserves_original`** — POST /proposals/{uuid}/respond `{response:"modify", user_quantity_pct:10}`. Response shows `original_quantity_pct=20` and `user_quantity_pct=10`. Assert the call to `record_user_response` passed `responded_at` set by the server (not from request body).
+5. **`test_accept_btc_eth_defer_sol`** — three POST /respond calls; each returns the updated proposal; verify per-proposal `user_response` independence.
+6. **`test_record_live_order_action`** — POST /actions `{action_kind:"live_order", external_order_id:"KIS-1", external_source:"kis", payload_snapshot:{...}}`. Assert 201 and that `record_decision_action` was called with those exact kwargs.
+7. **`test_record_watch_alert_action`** — analogous for `watch_alert` + `external_watch_id`.
+8. **`test_action_no_external_id_returns_422`** — body `{action_kind:"live_order"}` with no external_*; Pydantic validator rejects → 422.
+9. **`test_session_not_owned_returns_404`** — service helper returns `None`; assert 404 (not 403, not 401).
+10. **`test_proposal_not_owned_returns_404`** — same for proposal endpoints.
+11. **`test_create_proposals_on_archived_session_returns_409`** — service returns archived session; handler refuses.
+12. **`test_outcome_mark_invalid_track_combo_returns_422`** — request `{track_kind:"accepted_live", counterfactual_id:42}` rejected by validator.
+13. **`test_outcome_mark_duplicate_horizon_returns_409`** — service raises `IntegrityError`; handler maps to 409.
+14. **`test_modify_without_user_fields_returns_422`** — `{response:"modify"}` with no user_* fields → validator error.
+15. **`test_list_decisions_pagination`** — service returns 3 sessions w/ counts; assert response shape, `total`, `limit`, `offset` echoed.
+16. **`test_get_session_detail_includes_nested_actions_and_outcomes`** — service returns session w/ proposals → actions → outcomes; response nests them.
+17. **`test_create_counterfactual_track`** — POST /counterfactuals returns 201; service called with parsed `Decimal`.
+
+### 10.2 `tests/test_trading_decisions_router_safety.py` — forbidden-import safety
+
+Single test (`test_router_module_does_not_import_execution_paths`):
+- Subprocess script imports `app.routers.trading_decisions` (with the same `app.services` pre-stub trick as ROB-1’s `test_service_module_does_not_import_execution_paths`).
+- Asserts none of the §9 forbidden prefixes are present in `sys.modules`.
+
+### 10.3 Schema-vs-DB consistency test
+
+Single test in `tests/test_trading_decisions_router.py` (`test_pydantic_literals_match_db_enums`):
+- Imports `ProposalKind`, `UserResponse`, `ActionKind`, `TrackKind`, `OutcomeHorizon`, `SessionStatus` enums from `app.models.trading_decision` and the corresponding `Literal[...]` aliases from `app.schemas.trading_decisions`.
+- Asserts `set(EnumClass) == set(get_args(LiteralAlias))`. Catches drift if the model gains a new value but the schema is not updated.
+
+### 10.4 Optional integration test
+
+One smoke integration test gated by the `@pytest.mark.integration` marker, using the real test DB (same setup pattern as `tests/models/test_trading_decision_service.py`):
+
+- `test_full_btc_session_round_trip` — creates a user via raw SQL, hits `POST /decisions`, `POST /decisions/{uuid}/proposals`, `POST /proposals/{uuid}/respond`, `GET /decisions/{uuid}`, asserts the returned shape matches the service-level scenario tests in ROB-1.
+
+This test is allowed to be skipped in CI if PG is unavailable (same `_ensure_trading_decision_tables` skip pattern).
+
+### 10.5 Verification commands
+
+```bash
+# unit
+uv run pytest tests/test_trading_decisions_router.py -q
+uv run pytest tests/test_trading_decisions_router_safety.py -q
+
+# integration (DB-required)
+uv run pytest tests/test_trading_decisions_router.py -q -m integration
+
+# full ROB-1 + ROB-2 sanity
+uv run pytest tests/models/test_trading_decision_models.py tests/models/test_trading_decision_service.py tests/test_trading_decisions_router.py tests/test_trading_decisions_router_safety.py -q
+
+# lint
+uv run ruff check app/routers/trading_decisions.py app/schemas/trading_decisions.py tests/test_trading_decisions_router.py tests/test_trading_decisions_router_safety.py
+
+# type
+uv run ty check app/routers/trading_decisions.py app/schemas/trading_decisions.py app/services/trading_decision_service.py
+```
+
+---
+
+## 11. File-by-file changeset
+
+| File | Action | Notes |
+|---|---|---|
+| `app/routers/trading_decisions.py` | **new** | 8 endpoints, ~400 LOC |
+| `app/schemas/trading_decisions.py` | **new** | Pydantic request/response models, ~350 LOC |
+| `app/services/trading_decision_service.py` | **modify** | add 3 read helpers (`get_session_by_uuid`, `list_user_sessions`, `get_proposal_by_uuid`); existing write functions untouched |
+| `app/main.py` | **modify** | import + `include_router(trading_decisions.router)` |
+| `tests/test_trading_decisions_router.py` | **new** | unit/router tests |
+| `tests/test_trading_decisions_router_safety.py` | **new** | subprocess import safety test |
+| `docs/plans/ROB-2-trading-decision-api-contract-plan.md` | **this file** | — |
+
+No model files change. No migration. No template / static / settings change.
+
+---
+
+## 12. Acceptance checklist (used at PR review time)
+
+- [ ] All 8 endpoints in §3 are reachable under `/trading/api/...` exactly as in the roadmap.
+- [ ] All endpoints require authentication; unauthenticated calls return 401.
+- [ ] Cross-user access of `session_uuid` / `proposal_uuid` returns **404** (not 403).
+- [ ] `POST /respond` with `response="modify"` updates `user_*` columns and never mutates `original_*` (verified by integration test §10.4 *and* by the ROB-1 service-level test that already exists).
+- [ ] `responded_at` is server-stamped; client cannot override.
+- [ ] `POST /actions` for `live_order|paper_order|watch_alert` requires at least one external id (rejected at the schema layer with 422).
+- [ ] `POST /outcomes` enforces `(track_kind='accepted_live') ⇔ (counterfactual_id IS NULL)`.
+- [ ] Duplicate outcome at the same horizon returns 409 (DB unique constraint mapped).
+- [ ] `app/routers/trading_decisions.py` imports **none** of the §9 forbidden modules (test enforced).
+- [ ] No new SQLAlchemy model, no Alembic revision, no template, no static asset.
+- [ ] `ruff check app/ tests/` clean. `ty check` clean on the two new files.
+- [ ] `app/main.py` registers the router exactly once, after `trading.router`.
+- [ ] All §10.1–§10.3 tests pass; §10.4 passes when DB is available.
+- [ ] OpenAPI schema (`/openapi.json`) shows all 8 routes under tag `trading-decisions`.
+
+---
+
+## 13. Out-of-scope reminders (do not creep)
+
+If during implementation any of these is tempting, **stop and split into a new PR**:
+
+- Adding any frontend / React / Vite scaffold → ROB-3.
+- Adding outcome dashboard or analytics endpoint beyond the per-proposal POST → ROB-5.
+- Adding a Discord brief or webhook on session creation → out of scope.
+- Calling KIS / Upbit / brokers from the action endpoint, or auto-registering watch alerts → forbidden (§9).
+- Adding a Hermes ingestion route that auto-creates sessions from analyst output → separate PR.
+- Adding admin/global session list views → not now; user-scoped only.
+- Adding WebSocket push of new proposals → out of scope.
+- Soft-delete / archive cascade behavior beyond the 409 refusal → out of scope.
+
+---
+
+## 14. Implementer handoff prompt
+
+Paste the block below into a fresh **Sonnet implementer** session in the same worktree (`feature-ROB-2-trading-decision-api-contract`). The implementer should be a TDD agent — write the failing test first, then the minimal code to make it pass, commit, repeat.
+
+```text
+You are the implementer for ROB-2 (Trading Decision API contract PR).
+
+Worktree:  /Users/mgh3326/work/auto_trader-worktrees/feature-ROB-2-trading-decision-api-contract
+Branch:    feature/ROB-2-trading-decision-api-contract
+Plan:      docs/plans/ROB-2-trading-decision-api-contract-plan.md  ← READ FIRST, FOLLOW EXACTLY
+
+ROB-1 (DB schema + service) is already on main. Do NOT modify ROB-1 models or migrations.
+You may add 3 read helpers to app/services/trading_decision_service.py (see plan §8). Do not add new write helpers.
+
+Constraints (hard):
+1. No broker, watch, or Redis side-effect code. The §9 forbidden-import list is enforced by tests/test_trading_decisions_router_safety.py — that test must stay green.
+2. Cross-user access returns 404, never 403. Authorization is via service-layer helpers only.
+3. responded_at is server-stamped; reject any attempt to read it from the request body.
+4. Decimal fields are strings on the wire (Pydantic v2 default).
+5. Use the existing get_authenticated_user dependency from app/routers/dependencies.py.
+
+Build order (TDD, frequent commits):
+  1. tests/test_trading_decisions_router.py  — start with test_authenticated_create_session and test_unauthenticated_request_returns_401, drive scaffolding from there.
+  2. app/schemas/trading_decisions.py        — schemas exactly per plan §6.
+  3. app/services/trading_decision_service.py — add the 3 read helpers per plan §8 with their own unit tests.
+  4. app/routers/trading_decisions.py        — endpoints per plan §7, one at a time, each behind a failing test first.
+  5. app/main.py                             — register the router.
+  6. tests/test_trading_decisions_router_safety.py — subprocess forbidden-import test.
+  7. Run the verification commands in plan §10.5; everything must pass.
+
+When you finish each endpoint, commit with: `git commit -m "feat(rob-2): <verb> <endpoint>"`.
+
+Open a PR against main when §12 acceptance checklist is fully green.
+```
+
+---
+
+## 15. Open decisions (defaults chosen, easy to revisit in review)
+
+1. **Path parameter naming: `session_uuid` / `proposal_uuid` vs `session_id` / `proposal_id`.** → Use UUIDs. The roadmap uses `{session_id}` informally; FastAPI will type-validate the UUID string. Rationale: never leak DB sequence ids to the client; UUIDs are already stamped on every row.
+2. **One router or split into `decisions_router` + `proposals_router`.** → One router, one module. Eight endpoints, two URL roots, one logical concern.
+3. **Decimal serialization.** → Pydantic v2 default (string). Front-end can use `decimal.js`. Floats would lose precision on `100000000` BTC prices, etc.
+4. **Pagination default 50, max 200.** → Conservative; revisit when the inbox view actually exists in ROB-4.
+5. **Eager-loading strategy.** → `selectinload` for proposals → actions / counterfactuals / outcomes. Avoids N+1 without a giant JOIN cartesian.
+6. **Status filter on list endpoint.** → Optional `status=open|closed|archived`. Useful for the future inbox UI; cheap to add now.
+7. **No bulk respond endpoint.** → Each proposal is responded to individually. Roadmap UX (“accept BTC, accept ETH, defer SOL”) is N×POST. Bulk endpoint can be added in ROB-4 if it proves a real ergonomic need.
+8. **No PATCH/DELETE.** → ROB-2 ships create + read. Cancel/archive is deferred until ROB-4 product UX defines it.
+9. **Logging.** → Standard module logger; no Sentry custom tags in this PR. Sentry SQLAlchemy integration covers DB-level errors automatically.
+10. **Rate limiting.** → Not added. Existing `slowapi` setup applies app-wide; no per-endpoint limits needed for the workflow.

--- a/tests/test_trading_decisions_router.py
+++ b/tests/test_trading_decisions_router.py
@@ -1,4 +1,5 @@
 """Tests for trading decisions router."""
+
 from datetime import datetime
 from decimal import Decimal
 from types import SimpleNamespace
@@ -27,6 +28,7 @@ def _make_test_client():
 
 
 # ========== Authentication Tests ==========
+
 
 @pytest.mark.unit
 def test_authenticated_create_session():
@@ -57,7 +59,9 @@ def test_authenticated_create_session():
         updated_at=datetime.utcnow(),
         proposals=[],
     )
-    trading_decision_service.create_decision_session = AsyncMock(return_value=mock_session)
+    trading_decision_service.create_decision_session = AsyncMock(
+        return_value=mock_session
+    )
     trading_decision_service.get_session_by_uuid = AsyncMock(return_value=mock_session)
 
     client = TestClient(app)
@@ -103,6 +107,7 @@ def test_unauthenticated_request_returns_401():
 
 
 # ========== Session Tests ==========
+
 
 @pytest.mark.unit
 def test_create_proposals_btc_eth_sol():
@@ -168,8 +173,12 @@ def test_create_proposals_btc_eth_sol():
         make_mock_proposal(2, "ETH", "add", "buy"),
         make_mock_proposal(3, "SOL", "pullback_watch", "none"),
     ]
-    trading_decision_service.add_decision_proposals = AsyncMock(return_value=mock_proposals)
-    trading_decision_service.get_proposal_by_uuid = AsyncMock(side_effect=mock_proposals)
+    trading_decision_service.add_decision_proposals = AsyncMock(
+        return_value=mock_proposals
+    )
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(
+        side_effect=mock_proposals
+    )
 
     client = TestClient(app)
 
@@ -261,8 +270,12 @@ def test_modify_btc_20_to_10_preserves_original():
         )
 
     mock_proposal = make_full_mock_proposal()
-    trading_decision_service.get_proposal_by_uuid = AsyncMock(return_value=mock_proposal)
-    trading_decision_service.record_user_response = AsyncMock(return_value=mock_proposal)
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(
+        return_value=mock_proposal
+    )
+    trading_decision_service.record_user_response = AsyncMock(
+        return_value=mock_proposal
+    )
 
     client = TestClient(app)
 
@@ -375,6 +388,7 @@ def test_accept_btc_eth_defer_sol():
 
 # ========== Action Tests ==========
 
+
 @pytest.mark.unit
 def test_record_live_order_action():
     """POST /actions records a live order with external ID."""
@@ -397,7 +411,9 @@ def test_record_live_order_action():
         session=SimpleNamespace(status="open"),
         symbol="BTC",
     )
-    trading_decision_service.get_proposal_by_uuid = AsyncMock(return_value=mock_proposal)
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(
+        return_value=mock_proposal
+    )
 
     mock_action = SimpleNamespace(
         id=1,
@@ -411,7 +427,9 @@ def test_record_live_order_action():
         recorded_at=datetime.utcnow(),
         created_at=datetime.utcnow(),
     )
-    trading_decision_service.record_decision_action = AsyncMock(return_value=mock_action)
+    trading_decision_service.record_decision_action = AsyncMock(
+        return_value=mock_action
+    )
 
     client = TestClient(app)
 
@@ -458,7 +476,9 @@ def test_record_watch_alert_action():
         session=SimpleNamespace(status="open"),
         symbol="BTC",
     )
-    trading_decision_service.get_proposal_by_uuid = AsyncMock(return_value=mock_proposal)
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(
+        return_value=mock_proposal
+    )
 
     mock_action = SimpleNamespace(
         id=1,
@@ -472,7 +492,9 @@ def test_record_watch_alert_action():
         recorded_at=datetime.utcnow(),
         created_at=datetime.utcnow(),
     )
-    trading_decision_service.record_decision_action = AsyncMock(return_value=mock_action)
+    trading_decision_service.record_decision_action = AsyncMock(
+        return_value=mock_action
+    )
 
     client = TestClient(app)
 
@@ -521,6 +543,7 @@ def test_action_no_external_id_returns_422():
 
 
 # ========== Authorization Tests ==========
+
 
 @pytest.mark.unit
 def test_session_not_owned_returns_404():
@@ -578,6 +601,7 @@ def test_proposal_not_owned_returns_404():
 
 # ========== Session State Tests ==========
 
+
 @pytest.mark.unit
 def test_create_proposals_on_archived_session_returns_409():
     """Adding proposals to archived session returns 409."""
@@ -624,6 +648,7 @@ def test_create_proposals_on_archived_session_returns_409():
 
 # ========== Validation Tests ==========
 
+
 @pytest.mark.unit
 def test_modify_without_user_fields_returns_422():
     """Modify response without any user_* fields returns 422."""
@@ -649,6 +674,7 @@ def test_modify_without_user_fields_returns_422():
 
 
 # ========== Outcome Tests ==========
+
 
 @pytest.mark.unit
 def test_outcome_mark_invalid_track_combo_returns_422():
@@ -704,7 +730,9 @@ def test_outcome_mark_duplicate_horizon_returns_409():
         session=SimpleNamespace(status="open"),
         symbol="BTC",
     )
-    trading_decision_service.get_proposal_by_uuid = AsyncMock(return_value=mock_proposal)
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(
+        return_value=mock_proposal
+    )
 
     # Simulate unique constraint violation
     trading_decision_service.record_outcome_mark = AsyncMock(
@@ -728,6 +756,7 @@ def test_outcome_mark_duplicate_horizon_returns_409():
 
 
 # ========== List/Pagination Tests ==========
+
 
 @pytest.mark.unit
 def test_list_decisions_pagination():
@@ -774,7 +803,9 @@ def test_list_decisions_pagination():
             0,  # pending_count
         ),
     ]
-    trading_decision_service.list_user_sessions = AsyncMock(return_value=(mock_sessions, 10))
+    trading_decision_service.list_user_sessions = AsyncMock(
+        return_value=(mock_sessions, 10)
+    )
 
     client = TestClient(app)
 
@@ -899,6 +930,7 @@ def test_get_session_detail_includes_nested_actions_and_outcomes():
 
 # ========== Counterfactual Tests ==========
 
+
 @pytest.mark.unit
 def test_create_counterfactual_track():
     """POST /counterfactuals creates a counterfactual track."""
@@ -921,7 +953,9 @@ def test_create_counterfactual_track():
         session=SimpleNamespace(status="open"),
         symbol="SOL",
     )
-    trading_decision_service.get_proposal_by_uuid = AsyncMock(return_value=mock_proposal)
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(
+        return_value=mock_proposal
+    )
 
     mock_counterfactual = SimpleNamespace(
         id=1,
@@ -934,7 +968,9 @@ def test_create_counterfactual_track():
         notes=None,
         created_at=datetime.utcnow(),
     )
-    trading_decision_service.create_counterfactual_track = AsyncMock(return_value=mock_counterfactual)
+    trading_decision_service.create_counterfactual_track = AsyncMock(
+        return_value=mock_counterfactual
+    )
 
     client = TestClient(app)
 
@@ -957,6 +993,7 @@ def test_create_counterfactual_track():
 
 
 # ========== Schema Consistency Test ==========
+
 
 @pytest.mark.unit
 def test_pydantic_literals_match_db_enums():

--- a/tests/test_trading_decisions_router.py
+++ b/tests/test_trading_decisions_router.py
@@ -1,0 +1,991 @@
+"""Tests for trading decisions router."""
+from datetime import datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+# Helpers
+def _make_test_client():
+    """Create a test client with mocked dependencies."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    # Mock authenticated user
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    return TestClient(app), app, fake_user
+
+
+# ========== Authentication Tests ==========
+
+@pytest.mark.unit
+def test_authenticated_create_session():
+    """POST /decisions returns 201 with session data when authenticated."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+    from app.services import trading_decision_service
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    # Mock the service
+    mock_session = SimpleNamespace(
+        id=1,
+        session_uuid=uuid4(),
+        user_id=7,
+        source_profile="test_profile",
+        strategy_name=None,
+        market_scope=None,
+        status="open",
+        notes=None,
+        market_brief=None,
+        generated_at=datetime.utcnow(),
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+        proposals=[],
+    )
+    trading_decision_service.create_decision_session = AsyncMock(return_value=mock_session)
+    trading_decision_service.get_session_by_uuid = AsyncMock(return_value=mock_session)
+
+    client = TestClient(app)
+
+    response = client.post(
+        "/trading/api/decisions",
+        json={
+            "source_profile": "test_profile",
+            "generated_at": datetime.utcnow().isoformat(),
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert "session_uuid" in body
+    assert body["source_profile"] == "test_profile"
+    assert body["status"] == "open"
+    assert "proposals" in body
+
+
+@pytest.mark.unit
+def test_unauthenticated_request_returns_401():
+    """Unauthenticated requests return 401."""
+    from fastapi import HTTPException
+
+    from app.core.db import get_db
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    def raise_unauthorized():
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    app.dependency_overrides[get_authenticated_user] = raise_unauthorized
+    app.dependency_overrides[get_db] = lambda: AsyncMock()
+
+    client = TestClient(app)
+
+    response = client.get("/trading/api/decisions")
+    assert response.status_code == 401
+
+
+# ========== Session Tests ==========
+
+@pytest.mark.unit
+def test_create_proposals_btc_eth_sol():
+    """POST /decisions/{uuid}/proposals with 3 items returns 201 with all 3."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+    from app.services import trading_decision_service
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    session_uuid = uuid4()
+
+    # Mock session
+    mock_session = SimpleNamespace(
+        id=1,
+        session_uuid=session_uuid,
+        user_id=7,
+        status="open",
+    )
+    trading_decision_service.get_session_by_uuid = AsyncMock(return_value=mock_session)
+
+    # Mock proposals - need all fields for _to_proposal_detail
+    def make_mock_proposal(pid, symbol, kind, side):
+        return SimpleNamespace(
+            id=pid,
+            proposal_uuid=uuid4(),
+            session_id=1,
+            symbol=symbol,
+            instrument_type="crypto",
+            proposal_kind=kind,
+            side=side,
+            user_response="pending",
+            responded_at=None,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            original_quantity=None,
+            original_quantity_pct=None,
+            original_amount=None,
+            original_price=None,
+            original_trigger_price=None,
+            original_threshold_pct=None,
+            original_currency=None,
+            original_rationale=None,
+            original_payload={"test": "data"},
+            user_quantity=None,
+            user_quantity_pct=None,
+            user_amount=None,
+            user_price=None,
+            user_trigger_price=None,
+            user_threshold_pct=None,
+            user_note=None,
+            actions=[],
+            counterfactuals=[],
+            outcomes=[],
+        )
+
+    mock_proposals = [
+        make_mock_proposal(1, "BTC", "trim", "sell"),
+        make_mock_proposal(2, "ETH", "add", "buy"),
+        make_mock_proposal(3, "SOL", "pullback_watch", "none"),
+    ]
+    trading_decision_service.add_decision_proposals = AsyncMock(return_value=mock_proposals)
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(side_effect=mock_proposals)
+
+    client = TestClient(app)
+
+    response = client.post(
+        f"/trading/api/decisions/{session_uuid}/proposals",
+        json={
+            "proposals": [
+                {
+                    "symbol": "BTC",
+                    "instrument_type": "crypto",
+                    "proposal_kind": "trim",
+                    "side": "sell",
+                    "original_quantity": "0.5",
+                    "original_payload": {"test": "data"},
+                },
+                {
+                    "symbol": "ETH",
+                    "instrument_type": "crypto",
+                    "proposal_kind": "add",
+                    "side": "buy",
+                    "original_payload": {"test": "data"},
+                },
+                {
+                    "symbol": "SOL",
+                    "instrument_type": "crypto",
+                    "proposal_kind": "pullback_watch",
+                    "side": "none",
+                    "original_payload": {"test": "data"},
+                },
+            ]
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert len(body["proposals"]) == 3
+    for p in body["proposals"]:
+        assert p["user_response"] == "pending"
+
+
+@pytest.mark.unit
+def test_modify_btc_20_to_10_preserves_original():
+    """Modify response updates user_* fields while preserving original_* fields."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+    from app.services import trading_decision_service
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    proposal_uuid = uuid4()
+
+    def make_full_mock_proposal():
+        return SimpleNamespace(
+            id=1,
+            proposal_uuid=proposal_uuid,
+            session_id=1,
+            session=SimpleNamespace(status="open"),
+            symbol="BTC",
+            instrument_type="crypto",
+            proposal_kind="trim",
+            side="sell",
+            user_response="modify",
+            responded_at=datetime.utcnow(),
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            original_quantity=None,
+            original_quantity_pct=Decimal("20"),
+            original_amount=None,
+            original_price=None,
+            original_trigger_price=None,
+            original_threshold_pct=None,
+            original_currency=None,
+            original_rationale=None,
+            original_payload={},
+            user_quantity=None,
+            user_quantity_pct=Decimal("10"),
+            user_amount=None,
+            user_price=None,
+            user_trigger_price=None,
+            user_threshold_pct=None,
+            user_note=None,
+            actions=[],
+            counterfactuals=[],
+            outcomes=[],
+        )
+
+    mock_proposal = make_full_mock_proposal()
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(return_value=mock_proposal)
+    trading_decision_service.record_user_response = AsyncMock(return_value=mock_proposal)
+
+    client = TestClient(app)
+
+    response = client.post(
+        f"/trading/api/proposals/{proposal_uuid}/respond",
+        json={
+            "response": "modify",
+            "user_quantity_pct": "10",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["original_quantity_pct"] == "20"
+    assert body["user_quantity_pct"] == "10"
+
+    call_kwargs = trading_decision_service.record_user_response.await_args.kwargs
+    assert call_kwargs["responded_at"] is not None
+
+
+@pytest.mark.unit
+def test_accept_btc_eth_defer_sol():
+    """Test multiple proposals with different responses."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+    from app.services import trading_decision_service
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    def make_mock_proposal(proposal_uuid, symbol, response):
+        return SimpleNamespace(
+            id=1,
+            proposal_uuid=proposal_uuid,
+            session_id=1,
+            session=SimpleNamespace(status="open"),
+            symbol=symbol,
+            instrument_type="crypto",
+            proposal_kind="trim" if symbol == "BTC" else "add",
+            side="sell" if symbol == "BTC" else "buy",
+            user_response=response,
+            responded_at=datetime.utcnow(),
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+            original_quantity=None,
+            original_quantity_pct=None,
+            original_amount=None,
+            original_price=None,
+            original_trigger_price=None,
+            original_threshold_pct=None,
+            original_currency=None,
+            original_rationale=None,
+            original_payload={},
+            user_quantity=None,
+            user_quantity_pct=None,
+            user_amount=None,
+            user_price=None,
+            user_trigger_price=None,
+            user_threshold_pct=None,
+            user_note=None,
+            actions=[],
+            counterfactuals=[],
+            outcomes=[],
+        )
+
+    # BTC accept
+    btc_uuid = uuid4()
+    mock_btc = make_mock_proposal(btc_uuid, "BTC", "accept")
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(return_value=mock_btc)
+    trading_decision_service.record_user_response = AsyncMock(return_value=mock_btc)
+
+    client = TestClient(app)
+
+    response = client.post(
+        f"/trading/api/proposals/{btc_uuid}/respond",
+        json={"response": "accept"},
+    )
+    assert response.status_code == 200
+    assert response.json()["user_response"] == "accept"
+
+    # ETH accept
+    eth_uuid = uuid4()
+    mock_eth = make_mock_proposal(eth_uuid, "ETH", "accept")
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(return_value=mock_eth)
+    trading_decision_service.record_user_response = AsyncMock(return_value=mock_eth)
+
+    response = client.post(
+        f"/trading/api/proposals/{eth_uuid}/respond",
+        json={"response": "accept"},
+    )
+    assert response.status_code == 200
+    assert response.json()["user_response"] == "accept"
+
+    # SOL defer
+    sol_uuid = uuid4()
+    mock_sol = make_mock_proposal(sol_uuid, "SOL", "defer")
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(return_value=mock_sol)
+    trading_decision_service.record_user_response = AsyncMock(return_value=mock_sol)
+
+    response = client.post(
+        f"/trading/api/proposals/{sol_uuid}/respond",
+        json={"response": "defer"},
+    )
+    assert response.status_code == 200
+    assert response.json()["user_response"] == "defer"
+
+
+# ========== Action Tests ==========
+
+@pytest.mark.unit
+def test_record_live_order_action():
+    """POST /actions records a live order with external ID."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+    from app.services import trading_decision_service
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    proposal_uuid = uuid4()
+
+    mock_proposal = SimpleNamespace(
+        id=1,
+        proposal_uuid=proposal_uuid,
+        session_id=1,
+        session=SimpleNamespace(status="open"),
+        symbol="BTC",
+    )
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(return_value=mock_proposal)
+
+    mock_action = SimpleNamespace(
+        id=1,
+        proposal_id=1,
+        action_kind="live_order",
+        external_order_id="KIS-12345",
+        external_paper_id=None,
+        external_watch_id=None,
+        external_source="kis",
+        payload_snapshot={"order": "data"},
+        recorded_at=datetime.utcnow(),
+        created_at=datetime.utcnow(),
+    )
+    trading_decision_service.record_decision_action = AsyncMock(return_value=mock_action)
+
+    client = TestClient(app)
+
+    response = client.post(
+        f"/trading/api/proposals/{proposal_uuid}/actions",
+        json={
+            "action_kind": "live_order",
+            "external_order_id": "KIS-12345",
+            "external_source": "kis",
+            "payload_snapshot": {"order": "data"},
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["action_kind"] == "live_order"
+    assert body["external_order_id"] == "KIS-12345"
+
+    # Verify service was called with correct kwargs
+    call_kwargs = trading_decision_service.record_decision_action.await_args.kwargs
+    assert call_kwargs["external_order_id"] == "KIS-12345"
+    assert call_kwargs["external_source"] == "kis"
+
+
+@pytest.mark.unit
+def test_record_watch_alert_action():
+    """POST /actions records a watch alert with external watch ID."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+    from app.services import trading_decision_service
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    proposal_uuid = uuid4()
+
+    mock_proposal = SimpleNamespace(
+        id=1,
+        proposal_uuid=proposal_uuid,
+        session_id=1,
+        session=SimpleNamespace(status="open"),
+        symbol="BTC",
+    )
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(return_value=mock_proposal)
+
+    mock_action = SimpleNamespace(
+        id=1,
+        proposal_id=1,
+        action_kind="watch_alert",
+        external_order_id=None,
+        external_paper_id=None,
+        external_watch_id="WATCH-12345",
+        external_source="upbit",
+        payload_snapshot={"alert": "data"},
+        recorded_at=datetime.utcnow(),
+        created_at=datetime.utcnow(),
+    )
+    trading_decision_service.record_decision_action = AsyncMock(return_value=mock_action)
+
+    client = TestClient(app)
+
+    response = client.post(
+        f"/trading/api/proposals/{proposal_uuid}/actions",
+        json={
+            "action_kind": "watch_alert",
+            "external_watch_id": "WATCH-12345",
+            "external_source": "upbit",
+            "payload_snapshot": {"alert": "data"},
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["action_kind"] == "watch_alert"
+    assert body["external_watch_id"] == "WATCH-12345"
+
+
+@pytest.mark.unit
+def test_action_no_external_id_returns_422():
+    """Action requiring external ID but none provided returns 422."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    proposal_uuid = uuid4()
+
+    client = TestClient(app)
+
+    # Try to create live_order without external ID
+    response = client.post(
+        f"/trading/api/proposals/{proposal_uuid}/actions",
+        json={
+            "action_kind": "live_order",
+            "payload_snapshot": {"order": "data"},
+        },
+    )
+
+    assert response.status_code == 422
+
+
+# ========== Authorization Tests ==========
+
+@pytest.mark.unit
+def test_session_not_owned_returns_404():
+    """Accessing another user's session returns 404 (not 403)."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+    from app.services import trading_decision_service
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    session_uuid = uuid4()
+
+    # Service returns None when not found or not owned
+    trading_decision_service.get_session_by_uuid = AsyncMock(return_value=None)
+
+    client = TestClient(app)
+
+    response = client.get(f"/trading/api/decisions/{session_uuid}")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+@pytest.mark.unit
+def test_proposal_not_owned_returns_404():
+    """Accessing another user's proposal returns 404 (not 403)."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+    from app.services import trading_decision_service
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    proposal_uuid = uuid4()
+
+    # Service returns None when not found or not owned
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(return_value=None)
+
+    client = TestClient(app)
+
+    response = client.post(
+        f"/trading/api/proposals/{proposal_uuid}/respond",
+        json={"response": "accept"},
+    )
+
+    assert response.status_code == 404
+
+
+# ========== Session State Tests ==========
+
+@pytest.mark.unit
+def test_create_proposals_on_archived_session_returns_409():
+    """Adding proposals to archived session returns 409."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+    from app.services import trading_decision_service
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    session_uuid = uuid4()
+
+    # Mock archived session
+    mock_session = SimpleNamespace(
+        id=1,
+        session_uuid=session_uuid,
+        user_id=7,
+        status="archived",
+    )
+    trading_decision_service.get_session_by_uuid = AsyncMock(return_value=mock_session)
+
+    client = TestClient(app)
+
+    response = client.post(
+        f"/trading/api/decisions/{session_uuid}/proposals",
+        json={
+            "proposals": [
+                {
+                    "symbol": "BTC",
+                    "instrument_type": "crypto",
+                    "proposal_kind": "trim",
+                    "original_payload": {},
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 409
+    assert "not open" in response.json()["detail"].lower()
+
+
+# ========== Validation Tests ==========
+
+@pytest.mark.unit
+def test_modify_without_user_fields_returns_422():
+    """Modify response without any user_* fields returns 422."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    proposal_uuid = uuid4()
+
+    client = TestClient(app)
+
+    response = client.post(
+        f"/trading/api/proposals/{proposal_uuid}/respond",
+        json={"response": "modify"},  # No user_* fields
+    )
+
+    assert response.status_code == 422
+
+
+# ========== Outcome Tests ==========
+
+@pytest.mark.unit
+def test_outcome_mark_invalid_track_combo_returns_422():
+    """Outcome with accepted_live + counterfactual_id returns 422."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    proposal_uuid = uuid4()
+
+    client = TestClient(app)
+
+    response = client.post(
+        f"/trading/api/proposals/{proposal_uuid}/outcomes",
+        json={
+            "track_kind": "accepted_live",
+            "counterfactual_id": 42,
+            "horizon": "1h",
+            "price_at_mark": "50000",
+            "marked_at": datetime.utcnow().isoformat(),
+        },
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.unit
+def test_outcome_mark_duplicate_horizon_returns_409():
+    """Duplicate outcome mark at same horizon returns 409."""
+    from sqlalchemy.exc import IntegrityError
+
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+    from app.services import trading_decision_service
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    proposal_uuid = uuid4()
+
+    mock_proposal = SimpleNamespace(
+        id=1,
+        proposal_uuid=proposal_uuid,
+        session_id=1,
+        session=SimpleNamespace(status="open"),
+        symbol="BTC",
+    )
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(return_value=mock_proposal)
+
+    # Simulate unique constraint violation
+    trading_decision_service.record_outcome_mark = AsyncMock(
+        side_effect=IntegrityError("Duplicate", None, None)
+    )
+
+    client = TestClient(app)
+
+    response = client.post(
+        f"/trading/api/proposals/{proposal_uuid}/outcomes",
+        json={
+            "track_kind": "accepted_live",
+            "horizon": "1h",
+            "price_at_mark": "50000",
+            "marked_at": datetime.utcnow().isoformat(),
+        },
+    )
+
+    assert response.status_code == 409
+    assert "already exists" in response.json()["detail"].lower()
+
+
+# ========== List/Pagination Tests ==========
+
+@pytest.mark.unit
+def test_list_decisions_pagination():
+    """GET /decisions returns paginated list with counts."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+    from app.services import trading_decision_service
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    mock_sessions = [
+        (
+            SimpleNamespace(
+                id=1,
+                session_uuid=uuid4(),
+                source_profile="profile1",
+                strategy_name=None,
+                market_scope=None,
+                status="open",
+                generated_at=datetime.utcnow(),
+                created_at=datetime.utcnow(),
+                updated_at=datetime.utcnow(),
+            ),
+            5,  # proposals_count
+            2,  # pending_count
+        ),
+        (
+            SimpleNamespace(
+                id=2,
+                session_uuid=uuid4(),
+                source_profile="profile2",
+                strategy_name="test_strategy",
+                market_scope="KR",
+                status="closed",
+                generated_at=datetime.utcnow(),
+                created_at=datetime.utcnow(),
+                updated_at=datetime.utcnow(),
+            ),
+            3,  # proposals_count
+            0,  # pending_count
+        ),
+    ]
+    trading_decision_service.list_user_sessions = AsyncMock(return_value=(mock_sessions, 10))
+
+    client = TestClient(app)
+
+    response = client.get("/trading/api/decisions?limit=50&offset=0")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["total"] == 10
+    assert body["limit"] == 50
+    assert body["offset"] == 0
+    assert len(body["sessions"]) == 2
+    assert body["sessions"][0]["proposals_count"] == 5
+    assert body["sessions"][0]["pending_count"] == 2
+
+
+@pytest.mark.unit
+def test_get_session_detail_includes_nested_actions_and_outcomes():
+    """GET /decisions/{uuid} includes nested proposals with actions/outcomes."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+    from app.services import trading_decision_service
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    session_uuid = uuid4()
+    proposal_uuid = uuid4()
+
+    # Build nested structure
+    mock_session = SimpleNamespace(
+        id=1,
+        session_uuid=session_uuid,
+        user_id=7,
+        source_profile="test",
+        strategy_name=None,
+        market_scope=None,
+        status="open",
+        notes=None,
+        market_brief={},
+        generated_at=datetime.utcnow(),
+        created_at=datetime.utcnow(),
+        updated_at=datetime.utcnow(),
+        proposals=[
+            SimpleNamespace(
+                id=1,
+                proposal_uuid=proposal_uuid,
+                session_id=1,
+                symbol="BTC",
+                instrument_type="crypto",
+                proposal_kind="trim",
+                side="sell",
+                user_response="accept",
+                responded_at=datetime.utcnow(),
+                created_at=datetime.utcnow(),
+                updated_at=datetime.utcnow(),
+                original_quantity=Decimal("0.5"),
+                original_quantity_pct=None,
+                original_amount=None,
+                original_price=None,
+                original_trigger_price=None,
+                original_threshold_pct=None,
+                original_currency=None,
+                original_rationale=None,
+                original_payload={},
+                user_quantity=None,
+                user_quantity_pct=None,
+                user_amount=None,
+                user_price=None,
+                user_trigger_price=None,
+                user_threshold_pct=None,
+                user_note=None,
+                actions=[
+                    SimpleNamespace(
+                        id=1,
+                        proposal_id=1,
+                        action_kind="live_order",
+                        external_order_id="KIS-12345",
+                        external_paper_id=None,
+                        external_watch_id=None,
+                        external_source="kis",
+                        payload_snapshot={"order": "data"},
+                        recorded_at=datetime.utcnow(),
+                        created_at=datetime.utcnow(),
+                    )
+                ],
+                counterfactuals=[],
+                outcomes=[
+                    SimpleNamespace(
+                        id=1,
+                        proposal_id=1,
+                        counterfactual_id=None,
+                        track_kind="accepted_live",
+                        horizon="1h",
+                        price_at_mark=Decimal("50000"),
+                        pnl_pct=Decimal("5.5"),
+                        pnl_amount=Decimal("100"),
+                        marked_at=datetime.utcnow(),
+                        payload=None,
+                        created_at=datetime.utcnow(),
+                    )
+                ],
+            )
+        ],
+    )
+    trading_decision_service.get_session_by_uuid = AsyncMock(return_value=mock_session)
+
+    client = TestClient(app)
+
+    response = client.get(f"/trading/api/decisions/{session_uuid}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["proposals"]) == 1
+    assert len(body["proposals"][0]["actions"]) == 1
+    assert len(body["proposals"][0]["outcomes"]) == 1
+    assert body["proposals"][0]["actions"][0]["action_kind"] == "live_order"
+    assert body["proposals"][0]["outcomes"][0]["horizon"] == "1h"
+
+
+# ========== Counterfactual Tests ==========
+
+@pytest.mark.unit
+def test_create_counterfactual_track():
+    """POST /counterfactuals creates a counterfactual track."""
+    from app.routers import trading_decisions
+    from app.routers.dependencies import get_authenticated_user
+    from app.services import trading_decision_service
+
+    app = FastAPI()
+    app.include_router(trading_decisions.router)
+
+    fake_user = SimpleNamespace(id=7)
+    app.dependency_overrides[get_authenticated_user] = lambda: fake_user
+
+    proposal_uuid = uuid4()
+
+    mock_proposal = SimpleNamespace(
+        id=1,
+        proposal_uuid=proposal_uuid,
+        session_id=1,
+        session=SimpleNamespace(status="open"),
+        symbol="SOL",
+    )
+    trading_decision_service.get_proposal_by_uuid = AsyncMock(return_value=mock_proposal)
+
+    mock_counterfactual = SimpleNamespace(
+        id=1,
+        proposal_id=1,
+        track_kind="rejected_counterfactual",
+        baseline_price=Decimal("100"),
+        baseline_at=datetime.utcnow(),
+        quantity=Decimal("10"),
+        payload={"test": "data"},
+        notes=None,
+        created_at=datetime.utcnow(),
+    )
+    trading_decision_service.create_counterfactual_track = AsyncMock(return_value=mock_counterfactual)
+
+    client = TestClient(app)
+
+    response = client.post(
+        f"/trading/api/proposals/{proposal_uuid}/counterfactuals",
+        json={
+            "track_kind": "rejected_counterfactual",
+            "baseline_price": "100",
+            "baseline_at": datetime.utcnow().isoformat(),
+            "quantity": "10",
+            "payload": {"test": "data"},
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["track_kind"] == "rejected_counterfactual"
+    assert body["baseline_price"] == "100"
+    assert body["quantity"] == "10"
+
+
+# ========== Schema Consistency Test ==========
+
+@pytest.mark.unit
+def test_pydantic_literals_match_db_enums():
+    """Verify Pydantic Literal types match SQLAlchemy Enum values."""
+    from typing import get_args
+
+    from app.models.trading import InstrumentType
+    from app.models.trading_decision import (
+        ActionKind,
+        OutcomeHorizon,
+        ProposalKind,
+        SessionStatus,
+        TrackKind,
+        UserResponse,
+    )
+    from app.schemas.trading_decisions import (
+        ActionKindLiteral,
+        InstrumentTypeLiteral,
+        OutcomeHorizonLiteral,
+        ProposalKindLiteral,
+        SessionStatusLiteral,
+        TrackKindLiteral,
+        UserResponseLiteral,
+    )
+
+    assert set(InstrumentType) == set(get_args(InstrumentTypeLiteral))
+    assert set(ProposalKind) == set(get_args(ProposalKindLiteral))
+    assert set(UserResponse) == set(get_args(UserResponseLiteral))
+    assert set(ActionKind) == set(get_args(ActionKindLiteral))
+    assert set(TrackKind) == set(get_args(TrackKindLiteral))
+    assert set(OutcomeHorizon) == set(get_args(OutcomeHorizonLiteral))
+    assert set(SessionStatus) == set(get_args(SessionStatusLiteral))

--- a/tests/test_trading_decisions_router_safety.py
+++ b/tests/test_trading_decisions_router_safety.py
@@ -1,4 +1,5 @@
 """Safety test to verify trading_decisions router does not import execution paths."""
+
 import json
 import os
 import subprocess

--- a/tests/test_trading_decisions_router_safety.py
+++ b/tests/test_trading_decisions_router_safety.py
@@ -1,0 +1,59 @@
+"""Safety test to verify trading_decisions router does not import execution paths."""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+FORBIDDEN_PREFIXES = [
+    "app.services.kis",
+    "app.services.kis_trading_service",
+    "app.services.kis_trading_contracts",
+    "app.services.upbit",
+    "app.services.upbit_websocket",
+    "app.services.brokers",
+    "app.services.order_service",
+    "app.services.fill_notification",
+    "app.services.execution_event",
+    "app.services.redis_token_manager",
+    "app.services.kis_websocket",
+    "app.services.kis_websocket_internal",
+    "app.tasks",
+]
+
+
+@pytest.mark.unit
+def test_router_module_does_not_import_execution_paths():
+    """Import the router in a fresh process and check transitive imports."""
+    project_root = Path(__file__).resolve().parent.parent
+    script = """
+import importlib
+import json
+import sys
+
+importlib.import_module("app.routers.trading_decisions")
+print(json.dumps(sorted(sys.modules)))
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(project_root)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=project_root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    loaded_modules = set(json.loads(result.stdout))
+
+    violations = sorted(
+        module
+        for module in loaded_modules
+        for forbidden in FORBIDDEN_PREFIXES
+        if module == forbidden or module.startswith(f"{forbidden}.")
+    )
+
+    if violations:
+        pytest.fail(f"Found forbidden execution-path imports: {violations}")


### PR DESCRIPTION
## Summary
- Adds ROB-2 Trading Decision API contract endpoints for sessions, proposals, responses, actions, counterfactuals, and outcomes.
- Adds Pydantic schemas and service read helpers over the ROB-1 persistence layer.
- Registers the new FastAPI router and adds router/safety tests.
- Includes the AoE implementation plan doc for this PR slice.

## Scope / Safety
- Backend API only; no React/Vite UI.
- No Discord delivery, periodic reassessment, broker/watch execution, KIS/Upbit, or Redis side effects.
- Proposal `original_*` fields remain immutable through response APIs.
- Cross-user access returns 404 to avoid leaking session/proposal existence.

## Verification
- `uv run pytest tests/test_trading_decisions_router.py tests/test_trading_decisions_router_safety.py -q` → 19 passed
- `uv run ruff check app/routers/trading_decisions.py app/schemas/trading_decisions.py app/services/trading_decision_service.py app/main.py tests/test_trading_decisions_router.py tests/test_trading_decisions_router_safety.py` → passed
- `uv run ty check app/routers/trading_decisions.py app/schemas/trading_decisions.py app/services/trading_decision_service.py app/main.py` → passed

Linear: ROB-2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trading decisions API with authenticated endpoints for creating and managing decision sessions
  * Added support for creating proposals, responding with modifications, and tracking proposal metadata
  * Added ability to record actions, counterfactuals, and outcomes with comprehensive validation
  * Improved error handling and data integrity checks across the trading workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->