### PR TITLE
fix(ROB-99): allow Discord bot channel fallback

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -235,6 +235,7 @@ class Settings(BaseSettings):
     crypto_pending_order_failure_channel_id: str = "1500722535678083102"
     crypto_pending_order_alert_webhook_url: str | None = None
     crypto_pending_order_failure_webhook_url: str | None = None
+    crypto_pending_order_discord_bot_token: SecretStr | None = None
 
     # Strategy
     top_n: int = 30

--- a/app/services/crypto_pending_order_alert_service.py
+++ b/app/services/crypto_pending_order_alert_service.py
@@ -54,6 +54,7 @@ class CryptoPendingOrderAlertConfig:
     failure_channel_id: str
     normal_webhook_url: str | None
     failure_webhook_url: str | None
+    discord_bot_token: str | None
     trader_base_url: str
 
     @classmethod
@@ -84,8 +85,21 @@ class CryptoPendingOrderAlertConfig:
             failure_webhook_url=getattr(
                 settings_obj, "crypto_pending_order_failure_webhook_url", None
             ),
+            discord_bot_token=_resolve_secret_setting(
+                getattr(settings_obj, "crypto_pending_order_discord_bot_token", None)
+            ),
             trader_base_url=str(getattr(settings_obj, "trader_base_url", "") or ""),
         )
+
+
+def _resolve_secret_setting(value: Any) -> str | None:
+    if value in (None, ""):
+        return None
+    getter = getattr(value, "get_secret_value", None)
+    if callable(getter):
+        value = getter()
+    raw = str(value).strip()
+    return raw or None
 
 
 def _safe_float(value: Any) -> float | None:
@@ -293,13 +307,52 @@ async def _default_price_lookup(symbols: list[str]) -> dict[str, float]:
     return await fetch_multiple_current_prices(symbols, use_cache=False)
 
 
-async def _default_discord_sender(webhook_url: str, content: str) -> bool:
+async def _send_discord_channel_message(
+    *,
+    http_client: httpx.AsyncClient,
+    bot_token: str,
+    channel_id: str,
+    content: str,
+) -> bool:
+    try:
+        response = await http_client.post(
+            f"https://discord.com/api/v10/channels/{channel_id}/messages",
+            headers={"Authorization": f"Bot {bot_token}"},
+            json={"content": content},
+        )
+        response.raise_for_status()
+        return True
+    except Exception:
+        logger.exception("Failed to send Discord channel message to %s", channel_id)
+        return False
+
+
+async def _default_discord_sender(delivery_target: str, content: str) -> bool:
     async with httpx.AsyncClient(timeout=10.0, trust_env=False) as client:
+        if delivery_target.startswith("discord-bot://"):
+            _, rest = delivery_target.split("://", maxsplit=1)
+            channel_id, bot_token = rest.split("/", maxsplit=1)
+            return await _send_discord_channel_message(
+                http_client=client,
+                bot_token=bot_token,
+                channel_id=channel_id,
+                content=content,
+            )
         return await send_discord_content_single(
             http_client=client,
-            webhook_url=webhook_url,
+            webhook_url=delivery_target,
             content=content,
         )
+
+
+def _delivery_target(
+    webhook_url: str | None, channel_id: str, bot_token: str | None
+) -> str | None:
+    if webhook_url:
+        return webhook_url
+    if bot_token:
+        return f"discord-bot://{channel_id}/{bot_token}"
+    return None
 
 
 async def _send_failure(
@@ -325,13 +378,18 @@ async def _send_failure(
     )
     if dry_run:
         return {"failure_alert_sent": False, "failure_message": message}
-    if not config.failure_webhook_url:
+    target = _delivery_target(
+        config.failure_webhook_url,
+        config.failure_channel_id,
+        config.discord_bot_token,
+    )
+    if not target:
         return {
             "failure_alert_sent": False,
             "failure_message": message,
-            "failure_delivery_error": "missing failure webhook url",
+            "failure_delivery_error": "missing failure Discord webhook URL or bot token",
         }
-    delivered = await sender(config.failure_webhook_url, message)
+    delivered = await sender(target, message)
     return {"failure_alert_sent": delivered, "failure_message": message}
 
 
@@ -493,17 +551,22 @@ async def run_crypto_pending_order_alert(
             "orders": [asdict(order) for order in normalized],
         }
 
-    if not config.normal_webhook_url:
+    target = _delivery_target(
+        config.normal_webhook_url,
+        config.normal_channel_id,
+        config.discord_bot_token,
+    )
+    if not target:
         failure = await _send_failure(
             config=config,
             sender=discord_sender,
             stage="discord_delivery",
-            reason="missing normal webhook url",
-            failure_class="MissingDiscordWebhook",
+            reason="missing normal Discord webhook URL or bot token",
+            failure_class="MissingDiscordDeliveryTarget",
             partial=True,
             run_ts=run_ts,
             dry_run=False,
-            hint="Configure the dedicated CRYPTO_PENDING_ORDER_ALERT_WEBHOOK_URL for channel 1500719153508515870.",
+            hint="Configure CRYPTO_PENDING_ORDER_ALERT_WEBHOOK_URL or CRYPTO_PENDING_ORDER_DISCORD_BOT_TOKEN for channel 1500719153508515870.",
         )
         return (
             summary
@@ -515,7 +578,7 @@ async def run_crypto_pending_order_alert(
             | failure
         )
 
-    delivered = await discord_sender(config.normal_webhook_url, message)
+    delivered = await discord_sender(target, message)
     if not delivered:
         failure = await _send_failure(
             config=config,

--- a/tests/test_crypto_pending_order_alert_service.py
+++ b/tests/test_crypto_pending_order_alert_service.py
@@ -24,6 +24,7 @@ def _config() -> CryptoPendingOrderAlertConfig:
         failure_channel_id="1500722535678083102",
         normal_webhook_url="https://discord.example/normal",
         failure_webhook_url="https://discord.example/failure",
+        discord_bot_token=None,
         trader_base_url="https://trader.robinco.dev",
     )
 
@@ -313,6 +314,117 @@ async def test_normal_delivery_failure_is_surfaced_and_failure_alert_sent():
     assert [webhook for webhook, _ in sends] == [
         "https://discord.example/normal",
         "https://discord.example/failure",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_bot_token_fallback_targets_configured_channel_ids():
+    sends: list[tuple[str, str]] = []
+    config = CryptoPendingOrderAlertConfig(
+        enabled=True,
+        normal_channel_id="1500719153508515870",
+        failure_channel_id="1500722535678083102",
+        normal_webhook_url=None,
+        failure_webhook_url=None,
+        discord_bot_token="x",
+        trader_base_url="https://trader.robinco.dev",
+    )
+
+    async def lookup() -> dict[str, Any]:
+        return {"success": True, "orders": [_order()], "errors": []}
+
+    async def prices(symbols: list[str]) -> dict[str, float]:
+        return {"KRW-BTC": 95_000_000}
+
+    async def sender(target: str, content: str) -> bool:
+        sends.append((target, content))
+        return True
+
+    result = await run_crypto_pending_order_alert(
+        execute=True,
+        config=config,
+        order_lookup=lookup,
+        price_lookup=prices,
+        discord_sender=sender,
+        now=NOW,
+    )
+
+    assert result["status"] == "success"
+    assert sends[0][0] == "discord-bot://1500719153508515870/x"
+    assert "KRW-BTC" in sends[0][1]
+
+
+@pytest.mark.asyncio
+async def test_missing_all_discord_targets_routes_to_failure_without_delivery():
+    config = CryptoPendingOrderAlertConfig(
+        enabled=True,
+        normal_channel_id="1500719153508515870",
+        failure_channel_id="1500722535678083102",
+        normal_webhook_url=None,
+        failure_webhook_url=None,
+        discord_bot_token=None,
+        trader_base_url="https://trader.robinco.dev",
+    )
+
+    async def lookup() -> dict[str, Any]:
+        return {"success": True, "orders": [_order()], "errors": []}
+
+    async def prices(symbols: list[str]) -> dict[str, float]:
+        return {"KRW-BTC": 95_000_000}
+
+    result = await run_crypto_pending_order_alert(
+        execute=True,
+        config=config,
+        order_lookup=lookup,
+        price_lookup=prices,
+        now=NOW,
+    )
+
+    assert result["status"] == "failed"
+    assert result["stage"] == "discord_delivery"
+    assert result["failure_alert_sent"] is False
+    assert (
+        "missing failure Discord webhook URL or bot token"
+        in result["failure_delivery_error"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_normal_delivery_failure_uses_bot_token_failure_channel():
+    sends: list[tuple[str, str]] = []
+    config = CryptoPendingOrderAlertConfig(
+        enabled=True,
+        normal_channel_id="1500719153508515870",
+        failure_channel_id="1500722535678083102",
+        normal_webhook_url=None,
+        failure_webhook_url=None,
+        discord_bot_token="x",
+        trader_base_url="https://trader.robinco.dev",
+    )
+
+    async def lookup() -> dict[str, Any]:
+        return {"success": True, "orders": [_order()], "errors": []}
+
+    async def prices(symbols: list[str]) -> dict[str, float]:
+        return {"KRW-BTC": 95_000_000}
+
+    async def sender(target: str, content: str) -> bool:
+        sends.append((target, content))
+        return target.startswith("discord-bot://1500722535678082")
+
+    result = await run_crypto_pending_order_alert(
+        execute=True,
+        config=config,
+        order_lookup=lookup,
+        price_lookup=prices,
+        discord_sender=sender,
+        now=NOW,
+    )
+
+    assert result["status"] == "failed"
+    assert [target for target, _ in sends] == [
+        "discord-bot://1500719153508515870/x",
+        "discord-bot://1500722535678083102/x",
     ]
 
 


### PR DESCRIPTION
## Summary
- Add `CRYPTO_PENDING_ORDER_DISCORD_BOT_TOKEN` as a safe fallback when dedicated Discord webhooks are unavailable.
- Keep webhook delivery preferred; fallback sends directly to the configured normal/failure channel IDs via Discord bot API.
- Preserve read-only pending-order behavior and failure-channel routing.

## Why
Production webhook creation for the two dedicated ROB-99 channels is blocked by Discord `Missing Permissions`, while the production env already has an authorized Discord bot token. This lets ROB-99 activate against the user-approved channel IDs without creating/managing webhooks.

## Verification
- `uv run ruff check app/core/config.py app/services/crypto_pending_order_alert_service.py tests/test_crypto_pending_order_alert_service.py tests/test_crypto_pending_order_alert_tasks.py`
- `uv run pytest tests/test_crypto_pending_order_alert_service.py tests/test_crypto_pending_order_alert_tasks.py -q` → 17 passed, 2 warnings
- `uv run ty check app/core/config.py app/services/crypto_pending_order_alert_service.py tests/test_crypto_pending_order_alert_service.py`
- `uv run bandit -q -r app/services/crypto_pending_order_alert_service.py`
- static secret scan on diff → 0 findings

Closes ROB-99
