### PR TITLE
fix(ROB-93): accept reconciled Alpaca paper filled states

### DIFF
--- a/app/services/alpaca_paper_anomaly_checks.py
+++ b/app/services/alpaca_paper_anomaly_checks.py
@@ -65,7 +65,11 @@ class PaperExecutionPreflightReport:
 
 
 _OPEN_LEDGER_STATES = frozenset({"submitted", "open", "partially_filled"})
+_CANONICAL_FILLED_LEDGER_STATES = frozenset(
+    {"filled", "position_reconciled", "closed", "final_reconciled"}
+)
 _FILLED_STATES = frozenset({"filled", "partially_filled"})
+_BUY_REQUIRES_LINKED_SELL_STATES = _FILLED_STATES | _CANONICAL_FILLED_LEDGER_STATES
 _TERMINAL_STATES = frozenset({"filled", "canceled"})
 _SELL_SOURCE_KEYS = frozenset(
     {
@@ -320,7 +324,7 @@ def build_paper_execution_preflight_report(
         client_id = str(_get(row, "client_order_id") or "").strip()
         if (
             side == "buy"
-            and state in _FILLED_STATES
+            and state in _BUY_REQUIRES_LINKED_SELL_STATES
             and client_id not in sell_source_ids
         ):
             filled_buys_missing_sell.append(row)
@@ -360,7 +364,11 @@ def build_paper_execution_preflight_report(
             mismatches.append(
                 {"reason": "filled_state_without_filled_qty", **_row_ref(row)}
             )
-        if order_status == "filled" and state != "filled":
+        if (
+            order_status == "filled"
+            and state
+            and state not in _CANONICAL_FILLED_LEDGER_STATES
+        ):
             mismatches.append(
                 {"reason": "order_status_filled_state_mismatch", **_row_ref(row)}
             )

--- a/tests/services/test_alpaca_paper_anomaly_checks.py
+++ b/tests/services/test_alpaca_paper_anomaly_checks.py
@@ -130,6 +130,49 @@ def test_linked_sell_prevents_missing_sell_anomaly():
 
 
 @pytest.mark.unit
+def test_canonical_completed_roundtrip_states_do_not_block():
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(
+                client_order_id="buy-reconciled",
+                lifecycle_state="position_reconciled",
+                order_status="filled",
+            ),
+            _row(
+                client_order_id="sell-final-reconciled",
+                side="sell",
+                lifecycle_state="final_reconciled",
+                order_status="filled",
+                raw_responses={"payload": {"source_client_order_id": "buy-reconciled"}},
+            ),
+        ],
+        open_orders=[],
+        positions=[],
+    )
+
+    assert report.status == "pass"
+    assert report.should_block is False
+    assert [a.check_id for a in report.anomalies] == ["preflight_clean"]
+
+
+@pytest.mark.unit
+def test_reconciled_buy_without_linked_sell_blocks_as_missing_sell():
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(
+                client_order_id="buy-reconciled-without-sell",
+                lifecycle_state="position_reconciled",
+                order_status="filled",
+            )
+        ]
+    )
+
+    assert report.should_block is True
+    assert "previous_buy_filled_sell_missing" in _check_ids(report)
+    assert "ledger_order_fill_mismatch" not in _check_ids(report)
+
+
+@pytest.mark.unit
 def test_filled_sell_with_nonzero_final_position_blocks():
     report = build_paper_execution_preflight_report(
         ledger_rows=[


### PR DESCRIPTION
## Summary
- Accept canonical Alpaca Paper post-fill ledger states (`position_reconciled`, `closed`, `final_reconciled`) when broker `order_status` remains `filled`.
- Treat reconciled buys without a linked sell as `previous_buy_filled_sell_missing` rather than `ledger_order_fill_mismatch`.
- Add regression coverage for completed buy/sell roundtrips and reconciled buy-without-sell anomalies.

## Verification
- `uv run pytest tests/services/test_alpaca_paper_anomaly_checks.py tests/mcp_server/test_alpaca_paper_ledger_read_tools.py tests/test_alpaca_paper_smoke_safety.py -q` — 36 passed, 2 existing Pydantic deprecation warnings.
- `uv run ruff check app/services/alpaca_paper_anomaly_checks.py tests/services/test_alpaca_paper_anomaly_checks.py` — passed.
- `uv run ruff format --check app/services/alpaca_paper_anomaly_checks.py tests/services/test_alpaca_paper_anomaly_checks.py` — passed.
- Diff safety grep for broker/order/DB/secret mutation strings — no matches.

## Safety / non-actions
- Read-only anomaly-check logic only.
- No broker/order submission, cancellation, modification, generic broker route, live trading, repair write, production DB update/delete/backfill, scheduler change, or credential/secret output.

Linear: ROB-93
