### PR TITLE
feat(ROB-67): add paper_001 mock instance registry

### DIFF
--- a/app/services/mock_trading_instance_registry.py
+++ b/app/services/mock_trading_instance_registry.py
@@ -1,0 +1,98 @@
+"""Broker-agnostic mock trading instance registry.
+
+This registry names user-facing paper/mock trading instances independently from
+the broker implementation currently backing them.  For example, ``paper_001`` is
+"모의투자1" even though its first backend mapping is KIS official mock.
+
+The registry is metadata-only: it does not execute orders, read credentials, or
+instantiate broker clients.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+
+
+class MockTradingInstanceError(ValueError):
+    """Raised when a mock trading instance cannot be resolved safely."""
+
+
+class BrokerBackend(StrEnum):
+    """Broker backend identifiers allowed for mock trading instances."""
+
+    KIS_MOCK = "kis_mock"
+
+
+class MarketScope(StrEnum):
+    """Market scope for a mock trading instance."""
+
+    KR = "kr"
+
+
+@dataclass(frozen=True)
+class MockTradingInstance:
+    """User-facing mock trading account/strategy instance metadata."""
+
+    slug: str
+    display_name: str
+    broker_backend: BrokerBackend
+    broker_account_ref: str
+    market_scope: MarketScope
+    strategy_profile: str
+    persona_profile: str
+
+    @property
+    def is_live_backend(self) -> bool:
+        """Return True if this instance points at a live backend."""
+
+        return "live" in self.broker_backend.value
+
+
+PAPER_001 = MockTradingInstance(
+    slug="paper_001",
+    display_name="모의투자1",
+    broker_backend=BrokerBackend.KIS_MOCK,
+    # Reference the env/config key name only.  Never commit the actual KIS mock
+    # account number or credentials in this registry.
+    broker_account_ref="env:KIS_MOCK_ACCOUNT_NO",
+    market_scope=MarketScope.KR,
+    strategy_profile="balanced_kr_mock",
+    persona_profile="paper_001",
+)
+
+MOCK_TRADING_INSTANCES: Mapping[str, MockTradingInstance] = MappingProxyType(
+    {PAPER_001.slug: PAPER_001}
+)
+
+
+def get_mock_trading_instance(slug: str) -> MockTradingInstance:
+    """Resolve a mock trading instance by slug, failing closed if unknown."""
+
+    normalized_slug = str(slug or "").strip()
+    if not normalized_slug:
+        raise MockTradingInstanceError("Mock trading instance slug is required")
+
+    instance = MOCK_TRADING_INSTANCES.get(normalized_slug)
+    if instance is None:
+        raise MockTradingInstanceError(
+            f"Unknown mock trading instance: {normalized_slug!r}"
+        )
+    if instance.is_live_backend:
+        raise MockTradingInstanceError(
+            f"Mock trading instance {normalized_slug!r} resolves to live backend"
+        )
+    return instance
+
+
+__all__ = [
+    "BrokerBackend",
+    "MarketScope",
+    "MockTradingInstance",
+    "MockTradingInstanceError",
+    "MOCK_TRADING_INSTANCES",
+    "PAPER_001",
+    "get_mock_trading_instance",
+]

--- a/docs/runbooks/paper-001-mock-trading-instance.md
+++ b/docs/runbooks/paper-001-mock-trading-instance.md
@@ -1,0 +1,43 @@
+# ROB-67 — `paper_001` / `모의투자1` mock trading instance
+
+`paper_001` is the first broker-agnostic mock trading instance for the KIS
+official mock runtime smoke path.
+
+## Registry contract
+
+The source-of-truth registry is `app/services/mock_trading_instance_registry.py`.
+The initial entry is:
+
+| Field | Value |
+| --- | --- |
+| `slug` | `paper_001` |
+| `display_name` | `모의투자1` |
+| `broker_backend` | `kis_mock` |
+| `broker_account_ref` | `env:KIS_MOCK_ACCOUNT_NO` |
+| `market_scope` | `kr` |
+| `strategy_profile` | `balanced_kr_mock` |
+| `persona_profile` | `paper_001` |
+
+`broker_account_ref` is an environment/config key reference only. Do not commit
+real account numbers, KIS app keys, tokens, or secrets in this registry or in
+operator reports.
+
+## Safety rules
+
+- `paper_001` must resolve to `kis_mock` only.
+- Unknown instance lookup must fail closed.
+- The registry is metadata-only; it must not place orders, instantiate broker
+  clients, or read credentials.
+- Live backend routing, Alpaca paper routing, and daily autonomous trading loops
+  are out of scope for ROB-67.
+
+## Follow-up smoke
+
+After ROB-67 is merged and deployed, rerun ROB-66 from the top:
+
+1. Confirm `paper_001` resolves from the registry above.
+2. Confirm the dedicated paper MCP runtime still exposes only `kis_mock_*` order
+   tools and does not expose generic/live-capable order tools.
+3. Only then run KIS mock read-only smoke checks.
+4. Run mock order preview/dry-run only if it is explicitly paper/mock-only and
+   never with `dry_run=false`.

--- a/tests/services/test_mock_trading_instance_registry.py
+++ b/tests/services/test_mock_trading_instance_registry.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from app.services.mock_trading_instance_registry import (
+    MOCK_TRADING_INSTANCES,
+    BrokerBackend,
+    MarketScope,
+    MockTradingInstanceError,
+    get_mock_trading_instance,
+)
+
+
+def test_paper_001_registry_entry_is_broker_agnostic_kis_mock_mapping() -> None:
+    instance = get_mock_trading_instance("paper_001")
+
+    assert instance.slug == "paper_001"
+    assert instance.display_name == "모의투자1"
+    assert instance.broker_backend is BrokerBackend.KIS_MOCK
+    assert instance.broker_backend.value == "kis_mock"
+    assert instance.market_scope is MarketScope.KR
+    assert instance.strategy_profile == "balanced_kr_mock"
+    assert instance.persona_profile == "paper_001"
+
+
+def test_paper_001_account_ref_is_env_backed_not_literal_account_value() -> None:
+    instance = get_mock_trading_instance("paper_001")
+
+    assert instance.broker_account_ref == "env:KIS_MOCK_ACCOUNT_NO"
+    assert instance.broker_account_ref.startswith("env:")
+    assert not any(ch.isdigit() for ch in instance.broker_account_ref)
+
+
+def test_paper_001_never_resolves_to_live_backend() -> None:
+    instance = get_mock_trading_instance("paper_001")
+
+    assert not instance.is_live_backend
+    assert "live" not in instance.broker_backend.value
+
+
+def test_unknown_instance_lookup_fails_closed() -> None:
+    with pytest.raises(MockTradingInstanceError, match="Unknown mock trading instance"):
+        get_mock_trading_instance("paper_999")
+
+
+def test_blank_instance_lookup_fails_closed() -> None:
+    with pytest.raises(MockTradingInstanceError, match="slug is required"):
+        get_mock_trading_instance("   ")
+
+
+def test_registry_is_read_only() -> None:
+    with pytest.raises(TypeError):
+        MOCK_TRADING_INSTANCES["paper_999"] = get_mock_trading_instance("paper_001")  # type: ignore[index]


### PR DESCRIPTION
## Summary
- Add broker-agnostic mock trading instance registry for `paper_001` / `모의투자1`.
- Map `paper_001` explicitly to `kis_mock` using secret-safe env reference `env:KIS_MOCK_ACCOUNT_NO`.
- Add fail-closed resolver tests and an operator runbook for rerunning ROB-66 after merge/deploy.

## Safety
- No order execution paths added or invoked.
- No live backend mapping for `paper_001`.
- No secrets or literal account numbers committed.
- Alpaca routing and daily autonomous trading loop are out of scope.

## Verification
- `uv run pytest tests/services/test_mock_trading_instance_registry.py -q`
- `uv run ruff check app/services/mock_trading_instance_registry.py tests/services/test_mock_trading_instance_registry.py`
- `uv run ruff format --check app/services/mock_trading_instance_registry.py tests/services/test_mock_trading_instance_registry.py`
- `uv run ty check app/services/mock_trading_instance_registry.py tests/services/test_mock_trading_instance_registry.py`
- Independent review subagent: no must-fix issues found.

## Follow-up
- After merge/deploy, rerun ROB-66 from the top.
