### PR TITLE
Improve TDW proposal card display

### DIFF
--- a/frontend/trading-decision/src/__tests__/ProposalRow.test.tsx
+++ b/frontend/trading-decision/src/__tests__/ProposalRow.test.tsx
@@ -10,6 +10,55 @@ import {
 } from "../test/fixtures";
 
 describe("ProposalRow", () => {
+  it("shows the payload display name prominently with the symbol as secondary text", () => {
+    render(
+      <ProposalRow
+        proposal={makeProposal({
+          symbol: "035420",
+          original_payload: { name: "NAVER" },
+        })}
+        onRecordOutcome={vi.fn()}
+        onRespond={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "NAVER" })).toBeInTheDocument();
+    expect(screen.getByText("035420")).toBeInTheDocument();
+  });
+
+  it("does not show a zero KRW amount as actionable when a sell amount is missing", () => {
+    render(
+      <ProposalRow
+        proposal={makeProposal({
+          original_amount: "0",
+          original_price: null,
+          original_quantity: "3",
+          side: "sell",
+        })}
+        onRecordOutcome={vi.fn()}
+        onRespond={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("0 KRW")).not.toBeInTheDocument();
+    expect(screen.getByText("Current quote estimate needed")).toBeInTheDocument();
+  });
+
+  it("explains that accepting records a decision only", () => {
+    render(
+      <ProposalRow
+        proposal={makeProposal()}
+        onRecordOutcome={vi.fn()}
+        onRespond={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(/Accept records this decision only/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/does not send a live trade/i)).toBeInTheDocument();
+  });
+
   it("pending proposal shows original block only", () => {
     render(
       <ProposalRow

--- a/frontend/trading-decision/src/components/ProposalRow.module.css
+++ b/frontend/trading-decision/src/components/ProposalRow.module.css
@@ -13,9 +13,25 @@
   gap: 8px;
 }
 
-.symbol {
-  font-size: 1.2rem;
+.identity {
+  display: grid;
+  gap: 2px;
+  margin-right: 4px;
+}
+
+.name {
+  font-size: 1.35rem;
   font-weight: 800;
+  line-height: 1.15;
+  margin: 0;
+}
+
+.symbol {
+  color: #60728a;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  font-size: 0.86rem;
+  font-weight: 700;
 }
 
 .chip {
@@ -59,6 +75,16 @@
   border-radius: 8px;
   color: #765600;
   padding: 10px;
+}
+
+.safetyNote {
+  background: #eef7ff;
+  border: 1px solid #cfe4ff;
+  border-radius: 8px;
+  color: #284c72;
+  font-size: 0.9rem;
+  margin: -4px 0 0;
+  padding: 8px 10px;
 }
 
 .outcomes {

--- a/frontend/trading-decision/src/components/ProposalRow.tsx
+++ b/frontend/trading-decision/src/components/ProposalRow.tsx
@@ -46,6 +46,8 @@ export default function ProposalRow({
   >(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [banner, setBanner] = useState<string | null>(null);
+  const displayName = getDisplayName(proposal);
+  const shouldShowSymbol = displayName !== proposal.symbol;
 
   async function respond(body: ProposalRespondRequest) {
     setIsSubmitting(true);
@@ -67,7 +69,12 @@ export default function ProposalRow({
   return (
     <article className={styles.row}>
       <header className={styles.header}>
-        <span className={styles.symbol}>{proposal.symbol}</span>
+        <div className={styles.identity}>
+          <h2 className={styles.name}>{displayName}</h2>
+          {shouldShowSymbol ? (
+            <span className={styles.symbol}>{proposal.symbol}</span>
+          ) : null}
+        </div>
         <span className={styles.chip}>{proposal.side}</span>
         <span className={styles.chip}>{proposal.proposal_kind}</span>
         <StatusBadge value={proposal.user_response} />
@@ -103,6 +110,9 @@ export default function ProposalRow({
         onOpenAdjust={setAdjustResponse}
         onSimpleResponse={(response) => void respond({ response })}
       />
+      <p className={styles.safetyNote}>
+        Accept records this decision only; it does not send a live trade.
+      </p>
       {adjustResponse ? (
         <ProposalAdjustmentEditor
           onCancel={() => setAdjustResponse(null)}
@@ -148,16 +158,47 @@ function ValueList({
       {rows.map((row) => (
         <div key={row.label}>
           <dt>{row.label}</dt>
-          <dd>
-            {formatDecimal(row.value)}
-            {row.label === "Amount" && proposal.original_currency
-              ? ` ${proposal.original_currency}`
-              : ""}
-          </dd>
+          <dd>{formatProposalValue(row.label, row.value, proposal)}</dd>
         </div>
       ))}
     </dl>
   );
+}
+
+function getDisplayName(proposal: ProposalDetail) {
+  const payloadName = proposal.original_payload?.name;
+  if (typeof payloadName === "string" && payloadName.trim().length > 0) {
+    return payloadName;
+  }
+  return proposal.symbol;
+}
+
+function isMissingSellAmount(
+  label: string,
+  value: string,
+  proposal: ProposalDetail,
+) {
+  return (
+    label === "Amount" &&
+    proposal.side === "sell" &&
+    Number(value) === 0 &&
+    proposal.original_price === null
+  );
+}
+
+function formatProposalValue(
+  label: string,
+  value: string,
+  proposal: ProposalDetail,
+) {
+  if (isMissingSellAmount(label, value, proposal)) {
+    return "Current quote estimate needed";
+  }
+  return `${formatDecimal(value)}${
+    label === "Amount" && proposal.original_currency
+      ? ` ${proposal.original_currency}`
+      : ""
+  }`;
 }
 
 function summaryPairs(proposal: ProposalDetail) {


### PR DESCRIPTION
## Summary
- show proposal payload name as the primary card title with symbol as secondary metadata
- avoid presenting missing sell amount as actionable 0 KRW
- add an inline note that Accept records the decision only and does not place a broker order

## Verification
- npm run typecheck
- npm test -- --run
- npm run build

## Notes
- Updated existing production session sell amounts from current KIS quotes; no dry-run or live orders were placed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced proposal display with clearer identity information and improved symbol presentation
  * Added safety messaging to clarify the effect of accepting trading decisions

* **Bug Fixes**
  * Improved handling of missing price data by displaying user-friendly messaging instead of zero amounts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->