### PR TITLE
fix: filter low-signal US briefing news

### DIFF
--- a/app/services/market_news_briefing_formatter.py
+++ b/app/services/market_news_briefing_formatter.py
@@ -221,6 +221,38 @@ _NOISE_TERMS = (
     "wedding",
     "engagement",
 )
+_US_LOW_SIGNAL_TERMS = (
+    "high-yield savings",
+    "savings account",
+    "savings interest",
+    "apy",
+    "mortgage rates",
+    "home buyers",
+    "home-buying",
+    "streaming in",
+    "netflix",
+    "hulu",
+    "hbo max",
+)
+_US_HIGH_SIGNAL_TERMS = (
+    "fed",
+    "fomc",
+    "cpi",
+    "inflation",
+    "treasury",
+    "s&p",
+    "s&p 500",
+    "nasdaq",
+    "dow",
+    "earnings",
+    "guidance",
+    "stock",
+    "stocks",
+    "shares",
+    "analyst",
+    "upgrade",
+    "downgrade",
+)
 
 
 def _field(article: Any, name: str) -> Any:
@@ -235,6 +267,26 @@ def _article_text(article: Any) -> tuple[str, str]:
     keywords = _field(article, "keywords") or []
     keyword_text = " ".join(str(keyword) for keyword in keywords)
     return title.lower(), f"{title} {summary} {keyword_text}".lower()
+
+
+def _low_signal_us_noise_hit(article: Any) -> bool:
+    if _field(article, "stock_symbol"):
+        return False
+    title, full_text = _article_text(article)
+    if not any(term in full_text for term in _US_LOW_SIGNAL_TERMS):
+        return False
+    return not any(term in title for term in _US_HIGH_SIGNAL_TERMS)
+
+
+def _low_market_relevance() -> BriefingRelevance:
+    return BriefingRelevance(
+        score=0,
+        section_id=None,
+        section_title=None,
+        include_in_briefing=False,
+        matched_terms=[],
+        reason="low_market_relevance",
+    )
 
 
 def _score_rule(article: Any, rules: tuple[_SectionRule, ...]) -> BriefingRelevance:
@@ -307,6 +359,8 @@ def _section_order_for_market(market: str) -> list[str]:
 def _score_article(article: Any, market: str) -> BriefingRelevance:
     if market == "crypto":
         return _score_crypto(article)
+    if market == "us" and _low_signal_us_noise_hit(article):
+        return _low_market_relevance()
     return _score_rule(article, _rules_for_market(market))
 
 

--- a/tests/test_market_news_briefing_formatter.py
+++ b/tests/test_market_news_briefing_formatter.py
@@ -71,6 +71,41 @@ def test_format_us_news_groups_macro_big_tech_earnings_and_noise():
 
 
 @pytest.mark.unit
+def test_format_us_news_excludes_personal_finance_and_lifestyle_rate_noise():
+    from app.services.market_news_briefing_formatter import format_market_news_briefing
+
+    savings_rate = _article(
+        "Best high-yield savings interest rates today, April 30, 2026",
+        market="us",
+        summary="A personal finance roundup of accounts paying 4.1% APY.",
+    )
+    mortgage_rate = _article(
+        "Mortgage rates increase to 6.3% — but home buyers are not scared away",
+        market="us",
+        summary="Consumer mortgage and home-buying advice rather than market-moving macro.",
+    )
+    fed_rate = _article(
+        "Fed rate cut hopes lift S&P 500 futures before CPI report",
+        market="us",
+        summary="Inflation data and Treasury yields remain the macro focus.",
+    )
+
+    briefing = format_market_news_briefing(
+        [savings_rate, mortgage_rate, fed_rate], market="us", limit=10
+    )
+
+    assert briefing.summary["included"] == 1
+    assert briefing.sections[0].items[0].article.title == fed_rate.title
+    assert {item.article.title for item in briefing.excluded} == {
+        savings_rate.title,
+        mortgage_rate.title,
+    }
+    assert all(
+        item.relevance.reason == "low_market_relevance" for item in briefing.excluded
+    )
+
+
+@pytest.mark.unit
 def test_format_kr_news_groups_preopen_sector_disclosure_and_flow():
     from app.services.market_news_briefing_formatter import format_market_news_briefing
 


### PR DESCRIPTION
## Summary
- Add a US-specific low-signal noise guard for personal-finance/lifestyle rate stories in market news briefings
- Keep true macro/market signals such as Fed/CPI/Treasury/S&P/earnings/analyst headlines eligible for briefing inclusion
- Add regression coverage for high-yield savings and mortgage-rate stories that were being pulled into Macro/Fed via generic `rate` matches

## Test Plan
- `uv run pytest tests/test_market_news_briefing_formatter.py::test_format_us_news_excludes_personal_finance_and_lifestyle_rate_noise -q`
- `uv run pytest tests/test_market_news_briefing_formatter.py tests/test_mcp_news_crypto_relevance.py tests/test_crypto_news_relevance_service.py -q`
- `uv run ruff check app/services/market_news_briefing_formatter.py tests/test_market_news_briefing_formatter.py`
- `uv run ruff format --check app/services/market_news_briefing_formatter.py tests/test_market_news_briefing_formatter.py`
- `uv run pytest tests/test_news_ingestor_bulk.py tests/test_news_readiness_contract.py tests/test_router_preopen_news_brief.py tests/services/test_kr_preopen_news_brief_service.py tests/test_market_news_briefing_formatter.py tests/test_mcp_news_crypto_relevance.py tests/test_crypto_news_relevance_service.py -q`