### PR TITLE
Fix trading decision session URLs

### DIFF
--- a/app/services/trading_decision_session_url.py
+++ b/app/services/trading_decision_session_url.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 def build_trading_decision_session_url(base_url: str, session_uuid: UUID) -> str:
     base = base_url.rstrip("/")
-    return f"{base}/trading/decisions/{quote(str(session_uuid), safe='')}"
+    return f"{base}/trading/decisions/sessions/{quote(str(session_uuid), safe='')}"
 
 
 def resolve_trading_decision_base_url(

--- a/frontend/trading-decision/src/__tests__/routes.test.tsx
+++ b/frontend/trading-decision/src/__tests__/routes.test.tsx
@@ -1,0 +1,27 @@
+import { matchRoutes } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { isTradingDecisionSessionUuid, tradingDecisionRoutes } from "../routes";
+
+const SESSION_UUID = "11111111-1111-4111-8111-111111111111";
+
+describe("trading decision routes", () => {
+  it("keeps canonical session detail route", () => {
+    const matches = matchRoutes(tradingDecisionRoutes, `/sessions/${SESSION_UUID}`);
+
+    expect(matches?.at(-1)?.route.path).toBe("/sessions/:sessionUuid");
+    expect(matches?.at(-1)?.params.sessionUuid).toBe(SESSION_UUID);
+  });
+
+  it("supports legacy generated UUID session URLs as detail aliases", () => {
+    const matches = matchRoutes(tradingDecisionRoutes, `/${SESSION_UUID}`);
+
+    expect(matches?.at(-1)?.route.path).toBe("/:sessionUuid");
+    expect(matches?.at(-1)?.params.sessionUuid).toBe(SESSION_UUID);
+    expect(isTradingDecisionSessionUuid(matches?.at(-1)?.params.sessionUuid)).toBe(true);
+  });
+
+  it("does not treat arbitrary single-segment paths as legacy session UUIDs", () => {
+    expect(isTradingDecisionSessionUuid("settings")).toBe(false);
+    expect(isTradingDecisionSessionUuid("session-1")).toBe(false);
+  });
+});

--- a/frontend/trading-decision/src/routes.tsx
+++ b/frontend/trading-decision/src/routes.tsx
@@ -1,12 +1,34 @@
-import { createBrowserRouter } from "react-router-dom";
+import { createBrowserRouter, type RouteObject, useParams } from "react-router-dom";
 import SessionDetailPage from "./pages/SessionDetailPage";
 import SessionListPage from "./pages/SessionListPage";
 
-export const router = createBrowserRouter(
-  [
-    { path: "/", element: <SessionListPage /> },
-    { path: "/sessions/:sessionUuid", element: <SessionDetailPage /> },
-    { path: "*", element: <SessionListPage /> },
-  ],
-  { basename: "/trading/decisions" },
-);
+const SESSION_UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isTradingDecisionSessionUuid(value: string | undefined): value is string {
+  return Boolean(value && SESSION_UUID_RE.test(value));
+}
+
+function LegacySessionDetailAlias() {
+  const { sessionUuid } = useParams();
+
+  if (!isTradingDecisionSessionUuid(sessionUuid)) {
+    return <SessionListPage />;
+  }
+
+  return <SessionDetailPage />;
+}
+
+export const tradingDecisionRoutes: RouteObject[] = [
+  { path: "/", element: <SessionListPage /> },
+  { path: "/sessions/:sessionUuid", element: <SessionDetailPage /> },
+  // Backward-compatible alias for UUID session URLs generated before the
+  // canonical /sessions/:sessionUuid route was adopted. Keep arbitrary
+  // single-segment paths on the list page instead of treating them as sessions.
+  { path: "/:sessionUuid", element: <LegacySessionDetailAlias /> },
+  { path: "*", element: <SessionListPage /> },
+];
+
+export const router = createBrowserRouter(tradingDecisionRoutes, {
+  basename: "/trading/decisions",
+});

--- a/tests/routers/test_trading_decisions_operator_request.py
+++ b/tests/routers/test_trading_decisions_operator_request.py
@@ -17,7 +17,7 @@ def _make_test_client():
     app.include_router(trading_decisions.router)
     fake_user = SimpleNamespace(id=7)
     app.dependency_overrides[get_authenticated_user] = lambda: fake_user
-    return TestClient(app), app
+    return TestClient(app, base_url="https://testserver"), app
 
 
 class _FakeDB:
@@ -244,6 +244,6 @@ def test_response_session_url_falls_back_to_request_origin_when_unconfigured(
     assert resp.status_code == 201
     body = resp.json()
     assert body["session_url"].startswith(
-        "http://testserver/trading/decisions/sessions/"
+        "https://testserver/trading/decisions/sessions/"
     )
     assert body["session_url"].endswith(str(sess_uuid))

--- a/tests/routers/test_trading_decisions_operator_request.py
+++ b/tests/routers/test_trading_decisions_operator_request.py
@@ -72,7 +72,7 @@ def test_no_advisory_returns_201_with_session_url(monkeypatch):
     body = response.json()
     assert body["session_uuid"] == str(sess_uuid)
     assert body["session_url"] == (
-        f"https://trader.robinco.dev/trading/decisions/{sess_uuid}"
+        f"https://trader.robinco.dev/trading/decisions/sessions/{sess_uuid}"
     )
     assert body["proposal_count"] == 1
     assert body["advisory_used"] is False
@@ -243,5 +243,5 @@ def test_response_session_url_falls_back_to_request_origin_when_unconfigured(
     )
     assert resp.status_code == 201
     body = resp.json()
-    assert body["session_url"].startswith("http://testserver/trading/decisions/")
+    assert body["session_url"].startswith("http://testserver/trading/decisions/sessions/")
     assert body["session_url"].endswith(str(sess_uuid))

--- a/tests/routers/test_trading_decisions_operator_request.py
+++ b/tests/routers/test_trading_decisions_operator_request.py
@@ -243,5 +243,7 @@ def test_response_session_url_falls_back_to_request_origin_when_unconfigured(
     )
     assert resp.status_code == 201
     body = resp.json()
-    assert body["session_url"].startswith("http://testserver/trading/decisions/sessions/")
+    assert body["session_url"].startswith(
+        "http://testserver/trading/decisions/sessions/"
+    )
     assert body["session_url"].endswith(str(sess_uuid))

--- a/tests/routers/test_trading_decisions_operator_request_integration.py
+++ b/tests/routers/test_trading_decisions_operator_request_integration.py
@@ -160,7 +160,7 @@ def test_no_advisory_persists_session_and_proposals_in_db(monkeypatch):
             "no_advisory"
         ]
         assert body["session_url"] == (
-            f"https://trader.robinco.dev/trading/decisions/{persisted.session_uuid}"
+            f"https://trader.robinco.dev/trading/decisions/sessions/{persisted.session_uuid}"
         )
     finally:
         asyncio.run(_cleanup_user(user_id))

--- a/tests/test_async_rate_limiter.py
+++ b/tests/test_async_rate_limiter.py
@@ -89,19 +89,32 @@ class TestAsyncSlidingWindowRateLimiter:
         assert callback_wait_times[0] > 0
 
     @pytest.mark.asyncio
-    async def test_sync_blocking_callback_supported(self):
-        limiter = AsyncSlidingWindowRateLimiter(rate=1, period=0.2, name="test")
+    async def test_sync_blocking_callback_supported(self, monkeypatch):
+        limiter = AsyncSlidingWindowRateLimiter(rate=1, period=10.0, name="test")
+        current_time = 100.0
 
-        callback_invoked = False
+        def fake_monotonic():
+            return current_time
+
+        async def fake_sleep(delay: float):
+            nonlocal current_time
+            current_time += delay
+
+        monkeypatch.setattr(
+            "app.core.async_rate_limiter.time.monotonic", fake_monotonic
+        )
+        monkeypatch.setattr("app.core.async_rate_limiter.asyncio.sleep", fake_sleep)
+
+        callback_wait_times: list[float] = []
 
         def sync_callback(wait_time: float):
-            nonlocal callback_invoked
-            callback_invoked = True
+            callback_wait_times.append(wait_time)
 
         await limiter.acquire()
         await limiter.acquire(blocking_callback=sync_callback)
 
-        assert callback_invoked
+        assert len(callback_wait_times) == 1
+        assert callback_wait_times[0] == pytest.approx(10.05)
 
     @pytest.mark.asyncio
     async def test_concurrent_acquire_respects_limit(self):

--- a/tests/test_trading_decision_session_url.py
+++ b/tests/test_trading_decision_session_url.py
@@ -15,7 +15,7 @@ def test_builds_url_from_base_and_uuid():
         "https://trader.robinco.dev/", UUID("11111111-1111-1111-1111-111111111111")
     )
     assert url == (
-        "https://trader.robinco.dev/trading/decisions/"
+        "https://trader.robinco.dev/trading/decisions/sessions/"
         "11111111-1111-1111-1111-111111111111"
     )
 
@@ -31,7 +31,7 @@ def test_strips_trailing_slashes_and_quotes_uuid():
         UUID("22222222-2222-2222-2222-222222222222"),
     )
     assert url == (
-        "https://trader.robinco.dev/trading/decisions/"
+        "https://trader.robinco.dev/trading/decisions/sessions/"
         "22222222-2222-2222-2222-222222222222"
     )
 


### PR DESCRIPTION
## Summary
- Generate canonical Trading Decision Session links under `/trading/decisions/sessions/{uuid}`
- Preserve legacy UUID-only `/trading/decisions/{uuid}` links as frontend detail aliases
- Add frontend route coverage and update backend URL expectations

## Verification
- `uv run pytest tests/test_trading_decision_session_url.py tests/routers/test_trading_decisions_operator_request.py tests/test_research_run_decision_session_router.py tests/test_research_run_refresh_runner.py -q`
- `npm test -- routes.test.tsx`
- `npm run typecheck`
- `git diff --check`
- staged security scan: hardcoded secrets/shell injection/dangerous eval/pickle/sql string formatting all 0
- independent review: passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trading decision session URLs now use a refined path including a dedicated "sessions" segment.
  * Backward-compatible support for the legacy short session URL is preserved.
  * Session identifiers are validated to ensure correct routing.

* **Tests**
  * Added and updated tests for routing, URL construction, and operator request assertions to match the new URL shape.
  * Made rate-limiter timing test deterministic for reliable CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->