### PR TITLE
ROB-19 Normalize simulated vs KIS mock account routing

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -169,6 +169,14 @@ class Settings(BaseSettings):
     kis_access_token: str | None = None  # 최초엔 비워두고 자동 발급
     kis_account_no: str | None = None  # 계좌번호 (예: "12345678-01")
 
+    # KIS official mock/sandbox account. Disabled by default and must be
+    # explicitly configured by the runtime environment.
+    kis_mock_enabled: bool = False
+    kis_mock_app_key: str | None = None
+    kis_mock_app_secret: str | None = None
+    kis_mock_account_no: str | None = None
+    kis_mock_access_token: str | None = None
+
     # KIS WebSocket
     kis_ws_is_mock: bool = False  # Mock 모드 (테스트용)
     kis_ws_hts_id: str = ""  # HTS ID (WebSocket 인증용)
@@ -448,3 +456,22 @@ class Settings(BaseSettings):
 
 
 settings = _load_settings()  # import 하면 전역 singleton
+
+
+def _has_nonempty_value(value: Any) -> bool:
+    return bool(str(value or "").strip())
+
+
+def validate_kis_mock_config(settings_obj: Any = settings) -> list[str]:
+    """Return missing KIS mock env names without exposing configured values."""
+
+    missing: list[str] = []
+    if not bool(getattr(settings_obj, "kis_mock_enabled", False)):
+        missing.append("KIS_MOCK_ENABLED")
+    if not _has_nonempty_value(getattr(settings_obj, "kis_mock_app_key", None)):
+        missing.append("KIS_MOCK_APP_KEY")
+    if not _has_nonempty_value(getattr(settings_obj, "kis_mock_app_secret", None)):
+        missing.append("KIS_MOCK_APP_SECRET")
+    if not _has_nonempty_value(getattr(settings_obj, "kis_mock_account_no", None)):
+        missing.append("KIS_MOCK_ACCOUNT_NO")
+    return missing

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -166,6 +166,7 @@ class Settings(BaseSettings):
     # KIS
     kis_app_key: str
     kis_app_secret: str
+    kis_base_url: str = "https://openapi.koreainvestment.com:9443"
     kis_access_token: str | None = None  # 최초엔 비워두고 자동 발급
     kis_account_no: str | None = None  # 계좌번호 (예: "12345678-01")
 
@@ -174,6 +175,7 @@ class Settings(BaseSettings):
     kis_mock_enabled: bool = False
     kis_mock_app_key: str | None = None
     kis_mock_app_secret: str | None = None
+    kis_mock_base_url: str = "https://openapivts.koreainvestment.com:29443"
     kis_mock_account_no: str | None = None
     kis_mock_access_token: str | None = None
 

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -45,9 +45,9 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - US equity quote price resolution uses Yahoo directly via `app.services.brokers.yahoo.client`
   - US quote response keeps `source: "yahoo"` and includes `previous_close/open/high/low/volume` from Yahoo `fast_info`
   - US equity Yahoo lookup failures are propagated as tool-level errors (exceptions), not returned as in-band error payload dicts
-- `get_holdings(account=None, market=None, include_current_price=True, minimum_value=None)`
+- `get_holdings(account=None, market=None, include_current_price=True, minimum_value=None, account_mode=None)`
   - Crypto positions may include optional `strategy_signal` field when Phase 2 exit logic triggers (4.5% stop-loss or RSI > 46 mean-reversion on profitable positions)
-- `get_position(symbol, market=None)`
+- `get_position(symbol, market=None, account_mode=None)`
 - `get_ohlcv(symbol, count=100, period="day", end_date=None, market=None, include_indicators=False)`
   - period: `day`, `week`, `month`, `1m`, `5m`, `15m`, `30m`, `4h`, `1h`
   - `include_indicators=True` adds `indicators_included` at the payload top level and appends `rsi_14`, `ema_20`, `bb_upper`, `bb_mid`, `bb_lower`, `vwap` to each row
@@ -84,7 +84,7 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - US ticker (`AAPL`, `SMCI`) 와 crypto symbol (`KRW-BTC`) 은 지원하지 않음
   - `days` 는 1~60 범위로 cap 됨
 - `get_volume_profile(symbol, market=None, period=60, bins=20)`
-- `get_order_history(symbol=None, status="all", order_id=None, limit=50)`
+- `get_order_history(symbol=None, status="all", order_id=None, limit=50, account_mode=None)`
   - `status="pending"` 만 symbol 없이 호출 가능
   - `status in {"all", "filled", "cancelled"}` 는 symbol 필요
   - filled/cancelled 조회는 시장별 historical endpoint 제약 때문에 symbol fan-out을 자동 수행하지 않음
@@ -94,7 +94,7 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - `format_execution_comment(stage, symbol, side, filled_qty, filled_price, ...)` - Format Discord/Paperclip-ready Markdown for `fill` and `follow_up` execution stages.
 - `get_latest_market_brief(symbols=None, market=None, limit=10)` - Return concise latest AI analysis context for recent or selected symbols.
 - `get_market_reports(symbol, days=7, limit=10)` - Return detailed AI analysis report history and decision trend for one symbol.
-- `place_order(symbol, side, order_type="limit", quantity=None, price=None, amount=None, dry_run=True, reason="", exit_reason=None, thesis=None, strategy=None, target_price=None, stop_loss=None, min_hold_days=None, notes=None, indicators_snapshot=None, defensive_trim=False, approval_issue_id=None)`
+- `place_order(symbol, side, order_type="limit", quantity=None, price=None, amount=None, dry_run=True, reason="", exit_reason=None, thesis=None, strategy=None, target_price=None, stop_loss=None, min_hold_days=None, notes=None, indicators_snapshot=None, defensive_trim=False, approval_issue_id=None, account_mode=None)`
   - `side="buy"` 이고 `dry_run=False` 인 경우 `thesis` 와 `strategy` 가 필수
   - 실매수 성공 시 trade journal draft를 자동 생성하고 fill 저장 후 active로 연결 시도
   - 실매도 성공 시 동일 symbol의 active journal을 FIFO 기준으로 auto-close 시도
@@ -114,6 +114,25 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - `analyze_stock_batch(symbols, market=None, include_peers=False, quick=True)`
   - Analyze multiple symbols in parallel and return compact per-symbol summaries
   - Default `quick=True` returns compact summary with: symbol, current_price, rsi_14, consensus, recommendation, supports (top 3), resistances (top 3)
+
+### Account Routing
+
+MCP account-facing tools use `account_mode` to avoid mixing DB simulation,
+official KIS mock, and KIS live account paths:
+
+- `account_mode="db_simulated"`: DB-backed paper trading only. No KIS broker
+  calls. Existing `account_type="paper"`, `account_mode="paper"`, and
+  `account_mode="simulated"` remain aliases and return warnings.
+- `account_mode="kis_mock"`: official KIS mock/sandbox account. Uses KIS mock
+  credentials only, passes `is_mock=True` to KIS broker methods, and fails
+  closed if `KIS_MOCK_ENABLED=true`, `KIS_MOCK_APP_KEY`,
+  `KIS_MOCK_APP_SECRET`, or `KIS_MOCK_ACCOUNT_NO` are missing.
+- `account_mode="kis_live"` or omitted: existing live KIS behavior. For
+  `place_order`, `dry_run=True` remains the default.
+
+Do not use `account_type="paper"` for official KIS mock. It is always DB
+simulation. Responses from updated surfaces include `account_mode`; deprecated
+aliases include `warnings`.
   - Set `quick=False` for full analysis payload (like `analyze_portfolio`)
   - Example: `analyze_stock_batch(symbols=["NVDA", "AMZN", "MSFT", "GOOGL"], market="us")`
 

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -126,7 +126,9 @@ official KIS mock, and KIS live account paths:
 - `account_mode="kis_mock"`: official KIS mock/sandbox account. Uses KIS mock
   credentials only, passes `is_mock=True` to KIS broker methods, and fails
   closed if `KIS_MOCK_ENABLED=true`, `KIS_MOCK_APP_KEY`,
-  `KIS_MOCK_APP_SECRET`, or `KIS_MOCK_ACCOUNT_NO` are missing.
+  `KIS_MOCK_APP_SECRET`, or `KIS_MOCK_ACCOUNT_NO` are missing. HTTP requests
+  use `KIS_MOCK_BASE_URL`, which defaults to the official KIS mock host
+  `https://openapivts.koreainvestment.com:29443`.
 - `account_mode="kis_live"` or omitted: existing live KIS behavior. For
   `place_order`, `dry_run=True` remains the default.
 

--- a/app/mcp_server/tooling/account_modes.py
+++ b/app/mcp_server/tooling/account_modes.py
@@ -1,0 +1,157 @@
+"""Account-mode normalization for MCP brokerage surfaces."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+ACCOUNT_MODE_DB_SIMULATED = "db_simulated"
+ACCOUNT_MODE_KIS_MOCK = "kis_mock"
+ACCOUNT_MODE_KIS_LIVE = "kis_live"
+
+_ACCOUNT_MODE_ALIASES = {
+    "db_simulated": (ACCOUNT_MODE_DB_SIMULATED, False),
+    "paper": (ACCOUNT_MODE_DB_SIMULATED, True),
+    "simulated": (ACCOUNT_MODE_DB_SIMULATED, True),
+    "kis_mock": (ACCOUNT_MODE_KIS_MOCK, False),
+    "mock": (ACCOUNT_MODE_KIS_MOCK, True),
+    "kis_live": (ACCOUNT_MODE_KIS_LIVE, False),
+    "real": (ACCOUNT_MODE_KIS_LIVE, False),
+    "live": (ACCOUNT_MODE_KIS_LIVE, True),
+}
+
+_ACCOUNT_TYPE_ALIASES = {
+    "paper": (ACCOUNT_MODE_DB_SIMULATED, True),
+    "real": (ACCOUNT_MODE_KIS_LIVE, False),
+    "live": (ACCOUNT_MODE_KIS_LIVE, True),
+    "kis_live": (ACCOUNT_MODE_KIS_LIVE, False),
+    "kis_mock": (ACCOUNT_MODE_KIS_MOCK, False),
+}
+
+
+@dataclass(frozen=True)
+class AccountRouting:
+    account_mode: str
+    deprecated_alias_used: bool = False
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def is_db_simulated(self) -> bool:
+        return self.account_mode == ACCOUNT_MODE_DB_SIMULATED
+
+    @property
+    def is_kis_mock(self) -> bool:
+        return self.account_mode == ACCOUNT_MODE_KIS_MOCK
+
+    @property
+    def is_kis_live(self) -> bool:
+        return self.account_mode == ACCOUNT_MODE_KIS_LIVE
+
+    def response_metadata(self) -> dict[str, Any]:
+        metadata: dict[str, Any] = {"account_mode": self.account_mode}
+        if self.warnings:
+            metadata["warnings"] = self.warnings
+        return metadata
+
+
+def _clean_selector(value: str | None) -> str | None:
+    normalized = str(value or "").strip().lower()
+    return normalized or None
+
+
+def _resolve_selector(
+    *,
+    selector_name: str,
+    selector_value: str | None,
+    aliases: dict[str, tuple[str, bool]],
+) -> tuple[str, bool, list[str]] | None:
+    normalized = _clean_selector(selector_value)
+    if normalized is None:
+        return None
+    if normalized not in aliases:
+        allowed = ", ".join(sorted(aliases))
+        raise ValueError(f"{selector_name} must be one of: {allowed}")
+
+    account_mode, deprecated = aliases[normalized]
+    warnings: list[str] = []
+    if deprecated:
+        warnings.append(
+            f"{selector_name}='{normalized}' is deprecated; use "
+            f"account_mode='{account_mode}' instead."
+        )
+    if selector_name == "account_type":
+        warnings.append(
+            "account_type is deprecated for MCP account routing; use "
+            "account_mode instead."
+        )
+    return account_mode, deprecated or selector_name == "account_type", warnings
+
+
+def normalize_account_mode(
+    account_mode: str | None = None,
+    account_type: str | None = None,
+) -> AccountRouting:
+    """Normalize MCP account selectors into one explicit routing mode."""
+
+    mode_result = _resolve_selector(
+        selector_name="account_mode",
+        selector_value=account_mode,
+        aliases=_ACCOUNT_MODE_ALIASES,
+    )
+    type_result = _resolve_selector(
+        selector_name="account_type",
+        selector_value=account_type,
+        aliases=_ACCOUNT_TYPE_ALIASES,
+    )
+
+    if mode_result is None and type_result is None:
+        return AccountRouting(account_mode=ACCOUNT_MODE_KIS_LIVE)
+
+    if mode_result is not None and type_result is not None:
+        mode_value, _, _ = mode_result
+        type_value, _, _ = type_result
+        if mode_value != type_value:
+            raise ValueError(
+                "conflicting account selectors: "
+                f"account_mode resolves to '{mode_value}' but account_type "
+                f"resolves to '{type_value}'"
+            )
+
+    selected = mode_result if mode_result is not None else type_result
+    assert selected is not None
+    selected_mode, deprecated, warnings = selected
+
+    if mode_result is not None and type_result is not None:
+        warnings = [*mode_result[2], *type_result[2]]
+        deprecated = mode_result[1] or type_result[1]
+
+    return AccountRouting(
+        account_mode=selected_mode,
+        deprecated_alias_used=deprecated,
+        warnings=warnings,
+    )
+
+
+def apply_account_routing_metadata(
+    response: dict[str, Any],
+    routing: AccountRouting,
+) -> dict[str, Any]:
+    merged = dict(response)
+    merged["account_mode"] = routing.account_mode
+    if routing.warnings:
+        existing_warnings = merged.get("warnings")
+        if isinstance(existing_warnings, list):
+            merged["warnings"] = [*existing_warnings, *routing.warnings]
+        else:
+            merged["warnings"] = routing.warnings
+    return merged
+
+
+__all__ = [
+    "ACCOUNT_MODE_DB_SIMULATED",
+    "ACCOUNT_MODE_KIS_LIVE",
+    "ACCOUNT_MODE_KIS_MOCK",
+    "AccountRouting",
+    "apply_account_routing_metadata",
+    "normalize_account_mode",
+]

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -55,10 +55,7 @@ _order_cooldown_service: CryptoTradeCooldownService | None = None
 
 def _create_kis_client(*, is_mock: bool) -> KISClient:
     if is_mock:
-        try:
-            return KISClient(is_mock=True)
-        except TypeError:
-            return KISClient()
+        return KISClient(is_mock=True)
     return KISClient()
 
 

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -53,6 +53,22 @@ CRYPTO_STOP_LOSS_PCT = 0.045
 _order_cooldown_service: CryptoTradeCooldownService | None = None
 
 
+def _create_kis_client(*, is_mock: bool) -> KISClient:
+    if is_mock:
+        try:
+            return KISClient(is_mock=True)
+        except TypeError:
+            return KISClient()
+    return KISClient()
+
+
+async def _call_kis(method: Any, *args: Any, is_mock: bool, **kwargs: Any) -> Any:
+    kwargs.pop("is_mock", None)
+    if is_mock:
+        return await method(*args, **kwargs, is_mock=True)
+    return await method(*args, **kwargs)
+
+
 def _get_crypto_trade_cooldown_service() -> CryptoTradeCooldownService:
     """Get or create the crypto trade cooldown service."""
     global _order_cooldown_service
@@ -91,12 +107,15 @@ async def _execute_order(
     quantity: float | None,
     price: float | None,
     market_type: str,
+    is_mock: bool = False,
 ) -> dict[str, Any]:
     if market_type == "crypto":
         return await _execute_crypto_order(symbol, side, order_type, quantity, price)
     if market_type == "equity_kr":
-        return await _execute_kr_order(symbol, side, order_type, quantity, price)
-    return await _execute_us_order(symbol, side, quantity, price)
+        return await _execute_kr_order(
+            symbol, side, order_type, quantity, price, is_mock=is_mock
+        )
+    return await _execute_us_order(symbol, side, quantity, price, is_mock=is_mock)
 
 
 async def _execute_crypto_order(
@@ -135,8 +154,9 @@ async def _execute_kr_order(
     order_type: str,
     quantity: float | None,
     price: float | None,
+    is_mock: bool = False,
 ) -> dict[str, Any]:
-    kis = KISClient()
+    kis = _create_kis_client(is_mock=is_mock)
     stock_code = symbol
     order_quantity = int(quantity) if quantity else 0
     order_price = int(price) if price else 0
@@ -165,18 +185,22 @@ async def _execute_kr_order(
             )
 
     if side == "buy":
-        result = await kis.order_korea_stock(
+        result = await _call_kis(
+            kis.order_korea_stock,
             stock_code=stock_code,
             order_type="buy",
             quantity=order_quantity,
             price=order_price,
+            is_mock=is_mock,
         )
     else:
-        result = await kis.order_korea_stock(
+        result = await _call_kis(
+            kis.order_korea_stock,
             stock_code=stock_code,
             order_type="sell",
             quantity=order_quantity,
             price=order_price,
+            is_mock=is_mock,
         )
 
     if original_price is not None and order_price != original_price:
@@ -191,22 +215,27 @@ async def _execute_us_order(
     side: str,
     quantity: float | None,
     price: float | None,
+    is_mock: bool = False,
 ) -> dict[str, Any]:
-    kis = KISClient()
+    kis = _create_kis_client(is_mock=is_mock)
     exchange_code = await get_us_exchange_by_symbol(symbol)
 
     if side == "buy":
-        return await kis.buy_overseas_stock(
+        return await _call_kis(
+            kis.buy_overseas_stock,
             symbol=symbol,
             exchange_code=exchange_code,
             quantity=int(quantity) if quantity else 0,
             price=price if price else 0.0,
+            is_mock=is_mock,
         )
-    return await kis.sell_overseas_stock(
+    return await _call_kis(
+        kis.sell_overseas_stock,
         symbol=symbol,
         exchange_code=exchange_code,
         quantity=int(quantity) if quantity else 0,
         price=price if price else 0.0,
+        is_mock=is_mock,
     )
 
 
@@ -608,6 +637,7 @@ async def _execute_and_record(
     indicators_snapshot: dict[str, Any] | None,
     defensive_trim_ctx: DefensiveTrimContext | None,
     order_error_fn: Any,
+    is_mock: bool = False,
 ) -> dict[str, Any]:
     """Execute a live order, record history, fills, and journals."""
     if not await _check_daily_order_limit(_MAX_ORDERS_PER_DAY):
@@ -621,6 +651,7 @@ async def _execute_and_record(
             quantity=order_quantity,
             price=price,
             market_type=market_type,
+            is_mock=is_mock,
         )
     except Exception as exec_exc:
         logger.error(
@@ -721,6 +752,7 @@ async def _place_order_impl(
     indicators_snapshot: dict[str, Any] | None = None,
     defensive_trim: bool = False,
     approval_issue_id: str | None = None,
+    is_mock: bool = False,
 ) -> dict[str, Any]:
     symbol, side_lower, order_type_lower = _validate_inputs(
         symbol,
@@ -808,6 +840,7 @@ async def _place_order_impl(
                 current_price=current_price,
                 order_error_fn=_order_error,
                 defensive_trim_ctx=defensive_trim_ctx,
+                is_mock=is_mock,
             )
             if sell_error is not None:
                 return sell_error
@@ -839,6 +872,7 @@ async def _place_order_impl(
                 order_amount=order_amount,
                 dry_run=dry_run,
                 order_error_fn=_order_error,
+                is_mock=is_mock,
             )
             if balance_error is not None:
                 return balance_error
@@ -870,6 +904,7 @@ async def _place_order_impl(
             indicators_snapshot=indicators_snapshot,
             defensive_trim_ctx=defensive_trim_ctx,
             order_error_fn=_order_error,
+            is_mock=is_mock,
         )
     except Exception as exc:
         await _record_order_history(

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -46,6 +46,7 @@ async def _call_kis(method: Any, *args: Any, is_mock: bool, **kwargs: Any) -> An
         return await method(*args, **kwargs, is_mock=True)
     return await method(*args, **kwargs)
 
+
 _DEFENSIVE_TRIM_APPROVAL_REGEX = re.compile(r"^[A-Z]+-\d+$")
 _DEFENSIVE_TRIM_CACHE_TTL_SECONDS = 60.0
 _defensive_trim_success_cache: dict[str, float] = {}

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -37,10 +37,7 @@ from app.services.brokers.upbit.client import (
 
 def _create_kis_client(*, is_mock: bool) -> KISClient:
     if is_mock:
-        try:
-            return KISClient(is_mock=True)
-        except TypeError:
-            return KISClient()
+        return KISClient(is_mock=True)
     return KISClient()
 
 

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -34,6 +34,21 @@ from app.services.brokers.upbit.client import (
     parse_upbit_account_row as _parse_upbit_account_row,
 )
 
+
+def _create_kis_client(*, is_mock: bool) -> KISClient:
+    if is_mock:
+        try:
+            return KISClient(is_mock=True)
+        except TypeError:
+            return KISClient()
+    return KISClient()
+
+
+async def _call_kis(method: Any, *args: Any, is_mock: bool, **kwargs: Any) -> Any:
+    if is_mock:
+        return await method(*args, **kwargs, is_mock=True)
+    return await method(*args, **kwargs)
+
 _DEFENSIVE_TRIM_APPROVAL_REGEX = re.compile(r"^[A-Z]+-\d+$")
 _DEFENSIVE_TRIM_CACHE_TTL_SECONDS = 60.0
 _defensive_trim_success_cache: dict[str, float] = {}
@@ -197,7 +212,7 @@ async def _get_current_price_for_order(symbol: str, market_type: str) -> float |
 
 
 async def _get_holdings_for_order(
-    symbol: str, market_type: str
+    symbol: str, market_type: str, is_mock: bool = False
 ) -> dict[str, Any] | None:
     if market_type == "crypto":
         coins = await upbit_service.fetch_my_coins()
@@ -213,9 +228,9 @@ async def _get_holdings_for_order(
                 }
         return None
 
-    kis = KISClient()
+    kis = _create_kis_client(is_mock=is_mock)
     if market_type == "equity_kr":
-        stocks = await kis.fetch_my_stocks()
+        stocks = await _call_kis(kis.fetch_my_stocks, is_mock=is_mock)
         for stock in stocks:
             stock_code = str(stock.get("pdno", "")).strip().upper()
             if stock_code != symbol.upper():
@@ -226,7 +241,7 @@ async def _get_holdings_for_order(
             }
         return None
 
-    us_stocks = await kis.fetch_my_us_stocks()
+    us_stocks = await _call_kis(kis.fetch_my_us_stocks, is_mock=is_mock)
     for stock in us_stocks:
         stock_code = str(stock.get("ovrs_pdno", "")).strip().upper()
         if stock_code != symbol.upper():
@@ -238,7 +253,7 @@ async def _get_holdings_for_order(
     return None
 
 
-async def _get_balance_for_order(market_type: str) -> float:
+async def _get_balance_for_order(market_type: str, is_mock: bool = False) -> float:
     if market_type == "crypto":
         coins = await upbit_service.fetch_my_coins()
         for coin in coins:
@@ -247,15 +262,18 @@ async def _get_balance_for_order(market_type: str) -> float:
         return 0.0
 
     if market_type == "equity_kr":
-        kis = KISClient()
-        margin_data = await kis.inquire_integrated_margin()
+        kis = _create_kis_client(is_mock=is_mock)
+        margin_data = await _call_kis(
+            kis.inquire_integrated_margin,
+            is_mock=is_mock,
+        )
         domestic_cash = extract_domestic_cash_summary_from_integrated_margin(
             margin_data
         )
         return float(domestic_cash.get("orderable") or 0)
 
-    kis = KISClient()
-    margin_data = await kis.inquire_overseas_margin()
+    kis = _create_kis_client(is_mock=is_mock)
+    margin_data = await _call_kis(kis.inquire_overseas_margin, is_mock=is_mock)
     usd_row = _select_usd_row_for_us_order(margin_data)
     if usd_row is None:
         raise RuntimeError("USD margin data not found in KIS overseas margin")
@@ -572,12 +590,17 @@ async def _validate_sell_side(
     current_price: float,
     order_error_fn: Any,
     defensive_trim_ctx: DefensiveTrimContext | None = None,
+    is_mock: bool = False,
 ) -> tuple[float, float, dict[str, Any] | None]:
     """Validate sell-side: check holdings, locked, price constraints.
 
     Returns (order_quantity, avg_price, error_dict_or_None).
     """
-    holdings = await _get_holdings_for_order(normalized_symbol, market_type)
+    holdings = await _get_holdings_for_order(
+        normalized_symbol,
+        market_type,
+        is_mock=is_mock,
+    )
     if not holdings:
         return 0.0, 0.0, order_error_fn(f"No holdings found for {symbol}")
 
@@ -639,6 +662,7 @@ async def _check_balance_and_warn(
     order_amount: float,
     dry_run: bool,
     order_error_fn: Any,
+    is_mock: bool = False,
 ) -> tuple[str | None, dict[str, Any] | None]:
     """Pre-check cash balance for buy orders.
 
@@ -646,7 +670,7 @@ async def _check_balance_and_warn(
     If error_dict is not None, the caller should return it immediately.
     """
     try:
-        balance = await _get_balance_for_order(market_type)
+        balance = await _get_balance_for_order(market_type, is_mock=is_mock)
     except Exception as balance_exc:
         logger.error(
             "balance_precheck 조회 실패: stage=balance_query, market_type=%s, symbol=%s, side=%s, error=%s",

--- a/app/mcp_server/tooling/orders_history.py
+++ b/app/mcp_server/tooling/orders_history.py
@@ -29,6 +29,21 @@ from app.services.brokers.kis.client import KISClient
 from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
 
 
+def _create_kis_client(*, is_mock: bool) -> KISClient:
+    if is_mock:
+        try:
+            return KISClient(is_mock=True)
+        except TypeError:
+            return KISClient()
+    return KISClient()
+
+
+async def _call_kis(method: Any, *args: Any, is_mock: bool, **kwargs: Any) -> Any:
+    if is_mock:
+        return await method(*args, **kwargs, is_mock=True)
+    return await method(*args, **kwargs)
+
+
 def _calculate_order_summary(orders: list[dict[str, Any]]) -> dict[str, Any]:
     total_orders = len(orders)
     filled = sum(1 for o in orders if o.get("status") == "filled")
@@ -152,14 +167,15 @@ async def _fetch_kr_orders(
     normalized_symbol: str | None,
     status: str,
     effective_days: int | None,
+    is_mock: bool = False,
 ) -> list[dict[str, Any]]:
     """Fetch and normalize KIS domestic (Korean equity) orders."""
     fetched: list[dict[str, Any]] = []
-    kis = KISClient()
+    kis = _create_kis_client(is_mock=is_mock)
 
     if status in ("all", "pending"):
         logger.debug("Fetching KR pending orders, symbol=%s", normalized_symbol)
-        open_ops = await kis.inquire_korea_orders()
+        open_ops = await _call_kis(kis.inquire_korea_orders, is_mock=is_mock)
         if open_ops:
             logger.debug("Raw API response keys: %s", list(open_ops[0].keys()))
         for o in open_ops:
@@ -171,11 +187,13 @@ async def _fetch_kr_orders(
     if status in ("all", "filled", "cancelled") and normalized_symbol:
         lookup_days = effective_days if effective_days is not None else 30
         start_dt, end_dt = _calculate_date_range(lookup_days)
-        hist_ops = await kis.inquire_daily_order_domestic(
+        hist_ops = await _call_kis(
+            kis.inquire_daily_order_domestic,
             start_date=start_dt,
             end_date=end_dt,
             stock_code=normalized_symbol,
             side="00",
+            is_mock=is_mock,
         )
         fetched.extend([_normalize_kis_domestic_order(o) for o in hist_ops])
 
@@ -186,10 +204,11 @@ async def _fetch_us_orders(
     normalized_symbol: str | None,
     status: str,
     effective_days: int | None,
+    is_mock: bool = False,
 ) -> list[dict[str, Any]]:
     """Fetch and normalize KIS overseas (US equity) orders."""
     fetched: list[dict[str, Any]] = []
-    kis = KISClient()
+    kis = _create_kis_client(is_mock=is_mock)
 
     if status in ("all", "pending"):
         target_exchanges = ["NASD", "NYSE", "AMEX"]
@@ -199,7 +218,11 @@ async def _fetch_us_orders(
         seen_oids: set[str] = set()
         for ex in target_exchanges:
             try:
-                ops = await kis.inquire_overseas_orders(ex)
+                ops = await _call_kis(
+                    kis.inquire_overseas_orders,
+                    ex,
+                    is_mock=is_mock,
+                )
                 for o in ops:
                     oid = _extract_kis_order_number(o)
                     if oid in seen_oids:
@@ -217,12 +240,14 @@ async def _fetch_us_orders(
         lookup_days = effective_days if effective_days is not None else 30
         start_dt, end_dt = _calculate_date_range(lookup_days)
         ex = await get_us_exchange_by_symbol(normalized_symbol)
-        hist_ops = await kis.inquire_daily_order_overseas(
+        hist_ops = await _call_kis(
+            kis.inquire_daily_order_overseas,
             start_date=start_dt,
             end_date=end_dt,
             symbol=normalized_symbol,
             exchange_code=ex,
             side="00",
+            is_mock=is_mock,
         )
         fetched.extend([_normalize_kis_overseas_order(o) for o in hist_ops])
 
@@ -371,6 +396,7 @@ async def get_order_history_impl(
     side: str | None = None,
     days: int | None = None,
     limit: int | None = 50,
+    is_mock: bool = False,
 ) -> dict[str, Any]:
     (
         symbol,
@@ -388,10 +414,10 @@ async def get_order_history_impl(
             normalized_symbol, status, limit_val, limit or 50
         ),
         "equity_kr": lambda: _fetch_kr_orders(
-            normalized_symbol, status, effective_days
+            normalized_symbol, status, effective_days, is_mock=is_mock
         ),
         "equity_us": lambda: _fetch_us_orders(
-            normalized_symbol, status, effective_days
+            normalized_symbol, status, effective_days, is_mock=is_mock
         ),
     }
 

--- a/app/mcp_server/tooling/orders_history.py
+++ b/app/mcp_server/tooling/orders_history.py
@@ -31,10 +31,7 @@ from app.services.us_symbol_universe_service import get_us_exchange_by_symbol
 
 def _create_kis_client(*, is_mock: bool) -> KISClient:
     if is_mock:
-        try:
-            return KISClient(is_mock=True)
-        except TypeError:
-            return KISClient()
+        return KISClient(is_mock=True)
     return KISClient()
 
 

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal
 
+from app.core.config import validate_kis_mock_config
 from app.mcp_server.tooling import order_execution, orders_history
+from app.mcp_server.tooling.account_modes import (
+    apply_account_routing_metadata,
+    normalize_account_mode,
+)
 from app.mcp_server.tooling.orders_modify_cancel import (
     cancel_order_impl,
     modify_order_impl,
@@ -23,6 +28,21 @@ ORDER_TOOL_NAMES: set[str] = {
     "cancel_order",
     "get_order_history",
 }
+
+
+def _kis_mock_config_error() -> dict[str, Any] | None:
+    missing = validate_kis_mock_config()
+    if not missing:
+        return None
+    return {
+        "success": False,
+        "error": (
+            "KIS mock account is disabled or missing required configuration: "
+            + ", ".join(missing)
+        ),
+        "source": "kis",
+        "account_mode": "kis_mock",
+    }
 
 
 def register_order_tools(mcp: FastMCP) -> None:
@@ -45,11 +65,16 @@ def register_order_tools(mcp: FastMCP) -> None:
         side: str | None = None,
         days: int | None = None,
         limit: int | None = 50,
-        account_type: Literal["real", "paper"] = "real",
+        account_mode: str | None = None,
+        account_type: str | None = None,
         paper_account: str | None = None,
     ):
-        if account_type == "paper":
-            return await _get_paper_order_history(
+        routing = normalize_account_mode(
+            account_mode=account_mode,
+            account_type=account_type,
+        )
+        if routing.is_db_simulated:
+            return apply_account_routing_metadata(await _get_paper_order_history(
                 symbol=symbol,
                 status=status,
                 order_id=order_id,
@@ -58,8 +83,12 @@ def register_order_tools(mcp: FastMCP) -> None:
                 days=days,
                 limit=limit,
                 paper_account_name=paper_account,
-            )
-        return await orders_history.get_order_history_impl(
+            ), routing)
+        if routing.is_kis_mock:
+            config_error = _kis_mock_config_error()
+            if config_error:
+                return config_error
+        return apply_account_routing_metadata(await orders_history.get_order_history_impl(
             symbol=symbol,
             status=status,
             order_id=order_id,
@@ -67,7 +96,8 @@ def register_order_tools(mcp: FastMCP) -> None:
             side=side,
             days=days,
             limit=limit,
-        )
+            is_mock=routing.is_kis_mock,
+        ), routing)
 
     @mcp.tool(
         name="place_order",
@@ -114,9 +144,14 @@ def register_order_tools(mcp: FastMCP) -> None:
         indicators_snapshot: dict[str, Any] | None = None,
         defensive_trim: bool = False,
         approval_issue_id: str | None = None,
-        account_type: Literal["real", "paper"] = "real",
+        account_mode: str | None = None,
+        account_type: str | None = None,
         paper_account: str | None = None,
     ):
+        routing = normalize_account_mode(
+            account_mode=account_mode,
+            account_type=account_type,
+        )
         # Defense in depth: reject market orders even if a stale client
         # bypasses the tightened schema and still sends order_type="market".
         if str(order_type).lower().strip() != "limit":
@@ -141,8 +176,8 @@ def register_order_tools(mcp: FastMCP) -> None:
                 "symbol": symbol,
                 "order_type": order_type,
             }
-        if account_type == "paper":
-            return await _place_paper_order(
+        if routing.is_db_simulated:
+            return apply_account_routing_metadata(await _place_paper_order(
                 symbol=symbol,
                 side=side,
                 order_type=order_type,
@@ -160,8 +195,12 @@ def register_order_tools(mcp: FastMCP) -> None:
                 notes=notes,
                 indicators_snapshot=indicators_snapshot,
                 paper_account_name=paper_account,
-            )
-        return await order_execution._place_order_impl(
+            ), routing)
+        if routing.is_kis_mock:
+            config_error = _kis_mock_config_error()
+            if config_error:
+                return config_error
+        return apply_account_routing_metadata(await order_execution._place_order_impl(
             symbol=symbol,
             side=side,
             order_type=order_type,
@@ -180,7 +219,8 @@ def register_order_tools(mcp: FastMCP) -> None:
             indicators_snapshot=indicators_snapshot,
             defensive_trim=defensive_trim,
             approval_issue_id=approval_issue_id,
-        )
+            is_mock=routing.is_kis_mock,
+        ), routing)
 
     @mcp.tool(
         name="cancel_order",

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -54,7 +54,9 @@ def register_order_tools(mcp: FastMCP) -> None:
             "but filled/cancelled/all queries require symbol. "
             "Set account_type='paper' to query the virtual paper-trading "
             "account's trade history instead; pass paper_account to target a "
-            "named paper account (defaults to 'default')."
+            "named paper account (defaults to 'default'). "
+            "Use account_mode={'db_simulated','kis_mock','kis_live'} "
+            "(preferred); account_type aliases are deprecated and emit warnings."
         ),
     )
     async def get_order_history(
@@ -117,6 +119,8 @@ def register_order_tools(mcp: FastMCP) -> None:
             "(no real broker calls, uses PaperTradingService). In paper mode, the "
             "default account is auto-created with 100,000,000 KRW on first use; "
             "pass paper_account to target a named paper account. "
+            "Use account_mode={'db_simulated','kis_mock','kis_live'} "
+            "(preferred); account_type aliases are deprecated and emit warnings. "
             "Journal features (thesis/strategy/FIFO close) ARE supported in paper mode. "
             "defensive_trim=True enables a sell/limit-only floor bypass path. "
             "ROB-164/ROB-166 defensive_trim requires ALL of: (a) side='sell', "

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -76,7 +76,25 @@ def register_order_tools(mcp: FastMCP) -> None:
             account_type=account_type,
         )
         if routing.is_db_simulated:
-            return apply_account_routing_metadata(await _get_paper_order_history(
+            return apply_account_routing_metadata(
+                await _get_paper_order_history(
+                    symbol=symbol,
+                    status=status,
+                    order_id=order_id,
+                    market=market,
+                    side=side,
+                    days=days,
+                    limit=limit,
+                    paper_account_name=paper_account,
+                ),
+                routing,
+            )
+        if routing.is_kis_mock:
+            config_error = _kis_mock_config_error()
+            if config_error:
+                return config_error
+        return apply_account_routing_metadata(
+            await orders_history.get_order_history_impl(
                 symbol=symbol,
                 status=status,
                 order_id=order_id,
@@ -84,22 +102,10 @@ def register_order_tools(mcp: FastMCP) -> None:
                 side=side,
                 days=days,
                 limit=limit,
-                paper_account_name=paper_account,
-            ), routing)
-        if routing.is_kis_mock:
-            config_error = _kis_mock_config_error()
-            if config_error:
-                return config_error
-        return apply_account_routing_metadata(await orders_history.get_order_history_impl(
-            symbol=symbol,
-            status=status,
-            order_id=order_id,
-            market=market,
-            side=side,
-            days=days,
-            limit=limit,
-            is_mock=routing.is_kis_mock,
-        ), routing)
+                is_mock=routing.is_kis_mock,
+            ),
+            routing,
+        )
 
     @mcp.tool(
         name="place_order",
@@ -181,7 +187,34 @@ def register_order_tools(mcp: FastMCP) -> None:
                 "order_type": order_type,
             }
         if routing.is_db_simulated:
-            return apply_account_routing_metadata(await _place_paper_order(
+            return apply_account_routing_metadata(
+                await _place_paper_order(
+                    symbol=symbol,
+                    side=side,
+                    order_type=order_type,
+                    quantity=quantity,
+                    price=price,
+                    amount=amount,
+                    dry_run=dry_run,
+                    reason=reason,
+                    exit_reason=exit_reason,
+                    thesis=thesis,
+                    strategy=strategy,
+                    target_price=target_price,
+                    stop_loss=stop_loss,
+                    min_hold_days=min_hold_days,
+                    notes=notes,
+                    indicators_snapshot=indicators_snapshot,
+                    paper_account_name=paper_account,
+                ),
+                routing,
+            )
+        if routing.is_kis_mock:
+            config_error = _kis_mock_config_error()
+            if config_error:
+                return config_error
+        return apply_account_routing_metadata(
+            await order_execution._place_order_impl(
                 symbol=symbol,
                 side=side,
                 order_type=order_type,
@@ -198,33 +231,12 @@ def register_order_tools(mcp: FastMCP) -> None:
                 min_hold_days=min_hold_days,
                 notes=notes,
                 indicators_snapshot=indicators_snapshot,
-                paper_account_name=paper_account,
-            ), routing)
-        if routing.is_kis_mock:
-            config_error = _kis_mock_config_error()
-            if config_error:
-                return config_error
-        return apply_account_routing_metadata(await order_execution._place_order_impl(
-            symbol=symbol,
-            side=side,
-            order_type=order_type,
-            quantity=quantity,
-            price=price,
-            amount=amount,
-            dry_run=dry_run,
-            reason=reason,
-            exit_reason=exit_reason,
-            thesis=thesis,
-            strategy=strategy,
-            target_price=target_price,
-            stop_loss=stop_loss,
-            min_hold_days=min_hold_days,
-            notes=notes,
-            indicators_snapshot=indicators_snapshot,
-            defensive_trim=defensive_trim,
-            approval_issue_id=approval_issue_id,
-            is_mock=routing.is_kis_mock,
-        ), routing)
+                defensive_trim=defensive_trim,
+                approval_issue_id=approval_issue_id,
+                is_mock=routing.is_kis_mock,
+            ),
+            routing,
+        )
 
     @mcp.tool(
         name="cancel_order",

--- a/app/mcp_server/tooling/portfolio_cash.py
+++ b/app/mcp_server/tooling/portfolio_cash.py
@@ -22,9 +22,26 @@ from app.services.brokers.kis import (
 from app.services.exchange_rate_service import get_usd_krw_rate as _get_usd_krw_rate
 
 
-async def _get_kis_domestic_pending_buy_amount(kis: KISClient) -> float:
+def _create_kis_client(*, is_mock: bool) -> KISClient:
+    try:
+        return KISClient(is_mock=is_mock)
+    except TypeError:
+        return KISClient()
+
+
+async def _call_kis(method: Any, *args: Any, is_mock: bool, **kwargs: Any) -> Any:
+    if is_mock:
+        return await method(*args, **kwargs, is_mock=True)
+    return await method(*args, **kwargs)
+
+
+async def _get_kis_domestic_pending_buy_amount(
+    kis: KISClient,
+    *,
+    is_mock: bool = False,
+) -> float:
     total = 0.0
-    open_orders = await kis.inquire_korea_orders()
+    open_orders = await _call_kis(kis.inquire_korea_orders, is_mock=is_mock)
     for order in open_orders:
         if str(order.get("sll_buy_dvsn_cd", "")).strip() != "02":
             continue
@@ -37,11 +54,19 @@ async def _get_kis_domestic_pending_buy_amount(kis: KISClient) -> float:
     return total
 
 
-async def _get_kis_overseas_pending_buy_amount_usd(kis: KISClient) -> float:
+async def _get_kis_overseas_pending_buy_amount_usd(
+    kis: KISClient,
+    *,
+    is_mock: bool = False,
+) -> float:
     total = 0.0
     # KIS documents NASD as a US-wide open-order lookup. Querying NYSE/AMEX as
     # well can double-count the same locked cash when orders are mirrored there.
-    open_orders = await kis.inquire_overseas_orders("NASD")
+    open_orders = await _call_kis(
+        kis.inquire_overseas_orders,
+        "NASD",
+        is_mock=is_mock,
+    )
     for order in open_orders:
         if str(order.get("sll_buy_dvsn_cd", "")).strip() != "02":
             continue
@@ -92,7 +117,11 @@ def select_usd_row_for_us_order(
     return max(usd_rows, key=extract_usd_orderable_from_row)
 
 
-async def get_cash_balance_impl(account: str | None = None) -> dict[str, Any]:
+async def get_cash_balance_impl(
+    account: str | None = None,
+    *,
+    is_mock: bool = False,
+) -> dict[str, Any]:
     from app.mcp_server.tooling.paper_portfolio_handler import (
         collect_paper_cash_balances,
         is_paper_account_token,
@@ -147,11 +176,14 @@ async def get_cash_balance_impl(account: str | None = None) -> dict[str, Any]:
         "kis_domestic",
         "kis_overseas",
     ):
-        kis = KISClient()
+        kis = _create_kis_client(is_mock=is_mock)
 
         if account_filter is None or account_filter in ("kis", "kis_domestic"):
             try:
-                margin_data = await kis.inquire_integrated_margin()
+                margin_data = await _call_kis(
+                    kis.inquire_integrated_margin,
+                    is_mock=is_mock,
+                )
                 domestic_cash = extract_domestic_cash_summary_from_integrated_margin(
                     margin_data
                 )
@@ -160,7 +192,10 @@ async def get_cash_balance_impl(account: str | None = None) -> dict[str, Any]:
                 orderable = raw_orderable
 
                 try:
-                    pending_buy_amount = await _get_kis_domestic_pending_buy_amount(kis)
+                    pending_buy_amount = await _get_kis_domestic_pending_buy_amount(
+                        kis,
+                        is_mock=is_mock,
+                    )
                     orderable = max(0.0, raw_orderable - pending_buy_amount)
                 except Exception as exc:
                     logger.warning(
@@ -189,7 +224,10 @@ async def get_cash_balance_impl(account: str | None = None) -> dict[str, Any]:
 
         if account_filter is None or account_filter in ("kis", "kis_overseas"):
             try:
-                overseas_margin_data = await kis.inquire_overseas_margin()
+                overseas_margin_data = await _call_kis(
+                    kis.inquire_overseas_margin,
+                    is_mock=is_mock,
+                )
                 usd_margin = select_usd_row_for_us_order(overseas_margin_data)
                 if usd_margin is None:
                     raise RuntimeError(
@@ -205,7 +243,10 @@ async def get_cash_balance_impl(account: str | None = None) -> dict[str, Any]:
                 orderable = raw_orderable
 
                 try:
-                    pending_usd = await _get_kis_overseas_pending_buy_amount_usd(kis)
+                    pending_usd = await _get_kis_overseas_pending_buy_amount_usd(
+                        kis,
+                        is_mock=is_mock,
+                    )
                     orderable = max(0.0, raw_orderable - pending_usd)
                 except Exception as exc:
                     logger.warning(
@@ -269,6 +310,7 @@ def _is_stale_manual_cash(updated_at_iso: str | None) -> bool:
 async def get_available_capital_impl(
     account: str | None = None,
     include_manual: bool = True,
+    is_mock: bool = False,
 ) -> dict[str, Any]:
     """Query orderable capital across KIS, Upbit, and manual cash.
 
@@ -281,7 +323,7 @@ async def get_available_capital_impl(
     """
     errors: list[dict[str, Any]] = []
 
-    cash_result = await get_cash_balance_impl(account=account)
+    cash_result = await get_cash_balance_impl(account=account, is_mock=is_mock)
     accounts = cash_result.get("accounts", [])
     errors.extend(cash_result.get("errors", []))
 

--- a/app/mcp_server/tooling/portfolio_cash.py
+++ b/app/mcp_server/tooling/portfolio_cash.py
@@ -23,10 +23,9 @@ from app.services.exchange_rate_service import get_usd_krw_rate as _get_usd_krw_
 
 
 def _create_kis_client(*, is_mock: bool) -> KISClient:
-    try:
-        return KISClient(is_mock=is_mock)
-    except TypeError:
-        return KISClient()
+    if is_mock:
+        return KISClient(is_mock=True)
+    return KISClient()
 
 
 async def _call_kis(method: Any, *args: Any, is_mock: bool, **kwargs: Any) -> Any:

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -244,10 +244,7 @@ async def _collect_kis_positions(
 
     positions: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
-    try:
-        kis = KISClient(is_mock=is_mock)
-    except TypeError:
-        kis = KISClient()
+    kis = KISClient(is_mock=True) if is_mock else KISClient()
 
     if market_filter in (None, "equity_kr"):
         try:
@@ -1132,7 +1129,9 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
             "When minimum_value is None (default), per-currency thresholds are "
             "applied: KRW=5000, USD=10. Explicit number uses uniform threshold. "
             "Response includes filtered_count, filter_reason, and per-symbol "
-            "price lookup errors."
+            "price lookup errors. "
+            "Use account_mode={'db_simulated','kis_mock','kis_live'} "
+            "(preferred); account_type aliases are deprecated and emit warnings."
         ),
     )
     async def get_holdings(
@@ -1177,6 +1176,8 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
             "positions across all accounts. account_type='real' (default) scans "
             "live brokerage and manual holdings; account_type='paper' scans "
             "paper trading accounts, optionally scoped by paper_account. "
+            "Use account_mode={'db_simulated','kis_mock','kis_live'} "
+            "(preferred); account_type aliases are deprecated and emit warnings. "
             "Returns status='미보유' when no position exists."
         ),
     )
@@ -1242,7 +1243,9 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
             "Query available cash balances from all accounts. "
             "Supports Upbit (KRW), KIS domestic (KRW), KIS overseas (USD), "
             "and paper trading accounts (account='paper' or 'paper:<name>'). "
-            "Returns detailed balance information including orderable amounts."
+            "Returns detailed balance information including orderable amounts. "
+            "Use account_mode={'db_simulated','kis_mock','kis_live'} "
+            "(preferred); account_type aliases are deprecated and emit warnings."
         ),
     )
     async def get_cash_balance(
@@ -1280,7 +1283,9 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
             "Converts USD orderable cash to KRW and can optionally exclude "
             "manual cash. Manual cash is stored via set_user_setting/"
             "get_user_setting with key='manual_cash'; it is not added for "
-            "paper account queries."
+            "paper account queries. "
+            "Use account_mode={'db_simulated','kis_mock','kis_live'} "
+            "(preferred); account_type aliases are deprecated and emit warnings."
         ),
     )
     async def get_available_capital(

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -8,8 +8,13 @@ from typing import TYPE_CHECKING, Any, cast
 import pandas as pd
 
 import app.services.brokers.upbit.client as upbit_service
+from app.core.config import validate_kis_mock_config
 from app.core.db import AsyncSessionLocal
 from app.mcp_server.env_utils import _env_int
+from app.mcp_server.tooling.account_modes import (
+    apply_account_routing_metadata,
+    normalize_account_mode,
+)
 from app.mcp_server.tooling.market_data_indicators import (
     _compute_crypto_realtime_rsi_from_frame,
     _compute_indicators,
@@ -231,17 +236,25 @@ async def _compute_crypto_signals_for_position(
 
 async def _collect_kis_positions(
     market_filter: str | None,
+    *,
+    is_mock: bool = False,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     if market_filter == "crypto":
         return [], []
 
     positions: list[dict[str, Any]] = []
     errors: list[dict[str, Any]] = []
-    kis = KISClient()
+    try:
+        kis = KISClient(is_mock=is_mock)
+    except TypeError:
+        kis = KISClient()
 
     if market_filter in (None, "equity_kr"):
         try:
-            kr_stocks = await kis.fetch_my_stocks()
+            if is_mock:
+                kr_stocks = await kis.fetch_my_stocks(is_mock=True)
+            else:
+                kr_stocks = await kis.fetch_my_stocks()
             for stock in kr_stocks:
                 quantity = _to_float(stock.get("hldg_qty"))
                 if quantity <= 0:
@@ -274,7 +287,10 @@ async def _collect_kis_positions(
 
     if market_filter in (None, "equity_us"):
         try:
-            us_stocks = await kis.fetch_my_us_stocks()
+            if is_mock:
+                us_stocks = await kis.fetch_my_us_stocks(is_mock=True)
+            else:
+                us_stocks = await kis.fetch_my_us_stocks()
             for stock in us_stocks:
                 quantity = _to_float(stock.get("ovrs_cblc_qty"))
                 if quantity <= 0:
@@ -612,6 +628,7 @@ async def _collect_portfolio_positions(
     include_current_price: bool,
     account_name: str | None = None,
     user_id: int = _MCP_USER_ID,
+    is_mock: bool = False,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], str | None, str | None]:
     # Short-circuit to paper handler when the caller asked for a paper account.
     from app.mcp_server.tooling.paper_portfolio_handler import (
@@ -664,7 +681,10 @@ async def _collect_portfolio_positions(
 
     tasks: list[Any] = []
     if market_filter != "crypto":
-        tasks.append(_collect_kis_positions(market_filter))
+        if is_mock:
+            tasks.append(_collect_kis_positions(market_filter, is_mock=True))
+        else:
+            tasks.append(_collect_kis_positions(market_filter))
     if market_filter in (None, "crypto"):
         tasks.append(_collect_upbit_positions(market_filter))
     tasks.append(
@@ -813,6 +833,7 @@ async def _get_holdings_impl(
     include_current_price: bool = True,
     minimum_value: float | None = None,
     account_name: str | None = None,
+    is_mock: bool = False,
 ) -> dict[str, Any]:
     """Implementation for get_holdings tool."""
     if minimum_value is not None and minimum_value < 0:
@@ -828,6 +849,7 @@ async def _get_holdings_impl(
         market=market,
         include_current_price=include_current_price,
         account_name=account_name,
+        is_mock=is_mock,
     )
 
     filtered_count = 0
@@ -960,7 +982,8 @@ async def _get_position_impl(
     *,
     symbol: str,
     market: str | None = None,
-    account_type: str = "real",
+    account_mode: str | None = None,
+    account_type: str | None = None,
     paper_account: str | None = None,
 ) -> dict[str, Any]:
     """Implementation for get_position tool.
@@ -974,8 +997,10 @@ async def _get_position_impl(
     if not symbol:
         raise ValueError("symbol is required")
 
-    if account_type not in ("real", "paper"):
-        raise ValueError("account_type must be 'real' or 'paper'")
+    routing = normalize_account_mode(
+        account_mode=account_mode,
+        account_type=account_type,
+    )
 
     parsed_market = _parse_holdings_market_filter(market)
     if parsed_market == "equity_us":
@@ -987,7 +1012,7 @@ async def _get_position_impl(
     else:
         query_symbol = symbol.strip().upper()
 
-    if account_type == "paper":
+    if routing.is_db_simulated:
         token = "paper" if not paper_account else f"paper:{paper_account}"
         positions, errors, _, _ = await _collect_portfolio_positions(
             account=token,
@@ -995,10 +1020,19 @@ async def _get_position_impl(
             include_current_price=True,
         )
     else:
+        if routing.is_kis_mock:
+            missing = validate_kis_mock_config()
+            if missing:
+                raise RuntimeError(
+                    "KIS mock account is disabled or missing required "
+                    "configuration: "
+                    + ", ".join(missing)
+                )
         positions, errors, _, _ = await _collect_portfolio_positions(
             account=None,
             market=market,
             include_current_price=True,
+            is_mock=routing.is_kis_mock,
         )
 
     matched_positions = [
@@ -1012,7 +1046,7 @@ async def _get_position_impl(
     ]
 
     if not matched_positions:
-        return {
+        return apply_account_routing_metadata({
             "symbol": query_symbol,
             "market": _INSTRUMENT_TO_MARKET.get(parsed_market),
             "has_position": False,
@@ -1020,7 +1054,7 @@ async def _get_position_impl(
             "position_count": 0,
             "positions": [],
             "errors": errors,
-        }
+        }, routing)
 
     matched_positions.sort(
         key=lambda position: (
@@ -1030,7 +1064,7 @@ async def _get_position_impl(
         )
     )
 
-    return {
+    return apply_account_routing_metadata({
         "symbol": query_symbol,
         "market": _INSTRUMENT_TO_MARKET.get(parsed_market),
         "has_position": True,
@@ -1047,7 +1081,7 @@ async def _get_position_impl(
             for position in matched_positions
         ],
         "errors": errors,
-    }
+    }, routing)
 
 
 async def _update_manual_holdings_impl(
@@ -1107,13 +1141,33 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
         include_current_price: bool = True,
         minimum_value: float | None = None,
         account_name: str | None = None,
+        account_mode: str | None = None,
+        account_type: str | None = None,
     ) -> dict[str, Any]:
-        return await _get_holdings_impl(
-            account=account,
-            market=market,
-            include_current_price=include_current_price,
-            minimum_value=minimum_value,
-            account_name=account_name,
+        routing = normalize_account_mode(
+            account_mode=account_mode,
+            account_type=account_type,
+        )
+        if routing.is_db_simulated and account is None:
+            account = "paper"
+        if routing.is_kis_mock:
+            missing = validate_kis_mock_config()
+            if missing:
+                raise RuntimeError(
+                    "KIS mock account is disabled or missing required "
+                    "configuration: "
+                    + ", ".join(missing)
+                )
+        return apply_account_routing_metadata(
+            await _get_holdings_impl(
+                account=account,
+                market=market,
+                include_current_price=include_current_price,
+                minimum_value=minimum_value,
+                account_name=account_name,
+                is_mock=routing.is_kis_mock,
+            ),
+            routing,
         )
 
     @mcp.tool(
@@ -1129,12 +1183,14 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
     async def get_position(
         symbol: str,
         market: str | None = None,
-        account_type: str = "real",
+        account_mode: str | None = None,
+        account_type: str | None = None,
         paper_account: str | None = None,
     ) -> dict[str, Any]:
         return await _get_position_impl(
             symbol=symbol,
             market=market,
+            account_mode=account_mode,
             account_type=account_type,
             paper_account=paper_account,
         )
@@ -1189,8 +1245,32 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
             "Returns detailed balance information including orderable amounts."
         ),
     )
-    async def get_cash_balance(account: str | None = None) -> dict[str, Any]:
-        return await _get_cash_balance_impl(account=account)
+    async def get_cash_balance(
+        account: str | None = None,
+        account_mode: str | None = None,
+        account_type: str | None = None,
+    ) -> dict[str, Any]:
+        routing = normalize_account_mode(
+            account_mode=account_mode,
+            account_type=account_type,
+        )
+        if routing.is_db_simulated and account is None:
+            account = "paper"
+        if routing.is_kis_mock:
+            missing = validate_kis_mock_config()
+            if missing:
+                raise RuntimeError(
+                    "KIS mock account is disabled or missing required "
+                    "configuration: "
+                    + ", ".join(missing)
+                )
+        return apply_account_routing_metadata(
+            await _get_cash_balance_impl(
+                account=account,
+                is_mock=routing.is_kis_mock,
+            ),
+            routing,
+        )
 
     @mcp.tool(
         name="get_available_capital",
@@ -1205,10 +1285,31 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
     )
     async def get_available_capital(
         account: str | None = None,
+        account_mode: str | None = None,
+        account_type: str | None = None,
         include_manual: bool = True,
     ) -> dict[str, Any]:
-        return await _get_available_capital_impl(
-            account=account, include_manual=include_manual
+        routing = normalize_account_mode(
+            account_mode=account_mode,
+            account_type=account_type,
+        )
+        if routing.is_db_simulated and account is None:
+            account = "paper"
+        if routing.is_kis_mock:
+            missing = validate_kis_mock_config()
+            if missing:
+                raise RuntimeError(
+                    "KIS mock account is disabled or missing required "
+                    "configuration: "
+                    + ", ".join(missing)
+                )
+        return apply_account_routing_metadata(
+            await _get_available_capital_impl(
+                account=account,
+                include_manual=include_manual,
+                is_mock=routing.is_kis_mock,
+            ),
+            routing,
         )
 
 

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -1022,8 +1022,7 @@ async def _get_position_impl(
             if missing:
                 raise RuntimeError(
                     "KIS mock account is disabled or missing required "
-                    "configuration: "
-                    + ", ".join(missing)
+                    "configuration: " + ", ".join(missing)
                 )
         positions, errors, _, _ = await _collect_portfolio_positions(
             account=None,
@@ -1043,15 +1042,18 @@ async def _get_position_impl(
     ]
 
     if not matched_positions:
-        return apply_account_routing_metadata({
-            "symbol": query_symbol,
-            "market": _INSTRUMENT_TO_MARKET.get(parsed_market),
-            "has_position": False,
-            "status": "미보유",
-            "position_count": 0,
-            "positions": [],
-            "errors": errors,
-        }, routing)
+        return apply_account_routing_metadata(
+            {
+                "symbol": query_symbol,
+                "market": _INSTRUMENT_TO_MARKET.get(parsed_market),
+                "has_position": False,
+                "status": "미보유",
+                "position_count": 0,
+                "positions": [],
+                "errors": errors,
+            },
+            routing,
+        )
 
     matched_positions.sort(
         key=lambda position: (
@@ -1061,24 +1063,27 @@ async def _get_position_impl(
         )
     )
 
-    return apply_account_routing_metadata({
-        "symbol": query_symbol,
-        "market": _INSTRUMENT_TO_MARKET.get(parsed_market),
-        "has_position": True,
-        "status": "보유",
-        "position_count": len(matched_positions),
-        "accounts": sorted({position["account"] for position in matched_positions}),
-        "positions": [
-            {
-                "account": position["account"],
-                "broker": position["broker"],
-                "account_name": position["account_name"],
-                **_position_to_output(position),
-            }
-            for position in matched_positions
-        ],
-        "errors": errors,
-    }, routing)
+    return apply_account_routing_metadata(
+        {
+            "symbol": query_symbol,
+            "market": _INSTRUMENT_TO_MARKET.get(parsed_market),
+            "has_position": True,
+            "status": "보유",
+            "position_count": len(matched_positions),
+            "accounts": sorted({position["account"] for position in matched_positions}),
+            "positions": [
+                {
+                    "account": position["account"],
+                    "broker": position["broker"],
+                    "account_name": position["account_name"],
+                    **_position_to_output(position),
+                }
+                for position in matched_positions
+            ],
+            "errors": errors,
+        },
+        routing,
+    )
 
 
 async def _update_manual_holdings_impl(
@@ -1154,8 +1159,7 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
             if missing:
                 raise RuntimeError(
                     "KIS mock account is disabled or missing required "
-                    "configuration: "
-                    + ", ".join(missing)
+                    "configuration: " + ", ".join(missing)
                 )
         return apply_account_routing_metadata(
             await _get_holdings_impl(
@@ -1264,8 +1268,7 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
             if missing:
                 raise RuntimeError(
                     "KIS mock account is disabled or missing required "
-                    "configuration: "
-                    + ", ".join(missing)
+                    "configuration: " + ", ".join(missing)
                 )
         return apply_account_routing_metadata(
             await _get_cash_balance_impl(
@@ -1305,8 +1308,7 @@ def _register_portfolio_tools_impl(mcp: FastMCP) -> None:
             if missing:
                 raise RuntimeError(
                     "KIS mock account is disabled or missing required "
-                    "configuration: "
-                    + ", ".join(missing)
+                    "configuration: " + ", ".join(missing)
                 )
         return apply_account_routing_metadata(
             await _get_available_capital_impl(

--- a/app/services/brokers/kis/_base_market_data.py
+++ b/app/services/brokers/kis/_base_market_data.py
@@ -85,6 +85,14 @@ class MarketDataBase:
     def _settings(self):
         return self._parent._settings
 
+    def _kis_url(self, path: str) -> str:
+        """Build a KIS API URL through the owning client.
+
+        Market-data mixins are instantiated as sub-clients in tests and production;
+        routing through the parent keeps live vs mock base URL selection centralized.
+        """
+        return self._parent._kis_url(path)
+
     async def _request_with_token_retry(
         self,
         tr_id: str,

--- a/app/services/brokers/kis/account.py
+++ b/app/services/brokers/kis/account.py
@@ -302,7 +302,7 @@ class AccountClient:
 
             js = await self._parent._request_with_rate_limit(
                 "GET",
-                f"{constants.BASE}{url}",
+                self._parent._kis_url(url),
                 headers=hdr,
                 params=params,
                 timeout=5,
@@ -416,7 +416,7 @@ class AccountClient:
 
         js = await self._parent._request_with_rate_limit(
             "GET",
-            f"{constants.BASE}{constants.DOMESTIC_BALANCE_URL}",
+            self._parent._kis_url(constants.DOMESTIC_BALANCE_URL),
             headers=hdr,
             params=params,
             timeout=5,
@@ -518,7 +518,7 @@ class AccountClient:
 
         js = await self._parent._request_with_rate_limit(
             "GET",
-            f"{constants.BASE}{constants.OVERSEAS_MARGIN_URL}",
+            self._parent._kis_url(constants.OVERSEAS_MARGIN_URL),
             headers=hdr,
             params=params,
             timeout=5,
@@ -639,7 +639,7 @@ class AccountClient:
 
         js = await self._parent._request_with_rate_limit(
             "GET",
-            f"{constants.BASE}{constants.INTEGRATED_MARGIN_URL}",
+            self._parent._kis_url(constants.INTEGRATED_MARGIN_URL),
             headers=hdr,
             params=params,
             timeout=5,

--- a/app/services/brokers/kis/base.py
+++ b/app/services/brokers/kis/base.py
@@ -135,6 +135,12 @@ class BaseKISClient:
         """Access to application settings."""
         return settings
 
+    def _kis_url(self, path: str) -> str:
+        base_url = getattr(self._settings, "kis_base_url", "").rstrip("/")
+        if not base_url:
+            base_url = "https://openapi.koreainvestment.com:9443"
+        return f"{base_url}{path}"
+
     async def _get_limiter(self, api_key: str, *, rate: int, period: float) -> Any:
         return await get_limiter("kis", api_key, rate=rate, period=period)
 
@@ -262,12 +268,9 @@ class BaseKISClient:
             httpx.HTTPStatusError: On HTTP errors
             KeyError: If response doesn't contain access_token
         """
-        base_url = getattr(
-            self._settings, "kis_base_url", "https://openapi.koreainvestment.com:9443"
-        )
         cli = await self._ensure_client(timeout=5.0)
         r = await cli.post(
-            f"{base_url}/oauth2/token",
+            self._kis_url("/oauth2/token"),
             data={
                 "grant_type": "client_credentials",
                 "appkey": self._settings.kis_app_key,

--- a/app/services/brokers/kis/client.py
+++ b/app/services/brokers/kis/client.py
@@ -41,6 +41,8 @@ __all__ = [
 
 
 class _KISSettingsView:
+    """Expose live or KIS mock credentials without cross-account fallback."""
+
     def __init__(self, *, is_mock: bool) -> None:
         self._is_mock = is_mock
 
@@ -64,6 +66,12 @@ class _KISSettingsView:
         if self._is_mock:
             return settings.kis_mock_account_no
         return settings.kis_account_no
+
+    @property
+    def kis_base_url(self) -> str:
+        if self._is_mock:
+            return settings.kis_mock_base_url
+        return settings.kis_base_url
 
     @property
     def kis_access_token(self) -> str | None:

--- a/app/services/brokers/kis/client.py
+++ b/app/services/brokers/kis/client.py
@@ -9,6 +9,7 @@ from pandas import DataFrame
 
 from app.core.async_rate_limiter import get_limiter
 from app.core.config import settings
+from app.services.redis_token_manager import RedisTokenManager
 
 from .account import AccountClient, extract_domestic_cash_summary_from_integrated_margin
 from .base import BaseKISClient
@@ -39,6 +40,45 @@ __all__ = [
 ]
 
 
+class _KISSettingsView:
+    def __init__(self, *, is_mock: bool) -> None:
+        self._is_mock = is_mock
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(settings, name)
+
+    @property
+    def kis_app_key(self) -> str:
+        if self._is_mock:
+            return str(settings.kis_mock_app_key or "")
+        return settings.kis_app_key
+
+    @property
+    def kis_app_secret(self) -> str:
+        if self._is_mock:
+            return str(settings.kis_mock_app_secret or "")
+        return settings.kis_app_secret
+
+    @property
+    def kis_account_no(self) -> str | None:
+        if self._is_mock:
+            return settings.kis_mock_account_no
+        return settings.kis_account_no
+
+    @property
+    def kis_access_token(self) -> str | None:
+        if self._is_mock:
+            return settings.kis_mock_access_token
+        return settings.kis_access_token
+
+    @kis_access_token.setter
+    def kis_access_token(self, value: str | None) -> None:
+        if self._is_mock:
+            settings.kis_mock_access_token = value
+        else:
+            settings.kis_access_token = value
+
+
 class KISClient(BaseKISClient):
     """KIS API facade client that delegates to specialized sub-clients.
 
@@ -53,8 +93,12 @@ class KISClient(BaseKISClient):
     are inherited from BaseKISClient.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, is_mock: bool = False) -> None:
+        self._is_mock_client = is_mock
+        self._settings_view = _KISSettingsView(is_mock=is_mock)
         super().__init__()
+        if is_mock:
+            self._token_manager = RedisTokenManager("kis_mock")
         parent: KISClientProtocol = cast(KISClientProtocol, cast(object, self))
         self._market_data: MarketDataClient = MarketDataClient(parent)
         self._account: AccountClient = AccountClient(parent)
@@ -63,7 +107,7 @@ class KISClient(BaseKISClient):
 
     @property
     def _settings(self) -> Any:
-        return settings
+        return self._settings_view
 
     async def _get_limiter(self, api_key: str, *, rate: int, period: float) -> Any:
         return await get_limiter("kis", api_key, rate=rate, period=period)

--- a/app/services/brokers/kis/domestic_market_data.py
+++ b/app/services/brokers/kis/domestic_market_data.py
@@ -62,7 +62,7 @@ class DomesticMarketDataMixin(MarketDataBase):
     async def volume_rank(self, market: str = "J", limit: int = 30) -> list[dict]:
         js = await self._request_with_token_retry(
             tr_id=constants.DOMESTIC_VOLUME_TR,
-            url=f"{constants.BASE}{constants.DOMESTIC_VOLUME_URL}",
+            url=self._kis_url(constants.DOMESTIC_VOLUME_URL),
             params={
                 "FID_COND_MRKT_DIV_CODE": market,
                 "FID_COND_SCR_DIV_CODE": "20171",
@@ -91,7 +91,7 @@ class DomesticMarketDataMixin(MarketDataBase):
     async def market_cap_rank(self, market: str = "J", limit: int = 30) -> list[dict]:
         js = await self._request_with_token_retry(
             tr_id=constants.MARKET_CAP_RANK_TR,
-            url=f"{constants.BASE}{constants.MARKET_CAP_RANK_URL}",
+            url=self._kis_url(constants.MARKET_CAP_RANK_URL),
             params={
                 "FID_COND_MRKT_DIV_CODE": market,
                 "FID_COND_SCR_DIV_CODE": "20174",
@@ -123,7 +123,7 @@ class DomesticMarketDataMixin(MarketDataBase):
 
         js = await self._request_with_token_retry(
             tr_id=constants.FLUCTUATION_RANK_TR,
-            url=f"{constants.BASE}{constants.FLUCTUATION_RANK_URL}",
+            url=self._kis_url(constants.FLUCTUATION_RANK_URL),
             params={
                 "FID_COND_MRKT_DIV_CODE": market,
                 "FID_COND_SCR_DIV_CODE": "20170",
@@ -157,7 +157,7 @@ class DomesticMarketDataMixin(MarketDataBase):
     ) -> list[dict]:
         js = await self._request_with_token_retry(
             tr_id=constants.FOREIGN_BUYING_RANK_TR,
-            url=f"{constants.BASE}{constants.FOREIGN_BUYING_RANK_URL}",
+            url=self._kis_url(constants.FOREIGN_BUYING_RANK_URL),
             params={
                 "FID_COND_MRKT_DIV_CODE": "V",
                 "FID_COND_SCR_DIV_CODE": "16449",
@@ -181,7 +181,7 @@ class DomesticMarketDataMixin(MarketDataBase):
         """
         js = await self._request_with_token_retry(
             tr_id=constants.DOMESTIC_PRICE_TR,
-            url=f"{constants.BASE}{constants.DOMESTIC_PRICE_URL}",
+            url=self._kis_url(constants.DOMESTIC_PRICE_URL),
             params={
                 "FID_COND_MRKT_DIV_CODE": market,
                 "FID_INPUT_ISCD": code.zfill(6),
@@ -217,7 +217,7 @@ class DomesticMarketDataMixin(MarketDataBase):
     async def _request_orderbook_snapshot(self, code: str, market: str = "J") -> dict:
         return await self._request_with_token_retry(
             tr_id=constants.DOMESTIC_ORDERBOOK_TR,
-            url=f"{constants.BASE}{constants.DOMESTIC_ORDERBOOK_URL}",
+            url=self._kis_url(constants.DOMESTIC_ORDERBOOK_URL),
             params={
                 "FID_COND_MRKT_DIV_CODE": market,
                 "FID_INPUT_ISCD": code.zfill(6),
@@ -288,7 +288,7 @@ class DomesticMarketDataMixin(MarketDataBase):
 
         js = await self._request_with_token_retry(
             tr_id=constants.DOMESTIC_SHORT_SELLING_TR,
-            url=f"{constants.BASE}{constants.DOMESTIC_SHORT_SELLING_URL}",
+            url=self._kis_url(constants.DOMESTIC_SHORT_SELLING_URL),
             params=params,
             api_name="inquire_short_selling",
         )
@@ -322,7 +322,7 @@ class DomesticMarketDataMixin(MarketDataBase):
     ) -> list[dict[str, Any]]:
         js = await self._request_with_token_retry(
             tr_id=constants.INVESTOR_TRADING_TR,
-            url=f"{constants.BASE}{constants.INVESTOR_TRADING_URL}",
+            url=self._kis_url(constants.INVESTOR_TRADING_URL),
             params={
                 "FID_COND_MRKT_DIV_CODE": market,
                 "FID_INPUT_ISCD": code.zfill(6),
@@ -343,7 +343,7 @@ class DomesticMarketDataMixin(MarketDataBase):
         """
         js = await self._request_with_token_retry(
             tr_id=constants.DOMESTIC_PRICE_TR,
-            url=f"{constants.BASE}{constants.DOMESTIC_PRICE_URL}",
+            url=self._kis_url(constants.DOMESTIC_PRICE_URL),
             params={
                 "FID_COND_MRKT_DIV_CODE": market,
                 "FID_INPUT_ISCD": code.zfill(6),
@@ -443,7 +443,7 @@ class DomesticMarketDataMixin(MarketDataBase):
 
             js = await self._request_with_token_retry(
                 tr_id=constants.DOMESTIC_DAILY_CHART_TR,
-                url=f"{constants.BASE}{constants.DOMESTIC_DAILY_CHART_URL}",
+                url=self._kis_url(constants.DOMESTIC_DAILY_CHART_URL),
                 params=params,
                 api_name="inquire_daily_itemchartprice",
             )
@@ -491,7 +491,7 @@ class DomesticMarketDataMixin(MarketDataBase):
 
         js = await self._request_with_token_retry(
             tr_id=constants.DOMESTIC_TIME_DAILY_CHART_TR,
-            url=f"{constants.BASE}{constants.DOMESTIC_TIME_DAILY_CHART_URL}",
+            url=self._kis_url(constants.DOMESTIC_TIME_DAILY_CHART_URL),
             params=params,
             api_name="inquire_time_dailychartprice",
         )
@@ -557,7 +557,7 @@ class DomesticMarketDataMixin(MarketDataBase):
 
         js = await self._request_with_token_retry(
             tr_id=constants.DOMESTIC_MINUTE_CHART_TR,
-            url=f"{constants.BASE}{constants.DOMESTIC_MINUTE_CHART_URL}",
+            url=self._kis_url(constants.DOMESTIC_MINUTE_CHART_URL),
             params=params,
             api_name="inquire_minute_chart",
         )

--- a/app/services/brokers/kis/domestic_orders.py
+++ b/app/services/brokers/kis/domestic_orders.py
@@ -157,7 +157,7 @@ class DomesticOrderClient:
 
             js = await self._parent._request_with_rate_limit(
                 "GET",
-                f"{constants.BASE}{constants.DOMESTIC_ORDER_INQUIRY_URL}",
+                self._parent._kis_url(constants.DOMESTIC_ORDER_INQUIRY_URL),
                 headers=hdr,
                 params=params,
                 timeout=10,
@@ -302,7 +302,7 @@ class DomesticOrderClient:
 
         js = await self._parent._request_with_rate_limit(
             "POST",
-            f"{constants.BASE}{constants.DOMESTIC_ORDER_URL}",
+            self._parent._kis_url(constants.DOMESTIC_ORDER_URL),
             headers=hdr,
             json_body=body,
             timeout=10,
@@ -468,7 +468,7 @@ class DomesticOrderClient:
 
         js = await self._parent._request_with_rate_limit(
             "POST",
-            f"{constants.BASE}{constants.DOMESTIC_ORDER_CANCEL_URL}",
+            self._parent._kis_url(constants.DOMESTIC_ORDER_CANCEL_URL),
             headers=hdr,
             json_body=body,
             timeout=10,
@@ -610,7 +610,7 @@ class DomesticOrderClient:
 
             js = await self._parent._request_with_rate_limit(
                 "GET",
-                f"{constants.BASE}{constants.DOMESTIC_DAILY_ORDER_URL}",
+                self._parent._kis_url(constants.DOMESTIC_DAILY_ORDER_URL),
                 headers=hdr,
                 params=params,
                 timeout=10,
@@ -764,7 +764,7 @@ class DomesticOrderClient:
 
         js = await self._parent._request_with_rate_limit(
             "POST",
-            f"{constants.BASE}{constants.DOMESTIC_ORDER_CANCEL_URL}",
+            self._parent._kis_url(constants.DOMESTIC_ORDER_CANCEL_URL),
             headers=hdr,
             json_body=body,
             timeout=10,

--- a/app/services/brokers/kis/overseas_market_data.py
+++ b/app/services/brokers/kis/overseas_market_data.py
@@ -150,7 +150,7 @@ class OverseasMarketDataMixin(MarketDataBase):
 
             js = await self._request_with_token_retry(
                 tr_id=constants.OVERSEAS_DAILY_CHART_TR,
-                url=f"{constants.BASE}{constants.OVERSEAS_DAILY_CHART_URL}",
+                url=self._kis_url(constants.OVERSEAS_DAILY_CHART_URL),
                 params=params,
                 timeout=10,
                 api_name="inquire_overseas_daily_price",
@@ -260,7 +260,7 @@ class OverseasMarketDataMixin(MarketDataBase):
 
         js = await self._request_with_token_retry(
             tr_id=constants.OVERSEAS_MINUTE_CHART_TR,
-            url=f"{constants.BASE}{constants.OVERSEAS_MINUTE_CHART_URL}",
+            url=self._kis_url(constants.OVERSEAS_MINUTE_CHART_URL),
             params=params,
             timeout=10,
             api_name="inquire_overseas_minute_chart",

--- a/app/services/brokers/kis/overseas_orders.py
+++ b/app/services/brokers/kis/overseas_orders.py
@@ -169,7 +169,7 @@ class OverseasOrderClient:
 
         js = await self._parent._request_with_rate_limit(
             "POST",
-            f"{constants.BASE}{constants.OVERSEAS_ORDER_URL}",
+            self._parent._kis_url(constants.OVERSEAS_ORDER_URL),
             headers=hdr,
             json_body=body,
             timeout=10,
@@ -336,7 +336,7 @@ class OverseasOrderClient:
 
             js = await self._parent._request_with_rate_limit(
                 "GET",
-                f"{constants.BASE}{constants.OVERSEAS_ORDER_INQUIRY_URL}",
+                self._parent._kis_url(constants.OVERSEAS_ORDER_INQUIRY_URL),
                 headers=hdr,
                 params=params,
                 timeout=10,
@@ -467,7 +467,7 @@ class OverseasOrderClient:
 
         js = await self._parent._request_with_rate_limit(
             "POST",
-            f"{constants.BASE}{constants.OVERSEAS_ORDER_CANCEL_URL}",
+            self._parent._kis_url(constants.OVERSEAS_ORDER_CANCEL_URL),
             headers=hdr,
             json_body=body,
             timeout=10,
@@ -607,7 +607,7 @@ class OverseasOrderClient:
 
             js = await self._parent._request_with_rate_limit(
                 "GET",
-                f"{constants.BASE}{constants.OVERSEAS_DAILY_ORDER_URL}",
+                self._parent._kis_url(constants.OVERSEAS_DAILY_ORDER_URL),
                 headers=hdr,
                 params=params,
                 timeout=10,
@@ -739,7 +739,7 @@ class OverseasOrderClient:
 
         js = await self._parent._request_with_rate_limit(
             "POST",
-            f"{constants.BASE}{constants.OVERSEAS_ORDER_CANCEL_URL}",
+            self._parent._kis_url(constants.OVERSEAS_ORDER_CANCEL_URL),
             headers=hdr,
             json_body=body,
             timeout=10,

--- a/app/services/brokers/kis/protocols.py
+++ b/app/services/brokers/kis/protocols.py
@@ -62,6 +62,10 @@ class KISClientProtocol(Protocol):
         """Get rate limit for a specific API key."""
         ...
 
+    def _kis_url(self, path: str) -> str:
+        """Build a KIS API URL for the active account mode."""
+        ...
+
     @property
     def _settings(self) -> Any:
         """Access to application settings."""

--- a/app/services/redis_token_manager.py
+++ b/app/services/redis_token_manager.py
@@ -13,10 +13,10 @@ from app.core.config import settings
 class RedisTokenManager:
     """Redis 기반 토큰 관리 서비스 with 분산 락"""
 
-    def __init__(self):
+    def __init__(self, namespace: str = "kis"):
         self.redis_client: redis.Redis | None = None
-        self._lock_key = "kis:token:lock"
-        self._token_key = "kis:access_token"
+        self._lock_key = f"{namespace}:token:lock"
+        self._token_key = f"{namespace}:access_token"
         self._lock_timeout = 30  # 락 타임아웃 (초)
         self._token_expiry_buffer = 60  # 토큰 만료 전 버퍼 (초)
         self._current_lock_value: str | None = None  # 현재 획득한 락 값 저장

--- a/docs/plans/ROB-19-final-review-report.md
+++ b/docs/plans/ROB-19-final-review-report.md
@@ -1,0 +1,181 @@
+# ROB-19 Final Review Report
+
+**Verdict:** PASS
+
+AOE_STATUS: final-review
+AOE_ISSUE: ROB-19
+AOE_ROLE: reviewer-opus
+AOE_NEXT: signoff complete; PR is ready to merge to `main`. Phase-2 follow-up
+issue (KIS-mock write-side execution + standardized fail-closed shape) should
+be filed before any operator flips `KIS_MOCK_ENABLED=true` in production.
+
+- **Branch / worktree:** `feature/ROB-19-kis-mock-account-routing`
+  (`/Users/mgh3326/work/auto_trader-worktrees/feature-ROB-19-kis-mock-account-routing`)
+- **Commits since prior review:**
+  - `f9f1d883 fix(rob-19): harden kis mock routing safeguards`
+  - `8049e53b docs(rob-19): add opus review report`
+- **Test/lint evidence (re-run by orchestrator after fix commit):**
+  - `uv run pytest tests/test_kis_mock_routing.py tests/test_mcp_account_modes.py tests/test_paper_order_handler.py tests/test_mcp_portfolio_tools.py tests/test_mcp_order_tools.py tests/test_mcp_place_order.py tests/test_kis_order_ops.py -q` → **219 passed** (was 212; +7 from new
+    `tests/test_kis_mock_routing.py`)
+  - `uv run ruff check app tests` → **passed**
+  - `uv run python -m py_compile $(rg --files app tests -g '*.py')` → **passed**
+
+---
+
+## Fix Verification
+
+The three required fixes from the prior review (PASS_WITH_NOTES) have all
+landed and are covered by the new test suite.
+
+### Required fix #1 — KIS mock base URL switching ✅
+
+**Prior issue:** `_KISSettingsView` only overrode `kis_app_key`,
+`kis_app_secret`, `kis_account_no`, `kis_access_token`. `kis_base_url` fell
+through `__getattr__` to live `settings`, and trading paths used a hardcoded
+`f"{constants.BASE}{...}"` (live URL `:9443`). Mock requests would have hit
+the live host and 401'd — not a safety violation, but a functional gap.
+
+**Now:**
+
+- `Settings` exposes both `kis_base_url: str = "https://openapi.koreainvestment.com:9443"` and `kis_mock_base_url: str = "https://openapivts.koreainvestment.com:29443"`
+  as first-class fields (`app/core/config.py:169, 178`).
+- `_KISSettingsView.kis_base_url` (`app/services/brokers/kis/client.py:71-74`)
+  now picks the mock host when `is_mock=True` and the live host otherwise —
+  no more `__getattr__` fallback for this field.
+- `BaseKISClient._kis_url(path)` (`app/services/brokers/kis/base.py:138-142`)
+  resolves URLs from `self._settings.kis_base_url`, with the same
+  hardcoded-fallback only when settings is missing the field entirely (defense
+  in depth for legacy `Settings` shims).
+- All `f"{constants.BASE}{...}"` references in the trading paths have been
+  rewritten to `self._parent._kis_url(...)` /  `self._kis_url(...)`. Confirmed
+  by `rg -n 'constants\.BASE\b' app/services/brokers/kis/` returning **zero
+  matches** post-fix. The 26+ rewrites span:
+  - `account.py` (4 sites: integrated margin, balance, overseas margin, generic)
+  - `domestic_orders.py` (5 sites)
+  - `overseas_orders.py` (5 sites)
+  - `domestic_market_data.py` (12 sites)
+  - `overseas_market_data.py` (2 sites)
+  - `base.py` `_fetch_token` (1 site, for `/oauth2/token`)
+- `KISClientProtocol._kis_url(self, path: str) -> str` is added to the typing
+  protocol (`app/services/brokers/kis/protocols.py:65-67`) so sub-clients can
+  call `self._parent._kis_url(...)` under static analysis.
+
+**Test coverage:**
+- `tests/test_kis_mock_routing.py::test_kis_mock_settings_view_uses_mock_base_url`
+  asserts `KISClient(is_mock=True)._settings.kis_base_url` and `_kis_url(...)`
+  resolve to the mock host even when the live `kis_base_url` is patched to a
+  distinct value — closing the loop on Finding #3 from the prior review (the
+  leaky `__getattr__`).
+- `tests/test_kis_mock_routing.py::test_kis_mock_fetch_token_posts_to_mock_base_url`
+  is an end-to-end assertion that `_fetch_token` POSTs to
+  `https://mock.example.invalid/oauth2/token` — proves the mock auth call
+  no longer leaks to the live host.
+
+### Required fix #2 — env/docs/tool descriptions ✅
+
+**Prior issue:** `env.example` did not list `KIS_MOCK_*` settings, and tool
+description strings on `place_order`, `get_order_history`, `get_holdings`,
+`get_position` did not mention `account_mode`.
+
+**Now:**
+- `env.example:16-26` adds `KIS_BASE_URL`, `KIS_MOCK_ENABLED`, `KIS_MOCK_APP_KEY`,
+  `KIS_MOCK_APP_SECRET`, `KIS_MOCK_ACCOUNT_NO`, `KIS_MOCK_BASE_URL`,
+  `KIS_MOCK_ACCESS_TOKEN`, with the explicit comment *"Keep credential values
+  in operator-managed runtime env files; do not commit them."* — matches the
+  ROB-19 plan §1 directive and never embeds a real value.
+- All four affected tool descriptions append the canonical sentence
+  *"Use account_mode={'db_simulated','kis_mock','kis_live'} (preferred);
+  account_type aliases are deprecated and emit warnings."* — verified at:
+  - `orders_registration.py:58-59` (`get_order_history`)
+  - `orders_registration.py:122-123` (`place_order`)
+  - `portfolio_holdings.py:1133-1134` (`get_holdings`)
+  - `portfolio_holdings.py:1179-1180` (`get_position`)
+- README block at `app/mcp_server/README.md:118-136` was updated to mention
+  `KIS_MOCK_BASE_URL` and the official mock host default.
+
+### Required fix #3 — TypeError fallbacks ✅
+
+**Prior issue:** Five callsites had `try: KISClient(is_mock=True) except
+TypeError: return KISClient()`, which would silently route mock requests to
+live credentials if the `is_mock` keyword were ever dropped from
+`KISClient.__init__`.
+
+**Now:**
+- All five `try/except TypeError` fallbacks are removed. Confirmed by `grep`
+  across `order_execution.py:56-59`, `orders_history.py:32-35`,
+  `order_validation.py:38-41`, `portfolio_cash.py:25-28`, and
+  `portfolio_holdings.py:247` — each now reads simply
+  `return KISClient(is_mock=True)` (or for `_collect_kis_positions`,
+  `kis = KISClient(is_mock=True) if is_mock else KISClient()`).
+
+**Test coverage:** `tests/test_kis_mock_routing.py` adds **five regression
+tests** (`test_*_does_not_fallback_to_live`) — one per former fallback site
+— each substitutes a `BrokenKISClient` whose `__init__(is_mock=True)` raises
+`TypeError`. The tests assert the factory propagates the `TypeError` rather
+than silently degrading to a no-arg `KISClient()`. This is a high-quality
+regression net: any future refactor that re-introduces a silent fallback
+will fail one of these tests.
+
+---
+
+## Remaining Notes
+
+These are **not blockers** — they were rated LOW in the prior review and
+were not part of the required-fix list. They remain valid but can be
+deferred to the Phase-2 follow-up issue.
+
+| # | Severity | Status | Location | Note |
+| - | -------- | ------ | -------- | ---- |
+| 1 | LOW | Deferred | `orders_registration.py:33-45` (dict shape) vs `portfolio_holdings.py:1153-1159` (`RuntimeError`) | **Inconsistent fail-closed shape** persists: order tools return `{"success": False, "error": "...", "account_mode": "kis_mock"}`; portfolio tools raise `RuntimeError`. Tests cover both shapes. Downstream MCP clients still need to handle two flavors of the same condition. Recommend extracting a single `_kis_mock_config_error()` helper into `account_modes.py` and standardizing on the structured-error dict in Phase 2. |
+| 2 | LOW | Deferred | `client.py:43-87` | `_KISSettingsView.__getattr__` still falls through to live `settings` for any field not explicitly listed. Today the four credential fields plus `kis_base_url` are mock-isolated, which covers every settings access made by `BaseKISClient` per the current grep. Future settings (e.g., per-account rate limits) would need to be added to the explicit override list. The class docstring at `client.py:44` (*"Expose live or KIS mock credentials without cross-account fallback."*) signals intent, but does not enumerate the override list. Recommend converting to a frozen dataclass or annotating the explicit field list in Phase 2. |
+| 3 | LOW | Deferred | n/a | No fakeredis-backed test asserts that a token saved under the `kis_mock` namespace is invisible to the default-namespace `RedisTokenManager`. The constructor-level invariant is straightforward (`redis_token_manager.py:16-19`) but a 5-line round-trip test would harden the cache-isolation contract. The new `tests/test_kis_mock_routing.py` covers everything else; this is the only gap. |
+| 4 | INFO | n/a | n/a | KIS-mock **non-dry-run execution** still flows through `_place_order_impl` with `is_mock=True` once `KIS_MOCK_ENABLED=true`. The base-URL switch and credential isolation now make this a real path (rather than a 401 against live), but the journal/order-history persistence layer was not extended to source-tag mock fills. Operator-driven smoke before any production enablement should confirm KR/US mock fills don't collide with live `order_history` rows. Track in Phase-2 follow-up. |
+
+---
+
+## Final Recommendation
+
+**PASS — merge to `main`.**
+
+All three previously identified required fixes are present, structurally
+correct, and protected by new regression tests. The 219-pass test suite
+covers:
+
+- Account-mode selector normalization (`test_mcp_account_modes.py`).
+- Routing isolation: `account_type="paper"` → DB simulation only;
+  `account_mode="kis_mock"` → live impl with `is_mock=True`;
+  `account_mode="kis_live"` → unchanged live path
+  (`test_paper_order_handler.py`).
+- Fail-closed-before-broker contract on missing `KIS_MOCK_*` env
+  (`test_paper_order_handler.py`, `test_mcp_portfolio_tools.py`).
+- Mock base URL is honored at the credentials view, the URL builder, AND the
+  `/oauth2/token` POST (`test_kis_mock_routing.py`).
+- No silent fallback to live when the mock-client factory fails
+  (`test_kis_mock_routing.py` × 5 sites).
+
+Hard safety invariants from the original plan all hold:
+- ✅ No live order placed in tests, smoke, or review.
+- ✅ `dry_run=True` default preserved on `place_order`.
+- ✅ `kis_mock` fails closed with names-only error when config is incomplete;
+  no live fallback path exists.
+- ✅ No secret values printed/logged/persisted; `validate_kis_mock_config`
+  reports env-var **names only**.
+- ✅ Token cache namespaces (`kis:access_token` vs `kis_mock:access_token`)
+  cannot collide.
+- ✅ Mock requests now provably go to `openapivts.koreainvestment.com:29443`,
+  not the live host.
+
+**Required for Phase 2 (file as separate Linear issue before operator
+turns on `KIS_MOCK_ENABLED=true` in production):**
+1. Standardize the kis_mock fail-closed error shape (Remaining Note #1).
+2. Tighten `_KISSettingsView` against future leaky `__getattr__` regressions
+   (Remaining Note #2).
+3. Add a fakeredis round-trip test for token-namespace isolation
+   (Remaining Note #3).
+4. Source-tag KIS-mock order-history rows so they cannot interleave with
+   live `order_history` records (Remaining Note #4).
+5. Operator-driven read-only smoke harness against the actual KIS official
+   mock server (separate from CI) — recommended in the original plan, not
+   yet present.
+
+This PR is ready to merge as-is. Implementer is signed off for Phase 1.

--- a/docs/plans/ROB-19-kis-mock-account-routing-plan.md
+++ b/docs/plans/ROB-19-kis-mock-account-routing-plan.md
@@ -1,0 +1,138 @@
+# ROB-19 Normalize simulated vs KIS mock account routing — Implementation Plan
+
+AOE_STATUS: plan-ready
+AOE_ISSUE: ROB-19
+AOE_ROLE: planner-opus/manual-handoff
+AOE_NEXT: codex --yolo implementer should execute the scoped plan, run focused tests, commit, then request Opus review.
+
+## Goal
+
+Normalize auto_trader MCP account routing so three modes are explicit and cannot be confused:
+
+- `db_simulated`: DB-backed virtual/paper trading engine. Existing `account_type="paper"` remains a deprecated alias.
+- `kis_mock`: official KIS mock/sandbox account. Uses only `KIS_MOCK_*` credentials and `is_mock=True` broker paths.
+- `kis_live`: real KIS live account. Existing default real behavior remains, but live execution still requires `dry_run=False` and should not be exercised in this PR.
+
+## Safety invariants
+
+- Never place a live order during tests, smoke, or review.
+- Preserve `dry_run=True` default for MCP `place_order`.
+- `kis_mock` must fail closed if disabled/incomplete and must never fall back to live credentials.
+- Do not read, print, persist, or commit secret values from `/Users/mgh3326/services/auto_trader/shared/.env.kis-mock`.
+- Token/cache namespaces for mock must be distinct from live where modified.
+- `account_type="paper"` continues to mean DB simulation only, never KIS mock.
+- No watch registration/order intent/broker side effects in test or smoke unless using explicit mocks/fakes.
+
+## Suggested implementation scope
+
+Implement a safe first slice that exposes unambiguous routing at MCP boundary and broker config layer without requiring production to load mock secrets yet.
+
+### 1. Central account-mode helper
+
+Add `app/mcp_server/tooling/account_modes.py` or equivalent with:
+
+- enum/string constants: `db_simulated`, `kis_mock`, `kis_live`
+- `normalize_account_mode(account_mode: str | None = None, account_type: str | None = None) -> AccountRouting`
+- deprecated aliases:
+  - `account_type="paper"`, `account_mode="paper"`, `account_mode="simulated"` => `db_simulated` + warning
+  - `account_type="real"`, absent selector => `kis_live`
+  - `account_mode="kis_mock"`, maybe `account_type="kis_mock"` => `kis_mock`
+- conflict handling: incompatible `account_mode`/`account_type` should return/raise a clear validation error.
+- return fields: `account_mode`, `is_db_simulated`, `is_kis_mock`, `is_kis_live`, `deprecated_alias_used`, `warnings`.
+
+### 2. Settings/config
+
+Add optional settings in `app/core/config.py` or existing settings module:
+
+- `KIS_MOCK_ENABLED: bool = False`
+- `KIS_MOCK_APP_KEY: str | None = None`
+- `KIS_MOCK_APP_SECRET: str | None = None`
+- `KIS_MOCK_ACCOUNT_NO: str | None = None`
+
+Add a helper such as `validate_kis_mock_config()` returning missing names only, never values. `kis_mock` paths must fail closed when not enabled or missing values.
+
+### 3. KIS token/account separation
+
+Inspect existing `app/services/brokers/kis/*`, `app/services/kis_trading_service.py`, `app/services/orders/service.py`, and token manager. Where current KIS clients already accept `is_mock=True`, ensure MCP official mock routing passes `is_mock=True` and mock config only. If token key names are centralized, include account mode/mock in token key namespace to avoid live/mock token collision.
+
+### 4. MCP surfaces to update
+
+Prioritize these files:
+
+- `app/mcp_server/tooling/order_execution.py`
+- `app/mcp_server/tooling/orders_history.py`
+- `app/mcp_server/tooling/orders_modify_cancel.py` if small/safe
+- `app/mcp_server/tooling/portfolio_cash.py`
+- `app/mcp_server/tooling/portfolio_holdings.py`
+- `app/mcp_server/tooling/portfolio_registration.py` / `orders_registration.py` for schema docs if parameters are registered there
+- `app/mcp_server/README.md`
+
+Behavior:
+
+- Add optional `account_mode` parameter while retaining `account_type` for backward compatibility.
+- DB simulation path remains routed to `paper_*` handlers/services.
+- `kis_mock` routes to KIS real broker code with `is_mock=True`, but fail closed if config disabled/incomplete.
+- `kis_live` routes to existing live KIS path.
+- Responses include `account_mode` and, for deprecated alias, `warnings`.
+- Error messages should be explicit: e.g. `KIS mock account is disabled or missing required configuration: KIS_MOCK_ENABLED, KIS_MOCK_APP_KEY, ...` without values.
+
+### 5. Tests
+
+Add/extend focused tests, no real provider calls:
+
+- New unit tests for account-mode normalization:
+  - absent/default => `kis_live`
+  - `account_type="paper"` => `db_simulated` with deprecation warning
+  - `account_mode="db_simulated"` => DB simulation
+  - `account_mode="kis_mock"` => official mock
+  - conflicting selectors fail
+- MCP order tests:
+  - `account_type="paper"` still uses DB paper handler and not KIS.
+  - `account_mode="kis_mock"` passes `is_mock=True` to patched/fake KIS order service and includes `account_mode` in response.
+  - `account_mode="kis_mock"` with missing/disabled config fails before broker call.
+  - default/live dry-run preview remains dry-run; no live side effect.
+- Portfolio/cash/holdings tests:
+  - DB simulation alias remains DB simulation.
+  - KIS mock routes with `is_mock=True` under fakes and fails closed without config.
+- Token/cache test if central token key touched.
+
+Likely test files:
+
+- `tests/test_mcp_order_tools.py`
+- `tests/test_mcp_portfolio_tools.py` or related existing MCP portfolio tests
+- `tests/test_kis_constants.py` / new `tests/test_kis_account_modes.py`
+
+Commands:
+
+```bash
+uv sync --group test --group dev
+uv run pytest tests/test_mcp_order_tools.py tests/test_mcp_portfolio_tools.py tests/test_kis_constants.py -q
+uv run ruff check app tests
+uv run python -m py_compile $(git ls-files 'app/**/*.py' 'tests/**/*.py')
+```
+
+Adjust test file list to actual filenames present in repository.
+
+## Implementation cautions
+
+- Do not silently rename public `account_type`; keep compatibility but mark it in response warnings/docs.
+- Do not make `account_type="paper"` mean KIS mock.
+- Do not load `.env.kis-mock` automatically in code unless project already has a safe operator-approved env loading convention. Prefer documenting that production must inject `KIS_MOCK_*` into the MCP runtime environment later.
+- If official mock side-effect execution is technically enabled, tests and smoke must remain mocked/dry-run/fail-closed only.
+
+## PR / review / smoke plan
+
+1. Codex implements and commits.
+2. Opus review checks:
+   - account selector ambiguity eliminated
+   - fail-closed KIS mock config
+   - no live fallback
+   - no secret leakage
+   - tests mock all broker side effects
+3. PR CI required checks pass.
+4. Merge/deploy.
+5. Production smoke, no secrets and no broker side effects:
+   - verify `account_type="paper"`/`account_mode="db_simulated"` still returns DB simulation path marker or dry-run preview under simulation.
+   - verify `account_mode="kis_mock"` fails closed if production runtime lacks `KIS_MOCK_ENABLED=true`/required vars, with only variable names in error.
+   - verify default `place_order` remains `dry_run=True`; do not run `dry_run=False`.
+

--- a/docs/plans/ROB-19-review-report.md
+++ b/docs/plans/ROB-19-review-report.md
@@ -1,0 +1,199 @@
+# ROB-19 Review Report
+
+**Verdict:** PASS_WITH_NOTES
+
+AOE_STATUS: review
+AOE_ISSUE: ROB-19
+AOE_ROLE: reviewer-opus
+AOE_NEXT: implementer addresses Notes (or files Phase-2 follow-up issue) before merge; reviewer signs off after env.example + tool-description fixes.
+
+- **Branch / worktree:** `feature/ROB-19-kis-mock-account-routing`
+  (`/Users/mgh3326/work/auto_trader-worktrees/feature-ROB-19-kis-mock-account-routing`)
+- **Commits reviewed:**
+  - `6ece3c96 feat(rob-19): normalize kis mock account routing`
+  - `3d4dd37b docs(rob-19): add implementation plan`
+- **Test/lint evidence (already run by implementer):**
+  - `uv run pytest tests/test_mcp_account_modes.py tests/test_paper_order_handler.py tests/test_mcp_portfolio_tools.py tests/test_mcp_order_tools.py tests/test_mcp_place_order.py tests/test_kis_order_ops.py -q` → **212 passed**
+  - `uv run ruff check app tests` → **passed**
+  - `uv run python -m py_compile $(rg --files app tests -g '*.py')` → **passed**
+
+---
+
+## Safety Review
+
+The seven safety invariants from the plan were checked against the diff:
+
+1. **`account_type="paper"` remains DB simulation only and never KIS mock.** ✅
+   - `account_modes._ACCOUNT_TYPE_ALIASES` (`tooling/account_modes.py:23-29`) maps
+     `paper → db_simulated` exclusively. `kis_mock` is reachable only via
+     `account_mode="kis_mock"` (`_ACCOUNT_MODE_ALIASES`, line 12-21), never via
+     `account_type`. Conflicting `account_mode="kis_mock"` + `account_type="paper"`
+     raises `ValueError("conflicting account selectors")` — covered by
+     `tests/test_mcp_account_modes.py::test_conflicting_account_selectors_fail`.
+   - In `orders_registration.place_order` (line 179-198) the
+     `routing.is_db_simulated` branch routes only to `_place_paper_order`; the
+     KIS-mock branch (line 199-202) is reached only when `routing.is_kis_mock`
+     is true. There is no code path where `account_type="paper"` reaches the
+     KIS broker.
+
+2. **`account_mode="kis_mock"` fails closed before broker calls if config is
+   disabled/missing.** ✅
+   - `core/config.validate_kis_mock_config(...)` (`app/core/config.py:465-477`)
+     returns missing env-var **names only** (no values), checking
+     `KIS_MOCK_ENABLED`, `KIS_MOCK_APP_KEY`, `KIS_MOCK_APP_SECRET`,
+     `KIS_MOCK_ACCOUNT_NO`.
+   - The validator is invoked **before** any KIS HTTP call on every kis_mock
+     surface:
+     - `place_order` — `orders_registration.py:199-202` (returns structured
+       error dict containing only env names, no values).
+     - `get_order_history` — `orders_registration.py:87-90`.
+     - `get_holdings` — `portfolio_holdings.py:1153-1160` (raises `RuntimeError`).
+     - `get_position` — `portfolio_holdings.py:1023-1030`.
+     - `get_cash_balance` — `portfolio_holdings.py:1259-1266`.
+     - `get_available_capital` — `portfolio_holdings.py:1298-1306`.
+   - Tested by
+     `tests/test_paper_order_handler.py::TestPlaceOrderRegistration::test_account_mode_kis_mock_fails_closed_before_broker_call`
+     (asserts the live stub is **not** awaited and the missing env names appear
+     in the error string).
+
+3. **`kis_mock` uses only mock settings, `is_mock=True`, and a separate
+   token/cache namespace.** ✅ (with one functional gap — see Findings #1).
+   - `_KISSettingsView` (`app/services/brokers/kis/client.py:43-79`) overrides
+     `kis_app_key`, `kis_app_secret`, `kis_account_no`, and
+     `kis_access_token` with the mock variants when `is_mock=True`. It does
+     **not** delegate live values when in mock mode for those four fields.
+   - Token cache: `RedisTokenManager("kis_mock")` (`client.py:101`) produces
+     keys `kis_mock:access_token` / `kis_mock:token:lock`, distinct from the
+     live default `kis:access_token` / `kis:token:lock`
+     (`redis_token_manager.py:16-19`).
+   - `is_mock=True` is threaded through every KIS public method on the
+     mock-credentialed client (cash, holdings, place orders, history) via
+     `_call_kis(...)` helpers in `order_execution.py`, `orders_history.py`,
+     `order_validation.py`, and `portfolio_cash.py`. Verified end-to-end by
+     `tests/test_mcp_portfolio_tools.py::test_get_cash_balance_kis_mock_passes_is_mock`
+     which asserts `all(is_mock for _, is_mock in calls)`.
+
+4. **No secret values printed, logged, persisted, or documented.** ✅
+   - `validate_kis_mock_config` reports env-var names only (line 470-476). No
+     value access in any error path.
+   - Tool error messages on kis_mock failure embed only the env-var names
+     (`orders_registration.py:39-44`, `portfolio_holdings.py:1156-1160`).
+   - Tested by `test_validate_kis_mock_config_reports_names_only`
+     (`tests/test_mcp_account_modes.py:54-70`) including a positive assertion
+     that the placeholder secret string is **not** present in
+     `repr(missing)`.
+   - No new logging statements expose `kis_mock_app_key/secret/account_no`.
+     Confirmed by `grep -nE "kis_mock_app_secret|kis_mock_app_key|kis_mock_account_no" app/ tests/` — only definition/access sites in `config.py`,
+     the settings view, the validator, and one test stub.
+   - The path `/Users/mgh3326/services/auto_trader/shared/.env.kis-mock` is
+     not referenced anywhere in the diff.
+
+5. **Default/live behavior remains backward compatible and `dry_run=True`
+   default preserved.** ✅
+   - `KISClient(is_mock=False)` (the default) yields the same `_token_manager
+     = redis_token_manager` and the same `_settings_view` returning live
+     creds. The dispatch layer (`_create_kis_client`, `_call_kis`) routes
+     live calls through the existing path with no `is_mock` keyword
+     forwarded.
+   - `place_order` signature still has `dry_run: bool = True`
+     (`orders_registration.py:135`); no behavior or default changed.
+   - Legacy `account_type="paper"` and `account_type="real"` continue to
+     work, with `paper` carrying a deprecation warning and routing to the
+     paper handler exactly as before. Verified by
+     `test_paper_order_handler.py::TestPlaceOrderRegistration::test_account_type_paper_routes_to_paper_order`
+     and `test_account_type_real_still_calls_live_impl`.
+
+6. **Tests mock broker side effects and do not place orders.** ✅
+   - All new tests use `AsyncMock` / `MagicMock` for KIS and paper services.
+   - No `dry_run=False` test path was added that calls a real broker
+     dispatcher; the `_place_order_impl` call in
+     `test_account_mode_kis_mock_routes_to_order_impl_with_mock_enabled`
+     is patched to a `live_stub`.
+   - Confirmed by `grep -nE "dry_run\\s*=\\s*False" tests/test_paper_order_handler.py` — no new uses.
+
+7. **README/docs accurately describe account routing.** ✅
+   - `app/mcp_server/README.md` adds the “Account Routing” block
+     (line 118-135) describing the three modes, deprecation policy, and
+     fail-closed behavior. Public tool spec lines for `get_holdings`
+     (line 48), `get_position` (line 50), `get_order_history` (line 87),
+     and `place_order` (line 97) advertise the new `account_mode`
+     parameter.
+
+---
+
+## Findings
+
+| # | Severity | File / Line | Issue | Recommendation |
+| - | -------- | ----------- | ----- | -------------- |
+| 1 | **MEDIUM** | `app/services/brokers/kis/base.py:266`, `constants.py:4`, all `f"{constants.BASE}{...}"` callsites in `account.py` / `domestic_orders.py` / `overseas_orders.py` | KIS official mock **base URL is not switched**. Mock client still reads `kis_base_url` (or its hardcoded fallback `https://openapi.koreainvestment.com:9443`) and `constants.BASE` for trading URLs. The KIS official mock server is `https://openapivts.koreainvestment.com:29443`. Mock app keys cannot authenticate against the live auth endpoint, so once an operator sets `KIS_MOCK_ENABLED=true` plus the three mock credentials, the first read-only call (`inquire_integrated_margin`) will hit the **live** auth host with mock credentials and 401. **No live order can be placed** (the auth fails closed at the broker), so this is **not a safety violation**, but it is a functional gap that turns the “fail closed” promise into an opaque 401 instead of an explicit “mock not yet wired” error. | Either (a) add `kis_mock_base_url: str = "https://openapivts.koreainvestment.com:29443"` to `Settings`, override `kis_base_url` in `_KISSettingsView`, and route every `f"{constants.BASE}{...}"` in trading paths through a credentials/view-aware base URL; or (b) explicitly mark the kis_mock path as Phase-1 “preview only” with a guard in `KISClient.__init__(is_mock=True)` that raises a clear NotImplementedError on actual broker calls until base URL switching lands. Track as a Phase-2 follow-up issue. |
+| 2 | LOW | `orders_registration.py:33-45` vs `portfolio_holdings.py:1156-1160` (and 3 other call sites in the same file) | **Inconsistent fail-closed error shape.** `place_order` and `get_order_history` return a structured `{"success": False, "error": "...", "account_mode": "kis_mock"}` dict on missing config; `get_holdings`, `get_position`, `get_cash_balance`, and `get_available_capital` raise a bare `RuntimeError`. Tests cover both behaviors (`test_get_cash_balance_kis_mock_fails_closed` uses `pytest.raises(RuntimeError)`) so the suite is green, but downstream MCP clients now have to handle two different shapes for the same operator condition. | Standardize on the structured-error dict (preferred — matches existing in-band MCP error contract) across all kis_mock-gated surfaces. Extract a single `_kis_mock_config_error()` helper into `account_modes.py` and call it from every gated tool. |
+| 3 | LOW | `app/services/brokers/kis/client.py:43-79` | **Leaky `__getattr__` delegation in `_KISSettingsView`.** Only four fields are mock-aware (`kis_app_key`, `kis_app_secret`, `kis_account_no`, `kis_access_token`); every other settings access (notably `kis_base_url`, but also future per-account fields like rate limits) silently falls through to the live `settings`. This is the underlying cause of Finding #1. | Either replace the view with a frozen credentials dataclass that explicitly enumerates every field used by `BaseKISClient`, or document the override list at the top of `_KISSettingsView` so future contributors understand which fields are mock-isolated. |
+| 4 | LOW | `app/mcp_server/tooling/order_execution.py:56-62`, `orders_history.py:32-38`, `portfolio_holdings.py:247-250` | **Unreachable `try/except TypeError` fallback** silently routes mock to live if `KISClient.__init__` ever loses its `is_mock` kwarg. `KISClient` already accepts `is_mock` keyword-only (`client.py:96`), so the `except TypeError: return KISClient()` branch is dead code today, but it would mask a future regression. | Remove the `TypeError` fallback. If the KIS facade ever drops `is_mock`, that is a programming bug and should fail loudly, not degrade silently to live credentials. |
+| 5 | LOW | `app/mcp_server/tooling/orders_registration.py:51-58, 105-126`; `portfolio_holdings.py:1126-1136, 1175-1182, 1239-1246, 1276-1284` | **Tool description strings are stale.** They still say `"Set account_type='paper' to..."` and `"account_type='real' (default)"` and don't mention `account_mode`. The README block is updated, but the per-tool description is what the calling LLM sees in the schema first. | Append one sentence to each affected description: `"Use account_mode={'db_simulated','kis_mock','kis_live'} (preferred); account_type aliases are deprecated and emit warnings."` |
+| 6 | LOW | `env.example` | **`KIS_MOCK_*` settings not added.** The new `kis_mock_enabled`, `kis_mock_app_key`, `kis_mock_app_secret`, `kis_mock_account_no` settings are defined in `app/core/config.py:174-177` but not advertised in `env.example`. Operators copying the example file won't see them. | Append a `KIS_MOCK_*` block (variable names only, no values, comment referencing operator-managed `.env.kis-mock` injection at runtime). Plan §1 already documented this; it just wasn't carried into the diff. |
+| 7 | LOW | `tests/test_mcp_account_modes.py` | **No assertion that `RedisTokenManager("kis_mock")` produces a key namespace distinct from live.** `test_kis_token_namespace.py` from the original plan was not added. Token-cache isolation is provable by reading the constructor (`redis_token_manager.py:16-19`), but a 5-line `fakeredis`-backed test would prevent silent regressions in this load-bearing safety primitive. | Add `tests/test_kis_token_namespace.py` with two assertions: `RedisTokenManager()._token_key == "kis:access_token"` and `RedisTokenManager("kis_mock")._token_key == "kis_mock:access_token"`, plus an end-to-end fakeredis test that a token saved under `"kis_mock"` is not visible to the default-namespace manager. |
+| 8 | INFO | n/a | **Phase 1 scope is intentionally read-only-friendly + dry-run-default.** No KIS-mock smoke harness was added. The plan’s production smoke section calls for an operator-driven run; nothing in the diff blocks that, but no helper exists. | Optional: defer to Phase 2 along with the base-URL fix. |
+
+---
+
+## Test Review
+
+**Coverage of new behavior is solid where it lands; one isolation test is missing.**
+
+What is well-covered:
+- `tests/test_mcp_account_modes.py` (5 cases) — selector normalization, deprecation warnings, conflict detection, env-name-only validator. Includes a positive secret-leakage assertion.
+- `tests/test_paper_order_handler.py` (`TestPlaceOrderRegistration` and
+  `TestGetOrderHistoryRegistration` classes, ~6 new cases) — every routing
+  branch:
+  - `account_type="paper"` → paper handler, live impl never awaited.
+  - `account_mode="db_simulated"` → paper handler.
+  - `account_type="real"` → live impl, paper not called.
+  - `account_mode="kis_mock"` (mock enabled) → live impl awaited with
+    `is_mock=True`.
+  - `account_mode="kis_mock"` (mock disabled) → fails closed, live impl
+    never awaited.
+- `tests/test_mcp_portfolio_tools.py` adds `test_get_cash_balance_kis_mock_passes_is_mock` (asserts `all(is_mock for _, is_mock in calls)` across `inquire_integrated_margin`, `inquire_korea_orders`, `inquire_overseas_margin`, `inquire_overseas_orders`) and `test_get_cash_balance_kis_mock_fails_closed`.
+- All pre-existing live-path tests still pass (212 passed).
+
+What is missing or could be strengthened:
+- **Token-cache isolation test.** No test confirms that `kis:access_token` and `kis_mock:access_token` cannot collide. See Finding #7.
+- **No test for `get_holdings(account_mode="kis_mock")`** at the MCP level — only `get_cash_balance` is exercised end-to-end. The other surfaces (`get_position`, `get_holdings`, `get_available_capital`) are gated by the same validator but a routing test that asserts the mock client receives `is_mock=True` for `fetch_my_stocks` / `fetch_my_us_stocks` would mirror the cash-balance coverage.
+- **No test that mock and live clients use distinct `_token_manager` instances.** A 3-line assertion (`KISClient(is_mock=True)._token_manager is not KISClient()._token_manager`) would lock the invariant.
+- **No assertion that `_KISSettingsView` fails to leak live creds.** A targeted unit test on `_KISSettingsView(is_mock=True)` confirming that `kis_app_key` / `kis_app_secret` / `kis_account_no` come exclusively from `kis_mock_*` (and not from live `kis_*`) would close the loop on Finding #3.
+
+None of these gaps are blocking — the existing 212-pass suite covers all
+explicit safety invariants the plan called out — but they would harden the
+mock-isolation contract against future refactors.
+
+---
+
+## Final Recommendation
+
+**PASS_WITH_NOTES — safe to merge after Notes #5 and #6 are addressed.**
+
+The implementation correctly resolves the original ROB-19 ambiguity:
+`account_type="paper"` cannot accidentally reach a KIS broker, `kis_mock`
+fails closed at the MCP boundary when config is missing or disabled, mock and
+live credentials never share a token cache namespace, and no secret values
+are exposed in error messages or logs. The 212-pass suite plus ruff and
+py_compile demonstrate that the live trading path is unchanged. The plan’s
+hard safety constraints (no live orders, dry_run-default preserved, no
+fallback to live creds, no leaked secrets, no watch/intent side effects in
+tests) all hold.
+
+**Required before merge (low effort, blocks operator adoption):**
+1. Update tool description strings to advertise `account_mode` (Note #5).
+2. Add `KIS_MOCK_*` block to `env.example` (Note #6).
+
+**Strongly recommended follow-ups (Phase-2 issue, not blocking this PR):**
+3. Switch the KIS base URL by mode (Note #1) — without this, `KIS_MOCK_ENABLED=true` produces opaque 401s instead of working mock calls. File a Phase-2 follow-up Linear issue: *"ROB-19 follow-up: route KIS mock requests to openapivts:29443 host."*
+4. Standardize the kis_mock fail-closed error shape across all surfaces (Note #2).
+5. Remove the `try/except TypeError` fallbacks that silently degrade mock → live (Note #4).
+
+**Recommended hardening (cheap, defensive):**
+6. Add `tests/test_kis_token_namespace.py` (Note #7).
+7. Add per-field positive assertions for `_KISSettingsView` mock isolation (Test Review §missing).
+
+After items 1–2 are committed, this PR is ready for merge. Items 3–5 should
+be tracked as a follow-up Phase-2 issue that lands before any operator turns
+on `KIS_MOCK_ENABLED=true` in production.

--- a/env.example
+++ b/env.example
@@ -13,6 +13,17 @@ KIS_APP_SECRET=your_kis_app_secret_here
 KIS_ACCESS_TOKEN=
 # KIS 계좌번호 (형식: 12345678-01 또는 1234567801)
 KIS_ACCOUNT_NO=your_account_number_here
+# KIS API 기본 URL (실전 기본값)
+KIS_BASE_URL=https://openapi.koreainvestment.com:9443
+
+# KIS official mock/sandbox account settings.
+# Keep credential values in operator-managed runtime env files; do not commit them.
+KIS_MOCK_ENABLED=false
+KIS_MOCK_APP_KEY=
+KIS_MOCK_APP_SECRET=
+KIS_MOCK_ACCOUNT_NO=
+KIS_MOCK_BASE_URL=https://openapivts.koreainvestment.com:29443
+KIS_MOCK_ACCESS_TOKEN=
 
 # KIS WebSocket 설정
 # ========================================

--- a/tests/test_kis_mock_routing.py
+++ b/tests/test_kis_mock_routing.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def test_kis_mock_settings_view_uses_mock_base_url(monkeypatch):
+    from app.services.brokers.kis.client import KISClient
+
+    monkeypatch.setattr(
+        "app.services.brokers.kis.client.settings.kis_base_url",
+        "https://live.example.invalid",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.brokers.kis.client.settings.kis_mock_base_url",
+        "https://mock.example.invalid",
+        raising=False,
+    )
+
+    client = KISClient(is_mock=True)
+
+    assert client._settings.kis_base_url == "https://mock.example.invalid"
+    assert client._kis_url("/uapi/test") == "https://mock.example.invalid/uapi/test"
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_fetch_token_posts_to_mock_base_url(monkeypatch):
+    from app.services.brokers.kis.client import KISClient
+
+    monkeypatch.setattr(
+        "app.services.brokers.kis.client.settings.kis_mock_base_url",
+        "https://mock.example.invalid",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.brokers.kis.client.settings.kis_mock_app_key",
+        "mock-key",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.services.brokers.kis.client.settings.kis_mock_app_secret",
+        "mock-secret",
+        raising=False,
+    )
+
+    response = MagicMock()
+    response.json.return_value = {"access_token": "token", "expires_in": 1234}
+    http_client = AsyncMock()
+    http_client.post.return_value = response
+
+    client = KISClient(is_mock=True)
+    monkeypatch.setattr(client, "_ensure_client", AsyncMock(return_value=http_client))
+
+    token, expires_in = await client._fetch_token()
+
+    assert token == "token"
+    assert expires_in == 1234
+    assert http_client.post.await_args.args[0] == (
+        "https://mock.example.invalid/oauth2/token"
+    )
+
+
+def test_order_execution_mock_client_factory_does_not_fallback_to_live(monkeypatch):
+    from app.mcp_server.tooling import order_execution
+
+    class BrokenKISClient:
+        def __init__(self, *, is_mock: bool = False) -> None:
+            if is_mock:
+                raise TypeError("is_mock unsupported")
+
+    monkeypatch.setattr(order_execution, "KISClient", BrokenKISClient)
+
+    with pytest.raises(TypeError, match="is_mock unsupported"):
+        order_execution._create_kis_client(is_mock=True)
+
+
+def test_orders_history_mock_client_factory_does_not_fallback_to_live(monkeypatch):
+    from app.mcp_server.tooling import orders_history
+
+    class BrokenKISClient:
+        def __init__(self, *, is_mock: bool = False) -> None:
+            if is_mock:
+                raise TypeError("is_mock unsupported")
+
+    monkeypatch.setattr(orders_history, "KISClient", BrokenKISClient)
+
+    with pytest.raises(TypeError, match="is_mock unsupported"):
+        orders_history._create_kis_client(is_mock=True)
+
+
+def test_portfolio_cash_mock_client_factory_does_not_fallback_to_live(monkeypatch):
+    from app.mcp_server.tooling import portfolio_cash
+
+    class BrokenKISClient:
+        def __init__(self, *, is_mock: bool = False) -> None:
+            if is_mock:
+                raise TypeError("is_mock unsupported")
+
+    monkeypatch.setattr(portfolio_cash, "KISClient", BrokenKISClient)
+
+    with pytest.raises(TypeError, match="is_mock unsupported"):
+        portfolio_cash._create_kis_client(is_mock=True)
+
+
+def test_order_validation_mock_client_factory_does_not_fallback_to_live(monkeypatch):
+    from app.mcp_server.tooling import order_validation
+
+    class BrokenKISClient:
+        def __init__(self, *, is_mock: bool = False) -> None:
+            if is_mock:
+                raise TypeError("is_mock unsupported")
+
+    monkeypatch.setattr(order_validation, "KISClient", BrokenKISClient)
+
+    with pytest.raises(TypeError, match="is_mock unsupported"):
+        order_validation._create_kis_client(is_mock=True)
+
+
+@pytest.mark.asyncio
+async def test_portfolio_holdings_mock_collection_does_not_fallback_to_live(
+    monkeypatch,
+):
+    from app.mcp_server.tooling import portfolio_holdings
+
+    class BrokenKISClient:
+        def __init__(self, *, is_mock: bool = False) -> None:
+            if is_mock:
+                raise TypeError("is_mock unsupported")
+
+    monkeypatch.setattr(portfolio_holdings, "KISClient", BrokenKISClient)
+
+    with pytest.raises(TypeError, match="is_mock unsupported"):
+        await portfolio_holdings._collect_kis_positions(None, is_mock=True)

--- a/tests/test_mcp_account_modes.py
+++ b/tests/test_mcp_account_modes.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+
+
+def test_default_account_mode_is_kis_live():
+    from app.mcp_server.tooling.account_modes import normalize_account_mode
+
+    routing = normalize_account_mode()
+
+    assert routing.account_mode == "kis_live"
+    assert routing.is_kis_live is True
+    assert routing.warnings == []
+
+
+def test_account_type_paper_is_db_simulated_alias():
+    from app.mcp_server.tooling.account_modes import normalize_account_mode
+
+    routing = normalize_account_mode(account_type="paper")
+
+    assert routing.account_mode == "db_simulated"
+    assert routing.is_db_simulated is True
+    assert routing.deprecated_alias_used is True
+    assert routing.warnings
+
+
+def test_account_mode_simulated_is_db_simulated_alias():
+    from app.mcp_server.tooling.account_modes import normalize_account_mode
+
+    routing = normalize_account_mode(account_mode="simulated")
+
+    assert routing.account_mode == "db_simulated"
+    assert routing.is_db_simulated is True
+    assert routing.deprecated_alias_used is True
+
+
+def test_account_mode_kis_mock_is_official_kis_mock():
+    from app.mcp_server.tooling.account_modes import normalize_account_mode
+
+    routing = normalize_account_mode(account_mode="kis_mock")
+
+    assert routing.account_mode == "kis_mock"
+    assert routing.is_kis_mock is True
+    assert routing.is_db_simulated is False
+
+
+def test_conflicting_account_selectors_fail():
+    from app.mcp_server.tooling.account_modes import normalize_account_mode
+
+    with pytest.raises(ValueError, match="conflicting account selectors"):
+        normalize_account_mode(account_mode="kis_mock", account_type="paper")
+
+
+def test_validate_kis_mock_config_reports_names_only():
+    from app.core.config import validate_kis_mock_config
+
+    class DummySettings:
+        kis_mock_enabled = False
+        kis_mock_app_key = None
+        kis_mock_app_secret = "secret-value"
+        kis_mock_account_no = ""
+
+    missing = validate_kis_mock_config(DummySettings())
+
+    assert missing == [
+        "KIS_MOCK_ENABLED",
+        "KIS_MOCK_APP_KEY",
+        "KIS_MOCK_ACCOUNT_NO",
+    ]
+    assert "secret-value" not in repr(missing)

--- a/tests/test_mcp_available_capital.py
+++ b/tests/test_mcp_available_capital.py
@@ -10,7 +10,7 @@ async def test_get_available_capital_aggregates_accounts_and_manual_cash(monkeyp
     """Test that get_available_capital aggregates broker accounts and manual cash."""
     from app.mcp_server.tooling import portfolio_cash
 
-    async def mock_get_cash_balance_impl(account=None):
+    async def mock_get_cash_balance_impl(account=None, **_kwargs):
         return {
             "accounts": [
                 {
@@ -82,7 +82,7 @@ async def test_get_available_capital_excludes_manual_when_flag_disabled(monkeypa
     """Test that include_manual=False excludes manual cash from aggregation."""
     from app.mcp_server.tooling import portfolio_cash
 
-    async def mock_get_cash_balance_impl(account=None):
+    async def mock_get_cash_balance_impl(account=None, **_kwargs):
         return {
             "accounts": [
                 {"account": "upbit", "currency": "KRW", "orderable": 1000000.0},
@@ -120,7 +120,7 @@ async def test_get_available_capital_handles_missing_manual_cash(monkeypatch):
     """Test that missing manual cash is handled gracefully (amount = 0)."""
     from app.mcp_server.tooling import portfolio_cash
 
-    async def mock_get_cash_balance_impl(account=None):
+    async def mock_get_cash_balance_impl(account=None, **_kwargs):
         return {
             "accounts": [
                 {"account": "upbit", "currency": "KRW", "orderable": 1000000.0}
@@ -154,7 +154,7 @@ async def test_get_available_capital_marks_stale_manual_cash(monkeypatch):
     """Test that manual cash older than 3 days gets stale_warning=True."""
     from app.mcp_server.tooling import portfolio_cash
 
-    async def mock_get_cash_balance_impl(account=None):
+    async def mock_get_cash_balance_impl(account=None, **_kwargs):
         return {
             "accounts": [],
             "summary": {"total_krw": 0.0, "total_usd": 0.0},
@@ -193,7 +193,7 @@ async def test_get_available_capital_toss_filter_uses_manual_cash_path(monkeypat
 
     cash_balance_calls = []
 
-    async def mock_get_cash_balance_impl(account=None):
+    async def mock_get_cash_balance_impl(account=None, **_kwargs):
         cash_balance_calls.append(account)
         return {
             "accounts": [],

--- a/tests/test_mcp_portfolio_tools.py
+++ b/tests/test_mcp_portfolio_tools.py
@@ -90,6 +90,9 @@ async def test_get_cash_balance_kis_mock_passes_is_mock(monkeypatch):
     calls: list[tuple[str, bool]] = []
 
     class MockKISClient:
+        def __init__(self, *, is_mock: bool = False) -> None:
+            self.is_mock = is_mock
+
         async def inquire_integrated_margin(self, is_mock=False):
             calls.append(("integrated", is_mock))
             return {

--- a/tests/test_mcp_portfolio_tools.py
+++ b/tests/test_mcp_portfolio_tools.py
@@ -85,6 +85,64 @@ async def test_get_cash_balance_all_accounts(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_cash_balance_kis_mock_passes_is_mock(monkeypatch):
+    tools = build_tools()
+    calls: list[tuple[str, bool]] = []
+
+    class MockKISClient:
+        async def inquire_integrated_margin(self, is_mock=False):
+            calls.append(("integrated", is_mock))
+            return {
+                "stck_cash_objt_amt": "100000.0",
+                "stck_cash100_max_ord_psbl_amt": "80000.0",
+            }
+
+        async def inquire_korea_orders(self, is_mock=False):
+            calls.append(("kr_orders", is_mock))
+            return []
+
+        async def inquire_overseas_margin(self, is_mock=False):
+            calls.append(("overseas", is_mock))
+            return [
+                {
+                    "natn_name": "United States",
+                    "crcy_cd": "USD",
+                    "frcr_dncl_amt1": "25.0",
+                    "frcr_gnrl_ord_psbl_amt": "20.0",
+                }
+            ]
+
+        async def inquire_overseas_orders(self, exchange_code="NASD", is_mock=False):
+            del exchange_code
+            calls.append(("us_orders", is_mock))
+            return []
+
+    _patch_runtime_attr(monkeypatch, "KISClient", MockKISClient)
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.portfolio_holdings.validate_kis_mock_config",
+        lambda: [],
+    )
+
+    result = await tools["get_cash_balance"](account_mode="kis_mock")
+
+    assert result["account_mode"] == "kis_mock"
+    assert calls
+    assert all(is_mock for _, is_mock in calls)
+
+
+@pytest.mark.asyncio
+async def test_get_cash_balance_kis_mock_fails_closed(monkeypatch):
+    tools = build_tools()
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.portfolio_holdings.validate_kis_mock_config",
+        lambda: ["KIS_MOCK_ENABLED"],
+    )
+
+    with pytest.raises(RuntimeError, match="KIS_MOCK_ENABLED"):
+        await tools["get_cash_balance"](account_mode="kis_mock")
+
+
+@pytest.mark.asyncio
 async def test_get_cash_balance_with_account_filter(monkeypatch):
     tools = build_tools()
 

--- a/tests/test_paper_order_handler.py
+++ b/tests/test_paper_order_handler.py
@@ -510,6 +510,98 @@ class TestPlaceOrderRegistration:
         live_stub.assert_awaited_once()
         paper_stub.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_account_mode_kis_mock_routes_to_order_impl_with_mock_enabled(self):
+        from app.mcp_server.tooling import orders_registration
+
+        registered: dict[str, Any] = {}
+
+        class DummyMCP:
+            def tool(self, name: str, description: str):
+                def _wrap(fn):
+                    registered[name] = fn
+                    return fn
+
+                return _wrap
+
+        orders_registration.register_order_tools(DummyMCP())
+        place_order = registered["place_order"]
+
+        live_stub = AsyncMock(
+            return_value={"success": True, "dry_run": True, "source": "kis"}
+        )
+
+        with (
+            patch.object(
+                orders_registration,
+                "validate_kis_mock_config",
+                return_value=[],
+            ),
+            patch.object(
+                orders_registration.order_execution,
+                "_place_order_impl",
+                live_stub,
+            ),
+        ):
+            result = await place_order(
+                symbol="005930",
+                side="buy",
+                order_type="limit",
+                quantity=10,
+                price=70000,
+                account_mode="kis_mock",
+            )
+
+        assert result["account_mode"] == "kis_mock"
+        live_stub.assert_awaited_once()
+        assert live_stub.await_args.kwargs["is_mock"] is True
+
+    @pytest.mark.asyncio
+    async def test_account_mode_kis_mock_fails_closed_before_broker_call(self):
+        from app.mcp_server.tooling import orders_registration
+
+        registered: dict[str, Any] = {}
+
+        class DummyMCP:
+            def tool(self, name: str, description: str):
+                def _wrap(fn):
+                    registered[name] = fn
+                    return fn
+
+                return _wrap
+
+        orders_registration.register_order_tools(DummyMCP())
+        place_order = registered["place_order"]
+
+        live_stub = AsyncMock()
+
+        with (
+            patch.object(
+                orders_registration,
+                "validate_kis_mock_config",
+                return_value=["KIS_MOCK_ENABLED", "KIS_MOCK_APP_KEY"],
+            ),
+            patch.object(
+                orders_registration.order_execution,
+                "_place_order_impl",
+                live_stub,
+            ),
+        ):
+            result = await place_order(
+                symbol="005930",
+                side="buy",
+                order_type="limit",
+                quantity=10,
+                price=70000,
+                account_mode="kis_mock",
+            )
+
+        assert result["success"] is False
+        assert result["account_mode"] == "kis_mock"
+        assert "KIS_MOCK_ENABLED" in result["error"]
+        assert "KIS_MOCK_APP_KEY" in result["error"]
+        live_stub.assert_not_called()
+
 
 class TestGetOrderHistoryRegistration:
     @pytest.mark.asyncio
@@ -588,3 +680,43 @@ class TestGetOrderHistoryRegistration:
         assert result["success"] is True
         live_stub.assert_awaited_once()
         paper_stub.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_account_mode_kis_mock_routes_history_with_mock_enabled(self):
+        from app.mcp_server.tooling import orders_registration
+
+        registered: dict[str, Any] = {}
+
+        class DummyMCP:
+            def tool(self, name: str, description: str):
+                def _wrap(fn):
+                    registered[name] = fn
+                    return fn
+
+                return _wrap
+
+        orders_registration.register_order_tools(DummyMCP())
+        get_order_history = registered["get_order_history"]
+
+        live_stub = AsyncMock(return_value={"success": True, "orders": []})
+
+        with (
+            patch.object(
+                orders_registration,
+                "validate_kis_mock_config",
+                return_value=[],
+            ),
+            patch.object(
+                orders_registration.orders_history,
+                "get_order_history_impl",
+                live_stub,
+            ),
+        ):
+            result = await get_order_history(
+                symbol="005930",
+                account_mode="kis_mock",
+            )
+
+        assert result["account_mode"] == "kis_mock"
+        live_stub.assert_awaited_once()
+        assert live_stub.await_args.kwargs["is_mock"] is True


### PR DESCRIPTION
## Summary

Normalizes simulated vs KIS mock/live account routing:
- Adds explicit account mode selection so `account_type="paper"` remains DB simulation only.
- Adds fail-closed KIS mock credentials/settings plumbing with mock/live token namespace isolation.
- Extends KIS read paths and dry-run preview paths to accept `account_mode="kis_mock"` without live fallback.
- Documents KIS mock env placeholders and MCP account-mode contract.

## Safety

- No live orders.
- `dry_run=True` defaults preserved.
- KIS mock config fails closed if disabled or incomplete.
- KIS mock uses mock settings, mock base URL, and separate token/cache namespace.
- Removed TypeError fallback patterns that could silently route mock to live.
- Secrets are not printed, logged, or documented.

## Verification

- `uv run pytest tests/test_kis_mock_routing.py tests/test_mcp_account_modes.py tests/test_paper_order_handler.py tests/test_mcp_portfolio_tools.py tests/test_mcp_order_tools.py tests/test_mcp_place_order.py tests/test_kis_order_ops.py -q` => 219 passed
- `uv run ruff check app tests` => passed
- `uv run python -m py_compile $(rg --files app tests -g '*.py')` => passed

## Review

- Initial Opus review: `PASS_WITH_NOTES`
- Fix commit: `f9f1d883 fix(rob-19): harden kis mock routing safeguards`
- Final Opus signoff: `PASS`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced account routing system (`account_mode` parameter) for portfolio and order tools, enabling selection between database simulation, KIS mock/sandbox, and live account modes.
  * Added KIS mock/sandbox configuration support with environment variables for safe testing.

* **Documentation**
  * Updated all portfolio and order management tools with new `account_mode` parameter documentation.
  * Added environment configuration examples for KIS mock/sandbox credentials.
  * Deprecated `account_type="paper"` in favor of `account_mode="db_simulated"`.

* **Tests**
  * Added comprehensive test coverage for account mode routing and KIS mock behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->