### PR TITLE
feat: add preopen paper approval preview bridge

### DIFF
--- a/app/schemas/preopen.py
+++ b/app/schemas/preopen.py
@@ -84,6 +84,13 @@ PreopenQaCheckSeverity = Literal["info", "low", "medium", "high"]
 PreopenQaGrade = Literal["excellent", "good", "watch", "poor", "unavailable"]
 PreopenQaConfidence = Literal["high", "medium", "low", "unavailable"]
 PreopenQaEvaluatorStatus = Literal["ready", "needs_review", "unavailable", "skipped"]
+PreopenPaperApprovalBridgeStatus = Literal[
+    "available",
+    "warning",
+    "blocked",
+    "unavailable",
+]
+PreopenPaperApprovalCandidateStatus = Literal["available", "warning", "unavailable"]
 
 
 class PreopenQaCheck(BaseModel):
@@ -185,6 +192,40 @@ class ReconciliationSummary(BaseModel):
     warnings: list[str]
 
 
+class PreopenPaperApprovalCandidate(BaseModel):
+    candidate_uuid: UUID
+    symbol: str
+    status: PreopenPaperApprovalCandidateStatus
+    reason: str | None = None
+    warnings: list[str] = []
+    signal_symbol: str | None = None
+    signal_venue: str | None = None
+    execution_symbol: str | None = None
+    execution_venue: str | None = None
+    execution_asset_class: str | None = None
+    workflow_stage: str | None = None
+    purpose: str | None = None
+    preview_payload: dict[str, Any] | None = None
+    approval_copy: list[str] = []
+
+
+class PreopenPaperApprovalBridge(BaseModel):
+    status: PreopenPaperApprovalBridgeStatus
+    generated_at: datetime | None = None
+    source: Literal["deterministic_v1"] = "deterministic_v1"
+    preview_only: Literal[True] = True
+    advisory_only: Literal[True] = True
+    execution_allowed: Literal[False] = False
+    market_scope: Literal["kr", "us", "crypto"] | None = None
+    stage: Literal["preopen"] | None = None
+    eligible_count: int = 0
+    candidate_count: int = 0
+    candidates: list[PreopenPaperApprovalCandidate] = []
+    blocking_reasons: list[str] = []
+    warnings: list[str] = []
+    unsupported_reasons: list[str] = []
+
+
 class LinkedSessionRef(BaseModel):
     session_uuid: UUID
     status: str
@@ -219,3 +260,4 @@ class PreopenLatestResponse(BaseModel):
     market_news_briefing: PreopenMarketNewsBriefing | None = None
     briefing_artifact: PreopenBriefingArtifact | None = None
     qa_evaluator: PreopenQaEvaluatorSummary | None = None
+    paper_approval_bridge: PreopenPaperApprovalBridge | None = None

--- a/app/services/preopen_dashboard_service.py
+++ b/app/services/preopen_dashboard_service.py
@@ -45,6 +45,9 @@ from app.services.market_news_briefing_formatter import (
     BriefingItem,
     format_market_news_briefing,
 )
+from app.services.preopen_paper_approval_bridge import (
+    build_preopen_paper_approval_bridge,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -970,21 +973,31 @@ async def get_latest_preopen_dashboard(
     )
 
     if run is None:
+        qa_evaluator = _build_qa_evaluator_summary(
+            has_run=False,
+            generated_at=None,
+            candidate_count=0,
+            reconciliation_count=0,
+            candidates=[],
+            reconciliations=[],
+            linked=[],
+            news=None,
+            market_news_briefing=None,
+            briefing_artifact=_FAIL_OPEN.briefing_artifact,
+            advisory_skipped_reason="no_open_preopen_run",
+        )
+        paper_approval_bridge = build_preopen_paper_approval_bridge(
+            has_run=False,
+            market_scope=market_scope,
+            candidates=[],
+            briefing_artifact=_FAIL_OPEN.briefing_artifact,
+            qa_evaluator=qa_evaluator,
+            generated_at=None,
+        )
         return _FAIL_OPEN.model_copy(
             update={
-                "qa_evaluator": _build_qa_evaluator_summary(
-                    has_run=False,
-                    generated_at=None,
-                    candidate_count=0,
-                    reconciliation_count=0,
-                    candidates=[],
-                    reconciliations=[],
-                    linked=[],
-                    news=None,
-                    market_news_briefing=None,
-                    briefing_artifact=_FAIL_OPEN.briefing_artifact,
-                    advisory_skipped_reason="no_open_preopen_run",
-                )
+                "qa_evaluator": qa_evaluator,
+                "paper_approval_bridge": paper_approval_bridge,
             }
         )
 
@@ -1034,6 +1047,14 @@ async def get_latest_preopen_dashboard(
         briefing_artifact=briefing_artifact,
         advisory_skipped_reason=advisory_reason,
     )
+    paper_approval_bridge = build_preopen_paper_approval_bridge(
+        has_run=True,
+        market_scope=run.market_scope,
+        candidates=candidates,
+        briefing_artifact=briefing_artifact,
+        qa_evaluator=qa_evaluator,
+        generated_at=run.generated_at,
+    )
 
     return PreopenLatestResponse(
         has_run=True,
@@ -1063,4 +1084,5 @@ async def get_latest_preopen_dashboard(
         market_news_briefing=market_news_briefing,
         briefing_artifact=briefing_artifact,
         qa_evaluator=qa_evaluator,
+        paper_approval_bridge=paper_approval_bridge,
     )

--- a/app/services/preopen_paper_approval_bridge.py
+++ b/app/services/preopen_paper_approval_bridge.py
@@ -1,0 +1,243 @@
+"""Pure preopen paper approval preview bridge (ROB-81).
+
+This module is intentionally read-layer only. It maps already-built preopen
+transport objects into operator-facing preview metadata without touching broker,
+account, network, cache, scheduler, persistence, or approval systems.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.schemas.preopen import (
+    CandidateSummary,
+    PreopenBriefingArtifact,
+    PreopenPaperApprovalBridge,
+    PreopenPaperApprovalCandidate,
+    PreopenQaEvaluatorSummary,
+)
+from app.services.crypto_execution_mapping import (
+    CryptoExecutionMappingError,
+    build_crypto_paper_approval_metadata,
+)
+
+_FORBIDDEN_PREVIEW_KEYS = frozenset(
+    {
+        "confirm",
+        "dry_run",
+        "order_id",
+        "client_order_id",
+        "submitted",
+        "submit",
+        "action",
+    }
+)
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _unsupported_candidate(
+    candidate: CandidateSummary,
+    *,
+    reason: str,
+) -> PreopenPaperApprovalCandidate:
+    return PreopenPaperApprovalCandidate(
+        candidate_uuid=candidate.candidate_uuid,
+        symbol=candidate.symbol,
+        status="unavailable",
+        reason=reason,
+        warnings=list(candidate.warnings),
+    )
+
+
+def _qa_blocking_reasons(
+    qa_evaluator: PreopenQaEvaluatorSummary | None,
+    *,
+    has_run: bool,
+) -> list[str]:
+    if not has_run:
+        return ["no_open_preopen_run"]
+    if qa_evaluator is None:
+        return ["qa_evaluator_unavailable"]
+    if qa_evaluator.status in {"unavailable", "skipped"}:
+        return [f"qa_evaluator_{qa_evaluator.status}"]
+
+    reasons = list(qa_evaluator.blocking_reasons)
+    for check in qa_evaluator.checks:
+        if check.status == "fail" and check.severity == "high":
+            reasons.append(f"high_severity_fail:{check.id}")
+        if check.id == "actionability_guardrail" and check.status != "pass":
+            reasons.append("safety_guardrail_not_passed")
+
+    coverage = qa_evaluator.coverage or {}
+    if coverage.get("advisory_only") is not True:
+        reasons.append("advisory_only_guard_missing")
+    if coverage.get("execution_allowed") is not False:
+        reasons.append("execution_allowed_guard_missing")
+    return _dedupe(reasons)
+
+
+def _bridge_warnings(
+    qa_evaluator: PreopenQaEvaluatorSummary | None,
+    briefing_artifact: PreopenBriefingArtifact | None,
+    candidates: list[CandidateSummary],
+) -> list[str]:
+    warnings: list[str] = []
+    if qa_evaluator is not None:
+        if qa_evaluator.status == "needs_review":
+            warnings.append("qa_needs_review")
+        warnings.extend(qa_evaluator.warnings)
+    if briefing_artifact is not None:
+        if briefing_artifact.status == "degraded":
+            warnings.append("briefing_artifact_degraded")
+        warnings.extend(briefing_artifact.risk_notes)
+    for candidate in candidates:
+        warnings.extend(candidate.warnings)
+    return _dedupe(warnings)
+
+
+def _build_crypto_candidate(
+    candidate: CandidateSummary,
+    *,
+    bridge_has_warnings: bool,
+) -> PreopenPaperApprovalCandidate:
+    try:
+        metadata = build_crypto_paper_approval_metadata(
+            candidate.symbol,
+            stage="crypto_weekend",
+            purpose="paper_plumbing_smoke",
+        )
+    except CryptoExecutionMappingError as exc:
+        return _unsupported_candidate(candidate, reason=str(exc))
+
+    preview_payload = metadata.preview_payload.model_dump(mode="json")
+    forbidden = sorted(_FORBIDDEN_PREVIEW_KEYS.intersection(preview_payload))
+    if forbidden:
+        return _unsupported_candidate(
+            candidate,
+            reason="forbidden_preview_payload_keys:" + ",".join(forbidden),
+        )
+
+    candidate_warnings = list(candidate.warnings)
+    status = "warning" if bridge_has_warnings or candidate_warnings else "available"
+    return PreopenPaperApprovalCandidate(
+        candidate_uuid=candidate.candidate_uuid,
+        symbol=candidate.symbol,
+        status=status,
+        reason=None,
+        warnings=candidate_warnings,
+        signal_symbol=metadata.mapping.signal_symbol,
+        signal_venue=metadata.mapping.signal_venue,
+        execution_symbol=metadata.mapping.execution_symbol,
+        execution_venue=metadata.mapping.execution_venue,
+        execution_asset_class=metadata.mapping.asset_class,
+        workflow_stage=metadata.stage,
+        purpose=metadata.purpose,
+        preview_payload=preview_payload,
+        approval_copy=metadata.approval_copy,
+    )
+
+
+def build_preopen_paper_approval_bridge(
+    *,
+    has_run: bool,
+    market_scope: str | None,
+    candidates: list[CandidateSummary],
+    briefing_artifact: PreopenBriefingArtifact | None,
+    qa_evaluator: PreopenQaEvaluatorSummary | None,
+    generated_at: datetime | None = None,
+) -> PreopenPaperApprovalBridge:
+    """Build deterministic paper approval preview metadata for preopen output."""
+    blocking_reasons = _qa_blocking_reasons(qa_evaluator, has_run=has_run)
+    warnings = _bridge_warnings(qa_evaluator, briefing_artifact, candidates)
+    generated_at = generated_at or datetime.now(UTC)
+
+    bridge_candidates: list[PreopenPaperApprovalCandidate] = []
+    unsupported_reasons: list[str] = []
+
+    if blocking_reasons:
+        return PreopenPaperApprovalBridge(
+            status="blocked",
+            generated_at=generated_at,
+            market_scope=market_scope,  # type: ignore[arg-type]
+            stage="preopen" if has_run else None,
+            candidate_count=len(candidates),
+            candidates=[],
+            blocking_reasons=blocking_reasons,
+            warnings=warnings,
+            unsupported_reasons=[],
+        )
+
+    if market_scope != "crypto":
+        reason = f"unsupported_market_scope:{market_scope or 'unknown'}"
+        return PreopenPaperApprovalBridge(
+            status="unavailable",
+            generated_at=generated_at,
+            market_scope=market_scope,  # type: ignore[arg-type]
+            stage="preopen" if has_run else None,
+            candidate_count=len(candidates),
+            candidates=[
+                _unsupported_candidate(candidate, reason=reason)
+                for candidate in candidates
+            ],
+            warnings=warnings,
+            unsupported_reasons=[reason],
+        )
+
+    bridge_has_warnings = bool(warnings)
+    for candidate in candidates:
+        if candidate.instrument_type != "crypto":
+            reason = f"unsupported_instrument_type:{candidate.instrument_type}"
+            bridge_candidates.append(_unsupported_candidate(candidate, reason=reason))
+            unsupported_reasons.append(reason)
+            continue
+        if candidate.side != "buy":
+            reason = f"unsupported_side:{candidate.side}"
+            bridge_candidates.append(_unsupported_candidate(candidate, reason=reason))
+            unsupported_reasons.append(reason)
+            continue
+        bridge_candidate = _build_crypto_candidate(
+            candidate,
+            bridge_has_warnings=bridge_has_warnings,
+        )
+        bridge_candidates.append(bridge_candidate)
+        if bridge_candidate.status == "unavailable" and bridge_candidate.reason:
+            unsupported_reasons.append(bridge_candidate.reason)
+
+    eligible_count = sum(
+        1
+        for candidate in bridge_candidates
+        if candidate.status in {"available", "warning"}
+    )
+    if eligible_count == 0:
+        status = "unavailable"
+    elif bridge_has_warnings or any(
+        candidate.status == "warning" for candidate in bridge_candidates
+    ):
+        status = "warning"
+    else:
+        status = "available"
+
+    return PreopenPaperApprovalBridge(
+        status=status,
+        generated_at=generated_at,
+        market_scope="crypto",
+        stage="preopen" if has_run else None,
+        eligible_count=eligible_count,
+        candidate_count=len(candidates),
+        candidates=bridge_candidates,
+        blocking_reasons=[],
+        warnings=warnings,
+        unsupported_reasons=_dedupe(unsupported_reasons),
+    )
+
+
+__all__ = ["build_preopen_paper_approval_bridge"]

--- a/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
@@ -6,8 +6,10 @@ import PreopenPage from "../pages/PreopenPage";
 import {
   makePreopenFailOpen,
   makePreopenLinkedSession,
+  makePreopenBlockedPaperApprovalBridge,
   makePreopenBriefingArtifact,
   makePreopenMarketNewsBriefing,
+  makePreopenPaperApprovalBridge,
   makePreopenQaEvaluator,
   makePreopenUnavailableQaEvaluator,
   makePreopenNewsArticle,
@@ -357,6 +359,70 @@ describe("PreopenPage", () => {
     expect(
       screen.getByText(/No market news briefing available yet/i),
     ).toBeInTheDocument();
+  });
+
+  it("renders paper approval preview with safety copy and venue provenance", async () => {
+    const { calls } = mockFetch({
+      [PREOPEN_URL]: () =>
+        new Response(
+          JSON.stringify(
+            makePreopenResponse({
+              market_scope: "crypto",
+              paper_approval_bridge: makePreopenPaperApprovalBridge(),
+            }),
+          ),
+        ),
+    });
+
+    render(<PreopenPage />, { wrapper: MemoryRouter });
+
+    expect(
+      await screen.findByRole("region", { name: /paper approval preview/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Preview Available/i)).toBeInTheDocument();
+    expect(screen.getByText(/Advisory-only preview/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Execution is not allowed from this screen/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Explicit operator approval is required before any Alpaca Paper submit/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/does not submit or cancel paper orders/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Signal source")).toBeInTheDocument();
+    expect(screen.getAllByText(/Upbit KRW-BTC/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("Execution venue")).toBeInTheDocument();
+    expect(screen.getAllByText(/Alpaca Paper BTC\/USD/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/Preview payload: buy limit · \$10 @ 1.00 GTC/i)).toBeInTheDocument();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("GET");
+  });
+
+  it("renders blocked paper approval preview without execution actions", async () => {
+    const { calls } = mockFetch({
+      [PREOPEN_URL]: () =>
+        new Response(
+          JSON.stringify(
+            makePreopenResponse({
+              paper_approval_bridge: makePreopenBlockedPaperApprovalBridge(),
+            }),
+          ),
+        ),
+    });
+
+    render(<PreopenPage />, { wrapper: MemoryRouter });
+
+    expect(
+      await screen.findByRole("region", { name: /paper approval preview/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Preview Blocked/i)).toBeInTheDocument();
+    expect(screen.getByText(/qa evaluator unavailable/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/No paper approval preview candidates are currently available/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /submit|cancel paper|place order/i })).toBeNull();
+    expect(calls).toHaveLength(1);
   });
 
   it("surfaces ApiError detail (research_run_has_no_candidates) inline without throwing", async () => {

--- a/frontend/trading-decision/src/api/types.ts
+++ b/frontend/trading-decision/src/api/types.ts
@@ -335,6 +335,49 @@ export interface PreopenDecisionSessionCta {
   requires_confirmation: boolean;
 }
 
+export type PreopenPaperApprovalBridgeStatus =
+  | "available"
+  | "warning"
+  | "blocked"
+  | "unavailable";
+export type PreopenPaperApprovalCandidateStatus =
+  | "available"
+  | "warning"
+  | "unavailable";
+
+export interface PreopenPaperApprovalCandidate {
+  candidate_uuid: Uuid;
+  symbol: string;
+  status: PreopenPaperApprovalCandidateStatus;
+  reason: string | null;
+  warnings: string[];
+  signal_symbol: string | null;
+  signal_venue: string | null;
+  execution_symbol: string | null;
+  execution_venue: string | null;
+  execution_asset_class: string | null;
+  workflow_stage: string | null;
+  purpose: string | null;
+  preview_payload: CryptoPaperPreviewPayload | Record<string, unknown> | null;
+  approval_copy: string[];
+}
+
+export interface PreopenPaperApprovalBridge {
+  status: PreopenPaperApprovalBridgeStatus;
+  generated_at: IsoDateTime | null;
+  source: "deterministic_v1";
+  preview_only: true;
+  advisory_only: true;
+  execution_allowed: false;
+  market_scope: "kr" | "us" | "crypto" | null;
+  stage: "preopen" | null;
+  eligible_count: number;
+  candidate_count: number;
+  candidates: PreopenPaperApprovalCandidate[];
+  blocking_reasons: string[];
+  warnings: string[];
+  unsupported_reasons: string[];
+}
 
 export type PreopenQaCheckStatus = "pass" | "warn" | "fail" | "unknown" | "skipped";
 export type PreopenQaCheckSeverity = "info" | "low" | "medium" | "high";
@@ -423,6 +466,7 @@ export interface PreopenLatestResponse {
   market_news_briefing: PreopenMarketNewsBriefing | null;
   briefing_artifact: PreopenBriefingArtifact | null;
   qa_evaluator: PreopenQaEvaluatorSummary | null;
+  paper_approval_bridge: PreopenPaperApprovalBridge | null;
 }
 
 export interface CreateFromResearchRunRequest {

--- a/frontend/trading-decision/src/pages/PreopenPage.module.css
+++ b/frontend/trading-decision/src/pages/PreopenPage.module.css
@@ -177,3 +177,66 @@
   gap: 12px;
   padding: 16px;
 }
+
+.paperApprovalSection {
+  border: 1px solid #bfdbfe;
+  border-radius: 8px;
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.paperApprovalSafety {
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: 6px;
+  color: #1e3a8a;
+  padding: 10px 12px;
+}
+
+.paperApprovalCandidates {
+  display: grid;
+  gap: 10px;
+}
+
+.paperApprovalCandidate {
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+}
+
+.paperApprovalCandidateHeader {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.provenanceList {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin: 0;
+}
+
+.provenanceList div {
+  display: grid;
+  gap: 2px;
+}
+
+.provenanceList dt {
+  color: #475569;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.provenanceList dd {
+  margin: 0;
+}
+
+.approvalCopy {
+  margin: 0;
+  padding-left: 18px;
+}

--- a/frontend/trading-decision/src/pages/PreopenPage.tsx
+++ b/frontend/trading-decision/src/pages/PreopenPage.tsx
@@ -12,6 +12,7 @@ import {
 import type {
   PreopenBriefingArtifact,
   PreopenLatestResponse,
+  PreopenPaperApprovalBridge,
   PreopenQaEvaluatorSummary,
 } from "../api/types";
 import { formatDateTime } from "../format/datetime";
@@ -158,6 +159,183 @@ function PreopenQaEvaluatorPanel({
   );
 }
 
+const PAPER_APPROVAL_STATUS_LABEL: Record<
+  PreopenPaperApprovalBridge["status"],
+  string
+> = {
+  available: "Available",
+  warning: "Warning",
+  blocked: "Blocked",
+  unavailable: "Unavailable",
+};
+
+function formatOperatorToken(value: string | null | undefined): string {
+  return value ? value.replace(/_/g, " ") : "—";
+}
+
+function formatVenueLabel(venue: string | null, symbol: string | null): string {
+  const venueLabel =
+    venue === "upbit"
+      ? "Upbit"
+      : venue === "alpaca_paper"
+        ? "Alpaca Paper"
+        : formatOperatorToken(venue);
+  return [venueLabel, symbol].filter(Boolean).join(" ");
+}
+
+type PreviewPayloadLike = {
+  side?: unknown;
+  type?: unknown;
+  notional?: unknown;
+  limit_price?: unknown;
+  time_in_force?: unknown;
+};
+
+function formatPreviewPayload(payload: PreviewPayloadLike | null): string | null {
+  if (!payload) return null;
+  const side = typeof payload.side === "string" ? payload.side : null;
+  const type = typeof payload.type === "string" ? payload.type : null;
+  const notional = typeof payload.notional === "string" ? payload.notional : null;
+  const limitPrice =
+    typeof payload.limit_price === "string" ? payload.limit_price : null;
+  const tif =
+    typeof payload.time_in_force === "string" ? payload.time_in_force : null;
+  const parts = [side, type].filter(Boolean).join(" ");
+  const price = limitPrice ? ` @ ${limitPrice}` : "";
+  const suffix = tif ? ` ${tif.toUpperCase()}` : "";
+  const order = [parts, notional ? `$${notional}` : null]
+    .filter(Boolean)
+    .join(" · ");
+  return `${order}${price}${suffix}`;
+}
+
+function PreopenPaperApprovalBridgeSection({
+  bridge,
+}: {
+  bridge: PreopenPaperApprovalBridge | null;
+}) {
+  if (!bridge) return null;
+  const statusLabel = PAPER_APPROVAL_STATUS_LABEL[bridge.status] ?? bridge.status;
+
+  return (
+    <section
+      aria-label="Paper approval preview"
+      className={styles.paperApprovalSection}
+    >
+      <div className={styles.artifactHeader}>
+        <div>
+          <h2>Paper approval preview</h2>
+          <p className={styles.meta}>
+            {bridge.source} · {bridge.market_scope ?? "unknown market"} ·{" "}
+            {bridge.eligible_count} eligible / {bridge.candidate_count} candidates
+          </p>
+        </div>
+        <span className={styles.artifactStatus}>Preview {statusLabel}</span>
+      </div>
+
+      <div className={styles.paperApprovalSafety} role="note">
+        Advisory-only preview. Execution is not allowed from this screen. Explicit
+        operator approval is required before any Alpaca Paper submit; this card
+        does not submit or cancel paper orders.
+      </div>
+
+      {bridge.blocking_reasons.length > 0 ? (
+        <ul aria-label="Paper approval blocking reasons" className={styles.warnings}>
+          {bridge.blocking_reasons.map((reason) => (
+            <li className={styles.warningChip} key={reason}>
+              {formatOperatorToken(reason)}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {bridge.warnings.length > 0 || bridge.unsupported_reasons.length > 0 ? (
+        <ul aria-label="Paper approval warnings" className={styles.warnings}>
+          {[...bridge.warnings, ...bridge.unsupported_reasons].map((warning) => (
+            <li className={styles.warningChip} key={warning}>
+              {formatOperatorToken(warning)}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {bridge.candidates.length > 0 ? (
+        <div className={styles.paperApprovalCandidates}>
+          {bridge.candidates.map((candidate) => {
+            const previewPayload = formatPreviewPayload(candidate.preview_payload);
+            return (
+              <article
+                className={styles.paperApprovalCandidate}
+                key={candidate.candidate_uuid}
+              >
+                <div className={styles.paperApprovalCandidateHeader}>
+                  <strong>{candidate.symbol}</strong>
+                  <span>{formatOperatorToken(candidate.status)}</span>
+                </div>
+                <dl className={styles.provenanceList}>
+                  <div>
+                    <dt>Signal source</dt>
+                    <dd>
+                      {formatVenueLabel(
+                        candidate.signal_venue,
+                        candidate.signal_symbol ?? candidate.symbol,
+                      )}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Execution venue</dt>
+                    <dd>
+                      {formatVenueLabel(
+                        candidate.execution_venue,
+                        candidate.execution_symbol,
+                      )}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Asset class</dt>
+                    <dd>{formatOperatorToken(candidate.execution_asset_class)}</dd>
+                  </div>
+                  <div>
+                    <dt>Workflow</dt>
+                    <dd>{formatOperatorToken(candidate.workflow_stage)}</dd>
+                  </div>
+                </dl>
+                {candidate.purpose ? (
+                  <p>Purpose: {formatOperatorToken(candidate.purpose)}</p>
+                ) : null}
+                {previewPayload ? <p>Preview payload: {previewPayload}</p> : null}
+                {candidate.approval_copy.length > 0 ? (
+                  <ul
+                    aria-label={`${candidate.symbol} approval copy`}
+                    className={styles.approvalCopy}
+                  >
+                    {candidate.approval_copy.map((copy) => (
+                      <li key={copy}>{copy}</li>
+                    ))}
+                  </ul>
+                ) : null}
+                {candidate.warnings.length > 0 ? (
+                  <ul
+                    aria-label={`${candidate.symbol} paper approval warnings`}
+                    className={styles.warnings}
+                  >
+                    {candidate.warnings.map((warning) => (
+                      <li className={styles.warningChip} key={warning}>
+                        {formatOperatorToken(warning)}
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+              </article>
+            );
+          })}
+        </div>
+      ) : (
+        <p>No paper approval preview candidates are currently available.</p>
+      )}
+    </section>
+  );
+}
+
 export default function PreopenPage() {
   const navigate = useNavigate();
   const [state, setState] = useState<State>({ status: "loading" });
@@ -248,6 +426,7 @@ export default function PreopenPage() {
         </div>
         <PreopenBriefingArtifactSection artifact={data.briefing_artifact} />
         <PreopenQaEvaluatorPanel qa={data.qa_evaluator} />
+        <PreopenPaperApprovalBridgeSection bridge={data.paper_approval_bridge} />
       </main>
     );
   }
@@ -286,6 +465,7 @@ export default function PreopenPage() {
 
       <PreopenBriefingArtifactSection artifact={data.briefing_artifact} />
       <PreopenQaEvaluatorPanel qa={data.qa_evaluator} />
+      <PreopenPaperApprovalBridgeSection bridge={data.paper_approval_bridge} />
       <NewsReadinessSection news={data.news} preview={data.news_preview} />
       <MarketNewsBriefingSection briefing={data.market_news_briefing} />
 

--- a/frontend/trading-decision/src/test/fixtures/preopen.ts
+++ b/frontend/trading-decision/src/test/fixtures/preopen.ts
@@ -7,6 +7,7 @@ import type {
   PreopenMarketNewsItem,
   PreopenNewsArticlePreview,
   PreopenNewsReadinessSummary,
+  PreopenPaperApprovalBridge,
   PreopenQaEvaluatorSummary,
   PreopenReconciliationSummary,
 } from "../../api/types";
@@ -270,6 +271,71 @@ export function makePreopenBriefingArtifact(
   };
 }
 
+export function makePreopenPaperApprovalBridge(
+  overrides: Partial<PreopenPaperApprovalBridge> = {},
+): PreopenPaperApprovalBridge {
+  return {
+    status: "available",
+    generated_at: now,
+    source: "deterministic_v1",
+    preview_only: true,
+    advisory_only: true,
+    execution_allowed: false,
+    market_scope: "crypto",
+    stage: "preopen",
+    eligible_count: 1,
+    candidate_count: 1,
+    candidates: [
+      {
+        candidate_uuid: "cand-crypto-1111-2222-3333-444444444444",
+        symbol: "KRW-BTC",
+        status: "available",
+        reason: null,
+        warnings: [],
+        signal_symbol: "KRW-BTC",
+        signal_venue: "upbit",
+        execution_symbol: "BTC/USD",
+        execution_venue: "alpaca_paper",
+        execution_asset_class: "crypto",
+        workflow_stage: "crypto_weekend",
+        purpose: "paper_plumbing_smoke",
+        preview_payload: {
+          symbol: "BTC/USD",
+          side: "buy",
+          type: "limit",
+          notional: "10",
+          limit_price: "1.00",
+          time_in_force: "gtc",
+          asset_class: "crypto",
+        },
+        approval_copy: [
+          "Signal source: Upbit KRW-BTC",
+          "Execution venue: Alpaca Paper BTC/USD",
+          "Explicit approval required before any paper submit.",
+        ],
+      },
+    ],
+    blocking_reasons: [],
+    warnings: [],
+    unsupported_reasons: [],
+    ...overrides,
+  };
+}
+
+export function makePreopenBlockedPaperApprovalBridge(
+  overrides: Partial<PreopenPaperApprovalBridge> = {},
+): PreopenPaperApprovalBridge {
+  return makePreopenPaperApprovalBridge({
+    status: "blocked",
+    eligible_count: 0,
+    candidates: [],
+    blocking_reasons: ["qa_evaluator_unavailable"],
+    warnings: [],
+    unsupported_reasons: [],
+    ...overrides,
+  });
+}
+
 export function makePreopenUnavailableArtifact(
   overrides: Partial<PreopenBriefingArtifact> = {},
 ): PreopenBriefingArtifact {
@@ -428,6 +494,7 @@ export function makePreopenResponse(
     market_news_briefing: makePreopenMarketNewsBriefing(),
     briefing_artifact: makePreopenBriefingArtifact(),
     qa_evaluator: makePreopenQaEvaluator(),
+    paper_approval_bridge: null,
     ...overrides,
   };
 }
@@ -462,6 +529,7 @@ export function makePreopenFailOpen(
     market_news_briefing: null,
     briefing_artifact: makePreopenUnavailableArtifact(),
     qa_evaluator: makePreopenUnavailableQaEvaluator(),
+    paper_approval_bridge: null,
     ...overrides,
   };
 }

--- a/tests/services/test_preopen_paper_approval_bridge.py
+++ b/tests/services/test_preopen_paper_approval_bridge.py
@@ -1,0 +1,263 @@
+"""Tests for the ROB-81 preopen paper approval bridge."""
+
+from __future__ import annotations
+
+import ast
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+from app.schemas.preopen import (
+    CandidateSummary,
+    PreopenBriefingArtifact,
+    PreopenDecisionSessionCta,
+    PreopenQaCheck,
+    PreopenQaEvaluatorSummary,
+    PreopenQaScore,
+)
+from app.services.preopen_paper_approval_bridge import (
+    build_preopen_paper_approval_bridge,
+)
+
+
+def _candidate(**kwargs) -> CandidateSummary:
+    defaults = {
+        "candidate_uuid": uuid4(),
+        "symbol": "KRW-BTC",
+        "instrument_type": "crypto",
+        "side": "buy",
+        "candidate_kind": "proposed",
+        "proposed_price": Decimal("100000000"),
+        "proposed_qty": None,
+        "confidence": 70,
+        "rationale": "Crypto paper plumbing candidate",
+        "currency": "KRW",
+        "warnings": [],
+    }
+    defaults.update(kwargs)
+    return CandidateSummary(**defaults)
+
+
+def _artifact(**kwargs) -> PreopenBriefingArtifact:
+    defaults = {
+        "status": "ready",
+        "market_scope": "crypto",
+        "stage": "preopen",
+        "risk_notes": [],
+        "cta": PreopenDecisionSessionCta(
+            state="create_available",
+            label="Create decision session",
+            requires_confirmation=True,
+        ),
+        "qa": {"read_only": True},
+    }
+    defaults.update(kwargs)
+    return PreopenBriefingArtifact(**defaults)
+
+
+def _qa(**kwargs) -> PreopenQaEvaluatorSummary:
+    defaults = {
+        "status": "ready",
+        "generated_at": datetime.now(UTC),
+        "overall": PreopenQaScore(score=90, grade="excellent", confidence="high"),
+        "checks": [
+            PreopenQaCheck(
+                id="actionability_guardrail",
+                label="Actionability guardrail",
+                status="pass",
+                severity="info",
+                summary="Execution disabled.",
+                details={"advisory_only": True, "execution_allowed": False},
+            )
+        ],
+        "blocking_reasons": [],
+        "warnings": [],
+        "coverage": {"advisory_only": True, "execution_allowed": False},
+    }
+    defaults.update(kwargs)
+    return PreopenQaEvaluatorSummary(**defaults)
+
+
+def test_no_run_blocks_bridge() -> None:
+    bridge = build_preopen_paper_approval_bridge(
+        has_run=False,
+        market_scope="crypto",
+        candidates=[],
+        briefing_artifact=_artifact(status="unavailable"),
+        qa_evaluator=_qa(status="unavailable"),
+    )
+
+    assert bridge.status == "blocked"
+    assert bridge.preview_only is True
+    assert bridge.advisory_only is True
+    assert bridge.execution_allowed is False
+    assert "no_open_preopen_run" in bridge.blocking_reasons
+    assert bridge.candidates == []
+
+
+def test_high_severity_fail_blocks_even_for_crypto_candidate() -> None:
+    qa = _qa(
+        status="needs_review",
+        checks=[
+            PreopenQaCheck(
+                id="readiness_safety",
+                label="Readiness safety",
+                status="fail",
+                severity="high",
+                summary="Safety gate failed.",
+            )
+        ],
+        blocking_reasons=["readiness_safety"],
+    )
+
+    bridge = build_preopen_paper_approval_bridge(
+        has_run=True,
+        market_scope="crypto",
+        candidates=[_candidate()],
+        briefing_artifact=_artifact(),
+        qa_evaluator=qa,
+    )
+
+    assert bridge.status == "blocked"
+    assert "readiness_safety" in bridge.blocking_reasons
+    assert "high_severity_fail:readiness_safety" in bridge.blocking_reasons
+    assert bridge.eligible_count == 0
+    assert bridge.candidates == []
+
+
+def test_ready_crypto_buy_allowlist_builds_preview_with_provenance() -> None:
+    candidate = _candidate(symbol="KRW-BTC")
+
+    bridge = build_preopen_paper_approval_bridge(
+        has_run=True,
+        market_scope="crypto",
+        candidates=[candidate],
+        briefing_artifact=_artifact(),
+        qa_evaluator=_qa(),
+    )
+
+    assert bridge.status == "available"
+    assert bridge.eligible_count == 1
+    assert bridge.candidate_count == 1
+    item = bridge.candidates[0]
+    assert item.status == "available"
+    assert item.symbol == "KRW-BTC"
+    assert item.signal_symbol == "KRW-BTC"
+    assert item.signal_venue == "upbit"
+    assert item.execution_symbol == "BTC/USD"
+    assert item.execution_venue == "alpaca_paper"
+    assert item.execution_asset_class == "crypto"
+    assert item.workflow_stage == "crypto_weekend"
+    assert item.purpose == "paper_plumbing_smoke"
+    assert item.preview_payload == {
+        "symbol": "BTC/USD",
+        "side": "buy",
+        "type": "limit",
+        "notional": "10",
+        "limit_price": "1.00",
+        "time_in_force": "gtc",
+        "asset_class": "crypto",
+    }
+    forbidden = {
+        "confirm",
+        "dry_run",
+        "order_id",
+        "client_order_id",
+        "submitted",
+        "submit",
+        "action",
+    }
+    assert forbidden.isdisjoint(item.preview_payload or {})
+    assert any("Signal source: Upbit KRW-BTC" in line for line in item.approval_copy)
+    assert any(
+        "Execution venue: Alpaca Paper BTC/USD" in line for line in item.approval_copy
+    )
+
+
+def test_qa_warnings_and_degraded_artifact_make_bridge_warning() -> None:
+    bridge = build_preopen_paper_approval_bridge(
+        has_run=True,
+        market_scope="crypto",
+        candidates=[_candidate(warnings=["candidate_warning"])],
+        briefing_artifact=_artifact(
+            status="degraded", risk_notes=["briefing_degraded"]
+        ),
+        qa_evaluator=_qa(status="needs_review", warnings=["qa_warning"]),
+    )
+
+    assert bridge.status == "warning"
+    assert bridge.candidates[0].status == "warning"
+    assert "qa_needs_review" in bridge.warnings
+    assert "qa_warning" in bridge.warnings
+    assert "briefing_artifact_degraded" in bridge.warnings
+    assert "candidate_warning" in bridge.warnings
+
+
+def test_unsupported_crypto_symbol_is_unavailable_without_preview_payload() -> None:
+    bridge = build_preopen_paper_approval_bridge(
+        has_run=True,
+        market_scope="crypto",
+        candidates=[_candidate(symbol="KRW-XRP")],
+        briefing_artifact=_artifact(),
+        qa_evaluator=_qa(),
+    )
+
+    assert bridge.status == "unavailable"
+    assert bridge.eligible_count == 0
+    item = bridge.candidates[0]
+    assert item.status == "unavailable"
+    assert item.preview_payload is None
+    assert "unsupported crypto signal symbol" in (item.reason or "")
+
+
+def test_non_crypto_market_and_sell_candidates_are_unavailable() -> None:
+    kr_bridge = build_preopen_paper_approval_bridge(
+        has_run=True,
+        market_scope="kr",
+        candidates=[_candidate(symbol="005930", instrument_type="equity_kr")],
+        briefing_artifact=_artifact(market_scope="kr"),
+        qa_evaluator=_qa(),
+    )
+    sell_bridge = build_preopen_paper_approval_bridge(
+        has_run=True,
+        market_scope="crypto",
+        candidates=[_candidate(side="sell")],
+        briefing_artifact=_artifact(),
+        qa_evaluator=_qa(),
+    )
+
+    assert kr_bridge.status == "unavailable"
+    assert kr_bridge.candidates[0].reason == "unsupported_market_scope:kr"
+    assert sell_bridge.status == "unavailable"
+    assert sell_bridge.candidates[0].reason == "unsupported_side:sell"
+
+
+def test_bridge_module_imports_only_pure_allowed_modules() -> None:
+    path = Path("app/services/preopen_paper_approval_bridge.py")
+    tree = ast.parse(path.read_text())
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.append(node.module)
+
+    forbidden_fragments = [
+        "broker",
+        "kis",
+        "upbit",
+        "mcp",
+        "watch",
+        "redis",
+        "scheduler",
+        "httpx",
+        "requests",
+        "paper_trading",
+    ]
+    assert not [
+        module
+        for module in imported_modules
+        if any(fragment in module.lower() for fragment in forbidden_fragments)
+    ]
+    assert "app.services.crypto_execution_mapping" in imported_modules

--- a/tests/test_preopen_dashboard_service.py
+++ b/tests/test_preopen_dashboard_service.py
@@ -169,6 +169,11 @@ async def test_returns_fail_open_when_no_run():
     assert result.briefing_artifact.cta.state == "unavailable"
     assert result.briefing_artifact.cta.requires_confirmation is True
     assert "no_open_preopen_run" in result.briefing_artifact.risk_notes
+    assert result.paper_approval_bridge is not None
+    assert result.paper_approval_bridge.status == "blocked"
+    assert "no_open_preopen_run" in result.paper_approval_bridge.blocking_reasons
+    assert result.paper_approval_bridge.preview_only is True
+    assert result.paper_approval_bridge.execution_allowed is False
 
 
 @pytest.mark.asyncio
@@ -225,6 +230,67 @@ async def test_maps_candidates_and_reconciliations():
     sections = {s.section_id: s for s in result.briefing_artifact.sections}
     assert sections["new_buy_candidates"].item_count == 1
     assert sections["holdings_actions"].item_count == 2
+    assert result.paper_approval_bridge is not None
+    assert result.paper_approval_bridge.status == "unavailable"
+    assert result.paper_approval_bridge.unsupported_reasons == [
+        "unsupported_market_scope:kr"
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_crypto_preopen_response_includes_paper_approval_bridge_preview():
+    from app.services import preopen_dashboard_service, research_run_service
+
+    run = _make_run(
+        market_scope="crypto",
+        candidates=[
+            _make_candidate(
+                symbol="KRW-BTC",
+                instrument_type="crypto",
+                side="buy",
+                currency="KRW",
+            )
+        ],
+        reconciliations=[],
+    )
+
+    with _patched_dashboard_dependencies(
+        preopen_dashboard_service, research_run_service, run=run
+    ):
+        result = await preopen_dashboard_service.get_latest_preopen_dashboard(
+            db=AsyncMock(),
+            user_id=7,
+            market_scope="crypto",
+        )
+
+    assert result.paper_approval_bridge is not None
+    bridge = result.paper_approval_bridge
+    assert bridge.status == "warning"
+    assert (
+        "No linked decision session found; evaluator did not create one."
+        in bridge.warnings
+    )
+    assert bridge.eligible_count == 1
+    item = bridge.candidates[0]
+    assert item.symbol == "KRW-BTC"
+    assert item.signal_symbol == "KRW-BTC"
+    assert item.execution_symbol == "BTC/USD"
+    assert item.execution_venue == "alpaca_paper"
+    assert item.preview_payload == {
+        "symbol": "BTC/USD",
+        "side": "buy",
+        "type": "limit",
+        "notional": "10",
+        "limit_price": "1.00",
+        "time_in_force": "gtc",
+        "asset_class": "crypto",
+    }
+    assert {"confirm", "dry_run", "order_id", "client_order_id"}.isdisjoint(
+        item.preview_payload or {}
+    )
+    assert result.briefing_artifact is not None
+    assert result.briefing_artifact.cta.state == "create_available"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add deterministic preopen paper approval preview builder gated by the QA evaluator
- preserve signal/execution provenance, including explicit Upbit KRW -> Alpaca Paper USD crypto mapping
- render an advisory-only paper approval preview card/CTA on `/trading/decisions/preopen`

## Safety / Non-goals
- no live orders
- no Alpaca Paper submit/cancel
- no generic place_order/cancel_order/modify_order routing
- no watch alerts or order intents
- no scheduler changes or destructive DB changes
- no automatic Decision Session creation from GET/read paths
- no Upbit KRW prices used as Alpaca USD limit prices

## Test Plan
- `uv run pytest tests/services/test_preopen_paper_approval_bridge.py tests/test_preopen_dashboard_service.py tests/test_crypto_execution_mapping.py tests/test_router_preopen.py -q`
- `uv run ruff format --check app/schemas/preopen.py app/services/preopen_dashboard_service.py app/services/preopen_paper_approval_bridge.py tests/services/test_preopen_paper_approval_bridge.py tests/test_preopen_dashboard_service.py`
- `uv run ruff check app/schemas/preopen.py app/services/preopen_dashboard_service.py app/services/preopen_paper_approval_bridge.py tests/services/test_preopen_paper_approval_bridge.py tests/test_preopen_dashboard_service.py`
- `npm test -- --run`
- `npm run typecheck`

Closes ROB-81


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paper approval preview section to the preopen dashboard displaying candidate eligibility status with safety and advisory messaging.
  * Shows trading candidate details including execution venue, symbol, and payload preview.
  * Displays blocking reasons and warnings when approval is unavailable.

* **Tests**
  * Added comprehensive test coverage for paper approval bridge functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->