### PR TITLE
fix(ROB-95): address KIS mock pilot review feedback

### DIFF
--- a/app/services/kis_mock_market_open_pilot.py
+++ b/app/services/kis_mock_market_open_pilot.py
@@ -7,7 +7,7 @@ broker, MCP, KIS client, DB, cache, network, or scheduler modules.
 
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Any, Literal
@@ -158,10 +158,10 @@ def classify_kis_mock_market_open_report(
     return "accepted_but_fill_unknown"
 
 
-def run_kis_mock_market_open_pilot(
+async def run_kis_mock_market_open_pilot(
     request: KisMockMarketOpenPilotRequest,
     *,
-    kis_mock_place_order: Callable[..., Mapping[str, Any]],
+    kis_mock_place_order: Callable[..., Awaitable[Mapping[str, Any]]],
     is_regular_session: Callable[[], bool],
     readiness_probe: Callable[[], Mapping[str, Any]] | None = None,
 ) -> KisMockMarketOpenPilotResult:
@@ -191,7 +191,7 @@ def run_kis_mock_market_open_pilot(
 
     if request.mode == "dry-run":
         response = dict(
-            kis_mock_place_order(
+            await kis_mock_place_order(
                 symbol=request.symbol,
                 side=request.side,
                 order_type=request.order_type,
@@ -245,7 +245,7 @@ def run_kis_mock_market_open_pilot(
         )
 
     response = dict(
-        kis_mock_place_order(
+        await kis_mock_place_order(
             symbol=request.symbol,
             side=request.side,
             order_type=request.order_type,

--- a/app/services/kis_mock_preopen_approval_bridge.py
+++ b/app/services/kis_mock_preopen_approval_bridge.py
@@ -81,6 +81,10 @@ def _build_kr_candidate(
     quantity = int(candidate.proposed_qty) if candidate.proposed_qty is not None else 1
     price = str(int(candidate.proposed_price))
 
+    candidate_warnings = list(candidate.warnings)
+    if candidate.proposed_qty is None:
+        candidate_warnings.append("default_quantity_used:1")
+
     preview_payload = {
         "tool": "kis_mock_place_order",
         "symbol": candidate.symbol,
@@ -96,7 +100,6 @@ def _build_kr_candidate(
         "requires_final_mock_submit_approval": True,
     }
 
-    candidate_warnings = list(candidate.warnings)
     status = "warning" if bridge_has_warnings or candidate_warnings else "available"
 
     return PreopenPaperApprovalCandidate(

--- a/tests/services/test_kis_mock_preopen_approval_bridge.py
+++ b/tests/services/test_kis_mock_preopen_approval_bridge.py
@@ -93,6 +93,24 @@ def test_ready_kr_buy_candidate_builds_kis_mock_dry_run_preview_metadata() -> No
 
 
 @pytest.mark.unit
+def test_ready_kr_buy_with_implicit_quantity_is_warning_tagged() -> None:
+    bridge = build_kis_mock_preopen_approval_bridge(
+        has_run=True,
+        market_scope="kr",
+        candidates=[_candidate(proposed_qty=None)],
+        briefing_artifact=_artifact(),
+        qa_evaluator=_qa(),
+    )
+
+    assert bridge.status == "warning"
+    item = bridge.candidates[0]
+    assert item.status == "warning"
+    assert item.preview_payload is not None
+    assert item.preview_payload["quantity"] == 1
+    assert item.warnings == ["default_quantity_used:1"]
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("candidate", "expected_reason"),
     [
@@ -300,7 +318,12 @@ def test_high_severity_qa_failure_blocks_kis_mock_bridge() -> None:
 
 @pytest.mark.unit
 def test_kis_mock_bridge_module_imports_only_pure_allowed_modules() -> None:
-    path = Path("app/services/kis_mock_preopen_approval_bridge.py")
+    path = (
+        Path(__file__).parent.parent.parent
+        / "app"
+        / "services"
+        / "kis_mock_preopen_approval_bridge.py"
+    )
     imported_modules = [
         node.module
         for node in ast.walk(ast.parse(path.read_text()))

--- a/tests/test_kis_mock_market_open_pilot.py
+++ b/tests/test_kis_mock_market_open_pilot.py
@@ -18,7 +18,7 @@ class FakeKisMockPlaceOrder:
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []
 
-    def __call__(self, **kwargs: object) -> dict[str, object]:
+    async def __call__(self, **kwargs: object) -> dict[str, object]:
         self.calls.append(kwargs)
         return {
             "ok": True,
@@ -31,10 +31,11 @@ class FakeKisMockPlaceOrder:
 
 
 @pytest.mark.unit
-def test_readiness_mode_is_read_only_and_reports_guard_configuration() -> None:
+@pytest.mark.asyncio
+async def test_readiness_mode_is_read_only_and_reports_guard_configuration() -> None:
     route = FakeKisMockPlaceOrder()
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="readiness",
             symbol="005930",
@@ -58,12 +59,13 @@ def test_readiness_mode_is_read_only_and_reports_guard_configuration() -> None:
 
 
 @pytest.mark.unit
-def test_dry_run_calls_only_typed_kis_mock_place_order_with_forced_dry_run_true() -> (
+@pytest.mark.asyncio
+async def test_dry_run_calls_only_typed_kis_mock_place_order_with_forced_dry_run_true() -> (
     None
 ):
     route = FakeKisMockPlaceOrder()
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="dry-run",
             symbol="005930",
@@ -100,12 +102,13 @@ def test_dry_run_calls_only_typed_kis_mock_place_order_with_forced_dry_run_true(
 
 
 @pytest.mark.unit
-def test_submit_mock_rejects_missing_exact_approval_text_without_calling_route() -> (
+@pytest.mark.asyncio
+async def test_submit_mock_rejects_missing_exact_approval_text_without_calling_route() -> (
     None
 ):
     route = FakeKisMockPlaceOrder()
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="submit-mock",
             symbol="005930",
@@ -127,13 +130,14 @@ def test_submit_mock_rejects_missing_exact_approval_text_without_calling_route()
 
 
 @pytest.mark.unit
-def test_submit_mock_rejects_whitespace_variation_in_approval_text() -> None:
+@pytest.mark.asyncio
+async def test_submit_mock_rejects_whitespace_variation_in_approval_text() -> None:
     route = FakeKisMockPlaceOrder()
     approval = expected_kis_mock_submit_approval_text(
         symbol="005930", side="buy", quantity=1, price=Decimal("229500")
     )
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="submit-mock",
             symbol="005930",
@@ -152,13 +156,16 @@ def test_submit_mock_rejects_whitespace_variation_in_approval_text() -> None:
 
 
 @pytest.mark.unit
-def test_submit_mock_rejects_non_regular_session_even_with_exact_approval() -> None:
+@pytest.mark.asyncio
+async def test_submit_mock_rejects_non_regular_session_even_with_exact_approval() -> (
+    None
+):
     route = FakeKisMockPlaceOrder()
     approval = expected_kis_mock_submit_approval_text(
         symbol="005930", side="buy", quantity=1, price=Decimal("229500")
     )
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="submit-mock",
             symbol="005930",
@@ -177,13 +184,14 @@ def test_submit_mock_rejects_non_regular_session_even_with_exact_approval() -> N
 
 
 @pytest.mark.unit
-def test_submit_mock_rejects_quantity_above_one_by_default() -> None:
+@pytest.mark.asyncio
+async def test_submit_mock_rejects_quantity_above_one_by_default() -> None:
     route = FakeKisMockPlaceOrder()
     approval = expected_kis_mock_submit_approval_text(
         symbol="005930", side="buy", quantity=2, price=Decimal("229500")
     )
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="submit-mock",
             symbol="005930",
@@ -269,7 +277,8 @@ def test_submit_mock_rejects_quantity_above_one_by_default() -> None:
         ),
     ],
 )
-def test_runner_rejects_unsafe_request_shape_before_any_route_call(
+@pytest.mark.asyncio
+async def test_runner_rejects_unsafe_request_shape_before_any_route_call(
     symbol: str,
     side: str,
     quantity: int,
@@ -280,7 +289,7 @@ def test_runner_rejects_unsafe_request_shape_before_any_route_call(
 ) -> None:
     route = FakeKisMockPlaceOrder()
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="dry-run",
             symbol=symbol,
@@ -300,13 +309,16 @@ def test_runner_rejects_unsafe_request_shape_before_any_route_call(
 
 
 @pytest.mark.unit
-def test_submit_mock_with_exact_approval_calls_typed_route_with_dry_run_false() -> None:
+@pytest.mark.asyncio
+async def test_submit_mock_with_exact_approval_calls_typed_route_with_dry_run_false() -> (
+    None
+):
     route = FakeKisMockPlaceOrder()
     approval = expected_kis_mock_submit_approval_text(
         symbol="005930", side="buy", quantity=1, price=Decimal("229500")
     )
 
-    result = run_kis_mock_market_open_pilot(
+    result = await run_kis_mock_market_open_pilot(
         KisMockMarketOpenPilotRequest(
             mode="submit-mock",
             symbol="005930",
@@ -337,7 +349,8 @@ def test_submit_mock_with_exact_approval_calls_typed_route_with_dry_run_false() 
 
 
 @pytest.mark.unit
-def test_report_classification_separates_acceptance_from_inferred_fill() -> None:
+@pytest.mark.asyncio
+async def test_report_classification_separates_acceptance_from_inferred_fill() -> None:
     assert (
         classify_kis_mock_market_open_report(
             response={"ok": True, "fill_recorded": False, "journal_created": False},


### PR DESCRIPTION
## Summary
- make the KIS mock market-open pilot runner async-compatible with the production async typed mock route
- warn when KR buy previews fall back to the implicit 1-share quantity default
- anchor the KIS mock bridge import allowlist test to the test file path

## Verification
- uv run pytest tests/services/test_preopen_paper_approval_bridge.py tests/services/test_kis_mock_preopen_approval_bridge.py tests/test_kis_mock_market_open_pilot.py
- make lint

## Safety
- KIS mock-only code/test changes
- no KIS live route, no generic broker execution, no broker/order action, no scheduler change, no DB mutation
- no credentials/tokens/connection strings printed

Supersedes closed PR #664, which was opened from a dirty post-squash branch.