### PR TITLE
fix(rob-14): default advisory-only runner invariants

### DIFF
--- a/app/schemas/trading_decision_synthesis.py
+++ b/app/schemas/trading_decision_synthesis.py
@@ -136,8 +136,8 @@ def advisory_from_runner_result(payload: dict[str, Any]) -> AdvisoryEvidence:
             warning_items.append(str(value))
 
     return AdvisoryEvidence(
-        advisory_only=payload.get("advisory_only"),
-        execution_allowed=payload.get("execution_allowed"),
+        advisory_only=payload.get("advisory_only", True),
+        execution_allowed=payload.get("execution_allowed", False),
         advisory_action=str(
             payload.get("decision") or payload.get("advisory_action") or "Unknown"
         ),

--- a/tests/services/test_trading_decision_synthesis.py
+++ b/tests/services/test_trading_decision_synthesis.py
@@ -171,6 +171,20 @@ def test_runner_result_normalization_preserves_metadata_and_invariants():
     assert evidence.warnings == ["fallback used"]
 
 
+def test_runner_result_normalization_defaults_to_advisory_only_invariants():
+    evidence = advisory_from_runner_result(
+        {
+            "decision": "Underweight",
+            "model": "tradingagents-smoke",
+            "base_url": "local-smoke",
+        }
+    )
+
+    assert evidence.advisory_only is True
+    assert evidence.execution_allowed is False
+    assert evidence.advisory_action == "Underweight"
+
+
 def test_session_synthesis_meta_counts_conflicts_and_keeps_safety_flags():
     synthesized = synthesize_candidate_with_advisory(
         CandidateAnalysis(**_candidate_kwargs()), AdvisoryEvidence(**_advisory_kwargs())


### PR DESCRIPTION
## Summary

Fixes a ROB-14 post-deploy smoke bug where `advisory_from_runner_result()` passed `None` for missing safety invariant fields instead of using the schema defaults.

## Safety

- Missing runner fields now default to `advisory_only=True` and `execution_allowed=False`.
- Explicit unsafe values are still rejected by the `AdvisoryEvidence` literal validators.
- No broker/order/watch/task side effects.

## Verification

- `uv run python -m pytest tests/services/test_trading_decision_synthesis.py tests/services/test_trading_decision_synthesis_safety.py -q`
- `uv run ruff check app/schemas/trading_decision_synthesis.py tests/services/test_trading_decision_synthesis.py tests/services/test_trading_decision_synthesis_safety.py`
