### PR TITLE
feat(ROB-90): normalize Alpaca paper ledger taxonomy

### DIFF
--- a/alembic/versions/d4e5f6a7b8c9_normalize_alpaca_paper_ledger_taxonomy.py
+++ b/alembic/versions/d4e5f6a7b8c9_normalize_alpaca_paper_ledger_taxonomy.py
@@ -1,0 +1,398 @@
+"""Normalize Alpaca Paper ledger taxonomy (ROB-90)
+
+Adds canonical lifecycle states, record_kind, lifecycle_correlation_id,
+leg_role, validation_attempt fields, fee/settlement fields, qty_delta.
+Replaces old lifecycle CHECK and per-order unique constraint with
+partial unique indexes to support multiple rows per order lifecycle.
+
+Revision ID: d4e5f6a7b8c9
+Revises: c1d2e3f4a5b6
+Create Date: 2026-05-03 00:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e5f6a7b8c9"
+down_revision: str | Sequence[str] | None = "c1d2e3f4a5b6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "alpaca_paper_order_ledger"
+_SCHEMA = "review"
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # Step 1: Add new columns (nullable/defaulted first)
+    # ------------------------------------------------------------------
+    # record_kind — NOT NULL with server default 'execution' so existing rows get it.
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            "record_kind",
+            sa.Text(),
+            nullable=False,
+            server_default="execution",
+        ),
+        schema=_SCHEMA,
+    )
+    # lifecycle_correlation_id — add nullable first, then populate, then set NOT NULL.
+    op.add_column(
+        _TABLE,
+        sa.Column("lifecycle_correlation_id", sa.Text(), nullable=True),
+        schema=_SCHEMA,
+    )
+    op.add_column(
+        _TABLE,
+        sa.Column("leg_role", sa.Text(), nullable=True),
+        schema=_SCHEMA,
+    )
+    op.add_column(
+        _TABLE,
+        sa.Column("validation_attempt_no", sa.SmallInteger(), nullable=True),
+        schema=_SCHEMA,
+    )
+    op.add_column(
+        _TABLE,
+        sa.Column("validation_outcome", sa.Text(), nullable=True),
+        schema=_SCHEMA,
+    )
+    op.add_column(
+        _TABLE,
+        sa.Column("confirm_flag", sa.Boolean(), nullable=True),
+        schema=_SCHEMA,
+    )
+    op.add_column(
+        _TABLE,
+        sa.Column("fee_amount", sa.Numeric(20, 4), nullable=True),
+        schema=_SCHEMA,
+    )
+    op.add_column(
+        _TABLE,
+        sa.Column("fee_currency", sa.Text(), nullable=True),
+        schema=_SCHEMA,
+    )
+    op.add_column(
+        _TABLE,
+        sa.Column("settlement_status", sa.Text(), nullable=True),
+        schema=_SCHEMA,
+    )
+    op.add_column(
+        _TABLE,
+        sa.Column(
+            "settlement_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=True,
+        ),
+        schema=_SCHEMA,
+    )
+    op.add_column(
+        _TABLE,
+        sa.Column("qty_delta", sa.Numeric(20, 8), nullable=True),
+        schema=_SCHEMA,
+    )
+
+    # ------------------------------------------------------------------
+    # Step 2: Populate lifecycle_correlation_id from client_order_id
+    # ------------------------------------------------------------------
+    op.execute(
+        f"UPDATE {_SCHEMA}.{_TABLE} "
+        f"SET lifecycle_correlation_id = client_order_id "
+        f"WHERE lifecycle_correlation_id IS NULL"
+    )
+
+    # ------------------------------------------------------------------
+    # Step 3: Compatibility — map old lifecycle states to canonical
+    # ------------------------------------------------------------------
+    # validation_failed → anomaly, record_kind → validation_attempt
+    op.execute(
+        f"UPDATE {_SCHEMA}.{_TABLE} "
+        f"SET lifecycle_state = 'anomaly', "
+        f"    record_kind = 'validation_attempt', "
+        f"    validation_outcome = 'failed', "
+        f"    confirm_flag = false "
+        f"WHERE lifecycle_state = 'validation_failed'"
+    )
+    # open → submitted
+    op.execute(
+        f"UPDATE {_SCHEMA}.{_TABLE} "
+        f"SET lifecycle_state = 'submitted', confirm_flag = true "
+        f"WHERE lifecycle_state = 'open'"
+    )
+    # partially_filled → submitted (broker status preserved in order_status)
+    op.execute(
+        f"UPDATE {_SCHEMA}.{_TABLE} "
+        f"SET lifecycle_state = 'submitted', confirm_flag = true "
+        f"WHERE lifecycle_state = 'partially_filled'"
+    )
+    # canceled → anomaly
+    op.execute(
+        f"UPDATE {_SCHEMA}.{_TABLE} "
+        f"SET lifecycle_state = 'anomaly', confirm_flag = true "
+        f"WHERE lifecycle_state = 'canceled'"
+    )
+    # unexpected → anomaly
+    op.execute(
+        f"UPDATE {_SCHEMA}.{_TABLE} "
+        f"SET lifecycle_state = 'anomaly' "
+        f"WHERE lifecycle_state = 'unexpected'"
+    )
+    # previewed rows with no broker order → record_kind = 'preview'
+    op.execute(
+        f"UPDATE {_SCHEMA}.{_TABLE} "
+        f"SET record_kind = 'preview' "
+        f"WHERE lifecycle_state = 'previewed' AND broker_order_id IS NULL"
+    )
+    # remaining execution rows — set confirm_flag = true
+    op.execute(
+        f"UPDATE {_SCHEMA}.{_TABLE} "
+        f"SET confirm_flag = true "
+        f"WHERE confirm_flag IS NULL AND record_kind = 'execution'"
+    )
+    # settlement_status = 'n_a' for all existing rows
+    op.execute(
+        f"UPDATE {_SCHEMA}.{_TABLE} "
+        f"SET settlement_status = 'n_a' "
+        f"WHERE settlement_status IS NULL"
+    )
+
+    # ------------------------------------------------------------------
+    # Step 4: Make lifecycle_correlation_id NOT NULL
+    # ------------------------------------------------------------------
+    op.alter_column(
+        _TABLE,
+        "lifecycle_correlation_id",
+        nullable=False,
+        schema=_SCHEMA,
+    )
+
+    # ------------------------------------------------------------------
+    # Step 5: Replace old lifecycle CHECK with canonical states
+    # ------------------------------------------------------------------
+    op.drop_constraint(
+        "alpaca_paper_ledger_lifecycle_state",
+        _TABLE,
+        schema=_SCHEMA,
+        type_="check",
+    )
+    op.create_check_constraint(
+        "alpaca_paper_ledger_lifecycle_state",
+        _TABLE,
+        "lifecycle_state IN ("
+        "'planned','previewed','validated','submitted','filled',"
+        "'position_reconciled','sell_validated','closed','final_reconciled','anomaly'"
+        ")",
+        schema=_SCHEMA,
+    )
+
+    # ------------------------------------------------------------------
+    # Step 6: Add new CHECK constraints
+    # ------------------------------------------------------------------
+    op.create_check_constraint(
+        "alpaca_paper_ledger_record_kind",
+        _TABLE,
+        "record_kind IN ('plan','preview','validation_attempt','execution','reconcile','anomaly')",
+        schema=_SCHEMA,
+    )
+    op.create_check_constraint(
+        "alpaca_paper_ledger_validation_outcome",
+        _TABLE,
+        "validation_outcome IN ('passed','failed','skipped','n_a')",
+        schema=_SCHEMA,
+    )
+    op.create_check_constraint(
+        "alpaca_paper_ledger_leg_role",
+        _TABLE,
+        "leg_role IS NULL OR leg_role IN ('buy','sell','roundtrip')",
+        schema=_SCHEMA,
+    )
+    op.create_check_constraint(
+        "alpaca_paper_ledger_settlement_status",
+        _TABLE,
+        "settlement_status IN ('pending','settled','failed','n_a')",
+        schema=_SCHEMA,
+    )
+
+    # ------------------------------------------------------------------
+    # Step 7: Replace old unique constraint with partial unique indexes
+    # ------------------------------------------------------------------
+    op.drop_constraint(
+        "uq_alpaca_paper_ledger_client_order_id",
+        _TABLE,
+        schema=_SCHEMA,
+        type_="unique",
+    )
+    # Non-validation records: unique by (client_order_id, record_kind)
+    op.create_index(
+        "uq_alpaca_paper_ledger_client_order_kind",
+        _TABLE,
+        ["client_order_id", "record_kind"],
+        unique=True,
+        schema=_SCHEMA,
+        postgresql_where="validation_attempt_no IS NULL",
+    )
+    # Validation attempts: unique by (correlation_id, side, attempt_no)
+    op.create_index(
+        "uq_alpaca_paper_ledger_validation_attempt",
+        _TABLE,
+        ["lifecycle_correlation_id", "side", "validation_attempt_no"],
+        unique=True,
+        schema=_SCHEMA,
+        postgresql_where="record_kind = 'validation_attempt'",
+    )
+
+    # ------------------------------------------------------------------
+    # Step 8: Add new regular indexes
+    # ------------------------------------------------------------------
+    op.create_index(
+        "ix_alpaca_paper_ledger_correlation_id",
+        _TABLE,
+        ["lifecycle_correlation_id"],
+        schema=_SCHEMA,
+    )
+    op.create_index(
+        "ix_alpaca_paper_ledger_record_kind",
+        _TABLE,
+        ["record_kind"],
+        schema=_SCHEMA,
+    )
+
+
+def downgrade() -> None:
+    # ------------------------------------------------------------------
+    # Drop new indexes before normalizing rows back to the ROB-84 shape.
+    # ------------------------------------------------------------------
+    op.drop_index(
+        "ix_alpaca_paper_ledger_record_kind",
+        table_name=_TABLE,
+        schema=_SCHEMA,
+    )
+    op.drop_index(
+        "ix_alpaca_paper_ledger_correlation_id",
+        table_name=_TABLE,
+        schema=_SCHEMA,
+    )
+    op.drop_index(
+        "uq_alpaca_paper_ledger_validation_attempt",
+        table_name=_TABLE,
+        schema=_SCHEMA,
+    )
+    op.drop_index(
+        "uq_alpaca_paper_ledger_client_order_kind",
+        table_name=_TABLE,
+        schema=_SCHEMA,
+    )
+
+    # ------------------------------------------------------------------
+    # Drop ROB-90 CHECK constraints, then map canonical states back to the
+    # ROB-84 state vocabulary before restoring the old lifecycle CHECK.
+    # ------------------------------------------------------------------
+    op.drop_constraint(
+        "alpaca_paper_ledger_settlement_status",
+        _TABLE,
+        schema=_SCHEMA,
+        type_="check",
+    )
+    op.drop_constraint(
+        "alpaca_paper_ledger_leg_role",
+        _TABLE,
+        schema=_SCHEMA,
+        type_="check",
+    )
+    op.drop_constraint(
+        "alpaca_paper_ledger_validation_outcome",
+        _TABLE,
+        schema=_SCHEMA,
+        type_="check",
+    )
+    op.drop_constraint(
+        "alpaca_paper_ledger_record_kind",
+        _TABLE,
+        schema=_SCHEMA,
+        type_="check",
+    )
+    op.drop_constraint(
+        "alpaca_paper_ledger_lifecycle_state",
+        _TABLE,
+        schema=_SCHEMA,
+        type_="check",
+    )
+
+    op.execute(
+        f"UPDATE {_SCHEMA}.{_TABLE} "
+        f"SET lifecycle_state = CASE "
+        f"WHEN lifecycle_state = 'planned' THEN 'previewed' "
+        f"WHEN lifecycle_state = 'validated' THEN 'submitted' "
+        f"WHEN lifecycle_state = 'position_reconciled' THEN 'filled' "
+        f"WHEN lifecycle_state = 'sell_validated' THEN 'submitted' "
+        f"WHEN lifecycle_state = 'closed' THEN 'filled' "
+        f"WHEN lifecycle_state = 'final_reconciled' THEN 'filled' "
+        f"WHEN lifecycle_state = 'anomaly' AND validation_outcome = 'failed' "
+        f"THEN 'validation_failed' "
+        f"WHEN lifecycle_state = 'anomaly' THEN 'unexpected' "
+        f"ELSE lifecycle_state END"
+    )
+
+    op.create_check_constraint(
+        "alpaca_paper_ledger_lifecycle_state",
+        _TABLE,
+        "lifecycle_state IN ("
+        "'previewed','validation_failed','submitted','open',"
+        "'partially_filled','filled','canceled','unexpected'"
+        ")",
+        schema=_SCHEMA,
+    )
+
+    # ROB-90 permits multiple record kinds per client_order_id. ROB-84 did not.
+    # Preserve rows on downgrade by suffixing duplicate keys before restoring the
+    # legacy unique constraint.
+    op.execute(
+        f"WITH ranked AS ("
+        f"  SELECT id, client_order_id, "
+        f"         row_number() OVER ("
+        f"           PARTITION BY client_order_id "
+        f"           ORDER BY CASE record_kind "
+        f"             WHEN 'execution' THEN 0 "
+        f"             WHEN 'preview' THEN 1 "
+        f"             WHEN 'plan' THEN 2 "
+        f"             WHEN 'validation_attempt' THEN 3 "
+        f"             WHEN 'reconcile' THEN 4 "
+        f"             ELSE 5 END, id"
+        f"         ) AS rn "
+        f"  FROM {_SCHEMA}.{_TABLE}"
+        f") "
+        f"UPDATE {_SCHEMA}.{_TABLE} AS ledger "
+        f"SET client_order_id = ranked.client_order_id || '-legacy-' || ranked.id::text "
+        f"FROM ranked "
+        f"WHERE ledger.id = ranked.id AND ranked.rn > 1"
+    )
+
+    op.create_unique_constraint(
+        "uq_alpaca_paper_ledger_client_order_id",
+        _TABLE,
+        ["client_order_id"],
+        schema=_SCHEMA,
+    )
+
+    # ------------------------------------------------------------------
+    # Drop added columns
+    # ------------------------------------------------------------------
+    for col in [
+        "qty_delta",
+        "settlement_at",
+        "settlement_status",
+        "fee_currency",
+        "fee_amount",
+        "confirm_flag",
+        "validation_outcome",
+        "validation_attempt_no",
+        "leg_role",
+        "lifecycle_correlation_id",
+        "record_kind",
+    ]:
+        op.drop_column(_TABLE, col, schema=_SCHEMA)

--- a/app/mcp_server/tooling/alpaca_paper.py
+++ b/app/mcp_server/tooling/alpaca_paper.py
@@ -27,9 +27,10 @@ ALPACA_PAPER_READONLY_TOOL_NAMES: set[str] = {
     "alpaca_paper_get_order",
     "alpaca_paper_list_assets",
     "alpaca_paper_list_fills",
-    # ROB-84/ROB-93 ledger read and anomaly preflight tools
+    # ROB-84/ROB-90/ROB-93 ledger read and anomaly preflight tools
     "alpaca_paper_ledger_list_recent",
     "alpaca_paper_ledger_get",
+    "alpaca_paper_ledger_get_by_correlation",
     "alpaca_paper_execution_preflight_check",
 }
 

--- a/app/mcp_server/tooling/alpaca_paper_ledger_read.py
+++ b/app/mcp_server/tooling/alpaca_paper_ledger_read.py
@@ -1,4 +1,4 @@
-"""Read-only MCP tools for the Alpaca Paper order ledger (ROB-84).
+"""Read-only MCP tools for the Alpaca Paper order ledger (ROB-84/ROB-90).
 
 No broker mutation. No submit/cancel/replace. Pure record-keeping reads.
 """
@@ -47,8 +47,9 @@ async def alpaca_paper_ledger_list_recent(
 
     Args:
         limit: Maximum number of rows to return (default 50, max 200).
-        lifecycle_state: Optional filter — one of previewed, validation_failed,
-            submitted, open, partially_filled, filled, canceled, unexpected.
+        lifecycle_state: Optional filter — one of the ROB-90 canonical states:
+            planned, previewed, validated, submitted, filled,
+            position_reconciled, sell_validated, closed, final_reconciled, anomaly.
     """
     if limit < 1:
         raise ValueError("limit must be >= 1")
@@ -151,13 +152,42 @@ async def alpaca_paper_execution_preflight_check(
     return data
 
 
+async def alpaca_paper_ledger_get_by_correlation(
+    lifecycle_correlation_id: str,
+) -> dict[str, Any]:
+    """Fetch all Alpaca Paper ledger rows sharing a lifecycle_correlation_id (read-only).
+
+    Returns the buy/sell roundtrip records in chronological order.
+    lifecycle_correlation_id links buy and sell legs of the same paper roundtrip.
+    """
+    if not lifecycle_correlation_id or not lifecycle_correlation_id.strip():
+        raise ValueError("lifecycle_correlation_id is required")
+
+    async with _session_factory()() as db:
+        svc = AlpacaPaperLedgerService(db)
+        rows = await svc.list_by_correlation_id(lifecycle_correlation_id.strip())
+
+    items = [_row_to_dict(r) for r in rows]
+    return {
+        "success": True,
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper_ledger",
+        "lifecycle_correlation_id": lifecycle_correlation_id,
+        "count": len(items),
+        "items": items,
+    }
+
+
 def register_alpaca_paper_ledger_read_tools(mcp: FastMCP) -> None:
     """Register read-only Alpaca Paper ledger MCP tools."""
     _ = mcp.tool(
         name="alpaca_paper_ledger_list_recent",
         description=(
             "Read-only list of recent Alpaca Paper order ledger entries. "
-            "Supports optional lifecycle_state filter and limit. No broker mutation."
+            "Supports optional lifecycle_state filter (ROB-90 canonical states: "
+            "planned, previewed, validated, submitted, filled, position_reconciled, "
+            "sell_validated, closed, final_reconciled, anomaly) and limit. "
+            "No broker mutation."
         ),
     )(alpaca_paper_ledger_list_recent)
     _ = mcp.tool(
@@ -175,11 +205,20 @@ def register_alpaca_paper_ledger_read_tools(mcp: FastMCP) -> None:
             "No broker mutation and no repair writes."
         ),
     )(alpaca_paper_execution_preflight_check)
+    _ = mcp.tool(
+        name="alpaca_paper_ledger_get_by_correlation",
+        description=(
+            "Read-only fetch of all Alpaca Paper ledger rows sharing a "
+            "lifecycle_correlation_id. Returns the full buy/sell roundtrip records "
+            "in chronological order. No broker mutation."
+        ),
+    )(alpaca_paper_ledger_get_by_correlation)
 
 
 __all__ = [
     "alpaca_paper_execution_preflight_check",
     "alpaca_paper_ledger_get",
+    "alpaca_paper_ledger_get_by_correlation",
     "alpaca_paper_ledger_list_recent",
     "register_alpaca_paper_ledger_read_tools",
 ]

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from sqlalchemy import (
     TIMESTAMP,
     BigInteger,
+    Boolean,
     CheckConstraint,
     Enum,
     ForeignKey,
@@ -21,7 +22,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 from sqlalchemy.orm import Mapped, mapped_column
-from sqlalchemy.sql import func
+from sqlalchemy.sql import func, text
 
 from app.models.base import Base
 from app.models.trading import InstrumentType
@@ -231,16 +232,31 @@ class KISMockOrderLedger(Base):
 
 
 # ---------------------------------------------------------------------------
-# review.alpaca_paper_order_ledger — Alpaca Paper execution lifecycle ledger (ROB-84)
-# Records preview → validation → submit → status/fill → cancel → position → reconcile.
+# review.alpaca_paper_order_ledger — Alpaca Paper execution lifecycle ledger (ROB-84/ROB-90)
+# Records plan → preview → validation → submit → fill → position → close → final reconcile.
 # Fully isolated from live trade paths and review.trades.
 # All writes must go through AlpacaPaperLedgerService. No direct SQL writes.
 # ---------------------------------------------------------------------------
 class AlpacaPaperOrderLedger(Base):
     __tablename__ = "alpaca_paper_order_ledger"
     __table_args__ = (
-        UniqueConstraint(
-            "client_order_id", name="uq_alpaca_paper_ledger_client_order_id"
+        # ROB-90: partial unique indexes replace the old single-column unique constraint.
+        # Non-validation records are unique by (client_order_id, record_kind).
+        Index(
+            "uq_alpaca_paper_ledger_client_order_kind",
+            "client_order_id",
+            "record_kind",
+            unique=True,
+            postgresql_where=text("validation_attempt_no IS NULL"),
+        ),
+        # Validation attempts are unique by (correlation_id, side, attempt_no).
+        Index(
+            "uq_alpaca_paper_ledger_validation_attempt",
+            "lifecycle_correlation_id",
+            "side",
+            "validation_attempt_no",
+            unique=True,
+            postgresql_where=text("record_kind = 'validation_attempt'"),
         ),
         CheckConstraint("broker = 'alpaca'", name="alpaca_paper_ledger_broker"),
         CheckConstraint(
@@ -248,8 +264,8 @@ class AlpacaPaperOrderLedger(Base):
         ),
         CheckConstraint(
             "lifecycle_state IN ("
-            "'previewed','validation_failed','submitted','open',"
-            "'partially_filled','filled','canceled','unexpected'"
+            "'planned','previewed','validated','submitted','filled',"
+            "'position_reconciled','sell_validated','closed','final_reconciled','anomaly'"
             ")",
             name="alpaca_paper_ledger_lifecycle_state",
         ),
@@ -260,6 +276,22 @@ class AlpacaPaperOrderLedger(Base):
         CheckConstraint(
             "currency IN ('USD','KRW')", name="alpaca_paper_ledger_currency"
         ),
+        CheckConstraint(
+            "record_kind IN ('plan','preview','validation_attempt','execution','reconcile','anomaly')",
+            name="alpaca_paper_ledger_record_kind",
+        ),
+        CheckConstraint(
+            "validation_outcome IN ('passed','failed','skipped','n_a')",
+            name="alpaca_paper_ledger_validation_outcome",
+        ),
+        CheckConstraint(
+            "leg_role IS NULL OR leg_role IN ('buy','sell','roundtrip')",
+            name="alpaca_paper_ledger_leg_role",
+        ),
+        CheckConstraint(
+            "settlement_status IN ('pending','settled','failed','n_a')",
+            name="alpaca_paper_ledger_settlement_status",
+        ),
         Index("ix_alpaca_paper_ledger_broker_order_id", "broker_order_id"),
         Index("ix_alpaca_paper_ledger_lifecycle_state", "lifecycle_state"),
         Index("ix_alpaca_paper_ledger_created_at", "created_at"),
@@ -269,13 +301,22 @@ class AlpacaPaperOrderLedger(Base):
             "briefing_artifact_run_uuid",
         ),
         Index("ix_alpaca_paper_ledger_execution_symbol", "execution_symbol"),
+        Index("ix_alpaca_paper_ledger_correlation_id", "lifecycle_correlation_id"),
+        Index("ix_alpaca_paper_ledger_record_kind", "record_kind"),
         {"schema": "review"},
     )
 
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
-    # Correlation key
+    # Correlation key (per order leg)
     client_order_id: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # ROB-90: cross-leg correlation — buy and sell legs share this value.
+    # Defaults to client_order_id for backwards compatibility.
+    lifecycle_correlation_id: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # ROB-90: record type — distinguishes plan/preview/validation/execution/reconcile rows.
+    record_kind: Mapped[str] = mapped_column(Text, nullable=False, default="execution")
 
     # Broker/mode identity — pinned, never live
     broker: Mapped[str] = mapped_column(Text, nullable=False, default="alpaca")
@@ -283,8 +324,27 @@ class AlpacaPaperOrderLedger(Base):
         Text, nullable=False, default="alpaca_paper"
     )
 
-    # Application lifecycle state
+    # Application lifecycle state (ROB-90 canonical)
     lifecycle_state: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # ROB-90: buy/sell leg role — separate from broker `side` (order direction).
+    leg_role: Mapped[str | None] = mapped_column(Text)
+
+    # ROB-90: validation attempt tracking
+    validation_attempt_no: Mapped[int | None] = mapped_column(SmallInteger)
+    validation_outcome: Mapped[str | None] = mapped_column(Text)
+
+    # ROB-90: confirm flag — false=validation-only, true=executed, null=plan/preview
+    confirm_flag: Mapped[bool | None] = mapped_column(Boolean)
+
+    # ROB-90: fee/settlement
+    fee_amount: Mapped[float | None] = mapped_column(Numeric(20, 4))
+    fee_currency: Mapped[str | None] = mapped_column(Text)
+    settlement_status: Mapped[str | None] = mapped_column(Text)
+    settlement_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+
+    # ROB-90: signed quantity effect (buy positive, sell negative, preview/validation null)
+    qty_delta: Mapped[float | None] = mapped_column(Numeric(20, 8))
 
     # Signal provenance (kept separate from execution)
     signal_symbol: Mapped[str | None] = mapped_column(Text)

--- a/app/routers/alpaca_paper_ledger.py
+++ b/app/routers/alpaca_paper_ledger.py
@@ -1,4 +1,4 @@
-"""Read-only Alpaca Paper order ledger router (ROB-84).
+"""Read-only Alpaca Paper order ledger router (ROB-84/ROB-90).
 
 GET paths only. No POST/PATCH/DELETE. No broker mutation.
 """
@@ -14,6 +14,7 @@ from app.core.db import get_db
 from app.models.trading import User
 from app.routers.dependencies import get_authenticated_user
 from app.schemas.alpaca_paper_ledger import (
+    AlpacaPaperOrderLedgerCorrelationResponse,
     AlpacaPaperOrderLedgerListResponse,
     AlpacaPaperOrderLedgerRead,
 )
@@ -35,6 +36,25 @@ async def list_recent_ledger_entries(
     svc = AlpacaPaperLedgerService(db)
     rows = await svc.list_recent(limit=limit, lifecycle_state=lifecycle_state)
     return AlpacaPaperOrderLedgerListResponse(
+        count=len(rows),
+        items=[AlpacaPaperOrderLedgerRead.model_validate(r) for r in rows],
+    )
+
+
+@router.get(
+    "/api/alpaca-paper/ledger/by-correlation-id/{lifecycle_correlation_id}",
+    response_model=AlpacaPaperOrderLedgerCorrelationResponse,
+)
+async def get_ledger_by_correlation_id(
+    lifecycle_correlation_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+) -> AlpacaPaperOrderLedgerCorrelationResponse:
+    """Return all ledger rows sharing a lifecycle_correlation_id (buy/sell roundtrip)."""
+    svc = AlpacaPaperLedgerService(db)
+    rows = await svc.list_by_correlation_id(lifecycle_correlation_id)
+    return AlpacaPaperOrderLedgerCorrelationResponse(
+        lifecycle_correlation_id=lifecycle_correlation_id,
         count=len(rows),
         items=[AlpacaPaperOrderLedgerRead.model_validate(r) for r in rows],
     )

--- a/app/schemas/alpaca_paper_ledger.py
+++ b/app/schemas/alpaca_paper_ledger.py
@@ -1,4 +1,4 @@
-"""Pydantic read schemas for the Alpaca Paper order ledger (ROB-84)."""
+"""Pydantic read schemas for the Alpaca Paper order ledger (ROB-84/ROB-90)."""
 
 from __future__ import annotations
 
@@ -18,6 +18,19 @@ class AlpacaPaperOrderLedgerRead(BaseModel):
     broker: str
     account_mode: str
     lifecycle_state: str
+
+    # ROB-90 taxonomy fields
+    lifecycle_correlation_id: str
+    record_kind: str
+    leg_role: str | None = None
+    validation_attempt_no: int | None = None
+    validation_outcome: str | None = None
+    confirm_flag: bool | None = None
+    fee_amount: Decimal | None = None
+    fee_currency: str | None = None
+    settlement_status: str | None = None
+    settlement_at: datetime | None = None
+    qty_delta: Decimal | None = None
 
     signal_symbol: str | None = None
     signal_venue: str | None = None
@@ -70,7 +83,16 @@ class AlpacaPaperOrderLedgerListResponse(BaseModel):
     items: list[AlpacaPaperOrderLedgerRead]
 
 
+class AlpacaPaperOrderLedgerCorrelationResponse(BaseModel):
+    """Grouped response for all records sharing a lifecycle_correlation_id."""
+
+    lifecycle_correlation_id: str
+    count: int
+    items: list[AlpacaPaperOrderLedgerRead]
+
+
 __all__ = [
+    "AlpacaPaperOrderLedgerCorrelationResponse",
     "AlpacaPaperOrderLedgerListResponse",
     "AlpacaPaperOrderLedgerRead",
 ]

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -1,4 +1,4 @@
-"""Alpaca Paper execution state ledger service (ROB-84).
+"""Alpaca Paper execution state ledger service (ROB-84/ROB-90).
 
 Pure record-keeping only. Must not import or call broker mutation services,
 KIS, Upbit, watch alerts, order intents, or scheduler code.
@@ -14,7 +14,7 @@ from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import select, update
+from sqlalchemy import select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -25,6 +25,43 @@ from app.schemas.preopen import (
     PreopenPaperApprovalBridge,
     PreopenPaperApprovalCandidate,
 )
+
+# ---------------------------------------------------------------------------
+# ROB-90 canonical lifecycle state constants
+# ---------------------------------------------------------------------------
+LIFECYCLE_PLANNED = "planned"
+LIFECYCLE_PREVIEWED = "previewed"
+LIFECYCLE_VALIDATED = "validated"
+LIFECYCLE_SUBMITTED = "submitted"
+LIFECYCLE_FILLED = "filled"
+LIFECYCLE_POSITION_RECONCILED = "position_reconciled"
+LIFECYCLE_SELL_VALIDATED = "sell_validated"
+LIFECYCLE_CLOSED = "closed"
+LIFECYCLE_FINAL_RECONCILED = "final_reconciled"
+LIFECYCLE_ANOMALY = "anomaly"
+
+CANONICAL_LIFECYCLE_STATES: frozenset[str] = frozenset(
+    {
+        LIFECYCLE_PLANNED,
+        LIFECYCLE_PREVIEWED,
+        LIFECYCLE_VALIDATED,
+        LIFECYCLE_SUBMITTED,
+        LIFECYCLE_FILLED,
+        LIFECYCLE_POSITION_RECONCILED,
+        LIFECYCLE_SELL_VALIDATED,
+        LIFECYCLE_CLOSED,
+        LIFECYCLE_FINAL_RECONCILED,
+        LIFECYCLE_ANOMALY,
+    }
+)
+
+# ROB-90 record_kind constants
+RECORD_KIND_PLAN = "plan"
+RECORD_KIND_PREVIEW = "preview"
+RECORD_KIND_VALIDATION_ATTEMPT = "validation_attempt"
+RECORD_KIND_EXECUTION = "execution"
+RECORD_KIND_RECONCILE = "reconcile"
+RECORD_KIND_ANOMALY = "anomaly"
 
 # ---------------------------------------------------------------------------
 # Sensitive key patterns — redact before any JSON persistence
@@ -76,7 +113,7 @@ def _redact_sensitive_text(text: str | None) -> str | None:
 
 
 # ---------------------------------------------------------------------------
-# Lifecycle state derivation from broker order status
+# Lifecycle state derivation from broker order status (ROB-90 canonical)
 # ---------------------------------------------------------------------------
 _OPEN_STATUSES = frozenset(
     {
@@ -93,35 +130,42 @@ _OPEN_STATUSES = frozenset(
         "calculated",
     }
 )
-_UNEXPECTED_STATUSES = frozenset({"rejected", "expired", "suspended"})
+_ANOMALY_STATUSES = frozenset({"rejected", "expired", "suspended"})
 
 
 def _derive_lifecycle_state(
     order_status: str | None,
     filled_qty: Decimal | float | None = None,
 ) -> str:
+    """Map broker order_status to ROB-90 canonical lifecycle state.
+
+    Mapping:
+    - filled → filled
+    - partially_filled → submitted (broker status preserved in order_status)
+    - open statuses (new/accepted/…) → submitted
+    - open status with filled_qty > 0 → anomaly
+    - canceled → anomaly (ROB-90: no benign cancel state)
+    - rejected/expired/suspended/unknown → anomaly
+    """
     if order_status is None:
-        return "unexpected"
+        return LIFECYCLE_ANOMALY
     status = order_status.lower()
-    if status == "canceled":
-        return "canceled"
     if status == "filled":
-        return "filled"
+        return LIFECYCLE_FILLED
     if status == "partially_filled":
-        return "partially_filled"
+        return LIFECYCLE_SUBMITTED
     if status in _OPEN_STATUSES:
-        # If there is nonzero filled qty with an open status, treat as unexpected
         if filled_qty is not None:
             try:
                 qty = float(filled_qty)
             except (TypeError, ValueError):
                 qty = 0.0
             if qty > 0:
-                return "unexpected"
-        return "open"
-    if status in _UNEXPECTED_STATUSES:
-        return "unexpected"
-    return "unexpected"
+                return LIFECYCLE_ANOMALY
+        return LIFECYCLE_SUBMITTED
+    if status in _ANOMALY_STATUSES or status == "canceled":
+        return LIFECYCLE_ANOMALY
+    return LIFECYCLE_ANOMALY
 
 
 # ---------------------------------------------------------------------------
@@ -201,8 +245,14 @@ class AlpacaPaperLedgerService:
     async def get_by_client_order_id(
         self, client_order_id: str
     ) -> AlpacaPaperOrderLedger | None:
-        stmt = select(AlpacaPaperOrderLedger).where(
-            AlpacaPaperOrderLedger.client_order_id == client_order_id
+        stmt = (
+            select(AlpacaPaperOrderLedger)
+            .where(AlpacaPaperOrderLedger.client_order_id == client_order_id)
+            .order_by(
+                AlpacaPaperOrderLedger.created_at.desc(),
+                AlpacaPaperOrderLedger.id.desc(),
+            )
+            .limit(1)
         )
         result = await self._db.execute(stmt)
         return result.scalar_one_or_none()
@@ -225,6 +275,27 @@ class AlpacaPaperLedgerService:
         if lifecycle_state is not None:
             stmt = stmt.where(AlpacaPaperOrderLedger.lifecycle_state == lifecycle_state)
         stmt = stmt.limit(limit)
+        result = await self._db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def list_by_correlation_id(
+        self,
+        lifecycle_correlation_id: str,
+    ) -> list[AlpacaPaperOrderLedger]:
+        """Return all ledger rows sharing a lifecycle_correlation_id, ordered by created_at, id."""
+        if not lifecycle_correlation_id or not lifecycle_correlation_id.strip():
+            raise ValueError("lifecycle_correlation_id must not be empty")
+        stmt = (
+            select(AlpacaPaperOrderLedger)
+            .where(
+                AlpacaPaperOrderLedger.lifecycle_correlation_id
+                == lifecycle_correlation_id
+            )
+            .order_by(
+                AlpacaPaperOrderLedger.created_at.asc(),
+                AlpacaPaperOrderLedger.id.asc(),
+            )
+        )
         result = await self._db.execute(stmt)
         return list(result.scalars().all())
 
@@ -259,18 +330,101 @@ class AlpacaPaperLedgerService:
         existing[target_key] = sanitized
         await self._db.execute(
             update(AlpacaPaperOrderLedger)
-            .where(AlpacaPaperOrderLedger.client_order_id == client_order_id)
+            .where(AlpacaPaperOrderLedger.id == row.id)
             .values(raw_responses=existing)
         )
+
+    def _build_provenance_values(self, prov: ApprovalProvenance) -> dict[str, Any]:
+        return {
+            "signal_symbol": prov.signal_symbol,
+            "signal_venue": prov.signal_venue,
+            "execution_asset_class": prov.execution_asset_class,
+            "workflow_stage": prov.workflow_stage,
+            "purpose": prov.purpose,
+            "briefing_artifact_run_uuid": prov.briefing_artifact_run_uuid,
+            "briefing_artifact_status": prov.briefing_artifact_status,
+            "qa_evaluator_status": prov.qa_evaluator_status,
+            "approval_bridge_generated_at": prov.approval_bridge_generated_at,
+            "approval_bridge_status": prov.approval_bridge_status,
+            "candidate_uuid": prov.candidate_uuid,
+        }
 
     # ------------------------------------------------------------------
     # Lifecycle write methods
     # ------------------------------------------------------------------
 
+    async def record_plan(
+        self,
+        *,
+        client_order_id: str,
+        lifecycle_correlation_id: str | None = None,
+        execution_symbol: str,
+        execution_venue: str,
+        instrument_type: InstrumentType,
+        side: str,
+        order_type: str = "limit",
+        time_in_force: str | None = None,
+        requested_qty: Decimal | float | None = None,
+        requested_notional: Decimal | float | None = None,
+        requested_price: Decimal | float | None = None,
+        currency: str = "USD",
+        leg_role: str | None = None,
+        provenance: ApprovalProvenance | None = None,
+        notes: str | None = None,
+    ) -> AlpacaPaperOrderLedger:
+        """Insert a planned row (lifecycle_state='planned', record_kind='plan')."""
+        if not client_order_id or not client_order_id.strip():
+            raise ValueError("client_order_id must not be empty")
+
+        prov = provenance or ApprovalProvenance()
+        correlation_id = lifecycle_correlation_id or client_order_id
+
+        values: dict[str, Any] = {
+            "client_order_id": client_order_id,
+            "lifecycle_correlation_id": correlation_id,
+            "record_kind": RECORD_KIND_PLAN,
+            "broker": "alpaca",
+            "account_mode": "alpaca_paper",
+            "lifecycle_state": LIFECYCLE_PLANNED,
+            "execution_symbol": execution_symbol,
+            "execution_venue": execution_venue,
+            "instrument_type": instrument_type,
+            "side": side,
+            "order_type": order_type,
+            "time_in_force": time_in_force,
+            "requested_qty": requested_qty,
+            "requested_notional": requested_notional,
+            "requested_price": requested_price,
+            "currency": currency,
+            "leg_role": leg_role,
+            "confirm_flag": None,
+            "notes": _redact_sensitive_text(notes),
+            **self._build_provenance_values(prov),
+        }
+
+        stmt = (
+            pg_insert(AlpacaPaperOrderLedger)
+            .values(**values)
+            .on_conflict_do_nothing(
+                index_elements=["client_order_id", "record_kind"],
+                index_where=text("validation_attempt_no IS NULL"),
+            )
+        )
+        await self._db.execute(stmt)
+        await self._db.commit()
+
+        row = await self.get_by_client_order_id(client_order_id)
+        if row is None:
+            raise LedgerNotFoundError(
+                f"No ledger row found for client_order_id={client_order_id!r}"
+            )
+        return row
+
     async def record_preview(
         self,
         *,
         client_order_id: str,
+        lifecycle_correlation_id: str | None = None,
         execution_symbol: str,
         execution_venue: str,
         instrument_type: InstrumentType,
@@ -283,15 +437,17 @@ class AlpacaPaperLedgerService:
         currency: str = "USD",
         preview_payload: dict[str, Any] | None = None,
         validation_summary: dict[str, Any] | None = None,
-        lifecycle_state: str = "previewed",
+        lifecycle_state: str = LIFECYCLE_PREVIEWED,
+        leg_role: str | None = None,
         provenance: ApprovalProvenance | None = None,
         raw_response: dict[str, Any] | None = None,
     ) -> AlpacaPaperOrderLedger:
-        """Insert a previewed row; idempotent on duplicate client_order_id."""
+        """Insert a preview row (record_kind='preview'); idempotent on duplicate."""
         if not client_order_id or not client_order_id.strip():
             raise ValueError("client_order_id must not be empty")
 
         prov = provenance or ApprovalProvenance()
+        correlation_id = lifecycle_correlation_id or client_order_id
         sanitized_preview = (
             _redact_sensitive_keys(preview_payload) if preview_payload else None
         )
@@ -304,6 +460,8 @@ class AlpacaPaperLedgerService:
 
         values: dict[str, Any] = {
             "client_order_id": client_order_id,
+            "lifecycle_correlation_id": correlation_id,
+            "record_kind": RECORD_KIND_PREVIEW,
             "broker": "alpaca",
             "account_mode": "alpaca_paper",
             "lifecycle_state": lifecycle_state,
@@ -319,29 +477,120 @@ class AlpacaPaperLedgerService:
             "currency": currency,
             "preview_payload": sanitized_preview,
             "validation_summary": sanitized_validation,
-            "signal_symbol": prov.signal_symbol,
-            "signal_venue": prov.signal_venue,
-            "execution_asset_class": prov.execution_asset_class,
-            "workflow_stage": prov.workflow_stage,
-            "purpose": prov.purpose,
-            "briefing_artifact_run_uuid": prov.briefing_artifact_run_uuid,
-            "briefing_artifact_status": prov.briefing_artifact_status,
-            "qa_evaluator_status": prov.qa_evaluator_status,
-            "approval_bridge_generated_at": prov.approval_bridge_generated_at,
-            "approval_bridge_status": prov.approval_bridge_status,
-            "candidate_uuid": prov.candidate_uuid,
+            "leg_role": leg_role,
+            "confirm_flag": None,
             "raw_responses": initial_raw if initial_raw else None,
+            **self._build_provenance_values(prov),
         }
 
         stmt = (
             pg_insert(AlpacaPaperOrderLedger)
             .values(**values)
-            .on_conflict_do_nothing(constraint="uq_alpaca_paper_ledger_client_order_id")
+            .on_conflict_do_nothing(
+                index_elements=["client_order_id", "record_kind"],
+                index_where=text("validation_attempt_no IS NULL"),
+            )
         )
         await self._db.execute(stmt)
         await self._db.commit()
 
         return await self._require_row(client_order_id)
+
+    async def record_validation_attempt(
+        self,
+        *,
+        client_order_id: str,
+        lifecycle_correlation_id: str | None = None,
+        execution_symbol: str,
+        execution_venue: str,
+        instrument_type: InstrumentType,
+        side: str,
+        order_type: str = "limit",
+        time_in_force: str | None = None,
+        requested_qty: Decimal | float | None = None,
+        requested_notional: Decimal | float | None = None,
+        requested_price: Decimal | float | None = None,
+        currency: str = "USD",
+        validation_attempt_no: int = 1,
+        validation_outcome: str = "failed",
+        validation_summary: dict[str, Any] | None = None,
+        leg_role: str | None = None,
+        provenance: ApprovalProvenance | None = None,
+        raw_response: dict[str, Any] | None = None,
+    ) -> AlpacaPaperOrderLedger:
+        """Insert a validation attempt row (confirm=false).
+
+        Each attempt is distinguished by validation_attempt_no.
+        lifecycle_state is set to 'validated' for passed, 'anomaly' for failed.
+        """
+        if not client_order_id or not client_order_id.strip():
+            raise ValueError("client_order_id must not be empty")
+        if validation_attempt_no < 1:
+            raise ValueError("validation_attempt_no must be >= 1")
+
+        prov = provenance or ApprovalProvenance()
+        correlation_id = lifecycle_correlation_id or client_order_id
+        sanitized_validation = (
+            _redact_sensitive_keys(validation_summary) if validation_summary else None
+        )
+        initial_raw: dict[str, Any] = {}
+        if raw_response is not None:
+            initial_raw[f"validation_{validation_attempt_no}"] = _redact_sensitive_keys(
+                raw_response
+            )
+
+        if validation_outcome == "passed":
+            lc_state = LIFECYCLE_VALIDATED
+        else:
+            lc_state = LIFECYCLE_ANOMALY
+
+        values: dict[str, Any] = {
+            "client_order_id": client_order_id,
+            "lifecycle_correlation_id": correlation_id,
+            "record_kind": RECORD_KIND_VALIDATION_ATTEMPT,
+            "broker": "alpaca",
+            "account_mode": "alpaca_paper",
+            "lifecycle_state": lc_state,
+            "execution_symbol": execution_symbol,
+            "execution_venue": execution_venue,
+            "instrument_type": instrument_type,
+            "side": side,
+            "order_type": order_type,
+            "time_in_force": time_in_force,
+            "requested_qty": requested_qty,
+            "requested_notional": requested_notional,
+            "requested_price": requested_price,
+            "currency": currency,
+            "validation_attempt_no": validation_attempt_no,
+            "validation_outcome": validation_outcome,
+            "validation_summary": sanitized_validation,
+            "leg_role": leg_role,
+            "confirm_flag": False,
+            "raw_responses": initial_raw if initial_raw else None,
+            **self._build_provenance_values(prov),
+        }
+
+        stmt = (
+            pg_insert(AlpacaPaperOrderLedger)
+            .values(**values)
+            .on_conflict_do_nothing(
+                index_elements=[
+                    "lifecycle_correlation_id",
+                    "side",
+                    "validation_attempt_no",
+                ],
+                index_where=text("record_kind = 'validation_attempt'"),
+            )
+        )
+        await self._db.execute(stmt)
+        await self._db.commit()
+
+        row = await self.get_by_client_order_id(client_order_id)
+        if row is None:
+            raise LedgerNotFoundError(
+                f"No ledger row found for client_order_id={client_order_id!r}"
+            )
+        return row
 
     async def record_submit(
         self,
@@ -349,8 +598,8 @@ class AlpacaPaperLedgerService:
         order: dict[str, Any],
         raw_response: dict[str, Any] | None = None,
     ) -> AlpacaPaperOrderLedger:
-        """Update with broker order id, status, and filled quantities after submit."""
-        await self._require_row(client_order_id)
+        """Record a confirmed submit as a distinct execution row."""
+        source_row = await self._require_row(client_order_id)
 
         broker_order_id = (
             order.get("id") or order.get("order_id") or order.get("broker_order_id")
@@ -376,29 +625,70 @@ class AlpacaPaperLedgerService:
                 filled_avg_price = None
 
         lifecycle_state = _derive_lifecycle_state(order_status, filled_qty)
+        raw_responses = None
+        if raw_response is not None:
+            raw_responses = {"submit": _redact_sensitive_keys(raw_response)}
 
-        update_vals: dict[str, Any] = {
+        values: dict[str, Any] = {
+            "client_order_id": client_order_id,
+            "lifecycle_correlation_id": source_row.lifecycle_correlation_id
+            or client_order_id,
+            "record_kind": RECORD_KIND_EXECUTION,
+            "broker": "alpaca",
+            "account_mode": "alpaca_paper",
             "lifecycle_state": lifecycle_state,
+            "execution_symbol": source_row.execution_symbol,
+            "execution_venue": source_row.execution_venue,
+            "instrument_type": source_row.instrument_type,
+            "side": source_row.side,
+            "order_type": source_row.order_type,
+            "time_in_force": source_row.time_in_force,
+            "requested_qty": source_row.requested_qty,
+            "requested_notional": source_row.requested_notional,
+            "requested_price": source_row.requested_price,
+            "currency": source_row.currency,
+            "leg_role": source_row.leg_role,
+            "preview_payload": source_row.preview_payload,
+            "validation_summary": source_row.validation_summary,
+            "signal_symbol": source_row.signal_symbol,
+            "signal_venue": source_row.signal_venue,
+            "execution_asset_class": source_row.execution_asset_class,
+            "workflow_stage": source_row.workflow_stage,
+            "purpose": source_row.purpose,
+            "briefing_artifact_run_uuid": source_row.briefing_artifact_run_uuid,
+            "briefing_artifact_status": source_row.briefing_artifact_status,
+            "qa_evaluator_status": source_row.qa_evaluator_status,
+            "approval_bridge_generated_at": source_row.approval_bridge_generated_at,
+            "approval_bridge_status": source_row.approval_bridge_status,
+            "candidate_uuid": source_row.candidate_uuid,
             "order_status": order_status,
             "broker_order_id": str(broker_order_id) if broker_order_id else None,
             "submitted_at": datetime.now(UTC),
             "filled_qty": filled_qty,
             "filled_avg_price": filled_avg_price,
+            "confirm_flag": True,
+            "raw_responses": raw_responses,
         }
-        if lifecycle_state == "unexpected":
-            update_vals["error_summary"] = (
-                f"unexpected order_status={order_status!r} after submit"
+        if lifecycle_state == LIFECYCLE_ANOMALY:
+            values["error_summary"] = (
+                f"anomaly: order_status={order_status!r} after submit"
             )
 
-        await self._db.execute(
-            update(AlpacaPaperOrderLedger)
-            .where(AlpacaPaperOrderLedger.client_order_id == client_order_id)
-            .values(**update_vals)
+        update_vals = {
+            k: v
+            for k, v in values.items()
+            if k not in {"client_order_id", "record_kind"} and v is not None
+        }
+        stmt = (
+            pg_insert(AlpacaPaperOrderLedger)
+            .values(**values)
+            .on_conflict_do_update(
+                index_elements=["client_order_id", "record_kind"],
+                index_where=text("validation_attempt_no IS NULL"),
+                set_=update_vals,
+            )
         )
-
-        if raw_response is not None:
-            await self._accumulate_raw_response(client_order_id, "submit", raw_response)
-
+        await self._db.execute(stmt)
         await self._db.commit()
         return await self._require_row(client_order_id)
 
@@ -409,7 +699,7 @@ class AlpacaPaperLedgerService:
         raw_response: dict[str, Any] | None = None,
     ) -> AlpacaPaperOrderLedger:
         """Update lifecycle state from a status-check response."""
-        await self._require_row(client_order_id)
+        target_row = await self._require_row(client_order_id)
 
         order_status = order.get("status")
         filled_qty_raw = order.get("filled_qty") or order.get("filled_quantity")
@@ -439,14 +729,14 @@ class AlpacaPaperLedgerService:
             "filled_qty": filled_qty,
             "filled_avg_price": filled_avg_price,
         }
-        if lifecycle_state == "unexpected":
+        if lifecycle_state == LIFECYCLE_ANOMALY:
             update_vals["error_summary"] = (
-                f"unexpected order_status={order_status!r} during status check"
+                f"anomaly: order_status={order_status!r} during status check"
             )
 
         await self._db.execute(
             update(AlpacaPaperOrderLedger)
-            .where(AlpacaPaperOrderLedger.client_order_id == client_order_id)
+            .where(AlpacaPaperOrderLedger.id == target_row.id)
             .values(**update_vals)
         )
 
@@ -464,7 +754,7 @@ class AlpacaPaperLedgerService:
         error_summary: str | None = None,
     ) -> AlpacaPaperOrderLedger:
         """Record cancel metadata. Lifecycle state is set by record_status, not here."""
-        await self._require_row(client_order_id)
+        target_row = await self._require_row(client_order_id)
 
         update_vals: dict[str, Any] = {
             "cancel_status": cancel_status,
@@ -475,7 +765,7 @@ class AlpacaPaperLedgerService:
 
         await self._db.execute(
             update(AlpacaPaperOrderLedger)
-            .where(AlpacaPaperOrderLedger.client_order_id == client_order_id)
+            .where(AlpacaPaperOrderLedger.id == target_row.id)
             .values(**update_vals)
         )
 
@@ -491,12 +781,12 @@ class AlpacaPaperLedgerService:
         position: dict[str, Any] | None,
         raw_response: dict[str, Any] | None = None,
     ) -> AlpacaPaperOrderLedger:
-        """Record position snapshot.
+        """Record position snapshot and advance lifecycle to position_reconciled.
 
         position=None means no position found (explicit zero).
         position=dict means record qty and avg_entry_price from broker response.
         """
-        await self._require_row(client_order_id)
+        target_row = await self._require_row(client_order_id)
 
         if position is None:
             snapshot: dict[str, Any] = {
@@ -520,14 +810,133 @@ class AlpacaPaperLedgerService:
 
         await self._db.execute(
             update(AlpacaPaperOrderLedger)
-            .where(AlpacaPaperOrderLedger.client_order_id == client_order_id)
-            .values(position_snapshot=snapshot)
+            .where(AlpacaPaperOrderLedger.id == target_row.id)
+            .values(
+                position_snapshot=snapshot,
+                lifecycle_state=LIFECYCLE_POSITION_RECONCILED,
+            )
         )
 
         if raw_response is not None:
             await self._accumulate_raw_response(
                 client_order_id, "position", raw_response
             )
+
+        await self._db.commit()
+        return await self._require_row(client_order_id)
+
+    async def record_sell_validation(
+        self,
+        *,
+        client_order_id: str,
+        lifecycle_correlation_id: str | None = None,
+        execution_symbol: str,
+        execution_venue: str,
+        instrument_type: InstrumentType,
+        side: str = "sell",
+        order_type: str = "limit",
+        time_in_force: str | None = None,
+        requested_qty: Decimal | float | None = None,
+        requested_notional: Decimal | float | None = None,
+        requested_price: Decimal | float | None = None,
+        currency: str = "USD",
+        validation_attempt_no: int = 1,
+        validation_outcome: str = "passed",
+        validation_summary: dict[str, Any] | None = None,
+        leg_role: str | None = "sell",
+        provenance: ApprovalProvenance | None = None,
+        raw_response: dict[str, Any] | None = None,
+    ) -> AlpacaPaperOrderLedger:
+        """Insert a sell-side validation attempt row (lifecycle_state='sell_validated')."""
+        if not client_order_id or not client_order_id.strip():
+            raise ValueError("client_order_id must not be empty")
+
+        prov = provenance or ApprovalProvenance()
+        correlation_id = lifecycle_correlation_id or client_order_id
+        sanitized_validation = (
+            _redact_sensitive_keys(validation_summary) if validation_summary else None
+        )
+        initial_raw: dict[str, Any] = {}
+        if raw_response is not None:
+            initial_raw[f"sell_validation_{validation_attempt_no}"] = (
+                _redact_sensitive_keys(raw_response)
+            )
+
+        values: dict[str, Any] = {
+            "client_order_id": client_order_id,
+            "lifecycle_correlation_id": correlation_id,
+            "record_kind": RECORD_KIND_VALIDATION_ATTEMPT,
+            "broker": "alpaca",
+            "account_mode": "alpaca_paper",
+            "lifecycle_state": LIFECYCLE_SELL_VALIDATED,
+            "execution_symbol": execution_symbol,
+            "execution_venue": execution_venue,
+            "instrument_type": instrument_type,
+            "side": side,
+            "order_type": order_type,
+            "time_in_force": time_in_force,
+            "requested_qty": requested_qty,
+            "requested_notional": requested_notional,
+            "requested_price": requested_price,
+            "currency": currency,
+            "validation_attempt_no": validation_attempt_no,
+            "validation_outcome": validation_outcome,
+            "validation_summary": sanitized_validation,
+            "leg_role": leg_role,
+            "confirm_flag": False,
+            "raw_responses": initial_raw if initial_raw else None,
+            **self._build_provenance_values(prov),
+        }
+
+        stmt = (
+            pg_insert(AlpacaPaperOrderLedger)
+            .values(**values)
+            .on_conflict_do_nothing(
+                index_elements=[
+                    "lifecycle_correlation_id",
+                    "side",
+                    "validation_attempt_no",
+                ],
+                index_where=text("record_kind = 'validation_attempt'"),
+            )
+        )
+        await self._db.execute(stmt)
+        await self._db.commit()
+
+        row = await self.get_by_client_order_id(client_order_id)
+        if row is None:
+            raise LedgerNotFoundError(
+                f"No ledger row found for client_order_id={client_order_id!r}"
+            )
+        return row
+
+    async def record_close(
+        self,
+        client_order_id: str,
+        *,
+        qty_delta: Decimal | float | None = None,
+        notes: str | None = None,
+        raw_response: dict[str, Any] | None = None,
+    ) -> AlpacaPaperOrderLedger:
+        """Advance lifecycle to 'closed' after sell execution."""
+        target_row = await self._require_row(client_order_id)
+
+        update_vals: dict[str, Any] = {
+            "lifecycle_state": LIFECYCLE_CLOSED,
+        }
+        if qty_delta is not None:
+            update_vals["qty_delta"] = qty_delta
+        if notes is not None:
+            update_vals["notes"] = _redact_sensitive_text(notes)
+
+        await self._db.execute(
+            update(AlpacaPaperOrderLedger)
+            .where(AlpacaPaperOrderLedger.id == target_row.id)
+            .values(**update_vals)
+        )
+
+        if raw_response is not None:
+            await self._accumulate_raw_response(client_order_id, "close", raw_response)
 
         await self._db.commit()
         return await self._require_row(client_order_id)
@@ -541,7 +950,7 @@ class AlpacaPaperLedgerService:
         raw_response: dict[str, Any] | None = None,
     ) -> AlpacaPaperOrderLedger:
         """Record reconciliation result."""
-        await self._require_row(client_order_id)
+        target_row = await self._require_row(client_order_id)
 
         update_vals: dict[str, Any] = {
             "reconcile_status": reconcile_status,
@@ -555,7 +964,7 @@ class AlpacaPaperLedgerService:
 
         await self._db.execute(
             update(AlpacaPaperOrderLedger)
-            .where(AlpacaPaperOrderLedger.client_order_id == client_order_id)
+            .where(AlpacaPaperOrderLedger.id == target_row.id)
             .values(**update_vals)
         )
 
@@ -567,11 +976,71 @@ class AlpacaPaperLedgerService:
         await self._db.commit()
         return await self._require_row(client_order_id)
 
+    async def record_final_reconcile(
+        self,
+        client_order_id: str,
+        *,
+        reconcile_status: str = "ok",
+        settlement_status: str = "n_a",
+        qty_delta: Decimal | float | None = None,
+        notes: str | None = None,
+        error_summary: str | None = None,
+        raw_response: dict[str, Any] | None = None,
+    ) -> AlpacaPaperOrderLedger:
+        """Record final roundtrip reconciliation (lifecycle_state='final_reconciled')."""
+        target_row = await self._require_row(client_order_id)
+
+        update_vals: dict[str, Any] = {
+            "lifecycle_state": LIFECYCLE_FINAL_RECONCILED,
+            "record_kind": RECORD_KIND_RECONCILE,
+            "reconcile_status": reconcile_status,
+            "reconciled_at": datetime.now(UTC),
+            "settlement_status": settlement_status,
+            "error_summary": _redact_sensitive_text(error_summary)
+            if error_summary is not None
+            else None,
+        }
+        if qty_delta is not None:
+            update_vals["qty_delta"] = qty_delta
+        if notes is not None:
+            update_vals["notes"] = _redact_sensitive_text(notes)
+
+        await self._db.execute(
+            update(AlpacaPaperOrderLedger)
+            .where(AlpacaPaperOrderLedger.id == target_row.id)
+            .values(**update_vals)
+        )
+
+        if raw_response is not None:
+            await self._accumulate_raw_response(
+                client_order_id, "final_reconcile", raw_response
+            )
+
+        await self._db.commit()
+        return await self._require_row(client_order_id)
+
 
 __all__ = [
     "AlpacaPaperLedgerService",
     "ApprovalProvenance",
+    "CANONICAL_LIFECYCLE_STATES",
+    "LIFECYCLE_ANOMALY",
+    "LIFECYCLE_CLOSED",
+    "LIFECYCLE_FILLED",
+    "LIFECYCLE_FINAL_RECONCILED",
+    "LIFECYCLE_PLANNED",
+    "LIFECYCLE_POSITION_RECONCILED",
+    "LIFECYCLE_PREVIEWED",
+    "LIFECYCLE_SELL_VALIDATED",
+    "LIFECYCLE_SUBMITTED",
+    "LIFECYCLE_VALIDATED",
     "LedgerNotFoundError",
+    "RECORD_KIND_ANOMALY",
+    "RECORD_KIND_EXECUTION",
+    "RECORD_KIND_PLAN",
+    "RECORD_KIND_PREVIEW",
+    "RECORD_KIND_RECONCILE",
+    "RECORD_KIND_VALIDATION_ATTEMPT",
     "_derive_lifecycle_state",
     "_redact_sensitive_keys",
     "_redact_sensitive_text",

--- a/docs/runbooks/alpaca-paper-ledger.md
+++ b/docs/runbooks/alpaca-paper-ledger.md
@@ -1,39 +1,51 @@
-# Alpaca Paper Order Ledger Runbook (ROB-84)
+# Alpaca Paper Order Ledger Runbook (ROB-84/ROB-90)
 
 ## Purpose
 
 `review.alpaca_paper_order_ledger` is an internal operator/audit lifecycle ledger for Alpaca Paper broker execution attempts.
 
-It records the full lifecycle of a paper order: preview → validation → submit → status/fill → cancel → position snapshot → reconcile.
+It records the full lifecycle of a paper roundtrip: plan → preview → validation → submit → fill → position → sell → close → final reconcile.
 
-It was introduced in ROB-84 as a prerequisite for automating the preopen→paper buy/sell roundtrip (ROB-85).
+It was introduced in ROB-84 as a prerequisite for automating the preopen→paper buy/sell roundtrip (ROB-85). ROB-90 normalized the taxonomy to canonical states.
 
-Related: ROB-83 introduced the Alpaca Paper smoke workflow. ROB-84 adds persistent records before automation.
+Related: ROB-83 introduced the Alpaca Paper smoke workflow. ROB-84 adds persistent records. ROB-90 normalizes lifecycle states and adds roundtrip correlation.
 
 ---
 
-## Lifecycle States
+## Lifecycle States (ROB-90 Canonical)
 
 | State | Meaning |
 |-------|---------|
+| `planned` | Order intent recorded; no preview or submit yet |
 | `previewed` | Approval preview was built; no order submitted yet |
-| `validation_failed` | Confirm-false check failed; order not submitted |
-| `submitted` | Order was sent to Alpaca Paper broker |
-| `open` | Broker accepted; order is live/pending fill |
-| `partially_filled` | Partial fill received |
+| `validated` | Confirm-false check passed; order not yet submitted |
+| `submitted` | Order was sent to Alpaca Paper broker; awaiting fill (includes partially_filled broker status) |
 | `filled` | Order fully filled |
-| `canceled` | Order was canceled (broker confirmed) |
-| `unexpected` | Broker returned a status we do not recognize (rejected, expired, suspended, unknown) |
+| `position_reconciled` | Post-fill position snapshot recorded |
+| `sell_validated` | Sell-leg confirm-false check passed |
+| `closed` | Sell order executed; position closed |
+| `final_reconciled` | Roundtrip fully reconciled |
+| `anomaly` | Broker returned a non-recoverable status (rejected, expired, suspended, canceled, unknown) or a state mismatch |
 
 ### Lifecycle Transitions
 
 ```
+record_plan()
+  └─ lifecycle_state = planned, record_kind = plan
+
 record_preview()
-  └─ lifecycle_state = previewed  OR  validation_failed
+  └─ lifecycle_state = previewed, record_kind = preview
+
+record_validation_attempt(validation_outcome='passed')
+  └─ lifecycle_state = validated, record_kind = validation_attempt, confirm_flag = false
+
+record_validation_attempt(validation_outcome='failed')
+  └─ lifecycle_state = anomaly, record_kind = validation_attempt, confirm_flag = false
 
 record_submit()
   └─ lifecycle_state = _derive_lifecycle_state(order.status, order.filled_qty)
-       canceled / filled / partially_filled / open / unexpected
+       submitted / filled / anomaly
+       record_kind = execution, confirm_flag = true
 
 record_status()
   └─ lifecycle_state = _derive_lifecycle_state(order.status, order.filled_qty)
@@ -43,11 +55,71 @@ record_cancel()
   └─ writes cancel_status + canceled_at; lifecycle_state is set by record_status()
 
 record_position_snapshot()
-  └─ writes position_snapshot JSONB; {qty, avg_entry_price, fetched_at}
+  └─ writes position_snapshot JSONB + lifecycle_state = position_reconciled
+
+record_sell_validation()
+  └─ lifecycle_state = sell_validated, record_kind = validation_attempt, confirm_flag = false
+
+record_close()
+  └─ lifecycle_state = closed
 
 record_reconcile()
-  └─ writes reconcile_status + reconciled_at
+  └─ writes reconcile_status + reconciled_at (no lifecycle_state advance)
+
+record_final_reconcile()
+  └─ lifecycle_state = final_reconciled, record_kind = reconcile, settlement_status = n_a
 ```
+
+---
+
+## Legacy State Mapping (ROB-90 Migration)
+
+The migration `d4e5f6a7b8c9` (down_revision: `c1d2e3f4a5b6`) mapped old states as follows:
+
+| Old state | Canonical state | record_kind | Notes |
+|-----------|----------------|-------------|-------|
+| `previewed` (no broker order) | `previewed` | `preview` | Preview-only row |
+| `previewed` (with broker order) | `previewed` | `execution` | Execution row |
+| `validation_failed` | `anomaly` | `validation_attempt` | `validation_outcome='failed'`, `confirm_flag=false` |
+| `submitted` | `submitted` | `execution` | `confirm_flag=true` |
+| `open` | `submitted` | `execution` | `confirm_flag=true` |
+| `partially_filled` | `submitted` | `execution` | Broker status preserved in `order_status` |
+| `filled` | `filled` | `execution` | `confirm_flag=true` |
+| `canceled` | `anomaly` | `execution` | `confirm_flag=true` |
+| `unexpected` | `anomaly` | `execution` | — |
+
+---
+
+## record_kind Values
+
+| record_kind | Meaning |
+|------------|---------|
+| `plan` | Intent-only row, no preview/validation done |
+| `preview` | Approval preview built (confirm=false dry run) |
+| `validation_attempt` | Confirm-false API validation attempt |
+| `execution` | Actual broker order (confirm=true) |
+| `reconcile` | Post-execution reconciliation record |
+| `anomaly` | Unexpected/error row |
+
+---
+
+## Example: Buy/Sell Roundtrip Records
+
+Rows for a complete paper roundtrip sharing `lifecycle_correlation_id = "corr-abc"`:
+
+| client_order_id | side | record_kind | lifecycle_state | confirm_flag | validation_attempt_no |
+|----------------|------|------------|----------------|-------------|----------------------|
+| buy-001 | buy | plan | planned | null | null |
+| buy-001 | buy | preview | previewed | null | null |
+| buy-001 | buy | validation_attempt | validated | false | 1 |
+| buy-001 | buy | execution | submitted | true | null |
+| buy-001 | buy | execution | filled | true | null |
+| buy-001 | buy | execution | position_reconciled | true | null |
+| sell-001 | sell | validation_attempt | sell_validated | false | 1 |
+| sell-001 | sell | execution | closed | true | null |
+| sell-001 | sell | reconcile | final_reconciled | true | null |
+
+All rows: `lifecycle_correlation_id = "corr-abc"`, `broker = "alpaca"`, `account_mode = "alpaca_paper"`.
 
 ---
 
@@ -80,9 +152,10 @@ Use `from_approval_bridge(bridge, candidate, briefing_artifact=..., qa_evaluator
 ### FastAPI endpoints (authenticated, GET only)
 
 ```
-GET /trading/api/alpaca-paper/ledger/recent?limit=50&lifecycle_state=canceled
+GET /trading/api/alpaca-paper/ledger/recent?limit=50&lifecycle_state=anomaly
 GET /trading/api/alpaca-paper/ledger/{ledger_id}
 GET /trading/api/alpaca-paper/ledger/by-client-order-id/{client_order_id}
+GET /trading/api/alpaca-paper/ledger/by-correlation-id/{lifecycle_correlation_id}
 ```
 
 ### MCP tools (read-only, in `ALPACA_PAPER_READONLY_TOOL_NAMES`)
@@ -90,18 +163,19 @@ GET /trading/api/alpaca-paper/ledger/by-client-order-id/{client_order_id}
 ```
 alpaca_paper_ledger_list_recent(limit=50, lifecycle_state=None)
 alpaca_paper_ledger_get(client_order_id)
+alpaca_paper_ledger_get_by_correlation(lifecycle_correlation_id)
 ```
 
 ---
 
 ## Operator FAQ
 
-**Q: How do I find all canceled smoke orders?**
+**Q: How do I find all anomaly (formerly canceled/unexpected) orders?**
 
 ```
-GET /trading/api/alpaca-paper/ledger/recent?lifecycle_state=canceled&limit=100
+GET /trading/api/alpaca-paper/ledger/recent?lifecycle_state=anomaly&limit=100
 # or MCP:
-alpaca_paper_ledger_list_recent(lifecycle_state="canceled", limit=100)
+alpaca_paper_ledger_list_recent(lifecycle_state="anomaly", limit=100)
 ```
 
 **Q: How do I look up a specific order?**
@@ -112,9 +186,25 @@ GET /trading/api/alpaca-paper/ledger/by-client-order-id/{client_order_id}
 alpaca_paper_ledger_get(client_order_id="...")
 ```
 
-**Q: The lifecycle_state is `unexpected` — what happened?**
+**Q: How do I view a complete buy/sell roundtrip?**
 
-Check the `order_status` and `error_summary` fields. Unexpected maps to broker statuses: `rejected`, `expired`, `suspended`, or any unrecognized status.
+```
+GET /trading/api/alpaca-paper/ledger/by-correlation-id/{lifecycle_correlation_id}
+# or MCP:
+alpaca_paper_ledger_get_by_correlation(lifecycle_correlation_id="...")
+```
+
+**Q: The lifecycle_state is `anomaly` — what happened?**
+
+Check the `order_status`, `error_summary`, `record_kind`, and `validation_outcome` fields.
+Anomaly maps to: `canceled`, `rejected`, `expired`, `suspended`, any unrecognized status, or a
+validation_attempt with `validation_outcome='failed'`.
+
+**Q: What does `submitted` lifecycle_state mean if order_status is `partially_filled`?**
+
+ROB-90 maps `partially_filled` broker status to canonical `submitted` lifecycle_state.
+The raw broker status is preserved in `order_status`. When fully filled, `record_status()`
+will advance the lifecycle_state to `filled`.
 
 **Q: Can I write directly to the table with SQL?**
 
@@ -122,13 +212,18 @@ No. All writes must go through `AlpacaPaperLedgerService`. Direct SQL inserts/up
 
 ---
 
-## Safety Boundaries
+## Safety Non-Actions
+
+The following are explicitly out of scope and must not be added to this ledger or its service:
 
 - **No broker mutation**: The ledger service does not submit, cancel, or modify orders.
 - **No live trading routes**: This ledger is strictly `alpaca_paper`.
-- **No direct SQL backfill**: Use `AlpacaPaperLedgerService` methods only.
-- **No scheduler changes**: Ledger writes are triggered by execution flow, not by scheduler.
+- **No KIS/Upbit mutation**: This ledger has no relation to KIS or Upbit order paths.
+- **No direct SQL backfill**: Use `AlpacaPaperLedgerService` methods only; migration mechanics are the only approved bulk-write path.
+- **No scheduler changes**: Ledger writes are triggered by execution flow, not scheduler.
+- **No bulk close/cancel/liquidate**: Out of scope.
 - **No secrets persisted**: All JSONB payloads are run through `_redact_sensitive_keys()` before persistence. Keys matching `api_key`, `secret`, `authorization`, `token`, `account_no`, `account_number`, `account_id`, `email` are replaced with `[REDACTED]`.
+- **No generic broker routes**: Do not widen `place_order` / `cancel_order` / `modify_order` paths.
 - **Signal/execution separation**: `signal_symbol`/`signal_venue` (e.g. Upbit) are stored separately from `execution_symbol`/`execution_venue` (e.g. Alpaca Paper).
 
 ---
@@ -137,14 +232,37 @@ No. All writes must go through `AlpacaPaperLedgerService`. Direct SQL inserts/up
 
 Table: `review.alpaca_paper_order_ledger`
 
-- `client_order_id`: caller-supplied unique correlation key (up to 128 chars)
+### Core identity
+- `client_order_id`: per-leg caller-supplied correlation key
+- `lifecycle_correlation_id`: cross-leg roundtrip key (buy + sell share this value)
 - `broker`: always `alpaca`
 - `account_mode`: always `alpaca_paper`
-- `lifecycle_state`: application state (see table above)
-- `raw_responses`: JSONB map of sanitized event snapshots, keyed by event type (`preview`, `submit`, `status`, `cancel`, `position`, `reconcile`)
+- `lifecycle_state`: canonical ROB-90 state (see table above)
+- `record_kind`: row type — `plan`, `preview`, `validation_attempt`, `execution`, `reconcile`, `anomaly`
+
+### ROB-90 taxonomy fields
+- `leg_role`: `buy`, `sell`, `roundtrip` (optional, separate from broker `side`)
+- `validation_attempt_no`: monotonic per `(lifecycle_correlation_id, side)` for validation rows
+- `validation_outcome`: `passed`, `failed`, `skipped`, `n_a`
+- `confirm_flag`: `false` for validation-only rows, `true` for executed rows, `null` for plans/previews
+- `fee_amount` / `fee_currency`: fee labels (Alpaca Paper may return 0)
+- `settlement_status`: `pending`, `settled`, `failed`, `n_a`
+- `settlement_at`: settlement timestamp
+- `qty_delta`: signed quantity effect (buy positive, sell negative, preview null)
+
+### Raw events
+- `raw_responses`: JSONB map of sanitized event snapshots, keyed by event type (`preview`, `submit`, `status`, `cancel`, `position`, `reconcile`, `final_reconcile`)
+
+### Indexes
+- `ix_alpaca_paper_ledger_correlation_id` on `lifecycle_correlation_id` (roundtrip lookups)
+- `ix_alpaca_paper_ledger_record_kind` on `record_kind`
+- `uq_alpaca_paper_ledger_client_order_kind` — partial unique on `(client_order_id, record_kind) WHERE validation_attempt_no IS NULL`
+- `uq_alpaca_paper_ledger_validation_attempt` — partial unique on `(lifecycle_correlation_id, side, validation_attempt_no) WHERE record_kind = 'validation_attempt'`
 
 ORM model: `app.models.review.AlpacaPaperOrderLedger`
 
 Service: `app.services.alpaca_paper_ledger_service.AlpacaPaperLedgerService`
 
-Migration: `alembic/versions/c1d2e3f4a5b6_add_alpaca_paper_order_ledger.py`
+Migrations:
+- `alembic/versions/c1d2e3f4a5b6_add_alpaca_paper_order_ledger.py` (ROB-84 initial)
+- `alembic/versions/d4e5f6a7b8c9_normalize_alpaca_paper_ledger_taxonomy.py` (ROB-90 taxonomy normalization)

--- a/scripts/smoke/alpaca_paper_readonly_smoke.py
+++ b/scripts/smoke/alpaca_paper_readonly_smoke.py
@@ -22,6 +22,7 @@ from app.mcp_server.tooling.alpaca_paper import (
 from app.mcp_server.tooling.alpaca_paper_ledger_read import (
     alpaca_paper_execution_preflight_check,
     alpaca_paper_ledger_get,
+    alpaca_paper_ledger_get_by_correlation,
     alpaca_paper_ledger_list_recent,
 )
 
@@ -131,6 +132,29 @@ async def run_smoke() -> int:
         alpaca_paper_ledger_get(client_order_id),
         lambda p: f"found={p.get('found', False)}",
     )
+
+    correlation_id: str | None = None
+    if ledger_payload and ledger_payload.get("items"):
+        raw_correlation_id = ledger_payload["items"][0].get("lifecycle_correlation_id")
+        if isinstance(raw_correlation_id, str):
+            normalized_correlation_id = raw_correlation_id.strip()
+            if normalized_correlation_id:
+                correlation_id = normalized_correlation_id
+
+    if correlation_id:
+        await _probe(
+            "alpaca_paper_ledger_get_by_correlation",
+            alpaca_paper_ledger_get_by_correlation(correlation_id),
+            lambda p: f"count={p.get('count', 0)}",
+        )
+    else:
+        results.append(
+            (
+                "alpaca_paper_ledger_get_by_correlation",
+                True,
+                "skipped: no lifecycle correlation id to inspect",
+            )
+        )
 
     await _probe(
         "alpaca_paper_execution_preflight_check",

--- a/scripts/smoke/alpaca_paper_readonly_smoke.py
+++ b/scripts/smoke/alpaca_paper_readonly_smoke.py
@@ -137,9 +137,7 @@ async def run_smoke() -> int:
     if ledger_payload and ledger_payload.get("items"):
         raw_correlation_id = ledger_payload["items"][0].get("lifecycle_correlation_id")
         if isinstance(raw_correlation_id, str):
-            normalized_correlation_id = raw_correlation_id.strip()
-            if normalized_correlation_id:
-                correlation_id = normalized_correlation_id
+            correlation_id = raw_correlation_id.strip() or None
 
     if correlation_id:
         await _probe(

--- a/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
+++ b/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
@@ -63,6 +63,22 @@ def _mock_svc(*, row=None, rows=None, corr_rows=None):
     return svc
 
 
+class _FakeDB:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        pass
+
+
+def _patch_ledger_service(monkeypatch, mod, mock_svc) -> None:
+    monkeypatch.setattr(mod, "_session_factory", lambda: lambda: _FakeDB())
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.alpaca_paper_ledger_read.AlpacaPaperLedgerService",
+        lambda db: mock_svc,
+    )
+
+
 # ---------------------------------------------------------------------------
 # alpaca_paper_ledger_list_recent
 # ---------------------------------------------------------------------------
@@ -76,21 +92,7 @@ async def test_list_recent_returns_success_dict(monkeypatch):
     row = _fake_row()
     mock_svc = _mock_svc(rows=[row])
 
-    class _FakeDB:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            pass
-
-    def fake_factory():
-        return lambda: _FakeDB()
-
-    monkeypatch.setattr(mod, "_session_factory", fake_factory)
-    monkeypatch.setattr(
-        "app.mcp_server.tooling.alpaca_paper_ledger_read.AlpacaPaperLedgerService",
-        lambda db: mock_svc,
-    )
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
 
     result = await mod.alpaca_paper_ledger_list_recent(limit=10)
 
@@ -108,18 +110,7 @@ async def test_list_recent_empty_returns_zero_count(monkeypatch):
 
     mock_svc = _mock_svc(rows=[])
 
-    class _FakeDB:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            pass
-
-    monkeypatch.setattr(mod, "_session_factory", lambda: lambda: _FakeDB())
-    monkeypatch.setattr(
-        "app.mcp_server.tooling.alpaca_paper_ledger_read.AlpacaPaperLedgerService",
-        lambda db: mock_svc,
-    )
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
 
     result = await mod.alpaca_paper_ledger_list_recent(limit=50)
     assert result["count"] == 0
@@ -133,18 +124,7 @@ async def test_list_recent_limit_capped_at_200(monkeypatch):
 
     mock_svc = _mock_svc(rows=[])
 
-    class _FakeDB:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            pass
-
-    monkeypatch.setattr(mod, "_session_factory", lambda: lambda: _FakeDB())
-    monkeypatch.setattr(
-        "app.mcp_server.tooling.alpaca_paper_ledger_read.AlpacaPaperLedgerService",
-        lambda db: mock_svc,
-    )
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
 
     result = await mod.alpaca_paper_ledger_list_recent(limit=999)
     assert result["limit"] == 200
@@ -174,18 +154,7 @@ async def test_ledger_get_found(monkeypatch):
     row = _fake_row()
     mock_svc = _mock_svc(row=row)
 
-    class _FakeDB:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            pass
-
-    monkeypatch.setattr(mod, "_session_factory", lambda: lambda: _FakeDB())
-    monkeypatch.setattr(
-        "app.mcp_server.tooling.alpaca_paper_ledger_read.AlpacaPaperLedgerService",
-        lambda db: mock_svc,
-    )
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
 
     result = await mod.alpaca_paper_ledger_get("test-client-001")
     assert result["success"] is True
@@ -201,18 +170,7 @@ async def test_ledger_get_not_found(monkeypatch):
 
     mock_svc = _mock_svc(row=None)
 
-    class _FakeDB:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            pass
-
-    monkeypatch.setattr(mod, "_session_factory", lambda: lambda: _FakeDB())
-    monkeypatch.setattr(
-        "app.mcp_server.tooling.alpaca_paper_ledger_read.AlpacaPaperLedgerService",
-        lambda db: mock_svc,
-    )
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
 
     result = await mod.alpaca_paper_ledger_get("nonexistent")
     assert result["success"] is False
@@ -304,18 +262,7 @@ async def test_ledger_get_by_correlation_returns_rows(monkeypatch):
     )
     mock_svc = _mock_svc(corr_rows=[buy_row, sell_row])
 
-    class _FakeDB:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            pass
-
-    monkeypatch.setattr(mod, "_session_factory", lambda: lambda: _FakeDB())
-    monkeypatch.setattr(
-        "app.mcp_server.tooling.alpaca_paper_ledger_read.AlpacaPaperLedgerService",
-        lambda db: mock_svc,
-    )
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
 
     result = await mod.alpaca_paper_ledger_get_by_correlation("corr-test")
     assert result["success"] is True
@@ -331,18 +278,7 @@ async def test_ledger_get_by_correlation_empty_returns_zero_count(monkeypatch):
 
     mock_svc = _mock_svc(corr_rows=[])
 
-    class _FakeDB:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *a):
-            pass
-
-    monkeypatch.setattr(mod, "_session_factory", lambda: lambda: _FakeDB())
-    monkeypatch.setattr(
-        "app.mcp_server.tooling.alpaca_paper_ledger_read.AlpacaPaperLedgerService",
-        lambda db: mock_svc,
-    )
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
 
     result = await mod.alpaca_paper_ledger_get_by_correlation("no-such-corr")
     assert result["success"] is True

--- a/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
+++ b/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
@@ -1,4 +1,4 @@
-"""Tests for read-only Alpaca Paper ledger MCP tools (ROB-84)."""
+"""Tests for read-only Alpaca Paper ledger MCP tools (ROB-84/ROB-90)."""
 
 from __future__ import annotations
 
@@ -23,9 +23,11 @@ def _fake_row(**kwargs):
     defaults = {
         "id": 1,
         "client_order_id": "test-client-001",
+        "lifecycle_correlation_id": "test-client-001",
+        "record_kind": "execution",
         "broker": "alpaca",
         "account_mode": "alpaca_paper",
-        "lifecycle_state": "canceled",
+        "lifecycle_state": "anomaly",
         "execution_symbol": "BTCUSD",
         "execution_venue": "alpaca_paper",
         "instrument_type": "crypto",
@@ -36,6 +38,8 @@ def _fake_row(**kwargs):
             columns=[
                 SimpleNamespace(name="id"),
                 SimpleNamespace(name="client_order_id"),
+                SimpleNamespace(name="lifecycle_correlation_id"),
+                SimpleNamespace(name="record_kind"),
                 SimpleNamespace(name="broker"),
                 SimpleNamespace(name="account_mode"),
                 SimpleNamespace(name="lifecycle_state"),
@@ -47,11 +51,14 @@ def _fake_row(**kwargs):
     return ns
 
 
-def _mock_svc(*, row=None, rows=None):
+def _mock_svc(*, row=None, rows=None, corr_rows=None):
     svc = AsyncMock()
     svc.get_by_client_order_id = AsyncMock(return_value=row)
     svc.list_recent = AsyncMock(
         return_value=rows if rows is not None else ([row] if row else [])
+    )
+    svc.list_by_correlation_id = AsyncMock(
+        return_value=corr_rows if corr_rows is not None else []
     )
     return svc
 
@@ -274,6 +281,87 @@ async def test_execution_preflight_check_invalid_inputs_raise():
 
 
 # ---------------------------------------------------------------------------
+# alpaca_paper_ledger_get_by_correlation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_ledger_get_by_correlation_returns_rows(monkeypatch):
+    import app.mcp_server.tooling.alpaca_paper_ledger_read as mod
+
+    buy_row = _fake_row(
+        client_order_id="buy-001",
+        lifecycle_correlation_id="corr-test",
+        side="buy",
+        lifecycle_state="filled",
+    )
+    sell_row = _fake_row(
+        client_order_id="sell-001",
+        lifecycle_correlation_id="corr-test",
+        side="sell",
+        lifecycle_state="closed",
+    )
+    mock_svc = _mock_svc(corr_rows=[buy_row, sell_row])
+
+    class _FakeDB:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            pass
+
+    monkeypatch.setattr(mod, "_session_factory", lambda: lambda: _FakeDB())
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.alpaca_paper_ledger_read.AlpacaPaperLedgerService",
+        lambda db: mock_svc,
+    )
+
+    result = await mod.alpaca_paper_ledger_get_by_correlation("corr-test")
+    assert result["success"] is True
+    assert result["lifecycle_correlation_id"] == "corr-test"
+    assert result["count"] == 2
+    assert len(result["items"]) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_ledger_get_by_correlation_empty_returns_zero_count(monkeypatch):
+    import app.mcp_server.tooling.alpaca_paper_ledger_read as mod
+
+    mock_svc = _mock_svc(corr_rows=[])
+
+    class _FakeDB:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            pass
+
+    monkeypatch.setattr(mod, "_session_factory", lambda: lambda: _FakeDB())
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.alpaca_paper_ledger_read.AlpacaPaperLedgerService",
+        lambda db: mock_svc,
+    )
+
+    result = await mod.alpaca_paper_ledger_get_by_correlation("no-such-corr")
+    assert result["success"] is True
+    assert result["count"] == 0
+    assert result["items"] == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_ledger_get_by_correlation_empty_id_raises():
+    from app.mcp_server.tooling.alpaca_paper_ledger_read import (
+        alpaca_paper_ledger_get_by_correlation,
+    )
+
+    with pytest.raises(ValueError, match="lifecycle_correlation_id is required"):
+        await alpaca_paper_ledger_get_by_correlation("")
+
+
+# ---------------------------------------------------------------------------
 # Registered as read-only
 # ---------------------------------------------------------------------------
 
@@ -284,6 +372,7 @@ def test_ledger_tool_names_are_in_alpaca_readonly_set():
 
     assert "alpaca_paper_ledger_list_recent" in ALPACA_PAPER_READONLY_TOOL_NAMES
     assert "alpaca_paper_ledger_get" in ALPACA_PAPER_READONLY_TOOL_NAMES
+    assert "alpaca_paper_ledger_get_by_correlation" in ALPACA_PAPER_READONLY_TOOL_NAMES
     assert "alpaca_paper_execution_preflight_check" in ALPACA_PAPER_READONLY_TOOL_NAMES
 
 

--- a/tests/routers/test_alpaca_paper_ledger_router.py
+++ b/tests/routers/test_alpaca_paper_ledger_router.py
@@ -1,4 +1,4 @@
-"""Tests for the read-only Alpaca Paper ledger router (ROB-84)."""
+"""Tests for the read-only Alpaca Paper ledger router (ROB-84/ROB-90)."""
 
 from __future__ import annotations
 
@@ -16,9 +16,12 @@ def _make_fake_row(**kwargs):
     defaults = {
         "id": 1,
         "client_order_id": "test-client-001",
+        "lifecycle_correlation_id": "test-client-001",
+        "record_kind": "execution",
         "broker": "alpaca",
         "account_mode": "alpaca_paper",
-        "lifecycle_state": "canceled",
+        # ROB-90: canonical state (anomaly replaces old 'canceled')
+        "lifecycle_state": "anomaly",
         "signal_symbol": "KRW-BTC",
         "signal_venue": "upbit",
         "execution_symbol": "BTCUSD",
@@ -32,6 +35,15 @@ def _make_fake_row(**kwargs):
         "requested_notional": None,
         "requested_price": "50000",
         "currency": "USD",
+        "leg_role": None,
+        "validation_attempt_no": None,
+        "validation_outcome": None,
+        "confirm_flag": True,
+        "fee_amount": None,
+        "fee_currency": None,
+        "settlement_status": "n_a",
+        "settlement_at": None,
+        "qty_delta": None,
         "broker_order_id": "broker-id-001",
         "submitted_at": datetime(2026, 5, 3, 9, 0, tzinfo=UTC),
         "order_status": "canceled",
@@ -131,7 +143,11 @@ def test_list_recent_returns_200_with_items():
     data = resp.json()
     assert data["count"] == 1
     assert data["items"][0]["client_order_id"] == "test-client-001"
-    assert data["items"][0]["lifecycle_state"] == "canceled"
+    # ROB-90: canonical state
+    assert data["items"][0]["lifecycle_state"] == "anomaly"
+    # ROB-90: new taxonomy fields present
+    assert "lifecycle_correlation_id" in data["items"][0]
+    assert "record_kind" in data["items"][0]
 
 
 @pytest.mark.unit
@@ -149,15 +165,58 @@ def test_list_recent_empty_returns_200_empty_list():
 
 @pytest.mark.unit
 def test_list_recent_lifecycle_state_filter_passes():
-    row = _make_fake_row(lifecycle_state="canceled")
+    row = _make_fake_row(lifecycle_state="anomaly")
     db = _mock_db_for_rows([row])
     app = _make_app_with_db(db)
 
     client = TestClient(app)
-    resp = client.get(
-        "/trading/api/alpaca-paper/ledger/recent?lifecycle_state=canceled"
-    )
+    resp = client.get("/trading/api/alpaca-paper/ledger/recent?lifecycle_state=anomaly")
     assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# get_ledger_by_correlation_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_get_by_correlation_id_returns_200():
+    buy_row = _make_fake_row(
+        client_order_id="buy-001",
+        lifecycle_correlation_id="corr-abc",
+        lifecycle_state="filled",
+        side="buy",
+    )
+    sell_row = _make_fake_row(
+        id=2,
+        client_order_id="sell-001",
+        lifecycle_correlation_id="corr-abc",
+        lifecycle_state="closed",
+        side="sell",
+    )
+    db = _mock_db_for_rows([buy_row, sell_row])
+    app = _make_app_with_db(db)
+
+    client = TestClient(app)
+    resp = client.get("/trading/api/alpaca-paper/ledger/by-correlation-id/corr-abc")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["lifecycle_correlation_id"] == "corr-abc"
+    assert "count" in data
+    assert "items" in data
+
+
+@pytest.mark.unit
+def test_get_by_correlation_id_empty_returns_200_zero_count():
+    db = _mock_db_for_rows([])
+    app = _make_app_with_db(db)
+
+    client = TestClient(app)
+    resp = client.get("/trading/api/alpaca-paper/ledger/by-correlation-id/no-such-corr")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 0
+    assert data["items"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_alpaca_paper_ledger_lifecycle_fixture.py
+++ b/tests/services/test_alpaca_paper_ledger_lifecycle_fixture.py
@@ -1,0 +1,366 @@
+"""Buy/sell roundtrip lifecycle fixture tests for ROB-90 canonical taxonomy.
+
+Verifies that a complete paper roundtrip can be represented as a sequence of
+ledger rows sharing lifecycle_correlation_id but having distinct client_order_id,
+side, record_kind, and timestamps.
+
+All tests are pure-Python unit tests with no DB or broker calls.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.alpaca_paper_ledger_service import (
+    CANONICAL_LIFECYCLE_STATES,
+    LIFECYCLE_ANOMALY,
+    LIFECYCLE_CLOSED,
+    LIFECYCLE_FILLED,
+    LIFECYCLE_FINAL_RECONCILED,
+    LIFECYCLE_PLANNED,
+    LIFECYCLE_POSITION_RECONCILED,
+    LIFECYCLE_PREVIEWED,
+    LIFECYCLE_SELL_VALIDATED,
+    LIFECYCLE_SUBMITTED,
+    LIFECYCLE_VALIDATED,
+    RECORD_KIND_EXECUTION,
+    RECORD_KIND_PLAN,
+    RECORD_KIND_PREVIEW,
+    RECORD_KIND_RECONCILE,
+    RECORD_KIND_VALIDATION_ATTEMPT,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CORRELATION_ID = "corr-roundtrip-test-001"
+_BUY_CLIENT_ORDER_ID = "buy-order-001"
+_SELL_CLIENT_ORDER_ID = "sell-order-001"
+
+_T0 = datetime(2026, 5, 3, 9, 0, 0, tzinfo=UTC)
+
+
+def _ts(offset_seconds: int = 0) -> datetime:
+    return _T0 + timedelta(seconds=offset_seconds)
+
+
+def _make_row(
+    *,
+    client_order_id: str,
+    lifecycle_correlation_id: str = _CORRELATION_ID,
+    lifecycle_state: str,
+    record_kind: str,
+    side: str,
+    validation_attempt_no: int | None = None,
+    validation_outcome: str | None = None,
+    confirm_flag: bool | None = None,
+    leg_role: str | None = None,
+    qty_delta: str | None = None,
+    settlement_status: str | None = None,
+    signal_symbol: str | None = "KRW-BTC",
+    signal_venue: str | None = "upbit",
+    created_at: datetime | None = None,
+    **kwargs: Any,
+) -> Any:
+    return SimpleNamespace(
+        id=len(client_order_id),
+        client_order_id=client_order_id,
+        lifecycle_correlation_id=lifecycle_correlation_id,
+        lifecycle_state=lifecycle_state,
+        record_kind=record_kind,
+        side=side,
+        validation_attempt_no=validation_attempt_no,
+        validation_outcome=validation_outcome,
+        confirm_flag=confirm_flag,
+        leg_role=leg_role,
+        qty_delta=qty_delta,
+        settlement_status=settlement_status,
+        signal_symbol=signal_symbol,
+        signal_venue=signal_venue,
+        broker="alpaca",
+        account_mode="alpaca_paper",
+        execution_symbol="BTCUSD",
+        execution_venue="alpaca_paper",
+        execution_asset_class="crypto",
+        instrument_type="crypto",
+        order_type="limit",
+        currency="USD",
+        raw_responses=None,
+        created_at=created_at or _T0,
+        **kwargs,
+    )
+
+
+def _mock_db_returning(rows: list[Any]) -> AsyncMock:
+    """DB mock whose list_by_correlation_id returns the provided rows list."""
+
+    class _ScalarResult:
+        def __init__(self, row_list):
+            self._rows = row_list
+
+        def scalar_one_or_none(self):
+            return self._rows[0] if self._rows else None
+
+        def scalars(self):
+            rows = self._rows
+
+            class _S:
+                def all(self_inner):
+                    return rows
+
+            return _S()
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_ScalarResult(rows))
+    db.commit = AsyncMock()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Full buy/sell roundtrip fixture
+# ---------------------------------------------------------------------------
+
+
+def _build_roundtrip_fixture() -> list[Any]:
+    """Synthetic rows representing a complete buy/sell paper roundtrip."""
+    return [
+        # 1. Buy leg: planned
+        _make_row(
+            client_order_id=_BUY_CLIENT_ORDER_ID,
+            lifecycle_state=LIFECYCLE_PLANNED,
+            record_kind=RECORD_KIND_PLAN,
+            side="buy",
+            leg_role="buy",
+            confirm_flag=None,
+            created_at=_ts(0),
+        ),
+        # 2. Buy leg: previewed
+        _make_row(
+            client_order_id=_BUY_CLIENT_ORDER_ID,
+            lifecycle_state=LIFECYCLE_PREVIEWED,
+            record_kind=RECORD_KIND_PREVIEW,
+            side="buy",
+            leg_role="buy",
+            confirm_flag=None,
+            created_at=_ts(1),
+        ),
+        # 3. Buy leg: validation attempt (confirm=false)
+        _make_row(
+            client_order_id=_BUY_CLIENT_ORDER_ID,
+            lifecycle_state=LIFECYCLE_VALIDATED,
+            record_kind=RECORD_KIND_VALIDATION_ATTEMPT,
+            side="buy",
+            leg_role="buy",
+            validation_attempt_no=1,
+            validation_outcome="passed",
+            confirm_flag=False,
+            created_at=_ts(2),
+        ),
+        # 4. Buy leg: submitted (execution, confirm=true)
+        _make_row(
+            client_order_id=_BUY_CLIENT_ORDER_ID,
+            lifecycle_state=LIFECYCLE_SUBMITTED,
+            record_kind=RECORD_KIND_EXECUTION,
+            side="buy",
+            leg_role="buy",
+            confirm_flag=True,
+            created_at=_ts(3),
+        ),
+        # 5. Buy leg: filled
+        _make_row(
+            client_order_id=_BUY_CLIENT_ORDER_ID,
+            lifecycle_state=LIFECYCLE_FILLED,
+            record_kind=RECORD_KIND_EXECUTION,
+            side="buy",
+            leg_role="buy",
+            confirm_flag=True,
+            qty_delta="0.001",
+            created_at=_ts(10),
+        ),
+        # 6. Buy leg: position reconciled
+        _make_row(
+            client_order_id=_BUY_CLIENT_ORDER_ID,
+            lifecycle_state=LIFECYCLE_POSITION_RECONCILED,
+            record_kind=RECORD_KIND_EXECUTION,
+            side="buy",
+            leg_role="buy",
+            confirm_flag=True,
+            qty_delta="0.001",
+            created_at=_ts(15),
+        ),
+        # 7. Sell leg: sell_validated (confirm=false)
+        _make_row(
+            client_order_id=_SELL_CLIENT_ORDER_ID,
+            lifecycle_state=LIFECYCLE_SELL_VALIDATED,
+            record_kind=RECORD_KIND_VALIDATION_ATTEMPT,
+            side="sell",
+            leg_role="sell",
+            validation_attempt_no=1,
+            validation_outcome="passed",
+            confirm_flag=False,
+            created_at=_ts(20),
+        ),
+        # 8. Sell leg: closed (execution, confirm=true)
+        _make_row(
+            client_order_id=_SELL_CLIENT_ORDER_ID,
+            lifecycle_state=LIFECYCLE_CLOSED,
+            record_kind=RECORD_KIND_EXECUTION,
+            side="sell",
+            leg_role="sell",
+            confirm_flag=True,
+            qty_delta="-0.001",
+            created_at=_ts(25),
+        ),
+        # 9. Final reconcile
+        _make_row(
+            client_order_id=_SELL_CLIENT_ORDER_ID,
+            lifecycle_state=LIFECYCLE_FINAL_RECONCILED,
+            record_kind=RECORD_KIND_RECONCILE,
+            side="sell",
+            leg_role="roundtrip",
+            confirm_flag=True,
+            settlement_status="n_a",
+            created_at=_ts(30),
+        ),
+    ]
+
+
+@pytest.mark.unit
+def test_roundtrip_fixture_all_states_in_canonical_set():
+    rows = _build_roundtrip_fixture()
+    for row in rows:
+        assert row.lifecycle_state in CANONICAL_LIFECYCLE_STATES, (
+            f"lifecycle_state={row.lifecycle_state!r} not in canonical set"
+        )
+
+
+@pytest.mark.unit
+def test_roundtrip_fixture_covers_expected_lifecycle_sequence():
+    rows = _build_roundtrip_fixture()
+    states = [r.lifecycle_state for r in rows]
+    expected_sequence = [
+        LIFECYCLE_PLANNED,
+        LIFECYCLE_PREVIEWED,
+        LIFECYCLE_VALIDATED,
+        LIFECYCLE_SUBMITTED,
+        LIFECYCLE_FILLED,
+        LIFECYCLE_POSITION_RECONCILED,
+        LIFECYCLE_SELL_VALIDATED,
+        LIFECYCLE_CLOSED,
+        LIFECYCLE_FINAL_RECONCILED,
+    ]
+    assert states == expected_sequence
+
+
+@pytest.mark.unit
+def test_roundtrip_fixture_buy_sell_legs_share_correlation_id():
+    rows = _build_roundtrip_fixture()
+    for row in rows:
+        assert row.lifecycle_correlation_id == _CORRELATION_ID, (
+            f"row {row.client_order_id!r} has wrong correlation id"
+        )
+
+
+@pytest.mark.unit
+def test_roundtrip_fixture_buy_sell_legs_distinct_client_order_ids():
+    rows = _build_roundtrip_fixture()
+    buy_rows = [r for r in rows if r.side == "buy"]
+    sell_rows = [r for r in rows if r.side == "sell"]
+    buy_ids = {r.client_order_id for r in buy_rows}
+    sell_ids = {r.client_order_id for r in sell_rows}
+    assert buy_ids == {_BUY_CLIENT_ORDER_ID}
+    assert sell_ids == {_SELL_CLIENT_ORDER_ID}
+    assert buy_ids.isdisjoint(sell_ids)
+
+
+@pytest.mark.unit
+def test_roundtrip_fixture_validation_rows_have_confirm_false():
+    rows = _build_roundtrip_fixture()
+    validation_rows = [
+        r for r in rows if r.record_kind == RECORD_KIND_VALIDATION_ATTEMPT
+    ]
+    assert len(validation_rows) >= 2
+    for row in validation_rows:
+        assert row.confirm_flag is False, (
+            f"Validation attempt row should have confirm_flag=False: {row!r}"
+        )
+
+
+@pytest.mark.unit
+def test_roundtrip_fixture_execution_rows_have_confirm_true():
+    rows = _build_roundtrip_fixture()
+    execution_rows = [r for r in rows if r.record_kind == RECORD_KIND_EXECUTION]
+    assert len(execution_rows) >= 2
+    for row in execution_rows:
+        assert row.confirm_flag is True, (
+            f"Execution row should have confirm_flag=True: {row!r}"
+        )
+
+
+@pytest.mark.unit
+def test_roundtrip_fixture_all_rows_have_signal_provenance():
+    rows = _build_roundtrip_fixture()
+    for row in rows:
+        assert row.signal_symbol is not None, (
+            f"Row {row.client_order_id!r} missing signal_symbol"
+        )
+        assert row.signal_venue is not None, (
+            f"Row {row.client_order_id!r} missing signal_venue"
+        )
+
+
+@pytest.mark.unit
+def test_roundtrip_fixture_timestamps_ordered():
+    rows = _build_roundtrip_fixture()
+    timestamps = [r.created_at for r in rows]
+    assert timestamps == sorted(timestamps), "Roundtrip rows must be in time order"
+
+
+@pytest.mark.unit
+def test_roundtrip_fixture_final_reconcile_has_settlement_status():
+    rows = _build_roundtrip_fixture()
+    final_rows = [r for r in rows if r.lifecycle_state == LIFECYCLE_FINAL_RECONCILED]
+    assert len(final_rows) == 1
+    assert final_rows[0].settlement_status == "n_a"
+
+
+@pytest.mark.unit
+def test_roundtrip_fixture_no_anomaly_in_happy_path():
+    rows = _build_roundtrip_fixture()
+    anomaly_rows = [r for r in rows if r.lifecycle_state == LIFECYCLE_ANOMALY]
+    assert len(anomaly_rows) == 0, "Happy-path fixture should have no anomaly rows"
+
+
+# ---------------------------------------------------------------------------
+# service list_by_correlation_id returns all roundtrip rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_list_by_correlation_id_returns_all_roundtrip_rows():
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    rows = _build_roundtrip_fixture()
+    db = _mock_db_returning(rows)
+
+    svc = AlpacaPaperLedgerService(db)
+    result = await svc.list_by_correlation_id(_CORRELATION_ID)
+    assert isinstance(result, list)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_list_by_correlation_id_empty_raises():
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    db = AsyncMock()
+    svc = AlpacaPaperLedgerService(db)
+    with pytest.raises(ValueError):
+        await svc.list_by_correlation_id("")

--- a/tests/services/test_alpaca_paper_ledger_service.py
+++ b/tests/services/test_alpaca_paper_ledger_service.py
@@ -1,7 +1,7 @@
-"""Tests for AlpacaPaperLedgerService lifecycle methods (ROB-84).
+"""Tests for AlpacaPaperLedgerService lifecycle methods (ROB-84/ROB-90).
 
 Covers: model columns/constraints, _derive_lifecycle_state, service method behavior,
-forbidden imports/strings, ORM model shape.
+forbidden imports/strings, ORM model shape, canonical taxonomy constants.
 """
 
 from __future__ import annotations
@@ -30,6 +30,19 @@ def test_alpaca_paper_ledger_model_columns():
     expected = {
         "id",
         "client_order_id",
+        # ROB-90 new columns
+        "lifecycle_correlation_id",
+        "record_kind",
+        "leg_role",
+        "validation_attempt_no",
+        "validation_outcome",
+        "confirm_flag",
+        "fee_amount",
+        "fee_currency",
+        "settlement_status",
+        "settlement_at",
+        "qty_delta",
+        # existing columns
         "broker",
         "account_mode",
         "lifecycle_state",
@@ -81,8 +94,9 @@ def test_alpaca_paper_ledger_model_constraints():
     from app.models.review import AlpacaPaperOrderLedger
 
     constraint_names = {c.name for c in AlpacaPaperOrderLedger.__table__.constraints}
-    assert "uq_alpaca_paper_ledger_client_order_id" in constraint_names
-    # SQLAlchemy may prefix with table name via naming convention
+    # ROB-90: old single-column unique replaced by partial unique indexes
+    assert "uq_alpaca_paper_ledger_client_order_id" not in constraint_names
+    # Core broker/mode/side constraints must still exist
     assert any("alpaca_paper_ledger_broker" in (n or "") for n in constraint_names)
     assert any(
         "alpaca_paper_ledger_account_mode" in (n or "") for n in constraint_names
@@ -92,43 +106,157 @@ def test_alpaca_paper_ledger_model_constraints():
     )
     assert any("alpaca_paper_ledger_side" in (n or "") for n in constraint_names)
     assert any("alpaca_paper_ledger_order_type" in (n or "") for n in constraint_names)
+    # ROB-90 new CHECK constraints
+    assert any("alpaca_paper_ledger_record_kind" in (n or "") for n in constraint_names)
+    assert any(
+        "alpaca_paper_ledger_validation_outcome" in (n or "") for n in constraint_names
+    )
+    assert any(
+        "alpaca_paper_ledger_settlement_status" in (n or "") for n in constraint_names
+    )
+
+
+@pytest.mark.unit
+def test_alpaca_paper_ledger_partial_unique_indexes():
+    from app.models.review import AlpacaPaperOrderLedger
+
+    index_names = {i.name for i in AlpacaPaperOrderLedger.__table__.indexes}
+    # ROB-90 partial unique indexes
+    assert "uq_alpaca_paper_ledger_client_order_kind" in index_names
+    assert "uq_alpaca_paper_ledger_validation_attempt" in index_names
+    # New correlation/record_kind lookup indexes
+    assert "ix_alpaca_paper_ledger_correlation_id" in index_names
+    assert "ix_alpaca_paper_ledger_record_kind" in index_names
+
+
+@pytest.mark.unit
+def test_alpaca_paper_ledger_lifecycle_check_canonical_states():
+    """The lifecycle CHECK must contain exactly the 10 ROB-90 canonical states."""
+    from app.models.review import AlpacaPaperOrderLedger
+
+    lifecycle_check = None
+    for c in AlpacaPaperOrderLedger.__table__.constraints:
+        # SQLAlchemy naming_convention prefixes check names with ck_<table>_.
+        if hasattr(c, "name") and c.name.endswith(
+            "alpaca_paper_ledger_lifecycle_state"
+        ):
+            lifecycle_check = c
+            break
+
+    assert lifecycle_check is not None
+    check_text = str(lifecycle_check.sqltext)
+
+    canonical = [
+        "planned",
+        "previewed",
+        "validated",
+        "submitted",
+        "filled",
+        "position_reconciled",
+        "sell_validated",
+        "closed",
+        "final_reconciled",
+        "anomaly",
+    ]
+    for state in canonical:
+        assert state in check_text, f"Canonical state {state!r} missing from CHECK"
+
+    excluded = [
+        "validation_failed",
+        "open",
+        "partially_filled",
+        "canceled",
+        "unexpected",
+    ]
+    for state in excluded:
+        assert state not in check_text, f"Old state {state!r} should not be in CHECK"
 
 
 # ---------------------------------------------------------------------------
-# _derive_lifecycle_state
+# Canonical lifecycle constants
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_canonical_lifecycle_constants_exported():
+    from app.services.alpaca_paper_ledger_service import (
+        CANONICAL_LIFECYCLE_STATES,
+        LIFECYCLE_ANOMALY,
+        LIFECYCLE_CLOSED,
+        LIFECYCLE_FILLED,
+        LIFECYCLE_FINAL_RECONCILED,
+        LIFECYCLE_PLANNED,
+        LIFECYCLE_POSITION_RECONCILED,
+        LIFECYCLE_PREVIEWED,
+        LIFECYCLE_SELL_VALIDATED,
+        LIFECYCLE_SUBMITTED,
+        LIFECYCLE_VALIDATED,
+    )
+
+    assert LIFECYCLE_PLANNED == "planned"
+    assert LIFECYCLE_PREVIEWED == "previewed"
+    assert LIFECYCLE_VALIDATED == "validated"
+    assert LIFECYCLE_SUBMITTED == "submitted"
+    assert LIFECYCLE_FILLED == "filled"
+    assert LIFECYCLE_POSITION_RECONCILED == "position_reconciled"
+    assert LIFECYCLE_SELL_VALIDATED == "sell_validated"
+    assert LIFECYCLE_CLOSED == "closed"
+    assert LIFECYCLE_FINAL_RECONCILED == "final_reconciled"
+    assert LIFECYCLE_ANOMALY == "anomaly"
+
+    assert len(CANONICAL_LIFECYCLE_STATES) == 10
+    assert CANONICAL_LIFECYCLE_STATES == {
+        "planned",
+        "previewed",
+        "validated",
+        "submitted",
+        "filled",
+        "position_reconciled",
+        "sell_validated",
+        "closed",
+        "final_reconciled",
+        "anomaly",
+    }
+
+
+# ---------------------------------------------------------------------------
+# _derive_lifecycle_state — ROB-90 canonical mapping
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
     "order_status,filled_qty,expected",
     [
-        ("canceled", None, "canceled"),
-        ("canceled", 0, "canceled"),
+        # filled → filled
         ("filled", None, "filled"),
         ("filled", 1.5, "filled"),
-        ("partially_filled", None, "partially_filled"),
-        ("partially_filled", 0.5, "partially_filled"),
-        # open statuses
-        ("new", None, "open"),
-        ("accepted", None, "open"),
-        ("pending_new", None, "open"),
-        ("accepted_for_bidding", None, "open"),
-        ("held", None, "open"),
-        ("pending_cancel", None, "open"),
-        ("pending_replace", None, "open"),
-        ("replaced", None, "open"),
-        # open status with filled_qty > 0 → unexpected
-        ("new", 0.5, "unexpected"),
-        ("accepted", 1.0, "unexpected"),
-        # open status with filled_qty = 0 → open
-        ("new", 0.0, "open"),
-        # unexpected statuses
-        ("rejected", None, "unexpected"),
-        ("expired", None, "unexpected"),
-        ("suspended", None, "unexpected"),
-        # unknown status
-        ("mystery_status", None, "unexpected"),
-        (None, None, "unexpected"),
+        # partially_filled → submitted (broker status preserved in order_status)
+        ("partially_filled", None, "submitted"),
+        ("partially_filled", 0.5, "submitted"),
+        # open statuses → submitted
+        ("new", None, "submitted"),
+        ("accepted", None, "submitted"),
+        ("pending_new", None, "submitted"),
+        ("accepted_for_bidding", None, "submitted"),
+        ("held", None, "submitted"),
+        ("pending_cancel", None, "submitted"),
+        ("pending_replace", None, "submitted"),
+        ("replaced", None, "submitted"),
+        # open status with filled_qty = 0 → submitted (not anomaly)
+        ("new", 0.0, "submitted"),
+        # open status with filled_qty > 0 → anomaly
+        ("new", 0.5, "anomaly"),
+        ("accepted", 1.0, "anomaly"),
+        # canceled → anomaly (ROB-90: no benign cancel state)
+        ("canceled", None, "anomaly"),
+        ("canceled", 0, "anomaly"),
+        # broker anomaly statuses
+        ("rejected", None, "anomaly"),
+        ("expired", None, "anomaly"),
+        ("suspended", None, "anomaly"),
+        # unknown status → anomaly
+        ("mystery_status", None, "anomaly"),
+        (None, None, "anomaly"),
     ],
 )
 @pytest.mark.unit
@@ -148,6 +276,8 @@ def _make_row(**kwargs) -> Any:
     defaults: dict[str, Any] = {
         "id": 1,
         "client_order_id": "test-client-001",
+        "lifecycle_correlation_id": "test-client-001",
+        "record_kind": "execution",
         "broker": "alpaca",
         "account_mode": "alpaca_paper",
         "lifecycle_state": "previewed",
@@ -156,10 +286,31 @@ def _make_row(**kwargs) -> Any:
         "instrument_type": "crypto",
         "side": "buy",
         "order_type": "limit",
+        "time_in_force": "gtc",
+        "requested_qty": None,
+        "requested_notional": None,
+        "requested_price": None,
         "currency": "USD",
+        "preview_payload": None,
+        "validation_summary": None,
         "raw_responses": None,
         "signal_symbol": "KRW-BTC",
         "signal_venue": "upbit",
+        "execution_asset_class": "crypto",
+        "workflow_stage": None,
+        "purpose": None,
+        "briefing_artifact_run_uuid": None,
+        "briefing_artifact_status": None,
+        "qa_evaluator_status": None,
+        "approval_bridge_generated_at": None,
+        "approval_bridge_status": None,
+        "candidate_uuid": None,
+        "validation_attempt_no": None,
+        "validation_outcome": None,
+        "confirm_flag": None,
+        "leg_role": None,
+        "settlement_status": None,
+        "qty_delta": None,
     }
     defaults.update(kwargs)
     return SimpleNamespace(**defaults)
@@ -186,6 +337,58 @@ def _mock_db_with_row(row: Any):
 
 
 # ---------------------------------------------------------------------------
+# record_plan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_record_plan_inserts_planned_row():
+    from app.models.trading import InstrumentType
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    row = _make_row(lifecycle_state="planned", record_kind="plan")
+    db = _mock_db_with_row(row)
+
+    svc = AlpacaPaperLedgerService(db)
+    result = await svc.record_plan(
+        client_order_id="test-client-001",
+        execution_symbol="BTCUSD",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.crypto,
+        side="buy",
+    )
+    assert result.lifecycle_state == "planned"
+    assert result.record_kind == "plan"
+    db.execute.assert_called()
+    db.commit.assert_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_record_plan_uses_client_order_id_as_correlation_default():
+    from app.models.trading import InstrumentType
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    row = _make_row(
+        lifecycle_state="planned",
+        record_kind="plan",
+        lifecycle_correlation_id="test-client-001",
+    )
+    db = _mock_db_with_row(row)
+
+    svc = AlpacaPaperLedgerService(db)
+    result = await svc.record_plan(
+        client_order_id="test-client-001",
+        execution_symbol="BTCUSD",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.crypto,
+        side="buy",
+    )
+    assert result.lifecycle_correlation_id == "test-client-001"
+
+
+# ---------------------------------------------------------------------------
 # record_preview
 # ---------------------------------------------------------------------------
 
@@ -196,7 +399,7 @@ async def test_record_preview_inserts_and_returns_row():
     from app.models.trading import InstrumentType
     from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
 
-    row = _make_row(lifecycle_state="previewed")
+    row = _make_row(lifecycle_state="previewed", record_kind="preview")
     db = _mock_db_with_row(row)
 
     svc = AlpacaPaperLedgerService(db)
@@ -208,6 +411,7 @@ async def test_record_preview_inserts_and_returns_row():
         side="buy",
     )
     assert result.lifecycle_state == "previewed"
+    assert result.record_kind == "preview"
     assert result.client_order_id == "test-client-001"
     db.execute.assert_called()
     db.commit.assert_called()
@@ -234,24 +438,23 @@ async def test_record_preview_empty_client_order_id_raises():
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_record_preview_validation_failed_lifecycle():
+async def test_record_preview_sets_correlation_id():
     from app.models.trading import InstrumentType
     from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
 
-    row = _make_row(lifecycle_state="validation_failed")
+    row = _make_row(lifecycle_state="previewed", lifecycle_correlation_id="corr-999")
     db = _mock_db_with_row(row)
 
     svc = AlpacaPaperLedgerService(db)
     result = await svc.record_preview(
-        client_order_id="test-client-002",
+        client_order_id="test-client-001",
+        lifecycle_correlation_id="corr-999",
         execution_symbol="BTCUSD",
         execution_venue="alpaca_paper",
         instrument_type=InstrumentType.crypto,
         side="buy",
-        lifecycle_state="validation_failed",
-        validation_summary={"reason": "insufficient_buying_power"},
     )
-    assert result.lifecycle_state == "validation_failed"
+    assert result.lifecycle_correlation_id == "corr-999"
 
 
 @pytest.mark.asyncio
@@ -277,8 +480,6 @@ async def test_record_preview_sanitizes_preview_payload():
         side="buy",
         preview_payload={"symbol": "BTCUSD", "api_key": "***"},
     )
-    # The returned row's preview_payload should have no raw secret
-    # (sanitization happens before persistence; we verify the call happened)
     assert result is not None
 
 
@@ -302,18 +503,129 @@ def test_redact_sensitive_text_masks_operator_narrative_values():
 
 
 # ---------------------------------------------------------------------------
+# record_validation_attempt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_record_validation_attempt_failed_creates_anomaly_row():
+    from app.models.trading import InstrumentType
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    row = _make_row(
+        lifecycle_state="anomaly",
+        record_kind="validation_attempt",
+        validation_attempt_no=1,
+        validation_outcome="failed",
+        confirm_flag=False,
+    )
+    db = _mock_db_with_row(row)
+
+    svc = AlpacaPaperLedgerService(db)
+    result = await svc.record_validation_attempt(
+        client_order_id="test-val-001",
+        execution_symbol="BTCUSD",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.crypto,
+        side="buy",
+        validation_attempt_no=1,
+        validation_outcome="failed",
+    )
+    assert result.lifecycle_state == "anomaly"
+    assert result.record_kind == "validation_attempt"
+    assert result.validation_attempt_no == 1
+    assert result.validation_outcome == "failed"
+    assert result.confirm_flag is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_record_validation_attempt_passed_creates_validated_row():
+    from app.models.trading import InstrumentType
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    row = _make_row(
+        lifecycle_state="validated",
+        record_kind="validation_attempt",
+        validation_attempt_no=1,
+        validation_outcome="passed",
+        confirm_flag=False,
+    )
+    db = _mock_db_with_row(row)
+
+    svc = AlpacaPaperLedgerService(db)
+    result = await svc.record_validation_attempt(
+        client_order_id="test-val-002",
+        execution_symbol="BTCUSD",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.crypto,
+        side="buy",
+        validation_attempt_no=1,
+        validation_outcome="passed",
+    )
+    assert result.lifecycle_state == "validated"
+    assert result.confirm_flag is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_record_validation_attempt_increments():
+    from app.models.trading import InstrumentType
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    row2 = _make_row(
+        lifecycle_state="anomaly",
+        record_kind="validation_attempt",
+        validation_attempt_no=2,
+        validation_outcome="failed",
+        confirm_flag=False,
+    )
+    db = _mock_db_with_row(row2)
+
+    svc = AlpacaPaperLedgerService(db)
+    result = await svc.record_validation_attempt(
+        client_order_id="test-val-003",
+        execution_symbol="BTCUSD",
+        execution_venue="alpaca_paper",
+        instrument_type=InstrumentType.crypto,
+        side="buy",
+        validation_attempt_no=2,
+        validation_outcome="failed",
+    )
+    assert result.validation_attempt_no == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_record_validation_attempt_invalid_no_raises():
+    from app.models.trading import InstrumentType
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    db = AsyncMock()
+    svc = AlpacaPaperLedgerService(db)
+    with pytest.raises(ValueError, match="validation_attempt_no must be >= 1"):
+        await svc.record_validation_attempt(
+            client_order_id="test-val-004",
+            execution_symbol="BTCUSD",
+            execution_venue="alpaca_paper",
+            instrument_type=InstrumentType.crypto,
+            side="buy",
+            validation_attempt_no=0,
+        )
+
+
+# ---------------------------------------------------------------------------
 # record_submit
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_record_submit_canceled_order():
-    from app.services.alpaca_paper_ledger_service import (
-        AlpacaPaperLedgerService,
-    )
+async def test_record_submit_anomaly_on_canceled_order():
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
 
-    row = _make_row(lifecycle_state="canceled", order_status="canceled")
+    row = _make_row(lifecycle_state="anomaly", order_status="canceled")
     db = _mock_db_with_row(row)
 
     svc = AlpacaPaperLedgerService(db)
@@ -321,7 +633,7 @@ async def test_record_submit_canceled_order():
         "test-client-001",
         order={"id": "broker-order-id", "status": "canceled", "filled_qty": "0"},
     )
-    assert result.lifecycle_state == "canceled"
+    assert result.lifecycle_state == "anomaly"
 
 
 @pytest.mark.asyncio
@@ -352,10 +664,10 @@ async def test_record_submit_filled_order():
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_record_submit_partially_filled():
+async def test_record_submit_partially_filled_is_submitted():
     from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
 
-    row = _make_row(lifecycle_state="partially_filled", order_status="partially_filled")
+    row = _make_row(lifecycle_state="submitted", order_status="partially_filled")
     db = _mock_db_with_row(row)
 
     svc = AlpacaPaperLedgerService(db)
@@ -363,15 +675,15 @@ async def test_record_submit_partially_filled():
         "test-client-001",
         order={"id": "bid2", "status": "partially_filled", "filled_qty": "0.0005"},
     )
-    assert result.lifecycle_state == "partially_filled"
+    assert result.lifecycle_state == "submitted"
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_record_submit_rejected_is_unexpected():
+async def test_record_submit_rejected_is_anomaly():
     from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
 
-    row = _make_row(lifecycle_state="unexpected", order_status="rejected")
+    row = _make_row(lifecycle_state="anomaly", order_status="rejected")
     db = _mock_db_with_row(row)
 
     svc = AlpacaPaperLedgerService(db)
@@ -379,15 +691,15 @@ async def test_record_submit_rejected_is_unexpected():
         "test-client-001",
         order={"id": "bid3", "status": "rejected"},
     )
-    assert result.lifecycle_state == "unexpected"
+    assert result.lifecycle_state == "anomaly"
 
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_record_submit_unknown_status_is_unexpected():
+async def test_record_submit_unknown_status_is_anomaly():
     from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
 
-    row = _make_row(lifecycle_state="unexpected", order_status="mystery")
+    row = _make_row(lifecycle_state="anomaly", order_status="mystery")
     db = _mock_db_with_row(row)
 
     svc = AlpacaPaperLedgerService(db)
@@ -395,7 +707,7 @@ async def test_record_submit_unknown_status_is_unexpected():
         "test-client-001",
         order={"id": "bid4", "status": "mystery"},
     )
-    assert result.lifecycle_state == "unexpected"
+    assert result.lifecycle_state == "anomaly"
 
 
 # ---------------------------------------------------------------------------
@@ -408,13 +720,12 @@ async def test_record_submit_unknown_status_is_unexpected():
 async def test_record_cancel_writes_cancel_metadata():
     from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
 
-    row = _make_row(cancel_status="confirmed", lifecycle_state="canceled")
+    row = _make_row(cancel_status="confirmed", lifecycle_state="anomaly")
     db = _mock_db_with_row(row)
 
     svc = AlpacaPaperLedgerService(db)
     result = await svc.record_cancel("test-client-001", cancel_status="confirmed")
     assert result.cancel_status == "confirmed"
-    # lifecycle_state should come from record_status, not forced here
     db.execute.assert_called()
 
 
@@ -433,7 +744,8 @@ async def test_record_position_snapshot_none_writes_zero_qty():
             "qty": "0",
             "avg_entry_price": None,
             "fetched_at": "2026-05-03T00:00:00+00:00",
-        }
+        },
+        lifecycle_state="position_reconciled",
     )
     db = _mock_db_with_row(row)
 
@@ -441,6 +753,7 @@ async def test_record_position_snapshot_none_writes_zero_qty():
     result = await svc.record_position_snapshot("test-client-001", position=None)
     assert result.position_snapshot["qty"] == "0"
     assert result.position_snapshot["avg_entry_price"] is None
+    assert result.lifecycle_state == "position_reconciled"
 
 
 @pytest.mark.asyncio
@@ -453,7 +766,8 @@ async def test_record_position_snapshot_with_position_writes_qty():
             "qty": "0.001",
             "avg_entry_price": "50000",
             "fetched_at": "2026-05-03T00:00:00+00:00",
-        }
+        },
+        lifecycle_state="position_reconciled",
     )
     db = _mock_db_with_row(row)
 
@@ -464,6 +778,25 @@ async def test_record_position_snapshot_with_position_writes_qty():
     )
     assert result.position_snapshot["qty"] == "0.001"
     assert result.position_snapshot["avg_entry_price"] == "50000"
+
+
+# ---------------------------------------------------------------------------
+# record_close
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_record_close_advances_to_closed():
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    row = _make_row(lifecycle_state="closed", qty_delta="-0.001")
+    db = _mock_db_with_row(row)
+
+    svc = AlpacaPaperLedgerService(db)
+    result = await svc.record_close("test-client-001", qty_delta=-0.001)
+    assert result.lifecycle_state == "closed"
+    db.execute.assert_called()
 
 
 # ---------------------------------------------------------------------------
@@ -528,6 +861,83 @@ async def test_record_reconcile_clears_error_summary_when_omitted():
     update_stmt = db.execute.call_args_list[1].args[0]
     update_params = update_stmt.compile().params
     assert update_params["error_summary"] is None
+
+
+# ---------------------------------------------------------------------------
+# record_final_reconcile
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_record_final_reconcile_advances_to_final_reconciled():
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    row = _make_row(
+        lifecycle_state="final_reconciled",
+        record_kind="reconcile",
+        settlement_status="n_a",
+    )
+    db = _mock_db_with_row(row)
+
+    svc = AlpacaPaperLedgerService(db)
+    result = await svc.record_final_reconcile("test-client-001")
+    assert result.lifecycle_state == "final_reconciled"
+    assert result.settlement_status == "n_a"
+
+
+# ---------------------------------------------------------------------------
+# list_by_correlation_id
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_list_by_correlation_id_returns_rows():
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    buy_row = _make_row(
+        client_order_id="buy-001",
+        lifecycle_correlation_id="corr-abc",
+        side="buy",
+        lifecycle_state="filled",
+    )
+    sell_row = _make_row(
+        client_order_id="sell-001",
+        lifecycle_correlation_id="corr-abc",
+        side="sell",
+        lifecycle_state="closed",
+    )
+
+    class _ScalarResult:
+        def scalar_one_or_none(self):
+            return buy_row
+
+        def scalars(self):
+            class _S:
+                def all(self_inner):
+                    return [buy_row, sell_row]
+
+            return _S()
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_ScalarResult())
+    db.commit = AsyncMock()
+
+    svc = AlpacaPaperLedgerService(db)
+    rows = await svc.list_by_correlation_id("corr-abc")
+    assert isinstance(rows, list)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_list_by_correlation_id_empty_raises():
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    db = AsyncMock()
+    svc = AlpacaPaperLedgerService(db)
+    with pytest.raises(ValueError, match="lifecycle_correlation_id must not be empty"):
+        await svc.list_by_correlation_id("  ")
 
 
 # ---------------------------------------------------------------------------
@@ -597,7 +1007,6 @@ async def test_raw_responses_accumulate_by_event_key():
 
     def make_execute_mock():
         async def _execute(stmt):
-            # Track update calls that contain raw_responses
             nonlocal accumulated
             return _ScalarResult(
                 _make_row(raw_responses=accumulated if accumulated else None)
@@ -608,32 +1017,63 @@ async def test_raw_responses_accumulate_by_event_key():
     db = AsyncMock()
     db.commit = AsyncMock()
 
-    # Simulate accumulation by tracking the update values
     existing_raw: dict = {}
 
     async def execute_side_effect(stmt):
         nonlocal existing_raw
-        # When it's a select, return row with current raw_responses
         row = _make_row(raw_responses=dict(existing_raw))
         return _ScalarResult(row)
 
     db.execute = AsyncMock(side_effect=execute_side_effect)
 
     svc = AlpacaPaperLedgerService(db)
-    # First accumulation
     existing_raw["submit"] = {"status": "canceled"}
     await svc._accumulate_raw_response("test-client-001", "status", {"status": "new"})
-    # Second accumulation
     existing_raw["status"] = {"status": "new"}
     await svc._accumulate_raw_response("test-client-001", "cancel", {"cancel": "ok"})
 
-    # Verify execute was called multiple times
     assert db.execute.call_count >= 2
 
 
 # ---------------------------------------------------------------------------
-# Static safety: no broker mutation imports
+# Static safety: no broker mutation imports / fan-out ledger updates
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_lifecycle_update_statements_scope_by_primary_key():
+    """Lifecycle updates must not fan out across rows sharing client_order_id."""
+    source = SERVICE_PATH.read_text()
+    tree = ast.parse(source)
+
+    def is_ledger_update_expr(node: ast.AST) -> bool:
+        if isinstance(node, ast.Call):
+            if (
+                isinstance(node.func, ast.Name)
+                and node.func.id == "update"
+                and node.args
+                and ast.unparse(node.args[0]) == "AlpacaPaperOrderLedger"
+            ):
+                return True
+            return is_ledger_update_expr(node.func)
+        if isinstance(node, ast.Attribute):
+            return is_ledger_update_expr(node.value)
+        return False
+
+    update_where_conditions: list[str] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "where"
+            and is_ledger_update_expr(node.func.value)
+        ):
+            condition = ast.unparse(node.args[0])
+            update_where_conditions.append(condition)
+            assert "AlpacaPaperOrderLedger.id" in condition
+            assert "AlpacaPaperOrderLedger.client_order_id" not in condition
+
+    assert update_where_conditions
 
 
 @pytest.mark.unit
@@ -644,7 +1084,6 @@ def test_service_has_no_broker_mutation_imports():
     source = SERVICE_PATH.read_text()
     tree = _ast.parse(source)
 
-    # Collect all import lines as strings for pattern matching
     import_strings: list[str] = []
     for node in _ast.walk(tree):
         if isinstance(node, (_ast.Import, _ast.ImportFrom)):
@@ -652,7 +1091,6 @@ def test_service_has_no_broker_mutation_imports():
 
     import_source = "\n".join(import_strings)
 
-    # These must not appear in any import statement
     forbidden_imports = [
         "AlpacaPaperBrokerService",
         "app.services.brokers",
@@ -667,7 +1105,6 @@ def test_service_has_no_broker_mutation_imports():
             f"Forbidden import/string found in service imports: {term!r}"
         )
 
-    # These strings must not appear anywhere in the source (including non-import lines)
     forbidden_anywhere = [
         "submit_order",
         "cancel_order",

--- a/tests/test_alpaca_paper_smoke_safety.py
+++ b/tests/test_alpaca_paper_smoke_safety.py
@@ -93,6 +93,19 @@ async def test_run_smoke_exits_zero_when_all_tools_succeed(
     async def fake_ledger_get(client_order_id: str) -> dict:
         return {"success": False, "found": False, "client_order_id": client_order_id}
 
+    async def fake_ledger_get_by_correlation(lifecycle_correlation_id: str) -> dict:
+        if (
+            not isinstance(lifecycle_correlation_id, str)
+            or not lifecycle_correlation_id.strip()
+        ):
+            raise ValueError("lifecycle_correlation_id is required")
+        return {
+            "success": True,
+            "lifecycle_correlation_id": lifecycle_correlation_id,
+            "count": 0,
+            "items": [],
+        }
+
     async def fake_preflight_check(*args, **kwargs) -> dict:  # noqa: ANN002, ANN003
         return {"success": True, "should_block": False, "anomalies": []}
 
@@ -105,6 +118,7 @@ async def test_run_smoke_exits_zero_when_all_tools_succeed(
         spec.loader.exec_module(module)  # type: ignore[union-attr]
         module.alpaca_paper_ledger_list_recent = fake_ledger_list_recent
         module.alpaca_paper_ledger_get = fake_ledger_get
+        module.alpaca_paper_ledger_get_by_correlation = fake_ledger_get_by_correlation
         module.alpaca_paper_execution_preflight_check = fake_preflight_check
         exit_code = await module.run_smoke()
     finally:


### PR DESCRIPTION
## Summary
- Normalizes Alpaca Paper execution ledger taxonomy so submit/preview/validation attempts are represented consistently.
- Adds migration/backfill support, API/read-tool schema updates, and ledger service lifecycle helpers.
- Updates the Alpaca paper ledger runbook and expands service/router/MCP regression coverage.

## Safety / scope
- Alpaca Paper ledger taxonomy only.
- No live trading path, generic broker route, KIS/Upbit mutation, bulk cancel/close/liquidation, or order side-effect smoke was added or run.
- No secret, token, account credential, or Authorization value is included.

## Verification
From K2 independent review:
- `git diff --check` passed.
- Targeted safety grep passed: no mutating route decorators or broker/order mutation additions; only safety-doc/comment KIS/Upbit hits.
- Diff secret grep passed: only redaction docs/tests, no raw secrets.
- `uv run pytest tests/services/test_alpaca_paper_ledger_service.py tests/services/test_alpaca_paper_ledger_lifecycle_fixture.py tests/routers/test_alpaca_paper_ledger_router.py tests/mcp_server/test_alpaca_paper_ledger_read_tools.py -q` passed: 95 passed, 2 warnings.
- `uv run pytest -m unit -k alpaca_paper_ledger -q` passed: 105 passed, 4940 deselected, 8 warnings.
- Targeted `uv run ruff check` on changed Python files passed.
- Targeted `uv run ruff format --check` on changed Python files passed: 11 files already formatted.
- `uv run python -m py_compile alembic/versions/d4e5f6a7b8c9_normalize_alpaca_paper_ledger_taxonomy.py` passed.
- `uv run alembic heads` passed: `d4e5f6a7b8c9 (head)`.

## Review
- K2 independent Claude Opus review: PASS, no blocking findings.
- Linear review comment: `a511dc02-68c8-47e8-8a0d-b5b3a46b8c16`.

Linear: ROB-90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Correlation-based ledger lookup to fetch related buy/sell roundtrips; new read API endpoint and MCP tool to return grouped results with count and items
  * Ledger responses now include correlation/record metadata, validation/confirmation, fee/settlement details, and quantity delta

* **Documentation**
  * Runbook and docs updated to the new canonical lifecycle taxonomy and migration mapping

* **Tests**
  * Added coverage for correlation listing, lifecycle flows, and new ledger fields
<!-- end of auto-generated comment: release notes by coderabbit.ai -->