### PR TITLE
feat: add preopen workflow artifact MVP

### DIFF
--- a/app/schemas/preopen.py
+++ b/app/schemas/preopen.py
@@ -70,6 +70,59 @@ class PreopenMarketNewsBriefing(BaseModel):
     top_excluded: list[PreopenMarketNewsItem] = []
 
 
+PreopenArtifactStatus = Literal["unavailable", "draft", "ready", "degraded"]
+PreopenArtifactReadinessStatus = Literal["ready", "stale", "unavailable", "partial"]
+PreopenDecisionSessionCtaState = Literal[
+    "unavailable",
+    "create_available",
+    "linked_session_exists",
+]
+
+
+class PreopenArtifactReadinessItem(BaseModel):
+    key: str
+    status: PreopenArtifactReadinessStatus
+    is_ready: bool
+    warnings: list[str] = []
+    details: dict[str, Any] = {}
+
+
+class PreopenArtifactSection(BaseModel):
+    section_id: str
+    title: str
+    item_count: int
+    status: PreopenArtifactStatus
+    summary: str | None = None
+    items: list[dict[str, Any]] = []
+
+
+class PreopenDecisionSessionCta(BaseModel):
+    state: PreopenDecisionSessionCtaState
+    label: str
+    run_uuid: UUID | None = None
+    linked_session_uuid: UUID | None = None
+    disabled_reason: str | None = None
+    requires_confirmation: bool = True
+
+
+class PreopenBriefingArtifact(BaseModel):
+    artifact_type: Literal["preopen_briefing"] = "preopen_briefing"
+    artifact_version: Literal["v1"] = "v1"
+    status: PreopenArtifactStatus
+    run_uuid: UUID | None = None
+    market_scope: Literal["kr", "us", "crypto"] | None = None
+    stage: Literal["preopen"] | None = None
+    generated_at: datetime | None = None
+    source_run_status: str | None = None
+    readiness: list[PreopenArtifactReadinessItem] = []
+    market_summary: str | None = None
+    news_summary: str | None = None
+    sections: list[PreopenArtifactSection] = []
+    risk_notes: list[str] = []
+    cta: PreopenDecisionSessionCta
+    qa: dict[str, Any] = {}
+
+
 class CandidateSummary(BaseModel):
     candidate_uuid: UUID
     symbol: str
@@ -130,3 +183,4 @@ class PreopenLatestResponse(BaseModel):
     news_preview: list[NewsArticlePreview] = []
     news_brief: KRPreopenNewsBrief | None = None
     market_news_briefing: PreopenMarketNewsBriefing | None = None
+    briefing_artifact: PreopenBriefingArtifact | None = None

--- a/app/services/preopen_dashboard_service.py
+++ b/app/services/preopen_dashboard_service.py
@@ -20,7 +20,11 @@ from app.schemas.preopen import (
     LinkedSessionRef,
     NewsArticlePreview,
     NewsReadinessSummary,
+    PreopenArtifactReadinessItem,
+    PreopenArtifactSection,
+    PreopenBriefingArtifact,
     PreopenBriefingRelevance,
+    PreopenDecisionSessionCta,
     PreopenLatestResponse,
     PreopenMarketNewsBriefing,
     PreopenMarketNewsItem,
@@ -66,6 +70,34 @@ _FAIL_OPEN = PreopenLatestResponse(
     news_preview=[],
     news_brief=None,
     market_news_briefing=None,
+    briefing_artifact=PreopenBriefingArtifact(
+        status="unavailable",
+        source_run_status=None,
+        readiness=[
+            PreopenArtifactReadinessItem(
+                key="research_run",
+                status="unavailable",
+                is_ready=False,
+                warnings=["no_open_preopen_run"],
+                details={},
+            )
+        ],
+        market_summary=None,
+        news_summary=None,
+        sections=[],
+        risk_notes=["no_open_preopen_run"],
+        cta=PreopenDecisionSessionCta(
+            state="unavailable",
+            label="Create decision session unavailable",
+            disabled_reason="no_open_preopen_run",
+            requires_confirmation=True,
+        ),
+        qa={
+            "read_only": True,
+            "mutation_paths": [],
+            "decision_session_created": False,
+        },
+    ),
 )
 
 
@@ -362,6 +394,221 @@ def _build_news_brief(
         return None
 
 
+def _summarize_market_brief(market_brief: dict[str, Any] | None) -> str | None:
+    if not market_brief:
+        return None
+    summary = market_brief.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        return summary
+    return None
+
+
+def _build_briefing_artifact(
+    *,
+    run: ResearchRun,
+    candidates: list[CandidateSummary],
+    reconciliations: list[ReconciliationSummary],
+    linked: list[LinkedSessionRef],
+    news: NewsReadinessSummary | None,
+    news_brief: KRPreopenNewsBrief | None,
+    market_news_briefing: PreopenMarketNewsBriefing | None,
+    source_warnings: list[str],
+) -> PreopenBriefingArtifact:
+    """Build the additive read-only preopen artifact from already-loaded data.
+
+    The artifact is a transport-level workflow summary only. It deliberately does
+    not query broker/order/watch providers or persist anything.
+    """
+
+    buy_candidates = [c for c in candidates if c.side == "buy"]
+    holding_actions = [c for c in candidates if c.side in {"sell", "none"}]
+    risk_notes = list(dict.fromkeys([*source_warnings]))
+    if news is None:
+        risk_notes.append("news_readiness_unavailable")
+    elif not news.is_ready:
+        risk_notes.extend(news.warnings or [f"news_{news.status}"])
+    if market_news_briefing is None:
+        risk_notes.append("market_news_briefing_unavailable")
+
+    news_status = news.status if news is not None else "unavailable"
+    readiness = [
+        PreopenArtifactReadinessItem(
+            key="research_run",
+            status="ready",
+            is_ready=True,
+            warnings=[],
+            details={"source_run_status": run.status},
+        ),
+        PreopenArtifactReadinessItem(
+            key="news",
+            status=news_status,  # type: ignore[arg-type]
+            is_ready=bool(news and news.is_ready),
+            warnings=list(news.warnings if news else ["news_readiness_unavailable"]),
+            details={
+                "latest_run_uuid": news.latest_run_uuid if news else None,
+                "latest_status": news.latest_status if news else None,
+                "source_counts": news.source_counts if news else {},
+            },
+        ),
+        PreopenArtifactReadinessItem(
+            key="cash",
+            status="unavailable",
+            is_ready=False,
+            warnings=["not_in_current_preopen_contract"],
+            details={},
+        ),
+        PreopenArtifactReadinessItem(
+            key="holdings",
+            status="partial" if holding_actions or reconciliations else "unavailable",
+            is_ready=bool(holding_actions or reconciliations),
+            warnings=[]
+            if holding_actions or reconciliations
+            else ["not_in_current_preopen_contract"],
+            details={
+                "holding_action_count": len(holding_actions),
+                "reconciliation_count": len(reconciliations),
+            },
+        ),
+        PreopenArtifactReadinessItem(
+            key="quotes",
+            status="unavailable",
+            is_ready=False,
+            warnings=["not_in_current_preopen_contract"],
+            details={},
+        ),
+    ]
+
+    market_news_count = (
+        sum(len(section.items) for section in market_news_briefing.sections)
+        if market_news_briefing
+        else 0
+    )
+    sections = [
+        PreopenArtifactSection(
+            section_id="market_news",
+            title="Market news briefing",
+            item_count=market_news_count,
+            status="ready" if market_news_count else "unavailable",
+            summary=(
+                f"{market_news_count} high-signal articles across "
+                f"{len(market_news_briefing.sections)} sections"
+                if market_news_briefing
+                else "Market news briefing is unavailable."
+            ),
+            items=[
+                {
+                    "section_id": section.section_id,
+                    "title": section.title,
+                    "item_count": len(section.items),
+                }
+                for section in (
+                    market_news_briefing.sections if market_news_briefing else []
+                )
+            ],
+        ),
+        PreopenArtifactSection(
+            section_id="new_buy_candidates",
+            title="New buy candidates",
+            item_count=len(buy_candidates),
+            status="ready" if buy_candidates else "unavailable",
+            summary=(
+                f"{len(buy_candidates)} buy candidates prepared before decision-session review."
+                if buy_candidates
+                else "No buy candidates in the current run."
+            ),
+            items=[
+                {
+                    "symbol": c.symbol,
+                    "confidence": c.confidence,
+                    "rationale": c.rationale,
+                    "proposed_price": str(c.proposed_price)
+                    if c.proposed_price is not None
+                    else None,
+                    "proposed_qty": str(c.proposed_qty)
+                    if c.proposed_qty is not None
+                    else None,
+                }
+                for c in buy_candidates[:5]
+            ],
+        ),
+        PreopenArtifactSection(
+            section_id="holdings_actions",
+            title="Holdings actions",
+            item_count=len(holding_actions) + len(reconciliations),
+            status="ready" if holding_actions or reconciliations else "unavailable",
+            summary=(
+                f"{len(holding_actions)} candidate actions and {len(reconciliations)} pending reconciliations."
+            ),
+            items=[
+                {"symbol": c.symbol, "side": c.side, "rationale": c.rationale}
+                for c in holding_actions[:5]
+            ]
+            + [
+                {
+                    "symbol": r.symbol,
+                    "classification": r.classification,
+                    "summary": r.summary,
+                }
+                for r in reconciliations[:5]
+            ],
+        ),
+    ]
+
+    cta = (
+        PreopenDecisionSessionCta(
+            state="linked_session_exists",
+            label="Open linked decision session",
+            run_uuid=run.run_uuid,
+            linked_session_uuid=linked[0].session_uuid,
+            requires_confirmation=False,
+        )
+        if linked
+        else PreopenDecisionSessionCta(
+            state="create_available",
+            label="Create decision session",
+            run_uuid=run.run_uuid,
+            requires_confirmation=True,
+        )
+    )
+
+    status = "ready"
+    if risk_notes or any(
+        not item.is_ready for item in readiness if item.key in {"research_run", "news"}
+    ):
+        status = "degraded"
+
+    news_summary = None
+    if news_brief is not None:
+        signal_count = len(news_brief.sector_flags) + len(news_brief.candidate_flags)
+        news_summary = (
+            f"News readiness is {news_brief.news_readiness}; "
+            f"{signal_count} advisory signals summarized."
+        )
+    elif news is not None:
+        news_summary = f"News readiness is {news.status}."
+
+    return PreopenBriefingArtifact(
+        status=status,  # type: ignore[arg-type]
+        run_uuid=run.run_uuid,
+        market_scope=run.market_scope,  # type: ignore[arg-type]
+        stage="preopen",
+        generated_at=run.generated_at,
+        source_run_status=run.status,
+        readiness=readiness,
+        market_summary=_summarize_market_brief(run.market_brief),
+        news_summary=news_summary,
+        sections=sections,
+        risk_notes=risk_notes,
+        cta=cta,
+        qa={
+            "read_only": True,
+            "mutation_paths": [],
+            "decision_session_created": False,
+            "source": "latest_open_research_run",
+        },
+    )
+
+
 async def get_latest_preopen_dashboard(
     db: AsyncSession,
     *,
@@ -401,6 +648,17 @@ async def get_latest_preopen_dashboard(
     advisory_reason = _advisory_skipped_reason(run)
     linked = await _linked_sessions(db, run=run, user_id=user_id)
 
+    briefing_artifact = _build_briefing_artifact(
+        run=run,
+        candidates=candidates,
+        reconciliations=reconciliations,
+        linked=linked,
+        news=news_summary,
+        news_brief=news_brief,
+        market_news_briefing=market_news_briefing,
+        source_warnings=source_warnings,
+    )
+
     return PreopenLatestResponse(
         has_run=True,
         advisory_used=bool(run.advisory_links) and advisory_reason is None,
@@ -427,4 +685,5 @@ async def get_latest_preopen_dashboard(
         news_preview=news_preview,
         news_brief=news_brief,
         market_news_briefing=market_news_briefing,
+        briefing_artifact=briefing_artifact,
     )

--- a/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
@@ -30,6 +30,7 @@ describe("PreopenPage", () => {
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
     expect(await screen.findByText(/No preopen research run available/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: /Preopen briefing/i })).toBeInTheDocument();
     expect(screen.getAllByText(/no_open_preopen_run/i).length).toBeGreaterThan(0);
     expect(screen.getByText(/Artifact unavailable/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /create decision session/i })).toBeNull();
@@ -47,7 +48,7 @@ describe("PreopenPage", () => {
     expect(await screen.findAllByText("005930")).toHaveLength(2);
     expect(screen.getByText("near_fill")).toBeInTheDocument();
     expect(screen.getByText(/Morning scan/)).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /Preopen briefing/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: /Preopen briefing/i })).toBeInTheDocument();
     expect(screen.getByText(/Artifact ready/i)).toBeInTheDocument();
     expect(screen.getByText(/preopen_briefing v1/i)).toBeInTheDocument();
     expect(screen.getByText(/News brief: 장전 핵심 뉴스/i)).toBeInTheDocument();

--- a/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
@@ -6,6 +6,7 @@ import PreopenPage from "../pages/PreopenPage";
 import {
   makePreopenFailOpen,
   makePreopenLinkedSession,
+  makePreopenBriefingArtifact,
   makePreopenMarketNewsBriefing,
   makePreopenNewsArticle,
   makePreopenNewsStale,
@@ -29,7 +30,8 @@ describe("PreopenPage", () => {
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
     expect(await screen.findByText(/No preopen research run available/i)).toBeInTheDocument();
-    expect(screen.getByText(/no_open_preopen_run/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/no_open_preopen_run/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Artifact unavailable/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /create decision session/i })).toBeNull();
   });
 
@@ -45,6 +47,35 @@ describe("PreopenPage", () => {
     expect(await screen.findAllByText("005930")).toHaveLength(2);
     expect(screen.getByText("near_fill")).toBeInTheDocument();
     expect(screen.getByText(/Morning scan/)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /Preopen briefing/i })).toBeInTheDocument();
+    expect(screen.getByText(/Artifact ready/i)).toBeInTheDocument();
+    expect(screen.getByText(/preopen_briefing v1/i)).toBeInTheDocument();
+    expect(screen.getByText(/News brief: 장전 핵심 뉴스/i)).toBeInTheDocument();
+  });
+
+  it("renders degraded briefing artifact without hiding ROB-75 market news", async () => {
+    mockFetch({
+      [PREOPEN_URL]: () =>
+        new Response(
+          JSON.stringify(
+            makePreopenResponse({
+              briefing_artifact: makePreopenBriefingArtifact({
+                status: "degraded",
+                risk_notes: ["market_news_briefing_unavailable"],
+              }),
+              market_news_briefing: makePreopenMarketNewsBriefing(),
+            }),
+          ),
+        ),
+    });
+
+    render(<PreopenPage />, { wrapper: MemoryRouter });
+
+    expect(await screen.findByText(/Artifact degraded/i)).toBeInTheDocument();
+    expect(screen.getByText(/market_news_briefing_unavailable/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: /market news briefing/i }),
+    ).toBeInTheDocument();
   });
 
   it("clicking Create decision session calls api with correct args and navigates", async () => {

--- a/frontend/trading-decision/src/api/types.ts
+++ b/frontend/trading-decision/src/api/types.ts
@@ -269,6 +269,61 @@ export interface PreopenMarketNewsBriefing {
   top_excluded: PreopenMarketNewsItem[];
 }
 
+export type PreopenArtifactStatus = "unavailable" | "draft" | "ready" | "degraded";
+export type PreopenArtifactReadinessStatus =
+  | "ready"
+  | "stale"
+  | "unavailable"
+  | "partial";
+export type PreopenDecisionSessionCtaState =
+  | "unavailable"
+  | "create_available"
+  | "linked_session_exists";
+
+export interface PreopenArtifactReadinessItem {
+  key: string;
+  status: PreopenArtifactReadinessStatus;
+  is_ready: boolean;
+  warnings: string[];
+  details: Record<string, unknown>;
+}
+
+export interface PreopenArtifactSection {
+  section_id: string;
+  title: string;
+  item_count: number;
+  status: PreopenArtifactStatus;
+  summary: string | null;
+  items: Record<string, unknown>[];
+}
+
+export interface PreopenDecisionSessionCta {
+  state: PreopenDecisionSessionCtaState;
+  label: string;
+  run_uuid: Uuid | null;
+  linked_session_uuid: Uuid | null;
+  disabled_reason: string | null;
+  requires_confirmation: boolean;
+}
+
+export interface PreopenBriefingArtifact {
+  artifact_type: "preopen_briefing";
+  artifact_version: "v1";
+  status: PreopenArtifactStatus;
+  run_uuid: Uuid | null;
+  market_scope: "kr" | "us" | "crypto" | null;
+  stage: "preopen" | null;
+  generated_at: IsoDateTime | null;
+  source_run_status: string | null;
+  readiness: PreopenArtifactReadinessItem[];
+  market_summary: string | null;
+  news_summary: string | null;
+  sections: PreopenArtifactSection[];
+  risk_notes: string[];
+  cta: PreopenDecisionSessionCta;
+  qa: Record<string, unknown>;
+}
+
 export interface PreopenLatestResponse {
   has_run: boolean;
   advisory_used: boolean;
@@ -294,6 +349,7 @@ export interface PreopenLatestResponse {
   news: PreopenNewsReadinessSummary | null;
   news_preview: PreopenNewsArticlePreview[];
   market_news_briefing: PreopenMarketNewsBriefing | null;
+  briefing_artifact: PreopenBriefingArtifact | null;
 }
 
 export interface CreateFromResearchRunRequest {

--- a/frontend/trading-decision/src/pages/PreopenPage.module.css
+++ b/frontend/trading-decision/src/pages/PreopenPage.module.css
@@ -123,3 +123,48 @@
   display: flex;
   gap: 12px;
 }
+
+
+.artifactSection {
+  border: 1px solid #dbe4ef;
+  border-radius: 8px;
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.artifactHeader {
+  align-items: flex-start;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.artifactStatus {
+  background: #eef2ff;
+  border-radius: 999px;
+  color: #3730a3;
+  font-size: 0.8rem;
+  padding: 4px 10px;
+  text-transform: capitalize;
+}
+
+.artifactGrid {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.artifactCard {
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  display: grid;
+  gap: 4px;
+  padding: 10px;
+}
+
+.artifactCard span,
+.artifactCard small {
+  color: #64748b;
+}

--- a/frontend/trading-decision/src/pages/PreopenPage.tsx
+++ b/frontend/trading-decision/src/pages/PreopenPage.tsx
@@ -9,7 +9,7 @@ import {
   createDecisionFromResearchRun,
   getLatestPreopen,
 } from "../api/preopen";
-import type { PreopenLatestResponse } from "../api/types";
+import type { PreopenBriefingArtifact, PreopenLatestResponse } from "../api/types";
 import { formatDateTime } from "../format/datetime";
 import styles from "./PreopenPage.module.css";
 
@@ -17,6 +17,73 @@ type State =
   | { status: "loading" }
   | { status: "error"; message: string }
   | { status: "success"; data: PreopenLatestResponse };
+
+function formatArtifactVersion(version: string): string {
+  return version.startsWith("mvp.") ? version.slice(4) : version;
+}
+
+function PreopenBriefingArtifactSection({
+  artifact,
+}: {
+  artifact: PreopenBriefingArtifact | null;
+}) {
+  if (!artifact) return null;
+
+  return (
+    <section
+      aria-label="Preopen briefing artifact"
+      className={styles.artifactSection}
+    >
+      <div className={styles.artifactHeader}>
+        <div>
+          <h2>Preopen briefing</h2>
+          <p className={styles.meta}>
+            {artifact.artifact_type} {formatArtifactVersion(artifact.artifact_version)}
+          </p>
+        </div>
+        <span className={styles.artifactStatus}>Artifact {artifact.status}</span>
+      </div>
+
+      {artifact.market_summary ? <p>{artifact.market_summary}</p> : null}
+      {artifact.news_summary ? <p>News brief: {artifact.news_summary}</p> : null}
+
+      {artifact.risk_notes.length > 0 ? (
+        <ul aria-label="Preopen artifact risk notes" className={styles.warnings}>
+          {artifact.risk_notes.map((note) => (
+            <li className={styles.warningChip} key={note}>
+              {note}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {artifact.readiness.length > 0 ? (
+        <div className={styles.artifactGrid}>
+          {artifact.readiness.map((item) => (
+            <div className={styles.artifactCard} key={item.key}>
+              <strong>{item.key}</strong>
+              <span>{item.status}</span>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {artifact.sections.length > 0 ? (
+        <div className={styles.artifactGrid}>
+          {artifact.sections.map((section) => (
+            <div className={styles.artifactCard} key={section.section_id}>
+              <strong>{section.title}</strong>
+              <span>
+                {section.status} · {section.item_count}
+              </span>
+              {section.summary ? <small>{section.summary}</small> : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
 
 export default function PreopenPage() {
   const navigate = useNavigate();
@@ -86,6 +153,15 @@ export default function PreopenPage() {
   }
 
   const { data } = state;
+  const artifactCta = data.briefing_artifact?.cta ?? null;
+  const linkedSessionUuid =
+    artifactCta?.state === "linked_session_exists"
+      ? artifactCta.linked_session_uuid
+      : data.linked_sessions[0]?.session_uuid;
+  const createRunUuid =
+    artifactCta?.state === "create_available"
+      ? artifactCta.run_uuid
+      : data.run_uuid;
 
   if (!data.has_run) {
     return (
@@ -97,6 +173,7 @@ export default function PreopenPage() {
             <p>Reason: {data.advisory_skipped_reason}</p>
           ) : null}
         </div>
+        <PreopenBriefingArtifactSection artifact={data.briefing_artifact} />
       </main>
     );
   }
@@ -133,6 +210,7 @@ export default function PreopenPage() {
         </ul>
       ) : null}
 
+      <PreopenBriefingArtifactSection artifact={data.briefing_artifact} />
       <NewsReadinessSection news={data.news} preview={data.news_preview} />
       <MarketNewsBriefingSection briefing={data.market_news_briefing} />
 
@@ -240,26 +318,26 @@ export default function PreopenPage() {
       ) : null}
 
       <div className={styles.ctaRow}>
-        {data.linked_sessions.length > 0 ? (
+        {linkedSessionUuid ? (
           <Link
             className="btn"
-            to={`/sessions/${data.linked_sessions[0]!.session_uuid}`}
+            to={`/sessions/${linkedSessionUuid}`}
           >
             Open session
           </Link>
         ) : null}
-        {data.linked_sessions.length === 0 ? (
+        {!linkedSessionUuid ? (
           <button
             className="btn"
-            disabled={creating || !data.run_uuid}
-            onClick={() => data.run_uuid && handleCreate(String(data.run_uuid))}
+            disabled={creating || !createRunUuid || artifactCta?.state === "unavailable"}
+            onClick={() => createRunUuid && handleCreate(String(createRunUuid))}
             type="button"
           >
             {confirmPending
               ? "Confirm create decision session?"
               : creating
                 ? "Creating…"
-                : "Create decision session"}
+                : artifactCta?.label ?? "Create decision session"}
           </button>
         ) : null}
         {confirmPending ? (

--- a/frontend/trading-decision/src/pages/PreopenPage.tsx
+++ b/frontend/trading-decision/src/pages/PreopenPage.tsx
@@ -166,7 +166,7 @@ export default function PreopenPage() {
   if (!data.has_run) {
     return (
       <main className={styles.page}>
-        <h1>Preopen advisory</h1>
+        <h1>Preopen briefing</h1>
         <div className={styles.banner} role="status">
           <strong>No preopen research run available</strong>
           {data.advisory_skipped_reason ? (
@@ -181,7 +181,7 @@ export default function PreopenPage() {
   return (
     <main className={styles.page}>
       <div className={styles.header}>
-        <h1>Preopen advisory</h1>
+        <h1>Preopen briefing</h1>
         <div className={styles.meta}>
           Generated: {formatDateTime(data.generated_at)}
           {data.strategy_name ? ` · ${data.strategy_name}` : ""}

--- a/frontend/trading-decision/src/test/fixtures/preopen.ts
+++ b/frontend/trading-decision/src/test/fixtures/preopen.ts
@@ -1,4 +1,5 @@
 import type {
+  PreopenBriefingArtifact,
   PreopenCandidateSummary,
   PreopenLatestResponse,
   PreopenLinkedSession,
@@ -197,6 +198,112 @@ export function makePreopenMarketNewsBriefing(
   };
 }
 
+
+export function makePreopenBriefingArtifact(
+  overrides: Partial<PreopenBriefingArtifact> = {},
+): PreopenBriefingArtifact {
+  return {
+    artifact_type: "preopen_briefing",
+    artifact_version: "v1",
+    status: "ready",
+    run_uuid: "run-1111-2222-3333-444444444444",
+    market_scope: "kr",
+    stage: "preopen",
+    generated_at: now,
+    source_run_status: "open",
+    readiness: [
+      {
+        key: "research_run",
+        status: "ready",
+        is_ready: true,
+        warnings: [],
+        details: { source_run_status: "open" },
+      },
+      {
+        key: "news",
+        status: "ready",
+        is_ready: true,
+        warnings: [],
+        details: { latest_run_uuid: "news-run-1" },
+      },
+    ],
+    market_summary: "Cautious but constructive setup.",
+    news_summary: "장전 핵심 뉴스",
+    sections: [
+      {
+        section_id: "market_news",
+        title: "Market news briefing",
+        item_count: 3,
+        status: "ready",
+        summary: "3 high-signal articles across 2 sections",
+        items: [],
+      },
+      {
+        section_id: "new_buy_candidates",
+        title: "New buy candidates",
+        item_count: 1,
+        status: "ready",
+        summary: "1 buy candidates prepared before decision-session review.",
+        items: [{ symbol: "005930", confidence: 75 }],
+      },
+      {
+        section_id: "holdings_actions",
+        title: "Holdings actions",
+        item_count: 1,
+        status: "ready",
+        summary: "0 candidate actions and 1 pending reconciliations.",
+        items: [{ symbol: "005930", classification: "near_fill" }],
+      },
+    ],
+    risk_notes: [],
+    cta: {
+      state: "create_available",
+      label: "Create decision session",
+      run_uuid: "run-1111-2222-3333-444444444444",
+      linked_session_uuid: null,
+      disabled_reason: null,
+      requires_confirmation: true,
+    },
+    qa: { read_only: true, mutation_paths: [], decision_session_created: false },
+    ...overrides,
+  };
+}
+
+export function makePreopenUnavailableArtifact(
+  overrides: Partial<PreopenBriefingArtifact> = {},
+): PreopenBriefingArtifact {
+  return makePreopenBriefingArtifact({
+    status: "unavailable",
+    run_uuid: null,
+    market_scope: null,
+    stage: null,
+    generated_at: null,
+    source_run_status: null,
+    readiness: [
+      {
+        key: "research_run",
+        status: "unavailable",
+        is_ready: false,
+        warnings: ["no_open_preopen_run"],
+        details: {},
+      },
+    ],
+    market_summary: null,
+    news_summary: null,
+    sections: [],
+    risk_notes: ["no_open_preopen_run"],
+    cta: {
+      state: "unavailable",
+      label: "Create decision session unavailable",
+      run_uuid: null,
+      linked_session_uuid: null,
+      disabled_reason: "no_open_preopen_run",
+      requires_confirmation: true,
+    },
+    ...overrides,
+  });
+}
+
 export function makePreopenResponse(
   overrides: Partial<PreopenLatestResponse> = {},
 ): PreopenLatestResponse {
@@ -225,6 +332,7 @@ export function makePreopenResponse(
     news: makePreopenNewsReady(),
     news_preview: [makePreopenNewsArticle()],
     market_news_briefing: makePreopenMarketNewsBriefing(),
+    briefing_artifact: makePreopenBriefingArtifact(),
     ...overrides,
   };
 }
@@ -257,6 +365,7 @@ export function makePreopenFailOpen(
     news: null,
     news_preview: [],
     market_news_briefing: null,
+    briefing_artifact: makePreopenUnavailableArtifact(),
     ...overrides,
   };
 }

--- a/tests/test_preopen_dashboard_service.py
+++ b/tests/test_preopen_dashboard_service.py
@@ -163,6 +163,12 @@ async def test_returns_fail_open_when_no_run():
     assert result.reconciliations == []
     assert result.linked_sessions == []
     assert result.run_uuid is None
+    assert result.briefing_artifact is not None
+    assert result.briefing_artifact.status == "unavailable"
+    assert result.briefing_artifact.artifact_type == "preopen_briefing"
+    assert result.briefing_artifact.cta.state == "unavailable"
+    assert result.briefing_artifact.cta.requires_confirmation is True
+    assert "no_open_preopen_run" in result.briefing_artifact.risk_notes
 
 
 @pytest.mark.asyncio
@@ -205,6 +211,85 @@ async def test_maps_candidates_and_reconciliations():
     assert result.reconciliations[0].symbol == "005930"
     assert result.reconciliations[0].gap_pct == Decimal("0.50")
     assert result.run_uuid == run.run_uuid
+    assert result.briefing_artifact is not None
+    assert result.briefing_artifact.status == "ready"
+    assert result.briefing_artifact.run_uuid == run.run_uuid
+    assert result.briefing_artifact.market_scope == "kr"
+    assert result.briefing_artifact.stage == "preopen"
+    assert result.briefing_artifact.cta.state == "create_available"
+    assert result.briefing_artifact.cta.run_uuid == run.run_uuid
+    assert result.briefing_artifact.cta.requires_confirmation is True
+    assert {item.key: item.status for item in result.briefing_artifact.readiness}[
+        "news"
+    ] == "ready"
+    sections = {s.section_id: s for s in result.briefing_artifact.sections}
+    assert sections["new_buy_candidates"].item_count == 1
+    assert sections["holdings_actions"].item_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_briefing_artifact_degraded_when_market_news_briefing_is_null():
+    from app.services import preopen_dashboard_service, research_run_service
+
+    run = _make_run()
+    with (
+        _patched_dashboard_dependencies(
+            preopen_dashboard_service, research_run_service, run=run
+        ),
+        patch.object(
+            preopen_dashboard_service,
+            "_build_market_news_briefing",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+            db=AsyncMock(),
+            user_id=7,
+            market_scope="kr",
+        )
+
+    assert result.market_news_briefing is None
+    assert result.briefing_artifact is not None
+    assert result.briefing_artifact.status == "degraded"
+    assert "market_news_briefing_unavailable" in result.briefing_artifact.risk_notes
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_briefing_artifact_cta_links_existing_session():
+    from app.schemas.preopen import LinkedSessionRef
+    from app.services import preopen_dashboard_service, research_run_service
+
+    run = _make_run()
+    session_uuid = uuid4()
+    linked = [
+        LinkedSessionRef(
+            session_uuid=session_uuid,
+            status="open",
+            created_at=datetime.now(UTC),
+        )
+    ]
+    with (
+        _patched_dashboard_dependencies(
+            preopen_dashboard_service, research_run_service, run=run
+        ),
+        patch.object(
+            preopen_dashboard_service,
+            "_linked_sessions",
+            new=AsyncMock(return_value=linked),
+        ),
+    ):
+        result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+            db=AsyncMock(),
+            user_id=7,
+            market_scope="kr",
+        )
+
+    assert result.briefing_artifact is not None
+    assert result.briefing_artifact.cta.state == "linked_session_exists"
+    assert result.briefing_artifact.cta.linked_session_uuid == session_uuid
+    assert result.briefing_artifact.cta.requires_confirmation is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add a read-only Preopen Briefing Artifact DTO on the existing preopen latest response.
- Build artifact readiness, sections, risk notes, QA metadata, and Decision Session CTA state from already-loaded dashboard data without broker/order/watch side effects.
- Render the artifact in the Preopen page and update frontend types, fixtures, and coverage while preserving ROB-75 market-news sections.

## Test Plan
- uv run pytest tests/test_news_readiness_contract.py tests/test_router_preopen_news_brief.py tests/services/test_kr_preopen_news_brief_service.py tests/test_preopen_dashboard_service.py tests/test_router_preopen.py -q
- uv run ruff check app/schemas/preopen.py app/services/preopen_dashboard_service.py tests/test_preopen_dashboard_service.py tests/test_router_preopen.py
- uv run ruff format --check app/schemas/preopen.py app/services/preopen_dashboard_service.py tests/test_preopen_dashboard_service.py tests/test_router_preopen.py
- npm test -- PreopenPage preopenApi
- npm run typecheck
- npm run build

## Safety
- Existing preopen router remains read-only.
- No broker, order, watch, order-intent, scheduler, production deploy, or DB mutation path was added or executed.
- The artifact is additive on the current /trading/api/preopen/latest response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Preopen briefing" section displaying artifact status, readiness items, market news summaries, and risk notes
  * Includes visual status indicators (ready, degraded, unavailable) and detailed briefing sections
  * Updated decision session controls based on artifact state and linked session information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->