### PR TITLE
feat: add market news briefing formatter

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -31,9 +31,9 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
   - `market`: Optional market scope (`kr`, `us`, `crypto`) for market-separated briefing inputs
   - `feed_source`: Collection path key (e.g., `browser_naver_mainnews`, `browser_naver_research`, `rss_cointelegraph`)
   - `source`: Publisher label (e.g., `연합뉴스`, `매일경제`, `Cointelegraph`)
-  - `briefing_filter`: When `market="crypto"`, rank crypto-relevant articles and separate broad-tech/AI noise into `excluded_news`; raw storage is not affected
-  - Returns: `count`, `total`, `news` (list), `sources` (unique publishers), `feed_sources` (unique collection paths), `briefing_filter`, `briefing_summary`, `excluded_news`
-  - Each article includes `stock_symbol` and `stock_name` for holdings impact analysis; crypto articles also include `crypto_relevance` metadata
+  - `briefing_filter`: Format market-specific briefing sections for `kr`/`us`, and rank crypto-relevant articles while separating broad-tech/AI noise into `excluded_news`; raw storage is not affected
+  - Returns: `count`, `total`, `news` (list), `sources` (unique publishers), `feed_sources` (unique collection paths), `briefing_filter`, `briefing_summary`, `briefing_sections`, `excluded_news`
+  - Each article includes `stock_symbol` and `stock_name` for holdings impact analysis; formatted articles include `briefing_relevance`; crypto articles also include `crypto_relevance` metadata
 
 - `search_news(query, days=7, limit=20)`
   - Search news by keyword in title and keywords field

--- a/app/mcp_server/tooling/news_handlers.py
+++ b/app/mcp_server/tooling/news_handlers.py
@@ -15,6 +15,10 @@ from app.services.crypto_news_relevance_service import (
     score_crypto_news_article,
 )
 from app.services.llm_news_service import get_news_articles
+from app.services.market_news_briefing_formatter import (
+    BriefingSection,
+    format_market_news_briefing,
+)
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -26,6 +30,7 @@ def _article_to_dict(
     article: NewsArticle,
     *,
     include_crypto_relevance: bool = False,
+    briefing_relevance: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     item = {
         "id": article.id,
@@ -44,7 +49,32 @@ def _article_to_dict(
     }
     if include_crypto_relevance:
         item["crypto_relevance"] = score_crypto_news_article(article).as_dict()
+    if briefing_relevance is not None:
+        item["briefing_relevance"] = briefing_relevance
     return item
+
+
+def _briefing_sections_to_dict(
+    sections: list[BriefingSection],
+    *,
+    include_crypto_relevance: bool = False,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "section_id": section.section_id,
+            "title": section.title,
+            "count": len(section.items),
+            "items": [
+                _article_to_dict(
+                    item.article,
+                    include_crypto_relevance=include_crypto_relevance,
+                    briefing_relevance=item.relevance.as_dict(),
+                )
+                for item in section.items
+            ],
+        }
+        for section in sections
+    ]
 
 
 async def _get_market_news_impl(
@@ -60,9 +90,9 @@ async def _get_market_news_impl(
     limit = limit or 20
 
     query_limit = limit
-    if market == "crypto" and briefing_filter:
-        # Pull a slightly larger window so ranking can hide low-signal broad-tech
-        # items without returning an under-filled briefing when relevant items exist.
+    if market in {"crypto", "us", "kr"} and briefing_filter:
+        # Pull a slightly larger window so ranking can hide low-signal noise
+        # without returning an under-filled briefing when relevant items exist.
         query_limit = max(limit * 3, limit)
 
     articles, total = await get_news_articles(
@@ -76,6 +106,7 @@ async def _get_market_news_impl(
 
     excluded_news: list[dict[str, Any]] = []
     briefing_summary = None
+    briefing_sections: list[dict[str, Any]] = []
     if market == "crypto":
         if briefing_filter:
             ranking = rank_crypto_news_for_briefing(list(articles), limit=limit)
@@ -88,10 +119,37 @@ async def _get_market_news_impl(
                 for item in ranking.excluded
             ]
             briefing_summary = ranking.summary
+            briefing = format_market_news_briefing(
+                list(articles), market=market, limit=limit
+            )
+            briefing_sections = _briefing_sections_to_dict(
+                briefing.sections, include_crypto_relevance=True
+            )
         else:
             news_list = [
                 _article_to_dict(a, include_crypto_relevance=True) for a in articles
             ]
+    elif briefing_filter and market in {"us", "kr"}:
+        briefing = format_market_news_briefing(
+            list(articles), market=market, limit=limit
+        )
+        news_list = [
+            _article_to_dict(
+                item.article,
+                briefing_relevance=item.relevance.as_dict(),
+            )
+            for section in briefing.sections
+            for item in section.items
+        ]
+        excluded_news = [
+            _article_to_dict(
+                item.article,
+                briefing_relevance=item.relevance.as_dict(),
+            )
+            for item in briefing.excluded
+        ]
+        briefing_summary = briefing.summary
+        briefing_sections = _briefing_sections_to_dict(briefing.sections)
     else:
         news_list = [_article_to_dict(a) for a in articles]
     source_names = list({a.get("source") for a in news_list if a.get("source")})
@@ -108,6 +166,7 @@ async def _get_market_news_impl(
         "feed_sources": sorted(feed_source_names),
         "briefing_filter": bool(briefing_filter),
         "briefing_summary": briefing_summary,
+        "briefing_sections": briefing_sections,
         "excluded_news": excluded_news,
     }
 
@@ -170,8 +229,9 @@ def _register_news_tools_impl(mcp: FastMCP) -> None:
         description=(
             "Get recent market news. Supports filtering by market, publisher (source), "
             "collection path (feed_source), and keyword. Returns both publisher names "
-            "and collection paths for briefing segmentation. For market='crypto', "
-            "briefing_filter=True ranks crypto-relevant items and separates broad-tech noise."
+            "and collection paths for briefing segmentation. briefing_filter=True "
+            "formats market-specific sections for kr/us and ranks crypto-relevant "
+            "items while separating broad-tech noise."
         ),
     )
     async def get_market_news(

--- a/app/services/market_news_briefing_formatter.py
+++ b/app/services/market_news_briefing_formatter.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.services.crypto_news_relevance_service import score_crypto_news_article
+
+
+@dataclass(frozen=True)
+class BriefingRelevance:
+    score: int
+    section_id: str | None
+    section_title: str | None
+    include_in_briefing: bool
+    matched_terms: list[str]
+    reason: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "score": self.score,
+            "section_id": self.section_id,
+            "section_title": self.section_title,
+            "include_in_briefing": self.include_in_briefing,
+            "matched_terms": self.matched_terms,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class BriefingItem:
+    article: Any
+    relevance: BriefingRelevance
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"relevance": self.relevance.as_dict()}
+
+
+@dataclass(frozen=True)
+class BriefingSection:
+    section_id: str
+    title: str
+    items: list[BriefingItem]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "section_id": self.section_id,
+            "title": self.title,
+            "count": len(self.items),
+            "items": [item.as_dict() for item in self.items],
+        }
+
+
+@dataclass(frozen=True)
+class MarketNewsBriefing:
+    market: str
+    sections: list[BriefingSection]
+    excluded: list[BriefingItem]
+    summary: dict[str, int]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "market": self.market,
+            "sections": [section.as_dict() for section in self.sections],
+            "excluded": [item.as_dict() for item in self.excluded],
+            "summary": self.summary,
+        }
+
+
+@dataclass(frozen=True)
+class _SectionRule:
+    section_id: str
+    title: str
+    terms: tuple[str, ...]
+
+
+_US_RULES: tuple[_SectionRule, ...] = (
+    _SectionRule(
+        "macro_fed",
+        "Macro/Fed",
+        (
+            "fed",
+            "fomc",
+            "rate",
+            "rates",
+            "cpi",
+            "inflation",
+            "treasury",
+            "yield",
+            "yields",
+            "s&p",
+            "futures",
+            "jobs report",
+            "payrolls",
+        ),
+    ),
+    _SectionRule(
+        "big_tech",
+        "Big Tech / AI / Semis",
+        (
+            "microsoft",
+            "apple",
+            "alphabet",
+            "google",
+            "amazon",
+            "meta",
+            "tesla",
+            "nvidia",
+            "nasdaq",
+            "ai",
+            "chip",
+            "chips",
+            "semiconductor",
+            "semis",
+        ),
+    ),
+    _SectionRule(
+        "earnings",
+        "Earnings / Guidance",
+        (
+            "earnings",
+            "guidance",
+            "estimate",
+            "estimates",
+            "quarterly",
+            "revenue",
+            "eps",
+            "profit",
+        ),
+    ),
+    _SectionRule(
+        "market_sentiment",
+        "Market Sentiment",
+        (
+            "rally",
+            "selloff",
+            "sell-off",
+            "volatility",
+            "risk-on",
+            "risk off",
+            "risk-off",
+            "dow",
+            "s&p 500",
+            "market sentiment",
+        ),
+    ),
+    _SectionRule(
+        "watchlist_analyst",
+        "Watchlist / Analyst",
+        (
+            "analyst",
+            "upgrade",
+            "downgrade",
+            "price target",
+            "target price",
+            "rating",
+            "watchlist",
+        ),
+    ),
+)
+
+_KR_RULES: tuple[_SectionRule, ...] = (
+    _SectionRule(
+        "preopen_headlines",
+        "장전 주요 뉴스",
+        ("장전", "코스피", "코스닥", "환율", "금리", "지수", "시황", "미 증시"),
+    ),
+    _SectionRule(
+        "sector_theme",
+        "업종/테마",
+        (
+            "업종",
+            "테마",
+            "반도체",
+            "2차전지",
+            "배터리",
+            "바이오",
+            "조선",
+            "방산",
+            "강세",
+        ),
+    ),
+    _SectionRule(
+        "disclosure_research",
+        "공시/리포트",
+        ("공시", "리포트", "목표가", "투자의견", "계약", "공급계약", "실적", "발표"),
+    ),
+    _SectionRule(
+        "flow_watchlist",
+        "수급/관심종목 영향",
+        ("수급", "외국인", "기관", "순매수", "순매도", "관심종목", "거래대금"),
+    ),
+)
+
+_CRYPTO_SECTION_TITLES = {
+    "btc_eth_market": "BTC/ETH Market",
+    "etf_institutional": "ETF / Institutional Flows",
+    "regulation_policy": "Regulation / Policy",
+    "security_defi": "Security / DeFi",
+    "alt_sector": "Altcoins / Sector",
+}
+_CRYPTO_CATEGORY_TO_SECTION = {
+    "market_price": "btc_eth_market",
+    "etf_institutional": "btc_eth_market",
+    "regulation_policy": "regulation_policy",
+    "security_risk": "security_defi",
+    "stablecoin_defi": "security_defi",
+}
+_CRYPTO_SECTION_ORDER = (
+    "btc_eth_market",
+    "etf_institutional",
+    "regulation_policy",
+    "security_defi",
+    "alt_sector",
+)
+
+_NOISE_TERMS = (
+    "celebrity",
+    "mansion",
+    "renovation show",
+    "streaming show",
+    "wedding",
+    "engagement",
+)
+
+
+def _field(article: Any, name: str) -> Any:
+    if isinstance(article, dict):
+        return article.get(name)
+    return getattr(article, name, None)
+
+
+def _article_text(article: Any) -> tuple[str, str]:
+    title = str(_field(article, "title") or "")
+    summary = str(_field(article, "summary") or "")
+    keywords = _field(article, "keywords") or []
+    keyword_text = " ".join(str(keyword) for keyword in keywords)
+    return title.lower(), f"{title} {summary} {keyword_text}".lower()
+
+
+def _score_rule(article: Any, rules: tuple[_SectionRule, ...]) -> BriefingRelevance:
+    title, full_text = _article_text(article)
+    scored: list[tuple[int, _SectionRule, list[str]]] = []
+
+    for rule in rules:
+        matched = [term for term in rule.terms if term in full_text]
+        if not matched:
+            continue
+        score = min(90, 20 + len(matched) * 12)
+        score += min(25, sum(10 for term in matched if term in title))
+        if _field(article, "stock_symbol"):
+            score += 8
+        scored.append((min(100, score), rule, matched))
+
+    if not scored:
+        noise_hit = any(term in full_text for term in _NOISE_TERMS)
+        reason = "low_market_relevance" if noise_hit else "uncategorized_market_news"
+        return BriefingRelevance(
+            score=0,
+            section_id=None,
+            section_title=None,
+            include_in_briefing=False,
+            matched_terms=[],
+            reason=reason,
+        )
+
+    score, rule, matched_terms = max(scored, key=lambda item: item[0])
+    return BriefingRelevance(
+        score=score,
+        section_id=rule.section_id,
+        section_title=rule.title,
+        include_in_briefing=score >= 40,
+        matched_terms=sorted(set(matched_terms)),
+        reason=None if score >= 40 else "low_market_relevance",
+    )
+
+
+def _score_crypto(article: Any) -> BriefingRelevance:
+    crypto = score_crypto_news_article(article)
+    section_id = _CRYPTO_CATEGORY_TO_SECTION.get(crypto.category or "")
+    if crypto.include_in_briefing and section_id is None:
+        section_id = "alt_sector"
+    section_title = _CRYPTO_SECTION_TITLES.get(section_id or "") if section_id else None
+    return BriefingRelevance(
+        score=crypto.score,
+        section_id=section_id,
+        section_title=section_title,
+        include_in_briefing=crypto.include_in_briefing and section_id is not None,
+        matched_terms=crypto.matched_terms,
+        reason=crypto.noise_reason,
+    )
+
+
+def _rules_for_market(market: str) -> tuple[_SectionRule, ...]:
+    if market == "us":
+        return _US_RULES
+    if market == "kr":
+        return _KR_RULES
+    return ()
+
+
+def _section_order_for_market(market: str) -> list[str]:
+    if market == "crypto":
+        return list(_CRYPTO_SECTION_ORDER)
+    return [rule.section_id for rule in _rules_for_market(market)]
+
+
+def _score_article(article: Any, market: str) -> BriefingRelevance:
+    if market == "crypto":
+        return _score_crypto(article)
+    return _score_rule(article, _rules_for_market(market))
+
+
+def format_market_news_briefing(
+    articles: list[Any],
+    *,
+    market: str | None,
+    limit: int | None = None,
+) -> MarketNewsBriefing:
+    """Format recent raw market-news rows into briefing sections.
+
+    This is intentionally read-layer only. It groups/ranks already stored articles for
+    user-facing briefings without changing raw-news ingestion or persistence.
+    """
+
+    normalized_market = (market or "").lower()
+    scored = [
+        BriefingItem(
+            article=article, relevance=_score_article(article, normalized_market)
+        )
+        for article in articles
+    ]
+    included = [item for item in scored if item.relevance.include_in_briefing]
+    excluded = [item for item in scored if not item.relevance.include_in_briefing]
+
+    grouped: dict[str, list[BriefingItem]] = {}
+    for item in included:
+        if item.relevance.section_id is None:
+            excluded.append(item)
+            continue
+        grouped.setdefault(item.relevance.section_id, []).append(item)
+
+    for items in grouped.values():
+        items.sort(key=lambda item: item.relevance.score, reverse=True)
+
+    remaining = limit if limit is not None and limit >= 0 else None
+    sections: list[BriefingSection] = []
+    for section_id in _section_order_for_market(normalized_market):
+        items = grouped.get(section_id, [])
+        if not items:
+            continue
+        if remaining is not None:
+            if remaining <= 0:
+                break
+            items = items[:remaining]
+            remaining -= len(items)
+        title = items[0].relevance.section_title or section_id
+        sections.append(
+            BriefingSection(section_id=section_id, title=title, items=items)
+        )
+
+    summary = {
+        "included": sum(len(section.items) for section in sections),
+        "excluded": len(excluded),
+        "sections": len(sections),
+        "uncategorized": sum(
+            1
+            for item in excluded
+            if item.relevance.reason == "uncategorized_market_news"
+        ),
+    }
+    excluded.sort(key=lambda item: item.relevance.score, reverse=True)
+    return MarketNewsBriefing(
+        market=normalized_market,
+        sections=sections,
+        excluded=excluded,
+        summary=summary,
+    )

--- a/tests/test_market_news_briefing_formatter.py
+++ b/tests/test_market_news_briefing_formatter.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _article(
+    title: str,
+    *,
+    market: str,
+    summary: str | None = None,
+    source: str = "Test Source",
+    feed_source: str = "rss_test",
+    stock_symbol: str | None = None,
+    keywords: list[str] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=None,
+        title=title,
+        url="https://example.com/article",
+        source=source,
+        feed_source=feed_source,
+        market=market,
+        summary=summary,
+        article_published_at=None,
+        keywords=keywords or [],
+        stock_symbol=stock_symbol,
+        stock_name=None,
+    )
+
+
+@pytest.mark.unit
+def test_format_us_news_groups_macro_big_tech_earnings_and_noise():
+    from app.services.market_news_briefing_formatter import format_market_news_briefing
+
+    macro = _article(
+        "Fed rate cut hopes lift S&P 500 futures before CPI report",
+        market="us",
+        summary="Inflation data and Treasury yields remain the macro focus.",
+    )
+    big_tech = _article(
+        "Microsoft and Nvidia lead Nasdaq as AI chip demand grows",
+        market="us",
+        summary="Big tech and semiconductors continue to drive market sentiment.",
+        stock_symbol="NVDA",
+    )
+    earnings = _article(
+        "Apple earnings beat estimates but guidance disappoints",
+        market="us",
+        summary="Quarterly results and outlook are in focus.",
+        stock_symbol="AAPL",
+    )
+    lifestyle = _article(
+        "Celebrity mansion sells after renovation show",
+        market="us",
+        summary="Real estate lifestyle story with no market signal.",
+    )
+
+    briefing = format_market_news_briefing(
+        [lifestyle, earnings, big_tech, macro], market="us", limit=10
+    )
+
+    assert briefing.market == "us"
+    assert briefing.summary["included"] == 3
+    assert briefing.summary["excluded"] == 1
+    section_ids = [section.section_id for section in briefing.sections]
+    assert section_ids[:3] == ["macro_fed", "big_tech", "earnings"]
+    assert [item.article.title for item in briefing.sections[0].items] == [macro.title]
+    assert briefing.excluded[0].relevance.reason == "low_market_relevance"
+
+
+@pytest.mark.unit
+def test_format_kr_news_groups_preopen_sector_disclosure_and_flow():
+    from app.services.market_news_briefing_formatter import format_market_news_briefing
+
+    preopen = _article(
+        "코스피 장전 주요 뉴스: 환율 하락과 반도체 강세",
+        market="kr",
+        summary="장전 시황과 지수 흐름이 투자심리에 영향을 준다.",
+    )
+    sector = _article(
+        "2차전지 업종 강세, 배터리 소재 테마 부각",
+        market="kr",
+        summary="업종/테마 순환매가 나타난다.",
+    )
+    disclosure = _article(
+        "삼성전자 신규 공급계약 공시 발표",
+        market="kr",
+        summary="기업 공시와 계약 뉴스.",
+        stock_symbol="005930",
+    )
+    flow = _article(
+        "외국인 순매수 확대, 기관 수급도 개선",
+        market="kr",
+        summary="수급 개선과 관심종목 영향.",
+    )
+
+    briefing = format_market_news_briefing(
+        [flow, disclosure, sector, preopen], market="kr", limit=10
+    )
+
+    assert briefing.summary["included"] == 4
+    assert [section.section_id for section in briefing.sections] == [
+        "preopen_headlines",
+        "sector_theme",
+        "disclosure_research",
+        "flow_watchlist",
+    ]
+
+
+@pytest.mark.unit
+def test_format_crypto_news_reuses_crypto_relevance_and_sections():
+    from app.services.market_news_briefing_formatter import format_market_news_briefing
+
+    etf = _article(
+        "Bitcoin ETF inflows rebound as BTC volatility rises",
+        market="crypto",
+        feed_source="rss_cointelegraph",
+    )
+    security = _article(
+        "DeFi protocol hack drains exchange wallet funds",
+        market="crypto",
+        feed_source="rss_coindesk",
+    )
+    ai_noise = _article(
+        "OpenAI launches Linux coding model",
+        market="crypto",
+        summary="Developer tool story without blockchain or token impact.",
+        feed_source="rss_decrypt",
+    )
+
+    briefing = format_market_news_briefing(
+        [ai_noise, security, etf], market="crypto", limit=10
+    )
+
+    assert briefing.summary["included"] == 2
+    assert briefing.summary["excluded"] == 1
+    assert [section.section_id for section in briefing.sections] == [
+        "btc_eth_market",
+        "security_defi",
+    ]
+    assert briefing.sections[0].items[0].article.title == etf.title
+    assert briefing.excluded[0].relevance.reason == "broad_tech_without_crypto_signal"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_market_news_briefing_filter_formats_us_sections_for_mcp():
+    from unittest.mock import AsyncMock, patch
+
+    from app.mcp_server.tooling.news_handlers import _get_market_news_impl
+
+    rows = [
+        _article(
+            "Fed rate cut hopes lift S&P 500 futures before CPI report",
+            market="us",
+        ),
+        _article(
+            "Celebrity mansion sells after renovation show",
+            market="us",
+        ),
+    ]
+
+    with patch(
+        "app.mcp_server.tooling.news_handlers.get_news_articles",
+        new=AsyncMock(return_value=(rows, 2)),
+    ):
+        result = await _get_market_news_impl(
+            market="us",
+            hours=24,
+            limit=10,
+            briefing_filter=True,
+        )
+
+    assert result["count"] == 1
+    assert result["briefing_filter"] is True
+    assert result["briefing_summary"]["included"] == 1
+    assert result["briefing_sections"][0]["section_id"] == "macro_fed"
+    assert (
+        result["excluded_news"][0]["briefing_relevance"]["reason"]
+        == "low_market_relevance"
+    )


### PR DESCRIPTION
## Summary
- Add a read-layer `market_news_briefing_formatter` service that groups stored news into market-specific briefing sections for KR, US, and crypto
- Extend `get_market_news(..., briefing_filter=True)` so KR/US return `briefing_sections`, `briefing_relevance`, and low-signal `excluded_news` while preserving raw-news storage behavior
- Keep existing crypto relevance behavior and add section output for crypto briefing consumers
- Update MCP news tool docs for the expanded briefing response contract

## Verification
- `uv run pytest tests/test_market_news_briefing_formatter.py tests/test_mcp_news_crypto_relevance.py tests/test_crypto_news_relevance_service.py -q`
- `uv run pytest tests/test_news_ingestor_bulk.py tests/test_news_readiness_contract.py tests/test_router_preopen_news_brief.py tests/services/test_kr_preopen_news_brief_service.py tests/test_market_news_briefing_formatter.py tests/test_mcp_news_crypto_relevance.py tests/test_crypto_news_relevance_service.py -q`
- `uv run ruff check app/services/market_news_briefing_formatter.py app/mcp_server/tooling/news_handlers.py tests/test_market_news_briefing_formatter.py tests/test_mcp_news_crypto_relevance.py tests/test_crypto_news_relevance_service.py`
- `uv run ruff format --check app/services/market_news_briefing_formatter.py app/mcp_server/tooling/news_handlers.py tests/test_market_news_briefing_formatter.py tests/test_mcp_news_crypto_relevance.py tests/test_crypto_news_relevance_service.py`
- `git diff --check`

## Notes
- No schema migration and no raw ingestion changes.
- No broker/order/trading side effects.
