### PR TITLE
ROB-70: add Alpaca paper order preview MCP tool

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -143,6 +143,66 @@ visibility only.
 Operator runbook: [`docs/runbooks/alpaca-paper-readonly-smoke.md`](../../docs/runbooks/alpaca-paper-readonly-smoke.md)
 Smoke helper: `scripts/smoke/alpaca_paper_readonly_smoke.py` (argumentless, read-only, exits non-zero on failure)
 
+### Alpaca paper order preview
+
+ROB-70 adds `alpaca_paper_preview_order`: a side-effect-free validator + echo tool.
+
+**Signature:**
+```
+alpaca_paper_preview_order(
+    symbol,          # US equity ticker (1-10 chars, uppercased)
+    side,            # "buy" | "sell"
+    type,            # "market" | "limit"  (stop/stop_limit deferred)
+    qty=None,        # Decimal quantity (xor notional)
+    notional=None,   # Decimal notional USD (xor qty; market orders only)
+    time_in_force="day",   # "day" | "gtc" | "ioc" | "fok"
+    limit_price=None,      # required for limit orders, forbidden for market
+    stop_price=None,       # always rejected (deferred)
+    client_order_id=None,  # optional, 1-48 chars
+    asset_class="us_equity",  # only "us_equity" supported
+)
+```
+
+**Validation rules (enforced before any service call):**
+- `symbol`: non-empty after strip; uppercased; 1–10 chars
+- `side`: `"buy"` or `"sell"`; case-insensitive
+- `type`: `"market"` or `"limit"`; stop/stop_limit deferred
+- `qty` xor `notional`: exactly one required
+- `notional` + `type="limit"`: rejected (Alpaca only supports notional for market orders)
+- `limit_price`: required for `type="limit"`, forbidden for `type="market"`, must be > 0
+- `stop_price`: always rejected with explicit error
+- `asset_class`: only `"us_equity"`; `"crypto"` and others rejected
+- `time_in_force`: one of `"day"`, `"gtc"`, `"ioc"`, `"fok"`
+
+**Return shape:**
+```json
+{
+  "success": true,
+  "account_mode": "alpaca_paper",
+  "source": "alpaca_paper",
+  "preview": true,
+  "submitted": false,
+  "order_request": { "symbol": "AAPL", "side": "buy", "type": "market", ... },
+  "estimated_cost": "360" | null,
+  "account_context": { "cash": "...", "buying_power": "..." } | null,
+  "would_exceed_buying_power": false | null,
+  "warnings": []
+}
+```
+
+**Safety boundary:** Preview is a pure validator + echo. It does NOT call
+POST `/v2/orders`. There is no `alpaca_paper_submit_order` / `place_order` /
+`cancel_order` / `modify_order` / `replace_order` tool.
+
+Account context (cash/buying_power) is fetched via read-only `GET /v2/account`
+and fails soft: if unavailable, `account_context` is `null` and
+`"context_unavailable"` is added to `warnings`. The preview still returns
+`success: true` with the normalized `order_request` echo.
+
+The endpoint guard applies: if `ALPACA_PAPER_BASE_URL` is ever set to the live
+endpoint, the service constructor rejects it and the tool raises
+`AlpacaPaperEndpointError` (fail closed).
+
 ### Account Routing
 
 MCP account-facing tools use `account_mode` to avoid mixing DB simulation,

--- a/app/mcp_server/tooling/alpaca_paper_preview.py
+++ b/app/mcp_server/tooling/alpaca_paper_preview.py
@@ -1,0 +1,295 @@
+"""Side-effect-free Alpaca paper MCP order preview/validation tool (ROB-70).
+
+alpaca_paper_preview_order is a pure validator + echo. It does NOT call
+POST /v2/orders. There is no alpaca_paper_submit_order / place_order /
+cancel_order / modify_order / replace_order tool.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, field_validator, model_validator
+
+from app.services.brokers.alpaca.exceptions import (
+    AlpacaPaperConfigurationError,
+    AlpacaPaperEndpointError,
+    AlpacaPaperRequestError,
+)
+from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+ALPACA_PAPER_PREVIEW_TOOL_NAMES: set[str] = {"alpaca_paper_preview_order"}
+
+# Referenced by tests to confirm these methods are never called on the preview path
+_FORBIDDEN_SERVICE_METHODS = ("submit_order", "cancel_order")
+
+ServiceFactory = Callable[[], AlpacaPaperBrokerService]
+
+
+def _default_preview_service_factory() -> AlpacaPaperBrokerService:
+    """Build the guarded Alpaca paper service using app settings."""
+    return AlpacaPaperBrokerService()
+
+
+_preview_service_factory: ServiceFactory = _default_preview_service_factory
+
+
+def set_alpaca_paper_preview_service_factory(factory: ServiceFactory) -> None:
+    """Override the preview service factory for tests."""
+    global _preview_service_factory
+    _preview_service_factory = factory
+
+
+def reset_alpaca_paper_preview_service_factory() -> None:
+    """Restore the default preview service factory after tests."""
+    global _preview_service_factory
+    _preview_service_factory = _default_preview_service_factory
+
+
+class PreviewOrderInput(BaseModel):
+    """Strict input validation model for alpaca_paper_preview_order."""
+
+    symbol: str
+    side: str
+    type: str  # noqa: A003
+    qty: Decimal | None = None
+    notional: Decimal | None = None
+    time_in_force: str = "day"
+    limit_price: Decimal | None = None
+    stop_price: Decimal | None = None
+    client_order_id: str | None = None
+    asset_class: str = "us_equity"
+
+    @field_validator("symbol")
+    @classmethod
+    def validate_symbol(cls, v: str) -> str:
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("symbol must not be blank")
+        if len(stripped) > 10:
+            raise ValueError("symbol must be 1-10 characters")
+        return stripped.upper()
+
+    @field_validator("side")
+    @classmethod
+    def validate_side(cls, v: str) -> str:
+        normalized = v.strip().lower()
+        if normalized not in {"buy", "sell"}:
+            raise ValueError("side must be 'buy' or 'sell'")
+        return normalized
+
+    @field_validator("type")
+    @classmethod
+    def validate_order_type(cls, v: str) -> str:
+        normalized = v.strip().lower()
+        if normalized not in {"market", "limit"}:
+            raise ValueError("order type must be 'market' or 'limit'")
+        return normalized
+
+    @field_validator("qty")
+    @classmethod
+    def validate_qty(cls, v: Decimal | None) -> Decimal | None:
+        if v is None:
+            return None
+        if not v.is_finite():
+            raise ValueError("qty must be a finite number")
+        if v <= 0:
+            raise ValueError("qty must be > 0")
+        if v > Decimal("1000000"):
+            raise ValueError("qty exceeds maximum allowed value")
+        return v
+
+    @field_validator("notional")
+    @classmethod
+    def validate_notional(cls, v: Decimal | None) -> Decimal | None:
+        if v is None:
+            return None
+        if not v.is_finite():
+            raise ValueError("notional must be a finite number")
+        if v <= 0:
+            raise ValueError("notional must be > 0")
+        if v > Decimal("10000000"):
+            raise ValueError("notional exceeds maximum allowed value")
+        return v
+
+    @field_validator("stop_price")
+    @classmethod
+    def validate_stop_price(cls, v: Decimal | None) -> Decimal | None:
+        if v is not None:
+            raise ValueError("stop_price not supported in preview")
+        return None
+
+    @field_validator("time_in_force")
+    @classmethod
+    def validate_tif(cls, v: str) -> str:
+        normalized = v.strip().lower()
+        if normalized not in {"day", "gtc", "ioc", "fok"}:
+            raise ValueError("time_in_force must be one of: day, gtc, ioc, fok")
+        return normalized
+
+    @field_validator("client_order_id")
+    @classmethod
+    def validate_client_order_id(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("client_order_id must not be blank")
+        if len(stripped) > 48:
+            raise ValueError("client_order_id must be <= 48 characters")
+        return stripped
+
+    @field_validator("asset_class")
+    @classmethod
+    def validate_asset_class(cls, v: str) -> str:
+        normalized = v.strip().lower()
+        if normalized != "us_equity":
+            raise ValueError(
+                f"asset_class '{v}' not supported in preview (us_equity only)"
+            )
+        return normalized
+
+    @field_validator("limit_price")
+    @classmethod
+    def validate_limit_price_positive(cls, v: Decimal | None) -> Decimal | None:
+        if v is not None and v <= 0:
+            raise ValueError("limit_price must be > 0")
+        return v
+
+    @model_validator(mode="after")
+    def validate_cross_field_rules(self) -> PreviewOrderInput:
+        has_qty = self.qty is not None
+        has_notional = self.notional is not None
+
+        if has_qty and has_notional:
+            raise ValueError("exactly one of qty or notional is required")
+        if not has_qty and not has_notional:
+            raise ValueError("exactly one of qty or notional is required")
+
+        # notional + limit type is rejected — Alpaca only supports notional for market orders
+        if has_notional and self.type == "limit":
+            raise ValueError("notional is not supported for limit orders")
+
+        if self.type == "limit" and self.limit_price is None:
+            raise ValueError("limit_price is required for limit orders")
+
+        if self.type == "market" and self.limit_price is not None:
+            raise ValueError("limit_price is not allowed for market orders")
+
+        return self
+
+
+async def alpaca_paper_preview_order(
+    symbol: str,
+    side: str,
+    type: str,  # noqa: A002
+    qty: Decimal | None = None,
+    notional: Decimal | None = None,
+    time_in_force: str = "day",
+    limit_price: Decimal | None = None,
+    stop_price: Decimal | None = None,
+    client_order_id: str | None = None,
+    asset_class: str = "us_equity",
+) -> dict[str, Any]:
+    """Preview and validate an Alpaca paper US equity order without submitting it.
+
+    Pure validator + echo — preview only, no side effects, does not submit.
+    Does NOT call POST /v2/orders. There is no alpaca_paper_submit_order,
+    place_order, cancel_order, modify_order, or replace_order tool.
+    """
+    validated = PreviewOrderInput(
+        symbol=symbol,
+        side=side,
+        type=type,
+        qty=qty,
+        notional=notional,
+        time_in_force=time_in_force,
+        limit_price=limit_price,
+        stop_price=stop_price,
+        client_order_id=client_order_id,
+        asset_class=asset_class,
+    )
+
+    order_request: dict[str, Any] = {
+        "symbol": validated.symbol,
+        "side": validated.side,
+        "type": validated.type,
+        "time_in_force": validated.time_in_force,
+        "qty": str(validated.qty) if validated.qty is not None else None,
+        "notional": str(validated.notional) if validated.notional is not None else None,
+        "limit_price": str(validated.limit_price)
+        if validated.limit_price is not None
+        else None,
+        "stop_price": None,
+        "client_order_id": validated.client_order_id,
+        "asset_class": validated.asset_class,
+    }
+
+    warnings: list[str] = []
+    account_context: dict[str, Any] | None = None
+    estimated_cost: str | None = None
+    would_exceed_buying_power: bool | None = None
+
+    try:
+        service = _preview_service_factory()
+        cash = await service.get_cash()
+        account_context = {
+            "cash": str(cash.cash),
+            "buying_power": str(cash.buying_power),
+        }
+    except AlpacaPaperEndpointError:
+        raise  # fail closed — live endpoint is never allowed
+    except (AlpacaPaperConfigurationError, AlpacaPaperRequestError):
+        warnings.append("context_unavailable")
+
+    if (
+        validated.qty is not None
+        and validated.limit_price is not None
+        and account_context is not None
+    ):
+        cost = validated.qty * validated.limit_price
+        estimated_cost = str(cost)
+        would_exceed_buying_power = cost > Decimal(account_context["buying_power"])
+
+    return {
+        "success": True,
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper",
+        "preview": True,
+        "submitted": False,
+        "order_request": order_request,
+        "estimated_cost": estimated_cost,
+        "account_context": account_context,
+        "would_exceed_buying_power": would_exceed_buying_power,
+        "warnings": warnings,
+    }
+
+
+def register_alpaca_paper_preview_tools(mcp: FastMCP) -> None:
+    """Register Alpaca paper order preview MCP tool."""
+    _ = mcp.tool(
+        name="alpaca_paper_preview_order",
+        description=(
+            "Preview and validate an Alpaca paper US equity order without submitting it. "
+            "Pure validator + echo — preview only, no side effects, does not submit. "
+            "Does NOT call POST /v2/orders. "
+            "There is no alpaca_paper_submit_order / place_order / cancel_order / "
+            "modify_order / replace_order tool."
+        ),
+    )(alpaca_paper_preview_order)
+
+
+__all__ = [
+    "ALPACA_PAPER_PREVIEW_TOOL_NAMES",
+    "_FORBIDDEN_SERVICE_METHODS",
+    "PreviewOrderInput",
+    "alpaca_paper_preview_order",
+    "register_alpaca_paper_preview_tools",
+    "reset_alpaca_paper_preview_service_factory",
+    "set_alpaca_paper_preview_service_factory",
+]

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -22,6 +22,9 @@ from typing import TYPE_CHECKING
 
 from app.mcp_server.profiles import McpProfile
 from app.mcp_server.tooling.alpaca_paper import register_alpaca_paper_tools
+from app.mcp_server.tooling.alpaca_paper_preview import (
+    register_alpaca_paper_preview_tools,
+)
 from app.mcp_server.tooling.analysis_registration import register_analysis_tools
 from app.mcp_server.tooling.execution_comment_registration import (
     register_execution_comment_tools,
@@ -89,6 +92,7 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
     register_news_tools(mcp)
     register_market_brief_tools(mcp)
     register_alpaca_paper_tools(mcp)
+    register_alpaca_paper_preview_tools(mcp)
 
     # Always: read-only with account_mode (mock-safe via ROB-28)
     register_portfolio_tools(mcp)

--- a/tests/test_alpaca_paper_isolation.py
+++ b/tests/test_alpaca_paper_isolation.py
@@ -41,7 +41,10 @@ def test_no_router_imports_alpaca_paper():
 def test_only_explicit_readonly_mcp_tool_imports_alpaca_paper():
     """Only the ROB-69 read-only MCP tooling module may import Alpaca paper service."""
     mcp_dir = REPO_ROOT / "app" / "mcp_server"
-    allowed = {mcp_dir / "tooling" / "alpaca_paper.py"}
+    allowed = {
+        mcp_dir / "tooling" / "alpaca_paper.py",
+        mcp_dir / "tooling" / "alpaca_paper_preview.py",
+    }
     offenders = [
         p
         for p in _collect_python_files(mcp_dir)

--- a/tests/test_mcp_alpaca_paper_tools.py
+++ b/tests/test_mcp_alpaca_paper_tools.py
@@ -18,8 +18,15 @@ from app.mcp_server.tooling.alpaca_paper import (
     reset_alpaca_paper_service_factory,
     set_alpaca_paper_service_factory,
 )
+from app.mcp_server.tooling.alpaca_paper_preview import (
+    _FORBIDDEN_SERVICE_METHODS,
+    alpaca_paper_preview_order,
+    reset_alpaca_paper_preview_service_factory,
+    set_alpaca_paper_preview_service_factory,
+)
 from app.mcp_server.tooling.orders_registration import ORDER_TOOL_NAMES
 from app.mcp_server.tooling.registry import register_all_tools
+from app.services.brokers.alpaca.exceptions import AlpacaPaperRequestError
 from app.services.brokers.alpaca.schemas import (
     AccountSnapshot,
     Asset,
@@ -34,6 +41,7 @@ from tests._mcp_tooling_support import DummyMCP
 class FakeAlpacaPaperService:
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.submit_called: bool = False
 
     async def get_account(self) -> AccountSnapshot:
         self.calls.append(("get_account", {}))
@@ -119,6 +127,15 @@ class FakeAlpacaPaperService:
                 asset_class="us_equity",
             )
         ]
+
+    async def submit_order(self, request: Any) -> None:
+        self.submit_called = True
+        self.calls.append(("submit_order", {"request": request}))
+        raise AssertionError("submit_order must not be called on the preview path")
+
+    async def cancel_order(self, order_id: str) -> None:
+        self.calls.append(("cancel_order", {"order_id": order_id}))
+        raise AssertionError("cancel_order must not be called on the preview path")
 
     async def list_fills(
         self, *, after=None, until=None, limit: int | None = None
@@ -302,3 +319,418 @@ async def test_limit_validation_happens_before_service_call(
     with pytest.raises(ValueError, match="limit must be >= 1"):
         await alpaca_paper_list_fills(limit=0)
     assert fake_service.calls == []
+
+
+# ---------------------------------------------------------------------------
+# ROB-70: alpaca_paper_preview_order tests
+# ---------------------------------------------------------------------------
+
+
+class FakeAlpacaPaperServiceWithCashError(FakeAlpacaPaperService):
+    async def get_cash(self) -> CashBalance:
+        self.calls.append(("get_cash", {}))
+        raise AlpacaPaperRequestError("connection failed")
+
+
+@pytest.fixture
+def fake_preview_service() -> FakeAlpacaPaperService:
+    service = FakeAlpacaPaperService()
+    set_alpaca_paper_preview_service_factory(lambda: service)  # type: ignore[arg-type]
+    yield service
+    reset_alpaca_paper_preview_service_factory()
+
+
+@pytest.fixture
+def fake_preview_service_with_cash_error() -> FakeAlpacaPaperServiceWithCashError:
+    service = FakeAlpacaPaperServiceWithCashError()
+    set_alpaca_paper_preview_service_factory(lambda: service)  # type: ignore[arg-type]
+    yield service
+    reset_alpaca_paper_preview_service_factory()
+
+
+# --- 1. Registration / discoverability ---
+
+
+@pytest.mark.unit
+def test_registers_alpaca_paper_preview_tool_default_profile() -> None:
+    mcp = DummyMCP()
+    register_all_tools(mcp, profile=McpProfile.DEFAULT)  # type: ignore[arg-type]
+    assert "alpaca_paper_preview_order" in mcp.tools
+
+
+@pytest.mark.unit
+def test_registers_alpaca_paper_preview_tool_paper_profile() -> None:
+    mcp = DummyMCP()
+    register_all_tools(mcp, profile=McpProfile.HERMES_PAPER_KIS)  # type: ignore[arg-type]
+    assert "alpaca_paper_preview_order" in mcp.tools
+
+
+@pytest.mark.unit
+def test_preview_tool_description_documents_dry_run_and_no_submit() -> None:
+    from app.mcp_server.tooling.alpaca_paper_preview import (
+        register_alpaca_paper_preview_tools,
+    )
+
+    class _DescCapture:
+        def __init__(self) -> None:
+            self.descriptions: dict[str, str] = {}
+
+        def tool(self, name: str, description: str):
+            self.descriptions[name] = description
+
+            def decorator(func):
+                return func
+
+            return decorator
+
+    cap = _DescCapture()
+    register_alpaca_paper_preview_tools(cap)  # type: ignore[arg-type]
+    desc = cap.descriptions["alpaca_paper_preview_order"]
+    assert "preview" in desc.lower()
+    assert any(
+        kw in desc.lower()
+        for kw in ("no submit", "does not submit", "side-effect-free", "side effects")
+    )
+
+
+# --- 2. Forbidden-write absence ---
+
+
+@pytest.mark.unit
+def test_no_alpaca_paper_submit_or_cancel_or_modify_tools() -> None:
+    mcp = DummyMCP()
+    register_all_tools(mcp, profile=McpProfile.DEFAULT)  # type: ignore[arg-type]
+    forbidden = {
+        "alpaca_paper_submit_order",
+        "alpaca_paper_preview_submit",
+        "alpaca_paper_order_submit",
+        "alpaca_paper_replace",
+        "alpaca_paper_modify",
+        "alpaca_paper_cancel_order",
+        "alpaca_paper_place_order",
+    }
+    assert forbidden.isdisjoint(mcp.tools.keys())
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_handler_never_calls_service_submit_or_cancel(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    await alpaca_paper_preview_order(
+        symbol="AAPL",
+        side="buy",
+        type="market",
+        qty=Decimal("1"),
+    )
+    assert fake_preview_service.submit_called is False
+    method_names = [c[0] for c in fake_preview_service.calls]
+    assert "submit_order" not in method_names
+    assert "cancel_order" not in method_names
+
+
+@pytest.mark.unit
+def test_forbidden_service_methods_constant_covers_submit_and_cancel() -> None:
+    assert "submit_order" in _FORBIDDEN_SERVICE_METHODS
+    assert "cancel_order" in _FORBIDDEN_SERVICE_METHODS
+
+
+# --- 3. Validation (no service call) ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_rejects_invalid_side(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError):
+        await alpaca_paper_preview_order(
+            symbol="AAPL", side="hold", type="market", qty=Decimal("1")
+        )
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_rejects_invalid_order_type(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError):
+        await alpaca_paper_preview_order(
+            symbol="AAPL", side="buy", type="stop_limit", qty=Decimal("1")
+        )
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_rejects_non_positive_qty(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError):
+        await alpaca_paper_preview_order(
+            symbol="AAPL", side="buy", type="market", qty=Decimal("0")
+        )
+    with pytest.raises(ValueError):
+        await alpaca_paper_preview_order(
+            symbol="AAPL", side="buy", type="market", qty=Decimal("-1")
+        )
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_rejects_non_positive_notional(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError):
+        await alpaca_paper_preview_order(
+            symbol="AAPL", side="buy", type="market", notional=Decimal("0")
+        )
+    with pytest.raises(ValueError):
+        await alpaca_paper_preview_order(
+            symbol="AAPL", side="buy", type="market", notional=Decimal("-1")
+        )
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_rejects_both_qty_and_notional(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        await alpaca_paper_preview_order(
+            symbol="AAPL",
+            side="buy",
+            type="market",
+            qty=Decimal("1"),
+            notional=Decimal("100"),
+        )
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_rejects_neither_qty_nor_notional(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError, match="exactly one"):
+        await alpaca_paper_preview_order(symbol="AAPL", side="buy", type="market")
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_rejects_limit_without_limit_price(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError, match="limit_price is required"):
+        await alpaca_paper_preview_order(
+            symbol="AAPL", side="buy", type="limit", qty=Decimal("1")
+        )
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_rejects_market_with_limit_price(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError, match="limit_price is not allowed"):
+        await alpaca_paper_preview_order(
+            symbol="AAPL",
+            side="buy",
+            type="market",
+            qty=Decimal("1"),
+            limit_price=Decimal("100"),
+        )
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_rejects_notional_with_limit_type(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError, match="notional is not supported"):
+        await alpaca_paper_preview_order(
+            symbol="AAPL",
+            side="buy",
+            type="limit",
+            notional=Decimal("100"),
+        )
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_rejects_blank_symbol(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError, match="blank"):
+        await alpaca_paper_preview_order(
+            symbol="   ", side="buy", type="market", qty=Decimal("1")
+        )
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_rejects_crypto_asset_class(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError, match="crypto"):
+        await alpaca_paper_preview_order(
+            symbol="BTC",
+            side="buy",
+            type="market",
+            qty=Decimal("1"),
+            asset_class="crypto",
+        )
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_rejects_stop_price(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError, match="stop_price not supported"):
+        await alpaca_paper_preview_order(
+            symbol="AAPL",
+            side="buy",
+            type="market",
+            qty=Decimal("1"),
+            stop_price=Decimal("100"),
+        )
+    assert fake_preview_service.calls == []
+
+
+# --- 4. Happy paths ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_market_buy_qty_returns_normalized_echo(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    payload = await alpaca_paper_preview_order(
+        symbol="aapl",
+        side="BUY",
+        type="MARKET",
+        qty=Decimal("1"),
+    )
+    assert payload["preview"] is True
+    assert payload["submitted"] is False
+    assert payload["account_mode"] == "alpaca_paper"
+    req = payload["order_request"]
+    assert req["symbol"] == "AAPL"
+    assert req["side"] == "buy"
+    assert req["type"] == "market"
+    assert req["qty"] == "1"
+    assert req["notional"] is None
+    assert req["limit_price"] is None
+    assert req["time_in_force"] == "day"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_limit_buy_returns_estimated_cost_and_buying_power_check(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    payload = await alpaca_paper_preview_order(
+        symbol="AAPL",
+        side="buy",
+        type="limit",
+        qty=Decimal("2"),
+        limit_price=Decimal("180"),
+    )
+    assert payload["estimated_cost"] == "360"
+    assert payload["would_exceed_buying_power"] is False
+    assert payload["account_context"] is not None
+    assert payload["account_context"]["buying_power"] == "200000"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_flags_buying_power_exceeded(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    payload = await alpaca_paper_preview_order(
+        symbol="AAPL",
+        side="buy",
+        type="limit",
+        qty=Decimal("2000"),
+        limit_price=Decimal("180"),
+    )
+    assert payload["would_exceed_buying_power"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_market_notional_buy(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    payload = await alpaca_paper_preview_order(
+        symbol="AAPL",
+        side="buy",
+        type="market",
+        notional=Decimal("100"),
+    )
+    assert payload["order_request"]["notional"] == "100"
+    assert payload["order_request"]["qty"] is None
+    assert payload["estimated_cost"] is None
+    assert payload["would_exceed_buying_power"] is None
+
+
+# --- 5. Best-effort context fail-soft ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_when_get_cash_unavailable_returns_warning(
+    fake_preview_service_with_cash_error: FakeAlpacaPaperServiceWithCashError,
+) -> None:
+    payload = await alpaca_paper_preview_order(
+        symbol="AAPL",
+        side="buy",
+        type="market",
+        qty=Decimal("1"),
+    )
+    assert payload["success"] is True
+    assert payload["account_context"] is None
+    assert "context_unavailable" in payload["warnings"]
+    assert payload["would_exceed_buying_power"] is None
+
+
+# --- 6. Live endpoint fails closed ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_fails_closed_on_live_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services.brokers.alpaca.config import AlpacaPaperSettings
+    from app.services.brokers.alpaca.endpoints import LIVE_TRADING_BASE_URL
+    from app.services.brokers.alpaca.exceptions import AlpacaPaperEndpointError
+
+    def fake_from_app_settings() -> AlpacaPaperSettings:
+        return AlpacaPaperSettings(
+            api_key="pk-test",
+            api_secret="sk-test",
+            base_url=LIVE_TRADING_BASE_URL,
+        )
+
+    monkeypatch.setattr(
+        AlpacaPaperSettings, "from_app_settings", fake_from_app_settings
+    )
+
+    with pytest.raises(AlpacaPaperEndpointError):
+        await alpaca_paper_preview_order(
+            symbol="AAPL",
+            side="buy",
+            type="market",
+            qty=Decimal("1"),
+        )

--- a/tests/test_mcp_profiles.py
+++ b/tests/test_mcp_profiles.py
@@ -44,6 +44,16 @@ class TestDefaultProfile:
         assert KIS_MOCK_ORDER_TOOL_NAMES <= mcp.tools.keys()
 
 
+class TestAlpacaPaperPreviewProfile:
+    def test_preview_tool_registered_default_profile(self) -> None:
+        mcp = _build_mcp(McpProfile.DEFAULT)
+        assert "alpaca_paper_preview_order" in mcp.tools
+
+    def test_preview_tool_registered_hermes_paper_kis_profile(self) -> None:
+        mcp = _build_mcp(McpProfile.HERMES_PAPER_KIS)
+        assert "alpaca_paper_preview_order" in mcp.tools
+
+
 class TestHermesPaperKisProfile:
     def test_does_not_register_legacy_order_tools(self) -> None:
         mcp = _build_mcp(McpProfile.HERMES_PAPER_KIS)


### PR DESCRIPTION
## Summary
- Add explicit `alpaca_paper_preview_order` MCP tool for side-effect-free Alpaca paper order validation/preview.
- Register the preview tool for default and `hermes-paper-kis` MCP profiles and document its input/return contract.
- Add regression coverage for validation failures, live-endpoint fail-closed behavior, forbidden write/generic tool absence, and no submit/cancel path invocation.

## Safety notes
- Preview-only: no `POST /v2/orders`, no `DELETE /v2/orders/...`, and no submit/cancel/replace/modify tool surface.
- No generic `place_order`, `cancel_order`, or `modify_order` routing to Alpaca.
- No live endpoint support; live Alpaca base URL fails closed via `AlpacaPaperEndpointError`.
- No Alpaca credentials were printed or changed.
- No `paper_001` registry/profile/strategy/DB modeling was reintroduced.
- No live/paper broker order was submitted, canceled, replaced, or modified.

## Tests
- `uv run ruff check app/mcp_server/tooling/alpaca_paper_preview.py app/mcp_server/tooling/registry.py tests/test_mcp_alpaca_paper_tools.py tests/test_alpaca_paper_isolation.py tests/test_mcp_profiles.py` — passed
- `uv run ruff format --check app/mcp_server/tooling/alpaca_paper_preview.py app/mcp_server/tooling/registry.py tests/test_mcp_alpaca_paper_tools.py tests/test_alpaca_paper_isolation.py tests/test_mcp_profiles.py` — passed
- `uv run pytest tests/test_mcp_alpaca_paper_tools.py tests/test_alpaca_paper_isolation.py tests/test_alpaca_paper_config.py tests/test_alpaca_paper_service_endpoint_guard.py tests/test_alpaca_paper_service_methods.py tests/test_mcp_profiles.py tests/test_mcp_account_modes.py -q` — 88 passed, 2 existing Pydantic deprecation warnings

## Review
- Opus diff review: `review_passed` (no blockers)

Closes ROB-70
