### PR TITLE
fix: use KIS mock domestic cash for order balance checks

### DIFF
--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -261,6 +261,12 @@ async def _get_balance_for_order(market_type: str, is_mock: bool = False) -> flo
 
     if market_type == "equity_kr":
         kis = _create_kis_client(is_mock=is_mock)
+        if is_mock:
+            cash_summary = await _call_kis(
+                kis.inquire_domestic_cash_balance,
+                is_mock=is_mock,
+            )
+            return float(cash_summary.get("stck_cash_ord_psbl_amt") or 0)
         margin_data = await _call_kis(
             kis.inquire_integrated_margin,
             is_mock=is_mock,

--- a/tests/test_kis_mock_routing.py
+++ b/tests/test_kis_mock_routing.py
@@ -157,6 +157,31 @@ def test_order_validation_mock_client_factory_does_not_fallback_to_live(monkeypa
 
 
 @pytest.mark.asyncio
+async def test_order_validation_kis_mock_balance_uses_domestic_cash_not_integrated_margin(
+    monkeypatch,
+):
+    from app.mcp_server.tooling import order_validation
+
+    fake_kis = MagicMock()
+    fake_kis.inquire_integrated_margin = AsyncMock(
+        side_effect=AssertionError("must not call integrated margin in mock")
+    )
+    fake_kis.inquire_domestic_cash_balance = AsyncMock(
+        return_value={"stck_cash_ord_psbl_amt": "900000", "dnca_tot_amt": "1000000"}
+    )
+
+    monkeypatch.setattr(
+        order_validation, "_create_kis_client", lambda *, is_mock: fake_kis
+    )
+
+    balance = await order_validation._get_balance_for_order("equity_kr", is_mock=True)
+
+    assert balance == pytest.approx(900000.0)
+    fake_kis.inquire_integrated_margin.assert_not_called()
+    fake_kis.inquire_domestic_cash_balance.assert_awaited_once_with(is_mock=True)
+
+
+@pytest.mark.asyncio
 async def test_portfolio_holdings_mock_collection_does_not_fallback_to_live(
     monkeypatch,
 ):


### PR DESCRIPTION
## Summary
- Fix KIS mock KR order dry-run balance precheck to use domestic mock cash (`VTTC8434R`) instead of live-only integrated margin.
- Add regression test proving the mock balance path never calls integrated margin.

## Safety
- No live order behavior intended.
- `kis_live` path remains integrated-margin based.
- This unblocks `account_mode="kis_mock"` dry-run/order preview for KR mock pilot.

## Test Plan
- `uv run pytest tests/test_kis_mock_routing.py::test_order_validation_kis_mock_balance_uses_domestic_cash_not_integrated_margin -q`
- `uv run pytest tests/test_kis_mock_routing.py tests/test_portfolio_cash_kis_mock.py tests/test_kis_domestic_pending_mock.py tests/test_orders_history_kis_mock.py -q`
- `uv run ruff format --check app/mcp_server/tooling/order_validation.py tests/test_kis_mock_routing.py`
- `uv run ruff check app/mcp_server/tooling/order_validation.py tests/test_kis_mock_routing.py`