### PR TITLE
feat: add preopen dashboard for research run review

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -34,6 +34,7 @@ from app.routers import (
     order_estimation,
     pending_orders,
     portfolio,
+    preopen,
     research_run_decision_sessions,
     screener,
     symbol_settings,
@@ -166,6 +167,7 @@ def create_app() -> FastAPI:
     app.include_router(trading_decisions.router)
     app.include_router(trading_decisions_spa.router)
     app.include_router(research_run_decision_sessions.router)
+    app.include_router(preopen.router)
     app.include_router(kospi200.router)
     app.include_router(websocket.router)
     if settings.EXPOSE_MONITORING_TEST_ROUTES:

--- a/app/routers/preopen.py
+++ b/app/routers/preopen.py
@@ -1,0 +1,32 @@
+"""Preopen dashboard API router (ROB-39).
+
+Read-only. No order/watch/intent/broker imports allowed in this file.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.models.trading import User
+from app.routers.dependencies import get_authenticated_user
+from app.schemas.preopen import PreopenLatestResponse
+from app.services import preopen_dashboard_service
+
+router = APIRouter(prefix="/trading", tags=["preopen-dashboard"])
+
+
+@router.get("/api/preopen/latest", response_model=PreopenLatestResponse)
+async def get_latest_preopen(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+    market_scope: Literal["kr"] = "kr",
+) -> PreopenLatestResponse:
+    return await preopen_dashboard_service.get_latest_preopen_dashboard(
+        db,
+        user_id=current_user.id,
+        market_scope=market_scope,
+    )

--- a/app/schemas/preopen.py
+++ b/app/schemas/preopen.py
@@ -1,0 +1,68 @@
+"""Pydantic schemas for the preopen dashboard endpoint (ROB-39)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class CandidateSummary(BaseModel):
+    candidate_uuid: UUID
+    symbol: str
+    instrument_type: str
+    side: Literal["buy", "sell", "none"]
+    candidate_kind: str
+    proposed_price: Decimal | None
+    proposed_qty: Decimal | None
+    confidence: int | None
+    rationale: str | None
+    currency: str | None
+    warnings: list[str]
+
+
+class ReconciliationSummary(BaseModel):
+    order_id: str
+    symbol: str
+    market: str
+    side: Literal["buy", "sell"]
+    classification: str
+    nxt_classification: str | None
+    nxt_actionable: bool | None
+    gap_pct: Decimal | None
+    summary: str | None
+    reasons: list[str]
+    warnings: list[str]
+
+
+class LinkedSessionRef(BaseModel):
+    session_uuid: UUID
+    status: str
+    created_at: datetime
+
+
+class PreopenLatestResponse(BaseModel):
+    has_run: bool
+    advisory_used: bool = False
+    advisory_skipped_reason: str | None = None
+    run_uuid: UUID | None
+    market_scope: Literal["kr", "us", "crypto"] | None
+    stage: Literal["preopen"] | None
+    status: str | None
+    strategy_name: str | None
+    source_profile: str | None
+    generated_at: datetime | None
+    created_at: datetime | None
+    notes: str | None
+    market_brief: dict[str, Any] | None
+    source_freshness: dict[str, Any] | None
+    source_warnings: list[str]
+    advisory_links: list[dict[str, Any]]
+    candidate_count: int
+    reconciliation_count: int
+    candidates: list[CandidateSummary]
+    reconciliations: list[ReconciliationSummary]
+    linked_sessions: list[LinkedSessionRef]

--- a/app/services/preopen_dashboard_service.py
+++ b/app/services/preopen_dashboard_service.py
@@ -1,0 +1,192 @@
+"""Preopen dashboard aggregation service (ROB-39).
+
+Read-only. Never imports broker, order, watch, intent, or credential modules.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.research_run import ResearchRun, ResearchRunCandidate
+from app.models.trading_decision import TradingDecisionProposal, TradingDecisionSession
+from app.schemas.preopen import (
+    CandidateSummary,
+    LinkedSessionRef,
+    PreopenLatestResponse,
+    ReconciliationSummary,
+)
+from app.services import research_run_service
+
+logger = logging.getLogger(__name__)
+
+_FAIL_OPEN = PreopenLatestResponse(
+    has_run=False,
+    advisory_used=False,
+    advisory_skipped_reason="no_open_preopen_run",
+    run_uuid=None,
+    market_scope=None,
+    stage=None,
+    status=None,
+    strategy_name=None,
+    source_profile=None,
+    generated_at=None,
+    created_at=None,
+    notes=None,
+    market_brief=None,
+    source_freshness=None,
+    source_warnings=[],
+    advisory_links=[],
+    candidate_count=0,
+    reconciliation_count=0,
+    candidates=[],
+    reconciliations=[],
+    linked_sessions=[],
+)
+
+
+async def _linked_sessions(
+    db: AsyncSession,
+    *,
+    run: ResearchRun,
+    user_id: int,
+) -> list[LinkedSessionRef]:
+    """Best-effort: find TradingDecisionSessions created from this run."""
+    run_uuid_str = str(run.run_uuid)
+    try:
+        stmt = (
+            select(TradingDecisionSession)
+            .join(
+                TradingDecisionProposal,
+                TradingDecisionProposal.session_id == TradingDecisionSession.id,
+            )
+            .where(
+                TradingDecisionSession.user_id == user_id,
+                TradingDecisionProposal.original_payload["research_run_id"].astext
+                == run_uuid_str,
+            )
+            .distinct()
+            .order_by(TradingDecisionSession.created_at.desc())
+            .limit(5)
+        )
+        result = await db.execute(stmt)
+        sessions = result.scalars().all()
+        return [
+            LinkedSessionRef(
+                session_uuid=s.session_uuid,
+                status=s.status,
+                created_at=s.created_at,
+            )
+            for s in sessions
+        ]
+    except Exception:
+        # Fail-open: linked session lookup must not block the page
+        logger.warning(
+            "Failed to look up linked preopen decision sessions",
+            exc_info=True,
+            extra={"run_uuid": run_uuid_str, "user_id": user_id},
+        )
+        return []
+
+
+def _map_candidates(run: ResearchRun) -> list[CandidateSummary]:
+    def sort_key(c: ResearchRunCandidate) -> tuple:
+        side_order = {"buy": 0, "sell": 1, "none": 2}
+        return (side_order.get(c.side, 9), -(c.confidence or -1), c.symbol)
+
+    return [
+        CandidateSummary(
+            candidate_uuid=c.candidate_uuid,
+            symbol=c.symbol,
+            instrument_type=c.instrument_type.value
+            if hasattr(c.instrument_type, "value")
+            else str(c.instrument_type),
+            side=c.side,  # type: ignore[arg-type]
+            candidate_kind=c.candidate_kind,
+            proposed_price=c.proposed_price,
+            proposed_qty=c.proposed_qty,
+            confidence=c.confidence,
+            rationale=c.rationale,
+            currency=c.currency,
+            warnings=list(c.warnings),
+        )
+        for c in sorted(run.candidates, key=sort_key)
+    ]
+
+
+def _map_reconciliations(run: ResearchRun) -> list[ReconciliationSummary]:
+    return [
+        ReconciliationSummary(
+            order_id=r.order_id,
+            symbol=r.symbol,
+            market=r.market,
+            side=r.side,  # type: ignore[arg-type]
+            classification=r.classification,
+            nxt_classification=r.nxt_classification,
+            nxt_actionable=r.nxt_actionable,
+            gap_pct=r.gap_pct,
+            summary=r.summary,
+            reasons=list(r.reasons),
+            warnings=list(r.warnings),
+        )
+        for r in sorted(run.reconciliations, key=lambda r: (r.classification, r.symbol))
+    ]
+
+
+def _advisory_skipped_reason(run: ResearchRun) -> str | None:
+    if not run.candidates:
+        return "no_candidates"
+    advisory_failure_markers = {"advisory_failed", "advisory_error", "advisory_timeout"}
+    for w in run.source_warnings:
+        if w in advisory_failure_markers:
+            return w
+    return None
+
+
+async def get_latest_preopen_dashboard(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    market_scope: str,
+) -> PreopenLatestResponse:
+    run = await research_run_service.get_latest_research_run(
+        db,
+        user_id=user_id,
+        market_scope=market_scope,
+        stage="preopen",
+        status="open",
+    )
+
+    if run is None:
+        return _FAIL_OPEN
+
+    candidates = _map_candidates(run)
+    reconciliations = _map_reconciliations(run)
+    advisory_reason = _advisory_skipped_reason(run)
+    linked = await _linked_sessions(db, run=run, user_id=user_id)
+
+    return PreopenLatestResponse(
+        has_run=True,
+        advisory_used=bool(run.advisory_links) and advisory_reason is None,
+        advisory_skipped_reason=advisory_reason,
+        run_uuid=run.run_uuid,
+        market_scope=run.market_scope,  # type: ignore[arg-type]
+        stage="preopen",
+        status=run.status,
+        strategy_name=run.strategy_name,
+        source_profile=run.source_profile,
+        generated_at=run.generated_at,
+        created_at=run.created_at,
+        notes=run.notes,
+        market_brief=run.market_brief,
+        source_freshness=run.source_freshness,
+        source_warnings=list(run.source_warnings),
+        advisory_links=list(run.advisory_links),
+        candidate_count=len(candidates),
+        reconciliation_count=len(reconciliations),
+        candidates=candidates,
+        reconciliations=reconciliations,
+        linked_sessions=linked,
+    )

--- a/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import PreopenPage from "../pages/PreopenPage";
+import {
+  makePreopenFailOpen,
+  makePreopenResponse,
+} from "../test/fixtures/preopen";
+import { mockFetch } from "../test/server";
+
+const PREOPEN_URL = "/trading/api/preopen/latest?market_scope=kr";
+const CREATE_URL = "/trading/api/decisions/from-research-run";
+
+describe("PreopenPage", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("renders loading then fail-open banner with advisory_skipped_reason and no CTA", async () => {
+    mockFetch({
+      [PREOPEN_URL]: () =>
+        new Response(JSON.stringify(makePreopenFailOpen())),
+    });
+
+    render(<PreopenPage />, { wrapper: MemoryRouter });
+
+    expect(await screen.findByText(/No preopen research run available/i)).toBeInTheDocument();
+    expect(screen.getByText(/no_open_preopen_run/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /create decision session/i })).toBeNull();
+  });
+
+  it("renders run summary, candidates, reconciliations from fixture", async () => {
+    mockFetch({
+      [PREOPEN_URL]: () =>
+        new Response(JSON.stringify(makePreopenResponse())),
+    });
+
+    render(<PreopenPage />, { wrapper: MemoryRouter });
+
+    // Symbol appears in both candidates and reconciliations tables
+    expect(await screen.findAllByText("005930")).toHaveLength(2);
+    expect(screen.getByText("near_fill")).toBeInTheDocument();
+    expect(screen.getByText(/Morning scan/)).toBeInTheDocument();
+  });
+
+  it("clicking Create decision session calls api with correct args and navigates", async () => {
+    const user = userEvent.setup();
+    const sessionUuid = "sess-aaaa-1111-2222-333333333333";
+
+    const { calls } = mockFetch({
+      [PREOPEN_URL]: () =>
+        new Response(JSON.stringify(makePreopenResponse())),
+      [CREATE_URL]: () =>
+        new Response(
+          JSON.stringify({
+            session_uuid: sessionUuid,
+            session_url: `/trading/decisions/sessions/${sessionUuid}`,
+            status: "open",
+            advisory_skipped_reason: null,
+            warnings: [],
+          }),
+          { status: 201 },
+        ),
+    });
+
+    render(<PreopenPage />, { wrapper: MemoryRouter });
+
+    // Wait for page to load
+    expect(await screen.findByRole("button", { name: /create decision session/i })).toBeInTheDocument();
+
+    // First click triggers confirm prompt
+    await user.click(screen.getByRole("button", { name: /create decision session/i }));
+    expect(screen.getByRole("button", { name: /confirm/i })).toBeInTheDocument();
+
+    // Second click (confirm) submits
+    await user.click(screen.getByRole("button", { name: /confirm/i }));
+
+    await waitFor(() => {
+      const postCall = calls.find((c) => c.method === "POST");
+      expect(postCall).toBeDefined();
+      const body = JSON.parse(postCall?.body ?? "{}");
+      expect(body.selector.run_uuid).toBe("run-1111-2222-3333-444444444444");
+      expect(body.include_tradingagents).toBe(false);
+      expect(body.notes).toBe("Created from preopen dashboard");
+    });
+  });
+
+  it("surfaces ApiError detail (research_run_has_no_candidates) inline without throwing", async () => {
+    const user = userEvent.setup();
+
+    mockFetch({
+      [PREOPEN_URL]: () =>
+        new Response(JSON.stringify(makePreopenResponse())),
+      [CREATE_URL]: () =>
+        new Response(
+          JSON.stringify({ detail: "research_run_has_no_candidates" }),
+          { status: 422 },
+        ),
+    });
+
+    render(<PreopenPage />, { wrapper: MemoryRouter });
+    await screen.findByRole("button", { name: /create decision session/i });
+
+    // First click → confirm
+    await user.click(screen.getByRole("button", { name: /create decision session/i }));
+    // Second click → submit
+    await user.click(screen.getByRole("button", { name: /confirm/i }));
+
+    expect(
+      await screen.findByText(/research_run_has_no_candidates/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/trading-decision/src/__tests__/preopenApi.test.ts
+++ b/frontend/trading-decision/src/__tests__/preopenApi.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createDecisionFromResearchRun,
+  getLatestPreopen,
+} from "../api/preopen";
+import {
+  makePreopenFailOpen,
+  makePreopenResponse,
+} from "../test/fixtures/preopen";
+import { mockFetch } from "../test/server";
+
+describe("preopen API client", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("getLatestPreopen builds correct path with market_scope=kr", async () => {
+    const { calls } = mockFetch({
+      "/trading/api/preopen/latest?market_scope=kr": () =>
+        new Response(JSON.stringify(makePreopenFailOpen())),
+    });
+
+    await getLatestPreopen("kr");
+
+    expect(calls[0]?.url).toContain("/trading/api/preopen/latest?market_scope=kr");
+    expect(calls[0]?.method).toBe("GET");
+  });
+
+  it("getLatestPreopen returns parsed response", async () => {
+    mockFetch({
+      "/trading/api/preopen/latest?market_scope=kr": () =>
+        new Response(JSON.stringify(makePreopenResponse())),
+    });
+
+    const data = await getLatestPreopen();
+
+    expect(data.has_run).toBe(true);
+    expect(data.candidate_count).toBe(1);
+    expect(data.candidates[0]?.symbol).toBe("005930");
+  });
+
+  it("createDecisionFromResearchRun POSTs correct body", async () => {
+    const runUuid = "run-1111-2222-3333-444444444444";
+    const { calls } = mockFetch({
+      "/trading/api/decisions/from-research-run": () =>
+        new Response(
+          JSON.stringify({
+            session_uuid: "sess-uuid",
+            session_url: "/trading/decisions/sessions/sess-uuid",
+            status: "open",
+            advisory_skipped_reason: null,
+            warnings: [],
+          }),
+          { status: 201 },
+        ),
+    });
+
+    const result = await createDecisionFromResearchRun({ runUuid });
+
+    expect(result.session_uuid).toBe("sess-uuid");
+    expect(calls[0]?.method).toBe("POST");
+    const body = JSON.parse(calls[0]?.body ?? "{}");
+    expect(body.selector.run_uuid).toBe(runUuid);
+    expect(body.include_tradingagents).toBe(false);
+    expect(body.notes).toBe("Created from preopen dashboard");
+  });
+
+  it("only calls /trading/api paths", async () => {
+    const { calls } = mockFetch({
+      "/trading/api/preopen/latest?market_scope=kr": () =>
+        new Response(JSON.stringify(makePreopenFailOpen())),
+    });
+
+    await getLatestPreopen("kr");
+
+    for (const call of calls) {
+      expect(new URL(call.url, "https://example.test").pathname).toMatch(
+        /^\/trading\/api\//,
+      );
+    }
+  });
+});

--- a/frontend/trading-decision/src/api/preopen.ts
+++ b/frontend/trading-decision/src/api/preopen.ts
@@ -1,0 +1,27 @@
+import { apiFetch } from "./client";
+import type {
+  CreateFromResearchRunResponse,
+  PreopenLatestResponse,
+  Uuid,
+} from "./types";
+
+export function getLatestPreopen(
+  marketScope: "kr" = "kr",
+): Promise<PreopenLatestResponse> {
+  return apiFetch<PreopenLatestResponse>(
+    `/preopen/latest?market_scope=${encodeURIComponent(marketScope)}`,
+  );
+}
+
+export function createDecisionFromResearchRun(args: {
+  runUuid: Uuid;
+}): Promise<CreateFromResearchRunResponse> {
+  return apiFetch<CreateFromResearchRunResponse>("/decisions/from-research-run", {
+    method: "POST",
+    body: JSON.stringify({
+      selector: { run_uuid: args.runUuid },
+      include_tradingagents: false,
+      notes: "Created from preopen dashboard",
+    }),
+  });
+}

--- a/frontend/trading-decision/src/api/types.ts
+++ b/frontend/trading-decision/src/api/types.ts
@@ -175,3 +175,76 @@ export interface ProposalRespondRequest {
   user_threshold_pct?: DecimalString | null;
   user_note?: string | null;
 }
+
+// Preopen dashboard types (ROB-39)
+export interface PreopenCandidateSummary {
+  candidate_uuid: Uuid;
+  symbol: string;
+  instrument_type: InstrumentType;
+  side: Side;
+  candidate_kind: string;
+  proposed_price: DecimalString | null;
+  proposed_qty: DecimalString | null;
+  confidence: number | null;
+  rationale: string | null;
+  currency: string | null;
+  warnings: string[];
+}
+
+export interface PreopenReconciliationSummary {
+  order_id: string;
+  symbol: string;
+  market: string;
+  side: "buy" | "sell";
+  classification: string;
+  nxt_classification: string | null;
+  nxt_actionable: boolean | null;
+  gap_pct: DecimalString | null;
+  summary: string | null;
+  reasons: string[];
+  warnings: string[];
+}
+
+export interface PreopenLinkedSession {
+  session_uuid: Uuid;
+  status: string;
+  created_at: IsoDateTime;
+}
+
+export interface PreopenLatestResponse {
+  has_run: boolean;
+  advisory_used: boolean;
+  advisory_skipped_reason: string | null;
+  run_uuid: Uuid | null;
+  market_scope: "kr" | "us" | "crypto" | null;
+  stage: "preopen" | null;
+  status: string | null;
+  strategy_name: string | null;
+  source_profile: string | null;
+  generated_at: IsoDateTime | null;
+  created_at: IsoDateTime | null;
+  notes: string | null;
+  market_brief: Record<string, unknown> | null;
+  source_freshness: Record<string, unknown> | null;
+  source_warnings: string[];
+  advisory_links: Record<string, unknown>[];
+  candidate_count: number;
+  reconciliation_count: number;
+  candidates: PreopenCandidateSummary[];
+  reconciliations: PreopenReconciliationSummary[];
+  linked_sessions: PreopenLinkedSession[];
+}
+
+export interface CreateFromResearchRunRequest {
+  selector: { run_uuid: Uuid };
+  include_tradingagents: false;
+  notes: string;
+}
+
+export interface CreateFromResearchRunResponse {
+  session_uuid: Uuid;
+  session_url: string;
+  status: string;
+  advisory_skipped_reason: string | null;
+  warnings: string[];
+}

--- a/frontend/trading-decision/src/pages/PreopenPage.module.css
+++ b/frontend/trading-decision/src/pages/PreopenPage.module.css
@@ -1,0 +1,125 @@
+.page {
+  display: grid;
+  gap: 20px;
+}
+
+.header {
+  display: grid;
+  gap: 6px;
+}
+
+.meta {
+  color: #6b7280;
+  font-size: 0.875rem;
+}
+
+.banner {
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+  border-radius: 4px;
+  padding: 12px 16px;
+}
+
+.bannerError {
+  background: #f8d7da;
+  border-color: #dc3545;
+  border-radius: 4px;
+  padding: 12px 16px;
+}
+
+.warnings {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.warningChip {
+  background: #fff3cd;
+  border: 1px solid #ffc107;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  padding: 2px 10px;
+}
+
+.section {
+  display: grid;
+  gap: 8px;
+}
+
+.table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.table th,
+.table td {
+  border-bottom: 1px solid #e2e7ef;
+  padding: 10px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.sideBuy {
+  background: #d1fae5;
+  border-radius: 4px;
+  color: #065f46;
+  font-size: 0.8rem;
+  padding: 2px 8px;
+}
+
+.sideSell {
+  background: #fee2e2;
+  border-radius: 4px;
+  color: #991b1b;
+  font-size: 0.8rem;
+  padding: 2px 8px;
+}
+
+.sideNone {
+  background: #f3f4f6;
+  border-radius: 4px;
+  color: #6b7280;
+  font-size: 0.8rem;
+  padding: 2px 8px;
+}
+
+.rationale {
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.ctaRow {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+}
+
+.inlineError {
+  color: #dc3545;
+  font-size: 0.875rem;
+}
+
+.linkedSessions {
+  display: grid;
+  gap: 6px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.linkedSessionItem {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+}

--- a/frontend/trading-decision/src/pages/PreopenPage.tsx
+++ b/frontend/trading-decision/src/pages/PreopenPage.tsx
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import ErrorView from "../components/ErrorView";
+import LoadingView from "../components/LoadingView";
+import { ApiError } from "../api/client";
+import {
+  createDecisionFromResearchRun,
+  getLatestPreopen,
+} from "../api/preopen";
+import type { PreopenLatestResponse } from "../api/types";
+import { formatDateTime } from "../format/datetime";
+import styles from "./PreopenPage.module.css";
+
+type State =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "success"; data: PreopenLatestResponse };
+
+export default function PreopenPage() {
+  const navigate = useNavigate();
+  const [state, setState] = useState<State>({ status: "loading" });
+  const [version, setVersion] = useState(0);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [confirmPending, setConfirmPending] = useState(false);
+
+  const refetch = useCallback(() => setVersion((v) => v + 1), []);
+
+  useEffect(() => {
+    setState({ status: "loading" });
+    const controller = new AbortController();
+    getLatestPreopen("kr")
+      .then((data) => {
+        if (!controller.signal.aborted) {
+          setState({ status: "success", data });
+        }
+      })
+      .catch((err: unknown) => {
+        if (controller.signal.aborted) return;
+        if (err instanceof ApiError && err.status === 401) {
+          window.location.assign(
+            `/login?next=${encodeURIComponent(window.location.pathname)}`,
+          );
+          return;
+        }
+        setState({
+          status: "error",
+          message:
+            err instanceof ApiError ? err.detail : "Something went wrong. Try again.",
+        });
+      });
+    return () => controller.abort();
+  }, [version]);
+
+  const handleCreate = useCallback(async (runUuid: string) => {
+    if (confirmPending) {
+      setConfirmPending(false);
+      setCreating(true);
+      setCreateError(null);
+      try {
+        const result = await createDecisionFromResearchRun({ runUuid });
+        navigate(`/sessions/${result.session_uuid}`);
+      } catch (err: unknown) {
+        setCreateError(
+          err instanceof ApiError
+            ? err.detail
+            : "Failed to create decision session.",
+        );
+      } finally {
+        setCreating(false);
+      }
+    } else {
+      setConfirmPending(true);
+    }
+  }, [confirmPending, navigate]);
+
+  if (state.status === "loading") return <LoadingView />;
+  if (state.status === "error") {
+    return (
+      <main className={styles.page}>
+        <ErrorView message={state.message} onRetry={refetch} />
+      </main>
+    );
+  }
+
+  const { data } = state;
+
+  if (!data.has_run) {
+    return (
+      <main className={styles.page}>
+        <h1>Preopen advisory</h1>
+        <div className={styles.banner} role="status">
+          <strong>No preopen research run available</strong>
+          {data.advisory_skipped_reason ? (
+            <p>Reason: {data.advisory_skipped_reason}</p>
+          ) : null}
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className={styles.page}>
+      <div className={styles.header}>
+        <h1>Preopen advisory</h1>
+        <div className={styles.meta}>
+          Generated: {formatDateTime(data.generated_at)}
+          {data.strategy_name ? ` · ${data.strategy_name}` : ""}
+          {data.source_profile ? ` · ${data.source_profile}` : ""}
+          {data.market_scope ? ` · ${data.market_scope.toUpperCase()}` : ""}
+          {` · Advisory ${data.advisory_used ? "used" : "not used"}`}
+        </div>
+        {data.market_brief && typeof data.market_brief.summary === "string" ? (
+          <p>{data.market_brief.summary}</p>
+        ) : null}
+      </div>
+
+      {data.advisory_skipped_reason ? (
+        <div className={styles.banner} role="status">
+          Advisory notice: {data.advisory_skipped_reason}
+        </div>
+      ) : null}
+
+      {data.source_warnings.length > 0 ? (
+        <ul aria-label="Source warnings" className={styles.warnings}>
+          {data.source_warnings.map((w, i) => (
+            <li className={styles.warningChip} key={i}>
+              {w}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {data.candidates.length > 0 ? (
+        <section className={styles.section}>
+          <h2>Candidates ({data.candidate_count})</h2>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Symbol</th>
+                <th>Side</th>
+                <th>Kind</th>
+                <th>Confidence</th>
+                <th>Price</th>
+                <th>Qty</th>
+                <th>Rationale</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.candidates.map((c) => (
+                <tr key={c.candidate_uuid}>
+                  <td>{c.symbol}</td>
+                  <td>
+                    <span
+                      className={
+                        c.side === "buy"
+                          ? styles.sideBuy
+                          : c.side === "sell"
+                            ? styles.sideSell
+                            : styles.sideNone
+                      }
+                    >
+                      {c.side}
+                    </span>
+                  </td>
+                  <td>{c.candidate_kind}</td>
+                  <td>{c.confidence !== null ? `${c.confidence}%` : "—"}</td>
+                  <td>
+                    {c.proposed_price !== null
+                      ? `${c.proposed_price} ${c.currency ?? ""}`
+                      : "—"}
+                  </td>
+                  <td>{c.proposed_qty !== null ? c.proposed_qty : "—"}</td>
+                  <td className={styles.rationale} title={c.rationale ?? ""}>
+                    {c.rationale ?? "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      ) : null}
+
+      {data.reconciliations.length > 0 ? (
+        <section className={styles.section}>
+          <h2>Pending reconciliations ({data.reconciliation_count})</h2>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Symbol</th>
+                <th>Classification</th>
+                <th>NXT class</th>
+                <th>Actionable</th>
+                <th>Gap %</th>
+                <th>Summary</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.reconciliations.map((r, i) => (
+                <tr key={i}>
+                  <td>{r.symbol}</td>
+                  <td>{r.classification}</td>
+                  <td>{r.nxt_classification ?? "—"}</td>
+                  <td>
+                    {r.nxt_actionable === null
+                      ? "—"
+                      : r.nxt_actionable
+                        ? "Yes"
+                        : "No"}
+                  </td>
+                  <td>{r.gap_pct !== null ? `${r.gap_pct}%` : "—"}</td>
+                  <td>{r.summary ?? "—"}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      ) : null}
+
+      {data.linked_sessions.length > 0 ? (
+        <section className={styles.section}>
+          <h2>Linked decision sessions</h2>
+          <ul className={styles.linkedSessions}>
+            {data.linked_sessions.map((s) => (
+              <li className={styles.linkedSessionItem} key={String(s.session_uuid)}>
+                <Link to={`/sessions/${s.session_uuid}`}>
+                  {String(s.session_uuid)}
+                </Link>
+                <span>{s.status}</span>
+                <span>{formatDateTime(s.created_at)}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <div className={styles.ctaRow}>
+        {data.linked_sessions.length > 0 ? (
+          <Link
+            className="btn"
+            to={`/sessions/${data.linked_sessions[0]!.session_uuid}`}
+          >
+            Open session
+          </Link>
+        ) : null}
+        <button
+          className="btn"
+          disabled={creating || !data.run_uuid}
+          onClick={() => data.run_uuid && handleCreate(String(data.run_uuid))}
+          type="button"
+        >
+          {confirmPending
+            ? "Confirm create decision session?"
+            : creating
+              ? "Creating…"
+              : "Create decision session"}
+        </button>
+        {confirmPending ? (
+          <button
+            className="btn"
+            onClick={() => setConfirmPending(false)}
+            type="button"
+          >
+            Cancel
+          </button>
+        ) : null}
+        {createError ? (
+          <span className={styles.inlineError} role="alert">
+            {createError}
+          </span>
+        ) : null}
+      </div>
+
+      {data.notes ? <p>{data.notes}</p> : null}
+    </main>
+  );
+}

--- a/frontend/trading-decision/src/routes.tsx
+++ b/frontend/trading-decision/src/routes.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter, type RouteObject, useParams } from "react-router-dom";
+import PreopenPage from "./pages/PreopenPage";
 import SessionDetailPage from "./pages/SessionDetailPage";
 import SessionListPage from "./pages/SessionListPage";
 
@@ -21,6 +22,7 @@ function LegacySessionDetailAlias() {
 
 export const tradingDecisionRoutes: RouteObject[] = [
   { path: "/", element: <SessionListPage /> },
+  { path: "/preopen", element: <PreopenPage /> },
   { path: "/sessions/:sessionUuid", element: <SessionDetailPage /> },
   // Backward-compatible alias for UUID session URLs generated before the
   // canonical /sessions/:sessionUuid route was adopted. Keep arbitrary

--- a/frontend/trading-decision/src/test/fixtures/preopen.ts
+++ b/frontend/trading-decision/src/test/fixtures/preopen.ts
@@ -1,0 +1,115 @@
+import type {
+  PreopenCandidateSummary,
+  PreopenLatestResponse,
+  PreopenLinkedSession,
+  PreopenReconciliationSummary,
+} from "../../api/types";
+
+const now = "2026-04-29T06:00:00Z";
+
+export function makePreopenCandidate(
+  overrides: Partial<PreopenCandidateSummary> = {},
+): PreopenCandidateSummary {
+  return {
+    candidate_uuid: "cand-1111-1111-1111-111111111111",
+    symbol: "005930",
+    instrument_type: "equity_kr",
+    side: "buy",
+    candidate_kind: "proposed",
+    proposed_price: "70000",
+    proposed_qty: "10",
+    confidence: 75,
+    rationale: "Strong momentum play",
+    currency: "KRW",
+    warnings: [],
+    ...overrides,
+  };
+}
+
+export function makePreopenReconciliation(
+  overrides: Partial<PreopenReconciliationSummary> = {},
+): PreopenReconciliationSummary {
+  return {
+    order_id: "ORD-1",
+    symbol: "005930",
+    market: "kr",
+    side: "buy",
+    classification: "near_fill",
+    nxt_classification: "buy_pending_actionable",
+    nxt_actionable: true,
+    gap_pct: "0.5000",
+    summary: "Gap within near fill threshold",
+    reasons: ["gap_within_near_fill_pct"],
+    warnings: [],
+    ...overrides,
+  };
+}
+
+export function makePreopenLinkedSession(
+  overrides: Partial<PreopenLinkedSession> = {},
+): PreopenLinkedSession {
+  return {
+    session_uuid: "sess-aaaa-bbbb-cccc-dddddddddddd",
+    status: "open",
+    created_at: now,
+    ...overrides,
+  };
+}
+
+export function makePreopenResponse(
+  overrides: Partial<PreopenLatestResponse> = {},
+): PreopenLatestResponse {
+  return {
+    has_run: true,
+    advisory_used: true,
+    advisory_skipped_reason: null,
+    run_uuid: "run-1111-2222-3333-444444444444",
+    market_scope: "kr",
+    stage: "preopen",
+    status: "open",
+    strategy_name: "Morning scan",
+    source_profile: "roadmap",
+    generated_at: now,
+    created_at: now,
+    notes: null,
+    market_brief: null,
+    source_freshness: null,
+    source_warnings: [],
+    advisory_links: [],
+    candidate_count: 1,
+    reconciliation_count: 1,
+    candidates: [makePreopenCandidate()],
+    reconciliations: [makePreopenReconciliation()],
+    linked_sessions: [],
+    ...overrides,
+  };
+}
+
+export function makePreopenFailOpen(
+  overrides: Partial<PreopenLatestResponse> = {},
+): PreopenLatestResponse {
+  return {
+    has_run: false,
+    advisory_used: false,
+    advisory_skipped_reason: "no_open_preopen_run",
+    run_uuid: null,
+    market_scope: null,
+    stage: null,
+    status: null,
+    strategy_name: null,
+    source_profile: null,
+    generated_at: null,
+    created_at: null,
+    notes: null,
+    market_brief: null,
+    source_freshness: null,
+    source_warnings: [],
+    advisory_links: [],
+    candidate_count: 0,
+    reconciliation_count: 0,
+    candidates: [],
+    reconciliations: [],
+    linked_sessions: [],
+    ...overrides,
+  };
+}

--- a/tests/test_preopen_dashboard_service.py
+++ b/tests/test_preopen_dashboard_service.py
@@ -1,0 +1,263 @@
+"""Unit tests for preopen_dashboard_service (ROB-39)."""
+
+from __future__ import annotations
+
+import ast
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+
+def _make_candidate(**kwargs) -> SimpleNamespace:
+    defaults = {
+        "id": 1,
+        "candidate_uuid": uuid4(),
+        "symbol": "005930",
+        "instrument_type": SimpleNamespace(value="equity_kr"),
+        "side": "buy",
+        "candidate_kind": "proposed",
+        "proposed_price": Decimal("70000"),
+        "proposed_qty": Decimal("10"),
+        "confidence": 75,
+        "rationale": "Strong momentum",
+        "currency": "KRW",
+        "warnings": [],
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _make_reconciliation(**kwargs) -> SimpleNamespace:
+    defaults = {
+        "order_id": "ORD-1",
+        "symbol": "005930",
+        "market": "kr",
+        "side": "buy",
+        "classification": "near_fill",
+        "nxt_classification": "buy_pending_actionable",
+        "nxt_actionable": True,
+        "gap_pct": Decimal("0.50"),
+        "reasons": ["gap_within_near_fill_pct"],
+        "warnings": [],
+        "summary": "Gap within near fill threshold",
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _make_run(**kwargs) -> SimpleNamespace:
+    defaults = {
+        "id": 1,
+        "run_uuid": uuid4(),
+        "user_id": 7,
+        "market_scope": "kr",
+        "stage": "preopen",
+        "status": "open",
+        "source_profile": "roadmap",
+        "strategy_name": "Morning scan",
+        "notes": None,
+        "market_brief": {"summary": "Cautious"},
+        "source_freshness": None,
+        "source_warnings": [],
+        "advisory_links": [{"provider": "research"}],
+        "generated_at": datetime.now(UTC),
+        "created_at": datetime.now(UTC),
+        "candidates": [_make_candidate()],
+        "reconciliations": [_make_reconciliation()],
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_returns_fail_open_when_no_run():
+    from app.services import preopen_dashboard_service, research_run_service
+
+    with patch.object(
+        research_run_service,
+        "get_latest_research_run",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+            db=AsyncMock(),
+            user_id=7,
+            market_scope="kr",
+        )
+
+    assert result.has_run is False
+    assert result.advisory_used is False
+    assert result.advisory_skipped_reason == "no_open_preopen_run"
+    assert result.candidates == []
+    assert result.reconciliations == []
+    assert result.linked_sessions == []
+    assert result.run_uuid is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_maps_candidates_and_reconciliations():
+    from app.services import preopen_dashboard_service, research_run_service
+
+    run = _make_run(
+        candidates=[
+            _make_candidate(symbol="005930", side="buy", confidence=80),
+            _make_candidate(
+                id=2,
+                candidate_uuid=uuid4(),
+                symbol="000660",
+                side="sell",
+                confidence=60,
+            ),
+        ],
+        reconciliations=[
+            _make_reconciliation(symbol="005930", classification="near_fill"),
+        ],
+    )
+
+    with (
+        patch.object(
+            research_run_service,
+            "get_latest_research_run",
+            new=AsyncMock(return_value=run),
+        ),
+        patch.object(
+            preopen_dashboard_service,
+            "_linked_sessions",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+            db=AsyncMock(),
+            user_id=7,
+            market_scope="kr",
+        )
+
+    assert result.has_run is True
+    assert result.advisory_used is True
+    assert result.candidate_count == 2
+    assert result.reconciliation_count == 1
+    # buy comes before sell in ordering
+    assert result.candidates[0].side == "buy"
+    assert result.candidates[1].side == "sell"
+    assert result.reconciliations[0].symbol == "005930"
+    assert result.reconciliations[0].gap_pct == Decimal("0.50")
+    assert result.run_uuid == run.run_uuid
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_advisory_skipped_reason_when_zero_candidates():
+    from app.services import preopen_dashboard_service, research_run_service
+
+    run = _make_run(candidates=[])
+
+    with (
+        patch.object(
+            research_run_service,
+            "get_latest_research_run",
+            new=AsyncMock(return_value=run),
+        ),
+        patch.object(
+            preopen_dashboard_service,
+            "_linked_sessions",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+            db=AsyncMock(),
+            user_id=7,
+            market_scope="kr",
+        )
+
+    assert result.has_run is True
+    assert result.advisory_used is False
+    assert result.advisory_skipped_reason == "no_candidates"
+    assert result.candidate_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_advisory_skipped_reason_from_source_warning():
+    from app.services import preopen_dashboard_service, research_run_service
+
+    run = _make_run(source_warnings=["advisory_timeout"])
+
+    with (
+        patch.object(
+            research_run_service,
+            "get_latest_research_run",
+            new=AsyncMock(return_value=run),
+        ),
+        patch.object(
+            preopen_dashboard_service,
+            "_linked_sessions",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+            db=AsyncMock(),
+            user_id=7,
+            market_scope="kr",
+        )
+
+    assert result.has_run is True
+    assert result.advisory_used is False
+    assert result.advisory_skipped_reason == "advisory_timeout"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_linked_sessions_lookup_fail_open():
+    """linked_sessions returns [] if query fails."""
+    from app.services import preopen_dashboard_service
+
+    db_mock = AsyncMock()
+    db_mock.execute.side_effect = RuntimeError("DB unavailable")
+
+    run = _make_run()
+    result = await preopen_dashboard_service._linked_sessions(
+        db_mock, run=run, user_id=7
+    )
+    assert result == []
+
+
+@pytest.mark.unit
+def test_no_forbidden_imports():
+    """preopen modules must not import broker/order/watch/intent/credential modules."""
+    import app.routers.preopen as router_mod
+    import app.services.preopen_dashboard_service as svc_mod
+
+    forbidden_parts = (
+        "kis",
+        "upbit",
+        "broker",
+        "order_service",
+        "order_tool",
+        "trading_service",
+        "watch",
+        "alert",
+        "intent",
+        "credential",
+        "token_manager",
+    )
+
+    for mod in (router_mod, svc_mod):
+        tree = ast.parse(Path(mod.__file__).read_text())
+        for node in ast.walk(tree):
+            imported = []
+            if isinstance(node, ast.Import):
+                imported = [alias.name for alias in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported = [node.module]
+
+            for name in imported:
+                low = name.lower()
+                assert not any(part in low for part in forbidden_parts), (
+                    f"Forbidden import '{name}' found in {mod.__name__}"
+                )

--- a/tests/test_router_preopen.py
+++ b/tests/test_router_preopen.py
@@ -1,0 +1,185 @@
+"""Tests for the preopen dashboard router (ROB-39)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+ENDPOINT = "/trading/api/preopen/latest"
+
+
+def _app() -> FastAPI:
+    from app.routers import preopen as preopen_router
+    from app.routers.dependencies import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(preopen_router.router)
+    app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=7)
+    return app
+
+
+def _fail_open_response() -> SimpleNamespace:
+    from app.schemas.preopen import PreopenLatestResponse
+
+    return PreopenLatestResponse(
+        has_run=False,
+        advisory_skipped_reason="no_open_preopen_run",
+        run_uuid=None,
+        market_scope=None,
+        stage=None,
+        status=None,
+        strategy_name=None,
+        source_profile=None,
+        generated_at=None,
+        created_at=None,
+        notes=None,
+        market_brief=None,
+        source_freshness=None,
+        source_warnings=[],
+        advisory_links=[],
+        candidate_count=0,
+        reconciliation_count=0,
+        candidates=[],
+        reconciliations=[],
+        linked_sessions=[],
+    )
+
+
+def _full_response() -> SimpleNamespace:
+    from datetime import UTC, datetime
+    from decimal import Decimal
+
+    from app.schemas.preopen import (
+        CandidateSummary,
+        PreopenLatestResponse,
+        ReconciliationSummary,
+    )
+
+    return PreopenLatestResponse(
+        has_run=True,
+        advisory_skipped_reason=None,
+        run_uuid=uuid4(),
+        market_scope="kr",
+        stage="preopen",
+        status="open",
+        strategy_name="Morning scan",
+        source_profile="roadmap",
+        generated_at=datetime.now(UTC),
+        created_at=datetime.now(UTC),
+        notes=None,
+        market_brief=None,
+        source_freshness=None,
+        source_warnings=[],
+        advisory_links=[],
+        candidate_count=1,
+        reconciliation_count=1,
+        candidates=[
+            CandidateSummary(
+                candidate_uuid=uuid4(),
+                symbol="005930",
+                instrument_type="equity_kr",
+                side="buy",
+                candidate_kind="proposed",
+                proposed_price=Decimal("70000"),
+                proposed_qty=Decimal("10"),
+                confidence=75,
+                rationale="Strong momentum",
+                currency="KRW",
+                warnings=[],
+            )
+        ],
+        reconciliations=[
+            ReconciliationSummary(
+                order_id="ORD-1",
+                symbol="005930",
+                market="kr",
+                side="buy",
+                classification="near_fill",
+                nxt_classification="buy_pending_actionable",
+                nxt_actionable=True,
+                gap_pct=Decimal("0.50"),
+                summary="Near fill",
+                reasons=[],
+                warnings=[],
+            )
+        ],
+        linked_sessions=[],
+    )
+
+
+@pytest.mark.unit
+def test_get_latest_preopen_unauthenticated_401():
+    """Unauthenticated requests return 401."""
+    from app.routers import preopen as preopen_router
+
+    bare_app = FastAPI()
+    bare_app.include_router(preopen_router.router)
+    # No dependency override → real auth → 401
+    client = TestClient(bare_app, raise_server_exceptions=False)
+    response = client.get(ENDPOINT)
+    assert response.status_code == 401
+
+
+@pytest.mark.unit
+def test_get_latest_preopen_returns_fail_open_payload(monkeypatch: pytest.MonkeyPatch):
+    """GET /preopen/latest returns 200 with has_run=false when no run exists."""
+    from app.services import preopen_dashboard_service
+
+    monkeypatch.setattr(
+        preopen_dashboard_service,
+        "get_latest_preopen_dashboard",
+        AsyncMock(return_value=_fail_open_response()),
+    )
+
+    response = TestClient(_app()).get(ENDPOINT)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["has_run"] is False
+    assert body["advisory_skipped_reason"] == "no_open_preopen_run"
+    assert body["candidates"] == []
+    assert body["linked_sessions"] == []
+
+
+@pytest.mark.unit
+def test_get_latest_preopen_with_run_returns_full_payload(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """GET /preopen/latest returns 200 with full payload when run exists."""
+    from app.services import preopen_dashboard_service
+
+    full = _full_response()
+    monkeypatch.setattr(
+        preopen_dashboard_service,
+        "get_latest_preopen_dashboard",
+        AsyncMock(return_value=full),
+    )
+
+    response = TestClient(_app()).get(ENDPOINT)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["has_run"] is True
+    assert body["candidate_count"] == 1
+    assert body["reconciliation_count"] == 1
+    assert len(body["candidates"]) == 1
+    assert body["candidates"][0]["symbol"] == "005930"
+    assert body["candidates"][0]["side"] == "buy"
+
+
+@pytest.mark.unit
+def test_market_scope_param_validation_rejects_us_for_now():
+    """?market_scope=us returns 422 since only 'kr' is allowed now."""
+    from app.services import preopen_dashboard_service
+
+    app = _app()
+    # Patch so we don't hit DB
+    app.dependency_overrides[preopen_dashboard_service.get_latest_preopen_dashboard] = (
+        lambda: _fail_open_response()
+    )
+
+    response = TestClient(app).get(f"{ENDPOINT}?market_scope=us")
+    assert response.status_code == 422


### PR DESCRIPTION
## Summary
- Add read-only preopen dashboard API: `GET /trading/api/preopen/latest?market_scope=kr`
- Add Trading Decision SPA route `/trading/decisions/preopen` with run metadata, warnings, candidate/reconciliation summaries, linked-session status, and create/open session CTA
- Add backend/frontend tests for fail-open, warning/safety behavior, routing, API calls, and create-session flow

## Safety boundary
- Review/preparation UI only
- No live orders
- No broker dry-run orders
- No watch alerts
- No order intents
- No credential changes
- Create decision session uses existing `/trading/api/decisions/from-research-run` with `include_tradingagents: false`

## Local verification
- `uv run ruff format app/schemas/preopen.py app/services/preopen_dashboard_service.py app/routers/preopen.py tests/test_preopen_dashboard_service.py tests/test_router_preopen.py`
- `uv run ruff check app/schemas/preopen.py app/services/preopen_dashboard_service.py app/routers/preopen.py tests/test_preopen_dashboard_service.py tests/test_router_preopen.py`
- `uv run pytest tests/test_preopen_dashboard_service.py tests/test_router_preopen.py -q` (10 passed)
- `npm run test -- --reporter=verbose PreopenPage preopenApi` (8 passed)
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## Opus review
- Opus plan completed before implementation
- Opus review verdict: APPROVE
- Focused Opus re-review after fixes: APPROVE, no blocking issues

Closes ROB-39


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added preopen dashboard page displaying latest research run data, including candidate summaries and reconciliation information
  * Users can now create trading decisions directly from preopen research runs with confirmation flow

* **Tests**
  * Added comprehensive test coverage for preopen dashboard backend API and frontend components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->