### PR TITLE
feat: add Alpaca paper crypto preview smoke MVP

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -142,7 +142,8 @@ paper-only, confirm-gated `alpaca_paper_submit_order` and
 `alpaca_paper_cancel_order` tools for dev-owned smoke, with no runtime live
 switch and no bulk/by-symbol cancel. ROB-74 extends those explicit paper-only
 surfaces to a narrow crypto contract: buy-only, limit-only, allowlisted symbols
-(`BTC/USD`, `ETH/USD`, `SOL/USD`), and a $50 max notional/estimated-cost cap.
+(`BTC/USD`, `ETH/USD`, `SOL/USD`), `time_in_force` limited to `gtc`/`ioc`,
+and a $50 max notional/estimated-cost cap.
 There is still no Alpaca paper `place_order`, `replace_order`, `modify_order`,
 `cancel_all`, or generic Alpaca order-routing surface.
 
@@ -156,8 +157,9 @@ Dev submit/cancel smoke helper: `scripts/smoke/alpaca_paper_dev_smoke.py` (previ
 ROB-70 adds `alpaca_paper_preview_order`: a side-effect-free validator + echo tool.
 ROB-74 extends preview to a narrow Alpaca paper crypto shape without adding any
 broker side effects: `asset_class="crypto"` supports only `BTC/USD`, `ETH/USD`,
-and `SOL/USD`, is buy-only and limit-only, and is capped at $50 notional or
-estimated cost.
+and `SOL/USD`, is buy-only and limit-only, defaults omitted `time_in_force` to
+`gtc`, rejects crypto `day`/`fok`, and is capped at $50 notional or estimated
+cost.
 
 **Signature:**
 ```
@@ -167,7 +169,7 @@ alpaca_paper_preview_order(
     type,            # "market" | "limit"  (crypto: limit only)
     qty=None,        # Decimal quantity (xor notional)
     notional=None,   # Decimal notional USD (xor qty; crypto limit allowed)
-    time_in_force="day",   # "day" | "gtc" | "ioc" | "fok"
+    time_in_force=None,    # omitted => day for us_equity, gtc for crypto; crypto allows only "gtc" | "ioc"
     limit_price=None,      # required for limit orders, forbidden for equity market
     stop_price=None,       # always rejected (deferred)
     client_order_id=None,  # optional, 1-48 chars
@@ -183,7 +185,7 @@ alpaca_paper_preview_order(
 - `limit_price`: required for limit orders, forbidden for US-equity market orders, must be > 0
 - `stop_price`: always rejected with explicit error
 - `asset_class`: `"us_equity"` or `"crypto"`; other values rejected
-- `time_in_force`: one of `"day"`, `"gtc"`, `"ioc"`, `"fok"`
+- `time_in_force`: omitted/blank defaults to `"day"` for US equities and `"gtc"` for crypto; US equities allow `"day"`, `"gtc"`, `"ioc"`, `"fok"`; crypto allows only `"gtc"` or `"ioc"`
 - For `asset_class="us_equity"`, `notional + type="limit"` is rejected (Alpaca only supports equity notional for market orders in this surface)
 - For `asset_class="crypto"`, only `BTC/USD`, `ETH/USD`, and `SOL/USD` are supported; orders are buy-only, limit-only, require `limit_price`, permit `notional + limit_price`, and cap notional or `qty * limit_price` at $50
 

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -140,9 +140,11 @@ service-level endpoint guard: the trading base URL must be exactly
 Safety boundary: there are no Alpaca live MCP tools. ROB-73 adds explicit
 paper-only, confirm-gated `alpaca_paper_submit_order` and
 `alpaca_paper_cancel_order` tools for dev-owned smoke, with no runtime live
-switch and no bulk/by-symbol cancel. There is still no Alpaca paper
-`place_order`, `replace_order`, `modify_order`, `cancel_all`, or generic
-Alpaca order-routing surface.
+switch and no bulk/by-symbol cancel. ROB-74 extends those explicit paper-only
+surfaces to a narrow crypto contract: buy-only, limit-only, allowlisted symbols
+(`BTC/USD`, `ETH/USD`, `SOL/USD`), and a $50 max notional/estimated-cost cap.
+There is still no Alpaca paper `place_order`, `replace_order`, `modify_order`,
+`cancel_all`, or generic Alpaca order-routing surface.
 
 Read-only operator runbook: [`docs/runbooks/alpaca-paper-readonly-smoke.md`](../../docs/runbooks/alpaca-paper-readonly-smoke.md)
 Read-only smoke helper: `scripts/smoke/alpaca_paper_readonly_smoke.py` (argumentless, read-only, exits non-zero on failure)
@@ -152,20 +154,24 @@ Dev submit/cancel smoke helper: `scripts/smoke/alpaca_paper_dev_smoke.py` (previ
 ### Alpaca paper order preview
 
 ROB-70 adds `alpaca_paper_preview_order`: a side-effect-free validator + echo tool.
+ROB-74 extends preview to a narrow Alpaca paper crypto shape without adding any
+broker side effects: `asset_class="crypto"` supports only `BTC/USD`, `ETH/USD`,
+and `SOL/USD`, is buy-only and limit-only, and is capped at $50 notional or
+estimated cost.
 
 **Signature:**
 ```
 alpaca_paper_preview_order(
-    symbol,          # US equity ticker (1-10 chars, uppercased)
-    side,            # "buy" | "sell"
-    type,            # "market" | "limit"  (stop/stop_limit deferred)
+    symbol,          # US equity ticker or allowlisted crypto pair (uppercased)
+    side,            # "buy" | "sell" (crypto: buy only)
+    type,            # "market" | "limit"  (crypto: limit only)
     qty=None,        # Decimal quantity (xor notional)
-    notional=None,   # Decimal notional USD (xor qty; market orders only)
+    notional=None,   # Decimal notional USD (xor qty; crypto limit allowed)
     time_in_force="day",   # "day" | "gtc" | "ioc" | "fok"
-    limit_price=None,      # required for limit orders, forbidden for market
+    limit_price=None,      # required for limit orders, forbidden for equity market
     stop_price=None,       # always rejected (deferred)
     client_order_id=None,  # optional, 1-48 chars
-    asset_class="us_equity",  # only "us_equity" supported
+    asset_class="us_equity",  # "us_equity" or ROB-74 "crypto"
 )
 ```
 
@@ -174,11 +180,12 @@ alpaca_paper_preview_order(
 - `side`: `"buy"` or `"sell"`; case-insensitive
 - `type`: `"market"` or `"limit"`; stop/stop_limit deferred
 - `qty` xor `notional`: exactly one required
-- `notional` + `type="limit"`: rejected (Alpaca only supports notional for market orders)
-- `limit_price`: required for `type="limit"`, forbidden for `type="market"`, must be > 0
+- `limit_price`: required for limit orders, forbidden for US-equity market orders, must be > 0
 - `stop_price`: always rejected with explicit error
-- `asset_class`: only `"us_equity"`; `"crypto"` and others rejected
+- `asset_class`: `"us_equity"` or `"crypto"`; other values rejected
 - `time_in_force`: one of `"day"`, `"gtc"`, `"ioc"`, `"fok"`
+- For `asset_class="us_equity"`, `notional + type="limit"` is rejected (Alpaca only supports equity notional for market orders in this surface)
+- For `asset_class="crypto"`, only `BTC/USD`, `ETH/USD`, and `SOL/USD` are supported; orders are buy-only, limit-only, require `limit_price`, permit `notional + limit_price`, and cap notional or `qty * limit_price` at $50
 
 **Return shape:**
 ```json

--- a/app/mcp_server/tooling/__init__.py
+++ b/app/mcp_server/tooling/__init__.py
@@ -16,27 +16,8 @@ This package contains the refactored MCP tools split by domain:
 
 from __future__ import annotations
 
-from app.mcp_server.tooling.market_report_registration import (
-    MARKET_REPORT_TOOL_NAMES,
-    register_market_report_tools,
-)
-from app.mcp_server.tooling.news_registration import (
-    NEWS_TOOL_NAMES,
-    register_news_tools,
-)
-from app.mcp_server.tooling.registry import register_all_tools
-from app.mcp_server.tooling.trade_journal_registration import (
-    TRADE_JOURNAL_TOOL_NAMES,
-    register_trade_journal_tools,
-)
-from app.mcp_server.tooling.trade_profile_registration import (
-    TRADE_PROFILE_TOOL_NAMES,
-    register_trade_profile_tools,
-)
-from app.mcp_server.tooling.watch_alerts_registration import (
-    WATCH_ALERT_TOOL_NAMES,
-    register_watch_alert_tools,
-)
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     "MARKET_REPORT_TOOL_NAMES",
@@ -51,3 +32,66 @@ __all__ = [
     "register_watch_alert_tools",
     "register_news_tools",
 ]
+
+_LAZY_EXPORTS: dict[str, tuple[str, str]] = {
+    "MARKET_REPORT_TOOL_NAMES": (
+        "app.mcp_server.tooling.market_report_registration",
+        "MARKET_REPORT_TOOL_NAMES",
+    ),
+    "register_market_report_tools": (
+        "app.mcp_server.tooling.market_report_registration",
+        "register_market_report_tools",
+    ),
+    "NEWS_TOOL_NAMES": (
+        "app.mcp_server.tooling.news_registration",
+        "NEWS_TOOL_NAMES",
+    ),
+    "register_news_tools": (
+        "app.mcp_server.tooling.news_registration",
+        "register_news_tools",
+    ),
+    "register_all_tools": (
+        "app.mcp_server.tooling.registry",
+        "register_all_tools",
+    ),
+    "TRADE_JOURNAL_TOOL_NAMES": (
+        "app.mcp_server.tooling.trade_journal_registration",
+        "TRADE_JOURNAL_TOOL_NAMES",
+    ),
+    "register_trade_journal_tools": (
+        "app.mcp_server.tooling.trade_journal_registration",
+        "register_trade_journal_tools",
+    ),
+    "TRADE_PROFILE_TOOL_NAMES": (
+        "app.mcp_server.tooling.trade_profile_registration",
+        "TRADE_PROFILE_TOOL_NAMES",
+    ),
+    "register_trade_profile_tools": (
+        "app.mcp_server.tooling.trade_profile_registration",
+        "register_trade_profile_tools",
+    ),
+    "WATCH_ALERT_TOOL_NAMES": (
+        "app.mcp_server.tooling.watch_alerts_registration",
+        "WATCH_ALERT_TOOL_NAMES",
+    ),
+    "register_watch_alert_tools": (
+        "app.mcp_server.tooling.watch_alerts_registration",
+        "register_watch_alert_tools",
+    ),
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Load public registration helpers lazily.
+
+    Importing this package should be side-effect-light so tools such as coverage can
+    resolve a specific submodule without importing the whole MCP registry tree first.
+    """
+    try:
+        module_name, attr_name = _LAZY_EXPORTS[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+    value = getattr(import_module(module_name), attr_name)
+    globals()[name] = value
+    return value

--- a/app/mcp_server/tooling/alpaca_paper_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_orders.py
@@ -122,7 +122,7 @@ async def alpaca_paper_submit_order(
     asset_class: str = "us_equity",
     confirm: bool = False,
 ) -> dict[str, Any]:
-    """Submit a single Alpaca PAPER order (us_equity only).
+    """Submit a single Alpaca PAPER order (us_equity or narrow crypto).
 
     Defaults to ``confirm=False`` which performs no broker call.
     """

--- a/app/mcp_server/tooling/alpaca_paper_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_orders.py
@@ -20,7 +20,10 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
-from app.mcp_server.tooling.alpaca_paper_preview import PreviewOrderInput
+from app.mcp_server.tooling.alpaca_paper_preview import (
+    ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD,
+    PreviewOrderInput,
+)
 from app.services.brokers.alpaca.schemas import OrderRequest
 from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
 
@@ -86,7 +89,8 @@ def _canonical_payload(validated: PreviewOrderInput) -> dict[str, Any]:
 def _derive_client_order_id(payload: dict[str, Any]) -> str:
     blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     digest = hashlib.sha256(blob).hexdigest()[:16]
-    return f"rob73-{digest}"
+    prefix = "rob74-crypto" if payload.get("asset_class") == "crypto" else "rob73"
+    return f"{prefix}-{digest}"
 
 
 def _validate_exact_order_id(order_id: str) -> str:
@@ -135,20 +139,29 @@ async def alpaca_paper_submit_order(
         asset_class=asset_class,
     )
 
-    if validated.qty is not None and validated.qty > SUBMIT_MAX_QTY:
+    submit_notional_cap = (
+        ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD
+        if validated.asset_class == "crypto"
+        else SUBMIT_MAX_NOTIONAL_USD
+    )
+    if (
+        validated.asset_class != "crypto"
+        and validated.qty is not None
+        and validated.qty > SUBMIT_MAX_QTY
+    ):
         raise ValueError(f"qty {validated.qty} exceeds submit cap ({SUBMIT_MAX_QTY})")
-    if validated.notional is not None and validated.notional > SUBMIT_MAX_NOTIONAL_USD:
+    if validated.notional is not None and validated.notional > submit_notional_cap:
         raise ValueError(
-            f"notional {validated.notional} exceeds submit cap ({SUBMIT_MAX_NOTIONAL_USD})"
+            f"notional {validated.notional} exceeds submit cap ({submit_notional_cap})"
         )
     if (
         validated.qty is not None
         and validated.limit_price is not None
-        and validated.qty * validated.limit_price > SUBMIT_MAX_NOTIONAL_USD
+        and validated.qty * validated.limit_price > submit_notional_cap
     ):
         raise ValueError(
             f"estimated_cost {validated.qty * validated.limit_price} "
-            f"exceeds submit cap ({SUBMIT_MAX_NOTIONAL_USD})"
+            f"exceeds submit cap ({submit_notional_cap})"
         )
 
     canonical = _canonical_payload(validated)
@@ -230,11 +243,12 @@ def register_alpaca_paper_orders_tools(mcp: FastMCP) -> None:
     _ = mcp.tool(
         name="alpaca_paper_submit_order",
         description=(
-            "Submit a single Alpaca PAPER us_equity order. "
+            "Submit a single Alpaca PAPER us_equity or narrow crypto order. "
             "Defaults to confirm=False which validates and returns the request "
             "WITHOUT calling the broker. Use confirm=True to actually submit. "
             "Paper endpoint only; live endpoint cannot be selected. "
-            "Strict caps: qty<=5, notional<=$1000, qty*limit_price<=$1000."
+            "Strict caps: us_equity qty<=5/notional<=$1000/qty*limit_price<=$1000; "
+            "crypto is buy-limit-only, allowlisted, and capped at $50."
         ),
     )(alpaca_paper_submit_order)
     _ = mcp.tool(

--- a/app/mcp_server/tooling/alpaca_paper_orders.py
+++ b/app/mcp_server/tooling/alpaca_paper_orders.py
@@ -116,7 +116,7 @@ async def alpaca_paper_submit_order(
     type: str,  # noqa: A002
     qty: Decimal | None = None,
     notional: Decimal | None = None,
-    time_in_force: str = "day",
+    time_in_force: str | None = None,
     limit_price: Decimal | None = None,
     client_order_id: str | None = None,
     asset_class: str = "us_equity",

--- a/app/mcp_server/tooling/alpaca_paper_preview.py
+++ b/app/mcp_server/tooling/alpaca_paper_preview.py
@@ -234,7 +234,7 @@ async def alpaca_paper_preview_order(
     client_order_id: str | None = None,
     asset_class: str = "us_equity",
 ) -> dict[str, Any]:
-    """Preview and validate an Alpaca paper US equity order without submitting it.
+    """Preview and validate an Alpaca paper US equity or narrow crypto order without submitting it.
 
     Pure validator + echo — preview only, no side effects, does not submit.
     Does NOT call POST /v2/orders. Submission goes through the explicit,
@@ -323,7 +323,8 @@ def register_alpaca_paper_preview_tools(mcp: FastMCP) -> None:
     _ = mcp.tool(
         name="alpaca_paper_preview_order",
         description=(
-            "Preview and validate an Alpaca paper US equity order without submitting it. "
+            "Preview and validate an Alpaca paper US equity or narrow crypto order "
+            "without submitting it. "
             "Pure validator + echo — preview only, no side effects, does not submit. "
             "Does NOT call POST /v2/orders. "
             "Submission goes through the explicit, paper-only, confirm-gated "

--- a/app/mcp_server/tooling/alpaca_paper_preview.py
+++ b/app/mcp_server/tooling/alpaca_paper_preview.py
@@ -25,6 +25,14 @@ if TYPE_CHECKING:
     from fastmcp import FastMCP
 
 ALPACA_PAPER_PREVIEW_TOOL_NAMES: set[str] = {"alpaca_paper_preview_order"}
+ALPACA_PAPER_CRYPTO_ALLOWED_SYMBOLS: frozenset[str] = frozenset(
+    {
+        "BTC/USD",
+        "ETH/USD",
+        "SOL/USD",
+    }
+)
+ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD: Decimal = Decimal("50")
 
 # Referenced by tests to confirm these methods are never called on the preview path
 _FORBIDDEN_SERVICE_METHODS = ("submit_order", "cancel_order")
@@ -149,9 +157,9 @@ class PreviewOrderInput(BaseModel):
     @classmethod
     def validate_asset_class(cls, v: str) -> str:
         normalized = v.strip().lower()
-        if normalized != "us_equity":
+        if normalized not in {"us_equity", "crypto"}:
             raise ValueError(
-                f"asset_class '{v}' not supported in preview (us_equity only)"
+                f"asset_class '{v}' not supported in preview (us_equity or crypto only)"
             )
         return normalized
 
@@ -172,7 +180,36 @@ class PreviewOrderInput(BaseModel):
         if not has_qty and not has_notional:
             raise ValueError("exactly one of qty or notional is required")
 
-        # notional + limit type is rejected — Alpaca only supports notional for market orders
+        if self.asset_class == "crypto":
+            if self.symbol not in ALPACA_PAPER_CRYPTO_ALLOWED_SYMBOLS:
+                allowed = ", ".join(sorted(ALPACA_PAPER_CRYPTO_ALLOWED_SYMBOLS))
+                raise ValueError(f"crypto symbol must be one of: {allowed}")
+            if self.side != "buy":
+                raise ValueError("crypto preview is buy-only")
+            if self.type != "limit":
+                raise ValueError("crypto preview is limit-only")
+            if self.limit_price is None:
+                raise ValueError("limit_price is required for crypto limit orders")
+            if (
+                self.notional is not None
+                and self.notional > ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD
+            ):
+                raise ValueError(
+                    "crypto notional exceeds max "
+                    f"({ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD})"
+                )
+            if (
+                self.qty is not None
+                and self.qty * self.limit_price > ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD
+            ):
+                raise ValueError(
+                    "crypto estimated_cost exceeds max "
+                    f"({ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD})"
+                )
+            return self
+
+        # notional + limit type is rejected for US equities — Alpaca only
+        # supports equity notional orders for market orders in this surface.
         if has_notional and self.type == "limit":
             raise ValueError("notional is not supported for limit orders")
 
@@ -251,14 +288,21 @@ async def alpaca_paper_preview_order(
     except (AlpacaPaperConfigurationError, AlpacaPaperRequestError):
         warnings.append("context_unavailable")
 
-    if (
-        validated.qty is not None
-        and validated.limit_price is not None
-        and account_context is not None
-    ):
+    if validated.qty is not None and validated.limit_price is not None:
         cost = validated.qty * validated.limit_price
         estimated_cost = str(cost)
-        would_exceed_buying_power = cost > Decimal(account_context["buying_power"])
+        would_exceed_buying_power = (
+            cost > Decimal(account_context["buying_power"])
+            if account_context is not None
+            else None
+        )
+    elif validated.asset_class == "crypto" and validated.notional is not None:
+        estimated_cost = str(validated.notional)
+        would_exceed_buying_power = (
+            validated.notional > Decimal(account_context["buying_power"])
+            if account_context is not None
+            else None
+        )
 
     return {
         "success": True,
@@ -293,6 +337,8 @@ def register_alpaca_paper_preview_tools(mcp: FastMCP) -> None:
 
 
 __all__ = [
+    "ALPACA_PAPER_CRYPTO_ALLOWED_SYMBOLS",
+    "ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD",
     "ALPACA_PAPER_PREVIEW_TOOL_NAMES",
     "_FORBIDDEN_SERVICE_METHODS",
     "PreviewOrderInput",

--- a/app/mcp_server/tooling/alpaca_paper_preview.py
+++ b/app/mcp_server/tooling/alpaca_paper_preview.py
@@ -33,6 +33,10 @@ ALPACA_PAPER_CRYPTO_ALLOWED_SYMBOLS: frozenset[str] = frozenset(
     }
 )
 ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD: Decimal = Decimal("50")
+ALPACA_PAPER_EQUITY_TIME_IN_FORCE: frozenset[str] = frozenset(
+    {"day", "gtc", "ioc", "fok"}
+)
+ALPACA_PAPER_CRYPTO_TIME_IN_FORCE: frozenset[str] = frozenset({"gtc", "ioc"})
 
 # Referenced by tests to confirm these methods are never called on the preview path
 _FORBIDDEN_SERVICE_METHODS = ("submit_order", "cancel_order")
@@ -68,11 +72,31 @@ class PreviewOrderInput(BaseModel):
     type: str  # noqa: A003
     qty: Decimal | None = None
     notional: Decimal | None = None
-    time_in_force: str = "day"
+    time_in_force: str | None = None
     limit_price: Decimal | None = None
     stop_price: Decimal | None = None
     client_order_id: str | None = None
     asset_class: str = "us_equity"
+
+    @model_validator(mode="before")
+    @classmethod
+    def default_time_in_force_for_asset_class(cls, data: Any) -> Any:
+        """Default omitted TIF per asset class before field validation.
+
+        Alpaca accepts only gtc/ioc for crypto.  Keep the historical day default
+        for US equities, but ensure omitted crypto TIF never normalizes to day.
+        """
+        if not isinstance(data, dict):
+            return data
+        raw_asset_class = str(data.get("asset_class") or "us_equity").strip().lower()
+        raw_tif = data.get("time_in_force")
+        if raw_tif is None or (isinstance(raw_tif, str) and not raw_tif.strip()):
+            normalized = dict(data)
+            normalized["time_in_force"] = (
+                "gtc" if raw_asset_class == "crypto" else "day"
+            )
+            return normalized
+        return data
 
     @field_validator("symbol")
     @classmethod
@@ -137,8 +161,9 @@ class PreviewOrderInput(BaseModel):
     @classmethod
     def validate_tif(cls, v: str) -> str:
         normalized = v.strip().lower()
-        if normalized not in {"day", "gtc", "ioc", "fok"}:
-            raise ValueError("time_in_force must be one of: day, gtc, ioc, fok")
+        if normalized not in ALPACA_PAPER_EQUITY_TIME_IN_FORCE:
+            allowed = ", ".join(sorted(ALPACA_PAPER_EQUITY_TIME_IN_FORCE))
+            raise ValueError(f"time_in_force must be one of: {allowed}")
         return normalized
 
     @field_validator("client_order_id")
@@ -182,6 +207,9 @@ class PreviewOrderInput(BaseModel):
             raise ValueError("crypto preview is buy-only")
         if self.type != "limit":
             raise ValueError("crypto preview is limit-only")
+        if self.time_in_force not in ALPACA_PAPER_CRYPTO_TIME_IN_FORCE:
+            allowed_tif = ", ".join(sorted(ALPACA_PAPER_CRYPTO_TIME_IN_FORCE))
+            raise ValueError(f"crypto time_in_force must be one of: {allowed_tif}")
         if self.limit_price is None:
             raise ValueError("limit_price is required for crypto limit orders")
         if (
@@ -229,7 +257,7 @@ async def alpaca_paper_preview_order(
     type: str,  # noqa: A002
     qty: Decimal | None = None,
     notional: Decimal | None = None,
-    time_in_force: str = "day",
+    time_in_force: str | None = None,
     limit_price: Decimal | None = None,
     stop_price: Decimal | None = None,
     client_order_id: str | None = None,

--- a/app/mcp_server/tooling/alpaca_paper_preview.py
+++ b/app/mcp_server/tooling/alpaca_paper_preview.py
@@ -170,55 +170,56 @@ class PreviewOrderInput(BaseModel):
             raise ValueError("limit_price must be > 0")
         return v
 
+    def _validate_quantity_selection(self, has_qty: bool, has_notional: bool) -> None:
+        if has_qty == has_notional:
+            raise ValueError("exactly one of qty or notional is required")
+
+    def _validate_crypto_rules(self) -> None:
+        if self.symbol not in ALPACA_PAPER_CRYPTO_ALLOWED_SYMBOLS:
+            allowed = ", ".join(sorted(ALPACA_PAPER_CRYPTO_ALLOWED_SYMBOLS))
+            raise ValueError(f"crypto symbol must be one of: {allowed}")
+        if self.side != "buy":
+            raise ValueError("crypto preview is buy-only")
+        if self.type != "limit":
+            raise ValueError("crypto preview is limit-only")
+        if self.limit_price is None:
+            raise ValueError("limit_price is required for crypto limit orders")
+        if (
+            self.notional is not None
+            and self.notional > ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD
+        ):
+            raise ValueError(
+                f"crypto notional exceeds max ({ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD})"
+            )
+        if (
+            self.qty is not None
+            and self.qty * self.limit_price > ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD
+        ):
+            raise ValueError(
+                "crypto estimated_cost exceeds max "
+                f"({ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD})"
+            )
+
+    def _validate_equity_rules(self, has_notional: bool) -> None:
+        # notional + limit type is rejected for US equities — Alpaca only
+        # supports equity notional orders for market orders in this surface.
+        if has_notional and self.type == "limit":
+            raise ValueError("notional is not supported for limit orders")
+        if self.type == "limit" and self.limit_price is None:
+            raise ValueError("limit_price is required for limit orders")
+        if self.type == "market" and self.limit_price is not None:
+            raise ValueError("limit_price is not allowed for market orders")
+
     @model_validator(mode="after")
     def validate_cross_field_rules(self) -> PreviewOrderInput:
         has_qty = self.qty is not None
         has_notional = self.notional is not None
 
-        if has_qty and has_notional:
-            raise ValueError("exactly one of qty or notional is required")
-        if not has_qty and not has_notional:
-            raise ValueError("exactly one of qty or notional is required")
-
+        self._validate_quantity_selection(has_qty, has_notional)
         if self.asset_class == "crypto":
-            if self.symbol not in ALPACA_PAPER_CRYPTO_ALLOWED_SYMBOLS:
-                allowed = ", ".join(sorted(ALPACA_PAPER_CRYPTO_ALLOWED_SYMBOLS))
-                raise ValueError(f"crypto symbol must be one of: {allowed}")
-            if self.side != "buy":
-                raise ValueError("crypto preview is buy-only")
-            if self.type != "limit":
-                raise ValueError("crypto preview is limit-only")
-            if self.limit_price is None:
-                raise ValueError("limit_price is required for crypto limit orders")
-            if (
-                self.notional is not None
-                and self.notional > ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD
-            ):
-                raise ValueError(
-                    "crypto notional exceeds max "
-                    f"({ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD})"
-                )
-            if (
-                self.qty is not None
-                and self.qty * self.limit_price > ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD
-            ):
-                raise ValueError(
-                    "crypto estimated_cost exceeds max "
-                    f"({ALPACA_PAPER_CRYPTO_MAX_NOTIONAL_USD})"
-                )
-            return self
-
-        # notional + limit type is rejected for US equities — Alpaca only
-        # supports equity notional orders for market orders in this surface.
-        if has_notional and self.type == "limit":
-            raise ValueError("notional is not supported for limit orders")
-
-        if self.type == "limit" and self.limit_price is None:
-            raise ValueError("limit_price is required for limit orders")
-
-        if self.type == "market" and self.limit_price is not None:
-            raise ValueError("limit_price is not allowed for market orders")
-
+            self._validate_crypto_rules()
+        else:
+            self._validate_equity_rules(has_notional)
         return self
 
 

--- a/docs/runbooks/alpaca-paper-dev-smoke.md
+++ b/docs/runbooks/alpaca-paper-dev-smoke.md
@@ -12,7 +12,7 @@ intentionally hard to run with side effects by accident.
 - Adapter-specific paper-only tools. No live endpoint, no data endpoint as trading base, no generic order route, no bulk cancel.
 - Default mode: preview only. No broker mutations, no `submit_order` / `cancel_order` HTTP calls.
 - Side-effect mode requires BOTH a CLI flag (`--confirm-paper-side-effect`) AND an env var (`ALPACA_PAPER_SMOKE_ALLOW_SIDE_EFFECTS=1`). Either alone exits with code 2 and zero broker calls.
-- Side-effect smoke places ONE tiny PAPER order. Default equity mode uses `AAPL` buy `1` share `limit @ $1.00`; ROB-74 crypto mode is buy-only, limit-only, allowlisted (`BTC/USD`, `ETH/USD`, `SOL/USD`), capped at $50 notional/estimated cost, and requires an explicit `--limit-price`. If market behaviour fills the order before cancel, mark the result PARTIAL and document in the report.
+- Side-effect smoke places ONE tiny PAPER order. Default equity mode uses `AAPL` buy `1` share `limit @ $1.00`; ROB-74 crypto mode is buy-only, limit-only, allowlisted (`BTC/USD`, `ETH/USD`, `SOL/USD`), capped at $50 notional/estimated cost, defaults omitted `--time-in-force` to `gtc`, accepts only `gtc`/`ioc`, and requires an explicit `--limit-price`. If market behaviour fills the order before cancel, mark the result PARTIAL and document in the report.
 - ROB-74 candidate reports are operator metadata only: pass the path with `--candidate-report`; the script validates that the file exists and prints only `candidate_report_attached=True`, never report contents or derived trade instructions.
 - Never run this from production hosts. This issue is dev-owned smoke.
 - Never paste API keys, secrets, Authorization headers, or raw broker payloads.
@@ -53,7 +53,8 @@ Exit code 0 = PASS. Any FAIL line → BLOCKED.
 
 Crypto mode remains preview-only unless the separate operator approval gate is
 explicitly unblocked. The operator chooses the allowlisted symbol, limit price,
-and notional; the script does not parse candidate reports into orders.
+notional, and optionally `--time-in-force gtc|ioc` (omitted defaults to `gtc`);
+the script does not parse candidate reports into orders.
 
 ```bash
 uv run python scripts/smoke/alpaca_paper_dev_smoke.py \
@@ -81,7 +82,8 @@ contents, secrets, account payloads, and raw broker responses are not emitted.
 
 Only run when explicitly authorised on a dev host. For ROB-74 crypto smoke,
 include `--asset-class crypto`, an allowlisted `--symbol`, `--notional` at or
-below `50`, and an explicit operator-approved `--limit-price`; do not run this
+below `50`, a crypto-valid `--time-in-force` (`gtc`/`ioc`, or omitted for
+`gtc`), and an explicit operator-approved `--limit-price`; do not run this
 until 광현님 unblocks the separate paper submit/cancel approval gate.
 
 ```bash

--- a/docs/runbooks/alpaca-paper-dev-smoke.md
+++ b/docs/runbooks/alpaca-paper-dev-smoke.md
@@ -1,7 +1,7 @@
 # Alpaca Paper Dev Smoke (Submit → Cancel) — Operator Runbook
 
 Owner: Dev (NOT production ops)
-Related issues: ROB-73 / ROB-72 / ROB-71 / ROB-70 / ROB-69
+Related issues: ROB-73 / ROB-74 / ROB-72 / ROB-71 / ROB-70 / ROB-69
 
 This runbook covers the dev-owned smoke for the two new MCP tools
 `alpaca_paper_submit_order` and `alpaca_paper_cancel_order`. The smoke is
@@ -12,7 +12,8 @@ intentionally hard to run with side effects by accident.
 - Adapter-specific paper-only tools. No live endpoint, no data endpoint as trading base, no generic order route, no bulk cancel.
 - Default mode: preview only. No broker mutations, no `submit_order` / `cancel_order` HTTP calls.
 - Side-effect mode requires BOTH a CLI flag (`--confirm-paper-side-effect`) AND an env var (`ALPACA_PAPER_SMOKE_ALLOW_SIDE_EFFECTS=1`). Either alone exits with code 2 and zero broker calls.
-- Side-effect smoke places ONE tiny PAPER order: `AAPL` buy `1` share `limit @ $1.00`. The price is far below market so the order should not fill before cancel. If market behaviour fills it, mark the result PARTIAL and document in the report.
+- Side-effect smoke places ONE tiny PAPER order. Default equity mode uses `AAPL` buy `1` share `limit @ $1.00`; ROB-74 crypto mode is buy-only, limit-only, allowlisted (`BTC/USD`, `ETH/USD`, `SOL/USD`), capped at $50 notional/estimated cost, and requires an explicit `--limit-price`. If market behaviour fills the order before cancel, mark the result PARTIAL and document in the report.
+- ROB-74 candidate reports are operator metadata only: pass the path with `--candidate-report`; the script validates that the file exists and prints only `candidate_report_attached=True`, never report contents or derived trade instructions.
 - Never run this from production hosts. This issue is dev-owned smoke.
 - Never paste API keys, secrets, Authorization headers, or raw broker payloads.
 
@@ -48,9 +49,40 @@ summary: PASS mode=preview_only
 
 Exit code 0 = PASS. Any FAIL line → BLOCKED.
 
+### ROB-74 crypto preview-only smoke
+
+Crypto mode remains preview-only unless the separate operator approval gate is
+explicitly unblocked. The operator chooses the allowlisted symbol, limit price,
+and notional; the script does not parse candidate reports into orders.
+
+```bash
+uv run python scripts/smoke/alpaca_paper_dev_smoke.py \
+    --asset-class crypto \
+    --symbol BTC/USD \
+    --notional 10 \
+    --limit-price 50000 \
+    --candidate-report /path/to/candidate-report.md
+```
+
+Expected output shape:
+
+```text
+  [OK] get_account: status=ACTIVE
+  [OK] get_cash: cash_set=True
+  [OK] submit_order(confirm=False): blocked_reason=confirmation_required
+  [OK] cancel_order(confirm=False): blocked_reason=confirmation_required
+summary: PASS mode=preview_only asset_class=crypto candidate_report_attached=True
+```
+
+The candidate-report path must exist if supplied. Only its presence is printed;
+contents, secrets, account payloads, and raw broker responses are not emitted.
+
 ## Step 3 — Side-effect smoke (BOTH gates required)
 
-Only run when explicitly authorised on a dev host.
+Only run when explicitly authorised on a dev host. For ROB-74 crypto smoke,
+include `--asset-class crypto`, an allowlisted `--symbol`, `--notional` at or
+below `50`, and an explicit operator-approved `--limit-price`; do not run this
+until 광현님 unblocks the separate paper submit/cancel approval gate.
 
 ```bash
 ALPACA_PAPER_SMOKE_ALLOW_SIDE_EFFECTS=1 \

--- a/scripts/smoke/alpaca_paper_dev_smoke.py
+++ b/scripts/smoke/alpaca_paper_dev_smoke.py
@@ -1,4 +1,4 @@
-"""Dev/operator-only Alpaca PAPER submit→cancel smoke (ROB-73).
+"""Dev/operator-only Alpaca PAPER submit→cancel smoke (ROB-73/ROB-74).
 
 Modes:
   Preview-only (default):
@@ -6,6 +6,10 @@ Modes:
     Calls account/cash + alpaca_paper_submit_order(confirm=False) +
     alpaca_paper_cancel_order(order_id='dummy', confirm=False).
     No broker mutations.
+
+    ROB-74 crypto preview metadata can be supplied with --asset-class crypto,
+    --symbol, --notional, --limit-price, and --candidate-report. These inputs
+    are echoed only as redacted summary flags.
 
   Side-effect mode (BOTH gates required):
       ALPACA_PAPER_SMOKE_ALLOW_SIDE_EFFECTS=1 \\
@@ -36,7 +40,8 @@ from app.mcp_server.tooling.alpaca_paper_orders import (
     alpaca_paper_submit_order,
 )
 
-SMOKE_SYMBOL = "AAPL"
+DEFAULT_EQUITY_SYMBOL = "AAPL"
+DEFAULT_CRYPTO_SYMBOL = "BTC/USD"
 SMOKE_QTY = Decimal("1")
 SMOKE_LIMIT_PRICE = Decimal("1.00")  # far below market — should not fill
 ENV_GATE = "ALPACA_PAPER_SMOKE_ALLOW_SIDE_EFFECTS"
@@ -66,7 +71,7 @@ async def _preview_only() -> int:
 
     try:
         submit_result = await alpaca_paper_submit_order(
-            symbol=SMOKE_SYMBOL,
+            symbol=DEFAULT_EQUITY_SYMBOL,
             side="buy",
             type="limit",
             qty=SMOKE_QTY,
@@ -105,7 +110,89 @@ async def _preview_only() -> int:
     return 0 if ok else 1
 
 
-async def _side_effect_smoke() -> int:
+def _order_payload(args: argparse.Namespace) -> dict[str, object]:
+    symbol = args.symbol or (
+        DEFAULT_CRYPTO_SYMBOL if args.asset_class == "crypto" else DEFAULT_EQUITY_SYMBOL
+    )
+    payload: dict[str, object] = {
+        "symbol": symbol,
+        "side": args.side,
+        "type": args.order_type,
+        "asset_class": args.asset_class,
+    }
+    if args.notional is not None:
+        payload["notional"] = args.notional
+    else:
+        payload["qty"] = args.qty
+    if args.limit_price is not None:
+        payload["limit_price"] = args.limit_price
+    elif args.asset_class != "crypto":
+        payload["limit_price"] = SMOKE_LIMIT_PRICE
+    return payload
+
+
+async def _preview_only_for_args(args: argparse.Namespace) -> int:
+    lines: list[tuple[str, bool, str]] = []
+    try:
+        acct = await alpaca_paper_get_account()
+        lines.append(
+            ("get_account", True, f"status={acct['account'].get('status', '?')}")
+        )
+    except Exception as exc:  # noqa: BLE001
+        lines.append(("get_account", False, f"ERROR: {type(exc).__name__}"))
+
+    try:
+        cash = await alpaca_paper_get_cash()
+        lines.append(
+            ("get_cash", True, f"cash_set={cash['cash'].get('cash') is not None}")
+        )
+    except Exception as exc:  # noqa: BLE001
+        lines.append(("get_cash", False, f"ERROR: {type(exc).__name__}"))
+
+    try:
+        submit_result = await alpaca_paper_submit_order(**_order_payload(args))
+        lines.append(
+            (
+                "submit_order(confirm=False)",
+                submit_result["submitted"] is False,
+                f"blocked_reason={submit_result.get('blocked_reason')}",
+            )
+        )
+    except Exception as exc:  # noqa: BLE001
+        lines.append(
+            ("submit_order(confirm=False)", False, f"ERROR: {type(exc).__name__}")
+        )
+
+    if args.asset_class != "crypto":
+        try:
+            cancel_result = await alpaca_paper_cancel_order(order_id="dummy-no-op")
+            lines.append(
+                (
+                    "cancel_order(confirm=False)",
+                    cancel_result["cancelled"] is False,
+                    f"blocked_reason={cancel_result.get('blocked_reason')}",
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            lines.append(
+                ("cancel_order(confirm=False)", False, f"ERROR: {type(exc).__name__}")
+            )
+
+    ok = all(success for _, success, _ in lines)
+    for name, success, note in lines:
+        print(f"  [{'OK' if success else 'FAIL'}] {name}: {note}")
+    if args.asset_class == "crypto":
+        print(
+            "summary: "
+            f"{'PASS' if ok else 'FAIL'} mode=preview_only asset_class=crypto "
+            f"candidate_report_attached={args.candidate_report is not None}"
+        )
+    else:
+        print(f"summary: {'PASS' if ok else 'FAIL'} mode=preview_only")
+    return 0 if ok else 1
+
+
+async def _side_effect_smoke(args: argparse.Namespace) -> int:
     lines: list[tuple[str, bool, str]] = []
     submitted_id: str | None = None
     cancelled = False
@@ -124,11 +211,7 @@ async def _side_effect_smoke() -> int:
 
     try:
         submit_result = await alpaca_paper_submit_order(
-            symbol=SMOKE_SYMBOL,
-            side="buy",
-            type="limit",
-            qty=SMOKE_QTY,
-            limit_price=SMOKE_LIMIT_PRICE,
+            **_order_payload(args),
             confirm=True,
         )
         submitted_id = submit_result["order"]["id"]
@@ -189,8 +272,21 @@ async def _async_main(args: argparse.Namespace) -> int:
         )
         return 2
 
+    if (
+        args.confirm_paper_side_effect
+        and args.asset_class == "crypto"
+        and args.limit_price is None
+    ):
+        print(
+            "BLOCKED: crypto side-effect smoke requires explicit --limit-price.",
+            file=sys.stderr,
+        )
+        return 2
+
     if _both_gates_set(args):
-        return await _side_effect_smoke()
+        return await _side_effect_smoke(args)
+    if args.asset_class == "crypto" or args.symbol or args.candidate_report:
+        return await _preview_only_for_args(args)
     return await _preview_only()
 
 
@@ -202,6 +298,22 @@ def build_parser() -> argparse.ArgumentParser:
         "--confirm-paper-side-effect",
         action="store_true",
         help=f"Required (with {ENV_GATE}=1) to enable broker mutations",
+    )
+    parser.add_argument(
+        "--asset-class",
+        choices=("us_equity", "crypto"),
+        default="us_equity",
+        help="Paper Alpaca asset class to validate; crypto is ROB-74 preview/MVP only",
+    )
+    parser.add_argument("--symbol", help="Order symbol, e.g. AAPL or BTC/USD")
+    parser.add_argument("--side", choices=("buy", "sell"), default="buy")
+    parser.add_argument("--order-type", choices=("limit", "market"), default="limit")
+    parser.add_argument("--qty", type=Decimal, default=SMOKE_QTY)
+    parser.add_argument("--notional", type=Decimal)
+    parser.add_argument("--limit-price", type=Decimal)
+    parser.add_argument(
+        "--candidate-report",
+        help="Path to a candidate report; only its presence is printed, never contents",
     )
     return parser
 

--- a/scripts/smoke/alpaca_paper_dev_smoke.py
+++ b/scripts/smoke/alpaca_paper_dev_smoke.py
@@ -30,6 +30,7 @@ import asyncio
 import os
 import sys
 from decimal import Decimal
+from pathlib import Path
 
 from app.mcp_server.tooling.alpaca_paper import (
     alpaca_paper_get_account,
@@ -163,20 +164,19 @@ async def _preview_only_for_args(args: argparse.Namespace) -> int:
             ("submit_order(confirm=False)", False, f"ERROR: {type(exc).__name__}")
         )
 
-    if args.asset_class != "crypto":
-        try:
-            cancel_result = await alpaca_paper_cancel_order(order_id="dummy-no-op")
-            lines.append(
-                (
-                    "cancel_order(confirm=False)",
-                    cancel_result["cancelled"] is False,
-                    f"blocked_reason={cancel_result.get('blocked_reason')}",
-                )
+    try:
+        cancel_result = await alpaca_paper_cancel_order(order_id="dummy-no-op")
+        lines.append(
+            (
+                "cancel_order(confirm=False)",
+                cancel_result["cancelled"] is False,
+                f"blocked_reason={cancel_result.get('blocked_reason')}",
             )
-        except Exception as exc:  # noqa: BLE001
-            lines.append(
-                ("cancel_order(confirm=False)", False, f"ERROR: {type(exc).__name__}")
-            )
+        )
+    except Exception as exc:  # noqa: BLE001
+        lines.append(
+            ("cancel_order(confirm=False)", False, f"ERROR: {type(exc).__name__}")
+        )
 
     ok = all(success for _, success, _ in lines)
     for name, success, note in lines:
@@ -257,6 +257,13 @@ async def _side_effect_smoke(args: argparse.Namespace) -> int:
 
 
 async def _async_main(args: argparse.Namespace) -> int:
+    if args.candidate_report and not Path(args.candidate_report).is_file():
+        print(
+            "BLOCKED: --candidate-report path does not exist or is not a file.",
+            file=sys.stderr,
+        )
+        return 2
+
     if args.confirm_paper_side_effect and os.environ.get(ENV_GATE) != "1":
         print(
             f"BLOCKED: --confirm-paper-side-effect requires {ENV_GATE}=1; "
@@ -313,7 +320,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--limit-price", type=Decimal)
     parser.add_argument(
         "--candidate-report",
-        help="Path to a candidate report; only its presence is printed, never contents",
+        help=(
+            "Path to a candidate report; existence is validated, but contents are "
+            "never read, parsed, logged, or converted into order parameters"
+        ),
     )
     return parser
 

--- a/scripts/smoke/alpaca_paper_dev_smoke.py
+++ b/scripts/smoke/alpaca_paper_dev_smoke.py
@@ -138,6 +138,8 @@ def _order_payload(args: argparse.Namespace) -> dict[str, object]:
         "side": args.side,
         "type": args.order_type,
         "asset_class": args.asset_class,
+        "time_in_force": args.time_in_force
+        or ("gtc" if args.asset_class == "crypto" else "day"),
     }
     if args.notional is not None:
         payload["notional"] = args.notional
@@ -291,6 +293,17 @@ async def _async_main(args: argparse.Namespace) -> int:
         )
         return 2
 
+    if (
+        args.asset_class == "crypto"
+        and args.time_in_force is not None
+        and args.time_in_force not in {"gtc", "ioc"}
+    ):
+        print(
+            "BLOCKED: crypto --time-in-force must be gtc or ioc.",
+            file=sys.stderr,
+        )
+        return 2
+
     if _both_gates_set(args):
         return await _side_effect_smoke(args)
     if args.asset_class == "crypto" or args.symbol or args.candidate_report:
@@ -319,6 +332,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--qty", type=Decimal, default=SMOKE_QTY)
     parser.add_argument("--notional", type=Decimal)
     parser.add_argument("--limit-price", type=Decimal)
+    parser.add_argument(
+        "--time-in-force",
+        choices=("day", "gtc", "ioc", "fok"),
+        help="Order time_in_force; crypto defaults to gtc and only allows gtc/ioc",
+    )
     parser.add_argument(
         "--candidate-report",
         help=(

--- a/scripts/smoke/alpaca_paper_dev_smoke.py
+++ b/scripts/smoke/alpaca_paper_dev_smoke.py
@@ -46,6 +46,9 @@ DEFAULT_CRYPTO_SYMBOL = "BTC/USD"
 SMOKE_QTY = Decimal("1")
 SMOKE_LIMIT_PRICE = Decimal("1.00")  # far below market — should not fill
 ENV_GATE = "ALPACA_PAPER_SMOKE_ALLOW_SIDE_EFFECTS"
+PREVIEW_SUBMIT_CHECK = "submit_order(confirm=False)"
+PREVIEW_CANCEL_CHECK = "cancel_order(confirm=False)"
+SMOKE_LINE = tuple[str, bool, str]
 
 
 def _both_gates_set(args: argparse.Namespace) -> bool:
@@ -53,7 +56,29 @@ def _both_gates_set(args: argparse.Namespace) -> bool:
 
 
 async def _preview_only() -> int:
-    lines: list[tuple[str, bool, str]] = []
+    lines: list[SMOKE_LINE] = []
+    await _append_account_check(lines)
+    await _append_cash_check(lines)
+    await _append_preview_submit_check(
+        lines,
+        {
+            "symbol": DEFAULT_EQUITY_SYMBOL,
+            "side": "buy",
+            "type": "limit",
+            "qty": SMOKE_QTY,
+            "limit_price": SMOKE_LIMIT_PRICE,
+        },
+    )
+    await _append_preview_cancel_check(lines)
+
+    ok = all(success for _, success, _ in lines)
+    for name, success, note in lines:
+        print(f"  [{'OK' if success else 'FAIL'}] {name}: {note}")
+    print(f"summary: {'PASS' if ok else 'FAIL'} mode=preview_only")
+    return 0 if ok else 1
+
+
+async def _append_account_check(lines: list[SMOKE_LINE]) -> None:
     try:
         acct = await alpaca_paper_get_account()
         lines.append(
@@ -62,6 +87,8 @@ async def _preview_only() -> int:
     except Exception as exc:  # noqa: BLE001
         lines.append(("get_account", False, f"ERROR: {type(exc).__name__}"))
 
+
+async def _append_cash_check(lines: list[SMOKE_LINE]) -> None:
     try:
         cash = await alpaca_paper_get_cash()
         lines.append(
@@ -70,45 +97,36 @@ async def _preview_only() -> int:
     except Exception as exc:  # noqa: BLE001
         lines.append(("get_cash", False, f"ERROR: {type(exc).__name__}"))
 
+
+async def _append_preview_submit_check(
+    lines: list[SMOKE_LINE],
+    payload: dict[str, object],
+) -> None:
     try:
-        submit_result = await alpaca_paper_submit_order(
-            symbol=DEFAULT_EQUITY_SYMBOL,
-            side="buy",
-            type="limit",
-            qty=SMOKE_QTY,
-            limit_price=SMOKE_LIMIT_PRICE,
-        )
+        submit_result = await alpaca_paper_submit_order(**payload)
         lines.append(
             (
-                "submit_order(confirm=False)",
+                PREVIEW_SUBMIT_CHECK,
                 submit_result["submitted"] is False,
                 f"blocked_reason={submit_result.get('blocked_reason')}",
             )
         )
     except Exception as exc:  # noqa: BLE001
-        lines.append(
-            ("submit_order(confirm=False)", False, f"ERROR: {type(exc).__name__}")
-        )
+        lines.append((PREVIEW_SUBMIT_CHECK, False, f"ERROR: {type(exc).__name__}"))
 
+
+async def _append_preview_cancel_check(lines: list[SMOKE_LINE]) -> None:
     try:
         cancel_result = await alpaca_paper_cancel_order(order_id="dummy-no-op")
         lines.append(
             (
-                "cancel_order(confirm=False)",
+                PREVIEW_CANCEL_CHECK,
                 cancel_result["cancelled"] is False,
                 f"blocked_reason={cancel_result.get('blocked_reason')}",
             )
         )
     except Exception as exc:  # noqa: BLE001
-        lines.append(
-            ("cancel_order(confirm=False)", False, f"ERROR: {type(exc).__name__}")
-        )
-
-    ok = all(success for _, success, _ in lines)
-    for name, success, note in lines:
-        print(f"  [{'OK' if success else 'FAIL'}] {name}: {note}")
-    print(f"summary: {'PASS' if ok else 'FAIL'} mode=preview_only")
-    return 0 if ok else 1
+        lines.append((PREVIEW_CANCEL_CHECK, False, f"ERROR: {type(exc).__name__}"))
 
 
 def _order_payload(args: argparse.Namespace) -> dict[str, object]:
@@ -133,50 +151,11 @@ def _order_payload(args: argparse.Namespace) -> dict[str, object]:
 
 
 async def _preview_only_for_args(args: argparse.Namespace) -> int:
-    lines: list[tuple[str, bool, str]] = []
-    try:
-        acct = await alpaca_paper_get_account()
-        lines.append(
-            ("get_account", True, f"status={acct['account'].get('status', '?')}")
-        )
-    except Exception as exc:  # noqa: BLE001
-        lines.append(("get_account", False, f"ERROR: {type(exc).__name__}"))
-
-    try:
-        cash = await alpaca_paper_get_cash()
-        lines.append(
-            ("get_cash", True, f"cash_set={cash['cash'].get('cash') is not None}")
-        )
-    except Exception as exc:  # noqa: BLE001
-        lines.append(("get_cash", False, f"ERROR: {type(exc).__name__}"))
-
-    try:
-        submit_result = await alpaca_paper_submit_order(**_order_payload(args))
-        lines.append(
-            (
-                "submit_order(confirm=False)",
-                submit_result["submitted"] is False,
-                f"blocked_reason={submit_result.get('blocked_reason')}",
-            )
-        )
-    except Exception as exc:  # noqa: BLE001
-        lines.append(
-            ("submit_order(confirm=False)", False, f"ERROR: {type(exc).__name__}")
-        )
-
-    try:
-        cancel_result = await alpaca_paper_cancel_order(order_id="dummy-no-op")
-        lines.append(
-            (
-                "cancel_order(confirm=False)",
-                cancel_result["cancelled"] is False,
-                f"blocked_reason={cancel_result.get('blocked_reason')}",
-            )
-        )
-    except Exception as exc:  # noqa: BLE001
-        lines.append(
-            ("cancel_order(confirm=False)", False, f"ERROR: {type(exc).__name__}")
-        )
+    lines: list[SMOKE_LINE] = []
+    await _append_account_check(lines)
+    await _append_cash_check(lines)
+    await _append_preview_submit_check(lines, _order_payload(args))
+    await _append_preview_cancel_check(lines)
 
     ok = all(success for _, success, _ in lines)
     for name, success, note in lines:

--- a/scripts/smoke/alpaca_paper_dev_smoke.py
+++ b/scripts/smoke/alpaca_paper_dev_smoke.py
@@ -172,22 +172,37 @@ async def _preview_only_for_args(args: argparse.Namespace) -> int:
 
 
 async def _side_effect_smoke(args: argparse.Namespace) -> int:
-    lines: list[tuple[str, bool, str]] = []
-    submitted_id: str | None = None
-    cancelled = False
+    lines: list[SMOKE_LINE] = []
+    if not await _side_effect_account_ready(lines):
+        _print_lines(lines)
+        print("summary: BLOCKED mode=side_effects reason=account_unreachable")
+        return 1
 
+    submitted_id = await _side_effect_submit(lines, args)
+    cancelled = await _side_effect_cancel(lines, submitted_id)
+
+    ok = all(success for _, success, _ in lines)
+    _print_lines(lines)
+    classification = "PASS" if ok and cancelled else "PARTIAL"
+    print(f"summary: {classification} mode=side_effects")
+    return 0 if classification == "PASS" else 1
+
+
+async def _side_effect_account_ready(lines: list[SMOKE_LINE]) -> bool:
     try:
         acct = await alpaca_paper_get_account()
         lines.append(
             ("get_account", True, f"status={acct['account'].get('status', '?')}")
         )
+        return True
     except Exception as exc:  # noqa: BLE001
         lines.append(("get_account", False, f"ERROR: {type(exc).__name__}"))
-        for name, s, note in lines:
-            print(f"  [{'OK' if s else 'FAIL'}] {name}: {note}")
-        print("summary: BLOCKED mode=side_effects reason=account_unreachable")
-        return 1
+        return False
 
+
+async def _side_effect_submit(
+    lines: list[SMOKE_LINE], args: argparse.Namespace
+) -> str | None:
     try:
         submit_result = await alpaca_paper_submit_order(
             **_order_payload(args),
@@ -201,38 +216,45 @@ async def _side_effect_smoke(args: argparse.Namespace) -> int:
                 f"order_id_len={len(submitted_id)} status={submit_result['order'].get('status', '?')}",
             )
         )
+        return submitted_id
     except Exception as exc:  # noqa: BLE001
         lines.append(
             ("submit_order(confirm=True)", False, f"ERROR: {type(exc).__name__}")
         )
+        return None
 
-    if submitted_id:
-        try:
-            cancel_result = await alpaca_paper_cancel_order(
-                order_id=submitted_id,
-                confirm=True,
-            )
-            cancelled = bool(cancel_result.get("cancelled"))
-            readback_status = cancel_result.get("read_back_status", "unknown")
-            order_info = cancel_result.get("order") or {}
-            lines.append(
-                (
-                    "cancel_order(confirm=True)",
-                    cancelled,
-                    f"read_back={readback_status} final_status={order_info.get('status', '?')}",
-                )
-            )
-        except Exception as exc:  # noqa: BLE001
-            lines.append(
-                ("cancel_order(confirm=True)", False, f"ERROR: {type(exc).__name__}")
-            )
 
-    ok = all(success for _, success, _ in lines)
+async def _side_effect_cancel(
+    lines: list[SMOKE_LINE], submitted_id: str | None
+) -> bool:
+    if not submitted_id:
+        return False
+    try:
+        cancel_result = await alpaca_paper_cancel_order(
+            order_id=submitted_id,
+            confirm=True,
+        )
+        cancelled = bool(cancel_result.get("cancelled"))
+        readback_status = cancel_result.get("read_back_status", "unknown")
+        order_info = cancel_result.get("order") or {}
+        lines.append(
+            (
+                "cancel_order(confirm=True)",
+                cancelled,
+                f"read_back={readback_status} final_status={order_info.get('status', '?')}",
+            )
+        )
+        return cancelled
+    except Exception as exc:  # noqa: BLE001
+        lines.append(
+            ("cancel_order(confirm=True)", False, f"ERROR: {type(exc).__name__}")
+        )
+        return False
+
+
+def _print_lines(lines: list[SMOKE_LINE]) -> None:
     for name, success, note in lines:
         print(f"  [{'OK' if success else 'FAIL'}] {name}: {note}")
-    classification = "PASS" if ok and cancelled else "PARTIAL"
-    print(f"summary: {classification} mode=side_effects")
-    return 0 if classification == "PASS" else 1
 
 
 async def _async_main(args: argparse.Namespace) -> int:

--- a/tests/test_alpaca_paper_dev_smoke_safety.py
+++ b/tests/test_alpaca_paper_dev_smoke_safety.py
@@ -160,7 +160,41 @@ async def test_dev_smoke_crypto_preview_uses_confirm_false_and_redacted_report(
     assert "asset_class=crypto" in out
     assert "candidate_report_attached=True" in out
     assert "blocked_reason=confirmation_required" in out
+    assert "cancel_order(confirm=False)" in out
     assert [c for c in orders.calls if c[0] in ("submit_order", "cancel_order")] == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dev_smoke_candidate_report_must_exist_before_broker_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tests.test_alpaca_paper_orders_tools import FakeOrdersService
+    from tests.test_mcp_alpaca_paper_tools import FakeAlpacaPaperService
+
+    ro = FakeAlpacaPaperService()
+    orders = FakeOrdersService()
+    set_alpaca_paper_service_factory(lambda: ro)  # type: ignore[arg-type]
+    set_alpaca_paper_orders_service_factory(lambda: orders)  # type: ignore[arg-type]
+    monkeypatch.delenv("ALPACA_PAPER_SMOKE_ALLOW_SIDE_EFFECTS", raising=False)
+    try:
+        module = _load_module()
+        args = module.build_parser().parse_args(
+            [
+                "--asset-class",
+                "crypto",
+                "--candidate-report",
+                "/tmp/rob74-missing-candidate-report.md",
+            ]
+        )
+        rc = await module._async_main(args)
+    finally:
+        reset_alpaca_paper_service_factory()
+        reset_alpaca_paper_orders_service_factory()
+
+    assert rc == 2
+    assert ro.calls == []
+    assert orders.calls == []
 
 
 @pytest.mark.unit

--- a/tests/test_alpaca_paper_dev_smoke_safety.py
+++ b/tests/test_alpaca_paper_dev_smoke_safety.py
@@ -117,6 +117,69 @@ def test_dev_smoke_parser_accepts_crypto_operator_metadata() -> None:
     assert args.symbol == "BTC/USD"
     assert args.notional == module.Decimal("10")
     assert args.limit_price == module.Decimal("50000")
+    assert module._order_payload(args)["time_in_force"] == "gtc"
+
+
+@pytest.mark.unit
+def test_dev_smoke_parser_accepts_crypto_ioc_time_in_force() -> None:
+    module = _load_module()
+    args = module.build_parser().parse_args(
+        [
+            "--asset-class",
+            "crypto",
+            "--symbol",
+            "BTC/USD",
+            "--notional",
+            "10",
+            "--limit-price",
+            "50000",
+            "--time-in-force",
+            "ioc",
+        ]
+    )
+
+    assert module._order_payload(args)["time_in_force"] == "ioc"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_tif", ["day", "fok"])
+async def test_dev_smoke_crypto_blocks_invalid_time_in_force_before_broker_calls(
+    monkeypatch: pytest.MonkeyPatch,
+    bad_tif: str,
+) -> None:
+    from tests.test_alpaca_paper_orders_tools import FakeOrdersService
+    from tests.test_mcp_alpaca_paper_tools import FakeAlpacaPaperService
+
+    ro = FakeAlpacaPaperService()
+    orders = FakeOrdersService()
+    set_alpaca_paper_service_factory(lambda: ro)  # type: ignore[arg-type]
+    set_alpaca_paper_orders_service_factory(lambda: orders)  # type: ignore[arg-type]
+    monkeypatch.delenv("ALPACA_PAPER_SMOKE_ALLOW_SIDE_EFFECTS", raising=False)
+    try:
+        module = _load_module()
+        args = module.build_parser().parse_args(
+            [
+                "--asset-class",
+                "crypto",
+                "--symbol",
+                "BTC/USD",
+                "--notional",
+                "10",
+                "--limit-price",
+                "50000",
+                "--time-in-force",
+                bad_tif,
+            ]
+        )
+        rc = await module._async_main(args)
+    finally:
+        reset_alpaca_paper_service_factory()
+        reset_alpaca_paper_orders_service_factory()
+
+    assert rc == 2
+    assert ro.calls == []
+    assert orders.calls == []
 
 
 @pytest.mark.unit

--- a/tests/test_alpaca_paper_dev_smoke_safety.py
+++ b/tests/test_alpaca_paper_dev_smoke_safety.py
@@ -97,6 +97,97 @@ def _load_module():
 
 
 @pytest.mark.unit
+def test_dev_smoke_parser_accepts_crypto_operator_metadata() -> None:
+    module = _load_module()
+    args = module.build_parser().parse_args(
+        [
+            "--asset-class",
+            "crypto",
+            "--symbol",
+            "BTC/USD",
+            "--notional",
+            "10",
+            "--limit-price",
+            "50000",
+            "--candidate-report",
+            str(SCRIPT_PATH),
+        ]
+    )
+    assert args.asset_class == "crypto"
+    assert args.symbol == "BTC/USD"
+    assert args.notional == module.Decimal("10")
+    assert args.limit_price == module.Decimal("50000")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dev_smoke_crypto_preview_uses_confirm_false_and_redacted_report(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tests.test_alpaca_paper_orders_tools import FakeOrdersService
+    from tests.test_mcp_alpaca_paper_tools import FakeAlpacaPaperService
+
+    ro = FakeAlpacaPaperService()
+    orders = FakeOrdersService()
+    set_alpaca_paper_service_factory(lambda: ro)  # type: ignore[arg-type]
+    set_alpaca_paper_orders_service_factory(lambda: orders)  # type: ignore[arg-type]
+    monkeypatch.delenv("ALPACA_PAPER_SMOKE_ALLOW_SIDE_EFFECTS", raising=False)
+    try:
+        module = _load_module()
+        args = module.build_parser().parse_args(
+            [
+                "--asset-class",
+                "crypto",
+                "--symbol",
+                "BTC/USD",
+                "--notional",
+                "10",
+                "--limit-price",
+                "50000",
+                "--candidate-report",
+                str(SCRIPT_PATH),
+            ]
+        )
+        rc = await module._async_main(args)
+    finally:
+        reset_alpaca_paper_service_factory()
+        reset_alpaca_paper_orders_service_factory()
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "mode=preview_only" in out
+    assert "asset_class=crypto" in out
+    assert "candidate_report_attached=True" in out
+    assert "blocked_reason=confirmation_required" in out
+    assert [c for c in orders.calls if c[0] in ("submit_order", "cancel_order")] == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_dev_smoke_crypto_side_effect_requires_explicit_limit_price(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from tests.test_alpaca_paper_orders_tools import FakeOrdersService
+
+    orders = FakeOrdersService()
+    set_alpaca_paper_orders_service_factory(lambda: orders)  # type: ignore[arg-type]
+    monkeypatch.setenv("ALPACA_PAPER_SMOKE_ALLOW_SIDE_EFFECTS", "1")
+    try:
+        module = _load_module()
+        args = module.build_parser().parse_args(
+            ["--asset-class", "crypto", "--confirm-paper-side-effect"]
+        )
+        rc = await module._async_main(args)
+    finally:
+        reset_alpaca_paper_orders_service_factory()
+        monkeypatch.delenv("ALPACA_PAPER_SMOKE_ALLOW_SIDE_EFFECTS", raising=False)
+
+    assert rc == 2
+    assert [c for c in orders.calls if c[0] in ("submit_order", "cancel_order")] == []
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_dev_smoke_default_mode_no_broker_calls(
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_alpaca_paper_dev_smoke_safety.py
+++ b/tests/test_alpaca_paper_dev_smoke_safety.py
@@ -168,6 +168,7 @@ async def test_dev_smoke_crypto_preview_uses_confirm_false_and_redacted_report(
 @pytest.mark.asyncio
 async def test_dev_smoke_candidate_report_must_exist_before_broker_calls(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     from tests.test_alpaca_paper_orders_tools import FakeOrdersService
     from tests.test_mcp_alpaca_paper_tools import FakeAlpacaPaperService
@@ -184,7 +185,7 @@ async def test_dev_smoke_candidate_report_must_exist_before_broker_calls(
                 "--asset-class",
                 "crypto",
                 "--candidate-report",
-                "/tmp/rob74-missing-candidate-report.md",
+                str(tmp_path / "rob74-missing-candidate-report.md"),
             ]
         )
         rc = await module._async_main(args)

--- a/tests/test_alpaca_paper_orders_tools.py
+++ b/tests/test_alpaca_paper_orders_tools.py
@@ -153,6 +153,46 @@ async def test_crypto_submit_without_confirm_is_blocked_no_op(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_crypto_submit_omitted_time_in_force_defaults_to_gtc_no_op(
+    fake_orders_service: FakeOrdersService,
+) -> None:
+    payload = await alpaca_paper_submit_order(
+        symbol="BTC/USD",
+        side="buy",
+        type="limit",
+        notional=Decimal("10"),
+        limit_price=Decimal("50000"),
+        asset_class="crypto",
+    )
+
+    assert payload["submitted"] is False
+    assert payload["order_request"]["time_in_force"] == "gtc"
+    assert fake_orders_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_tif", ["day", "fok"])
+async def test_crypto_submit_rejects_invalid_time_in_force_before_service_call(
+    fake_orders_service: FakeOrdersService,
+    bad_tif: str,
+) -> None:
+    with pytest.raises(ValueError, match="crypto time_in_force"):
+        await alpaca_paper_submit_order(
+            symbol="BTC/USD",
+            side="buy",
+            type="limit",
+            notional=Decimal("10"),
+            limit_price=Decimal("50000"),
+            time_in_force=bad_tif,
+            asset_class="crypto",
+            confirm=True,
+        )
+    assert fake_orders_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_crypto_submit_with_confirm_calls_service_once(
     fake_orders_service: FakeOrdersService,
 ) -> None:

--- a/tests/test_alpaca_paper_orders_tools.py
+++ b/tests/test_alpaca_paper_orders_tools.py
@@ -132,6 +132,82 @@ async def test_submit_with_confirm_calls_service_once(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_crypto_submit_without_confirm_is_blocked_no_op(
+    fake_orders_service: FakeOrdersService,
+) -> None:
+    payload = await alpaca_paper_submit_order(
+        symbol="BTC/USD",
+        side="buy",
+        type="limit",
+        notional=Decimal("10"),
+        limit_price=Decimal("50000"),
+        time_in_force="gtc",
+        asset_class="crypto",
+    )
+    assert payload["submitted"] is False
+    assert payload["blocked_reason"] == "confirmation_required"
+    assert payload["order_request"]["asset_class"] == "crypto"
+    assert payload["client_order_id"].startswith("rob74-crypto-")
+    assert fake_orders_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_crypto_submit_with_confirm_calls_service_once(
+    fake_orders_service: FakeOrdersService,
+) -> None:
+    payload = await alpaca_paper_submit_order(
+        symbol="BTC/USD",
+        side="buy",
+        type="limit",
+        notional=Decimal("10"),
+        limit_price=Decimal("50000"),
+        time_in_force="gtc",
+        asset_class="crypto",
+        confirm=True,
+    )
+    assert payload["submitted"] is True
+    assert payload["client_order_id"].startswith("rob74-crypto-")
+    sent = [c for c in fake_orders_service.calls if c[0] == "submit_order"][0][1][
+        "request"
+    ]
+    assert sent.symbol == "BTC/USD"
+    assert sent.notional == Decimal("10")
+    assert sent.limit_price == Decimal("50000")
+    assert sent.side == "buy"
+    assert sent.type == "limit"
+    assert sent.time_in_force == "gtc"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_crypto_submit_rejects_unsafe_shapes_before_service_call(
+    fake_orders_service: FakeOrdersService,
+) -> None:
+    base = {
+        "symbol": "BTC/USD",
+        "side": "buy",
+        "type": "limit",
+        "notional": Decimal("10"),
+        "limit_price": Decimal("50000"),
+        "asset_class": "crypto",
+        "confirm": True,
+    }
+    cases = [
+        ({"symbol": "DOGE/USD"}, "crypto symbol"),
+        ({"side": "sell"}, "buy-only"),
+        ({"type": "market", "limit_price": None}, "limit-only"),
+        ({"notional": Decimal("51")}, "crypto notional"),
+    ]
+    for kwargs, message in cases:
+        payload = base | kwargs
+        with pytest.raises(ValueError, match=message):
+            await alpaca_paper_submit_order(**payload)
+    assert fake_orders_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_submit_caller_client_order_id_passes_through(
     fake_orders_service: FakeOrdersService,
 ) -> None:
@@ -228,14 +304,6 @@ async def test_submit_propagates_preview_validation_errors(
             type="market",
             qty=Decimal("1"),
             notional=Decimal("100"),
-        )
-    with pytest.raises(ValueError, match="us_equity only"):
-        await alpaca_paper_submit_order(
-            symbol="BTC",
-            side="buy",
-            type="market",
-            qty=Decimal("1"),
-            asset_class="crypto",
         )
     assert fake_orders_service.calls == []
 

--- a/tests/test_mcp_alpaca_paper_tools.py
+++ b/tests/test_mcp_alpaca_paper_tools.py
@@ -602,6 +602,59 @@ async def test_preview_crypto_limit_notional_buy_returns_normalized_echo(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_preview_crypto_omitted_time_in_force_defaults_to_gtc(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    payload = await alpaca_paper_preview_order(
+        symbol="BTC/USD",
+        side="buy",
+        type="limit",
+        notional=Decimal("10"),
+        limit_price=Decimal("50000"),
+        asset_class="crypto",
+    )
+
+    assert payload["order_request"]["time_in_force"] == "gtc"
+    assert fake_preview_service.calls == [("get_cash", {})]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_tif", ["day", "fok"])
+async def test_preview_crypto_rejects_invalid_time_in_force_before_service_call(
+    fake_preview_service: FakeAlpacaPaperService,
+    bad_tif: str,
+) -> None:
+    with pytest.raises(ValueError, match="crypto time_in_force"):
+        await alpaca_paper_preview_order(
+            symbol="BTC/USD",
+            side="buy",
+            type="limit",
+            notional=Decimal("10"),
+            limit_price=Decimal("50000"),
+            time_in_force=bad_tif,
+            asset_class="crypto",
+        )
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_equity_omitted_time_in_force_keeps_day_default(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    payload = await alpaca_paper_preview_order(
+        symbol="AAPL",
+        side="buy",
+        type="market",
+        qty=Decimal("1"),
+    )
+
+    assert payload["order_request"]["time_in_force"] == "day"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_preview_crypto_rejects_non_allowlisted_symbol(
     fake_preview_service: FakeAlpacaPaperService,
 ) -> None:

--- a/tests/test_mcp_alpaca_paper_tools.py
+++ b/tests/test_mcp_alpaca_paper_tools.py
@@ -573,6 +573,40 @@ async def test_preview_rejects_blank_symbol(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"symbol": "TOO-LONG-SYMBOL"}, "1-10 characters"),
+        ({"qty": Decimal("Infinity")}, "finite number"),
+        ({"qty": Decimal("1000001")}, "maximum allowed"),
+        ({"notional": Decimal("NaN"), "qty": None}, "finite number"),
+        ({"notional": Decimal("10000001"), "qty": None}, "maximum allowed"),
+        ({"time_in_force": "opg"}, "time_in_force"),
+        ({"client_order_id": "   "}, "client_order_id"),
+        ({"client_order_id": "x" * 49}, "client_order_id"),
+        ({"asset_class": "option"}, "asset_class"),
+        ({"type": "limit", "limit_price": Decimal("0")}, "limit_price"),
+    ],
+)
+async def test_preview_rejects_additional_invalid_inputs_before_service_call(
+    fake_preview_service: FakeAlpacaPaperService,
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    base: dict[str, object] = {
+        "symbol": "AAPL",
+        "side": "buy",
+        "type": "market",
+        "qty": Decimal("1"),
+    }
+    base.update(kwargs)
+    with pytest.raises(ValueError, match=message):
+        await alpaca_paper_preview_order(**base)
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_preview_crypto_limit_notional_buy_returns_normalized_echo(
     fake_preview_service: FakeAlpacaPaperService,
 ) -> None:
@@ -665,6 +699,22 @@ async def test_preview_crypto_rejects_non_allowlisted_symbol(
             type="limit",
             notional=Decimal("10"),
             limit_price=Decimal("1"),
+            asset_class="crypto",
+        )
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_crypto_rejects_missing_limit_price(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError, match="limit_price is required"):
+        await alpaca_paper_preview_order(
+            symbol="BTC/USD",
+            side="buy",
+            type="limit",
+            notional=Decimal("10"),
             asset_class="crypto",
         )
     assert fake_preview_service.calls == []

--- a/tests/test_mcp_alpaca_paper_tools.py
+++ b/tests/test_mcp_alpaca_paper_tools.py
@@ -573,17 +573,77 @@ async def test_preview_rejects_blank_symbol(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_preview_rejects_crypto_asset_class(
+async def test_preview_crypto_limit_notional_buy_returns_normalized_echo(
     fake_preview_service: FakeAlpacaPaperService,
 ) -> None:
-    with pytest.raises(ValueError, match="crypto"):
+    payload = await alpaca_paper_preview_order(
+        symbol="btc/usd",
+        side="BUY",
+        type="LIMIT",
+        notional=Decimal("10"),
+        limit_price=Decimal("50000"),
+        time_in_force="gtc",
+        asset_class="crypto",
+    )
+
+    assert payload["preview"] is True
+    assert payload["submitted"] is False
+    req = payload["order_request"]
+    assert req["symbol"] == "BTC/USD"
+    assert req["side"] == "buy"
+    assert req["type"] == "limit"
+    assert req["notional"] == "10"
+    assert req["limit_price"] == "50000"
+    assert req["time_in_force"] == "gtc"
+    assert req["asset_class"] == "crypto"
+    assert payload["estimated_cost"] == "10"
+    assert payload["would_exceed_buying_power"] is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_preview_crypto_rejects_non_allowlisted_symbol(
+    fake_preview_service: FakeAlpacaPaperService,
+) -> None:
+    with pytest.raises(ValueError, match="crypto symbol"):
         await alpaca_paper_preview_order(
-            symbol="BTC",
+            symbol="DOGE/USD",
             side="buy",
-            type="market",
-            qty=Decimal("1"),
+            type="limit",
+            notional=Decimal("10"),
+            limit_price=Decimal("1"),
             asset_class="crypto",
         )
+    assert fake_preview_service.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"side": "sell"}, "buy-only"),
+        ({"type": "market", "limit_price": None}, "limit-only"),
+        ({"notional": Decimal("51")}, "crypto notional"),
+        ({"qty": Decimal("0.002"), "notional": None}, "estimated_cost"),
+    ],
+)
+async def test_preview_crypto_rejects_unsafe_order_shapes(
+    fake_preview_service: FakeAlpacaPaperService,
+    kwargs: dict[str, object],
+    message: str,
+) -> None:
+    base = {
+        "symbol": "BTC/USD",
+        "side": "buy",
+        "type": "limit",
+        "notional": Decimal("10"),
+        "limit_price": Decimal("50000"),
+        "asset_class": "crypto",
+    }
+    base.update(kwargs)
+    with pytest.raises(ValueError, match=message):
+        await alpaca_paper_preview_order(**base)
     assert fake_preview_service.calls == []
 
 


### PR DESCRIPTION
## Summary
- Adds narrow Alpaca paper crypto preview/submit validation for ROB-74: `asset_class=crypto`, allowlisted `BTC/USD`, `ETH/USD`, `SOL/USD`, buy-only, limit-only, explicit limit price, and $50 notional/estimated-cost cap.
- Enforces broker-valid crypto `time_in_force`: omitted crypto TIF defaults to `gtc`, and invalid `day`/`fok` crypto requests are rejected before service calls.
- Extends the dev smoke helper so crypto preview mode exercises submit/cancel `confirm=False` paths without broker mutations; candidate reports are metadata only and are never read/parsed/logged or converted into order parameters.
- Updates MCP README and Alpaca paper dev smoke runbook with ROB-74 safety boundaries and approval-gated side-effect flow.

## Safety boundaries
- Alpaca paper endpoint/tooling only; no live Alpaca endpoint or live broker route added.
- Explicit `alpaca_paper_*` tools only; no generic place/modify/replace/cancel-all/bulk route added.
- Crypto execution remains buy-only, limit-only, allowlisted, and capped at $50.
- Side effects remain blocked by default; smoke side effects require both `--confirm-paper-side-effect` and `ALPACA_PAPER_SMOKE_ALLOW_SIDE_EFFECTS=1`.
- No production deploy, live smoke, or `confirm=True` broker submit/cancel was run as part of K3 review.

## Test Plan
- `git diff --check origin/main...HEAD` — passed.
- `uv run ruff format --check app/mcp_server/tooling/alpaca_paper_preview.py app/mcp_server/tooling/alpaca_paper_orders.py app/mcp_server/tooling/__init__.py scripts/smoke/alpaca_paper_dev_smoke.py tests/test_alpaca_paper_orders_tools.py tests/test_mcp_alpaca_paper_tools.py tests/test_alpaca_paper_dev_smoke_safety.py` — passed.
- `uv run ruff check app/mcp_server/tooling/alpaca_paper_preview.py app/mcp_server/tooling/alpaca_paper_orders.py app/mcp_server/tooling/__init__.py scripts/smoke/alpaca_paper_dev_smoke.py tests/test_alpaca_paper_orders_tools.py tests/test_mcp_alpaca_paper_tools.py tests/test_alpaca_paper_dev_smoke_safety.py` — passed.
- `uv run pytest tests/test_mcp_alpaca_paper_tools.py tests/test_alpaca_paper_orders_tools.py tests/test_alpaca_paper_isolation.py tests/test_alpaca_paper_dev_smoke_safety.py -q` — 117 passed, 2 existing Pydantic warnings.
- `uv run pytest tests -q` — 4829 passed, 15 skipped, 74 existing warnings.
- Added-line safety scan over changed files — no blocking live endpoint/generic mutating route/raw secret print finding; one benign false-positive matched `read_back_status` text only.

Closes ROB-74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cryptocurrency trading now supported in paper trading surfaces
  * Crypto orders limited to buy-limit-only with allowlisted symbols (BTC/USD, ETH/USD, SOL/USD)
  * Notional cap of $50 USD enforced for crypto orders
  * Added preview functionality for crypto orders

* **Documentation**
  * Updated platform documentation with crypto-specific constraints and validation rules
  * Enhanced runbook with crypto testing workflows

* **Tests**
  * Added comprehensive test coverage for crypto order operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
