### PR TITLE
feat(rob-9): ingest TradingAgents advisory research

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,6 +422,12 @@ TELEGRAM_CHAT_IDS_STR=chat_id1,chat_id2
 
 # OpenDART (선택사항)
 OPENDART_API_KEY=xxx
+
+# TradingAgents advisory runner (ROB-9, 선택사항)
+TRADINGAGENTS_REPO_PATH=/path/to/TradingAgents
+TRADINGAGENTS_PYTHON=/path/to/TradingAgents/.venv/bin/python
+TRADINGAGENTS_RUNNER_PATH=/path/to/run_auto_trader_research.py
+# 전체 설정과 안전 제약은 docs/plans/ROB-9-tradingagents-auto-trader-integration-plan.md 참고
 ```
 
 ## 테스트 작성

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -421,6 +421,21 @@ class Settings(BaseSettings):
     ai_advisor_timeout: float = 60.0
     ai_advisor_default_provider: str = "gemini"
 
+    # TradingAgents advisory runner (ROB-9)
+    tradingagents_repo_path: str | None = None
+    tradingagents_python: str | None = None
+    tradingagents_runner_path: str | None = None
+    tradingagents_base_url: str = "http://127.0.0.1:8796/v1"
+    tradingagents_model: str = "gpt-5.5"
+    tradingagents_default_analysts: str = "market"
+    tradingagents_subprocess_timeout_sec: int = 300
+    tradingagents_max_debate_rounds: int = 1
+    tradingagents_max_risk_discuss_rounds: int = 1
+    tradingagents_max_recur_limit: int = 30
+    tradingagents_output_language: str = "English"
+    tradingagents_checkpoint_enabled: bool = False
+    tradingagents_memory_log_path: str | None = None
+
     model_config = SettingsConfigDict(
         env_file=os.getenv("ENV_FILE", ".env"),
         env_file_encoding="utf-8",

--- a/app/schemas/tradingagents_research.py
+++ b/app/schemas/tradingagents_research.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TradingAgentsLLM(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    provider: str
+    model: str
+    base_url: str
+
+
+class TradingAgentsConfigSnapshot(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    max_debate_rounds: int
+    max_risk_discuss_rounds: int
+    max_recur_limit: int
+    output_language: str
+    checkpoint_enabled: bool
+
+
+class TradingAgentsWarnings(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    structured_output: list[str] = Field(default_factory=list)
+
+
+class TradingAgentsRunnerResult(BaseModel):
+    """Strict contract for advisory-only TradingAgents runner output."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    status: Literal["ok"]
+    symbol: str = Field(min_length=1, max_length=64)
+    as_of_date: date
+    decision: str
+    advisory_only: Literal[True]
+    execution_allowed: Literal[False]
+    analysts: list[str] = Field(min_length=1)
+    llm: TradingAgentsLLM
+    config: TradingAgentsConfigSnapshot
+    warnings: TradingAgentsWarnings
+    final_trade_decision: str
+    raw_state_keys: list[str]

--- a/app/services/tradingagents_research_service.py
+++ b/app/services/tradingagents_research_service.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import logging
+import os
+import re
+import sys
+from collections.abc import Sequence
+from datetime import UTC, date, datetime, time
+from pathlib import Path
+
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.trading import InstrumentType
+from app.models.trading_decision import (
+    ProposalKind,
+    TradingDecisionProposal,
+    TradingDecisionSession,
+)
+from app.schemas.tradingagents_research import TradingAgentsRunnerResult
+from app.services import trading_decision_service
+
+logger = logging.getLogger(__name__)
+
+_SYMBOL_RE = re.compile(r"^[A-Za-z0-9._/-]{1,32}$")
+_ANALYST_RE = re.compile(r"^[a-z_]{1,32}$")
+_ENV_ALLOWLIST = {"PATH", "HOME", "LANG", "LC_ALL", "PYTHONPATH"}
+_SENSITIVE_LINE_RE = re.compile(
+    r"(key|token|secret|authorization)", flags=re.IGNORECASE
+)
+
+
+class TradingAgentsNotConfigured(RuntimeError):
+    """TradingAgents runner settings or files are missing."""
+
+
+class TradingAgentsRunnerError(RuntimeError):
+    """TradingAgents subprocess failed or produced unusable output."""
+
+
+class AdvisoryInvariantViolation(TradingAgentsRunnerError):
+    """Runner JSON violated the advisory-only safety contract."""
+
+
+def _validate_symbol(symbol: str) -> str:
+    if not _SYMBOL_RE.fullmatch(symbol):
+        raise ValueError("symbol contains unsupported characters")
+    return symbol
+
+
+def _analysts_or_default(analysts: Sequence[str] | None) -> list[str]:
+    values = (
+        list(analysts)
+        if analysts is not None
+        else [
+            item.strip()
+            for item in settings.tradingagents_default_analysts.split(",")
+            if item.strip()
+        ]
+    )
+    if not values:
+        raise ValueError("at least one analyst is required")
+    for analyst in values:
+        if not _ANALYST_RE.fullmatch(analyst):
+            raise ValueError("analyst contains unsupported characters")
+    return values
+
+
+def _resolve_existing_file(path: Path, label: str) -> str:
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise TradingAgentsNotConfigured(f"{label} does not exist or is not a file")
+    return str(resolved)
+
+
+def _resolve_existing_dir(path: Path, label: str) -> str:
+    resolved = path.expanduser().resolve()
+    if not resolved.is_dir():
+        raise TradingAgentsNotConfigured(
+            f"{label} does not exist or is not a directory"
+        )
+    return str(resolved)
+
+
+def _resolve_runner_paths() -> tuple[str, str, str]:
+    if settings.tradingagents_repo_path is None:
+        raise TradingAgentsNotConfigured("tradingagents_repo_path is not configured")
+
+    repo = Path(settings.tradingagents_repo_path)
+    repo_path = _resolve_existing_dir(repo, "tradingagents_repo_path")
+
+    if settings.tradingagents_runner_path is None:
+        runner = Path(repo_path) / "scripts" / "run_auto_trader_research.py"
+    else:
+        runner = Path(settings.tradingagents_runner_path)
+    runner_path = _resolve_existing_file(runner, "tradingagents_runner_path")
+
+    if settings.tradingagents_python is None:
+        if importlib.util.find_spec("tradingagents") is None:
+            raise TradingAgentsNotConfigured("tradingagents_python is not configured")
+        python_path = sys.executable
+    else:
+        python_path = _resolve_existing_file(
+            Path(settings.tradingagents_python), "tradingagents_python"
+        )
+
+    return repo_path, python_path, runner_path
+
+
+def _filtered_child_env() -> dict[str, str]:
+    child_env: dict[str, str] = {}
+    for key, value in os.environ.items():
+        if key in _ENV_ALLOWLIST or key.startswith("TRADINGAGENTS_"):
+            child_env[key] = value
+        elif key == "OPENAI_API_KEY":
+            child_env[key] = value
+    child_env.setdefault("OPENAI_API_KEY", "no-key-required")
+    return child_env
+
+
+def _redact_stderr(stderr: bytes) -> str:
+    text = stderr.decode("utf-8", errors="replace")[:4096]
+    lines = [line for line in text.splitlines() if not _SENSITIVE_LINE_RE.search(line)]
+    return "\n".join(lines)
+
+
+def _build_argv(
+    *,
+    python_path: str,
+    runner_path: str,
+    symbol: str,
+    as_of_date: date,
+    analysts: Sequence[str],
+) -> list[str]:
+    argv = [
+        python_path,
+        runner_path,
+        "--symbol",
+        symbol,
+        "--date",
+        as_of_date.isoformat(),
+        "--analysts",
+        ",".join(analysts),
+        "--base-url",
+        settings.tradingagents_base_url,
+        "--model",
+        settings.tradingagents_model,
+        "--max-debate-rounds",
+        str(settings.tradingagents_max_debate_rounds),
+        "--max-risk-discuss-rounds",
+        str(settings.tradingagents_max_risk_discuss_rounds),
+        "--max-recur-limit",
+        str(settings.tradingagents_max_recur_limit),
+        "--output-language",
+        settings.tradingagents_output_language,
+    ]
+    if settings.tradingagents_checkpoint_enabled:
+        argv.append("--checkpoint-enabled")
+    return argv
+
+
+def _validate_runner_payload(payload: object) -> TradingAgentsRunnerResult:
+    try:
+        return TradingAgentsRunnerResult.model_validate(payload)
+    except ValidationError as exc:
+        details = exc.errors(include_url=False)
+        invariant_fields = {"status", "advisory_only", "execution_allowed"}
+        failed_fields = {
+            str(error.get("loc", ("",))[0]) for error in details if error.get("loc")
+        }
+        if failed_fields & invariant_fields:
+            raise AdvisoryInvariantViolation(
+                f"runner output violated advisory contract: {details}"
+            ) from exc
+        raise TradingAgentsRunnerError(
+            f"runner output failed advisory contract: {details}"
+        ) from exc
+
+
+def _write_memory_log(
+    result: TradingAgentsRunnerResult, *, session_uuid: object
+) -> None:
+    if settings.tradingagents_memory_log_path is None:
+        return
+
+    base = Path(settings.tradingagents_memory_log_path).expanduser().resolve()
+    target_dir = (base / result.as_of_date.isoformat()).resolve()
+    target_path = (target_dir / f"{result.symbol}-{session_uuid}.json").resolve()
+    if not target_path.is_relative_to(base):
+        logger.warning("TradingAgents memory log path escaped configured base")
+        return
+
+    try:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target_path.write_text(result.model_dump_json(indent=2), encoding="utf-8")
+    except OSError:
+        logger.warning("Failed to write TradingAgents memory log", exc_info=True)
+
+
+async def run_tradingagents_research(
+    *,
+    symbol: str,
+    instrument_type: InstrumentType,
+    as_of_date: date | None = None,
+    analysts: Sequence[str] | None = None,
+) -> TradingAgentsRunnerResult:
+    """Invoke the advisory-only TradingAgents runner and validate its JSON output."""
+    _ = instrument_type
+    safe_symbol = _validate_symbol(symbol)
+    safe_analysts = _analysts_or_default(analysts)
+    run_date = as_of_date or date.today()
+    repo_path, python_path, runner_path = _resolve_runner_paths()
+    argv = _build_argv(
+        python_path=python_path,
+        runner_path=runner_path,
+        symbol=safe_symbol,
+        as_of_date=run_date,
+        analysts=safe_analysts,
+    )
+
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        cwd=repo_path,
+        env=_filtered_child_env(),
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(),
+            timeout=settings.tradingagents_subprocess_timeout_sec,
+        )
+    except TimeoutError as exc:
+        proc.kill()
+        await proc.wait()
+        raise TradingAgentsRunnerError("tradingagents runner timed out") from exc
+
+    if stderr:
+        logger.debug("TradingAgents runner stderr: %s", _redact_stderr(stderr))
+
+    if proc.returncode != 0:
+        raise TradingAgentsRunnerError(
+            f"tradingagents runner exited with {proc.returncode}"
+        )
+
+    try:
+        payload = json.loads(stdout.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise TradingAgentsRunnerError("runner produced non-JSON stdout") from exc
+
+    return _validate_runner_payload(payload)
+
+
+def _market_scope_for(instrument_type: InstrumentType) -> str:
+    if instrument_type == InstrumentType.equity_kr:
+        return "kr"
+    if instrument_type == InstrumentType.equity_us:
+        return "us"
+    if instrument_type == InstrumentType.crypto:
+        return "crypto"
+    return instrument_type.value
+
+
+async def ingest_tradingagents_research(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    symbol: str,
+    instrument_type: InstrumentType,
+    as_of_date: date | None = None,
+    analysts: Sequence[str] | None = None,
+) -> tuple[TradingDecisionSession, TradingDecisionProposal]:
+    """Run TradingAgents advisory research and persist one session plus proposal."""
+    result = await run_tradingagents_research(
+        symbol=symbol,
+        instrument_type=instrument_type,
+        as_of_date=as_of_date,
+        analysts=analysts,
+    )
+
+    session_obj = await trading_decision_service.create_decision_session(
+        db,
+        user_id=user_id,
+        source_profile="tradingagents",
+        strategy_name=f"tradingagents:{result.llm.model}:{','.join(result.analysts)}",
+        market_scope=_market_scope_for(instrument_type),
+        market_brief={
+            "advisory_only": True,
+            "execution_allowed": False,
+            "llm": result.llm.model_dump(),
+            "config": result.config.model_dump(),
+            "warnings": result.warnings.model_dump(),
+            "raw_state_keys": result.raw_state_keys,
+        },
+        generated_at=datetime.combine(result.as_of_date, time.min, tzinfo=UTC),
+        notes=(
+            "TradingAgents advisory research; advisory-only. "
+            "No execution, watch alert, or paper trade is authorized by this row."
+        ),
+    )
+    _write_memory_log(result, session_uuid=session_obj.session_uuid)
+
+    proposals = await trading_decision_service.add_decision_proposals(
+        db,
+        session_id=session_obj.id,
+        proposals=[
+            {
+                "symbol": result.symbol,
+                "instrument_type": instrument_type,
+                "proposal_kind": ProposalKind.other,
+                "side": "none",
+                "original_payload": {
+                    "advisory_only": True,
+                    "execution_allowed": False,
+                    "decision": result.decision,
+                    "final_trade_decision": result.final_trade_decision,
+                    "warnings": result.warnings.model_dump(),
+                    "llm": result.llm.model_dump(),
+                    "config": result.config.model_dump(),
+                    "as_of_date": result.as_of_date.isoformat(),
+                },
+                "original_rationale": result.decision[:4000],
+            }
+        ],
+    )
+    return session_obj, proposals[0]

--- a/docs/plans/ROB-9-review-report.md
+++ b/docs/plans/ROB-9-review-report.md
@@ -1,0 +1,149 @@
+# ROB-9 — TradingAgents Advisory Integration · Review Report
+
+- **Reviewer:** Claude Opus (planner/reviewer)
+- **Implementer:** Codex (Hermes auto mode)
+- **Branch:** `feature/ROB-9-tradingagents-advisory-integration` (1 commit ahead of `origin/main`)
+- **Commit:** `3ae981d1 feat: ingest TradingAgents advisory research`
+- **Worktree:** `/Users/mgh3326/work/auto_trader-worktrees/feature-ROB-9-tradingagents-advisory-integration`
+- **Plan reviewed against:** `docs/plans/ROB-9-tradingagents-auto-trader-integration-plan.md`
+- **Verdict:** ✅ **PR-ready** — no blockers; non-blocking observations in §5.
+
+---
+
+## 1. Verifications run
+
+| Check | Result |
+|---|---|
+| `git log --oneline origin/main..HEAD` | 1 commit (`3ae981d1`) |
+| `git show --stat HEAD` | 10 files, +1796 lines (service, schema, config delta, plan, fixtures, three test files, CLAUDE.md note) |
+| Hermes-reported `uv run pytest tests/services/test_tradingagents_research_service{,_safety}.py -q` | 18 passed |
+| Hermes-reported `uv run pytest tests/services/test_tradingagents_research_service{,_safety,_integration}.py -q` | 18 passed, 6 skipped (DB-gated integration suite) |
+| Hermes-reported `uv run ruff check / ruff format --check` on touched files | PASS |
+| Source grep for forbidden surfaces (`place_order`, `manage_watch_alerts`, `order_service`, `watch_alerts`, `paper_trading`, `brokers`, `kis.`, `upbit.`, `redis`, `paperclip`) over `app/services/tradingagents_research_service.py` + `app/schemas/tradingagents_research.py` | EMPTY |
+| Source grep for `TradingDecisionAction`/`TradingDecisionCounterfactual`/`TradingDecisionOutcome` in service module | EMPTY (service never constructs execution-track rows) |
+| Source grep for `shell=`, `os.system`, `subprocess.Popen` in service module | EMPTY (only `asyncio.create_subprocess_exec` is used) |
+| `CLAUDE.md` env-vars section | Carries the new `TRADINGAGENTS_*` block pointing to this plan, no secret values |
+
+---
+
+## 2. Plan ↔ implementation diff (file-by-file)
+
+| Plan section | Implementation file | Status |
+|---|---|---|
+| §4.1 Schema | `app/schemas/tradingagents_research.py` (49 lines) | ✅ Mirrors §6 exactly. `Literal["ok"]`, `Literal[True]`, `Literal[False]` are pinned on `status`/`advisory_only`/`execution_allowed`. `warnings` uses `extra="allow"` for forward-compat; rest use `extra="ignore"`. |
+| §4.1 Service | `app/services/tradingagents_research_service.py` (330 lines) | ✅ Public surface (`run_tradingagents_research`, `ingest_tradingagents_research`, three exception classes) matches §7.1. |
+| §4.2 Settings | `app/core/config.py` (+15 lines) | ✅ All 13 `tradingagents_*` settings with the documented defaults; no other settings touched. |
+| §4.3 No-touch list | `app/services/__init__.py`, `app/models/trading_decision.py`, `app/routers/trading_decisions.py`, KIS/Upbit/brokers/order_service/watch_alerts/paper_trading | ✅ None of these files appear in `git show --stat`. |
+| §6 Pydantic contract | `tests/fixtures/tradingagents/runner_ok_nvda.json`, `runner_invariant_violation.json` | ✅ Both fixtures exercise the schema, including the `execution_allowed: true` rejection path. |
+| §7.2 argv hardening | `_validate_symbol`, `_analysts_or_default`, `_build_argv` | ✅ Symbol regex `^[A-Za-z0-9._/-]{1,32}$`, analyst regex `^[a-z_]{1,32}$`. argv is built as a `list[str]` with no f-string interpolation. `cwd` set to repo path. |
+| §7.3 timeout/cleanup | `run_tradingagents_research` lines 232–240 | ✅ `asyncio.wait_for` → on `TimeoutError`: `proc.kill()` + `await proc.wait()` + `TradingAgentsRunnerError("tradingagents runner timed out")`. |
+| §7.4 JSON parse + validation | lines 250–255, `_validate_runner_payload` | ✅ Catches `UnicodeDecodeError`, `json.JSONDecodeError`. Routes `status`/`advisory_only`/`execution_allowed` Pydantic failures to `AdvisoryInvariantViolation` (a subclass of `TradingAgentsRunnerError`); other validation errors raise the parent class. |
+| §7.5 DB mapping | `ingest_tradingagents_research` lines 285–330 | ✅ One `TradingDecisionSession` (`source_profile="tradingagents"`, `market_brief` carries advisory invariants) + one `TradingDecisionProposal` (`proposal_kind=other`, `side="none"`, all numeric `original_*` fields `None`, `original_payload` carries advisory invariants + decision text). No actions/counterfactuals/outcomes created. |
+| §7.6 Memory log | `_write_memory_log` | ✅ Guarded by setting; `is_relative_to(base)` traversal check; OSError → WARNING (does not abort). |
+| §8.1 unit tests | `tests/services/test_tradingagents_research_service.py` | ✅ Covers all 11 cases listed in plan plus two memory-log tests and a parametrized invariant-violation test. |
+| §8.2 integration tests | `tests/services/test_tradingagents_research_service_integration.py` | ✅ Covers all 6 cases listed in plan; uses `_create_user`/`_cleanup_user` pattern from ROB-1 tests; gates on `to_regclass(...)` so suite skips cleanly without DB. |
+| §8.3 forbidden-import safety | `tests/services/test_tradingagents_research_service_safety.py` | ✅ Subprocess-import test extends the ROB-1 forbidden list with `watch_alerts`, `paper_trading_service`, `openclaw_client`, `crypto_trade_cooldown_service`. |
+
+No plan section is missing an implementation. No implementation files exist outside the plan's allow-list.
+
+---
+
+## 3. Safety boundary review
+
+| Constraint (from plan §9 + handoff) | Verdict | Evidence |
+|---|---|---|
+| Service module does **not** import any KIS / Upbit / brokers / order_service / watch_alerts / paper_trading / openclaw / crypto_trade_cooldown / fill_notification / execution_event / redis_token_manager / kis_websocket / app.tasks module | ✅ | Source grep empty; safety test (§8.3) enforces this in CI via subprocess clean-import. |
+| No `place_order`, `manage_watch_alerts`, broker construction, Paperclip write, Redis write | ✅ | Source grep empty. Service touches only `app.services.trading_decision_service` (which itself was already proven boundary-safe in ROB-1). |
+| No `TradingDecisionAction` / `TradingDecisionCounterfactual` / `TradingDecisionOutcome` row creation | ✅ | Source grep empty in the service module. Integration test `test_ingest_does_not_create_action_or_counterfactual_or_outcome` asserts post-ingest counts of all three child tables are 0. |
+| `subprocess` invocation uses explicit argv list, no shell, no string interpolation | ✅ | Only `asyncio.create_subprocess_exec(*argv, ...)` is used; no `shell=True` / `Popen` / `os.system` anywhere in the service. argv is built from typed settings + regex-validated caller args. |
+| Symbol / analysts / date validation before subprocess | ✅ | `_validate_symbol` rejects shell metachars (`AAPL; rm -rf /` blocked, subprocess never called — proven by `test_symbol_argv_validation_rejects_shell_metachars`). `_ANALYST_RE` rejects `market;bad`. `as_of_date` is typed `date` so spoofing via string is impossible. |
+| Env filtering: only `PATH`, `HOME`, `LANG`, `LC_ALL`, `PYTHONPATH`, `TRADINGAGENTS_*`, `OPENAI_API_KEY` forwarded | ✅ | `_filtered_child_env` uses an allow-list. `test_filtered_env_does_not_leak_unrelated_vars` verifies an unrelated `ROB9_UNRELATED_SECRET` does **not** appear in the child env. |
+| Timeout → kill+wait → no DB write | ✅ | `proc.kill()` + `await proc.wait()` on `TimeoutError`; `TradingAgentsRunnerError` raised before any DB call. `test_runner_timeout_kills_and_raises` asserts `kill_called` and `wait.assert_awaited_once()`. |
+| Non-zero exit / non-JSON stdout → no DB write | ✅ | Both raise `TradingAgentsRunnerError` before `ingest_tradingagents_research` reaches DB calls. Tested. Integration test `test_ingest_runner_failure_rolls_back` proves end-to-end DB rollback. |
+| `advisory_only=False` / `execution_allowed=True` / `status="error"` → rejected pre-persist | ✅ | Pydantic `Literal` pins enforce this at validation. `_validate_runner_payload` re-wraps as `AdvisoryInvariantViolation`. Parametrized test covers all three deviations. |
+| `warnings.structured_output` preserved | ✅ | Asserted in unit test (`test_warnings_structured_output_preserved`) and integration test (`test_ingest_preserves_warnings_structured_output`). Stored in both `session.market_brief["warnings"]` and `proposal.original_payload["warnings"]`. |
+| `advisory_only`/`execution_allowed` flags persisted at session AND proposal level | ✅ | Confirmed in `test_ingest_persists_advisory_invariants_in_market_brief_and_payload`. |
+| No `os.environ` value echoed in logs / exceptions / persisted JSON | ✅ | `_redact_stderr` filters lines matching `(key|token|secret|authorization)` (case-insensitive) and truncates to 4 KiB before a single `logger.debug` call. Exception messages contain only Pydantic error structures + return codes — never raw stdout. `original_payload` / `market_brief` only ingest validated Pydantic-model dumps. |
+| Caller owns DB commit | ✅ | Service uses only `session.flush()` (transitively via `trading_decision_service`). No `await db.commit()` in `tradingagents_research_service.py`. Integration tests confirm rollback works. |
+
+**No safety-boundary violations identified.**
+
+---
+
+## 4. Test-coverage review
+
+Unit (`test_tradingagents_research_service.py` — 13 cases):
+
+- ✅ `test_settings_parse_tradingagents_env_values`
+- ✅ `test_schema_accepts_ok_payload_and_rejects_invariant_violation`
+- ✅ `test_runner_ok_returns_validated_result` (also asserts argv shape and PIPE wiring)
+- ✅ `test_runner_nonzero_exit_raises`
+- ✅ `test_runner_timeout_kills_and_raises`
+- ✅ `test_runner_non_json_stdout_raises`
+- ✅ `test_runner_advisory_invariant_violations_are_rejected` (parametrized over `status="error"`, `advisory_only=False`, `execution_allowed=True`)
+- ✅ `test_warnings_structured_output_preserved`
+- ✅ `test_symbol_argv_validation_rejects_shell_metachars` + `test_analyst_argv_validation_rejects_shell_metachars`
+- ✅ `test_settings_missing_repo_path_raises`
+- ✅ `test_filtered_env_does_not_leak_unrelated_vars` + `test_default_openai_api_key_injected_when_missing`
+- ✅ `test_memory_log_disabled_writes_no_file` + `test_memory_log_enabled_writes_validated_payload_under_configured_path`
+
+Integration (`test_tradingagents_research_service_integration.py` — 6 cases, all `@pytest.mark.integration`):
+
+- ✅ session+single proposal shape
+- ✅ advisory invariants in `market_brief` AND `original_payload`
+- ✅ warnings preserved end-to-end
+- ✅ no actions/counterfactuals/outcomes
+- ✅ runner failure rollback
+- ✅ user-response fields untouched
+
+Safety (`test_tradingagents_research_service_safety.py` — 1 subprocess test):
+
+- ✅ Forbidden-prefix list extends ROB-1's set with `watch_alerts`, `paper_trading_service`, `openclaw_client`, `crypto_trade_cooldown_service`. Test imports the new service in a clean Python and asserts no forbidden module loaded as a transitive consequence.
+
+Hermes-reported counts (18 + 18+6 skipped) match what the source files produce. CI on `main`-style runs will pass the unit + safety suites without DB; the 6 integration tests will skip cleanly via `_ensure_trading_decision_tables`.
+
+---
+
+## 5. Non-blocking observations
+
+These are **not must-fix** for this PR but are worth noting for follow-ups.
+
+1. **`OPENAI_API_KEY="no-key-required"` placeholder injection** — `_filtered_child_env` (line 121) sets a fallback `OPENAI_API_KEY` when none is present. The plan §5/§9 documented forwarding of `OPENAI_API_KEY` if present, but did not specify a placeholder default. The implementer chose this so the OpenAI SDK inside TradingAgents does not crash when pointed at a no-auth local shim. The placeholder is a literal string, not a real secret, so this does not violate the no-secret-leak constraint. Consider: making this either (a) opt-in via a new setting, or (b) explicitly documented in `CLAUDE.md` and the plan, in a follow-up doc PR. Not a blocker.
+
+2. **`_redact_stderr` not directly unit-tested** — the redaction helper is called only from `logger.debug`, so the security surface is small (debug-level logging is typically off in production). If the redaction logic ever expands, add a focused unit test asserting that lines containing `key`, `token`, `secret`, `authorization` are dropped and that the result is truncated to ≤4096 chars.
+
+3. **Schema `extra="ignore"` on top-level result** — future runner additions (e.g., a new `tools_used` list) are silently dropped before they reach `original_payload`. Acceptable for an advisory-only ingestion (we control which fields we persist), but if a follow-up wants to surface new runner fields in the UI, the schema will need an explicit update.
+
+4. **`AdvisoryInvariantViolation` field detection** — `_validate_runner_payload` matches the first element of `error["loc"]` against `{"status","advisory_only","execution_allowed"}`. This works because all three are top-level fields. If a future schema move turns one of these into a nested field (e.g. `safety.advisory_only`), the routing would silently fall back to the parent `TradingAgentsRunnerError` class and callers checking `except AdvisoryInvariantViolation` would miss the violation. Keep this in mind if the schema is ever restructured.
+
+None of the above changes the verdict.
+
+---
+
+## 6. PR-readiness checklist (plan §12 cross-check)
+
+- [x] No `app/services/kis*`, `upbit*`, `brokers`, `order_service`, `watch_alerts`, `paper_trading_service` import.
+- [x] No `place_order`, `manage_watch_alerts`, broker construction, Redis write, Paperclip call.
+- [x] No `TradingDecisionAction` / `Counterfactual` / `Outcome` row created by service or tests.
+- [x] `advisory_only=True` and `execution_allowed=False` present at three layers (Pydantic Literal pin, `session.market_brief`, `proposal.original_payload`).
+- [x] No `os.environ` value appears in any log / exception message / persisted row / memory-log file.
+- [x] No `subprocess.run(..., shell=True)` or f-string argv interpolation.
+- [x] All §8 tests pass locally per Hermes verification (18 + 6 skipped).
+- [x] `make lint && make typecheck` parity confirmed via Hermes ruff check + format pass on touched files.
+- [ ] PR description should explicitly state **"advisory-only, no execution path"** in the summary — recommend the PR author include this phrasing when opening the GitHub PR.
+
+---
+
+## 7. Conclusion
+
+The implementation faithfully realizes the ROB-9 plan with no scope drift, no execution-path leakage, and comprehensive test coverage of the safety invariants. All non-negotiable constraints in the handoff (advisory-only invariants, no broker / watch / order / Paperclip / Redis side effects, no env leakage, subprocess hardening) are enforced both in code and in CI-runnable tests.
+
+**Recommendation:** ship as-is. Open the PR with `main` as the base, ensure the description explicitly includes "advisory-only, no execution path", and link Linear ROB-9.
+
+```
+AOE_STATUS: review_passed
+AOE_ISSUE: ROB-9
+AOE_ROLE: reviewer
+AOE_REPORT_PATH: docs/plans/ROB-9-review-report.md
+AOE_NEXT: create_pr
+```

--- a/docs/plans/ROB-9-tradingagents-auto-trader-integration-plan.md
+++ b/docs/plans/ROB-9-tradingagents-auto-trader-integration-plan.md
@@ -1,0 +1,590 @@
+# ROB-9 — TradingAgents Advisory → auto_trader Decision Workspace Plan
+
+- **PR scope:** Linear ROB-9, single PR slice. No UI, no API endpoint, no scheduler, no broker/watch side effect.
+- **Branch / worktree:** `feature/ROB-9-tradingagents-advisory-integration` (this worktree).
+- **Status:** Plan only. **No code is to be written until this plan is reviewed.**
+- **Depends on:**
+  - ROB-1 / PR #595 — `trading_decision_*` schema, models, service (merged to `main`).
+  - ROB-2 / PR #597 — `trading_decisions` API contract endpoints (merged to `main`).
+  - TradingAgents fork branch `auto-trader-research-runner` @ `8d3fa63` providing
+    `scripts/run_auto_trader_research.py`. The runner emits **advisory-only JSON**
+    (`advisory_only: true`, `execution_allowed: false`) and is the only TradingAgents
+    surface auto_trader is permitted to call.
+
+> ⚠️ **Advisory-only.** This PR ships a research-ingestion adapter that converts a
+> TradingAgents runner JSON payload into a `TradingDecisionSession` +
+> `TradingDecisionProposal` row with `source_profile="tradingagents"`. It performs
+> **zero** broker, watch-alert, paper-trading, Paperclip, or Redis-watch-key writes.
+> It is **forbidden** to create `TradingDecisionAction` rows, register watch alerts,
+> place live or paper orders, call `place_order`, `manage_watch_alerts`, KIS/Upbit
+> trading services, or treat the TradingAgents output as authorization for a real or
+> paper trade. Those concerns are out of scope and tracked as follow-ups (§10).
+
+---
+
+## 1. Goal
+
+Provide a single internal Python entry point that:
+
+1. Invokes the TradingAgents runner (`scripts/run_auto_trader_research.py`) as a
+   short-lived subprocess against a known local OpenAI-compatible shim.
+2. Validates the resulting JSON against a strict Pydantic contract that **enforces the
+   advisory-only invariants** (`advisory_only=True`, `execution_allowed=False`,
+   `status="ok"`).
+3. Persists the validated payload into the existing ROB-1 trading_decision tables as
+   one session + one proposal, mapped so a future Decision Workspace UI can render the
+   advisory next to other proposals **without** any execution affordance attached.
+
+The single-call surface from auto_trader code is:
+
+```python
+async def ingest_tradingagents_research(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    symbol: str,
+    instrument_type: InstrumentType,
+    as_of_date: date | None = None,
+    analysts: Sequence[str] | None = None,
+) -> tuple[TradingDecisionSession, TradingDecisionProposal]:
+    ...
+```
+
+Nothing else (no FastAPI route, no Discord push, no cron registration) is in scope.
+
+---
+
+## 2. In-scope vs Out-of-scope
+
+| Area | In scope (this PR) | Deferred |
+|---|---|---|
+| Pydantic models for the runner JSON contract | ✅ `app/schemas/tradingagents_research.py` | — |
+| `TradingAgentsResearchService` subprocess wrapper | ✅ `app/services/tradingagents_research_service.py` | — |
+| Settings additions for repo path / runner path / shim URL / model / timeout | ✅ `app/core/config.py` | — |
+| Mapping runner output → `TradingDecisionSession` + `TradingDecisionProposal` | ✅ Reuses existing `trading_decision_service.create_decision_session` / `add_decision_proposals` | — |
+| Unit tests: subprocess success, failure, timeout, JSON parse error, invariant violations | ✅ `tests/services/test_tradingagents_research_service.py` | — |
+| Integration test: persisted session/proposal shape against a stubbed subprocess | ✅ `tests/services/test_tradingagents_research_service_integration.py` | — |
+| Side-effect-safety test: importing the new service must not load forbidden execution modules | ✅ `tests/services/test_tradingagents_research_service_safety.py` | — |
+| FastAPI endpoint to trigger an ingestion | ❌ | ROB-10 (proposed) |
+| UI surface for `source_profile="tradingagents"` proposals | ❌ | follow-up (UI track) |
+| Action / counterfactual / outcome creation for these proposals | ❌ — **forbidden** | product decision required before any future PR |
+| Scheduler / CLI to run the runner on a symbol list | ❌ | follow-up |
+| Discord / Telegram delivery of new advisories | ❌ | follow-up |
+| Modifying the TradingAgents fork itself | ❌ | upstream-only |
+| Reading or echoing API keys / env values in logs | ❌ — **forbidden** | — |
+
+---
+
+## 3. Workflow the service must support
+
+```text
+caller → ingest_tradingagents_research(db, user_id, symbol, instrument_type)
+         │
+         ├─ build argv from settings + caller args (no shell interpolation)
+         ├─ asyncio.create_subprocess_exec(...)         # stdout=PIPE, stderr=PIPE, env filtered
+         ├─ communicate() with timeout                   # cancel + kill on timeout
+         ├─ json.loads(stdout)                           # ParseError → raise
+         ├─ TradingAgentsRunnerResult.model_validate(..) # invariant violations → raise
+         ├─ create_decision_session(source_profile="tradingagents", ...)
+         ├─ add_decision_proposals([single advisory proposal])
+         └─ return (session, proposal)
+```
+
+The caller is responsible for the surrounding `db.commit()`. The service performs only
+`session.flush()` (consistent with `trading_decision_service`) so the caller controls
+the transaction boundary.
+
+---
+
+## 4. Files
+
+### 4.1 New files
+
+| File | Purpose |
+|---|---|
+| `app/schemas/tradingagents_research.py` | Pydantic v2 models for runner JSON contract + helpers |
+| `app/services/tradingagents_research_service.py` | Subprocess invocation + mapping to `trading_decision_*` |
+| `tests/services/test_tradingagents_research_service.py` | Unit tests (subprocess stubbed) |
+| `tests/services/test_tradingagents_research_service_integration.py` | Integration tests (real DB, stubbed subprocess) |
+| `tests/services/test_tradingagents_research_service_safety.py` | Forbidden-import boundary test |
+| `tests/fixtures/tradingagents/runner_ok_nvda.json` | Canned runner output for tests |
+| `tests/fixtures/tradingagents/runner_invariant_violation.json` | `execution_allowed=true` payload to assert rejection |
+
+### 4.2 Files modified
+
+| File | Change |
+|---|---|
+| `app/core/config.py` | Add `tradingagents_*` settings block (§5) |
+| `app/services/__init__.py` | **No re-export needed.** Service is imported by absolute path; do not add to package init to avoid pulling subprocess code into unrelated import paths. |
+
+### 4.3 Files NOT modified
+
+| File | Reason |
+|---|---|
+| `app/services/trading_decision_service.py` | New service composes existing helpers; no schema or signature change. |
+| `app/models/trading_decision.py` | No new columns, no new enum values. `proposal_kind="other"` is already valid for non-actionable advisories. |
+| `app/routers/trading_decisions.py` | No endpoint exposure in this PR. |
+| `app/services/order_service.py`, `app/services/brokers/*`, `app/services/kis*`, `app/services/upbit*`, `app/services/watch_alerts.py`, `app/services/paper_trading_service.py` | **Must not be touched or imported.** Forbidden by §9. |
+
+---
+
+## 5. Settings additions (`app/core/config.py`)
+
+Append to `Settings`:
+
+```python
+# TradingAgents advisory runner (ROB-9)
+tradingagents_repo_path: str | None = None
+# Path to the python interpreter that has `tradingagents` installed.
+# Typically the .venv python inside the TradingAgents fork checkout.
+tradingagents_python: str | None = None
+# Defaults to <repo>/scripts/run_auto_trader_research.py when None.
+tradingagents_runner_path: str | None = None
+tradingagents_base_url: str = "http://127.0.0.1:8796/v1"
+tradingagents_model: str = "gpt-5.5"
+tradingagents_default_analysts: str = "market"
+tradingagents_subprocess_timeout_sec: int = 300
+tradingagents_max_debate_rounds: int = 1
+tradingagents_max_risk_discuss_rounds: int = 1
+tradingagents_max_recur_limit: int = 30
+tradingagents_output_language: str = "English"
+tradingagents_checkpoint_enabled: bool = False
+# Optional path under which to write a per-run JSON copy for ops review.
+# When None (default) no extra file is written.
+tradingagents_memory_log_path: str | None = None
+```
+
+**Resolution rules (in service code, not config):**
+
+- If `tradingagents_repo_path` is `None` → service raises `TradingAgentsNotConfigured`.
+- If `tradingagents_python` is `None` → fall back to `sys.executable` only when
+  the runner is importable from auto_trader's own venv. Otherwise raise
+  `TradingAgentsNotConfigured`. (Default expectation: separate venv configured.)
+- If `tradingagents_runner_path` is `None` →
+  `Path(tradingagents_repo_path) / "scripts/run_auto_trader_research.py"`.
+- All three resolved paths must exist and be readable before the subprocess is
+  launched; otherwise raise `TradingAgentsNotConfigured`.
+
+**Env policy:** the service passes a **filtered** env to the subprocess containing
+only `PATH`, `HOME`, `LANG`, `LC_ALL`, `PYTHONPATH` (when set), and
+`TRADINGAGENTS_*` / `OPENAI_API_KEY` keys that are already present in
+`os.environ`. Other variables are **not** forwarded, never logged, never echoed,
+and never embedded in error messages.
+
+---
+
+## 6. JSON contract (`app/schemas/tradingagents_research.py`)
+
+The runner output is documented in `scripts/run_auto_trader_research.py:run_analysis`.
+Mirror it as Pydantic v2 models with **strict literal pins** on the safety fields.
+
+```python
+from typing import Literal
+from datetime import date
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class TradingAgentsLLM(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    provider: str
+    model: str
+    base_url: str
+
+
+class TradingAgentsConfigSnapshot(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    max_debate_rounds: int
+    max_risk_discuss_rounds: int
+    max_recur_limit: int
+    output_language: str
+    checkpoint_enabled: bool
+
+
+class TradingAgentsWarnings(BaseModel):
+    model_config = ConfigDict(extra="allow")  # forward-compatible
+    structured_output: list[str] = Field(default_factory=list)
+
+
+class TradingAgentsRunnerResult(BaseModel):
+    """Strict contract for run_auto_trader_research.py JSON output.
+
+    Invariant pins (advisory_only / execution_allowed) are Literal-typed so
+    Pydantic itself rejects any payload that claims execution authorization.
+    """
+    model_config = ConfigDict(extra="ignore")
+
+    status: Literal["ok"]
+    symbol: str = Field(min_length=1, max_length=64)
+    as_of_date: date
+    decision: str
+    advisory_only: Literal[True]
+    execution_allowed: Literal[False]
+    analysts: list[str] = Field(min_length=1)
+    llm: TradingAgentsLLM
+    config: TradingAgentsConfigSnapshot
+    warnings: TradingAgentsWarnings
+    final_trade_decision: str
+    raw_state_keys: list[str]
+```
+
+**Why `Literal[True]` / `Literal[False]`:** any deviation (e.g. an upstream change
+flipping `execution_allowed` to `True`) is caught at validation time and raises
+`ValidationError`, which the service surfaces as `AdvisoryInvariantViolation`
+**before** any DB write.
+
+**Error payload contract:** the runner can also exit with `status != "ok"` in the
+future. Today only `"ok"` is emitted, but the service treats any payload that
+fails this model — including a payload with `status="error"` — as a runner failure
+and raises `TradingAgentsRunnerError` without any DB write.
+
+---
+
+## 7. Service design (`app/services/tradingagents_research_service.py`)
+
+### 7.1 Public surface
+
+```python
+class TradingAgentsNotConfigured(RuntimeError): ...
+class TradingAgentsRunnerError(RuntimeError):
+    """Subprocess exited non-zero, timed out, produced no JSON, or produced JSON
+    that fails the contract. Includes a redacted summary suitable for logs."""
+class AdvisoryInvariantViolation(RuntimeError):
+    """Reserved name; today this is raised by Pydantic ValidationError on the
+    Literal-pinned fields and re-wrapped here so callers can catch it explicitly."""
+
+
+async def run_tradingagents_research(
+    *,
+    symbol: str,
+    instrument_type: InstrumentType,
+    as_of_date: date | None = None,
+    analysts: Sequence[str] | None = None,
+) -> TradingAgentsRunnerResult:
+    """Invoke the runner subprocess and return a validated, advisory-only result.
+    Does NOT touch the DB."""
+
+
+async def ingest_tradingagents_research(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    symbol: str,
+    instrument_type: InstrumentType,
+    as_of_date: date | None = None,
+    analysts: Sequence[str] | None = None,
+) -> tuple[TradingDecisionSession, TradingDecisionProposal]:
+    """run_tradingagents_research + map onto a single session/proposal.
+    Caller owns commit."""
+```
+
+### 7.2 Subprocess invocation rules
+
+- Use `asyncio.create_subprocess_exec(*argv, stdout=PIPE, stderr=PIPE, env=filtered_env)`.
+- **Never** use `shell=True`, `os.system`, or string interpolation into a shell.
+- `argv` is a `list[str]` built explicitly:
+  ```python
+  argv = [
+      tradingagents_python,
+      tradingagents_runner_path,
+      "--symbol", symbol,
+      "--date", as_of_date.isoformat(),
+      "--analysts", ",".join(analysts),
+      "--base-url", settings.tradingagents_base_url,
+      "--model", settings.tradingagents_model,
+      "--max-debate-rounds", str(settings.tradingagents_max_debate_rounds),
+      "--max-risk-discuss-rounds", str(settings.tradingagents_max_risk_discuss_rounds),
+      "--max-recur-limit", str(settings.tradingagents_max_recur_limit),
+      "--output-language", settings.tradingagents_output_language,
+  ]
+  if settings.tradingagents_checkpoint_enabled:
+      argv.append("--checkpoint-enabled")
+  ```
+- Validate caller-supplied `symbol` against `^[A-Za-z0-9._/-]{1,32}$` before adding to
+  argv. Reject anything else with `ValueError` (defense-in-depth even though
+  `create_subprocess_exec` does not invoke a shell).
+- Validate each analyst name against `^[a-z_]{1,32}$`.
+- `cwd = settings.tradingagents_repo_path` so the runner's relative file lookups work.
+
+### 7.3 Timeout + cleanup
+
+```python
+proc = await asyncio.create_subprocess_exec(...)
+try:
+    stdout, stderr = await asyncio.wait_for(
+        proc.communicate(), timeout=settings.tradingagents_subprocess_timeout_sec,
+    )
+except asyncio.TimeoutError:
+    proc.kill()
+    await proc.wait()
+    raise TradingAgentsRunnerError("tradingagents runner timed out")
+if proc.returncode != 0:
+    raise TradingAgentsRunnerError(
+        f"tradingagents runner exited with {proc.returncode}"
+    )
+```
+
+`stderr` is captured for debug logging at `logger.debug(...)` only — **never**
+echoed at INFO/ERROR level in full because the runner can include arbitrary
+content. Truncate to 4 KiB before logging and strip any line containing
+`"key"`, `"token"`, `"secret"`, `"authorization"` (case-insensitive) before write.
+
+### 7.4 JSON parsing
+
+```python
+try:
+    payload = json.loads(stdout.decode("utf-8"))
+except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+    raise TradingAgentsRunnerError("runner produced non-JSON stdout") from exc
+try:
+    result = TradingAgentsRunnerResult.model_validate(payload)
+except ValidationError as exc:
+    raise TradingAgentsRunnerError(
+        f"runner output failed advisory contract: {exc.errors(include_url=False)}"
+    ) from exc
+```
+
+The `from exc` chain is preserved; the wrapped message **does not** include the
+raw payload (which may contain rationale text that ought not be repeated in error
+logs uncritically).
+
+### 7.5 DB mapping
+
+```python
+session_obj = await trading_decision_service.create_decision_session(
+    db,
+    user_id=user_id,
+    source_profile="tradingagents",
+    strategy_name=f"tradingagents:{result.llm.model}:{','.join(result.analysts)}",
+    market_scope=_market_scope_for(instrument_type),  # "kr" / "us" / "crypto"
+    market_brief={
+        "advisory_only": True,
+        "execution_allowed": False,
+        "llm": result.llm.model_dump(),
+        "config": result.config.model_dump(),
+        "warnings": result.warnings.model_dump(),
+        "raw_state_keys": result.raw_state_keys,
+    },
+    generated_at=datetime.combine(result.as_of_date, time.min, tzinfo=UTC),
+    notes=(
+        "TradingAgents advisory research; advisory-only. "
+        "No execution, watch alert, or paper trade is authorized by this row."
+    ),
+)
+
+[proposal] = await trading_decision_service.add_decision_proposals(
+    db,
+    session_id=session_obj.id,
+    proposals=[
+        ProposalCreate(
+            symbol=result.symbol,
+            instrument_type=instrument_type,
+            proposal_kind=ProposalKind.other,   # advisory output, no actionable kind yet
+            side="none",                         # researcher does not size the trade
+            original_payload={
+                "advisory_only": True,
+                "execution_allowed": False,
+                "decision": result.decision,
+                "final_trade_decision": result.final_trade_decision,
+                "warnings": result.warnings.model_dump(),
+                "llm": result.llm.model_dump(),
+                "config": result.config.model_dump(),
+                "as_of_date": result.as_of_date.isoformat(),
+            },
+            original_rationale=result.decision[:4000],
+        ),
+    ],
+)
+```
+
+Notes on this mapping:
+
+- `proposal_kind=other` is intentional: ROB-1 enum allows it, and we deliberately do
+  **not** infer `enter`/`add`/`trim` from the LLM's free-form decision text in this
+  PR. Inference (and any side that follows from it) is a product question.
+- `side="none"` keeps the row out of accidental `side IN ('buy','sell')` queries
+  used by execution-adjacent code paths.
+- All `original_*` numeric fields are left `None`. The advisory does not size or
+  price the trade.
+- `market_brief` carries the full advisory-only invariant flags at the **session**
+  level so any UI listing this session can refuse execution affordances even before
+  rendering proposal detail.
+
+### 7.6 Optional run log
+
+If `settings.tradingagents_memory_log_path` is set, the service additionally writes
+the validated `result.model_dump_json()` to
+`{memory_log_path}/{as_of_date}/{symbol}-{session_uuid}.json`. The path is built
+with `Path(...).resolve()` and asserted to remain inside the configured base via
+`is_relative_to`. No env values are written. This step is best-effort: an OSError
+is logged at WARNING and does **not** abort the DB transaction (the row already
+captures the same payload in `original_payload`).
+
+---
+
+## 8. Tests
+
+All under `tests/services/`. Each test file is independent.
+
+### 8.1 `test_tradingagents_research_service.py` (unit, no DB)
+
+Patch `asyncio.create_subprocess_exec` with a `unittest.mock.AsyncMock` that
+returns a fake process whose `communicate()` is preprogrammed.
+
+| Test | Setup | Assertion |
+|---|---|---|
+| `test_runner_ok_returns_validated_result` | stdout = canned valid JSON, returncode=0 | returns `TradingAgentsRunnerResult` with `advisory_only is True` and `execution_allowed is False` |
+| `test_runner_nonzero_exit_raises` | returncode=1 | `TradingAgentsRunnerError`, no DB call attempted |
+| `test_runner_timeout_kills_and_raises` | `communicate()` raises `asyncio.TimeoutError` via `wait_for` patch | `TradingAgentsRunnerError("tradingagents runner timed out")`, `proc.kill()` was called, `proc.wait()` was awaited |
+| `test_runner_non_json_stdout_raises` | stdout = `b"<<not json>>"` | `TradingAgentsRunnerError` |
+| `test_runner_status_error_rejected` | stdout JSON has `"status": "error"` | `TradingAgentsRunnerError` (Literal mismatch) |
+| `test_runner_advisory_only_false_rejected` | stdout JSON has `"advisory_only": false` | `TradingAgentsRunnerError`; **no DB write** verifiable because no DB session is even constructed |
+| `test_runner_execution_allowed_true_rejected` | stdout JSON has `"execution_allowed": true` | `TradingAgentsRunnerError` |
+| `test_warnings_structured_output_preserved` | stdout JSON has 2 entries in `warnings.structured_output` | result.warnings.structured_output equals the input list |
+| `test_symbol_argv_validation_rejects_shell_metachars` | call with `symbol="AAPL; rm -rf /"` | `ValueError`, subprocess never invoked |
+| `test_settings_missing_repo_path_raises` | `settings.tradingagents_repo_path = None` | `TradingAgentsNotConfigured` |
+| `test_filtered_env_does_not_leak_unrelated_vars` | os.environ contains a junk var; subprocess invoked | the `env=` kwarg passed to `create_subprocess_exec` does **not** contain that key |
+
+### 8.2 `test_tradingagents_research_service_integration.py` (DB-integration)
+
+Marker: `@pytest.mark.integration`. Reuses the `_create_user` / `_cleanup_user`
+helpers used by `tests/models/test_trading_decision_service.py`.
+
+| Test | Assertion |
+|---|---|
+| `test_ingest_creates_session_and_single_proposal` | `source_profile == "tradingagents"`; one proposal, `proposal_kind == ProposalKind.other`, `side == "none"` |
+| `test_ingest_persists_advisory_invariants_in_market_brief_and_payload` | `session.market_brief["advisory_only"] is True`, `session.market_brief["execution_allowed"] is False`, `proposal.original_payload["advisory_only"] is True`, `proposal.original_payload["execution_allowed"] is False` |
+| `test_ingest_preserves_warnings_structured_output` | `session.market_brief["warnings"]["structured_output"]` equals canned list |
+| `test_ingest_does_not_create_action_or_counterfactual_or_outcome` | After ingestion, querying `trading_decision_actions`, `trading_decision_counterfactuals`, `trading_decision_outcomes` for the proposal returns 0 rows |
+| `test_ingest_runner_failure_rolls_back` | runner raises → caller-side `db.rollback()` works; assert no session row exists |
+| `test_ingest_does_not_touch_user_response_fields` | `proposal.user_response == "pending"`, `responded_at is None`, all `user_*` fields None |
+
+### 8.3 `test_tradingagents_research_service_safety.py`
+
+Clone the subprocess pattern from
+`tests/models/test_trading_decision_service.py:test_service_module_does_not_import_execution_paths`,
+swapping the target to `app.services.tradingagents_research_service`.
+
+`_FORBIDDEN_PREFIXES` extends the existing list with:
+
+```python
+"app.services.watch_alerts",
+"app.services.paper_trading_service",
+"app.services.openclaw_client",
+"app.services.crypto_trade_cooldown_service",
+```
+
+Plus the existing forbidden set (kis*, upbit*, brokers, order_service,
+fill_notification, execution_event, redis_token_manager, kis_websocket*,
+app.tasks).
+
+The test imports the new service in a clean subprocess and asserts none of
+these modules ended up in `sys.modules` as a transitive consequence.
+
+### 8.4 Test fixtures
+
+`tests/fixtures/tradingagents/runner_ok_nvda.json` — captured (or hand-written)
+runner output for NVDA on a fixed date; mirrors §6 exactly.
+`tests/fixtures/tradingagents/runner_invariant_violation.json` — same shape but
+`execution_allowed=true`; used by §8.1 to assert rejection.
+
+---
+
+## 9. Forbidden-import / forbidden-call boundary
+
+The new service module **must not**:
+
+- Import from any module whose path starts with: `app.services.kis*`,
+  `app.services.upbit*`, `app.services.brokers`, `app.services.order_service`,
+  `app.services.fill_notification`, `app.services.execution_event`,
+  `app.services.redis_token_manager`, `app.services.kis_websocket*`,
+  `app.services.watch_alerts`, `app.services.paper_trading_service`,
+  `app.services.openclaw_client`, `app.tasks`.
+- Call `place_order`, `manage_watch_alerts`, or any function that creates rows in
+  `trading_decision_actions`, `trading_decision_counterfactuals`, or
+  `trading_decision_outcomes`.
+- Write to Redis (no `redis.Redis(...).set(...)`, no token-manager touchpoints).
+- Read or echo `os.environ` values into log records, exceptions, or persisted rows.
+  Specifically: `OPENAI_API_KEY`, `TRADINGAGENTS_*`, `KIS_*`, `UPBIT_*`,
+  `GOOGLE_API_KEY*`, `TELEGRAM_TOKEN`, `OPENDART_API_KEY`, `KRX_*` must never appear
+  in stdout, stderr, exception messages, or `original_payload`/`market_brief` JSON.
+
+§8.3 enforces the import boundary. §8.1's
+`test_filtered_env_does_not_leak_unrelated_vars` enforces the env boundary.
+The remaining behaviors (no execution-side writes) are guaranteed by §8.2's
+`test_ingest_does_not_create_action_or_counterfactual_or_outcome`.
+
+---
+
+## 10. Out-of-scope follow-ups (proposed Linear children of ROB-9)
+
+The following are **explicitly deferred** to follow-up issues. None of them are
+implemented in this PR and the design must not pre-empt them in ways that imply
+an execution path is acceptable.
+
+| Follow-up | Description | Reason it is not in this PR |
+|---|---|---|
+| ROB-10 (proposed) — API endpoint | `POST /trading/api/research/tradingagents` accepting `{symbols: [...], instrument_type, as_of_date?}` and returning the persisted `SessionDetail` | Needs auth + rate-limiting design, plus product call on whether viewers can trigger remote LLM compute |
+| Decision Workspace UI surface | Render `source_profile="tradingagents"` proposals in the existing inbox + detail pages | Out of UI track; ROB-7 owns the workspace UI |
+| Scheduler / batch CLI | Nightly run over a curated symbol list | Needs ops decision on shim availability and cost budget |
+| Discord / Telegram delivery | Auto-post advisories | Needs the UI surface first so users can ack/reject from a single source of truth |
+| Action wiring | Allow accept → live order from a tradingagents proposal | **Product decision required.** Today the design assumes advisories are read-only references and *cannot* drive execution. Re-opening this requires a separate Linear issue with explicit safety review. |
+| Inference of `proposal_kind` (`enter`/`add`/`trim`) from `decision` text | Useful for filtering | Not in this PR — would create the appearance of an actionable signal where none has been validated |
+
+---
+
+## 11. Implementation order (TDD-first, bite-sized)
+
+Each step is a single commit. Run the test suite after every code-touching step.
+
+1. **Settings additions** — extend `Settings` per §5. Add a unit test that parses
+   the new env vars and confirms `tradingagents_runner_path` resolution.
+2. **Schema** — write `app/schemas/tradingagents_research.py`. Test:
+   `model_validate` accepts the canned ok-payload and rejects the
+   invariant-violation payload.
+3. **Service skeleton** — empty class, custom exception types, public function
+   signatures. Test: importing the module raises nothing and the safety test
+   (§8.3) passes.
+4. **Subprocess invocation (success path)** — implement `run_tradingagents_research`
+   with a stubbed `create_subprocess_exec`. Test §8.1 ok case + warnings
+   preservation.
+5. **Subprocess invocation (failure paths)** — non-zero exit, timeout (kill+wait),
+   non-JSON stdout, validation errors. Tests §8.1 failure cases.
+6. **Argv & env hardening** — symbol/analyst regex validation, env filtering.
+   Tests §8.1 metachar rejection + env filter.
+7. **DB mapping** — implement `ingest_tradingagents_research`. Tests §8.2.
+8. **Optional memory-log writer** — implement under `tradingagents_memory_log_path`
+   guard; test that without the setting nothing is written, with the setting
+   exactly one file appears under the expected path.
+9. **Safety test** — add the forbidden-import boundary test (§8.3) and verify it
+   passes.
+10. **Docs touch-up** — add a 5-line stub to `CLAUDE.md` under "환경 변수" listing
+    the new `tradingagents_*` envs and pointing at this plan.
+
+---
+
+## 12. Self-review checklist (run before opening the PR)
+
+- [ ] No `app/services/kis*`, `app/services/upbit*`, `app/services/brokers`,
+      `app/services/order_service`, `app/services/watch_alerts`,
+      `app/services/paper_trading_service` imports anywhere in the diff.
+- [ ] No `place_order`, `manage_watch_alerts`, broker construction, Redis
+      write, Paperclip call.
+- [ ] No `TradingDecisionAction`, `TradingDecisionCounterfactual`, or
+      `TradingDecisionOutcome` row created by the new service or tests.
+- [ ] `advisory_only=True` and `execution_allowed=False` are present at three
+      layers: Pydantic `Literal` pin, `session.market_brief`,
+      `proposal.original_payload`.
+- [ ] No `os.environ` values appear in any log record, exception message,
+      `original_payload`, `market_brief`, or memory-log file. Grep the diff for
+      `KEY`, `SECRET`, `TOKEN`, `os.environ` and confirm.
+- [ ] No `subprocess.run(..., shell=True)` and no f-string interpolation into
+      argv.
+- [ ] All §8 tests pass locally:
+      `uv run pytest tests/services/test_tradingagents_research_service*.py -v`
+- [ ] `make lint && make typecheck` pass.
+- [ ] PR description links Linear ROB-9 and explicitly states **"advisory-only,
+      no execution path"** in the summary.
+
+---
+
+**End of plan.** Implementation should not begin until this plan is reviewed.

--- a/tests/fixtures/tradingagents/runner_invariant_violation.json
+++ b/tests/fixtures/tradingagents/runner_invariant_violation.json
@@ -1,0 +1,26 @@
+{
+  "status": "ok",
+  "symbol": "NVDA",
+  "as_of_date": "2026-04-27",
+  "decision": "This malformed payload incorrectly allows execution.",
+  "advisory_only": true,
+  "execution_allowed": true,
+  "analysts": ["market"],
+  "llm": {
+    "provider": "openai-compatible",
+    "model": "gpt-5.5",
+    "base_url": "http://127.0.0.1:8796/v1"
+  },
+  "config": {
+    "max_debate_rounds": 1,
+    "max_risk_discuss_rounds": 1,
+    "max_recur_limit": 30,
+    "output_language": "English",
+    "checkpoint_enabled": false
+  },
+  "warnings": {
+    "structured_output": []
+  },
+  "final_trade_decision": "Execution incorrectly authorized.",
+  "raw_state_keys": ["market_report"]
+}

--- a/tests/fixtures/tradingagents/runner_ok_nvda.json
+++ b/tests/fixtures/tradingagents/runner_ok_nvda.json
@@ -1,0 +1,29 @@
+{
+  "status": "ok",
+  "symbol": "NVDA",
+  "as_of_date": "2026-04-27",
+  "decision": "Advisory research only: monitor NVDA momentum and valuation risk.",
+  "advisory_only": true,
+  "execution_allowed": false,
+  "analysts": ["market", "news"],
+  "llm": {
+    "provider": "openai-compatible",
+    "model": "gpt-5.5",
+    "base_url": "http://127.0.0.1:8796/v1"
+  },
+  "config": {
+    "max_debate_rounds": 1,
+    "max_risk_discuss_rounds": 1,
+    "max_recur_limit": 30,
+    "output_language": "English",
+    "checkpoint_enabled": false
+  },
+  "warnings": {
+    "structured_output": [
+      "earnings sensitivity noted",
+      "macro liquidity risk noted"
+    ]
+  },
+  "final_trade_decision": "No execution authorized.",
+  "raw_state_keys": ["market_report", "news_report", "investment_plan"]
+}

--- a/tests/services/test_tradingagents_research_service.py
+++ b/tests/services/test_tradingagents_research_service.py
@@ -56,7 +56,9 @@ def _configure_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path
     monkeypatch.setattr(svc.settings, "tradingagents_repo_path", str(repo))
     monkeypatch.setattr(svc.settings, "tradingagents_python", sys.executable)
     monkeypatch.setattr(svc.settings, "tradingagents_runner_path", None)
-    monkeypatch.setattr(svc.settings, "tradingagents_base_url", "http://shim/v1")
+    monkeypatch.setattr(
+        svc.settings, "tradingagents_base_url", "https://shim.invalid/v1"
+    )
     monkeypatch.setattr(svc.settings, "tradingagents_model", "gpt-5.5")
     monkeypatch.setattr(svc.settings, "tradingagents_default_analysts", "market")
     monkeypatch.setattr(svc.settings, "tradingagents_subprocess_timeout_sec", 15)
@@ -81,13 +83,18 @@ def _required_settings() -> dict[str, str]:
     }
 
 
-def test_settings_parse_tradingagents_env_values() -> None:
+def test_settings_parse_tradingagents_env_values(tmp_path: Path) -> None:
+    repo_path = tmp_path / "TradingAgents"
+    python_path = repo_path / ".venv" / "bin" / "python"
+    runner_path = tmp_path / "runner.py"
+    memory_path = tmp_path / "tradingagents-memory"
+
     settings = Settings(
         **_required_settings(),
-        tradingagents_repo_path="/tmp/TradingAgents",
-        tradingagents_python="/tmp/TradingAgents/.venv/bin/python",
-        tradingagents_runner_path="/tmp/runner.py",
-        tradingagents_base_url="http://localhost:8796/v1",
+        tradingagents_repo_path=str(repo_path),
+        tradingagents_python=str(python_path),
+        tradingagents_runner_path=str(runner_path),
+        tradingagents_base_url="https://localhost:8796/v1",
         tradingagents_model="local-model",
         tradingagents_default_analysts="market,news",
         tradingagents_subprocess_timeout_sec=45,
@@ -96,11 +103,11 @@ def test_settings_parse_tradingagents_env_values() -> None:
         tradingagents_max_recur_limit=12,
         tradingagents_output_language="Korean",
         tradingagents_checkpoint_enabled=True,
-        tradingagents_memory_log_path="/tmp/tradingagents-memory",
+        tradingagents_memory_log_path=str(memory_path),
     )
 
-    assert settings.tradingagents_repo_path == "/tmp/TradingAgents"
-    assert settings.tradingagents_runner_path == "/tmp/runner.py"
+    assert settings.tradingagents_repo_path == str(repo_path)
+    assert settings.tradingagents_runner_path == str(runner_path)
     assert settings.tradingagents_subprocess_timeout_sec == 45
     assert settings.tradingagents_checkpoint_enabled is True
 

--- a/tests/services/test_tradingagents_research_service.py
+++ b/tests/services/test_tradingagents_research_service.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from app.core.config import Settings
+from app.models.trading import InstrumentType
+from app.schemas.tradingagents_research import TradingAgentsRunnerResult
+from app.services import tradingagents_research_service as svc
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "tradingagents"
+
+
+class FakeProcess:
+    def __init__(
+        self,
+        *,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+        returncode: int = 0,
+    ) -> None:
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+        self.kill_called = False
+        self.wait = AsyncMock(return_value=None)
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self._stdout, self._stderr
+
+    def kill(self) -> None:
+        self.kill_called = True
+
+
+def _payload(name: str = "runner_ok_nvda.json") -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def _payload_bytes(name: str = "runner_ok_nvda.json") -> bytes:
+    return (FIXTURE_DIR / name).read_bytes()
+
+
+def _configure_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    repo = tmp_path / "TradingAgents"
+    runner = repo / "scripts" / "run_auto_trader_research.py"
+    runner.parent.mkdir(parents=True)
+    runner.write_text("print('stub')\n", encoding="utf-8")
+    monkeypatch.setattr(svc.settings, "tradingagents_repo_path", str(repo))
+    monkeypatch.setattr(svc.settings, "tradingagents_python", sys.executable)
+    monkeypatch.setattr(svc.settings, "tradingagents_runner_path", None)
+    monkeypatch.setattr(svc.settings, "tradingagents_base_url", "http://shim/v1")
+    monkeypatch.setattr(svc.settings, "tradingagents_model", "gpt-5.5")
+    monkeypatch.setattr(svc.settings, "tradingagents_default_analysts", "market")
+    monkeypatch.setattr(svc.settings, "tradingagents_subprocess_timeout_sec", 15)
+    monkeypatch.setattr(svc.settings, "tradingagents_max_debate_rounds", 1)
+    monkeypatch.setattr(svc.settings, "tradingagents_max_risk_discuss_rounds", 1)
+    monkeypatch.setattr(svc.settings, "tradingagents_max_recur_limit", 30)
+    monkeypatch.setattr(svc.settings, "tradingagents_output_language", "English")
+    monkeypatch.setattr(svc.settings, "tradingagents_checkpoint_enabled", False)
+    monkeypatch.setattr(svc.settings, "tradingagents_memory_log_path", None)
+    return runner
+
+
+def _required_settings() -> dict[str, str]:
+    return {
+        "kis_app_key": "dummy",
+        "kis_app_secret": "dummy",
+        "opendart_api_key": "dummy",
+        "DATABASE_URL": "postgresql+asyncpg://postgres:postgres@localhost/test",
+        "upbit_access_key": "dummy",
+        "upbit_secret_key": "dummy",
+        "SECRET_KEY": "Test_Secret_Key_12345_Test_Secret_Key_12345",
+    }
+
+
+def test_settings_parse_tradingagents_env_values() -> None:
+    settings = Settings(
+        **_required_settings(),
+        tradingagents_repo_path="/tmp/TradingAgents",
+        tradingagents_python="/tmp/TradingAgents/.venv/bin/python",
+        tradingagents_runner_path="/tmp/runner.py",
+        tradingagents_base_url="http://localhost:8796/v1",
+        tradingagents_model="local-model",
+        tradingagents_default_analysts="market,news",
+        tradingagents_subprocess_timeout_sec=45,
+        tradingagents_max_debate_rounds=2,
+        tradingagents_max_risk_discuss_rounds=3,
+        tradingagents_max_recur_limit=12,
+        tradingagents_output_language="Korean",
+        tradingagents_checkpoint_enabled=True,
+        tradingagents_memory_log_path="/tmp/tradingagents-memory",
+    )
+
+    assert settings.tradingagents_repo_path == "/tmp/TradingAgents"
+    assert settings.tradingagents_runner_path == "/tmp/runner.py"
+    assert settings.tradingagents_subprocess_timeout_sec == 45
+    assert settings.tradingagents_checkpoint_enabled is True
+
+
+def test_schema_accepts_ok_payload_and_rejects_invariant_violation() -> None:
+    ok = TradingAgentsRunnerResult.model_validate(_payload())
+    assert ok.advisory_only is True
+    assert ok.execution_allowed is False
+
+    with pytest.raises(ValidationError):
+        TradingAgentsRunnerResult.model_validate(
+            _payload("runner_invariant_violation.json")
+        )
+
+
+@pytest.mark.asyncio
+async def test_runner_ok_returns_validated_result(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = _configure_settings(monkeypatch, tmp_path)
+    proc = FakeProcess(stdout=_payload_bytes())
+    create = AsyncMock(return_value=proc)
+    monkeypatch.setattr(svc.asyncio, "create_subprocess_exec", create)
+
+    result = await svc.run_tradingagents_research(
+        symbol="NVDA",
+        instrument_type=InstrumentType.equity_us,
+        analysts=["market", "news"],
+    )
+
+    assert result.symbol == "NVDA"
+    assert result.advisory_only is True
+    assert result.execution_allowed is False
+    argv = create.call_args.args
+    assert argv[:2] == (str(Path(sys.executable).resolve()), str(runner.resolve()))
+    assert "--symbol" in argv
+    assert ";" not in argv
+    assert create.call_args.kwargs["cwd"] == str(runner.parents[1])
+    assert create.call_args.kwargs["stdout"] == asyncio.subprocess.PIPE
+    assert create.call_args.kwargs["stderr"] == asyncio.subprocess.PIPE
+
+
+@pytest.mark.asyncio
+async def test_runner_nonzero_exit_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _configure_settings(monkeypatch, tmp_path)
+    proc = FakeProcess(stdout=b"{}", stderr=b"boom", returncode=1)
+    monkeypatch.setattr(
+        svc.asyncio, "create_subprocess_exec", AsyncMock(return_value=proc)
+    )
+
+    with pytest.raises(svc.TradingAgentsRunnerError, match="exited with 1"):
+        await svc.run_tradingagents_research(
+            symbol="NVDA", instrument_type=InstrumentType.equity_us
+        )
+
+
+@pytest.mark.asyncio
+async def test_runner_timeout_kills_and_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _configure_settings(monkeypatch, tmp_path)
+    proc = FakeProcess()
+    monkeypatch.setattr(
+        svc.asyncio, "create_subprocess_exec", AsyncMock(return_value=proc)
+    )
+
+    async def _timeout(awaitable, *, timeout):
+        _ = timeout
+        awaitable.close()
+        raise TimeoutError
+
+    monkeypatch.setattr(svc.asyncio, "wait_for", _timeout)
+
+    with pytest.raises(svc.TradingAgentsRunnerError, match="timed out"):
+        await svc.run_tradingagents_research(
+            symbol="NVDA", instrument_type=InstrumentType.equity_us
+        )
+
+    assert proc.kill_called is True
+    proc.wait.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_runner_non_json_stdout_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _configure_settings(monkeypatch, tmp_path)
+    proc = FakeProcess(stdout=b"<<not json>>")
+    monkeypatch.setattr(
+        svc.asyncio, "create_subprocess_exec", AsyncMock(return_value=proc)
+    )
+
+    with pytest.raises(svc.TradingAgentsRunnerError, match="non-JSON"):
+        await svc.run_tradingagents_research(
+            symbol="NVDA", instrument_type=InstrumentType.equity_us
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("status", "error"),
+        ("advisory_only", False),
+        ("execution_allowed", True),
+    ],
+)
+async def test_runner_advisory_invariant_violations_are_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    field: str,
+    value: object,
+) -> None:
+    _configure_settings(monkeypatch, tmp_path)
+    payload = _payload()
+    payload[field] = value
+    proc = FakeProcess(stdout=json.dumps(payload).encode("utf-8"))
+    monkeypatch.setattr(
+        svc.asyncio, "create_subprocess_exec", AsyncMock(return_value=proc)
+    )
+
+    with pytest.raises(svc.AdvisoryInvariantViolation):
+        await svc.run_tradingagents_research(
+            symbol="NVDA", instrument_type=InstrumentType.equity_us
+        )
+
+
+@pytest.mark.asyncio
+async def test_warnings_structured_output_preserved(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _configure_settings(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        svc.asyncio,
+        "create_subprocess_exec",
+        AsyncMock(return_value=FakeProcess(stdout=_payload_bytes())),
+    )
+
+    result = await svc.run_tradingagents_research(
+        symbol="NVDA", instrument_type=InstrumentType.equity_us
+    )
+
+    assert result.warnings.structured_output == [
+        "earnings sensitivity noted",
+        "macro liquidity risk noted",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_symbol_argv_validation_rejects_shell_metachars(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _configure_settings(monkeypatch, tmp_path)
+    create = AsyncMock()
+    monkeypatch.setattr(svc.asyncio, "create_subprocess_exec", create)
+
+    with pytest.raises(ValueError, match="symbol"):
+        await svc.run_tradingagents_research(
+            symbol="AAPL; rm -rf /",
+            instrument_type=InstrumentType.equity_us,
+        )
+
+    create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_analyst_argv_validation_rejects_shell_metachars(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _configure_settings(monkeypatch, tmp_path)
+    create = AsyncMock()
+    monkeypatch.setattr(svc.asyncio, "create_subprocess_exec", create)
+
+    with pytest.raises(ValueError, match="analyst"):
+        await svc.run_tradingagents_research(
+            symbol="NVDA",
+            instrument_type=InstrumentType.equity_us,
+            analysts=["market;bad"],
+        )
+
+    create.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_settings_missing_repo_path_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _configure_settings(monkeypatch, tmp_path)
+    monkeypatch.setattr(svc.settings, "tradingagents_repo_path", None)
+
+    with pytest.raises(svc.TradingAgentsNotConfigured):
+        await svc.run_tradingagents_research(
+            symbol="NVDA", instrument_type=InstrumentType.equity_us
+        )
+
+
+@pytest.mark.asyncio
+async def test_filtered_env_does_not_leak_unrelated_vars(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _configure_settings(monkeypatch, tmp_path)
+    monkeypatch.setenv("ROB9_UNRELATED_SECRET", "must-not-leak")
+    monkeypatch.setenv("TRADINGAGENTS_ALLOWED_FLAG", "allowed")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    create = AsyncMock(return_value=FakeProcess(stdout=_payload_bytes()))
+    monkeypatch.setattr(svc.asyncio, "create_subprocess_exec", create)
+
+    await svc.run_tradingagents_research(
+        symbol="NVDA", instrument_type=InstrumentType.equity_us
+    )
+
+    child_env = create.call_args.kwargs["env"]
+    assert "ROB9_UNRELATED_SECRET" not in child_env
+    assert child_env["TRADINGAGENTS_ALLOWED_FLAG"] == "allowed"
+    assert child_env["OPENAI_API_KEY"] == "test-key"
+
+
+@pytest.mark.asyncio
+async def test_default_openai_api_key_injected_when_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _configure_settings(monkeypatch, tmp_path)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    create = AsyncMock(return_value=FakeProcess(stdout=_payload_bytes()))
+    monkeypatch.setattr(svc.asyncio, "create_subprocess_exec", create)
+
+    await svc.run_tradingagents_research(
+        symbol="NVDA", instrument_type=InstrumentType.equity_us
+    )
+
+    assert create.call_args.kwargs["env"]["OPENAI_API_KEY"] == "no-key-required"
+
+
+@pytest.mark.asyncio
+async def test_memory_log_disabled_writes_no_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _configure_settings(monkeypatch, tmp_path)
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr(svc.settings, "tradingagents_memory_log_path", None)
+    monkeypatch.setattr(
+        svc.asyncio,
+        "create_subprocess_exec",
+        AsyncMock(return_value=FakeProcess(stdout=_payload_bytes())),
+    )
+
+    await svc.run_tradingagents_research(
+        symbol="NVDA", instrument_type=InstrumentType.equity_us
+    )
+
+    assert not log_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_memory_log_enabled_writes_validated_payload_under_configured_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _configure_settings(monkeypatch, tmp_path)
+    log_dir = tmp_path / "logs"
+    monkeypatch.setattr(svc.settings, "tradingagents_memory_log_path", str(log_dir))
+    result = TradingAgentsRunnerResult.model_validate(_payload())
+    session_uuid = uuid.uuid4()
+    session_obj = SimpleNamespace(id=123, session_uuid=session_uuid)
+    proposal = SimpleNamespace(id=456)
+    monkeypatch.setattr(
+        svc,
+        "run_tradingagents_research",
+        AsyncMock(return_value=result),
+    )
+    monkeypatch.setattr(
+        svc.trading_decision_service,
+        "create_decision_session",
+        AsyncMock(return_value=session_obj),
+    )
+    monkeypatch.setattr(
+        svc.trading_decision_service,
+        "add_decision_proposals",
+        AsyncMock(return_value=[proposal]),
+    )
+
+    await svc.ingest_tradingagents_research(
+        MagicMock(),
+        user_id=1,
+        symbol="NVDA",
+        instrument_type=InstrumentType.equity_us,
+    )
+
+    files = list(log_dir.rglob("*.json"))
+    assert len(files) == 1
+    assert files[0].is_relative_to(log_dir)
+    assert files[0].name == f"NVDA-{session_uuid}.json"
+    logged = json.loads(files[0].read_text(encoding="utf-8"))
+    assert logged["advisory_only"] is True
+    assert logged["execution_allowed"] is False

--- a/tests/services/test_tradingagents_research_service_integration.py
+++ b/tests/services/test_tradingagents_research_service_integration.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import engine
+from app.models.trading import InstrumentType
+from app.models.trading_decision import (
+    ProposalKind,
+    TradingDecisionAction,
+    TradingDecisionCounterfactual,
+    TradingDecisionOutcome,
+    TradingDecisionProposal,
+    TradingDecisionSession,
+    UserResponse,
+)
+from app.services import tradingagents_research_service as svc
+
+FIXTURE_DIR = Path(__file__).resolve().parents[1] / "fixtures" / "tradingagents"
+SessionLocal = async_sessionmaker(
+    bind=engine, class_=AsyncSession, expire_on_commit=False
+)
+
+
+async def _ensure_trading_decision_tables() -> None:
+    try:
+        async with SessionLocal() as session:
+            row = await session.execute(
+                text("SELECT to_regclass('trading_decision_sessions')")
+            )
+            if row.scalar_one_or_none() is None:
+                pytest.skip("trading_decision tables are not migrated")
+    except Exception:
+        pytest.skip("database is not available for integration persistence checks")
+
+
+async def _create_user() -> int:
+    suffix = uuid.uuid4().hex[:8]
+    async with SessionLocal() as session:
+        user_id = (
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO users (username, email, role, tz, base_currency, is_active)
+                    VALUES (:username, :email, 'viewer', 'Asia/Seoul', 'KRW', true)
+                    RETURNING id
+                    """
+                ),
+                {
+                    "username": f"ta_research_test_{suffix}",
+                    "email": f"ta_research_{suffix}@example.com",
+                },
+            )
+        ).scalar_one()
+        await session.commit()
+        return user_id
+
+
+async def _cleanup_user(user_id: int) -> None:
+    async with SessionLocal() as session:
+        await session.execute(
+            text("DELETE FROM users WHERE id = :user_id"), {"user_id": user_id}
+        )
+        await session.commit()
+
+
+def _payload() -> dict:
+    return json.loads((FIXTURE_DIR / "runner_ok_nvda.json").read_text("utf-8"))
+
+
+@pytest.fixture
+def stub_runner(monkeypatch: pytest.MonkeyPatch):
+    async def _run_tradingagents_research(**_kwargs):
+        from app.schemas.tradingagents_research import TradingAgentsRunnerResult
+
+        return TradingAgentsRunnerResult.model_validate(_payload())
+
+    monkeypatch.setattr(svc, "run_tradingagents_research", _run_tradingagents_research)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ingest_creates_session_and_single_proposal(stub_runner) -> None:
+    await _ensure_trading_decision_tables()
+    user_id = await _create_user()
+    try:
+        async with SessionLocal() as session:
+            ds, proposal = await svc.ingest_tradingagents_research(
+                session,
+                user_id=user_id,
+                symbol="NVDA",
+                instrument_type=InstrumentType.equity_us,
+            )
+            await session.commit()
+
+            assert ds.source_profile == "tradingagents"
+            assert ds.strategy_name == "tradingagents:gpt-5.5:market,news"
+            assert ds.market_scope == "us"
+            assert proposal.proposal_kind == ProposalKind.other
+            assert proposal.side == "none"
+            assert proposal.session_id == ds.id
+
+            count = await session.scalar(
+                select(func.count(TradingDecisionProposal.id)).where(
+                    TradingDecisionProposal.session_id == ds.id
+                )
+            )
+            assert count == 1
+    finally:
+        await _cleanup_user(user_id)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ingest_persists_advisory_invariants_in_market_brief_and_payload(
+    stub_runner,
+) -> None:
+    await _ensure_trading_decision_tables()
+    user_id = await _create_user()
+    try:
+        async with SessionLocal() as session:
+            ds, proposal = await svc.ingest_tradingagents_research(
+                session,
+                user_id=user_id,
+                symbol="NVDA",
+                instrument_type=InstrumentType.equity_us,
+            )
+            await session.commit()
+
+            assert ds.market_brief["advisory_only"] is True
+            assert ds.market_brief["execution_allowed"] is False
+            assert proposal.original_payload["advisory_only"] is True
+            assert proposal.original_payload["execution_allowed"] is False
+    finally:
+        await _cleanup_user(user_id)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ingest_preserves_warnings_structured_output(stub_runner) -> None:
+    await _ensure_trading_decision_tables()
+    user_id = await _create_user()
+    try:
+        async with SessionLocal() as session:
+            ds, proposal = await svc.ingest_tradingagents_research(
+                session,
+                user_id=user_id,
+                symbol="NVDA",
+                instrument_type=InstrumentType.equity_us,
+            )
+            await session.commit()
+
+            expected = ["earnings sensitivity noted", "macro liquidity risk noted"]
+            assert ds.market_brief["warnings"]["structured_output"] == expected
+            assert (
+                proposal.original_payload["warnings"]["structured_output"] == expected
+            )
+    finally:
+        await _cleanup_user(user_id)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ingest_does_not_create_action_or_counterfactual_or_outcome(
+    stub_runner,
+) -> None:
+    await _ensure_trading_decision_tables()
+    user_id = await _create_user()
+    try:
+        async with SessionLocal() as session:
+            _, proposal = await svc.ingest_tradingagents_research(
+                session,
+                user_id=user_id,
+                symbol="NVDA",
+                instrument_type=InstrumentType.equity_us,
+            )
+            await session.commit()
+
+            action_count = await session.scalar(
+                select(func.count(TradingDecisionAction.id)).where(
+                    TradingDecisionAction.proposal_id == proposal.id
+                )
+            )
+            counterfactual_count = await session.scalar(
+                select(func.count(TradingDecisionCounterfactual.id)).where(
+                    TradingDecisionCounterfactual.proposal_id == proposal.id
+                )
+            )
+            outcome_count = await session.scalar(
+                select(func.count(TradingDecisionOutcome.id)).where(
+                    TradingDecisionOutcome.proposal_id == proposal.id
+                )
+            )
+            assert action_count == 0
+            assert counterfactual_count == 0
+            assert outcome_count == 0
+    finally:
+        await _cleanup_user(user_id)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ingest_runner_failure_rolls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _ensure_trading_decision_tables()
+    user_id = await _create_user()
+
+    async def _raise(**_kwargs):
+        raise svc.TradingAgentsRunnerError("runner failed")
+
+    monkeypatch.setattr(svc, "run_tradingagents_research", _raise)
+    try:
+        async with SessionLocal() as session:
+            with pytest.raises(svc.TradingAgentsRunnerError):
+                await svc.ingest_tradingagents_research(
+                    session,
+                    user_id=user_id,
+                    symbol="NVDA",
+                    instrument_type=InstrumentType.equity_us,
+                )
+            await session.rollback()
+
+            count = await session.scalar(
+                select(func.count(TradingDecisionSession.id)).where(
+                    TradingDecisionSession.user_id == user_id,
+                    TradingDecisionSession.source_profile == "tradingagents",
+                )
+            )
+            assert count == 0
+    finally:
+        await _cleanup_user(user_id)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_ingest_does_not_touch_user_response_fields(stub_runner) -> None:
+    await _ensure_trading_decision_tables()
+    user_id = await _create_user()
+    try:
+        async with SessionLocal() as session:
+            _, proposal = await svc.ingest_tradingagents_research(
+                session,
+                user_id=user_id,
+                symbol="NVDA",
+                instrument_type=InstrumentType.equity_us,
+            )
+            await session.commit()
+
+            assert proposal.user_response == UserResponse.pending
+            assert proposal.responded_at is None
+            assert proposal.user_quantity is None
+            assert proposal.user_quantity_pct is None
+            assert proposal.user_amount is None
+            assert proposal.user_price is None
+            assert proposal.user_trigger_price is None
+            assert proposal.user_threshold_pct is None
+            assert proposal.user_note is None
+    finally:
+        await _cleanup_user(user_id)

--- a/tests/services/test_tradingagents_research_service_safety.py
+++ b/tests/services/test_tradingagents_research_service_safety.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+_FORBIDDEN_PREFIXES = [
+    "app.services.kis",
+    "app.services.kis_trading_service",
+    "app.services.kis_trading_contracts",
+    "app.services.upbit",
+    "app.services.upbit_websocket",
+    "app.services.brokers",
+    "app.services.order_service",
+    "app.services.fill_notification",
+    "app.services.execution_event",
+    "app.services.redis_token_manager",
+    "app.services.kis_websocket",
+    "app.services.kis_websocket_internal",
+    "app.services.watch_alerts",
+    "app.services.paper_trading_service",
+    "app.services.openclaw_client",
+    "app.services.crypto_trade_cooldown_service",
+    "app.tasks",
+]
+
+
+@pytest.mark.integration
+def test_service_module_does_not_import_execution_paths() -> None:
+    project_root = str(pathlib.Path(__file__).parent.parent.parent)
+    service_file = str(
+        pathlib.Path(__file__).parent.parent.parent
+        / "app"
+        / "services"
+        / "tradingagents_research_service.py"
+    )
+
+    script = f"""
+import sys
+import types
+import json
+import importlib.util
+import pathlib
+
+project_root = {project_root!r}
+service_file = {service_file!r}
+sys.path.insert(0, project_root)
+
+svc_stub = types.ModuleType("app.services")
+svc_stub.__path__ = [str(pathlib.Path(project_root) / "app" / "services")]
+svc_stub.__package__ = "app.services"
+sys.modules.setdefault("app.services", svc_stub)
+
+spec = importlib.util.spec_from_file_location(
+    "app.services.tradingagents_research_service", service_file
+)
+mod = importlib.util.module_from_spec(spec)
+sys.modules["app.services.tradingagents_research_service"] = mod
+spec.loader.exec_module(mod)
+
+print(json.dumps(sorted(sys.modules.keys())))
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"Subprocess import of tradingagents_research_service failed:\n{result.stderr}"
+    )
+
+    loaded: list[str] = json.loads(result.stdout)
+    violations = [
+        m
+        for prefix in _FORBIDDEN_PREFIXES
+        for m in loaded
+        if m == prefix or m.startswith(prefix + ".")
+    ]
+
+    assert not violations, (
+        "Forbidden module(s) loaded as a transitive consequence of importing "
+        "tradingagents_research_service:\n" + "\n".join(violations)
+    )


### PR DESCRIPTION
## Summary
- Add an internal TradingAgents advisory research service that runs the forked TradingAgents runner via explicit `asyncio.create_subprocess_exec` argv.
- Validate runner JSON with hard advisory-only invariants: `status="ok"`, `advisory_only=true`, `execution_allowed=false`.
- Persist validated output into Trading Decision Workspace as one `TradingDecisionSession` plus one `TradingDecisionProposal` with `source_profile="tradingagents"`.
- Include AoE plan and Claude Opus review report for ROB-9.

**Safety boundary:** advisory-only, no execution path. This PR does not create orders, watches, actions, counterfactuals, outcomes, scheduler jobs, API endpoints, Paperclip writes, Redis writes, or broker calls.

## Validation
- `uv run ruff check app/schemas/tradingagents_research.py app/services/tradingagents_research_service.py tests/services/test_tradingagents_research_service.py tests/services/test_tradingagents_research_service_safety.py tests/services/test_tradingagents_research_service_integration.py`
- `uv run ruff format --check app/schemas/tradingagents_research.py app/services/tradingagents_research_service.py tests/services/test_tradingagents_research_service.py tests/services/test_tradingagents_research_service_safety.py tests/services/test_tradingagents_research_service_integration.py`
- `uv run pytest tests/services/test_tradingagents_research_service.py tests/services/test_tradingagents_research_service_safety.py tests/services/test_tradingagents_research_service_integration.py -q`
  - Result: `18 passed, 6 skipped`

## Review
- AoE planner/reviewer: Claude Opus
- Implementer: Codex (`--yolo`) in the ROB-9 AoE worktree
- Review report: `docs/plans/ROB-9-review-report.md`
- Verdict: `AOE_STATUS: review_passed`

Closes ROB-9
