### PR TITLE
feat: map new US news sources into briefings

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -29,9 +29,10 @@ MCP tools (market data, portfolio, order execution) exposed via `fastmcp`.
 - `get_market_news(market=None, hours=24, feed_source=None, source=None, keyword=None, limit=20, briefing_filter=False)`
   - Fetch recent market news for OpenClaw pre-market briefing
   - `market`: Optional market scope (`kr`, `us`, `crypto`) for market-separated briefing inputs
-  - `feed_source`: Collection path key (e.g., `browser_naver_mainnews`, `browser_naver_research`, `rss_cointelegraph`)
-  - `source`: Publisher label (e.g., `연합뉴스`, `매일경제`, `Cointelegraph`)
+  - `feed_source`: Collection path key (e.g., `browser_naver_mainnews`, `browser_naver_research`, `rss_cointelegraph`, `rss_cnbc_earnings`, `rss_cnbc_finance`)
+  - `source`: Publisher label (e.g., `연합뉴스`, `매일경제`, `CNBC`, `Cointelegraph`)
   - `briefing_filter`: Format market-specific briefing sections for `kr`/`us`, and rank crypto-relevant articles while separating broad-tech/AI noise into `excluded_news`; raw storage is not affected
+  - US briefing sections include `macro_fed`, `finance_credit_rates`, `big_tech`, `earnings`, `market_sentiment`, and `watchlist_analyst`; `rss_cnbc_earnings` is source-hinted into `earnings`, `rss_cnbc_finance` into `finance_credit_rates`, while `http_finviz_news` and `rss_investing_stock_market_news` remain experimental and are only boosted when already market-relevant
   - Returns: `count`, `total`, `news` (list), `sources` (unique publishers), `feed_sources` (unique collection paths), `briefing_filter`, `briefing_summary`, `briefing_sections`, `excluded_news`
   - Each article includes `stock_symbol` and `stock_name` for holdings impact analysis; formatted articles include `briefing_relevance`; crypto articles also include `crypto_relevance` metadata
 

--- a/app/services/market_news_briefing_formatter.py
+++ b/app/services/market_news_briefing_formatter.py
@@ -94,6 +94,31 @@ _US_RULES: tuple[_SectionRule, ...] = (
         ),
     ),
     _SectionRule(
+        "finance_credit_rates",
+        "Finance / Credit / Rates",
+        (
+            "finance",
+            "financial",
+            "credit",
+            "credit market",
+            "credit markets",
+            "bank",
+            "banks",
+            "banking",
+            "lending",
+            "loan",
+            "loans",
+            "debt",
+            "bond",
+            "bonds",
+            "liquidity",
+            "default",
+            "spreads",
+            "regional bank",
+            "commercial real estate",
+        ),
+    ),
+    _SectionRule(
         "big_tech",
         "Big Tech / AI / Semis",
         (
@@ -253,6 +278,14 @@ _US_HIGH_SIGNAL_TERMS = (
     "upgrade",
     "downgrade",
 )
+_US_FEED_SOURCE_SECTION_HINTS = {
+    "rss_cnbc_earnings": ("earnings", "Earnings / Guidance", 64),
+    "rss_cnbc_finance": ("finance_credit_rates", "Finance / Credit / Rates", 60),
+}
+_US_EXPERIMENTAL_FEED_SOURCES = {
+    "http_finviz_news",
+    "rss_investing_stock_market_news",
+}
 
 
 def _field(article: Any, name: str) -> Any:
@@ -326,6 +359,45 @@ def _score_rule(article: Any, rules: tuple[_SectionRule, ...]) -> BriefingReleva
     )
 
 
+def _apply_us_feed_source_hints(
+    article: Any,
+    relevance: BriefingRelevance,
+) -> BriefingRelevance:
+    feed_source = str(_field(article, "feed_source") or "")
+    source_hint = f"feed_source:{feed_source}" if feed_source else ""
+
+    if feed_source in _US_FEED_SOURCE_SECTION_HINTS:
+        section_id, section_title, minimum_score = _US_FEED_SOURCE_SECTION_HINTS[
+            feed_source
+        ]
+        matched_terms = list(relevance.matched_terms)
+        if source_hint:
+            matched_terms.append(source_hint)
+        return BriefingRelevance(
+            score=max(relevance.score, minimum_score),
+            section_id=section_id,
+            section_title=section_title,
+            include_in_briefing=True,
+            matched_terms=sorted(set(matched_terms)),
+            reason=None,
+        )
+
+    if feed_source in _US_EXPERIMENTAL_FEED_SOURCES and relevance.include_in_briefing:
+        matched_terms = list(relevance.matched_terms)
+        if source_hint:
+            matched_terms.append(source_hint)
+        return BriefingRelevance(
+            score=min(100, relevance.score + 4),
+            section_id=relevance.section_id,
+            section_title=relevance.section_title,
+            include_in_briefing=relevance.include_in_briefing,
+            matched_terms=sorted(set(matched_terms)),
+            reason=relevance.reason,
+        )
+
+    return relevance
+
+
 def _score_crypto(article: Any) -> BriefingRelevance:
     crypto = score_crypto_news_article(article)
     section_id = _CRYPTO_CATEGORY_TO_SECTION.get(crypto.category or "")
@@ -361,7 +433,10 @@ def _score_article(article: Any, market: str) -> BriefingRelevance:
         return _score_crypto(article)
     if market == "us" and _low_signal_us_noise_hit(article):
         return _low_market_relevance()
-    return _score_rule(article, _rules_for_market(market))
+    relevance = _score_rule(article, _rules_for_market(market))
+    if market == "us":
+        return _apply_us_feed_source_hints(article, relevance)
+    return relevance
 
 
 def format_market_news_briefing(

--- a/tests/test_market_news_briefing_formatter.py
+++ b/tests/test_market_news_briefing_formatter.py
@@ -106,6 +106,68 @@ def test_format_us_news_excludes_personal_finance_and_lifestyle_rate_noise():
 
 
 @pytest.mark.unit
+def test_format_us_news_maps_new_cnbc_core_sources_to_briefing_sections():
+    from app.services.market_news_briefing_formatter import format_market_news_briefing
+
+    earnings_feed = _article(
+        "Three companies to watch before the bell",
+        market="us",
+        feed_source="rss_cnbc_earnings",
+    )
+    finance_feed = _article(
+        "Regional bank credit spreads widen as loan losses rise",
+        market="us",
+        feed_source="rss_cnbc_finance",
+    )
+
+    briefing = format_market_news_briefing(
+        [finance_feed, earnings_feed], market="us", limit=10
+    )
+
+    section_ids = [section.section_id for section in briefing.sections]
+    assert section_ids == ["finance_credit_rates", "earnings"]
+    earnings_item = briefing.sections[1].items[0]
+    assert earnings_item.article.title == earnings_feed.title
+    assert "feed_source:rss_cnbc_earnings" in earnings_item.relevance.matched_terms
+    finance_item = briefing.sections[0].items[0]
+    assert finance_item.article.title == finance_feed.title
+    assert "feed_source:rss_cnbc_finance" in finance_item.relevance.matched_terms
+
+
+@pytest.mark.unit
+def test_format_us_news_does_not_force_experimental_sources_into_briefing():
+    from app.services.market_news_briefing_formatter import format_market_news_briefing
+
+    uncategorized_finviz = _article(
+        "Company board announces routine annual meeting",
+        market="us",
+        feed_source="http_finviz_news",
+    )
+    market_relevant_investing = _article(
+        "Analyst upgrade sends chip stocks higher before Nasdaq open",
+        market="us",
+        feed_source="rss_investing_stock_market_news",
+        stock_symbol="NVDA",
+    )
+
+    briefing = format_market_news_briefing(
+        [uncategorized_finviz, market_relevant_investing], market="us", limit=10
+    )
+
+    assert briefing.summary["included"] == 1
+    assert briefing.sections[0].section_id == "big_tech"
+    assert (
+        briefing.sections[0].items[0].article.title == market_relevant_investing.title
+    )
+    assert (
+        "feed_source:rss_investing_stock_market_news"
+        in briefing.sections[0].items[0].relevance.matched_terms
+    )
+    assert briefing.excluded[0].article.title == uncategorized_finviz.title
+    assert briefing.excluded[0].relevance.reason == "uncategorized_market_news"
+
+
+@pytest.mark.unit
 def test_format_kr_news_groups_preopen_sector_disclosure_and_flow():
     from app.services.market_news_briefing_formatter import format_market_news_briefing
 


### PR DESCRIPTION
## Summary
- Add a US `finance_credit_rates` briefing section for finance/credit/rates market news.
- Source-hint new `news-ingestor` core CNBC feeds:
  - `rss_cnbc_earnings` -> `earnings`
  - `rss_cnbc_finance` -> `finance_credit_rates`
- Keep `http_finviz_news` and `rss_investing_stock_market_news` experimental: they receive a small relevance boost only when already market-relevant, but are not forced into the briefing.
- Update MCP news tool docs with the new source/section mapping.

## Safety / Scope
- Read-layer formatter/MCP documentation only.
- No DB schema, scheduler, ingestion, broker/order, paper/live trading, or deployment changes.
- Raw news storage remains unchanged.

## Test Plan
- `uv run pytest tests/test_market_news_briefing_formatter.py tests/test_mcp_news_crypto_relevance.py tests/test_crypto_news_relevance_service.py -q`
- `uv run pytest tests/test_news_ingestor_bulk.py tests/test_news_readiness_contract.py tests/test_router_preopen_news_brief.py tests/services/test_kr_preopen_news_brief_service.py tests/test_market_news_briefing_formatter.py tests/test_mcp_news_crypto_relevance.py tests/test_crypto_news_relevance_service.py -q`
- `uv run ruff check app/services/market_news_briefing_formatter.py app/mcp_server/tooling/news_handlers.py tests/test_market_news_briefing_formatter.py tests/test_mcp_news_crypto_relevance.py tests/test_crypto_news_relevance_service.py`
- `uv run ruff format --check app/services/market_news_briefing_formatter.py app/mcp_server/tooling/news_handlers.py tests/test_market_news_briefing_formatter.py`
