### PR TITLE
feat: add crypto paper workflow approval metadata

### DIFF
--- a/app/schemas/operator_decision_session.py
+++ b/app/schemas/operator_decision_session.py
@@ -8,7 +8,7 @@ from decimal import Decimal
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.schemas.trading_decisions import (
     InstrumentTypeLiteral,
@@ -21,6 +21,43 @@ OperatorMarketScopeLiteral = Literal["kr", "us", "crypto"]
 
 _SYMBOL_RE = re.compile(r"^[A-Za-z0-9._/-]{1,32}$")
 _ANALYST_RE = re.compile(r"^[a-z_]{1,32}$")
+_CRYPTO_SIGNAL_RE = re.compile(r"^KRW-[A-Z0-9]{2,16}$")
+_CRYPTO_EXECUTION_RE = re.compile(r"^[A-Z0-9]{2,16}/USD$")
+_CRYPTO_ALLOWED_SIGNAL_TO_EXECUTION = {
+    "KRW-BTC": "BTC/USD",
+    "KRW-ETH": "ETH/USD",
+    "KRW-SOL": "SOL/USD",
+}
+_CRYPTO_WORKFLOW_REQUIRED_FIELDS = {
+    "signal_symbol",
+    "signal_venue",
+    "execution_symbol",
+    "execution_venue",
+    "execution_mode",
+    "execution_asset_class",
+    "workflow_stage",
+    "purpose",
+    "preview_payload",
+    "approval_copy",
+}
+_CRYPTO_PREVIEW_REQUIRED_FIELDS = {
+    "symbol",
+    "side",
+    "type",
+    "notional",
+    "limit_price",
+    "time_in_force",
+    "asset_class",
+}
+_CRYPTO_PREVIEW_FORBIDDEN_FIELDS = {
+    "confirm",
+    "dry_run",
+    "order_id",
+    "client_order_id",
+    "submitted",
+    "submit",
+    "action",
+}
 
 
 class OperatorCandidate(BaseModel):
@@ -39,6 +76,16 @@ class OperatorCandidate(BaseModel):
     trigger_price: Decimal | None = Field(default=None, ge=0)
     threshold_pct: Decimal | None = Field(default=None, ge=0, le=100)
     currency: str | None = Field(default=None, max_length=8)
+    signal_symbol: str | None = None
+    signal_venue: Literal["upbit"] | None = None
+    execution_symbol: str | None = None
+    execution_venue: Literal["alpaca_paper"] | None = None
+    execution_mode: Literal["paper"] | None = None
+    execution_asset_class: Literal["crypto"] | None = None
+    workflow_stage: Literal["crypto_weekend", "crypto_always_open"] | None = None
+    purpose: Literal["paper_plumbing_smoke", "alpha_candidate_review"] | None = None
+    preview_payload: dict[str, object] | None = None
+    approval_copy: list[str] | None = None
 
     @field_validator("symbol")
     @classmethod
@@ -46,6 +93,125 @@ class OperatorCandidate(BaseModel):
         if not _SYMBOL_RE.fullmatch(value):
             raise ValueError("symbol contains unsupported characters")
         return value
+
+    @model_validator(mode="after")
+    def _validate_crypto_paper_workflow(self) -> OperatorCandidate:
+        flat_workflow = {
+            "signal_symbol": self.signal_symbol,
+            "signal_venue": self.signal_venue,
+            "execution_symbol": self.execution_symbol,
+            "execution_venue": self.execution_venue,
+            "execution_mode": self.execution_mode,
+            "execution_asset_class": self.execution_asset_class,
+            "workflow_stage": self.workflow_stage,
+            "purpose": self.purpose,
+            "preview_payload": self.preview_payload,
+            "approval_copy": self.approval_copy,
+        }
+        workflow = {
+            key: value for key, value in flat_workflow.items() if value is not None
+        }
+        if not workflow:
+            return self
+        if self.instrument_type != "crypto":
+            raise ValueError(
+                "crypto_paper_workflow is only allowed for crypto candidates"
+            )
+        missing = _CRYPTO_WORKFLOW_REQUIRED_FIELDS - set(workflow)
+        extra = set(workflow) - _CRYPTO_WORKFLOW_REQUIRED_FIELDS
+        if missing or extra:
+            raise ValueError(
+                "crypto_paper_workflow must contain the complete expected fields"
+            )
+        self._validate_crypto_workflow_scalars(workflow)
+        self._validate_crypto_preview_payload(
+            workflow.get("preview_payload"),
+            execution_symbol=workflow.get("execution_symbol"),
+        )
+        approval_copy = workflow.get("approval_copy")
+        if not isinstance(approval_copy, list) or not approval_copy:
+            raise ValueError("approval_copy must be a non-empty list")
+        if not all(isinstance(line, str) and line.strip() for line in approval_copy):
+            raise ValueError("approval_copy must contain non-empty strings")
+        return self
+
+    @staticmethod
+    def _validate_crypto_workflow_scalars(workflow: dict[str, object]) -> None:
+        if workflow.get("signal_venue") != "upbit":
+            raise ValueError("crypto signal_venue must be upbit")
+        if workflow.get("execution_venue") != "alpaca_paper":
+            raise ValueError("crypto execution_venue must be alpaca_paper")
+        if workflow.get("execution_mode") != "paper":
+            raise ValueError("crypto execution_mode must be paper")
+        if workflow.get("execution_asset_class") != "crypto":
+            raise ValueError("crypto execution_asset_class must be crypto")
+        if workflow.get("workflow_stage") not in {
+            "crypto_weekend",
+            "crypto_always_open",
+        }:
+            raise ValueError("crypto workflow_stage is unsupported")
+        if workflow.get("purpose") not in {
+            "paper_plumbing_smoke",
+            "alpha_candidate_review",
+        }:
+            raise ValueError("crypto purpose is unsupported")
+        signal_symbol = workflow.get("signal_symbol")
+        execution_symbol = workflow.get("execution_symbol")
+        if not isinstance(signal_symbol, str) or not _CRYPTO_SIGNAL_RE.fullmatch(
+            signal_symbol
+        ):
+            raise ValueError("crypto signal_symbol must be an Upbit KRW symbol")
+        if not isinstance(execution_symbol, str) or not _CRYPTO_EXECUTION_RE.fullmatch(
+            execution_symbol
+        ):
+            raise ValueError("crypto execution_symbol must be an Alpaca USD pair")
+        expected_execution_symbol = _CRYPTO_ALLOWED_SIGNAL_TO_EXECUTION.get(
+            signal_symbol
+        )
+        if expected_execution_symbol is None:
+            raise ValueError("crypto signal_symbol is unsupported for Alpaca paper")
+        if execution_symbol != expected_execution_symbol:
+            raise ValueError(
+                "crypto signal_symbol and execution_symbol mapping mismatch"
+            )
+
+    @staticmethod
+    def _validate_crypto_preview_payload(
+        preview_payload: object, *, execution_symbol: object
+    ) -> None:
+        if not isinstance(preview_payload, dict):
+            raise ValueError("preview_payload must be an object")
+        keys = set(preview_payload)
+        if _CRYPTO_PREVIEW_FORBIDDEN_FIELDS & keys:
+            raise ValueError("preview_payload must not contain submit/order fields")
+        missing = _CRYPTO_PREVIEW_REQUIRED_FIELDS - keys
+        extra = keys - _CRYPTO_PREVIEW_REQUIRED_FIELDS
+        if missing or extra:
+            raise ValueError("preview_payload must contain only preview fields")
+        if preview_payload.get("side") != "buy":
+            raise ValueError("crypto preview side must be buy")
+        if preview_payload.get("type") != "limit":
+            raise ValueError("crypto preview type must be limit")
+        if preview_payload.get("asset_class") != "crypto":
+            raise ValueError("crypto preview asset_class must be crypto")
+        if preview_payload.get("time_in_force") not in {"gtc", "ioc"}:
+            raise ValueError("crypto preview time_in_force is unsupported")
+        symbol = preview_payload.get("symbol")
+        if not isinstance(symbol, str) or not _CRYPTO_EXECUTION_RE.fullmatch(symbol):
+            raise ValueError("crypto preview symbol must be an Alpaca USD pair")
+        if not isinstance(execution_symbol, str) or symbol != execution_symbol:
+            raise ValueError("preview_payload symbol must match execution_symbol")
+        try:
+            notional = Decimal(str(preview_payload.get("notional")))
+            limit_price = Decimal(str(preview_payload.get("limit_price")))
+        except Exception as exc:
+            raise ValueError(
+                "crypto preview notional and limit_price must be numeric"
+            ) from exc
+        if notional <= 0 or notional > Decimal("50"):
+            raise ValueError("crypto preview notional must be > 0 and <= 50")
+        if limit_price <= 0:
+            raise ValueError("crypto preview limit_price must be > 0")
 
 
 class OperatorDecisionRequest(BaseModel):

--- a/app/schemas/operator_decision_session.py
+++ b/app/schemas/operator_decision_session.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import Literal
 from uuid import UUID
 
@@ -204,10 +204,12 @@ class OperatorCandidate(BaseModel):
         try:
             notional = Decimal(str(preview_payload.get("notional")))
             limit_price = Decimal(str(preview_payload.get("limit_price")))
-        except Exception as exc:
+        except (InvalidOperation, TypeError, ValueError) as exc:
             raise ValueError(
                 "crypto preview notional and limit_price must be numeric"
             ) from exc
+        if not notional.is_finite() or not limit_price.is_finite():
+            raise ValueError("crypto preview notional and limit_price must be finite")
         if notional <= 0 or notional > Decimal("50"):
             raise ValueError("crypto preview notional must be > 0 and <= 50")
         if limit_price <= 0:

--- a/app/services/crypto_execution_mapping.py
+++ b/app/services/crypto_execution_mapping.py
@@ -1,0 +1,176 @@
+"""Pure crypto signal-to-paper-execution mapping helpers.
+
+This module is intentionally side-effect free: no broker services, settings, DB,
+or MCP order tooling imports belong here.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+SignalVenue = Literal["upbit"]
+ExecutionVenue = Literal["alpaca_paper"]
+CryptoStage = Literal["crypto_weekend", "crypto_always_open"]
+ExecutionMode = Literal["paper"]
+PurposeLabel = Literal["paper_plumbing_smoke", "alpha_candidate_review"]
+
+
+class CryptoExecutionMappingError(ValueError):
+    """Raised when a signal symbol is not supported for paper execution."""
+
+
+class CryptoSignalExecutionMapping(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    signal_symbol: str
+    signal_venue: SignalVenue = "upbit"
+    execution_symbol: str
+    execution_venue: ExecutionVenue = "alpaca_paper"
+    asset_class: Literal["crypto"] = "crypto"
+    execution_mode: ExecutionMode = "paper"
+
+
+class CryptoWeekendReadiness(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    market_scope: Literal["crypto"] = "crypto"
+    stage: CryptoStage = "crypto_weekend"
+    upbit_ohlcv: Literal["ready", "degraded", "unavailable"] = "ready"
+    crypto_news: Literal["ready", "degraded", "unavailable"] = "degraded"
+    alpaca_paper: Literal["ready", "unavailable"] = "unavailable"
+    execution: Literal["approval_required"] = "approval_required"
+
+
+class AlpacaPaperCryptoPreviewPayload(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    symbol: str
+    side: Literal["buy"] = "buy"
+    type: Literal["limit"] = "limit"
+    notional: Decimal = Field(default=Decimal("10"), gt=0, le=Decimal("50"))
+    limit_price: Decimal = Field(default=Decimal("1.00"), gt=0)
+    time_in_force: Literal["gtc", "ioc"] = "gtc"
+    asset_class: Literal["crypto"] = "crypto"
+
+
+class CryptoPaperApprovalMetadata(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    mapping: CryptoSignalExecutionMapping
+    stage: CryptoStage = "crypto_weekend"
+    purpose: PurposeLabel
+    preview_payload: AlpacaPaperCryptoPreviewPayload
+    approval_copy: list[str]
+
+
+_ALLOWED_SIGNAL_TO_EXECUTION = {
+    "KRW-BTC": "BTC/USD",
+    "KRW-ETH": "ETH/USD",
+    "KRW-SOL": "SOL/USD",
+}
+
+
+def map_upbit_to_alpaca_paper(signal_symbol: str) -> CryptoSignalExecutionMapping:
+    """Map an explicit Upbit KRW signal symbol to an Alpaca Paper USD pair."""
+    normalized = (signal_symbol or "").strip().upper()
+    try:
+        execution_symbol = _ALLOWED_SIGNAL_TO_EXECUTION[normalized]
+    except KeyError as exc:
+        allowed = ", ".join(sorted(_ALLOWED_SIGNAL_TO_EXECUTION))
+        raise CryptoExecutionMappingError(
+            f"unsupported crypto signal symbol {signal_symbol!r}; allowed: {allowed}"
+        ) from exc
+    return CryptoSignalExecutionMapping(
+        signal_symbol=normalized,
+        execution_symbol=execution_symbol,
+    )
+
+
+def build_alpaca_paper_crypto_preview_payload(
+    mapping: CryptoSignalExecutionMapping,
+    *,
+    notional: Decimal = Decimal("10"),
+    limit_price: Decimal = Decimal("1.00"),
+    time_in_force: Literal["gtc", "ioc"] = "gtc",
+) -> AlpacaPaperCryptoPreviewPayload:
+    """Build a pure Alpaca Paper preview payload without account/broker calls."""
+    return AlpacaPaperCryptoPreviewPayload(
+        symbol=mapping.execution_symbol,
+        notional=notional,
+        limit_price=limit_price,
+        time_in_force=time_in_force,
+    )
+
+
+def build_crypto_paper_approval_metadata(
+    signal_symbol: str,
+    *,
+    purpose: PurposeLabel = "paper_plumbing_smoke",
+    stage: CryptoStage = "crypto_weekend",
+    notional: Decimal = Decimal("10"),
+    limit_price: Decimal = Decimal("1.00"),
+    time_in_force: Literal["gtc", "ioc"] = "gtc",
+) -> CryptoPaperApprovalMetadata:
+    """Build provenance, pure preview payload, and operator approval copy."""
+    mapping = map_upbit_to_alpaca_paper(signal_symbol)
+    preview_payload = build_alpaca_paper_crypto_preview_payload(
+        mapping,
+        notional=notional,
+        limit_price=limit_price,
+        time_in_force=time_in_force,
+    )
+    approval_copy = [
+        f"Signal source: Upbit {mapping.signal_symbol}",
+        f"Execution venue: Alpaca Paper {mapping.execution_symbol}",
+        f"Purpose: {purpose}",
+        "Order: buy limit "
+        f"${preview_payload.notional} @ ${preview_payload.limit_price} "
+        f"{preview_payload.time_in_force.upper()}",
+    ]
+    return CryptoPaperApprovalMetadata(
+        mapping=mapping,
+        stage=stage,
+        purpose=purpose,
+        preview_payload=preview_payload,
+        approval_copy=approval_copy,
+    )
+
+
+def build_operator_candidate_crypto_metadata(
+    signal_symbol: str, **kwargs: Any
+) -> dict[str, Any]:
+    """Return JSON-ready fields for OperatorCandidate crypto paper metadata."""
+    metadata = build_crypto_paper_approval_metadata(signal_symbol, **kwargs)
+    return {
+        "signal_symbol": metadata.mapping.signal_symbol,
+        "signal_venue": metadata.mapping.signal_venue,
+        "execution_symbol": metadata.mapping.execution_symbol,
+        "execution_venue": metadata.mapping.execution_venue,
+        "execution_mode": metadata.mapping.execution_mode,
+        "execution_asset_class": metadata.mapping.asset_class,
+        "workflow_stage": metadata.stage,
+        "purpose": metadata.purpose,
+        "preview_payload": metadata.preview_payload.model_dump(mode="json"),
+        "approval_copy": metadata.approval_copy,
+    }
+
+
+__all__ = [
+    "AlpacaPaperCryptoPreviewPayload",
+    "CryptoExecutionMappingError",
+    "CryptoPaperApprovalMetadata",
+    "CryptoSignalExecutionMapping",
+    "CryptoStage",
+    "CryptoWeekendReadiness",
+    "ExecutionMode",
+    "ExecutionVenue",
+    "PurposeLabel",
+    "SignalVenue",
+    "build_alpaca_paper_crypto_preview_payload",
+    "build_crypto_paper_approval_metadata",
+    "build_operator_candidate_crypto_metadata",
+    "map_upbit_to_alpaca_paper",
+]

--- a/app/services/operator_decision_session_service.py
+++ b/app/services/operator_decision_session_service.py
@@ -51,6 +51,20 @@ def _build_no_advisory_proposal(
     *,
     source_profile: str,
 ) -> dict[str, Any]:
+    original_payload: dict[str, Any] = {
+        "advisory_only": True,
+        "execution_allowed": False,
+        "operator_request": {
+            "source_profile": source_profile,
+            "applied_policies": ["no_advisory"],
+            "candidate": candidate.model_dump(mode="json"),
+        },
+    }
+    workflow = _candidate_crypto_paper_workflow(candidate)
+    if workflow is not None:
+        original_payload["crypto_paper_workflow"] = _serialize_crypto_paper_workflow(
+            workflow
+        )
     return {
         "symbol": candidate.symbol,
         "instrument_type": InstrumentType(candidate.instrument_type),
@@ -64,19 +78,79 @@ def _build_no_advisory_proposal(
         "original_threshold_pct": candidate.threshold_pct,
         "original_currency": candidate.currency,
         "original_rationale": candidate.rationale,
-        "original_payload": {
-            "advisory_only": True,
-            "execution_allowed": False,
-            "operator_request": {
-                "source_profile": source_profile,
-                "applied_policies": ["no_advisory"],
-                "candidate": candidate.model_dump(mode="json"),
-            },
-        },
+        "original_payload": original_payload,
     }
 
 
+def _candidate_crypto_paper_workflow(
+    candidate: OperatorCandidate,
+) -> dict[str, Any] | None:
+    workflow = {
+        "signal_symbol": candidate.signal_symbol,
+        "signal_venue": candidate.signal_venue,
+        "execution_symbol": candidate.execution_symbol,
+        "execution_venue": candidate.execution_venue,
+        "execution_mode": candidate.execution_mode,
+        "execution_asset_class": candidate.execution_asset_class,
+        "workflow_stage": candidate.workflow_stage,
+        "purpose": candidate.purpose,
+        "preview_payload": candidate.preview_payload,
+        "approval_copy": candidate.approval_copy,
+    }
+    if all(value is None for value in workflow.values()):
+        return None
+    return workflow
+
+
+def _serialize_crypto_paper_workflow(workflow: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "signal_symbol": workflow["signal_symbol"],
+        "signal_venue": workflow["signal_venue"],
+        "execution_symbol": workflow["execution_symbol"],
+        "execution_venue": workflow["execution_venue"],
+        "asset_class": workflow["execution_asset_class"],
+        "execution_mode": workflow["execution_mode"],
+        "stage": workflow["workflow_stage"],
+        "purpose": workflow["purpose"],
+        "preview_payload": workflow["preview_payload"],
+        "approval_copy": workflow["approval_copy"],
+    }
+
+
+def _build_no_advisory_market_brief(request: OperatorDecisionRequest) -> dict[str, Any]:
+    market_brief: dict[str, Any] = {
+        "advisory_only": True,
+        "execution_allowed": False,
+        "operator_request": {
+            "applied_policies": ["no_advisory"],
+            "include_tradingagents": False,
+        },
+    }
+    crypto_workflows = [
+        workflow
+        for candidate in request.candidates
+        if (workflow := _candidate_crypto_paper_workflow(candidate)) is not None
+    ]
+    if request.market_scope == "crypto" and crypto_workflows:
+        first_workflow = crypto_workflows[0]
+        market_brief["stage"] = first_workflow.get("workflow_stage")
+        market_brief["crypto_paper_workflow"] = {
+            "stage": first_workflow.get("workflow_stage"),
+            "workflow_count": len(crypto_workflows),
+            "signal_venue": first_workflow.get("signal_venue"),
+            "execution_venue": first_workflow.get("execution_venue"),
+            "execution_mode": first_workflow.get("execution_mode"),
+        }
+    return market_brief
+
+
 def _build_candidate_analysis(candidate: OperatorCandidate) -> CandidateAnalysis:
+    deterministic_payload: dict[str, Any] = {}
+    workflow = _candidate_crypto_paper_workflow(candidate)
+    if workflow is not None:
+        deterministic_payload["crypto_paper_workflow"] = (
+            _serialize_crypto_paper_workflow(workflow)
+        )
     return CandidateAnalysis(
         symbol=candidate.symbol,
         instrument_type=candidate.instrument_type,
@@ -91,6 +165,7 @@ def _build_candidate_analysis(candidate: OperatorCandidate) -> CandidateAnalysis
         trigger_price=candidate.trigger_price,
         threshold_pct=candidate.threshold_pct,
         currency=candidate.currency,
+        deterministic_payload=deterministic_payload,
     )
 
 
@@ -124,14 +199,7 @@ async def _run_without_advisory(
         source_profile=request.source_profile,
         strategy_name=request.strategy_name,
         market_scope=request.market_scope,
-        market_brief={
-            "advisory_only": True,
-            "execution_allowed": False,
-            "operator_request": {
-                "applied_policies": ["no_advisory"],
-                "include_tradingagents": False,
-            },
-        },
+        market_brief=_build_no_advisory_market_brief(request),
         generated_at=generated_at,
         notes=request.notes,
     )

--- a/app/services/trading_decision_synthesis.py
+++ b/app/services/trading_decision_synthesis.py
@@ -111,7 +111,7 @@ def _build_original_payload(
 ) -> dict[str, Any]:
     advisory_dump = advisory.model_dump(mode="json")
     candidate_dump = candidate.model_dump(mode="json")
-    return {
+    payload = {
         "advisory_only": True,
         "execution_allowed": False,
         "synthesis": {
@@ -126,6 +126,10 @@ def _build_original_payload(
             "reflected_action": advisory.advisory_action,
         },
     }
+    crypto_workflow = candidate.deterministic_payload.get("crypto_paper_workflow")
+    if crypto_workflow is not None:
+        payload["crypto_paper_workflow"] = crypto_workflow
+    return payload
 
 
 def build_session_synthesis_meta(

--- a/frontend/trading-decision/src/__tests__/ProposalRow.test.tsx
+++ b/frontend/trading-decision/src/__tests__/ProposalRow.test.tsx
@@ -60,6 +60,56 @@ describe("ProposalRow", () => {
     expect(screen.getByText(/does not send a live trade/i)).toBeInTheDocument();
   });
 
+  it("renders crypto paper workflow provenance from approval copy", () => {
+    render(
+      <ProposalRow
+        proposal={makeProposal({
+          symbol: "KRW-BTC",
+          instrument_type: "crypto",
+          side: "buy",
+          proposal_kind: "pullback_watch",
+          original_payload: {
+            crypto_paper_workflow: {
+              signal_symbol: "KRW-BTC",
+              signal_venue: "upbit",
+              execution_symbol: "BTC/USD",
+              execution_venue: "alpaca_paper",
+              asset_class: "crypto",
+              execution_mode: "paper",
+              stage: "crypto_weekend",
+              purpose: "paper_plumbing_smoke",
+              preview_payload: {
+                symbol: "BTC/USD",
+                side: "buy",
+                type: "limit",
+                notional: "10",
+                limit_price: "1.00",
+                time_in_force: "gtc",
+                asset_class: "crypto",
+              },
+              approval_copy: [
+                "Signal source: Upbit KRW-BTC",
+                "Execution venue: Alpaca Paper BTC/USD",
+                "Purpose: paper_plumbing_smoke",
+                "Order: buy limit $10 @ $1.00 GTC",
+              ],
+            },
+          },
+        })}
+        onRecordOutcome={vi.fn()}
+        onRespond={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Crypto paper workflow")).toBeInTheDocument();
+    expect(screen.getByText("Signal source: Upbit KRW-BTC")).toBeInTheDocument();
+    expect(
+      screen.getByText("Execution venue: Alpaca Paper BTC/USD"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Purpose: paper_plumbing_smoke")).toBeInTheDocument();
+    expect(screen.getByText("Order: buy limit $10 @ $1.00 GTC")).toBeInTheDocument();
+  });
+
   it("pending proposal shows original block only", () => {
     render(
       <ProposalRow

--- a/frontend/trading-decision/src/api/types.ts
+++ b/frontend/trading-decision/src/api/types.ts
@@ -126,6 +126,35 @@ export interface SessionAnalyticsResponse {
   cells: SessionAnalyticsCell[];
 }
 
+export interface CryptoPaperPreviewPayload {
+  symbol: string;
+  side: "buy";
+  type: "limit";
+  notional: DecimalString;
+  limit_price: DecimalString;
+  time_in_force: "gtc" | "ioc";
+  asset_class: "crypto";
+}
+
+export interface CryptoPaperWorkflowMetadata {
+  signal_symbol: string;
+  signal_venue: "upbit";
+  execution_symbol: string;
+  execution_venue: "alpaca_paper";
+  execution_mode: "paper";
+  execution_asset_class?: "crypto";
+  asset_class?: "crypto";
+  workflow_stage?: "crypto_weekend" | "crypto_always_open";
+  stage?: "crypto_weekend" | "crypto_always_open";
+  purpose: "paper_plumbing_smoke" | "alpha_candidate_review" | string;
+  preview_payload: CryptoPaperPreviewPayload;
+  approval_copy: string[];
+}
+
+export interface ProposalOriginalPayload extends Record<string, unknown> {
+  crypto_paper_workflow?: CryptoPaperWorkflowMetadata;
+}
+
 export interface ProposalDetail {
   proposal_uuid: Uuid;
   symbol: string;
@@ -144,7 +173,7 @@ export interface ProposalDetail {
   original_threshold_pct: DecimalString | null;
   original_currency: string | null;
   original_rationale: string | null;
-  original_payload: Record<string, unknown>;
+  original_payload: ProposalOriginalPayload;
   user_quantity: DecimalString | null;
   user_quantity_pct: DecimalString | null;
   user_amount: DecimalString | null;

--- a/frontend/trading-decision/src/components/ProposalRow.module.css
+++ b/frontend/trading-decision/src/components/ProposalRow.module.css
@@ -112,3 +112,25 @@
   margin: 0;
   padding: 10px 12px;
 }
+
+.cryptoPaperWorkflow {
+  margin-top: 1rem;
+  border: 1px solid rgba(59, 130, 246, 0.24);
+  border-radius: 0.75rem;
+  background: rgba(59, 130, 246, 0.08);
+  padding: 0.9rem 1rem;
+}
+
+.cryptoPaperWorkflow h3 {
+  margin: 0 0 0.5rem;
+  font-size: 0.95rem;
+}
+
+.cryptoPaperWorkflow ul {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.cryptoPaperWorkflow li + li {
+  margin-top: 0.25rem;
+}

--- a/frontend/trading-decision/src/components/ProposalRow.tsx
+++ b/frontend/trading-decision/src/components/ProposalRow.tsx
@@ -55,6 +55,7 @@ export default function ProposalRow({
   const shouldShowSymbol = displayName !== proposal.symbol;
 
   const recon = parseReconciliationPayload(proposal.original_payload);
+  const cryptoPaperWorkflow = proposal.original_payload.crypto_paper_workflow;
   const nonActionable =
     proposal.proposal_kind === "other" &&
     recon !== null &&
@@ -128,6 +129,16 @@ export default function ProposalRow({
           </section>
         ) : null}
       </div>
+      {cryptoPaperWorkflow?.approval_copy?.length ? (
+        <section className={styles.cryptoPaperWorkflow}>
+          <h3>Crypto paper workflow</h3>
+          <ul>
+            {cryptoPaperWorkflow.approval_copy.map((line) => (
+              <li key={line}>{line}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
       {recon ? (
         <>
           <WarningChips tokens={recon.warnings} />

--- a/tests/services/test_operator_decision_session_safety.py
+++ b/tests/services/test_operator_decision_session_safety.py
@@ -84,6 +84,14 @@ def test_schema_module_does_not_import_forbidden_prefixes_in_subprocess():
 
 
 @pytest.mark.unit
+def test_crypto_mapping_module_does_not_import_forbidden_prefixes_in_subprocess():
+    loaded = _loaded_modules_after_import("app.services.crypto_execution_mapping")
+    violations = _forbidden_violations(loaded)
+    if violations:
+        pytest.fail(f"forbidden modules transitively imported: {violations}")
+
+
+@pytest.mark.unit
 def test_url_helper_module_has_no_settings_or_db_imports_in_subprocess():
     loaded = _loaded_modules_after_import("app.services.trading_decision_session_url")
     forbidden = [

--- a/tests/services/test_operator_decision_session_service.py
+++ b/tests/services/test_operator_decision_session_service.py
@@ -140,6 +140,218 @@ async def test_no_advisory_path_uses_now_callable(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_no_advisory_crypto_path_preserves_paper_workflow_metadata(monkeypatch):
+    import app.services.operator_decision_session_service as svc
+    from app.schemas.operator_decision_session import (
+        OperatorCandidate,
+        OperatorDecisionRequest,
+    )
+    from app.services.crypto_execution_mapping import (
+        build_operator_candidate_crypto_metadata,
+    )
+
+    fake_session = SimpleNamespace(
+        id=77,
+        session_uuid="cccccccc-cccc-cccc-cccc-cccccccccccc",
+        status="open",
+        market_brief={},
+    )
+    create_session_mock = AsyncMock(return_value=fake_session)
+    add_proposals_mock = AsyncMock(return_value=[SimpleNamespace(id=100)])
+    monkeypatch.setattr(
+        svc.trading_decision_service,
+        "create_decision_session",
+        create_session_mock,
+    )
+    monkeypatch.setattr(
+        svc.trading_decision_service,
+        "add_decision_proposals",
+        add_proposals_mock,
+    )
+    monkeypatch.setattr(
+        svc,
+        "run_tradingagents_research",
+        AsyncMock(side_effect=AssertionError("must not run")),
+    )
+
+    req = OperatorDecisionRequest(
+        market_scope="crypto",
+        candidates=[
+            OperatorCandidate(
+                symbol="KRW-BTC",
+                instrument_type="crypto",
+                side="buy",
+                confidence=55,
+                proposal_kind="pullback_watch",
+                rationale="Weekend plumbing smoke from Upbit signal.",
+                **build_operator_candidate_crypto_metadata("KRW-BTC"),
+            )
+        ],
+        include_tradingagents=False,
+        notes="crypto weekend smoke",
+    )
+
+    result = await svc.create_operator_decision_session(
+        SimpleNamespace(), user_id=9, request=req
+    )
+
+    assert result.advisory_used is False
+    create_kwargs = create_session_mock.await_args.kwargs
+    assert create_kwargs["market_scope"] == "crypto"
+    assert create_kwargs["market_brief"]["execution_allowed"] is False
+    assert create_kwargs["market_brief"]["stage"] == "crypto_weekend"
+
+    proposal = add_proposals_mock.await_args.kwargs["proposals"][0]
+    payload = proposal["original_payload"]
+    workflow = payload["crypto_paper_workflow"]
+    assert workflow == {
+        "signal_symbol": "KRW-BTC",
+        "signal_venue": "upbit",
+        "execution_symbol": "BTC/USD",
+        "execution_venue": "alpaca_paper",
+        "asset_class": "crypto",
+        "execution_mode": "paper",
+        "stage": "crypto_weekend",
+        "purpose": "paper_plumbing_smoke",
+        "preview_payload": {
+            "symbol": "BTC/USD",
+            "side": "buy",
+            "type": "limit",
+            "notional": "10",
+            "limit_price": "1.00",
+            "time_in_force": "gtc",
+            "asset_class": "crypto",
+        },
+        "approval_copy": [
+            "Signal source: Upbit KRW-BTC",
+            "Execution venue: Alpaca Paper BTC/USD",
+            "Purpose: paper_plumbing_smoke",
+            "Order: buy limit $10 @ $1.00 GTC",
+        ],
+    }
+    assert payload["operator_request"]["candidate"]["signal_symbol"] == "KRW-BTC"
+    assert payload["operator_request"]["candidate"]["execution_symbol"] == "BTC/USD"
+
+
+@pytest.mark.asyncio
+async def test_advisory_crypto_path_preserves_paper_workflow_metadata(monkeypatch):
+    import app.services.operator_decision_session_service as svc
+    from app.schemas.operator_decision_session import (
+        OperatorCandidate,
+        OperatorDecisionRequest,
+    )
+    from app.schemas.tradingagents_research import (
+        TradingAgentsConfigSnapshot,
+        TradingAgentsLLM,
+        TradingAgentsRunnerResult,
+        TradingAgentsWarnings,
+    )
+    from app.services.crypto_execution_mapping import (
+        build_operator_candidate_crypto_metadata,
+    )
+
+    fake_runner_result = TradingAgentsRunnerResult(
+        status="ok",
+        symbol="KRW-BTC",
+        as_of_date=date(2026, 5, 2),
+        decision="Neutral",
+        advisory_only=True,
+        execution_allowed=False,
+        analysts=["market"],
+        llm=TradingAgentsLLM(
+            provider="openai-compatible",
+            model="gpt-5.5",
+            base_url="http://127.0.0.1:8796/v1",
+        ),
+        config=TradingAgentsConfigSnapshot(
+            max_debate_rounds=1,
+            max_risk_discuss_rounds=1,
+            max_recur_limit=30,
+            output_language="English",
+            checkpoint_enabled=False,
+        ),
+        warnings=TradingAgentsWarnings(),
+        final_trade_decision="advisory only",
+        raw_state_keys=["market_report"],
+    )
+    fake_session = SimpleNamespace(
+        id=101,
+        session_uuid="dddddddd-dddd-dddd-dddd-dddddddddddd",
+        status="open",
+    )
+    runner_mock = AsyncMock(return_value=fake_runner_result)
+    synth_persist_mock = AsyncMock(
+        return_value=(fake_session, [SimpleNamespace(id=11)])
+    )
+    monkeypatch.setattr(svc, "run_tradingagents_research", runner_mock)
+    monkeypatch.setattr(svc, "create_synthesized_decision_session", synth_persist_mock)
+    monkeypatch.setattr(
+        svc.trading_decision_service,
+        "create_decision_session",
+        AsyncMock(side_effect=AssertionError("must not run")),
+    )
+
+    req = OperatorDecisionRequest(
+        market_scope="crypto",
+        candidates=[
+            OperatorCandidate(
+                symbol="KRW-BTC",
+                instrument_type="crypto",
+                side="buy",
+                confidence=55,
+                proposal_kind="pullback_watch",
+                rationale="Weekend plumbing smoke from Upbit signal.",
+                **build_operator_candidate_crypto_metadata("KRW-BTC"),
+            )
+        ],
+        include_tradingagents=True,
+        analysts=["market"],
+        notes="crypto advisory smoke",
+    )
+
+    result = await svc.create_operator_decision_session(
+        SimpleNamespace(), user_id=9, request=req
+    )
+
+    assert result.advisory_used is True
+    synth_persist_mock.assert_awaited_once()
+    persist_kwargs = synth_persist_mock.await_args.kwargs
+    assert persist_kwargs["market_scope"] == "crypto"
+    synthesized = persist_kwargs["proposals"]
+    assert len(synthesized) == 1
+    payload = synthesized[0].original_payload
+    workflow = payload["crypto_paper_workflow"]
+    assert workflow == {
+        "signal_symbol": "KRW-BTC",
+        "signal_venue": "upbit",
+        "execution_symbol": "BTC/USD",
+        "execution_venue": "alpaca_paper",
+        "asset_class": "crypto",
+        "execution_mode": "paper",
+        "stage": "crypto_weekend",
+        "purpose": "paper_plumbing_smoke",
+        "preview_payload": {
+            "symbol": "BTC/USD",
+            "side": "buy",
+            "type": "limit",
+            "notional": "10",
+            "limit_price": "1.00",
+            "time_in_force": "gtc",
+            "asset_class": "crypto",
+        },
+        "approval_copy": [
+            "Signal source: Upbit KRW-BTC",
+            "Execution venue: Alpaca Paper BTC/USD",
+            "Purpose: paper_plumbing_smoke",
+            "Order: buy limit $10 @ $1.00 GTC",
+        ],
+    }
+    assert payload["synthesis"]["auto_trader"]["deterministic_payload"] == {
+        "crypto_paper_workflow": workflow
+    }
+
+
+@pytest.mark.asyncio
 async def test_advisory_path_uses_synthesis_persistence(monkeypatch):
     import app.services.operator_decision_session_service as svc
     from app.schemas.operator_decision_session import (

--- a/tests/services/test_operator_decision_session_service.py
+++ b/tests/services/test_operator_decision_session_service.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 from datetime import UTC, date, datetime
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _mock_async_db_session() -> AsyncSession:
+    return cast(AsyncSession, AsyncMock(spec=AsyncSession))
 
 
 @pytest.mark.asyncio
@@ -70,7 +76,7 @@ async def test_no_advisory_path_persists_via_raw_helpers(monkeypatch):
     )
 
     result = await svc.create_operator_decision_session(
-        SimpleNamespace(), user_id=7, request=req
+        _mock_async_db_session(), user_id=7, request=req
     )
 
     assert result.advisory_used is False
@@ -128,7 +134,7 @@ async def test_no_advisory_path_uses_now_callable(monkeypatch):
     )
     fixed = datetime(2026, 4, 28, 12, 0, tzinfo=UTC)
     await svc.create_operator_decision_session(
-        SimpleNamespace(),
+        _mock_async_db_session(),
         user_id=1,
         request=req,
         now=lambda: fixed,
@@ -192,7 +198,7 @@ async def test_no_advisory_crypto_path_preserves_paper_workflow_metadata(monkeyp
     )
 
     result = await svc.create_operator_decision_session(
-        SimpleNamespace(), user_id=9, request=req
+        _mock_async_db_session(), user_id=9, request=req
     )
 
     assert result.advisory_used is False
@@ -310,7 +316,7 @@ async def test_advisory_crypto_path_preserves_paper_workflow_metadata(monkeypatc
     )
 
     result = await svc.create_operator_decision_session(
-        SimpleNamespace(), user_id=9, request=req
+        _mock_async_db_session(), user_id=9, request=req
     )
 
     assert result.advisory_used is True
@@ -424,7 +430,7 @@ async def test_advisory_path_uses_synthesis_persistence(monkeypatch):
     )
 
     result = await svc.create_operator_decision_session(
-        SimpleNamespace(), user_id=7, request=req
+        _mock_async_db_session(), user_id=7, request=req
     )
 
     assert result.advisory_used is True
@@ -489,7 +495,7 @@ async def test_advisory_missing_config_raises_without_persistence(monkeypatch):
 
     with pytest.raises(TradingAgentsNotConfigured):
         await svc.create_operator_decision_session(
-            SimpleNamespace(), user_id=1, request=req
+            _mock_async_db_session(), user_id=1, request=req
         )
 
 
@@ -529,5 +535,5 @@ async def test_advisory_runner_error_propagates_without_persistence(monkeypatch)
 
     with pytest.raises(TradingAgentsRunnerError):
         await svc.create_operator_decision_session(
-            SimpleNamespace(), user_id=1, request=req
+            _mock_async_db_session(), user_id=1, request=req
         )

--- a/tests/test_crypto_execution_mapping.py
+++ b/tests/test_crypto_execution_mapping.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import inspect
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+
+@pytest.mark.unit
+def test_maps_allowed_upbit_symbols_to_alpaca_paper_execution_metadata():
+    from app.services.crypto_execution_mapping import map_upbit_to_alpaca_paper
+
+    expected = {
+        "KRW-BTC": "BTC/USD",
+        "KRW-ETH": "ETH/USD",
+        "KRW-SOL": "SOL/USD",
+    }
+
+    for signal_symbol, execution_symbol in expected.items():
+        mapping = map_upbit_to_alpaca_paper(signal_symbol)
+
+        assert mapping.signal_symbol == signal_symbol
+        assert mapping.signal_venue == "upbit"
+        assert mapping.execution_symbol == execution_symbol
+        assert mapping.execution_venue == "alpaca_paper"
+        assert mapping.asset_class == "crypto"
+        assert mapping.execution_mode == "paper"
+
+
+@pytest.mark.unit
+def test_mapping_normalizes_whitespace_and_case():
+    from app.services.crypto_execution_mapping import map_upbit_to_alpaca_paper
+
+    mapping = map_upbit_to_alpaca_paper(" krw-btc ")
+
+    assert mapping.signal_symbol == "KRW-BTC"
+    assert mapping.execution_symbol == "BTC/USD"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("signal_symbol", ["BTC/USD", "KRW-XRP", "USDT-BTC", "BTC", ""])
+def test_unsupported_symbols_fail_closed(signal_symbol: str):
+    from app.services.crypto_execution_mapping import (
+        CryptoExecutionMappingError,
+        map_upbit_to_alpaca_paper,
+    )
+
+    with pytest.raises(CryptoExecutionMappingError):
+        map_upbit_to_alpaca_paper(signal_symbol)
+
+
+@pytest.mark.unit
+def test_default_preview_payload_is_plumbing_smoke():
+    from app.services.crypto_execution_mapping import (
+        build_alpaca_paper_crypto_preview_payload,
+        map_upbit_to_alpaca_paper,
+    )
+
+    payload = build_alpaca_paper_crypto_preview_payload(
+        map_upbit_to_alpaca_paper("KRW-BTC")
+    )
+
+    assert payload.model_dump(mode="json") == {
+        "symbol": "BTC/USD",
+        "side": "buy",
+        "type": "limit",
+        "notional": "10",
+        "limit_price": "1.00",
+        "time_in_force": "gtc",
+        "asset_class": "crypto",
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("notional", "limit_price"),
+    [
+        (Decimal("50.01"), Decimal("1.00")),
+        (Decimal("0"), Decimal("1.00")),
+        (Decimal("10"), Decimal("0")),
+    ],
+)
+def test_preview_payload_rejects_over_cap_and_non_positive_values(
+    notional: Decimal, limit_price: Decimal
+):
+    from app.services.crypto_execution_mapping import (
+        build_alpaca_paper_crypto_preview_payload,
+        map_upbit_to_alpaca_paper,
+    )
+
+    with pytest.raises(ValidationError):
+        build_alpaca_paper_crypto_preview_payload(
+            map_upbit_to_alpaca_paper("KRW-BTC"),
+            notional=notional,
+            limit_price=limit_price,
+        )
+
+
+@pytest.mark.unit
+def test_approval_metadata_copy_preserves_both_venues():
+    from app.services.crypto_execution_mapping import (
+        build_crypto_paper_approval_metadata,
+    )
+
+    metadata = build_crypto_paper_approval_metadata("KRW-BTC")
+
+    assert "Signal source: Upbit KRW-BTC" in metadata.approval_copy
+    assert "Execution venue: Alpaca Paper BTC/USD" in metadata.approval_copy
+    assert "Order: buy limit $10 @ $1.00 GTC" in metadata.approval_copy
+    assert metadata.stage == "crypto_weekend"
+
+
+@pytest.mark.unit
+def test_operator_candidate_crypto_metadata_helper_is_json_ready():
+    from app.services.crypto_execution_mapping import (
+        build_operator_candidate_crypto_metadata,
+    )
+
+    metadata = build_operator_candidate_crypto_metadata("KRW-ETH")
+
+    assert metadata == {
+        "signal_symbol": "KRW-ETH",
+        "signal_venue": "upbit",
+        "execution_symbol": "ETH/USD",
+        "execution_venue": "alpaca_paper",
+        "execution_mode": "paper",
+        "execution_asset_class": "crypto",
+        "workflow_stage": "crypto_weekend",
+        "purpose": "paper_plumbing_smoke",
+        "preview_payload": {
+            "symbol": "ETH/USD",
+            "side": "buy",
+            "type": "limit",
+            "notional": "10",
+            "limit_price": "1.00",
+            "time_in_force": "gtc",
+            "asset_class": "crypto",
+        },
+        "approval_copy": [
+            "Signal source: Upbit KRW-ETH",
+            "Execution venue: Alpaca Paper ETH/USD",
+            "Purpose: paper_plumbing_smoke",
+            "Order: buy limit $10 @ $1.00 GTC",
+        ],
+    }
+
+
+@pytest.mark.unit
+def test_service_has_no_broker_side_effect_imports():
+    import app.services.crypto_execution_mapping as module
+
+    source = inspect.getsource(module)
+
+    forbidden_tokens = [
+        "AlpacaPaperBrokerService",
+        "alpaca_paper_submit_order",
+        "alpaca_paper_cancel_order",
+        "submit_order",
+        "cancel_order",
+        "place_order",
+        "modify_order",
+        "watch_alert",
+    ]
+    for token in forbidden_tokens:
+        assert token not in source

--- a/tests/test_operator_decision_session_schemas.py
+++ b/tests/test_operator_decision_session_schemas.py
@@ -122,3 +122,179 @@ def test_operator_request_accepts_decimal_quantity():
         amount=Decimal("100000"),
     )
     OperatorDecisionRequest(market_scope="crypto", candidates=[cand])
+
+
+@pytest.mark.unit
+def test_crypto_candidate_accepts_complete_paper_workflow_metadata():
+    from app.schemas.operator_decision_session import OperatorCandidate
+    from app.services.crypto_execution_mapping import (
+        build_operator_candidate_crypto_metadata,
+    )
+
+    cand = OperatorCandidate(
+        symbol="KRW-BTC",
+        instrument_type="crypto",
+        confidence=45,
+        side="buy",
+        proposal_kind="pullback_watch",
+        **build_operator_candidate_crypto_metadata("KRW-BTC"),
+    )
+
+    assert cand.signal_symbol == "KRW-BTC"
+    assert cand.signal_venue == "upbit"
+    assert cand.execution_symbol == "BTC/USD"
+    assert cand.execution_venue == "alpaca_paper"
+    assert cand.execution_mode == "paper"
+    assert cand.execution_asset_class == "crypto"
+    assert cand.workflow_stage == "crypto_weekend"
+    assert cand.purpose == "paper_plumbing_smoke"
+    assert cand.preview_payload == {
+        "symbol": "BTC/USD",
+        "side": "buy",
+        "type": "limit",
+        "notional": "10",
+        "limit_price": "1.00",
+        "time_in_force": "gtc",
+        "asset_class": "crypto",
+    }
+    assert "Signal source: Upbit KRW-BTC" in cand.approval_copy
+
+
+@pytest.mark.unit
+def test_crypto_candidate_rejects_partial_paper_workflow_metadata():
+    from app.schemas.operator_decision_session import OperatorCandidate
+    from app.services.crypto_execution_mapping import (
+        build_operator_candidate_crypto_metadata,
+    )
+
+    metadata = build_operator_candidate_crypto_metadata("KRW-BTC")
+    metadata.pop("execution_venue")
+
+    with pytest.raises(ValueError):
+        OperatorCandidate(
+            symbol="KRW-BTC",
+            instrument_type="crypto",
+            confidence=45,
+            **metadata,
+        )
+
+
+@pytest.mark.unit
+def test_crypto_candidate_rejects_loose_nested_workflow_metadata():
+    from app.schemas.operator_decision_session import OperatorCandidate
+    from app.services.crypto_execution_mapping import (
+        build_operator_candidate_crypto_metadata,
+    )
+
+    with pytest.raises(ValueError):
+        OperatorCandidate(
+            symbol="KRW-BTC",
+            instrument_type="crypto",
+            confidence=45,
+            crypto_paper_workflow=build_operator_candidate_crypto_metadata("KRW-BTC"),
+        )
+
+
+@pytest.mark.unit
+def test_non_crypto_candidate_rejects_crypto_paper_workflow_metadata():
+    from app.schemas.operator_decision_session import OperatorCandidate
+    from app.services.crypto_execution_mapping import (
+        build_operator_candidate_crypto_metadata,
+    )
+
+    with pytest.raises(ValueError):
+        OperatorCandidate(
+            symbol="AAPL",
+            instrument_type="equity_us",
+            confidence=50,
+            **build_operator_candidate_crypto_metadata("KRW-BTC"),
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "bad_preview_payload",
+    [
+        {"symbol": "BTC/USD", "side": "sell"},
+        {"symbol": "BTC/USD", "confirm": True},
+        {"symbol": "BTC/USD", "order_id": "paper-order-1"},
+    ],
+)
+def test_crypto_candidate_rejects_submit_like_or_sell_preview_payload(
+    bad_preview_payload: dict[str, object],
+):
+    from app.schemas.operator_decision_session import OperatorCandidate
+    from app.services.crypto_execution_mapping import (
+        build_operator_candidate_crypto_metadata,
+    )
+
+    metadata = build_operator_candidate_crypto_metadata("KRW-BTC")
+    metadata["preview_payload"] = bad_preview_payload
+
+    with pytest.raises(ValueError):
+        OperatorCandidate(
+            symbol="KRW-BTC",
+            instrument_type="crypto",
+            confidence=45,
+            **metadata,
+        )
+
+
+@pytest.mark.unit
+def test_crypto_candidate_rejects_mismatched_signal_execution_mapping():
+    from app.schemas.operator_decision_session import OperatorCandidate
+    from app.services.crypto_execution_mapping import (
+        build_operator_candidate_crypto_metadata,
+    )
+
+    metadata = build_operator_candidate_crypto_metadata("KRW-BTC")
+    metadata["execution_symbol"] = "ETH/USD"
+    metadata["preview_payload"]["symbol"] = "ETH/USD"
+
+    with pytest.raises(ValueError):
+        OperatorCandidate(
+            symbol="KRW-BTC",
+            instrument_type="crypto",
+            confidence=45,
+            **metadata,
+        )
+
+
+@pytest.mark.unit
+def test_crypto_candidate_rejects_unsupported_signal_execution_mapping():
+    from app.schemas.operator_decision_session import OperatorCandidate
+    from app.services.crypto_execution_mapping import (
+        build_operator_candidate_crypto_metadata,
+    )
+
+    metadata = build_operator_candidate_crypto_metadata("KRW-BTC")
+    metadata["signal_symbol"] = "KRW-XRP"
+    metadata["execution_symbol"] = "XRP/USD"
+    metadata["preview_payload"]["symbol"] = "XRP/USD"
+
+    with pytest.raises(ValueError):
+        OperatorCandidate(
+            symbol="KRW-XRP",
+            instrument_type="crypto",
+            confidence=45,
+            **metadata,
+        )
+
+
+@pytest.mark.unit
+def test_crypto_candidate_rejects_preview_payload_symbol_mismatch():
+    from app.schemas.operator_decision_session import OperatorCandidate
+    from app.services.crypto_execution_mapping import (
+        build_operator_candidate_crypto_metadata,
+    )
+
+    metadata = build_operator_candidate_crypto_metadata("KRW-BTC")
+    metadata["preview_payload"]["symbol"] = "ETH/USD"
+
+    with pytest.raises(ValueError):
+        OperatorCandidate(
+            symbol="KRW-BTC",
+            instrument_type="crypto",
+            confidence=45,
+            **metadata,
+        )

--- a/tests/test_operator_decision_session_schemas.py
+++ b/tests/test_operator_decision_session_schemas.py
@@ -373,6 +373,14 @@ def test_crypto_candidate_rejects_invalid_workflow_scalar_or_copy_fields(
             {"notional": "not-a-number"},
             "crypto preview notional and limit_price must be numeric",
         ),
+        (
+            {"notional": Decimal("NaN")},
+            "crypto preview notional and limit_price must be finite",
+        ),
+        (
+            {"limit_price": Decimal("Infinity")},
+            "crypto preview notional and limit_price must be finite",
+        ),
         ({"notional": "51"}, "crypto preview notional must be > 0 and <= 50"),
         ({"limit_price": "0"}, "crypto preview limit_price must be > 0"),
     ],

--- a/tests/test_operator_decision_session_schemas.py
+++ b/tests/test_operator_decision_session_schemas.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from decimal import Decimal
 
 import pytest
@@ -105,6 +106,32 @@ def test_operator_request_validates_analyst_token_charset():
             candidates=cand,
             analysts=["BAD-TOKEN"],
         )
+
+
+@pytest.mark.unit
+def test_operator_request_accepts_valid_or_missing_analyst_tokens():
+    from app.schemas.operator_decision_session import (
+        OperatorCandidate,
+        OperatorDecisionRequest,
+    )
+
+    cand = [
+        OperatorCandidate(symbol="AAPL", instrument_type="equity_us", confidence=50)
+    ]
+
+    assert (
+        OperatorDecisionRequest(
+            market_scope="us",
+            candidates=cand,
+            analysts=None,
+        ).analysts
+        is None
+    )
+    assert OperatorDecisionRequest(
+        market_scope="us",
+        candidates=cand,
+        analysts=["market_news", "technical"],
+    ).analysts == ["market_news", "technical"]
 
 
 @pytest.mark.unit
@@ -297,4 +324,119 @@ def test_crypto_candidate_rejects_preview_payload_symbol_mismatch():
             instrument_type="crypto",
             confidence=45,
             **metadata,
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("metadata_patch", "error_match"),
+    [
+        ({"approval_copy": []}, "approval_copy must be a non-empty list"),
+        ({"approval_copy": [""]}, "approval_copy must contain non-empty strings"),
+        ({"signal_symbol": "BTC"}, "crypto signal_symbol must be an Upbit KRW symbol"),
+        (
+            {"execution_symbol": "BTC-USDT"},
+            "crypto execution_symbol must be an Alpaca USD pair",
+        ),
+    ],
+)
+def test_crypto_candidate_rejects_invalid_workflow_scalar_or_copy_fields(
+    metadata_patch: dict[str, object], error_match: str
+):
+    from app.schemas.operator_decision_session import OperatorCandidate
+    from app.services.crypto_execution_mapping import (
+        build_operator_candidate_crypto_metadata,
+    )
+
+    metadata = build_operator_candidate_crypto_metadata("KRW-BTC")
+    metadata.update(metadata_patch)
+
+    with pytest.raises(ValueError, match=error_match):
+        OperatorCandidate(
+            symbol="KRW-BTC",
+            instrument_type="crypto",
+            confidence=45,
+            **metadata,
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("preview_patch", "error_match"),
+    [
+        ({"side": "sell"}, "crypto preview side must be buy"),
+        ({"type": "market"}, "crypto preview type must be limit"),
+        ({"asset_class": "us_equity"}, "crypto preview asset_class must be crypto"),
+        ({"time_in_force": "day"}, "crypto preview time_in_force is unsupported"),
+        ({"symbol": "BTC-USDT"}, "crypto preview symbol must be an Alpaca USD pair"),
+        (
+            {"notional": "not-a-number"},
+            "crypto preview notional and limit_price must be numeric",
+        ),
+        ({"notional": "51"}, "crypto preview notional must be > 0 and <= 50"),
+        ({"limit_price": "0"}, "crypto preview limit_price must be > 0"),
+    ],
+)
+def test_crypto_candidate_rejects_invalid_preview_field_values(
+    preview_patch: dict[str, object], error_match: str
+):
+    from app.schemas.operator_decision_session import OperatorCandidate
+    from app.services.crypto_execution_mapping import (
+        build_operator_candidate_crypto_metadata,
+    )
+
+    metadata = build_operator_candidate_crypto_metadata("KRW-BTC")
+    metadata["preview_payload"] = deepcopy(metadata["preview_payload"])
+    metadata["preview_payload"].update(preview_patch)
+
+    with pytest.raises(ValueError, match=error_match):
+        OperatorCandidate(
+            symbol="KRW-BTC",
+            instrument_type="crypto",
+            confidence=45,
+            **metadata,
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("metadata_patch", "error_match"),
+    [
+        ({"signal_venue": "binance"}, "crypto signal_venue must be upbit"),
+        (
+            {"execution_venue": "alpaca_live"},
+            "crypto execution_venue must be alpaca_paper",
+        ),
+        ({"execution_mode": "live"}, "crypto execution_mode must be paper"),
+        (
+            {"execution_asset_class": "us_equity"},
+            "crypto execution_asset_class must be crypto",
+        ),
+        ({"workflow_stage": "weekday_open"}, "crypto workflow_stage is unsupported"),
+        ({"purpose": "submit_order"}, "crypto purpose is unsupported"),
+    ],
+)
+def test_crypto_workflow_scalar_helper_rejects_invalid_values(
+    metadata_patch: dict[str, object], error_match: str
+):
+    from app.schemas.operator_decision_session import OperatorCandidate
+    from app.services.crypto_execution_mapping import (
+        build_operator_candidate_crypto_metadata,
+    )
+
+    metadata = build_operator_candidate_crypto_metadata("KRW-BTC")
+    metadata.update(metadata_patch)
+
+    with pytest.raises(ValueError, match=error_match):
+        OperatorCandidate._validate_crypto_workflow_scalars(metadata)
+
+
+@pytest.mark.unit
+def test_crypto_preview_payload_helper_rejects_non_object_payload():
+    from app.schemas.operator_decision_session import OperatorCandidate
+
+    with pytest.raises(ValueError, match="preview_payload must be an object"):
+        OperatorCandidate._validate_crypto_preview_payload(
+            None,
+            execution_symbol="BTC/USD",
         )


### PR DESCRIPTION
## Summary
- Adds explicit crypto paper workflow mapping metadata for ROB-78: Upbit signal symbols stay separate from Alpaca Paper execution symbols.
- Enforces the allowlist `KRW-BTC -> BTC/USD`, `KRW-ETH -> ETH/USD`, and `KRW-SOL -> SOL/USD`, including preview payload symbol equality and unsupported/mismatched symbol rejection.
- Preserves `crypto_paper_workflow` through no-advisory and TradingAgents advisory proposal payloads, and renders the approval copy in the operator UI.

## Safety notes
- No live trading route is added.
- No generic `place_order`, `cancel_order`, or `modify_order` routing is added.
- No broker submit/cancel side effect, watch alert, order intent, scheduler change, or DB mutation was performed during implementation.
- Alpaca Paper crypto allowlist remains explicit and narrow.
- Upbit KRW prices are not used directly as Alpaca USD limit prices; the default preview remains a paper plumbing payload.
- Signal provenance and execution venue are kept as distinct payload fields and approval-copy lines.

## Verification
- `uv run pytest tests/test_crypto_execution_mapping.py tests/test_operator_decision_session_schemas.py tests/services/test_operator_decision_session_service.py tests/services/test_operator_decision_session_safety.py tests/routers/test_trading_decisions_operator_request.py tests/test_alpaca_paper_orders_tools.py tests/test_mcp_alpaca_paper_tools.py -q` -> 147 passed, 2 unrelated Pydantic deprecation warnings.
- `uv run ruff check app/services/crypto_execution_mapping.py app/schemas/operator_decision_session.py app/services/operator_decision_session_service.py app/services/trading_decision_synthesis.py tests/test_crypto_execution_mapping.py tests/test_operator_decision_session_schemas.py tests/services/test_operator_decision_session_service.py tests/services/test_operator_decision_session_safety.py` -> passed.
- `uv run ruff format --check app/services/crypto_execution_mapping.py app/schemas/operator_decision_session.py app/services/operator_decision_session_service.py app/services/trading_decision_synthesis.py tests/test_crypto_execution_mapping.py tests/test_operator_decision_session_schemas.py tests/services/test_operator_decision_session_service.py tests/services/test_operator_decision_session_safety.py` -> 8 files already formatted.
- `npm test -- ProposalRow.test.tsx` -> 15 passed.
- `npm run typecheck` -> passed.

Linear: ROB-78


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added crypto paper workflow support with metadata tracking including signal sources and execution venues.
  * Crypto workflows now display approval information and workflow details in the proposal interface.
  * Added validation for crypto workflow configurations including symbol mapping and execution parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->