### PR TITLE
feat: add news-ingestor ingest token auth

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -363,6 +363,11 @@ class Settings(BaseSettings):
     # N8N API Key Authentication
     N8N_API_KEY: str = ""
     PUBLIC_API_PATHS: list[str] = []
+
+    # news-ingestor machine-to-machine bulk ingest authentication
+    NEWS_INGESTOR_INGEST_TOKEN: str = ""
+    NEWS_INGESTOR_INGEST_TOKEN_HEADER: str = "X-News-Ingestor-Token"
+
     trader_agent_id: str = "6b2192cc-14fa-4335-b572-2fe1e0cb54a7"
     paperclip_api_url: str | None = None
     paperclip_api_key: str | None = None

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -51,6 +51,7 @@ class AuthMiddleware:
         "/api/v1/openclaw/callback",
         "/api/screener/callback",
     ]
+    NEWS_INGESTOR_BULK_INGEST_PATH: ClassVar[str] = "/api/v1/news/ingest/bulk"
     LEGACY_DEPRECATED_PREFIXES: ClassVar[tuple[str, ...]] = LEGACY_PREFIXES
 
     def __init__(self, app: ASGIApp):
@@ -140,6 +141,32 @@ class AuthMiddleware:
                 return JSONResponse(
                     status_code=401,
                     content={"detail": "Invalid N8N API key"},
+                )
+            return None
+
+        # news-ingestor bulk ingest API: dedicated machine-to-machine token auth.
+        # This path deliberately bypasses session-cookie auth only after the
+        # internal ingest token has been configured and validated.
+        if path == self.NEWS_INGESTOR_BULK_INGEST_PATH:
+            expected_token = settings.NEWS_INGESTOR_INGEST_TOKEN
+            if not expected_token:
+                return JSONResponse(
+                    status_code=403,
+                    content={"detail": "News ingestor ingest token not configured"},
+                )
+            header_name = settings.NEWS_INGESTOR_INGEST_TOKEN_HEADER.strip()
+            if not header_name:
+                return JSONResponse(
+                    status_code=403,
+                    content={
+                        "detail": "News ingestor ingest token header not configured"
+                    },
+                )
+            supplied_token = request.headers.get(header_name, "")
+            if not hmac.compare_digest(supplied_token, expected_token):
+                return JSONResponse(
+                    status_code=401,
+                    content={"detail": "Invalid news ingestor ingest token"},
                 )
             return None
 

--- a/tests/test_news_ingestor_ingest_token_auth.py
+++ b/tests/test_news_ingestor_ingest_token_auth.py
@@ -1,0 +1,125 @@
+"""Tests for news-ingestor bulk ingest machine-to-machine auth."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.middleware.auth import AuthMiddleware
+
+_HEADER_NAME = "X-News-Ingestor-Token"
+_EXPECTED_VALUE = "expected-ingest-value-123"
+_WRONG_VALUE = "wrong-ingest-value-456"
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(AuthMiddleware)
+
+    @app.post("/api/v1/news/ingest/bulk")
+    async def news_ingest_bulk():
+        return {"success": True}
+
+    @app.get("/api/v1/news/readiness")
+    async def news_readiness():
+        return {"status": "ok"}
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    return app
+
+
+@pytest.fixture
+def client_with_ingest_value() -> TestClient:
+    with patch("app.middleware.auth.settings") as mock_settings:
+        mock_settings.DOCS_ENABLED = False
+        mock_settings.PUBLIC_API_PATHS = []
+        mock_settings.N8N_API_KEY = ""
+        mock_settings.NEWS_INGESTOR_INGEST_TOKEN = _EXPECTED_VALUE
+        mock_settings.NEWS_INGESTOR_INGEST_TOKEN_HEADER = _HEADER_NAME
+        yield TestClient(_build_app())
+
+
+@pytest.fixture
+def client_without_ingest_value() -> TestClient:
+    with patch("app.middleware.auth.settings") as mock_settings:
+        mock_settings.DOCS_ENABLED = False
+        mock_settings.PUBLIC_API_PATHS = []
+        mock_settings.N8N_API_KEY = ""
+        mock_settings.NEWS_INGESTOR_INGEST_TOKEN = ""
+        mock_settings.NEWS_INGESTOR_INGEST_TOKEN_HEADER = _HEADER_NAME
+        yield TestClient(_build_app())
+
+
+def test_bulk_ingest_fails_closed_when_env_value_unset(
+    client_without_ingest_value: TestClient,
+) -> None:
+    response = client_without_ingest_value.post(
+        "/api/v1/news/ingest/bulk",
+        headers={_HEADER_NAME: _EXPECTED_VALUE},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "News ingestor ingest token not configured"
+    assert _EXPECTED_VALUE not in response.text
+
+
+def test_bulk_ingest_missing_header_returns_401(
+    client_with_ingest_value: TestClient,
+) -> None:
+    response = client_with_ingest_value.post("/api/v1/news/ingest/bulk")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid news ingestor ingest token"
+    assert _EXPECTED_VALUE not in response.text
+
+
+def test_bulk_ingest_wrong_header_value_returns_401(
+    client_with_ingest_value: TestClient,
+) -> None:
+    response = client_with_ingest_value.post(
+        "/api/v1/news/ingest/bulk",
+        headers={_HEADER_NAME: _WRONG_VALUE},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid news ingestor ingest token"
+    assert _WRONG_VALUE not in response.text
+    assert _EXPECTED_VALUE not in response.text
+
+
+def test_bulk_ingest_correct_header_value_reaches_route(
+    client_with_ingest_value: TestClient,
+) -> None:
+    response = client_with_ingest_value.post(
+        "/api/v1/news/ingest/bulk",
+        headers={_HEADER_NAME: _EXPECTED_VALUE},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"success": True}
+    assert _EXPECTED_VALUE not in response.text
+
+
+def test_other_news_api_still_uses_session_auth(
+    client_with_ingest_value: TestClient,
+) -> None:
+    response = client_with_ingest_value.get(
+        "/api/v1/news/readiness",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Authentication required for this endpoint."
+
+
+def test_health_endpoint_unaffected(client_with_ingest_value: TestClient) -> None:
+    response = client_with_ingest_value.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- Add dedicated news-ingestor machine-to-machine token settings for bulk ingest
- Allow `/api/v1/news/ingest/bulk` through auth middleware only when a configured ingest token matches the request header
- Fail closed when the ingest token is unset/missing/wrong and keep readiness/session auth behavior covered by tests

Refs ROB-54

## Verification
- `uv run ruff check app/core/config.py app/middleware/auth.py tests/test_news_ingestor_ingest_token_auth.py` — passed
- `uv run ruff format --check app/core/config.py app/middleware/auth.py tests/test_news_ingestor_ingest_token_auth.py` — passed
- `uv run pytest tests/test_news_ingestor_ingest_token_auth.py tests/test_news_ingestor_bulk.py tests/test_news_rss.py tests/test_n8n_news.py tests/test_auth_middleware.py tests/test_n8n_api_key_auth.py` — 104 passed, 2 warnings

## Safety / Non-goals
- No production deploy
- No real `push-pending --execute`
- No Prefect scheduler change or `--no-push` removal
- No direct DB insert or broker/order/watch/order-intent side effects
- No credentials or token values committed/logged

## Follow-up
- Set production env `NEWS_INGESTOR_INGEST_TOKEN=[REDACTED]` before deployment/use
- Match header name with news-ingestor default or configured override


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token-based machine-to-machine authentication for bulk news ingestion endpoint
  * Introduced configurable ingest token and header settings for secure API access

* **Tests**
  * Added comprehensive test coverage for ingest token authentication flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->