### PR TITLE
ROB-93: add Alpaca paper anomaly preflight checks

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -129,8 +129,22 @@ names only:
 - `alpaca_paper_get_order(order_id)`
 - `alpaca_paper_list_assets(status="active", asset_class="us_equity")`
 - `alpaca_paper_list_fills(after=None, until=None, limit=50)`
+- `alpaca_paper_ledger_list_recent(limit=50, lifecycle_state=None)`
+- `alpaca_paper_ledger_get(client_order_id)`
+- `alpaca_paper_execution_preflight_check(...)`
 
-These tools instantiate `AlpacaPaperBrokerService`, so they inherit the
+`alpaca_paper_execution_preflight_check` is a read-only runner gate for the
+later automated paper cycle. It reads recent ledger rows and accepts optional
+caller-supplied read-only `open_orders`, `positions`, and `approval_packet`
+snapshots, then returns severity-classified anomalies plus `should_block`. ROB-93
+checks include unexpected open orders, residual positions, duplicate
+`client_order_id`, filled buys without linked sells, filled sells without a zero
+final position snapshot, ledger/order/fill mismatches, stale previews/approval
+packets, and signal/execution symbol mismatches. It performs no broker mutation,
+no repair writes, and no direct DB backfill.
+
+The broker inspection tools instantiate `AlpacaPaperBrokerService`, so they
+inherit the
 service-level endpoint guard: the trading base URL must be exactly
 `https://paper-api.alpaca.markets`. The Alpaca dashboard may display
 `https://paper-api.alpaca.markets/v2`, but runtime env should **not** include

--- a/app/mcp_server/tooling/alpaca_paper.py
+++ b/app/mcp_server/tooling/alpaca_paper.py
@@ -27,9 +27,10 @@ ALPACA_PAPER_READONLY_TOOL_NAMES: set[str] = {
     "alpaca_paper_get_order",
     "alpaca_paper_list_assets",
     "alpaca_paper_list_fills",
-    # ROB-84 ledger read tools
+    # ROB-84/ROB-93 ledger read and anomaly preflight tools
     "alpaca_paper_ledger_list_recent",
     "alpaca_paper_ledger_get",
+    "alpaca_paper_execution_preflight_check",
 }
 
 ServiceFactory = Callable[[], AlpacaPaperBrokerService]

--- a/app/mcp_server/tooling/alpaca_paper_ledger_read.py
+++ b/app/mcp_server/tooling/alpaca_paper_ledger_read.py
@@ -10,6 +10,9 @@ from typing import TYPE_CHECKING, Any, cast
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.db import AsyncSessionLocal
+from app.services.alpaca_paper_anomaly_checks import (
+    build_paper_execution_preflight_report,
+)
 from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
 
 if TYPE_CHECKING:
@@ -100,6 +103,54 @@ async def alpaca_paper_ledger_get(
     }
 
 
+async def alpaca_paper_execution_preflight_check(
+    limit: int = 50,
+    open_orders: list[dict[str, Any]] | None = None,
+    positions: list[dict[str, Any]] | None = None,
+    approval_packet: dict[str, Any] | None = None,
+    expected_signal_symbol: str | None = None,
+    expected_execution_symbol: str | None = None,
+    stale_after_minutes: int = 30,
+) -> dict[str, Any]:
+    """Run read-only Alpaca Paper execution anomaly checks.
+
+    The tool reads recent ledger rows and combines them with optional caller-
+    supplied read-only broker snapshots. It never submits, cancels, repairs, or
+    writes data. The returned ``should_block`` field is intended for runner
+    preflight gates.
+    """
+    if limit < 1:
+        raise ValueError("limit must be >= 1")
+    limit = min(limit, 200)
+    if stale_after_minutes < 1:
+        raise ValueError("stale_after_minutes must be >= 1")
+
+    async with _session_factory()() as db:
+        svc = AlpacaPaperLedgerService(db)
+        rows = await svc.list_recent(limit=limit)
+
+    report = build_paper_execution_preflight_report(
+        ledger_rows=rows,
+        open_orders=open_orders or [],
+        positions=positions or [],
+        approval_packet=approval_packet,
+        expected_signal_symbol=expected_signal_symbol,
+        expected_execution_symbol=expected_execution_symbol,
+        stale_after_minutes=stale_after_minutes,
+    )
+    data = report.to_dict()
+    data.update(
+        {
+            "success": True,
+            "account_mode": "alpaca_paper",
+            "source": "alpaca_paper_execution_preflight",
+            "read_only": True,
+            "limit": limit,
+        }
+    )
+    return data
+
+
 def register_alpaca_paper_ledger_read_tools(mcp: FastMCP) -> None:
     """Register read-only Alpaca Paper ledger MCP tools."""
     _ = mcp.tool(
@@ -116,9 +167,18 @@ def register_alpaca_paper_ledger_read_tools(mcp: FastMCP) -> None:
             "Returns found/not-found shape. No broker mutation."
         ),
     )(alpaca_paper_ledger_get)
+    _ = mcp.tool(
+        name="alpaca_paper_execution_preflight_check",
+        description=(
+            "Read-only Alpaca Paper execution anomaly preflight. Returns "
+            "severity-classified findings and should_block for cycle runners. "
+            "No broker mutation and no repair writes."
+        ),
+    )(alpaca_paper_execution_preflight_check)
 
 
 __all__ = [
+    "alpaca_paper_execution_preflight_check",
     "alpaca_paper_ledger_get",
     "alpaca_paper_ledger_list_recent",
     "register_alpaca_paper_ledger_read_tools",

--- a/app/services/alpaca_paper_anomaly_checks.py
+++ b/app/services/alpaca_paper_anomaly_checks.py
@@ -1,0 +1,489 @@
+"""Read-only Alpaca Paper execution anomaly checks (ROB-93).
+
+The checks in this module are deterministic and side-effect free.  They do not
+call brokers, submit/cancel orders, repair rows, or write to the database.  A
+runner or report builder supplies ledger rows plus optional read-only broker
+snapshots, and the service returns an operator-readable preflight report.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from enum import StrEnum
+from typing import Any
+
+
+class PaperExecutionAnomalySeverity(StrEnum):
+    """Severity used by runner gates and operator reports."""
+
+    info = "info"
+    warning = "warning"
+    block = "block"
+
+
+@dataclass(frozen=True)
+class PaperExecutionAnomaly:
+    """One deterministic anomaly finding."""
+
+    check_id: str
+    severity: PaperExecutionAnomalySeverity
+    summary: str
+    details: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "check_id": self.check_id,
+            "severity": self.severity.value,
+            "summary": self.summary,
+            "details": self.details,
+        }
+
+
+@dataclass(frozen=True)
+class PaperExecutionPreflightReport:
+    """Preflight anomaly report consumed by runners and audit views."""
+
+    status: str
+    should_block: bool
+    checked_at: datetime
+    stale_after_minutes: int
+    anomalies: tuple[PaperExecutionAnomaly, ...]
+    counts: dict[str, int]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "should_block": self.should_block,
+            "checked_at": self.checked_at.isoformat(),
+            "stale_after_minutes": self.stale_after_minutes,
+            "counts": self.counts,
+            "anomalies": [a.to_dict() for a in self.anomalies],
+        }
+
+
+_OPEN_LEDGER_STATES = frozenset({"submitted", "open", "partially_filled"})
+_FILLED_STATES = frozenset({"filled", "partially_filled"})
+_TERMINAL_STATES = frozenset({"filled", "canceled"})
+_SELL_SOURCE_KEYS = frozenset(
+    {
+        "source_client_order_id",
+        "source_order_client_order_id",
+        "previous_buy_client_order_id",
+        "buy_client_order_id",
+        "source_ledger_client_order_id",
+    }
+)
+
+
+def _get(row: Any, key: str, default: Any = None) -> Any:
+    if isinstance(row, dict):
+        return row.get(key, default)
+    return getattr(row, key, default)
+
+
+def _iso(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def _decimal(value: Any) -> Decimal:
+    if value is None or value == "":
+        return Decimal("0")
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return Decimal("0")
+
+
+def _normalize_symbol(symbol: Any) -> str:
+    return str(symbol or "").upper().replace("/", "").replace("-", "").strip()
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if value is None or isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        if text.endswith("Z"):
+            text = f"{text[:-1]}+00:00"
+        try:
+            return datetime.fromisoformat(text)
+        except ValueError:
+            return None
+    return None
+
+
+def _as_aware_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _iter_nested_values(payload: Any) -> Iterable[tuple[str, Any]]:
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            yield str(key), value
+            yield from _iter_nested_values(value)
+    elif isinstance(payload, list):
+        for item in payload:
+            yield from _iter_nested_values(item)
+
+
+def _source_client_order_ids(row: Any) -> set[str]:
+    ids: set[str] = set()
+    for field in ("preview_payload", "validation_summary", "raw_responses"):
+        for key, value in _iter_nested_values(_get(row, field) or {}):
+            if key in _SELL_SOURCE_KEYS and value:
+                ids.add(str(value))
+    return ids
+
+
+def _is_open_order(order: dict[str, Any]) -> bool:
+    status = str(order.get("status") or "").lower()
+    if not status:
+        return True
+    return status not in {"filled", "canceled", "cancelled", "expired", "rejected"}
+
+
+def _position_qty(position: dict[str, Any]) -> Decimal:
+    return _decimal(
+        position.get("qty")
+        or position.get("quantity")
+        or position.get("position_qty")
+        or position.get("available")
+    )
+
+
+def _latest_preview_time(row: Any) -> datetime | None:
+    candidates = [
+        _get(row, "approval_bridge_generated_at"),
+        _get(row, "created_at"),
+    ]
+    preview_payload = _get(row, "preview_payload") or {}
+    if isinstance(preview_payload, dict):
+        candidates.extend(
+            [
+                preview_payload.get("generated_at"),
+                preview_payload.get("previewed_at"),
+                preview_payload.get("expires_at"),
+            ]
+        )
+    for value in candidates:
+        parsed = _as_aware_utc(_parse_datetime(value))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _row_ref(row: Any) -> dict[str, Any]:
+    return {
+        "client_order_id": _get(row, "client_order_id"),
+        "side": _get(row, "side"),
+        "lifecycle_state": _get(row, "lifecycle_state"),
+        "order_status": _get(row, "order_status"),
+        "execution_symbol": _get(row, "execution_symbol"),
+        "signal_symbol": _get(row, "signal_symbol"),
+        "filled_qty": str(_get(row, "filled_qty"))
+        if _get(row, "filled_qty") is not None
+        else None,
+        "created_at": _iso(_get(row, "created_at")),
+    }
+
+
+def build_paper_execution_preflight_report(
+    *,
+    ledger_rows: Iterable[Any] = (),
+    open_orders: Iterable[dict[str, Any]] = (),
+    positions: Iterable[dict[str, Any]] = (),
+    approval_packet: dict[str, Any] | None = None,
+    expected_signal_symbol: str | None = None,
+    expected_execution_symbol: str | None = None,
+    now: datetime | None = None,
+    stale_after_minutes: int = 30,
+) -> PaperExecutionPreflightReport:
+    """Build a read-only Alpaca Paper execution preflight anomaly report.
+
+    Args:
+        ledger_rows: Recent or correlation-scoped ledger rows. ORM rows and
+            dictionaries are both accepted for deterministic tests.
+        open_orders: Read-only broker open-order snapshot already fetched by
+            the caller. Non-terminal rows block a new cycle.
+        positions: Read-only position snapshot already fetched by the caller.
+            Any non-zero quantity blocks a new cycle.
+        approval_packet: Optional preview/approval packet being considered for
+            execution. Used for duplicate, stale, and symbol checks.
+        expected_signal_symbol: Optional symbol from the signal artifact.
+        expected_execution_symbol: Optional symbol expected at Alpaca Paper.
+        now: Clock injection for deterministic tests.
+        stale_after_minutes: Preview/approval max age before blocking.
+    """
+    checked_at = _as_aware_utc(now) or datetime.now(UTC)
+    ledger = list(ledger_rows)
+    orders = list(open_orders)
+    position_rows = list(positions)
+    packet = approval_packet or {}
+    anomalies: list[PaperExecutionAnomaly] = []
+
+    def add(
+        check_id: str,
+        severity: PaperExecutionAnomalySeverity,
+        summary: str,
+        details: dict[str, Any],
+    ) -> None:
+        anomalies.append(PaperExecutionAnomaly(check_id, severity, summary, details))
+
+    # 1. Unexpected open orders.
+    open_snapshot = [o for o in orders if _is_open_order(o)]
+    if open_snapshot:
+        add(
+            "unexpected_open_orders",
+            PaperExecutionAnomalySeverity.block,
+            "Alpaca Paper has open orders before starting a new cycle",
+            {
+                "count": len(open_snapshot),
+                "orders": [
+                    {
+                        "id": o.get("id") or o.get("order_id"),
+                        "client_order_id": o.get("client_order_id"),
+                        "symbol": o.get("symbol"),
+                        "status": o.get("status"),
+                        "side": o.get("side"),
+                    }
+                    for o in open_snapshot
+                ],
+            },
+        )
+
+    # 2. Residual positions before a new cycle.
+    residual_positions = [p for p in position_rows if _position_qty(p) != Decimal("0")]
+    if residual_positions:
+        add(
+            "residual_position_exists",
+            PaperExecutionAnomalySeverity.block,
+            "Residual Alpaca Paper position exists before starting a new cycle",
+            {
+                "count": len(residual_positions),
+                "positions": [
+                    {
+                        "symbol": p.get("symbol"),
+                        "qty": str(_position_qty(p)),
+                        "asset_class": p.get("asset_class"),
+                    }
+                    for p in residual_positions
+                ],
+            },
+        )
+
+    # 3. Duplicate client_order_id, both within the ledger slice and against
+    # the candidate approval packet.
+    by_client_id: dict[str, list[Any]] = {}
+    for row in ledger:
+        client_id = str(_get(row, "client_order_id") or "").strip()
+        if client_id:
+            by_client_id.setdefault(client_id, []).append(row)
+    duplicate_ids = {k: v for k, v in by_client_id.items() if len(v) > 1}
+    packet_client_id = str(packet.get("client_order_id") or "").strip()
+    if packet_client_id and packet_client_id in by_client_id:
+        duplicate_ids.setdefault(packet_client_id, by_client_id[packet_client_id])
+    if duplicate_ids:
+        add(
+            "duplicate_client_order_id",
+            PaperExecutionAnomalySeverity.block,
+            "client_order_id is already present in the Alpaca Paper ledger",
+            {
+                "client_order_ids": sorted(duplicate_ids),
+                "rows": [
+                    _row_ref(row) for rows in duplicate_ids.values() for row in rows[:5]
+                ],
+            },
+        )
+
+    # 4. Previous buy filled but no linked sell exists.
+    sell_source_ids = {
+        source_id
+        for row in ledger
+        if str(_get(row, "side") or "").lower() == "sell"
+        for source_id in _source_client_order_ids(row)
+    }
+    filled_buys_missing_sell = []
+    for row in ledger:
+        side = str(_get(row, "side") or "").lower()
+        state = str(_get(row, "lifecycle_state") or "").lower()
+        client_id = str(_get(row, "client_order_id") or "").strip()
+        if (
+            side == "buy"
+            and state in _FILLED_STATES
+            and client_id not in sell_source_ids
+        ):
+            filled_buys_missing_sell.append(row)
+    if filled_buys_missing_sell:
+        add(
+            "previous_buy_filled_sell_missing",
+            PaperExecutionAnomalySeverity.block,
+            "A previous filled buy has no linked sell ledger row",
+            {"rows": [_row_ref(r) for r in filled_buys_missing_sell[:10]]},
+        )
+
+    # 5. Sell filled but final position not closed.
+    sells_not_closed = []
+    for row in ledger:
+        side = str(_get(row, "side") or "").lower()
+        state = str(_get(row, "lifecycle_state") or "").lower()
+        if side != "sell" or state != "filled":
+            continue
+        snapshot = _get(row, "position_snapshot") or {}
+        if not isinstance(snapshot, dict) or _position_qty(snapshot) != Decimal("0"):
+            sells_not_closed.append(row)
+    if sells_not_closed:
+        add(
+            "sell_filled_position_not_closed",
+            PaperExecutionAnomalySeverity.block,
+            "A filled sell does not have a zero final position snapshot",
+            {"rows": [_row_ref(r) for r in sells_not_closed[:10]]},
+        )
+
+    # 6. Ledger/order/fill mismatches.
+    mismatches = []
+    for row in ledger:
+        state = str(_get(row, "lifecycle_state") or "").lower()
+        order_status = str(_get(row, "order_status") or "").lower()
+        filled_qty = _decimal(_get(row, "filled_qty"))
+        if state == "filled" and filled_qty <= Decimal("0"):
+            mismatches.append(
+                {"reason": "filled_state_without_filled_qty", **_row_ref(row)}
+            )
+        if order_status == "filled" and state != "filled":
+            mismatches.append(
+                {"reason": "order_status_filled_state_mismatch", **_row_ref(row)}
+            )
+        if state in _OPEN_LEDGER_STATES and order_status in {"filled", "canceled"}:
+            mismatches.append(
+                {"reason": "terminal_order_status_with_open_state", **_row_ref(row)}
+            )
+    if mismatches:
+        add(
+            "ledger_order_fill_mismatch",
+            PaperExecutionAnomalySeverity.block,
+            "Ledger lifecycle state does not match order/fill data",
+            {"rows": mismatches[:10]},
+        )
+
+    # 7. Stale preview/approval packet.
+    stale_cutoff = checked_at - timedelta(minutes=stale_after_minutes)
+    stale_rows = []
+    for row in ledger:
+        state = str(_get(row, "lifecycle_state") or "").lower()
+        if state not in {"previewed", "validation_failed"}:
+            continue
+        preview_time = _latest_preview_time(row)
+        if preview_time is not None and preview_time < stale_cutoff:
+            stale_rows.append(row)
+    packet_time = _as_aware_utc(
+        _parse_datetime(
+            packet.get("expires_at")
+            or packet.get("generated_at")
+            or packet.get("approval_bridge_generated_at")
+        )
+    )
+    if packet_time is not None and packet_time < stale_cutoff:
+        stale_rows.append(
+            {"client_order_id": packet_client_id, "created_at": packet_time}
+        )
+    if stale_rows:
+        add(
+            "stale_preview_or_approval_packet",
+            PaperExecutionAnomalySeverity.block,
+            "Preview or approval packet is older than the allowed threshold",
+            {
+                "stale_after_minutes": stale_after_minutes,
+                "cutoff": stale_cutoff.isoformat(),
+                "rows": [_row_ref(r) for r in stale_rows[:10]],
+            },
+        )
+
+    # 8. Signal/execution symbol mismatch.
+    symbol_mismatches = []
+    expected_signal = _normalize_symbol(
+        expected_signal_symbol or packet.get("signal_symbol")
+    )
+    expected_execution = _normalize_symbol(
+        expected_execution_symbol or packet.get("execution_symbol")
+    )
+    for row in ledger:
+        row_signal = _normalize_symbol(_get(row, "signal_symbol"))
+        row_execution = _normalize_symbol(_get(row, "execution_symbol"))
+        if expected_signal and row_signal and row_signal != expected_signal:
+            symbol_mismatches.append(
+                {
+                    "reason": "signal_symbol_mismatch",
+                    "expected": expected_signal_symbol or packet.get("signal_symbol"),
+                    **_row_ref(row),
+                }
+            )
+        if expected_execution and row_execution and row_execution != expected_execution:
+            symbol_mismatches.append(
+                {
+                    "reason": "execution_symbol_mismatch",
+                    "expected": expected_execution_symbol
+                    or packet.get("execution_symbol"),
+                    **_row_ref(row),
+                }
+            )
+    if symbol_mismatches:
+        add(
+            "signal_execution_symbol_mismatch",
+            PaperExecutionAnomalySeverity.block,
+            "Signal or execution symbol does not match the approval context",
+            {"rows": symbol_mismatches[:10]},
+        )
+
+    # Info row for a clean preflight gives operators an explicit positive audit
+    # marker without weakening block semantics.
+    if not anomalies:
+        add(
+            "preflight_clean",
+            PaperExecutionAnomalySeverity.info,
+            "No Alpaca Paper execution anomalies detected",
+            {},
+        )
+
+    should_block = any(
+        a.severity == PaperExecutionAnomalySeverity.block for a in anomalies
+    )
+    return PaperExecutionPreflightReport(
+        status="blocked" if should_block else "pass",
+        should_block=should_block,
+        checked_at=checked_at,
+        stale_after_minutes=stale_after_minutes,
+        anomalies=tuple(anomalies),
+        counts={
+            "ledger_rows": len(ledger),
+            "open_orders": len(orders),
+            "positions": len(position_rows),
+            "block": sum(
+                a.severity == PaperExecutionAnomalySeverity.block for a in anomalies
+            ),
+            "warning": sum(
+                a.severity == PaperExecutionAnomalySeverity.warning for a in anomalies
+            ),
+            "info": sum(
+                a.severity == PaperExecutionAnomalySeverity.info for a in anomalies
+            ),
+        },
+    )
+
+
+__all__ = [
+    "PaperExecutionAnomaly",
+    "PaperExecutionAnomalySeverity",
+    "PaperExecutionPreflightReport",
+    "build_paper_execution_preflight_report",
+]

--- a/scripts/smoke/alpaca_paper_readonly_smoke.py
+++ b/scripts/smoke/alpaca_paper_readonly_smoke.py
@@ -20,6 +20,7 @@ from app.mcp_server.tooling.alpaca_paper import (
     alpaca_paper_list_positions,
 )
 from app.mcp_server.tooling.alpaca_paper_ledger_read import (
+    alpaca_paper_execution_preflight_check,
     alpaca_paper_ledger_get,
     alpaca_paper_ledger_list_recent,
 )
@@ -129,6 +130,15 @@ async def run_smoke() -> int:
         "alpaca_paper_ledger_get",
         alpaca_paper_ledger_get(client_order_id),
         lambda p: f"found={p.get('found', False)}",
+    )
+
+    await _probe(
+        "alpaca_paper_execution_preflight_check",
+        alpaca_paper_execution_preflight_check(limit=1),
+        lambda p: (
+            f"should_block={p.get('should_block', False)} "
+            f"anomalies={len(p.get('anomalies', []))}"
+        ),
     )
 
     # Confirm every expected tool was exercised

--- a/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
+++ b/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
@@ -223,6 +223,57 @@ async def test_ledger_get_empty_client_order_id_raises():
 
 
 # ---------------------------------------------------------------------------
+# alpaca_paper_execution_preflight_check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_execution_preflight_check_returns_blocking_report(monkeypatch):
+    import app.mcp_server.tooling.alpaca_paper_ledger_read as mod
+
+    mock_svc = _mock_svc(rows=[])
+
+    class _FakeDB:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            pass
+
+    monkeypatch.setattr(mod, "_session_factory", lambda: lambda: _FakeDB())
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.alpaca_paper_ledger_read.AlpacaPaperLedgerService",
+        lambda db: mock_svc,
+    )
+
+    result = await mod.alpaca_paper_execution_preflight_check(
+        limit=20,
+        open_orders=[{"id": "order-1", "status": "new", "symbol": "BTCUSD"}],
+    )
+
+    assert result["success"] is True
+    assert result["read_only"] is True
+    assert result["source"] == "alpaca_paper_execution_preflight"
+    assert result["should_block"] is True
+    assert result["anomalies"][0]["check_id"] == "unexpected_open_orders"
+    mock_svc.list_recent.assert_awaited_once_with(limit=20)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_execution_preflight_check_invalid_inputs_raise():
+    from app.mcp_server.tooling.alpaca_paper_ledger_read import (
+        alpaca_paper_execution_preflight_check,
+    )
+
+    with pytest.raises(ValueError, match="limit must be >= 1"):
+        await alpaca_paper_execution_preflight_check(limit=0)
+    with pytest.raises(ValueError, match="stale_after_minutes must be >= 1"):
+        await alpaca_paper_execution_preflight_check(stale_after_minutes=0)
+
+
+# ---------------------------------------------------------------------------
 # Registered as read-only
 # ---------------------------------------------------------------------------
 
@@ -233,6 +284,7 @@ def test_ledger_tool_names_are_in_alpaca_readonly_set():
 
     assert "alpaca_paper_ledger_list_recent" in ALPACA_PAPER_READONLY_TOOL_NAMES
     assert "alpaca_paper_ledger_get" in ALPACA_PAPER_READONLY_TOOL_NAMES
+    assert "alpaca_paper_execution_preflight_check" in ALPACA_PAPER_READONLY_TOOL_NAMES
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_alpaca_paper_anomaly_checks.py
+++ b/tests/services/test_alpaca_paper_anomaly_checks.py
@@ -1,0 +1,211 @@
+"""Tests for read-only Alpaca Paper execution anomaly checks (ROB-93)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.alpaca_paper_anomaly_checks import (
+    PaperExecutionAnomalySeverity,
+    build_paper_execution_preflight_report,
+)
+
+
+def _row(**kwargs):
+    defaults = {
+        "client_order_id": "rob93-buy-001",
+        "side": "buy",
+        "lifecycle_state": "filled",
+        "order_status": "filled",
+        "execution_symbol": "BTCUSD",
+        "signal_symbol": "KRW-BTC",
+        "filled_qty": "0.001",
+        "position_snapshot": {"qty": "0"},
+        "preview_payload": {},
+        "validation_summary": {},
+        "raw_responses": {},
+        "created_at": datetime(2026, 5, 3, 12, 0, tzinfo=UTC),
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def _check_ids(report):
+    return {a.check_id for a in report.anomalies}
+
+
+@pytest.mark.unit
+def test_clean_preflight_returns_info_and_does_not_block():
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(client_order_id="rob93-buy-001"),
+            _row(
+                client_order_id="rob93-sell-001",
+                side="sell",
+                raw_responses={"payload": {"source_client_order_id": "rob93-buy-001"}},
+            ),
+        ],
+        open_orders=[],
+        positions=[],
+        approval_packet={"client_order_id": "rob93-buy-002"},
+        expected_signal_symbol="KRW-BTC",
+        expected_execution_symbol="BTC/USD",
+        now=datetime(2026, 5, 3, 12, 5, tzinfo=UTC),
+    )
+
+    assert report.status == "pass"
+    assert report.should_block is False
+    assert [a.check_id for a in report.anomalies] == ["preflight_clean"]
+    assert report.anomalies[0].severity == PaperExecutionAnomalySeverity.info
+
+
+@pytest.mark.unit
+def test_open_order_blocks_new_cycle():
+    report = build_paper_execution_preflight_report(
+        open_orders=[
+            {
+                "id": "order-1",
+                "client_order_id": "rob93-open-001",
+                "symbol": "BTCUSD",
+                "status": "accepted",
+                "side": "buy",
+            }
+        ]
+    )
+
+    assert report.should_block is True
+    assert "unexpected_open_orders" in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_residual_position_blocks_new_cycle():
+    report = build_paper_execution_preflight_report(
+        positions=[{"symbol": "BTCUSD", "qty": "0.001", "asset_class": "crypto"}]
+    )
+
+    assert report.should_block is True
+    assert "residual_position_exists" in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_duplicate_client_order_id_blocks_against_packet_and_ledger():
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(client_order_id="dup-001"),
+            _row(client_order_id="dup-001", created_at=datetime(2026, 5, 3, 12, 1)),
+        ],
+        approval_packet={"client_order_id": "dup-001"},
+    )
+
+    assert report.should_block is True
+    assert "duplicate_client_order_id" in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_previous_buy_filled_without_linked_sell_blocks():
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[_row(client_order_id="buy-without-sell")]
+    )
+
+    assert report.should_block is True
+    assert "previous_buy_filled_sell_missing" in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_linked_sell_prevents_missing_sell_anomaly():
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(client_order_id="buy-closed"),
+            _row(
+                client_order_id="sell-closed",
+                side="sell",
+                raw_responses={"payload": {"source_client_order_id": "buy-closed"}},
+            ),
+        ]
+    )
+
+    assert "previous_buy_filled_sell_missing" not in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_filled_sell_with_nonzero_final_position_blocks():
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(
+                client_order_id="sell-not-closed",
+                side="sell",
+                lifecycle_state="filled",
+                position_snapshot={"qty": "0.001"},
+            )
+        ]
+    )
+
+    assert report.should_block is True
+    assert "sell_filled_position_not_closed" in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_ledger_order_fill_mismatch_blocks():
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(
+                client_order_id="bad-fill",
+                lifecycle_state="filled",
+                order_status="filled",
+                filled_qty="0",
+            )
+        ]
+    )
+
+    assert report.should_block is True
+    assert "ledger_order_fill_mismatch" in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_stale_preview_blocks():
+    now = datetime(2026, 5, 3, 12, 0, tzinfo=UTC)
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(
+                client_order_id="stale-preview",
+                side="buy",
+                lifecycle_state="previewed",
+                order_status=None,
+                filled_qty=None,
+                created_at=now - timedelta(minutes=45),
+            )
+        ],
+        now=now,
+        stale_after_minutes=30,
+    )
+
+    assert report.should_block is True
+    assert "stale_preview_or_approval_packet" in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_signal_execution_symbol_mismatch_blocks():
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[_row(signal_symbol="KRW-ETH", execution_symbol="ETHUSD")],
+        expected_signal_symbol="KRW-BTC",
+        expected_execution_symbol="BTC/USD",
+    )
+
+    assert report.should_block is True
+    assert "signal_execution_symbol_mismatch" in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_report_to_dict_is_operator_readable():
+    report = build_paper_execution_preflight_report(
+        open_orders=[{"id": "order-1", "status": "new", "symbol": "BTCUSD"}],
+        now=datetime(2026, 5, 3, 12, 0, tzinfo=UTC),
+    )
+    data = report.to_dict()
+
+    assert data["status"] == "blocked"
+    assert data["should_block"] is True
+    assert data["counts"]["block"] == 1
+    assert data["anomalies"][0]["check_id"] == "unexpected_open_orders"

--- a/tests/test_alpaca_paper_smoke_safety.py
+++ b/tests/test_alpaca_paper_smoke_safety.py
@@ -93,6 +93,9 @@ async def test_run_smoke_exits_zero_when_all_tools_succeed(
     async def fake_ledger_get(client_order_id: str) -> dict:
         return {"success": False, "found": False, "client_order_id": client_order_id}
 
+    async def fake_preflight_check(*args, **kwargs) -> dict:  # noqa: ANN002, ANN003
+        return {"success": True, "should_block": False, "anomalies": []}
+
     service = FakeAlpacaPaperService()
     set_alpaca_paper_service_factory(lambda: service)  # type: ignore[arg-type]
     try:
@@ -102,6 +105,7 @@ async def test_run_smoke_exits_zero_when_all_tools_succeed(
         spec.loader.exec_module(module)  # type: ignore[union-attr]
         module.alpaca_paper_ledger_list_recent = fake_ledger_list_recent
         module.alpaca_paper_ledger_get = fake_ledger_get
+        module.alpaca_paper_execution_preflight_check = fake_preflight_check
         exit_code = await module.run_smoke()
     finally:
         reset_alpaca_paper_service_factory()


### PR DESCRIPTION
## Summary
- add a read-only Alpaca Paper execution anomaly preflight service returning severity-classified findings and should_block
- expose alpaca_paper_execution_preflight_check as an MCP read-only tool and include it in the read-only smoke inventory
- cover unexpected open orders, residual positions, duplicate client_order_id, filled buy/sell lifecycle gaps, ledger/fill mismatches, stale approvals, and signal/execution symbol mismatches

## Safety
- read-only only: no broker mutation, no repair writes, no DB backfill
- optional broker snapshots are caller-supplied and treated as read-only inputs

## Verification
- uv run pytest tests/test_alpaca_paper_smoke_safety.py tests/services/test_alpaca_paper_anomaly_checks.py tests/mcp_server/test_alpaca_paper_ledger_read_tools.py -q
- uv run pytest tests/services/test_alpaca_paper_ledger_service.py tests/mcp_server/test_alpaca_paper_ledger_read_tools.py tests/test_mcp_alpaca_paper_tools.py tests/test_alpaca_paper_orders_tools.py -q
- uv run ruff check app/services/alpaca_paper_anomaly_checks.py app/mcp_server/tooling/alpaca_paper_ledger_read.py app/mcp_server/tooling/alpaca_paper.py scripts/smoke/alpaca_paper_readonly_smoke.py tests/services/test_alpaca_paper_anomaly_checks.py tests/mcp_server/test_alpaca_paper_ledger_read_tools.py tests/test_alpaca_paper_smoke_safety.py
- uv run ruff format --check app/services/alpaca_paper_anomaly_checks.py app/mcp_server/tooling/alpaca_paper_ledger_read.py app/mcp_server/tooling/alpaca_paper.py scripts/smoke/alpaca_paper_readonly_smoke.py tests/services/test_alpaca_paper_anomaly_checks.py tests/mcp_server/test_alpaca_paper_ledger_read_tools.py tests/test_alpaca_paper_smoke_safety.py

## Known unrelated baseline issues
- full repo ruff check/format still fails on pre-existing backtest/blog/scripts formatting and lint issues outside this PR scope
- full pytest now passes the Alpaca smoke failure fixed by this PR but still has pre-existing robinco.dev vs mgh3326.duckdns.org URL expectation failures in notification/link tests