### PR TITLE
feat: add crypto news briefing relevance filter

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -26,12 +26,14 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 
 ### News Tools (Pre-Market Briefing Pipeline)
 
-- `get_market_news(hours=24, feed_source=None, source=None, keyword=None, limit=20)`
+- `get_market_news(market=None, hours=24, feed_source=None, source=None, keyword=None, limit=20, briefing_filter=False)`
   - Fetch recent market news for OpenClaw pre-market briefing
-  - `feed_source`: Collection path key (e.g., `browser_naver_mainnews`, `browser_naver_research`, `rss_mk`)
-  - `source`: Publisher label (e.g., `연합뉴스`, `매일경제`, `유안타증권`)
-  - Returns: `count`, `total`, `news` (list), `sources` (unique publishers), `feed_sources` (unique collection paths)
-  - Each article includes `stock_symbol` and `stock_name` for holdings impact analysis
+  - `market`: Optional market scope (`kr`, `us`, `crypto`) for market-separated briefing inputs
+  - `feed_source`: Collection path key (e.g., `browser_naver_mainnews`, `browser_naver_research`, `rss_cointelegraph`)
+  - `source`: Publisher label (e.g., `연합뉴스`, `매일경제`, `Cointelegraph`)
+  - `briefing_filter`: When `market="crypto"`, rank crypto-relevant articles and separate broad-tech/AI noise into `excluded_news`; raw storage is not affected
+  - Returns: `count`, `total`, `news` (list), `sources` (unique publishers), `feed_sources` (unique collection paths), `briefing_filter`, `briefing_summary`, `excluded_news`
+  - Each article includes `stock_symbol` and `stock_name` for holdings impact analysis; crypto articles also include `crypto_relevance` metadata
 
 - `search_news(query, days=7, limit=20)`
   - Search news by keyword in title and keywords field

--- a/app/mcp_server/tooling/news_handlers.py
+++ b/app/mcp_server/tooling/news_handlers.py
@@ -10,6 +10,10 @@ from sqlalchemy.dialects.postgresql import JSONB
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst_naive
 from app.models.news import NewsArticle
+from app.services.crypto_news_relevance_service import (
+    rank_crypto_news_for_briefing,
+    score_crypto_news_article,
+)
 from app.services.llm_news_service import get_news_articles
 
 if TYPE_CHECKING:
@@ -18,8 +22,12 @@ if TYPE_CHECKING:
 NEWS_TOOL_NAMES = ["get_market_news", "search_news"]
 
 
-def _article_to_dict(article: NewsArticle) -> dict[str, Any]:
-    return {
+def _article_to_dict(
+    article: NewsArticle,
+    *,
+    include_crypto_relevance: bool = False,
+) -> dict[str, Any]:
+    item = {
         "id": article.id,
         "title": article.title,
         "url": article.url,
@@ -34,6 +42,9 @@ def _article_to_dict(article: NewsArticle) -> dict[str, Any]:
         "stock_symbol": article.stock_symbol,
         "stock_name": article.stock_name,
     }
+    if include_crypto_relevance:
+        item["crypto_relevance"] = score_crypto_news_article(article).as_dict()
+    return item
 
 
 async def _get_market_news_impl(
@@ -43,9 +54,16 @@ async def _get_market_news_impl(
     source: str | None = None,
     keyword: str | None = None,
     limit: int | None = 20,
+    briefing_filter: bool = False,
 ) -> dict[str, Any]:
     hours = hours or 24
     limit = limit or 20
+
+    query_limit = limit
+    if market == "crypto" and briefing_filter:
+        # Pull a slightly larger window so ranking can hide low-signal broad-tech
+        # items without returning an under-filled briefing when relevant items exist.
+        query_limit = max(limit * 3, limit)
 
     articles, total = await get_news_articles(
         market=market,
@@ -53,10 +71,29 @@ async def _get_market_news_impl(
         feed_source=feed_source,
         source=source,
         keyword=keyword,
-        limit=limit,
+        limit=query_limit,
     )
 
-    news_list = [_article_to_dict(a) for a in articles]
+    excluded_news: list[dict[str, Any]] = []
+    briefing_summary = None
+    if market == "crypto":
+        if briefing_filter:
+            ranking = rank_crypto_news_for_briefing(list(articles), limit=limit)
+            news_list = [
+                _article_to_dict(item.article, include_crypto_relevance=True)
+                for item in ranking.included
+            ]
+            excluded_news = [
+                _article_to_dict(item.article, include_crypto_relevance=True)
+                for item in ranking.excluded
+            ]
+            briefing_summary = ranking.summary
+        else:
+            news_list = [
+                _article_to_dict(a, include_crypto_relevance=True) for a in articles
+            ]
+    else:
+        news_list = [_article_to_dict(a) for a in articles]
     source_names = list({a.get("source") for a in news_list if a.get("source")})
     feed_source_names = list(
         {a.get("feed_source") for a in news_list if a.get("feed_source")}
@@ -69,6 +106,9 @@ async def _get_market_news_impl(
         "news": news_list,
         "sources": sorted(source_names),
         "feed_sources": sorted(feed_source_names),
+        "briefing_filter": bool(briefing_filter),
+        "briefing_summary": briefing_summary,
+        "excluded_news": excluded_news,
     }
 
 
@@ -130,7 +170,8 @@ def _register_news_tools_impl(mcp: FastMCP) -> None:
         description=(
             "Get recent market news. Supports filtering by market, publisher (source), "
             "collection path (feed_source), and keyword. Returns both publisher names "
-            "and collection paths for briefing segmentation."
+            "and collection paths for briefing segmentation. For market='crypto', "
+            "briefing_filter=True ranks crypto-relevant items and separates broad-tech noise."
         ),
     )
     async def get_market_news(
@@ -140,6 +181,7 @@ def _register_news_tools_impl(mcp: FastMCP) -> None:
         source: str | None = None,
         keyword: str | None = None,
         limit: int = 20,
+        briefing_filter: bool = False,
     ) -> dict[str, Any]:
         return await _get_market_news_impl(
             market=market,
@@ -148,6 +190,7 @@ def _register_news_tools_impl(mcp: FastMCP) -> None:
             source=source,
             keyword=keyword,
             limit=limit,
+            briefing_filter=briefing_filter,
         )
 
     @mcp.tool(

--- a/app/services/crypto_news_relevance_service.py
+++ b/app/services/crypto_news_relevance_service.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CryptoNewsRelevance:
+    score: int
+    bucket: str
+    category: str | None
+    include_in_briefing: bool
+    matched_terms: list[str]
+    noise_reason: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "bucket": self.bucket,
+            "category": self.category,
+            "include_in_briefing": self.include_in_briefing,
+            "matched_terms": self.matched_terms,
+            "noise_reason": self.noise_reason,
+        }
+
+
+@dataclass(frozen=True)
+class RankedCryptoNewsItem:
+    article: Any
+    relevance: CryptoNewsRelevance
+
+
+@dataclass(frozen=True)
+class CryptoBriefingRanking:
+    included: list[RankedCryptoNewsItem]
+    excluded: list[RankedCryptoNewsItem]
+    summary: dict[str, int]
+
+
+_CATEGORY_TERMS: dict[str, tuple[str, ...]] = {
+    "etf_institutional": (
+        "etf",
+        "spot bitcoin etf",
+        "inflow",
+        "outflow",
+        "blackrock",
+        "grayscale",
+        "institutional",
+        "treasury",
+        "reserve",
+    ),
+    "market_price": (
+        "crypto",
+        "bitcoin",
+        "btc",
+        "ether",
+        "ethereum",
+        "eth",
+        "price",
+        "volatility",
+        "support",
+        "resistance",
+        "liquidation",
+        "open interest",
+        "market",
+        "crash",
+        "surge",
+        "rally",
+        "momentum",
+        "bull",
+        "bear",
+    ),
+    "regulation_policy": (
+        "sec",
+        "cftc",
+        "senate",
+        "congress",
+        "regulation",
+        "regulatory",
+        "lawsuit",
+        "ban",
+        "policy",
+        "tether",
+    ),
+    "security_risk": (
+        "hack",
+        "hacker",
+        "exploit",
+        "drain",
+        "stolen",
+        "breach",
+        "scam",
+        "wallet",
+        "protocol",
+    ),
+    "stablecoin_defi": (
+        "stablecoin",
+        "defi",
+        "exchange",
+        "dex",
+        "token",
+        "staking",
+        "yield",
+        "chain",
+        "blockchain",
+        "web3",
+        "onchain",
+        "on-chain",
+    ),
+}
+
+_BROAD_TECH_TERMS = (
+    "openai",
+    "ai model",
+    "artificial intelligence",
+    "linux",
+    "developer tool",
+    "coding model",
+    "chatgpt",
+    "software",
+)
+
+_NEGATED_CRYPTO_PHRASES = (
+    "without crypto",
+    "no crypto",
+    "without token",
+    "without blockchain",
+    "no blockchain",
+)
+
+_STRONG_FEEDS = {"rss_cointelegraph", "rss_coindesk", "rss_bitcoin_magazine"}
+_BROADER_FEEDS = {"rss_decrypt"}
+
+
+def _field(article: Any, name: str) -> Any:
+    if isinstance(article, dict):
+        return article.get(name)
+    return getattr(article, name, None)
+
+
+def _text(article: Any) -> tuple[str, str]:
+    title = str(_field(article, "title") or "")
+    summary = str(_field(article, "summary") or "")
+    keywords = _field(article, "keywords") or []
+    keyword_text = " ".join(str(k) for k in keywords)
+    full = f"{title} {summary} {keyword_text}".lower()
+    for phrase in _NEGATED_CRYPTO_PHRASES:
+        full = full.replace(phrase, " ")
+    return title.lower(), full
+
+
+def _bucket(score: int) -> str:
+    if score >= 60:
+        return "high"
+    if score >= 40:
+        return "medium"
+    return "low"
+
+
+def score_crypto_news_article(article: Any) -> CryptoNewsRelevance:
+    """Score one crypto-market article for user-facing briefing relevance.
+
+    This is intentionally read-layer only: it does not decide whether raw news should
+    be stored. The goal is to keep broad tech items available while hiding them from
+    concise crypto briefings unless they contain clear crypto-market signals.
+    """
+
+    title, full_text = _text(article)
+    feed_source = str(_field(article, "feed_source") or "").lower()
+
+    category_hits: dict[str, list[str]] = {}
+    matched_terms: list[str] = []
+    for category, terms in _CATEGORY_TERMS.items():
+        hits = [term for term in terms if term in full_text]
+        if hits:
+            category_hits[category] = hits
+            matched_terms.extend(hits)
+
+    score = 0
+    if feed_source in _STRONG_FEEDS:
+        score += 20
+    elif feed_source in _BROADER_FEEDS:
+        score += 5
+
+    for hits in category_hits.values():
+        score += min(40, len(hits) * 15)
+        # Title hits are more likely to be the article thesis.
+        score += min(25, sum(15 for term in hits if term in title))
+
+    broad_hits = [term for term in _BROAD_TECH_TERMS if term in full_text]
+    title_crypto_hits = [
+        term for terms in _CATEGORY_TERMS.values() for term in terms if term in title
+    ]
+    if broad_hits and not title_crypto_hits:
+        # Decrypt and similar feeds can publish broader AI/software stories that
+        # mention crypto only in boilerplate or negated context. Do not let summary
+        # noise promote them into a market briefing.
+        category_hits = {}
+        matched_terms = []
+        score = min(score, 15)
+    elif broad_hits and not category_hits:
+        score -= 25
+
+    score = max(0, min(100, score))
+    primary_category = None
+    if category_hits:
+        primary_category = max(category_hits, key=lambda cat: len(category_hits[cat]))
+
+    noise_reason = None
+    include = score >= 40
+    if not include and broad_hits:
+        noise_reason = "broad_tech_without_crypto_signal"
+    elif not include:
+        noise_reason = "low_crypto_relevance"
+
+    return CryptoNewsRelevance(
+        score=score,
+        bucket=_bucket(score),
+        category=primary_category,
+        include_in_briefing=include,
+        matched_terms=sorted(set(matched_terms)),
+        noise_reason=noise_reason,
+    )
+
+
+def rank_crypto_news_for_briefing(
+    articles: list[Any],
+    *,
+    limit: int | None = None,
+) -> CryptoBriefingRanking:
+    scored = [
+        RankedCryptoNewsItem(
+            article=article, relevance=score_crypto_news_article(article)
+        )
+        for article in articles
+    ]
+    included = [item for item in scored if item.relevance.include_in_briefing]
+    excluded = [item for item in scored if not item.relevance.include_in_briefing]
+
+    included.sort(key=lambda item: item.relevance.score, reverse=True)
+    excluded.sort(key=lambda item: item.relevance.score, reverse=True)
+
+    if limit is not None and limit >= 0:
+        included = included[:limit]
+
+    summary = {
+        "included": len(included),
+        "excluded": len(excluded),
+        "high": sum(1 for item in scored if item.relevance.bucket == "high"),
+        "medium": sum(1 for item in scored if item.relevance.bucket == "medium"),
+        "low": sum(1 for item in scored if item.relevance.bucket == "low"),
+    }
+    return CryptoBriefingRanking(included=included, excluded=excluded, summary=summary)

--- a/tests/routers/test_trading_decisions_operator_request_integration.py
+++ b/tests/routers/test_trading_decisions_operator_request_integration.py
@@ -129,7 +129,7 @@ def test_no_advisory_persists_session_and_proposals_in_db(monkeypatch):
                 persisted = (
                     await session.execute(
                         select(TradingDecisionSession).where(
-                            TradingDecisionSession.user_id == user_id
+                            TradingDecisionSession.session_uuid == body["session_uuid"]
                         )
                     )
                 ).scalar_one()
@@ -232,14 +232,15 @@ def test_advisory_path_persists_synthesis_block(monkeypatch):
             },
         )
         assert resp.status_code == 201, resp.text
-        assert resp.json()["advisory_used"] is True
+        body = resp.json()
+        assert body["advisory_used"] is True
 
         async def _load():
             async with SessionLocal() as session:
                 persisted = (
                     await session.execute(
                         select(TradingDecisionSession).where(
-                            TradingDecisionSession.user_id == user_id
+                            TradingDecisionSession.session_uuid == body["session_uuid"]
                         )
                     )
                 ).scalar_one()

--- a/tests/test_crypto_news_relevance_service.py
+++ b/tests/test_crypto_news_relevance_service.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _article(
+    title: str,
+    *,
+    summary: str | None = None,
+    feed_source: str = "rss_decrypt",
+    keywords: list[str] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        title=title,
+        summary=summary,
+        feed_source=feed_source,
+        keywords=keywords or [],
+    )
+
+
+@pytest.mark.unit
+def test_score_crypto_news_prioritizes_bitcoin_etf_market_impact():
+    from app.services.crypto_news_relevance_service import score_crypto_news_article
+
+    scored = score_crypto_news_article(
+        _article(
+            "Spot Bitcoin ETF outflows top $490M as BTC tests key support",
+            summary="ETF flow and Bitcoin price support levels drive crypto market risk.",
+            feed_source="rss_coindesk",
+        )
+    )
+
+    assert scored.score >= 80
+    assert scored.bucket == "high"
+    assert scored.category in {"etf_institutional", "market_price"}
+    assert scored.include_in_briefing is True
+    assert scored.noise_reason is None
+
+
+@pytest.mark.unit
+def test_score_crypto_news_keeps_crypto_price_warning_from_decrypt():
+    from app.services.crypto_news_relevance_service import score_crypto_news_article
+
+    scored = score_crypto_news_article(
+        _article(
+            "Bitcoin Crash Incoming? April Surge Was Built on Shaky Ground, Analysts Warn",
+            feed_source="rss_decrypt",
+        )
+    )
+
+    assert scored.include_in_briefing is True
+    assert scored.bucket in {"medium", "high"}
+    assert scored.category == "market_price"
+
+
+@pytest.mark.unit
+def test_score_crypto_news_demotes_broader_ai_tech_from_decrypt():
+    from app.services.crypto_news_relevance_service import score_crypto_news_article
+
+    scored = score_crypto_news_article(
+        _article(
+            "OpenAI launches new coding model for Linux developers",
+            summary="The release focuses on developer tools and AI assistants without crypto links.",
+            feed_source="rss_decrypt",
+        )
+    )
+
+    assert scored.score < 40
+    assert scored.bucket == "low"
+    assert scored.include_in_briefing is False
+    assert scored.noise_reason == "broad_tech_without_crypto_signal"
+
+
+@pytest.mark.unit
+def test_rank_crypto_news_for_briefing_orders_relevant_items_and_keeps_exclusions():
+    from app.services.crypto_news_relevance_service import rank_crypto_news_for_briefing
+
+    btc = _article(
+        "Bitcoin ETF inflows rebound as BTC volatility rises",
+        feed_source="rss_cointelegraph",
+    )
+    ai = _article("OpenAI launches Linux coding model", feed_source="rss_decrypt")
+    stablecoin = _article(
+        "Stablecoins overtake Bitcoin in Latin America purchases",
+        feed_source="rss_decrypt",
+    )
+
+    result = rank_crypto_news_for_briefing([ai, stablecoin, btc], limit=2)
+
+    assert [item.article.title for item in result.included] == [
+        btc.title,
+        stablecoin.title,
+    ]
+    assert [item.article.title for item in result.excluded] == [ai.title]
+    assert result.summary == {
+        "included": 2,
+        "excluded": 1,
+        "high": 2,
+        "medium": 0,
+        "low": 1,
+    }

--- a/tests/test_mcp_news_crypto_relevance.py
+++ b/tests/test_mcp_news_crypto_relevance.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_market_news_can_return_crypto_briefing_ranked_candidates():
+    from app.mcp_server.tooling.news_handlers import _get_market_news_impl
+
+    rows = [
+        SimpleNamespace(
+            id=1,
+            title="OpenAI launches Linux coding model",
+            url="https://decrypt.co/ai",
+            source="Decrypt",
+            feed_source="rss_decrypt",
+            market="crypto",
+            summary="Developer AI story without token, blockchain, or crypto market impact.",
+            article_published_at=datetime(2026, 5, 1, 12, 0, 0),
+            keywords=[],
+            stock_symbol=None,
+            stock_name=None,
+        ),
+        SimpleNamespace(
+            id=2,
+            title="Bitcoin ETF inflows rebound as BTC volatility rises",
+            url="https://cointelegraph.com/btc-etf",
+            source="Cointelegraph",
+            feed_source="rss_cointelegraph",
+            market="crypto",
+            summary="Spot ETF flows and BTC volatility affect crypto market direction.",
+            article_published_at=datetime(2026, 5, 1, 12, 5, 0),
+            keywords=[],
+            stock_symbol=None,
+            stock_name=None,
+        ),
+    ]
+
+    with patch(
+        "app.mcp_server.tooling.news_handlers.get_news_articles",
+        new=AsyncMock(return_value=(rows, 2)),
+    ):
+        result = await _get_market_news_impl(
+            market="crypto",
+            hours=48,
+            limit=2,
+            briefing_filter=True,
+        )
+
+    assert result["count"] == 1
+    assert result["total"] == 2
+    assert result["briefing_filter"] is True
+    assert result["briefing_summary"] == {
+        "included": 1,
+        "excluded": 1,
+        "high": 1,
+        "medium": 0,
+        "low": 1,
+    }
+    assert result["news"][0]["title"].startswith("Bitcoin ETF")
+    assert result["news"][0]["crypto_relevance"]["bucket"] == "high"
+    assert result["excluded_news"][0]["title"].startswith("OpenAI")
+    assert (
+        result["excluded_news"][0]["crypto_relevance"]["noise_reason"]
+        == "broad_tech_without_crypto_signal"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_market_news_default_keeps_raw_crypto_news_with_relevance_metadata():
+    from app.mcp_server.tooling.news_handlers import _get_market_news_impl
+
+    row = SimpleNamespace(
+        id=1,
+        title="OpenAI launches Linux coding model",
+        url="https://decrypt.co/ai",
+        source="Decrypt",
+        feed_source="rss_decrypt",
+        market="crypto",
+        summary="Developer AI story without crypto market impact.",
+        article_published_at=None,
+        keywords=[],
+        stock_symbol=None,
+        stock_name=None,
+    )
+
+    with patch(
+        "app.mcp_server.tooling.news_handlers.get_news_articles",
+        new=AsyncMock(return_value=([row], 1)),
+    ):
+        result = await _get_market_news_impl(market="crypto", limit=1)
+
+    assert result["briefing_filter"] is False
+    assert result["count"] == 1
+    assert result["excluded_news"] == []
+    assert result["news"][0]["crypto_relevance"]["bucket"] == "low"


### PR DESCRIPTION
## Summary
- Adds a read-layer crypto news relevance scorer for briefing quality without dropping raw stored articles
- Adds `briefing_filter` to `get_market_news` so `market="crypto"` can rank crypto-relevant items and separate broad-tech/AI noise into `excluded_news`
- Adds crypto relevance metadata (`score`, `bucket`, `category`, `noise_reason`) and updates MCP README

## Verification
- RED first: `uv run pytest tests/test_crypto_news_relevance_service.py tests/test_mcp_news_crypto_relevance.py -q` failed before implementation
- `uv run ruff check app/services/crypto_news_relevance_service.py app/mcp_server/tooling/news_handlers.py tests/test_crypto_news_relevance_service.py tests/test_mcp_news_crypto_relevance.py`
- `uv run ruff format --check app/services/crypto_news_relevance_service.py app/mcp_server/tooling/news_handlers.py tests/test_crypto_news_relevance_service.py tests/test_mcp_news_crypto_relevance.py`
- `uv run pytest tests/test_crypto_news_relevance_service.py tests/test_mcp_news_crypto_relevance.py tests/test_news_ingestor_bulk.py tests/test_llm_news_preview.py -q`
- `uv run pytest tests/test_news_rss.py tests/test_crypto_news_relevance_service.py tests/test_mcp_news_crypto_relevance.py -q`
- Local read-only smoke against production DB env via `scripts/common.sh`: `market="crypto", briefing_filter=True` returned `total=100`, ranked top crypto items, and separated broad-tech AI/Linux items into `excluded_news`

## Safety
- Read-only query/formatting change; no DB migration
- Does not mutate raw article storage or pending outbox
- No broker/order/watch/order-intent side effects


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added market scoping to the news tool (crypto, US, Korean markets).
  * Introduced briefing filter for crypto news to rank relevant articles and separate broad tech/AI content into an excluded list.
  * Added crypto relevance scoring and metadata to articles.

* **Documentation**
  * Updated tool documentation to reflect new parameters and extended response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->