### PR TITLE
feat(ROB-56): hard-separate KIS mock MCP profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,4 +15,16 @@
 - `total_available` integer field in `get_order_history` response.
 
 ## Unreleased
+
+### Added (ROB-56 — KIS official mock hard-separation)
+- `MCP_PROFILE` env var (`default` / `hermes-paper-kis`) gates which order tool surface is registered at startup.
+- New `hermes-paper-kis` profile: only `kis_mock_*` typed order tools registered; live order surface (`kis_live_*`, legacy ambiguous tools) physically absent from the MCP tool list.
+- Typed `kis_live_*` MCP order tools (`kis_live_place_order`, `kis_live_cancel_order`, `kis_live_modify_order`, `kis_live_get_order_history`) — hard-pin `is_mock=False`; additive in `default` profile.
+- Typed `kis_mock_*` MCP order tools (`kis_mock_place_order`, `kis_mock_cancel_order`, `kis_mock_modify_order`, `kis_mock_get_order_history`) — hard-pin `is_mock=True`; fail closed on missing KIS mock config.
+- Broker capability metadata registry (`app/services/brokers/capabilities.py`): KIS and Kiwoom declared as KR+US equity brokers; metadata only, no routing change.
+- `_KISSettingsView` credential isolation regression tests (ROB-19 phase-2 carry).
+
+### Changed (ROB-56)
+- `register_all_tools` now accepts an optional `profile: McpProfile` parameter (default `McpProfile.DEFAULT`); existing deployments unaffected.
+
 - Breaking: Require Python 3.13+ and drop support for Python 3.11 and 3.12.

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -1003,3 +1003,60 @@ docker compose -f docker-compose.prod.yml up -d mcp
 ```
 
 > Note: current prod compose uses `network_mode: host`, so port publishing is handled by the host network.
+
+---
+
+## MCP Profiles (ROB-56)
+
+### Overview
+
+The `MCP_PROFILE` env var selects which tool subset is registered at startup.
+
+| Profile | Value | Order surface |
+|---|---|---|
+| Default (unchanged) | `default` (or unset) | Legacy `place_order`/`cancel_order`/`modify_order`/`get_order_history` + typed `kis_live_*` + typed `kis_mock_*` |
+| Paper/mock-only | `hermes-paper-kis` | Typed `kis_mock_*` only — live surface **physically absent** |
+
+### Profile: `hermes-paper-kis`
+
+Set `MCP_PROFILE=hermes-paper-kis` on paper-only deployments (e.g., where `KIS_MOCK_ENABLED=true`).
+
+- `kis_live_place_order`, `kis_live_cancel_order`, `kis_live_modify_order`, `kis_live_get_order_history` are **not registered**.
+- The legacy ambiguous `place_order`, `cancel_order`, `modify_order`, `get_order_history` are **not registered**.
+- Only `kis_mock_*` typed order tools are registered.
+- All read-only research and portfolio tools remain available.
+
+**Operator validation:** after deploying with `hermes-paper-kis`, check the MCP `/mcp` listing and confirm that none of `kis_live_*` or the legacy ambiguous order tools appear.
+
+### Typed KIS order tools
+
+Both profiles (including `default`) provide explicitly-named typed variants:
+
+**Mock (KIS official mock / paper):**
+- `kis_mock_place_order` — hard-pinned `is_mock=True`; fails closed if KIS mock config missing
+- `kis_mock_cancel_order`
+- `kis_mock_modify_order`
+- `kis_mock_get_order_history`
+
+**Live (real-money):**
+- `kis_live_place_order` — hard-pinned `is_mock=False`
+- `kis_live_cancel_order`
+- `kis_live_modify_order`
+- `kis_live_get_order_history`
+
+Each typed tool rejects any `account_mode` value other than its own pinned mode.
+
+### Fail-closed behavior
+
+`kis_mock_*` tools return a structured error (without delegating) when KIS mock config is incomplete:
+
+```json
+{
+  "success": false,
+  "error": "KIS mock account is disabled or missing required configuration: KIS_MOCK_ENABLED, KIS_MOCK_APP_KEY",
+  "source": "kis",
+  "account_mode": "kis_mock"
+}
+```
+
+With all mock vars missing, the `hermes-paper-kis` profile is effectively read-only KIS — the safe state for a misconfigured paper deployment.

--- a/app/mcp_server/main.py
+++ b/app/mcp_server/main.py
@@ -2,6 +2,7 @@ import logging
 
 from app.core.config import settings
 from app.mcp_server.env_utils import _env, _env_int, get_mcp_graceful_shutdown_timeout
+from app.mcp_server.profiles import resolve_mcp_profile
 from app.monitoring.sentry import capture_exception, init_sentry
 
 # ──────────────────────────────────────────────────────────────────────
@@ -48,7 +49,8 @@ mcp = FastMCP(
 
 mcp.add_middleware(McpToolCallSentryMiddleware())
 mcp.add_middleware(CallerIdentityMiddleware())
-register_all_tools(mcp)
+_mcp_profile = resolve_mcp_profile(_env("MCP_PROFILE"))
+register_all_tools(mcp, profile=_mcp_profile)
 
 
 def _validate_caller_agent_id_fallback(mcp_type: str) -> None:

--- a/app/mcp_server/profiles.py
+++ b/app/mcp_server/profiles.py
@@ -1,0 +1,34 @@
+"""MCP server profile definitions.
+
+Profiles gate which tool subsets are registered at startup.
+Profile selection is driven by the MCP_PROFILE env var (default: "default").
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class McpProfile(StrEnum):
+    DEFAULT = "default"
+    HERMES_PAPER_KIS = "hermes-paper-kis"
+
+
+def resolve_mcp_profile(env: str | None) -> McpProfile:
+    """Resolve MCP_PROFILE env value to McpProfile.
+
+    Empty/None → DEFAULT. Invalid string → ValueError.
+    """
+    normalized = (env or "").strip()
+    if not normalized:
+        return McpProfile.DEFAULT
+    try:
+        return McpProfile(normalized)
+    except ValueError:
+        allowed = ", ".join(f'"{p}"' for p in McpProfile)
+        raise ValueError(
+            f"Unknown MCP_PROFILE '{normalized}'; allowed values: {allowed}"
+        )
+
+
+__all__ = ["McpProfile", "resolve_mcp_profile"]

--- a/app/mcp_server/tooling/orders_kis_variants.py
+++ b/app/mcp_server/tooling/orders_kis_variants.py
@@ -1,0 +1,513 @@
+"""Typed KIS order tool variants: kis_live_* and kis_mock_*.
+
+Each variant is a thin wrapper that:
+- Hard-pins is_mock (live=False, mock=True).
+- Validates any supplied account_mode/account_type matches the pinned mode.
+- For mock variants: fails closed via _mock_config_error() before delegating.
+- Delegates to existing order implementation functions.
+- Wraps response in apply_account_routing_metadata for a consistent envelope.
+
+The original ambiguous place_order/cancel_order/modify_order/get_order_history
+tools in orders_registration.py are unchanged; these are additive.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal
+
+from app.core.config import validate_kis_mock_config
+from app.mcp_server.tooling import order_execution, orders_history
+from app.mcp_server.tooling.account_modes import (
+    ACCOUNT_MODE_KIS_LIVE,
+    ACCOUNT_MODE_KIS_MOCK,
+    AccountRouting,
+    apply_account_routing_metadata,
+)
+from app.mcp_server.tooling.orders_modify_cancel import (
+    cancel_order_impl,
+    modify_order_impl,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+KIS_LIVE_ORDER_TOOL_NAMES: set[str] = {
+    "kis_live_place_order",
+    "kis_live_cancel_order",
+    "kis_live_modify_order",
+    "kis_live_get_order_history",
+}
+
+KIS_MOCK_ORDER_TOOL_NAMES: set[str] = {
+    "kis_mock_place_order",
+    "kis_mock_cancel_order",
+    "kis_mock_modify_order",
+    "kis_mock_get_order_history",
+}
+
+
+def _pinned_routing(account_mode: str) -> AccountRouting:
+    return AccountRouting(account_mode=account_mode)
+
+
+def _mock_config_error() -> dict[str, Any] | None:
+    missing = validate_kis_mock_config()
+    if not missing:
+        return None
+    return {
+        "success": False,
+        "error": (
+            "KIS mock account is disabled or missing required configuration: "
+            + ", ".join(missing)
+        ),
+        "source": "kis",
+        "account_mode": ACCOUNT_MODE_KIS_MOCK,
+    }
+
+
+def _check_mode_arg(
+    tool_name: str,
+    pinned_mode: str,
+    account_mode: str | None,
+    account_type: str | None,
+) -> dict[str, Any] | None:
+    """Return a structured rejection if account_mode or account_type mismatches pinned_mode."""
+    for param_name, value in (
+        ("account_mode", account_mode),
+        ("account_type", account_type),
+    ):
+        if value is None:
+            continue
+        normalized = str(value).strip().lower()
+        if normalized and normalized != pinned_mode:
+            return {
+                "success": False,
+                "error": (
+                    f"{tool_name} does not accept {param_name}='{value}'; "
+                    f"this tool is pinned to account_mode='{pinned_mode}'"
+                ),
+                "source": "mcp",
+                "account_mode": pinned_mode,
+            }
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Live variants (is_mock=False hard-pinned)
+# ---------------------------------------------------------------------------
+
+
+def register_kis_live_order_tools(mcp: FastMCP) -> None:
+    """Register kis_live_* typed order tools (is_mock=False hard-pinned)."""
+    _PINNED = ACCOUNT_MODE_KIS_LIVE
+
+    @mcp.tool(
+        name="kis_live_place_order",
+        description=(
+            "Place a LIMIT buy/sell order on KIS live (real-money) account. "
+            "is_mock is hard-pinned to False. "
+            "dry_run=True by default for safety. "
+            "For buy orders (dry_run=False), thesis and strategy are required. "
+            "Safety limit: max 20 orders/day. "
+            "account_mode='kis_live' is accepted but redundant; "
+            "any other account_mode value is rejected."
+        ),
+    )
+    async def kis_live_place_order(
+        symbol: str,
+        side: Literal["buy", "sell"],
+        order_type: Literal["limit"] = "limit",
+        quantity: float | None = None,
+        price: float | None = None,
+        amount: float | None = None,
+        dry_run: bool = True,
+        reason: str = "",
+        exit_reason: str | None = None,
+        thesis: str | None = None,
+        strategy: str | None = None,
+        target_price: float | None = None,
+        stop_loss: float | None = None,
+        min_hold_days: int | None = None,
+        notes: str | None = None,
+        indicators_snapshot: dict[str, Any] | None = None,
+        defensive_trim: bool = False,
+        approval_issue_id: str | None = None,
+        account_mode: str | None = None,
+        account_type: str | None = None,
+    ) -> dict[str, Any]:
+        rejection = _check_mode_arg(
+            "kis_live_place_order", _PINNED, account_mode, account_type
+        )
+        if rejection:
+            return rejection
+        if str(order_type).lower().strip() != "limit":
+            return {
+                "success": False,
+                "error": "kis_live_place_order only supports limit orders.",
+                "source": "mcp",
+                "symbol": symbol,
+                "order_type": order_type,
+            }
+        routing = _pinned_routing(_PINNED)
+        return apply_account_routing_metadata(
+            await order_execution._place_order_impl(
+                symbol=symbol,
+                side=side,
+                order_type=order_type,
+                quantity=quantity,
+                price=price,
+                amount=amount,
+                dry_run=dry_run,
+                reason=reason,
+                exit_reason=exit_reason,
+                thesis=thesis,
+                strategy=strategy,
+                target_price=target_price,
+                stop_loss=stop_loss,
+                min_hold_days=min_hold_days,
+                notes=notes,
+                indicators_snapshot=indicators_snapshot,
+                defensive_trim=defensive_trim,
+                approval_issue_id=approval_issue_id,
+                is_mock=False,
+            ),
+            routing,
+        )
+
+    @mcp.tool(
+        name="kis_live_cancel_order",
+        description=(
+            "Cancel a pending order on KIS live (real-money) account. "
+            "is_mock is hard-pinned to False. "
+            "account_mode='kis_live' is accepted but redundant; "
+            "any other account_mode value is rejected."
+        ),
+    )
+    async def kis_live_cancel_order(
+        order_id: str,
+        symbol: str | None = None,
+        market: str | None = None,
+        account_mode: str | None = None,
+        account_type: str | None = None,
+    ) -> dict[str, Any]:
+        rejection = _check_mode_arg(
+            "kis_live_cancel_order", _PINNED, account_mode, account_type
+        )
+        if rejection:
+            return rejection
+        routing = _pinned_routing(_PINNED)
+        return apply_account_routing_metadata(
+            await cancel_order_impl(
+                order_id=order_id,
+                symbol=symbol,
+                market=market,
+                is_mock=False,
+            ),
+            routing,
+        )
+
+    @mcp.tool(
+        name="kis_live_modify_order",
+        description=(
+            "Modify a pending order (price/quantity) on KIS live (real-money) account. "
+            "is_mock is hard-pinned to False. dry_run=True by default for safety. "
+            "account_mode='kis_live' is accepted but redundant; "
+            "any other account_mode value is rejected."
+        ),
+    )
+    async def kis_live_modify_order(
+        order_id: str,
+        symbol: str,
+        market: str | None = None,
+        new_price: float | None = None,
+        new_quantity: float | None = None,
+        dry_run: bool = True,
+        reason: str = "",
+        account_mode: str | None = None,
+        account_type: str | None = None,
+    ) -> dict[str, Any]:
+        del reason
+        rejection = _check_mode_arg(
+            "kis_live_modify_order", _PINNED, account_mode, account_type
+        )
+        if rejection:
+            return rejection
+        routing = _pinned_routing(_PINNED)
+        return apply_account_routing_metadata(
+            await modify_order_impl(
+                order_id=order_id,
+                symbol=symbol,
+                market=market,
+                new_price=new_price,
+                new_quantity=new_quantity,
+                dry_run=dry_run,
+                is_mock=False,
+            ),
+            routing,
+        )
+
+    @mcp.tool(
+        name="kis_live_get_order_history",
+        description=(
+            "Get order history on KIS live (real-money) account. "
+            "is_mock is hard-pinned to False. "
+            "account_mode='kis_live' is accepted but redundant; "
+            "any other account_mode value is rejected."
+        ),
+    )
+    async def kis_live_get_order_history(
+        symbol: str | None = None,
+        status: Literal["all", "pending", "filled", "cancelled"] = "all",
+        order_id: str | None = None,
+        market: str | None = None,
+        side: str | None = None,
+        days: int | None = None,
+        limit: int | None = 50,
+        account_mode: str | None = None,
+        account_type: str | None = None,
+    ) -> dict[str, Any]:
+        rejection = _check_mode_arg(
+            "kis_live_get_order_history", _PINNED, account_mode, account_type
+        )
+        if rejection:
+            return rejection
+        routing = _pinned_routing(_PINNED)
+        return apply_account_routing_metadata(
+            await orders_history.get_order_history_impl(
+                symbol=symbol,
+                status=status,
+                order_id=order_id,
+                market=market,
+                side=side,
+                days=days,
+                limit=limit,
+                is_mock=False,
+            ),
+            routing,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Mock variants (is_mock=True hard-pinned)
+# ---------------------------------------------------------------------------
+
+
+def register_kis_mock_order_tools(mcp: FastMCP) -> None:
+    """Register kis_mock_* typed order tools (is_mock=True hard-pinned)."""
+    _PINNED = ACCOUNT_MODE_KIS_MOCK
+
+    @mcp.tool(
+        name="kis_mock_place_order",
+        description=(
+            "Place a LIMIT buy/sell order on KIS official mock (paper) account. "
+            "is_mock is hard-pinned to True. Fails closed if KIS mock config "
+            "(KIS_MOCK_ENABLED, KIS_MOCK_APP_KEY, KIS_MOCK_APP_SECRET, "
+            "KIS_MOCK_ACCOUNT_NO) is missing. "
+            "dry_run=True by default for safety. "
+            "account_mode='kis_mock' is accepted but redundant; "
+            "any other account_mode value is rejected."
+        ),
+    )
+    async def kis_mock_place_order(
+        symbol: str,
+        side: Literal["buy", "sell"],
+        order_type: Literal["limit"] = "limit",
+        quantity: float | None = None,
+        price: float | None = None,
+        amount: float | None = None,
+        dry_run: bool = True,
+        reason: str = "",
+        exit_reason: str | None = None,
+        thesis: str | None = None,
+        strategy: str | None = None,
+        target_price: float | None = None,
+        stop_loss: float | None = None,
+        min_hold_days: int | None = None,
+        notes: str | None = None,
+        indicators_snapshot: dict[str, Any] | None = None,
+        defensive_trim: bool = False,
+        approval_issue_id: str | None = None,
+        account_mode: str | None = None,
+        account_type: str | None = None,
+    ) -> dict[str, Any]:
+        rejection = _check_mode_arg(
+            "kis_mock_place_order", _PINNED, account_mode, account_type
+        )
+        if rejection:
+            return rejection
+        config_error = _mock_config_error()
+        if config_error:
+            return apply_account_routing_metadata(
+                config_error, _pinned_routing(_PINNED)
+            )
+        if str(order_type).lower().strip() != "limit":
+            return {
+                "success": False,
+                "error": "kis_mock_place_order only supports limit orders.",
+                "source": "mcp",
+                "symbol": symbol,
+                "order_type": order_type,
+            }
+        routing = _pinned_routing(_PINNED)
+        return apply_account_routing_metadata(
+            await order_execution._place_order_impl(
+                symbol=symbol,
+                side=side,
+                order_type=order_type,
+                quantity=quantity,
+                price=price,
+                amount=amount,
+                dry_run=dry_run,
+                reason=reason,
+                exit_reason=exit_reason,
+                thesis=thesis,
+                strategy=strategy,
+                target_price=target_price,
+                stop_loss=stop_loss,
+                min_hold_days=min_hold_days,
+                notes=notes,
+                indicators_snapshot=indicators_snapshot,
+                defensive_trim=defensive_trim,
+                approval_issue_id=approval_issue_id,
+                is_mock=True,
+            ),
+            routing,
+        )
+
+    @mcp.tool(
+        name="kis_mock_cancel_order",
+        description=(
+            "Cancel a pending order on KIS official mock (paper) account. "
+            "is_mock is hard-pinned to True. Fails closed if KIS mock config is missing. "
+            "account_mode='kis_mock' is accepted but redundant; "
+            "any other account_mode value is rejected."
+        ),
+    )
+    async def kis_mock_cancel_order(
+        order_id: str,
+        symbol: str | None = None,
+        market: str | None = None,
+        account_mode: str | None = None,
+        account_type: str | None = None,
+    ) -> dict[str, Any]:
+        rejection = _check_mode_arg(
+            "kis_mock_cancel_order", _PINNED, account_mode, account_type
+        )
+        if rejection:
+            return rejection
+        config_error = _mock_config_error()
+        if config_error:
+            return apply_account_routing_metadata(
+                config_error, _pinned_routing(_PINNED)
+            )
+        routing = _pinned_routing(_PINNED)
+        return apply_account_routing_metadata(
+            await cancel_order_impl(
+                order_id=order_id,
+                symbol=symbol,
+                market=market,
+                is_mock=True,
+            ),
+            routing,
+        )
+
+    @mcp.tool(
+        name="kis_mock_modify_order",
+        description=(
+            "Modify a pending order (price/quantity) on KIS official mock (paper) account. "
+            "is_mock is hard-pinned to True. Fails closed if KIS mock config is missing. "
+            "dry_run=True by default for safety. "
+            "account_mode='kis_mock' is accepted but redundant; "
+            "any other account_mode value is rejected."
+        ),
+    )
+    async def kis_mock_modify_order(
+        order_id: str,
+        symbol: str,
+        market: str | None = None,
+        new_price: float | None = None,
+        new_quantity: float | None = None,
+        dry_run: bool = True,
+        reason: str = "",
+        account_mode: str | None = None,
+        account_type: str | None = None,
+    ) -> dict[str, Any]:
+        del reason
+        rejection = _check_mode_arg(
+            "kis_mock_modify_order", _PINNED, account_mode, account_type
+        )
+        if rejection:
+            return rejection
+        config_error = _mock_config_error()
+        if config_error:
+            return apply_account_routing_metadata(
+                config_error, _pinned_routing(_PINNED)
+            )
+        routing = _pinned_routing(_PINNED)
+        return apply_account_routing_metadata(
+            await modify_order_impl(
+                order_id=order_id,
+                symbol=symbol,
+                market=market,
+                new_price=new_price,
+                new_quantity=new_quantity,
+                dry_run=dry_run,
+                is_mock=True,
+            ),
+            routing,
+        )
+
+    @mcp.tool(
+        name="kis_mock_get_order_history",
+        description=(
+            "Get order history on KIS official mock (paper) account. "
+            "is_mock is hard-pinned to True. Fails closed if KIS mock config is missing. "
+            "Note: some KR order history endpoints (e.g. TTTC8036R) are unsupported "
+            "in KIS mock and return mock_unsupported-tagged errors. "
+            "account_mode='kis_mock' is accepted but redundant; "
+            "any other account_mode value is rejected."
+        ),
+    )
+    async def kis_mock_get_order_history(
+        symbol: str | None = None,
+        status: Literal["all", "pending", "filled", "cancelled"] = "all",
+        order_id: str | None = None,
+        market: str | None = None,
+        side: str | None = None,
+        days: int | None = None,
+        limit: int | None = 50,
+        account_mode: str | None = None,
+        account_type: str | None = None,
+    ) -> dict[str, Any]:
+        rejection = _check_mode_arg(
+            "kis_mock_get_order_history", _PINNED, account_mode, account_type
+        )
+        if rejection:
+            return rejection
+        config_error = _mock_config_error()
+        if config_error:
+            return apply_account_routing_metadata(
+                config_error, _pinned_routing(_PINNED)
+            )
+        routing = _pinned_routing(_PINNED)
+        return apply_account_routing_metadata(
+            await orders_history.get_order_history_impl(
+                symbol=symbol,
+                status=status,
+                order_id=order_id,
+                market=market,
+                side=side,
+                days=days,
+                limit=limit,
+                is_mock=True,
+            ),
+            routing,
+        )
+
+
+__all__ = [
+    "KIS_LIVE_ORDER_TOOL_NAMES",
+    "KIS_MOCK_ORDER_TOOL_NAMES",
+    "register_kis_live_order_tools",
+    "register_kis_mock_order_tools",
+]

--- a/app/mcp_server/tooling/orders_kis_variants.py
+++ b/app/mcp_server/tooling/orders_kis_variants.py
@@ -46,8 +46,17 @@ KIS_MOCK_ORDER_TOOL_NAMES: set[str] = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Shared guard/delegation helpers
+# ---------------------------------------------------------------------------
+
+
 def _pinned_routing(account_mode: str) -> AccountRouting:
     return AccountRouting(account_mode=account_mode)
+
+
+def _is_mock_mode(pinned_mode: str) -> bool:
+    return pinned_mode == ACCOUNT_MODE_KIS_MOCK
 
 
 def _mock_config_error() -> dict[str, Any] | None:
@@ -92,6 +101,183 @@ def _check_mode_arg(
     return None
 
 
+def _prepare_variant_call(
+    tool_name: str,
+    pinned_mode: str,
+    account_mode: str | None,
+    account_type: str | None,
+) -> tuple[AccountRouting, dict[str, Any] | None]:
+    routing = _pinned_routing(pinned_mode)
+    rejection = _check_mode_arg(tool_name, pinned_mode, account_mode, account_type)
+    if rejection:
+        return routing, rejection
+    if _is_mock_mode(pinned_mode):
+        config_error = _mock_config_error()
+        if config_error:
+            return routing, apply_account_routing_metadata(config_error, routing)
+    return routing, None
+
+
+def _limit_order_error(tool_name: str, symbol: str, order_type: str) -> dict[str, Any]:
+    return {
+        "success": False,
+        "error": f"{tool_name} only supports limit orders.",
+        "source": "mcp",
+        "symbol": symbol,
+        "order_type": order_type,
+    }
+
+
+async def _place_order_variant(
+    *,
+    tool_name: str,
+    pinned_mode: str,
+    symbol: str,
+    side: Literal["buy", "sell"],
+    order_type: Literal["limit"],
+    quantity: float | None,
+    price: float | None,
+    amount: float | None,
+    dry_run: bool,
+    reason: str,
+    exit_reason: str | None,
+    thesis: str | None,
+    strategy: str | None,
+    target_price: float | None,
+    stop_loss: float | None,
+    min_hold_days: int | None,
+    notes: str | None,
+    indicators_snapshot: dict[str, Any] | None,
+    defensive_trim: bool,
+    approval_issue_id: str | None,
+    account_mode: str | None,
+    account_type: str | None,
+) -> dict[str, Any]:  # NOSONAR - mirrors the public MCP order contract.
+    routing, early_response = _prepare_variant_call(
+        tool_name, pinned_mode, account_mode, account_type
+    )
+    if early_response:
+        return early_response
+    if str(order_type).lower().strip() != "limit":
+        return _limit_order_error(tool_name, symbol, order_type)
+    return apply_account_routing_metadata(
+        await order_execution._place_order_impl(
+            symbol=symbol,
+            side=side,
+            order_type=order_type,
+            quantity=quantity,
+            price=price,
+            amount=amount,
+            dry_run=dry_run,
+            reason=reason,
+            exit_reason=exit_reason,
+            thesis=thesis,
+            strategy=strategy,
+            target_price=target_price,
+            stop_loss=stop_loss,
+            min_hold_days=min_hold_days,
+            notes=notes,
+            indicators_snapshot=indicators_snapshot,
+            defensive_trim=defensive_trim,
+            approval_issue_id=approval_issue_id,
+            is_mock=_is_mock_mode(pinned_mode),
+        ),
+        routing,
+    )
+
+
+async def _cancel_order_variant(
+    *,
+    tool_name: str,
+    pinned_mode: str,
+    order_id: str,
+    symbol: str | None,
+    market: str | None,
+    account_mode: str | None,
+    account_type: str | None,
+) -> dict[str, Any]:
+    routing, early_response = _prepare_variant_call(
+        tool_name, pinned_mode, account_mode, account_type
+    )
+    if early_response:
+        return early_response
+    return apply_account_routing_metadata(
+        await cancel_order_impl(
+            order_id=order_id,
+            symbol=symbol,
+            market=market,
+            is_mock=_is_mock_mode(pinned_mode),
+        ),
+        routing,
+    )
+
+
+async def _modify_order_variant(
+    *,
+    tool_name: str,
+    pinned_mode: str,
+    order_id: str,
+    symbol: str,
+    market: str | None,
+    new_price: float | None,
+    new_quantity: float | None,
+    dry_run: bool,
+    account_mode: str | None,
+    account_type: str | None,
+) -> dict[str, Any]:
+    routing, early_response = _prepare_variant_call(
+        tool_name, pinned_mode, account_mode, account_type
+    )
+    if early_response:
+        return early_response
+    return apply_account_routing_metadata(
+        await modify_order_impl(
+            order_id=order_id,
+            symbol=symbol,
+            market=market,
+            new_price=new_price,
+            new_quantity=new_quantity,
+            dry_run=dry_run,
+            is_mock=_is_mock_mode(pinned_mode),
+        ),
+        routing,
+    )
+
+
+async def _get_order_history_variant(
+    *,
+    tool_name: str,
+    pinned_mode: str,
+    symbol: str | None,
+    status: Literal["all", "pending", "filled", "cancelled"],
+    order_id: str | None,
+    market: str | None,
+    side: str | None,
+    days: int | None,
+    limit: int | None,
+    account_mode: str | None,
+    account_type: str | None,
+) -> dict[str, Any]:
+    routing, early_response = _prepare_variant_call(
+        tool_name, pinned_mode, account_mode, account_type
+    )
+    if early_response:
+        return early_response
+    return apply_account_routing_metadata(
+        await orders_history.get_order_history_impl(
+            symbol=symbol,
+            status=status,
+            order_id=order_id,
+            market=market,
+            side=side,
+            days=days,
+            limit=limit,
+            is_mock=_is_mock_mode(pinned_mode),
+        ),
+        routing,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Live variants (is_mock=False hard-pinned)
 # ---------------------------------------------------------------------------
@@ -113,7 +299,7 @@ def register_kis_live_order_tools(mcp: FastMCP) -> None:
             "any other account_mode value is rejected."
         ),
     )
-    async def kis_live_place_order(
+    async def kis_live_place_order(  # NOSONAR - public MCP order schema mirrors legacy tool.
         symbol: str,
         side: Literal["buy", "sell"],
         order_type: Literal["limit"] = "limit",
@@ -135,43 +321,29 @@ def register_kis_live_order_tools(mcp: FastMCP) -> None:
         account_mode: str | None = None,
         account_type: str | None = None,
     ) -> dict[str, Any]:
-        rejection = _check_mode_arg(
-            "kis_live_place_order", _PINNED, account_mode, account_type
-        )
-        if rejection:
-            return rejection
-        if str(order_type).lower().strip() != "limit":
-            return {
-                "success": False,
-                "error": "kis_live_place_order only supports limit orders.",
-                "source": "mcp",
-                "symbol": symbol,
-                "order_type": order_type,
-            }
-        routing = _pinned_routing(_PINNED)
-        return apply_account_routing_metadata(
-            await order_execution._place_order_impl(
-                symbol=symbol,
-                side=side,
-                order_type=order_type,
-                quantity=quantity,
-                price=price,
-                amount=amount,
-                dry_run=dry_run,
-                reason=reason,
-                exit_reason=exit_reason,
-                thesis=thesis,
-                strategy=strategy,
-                target_price=target_price,
-                stop_loss=stop_loss,
-                min_hold_days=min_hold_days,
-                notes=notes,
-                indicators_snapshot=indicators_snapshot,
-                defensive_trim=defensive_trim,
-                approval_issue_id=approval_issue_id,
-                is_mock=False,
-            ),
-            routing,
+        return await _place_order_variant(
+            tool_name="kis_live_place_order",
+            pinned_mode=_PINNED,
+            symbol=symbol,
+            side=side,
+            order_type=order_type,
+            quantity=quantity,
+            price=price,
+            amount=amount,
+            dry_run=dry_run,
+            reason=reason,
+            exit_reason=exit_reason,
+            thesis=thesis,
+            strategy=strategy,
+            target_price=target_price,
+            stop_loss=stop_loss,
+            min_hold_days=min_hold_days,
+            notes=notes,
+            indicators_snapshot=indicators_snapshot,
+            defensive_trim=defensive_trim,
+            approval_issue_id=approval_issue_id,
+            account_mode=account_mode,
+            account_type=account_type,
         )
 
     @mcp.tool(
@@ -190,20 +362,14 @@ def register_kis_live_order_tools(mcp: FastMCP) -> None:
         account_mode: str | None = None,
         account_type: str | None = None,
     ) -> dict[str, Any]:
-        rejection = _check_mode_arg(
-            "kis_live_cancel_order", _PINNED, account_mode, account_type
-        )
-        if rejection:
-            return rejection
-        routing = _pinned_routing(_PINNED)
-        return apply_account_routing_metadata(
-            await cancel_order_impl(
-                order_id=order_id,
-                symbol=symbol,
-                market=market,
-                is_mock=False,
-            ),
-            routing,
+        return await _cancel_order_variant(
+            tool_name="kis_live_cancel_order",
+            pinned_mode=_PINNED,
+            order_id=order_id,
+            symbol=symbol,
+            market=market,
+            account_mode=account_mode,
+            account_type=account_type,
         )
 
     @mcp.tool(
@@ -227,23 +393,17 @@ def register_kis_live_order_tools(mcp: FastMCP) -> None:
         account_type: str | None = None,
     ) -> dict[str, Any]:
         del reason
-        rejection = _check_mode_arg(
-            "kis_live_modify_order", _PINNED, account_mode, account_type
-        )
-        if rejection:
-            return rejection
-        routing = _pinned_routing(_PINNED)
-        return apply_account_routing_metadata(
-            await modify_order_impl(
-                order_id=order_id,
-                symbol=symbol,
-                market=market,
-                new_price=new_price,
-                new_quantity=new_quantity,
-                dry_run=dry_run,
-                is_mock=False,
-            ),
-            routing,
+        return await _modify_order_variant(
+            tool_name="kis_live_modify_order",
+            pinned_mode=_PINNED,
+            order_id=order_id,
+            symbol=symbol,
+            market=market,
+            new_price=new_price,
+            new_quantity=new_quantity,
+            dry_run=dry_run,
+            account_mode=account_mode,
+            account_type=account_type,
         )
 
     @mcp.tool(
@@ -266,24 +426,18 @@ def register_kis_live_order_tools(mcp: FastMCP) -> None:
         account_mode: str | None = None,
         account_type: str | None = None,
     ) -> dict[str, Any]:
-        rejection = _check_mode_arg(
-            "kis_live_get_order_history", _PINNED, account_mode, account_type
-        )
-        if rejection:
-            return rejection
-        routing = _pinned_routing(_PINNED)
-        return apply_account_routing_metadata(
-            await orders_history.get_order_history_impl(
-                symbol=symbol,
-                status=status,
-                order_id=order_id,
-                market=market,
-                side=side,
-                days=days,
-                limit=limit,
-                is_mock=False,
-            ),
-            routing,
+        return await _get_order_history_variant(
+            tool_name="kis_live_get_order_history",
+            pinned_mode=_PINNED,
+            symbol=symbol,
+            status=status,
+            order_id=order_id,
+            market=market,
+            side=side,
+            days=days,
+            limit=limit,
+            account_mode=account_mode,
+            account_type=account_type,
         )
 
 
@@ -308,7 +462,7 @@ def register_kis_mock_order_tools(mcp: FastMCP) -> None:
             "any other account_mode value is rejected."
         ),
     )
-    async def kis_mock_place_order(
+    async def kis_mock_place_order(  # NOSONAR - public MCP order schema mirrors legacy tool.
         symbol: str,
         side: Literal["buy", "sell"],
         order_type: Literal["limit"] = "limit",
@@ -330,48 +484,29 @@ def register_kis_mock_order_tools(mcp: FastMCP) -> None:
         account_mode: str | None = None,
         account_type: str | None = None,
     ) -> dict[str, Any]:
-        rejection = _check_mode_arg(
-            "kis_mock_place_order", _PINNED, account_mode, account_type
-        )
-        if rejection:
-            return rejection
-        config_error = _mock_config_error()
-        if config_error:
-            return apply_account_routing_metadata(
-                config_error, _pinned_routing(_PINNED)
-            )
-        if str(order_type).lower().strip() != "limit":
-            return {
-                "success": False,
-                "error": "kis_mock_place_order only supports limit orders.",
-                "source": "mcp",
-                "symbol": symbol,
-                "order_type": order_type,
-            }
-        routing = _pinned_routing(_PINNED)
-        return apply_account_routing_metadata(
-            await order_execution._place_order_impl(
-                symbol=symbol,
-                side=side,
-                order_type=order_type,
-                quantity=quantity,
-                price=price,
-                amount=amount,
-                dry_run=dry_run,
-                reason=reason,
-                exit_reason=exit_reason,
-                thesis=thesis,
-                strategy=strategy,
-                target_price=target_price,
-                stop_loss=stop_loss,
-                min_hold_days=min_hold_days,
-                notes=notes,
-                indicators_snapshot=indicators_snapshot,
-                defensive_trim=defensive_trim,
-                approval_issue_id=approval_issue_id,
-                is_mock=True,
-            ),
-            routing,
+        return await _place_order_variant(
+            tool_name="kis_mock_place_order",
+            pinned_mode=_PINNED,
+            symbol=symbol,
+            side=side,
+            order_type=order_type,
+            quantity=quantity,
+            price=price,
+            amount=amount,
+            dry_run=dry_run,
+            reason=reason,
+            exit_reason=exit_reason,
+            thesis=thesis,
+            strategy=strategy,
+            target_price=target_price,
+            stop_loss=stop_loss,
+            min_hold_days=min_hold_days,
+            notes=notes,
+            indicators_snapshot=indicators_snapshot,
+            defensive_trim=defensive_trim,
+            approval_issue_id=approval_issue_id,
+            account_mode=account_mode,
+            account_type=account_type,
         )
 
     @mcp.tool(
@@ -390,25 +525,14 @@ def register_kis_mock_order_tools(mcp: FastMCP) -> None:
         account_mode: str | None = None,
         account_type: str | None = None,
     ) -> dict[str, Any]:
-        rejection = _check_mode_arg(
-            "kis_mock_cancel_order", _PINNED, account_mode, account_type
-        )
-        if rejection:
-            return rejection
-        config_error = _mock_config_error()
-        if config_error:
-            return apply_account_routing_metadata(
-                config_error, _pinned_routing(_PINNED)
-            )
-        routing = _pinned_routing(_PINNED)
-        return apply_account_routing_metadata(
-            await cancel_order_impl(
-                order_id=order_id,
-                symbol=symbol,
-                market=market,
-                is_mock=True,
-            ),
-            routing,
+        return await _cancel_order_variant(
+            tool_name="kis_mock_cancel_order",
+            pinned_mode=_PINNED,
+            order_id=order_id,
+            symbol=symbol,
+            market=market,
+            account_mode=account_mode,
+            account_type=account_type,
         )
 
     @mcp.tool(
@@ -433,28 +557,17 @@ def register_kis_mock_order_tools(mcp: FastMCP) -> None:
         account_type: str | None = None,
     ) -> dict[str, Any]:
         del reason
-        rejection = _check_mode_arg(
-            "kis_mock_modify_order", _PINNED, account_mode, account_type
-        )
-        if rejection:
-            return rejection
-        config_error = _mock_config_error()
-        if config_error:
-            return apply_account_routing_metadata(
-                config_error, _pinned_routing(_PINNED)
-            )
-        routing = _pinned_routing(_PINNED)
-        return apply_account_routing_metadata(
-            await modify_order_impl(
-                order_id=order_id,
-                symbol=symbol,
-                market=market,
-                new_price=new_price,
-                new_quantity=new_quantity,
-                dry_run=dry_run,
-                is_mock=True,
-            ),
-            routing,
+        return await _modify_order_variant(
+            tool_name="kis_mock_modify_order",
+            pinned_mode=_PINNED,
+            order_id=order_id,
+            symbol=symbol,
+            market=market,
+            new_price=new_price,
+            new_quantity=new_quantity,
+            dry_run=dry_run,
+            account_mode=account_mode,
+            account_type=account_type,
         )
 
     @mcp.tool(
@@ -479,29 +592,18 @@ def register_kis_mock_order_tools(mcp: FastMCP) -> None:
         account_mode: str | None = None,
         account_type: str | None = None,
     ) -> dict[str, Any]:
-        rejection = _check_mode_arg(
-            "kis_mock_get_order_history", _PINNED, account_mode, account_type
-        )
-        if rejection:
-            return rejection
-        config_error = _mock_config_error()
-        if config_error:
-            return apply_account_routing_metadata(
-                config_error, _pinned_routing(_PINNED)
-            )
-        routing = _pinned_routing(_PINNED)
-        return apply_account_routing_metadata(
-            await orders_history.get_order_history_impl(
-                symbol=symbol,
-                status=status,
-                order_id=order_id,
-                market=market,
-                side=side,
-                days=days,
-                limit=limit,
-                is_mock=True,
-            ),
-            routing,
+        return await _get_order_history_variant(
+            tool_name="kis_mock_get_order_history",
+            pinned_mode=_PINNED,
+            symbol=symbol,
+            status=status,
+            order_id=order_id,
+            market=market,
+            side=side,
+            days=days,
+            limit=limit,
+            account_mode=account_mode,
+            account_type=account_type,
         )
 
 

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -1,9 +1,26 @@
-"""Tool registration orchestration for MCP server."""
+"""Tool registration orchestration for MCP server.
+
+Profile → tool surface mapping
+────────────────────────────────────────────────────────────────────────────
+"default" (McpProfile.DEFAULT):
+  All side-effect-free research tools + read-only portfolio tools +
+  legacy ambiguous order tools (place_order / cancel_order / modify_order /
+  get_order_history with account_mode switching) +
+  typed kis_live_* and kis_mock_* variants (additive).
+
+"hermes-paper-kis" (McpProfile.HERMES_PAPER_KIS):
+  All side-effect-free research tools + read-only portfolio tools +
+  typed kis_mock_* variants ONLY.
+  Explicitly omits: register_order_tools, register_kis_live_order_tools.
+
+See app/mcp_server/profiles.py and docs in app/mcp_server/README.md.
+"""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from app.mcp_server.profiles import McpProfile
 from app.mcp_server.tooling.analysis_registration import register_analysis_tools
 from app.mcp_server.tooling.execution_comment_registration import (
     register_execution_comment_tools,
@@ -17,6 +34,10 @@ from app.mcp_server.tooling.market_report_registration import (
     register_market_report_tools,
 )
 from app.mcp_server.tooling.news_registration import register_news_tools
+from app.mcp_server.tooling.orders_kis_variants import (
+    register_kis_live_order_tools,
+    register_kis_mock_order_tools,
+)
 from app.mcp_server.tooling.orders_registration import register_order_tools
 from app.mcp_server.tooling.paper_account_registration import (
     register_paper_account_tools,
@@ -48,10 +69,16 @@ if TYPE_CHECKING:
     from fastmcp import FastMCP
 
 
-def register_all_tools(mcp: FastMCP) -> None:
+def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -> None:
+    """Register MCP tools according to the given profile.
+
+    Side-effect-free research and read-only tools are always registered.
+    Side-effect order tool registration depends on profile:
+      - DEFAULT: legacy ambiguous tools + typed kis_live_* + typed kis_mock_*
+      - HERMES_PAPER_KIS: typed kis_mock_* only (live surface absent)
+    """
+    # Always: side-effect-free research + read-only tools
     register_market_data_tools(mcp)
-    register_portfolio_tools(mcp)
-    register_order_tools(mcp)
     register_fundamentals_tools(mcp)
     register_analysis_tools(mcp)
     register_watch_alert_tools(mcp)
@@ -59,13 +86,28 @@ def register_all_tools(mcp: FastMCP) -> None:
     register_market_report_tools(mcp)
     register_user_settings_tools(mcp)
     register_news_tools(mcp)
+    register_market_brief_tools(mcp)
+
+    # Always: read-only with account_mode (mock-safe via ROB-28)
+    register_portfolio_tools(mcp)
     register_trade_journal_tools(mcp)
+    register_paperclip_comment_tools(mcp)
+    register_execution_comment_tools(mcp)
     register_paper_account_tools(mcp)
     register_paper_analytics_tools(mcp)
     register_paper_journal_tools(mcp)
-    register_execution_comment_tools(mcp)
-    register_market_brief_tools(mcp)
-    register_paperclip_comment_tools(mcp)
+
+    # Profile-gated: side-effect order surfaces
+    if profile is McpProfile.DEFAULT:
+        # Preserve today's behavior: ambiguous account_mode tools for legacy callers.
+        # Typed kis_live_* and kis_mock_* are additive — new typed callers use them.
+        register_order_tools(mcp)
+        register_kis_live_order_tools(mcp)
+        register_kis_mock_order_tools(mcp)
+    elif profile is McpProfile.HERMES_PAPER_KIS:
+        # Paper-only: only mock-pinned order surface. Live surface is physically absent.
+        register_kis_mock_order_tools(mcp)
+        # Intentionally NOT: register_order_tools, register_kis_live_order_tools
 
 
 __all__ = ["register_all_tools"]

--- a/app/services/brokers/capabilities.py
+++ b/app/services/brokers/capabilities.py
@@ -1,0 +1,62 @@
+"""Broker capability metadata registry.
+
+Declares which markets each broker supports and whether paper/live modes are
+available. Metadata-only: no order routing logic consumes this yet.
+Forward-looking Kiwoom entry is included for planning; no Kiwoom client exists.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class Market(StrEnum):
+    KR_EQUITY = "kr_equity"
+    US_EQUITY = "us_equity"
+    CRYPTO = "crypto"
+
+
+class Broker(StrEnum):
+    KIS = "kis"
+    KIWOOM = "kiwoom"
+    UPBIT = "upbit"
+
+
+@dataclass(frozen=True)
+class BrokerCapability:
+    broker: Broker
+    markets: frozenset[Market]
+    supports_paper: bool
+    supports_live: bool
+
+
+BROKER_CAPABILITIES: Mapping[Broker, BrokerCapability] = {
+    Broker.KIS: BrokerCapability(
+        broker=Broker.KIS,
+        markets=frozenset({Market.KR_EQUITY, Market.US_EQUITY}),
+        supports_paper=True,
+        supports_live=True,
+    ),
+    Broker.KIWOOM: BrokerCapability(
+        broker=Broker.KIWOOM,
+        markets=frozenset({Market.KR_EQUITY, Market.US_EQUITY}),
+        supports_paper=False,
+        supports_live=False,
+    ),
+    Broker.UPBIT: BrokerCapability(
+        broker=Broker.UPBIT,
+        markets=frozenset({Market.CRYPTO}),
+        supports_paper=False,
+        supports_live=True,
+    ),
+}
+
+
+__all__ = [
+    "Broker",
+    "BrokerCapability",
+    "BROKER_CAPABILITIES",
+    "Market",
+]

--- a/docs/plans/ROB-56-kis-mock-hard-separation-plan.md
+++ b/docs/plans/ROB-56-kis-mock-hard-separation-plan.md
@@ -1,0 +1,768 @@
+# ROB-56 — KIS Official Mock Hard-Separation (Implementation Plan)
+
+**Planner:** Claude Opus 4.7 (planner/reviewer)
+**Implementer (handoff):** Claude Sonnet (same AoE session, same worktree)
+**Issue:** ROB-56
+**Branch / worktree:** `feature/ROB-56-kis-mock-hard-separation`
+(`/Users/mgh3326/work/auto_trader-worktrees/feature-ROB-56-kis-mock-hard-separation`)
+**Status:** plan_ready
+
+---
+
+## 1. Executive summary
+
+ROB-19/28/31/37 already established a strong **runtime-parameter** boundary
+between KIS live and KIS official mock: a single `KISClient(is_mock=...)`
+with a non-fallback `_KISSettingsView`, a fail-closed `validate_kis_mock_config()`
+gate, separate Redis token namespaces, a frozen `mock_unsupported` TR set,
+and a fully isolated `review.kis_mock_order_ledger` write path. The remaining
+risk is that this separation lives **inside one MCP tool** that selects mode
+from a `account_mode` argument — a misconfigured agent, a prompt-injected
+caller, or a buggy router can still reach the live order surface from a tool
+that an operator intended to be mock-only.
+
+ROB-56 closes that gap by:
+
+1. Splitting the **side-effect** KIS order MCP tools into **explicitly-named
+   `kis_mock_*` and `kis_live_*` tool registrations** (separate functions
+   registered as separate MCP tool names), so paper/mock deployments load
+   only the mock variants and the live order surface is **physically absent**
+   from the tool list.
+2. Introducing a small **profile-based registration shim**
+   (`register_order_tools_for_profile(...)`) that drives the existing
+   `app/mcp_server/main.py` setup. Profiles: `default` (today's behavior),
+   `hermes-paper-kis` (mock + read-only only).
+3. Keeping shared **side-effect-free** research tools (market data,
+   fundamentals, news, analysis, watch alerts, market reports) registered in
+   both profiles, after a per-tool side-effect audit that pins this in a
+   test.
+4. Adding a **broker capability metadata** module so KIS (and forward-looking
+   Kiwoom) declare KR/US support without changing routing today.
+5. Pinning all of the above with focused pytest targets, including a
+   regression guard that fails if a `kis_live_*` order tool is ever
+   registered in `hermes-paper-kis`.
+
+The implementation is **read/write code only inside `app/mcp_server/`,
+`app/core/config.py`, and tests**. No broker behavior changes, no migrations,
+no live order code path changes, no Kiwoom client. `dry_run=True` defaults
+remain. No autonomous trading enablement.
+
+---
+
+## 2. Prior issue audit (ROB-19 / 28 / 31 / 37)
+
+Search performed against repo (`docs/plans/`, `git log --all`, source).
+All four issues are **completed and merged** as of `main` at this worktree's
+fork point (`6cb8656a feat: add preopen news readiness section (#629)`).
+
+### 2.1 ROB-19 — Normalize simulated vs KIS mock account routing
+- **Plan / report:** `docs/plans/ROB-19-kis-mock-account-routing-plan.md`,
+  `docs/plans/ROB-19-final-review-report.md`,
+  `docs/plans/ROB-19-review-report.md`.
+- **Commits (search):** `git log --all --oneline --grep='ROB-19'`
+  (e.g. `f9f1d883 fix(rob-19): harden kis mock routing safeguards`).
+- **Decisions that constrain ROB-56:**
+  - Live and mock credentials live in distinct `Settings` fields
+    (`kis_app_*` vs `kis_mock_*`); access goes through
+    `_KISSettingsView` with property routing (no `__getattr__` fallback for
+    those four fields). See `app/services/brokers/kis/client.py:43-88`.
+  - Mock client uses `RedisTokenManager("kis_mock")` namespace
+    (`client.py:108-109`).
+  - Default `account_mode` resolves to `kis_live`
+    (`tests/test_mcp_account_modes.py:8`,
+    `app/mcp_server/tooling/account_modes.py:107-108`).
+  - `validate_kis_mock_config()` fails closed without leaking values
+    (`app/core/config.py:484-496`,
+    `tests/test_mcp_account_modes.py:56-72`).
+- **Phase-2 follow-up flagged in the final review:** standardize the
+  fail-closed error shape, tighten `_KISSettingsView` against future leaky
+  `__getattr__` regressions, add a token-namespace isolation test, run an
+  operator smoke against the actual mock server. ROB-56 is the right
+  carrier for the first three (test-pinned).
+
+### 2.2 ROB-28 — Harden KIS mock `account_mode` routing for order lifecycle
+- **Plan / report:** `docs/plans/ROB-28-kis-mock-routing-plan.md`,
+  `docs/plans/ROB-28-review-report.md`.
+- **Commits (search):** `git log --all --oneline --grep='ROB-28'`.
+- **Decisions:** `cancel_order` / `modify_order` MCP tools accept
+  `account_mode`, validate via `_kis_mock_config_error()` and pass
+  `is_mock=routing.is_kis_mock` to
+  `cancel_order_impl` / `modify_order_impl`
+  (`app/mcp_server/tooling/orders_registration.py:241-343`,
+  `tests/test_mcp_account_modes.py:75-251`).
+  Mock-side `inquire_integrated_margin(is_mock=True)` and
+  `inquire_overseas_orders(is_mock=True)` raise structured errors instead of
+  falling back to live.
+- **Constraint on ROB-56:** new `kis_mock_*` tool variants must continue to
+  produce these structured errors and the same fail-closed metadata
+  envelope, **without re-implementing the cash-routing logic**.
+
+### 2.3 ROB-31 — KIS mock TR routing matrix + KR pending fail-closed
+- **Doc:** `docs/kis-mock-tr-routing-matrix.md`, README updates in
+  `app/mcp_server/README.md`.
+- **Commit:** `151fd9fa ROB-31 KIS mock TR routing matrix + KR pending fail-closed`.
+- **Decisions:** `mock_unsupported` set frozen in
+  `tests/test_kis_constants.py::test_mock_unsupported_tr_set_is_documented`
+  → `{TTTC8036R, TTTS3018R, TTTC0869R, TTTC2101R}`. `inquire_korea_orders`
+  (`TTTC8036R`) returns `EGW02006`-tagged error under mock.
+- **Constraint on ROB-56:** the new mock-only `kis_mock_get_order_history`
+  tool must not silently route around `mock_unsupported` endpoints; the
+  underlying `orders_history.get_order_history_impl(..., is_mock=True)`
+  already tags responses with `mock_unsupported=true`. Test pinning must
+  remain green.
+
+### 2.4 ROB-37 — Isolate KIS mock order ledger
+- **Commit:** `aced64c7 feat(ROB-37): isolate KIS mock order ledger`.
+- **Source:** `app/mcp_server/tooling/kis_mock_ledger.py:1-100`,
+  `app/models/review.py` (`KISMockOrderLedger`),
+  Alembic `d3703007a676` (down_revision `d34d6def084b`).
+- **Decisions:** `review.kis_mock_order_ledger` enforces
+  `account_mode='kis_mock'` and `broker='kis'` via DB CHECK constraints;
+  unique index `uq_kis_mock_ledger_order_no` per
+  `app/mcp_server/tooling/kis_mock_ledger.py:79`. Live execution path
+  (`order_execution._execute_and_record`) branches on `is_mock=True` and
+  skips `_save_order_fill`, `_create_trade_journal_for_buy`,
+  `_close_journals_on_sell`, `_link_journal_to_fill`.
+- **Constraint on ROB-56:** the data-layer split is already complete. ROB-56
+  must not re-route mock writes back through `review.trades`. The new
+  `kis_mock_*` MCP tools delegate to the **same** underlying
+  `_place_order_impl(..., is_mock=True)` so this isolation is preserved.
+
+### 2.5 Cross-cutting risks affecting ROB-56
+- **Do not** introduce a fallback path from `kis_mock_*` tools to live
+  credentials or live execution — even on missing-config errors.
+- **Do not** widen `_KISSettingsView.__getattr__` to expose live values from
+  a mock view; ROB-56 will add a regression test that pins the
+  property-only routing for the four hot fields.
+- **Do not** modify the `mock_unsupported` TR set; ROB-31's frozen test must
+  still pass.
+
+---
+
+## 3. Current code routing audit
+
+Working directory:
+`/Users/mgh3326/work/auto_trader-worktrees/feature-ROB-56-kis-mock-hard-separation`.
+
+### 3.1 KIS clients / adapters
+- `app/services/brokers/kis/client.py:43-88` — `_KISSettingsView` exposes
+  live or mock credentials per `is_mock` flag without cross-account fallback
+  for `kis_app_key`, `kis_app_secret`, `kis_account_no`, `kis_base_url`,
+  `kis_access_token`. All other settings still come from the global object
+  via `__getattr__`.
+- `app/services/brokers/kis/client.py:90-114` — `KISClient(is_mock: bool=False)`;
+  `is_mock=True` swaps the token manager to `RedisTokenManager("kis_mock")`.
+- `app/services/brokers/kis/{domestic_orders,overseas_orders,account}.py`
+  — used unchanged from both live and mock clients.
+
+### 3.2 Credentials / env
+- `app/core/config.py:166-180` — `Settings` fields:
+  `kis_app_key`, `kis_app_secret`, `kis_base_url`, `kis_access_token`,
+  `kis_account_no`, plus mock siblings `kis_mock_enabled`,
+  `kis_mock_app_key`, `kis_mock_app_secret`, `kis_mock_base_url`
+  (`https://openapivts.koreainvestment.com:29443`),
+  `kis_mock_account_no`, `kis_mock_access_token`.
+- `app/core/config.py:484-496` — `validate_kis_mock_config(settings_obj)`
+  returns names of missing required mock vars without exposing values.
+- `env.example:8-26` — documents both live and mock vars; commits the
+  warning "Keep credential values in operator-managed runtime env files;
+  do not commit them."
+
+### 3.3 Order execution boundary
+- `app/mcp_server/tooling/order_execution.py:56-66` — `_create_kis_client`
+  and `_call_kis` thread `is_mock` to `KISClient(is_mock=True)` and
+  `method(..., is_mock=True)`.
+- `app/mcp_server/tooling/order_execution.py:100-116` — `_execute_order`
+  passes `is_mock` to `_execute_kr_order` / `_execute_us_order`. Crypto
+  path (`_execute_crypto_order`) ignores `is_mock`.
+- `app/mcp_server/tooling/kis_mock_ledger.py` — `_save_kis_mock_order_ledger`
+  always sets `account_mode="kis_mock"` and `broker="kis"`; row insert
+  isolated to `review.kis_mock_order_ledger` (DB CHECK constraints enforce
+  this).
+
+### 3.4 MCP tool registration
+- Entry: `app/mcp_server/main.py:39-51` instantiates one `FastMCP` and calls
+  `register_all_tools(mcp)` (no profile selection today).
+- Orchestrator: `app/mcp_server/tooling/registry.py:51-71` calls 17
+  registration helpers in fixed order, including
+  `register_order_tools(mcp)` and `register_portfolio_tools(mcp)`.
+- Side-effect order tools (today, single-tool routing):
+  - `place_order` (`orders_registration.py:110-239`)
+  - `cancel_order` (`orders_registration.py:241-285`)
+  - `modify_order` (`orders_registration.py:287-343`)
+  - `get_order_history` (`orders_registration.py:48-108`)
+  All four normalize `account_mode` (preferred) or `account_type`
+  (deprecated) → `AccountRouting{is_db_simulated, is_kis_mock, is_kis_live}`
+  (`app/mcp_server/tooling/account_modes.py:32-54, 90-132`). Default routing
+  is `kis_live` (line 107-108). Each tool calls `_kis_mock_config_error()`
+  on the kis_mock branch; `db_simulated` for `cancel_order`/`modify_order`
+  returns `not supported`.
+- Read-only / research tools (no `account_mode`-driven side effects today):
+  registered by `register_market_data_tools`, `register_fundamentals_tools`,
+  `register_analysis_tools`, `register_watch_alert_tools`,
+  `register_trade_profile_tools`, `register_market_report_tools`,
+  `register_user_settings_tools`, `register_news_tools`,
+  `register_market_brief_tools`. Some portfolio tools
+  (`get_holdings`, `portfolio_cash`, `portfolio_avg_cost`) accept
+  `account_mode` for routing read paths to mock vs live KIS.
+
+### 3.5 Hermes / profile config
+- **No profile config exists in the repo.** `hermes` is only a label:
+  - `app/models/trading_decision.py` enum value
+    `source_profile="hermes"`
+  - `app/schemas/strategy_events.py` source allowlist contains `"hermes"`
+  - 35 docs/plans mention "Hermes" as the operator agent identity
+- **No file in the repo contains `hermes-paper-kis`, `paper-kis`, or
+  `paper_kis`** (verified by grep). ROB-56 introduces this profile
+  identifier for the first time.
+
+### 3.6 Capability model
+- **No broker capability registry exists.** Market routing in
+  `order_execution._execute_order` is hard-coded by `market_type` string
+  (`crypto`, `equity_kr`, `equity_us`). No `BrokerCapability`,
+  `supports_kr`, `supports_us` types. No `Kiwoom` directory under
+  `app/services/brokers/`. Kiwoom is only mentioned twice, both in ROB-28
+  docs as a non-goal.
+
+### 3.7 Existing tests touching this surface
+- `tests/test_kis_mock_routing.py` — `KISClient(is_mock=True)` URL/token
+  paths.
+- `tests/test_mcp_account_modes.py` — covers default `kis_live`, alias
+  warnings, conflicting selectors, fail-closed config, `is_mock` propagated
+  to `cancel_order_impl` / `modify_order_impl`.
+- `tests/test_kis_mock_order_ledger.py` — DB ledger isolation.
+- `tests/test_kis_constants.py::test_mock_unsupported_tr_set_is_documented`
+  — frozen `mock_unsupported` TR set.
+- `tests/test_orders_history_kis_mock.py`,
+  `tests/test_portfolio_cash_kis_mock.py`,
+  `tests/test_kis_integrated_margin_mock.py` — read-side coverage.
+- Test harness: `tests/_mcp_tooling_support.py` exposes `DummyMCP`, used
+  by `test_mcp_account_modes.py:75-251`.
+
+---
+
+## 4. Proposed architecture
+
+### 4.1 Goals
+- **G1:** A `hermes-paper-kis` MCP profile in which the live KIS order
+  surface is **not registered**. A test must fail if any
+  `kis_live_*`-tagged side-effect tool is registered in that profile.
+- **G2:** Make the per-account-mode boundary visible at the **MCP tool name**
+  level for KIS side-effect tools, so logs/audit/typed clients can see
+  exactly which surface was called.
+- **G3:** Preserve all existing behavior in the `default` profile,
+  including the existing `place_order` / `cancel_order` / `modify_order`
+  tool names and `account_mode` semantics. Backwards compatibility for
+  callers that already use `account_mode="kis_mock"` is non-negotiable —
+  do not break ROB-19/28/31/37 callers.
+- **G4:** Add forward-looking broker capability metadata for KIS and
+  Kiwoom, scoped to metadata only.
+
+### 4.2 Profile definition
+
+Profiles are an **enum + a registration switch**, not a config file. They
+gate which subset of `register_*_tools(mcp)` runs and which side-effect
+order variants register.
+
+```
+app/mcp_server/profiles.py  (new)
+
+class McpProfile(StrEnum):
+    DEFAULT = "default"
+    HERMES_PAPER_KIS = "hermes-paper-kis"
+```
+
+Profile selection: `MCP_PROFILE` env var (default `"default"`), parsed
+in `app/mcp_server/main.py` and threaded into a new
+`register_all_tools(mcp, profile=...)` signature. No new YAML/TOML.
+
+### 4.3 Side-effect KIS order tool split
+
+Add a new module
+`app/mcp_server/tooling/orders_kis_variants.py` exposing two factories:
+
+- `register_kis_live_order_tools(mcp)` → registers
+  - `kis_live_place_order`
+  - `kis_live_cancel_order`
+  - `kis_live_modify_order`
+  - `kis_live_get_order_history`
+- `register_kis_mock_order_tools(mcp)` → registers
+  - `kis_mock_place_order`
+  - `kis_mock_cancel_order`
+  - `kis_mock_modify_order`
+  - `kis_mock_get_order_history`
+
+Each variant is a **thin wrapper** that:
+1. Hard-pins `is_mock` (live=False, mock=True) and **rejects** any
+   `account_mode` argument other than its own (or accepts only its own
+   value as a redundancy check). For mock variants only, calls
+   `_kis_mock_config_error()` first.
+2. Delegates to the existing implementations
+   `order_execution._place_order_impl`, `cancel_order_impl`,
+   `modify_order_impl`, `orders_history.get_order_history_impl`.
+3. Reuses `apply_account_routing_metadata` to keep the response envelope
+   identical to today.
+
+The original `place_order`/`cancel_order`/`modify_order`/
+`get_order_history` tools (in `orders_registration.py`) remain unchanged
+and continue to support `account_mode` switching for the `default` profile.
+
+### 4.4 Profile-driven registration
+
+```
+app/mcp_server/tooling/registry.py
+
+def register_all_tools(mcp, profile: McpProfile = McpProfile.DEFAULT) -> None:
+    # Always: side-effect-free research + read-only tools
+    register_market_data_tools(mcp)
+    register_fundamentals_tools(mcp)
+    register_analysis_tools(mcp)
+    register_watch_alert_tools(mcp)
+    register_market_report_tools(mcp)
+    register_news_tools(mcp)
+    register_market_brief_tools(mcp)
+    register_user_settings_tools(mcp)
+    register_trade_profile_tools(mcp)
+
+    # Read-only with account_mode (mock-safe) — keep in both profiles
+    register_portfolio_tools(mcp)             # holdings/cash/avg-cost
+    register_trade_journal_tools(mcp)
+    register_paperclip_comment_tools(mcp)
+    register_execution_comment_tools(mcp)
+    register_paper_account_tools(mcp)         # db_simulated only
+    register_paper_analytics_tools(mcp)
+    register_paper_journal_tools(mcp)
+
+    if profile is McpProfile.DEFAULT:
+        # Today's behavior preserved.
+        register_order_tools(mcp)             # ambiguous account_mode tools
+        register_kis_live_order_tools(mcp)    # additive — typed callers
+        register_kis_mock_order_tools(mcp)
+    elif profile is McpProfile.HERMES_PAPER_KIS:
+        register_kis_mock_order_tools(mcp)
+        # explicitly NOT: register_order_tools, register_kis_live_order_tools
+```
+
+Notes:
+- In `default`, all three registration paths coexist; nothing breaks for
+  legacy callers using `place_order(account_mode="kis_mock")`. The new
+  `kis_*_*` typed tools are additive.
+- In `hermes-paper-kis`, the legacy ambiguous `place_order` / `cancel_order`
+  / `modify_order` / `get_order_history` are **not registered** at all,
+  removing the "pass `account_mode='kis_live'` and reach live" surface.
+- Crypto (Upbit) order routing today flows through `place_order`. In
+  `hermes-paper-kis` Upbit ordering is therefore unavailable. This matches
+  the profile's intent (KIS-paper-only). Out of scope to add a
+  `upbit_place_order` for ROB-56; document as follow-up.
+
+### 4.5 Fail-closed envelope (ROB-19 phase-2 carry)
+
+Standardize the structured fail-closed return for KIS mock missing-config
+across all four mock variants by reusing `_kis_mock_config_error()` plus
+`apply_account_routing_metadata`. Concrete shape (already used by
+`orders_registration.py:33-45`):
+
+```
+{
+  "success": False,
+  "error": "KIS mock account is disabled or missing required configuration: KIS_MOCK_ENABLED, KIS_MOCK_APP_KEY",
+  "source": "kis",
+  "account_mode": "kis_mock",
+}
+```
+
+ROB-56 must not change this shape; it must propagate it from every
+`kis_mock_*` tool.
+
+### 4.6 `_KISSettingsView` regression guard
+
+Add a unit test that constructs `_KISSettingsView(is_mock=True)` and asserts
+that `kis_app_key`, `kis_app_secret`, `kis_account_no`, `kis_base_url`, and
+`kis_access_token` route to the mock fields, regardless of whether the
+underlying live `Settings.kis_app_key` is set. (Phase-2 carry from ROB-19.)
+
+---
+
+## 5. MCP split design — shared read-only vs side-effect live/mock order
+
+### 5.1 Side-effect audit (per-tool determination)
+
+For each registered tool, classify as **side-effect order** (must split),
+**read-only with account scoping** (keep in both profiles), or
+**side-effect-free research** (keep in both profiles).
+
+| Registration helper | Classification | Profile inclusion |
+|---|---|---|
+| `register_order_tools` (`place_order`, `cancel_order`, `modify_order`, `get_order_history`) | side-effect order, ambiguous mode | `default` only |
+| `register_kis_mock_order_tools` (new) | side-effect order, mock-only | `default`, `hermes-paper-kis` |
+| `register_kis_live_order_tools` (new) | side-effect order, live-only | `default` only |
+| `register_market_data_tools` | side-effect-free | both |
+| `register_fundamentals_tools` | side-effect-free | both |
+| `register_analysis_tools` | side-effect-free | both |
+| `register_news_tools` | side-effect-free | both |
+| `register_market_report_tools` | read DB only | both |
+| `register_market_brief_tools` | read DB only | both |
+| `register_watch_alert_tools` | read/write internal alerts (no broker) | both |
+| `register_trade_profile_tools` | DB CRUD on user-owned profiles, no broker | both |
+| `register_user_settings_tools` | DB CRUD on user settings, no broker | both |
+| `register_portfolio_tools` (`get_holdings`, `portfolio_cash`, `portfolio_avg_cost`) | read-only, accepts `account_mode` (already mock-safe via ROB-28) | both |
+| `register_trade_journal_tools` | DB read/write on trade journal | both |
+| `register_paper_account_tools` | `db_simulated` only — no broker | both |
+| `register_paper_analytics_tools` | `db_simulated` only — no broker | both |
+| `register_paper_journal_tools` | `db_simulated` only — no broker | both |
+| `register_paperclip_comment_tools` | external Paperclip API; not a broker order | both |
+| `register_execution_comment_tools` | DB read/write on execution comments | both |
+
+The implementer must verify the "side-effect-free" classification by
+reading each helper before adding it to the always-on list. If any helper
+turns out to issue broker mutations, exclude it from `hermes-paper-kis` and
+note it in the test.
+
+### 5.2 Tool naming choice
+
+Repo precedent uses snake_case verb-noun (`get_holdings`, `place_order`,
+`portfolio_cash`, `kis_websocket_*`). Prefix-style **`kis_live_*`** /
+**`kis_mock_*`** matches both readability and the existing
+`kis_websocket_*` family. Suffix-style (`place_order_kis_live`) is rejected
+because it places the most important semantic distinction at the end of the
+name.
+
+Final names (must exactly match in the implementation):
+- `kis_live_place_order`, `kis_live_cancel_order`, `kis_live_modify_order`, `kis_live_get_order_history`
+- `kis_mock_place_order`, `kis_mock_cancel_order`, `kis_mock_modify_order`, `kis_mock_get_order_history`
+
+### 5.3 Argument compatibility
+
+The new tools have the **same signature** as their canonical counterparts
+in `orders_registration.py`, with **two differences**:
+1. `account_mode`/`account_type` parameters are accepted **only** if equal
+   to the tool's pinned mode. Mismatches return:
+   ```
+   {"success": False,
+    "error": "kis_mock_place_order does not accept account_mode='kis_live'",
+    "source": "mcp",
+    "account_mode": "kis_mock"}
+   ```
+   Omitted is the common case and proceeds with the pinned mode.
+2. The `kis_mock_*` variants reject crypto / `db_simulated` paths the same
+   way `cancel_order`/`modify_order` already do for `db_simulated`.
+
+This contract must be unit-tested per tool.
+
+---
+
+## 6. Capability model update plan
+
+Scope: **metadata only.** No order routing change in this issue.
+
+Add `app/services/brokers/capabilities.py`:
+
+```
+class Market(StrEnum):
+    KR_EQUITY = "kr_equity"
+    US_EQUITY = "us_equity"
+    CRYPTO = "crypto"
+
+class Broker(StrEnum):
+    KIS = "kis"
+    KIWOOM = "kiwoom"
+    UPBIT = "upbit"
+
+@dataclass(frozen=True)
+class BrokerCapability:
+    broker: Broker
+    markets: frozenset[Market]
+    supports_paper: bool
+    supports_live: bool
+
+BROKER_CAPABILITIES: Mapping[Broker, BrokerCapability] = {
+    Broker.KIS: BrokerCapability(
+        broker=Broker.KIS,
+        markets=frozenset({Market.KR_EQUITY, Market.US_EQUITY}),
+        supports_paper=True,   # official KIS mock
+        supports_live=True,
+    ),
+    Broker.KIWOOM: BrokerCapability(
+        broker=Broker.KIWOOM,
+        markets=frozenset({Market.KR_EQUITY, Market.US_EQUITY}),
+        supports_paper=False,  # not yet integrated
+        supports_live=False,
+    ),
+    Broker.UPBIT: BrokerCapability(
+        broker=Broker.UPBIT,
+        markets=frozenset({Market.CRYPTO}),
+        supports_paper=False,
+        supports_live=True,
+    ),
+}
+```
+
+Tests pin the registry; **no production code consumes it yet**. This
+prepares ROB-56's stated capability claim without changing routing.
+
+---
+
+## 7. Step-by-step implementation tasks (for Sonnet)
+
+Each task is intended to be a single commit on
+`feature/ROB-56-kis-mock-hard-separation`. After every task, run the
+focused pytest set in §8.
+
+**T1. Add `McpProfile` enum and env wiring.**
+- Create `app/mcp_server/profiles.py` with the `McpProfile` StrEnum and a
+  helper `resolve_mcp_profile(env: str | None) -> McpProfile` that defaults
+  to `DEFAULT` and validates strings.
+- Wire `MCP_PROFILE` env var in `app/mcp_server/main.py` and pass the
+  resolved profile into `register_all_tools(mcp, profile=...)`. Do **not**
+  read `MCP_PROFILE` directly anywhere else.
+- Update `app/mcp_server/env_utils.py` only if needed (likely not).
+
+**T2. Refactor `registry.register_all_tools` to accept `profile`.**
+- Add `profile: McpProfile = McpProfile.DEFAULT` parameter.
+- Move `register_order_tools(mcp)` behind a `profile is DEFAULT` branch.
+- Keep the rest of the registration order intact for `default`.
+- Add a docstring listing which helpers run in each profile, mirroring the
+  table in §5.1.
+
+**T3. Implement `register_kis_mock_order_tools` and
+`register_kis_live_order_tools`.**
+- New file `app/mcp_server/tooling/orders_kis_variants.py`.
+- For each of the eight tool names in §5.2, register a thin wrapper that:
+  - Validates the optional `account_mode`/`account_type` arg against the
+    tool's pinned mode (mismatch → structured error, no delegation).
+  - For mock variants: call `_kis_mock_config_error()` and short-circuit if
+    config is missing.
+  - Delegate to the existing `_place_order_impl` / `cancel_order_impl` /
+    `modify_order_impl` / `orders_history.get_order_history_impl` with
+    `is_mock` hard-pinned.
+  - Wrap the result in `apply_account_routing_metadata(routing)` so the
+    response envelope matches today.
+- Export `register_kis_mock_order_tools` and `register_kis_live_order_tools`
+  via `app/mcp_server/tooling/__init__.py` if that module currently
+  re-exports the registration helpers; otherwise import them directly in
+  `registry.py`.
+
+**T4. Wire the new variants into `registry.py`.**
+- In `default`: call both `register_kis_live_order_tools` and
+  `register_kis_mock_order_tools` after `register_order_tools`.
+- In `hermes-paper-kis`: call only `register_kis_mock_order_tools`.
+
+**T5. Add broker capability registry.**
+- Create `app/services/brokers/capabilities.py` per §6.
+- Do **not** import it from any production code path. Only tests.
+
+**T6. Add the `_KISSettingsView` regression test.**
+- New file `tests/test_kis_settings_view_isolation.py`. Pin: when
+  constructed with `is_mock=True`, the five hot fields return mock values,
+  and (with monkeypatched `settings.kis_app_key`) live values are not
+  observable through the view.
+
+**T7. Add MCP profile registration tests.**
+- New file `tests/test_mcp_profiles.py`. See §8 for cases.
+
+**T8. Add tool-naming/contract tests for the new variants.**
+- New file `tests/test_mcp_kis_order_variants.py`. See §8 for cases.
+
+**T9. Add capability registry test.**
+- New file `tests/test_broker_capabilities.py`. Pin the per-broker market
+  sets and `supports_paper` / `supports_live` flags.
+
+**T10. Documentation.**
+- Append a new section to `app/mcp_server/README.md` documenting the
+  profile env var, the `kis_live_*` / `kis_mock_*` tool names, and the
+  fact that `hermes-paper-kis` omits live order surfaces.
+- Add a brief operator note to `env.example` near the existing `KIS_MOCK_*`
+  block: "Set MCP_PROFILE=hermes-paper-kis on paper-only deployments."
+
+**T11. Run the full focused test set in §8 and `ruff` / `ruff format`.**
+Do not run the integration or slow markers.
+
+**T12. Update CHANGELOG.md** with a brief entry under "Unreleased / Added".
+
+**Out of scope reminders:**
+- Do not change any `_place_order_impl` / `cancel_order_impl` / behavior.
+- Do not modify Alembic migrations.
+- Do not register `kis_live_*` tools in the `hermes-paper-kis` profile
+  for any reason.
+- Do not introduce a Kiwoom client.
+
+---
+
+## 8. Test plan
+
+All tests in this plan are unit/lightweight and use the existing
+`tests/_mcp_tooling_support.py::DummyMCP` harness. None require a live
+broker connection or PostgreSQL.
+
+### 8.1 New tests
+
+**`tests/test_mcp_profiles.py`**
+- `test_default_profile_registers_legacy_order_tools`: build `DummyMCP`,
+  call `register_all_tools(mcp, profile=McpProfile.DEFAULT)`. Assert
+  `{place_order, cancel_order, modify_order, get_order_history}` ⊆ tools.
+- `test_default_profile_also_registers_typed_kis_variants`: in DEFAULT,
+  assert all eight `kis_live_*` and `kis_mock_*` names are present.
+- `test_hermes_paper_kis_does_not_register_live_order_tools`: build
+  `DummyMCP`, call `register_all_tools(mcp, profile=HERMES_PAPER_KIS)`.
+  Assert **none of** `{place_order, cancel_order, modify_order,
+  get_order_history, kis_live_place_order, kis_live_cancel_order,
+  kis_live_modify_order, kis_live_get_order_history}` are in `mcp.tools`.
+- `test_hermes_paper_kis_registers_kis_mock_order_tools`: same setup,
+  assert all four `kis_mock_*` tool names present.
+- `test_hermes_paper_kis_registers_readonly_research_tools`: assert at
+  least `get_holdings`, `portfolio_cash`, plus a representative read-only
+  tool from each helper (e.g. `get_quote`, `get_company_profile` if they
+  exist) are present.
+- `test_resolve_mcp_profile_default_and_explicit_and_invalid`: covers
+  `None`, `""`, `"default"`, `"hermes-paper-kis"`, and an invalid string
+  raising `ValueError`.
+
+**`tests/test_mcp_kis_order_variants.py`** (mock with monkeypatched impls)
+- For each of `kis_mock_place_order` / `kis_mock_cancel_order` /
+  `kis_mock_modify_order` / `kis_mock_get_order_history`:
+  - `..._fails_closed_when_config_missing`: monkeypatch
+    `validate_kis_mock_config` to return missing names; assert the call
+    short-circuits with the standardized envelope (`success=False`,
+    `account_mode="kis_mock"`, error string contains the missing names).
+  - `..._passes_is_mock_true_to_impl`: monkeypatch the underlying
+    `_place_order_impl` / `cancel_order_impl` / `modify_order_impl` /
+    `get_order_history_impl` and assert it was called with
+    `is_mock=True`.
+  - `..._rejects_account_mode_kis_live_argument`: pass
+    `account_mode="kis_live"` and assert structured rejection (no
+    delegation).
+- For each of `kis_live_place_order` / `kis_live_cancel_order` /
+  `kis_live_modify_order` / `kis_live_get_order_history`:
+  - `..._passes_is_mock_false_to_impl`.
+  - `..._rejects_account_mode_kis_mock_argument`.
+
+**`tests/test_kis_settings_view_isolation.py`**
+- `test_mock_view_does_not_leak_live_app_key`: monkeypatch
+  `settings.kis_app_key` to `"LIVE-KEY"` and `settings.kis_mock_app_key` to
+  `"MOCK-KEY"`; assert `_KISSettingsView(is_mock=True).kis_app_key ==
+  "MOCK-KEY"`.
+- Repeat for `kis_app_secret`, `kis_account_no`, `kis_base_url`,
+  `kis_access_token`.
+- `test_live_view_does_not_leak_mock_app_key`: symmetric assertion for
+  `is_mock=False`.
+
+**`tests/test_broker_capabilities.py`**
+- `test_kis_supports_kr_and_us`: assert
+  `BROKER_CAPABILITIES[Broker.KIS].markets == {Market.KR_EQUITY,
+  Market.US_EQUITY}`.
+- `test_kiwoom_capability_metadata_only`: assert Kiwoom is registered with
+  `supports_paper=False` and `supports_live=False` and the same KR+US
+  markets.
+- `test_upbit_supports_only_crypto`.
+
+### 8.2 Regression coverage to keep green (no edits expected)
+
+- `tests/test_mcp_account_modes.py` — full file (default routing, alias
+  handling, fail-closed envelope, `is_mock=True` propagation).
+- `tests/test_kis_mock_routing.py`, `tests/test_kis_mock_order_ledger.py`.
+- `tests/test_kis_constants.py::test_mock_unsupported_tr_set_is_documented`.
+- `tests/test_orders_history_kis_mock.py`,
+  `tests/test_portfolio_cash_kis_mock.py`,
+  `tests/test_kis_integrated_margin_mock.py`.
+
+### 8.3 Focused pytest target
+
+After each task and at the end of T11:
+
+```
+uv run pytest \
+  tests/test_mcp_profiles.py \
+  tests/test_mcp_kis_order_variants.py \
+  tests/test_kis_settings_view_isolation.py \
+  tests/test_broker_capabilities.py \
+  tests/test_mcp_account_modes.py \
+  tests/test_kis_mock_routing.py \
+  tests/test_kis_mock_order_ledger.py \
+  tests/test_kis_constants.py \
+  tests/test_orders_history_kis_mock.py \
+  tests/test_portfolio_cash_kis_mock.py \
+  tests/test_kis_integrated_margin_mock.py \
+  tests/test_paper_order_handler.py \
+  tests/test_mcp_order_tools.py \
+  tests/test_mcp_place_order.py \
+  -q
+```
+
+Lint:
+
+```
+uv run ruff check app tests
+uv run ruff format --check app tests
+```
+
+`ty` typecheck if it's part of the standard make target:
+
+```
+uv run ty check app/mcp_server/profiles.py \
+                app/mcp_server/tooling/orders_kis_variants.py \
+                app/mcp_server/tooling/registry.py \
+                app/services/brokers/capabilities.py
+```
+
+(Or `make typecheck` if it doesn't take a path.)
+
+---
+
+## 9. Rollout / safety notes
+
+- **`MCP_PROFILE` defaults to `default`.** Existing deployments are
+  unaffected unless an operator explicitly sets the env var.
+- **`hermes-paper-kis` requires `KIS_MOCK_ENABLED=true` and the four mock
+  vars** to do anything useful. With them missing, the `kis_mock_*` tools
+  return the standardized fail-closed envelope; the deployment is then
+  effectively read-only KIS, which is the intended safe state.
+- **No live order code path changes.** The new live variants
+  (`kis_live_*`) delegate to the same `_place_order_impl` etc. used by
+  today's `place_order`. Behavior on `default` is unchanged.
+- **`dry_run=True` defaults preserved** in all wrappers (must be verified
+  in the contract tests).
+- **Audit log surface.** With distinct tool names, the `CallerIdentityMiddleware`
+  / `McpToolCallSentryMiddleware` will record tool name = `kis_live_place_order`
+  vs `kis_mock_place_order`, making "which surface was called" trivially
+  visible in Sentry traces.
+- **Operator runbook** (suggested addendum to
+  `app/mcp_server/README.md`): when validating a paper-only environment,
+  hit the MCP `/mcp` listing and confirm absence of `kis_live_*` and the
+  legacy ambiguous tools.
+- **Secrets:** never print KIS keys. The fail-closed envelope already
+  returns names only; reuse it.
+
+---
+
+## 10. Out-of-scope / follow-ups
+
+- **F1.** Upbit / crypto in `hermes-paper-kis`. Today crypto routes
+  through `place_order`, which won't be in the paper-only profile. If
+  paper-only crypto is needed, file a follow-up to add `db_simulated`
+  Upbit variants or split similarly.
+- **F2.** Kiwoom broker integration (live or paper). ROB-56 only adds
+  capability metadata; no live client.
+- **F3.** Capability-driven routing in `_execute_order`. Today it's still
+  hard-coded by `market_type`; once Kiwoom or a second KR broker exists,
+  follow up to consume `BROKER_CAPABILITIES`.
+- **F4.** Operator smoke test against the real KIS mock server. Phase-2
+  carry from ROB-19. Out of scope here because it requires a live mock
+  account.
+- **F5.** Move the legacy ambiguous `place_order` / `cancel_order` /
+  `modify_order` / `get_order_history` to deprecated status once typed
+  callers have migrated. ROB-56 only adds the typed variants alongside.
+
+---
+
+## Handoff
+
+When Sonnet picks this up:
+
+- Read this plan top-to-bottom before starting T1.
+- Implement task-by-task; do not skip ahead.
+- After each task, run the focused pytest set in §8.3 and only then
+  commit. Use commit messages of the form
+  `feat(ROB-56): <task summary>` or `test(ROB-56): <task summary>`.
+- Do **not** rebase, force-push, or amend any merged commits.
+- If you find an inconsistency between this plan and the current code,
+  stop and surface it before deviating.

--- a/docs/plans/ROB-56-review-report.md
+++ b/docs/plans/ROB-56-review-report.md
@@ -1,0 +1,293 @@
+# ROB-56 Review Report — KIS Official Mock Hard-Separation
+
+**Reviewer:** Claude Opus 4.7
+**Branch / worktree:** `feature/ROB-56-kis-mock-hard-separation`
+(`/Users/mgh3326/work/auto_trader-worktrees/feature-ROB-56-kis-mock-hard-separation`)
+**Plan:** `docs/plans/ROB-56-kis-mock-hard-separation-plan.md`
+**Implementer:** Claude Sonnet
+**Status:** review_passed
+
+---
+
+## 1. Scope of review
+
+Review-only pass over the diff produced by Sonnet against the
+ROB-56 plan. No production code modified. No broker mutation calls.
+No live autonomous trading enabled.
+
+Files inspected (changed / added):
+
+- `app/mcp_server/main.py` (modified)
+- `app/mcp_server/profiles.py` (new)
+- `app/mcp_server/tooling/registry.py` (modified)
+- `app/mcp_server/tooling/orders_kis_variants.py` (new)
+- `app/services/brokers/capabilities.py` (new)
+- `app/mcp_server/README.md` (modified — appended profile docs)
+- `env.example` (modified)
+- `CHANGELOG.md` (modified)
+- `tests/test_mcp_profiles.py` (new)
+- `tests/test_mcp_kis_order_variants.py` (new)
+- `tests/test_kis_settings_view_isolation.py` (new)
+- `tests/test_broker_capabilities.py` (new)
+
+Reference files (read-only): `app/services/brokers/kis/client.py`,
+`app/mcp_server/tooling/account_modes.py`,
+`app/mcp_server/tooling/orders_registration.py`.
+
+---
+
+## 2. Required-scope findings
+
+### 2.1 Live/mock credential and env separation (G1, plan §2.1, §4.6)
+**Pass.** `_KISSettingsView` (`client.py:43-88`) is unchanged on this
+branch and continues to expose `kis_app_key`, `kis_app_secret`,
+`kis_account_no`, `kis_base_url`, `kis_access_token` via explicit
+`@property` accessors that branch on `self._is_mock`. Since properties
+take precedence over `__getattr__`, the four hot fields cannot fall
+through to the live settings object even if a future regression weakens
+`__getattr__`. The new
+`tests/test_kis_settings_view_isolation.py` pins this for both
+directions (mock→mock-only, live→live-only) across all five fields,
+which is the ROB-19 phase-2 carry the plan called out.
+
+### 2.2 Mock-only service / order boundary fail-closed (G1, plan §4.5)
+**Pass.** `orders_kis_variants._mock_config_error` in
+`orders_kis_variants.py:53-65` reproduces the canonical envelope
+(`success=False`, `source="kis"`, `account_mode="kis_mock"`,
+error message lists missing var **names only**) used by the legacy
+path in `orders_registration.py:33-45`. Each `kis_mock_*` wrapper
+calls it **before** delegating to the underlying impl. There is no
+fallback to live credentials anywhere in the mock variants —
+`is_mock=True` is a literal in the delegated call, not derived from
+input.
+
+### 2.3 MCP tool surface split into `kis_live_*` / `kis_mock_*` (G2, plan §4.3, §5.2)
+**Pass.** All eight tool names from the plan are present and exact:
+- `kis_live_place_order`, `kis_live_cancel_order`,
+  `kis_live_modify_order`, `kis_live_get_order_history`
+- `kis_mock_place_order`, `kis_mock_cancel_order`,
+  `kis_mock_modify_order`, `kis_mock_get_order_history`
+
+Each variant:
+- Hard-pins `is_mock` (literal `False` for live, `True` for mock —
+  `orders_kis_variants.py:172, 204, 244, 284, 372, 409, 455, 502`).
+- Validates any supplied `account_mode` / `account_type` against the
+  pinned mode via `_check_mode_arg` and rejects mismatches with a
+  structured error (`source="mcp"`, `account_mode=pinned`).
+- Delegates to the same `_place_order_impl` / `cancel_order_impl` /
+  `modify_order_impl` / `orders_history.get_order_history_impl` used
+  by the legacy `place_order` etc., so ROB-37's mock-ledger isolation
+  and ROB-31's `mock_unsupported` tagging are preserved.
+- Wraps the result in `apply_account_routing_metadata` for envelope
+  parity with the legacy tools.
+
+### 2.4 `hermes-paper-kis` profile excludes live tools (G1, plan §4.4)
+**Pass.** `registry.py:101-110` gates the side-effect order tool
+registration on `profile`:
+- `DEFAULT`: `register_order_tools` + `register_kis_live_order_tools`
+  + `register_kis_mock_order_tools` (additive — preserves backward
+  compat, G3).
+- `HERMES_PAPER_KIS`: only `register_kis_mock_order_tools`. The
+  legacy ambiguous tools and `register_kis_live_order_tools` are
+  **physically not registered**.
+
+`tests/test_mcp_profiles.py::TestHermesPaperKisProfile` enforces this:
+- `test_does_not_register_legacy_order_tools` asserts none of
+  `{place_order, cancel_order, modify_order, get_order_history}` is
+  in `mcp.tools` under `HERMES_PAPER_KIS`.
+- `test_does_not_register_live_order_tools` asserts none of the four
+  `kis_live_*` names is registered.
+- `test_registers_kis_mock_order_tools` asserts the four mock-pinned
+  variants are registered.
+
+These tests would fail if any live or legacy ambiguous order tool
+ever leaked into the paper profile. Verified by running the suite
+locally — all assertions pass.
+
+`MCP_PROFILE` env wiring is hooked exactly once, in `main.py:52` via
+`resolve_mcp_profile(_env("MCP_PROFILE"))`, and the resolved profile
+is passed into `register_all_tools`. `resolve_mcp_profile`
+(`profiles.py:17-31`) handles `None`, empty, whitespace-only,
+`"default"`, `"hermes-paper-kis"`, and raises `ValueError` for
+unknown values — pinned by `TestResolveMcpProfile`.
+
+### 2.5 Shared read-only/research tools remain side-effect-free (plan §5.1)
+**Pass.** The unconditional registration block in `registry.py:81-98`
+matches the plan's §5.1 table: all market data, fundamentals,
+analysis, news, market report/brief, watch alerts, trade profile,
+user settings, portfolio (read-only with mock-safe `account_mode`),
+trade journal, paperclip comment, execution comment, and paper
+account/analytics/journal helpers. Each of these helpers is either
+read-only against external APIs / DB or strictly bound to
+`db_simulated` (paper_*) — none can issue a KIS broker mutation.
+`update_manual_holdings` writes to user-owned `manual_holdings`, not
+through any broker, so retaining it in the paper profile is correct.
+
+### 2.6 Broker capability model (plan §6, §2.6)
+**Pass.** `app/services/brokers/capabilities.py` introduces
+`Market`, `Broker`, `BrokerCapability`, and `BROKER_CAPABILITIES`
+with the exact contents the plan specifies:
+- KIS → `{KR_EQUITY, US_EQUITY}`, `supports_paper=True`,
+  `supports_live=True`.
+- Kiwoom → `{KR_EQUITY, US_EQUITY}`, `supports_paper=False`,
+  `supports_live=False` (metadata only — no client integrated).
+- Upbit → `{CRYPTO}`, `supports_paper=False`, `supports_live=True`.
+
+`tests/test_broker_capabilities.py` pins each broker's market set,
+paper/live flags, and the registry's exact key set. The dataclass is
+frozen and uses a `frozenset` for markets, so the registry cannot be
+silently mutated. No production code consumes `BROKER_CAPABILITIES`
+yet, which matches the plan's metadata-only scope.
+
+### 2.7 Test meaningfulness against live-tool leakage
+**Pass.** The new tests are not surface-only — they directly assert
+the absence of live and legacy ambiguous order tool names from the
+paper profile (`test_does_not_register_legacy_order_tools`,
+`test_does_not_register_live_order_tools`), and they assert
+`is_mock=True` / `is_mock=False` is propagated from each typed wrapper
+to the underlying impl by patching the impl and capturing kwargs.
+A regression that registered a `kis_live_*` tool (or the legacy
+ambiguous tools) into `HERMES_PAPER_KIS` would fail loudly here.
+
+### 2.8 No live autonomous trading or broker mutation enabled
+**Pass.** `dry_run` defaults to `True` on every wrapper that takes it
+(`kis_live_place_order`, `kis_live_modify_order`,
+`kis_mock_place_order`, `kis_mock_modify_order`). No code path
+removes the safety; no scheduler, cron, or autonomous loop is
+introduced. The diff does not modify `_place_order_impl`,
+`cancel_order_impl`, `modify_order_impl`, or any broker client.
+
+### 2.9 Backward compatibility for default profile
+**Pass.** Under `MCP_PROFILE` unset (or `"default"`), the legacy
+ambiguous tools (`place_order`, `cancel_order`, `modify_order`,
+`get_order_history`) are still registered via `register_order_tools`
+and continue to honor `account_mode` switching exactly as before.
+The new typed `kis_live_*` / `kis_mock_*` tools are additive. ROB-19,
+ROB-28, ROB-31, ROB-37 callers using
+`account_mode="kis_mock"` / `"kis_live"` see no behavior change. The
+regression suite (`test_mcp_account_modes.py`,
+`test_kis_mock_routing.py`, `test_kis_mock_order_ledger.py`,
+`test_kis_constants.py`, `test_orders_history_kis_mock.py`,
+`test_portfolio_cash_kis_mock.py`,
+`test_kis_integrated_margin_mock.py`,
+`test_paper_order_handler.py`, `test_mcp_order_tools.py`,
+`test_mcp_place_order.py`) passes locally — 163 tests, no failures.
+
+---
+
+## 3. Test results
+
+Focused suite (plan §8.3, the new tests):
+
+```
+uv run pytest \
+  tests/test_mcp_profiles.py \
+  tests/test_mcp_kis_order_variants.py \
+  tests/test_kis_settings_view_isolation.py \
+  tests/test_broker_capabilities.py -q
+→ 58 passed, 2 warnings in 2.43s
+```
+
+Regression suite (existing tests, no edits expected):
+
+```
+uv run pytest \
+  tests/test_mcp_account_modes.py \
+  tests/test_kis_mock_routing.py \
+  tests/test_kis_mock_order_ledger.py \
+  tests/test_kis_constants.py \
+  tests/test_orders_history_kis_mock.py \
+  tests/test_portfolio_cash_kis_mock.py \
+  tests/test_kis_integrated_margin_mock.py -q
+→ 47 passed, 2 warnings in 1.96s
+
+uv run pytest \
+  tests/test_paper_order_handler.py \
+  tests/test_mcp_order_tools.py \
+  tests/test_mcp_place_order.py -q
+→ 116 passed, 3 warnings in 5.62s
+```
+
+Lint:
+
+```
+uv run ruff check app/mcp_server/profiles.py \
+  app/mcp_server/tooling/orders_kis_variants.py \
+  app/mcp_server/tooling/registry.py \
+  app/services/brokers/capabilities.py \
+  tests/test_mcp_profiles.py \
+  tests/test_mcp_kis_order_variants.py \
+  tests/test_kis_settings_view_isolation.py \
+  tests/test_broker_capabilities.py
+→ All checks passed!
+```
+
+Total: 221 tests pass across new + regression coverage. No live
+broker calls were made.
+
+---
+
+## 4. Documentation & changelog
+
+- `app/mcp_server/README.md` adds an "MCP Profiles (ROB-56)" section
+  (line 1009+) covering the env var, the profile→tool-surface table,
+  the typed `kis_live_*` / `kis_mock_*` names, the operator
+  validation step, and the fail-closed envelope shape.
+- `env.example` adds `MCP_PROFILE=default` plus a comment near the
+  KIS_MOCK block instructing operators to set
+  `MCP_PROFILE=hermes-paper-kis` on paper-only deployments.
+- `CHANGELOG.md` has a complete "Unreleased / Added (ROB-56)" entry
+  enumerating the env var, profile, typed tools, capability registry,
+  and `_KISSettingsView` regression tests.
+
+---
+
+## 5. Minor observations (non-blocking, no fix required)
+
+These are advisory only — the plan's acceptance criteria are met and
+none of these block merge.
+
+- **O1.** `_check_mode_arg` only accepts the canonical `account_mode`
+  value (`"kis_mock"` / `"kis_live"`); aliases like `"mock"` or
+  `"live"` are rejected as mismatches. This matches the plan's §5.3
+  contract ("accepted only if equal to the tool's pinned mode") and
+  is the safer choice — but if a typed caller is migrated from a
+  client that previously passed alias values it would need to use the
+  canonical form. No action required; mention in operator notes if
+  the deprecated alias path was widely used by automation.
+- **O2.** `tests/test_mcp_kis_order_variants.py` covers
+  `account_mode` rejection but not `account_type` rejection.
+  `_check_mode_arg` covers both, so functionally this is fine; a
+  future test could pin the `account_type='kis_live'` rejection on a
+  `kis_mock_*` tool for symmetry.
+- **O3.** The plan §9 mentions verifying `dry_run=True` defaults in
+  the contract tests. The new variants preserve `dry_run: bool =
+  True` as a parameter default; the tests rely on this implicitly
+  (callers omit it) but do not assert the resulting `is_mock+dry_run`
+  pair on the captured kwargs. Existing `test_mcp_place_order.py`
+  covers the default for the legacy tool, so the live wrapper's
+  delegation chain is exercised — but a direct assertion on the
+  typed wrappers' default would close the loop.
+- **O4.** Out-of-scope items F1 (Upbit/crypto in `hermes-paper-kis`)
+  and F5 (deprecation of legacy ambiguous tools) remain follow-ups.
+  Confirmed in scope only as documented; no action this PR.
+
+---
+
+## 6. Verdict
+
+The diff implements ROB-56 exactly as planned. Live KIS credentials
+and live-order MCP surfaces cannot be reached from the
+`hermes-paper-kis` profile; mock variants fail closed without
+fallback; the capability registry pins KIS+Kiwoom KR/US support; the
+default profile is unchanged; tests are meaningful and would catch
+the regression the issue is designed to prevent. All focused and
+regression tests pass; lint is clean.
+
+---
+
+AOE_STATUS: review_passed
+AOE_ISSUE: ROB-56
+AOE_ROLE: reviewer
+AOE_REPORT_PATH: docs/plans/ROB-56-review-report.md
+AOE_NEXT: create_pr

--- a/env.example
+++ b/env.example
@@ -18,12 +18,15 @@ KIS_BASE_URL=https://openapi.koreainvestment.com:9443
 
 # KIS official mock/sandbox account settings.
 # Keep credential values in operator-managed runtime env files; do not commit them.
+# Set MCP_PROFILE=hermes-paper-kis on paper-only deployments so the live order
+# surface is physically absent from the MCP tool list.
 KIS_MOCK_ENABLED=false
 KIS_MOCK_APP_KEY=
 KIS_MOCK_APP_SECRET=
 KIS_MOCK_ACCOUNT_NO=
 KIS_MOCK_BASE_URL=https://openapivts.koreainvestment.com:29443
 KIS_MOCK_ACCESS_TOKEN=
+MCP_PROFILE=default
 
 # KIS WebSocket 설정
 # ========================================

--- a/tests/test_broker_capabilities.py
+++ b/tests/test_broker_capabilities.py
@@ -1,0 +1,82 @@
+"""Tests for broker capability metadata registry.
+
+Pins the per-broker market sets and supports_paper/supports_live flags.
+No production code consumes BROKER_CAPABILITIES yet; this test pins the
+registry for forward-looking planning and prevents silent drift.
+"""
+
+from __future__ import annotations
+
+from app.services.brokers.capabilities import (
+    BROKER_CAPABILITIES,
+    Broker,
+    BrokerCapability,
+    Market,
+)
+
+
+class TestKisCapabilities:
+    def test_kis_supports_kr_and_us_equity(self) -> None:
+        cap = BROKER_CAPABILITIES[Broker.KIS]
+        assert cap.markets == frozenset({Market.KR_EQUITY, Market.US_EQUITY})
+
+    def test_kis_does_not_support_crypto(self) -> None:
+        cap = BROKER_CAPABILITIES[Broker.KIS]
+        assert Market.CRYPTO not in cap.markets
+
+    def test_kis_supports_paper(self) -> None:
+        cap = BROKER_CAPABILITIES[Broker.KIS]
+        assert cap.supports_paper is True
+
+    def test_kis_supports_live(self) -> None:
+        cap = BROKER_CAPABILITIES[Broker.KIS]
+        assert cap.supports_live is True
+
+    def test_kis_broker_field(self) -> None:
+        cap = BROKER_CAPABILITIES[Broker.KIS]
+        assert cap.broker is Broker.KIS
+
+
+class TestKiwoomCapabilities:
+    def test_kiwoom_capability_metadata_only(self) -> None:
+        cap = BROKER_CAPABILITIES[Broker.KIWOOM]
+        assert cap.supports_paper is False
+        assert cap.supports_live is False
+
+    def test_kiwoom_supports_kr_and_us_equity(self) -> None:
+        cap = BROKER_CAPABILITIES[Broker.KIWOOM]
+        assert cap.markets == frozenset({Market.KR_EQUITY, Market.US_EQUITY})
+
+    def test_kiwoom_broker_field(self) -> None:
+        cap = BROKER_CAPABILITIES[Broker.KIWOOM]
+        assert cap.broker is Broker.KIWOOM
+
+
+class TestUpbitCapabilities:
+    def test_upbit_supports_only_crypto(self) -> None:
+        cap = BROKER_CAPABILITIES[Broker.UPBIT]
+        assert cap.markets == frozenset({Market.CRYPTO})
+        assert Market.KR_EQUITY not in cap.markets
+        assert Market.US_EQUITY not in cap.markets
+
+    def test_upbit_does_not_support_paper(self) -> None:
+        cap = BROKER_CAPABILITIES[Broker.UPBIT]
+        assert cap.supports_paper is False
+
+    def test_upbit_supports_live(self) -> None:
+        cap = BROKER_CAPABILITIES[Broker.UPBIT]
+        assert cap.supports_live is True
+
+
+class TestBrokerCapabilityRegistry:
+    def test_all_brokers_registered(self) -> None:
+        assert set(BROKER_CAPABILITIES.keys()) == {
+            Broker.KIS,
+            Broker.KIWOOM,
+            Broker.UPBIT,
+        }
+
+    def test_capabilities_are_frozen(self) -> None:
+        cap = BROKER_CAPABILITIES[Broker.KIS]
+        assert isinstance(cap, BrokerCapability)
+        assert isinstance(cap.markets, frozenset)

--- a/tests/test_kis_settings_view_isolation.py
+++ b/tests/test_kis_settings_view_isolation.py
@@ -1,0 +1,93 @@
+"""Regression tests for _KISSettingsView credential isolation.
+
+Pins that when is_mock=True the five hot credential fields return mock values
+and do NOT leak live values, and vice versa when is_mock=False.
+
+ROB-19 phase-2 carry: tightens _KISSettingsView against future leaky
+__getattr__ regressions for the four sensitive live/mock credential fields.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import settings
+from app.services.brokers.kis.client import _KISSettingsView
+
+
+class TestMockViewDoesNotLeakLiveCredentials:
+    """When is_mock=True, all five hot fields must return mock values."""
+
+    def test_kis_app_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "kis_app_key", "LIVE-KEY")
+        monkeypatch.setattr(settings, "kis_mock_app_key", "MOCK-KEY")
+        view = _KISSettingsView(is_mock=True)
+        assert view.kis_app_key == "MOCK-KEY"
+        assert view.kis_app_key != "LIVE-KEY"
+
+    def test_kis_app_secret(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "kis_app_secret", "LIVE-SECRET")
+        monkeypatch.setattr(settings, "kis_mock_app_secret", "MOCK-SECRET")
+        view = _KISSettingsView(is_mock=True)
+        assert view.kis_app_secret == "MOCK-SECRET"
+        assert view.kis_app_secret != "LIVE-SECRET"
+
+    def test_kis_account_no(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "kis_account_no", "11111111-01")
+        monkeypatch.setattr(settings, "kis_mock_account_no", "99999999-01")
+        view = _KISSettingsView(is_mock=True)
+        assert view.kis_account_no == "99999999-01"
+        assert view.kis_account_no != "11111111-01"
+
+    def test_kis_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "kis_base_url", "https://live.example.com")
+        monkeypatch.setattr(settings, "kis_mock_base_url", "https://mock.example.com")
+        view = _KISSettingsView(is_mock=True)
+        assert view.kis_base_url == "https://mock.example.com"
+        assert view.kis_base_url != "https://live.example.com"
+
+    def test_kis_access_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "kis_access_token", "LIVE-TOKEN")
+        monkeypatch.setattr(settings, "kis_mock_access_token", "MOCK-TOKEN")
+        view = _KISSettingsView(is_mock=True)
+        assert view.kis_access_token == "MOCK-TOKEN"
+        assert view.kis_access_token != "LIVE-TOKEN"
+
+
+class TestLiveViewDoesNotLeakMockCredentials:
+    """When is_mock=False, all five hot fields must return live values."""
+
+    def test_kis_app_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "kis_app_key", "LIVE-KEY")
+        monkeypatch.setattr(settings, "kis_mock_app_key", "MOCK-KEY")
+        view = _KISSettingsView(is_mock=False)
+        assert view.kis_app_key == "LIVE-KEY"
+        assert view.kis_app_key != "MOCK-KEY"
+
+    def test_kis_app_secret(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "kis_app_secret", "LIVE-SECRET")
+        monkeypatch.setattr(settings, "kis_mock_app_secret", "MOCK-SECRET")
+        view = _KISSettingsView(is_mock=False)
+        assert view.kis_app_secret == "LIVE-SECRET"
+        assert view.kis_app_secret != "MOCK-SECRET"
+
+    def test_kis_account_no(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "kis_account_no", "11111111-01")
+        monkeypatch.setattr(settings, "kis_mock_account_no", "99999999-01")
+        view = _KISSettingsView(is_mock=False)
+        assert view.kis_account_no == "11111111-01"
+        assert view.kis_account_no != "99999999-01"
+
+    def test_kis_base_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "kis_base_url", "https://live.example.com")
+        monkeypatch.setattr(settings, "kis_mock_base_url", "https://mock.example.com")
+        view = _KISSettingsView(is_mock=False)
+        assert view.kis_base_url == "https://live.example.com"
+        assert view.kis_base_url != "https://mock.example.com"
+
+    def test_kis_access_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "kis_access_token", "LIVE-TOKEN")
+        monkeypatch.setattr(settings, "kis_mock_access_token", "MOCK-TOKEN")
+        view = _KISSettingsView(is_mock=False)
+        assert view.kis_access_token == "LIVE-TOKEN"
+        assert view.kis_access_token != "MOCK-TOKEN"

--- a/tests/test_mcp_kis_order_variants.py
+++ b/tests/test_mcp_kis_order_variants.py
@@ -10,6 +10,7 @@ Verifies:
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, cast
 
 import pytest
@@ -92,6 +93,7 @@ class TestKisMockPlaceOrder:
         captured: dict[str, Any] = {}
 
         async def fake_place_order_impl(**kwargs: Any) -> dict[str, Any]:
+            await asyncio.sleep(0)
             captured.update(kwargs)
             return {"success": True, "dry_run": True}
 
@@ -126,6 +128,7 @@ class TestKisMockPlaceOrder:
         captured: dict[str, Any] = {}
 
         async def fake_place_order_impl(**kwargs: Any) -> dict[str, Any]:
+            await asyncio.sleep(0)
             captured.update(kwargs)
             return {"success": True, "dry_run": True}
 
@@ -165,6 +168,7 @@ class TestKisMockCancelOrder:
         captured: dict[str, Any] = {}
 
         async def fake_cancel_impl(**kwargs: Any) -> dict[str, Any]:
+            await asyncio.sleep(0)
             captured.update(kwargs)
             return {"success": True, "order_id": kwargs.get("order_id")}
 
@@ -218,6 +222,7 @@ class TestKisMockModifyOrder:
         captured: dict[str, Any] = {}
 
         async def fake_modify_impl(**kwargs: Any) -> dict[str, Any]:
+            await asyncio.sleep(0)
             captured.update(kwargs)
             return {"success": True, "dry_run": True}
 
@@ -272,6 +277,7 @@ class TestKisMockGetOrderHistory:
         captured: dict[str, Any] = {}
 
         async def fake_get_history_impl(**kwargs: Any) -> dict[str, Any]:
+            await asyncio.sleep(0)
             captured.update(kwargs)
             return {"success": True, "orders": []}
 
@@ -311,6 +317,7 @@ class TestKisLivePlaceOrder:
         captured: dict[str, Any] = {}
 
         async def fake_place_order_impl(**kwargs: Any) -> dict[str, Any]:
+            await asyncio.sleep(0)
             captured.update(kwargs)
             return {"success": True, "dry_run": True}
 
@@ -348,6 +355,7 @@ class TestKisLiveCancelOrder:
         captured: dict[str, Any] = {}
 
         async def fake_cancel_impl(**kwargs: Any) -> dict[str, Any]:
+            await asyncio.sleep(0)
             captured.update(kwargs)
             return {"success": True, "order_id": kwargs.get("order_id")}
 
@@ -382,6 +390,7 @@ class TestKisLiveModifyOrder:
         captured: dict[str, Any] = {}
 
         async def fake_modify_impl(**kwargs: Any) -> dict[str, Any]:
+            await asyncio.sleep(0)
             captured.update(kwargs)
             return {"success": True, "dry_run": True}
 
@@ -421,6 +430,7 @@ class TestKisLiveGetOrderHistory:
         captured: dict[str, Any] = {}
 
         async def fake_get_history_impl(**kwargs: Any) -> dict[str, Any]:
+            await asyncio.sleep(0)
             captured.update(kwargs)
             return {"success": True, "orders": []}
 

--- a/tests/test_mcp_kis_order_variants.py
+++ b/tests/test_mcp_kis_order_variants.py
@@ -1,0 +1,442 @@
+"""Tests for the typed KIS order tool variants (kis_live_* / kis_mock_*).
+
+Verifies:
+- kis_mock_* tools fail closed when KIS mock config is missing.
+- kis_mock_* tools pass is_mock=True to underlying impls.
+- kis_mock_* tools reject account_mode='kis_live' argument.
+- kis_live_* tools pass is_mock=False to underlying impls.
+- kis_live_* tools reject account_mode='kis_mock' argument.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+import app.mcp_server.tooling.orders_kis_variants as orders_kis_variants
+from app.mcp_server.tooling import order_execution, orders_history
+from app.mcp_server.tooling.orders_kis_variants import (
+    register_kis_live_order_tools,
+    register_kis_mock_order_tools,
+)
+from tests._mcp_tooling_support import DummyMCP
+
+
+def _build_live_mcp() -> DummyMCP:
+    mcp = DummyMCP()
+    register_kis_live_order_tools(cast(Any, mcp))
+    return mcp
+
+
+def _build_mock_mcp() -> DummyMCP:
+    mcp = DummyMCP()
+    register_kis_mock_order_tools(cast(Any, mcp))
+    return mcp
+
+
+# ---------------------------------------------------------------------------
+# Helper: patch validate_kis_mock_config to simulate missing config
+# ---------------------------------------------------------------------------
+
+
+def _patch_mock_config_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    missing: list[str] | None = None,
+) -> None:
+    names = missing or ["KIS_MOCK_ENABLED", "KIS_MOCK_APP_KEY"]
+    monkeypatch.setattr(
+        orders_kis_variants,
+        "validate_kis_mock_config",
+        lambda: names,
+    )
+
+
+def _patch_mock_config_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        orders_kis_variants,
+        "validate_kis_mock_config",
+        lambda: [],
+    )
+
+
+# ===========================================================================
+# kis_mock_place_order
+# ===========================================================================
+
+
+class TestKisMockPlaceOrder:
+    @pytest.mark.asyncio
+    async def test_fails_closed_when_config_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_mock_mcp()
+        _patch_mock_config_missing(
+            monkeypatch, ["KIS_MOCK_ENABLED", "KIS_MOCK_APP_KEY"]
+        )
+        result = await mcp.tools["kis_mock_place_order"](
+            symbol="005930", side="buy", price=50000.0
+        )
+        assert result["success"] is False
+        assert result["account_mode"] == "kis_mock"
+        assert "KIS_MOCK_ENABLED" in result["error"]
+        assert "KIS_MOCK_APP_KEY" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_passes_is_mock_true_to_impl(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_mock_mcp()
+        _patch_mock_config_ok(monkeypatch)
+
+        captured: dict[str, Any] = {}
+
+        async def fake_place_order_impl(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"success": True, "dry_run": True}
+
+        monkeypatch.setattr(order_execution, "_place_order_impl", fake_place_order_impl)
+
+        await mcp.tools["kis_mock_place_order"](
+            symbol="005930", side="buy", price=50000.0
+        )
+        assert captured.get("is_mock") is True
+
+    @pytest.mark.asyncio
+    async def test_rejects_account_mode_kis_live_argument(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_mock_mcp()
+        _patch_mock_config_ok(monkeypatch)
+
+        result = await mcp.tools["kis_mock_place_order"](
+            symbol="005930", side="buy", price=50000.0, account_mode="kis_live"
+        )
+        assert result["success"] is False
+        assert "kis_mock" in result["error"]
+        assert "account_mode" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_accepts_matching_account_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_mock_mcp()
+        _patch_mock_config_ok(monkeypatch)
+
+        captured: dict[str, Any] = {}
+
+        async def fake_place_order_impl(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"success": True, "dry_run": True}
+
+        monkeypatch.setattr(order_execution, "_place_order_impl", fake_place_order_impl)
+
+        result = await mcp.tools["kis_mock_place_order"](
+            symbol="005930", side="buy", price=50000.0, account_mode="kis_mock"
+        )
+        assert result.get("success") is True
+
+
+# ===========================================================================
+# kis_mock_cancel_order
+# ===========================================================================
+
+
+class TestKisMockCancelOrder:
+    @pytest.mark.asyncio
+    async def test_fails_closed_when_config_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_mock_mcp()
+        _patch_mock_config_missing(monkeypatch, ["KIS_MOCK_ENABLED"])
+
+        result = await mcp.tools["kis_mock_cancel_order"](order_id="ORD-001")
+        assert result["success"] is False
+        assert result["account_mode"] == "kis_mock"
+        assert "KIS_MOCK_ENABLED" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_passes_is_mock_true_to_impl(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_mock_mcp()
+        _patch_mock_config_ok(monkeypatch)
+
+        captured: dict[str, Any] = {}
+
+        async def fake_cancel_impl(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"success": True, "order_id": kwargs.get("order_id")}
+
+        monkeypatch.setattr(orders_kis_variants, "cancel_order_impl", fake_cancel_impl)
+
+        await mcp.tools["kis_mock_cancel_order"](order_id="ORD-001")
+        assert captured.get("is_mock") is True
+
+    @pytest.mark.asyncio
+    async def test_rejects_account_mode_kis_live_argument(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_mock_mcp()
+        _patch_mock_config_ok(monkeypatch)
+
+        result = await mcp.tools["kis_mock_cancel_order"](
+            order_id="ORD-001", account_mode="kis_live"
+        )
+        assert result["success"] is False
+        assert "kis_mock" in result["error"]
+
+
+# ===========================================================================
+# kis_mock_modify_order
+# ===========================================================================
+
+
+class TestKisMockModifyOrder:
+    @pytest.mark.asyncio
+    async def test_fails_closed_when_config_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_mock_mcp()
+        _patch_mock_config_missing(
+            monkeypatch, ["KIS_MOCK_ENABLED", "KIS_MOCK_APP_KEY"]
+        )
+
+        result = await mcp.tools["kis_mock_modify_order"](
+            order_id="ORD-001", symbol="005930", new_price=51000.0
+        )
+        assert result["success"] is False
+        assert result["account_mode"] == "kis_mock"
+
+    @pytest.mark.asyncio
+    async def test_passes_is_mock_true_to_impl(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_mock_mcp()
+        _patch_mock_config_ok(monkeypatch)
+
+        captured: dict[str, Any] = {}
+
+        async def fake_modify_impl(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"success": True, "dry_run": True}
+
+        monkeypatch.setattr(orders_kis_variants, "modify_order_impl", fake_modify_impl)
+
+        await mcp.tools["kis_mock_modify_order"](
+            order_id="ORD-001", symbol="005930", new_price=51000.0
+        )
+        assert captured.get("is_mock") is True
+
+    @pytest.mark.asyncio
+    async def test_rejects_account_mode_kis_live_argument(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_mock_mcp()
+        _patch_mock_config_ok(monkeypatch)
+
+        result = await mcp.tools["kis_mock_modify_order"](
+            order_id="ORD-001",
+            symbol="005930",
+            new_price=51000.0,
+            account_mode="kis_live",
+        )
+        assert result["success"] is False
+        assert "kis_mock" in result["error"]
+
+
+# ===========================================================================
+# kis_mock_get_order_history
+# ===========================================================================
+
+
+class TestKisMockGetOrderHistory:
+    @pytest.mark.asyncio
+    async def test_fails_closed_when_config_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_mock_mcp()
+        _patch_mock_config_missing(monkeypatch, ["KIS_MOCK_ENABLED"])
+
+        result = await mcp.tools["kis_mock_get_order_history"](symbol="005930")
+        assert result["success"] is False
+        assert result["account_mode"] == "kis_mock"
+
+    @pytest.mark.asyncio
+    async def test_passes_is_mock_true_to_impl(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_mock_mcp()
+        _patch_mock_config_ok(monkeypatch)
+
+        captured: dict[str, Any] = {}
+
+        async def fake_get_history_impl(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"success": True, "orders": []}
+
+        monkeypatch.setattr(
+            orders_history, "get_order_history_impl", fake_get_history_impl
+        )
+
+        await mcp.tools["kis_mock_get_order_history"](symbol="005930")
+        assert captured.get("is_mock") is True
+
+    @pytest.mark.asyncio
+    async def test_rejects_account_mode_kis_live_argument(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_mock_mcp()
+        _patch_mock_config_ok(monkeypatch)
+
+        result = await mcp.tools["kis_mock_get_order_history"](
+            symbol="005930", account_mode="kis_live"
+        )
+        assert result["success"] is False
+        assert "kis_mock" in result["error"]
+
+
+# ===========================================================================
+# kis_live_place_order
+# ===========================================================================
+
+
+class TestKisLivePlaceOrder:
+    @pytest.mark.asyncio
+    async def test_passes_is_mock_false_to_impl(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_live_mcp()
+
+        captured: dict[str, Any] = {}
+
+        async def fake_place_order_impl(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"success": True, "dry_run": True}
+
+        monkeypatch.setattr(order_execution, "_place_order_impl", fake_place_order_impl)
+
+        await mcp.tools["kis_live_place_order"](
+            symbol="005930", side="buy", price=50000.0
+        )
+        assert captured.get("is_mock") is False
+
+    @pytest.mark.asyncio
+    async def test_rejects_account_mode_kis_mock_argument(self) -> None:
+        mcp = _build_live_mcp()
+
+        result = await mcp.tools["kis_live_place_order"](
+            symbol="005930", side="buy", price=50000.0, account_mode="kis_mock"
+        )
+        assert result["success"] is False
+        assert "kis_live" in result["error"]
+        assert "account_mode" in result["error"]
+
+
+# ===========================================================================
+# kis_live_cancel_order
+# ===========================================================================
+
+
+class TestKisLiveCancelOrder:
+    @pytest.mark.asyncio
+    async def test_passes_is_mock_false_to_impl(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_live_mcp()
+
+        captured: dict[str, Any] = {}
+
+        async def fake_cancel_impl(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"success": True, "order_id": kwargs.get("order_id")}
+
+        monkeypatch.setattr(orders_kis_variants, "cancel_order_impl", fake_cancel_impl)
+
+        await mcp.tools["kis_live_cancel_order"](order_id="ORD-001")
+        assert captured.get("is_mock") is False
+
+    @pytest.mark.asyncio
+    async def test_rejects_account_mode_kis_mock_argument(self) -> None:
+        mcp = _build_live_mcp()
+
+        result = await mcp.tools["kis_live_cancel_order"](
+            order_id="ORD-001", account_mode="kis_mock"
+        )
+        assert result["success"] is False
+        assert "kis_live" in result["error"]
+
+
+# ===========================================================================
+# kis_live_modify_order
+# ===========================================================================
+
+
+class TestKisLiveModifyOrder:
+    @pytest.mark.asyncio
+    async def test_passes_is_mock_false_to_impl(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_live_mcp()
+
+        captured: dict[str, Any] = {}
+
+        async def fake_modify_impl(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"success": True, "dry_run": True}
+
+        monkeypatch.setattr(orders_kis_variants, "modify_order_impl", fake_modify_impl)
+
+        await mcp.tools["kis_live_modify_order"](
+            order_id="ORD-001", symbol="005930", new_price=51000.0
+        )
+        assert captured.get("is_mock") is False
+
+    @pytest.mark.asyncio
+    async def test_rejects_account_mode_kis_mock_argument(self) -> None:
+        mcp = _build_live_mcp()
+
+        result = await mcp.tools["kis_live_modify_order"](
+            order_id="ORD-001",
+            symbol="005930",
+            new_price=51000.0,
+            account_mode="kis_mock",
+        )
+        assert result["success"] is False
+        assert "kis_live" in result["error"]
+
+
+# ===========================================================================
+# kis_live_get_order_history
+# ===========================================================================
+
+
+class TestKisLiveGetOrderHistory:
+    @pytest.mark.asyncio
+    async def test_passes_is_mock_false_to_impl(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mcp = _build_live_mcp()
+
+        captured: dict[str, Any] = {}
+
+        async def fake_get_history_impl(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {"success": True, "orders": []}
+
+        monkeypatch.setattr(
+            orders_history, "get_order_history_impl", fake_get_history_impl
+        )
+
+        await mcp.tools["kis_live_get_order_history"](symbol="005930")
+        assert captured.get("is_mock") is False
+
+    @pytest.mark.asyncio
+    async def test_rejects_account_mode_kis_mock_argument(self) -> None:
+        mcp = _build_live_mcp()
+
+        result = await mcp.tools["kis_live_get_order_history"](
+            symbol="005930", account_mode="kis_mock"
+        )
+        assert result["success"] is False
+        assert "kis_live" in result["error"]

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -1,0 +1,98 @@
+"""Tests for MCP profile-driven tool registration.
+
+Verifies that:
+- DEFAULT profile registers legacy ambiguous order tools AND typed variants.
+- HERMES_PAPER_KIS profile registers only kis_mock_* order tools; live surface absent.
+- resolve_mcp_profile handles None/empty/valid/invalid inputs correctly.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from app.mcp_server.profiles import McpProfile, resolve_mcp_profile
+from app.mcp_server.tooling.orders_kis_variants import (
+    KIS_LIVE_ORDER_TOOL_NAMES,
+    KIS_MOCK_ORDER_TOOL_NAMES,
+)
+from app.mcp_server.tooling.orders_registration import ORDER_TOOL_NAMES
+from app.mcp_server.tooling.registry import register_all_tools
+from tests._mcp_tooling_support import DummyMCP
+
+_LEGACY_ORDER_TOOL_NAMES = ORDER_TOOL_NAMES  # {place_order, cancel_order, ...}
+
+
+def _build_mcp(profile: McpProfile) -> DummyMCP:
+    mcp = DummyMCP()
+    register_all_tools(cast(Any, mcp), profile=profile)
+    return mcp
+
+
+class TestDefaultProfile:
+    def test_registers_legacy_order_tools(self) -> None:
+        mcp = _build_mcp(McpProfile.DEFAULT)
+        assert _LEGACY_ORDER_TOOL_NAMES <= mcp.tools.keys()
+
+    def test_registers_typed_kis_live_variants(self) -> None:
+        mcp = _build_mcp(McpProfile.DEFAULT)
+        assert KIS_LIVE_ORDER_TOOL_NAMES <= mcp.tools.keys()
+
+    def test_registers_typed_kis_mock_variants(self) -> None:
+        mcp = _build_mcp(McpProfile.DEFAULT)
+        assert KIS_MOCK_ORDER_TOOL_NAMES <= mcp.tools.keys()
+
+
+class TestHermesPaperKisProfile:
+    def test_does_not_register_legacy_order_tools(self) -> None:
+        mcp = _build_mcp(McpProfile.HERMES_PAPER_KIS)
+        for name in _LEGACY_ORDER_TOOL_NAMES:
+            assert name not in mcp.tools, (
+                f"hermes-paper-kis must not register legacy tool '{name}'"
+            )
+
+    def test_does_not_register_live_order_tools(self) -> None:
+        mcp = _build_mcp(McpProfile.HERMES_PAPER_KIS)
+        for name in KIS_LIVE_ORDER_TOOL_NAMES:
+            assert name not in mcp.tools, (
+                f"hermes-paper-kis must not register live tool '{name}'"
+            )
+
+    def test_registers_kis_mock_order_tools(self) -> None:
+        mcp = _build_mcp(McpProfile.HERMES_PAPER_KIS)
+        assert KIS_MOCK_ORDER_TOOL_NAMES <= mcp.tools.keys()
+
+    def test_registers_readonly_research_tools(self) -> None:
+        mcp = _build_mcp(McpProfile.HERMES_PAPER_KIS)
+        # Representative read-only tools that must be present in paper profile
+        expected_readonly = {"get_quote", "get_holdings", "get_cash_balance"}
+        for name in expected_readonly:
+            assert name in mcp.tools, (
+                f"hermes-paper-kis must register read-only tool '{name}'"
+            )
+
+
+class TestResolveMcpProfile:
+    def test_none_returns_default(self) -> None:
+        assert resolve_mcp_profile(None) is McpProfile.DEFAULT
+
+    def test_empty_string_returns_default(self) -> None:
+        assert resolve_mcp_profile("") is McpProfile.DEFAULT
+
+    def test_whitespace_only_returns_default(self) -> None:
+        assert resolve_mcp_profile("   ") is McpProfile.DEFAULT
+
+    def test_explicit_default(self) -> None:
+        assert resolve_mcp_profile("default") is McpProfile.DEFAULT
+
+    def test_hermes_paper_kis(self) -> None:
+        assert resolve_mcp_profile("hermes-paper-kis") is McpProfile.HERMES_PAPER_KIS
+
+    def test_invalid_string_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Unknown MCP_PROFILE"):
+            resolve_mcp_profile("unknown-profile")
+
+    def test_invalid_string_mentions_allowed_values(self) -> None:
+        with pytest.raises(ValueError, match="default"):
+            resolve_mcp_profile("bogus")


### PR DESCRIPTION
## Summary
- Add MCP profile support with `MCP_PROFILE=default|hermes-paper-kis`.
- Split KIS side-effect order MCP tools into explicit `kis_live_*` and `kis_mock_*` variants.
- Ensure `hermes-paper-kis` registers mock-only order tools and excludes live/legacy ambiguous order tools.
- Add broker capability metadata for KIS/Kiwoom KR+US and Upbit crypto.
- Document operator validation and env guidance.

## Safety
- No live autonomous trading enabled.
- No real broker mutation calls made.
- Mock KIS paths fail closed without fallback to live credentials.
- Default MCP profile keeps existing legacy behavior for backward compatibility.

## Verification
- `uv run pytest tests/test_mcp_profiles.py tests/test_mcp_kis_order_variants.py tests/test_kis_settings_view_isolation.py tests/test_broker_capabilities.py -q` → 58 passed
- Sonnet implementer reported full focused/regression suite: 221 passed
- Opus reviewer passed implementation and wrote `docs/plans/ROB-56-review-report.md`
- `uv run ruff check ...` → passed
- `uv run ruff format --check ...` → passed

## Review artifacts
- Plan: `docs/plans/ROB-56-kis-mock-hard-separation-plan.md`
- Review: `docs/plans/ROB-56-review-report.md`