### PR TITLE
ROB-91 add paper approval packet idempotency guards

### DIFF
--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -55,6 +55,19 @@ CANONICAL_LIFECYCLE_STATES: frozenset[str] = frozenset(
     }
 )
 
+# ROB-91: post-submit executed states used for idempotency checks.
+# Excludes pre-submit (planned/previewed/validated) and anomaly.
+EXECUTED_LIFECYCLE_STATES: frozenset[str] = frozenset(
+    {
+        LIFECYCLE_SUBMITTED,
+        LIFECYCLE_FILLED,
+        LIFECYCLE_POSITION_RECONCILED,
+        LIFECYCLE_SELL_VALIDATED,
+        LIFECYCLE_CLOSED,
+        LIFECYCLE_FINAL_RECONCILED,
+    }
+)
+
 # ROB-90 record_kind constants
 RECORD_KIND_PLAN = "plan"
 RECORD_KIND_PREVIEW = "preview"
@@ -298,6 +311,31 @@ class AlpacaPaperLedgerService:
         )
         result = await self._db.execute(stmt)
         return list(result.scalars().all())
+
+    async def find_executed_by_client_order_id(
+        self,
+        client_order_id: str,
+    ) -> AlpacaPaperOrderLedger | None:
+        """Return the execution row for client_order_id if it is in an executed lifecycle state.
+
+        Returns None if the row does not exist or is in a pre-submit / preview-only state.
+        Filters to record_kind='execution' and lifecycle_state in EXECUTED_LIFECYCLE_STATES.
+        """
+        stmt = (
+            select(AlpacaPaperOrderLedger)
+            .where(
+                AlpacaPaperOrderLedger.client_order_id == client_order_id,
+                AlpacaPaperOrderLedger.record_kind == RECORD_KIND_EXECUTION,
+                AlpacaPaperOrderLedger.lifecycle_state.in_(EXECUTED_LIFECYCLE_STATES),
+            )
+            .order_by(
+                AlpacaPaperOrderLedger.created_at.desc(),
+                AlpacaPaperOrderLedger.id.desc(),
+            )
+            .limit(1)
+        )
+        result = await self._db.execute(stmt)
+        return result.scalar_one_or_none()
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -1024,6 +1062,7 @@ __all__ = [
     "AlpacaPaperLedgerService",
     "ApprovalProvenance",
     "CANONICAL_LIFECYCLE_STATES",
+    "EXECUTED_LIFECYCLE_STATES",
     "LIFECYCLE_ANOMALY",
     "LIFECYCLE_CLOSED",
     "LIFECYCLE_FILLED",

--- a/app/services/paper_approval_packet.py
+++ b/app/services/paper_approval_packet.py
@@ -1,0 +1,358 @@
+"""Bounded, frozen paper approval packet and deterministic verifiers (ROB-91).
+
+This module is intentionally pure and side-effect free:
+- No broker calls, no DB writes, no scheduler/network work.
+- Verifiers never read the clock themselves — callers supply wall-clock via `now=`.
+- Verifiers consume already-fetched ledger snapshots from the caller.
+
+Usage pattern (producer side):
+    packet = PaperApprovalPacket(
+        signal_source="preopen_briefing",
+        artifact_id=uuid.uuid4(),
+        signal_symbol="KRW-BTC",
+        signal_venue="upbit",
+        execution_symbol="BTC/USD",
+        execution_venue="alpaca_paper",
+        execution_asset_class="crypto",
+        side="buy",
+        max_notional=Decimal("10"),
+        qty_source="notional_estimate",
+        expected_lifecycle_step="previewed",
+        lifecycle_correlation_id="corr-abc",
+        client_order_id="buy-001",
+        expires_at=datetime(2026, 5, 4, 12, 0, 0, tzinfo=UTC),
+    )
+
+Usage pattern (pre-submit caller):
+    caller_now = ...  # timezone-aware wall clock supplied by the caller
+    verify_packet_freshness(packet, now=caller_now)
+    await verify_packet_idempotency(packet, ledger=svc)
+    await verify_sell_packet_source(packet, ledger=svc)
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+if TYPE_CHECKING:
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+# ---------------------------------------------------------------------------
+# Pre-submit lifecycle steps allowed in a packet
+# ---------------------------------------------------------------------------
+_PRE_SUBMIT_STEPS: frozenset[str] = frozenset(
+    {"planned", "previewed", "validated", "submitted"}
+)
+
+# ---------------------------------------------------------------------------
+# Allowed qty_source values for sell packets (ledger/reconcile-derived only)
+# ---------------------------------------------------------------------------
+_SELL_QTY_SOURCES: frozenset[str] = frozenset(
+    {
+        "ledger_filled_qty",
+        "ledger_position_snapshot",
+        "reconcile_filled_qty",
+        "reconcile_position_snapshot",
+    }
+)
+
+# ---------------------------------------------------------------------------
+# Reconciled buy states: conservative set — position must be confirmed
+# ---------------------------------------------------------------------------
+_RECONCILED_BUY_STATES: frozenset[str] = frozenset(
+    {
+        "position_reconciled",
+        "closed",
+        "final_reconciled",
+        # Include filled only for conservative completeness; callers with
+        # position_reconciled rows are preferred.
+        "filled",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Error
+# ---------------------------------------------------------------------------
+class PaperApprovalPacketError(ValueError):
+    """Raised by packet verifiers with a stable machine-readable code.
+
+    Stable code values:
+        stale_packet              — expires_at is in the past relative to now
+        naive_now                 — caller supplied a naive (tz-unaware) now
+        duplicate_client_order_id — client_order_id already executed in ledger
+        missing_source_order      — sell packet has no prior buy in ledger
+        multiple_source_orders    — sell packet has >1 buy execution rows
+        source_not_reconciled     — buy source not in a reconciled lifecycle state
+        wrong_symbol              — execution_symbol doesn't match buy source row
+        qty_exceeds_source        — sell max_qty > source buy filled_qty
+        invalid_qty_source        — sell qty_source not in allowed ledger values
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        self.code = code
+        super().__init__(message)
+
+    def __repr__(self) -> str:
+        return f"PaperApprovalPacketError(code={self.code!r}, message={str(self)!r})"
+
+
+# ---------------------------------------------------------------------------
+# Packet schema
+# ---------------------------------------------------------------------------
+class PaperApprovalPacket(BaseModel):
+    """Frozen, bounded approval packet for a single Alpaca Paper order leg.
+
+    Exactly one of max_notional or max_qty must be provided and positive.
+    expires_at must be timezone-aware.
+    Unknown fields are forbidden.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    signal_source: str
+    artifact_id: uuid.UUID
+    signal_symbol: str
+    signal_venue: Literal["upbit"]
+    execution_symbol: str
+    execution_venue: Literal["alpaca_paper"]
+    execution_asset_class: Literal["crypto", "us_equity"]
+    side: Literal["buy", "sell"]
+    max_notional: Decimal | None = None
+    max_qty: Decimal | None = None
+    qty_source: str
+    expected_lifecycle_step: str
+    lifecycle_correlation_id: str
+    client_order_id: str
+    expires_at: datetime
+
+    @field_validator("expires_at")
+    @classmethod
+    def _require_aware_expires_at(cls, v: datetime) -> datetime:
+        if v.tzinfo is None or v.tzinfo.utcoffset(v) is None:
+            raise ValueError("expires_at must be timezone-aware")
+        return v
+
+    @field_validator("expected_lifecycle_step")
+    @classmethod
+    def _require_pre_submit_step(cls, v: str) -> str:
+        if v not in _PRE_SUBMIT_STEPS:
+            raise ValueError(
+                f"expected_lifecycle_step must be one of {sorted(_PRE_SUBMIT_STEPS)}; got {v!r}"
+            )
+        return v
+
+    @model_validator(mode="after")
+    def _require_exactly_one_max_guard(self) -> PaperApprovalPacket:
+        has_notional = self.max_notional is not None
+        has_qty = self.max_qty is not None
+        if has_notional and has_qty:
+            raise ValueError("Provide exactly one of max_notional or max_qty, not both")
+        if not has_notional and not has_qty:
+            raise ValueError("Provide exactly one of max_notional or max_qty")
+        if has_notional and self.max_notional <= Decimal("0"):
+            raise ValueError("max_notional must be positive")
+        if has_qty and self.max_qty <= Decimal("0"):
+            raise ValueError("max_qty must be positive")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_crypto_symbol_mapping(self) -> PaperApprovalPacket:
+        if self.signal_venue == "upbit" and self.execution_asset_class == "crypto":
+            from app.services.crypto_execution_mapping import (
+                CryptoExecutionMappingError,
+                map_upbit_to_alpaca_paper,
+            )
+
+            try:
+                mapping = map_upbit_to_alpaca_paper(self.signal_symbol)
+            except CryptoExecutionMappingError as exc:
+                raise ValueError(
+                    f"signal_symbol {self.signal_symbol!r} is not supported for Upbit→Alpaca Paper mapping: {exc}"
+                ) from exc
+            if mapping.execution_symbol != self.execution_symbol:
+                raise ValueError(
+                    f"execution_symbol {self.execution_symbol!r} does not match "
+                    f"expected {mapping.execution_symbol!r} for signal {self.signal_symbol!r}"
+                )
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Verifier: freshness
+# ---------------------------------------------------------------------------
+def verify_packet_freshness(packet: PaperApprovalPacket, *, now: datetime) -> None:
+    """Raise PaperApprovalPacketError if the packet is expired or now is naive.
+
+    Args:
+        packet: The approval packet to verify.
+        now: Caller-supplied wall clock. Must be timezone-aware.
+
+    Raises:
+        PaperApprovalPacketError(code='naive_now') if now has no tzinfo.
+        PaperApprovalPacketError(code='stale_packet') if now >= packet.expires_at.
+    """
+    if now.tzinfo is None or now.tzinfo.utcoffset(now) is None:
+        raise PaperApprovalPacketError(
+            code="naive_now",
+            message="now must be timezone-aware; use a caller-supplied UTC clock",
+        )
+    if now >= packet.expires_at:
+        raise PaperApprovalPacketError(
+            code="stale_packet",
+            message=(
+                f"packet expired: expires_at={packet.expires_at.isoformat()}, "
+                f"now={now.isoformat()}"
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Verifier: idempotency
+# ---------------------------------------------------------------------------
+async def verify_packet_idempotency(
+    packet: PaperApprovalPacket,
+    *,
+    ledger: AlpacaPaperLedgerService,
+) -> None:
+    """Raise PaperApprovalPacketError if client_order_id already executed.
+
+    Calls ledger.find_executed_by_client_order_id to check for a prior
+    execution row in an executed lifecycle state.
+
+    Raises:
+        PaperApprovalPacketError(code='duplicate_client_order_id').
+    """
+    existing = await ledger.find_executed_by_client_order_id(packet.client_order_id)
+    if existing is not None:
+        raise PaperApprovalPacketError(
+            code="duplicate_client_order_id",
+            message=(
+                f"client_order_id {packet.client_order_id!r} already has an execution "
+                f"row in state {existing.lifecycle_state!r}"
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Verifier: sell source order
+# ---------------------------------------------------------------------------
+def _get_attr(row: Any, key: str, default: Any = None) -> Any:
+    if isinstance(row, dict):
+        return row.get(key, default)
+    return getattr(row, key, default)
+
+
+async def verify_sell_packet_source(
+    packet: PaperApprovalPacket,
+    *,
+    ledger: AlpacaPaperLedgerService,
+) -> None:
+    """For sell packets, verify exactly one prior reconciled buy source exists.
+
+    Buy packets pass without any source check.
+
+    For sell packets:
+    - qty_source must be a ledger/reconcile-derived value.
+    - Calls ledger.list_by_correlation_id to retrieve the correlation scope.
+    - Exactly one buy execution row must exist.
+    - That buy row must be in a reconciled state (position_reconciled / filled / closed / final_reconciled).
+    - execution_symbol must match between packet and source row.
+    - packet.max_qty (if set) must not exceed the source buy filled_qty.
+
+    Raises:
+        PaperApprovalPacketError with one of the stable codes:
+            invalid_qty_source, missing_source_order, multiple_source_orders,
+            source_not_reconciled, wrong_symbol, qty_exceeds_source.
+    """
+    if packet.side == "buy":
+        return
+
+    # Sell packet: validate qty_source first
+    if packet.qty_source not in _SELL_QTY_SOURCES:
+        raise PaperApprovalPacketError(
+            code="invalid_qty_source",
+            message=(
+                f"sell packet qty_source {packet.qty_source!r} is not allowed; "
+                f"must be one of {sorted(_SELL_QTY_SOURCES)}"
+            ),
+        )
+
+    rows = await ledger.list_by_correlation_id(packet.lifecycle_correlation_id)
+
+    # Filter to buy execution rows
+    buy_exec_rows = [
+        row
+        for row in rows
+        if str(_get_attr(row, "side") or "").lower() == "buy"
+        and str(_get_attr(row, "record_kind") or "") == "execution"
+    ]
+
+    if not buy_exec_rows:
+        raise PaperApprovalPacketError(
+            code="missing_source_order",
+            message=(
+                f"no buy execution row found for lifecycle_correlation_id "
+                f"{packet.lifecycle_correlation_id!r}"
+            ),
+        )
+
+    if len(buy_exec_rows) > 1:
+        raise PaperApprovalPacketError(
+            code="multiple_source_orders",
+            message=(
+                f"expected exactly one buy execution row for correlation "
+                f"{packet.lifecycle_correlation_id!r}; found {len(buy_exec_rows)}"
+            ),
+        )
+
+    source = buy_exec_rows[0]
+    source_state = str(_get_attr(source, "lifecycle_state") or "")
+    if source_state not in _RECONCILED_BUY_STATES:
+        raise PaperApprovalPacketError(
+            code="source_not_reconciled",
+            message=(
+                f"buy source lifecycle_state is {source_state!r}; "
+                f"must be in {sorted(_RECONCILED_BUY_STATES)}"
+            ),
+        )
+
+    source_symbol = str(_get_attr(source, "execution_symbol") or "")
+    if source_symbol != packet.execution_symbol:
+        raise PaperApprovalPacketError(
+            code="wrong_symbol",
+            message=(
+                f"sell packet execution_symbol {packet.execution_symbol!r} does not match "
+                f"buy source execution_symbol {source_symbol!r}"
+            ),
+        )
+
+    if packet.max_qty is not None:
+        source_filled_qty_raw = _get_attr(source, "filled_qty")
+        if source_filled_qty_raw is not None:
+            try:
+                source_filled_qty = Decimal(str(source_filled_qty_raw))
+            except Exception:
+                source_filled_qty = None
+            if source_filled_qty is not None and packet.max_qty > source_filled_qty:
+                raise PaperApprovalPacketError(
+                    code="qty_exceeds_source",
+                    message=(
+                        f"sell max_qty {packet.max_qty} exceeds buy source filled_qty "
+                        f"{source_filled_qty}"
+                    ),
+                )
+
+
+__all__ = [
+    "PaperApprovalPacket",
+    "PaperApprovalPacketError",
+    "verify_packet_freshness",
+    "verify_packet_idempotency",
+    "verify_sell_packet_source",
+]

--- a/docs/runbooks/alpaca-paper-ledger.md
+++ b/docs/runbooks/alpaca-paper-ledger.md
@@ -228,6 +228,83 @@ The following are explicitly out of scope and must not be added to this ledger o
 
 ---
 
+---
+
+## ROB-91 Paper Approval Packet Contract
+
+`app/services/paper_approval_packet.py` introduces a bounded, frozen approval packet and three deterministic verifiers that run immediately before a confirmed broker submit.
+
+### Purpose
+
+Before calling `alpaca_paper_submit_order(confirm=True)`, producers build a `PaperApprovalPacket` and callers run:
+
+1. `verify_packet_freshness(packet, now=datetime.now(UTC))` — rejects expired packets.
+2. `await verify_packet_idempotency(packet, ledger=svc)` — rejects duplicate `client_order_id` that already executed.
+3. `await verify_sell_packet_source(packet, ledger=svc)` — for sell packets, validates exactly one reconciled buy source.
+
+### PaperApprovalPacket Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `signal_source` | `str` | Source artifact identifier |
+| `artifact_id` | `UUID` | Unique artifact ID |
+| `signal_symbol` | `str` | Signal symbol (e.g. `KRW-BTC`) |
+| `signal_venue` | `"upbit"` | Signal origin venue |
+| `execution_symbol` | `str` | Alpaca Paper symbol (e.g. `BTC/USD`) |
+| `execution_venue` | `"alpaca_paper"` | Always `alpaca_paper` |
+| `execution_asset_class` | `"crypto" \| "us_equity"` | Asset class |
+| `side` | `"buy" \| "sell"` | Order side |
+| `max_notional` | `Decimal \| None` | Exclusive with `max_qty`; must be > 0 |
+| `max_qty` | `Decimal \| None` | Exclusive with `max_notional`; must be > 0 |
+| `qty_source` | `str` | How qty was derived; sell packets restricted to ledger/reconcile values |
+| `expected_lifecycle_step` | `str` | Pre-submit step: `planned/previewed/validated/submitted` |
+| `lifecycle_correlation_id` | `str` | Roundtrip correlation key |
+| `client_order_id` | `str` | Per-leg caller-supplied key |
+| `expires_at` | `datetime` | Timezone-aware expiry; freshness check rejects if `now >= expires_at` |
+
+**Schema constraints:** `extra="forbid"`, `frozen=True`, exactly one of `max_notional`/`max_qty` positive, timezone-aware `expires_at`, `expected_lifecycle_step` in `{planned, previewed, validated, submitted}`. For Upbit crypto packets, `signal_symbol → execution_symbol` is validated via `map_upbit_to_alpaca_paper`.
+
+### Verifier Table
+
+| Verifier | Trigger condition | Error code |
+|----------|------------------|-----------|
+| `verify_packet_freshness` | `now >= expires_at` | `stale_packet` |
+| `verify_packet_freshness` | `now` has no tzinfo | `naive_now` |
+| `verify_packet_idempotency` | `client_order_id` already in executed state | `duplicate_client_order_id` |
+| `verify_sell_packet_source` | sell `qty_source` not in ledger/reconcile values | `invalid_qty_source` |
+| `verify_sell_packet_source` | no buy execution row in correlation scope | `missing_source_order` |
+| `verify_sell_packet_source` | >1 buy execution row in correlation scope | `multiple_source_orders` |
+| `verify_sell_packet_source` | buy source not in reconciled state | `source_not_reconciled` |
+| `verify_sell_packet_source` | execution symbol mismatch | `wrong_symbol` |
+| `verify_sell_packet_source` | `max_qty > source filled_qty` | `qty_exceeds_source` |
+
+### Allowed `qty_source` values for sell packets
+
+Only ledger/reconcile-derived sources are accepted. Manual sources are rejected.
+
+- `ledger_filled_qty`
+- `ledger_position_snapshot`
+- `reconcile_filled_qty`
+- `reconcile_position_snapshot`
+
+### Verifier purity guarantees
+
+- No broker calls, no DB writes, no `datetime.now()` inside verifiers.
+- `find_executed_by_client_order_id` and `list_by_correlation_id` are read-only SELECT helpers.
+- Callers supply wall-clock (`now=`) for deterministic testing.
+
+### New ledger read helpers (ROB-91)
+
+`EXECUTED_LIFECYCLE_STATES` — frozenset of post-submit states used by the idempotency verifier:
+`{submitted, filled, position_reconciled, sell_validated, closed, final_reconciled}`.
+Excludes pre-submit (`planned/previewed/validated`) and `anomaly`.
+
+`find_executed_by_client_order_id(client_order_id)` — returns the execution row if `record_kind='execution'` and `lifecycle_state` is in `EXECUTED_LIFECYCLE_STATES`; else `None`.
+
+`list_by_correlation_id(lifecycle_correlation_id)` — returns all rows sharing the correlation ID, ordered oldest-first. Used by the sell-source verifier.
+
+---
+
 ## Schema Reference
 
 Table: `review.alpaca_paper_order_ledger`

--- a/tests/services/test_alpaca_paper_ledger_service.py
+++ b/tests/services/test_alpaca_paper_ledger_service.py
@@ -941,6 +941,143 @@ async def test_list_by_correlation_id_empty_raises():
 
 
 # ---------------------------------------------------------------------------
+# find_executed_by_client_order_id (ROB-91)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_find_executed_returns_none_for_preview_only_row():
+    """A preview-only row (record_kind='preview') must not be returned."""
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    class _ScalarResult:
+        def scalar_one_or_none(self):
+            return None
+
+        def scalars(self):
+            class _S:
+                def all(self_inner):
+                    return []
+
+            return _S()
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_ScalarResult())
+    svc = AlpacaPaperLedgerService(db)
+    result = await svc.find_executed_by_client_order_id("preview-only-001")
+    assert result is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_find_executed_returns_row_after_fill():
+    """An execution row in 'filled' state must be returned."""
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    exec_row = _make_row(
+        client_order_id="buy-exec-001",
+        record_kind="execution",
+        lifecycle_state="filled",
+        filled_qty="0.001",
+    )
+
+    class _ScalarResult:
+        def scalar_one_or_none(self):
+            return exec_row
+
+        def scalars(self):
+            class _S:
+                def all(self_inner):
+                    return [exec_row]
+
+            return _S()
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_ScalarResult())
+    svc = AlpacaPaperLedgerService(db)
+    result = await svc.find_executed_by_client_order_id("buy-exec-001")
+    assert result is not None
+    assert result.lifecycle_state == "filled"
+    assert result.record_kind == "execution"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_find_executed_returns_row_for_position_reconciled():
+    """An execution row in 'position_reconciled' is an executed state."""
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    exec_row = _make_row(
+        client_order_id="buy-exec-002",
+        record_kind="execution",
+        lifecycle_state="position_reconciled",
+    )
+
+    class _ScalarResult:
+        def scalar_one_or_none(self):
+            return exec_row
+
+        def scalars(self):
+            class _S:
+                def all(self_inner):
+                    return [exec_row]
+
+            return _S()
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_ScalarResult())
+    svc = AlpacaPaperLedgerService(db)
+    result = await svc.find_executed_by_client_order_id("buy-exec-002")
+    assert result is not None
+    assert result.lifecycle_state == "position_reconciled"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_find_executed_returns_none_for_anomaly_execution():
+    """An execution row in 'anomaly' state is not an executed state."""
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    class _ScalarResult:
+        def scalar_one_or_none(self):
+            return None
+
+        def scalars(self):
+            class _S:
+                def all(self_inner):
+                    return []
+
+            return _S()
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_ScalarResult())
+    svc = AlpacaPaperLedgerService(db)
+    result = await svc.find_executed_by_client_order_id("anomaly-exec-001")
+    assert result is None
+
+
+@pytest.mark.unit
+def test_executed_lifecycle_states_exported():
+    """EXECUTED_LIFECYCLE_STATES must be exported and contain correct post-submit states."""
+    from app.services.alpaca_paper_ledger_service import EXECUTED_LIFECYCLE_STATES
+
+    assert isinstance(EXECUTED_LIFECYCLE_STATES, frozenset)
+    # All post-submit states included
+    assert "submitted" in EXECUTED_LIFECYCLE_STATES
+    assert "filled" in EXECUTED_LIFECYCLE_STATES
+    assert "position_reconciled" in EXECUTED_LIFECYCLE_STATES
+    assert "sell_validated" in EXECUTED_LIFECYCLE_STATES
+    assert "closed" in EXECUTED_LIFECYCLE_STATES
+    assert "final_reconciled" in EXECUTED_LIFECYCLE_STATES
+    # Pre-submit and anomaly excluded
+    assert "planned" not in EXECUTED_LIFECYCLE_STATES
+    assert "previewed" not in EXECUTED_LIFECYCLE_STATES
+    assert "validated" not in EXECUTED_LIFECYCLE_STATES
+    assert "anomaly" not in EXECUTED_LIFECYCLE_STATES
+
+
+# ---------------------------------------------------------------------------
 # LedgerNotFoundError
 # ---------------------------------------------------------------------------
 

--- a/tests/services/test_paper_approval_packet.py
+++ b/tests/services/test_paper_approval_packet.py
@@ -1,0 +1,783 @@
+"""Tests for PaperApprovalPacket schema and verifiers (ROB-91).
+
+Covers:
+- Schema validation: required fields, frozen model, extra-field rejection,
+  timezone-aware expiry, signal/execution mismatch, exactly-one max guard,
+  lifecycle step constraint.
+- verify_packet_freshness: stale, fresh, naive now.
+- verify_packet_idempotency: no prior execution (pass), existing row (fail).
+- verify_sell_packet_source: buy skips check, sell scenarios (pass/fail).
+- TestRob91AcceptanceScenarios: named acceptance test class.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FUTURE = datetime(2030, 1, 1, 12, 0, 0, tzinfo=UTC)
+_PAST = datetime(2020, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def _make_packet(**overrides: Any):
+    from app.services.paper_approval_packet import PaperApprovalPacket
+
+    defaults: dict[str, Any] = {
+        "signal_source": "test_signal",
+        "artifact_id": uuid.uuid4(),
+        "signal_symbol": "KRW-BTC",
+        "signal_venue": "upbit",
+        "execution_symbol": "BTC/USD",
+        "execution_venue": "alpaca_paper",
+        "execution_asset_class": "crypto",
+        "side": "buy",
+        "max_notional": Decimal("10"),
+        "qty_source": "notional_estimate",
+        "expected_lifecycle_step": "previewed",
+        "lifecycle_correlation_id": "corr-test-001",
+        "client_order_id": "buy-test-001",
+        "expires_at": _FUTURE,
+    }
+    defaults.update(overrides)
+    return PaperApprovalPacket(**defaults)
+
+
+def _make_ledger_row(**overrides: Any) -> Any:
+    defaults: dict[str, Any] = {
+        "id": 1,
+        "client_order_id": "buy-test-001",
+        "lifecycle_correlation_id": "corr-test-001",
+        "record_kind": "execution",
+        "lifecycle_state": "position_reconciled",
+        "execution_symbol": "BTC/USD",
+        "side": "buy",
+        "filled_qty": Decimal("0.001"),
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _mock_ledger(
+    *,
+    find_executed_result: Any = None,
+    list_by_correlation_result: list[Any] | None = None,
+) -> Any:
+    ledger = MagicMock()
+    ledger.find_executed_by_client_order_id = AsyncMock(
+        return_value=find_executed_result
+    )
+    ledger.list_by_correlation_id = AsyncMock(
+        return_value=list_by_correlation_result or []
+    )
+    return ledger
+
+
+# ---------------------------------------------------------------------------
+# Schema: basic construction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_packet_constructs_with_max_notional():
+    packet = _make_packet()
+    assert packet.signal_symbol == "KRW-BTC"
+    assert packet.execution_symbol == "BTC/USD"
+    assert packet.max_notional == Decimal("10")
+    assert packet.max_qty is None
+
+
+@pytest.mark.unit
+def test_packet_constructs_with_max_qty():
+    packet = _make_packet(max_notional=None, max_qty=Decimal("0.001"))
+    assert packet.max_qty == Decimal("0.001")
+    assert packet.max_notional is None
+
+
+@pytest.mark.unit
+def test_packet_is_frozen():
+    from pydantic import ValidationError
+
+    packet = _make_packet()
+    with pytest.raises((ValidationError, TypeError)):
+        packet.side = "sell"  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_packet_forbids_extra_fields():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="extra"):
+        _make_packet(unknown_field="bad")
+
+
+# ---------------------------------------------------------------------------
+# Schema: expires_at must be timezone-aware
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_packet_rejects_naive_expires_at():
+    from pydantic import ValidationError
+
+    naive = datetime(2030, 1, 1, 12, 0, 0)  # no tzinfo
+    with pytest.raises(ValidationError, match="timezone-aware"):
+        _make_packet(expires_at=naive)
+
+
+@pytest.mark.unit
+def test_packet_accepts_non_utc_aware_expires_at():
+    tz_plus9 = timezone(timedelta(hours=9))
+    aware = datetime(2030, 1, 1, 21, 0, 0, tzinfo=tz_plus9)
+    packet = _make_packet(expires_at=aware)
+    assert packet.expires_at.tzinfo is not None
+
+
+# ---------------------------------------------------------------------------
+# Schema: exactly-one max guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_packet_rejects_both_max_notional_and_max_qty():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="not both"):
+        _make_packet(max_notional=Decimal("10"), max_qty=Decimal("0.001"))
+
+
+@pytest.mark.unit
+def test_packet_rejects_neither_max_guard():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        _make_packet(max_notional=None, max_qty=None)
+
+
+@pytest.mark.unit
+def test_packet_rejects_zero_max_notional():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="positive"):
+        _make_packet(max_notional=Decimal("0"))
+
+
+@pytest.mark.unit
+def test_packet_rejects_negative_max_qty():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="positive"):
+        _make_packet(max_notional=None, max_qty=Decimal("-1"))
+
+
+# ---------------------------------------------------------------------------
+# Schema: expected_lifecycle_step constraint
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("step", ["planned", "previewed", "validated", "submitted"])
+def test_packet_accepts_valid_lifecycle_steps(step: str):
+    packet = _make_packet(expected_lifecycle_step=step)
+    assert packet.expected_lifecycle_step == step
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "step", ["filled", "closed", "anomaly", "final_reconciled", "unknown"]
+)
+def test_packet_rejects_invalid_lifecycle_steps(step: str):
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="expected_lifecycle_step"):
+        _make_packet(expected_lifecycle_step=step)
+
+
+# ---------------------------------------------------------------------------
+# Schema: signal/execution symbol mapping for crypto
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_packet_rejects_unsupported_upbit_signal_symbol():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="not supported"):
+        _make_packet(signal_symbol="KRW-DOGE", execution_symbol="DOGE/USD")
+
+
+@pytest.mark.unit
+def test_packet_rejects_wrong_execution_symbol_for_known_signal():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="does not match"):
+        _make_packet(signal_symbol="KRW-BTC", execution_symbol="ETH/USD")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "signal,execution",
+    [
+        ("KRW-BTC", "BTC/USD"),
+        ("KRW-ETH", "ETH/USD"),
+        ("KRW-SOL", "SOL/USD"),
+    ],
+)
+def test_packet_accepts_valid_crypto_mappings(signal: str, execution: str):
+    packet = _make_packet(signal_symbol=signal, execution_symbol=execution)
+    assert packet.signal_symbol == signal
+    assert packet.execution_symbol == execution
+
+
+# ---------------------------------------------------------------------------
+# verify_packet_freshness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_freshness_passes_when_now_before_expires_at():
+    from app.services.paper_approval_packet import verify_packet_freshness
+
+    packet = _make_packet(expires_at=_FUTURE)
+    now = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+    verify_packet_freshness(packet, now=now)  # must not raise
+
+
+@pytest.mark.unit
+def test_freshness_raises_stale_when_now_equals_expires_at():
+    from app.services.paper_approval_packet import (
+        PaperApprovalPacketError,
+        verify_packet_freshness,
+    )
+
+    expires = datetime(2026, 5, 4, 12, 0, 0, tzinfo=UTC)
+    packet = _make_packet(expires_at=expires)
+    with pytest.raises(PaperApprovalPacketError) as exc_info:
+        verify_packet_freshness(packet, now=expires)
+    assert exc_info.value.code == "stale_packet"
+
+
+@pytest.mark.unit
+def test_freshness_raises_stale_when_now_after_expires_at():
+    from app.services.paper_approval_packet import (
+        PaperApprovalPacketError,
+        verify_packet_freshness,
+    )
+
+    expires = datetime(2026, 5, 4, 12, 0, 0, tzinfo=UTC)
+    now = datetime(2026, 5, 4, 13, 0, 0, tzinfo=UTC)
+    packet = _make_packet(expires_at=expires)
+    with pytest.raises(PaperApprovalPacketError) as exc_info:
+        verify_packet_freshness(packet, now=now)
+    assert exc_info.value.code == "stale_packet"
+
+
+@pytest.mark.unit
+def test_freshness_raises_naive_now():
+    from app.services.paper_approval_packet import (
+        PaperApprovalPacketError,
+        verify_packet_freshness,
+    )
+
+    packet = _make_packet(expires_at=_FUTURE)
+    naive_now = datetime(2026, 1, 1, 0, 0, 0)  # no tzinfo
+    with pytest.raises(PaperApprovalPacketError) as exc_info:
+        verify_packet_freshness(packet, now=naive_now)
+    assert exc_info.value.code == "naive_now"
+
+
+# ---------------------------------------------------------------------------
+# verify_packet_idempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_idempotency_passes_when_no_execution_row():
+    from app.services.paper_approval_packet import verify_packet_idempotency
+
+    packet = _make_packet()
+    ledger = _mock_ledger(find_executed_result=None)
+    await verify_packet_idempotency(packet, ledger=ledger)  # must not raise
+    ledger.find_executed_by_client_order_id.assert_called_once_with(
+        packet.client_order_id
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_idempotency_raises_duplicate_when_execution_exists():
+    from app.services.paper_approval_packet import (
+        PaperApprovalPacketError,
+        verify_packet_idempotency,
+    )
+
+    existing = _make_ledger_row(lifecycle_state="filled")
+    ledger = _mock_ledger(find_executed_result=existing)
+    packet = _make_packet()
+    with pytest.raises(PaperApprovalPacketError) as exc_info:
+        await verify_packet_idempotency(packet, ledger=ledger)
+    assert exc_info.value.code == "duplicate_client_order_id"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_idempotency_raises_duplicate_for_submitted_state():
+    from app.services.paper_approval_packet import (
+        PaperApprovalPacketError,
+        verify_packet_idempotency,
+    )
+
+    existing = _make_ledger_row(lifecycle_state="submitted")
+    ledger = _mock_ledger(find_executed_result=existing)
+    packet = _make_packet()
+    with pytest.raises(PaperApprovalPacketError) as exc_info:
+        await verify_packet_idempotency(packet, ledger=ledger)
+    assert exc_info.value.code == "duplicate_client_order_id"
+
+
+# ---------------------------------------------------------------------------
+# verify_sell_packet_source
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_sell_source_passes_for_buy_packet():
+    """Buy packets must skip source check entirely."""
+    from app.services.paper_approval_packet import verify_sell_packet_source
+
+    packet = _make_packet(side="buy")
+    ledger = _mock_ledger()
+    await verify_sell_packet_source(packet, ledger=ledger)  # must not raise
+    ledger.list_by_correlation_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_sell_source_passes_with_valid_reconciled_buy():
+    """A sell packet with exactly one reconciled buy source must pass."""
+    from app.services.paper_approval_packet import verify_sell_packet_source
+
+    buy_row = _make_ledger_row(
+        side="buy",
+        record_kind="execution",
+        lifecycle_state="position_reconciled",
+        execution_symbol="BTC/USD",
+        filled_qty=Decimal("0.002"),
+    )
+    packet = _make_packet(
+        side="sell",
+        max_notional=None,
+        max_qty=Decimal("0.001"),
+        qty_source="ledger_filled_qty",
+        execution_symbol="BTC/USD",
+    )
+    ledger = _mock_ledger(list_by_correlation_result=[buy_row])
+    await verify_sell_packet_source(packet, ledger=ledger)  # must not raise
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_sell_source_raises_invalid_qty_source():
+    from app.services.paper_approval_packet import (
+        PaperApprovalPacketError,
+        verify_sell_packet_source,
+    )
+
+    packet = _make_packet(
+        side="sell",
+        max_notional=Decimal("10"),
+        qty_source="manual",  # not allowed for sell
+    )
+    ledger = _mock_ledger()
+    with pytest.raises(PaperApprovalPacketError) as exc_info:
+        await verify_sell_packet_source(packet, ledger=ledger)
+    assert exc_info.value.code == "invalid_qty_source"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_sell_source_raises_missing_source_when_no_rows():
+    from app.services.paper_approval_packet import (
+        PaperApprovalPacketError,
+        verify_sell_packet_source,
+    )
+
+    packet = _make_packet(
+        side="sell",
+        max_notional=Decimal("10"),
+        qty_source="ledger_filled_qty",
+    )
+    ledger = _mock_ledger(list_by_correlation_result=[])
+    with pytest.raises(PaperApprovalPacketError) as exc_info:
+        await verify_sell_packet_source(packet, ledger=ledger)
+    assert exc_info.value.code == "missing_source_order"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_sell_source_raises_missing_source_when_only_sell_rows():
+    from app.services.paper_approval_packet import (
+        PaperApprovalPacketError,
+        verify_sell_packet_source,
+    )
+
+    sell_row = _make_ledger_row(
+        side="sell",
+        record_kind="execution",
+        lifecycle_state="closed",
+    )
+    packet = _make_packet(
+        side="sell",
+        max_notional=Decimal("10"),
+        qty_source="ledger_filled_qty",
+    )
+    ledger = _mock_ledger(list_by_correlation_result=[sell_row])
+    with pytest.raises(PaperApprovalPacketError) as exc_info:
+        await verify_sell_packet_source(packet, ledger=ledger)
+    assert exc_info.value.code == "missing_source_order"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_sell_source_raises_multiple_source_orders():
+    from app.services.paper_approval_packet import (
+        PaperApprovalPacketError,
+        verify_sell_packet_source,
+    )
+
+    buy1 = _make_ledger_row(
+        id=1,
+        client_order_id="buy-001",
+        side="buy",
+        record_kind="execution",
+        lifecycle_state="position_reconciled",
+        execution_symbol="BTC/USD",
+        filled_qty=Decimal("0.001"),
+    )
+    buy2 = _make_ledger_row(
+        id=2,
+        client_order_id="buy-002",
+        side="buy",
+        record_kind="execution",
+        lifecycle_state="position_reconciled",
+        execution_symbol="BTC/USD",
+        filled_qty=Decimal("0.001"),
+    )
+    packet = _make_packet(
+        side="sell",
+        max_notional=Decimal("10"),
+        qty_source="ledger_filled_qty",
+    )
+    ledger = _mock_ledger(list_by_correlation_result=[buy1, buy2])
+    with pytest.raises(PaperApprovalPacketError) as exc_info:
+        await verify_sell_packet_source(packet, ledger=ledger)
+    assert exc_info.value.code == "multiple_source_orders"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_sell_source_raises_source_not_reconciled():
+    from app.services.paper_approval_packet import (
+        PaperApprovalPacketError,
+        verify_sell_packet_source,
+    )
+
+    buy_row = _make_ledger_row(
+        side="buy",
+        record_kind="execution",
+        lifecycle_state="submitted",  # not reconciled
+        execution_symbol="BTC/USD",
+        filled_qty=Decimal("0.001"),
+    )
+    packet = _make_packet(
+        side="sell",
+        max_notional=Decimal("10"),
+        qty_source="ledger_filled_qty",
+        execution_symbol="BTC/USD",
+    )
+    ledger = _mock_ledger(list_by_correlation_result=[buy_row])
+    with pytest.raises(PaperApprovalPacketError) as exc_info:
+        await verify_sell_packet_source(packet, ledger=ledger)
+    assert exc_info.value.code == "source_not_reconciled"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_sell_source_raises_wrong_symbol():
+    from app.services.paper_approval_packet import (
+        PaperApprovalPacketError,
+        verify_sell_packet_source,
+    )
+
+    buy_row = _make_ledger_row(
+        side="buy",
+        record_kind="execution",
+        lifecycle_state="position_reconciled",
+        execution_symbol="ETH/USD",  # different from packet
+        filled_qty=Decimal("0.5"),
+    )
+    packet = _make_packet(
+        side="sell",
+        max_notional=Decimal("10"),
+        qty_source="ledger_filled_qty",
+        signal_symbol="KRW-BTC",
+        execution_symbol="BTC/USD",
+    )
+    ledger = _mock_ledger(list_by_correlation_result=[buy_row])
+    with pytest.raises(PaperApprovalPacketError) as exc_info:
+        await verify_sell_packet_source(packet, ledger=ledger)
+    assert exc_info.value.code == "wrong_symbol"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_sell_source_raises_qty_exceeds_source():
+    from app.services.paper_approval_packet import (
+        PaperApprovalPacketError,
+        verify_sell_packet_source,
+    )
+
+    buy_row = _make_ledger_row(
+        side="buy",
+        record_kind="execution",
+        lifecycle_state="position_reconciled",
+        execution_symbol="BTC/USD",
+        filled_qty=Decimal("0.001"),  # source only has 0.001
+    )
+    packet = _make_packet(
+        side="sell",
+        max_notional=None,
+        max_qty=Decimal("0.005"),  # requesting more than available
+        qty_source="ledger_filled_qty",
+        execution_symbol="BTC/USD",
+    )
+    ledger = _mock_ledger(list_by_correlation_result=[buy_row])
+    with pytest.raises(PaperApprovalPacketError) as exc_info:
+        await verify_sell_packet_source(packet, ledger=ledger)
+    assert exc_info.value.code == "qty_exceeds_source"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_sell_source_passes_with_notional_no_qty_check():
+    """max_notional sell packets skip qty_exceeds_source check."""
+    from app.services.paper_approval_packet import verify_sell_packet_source
+
+    buy_row = _make_ledger_row(
+        side="buy",
+        record_kind="execution",
+        lifecycle_state="position_reconciled",
+        execution_symbol="BTC/USD",
+        filled_qty=Decimal("0.001"),
+    )
+    packet = _make_packet(
+        side="sell",
+        max_notional=Decimal("500"),  # notional, not qty
+        qty_source="ledger_filled_qty",
+        execution_symbol="BTC/USD",
+    )
+    ledger = _mock_ledger(list_by_correlation_result=[buy_row])
+    await verify_sell_packet_source(packet, ledger=ledger)  # must not raise
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_sell_source_passes_with_filled_state_buy():
+    """filled state is in reconciled buy states as a conservative inclusion."""
+    from app.services.paper_approval_packet import verify_sell_packet_source
+
+    buy_row = _make_ledger_row(
+        side="buy",
+        record_kind="execution",
+        lifecycle_state="filled",
+        execution_symbol="BTC/USD",
+        filled_qty=Decimal("0.002"),
+    )
+    packet = _make_packet(
+        side="sell",
+        max_notional=None,
+        max_qty=Decimal("0.001"),
+        qty_source="reconcile_filled_qty",
+        execution_symbol="BTC/USD",
+    )
+    ledger = _mock_ledger(list_by_correlation_result=[buy_row])
+    await verify_sell_packet_source(packet, ledger=ledger)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# PaperApprovalPacketError repr and code access
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_packet_error_has_code_attribute():
+    from app.services.paper_approval_packet import PaperApprovalPacketError
+
+    err = PaperApprovalPacketError(code="stale_packet", message="expired")
+    assert err.code == "stale_packet"
+    assert str(err) == "expired"
+    assert isinstance(err, ValueError)
+
+
+@pytest.mark.unit
+def test_packet_error_repr():
+    from app.services.paper_approval_packet import PaperApprovalPacketError
+
+    err = PaperApprovalPacketError(code="duplicate_client_order_id", message="dup")
+    assert "duplicate_client_order_id" in repr(err)
+
+
+# ---------------------------------------------------------------------------
+# Module-level static safety checks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_paper_approval_packet_module_has_no_broker_calls():
+    """The module must contain no broker submit/cancel/modify calls or DB mutations."""
+    import ast
+    from pathlib import Path
+
+    source = (
+        Path(__file__).parents[2] / "app/services/paper_approval_packet.py"
+    ).read_text()
+
+    # String-based checks for terms that must not appear anywhere (even in strings)
+    string_forbidden = [
+        "submit_order",
+        "cancel_order",
+        "place_order",
+        "modify_order",
+        "INSERT",
+        "UPDATE",
+        "DELETE",
+        "commit()",
+    ]
+    for term in string_forbidden:
+        assert term not in source, f"Forbidden term found in packet module: {term!r}"
+
+    # AST-based check: datetime.now() must not be called in any function body
+    tree = ast.parse(source)
+    datetime_now_calls: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant):
+            continue  # skip string constants (docstrings)
+        if isinstance(node, ast.Call):
+            # datetime.now(...) or datetime.now()
+            if (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "now"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "datetime"
+            ):
+                datetime_now_calls.append(getattr(node, "lineno", 0))
+
+    assert not datetime_now_calls, (
+        f"datetime.now() call(s) found in verifier module at lines: {datetime_now_calls}"
+    )
+
+
+@pytest.mark.unit
+def test_paper_approval_packet_module_is_valid_python():
+    import ast
+    from pathlib import Path
+
+    source = (
+        Path(__file__).parents[2] / "app/services/paper_approval_packet.py"
+    ).read_text()
+    tree = ast.parse(source)
+    assert tree is not None
+
+
+# ---------------------------------------------------------------------------
+# TestRob91AcceptanceScenarios — named acceptance criteria
+# ---------------------------------------------------------------------------
+
+
+class TestRob91AcceptanceScenarios:
+    """Named acceptance tests covering the four ROB-91 acceptance criteria."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_duplicate_client_order_id_cannot_execute_twice(self):
+        """AC: A client_order_id that already executed must be rejected before broker call."""
+        from app.services.paper_approval_packet import (
+            PaperApprovalPacketError,
+            verify_packet_idempotency,
+        )
+
+        existing_row = _make_ledger_row(lifecycle_state="filled")
+        ledger = _mock_ledger(find_executed_result=existing_row)
+
+        packet = _make_packet(client_order_id="dup-order-001")
+        with pytest.raises(PaperApprovalPacketError) as exc_info:
+            await verify_packet_idempotency(packet, ledger=ledger)
+
+        assert exc_info.value.code == "duplicate_client_order_id"
+        assert "dup-order-001" in str(exc_info.value)
+
+    @pytest.mark.unit
+    def test_stale_packet_fails_closed(self):
+        """AC: A packet whose expires_at is in the past must be rejected."""
+        from app.services.paper_approval_packet import (
+            PaperApprovalPacketError,
+            verify_packet_freshness,
+        )
+
+        past_expiry = datetime(2020, 6, 1, 0, 0, 0, tzinfo=UTC)
+        packet = _make_packet(expires_at=past_expiry)
+        now = datetime(2026, 5, 4, 12, 0, 0, tzinfo=UTC)
+
+        with pytest.raises(PaperApprovalPacketError) as exc_info:
+            verify_packet_freshness(packet, now=now)
+
+        assert exc_info.value.code == "stale_packet"
+
+    @pytest.mark.unit
+    def test_wrong_symbol_payload_fails_closed(self):
+        """AC: A packet whose execution_symbol does not match the signal mapping must be rejected at schema construction."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as exc_info:
+            _make_packet(
+                signal_symbol="KRW-BTC",
+                execution_symbol="SOL/USD",  # wrong symbol for BTC signal
+            )
+
+        error_text = str(exc_info.value)
+        assert "SOL/USD" in error_text or "does not match" in error_text
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_sell_missing_source_order_fails_closed(self):
+        """AC: A sell packet with no prior buy source in the ledger must be rejected."""
+        from app.services.paper_approval_packet import (
+            PaperApprovalPacketError,
+            verify_sell_packet_source,
+        )
+
+        packet = _make_packet(
+            side="sell",
+            max_notional=Decimal("10"),
+            qty_source="ledger_filled_qty",
+            lifecycle_correlation_id="corr-no-buy",
+        )
+        # Empty ledger — no buy rows at all
+        ledger = _mock_ledger(list_by_correlation_result=[])
+
+        with pytest.raises(PaperApprovalPacketError) as exc_info:
+            await verify_sell_packet_source(packet, ledger=ledger)
+
+        assert exc_info.value.code == "missing_source_order"
+        assert "corr-no-buy" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- Add structured bounded Alpaca Paper approval packet validation for preview/executable packet states.
- Add client_order_id duplicate/reuse guards backed by recent ledger entries.
- Add buy/sell lifecycle correlation rules, including sell-source validation against exactly one prior reconciled buy ledger row.
- Document approval packet/idempotency runbook expectations.

## Verification
- `uv run pytest tests/services/test_paper_approval_packet.py tests/services/test_alpaca_paper_ledger_service.py -q` → 114 passed, 2 warnings
- `uv run ruff check app/services/paper_approval_packet.py app/services/alpaca_paper_ledger_service.py tests/services/test_paper_approval_packet.py tests/services/test_alpaca_paper_ledger_service.py` → passed
- `uv run ruff format --check app/services/paper_approval_packet.py app/services/alpaca_paper_ledger_service.py tests/services/test_paper_approval_packet.py tests/services/test_alpaca_paper_ledger_service.py` → passed
- `uv run ty check app/services/paper_approval_packet.py app/services/alpaca_paper_ledger_service.py` → passed
- `uv run pytest tests/test_alpaca_paper_orders_tools.py tests/test_alpaca_paper_fill_reconcile_smoke.py tests/test_alpaca_paper_sell_close_smoke.py tests/test_mcp_alpaca_paper_tools.py -q` → 128 passed, 2 warnings
- Claude Code Opus K2 review → PASS, no blocking issues

## Safety / non-actions
- Paper approval/idempotency contract only.
- No live trading.
- No generic broker route.
- No KIS/Upbit mutation.
- No Alpaca Paper submit/cancel or other broker mutation.
- No direct database update/delete/backfill.
- No scheduler changes.
- No secrets printed or committed.

Linear: ROB-91


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new approval packet system with built-in validation checks for paper trading orders, including freshness verification, idempotency checks, and source validation for sell orders.

* **Documentation**
  * Added comprehensive runbook documentation outlining the approval packet contract, validation constraints, and verification procedures.

* **Tests**
  * Added extensive test coverage for the approval packet schema and validation functions to ensure reliability and correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->