### PR TITLE
feat: connect preopen market news briefing sections

### DIFF
--- a/app/schemas/preopen.py
+++ b/app/schemas/preopen.py
@@ -37,6 +37,39 @@ class NewsReadinessSummary(BaseModel):
     max_age_minutes: int
 
 
+class PreopenBriefingRelevance(BaseModel):
+    score: int
+    reason: str
+    section_id: str | None = None
+    matched_terms: list[str] = []
+
+
+class PreopenMarketNewsItem(BaseModel):
+    id: int
+    title: str
+    url: str
+    source: str | None = None
+    feed_source: str | None = None
+    published_at: datetime | None = None
+    summary: str | None = None
+    briefing_relevance: PreopenBriefingRelevance | None = None
+    crypto_relevance: dict[str, Any] | None = None
+
+
+class PreopenMarketNewsSection(BaseModel):
+    section_id: str
+    title: str
+    items: list[PreopenMarketNewsItem] = []
+
+
+class PreopenMarketNewsBriefing(BaseModel):
+    briefing_filter: Literal[True] = True
+    summary: dict[str, Any]
+    sections: list[PreopenMarketNewsSection] = []
+    excluded_count: int = 0
+    top_excluded: list[PreopenMarketNewsItem] = []
+
+
 class CandidateSummary(BaseModel):
     candidate_uuid: UUID
     symbol: str
@@ -96,3 +129,4 @@ class PreopenLatestResponse(BaseModel):
     news: NewsReadinessSummary | None = None
     news_preview: list[NewsArticlePreview] = []
     news_brief: KRPreopenNewsBrief | None = None
+    market_news_briefing: PreopenMarketNewsBriefing | None = None

--- a/app/services/preopen_dashboard_service.py
+++ b/app/services/preopen_dashboard_service.py
@@ -6,10 +6,13 @@ Read-only. Never imports broker, order, watch, intent, or credential modules.
 from __future__ import annotations
 
 import logging
+from inspect import isawaitable
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.news import NewsArticle
 from app.models.research_run import ResearchRun, ResearchRunCandidate
 from app.models.trading_decision import TradingDecisionProposal, TradingDecisionSession
 from app.schemas.preopen import (
@@ -17,7 +20,11 @@ from app.schemas.preopen import (
     LinkedSessionRef,
     NewsArticlePreview,
     NewsReadinessSummary,
+    PreopenBriefingRelevance,
     PreopenLatestResponse,
+    PreopenMarketNewsBriefing,
+    PreopenMarketNewsItem,
+    PreopenMarketNewsSection,
     ReconciliationSummary,
 )
 from app.schemas.preopen_news_brief import KRPreopenNewsBrief
@@ -25,6 +32,10 @@ from app.services import kr_preopen_news_brief_service, research_run_service
 from app.services.llm_news_service import (
     get_latest_news_preview,
     get_news_readiness,
+)
+from app.services.market_news_briefing_formatter import (
+    BriefingItem,
+    format_market_news_briefing,
 )
 
 logger = logging.getLogger(__name__)
@@ -54,6 +65,7 @@ _FAIL_OPEN = PreopenLatestResponse(
     news=None,
     news_preview=[],
     news_brief=None,
+    market_news_briefing=None,
 )
 
 
@@ -250,6 +262,89 @@ async def _build_news_section(
     return summary, preview, merged_freshness, merged_warnings, readiness
 
 
+def _article_field(article: Any, name: str) -> Any:
+    if isinstance(article, dict):
+        return article.get(name)
+    return getattr(article, name, None)
+
+
+def _map_market_news_item(item: BriefingItem) -> PreopenMarketNewsItem:
+    article = item.article
+    relevance = item.relevance
+    published_at = _article_field(article, "article_published_at") or _article_field(
+        article, "published_at"
+    )
+    return PreopenMarketNewsItem(
+        id=int(_article_field(article, "id")),
+        title=str(_article_field(article, "title") or ""),
+        url=str(_article_field(article, "url") or ""),
+        source=_article_field(article, "source"),
+        feed_source=_article_field(article, "feed_source"),
+        published_at=published_at,
+        summary=_article_field(article, "summary"),
+        briefing_relevance=PreopenBriefingRelevance(
+            score=relevance.score,
+            reason=relevance.reason or "matched_section_terms",
+            section_id=relevance.section_id,
+            matched_terms=list(relevance.matched_terms),
+        ),
+        crypto_relevance=_article_field(article, "crypto_relevance"),
+    )
+
+
+async def _build_market_news_briefing(
+    db: AsyncSession,
+    *,
+    market_scope: str,
+) -> PreopenMarketNewsBriefing | None:
+    """Build a read-only market news briefing DTO for the preopen dashboard."""
+    try:
+        stmt = (
+            select(NewsArticle)
+            .where(NewsArticle.market == market_scope)
+            .order_by(
+                NewsArticle.article_published_at.desc().nullslast(),
+                NewsArticle.scraped_at.desc(),
+            )
+            .limit(30)
+        )
+        result = await db.execute(stmt)
+        scalars = result.scalars()
+        if isawaitable(scalars):
+            scalars = await scalars
+        articles = scalars.all()
+        if isawaitable(articles):
+            articles = await articles
+        articles = list(articles)
+        briefing = format_market_news_briefing(
+            articles,
+            market=market_scope,
+            limit=10,
+        )
+        return PreopenMarketNewsBriefing(
+            summary=dict(briefing.summary),
+            sections=[
+                PreopenMarketNewsSection(
+                    section_id=section.section_id,
+                    title=section.title,
+                    items=[_map_market_news_item(item) for item in section.items],
+                )
+                for section in briefing.sections
+            ],
+            excluded_count=len(briefing.excluded),
+            top_excluded=[
+                _map_market_news_item(item) for item in briefing.excluded[:3]
+            ],
+        )
+    except Exception:
+        logger.warning(
+            "Failed to build market news briefing for preopen dashboard",
+            exc_info=True,
+            extra={"market_scope": market_scope},
+        )
+        return None
+
+
 def _build_news_brief(
     readiness_raw: object | None,
     run: ResearchRun | None,
@@ -299,6 +394,10 @@ async def get_latest_preopen_dashboard(
         source_warnings=list(run.source_warnings),
     )
     news_brief = _build_news_brief(readiness_raw, run)
+    market_news_briefing = await _build_market_news_briefing(
+        db,
+        market_scope=market_scope,
+    )
     advisory_reason = _advisory_skipped_reason(run)
     linked = await _linked_sessions(db, run=run, user_id=user_id)
 
@@ -327,4 +426,5 @@ async def get_latest_preopen_dashboard(
         news=news_summary,
         news_preview=news_preview,
         news_brief=news_brief,
+        market_news_briefing=market_news_briefing,
     )

--- a/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
@@ -6,6 +6,7 @@ import PreopenPage from "../pages/PreopenPage";
 import {
   makePreopenFailOpen,
   makePreopenLinkedSession,
+  makePreopenMarketNewsBriefing,
   makePreopenNewsArticle,
   makePreopenNewsStale,
   makePreopenNewsUnavailable,
@@ -195,6 +196,51 @@ describe("PreopenPage", () => {
     expect(await screen.findByText("Unavailable")).toBeInTheDocument();
     expect(
       screen.getByText(/News readiness lookup failed/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders market news briefing sections and filtered count", async () => {
+    mockFetch({
+      [PREOPEN_URL]: () =>
+        new Response(
+          JSON.stringify(
+            makePreopenResponse({
+              market_news_briefing: makePreopenMarketNewsBriefing(),
+            }),
+          ),
+        ),
+    });
+
+    render(<PreopenPage />, { wrapper: MemoryRouter });
+
+    expect(
+      await screen.findByRole("region", { name: /market news briefing/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Preopen headlines/i)).toBeInTheDocument();
+    expect(screen.getByText(/Filtered noise: 2/i)).toBeInTheDocument();
+    expect(screen.getByText(/Score 82/i)).toBeInTheDocument();
+    expect(screen.getByText(/Terms: AI, 반도체/i)).toBeInTheDocument();
+  });
+
+  it("renders market news briefing fail-open state when field is null", async () => {
+    mockFetch({
+      [PREOPEN_URL]: () =>
+        new Response(
+          JSON.stringify(
+            makePreopenResponse({
+              market_news_briefing: null,
+            }),
+          ),
+        ),
+    });
+
+    render(<PreopenPage />, { wrapper: MemoryRouter });
+
+    expect(
+      await screen.findByRole("region", { name: /market news briefing/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/No market news briefing available yet/i),
     ).toBeInTheDocument();
   });
 

--- a/frontend/trading-decision/src/api/types.ts
+++ b/frontend/trading-decision/src/api/types.ts
@@ -236,6 +236,39 @@ export interface PreopenNewsArticlePreview {
   summary: string | null;
 }
 
+export interface PreopenBriefingRelevance {
+  score: number;
+  reason: string;
+  section_id: string | null;
+  matched_terms: string[];
+}
+
+export interface PreopenMarketNewsItem {
+  id: number;
+  title: string;
+  url: string;
+  source: string | null;
+  feed_source: string | null;
+  published_at: IsoDateTime | null;
+  summary: string | null;
+  briefing_relevance: PreopenBriefingRelevance | null;
+  crypto_relevance: Record<string, unknown> | null;
+}
+
+export interface PreopenMarketNewsSection {
+  section_id: string;
+  title: string;
+  items: PreopenMarketNewsItem[];
+}
+
+export interface PreopenMarketNewsBriefing {
+  briefing_filter: true;
+  summary: Record<string, unknown>;
+  sections: PreopenMarketNewsSection[];
+  excluded_count: number;
+  top_excluded: PreopenMarketNewsItem[];
+}
+
 export interface PreopenLatestResponse {
   has_run: boolean;
   advisory_used: boolean;
@@ -260,6 +293,7 @@ export interface PreopenLatestResponse {
   linked_sessions: PreopenLinkedSession[];
   news: PreopenNewsReadinessSummary | null;
   news_preview: PreopenNewsArticlePreview[];
+  market_news_briefing: PreopenMarketNewsBriefing | null;
 }
 
 export interface CreateFromResearchRunRequest {

--- a/frontend/trading-decision/src/components/MarketNewsBriefingSection.module.css
+++ b/frontend/trading-decision/src/components/MarketNewsBriefingSection.module.css
@@ -1,0 +1,181 @@
+.section {
+  border: 1px solid #dbe5f0;
+  background: #ffffff;
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1.25rem;
+}
+
+.header {
+  align-items: flex-start;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.subtitle {
+  color: #5f6b7a;
+  margin: 0.2rem 0 0;
+  font-size: 0.85rem;
+}
+
+.summaryChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0 0 0.9rem;
+  padding: 0;
+}
+
+.summaryChip {
+  align-items: center;
+  background: #eef6ff;
+  border: 1px solid #cde4ff;
+  border-radius: 999px;
+  color: #174b7c;
+  display: flex;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  padding: 0.2rem 0.65rem;
+  text-transform: capitalize;
+}
+
+.summaryChip strong {
+  color: #0d3155;
+}
+
+.sectionGrid {
+  display: grid;
+  gap: 0.8rem;
+}
+
+.card {
+  border: 1px solid #edf1f5;
+  border-radius: 8px;
+  padding: 0.85rem;
+  background: #fbfdff;
+}
+
+.cardHeader {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.cardHeader h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.count {
+  background: #f1f5f9;
+  border-radius: 999px;
+  color: #5f6b7a;
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+  white-space: nowrap;
+}
+
+.itemList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.item {
+  border-top: 1px solid #eef2f6;
+  padding: 0.6rem 0;
+}
+
+.item:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.item:last-child {
+  padding-bottom: 0;
+}
+
+.itemTitle {
+  color: #1f5f99;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.itemTitle:hover {
+  text-decoration: underline;
+}
+
+.itemMeta {
+  color: #5f6b7a;
+  display: block;
+  font-size: 0.78rem;
+  margin-top: 0.1rem;
+}
+
+.itemSummary {
+  color: #27364a;
+  font-size: 0.86rem;
+  margin: 0.35rem 0 0;
+}
+
+.relevance {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-top: 0.4rem;
+}
+
+.score,
+.terms {
+  border-radius: 999px;
+  font-size: 0.75rem;
+  padding: 0.12rem 0.5rem;
+}
+
+.score {
+  background: #ecfdf3;
+  color: #116534;
+}
+
+.terms {
+  background: #f7f2ff;
+  color: #5b2a86;
+}
+
+.excludedLine {
+  color: #5f6b7a;
+  font-size: 0.85rem;
+  margin-top: 0.8rem;
+}
+
+.excludedDetails {
+  margin-top: 0.4rem;
+}
+
+.excludedDetails summary {
+  color: #1f5f99;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.excludedDetails .itemList {
+  border: 1px solid #eef2f6;
+  border-radius: 8px;
+  margin-top: 0.5rem;
+  padding: 0.65rem;
+}
+
+.muted {
+  color: #5f6b7a;
+  margin: 0.25rem 0;
+}

--- a/frontend/trading-decision/src/components/MarketNewsBriefingSection.tsx
+++ b/frontend/trading-decision/src/components/MarketNewsBriefingSection.tsx
@@ -1,0 +1,139 @@
+import type {
+  PreopenMarketNewsBriefing,
+  PreopenMarketNewsItem,
+} from "../api/types";
+import { formatDateTime } from "../format/datetime";
+import styles from "./MarketNewsBriefingSection.module.css";
+
+export interface MarketNewsBriefingSectionProps {
+  briefing: PreopenMarketNewsBriefing | null;
+}
+
+type SummaryKey = "included" | "excluded" | "sections" | "uncategorized";
+
+function summaryNumber(
+  summary: Record<string, unknown>,
+  key: SummaryKey,
+): number | null {
+  const value = summary[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function NewsItem({ item }: { item: PreopenMarketNewsItem }) {
+  const relevance = item.briefing_relevance;
+  const matchedTerms = relevance?.matched_terms ?? [];
+
+  return (
+    <li className={styles.item}>
+      <a
+        className={styles.itemTitle}
+        href={item.url}
+        rel="noreferrer noopener"
+        target="_blank"
+      >
+        {item.title}
+      </a>
+      <span className={styles.itemMeta}>
+        {item.source ?? item.feed_source ?? "—"} ·{" "}
+        {formatDateTime(item.published_at)}
+      </span>
+      {item.summary ? (
+        <p className={styles.itemSummary}>{item.summary}</p>
+      ) : null}
+      {relevance ? (
+        <div className={styles.relevance}>
+          <span className={styles.score}>Score {relevance.score}</span>
+          {matchedTerms.length > 0 ? (
+            <span className={styles.terms}>Terms: {matchedTerms.join(", ")}</span>
+          ) : null}
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+export default function MarketNewsBriefingSection({
+  briefing,
+}: MarketNewsBriefingSectionProps) {
+  if (briefing === null) {
+    return (
+      <section aria-label="Market news briefing" className={styles.section}>
+        <header className={styles.header}>
+          <h2>Market news briefing</h2>
+        </header>
+        <p className={styles.muted}>No market news briefing available yet.</p>
+      </section>
+    );
+  }
+
+  const summaryChips = (
+    ["included", "excluded", "sections", "uncategorized"] as const
+  )
+    .map((key) => [key, summaryNumber(briefing.summary, key)] as const)
+    .filter(
+      (entry): entry is readonly [SummaryKey, number] => entry[1] !== null,
+    );
+
+  return (
+    <section aria-label="Market news briefing" className={styles.section}>
+      <header className={styles.header}>
+        <div>
+          <h2>Market news briefing</h2>
+          <p className={styles.subtitle}>
+            Market-aware sections from recent news, filtered before trading
+            review.
+          </p>
+        </div>
+      </header>
+
+      {summaryChips.length > 0 ? (
+        <ul aria-label="Market news briefing summary" className={styles.summaryChips}>
+          {summaryChips.map(([key, value]) => (
+            <li className={styles.summaryChip} key={key}>
+              <span>{key}</span>
+              <strong>{value}</strong>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {briefing.sections.length === 0 ? (
+        <p className={styles.muted}>No high-signal briefing sections found.</p>
+      ) : (
+        <div className={styles.sectionGrid}>
+          {briefing.sections.map((section) => (
+            <article className={styles.card} key={section.section_id}>
+              <header className={styles.cardHeader}>
+                <h3>{section.title}</h3>
+                <span className={styles.count}>{section.items.length} items</span>
+              </header>
+              {section.items.length === 0 ? (
+                <p className={styles.muted}>No articles in this section.</p>
+              ) : (
+                <ul className={styles.itemList}>
+                  {section.items.map((item) => (
+                    <NewsItem item={item} key={item.id} />
+                  ))}
+                </ul>
+              )}
+            </article>
+          ))}
+        </div>
+      )}
+
+      <div className={styles.excludedLine}>
+        Filtered noise: {briefing.excluded_count}
+      </div>
+      {briefing.top_excluded.length > 0 ? (
+        <details className={styles.excludedDetails}>
+          <summary>Show top excluded articles ({briefing.top_excluded.length})</summary>
+          <ul className={styles.itemList}>
+            {briefing.top_excluded.map((item) => (
+              <NewsItem item={item} key={item.id} />
+            ))}
+          </ul>
+        </details>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/trading-decision/src/pages/PreopenPage.tsx
+++ b/frontend/trading-decision/src/pages/PreopenPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import ErrorView from "../components/ErrorView";
 import LoadingView from "../components/LoadingView";
+import MarketNewsBriefingSection from "../components/MarketNewsBriefingSection";
 import NewsReadinessSection from "../components/NewsReadinessSection";
 import { ApiError } from "../api/client";
 import {
@@ -133,6 +134,7 @@ export default function PreopenPage() {
       ) : null}
 
       <NewsReadinessSection news={data.news} preview={data.news_preview} />
+      <MarketNewsBriefingSection briefing={data.market_news_briefing} />
 
       {data.candidates.length > 0 ? (
         <section className={styles.section}>

--- a/frontend/trading-decision/src/test/fixtures/preopen.ts
+++ b/frontend/trading-decision/src/test/fixtures/preopen.ts
@@ -2,6 +2,8 @@ import type {
   PreopenCandidateSummary,
   PreopenLatestResponse,
   PreopenLinkedSession,
+  PreopenMarketNewsBriefing,
+  PreopenMarketNewsItem,
   PreopenNewsArticlePreview,
   PreopenNewsReadinessSummary,
   PreopenReconciliationSummary,
@@ -122,6 +124,79 @@ export function makePreopenNewsArticle(
   };
 }
 
+export function makePreopenMarketNewsItem(
+  overrides: Partial<PreopenMarketNewsItem> = {},
+): PreopenMarketNewsItem {
+  return {
+    id: 2001,
+    title: "코스피 장전 AI 반도체 강세 전망",
+    url: "https://example.com/briefing/2001",
+    source: "Yonhap",
+    feed_source: "yna_market",
+    published_at: now,
+    summary: "AI 반도체와 대형주 수급을 장전 핵심 변수로 정리했습니다.",
+    briefing_relevance: {
+      score: 82,
+      reason: "matched_section_terms",
+      section_id: "preopen_headlines",
+      matched_terms: ["AI", "반도체"],
+    },
+    crypto_relevance: null,
+    ...overrides,
+  };
+}
+
+export function makePreopenMarketNewsBriefing(
+  overrides: Partial<PreopenMarketNewsBriefing> = {},
+): PreopenMarketNewsBriefing {
+  return {
+    briefing_filter: true,
+    summary: {
+      included: 3,
+      excluded: 2,
+      sections: 2,
+      uncategorized: 1,
+    },
+    sections: [
+      {
+        section_id: "preopen_headlines",
+        title: "Preopen headlines",
+        items: [makePreopenMarketNewsItem()],
+      },
+      {
+        section_id: "sector_theme",
+        title: "Sector themes",
+        items: [
+          makePreopenMarketNewsItem({
+            id: 2002,
+            title: "조선·방산 업종 수주 모멘텀 점검",
+            briefing_relevance: {
+              score: 74,
+              reason: "matched_section_terms",
+              section_id: "sector_theme",
+              matched_terms: ["방산", "수주"],
+            },
+          }),
+        ],
+      },
+    ],
+    excluded_count: 2,
+    top_excluded: [
+      makePreopenMarketNewsItem({
+        id: 2999,
+        title: "저신호 단신 모음",
+        briefing_relevance: {
+          score: 12,
+          reason: "low_relevance",
+          section_id: null,
+          matched_terms: [],
+        },
+      }),
+    ],
+    ...overrides,
+  };
+}
+
 export function makePreopenResponse(
   overrides: Partial<PreopenLatestResponse> = {},
 ): PreopenLatestResponse {
@@ -149,6 +224,7 @@ export function makePreopenResponse(
     linked_sessions: [],
     news: makePreopenNewsReady(),
     news_preview: [makePreopenNewsArticle()],
+    market_news_briefing: makePreopenMarketNewsBriefing(),
     ...overrides,
   };
 }
@@ -180,6 +256,7 @@ export function makePreopenFailOpen(
     linked_sessions: [],
     news: null,
     news_preview: [],
+    market_news_briefing: null,
     ...overrides,
   };
 }

--- a/tests/test_preopen_market_news_briefing.py
+++ b/tests/test_preopen_market_news_briefing.py
@@ -1,0 +1,239 @@
+"""ROB-75 preopen market news briefing API contract tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+
+def _response_kwargs(**overrides):
+    defaults = {
+        "has_run": True,
+        "advisory_used": False,
+        "advisory_skipped_reason": None,
+        "run_uuid": uuid4(),
+        "market_scope": "kr",
+        "stage": "preopen",
+        "status": "open",
+        "strategy_name": "Morning scan",
+        "source_profile": "roadmap",
+        "generated_at": datetime.now(UTC),
+        "created_at": datetime.now(UTC),
+        "notes": None,
+        "market_brief": {"summary": "cautious"},
+        "source_freshness": None,
+        "source_warnings": [],
+        "advisory_links": [],
+        "candidate_count": 0,
+        "reconciliation_count": 0,
+        "candidates": [],
+        "reconciliations": [],
+        "linked_sessions": [],
+        "news": None,
+        "news_preview": [],
+        "news_brief": None,
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def _article(**overrides):
+    published_at = overrides.pop("article_published_at", datetime.now(UTC))
+    defaults = {
+        "id": 10,
+        "title": "코스피 장전 시황과 반도체 강세",
+        "url": "https://example.com/market-open",
+        "source": "Example News",
+        "feed_source": "browser_naver_mainnews",
+        "article_published_at": published_at,
+        "scraped_at": published_at,
+        "summary": "반도체와 코스피 장전 흐름 요약",
+        "keywords": ["코스피", "반도체"],
+        "stock_symbol": None,
+        "crypto_relevance": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.mark.unit
+def test_preopen_response_serializes_market_news_briefing_contract():
+    from app.schemas.preopen import (
+        PreopenLatestResponse,
+        PreopenMarketNewsBriefing,
+        PreopenMarketNewsItem,
+        PreopenMarketNewsSection,
+    )
+
+    published_at = datetime.now(UTC)
+    response = PreopenLatestResponse(
+        **_response_kwargs(
+            market_news_briefing=PreopenMarketNewsBriefing(
+                summary={
+                    "included": 1,
+                    "excluded": 2,
+                    "sections": 1,
+                    "uncategorized": 1,
+                },
+                sections=[
+                    PreopenMarketNewsSection(
+                        section_id="preopen_headlines",
+                        title="장전 주요 뉴스",
+                        items=[
+                            PreopenMarketNewsItem(
+                                id=123,
+                                title="코스피 장전 시황",
+                                url="https://example.com/news/123",
+                                source="Example News",
+                                feed_source="browser_naver_mainnews",
+                                published_at=published_at,
+                                summary="장전 핵심 요약",
+                                briefing_relevance={
+                                    "score": 64,
+                                    "reason": "matched_section_terms",
+                                    "section_id": "preopen_headlines",
+                                    "matched_terms": ["코스피", "장전"],
+                                },
+                            )
+                        ],
+                    )
+                ],
+                excluded_count=2,
+                top_excluded=[
+                    PreopenMarketNewsItem(
+                        id=124,
+                        title="저신호 기사",
+                        url="https://example.com/news/124",
+                    )
+                ],
+            )
+        )
+    )
+
+    dumped = response.model_dump()
+    briefing = dumped["market_news_briefing"]
+    assert briefing["briefing_filter"] is True
+    assert briefing["summary"]["included"] == 1
+    assert briefing["sections"][0]["section_id"] == "preopen_headlines"
+    assert briefing["sections"][0]["items"][0]["briefing_relevance"]["score"] == 64
+    assert briefing["excluded_count"] == 2
+    assert briefing["top_excluded"][0]["id"] == 124
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_build_market_news_briefing_uses_formatter_and_maps_sections():
+    from app.services import preopen_dashboard_service
+
+    included = _article(
+        id=1, title="장전 코스피 반도체 강세", keywords=["장전", "코스피", "반도체"]
+    )
+    excluded = _article(
+        id=2, title="연예인 결혼 소식", summary="생활 문화 소식", keywords=[]
+    )
+    result_mock = MagicMock()
+    result_mock.scalars.return_value.all.return_value = [included, excluded]
+    db = AsyncMock()
+    db.execute.return_value = result_mock
+
+    briefing = await preopen_dashboard_service._build_market_news_briefing(
+        db,
+        market_scope="kr",
+    )
+
+    assert briefing is not None
+    assert briefing.briefing_filter is True
+    assert briefing.summary["included"] >= 1
+    assert briefing.sections
+    assert briefing.sections[0].items[0].id == 1
+    assert briefing.sections[0].items[0].briefing_relevance is not None
+    assert briefing.excluded_count >= 1
+    assert len(briefing.top_excluded) <= 3
+    db.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_preopen_dashboard_attaches_market_news_briefing_and_preserves_news_preview():
+    from app.schemas.preopen import NewsArticlePreview, PreopenMarketNewsBriefing
+    from app.services import preopen_dashboard_service, research_run_service
+    from tests.test_preopen_dashboard_service import _make_news_readiness, _make_run
+
+    preview = [
+        NewsArticlePreview(
+            id=99,
+            title="raw preview",
+            url="https://example.com/raw",
+            source="Example",
+            feed_source="browser_naver_mainnews",
+            published_at=datetime.now(UTC),
+            summary=None,
+        )
+    ]
+    market_briefing = PreopenMarketNewsBriefing(
+        summary={"included": 1, "excluded": 0, "sections": 1, "uncategorized": 0},
+        sections=[],
+    )
+
+    with (
+        patch.object(
+            research_run_service,
+            "get_latest_research_run",
+            new=AsyncMock(return_value=_make_run()),
+        ),
+        patch.object(
+            preopen_dashboard_service,
+            "_linked_sessions",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            preopen_dashboard_service,
+            "get_news_readiness",
+            new=AsyncMock(return_value=_make_news_readiness()),
+        ),
+        patch.object(
+            preopen_dashboard_service,
+            "get_latest_news_preview",
+            new=AsyncMock(return_value=preview),
+        ),
+        patch.object(
+            preopen_dashboard_service,
+            "_build_market_news_briefing",
+            new=AsyncMock(return_value=market_briefing),
+        ),
+    ):
+        result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+            db=AsyncMock(),
+            user_id=7,
+            market_scope="kr",
+        )
+
+    assert result.market_news_briefing is market_briefing
+    assert result.news_preview == preview
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_market_news_briefing_formatter_failure_fails_open():
+    from app.services import preopen_dashboard_service
+
+    result_mock = MagicMock()
+    result_mock.scalars.return_value.all.return_value = [_article()]
+    db = AsyncMock()
+    db.execute.return_value = result_mock
+
+    with patch.object(
+        preopen_dashboard_service,
+        "format_market_news_briefing",
+        side_effect=RuntimeError("formatter failed"),
+    ):
+        briefing = await preopen_dashboard_service._build_market_news_briefing(
+            db,
+            market_scope="kr",
+        )
+
+    assert briefing is None


### PR DESCRIPTION
## Summary
- Adds an additive `market_news_briefing` contract to the KR preopen response.
- Connects the preopen dashboard service to the market news briefing formatter with fail-open behavior.
- Renders the Market news briefing section in the preopen SPA with empty/null-safe UI states.

## Safety / non-goals
- No broker, live/paper order, watch alert, order-intent, or Decision Session creation paths are added or exercised.
- No raw news ingestion/storage behavior is changed.
- The formatter integration is read-layer only and fails open if briefing data is unavailable.
- No production deploy or merge is performed in this PR/CI task.

## Verification
- `uv run pytest tests/test_preopen_market_news_briefing.py -q` — 4 passed, 2 existing Pydantic deprecation warnings.
- `uv run ruff check app/schemas/preopen.py app/services/preopen_dashboard_service.py tests/test_preopen_market_news_briefing.py` — passed.
- `npm test -- src/__tests__/PreopenPage.test.tsx` — 11 passed.
- `npm run typecheck` — passed.

Closes ROB-75


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added market news briefing section displaying curated market news organized by categories.
  * Each news item shows relevance score, matched search terms, and publication details.
  * Summary view displays counts of included/excluded items with collapsible excluded items list.
  * Graceful handling when market news briefing is not yet available.

* **Tests**
  * Added test coverage for market news briefing API contract and service integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->