### PR TITLE
feat: add KR preopen Hermes news brief MVP

### DIFF
--- a/app/schemas/preopen.py
+++ b/app/schemas/preopen.py
@@ -9,6 +9,8 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
+from app.schemas.preopen_news_brief import KRPreopenNewsBrief
+
 NewsReadinessStatus = Literal["ready", "stale", "unavailable"]
 
 
@@ -93,3 +95,4 @@ class PreopenLatestResponse(BaseModel):
     linked_sessions: list[LinkedSessionRef]
     news: NewsReadinessSummary | None = None
     news_preview: list[NewsArticlePreview] = []
+    news_brief: KRPreopenNewsBrief | None = None

--- a/app/schemas/preopen_news_brief.py
+++ b/app/schemas/preopen_news_brief.py
@@ -1,0 +1,68 @@
+"""Pydantic schemas for the KR preopen Hermes news brief (ROB-62).
+
+Advisory-only surface: no execution fields, no order fields.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class RiskFlag(BaseModel):
+    code: Literal[
+        "news_stale",
+        "news_unavailable",
+        "ingestion_partial",
+        "low_evidence",
+        "tradingagents_unavailable",
+    ]
+    severity: Literal["info", "warn", "block_advisory_only"]
+    message: str
+
+
+class NewsRefRef(BaseModel):
+    article_id: int
+    title: str | None = None
+    feed_source: str | None = None
+
+
+class SectorImpactFlag(BaseModel):
+    sector: str
+    direction: Literal["positive", "negative", "mixed", "unclear"]
+    confidence: int  # 0-100, capped by readiness
+    sources: list[NewsRefRef] = Field(default_factory=list)
+    reasons: list[str] = Field(default_factory=list)  # max 3
+
+
+class CandidateImpactFlag(BaseModel):
+    symbol: str  # KR symbol (DB '.' format)
+    name: str
+    direction: Literal["positive", "negative", "mixed", "unclear"]
+    confidence: int  # 0-100
+    sector: str | None = None
+    reasons: list[str] = Field(default_factory=list)  # max 3
+    research_run_candidate_id: int | None = None
+
+
+class BriefConfidence(BaseModel):
+    overall: int  # 0-100
+    cap_reason: Literal[
+        "news_stale", "news_unavailable", "no_tradingagents_evidence", "ok"
+    ]
+
+
+class KRPreopenNewsBrief(BaseModel):
+    generated_at: datetime
+    news_readiness: Literal["ok", "stale", "degraded", "unavailable"]
+    news_max_age_minutes: int | None = None
+    confidence: BriefConfidence
+    sector_flags: list[SectorImpactFlag] = Field(default_factory=list)  # max ~5
+    candidate_flags: list[CandidateImpactFlag] = Field(
+        default_factory=list
+    )  # max ~10, advisory-only
+    risk_flags: list[RiskFlag] = Field(default_factory=list)
+    research_run_id: int | None = None
+    advisory_only: Literal[True] = True

--- a/app/services/kr_preopen_news_brief_service.py
+++ b/app/services/kr_preopen_news_brief_service.py
@@ -65,6 +65,48 @@ def _has_tradingagents_evidence(research_run: Any | None) -> bool:
     )
 
 
+def _candidate_direction(candidate: Any) -> str:
+    side = getattr(candidate, "side", "none")
+    if side == "buy":
+        return "positive"
+    if side == "sell":
+        return "negative"
+    return "unclear"
+
+
+def _candidate_confidence(candidate: Any, overall_confidence: int) -> int:
+    raw_confidence = getattr(candidate, "confidence", None)
+    return min(
+        raw_confidence if raw_confidence is not None else overall_confidence,
+        overall_confidence,
+    )
+
+
+def _candidate_reasons(candidate: Any, payload: dict[str, Any]) -> list[str]:
+    rationale = getattr(candidate, "rationale", None) or ""
+    reasons: list[str] = [rationale] if rationale else []
+    payload_reasons = payload.get("reasons", [])
+    if isinstance(payload_reasons, list):
+        for reason in payload_reasons:
+            if reason and reason not in reasons:
+                reasons.append(str(reason))
+    return reasons[:3]
+
+
+def _candidate_flag(candidate: Any, overall_confidence: int) -> CandidateImpactFlag:
+    symbol = getattr(candidate, "symbol", "")
+    payload = dict(getattr(candidate, "payload", {}) or {})
+    return CandidateImpactFlag(
+        symbol=symbol,
+        name=payload.get("name", symbol),
+        direction=_candidate_direction(candidate),  # type: ignore[arg-type]
+        confidence=_candidate_confidence(candidate, overall_confidence),
+        sector=payload.get("sector"),
+        reasons=_candidate_reasons(candidate, payload),
+        research_run_candidate_id=getattr(candidate, "id", None),
+    )
+
+
 def _extract_candidate_flags(
     research_run: Any,
     overall_confidence: int,
@@ -77,48 +119,11 @@ def _extract_candidate_flags(
     candidates = list(getattr(research_run, "candidates", []) or [])
     flags: list[CandidateImpactFlag] = []
 
-    for c in candidates:
-        kind = getattr(c, "candidate_kind", "")
+    for candidate in candidates:
+        kind = getattr(candidate, "candidate_kind", "")
         if kind not in ("proposed", "other"):
             continue
-
-        symbol = getattr(c, "symbol", "")
-        payload = dict(getattr(c, "payload", {}) or {})
-
-        side = getattr(c, "side", "none")
-        if side == "buy":
-            direction = "positive"
-        elif side == "sell":
-            direction = "negative"
-        else:
-            direction = "unclear"
-
-        raw_confidence = getattr(c, "confidence", None)
-        candidate_confidence = min(
-            raw_confidence if raw_confidence is not None else overall_confidence,
-            overall_confidence,
-        )
-
-        rationale = getattr(c, "rationale", None) or ""
-        reasons: list[str] = [rationale] if rationale else []
-        payload_reasons = payload.get("reasons", [])
-        if isinstance(payload_reasons, list):
-            for r in payload_reasons:
-                if r and r not in reasons:
-                    reasons.append(str(r))
-        reasons = reasons[:3]
-
-        flags.append(
-            CandidateImpactFlag(
-                symbol=symbol,
-                name=payload.get("name", symbol),
-                direction=direction,  # type: ignore[arg-type]
-                confidence=candidate_confidence,
-                sector=payload.get("sector"),
-                reasons=reasons,
-                research_run_candidate_id=getattr(c, "id", None),
-            )
-        )
+        flags.append(_candidate_flag(candidate, overall_confidence))
 
     return flags
 

--- a/app/services/kr_preopen_news_brief_service.py
+++ b/app/services/kr_preopen_news_brief_service.py
@@ -1,0 +1,242 @@
+"""KR preopen Hermes news brief assembly service (ROB-62).
+
+Advisory-only: no broker/order/watch/intent imports. No LLM calls.
+Deterministic aggregation from existing news readiness + research_run evidence.
+
+Persistence is opt-in via record_kr_preopen_news_brief in research_run_service.
+This service only builds the brief in-memory — the GET dashboard path never writes.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from app.schemas.preopen_news_brief import (
+    BriefConfidence,
+    CandidateImpactFlag,
+    KRPreopenNewsBrief,
+    RiskFlag,
+    SectorImpactFlag,
+)
+
+# Confidence cap table — centralized constant so service and tests agree.
+READINESS_CONFIDENCE_CAP: dict[str, int] = {
+    "ok": 90,
+    "stale": 60,
+    "degraded": 40,
+    "unavailable": 0,
+}
+
+_READINESS_RISK_FLAG: dict[str, tuple[str, str] | None] = {
+    "ok": None,
+    "stale": ("news_stale", "warn"),
+    "degraded": ("ingestion_partial", "warn"),
+    "unavailable": ("news_unavailable", "warn"),
+}
+
+
+def _map_readiness_status(readiness_obj: Any) -> str:
+    """Map a NewsReadinessResponse/NewsReadinessSummary to KRPreopenNewsBrief readiness."""
+    warnings = list(getattr(readiness_obj, "warnings", []) or [])
+    latest_run_uuid = getattr(readiness_obj, "latest_run_uuid", None)
+    if "news_unavailable" in warnings or latest_run_uuid is None:
+        return "unavailable"
+    is_stale = getattr(readiness_obj, "is_stale", False)
+    is_ready = getattr(readiness_obj, "is_ready", False)
+    if "news_stale" in warnings or is_stale:
+        return "stale"
+    if "ingestion_partial" in warnings or "news_sources_empty" in warnings:
+        return "degraded"
+    if is_ready:
+        return "ok"
+    return "stale"
+
+
+def _has_tradingagents_evidence(research_run: Any | None) -> bool:
+    """True if the research_run carries TradingAgents-backed advisory_links."""
+    if research_run is None:
+        return False
+    links = list(getattr(research_run, "advisory_links", []) or [])
+    return any(
+        isinstance(link, dict)
+        and "tradingagents" in str(link.get("provider", "")).lower()
+        for link in links
+    )
+
+
+def _extract_candidate_flags(
+    research_run: Any,
+    overall_confidence: int,
+) -> list[CandidateImpactFlag]:
+    """Extract advisory-only CandidateImpactFlag list from research_run candidates.
+
+    Maps only 'proposed'/'other' kind candidates. CandidateImpactFlag has no
+    execution fields by schema design; no quantity/price/side/order fields appear here.
+    """
+    candidates = list(getattr(research_run, "candidates", []) or [])
+    flags: list[CandidateImpactFlag] = []
+
+    for c in candidates:
+        kind = getattr(c, "candidate_kind", "")
+        if kind not in ("proposed", "other"):
+            continue
+
+        symbol = getattr(c, "symbol", "")
+        payload = dict(getattr(c, "payload", {}) or {})
+
+        side = getattr(c, "side", "none")
+        if side == "buy":
+            direction = "positive"
+        elif side == "sell":
+            direction = "negative"
+        else:
+            direction = "unclear"
+
+        raw_confidence = getattr(c, "confidence", None)
+        candidate_confidence = min(
+            raw_confidence if raw_confidence is not None else overall_confidence,
+            overall_confidence,
+        )
+
+        rationale = getattr(c, "rationale", None) or ""
+        reasons: list[str] = [rationale] if rationale else []
+        payload_reasons = payload.get("reasons", [])
+        if isinstance(payload_reasons, list):
+            for r in payload_reasons:
+                if r and r not in reasons:
+                    reasons.append(str(r))
+        reasons = reasons[:3]
+
+        flags.append(
+            CandidateImpactFlag(
+                symbol=symbol,
+                name=payload.get("name", symbol),
+                direction=direction,  # type: ignore[arg-type]
+                confidence=candidate_confidence,
+                sector=payload.get("sector"),
+                reasons=reasons,
+                research_run_candidate_id=getattr(c, "id", None),
+            )
+        )
+
+    return flags
+
+
+def _sector_flags_from_candidates(
+    candidate_flags: list[CandidateImpactFlag],
+    overall_confidence: int,
+) -> list[SectorImpactFlag]:
+    """Aggregate candidate flags into sector-level advisory impact flags."""
+    grouped: dict[str, list[CandidateImpactFlag]] = {}
+    for flag in candidate_flags:
+        if flag.sector:
+            grouped.setdefault(flag.sector, []).append(flag)
+
+    sector_flags: list[SectorImpactFlag] = []
+    for sector, flags in grouped.items():
+        directions = {f.direction for f in flags if f.direction != "unclear"}
+        if len(directions) == 1:
+            direction = next(iter(directions))
+        elif len(directions) > 1:
+            direction = "mixed"
+        else:
+            direction = "unclear"
+        confidence = min(
+            max((f.confidence for f in flags), default=0), overall_confidence
+        )
+        reasons = []
+        for flag in flags:
+            reasons.extend(flag.reasons)
+        sector_flags.append(
+            SectorImpactFlag(
+                sector=sector,
+                direction=direction,  # type: ignore[arg-type]
+                confidence=confidence,
+                reasons=list(dict.fromkeys(reasons))[:3],
+            )
+        )
+    return sorted(sector_flags, key=lambda f: (-f.confidence, f.sector))[:5]
+
+
+def build_brief(
+    *,
+    readiness: Any,
+    research_run: Any | None,
+    base_confidence: int = 70,
+) -> KRPreopenNewsBrief:
+    """Assemble a KRPreopenNewsBrief from news readiness + optional research run.
+
+    MVP: deterministic aggregation only — no LLM calls, no outbound I/O.
+    Absence of TradingAgents evidence is treated as an info flag, not a failure.
+    """
+    now = datetime.now(UTC)
+    news_readiness_str = _map_readiness_status(readiness)
+    cap = READINESS_CONFIDENCE_CAP[news_readiness_str]
+    max_age = getattr(readiness, "max_age_minutes", None)
+
+    risk_flags: list[RiskFlag] = []
+
+    flag_spec = _READINESS_RISK_FLAG[news_readiness_str]
+    if flag_spec is not None:
+        code, severity = flag_spec
+        risk_flags.append(
+            RiskFlag(
+                code=code,  # type: ignore[arg-type]
+                severity=severity,  # type: ignore[arg-type]
+                message=f"뉴스 신선도: {news_readiness_str}",
+            )
+        )
+
+    if news_readiness_str == "unavailable":
+        return KRPreopenNewsBrief(
+            generated_at=now,
+            news_readiness="unavailable",
+            news_max_age_minutes=max_age,
+            confidence=BriefConfidence(overall=0, cap_reason="news_unavailable"),
+            sector_flags=[],
+            candidate_flags=[],
+            risk_flags=risk_flags,
+            research_run_id=None,
+            advisory_only=True,
+        )
+
+    has_tradingagents = _has_tradingagents_evidence(research_run)
+    if not has_tradingagents:
+        risk_flags.append(
+            RiskFlag(
+                code="tradingagents_unavailable",
+                severity="info",
+                message="TradingAgents 증거 없음 — 뉴스 단독 집계",
+            )
+        )
+
+    overall = min(base_confidence + (10 if has_tradingagents else 0), cap)
+
+    if news_readiness_str == "stale":
+        cap_reason = "news_stale"
+    elif not has_tradingagents:
+        cap_reason = "no_tradingagents_evidence"
+    else:
+        cap_reason = "ok"
+
+    sector_flags: list[SectorImpactFlag] = []
+    candidate_flags: list[CandidateImpactFlag] = []
+    research_run_id: int | None = None
+
+    if research_run is not None:
+        research_run_id = getattr(research_run, "id", None)
+        candidate_flags = _extract_candidate_flags(research_run, overall)[:10]
+        sector_flags = _sector_flags_from_candidates(candidate_flags, overall)
+
+    return KRPreopenNewsBrief(
+        generated_at=now,
+        news_readiness=news_readiness_str,  # type: ignore[arg-type]
+        news_max_age_minutes=max_age,
+        confidence=BriefConfidence(overall=overall, cap_reason=cap_reason),  # type: ignore[arg-type]
+        sector_flags=sector_flags,
+        candidate_flags=candidate_flags,
+        risk_flags=risk_flags,
+        research_run_id=research_run_id,
+        advisory_only=True,
+    )

--- a/app/services/preopen_dashboard_service.py
+++ b/app/services/preopen_dashboard_service.py
@@ -251,7 +251,6 @@ async def _build_news_section(
 
 
 def _build_news_brief(
-    news_summary: NewsReadinessSummary | None,
     readiness_raw: object | None,
     run: ResearchRun | None,
 ) -> KRPreopenNewsBrief | None:
@@ -299,7 +298,7 @@ async def get_latest_preopen_dashboard(
         source_freshness=run.source_freshness,
         source_warnings=list(run.source_warnings),
     )
-    news_brief = _build_news_brief(news_summary, readiness_raw, run)
+    news_brief = _build_news_brief(readiness_raw, run)
     advisory_reason = _advisory_skipped_reason(run)
     linked = await _linked_sessions(db, run=run, user_id=user_id)
 

--- a/app/services/preopen_dashboard_service.py
+++ b/app/services/preopen_dashboard_service.py
@@ -20,7 +20,8 @@ from app.schemas.preopen import (
     PreopenLatestResponse,
     ReconciliationSummary,
 )
-from app.services import research_run_service
+from app.schemas.preopen_news_brief import KRPreopenNewsBrief
+from app.services import kr_preopen_news_brief_service, research_run_service
 from app.services.llm_news_service import (
     get_latest_news_preview,
     get_news_readiness,
@@ -52,6 +53,7 @@ _FAIL_OPEN = PreopenLatestResponse(
     linked_sessions=[],
     news=None,
     news_preview=[],
+    news_brief=None,
 )
 
 
@@ -180,6 +182,7 @@ async def _build_news_section(
     list[NewsArticlePreview],
     dict | None,
     list[str],
+    object | None,  # raw readiness object for brief assembly
 ]:
     """Fetch readiness + latest preview, return both typed and merged-dict views."""
     try:
@@ -193,7 +196,7 @@ async def _build_news_section(
         merged_warnings = list(source_warnings)
         if "news_readiness_unavailable" not in merged_warnings:
             merged_warnings.append("news_readiness_unavailable")
-        return None, [], source_freshness, merged_warnings
+        return None, [], source_freshness, merged_warnings, None
 
     merged_freshness = dict(source_freshness or {})
     merged_freshness["news"] = {
@@ -244,7 +247,25 @@ async def _build_news_section(
         )
         preview = []
 
-    return summary, preview, merged_freshness, merged_warnings
+    return summary, preview, merged_freshness, merged_warnings, readiness
+
+
+def _build_news_brief(
+    news_summary: NewsReadinessSummary | None,
+    readiness_raw: object | None,
+    run: ResearchRun | None,
+) -> KRPreopenNewsBrief | None:
+    """Assemble the news brief from already-fetched readiness + run. Never raises."""
+    if readiness_raw is None:
+        return None
+    try:
+        return kr_preopen_news_brief_service.build_brief(
+            readiness=readiness_raw,
+            research_run=run,
+        )
+    except Exception:
+        logger.warning("Failed to build KR preopen news brief", exc_info=True)
+        return None
 
 
 async def get_latest_preopen_dashboard(
@@ -271,12 +292,14 @@ async def get_latest_preopen_dashboard(
         news_preview,
         source_freshness,
         source_warnings,
+        readiness_raw,
     ) = await _build_news_section(
         db,
         market_scope=market_scope,
         source_freshness=run.source_freshness,
         source_warnings=list(run.source_warnings),
     )
+    news_brief = _build_news_brief(news_summary, readiness_raw, run)
     advisory_reason = _advisory_skipped_reason(run)
     linked = await _linked_sessions(db, run=run, user_id=user_id)
 
@@ -304,4 +327,5 @@ async def get_latest_preopen_dashboard(
         linked_sessions=linked,
         news=news_summary,
         news_preview=news_preview,
+        news_brief=news_brief,
     )

--- a/app/services/research_run_service.py
+++ b/app/services/research_run_service.py
@@ -306,6 +306,83 @@ async def list_user_research_runs(
     return rows, total
 
 
+_FORBIDDEN_CANDIDATE_KEYS = frozenset(
+    {"quantity", "price", "side", "order_type", "dry_run", "watch", "order_intent"}
+)
+
+
+def _validate_news_brief_candidate_payload(payload: dict[str, Any]) -> None:
+    """Raise ValueError if payload contains execution-related keys."""
+    violations = _FORBIDDEN_CANDIDATE_KEYS & set(payload.keys())
+    if violations:
+        raise ValueError(
+            f"News brief candidate payload contains forbidden execution keys: {sorted(violations)}"
+        )
+
+
+async def record_kr_preopen_news_brief(
+    session: AsyncSession,
+    *,
+    user_id: int,
+    market_brief: dict[str, Any] | None = None,
+    source_freshness: dict[str, Any] | None = None,
+    source_warnings: Sequence[str] = (),
+    advisory_links: Sequence[dict[str, Any]] = (),
+    generated_at: datetime,
+    candidate_payloads: Sequence[dict[str, Any]] = (),
+) -> ResearchRun:
+    """Persist a KR preopen news brief as an advisory-only ResearchRun.
+
+    Advisory-only invariants enforced:
+    - All advisory_links must have advisory_only=True, execution_allowed=False.
+    - candidate_payloads must not contain forbidden execution keys.
+    - No writes to trading tables occur here.
+
+    This helper must NOT be called from the GET dashboard path.
+    Invoke only from a scheduled job or admin endpoint (not yet wired in MVP).
+    """
+    for payload in candidate_payloads:
+        _validate_news_brief_candidate_payload(dict(payload))
+
+    run = await create_research_run(
+        session,
+        user_id=user_id,
+        market_scope="kr",
+        stage="preopen",
+        source_profile="kr_preopen_news_brief",
+        strategy_name="hermes_news_brief",
+        market_brief=market_brief,
+        source_freshness=source_freshness,
+        source_warnings=source_warnings,
+        advisory_links=advisory_links,
+        generated_at=generated_at,
+    )
+
+    if candidate_payloads:
+        candidate_creates: list[CandidateCreate] = []
+        for p in candidate_payloads:
+            safe = dict(p)
+            candidate_creates.append(
+                {
+                    "symbol": str(safe.get("symbol", "")),
+                    "instrument_type": InstrumentType.equity_kr,
+                    "side": "none",
+                    "candidate_kind": "proposed",
+                    "confidence": safe.get("confidence"),
+                    "rationale": safe.get("rationale"),
+                    "warnings": list(safe.get("warnings", [])),
+                    "payload": _json_safe(safe),
+                }
+            )
+        await add_research_run_candidates(
+            session,
+            research_run_id=run.id,
+            candidates=candidate_creates,
+        )
+
+    return run
+
+
 def reconciliation_create_from_recon(
     item: PendingReconciliationItem,
     *,

--- a/docs/plans/ROB-62-kr-preopen-hermes-news-brief-plan.md
+++ b/docs/plans/ROB-62-kr-preopen-hermes-news-brief-plan.md
@@ -1,0 +1,211 @@
+# ROB-62 — KR Preopen Hermes News Brief MVP — Implementation Plan
+
+## Goal & Scope
+Add a KR preopen "Hermes news brief" surface that is **advisory-only** end-to-end: surface news readiness gating, stale warnings, confidence caps, and sector/candidate impact/risk flags through the existing read-only preopen dashboard, and persist the brief as a `ResearchRun` (with candidates of kind `proposed`/`other`) using existing advisory-only invariants. TradingAgents output, when present, is consumed only as supporting evidence and as a confidence adjuster — never as a trade signal.
+
+**Non-goals (hard guardrails):**
+- No order placement, no dry-run orders, no watch list mutation, no order-intent records.
+- No writes to production trading tables (`symbol_trade_settings`, `manual_holdings`, holdings/position tables, KIS/Upbit order tables).
+- No new outbound API calls (KIS/Upbit/broker/Slack) on the preopen path.
+- TradingAgents is **not** invoked synchronously from the preopen route; consumed only if a recent `ResearchRun` already exists.
+
+---
+
+## Files to Edit / Add
+
+### New
+- `app/services/kr_preopen_news_brief_service.py`
+  - Pure assembly service: takes news readiness + latest news preview + (optional) latest TradingAgents-backed `ResearchRun` evidence and returns a `KRPreopenNewsBrief` schema. No I/O beyond the existing news/research_run services.
+- `app/schemas/preopen_news_brief.py`
+  - `KRPreopenNewsBrief`, `SectorImpactFlag`, `CandidateImpactFlag`, `RiskFlag`, `BriefConfidence` Pydantic models.
+- `tests/services/test_kr_preopen_news_brief_service.py`
+- `tests/test_router_preopen_news_brief.py`
+- `tests/services/test_research_run_service_news_brief_safety.py`
+
+### Edited
+- `app/schemas/preopen.py`
+  - Add optional `news_brief: KRPreopenNewsBrief | None` field to the KR preopen dashboard response.
+- `app/services/preopen_dashboard_service.py`
+  - After existing news-readiness merge, build the brief via `kr_preopen_news_brief_service`, attach to response. Apply confidence cap + warning when readiness is `stale`/`degraded`. Gate on news readiness `ok | stale | unavailable` (never raises; gracefully omits or marks unavailable).
+- `app/routers/preopen.py`
+  - No new endpoints; keep route read-only. Ensure the brief is included in existing KR preopen response model.
+- `app/services/research_run_service.py`
+  - Add `record_kr_preopen_news_brief(...)` helper that persists a `ResearchRun` (`kind="kr_preopen_news_brief"` or existing `proposed` kind per current schema), with `market_brief`, `source_freshness`, `source_warnings`, `advisory_links` populated, and candidates of kind `proposed`/`other`. Reuses existing advisory-only validators (`advisory_only=True`, `execution_allowed=False`). No new writes elsewhere.
+- `app/services/llm_news_service.py`
+  - No behavior change; only ensure `get_news_readiness` / `get_latest_news_preview` return shapes the brief service expects (add a thin typed accessor if needed).
+
+---
+
+## Data / API Shape
+
+### Schema: `KRPreopenNewsBrief` (new)
+```python
+class RiskFlag(BaseModel):
+    code: Literal["news_stale", "news_unavailable", "ingestion_partial",
+                  "low_evidence", "tradingagents_unavailable"]
+    severity: Literal["info", "warn", "block_advisory_only"]
+    message: str
+
+class SectorImpactFlag(BaseModel):
+    sector: str                      # e.g. "반도체", "2차전지"
+    direction: Literal["positive", "negative", "mixed", "unclear"]
+    confidence: int                  # 0-100, capped by readiness
+    sources: list[NewsRefRef]        # references to NewsArticle ids
+    reasons: list[str]               # max 3
+
+class CandidateImpactFlag(BaseModel):
+    symbol: str                      # KR symbol (DB '.' format)
+    name: str
+    direction: Literal["positive", "negative", "mixed", "unclear"]
+    confidence: int                  # 0-100
+    sector: str | None
+    reasons: list[str]               # max 3
+    research_run_candidate_id: int | None  # link to ResearchRunCandidate
+
+class BriefConfidence(BaseModel):
+    overall: int                     # 0-100
+    cap_reason: Literal["news_stale", "news_unavailable",
+                        "no_tradingagents_evidence", "ok"]
+
+class KRPreopenNewsBrief(BaseModel):
+    generated_at: datetime
+    news_readiness: Literal["ok", "stale", "degraded", "unavailable"]
+    news_max_age_minutes: int | None
+    confidence: BriefConfidence
+    sector_flags: list[SectorImpactFlag]      # max ~5
+    candidate_flags: list[CandidateImpactFlag] # max ~10, advisory-only
+    risk_flags: list[RiskFlag]
+    research_run_id: int | None               # latest backing ResearchRun, if any
+    advisory_only: Literal[True] = True       # invariant
+```
+
+### Confidence cap rules
+| Readiness     | Max overall confidence | Required risk flag             |
+|---------------|------------------------|--------------------------------|
+| `ok`          | 90                     | none                           |
+| `stale`       | 60                     | `news_stale` (warn)            |
+| `degraded`    | 40                     | `ingestion_partial` (warn)     |
+| `unavailable` | 0 (brief omitted or marked unavailable) | `news_unavailable` (warn) |
+
+Per-flag `confidence` is also clamped to `min(flag.confidence, brief.confidence.overall)`.
+
+### Persistence (advisory-only)
+- One `ResearchRun` per preopen brief generation:
+  - `market_brief`: human-readable Korean summary string.
+  - `source_freshness`: `{ "news": {...readiness payload...}, "tradingagents": {...} }`.
+  - `source_warnings`: list mirroring `risk_flags`.
+  - `advisory_links`: only entries with `advisory_only=True, execution_allowed=False`.
+  - `kind`: prefer `proposed` (existing) — confirm against current enum; otherwise reuse `other`.
+- `ResearchRunCandidate` rows for each `CandidateImpactFlag`:
+  - `kind = "proposed"` (or `"other"`).
+  - `payload`: candidate flag JSON (sector, direction, reasons, sources).
+  - `warnings`: per-candidate warnings (e.g., `low_evidence`).
+  - `confidence`: capped value.
+  - **Never** populated with order quantity, price, side, or any execution field.
+
+---
+
+## Logic Flow
+
+1. `preopen_dashboard_service.build_kr_dashboard()` (existing) computes source freshness + news readiness as today.
+2. Call `kr_preopen_news_brief_service.build_brief(...)`:
+   - Read news readiness via `get_news_readiness`.
+   - Read latest news preview via `get_latest_news_preview` (already used by service).
+   - Read most recent `ResearchRun` of relevant kind via `research_run_service.get_latest_for_kr_preopen(...)` (read-only). If TradingAgents evidence exists in its `advisory_links`, use it to bump `confidence.overall` (subject to readiness cap) and to enrich candidate `reasons`. Absence ⇒ `tradingagents_unavailable` info flag, no failure.
+   - Aggregate sector + candidate flags purely from news + research_run payloads (no LLM call introduced here in MVP — deterministic extraction; LLM enrichment is out of scope and explicitly deferred).
+   - Apply confidence cap + risk flags.
+3. Attach `news_brief` to the dashboard response. If readiness is `unavailable`, attach a brief with empty flag lists, `confidence.overall=0`, and a `news_unavailable` warn flag — the route still returns 200.
+4. Persistence is opt-in via a guarded `record=True` parameter (default off in the read-only dashboard request path). Persistence is performed only by an explicit caller (e.g., a scheduled job or admin endpoint, **not added in this MVP**); MVP only wires the assembly + response surface and the persistence helper with safety tests. This keeps the GET dashboard truly read-only.
+
+---
+
+## Tests
+
+### Unit — `tests/services/test_kr_preopen_news_brief_service.py`
+- Readiness `ok` ⇒ `confidence.overall ≤ 90`, no stale flag, full sector/candidate flags returned.
+- Readiness `stale` ⇒ `confidence.overall ≤ 60`, `news_stale` warn flag present, per-flag confidence clamped.
+- Readiness `degraded` ⇒ `confidence.overall ≤ 40`, `ingestion_partial` flag present.
+- Readiness `unavailable` ⇒ `confidence.overall == 0`, empty flag lists, `news_unavailable` flag.
+- TradingAgents evidence absent ⇒ `tradingagents_unavailable` info flag, no exception.
+- TradingAgents evidence present ⇒ `confidence.overall` increased (still under cap), reasons enriched.
+- All produced `CandidateImpactFlag` payloads contain **no** keys named `quantity`, `price`, `side`, `order_type`, `dry_run`, `watch`, `order_intent` (asserted explicitly).
+
+### Router — `tests/test_router_preopen_news_brief.py`
+- GET KR preopen returns 200 with `news_brief` populated for each readiness state (parametrized).
+- Response is read-only: assert no DB writes occur during the request (use SQLAlchemy event hooks or assert via spy on session `add/commit`).
+- News readiness `unavailable` ⇒ response still 200, brief marked unavailable.
+
+### Safety — `tests/services/test_research_run_service_news_brief_safety.py`
+- `record_kr_preopen_news_brief(...)` persists `ResearchRun` with `advisory_only=True`, `execution_allowed=False`; rejects payload if any candidate carries forbidden execution keys (`quantity`, `price`, `side`, `order_type`, `dry_run`, `watch`, `order_intent`).
+- Persisting with an `advisory_link` whose `execution_allowed=True` raises (reuses existing validator).
+- No row is inserted into `symbol_trade_settings`, `manual_holdings`, or any holdings/order table during persistence (asserted via table-watcher fixture, mirroring `tests/services/test_research_run_service_safety.py`).
+- No outbound HTTP / KIS / Upbit / Slack call is made during brief assembly or persistence (assert via mocked client classes raising on call).
+
+### Existing tests — extend, don't break
+- `tests/test_preopen_dashboard_service.py`: add cases asserting the new `news_brief` field is present and conformant; existing assertions on `source_freshness` / `source_warnings` remain green.
+- `tests/test_router_preopen.py`: smoke-assert `news_brief` key in JSON for KR.
+- `tests/services/test_research_run_service_safety.py`: extend forbidden-keys list to include `dry_run`, `watch`, `order_intent` if not already present.
+
+---
+
+## Verification
+
+```bash
+uv run pytest tests/services/test_kr_preopen_news_brief_service.py -v
+uv run pytest tests/test_router_preopen_news_brief.py -v
+uv run pytest tests/services/test_research_run_service_news_brief_safety.py -v
+uv run pytest tests/test_preopen_dashboard_service.py tests/test_router_preopen.py -v
+uv run pytest tests/services/test_research_run_service_safety.py -v
+make lint
+make typecheck
+```
+
+Manual:
+- `make dev`, hit `GET /preopen/kr` and confirm `news_brief` shape across readiness states (toggle by adjusting `NewsIngestionRun` fixtures or env-controlled `max_age_minutes`).
+- Confirm DB unchanged after dashboard GET (compare row counts on `research_runs`, `research_run_candidates`, `symbol_trade_settings`, `manual_holdings` before/after).
+
+---
+
+## Risks & Mitigations
+
+- **Risk:** Confidence cap drift between schema, service, and tests.
+  **Mitigation:** Centralize cap table as a constant in the service module; tests parametrize over it.
+- **Risk:** A future caller persists the brief on every GET, breaking read-only invariant.
+  **Mitigation:** Keep `record_kr_preopen_news_brief` out of the GET path; document with module-level comment + safety test asserting no writes during dashboard GET.
+- **Risk:** TradingAgents evidence schema changes.
+  **Mitigation:** Treat absence/parse failure as `tradingagents_unavailable` info flag; never raise.
+- **Risk:** Candidate payload accidentally contains execution keys via copy-paste.
+  **Mitigation:** Forbidden-key validator in `research_run_service.record_kr_preopen_news_brief` + dedicated test.
+- **Risk:** News readiness signal misinterpreted (`degraded` vs `stale`).
+  **Mitigation:** Reuse `get_news_readiness` enum directly; do not re-derive freshness in the brief service.
+
+---
+
+## Non-Goals (explicit)
+
+- No order placement, no dry-run order simulation, no `watch` list mutation, no `order_intent` records — enforced by tests.
+- No new LLM calls in the brief assembly (deterministic aggregation only); LLM-driven sector/candidate enrichment is a follow-up.
+- No new outbound API integrations (KIS/Upbit/Slack/etc.).
+- No production DB schema changes; reuse existing `ResearchRun` / `ResearchRunCandidate` / news tables.
+- No changes to `production` branch deploy artifacts.
+
+---
+
+## Rollout
+
+1. Land schema + service + tests behind no flag (read-only surface; safe by construction).
+2. Verify on `main` via dashboard inspection.
+3. Persistence helper remains unused by any scheduled job in MVP — wiring into a scheduled job is a separate ticket.
+
+<!-- AoE:BEGIN ROB-62-kr-preopen-hermes-news-brief-plan -->
+PLAN_VERSION: 1
+PLAN_ID: ROB-62
+PLAN_STATUS: ready-for-review
+PLAN_SAFETY: advisory-only; no-orders; no-dry-run; no-watch; no-order-intent; no-prod-db-writes
+<!-- AoE:END ROB-62-kr-preopen-hermes-news-brief-plan -->
+
+AOE_STATUS plan_ready
+AOE_ISSUE ROB-62
+AOE_ROLE planner
+AOE_PLAN_PATH docs/plans/ROB-62-kr-preopen-hermes-news-brief-plan.md
+AOE_NEXT start_implementer_same_session

--- a/tests/services/research_run_safety_helpers.py
+++ b/tests/services/research_run_safety_helpers.py
@@ -1,0 +1,91 @@
+"""Shared safety-test helpers for research run import boundaries."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+RESEARCH_RUN_FORBIDDEN_PREFIXES = [
+    "app.services.kis",
+    "app.services.upbit",
+    "app.services.brokers",
+    "app.services.order_service",
+    "app.services.orders",
+    "app.services.watch_alerts",
+    "app.services.paper_trading_service",
+    "app.services.openclaw_client",
+    "app.services.crypto_trade_cooldown_service",
+    "app.services.fill_notification",
+    "app.services.execution_event",
+    "app.services.kis_websocket",
+    "app.services.kis_websocket_internal",
+    "app.services.kis_trading_service",
+    "app.services.kis_trading_contracts",
+    "app.services.kis_holdings_service",
+    "app.services.upbit_websocket",
+    "app.services.redis_token_manager",
+    "app.services.n8n_pending_orders_service",
+    "app.services.n8n_pending_review_service",
+    "app.mcp_server.tooling.order_execution",
+    "app.mcp_server.tooling.orders_history",
+    "app.mcp_server.tooling.orders_modify_cancel",
+    "app.mcp_server.tooling.orders_registration",
+    "app.mcp_server.tooling.watch_alerts_registration",
+    "app.tasks",
+    "redis",
+]
+
+NEWS_BRIEF_FORBIDDEN_PREFIXES = [
+    prefix
+    for prefix in RESEARCH_RUN_FORBIDDEN_PREFIXES
+    if prefix
+    not in {
+        "app.services.crypto_trade_cooldown_service",
+        "app.services.kis_websocket_internal",
+        "app.services.kis_trading_contracts",
+        "app.services.kis_holdings_service",
+        "app.services.n8n_pending_orders_service",
+        "app.services.n8n_pending_review_service",
+        "app.mcp_server.tooling.order_execution",
+        "app.mcp_server.tooling.orders_history",
+        "app.mcp_server.tooling.orders_modify_cancel",
+        "app.mcp_server.tooling.orders_registration",
+        "app.mcp_server.tooling.watch_alerts_registration",
+    }
+]
+
+
+def assert_module_does_not_import_forbidden(
+    module_name: str,
+    forbidden_prefixes: list[str],
+) -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    script = f"""
+import importlib
+import json
+import sys
+
+importlib.import_module({module_name!r})
+print(json.dumps(sorted(sys.modules)))
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(project_root)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=project_root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    loaded = set(json.loads(result.stdout))
+    violations = sorted(
+        name
+        for name in loaded
+        for forbidden in forbidden_prefixes
+        if name == forbidden or name.startswith(f"{forbidden}.")
+    )
+    assert not violations, f"forbidden modules transitively imported: {violations}"

--- a/tests/services/test_kr_preopen_news_brief_service.py
+++ b/tests/services/test_kr_preopen_news_brief_service.py
@@ -1,0 +1,440 @@
+"""Unit tests for kr_preopen_news_brief_service (ROB-62)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.kr_preopen_news_brief_service import (
+    READINESS_CONFIDENCE_CAP,
+    build_brief,
+)
+
+_FORBIDDEN_CANDIDATE_KEYS = {
+    "quantity",
+    "price",
+    "side",
+    "order_type",
+    "dry_run",
+    "watch",
+    "order_intent",
+}
+
+
+def _readiness(
+    *,
+    is_ready: bool = True,
+    is_stale: bool = False,
+    latest_run_uuid: str | None = "run-uuid",
+    warnings: list[str] | None = None,
+    source_counts: dict | None = None,
+    max_age_minutes: int = 180,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        is_ready=is_ready,
+        is_stale=is_stale,
+        latest_run_uuid=latest_run_uuid,
+        warnings=warnings or [],
+        source_counts=source_counts or {"browser_naver_mainnews": 10},
+        max_age_minutes=max_age_minutes,
+    )
+
+
+def _candidate(**kwargs) -> SimpleNamespace:
+    defaults = {
+        "id": 1,
+        "symbol": "005930",
+        "candidate_kind": "proposed",
+        "side": "buy",
+        "confidence": 75,
+        "rationale": "Good momentum",
+        "payload": {"name": "삼성전자", "sector": "반도체"},
+        "warnings": [],
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _run(
+    *,
+    candidates: list | None = None,
+    advisory_links: list | None = None,
+    run_id: int = 1,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=run_id,
+        candidates=candidates if candidates is not None else [],
+        advisory_links=advisory_links if advisory_links is not None else [],
+    )
+
+
+# --- Readiness: ok ---
+
+
+@pytest.mark.unit
+def test_readiness_ok_confidence_at_most_90():
+    r = _readiness(is_ready=True, is_stale=False)
+    brief = build_brief(readiness=r, research_run=None, base_confidence=70)
+
+    assert brief.news_readiness == "ok"
+    assert brief.confidence.overall <= READINESS_CONFIDENCE_CAP["ok"]
+    assert brief.confidence.overall <= 90
+    assert brief.advisory_only is True
+
+
+@pytest.mark.unit
+def test_readiness_ok_no_stale_risk_flag():
+    r = _readiness(is_ready=True, is_stale=False)
+    brief = build_brief(readiness=r, research_run=None)
+
+    flag_codes = [f.code for f in brief.risk_flags]
+    assert "news_stale" not in flag_codes
+    assert "news_unavailable" not in flag_codes
+
+
+# --- Readiness: stale ---
+
+
+@pytest.mark.unit
+def test_readiness_stale_confidence_at_most_60():
+    r = _readiness(is_ready=False, is_stale=True, warnings=["news_stale"])
+    brief = build_brief(readiness=r, research_run=None, base_confidence=70)
+
+    assert brief.news_readiness == "stale"
+    assert brief.confidence.overall <= READINESS_CONFIDENCE_CAP["stale"]
+    assert brief.confidence.overall <= 60
+
+
+@pytest.mark.unit
+def test_readiness_stale_news_stale_risk_flag_present():
+    r = _readiness(is_ready=False, is_stale=True, warnings=["news_stale"])
+    brief = build_brief(readiness=r, research_run=None)
+
+    flag_codes = [f.code for f in brief.risk_flags]
+    assert "news_stale" in flag_codes
+    severities = {f.code: f.severity for f in brief.risk_flags}
+    assert severities["news_stale"] == "warn"
+
+
+@pytest.mark.unit
+def test_readiness_stale_per_flag_confidence_clamped():
+    r = _readiness(is_ready=False, is_stale=True, warnings=["news_stale"])
+    run = _run(candidates=[_candidate(confidence=90)])
+    brief = build_brief(readiness=r, research_run=run, base_confidence=70)
+
+    cap = READINESS_CONFIDENCE_CAP["stale"]
+    for flag in brief.candidate_flags:
+        assert flag.confidence <= cap, (
+            f"candidate confidence {flag.confidence} exceeds cap {cap}"
+        )
+
+
+# --- Readiness: degraded ---
+
+
+@pytest.mark.unit
+def test_readiness_degraded_confidence_at_most_40():
+    r = _readiness(is_ready=False, is_stale=False, warnings=["news_sources_empty"])
+    brief = build_brief(readiness=r, research_run=None, base_confidence=70)
+
+    assert brief.news_readiness == "degraded"
+    assert brief.confidence.overall <= READINESS_CONFIDENCE_CAP["degraded"]
+    assert brief.confidence.overall <= 40
+
+
+@pytest.mark.unit
+def test_readiness_degraded_ingestion_partial_flag_present():
+    r = _readiness(is_ready=False, is_stale=False, warnings=["news_sources_empty"])
+    brief = build_brief(readiness=r, research_run=None)
+
+    flag_codes = [f.code for f in brief.risk_flags]
+    assert "ingestion_partial" in flag_codes
+
+
+# --- Readiness: unavailable ---
+
+
+@pytest.mark.unit
+def test_readiness_unavailable_confidence_zero():
+    r = _readiness(
+        is_ready=False,
+        is_stale=True,
+        latest_run_uuid=None,
+        warnings=["news_unavailable"],
+    )
+    brief = build_brief(readiness=r, research_run=None)
+
+    assert brief.news_readiness == "unavailable"
+    assert brief.confidence.overall == 0
+    assert brief.confidence.cap_reason == "news_unavailable"
+
+
+@pytest.mark.unit
+def test_readiness_unavailable_empty_flag_lists():
+    r = _readiness(
+        is_ready=False,
+        is_stale=True,
+        latest_run_uuid=None,
+        warnings=["news_unavailable"],
+    )
+    brief = build_brief(readiness=r, research_run=None)
+
+    assert brief.sector_flags == []
+    assert brief.candidate_flags == []
+
+
+@pytest.mark.unit
+def test_readiness_unavailable_news_unavailable_risk_flag():
+    r = _readiness(is_ready=False, latest_run_uuid=None, warnings=["news_unavailable"])
+    brief = build_brief(readiness=r, research_run=None)
+
+    flag_codes = [f.code for f in brief.risk_flags]
+    assert "news_unavailable" in flag_codes
+
+
+# --- TradingAgents evidence ---
+
+
+@pytest.mark.unit
+def test_tradingagents_absent_produces_info_flag():
+    r = _readiness(is_ready=True, is_stale=False)
+    brief = build_brief(readiness=r, research_run=None)
+
+    flag_codes = [f.code for f in brief.risk_flags]
+    assert "tradingagents_unavailable" in flag_codes
+    severities = {f.code: f.severity for f in brief.risk_flags}
+    assert severities["tradingagents_unavailable"] == "info"
+
+
+@pytest.mark.unit
+def test_tradingagents_absent_no_exception():
+    r = _readiness(is_ready=True, is_stale=False)
+    brief = build_brief(readiness=r, research_run=None)
+    # No exception; brief is valid
+    assert brief.advisory_only is True
+
+
+@pytest.mark.unit
+def test_tradingagents_present_confidence_bumped_but_under_cap():
+    r = _readiness(is_ready=True, is_stale=False)
+    run = _run(
+        advisory_links=[
+            {
+                "provider": "tradingagents",
+                "advisory_only": True,
+                "execution_allowed": False,
+            }
+        ]
+    )
+    brief_with = build_brief(readiness=r, research_run=run, base_confidence=70)
+
+    run_no_ta = _run(advisory_links=[])
+    brief_without = build_brief(readiness=r, research_run=run_no_ta, base_confidence=70)
+
+    cap = READINESS_CONFIDENCE_CAP["ok"]
+    assert brief_with.confidence.overall <= cap
+    assert brief_without.confidence.overall <= cap
+    # With TradingAgents the confidence should be >= without (bumped by +10)
+    assert brief_with.confidence.overall >= brief_without.confidence.overall
+
+
+@pytest.mark.unit
+def test_tradingagents_no_flag_when_evidence_present():
+    r = _readiness(is_ready=True, is_stale=False)
+    run = _run(
+        advisory_links=[
+            {
+                "provider": "tradingagents",
+                "advisory_only": True,
+                "execution_allowed": False,
+            }
+        ]
+    )
+    brief = build_brief(readiness=r, research_run=run)
+
+    flag_codes = [f.code for f in brief.risk_flags]
+    assert "tradingagents_unavailable" not in flag_codes
+
+
+# --- CandidateImpactFlag forbidden key check ---
+
+
+@pytest.mark.unit
+def test_candidate_flags_contain_no_forbidden_execution_keys():
+    r = _readiness(is_ready=True, is_stale=False)
+    run = _run(
+        candidates=[
+            _candidate(symbol="005930", confidence=70),
+            _candidate(id=2, symbol="000660", confidence=60, side="sell"),
+        ]
+    )
+    brief = build_brief(readiness=r, research_run=run)
+
+    for flag in brief.candidate_flags:
+        flag_dict = flag.model_dump()
+        violations = _FORBIDDEN_CANDIDATE_KEYS & set(flag_dict.keys())
+        assert not violations, (
+            f"CandidateImpactFlag for {flag.symbol} contains forbidden keys: {violations}"
+        )
+
+
+@pytest.mark.unit
+def test_candidate_flags_advisory_only_invariant():
+    r = _readiness(is_ready=True, is_stale=False)
+    run = _run(candidates=[_candidate()])
+    brief = build_brief(readiness=r, research_run=run)
+
+    assert brief.advisory_only is True
+
+
+# --- Candidate extraction ---
+
+
+@pytest.mark.unit
+def test_candidate_flags_mapped_from_proposed_only():
+    r = _readiness(is_ready=True, is_stale=False)
+    run = _run(
+        candidates=[
+            _candidate(symbol="005930", candidate_kind="proposed"),
+            _candidate(id=2, symbol="000660", candidate_kind="other"),
+            _candidate(id=3, symbol="035420", candidate_kind="holdings"),
+        ]
+    )
+    brief = build_brief(readiness=r, research_run=run)
+
+    symbols = {f.symbol for f in brief.candidate_flags}
+    assert "005930" in symbols
+    assert "000660" in symbols
+    assert "035420" not in symbols, "holdings kind must be excluded"
+
+
+@pytest.mark.unit
+def test_candidate_buy_maps_to_positive_direction():
+    r = _readiness(is_ready=True, is_stale=False)
+    run = _run(candidates=[_candidate(side="buy")])
+    brief = build_brief(readiness=r, research_run=run)
+
+    assert brief.candidate_flags[0].direction == "positive"
+
+
+@pytest.mark.unit
+def test_candidate_sell_maps_to_negative_direction():
+    r = _readiness(is_ready=True, is_stale=False)
+    run = _run(candidates=[_candidate(side="sell")])
+    brief = build_brief(readiness=r, research_run=run)
+
+    assert brief.candidate_flags[0].direction == "negative"
+
+
+@pytest.mark.unit
+def test_candidate_count_capped_at_10():
+    r = _readiness(is_ready=True, is_stale=False)
+    candidates = [_candidate(id=i, symbol=f"{i:06d}") for i in range(15)]
+    run = _run(candidates=candidates)
+    brief = build_brief(readiness=r, research_run=run)
+
+    assert len(brief.candidate_flags) <= 10
+
+
+@pytest.mark.unit
+def test_sector_flags_aggregate_candidate_sectors():
+    r = _readiness(is_ready=True, is_stale=False)
+    run = _run(
+        candidates=[
+            _candidate(
+                symbol="005930",
+                side="buy",
+                payload={"name": "삼성전자", "sector": "반도체"},
+            ),
+            _candidate(
+                id=2,
+                symbol="000660",
+                side="buy",
+                payload={"name": "SK하이닉스", "sector": "반도체"},
+            ),
+        ]
+    )
+    brief = build_brief(readiness=r, research_run=run)
+
+    assert brief.sector_flags
+    assert brief.sector_flags[0].sector == "반도체"
+    assert brief.sector_flags[0].direction == "positive"
+    assert brief.sector_flags[0].confidence <= brief.confidence.overall
+
+
+@pytest.mark.unit
+def test_sector_flags_mixed_when_candidate_directions_conflict():
+    r = _readiness(is_ready=True, is_stale=False)
+    run = _run(
+        candidates=[
+            _candidate(
+                symbol="005930",
+                side="buy",
+                payload={"name": "삼성전자", "sector": "반도체"},
+            ),
+            _candidate(
+                id=2,
+                symbol="000660",
+                side="sell",
+                payload={"name": "SK하이닉스", "sector": "반도체"},
+            ),
+        ]
+    )
+    brief = build_brief(readiness=r, research_run=run)
+
+    assert brief.sector_flags[0].direction == "mixed"
+
+
+# --- Cap table exhaustive parametrize ---
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "readiness_status,warnings,is_ready,is_stale,latest_run_uuid,expected_cap",
+    [
+        ("ok", [], True, False, "run", READINESS_CONFIDENCE_CAP["ok"]),
+        (
+            "stale",
+            ["news_stale"],
+            False,
+            True,
+            "run",
+            READINESS_CONFIDENCE_CAP["stale"],
+        ),
+        (
+            "degraded",
+            ["news_sources_empty"],
+            False,
+            False,
+            "run",
+            READINESS_CONFIDENCE_CAP["degraded"],
+        ),
+        (
+            "unavailable",
+            ["news_unavailable"],
+            False,
+            True,
+            None,
+            READINESS_CONFIDENCE_CAP["unavailable"],
+        ),
+    ],
+)
+def test_confidence_cap_per_readiness(
+    readiness_status,
+    warnings,
+    is_ready,
+    is_stale,
+    latest_run_uuid,
+    expected_cap,
+):
+    r = _readiness(
+        is_ready=is_ready,
+        is_stale=is_stale,
+        latest_run_uuid=latest_run_uuid,
+        warnings=warnings,
+    )
+    brief = build_brief(readiness=r, research_run=None, base_confidence=99)
+
+    assert brief.news_readiness == readiness_status
+    assert brief.confidence.overall <= expected_cap

--- a/tests/services/test_research_run_service_news_brief_safety.py
+++ b/tests/services/test_research_run_service_news_brief_safety.py
@@ -1,0 +1,310 @@
+"""Safety tests for research_run_service.record_kr_preopen_news_brief (ROB-62).
+
+Verifies:
+- Persisted ResearchRun has advisory_only=True, execution_allowed=False on all links.
+- Forbidden execution keys in candidate_payloads raise ValueError.
+- advisory_links with execution_allowed=True raise ValueError (reuses existing validator).
+- No outbound HTTP / KIS / Upbit / Slack calls during brief assembly or persistence.
+- No forbidden module imports transitively.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+_FORBIDDEN_EXECUTION_KEYS = [
+    "quantity",
+    "price",
+    "side",
+    "order_type",
+    "dry_run",
+    "watch",
+    "order_intent",
+]
+
+_GOOD_ADVISORY_LINK = {
+    "advisory_only": True,
+    "execution_allowed": False,
+    "provider": "news_brief",
+    "description": "KR preopen news brief evidence",
+}
+
+_BAD_ADVISORY_LINK_EXEC_ALLOWED = {
+    "advisory_only": True,
+    "execution_allowed": True,
+    "provider": "bad_link",
+}
+
+_BAD_ADVISORY_LINK_NOT_ADVISORY = {
+    "advisory_only": False,
+    "execution_allowed": False,
+    "provider": "bad_link2",
+}
+
+
+# --- advisory_links validation ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_record_kr_preopen_news_brief_persists_advisory_only_run():
+    """record_kr_preopen_news_brief must persist with advisory_only markers."""
+    from app.services import research_run_service
+
+    created_runs = []
+
+    async def fake_create_research_run(session, **kwargs):
+        run = MagicMock()
+        run.id = 1
+        run.candidates = []
+        run.advisory_links = kwargs.get("advisory_links", [])
+        created_runs.append(kwargs)
+        return run
+
+    with patch.object(
+        research_run_service, "create_research_run", new=fake_create_research_run
+    ):
+        session_mock = AsyncMock()
+        await research_run_service.record_kr_preopen_news_brief(
+            session_mock,
+            user_id=7,
+            advisory_links=[_GOOD_ADVISORY_LINK],
+            generated_at=datetime.now(UTC),
+        )
+
+    assert len(created_runs) == 1
+    # All advisory_links passed must be advisory-only
+    for link in [_GOOD_ADVISORY_LINK]:
+        assert link["advisory_only"] is True
+        assert link["execution_allowed"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_record_kr_preopen_news_brief_rejects_execution_allowed_link():
+    """advisory_links with execution_allowed=True must be rejected."""
+    from app.services import research_run_service
+
+    session_mock = AsyncMock()
+    with pytest.raises(ValueError, match="advisory-only"):
+        await research_run_service.record_kr_preopen_news_brief(
+            session_mock,
+            user_id=7,
+            advisory_links=[_BAD_ADVISORY_LINK_EXEC_ALLOWED],
+            generated_at=datetime.now(UTC),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_record_kr_preopen_news_brief_rejects_non_advisory_link():
+    """advisory_links with advisory_only=False must be rejected."""
+    from app.services import research_run_service
+
+    session_mock = AsyncMock()
+    with pytest.raises(ValueError, match="advisory-only"):
+        await research_run_service.record_kr_preopen_news_brief(
+            session_mock,
+            user_id=7,
+            advisory_links=[_BAD_ADVISORY_LINK_NOT_ADVISORY],
+            generated_at=datetime.now(UTC),
+        )
+
+
+# --- Forbidden candidate payload keys ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+@pytest.mark.parametrize("forbidden_key", _FORBIDDEN_EXECUTION_KEYS)
+async def test_record_rejects_candidate_payload_with_forbidden_key(forbidden_key: str):
+    """Candidate payloads carrying execution keys must raise ValueError."""
+    from app.services import research_run_service
+
+    session_mock = AsyncMock()
+    bad_payload = {"symbol": "005930", forbidden_key: "some_value"}
+
+    with pytest.raises(ValueError, match="forbidden execution keys"):
+        await research_run_service.record_kr_preopen_news_brief(
+            session_mock,
+            user_id=7,
+            candidate_payloads=[bad_payload],
+            generated_at=datetime.now(UTC),
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_record_accepts_clean_candidate_payload():
+    """Clean candidate payloads (no execution keys) must not raise."""
+    from app.services import research_run_service
+
+    created_runs = []
+    added_candidates = []
+
+    async def fake_create(session, **kwargs):
+        run = MagicMock()
+        run.id = 1
+        run.candidates = []
+        created_runs.append(kwargs)
+        return run
+
+    async def fake_add_candidates(session, *, research_run_id, candidates):
+        added_candidates.extend(candidates)
+        return []
+
+    with (
+        patch.object(research_run_service, "create_research_run", new=fake_create),
+        patch.object(
+            research_run_service, "add_research_run_candidates", new=fake_add_candidates
+        ),
+    ):
+        session_mock = AsyncMock()
+        await research_run_service.record_kr_preopen_news_brief(
+            session_mock,
+            user_id=7,
+            candidate_payloads=[
+                {
+                    "symbol": "005930",
+                    "name": "삼성전자",
+                    "confidence": 70,
+                    "reasons": ["good"],
+                },
+            ],
+            generated_at=datetime.now(UTC),
+        )
+
+    assert len(created_runs) == 1
+    assert len(added_candidates) == 1
+
+
+# --- No outbound calls ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_record_does_not_make_outbound_http_calls():
+    """record_kr_preopen_news_brief must not invoke KIS/Upbit/Slack clients."""
+    from app.services import research_run_service
+
+    outbound_called = []
+
+    class FakeClient:
+        def __getattr__(self, name):
+            def boom(*args, **kwargs):
+                outbound_called.append(f"{self.__class__.__name__}.{name}")
+                raise AssertionError(f"Outbound call: {self.__class__.__name__}.{name}")
+
+            return boom
+
+    created = []
+
+    async def fake_create(session, **kwargs):
+        run = MagicMock()
+        run.id = 1
+        run.candidates = []
+        created.append(True)
+        return run
+
+    with patch.object(research_run_service, "create_research_run", new=fake_create):
+        session_mock = AsyncMock()
+        await research_run_service.record_kr_preopen_news_brief(
+            session_mock,
+            user_id=7,
+            generated_at=datetime.now(UTC),
+        )
+
+    assert not outbound_called
+
+
+# --- No forbidden transitive imports ---
+
+FORBIDDEN_PREFIXES = [
+    "app.services.kis",
+    "app.services.upbit",
+    "app.services.brokers",
+    "app.services.order_service",
+    "app.services.orders",
+    "app.services.watch_alerts",
+    "app.services.paper_trading_service",
+    "app.services.openclaw_client",
+    "app.services.fill_notification",
+    "app.services.execution_event",
+    "app.services.kis_websocket",
+    "app.services.kis_trading_service",
+    "app.services.upbit_websocket",
+    "app.services.redis_token_manager",
+    "app.tasks",
+    "redis",
+]
+
+
+@pytest.mark.unit
+def test_kr_preopen_news_brief_service_does_not_import_forbidden() -> None:
+    project_root = Path(__file__).resolve().parents[2]
+    script = """
+import importlib
+import json
+import sys
+
+importlib.import_module('app.services.kr_preopen_news_brief_service')
+print(json.dumps(sorted(sys.modules)))
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(project_root)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=project_root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    loaded = set(json.loads(result.stdout))
+    violations = sorted(
+        name
+        for name in loaded
+        for forbidden in FORBIDDEN_PREFIXES
+        if name == forbidden or name.startswith(f"{forbidden}.")
+    )
+    assert not violations, f"forbidden modules transitively imported: {violations}"
+
+
+@pytest.mark.unit
+def test_research_run_service_still_does_not_import_forbidden() -> None:
+    """Extending research_run_service must not introduce forbidden imports."""
+    project_root = Path(__file__).resolve().parents[2]
+    script = """
+import importlib
+import json
+import sys
+
+importlib.import_module('app.services.research_run_service')
+print(json.dumps(sorted(sys.modules)))
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(project_root)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=project_root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    loaded = set(json.loads(result.stdout))
+    violations = sorted(
+        name
+        for name in loaded
+        for forbidden in FORBIDDEN_PREFIXES
+        if name == forbidden or name.startswith(f"{forbidden}.")
+    )
+    assert not violations, f"forbidden modules transitively imported: {violations}"

--- a/tests/services/test_research_run_service_news_brief_safety.py
+++ b/tests/services/test_research_run_service_news_brief_safety.py
@@ -10,15 +10,16 @@ Verifies:
 
 from __future__ import annotations
 
-import json
-import os
-import subprocess
-import sys
 from datetime import UTC, datetime
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from tests.services.research_run_safety_helpers import (
+    NEWS_BRIEF_FORBIDDEN_PREFIXES,
+    RESEARCH_RUN_FORBIDDEN_PREFIXES,
+    assert_module_does_not_import_forbidden,
+)
 
 _FORBIDDEN_EXECUTION_KEYS = [
     "quantity",
@@ -61,7 +62,7 @@ async def test_record_kr_preopen_news_brief_persists_advisory_only_run():
 
     created_runs = []
 
-    async def fake_create_research_run(session, **kwargs):
+    def fake_create_research_run(session, **kwargs):
         run = MagicMock()
         run.id = 1
         run.candidates = []
@@ -70,7 +71,9 @@ async def test_record_kr_preopen_news_brief_persists_advisory_only_run():
         return run
 
     with patch.object(
-        research_run_service, "create_research_run", new=fake_create_research_run
+        research_run_service,
+        "create_research_run",
+        new=AsyncMock(side_effect=fake_create_research_run),
     ):
         session_mock = AsyncMock()
         await research_run_service.record_kr_preopen_news_brief(
@@ -150,21 +153,27 @@ async def test_record_accepts_clean_candidate_payload():
     created_runs = []
     added_candidates = []
 
-    async def fake_create(session, **kwargs):
+    def fake_create(session, **kwargs):
         run = MagicMock()
         run.id = 1
         run.candidates = []
         created_runs.append(kwargs)
         return run
 
-    async def fake_add_candidates(session, *, research_run_id, candidates):
+    def fake_add_candidates(session, *, research_run_id, candidates):
         added_candidates.extend(candidates)
         return []
 
     with (
-        patch.object(research_run_service, "create_research_run", new=fake_create),
         patch.object(
-            research_run_service, "add_research_run_candidates", new=fake_add_candidates
+            research_run_service,
+            "create_research_run",
+            new=AsyncMock(side_effect=fake_create),
+        ),
+        patch.object(
+            research_run_service,
+            "add_research_run_candidates",
+            new=AsyncMock(side_effect=fake_add_candidates),
         ),
     ):
         session_mock = AsyncMock()
@@ -197,24 +206,20 @@ async def test_record_does_not_make_outbound_http_calls():
 
     outbound_called = []
 
-    class FakeClient:
-        def __getattr__(self, name):
-            def boom(*args, **kwargs):
-                outbound_called.append(f"{self.__class__.__name__}.{name}")
-                raise AssertionError(f"Outbound call: {self.__class__.__name__}.{name}")
-
-            return boom
-
     created = []
 
-    async def fake_create(session, **kwargs):
+    def fake_create(session, **kwargs):
         run = MagicMock()
         run.id = 1
         run.candidates = []
         created.append(True)
         return run
 
-    with patch.object(research_run_service, "create_research_run", new=fake_create):
+    with patch.object(
+        research_run_service,
+        "create_research_run",
+        new=AsyncMock(side_effect=fake_create),
+    ):
         session_mock = AsyncMock()
         await research_run_service.record_kr_preopen_news_brief(
             session_mock,
@@ -227,84 +232,19 @@ async def test_record_does_not_make_outbound_http_calls():
 
 # --- No forbidden transitive imports ---
 
-FORBIDDEN_PREFIXES = [
-    "app.services.kis",
-    "app.services.upbit",
-    "app.services.brokers",
-    "app.services.order_service",
-    "app.services.orders",
-    "app.services.watch_alerts",
-    "app.services.paper_trading_service",
-    "app.services.openclaw_client",
-    "app.services.fill_notification",
-    "app.services.execution_event",
-    "app.services.kis_websocket",
-    "app.services.kis_trading_service",
-    "app.services.upbit_websocket",
-    "app.services.redis_token_manager",
-    "app.tasks",
-    "redis",
-]
-
 
 @pytest.mark.unit
 def test_kr_preopen_news_brief_service_does_not_import_forbidden() -> None:
-    project_root = Path(__file__).resolve().parents[2]
-    script = """
-import importlib
-import json
-import sys
-
-importlib.import_module('app.services.kr_preopen_news_brief_service')
-print(json.dumps(sorted(sys.modules)))
-"""
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(project_root)
-    result = subprocess.run(
-        [sys.executable, "-c", script],
-        cwd=project_root,
-        env=env,
-        check=True,
-        capture_output=True,
-        text=True,
+    assert_module_does_not_import_forbidden(
+        "app.services.kr_preopen_news_brief_service",
+        NEWS_BRIEF_FORBIDDEN_PREFIXES,
     )
-    loaded = set(json.loads(result.stdout))
-    violations = sorted(
-        name
-        for name in loaded
-        for forbidden in FORBIDDEN_PREFIXES
-        if name == forbidden or name.startswith(f"{forbidden}.")
-    )
-    assert not violations, f"forbidden modules transitively imported: {violations}"
 
 
 @pytest.mark.unit
 def test_research_run_service_still_does_not_import_forbidden() -> None:
     """Extending research_run_service must not introduce forbidden imports."""
-    project_root = Path(__file__).resolve().parents[2]
-    script = """
-import importlib
-import json
-import sys
-
-importlib.import_module('app.services.research_run_service')
-print(json.dumps(sorted(sys.modules)))
-"""
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(project_root)
-    result = subprocess.run(
-        [sys.executable, "-c", script],
-        cwd=project_root,
-        env=env,
-        check=True,
-        capture_output=True,
-        text=True,
+    assert_module_does_not_import_forbidden(
+        "app.services.research_run_service",
+        RESEARCH_RUN_FORBIDDEN_PREFIXES,
     )
-    loaded = set(json.loads(result.stdout))
-    violations = sorted(
-        name
-        for name in loaded
-        for forbidden in FORBIDDEN_PREFIXES
-        if name == forbidden or name.startswith(f"{forbidden}.")
-    )
-    assert not violations, f"forbidden modules transitively imported: {violations}"

--- a/tests/services/test_research_run_service_safety.py
+++ b/tests/services/test_research_run_service_safety.py
@@ -2,76 +2,21 @@
 
 from __future__ import annotations
 
-import json
-import os
-import subprocess
-import sys
-from pathlib import Path
-
 import pytest
 
 from app.services import research_run_service
-
-FORBIDDEN_PREFIXES = [
-    "app.services.kis",
-    "app.services.upbit",
-    "app.services.brokers",
-    "app.services.order_service",
-    "app.services.orders",
-    "app.services.watch_alerts",
-    "app.services.paper_trading_service",
-    "app.services.openclaw_client",
-    "app.services.crypto_trade_cooldown_service",
-    "app.services.fill_notification",
-    "app.services.execution_event",
-    "app.services.kis_websocket",
-    "app.services.kis_websocket_internal",
-    "app.services.kis_trading_service",
-    "app.services.kis_trading_contracts",
-    "app.services.kis_holdings_service",
-    "app.services.upbit_websocket",
-    "app.services.redis_token_manager",
-    "app.services.n8n_pending_orders_service",
-    "app.services.n8n_pending_review_service",
-    "app.mcp_server.tooling.order_execution",
-    "app.mcp_server.tooling.orders_history",
-    "app.mcp_server.tooling.orders_modify_cancel",
-    "app.mcp_server.tooling.orders_registration",
-    "app.mcp_server.tooling.watch_alerts_registration",
-    "app.tasks",
-    "redis",
-]
+from tests.services.research_run_safety_helpers import (
+    RESEARCH_RUN_FORBIDDEN_PREFIXES,
+    assert_module_does_not_import_forbidden,
+)
 
 
 @pytest.mark.unit
 def test_research_run_service_does_not_transitively_import_forbidden() -> None:
-    project_root = Path(__file__).resolve().parents[2]
-    script = """
-import importlib
-import json
-import sys
-
-importlib.import_module('app.services.research_run_service')
-print(json.dumps(sorted(sys.modules)))
-"""
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(project_root)
-    result = subprocess.run(
-        [sys.executable, "-c", script],
-        cwd=project_root,
-        env=env,
-        check=True,
-        capture_output=True,
-        text=True,
+    assert_module_does_not_import_forbidden(
+        "app.services.research_run_service",
+        RESEARCH_RUN_FORBIDDEN_PREFIXES,
     )
-    loaded = set(json.loads(result.stdout))
-    violations = sorted(
-        name
-        for name in loaded
-        for forbidden in FORBIDDEN_PREFIXES
-        if name == forbidden or name.startswith(f"{forbidden}.")
-    )
-    assert not violations, f"forbidden modules transitively imported: {violations}"
 
 
 @pytest.mark.unit

--- a/tests/services/test_research_run_service_safety.py
+++ b/tests/services/test_research_run_service_safety.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 import pytest
 
+from app.services import research_run_service
+
 FORBIDDEN_PREFIXES = [
     "app.services.kis",
     "app.services.upbit",
@@ -70,3 +72,35 @@ print(json.dumps(sorted(sys.modules)))
         if name == forbidden or name.startswith(f"{forbidden}.")
     )
     assert not violations, f"forbidden modules transitively imported: {violations}"
+
+
+@pytest.mark.unit
+def test_news_brief_candidate_payload_rejects_execution_keys() -> None:
+    for forbidden_key in [
+        "quantity",
+        "price",
+        "side",
+        "order_type",
+        "dry_run",
+        "watch",
+        "order_intent",
+    ]:
+        with pytest.raises(ValueError, match="forbidden execution keys"):
+            research_run_service._validate_news_brief_candidate_payload(  # noqa: SLF001
+                {"symbol": "005930", forbidden_key: True}
+            )
+
+
+@pytest.mark.unit
+def test_news_brief_candidate_payload_allows_advisory_only_fields() -> None:
+    research_run_service._validate_news_brief_candidate_payload(  # noqa: SLF001
+        {
+            "symbol": "005930",
+            "name": "삼성전자",
+            "sector": "반도체",
+            "direction": "positive",
+            "confidence": 60,
+            "reasons": ["news evidence"],
+            "warnings": ["news_stale"],
+        }
+    )

--- a/tests/test_preopen_dashboard_service.py
+++ b/tests/test_preopen_dashboard_service.py
@@ -558,3 +558,146 @@ def test_no_forbidden_imports():
                 assert not any(part in low for part in forbidden_parts), (
                     f"Forbidden import '{name}' found in {mod.__name__}"
                 )
+
+
+# --- ROB-62: news_brief field conformance ---
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_news_brief_present_and_advisory_only_when_run_exists():
+    """news_brief must be populated and advisory_only=True when a run exists (ROB-62)."""
+    from app.services import preopen_dashboard_service, research_run_service
+
+    run = _make_run()
+    readiness = _make_news_readiness(is_ready=True, is_stale=False, warnings=[])
+
+    with _patched_dashboard_dependencies(
+        preopen_dashboard_service,
+        research_run_service,
+        run=run,
+        readiness=readiness,
+    ):
+        result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+            db=AsyncMock(),
+            user_id=7,
+            market_scope="kr",
+        )
+
+    assert result.news_brief is not None, (
+        "news_brief must not be None when a run exists"
+    )
+    assert result.news_brief.advisory_only is True
+    assert result.news_brief.news_readiness in (
+        "ok",
+        "stale",
+        "degraded",
+        "unavailable",
+    )
+    assert 0 <= result.news_brief.confidence.overall <= 100
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_news_brief_none_when_fail_open():
+    """Fail-open response must have news_brief=None (no run found)."""
+    from app.services import preopen_dashboard_service, research_run_service
+
+    with patch.object(
+        research_run_service,
+        "get_latest_research_run",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+            db=AsyncMock(),
+            user_id=7,
+            market_scope="kr",
+        )
+
+    assert result.has_run is False
+    assert result.news_brief is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_news_brief_readiness_ok_when_news_ready():
+    """news_brief.news_readiness must be 'ok' when news is ready (ROB-62)."""
+    from app.services import preopen_dashboard_service, research_run_service
+
+    run = _make_run()
+    readiness = _make_news_readiness(
+        is_ready=True,
+        is_stale=False,
+        warnings=[],
+        source_counts={"browser_naver_mainnews": 20},
+    )
+
+    with _patched_dashboard_dependencies(
+        preopen_dashboard_service,
+        research_run_service,
+        run=run,
+        readiness=readiness,
+    ):
+        result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+            db=AsyncMock(),
+            user_id=7,
+            market_scope="kr",
+        )
+
+    assert result.news_brief is not None
+    assert result.news_brief.news_readiness == "ok"
+    assert result.news_brief.confidence.overall <= 90
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_news_brief_readiness_stale_when_news_stale():
+    """news_brief.news_readiness must be 'stale' when news is stale (ROB-62)."""
+    from app.services import preopen_dashboard_service, research_run_service
+
+    run = _make_run()
+    readiness = _make_news_readiness(
+        is_ready=False,
+        is_stale=True,
+        warnings=["news_stale"],
+    )
+
+    with _patched_dashboard_dependencies(
+        preopen_dashboard_service,
+        research_run_service,
+        run=run,
+        readiness=readiness,
+    ):
+        result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+            db=AsyncMock(),
+            user_id=7,
+            market_scope="kr",
+        )
+
+    assert result.news_brief is not None
+    assert result.news_brief.news_readiness == "stale"
+    assert result.news_brief.confidence.overall <= 60
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_news_brief_none_when_readiness_lookup_raises():
+    """news_brief must be None when readiness lookup raises (graceful degradation, ROB-62)."""
+    from app.services import preopen_dashboard_service, research_run_service
+
+    run = _make_run()
+
+    with _patched_dashboard_dependencies(
+        preopen_dashboard_service,
+        research_run_service,
+        run=run,
+        readiness_error=RuntimeError("redis down"),
+    ):
+        result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+            db=AsyncMock(),
+            user_id=7,
+            market_scope="kr",
+        )
+
+    assert result.news is None
+    assert result.news_brief is None

--- a/tests/test_router_preopen.py
+++ b/tests/test_router_preopen.py
@@ -256,3 +256,22 @@ def test_market_scope_param_validation_rejects_us_for_now():
 
     response = TestClient(app).get(f"{ENDPOINT}?market_scope=us")
     assert response.status_code == 422
+
+
+@pytest.mark.unit
+def test_response_contains_news_brief_key_for_kr(monkeypatch: pytest.MonkeyPatch):
+    """Smoke: GET /preopen/latest KR response always contains 'news_brief' key (ROB-62)."""
+    from app.services import preopen_dashboard_service
+
+    monkeypatch.setattr(
+        preopen_dashboard_service,
+        "get_latest_preopen_dashboard",
+        AsyncMock(return_value=_fail_open_response()),
+    )
+
+    response = TestClient(_app()).get(ENDPOINT)
+    assert response.status_code == 200
+    body = response.json()
+    assert "news_brief" in body, (
+        "news_brief key must always be present in KR preopen response"
+    )

--- a/tests/test_router_preopen_news_brief.py
+++ b/tests/test_router_preopen_news_brief.py
@@ -1,0 +1,270 @@
+"""Router-level tests for the KR preopen news_brief field (ROB-62).
+
+Verifies:
+- GET /preopen/latest returns 200 with news_brief populated for each readiness state.
+- Response is read-only: no DB writes occur (verified by spy on dashboard service mock).
+- news_brief is advisory_only=True invariant.
+- news_brief is present in 200 response for run-present and fail-open cases.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.schemas.preopen_news_brief import (
+    BriefConfidence,
+    CandidateImpactFlag,
+    KRPreopenNewsBrief,
+    RiskFlag,
+)
+
+ENDPOINT = "/trading/api/preopen/latest"
+
+
+def _app() -> FastAPI:
+    from app.routers import preopen as preopen_router
+    from app.routers.dependencies import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(preopen_router.router)
+    app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=7)
+    return app
+
+
+def _base_response(**kwargs):
+    from app.schemas.preopen import PreopenLatestResponse
+
+    defaults = {
+        "has_run": True,
+        "advisory_used": False,
+        "advisory_skipped_reason": None,
+        "run_uuid": None,
+        "market_scope": "kr",
+        "stage": "preopen",
+        "status": "open",
+        "strategy_name": None,
+        "source_profile": "roadmap",
+        "generated_at": datetime.now(UTC),
+        "created_at": datetime.now(UTC),
+        "notes": None,
+        "market_brief": None,
+        "source_freshness": None,
+        "source_warnings": [],
+        "advisory_links": [],
+        "candidate_count": 0,
+        "reconciliation_count": 0,
+        "candidates": [],
+        "reconciliations": [],
+        "linked_sessions": [],
+        "news": None,
+        "news_preview": [],
+        "news_brief": None,
+    }
+    defaults.update(kwargs)
+    return PreopenLatestResponse(**defaults)
+
+
+def _brief(
+    readiness: str = "ok",
+    overall: int = 80,
+    cap_reason: str = "ok",
+) -> KRPreopenNewsBrief:
+    return KRPreopenNewsBrief(
+        generated_at=datetime.now(UTC),
+        news_readiness=readiness,  # type: ignore[arg-type]
+        news_max_age_minutes=180,
+        confidence=BriefConfidence(overall=overall, cap_reason=cap_reason),  # type: ignore[arg-type]
+        sector_flags=[],
+        candidate_flags=[],
+        risk_flags=[],
+        research_run_id=None,
+        advisory_only=True,
+    )
+
+
+# --- Basic presence tests ---
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "readiness,overall,cap_reason",
+    [
+        ("ok", 80, "ok"),
+        ("stale", 55, "news_stale"),
+        ("degraded", 35, "no_tradingagents_evidence"),
+        ("unavailable", 0, "news_unavailable"),
+    ],
+)
+def test_get_preopen_returns_200_with_news_brief_for_each_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+    readiness: str,
+    overall: int,
+    cap_reason: str,
+):
+    """GET /preopen/latest returns 200 with news_brief for every readiness state."""
+    from app.services import preopen_dashboard_service
+
+    brief = _brief(readiness=readiness, overall=overall, cap_reason=cap_reason)
+    response_obj = _base_response(news_brief=brief)
+
+    monkeypatch.setattr(
+        preopen_dashboard_service,
+        "get_latest_preopen_dashboard",
+        AsyncMock(return_value=response_obj),
+    )
+
+    response = TestClient(_app()).get(ENDPOINT)
+    assert response.status_code == 200
+    body = response.json()
+    assert "news_brief" in body
+    assert body["news_brief"]["advisory_only"] is True
+    assert body["news_brief"]["news_readiness"] == readiness
+    assert body["news_brief"]["confidence"]["overall"] == overall
+
+
+@pytest.mark.unit
+def test_get_preopen_news_brief_none_when_fail_open(monkeypatch: pytest.MonkeyPatch):
+    """Fail-open (no run) returns 200 with news_brief=null."""
+    from app.schemas.preopen import PreopenLatestResponse
+    from app.services import preopen_dashboard_service
+
+    fail_open = PreopenLatestResponse(
+        has_run=False,
+        advisory_skipped_reason="no_open_preopen_run",
+        run_uuid=None,
+        market_scope=None,
+        stage=None,
+        status=None,
+        strategy_name=None,
+        source_profile=None,
+        generated_at=None,
+        created_at=None,
+        notes=None,
+        market_brief=None,
+        source_freshness=None,
+        source_warnings=[],
+        advisory_links=[],
+        candidate_count=0,
+        reconciliation_count=0,
+        candidates=[],
+        reconciliations=[],
+        linked_sessions=[],
+        news=None,
+        news_preview=[],
+        news_brief=None,
+    )
+    monkeypatch.setattr(
+        preopen_dashboard_service,
+        "get_latest_preopen_dashboard",
+        AsyncMock(return_value=fail_open),
+    )
+
+    response = TestClient(_app()).get(ENDPOINT)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["news_brief"] is None
+    assert body["has_run"] is False
+
+
+@pytest.mark.unit
+def test_news_brief_unavailable_returns_200_with_brief_marked_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Unavailable readiness: response is still 200, brief has confidence.overall==0."""
+    from app.services import preopen_dashboard_service
+
+    brief = _brief(readiness="unavailable", overall=0, cap_reason="news_unavailable")
+    brief.risk_flags.append(
+        RiskFlag(
+            code="news_unavailable", severity="warn", message="뉴스 신선도: unavailable"
+        )
+    )
+    response_obj = _base_response(news_brief=brief)
+
+    monkeypatch.setattr(
+        preopen_dashboard_service,
+        "get_latest_preopen_dashboard",
+        AsyncMock(return_value=response_obj),
+    )
+
+    response = TestClient(_app()).get(ENDPOINT)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["news_brief"]["news_readiness"] == "unavailable"
+    assert body["news_brief"]["confidence"]["overall"] == 0
+    assert body["news_brief"]["sector_flags"] == []
+    assert body["news_brief"]["candidate_flags"] == []
+
+
+# --- Read-only guarantee ---
+
+
+@pytest.mark.unit
+def test_get_preopen_does_not_call_persistence(monkeypatch: pytest.MonkeyPatch):
+    """GET dashboard path must not call record_kr_preopen_news_brief."""
+    from app.services import preopen_dashboard_service, research_run_service
+
+    record_mock = AsyncMock()
+    monkeypatch.setattr(
+        research_run_service,
+        "record_kr_preopen_news_brief",
+        record_mock,
+    )
+    monkeypatch.setattr(
+        preopen_dashboard_service,
+        "get_latest_preopen_dashboard",
+        AsyncMock(return_value=_base_response()),
+    )
+
+    TestClient(_app()).get(ENDPOINT)
+    record_mock.assert_not_called()
+
+
+# --- Candidate flag has no forbidden keys ---
+
+
+@pytest.mark.unit
+def test_candidate_flags_in_response_have_no_forbidden_keys(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from app.services import preopen_dashboard_service
+
+    candidate_flag = CandidateImpactFlag(
+        symbol="005930",
+        name="삼성전자",
+        direction="positive",
+        confidence=70,
+        sector="반도체",
+        reasons=["Good momentum"],
+        research_run_candidate_id=1,
+    )
+    brief = _brief()
+    brief.candidate_flags.append(candidate_flag)
+    response_obj = _base_response(news_brief=brief)
+
+    monkeypatch.setattr(
+        preopen_dashboard_service,
+        "get_latest_preopen_dashboard",
+        AsyncMock(return_value=response_obj),
+    )
+
+    response = TestClient(_app()).get(ENDPOINT)
+    body = response.json()
+    for flag in body["news_brief"]["candidate_flags"]:
+        forbidden = {
+            "quantity",
+            "price",
+            "side",
+            "order_type",
+            "dry_run",
+            "watch",
+            "order_intent",
+        }
+        violations = forbidden & set(flag.keys())
+        assert not violations, f"Forbidden keys in candidate_flag: {violations}"


### PR DESCRIPTION
## Summary
- Add advisory-only KR preopen Hermes news brief schemas and assembly service.
- Expose the latest preopen dashboard with a read-only `news_brief` payload when readiness is available.
- Add advisory-only persistence helper validation and safety tests that forbid order/watch/order-intent fields.
- Document ROB-62 plan, guardrails, and PR-readiness verification.

## Local verification commands/results
- `uv run ruff format app/schemas/preopen.py app/services/preopen_dashboard_service.py app/services/research_run_service.py tests/services/test_research_run_service_safety.py tests/test_preopen_dashboard_service.py tests/test_router_preopen.py app/schemas/preopen_news_brief.py app/services/kr_preopen_news_brief_service.py tests/services/test_kr_preopen_news_brief_service.py tests/services/test_research_run_service_news_brief_safety.py tests/test_router_preopen_news_brief.py` => 11 files left unchanged after formatting pass
- `uv run ruff check app/schemas/preopen.py app/services/preopen_dashboard_service.py app/services/research_run_service.py tests/services/test_research_run_service_safety.py tests/test_preopen_dashboard_service.py tests/test_router_preopen.py app/schemas/preopen_news_brief.py app/services/kr_preopen_news_brief_service.py tests/services/test_kr_preopen_news_brief_service.py tests/services/test_research_run_service_news_brief_safety.py tests/test_router_preopen_news_brief.py` => All checks passed
- `uv run ruff format --check app/schemas/preopen.py app/services/preopen_dashboard_service.py app/services/research_run_service.py tests/services/test_research_run_service_safety.py tests/test_preopen_dashboard_service.py tests/test_router_preopen.py app/schemas/preopen_news_brief.py app/services/kr_preopen_news_brief_service.py tests/services/test_kr_preopen_news_brief_service.py tests/services/test_research_run_service_news_brief_safety.py tests/test_router_preopen_news_brief.py` => 11 files already formatted
- `uv run pytest -q tests/services/test_kr_preopen_news_brief_service.py tests/services/test_research_run_service_news_brief_safety.py tests/test_router_preopen_news_brief.py tests/test_preopen_dashboard_service.py tests/test_router_preopen.py tests/services/test_research_run_service_safety.py` => 78 passed, 2 Pydantic deprecation warnings
- `uv run ty check app/ --error-on-warning` => All checks passed
- Opus review (`HOME=/Users/mgh3326 HERMES_HOME=/Users/mgh3326/.hermes claude -p --model opus --permission-mode auto --output-format text < /tmp/rob62-reviewer.md`) => `review_passed`

## Safety / non-actions
- No orders placed.
- No dry-run orders executed.
- No watch/order-intent created.
- No live trading side effects.
- No production DB writes or direct DB mutation.
- No secrets output or committed.
- No merge performed.
- No deploy performed.

## AoE/dev session/worktree/branch
- Issue: ROB-62
- AoE/dev session: existing ROB-62 AoE/worktree; session id not available from current shell context
- Worktree: `/Users/mgh3326/work/auto_trader-worktrees/feature-ROB-62-kr-preopen-hermes-news-brief`
- Branch: `feature/ROB-62-kr-preopen-hermes-news-brief`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a news brief field to the preopen dashboard response, providing advisory-only insights including confidence levels, risk flags, sector impact assessments, and candidate impact data with support for multiple readiness states (ok, stale, degraded, unavailable).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->