### PR TITLE
docs(ROB-71): add Alpaca paper readonly smoke runbook

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -140,6 +140,9 @@ Safety boundary: there are no Alpaca live MCP tools in this issue and no
 or generic Alpaca order-routing surface. These smoke tools are for paper account
 visibility only.
 
+Operator runbook: [`docs/runbooks/alpaca-paper-readonly-smoke.md`](../../docs/runbooks/alpaca-paper-readonly-smoke.md)
+Smoke helper: `scripts/smoke/alpaca_paper_readonly_smoke.py` (argumentless, read-only, exits non-zero on failure)
+
 ### Account Routing
 
 MCP account-facing tools use `account_mode` to avoid mixing DB simulation,

--- a/docs/runbooks/alpaca-paper-readonly-smoke.md
+++ b/docs/runbooks/alpaca-paper-readonly-smoke.md
@@ -1,0 +1,190 @@
+# Alpaca Paper Read-Only Smoke Check — Operator Runbook
+
+Owner: Ops
+Related issues: ROB-71 / ROB-69
+
+Verify that the deployed Alpaca paper MCP tools are reachable and healthy without mutating any broker state.
+
+## Scope and safety boundary
+
+This runbook covers the 7 read-only MCP tools in `ALPACA_PAPER_READONLY_TOOL_NAMES` (defined in `app/mcp_server/tooling/alpaca_paper.py`). It covers account, cash, positions, open orders, single-order lookup when an open order exists, assets, and fills.
+
+Hard safety rules:
+
+- Do **not** submit, place, cancel, replace, modify, or otherwise mutate any order.
+- Do **not** use a generic order route.
+- Do **not** print or paste Alpaca API keys, secrets, account numbers, or full raw broker payloads.
+- Do **not** edit production files under `/Users/mgh3326/services/auto_trader/` while following this smoke runbook.
+- Do **not** reintroduce `paper_001` registry/profile/strategy/DB-row modeling.
+- `ALPACA_PAPER_BASE_URL` must be unset or exactly `https://paper-api.alpaca.markets` without `/v2`. The service appends `/v2/...` internally.
+- Forbidden endpoint (safety note — do not set as target): the live trading endpoint (`https://api.alpaca.markets`) is explicitly rejected by the Alpaca paper endpoint guard before network calls.
+
+## Step 1 — Verify repo/main vs production SHA
+
+Run from the operator checkout:
+
+```bash
+cd /Users/mgh3326/work/auto_trader
+git fetch origin main production --prune
+printf 'repo_HEAD=' && git rev-parse HEAD
+printf 'origin_main=' && git rev-parse origin/main
+printf 'origin_production=' && git rev-parse origin/production
+printf 'native_current=' && git -C /Users/mgh3326/services/auto_trader/current rev-parse HEAD
+```
+
+Interpretation:
+
+- If `repo_HEAD != origin_main`, mark **BLOCKED** until the checkout is updated.
+- If `native_current != origin_production`, mark **BLOCKED** until the native production release is reconciled.
+- If `origin_main != origin_production`, record it. This can be **PASS** only if the operator intentionally smokes the currently deployed production release rather than latest main.
+
+## Step 2 — Verify environment without printing secrets
+
+Check presence and lengths only. Never echo secret values.
+
+```bash
+python - <<'PY'
+import os
+for key in ('ALPACA_PAPER_API_KEY', 'ALPACA_PAPER_API_SECRET'):
+    value = os.environ.get(key, '')
+    print(f'{key}: present={bool(value)} len={len(value)}')
+base = os.environ.get('ALPACA_PAPER_BASE_URL', '<unset, will default>')
+print(f'ALPACA_PAPER_BASE_URL: {base}')
+PY
+```
+
+Expected:
+
+- API key and secret are present with non-zero lengths.
+- `ALPACA_PAPER_BASE_URL` is either unset or exactly `https://paper-api.alpaca.markets`.
+- `https://paper-api.alpaca.markets/v2` is invalid because the service appends `/v2/...` internally and would produce duplicated `/v2/v2/...` requests.
+- Any live/data endpoint configuration is **BLOCKED**.
+
+## Step 3 — Run local guard tests
+
+```bash
+uv run pytest tests/test_alpaca_paper_config.py tests/test_alpaca_paper_isolation.py tests/test_mcp_alpaca_paper_tools.py -q
+```
+
+Expected: all tests pass before live paper smoke. If they fail, mark **BLOCKED** and do not continue.
+
+## Step 4 — Confirm the 7 read-only tools are present
+
+```bash
+uv run python - <<'PY'
+from app.mcp_server.tooling.alpaca_paper import ALPACA_PAPER_READONLY_TOOL_NAMES
+for name in sorted(ALPACA_PAPER_READONLY_TOOL_NAMES):
+    print(name)
+print('count=', len(ALPACA_PAPER_READONLY_TOOL_NAMES))
+PY
+```
+
+Expected exactly 7 names:
+
+- `alpaca_paper_get_account`
+- `alpaca_paper_get_cash`
+- `alpaca_paper_get_order`
+- `alpaca_paper_list_assets`
+- `alpaca_paper_list_fills`
+- `alpaca_paper_list_orders`
+- `alpaca_paper_list_positions`
+
+If any registered Alpaca paper MCP name includes `submit`, `place`, `cancel`, `replace`, or `modify`, mark **BLOCKED**.
+
+## Step 5 — Run `hermes mcp test auto_trader`
+
+Use the operator's existing Hermes CLI configuration for the deployed MCP server:
+
+```bash
+mkdir -p .smoke
+hermes mcp test auto_trader 2>&1 | tee ".smoke/alpaca-paper-mcp-test-$(date +%Y%m%d-%H%M%S).log"
+```
+
+Expected:
+
+- MCP connection succeeds.
+- The 7 Alpaca paper read-only tool names from Step 4 are visible.
+- No `alpaca_live_*` tool is visible.
+- No Alpaca submit/place/cancel/replace/modify tool is visible.
+
+If the command prints a credential value, redact it before sharing the log and file a follow-up hardening issue. Do not paste unredacted logs into Linear, Discord, or Paperclip.
+
+## Step 6 — Run the read-only helper script
+
+```bash
+uv run python scripts/smoke/alpaca_paper_readonly_smoke.py
+```
+
+The helper is argumentless by design. It calls only the 7 read-only handlers, prints counts/status only, and exits non-zero if any required call fails.
+
+Expected successful shape:
+
+```text
+  [OK] alpaca_paper_get_account: status=ACTIVE
+  [OK] alpaca_paper_get_cash: cash_set=True
+  [OK] alpaca_paper_list_positions: count=0
+  [OK] alpaca_paper_list_orders: count=0
+  [OK] alpaca_paper_get_order: skipped: no orders to inspect
+  [OK] alpaca_paper_list_assets: count=8742
+  [OK] alpaca_paper_list_fills: count=0
+summary: PASS tools_ok=7/7
+```
+
+Notes:
+
+- `count=0` is normal for a fresh paper account with no open orders or fills.
+- `alpaca_paper_get_order` is skipped and counted as OK when no open orders exist. When open orders are present, the script derives one order id from `list_orders(status="open", limit=1)` and fetches it read-only.
+- The script must never print full account, position, order, asset, or fill records.
+
+## Step 7 — Classify result
+
+Use one of these labels in the operator report.
+
+### PASS
+
+All of the following are true:
+
+- Repo/production SHA checks are understood and not blocked.
+- Env presence checks pass and base URL is unset or exactly `https://paper-api.alpaca.markets`.
+- Local guard tests pass.
+- `hermes mcp test auto_trader` connects and lists the expected 7 read-only tools.
+- Helper script exits `0` and prints `summary: PASS tools_ok=7/7`.
+- No forbidden tool name or write-path endpoint is observed.
+
+### PARTIAL
+
+Use **PARTIAL** when the safety boundary is intact but a read-only upstream call fails. Examples:
+
+- `hermes mcp test auto_trader` connects, tool inventory is correct, but one Alpaca read-only call returns a rate limit or transient upstream error.
+- The helper exits non-zero with one or more `[FAIL]` lines that are not configuration/endpoint guard failures.
+
+Record the failed tool name and exception class, but do not paste raw payloads or secrets.
+
+### BLOCKED
+
+Use **BLOCKED** for any safety or prerequisite failure:
+
+- Checkout or production SHA cannot be verified.
+- API key/secret presence check fails.
+- Base URL contains `/v2`, points to a live/data endpoint, or raises `AlpacaPaperEndpointError`.
+- Local guard tests fail.
+- `hermes mcp test auto_trader` cannot connect.
+- A forbidden tool name appears (`submit`, `place`, `cancel`, `replace`, or `modify`).
+- Any generic Alpaca order route appears.
+- The script or command output contains an unredacted secret.
+
+## Step 8 — Report template
+
+Paste a short report like this, with no secrets and no raw broker payloads:
+
+```text
+ROB-71 Alpaca paper read-only smoke: PASS|PARTIAL|BLOCKED
+repo_HEAD: <sha>
+origin_main: <sha>
+origin_production: <sha>
+native_current: <sha>
+hermes_mcp_test: PASS|PARTIAL|BLOCKED
+helper_summary: summary: PASS tools_ok=7/7
+notes: <redacted exception class/tool name only, if any>
+safety: no submit/place/cancel/replace/modify calls; no generic order route; no secrets printed; base URL has no /v2.
+```

--- a/scripts/smoke/alpaca_paper_readonly_smoke.py
+++ b/scripts/smoke/alpaca_paper_readonly_smoke.py
@@ -1,0 +1,123 @@
+"""Argumentless read-only smoke check for Alpaca paper MCP tools (ROB-71).
+
+Calls every tool in ALPACA_PAPER_READONLY_TOOL_NAMES once, prints counts/status
+only (never raw payloads), and exits non-zero if any call fails.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from app.mcp_server.tooling.alpaca_paper import (
+    ALPACA_PAPER_READONLY_TOOL_NAMES,
+    alpaca_paper_get_account,
+    alpaca_paper_get_cash,
+    alpaca_paper_get_order,
+    alpaca_paper_list_assets,
+    alpaca_paper_list_fills,
+    alpaca_paper_list_orders,
+    alpaca_paper_list_positions,
+)
+
+
+async def run_smoke() -> int:
+    """Run all read-only Alpaca paper checks; return 0 if all OK, 1 otherwise."""
+    results: list[tuple[str, bool, str]] = []
+
+    async def _probe(name: str, coro, note_fn) -> None:  # type: ignore[type-arg]
+        try:
+            payload = await coro
+            results.append((name, True, note_fn(payload)))
+        except Exception as exc:  # noqa: BLE001
+            results.append((name, False, f"ERROR: {type(exc).__name__}: {exc}"))
+
+    await _probe(
+        "alpaca_paper_get_account",
+        alpaca_paper_get_account(),
+        lambda p: f"status={p['account'].get('status', '?')}",
+    )
+
+    await _probe(
+        "alpaca_paper_get_cash",
+        alpaca_paper_get_cash(),
+        lambda p: f"cash_set={p['cash'].get('cash') is not None}",
+    )
+
+    await _probe(
+        "alpaca_paper_list_positions",
+        alpaca_paper_list_positions(),
+        lambda p: f"count={p['count']}",
+    )
+
+    # list_orders also seeds the order_id for the get_order probe below
+    orders_payload: dict | None = None  # type: ignore[type-arg]
+    try:
+        orders_payload = await alpaca_paper_list_orders(status="open", limit=1)
+        results.append(
+            ("alpaca_paper_list_orders", True, f"count={orders_payload['count']}")
+        )
+    except Exception as exc:  # noqa: BLE001
+        results.append(
+            (
+                "alpaca_paper_list_orders",
+                False,
+                f"ERROR: {type(exc).__name__}: {exc}",
+            )
+        )
+
+    # get_order: derive id from list_orders; skip as OK when no orders exist
+    order_id: str | None = None
+    if orders_payload and orders_payload.get("orders"):
+        order_id = orders_payload["orders"][0].get("id")
+
+    if order_id:
+        await _probe(
+            "alpaca_paper_get_order",
+            alpaca_paper_get_order(order_id),
+            lambda p: f"status={p['order'].get('status', '?')}",
+        )
+    else:
+        results.append(
+            ("alpaca_paper_get_order", True, "skipped: no orders to inspect")
+        )
+
+    await _probe(
+        "alpaca_paper_list_assets",
+        alpaca_paper_list_assets(status="active", asset_class="us_equity"),
+        lambda p: f"count={p['count']}",
+    )
+
+    await _probe(
+        "alpaca_paper_list_fills",
+        alpaca_paper_list_fills(limit=5),
+        lambda p: f"count={p['count']}",
+    )
+
+    # Confirm every expected tool was exercised
+    exercised = {name for name, _, _ in results}
+    missing = ALPACA_PAPER_READONLY_TOOL_NAMES - exercised
+    if missing:
+        results.append(("_inventory", False, f"missing tools: {sorted(missing)}"))
+
+    all_ok = True
+    ok_tool_count = 0
+    for name, ok, note in results:
+        tag = "OK" if ok else "FAIL"
+        print(f"  [{tag}] {name}: {note}")
+        if name in ALPACA_PAPER_READONLY_TOOL_NAMES and ok:
+            ok_tool_count += 1
+        if not ok:
+            all_ok = False
+
+    classification = "PASS" if all_ok and ok_tool_count == 7 else "PARTIAL"
+    print(f"summary: {classification} tools_ok={ok_tool_count}/7")
+    return 0 if classification == "PASS" else 1
+
+
+def main() -> None:
+    sys.exit(asyncio.run(run_smoke()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_alpaca_paper_smoke_safety.py
+++ b/tests/test_alpaca_paper_smoke_safety.py
@@ -1,0 +1,99 @@
+"""Safety tests for scripts/smoke/alpaca_paper_readonly_smoke.py (ROB-71)."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from app.mcp_server.tooling.alpaca_paper import (
+    reset_alpaca_paper_service_factory,
+    set_alpaca_paper_service_factory,
+)
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "smoke"
+    / "alpaca_paper_readonly_smoke.py"
+)
+
+FORBIDDEN_VERBS = {
+    "submit_order",
+    "cancel_order",
+    "place_order",
+    "modify_order",
+    "replace_order",
+}
+
+
+@pytest.mark.unit
+def test_smoke_script_exists() -> None:
+    assert SCRIPT_PATH.exists(), f"smoke script not found: {SCRIPT_PATH}"
+
+
+@pytest.mark.unit
+def test_smoke_script_no_forbidden_order_verbs() -> None:
+    """The smoke script must not reference any mutating order verb."""
+    text = SCRIPT_PATH.read_text(encoding="utf-8")
+    found = [v for v in FORBIDDEN_VERBS if v in text]
+    assert not found, f"smoke script references forbidden order verbs: {found}"
+
+
+@pytest.mark.unit
+def test_smoke_script_references_readonly_tool_names_constant() -> None:
+    """The script must use ALPACA_PAPER_READONLY_TOOL_NAMES for inventory coverage."""
+    text = SCRIPT_PATH.read_text(encoding="utf-8")
+    assert "ALPACA_PAPER_READONLY_TOOL_NAMES" in text
+
+
+@pytest.mark.unit
+def test_smoke_script_no_raw_payload_print() -> None:
+    """print() calls must not dump raw broker objects by name."""
+    source = SCRIPT_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    raw_names = {
+        "payload",
+        "result",
+        "orders",
+        "positions",
+        "account",
+        "fills",
+        "assets",
+        "order",
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "print":
+                for arg in node.args:
+                    if isinstance(arg, ast.Name) and arg.id in raw_names:
+                        pytest.fail(
+                            f"smoke script calls print({arg.id}) which would dump a raw broker payload"
+                        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_run_smoke_exits_zero_when_all_tools_succeed(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """run_smoke() returns 0 when every tool call succeeds via the fake service."""
+    from tests.test_mcp_alpaca_paper_tools import FakeAlpacaPaperService
+
+    service = FakeAlpacaPaperService()
+    set_alpaca_paper_service_factory(lambda: service)  # type: ignore[arg-type]
+    try:
+        spec = importlib.util.spec_from_file_location("_alpaca_smoke", SCRIPT_PATH)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+        exit_code = await module.run_smoke()
+    finally:
+        reset_alpaca_paper_service_factory()
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "summary: PASS tools_ok=7/7" in captured.out


### PR DESCRIPTION
## Summary
- Add a production operator runbook for Alpaca paper read-only MCP smoke checks.
- Add an argumentless read-only smoke helper for the 7 Alpaca paper MCP tools.
- Add safety tests to prevent forbidden order verbs and raw payload printing.
- Link the runbook/helper from the MCP README.

## Safety
- Read-only runbook/script only.
- No order submit/place/cancel/replace/modify calls.
- No generic order route.
- No secrets printed or changed.
- No production direct edits.
- No `paper_001` registry/profile/strategy/DB-row modeling reintroduced.
- Base URL documented as `https://paper-api.alpaca.markets` without `/v2`; live endpoint appears only as forbidden safety prose.

## Validation
- `uv run ruff format --check scripts/smoke/alpaca_paper_readonly_smoke.py tests/test_alpaca_paper_smoke_safety.py`
- `uv run ruff check scripts/smoke/alpaca_paper_readonly_smoke.py tests/test_alpaca_paper_smoke_safety.py`
- `uv run pytest tests/test_mcp_alpaca_paper_tools.py tests/test_alpaca_paper_isolation.py tests/test_alpaca_paper_smoke_safety.py tests/test_alpaca_paper_config.py -q` — 26 passed, 2 existing warnings
- Opus diff review: `review_passed`

## Notes
- No production deploy or live Alpaca smoke was performed in this branch; this issue adds the safe operator runbook/helper for a future operator-run smoke.
