### PR TITLE
feat(ROB-69): expose Alpaca paper read-only MCP tools

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -115,6 +115,31 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - Analyze multiple symbols in parallel and return compact per-symbol summaries
   - Default `quick=True` returns compact summary with: symbol, current_price, rsi_14, consensus, recommendation, supports (top 3), resistances (top 3)
 
+### Alpaca paper read-only smoke tools
+
+ROB-69 exposes Alpaca paper broker inspection via explicit read-only MCP tool
+names only:
+
+- `alpaca_paper_get_account()`
+- `alpaca_paper_get_cash()`
+- `alpaca_paper_list_positions()`
+- `alpaca_paper_list_orders(status="open", limit=50)`
+- `alpaca_paper_get_order(order_id)`
+- `alpaca_paper_list_assets(status="active", asset_class="us_equity")`
+- `alpaca_paper_list_fills(after=None, until=None, limit=50)`
+
+These tools instantiate `AlpacaPaperBrokerService`, so they inherit the
+service-level endpoint guard: the trading base URL must be exactly
+`https://paper-api.alpaca.markets`. The Alpaca dashboard may display
+`https://paper-api.alpaca.markets/v2`, but runtime env should **not** include
+`/v2`; service methods append `/v2/...` paths internally, and setting the env to
+`.../v2` would produce duplicated `/v2/v2/...` requests.
+
+Safety boundary: there are no Alpaca live MCP tools in this issue and no
+`alpaca_paper_submit_order`, `alpaca_paper_cancel_order`, replace/modify tool,
+or generic Alpaca order-routing surface. These smoke tools are for paper account
+visibility only.
+
 ### Account Routing
 
 MCP account-facing tools use `account_mode` to avoid mixing DB simulation,

--- a/app/mcp_server/tooling/alpaca_paper.py
+++ b/app/mcp_server/tooling/alpaca_paper.py
@@ -1,0 +1,250 @@
+"""Read-only Alpaca paper MCP tooling.
+
+ROB-69 intentionally exposes only inspection/smoke helpers for the Alpaca paper
+broker.  Do not add submit/cancel/replace handlers here; paper order mutation is
+out of scope until a later issue defines the account/profile/strategy model.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+
+ALPACA_PAPER_READONLY_TOOL_NAMES: set[str] = {
+    "alpaca_paper_get_account",
+    "alpaca_paper_get_cash",
+    "alpaca_paper_list_positions",
+    "alpaca_paper_list_orders",
+    "alpaca_paper_get_order",
+    "alpaca_paper_list_assets",
+    "alpaca_paper_list_fills",
+}
+
+ServiceFactory = Callable[[], AlpacaPaperBrokerService]
+
+
+def _default_service_factory() -> AlpacaPaperBrokerService:
+    """Build the guarded Alpaca paper service using app settings."""
+
+    return AlpacaPaperBrokerService()
+
+
+_service_factory: ServiceFactory = _default_service_factory
+
+
+def set_alpaca_paper_service_factory(factory: ServiceFactory) -> None:
+    """Override the service factory for tests."""
+
+    global _service_factory
+    _service_factory = factory
+
+
+def reset_alpaca_paper_service_factory() -> None:
+    """Restore the default service factory after tests."""
+
+    global _service_factory
+    _service_factory = _default_service_factory
+
+
+def _model_to_jsonable(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json", by_alias=True)
+    if isinstance(value, list):
+        return [_model_to_jsonable(item) for item in value]
+    if isinstance(value, tuple):
+        return [_model_to_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _model_to_jsonable(item) for key, item in value.items()}
+    return value
+
+
+def _parse_optional_datetime(value: str | None, *, field_name: str) -> datetime | None:
+    if value is None or value == "":
+        return None
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be an ISO-8601 datetime") from exc
+
+
+def _normalize_optional_limit(limit: int | None, *, max_limit: int = 500) -> int | None:
+    if limit is None:
+        return None
+    if limit < 1:
+        raise ValueError("limit must be >= 1")
+    return min(limit, max_limit)
+
+
+async def alpaca_paper_get_account() -> dict[str, Any]:
+    """Return the Alpaca paper account snapshot using the paper-only service."""
+
+    account = await _service_factory().get_account()
+    return {
+        "success": True,
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper",
+        "account": _model_to_jsonable(account),
+    }
+
+
+async def alpaca_paper_get_cash() -> dict[str, Any]:
+    """Return paper cash and buying power."""
+
+    cash = await _service_factory().get_cash()
+    return {
+        "success": True,
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper",
+        "cash": _model_to_jsonable(cash),
+    }
+
+
+async def alpaca_paper_list_positions() -> dict[str, Any]:
+    """List current Alpaca paper positions."""
+
+    positions = await _service_factory().list_positions()
+    return {
+        "success": True,
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper",
+        "count": len(positions),
+        "positions": _model_to_jsonable(positions),
+    }
+
+
+async def alpaca_paper_list_orders(
+    status: str | None = "open",
+    limit: int | None = 50,
+) -> dict[str, Any]:
+    """List Alpaca paper orders without mutating broker state."""
+
+    normalized_limit = _normalize_optional_limit(limit)
+    orders = await _service_factory().list_orders(status=status, limit=normalized_limit)
+    return {
+        "success": True,
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper",
+        "status": status,
+        "limit": normalized_limit,
+        "count": len(orders),
+        "orders": _model_to_jsonable(orders),
+    }
+
+
+async def alpaca_paper_get_order(order_id: str) -> dict[str, Any]:
+    """Fetch one Alpaca paper order by id without modifying it."""
+
+    if not order_id.strip():
+        raise ValueError("order_id is required")
+    order = await _service_factory().get_order(order_id.strip())
+    return {
+        "success": True,
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper",
+        "order": _model_to_jsonable(order),
+    }
+
+
+async def alpaca_paper_list_assets(
+    status: str | None = "active",
+    asset_class: str | None = "us_equity",
+) -> dict[str, Any]:
+    """List Alpaca paper-visible assets with optional status/class filters."""
+
+    assets = await _service_factory().list_assets(
+        status=status, asset_class=asset_class
+    )
+    return {
+        "success": True,
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper",
+        "status": status,
+        "asset_class": asset_class,
+        "count": len(assets),
+        "assets": _model_to_jsonable(assets),
+    }
+
+
+async def alpaca_paper_list_fills(
+    after: str | None = None,
+    until: str | None = None,
+    limit: int | None = 50,
+) -> dict[str, Any]:
+    """List Alpaca paper fill activities without placing/cancelling orders."""
+
+    parsed_after = _parse_optional_datetime(after, field_name="after")
+    parsed_until = _parse_optional_datetime(until, field_name="until")
+    normalized_limit = _normalize_optional_limit(limit)
+    fills = await _service_factory().list_fills(
+        after=parsed_after,
+        until=parsed_until,
+        limit=normalized_limit,
+    )
+    return {
+        "success": True,
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper",
+        "after": after,
+        "until": until,
+        "limit": normalized_limit,
+        "count": len(fills),
+        "fills": _model_to_jsonable(fills),
+    }
+
+
+def register_alpaca_paper_tools(mcp: FastMCP) -> None:
+    """Register Alpaca paper read-only MCP tools."""
+
+    _ = mcp.tool(
+        name="alpaca_paper_get_account",
+        description="Read-only Alpaca paper account snapshot. Uses paper endpoint guard; no live endpoint or order mutation.",
+    )(alpaca_paper_get_account)
+    _ = mcp.tool(
+        name="alpaca_paper_get_cash",
+        description="Read-only Alpaca paper cash and buying power. Uses paper endpoint guard.",
+    )(alpaca_paper_get_cash)
+    _ = mcp.tool(
+        name="alpaca_paper_list_positions",
+        description="Read-only list of Alpaca paper positions.",
+    )(alpaca_paper_list_positions)
+    _ = mcp.tool(
+        name="alpaca_paper_list_orders",
+        description="Read-only list of Alpaca paper orders by status and limit; does not submit/cancel/replace.",
+    )(alpaca_paper_list_orders)
+    _ = mcp.tool(
+        name="alpaca_paper_get_order",
+        description="Read-only fetch of one Alpaca paper order by id; does not modify broker state.",
+    )(alpaca_paper_get_order)
+    _ = mcp.tool(
+        name="alpaca_paper_list_assets",
+        description="Read-only list of Alpaca assets with status and asset_class filters.",
+    )(alpaca_paper_list_assets)
+    _ = mcp.tool(
+        name="alpaca_paper_list_fills",
+        description="Read-only list of Alpaca paper fill activities with optional ISO datetime window and limit.",
+    )(alpaca_paper_list_fills)
+
+
+__all__ = [
+    "ALPACA_PAPER_READONLY_TOOL_NAMES",
+    "alpaca_paper_get_account",
+    "alpaca_paper_get_cash",
+    "alpaca_paper_list_assets",
+    "alpaca_paper_list_fills",
+    "alpaca_paper_get_order",
+    "alpaca_paper_list_orders",
+    "alpaca_paper_list_positions",
+    "register_alpaca_paper_tools",
+    "reset_alpaca_paper_service_factory",
+    "set_alpaca_paper_service_factory",
+]

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from app.mcp_server.profiles import McpProfile
+from app.mcp_server.tooling.alpaca_paper import register_alpaca_paper_tools
 from app.mcp_server.tooling.analysis_registration import register_analysis_tools
 from app.mcp_server.tooling.execution_comment_registration import (
     register_execution_comment_tools,
@@ -87,6 +88,7 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
     register_user_settings_tools(mcp)
     register_news_tools(mcp)
     register_market_brief_tools(mcp)
+    register_alpaca_paper_tools(mcp)
 
     # Always: read-only with account_mode (mock-safe via ROB-28)
     register_portfolio_tools(mcp)

--- a/tests/test_alpaca_paper_isolation.py
+++ b/tests/test_alpaca_paper_isolation.py
@@ -38,12 +38,17 @@ def test_no_router_imports_alpaca_paper():
 
 
 @pytest.mark.unit
-def test_no_mcp_tool_imports_alpaca_paper():
-    """No file under app/mcp_server/ imports app.services.brokers.alpaca."""
+def test_only_explicit_readonly_mcp_tool_imports_alpaca_paper():
+    """Only the ROB-69 read-only MCP tooling module may import Alpaca paper service."""
     mcp_dir = REPO_ROOT / "app" / "mcp_server"
-    offenders = [p for p in _collect_python_files(mcp_dir) if _source_imports_alpaca(p)]
+    allowed = {mcp_dir / "tooling" / "alpaca_paper.py"}
+    offenders = [
+        p
+        for p in _collect_python_files(mcp_dir)
+        if _source_imports_alpaca(p) and p not in allowed
+    ]
     assert not offenders, (
-        f"These MCP files import the Alpaca package (not allowed in this issue): "
+        f"Only app/mcp_server/tooling/alpaca_paper.py may import Alpaca package: "
         f"{[str(p) for p in offenders]}"
     )
 

--- a/tests/test_mcp_alpaca_paper_tools.py
+++ b/tests/test_mcp_alpaca_paper_tools.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from app.mcp_server.profiles import McpProfile
+from app.mcp_server.tooling.alpaca_paper import (
+    ALPACA_PAPER_READONLY_TOOL_NAMES,
+    alpaca_paper_get_account,
+    alpaca_paper_get_cash,
+    alpaca_paper_get_order,
+    alpaca_paper_list_assets,
+    alpaca_paper_list_fills,
+    alpaca_paper_list_orders,
+    alpaca_paper_list_positions,
+    reset_alpaca_paper_service_factory,
+    set_alpaca_paper_service_factory,
+)
+from app.mcp_server.tooling.orders_registration import ORDER_TOOL_NAMES
+from app.mcp_server.tooling.registry import register_all_tools
+from app.services.brokers.alpaca.schemas import (
+    AccountSnapshot,
+    Asset,
+    CashBalance,
+    Fill,
+    Order,
+    Position,
+)
+from tests._mcp_tooling_support import DummyMCP
+
+
+class FakeAlpacaPaperService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def get_account(self) -> AccountSnapshot:
+        self.calls.append(("get_account", {}))
+        return AccountSnapshot(
+            id="paper-account",
+            buying_power=Decimal("200000"),
+            cash=Decimal("100000"),
+            portfolio_value=Decimal("100000"),
+            status="ACTIVE",
+        )
+
+    async def get_cash(self) -> CashBalance:
+        self.calls.append(("get_cash", {}))
+        return CashBalance(cash=Decimal("100000"), buying_power=Decimal("200000"))
+
+    async def list_positions(self) -> list[Position]:
+        self.calls.append(("list_positions", {}))
+        return [
+            Position(
+                asset_id="asset-aapl",
+                symbol="AAPL",
+                qty=Decimal("2"),
+                avg_entry_price=Decimal("180.12"),
+                current_price=Decimal("190.50"),
+                market_value=Decimal("381.00"),
+                unrealized_pl=Decimal("20.76"),
+                side="long",
+            )
+        ]
+
+    async def list_orders(
+        self,
+        *,
+        status: str | None = None,
+        limit: int | None = None,
+    ) -> list[Order]:
+        self.calls.append(("list_orders", {"status": status, "limit": limit}))
+        return [
+            Order(
+                id="order-1",
+                client_order_id="client-1",
+                symbol="AAPL",
+                qty=Decimal("1"),
+                filled_qty=Decimal("0"),
+                side="buy",
+                type="limit",
+                time_in_force="day",
+                status="open",
+                limit_price=Decimal("180"),
+            )
+        ]
+
+    async def get_order(self, order_id: str) -> Order:
+        self.calls.append(("get_order", {"order_id": order_id}))
+        return Order(
+            id=order_id,
+            symbol="MSFT",
+            qty=Decimal("1"),
+            filled_qty=Decimal("1"),
+            side="buy",
+            type="market",
+            time_in_force="day",
+            status="filled",
+            filled_avg_price=Decimal("420.50"),
+        )
+
+    async def list_assets(
+        self,
+        *,
+        status: str | None = None,
+        asset_class: str | None = None,
+    ) -> list[Asset]:
+        self.calls.append(
+            ("list_assets", {"status": status, "asset_class": asset_class})
+        )
+        return [
+            Asset(
+                id="asset-aapl",
+                symbol="AAPL",
+                name="Apple Inc.",
+                status="active",
+                tradable=True,
+                asset_class="us_equity",
+            )
+        ]
+
+    async def list_fills(
+        self, *, after=None, until=None, limit: int | None = None
+    ) -> list[Fill]:
+        self.calls.append(
+            ("list_fills", {"after": after, "until": until, "limit": limit})
+        )
+        return [
+            Fill(
+                id="fill-1",
+                activity_type="FILL",
+                symbol="AAPL",
+                qty=Decimal("1"),
+                price=Decimal("180.00"),
+                side="buy",
+                order_id="order-1",
+            )
+        ]
+
+
+@pytest.fixture
+def fake_service() -> FakeAlpacaPaperService:
+    service = FakeAlpacaPaperService()
+    set_alpaca_paper_service_factory(lambda: service)  # type: ignore[arg-type]
+    yield service
+    reset_alpaca_paper_service_factory()
+
+
+@pytest.mark.unit
+def test_registers_explicit_alpaca_paper_readonly_tools_default_profile() -> None:
+    mcp = DummyMCP()
+    register_all_tools(mcp, profile=McpProfile.DEFAULT)  # type: ignore[arg-type]
+    assert ALPACA_PAPER_READONLY_TOOL_NAMES <= mcp.tools.keys()
+
+
+@pytest.mark.unit
+def test_registers_explicit_alpaca_paper_readonly_tools_paper_profile() -> None:
+    mcp = DummyMCP()
+    register_all_tools(mcp, profile=McpProfile.HERMES_PAPER_KIS)  # type: ignore[arg-type]
+    assert ALPACA_PAPER_READONLY_TOOL_NAMES <= mcp.tools.keys()
+
+
+@pytest.mark.unit
+def test_no_alpaca_live_or_mutating_alpaca_order_tools_registered() -> None:
+    mcp = DummyMCP()
+    register_all_tools(mcp, profile=McpProfile.DEFAULT)  # type: ignore[arg-type]
+
+    forbidden_names = {
+        "alpaca_live_get_account",
+        "alpaca_live_list_orders",
+        "alpaca_paper_submit_order",
+        "alpaca_paper_place_order",
+        "alpaca_paper_cancel_order",
+        "alpaca_paper_replace_order",
+        "alpaca_paper_modify_order",
+    }
+    assert forbidden_names.isdisjoint(mcp.tools.keys())
+    assert {name for name in mcp.tools if name.startswith("alpaca_live_")} == set()
+    assert {
+        name
+        for name in mcp.tools
+        if name.startswith("alpaca_paper_")
+        and any(
+            verb in name for verb in ("submit", "place", "cancel", "replace", "modify")
+        )
+    } == set()
+
+
+@pytest.mark.unit
+def test_existing_generic_order_tools_are_not_alpaca_tools() -> None:
+    # ROB-69 adds explicit read-only Alpaca paper names only; it does not route
+    # Alpaca through legacy generic order mutation tools.
+    assert not any(name.startswith("alpaca_") for name in ORDER_TOOL_NAMES)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_account_handler_uses_mocked_service(
+    fake_service: FakeAlpacaPaperService,
+) -> None:
+    payload = await alpaca_paper_get_account()
+    assert payload["success"] is True
+    assert payload["account_mode"] == "alpaca_paper"
+    assert payload["account"]["status"] == "ACTIVE"
+    assert payload["account"]["cash"] == "100000"
+    assert fake_service.calls == [("get_account", {})]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_cash_handler_uses_mocked_service(
+    fake_service: FakeAlpacaPaperService,
+) -> None:
+    payload = await alpaca_paper_get_cash()
+    assert payload["cash"] == {"cash": "100000", "buying_power": "200000"}
+    assert fake_service.calls == [("get_cash", {})]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_list_positions_handler_serializes_positions(
+    fake_service: FakeAlpacaPaperService,
+) -> None:
+    payload = await alpaca_paper_list_positions()
+    assert payload["count"] == 1
+    assert payload["positions"][0]["symbol"] == "AAPL"
+    assert payload["positions"][0]["qty"] == "2"
+    assert fake_service.calls == [("list_positions", {})]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_list_orders_handler_forwards_filters(
+    fake_service: FakeAlpacaPaperService,
+) -> None:
+    payload = await alpaca_paper_list_orders(status="open", limit=10)
+    assert payload["count"] == 1
+    assert payload["orders"][0]["id"] == "order-1"
+    assert fake_service.calls == [("list_orders", {"status": "open", "limit": 10})]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_order_handler_requires_non_blank_id(
+    fake_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError, match="order_id is required"):
+        await alpaca_paper_get_order("   ")
+    assert fake_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_order_handler_forwards_trimmed_id(
+    fake_service: FakeAlpacaPaperService,
+) -> None:
+    payload = await alpaca_paper_get_order(" order-123 ")
+    assert payload["order"]["id"] == "order-123"
+    assert fake_service.calls == [("get_order", {"order_id": "order-123"})]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_list_assets_handler_forwards_status_and_class(
+    fake_service: FakeAlpacaPaperService,
+) -> None:
+    payload = await alpaca_paper_list_assets(status="active", asset_class="crypto")
+    assert payload["count"] == 1
+    assert payload["assets"][0]["class"] == "us_equity"
+    assert fake_service.calls == [
+        ("list_assets", {"status": "active", "asset_class": "crypto"})
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_list_fills_handler_parses_window_and_forwards_limit(
+    fake_service: FakeAlpacaPaperService,
+) -> None:
+    payload = await alpaca_paper_list_fills(
+        after="2026-01-01T00:00:00Z",
+        until="2026-01-02T00:00:00+00:00",
+        limit=10,
+    )
+    assert payload["count"] == 1
+    assert payload["fills"][0]["id"] == "fill-1"
+    call = fake_service.calls[0]
+    assert call[0] == "list_fills"
+    assert call[1]["limit"] == 10
+    assert call[1]["after"].isoformat() == "2026-01-01T00:00:00+00:00"
+    assert call[1]["until"].isoformat() == "2026-01-02T00:00:00+00:00"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_limit_validation_happens_before_service_call(
+    fake_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError, match="limit must be >= 1"):
+        await alpaca_paper_list_orders(limit=0)
+    with pytest.raises(ValueError, match="limit must be >= 1"):
+        await alpaca_paper_list_fills(limit=0)
+    assert fake_service.calls == []


### PR DESCRIPTION
## Summary
- Add explicit Alpaca paper read-only MCP tools for account, cash, positions, orders, order lookup, assets, and fills.
- Register the tools in the MCP read-only surface for both default and paper-KIS profiles while preserving Alpaca paper endpoint guard behavior through `AlpacaPaperBrokerService`.
- Add mocked handler/registration safety tests and update isolation/docs for the Alpaca dashboard `/v2` vs env base URL pitfall.

## Safety boundaries
- Read-only only: no `alpaca_paper_submit_order`, cancel, replace, modify, or place-order tool is added.
- No `alpaca_live_*` tools or live config namespace.
- No generic Alpaca routing through `place_order`, `cancel_order`, or `modify_order`.
- No `paper_001` / registry / profile / strategy modeling and no DB schema changes.
- No secrets printed or changed.

## Verification
- `uv run pytest tests/test_alpaca_paper_config.py tests/test_alpaca_paper_service_endpoint_guard.py tests/test_alpaca_paper_service_methods.py tests/test_alpaca_paper_isolation.py -q` — 23 passed
- `uv run pytest tests/test_mcp_alpaca_paper_tools.py -q` — 13 passed
- `uv run pytest tests/test_mcp_profiles.py tests/test_mcp_account_modes.py -q` — 26 passed
- `uv run ruff check app/mcp_server app/services/brokers/alpaca tests/test_mcp_alpaca_paper_tools.py tests/test_alpaca_paper_isolation.py` — passed
- `uv run ty check app/mcp_server app/services/brokers/alpaca tests/test_mcp_alpaca_paper_tools.py tests/test_alpaca_paper_isolation.py` — passed
- Opus diff review: `review_passed`

Linear: ROB-69