### PR TITLE
feat: add news-ingestor bulk ingestion readiness

### DIFF
--- a/alembic/versions/e2f3a4b5c6d7_add_news_ingestion_runs.py
+++ b/alembic/versions/e2f3a4b5c6d7_add_news_ingestion_runs.py
@@ -1,0 +1,86 @@
+"""add news ingestion runs
+
+Revision ID: e2f3a4b5c6d7
+Revises: e1f2a3b4c5d6
+Create Date: 2026-04-30 11:15:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "e2f3a4b5c6d7"
+down_revision: str | Sequence[str] | None = "e1f2a3b4c5d6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "news_ingestion_runs",
+        sa.Column("id", sa.BigInteger(), nullable=False),
+        sa.Column("run_uuid", sa.String(length=64), nullable=False),
+        sa.Column("market", sa.String(length=20), nullable=False),
+        sa.Column("feed_set", sa.String(length=100), nullable=False),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column(
+            "source_counts",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "inserted_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "skipped_count",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("error_message", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('success', 'partial', 'failed', 'dry_run_ok')",
+            name="ck_news_ingestion_runs_status",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_news_ingestion_runs")),
+        sa.UniqueConstraint("run_uuid", name="uq_news_ingestion_runs_run_uuid"),
+    )
+    op.create_index(
+        "ix_news_ingestion_runs_market",
+        "news_ingestion_runs",
+        ["market"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_news_ingestion_runs_finished_at",
+        "news_ingestion_runs",
+        ["finished_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_news_ingestion_runs_market_finished",
+        "news_ingestion_runs",
+        ["market", "finished_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_news_ingestion_runs_market_finished", table_name="news_ingestion_runs"
+    )
+    op.drop_index(
+        "ix_news_ingestion_runs_finished_at", table_name="news_ingestion_runs"
+    )
+    op.drop_index("ix_news_ingestion_runs_market", table_name="news_ingestion_runs")
+    op.drop_table("news_ingestion_runs")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -10,7 +10,7 @@ from .manual_holdings import (
     StockAlias,
 )
 from .market_report import MarketReport
-from .news import NewsAnalysisResult, NewsArticle, Sentiment
+from .news import NewsAnalysisResult, NewsArticle, NewsIngestionRun, Sentiment
 from .paper_trading import PaperAccount, PaperPosition, PaperTrade
 from .portfolio_decision_run import PortfolioDecisionRun
 from .prompt import PromptResult
@@ -97,6 +97,7 @@ __all__ = [
     "SymbolTradeSettings",
     "NewsArticle",
     "NewsAnalysisResult",
+    "NewsIngestionRun",
     "Sentiment",
     "BrokerType",
     "MarketType",

--- a/app/models/news.py
+++ b/app/models/news.py
@@ -7,6 +7,7 @@ import sqlalchemy as sa
 from sqlalchemy import (
     BigInteger,
     Boolean,
+    CheckConstraint,
     ForeignKey,
     Index,
     String,
@@ -108,6 +109,39 @@ class NewsArticle(Base):
 
     def __repr__(self) -> str:
         return f"<NewsArticle(id={self.id}, title='{self.title[:50]}...', url='{self.url[:50]}...')>"
+
+
+class NewsIngestionRun(Base):
+    __tablename__ = "news_ingestion_runs"
+
+    __table_args__ = (
+        UniqueConstraint("run_uuid", name="uq_news_ingestion_runs_run_uuid"),
+        CheckConstraint(
+            "status IN ('success', 'partial', 'failed', 'dry_run_ok')",
+            name="ck_news_ingestion_runs_status",
+        ),
+        Index("ix_news_ingestion_runs_market_finished", "market", "finished_at"),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    run_uuid: Mapped[str] = mapped_column(String(64), nullable=False)
+    market: Mapped[str] = mapped_column(String(20), nullable=False, index=True)
+    feed_set: Mapped[str] = mapped_column(String(100), nullable=False)
+    started_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(nullable=True, index=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="success")
+    source_counts: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    inserted_count: Mapped[int] = mapped_column(nullable=False, default=0)
+    skipped_count: Mapped[int] = mapped_column(nullable=False, default=0)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(nullable=False)
+
+    def __repr__(self) -> str:
+        return (
+            "<NewsIngestionRun("
+            f"id={self.id}, run_uuid='{self.run_uuid}', market='{self.market}', "
+            f"status='{self.status}')>"
+        )
 
 
 class NewsAnalysisResult(Base):

--- a/app/routers/news_analysis.py
+++ b/app/routers/news_analysis.py
@@ -11,13 +11,18 @@ from app.schemas.news import (
     NewsAnalysisResultResponse,
     NewsArticleBulkCreate,
     NewsArticleResponse,
+    NewsBulkIngestRequest,
+    NewsBulkIngestResponse,
     NewsListResponse,
+    NewsReadinessResponse,
 )
 from app.services.llm_news_service import (
     bulk_create_news_articles,
     create_news_article,
     get_news_analysis,
     get_news_articles,
+    get_news_readiness,
+    ingest_news_ingestor_bulk,
 )
 
 router = APIRouter(prefix="/api/v1/news", tags=["News Analysis"])
@@ -69,6 +74,43 @@ async def bulk_create_news(request: NewsArticleBulkCreate):
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to bulk create news: {str(e)}",
+        )
+
+
+@router.post(
+    "/ingest/bulk",
+    response_model=NewsBulkIngestResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def bulk_ingest_news_ingestor_payload(request: NewsBulkIngestRequest):
+    try:
+        return await ingest_news_ingestor_bulk(request)
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to ingest news-ingestor payload: {str(e)}",
+        )
+
+
+@router.get("/readiness", response_model=NewsReadinessResponse)
+async def get_news_readiness_status(
+    market: str = Query("kr", description="Market scope for news readiness"),
+    max_age_minutes: int = Query(
+        180,
+        ge=1,
+        le=1440,
+        description="Freshness threshold before news is considered stale",
+    ),
+):
+    try:
+        return await get_news_readiness(
+            market=market,
+            max_age_minutes=max_age_minutes,
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to get news readiness: {str(e)}",
         )
 
 

--- a/app/schemas/news.py
+++ b/app/schemas/news.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class NewsArticleCreate(BaseModel):
@@ -57,6 +57,92 @@ class NewsArticleCreate(BaseModel):
 
 class NewsArticleBulkCreate(BaseModel):
     articles: list[NewsArticleCreate] = Field(..., max_length=500)
+
+
+class NewsIngestionRunCreate(BaseModel):
+    run_uuid: str = Field(..., min_length=1, max_length=64)
+    market: str = Field(..., min_length=1, max_length=20)
+    feed_set: str = Field(..., min_length=1, max_length=100)
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    status: str = Field("success", pattern="^(success|partial|failed|dry_run_ok)$")
+    source_counts: dict[str, int] = Field(default_factory=dict)
+    error_message: str | None = None
+
+    @field_validator("run_uuid", "market", "feed_set", "status")
+    @classmethod
+    def normalize_required_text(cls, v: str) -> str:
+        return v.strip()
+
+
+class NewsIngestArticle(NewsArticleCreate):
+    """news-ingestor article payload mapped into auto_trader article fields."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    fingerprint: str = Field(..., min_length=1, max_length=128)
+    market: str = Field(..., min_length=1, max_length=20)
+    feed_source: str = Field(
+        ...,
+        validation_alias="source",
+        max_length=50,
+        description="news-ingestor source/feed key",
+    )
+    source: str | None = Field(
+        None,
+        validation_alias="publisher",
+        max_length=100,
+        description="Publisher mapped to auto_trader news source",
+    )
+    canonical_url: str | None = Field(None, max_length=2048)
+    published_at: datetime | None = Field(None, description="기사 발행일시")
+    raw: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("canonical_url")
+    @classmethod
+    def normalize_canonical_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        value = v.strip()
+        return value or None
+
+    @model_validator(mode="after")
+    def map_ingestor_metadata(self) -> "NewsIngestArticle":
+        if self.canonical_url:
+            self.url = self.canonical_url
+        metadata_keywords = [f"fingerprint:{self.fingerprint.strip()}"]
+        if self.canonical_url:
+            metadata_keywords.append(f"canonical_url:{self.canonical_url}")
+        if self.keywords:
+            metadata_keywords.extend(self.keywords)
+        self.keywords = metadata_keywords
+        return self
+
+
+class NewsBulkIngestRequest(BaseModel):
+    ingestion_run: NewsIngestionRunCreate
+    articles: list[NewsIngestArticle] = Field(..., max_length=500)
+
+
+class NewsBulkIngestResponse(BaseModel):
+    success: bool
+    run_uuid: str
+    inserted_count: int
+    skipped_count: int
+    skipped_urls: list[str]
+
+
+class NewsReadinessResponse(BaseModel):
+    market: str
+    is_ready: bool
+    is_stale: bool
+    latest_run_uuid: str | None
+    latest_status: str | None
+    latest_finished_at: datetime | None
+    latest_article_published_at: datetime | None
+    source_counts: dict[str, int]
+    warnings: list[str]
+    max_age_minutes: int
 
 
 class BulkCreateResponse(BaseModel):

--- a/app/services/llm_news_service.py
+++ b/app/services/llm_news_service.py
@@ -1,12 +1,20 @@
 import json
 from datetime import datetime, timedelta
+from typing import Any
 
 from sqlalchemy import cast, func, select
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst_naive, to_kst_naive
-from app.models.news import NewsAnalysisResult, NewsArticle
+from app.models.news import NewsAnalysisResult, NewsArticle, NewsIngestionRun
+from app.schemas.news import (
+    NewsBulkIngestRequest,
+    NewsBulkIngestResponse,
+    NewsReadinessResponse,
+)
 
 
 async def create_news_article(
@@ -173,3 +181,219 @@ async def get_news_analysis(article_id: int) -> NewsAnalysisResult | None:
             .limit(1)
         )
         return result.scalars().first()
+
+
+def _news_readiness_payload(
+    *,
+    market: str,
+    latest_run: NewsIngestionRun | None,
+    latest_article_published_at: datetime | None,
+    max_age_minutes: int,
+) -> NewsReadinessResponse:
+    warnings: list[str] = []
+    latest_finished_at = latest_run.finished_at if latest_run else None
+    if latest_finished_at is not None:
+        latest_finished_at = to_kst_naive(latest_finished_at)
+    if latest_article_published_at is not None:
+        latest_article_published_at = to_kst_naive(latest_article_published_at)
+    source_counts: dict[str, int] = latest_run.source_counts if latest_run else {}
+
+    if latest_run is None:
+        warnings.append("news_unavailable")
+    elif latest_finished_at is None:
+        warnings.append("news_run_unfinished")
+    if latest_run is not None and not source_counts:
+        warnings.append("news_sources_empty")
+
+    freshness_anchor = latest_finished_at
+    is_stale = True
+    if freshness_anchor is not None and source_counts:
+        is_stale = freshness_anchor < now_kst_naive() - timedelta(
+            minutes=max_age_minutes
+        )
+    if is_stale:
+        warnings.append("news_stale")
+
+    is_ready = (
+        latest_run is not None
+        and latest_finished_at is not None
+        and bool(source_counts)
+        and not is_stale
+    )
+
+    return NewsReadinessResponse(
+        market=market,
+        is_ready=is_ready,
+        is_stale=is_stale,
+        latest_run_uuid=latest_run.run_uuid if latest_run else None,
+        latest_status=latest_run.status if latest_run else None,
+        latest_finished_at=latest_finished_at,
+        latest_article_published_at=latest_article_published_at,
+        source_counts=source_counts,
+        warnings=list(dict.fromkeys(warnings)),
+        max_age_minutes=max_age_minutes,
+    )
+
+
+def _article_values_from_ingestor_payload(article_data: Any) -> dict[str, Any]:
+    return {
+        "url": article_data.url.strip(),
+        "title": article_data.title.strip(),
+        "article_content": article_data.content,
+        "summary": article_data.summary,
+        "source": article_data.source,
+        "author": article_data.author,
+        "stock_symbol": article_data.stock_symbol,
+        "stock_name": article_data.stock_name,
+        "article_published_at": to_kst_naive(article_data.published_at)
+        if article_data.published_at
+        else None,
+        "feed_source": article_data.feed_source,
+        "keywords": article_data.keywords,
+        "scraped_at": now_kst_naive(),
+        "created_at": now_kst_naive(),
+    }
+
+
+async def ingest_news_ingestor_bulk(
+    request: NewsBulkIngestRequest,
+) -> NewsBulkIngestResponse:
+    """Persist a news-ingestor normalized payload through auto_trader boundary.
+
+    Articles are deduped by the URL stored in auto_trader (canonical_url if supplied,
+    otherwise url). No auto_trader DB direct insert from news-ingestor is used; this is
+    the HTTP/API service boundary counterpart.
+    """
+    urls = [article.url.strip() for article in request.articles]
+
+    async with AsyncSessionLocal() as db:
+        existing_run_result = await db.execute(
+            select(NewsIngestionRun).where(
+                NewsIngestionRun.run_uuid == request.ingestion_run.run_uuid
+            )
+        )
+        existing_run = existing_run_result.scalars().first()
+        if existing_run is not None:
+            return NewsBulkIngestResponse(
+                success=True,
+                run_uuid=existing_run.run_uuid,
+                inserted_count=existing_run.inserted_count,
+                skipped_count=existing_run.skipped_count,
+                skipped_urls=[],
+            )
+
+        article_values = [
+            _article_values_from_ingestor_payload(article_data)
+            for article_data in request.articles
+        ]
+        article_stmt = (
+            pg_insert(NewsArticle)
+            .values(article_values)
+            .on_conflict_do_nothing(index_elements=[NewsArticle.url])
+            .returning(NewsArticle.url)
+        )
+        article_result = await db.execute(article_stmt)
+        inserted_urls = set(article_result.scalars().all())
+
+        consumed_inserted_urls: set[str] = set()
+        skipped_urls: list[str] = []
+        for url in urls:
+            if url in inserted_urls and url not in consumed_inserted_urls:
+                consumed_inserted_urls.add(url)
+            else:
+                skipped_urls.append(url)
+        inserted_count = len(inserted_urls)
+
+        run = request.ingestion_run
+        run_values = {
+            "run_uuid": run.run_uuid,
+            "market": run.market,
+            "feed_set": run.feed_set,
+            "started_at": to_kst_naive(run.started_at) if run.started_at else None,
+            "finished_at": to_kst_naive(run.finished_at) if run.finished_at else None,
+            "status": run.status,
+            "source_counts": dict(run.source_counts),
+            "inserted_count": inserted_count,
+            "skipped_count": len(skipped_urls),
+            "error_message": run.error_message,
+            "created_at": now_kst_naive(),
+        }
+        run_stmt = (
+            pg_insert(NewsIngestionRun)
+            .values(run_values)
+            .on_conflict_do_nothing(index_elements=[NewsIngestionRun.run_uuid])
+            .returning(NewsIngestionRun.run_uuid)
+        )
+        run_result = await db.execute(run_stmt)
+        inserted_run_uuid = run_result.scalar_one_or_none()
+        if inserted_run_uuid is None:
+            existing_run_result = await db.execute(
+                select(NewsIngestionRun).where(
+                    NewsIngestionRun.run_uuid == request.ingestion_run.run_uuid
+                )
+            )
+            existing_run = existing_run_result.scalars().first()
+            await db.commit()
+            if existing_run is not None:
+                return NewsBulkIngestResponse(
+                    success=True,
+                    run_uuid=existing_run.run_uuid,
+                    inserted_count=existing_run.inserted_count,
+                    skipped_count=existing_run.skipped_count,
+                    skipped_urls=[],
+                )
+        await db.commit()
+
+    return NewsBulkIngestResponse(
+        success=True,
+        run_uuid=request.ingestion_run.run_uuid,
+        inserted_count=inserted_count,
+        skipped_count=len(skipped_urls),
+        skipped_urls=skipped_urls,
+    )
+
+
+async def get_news_readiness(
+    *,
+    market: str = "kr",
+    max_age_minutes: int = 180,
+    db: AsyncSession | None = None,
+) -> NewsReadinessResponse:
+    """Return latest news ingestion freshness for readiness/preopen checks."""
+
+    async def _query(session: AsyncSession) -> NewsReadinessResponse:
+        run_result = await session.execute(
+            select(NewsIngestionRun)
+            .where(
+                NewsIngestionRun.market == market,
+                NewsIngestionRun.status.in_(["success", "partial"]),
+            )
+            .order_by(NewsIngestionRun.finished_at.desc().nulls_last())
+            .limit(1)
+        )
+        latest_run = run_result.scalars().first()
+
+        article_conditions = [NewsArticle.feed_source.is_not(None)]
+        if latest_run and latest_run.source_counts:
+            article_conditions.append(
+                NewsArticle.feed_source.in_(list(latest_run.source_counts.keys()))
+            )
+        article_result = await session.execute(
+            select(func.max(NewsArticle.article_published_at)).where(
+                *article_conditions
+            )
+        )
+        latest_article_published_at = article_result.scalar_one_or_none()
+
+        return _news_readiness_payload(
+            market=market,
+            latest_run=latest_run,
+            latest_article_published_at=latest_article_published_at,
+            max_age_minutes=max_age_minutes,
+        )
+
+    if db is not None:
+        return await _query(db)
+
+    async with AsyncSessionLocal() as session:
+        return await _query(session)

--- a/app/services/preopen_dashboard_service.py
+++ b/app/services/preopen_dashboard_service.py
@@ -19,6 +19,7 @@ from app.schemas.preopen import (
     ReconciliationSummary,
 )
 from app.services import research_run_service
+from app.services.llm_news_service import get_news_readiness
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +151,50 @@ def _advisory_skipped_reason(run: ResearchRun) -> str | None:
     return None
 
 
+async def _merge_news_readiness(
+    db: AsyncSession,
+    *,
+    market_scope: str,
+    source_freshness: dict | None,
+    source_warnings: list[str],
+) -> tuple[dict | None, list[str]]:
+    try:
+        readiness = await get_news_readiness(market=market_scope, db=db)
+    except Exception:
+        logger.warning(
+            "Failed to look up news readiness for preopen dashboard",
+            exc_info=True,
+            extra={"market_scope": market_scope},
+        )
+        merged_warnings = list(source_warnings)
+        if "news_readiness_unavailable" not in merged_warnings:
+            merged_warnings.append("news_readiness_unavailable")
+        return source_freshness, merged_warnings
+
+    merged_freshness = dict(source_freshness or {})
+    merged_freshness["news"] = {
+        "is_ready": readiness.is_ready,
+        "is_stale": readiness.is_stale,
+        "latest_run_uuid": readiness.latest_run_uuid,
+        "latest_status": readiness.latest_status,
+        "latest_finished_at": readiness.latest_finished_at.isoformat()
+        if readiness.latest_finished_at
+        else None,
+        "latest_article_published_at": readiness.latest_article_published_at.isoformat()
+        if readiness.latest_article_published_at
+        else None,
+        "source_counts": readiness.source_counts,
+        "warnings": readiness.warnings,
+        "max_age_minutes": readiness.max_age_minutes,
+    }
+
+    merged_warnings = list(source_warnings)
+    for warning in readiness.warnings:
+        if warning not in merged_warnings:
+            merged_warnings.append(warning)
+    return merged_freshness, merged_warnings
+
+
 async def get_latest_preopen_dashboard(
     db: AsyncSession,
     *,
@@ -169,6 +214,12 @@ async def get_latest_preopen_dashboard(
 
     candidates = _map_candidates(run)
     reconciliations = _map_reconciliations(run)
+    source_freshness, source_warnings = await _merge_news_readiness(
+        db,
+        market_scope=market_scope,
+        source_freshness=run.source_freshness,
+        source_warnings=list(run.source_warnings),
+    )
     advisory_reason = _advisory_skipped_reason(run)
     linked = await _linked_sessions(db, run=run, user_id=user_id)
 
@@ -186,8 +237,8 @@ async def get_latest_preopen_dashboard(
         created_at=run.created_at,
         notes=run.notes,
         market_brief=run.market_brief,
-        source_freshness=run.source_freshness,
-        source_warnings=list(run.source_warnings),
+        source_freshness=source_freshness,
+        source_warnings=source_warnings,
         advisory_links=list(run.advisory_links),
         candidate_count=len(candidates),
         reconciliation_count=len(reconciliations),

--- a/tests/test_news_ingestor_bulk.py
+++ b/tests/test_news_ingestor_bulk.py
@@ -1,0 +1,279 @@
+"""Tests for news-ingestor bulk ingestion and readiness (ROB-46)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _make_test_app() -> FastAPI:
+    from app.routers.news_analysis import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+def _sample_payload() -> dict:
+    return {
+        "ingestion_run": {
+            "run_uuid": "run-rob-46",
+            "market": "kr",
+            "feed_set": "kr-core",
+            "started_at": "2026-04-30T01:42:31+00:00",
+            "finished_at": "2026-04-30T01:42:37+00:00",
+            "source_counts": {
+                "browser_naver_mainnews": 1,
+                "browser_naver_research": 1,
+            },
+        },
+        "articles": [
+            {
+                "fingerprint": "fp-1",
+                "market": "kr",
+                "source": "browser_naver_mainnews",
+                "title": "시장 뉴스",
+                "url": "https://n.news.naver.com/mnews/article/001/1",
+                "canonical_url": "https://n.news.naver.com/mnews/article/001/1",
+                "publisher": "연합뉴스",
+                "published_at": "2026-04-30T10:32:00+09:00",
+                "summary": "요약",
+                "raw": {"row_index": 0},
+            }
+        ],
+    }
+
+
+class TestNewsIngestorSchemas:
+    def test_news_ingestor_bulk_schema_maps_payload(self):
+        from app.schemas.news import NewsBulkIngestRequest
+
+        request = NewsBulkIngestRequest.model_validate(_sample_payload())
+
+        assert request.ingestion_run.run_uuid == "run-rob-46"
+        assert request.ingestion_run.market == "kr"
+        assert request.articles[0].feed_source == "browser_naver_mainnews"
+        assert request.articles[0].source == "연합뉴스"
+        assert request.articles[0].url == "https://n.news.naver.com/mnews/article/001/1"
+        assert request.articles[0].keywords == [
+            "fingerprint:fp-1",
+            "canonical_url:https://n.news.naver.com/mnews/article/001/1",
+        ]
+
+    def test_blank_canonical_url_does_not_override_valid_url(self):
+        from app.schemas.news import NewsBulkIngestRequest
+
+        payload = _sample_payload()
+        payload["articles"][0]["canonical_url"] = "   "
+        request = NewsBulkIngestRequest.model_validate(payload)
+
+        assert request.articles[0].url == "https://n.news.naver.com/mnews/article/001/1"
+        assert request.articles[0].canonical_url is None
+        assert request.articles[0].keywords == ["fingerprint:fp-1"]
+
+    def test_news_ingestion_run_model_has_required_columns(self):
+        from app.models.news import NewsIngestionRun
+
+        run = NewsIngestionRun(
+            run_uuid="run-rob-46",
+            market="kr",
+            feed_set="kr-core",
+            started_at=datetime(2026, 4, 30, 1, 42, 31),
+            finished_at=datetime(2026, 4, 30, 1, 42, 37),
+            status="success",
+            source_counts={"browser_naver_mainnews": 20},
+            inserted_count=12,
+            skipped_count=39,
+        )
+
+        assert run.run_uuid == "run-rob-46"
+        assert run.source_counts == {"browser_naver_mainnews": 20}
+        assert run.inserted_count == 12
+        assert run.skipped_count == 39
+
+
+class TestNewsIngestorRouter:
+    def test_new_bulk_ingest_endpoint_exists_without_breaking_legacy_bulk(self):
+        app = _make_test_app()
+        routes = {route.path for route in app.routes}
+
+        assert "/api/v1/news/bulk" in routes
+        assert "/api/v1/news/ingest/bulk" in routes
+        assert "/api/v1/news/readiness" in routes
+
+    def test_bulk_ingest_endpoint_delegates_to_service(self):
+        app = _make_test_app()
+        client = TestClient(app)
+
+        with patch(
+            "app.routers.news_analysis.ingest_news_ingestor_bulk",
+            new=AsyncMock(
+                return_value=SimpleNamespace(
+                    success=True,
+                    run_uuid="run-rob-46",
+                    inserted_count=1,
+                    skipped_count=0,
+                    skipped_urls=[],
+                )
+            ),
+        ) as mock_ingest:
+            response = client.post("/api/v1/news/ingest/bulk", json=_sample_payload())
+
+        assert response.status_code == 201
+        assert response.json()["inserted_count"] == 1
+        mock_ingest.assert_awaited_once()
+
+    def test_readiness_endpoint_returns_service_result(self):
+        app = _make_test_app()
+        client = TestClient(app)
+        generated_at = datetime(2026, 4, 30, 10, 0, tzinfo=UTC)
+
+        with patch(
+            "app.routers.news_analysis.get_news_readiness",
+            new=AsyncMock(
+                return_value=SimpleNamespace(
+                    market="kr",
+                    is_ready=True,
+                    is_stale=False,
+                    latest_run_uuid="run-rob-46",
+                    latest_status="success",
+                    latest_finished_at=generated_at,
+                    latest_article_published_at=generated_at,
+                    source_counts={"browser_naver_mainnews": 20},
+                    warnings=[],
+                    max_age_minutes=180,
+                )
+            ),
+        ):
+            response = client.get("/api/v1/news/readiness?market=kr")
+
+        assert response.status_code == 200
+        assert response.json()["is_ready"] is True
+        assert response.json()["latest_run_uuid"] == "run-rob-46"
+
+
+class TestNewsReadinessPreopenIntegration:
+    def test_unfinished_latest_run_is_not_ready(self):
+        from app.models.news import NewsIngestionRun
+        from app.services.llm_news_service import _news_readiness_payload
+
+        run = NewsIngestionRun(
+            run_uuid="unfinished",
+            market="kr",
+            feed_set="kr-core",
+            started_at=datetime.now(UTC),
+            finished_at=None,
+            status="success",
+            source_counts={"browser_naver_mainnews": 20},
+            inserted_count=20,
+            skipped_count=0,
+            created_at=datetime.now(UTC),
+        )
+
+        result = _news_readiness_payload(
+            market="kr",
+            latest_run=run,
+            latest_article_published_at=datetime.now(UTC),
+            max_age_minutes=180,
+        )
+
+        assert result.is_ready is False
+        assert "news_run_unfinished" in result.warnings
+
+    def test_empty_source_counts_are_not_ready(self):
+        from app.models.news import NewsIngestionRun
+        from app.services.llm_news_service import _news_readiness_payload
+
+        run = NewsIngestionRun(
+            run_uuid="empty-sources",
+            market="kr",
+            feed_set="kr-core",
+            started_at=datetime.now(UTC),
+            finished_at=datetime.now(UTC),
+            status="success",
+            source_counts={},
+            inserted_count=0,
+            skipped_count=0,
+            created_at=datetime.now(UTC),
+        )
+
+        result = _news_readiness_payload(
+            market="kr",
+            latest_run=run,
+            latest_article_published_at=datetime.now(UTC),
+            max_age_minutes=180,
+        )
+
+        assert result.is_ready is False
+        assert "news_sources_empty" in result.warnings
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_preopen_dashboard_adds_news_stale_warning(self):
+        from app.services import preopen_dashboard_service, research_run_service
+
+        run = SimpleNamespace(
+            id=1,
+            run_uuid=uuid4(),
+            user_id=7,
+            market_scope="kr",
+            stage="preopen",
+            status="open",
+            source_profile="roadmap",
+            strategy_name="Morning scan",
+            notes=None,
+            market_brief={"summary": "Cautious"},
+            source_freshness={"existing": {"ok": True}},
+            source_warnings=[],
+            advisory_links=[],
+            generated_at=datetime.now(UTC),
+            created_at=datetime.now(UTC),
+            candidates=[],
+            reconciliations=[],
+        )
+        readiness = SimpleNamespace(
+            market="kr",
+            is_ready=False,
+            is_stale=True,
+            latest_run_uuid="run-old",
+            latest_status="success",
+            latest_finished_at=datetime.now(UTC) - timedelta(hours=8),
+            latest_article_published_at=datetime.now(UTC) - timedelta(hours=8),
+            source_counts={"browser_naver_mainnews": 20},
+            warnings=["news_stale"],
+            max_age_minutes=180,
+        )
+
+        with (
+            patch.object(
+                research_run_service,
+                "get_latest_research_run",
+                new=AsyncMock(return_value=run),
+            ),
+            patch.object(
+                preopen_dashboard_service,
+                "_linked_sessions",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch.object(
+                preopen_dashboard_service,
+                "get_news_readiness",
+                new=AsyncMock(return_value=readiness),
+            ),
+        ):
+            result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+                db=AsyncMock(),
+                user_id=7,
+                market_scope="kr",
+            )
+
+        assert "news_stale" in result.source_warnings
+        assert result.source_freshness is not None
+        assert result.source_freshness["news"]["is_stale"] is True
+        assert result.source_freshness["news"]["latest_run_uuid"] == "run-old"

--- a/tests/test_preopen_dashboard_service.py
+++ b/tests/test_preopen_dashboard_service.py
@@ -74,6 +74,23 @@ def _make_run(**kwargs) -> SimpleNamespace:
     return SimpleNamespace(**defaults)
 
 
+def _make_news_readiness(**kwargs) -> SimpleNamespace:
+    defaults = {
+        "market": "kr",
+        "is_ready": True,
+        "is_stale": False,
+        "latest_run_uuid": "news-run",
+        "latest_status": "success",
+        "latest_finished_at": datetime.now(UTC),
+        "latest_article_published_at": datetime.now(UTC),
+        "source_counts": {"browser_naver_mainnews": 20},
+        "warnings": [],
+        "max_age_minutes": 180,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
 @pytest.mark.asyncio
 @pytest.mark.unit
 async def test_returns_fail_open_when_no_run():
@@ -131,6 +148,11 @@ async def test_maps_candidates_and_reconciliations():
             "_linked_sessions",
             new=AsyncMock(return_value=[]),
         ),
+        patch.object(
+            preopen_dashboard_service,
+            "get_news_readiness",
+            new=AsyncMock(return_value=_make_news_readiness()),
+        ),
     ):
         result = await preopen_dashboard_service.get_latest_preopen_dashboard(
             db=AsyncMock(),
@@ -168,6 +190,11 @@ async def test_advisory_skipped_reason_when_zero_candidates():
             "_linked_sessions",
             new=AsyncMock(return_value=[]),
         ),
+        patch.object(
+            preopen_dashboard_service,
+            "get_news_readiness",
+            new=AsyncMock(return_value=_make_news_readiness()),
+        ),
     ):
         result = await preopen_dashboard_service.get_latest_preopen_dashboard(
             db=AsyncMock(),
@@ -202,6 +229,11 @@ async def test_advisory_skipped_reason_from_source_warning(warning: str):
             preopen_dashboard_service,
             "_linked_sessions",
             new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            preopen_dashboard_service,
+            "get_news_readiness",
+            new=AsyncMock(return_value=_make_news_readiness()),
         ),
     ):
         result = await preopen_dashboard_service.get_latest_preopen_dashboard(


### PR DESCRIPTION
## Summary
- Add `news_ingestion_runs` persistence for news-ingestor run metadata.
- Add `POST /api/v1/news/ingest/bulk` for normalized news-ingestor payloads while preserving legacy `POST /api/v1/news/bulk` compatibility.
- Add `GET /api/v1/news/readiness` and merge news freshness into preopen dashboard `source_freshness` / `source_warnings`.
- Map news-ingestor source → `feed_source`, publisher → `source`, published_at → `article_published_at`, and store fingerprint/canonical URL metadata in `keywords` without adding extra article columns.

## Safety / boundaries
- No broker/order/watch/order-intent/paper/live trading changes.
- No Prefect deployment.
- No secrets or connection strings added/printed.
- news-ingestor still crosses into auto_trader only through HTTP API; no direct auto_trader DB insert path.

## Notes
- DB migration: `e2f3a4b5c6d7_add_news_ingestion_runs.py`.
- New bulk ingest uses PostgreSQL `ON CONFLICT DO NOTHING` for URL and run UUID idempotency.
- Readiness treats unfinished or source-empty runs as not ready/stale.

## Test plan
- `uv run pytest tests/test_news_ingestor_bulk.py tests/test_news_rss.py tests/test_preopen_dashboard_service.py -q` → 72 passed, 2 pre-existing Pydantic deprecation warnings.
- `uv run ruff check app/ tests/test_news_ingestor_bulk.py alembic/versions/e2f3a4b5c6d7_add_news_ingestion_runs.py` → pass.
- `uv run ruff format --check app/ tests/test_news_ingestor_bulk.py alembic/versions/e2f3a4b5c6d7_add_news_ingestion_runs.py` → pass.
- `uv run alembic heads` → single head `e2f3a4b5c6d7`.
- PostgreSQL dialect compile smoke confirmed article/run upserts include `ON CONFLICT`.
- staged diff secret scan → none.

Closes ROB-46.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bulk news ingestion API endpoint for importing news articles in batch operations
  * Added news readiness check endpoint to monitor freshness and availability of news data
  * Preopen dashboard now displays news readiness status and source freshness information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->