### PR TITLE
feat: fail open research run TradingAgents advisory

### DIFF
--- a/app/routers/research_run_decision_sessions.py
+++ b/app/routers/research_run_decision_sessions.py
@@ -102,11 +102,7 @@ async def create_decision_from_research_run(
         refreshed_at=result.refreshed_at,
         proposal_count=result.proposal_count,
         reconciliation_count=result.reconciliation_count,
-        advisory_used=False,
-        advisory_skipped_reason=(
-            "include_tradingagents_not_supported"
-            if payload.include_tradingagents
-            else None
-        ),
+        advisory_used=result.advisory_used,
+        advisory_skipped_reason=result.advisory_skipped_reason,
         warnings=list(result.warnings),
     )

--- a/app/services/research_run_decision_session_service.py
+++ b/app/services/research_run_decision_session_service.py
@@ -43,12 +43,18 @@ class ResearchRunDecisionSessionResult:
     proposal_count: int
     reconciliation_count: int
     warnings: tuple[str, ...]
+    advisory_used: bool = False
+    advisory_skipped_reason: str | None = None
 
 
 class ResearchRunNotFound(Exception): ...
 
 
 class EmptyResearchRunError(Exception): ...
+
+
+def _tradingagents_skip_reason() -> str:
+    return "tradingagents_not_configured"
 
 
 def _json_safe(value: Any) -> Any:
@@ -441,8 +447,10 @@ async def create_decision_session_from_research_run(
     request: ResearchRunDecisionSessionRequest,
     now: Callable[[], datetime] = lambda: datetime.now(UTC),
 ) -> ResearchRunDecisionSessionResult:
-    if request.include_tradingagents is True:
-        raise NotImplementedError("include_tradingagents=True is not implemented")
+    advisory_used = False
+    advisory_skipped_reason = (
+        _tradingagents_skip_reason() if request.include_tradingagents is True else None
+    )
 
     candidates = await _load_research_run_candidates(
         db, research_run_id=research_run.id
@@ -470,6 +478,8 @@ async def create_decision_session_from_research_run(
 
     proposals: list[trading_decision_service.ProposalCreate] = []
     warnings: list[str] = list(snapshot.warnings)
+    if advisory_skipped_reason is not None:
+        warnings.append(advisory_skipped_reason)
     reconciliation_count = 0
     reconciliation_summary: dict[str, int] = {}
     nxt_summary: dict[str, int] = {}
@@ -581,6 +591,11 @@ async def create_decision_session_from_research_run(
             "nxt_summary": nxt_summary,
             "snapshot_warnings": list(snapshot.warnings),
             "source_warnings": list(research_run.source_warnings),
+            "tradingagents": {
+                "requested": request.include_tradingagents,
+                "advisory_used": advisory_used,
+                "skipped_reason": advisory_skipped_reason,
+            },
         }
     )
     await db.flush()
@@ -599,6 +614,8 @@ async def create_decision_session_from_research_run(
         proposal_count=len(created_proposals),
         reconciliation_count=reconciliation_count,
         warnings=tuple(dict.fromkeys(warnings)),
+        advisory_used=advisory_used,
+        advisory_skipped_reason=advisory_skipped_reason,
     )
 
 

--- a/tests/test_research_run_decision_session_router.py
+++ b/tests/test_research_run_decision_session_router.py
@@ -86,7 +86,13 @@ def _session() -> SimpleNamespace:
     )
 
 
-def _result(run: SimpleNamespace) -> SimpleNamespace:
+def _result(
+    run: SimpleNamespace,
+    *,
+    advisory_used: bool = False,
+    advisory_skipped_reason: str | None = None,
+    warnings: tuple[str, ...] = (),
+) -> SimpleNamespace:
     return SimpleNamespace(
         session=_session(),
         research_run=run,
@@ -94,7 +100,9 @@ def _result(run: SimpleNamespace) -> SimpleNamespace:
         refreshed_at=datetime.now(UTC),
         proposal_count=1,
         reconciliation_count=0,
-        warnings=(),
+        advisory_used=advisory_used,
+        advisory_skipped_reason=advisory_skipped_reason,
+        warnings=warnings,
     )
 
 
@@ -103,6 +111,7 @@ def _patch_services(
     *,
     run: SimpleNamespace,
     snapshot: SimpleNamespace | None = None,
+    result: SimpleNamespace | None = None,
     create_side_effect: Exception | None = None,
 ) -> None:
     from app.services import (
@@ -125,7 +134,7 @@ def _patch_services(
         "create_decision_session_from_research_run",
         AsyncMock(side_effect=create_side_effect)
         if create_side_effect is not None
-        else AsyncMock(return_value=_result(run)),
+        else AsyncMock(return_value=result or _result(run)),
     )
 
 
@@ -220,14 +229,21 @@ def test_create_decision_422_empty_candidates(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.unit
-def test_create_decision_501_tradingagents(monkeypatch: pytest.MonkeyPatch):
-    """POST /decisions/from-research-run returns 501 for include_tradingagents=True."""
+def test_create_decision_tradingagents_fail_open_response(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """POST /decisions/from-research-run exposes TA skip state instead of 501."""
     run = _run()
     _patch_services(
         monkeypatch,
         run=run,
         snapshot=_snapshot(),
-        create_side_effect=NotImplementedError("TradingAgents not supported"),
+        result=_result(
+            run,
+            advisory_used=False,
+            advisory_skipped_reason="tradingagents_not_configured:repo_path_missing",
+            warnings=("tradingagents_not_configured:repo_path_missing",),
+        ),
     )
 
     response = _post(
@@ -238,5 +254,11 @@ def test_create_decision_501_tradingagents(monkeypatch: pytest.MonkeyPatch):
         },
     )
 
-    assert response.status_code == 501
-    assert response.json()["detail"] == "not_implemented"
+    assert response.status_code == 201
+    body = response.json()
+    assert body["advisory_used"] is False
+    assert (
+        body["advisory_skipped_reason"]
+        == "tradingagents_not_configured:repo_path_missing"
+    )
+    assert body["warnings"] == ["tradingagents_not_configured:repo_path_missing"]

--- a/tests/test_research_run_decision_session_service.py
+++ b/tests/test_research_run_decision_session_service.py
@@ -120,10 +120,19 @@ async def test_create_session_empty_candidates_raises(
 
 
 @pytest.mark.unit
-async def test_create_session_not_implemented_tradingagents(
-    db_session, user, research_run_factory, research_run_candidate_factory
+async def test_create_session_tradingagents_missing_config_fail_open(
+    monkeypatch, db_session, user, research_run_factory, research_run_candidate_factory
 ):
-    """Test that NotImplementedError is raised for TradingAgents in v1."""
+    """include_tradingagents=True should not block session creation when TA is unavailable."""
+    from app.services import research_run_decision_session_service
+
+    monkeypatch.setattr(
+        research_run_decision_session_service,
+        "_tradingagents_skip_reason",
+        lambda: "tradingagents_not_configured:repo_path_missing",
+        raising=False,
+    )
+
     run = await research_run_factory(db_session, user_id=user.id)
     await research_run_candidate_factory(
         db_session, research_run_id=run.id, symbol="000660"
@@ -141,14 +150,27 @@ async def test_create_session_not_implemented_tradingagents(
         include_tradingagents=True,
     )
 
-    with pytest.raises(NotImplementedError):
-        await create_decision_session_from_research_run(
-            db_session,
-            user_id=user.id,
-            research_run=run,
-            snapshot=snapshot,
-            request=request,
-        )
+    result = await create_decision_session_from_research_run(
+        db_session,
+        user_id=user.id,
+        research_run=run,
+        snapshot=snapshot,
+        request=request,
+    )
+
+    assert result.proposal_count == 1
+    assert result.advisory_used is False
+    assert (
+        result.advisory_skipped_reason
+        == "tradingagents_not_configured:repo_path_missing"
+    )
+    assert "tradingagents_not_configured:repo_path_missing" in result.warnings
+    assert result.session.market_brief["tradingagents"]["requested"] is True
+    assert result.session.market_brief["tradingagents"]["advisory_used"] is False
+    assert (
+        result.session.market_brief["tradingagents"]["skipped_reason"]
+        == "tradingagents_not_configured:repo_path_missing"
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Changes Research Run Decision Session creation so include_tradingagents=true no longer hard-fails with 501/NotImplemented when TradingAgents is unavailable.
- Propagates advisory skip state through service result, session market_brief, router response, and warnings.
- Adds TDD regression coverage for service and router fail-open behavior.

## Test Plan
- uv run pytest tests/test_research_run_decision_session_service.py::test_create_session_tradingagents_missing_config_fail_open tests/test_research_run_decision_session_router.py::test_create_decision_tradingagents_fail_open_response -q
- uv run pytest tests/test_research_run_decision_session_service.py tests/test_research_run_decision_session_router.py tests/test_research_run_decision_session_service_safety.py -q
- uv run pytest tests/test_research_run_refresh_runner.py -q
- uv run ruff check app/services/research_run_decision_session_service.py app/routers/research_run_decision_sessions.py tests/test_research_run_decision_session_service.py tests/test_research_run_decision_session_router.py
- git diff --check
- static scan for hardcoded secrets/shell=True/eval/exec/pickle/sql f-string execute: 0 findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trading agent advisory requests now gracefully handle missing configuration, providing clear advisory status and skip reasons in the response instead of failing with an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->