### PR TITLE
fix: isolate KIS mock sell preview holdings

### DIFF
--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -317,6 +317,7 @@ async def _build_preview(
     current_price: float,
     market_type: str,
     defensive_trim_ctx: DefensiveTrimContext | None,
+    is_mock: bool = False,
 ) -> dict[str, Any]:
     """Run preview and enrich result with defaults."""
     dry_run_result = await _preview_order(
@@ -328,6 +329,7 @@ async def _build_preview(
         current_price=current_price,
         market_type=market_type,
         defensive_trim_ctx=defensive_trim_ctx,
+        is_mock=is_mock,
     )
     if not isinstance(dry_run_result, dict):
         raise ValueError("Order preview returned invalid result")
@@ -873,6 +875,7 @@ async def _place_order_impl(
                 current_price=current_price,
                 market_type=market_type,
                 defensive_trim_ctx=defensive_trim_ctx,
+                is_mock=is_mock,
             )
         except ValueError as preview_exc:
             return _order_error(str(preview_exc))

--- a/app/mcp_server/tooling/order_validation.py
+++ b/app/mcp_server/tooling/order_validation.py
@@ -437,6 +437,7 @@ async def _preview_sell(
     current_price: float,
     market_type: str,
     defensive_trim_ctx: DefensiveTrimContext | None = None,
+    is_mock: bool = False,
 ) -> dict[str, Any]:
     """Build a dry-run preview dict for a sell order."""
     result: dict[str, Any] = {
@@ -446,7 +447,7 @@ async def _preview_sell(
         "current_price": current_price,
     }
 
-    holdings = await _get_holdings_for_order(symbol, market_type)
+    holdings = await _get_holdings_for_order(symbol, market_type, is_mock=is_mock)
     if not holdings:
         result["error"] = "No holdings found"
         return result
@@ -509,6 +510,7 @@ async def _preview_order(
     current_price: float,
     market_type: str,
     defensive_trim_ctx: DefensiveTrimContext | None = None,
+    is_mock: bool = False,
 ) -> dict[str, Any]:
     """Validate order and return a dry-run simulation dict.
 
@@ -531,6 +533,7 @@ async def _preview_order(
         current_price=current_price,
         market_type=market_type,
         defensive_trim_ctx=defensive_trim_ctx,
+        is_mock=is_mock,
     )
 
 

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -12,7 +12,7 @@ import pytest
 
 import app.services.brokers.upbit.client as upbit_service
 from app.core.config import settings
-from app.mcp_server.tooling import order_execution
+from app.mcp_server.tooling import order_execution, orders_registration
 from tests._mcp_tooling_support import (
     _patch_runtime_attr,
     build_tools,
@@ -1304,6 +1304,54 @@ async def test_place_order_kr_equity_balance_lookup_failure_blocks_real_order(
     assert "dry_run" not in result
     assert "OPSQ2001 CMA_EVLU_AMT_ICLD_YN error" in result["error"]
     assert len(order_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_place_order_kis_mock_sell_preview_uses_mock_holdings(monkeypatch):
+    """kis_mock sell dry-run preview must not fall back to live KIS holdings."""
+    tools = build_tools()
+    kis_calls: list[bool] = []
+
+    class MockKISClient:
+        def __init__(self, is_mock: bool = False):
+            self.is_mock = is_mock
+
+        async def fetch_my_stocks(self, *, is_mock: bool = False):
+            kis_calls.append(is_mock)
+            avg_price = 227000.0 if is_mock else 194950.0
+            return [
+                {
+                    "pdno": "005930",
+                    "hldg_qty": "1",
+                    "pchs_avg_pric": str(avg_price),
+                }
+            ]
+
+    async def fetch_quote(symbol):
+        assert symbol == "005930"
+        return {"price": 226000.0}
+
+    monkeypatch.setattr(orders_registration, "validate_kis_mock_config", lambda: [])
+    _patch_runtime_attr(monkeypatch, "KISClient", MockKISClient)
+    _patch_runtime_attr(monkeypatch, "_fetch_quote_equity_kr", fetch_quote)
+
+    result = await tools["place_order"](
+        symbol="005930",
+        side="sell",
+        order_type="limit",
+        quantity=1,
+        price=229500.0,
+        dry_run=True,
+        account_mode="kis_mock",
+    )
+
+    assert result["success"] is True
+    assert result["dry_run"] is True
+    assert result["account_mode"] == "kis_mock"
+    assert result["avg_buy_price"] == 227000.0
+    assert result["realized_pnl"] == 2500.0
+    assert kis_calls
+    assert all(kis_calls)
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Pass KIS mock routing into the sell dry-run preview chain
- Ensure preview holdings lookup uses KIS mock holdings instead of live/default holdings
- Add regression coverage for account_mode="kis_mock" sell dry-run preview

## Test Plan
- uv run pytest tests/test_mcp_place_order.py::test_place_order_kis_mock_sell_preview_uses_mock_holdings -q
- uv run pytest tests/test_mcp_place_order.py tests/test_mcp_account_modes.py -q