### PR TITLE
fix: route crypto ETF news to briefing section

### DIFF
--- a/app/services/market_news_briefing_formatter.py
+++ b/app/services/market_news_briefing_formatter.py
@@ -200,7 +200,7 @@ _CRYPTO_SECTION_TITLES = {
 }
 _CRYPTO_CATEGORY_TO_SECTION = {
     "market_price": "btc_eth_market",
-    "etf_institutional": "btc_eth_market",
+    "etf_institutional": "etf_institutional",
     "regulation_policy": "regulation_policy",
     "security_risk": "security_defi",
     "stablecoin_defi": "security_defi",

--- a/tests/test_market_news_briefing_formatter.py
+++ b/tests/test_market_news_briefing_formatter.py
@@ -144,6 +144,31 @@ def test_format_crypto_news_reuses_crypto_relevance_and_sections():
     assert briefing.excluded[0].relevance.reason == "broad_tech_without_crypto_signal"
 
 
+@pytest.mark.unit
+def test_format_crypto_news_routes_etf_institutional_to_dedicated_section():
+    from app.services.market_news_briefing_formatter import format_market_news_briefing
+
+    etf_flows = _article(
+        "BlackRock ETF inflows accelerate as institutions add to reserves",
+        market="crypto",
+        feed_source="rss_cointelegraph",
+    )
+
+    briefing = format_market_news_briefing([etf_flows], market="crypto", limit=10)
+
+    assert briefing.summary["included"] == 1
+    assert [section.section_id for section in briefing.sections] == [
+        "etf_institutional"
+    ]
+    assert briefing.sections[0].title == "ETF / Institutional Flows"
+    assert briefing.sections[0].items[0].relevance.matched_terms == [
+        "blackrock",
+        "etf",
+        "inflow",
+        "reserve",
+    ]
+
+
 @pytest.mark.asyncio
 @pytest.mark.unit
 async def test_market_news_briefing_filter_formats_us_sections_for_mcp():


### PR DESCRIPTION
## Summary
- Route crypto `etf_institutional` relevance results to the dedicated ETF / Institutional Flows briefing section
- Add regression coverage for ETF/institutional crypto briefing grouping
- Preserve raw news ingestion and existing read-layer formatter behavior for other sections

## Verification
- `uv run pytest tests/test_market_news_briefing_formatter.py::test_format_crypto_news_routes_etf_institutional_to_dedicated_section -q` — 1 passed
- `uv run pytest tests/test_market_news_briefing_formatter.py tests/test_mcp_news_crypto_relevance.py tests/test_crypto_news_relevance_service.py -q` — 11 passed
- `uv run pytest tests/test_news_ingestor_bulk.py tests/test_news_readiness_contract.py tests/test_router_preopen_news_brief.py tests/services/test_kr_preopen_news_brief_service.py tests/test_market_news_briefing_formatter.py tests/test_mcp_news_crypto_relevance.py tests/test_crypto_news_relevance_service.py -q` — 74 passed
- `uv run ruff check app/services/market_news_briefing_formatter.py tests/test_market_news_briefing_formatter.py` — passed
- `uv run ruff format --check app/services/market_news_briefing_formatter.py tests/test_market_news_briefing_formatter.py` — passed

Refs: market-news briefing formatter follow-up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the categorization of ETF and institutional flow articles; they now appear in a dedicated "ETF / Institutional Flows" section instead of being grouped with general market news.

* **Tests**
  * Added test coverage for ETF and institutional market news article routing and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->