### PR TITLE
fix: polish preopen advisory session state

### DIFF
--- a/app/services/preopen_dashboard_service.py
+++ b/app/services/preopen_dashboard_service.py
@@ -138,7 +138,12 @@ def _map_reconciliations(run: ResearchRun) -> list[ReconciliationSummary]:
 def _advisory_skipped_reason(run: ResearchRun) -> str | None:
     if not run.candidates:
         return "no_candidates"
-    advisory_failure_markers = {"advisory_failed", "advisory_error", "advisory_timeout"}
+    advisory_failure_markers = {
+        "advisory_failed",
+        "advisory_error",
+        "advisory_timeout",
+        "tradingagents_not_configured",
+    }
     for w in run.source_warnings:
         if w in advisory_failure_markers:
             return w

--- a/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import PreopenPage from "../pages/PreopenPage";
 import {
   makePreopenFailOpen,
+  makePreopenLinkedSession,
   makePreopenResponse,
 } from "../test/fixtures/preopen";
 import { mockFetch } from "../test/server";
@@ -82,6 +83,26 @@ describe("PreopenPage", () => {
       expect(body.include_tradingagents).toBe(false);
       expect(body.notes).toBe("Created from preopen dashboard");
     });
+  });
+
+  it("hides Create decision session when a linked session already exists", async () => {
+    mockFetch({
+      [PREOPEN_URL]: () =>
+        new Response(
+          JSON.stringify(
+            makePreopenResponse({
+              linked_sessions: [makePreopenLinkedSession()],
+            }),
+          ),
+        ),
+    });
+
+    render(<PreopenPage />, { wrapper: MemoryRouter });
+
+    expect(await screen.findByRole("link", { name: /open session/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /create decision session/i }),
+    ).toBeNull();
   });
 
   it("surfaces ApiError detail (research_run_has_no_candidates) inline without throwing", async () => {

--- a/frontend/trading-decision/src/pages/PreopenPage.tsx
+++ b/frontend/trading-decision/src/pages/PreopenPage.tsx
@@ -243,18 +243,20 @@ export default function PreopenPage() {
             Open session
           </Link>
         ) : null}
-        <button
-          className="btn"
-          disabled={creating || !data.run_uuid}
-          onClick={() => data.run_uuid && handleCreate(String(data.run_uuid))}
-          type="button"
-        >
-          {confirmPending
-            ? "Confirm create decision session?"
-            : creating
-              ? "Creating…"
-              : "Create decision session"}
-        </button>
+        {data.linked_sessions.length === 0 ? (
+          <button
+            className="btn"
+            disabled={creating || !data.run_uuid}
+            onClick={() => data.run_uuid && handleCreate(String(data.run_uuid))}
+            type="button"
+          >
+            {confirmPending
+              ? "Confirm create decision session?"
+              : creating
+                ? "Creating…"
+                : "Create decision session"}
+          </button>
+        ) : null}
         {confirmPending ? (
           <button
             className="btn"

--- a/tests/test_preopen_dashboard_service.py
+++ b/tests/test_preopen_dashboard_service.py
@@ -183,10 +183,14 @@ async def test_advisory_skipped_reason_when_zero_candidates():
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_advisory_skipped_reason_from_source_warning():
+@pytest.mark.parametrize(
+    "warning",
+    ["advisory_timeout", "tradingagents_not_configured"],
+)
+async def test_advisory_skipped_reason_from_source_warning(warning: str):
     from app.services import preopen_dashboard_service, research_run_service
 
-    run = _make_run(source_warnings=["advisory_timeout"])
+    run = _make_run(source_warnings=[warning])
 
     with (
         patch.object(
@@ -208,7 +212,7 @@ async def test_advisory_skipped_reason_from_source_warning():
 
     assert result.has_run is True
     assert result.advisory_used is False
-    assert result.advisory_skipped_reason == "advisory_timeout"
+    assert result.advisory_skipped_reason == warning
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Treat tradingagents_not_configured as an advisory skipped reason on the preopen dashboard
- Hide the create decision session CTA when a linked session already exists to avoid duplicate sessions
- Add backend and frontend regression tests

## Test Plan
- uv run pytest tests/test_preopen_dashboard_service.py tests/test_router_preopen.py -q
- cd frontend/trading-decision && npm test -- --run src/__tests__/PreopenPage.test.tsx
- cd frontend/trading-decision && npm run typecheck
- cd frontend/trading-decision && npm run build
- git diff --check
- uv run ruff format --check app/services/preopen_dashboard_service.py tests/test_preopen_dashboard_service.py
- uv run ruff check app/services/preopen_dashboard_service.py tests/test_preopen_dashboard_service.py