### PR TITLE
ROB-99: add crypto pending-order reminders

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -229,6 +229,13 @@ class Settings(BaseSettings):
     discord_webhook_crypto: str | None = None
     discord_webhook_alerts: str | None = None
 
+    # ROB-99 — crypto pending-order reminders
+    crypto_pending_order_alert_enabled: bool = False
+    crypto_pending_order_alert_channel_id: str = "1500719153508515870"
+    crypto_pending_order_failure_channel_id: str = "1500722535678083102"
+    crypto_pending_order_alert_webhook_url: str | None = None
+    crypto_pending_order_failure_webhook_url: str | None = None
+
     # Strategy
     top_n: int = 30
     drop_pct: float = -3.0  # '-3'은 -3 %

--- a/app/jobs/crypto_pending_order_alert_runner.py
+++ b/app/jobs/crypto_pending_order_alert_runner.py
@@ -1,0 +1,18 @@
+"""Scheduler-agnostic runner for ROB-99 crypto pending-order reminders."""
+
+from __future__ import annotations
+
+from app.services.crypto_pending_order_alert_service import (
+    run_crypto_pending_order_alert,
+)
+
+
+async def run_crypto_pending_order_reminder(
+    *, execute: bool = True
+) -> dict[str, object]:
+    """Run the read-only crypto pending-order reminder.
+
+    TaskIQ/Prefect/CLI wrappers should call this thin function rather than
+    duplicating broker lookup, formatting, or delivery policy.
+    """
+    return await run_crypto_pending_order_alert(execute=execute)

--- a/app/services/crypto_pending_order_alert_service.py
+++ b/app/services/crypto_pending_order_alert_service.py
@@ -1,0 +1,546 @@
+"""Read-only crypto pending-order reminder service (ROB-99)."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+from app.mcp_server.tooling.orders_history import get_order_history_impl
+from app.monitoring.trade_notifier.transports import send_discord_content_single
+from app.services.brokers.upbit.client import fetch_multiple_current_prices
+
+logger = logging.getLogger(__name__)
+
+NORMAL_CHANNEL_ID = "1500719153508515870"
+FAILURE_CHANNEL_ID = "1500722535678083102"
+SERVICE_NAME = "crypto_pending_order_alert"
+READ_ONLY_NOTICE = "읽기 전용 미체결 주문 리마인더입니다. 보유/취소 추천이 아닙니다."
+MAX_DISCORD_CONTENT_CHARS = 1900
+MAX_LISTED_ORDERS = 12
+
+OrderLookup = Callable[[], Awaitable[dict[str, Any]]]
+PriceLookup = Callable[[list[str]], Awaitable[dict[str, float]]]
+DiscordSender = Callable[[str, str], Awaitable[bool]]
+
+
+@dataclass(frozen=True)
+class PendingCryptoOrder:
+    exchange: str
+    account: str
+    symbol: str
+    side: str
+    status: str
+    order_price: float | None
+    current_price: float | None
+    gap_pct: float | None
+    remaining_qty: float | None
+    ordered_qty: float | None
+    estimated_remaining_krw: float | None
+    ordered_at: str | None
+    age: str | None
+    order_ref: str
+
+
+@dataclass(frozen=True)
+class CryptoPendingOrderAlertConfig:
+    enabled: bool
+    normal_channel_id: str
+    failure_channel_id: str
+    normal_webhook_url: str | None
+    failure_webhook_url: str | None
+    trader_base_url: str
+
+    @classmethod
+    def from_settings(
+        cls, settings_obj: Any = settings
+    ) -> CryptoPendingOrderAlertConfig:
+        return cls(
+            enabled=bool(
+                getattr(settings_obj, "crypto_pending_order_alert_enabled", False)
+            ),
+            normal_channel_id=str(
+                getattr(
+                    settings_obj,
+                    "crypto_pending_order_alert_channel_id",
+                    NORMAL_CHANNEL_ID,
+                )
+            ),
+            failure_channel_id=str(
+                getattr(
+                    settings_obj,
+                    "crypto_pending_order_failure_channel_id",
+                    FAILURE_CHANNEL_ID,
+                )
+            ),
+            normal_webhook_url=getattr(
+                settings_obj, "crypto_pending_order_alert_webhook_url", None
+            ),
+            failure_webhook_url=getattr(
+                settings_obj, "crypto_pending_order_failure_webhook_url", None
+            ),
+            trader_base_url=str(getattr(settings_obj, "trader_base_url", "") or ""),
+        )
+
+
+def _safe_float(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _fmt_money(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"₩{value:,.0f}"
+
+
+def _fmt_qty(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.8f}".rstrip("0").rstrip(".")
+
+
+def _fmt_pct(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:+.2f}%"
+
+
+def _short_ref(order_id: Any) -> str:
+    raw = str(order_id or "").strip()
+    if not raw:
+        return "n/a"
+    return raw[:8]
+
+
+def _parse_ordered_at(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    raw = value.strip()
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _human_age(ordered_at: str | None, *, now: datetime) -> str | None:
+    created = _parse_ordered_at(ordered_at)
+    if created is None:
+        return None
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=UTC)
+    delta = now.astimezone(UTC) - created.astimezone(UTC)
+    total_minutes = max(int(delta.total_seconds() // 60), 0)
+    days, rem_minutes = divmod(total_minutes, 1440)
+    hours, minutes = divmod(rem_minutes, 60)
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {minutes}m"
+    return f"{minutes}m"
+
+
+def _position_url(config: CryptoPendingOrderAlertConfig, symbol: str) -> str | None:
+    base = config.trader_base_url.strip().rstrip("/")
+    if not base:
+        return None
+    return f"{base}/portfolio?market=crypto&symbol={symbol}"
+
+
+def normalize_pending_orders(
+    orders: list[dict[str, Any]],
+    prices: dict[str, float],
+    *,
+    now: datetime | None = None,
+) -> list[PendingCryptoOrder]:
+    now = now or datetime.now(UTC)
+    normalized: list[PendingCryptoOrder] = []
+    for order in orders:
+        symbol = str(order.get("symbol") or "").upper()
+        current_price = prices.get(symbol)
+        order_price = _safe_float(order.get("ordered_price"))
+        remaining_qty = _safe_float(order.get("remaining_qty"))
+        ordered_qty = _safe_float(order.get("ordered_qty"))
+        gap_pct = None
+        if order_price is not None and current_price:
+            gap_pct = ((order_price - current_price) / current_price) * 100
+        estimated_remaining_krw = None
+        if remaining_qty is not None and order_price is not None:
+            estimated_remaining_krw = remaining_qty * order_price
+        ordered_at = str(order.get("ordered_at") or "") or None
+        normalized.append(
+            PendingCryptoOrder(
+                exchange="Upbit",
+                account="default",
+                symbol=symbol,
+                side=str(order.get("side") or "unknown"),
+                status=str(order.get("status") or "unknown"),
+                order_price=order_price,
+                current_price=current_price,
+                gap_pct=gap_pct,
+                remaining_qty=remaining_qty,
+                ordered_qty=ordered_qty,
+                estimated_remaining_krw=estimated_remaining_krw,
+                ordered_at=ordered_at,
+                age=_human_age(ordered_at, now=now),
+                order_ref=_short_ref(order.get("order_id")),
+            )
+        )
+    return normalized
+
+
+def format_pending_order_message(
+    orders: list[PendingCryptoOrder],
+    *,
+    config: CryptoPendingOrderAlertConfig,
+    run_ts: datetime | None = None,
+) -> str:
+    run_ts = run_ts or datetime.now(UTC)
+    lines = [
+        f"🔔 **Crypto pending orders: {len(orders)} open**",
+        READ_ONLY_NOTICE,
+        f"Channel: <#{config.normal_channel_id}>",
+        f"Run: {run_ts.isoformat()}",
+        "",
+    ]
+    omitted_count = max(len(orders) - MAX_LISTED_ORDERS, 0)
+    for idx, order in enumerate(orders[:MAX_LISTED_ORDERS], 1):
+        link = _position_url(config, order.symbol)
+        title = f"{idx}. `{order.symbol}` {order.side.upper()} ({order.status})"
+        if link:
+            title += f" — {link}"
+        lines.extend(
+            [
+                title,
+                f"   • order/current/gap: {_fmt_money(order.order_price)} / {_fmt_money(order.current_price)} / {_fmt_pct(order.gap_pct)}",
+                f"   • remaining/original: {_fmt_qty(order.remaining_qty)} / {_fmt_qty(order.ordered_qty)}",
+                f"   • remaining value: {_fmt_money(order.estimated_remaining_krw)}",
+                f"   • ordered_at/age/ref: {order.ordered_at or 'n/a'} / {order.age or 'n/a'} / `{order.order_ref}`",
+            ]
+        )
+    if omitted_count:
+        lines.append(
+            f"…and {omitted_count} more pending order(s) omitted to fit Discord content limits."
+        )
+    message = "\n".join(lines)
+    if len(message) > MAX_DISCORD_CONTENT_CHARS:
+        return (
+            message[: MAX_DISCORD_CONTENT_CHARS - 80].rstrip()
+            + "\n…truncated to fit Discord content limits."
+        )
+    return message
+
+
+def format_failure_message(
+    *,
+    stage: str,
+    reason: str,
+    failure_class: str,
+    partial: bool,
+    run_ts: datetime | None = None,
+    hint: str | None = None,
+    config: CryptoPendingOrderAlertConfig | None = None,
+) -> str:
+    run_ts = run_ts or datetime.now(UTC)
+    channel_id = config.failure_channel_id if config else FAILURE_CHANNEL_ID
+    lines = [
+        f"🚨 **{SERVICE_NAME} failure**",
+        f"Channel: <#{channel_id}>",
+        f"Stage: `{stage}`",
+        f"Class: `{failure_class}`",
+        f"Partial data: `{str(partial).lower()}`",
+        f"Run: {run_ts.isoformat()}",
+        f"Reason: {reason}",
+    ]
+    if hint:
+        lines.append(f"Hint: {hint}")
+    return "\n".join(lines)
+
+
+def _validate_order_symbols(
+    orders: list[dict[str, Any]],
+) -> tuple[list[str], list[str]]:
+    symbols: list[str] = []
+    malformed_refs: list[str] = []
+    seen: set[str] = set()
+    for order in orders:
+        symbol = str(order.get("symbol") or "").strip().upper()
+        if not symbol or "-" not in symbol:
+            malformed_refs.append(_short_ref(order.get("order_id")))
+            continue
+        if symbol not in seen:
+            seen.add(symbol)
+            symbols.append(symbol)
+    return sorted(symbols), malformed_refs
+
+
+async def _default_order_lookup() -> dict[str, Any]:
+    return await get_order_history_impl(status="pending", market="crypto", limit=-1)
+
+
+async def _default_price_lookup(symbols: list[str]) -> dict[str, float]:
+    return await fetch_multiple_current_prices(symbols, use_cache=False)
+
+
+async def _default_discord_sender(webhook_url: str, content: str) -> bool:
+    async with httpx.AsyncClient(timeout=10.0, trust_env=False) as client:
+        return await send_discord_content_single(
+            http_client=client,
+            webhook_url=webhook_url,
+            content=content,
+        )
+
+
+async def _send_failure(
+    *,
+    config: CryptoPendingOrderAlertConfig,
+    sender: DiscordSender,
+    stage: str,
+    reason: str,
+    failure_class: str,
+    partial: bool,
+    run_ts: datetime,
+    dry_run: bool,
+    hint: str | None = None,
+) -> dict[str, Any]:
+    message = format_failure_message(
+        stage=stage,
+        reason=reason,
+        failure_class=failure_class,
+        partial=partial,
+        run_ts=run_ts,
+        hint=hint,
+        config=config,
+    )
+    if dry_run:
+        return {"failure_alert_sent": False, "failure_message": message}
+    if not config.failure_webhook_url:
+        return {
+            "failure_alert_sent": False,
+            "failure_message": message,
+            "failure_delivery_error": "missing failure webhook url",
+        }
+    delivered = await sender(config.failure_webhook_url, message)
+    return {"failure_alert_sent": delivered, "failure_message": message}
+
+
+async def run_crypto_pending_order_alert(
+    *,
+    execute: bool = False,
+    config: CryptoPendingOrderAlertConfig | None = None,
+    order_lookup: OrderLookup | None = None,
+    price_lookup: PriceLookup | None = None,
+    discord_sender: DiscordSender | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Run the read-only pending-order reminder.
+
+    `execute=False` is dry-run mode and never posts to Discord.
+    """
+    config = config or CryptoPendingOrderAlertConfig.from_settings()
+    order_lookup = order_lookup or _default_order_lookup
+    price_lookup = price_lookup or _default_price_lookup
+    discord_sender = discord_sender or _default_discord_sender
+    run_ts = now or datetime.now(UTC)
+    dry_run = not execute
+
+    summary: dict[str, Any] = {
+        "service": SERVICE_NAME,
+        "execute": execute,
+        "dry_run": dry_run,
+        "enabled": config.enabled,
+        "normal_channel_id": config.normal_channel_id,
+        "failure_channel_id": config.failure_channel_id,
+        "run_ts": run_ts.isoformat(),
+    }
+
+    if execute and not config.enabled:
+        return summary | {"status": "skipped", "reason": "disabled"}
+
+    try:
+        history = await order_lookup()
+    except Exception as exc:  # noqa: BLE001
+        failure = await _send_failure(
+            config=config,
+            sender=discord_sender,
+            stage="lookup",
+            reason=f"{type(exc).__name__}: {exc}",
+            failure_class=type(exc).__name__,
+            partial=False,
+            run_ts=run_ts,
+            dry_run=dry_run,
+            hint="Check Upbit credentials/connectivity and order-history handler logs.",
+        )
+        return summary | {"status": "failed", "stage": "lookup"} | failure
+
+    orders = list(history.get("orders") or [])
+    errors = list(history.get("errors") or [])
+    if errors:
+        failure = await _send_failure(
+            config=config,
+            sender=discord_sender,
+            stage="lookup",
+            reason=f"order history returned errors: {errors}",
+            failure_class="PartialOrderLookup",
+            partial=bool(orders),
+            run_ts=run_ts,
+            dry_run=dry_run,
+            hint="Inspect broker-specific errors before trusting the reminder output.",
+        )
+        return (
+            summary
+            | {"status": "failed", "stage": "lookup", "orders_count": len(orders)}
+            | failure
+        )
+
+    if not orders:
+        return summary | {
+            "status": "success",
+            "orders_count": 0,
+            "normal_alert_sent": False,
+            "reason": "no pending crypto orders",
+        }
+
+    symbols, malformed_refs = _validate_order_symbols(orders)
+    if malformed_refs:
+        failure = await _send_failure(
+            config=config,
+            sender=discord_sender,
+            stage="order_validation",
+            reason=f"malformed pending order rows without valid crypto symbols: {malformed_refs}",
+            failure_class="MalformedOrderRows",
+            partial=True,
+            run_ts=run_ts,
+            dry_run=dry_run,
+            hint="Check the broker order-history normalization before sending a normal reminder.",
+        )
+        return (
+            summary
+            | {
+                "status": "failed",
+                "stage": "order_validation",
+                "orders_count": len(orders),
+            }
+            | failure
+        )
+
+    try:
+        prices = await price_lookup(symbols)
+    except Exception as exc:  # noqa: BLE001
+        failure = await _send_failure(
+            config=config,
+            sender=discord_sender,
+            stage="quote_enrichment",
+            reason=f"{type(exc).__name__}: {exc}",
+            failure_class=type(exc).__name__,
+            partial=True,
+            run_ts=run_ts,
+            dry_run=dry_run,
+            hint="Pending orders were found but quote enrichment failed.",
+        )
+        return (
+            summary
+            | {
+                "status": "failed",
+                "stage": "quote_enrichment",
+                "orders_count": len(orders),
+            }
+            | failure
+        )
+
+    missing_prices = [symbol for symbol in symbols if symbol not in prices]
+    if missing_prices:
+        failure = await _send_failure(
+            config=config,
+            sender=discord_sender,
+            stage="quote_enrichment",
+            reason=f"missing current prices for: {', '.join(missing_prices)}",
+            failure_class="PartialQuoteEnrichment",
+            partial=True,
+            run_ts=run_ts,
+            dry_run=dry_run,
+            hint="Verify Upbit market codes and ticker endpoint availability.",
+        )
+        return (
+            summary
+            | {
+                "status": "failed",
+                "stage": "quote_enrichment",
+                "orders_count": len(orders),
+            }
+            | failure
+        )
+
+    normalized = normalize_pending_orders(orders, prices, now=run_ts)
+    message = format_pending_order_message(normalized, config=config, run_ts=run_ts)
+    if dry_run:
+        return summary | {
+            "status": "success",
+            "orders_count": len(normalized),
+            "normal_alert_sent": False,
+            "message": message,
+            "orders": [asdict(order) for order in normalized],
+        }
+
+    if not config.normal_webhook_url:
+        failure = await _send_failure(
+            config=config,
+            sender=discord_sender,
+            stage="discord_delivery",
+            reason="missing normal webhook url",
+            failure_class="MissingDiscordWebhook",
+            partial=True,
+            run_ts=run_ts,
+            dry_run=False,
+            hint="Configure the dedicated CRYPTO_PENDING_ORDER_ALERT_WEBHOOK_URL for channel 1500719153508515870.",
+        )
+        return (
+            summary
+            | {
+                "status": "failed",
+                "stage": "discord_delivery",
+                "orders_count": len(normalized),
+            }
+            | failure
+        )
+
+    delivered = await discord_sender(config.normal_webhook_url, message)
+    if not delivered:
+        failure = await _send_failure(
+            config=config,
+            sender=discord_sender,
+            stage="discord_delivery",
+            reason="normal Discord webhook returned unsuccessful delivery",
+            failure_class="DiscordDeliveryFailed",
+            partial=True,
+            run_ts=run_ts,
+            dry_run=False,
+            hint="Check normal webhook URL/channel and Discord webhook permissions.",
+        )
+        return (
+            summary
+            | {
+                "status": "failed",
+                "stage": "discord_delivery",
+                "orders_count": len(normalized),
+            }
+            | failure
+        )
+
+    return summary | {
+        "status": "success",
+        "orders_count": len(normalized),
+        "normal_alert_sent": True,
+        "orders": [asdict(order) for order in normalized],
+    }

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -1,4 +1,5 @@
 from app.tasks import (
+    crypto_pending_order_alert_tasks,
     daily_scan_tasks,
     intraday_order_review_tasks,
     kr_candles_tasks,
@@ -12,6 +13,7 @@ from app.tasks import (
 )
 
 TASKIQ_TASK_MODULES = (
+    crypto_pending_order_alert_tasks,
     daily_scan_tasks,
     intraday_order_review_tasks,
     research_run_refresh_tasks,

--- a/app/tasks/crypto_pending_order_alert_tasks.py
+++ b/app/tasks/crypto_pending_order_alert_tasks.py
@@ -1,0 +1,29 @@
+"""ROB-99 — scheduled crypto pending-order reminders.
+
+Current repository scheduling is TaskIQ-based. The job runner is intentionally
+scheduler-agnostic so a Prefect deployment can call the same entrypoint without
+changing broker lookup or notification policy.
+"""
+
+from __future__ import annotations
+
+from app.core.taskiq_broker import broker
+from app.jobs.crypto_pending_order_alert_runner import run_crypto_pending_order_reminder
+
+_KST = "Asia/Seoul"
+
+
+@broker.task(
+    task_name="crypto.pending_orders.reminder_0830",
+    schedule=[{"cron": "30 8 * * *", "cron_offset": _KST}],
+)
+async def crypto_pending_orders_reminder_0830() -> dict[str, object]:
+    return await run_crypto_pending_order_reminder(execute=True)
+
+
+@broker.task(
+    task_name="crypto.pending_orders.reminder_2200",
+    schedule=[{"cron": "0 22 * * *", "cron_offset": _KST}],
+)
+async def crypto_pending_orders_reminder_2200() -> dict[str, object]:
+    return await run_crypto_pending_order_reminder(execute=True)

--- a/scripts/run_crypto_pending_order_alert.py
+++ b/scripts/run_crypto_pending_order_alert.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Run the ROB-99 crypto pending-order alert manually.
+
+Default mode is dry-run and never posts to Discord:
+    uv run python scripts/run_crypto_pending_order_alert.py --dry-run
+
+Execute mode applies the notification policy:
+    uv run python scripts/run_crypto_pending_order_alert.py --execute
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+from app.services.crypto_pending_order_alert_service import (
+    run_crypto_pending_order_alert,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print summary only; no Discord send (default).",
+    )
+    mode.add_argument(
+        "--execute",
+        action="store_true",
+        help="Send Discord alerts according to policy.",
+    )
+    return parser.parse_args()
+
+
+async def _main() -> int:
+    args = parse_args()
+    result = await run_crypto_pending_order_alert(execute=bool(args.execute))
+    print(json.dumps(result, ensure_ascii=False, indent=2, default=str))
+    return 0 if result.get("status") in {"success", "skipped"} else 1
+
+
+def main() -> None:
+    raise SystemExit(asyncio.run(_main()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_crypto_pending_order_alert_service.py
+++ b/tests/test_crypto_pending_order_alert_service.py
@@ -1,0 +1,346 @@
+"""ROB-99 crypto pending-order reminder tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+
+from app.services.crypto_pending_order_alert_service import (
+    CryptoPendingOrderAlertConfig,
+    format_pending_order_message,
+    normalize_pending_orders,
+    run_crypto_pending_order_alert,
+)
+
+NOW = datetime(2026, 5, 4, 0, 0, tzinfo=UTC)
+
+
+def _config() -> CryptoPendingOrderAlertConfig:
+    return CryptoPendingOrderAlertConfig(
+        enabled=True,
+        normal_channel_id="1500719153508515870",
+        failure_channel_id="1500722535678083102",
+        normal_webhook_url="https://discord.example/normal",
+        failure_webhook_url="https://discord.example/failure",
+        trader_base_url="https://trader.robinco.dev",
+    )
+
+
+def _order(
+    *,
+    symbol: str = "KRW-BTC",
+    side: str = "sell",
+    order_id: str = "12345678-aaaa-bbbb-cccc-123456789abc",
+    price: float = 100_000_000,
+    remaining: float = 0.1,
+    ordered: float = 0.2,
+) -> dict[str, Any]:
+    return {
+        "order_id": order_id,
+        "symbol": symbol,
+        "side": side,
+        "status": "pending",
+        "ordered_price": price,
+        "remaining_qty": remaining,
+        "ordered_qty": ordered,
+        "ordered_at": "2026-05-03T23:00:00+00:00",
+    }
+
+
+def test_from_settings_requires_dedicated_webhooks():
+    class DummySettings:
+        crypto_pending_order_alert_enabled = True
+        crypto_pending_order_alert_channel_id = "1500719153508515870"
+        crypto_pending_order_failure_channel_id = "1500722535678083102"
+        crypto_pending_order_alert_webhook_url = None
+        crypto_pending_order_failure_webhook_url = None
+        discord_webhook_crypto = "https://discord.example/generic-crypto"
+        discord_webhook_alerts = "https://discord.example/generic-alerts"
+        trader_base_url = ""
+
+    config = CryptoPendingOrderAlertConfig.from_settings(DummySettings())
+
+    assert config.normal_webhook_url is None
+    assert config.failure_webhook_url is None
+
+
+@pytest.mark.asyncio
+async def test_no_orders_is_quiet_success():
+    sends: list[tuple[str, str]] = []
+
+    async def lookup() -> dict[str, Any]:
+        return {"success": True, "orders": [], "errors": []}
+
+    async def sender(webhook: str, content: str) -> bool:
+        sends.append((webhook, content))
+        return True
+
+    result = await run_crypto_pending_order_alert(
+        execute=True,
+        config=_config(),
+        order_lookup=lookup,
+        discord_sender=sender,
+        now=NOW,
+    )
+
+    assert result["status"] == "success"
+    assert result["orders_count"] == 0
+    assert result["normal_alert_sent"] is False
+    assert sends == []
+
+
+@pytest.mark.asyncio
+async def test_one_sell_order_sends_normal_payload():
+    sends: list[tuple[str, str]] = []
+
+    async def lookup() -> dict[str, Any]:
+        return {"success": True, "orders": [_order(side="sell")], "errors": []}
+
+    async def prices(symbols: list[str]) -> dict[str, float]:
+        assert symbols == ["KRW-BTC"]
+        return {"KRW-BTC": 95_000_000}
+
+    async def sender(webhook: str, content: str) -> bool:
+        sends.append((webhook, content))
+        return True
+
+    result = await run_crypto_pending_order_alert(
+        execute=True,
+        config=_config(),
+        order_lookup=lookup,
+        price_lookup=prices,
+        discord_sender=sender,
+        now=NOW,
+    )
+
+    assert result["status"] == "success"
+    assert result["normal_alert_sent"] is True
+    assert len(sends) == 1
+    assert sends[0][0] == "https://discord.example/normal"
+    assert "KRW-BTC" in sends[0][1]
+    assert "SELL" in sends[0][1]
+    assert "+5.26%" in sends[0][1]
+    assert "보유/취소 추천이 아닙니다" in sends[0][1]
+
+
+@pytest.mark.asyncio
+async def test_one_buy_order_sends_normal_payload():
+    sends: list[tuple[str, str]] = []
+
+    async def lookup() -> dict[str, Any]:
+        return {
+            "success": True,
+            "orders": [_order(side="buy", price=90_000_000)],
+            "errors": [],
+        }
+
+    async def prices(symbols: list[str]) -> dict[str, float]:
+        return {"KRW-BTC": 95_000_000}
+
+    async def sender(webhook: str, content: str) -> bool:
+        sends.append((webhook, content))
+        return True
+
+    result = await run_crypto_pending_order_alert(
+        execute=True,
+        config=_config(),
+        order_lookup=lookup,
+        price_lookup=prices,
+        discord_sender=sender,
+        now=NOW,
+    )
+
+    assert result["status"] == "success"
+    assert "BUY" in sends[0][1]
+    assert "-5.26%" in sends[0][1]
+
+
+@pytest.mark.asyncio
+async def test_multiple_orders_are_grouped_in_one_message():
+    sends: list[tuple[str, str]] = []
+
+    async def lookup() -> dict[str, Any]:
+        return {
+            "success": True,
+            "orders": [
+                _order(
+                    symbol="KRW-BTC", order_id="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+                ),
+                _order(
+                    symbol="KRW-ETH",
+                    order_id="bbbbbbbb-bbbb-cccc-dddd-eeeeeeeeeeee",
+                    price=4_000_000,
+                ),
+            ],
+            "errors": [],
+        }
+
+    async def prices(symbols: list[str]) -> dict[str, float]:
+        assert symbols == ["KRW-BTC", "KRW-ETH"]
+        return {"KRW-BTC": 95_000_000, "KRW-ETH": 4_100_000}
+
+    async def sender(webhook: str, content: str) -> bool:
+        sends.append((webhook, content))
+        return True
+
+    result = await run_crypto_pending_order_alert(
+        execute=True,
+        config=_config(),
+        order_lookup=lookup,
+        price_lookup=prices,
+        discord_sender=sender,
+        now=NOW,
+    )
+
+    assert result["status"] == "success"
+    assert result["orders_count"] == 2
+    assert len(sends) == 1
+    assert "Crypto pending orders: 2 open" in sends[0][1]
+    assert "KRW-BTC" in sends[0][1]
+    assert "KRW-ETH" in sends[0][1]
+
+
+@pytest.mark.asyncio
+async def test_malformed_order_symbol_routes_to_failure_alert():
+    sends: list[tuple[str, str]] = []
+
+    async def lookup() -> dict[str, Any]:
+        return {"success": True, "orders": [_order(symbol="")], "errors": []}
+
+    async def sender(webhook: str, content: str) -> bool:
+        sends.append((webhook, content))
+        return True
+
+    result = await run_crypto_pending_order_alert(
+        execute=True,
+        config=_config(),
+        order_lookup=lookup,
+        discord_sender=sender,
+        now=NOW,
+    )
+
+    assert result["status"] == "failed"
+    assert result["stage"] == "order_validation"
+    assert result["failure_alert_sent"] is True
+    assert len(sends) == 1
+    assert sends[0][0] == "https://discord.example/failure"
+    assert "MalformedOrderRows" in sends[0][1]
+
+
+@pytest.mark.asyncio
+async def test_lookup_failure_sends_failure_alert():
+    sends: list[tuple[str, str]] = []
+
+    async def lookup() -> dict[str, Any]:
+        raise RuntimeError("upbit unavailable")
+
+    async def sender(webhook: str, content: str) -> bool:
+        sends.append((webhook, content))
+        return True
+
+    result = await run_crypto_pending_order_alert(
+        execute=True,
+        config=_config(),
+        order_lookup=lookup,
+        discord_sender=sender,
+        now=NOW,
+    )
+
+    assert result["status"] == "failed"
+    assert result["stage"] == "lookup"
+    assert result["failure_alert_sent"] is True
+    assert sends[0][0] == "https://discord.example/failure"
+    assert "upbit unavailable" in sends[0][1]
+
+
+@pytest.mark.asyncio
+async def test_partial_lookup_result_sends_failure_alert():
+    sends: list[tuple[str, str]] = []
+
+    async def lookup() -> dict[str, Any]:
+        return {
+            "success": False,
+            "orders": [_order()],
+            "errors": [{"market": "crypto", "error": "partial"}],
+        }
+
+    async def sender(webhook: str, content: str) -> bool:
+        sends.append((webhook, content))
+        return True
+
+    result = await run_crypto_pending_order_alert(
+        execute=True,
+        config=_config(),
+        order_lookup=lookup,
+        discord_sender=sender,
+        now=NOW,
+    )
+
+    assert result["status"] == "failed"
+    assert result["failure_alert_sent"] is True
+    assert "PartialOrderLookup" in sends[0][1]
+    assert "partial data: `true`".lower() in sends[0][1].lower()
+
+
+@pytest.mark.asyncio
+async def test_normal_delivery_failure_is_surfaced_and_failure_alert_sent():
+    sends: list[tuple[str, str]] = []
+
+    async def lookup() -> dict[str, Any]:
+        return {"success": True, "orders": [_order()], "errors": []}
+
+    async def prices(symbols: list[str]) -> dict[str, float]:
+        return {"KRW-BTC": 95_000_000}
+
+    async def sender(webhook: str, content: str) -> bool:
+        sends.append((webhook, content))
+        return webhook.endswith("failure")
+
+    result = await run_crypto_pending_order_alert(
+        execute=True,
+        config=_config(),
+        order_lookup=lookup,
+        price_lookup=prices,
+        discord_sender=sender,
+        now=NOW,
+    )
+
+    assert result["status"] == "failed"
+    assert result["stage"] == "discord_delivery"
+    assert result["failure_alert_sent"] is True
+    assert [webhook for webhook, _ in sends] == [
+        "https://discord.example/normal",
+        "https://discord.example/failure",
+    ]
+
+
+def test_formatter_caps_long_message_for_discord_content_limit():
+    orders = normalize_pending_orders(
+        [
+            _order(
+                symbol=f"KRW-COIN{idx}",
+                order_id=f"{idx:08d}-aaaa-bbbb-cccc-123456789abc",
+            )
+            for idx in range(40)
+        ],
+        {f"KRW-COIN{idx}": 95_000_000 for idx in range(40)},
+        now=NOW,
+    )
+    message = format_pending_order_message(orders, config=_config(), run_ts=NOW)
+
+    assert len(message) <= 1900
+    assert "Crypto pending orders: 40 open" in message
+    assert "omitted" in message or "truncated" in message
+
+
+def test_formatter_keeps_order_id_short_and_includes_link():
+    orders = normalize_pending_orders([_order()], {"KRW-BTC": 95_000_000}, now=NOW)
+    message = format_pending_order_message(orders, config=_config(), run_ts=NOW)
+
+    assert "12345678" in message
+    assert "12345678-aaaa" not in message
+    assert (
+        "https://trader.robinco.dev/portfolio?market=crypto&symbol=KRW-BTC" in message
+    )

--- a/tests/test_crypto_pending_order_alert_tasks.py
+++ b/tests/test_crypto_pending_order_alert_tasks.py
@@ -1,0 +1,43 @@
+"""ROB-99 scheduled crypto pending-order reminder task tests."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.tasks import crypto_pending_order_alert_tasks as mod
+
+EXPECTED_SCHEDULES = {
+    "crypto_pending_orders_reminder_0830": "30 8 * * *",
+    "crypto_pending_orders_reminder_2200": "0 22 * * *",
+}
+
+
+def test_crypto_pending_order_tasks_are_registered():
+    import app.tasks as task_package
+
+    assert mod in task_package.TASKIQ_TASK_MODULES
+
+
+def test_crypto_pending_order_schedule_matrix():
+    for name, cron in EXPECTED_SCHEDULES.items():
+        task = getattr(mod, name)
+        schedules = getattr(task, "labels", {}).get("schedule") or []
+        assert any(
+            item.get("cron") == cron and item.get("cron_offset") == "Asia/Seoul"
+            for item in schedules
+        )
+
+
+@pytest.mark.asyncio
+async def test_crypto_pending_order_tasks_delegate_to_runner():
+    for name in EXPECTED_SCHEDULES:
+        task = getattr(mod, name)
+        with patch(
+            "app.tasks.crypto_pending_order_alert_tasks.run_crypto_pending_order_reminder",
+            AsyncMock(return_value={"status": "success"}),
+        ) as runner:
+            result = await task()
+            assert result == {"status": "success"}
+            runner.assert_awaited_once_with(execute=True)


### PR DESCRIPTION
## Summary
- Add read-only crypto pending-order reminder service and scheduler-agnostic runner
- Register TaskIQ reminders for 08:30 and 22:00 KST
- Send normal Discord alert only when pending crypto orders exist; no success/completion/no-order notifications
- Route lookup errors, partial/ambiguous order data, quote enrichment issues, and delivery failures to the dedicated failure webhook/channel
- Add manual dry-run/execute script and unit tests for no-order, buy/sell, multi-order, failure, malformed, and long-message cases

## Verification
- `uv run ruff check app/services/crypto_pending_order_alert_service.py app/jobs/crypto_pending_order_alert_runner.py app/tasks/crypto_pending_order_alert_tasks.py app/tasks/__init__.py app/core/config.py scripts/run_crypto_pending_order_alert.py tests/test_crypto_pending_order_alert_service.py tests/test_crypto_pending_order_alert_tasks.py`
- `uv run ty check app/services/crypto_pending_order_alert_service.py app/jobs/crypto_pending_order_alert_runner.py app/tasks/crypto_pending_order_alert_tasks.py`
- `uv run pytest tests/test_crypto_pending_order_alert_service.py tests/test_crypto_pending_order_alert_tasks.py tests/test_research_run_refresh_import_safety.py tests/test_strategy_events_import_safety.py`

## Notes
- Requires dedicated production env vars before enabling: `CRYPTO_PENDING_ORDER_ALERT_ENABLED=true`, `CRYPTO_PENDING_ORDER_ALERT_WEBHOOK_URL`, `CRYPTO_PENDING_ORDER_FAILURE_WEBHOOK_URL`.
- The service intentionally does not fall back to generic Discord webhooks, to avoid sending to the wrong channel.