### PR TITLE
feat(ROB-37): isolate KIS mock order ledger

### DIFF
--- a/alembic/versions/d3703007a676_add_kis_mock_order_ledger.py
+++ b/alembic/versions/d3703007a676_add_kis_mock_order_ledger.py
@@ -1,0 +1,124 @@
+"""add kis_mock_order_ledger
+
+Revision ID: d3703007a676
+Revises: d34d6def084b
+Create Date: 2026-04-29 11:02:14.936643
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "d3703007a676"
+down_revision: Union[str, Sequence[str], None] = "d34d6def084b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+instrument_type_enum = postgresql.ENUM(
+    "equity_kr",
+    "equity_us",
+    "crypto",
+    "forex",
+    "index",
+    name="instrument_type",
+    create_type=False,
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "kis_mock_order_ledger",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("trade_date", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column("instrument_type", instrument_type_enum, nullable=False),
+        sa.Column("side", sa.Text(), nullable=False),
+        sa.Column(
+            "order_type", sa.Text(), nullable=False, server_default="limit"
+        ),
+        sa.Column("quantity", sa.Numeric(20, 8), nullable=False),
+        sa.Column("price", sa.Numeric(20, 4), nullable=False),
+        sa.Column(
+            "amount", sa.Numeric(20, 4), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "fee", sa.Numeric(20, 4), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "currency", sa.Text(), nullable=False, server_default="KRW"
+        ),
+        sa.Column("order_no", sa.Text(), nullable=True),
+        sa.Column("order_time", sa.Text(), nullable=True),
+        sa.Column("krx_fwdg_ord_orgno", sa.Text(), nullable=True),
+        sa.Column(
+            "account_mode", sa.Text(), nullable=False, server_default="kis_mock"
+        ),
+        sa.Column(
+            "broker", sa.Text(), nullable=False, server_default="kis"
+        ),
+        sa.Column(
+            "status", sa.Text(), nullable=False, server_default="unknown"
+        ),
+        sa.Column("response_code", sa.Text(), nullable=True),
+        sa.Column("response_message", sa.Text(), nullable=True),
+        sa.Column("raw_response", postgresql.JSONB(), nullable=True),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("thesis", sa.Text(), nullable=True),
+        sa.Column("strategy", sa.Text(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("order_no", name="uq_kis_mock_ledger_order_no"),
+        sa.CheckConstraint(
+            "side IN ('buy','sell')", name="kis_mock_ledger_side"
+        ),
+        sa.CheckConstraint(
+            "currency IN ('KRW','USD')", name="kis_mock_ledger_currency"
+        ),
+        sa.CheckConstraint(
+            "account_mode = 'kis_mock'",
+            name="kis_mock_ledger_account_mode_kis_mock",
+        ),
+        sa.CheckConstraint(
+            "broker = 'kis'", name="kis_mock_ledger_broker_kis"
+        ),
+        sa.CheckConstraint(
+            "status IN ('accepted','rejected','unknown')",
+            name="kis_mock_ledger_status_allowed",
+        ),
+        schema="review",
+    )
+    op.create_index(
+        "ix_kis_mock_ledger_trade_date",
+        "kis_mock_order_ledger",
+        ["trade_date"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_kis_mock_ledger_symbol",
+        "kis_mock_order_ledger",
+        ["symbol"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_kis_mock_ledger_symbol",
+        table_name="kis_mock_order_ledger",
+        schema="review",
+    )
+    op.drop_index(
+        "ix_kis_mock_ledger_trade_date",
+        table_name="kis_mock_order_ledger",
+        schema="review",
+    )
+    op.drop_table("kis_mock_order_ledger", schema="review")

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -1,0 +1,171 @@
+"""KIS mock order ledger writes — fully isolated from live journal/fill paths."""
+
+from __future__ import annotations
+
+from typing import Any
+from typing import cast as typing_cast
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.core.db import AsyncSessionLocal
+from app.core.timezone import now_kst
+from app.mcp_server.tooling.shared import logger
+from app.mcp_server.tooling.shared import to_float as _to_float
+from app.models.review import KISMockOrderLedger
+
+
+def _order_session_factory() -> async_sessionmaker[AsyncSession]:
+    return typing_cast(
+        async_sessionmaker[AsyncSession], typing_cast(object, AsyncSessionLocal)
+    )
+
+
+async def _save_kis_mock_order_ledger(
+    *,
+    symbol: str,
+    instrument_type: str,
+    side: str,
+    order_type: str,
+    quantity: float,
+    price: float,
+    amount: float,
+    currency: str,
+    order_no: str | None,
+    order_time: str | None,
+    krx_fwdg_ord_orgno: str | None,
+    status: str,
+    response_code: str | None,
+    response_message: str | None,
+    raw_response: dict[str, Any] | None,
+    reason: str | None,
+    thesis: str | None,
+    strategy: str | None,
+    notes: str | None,
+) -> int | None:
+    """Insert one row into review.kis_mock_order_ledger.
+
+    Returns the new primary-key id, or None on conflict / error.
+    """
+    try:
+        async with _order_session_factory()() as db:
+            stmt = (
+                pg_insert(KISMockOrderLedger)
+                .values(
+                    trade_date=now_kst(),
+                    symbol=symbol,
+                    instrument_type=instrument_type,
+                    side=side,
+                    order_type=order_type,
+                    quantity=quantity,
+                    price=price,
+                    amount=amount,
+                    fee=0,
+                    currency=currency,
+                    order_no=order_no,
+                    order_time=order_time,
+                    krx_fwdg_ord_orgno=krx_fwdg_ord_orgno,
+                    account_mode="kis_mock",
+                    broker="kis",
+                    status=status,
+                    response_code=response_code,
+                    response_message=response_message,
+                    raw_response=raw_response,
+                    reason=(reason or None),
+                    thesis=thesis,
+                    strategy=strategy,
+                    notes=notes,
+                )
+                .on_conflict_do_nothing(constraint="uq_kis_mock_ledger_order_no")
+            )
+            result = await db.execute(stmt)
+            await db.commit()
+            if result.inserted_primary_key and result.inserted_primary_key[0]:
+                return typing_cast(int, result.inserted_primary_key[0])
+            return None
+    except Exception as exc:
+        logger.warning("Failed to save kis_mock order ledger row: %s", exc)
+        return None
+
+
+async def _record_kis_mock_order(
+    *,
+    normalized_symbol: str,
+    market_type: str,
+    side: str,
+    order_type: str,
+    dry_run_result: dict[str, Any],
+    execution_result: dict[str, Any],
+    reason: str | None,
+    thesis: str | None,
+    strategy: str | None,
+    notes: str | None,
+) -> dict[str, Any]:
+    """Build ledger row from execution result and return the mock-order response dict."""
+    price_val = _to_float(dry_run_result.get("price"), default=0.0)
+    qty_val = _to_float(dry_run_result.get("quantity"), default=0.0)
+    amt_val = _to_float(dry_run_result.get("estimated_value"), default=0.0)
+    currency = "KRW" if market_type != "equity_us" else "USD"
+
+    order_no = execution_result.get("odno") or execution_result.get("ord_no")
+    order_time = execution_result.get("ord_tmd")
+    raw_output = execution_result.get("output") or {}
+    krx_orgno = execution_result.get("krx_fwdg_ord_orgno") or raw_output.get(
+        "KRX_FWDG_ORD_ORGNO"
+    )
+    rt_cd = str(execution_result.get("rt_cd", "")) or None
+    msg = execution_result.get("msg") or execution_result.get("msg1")
+
+    if rt_cd == "0":
+        status = "accepted"
+    elif rt_cd and rt_cd != "0":
+        status = "rejected"
+    else:
+        status = "accepted" if order_no else "unknown"
+
+    ledger_id = await _save_kis_mock_order_ledger(
+        symbol=normalized_symbol,
+        instrument_type=market_type,
+        side=side,
+        order_type=order_type,
+        quantity=qty_val,
+        price=price_val,
+        amount=amt_val,
+        currency=currency,
+        order_no=str(order_no) if order_no else None,
+        order_time=order_time,
+        krx_fwdg_ord_orgno=krx_orgno,
+        status=status,
+        response_code=rt_cd,
+        response_message=msg,
+        raw_response=execution_result,
+        reason=reason,
+        thesis=thesis,
+        strategy=strategy,
+        notes=notes,
+    )
+
+    return {
+        "success": True,
+        "dry_run": False,
+        "preview": dry_run_result,
+        "execution": execution_result,
+        "account_mode": "kis_mock",
+        "broker": "kis",
+        "ledger_id": ledger_id,
+        "order_no": str(order_no) if order_no else None,
+        "odno": str(order_no) if order_no else None,
+        "order_time": order_time,
+        "ord_tmd": order_time,
+        "krx_fwdg_ord_orgno": krx_orgno,
+        "status": status,
+        "response_code": rt_cd,
+        "response_message": msg,
+        "fill_recorded": False,
+        "journal_created": False,
+        "message": (
+            "KIS mock order recorded to kis_mock_order_ledger"
+            if ledger_id
+            else "KIS mock order accepted but ledger insert returned no id"
+        ),
+    }

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -680,6 +680,23 @@ async def _execute_and_record(
         caller_source=get_caller_source() if defensive_trim_ctx else None,
     )
 
+    # KIS mock: write to dedicated ledger, skip live journal/fill paths entirely.
+    if is_mock:
+        from app.mcp_server.tooling.kis_mock_ledger import _record_kis_mock_order
+
+        return await _record_kis_mock_order(
+            normalized_symbol=normalized_symbol,
+            market_type=market_type,
+            side=side,
+            order_type=order_type,
+            dry_run_result=dry_run_result,
+            execution_result=execution_result,
+            reason=reason,
+            thesis=thesis,
+            strategy=strategy,
+            notes=notes,
+        )
+
     # Record phase: fills + journals
     record_result = await _record_fill_and_journals(
         side=side,
@@ -762,22 +779,25 @@ async def _place_order_impl(
 
     market_type, normalized_symbol = _resolve_market_type(symbol, market)
 
-    # Validate buy order journal requirements before any external API calls
-    try:
-        _validate_buy_journal_requirements(
-            side=side_lower,
-            dry_run=dry_run,
-            thesis=thesis,
-            strategy=strategy,
-        )
-    except ValueError as e:
-        return {
-            "success": False,
-            "error": str(e),
-            "source": "upbit" if market_type == "crypto" else "kis",
-            "symbol": normalized_symbol,
-            "instrument_type": market_type,
-        }
+    # Validate buy order journal requirements before any external API calls.
+    # Skipped for KIS mock: mock orders write to kis_mock_order_ledger and
+    # never create a TradeJournal, so thesis/strategy are optional.
+    if not is_mock:
+        try:
+            _validate_buy_journal_requirements(
+                side=side_lower,
+                dry_run=dry_run,
+                thesis=thesis,
+                strategy=strategy,
+            )
+        except ValueError as e:
+            return {
+                "success": False,
+                "error": str(e),
+                "source": "upbit" if market_type == "crypto" else "kis",
+                "symbol": normalized_symbol,
+                "instrument_type": market_type,
+            }
 
     source_map = {"crypto": "upbit", "equity_kr": "kis", "equity_us": "kis"}
     source = source_map[market_type]

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
@@ -162,6 +163,66 @@ class PendingSnapshot(Base):
     order_id: Mapped[str | None] = mapped_column(Text)
     resolved_as: Mapped[str] = mapped_column(Text, nullable=False, default="pending")
     resolved_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+# ---------------------------------------------------------------------------
+# review.kis_mock_order_ledger — KIS official-mock execution records (ROB-37)
+# Fully isolated from live review.trades / TradeJournal paths.
+# ---------------------------------------------------------------------------
+class KISMockOrderLedger(Base):
+    __tablename__ = "kis_mock_order_ledger"
+    __table_args__ = (
+        UniqueConstraint("order_no", name="uq_kis_mock_ledger_order_no"),
+        CheckConstraint("side IN ('buy','sell')", name="kis_mock_ledger_side"),
+        CheckConstraint("currency IN ('KRW','USD')", name="kis_mock_ledger_currency"),
+        CheckConstraint(
+            "account_mode = 'kis_mock'", name="kis_mock_ledger_account_mode_kis_mock"
+        ),
+        CheckConstraint("broker = 'kis'", name="kis_mock_ledger_broker_kis"),
+        CheckConstraint(
+            "status IN ('accepted','rejected','unknown')",
+            name="kis_mock_ledger_status_allowed",
+        ),
+        Index("ix_kis_mock_ledger_trade_date", "trade_date"),
+        Index("ix_kis_mock_ledger_symbol", "symbol"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    trade_date: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    instrument_type: Mapped[InstrumentType] = mapped_column(
+        Enum(InstrumentType, name="instrument_type", create_type=False), nullable=False
+    )
+    side: Mapped[str] = mapped_column(Text, nullable=False)
+    order_type: Mapped[str] = mapped_column(Text, nullable=False, default="limit")
+    quantity: Mapped[float] = mapped_column(Numeric(20, 8), nullable=False)
+    price: Mapped[float] = mapped_column(Numeric(20, 4), nullable=False)
+    amount: Mapped[float] = mapped_column(Numeric(20, 4), nullable=False, default=0)
+    fee: Mapped[float] = mapped_column(Numeric(20, 4), nullable=False, default=0)
+    currency: Mapped[str] = mapped_column(Text, nullable=False, default="KRW")
+
+    order_no: Mapped[str | None] = mapped_column(Text)
+    order_time: Mapped[str | None] = mapped_column(Text)
+    krx_fwdg_ord_orgno: Mapped[str | None] = mapped_column(Text)
+
+    account_mode: Mapped[str] = mapped_column(Text, nullable=False, default="kis_mock")
+    broker: Mapped[str] = mapped_column(Text, nullable=False, default="kis")
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="unknown")
+    response_code: Mapped[str | None] = mapped_column(Text)
+    response_message: Mapped[str | None] = mapped_column(Text)
+    raw_response: Mapped[dict | None] = mapped_column(JSONB)
+
+    reason: Mapped[str | None] = mapped_column(Text)
+    thesis: Mapped[str | None] = mapped_column(Text)
+    strategy: Mapped[str | None] = mapped_column(Text)
+    notes: Mapped[str | None] = mapped_column(Text)
+
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
     )

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -1,0 +1,538 @@
+"""Tests for KIS mock order ledger (ROB-37).
+
+Covers:
+- ORM model columns/constraints
+- _save_kis_mock_order_ledger helper
+- buy/sell execution writes ledger and skips live journal/fill paths
+- fail-closed config behaviour
+- live-path unchanged regression
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Task 1: model shape
+# ---------------------------------------------------------------------------
+
+
+def test_model_columns_and_constraints():
+    from app.models.review import KISMockOrderLedger
+
+    cols = {c.name for c in KISMockOrderLedger.__table__.columns}
+    assert {
+        "id",
+        "trade_date",
+        "symbol",
+        "instrument_type",
+        "side",
+        "order_type",
+        "quantity",
+        "price",
+        "amount",
+        "fee",
+        "currency",
+        "order_no",
+        "order_time",
+        "krx_fwdg_ord_orgno",
+        "account_mode",
+        "broker",
+        "status",
+        "response_code",
+        "response_message",
+        "raw_response",
+        "reason",
+        "thesis",
+        "strategy",
+        "notes",
+        "created_at",
+    } <= cols
+    assert KISMockOrderLedger.__table__.schema == "review"
+    # Naming convention: ck_%(table_name)s_%(constraint_name)s
+    constraint_names = {c.name for c in KISMockOrderLedger.__table__.constraints}
+    assert "uq_kis_mock_ledger_order_no" in constraint_names
+    assert any(
+        "kis_mock_ledger_account_mode_kis_mock" in (n or "") for n in constraint_names
+    )
+    assert any("kis_mock_ledger_broker_kis" in (n or "") for n in constraint_names)
+    assert any("kis_mock_ledger_status_allowed" in (n or "") for n in constraint_names)
+
+
+# ---------------------------------------------------------------------------
+# Task 3: helper insert
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_save_helper_inserts_row(monkeypatch):
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    captured: dict = {}
+
+    class FakeResult:
+        inserted_primary_key = (123,)
+
+    class FakeDB:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            pass
+
+        async def execute(self, stmt):
+            captured["stmt"] = stmt
+            return FakeResult()
+
+        async def commit(self):
+            pass
+
+    def fake_factory():
+        return lambda: FakeDB()
+
+    monkeypatch.setattr(kis_mock_ledger, "_order_session_factory", fake_factory)
+
+    ledger_id = await kis_mock_ledger._save_kis_mock_order_ledger(
+        symbol="005930",
+        instrument_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        quantity=10,
+        price=70000,
+        amount=700000,
+        currency="KRW",
+        order_no="0001234567",
+        order_time="091500",
+        krx_fwdg_ord_orgno=None,
+        status="accepted",
+        response_code="0",
+        response_message="정상처리",
+        raw_response={"rt_cd": "0", "output": {"ODNO": "0001234567"}},
+        reason="t",
+        thesis=None,
+        strategy=None,
+        notes=None,
+    )
+    assert ledger_id == 123
+
+
+# ---------------------------------------------------------------------------
+# Task 4: buy — writes ledger, skips live paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_buy_writes_ledger_and_skips_live(monkeypatch):
+    from app.mcp_server.tooling import kis_mock_ledger, order_execution, order_journal
+    from tests._mcp_tooling_support import build_tools
+
+    # Allow KIS mock config through
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda *_, **__: [],
+    )
+
+    monkeypatch.setattr(
+        order_execution,
+        "_execute_order",
+        AsyncMock(
+            return_value={
+                "odno": "0001234567",
+                "ord_tmd": "091500",
+                "msg": "정상처리",
+                "rt_cd": "0",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_fetch_current_price",
+        AsyncMock(return_value=70000.0),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_build_preview",
+        AsyncMock(
+            return_value={
+                "symbol": "005930",
+                "side": "buy",
+                "order_type": "limit",
+                "price": 70000.0,
+                "quantity": 10,
+                "estimated_value": 700000.0,
+                "fee": 0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_check_balance_and_warn",
+        AsyncMock(return_value=(None, None)),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_check_daily_order_limit",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_record_order_history",
+        AsyncMock(),
+    )
+
+    save_ledger = AsyncMock(return_value=42)
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save_ledger)
+
+    save_fill = AsyncMock()
+    create_journal = AsyncMock()
+    close_journals = AsyncMock()
+    link_journal = AsyncMock()
+    monkeypatch.setattr(order_journal, "_save_order_fill", save_fill)
+    monkeypatch.setattr(order_journal, "_create_trade_journal_for_buy", create_journal)
+    monkeypatch.setattr(order_journal, "_close_journals_on_sell", close_journals)
+    monkeypatch.setattr(order_journal, "_link_journal_to_fill", link_journal)
+
+    tools = build_tools()
+    result = await tools["place_order"](
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity=10,
+        price=70000.0,
+        dry_run=False,
+        account_mode="kis_mock",
+    )
+
+    assert result["success"] is True, result
+    assert result["account_mode"] == "kis_mock"
+    assert result["ledger_id"] == 42
+    assert result["order_no"] == "0001234567"
+    assert result["order_time"] == "091500"
+    save_ledger.assert_awaited_once()
+    save_fill.assert_not_awaited()
+    create_journal.assert_not_awaited()
+    close_journals.assert_not_awaited()
+    link_journal.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Task 4: sell — writes ledger, does NOT close live journals
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_sell_writes_ledger_and_does_not_close_journals(monkeypatch):
+    from app.mcp_server.tooling import kis_mock_ledger, order_execution, order_journal
+    from tests._mcp_tooling_support import build_tools
+
+    # Allow KIS mock config through
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda *_, **__: [],
+    )
+
+    monkeypatch.setattr(
+        order_execution,
+        "_execute_order",
+        AsyncMock(
+            return_value={
+                "odno": "0009999999",
+                "ord_tmd": "103000",
+                "msg": "정상처리",
+                "rt_cd": "0",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_fetch_current_price",
+        AsyncMock(return_value=70000.0),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_build_preview",
+        AsyncMock(
+            return_value={
+                "symbol": "005930",
+                "side": "sell",
+                "order_type": "limit",
+                "price": 70000.0,
+                "quantity": 5,
+                "estimated_value": 350000.0,
+                "fee": 0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_check_balance_and_warn",
+        AsyncMock(return_value=(None, None)),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_check_daily_order_limit",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_record_order_history",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.order_validation._validate_sell_side",
+        AsyncMock(return_value=(5, 70000.0, None)),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_validate_sell_side",
+        AsyncMock(return_value=(5, 70000.0, None)),
+    )
+
+    save_ledger = AsyncMock(return_value=99)
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save_ledger)
+
+    save_fill = AsyncMock()
+    create_journal = AsyncMock()
+    close_journals = AsyncMock()
+    link_journal = AsyncMock()
+    monkeypatch.setattr(order_journal, "_save_order_fill", save_fill)
+    monkeypatch.setattr(order_journal, "_create_trade_journal_for_buy", create_journal)
+    monkeypatch.setattr(order_journal, "_close_journals_on_sell", close_journals)
+    monkeypatch.setattr(order_journal, "_link_journal_to_fill", link_journal)
+
+    tools = build_tools()
+    result = await tools["place_order"](
+        symbol="005930",
+        side="sell",
+        order_type="limit",
+        quantity=5,
+        price=70000.0,
+        dry_run=False,
+        account_mode="kis_mock",
+    )
+
+    assert result["success"] is True, result
+    assert result["account_mode"] == "kis_mock"
+    assert result["ledger_id"] == 99
+    save_ledger.assert_awaited_once()
+    save_fill.assert_not_awaited()
+    create_journal.assert_not_awaited()
+    close_journals.assert_not_awaited()
+    link_journal.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Task 5: fail-closed — missing config blocks broker before call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_missing_config_fails_closed_before_broker(monkeypatch):
+    from app.mcp_server.tooling import order_execution
+    from tests._mcp_tooling_support import build_tools
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda *_, **__: ["KIS_MOCK_ENABLED", "KIS_MOCK_APP_KEY"],
+    )
+    sentinel = AsyncMock(side_effect=AssertionError("must not call broker"))
+    monkeypatch.setattr(order_execution, "_execute_order", sentinel)
+
+    tools = build_tools()
+    result = await tools["place_order"](
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity=1,
+        price=70000.0,
+        dry_run=False,
+        account_mode="kis_mock",
+    )
+    assert result["success"] is False
+    assert "KIS_MOCK_ENABLED" in result["error"]
+    assert result["account_mode"] == "kis_mock"
+    sentinel.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Task 5: kis_mock buy does NOT require thesis/strategy
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_buy_does_not_require_thesis_strategy(monkeypatch):
+    from app.mcp_server.tooling import kis_mock_ledger, order_execution, order_journal
+    from tests._mcp_tooling_support import build_tools
+
+    # Allow KIS mock config through
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda *_, **__: [],
+    )
+
+    monkeypatch.setattr(
+        order_execution,
+        "_execute_order",
+        AsyncMock(
+            return_value={
+                "odno": "0001111111",
+                "ord_tmd": "100000",
+                "msg": "정상처리",
+                "rt_cd": "0",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_fetch_current_price",
+        AsyncMock(return_value=70000.0),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_build_preview",
+        AsyncMock(
+            return_value={
+                "symbol": "005930",
+                "side": "buy",
+                "order_type": "limit",
+                "price": 70000.0,
+                "quantity": 3,
+                "estimated_value": 210000.0,
+                "fee": 0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_check_balance_and_warn",
+        AsyncMock(return_value=(None, None)),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_check_daily_order_limit",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_record_order_history",
+        AsyncMock(),
+    )
+
+    save_ledger = AsyncMock(return_value=7)
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save_ledger)
+    monkeypatch.setattr(order_journal, "_save_order_fill", AsyncMock())
+
+    tools = build_tools()
+    # No thesis, no strategy — should succeed for kis_mock
+    result = await tools["place_order"](
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity=3,
+        price=70000.0,
+        dry_run=False,
+        account_mode="kis_mock",
+    )
+    assert result["success"] is True, result
+    assert result["ledger_id"] == 7
+    save_ledger.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Task 5: kis_live path unchanged — still calls _save_order_fill, not ledger
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_kis_live_path_unchanged_calls_save_order_fill(monkeypatch):
+    from app.mcp_server.tooling import kis_mock_ledger, order_execution, order_journal
+    from tests._mcp_tooling_support import build_tools
+
+    monkeypatch.setattr(
+        order_execution,
+        "_execute_order",
+        AsyncMock(
+            return_value={
+                "odno": "9990000001",
+                "ord_tmd": "090000",
+                "msg": "정상처리",
+                "rt_cd": "0",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_fetch_current_price",
+        AsyncMock(return_value=70000.0),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_build_preview",
+        AsyncMock(
+            return_value={
+                "symbol": "005930",
+                "side": "buy",
+                "order_type": "limit",
+                "price": 70000.0,
+                "quantity": 1,
+                "estimated_value": 70000.0,
+                "fee": 0,
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_check_balance_and_warn",
+        AsyncMock(return_value=(None, None)),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_check_daily_order_limit",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(
+        order_execution,
+        "_record_order_history",
+        AsyncMock(),
+    )
+
+    save_fill = AsyncMock(return_value=55)
+    create_journal = AsyncMock(
+        return_value={
+            "journal_created": True,
+            "journal_id": 10,
+            "journal_status": "active",
+        }
+    )
+    link_journal = AsyncMock()
+    # order_execution imports these names directly, so patch on order_execution too
+    monkeypatch.setattr(order_execution, "_save_order_fill", save_fill)
+    monkeypatch.setattr(order_journal, "_save_order_fill", save_fill)
+    monkeypatch.setattr(
+        order_execution, "_create_trade_journal_for_buy", create_journal
+    )
+    monkeypatch.setattr(order_journal, "_create_trade_journal_for_buy", create_journal)
+    monkeypatch.setattr(order_execution, "_link_journal_to_fill", link_journal)
+    monkeypatch.setattr(order_journal, "_link_journal_to_fill", link_journal)
+
+    save_ledger = AsyncMock(return_value=None)
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save_ledger)
+
+    tools = build_tools()
+    result = await tools["place_order"](
+        symbol="005930",
+        side="buy",
+        order_type="limit",
+        quantity=1,
+        price=70000.0,
+        dry_run=False,
+        account_mode="kis_live",
+        thesis="t",
+        strategy="s",
+    )
+
+    assert result["success"] is True, result
+    save_fill.assert_awaited_once()
+    save_ledger.assert_not_awaited()


### PR DESCRIPTION
## Summary
- Add `review.kis_mock_order_ledger` model + Alembic migration for KIS official mock executions.
- Route `place_order(..., account_mode="kis_mock", dry_run=False)` through a dedicated mock ledger path before live fill/journal recording.
- Skip live buy journal validation for KIS mock orders and assert mock buy/sell do not create/close live journals or save live fills.
- Preserve KIS live, DB-simulated/paper, and KIS mock order-history fail-closed behavior.

## Safety / scope
- No live orders were run.
- No `dry_run=false` broker smoke was run.
- No credentials were read, printed, or changed.
- KIS mock production smoke remains gated on explicit operator approval.

## Validation
- `uv run ruff format --check app/ tests/`
- `uv run ruff check app/ tests/`
- `uv run pytest tests/test_kis_mock_order_ledger.py tests/test_kis_mock_routing.py tests/test_portfolio_cash_kis_mock.py tests/test_orders_history_kis_mock.py tests/test_mcp_place_order.py -q` — 83 passed
- `uv run alembic heads` — `d3703007a676 (head)`
- `git diff --check origin/main..HEAD`
- Diff secret-pattern scan — no obvious added secret assignment/token patterns

## Model review
- Opus planning completed.
- Opus review verdict: APPROVED; no blocking issues.

Closes ROB-37


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mock KIS order ledger to independently record simulated order executions. Users can safely test order placement and trading strategies without affecting live trading records, settlement journals, or order fulfillment data. Mock orders now follow dedicated execution paths completely separate from production systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->