### PR TITLE
feat(ROB-92): add Alpaca paper roundtrip audit report

### DIFF
--- a/app/mcp_server/tooling/alpaca_paper.py
+++ b/app/mcp_server/tooling/alpaca_paper.py
@@ -27,10 +27,11 @@ ALPACA_PAPER_READONLY_TOOL_NAMES: set[str] = {
     "alpaca_paper_get_order",
     "alpaca_paper_list_assets",
     "alpaca_paper_list_fills",
-    # ROB-84/ROB-90/ROB-93 ledger read and anomaly preflight tools
+    # ROB-84/ROB-90/ROB-92/ROB-93 ledger read and anomaly preflight tools
     "alpaca_paper_ledger_list_recent",
     "alpaca_paper_ledger_get",
     "alpaca_paper_ledger_get_by_correlation",
+    "alpaca_paper_roundtrip_report",
     "alpaca_paper_execution_preflight_check",
 }
 

--- a/app/mcp_server/tooling/alpaca_paper_ledger_read.py
+++ b/app/mcp_server/tooling/alpaca_paper_ledger_read.py
@@ -5,6 +5,7 @@ No broker mutation. No submit/cancel/replace. Pure record-keeping reads.
 
 from __future__ import annotations
 
+import uuid
 from typing import TYPE_CHECKING, Any, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -14,6 +15,9 @@ from app.services.alpaca_paper_anomaly_checks import (
     build_paper_execution_preflight_report,
 )
 from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+from app.services.alpaca_paper_roundtrip_report_service import (
+    AlpacaPaperRoundtripReportService,
+)
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -178,6 +182,80 @@ async def alpaca_paper_ledger_get_by_correlation(
     }
 
 
+async def alpaca_paper_roundtrip_report(
+    lifecycle_correlation_id: str | None = None,
+    client_order_id: str | None = None,
+    candidate_uuid: str | None = None,
+    briefing_artifact_run_uuid: str | None = None,
+    open_orders: list[dict[str, Any]] | None = None,
+    positions: list[dict[str, Any]] | None = None,
+    stale_after_minutes: int = 30,
+    include_ledger_rows: bool = True,
+) -> dict[str, Any]:
+    """Build a read-only Alpaca Paper roundtrip audit report.
+
+    Exactly one of lifecycle_correlation_id, client_order_id, candidate_uuid, or
+    briefing_artifact_run_uuid is required. open_orders and positions are
+    optional caller-supplied read-only snapshots; this tool never fetches broker
+    state itself.
+    """
+    supplied = [
+        lifecycle_correlation_id is not None,
+        client_order_id is not None,
+        candidate_uuid is not None,
+        briefing_artifact_run_uuid is not None,
+    ]
+    if sum(supplied) != 1:
+        raise ValueError("exactly one lookup key is required")
+    if stale_after_minutes < 1:
+        raise ValueError("stale_after_minutes must be >= 1")
+
+    candidate_lookup = uuid.UUID(candidate_uuid) if candidate_uuid is not None else None
+    briefing_lookup = (
+        uuid.UUID(briefing_artifact_run_uuid)
+        if briefing_artifact_run_uuid is not None
+        else None
+    )
+
+    async with _session_factory()() as db:
+        svc = AlpacaPaperRoundtripReportService(db)
+        if candidate_lookup is not None:
+            response = await svc.build_reports_for_candidate_uuid(
+                candidate_lookup,
+                stale_after_minutes=stale_after_minutes,
+                include_ledger_rows=include_ledger_rows,
+            )
+            payload = response.model_dump(mode="json")
+            success = response.count > 0
+        elif briefing_lookup is not None:
+            response = await svc.build_reports_for_briefing_artifact_run_uuid(
+                briefing_lookup,
+                stale_after_minutes=stale_after_minutes,
+                include_ledger_rows=include_ledger_rows,
+            )
+            payload = response.model_dump(mode="json")
+            success = response.count > 0
+        else:
+            report = await svc.build_report(
+                lifecycle_correlation_id=lifecycle_correlation_id,
+                client_order_id=client_order_id,
+                open_orders=open_orders or [],
+                positions=positions or [],
+                stale_after_minutes=stale_after_minutes,
+                include_ledger_rows=include_ledger_rows,
+            )
+            payload = report.model_dump(mode="json")
+            success = report.status != "not_found"
+
+    return {
+        "success": success,
+        "account_mode": "alpaca_paper",
+        "source": "alpaca_paper_roundtrip_report",
+        "read_only": True,
+        "report": payload,
+    }
+
+
 def register_alpaca_paper_ledger_read_tools(mcp: FastMCP) -> None:
     """Register read-only Alpaca Paper ledger MCP tools."""
     _ = mcp.tool(
@@ -213,6 +291,14 @@ def register_alpaca_paper_ledger_read_tools(mcp: FastMCP) -> None:
             "in chronological order. No broker mutation."
         ),
     )(alpaca_paper_ledger_get_by_correlation)
+    _ = mcp.tool(
+        name="alpaca_paper_roundtrip_report",
+        description=(
+            "Read-only Alpaca Paper roundtrip audit report from persisted ledger "
+            "rows, with optional caller-supplied open_orders/positions snapshots. "
+            "Does not call broker APIs and does not mutate database state."
+        ),
+    )(alpaca_paper_roundtrip_report)
 
 
 __all__ = [
@@ -220,5 +306,6 @@ __all__ = [
     "alpaca_paper_ledger_get",
     "alpaca_paper_ledger_get_by_correlation",
     "alpaca_paper_ledger_list_recent",
+    "alpaca_paper_roundtrip_report",
     "register_alpaca_paper_ledger_read_tools",
 ]

--- a/app/routers/alpaca_paper_ledger.py
+++ b/app/routers/alpaca_paper_ledger.py
@@ -5,6 +5,7 @@ GET paths only. No POST/PATCH/DELETE. No broker mutation.
 
 from __future__ import annotations
 
+import uuid
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -18,7 +19,14 @@ from app.schemas.alpaca_paper_ledger import (
     AlpacaPaperOrderLedgerListResponse,
     AlpacaPaperOrderLedgerRead,
 )
+from app.schemas.alpaca_paper_roundtrip_report import (
+    AlpacaPaperRoundtripReport,
+    AlpacaPaperRoundtripReportListResponse,
+)
 from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+from app.services.alpaca_paper_roundtrip_report_service import (
+    AlpacaPaperRoundtripReportService,
+)
 
 router = APIRouter(prefix="/trading", tags=["alpaca-paper-ledger"])
 
@@ -77,6 +85,112 @@ async def get_ledger_by_client_order_id(
             detail=f"Ledger entry not found for client_order_id={client_order_id!r}",
         )
     return AlpacaPaperOrderLedgerRead.model_validate(row)
+
+
+@router.get(
+    "/api/alpaca-paper/roundtrip-report/by-correlation-id/{lifecycle_correlation_id}",
+    response_model=AlpacaPaperRoundtripReport,
+)
+async def get_roundtrip_report_by_correlation_id(
+    lifecycle_correlation_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+    include_ledger_rows: bool = True,
+    stale_after_minutes: int = 30,
+) -> AlpacaPaperRoundtripReport:
+    svc = AlpacaPaperRoundtripReportService(db)
+    report = await svc.build_report(
+        lifecycle_correlation_id=lifecycle_correlation_id,
+        include_ledger_rows=include_ledger_rows,
+        stale_after_minutes=stale_after_minutes,
+    )
+    if report.status == "not_found":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                "Roundtrip report not found for "
+                f"lifecycle_correlation_id={lifecycle_correlation_id!r}"
+            ),
+        )
+    return report
+
+
+@router.get(
+    "/api/alpaca-paper/roundtrip-report/by-client-order-id/{client_order_id}",
+    response_model=AlpacaPaperRoundtripReport,
+)
+async def get_roundtrip_report_by_client_order_id(
+    client_order_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+    include_ledger_rows: bool = True,
+    stale_after_minutes: int = 30,
+) -> AlpacaPaperRoundtripReport:
+    svc = AlpacaPaperRoundtripReportService(db)
+    report = await svc.build_report(
+        client_order_id=client_order_id,
+        include_ledger_rows=include_ledger_rows,
+        stale_after_minutes=stale_after_minutes,
+    )
+    if report.status == "not_found":
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Roundtrip report not found for client_order_id={client_order_id!r}",
+        )
+    return report
+
+
+@router.get(
+    "/api/alpaca-paper/roundtrip-report/by-candidate-uuid/{candidate_uuid}",
+    response_model=AlpacaPaperRoundtripReportListResponse,
+)
+async def get_roundtrip_reports_by_candidate_uuid(
+    candidate_uuid: uuid.UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+    include_ledger_rows: bool = True,
+    stale_after_minutes: int = 30,
+) -> AlpacaPaperRoundtripReportListResponse:
+    svc = AlpacaPaperRoundtripReportService(db)
+    response = await svc.build_reports_for_candidate_uuid(
+        candidate_uuid,
+        include_ledger_rows=include_ledger_rows,
+        stale_after_minutes=stale_after_minutes,
+    )
+    if response.count == 0:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Roundtrip reports not found for candidate_uuid={candidate_uuid}",
+        )
+    return response
+
+
+@router.get(
+    "/api/alpaca-paper/roundtrip-report/by-briefing-artifact-run-uuid/{briefing_artifact_run_uuid}",
+    response_model=AlpacaPaperRoundtripReportListResponse,
+)
+async def get_roundtrip_reports_by_briefing_artifact_run_uuid(
+    briefing_artifact_run_uuid: uuid.UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+    include_ledger_rows: bool = True,
+    stale_after_minutes: int = 30,
+) -> AlpacaPaperRoundtripReportListResponse:
+    svc = AlpacaPaperRoundtripReportService(db)
+    response = await svc.build_reports_for_briefing_artifact_run_uuid(
+        briefing_artifact_run_uuid,
+        include_ledger_rows=include_ledger_rows,
+        stale_after_minutes=stale_after_minutes,
+    )
+    if response.count == 0:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                "Roundtrip reports not found for "
+                f"briefing_artifact_run_uuid={briefing_artifact_run_uuid}"
+            ),
+        )
+    return response
 
 
 @router.get(

--- a/app/schemas/alpaca_paper_roundtrip_report.py
+++ b/app/schemas/alpaca_paper_roundtrip_report.py
@@ -1,0 +1,177 @@
+"""Read-only Alpaca Paper roundtrip audit report schemas (ROB-92)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, field_serializer
+
+from app.schemas.alpaca_paper_ledger import AlpacaPaperOrderLedgerRead
+
+
+class _RoundtripBaseModel(BaseModel):
+    @field_serializer("*", when_used="json")
+    def _serialize_decimal(self, value: Any) -> Any:
+        if isinstance(value, Decimal):
+            return str(value)
+        return value
+
+
+class RoundtripLookupKey(_RoundtripBaseModel):
+    kind: Literal[
+        "lifecycle_correlation_id",
+        "client_order_id",
+        "candidate_uuid",
+        "briefing_artifact_run_uuid",
+    ]
+    value: str
+
+
+class RoundtripCompleteness(_RoundtripBaseModel):
+    required_steps: list[str]
+    observed_steps: list[str]
+    missing_steps: list[str]
+    is_complete: bool
+
+
+class RoundtripCandidateBlock(_RoundtripBaseModel):
+    candidate_uuid: str | None = None
+    signal_symbol: str | None = None
+    signal_venue: str | None = None
+    execution_symbol: str | None = None
+    execution_venue: str | None = None
+    execution_asset_class: str | None = None
+    instrument_type: str | None = None
+    workflow_stage: str | None = None
+    purpose: str | None = None
+
+
+class RoundtripQaBlock(_RoundtripBaseModel):
+    briefing_artifact_run_uuid: str | None = None
+    briefing_artifact_status: str | None = None
+    qa_evaluator_status: str | None = None
+
+
+class RoundtripApprovalPacketBlock(_RoundtripBaseModel):
+    approval_bridge_generated_at: datetime | None = None
+    approval_bridge_status: str | None = None
+    preview_payload: dict[str, Any] | None = None
+    validation_summary: dict[str, Any] | None = None
+
+
+class RoundtripOrderBlock(_RoundtripBaseModel):
+    client_order_id: str | None = None
+    broker_order_id: str | None = None
+    order_status: str | None = None
+    order_type: str | None = None
+    time_in_force: str | None = None
+    requested_qty: Decimal | None = None
+    requested_notional: Decimal | None = None
+    requested_price: Decimal | None = None
+    currency: str | None = None
+    submitted_at: datetime | None = None
+
+
+class RoundtripFillBlock(_RoundtripBaseModel):
+    filled_qty: Decimal | None = None
+    filled_avg_price: Decimal | None = None
+    fee_amount: Decimal | None = None
+    fee_currency: str | None = None
+    qty_delta: Decimal | None = None
+
+
+class RoundtripReconcileBlock(_RoundtripBaseModel):
+    reconcile_status: str | None = None
+    reconciled_at: datetime | None = None
+    settlement_status: str | None = None
+    settlement_at: datetime | None = None
+    position_snapshot: dict[str, Any] | None = None
+    notes: str | None = None
+    error_summary: str | None = None
+
+
+class RoundtripLegBlock(_RoundtripBaseModel):
+    side: Literal["buy", "sell"]
+    lifecycle_states: list[str] = Field(default_factory=list)
+    record_kinds: list[str] = Field(default_factory=list)
+    order: RoundtripOrderBlock = Field(default_factory=RoundtripOrderBlock)
+    fill: RoundtripFillBlock = Field(default_factory=RoundtripFillBlock)
+    reconcile: RoundtripReconcileBlock = Field(default_factory=RoundtripReconcileBlock)
+    latest_row_created_at: datetime | None = None
+
+
+class RoundtripFinalPositionBlock(_RoundtripBaseModel):
+    source: Literal["caller_supplied", "ledger_snapshot", "missing"] = "missing"
+    symbol: str | None = None
+    qty: Decimal | None = None
+    snapshot: dict[str, Any] | None = None
+
+
+class RoundtripOpenOrdersBlock(_RoundtripBaseModel):
+    source: Literal["caller_supplied", "missing"] = "missing"
+    count: int = 0
+    orders: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class RoundtripAnomalyBlock(_RoundtripBaseModel):
+    status: str
+    should_block: bool
+    anomalies: list[dict[str, Any]] = Field(default_factory=list)
+    counts: dict[str, int] = Field(default_factory=dict)
+    preflight: dict[str, Any] = Field(default_factory=dict)
+
+
+class RoundtripSafetyBlock(_RoundtripBaseModel):
+    read_only: bool = True
+    broker_mutation_performed: bool = False
+    db_write_performed: bool = False
+    broker_snapshot_fetched: bool = False
+    statement: str = (
+        "Read-only audit report assembled from ledger rows and caller-supplied "
+        "snapshots only; no broker mutation, DB repair/backfill, or schema change."
+    )
+
+
+class AlpacaPaperRoundtripReport(_RoundtripBaseModel):
+    lookup_key: RoundtripLookupKey
+    lifecycle_correlation_id: str | None = None
+    generated_at: datetime
+    status: Literal["complete", "incomplete", "anomaly", "not_found"]
+    completeness: RoundtripCompleteness
+    candidate: RoundtripCandidateBlock
+    qa_result: RoundtripQaBlock
+    approval_packet: RoundtripApprovalPacketBlock
+    buy_leg: RoundtripLegBlock | None = None
+    sell_leg: RoundtripLegBlock | None = None
+    final_position: RoundtripFinalPositionBlock
+    open_orders: RoundtripOpenOrdersBlock
+    anomalies: RoundtripAnomalyBlock
+    safety: RoundtripSafetyBlock = Field(default_factory=RoundtripSafetyBlock)
+    ledger_rows: list[AlpacaPaperOrderLedgerRead] | None = None
+
+
+class AlpacaPaperRoundtripReportListResponse(_RoundtripBaseModel):
+    lookup_key: RoundtripLookupKey
+    count: int
+    items: list[AlpacaPaperRoundtripReport]
+
+
+__all__ = [
+    "AlpacaPaperRoundtripReport",
+    "AlpacaPaperRoundtripReportListResponse",
+    "RoundtripAnomalyBlock",
+    "RoundtripApprovalPacketBlock",
+    "RoundtripCandidateBlock",
+    "RoundtripCompleteness",
+    "RoundtripFillBlock",
+    "RoundtripFinalPositionBlock",
+    "RoundtripLegBlock",
+    "RoundtripLookupKey",
+    "RoundtripOpenOrdersBlock",
+    "RoundtripOrderBlock",
+    "RoundtripQaBlock",
+    "RoundtripReconcileBlock",
+    "RoundtripSafetyBlock",
+]

--- a/app/services/alpaca_paper_ledger_service.py
+++ b/app/services/alpaca_paper_ledger_service.py
@@ -312,6 +312,41 @@ class AlpacaPaperLedgerService:
         result = await self._db.execute(stmt)
         return list(result.scalars().all())
 
+    async def list_by_candidate_uuid(
+        self,
+        candidate_uuid: uuid.UUID,
+    ) -> list[AlpacaPaperOrderLedger]:
+        """Return all ledger rows for a candidate UUID, ordered by created_at, id."""
+        stmt = (
+            select(AlpacaPaperOrderLedger)
+            .where(AlpacaPaperOrderLedger.candidate_uuid == candidate_uuid)
+            .order_by(
+                AlpacaPaperOrderLedger.created_at.asc(),
+                AlpacaPaperOrderLedger.id.asc(),
+            )
+        )
+        result = await self._db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def list_by_briefing_artifact_run_uuid(
+        self,
+        briefing_artifact_run_uuid: uuid.UUID,
+    ) -> list[AlpacaPaperOrderLedger]:
+        """Return all ledger rows for a briefing artifact UUID, ordered by created_at, id."""
+        stmt = (
+            select(AlpacaPaperOrderLedger)
+            .where(
+                AlpacaPaperOrderLedger.briefing_artifact_run_uuid
+                == briefing_artifact_run_uuid
+            )
+            .order_by(
+                AlpacaPaperOrderLedger.created_at.asc(),
+                AlpacaPaperOrderLedger.id.asc(),
+            )
+        )
+        result = await self._db.execute(stmt)
+        return list(result.scalars().all())
+
     async def find_executed_by_client_order_id(
         self,
         client_order_id: str,

--- a/app/services/alpaca_paper_roundtrip_report_service.py
+++ b/app/services/alpaca_paper_roundtrip_report_service.py
@@ -1,0 +1,490 @@
+"""Read-only Alpaca Paper roundtrip audit report assembler (ROB-92).
+
+This module is deliberately side-effect free: it reads ledger rows already
+provided by AlpacaPaperLedgerService and combines them with optional
+caller-supplied snapshots. It must not call brokers or write to the database.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.alpaca_paper_ledger import AlpacaPaperOrderLedgerRead
+from app.schemas.alpaca_paper_roundtrip_report import (
+    AlpacaPaperRoundtripReport,
+    AlpacaPaperRoundtripReportListResponse,
+    RoundtripAnomalyBlock,
+    RoundtripApprovalPacketBlock,
+    RoundtripCandidateBlock,
+    RoundtripCompleteness,
+    RoundtripFillBlock,
+    RoundtripFinalPositionBlock,
+    RoundtripLegBlock,
+    RoundtripLookupKey,
+    RoundtripOpenOrdersBlock,
+    RoundtripOrderBlock,
+    RoundtripQaBlock,
+    RoundtripReconcileBlock,
+)
+from app.services.alpaca_paper_anomaly_checks import (
+    build_paper_execution_preflight_report,
+)
+from app.services.alpaca_paper_ledger_service import (
+    LIFECYCLE_ANOMALY,
+    LIFECYCLE_CLOSED,
+    LIFECYCLE_FILLED,
+    LIFECYCLE_FINAL_RECONCILED,
+    LIFECYCLE_PLANNED,
+    LIFECYCLE_POSITION_RECONCILED,
+    LIFECYCLE_PREVIEWED,
+    LIFECYCLE_SELL_VALIDATED,
+    LIFECYCLE_SUBMITTED,
+    LIFECYCLE_VALIDATED,
+    AlpacaPaperLedgerService,
+)
+
+_REQUIRED_STEPS = [
+    LIFECYCLE_PLANNED,
+    LIFECYCLE_PREVIEWED,
+    LIFECYCLE_VALIDATED,
+    LIFECYCLE_SUBMITTED,
+    LIFECYCLE_FILLED,
+    LIFECYCLE_POSITION_RECONCILED,
+    LIFECYCLE_SELL_VALIDATED,
+    LIFECYCLE_CLOSED,
+    LIFECYCLE_FINAL_RECONCILED,
+]
+
+
+def _get(row: Any, key: str, default: Any = None) -> Any:
+    if isinstance(row, dict):
+        return row.get(key, default)
+    return getattr(row, key, default)
+
+
+def _as_decimal(value: Any) -> Decimal | None:
+    if value is None or value == "":
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+
+
+def _as_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _row_sort_key(row: Any) -> tuple[datetime, int]:
+    created = _get(row, "created_at")
+    if not isinstance(created, datetime):
+        created = datetime.min.replace(tzinfo=UTC)
+    row_id = _get(row, "id") or 0
+    try:
+        row_id_int = int(row_id)
+    except (TypeError, ValueError):
+        row_id_int = 0
+    return created, row_id_int
+
+
+def _safe_ledger_read(row: Any) -> AlpacaPaperOrderLedgerRead | None:
+    try:
+        return AlpacaPaperOrderLedgerRead.model_validate(row)
+    except Exception:
+        return None
+
+
+def _latest(rows: Iterable[Any], predicate) -> Any | None:
+    matching = [row for row in rows if predicate(row)]
+    if not matching:
+        return None
+    return sorted(matching, key=_row_sort_key)[-1]
+
+
+def _first(rows: list[Any]) -> Any | None:
+    return rows[0] if rows else None
+
+
+class AlpacaPaperRoundtripReportService:
+    """Build read-only Alpaca Paper roundtrip reports from ledger rows."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self._ledger = AlpacaPaperLedgerService(db)
+
+    async def build_report(
+        self,
+        *,
+        lifecycle_correlation_id: str | None = None,
+        client_order_id: str | None = None,
+        candidate_uuid: uuid.UUID | None = None,
+        briefing_artifact_run_uuid: uuid.UUID | None = None,
+        open_orders: list[dict[str, Any]] | None = None,
+        positions: list[dict[str, Any]] | None = None,
+        stale_after_minutes: int = 30,
+        include_ledger_rows: bool = True,
+        now: datetime | None = None,
+    ) -> AlpacaPaperRoundtripReport:
+        lookups = [
+            lifecycle_correlation_id is not None,
+            client_order_id is not None,
+            candidate_uuid is not None,
+            briefing_artifact_run_uuid is not None,
+        ]
+        if sum(lookups) != 1:
+            raise ValueError("exactly one roundtrip lookup key is required")
+        if stale_after_minutes < 1:
+            raise ValueError("stale_after_minutes must be >= 1")
+
+        lookup_key: RoundtripLookupKey
+        rows: list[Any]
+        if lifecycle_correlation_id is not None:
+            value = lifecycle_correlation_id.strip()
+            if not value:
+                raise ValueError("lifecycle_correlation_id is required")
+            lookup_key = RoundtripLookupKey(
+                kind="lifecycle_correlation_id", value=value
+            )
+            rows = await self._ledger.list_by_correlation_id(value)
+        elif client_order_id is not None:
+            value = client_order_id.strip()
+            if not value:
+                raise ValueError("client_order_id is required")
+            lookup_key = RoundtripLookupKey(kind="client_order_id", value=value)
+            seed = await self._ledger.get_by_client_order_id(value)
+            if seed is None:
+                rows = []
+            else:
+                corr = _get(seed, "lifecycle_correlation_id") or value
+                rows = await self._ledger.list_by_correlation_id(str(corr))
+        elif candidate_uuid is not None:
+            lookup_key = RoundtripLookupKey(
+                kind="candidate_uuid", value=str(candidate_uuid)
+            )
+            rows = await self._ledger.list_by_candidate_uuid(candidate_uuid)
+        else:
+            assert briefing_artifact_run_uuid is not None
+            lookup_key = RoundtripLookupKey(
+                kind="briefing_artifact_run_uuid", value=str(briefing_artifact_run_uuid)
+            )
+            rows = await self._ledger.list_by_briefing_artifact_run_uuid(
+                briefing_artifact_run_uuid
+            )
+
+        return self._build_report_from_rows(
+            rows=rows,
+            lookup_key=lookup_key,
+            open_orders=open_orders or [],
+            positions=positions or [],
+            stale_after_minutes=stale_after_minutes,
+            include_ledger_rows=include_ledger_rows,
+            now=now,
+        )
+
+    async def build_reports_for_candidate_uuid(
+        self,
+        candidate_uuid: uuid.UUID,
+        *,
+        include_ledger_rows: bool = True,
+        stale_after_minutes: int = 30,
+        now: datetime | None = None,
+    ) -> AlpacaPaperRoundtripReportListResponse:
+        rows = await self._ledger.list_by_candidate_uuid(candidate_uuid)
+        return self._build_grouped_response(
+            rows=rows,
+            lookup_key=RoundtripLookupKey(
+                kind="candidate_uuid", value=str(candidate_uuid)
+            ),
+            include_ledger_rows=include_ledger_rows,
+            stale_after_minutes=stale_after_minutes,
+            now=now,
+        )
+
+    async def build_reports_for_briefing_artifact_run_uuid(
+        self,
+        briefing_artifact_run_uuid: uuid.UUID,
+        *,
+        include_ledger_rows: bool = True,
+        stale_after_minutes: int = 30,
+        now: datetime | None = None,
+    ) -> AlpacaPaperRoundtripReportListResponse:
+        rows = await self._ledger.list_by_briefing_artifact_run_uuid(
+            briefing_artifact_run_uuid
+        )
+        return self._build_grouped_response(
+            rows=rows,
+            lookup_key=RoundtripLookupKey(
+                kind="briefing_artifact_run_uuid",
+                value=str(briefing_artifact_run_uuid),
+            ),
+            include_ledger_rows=include_ledger_rows,
+            stale_after_minutes=stale_after_minutes,
+            now=now,
+        )
+
+    def _build_grouped_response(
+        self,
+        *,
+        rows: list[Any],
+        lookup_key: RoundtripLookupKey,
+        include_ledger_rows: bool,
+        stale_after_minutes: int,
+        now: datetime | None,
+    ) -> AlpacaPaperRoundtripReportListResponse:
+        grouped: dict[str, list[Any]] = {}
+        for row in rows:
+            corr = str(_get(row, "lifecycle_correlation_id") or "")
+            grouped.setdefault(corr, []).append(row)
+        reports = [
+            self._build_report_from_rows(
+                rows=group_rows,
+                lookup_key=lookup_key,
+                open_orders=[],
+                positions=[],
+                stale_after_minutes=stale_after_minutes,
+                include_ledger_rows=include_ledger_rows,
+                now=now,
+            )
+            for _, group_rows in sorted(grouped.items())
+        ]
+        return AlpacaPaperRoundtripReportListResponse(
+            lookup_key=lookup_key,
+            count=len(reports),
+            items=reports,
+        )
+
+    def _build_report_from_rows(
+        self,
+        *,
+        rows: list[Any],
+        lookup_key: RoundtripLookupKey,
+        open_orders: list[dict[str, Any]],
+        positions: list[dict[str, Any]],
+        stale_after_minutes: int,
+        include_ledger_rows: bool,
+        now: datetime | None,
+    ) -> AlpacaPaperRoundtripReport:
+        generated_at = now or datetime.now(UTC)
+        ordered = sorted(rows, key=_row_sort_key)
+        observed_steps = list(
+            dict.fromkeys(str(_get(r, "lifecycle_state")) for r in ordered)
+        )
+        missing_steps = [step for step in _REQUIRED_STEPS if step not in observed_steps]
+        completeness = RoundtripCompleteness(
+            required_steps=list(_REQUIRED_STEPS),
+            observed_steps=observed_steps,
+            missing_steps=missing_steps,
+            is_complete=not missing_steps,
+        )
+        first = _first(ordered)
+        lifecycle_correlation_id = (
+            _as_str(_get(first, "lifecycle_correlation_id")) if first else None
+        )
+
+        preflight = build_paper_execution_preflight_report(
+            ledger_rows=[],
+            open_orders=open_orders,
+            positions=positions,
+            stale_after_minutes=stale_after_minutes,
+            now=generated_at,
+        ).to_dict()
+        row_anomalies = [
+            {
+                "check_id": "ledger_anomaly_row",
+                "severity": "block",
+                "summary": "Roundtrip ledger contains anomaly lifecycle row",
+                "details": {
+                    "client_order_id": _get(row, "client_order_id"),
+                    "lifecycle_state": _get(row, "lifecycle_state"),
+                    "error_summary": _get(row, "error_summary"),
+                },
+            }
+            for row in ordered
+            if _get(row, "lifecycle_state") == LIFECYCLE_ANOMALY
+        ]
+        anomalies_list = list(preflight.get("anomalies") or []) + row_anomalies
+        should_block = bool(preflight.get("should_block")) or bool(row_anomalies)
+        if not ordered:
+            status = "not_found"
+        elif should_block:
+            status = "anomaly"
+        elif completeness.is_complete:
+            status = "complete"
+        else:
+            status = "incomplete"
+
+        latest_validation = _latest(
+            ordered, lambda r: _get(r, "validation_summary") is not None
+        )
+        latest_preview = _latest(
+            ordered, lambda r: _get(r, "preview_payload") is not None
+        )
+        ledger_reads = (
+            [_safe_ledger_read(r) for r in ordered] if include_ledger_rows else None
+        )
+
+        return AlpacaPaperRoundtripReport(
+            lookup_key=lookup_key,
+            lifecycle_correlation_id=lifecycle_correlation_id,
+            generated_at=generated_at,
+            status=status,
+            completeness=completeness,
+            candidate=self._candidate_block(first),
+            qa_result=RoundtripQaBlock(
+                briefing_artifact_run_uuid=_as_str(
+                    _get(first, "briefing_artifact_run_uuid")
+                ),
+                briefing_artifact_status=_get(first, "briefing_artifact_status"),
+                qa_evaluator_status=_get(first, "qa_evaluator_status"),
+            ),
+            approval_packet=RoundtripApprovalPacketBlock(
+                approval_bridge_generated_at=_get(
+                    first, "approval_bridge_generated_at"
+                ),
+                approval_bridge_status=_get(first, "approval_bridge_status"),
+                preview_payload=_get(latest_preview, "preview_payload"),
+                validation_summary=_get(latest_validation, "validation_summary"),
+            ),
+            buy_leg=self._leg_block(ordered, "buy"),
+            sell_leg=self._leg_block(ordered, "sell"),
+            final_position=self._final_position_block(ordered, positions),
+            open_orders=RoundtripOpenOrdersBlock(
+                source="caller_supplied" if open_orders else "missing",
+                count=len(open_orders),
+                orders=open_orders,
+            ),
+            anomalies=RoundtripAnomalyBlock(
+                status=str(preflight.get("status") or "pass"),
+                should_block=should_block,
+                anomalies=anomalies_list,
+                counts=dict(preflight.get("counts") or {}),
+                preflight=preflight,
+            ),
+            ledger_rows=[r for r in ledger_reads or [] if r is not None]
+            if include_ledger_rows
+            else None,
+        )
+
+    def _candidate_block(self, row: Any | None) -> RoundtripCandidateBlock:
+        return RoundtripCandidateBlock(
+            candidate_uuid=_as_str(_get(row, "candidate_uuid")),
+            signal_symbol=_get(row, "signal_symbol"),
+            signal_venue=_get(row, "signal_venue"),
+            execution_symbol=_get(row, "execution_symbol"),
+            execution_venue=_get(row, "execution_venue"),
+            execution_asset_class=_get(row, "execution_asset_class"),
+            instrument_type=_as_str(_get(row, "instrument_type")),
+            workflow_stage=_get(row, "workflow_stage"),
+            purpose=_get(row, "purpose"),
+        )
+
+    def _leg_block(self, rows: list[Any], side: str) -> RoundtripLegBlock | None:
+        leg_rows = [r for r in rows if str(_get(r, "side") or "").lower() == side]
+        if not leg_rows:
+            return None
+        latest_order = (
+            _latest(
+                leg_rows,
+                lambda r: (
+                    _get(r, "broker_order_id") is not None
+                    or _get(r, "submitted_at") is not None
+                    or _get(r, "record_kind") == "execution"
+                ),
+            )
+            or leg_rows[-1]
+        )
+        latest_fill = _latest(
+            leg_rows,
+            lambda r: (
+                _get(r, "filled_qty") is not None
+                or _get(r, "filled_avg_price") is not None
+                or _get(r, "lifecycle_state") in {LIFECYCLE_FILLED, LIFECYCLE_CLOSED}
+            ),
+        )
+        latest_reconcile = _latest(
+            leg_rows,
+            lambda r: (
+                _get(r, "reconcile_status") is not None
+                or _get(r, "position_snapshot") is not None
+                or _get(r, "lifecycle_state")
+                in {LIFECYCLE_POSITION_RECONCILED, LIFECYCLE_FINAL_RECONCILED}
+            ),
+        )
+        return RoundtripLegBlock(
+            side=side,  # type: ignore[arg-type]
+            lifecycle_states=list(
+                dict.fromkeys(str(_get(r, "lifecycle_state")) for r in leg_rows)
+            ),
+            record_kinds=list(
+                dict.fromkeys(str(_get(r, "record_kind")) for r in leg_rows)
+            ),
+            order=RoundtripOrderBlock(
+                client_order_id=_get(latest_order, "client_order_id"),
+                broker_order_id=_get(latest_order, "broker_order_id"),
+                order_status=_get(latest_order, "order_status"),
+                order_type=_get(latest_order, "order_type"),
+                time_in_force=_get(latest_order, "time_in_force"),
+                requested_qty=_as_decimal(_get(latest_order, "requested_qty")),
+                requested_notional=_as_decimal(
+                    _get(latest_order, "requested_notional")
+                ),
+                requested_price=_as_decimal(_get(latest_order, "requested_price")),
+                currency=_get(latest_order, "currency"),
+                submitted_at=_get(latest_order, "submitted_at"),
+            ),
+            fill=RoundtripFillBlock(
+                filled_qty=_as_decimal(_get(latest_fill, "filled_qty")),
+                filled_avg_price=_as_decimal(_get(latest_fill, "filled_avg_price")),
+                fee_amount=_as_decimal(_get(latest_fill, "fee_amount")),
+                fee_currency=_get(latest_fill, "fee_currency"),
+                qty_delta=_as_decimal(_get(latest_fill, "qty_delta")),
+            ),
+            reconcile=RoundtripReconcileBlock(
+                reconcile_status=_get(latest_reconcile, "reconcile_status"),
+                reconciled_at=_get(latest_reconcile, "reconciled_at"),
+                settlement_status=_get(latest_reconcile, "settlement_status"),
+                settlement_at=_get(latest_reconcile, "settlement_at"),
+                position_snapshot=_get(latest_reconcile, "position_snapshot"),
+                notes=_get(latest_reconcile, "notes"),
+                error_summary=_get(latest_reconcile, "error_summary"),
+            ),
+            latest_row_created_at=_get(leg_rows[-1], "created_at"),
+        )
+
+    def _final_position_block(
+        self, rows: list[Any], positions: list[dict[str, Any]]
+    ) -> RoundtripFinalPositionBlock:
+        if positions:
+            first = positions[0]
+            return RoundtripFinalPositionBlock(
+                source="caller_supplied",
+                symbol=_as_str(first.get("symbol")),
+                qty=_as_decimal(first.get("qty") or first.get("quantity")),
+                snapshot=first,
+            )
+        snapshot_row = _latest(rows, lambda r: _get(r, "position_snapshot") is not None)
+        snapshot = _get(snapshot_row, "position_snapshot") if snapshot_row else None
+        if isinstance(snapshot, dict):
+            return RoundtripFinalPositionBlock(
+                source="ledger_snapshot",
+                symbol=_get(snapshot_row, "execution_symbol"),
+                qty=_as_decimal(snapshot.get("qty") or snapshot.get("quantity")),
+                snapshot=snapshot,
+            )
+        if LIFECYCLE_FINAL_RECONCILED in {
+            str(_get(row, "lifecycle_state")) for row in rows
+        }:
+            return RoundtripFinalPositionBlock(
+                source="ledger_snapshot", qty=Decimal("0")
+            )
+        return RoundtripFinalPositionBlock(source="missing")
+
+
+__all__ = ["AlpacaPaperRoundtripReportService"]

--- a/docs/runbooks/alpaca-paper-ledger.md
+++ b/docs/runbooks/alpaca-paper-ledger.md
@@ -8,7 +8,7 @@ It records the full lifecycle of a paper roundtrip: plan → preview → validat
 
 It was introduced in ROB-84 as a prerequisite for automating the preopen→paper buy/sell roundtrip (ROB-85). ROB-90 normalized the taxonomy to canonical states.
 
-Related: ROB-83 introduced the Alpaca Paper smoke workflow. ROB-84 adds persistent records. ROB-90 normalizes lifecycle states and adds roundtrip correlation.
+Related: ROB-83 introduced the Alpaca Paper smoke workflow. ROB-84 adds persistent records. ROB-90 normalizes lifecycle states and adds roundtrip correlation. ROB-92 adds a read-only structured roundtrip audit report; see `docs/runbooks/alpaca-paper-roundtrip-report.md`.
 
 ---
 
@@ -156,6 +156,10 @@ GET /trading/api/alpaca-paper/ledger/recent?limit=50&lifecycle_state=anomaly
 GET /trading/api/alpaca-paper/ledger/{ledger_id}
 GET /trading/api/alpaca-paper/ledger/by-client-order-id/{client_order_id}
 GET /trading/api/alpaca-paper/ledger/by-correlation-id/{lifecycle_correlation_id}
+GET /trading/api/alpaca-paper/roundtrip-report/by-correlation-id/{lifecycle_correlation_id}
+GET /trading/api/alpaca-paper/roundtrip-report/by-client-order-id/{client_order_id}
+GET /trading/api/alpaca-paper/roundtrip-report/by-candidate-uuid/{candidate_uuid}
+GET /trading/api/alpaca-paper/roundtrip-report/by-briefing-artifact-run-uuid/{briefing_artifact_run_uuid}
 ```
 
 ### MCP tools (read-only, in `ALPACA_PAPER_READONLY_TOOL_NAMES`)
@@ -164,6 +168,7 @@ GET /trading/api/alpaca-paper/ledger/by-correlation-id/{lifecycle_correlation_id
 alpaca_paper_ledger_list_recent(limit=50, lifecycle_state=None)
 alpaca_paper_ledger_get(client_order_id)
 alpaca_paper_ledger_get_by_correlation(lifecycle_correlation_id)
+alpaca_paper_roundtrip_report(lifecycle_correlation_id=None, client_order_id=None, candidate_uuid=None, briefing_artifact_run_uuid=None, open_orders=None, positions=None)
 ```
 
 ---

--- a/docs/runbooks/alpaca-paper-roundtrip-report.md
+++ b/docs/runbooks/alpaca-paper-roundtrip-report.md
@@ -1,0 +1,156 @@
+# Alpaca Paper Roundtrip Audit Report Runbook (ROB-92)
+
+## Purpose
+
+The Alpaca Paper roundtrip audit report is a read-only operator view over existing `review.alpaca_paper_order_ledger` rows. It assembles one buy/sell lifecycle into a structured report with candidate/QA provenance, approval context, buy and sell legs, final position evidence, caller-supplied open-order/position snapshots, anomaly flags, and explicit safety metadata.
+
+This report is an audit/read model only. It does not submit, cancel, modify, repair, backfill, or reconcile orders.
+
+## Safety contract
+
+ROB-92 must remain read-only:
+
+- No broker mutation.
+- No broker open-order or position fetch from the API/service assembler.
+- No database writes, commits, flushes, inserts, updates, deletes, migrations, or repair actions.
+- No secrets or raw credentials in report fields.
+- HTTP routes are GET-only and use the existing ledger router authentication dependency.
+- MCP tool inputs may include caller-supplied `open_orders` and `positions` snapshots; the tool must not fetch those snapshots itself.
+
+The report includes a `safety` block with:
+
+- `read_only=true`
+- `broker_mutation_performed=false`
+- `db_write_performed=false`
+- `broker_snapshot_fetched=false`
+
+## API endpoints
+
+All endpoints are authenticated GET routes under `/trading`.
+
+Single-report lookups:
+
+```text
+GET /trading/api/alpaca-paper/roundtrip-report/by-correlation-id/{lifecycle_correlation_id}
+GET /trading/api/alpaca-paper/roundtrip-report/by-client-order-id/{client_order_id}
+```
+
+List lookups, grouped by lifecycle correlation ID:
+
+```text
+GET /trading/api/alpaca-paper/roundtrip-report/by-candidate-uuid/{candidate_uuid}
+GET /trading/api/alpaca-paper/roundtrip-report/by-briefing-artifact-run-uuid/{briefing_artifact_run_uuid}
+```
+
+Query parameters:
+
+```text
+include_ledger_rows=true|false   # default true
+stale_after_minutes=30           # must be >= 1
+```
+
+HTTP report endpoints do not fetch broker open orders or positions. When no caller-supplied snapshot path exists, `open_orders.source` is `missing` and `final_position.source` is based on ledger snapshots when available.
+
+## MCP tool
+
+```python
+alpaca_paper_roundtrip_report(
+    lifecycle_correlation_id=None,
+    client_order_id=None,
+    candidate_uuid=None,
+    briefing_artifact_run_uuid=None,
+    open_orders=None,
+    positions=None,
+    stale_after_minutes=30,
+    include_ledger_rows=True,
+)
+```
+
+Exactly one lookup key is required.
+
+Return wrapper:
+
+```json
+{
+  "success": true,
+  "account_mode": "alpaca_paper",
+  "source": "alpaca_paper_roundtrip_report",
+  "read_only": true,
+  "report": { }
+}
+```
+
+For `candidate_uuid` and `briefing_artifact_run_uuid`, `report` is a list response with `lookup_key`, `count`, and `items`. For correlation/client-order lookups, `report` is a single report.
+
+## Report status
+
+- `complete`: all canonical ROB-90 lifecycle steps are present.
+- `incomplete`: ledger rows exist, but one or more expected lifecycle steps are missing.
+- `anomaly`: anomaly lifecycle rows or caller-supplied snapshot checks produced blocking findings.
+- `not_found`: no matching ledger rows were found.
+
+HTTP routes convert `not_found` or empty list responses to 404.
+
+## Completeness model
+
+The report compares observed lifecycle states against the canonical ROB-90 roundtrip sequence:
+
+```text
+planned
+previewed
+validated
+submitted
+filled
+position_reconciled
+sell_validated
+closed
+final_reconciled
+```
+
+`completeness.required_steps`, `observed_steps`, `missing_steps`, and `is_complete` are included so operators can see what evidence is missing.
+
+## Operator examples
+
+Find a complete report by correlation ID:
+
+```text
+GET /trading/api/alpaca-paper/roundtrip-report/by-correlation-id/corr-abc?include_ledger_rows=false
+```
+
+Find the full roundtrip when you only have a client order ID:
+
+```text
+GET /trading/api/alpaca-paper/roundtrip-report/by-client-order-id/buy-001
+```
+
+Find all reports associated with a candidate:
+
+```text
+GET /trading/api/alpaca-paper/roundtrip-report/by-candidate-uuid/00000000-0000-4000-8000-000000000000
+```
+
+Use MCP with pre-fetched read-only snapshots:
+
+```python
+await alpaca_paper_roundtrip_report(
+    lifecycle_correlation_id="corr-abc",
+    open_orders=[{"id": "order-1", "symbol": "BTCUSD", "status": "new"}],
+    positions=[{"symbol": "BTCUSD", "qty": "0"}],
+    include_ledger_rows=False,
+)
+```
+
+## Stop conditions
+
+Stop and investigate rather than executing any repair if:
+
+- `status` is `anomaly`.
+- `anomalies.should_block` is true.
+- `completeness.is_complete` is false for a roundtrip that was expected to be fully closed.
+- `final_position.qty` is non-zero after an expected close.
+- The report needs broker-state freshness beyond caller-supplied snapshots; that is outside ROB-92 scope.
+
+## Related docs
+
+- `docs/runbooks/alpaca-paper-ledger.md`
+- `docs/post-mortems/2026-05-03-rob87-alpaca-paper-roundtrip.md`

--- a/scripts/smoke/alpaca_paper_readonly_smoke.py
+++ b/scripts/smoke/alpaca_paper_readonly_smoke.py
@@ -24,6 +24,7 @@ from app.mcp_server.tooling.alpaca_paper_ledger_read import (
     alpaca_paper_ledger_get,
     alpaca_paper_ledger_get_by_correlation,
     alpaca_paper_ledger_list_recent,
+    alpaca_paper_roundtrip_report,
 )
 
 
@@ -145,10 +146,22 @@ async def run_smoke() -> int:
             alpaca_paper_ledger_get_by_correlation(correlation_id),
             lambda p: f"count={p.get('count', 0)}",
         )
+        await _probe(
+            "alpaca_paper_roundtrip_report",
+            alpaca_paper_roundtrip_report(lifecycle_correlation_id=correlation_id),
+            lambda p: f"success={p.get('success', False)}",
+        )
     else:
         results.append(
             (
                 "alpaca_paper_ledger_get_by_correlation",
+                True,
+                "skipped: no lifecycle correlation id to inspect",
+            )
+        )
+        results.append(
+            (
+                "alpaca_paper_roundtrip_report",
                 True,
                 "skipped: no lifecycle correlation id to inspect",
             )

--- a/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
+++ b/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
@@ -298,6 +298,93 @@ async def test_ledger_get_by_correlation_empty_id_raises():
 
 
 # ---------------------------------------------------------------------------
+# alpaca_paper_roundtrip_report
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_roundtrip_report_tool_by_correlation_returns_success(monkeypatch):
+    import app.mcp_server.tooling.alpaca_paper_ledger_read as mod
+
+    report = SimpleNamespace(
+        status="complete",
+        model_dump=lambda mode: {  # noqa: ARG005
+            "lookup_key": {"kind": "lifecycle_correlation_id", "value": "corr-test"},
+            "status": "complete",
+            "safety": {"read_only": True},
+        },
+    )
+    svc = SimpleNamespace(build_report=AsyncMock(return_value=report))
+
+    monkeypatch.setattr(mod, "_session_factory", lambda: lambda: _FakeDB())
+    monkeypatch.setattr(mod, "AlpacaPaperRoundtripReportService", lambda db: svc)
+
+    result = await mod.alpaca_paper_roundtrip_report(
+        lifecycle_correlation_id="corr-test",
+        open_orders=[{"id": "order-1", "status": "new"}],
+        include_ledger_rows=False,
+    )
+
+    assert result["success"] is True
+    assert result["account_mode"] == "alpaca_paper"
+    assert result["source"] == "alpaca_paper_roundtrip_report"
+    assert result["read_only"] is True
+    assert result["report"]["safety"]["read_only"] is True
+    svc.build_report.assert_awaited_once_with(
+        lifecycle_correlation_id="corr-test",
+        client_order_id=None,
+        open_orders=[{"id": "order-1", "status": "new"}],
+        positions=[],
+        stale_after_minutes=30,
+        include_ledger_rows=False,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_roundtrip_report_tool_by_candidate_returns_list_payload(monkeypatch):
+    import app.mcp_server.tooling.alpaca_paper_ledger_read as mod
+
+    candidate_uuid = "22222222-2222-4222-8222-222222222222"
+    response = SimpleNamespace(
+        count=1,
+        model_dump=lambda mode: {  # noqa: ARG005
+            "lookup_key": {"kind": "candidate_uuid", "value": candidate_uuid},
+            "count": 1,
+            "items": [],
+        },
+    )
+    svc = SimpleNamespace(
+        build_reports_for_candidate_uuid=AsyncMock(return_value=response)
+    )
+
+    monkeypatch.setattr(mod, "_session_factory", lambda: lambda: _FakeDB())
+    monkeypatch.setattr(mod, "AlpacaPaperRoundtripReportService", lambda db: svc)
+
+    result = await mod.alpaca_paper_roundtrip_report(candidate_uuid=candidate_uuid)
+
+    assert result["success"] is True
+    assert result["report"]["count"] == 1
+    svc.build_reports_for_candidate_uuid.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_roundtrip_report_tool_invalid_lookup_count_raises():
+    from app.mcp_server.tooling.alpaca_paper_ledger_read import (
+        alpaca_paper_roundtrip_report,
+    )
+
+    with pytest.raises(ValueError, match="exactly one lookup key"):
+        await alpaca_paper_roundtrip_report()
+    with pytest.raises(ValueError, match="exactly one lookup key"):
+        await alpaca_paper_roundtrip_report(
+            lifecycle_correlation_id="corr", client_order_id="client"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Registered as read-only
 # ---------------------------------------------------------------------------
 
@@ -309,6 +396,7 @@ def test_ledger_tool_names_are_in_alpaca_readonly_set():
     assert "alpaca_paper_ledger_list_recent" in ALPACA_PAPER_READONLY_TOOL_NAMES
     assert "alpaca_paper_ledger_get" in ALPACA_PAPER_READONLY_TOOL_NAMES
     assert "alpaca_paper_ledger_get_by_correlation" in ALPACA_PAPER_READONLY_TOOL_NAMES
+    assert "alpaca_paper_roundtrip_report" in ALPACA_PAPER_READONLY_TOOL_NAMES
     assert "alpaca_paper_execution_preflight_check" in ALPACA_PAPER_READONLY_TOOL_NAMES
 
 

--- a/tests/routers/test_alpaca_paper_ledger_router.py
+++ b/tests/routers/test_alpaca_paper_ledger_router.py
@@ -278,6 +278,137 @@ def test_get_by_client_order_id_missing_returns_404():
 
 
 # ---------------------------------------------------------------------------
+# ROB-92 roundtrip report endpoints
+# ---------------------------------------------------------------------------
+
+
+def _make_roundtrip_rows_for_router():
+    buy_row = _make_fake_row(
+        client_order_id="buy-rob92",
+        lifecycle_correlation_id="corr-rob92",
+        lifecycle_state="filled",
+        side="buy",
+        order_status="filled",
+        filled_qty="0.001",
+        filled_avg_price="50000",
+        qty_delta="0.001",
+        created_at=datetime(2026, 5, 3, 9, 1, tzinfo=UTC),
+    )
+    sell_row = _make_fake_row(
+        id=2,
+        client_order_id="sell-rob92",
+        lifecycle_correlation_id="corr-rob92",
+        lifecycle_state="closed",
+        side="sell",
+        order_status="filled",
+        filled_qty="0.001",
+        filled_avg_price="51000",
+        qty_delta="-0.001",
+        created_at=datetime(2026, 5, 3, 9, 2, tzinfo=UTC),
+    )
+    return [buy_row, sell_row]
+
+
+@pytest.mark.unit
+def test_roundtrip_report_by_correlation_id_returns_200():
+    db = _mock_db_for_rows(_make_roundtrip_rows_for_router())
+    app = _make_app_with_db(db)
+
+    client = TestClient(app)
+    resp = client.get(
+        "/trading/api/alpaca-paper/roundtrip-report/by-correlation-id/corr-rob92"
+        "?include_ledger_rows=false"
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["lookup_key"] == {
+        "kind": "lifecycle_correlation_id",
+        "value": "corr-rob92",
+    }
+    assert data["lifecycle_correlation_id"] == "corr-rob92"
+    assert data["safety"]["read_only"] is True
+    assert data["ledger_rows"] is None
+    assert data["buy_leg"]["order"]["client_order_id"] == "buy-rob92"
+    assert data["sell_leg"]["order"]["client_order_id"] == "sell-rob92"
+
+
+@pytest.mark.unit
+def test_roundtrip_report_by_correlation_id_missing_returns_404():
+    db = _mock_db_for_rows([])
+    app = _make_app_with_db(db)
+
+    client = TestClient(app)
+    resp = client.get(
+        "/trading/api/alpaca-paper/roundtrip-report/by-correlation-id/missing"
+    )
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.unit
+def test_roundtrip_report_by_client_order_id_returns_200():
+    db = _mock_db_for_rows(_make_roundtrip_rows_for_router())
+    app = _make_app_with_db(db)
+
+    client = TestClient(app)
+    resp = client.get(
+        "/trading/api/alpaca-paper/roundtrip-report/by-client-order-id/buy-rob92"
+        "?include_ledger_rows=false"
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["lookup_key"] == {"kind": "client_order_id", "value": "buy-rob92"}
+    assert data["lifecycle_correlation_id"] == "corr-rob92"
+
+
+@pytest.mark.unit
+def test_roundtrip_report_by_candidate_uuid_returns_list_response():
+    rows = _make_roundtrip_rows_for_router()
+    candidate_uuid = rows[0].candidate_uuid
+    db = _mock_db_for_rows(rows)
+    app = _make_app_with_db(db)
+
+    client = TestClient(app)
+    resp = client.get(
+        f"/trading/api/alpaca-paper/roundtrip-report/by-candidate-uuid/{candidate_uuid}"
+        "?include_ledger_rows=false"
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["lookup_key"] == {
+        "kind": "candidate_uuid",
+        "value": str(candidate_uuid),
+    }
+    assert data["count"] == 1
+    assert data["items"][0]["lifecycle_correlation_id"] == "corr-rob92"
+
+
+@pytest.mark.unit
+def test_roundtrip_report_by_briefing_artifact_run_uuid_returns_list_response():
+    rows = _make_roundtrip_rows_for_router()
+    briefing_uuid = rows[0].briefing_artifact_run_uuid
+    db = _mock_db_for_rows(rows)
+    app = _make_app_with_db(db)
+
+    client = TestClient(app)
+    resp = client.get(
+        "/trading/api/alpaca-paper/roundtrip-report/"
+        f"by-briefing-artifact-run-uuid/{briefing_uuid}?include_ledger_rows=false"
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["lookup_key"] == {
+        "kind": "briefing_artifact_run_uuid",
+        "value": str(briefing_uuid),
+    }
+    assert data["count"] == 1
+
+
+# ---------------------------------------------------------------------------
 # Auth — unauthenticated requests return 401
 # ---------------------------------------------------------------------------
 

--- a/tests/services/test_alpaca_paper_ledger_service.py
+++ b/tests/services/test_alpaca_paper_ledger_service.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
+from uuid import uuid4
 
 import pytest
 
@@ -938,6 +939,67 @@ async def test_list_by_correlation_id_empty_raises():
     svc = AlpacaPaperLedgerService(db)
     with pytest.raises(ValueError, match="lifecycle_correlation_id must not be empty"):
         await svc.list_by_correlation_id("  ")
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_list_by_candidate_uuid_returns_rows():
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    candidate_uuid = uuid4()
+    row = _make_row(
+        candidate_uuid=candidate_uuid, lifecycle_correlation_id="corr-candidate"
+    )
+
+    class _ScalarResult:
+        def scalars(self):
+            class _S:
+                def all(self_inner):
+                    return [row]
+
+            return _S()
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_ScalarResult())
+    db.commit = AsyncMock()
+
+    svc = AlpacaPaperLedgerService(db)
+    rows = await svc.list_by_candidate_uuid(candidate_uuid)
+
+    assert rows == [row]
+    db.execute.assert_awaited_once()
+    db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_list_by_briefing_artifact_run_uuid_returns_rows():
+    from app.services.alpaca_paper_ledger_service import AlpacaPaperLedgerService
+
+    briefing_uuid = uuid4()
+    row = _make_row(
+        briefing_artifact_run_uuid=briefing_uuid,
+        lifecycle_correlation_id="corr-briefing",
+    )
+
+    class _ScalarResult:
+        def scalars(self):
+            class _S:
+                def all(self_inner):
+                    return [row]
+
+            return _S()
+
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_ScalarResult())
+    db.commit = AsyncMock()
+
+    svc = AlpacaPaperLedgerService(db)
+    rows = await svc.list_by_briefing_artifact_run_uuid(briefing_uuid)
+
+    assert rows == [row]
+    db.execute.assert_awaited_once()
+    db.commit.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/services/test_alpaca_paper_roundtrip_report_service.py
+++ b/tests/services/test_alpaca_paper_roundtrip_report_service.py
@@ -250,6 +250,30 @@ async def test_build_report_by_correlation_returns_complete_read_only_report():
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_build_report_missing_required_steps_marks_incomplete_read_only():
+    omitted_steps = {LIFECYCLE_CLOSED, LIFECYCLE_FINAL_RECONCILED}
+    rows = [
+        row
+        for row in _complete_roundtrip_rows()
+        if row.lifecycle_state not in omitted_steps
+    ]
+    svc, db = _service_with_rows(rows)
+
+    report = await svc.build_report(
+        lifecycle_correlation_id="corr-rob92",
+        include_ledger_rows=False,
+        now=_ts(30),
+    )
+
+    assert report.status == "incomplete"
+    assert report.completeness.is_complete is False
+    assert omitted_steps.issubset(set(report.completeness.missing_steps))
+    assert report.ledger_rows is None
+    db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_build_report_by_client_order_id_expands_to_correlation_rows():
     rows = _complete_roundtrip_rows()
     svc, _db = _service_with_rows(rows)

--- a/tests/services/test_alpaca_paper_roundtrip_report_service.py
+++ b/tests/services/test_alpaca_paper_roundtrip_report_service.py
@@ -1,0 +1,320 @@
+"""Tests for the read-only Alpaca Paper roundtrip report assembler (ROB-92)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.alpaca_paper_ledger_service import (
+    LIFECYCLE_CLOSED,
+    LIFECYCLE_FILLED,
+    LIFECYCLE_FINAL_RECONCILED,
+    LIFECYCLE_PLANNED,
+    LIFECYCLE_POSITION_RECONCILED,
+    LIFECYCLE_PREVIEWED,
+    LIFECYCLE_SELL_VALIDATED,
+    LIFECYCLE_SUBMITTED,
+    LIFECYCLE_VALIDATED,
+    RECORD_KIND_EXECUTION,
+    RECORD_KIND_PLAN,
+    RECORD_KIND_PREVIEW,
+    RECORD_KIND_RECONCILE,
+    RECORD_KIND_VALIDATION_ATTEMPT,
+)
+from app.services.alpaca_paper_roundtrip_report_service import (
+    AlpacaPaperRoundtripReportService,
+)
+
+_T0 = datetime(2026, 5, 4, 9, 0, tzinfo=UTC)
+_CANDIDATE_UUID = uuid.uuid4()
+_BRIEFING_UUID = uuid.uuid4()
+
+
+def _ts(seconds: int) -> datetime:
+    return _T0 + timedelta(seconds=seconds)
+
+
+def _row(
+    *,
+    lifecycle_state: str,
+    side: str,
+    record_kind: str,
+    client_order_id: str,
+    lifecycle_correlation_id: str = "corr-rob92",
+    created_at: datetime | None = None,
+    **overrides,
+) -> SimpleNamespace:
+    defaults = {
+        "id": len(client_order_id) + int((created_at or _T0).timestamp()) % 100,
+        "client_order_id": client_order_id,
+        "lifecycle_correlation_id": lifecycle_correlation_id,
+        "record_kind": record_kind,
+        "broker": "alpaca",
+        "account_mode": "alpaca_paper",
+        "lifecycle_state": lifecycle_state,
+        "signal_symbol": "KRW-BTC",
+        "signal_venue": "upbit",
+        "execution_symbol": "BTCUSD",
+        "execution_venue": "alpaca_paper",
+        "execution_asset_class": "crypto",
+        "instrument_type": "crypto",
+        "side": side,
+        "order_type": "limit",
+        "time_in_force": "gtc",
+        "requested_qty": "0.001",
+        "requested_notional": None,
+        "requested_price": "50000",
+        "currency": "USD",
+        "broker_order_id": None,
+        "submitted_at": None,
+        "order_status": None,
+        "filled_qty": None,
+        "filled_avg_price": None,
+        "fee_amount": None,
+        "fee_currency": None,
+        "qty_delta": None,
+        "position_snapshot": None,
+        "reconcile_status": None,
+        "reconciled_at": None,
+        "settlement_status": None,
+        "settlement_at": None,
+        "notes": None,
+        "error_summary": None,
+        "preview_payload": None,
+        "validation_summary": None,
+        "briefing_artifact_run_uuid": _BRIEFING_UUID,
+        "briefing_artifact_status": "ready",
+        "qa_evaluator_status": "passed",
+        "approval_bridge_generated_at": _ts(-60),
+        "approval_bridge_status": "available",
+        "candidate_uuid": _CANDIDATE_UUID,
+        "workflow_stage": "crypto_weekend",
+        "purpose": "paper_roundtrip_audit",
+        "created_at": created_at or _T0,
+        "updated_at": created_at or _T0,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _complete_roundtrip_rows(
+    correlation_id: str = "corr-rob92",
+) -> list[SimpleNamespace]:
+    return [
+        _row(
+            lifecycle_state=LIFECYCLE_PLANNED,
+            record_kind=RECORD_KIND_PLAN,
+            side="buy",
+            client_order_id="buy-rob92",
+            lifecycle_correlation_id=correlation_id,
+            created_at=_ts(0),
+        ),
+        _row(
+            lifecycle_state=LIFECYCLE_PREVIEWED,
+            record_kind=RECORD_KIND_PREVIEW,
+            side="buy",
+            client_order_id="buy-rob92",
+            lifecycle_correlation_id=correlation_id,
+            preview_payload={"symbol": "BTCUSD", "side": "buy"},
+            created_at=_ts(1),
+        ),
+        _row(
+            lifecycle_state=LIFECYCLE_VALIDATED,
+            record_kind=RECORD_KIND_VALIDATION_ATTEMPT,
+            side="buy",
+            client_order_id="buy-rob92",
+            lifecycle_correlation_id=correlation_id,
+            validation_summary={"ok": True},
+            created_at=_ts(2),
+        ),
+        _row(
+            lifecycle_state=LIFECYCLE_SUBMITTED,
+            record_kind=RECORD_KIND_EXECUTION,
+            side="buy",
+            client_order_id="buy-rob92",
+            lifecycle_correlation_id=correlation_id,
+            broker_order_id="broker-buy",
+            submitted_at=_ts(3),
+            order_status="accepted",
+            created_at=_ts(3),
+        ),
+        _row(
+            lifecycle_state=LIFECYCLE_FILLED,
+            record_kind=RECORD_KIND_EXECUTION,
+            side="buy",
+            client_order_id="buy-rob92",
+            lifecycle_correlation_id=correlation_id,
+            filled_qty="0.001",
+            filled_avg_price="50000",
+            qty_delta="0.001",
+            order_status="filled",
+            created_at=_ts(4),
+        ),
+        _row(
+            lifecycle_state=LIFECYCLE_POSITION_RECONCILED,
+            record_kind=RECORD_KIND_EXECUTION,
+            side="buy",
+            client_order_id="buy-rob92",
+            lifecycle_correlation_id=correlation_id,
+            reconcile_status="matched",
+            position_snapshot={"symbol": "BTCUSD", "qty": "0.001"},
+            created_at=_ts(5),
+        ),
+        _row(
+            lifecycle_state=LIFECYCLE_SELL_VALIDATED,
+            record_kind=RECORD_KIND_VALIDATION_ATTEMPT,
+            side="sell",
+            client_order_id="sell-rob92",
+            lifecycle_correlation_id=correlation_id,
+            validation_summary={"ok": True, "side": "sell"},
+            created_at=_ts(6),
+        ),
+        _row(
+            lifecycle_state=LIFECYCLE_CLOSED,
+            record_kind=RECORD_KIND_EXECUTION,
+            side="sell",
+            client_order_id="sell-rob92",
+            lifecycle_correlation_id=correlation_id,
+            broker_order_id="broker-sell",
+            filled_qty="0.001",
+            filled_avg_price="51000",
+            qty_delta="-0.001",
+            order_status="filled",
+            created_at=_ts(7),
+        ),
+        _row(
+            lifecycle_state=LIFECYCLE_FINAL_RECONCILED,
+            record_kind=RECORD_KIND_RECONCILE,
+            side="sell",
+            client_order_id="sell-rob92",
+            lifecycle_correlation_id=correlation_id,
+            reconcile_status="flat",
+            settlement_status="n_a",
+            position_snapshot={"symbol": "BTCUSD", "qty": "0"},
+            created_at=_ts(8),
+        ),
+    ]
+
+
+def _service_with_rows(
+    rows: list[SimpleNamespace],
+) -> tuple[AlpacaPaperRoundtripReportService, AsyncMock]:
+    db = AsyncMock()
+    svc = AlpacaPaperRoundtripReportService(db)
+    ledger = SimpleNamespace(
+        list_by_correlation_id=AsyncMock(return_value=rows),
+        get_by_client_order_id=AsyncMock(return_value=rows[0] if rows else None),
+        list_by_candidate_uuid=AsyncMock(return_value=rows),
+        list_by_briefing_artifact_run_uuid=AsyncMock(return_value=rows),
+    )
+    svc._ledger = ledger  # noqa: SLF001 - isolate the read assembler from SQL in unit tests
+    return svc, db
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_build_report_by_correlation_returns_complete_read_only_report():
+    rows = _complete_roundtrip_rows()
+    svc, db = _service_with_rows(rows)
+
+    report = await svc.build_report(
+        lifecycle_correlation_id="corr-rob92",
+        include_ledger_rows=False,
+        now=_ts(30),
+    )
+
+    assert report.status == "complete"
+    assert report.lifecycle_correlation_id == "corr-rob92"
+    assert report.completeness.is_complete is True
+    assert report.candidate.candidate_uuid == str(_CANDIDATE_UUID)
+    assert report.qa_result.briefing_artifact_run_uuid == str(_BRIEFING_UUID)
+    assert report.approval_packet.preview_payload == {"symbol": "BTCUSD", "side": "buy"}
+    assert report.buy_leg is not None
+    assert report.buy_leg.fill.filled_qty == Decimal("0.001")
+    assert report.sell_leg is not None
+    assert report.sell_leg.fill.filled_avg_price == Decimal("51000")
+    assert report.final_position.source == "ledger_snapshot"
+    assert report.final_position.qty == Decimal("0")
+    assert report.open_orders.source == "missing"
+    assert report.anomalies.should_block is False
+    assert report.safety.read_only is True
+    assert report.safety.broker_mutation_performed is False
+    assert report.ledger_rows is None
+    db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_build_report_by_client_order_id_expands_to_correlation_rows():
+    rows = _complete_roundtrip_rows()
+    svc, _db = _service_with_rows(rows)
+
+    report = await svc.build_report(
+        client_order_id="buy-rob92", include_ledger_rows=False
+    )
+
+    assert report.status == "complete"
+    svc._ledger.get_by_client_order_id.assert_awaited_once_with("buy-rob92")  # noqa: SLF001
+    svc._ledger.list_by_correlation_id.assert_awaited_once_with("corr-rob92")  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_build_report_not_found_has_safe_empty_shape():
+    svc, db = _service_with_rows([])
+
+    report = await svc.build_report(
+        lifecycle_correlation_id="missing-corr",
+        include_ledger_rows=False,
+        now=_ts(30),
+    )
+
+    assert report.status == "not_found"
+    assert report.completeness.is_complete is False
+    assert report.buy_leg is None
+    assert report.sell_leg is None
+    assert report.safety.read_only is True
+    db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_candidate_lookup_returns_grouped_list_response():
+    rows = _complete_roundtrip_rows("corr-a") + _complete_roundtrip_rows("corr-b")
+    svc, _db = _service_with_rows(rows)
+
+    response = await svc.build_reports_for_candidate_uuid(
+        _CANDIDATE_UUID,
+        include_ledger_rows=False,
+    )
+
+    assert response.lookup_key.kind == "candidate_uuid"
+    assert response.count == 2
+    assert [item.lifecycle_correlation_id for item in response.items] == [
+        "corr-a",
+        "corr-b",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_open_order_snapshot_is_caller_supplied_and_can_block_report():
+    rows = _complete_roundtrip_rows()
+    svc, _db = _service_with_rows(rows)
+
+    report = await svc.build_report(
+        lifecycle_correlation_id="corr-rob92",
+        open_orders=[{"id": "open-1", "status": "new", "symbol": "BTCUSD"}],
+        include_ledger_rows=False,
+        now=_ts(30),
+    )
+
+    assert report.status == "anomaly"
+    assert report.open_orders.source == "caller_supplied"
+    assert report.anomalies.should_block is True
+    assert report.anomalies.anomalies[0]["check_id"] == "unexpected_open_orders"


### PR DESCRIPTION
## Summary
- Adds a read-only Alpaca Paper roundtrip audit report service, schemas, API route, and MCP read-only tool integration.
- Extends ledger helpers/docs and readonly smoke coverage for report and lifecycle completeness checks.
- Adds regression coverage for incomplete lifecycle reports, include_ledger_rows behavior, and no DB mutation.

## Validation
- `uv run pytest tests/services/test_alpaca_paper_roundtrip_report_service.py -q` => 6 passed
- `uv run pytest tests/services/test_alpaca_paper_roundtrip_report_service.py tests/routers/test_alpaca_paper_ledger_router.py tests/mcp_server/test_alpaca_paper_ledger_read_tools.py tests/services/test_alpaca_paper_ledger_service.py -q` => 117 passed
- Reviewer rerun additionally reported 106 passed on ledger/report route+MCP lane and 312 passed on `-k "alpaca_paper or roundtrip_report"`
- `make lint` => passed
- Claude Code Opus review rerun => PASS/no blocking findings

## Safety / Non-actions
- Read-only report only: no broker submit/cancel/replace/modify, no KIS/Upbit mutation, no live trading.
- No direct DB update/delete/backfill or repair mutation.
- No scheduler/deploy side effects in this PR step.
- No credentials, tokens, connection strings, Authorization headers, or account secrets included.

Closes ROB-92


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Alpaca Paper roundtrip audit report API endpoints with multiple lookup options (correlation ID, client order ID, candidate UUID, briefing artifact run UUID).
  * New read-only MCP tool for assembling and retrieving roundtrip audit reports.

* **Documentation**
  * Added comprehensive runbook for the roundtrip audit report feature.
  * Updated ledger documentation with new API endpoints and MCP tool details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->