### PR TITLE
fix(ROB-95): address KIS mock pilot review feedback

### DIFF
--- a/app/services/kis_mock_market_open_pilot.py
+++ b/app/services/kis_mock_market_open_pilot.py
@@ -7,7 +7,7 @@ broker, MCP, KIS client, DB, cache, network, or scheduler modules.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Any, Literal
@@ -158,10 +158,10 @@ def classify_kis_mock_market_open_report(
     return "accepted_but_fill_unknown"
 
 
-def run_kis_mock_market_open_pilot(
+async def run_kis_mock_market_open_pilot(
     request: KisMockMarketOpenPilotRequest,
     *,
-    kis_mock_place_order: Callable[..., Mapping[str, Any]],
+    kis_mock_place_order: Callable[..., Awaitable[Mapping[str, Any]]],
     is_regular_session: Callable[[], bool],
     readiness_probe: Callable[[], Mapping[str, Any]] | None = None,
 ) -> KisMockMarketOpenPilotResult:
@@ -191,7 +191,7 @@ def run_kis_mock_market_open_pilot(
 
     if request.mode == "dry-run":
         response = dict(
-            kis_mock_place_order(
+            await kis_mock_place_order(
                 symbol=request.symbol,
                 side=request.side,
                 order_type=request.order_type,
@@ -245,7 +245,7 @@ def run_kis_mock_market_open_pilot(
         )
 
     response = dict(
-        kis_mock_place_order(
+        await kis_mock_place_order(
             symbol=request.symbol,
             side=request.side,
             order_type=request.order_type,

--- a/app/services/kis_mock_market_open_pilot.py
+++ b/app/services/kis_mock_market_open_pilot.py
@@ -66,10 +66,6 @@ def _is_positive_integer_decimal(value: Decimal) -> bool:
     return value > 0 and value == value.to_integral_value()
 
 
-def _normalized_text(value: str | None) -> str:
-    return " ".join((value or "").split())
-
-
 def _side_ko(side: str) -> str:
     return "매도" if side == "sell" else "매수"
 
@@ -232,7 +228,7 @@ def run_kis_mock_market_open_pilot(
         quantity=request.quantity,
         price=request.price,
     )
-    if _normalized_text(request.approval_text) != _normalized_text(expected_approval):
+    if request.approval_text != expected_approval:
         return _blocked_result(
             request,
             reasons=["approval_text_mismatch"],

--- a/app/services/kis_mock_market_open_pilot.py
+++ b/app/services/kis_mock_market_open_pilot.py
@@ -1,0 +1,281 @@
+"""Operator-gated KIS mock market-open pilot helper (ROB-95).
+
+This module is intentionally dependency-injected and side-effect-free unless the
+caller supplies the typed ``kis_mock_place_order`` callable. It must not import
+broker, MCP, KIS client, DB, cache, network, or scheduler modules.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any, Literal
+
+PilotMode = Literal["readiness", "dry-run", "submit-mock"]
+PilotStatus = Literal["ready", "submitted", "blocked"]
+PilotSide = Literal["buy", "sell"]
+ReportStatus = Literal["accepted_but_fill_unknown", "filled_inferred", "rejected"]
+
+_ALLOWED_TOOL_NAME = "kis_mock_place_order"
+_ALLOWED_ACCOUNT_MODE = "kis_mock"
+_ALLOWED_ORDER_TYPE = "limit"
+
+
+@dataclass(frozen=True)
+class KisMockMarketOpenPilotRequest:
+    """Narrow request contract for the ROB-95 KIS mock market-open pilot."""
+
+    mode: PilotMode
+    symbol: str
+    side: str
+    quantity: int
+    price: Decimal
+    approval_text: str | None = None
+    account_mode: str = _ALLOWED_ACCOUNT_MODE
+    order_type: str = _ALLOWED_ORDER_TYPE
+    tool_name: str = _ALLOWED_TOOL_NAME
+
+
+@dataclass(frozen=True)
+class KisMockMarketOpenPilotResult:
+    """Deterministic result from a pilot readiness/dry-run/submit attempt."""
+
+    status: PilotStatus
+    mode: PilotMode
+    symbol: str
+    side: str
+    quantity: int
+    price: int | None
+    tool_name: str
+    account_mode: str
+    dry_run: bool | None
+    safety_checks: dict[str, bool] = field(default_factory=dict)
+    blocking_reasons: list[str] = field(default_factory=list)
+    readiness: dict[str, Any] = field(default_factory=dict)
+    response: dict[str, Any] | None = None
+    expected_approval_text: str | None = None
+    report_status: ReportStatus | None = None
+
+
+def _is_kr_equity_symbol(symbol: str) -> bool:
+    return len(symbol) == 6 and symbol.isdigit()
+
+
+def _is_positive_integer_decimal(value: Decimal) -> bool:
+    return value > 0 and value == value.to_integral_value()
+
+
+def _normalized_text(value: str | None) -> str:
+    return " ".join((value or "").split())
+
+
+def _side_ko(side: str) -> str:
+    return "매도" if side == "sell" else "매수"
+
+
+def _approval_suffix(side: str) -> str:
+    return "청산 승인" if side == "sell" else "제출 승인"
+
+
+def expected_kis_mock_submit_approval_text(
+    *, symbol: str, side: str, quantity: int, price: Decimal
+) -> str:
+    """Return the exact operator approval text required for mock submit."""
+    price_int = int(price)
+    return (
+        f"ROB-95 KIS mock 승인: {symbol} {_side_ko(side)} {quantity}주 "
+        f"지정가 {price_int}원 account_mode=kis_mock dry_run=False "
+        f"정규장 모의투자 {_approval_suffix(side)}"
+    )
+
+
+def _base_safety_checks(request: KisMockMarketOpenPilotRequest) -> dict[str, bool]:
+    return {
+        "typed_kis_mock_route_only": request.tool_name == _ALLOWED_TOOL_NAME,
+        "no_generic_place_order": request.tool_name != "place_order",
+        "no_kis_live_route": not request.tool_name.startswith("kis_live"),
+        "kis_mock_account_mode": request.account_mode == _ALLOWED_ACCOUNT_MODE,
+        "limit_order_only": request.order_type == _ALLOWED_ORDER_TYPE,
+        "kr_equity_symbol": _is_kr_equity_symbol(request.symbol),
+        "supported_side": request.side in {"buy", "sell"},
+        "positive_integer_quantity": isinstance(request.quantity, int)
+        and request.quantity > 0,
+        "positive_integer_limit_price": _is_positive_integer_decimal(request.price),
+    }
+
+
+def _blocking_reasons(request: KisMockMarketOpenPilotRequest) -> list[str]:
+    reasons: list[str] = []
+    if request.tool_name != _ALLOWED_TOOL_NAME:
+        reasons.append("invalid_tool_name")
+    if request.account_mode != _ALLOWED_ACCOUNT_MODE:
+        reasons.append("invalid_account_mode")
+    if request.order_type != _ALLOWED_ORDER_TYPE:
+        reasons.append("invalid_order_type")
+    if not _is_kr_equity_symbol(request.symbol):
+        reasons.append("unsupported_kr_equity_symbol")
+    if request.side not in {"buy", "sell"}:
+        reasons.append("unsupported_side")
+    if not isinstance(request.quantity, int) or request.quantity <= 0:
+        reasons.append("invalid_quantity")
+    if not _is_positive_integer_decimal(request.price):
+        reasons.append("invalid_limit_price")
+    return reasons
+
+
+def _blocked_result(
+    request: KisMockMarketOpenPilotRequest,
+    *,
+    reasons: list[str],
+    expected_approval_text: str | None = None,
+) -> KisMockMarketOpenPilotResult:
+    price = int(request.price) if _is_positive_integer_decimal(request.price) else None
+    return KisMockMarketOpenPilotResult(
+        status="blocked",
+        mode=request.mode,
+        symbol=request.symbol,
+        side=request.side,
+        quantity=request.quantity,
+        price=price,
+        tool_name=request.tool_name,
+        account_mode=request.account_mode,
+        dry_run=None,
+        safety_checks=_base_safety_checks(request),
+        blocking_reasons=reasons,
+        expected_approval_text=expected_approval_text,
+    )
+
+
+def classify_kis_mock_market_open_report(
+    *,
+    response: Mapping[str, Any],
+    holdings_delta_qty: int | Decimal | None = None,
+    cash_delta_krw: int | Decimal | None = None,
+    order_history_supported: bool = False,
+) -> ReportStatus:
+    """Classify KIS mock order evidence without confusing acceptance with fill."""
+    if response.get("ok") is False or response.get("error"):
+        return "rejected"
+
+    has_holding_delta = holdings_delta_qty not in {None, 0, Decimal("0")}
+    has_cash_delta = cash_delta_krw not in {None, 0, Decimal("0")}
+    if order_history_supported and has_holding_delta and has_cash_delta:
+        return "filled_inferred"
+    return "accepted_but_fill_unknown"
+
+
+def run_kis_mock_market_open_pilot(
+    request: KisMockMarketOpenPilotRequest,
+    *,
+    kis_mock_place_order: Callable[..., Mapping[str, Any]],
+    is_regular_session: Callable[[], bool],
+    readiness_probe: Callable[[], Mapping[str, Any]] | None = None,
+) -> KisMockMarketOpenPilotResult:
+    """Run a guarded ROB-95 pilot mode through the injected typed mock route."""
+    shape_reasons = _blocking_reasons(request)
+    if shape_reasons:
+        return _blocked_result(request, reasons=shape_reasons)
+
+    safety_checks = _base_safety_checks(request)
+    price = int(request.price)
+
+    if request.mode == "readiness":
+        readiness = dict(readiness_probe() if readiness_probe else {})
+        return KisMockMarketOpenPilotResult(
+            status="ready",
+            mode=request.mode,
+            symbol=request.symbol,
+            side=request.side,
+            quantity=request.quantity,
+            price=price,
+            tool_name=request.tool_name,
+            account_mode=request.account_mode,
+            dry_run=None,
+            safety_checks=safety_checks,
+            readiness=readiness,
+        )
+
+    if request.mode == "dry-run":
+        response = dict(
+            kis_mock_place_order(
+                symbol=request.symbol,
+                side=request.side,
+                order_type=request.order_type,
+                quantity=request.quantity,
+                price=price,
+                dry_run=True,
+                account_mode=request.account_mode,
+                reason="ROB-95 KIS mock market-open pilot dry-run",
+            )
+        )
+        return KisMockMarketOpenPilotResult(
+            status="submitted",
+            mode=request.mode,
+            symbol=request.symbol,
+            side=request.side,
+            quantity=request.quantity,
+            price=price,
+            tool_name=request.tool_name,
+            account_mode=request.account_mode,
+            dry_run=True,
+            safety_checks=safety_checks,
+            response=response,
+        )
+
+    if request.mode != "submit-mock":
+        return _blocked_result(request, reasons=["unsupported_mode"])
+
+    expected_approval = expected_kis_mock_submit_approval_text(
+        symbol=request.symbol,
+        side=request.side,
+        quantity=request.quantity,
+        price=request.price,
+    )
+    if _normalized_text(request.approval_text) != _normalized_text(expected_approval):
+        return _blocked_result(
+            request,
+            reasons=["approval_text_mismatch"],
+            expected_approval_text=expected_approval,
+        )
+    if not is_regular_session():
+        return _blocked_result(
+            request,
+            reasons=["regular_session_closed"],
+            expected_approval_text=expected_approval,
+        )
+    if request.quantity > 1:
+        return _blocked_result(
+            request,
+            reasons=["quantity_exceeds_default_smoke_limit"],
+            expected_approval_text=expected_approval,
+        )
+
+    response = dict(
+        kis_mock_place_order(
+            symbol=request.symbol,
+            side=request.side,
+            order_type=request.order_type,
+            quantity=request.quantity,
+            price=price,
+            dry_run=False,
+            account_mode=request.account_mode,
+            reason="ROB-95 KIS mock market-open pilot exact-approved mock submit",
+        )
+    )
+    report_status = classify_kis_mock_market_open_report(response=response)
+    return KisMockMarketOpenPilotResult(
+        status="submitted",
+        mode=request.mode,
+        symbol=request.symbol,
+        side=request.side,
+        quantity=request.quantity,
+        price=price,
+        tool_name=request.tool_name,
+        account_mode=request.account_mode,
+        dry_run=False,
+        safety_checks=safety_checks,
+        response=response,
+        expected_approval_text=expected_approval,
+        report_status=report_status,
+    )

--- a/app/services/kis_mock_market_open_pilot.py
+++ b/app/services/kis_mock_market_open_pilot.py
@@ -12,6 +12,11 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Any, Literal
 
+from app.services.preopen_approval_safety import (
+    is_kr_equity_symbol,
+    is_positive_integer_decimal,
+)
+
 PilotMode = Literal["readiness", "dry-run", "submit-mock"]
 PilotStatus = Literal["ready", "submitted", "blocked"]
 PilotSide = Literal["buy", "sell"]
@@ -58,15 +63,7 @@ class KisMockMarketOpenPilotResult:
     report_status: ReportStatus | None = None
 
 
-def _is_kr_equity_symbol(symbol: str) -> bool:
-    return len(symbol) == 6 and symbol.isdigit()
-
-
-def _is_positive_integer_decimal(value: Decimal) -> bool:
-    return value > 0 and value == value.to_integral_value()
-
-
-def _side_ko(side: str) -> str:
+def _side_ko(side: PilotSide) -> str:
     return "매도" if side == "sell" else "매수"
 
 
@@ -93,11 +90,11 @@ def _base_safety_checks(request: KisMockMarketOpenPilotRequest) -> dict[str, boo
         "no_kis_live_route": not request.tool_name.startswith("kis_live"),
         "kis_mock_account_mode": request.account_mode == _ALLOWED_ACCOUNT_MODE,
         "limit_order_only": request.order_type == _ALLOWED_ORDER_TYPE,
-        "kr_equity_symbol": _is_kr_equity_symbol(request.symbol),
+        "kr_equity_symbol": is_kr_equity_symbol(request.symbol),
         "supported_side": request.side in {"buy", "sell"},
         "positive_integer_quantity": isinstance(request.quantity, int)
         and request.quantity > 0,
-        "positive_integer_limit_price": _is_positive_integer_decimal(request.price),
+        "positive_integer_limit_price": is_positive_integer_decimal(request.price),
     }
 
 
@@ -109,13 +106,13 @@ def _blocking_reasons(request: KisMockMarketOpenPilotRequest) -> list[str]:
         reasons.append("invalid_account_mode")
     if request.order_type != _ALLOWED_ORDER_TYPE:
         reasons.append("invalid_order_type")
-    if not _is_kr_equity_symbol(request.symbol):
+    if not is_kr_equity_symbol(request.symbol):
         reasons.append("unsupported_kr_equity_symbol")
     if request.side not in {"buy", "sell"}:
         reasons.append("unsupported_side")
     if not isinstance(request.quantity, int) or request.quantity <= 0:
         reasons.append("invalid_quantity")
-    if not _is_positive_integer_decimal(request.price):
+    if not is_positive_integer_decimal(request.price):
         reasons.append("invalid_limit_price")
     return reasons
 
@@ -126,7 +123,7 @@ def _blocked_result(
     reasons: list[str],
     expected_approval_text: str | None = None,
 ) -> KisMockMarketOpenPilotResult:
-    price = int(request.price) if _is_positive_integer_decimal(request.price) else None
+    price = int(request.price) if is_positive_integer_decimal(request.price) else None
     return KisMockMarketOpenPilotResult(
         status="blocked",
         mode=request.mode,

--- a/app/services/kis_mock_preopen_approval_bridge.py
+++ b/app/services/kis_mock_preopen_approval_bridge.py
@@ -1,0 +1,279 @@
+"""Pure KIS mock preopen approval preview bridge (ROB-95).
+
+Maps already-built KR preopen transport objects into operator-facing KIS
+official mock dry-run preview metadata without touching broker, account,
+network, cache, scheduler, persistence, or approval systems.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+from app.schemas.preopen import (
+    CandidateSummary,
+    PreopenBriefingArtifact,
+    PreopenPaperApprovalBridge,
+    PreopenPaperApprovalCandidate,
+    PreopenQaEvaluatorSummary,
+)
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _unsupported_candidate(
+    candidate: CandidateSummary,
+    *,
+    reason: str,
+) -> PreopenPaperApprovalCandidate:
+    return PreopenPaperApprovalCandidate(
+        candidate_uuid=candidate.candidate_uuid,
+        symbol=candidate.symbol,
+        status="unavailable",
+        reason=reason,
+        warnings=list(candidate.warnings),
+    )
+
+
+def _qa_blocking_reasons(
+    qa_evaluator: PreopenQaEvaluatorSummary | None,
+    *,
+    has_run: bool,
+) -> list[str]:
+    if not has_run:
+        return ["no_open_preopen_run"]
+    if qa_evaluator is None:
+        return ["qa_evaluator_unavailable"]
+    if qa_evaluator.status in {"unavailable", "skipped"}:
+        return [f"qa_evaluator_{qa_evaluator.status}"]
+
+    reasons = list(qa_evaluator.blocking_reasons)
+    for check in qa_evaluator.checks:
+        if check.status == "fail" and check.severity == "high":
+            reasons.append(f"high_severity_fail:{check.id}")
+        if check.id == "actionability_guardrail" and check.status != "pass":
+            reasons.append("safety_guardrail_not_passed")
+
+    coverage = qa_evaluator.coverage or {}
+    if coverage.get("advisory_only") is not True:
+        reasons.append("advisory_only_guard_missing")
+    if coverage.get("execution_allowed") is not False:
+        reasons.append("execution_allowed_guard_missing")
+    return _dedupe(reasons)
+
+
+def _bridge_warnings(
+    qa_evaluator: PreopenQaEvaluatorSummary | None,
+    briefing_artifact: PreopenBriefingArtifact | None,
+    candidates: list[CandidateSummary],
+) -> list[str]:
+    warnings: list[str] = []
+    if qa_evaluator is not None:
+        if qa_evaluator.status == "needs_review":
+            warnings.append("qa_needs_review")
+        warnings.extend(qa_evaluator.warnings)
+    if briefing_artifact is not None:
+        if briefing_artifact.status == "degraded":
+            warnings.append("briefing_artifact_degraded")
+        warnings.extend(briefing_artifact.risk_notes)
+    for candidate in candidates:
+        warnings.extend(candidate.warnings)
+    return _dedupe(warnings)
+
+
+def _build_approval_copy(
+    symbol: str, side: str, quantity: int, price: str
+) -> list[str]:
+    return [
+        f"KIS official mock only — symbol={symbol} side={side} qty={quantity} price={price}",
+        "No KIS live order will be submitted.",
+        "Preview: dry_run=True — confirms KIS mock routing before any mock submit.",
+        "Final submit: dry_run=False requires second exact approval from operator.",
+    ]
+
+
+def _is_positive_integer_decimal(value: Decimal | None) -> bool:
+    if value is None:
+        return False
+    return value > 0 and value == value.to_integral_value()
+
+
+def _is_kr_equity_symbol(symbol: str) -> bool:
+    return len(symbol) == 6 and symbol.isdigit()
+
+
+def _bridge_market_scope(market_scope: str | None) -> str | None:
+    return market_scope if market_scope in {"kr", "us", "crypto"} else None
+
+
+def _build_kr_candidate(
+    candidate: CandidateSummary,
+    *,
+    bridge_has_warnings: bool,
+) -> PreopenPaperApprovalCandidate:
+    if candidate.instrument_type != "equity_kr":
+        return _unsupported_candidate(
+            candidate,
+            reason=f"unsupported_instrument_type:{candidate.instrument_type}",
+        )
+
+    if not _is_kr_equity_symbol(candidate.symbol):
+        return _unsupported_candidate(
+            candidate,
+            reason=f"unsupported_symbol:{candidate.symbol}",
+        )
+
+    if candidate.side not in {"buy", "sell"}:
+        return _unsupported_candidate(
+            candidate, reason=f"unsupported_side:{candidate.side}"
+        )
+
+    if candidate.side == "sell" and candidate.proposed_qty is None:
+        return PreopenPaperApprovalCandidate(
+            candidate_uuid=candidate.candidate_uuid,
+            symbol=candidate.symbol,
+            status="unavailable",
+            reason="missing_quantity",
+            warnings=list(candidate.warnings),
+        )
+
+    if candidate.proposed_price is None:
+        return _unsupported_candidate(candidate, reason="missing_price")
+    if not _is_positive_integer_decimal(candidate.proposed_price):
+        return _unsupported_candidate(candidate, reason="invalid_price")
+    if candidate.proposed_qty is not None and not _is_positive_integer_decimal(
+        candidate.proposed_qty
+    ):
+        return _unsupported_candidate(candidate, reason="invalid_quantity")
+
+    quantity = int(candidate.proposed_qty) if candidate.proposed_qty is not None else 1
+    price = str(int(candidate.proposed_price))
+
+    preview_payload = {
+        "tool": "kis_mock_place_order",
+        "symbol": candidate.symbol,
+        "side": candidate.side,
+        "order_type": "limit",
+        "quantity": quantity,
+        "price": price,
+        "account_mode": "kis_mock",
+        "execution_venue": "kis_mock",
+        "execution_asset_class": "equity_kr",
+        "dry_run": True,
+        "regular_session_only": True,
+        "requires_final_mock_submit_approval": True,
+    }
+
+    candidate_warnings = list(candidate.warnings)
+    status = "warning" if bridge_has_warnings or candidate_warnings else "available"
+
+    return PreopenPaperApprovalCandidate(
+        candidate_uuid=candidate.candidate_uuid,
+        symbol=candidate.symbol,
+        status=status,
+        reason=None,
+        warnings=candidate_warnings,
+        signal_symbol=candidate.symbol,
+        signal_venue="kr_preopen",
+        execution_symbol=candidate.symbol,
+        execution_venue="kis_mock",
+        execution_asset_class="equity_kr",
+        workflow_stage="kr_market_open_mock",
+        purpose="kis_mock_market_open_pilot",
+        preview_payload=preview_payload,
+        approval_copy=_build_approval_copy(
+            candidate.symbol, candidate.side, quantity, price
+        ),
+    )
+
+
+def build_kis_mock_preopen_approval_bridge(
+    *,
+    has_run: bool,
+    market_scope: str | None,
+    candidates: list[CandidateSummary],
+    briefing_artifact: PreopenBriefingArtifact | None,
+    qa_evaluator: PreopenQaEvaluatorSummary | None,
+    generated_at: datetime | None = None,
+) -> PreopenPaperApprovalBridge:
+    """Build deterministic KIS mock preopen approval preview metadata."""
+    blocking_reasons = _qa_blocking_reasons(qa_evaluator, has_run=has_run)
+    warnings = _bridge_warnings(qa_evaluator, briefing_artifact, candidates)
+    generated_at = generated_at or datetime.now(UTC)
+
+    if blocking_reasons:
+        return PreopenPaperApprovalBridge(
+            status="blocked",
+            generated_at=generated_at,
+            market_scope=_bridge_market_scope(market_scope),
+            stage="preopen" if has_run else None,
+            candidate_count=len(candidates),
+            candidates=[],
+            blocking_reasons=blocking_reasons,
+            warnings=warnings,
+            unsupported_reasons=[],
+        )
+
+    if market_scope != "kr":
+        reason = f"unsupported_market_scope:{market_scope or 'unknown'}"
+        return PreopenPaperApprovalBridge(
+            status="unavailable",
+            generated_at=generated_at,
+            market_scope=_bridge_market_scope(market_scope),
+            stage="preopen" if has_run else None,
+            candidate_count=len(candidates),
+            candidates=[
+                _unsupported_candidate(candidate, reason=reason)
+                for candidate in candidates
+            ],
+            warnings=warnings,
+            unsupported_reasons=[reason],
+        )
+
+    bridge_has_warnings = bool(warnings)
+    bridge_candidates: list[PreopenPaperApprovalCandidate] = []
+    unsupported_reasons: list[str] = []
+
+    for candidate in candidates:
+        bridge_candidate = _build_kr_candidate(
+            candidate,
+            bridge_has_warnings=bridge_has_warnings,
+        )
+        bridge_candidates.append(bridge_candidate)
+        if bridge_candidate.status == "unavailable" and bridge_candidate.reason:
+            unsupported_reasons.append(bridge_candidate.reason)
+
+    eligible_count = sum(
+        1 for c in bridge_candidates if c.status in {"available", "warning"}
+    )
+
+    if eligible_count == 0:
+        status = "unavailable"
+    elif bridge_has_warnings or any(c.status == "warning" for c in bridge_candidates):
+        status = "warning"
+    else:
+        status = "available"
+
+    return PreopenPaperApprovalBridge(
+        status=status,
+        generated_at=generated_at,
+        market_scope="kr",
+        stage="preopen" if has_run else None,
+        eligible_count=eligible_count,
+        candidate_count=len(candidates),
+        candidates=bridge_candidates,
+        blocking_reasons=[],
+        warnings=warnings,
+        unsupported_reasons=_dedupe(unsupported_reasons),
+    )
+
+
+__all__ = ["build_kis_mock_preopen_approval_bridge"]

--- a/app/services/kis_mock_preopen_approval_bridge.py
+++ b/app/services/kis_mock_preopen_approval_bridge.py
@@ -81,6 +81,10 @@ def _build_kr_candidate(
     quantity = int(candidate.proposed_qty) if candidate.proposed_qty is not None else 1
     price = str(int(candidate.proposed_price))
 
+    candidate_warnings = list(candidate.warnings)
+    if candidate.proposed_qty is None:
+        candidate_warnings.append("default_quantity_used:1")
+
     preview_payload = {
         "tool": "kis_mock_place_order",
         "symbol": candidate.symbol,
@@ -96,7 +100,6 @@ def _build_kr_candidate(
         "requires_final_mock_submit_approval": True,
     }
 
-    candidate_warnings = list(candidate.warnings)
     status = "warning" if bridge_has_warnings or candidate_warnings else "available"
 
     return PreopenPaperApprovalCandidate(

--- a/app/services/kis_mock_preopen_approval_bridge.py
+++ b/app/services/kis_mock_preopen_approval_bridge.py
@@ -107,6 +107,33 @@ def _bridge_market_scope(market_scope: str | None) -> str | None:
     return market_scope if market_scope in {"kr", "us", "crypto"} else None
 
 
+def _bridge_result(
+    *,
+    status: str,
+    generated_at: datetime,
+    market_scope: str | None,
+    has_run: bool,
+    candidate_count: int,
+    candidates: list[PreopenPaperApprovalCandidate],
+    warnings: list[str],
+    blocking_reasons: list[str] | None = None,
+    unsupported_reasons: list[str] | None = None,
+    eligible_count: int = 0,
+) -> PreopenPaperApprovalBridge:
+    return PreopenPaperApprovalBridge(
+        status=status,
+        generated_at=generated_at,
+        market_scope=market_scope,
+        stage="preopen" if has_run else None,
+        eligible_count=eligible_count,
+        candidate_count=candidate_count,
+        candidates=candidates,
+        blocking_reasons=blocking_reasons or [],
+        warnings=warnings,
+        unsupported_reasons=unsupported_reasons or [],
+    )
+
+
 def _build_kr_candidate(
     candidate: CandidateSummary,
     *,
@@ -130,13 +157,7 @@ def _build_kr_candidate(
         )
 
     if candidate.side == "sell" and candidate.proposed_qty is None:
-        return PreopenPaperApprovalCandidate(
-            candidate_uuid=candidate.candidate_uuid,
-            symbol=candidate.symbol,
-            status="unavailable",
-            reason="missing_quantity",
-            warnings=list(candidate.warnings),
-        )
+        return _unsupported_candidate(candidate, reason="missing_quantity")
 
     if candidate.proposed_price is None:
         return _unsupported_candidate(candidate, reason="missing_price")
@@ -203,30 +224,29 @@ def build_kis_mock_preopen_approval_bridge(
     generated_at = generated_at or datetime.now(UTC)
 
     if blocking_reasons:
-        return PreopenPaperApprovalBridge(
+        return _bridge_result(
             status="blocked",
             generated_at=generated_at,
             market_scope=_bridge_market_scope(market_scope),
-            stage="preopen" if has_run else None,
             candidate_count=len(candidates),
             candidates=[],
+            has_run=has_run,
             blocking_reasons=blocking_reasons,
             warnings=warnings,
-            unsupported_reasons=[],
         )
 
     if market_scope != "kr":
         reason = f"unsupported_market_scope:{market_scope or 'unknown'}"
-        return PreopenPaperApprovalBridge(
+        return _bridge_result(
             status="unavailable",
             generated_at=generated_at,
             market_scope=_bridge_market_scope(market_scope),
-            stage="preopen" if has_run else None,
             candidate_count=len(candidates),
             candidates=[
                 _unsupported_candidate(candidate, reason=reason)
                 for candidate in candidates
             ],
+            has_run=has_run,
             warnings=warnings,
             unsupported_reasons=[reason],
         )
@@ -255,15 +275,14 @@ def build_kis_mock_preopen_approval_bridge(
     else:
         status = "available"
 
-    return PreopenPaperApprovalBridge(
+    return _bridge_result(
         status=status,
         generated_at=generated_at,
         market_scope="kr",
-        stage="preopen" if has_run else None,
         eligible_count=eligible_count,
         candidate_count=len(candidates),
         candidates=bridge_candidates,
-        blocking_reasons=[],
+        has_run=has_run,
         warnings=warnings,
         unsupported_reasons=_dedupe(unsupported_reasons),
     )

--- a/app/services/kis_mock_preopen_approval_bridge.py
+++ b/app/services/kis_mock_preopen_approval_bridge.py
@@ -16,80 +16,17 @@ from app.schemas.preopen import (
     PreopenPaperApprovalCandidate,
     PreopenQaEvaluatorSummary,
 )
+from app.services.preopen_approval_bridge_common import (
+    bridge_result,
+    bridge_warnings,
+    dedupe,
+    qa_blocking_reasons,
+    unsupported_candidate,
+)
 from app.services.preopen_approval_safety import (
     is_kr_equity_symbol,
     is_positive_integer_decimal,
 )
-
-
-def _dedupe(values: list[str]) -> list[str]:
-    seen: set[str] = set()
-    result: list[str] = []
-    for value in values:
-        if value not in seen:
-            seen.add(value)
-            result.append(value)
-    return result
-
-
-def _unsupported_candidate(
-    candidate: CandidateSummary,
-    *,
-    reason: str,
-) -> PreopenPaperApprovalCandidate:
-    return PreopenPaperApprovalCandidate(
-        candidate_uuid=candidate.candidate_uuid,
-        symbol=candidate.symbol,
-        status="unavailable",
-        reason=reason,
-        warnings=list(candidate.warnings),
-    )
-
-
-def _qa_blocking_reasons(
-    qa_evaluator: PreopenQaEvaluatorSummary | None,
-    *,
-    has_run: bool,
-) -> list[str]:
-    if not has_run:
-        return ["no_open_preopen_run"]
-    if qa_evaluator is None:
-        return ["qa_evaluator_unavailable"]
-    if qa_evaluator.status in {"unavailable", "skipped"}:
-        return [f"qa_evaluator_{qa_evaluator.status}"]
-
-    reasons = list(qa_evaluator.blocking_reasons)
-    for check in qa_evaluator.checks:
-        if check.status == "fail" and check.severity == "high":
-            reasons.append(f"high_severity_fail:{check.id}")
-        if check.id == "actionability_guardrail" and check.status != "pass":
-            reasons.append("safety_guardrail_not_passed")
-
-    coverage = qa_evaluator.coverage or {}
-    if coverage.get("advisory_only") is not True:
-        reasons.append("advisory_only_guard_missing")
-    if coverage.get("execution_allowed") is not False:
-        reasons.append("execution_allowed_guard_missing")
-    return _dedupe(reasons)
-
-
-def _bridge_warnings(
-    qa_evaluator: PreopenQaEvaluatorSummary | None,
-    briefing_artifact: PreopenBriefingArtifact | None,
-    candidates: list[CandidateSummary],
-) -> list[str]:
-    warnings: list[str] = []
-    if qa_evaluator is not None:
-        if qa_evaluator.status == "needs_review":
-            warnings.append("qa_needs_review")
-        warnings.extend(qa_evaluator.warnings)
-    if briefing_artifact is not None:
-        if briefing_artifact.status == "degraded":
-            warnings.append("briefing_artifact_degraded")
-        warnings.extend(briefing_artifact.risk_notes)
-    for candidate in candidates:
-        warnings.extend(candidate.warnings)
-    return _dedupe(warnings)
 
 
 def _build_approval_copy(
@@ -107,66 +44,39 @@ def _bridge_market_scope(market_scope: str | None) -> str | None:
     return market_scope if market_scope in {"kr", "us", "crypto"} else None
 
 
-def _bridge_result(
-    *,
-    status: str,
-    generated_at: datetime,
-    market_scope: str | None,
-    has_run: bool,
-    candidate_count: int,
-    candidates: list[PreopenPaperApprovalCandidate],
-    warnings: list[str],
-    blocking_reasons: list[str] | None = None,
-    unsupported_reasons: list[str] | None = None,
-    eligible_count: int = 0,
-) -> PreopenPaperApprovalBridge:
-    return PreopenPaperApprovalBridge(
-        status=status,
-        generated_at=generated_at,
-        market_scope=market_scope,
-        stage="preopen" if has_run else None,
-        eligible_count=eligible_count,
-        candidate_count=candidate_count,
-        candidates=candidates,
-        blocking_reasons=blocking_reasons or [],
-        warnings=warnings,
-        unsupported_reasons=unsupported_reasons or [],
-    )
-
-
 def _build_kr_candidate(
     candidate: CandidateSummary,
     *,
     bridge_has_warnings: bool,
 ) -> PreopenPaperApprovalCandidate:
     if candidate.instrument_type != "equity_kr":
-        return _unsupported_candidate(
+        return unsupported_candidate(
             candidate,
             reason=f"unsupported_instrument_type:{candidate.instrument_type}",
         )
 
     if not is_kr_equity_symbol(candidate.symbol):
-        return _unsupported_candidate(
+        return unsupported_candidate(
             candidate,
             reason=f"unsupported_symbol:{candidate.symbol}",
         )
 
     if candidate.side not in {"buy", "sell"}:
-        return _unsupported_candidate(
+        return unsupported_candidate(
             candidate, reason=f"unsupported_side:{candidate.side}"
         )
 
     if candidate.side == "sell" and candidate.proposed_qty is None:
-        return _unsupported_candidate(candidate, reason="missing_quantity")
+        return unsupported_candidate(candidate, reason="missing_quantity")
 
     if candidate.proposed_price is None:
-        return _unsupported_candidate(candidate, reason="missing_price")
+        return unsupported_candidate(candidate, reason="missing_price")
     if not is_positive_integer_decimal(candidate.proposed_price):
-        return _unsupported_candidate(candidate, reason="invalid_price")
+        return unsupported_candidate(candidate, reason="invalid_price")
     if candidate.proposed_qty is not None and not is_positive_integer_decimal(
         candidate.proposed_qty
     ):
-        return _unsupported_candidate(candidate, reason="invalid_quantity")
+        return unsupported_candidate(candidate, reason="invalid_quantity")
 
     quantity = int(candidate.proposed_qty) if candidate.proposed_qty is not None else 1
     price = str(int(candidate.proposed_price))
@@ -219,12 +129,12 @@ def build_kis_mock_preopen_approval_bridge(
     generated_at: datetime | None = None,
 ) -> PreopenPaperApprovalBridge:
     """Build deterministic KIS mock preopen approval preview metadata."""
-    blocking_reasons = _qa_blocking_reasons(qa_evaluator, has_run=has_run)
-    warnings = _bridge_warnings(qa_evaluator, briefing_artifact, candidates)
+    blocking_reasons = qa_blocking_reasons(qa_evaluator, has_run=has_run)
+    warnings = bridge_warnings(qa_evaluator, briefing_artifact, candidates)
     generated_at = generated_at or datetime.now(UTC)
 
     if blocking_reasons:
-        return _bridge_result(
+        return bridge_result(
             status="blocked",
             generated_at=generated_at,
             market_scope=_bridge_market_scope(market_scope),
@@ -237,13 +147,13 @@ def build_kis_mock_preopen_approval_bridge(
 
     if market_scope != "kr":
         reason = f"unsupported_market_scope:{market_scope or 'unknown'}"
-        return _bridge_result(
+        return bridge_result(
             status="unavailable",
             generated_at=generated_at,
             market_scope=_bridge_market_scope(market_scope),
             candidate_count=len(candidates),
             candidates=[
-                _unsupported_candidate(candidate, reason=reason)
+                unsupported_candidate(candidate, reason=reason)
                 for candidate in candidates
             ],
             has_run=has_run,
@@ -275,7 +185,7 @@ def build_kis_mock_preopen_approval_bridge(
     else:
         status = "available"
 
-    return _bridge_result(
+    return bridge_result(
         status=status,
         generated_at=generated_at,
         market_scope="kr",
@@ -284,7 +194,7 @@ def build_kis_mock_preopen_approval_bridge(
         candidates=bridge_candidates,
         has_run=has_run,
         warnings=warnings,
-        unsupported_reasons=_dedupe(unsupported_reasons),
+        unsupported_reasons=dedupe(unsupported_reasons),
     )
 
 

--- a/app/services/kis_mock_preopen_approval_bridge.py
+++ b/app/services/kis_mock_preopen_approval_bridge.py
@@ -8,7 +8,6 @@ network, cache, scheduler, persistence, or approval systems.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from decimal import Decimal
 
 from app.schemas.preopen import (
     CandidateSummary,
@@ -16,6 +15,10 @@ from app.schemas.preopen import (
     PreopenPaperApprovalBridge,
     PreopenPaperApprovalCandidate,
     PreopenQaEvaluatorSummary,
+)
+from app.services.preopen_approval_safety import (
+    is_kr_equity_symbol,
+    is_positive_integer_decimal,
 )
 
 
@@ -100,16 +103,6 @@ def _build_approval_copy(
     ]
 
 
-def _is_positive_integer_decimal(value: Decimal | None) -> bool:
-    if value is None:
-        return False
-    return value > 0 and value == value.to_integral_value()
-
-
-def _is_kr_equity_symbol(symbol: str) -> bool:
-    return len(symbol) == 6 and symbol.isdigit()
-
-
 def _bridge_market_scope(market_scope: str | None) -> str | None:
     return market_scope if market_scope in {"kr", "us", "crypto"} else None
 
@@ -125,7 +118,7 @@ def _build_kr_candidate(
             reason=f"unsupported_instrument_type:{candidate.instrument_type}",
         )
 
-    if not _is_kr_equity_symbol(candidate.symbol):
+    if not is_kr_equity_symbol(candidate.symbol):
         return _unsupported_candidate(
             candidate,
             reason=f"unsupported_symbol:{candidate.symbol}",
@@ -147,9 +140,9 @@ def _build_kr_candidate(
 
     if candidate.proposed_price is None:
         return _unsupported_candidate(candidate, reason="missing_price")
-    if not _is_positive_integer_decimal(candidate.proposed_price):
+    if not is_positive_integer_decimal(candidate.proposed_price):
         return _unsupported_candidate(candidate, reason="invalid_price")
-    if candidate.proposed_qty is not None and not _is_positive_integer_decimal(
+    if candidate.proposed_qty is not None and not is_positive_integer_decimal(
         candidate.proposed_qty
     ):
         return _unsupported_candidate(candidate, reason="invalid_quantity")

--- a/app/services/preopen_approval_bridge_common.py
+++ b/app/services/preopen_approval_bridge_common.py
@@ -1,0 +1,120 @@
+"""Pure shared helpers for preopen approval preview bridge builders."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.schemas.preopen import (
+    CandidateSummary,
+    PreopenBriefingArtifact,
+    PreopenPaperApprovalBridge,
+    PreopenPaperApprovalCandidate,
+    PreopenQaEvaluatorSummary,
+)
+
+
+def dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def unsupported_candidate(
+    candidate: CandidateSummary,
+    *,
+    reason: str,
+) -> PreopenPaperApprovalCandidate:
+    return PreopenPaperApprovalCandidate(
+        candidate_uuid=candidate.candidate_uuid,
+        symbol=candidate.symbol,
+        status="unavailable",
+        reason=reason,
+        warnings=list(candidate.warnings),
+    )
+
+
+def qa_blocking_reasons(
+    qa_evaluator: PreopenQaEvaluatorSummary | None,
+    *,
+    has_run: bool,
+) -> list[str]:
+    if not has_run:
+        return ["no_open_preopen_run"]
+    if qa_evaluator is None:
+        return ["qa_evaluator_unavailable"]
+    if qa_evaluator.status in {"unavailable", "skipped"}:
+        return [f"qa_evaluator_{qa_evaluator.status}"]
+
+    reasons = list(qa_evaluator.blocking_reasons)
+    for check in qa_evaluator.checks:
+        if check.status == "fail" and check.severity == "high":
+            reasons.append(f"high_severity_fail:{check.id}")
+        if check.id == "actionability_guardrail" and check.status != "pass":
+            reasons.append("safety_guardrail_not_passed")
+
+    coverage = qa_evaluator.coverage or {}
+    if coverage.get("advisory_only") is not True:
+        reasons.append("advisory_only_guard_missing")
+    if coverage.get("execution_allowed") is not False:
+        reasons.append("execution_allowed_guard_missing")
+    return dedupe(reasons)
+
+
+def bridge_warnings(
+    qa_evaluator: PreopenQaEvaluatorSummary | None,
+    briefing_artifact: PreopenBriefingArtifact | None,
+    candidates: list[CandidateSummary],
+) -> list[str]:
+    warnings: list[str] = []
+    if qa_evaluator is not None:
+        if qa_evaluator.status == "needs_review":
+            warnings.append("qa_needs_review")
+        warnings.extend(qa_evaluator.warnings)
+    if briefing_artifact is not None:
+        if briefing_artifact.status == "degraded":
+            warnings.append("briefing_artifact_degraded")
+        warnings.extend(briefing_artifact.risk_notes)
+    for candidate in candidates:
+        warnings.extend(candidate.warnings)
+    return dedupe(warnings)
+
+
+def bridge_result(
+    *,
+    status: str,
+    generated_at: datetime,
+    market_scope: str | None,
+    has_run: bool,
+    candidate_count: int,
+    candidates: list[PreopenPaperApprovalCandidate],
+    warnings: list[str],
+    blocking_reasons: list[str] | None = None,
+    unsupported_reasons: list[str] | None = None,
+    eligible_count: int = 0,
+    stage: str = "preopen",
+) -> PreopenPaperApprovalBridge:
+    return PreopenPaperApprovalBridge(
+        status=status,
+        generated_at=generated_at,
+        market_scope=market_scope,  # type: ignore[arg-type]
+        stage=stage if has_run else None,  # type: ignore[arg-type]
+        eligible_count=eligible_count,
+        candidate_count=candidate_count,
+        candidates=candidates,
+        blocking_reasons=blocking_reasons or [],
+        warnings=warnings,
+        unsupported_reasons=unsupported_reasons or [],
+    )
+
+
+__all__ = [
+    "bridge_result",
+    "bridge_warnings",
+    "dedupe",
+    "qa_blocking_reasons",
+    "unsupported_candidate",
+]

--- a/app/services/preopen_approval_safety.py
+++ b/app/services/preopen_approval_safety.py
@@ -1,0 +1,20 @@
+"""Pure shared safety helpers for preopen approval pilot flows."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+
+def is_kr_equity_symbol(symbol: str) -> bool:
+    """Return true for canonical six-digit KR equity symbols."""
+    return len(symbol) == 6 and symbol.isdigit()
+
+
+def is_positive_integer_decimal(value: Decimal | None) -> bool:
+    """Return true when value is a positive whole-number Decimal."""
+    if value is None:
+        return False
+    return value > 0 and value == value.to_integral_value()
+
+
+__all__ = ["is_kr_equity_symbol", "is_positive_integer_decimal"]

--- a/app/services/preopen_paper_approval_bridge.py
+++ b/app/services/preopen_paper_approval_bridge.py
@@ -20,6 +20,13 @@ from app.services.crypto_execution_mapping import (
     CryptoExecutionMappingError,
     build_crypto_paper_approval_metadata,
 )
+from app.services.preopen_approval_bridge_common import (
+    bridge_result,
+    bridge_warnings,
+    dedupe,
+    qa_blocking_reasons,
+    unsupported_candidate,
+)
 
 _FORBIDDEN_PREVIEW_KEYS = frozenset(
     {
@@ -34,76 +41,6 @@ _FORBIDDEN_PREVIEW_KEYS = frozenset(
 )
 
 
-def _dedupe(values: list[str]) -> list[str]:
-    seen: set[str] = set()
-    result: list[str] = []
-    for value in values:
-        if value not in seen:
-            seen.add(value)
-            result.append(value)
-    return result
-
-
-def _unsupported_candidate(
-    candidate: CandidateSummary,
-    *,
-    reason: str,
-) -> PreopenPaperApprovalCandidate:
-    return PreopenPaperApprovalCandidate(
-        candidate_uuid=candidate.candidate_uuid,
-        symbol=candidate.symbol,
-        status="unavailable",
-        reason=reason,
-        warnings=list(candidate.warnings),
-    )
-
-
-def _qa_blocking_reasons(
-    qa_evaluator: PreopenQaEvaluatorSummary | None,
-    *,
-    has_run: bool,
-) -> list[str]:
-    if not has_run:
-        return ["no_open_preopen_run"]
-    if qa_evaluator is None:
-        return ["qa_evaluator_unavailable"]
-    if qa_evaluator.status in {"unavailable", "skipped"}:
-        return [f"qa_evaluator_{qa_evaluator.status}"]
-
-    reasons = list(qa_evaluator.blocking_reasons)
-    for check in qa_evaluator.checks:
-        if check.status == "fail" and check.severity == "high":
-            reasons.append(f"high_severity_fail:{check.id}")
-        if check.id == "actionability_guardrail" and check.status != "pass":
-            reasons.append("safety_guardrail_not_passed")
-
-    coverage = qa_evaluator.coverage or {}
-    if coverage.get("advisory_only") is not True:
-        reasons.append("advisory_only_guard_missing")
-    if coverage.get("execution_allowed") is not False:
-        reasons.append("execution_allowed_guard_missing")
-    return _dedupe(reasons)
-
-
-def _bridge_warnings(
-    qa_evaluator: PreopenQaEvaluatorSummary | None,
-    briefing_artifact: PreopenBriefingArtifact | None,
-    candidates: list[CandidateSummary],
-) -> list[str]:
-    warnings: list[str] = []
-    if qa_evaluator is not None:
-        if qa_evaluator.status == "needs_review":
-            warnings.append("qa_needs_review")
-        warnings.extend(qa_evaluator.warnings)
-    if briefing_artifact is not None:
-        if briefing_artifact.status == "degraded":
-            warnings.append("briefing_artifact_degraded")
-        warnings.extend(briefing_artifact.risk_notes)
-    for candidate in candidates:
-        warnings.extend(candidate.warnings)
-    return _dedupe(warnings)
-
-
 def _build_crypto_candidate(
     candidate: CandidateSummary,
     *,
@@ -116,12 +53,12 @@ def _build_crypto_candidate(
             purpose="paper_plumbing_smoke",
         )
     except CryptoExecutionMappingError as exc:
-        return _unsupported_candidate(candidate, reason=str(exc))
+        return unsupported_candidate(candidate, reason=str(exc))
 
     preview_payload = metadata.preview_payload.model_dump(mode="json")
     forbidden = sorted(_FORBIDDEN_PREVIEW_KEYS.intersection(preview_payload))
     if forbidden:
-        return _unsupported_candidate(
+        return unsupported_candidate(
             candidate,
             reason="forbidden_preview_payload_keys:" + ",".join(forbidden),
         )
@@ -158,38 +95,39 @@ def build_preopen_paper_approval_bridge(
 ) -> PreopenPaperApprovalBridge:
     """Build deterministic paper approval preview metadata for preopen output."""
     stage = stage or "preopen"
-    blocking_reasons = _qa_blocking_reasons(qa_evaluator, has_run=has_run)
-    warnings = _bridge_warnings(qa_evaluator, briefing_artifact, candidates)
+    blocking_reasons = qa_blocking_reasons(qa_evaluator, has_run=has_run)
+    warnings = bridge_warnings(qa_evaluator, briefing_artifact, candidates)
     generated_at = generated_at or datetime.now(UTC)
 
     bridge_candidates: list[PreopenPaperApprovalCandidate] = []
     unsupported_reasons: list[str] = []
 
     if blocking_reasons:
-        return PreopenPaperApprovalBridge(
+        return bridge_result(
             status="blocked",
             generated_at=generated_at,
-            market_scope=market_scope,  # type: ignore[arg-type]
-            stage=stage if has_run else None,  # type: ignore[arg-type]
+            market_scope=market_scope,
+            stage=stage,
             candidate_count=len(candidates),
             candidates=[],
+            has_run=has_run,
             blocking_reasons=blocking_reasons,
             warnings=warnings,
-            unsupported_reasons=[],
         )
 
     if market_scope != "crypto":
         reason = f"unsupported_market_scope:{market_scope or 'unknown'}"
-        return PreopenPaperApprovalBridge(
+        return bridge_result(
             status="unavailable",
             generated_at=generated_at,
-            market_scope=market_scope,  # type: ignore[arg-type]
-            stage=stage if has_run else None,  # type: ignore[arg-type]
+            market_scope=market_scope,
+            stage=stage,
             candidate_count=len(candidates),
             candidates=[
-                _unsupported_candidate(candidate, reason=reason)
+                unsupported_candidate(candidate, reason=reason)
                 for candidate in candidates
             ],
+            has_run=has_run,
             warnings=warnings,
             unsupported_reasons=[reason],
         )
@@ -198,12 +136,12 @@ def build_preopen_paper_approval_bridge(
     for candidate in candidates:
         if candidate.instrument_type != "crypto":
             reason = f"unsupported_instrument_type:{candidate.instrument_type}"
-            bridge_candidates.append(_unsupported_candidate(candidate, reason=reason))
+            bridge_candidates.append(unsupported_candidate(candidate, reason=reason))
             unsupported_reasons.append(reason)
             continue
         if candidate.side != "buy":
             reason = f"unsupported_side:{candidate.side}"
-            bridge_candidates.append(_unsupported_candidate(candidate, reason=reason))
+            bridge_candidates.append(unsupported_candidate(candidate, reason=reason))
             unsupported_reasons.append(reason)
             continue
         bridge_candidate = _build_crypto_candidate(
@@ -228,17 +166,17 @@ def build_preopen_paper_approval_bridge(
     else:
         status = "available"
 
-    return PreopenPaperApprovalBridge(
+    return bridge_result(
         status=status,
         generated_at=generated_at,
         market_scope="crypto",
-        stage=stage if has_run else None,  # type: ignore[arg-type]
+        stage=stage,
         eligible_count=eligible_count,
         candidate_count=len(candidates),
         candidates=bridge_candidates,
-        blocking_reasons=[],
+        has_run=has_run,
         warnings=warnings,
-        unsupported_reasons=_dedupe(unsupported_reasons),
+        unsupported_reasons=dedupe(unsupported_reasons),
     )
 
 

--- a/tests/services/preopen_approval_bridge_helpers.py
+++ b/tests/services/preopen_approval_bridge_helpers.py
@@ -61,7 +61,9 @@ def preopen_artifact(market_scope: str, **overrides) -> PreopenBriefingArtifact:
     return PreopenBriefingArtifact(**payload)
 
 
-def preopen_qa(summary: str = "Execution disabled.", **overrides) -> PreopenQaEvaluatorSummary:
+def preopen_qa(
+    summary: str = "Execution disabled.", **overrides
+) -> PreopenQaEvaluatorSummary:
     payload = {
         "status": "ready",
         "generated_at": datetime.now(UTC),

--- a/tests/services/preopen_approval_bridge_helpers.py
+++ b/tests/services/preopen_approval_bridge_helpers.py
@@ -1,0 +1,84 @@
+"""Shared test builders for preopen approval bridge tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from uuid import uuid4
+
+from app.schemas.preopen import (
+    CandidateSummary,
+    PreopenBriefingArtifact,
+    PreopenDecisionSessionCta,
+    PreopenQaCheck,
+    PreopenQaEvaluatorSummary,
+    PreopenQaScore,
+)
+
+
+def preopen_candidate(
+    *,
+    symbol: str,
+    instrument_type: str,
+    side: str = "buy",
+    price: Decimal | None = None,
+    quantity: Decimal | None = None,
+    currency: str = "KRW",
+    rationale: str = "Preopen approval bridge candidate",
+    **overrides,
+) -> CandidateSummary:
+    payload = {
+        "candidate_uuid": uuid4(),
+        "symbol": symbol,
+        "instrument_type": instrument_type,
+        "side": side,
+        "candidate_kind": "proposed",
+        "proposed_price": price,
+        "proposed_qty": quantity,
+        "confidence": 70,
+        "rationale": rationale,
+        "currency": currency,
+        "warnings": [],
+    }
+    payload.update(overrides)
+    return CandidateSummary(**payload)
+
+
+def preopen_artifact(market_scope: str, **overrides) -> PreopenBriefingArtifact:
+    payload = {
+        "status": "ready",
+        "market_scope": market_scope,
+        "stage": "preopen",
+        "risk_notes": [],
+        "cta": PreopenDecisionSessionCta(
+            state="create_available",
+            label="Create decision session",
+            requires_confirmation=True,
+        ),
+        "qa": {"read_only": True},
+    }
+    payload.update(overrides)
+    return PreopenBriefingArtifact(**payload)
+
+
+def preopen_qa(summary: str = "Execution disabled.", **overrides) -> PreopenQaEvaluatorSummary:
+    payload = {
+        "status": "ready",
+        "generated_at": datetime.now(UTC),
+        "overall": PreopenQaScore(score=90, grade="excellent", confidence="high"),
+        "checks": [
+            PreopenQaCheck(
+                id="actionability_guardrail",
+                label="Actionability guardrail",
+                status="pass",
+                severity="info",
+                summary=summary,
+                details={"advisory_only": True, "execution_allowed": False},
+            )
+        ],
+        "blocking_reasons": [],
+        "warnings": [],
+        "coverage": {"advisory_only": True, "execution_allowed": False},
+    }
+    payload.update(overrides)
+    return PreopenQaEvaluatorSummary(**payload)

--- a/tests/services/test_kis_mock_preopen_approval_bridge.py
+++ b/tests/services/test_kis_mock_preopen_approval_bridge.py
@@ -93,6 +93,24 @@ def test_ready_kr_buy_candidate_builds_kis_mock_dry_run_preview_metadata() -> No
 
 
 @pytest.mark.unit
+def test_ready_kr_buy_with_implicit_quantity_is_warning_tagged() -> None:
+    bridge = build_kis_mock_preopen_approval_bridge(
+        has_run=True,
+        market_scope="kr",
+        candidates=[_candidate(proposed_qty=None)],
+        briefing_artifact=_artifact(),
+        qa_evaluator=_qa(),
+    )
+
+    assert bridge.status == "warning"
+    item = bridge.candidates[0]
+    assert item.status == "warning"
+    assert item.preview_payload is not None
+    assert item.preview_payload["quantity"] == 1
+    assert item.warnings == ["default_quantity_used:1"]
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("candidate", "expected_reason"),
     [
@@ -300,7 +318,12 @@ def test_high_severity_qa_failure_blocks_kis_mock_bridge() -> None:
 
 @pytest.mark.unit
 def test_kis_mock_bridge_module_imports_only_pure_allowed_modules() -> None:
-    path = Path("app/services/kis_mock_preopen_approval_bridge.py")
+    path = (
+        Path(__file__).parent.parent.parent
+        / "app"
+        / "services"
+        / "kis_mock_preopen_approval_bridge.py"
+    )
     imported_modules = [
         node.module
         for node in ast.walk(ast.parse(path.read_text()))

--- a/tests/services/test_kis_mock_preopen_approval_bridge.py
+++ b/tests/services/test_kis_mock_preopen_approval_bridge.py
@@ -1,0 +1,371 @@
+"""Tests for the ROB-95 KR/KIS mock preopen approval bridge."""
+
+from __future__ import annotations
+
+import ast
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from app.schemas.preopen import (
+    CandidateSummary,
+    PreopenBriefingArtifact,
+    PreopenDecisionSessionCta,
+    PreopenQaCheck,
+    PreopenQaEvaluatorSummary,
+    PreopenQaScore,
+)
+from app.services.kis_mock_preopen_approval_bridge import (
+    build_kis_mock_preopen_approval_bridge,
+)
+
+
+def _candidate(**kwargs) -> CandidateSummary:
+    defaults = {
+        "candidate_uuid": uuid4(),
+        "symbol": "005930",
+        "instrument_type": "equity_kr",
+        "side": "buy",
+        "candidate_kind": "proposed",
+        "proposed_price": Decimal("229500"),
+        "proposed_qty": Decimal("1"),
+        "confidence": 72,
+        "rationale": "KR mock pilot candidate",
+        "currency": "KRW",
+        "warnings": [],
+    }
+    defaults.update(kwargs)
+    return CandidateSummary(**defaults)
+
+
+def _artifact(**kwargs) -> PreopenBriefingArtifact:
+    defaults = {
+        "status": "ready",
+        "market_scope": "kr",
+        "stage": "preopen",
+        "risk_notes": [],
+        "cta": PreopenDecisionSessionCta(
+            state="create_available",
+            label="Create decision session",
+            requires_confirmation=True,
+        ),
+        "qa": {"read_only": True},
+    }
+    defaults.update(kwargs)
+    return PreopenBriefingArtifact(**defaults)
+
+
+def _qa(**kwargs) -> PreopenQaEvaluatorSummary:
+    defaults = {
+        "status": "ready",
+        "generated_at": datetime.now(UTC),
+        "overall": PreopenQaScore(score=90, grade="excellent", confidence="high"),
+        "checks": [
+            PreopenQaCheck(
+                id="actionability_guardrail",
+                label="Actionability guardrail",
+                status="pass",
+                severity="info",
+                summary="Execution disabled before operator approval.",
+                details={"advisory_only": True, "execution_allowed": False},
+            )
+        ],
+        "blocking_reasons": [],
+        "warnings": [],
+        "coverage": {"advisory_only": True, "execution_allowed": False},
+    }
+    defaults.update(kwargs)
+    return PreopenQaEvaluatorSummary(**defaults)
+
+
+@pytest.mark.unit
+def test_ready_kr_buy_candidate_builds_kis_mock_dry_run_preview_metadata() -> None:
+    bridge = build_kis_mock_preopen_approval_bridge(
+        has_run=True,
+        market_scope="kr",
+        candidates=[_candidate()],
+        briefing_artifact=_artifact(),
+        qa_evaluator=_qa(),
+    )
+
+    assert bridge.status == "available"
+    assert bridge.preview_only is True
+    assert bridge.advisory_only is True
+    assert bridge.execution_allowed is False
+    assert bridge.market_scope == "kr"
+    assert bridge.eligible_count == 1
+    item = bridge.candidates[0]
+    assert item.status == "available"
+    assert item.symbol == "005930"
+    assert item.signal_symbol == "005930"
+    assert item.signal_venue == "kr_preopen"
+    assert item.execution_symbol == "005930"
+    assert item.execution_venue == "kis_mock"
+    assert item.execution_asset_class == "equity_kr"
+    assert item.workflow_stage == "kr_market_open_mock"
+    assert item.purpose == "kis_mock_market_open_pilot"
+    assert item.preview_payload == {
+        "tool": "kis_mock_place_order",
+        "symbol": "005930",
+        "side": "buy",
+        "order_type": "limit",
+        "quantity": 1,
+        "price": "229500",
+        "account_mode": "kis_mock",
+        "execution_venue": "kis_mock",
+        "execution_asset_class": "equity_kr",
+        "dry_run": True,
+        "regular_session_only": True,
+        "requires_final_mock_submit_approval": True,
+    }
+    approval_copy = "\n".join(item.approval_copy)
+    assert "KIS official mock only" in approval_copy
+    assert "No KIS live order" in approval_copy
+    assert "dry_run=True" in approval_copy
+    assert "dry_run=False" in approval_copy
+    assert "live submission" not in approval_copy.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("candidate", "expected_reason"),
+    [
+        (_candidate(symbol="AAPL"), "unsupported_symbol:AAPL"),
+        (_candidate(symbol="KRW-BTC"), "unsupported_symbol:KRW-BTC"),
+        (_candidate(symbol="00593A"), "unsupported_symbol:00593A"),
+        (_candidate(symbol="5930"), "unsupported_symbol:5930"),
+    ],
+)
+def test_malformed_or_non_kr_symbols_are_unavailable_without_preview_payload(
+    candidate: CandidateSummary,
+    expected_reason: str,
+) -> None:
+    bridge = build_kis_mock_preopen_approval_bridge(
+        has_run=True,
+        market_scope="kr",
+        candidates=[candidate],
+        briefing_artifact=_artifact(),
+        qa_evaluator=_qa(),
+    )
+
+    assert bridge.status == "unavailable"
+    item = bridge.candidates[0]
+    assert item.status == "unavailable"
+    assert item.reason == expected_reason
+    assert item.preview_payload is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("candidate_patch", "expected_reason"),
+    [
+        ({"proposed_price": Decimal("0")}, "invalid_price"),
+        ({"proposed_price": Decimal("-1")}, "invalid_price"),
+        ({"proposed_price": Decimal("229500.5")}, "invalid_price"),
+        ({"proposed_qty": Decimal("0")}, "invalid_quantity"),
+        ({"proposed_qty": Decimal("-1")}, "invalid_quantity"),
+        ({"proposed_qty": Decimal("1.5")}, "invalid_quantity"),
+    ],
+)
+def test_invalid_price_or_quantity_is_unavailable_without_preview_payload(
+    candidate_patch: dict[str, Decimal],
+    expected_reason: str,
+) -> None:
+    bridge = build_kis_mock_preopen_approval_bridge(
+        has_run=True,
+        market_scope="kr",
+        candidates=[_candidate(**candidate_patch)],
+        briefing_artifact=_artifact(),
+        qa_evaluator=_qa(),
+    )
+
+    assert bridge.status == "unavailable"
+    item = bridge.candidates[0]
+    assert item.status == "unavailable"
+    assert item.reason == expected_reason
+    assert item.preview_payload is None
+
+
+@pytest.mark.unit
+def test_missing_limit_price_is_unavailable_without_preview_payload() -> None:
+    bridge = build_kis_mock_preopen_approval_bridge(
+        has_run=True,
+        market_scope="kr",
+        candidates=[_candidate(proposed_price=None)],
+        briefing_artifact=_artifact(),
+        qa_evaluator=_qa(),
+    )
+
+    assert bridge.status == "unavailable"
+    assert bridge.eligible_count == 0
+    item = bridge.candidates[0]
+    assert item.status == "unavailable"
+    assert item.reason == "missing_price"
+    assert item.preview_payload is None
+
+
+@pytest.mark.unit
+def test_ready_kr_sell_requires_explicit_quantity() -> None:
+    bridge = build_kis_mock_preopen_approval_bridge(
+        has_run=True,
+        market_scope="kr",
+        candidates=[_candidate(side="sell", proposed_qty=None)],
+        briefing_artifact=_artifact(),
+        qa_evaluator=_qa(),
+    )
+
+    assert bridge.status == "unavailable"
+    assert bridge.eligible_count == 0
+    assert bridge.unsupported_reasons == ["missing_quantity"]
+    item = bridge.candidates[0]
+    assert item.status == "unavailable"
+    assert item.reason == "missing_quantity"
+    assert item.preview_payload is None
+
+
+@pytest.mark.unit
+def test_side_none_is_unavailable_without_preview_payload() -> None:
+    bridge = build_kis_mock_preopen_approval_bridge(
+        has_run=True,
+        market_scope="kr",
+        candidates=[_candidate(side="none")],
+        briefing_artifact=_artifact(),
+        qa_evaluator=_qa(),
+    )
+
+    assert bridge.status == "unavailable"
+    assert bridge.eligible_count == 0
+    item = bridge.candidates[0]
+    assert item.status == "unavailable"
+    assert item.reason == "unsupported_side:none"
+    assert item.preview_payload is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("market_scope", "candidate", "expected_reason", "expected_bridge_scope"),
+    [
+        (
+            "crypto",
+            _candidate(symbol="KRW-BTC", instrument_type="crypto"),
+            "unsupported_market_scope:crypto",
+            "crypto",
+        ),
+        (
+            "kr",
+            _candidate(symbol="KRW-BTC", instrument_type="crypto"),
+            "unsupported_instrument_type:crypto",
+            "kr",
+        ),
+        (
+            "us",
+            _candidate(symbol="AAPL", instrument_type="equity_us"),
+            "unsupported_market_scope:us",
+            "us",
+        ),
+        (
+            "jp",
+            _candidate(symbol="7203", instrument_type="equity_jp"),
+            "unsupported_market_scope:jp",
+            None,
+        ),
+    ],
+)
+def test_non_kr_and_crypto_candidates_are_unavailable_without_kis_suggestion(
+    market_scope: str,
+    candidate: CandidateSummary,
+    expected_reason: str,
+    expected_bridge_scope: str | None,
+) -> None:
+    briefing_artifact = (
+        None
+        if market_scope not in {"kr", "us", "crypto"}
+        else _artifact(market_scope="kr" if market_scope == "kr" else market_scope)
+    )
+    bridge = build_kis_mock_preopen_approval_bridge(
+        has_run=True,
+        market_scope=market_scope,
+        candidates=[candidate],
+        briefing_artifact=briefing_artifact,
+        qa_evaluator=_qa(),
+    )
+
+    assert bridge.status == "unavailable"
+    assert bridge.market_scope == expected_bridge_scope
+    assert bridge.eligible_count == 0
+    item = bridge.candidates[0]
+    assert item.status == "unavailable"
+    assert item.reason == expected_reason
+    assert item.preview_payload is None
+    assert item.execution_venue is None
+    assert "kis_mock_place_order" not in "\n".join(item.approval_copy)
+
+
+@pytest.mark.unit
+def test_high_severity_qa_failure_blocks_kis_mock_bridge() -> None:
+    qa = _qa(
+        status="needs_review",
+        checks=[
+            PreopenQaCheck(
+                id="readiness_safety",
+                label="Readiness safety",
+                status="fail",
+                severity="high",
+                summary="Safety gate failed.",
+            )
+        ],
+        blocking_reasons=["readiness_safety"],
+    )
+
+    bridge = build_kis_mock_preopen_approval_bridge(
+        has_run=True,
+        market_scope="kr",
+        candidates=[_candidate()],
+        briefing_artifact=_artifact(),
+        qa_evaluator=qa,
+    )
+
+    assert bridge.status == "blocked"
+    assert "readiness_safety" in bridge.blocking_reasons
+    assert "high_severity_fail:readiness_safety" in bridge.blocking_reasons
+    assert bridge.eligible_count == 0
+    assert bridge.candidates == []
+
+
+@pytest.mark.unit
+def test_kis_mock_bridge_module_imports_only_pure_allowed_modules() -> None:
+    path = Path("app/services/kis_mock_preopen_approval_bridge.py")
+    tree = ast.parse(path.read_text())
+    imported_modules: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported_modules.append(node.module)
+
+    forbidden_fragments = [
+        "broker",
+        "kis",
+        "upbit",
+        "mcp",
+        "watch",
+        "redis",
+        "scheduler",
+        "httpx",
+        "requests",
+        "paper_trading",
+    ]
+    assert not [
+        module
+        for module in imported_modules
+        if any(fragment in module.lower() for fragment in forbidden_fragments)
+    ]
+    assert set(imported_modules) <= {
+        "__future__",
+        "datetime",
+        "decimal",
+        "app.schemas.preopen",
+    }

--- a/tests/services/test_kis_mock_preopen_approval_bridge.py
+++ b/tests/services/test_kis_mock_preopen_approval_bridge.py
@@ -368,4 +368,5 @@ def test_kis_mock_bridge_module_imports_only_pure_allowed_modules() -> None:
         "datetime",
         "decimal",
         "app.schemas.preopen",
+        "app.services.preopen_approval_safety",
     }

--- a/tests/services/test_kis_mock_preopen_approval_bridge.py
+++ b/tests/services/test_kis_mock_preopen_approval_bridge.py
@@ -368,5 +368,6 @@ def test_kis_mock_bridge_module_imports_only_pure_allowed_modules() -> None:
         "datetime",
         "decimal",
         "app.schemas.preopen",
+        "app.services.preopen_approval_bridge_common",
         "app.services.preopen_approval_safety",
     }

--- a/tests/services/test_kis_mock_preopen_approval_bridge.py
+++ b/tests/services/test_kis_mock_preopen_approval_bridge.py
@@ -3,82 +3,45 @@
 from __future__ import annotations
 
 import ast
-from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
-from uuid import uuid4
 
 import pytest
 
-from app.schemas.preopen import (
-    CandidateSummary,
-    PreopenBriefingArtifact,
-    PreopenDecisionSessionCta,
-    PreopenQaCheck,
-    PreopenQaEvaluatorSummary,
-    PreopenQaScore,
-)
+from app.schemas.preopen import CandidateSummary, PreopenQaCheck
 from app.services.kis_mock_preopen_approval_bridge import (
     build_kis_mock_preopen_approval_bridge,
+)
+from tests.services.preopen_approval_bridge_helpers import (
+    preopen_artifact,
+    preopen_candidate,
+    preopen_qa,
 )
 
 
 def _candidate(**kwargs) -> CandidateSummary:
-    defaults = {
-        "candidate_uuid": uuid4(),
+    payload = {
         "symbol": "005930",
         "instrument_type": "equity_kr",
-        "side": "buy",
-        "candidate_kind": "proposed",
-        "proposed_price": Decimal("229500"),
-        "proposed_qty": Decimal("1"),
+        "price": Decimal("229500"),
+        "quantity": Decimal("1"),
         "confidence": 72,
         "rationale": "KR mock pilot candidate",
-        "currency": "KRW",
-        "warnings": [],
     }
-    defaults.update(kwargs)
-    return CandidateSummary(**defaults)
+    if "proposed_price" in kwargs:
+        payload["price"] = kwargs.pop("proposed_price")
+    if "proposed_qty" in kwargs:
+        payload["quantity"] = kwargs.pop("proposed_qty")
+    payload.update(kwargs)
+    return preopen_candidate(**payload)
 
 
-def _artifact(**kwargs) -> PreopenBriefingArtifact:
-    defaults = {
-        "status": "ready",
-        "market_scope": "kr",
-        "stage": "preopen",
-        "risk_notes": [],
-        "cta": PreopenDecisionSessionCta(
-            state="create_available",
-            label="Create decision session",
-            requires_confirmation=True,
-        ),
-        "qa": {"read_only": True},
-    }
-    defaults.update(kwargs)
-    return PreopenBriefingArtifact(**defaults)
+def _artifact(**kwargs):
+    return preopen_artifact(kwargs.pop("market_scope", "kr"), **kwargs)
 
 
-def _qa(**kwargs) -> PreopenQaEvaluatorSummary:
-    defaults = {
-        "status": "ready",
-        "generated_at": datetime.now(UTC),
-        "overall": PreopenQaScore(score=90, grade="excellent", confidence="high"),
-        "checks": [
-            PreopenQaCheck(
-                id="actionability_guardrail",
-                label="Actionability guardrail",
-                status="pass",
-                severity="info",
-                summary="Execution disabled before operator approval.",
-                details={"advisory_only": True, "execution_allowed": False},
-            )
-        ],
-        "blocking_reasons": [],
-        "warnings": [],
-        "coverage": {"advisory_only": True, "execution_allowed": False},
-    }
-    defaults.update(kwargs)
-    return PreopenQaEvaluatorSummary(**defaults)
+def _qa(**kwargs):
+    return preopen_qa("Execution disabled before operator approval.", **kwargs)
 
 
 @pytest.mark.unit
@@ -283,7 +246,7 @@ def test_non_kr_and_crypto_candidates_are_unavailable_without_kis_suggestion(
     briefing_artifact = (
         None
         if market_scope not in {"kr", "us", "crypto"}
-        else _artifact(market_scope="kr" if market_scope == "kr" else market_scope)
+        else _artifact(market_scope=market_scope)
     )
     bridge = build_kis_mock_preopen_approval_bridge(
         has_run=True,
@@ -338,15 +301,13 @@ def test_high_severity_qa_failure_blocks_kis_mock_bridge() -> None:
 @pytest.mark.unit
 def test_kis_mock_bridge_module_imports_only_pure_allowed_modules() -> None:
     path = Path("app/services/kis_mock_preopen_approval_bridge.py")
-    tree = ast.parse(path.read_text())
-    imported_modules: list[str] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            imported_modules.extend(alias.name for alias in node.names)
-        elif isinstance(node, ast.ImportFrom) and node.module:
-            imported_modules.append(node.module)
+    imported_modules = [
+        node.module
+        for node in ast.walk(ast.parse(path.read_text()))
+        if isinstance(node, ast.ImportFrom) and node.module
+    ]
 
-    forbidden_fragments = [
+    forbidden_fragments = {
         "broker",
         "kis",
         "upbit",
@@ -357,16 +318,14 @@ def test_kis_mock_bridge_module_imports_only_pure_allowed_modules() -> None:
         "httpx",
         "requests",
         "paper_trading",
-    ]
-    assert not [
-        module
+    }
+    assert all(
+        not any(fragment in module.lower() for fragment in forbidden_fragments)
         for module in imported_modules
-        if any(fragment in module.lower() for fragment in forbidden_fragments)
-    ]
-    assert set(imported_modules) <= {
+    )
+    assert set(imported_modules) == {
         "__future__",
         "datetime",
-        "decimal",
         "app.schemas.preopen",
         "app.services.preopen_approval_bridge_common",
         "app.services.preopen_approval_safety",

--- a/tests/services/test_preopen_paper_approval_bridge.py
+++ b/tests/services/test_preopen_paper_approval_bridge.py
@@ -3,80 +3,37 @@
 from __future__ import annotations
 
 import ast
-from datetime import UTC, datetime
-from decimal import Decimal
 from pathlib import Path
-from uuid import uuid4
 
-from app.schemas.preopen import (
-    CandidateSummary,
-    PreopenBriefingArtifact,
-    PreopenDecisionSessionCta,
-    PreopenQaCheck,
-    PreopenQaEvaluatorSummary,
-    PreopenQaScore,
-)
+from app.schemas.preopen import PreopenQaCheck
 from app.services.preopen_paper_approval_bridge import (
     build_preopen_paper_approval_bridge,
 )
+from tests.services.preopen_approval_bridge_helpers import (
+    preopen_artifact,
+    preopen_candidate,
+    preopen_qa,
+)
 
 
-def _candidate(**kwargs) -> CandidateSummary:
-    defaults = {
-        "candidate_uuid": uuid4(),
+def _candidate(**kwargs):
+    payload = {
         "symbol": "KRW-BTC",
         "instrument_type": "crypto",
-        "side": "buy",
-        "candidate_kind": "proposed",
-        "proposed_price": Decimal("100000000"),
-        "proposed_qty": None,
-        "confidence": 70,
+        "price": None,
+        "quantity": None,
         "rationale": "Crypto paper plumbing candidate",
-        "currency": "KRW",
-        "warnings": [],
     }
-    defaults.update(kwargs)
-    return CandidateSummary(**defaults)
+    payload.update(kwargs)
+    return preopen_candidate(**payload)
 
 
-def _artifact(**kwargs) -> PreopenBriefingArtifact:
-    defaults = {
-        "status": "ready",
-        "market_scope": "crypto",
-        "stage": "preopen",
-        "risk_notes": [],
-        "cta": PreopenDecisionSessionCta(
-            state="create_available",
-            label="Create decision session",
-            requires_confirmation=True,
-        ),
-        "qa": {"read_only": True},
-    }
-    defaults.update(kwargs)
-    return PreopenBriefingArtifact(**defaults)
+def _artifact(**kwargs):
+    return preopen_artifact(kwargs.pop("market_scope", "crypto"), **kwargs)
 
 
-def _qa(**kwargs) -> PreopenQaEvaluatorSummary:
-    defaults = {
-        "status": "ready",
-        "generated_at": datetime.now(UTC),
-        "overall": PreopenQaScore(score=90, grade="excellent", confidence="high"),
-        "checks": [
-            PreopenQaCheck(
-                id="actionability_guardrail",
-                label="Actionability guardrail",
-                status="pass",
-                severity="info",
-                summary="Execution disabled.",
-                details={"advisory_only": True, "execution_allowed": False},
-            )
-        ],
-        "blocking_reasons": [],
-        "warnings": [],
-        "coverage": {"advisory_only": True, "execution_allowed": False},
-    }
-    defaults.update(kwargs)
-    return PreopenQaEvaluatorSummary(**defaults)
+def _qa(**kwargs):
+    return preopen_qa(**kwargs)
 
 
 def test_no_run_blocks_bridge() -> None:

--- a/tests/test_kis_mock_market_open_pilot.py
+++ b/tests/test_kis_mock_market_open_pilot.py
@@ -1,0 +1,333 @@
+"""Tests for the ROB-95 operator-gated KIS mock market-open pilot."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from app.services.kis_mock_market_open_pilot import (
+    KisMockMarketOpenPilotRequest,
+    classify_kis_mock_market_open_report,
+    expected_kis_mock_submit_approval_text,
+    run_kis_mock_market_open_pilot,
+)
+
+
+class FakeKisMockPlaceOrder:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    def __call__(self, **kwargs: object) -> dict[str, object]:
+        self.calls.append(kwargs)
+        return {
+            "ok": True,
+            "account_mode": kwargs.get("account_mode"),
+            "dry_run": kwargs.get("dry_run"),
+            "order_id": "mock-order-1",
+            "fill_recorded": False,
+            "journal_created": False,
+        }
+
+
+@pytest.mark.unit
+def test_readiness_mode_is_read_only_and_reports_guard_configuration() -> None:
+    route = FakeKisMockPlaceOrder()
+
+    result = run_kis_mock_market_open_pilot(
+        KisMockMarketOpenPilotRequest(
+            mode="readiness",
+            symbol="005930",
+            side="buy",
+            quantity=1,
+            price=Decimal("229500"),
+        ),
+        kis_mock_place_order=route,
+        is_regular_session=lambda: False,
+        readiness_probe=lambda: {"mock_config_present": True, "quote_checked": True},
+    )
+
+    assert result.status == "ready"
+    assert result.mode == "readiness"
+    assert result.dry_run is None
+    assert result.tool_name == "kis_mock_place_order"
+    assert result.account_mode == "kis_mock"
+    assert result.safety_checks["typed_kis_mock_route_only"] is True
+    assert result.readiness == {"mock_config_present": True, "quote_checked": True}
+    assert route.calls == []
+
+
+@pytest.mark.unit
+def test_dry_run_calls_only_typed_kis_mock_place_order_with_forced_dry_run_true() -> (
+    None
+):
+    route = FakeKisMockPlaceOrder()
+
+    result = run_kis_mock_market_open_pilot(
+        KisMockMarketOpenPilotRequest(
+            mode="dry-run",
+            symbol="005930",
+            side="buy",
+            quantity=1,
+            price=Decimal("229500"),
+        ),
+        kis_mock_place_order=route,
+        is_regular_session=lambda: False,
+    )
+
+    assert result.status == "submitted"
+    assert result.dry_run is True
+    assert result.response == {
+        "ok": True,
+        "account_mode": "kis_mock",
+        "dry_run": True,
+        "order_id": "mock-order-1",
+        "fill_recorded": False,
+        "journal_created": False,
+    }
+    assert route.calls == [
+        {
+            "symbol": "005930",
+            "side": "buy",
+            "order_type": "limit",
+            "quantity": 1,
+            "price": 229500,
+            "dry_run": True,
+            "account_mode": "kis_mock",
+            "reason": "ROB-95 KIS mock market-open pilot dry-run",
+        }
+    ]
+
+
+@pytest.mark.unit
+def test_submit_mock_rejects_missing_exact_approval_text_without_calling_route() -> (
+    None
+):
+    route = FakeKisMockPlaceOrder()
+
+    result = run_kis_mock_market_open_pilot(
+        KisMockMarketOpenPilotRequest(
+            mode="submit-mock",
+            symbol="005930",
+            side="buy",
+            quantity=1,
+            price=Decimal("229500"),
+        ),
+        kis_mock_place_order=route,
+        is_regular_session=lambda: True,
+    )
+
+    assert result.status == "blocked"
+    assert result.blocking_reasons == ["approval_text_mismatch"]
+    assert result.expected_approval_text == (
+        "ROB-95 KIS mock 승인: 005930 매수 1주 지정가 229500원 "
+        "account_mode=kis_mock dry_run=False 정규장 모의투자 제출 승인"
+    )
+    assert route.calls == []
+
+
+@pytest.mark.unit
+def test_submit_mock_rejects_non_regular_session_even_with_exact_approval() -> None:
+    route = FakeKisMockPlaceOrder()
+    approval = expected_kis_mock_submit_approval_text(
+        symbol="005930", side="buy", quantity=1, price=Decimal("229500")
+    )
+
+    result = run_kis_mock_market_open_pilot(
+        KisMockMarketOpenPilotRequest(
+            mode="submit-mock",
+            symbol="005930",
+            side="buy",
+            quantity=1,
+            price=Decimal("229500"),
+            approval_text=approval,
+        ),
+        kis_mock_place_order=route,
+        is_regular_session=lambda: False,
+    )
+
+    assert result.status == "blocked"
+    assert result.blocking_reasons == ["regular_session_closed"]
+    assert route.calls == []
+
+
+@pytest.mark.unit
+def test_submit_mock_rejects_quantity_above_one_by_default() -> None:
+    route = FakeKisMockPlaceOrder()
+    approval = expected_kis_mock_submit_approval_text(
+        symbol="005930", side="buy", quantity=2, price=Decimal("229500")
+    )
+
+    result = run_kis_mock_market_open_pilot(
+        KisMockMarketOpenPilotRequest(
+            mode="submit-mock",
+            symbol="005930",
+            side="buy",
+            quantity=2,
+            price=Decimal("229500"),
+            approval_text=approval,
+        ),
+        kis_mock_place_order=route,
+        is_regular_session=lambda: True,
+    )
+
+    assert result.status == "blocked"
+    assert result.blocking_reasons == ["quantity_exceeds_default_smoke_limit"]
+    assert route.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    (
+        "symbol",
+        "side",
+        "quantity",
+        "price",
+        "account_mode",
+        "tool_name",
+        "expected_reason",
+    ),
+    [
+        (
+            "AAPL",
+            "buy",
+            1,
+            Decimal("229500"),
+            "kis_mock",
+            "kis_mock_place_order",
+            "unsupported_kr_equity_symbol",
+        ),
+        (
+            "005930",
+            "hold",
+            1,
+            Decimal("229500"),
+            "kis_mock",
+            "kis_mock_place_order",
+            "unsupported_side",
+        ),
+        (
+            "005930",
+            "buy",
+            1,
+            Decimal("0"),
+            "kis_mock",
+            "kis_mock_place_order",
+            "invalid_limit_price",
+        ),
+        (
+            "005930",
+            "buy",
+            1,
+            Decimal("229500"),
+            "kis_live",
+            "kis_mock_place_order",
+            "invalid_account_mode",
+        ),
+        (
+            "005930",
+            "buy",
+            1,
+            Decimal("229500"),
+            "kis_mock",
+            "place_order",
+            "invalid_tool_name",
+        ),
+        (
+            "005930",
+            "buy",
+            1,
+            Decimal("229500"),
+            "kis_mock",
+            "kis_live_place_order",
+            "invalid_tool_name",
+        ),
+    ],
+)
+def test_runner_rejects_unsafe_request_shape_before_any_route_call(
+    symbol: str,
+    side: str,
+    quantity: int,
+    price: Decimal,
+    account_mode: str,
+    tool_name: str,
+    expected_reason: str,
+) -> None:
+    route = FakeKisMockPlaceOrder()
+
+    result = run_kis_mock_market_open_pilot(
+        KisMockMarketOpenPilotRequest(
+            mode="dry-run",
+            symbol=symbol,
+            side=side,
+            quantity=quantity,
+            price=price,
+            account_mode=account_mode,
+            tool_name=tool_name,
+        ),
+        kis_mock_place_order=route,
+        is_regular_session=lambda: True,
+    )
+
+    assert result.status == "blocked"
+    assert expected_reason in result.blocking_reasons
+    assert route.calls == []
+
+
+@pytest.mark.unit
+def test_submit_mock_with_exact_approval_calls_typed_route_with_dry_run_false() -> None:
+    route = FakeKisMockPlaceOrder()
+    approval = expected_kis_mock_submit_approval_text(
+        symbol="005930", side="buy", quantity=1, price=Decimal("229500")
+    )
+
+    result = run_kis_mock_market_open_pilot(
+        KisMockMarketOpenPilotRequest(
+            mode="submit-mock",
+            symbol="005930",
+            side="buy",
+            quantity=1,
+            price=Decimal("229500"),
+            approval_text=approval,
+        ),
+        kis_mock_place_order=route,
+        is_regular_session=lambda: True,
+    )
+
+    assert result.status == "submitted"
+    assert result.dry_run is False
+    assert result.report_status == "accepted_but_fill_unknown"
+    assert route.calls == [
+        {
+            "symbol": "005930",
+            "side": "buy",
+            "order_type": "limit",
+            "quantity": 1,
+            "price": 229500,
+            "dry_run": False,
+            "account_mode": "kis_mock",
+            "reason": "ROB-95 KIS mock market-open pilot exact-approved mock submit",
+        }
+    ]
+
+
+@pytest.mark.unit
+def test_report_classification_separates_acceptance_from_inferred_fill() -> None:
+    assert (
+        classify_kis_mock_market_open_report(
+            response={"ok": True, "fill_recorded": False, "journal_created": False},
+            holdings_delta_qty=0,
+            cash_delta_krw=0,
+            order_history_supported=False,
+        )
+        == "accepted_but_fill_unknown"
+    )
+    assert (
+        classify_kis_mock_market_open_report(
+            response={"ok": True, "fill_recorded": False, "journal_created": False},
+            holdings_delta_qty=1,
+            cash_delta_krw=-229500,
+            order_history_supported=True,
+        )
+        == "filled_inferred"
+    )

--- a/tests/test_kis_mock_market_open_pilot.py
+++ b/tests/test_kis_mock_market_open_pilot.py
@@ -18,7 +18,7 @@ class FakeKisMockPlaceOrder:
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []
 
-    def __call__(self, **kwargs: object) -> dict[str, object]:
+    async def __call__(self, **kwargs: object) -> dict[str, object]:
         self.calls.append(kwargs)
         return {
             "ok": True,
@@ -31,10 +31,11 @@ class FakeKisMockPlaceOrder:
 
 
 @pytest.mark.unit
-def test_readiness_mode_is_read_only_and_reports_guard_configuration() -> None:
+@pytest.mark.asyncio
+async def test_readiness_mode_is_read_only_and_reports_guard_configuration() -> None:
     route = FakeKisMockPlaceOrder()
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="readiness",
             symbol="005930",
@@ -58,12 +59,13 @@ def test_readiness_mode_is_read_only_and_reports_guard_configuration() -> None:
 
 
 @pytest.mark.unit
-def test_dry_run_calls_only_typed_kis_mock_place_order_with_forced_dry_run_true() -> (
+@pytest.mark.asyncio
+async def test_dry_run_calls_only_typed_kis_mock_place_order_with_forced_dry_run_true() -> (
     None
 ):
     route = FakeKisMockPlaceOrder()
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="dry-run",
             symbol="005930",
@@ -100,12 +102,13 @@ def test_dry_run_calls_only_typed_kis_mock_place_order_with_forced_dry_run_true(
 
 
 @pytest.mark.unit
-def test_submit_mock_rejects_missing_exact_approval_text_without_calling_route() -> (
+@pytest.mark.asyncio
+async def test_submit_mock_rejects_missing_exact_approval_text_without_calling_route() -> (
     None
 ):
     route = FakeKisMockPlaceOrder()
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="submit-mock",
             symbol="005930",
@@ -127,13 +130,14 @@ def test_submit_mock_rejects_missing_exact_approval_text_without_calling_route()
 
 
 @pytest.mark.unit
-def test_submit_mock_rejects_whitespace_variation_in_approval_text() -> None:
+@pytest.mark.asyncio
+async def test_submit_mock_rejects_whitespace_variation_in_approval_text() -> None:
     route = FakeKisMockPlaceOrder()
     approval = expected_kis_mock_submit_approval_text(
         symbol="005930", side="buy", quantity=1, price=Decimal("229500")
     )
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="submit-mock",
             symbol="005930",
@@ -152,13 +156,16 @@ def test_submit_mock_rejects_whitespace_variation_in_approval_text() -> None:
 
 
 @pytest.mark.unit
-def test_submit_mock_rejects_non_regular_session_even_with_exact_approval() -> None:
+@pytest.mark.asyncio
+async def test_submit_mock_rejects_non_regular_session_even_with_exact_approval() -> (
+    None
+):
     route = FakeKisMockPlaceOrder()
     approval = expected_kis_mock_submit_approval_text(
         symbol="005930", side="buy", quantity=1, price=Decimal("229500")
     )
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="submit-mock",
             symbol="005930",
@@ -177,13 +184,14 @@ def test_submit_mock_rejects_non_regular_session_even_with_exact_approval() -> N
 
 
 @pytest.mark.unit
-def test_submit_mock_rejects_quantity_above_one_by_default() -> None:
+@pytest.mark.asyncio
+async def test_submit_mock_rejects_quantity_above_one_by_default() -> None:
     route = FakeKisMockPlaceOrder()
     approval = expected_kis_mock_submit_approval_text(
         symbol="005930", side="buy", quantity=2, price=Decimal("229500")
     )
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="submit-mock",
             symbol="005930",
@@ -269,7 +277,8 @@ def test_submit_mock_rejects_quantity_above_one_by_default() -> None:
         ),
     ],
 )
-def test_runner_rejects_unsafe_request_shape_before_any_route_call(
+@pytest.mark.asyncio
+async def test_runner_rejects_unsafe_request_shape_before_any_route_call(
     symbol: str,
     side: str,
     quantity: int,
@@ -280,7 +289,7 @@ def test_runner_rejects_unsafe_request_shape_before_any_route_call(
 ) -> None:
     route = FakeKisMockPlaceOrder()
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="dry-run",
             symbol=symbol,
@@ -300,13 +309,16 @@ def test_runner_rejects_unsafe_request_shape_before_any_route_call(
 
 
 @pytest.mark.unit
-def test_submit_mock_with_exact_approval_calls_typed_route_with_dry_run_false() -> None:
+@pytest.mark.asyncio
+async def test_submit_mock_with_exact_approval_calls_typed_route_with_dry_run_false() -> (
+    None
+):
     route = FakeKisMockPlaceOrder()
     approval = expected_kis_mock_submit_approval_text(
         symbol="005930", side="buy", quantity=1, price=Decimal("229500")
     )
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="submit-mock",
             symbol="005930",
@@ -337,7 +349,8 @@ def test_submit_mock_with_exact_approval_calls_typed_route_with_dry_run_false() 
 
 
 @pytest.mark.unit
-def test_report_classification_separates_acceptance_from_inferred_fill() -> None:
+@pytest.mark.asyncio
+async def test_report_classification_separates_acceptance_from_inferred_fill() -> None:
     assert (
         classify_kis_mock_market_open_report(
             response={"ok": True, "fill_recorded": False, "journal_created": False},

--- a/tests/test_kis_mock_market_open_pilot.py
+++ b/tests/test_kis_mock_market_open_pilot.py
@@ -127,6 +127,31 @@ def test_submit_mock_rejects_missing_exact_approval_text_without_calling_route()
 
 
 @pytest.mark.unit
+def test_submit_mock_rejects_whitespace_variation_in_approval_text() -> None:
+    route = FakeKisMockPlaceOrder()
+    approval = expected_kis_mock_submit_approval_text(
+        symbol="005930", side="buy", quantity=1, price=Decimal("229500")
+    )
+
+    result = run_kis_mock_market_open_pilot(
+        KisMockMarketOpenPilotRequest(
+            mode="submit-mock",
+            symbol="005930",
+            side="buy",
+            quantity=1,
+            price=Decimal("229500"),
+            approval_text=f" {approval} ",
+        ),
+        kis_mock_place_order=route,
+        is_regular_session=lambda: True,
+    )
+
+    assert result.status == "blocked"
+    assert result.blocking_reasons == ["approval_text_mismatch"]
+    assert route.calls == []
+
+
+@pytest.mark.unit
 def test_submit_mock_rejects_non_regular_session_even_with_exact_approval() -> None:
     route = FakeKisMockPlaceOrder()
     approval = expected_kis_mock_submit_approval_text(


### PR DESCRIPTION
## Summary
- make the KIS mock market-open pilot runner async-compatible with the production async typed mock route
- warn when KR buy previews fall back to the implicit 1-share quantity default
- anchor the KIS mock bridge import allowlist test to the test file path

## Verification
- uv run pytest tests/services/test_preopen_paper_approval_bridge.py tests/services/test_kis_mock_preopen_approval_bridge.py tests/test_kis_mock_market_open_pilot.py
- make lint

## Safety
- KIS mock-only code/test changes
- no KIS live route, no generic broker execution, no broker/order action, no scheduler change, no DB mutation
- no credentials/tokens/connection strings printed