### PR TITLE
feat(ROB-100): add shared execution/order/lifecycle contracts foundation

### DIFF
--- a/app/schemas/execution_contracts.py
+++ b/app/schemas/execution_contracts.py
@@ -21,11 +21,12 @@ states cannot coexist.
 
 from __future__ import annotations
 
-CONTRACT_VERSION = "v1"
-
+from datetime import datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
+
+CONTRACT_VERSION = "v1"
 
 
 AccountMode = Literal["kis_live", "kis_mock", "alpaca_paper", "db_simulated"]
@@ -111,6 +112,26 @@ class ExecutionGuard(BaseModel):
         return self
 
 
+class ExecutionReadiness(BaseModel):
+    """Whether a given (account_mode, execution_source) is ready to submit orders right now."""
+
+    contract_version: Literal["v1"] = "v1"
+    account_mode: AccountMode
+    execution_source: ExecutionSource
+    is_ready: bool = False
+    guard: ExecutionGuard = Field(default_factory=ExecutionGuard)
+    checked_at: datetime | None = None
+    notes: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _ready_implies_no_blocking(self) -> "ExecutionReadiness":
+        if self.is_ready and self.guard.blocking_reasons:
+            raise ValueError(
+                "is_ready cannot be True while guard.blocking_reasons is non-empty"
+            )
+        return self
+
+
 __all__ = [
     "CONTRACT_VERSION",
     "AccountMode",
@@ -124,4 +145,5 @@ __all__ = [
     "is_terminal_state",
     "is_in_flight_state",
     "ExecutionGuard",
+    "ExecutionReadiness",
 ]

--- a/app/schemas/execution_contracts.py
+++ b/app/schemas/execution_contracts.py
@@ -68,11 +68,11 @@ ORDER_LIFECYCLE_STATES: frozenset[str] = frozenset(
 )
 
 # Terminal: order has reached a final outcome that does not change without
-# explicit operator action. ``anomaly`` is intentionally NOT terminal — it
-# means "needs operator review", which is a hand-off, not a conclusion.
-TERMINAL_LIFECYCLE_STATES: frozenset[str] = frozenset(
-    {"fill", "reconciled", "failed", "stale"}
-)
+# explicit operator action. ``fill`` is intentionally NOT terminal because
+# follow-up reconcilers may still need to confirm holdings/position state and
+# emit ``reconciled``. ``anomaly`` is also intentionally NOT terminal — it means
+# "needs operator review", which is a hand-off, not a conclusion.
+TERMINAL_LIFECYCLE_STATES: frozenset[str] = frozenset({"reconciled", "failed", "stale"})
 
 # In-flight: order has been sent or acknowledged by the broker and is
 # expected to transition without operator input.

--- a/app/schemas/execution_contracts.py
+++ b/app/schemas/execution_contracts.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -178,6 +178,24 @@ class OrderBasketPreview(BaseModel):
         return self
 
 
+class OrderLifecycleEvent(BaseModel):
+    """Vocabulary-shaped lifecycle event emitted by reconciler / websocket / broker code.
+
+    ``detail`` carries broker-raw payload and is intentionally untyped; each
+    follow-up branch fills it in its own format.
+    """
+
+    contract_version: Literal["v1"] = "v1"
+    account_mode: AccountMode
+    execution_source: ExecutionSource
+    state: OrderLifecycleState
+    occurred_at: datetime
+    broker_order_id: str | None = None
+    correlation_id: str | None = None
+    detail: dict[str, Any] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
+
+
 __all__ = [
     "CONTRACT_VERSION",
     "AccountMode",
@@ -194,4 +212,5 @@ __all__ = [
     "ExecutionReadiness",
     "OrderPreviewLine",
     "OrderBasketPreview",
+    "OrderLifecycleEvent",
 ]

--- a/app/schemas/execution_contracts.py
+++ b/app/schemas/execution_contracts.py
@@ -35,9 +35,7 @@ ACCOUNT_MODES: frozenset[str] = frozenset(
     {"kis_live", "kis_mock", "alpaca_paper", "db_simulated"}
 )
 
-ExecutionSource = Literal[
-    "preopen", "watch", "manual", "websocket", "reconciler"
-]
+ExecutionSource = Literal["preopen", "watch", "manual", "websocket", "reconciler"]
 EXECUTION_SOURCES: frozenset[str] = frozenset(
     {"preopen", "watch", "manual", "websocket", "reconciler"}
 )
@@ -105,7 +103,7 @@ class ExecutionGuard(BaseModel):
     warnings: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def _enforce_block_when_blocking_reasons(self) -> "ExecutionGuard":
+    def _enforce_block_when_blocking_reasons(self) -> ExecutionGuard:
         if self.blocking_reasons and self.execution_allowed:
             raise ValueError(
                 "execution_allowed must be False when blocking_reasons is non-empty"
@@ -125,7 +123,7 @@ class ExecutionReadiness(BaseModel):
     notes: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def _ready_implies_no_blocking(self) -> "ExecutionReadiness":
+    def _ready_implies_no_blocking(self) -> ExecutionReadiness:
         if self.is_ready and self.guard.blocking_reasons:
             raise ValueError(
                 "is_ready cannot be True while guard.blocking_reasons is non-empty"
@@ -163,7 +161,7 @@ class OrderBasketPreview(BaseModel):
     basket_warnings: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def _lines_must_match_basket(self) -> "OrderBasketPreview":
+    def _lines_must_match_basket(self) -> OrderBasketPreview:
         for idx, line in enumerate(self.lines):
             if line.account_mode != self.account_mode:
                 raise ValueError(

--- a/app/schemas/execution_contracts.py
+++ b/app/schemas/execution_contracts.py
@@ -25,6 +25,9 @@ CONTRACT_VERSION = "v1"
 
 from typing import Literal
 
+from pydantic import BaseModel, Field, model_validator
+
+
 AccountMode = Literal["kis_live", "kis_mock", "alpaca_paper", "db_simulated"]
 ACCOUNT_MODES: frozenset[str] = frozenset(
     {"kis_live", "kis_mock", "alpaca_paper", "db_simulated"}
@@ -86,6 +89,28 @@ def is_in_flight_state(state: OrderLifecycleState) -> bool:
     return state in IN_FLIGHT_LIFECYCLE_STATES
 
 
+class ExecutionGuard(BaseModel):
+    """Approval / execution gating fields shared by readiness, preview, and event models.
+
+    Defaults are conservative. ``bool`` (not ``Literal[False]``) so future
+    broker-submit code can flip values; the validator below keeps the
+    invariant that any blocking reason forces ``execution_allowed=False``.
+    """
+
+    execution_allowed: bool = False
+    approval_required: bool = True
+    blocking_reasons: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _enforce_block_when_blocking_reasons(self) -> "ExecutionGuard":
+        if self.blocking_reasons and self.execution_allowed:
+            raise ValueError(
+                "execution_allowed must be False when blocking_reasons is non-empty"
+            )
+        return self
+
+
 __all__ = [
     "CONTRACT_VERSION",
     "AccountMode",
@@ -98,4 +123,5 @@ __all__ = [
     "IN_FLIGHT_LIFECYCLE_STATES",
     "is_terminal_state",
     "is_in_flight_state",
+    "ExecutionGuard",
 ]

--- a/app/schemas/execution_contracts.py
+++ b/app/schemas/execution_contracts.py
@@ -30,8 +30,72 @@ ACCOUNT_MODES: frozenset[str] = frozenset(
     {"kis_live", "kis_mock", "alpaca_paper", "db_simulated"}
 )
 
+ExecutionSource = Literal[
+    "preopen", "watch", "manual", "websocket", "reconciler"
+]
+EXECUTION_SOURCES: frozenset[str] = frozenset(
+    {"preopen", "watch", "manual", "websocket", "reconciler"}
+)
+
+OrderLifecycleState = Literal[
+    "planned",
+    "previewed",
+    "submitted",
+    "accepted",
+    "pending",
+    "fill",
+    "reconciled",
+    "stale",
+    "failed",
+    "anomaly",
+]
+ORDER_LIFECYCLE_STATES: frozenset[str] = frozenset(
+    {
+        "planned",
+        "previewed",
+        "submitted",
+        "accepted",
+        "pending",
+        "fill",
+        "reconciled",
+        "stale",
+        "failed",
+        "anomaly",
+    }
+)
+
+# Terminal: order has reached a final outcome that does not change without
+# explicit operator action. ``anomaly`` is intentionally NOT terminal — it
+# means "needs operator review", which is a hand-off, not a conclusion.
+TERMINAL_LIFECYCLE_STATES: frozenset[str] = frozenset(
+    {"fill", "reconciled", "failed", "stale"}
+)
+
+# In-flight: order has been sent or acknowledged by the broker and is
+# expected to transition without operator input.
+IN_FLIGHT_LIFECYCLE_STATES: frozenset[str] = frozenset(
+    {"submitted", "accepted", "pending"}
+)
+
+
+def is_terminal_state(state: OrderLifecycleState) -> bool:
+    return state in TERMINAL_LIFECYCLE_STATES
+
+
+def is_in_flight_state(state: OrderLifecycleState) -> bool:
+    return state in IN_FLIGHT_LIFECYCLE_STATES
+
+
 __all__ = [
     "CONTRACT_VERSION",
     "AccountMode",
     "ACCOUNT_MODES",
+    "ExecutionSource",
+    "EXECUTION_SOURCES",
+    "OrderLifecycleState",
+    "ORDER_LIFECYCLE_STATES",
+    "TERMINAL_LIFECYCLE_STATES",
+    "IN_FLIGHT_LIFECYCLE_STATES",
+    "is_terminal_state",
+    "is_in_flight_state",
 ]

--- a/app/schemas/execution_contracts.py
+++ b/app/schemas/execution_contracts.py
@@ -22,6 +22,7 @@ states cannot coexist.
 from __future__ import annotations
 
 from datetime import datetime
+from decimal import Decimal
 from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
@@ -132,6 +133,25 @@ class ExecutionReadiness(BaseModel):
         return self
 
 
+class OrderPreviewLine(BaseModel):
+    """A single previewed broker order line. Shared shape for basket previews and intent previews."""
+
+    contract_version: Literal["v1"] = "v1"
+    symbol: str
+    market: str
+    side: Literal["buy", "sell"]
+    account_mode: AccountMode
+    execution_source: ExecutionSource
+    lifecycle_state: OrderLifecycleState = "previewed"
+    quantity: Decimal | None = None
+    limit_price: Decimal | None = None
+    notional: Decimal | None = None
+    currency: str | None = None
+    guard: ExecutionGuard = Field(default_factory=ExecutionGuard)
+    rationale: list[str] = Field(default_factory=list)
+    correlation_id: str | None = None
+
+
 __all__ = [
     "CONTRACT_VERSION",
     "AccountMode",
@@ -146,4 +166,5 @@ __all__ = [
     "is_in_flight_state",
     "ExecutionGuard",
     "ExecutionReadiness",
+    "OrderPreviewLine",
 ]

--- a/app/schemas/execution_contracts.py
+++ b/app/schemas/execution_contracts.py
@@ -152,6 +152,32 @@ class OrderPreviewLine(BaseModel):
     correlation_id: str | None = None
 
 
+class OrderBasketPreview(BaseModel):
+    """A previewed basket of lines for one (account_mode, execution_source)."""
+
+    contract_version: Literal["v1"] = "v1"
+    account_mode: AccountMode
+    execution_source: ExecutionSource
+    readiness: ExecutionReadiness
+    lines: list[OrderPreviewLine] = Field(default_factory=list)
+    basket_warnings: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def _lines_must_match_basket(self) -> "OrderBasketPreview":
+        for idx, line in enumerate(self.lines):
+            if line.account_mode != self.account_mode:
+                raise ValueError(
+                    f"lines[{idx}].account_mode ({line.account_mode!r}) must match basket "
+                    f"({self.account_mode!r})"
+                )
+            if line.execution_source != self.execution_source:
+                raise ValueError(
+                    f"lines[{idx}].execution_source ({line.execution_source!r}) must match basket "
+                    f"({self.execution_source!r})"
+                )
+        return self
+
+
 __all__ = [
     "CONTRACT_VERSION",
     "AccountMode",
@@ -167,4 +193,5 @@ __all__ = [
     "ExecutionGuard",
     "ExecutionReadiness",
     "OrderPreviewLine",
+    "OrderBasketPreview",
 ]

--- a/app/schemas/execution_contracts.py
+++ b/app/schemas/execution_contracts.py
@@ -1,0 +1,37 @@
+"""Shared execution / order preview / lifecycle vocabulary (ROB-100 foundation).
+
+Pure additive contract. This module defines the shared schema/types used by
+follow-up parallel branches:
+
+* preopen execution review panel and basket preview UI
+* KIS mock order lifecycle and reconciliation worker
+* watch order-intent MVP
+* KIS websocket live/mock event tagging
+
+This module MUST stay a leaf:
+* It does not import any other ``app.*`` module.
+* No existing ``app.*`` module imports it as part of ROB-100. Follow-up branches
+  consume it on their own schedule (see design spec
+  ``docs/superpowers/specs/2026-05-04-rob-100-execution-contracts-design.md``).
+
+Defaults are conservative: ``execution_allowed=False``, ``approval_required=True``,
+``is_ready=False``. Validators enforce that blocking reasons and "allowed/ready"
+states cannot coexist.
+"""
+
+from __future__ import annotations
+
+CONTRACT_VERSION = "v1"
+
+from typing import Literal
+
+AccountMode = Literal["kis_live", "kis_mock", "alpaca_paper", "db_simulated"]
+ACCOUNT_MODES: frozenset[str] = frozenset(
+    {"kis_live", "kis_mock", "alpaca_paper", "db_simulated"}
+)
+
+__all__ = [
+    "CONTRACT_VERSION",
+    "AccountMode",
+    "ACCOUNT_MODES",
+]

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -70,3 +70,35 @@ class TestOrderLifecycleState:
         for state in ec.ORDER_LIFECYCLE_STATES:
             expected = state in ec.IN_FLIGHT_LIFECYCLE_STATES
             assert ec.is_in_flight_state(state) is expected, state
+
+
+from pydantic import ValidationError
+
+
+class TestExecutionGuard:
+    def test_default_is_conservative(self):
+        guard = ec.ExecutionGuard()
+        assert guard.execution_allowed is False
+        assert guard.approval_required is True
+        assert guard.blocking_reasons == []
+        assert guard.warnings == []
+
+    def test_can_allow_execution_when_no_blocking_reasons(self):
+        guard = ec.ExecutionGuard(execution_allowed=True, approval_required=False)
+        assert guard.execution_allowed is True
+        assert guard.approval_required is False
+
+    def test_blocking_reasons_force_execution_not_allowed(self):
+        with pytest.raises(ValidationError) as excinfo:
+            ec.ExecutionGuard(execution_allowed=True, blocking_reasons=["x"])
+        assert "blocking_reasons" in str(excinfo.value)
+
+    def test_blocking_reasons_with_default_execution_allowed_is_ok(self):
+        guard = ec.ExecutionGuard(blocking_reasons=["risk_too_high"])
+        assert guard.execution_allowed is False
+        assert guard.blocking_reasons == ["risk_too_high"]
+
+    def test_warnings_do_not_force_execution_not_allowed(self):
+        guard = ec.ExecutionGuard(execution_allowed=True, warnings=["soft warn"])
+        assert guard.execution_allowed is True
+        assert guard.warnings == ["soft warn"]

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -1,6 +1,10 @@
 """Tests for shared execution contracts (ROB-100)."""
 
+from datetime import UTC, datetime
+from decimal import Decimal
+
 import pytest
+from pydantic import ValidationError
 
 from app.schemas import execution_contracts as ec
 
@@ -48,8 +52,7 @@ class TestOrderLifecycleState:
 
     def test_terminal_and_in_flight_are_disjoint(self):
         assert (
-            ec.TERMINAL_LIFECYCLE_STATES & ec.IN_FLIGHT_LIFECYCLE_STATES
-            == frozenset()
+            ec.TERMINAL_LIFECYCLE_STATES & ec.IN_FLIGHT_LIFECYCLE_STATES == frozenset()
         )
 
     def test_anomaly_is_in_neither_classification_set(self):
@@ -70,9 +73,6 @@ class TestOrderLifecycleState:
         for state in ec.ORDER_LIFECYCLE_STATES:
             expected = state in ec.IN_FLIGHT_LIFECYCLE_STATES
             assert ec.is_in_flight_state(state) is expected, state
-
-
-from pydantic import ValidationError
 
 
 class TestExecutionGuard:
@@ -104,9 +104,6 @@ class TestExecutionGuard:
         assert guard.warnings == ["soft warn"]
 
 
-from datetime import datetime, timezone
-
-
 class TestExecutionReadiness:
     def test_default_is_not_ready_with_conservative_guard(self):
         readiness = ec.ExecutionReadiness(
@@ -128,7 +125,7 @@ class TestExecutionReadiness:
             execution_source="manual",
             is_ready=True,
             guard=ec.ExecutionGuard(execution_allowed=True, approval_required=False),
-            checked_at=datetime(2026, 5, 4, 10, 0, tzinfo=timezone.utc),
+            checked_at=datetime(2026, 5, 4, 10, 0, tzinfo=UTC),
             notes=["operator confirmed"],
         )
         assert readiness.is_ready is True
@@ -159,18 +156,15 @@ class TestExecutionReadiness:
             )
 
 
-from decimal import Decimal
-
-
 class TestOrderPreviewLine:
     def _minimal_kwargs(self):
-        return dict(
-            symbol="005930",
-            market="KOSPI",
-            side="buy",
-            account_mode="kis_mock",
-            execution_source="preopen",
-        )
+        return {
+            "symbol": "005930",
+            "market": "KOSPI",
+            "side": "buy",
+            "account_mode": "kis_mock",
+            "execution_source": "preopen",
+        }
 
     def test_defaults(self):
         line = ec.OrderPreviewLine(**self._minimal_kwargs())
@@ -222,13 +216,13 @@ class TestOrderBasketPreview:
         )
 
     def _line(self, **overrides):
-        kwargs = dict(
-            symbol="005930",
-            market="KOSPI",
-            side="buy",
-            account_mode="kis_mock",
-            execution_source="preopen",
-        )
+        kwargs = {
+            "symbol": "005930",
+            "market": "KOSPI",
+            "side": "buy",
+            "account_mode": "kis_mock",
+            "execution_source": "preopen",
+        }
         kwargs.update(overrides)
         return ec.OrderPreviewLine(**kwargs)
 
@@ -279,7 +273,7 @@ class TestOrderLifecycleEvent:
             account_mode="kis_mock",
             execution_source="reconciler",
             state="submitted",
-            occurred_at=datetime(2026, 5, 4, 10, 0, tzinfo=timezone.utc),
+            occurred_at=datetime(2026, 5, 4, 10, 0, tzinfo=UTC),
         )
         assert event.contract_version == "v1"
         assert event.state == "submitted"
@@ -293,7 +287,7 @@ class TestOrderLifecycleEvent:
             account_mode="kis_live",
             execution_source="websocket",
             state="fill",
-            occurred_at=datetime(2026, 5, 4, 10, 1, tzinfo=timezone.utc),
+            occurred_at=datetime(2026, 5, 4, 10, 1, tzinfo=UTC),
             broker_order_id="0000123456",
             correlation_id="watch_alert_xyz",
             detail={"raw": {"FILL_QTY": "10"}},
@@ -308,7 +302,7 @@ class TestOrderLifecycleEvent:
                 account_mode="kis_mock",
                 execution_source="reconciler",
                 state="queued",  # not in the literal
-                occurred_at=datetime(2026, 5, 4, 10, 0, tzinfo=timezone.utc),
+                occurred_at=datetime(2026, 5, 4, 10, 0, tzinfo=UTC),
             )
 
 
@@ -326,7 +320,7 @@ class TestSerializationRoundTrip:
                 execution_source="preopen",
                 is_ready=False,
                 guard=ec.ExecutionGuard(blocking_reasons=["news_stale"]),
-                checked_at=datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc),
+                checked_at=datetime(2026, 5, 4, 9, 0, tzinfo=UTC),
                 notes=["initial check"],
             ),
             ec.OrderPreviewLine(
@@ -365,7 +359,7 @@ class TestSerializationRoundTrip:
                 account_mode="kis_live",
                 execution_source="websocket",
                 state="fill",
-                occurred_at=datetime(2026, 5, 4, 10, 1, tzinfo=timezone.utc),
+                occurred_at=datetime(2026, 5, 4, 10, 1, tzinfo=UTC),
                 broker_order_id="0000123456",
                 correlation_id="watch_alert_xyz",
                 detail={"raw": {"FILL_QTY": "10"}},
@@ -403,11 +397,7 @@ class TestCompatibilityWithExistingSchemas:
             "paper_only",
             "dry_run_only",
         }
-        new_vocab = (
-            ec.ACCOUNT_MODES
-            | ec.EXECUTION_SOURCES
-            | ec.ORDER_LIFECYCLE_STATES
-        )
+        new_vocab = ec.ACCOUNT_MODES | ec.EXECUTION_SOURCES | ec.ORDER_LIFECYCLE_STATES
         overlap = existing_execution_mode_values & new_vocab
         assert overlap == set(), (
             f"new vocabulary collides with existing execution_mode values: {overlap}"

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -271,3 +271,42 @@ class TestOrderBasketPreview:
                 lines=[self._line(execution_source="watch")],
             )
         assert "execution_source" in str(excinfo.value)
+
+
+class TestOrderLifecycleEvent:
+    def test_minimal_event(self):
+        event = ec.OrderLifecycleEvent(
+            account_mode="kis_mock",
+            execution_source="reconciler",
+            state="submitted",
+            occurred_at=datetime(2026, 5, 4, 10, 0, tzinfo=timezone.utc),
+        )
+        assert event.contract_version == "v1"
+        assert event.state == "submitted"
+        assert event.broker_order_id is None
+        assert event.correlation_id is None
+        assert event.detail == {}
+        assert event.warnings == []
+
+    def test_full_event(self):
+        event = ec.OrderLifecycleEvent(
+            account_mode="kis_live",
+            execution_source="websocket",
+            state="fill",
+            occurred_at=datetime(2026, 5, 4, 10, 1, tzinfo=timezone.utc),
+            broker_order_id="0000123456",
+            correlation_id="watch_alert_xyz",
+            detail={"raw": {"FILL_QTY": "10"}},
+            warnings=["partial_then_full"],
+        )
+        assert event.broker_order_id == "0000123456"
+        assert event.detail["raw"]["FILL_QTY"] == "10"
+
+    def test_invalid_state_rejected(self):
+        with pytest.raises(ValidationError):
+            ec.OrderLifecycleEvent(
+                account_mode="kis_mock",
+                execution_source="reconciler",
+                state="queued",  # not in the literal
+                occurred_at=datetime(2026, 5, 4, 10, 0, tzinfo=timezone.utc),
+            )

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -10,3 +10,63 @@ class TestAccountMode:
         assert ec.ACCOUNT_MODES == frozenset(
             {"kis_live", "kis_mock", "alpaca_paper", "db_simulated"}
         )
+
+
+class TestExecutionSource:
+    def test_execution_sources_constant_matches_spec(self):
+        assert ec.EXECUTION_SOURCES == frozenset(
+            {"preopen", "watch", "manual", "websocket", "reconciler"}
+        )
+
+
+class TestOrderLifecycleState:
+    def test_order_lifecycle_states_constant_matches_spec(self):
+        assert ec.ORDER_LIFECYCLE_STATES == frozenset(
+            {
+                "planned",
+                "previewed",
+                "submitted",
+                "accepted",
+                "pending",
+                "fill",
+                "reconciled",
+                "stale",
+                "failed",
+                "anomaly",
+            }
+        )
+
+    def test_terminal_states(self):
+        assert ec.TERMINAL_LIFECYCLE_STATES == frozenset(
+            {"fill", "reconciled", "failed", "stale"}
+        )
+
+    def test_in_flight_states(self):
+        assert ec.IN_FLIGHT_LIFECYCLE_STATES == frozenset(
+            {"submitted", "accepted", "pending"}
+        )
+
+    def test_terminal_and_in_flight_are_disjoint(self):
+        assert (
+            ec.TERMINAL_LIFECYCLE_STATES & ec.IN_FLIGHT_LIFECYCLE_STATES
+            == frozenset()
+        )
+
+    def test_anomaly_is_in_neither_classification_set(self):
+        assert "anomaly" not in ec.TERMINAL_LIFECYCLE_STATES
+        assert "anomaly" not in ec.IN_FLIGHT_LIFECYCLE_STATES
+
+    def test_planned_and_previewed_are_in_neither_classification_set(self):
+        for state in ("planned", "previewed"):
+            assert state not in ec.TERMINAL_LIFECYCLE_STATES
+            assert state not in ec.IN_FLIGHT_LIFECYCLE_STATES
+
+    def test_is_terminal_state_for_every_state(self):
+        for state in ec.ORDER_LIFECYCLE_STATES:
+            expected = state in ec.TERMINAL_LIFECYCLE_STATES
+            assert ec.is_terminal_state(state) is expected, state
+
+    def test_is_in_flight_state_for_every_state(self):
+        for state in ec.ORDER_LIFECYCLE_STATES:
+            expected = state in ec.IN_FLIGHT_LIFECYCLE_STATES
+            assert ec.is_in_flight_state(state) is expected, state

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -102,3 +102,58 @@ class TestExecutionGuard:
         guard = ec.ExecutionGuard(execution_allowed=True, warnings=["soft warn"])
         assert guard.execution_allowed is True
         assert guard.warnings == ["soft warn"]
+
+
+from datetime import datetime, timezone
+
+
+class TestExecutionReadiness:
+    def test_default_is_not_ready_with_conservative_guard(self):
+        readiness = ec.ExecutionReadiness(
+            account_mode="kis_mock",
+            execution_source="preopen",
+        )
+        assert readiness.contract_version == "v1"
+        assert readiness.account_mode == "kis_mock"
+        assert readiness.execution_source == "preopen"
+        assert readiness.is_ready is False
+        assert readiness.guard.execution_allowed is False
+        assert readiness.guard.approval_required is True
+        assert readiness.checked_at is None
+        assert readiness.notes == []
+
+    def test_can_construct_ready_state_with_clean_guard(self):
+        readiness = ec.ExecutionReadiness(
+            account_mode="alpaca_paper",
+            execution_source="manual",
+            is_ready=True,
+            guard=ec.ExecutionGuard(execution_allowed=True, approval_required=False),
+            checked_at=datetime(2026, 5, 4, 10, 0, tzinfo=timezone.utc),
+            notes=["operator confirmed"],
+        )
+        assert readiness.is_ready is True
+        assert readiness.checked_at.year == 2026
+
+    def test_is_ready_with_blocking_reasons_raises(self):
+        with pytest.raises(ValidationError) as excinfo:
+            ec.ExecutionReadiness(
+                account_mode="kis_live",
+                execution_source="watch",
+                is_ready=True,
+                guard=ec.ExecutionGuard(blocking_reasons=["market_closed"]),
+            )
+        assert "is_ready" in str(excinfo.value)
+
+    def test_invalid_account_mode_rejected(self):
+        with pytest.raises(ValidationError):
+            ec.ExecutionReadiness(
+                account_mode="binance_live",  # not in the literal
+                execution_source="manual",
+            )
+
+    def test_invalid_execution_source_rejected(self):
+        with pytest.raises(ValidationError):
+            ec.ExecutionReadiness(
+                account_mode="kis_mock",
+                execution_source="cron",  # not in the literal
+            )

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -1,0 +1,12 @@
+"""Tests for shared execution contracts (ROB-100)."""
+
+import pytest
+
+from app.schemas import execution_contracts as ec
+
+
+class TestAccountMode:
+    def test_account_modes_constant_matches_spec(self):
+        assert ec.ACCOUNT_MODES == frozenset(
+            {"kis_live", "kis_mock", "alpaca_paper", "db_simulated"}
+        )

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -42,7 +42,7 @@ class TestOrderLifecycleState:
 
     def test_terminal_states(self):
         assert ec.TERMINAL_LIFECYCLE_STATES == frozenset(
-            {"fill", "reconciled", "failed", "stale"}
+            {"reconciled", "failed", "stale"}
         )
 
     def test_in_flight_states(self):
@@ -58,6 +58,10 @@ class TestOrderLifecycleState:
     def test_anomaly_is_in_neither_classification_set(self):
         assert "anomaly" not in ec.TERMINAL_LIFECYCLE_STATES
         assert "anomaly" not in ec.IN_FLIGHT_LIFECYCLE_STATES
+
+    def test_fill_is_not_terminal_until_position_reconciled(self):
+        assert "fill" not in ec.TERMINAL_LIFECYCLE_STATES
+        assert not ec.is_terminal_state("fill")
 
     def test_planned_and_previewed_are_in_neither_classification_set(self):
         for state in ("planned", "previewed"):

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -392,3 +392,31 @@ class TestSerializationRoundTrip:
 
     def test_module_constant_matches_field_default(self):
         assert ec.CONTRACT_VERSION == "v1"
+
+
+class TestCompatibilityWithExistingSchemas:
+    def test_no_string_overlap_with_existing_order_intent_execution_mode(self):
+        # Existing values in OrderIntentPreviewRequest.execution_mode.
+        # Hard-coded to avoid coupling this test to that schema's import graph.
+        existing_execution_mode_values = {
+            "requires_final_approval",
+            "paper_only",
+            "dry_run_only",
+        }
+        new_vocab = (
+            ec.ACCOUNT_MODES
+            | ec.EXECUTION_SOURCES
+            | ec.ORDER_LIFECYCLE_STATES
+        )
+        overlap = existing_execution_mode_values & new_vocab
+        assert overlap == set(), (
+            f"new vocabulary collides with existing execution_mode values: {overlap}"
+        )
+
+    def test_existing_order_intent_preview_request_still_imports(self):
+        # Sanity check: the existing schema still loads and exposes the same
+        # execution_mode literal we asserted above. Catches accidental damage.
+        from app.schemas.order_intent_preview import OrderIntentPreviewRequest
+
+        req = OrderIntentPreviewRequest()
+        assert req.execution_mode == "requires_final_approval"

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -212,3 +212,62 @@ class TestOrderPreviewLine:
         kwargs["lifecycle_state"] = "queued"
         with pytest.raises(ValidationError):
             ec.OrderPreviewLine(**kwargs)
+
+
+class TestOrderBasketPreview:
+    def _readiness(self, account="kis_mock", source="preopen"):
+        return ec.ExecutionReadiness(
+            account_mode=account,
+            execution_source=source,
+        )
+
+    def _line(self, **overrides):
+        kwargs = dict(
+            symbol="005930",
+            market="KOSPI",
+            side="buy",
+            account_mode="kis_mock",
+            execution_source="preopen",
+        )
+        kwargs.update(overrides)
+        return ec.OrderPreviewLine(**kwargs)
+
+    def test_empty_basket_defaults(self):
+        basket = ec.OrderBasketPreview(
+            account_mode="kis_mock",
+            execution_source="preopen",
+            readiness=self._readiness(),
+        )
+        assert basket.contract_version == "v1"
+        assert basket.lines == []
+        assert basket.basket_warnings == []
+        assert basket.readiness.is_ready is False
+
+    def test_basket_with_matching_lines(self):
+        basket = ec.OrderBasketPreview(
+            account_mode="kis_mock",
+            execution_source="preopen",
+            readiness=self._readiness(),
+            lines=[self._line(), self._line(symbol="000660")],
+        )
+        assert len(basket.lines) == 2
+
+    def test_line_account_mode_mismatch_rejected(self):
+        with pytest.raises(ValidationError) as excinfo:
+            ec.OrderBasketPreview(
+                account_mode="kis_mock",
+                execution_source="preopen",
+                readiness=self._readiness(),
+                lines=[self._line(account_mode="alpaca_paper")],
+            )
+        assert "account_mode" in str(excinfo.value)
+
+    def test_line_execution_source_mismatch_rejected(self):
+        with pytest.raises(ValidationError) as excinfo:
+            ec.OrderBasketPreview(
+                account_mode="kis_mock",
+                execution_source="preopen",
+                readiness=self._readiness(),
+                lines=[self._line(execution_source="watch")],
+            )
+        assert "execution_source" in str(excinfo.value)

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -310,3 +310,85 @@ class TestOrderLifecycleEvent:
                 state="queued",  # not in the literal
                 occurred_at=datetime(2026, 5, 4, 10, 0, tzinfo=timezone.utc),
             )
+
+
+class TestSerializationRoundTrip:
+    def _sample_models(self):
+        return [
+            ec.ExecutionGuard(
+                execution_allowed=False,
+                approval_required=True,
+                blocking_reasons=["market_closed"],
+                warnings=["soft warn"],
+            ),
+            ec.ExecutionReadiness(
+                account_mode="kis_mock",
+                execution_source="preopen",
+                is_ready=False,
+                guard=ec.ExecutionGuard(blocking_reasons=["news_stale"]),
+                checked_at=datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc),
+                notes=["initial check"],
+            ),
+            ec.OrderPreviewLine(
+                symbol="005930",
+                market="KOSPI",
+                side="buy",
+                account_mode="kis_mock",
+                execution_source="preopen",
+                quantity=Decimal("10"),
+                limit_price=Decimal("70000.5"),
+                notional=Decimal("705005"),
+                currency="KRW",
+                rationale=["test"],
+                correlation_id="decision_run_xyz",
+            ),
+            ec.OrderBasketPreview(
+                account_mode="alpaca_paper",
+                execution_source="manual",
+                readiness=ec.ExecutionReadiness(
+                    account_mode="alpaca_paper",
+                    execution_source="manual",
+                ),
+                lines=[
+                    ec.OrderPreviewLine(
+                        symbol="AAPL",
+                        market="NASDAQ",
+                        side="buy",
+                        account_mode="alpaca_paper",
+                        execution_source="manual",
+                        notional=Decimal("100"),
+                        currency="USD",
+                    )
+                ],
+            ),
+            ec.OrderLifecycleEvent(
+                account_mode="kis_live",
+                execution_source="websocket",
+                state="fill",
+                occurred_at=datetime(2026, 5, 4, 10, 1, tzinfo=timezone.utc),
+                broker_order_id="0000123456",
+                correlation_id="watch_alert_xyz",
+                detail={"raw": {"FILL_QTY": "10"}},
+            ),
+        ]
+
+    def test_python_round_trip(self):
+        for model in self._sample_models():
+            dumped = model.model_dump()
+            restored = type(model).model_validate(dumped)
+            assert restored == model
+
+    def test_json_round_trip(self):
+        for model in self._sample_models():
+            dumped_json = model.model_dump_json()
+            restored = type(model).model_validate_json(dumped_json)
+            assert restored == model
+
+    def test_contract_version_present_in_serialized_output(self):
+        for model in self._sample_models():
+            dumped = model.model_dump()
+            if "contract_version" in type(model).model_fields:
+                assert dumped["contract_version"] == "v1"
+
+    def test_module_constant_matches_field_default(self):
+        assert ec.CONTRACT_VERSION == "v1"

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -157,3 +157,58 @@ class TestExecutionReadiness:
                 account_mode="kis_mock",
                 execution_source="cron",  # not in the literal
             )
+
+
+from decimal import Decimal
+
+
+class TestOrderPreviewLine:
+    def _minimal_kwargs(self):
+        return dict(
+            symbol="005930",
+            market="KOSPI",
+            side="buy",
+            account_mode="kis_mock",
+            execution_source="preopen",
+        )
+
+    def test_defaults(self):
+        line = ec.OrderPreviewLine(**self._minimal_kwargs())
+        assert line.contract_version == "v1"
+        assert line.lifecycle_state == "previewed"
+        assert line.quantity is None
+        assert line.limit_price is None
+        assert line.notional is None
+        assert line.currency is None
+        assert line.guard.execution_allowed is False
+        assert line.guard.approval_required is True
+        assert line.rationale == []
+        assert line.correlation_id is None
+
+    def test_full_construction(self):
+        line = ec.OrderPreviewLine(
+            **self._minimal_kwargs(),
+            quantity=Decimal("10"),
+            limit_price=Decimal("70000"),
+            notional=Decimal("700000"),
+            currency="KRW",
+            rationale=["RSI oversold", "above MA20"],
+            correlation_id="decision_run_abc123",
+        )
+        assert line.quantity == Decimal("10")
+        assert line.limit_price == Decimal("70000")
+        assert line.notional == Decimal("700000")
+        assert line.currency == "KRW"
+        assert line.correlation_id == "decision_run_abc123"
+
+    def test_invalid_side_rejected(self):
+        kwargs = self._minimal_kwargs()
+        kwargs["side"] = "hold"
+        with pytest.raises(ValidationError):
+            ec.OrderPreviewLine(**kwargs)
+
+    def test_invalid_lifecycle_state_rejected(self):
+        kwargs = self._minimal_kwargs()
+        kwargs["lifecycle_state"] = "queued"
+        with pytest.raises(ValidationError):
+            ec.OrderPreviewLine(**kwargs)

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -420,3 +420,34 @@ class TestCompatibilityWithExistingSchemas:
 
         req = OrderIntentPreviewRequest()
         assert req.execution_mode == "requires_final_approval"
+
+
+class TestModuleIsLeaf:
+    def test_does_not_import_other_app_modules(self):
+        import importlib
+        import sys
+
+        # Drop everything under app.* so we measure only what loading
+        # execution_contracts pulls in. Capture and restore so the rest of
+        # the test session is unaffected.
+        snapshot = {
+            name: mod for name, mod in sys.modules.items() if name.startswith("app")
+        }
+        for name in list(snapshot):
+            del sys.modules[name]
+        try:
+            importlib.import_module("app.schemas.execution_contracts")
+            loaded_app_modules = {
+                name for name in sys.modules if name.startswith("app")
+            }
+            allowed = {"app", "app.schemas", "app.schemas.execution_contracts"}
+            unexpected = loaded_app_modules - allowed
+            assert unexpected == set(), (
+                f"execution_contracts pulled in unexpected app.* modules: {unexpected}"
+            )
+        finally:
+            for name in list(sys.modules):
+                if name.startswith("app"):
+                    del sys.modules[name]
+            for name, mod in snapshot.items():
+                sys.modules[name] = mod


### PR DESCRIPTION
## Summary

Pure additive foundation PR. Adds a single shared Pydantic schema module (`app/schemas/execution_contracts.py`) so the four planned parallel follow-up branches can speak the same vocabulary instead of inventing incompatible local schemas.

Linear: https://linear.app/mgh3326/issue/ROB-100/foundation-execution-readiness-order-preview-and-lifecycle-contracts
Parent epic: ROB-40

## What's added

- **Vocabulary** (Literal type aliases + `frozenset` constants):
  - `AccountMode`: `kis_live | kis_mock | alpaca_paper | db_simulated`
  - `ExecutionSource`: `preopen | watch | manual | websocket | reconciler`
  - `OrderLifecycleState`: `planned | previewed | submitted | accepted | pending | fill | reconciled | stale | failed | anomaly`
  - Helpers: `TERMINAL_LIFECYCLE_STATES`, `IN_FLIGHT_LIFECYCLE_STATES`, `is_terminal_state`, `is_in_flight_state`. `anomaly` is intentionally in neither classification set — it's an operator hand-off, not a conclusion.
- **Models** (Pydantic v2):
  - `ExecutionGuard` — `execution_allowed=False`, `approval_required=True` defaults; validator rejects `execution_allowed=True` when `blocking_reasons` is non-empty.
  - `ExecutionReadiness` — wraps a guard + account/source; validator rejects `is_ready=True` when guard has `blocking_reasons`.
  - `OrderPreviewLine` — shared shape for basket / intent previews.
  - `OrderBasketPreview` — basket of lines + readiness; validator enforces every line's `account_mode` and `execution_source` match the basket.
  - `OrderLifecycleEvent` — vocabulary-shaped event for follow-up reconciler / websocket emitters.
- Module constant `CONTRACT_VERSION = "v1"` + per-model `contract_version: Literal["v1"]` field for serialized payloads.

## Why a separate module instead of extending existing schemas

Existing ad-hoc guards in `preopen.py`, `tradingagents_research.py`, `trading_decision_synthesis.py`, `order_intent_preview.py` are **not** modified. Migration to the shared vocabulary will happen piecemeal in the four follow-up branches that this PR exists to unblock — that keeps this PR small enough to merge before parallel work starts.

## Non-goals (explicitly out of scope)

- No changes to `app/services/brokers/`, `app/services/orders/`, `app/routers/`, `app/models/`.
- No Alembic migration.
- No router/endpoint additions.
- No modification of existing schema files (`preopen.py`, `tradingagents_research.py`, `trading_decision_synthesis.py`, `order_intent_preview.py`).
- No watch / KIS websocket / KIS mock reconciler / preopen UI consumer wiring (those are the four follow-up branches this PR unblocks).
- No scheduler/launchd changes.

## Acceptance criteria status

- [x] Shared contract is available for follow-up PRs.
- [x] Existing preopen/trading-decision tests continue to pass — the new module has zero consumers in `app/` or `tests/` outside its own test file (regression impossible by construction).
- [x] New contract tests cover degraded/default guardrail states — `test_default_is_conservative`, `test_default_is_not_ready_with_conservative_guard`, plus 5 validator-rejection tests.
- [x] PR is small enough to merge before parallel follow-up branches — 2 new files, 657 lines total (214 source + 443 tests), no migrations.

## Follow-up branches enabled

- Preopen execution review panel & basket preview UI — consumes `OrderBasketPreview`.
- KIS mock order lifecycle/reconciliation worker — emits `OrderLifecycleEvent` with `account_mode="kis_mock"`.
- Watch order intent MVP — emits `OrderPreviewLine` with `execution_source="watch"`.
- KIS websocket live/mock event tagging — emits `OrderLifecycleEvent` with `execution_source="websocket"`.

## Test plan

- [x] `uv run pytest tests/test_execution_contracts.py -v --no-cov` → 38 passed
- [x] `uv run ruff check` on the new files → All checks passed
- [x] `uv run ruff format --check` on the new files → already formatted
- [x] `uv run ty check app/schemas/execution_contracts.py` → All checks passed
- [x] Neighboring schema tests (`test_ai_markdown_schemas`, `test_research_run_decision_session_schemas`, `test_news_readiness_contract`, `test_ci_contract`) → 37 passed
- [x] `grep -rE "execution_contracts" app tests` → only the new module + its test file (leaf-module property holds)
- [ ] CI: full test suite green
- [ ] CI: lint / typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)