### PR TITLE
feat: scope news articles by market

### DIFF
--- a/alembic/versions/b6c7d8e9f0a1_add_news_article_market.py
+++ b/alembic/versions/b6c7d8e9f0a1_add_news_article_market.py
@@ -1,0 +1,43 @@
+"""add market scope to news articles
+
+Revision ID: b6c7d8e9f0a1
+Revises: e2f3a4b5c6d7
+Create Date: 2026-05-01 14:45:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b6c7d8e9f0a1"
+down_revision: str | Sequence[str] | None = "e2f3a4b5c6d7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "news_articles",
+        sa.Column(
+            "market",
+            sa.String(length=20),
+            nullable=False,
+            server_default="kr",
+            comment="Market scope for the article (kr, us, crypto)",
+        ),
+    )
+    op.create_index("ix_news_articles_market", "news_articles", ["market"])
+    op.create_index(
+        "ix_news_articles_market_published",
+        "news_articles",
+        ["market", "article_published_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_news_articles_market_published", table_name="news_articles")
+    op.drop_index("ix_news_articles_market", table_name="news_articles")
+    op.drop_column("news_articles", "market")

--- a/app/mcp_server/tooling/news_handlers.py
+++ b/app/mcp_server/tooling/news_handlers.py
@@ -25,6 +25,7 @@ def _article_to_dict(article: NewsArticle) -> dict[str, Any]:
         "url": article.url,
         "source": article.source,
         "feed_source": article.feed_source,
+        "market": article.market,
         "summary": article.summary,
         "published_at": article.article_published_at.isoformat()
         if article.article_published_at
@@ -36,6 +37,7 @@ def _article_to_dict(article: NewsArticle) -> dict[str, Any]:
 
 
 async def _get_market_news_impl(
+    market: str | None = None,
     hours: int | None = 24,
     feed_source: str | None = None,
     source: str | None = None,
@@ -46,6 +48,7 @@ async def _get_market_news_impl(
     limit = limit or 20
 
     articles, total = await get_news_articles(
+        market=market,
         hours=hours,
         feed_source=feed_source,
         source=source,
@@ -60,6 +63,7 @@ async def _get_market_news_impl(
     )
 
     return {
+        "market": market,
         "count": len(news_list),
         "total": total,
         "news": news_list,
@@ -124,12 +128,13 @@ def _register_news_tools_impl(mcp: FastMCP) -> None:
     @mcp.tool(
         name="get_market_news",
         description=(
-            "Get recent market news. Supports filtering by publisher (source), "
+            "Get recent market news. Supports filtering by market, publisher (source), "
             "collection path (feed_source), and keyword. Returns both publisher names "
             "and collection paths for briefing segmentation."
         ),
     )
     async def get_market_news(
+        market: str | None = None,
         hours: int = 24,
         feed_source: str | None = None,
         source: str | None = None,
@@ -137,6 +142,7 @@ def _register_news_tools_impl(mcp: FastMCP) -> None:
         limit: int = 20,
     ) -> dict[str, Any]:
         return await _get_market_news_impl(
+            market=market,
             hours=hours,
             feed_source=feed_source,
             source=source,

--- a/app/models/news.py
+++ b/app/models/news.py
@@ -33,6 +33,7 @@ class NewsArticle(Base):
         UniqueConstraint("url", name="uq_news_article_url"),
         Index("ix_news_articles_keywords", "keywords", postgresql_using="gin"),
         Index("ix_news_articles_published_feed", "article_published_at", "feed_source"),
+        Index("ix_news_articles_market_published", "market", "article_published_at"),
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
@@ -59,6 +60,14 @@ class NewsArticle(Base):
         nullable=True,
         index=True,
         comment="RSS 피드 소스 (mk_stock, yna_market 등)",
+    )
+    market: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default="kr",
+        server_default="kr",
+        index=True,
+        comment="Market scope (kr, us, crypto)",
     )
     keywords: Mapped[list | None] = mapped_column(
         JSONB, nullable=True, comment="키워드 배열"

--- a/app/routers/news_analysis.py
+++ b/app/routers/news_analysis.py
@@ -116,6 +116,7 @@ async def get_news_readiness_status(
 
 @router.get("", response_model=NewsListResponse)
 async def list_news_articles(
+    market: str | None = Query(None, description="시장 구분으로 필터링 (kr/us/crypto)"),
     stock_symbol: str | None = Query(None, description="종목 코드로 필터링"),
     sentiment: str | None = Query(
         None, description="감정 분석으로 필터링 (positive/negative/neutral)"
@@ -136,6 +137,7 @@ async def list_news_articles(
 ):
     try:
         articles, total = await get_news_articles(
+            market=market,
             stock_symbol=stock_symbol,
             sentiment=sentiment,
             source=source,

--- a/app/schemas/news.py
+++ b/app/schemas/news.py
@@ -16,6 +16,7 @@ class NewsArticleCreate(BaseModel):
     stock_symbol: str | None = Field(None, max_length=20, description="관련 종목 코드")
     stock_name: str | None = Field(None, max_length=100, description="관련 종목명")
     published_at: datetime | None = Field(None, description="기사 발행일시")
+    market: str = Field("kr", min_length=1, max_length=20, description="시장 구분")
     feed_source: str | None = Field(
         None,
         max_length=50,
@@ -44,6 +45,11 @@ class NewsArticleCreate(BaseModel):
             return None
         value = v.strip()
         return value or None
+
+    @field_validator("market")
+    @classmethod
+    def normalize_market(cls, v: str) -> str:
+        return v.strip()
 
     @field_validator("keywords")
     @classmethod
@@ -170,6 +176,7 @@ class NewsArticleResponse(BaseModel):
     created_at: datetime
     updated_at: datetime | None
     feed_source: str | None = None
+    market: str = "kr"
     keywords: list[str] | None = None
     is_analyzed: bool = False
 
@@ -219,6 +226,7 @@ class NewsAnalysisResponse(BaseModel):
 
 
 class NewsQueryParams(BaseModel):
+    market: str | None = Field(None, description="시장 구분으로 필터링 (kr/us/crypto)")
     stock_symbol: str | None = Field(None, description="종목 코드로 필터링")
     sentiment: str | None = Field(
         None, description="감정으로 필터링 (positive/negative/neutral)"

--- a/app/services/llm_news_service.py
+++ b/app/services/llm_news_service.py
@@ -26,6 +26,7 @@ async def create_news_article(
     stock_symbol: str | None = None,
     stock_name: str | None = None,
     published_at: datetime | None = None,
+    market: str = "kr",
     feed_source: str | None = None,
     keywords: list[str] | None = None,
     summary: str | None = None,
@@ -40,6 +41,7 @@ async def create_news_article(
         stock_symbol=stock_symbol,
         stock_name=stock_name,
         article_published_at=to_kst_naive(published_at) if published_at else None,
+        market=market,
         feed_source=feed_source,
         keywords=keywords,
         scraped_at=now_kst_naive(),
@@ -94,6 +96,7 @@ async def bulk_create_news_articles(
                 article_published_at=to_kst_naive(article_data.published_at)
                 if article_data.published_at
                 else None,
+                market=article_data.market,
                 feed_source=article_data.feed_source,
                 keywords=article_data.keywords,
                 scraped_at=now_kst_naive(),
@@ -110,6 +113,7 @@ async def bulk_create_news_articles(
 
 
 async def get_news_articles(
+    market: str | None = None,
     stock_symbol: str | None = None,
     sentiment: str | None = None,
     source: str | None = None,
@@ -132,6 +136,8 @@ async def get_news_articles(
 
         conditions = []
 
+        if market:
+            conditions.append(NewsArticle.market == market)
         if stock_symbol:
             conditions.append(NewsArticle.stock_symbol == stock_symbol)
         if source:
@@ -248,6 +254,7 @@ def _article_values_from_ingestor_payload(article_data: Any) -> dict[str, Any]:
         "article_published_at": to_kst_naive(article_data.published_at)
         if article_data.published_at
         else None,
+        "market": article_data.market,
         "feed_source": article_data.feed_source,
         "keywords": article_data.keywords,
         "scraped_at": now_kst_naive(),

--- a/tests/test_news_ingestor_bulk.py
+++ b/tests/test_news_ingestor_bulk.py
@@ -58,6 +58,7 @@ class TestNewsIngestorSchemas:
 
         assert request.ingestion_run.run_uuid == "run-rob-46"
         assert request.ingestion_run.market == "kr"
+        assert request.articles[0].market == "kr"
         assert request.articles[0].feed_source == "browser_naver_mainnews"
         assert request.articles[0].source == "연합뉴스"
         assert request.articles[0].url == "https://n.news.naver.com/mnews/article/001/1"
@@ -97,6 +98,37 @@ class TestNewsIngestorSchemas:
         assert run.inserted_count == 12
         assert run.skipped_count == 39
 
+    def test_news_article_model_has_market_scope(self):
+        from app.models.news import NewsArticle
+
+        article = NewsArticle(
+            url="https://cointelegraph.com/news/example",
+            title="Bitcoin ETF update",
+            market="crypto",
+            feed_source="rss_cointelegraph",
+            scraped_at=datetime(2026, 5, 1, 5, 0, 0),
+            created_at=datetime(2026, 5, 1, 5, 0, 0),
+        )
+
+        assert article.market == "crypto"
+
+    def test_ingestor_article_values_include_market_scope(self):
+        from app.schemas.news import NewsBulkIngestRequest
+        from app.services.llm_news_service import _article_values_from_ingestor_payload
+
+        payload = _sample_payload()
+        payload["ingestion_run"]["market"] = "crypto"
+        payload["ingestion_run"]["feed_set"] = "crypto-core"
+        payload["articles"][0]["market"] = "crypto"
+        payload["articles"][0]["source"] = "rss_cointelegraph"
+        payload["articles"][0]["publisher"] = "Cointelegraph"
+
+        request = NewsBulkIngestRequest.model_validate(payload)
+        values = _article_values_from_ingestor_payload(request.articles[0])
+
+        assert values["market"] == "crypto"
+        assert values["feed_source"] == "rss_cointelegraph"
+
 
 class TestNewsIngestorRouter:
     def test_new_bulk_ingest_endpoint_exists_without_breaking_legacy_bulk(self):
@@ -128,6 +160,20 @@ class TestNewsIngestorRouter:
         assert response.status_code == 201
         assert response.json()["inserted_count"] == 1
         mock_ingest.assert_awaited_once()
+
+    def test_list_news_endpoint_accepts_market_filter(self):
+        app = _make_test_app()
+        client = TestClient(app)
+
+        with patch(
+            "app.routers.news_analysis.get_news_articles",
+            new=AsyncMock(return_value=([], 0)),
+        ) as mock_get_news:
+            response = client.get("/api/v1/news?market=crypto&limit=5")
+
+        assert response.status_code == 200
+        mock_get_news.assert_awaited_once()
+        assert mock_get_news.await_args.kwargs["market"] == "crypto"
 
     def test_readiness_endpoint_returns_service_result(self):
         app = _make_test_app()

--- a/tests/test_news_rss.py
+++ b/tests/test_news_rss.py
@@ -246,11 +246,13 @@ class TestNewsSchemas:
                 "created_at": "2026-03-27T09:00:00",
                 "updated_at": None,
                 "feed_source": "mk_stock",
+                "market": "kr",
                 "keywords": ["반도체"],
                 "is_analyzed": False,
             }
         )
         assert resp.feed_source == "mk_stock"
+        assert resp.market == "kr"
         assert resp.keywords == ["반도체"]
         assert resp.is_analyzed is False
 
@@ -522,6 +524,7 @@ class TestMCPNewsTools:
                 title="Test News 1",
                 source="매일경제",
                 feed_source="mk_stock",
+                market="kr",
                 summary="요약1",
                 article_published_at=datetime(2026, 3, 27, 9, 0, 0),
                 keywords=["반도체"],
@@ -534,6 +537,7 @@ class TestMCPNewsTools:
                 title="Test News 2",
                 source="연합뉴스",
                 feed_source="browser_naver_mainnews",
+                market="kr",
                 summary="요약2",
                 article_published_at=datetime(2026, 3, 27, 9, 30, 0),
                 keywords=["AI"],
@@ -560,7 +564,8 @@ class TestMCPNewsTools:
         # feed_sources should contain collection path keys
         assert "mk_stock" in result["feed_sources"]
         assert "browser_naver_mainnews" in result["feed_sources"]
-        # Each news item should have stock_symbol and stock_name
+        # Each news item should have market, stock_symbol and stock_name
+        assert result["news"][0]["market"] == "kr"
         assert result["news"][0]["stock_symbol"] == "005930"
         assert result["news"][0]["stock_name"] == "삼성전자"
 
@@ -575,6 +580,7 @@ class TestMCPNewsTools:
                 title="Test News",
                 source="매일경제",
                 feed_source="mk_stock",
+                market="kr",
                 summary="요약",
                 article_published_at=datetime(2026, 3, 27, 9, 0, 0),
                 keywords=["반도체"],
@@ -591,6 +597,22 @@ class TestMCPNewsTools:
         assert result["count"] == 1
         assert len(result["news"]) == 1
         assert result["news"][0]["title"] == "Test News"
+
+    @pytest.mark.asyncio
+    async def test_get_market_news_forwards_market_filter(self):
+        from app.mcp_server.tooling.news_handlers import _get_market_news_impl
+
+        with patch(
+            "app.mcp_server.tooling.news_handlers.get_news_articles",
+            new_callable=AsyncMock,
+            return_value=([], 0),
+        ) as mock_get:
+            result = await _get_market_news_impl(
+                market="crypto", hours=24, feed_source=None, limit=20
+            )
+
+        assert result["market"] == "crypto"
+        assert mock_get.call_args.kwargs["market"] == "crypto"
 
     @pytest.mark.asyncio
     async def test_search_news_calls_service(self):
@@ -626,6 +648,7 @@ class TestGetMarketNewsNoneDefaults:
             )
 
         call_kwargs = mock_get.call_args.kwargs
+        assert call_kwargs["market"] is None
         assert call_kwargs["hours"] == 24
         assert call_kwargs["limit"] == 20
         assert result["count"] == 0


### PR DESCRIPTION
## Summary
- add `news_articles.market` with default `kr` and an Alembic migration
- preserve `market` from news-ingestor bulk payloads so crypto/US/KR articles stay separable
- add `market` filters to `/news/articles`, MCP `get_market_news`, and news query service responses

## Test Plan
- `uv run ruff check app/models/news.py app/schemas/news.py app/services/llm_news_service.py app/routers/news_analysis.py app/mcp_server/tooling/news_handlers.py tests/test_news_ingestor_bulk.py tests/test_news_rss.py alembic/versions/b6c7d8e9f0a1_add_news_article_market.py`
- `uv run ruff format --check app/models/news.py app/schemas/news.py app/services/llm_news_service.py app/routers/news_analysis.py app/mcp_server/tooling/news_handlers.py tests/test_news_ingestor_bulk.py tests/test_news_rss.py alembic/versions/b6c7d8e9f0a1_add_news_article_market.py`
- `uv run python -m pytest tests/test_news_ingestor_bulk.py tests/test_news_rss.py tests/test_n8n_news.py tests/test_llm_news_preview.py -q`

## Notes
- Required before pushing `crypto-core` pending news into auto_trader so crypto articles do not mix with KR/US rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added market filtering to news articles—retrieve news by market scope (kr/us/crypto) for more targeted insights.
  * News API endpoints now support an optional market parameter to filter results by market.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->