### PR TITLE
docs(news): add KR scheduled push readiness runbook

### DIFF
--- a/docs/plans/ROB-61-kr-news-prefect-push-readiness-plan.md
+++ b/docs/plans/ROB-61-kr-news-prefect-push-readiness-plan.md
@@ -1,0 +1,296 @@
+# ROB-61 — KR News Prefect Scheduled Push & Readiness Operations
+
+**Path:** `docs/plans/ROB-61-kr-news-prefect-push-readiness-plan.md`
+**Issue:** ROB-61 — auto_trader: KR news Prefect scheduled push/readiness operations
+**Branch:** `feature/ROB-61-kr-news-prefect-push-readiness`
+**Role:** planner (Opus)
+**Date:** 2026-04-30
+
+## 0. Context Recap
+
+KR news ingestion now has two halves wired up:
+
+- **News Ingestor side (out of repo):** `/Users/mgh3326/services/prefect/flows/auto_trader/news_ingestion.py` defines `news_ingestor_kr_core` (hourly KR feed crawl/store) and `news_ingestor_pending_push` (manual flush of pending articles into auto_trader).
+- **auto_trader side (this repo):**
+  - `app/services/llm_news_service.py::ingest_news_ingestor_bulk` persists `NewsArticle` rows via URL conflict and writes a `NewsIngestionRun` row (`run_uuid`, `market`, `feed_set`, `started_at`, `finished_at`, `status`, `source_counts`, `inserted_count`, `skipped_count`, `error_message`).
+  - `app/services/llm_news_service.py::get_news_readiness(market='kr', max_age_minutes=180, db=None)` returns a `_news_readiness_payload(...)` summary used by `/trading/decisions/preopen`.
+  - `app/services/preopen_dashboard_service.py` merges that readiness into `NewsReadinessSummary`, `source_freshness['news']`, and `source_warnings` and renders `news_preview`. It is fail-open on readiness/preview lookup.
+  - Tests: `tests/test_news_ingestor_bulk.py`, `tests/test_preopen_dashboard_service.py` already cover schema, router, readiness, and preopen stale-warning paths.
+
+**Reconfirmed Prefect deployment status (read-only, no mutation done):**
+
+| Deployment | Schedule | Paused | Tags | Params | Status | Entrypoint |
+|---|---|---|---|---|---|---|
+| News Ingestor KR Core / hourly | `interval=3600s` (defined) | **true** | `news-ingestor`, `kr-core`, `no-push` | (defaults) | `NOT_READY` | `flows/auto_trader/news_ingestion.py:news_ingestor_kr_core` |
+| News Ingestor Pending Push / manual | (none) | **true** | `news-ingestor`, `pending-push`, `manual`, `execute-explicit` | `{limit: 25, execute: false}` | `NOT_READY` | `flows/auto_trader/news_ingestion.py:news_ingestor_pending_push` |
+
+Both deployments stay paused for this PR. The bulk ingest endpoint has the readiness contract that the push flow must keep healthy; this PR codifies the contract, the operational schedule, and the smoke procedure in auto_trader. The actual unpause/cron tuning lives in `robin-prefect-automations` and is tracked as an out-of-repo follow-up.
+
+## 1. Scope Decision — Smallest Safe auto_trader PR Slice
+
+**In scope (this PR, auto_trader):**
+
+1. Operator runbook (Markdown) describing current Prefect deployment state, the proposed scheduled push contract (cadence, `limit`, freshness window, dry-run posture, failure alert, rollback), and the unpause checklist.
+2. The plan document itself.
+3. Read-only `/trading/decisions/preopen` news readiness smoke script and its docs section.
+4. A small set of additive tests asserting the readiness/run-status contract that the Prefect side relies on (no behavior change, lock-in only).
+
+**Out of scope (explicit non-goals):**
+
+- Touching `/Users/mgh3326/services/prefect/...` flows or unpause/execute. Tracked as **OOR-1** below.
+- ROB-62 (push automation tuning) and ROB-63 (any downstream advisory work).
+- Any change to ingest, readiness, preopen, or trading code paths.
+- Production DB writes, broker calls, watch alerts, order-intents, or any `--execute` path.
+- Secret/connection-string output or storage.
+
+**Out-of-repo follow-ups (linked, not implemented here):**
+
+- **OOR-1 (robin-prefect-automations):** unpause `kr-core` hourly, register `pending-push` schedule per the contract in §3, wire failure alert hook.
+- **OOR-2 (robin-prefect-automations):** parameterize `pending-push` `limit` and freshness via deployment params, default `execute=false`.
+
+## 2. Proposed Files & Exact Changes
+
+| File | Change | Notes |
+|---|---|---|
+| `docs/plans/ROB-61-kr-news-prefect-push-readiness-plan.md` | **add** | This document. |
+| `docs/runbooks/news-ingestor-kr-scheduled-push.md` | **add** | Operator runbook (content in §3). |
+| `scripts/smoke/preopen_news_readiness.sh` | **add** | Read-only `curl` smoke against `http://127.0.0.1:8000/trading/decisions/preopen` on the `current` symlinked deploy; prints the `news` readiness/`source_warnings` slice via `jq`. **No** `--execute`, **no** ingest invocation. |
+| `tests/test_news_readiness_contract.py` | **add** | Pure-unit contract tests for `_news_readiness_payload` and `get_news_readiness` behavior the Prefect push flow depends on (status whitelist, `max_age_minutes` default, `source_counts` empty -> warning, latest-finished-at selection). Uses in-memory fakes; no DB or network. |
+| `tests/test_preopen_dashboard_service.py` | **extend** (additive) | One new case asserting that `news_unavailable` does **not** demote non-news readiness signals (fail-open guard). Skip if equivalent already exists; do not modify existing tests. |
+| `app/services/llm_news_service.py` | **no change** | Contract is stable; do not touch. |
+| `app/services/preopen_dashboard_service.py` | **no change** | Same. |
+
+**Not creating:** any module under `app/tasks/prefect*`, any new config flag, any scheduler shim. Prefect ownership stays in `robin-prefect-automations`.
+
+## 3. Operator Runbook — `docs/runbooks/news-ingestor-kr-scheduled-push.md`
+
+> Drop-in content. Implementer should write verbatim, adjusting only paths if the deploy symlink moves.
+
+### 3.1 Purpose
+
+Keep `/trading/decisions/preopen` `news` readiness fresh by running KR News Ingestor crawl + bulk push on a schedule, with bounded blast radius and a clear rollback.
+
+### 3.2 Current Deployment Status (as of 2026-04-30)
+
+```
+News Ingestor KR Core / hourly
+  schedule:   interval 3600s   (defined, INACTIVE)
+  paused:     true
+  tags:       news-ingestor, kr-core, no-push
+  status:     NOT_READY
+  entrypoint: flows/auto_trader/news_ingestion.py:news_ingestor_kr_core
+
+News Ingestor Pending Push / manual
+  schedule:   none
+  paused:     true
+  tags:       news-ingestor, pending-push, manual, execute-explicit
+  params:     { limit: 25, execute: false }   # dry-run posture
+  status:     NOT_READY
+  entrypoint: flows/auto_trader/news_ingestion.py:news_ingestor_pending_push
+```
+
+Both deployments **must remain paused** until the unpause checklist (§3.7) is satisfied.
+
+### 3.3 Readiness Contract auto_trader Exposes
+
+`get_news_readiness(market='kr', max_age_minutes=180)` returns "ready" only when **all** of:
+
+- The latest `NewsIngestionRun` for `market='kr'` has `status ∈ {success, partial}`.
+- That run has `finished_at` set and `now - finished_at ≤ max_age_minutes` (default **180 min**).
+- That run's `source_counts` is non-empty.
+
+Warnings emitted otherwise: `news_unavailable`, `news_run_unfinished`, `news_sources_empty`, `news_stale`. `/trading/decisions/preopen` surfaces these in `source_warnings` and demotes only the `news` slot of `source_freshness`; it is fail-open on readiness lookup errors.
+
+### 3.4 Proposed Safe Schedule (DEFINITION ONLY — DO NOT ACTIVATE IN THIS PR)
+
+Track in `robin-prefect-automations` (OOR-1, OOR-2):
+
+| Deployment | Cadence | Params | Freshness budget |
+|---|---|---|---|
+| `news-ingestor-kr-core/hourly` | `interval=3600s` (existing) | (defaults) | Crawl populates pending pool; budget consumed by push step. |
+| `news-ingestor-pending-push/scheduled` | `interval=1800s` (every 30 min) | `{ limit: 25, execute: false }` first, then **`execute: true`** only after dry-run window passes | 30 min cadence with 25-row cap keeps `now - finished_at ≪ 180 min` even on one missed tick. |
+
+Rationale:
+- 30 min push cadence × `limit=25` → with 180 min readiness window we tolerate **5 missed ticks** before stale.
+- `limit=25` caps DB write fan-out per run; combined with URL-conflict upsert in `ingest_news_ingestor_bulk`, repeated runs are idempotent.
+- Keeping `pending-push` on its own deployment preserves the `execute-explicit` tag contract — production execution requires an explicit param flip, not a code path.
+
+### 3.5 Dry-Run Preview (operator workflow, not in this PR's CI)
+
+From an operator host with Prefect CLI access (NOT from this repo's CI):
+
+```text
+# 1) Inspect deployment without mutating
+prefect deployment inspect 'news-ingestor-pending-push/manual'
+
+# 2) Run pending-push in DRY-RUN (execute=false). This will NOT call /llm/news/ingestor/bulk.
+prefect deployment run 'news-ingestor-pending-push/manual' \
+  --param limit=25 --param execute=false
+
+# 3) Confirm the flow logged: "dry-run: would push N articles" and exited 0.
+```
+
+`execute=false` MUST be the default until the unpause checklist (§3.7) is signed off. Any `execute=true` invocation is treated as a production push.
+
+### 3.6 Failure Alert
+
+Owned in `robin-prefect-automations` (OOR-1). Required signals:
+
+- Flow run `Failed` or `Crashed` on `news-ingestor-pending-push/scheduled` → Telegram alert via existing `TELEGRAM_TOKEN` / `TELEGRAM_CHAT_IDS_STR` channel.
+- Two consecutive `kr-core/hourly` failures → same channel, separate message tag (`[kr-core]`).
+- Auto_trader `/trading/decisions/preopen` returning `news_stale` for ≥ 2 consecutive smoke runs → human escalation (handled by smoke cron in `robin-prefect-automations`, **not** by this PR's smoke script which is on-demand only).
+
+The smoke script in this PR is operator-invoked; no scheduled alerter ships in auto_trader.
+
+### 3.7 Unpause Checklist (must all be ✅ before flipping `paused=false` in robin-prefect-automations)
+
+1. ✅ `tests/test_news_readiness_contract.py` and `tests/test_news_ingestor_bulk.py` green on `main`.
+2. ✅ `scripts/smoke/preopen_news_readiness.sh` against `current` returns HTTP 200 with `news` readiness payload present (ready or warned, but not 5xx).
+3. ✅ Three consecutive `pending-push` dry-runs (`execute=false`) in Prefect succeed and log non-empty pending counts.
+4. ✅ Telegram failure alert hook verified by deliberately failing one dry-run.
+5. ✅ `news` readiness `max_age_minutes=180` confirmed in `app/services/llm_news_service.py` (no drift).
+6. ✅ Operator on call acknowledged the rollback steps in §3.8.
+
+### 3.8 Rollback / Disable
+
+Order matters. Each step is reversible.
+
+1. **Pause push** (highest priority, stops writes):
+   ```text
+   prefect deployment pause 'news-ingestor-pending-push/scheduled'
+   ```
+   The `scheduled` deployment slug applies after OOR-1 creates it; before that, pause the existing `News Ingestor Pending Push/manual` deployment if it has been unpaused for dry-run testing. Crawl can keep running; only push affects `NewsIngestionRun`.
+
+2. **Pause crawl** (only if crawl itself misbehaving):
+   ```text
+   prefect deployment pause 'news-ingestor-kr-core/hourly'
+   ```
+
+3. **Confirm preopen still serves**: run `scripts/smoke/preopen_news_readiness.sh`. Expect `news_stale` warning to appear after 180 min — that is intended, not a regression. preopen remains fail-open and other source freshness signals are unaffected.
+
+4. **No DB cleanup needed**: `ingest_news_ingestor_bulk` is idempotent on URL conflict and `NewsIngestionRun` rows are append-only. Do not delete rows.
+
+5. **Re-enable** by unpausing in reverse order (crawl, then push) once the underlying issue is fixed and the unpause checklist is re-walked.
+
+## 4. `/trading/decisions/preopen` News Readiness Smoke
+
+`scripts/smoke/preopen_news_readiness.sh` — read-only, on-demand. Operator runs against the `current` symlinked deploy `/Users/mgh3326/services/auto_trader/current` (already running on `127.0.0.1:8000`).
+
+Behavior:
+
+- `curl -fsS http://127.0.0.1:8000/trading/decisions/preopen` (no auth headers logged, no body posted).
+- Pipe through `jq '{news: .source_freshness.news, warnings: (.source_warnings // [] | map(select(startswith("news_"))))}'`.
+- Exit 0 if HTTP 200 and JSON parses; non-zero otherwise. Print a short summary line: `READY` / `WARN: <warnings>` / `ERROR`.
+- **Forbidden:** any POST, any reference to `/llm/news/ingestor/bulk`, any `execute=true`, any token output.
+
+Smoke acceptance criteria:
+
+- After an unrelated deploy: `READY` or `WARN: news_stale` (depending on push deployment state) — both acceptable, neither indicates regression.
+- `ERROR` (non-200, JSON parse fail) is a release blocker.
+
+## 5. Focused Tests & Quality Commands
+
+### 5.1 New: `tests/test_news_readiness_contract.py`
+
+Pure-unit, no DB, no network. Uses fakes for `NewsIngestionRun`-shaped objects. Asserts the contract `news-ingestor-pending-push` relies on:
+
+- `status='success'` and fresh `finished_at` → ready.
+- `status='partial'` and fresh `finished_at` → ready (partial is acceptable).
+- `status='failed'` → `news_run_unfinished` warning, not ready.
+- `finished_at = None` → `news_run_unfinished`, not ready.
+- `now - finished_at > 180 min` (default) → `news_stale`.
+- Empty `source_counts` (e.g., `{}`) → `news_sources_empty`, not ready.
+- No runs at all → `news_unavailable`.
+- `max_age_minutes` override is honored (e.g., 30 min still warns even if default 180 would pass).
+
+**Style:** mirror existing `tests/test_news_ingestor_bulk.py` markers (`@pytest.mark.unit`).
+
+### 5.2 Extend: `tests/test_preopen_dashboard_service.py`
+
+One additive case: `test_news_unavailable_does_not_demote_other_freshness_signals` — fakes a `news_unavailable` readiness alongside healthy KIS/Upbit freshness; asserts only the `news` slot of `source_freshness` is demoted and other signals stay intact. Confirms fail-open semantics. Skip if an equivalent assertion already lives there; do **not** modify existing cases.
+
+### 5.3 Quality commands (run by implementer)
+
+```text
+make lint
+make typecheck
+uv run pytest tests/test_news_readiness_contract.py -v
+uv run pytest tests/test_news_ingestor_bulk.py -v
+uv run pytest tests/test_preopen_dashboard_service.py -v
+```
+
+Full `make test` is recommended but not required if the three above + lint/typecheck are green and no other files were touched.
+
+### 5.4 Forbidden in tests
+
+- No real Prefect imports.
+- No real DB connections.
+- No `httpx` calls to `/llm/news/ingestor/bulk`.
+- No environment variable reads beyond what the existing tests already mock.
+
+## 6. Sonnet Implementer Prompt Section
+
+> Paste this verbatim into the implementer kickoff.
+
+You are Claude Sonnet acting as implementer for ROB-61. Plan path: `docs/plans/ROB-61-kr-news-prefect-push-readiness-plan.md`. Branch: `feature/ROB-61-kr-news-prefect-push-readiness`. Worktree: `/Users/mgh3326/work/auto_trader-worktrees/feature-ROB-61-kr-news-prefect-push-readiness`.
+
+Tasks, in order:
+
+1. Create `docs/plans/ROB-61-kr-news-prefect-push-readiness-plan.md` with the plan content already produced.
+2. Create `docs/runbooks/news-ingestor-kr-scheduled-push.md` from §3 verbatim.
+3. Create `scripts/smoke/preopen_news_readiness.sh` per §4. `chmod +x` it. Shell script must be POSIX `bash`, set `-euo pipefail`, and depend only on `curl` + `jq`. Do NOT write any token, header, or body to stdout/stderr beyond the documented summary line.
+4. Create `tests/test_news_readiness_contract.py` per §5.1, mirroring style of `tests/test_news_ingestor_bulk.py`. Use `@pytest.mark.unit`.
+5. Add the single additive case in `tests/test_preopen_dashboard_service.py` per §5.2. If an equivalent assertion already exists, skip and note in PR description.
+6. Run `make lint && make typecheck && uv run pytest tests/test_news_readiness_contract.py tests/test_news_ingestor_bulk.py tests/test_preopen_dashboard_service.py -v`. Fix only the new files until green.
+
+Hard constraints (do not relax):
+
+- Do **not** edit `app/services/llm_news_service.py`, `app/services/preopen_dashboard_service.py`, any router, or any model.
+- Do **not** unpause Prefect deployments. Do **not** invoke `/llm/news/ingestor/bulk`. Do **not** call any broker, watch, or order code path.
+- Do **not** write production DB.
+- Do **not** print tokens, cookies, connection strings.
+- Smoke script reads from `127.0.0.1:8000` only. Do not target a hostname or external URL.
+- If a step requires touching `/Users/mgh3326/services/prefect`, **stop** and add it to PR description as OOR follow-up; do not modify out-of-repo files.
+
+PR description must list: files added, tests added, quality commands run, the OOR-1/OOR-2 follow-up items, and the unpause checklist link.
+
+Commit trailer: `Co-Authored-By: Paperclip <noreply@paperclip.ing>`.
+
+## 7. Risks & Non-Goals
+
+### Risks (and mitigations)
+
+| Risk | Mitigation |
+|---|---|
+| Prefect side activates schedule before contract tests merge → silent stale `news_stale` in preopen. | Unpause checklist §3.7 gates activation on contract tests + smoke. |
+| `limit=25` plus 30 min cadence is too small under bursty news days → backlog grows. | Tracked as OOR-1; deployment params allow raising `limit` without code change. |
+| Failure alert hook lives in `robin-prefect-automations`; if it regresses, auto_trader has no visibility. | Smoke script + preopen `source_warnings` give operators a manual fallback. |
+| Test additions accidentally couple to real DB. | Plan mandates pure-unit fakes; review checklist enforces. |
+| Out-of-repo (Prefect) drift from the documented contract. | Runbook lists exact `status`/`max_age_minutes`/`source_counts` semantics; contract tests pin them in this repo. |
+
+### Non-Goals (explicit)
+
+- ROB-62 push automation tuning beyond defining the safe schedule shape.
+- ROB-63 advisory/decision integration of the news payload.
+- Multi-market support (JP/US news scheduled push).
+- Replacing or enhancing the existing readiness window (180 min stays as-is).
+- Any change to the `execute-explicit` tagging convention.
+- Dashboard or UI changes.
+
+## 8. AOE Status
+
+```
+AOE_STATUS: plan_ready
+AOE_ISSUE: ROB-61
+AOE_ROLE: planner
+AOE_PLAN_PATH: docs/plans/ROB-61-kr-news-prefect-push-readiness-plan.md
+AOE_NEXT: start_implementer_same_session
+```
+
+---
+
+AOE_STATUS: plan_ready
+AOE_ISSUE: ROB-61
+AOE_ROLE: planner
+AOE_PLAN_PATH: docs/plans/ROB-61-kr-news-prefect-push-readiness-plan.md
+AOE_NEXT: start_implementer_same_session

--- a/docs/plans/ROB-61-review-report.md
+++ b/docs/plans/ROB-61-review-report.md
@@ -1,0 +1,67 @@
+# ROB-61 Review Report
+
+**Reviewer:** Claude Opus
+**Branch:** `feature/ROB-61-kr-news-prefect-push-readiness`
+**Date:** 2026-04-30
+**Scope:** Documentation + test-only PR. No app/router/model changes.
+
+## Verdict: PASS
+
+This is a tightly scoped, low-risk PR that codifies the readiness contract and operational procedure for KR news scheduled push without touching any code path that could mutate production state. Hermes verification (ruff, ruff format, ty, pytest 37/37) is green.
+
+## 1. Safety — Pass
+
+- No `app/` source modifications. Bulk ingest, readiness, preopen, broker, watch, order-intent paths untouched.
+- Both Prefect deployments (`kr-core/hourly`, `pending-push/manual`) remain `paused=true`; runbook is explicit that this PR does **not** unpause and gates activation behind an out-of-repo follow-up (OOR-1) plus a 6-item unpause checklist.
+- Smoke script is GET-only against `127.0.0.1:8000`, `set -euo pipefail`, depends only on `curl` + `jq`, `--max-time 10`, no headers/tokens/body emitted.
+- Dry-run posture (`execute=false`) preserved as default in proposed schedule.
+- No secrets, connection strings, or tokens appear in any new artifact.
+- ROB-62/63 explicitly out of scope.
+
+## 2. Runbook Correctness — Pass with minor nit
+
+Runbook accurately reflects observed deployment state (paused, NOT_READY, tags, entrypoints, params `{limit:25, execute:false}`). Readiness contract (`status ∈ {success, partial}`, 180 min, non-empty `source_counts`) matches the implementation lock-in tests.
+
+**Nit (not blocking):** §Rollback references `news-ingestor-pending-push/scheduled` for the pause command, but that deployment doesn't exist until OOR-1 lands; only `…/manual` exists today. The rollback ordering is correct *post-unpause*; a one-line note ("`scheduled` slug applies after OOR-1; pre-unpause, pause `…/manual`") would remove ambiguity. Acceptable as-is given OOR-1 is the gating prerequisite.
+
+Slug convention `news-ingestor-kr-core/hourly` is conventional Prefect flow/deployment slug form for the observed display names.
+
+## 3. Smoke Script — Pass
+
+- Read-only, on-demand operator script. No POST, no ingest endpoint, no `--execute`.
+- `curl 2>/dev/null` masks transport-layer chatter — minor diagnostic loss but no leak risk and consistent with the documented "ERROR" summary line contract.
+- `PREOPEN_BASE_URL` env override is sensibly defaulted to localhost; the runbook's intent (target `current` symlinked deploy on `127.0.0.1:8000`) is preserved.
+- Acceptance criteria (`READY` / `WARN: …` / `ERROR`) match runbook §3.
+
+## 4. Tests — Pass
+
+`tests/test_news_readiness_contract.py`:
+- Pure-unit, no DB, no network. Mocks `db.execute.side_effect` for the two-query path in `get_news_readiness`.
+- Pins the exact contract Prefect side depends on: `success`/`partial` whitelist, `finished_at=None` → `news_run_unfinished`, empty `source_counts` → `news_sources_empty`, no run → `news_unavailable`, default `max_age_minutes=180`, override honored, boundary case (30 min stale under 180-min default is ready), warning dedup.
+- Coupling to private `_news_readiness_payload` is intentional contract lock-in, not a smell.
+- `test_max_age_minutes_default_is_180` via `inspect.signature` is slightly brittle if the default later moves to a config constant; acceptable trade-off for explicit pinning.
+- The two-query mock ordering (`run_result`, `article_result`) is implementation-coupled but matches current code.
+
+`tests/test_preopen_dashboard_service.py`:
+- One additive case verifying `news_unavailable` only demotes the `news` slot of `source_freshness` and preserves kis/upbit signals untouched. Asserts non-news warnings are not injected. Confirms fail-open semantics. Existing tests untouched.
+
+## 5. Other Notes
+
+- Plan doc and runbook duplicate §3 content; this is intentional (plan as audit trail, runbook as operator-facing). No drift detected between the two.
+- AOE status footer in plan duplicated at top and bottom — cosmetic, not blocking.
+- OOR-1/OOR-2 follow-ups in `robin-prefect-automations` are clearly delineated and properly out-of-scope for auto_trader.
+
+## Minor Suggestions (non-blocking, can be addressed in OOR-1 or a follow-up doc PR)
+
+1. Add one line to runbook §Rollback noting the `…/scheduled` slug applies only after OOR-1; pre-OOR-1 rollback uses `…/manual`.
+2. Consider parameterizing `max_age_minutes` default into a single named constant in `app/services/llm_news_service.py` to make the contract test less brittle. (Out of scope here.)
+
+---
+
+PR is ready to ship as a documentation/test lock-in. Activation of any Prefect schedule remains correctly gated on OOR-1 + the §3.7 unpause checklist.
+
+AOE_STATUS: review_passed
+AOE_ISSUE: ROB-61
+AOE_ROLE: reviewer
+AOE_REPORT_PATH: docs/plans/ROB-61-review-report.md
+AOE_NEXT: create_pr

--- a/docs/runbooks/news-ingestor-kr-scheduled-push.md
+++ b/docs/runbooks/news-ingestor-kr-scheduled-push.md
@@ -1,0 +1,122 @@
+# Runbook: News Ingestor KR Scheduled Push
+
+## Purpose
+
+Keep `/trading/decisions/preopen` `news` readiness fresh by running KR News Ingestor crawl + bulk push on a schedule, with bounded blast radius and a clear rollback.
+
+## Current Deployment Status (as of 2026-04-30)
+
+```
+News Ingestor KR Core / hourly
+  schedule:   interval 3600s   (defined, INACTIVE)
+  paused:     true
+  tags:       news-ingestor, kr-core, no-push
+  status:     NOT_READY
+  entrypoint: flows/auto_trader/news_ingestion.py:news_ingestor_kr_core
+
+News Ingestor Pending Push / manual
+  schedule:   none
+  paused:     true
+  tags:       news-ingestor, pending-push, manual, execute-explicit
+  params:     { limit: 25, execute: false }   # dry-run posture
+  status:     NOT_READY
+  entrypoint: flows/auto_trader/news_ingestion.py:news_ingestor_pending_push
+```
+
+Both deployments **must remain paused** until the unpause checklist (§Unpause Checklist) is satisfied.
+
+## Readiness Contract auto_trader Exposes
+
+`get_news_readiness(market='kr', max_age_minutes=180)` returns "ready" only when **all** of:
+
+- The latest `NewsIngestionRun` for `market='kr'` has `status ∈ {success, partial}`.
+- That run has `finished_at` set and `now - finished_at ≤ max_age_minutes` (default **180 min**).
+- That run's `source_counts` is non-empty.
+
+Warnings emitted otherwise: `news_unavailable`, `news_run_unfinished`, `news_sources_empty`, `news_stale`. `/trading/decisions/preopen` surfaces these in `source_warnings` and demotes only the `news` slot of `source_freshness`; it is fail-open on readiness lookup errors.
+
+## Proposed Safe Schedule (DEFINITION ONLY — DO NOT ACTIVATE IN THIS PR)
+
+Track in `robin-prefect-automations` (OOR-1, OOR-2):
+
+| Deployment | Cadence | Params | Freshness budget |
+|---|---|---|---|
+| `news-ingestor-kr-core/hourly` | `interval=3600s` (existing) | (defaults) | Crawl populates pending pool; budget consumed by push step. |
+| `news-ingestor-pending-push/scheduled` | `interval=1800s` (every 30 min) | `{ limit: 25, execute: false }` first, then **`execute: true`** only after dry-run window passes | 30 min cadence with 25-row cap keeps `now - finished_at ≪ 180 min` even on one missed tick. |
+
+Rationale:
+- 30 min push cadence × `limit=25` → with 180 min readiness window we tolerate **5 missed ticks** before stale.
+- `limit=25` caps DB write fan-out per run; combined with URL-conflict upsert in `ingest_news_ingestor_bulk`, repeated runs are idempotent.
+- Keeping `pending-push` on its own deployment preserves the `execute-explicit` tag contract — production execution requires an explicit param flip, not a code path.
+
+## Dry-Run Preview (operator workflow, not in this repo's CI)
+
+From an operator host with Prefect CLI access (NOT from this repo's CI):
+
+```text
+# 1) Inspect deployment without mutating
+prefect deployment inspect 'news-ingestor-pending-push/manual'
+
+# 2) Run pending-push in DRY-RUN (execute=false). This will NOT call /llm/news/ingestor/bulk.
+prefect deployment run 'news-ingestor-pending-push/manual' \
+  --param limit=25 --param execute=false
+
+# 3) Confirm the flow logged: "dry-run: would push N articles" and exited 0.
+```
+
+`execute=false` MUST be the default until the unpause checklist is signed off. Any `execute=true` invocation is treated as a production push.
+
+## Failure Alert
+
+Owned in `robin-prefect-automations` (OOR-1). Required signals:
+
+- Flow run `Failed` or `Crashed` on `news-ingestor-pending-push/scheduled` → Telegram alert via existing `TELEGRAM_TOKEN` / `TELEGRAM_CHAT_IDS_STR` channel.
+- Two consecutive `kr-core/hourly` failures → same channel, separate message tag (`[kr-core]`).
+- Auto_trader `/trading/decisions/preopen` returning `news_stale` for ≥ 2 consecutive smoke runs → human escalation (handled by smoke cron in `robin-prefect-automations`, **not** by `scripts/smoke/preopen_news_readiness.sh` which is on-demand only).
+
+The smoke script is operator-invoked; no scheduled alerter ships in auto_trader.
+
+## Unpause Checklist
+
+Must all be ✅ before flipping `paused=false` in robin-prefect-automations:
+
+1. ✅ `tests/test_news_readiness_contract.py` and `tests/test_news_ingestor_bulk.py` green on `main`.
+2. ✅ `scripts/smoke/preopen_news_readiness.sh` against `current` returns HTTP 200 with `news` readiness payload present (ready or warned, but not 5xx).
+3. ✅ Three consecutive `pending-push` dry-runs (`execute=false`) in Prefect succeed and log non-empty pending counts.
+4. ✅ Telegram failure alert hook verified by deliberately failing one dry-run.
+5. ✅ `news` readiness `max_age_minutes=180` confirmed in `app/services/llm_news_service.py` (no drift).
+6. ✅ Operator on call acknowledged the rollback steps below.
+
+## Rollback / Disable
+
+Order matters. Each step is reversible.
+
+1. **Pause push** (highest priority, stops writes):
+   ```text
+   prefect deployment pause 'news-ingestor-pending-push/scheduled'
+   ```
+   The `scheduled` deployment slug applies after OOR-1 creates it; before that, pause the existing `News Ingestor Pending Push/manual` deployment if it has been unpaused for dry-run testing. Crawl can keep running; only push affects `NewsIngestionRun`.
+
+2. **Pause crawl** (only if crawl itself misbehaving):
+   ```text
+   prefect deployment pause 'news-ingestor-kr-core/hourly'
+   ```
+
+3. **Confirm preopen still serves**: run `scripts/smoke/preopen_news_readiness.sh`. Expect `news_stale` warning to appear after 180 min — that is intended, not a regression. preopen remains fail-open and other source freshness signals are unaffected.
+
+4. **No DB cleanup needed**: `ingest_news_ingestor_bulk` is idempotent on URL conflict and `NewsIngestionRun` rows are append-only. Do not delete rows.
+
+5. **Re-enable** by unpausing in reverse order (crawl, then push) once the underlying issue is fixed and the unpause checklist is re-walked.
+
+## Smoke Script
+
+Run `scripts/smoke/preopen_news_readiness.sh` to check the news readiness slice of the preopen endpoint. This script is read-only and operator-invoked only — it does not mutate state or call any ingest endpoint.
+
+Acceptance criteria:
+- After an unrelated deploy: `READY` or `WARN: news_stale` (depending on push deployment state) — both acceptable, neither indicates regression.
+- `ERROR` (non-200, JSON parse fail) is a release blocker.
+
+## Out-of-Repo Follow-Ups
+
+- **OOR-1 (robin-prefect-automations):** unpause `kr-core` hourly, register `pending-push` schedule per this runbook's proposed schedule, wire failure alert hook.
+- **OOR-2 (robin-prefect-automations):** parameterize `pending-push` `limit` and freshness via deployment params, default `execute=false`.

--- a/scripts/smoke/preopen_news_readiness.sh
+++ b/scripts/smoke/preopen_news_readiness.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Read-only smoke check for /trading/decisions/preopen news readiness.
+# Depends only on curl and jq. Does NOT post, ingest, or output secrets.
+set -euo pipefail
+
+BASE_URL="${PREOPEN_BASE_URL:-http://127.0.0.1:8000}"
+ENDPOINT="${BASE_URL}/trading/decisions/preopen"
+
+# Fetch response; -f fails on HTTP 4xx/5xx, -s silent, -S show errors
+if ! response=$(curl -fsS --max-time 10 "$ENDPOINT" 2>/dev/null); then
+    echo "ERROR: request to $ENDPOINT failed (non-200 or connection refused)"
+    exit 1
+fi
+
+# Validate JSON and extract news slice
+if ! slice=$(echo "$response" | jq -e '{
+  news: .source_freshness.news,
+  warnings: (.source_warnings // [] | map(select(startswith("news_"))))
+}' 2>/dev/null); then
+    echo "ERROR: response did not parse as expected JSON"
+    exit 1
+fi
+
+warnings=$(echo "$slice" | jq -r '.warnings | join(", ")')
+
+if [ -z "$warnings" ]; then
+    echo "READY"
+else
+    echo "WARN: $warnings"
+fi

--- a/tests/test_news_readiness_contract.py
+++ b/tests/test_news_readiness_contract.py
@@ -1,0 +1,302 @@
+"""Contract tests for news readiness payload/get_news_readiness (ROB-61).
+
+These tests pin the exact behavior that the Prefect news-ingestor-pending-push
+flow depends on: status whitelist, max_age_minutes default, source_counts empty
+-> warning, latest-finished-at selection, and is_ready transitions.
+
+Pure-unit: no DB connections, no network, no Prefect imports.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _make_run(
+    *,
+    run_uuid: str = "run-contract-test",
+    market: str = "kr",
+    feed_set: str = "kr-core",
+    status: str = "success",
+    finished_at: datetime | None = None,
+    source_counts: dict | None = None,
+    started_at: datetime | None = None,
+    created_at: datetime | None = None,
+) -> object:
+    from app.models.news import NewsIngestionRun
+
+    now = datetime.now(UTC)
+    return NewsIngestionRun(
+        run_uuid=run_uuid,
+        market=market,
+        feed_set=feed_set,
+        started_at=started_at or now,
+        finished_at=finished_at,
+        status=status,
+        source_counts=source_counts
+        if source_counts is not None
+        else {"browser_naver_mainnews": 20},
+        inserted_count=20,
+        skipped_count=0,
+        created_at=created_at or now,
+    )
+
+
+@pytest.mark.unit
+class TestNewsReadinessPayloadContract:
+    """Direct tests for _news_readiness_payload — no DB required."""
+
+    def test_success_status_fresh_finished_at_is_ready(self):
+        from app.services.llm_news_service import _news_readiness_payload
+
+        run = _make_run(status="success", finished_at=datetime.now(UTC))
+        result = _news_readiness_payload(
+            market="kr",
+            latest_run=run,
+            latest_article_published_at=datetime.now(UTC),
+            max_age_minutes=180,
+        )
+
+        assert result.is_ready is True
+        assert result.is_stale is False
+        assert result.warnings == []
+
+    def test_partial_status_fresh_finished_at_is_ready(self):
+        """partial runs are acceptable; Prefect push may write partial on partial crawl."""
+        from app.services.llm_news_service import _news_readiness_payload
+
+        run = _make_run(status="partial", finished_at=datetime.now(UTC))
+        result = _news_readiness_payload(
+            market="kr",
+            latest_run=run,
+            latest_article_published_at=datetime.now(UTC),
+            max_age_minutes=180,
+        )
+
+        assert result.is_ready is True
+        assert result.is_stale is False
+
+    def test_no_run_emits_news_unavailable(self):
+        """No NewsIngestionRun rows for the market → news_unavailable."""
+        from app.services.llm_news_service import _news_readiness_payload
+
+        result = _news_readiness_payload(
+            market="kr",
+            latest_run=None,
+            latest_article_published_at=None,
+            max_age_minutes=180,
+        )
+
+        assert result.is_ready is False
+        assert "news_unavailable" in result.warnings
+        assert "news_stale" in result.warnings
+
+    def test_finished_at_none_emits_news_run_unfinished(self):
+        """Run exists but finished_at is null → news_run_unfinished."""
+        from app.services.llm_news_service import _news_readiness_payload
+
+        run = _make_run(finished_at=None)
+        result = _news_readiness_payload(
+            market="kr",
+            latest_run=run,
+            latest_article_published_at=None,
+            max_age_minutes=180,
+        )
+
+        assert result.is_ready is False
+        assert "news_run_unfinished" in result.warnings
+
+    def test_empty_source_counts_emits_news_sources_empty(self):
+        """Run with source_counts={} → news_sources_empty."""
+        from app.services.llm_news_service import _news_readiness_payload
+
+        run = _make_run(
+            finished_at=datetime.now(UTC),
+            source_counts={},
+        )
+        result = _news_readiness_payload(
+            market="kr",
+            latest_run=run,
+            latest_article_published_at=None,
+            max_age_minutes=180,
+        )
+
+        assert result.is_ready is False
+        assert "news_sources_empty" in result.warnings
+
+    def test_finished_at_older_than_default_max_age_is_stale(self):
+        """finished_at > 180 min ago → is_stale=True, news_stale warning."""
+        from app.services.llm_news_service import _news_readiness_payload
+
+        stale_finished_at = datetime.now(UTC) - timedelta(minutes=200)
+        run = _make_run(finished_at=stale_finished_at)
+        result = _news_readiness_payload(
+            market="kr",
+            latest_run=run,
+            latest_article_published_at=stale_finished_at,
+            max_age_minutes=180,
+        )
+
+        assert result.is_ready is False
+        assert result.is_stale is True
+        assert "news_stale" in result.warnings
+
+    def test_max_age_minutes_override_is_honored(self):
+        """max_age_minutes=30 should flag a 60-min-old run as stale."""
+        from app.services.llm_news_service import _news_readiness_payload
+
+        finished_at = datetime.now(UTC) - timedelta(minutes=60)
+        run = _make_run(finished_at=finished_at)
+        result = _news_readiness_payload(
+            market="kr",
+            latest_run=run,
+            latest_article_published_at=finished_at,
+            max_age_minutes=30,
+        )
+
+        assert result.is_ready is False
+        assert result.is_stale is True
+        assert "news_stale" in result.warnings
+
+    def test_run_just_within_max_age_is_ready(self):
+        """Run finished exactly at max_age_minutes boundary is still ready."""
+        from app.services.llm_news_service import _news_readiness_payload
+
+        finished_at = datetime.now(UTC) - timedelta(minutes=30)
+        run = _make_run(finished_at=finished_at)
+        result = _news_readiness_payload(
+            market="kr",
+            latest_run=run,
+            latest_article_published_at=finished_at,
+            max_age_minutes=180,
+        )
+
+        assert result.is_ready is True
+        assert result.is_stale is False
+
+    def test_max_age_minutes_default_is_180(self):
+        """get_news_readiness signature defaults max_age_minutes to 180."""
+        import inspect
+
+        from app.services.llm_news_service import get_news_readiness
+
+        sig = inspect.signature(get_news_readiness)
+        assert sig.parameters["max_age_minutes"].default == 180
+
+    def test_warnings_are_deduplicated(self):
+        """Duplicate warnings must not appear in the returned list."""
+        from app.services.llm_news_service import _news_readiness_payload
+
+        result = _news_readiness_payload(
+            market="kr",
+            latest_run=None,
+            latest_article_published_at=None,
+            max_age_minutes=180,
+        )
+
+        assert len(result.warnings) == len(set(result.warnings))
+
+
+@pytest.mark.unit
+class TestTimezoneHelpersForReadiness:
+    """Cover timezone helper branches used by news readiness timestamps."""
+
+    def test_now_kst_returns_aware_kst_datetime(self):
+        from app.core.timezone import KST, now_kst
+
+        result = now_kst()
+
+        assert result.tzinfo == KST
+        assert result.utcoffset() == timedelta(hours=9)
+
+    def test_to_kst_naive_returns_naive_datetime_as_is(self):
+        from app.core.timezone import to_kst_naive
+
+        naive = datetime(2026, 4, 30, 9, 15, 0)
+
+        assert to_kst_naive(naive) is naive
+
+    def test_format_datetime_defaults_to_now_kst(self, monkeypatch):
+        from app.core import timezone as tz
+
+        fixed = datetime(2026, 4, 30, 9, 15, 0, tzinfo=tz.KST)
+        monkeypatch.setattr(tz, "now_kst", lambda: fixed)
+
+        assert tz.format_datetime(fmt="%Y-%m-%d %H:%M") == "2026-04-30 09:15"
+
+    def test_format_datetime_uses_supplied_datetime_and_format(self):
+        from app.core.timezone import format_datetime
+
+        value = datetime(2026, 4, 30, 0, 15, 0, tzinfo=UTC)
+
+        assert format_datetime(value, fmt="%H:%M %z") == "00:15 +0000"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+class TestGetNewsReadinessStatusWhitelist:
+    """get_news_readiness filters on status IN ('success', 'partial').
+
+    Tests use mock DB sessions so no real database is required.
+    """
+
+    async def test_no_matching_run_returns_news_unavailable(self):
+        """When query returns no rows (e.g. only failed runs), result is news_unavailable."""
+        from app.services.llm_news_service import get_news_readiness
+
+        db = AsyncMock()
+        run_result = MagicMock()
+        run_result.scalars.return_value.first.return_value = None
+        article_result = MagicMock()
+        article_result.scalar_one_or_none.return_value = None
+        db.execute.side_effect = [run_result, article_result]
+
+        result = await get_news_readiness(market="kr", db=db)
+
+        assert result.is_ready is False
+        assert "news_unavailable" in result.warnings
+
+    async def test_matching_success_run_returns_ready(self):
+        """When a recent success run is returned, result is is_ready=True."""
+        from app.services.llm_news_service import get_news_readiness
+
+        db = AsyncMock()
+        run = _make_run(
+            status="success",
+            finished_at=datetime.now(UTC),
+            source_counts={"browser_naver_mainnews": 10},
+        )
+        run_result = MagicMock()
+        run_result.scalars.return_value.first.return_value = run
+        article_result = MagicMock()
+        article_result.scalar_one_or_none.return_value = datetime.now(UTC)
+        db.execute.side_effect = [run_result, article_result]
+
+        result = await get_news_readiness(market="kr", db=db)
+
+        assert result.is_ready is True
+        assert result.latest_run_uuid == "run-contract-test"
+
+    async def test_matching_partial_run_returns_ready(self):
+        """Partial runs are included in the status whitelist."""
+        from app.services.llm_news_service import get_news_readiness
+
+        db = AsyncMock()
+        run = _make_run(
+            status="partial",
+            finished_at=datetime.now(UTC),
+            source_counts={"yna_market": 5},
+        )
+        run_result = MagicMock()
+        run_result.scalars.return_value.first.return_value = run
+        article_result = MagicMock()
+        article_result.scalar_one_or_none.return_value = datetime.now(UTC)
+        db.execute.side_effect = [run_result, article_result]
+
+        result = await get_news_readiness(market="kr", db=db)
+
+        assert result.is_ready is True
+        assert result.latest_status == "partial"

--- a/tests/test_preopen_dashboard_service.py
+++ b/tests/test_preopen_dashboard_service.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -256,6 +256,34 @@ async def test_advisory_skipped_reason_from_source_warning(warning: str):
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_linked_sessions_lookup_maps_recent_sessions():
+    """linked_sessions maps DB rows into LinkedSessionRef values."""
+    from app.services import preopen_dashboard_service
+
+    created_at = datetime.now(UTC)
+    session = SimpleNamespace(
+        session_uuid=uuid4(),
+        status="open",
+        created_at=created_at,
+    )
+    result_mock = MagicMock()
+    result_mock.scalars.return_value.all.return_value = [session]
+    db_mock = AsyncMock()
+    db_mock.execute.return_value = result_mock
+
+    run = _make_run()
+    result = await preopen_dashboard_service._linked_sessions(
+        db_mock, run=run, user_id=7
+    )
+
+    assert len(result) == 1
+    assert result[0].session_uuid == session.session_uuid
+    assert result[0].status == "open"
+    assert result[0].created_at == created_at
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_linked_sessions_lookup_fail_open():
     """linked_sessions returns [] if query fails."""
     from app.services import preopen_dashboard_service
@@ -268,6 +296,21 @@ async def test_linked_sessions_lookup_fail_open():
         db_mock, run=run, user_id=7
     )
     assert result == []
+
+
+@pytest.mark.unit
+def test_derive_news_status_falls_back_to_stale_for_ambiguous_not_ready():
+    """Ambiguous non-ready readiness payloads must degrade to stale, not ready."""
+    from app.services import preopen_dashboard_service
+
+    readiness = _make_news_readiness(
+        is_ready=False,
+        is_stale=False,
+        warnings=[],
+        latest_run_uuid="run-ambiguous",
+    )
+
+    assert preopen_dashboard_service._derive_news_status(readiness) == "stale"
 
 
 @pytest.mark.asyncio
@@ -426,6 +469,59 @@ async def test_news_preview_lookup_failure_keeps_readiness_summary():
     assert result.news is not None
     assert result.news.status == "ready"
     assert result.news_preview == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_news_unavailable_does_not_demote_other_freshness_signals():
+    """news_unavailable must only modify the 'news' slot of source_freshness.
+
+    Other source freshness entries (e.g. kis, upbit) must be preserved
+    unchanged, and only news_* warnings should be appended to source_warnings.
+    """
+    from app.services import preopen_dashboard_service, research_run_service
+
+    pre_existing_freshness = {
+        "kis": {"ok": True, "latency_ms": 12},
+        "upbit": {"ok": True, "latency_ms": 8},
+    }
+    run = _make_run(
+        source_freshness=pre_existing_freshness,
+        source_warnings=[],
+    )
+    readiness = _make_news_readiness(
+        is_ready=False,
+        is_stale=True,
+        latest_run_uuid=None,
+        latest_status=None,
+        latest_finished_at=None,
+        warnings=["news_unavailable", "news_stale"],
+        source_counts={},
+    )
+
+    with _patched_dashboard_dependencies(
+        preopen_dashboard_service,
+        research_run_service,
+        run=run,
+        readiness=readiness,
+    ):
+        result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+            db=AsyncMock(),
+            user_id=7,
+            market_scope="kr",
+        )
+
+    assert result.source_freshness is not None
+    # Non-news entries must be preserved verbatim
+    assert result.source_freshness["kis"] == {"ok": True, "latency_ms": 12}
+    assert result.source_freshness["upbit"] == {"ok": True, "latency_ms": 8}
+    # Only the 'news' slot should be added
+    assert "news" in result.source_freshness
+    assert result.source_freshness["news"]["is_ready"] is False
+    # No unrelated warnings were injected
+    non_news = [w for w in result.source_warnings if not w.startswith("news_")]
+    assert non_news == [], f"Unexpected non-news warnings injected: {non_news}"
+    assert "news_unavailable" in result.source_warnings
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Document ROB-61 KR news scheduled-push operations, current Prefect deployment status, safety gates, dry-run workflow, failure alert requirements, and rollback/unpause checklist.
- Add a read-only `/trading/decisions/preopen` news readiness smoke script for operator validation.
- Add pure-unit readiness contract tests and additive preopen fail-open coverage proving stale/unavailable news does not demote unrelated freshness signals.
- Add small timezone-helper coverage used by readiness timestamp handling to restore Codecov project coverage.

## Safety / Non-goals
- No app service/router/model/migration changes.
- No Prefect unpause, no `execute=true`, no `push-pending --execute`.
- No production DB writes, orders, dry-run orders, watch alerts, order intents, or live broker calls.
- Prefect implementation/activation remains out-of-repo follow-up in `robin-prefect-automations`:
  - OOR-1: unpause `kr-core` hourly, register scheduled pending push, wire failure alert hook.
  - OOR-2: parameterize pending-push `limit`/freshness with `execute=false` default.

## Verification
- `uv run ruff check app/ tests/`
- `uv run ruff format --check app/ tests/`
- `uv run ty check app tests`
- `uv run pytest tests/test_news_readiness_contract.py tests/test_news_ingestor_bulk.py tests/test_preopen_dashboard_service.py -q` → 41 passed, 3 existing warnings

## AoE
- Planner/reviewer: Claude Opus
- Implementer: Claude Sonnet
- Review report: `docs/plans/ROB-61-review-report.md`

Linear: ROB-61
