### PR TITLE
feat(ROB-97): add Kiwoom mock broker foundation and MCP tools

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -179,6 +179,17 @@ class Settings(BaseSettings):
     kis_mock_account_no: str | None = None
     kis_mock_access_token: str | None = None
 
+    # Kiwoom Securities mock account. Disabled by default; mock-only foundation
+    # added in ROB-97. Live URL is recorded so the runtime can defensively
+    # reject it — no code path may target the live host in this PR.
+    kiwoom_mock_enabled: bool = False
+    kiwoom_mock_app_key: str | None = None
+    kiwoom_mock_app_secret: str | None = None
+    kiwoom_mock_account_no: str | None = None
+    kiwoom_mock_base_url: str = "https://mockapi.kiwoom.com"
+    kiwoom_base_url: str = "https://api.kiwoom.com"  # live disabled in this PR
+    kiwoom_mock_access_token: str | None = None
+
     # KIS WebSocket
     kis_ws_is_mock: bool = False  # Mock 모드 (테스트용)
     kis_ws_hts_id: str = ""  # HTS ID (WebSocket 인증용)
@@ -518,4 +529,18 @@ def validate_kis_mock_config(settings_obj: Any = settings) -> list[str]:
         missing.append("KIS_MOCK_APP_SECRET")
     if not _has_nonempty_value(getattr(settings_obj, "kis_mock_account_no", None)):
         missing.append("KIS_MOCK_ACCOUNT_NO")
+    return missing
+
+def validate_kiwoom_mock_config(settings_obj: Any = settings) -> list[str]:
+    """Return missing Kiwoom mock env names without exposing configured values."""
+
+    missing: list[str] = []
+    if not bool(getattr(settings_obj, "kiwoom_mock_enabled", False)):
+        missing.append("KIWOOM_MOCK_ENABLED")
+    if not _has_nonempty_value(getattr(settings_obj, "kiwoom_mock_app_key", None)):
+        missing.append("KIWOOM_MOCK_APP_KEY")
+    if not _has_nonempty_value(getattr(settings_obj, "kiwoom_mock_app_secret", None)):
+        missing.append("KIWOOM_MOCK_APP_SECRET")
+    if not _has_nonempty_value(getattr(settings_obj, "kiwoom_mock_account_no", None)):
+        missing.append("KIWOOM_MOCK_ACCOUNT_NO")
     return missing

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -531,6 +531,7 @@ def validate_kis_mock_config(settings_obj: Any = settings) -> list[str]:
         missing.append("KIS_MOCK_ACCOUNT_NO")
     return missing
 
+
 def validate_kiwoom_mock_config(settings_obj: Any = settings) -> list[str]:
     """Return missing Kiwoom mock env names without exposing configured values."""
 

--- a/app/mcp_server/tooling/orders_kiwoom_variants.py
+++ b/app/mcp_server/tooling/orders_kiwoom_variants.py
@@ -1,0 +1,325 @@
+# app/mcp_server/tooling/orders_kiwoom_variants.py
+"""Kiwoom mock-only MCP tools.
+
+Every tool is hard-pinned to ``account_mode="kiwoom_mock"``. They:
+- Validate ``validate_kiwoom_mock_config`` before any side effect.
+- Reject anything except KR equity (``market="kr"``).
+- Reject ``NXT``/``SOR`` exchanges.
+- Reject unsafe order ids (path separators, query fragments, whitespace,
+  commas, newlines).
+- Default order-like tools to ``dry_run=True`` and never call the broker
+  unless ``dry_run=False`` AND ``confirm=True`` are both supplied.
+
+Mirrors the structure of ``orders_kis_variants.py``.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any, Literal
+
+from app.core.config import validate_kiwoom_mock_config
+from app.services.brokers.kiwoom import constants
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+ACCOUNT_MODE_KIWOOM_MOCK = "kiwoom_mock"
+
+KIWOOM_MOCK_TOOL_NAMES: set[str] = {
+    "kiwoom_mock_preview_order",
+    "kiwoom_mock_place_order",
+    "kiwoom_mock_cancel_order",
+    "kiwoom_mock_modify_order",
+    "kiwoom_mock_get_order_history",
+    "kiwoom_mock_get_positions",
+    "kiwoom_mock_get_orderable_cash",
+}
+
+_SAFE_ORDER_ID_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
+
+
+def _mock_config_error() -> dict[str, Any] | None:
+    missing = validate_kiwoom_mock_config()
+    if not missing:
+        return None
+    return {
+        "success": False,
+        "error": (
+            "Kiwoom mock account is disabled or missing required configuration: "
+            + ", ".join(missing)
+        ),
+        "source": "kiwoom",
+        "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+    }
+
+
+def _market_error(market: str | None) -> dict[str, Any] | None:
+    if market is None:
+        return None
+    if str(market).strip().lower() != "kr":
+        return {
+            "success": False,
+            "error": "kiwoom_mock tools only support market='kr' (KR equity).",
+            "source": "kiwoom",
+            "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+        }
+    return None
+
+
+def _exchange_error(exchange: str | None) -> dict[str, Any] | None:
+    if exchange is None:
+        return None
+    value = str(exchange).strip().upper()
+    if value in constants.MOCK_REJECTED_EXCHANGES or value != constants.MOCK_EXCHANGE_KRX:
+        return {
+            "success": False,
+            "error": f"kiwoom_mock supports KRX only; rejected exchange={exchange!r}.",
+            "source": "kiwoom",
+            "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+        }
+    return None
+
+
+def _order_id_error(order_id: str) -> dict[str, Any] | None:
+    candidate = (order_id or "").strip()
+    if not candidate or not _SAFE_ORDER_ID_RE.fullmatch(candidate):
+        return {
+            "success": False,
+            "error": f"Unsafe order id rejected by kiwoom_mock: {order_id!r}",
+            "source": "kiwoom",
+            "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+        }
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Implementation seams (overridable via monkeypatch in tests).
+
+
+async def _kiwoom_mock_place_order_impl(**kwargs: Any) -> dict[str, Any]:
+    # Real implementation would build KiwoomMockClient.from_app_settings()
+    # and call KiwoomDomesticOrderClient.place_buy_order/place_sell_order.
+    # In this PR we only support dry_run; live submission is intentionally
+    # blocked at the tool boundary (see register()).
+    return {
+        "success": True,
+        "dry_run": kwargs.get("dry_run", True),
+        "side": kwargs.get("side"),
+        "symbol": kwargs.get("symbol"),
+        "quantity": kwargs.get("quantity"),
+        "price": kwargs.get("price"),
+        "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+    }
+
+
+async def _kiwoom_mock_preview_impl(**kwargs: Any) -> dict[str, Any]:
+    return {
+        "success": True,
+        "preview": True,
+        "symbol": kwargs.get("symbol"),
+        "side": kwargs.get("side"),
+        "quantity": kwargs.get("quantity"),
+        "price": kwargs.get("price"),
+        "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+    }
+
+
+async def _kiwoom_mock_cancel_impl(**kwargs: Any) -> dict[str, Any]:
+    return {
+        "success": True,
+        "dry_run": kwargs.get("dry_run", True),
+        "order_id": kwargs.get("order_id"),
+        "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+    }
+
+
+async def _kiwoom_mock_modify_impl(**kwargs: Any) -> dict[str, Any]:
+    return {
+        "success": True,
+        "dry_run": kwargs.get("dry_run", True),
+        "order_id": kwargs.get("order_id"),
+        "new_price": kwargs.get("new_price"),
+        "new_quantity": kwargs.get("new_quantity"),
+        "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+    }
+
+
+async def _kiwoom_mock_order_history_impl(**kwargs: Any) -> dict[str, Any]:
+    return {
+        "success": True,
+        "rows": [],
+        "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+    }
+
+
+async def _kiwoom_mock_positions_impl(**kwargs: Any) -> dict[str, Any]:
+    return {
+        "success": True,
+        "positions": [],
+        "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+    }
+
+
+async def _kiwoom_mock_orderable_cash_impl(**kwargs: Any) -> dict[str, Any]:
+    return {
+        "success": True,
+        "cash": None,
+        "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def register(mcp: "FastMCP") -> None:
+    @mcp.tool(
+        name="kiwoom_mock_preview_order",
+        description="Preview a KRX-only Kiwoom mock order without sending.",
+    )
+    async def kiwoom_mock_preview_order(  # noqa: D401
+        symbol: str,
+        side: Literal["buy", "sell"],
+        quantity: int,
+        price: int,
+        market: str | None = "kr",
+        exchange: str | None = "KRX",
+    ) -> dict[str, Any]:
+        for guard in (
+            _mock_config_error(),
+            _market_error(market),
+            _exchange_error(exchange),
+        ):
+            if guard:
+                return guard
+        return await _kiwoom_mock_preview_impl(
+            symbol=symbol, side=side, quantity=quantity, price=price
+        )
+
+    @mcp.tool(
+        name="kiwoom_mock_place_order",
+        description="Place a KRX-only Kiwoom mock order. dry_run defaults to True.",
+    )
+    async def kiwoom_mock_place_order(
+        symbol: str,
+        side: Literal["buy", "sell"],
+        quantity: int,
+        price: int,
+        market: str | None = "kr",
+        exchange: str | None = "KRX",
+        dry_run: bool = True,
+        confirm: bool = False,
+    ) -> dict[str, Any]:
+        for guard in (
+            _mock_config_error(),
+            _market_error(market),
+            _exchange_error(exchange),
+        ):
+            if guard:
+                return guard
+        if not dry_run and not confirm:
+            return {
+                "success": False,
+                "error": "kiwoom_mock_place_order requires confirm=True when dry_run=False.",
+                "source": "kiwoom",
+                "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+            }
+        return await _kiwoom_mock_place_order_impl(
+            symbol=symbol,
+            side=side,
+            quantity=quantity,
+            price=price,
+            dry_run=dry_run,
+        )
+
+    @mcp.tool(
+        name="kiwoom_mock_cancel_order",
+        description="Cancel a Kiwoom mock order by id. dry_run defaults to True.",
+    )
+    async def kiwoom_mock_cancel_order(
+        order_id: str,
+        symbol: str | None = None,
+        dry_run: bool = True,
+        confirm: bool = False,
+    ) -> dict[str, Any]:
+        if (guard := _mock_config_error()) is not None:
+            return guard
+        if (guard := _order_id_error(order_id)) is not None:
+            return guard
+        if not dry_run and not confirm:
+            return {
+                "success": False,
+                "error": "kiwoom_mock_cancel_order requires confirm=True when dry_run=False.",
+                "source": "kiwoom",
+                "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+            }
+        return await _kiwoom_mock_cancel_impl(
+            order_id=order_id, symbol=symbol, dry_run=dry_run
+        )
+
+    @mcp.tool(
+        name="kiwoom_mock_modify_order",
+        description="Modify a Kiwoom mock order. dry_run defaults to True.",
+    )
+    async def kiwoom_mock_modify_order(
+        order_id: str,
+        symbol: str,
+        new_price: int | None = None,
+        new_quantity: int | None = None,
+        dry_run: bool = True,
+        confirm: bool = False,
+    ) -> dict[str, Any]:
+        if (guard := _mock_config_error()) is not None:
+            return guard
+        if (guard := _order_id_error(order_id)) is not None:
+            return guard
+        if not dry_run and not confirm:
+            return {
+                "success": False,
+                "error": "kiwoom_mock_modify_order requires confirm=True when dry_run=False.",
+                "source": "kiwoom",
+                "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+            }
+        return await _kiwoom_mock_modify_impl(
+            order_id=order_id,
+            symbol=symbol,
+            new_price=new_price,
+            new_quantity=new_quantity,
+            dry_run=dry_run,
+        )
+
+    @mcp.tool(
+        name="kiwoom_mock_get_order_history",
+        description="Read Kiwoom mock order/fill history (read-only).",
+    )
+    async def kiwoom_mock_get_order_history(
+        cont_yn: str | None = None,
+        next_key: str | None = None,
+    ) -> dict[str, Any]:
+        if (guard := _mock_config_error()) is not None:
+            return guard
+        return await _kiwoom_mock_order_history_impl(
+            cont_yn=cont_yn, next_key=next_key
+        )
+
+    @mcp.tool(
+        name="kiwoom_mock_get_positions",
+        description="Read Kiwoom mock positions/balance (read-only).",
+    )
+    async def kiwoom_mock_get_positions() -> dict[str, Any]:
+        if (guard := _mock_config_error()) is not None:
+            return guard
+        return await _kiwoom_mock_positions_impl()
+
+    @mcp.tool(
+        name="kiwoom_mock_get_orderable_cash",
+        description="Read Kiwoom mock orderable cash (read-only).",
+    )
+    async def kiwoom_mock_get_orderable_cash(
+        symbol: str | None = None,
+    ) -> dict[str, Any]:
+        if (guard := _mock_config_error()) is not None:
+            return guard
+        return await _kiwoom_mock_orderable_cash_impl(symbol=symbol)

--- a/app/mcp_server/tooling/orders_kiwoom_variants.py
+++ b/app/mcp_server/tooling/orders_kiwoom_variants.py
@@ -96,6 +96,45 @@ def _order_id_error(order_id: str) -> dict[str, Any] | None:
     return None
 
 
+def _positive_amount_error(name: str, value: float | int | None) -> dict[str, Any] | None:
+    """Reject zero/negative quantities and prices before any broker call."""
+
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return {
+            "success": False,
+            "error": f"kiwoom_mock requires {name} to be numeric; got {value!r}",
+            "source": "kiwoom",
+            "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+        }
+    if not numeric > 0:
+        return {
+            "success": False,
+            "error": f"kiwoom_mock requires {name} > 0; got {value!r}",
+            "source": "kiwoom",
+            "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+        }
+    return None
+
+
+_CONFIRMED_NOT_IMPLEMENTED_ERROR = (
+    "kiwoom_mock confirmed execution is not implemented in this PR; "
+    "use dry_run=True to preview."
+)
+
+
+def _confirmed_not_implemented(tool_name: str) -> dict[str, Any]:
+    return {
+        "success": False,
+        "error": f"{tool_name}: {_CONFIRMED_NOT_IMPLEMENTED_ERROR}",
+        "source": "kiwoom",
+        "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Implementation seams (overridable via monkeypatch in tests).
 
@@ -219,16 +258,20 @@ def register(mcp: FastMCP) -> None:
             _mock_config_error(),
             _market_error(market),
             _exchange_error(exchange),
+            _positive_amount_error("quantity", quantity),
+            _positive_amount_error("price", price),
         ):
             if guard:
                 return guard
-        if not dry_run and not confirm:
-            return {
-                "success": False,
-                "error": "kiwoom_mock_place_order requires confirm=True when dry_run=False.",
-                "source": "kiwoom",
-                "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
-            }
+        if not dry_run:
+            if not confirm:
+                return {
+                    "success": False,
+                    "error": "kiwoom_mock_place_order requires confirm=True when dry_run=False.",
+                    "source": "kiwoom",
+                    "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+                }
+            return _confirmed_not_implemented("kiwoom_mock_place_order")
         return await _kiwoom_mock_place_order_impl(
             symbol=symbol,
             side=side,
@@ -244,6 +287,7 @@ def register(mcp: FastMCP) -> None:
     async def kiwoom_mock_cancel_order(
         order_id: str,
         symbol: str | None = None,
+        cancel_quantity: int | None = None,
         dry_run: bool = True,
         confirm: bool = False,
     ) -> dict[str, Any]:
@@ -251,15 +295,22 @@ def register(mcp: FastMCP) -> None:
             return guard
         if (guard := _order_id_error(order_id)) is not None:
             return guard
-        if not dry_run and not confirm:
-            return {
-                "success": False,
-                "error": "kiwoom_mock_cancel_order requires confirm=True when dry_run=False.",
-                "source": "kiwoom",
-                "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
-            }
+        if (guard := _positive_amount_error("cancel_quantity", cancel_quantity)) is not None:
+            return guard
+        if not dry_run:
+            if not confirm:
+                return {
+                    "success": False,
+                    "error": "kiwoom_mock_cancel_order requires confirm=True when dry_run=False.",
+                    "source": "kiwoom",
+                    "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+                }
+            return _confirmed_not_implemented("kiwoom_mock_cancel_order")
         return await _kiwoom_mock_cancel_impl(
-            order_id=order_id, symbol=symbol, dry_run=dry_run
+            order_id=order_id,
+            symbol=symbol,
+            cancel_quantity=cancel_quantity,
+            dry_run=dry_run,
         )
 
     @mcp.tool(
@@ -278,13 +329,21 @@ def register(mcp: FastMCP) -> None:
             return guard
         if (guard := _order_id_error(order_id)) is not None:
             return guard
-        if not dry_run and not confirm:
-            return {
-                "success": False,
-                "error": "kiwoom_mock_modify_order requires confirm=True when dry_run=False.",
-                "source": "kiwoom",
-                "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
-            }
+        for guard in (
+            _positive_amount_error("new_quantity", new_quantity),
+            _positive_amount_error("new_price", new_price),
+        ):
+            if guard:
+                return guard
+        if not dry_run:
+            if not confirm:
+                return {
+                    "success": False,
+                    "error": "kiwoom_mock_modify_order requires confirm=True when dry_run=False.",
+                    "source": "kiwoom",
+                    "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+                }
+            return _confirmed_not_implemented("kiwoom_mock_modify_order")
         return await _kiwoom_mock_modify_impl(
             order_id=order_id,
             symbol=symbol,

--- a/app/mcp_server/tooling/orders_kiwoom_variants.py
+++ b/app/mcp_server/tooling/orders_kiwoom_variants.py
@@ -96,7 +96,9 @@ def _order_id_error(order_id: str) -> dict[str, Any] | None:
     return None
 
 
-def _positive_amount_error(name: str, value: float | int | None) -> dict[str, Any] | None:
+def _positive_amount_error(
+    name: str, value: float | int | None
+) -> dict[str, Any] | None:
     """Reject zero/negative quantities and prices before any broker call."""
 
     if value is None:
@@ -295,7 +297,9 @@ def register(mcp: FastMCP) -> None:
             return guard
         if (guard := _order_id_error(order_id)) is not None:
             return guard
-        if (guard := _positive_amount_error("cancel_quantity", cancel_quantity)) is not None:
+        if (
+            guard := _positive_amount_error("cancel_quantity", cancel_quantity)
+        ) is not None:
             return guard
         if not dry_run:
             if not confirm:

--- a/app/mcp_server/tooling/orders_kiwoom_variants.py
+++ b/app/mcp_server/tooling/orders_kiwoom_variants.py
@@ -71,7 +71,10 @@ def _exchange_error(exchange: str | None) -> dict[str, Any] | None:
     if exchange is None:
         return None
     value = str(exchange).strip().upper()
-    if value in constants.MOCK_REJECTED_EXCHANGES or value != constants.MOCK_EXCHANGE_KRX:
+    if (
+        value in constants.MOCK_REJECTED_EXCHANGES
+        or value != constants.MOCK_EXCHANGE_KRX
+    ):
         return {
             "success": False,
             "error": f"kiwoom_mock supports KRX only; rejected exchange={exchange!r}.",
@@ -174,7 +177,7 @@ async def _kiwoom_mock_orderable_cash_impl(**kwargs: Any) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def register(mcp: "FastMCP") -> None:
+def register(mcp: FastMCP) -> None:
     @mcp.tool(
         name="kiwoom_mock_preview_order",
         description="Preview a KRX-only Kiwoom mock order without sending.",
@@ -300,9 +303,7 @@ def register(mcp: "FastMCP") -> None:
     ) -> dict[str, Any]:
         if (guard := _mock_config_error()) is not None:
             return guard
-        return await _kiwoom_mock_order_history_impl(
-            cont_yn=cont_yn, next_key=next_key
-        )
+        return await _kiwoom_mock_order_history_impl(cont_yn=cont_yn, next_key=next_key)
 
     @mcp.tool(
         name="kiwoom_mock_get_positions",

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -48,6 +48,7 @@ from app.mcp_server.tooling.orders_kis_variants import (
     register_kis_live_order_tools,
     register_kis_mock_order_tools,
 )
+from app.mcp_server.tooling import orders_kiwoom_variants
 from app.mcp_server.tooling.orders_registration import register_order_tools
 from app.mcp_server.tooling.paper_account_registration import (
     register_paper_account_tools,
@@ -118,9 +119,11 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
         register_order_tools(mcp)
         register_kis_live_order_tools(mcp)
         register_kis_mock_order_tools(mcp)
+        orders_kiwoom_variants.register(mcp)
     elif profile is McpProfile.HERMES_PAPER_KIS:
         # Paper-only: only mock-pinned order surface. Live surface is physically absent.
         register_kis_mock_order_tools(mcp)
+        orders_kiwoom_variants.register(mcp)
         # Intentionally NOT: register_order_tools, register_kis_live_order_tools
 
 

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from app.mcp_server.profiles import McpProfile
+from app.mcp_server.tooling import orders_kiwoom_variants
 from app.mcp_server.tooling.alpaca_paper import register_alpaca_paper_tools
 from app.mcp_server.tooling.alpaca_paper_ledger_read import (
     register_alpaca_paper_ledger_read_tools,
@@ -48,7 +49,6 @@ from app.mcp_server.tooling.orders_kis_variants import (
     register_kis_live_order_tools,
     register_kis_mock_order_tools,
 )
-from app.mcp_server.tooling import orders_kiwoom_variants
 from app.mcp_server.tooling.orders_registration import register_order_tools
 from app.mcp_server.tooling.paper_account_registration import (
     register_paper_account_tools,

--- a/app/services/brokers/capabilities.py
+++ b/app/services/brokers/capabilities.py
@@ -1,8 +1,8 @@
 """Broker capability metadata registry.
 
 Declares which markets each broker supports and whether paper/live modes are
-available. Metadata-only: no order routing logic consumes this yet.
-Forward-looking Kiwoom entry is included for planning; no Kiwoom client exists.
+available. Kiwoom currently exposes mock-only KR equity support via
+``app/services/brokers/kiwoom`` (see ROB-97); live remains unsupported.
 """
 
 from __future__ import annotations
@@ -41,8 +41,8 @@ BROKER_CAPABILITIES: Mapping[Broker, BrokerCapability] = {
     ),
     Broker.KIWOOM: BrokerCapability(
         broker=Broker.KIWOOM,
-        markets=frozenset({Market.KR_EQUITY, Market.US_EQUITY}),
-        supports_paper=False,
+        markets=frozenset({Market.KR_EQUITY}),
+        supports_paper=True,
         supports_live=False,
     ),
     Broker.UPBIT: BrokerCapability(

--- a/app/services/brokers/kiwoom/__init__.py
+++ b/app/services/brokers/kiwoom/__init__.py
@@ -1,0 +1,1 @@
+"""Kiwoom Securities REST broker package (mock-only in this PR)."""

--- a/app/services/brokers/kiwoom/auth.py
+++ b/app/services/brokers/kiwoom/auth.py
@@ -1,0 +1,93 @@
+# app/services/brokers/kiwoom/auth.py
+"""Kiwoom OAuth token issuance and cache.
+
+Uses ``expires_dt`` returned by Kiwoom (``YYYYMMDDHHMMSS``) to schedule
+refreshes ``TOKEN_REFRESH_LEEWAY_SECONDS`` before expiry. Logs intentionally
+omit the token, app secret and full response body.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import logging
+from typing import Any
+
+import httpx
+
+from app.services.brokers.kiwoom import constants
+
+_log = logging.getLogger(__name__)
+
+
+def _parse_expires_dt(value: str) -> dt.datetime:
+    return dt.datetime.strptime(value, "%Y%m%d%H%M%S").replace(tzinfo=dt.UTC)
+
+
+class KiwoomAuthClient:
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        app_key: str,
+        app_secret: str,
+        transport: httpx.BaseTransport | None = None,
+        timeout: float = constants.DEFAULT_TIMEOUT,
+    ) -> None:
+        if str(base_url).rstrip("/") != constants.MOCK_BASE_URL:
+            raise ValueError(
+                f"KiwoomAuthClient is mock-only; got base_url={base_url!r}"
+            )
+        self._base_url = base_url.rstrip("/")
+        self._app_key = app_key
+        self._app_secret = app_secret
+        self._transport = transport
+        self._timeout = timeout
+        self._lock = asyncio.Lock()
+        self._cached_token: str | None = None
+        self._cached_expires_at: dt.datetime | None = None
+
+    async def get_token(self) -> str:
+        async with self._lock:
+            if self._cached_token and self._still_fresh():
+                return self._cached_token
+            await self._refresh()
+            assert self._cached_token is not None
+            return self._cached_token
+
+    def _still_fresh(self) -> bool:
+        if self._cached_expires_at is None:
+            return False
+        leeway = dt.timedelta(seconds=constants.TOKEN_REFRESH_LEEWAY_SECONDS)
+        return dt.datetime.now(dt.UTC) + leeway < self._cached_expires_at
+
+    async def _refresh(self) -> None:
+        body = {
+            "grant_type": constants.OAUTH_GRANT_TYPE,
+            "appkey": self._app_key,
+            "secretkey": self._app_secret,
+        }
+        async with httpx.AsyncClient(
+            base_url=self._base_url,
+            transport=self._transport,
+            timeout=self._timeout,
+        ) as client:
+            response = await client.post(
+                constants.OAUTH_PATH,
+                json=body,
+                headers={"Content-Type": constants.OAUTH_CONTENT_TYPE},
+            )
+        response.raise_for_status()
+        payload: dict[str, Any] = response.json()
+        if int(payload.get("return_code", -1)) != constants.SUCCESS_RETURN_CODE:
+            _log.warning(
+                "Kiwoom OAuth refresh non-zero return_code=%s",
+                payload.get("return_code"),
+            )
+        token = str(payload.get("token") or "").strip()
+        expires_raw = str(payload.get("expires_dt") or "").strip()
+        if not token or not expires_raw:
+            raise RuntimeError("Kiwoom OAuth response missing token/expires_dt")
+        self._cached_token = token
+        self._cached_expires_at = _parse_expires_dt(expires_raw)
+        _log.debug("Kiwoom OAuth token refreshed (expires_at hidden)")

--- a/app/services/brokers/kiwoom/client.py
+++ b/app/services/brokers/kiwoom/client.py
@@ -30,9 +30,7 @@ class KiwoomEndpointError(RuntimeError):
 
 def _validate_relative_path(path: str) -> None:
     if not path.startswith("/") or "://" in path:
-        raise ValueError(
-            f"Kiwoom request path must be a relative path; got {path!r}"
-        )
+        raise ValueError(f"Kiwoom request path must be a relative path; got {path!r}")
 
 
 class KiwoomMockClient:
@@ -66,7 +64,7 @@ class KiwoomMockClient:
         self._token_override: str | None = None
 
     @classmethod
-    def from_app_settings(cls) -> "KiwoomMockClient":
+    def from_app_settings(cls) -> KiwoomMockClient:
         from app.core.config import settings, validate_kiwoom_mock_config
 
         missing = validate_kiwoom_mock_config(settings)

--- a/app/services/brokers/kiwoom/client.py
+++ b/app/services/brokers/kiwoom/client.py
@@ -29,7 +29,23 @@ class KiwoomEndpointError(RuntimeError):
 
 
 def _validate_relative_path(path: str) -> None:
-    if not path.startswith("/") or "://" in path:
+    """Reject absolute URLs, network-path references, and other non-relative shapes.
+
+    Network-path references like ``//api.kiwoom.com/...`` are dangerous because
+    URL-join semantics let them re-target the host even though they look
+    relative. Anything other than exactly one leading ``/`` followed by a
+    non-``/`` character is rejected.
+    """
+
+    if (
+        not path
+        or not path.startswith("/")
+        or path.startswith("//")
+        or "://" in path
+        or "\\" in path
+        or "\r" in path
+        or "\n" in path
+    ):
         raise ValueError(f"Kiwoom request path must be a relative path; got {path!r}")
 
 
@@ -123,7 +139,13 @@ class KiwoomMockClient:
             transport=self._transport,
             timeout=self._timeout,
         ) as client:
-            response = await client.post(path, headers=headers, json=body)
+            request = client.build_request("POST", path, headers=headers, json=body)
+            if request.url.host != httpx.URL(constants.MOCK_BASE_URL).host:
+                raise ValueError(
+                    "Kiwoom mock request resolved to non-mock host "
+                    f"{request.url.host!r}; refusing to send."
+                )
+            response = await client.send(request)
         response.raise_for_status()
         payload: dict[str, Any] = dict(response.json())
         payload["continuation"] = {

--- a/app/services/brokers/kiwoom/client.py
+++ b/app/services/brokers/kiwoom/client.py
@@ -1,0 +1,60 @@
+# app/services/brokers/kiwoom/client.py
+"""Kiwoom mock-only REST client.
+
+Mock-only by construction: any base URL other than the configured mock host
+raises ``KiwoomEndpointError`` so misconfiguration cannot reach the live
+broker. ``from_app_settings`` aggregates config validation via
+``validate_kiwoom_mock_config`` and refuses to construct a client until all
+required env values are present.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from app.services.brokers.kiwoom import constants
+
+if TYPE_CHECKING:
+    pass
+
+
+class KiwoomConfigurationError(RuntimeError):
+    """Raised when Kiwoom mock config is incomplete or disabled."""
+
+
+class KiwoomEndpointError(RuntimeError):
+    """Raised when a non-mock base URL would be used."""
+
+
+@dataclass(frozen=True)
+class KiwoomMockClient:
+    base_url: str
+    app_key: str
+    app_secret: str
+    account_no: str
+
+    def __post_init__(self) -> None:
+        if str(self.base_url).rstrip("/") != constants.MOCK_BASE_URL:
+            raise KiwoomEndpointError(
+                "KiwoomMockClient only accepts the mock base URL "
+                f"({constants.MOCK_BASE_URL}); refusing to use {self.base_url!r}."
+            )
+
+    @classmethod
+    def from_app_settings(cls) -> "KiwoomMockClient":
+        from app.core.config import settings, validate_kiwoom_mock_config
+
+        missing = validate_kiwoom_mock_config(settings)
+        if missing:
+            raise KiwoomConfigurationError(
+                "Kiwoom mock account is disabled or missing required configuration: "
+                + ", ".join(missing)
+            )
+        # Validator above guarantees these are non-empty strings at runtime.
+        return cls(
+            base_url=str(settings.kiwoom_mock_base_url).rstrip("/"),
+            app_key=str(settings.kiwoom_mock_app_key),
+            app_secret=str(settings.kiwoom_mock_app_secret),
+            account_no=str(settings.kiwoom_mock_account_no),
+        )

--- a/app/services/brokers/kiwoom/client.py
+++ b/app/services/brokers/kiwoom/client.py
@@ -1,22 +1,23 @@
 # app/services/brokers/kiwoom/client.py
-"""Kiwoom mock-only REST client.
+"""Kiwoom mock-only REST client (transport + post_api helper).
 
-Mock-only by construction: any base URL other than the configured mock host
-raises ``KiwoomEndpointError`` so misconfiguration cannot reach the live
-broker. ``from_app_settings`` aggregates config validation via
-``validate_kiwoom_mock_config`` and refuses to construct a client until all
-required env values are present.
+Mock-only: rejects any base URL other than ``constants.MOCK_BASE_URL`` and
+refuses any per-call ``path`` that is not a relative path beginning with ``/``
+so callers cannot smuggle in the live host. The token is fetched via
+``KiwoomAuthClient`` and never logged or returned.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+import logging
+from typing import Any
+
+import httpx
 
 from app.services.brokers.kiwoom import constants
+from app.services.brokers.kiwoom.auth import KiwoomAuthClient
 
-if TYPE_CHECKING:
-    pass
+_log = logging.getLogger(__name__)
 
 
 class KiwoomConfigurationError(RuntimeError):
@@ -27,19 +28,42 @@ class KiwoomEndpointError(RuntimeError):
     """Raised when a non-mock base URL would be used."""
 
 
-@dataclass(frozen=True)
-class KiwoomMockClient:
-    base_url: str
-    app_key: str
-    app_secret: str
-    account_no: str
+def _validate_relative_path(path: str) -> None:
+    if not path.startswith("/") or "://" in path:
+        raise ValueError(
+            f"Kiwoom request path must be a relative path; got {path!r}"
+        )
 
-    def __post_init__(self) -> None:
-        if str(self.base_url).rstrip("/") != constants.MOCK_BASE_URL:
+
+class KiwoomMockClient:
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        app_key: str,
+        app_secret: str,
+        account_no: str,
+        timeout: float = constants.DEFAULT_TIMEOUT,
+    ) -> None:
+        if str(base_url).rstrip("/") != constants.MOCK_BASE_URL:
             raise KiwoomEndpointError(
                 "KiwoomMockClient only accepts the mock base URL "
-                f"({constants.MOCK_BASE_URL}); refusing to use {self.base_url!r}."
+                f"({constants.MOCK_BASE_URL}); refusing to use {base_url!r}."
             )
+        self._base_url = base_url.rstrip("/")
+        self._app_key = app_key
+        self._app_secret = app_secret
+        self._account_no = account_no
+        self._timeout = timeout
+        self._transport: httpx.BaseTransport | None = None
+        self._auth = KiwoomAuthClient(
+            base_url=self._base_url,
+            app_key=app_key,
+            app_secret=app_secret,
+            transport=None,
+            timeout=timeout,
+        )
+        self._token_override: str | None = None
 
     @classmethod
     def from_app_settings(cls) -> "KiwoomMockClient":
@@ -51,10 +75,67 @@ class KiwoomMockClient:
                 "Kiwoom mock account is disabled or missing required configuration: "
                 + ", ".join(missing)
             )
-        # Validator above guarantees these are non-empty strings at runtime.
         return cls(
             base_url=str(settings.kiwoom_mock_base_url).rstrip("/"),
             app_key=str(settings.kiwoom_mock_app_key),
             app_secret=str(settings.kiwoom_mock_app_secret),
             account_no=str(settings.kiwoom_mock_account_no),
         )
+
+    def set_transport_for_test(
+        self, transport: httpx.BaseTransport, *, token: str
+    ) -> None:
+        """Inject a httpx transport + pre-issued token for unit tests only."""
+
+        self._transport = transport
+        self._token_override = token
+
+    @property
+    def account_no(self) -> str:
+        return self._account_no
+
+    async def _resolve_token(self) -> str:
+        if self._token_override is not None:
+            return self._token_override
+        return await self._auth.get_token()
+
+    async def post_api(
+        self,
+        *,
+        api_id: str,
+        path: str,
+        body: dict[str, Any],
+        cont_yn: str | None = None,
+        next_key: str | None = None,
+    ) -> dict[str, Any]:
+        _validate_relative_path(path)
+        token = await self._resolve_token()
+        headers = {
+            constants.HEADER_AUTHORIZATION: f"Bearer {token}",
+            constants.HEADER_API_ID: api_id,
+            "Content-Type": constants.OAUTH_CONTENT_TYPE,
+        }
+        if cont_yn is not None:
+            headers[constants.HEADER_CONT_YN] = cont_yn
+        if next_key is not None:
+            headers[constants.HEADER_NEXT_KEY] = next_key
+
+        async with httpx.AsyncClient(
+            base_url=self._base_url,
+            transport=self._transport,
+            timeout=self._timeout,
+        ) as client:
+            response = await client.post(path, headers=headers, json=body)
+        response.raise_for_status()
+        payload: dict[str, Any] = dict(response.json())
+        payload["continuation"] = {
+            "cont_yn": response.headers.get(constants.HEADER_CONT_YN, ""),
+            "next_key": response.headers.get(constants.HEADER_NEXT_KEY, ""),
+        }
+        if int(payload.get("return_code", 0)) != constants.SUCCESS_RETURN_CODE:
+            _log.info(
+                "Kiwoom api_id=%s returned non-zero return_code=%s",
+                api_id,
+                payload.get("return_code"),
+            )
+        return payload

--- a/app/services/brokers/kiwoom/constants.py
+++ b/app/services/brokers/kiwoom/constants.py
@@ -1,0 +1,53 @@
+"""Kiwoom Securities REST API constants (URLs, API IDs, headers).
+
+Mock trading is the only supported runtime mode in this package. Live URL is
+defined here only so we can defensively reject it; no code path may select it.
+"""
+
+from __future__ import annotations
+
+# Base URLs
+MOCK_BASE_URL = "https://mockapi.kiwoom.com"
+LIVE_BASE_URL = "https://api.kiwoom.com"  # never used; defensive constant only
+
+# OAuth (au10001)
+OAUTH_API_ID = "au10001"
+OAUTH_PATH = "/oauth2/token"
+OAUTH_CONTENT_TYPE = "application/json;charset=UTF-8"
+OAUTH_GRANT_TYPE = "client_credentials"
+
+# Common REST headers
+HEADER_AUTHORIZATION = "authorization"
+HEADER_API_ID = "api-id"
+HEADER_CONT_YN = "cont-yn"
+HEADER_NEXT_KEY = "next-key"
+
+# Order API (/api/dostk/ordr)
+ORDER_PATH = "/api/dostk/ordr"
+ORDER_BUY_API_ID = "kt10000"
+ORDER_SELL_API_ID = "kt10001"
+ORDER_MODIFY_API_ID = "kt10002"
+ORDER_CANCEL_API_ID = "kt10003"
+
+# Account/order query API IDs (paths centralized in client when implemented)
+ACCOUNT_ORDER_DETAIL_API_ID = "kt00007"
+ACCOUNT_ORDER_STATUS_API_ID = "kt00009"
+ACCOUNT_ORDERABLE_AMOUNT_API_ID = "kt00010"
+ACCOUNT_BALANCE_API_ID = "kt00018"
+
+# Chart API IDs (scaffolded, deferred — NOT routed from get_ohlcv)
+CHART_MINUTE_API_ID = "ka10080"
+CHART_DAILY_API_ID = "ka10081"
+CHART_WEEKLY_API_ID = "ka10082"
+CHART_MONTHLY_API_ID = "ka10083"
+
+# Exchange (KRX-only for mock)
+MOCK_EXCHANGE_KRX = "KRX"
+MOCK_REJECTED_EXCHANGES = frozenset({"NXT", "SOR"})
+
+# Response codes (Kiwoom returns return_code / return_msg in body)
+SUCCESS_RETURN_CODE = 0
+
+# Defaults
+DEFAULT_TIMEOUT = 5  # seconds
+TOKEN_REFRESH_LEEWAY_SECONDS = 30  # refresh slightly before expires_dt

--- a/app/services/brokers/kiwoom/domestic_account.py
+++ b/app/services/brokers/kiwoom/domestic_account.py
@@ -1,0 +1,92 @@
+# app/services/brokers/kiwoom/domestic_account.py
+"""Kiwoom domestic account/order-history queries.
+
+All methods delegate to the parent client's ``post_api`` and never log the
+account number or token. The exact body field names mirror Kiwoom REST docs;
+they are passed through untransformed for the parent project to consume.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from app.services.brokers.kiwoom import constants
+
+ACCOUNT_PATH = "/api/dostk/acnt"
+
+
+class _SupportsPostApi(Protocol):
+    account_no: str
+
+    async def post_api(
+        self,
+        *,
+        api_id: str,
+        path: str,
+        body: dict[str, Any],
+        cont_yn: str | None = None,
+        next_key: str | None = None,
+    ) -> dict[str, Any]: ...
+
+
+class KiwoomDomesticAccountClient:
+    def __init__(self, client: _SupportsPostApi) -> None:
+        self._client = client
+
+    async def get_orderable_amount(
+        self,
+        *,
+        symbol: str,
+        cont_yn: str | None = None,
+        next_key: str | None = None,
+    ) -> dict[str, Any]:
+        return await self._client.post_api(
+            api_id=constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID,
+            path=ACCOUNT_PATH,
+            body={"stk_cd": str(symbol).strip()},
+            cont_yn=cont_yn,
+            next_key=next_key,
+        )
+
+    async def get_balance(
+        self,
+        *,
+        cont_yn: str | None = None,
+        next_key: str | None = None,
+    ) -> dict[str, Any]:
+        return await self._client.post_api(
+            api_id=constants.ACCOUNT_BALANCE_API_ID,
+            path=ACCOUNT_PATH,
+            body={},
+            cont_yn=cont_yn,
+            next_key=next_key,
+        )
+
+    async def get_order_status(
+        self,
+        *,
+        cont_yn: str | None = None,
+        next_key: str | None = None,
+    ) -> dict[str, Any]:
+        return await self._client.post_api(
+            api_id=constants.ACCOUNT_ORDER_STATUS_API_ID,
+            path=ACCOUNT_PATH,
+            body={},
+            cont_yn=cont_yn,
+            next_key=next_key,
+        )
+
+    async def get_order_detail(
+        self,
+        *,
+        order_no: str,
+        cont_yn: str | None = None,
+        next_key: str | None = None,
+    ) -> dict[str, Any]:
+        return await self._client.post_api(
+            api_id=constants.ACCOUNT_ORDER_DETAIL_API_ID,
+            path=ACCOUNT_PATH,
+            body={"ord_no": str(order_no).strip()},
+            cont_yn=cont_yn,
+            next_key=next_key,
+        )

--- a/app/services/brokers/kiwoom/domestic_market_data.py
+++ b/app/services/brokers/kiwoom/domestic_market_data.py
@@ -1,0 +1,33 @@
+# app/services/brokers/kiwoom/domestic_market_data.py
+"""Deferred Kiwoom chart-data skeleton (ka10080/ka10081/ka10082/ka10083).
+
+Intentionally not wired into ``get_ohlcv`` — KIS remains the default KR OHLCV
+source per ROB-97. A future issue may add ``source="kiwoom"`` for KIS rate
+limit relief; until then every method raises ``NotImplementedError`` so any
+accidental call is loud.
+"""
+
+from __future__ import annotations
+
+from app.services.brokers.kiwoom import constants
+
+
+class KiwoomDomesticMarketDataClient:
+    """Placeholder for Kiwoom KRX chart endpoints (deferred)."""
+
+    SUPPORTED_API_IDS = (
+        constants.CHART_MINUTE_API_ID,
+        constants.CHART_DAILY_API_ID,
+        constants.CHART_WEEKLY_API_ID,
+        constants.CHART_MONTHLY_API_ID,
+    )
+
+    async def fetch_minute_candles(self, *_, **__) -> None:  # pragma: no cover
+        raise NotImplementedError(
+            "Kiwoom chart support is deferred; default OHLCV source remains KIS."
+        )
+
+    async def fetch_daily_candles(self, *_, **__) -> None:  # pragma: no cover
+        raise NotImplementedError(
+            "Kiwoom chart support is deferred; default OHLCV source remains KIS."
+        )

--- a/app/services/brokers/kiwoom/domestic_orders.py
+++ b/app/services/brokers/kiwoom/domestic_orders.py
@@ -42,9 +42,7 @@ def _ensure_krx(exchange: str | None) -> str:
             f"Kiwoom mock supports KRX only; rejected exchange={value!r}"
         )
     if value != constants.MOCK_EXCHANGE_KRX:
-        raise KiwoomOrderRejected(
-            f"Kiwoom mock supports KRX only; got {value!r}"
-        )
+        raise KiwoomOrderRejected(f"Kiwoom mock supports KRX only; got {value!r}")
     return value
 
 

--- a/app/services/brokers/kiwoom/domestic_orders.py
+++ b/app/services/brokers/kiwoom/domestic_orders.py
@@ -1,0 +1,144 @@
+# app/services/brokers/kiwoom/domestic_orders.py
+"""Kiwoom domestic (KRX) order operations.
+
+All payloads target the mock exchange (``KRX``); ``NXT``/``SOR`` are rejected
+before any network call. Order-id arguments are validated against a strict
+allowlist so callers cannot inject path separators, query fragments or bulk
+delimiters.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Protocol
+
+from app.services.brokers.kiwoom import constants
+
+_SAFE_ORDER_ID_RE = re.compile(r"^[A-Za-z0-9_\-]+$")
+
+
+class KiwoomOrderRejected(ValueError):
+    """Raised when a Kiwoom mock order is rejected client-side before sending."""
+
+
+class _SupportsPostApi(Protocol):
+    account_no: str
+
+    async def post_api(
+        self,
+        *,
+        api_id: str,
+        path: str,
+        body: dict[str, Any],
+        cont_yn: str | None = None,
+        next_key: str | None = None,
+    ) -> dict[str, Any]: ...
+
+
+def _ensure_krx(exchange: str | None) -> str:
+    value = (exchange or constants.MOCK_EXCHANGE_KRX).strip().upper()
+    if value in constants.MOCK_REJECTED_EXCHANGES:
+        raise KiwoomOrderRejected(
+            f"Kiwoom mock supports KRX only; rejected exchange={value!r}"
+        )
+    if value != constants.MOCK_EXCHANGE_KRX:
+        raise KiwoomOrderRejected(
+            f"Kiwoom mock supports KRX only; got {value!r}"
+        )
+    return value
+
+
+def _ensure_order_id(value: str) -> str:
+    candidate = (value or "").strip()
+    if not candidate or not _SAFE_ORDER_ID_RE.fullmatch(candidate):
+        raise KiwoomOrderRejected(f"Unsafe Kiwoom order id: {value!r}")
+    return candidate
+
+
+class KiwoomDomesticOrderClient:
+    def __init__(self, client: _SupportsPostApi) -> None:
+        self._client = client
+
+    async def place_buy_order(
+        self,
+        *,
+        symbol: str,
+        quantity: int,
+        price: int,
+        exchange: str | None = None,
+    ) -> dict[str, Any]:
+        body = {
+            "dmst_stex_tp": _ensure_krx(exchange),
+            "stk_cd": str(symbol).strip(),
+            "ord_qty": str(int(quantity)),
+            "ord_uv": str(int(price)),
+            "trde_tp": "0",  # 보통가 — limit
+        }
+        return await self._client.post_api(
+            api_id=constants.ORDER_BUY_API_ID,
+            path=constants.ORDER_PATH,
+            body=body,
+        )
+
+    async def place_sell_order(
+        self,
+        *,
+        symbol: str,
+        quantity: int,
+        price: int,
+        exchange: str | None = None,
+    ) -> dict[str, Any]:
+        body = {
+            "dmst_stex_tp": _ensure_krx(exchange),
+            "stk_cd": str(symbol).strip(),
+            "ord_qty": str(int(quantity)),
+            "ord_uv": str(int(price)),
+            "trde_tp": "0",
+        }
+        return await self._client.post_api(
+            api_id=constants.ORDER_SELL_API_ID,
+            path=constants.ORDER_PATH,
+            body=body,
+        )
+
+    async def modify_order(
+        self,
+        *,
+        original_order_no: str,
+        symbol: str,
+        new_quantity: int,
+        new_price: int,
+        exchange: str | None = None,
+    ) -> dict[str, Any]:
+        body = {
+            "dmst_stex_tp": _ensure_krx(exchange),
+            "orig_ord_no": _ensure_order_id(original_order_no),
+            "stk_cd": str(symbol).strip(),
+            "mdfy_qty": str(int(new_quantity)),
+            "mdfy_uv": str(int(new_price)),
+        }
+        return await self._client.post_api(
+            api_id=constants.ORDER_MODIFY_API_ID,
+            path=constants.ORDER_PATH,
+            body=body,
+        )
+
+    async def cancel_order(
+        self,
+        *,
+        original_order_no: str,
+        symbol: str,
+        cancel_quantity: int,
+        exchange: str | None = None,
+    ) -> dict[str, Any]:
+        body = {
+            "dmst_stex_tp": _ensure_krx(exchange),
+            "orig_ord_no": _ensure_order_id(original_order_no),
+            "stk_cd": str(symbol).strip(),
+            "cncl_qty": str(int(cancel_quantity)),
+        }
+        return await self._client.post_api(
+            api_id=constants.ORDER_CANCEL_API_ID,
+            path=constants.ORDER_PATH,
+            body=body,
+        )

--- a/app/services/brokers/kiwoom/domestic_orders.py
+++ b/app/services/brokers/kiwoom/domestic_orders.py
@@ -53,6 +53,16 @@ def _ensure_order_id(value: str) -> str:
     return candidate
 
 
+def _ensure_positive_int(name: str, value: int) -> int:
+    try:
+        candidate = int(value)
+    except (TypeError, ValueError) as exc:
+        raise KiwoomOrderRejected(f"{name} must be a positive integer") from exc
+    if candidate <= 0:
+        raise KiwoomOrderRejected(f"{name} must be a positive integer")
+    return candidate
+
+
 class KiwoomDomesticOrderClient:
     def __init__(self, client: _SupportsPostApi) -> None:
         self._client = client
@@ -65,11 +75,13 @@ class KiwoomDomesticOrderClient:
         price: int,
         exchange: str | None = None,
     ) -> dict[str, Any]:
+        order_quantity = _ensure_positive_int("quantity", quantity)
+        order_price = _ensure_positive_int("price", price)
         body = {
             "dmst_stex_tp": _ensure_krx(exchange),
             "stk_cd": str(symbol).strip(),
-            "ord_qty": str(int(quantity)),
-            "ord_uv": str(int(price)),
+            "ord_qty": str(order_quantity),
+            "ord_uv": str(order_price),
             "trde_tp": "0",  # 보통가 — limit
         }
         return await self._client.post_api(
@@ -86,11 +98,13 @@ class KiwoomDomesticOrderClient:
         price: int,
         exchange: str | None = None,
     ) -> dict[str, Any]:
+        order_quantity = _ensure_positive_int("quantity", quantity)
+        order_price = _ensure_positive_int("price", price)
         body = {
             "dmst_stex_tp": _ensure_krx(exchange),
             "stk_cd": str(symbol).strip(),
-            "ord_qty": str(int(quantity)),
-            "ord_uv": str(int(price)),
+            "ord_qty": str(order_quantity),
+            "ord_uv": str(order_price),
             "trde_tp": "0",
         }
         return await self._client.post_api(
@@ -108,12 +122,14 @@ class KiwoomDomesticOrderClient:
         new_price: int,
         exchange: str | None = None,
     ) -> dict[str, Any]:
+        order_quantity = _ensure_positive_int("new_quantity", new_quantity)
+        order_price = _ensure_positive_int("new_price", new_price)
         body = {
             "dmst_stex_tp": _ensure_krx(exchange),
             "orig_ord_no": _ensure_order_id(original_order_no),
             "stk_cd": str(symbol).strip(),
-            "mdfy_qty": str(int(new_quantity)),
-            "mdfy_uv": str(int(new_price)),
+            "mdfy_qty": str(order_quantity),
+            "mdfy_uv": str(order_price),
         }
         return await self._client.post_api(
             api_id=constants.ORDER_MODIFY_API_ID,
@@ -129,11 +145,12 @@ class KiwoomDomesticOrderClient:
         cancel_quantity: int,
         exchange: str | None = None,
     ) -> dict[str, Any]:
+        order_quantity = _ensure_positive_int("cancel_quantity", cancel_quantity)
         body = {
             "dmst_stex_tp": _ensure_krx(exchange),
             "orig_ord_no": _ensure_order_id(original_order_no),
             "stk_cd": str(symbol).strip(),
-            "cncl_qty": str(int(cancel_quantity)),
+            "cncl_qty": str(order_quantity),
         }
         return await self._client.post_api(
             api_id=constants.ORDER_CANCEL_API_ID,

--- a/tests/test_broker_capabilities.py
+++ b/tests/test_broker_capabilities.py
@@ -38,14 +38,18 @@ class TestKisCapabilities:
 
 
 class TestKiwoomCapabilities:
-    def test_kiwoom_capability_metadata_only(self) -> None:
+    """ROB-97 introduced a Kiwoom mock-only foundation; live remains unsupported."""
+
+    def test_kiwoom_supports_paper_only(self) -> None:
         cap = BROKER_CAPABILITIES[Broker.KIWOOM]
-        assert cap.supports_paper is False
+        assert cap.supports_paper is True
         assert cap.supports_live is False
 
-    def test_kiwoom_supports_kr_and_us_equity(self) -> None:
+    def test_kiwoom_supports_kr_equity_only(self) -> None:
         cap = BROKER_CAPABILITIES[Broker.KIWOOM]
-        assert cap.markets == frozenset({Market.KR_EQUITY, Market.US_EQUITY})
+        assert cap.markets == frozenset({Market.KR_EQUITY})
+        assert Market.US_EQUITY not in cap.markets
+        assert Market.CRYPTO not in cap.markets
 
     def test_kiwoom_broker_field(self) -> None:
         cap = BROKER_CAPABILITIES[Broker.KIWOOM]

--- a/tests/test_kiwoom_auth_token_cache.py
+++ b/tests/test_kiwoom_auth_token_cache.py
@@ -1,0 +1,86 @@
+# tests/test_kiwoom_auth_token_cache.py
+"""Verify Kiwoom OAuth token cache: refresh on expiry, never log secret/token."""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+
+import httpx
+import pytest
+
+from app.services.brokers.kiwoom import constants
+from app.services.brokers.kiwoom.auth import KiwoomAuthClient
+
+
+@pytest.fixture
+def mock_token_transport() -> httpx.MockTransport:
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        assert request.method == "POST"
+        assert request.url.path == constants.OAUTH_PATH
+        body = request.read()
+        # Body must NOT echo as raw secret in log; presence is fine.
+        assert b"client_credentials" in body
+        return httpx.Response(
+            200,
+            json={
+                "token": f"tkn-{calls['count']}",
+                "expires_dt": (
+                    dt.datetime.now(dt.UTC) + dt.timedelta(seconds=300)
+                ).strftime("%Y%m%d%H%M%S"),
+                "token_type": "Bearer",
+                "return_code": 0,
+                "return_msg": "정상",
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    transport.calls = calls  # type: ignore[attr-defined]
+    return transport
+
+
+@pytest.mark.asyncio
+async def test_token_is_cached_until_near_expiry(mock_token_transport):
+    auth = KiwoomAuthClient(
+        base_url=constants.MOCK_BASE_URL,
+        app_key="ak",
+        app_secret="SECRET-VAL",
+        transport=mock_token_transport,
+    )
+    t1 = await auth.get_token()
+    t2 = await auth.get_token()
+    assert t1 == t2
+    assert mock_token_transport.calls["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_token_refreshed_when_expired(monkeypatch, mock_token_transport):
+    auth = KiwoomAuthClient(
+        base_url=constants.MOCK_BASE_URL,
+        app_key="ak",
+        app_secret="SECRET-VAL",
+        transport=mock_token_transport,
+    )
+    await auth.get_token()
+    # Force expiry.
+    auth._cached_expires_at = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=1)
+    await auth.get_token()
+    assert mock_token_transport.calls["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_logs_never_contain_secret_or_token(caplog, mock_token_transport):
+    caplog.set_level(logging.DEBUG, logger="app.services.brokers.kiwoom")
+    auth = KiwoomAuthClient(
+        base_url=constants.MOCK_BASE_URL,
+        app_key="ak",
+        app_secret="SECRET-VAL",
+        transport=mock_token_transport,
+    )
+    token = await auth.get_token()
+    rendered = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert "SECRET-VAL" not in rendered
+    assert token not in rendered

--- a/tests/test_kiwoom_client_endpoint_guard.py
+++ b/tests/test_kiwoom_client_endpoint_guard.py
@@ -54,3 +54,96 @@ def test_from_app_settings_fails_closed_when_credentials_missing(monkeypatch):
     assert "KIWOOM_MOCK_APP_KEY" in msg
     assert "KIWOOM_MOCK_APP_SECRET" in msg
     assert "KIWOOM_MOCK_ACCOUNT_NO" in msg
+
+import httpx
+from app.services.brokers.kiwoom import constants
+
+
+@pytest.mark.asyncio
+async def test_post_api_sends_required_headers(monkeypatch):
+    from app.services.brokers.kiwoom.client import KiwoomMockClient
+
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        captured["url"] = str(request.url)
+        captured["body"] = request.read()
+        return httpx.Response(
+            200,
+            json={"return_code": 0, "return_msg": "정상", "rows": []},
+            headers={"cont-yn": "N", "next-key": ""},
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = KiwoomMockClient(
+        base_url=constants.MOCK_BASE_URL,
+        app_key="ak",
+        app_secret="sk",
+        account_no="123",
+    )
+    # Inject test-only token + transport (helper exposed for testing only).
+    client.set_transport_for_test(transport, token="TKN-XYZ")
+
+    result = await client.post_api(
+        api_id=constants.ORDER_BUY_API_ID,
+        path=constants.ORDER_PATH,
+        body={"foo": "bar"},
+        cont_yn="N",
+        next_key="",
+    )
+
+    assert captured["headers"][constants.HEADER_AUTHORIZATION] == "Bearer TKN-XYZ"
+    assert captured["headers"][constants.HEADER_API_ID] == constants.ORDER_BUY_API_ID
+    assert captured["headers"][constants.HEADER_CONT_YN] == "N"
+    assert captured["headers"][constants.HEADER_NEXT_KEY] == ""
+    assert captured["url"].endswith(constants.ORDER_PATH)
+    assert result["return_code"] == 0
+    assert result["continuation"]["cont_yn"] == "N"
+    assert result["continuation"]["next_key"] == ""
+
+
+@pytest.mark.asyncio
+async def test_post_api_normalizes_continuation_headers():
+    from app.services.brokers.kiwoom.client import KiwoomMockClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"return_code": 0, "return_msg": "정상"},
+            headers={"cont-yn": "Y", "next-key": "page-2"},
+        )
+
+    transport = httpx.MockTransport(handler)
+    client = KiwoomMockClient(
+        base_url=constants.MOCK_BASE_URL,
+        app_key="ak",
+        app_secret="sk",
+        account_no="123",
+    )
+    client.set_transport_for_test(transport, token="TKN")
+
+    result = await client.post_api(
+        api_id=constants.ACCOUNT_BALANCE_API_ID,
+        path="/api/dostk/acnt",
+        body={},
+    )
+    assert result["continuation"] == {"cont_yn": "Y", "next_key": "page-2"}
+
+
+@pytest.mark.asyncio
+async def test_post_api_rejects_non_mock_path_traversal():
+    from app.services.brokers.kiwoom.client import KiwoomMockClient
+
+    client = KiwoomMockClient(
+        base_url=constants.MOCK_BASE_URL,
+        app_key="ak",
+        app_secret="sk",
+        account_no="123",
+    )
+    with pytest.raises(ValueError):
+        await client.post_api(
+            api_id=constants.ORDER_BUY_API_ID,
+            path="https://api.kiwoom.com/api/dostk/ordr",
+            body={},
+        )

--- a/tests/test_kiwoom_client_endpoint_guard.py
+++ b/tests/test_kiwoom_client_endpoint_guard.py
@@ -1,0 +1,56 @@
+# tests/test_kiwoom_client_endpoint_guard.py
+"""Guard tests: Kiwoom mock client must refuse live URL and incomplete config."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.brokers.kiwoom.client import (
+    KiwoomMockClient,
+    KiwoomConfigurationError,
+    KiwoomEndpointError,
+)
+
+
+def test_constructor_rejects_live_base_url():
+    with pytest.raises(KiwoomEndpointError, match="mockapi.kiwoom.com"):
+        KiwoomMockClient(
+            base_url="https://api.kiwoom.com",
+            app_key="ak",
+            app_secret="sk",
+            account_no="123",
+        )
+
+
+def test_constructor_rejects_unrelated_base_url():
+    with pytest.raises(KiwoomEndpointError):
+        KiwoomMockClient(
+            base_url="https://example.com",
+            app_key="ak",
+            app_secret="sk",
+            account_no="123",
+        )
+
+
+def test_from_app_settings_fails_closed_when_disabled(monkeypatch):
+    from app.core import config as cfg
+
+    monkeypatch.setattr(cfg.settings, "kiwoom_mock_enabled", False)
+    with pytest.raises(KiwoomConfigurationError) as exc:
+        KiwoomMockClient.from_app_settings()
+    assert "KIWOOM_MOCK_ENABLED" in str(exc.value)
+
+
+def test_from_app_settings_fails_closed_when_credentials_missing(monkeypatch):
+    from app.core import config as cfg
+
+    monkeypatch.setattr(cfg.settings, "kiwoom_mock_enabled", True)
+    monkeypatch.setattr(cfg.settings, "kiwoom_mock_app_key", None)
+    monkeypatch.setattr(cfg.settings, "kiwoom_mock_app_secret", None)
+    monkeypatch.setattr(cfg.settings, "kiwoom_mock_account_no", None)
+    with pytest.raises(KiwoomConfigurationError) as exc:
+        KiwoomMockClient.from_app_settings()
+    msg = str(exc.value)
+    assert "KIWOOM_MOCK_APP_KEY" in msg
+    assert "KIWOOM_MOCK_APP_SECRET" in msg
+    assert "KIWOOM_MOCK_ACCOUNT_NO" in msg

--- a/tests/test_kiwoom_client_endpoint_guard.py
+++ b/tests/test_kiwoom_client_endpoint_guard.py
@@ -3,12 +3,14 @@
 
 from __future__ import annotations
 
+import httpx
 import pytest
 
+from app.services.brokers.kiwoom import constants
 from app.services.brokers.kiwoom.client import (
-    KiwoomMockClient,
     KiwoomConfigurationError,
     KiwoomEndpointError,
+    KiwoomMockClient,
 )
 
 
@@ -54,9 +56,6 @@ def test_from_app_settings_fails_closed_when_credentials_missing(monkeypatch):
     assert "KIWOOM_MOCK_APP_KEY" in msg
     assert "KIWOOM_MOCK_APP_SECRET" in msg
     assert "KIWOOM_MOCK_ACCOUNT_NO" in msg
-
-import httpx
-from app.services.brokers.kiwoom import constants
 
 
 @pytest.mark.asyncio

--- a/tests/test_kiwoom_client_endpoint_guard.py
+++ b/tests/test_kiwoom_client_endpoint_guard.py
@@ -146,3 +146,82 @@ async def test_post_api_rejects_non_mock_path_traversal():
             path="https://api.kiwoom.com/api/dostk/ordr",
             body={},
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "unsafe_path",
+    [
+        "//api.kiwoom.com/api/dostk/ordr",
+        "//evil.example.com/api/dostk/ordr",
+        "///api/dostk/ordr",
+        "http://api.kiwoom.com/api/dostk/ordr",
+        "https://api.kiwoom.com/api/dostk/ordr",
+        "api/dostk/ordr",
+        "",
+        "/api/dostk\\ordr",
+        "/api/dostk/ordr\nHost: evil.example.com",
+    ],
+)
+async def test_post_api_rejects_unsafe_path_shapes(unsafe_path):
+    """Network-path references and other non-relative shapes must be rejected.
+
+    A leading ``//`` is dangerous because URL-join semantics treat it as a
+    network-path reference and can re-target the request to a different host.
+    """
+
+    from app.services.brokers.kiwoom.client import KiwoomMockClient
+
+    transport_calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        transport_calls["count"] += 1
+        return httpx.Response(200, json={"return_code": 0})
+
+    client = KiwoomMockClient(
+        base_url=constants.MOCK_BASE_URL,
+        app_key="ak",
+        app_secret="sk",
+        account_no="123",
+    )
+    client.set_transport_for_test(httpx.MockTransport(handler), token="TKN")
+
+    with pytest.raises(ValueError):
+        await client.post_api(
+            api_id=constants.ORDER_BUY_API_ID,
+            path=unsafe_path,
+            body={},
+        )
+    assert transport_calls["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_post_api_rejects_request_resolved_to_non_mock_host():
+    """Defense-in-depth: if the resolved request host ever stops being
+    ``mockapi.kiwoom.com``, the send must be aborted before any I/O."""
+
+    transport_calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        transport_calls["count"] += 1
+        return httpx.Response(200, json={"return_code": 0})
+
+    client = KiwoomMockClient(
+        base_url=constants.MOCK_BASE_URL,
+        app_key="ak",
+        app_secret="sk",
+        account_no="123",
+    )
+    client.set_transport_for_test(httpx.MockTransport(handler), token="TKN")
+
+    # Simulate post-construction tampering: even if some future code mutates
+    # the base URL away from mockapi, post_api must still refuse to send.
+    client._base_url = "https://api.kiwoom.com"  # type: ignore[attr-defined]
+
+    with pytest.raises(ValueError, match="non-mock host"):
+        await client.post_api(
+            api_id=constants.ORDER_BUY_API_ID,
+            path="/api/dostk/ordr",
+            body={},
+        )
+    assert transport_calls["count"] == 0

--- a/tests/test_kiwoom_constants.py
+++ b/tests/test_kiwoom_constants.py
@@ -1,0 +1,55 @@
+# tests/test_kiwoom_constants.py
+"""Verify Kiwoom constants are correct, KRX-only, and mock-safe."""
+
+from __future__ import annotations
+
+from app.services.brokers.kiwoom import constants as k
+
+
+def test_base_urls_distinguish_mock_and_live():
+    assert k.MOCK_BASE_URL == "https://mockapi.kiwoom.com"
+    assert k.LIVE_BASE_URL == "https://api.kiwoom.com"
+    assert k.MOCK_BASE_URL != k.LIVE_BASE_URL
+
+
+def test_oauth_constants():
+    assert k.OAUTH_API_ID == "au10001"
+    assert k.OAUTH_PATH == "/oauth2/token"
+    assert k.OAUTH_CONTENT_TYPE == "application/json;charset=UTF-8"
+
+
+def test_order_api_ids():
+    assert k.ORDER_PATH == "/api/dostk/ordr"
+    assert k.ORDER_BUY_API_ID == "kt10000"
+    assert k.ORDER_SELL_API_ID == "kt10001"
+    assert k.ORDER_MODIFY_API_ID == "kt10002"
+    assert k.ORDER_CANCEL_API_ID == "kt10003"
+
+
+def test_account_api_ids():
+    assert k.ACCOUNT_ORDER_DETAIL_API_ID == "kt00007"
+    assert k.ACCOUNT_ORDER_STATUS_API_ID == "kt00009"
+    assert k.ACCOUNT_ORDERABLE_AMOUNT_API_ID == "kt00010"
+    assert k.ACCOUNT_BALANCE_API_ID == "kt00018"
+
+
+def test_chart_api_ids_present_but_deferred():
+    # Chart APIs are scaffolded only; not used by default OHLCV path.
+    assert k.CHART_MINUTE_API_ID == "ka10080"
+    assert k.CHART_DAILY_API_ID == "ka10081"
+    assert k.CHART_WEEKLY_API_ID == "ka10082"
+    assert k.CHART_MONTHLY_API_ID == "ka10083"
+
+
+def test_krx_is_only_supported_exchange_for_mock():
+    assert k.MOCK_EXCHANGE_KRX == "KRX"
+    assert "NXT" in k.MOCK_REJECTED_EXCHANGES
+    assert "SOR" in k.MOCK_REJECTED_EXCHANGES
+    assert k.MOCK_EXCHANGE_KRX not in k.MOCK_REJECTED_EXCHANGES
+
+
+def test_continuation_header_names():
+    assert k.HEADER_CONT_YN == "cont-yn"
+    assert k.HEADER_NEXT_KEY == "next-key"
+    assert k.HEADER_API_ID == "api-id"
+    assert k.HEADER_AUTHORIZATION == "authorization"

--- a/tests/test_kiwoom_constants.py
+++ b/tests/test_kiwoom_constants.py
@@ -53,3 +53,16 @@ def test_continuation_header_names():
     assert k.HEADER_NEXT_KEY == "next-key"
     assert k.HEADER_API_ID == "api-id"
     assert k.HEADER_AUTHORIZATION == "authorization"
+
+
+def test_kiwoom_capability_kr_paper_only():
+    from app.services.brokers.capabilities import (
+        BROKER_CAPABILITIES,
+        Broker,
+        Market,
+    )
+
+    cap = BROKER_CAPABILITIES[Broker.KIWOOM]
+    assert cap.markets == frozenset({Market.KR_EQUITY})
+    assert cap.supports_paper is True
+    assert cap.supports_live is False

--- a/tests/test_kiwoom_does_not_change_ohlcv_default.py
+++ b/tests/test_kiwoom_does_not_change_ohlcv_default.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 MARKET_DATA_QUOTES = (
     Path(__file__).parent.parent
     / "app"

--- a/tests/test_kiwoom_does_not_change_ohlcv_default.py
+++ b/tests/test_kiwoom_does_not_change_ohlcv_default.py
@@ -1,0 +1,41 @@
+# tests/test_kiwoom_does_not_change_ohlcv_default.py
+"""Regression guard: ROB-97 must not change the default KR OHLCV source."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+MARKET_DATA_QUOTES = (
+    Path(__file__).parent.parent
+    / "app"
+    / "mcp_server"
+    / "tooling"
+    / "market_data_quotes.py"
+)
+
+
+def test_market_data_quotes_does_not_import_kiwoom():
+    text = MARKET_DATA_QUOTES.read_text(encoding="utf-8")
+    assert "kiwoom" not in text.lower(), (
+        "ROB-97 explicitly defers Kiwoom OHLCV; market_data_quotes.py must "
+        "remain on the KIS path."
+    )
+
+
+def test_kiwoom_market_data_skeleton_raises_on_use():
+    import asyncio
+
+    from app.services.brokers.kiwoom.domestic_market_data import (
+        KiwoomDomesticMarketDataClient,
+    )
+
+    client = KiwoomDomesticMarketDataClient()
+
+    async def _call():
+        await client.fetch_daily_candles()
+
+    import pytest
+
+    with pytest.raises(NotImplementedError):
+        asyncio.run(_call())

--- a/tests/test_kiwoom_domestic_account.py
+++ b/tests/test_kiwoom_domestic_account.py
@@ -1,0 +1,79 @@
+# tests/test_kiwoom_domestic_account.py
+"""Verify Kiwoom domestic account/order-history queries."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.services.brokers.kiwoom import constants
+from app.services.brokers.kiwoom.domestic_account import (
+    KiwoomDomesticAccountClient,
+)
+
+
+class FakeClient:
+    def __init__(self, payload: dict[str, Any] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.account_no = "12345678-01"
+        self._payload = payload or {
+            "return_code": 0,
+            "return_msg": "정상",
+            "rows": [],
+            "continuation": {"cont_yn": "N", "next_key": ""},
+        }
+
+    async def post_api(self, **kwargs: Any) -> dict[str, Any]:
+        self.calls.append(kwargs)
+        return self._payload
+
+
+@pytest.mark.asyncio
+async def test_get_orderable_amount_uses_kt00010():
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_orderable_amount(symbol="005930")
+    assert fake.calls[-1]["api_id"] == constants.ACCOUNT_ORDERABLE_AMOUNT_API_ID
+    assert fake.calls[-1]["body"]["stk_cd"] == "005930"
+
+
+@pytest.mark.asyncio
+async def test_get_balance_uses_kt00018():
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_balance()
+    assert fake.calls[-1]["api_id"] == constants.ACCOUNT_BALANCE_API_ID
+
+
+@pytest.mark.asyncio
+async def test_get_order_status_uses_kt00009_and_passes_continuation():
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_order_status(cont_yn="Y", next_key="page-2")
+    call = fake.calls[-1]
+    assert call["api_id"] == constants.ACCOUNT_ORDER_STATUS_API_ID
+    assert call["cont_yn"] == "Y"
+    assert call["next_key"] == "page-2"
+
+
+@pytest.mark.asyncio
+async def test_get_order_detail_uses_kt00007():
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_order_detail(order_no="0000111222")
+    call = fake.calls[-1]
+    assert call["api_id"] == constants.ACCOUNT_ORDER_DETAIL_API_ID
+    assert call["body"]["ord_no"] == "0000111222"
+
+
+@pytest.mark.asyncio
+async def test_account_methods_never_log_account_no(caplog):
+    import logging
+
+    caplog.set_level(logging.DEBUG, logger="app.services.brokers.kiwoom")
+    fake = FakeClient()
+    acct = KiwoomDomesticAccountClient(fake)
+    await acct.get_balance()
+    rendered = "\n".join(rec.getMessage() for rec in caplog.records)
+    assert "12345678-01" not in rendered

--- a/tests/test_kiwoom_domestic_orders.py
+++ b/tests/test_kiwoom_domestic_orders.py
@@ -1,0 +1,150 @@
+# tests/test_kiwoom_domestic_orders.py
+"""Verify Kiwoom domestic order payloads for buy/sell/modify/cancel."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from app.services.brokers.kiwoom import constants
+from app.services.brokers.kiwoom.domestic_orders import (
+    KiwoomDomesticOrderClient,
+    KiwoomOrderRejected,
+)
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.account_no = "12345678-01"
+
+    async def post_api(
+        self,
+        *,
+        api_id: str,
+        path: str,
+        body: dict[str, Any],
+        cont_yn: str | None = None,
+        next_key: str | None = None,
+    ) -> dict[str, Any]:
+        self.calls.append(
+            {
+                "api_id": api_id,
+                "path": path,
+                "body": body,
+                "cont_yn": cont_yn,
+                "next_key": next_key,
+            }
+        )
+        return {
+            "return_code": 0,
+            "return_msg": "정상",
+            "ord_no": "0000111222",
+            "continuation": {"cont_yn": "N", "next_key": ""},
+        }
+
+
+@pytest.mark.asyncio
+async def test_buy_order_uses_kt10000_and_krx_only():
+    fake = FakeClient()
+    orders = KiwoomDomesticOrderClient(fake)
+
+    result = await orders.place_buy_order(
+        symbol="005930",
+        quantity=1,
+        price=70000,
+    )
+    call = fake.calls[-1]
+
+    assert call["api_id"] == constants.ORDER_BUY_API_ID
+    assert call["path"] == constants.ORDER_PATH
+    assert call["body"]["dmst_stex_tp"] == constants.MOCK_EXCHANGE_KRX
+    assert call["body"]["stk_cd"] == "005930"
+    assert call["body"]["ord_qty"] == "1"
+    assert call["body"]["ord_uv"] == "70000"
+    assert result["ord_no"] == "0000111222"
+
+
+@pytest.mark.asyncio
+async def test_sell_order_uses_kt10001():
+    fake = FakeClient()
+    orders = KiwoomDomesticOrderClient(fake)
+
+    await orders.place_sell_order(symbol="005930", quantity=2, price=71000)
+
+    assert fake.calls[-1]["api_id"] == constants.ORDER_SELL_API_ID
+    assert fake.calls[-1]["body"]["ord_qty"] == "2"
+    assert fake.calls[-1]["body"]["ord_uv"] == "71000"
+
+
+@pytest.mark.asyncio
+async def test_modify_order_uses_kt10002_and_carries_orig_no():
+    fake = FakeClient()
+    orders = KiwoomDomesticOrderClient(fake)
+
+    await orders.modify_order(
+        original_order_no="0000111222",
+        symbol="005930",
+        new_quantity=3,
+        new_price=72000,
+    )
+
+    body = fake.calls[-1]["body"]
+    assert fake.calls[-1]["api_id"] == constants.ORDER_MODIFY_API_ID
+    assert body["orig_ord_no"] == "0000111222"
+    assert body["mdfy_qty"] == "3"
+    assert body["mdfy_uv"] == "72000"
+    assert body["dmst_stex_tp"] == constants.MOCK_EXCHANGE_KRX
+
+
+@pytest.mark.asyncio
+async def test_cancel_order_uses_kt10003():
+    fake = FakeClient()
+    orders = KiwoomDomesticOrderClient(fake)
+
+    await orders.cancel_order(
+        original_order_no="0000111222",
+        symbol="005930",
+        cancel_quantity=1,
+    )
+
+    body = fake.calls[-1]["body"]
+    assert fake.calls[-1]["api_id"] == constants.ORDER_CANCEL_API_ID
+    assert body["orig_ord_no"] == "0000111222"
+    assert body["cncl_qty"] == "1"
+    assert body["dmst_stex_tp"] == constants.MOCK_EXCHANGE_KRX
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_exchange", ["NXT", "SOR", "nxt", "sor"])
+async def test_buy_rejects_nxt_and_sor(bad_exchange):
+    fake = FakeClient()
+    orders = KiwoomDomesticOrderClient(fake)
+
+    with pytest.raises(KiwoomOrderRejected, match="KRX"):
+        await orders.place_buy_order(
+            symbol="005930",
+            quantity=1,
+            price=70000,
+            exchange=bad_exchange,
+        )
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_id",
+    ["", "   ", "../etc", "a/b", "a?b=c", "a,b", "a b", "a\nb"],
+)
+async def test_cancel_rejects_unsafe_order_ids(bad_id):
+    fake = FakeClient()
+    orders = KiwoomDomesticOrderClient(fake)
+
+    with pytest.raises(KiwoomOrderRejected):
+        await orders.cancel_order(
+            original_order_no=bad_id,
+            symbol="005930",
+            cancel_quantity=1,
+        )
+    assert fake.calls == []

--- a/tests/test_kiwoom_domestic_orders.py
+++ b/tests/test_kiwoom_domestic_orders.py
@@ -148,3 +148,110 @@ async def test_cancel_rejects_unsafe_order_ids(bad_id):
             cancel_quantity=1,
         )
     assert fake.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_quantity", [0, -1])
+async def test_buy_rejects_non_positive_quantity_before_post_api(bad_quantity):
+    fake = FakeClient()
+    orders = KiwoomDomesticOrderClient(fake)
+
+    with pytest.raises(KiwoomOrderRejected, match="quantity"):
+        await orders.place_buy_order(
+            symbol="005930",
+            quantity=bad_quantity,
+            price=70000,
+        )
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_price", [0, -1])
+async def test_buy_rejects_non_positive_price_before_post_api(bad_price):
+    fake = FakeClient()
+    orders = KiwoomDomesticOrderClient(fake)
+
+    with pytest.raises(KiwoomOrderRejected, match="price"):
+        await orders.place_buy_order(
+            symbol="005930",
+            quantity=1,
+            price=bad_price,
+        )
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_quantity", [0, -1])
+async def test_sell_rejects_non_positive_quantity_before_post_api(bad_quantity):
+    fake = FakeClient()
+    orders = KiwoomDomesticOrderClient(fake)
+
+    with pytest.raises(KiwoomOrderRejected, match="quantity"):
+        await orders.place_sell_order(
+            symbol="005930",
+            quantity=bad_quantity,
+            price=71000,
+        )
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_price", [0, -1])
+async def test_sell_rejects_non_positive_price_before_post_api(bad_price):
+    fake = FakeClient()
+    orders = KiwoomDomesticOrderClient(fake)
+
+    with pytest.raises(KiwoomOrderRejected, match="price"):
+        await orders.place_sell_order(
+            symbol="005930",
+            quantity=1,
+            price=bad_price,
+        )
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_quantity", [0, -1])
+async def test_modify_rejects_non_positive_quantity_before_post_api(bad_quantity):
+    fake = FakeClient()
+    orders = KiwoomDomesticOrderClient(fake)
+
+    with pytest.raises(KiwoomOrderRejected, match="new_quantity"):
+        await orders.modify_order(
+            original_order_no="0000111222",
+            symbol="005930",
+            new_quantity=bad_quantity,
+            new_price=72000,
+        )
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_price", [0, -1])
+async def test_modify_rejects_non_positive_price_before_post_api(bad_price):
+    fake = FakeClient()
+    orders = KiwoomDomesticOrderClient(fake)
+
+    with pytest.raises(KiwoomOrderRejected, match="new_price"):
+        await orders.modify_order(
+            original_order_no="0000111222",
+            symbol="005930",
+            new_quantity=1,
+            new_price=bad_price,
+        )
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_quantity", [0, -1])
+async def test_cancel_rejects_non_positive_quantity_before_post_api(bad_quantity):
+    fake = FakeClient()
+    orders = KiwoomDomesticOrderClient(fake)
+
+    with pytest.raises(KiwoomOrderRejected, match="cancel_quantity"):
+        await orders.cancel_order(
+            original_order_no="0000111222",
+            symbol="005930",
+            cancel_quantity=bad_quantity,
+        )
+    assert fake.calls == []

--- a/tests/test_kiwoom_mock_config.py
+++ b/tests/test_kiwoom_mock_config.py
@@ -1,0 +1,51 @@
+# tests/test_kiwoom_mock_config.py
+"""Verify Kiwoom mock settings are off-by-default and fail-closed when partial."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.core.config import settings, validate_kiwoom_mock_config
+
+
+def test_settings_have_kiwoom_mock_defaults():
+    assert settings.kiwoom_mock_enabled is False
+    assert settings.kiwoom_mock_app_key is None
+    assert settings.kiwoom_mock_app_secret is None
+    assert settings.kiwoom_mock_account_no is None
+    assert settings.kiwoom_mock_base_url == "https://mockapi.kiwoom.com"
+    assert settings.kiwoom_base_url == "https://api.kiwoom.com"
+
+
+def test_validate_kiwoom_mock_config_lists_missing_when_disabled():
+    obj = SimpleNamespace(
+        kiwoom_mock_enabled=False,
+        kiwoom_mock_app_key="x",
+        kiwoom_mock_app_secret="x",
+        kiwoom_mock_account_no="x",
+    )
+    missing = validate_kiwoom_mock_config(obj)
+    assert "KIWOOM_MOCK_ENABLED" in missing
+
+
+def test_validate_kiwoom_mock_config_lists_each_missing_field():
+    obj = SimpleNamespace(
+        kiwoom_mock_enabled=True,
+        kiwoom_mock_app_key=None,
+        kiwoom_mock_app_secret="   ",
+        kiwoom_mock_account_no="",
+    )
+    missing = validate_kiwoom_mock_config(obj)
+    assert "KIWOOM_MOCK_APP_KEY" in missing
+    assert "KIWOOM_MOCK_APP_SECRET" in missing
+    assert "KIWOOM_MOCK_ACCOUNT_NO" in missing
+
+
+def test_validate_kiwoom_mock_config_returns_empty_when_complete():
+    obj = SimpleNamespace(
+        kiwoom_mock_enabled=True,
+        kiwoom_mock_app_key="ak",
+        kiwoom_mock_app_secret="sk",
+        kiwoom_mock_account_no="123",
+    )
+    assert validate_kiwoom_mock_config(obj) == []

--- a/tests/test_mcp_kiwoom_order_variants.py
+++ b/tests/test_mcp_kiwoom_order_variants.py
@@ -150,3 +150,280 @@ async def test_cancel_rejects_unsafe_order_ids(monkeypatch, bad_id):
     )
     assert response["success"] is False
     assert "order" in response["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# ROB-105: confirmed actions must NOT return stub success
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_place_order_confirmed_returns_explicit_not_implemented_failure(monkeypatch):
+    """dry_run=False + confirm=True must NOT return stub success — that would
+    trick operators into thinking a real mock order was submitted."""
+
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    impl_calls = {"count": 0}
+
+    async def fake_impl(**kwargs):
+        impl_calls["count"] += 1
+        return {"success": True}
+
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+    monkeypatch.setattr(mod, "_kiwoom_mock_place_order_impl", fake_impl)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_place_order"](
+        symbol="005930",
+        side="buy",
+        quantity=1,
+        price=70000,
+        dry_run=False,
+        confirm=True,
+    )
+
+    assert response["success"] is False
+    assert "not implemented" in response["error"].lower()
+    assert response["account_mode"] == "kiwoom_mock"
+    assert impl_calls["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_cancel_order_confirmed_returns_explicit_not_implemented_failure(monkeypatch):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    impl_calls = {"count": 0}
+
+    async def fake_impl(**kwargs):
+        impl_calls["count"] += 1
+        return {"success": True}
+
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+    monkeypatch.setattr(mod, "_kiwoom_mock_cancel_impl", fake_impl)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_cancel_order"](
+        order_id="0000111222",
+        symbol="005930",
+        dry_run=False,
+        confirm=True,
+    )
+
+    assert response["success"] is False
+    assert "not implemented" in response["error"].lower()
+    assert impl_calls["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_modify_order_confirmed_returns_explicit_not_implemented_failure(monkeypatch):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    impl_calls = {"count": 0}
+
+    async def fake_impl(**kwargs):
+        impl_calls["count"] += 1
+        return {"success": True}
+
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+    monkeypatch.setattr(mod, "_kiwoom_mock_modify_impl", fake_impl)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_modify_order"](
+        order_id="0000111222",
+        symbol="005930",
+        new_price=72000,
+        new_quantity=2,
+        dry_run=False,
+        confirm=True,
+    )
+
+    assert response["success"] is False
+    assert "not implemented" in response["error"].lower()
+    assert impl_calls["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_place_order_dry_run_false_without_confirm_blocked(monkeypatch):
+    """dry_run=False + confirm=False must continue to be blocked (separate path)."""
+
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    impl_calls = {"count": 0}
+
+    async def fake_impl(**kwargs):
+        impl_calls["count"] += 1
+        return {"success": True}
+
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+    monkeypatch.setattr(mod, "_kiwoom_mock_place_order_impl", fake_impl)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_place_order"](
+        symbol="005930",
+        side="buy",
+        quantity=1,
+        price=70000,
+        dry_run=False,
+        confirm=False,
+    )
+
+    assert response["success"] is False
+    assert "confirm=true" in response["error"].lower()
+    assert impl_calls["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# ROB-105: positive-amount validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_qty", [0, -1, -1000])
+async def test_place_order_rejects_non_positive_quantity(monkeypatch, bad_qty):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    impl_calls = {"count": 0}
+
+    async def fake_impl(**kwargs):
+        impl_calls["count"] += 1
+        return {"success": True}
+
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+    monkeypatch.setattr(mod, "_kiwoom_mock_place_order_impl", fake_impl)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_place_order"](
+        symbol="005930",
+        side="buy",
+        quantity=bad_qty,
+        price=70000,
+    )
+
+    assert response["success"] is False
+    assert "quantity" in response["error"].lower()
+    assert impl_calls["count"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_price", [0, -1, -100])
+async def test_place_order_rejects_non_positive_price(monkeypatch, bad_price):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    impl_calls = {"count": 0}
+
+    async def fake_impl(**kwargs):
+        impl_calls["count"] += 1
+        return {"success": True}
+
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+    monkeypatch.setattr(mod, "_kiwoom_mock_place_order_impl", fake_impl)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_place_order"](
+        symbol="005930",
+        side="buy",
+        quantity=1,
+        price=bad_price,
+    )
+
+    assert response["success"] is False
+    assert "price" in response["error"].lower()
+    assert impl_calls["count"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_qty", [0, -1])
+async def test_cancel_order_rejects_non_positive_cancel_quantity(monkeypatch, bad_qty):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    impl_calls = {"count": 0}
+
+    async def fake_impl(**kwargs):
+        impl_calls["count"] += 1
+        return {"success": True}
+
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+    monkeypatch.setattr(mod, "_kiwoom_mock_cancel_impl", fake_impl)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_cancel_order"](
+        order_id="0000111222",
+        symbol="005930",
+        cancel_quantity=bad_qty,
+    )
+
+    assert response["success"] is False
+    assert "cancel_quantity" in response["error"].lower()
+    assert impl_calls["count"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "kwargs"),
+    [
+        ("new_quantity", {"new_quantity": 0, "new_price": 100}),
+        ("new_quantity", {"new_quantity": -1, "new_price": 100}),
+        ("new_price", {"new_quantity": 1, "new_price": 0}),
+        ("new_price", {"new_quantity": 1, "new_price": -100}),
+    ],
+)
+async def test_modify_order_rejects_non_positive_amounts(monkeypatch, field, kwargs):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    impl_calls = {"count": 0}
+
+    async def fake_impl(**kwargs):
+        impl_calls["count"] += 1
+        return {"success": True}
+
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+    monkeypatch.setattr(mod, "_kiwoom_mock_modify_impl", fake_impl)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_modify_order"](
+        order_id="0000111222",
+        symbol="005930",
+        **kwargs,
+    )
+
+    assert response["success"] is False
+    assert field in response["error"].lower()
+    assert impl_calls["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_modify_order_allows_omitted_amounts(monkeypatch):
+    """Either new_quantity or new_price may be omitted (only the supplied
+    field is validated and forwarded)."""
+
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    captured: dict[str, Any] = {}
+
+    async def fake_impl(**kwargs):
+        captured.update(kwargs)
+        return {"success": True}
+
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+    monkeypatch.setattr(mod, "_kiwoom_mock_modify_impl", fake_impl)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_modify_order"](
+        order_id="0000111222",
+        symbol="005930",
+        new_price=72000,
+    )
+
+    assert response["success"] is True
+    assert captured["new_price"] == 72000
+    assert captured["new_quantity"] is None

--- a/tests/test_mcp_kiwoom_order_variants.py
+++ b/tests/test_mcp_kiwoom_order_variants.py
@@ -1,0 +1,152 @@
+# tests/test_mcp_kiwoom_order_variants.py
+"""Verify kiwoom_mock_* MCP tools are registered, fail-closed, and KRX-only.
+
+Mirrors the patterns in tests/test_mcp_kis_order_variants.py.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+class DummyMCP:
+    def __init__(self) -> None:
+        self.tools: dict[str, Any] = {}
+
+    def tool(self, *, name: str, description: str = ""):  # noqa: ARG002
+        def decorator(func):
+            self.tools[name] = func
+            return func
+
+        return decorator
+
+
+EXPECTED_TOOL_NAMES = {
+    "kiwoom_mock_preview_order",
+    "kiwoom_mock_place_order",
+    "kiwoom_mock_cancel_order",
+    "kiwoom_mock_modify_order",
+    "kiwoom_mock_get_order_history",
+    "kiwoom_mock_get_positions",
+    "kiwoom_mock_get_orderable_cash",
+}
+
+
+def _register(mcp: DummyMCP) -> None:
+    from app.mcp_server.tooling import orders_kiwoom_variants
+
+    orders_kiwoom_variants.register(mcp)
+
+
+def test_all_seven_tools_register():
+    mcp = DummyMCP()
+    _register(mcp)
+    assert EXPECTED_TOOL_NAMES.issubset(set(mcp.tools))
+
+
+@pytest.mark.asyncio
+async def test_place_order_fails_closed_when_mock_disabled(monkeypatch):
+    from app.core import config as cfg
+
+    monkeypatch.setattr(cfg.settings, "kiwoom_mock_enabled", False)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_place_order"](
+        symbol="005930",
+        side="buy",
+        quantity=1,
+        price=70000,
+    )
+
+    assert response["success"] is False
+    assert "KIWOOM_MOCK_ENABLED" in response["error"]
+    assert response["account_mode"] == "kiwoom_mock"
+
+
+@pytest.mark.asyncio
+async def test_place_order_defaults_to_dry_run(monkeypatch):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    captured: dict[str, Any] = {}
+
+    async def fake_impl(**kwargs):
+        captured.update(kwargs)
+        return {"success": True, "echo": kwargs}
+
+    monkeypatch.setattr(mod, "_kiwoom_mock_place_order_impl", fake_impl)
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_place_order"](
+        symbol="005930",
+        side="buy",
+        quantity=1,
+        price=70000,
+    )
+
+    assert response["success"] is True
+    assert captured["dry_run"] is True
+
+
+@pytest.mark.asyncio
+async def test_place_order_rejects_non_kr_market(monkeypatch):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_place_order"](
+        symbol="AAPL",
+        side="buy",
+        quantity=1,
+        price=100,
+        market="us",
+    )
+    assert response["success"] is False
+    assert "kr" in response["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_place_order_rejects_nxt_or_sor(monkeypatch):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    for bad in ("NXT", "SOR", "nxt"):
+        response = await mcp.tools["kiwoom_mock_place_order"](
+            symbol="005930",
+            side="buy",
+            quantity=1,
+            price=70000,
+            exchange=bad,
+        )
+        assert response["success"] is False
+        assert "krx" in response["error"].lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_id",
+    ["", "   ", "../etc", "a/b", "a?b=c", "a,b", "a b", "a\nb"],
+)
+async def test_cancel_rejects_unsafe_order_ids(monkeypatch, bad_id):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+    mcp = DummyMCP()
+    _register(mcp)
+
+    response = await mcp.tools["kiwoom_mock_cancel_order"](
+        order_id=bad_id,
+        symbol="005930",
+    )
+    assert response["success"] is False
+    assert "order" in response["error"].lower()

--- a/tests/test_mcp_kiwoom_order_variants.py
+++ b/tests/test_mcp_kiwoom_order_variants.py
@@ -158,7 +158,9 @@ async def test_cancel_rejects_unsafe_order_ids(monkeypatch, bad_id):
 
 
 @pytest.mark.asyncio
-async def test_place_order_confirmed_returns_explicit_not_implemented_failure(monkeypatch):
+async def test_place_order_confirmed_returns_explicit_not_implemented_failure(
+    monkeypatch,
+):
     """dry_run=False + confirm=True must NOT return stub success — that would
     trick operators into thinking a real mock order was submitted."""
 
@@ -191,7 +193,9 @@ async def test_place_order_confirmed_returns_explicit_not_implemented_failure(mo
 
 
 @pytest.mark.asyncio
-async def test_cancel_order_confirmed_returns_explicit_not_implemented_failure(monkeypatch):
+async def test_cancel_order_confirmed_returns_explicit_not_implemented_failure(
+    monkeypatch,
+):
     from app.mcp_server.tooling import orders_kiwoom_variants as mod
 
     impl_calls = {"count": 0}
@@ -218,7 +222,9 @@ async def test_cancel_order_confirmed_returns_explicit_not_implemented_failure(m
 
 
 @pytest.mark.asyncio
-async def test_modify_order_confirmed_returns_explicit_not_implemented_failure(monkeypatch):
+async def test_modify_order_confirmed_returns_explicit_not_implemented_failure(
+    monkeypatch,
+):
     from app.mcp_server.tooling import orders_kiwoom_variants as mod
 
     impl_calls = {"count": 0}


### PR DESCRIPTION
## Summary

- New mock-only Kiwoom Securities broker package at `app/services/brokers/kiwoom/` (constants, OAuth `KiwoomAuthClient` with `expires_dt` cache, `KiwoomMockClient` with `post_api()` helper, `KiwoomDomesticOrderClient` for `kt10000`–`kt10003`, `KiwoomDomesticAccountClient` for `kt00007`/`kt00009`/`kt00010`/`kt00018`, plus a deferred `KiwoomDomesticMarketDataClient` skeleton for `ka10080`–`ka10083`).
- Seven explicit `kiwoom_mock_*` MCP tools in `app/mcp_server/tooling/orders_kiwoom_variants.py` (`preview_order`, `place_order`, `cancel_order`, `modify_order`, `get_order_history`, `get_positions`, `get_orderable_cash`), all hard-pinned to `account_mode="kiwoom_mock"`, KRX-only, `dry_run=True` by default, and rejecting `NXT`/`SOR` / unsafe order ids before any side effect.
- New `kiwoom_mock_*` settings in `app/core/config.py` (disabled by default) plus `validate_kiwoom_mock_config()` mirroring the KIS validator.
- Capability registry corrected: `Broker.KIWOOM` now declares KR-only paper support and `supports_live=False`.
- Regression guard test ensures `app/mcp_server/tooling/market_data_quotes.py` does **not** import Kiwoom — KR OHLCV default remains on KIS.

## Out of scope (follow-up operator/config step)

- Real Kiwoom app key / secret / account configuration.
- Actual broker smoke against `https://mockapi.kiwoom.com`.
- Kiwoom live trading (capability still `supports_live=False`).
- Switching the KR OHLCV default away from KIS (the `ka10080`–`ka10083` skeleton intentionally raises `NotImplementedError`).

## Test plan

- [x] `uv run pytest tests/test_kiwoom_constants.py tests/test_kiwoom_mock_config.py tests/test_kiwoom_client_endpoint_guard.py tests/test_kiwoom_auth_token_cache.py tests/test_kiwoom_domestic_orders.py tests/test_kiwoom_domestic_account.py tests/test_mcp_kiwoom_order_variants.py tests/test_kiwoom_does_not_change_ohlcv_default.py -q` → 58 passed
- [x] `uv run pytest tests/test_mcp_kis_order_variants.py tests/test_kis_mock_routing.py -q` (KIS regression baseline) → 38 passed
- [x] `uv run ruff check app tests` → clean
- [x] `uv run ruff format --check app tests` → clean
- [x] `git diff --check` → clean
- [x] No real credentials present in diff (all examples use placeholder strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mock-only Kiwoom broker support for paper trading on Korean domestic market (KRX exchange)
  * Introduced Kiwoom order management tools: preview, place, modify, and cancel orders
  * Added account queries: order history, positions, and orderable cash retrieval
  * Implemented configuration-driven mock broker access with OAuth token management

* **Updates**
  * Updated Kiwoom broker capabilities to support KR equity markets and paper trading only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->