### PR TITLE
feat(ROB-102): KIS mock lifecycle ledger + holdings-based reconciliation

### DIFF
--- a/alembic/versions/d4f1c5a3e2b1_add_kis_mock_ledger_lifecycle.py
+++ b/alembic/versions/d4f1c5a3e2b1_add_kis_mock_ledger_lifecycle.py
@@ -1,0 +1,125 @@
+"""add kis_mock_order_ledger lifecycle columns (ROB-102)
+
+Revision ID: d4f1c5a3e2b1
+Revises: d4e5f6a7b8c9
+Create Date: 2026-05-04 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "d4f1c5a3e2b1"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_LIFECYCLE_STATES = (
+    "planned",
+    "previewed",
+    "submitted",
+    "accepted",
+    "pending",
+    "fill",
+    "reconciled",
+    "stale",
+    "failed",
+    "anomaly",
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "kis_mock_order_ledger",
+        sa.Column(
+            "lifecycle_state",
+            sa.Text(),
+            nullable=False,
+            server_default="anomaly",
+        ),
+        schema="review",
+    )
+    op.add_column(
+        "kis_mock_order_ledger",
+        sa.Column("holdings_baseline_qty", sa.Numeric(20, 8), nullable=True),
+        schema="review",
+    )
+    op.add_column(
+        "kis_mock_order_ledger",
+        sa.Column(
+            "reconcile_attempts",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+        schema="review",
+    )
+    op.add_column(
+        "kis_mock_order_ledger",
+        sa.Column(
+            "reconciled_at", sa.TIMESTAMP(timezone=True), nullable=True
+        ),
+        schema="review",
+    )
+    op.add_column(
+        "kis_mock_order_ledger",
+        sa.Column(
+            "last_reconcile_detail", postgresql.JSONB(), nullable=True
+        ),
+        schema="review",
+    )
+
+    op.execute(
+        """
+        UPDATE review.kis_mock_order_ledger
+        SET lifecycle_state = CASE status
+            WHEN 'accepted' THEN 'accepted'
+            WHEN 'rejected' THEN 'failed'
+            ELSE 'anomaly'
+        END
+        """
+    )
+
+    states = ", ".join(f"'{s}'" for s in _LIFECYCLE_STATES)
+    op.create_check_constraint(
+        "kis_mock_ledger_lifecycle_state_allowed",
+        "kis_mock_order_ledger",
+        f"lifecycle_state IN ({states})",
+        schema="review",
+    )
+    op.create_index(
+        "ix_kis_mock_ledger_lifecycle_state",
+        "kis_mock_order_ledger",
+        ["lifecycle_state"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_kis_mock_ledger_lifecycle_state",
+        table_name="kis_mock_order_ledger",
+        schema="review",
+    )
+    op.drop_constraint(
+        "kis_mock_ledger_lifecycle_state_allowed",
+        "kis_mock_order_ledger",
+        schema="review",
+        type_="check",
+    )
+    op.drop_column(
+        "kis_mock_order_ledger", "last_reconcile_detail", schema="review"
+    )
+    op.drop_column(
+        "kis_mock_order_ledger", "reconciled_at", schema="review"
+    )
+    op.drop_column(
+        "kis_mock_order_ledger", "reconcile_attempts", schema="review"
+    )
+    op.drop_column(
+        "kis_mock_order_ledger", "holdings_baseline_qty", schema="review"
+    )
+    op.drop_column("kis_mock_order_ledger", "lifecycle_state", schema="review")

--- a/app/jobs/kis_mock_reconciliation_job.py
+++ b/app/jobs/kis_mock_reconciliation_job.py
@@ -2,19 +2,25 @@
 
 Composes:
 - KISMockLifecycleService (DB read/write)
-- KISClient (Live holdings fetch)
-- kis_mock_holdings_reconciler (Pure logic)
+- KISClient (read-only mock holdings via fetch_my_stocks(is_mock=True))
+- kis_mock_holdings_reconciler (pure decision logic)
+
+No broker mutation. No live-account access. The reconciler treats
+``baseline_missing`` as an operator-review signal (anomaly); the row's
+baseline is captured at order-insert time by the order execution path.
 """
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from decimal import Decimal
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.services.brokers.kis import kis
+from app.core.symbol import to_db_symbol
+from app.schemas.execution_contracts import OrderLifecycleEvent
+from app.services.brokers.kis import KISClient
 from app.services.kis_mock_holdings_reconciler import (
     HoldingsSnapshot,
     LedgerOrderInput,
@@ -24,103 +30,151 @@ from app.services.kis_mock_holdings_reconciler import (
 from app.services.kis_mock_lifecycle_service import KISMockLifecycleService
 
 
+def _to_decimal(val: Any) -> Decimal:
+    if val in ("", None):
+        return Decimal(0)
+    try:
+        return Decimal(str(val))
+    except (InvalidOperation, TypeError, ValueError):
+        return Decimal(0)
+
+
+async def _collect_kis_mock_holdings(
+    kis_client: KISClient,
+    *,
+    taken_at: datetime,
+) -> dict[str, HoldingsSnapshot]:
+    """Read-only snapshot of KIS mock holdings (KR + US)."""
+    snapshots: dict[str, HoldingsSnapshot] = {}
+
+    kr = await kis_client.fetch_my_stocks(is_mock=True, is_overseas=False)
+    for stock in kr or []:
+        symbol = to_db_symbol(str(stock.get("pdno") or ""))
+        if not symbol:
+            continue
+        snapshots[symbol] = HoldingsSnapshot(
+            symbol=symbol,
+            quantity=_to_decimal(stock.get("hldg_qty")),
+            taken_at=taken_at,
+        )
+
+    us = await kis_client.fetch_my_stocks(is_mock=True, is_overseas=True)
+    for stock in us or []:
+        symbol = to_db_symbol(str(stock.get("ovrs_pdno") or ""))
+        if not symbol:
+            continue
+        snapshots[symbol] = HoldingsSnapshot(
+            symbol=symbol,
+            quantity=_to_decimal(stock.get("ovrs_cblc_qty")),
+            taken_at=taken_at,
+        )
+
+    return snapshots
+
+
 async def run_kis_mock_reconciliation(
     db: AsyncSession,
     *,
     dry_run: bool = True,
     limit: int = 100,
+    thresholds: ReconcilerThresholds | None = None,
+    kis_client: KISClient | None = None,
 ) -> dict[str, Any]:
-    """Fetch open mock orders, fetch live holdings, and apply transitions."""
+    """Fetch open mock orders, fetch mock holdings, propose & optionally apply transitions."""
+    thresholds = thresholds or ReconcilerThresholds()
     lifecycle_svc = KISMockLifecycleService(db)
     open_rows = await lifecycle_svc.list_open_orders(limit=limit)
     if not open_rows:
         return {
+            "success": True,
+            "account_mode": "kis_mock",
+            "broker": "kis",
             "orders_processed": 0,
             "transitions_applied": 0,
             "dry_run": dry_run,
+            "transitions": [],
+            "events": [],
             "message": "No open KIS mock orders found",
         }
 
-    # 1. Fetch live holdings from KIS (Domestic only for now as KIS mock is domestic)
-    raw_holdings = await kis.fetch_my_stocks()
-    
-    now = datetime.now(timezone.utc)
-    holdings_map: dict[str, HoldingsSnapshot] = {}
-    for h in raw_holdings:
-        symbol = h["symbol"]
-        qty = Decimal(str(h["qty"]))
-        holdings_map[symbol] = HoldingsSnapshot(
-            symbol=symbol, quantity=qty, taken_at=now
-        )
+    now = datetime.now(UTC)
+    client = kis_client if kis_client is not None else KISClient(is_mock=True)
+    holdings_map = await _collect_kis_mock_holdings(client, taken_at=now)
 
-    # 2. Map DB rows to Reconciler input
-    order_inputs: list[LedgerOrderInput] = []
-    for row in open_rows:
-        order_inputs.append(
-            LedgerOrderInput(
-                ledger_id=row.id,
-                symbol=row.symbol,
-                side=row.side,  # type: ignore
-                ordered_qty=Decimal(str(row.quantity)),
-                lifecycle_state=row.lifecycle_state,  # type: ignore
-                holdings_baseline_qty=(
-                    Decimal(str(row.holdings_baseline_qty))
-                    if row.holdings_baseline_qty is not None
-                    else None
-                ),
-                accepted_at=row.trade_date,
-            )
+    order_inputs: list[LedgerOrderInput] = [
+        LedgerOrderInput(
+            ledger_id=row.id,
+            symbol=row.symbol,
+            side=row.side,
+            ordered_qty=_to_decimal(row.quantity),
+            lifecycle_state=row.lifecycle_state,
+            holdings_baseline_qty=(
+                Decimal(str(row.holdings_baseline_qty))
+                if row.holdings_baseline_qty is not None
+                else None
+            ),
+            accepted_at=row.trade_date,
         )
+        for row in open_rows
+    ]
 
-    # 3. Classify
     proposals = classify_orders(
         orders=order_inputs,
         holdings=holdings_map,
-        thresholds=ReconcilerThresholds(),
+        thresholds=thresholds,
         now=now,
     )
 
-    # 4. Apply
     applied_count = 0
-    transition_logs = []
-    
-    for p in proposals:
-        # Special case: if baseline was missing, we just used current holdings as the new baseline
-        # but the reconciler already emitted 'baseline_missing' -> 'anomaly' proposal.
-        # However, for 'accepted' orders with missing baseline, we want to FIX the baseline first.
-        if p.reason_code == "baseline_missing":
-            snap = holdings_map.get(p.symbol)
-            if snap:
-                if not dry_run:
-                    await lifecycle_svc.record_holdings_baseline(
-                        ledger_id=p.ledger_id, baseline_qty=snap.quantity
-                    )
-                applied_count += 1
-                transition_logs.append({
-                    "ledger_id": p.ledger_id,
-                    "symbol": p.symbol,
-                    "action": "fixed_baseline",
-                    "baseline_qty": str(snap.quantity),
-                })
-            continue
+    transition_logs: list[dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
 
-        res = await lifecycle_svc.apply_lifecycle_transition(
-            ledger_id=p.ledger_id,
-            next_state=p.next_state,
-            reason_code=p.reason_code,
-            detail={
-                "observed_holdings_qty": str(p.observed_holdings_qty),
-                "observed_delta": str(p.observed_delta),
-            },
+    for proposal in proposals:
+        detail = {
+            "observed_holdings_qty": (
+                str(proposal.observed_holdings_qty)
+                if proposal.observed_holdings_qty is not None
+                else None
+            ),
+            "observed_delta": (
+                str(proposal.observed_delta)
+                if proposal.observed_delta is not None
+                else None
+            ),
+        }
+        outcome = await lifecycle_svc.apply_lifecycle_transition(
+            ledger_id=proposal.ledger_id,
+            next_state=proposal.next_state,
+            reason_code=proposal.reason_code,
+            detail=detail,
             dry_run=dry_run,
         )
-        if res.get("applied") or res.get("would_change"):
+        if outcome.get("applied"):
             applied_count += 1
-        transition_logs.append(res)
+        transition_logs.append(outcome)
+        events.append(
+            OrderLifecycleEvent(
+                account_mode="kis_mock",
+                execution_source="reconciler",
+                state=proposal.next_state,
+                occurred_at=now,
+                detail={
+                    "ledger_id": proposal.ledger_id,
+                    "symbol": proposal.symbol,
+                    "prior_state": proposal.prior_state,
+                    "reason_code": proposal.reason_code,
+                    **detail,
+                },
+            ).model_dump(mode="json")
+        )
 
     return {
+        "success": True,
+        "account_mode": "kis_mock",
+        "broker": "kis",
         "orders_processed": len(open_rows),
         "transitions_applied": applied_count,
         "dry_run": dry_run,
         "transitions": transition_logs,
+        "events": events,
     }

--- a/app/jobs/kis_mock_reconciliation_job.py
+++ b/app/jobs/kis_mock_reconciliation_job.py
@@ -1,0 +1,126 @@
+"""KIS mock reconciliation job (ROB-102).
+
+Composes:
+- KISMockLifecycleService (DB read/write)
+- KISClient (Live holdings fetch)
+- kis_mock_holdings_reconciler (Pure logic)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.brokers.kis import kis
+from app.services.kis_mock_holdings_reconciler import (
+    HoldingsSnapshot,
+    LedgerOrderInput,
+    ReconcilerThresholds,
+    classify_orders,
+)
+from app.services.kis_mock_lifecycle_service import KISMockLifecycleService
+
+
+async def run_kis_mock_reconciliation(
+    db: AsyncSession,
+    *,
+    dry_run: bool = True,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Fetch open mock orders, fetch live holdings, and apply transitions."""
+    lifecycle_svc = KISMockLifecycleService(db)
+    open_rows = await lifecycle_svc.list_open_orders(limit=limit)
+    if not open_rows:
+        return {
+            "orders_processed": 0,
+            "transitions_applied": 0,
+            "dry_run": dry_run,
+            "message": "No open KIS mock orders found",
+        }
+
+    # 1. Fetch live holdings from KIS (Domestic only for now as KIS mock is domestic)
+    raw_holdings = await kis.fetch_my_stocks()
+    
+    now = datetime.now(timezone.utc)
+    holdings_map: dict[str, HoldingsSnapshot] = {}
+    for h in raw_holdings:
+        symbol = h["symbol"]
+        qty = Decimal(str(h["qty"]))
+        holdings_map[symbol] = HoldingsSnapshot(
+            symbol=symbol, quantity=qty, taken_at=now
+        )
+
+    # 2. Map DB rows to Reconciler input
+    order_inputs: list[LedgerOrderInput] = []
+    for row in open_rows:
+        order_inputs.append(
+            LedgerOrderInput(
+                ledger_id=row.id,
+                symbol=row.symbol,
+                side=row.side,  # type: ignore
+                ordered_qty=Decimal(str(row.quantity)),
+                lifecycle_state=row.lifecycle_state,  # type: ignore
+                holdings_baseline_qty=(
+                    Decimal(str(row.holdings_baseline_qty))
+                    if row.holdings_baseline_qty is not None
+                    else None
+                ),
+                accepted_at=row.trade_date,
+            )
+        )
+
+    # 3. Classify
+    proposals = classify_orders(
+        orders=order_inputs,
+        holdings=holdings_map,
+        thresholds=ReconcilerThresholds(),
+        now=now,
+    )
+
+    # 4. Apply
+    applied_count = 0
+    transition_logs = []
+    
+    for p in proposals:
+        # Special case: if baseline was missing, we just used current holdings as the new baseline
+        # but the reconciler already emitted 'baseline_missing' -> 'anomaly' proposal.
+        # However, for 'accepted' orders with missing baseline, we want to FIX the baseline first.
+        if p.reason_code == "baseline_missing":
+            snap = holdings_map.get(p.symbol)
+            if snap:
+                if not dry_run:
+                    await lifecycle_svc.record_holdings_baseline(
+                        ledger_id=p.ledger_id, baseline_qty=snap.quantity
+                    )
+                applied_count += 1
+                transition_logs.append({
+                    "ledger_id": p.ledger_id,
+                    "symbol": p.symbol,
+                    "action": "fixed_baseline",
+                    "baseline_qty": str(snap.quantity),
+                })
+            continue
+
+        res = await lifecycle_svc.apply_lifecycle_transition(
+            ledger_id=p.ledger_id,
+            next_state=p.next_state,
+            reason_code=p.reason_code,
+            detail={
+                "observed_holdings_qty": str(p.observed_holdings_qty),
+                "observed_delta": str(p.observed_delta),
+            },
+            dry_run=dry_run,
+        )
+        if res.get("applied") or res.get("would_change"):
+            applied_count += 1
+        transition_logs.append(res)
+
+    return {
+        "orders_processed": len(open_rows),
+        "transitions_applied": applied_count,
+        "dry_run": dry_run,
+        "transitions": transition_logs,
+    }

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst
+from app.jobs.kis_mock_reconciliation_job import run_kis_mock_reconciliation
 from app.mcp_server.tooling.shared import logger
 from app.mcp_server.tooling.shared import to_float as _to_float
 from app.models.review import KISMockOrderLedger
@@ -185,3 +186,23 @@ async def _record_kis_mock_order(
             else "KIS mock order accepted but ledger insert returned no id"
         ),
     }
+
+async def kis_mock_reconciliation_run_impl(
+    *,
+    dry_run: bool = True,
+    limit: int = 100,
+) -> dict[str, Any]:
+    """Execute KIS mock order reconciliation and return summary."""
+    try:
+        async with _order_session_factory()() as db:
+            return await run_kis_mock_reconciliation(
+                db, dry_run=dry_run, limit=limit
+            )
+    except Exception as exc:
+        logger.exception("Failed to run KIS mock reconciliation: %s", exc)
+        return {
+            "success": False,
+            "error": str(exc),
+            "source": "mcp",
+            "account_mode": "kis_mock",
+        }

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -14,6 +14,18 @@ from app.mcp_server.tooling.shared import logger
 from app.mcp_server.tooling.shared import to_float as _to_float
 from app.models.review import KISMockOrderLedger
 
+_LEDGER_STATUS_TO_LIFECYCLE: dict[str, str] = {
+    "accepted": "accepted",
+    "rejected": "failed",
+    "unknown": "anomaly",
+}
+
+
+def _status_to_lifecycle_state(status: str | None) -> str:
+    if status is None:
+        return "anomaly"
+    return _LEDGER_STATUS_TO_LIFECYCLE.get(status, "anomaly")
+
 
 def _order_session_factory() -> async_sessionmaker[AsyncSession]:
     return typing_cast(
@@ -42,11 +54,13 @@ async def _save_kis_mock_order_ledger(
     thesis: str | None,
     strategy: str | None,
     notes: str | None,
+    lifecycle_state: str | None = None,
 ) -> int | None:
     """Insert one row into review.kis_mock_order_ledger.
 
     Returns the new primary-key id, or None on conflict / error.
     """
+    resolved_lifecycle = lifecycle_state or _status_to_lifecycle_state(status)
     try:
         async with _order_session_factory()() as db:
             stmt = (
@@ -75,6 +89,7 @@ async def _save_kis_mock_order_ledger(
                     thesis=thesis,
                     strategy=strategy,
                     notes=notes,
+                    lifecycle_state=resolved_lifecycle,
                 )
                 .on_conflict_do_nothing(constraint="uq_kis_mock_ledger_order_no")
             )
@@ -143,6 +158,7 @@ async def _record_kis_mock_order(
         thesis=thesis,
         strategy=strategy,
         notes=notes,
+        lifecycle_state=_status_to_lifecycle_state(status),
     )
 
     return {

--- a/app/mcp_server/tooling/kis_mock_ledger.py
+++ b/app/mcp_server/tooling/kis_mock_ledger.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from decimal import Decimal, InvalidOperation
 from typing import Any
 from typing import cast as typing_cast
 
@@ -9,6 +10,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.core.db import AsyncSessionLocal
+from app.core.symbol import to_db_symbol
 from app.core.timezone import now_kst
 from app.jobs.kis_mock_reconciliation_job import run_kis_mock_reconciliation
 from app.mcp_server.tooling.shared import logger
@@ -26,6 +28,51 @@ def _status_to_lifecycle_state(status: str | None) -> str:
     if status is None:
         return "anomaly"
     return _LEDGER_STATUS_TO_LIFECYCLE.get(status, "anomaly")
+
+
+def _to_decimal(val: Any) -> Decimal | None:
+    if val in ("", None):
+        return None
+    try:
+        return Decimal(str(val))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+
+async def _fetch_kis_mock_baseline_qty(
+    *, normalized_symbol: str, market_type: str
+) -> Decimal | None:
+    """Best-effort: read current is_mock holdings qty for ``normalized_symbol``.
+
+    Returns ``Decimal(0)`` when the position simply does not exist (legitimate
+    pre-buy baseline) and ``None`` only on broker/decoding failure so that the
+    reconciler can flag it as ``baseline_missing`` later.
+    """
+    from app.services.brokers.kis import KISClient
+
+    try:
+        kis = KISClient(is_mock=True)
+        if market_type == "equity_us":
+            stocks = await kis.fetch_my_stocks(is_mock=True, is_overseas=True)
+            for stock in stocks or []:
+                if to_db_symbol(str(stock.get("ovrs_pdno") or "")) == normalized_symbol:
+                    qty = _to_decimal(stock.get("ovrs_cblc_qty"))
+                    return qty if qty is not None else Decimal(0)
+            return Decimal(0)
+        stocks = await kis.fetch_my_stocks(is_mock=True, is_overseas=False)
+        for stock in stocks or []:
+            if to_db_symbol(str(stock.get("pdno") or "")) == normalized_symbol:
+                qty = _to_decimal(stock.get("hldg_qty"))
+                return qty if qty is not None else Decimal(0)
+        return Decimal(0)
+    except Exception as exc:
+        logger.warning(
+            "Failed to fetch KIS mock baseline for %s (%s): %s",
+            normalized_symbol,
+            market_type,
+            exc,
+        )
+        return None
 
 
 def _order_session_factory() -> async_sessionmaker[AsyncSession]:
@@ -56,6 +103,7 @@ async def _save_kis_mock_order_ledger(
     strategy: str | None,
     notes: str | None,
     lifecycle_state: str | None = None,
+    holdings_baseline_qty: Decimal | None = None,
 ) -> int | None:
     """Insert one row into review.kis_mock_order_ledger.
 
@@ -91,6 +139,7 @@ async def _save_kis_mock_order_ledger(
                     strategy=strategy,
                     notes=notes,
                     lifecycle_state=resolved_lifecycle,
+                    holdings_baseline_qty=holdings_baseline_qty,
                 )
                 .on_conflict_do_nothing(constraint="uq_kis_mock_ledger_order_no")
             )
@@ -116,6 +165,7 @@ async def _record_kis_mock_order(
     thesis: str | None,
     strategy: str | None,
     notes: str | None,
+    holdings_baseline_qty: Decimal | None = None,
 ) -> dict[str, Any]:
     """Build ledger row from execution result and return the mock-order response dict."""
     price_val = _to_float(dry_run_result.get("price"), default=0.0)
@@ -160,6 +210,7 @@ async def _record_kis_mock_order(
         strategy=strategy,
         notes=notes,
         lifecycle_state=_status_to_lifecycle_state(status),
+        holdings_baseline_qty=holdings_baseline_qty,
     )
 
     return {
@@ -187,6 +238,7 @@ async def _record_kis_mock_order(
         ),
     }
 
+
 async def kis_mock_reconciliation_run_impl(
     *,
     dry_run: bool = True,
@@ -195,9 +247,7 @@ async def kis_mock_reconciliation_run_impl(
     """Execute KIS mock order reconciliation and return summary."""
     try:
         async with _order_session_factory()() as db:
-            return await run_kis_mock_reconciliation(
-                db, dry_run=dry_run, limit=limit
-            )
+            return await run_kis_mock_reconciliation(db, dry_run=dry_run, limit=limit)
     except Exception as exc:
         logger.exception("Failed to run KIS mock reconciliation: %s", exc)
         return {

--- a/app/mcp_server/tooling/order_execution.py
+++ b/app/mcp_server/tooling/order_execution.py
@@ -7,6 +7,7 @@ Business logic lives in order_validation and order_journal.
 from __future__ import annotations
 
 import datetime
+from decimal import Decimal
 from typing import Any, Literal
 from typing import cast as typing_cast
 
@@ -642,6 +643,19 @@ async def _execute_and_record(
     if not await _check_daily_order_limit(_MAX_ORDERS_PER_DAY):
         return order_error_fn(f"Daily order limit ({_MAX_ORDERS_PER_DAY}) exceeded")
 
+    # ROB-102: capture pre-order KIS mock holdings as the reconciler baseline.
+    # Best-effort — failure leaves the column NULL and the reconciler will
+    # surface the row as `baseline_missing → anomaly` for operator review.
+    kis_mock_baseline_qty: Decimal | None = None
+    if is_mock:
+        from app.mcp_server.tooling.kis_mock_ledger import (
+            _fetch_kis_mock_baseline_qty,
+        )
+
+        kis_mock_baseline_qty = await _fetch_kis_mock_baseline_qty(
+            normalized_symbol=normalized_symbol, market_type=market_type
+        )
+
     try:
         execution_result = await _execute_order(
             symbol=normalized_symbol,
@@ -697,6 +711,7 @@ async def _execute_and_record(
             thesis=thesis,
             strategy=strategy,
             notes=notes,
+            holdings_baseline_qty=kis_mock_baseline_qty,
         )
 
     # Record phase: fills + journals

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -347,19 +347,28 @@ def register_order_tools(mcp: FastMCP) -> None:
         name="kis_mock_reconciliation_run",
         description=(
             "Manually trigger reconciliation of open KIS mock orders against "
-            "live holdings. Detects fills and updates ledger lifecycle states. "
-            "dry_run=True by default for safety. Set dry_run=False to persist "
-            "lifecycle transitions to the DB. "
+            "KIS mock holdings (read-only, is_mock=True). Detects fills via "
+            "holdings deltas and updates ledger lifecycle states. "
+            "dry_run=True by default for safety. Applying transitions requires "
+            "BOTH dry_run=False AND confirm=True. "
             "Fails closed if KIS mock config is missing."
         ),
     )
     async def kis_mock_reconciliation_run(
         dry_run: bool = True,
+        confirm: bool = False,
         limit: int = 100,
     ):
         config_error = _kis_mock_config_error()
         if config_error:
             return config_error
+        if not dry_run and not confirm:
+            return {
+                "success": False,
+                "account_mode": "kis_mock",
+                "dry_run": dry_run,
+                "error": "confirm=True is required when dry_run=False",
+            }
         return await kis_mock_ledger.kis_mock_reconciliation_run_impl(
             dry_run=dry_run, limit=limit
         )

--- a/app/mcp_server/tooling/orders_registration.py
+++ b/app/mcp_server/tooling/orders_registration.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Literal
 
 from app.core.config import validate_kis_mock_config
-from app.mcp_server.tooling import order_execution, orders_history
+from app.mcp_server.tooling import kis_mock_ledger, order_execution, orders_history
 from app.mcp_server.tooling.account_modes import (
     apply_account_routing_metadata,
     normalize_account_mode,
@@ -27,6 +27,7 @@ ORDER_TOOL_NAMES: set[str] = {
     "modify_order",
     "cancel_order",
     "get_order_history",
+    "kis_mock_reconciliation_run",
 }
 
 
@@ -340,6 +341,27 @@ def register_order_tools(mcp: FastMCP) -> None:
                 is_mock=routing.is_kis_mock,
             ),
             routing,
+        )
+
+    @mcp.tool(
+        name="kis_mock_reconciliation_run",
+        description=(
+            "Manually trigger reconciliation of open KIS mock orders against "
+            "live holdings. Detects fills and updates ledger lifecycle states. "
+            "dry_run=True by default for safety. Set dry_run=False to persist "
+            "lifecycle transitions to the DB. "
+            "Fails closed if KIS mock config is missing."
+        ),
+    )
+    async def kis_mock_reconciliation_run(
+        dry_run: bool = True,
+        limit: int = 100,
+    ):
+        config_error = _kis_mock_config_error()
+        if config_error:
+            return config_error
+        return await kis_mock_ledger.kis_mock_reconciliation_run_impl(
+            dry_run=dry_run, limit=limit
         )
 
 

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -189,8 +189,16 @@ class KISMockOrderLedger(Base):
             "status IN ('accepted','rejected','unknown')",
             name="kis_mock_ledger_status_allowed",
         ),
+        CheckConstraint(
+            "lifecycle_state IN ("
+            "'planned','previewed','submitted','accepted','pending','fill',"
+            "'reconciled','stale','failed','anomaly'"
+            ")",
+            name="kis_mock_ledger_lifecycle_state_allowed",
+        ),
         Index("ix_kis_mock_ledger_trade_date", "trade_date"),
         Index("ix_kis_mock_ledger_symbol", "symbol"),
+        Index("ix_kis_mock_ledger_lifecycle_state", "lifecycle_state"),
         {"schema": "review"},
     )
 
@@ -225,6 +233,15 @@ class KISMockOrderLedger(Base):
     thesis: Mapped[str | None] = mapped_column(Text)
     strategy: Mapped[str | None] = mapped_column(Text)
     notes: Mapped[str | None] = mapped_column(Text)
+
+    # ROB-102 lifecycle columns
+    lifecycle_state: Mapped[str] = mapped_column(Text, nullable=False, default="anomaly")
+    holdings_baseline_qty: Mapped[float | None] = mapped_column(Numeric(20, 8))
+    reconcile_attempts: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=0
+    )
+    reconciled_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    last_reconcile_detail: Mapped[dict | None] = mapped_column(JSONB)
 
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -235,7 +235,9 @@ class KISMockOrderLedger(Base):
     notes: Mapped[str | None] = mapped_column(Text)
 
     # ROB-102 lifecycle columns
-    lifecycle_state: Mapped[str] = mapped_column(Text, nullable=False, default="anomaly")
+    lifecycle_state: Mapped[str] = mapped_column(
+        Text, nullable=False, default="anomaly"
+    )
     holdings_baseline_qty: Mapped[float | None] = mapped_column(Numeric(20, 8))
     reconcile_attempts: Mapped[int] = mapped_column(
         BigInteger, nullable=False, default=0

--- a/app/services/kis_mock_holdings_reconciler.py
+++ b/app/services/kis_mock_holdings_reconciler.py
@@ -117,12 +117,9 @@ def classify_orders(
         delta = snapshot.quantity - order.holdings_baseline_qty
 
         if order.lifecycle_state == "fill":
-            expected = (
-                order.ordered_qty if order.side == "buy" else -order.ordered_qty
-            )
-            if (
-                (order.side == "buy" and delta >= expected)
-                or (order.side == "sell" and delta <= expected)
+            expected = order.ordered_qty if order.side == "buy" else -order.ordered_qty
+            if (order.side == "buy" and delta >= expected) or (
+                order.side == "sell" and delta <= expected
             ):
                 proposals.append(
                     LifecycleTransitionProposal(

--- a/app/services/kis_mock_holdings_reconciler.py
+++ b/app/services/kis_mock_holdings_reconciler.py
@@ -1,0 +1,200 @@
+"""Pure holdings-delta reconciler for KIS mock orders (ROB-102).
+
+Read-only / decision-support only. This module must not import broker,
+DB, KIS client, ORM, or sqlalchemy code. Callers collect ledger rows and
+holdings snapshots and pass plain dataclasses.
+
+Output `next_state` values are always one of the ROB-100
+`OrderLifecycleState` literals. Internal "fine-grained" meaning is encoded
+in `reason_code`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+from app.schemas.execution_contracts import OrderLifecycleState
+
+ReasonCode = Literal[
+    "fill_detected",
+    "partial_fill_detected",
+    "pending_unconfirmed",
+    "stale_unconfirmed",
+    "position_reconciled",
+    "holdings_mismatch",
+    "holdings_snapshot_missing",
+    "baseline_missing",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class LedgerOrderInput:
+    ledger_id: int
+    symbol: str
+    side: Literal["buy", "sell"]
+    ordered_qty: Decimal
+    lifecycle_state: OrderLifecycleState
+    holdings_baseline_qty: Decimal | None
+    accepted_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class HoldingsSnapshot:
+    symbol: str
+    quantity: Decimal
+    taken_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class ReconcilerThresholds:
+    pending_threshold_sec: int = 60
+    stale_threshold_sec: int = 1800
+
+
+@dataclass(frozen=True, slots=True)
+class LifecycleTransitionProposal:
+    ledger_id: int
+    symbol: str
+    prior_state: OrderLifecycleState
+    next_state: OrderLifecycleState
+    reason_code: ReasonCode
+    observed_holdings_qty: Decimal | None
+    observed_delta: Decimal | None
+
+
+_TERMINAL: frozenset[str] = frozenset({"reconciled", "failed", "stale"})
+_RECONCILABLE_INPUTS: frozenset[str] = frozenset({"accepted", "pending", "fill"})
+
+
+def classify_orders(
+    *,
+    orders: Sequence[LedgerOrderInput],
+    holdings: Mapping[str, HoldingsSnapshot],
+    thresholds: ReconcilerThresholds,
+    now: datetime,
+) -> list[LifecycleTransitionProposal]:
+    proposals: list[LifecycleTransitionProposal] = []
+    for order in orders:
+        if order.lifecycle_state in _TERMINAL:
+            continue
+        if order.lifecycle_state not in _RECONCILABLE_INPUTS:
+            # planned/previewed/submitted/anomaly are out of scope here.
+            continue
+
+        if order.holdings_baseline_qty is None:
+            proposals.append(
+                LifecycleTransitionProposal(
+                    ledger_id=order.ledger_id,
+                    symbol=order.symbol,
+                    prior_state=order.lifecycle_state,
+                    next_state="anomaly",
+                    reason_code="baseline_missing",
+                    observed_holdings_qty=None,
+                    observed_delta=None,
+                )
+            )
+            continue
+
+        snapshot = holdings.get(order.symbol)
+        if snapshot is None:
+            proposals.append(
+                LifecycleTransitionProposal(
+                    ledger_id=order.ledger_id,
+                    symbol=order.symbol,
+                    prior_state=order.lifecycle_state,
+                    next_state="anomaly",
+                    reason_code="holdings_snapshot_missing",
+                    observed_holdings_qty=None,
+                    observed_delta=None,
+                )
+            )
+            continue
+
+        delta = snapshot.quantity - order.holdings_baseline_qty
+
+        if order.lifecycle_state == "fill":
+            expected = (
+                order.ordered_qty if order.side == "buy" else -order.ordered_qty
+            )
+            if (
+                (order.side == "buy" and delta >= expected)
+                or (order.side == "sell" and delta <= expected)
+            ):
+                proposals.append(
+                    LifecycleTransitionProposal(
+                        ledger_id=order.ledger_id,
+                        symbol=order.symbol,
+                        prior_state=order.lifecycle_state,
+                        next_state="reconciled",
+                        reason_code="position_reconciled",
+                        observed_holdings_qty=snapshot.quantity,
+                        observed_delta=delta,
+                    )
+                )
+            else:
+                proposals.append(
+                    LifecycleTransitionProposal(
+                        ledger_id=order.ledger_id,
+                        symbol=order.symbol,
+                        prior_state=order.lifecycle_state,
+                        next_state="anomaly",
+                        reason_code="holdings_mismatch",
+                        observed_holdings_qty=snapshot.quantity,
+                        observed_delta=delta,
+                    )
+                )
+            continue
+
+        # accepted / pending paths
+        if order.side == "buy":
+            if delta >= order.ordered_qty:
+                next_state, reason = "fill", "fill_detected"
+            elif delta > 0:
+                next_state, reason = "fill", "partial_fill_detected"
+            else:
+                next_state, reason = _pending_or_stale(order, now, thresholds)
+        else:  # sell
+            if delta <= -order.ordered_qty:
+                next_state, reason = "fill", "fill_detected"
+            elif delta < 0:
+                next_state, reason = "fill", "partial_fill_detected"
+            else:
+                next_state, reason = _pending_or_stale(order, now, thresholds)
+
+        proposals.append(
+            LifecycleTransitionProposal(
+                ledger_id=order.ledger_id,
+                symbol=order.symbol,
+                prior_state=order.lifecycle_state,
+                next_state=next_state,
+                reason_code=reason,
+                observed_holdings_qty=snapshot.quantity,
+                observed_delta=delta,
+            )
+        )
+    return proposals
+
+
+def _pending_or_stale(
+    order: LedgerOrderInput,
+    now: datetime,
+    thresholds: ReconcilerThresholds,
+) -> tuple[OrderLifecycleState, ReasonCode]:
+    age = (now - order.accepted_at).total_seconds()
+    if age >= thresholds.stale_threshold_sec:
+        return "stale", "stale_unconfirmed"
+    return "pending", "pending_unconfirmed"
+
+
+__all__ = [
+    "HoldingsSnapshot",
+    "LedgerOrderInput",
+    "LifecycleTransitionProposal",
+    "ReasonCode",
+    "ReconcilerThresholds",
+    "classify_orders",
+]

--- a/app/services/kis_mock_lifecycle_service.py
+++ b/app/services/kis_mock_lifecycle_service.py
@@ -1,0 +1,140 @@
+"""KIS mock order lifecycle service (ROB-102).
+
+Pure record-keeping. Must not import or call broker mutation services,
+KIS live execution, watch alerts, order intents, scheduler, fill
+notification, or trade journal code. All writes are atomic per call.
+
+Lifecycle vocabulary follows ROB-100 (`app.schemas.execution_contracts`).
+Fine-grained reasoning is stored in `last_reconcile_detail.reason_code`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import KISMockOrderLedger
+from app.schemas.execution_contracts import (
+    ORDER_LIFECYCLE_STATES,
+    OrderLifecycleState,
+    TERMINAL_LIFECYCLE_STATES,
+)
+
+# These are the lifecycle states the reconciler reads from. anything
+# else is excluded from `list_open_orders`.
+OPEN_LIFECYCLE_STATES: frozenset[str] = frozenset({"accepted", "pending", "fill"})
+
+
+class LedgerNotFoundError(Exception):
+    """Raised when a ledger row with the given id does not exist."""
+
+
+class KISMockLifecycleService:
+    """Pure record-keeping service for KIS mock order lifecycle."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def list_open_orders(
+        self, *, limit: int = 100
+    ) -> list[KISMockOrderLedger]:
+        if limit < 1:
+            raise ValueError("limit must be >= 1")
+        stmt = (
+            select(KISMockOrderLedger)
+            .where(
+                KISMockOrderLedger.lifecycle_state.in_(OPEN_LIFECYCLE_STATES)
+            )
+            .order_by(
+                KISMockOrderLedger.trade_date.asc(),
+                KISMockOrderLedger.id.asc(),
+            )
+            .limit(limit)
+        )
+        result = await self._db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def record_holdings_baseline(
+        self,
+        *,
+        ledger_id: int,
+        baseline_qty: Decimal,
+    ) -> None:
+        row = await self._db.get(KISMockOrderLedger, ledger_id)
+        if row is None:
+            raise LedgerNotFoundError(str(ledger_id))
+        row.holdings_baseline_qty = baseline_qty
+        await self._db.commit()
+
+    async def apply_lifecycle_transition(
+        self,
+        *,
+        ledger_id: int,
+        next_state: OrderLifecycleState,
+        reason_code: str,
+        detail: dict[str, Any],
+        dry_run: bool,
+    ) -> dict[str, Any]:
+        if next_state not in ORDER_LIFECYCLE_STATES:
+            raise ValueError(f"unknown lifecycle state: {next_state!r}")
+
+        row = await self._db.get(KISMockOrderLedger, ledger_id)
+        if row is None:
+            raise LedgerNotFoundError(str(ledger_id))
+
+        prior_state = row.lifecycle_state
+        would_change = prior_state != next_state
+
+        if dry_run:
+            return {
+                "ledger_id": ledger_id,
+                "prior_state": prior_state,
+                "next_state": next_state,
+                "reason_code": reason_code,
+                "would_change": would_change,
+                "applied": False,
+                "dry_run": True,
+            }
+
+        if not would_change:
+            row.reconcile_attempts = (row.reconcile_attempts or 0) + 1
+            row.last_reconcile_detail = {"reason_code": reason_code, **detail}
+            await self._db.commit()
+            return {
+                "ledger_id": ledger_id,
+                "prior_state": prior_state,
+                "next_state": next_state,
+                "reason_code": reason_code,
+                "applied": True,
+                "would_change": False,
+                "dry_run": False,
+            }
+
+        row.lifecycle_state = next_state
+        row.reconcile_attempts = (row.reconcile_attempts or 0) + 1
+        row.last_reconcile_detail = {"reason_code": reason_code, **detail}
+        if next_state in TERMINAL_LIFECYCLE_STATES:
+            row.reconciled_at = datetime.now(tz=timezone.utc)
+        await self._db.commit()
+
+        return {
+            "ledger_id": ledger_id,
+            "prior_state": prior_state,
+            "next_state": next_state,
+            "reason_code": reason_code,
+            "applied": True,
+            "would_change": True,
+            "dry_run": False,
+        }
+
+
+__all__ = [
+    "KISMockLifecycleService",
+    "LedgerNotFoundError",
+    "OPEN_LIFECYCLE_STATES",
+]

--- a/app/services/kis_mock_lifecycle_service.py
+++ b/app/services/kis_mock_lifecycle_service.py
@@ -10,19 +10,18 @@ Fine-grained reasoning is stored in `last_reconcile_detail.reason_code`.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import select, update
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.review import KISMockOrderLedger
 from app.schemas.execution_contracts import (
     ORDER_LIFECYCLE_STATES,
-    OrderLifecycleState,
     TERMINAL_LIFECYCLE_STATES,
+    OrderLifecycleState,
 )
 
 # These are the lifecycle states the reconciler reads from. anything
@@ -40,16 +39,12 @@ class KISMockLifecycleService:
     def __init__(self, db: AsyncSession) -> None:
         self._db = db
 
-    async def list_open_orders(
-        self, *, limit: int = 100
-    ) -> list[KISMockOrderLedger]:
+    async def list_open_orders(self, *, limit: int = 100) -> list[KISMockOrderLedger]:
         if limit < 1:
             raise ValueError("limit must be >= 1")
         stmt = (
             select(KISMockOrderLedger)
-            .where(
-                KISMockOrderLedger.lifecycle_state.in_(OPEN_LIFECYCLE_STATES)
-            )
+            .where(KISMockOrderLedger.lifecycle_state.in_(OPEN_LIFECYCLE_STATES))
             .order_by(
                 KISMockOrderLedger.trade_date.asc(),
                 KISMockOrderLedger.id.asc(),
@@ -119,7 +114,7 @@ class KISMockLifecycleService:
         row.reconcile_attempts = (row.reconcile_attempts or 0) + 1
         row.last_reconcile_detail = {"reason_code": reason_code, **detail}
         if next_state in TERMINAL_LIFECYCLE_STATES:
-            row.reconciled_at = datetime.now(tz=timezone.utc)
+            row.reconciled_at = datetime.now(tz=UTC)
         await self._db.commit()
 
         return {

--- a/docs/runbooks/kis-mock-reconciliation.md
+++ b/docs/runbooks/kis-mock-reconciliation.md
@@ -1,0 +1,98 @@
+# KIS Mock Holdings-Based Reconciliation Runbook (ROB-102)
+
+## Purpose
+
+`review.kis_mock_order_ledger` tracks KIS official-mock order lifecycle.
+Because the KIS mock domestic pending-orders endpoint is unsupported and
+cash/orderable APIs do not reliably indicate fills, this reconciler uses
+**holdings deltas** (against a baseline captured at order-insert time) as
+the primary fill signal.
+
+Related: ROB-37 introduced the ledger. ROB-100 introduced the shared
+lifecycle/account-mode contract. ROB-102 adds lifecycle tracking and the
+holdings-delta reconciler.
+
+---
+
+## Lifecycle States (ROB-100 vocabulary)
+
+| State | Meaning here |
+|-------|--------------|
+| `accepted` | Broker accepted the mock order; awaiting reconciliation |
+| `pending` | No holdings delta yet; under stale threshold |
+| `fill` | Holdings delta ≥ ordered qty (or partial delta) detected |
+| `reconciled` | Post-fill holdings still match expected position |
+| `stale` | No holdings delta after the stale threshold |
+| `failed` | Broker rejected at submit time |
+| `anomaly` | Holdings snapshot missing, baseline missing, or holdings disagree post-fill |
+
+`reconciled`, `failed`, `stale` are terminal. `anomaly` is an operator
+hand-off and is not terminal success/failure.
+
+Fine-grained reasons (`reason_code`) live in `last_reconcile_detail`:
+`fill_detected`, `partial_fill_detected`, `pending_unconfirmed`,
+`stale_unconfirmed`, `position_reconciled`, `holdings_mismatch`,
+`holdings_snapshot_missing`, `baseline_missing`.
+
+---
+
+## Baseline capture
+
+When `_record_kis_mock_order` runs (immediately after broker acceptance),
+it persists a snapshot of the **current KIS mock holdings qty** for the
+symbol into `holdings_baseline_qty`. This is read-only against the
+mock account (`fetch_my_stocks(is_mock=True)`).
+
+If the broker call fails or a transient error occurs, `holdings_baseline_qty`
+is left `NULL` and the reconciler will surface the row as
+`baseline_missing → anomaly` for operator review.
+
+---
+
+## How to run
+
+Default invocation (dry-run, returns proposals only):
+
+```
+kis_mock_reconciliation_run()
+```
+
+Apply transitions (operator-gated):
+
+```
+kis_mock_reconciliation_run(dry_run=False, confirm=True)
+```
+
+Tunable bound:
+
+```
+kis_mock_reconciliation_run(limit=100)
+```
+
+Thresholds (`pending_threshold_sec=60`, `stale_threshold_sec=1800`)
+are currently configured at the reconciler default and can be tuned by
+passing a `ReconcilerThresholds` to `run_kis_mock_reconciliation` directly
+from a script or test.
+
+---
+
+## Safety
+
+* No broker submit/cancel/modify calls.
+* No KIS live-account access (`fetch_my_stocks(is_mock=True)` only).
+* Direct SQL writes against `review.kis_mock_order_ledger` are forbidden;
+  go through `KISMockLifecycleService`.
+* `dry_run=False` requires `confirm=True` from the operator.
+* No scheduler/launchd hooks added by ROB-102 — invoke manually for now.
+
+## Troubleshooting
+
+* `holdings_snapshot_missing` — KIS holdings call returned no row for the
+  symbol; verify `fetch_my_stocks(is_mock=True)` and symbol normalization
+  (KR `pdno`, US `ovrs_pdno`).
+* `baseline_missing` — the order-insert baseline fetch failed at submission
+  time. Either backfill via
+  `KISMockLifecycleService.record_holdings_baseline` or hand off to the
+  operator via the anomaly path.
+* `holdings_mismatch` — post-fill holdings disagree with the expected
+  position; do NOT auto-resolve. Escalate to operator.

--- a/tests/jobs/test_kis_mock_reconciliation_job.py
+++ b/tests/jobs/test_kis_mock_reconciliation_job.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
@@ -9,56 +10,141 @@ import pytest
 
 from app.jobs.kis_mock_reconciliation_job import run_kis_mock_reconciliation
 from app.models.review import KISMockOrderLedger
-from app.services.kis_mock_holdings_reconciler import (
-    HoldingsSnapshot,
-    LifecycleTransitionProposal,
-)
+
+
+def _ledger_row(
+    *,
+    ledger_id: int = 101,
+    symbol: str = "005930",
+    side: str = "buy",
+    qty: Decimal = Decimal("10"),
+    state: str = "accepted",
+    baseline: Decimal | None = Decimal("5"),
+    accepted_age_sec: int = 5,
+):
+    row = MagicMock(spec=KISMockOrderLedger)
+    row.id = ledger_id
+    row.symbol = symbol
+    row.side = side
+    row.quantity = qty
+    row.lifecycle_state = state
+    row.holdings_baseline_qty = baseline
+    row.trade_date = datetime.now(UTC) - timedelta(seconds=accepted_age_sec)
+    return row
+
+
+def _fake_kis_client(*, kr=None, us=None):
+    client = MagicMock()
+    client.fetch_my_stocks = AsyncMock(side_effect=[kr or [], us or []])
+    return client
 
 
 @pytest.mark.asyncio
-async def test_reconciliation_job_composition(monkeypatch):
-    # 1. Mock DB session
+async def test_reconciliation_job_uses_kis_mock_holdings(monkeypatch):
+    """Job must call fetch_my_stocks(is_mock=True) for both KR and US."""
     mock_db = AsyncMock()
-    
-    # 2. Mock KISMockLifecycleService
-    mock_ledger_row = MagicMock(spec=KISMockOrderLedger)
-    mock_ledger_row.id = 101
-    mock_ledger_row.symbol = "005930"
-    mock_ledger_row.side = "buy"
-    mock_ledger_row.quantity = Decimal("10")
-    mock_ledger_row.lifecycle_state = "accepted"
-    mock_ledger_row.holdings_baseline_qty = Decimal("5")
-    mock_ledger_row.trade_date = MagicMock()
-    
+
     mock_lifecycle_svc = AsyncMock()
-    mock_lifecycle_svc.list_open_orders.return_value = [mock_ledger_row]
+    mock_lifecycle_svc.list_open_orders.return_value = [_ledger_row()]
     mock_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": True}
-    
     monkeypatch.setattr(
         "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
         lambda _: mock_lifecycle_svc,
     )
-    
-    # 3. Mock KISClient (Broker) for holdings
-    mock_kis = AsyncMock()
-    mock_kis.fetch_my_stocks.return_value = [
-        {"symbol": "005930", "qty": "15"}
-    ]
-    monkeypatch.setattr(
-        "app.jobs.kis_mock_reconciliation_job.kis",
-        mock_kis,
+
+    # Real KIS contract: KR uses pdno/hldg_qty, US uses ovrs_pdno/ovrs_cblc_qty.
+    fake_kis = _fake_kis_client(kr=[{"pdno": "005930", "hldg_qty": "15"}])
+
+    result = await run_kis_mock_reconciliation(
+        mock_db, dry_run=False, kis_client=fake_kis
     )
-    
-    # 4. Run job (don't mock pure reconciler)
-    results = await run_kis_mock_reconciliation(mock_db, dry_run=False)
-    
-    # Verify composition
-    assert results["orders_processed"] == 1
-    assert results["transitions_applied"] == 1
-    
-    # Verify transition was applied
-    mock_lifecycle_svc.apply_lifecycle_transition.assert_awaited_once()
+
+    assert result["orders_processed"] == 1
+    assert result["transitions_applied"] == 1
+    assert result["account_mode"] == "kis_mock"
+
+    # Verify both KR and US holdings calls were issued with is_mock=True.
+    assert fake_kis.fetch_my_stocks.await_count == 2
+    kr_call = fake_kis.fetch_my_stocks.await_args_list[0]
+    us_call = fake_kis.fetch_my_stocks.await_args_list[1]
+    assert kr_call.kwargs == {"is_mock": True, "is_overseas": False}
+    assert us_call.kwargs == {"is_mock": True, "is_overseas": True}
+
+    # Verify transition was applied to the right ledger row.
     args = mock_lifecycle_svc.apply_lifecycle_transition.call_args.kwargs
     assert args["ledger_id"] == 101
     assert args["next_state"] == "fill"
+    assert args["reason_code"] == "fill_detected"
     assert args["dry_run"] is False
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_job_handles_overseas_holdings(monkeypatch):
+    mock_db = AsyncMock()
+
+    mock_lifecycle_svc = AsyncMock()
+    mock_lifecycle_svc.list_open_orders.return_value = [
+        _ledger_row(ledger_id=202, symbol="AAPL")
+    ]
+    mock_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": True}
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+
+    fake_kis = _fake_kis_client(
+        kr=[],
+        us=[{"ovrs_pdno": "AAPL", "ovrs_cblc_qty": "15"}],
+    )
+
+    result = await run_kis_mock_reconciliation(
+        mock_db, dry_run=False, kis_client=fake_kis
+    )
+
+    assert result["transitions_applied"] == 1
+    args = mock_lifecycle_svc.apply_lifecycle_transition.call_args.kwargs
+    assert args["next_state"] == "fill"
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_job_emits_lifecycle_events(monkeypatch):
+    mock_db = AsyncMock()
+
+    mock_lifecycle_svc = AsyncMock()
+    mock_lifecycle_svc.list_open_orders.return_value = [_ledger_row()]
+    mock_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": True}
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+
+    fake_kis = _fake_kis_client(kr=[{"pdno": "005930", "hldg_qty": "15"}])
+
+    result = await run_kis_mock_reconciliation(
+        mock_db, dry_run=True, kis_client=fake_kis
+    )
+
+    assert len(result["events"]) == 1
+    event = result["events"][0]
+    assert event["account_mode"] == "kis_mock"
+    assert event["execution_source"] == "reconciler"
+    assert event["state"] == "fill"
+    assert event["detail"]["ledger_id"] == 101
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_job_no_open_orders(monkeypatch):
+    mock_db = AsyncMock()
+    mock_lifecycle_svc = AsyncMock()
+    mock_lifecycle_svc.list_open_orders.return_value = []
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+    fake_kis = _fake_kis_client()
+
+    result = await run_kis_mock_reconciliation(
+        mock_db, dry_run=True, kis_client=fake_kis
+    )
+    assert result["orders_processed"] == 0
+    fake_kis.fetch_my_stocks.assert_not_called()

--- a/tests/jobs/test_kis_mock_reconciliation_job.py
+++ b/tests/jobs/test_kis_mock_reconciliation_job.py
@@ -1,0 +1,64 @@
+"""Tests for KIS mock reconciliation job composition (ROB-102)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.jobs.kis_mock_reconciliation_job import run_kis_mock_reconciliation
+from app.models.review import KISMockOrderLedger
+from app.services.kis_mock_holdings_reconciler import (
+    HoldingsSnapshot,
+    LifecycleTransitionProposal,
+)
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_job_composition(monkeypatch):
+    # 1. Mock DB session
+    mock_db = AsyncMock()
+    
+    # 2. Mock KISMockLifecycleService
+    mock_ledger_row = MagicMock(spec=KISMockOrderLedger)
+    mock_ledger_row.id = 101
+    mock_ledger_row.symbol = "005930"
+    mock_ledger_row.side = "buy"
+    mock_ledger_row.quantity = Decimal("10")
+    mock_ledger_row.lifecycle_state = "accepted"
+    mock_ledger_row.holdings_baseline_qty = Decimal("5")
+    mock_ledger_row.trade_date = MagicMock()
+    
+    mock_lifecycle_svc = AsyncMock()
+    mock_lifecycle_svc.list_open_orders.return_value = [mock_ledger_row]
+    mock_lifecycle_svc.apply_lifecycle_transition.return_value = {"applied": True}
+    
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+    
+    # 3. Mock KISClient (Broker) for holdings
+    mock_kis = AsyncMock()
+    mock_kis.fetch_my_stocks.return_value = [
+        {"symbol": "005930", "qty": "15"}
+    ]
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.kis",
+        mock_kis,
+    )
+    
+    # 4. Run job (don't mock pure reconciler)
+    results = await run_kis_mock_reconciliation(mock_db, dry_run=False)
+    
+    # Verify composition
+    assert results["orders_processed"] == 1
+    assert results["transitions_applied"] == 1
+    
+    # Verify transition was applied
+    mock_lifecycle_svc.apply_lifecycle_transition.assert_awaited_once()
+    args = mock_lifecycle_svc.apply_lifecycle_transition.call_args.kwargs
+    assert args["ledger_id"] == 101
+    assert args["next_state"] == "fill"
+    assert args["dry_run"] is False

--- a/tests/mcp_server/test_kis_mock_reconciliation_tool.py
+++ b/tests/mcp_server/test_kis_mock_reconciliation_tool.py
@@ -10,26 +10,63 @@ from tests._mcp_tooling_support import build_tools
 
 
 @pytest.mark.asyncio
-async def test_kis_mock_reconciliation_tool_available_and_calls_impl(monkeypatch):
+async def test_kis_mock_reconciliation_tool_dry_run_default(monkeypatch):
     from app.mcp_server.tooling import kis_mock_ledger
-    
-    # 1. Mock config to pass
+
     monkeypatch.setattr(
         "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
         lambda: [],
     )
-    
-    # 2. Mock implementation
-    mock_run = AsyncMock(return_value={"success": True, "applied": 5})
+
+    mock_run = AsyncMock(return_value={"success": True, "applied": 0})
     monkeypatch.setattr(kis_mock_ledger, "kis_mock_reconciliation_run_impl", mock_run)
-    
-    # 3. Build tools
+
     tools = build_tools()
     assert "kis_mock_reconciliation_run" in tools
-    
-    # 4. Call tool
-    result = await tools["kis_mock_reconciliation_run"](dry_run=True, limit=10)
-    
-    # 5. Verify
-    assert result == {"success": True, "applied": 5}
-    mock_run.assert_awaited_once_with(dry_run=True, limit=10)
+
+    result = await tools["kis_mock_reconciliation_run"]()
+    assert result == {"success": True, "applied": 0}
+    mock_run.assert_awaited_once_with(dry_run=True, limit=100)
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_reconciliation_tool_apply_requires_confirm(monkeypatch):
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda: [],
+    )
+
+    mock_run = AsyncMock()
+    monkeypatch.setattr(kis_mock_ledger, "kis_mock_reconciliation_run_impl", mock_run)
+
+    tools = build_tools()
+    result = await tools["kis_mock_reconciliation_run"](
+        dry_run=False, confirm=False, limit=10
+    )
+
+    assert result["success"] is False
+    assert "confirm" in result["error"].lower()
+    mock_run.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_reconciliation_tool_apply_with_confirm(monkeypatch):
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda: [],
+    )
+
+    mock_run = AsyncMock(return_value={"success": True, "applied": 3})
+    monkeypatch.setattr(kis_mock_ledger, "kis_mock_reconciliation_run_impl", mock_run)
+
+    tools = build_tools()
+    result = await tools["kis_mock_reconciliation_run"](
+        dry_run=False, confirm=True, limit=10
+    )
+
+    assert result == {"success": True, "applied": 3}
+    mock_run.assert_awaited_once_with(dry_run=False, limit=10)

--- a/tests/mcp_server/test_kis_mock_reconciliation_tool.py
+++ b/tests/mcp_server/test_kis_mock_reconciliation_tool.py
@@ -1,0 +1,35 @@
+"""Smoke tests for KIS mock reconciliation tool (ROB-102)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests._mcp_tooling_support import build_tools
+
+
+@pytest.mark.asyncio
+async def test_kis_mock_reconciliation_tool_available_and_calls_impl(monkeypatch):
+    from app.mcp_server.tooling import kis_mock_ledger
+    
+    # 1. Mock config to pass
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda: [],
+    )
+    
+    # 2. Mock implementation
+    mock_run = AsyncMock(return_value={"success": True, "applied": 5})
+    monkeypatch.setattr(kis_mock_ledger, "kis_mock_reconciliation_run_impl", mock_run)
+    
+    # 3. Build tools
+    tools = build_tools()
+    assert "kis_mock_reconciliation_run" in tools
+    
+    # 4. Call tool
+    result = await tools["kis_mock_reconciliation_run"](dry_run=True, limit=10)
+    
+    # 5. Verify
+    assert result == {"success": True, "applied": 5}
+    mock_run.assert_awaited_once_with(dry_run=True, limit=10)

--- a/tests/services/test_kis_mock_holdings_reconciler.py
+++ b/tests/services/test_kis_mock_holdings_reconciler.py
@@ -1,0 +1,216 @@
+"""Pure tests for KIS mock holdings-delta reconciler (ROB-102)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+
+from app.services.kis_mock_holdings_reconciler import (
+    HoldingsSnapshot,
+    LedgerOrderInput,
+    LifecycleTransitionProposal,
+    ReconcilerThresholds,
+    classify_orders,
+)
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 4, 9, 30, tzinfo=timezone.utc)
+
+
+def _order(
+    *,
+    side: str = "buy",
+    state: str = "accepted",
+    ordered_qty: Decimal = Decimal("10"),
+    baseline: Decimal | None = Decimal("0"),
+    accepted_age_sec: int = 0,
+) -> LedgerOrderInput:
+    return LedgerOrderInput(
+        ledger_id=1,
+        symbol="005930",
+        side=side,
+        ordered_qty=ordered_qty,
+        lifecycle_state=state,
+        holdings_baseline_qty=baseline,
+        accepted_at=_now() - timedelta(seconds=accepted_age_sec),
+    )
+
+
+def _snap(qty: Decimal) -> HoldingsSnapshot:
+    return HoldingsSnapshot(symbol="005930", quantity=qty, taken_at=_now())
+
+
+@pytest.mark.unit
+def test_full_buy_fill_detected():
+    proposals = classify_orders(
+        orders=[_order(baseline=Decimal("5"))],
+        holdings={"005930": _snap(Decimal("15"))},  # delta = +10
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    assert len(proposals) == 1
+    assert proposals[0].next_state == "fill"
+    assert proposals[0].reason_code == "fill_detected"
+
+
+@pytest.mark.unit
+def test_partial_buy_fill_detected():
+    proposals = classify_orders(
+        orders=[_order(baseline=Decimal("5"))],
+        holdings={"005930": _snap(Decimal("9"))},  # delta = +4 of ordered 10
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    assert proposals[0].next_state == "fill"
+    assert proposals[0].reason_code == "partial_fill_detected"
+
+
+@pytest.mark.unit
+def test_buy_no_delta_recent_marks_pending():
+    proposals = classify_orders(
+        orders=[_order(baseline=Decimal("5"), accepted_age_sec=10)],
+        holdings={"005930": _snap(Decimal("5"))},  # no delta
+        thresholds=ReconcilerThresholds(
+            pending_threshold_sec=60, stale_threshold_sec=1800
+        ),
+        now=_now(),
+    )
+    assert proposals[0].next_state == "pending"
+    assert proposals[0].reason_code == "pending_unconfirmed"
+
+
+@pytest.mark.unit
+def test_buy_no_delta_after_stale_threshold_marks_stale():
+    proposals = classify_orders(
+        orders=[_order(baseline=Decimal("5"), accepted_age_sec=3600)],
+        holdings={"005930": _snap(Decimal("5"))},
+        thresholds=ReconcilerThresholds(
+            pending_threshold_sec=60, stale_threshold_sec=1800
+        ),
+        now=_now(),
+    )
+    assert proposals[0].next_state == "stale"
+    assert proposals[0].reason_code == "stale_unconfirmed"
+
+
+@pytest.mark.unit
+def test_full_sell_fill_detected():
+    proposals = classify_orders(
+        orders=[_order(side="sell", baseline=Decimal("20"))],
+        holdings={"005930": _snap(Decimal("10"))},  # delta = -10
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    assert proposals[0].next_state == "fill"
+    assert proposals[0].reason_code == "fill_detected"
+
+
+@pytest.mark.unit
+def test_baseline_missing_emits_anomaly():
+    proposals = classify_orders(
+        orders=[_order(baseline=None)],
+        holdings={"005930": _snap(Decimal("5"))},
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    assert proposals[0].next_state == "anomaly"
+    assert proposals[0].reason_code == "baseline_missing"
+
+
+@pytest.mark.unit
+def test_snapshot_missing_emits_anomaly():
+    proposals = classify_orders(
+        orders=[_order(baseline=Decimal("5"))],
+        holdings={},
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    assert proposals[0].next_state == "anomaly"
+    assert proposals[0].reason_code == "holdings_snapshot_missing"
+
+
+@pytest.mark.unit
+def test_fill_to_reconciled_when_holdings_match_expected():
+    proposals = classify_orders(
+        orders=[
+            LedgerOrderInput(
+                ledger_id=2,
+                symbol="005930",
+                side="buy",
+                ordered_qty=Decimal("10"),
+                lifecycle_state="fill",
+                holdings_baseline_qty=Decimal("5"),
+                accepted_at=_now(),
+            )
+        ],
+        holdings={"005930": _snap(Decimal("15"))},
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    assert proposals[0].next_state == "reconciled"
+    assert proposals[0].reason_code == "position_reconciled"
+
+
+@pytest.mark.unit
+def test_fill_to_anomaly_when_holdings_disagree():
+    proposals = classify_orders(
+        orders=[
+            LedgerOrderInput(
+                ledger_id=3,
+                symbol="005930",
+                side="buy",
+                ordered_qty=Decimal("10"),
+                lifecycle_state="fill",
+                holdings_baseline_qty=Decimal("5"),
+                accepted_at=_now(),
+            )
+        ],
+        holdings={"005930": _snap(Decimal("3"))},  # holdings dropped
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    assert proposals[0].next_state == "anomaly"
+    assert proposals[0].reason_code == "holdings_mismatch"
+
+
+@pytest.mark.unit
+def test_terminal_states_are_skipped():
+    """reconciled, failed, stale orders should not be re-classified."""
+    orders = [
+        LedgerOrderInput(
+            ledger_id=4,
+            symbol="005930",
+            side="buy",
+            ordered_qty=Decimal("10"),
+            lifecycle_state=state,
+            holdings_baseline_qty=Decimal("5"),
+            accepted_at=_now(),
+        )
+        for state in ("reconciled", "failed", "stale")
+    ]
+    proposals = classify_orders(
+        orders=orders,
+        holdings={"005930": _snap(Decimal("99"))},
+        thresholds=ReconcilerThresholds(),
+        now=_now(),
+    )
+    assert proposals == []
+
+
+@pytest.mark.unit
+def test_reconciler_does_not_import_db_or_broker():
+    """Reconciler must remain pure; no DB / broker imports."""
+    import app.services.kis_mock_holdings_reconciler as mod
+    src = open(mod.__file__).read()
+    forbidden = [
+        "from app.core.db",
+        "AsyncSession",
+        "KISClient",
+        "from app.services.brokers",
+        "import sqlalchemy",
+    ]
+    for tok in forbidden:
+        assert tok not in src, f"forbidden import in reconciler: {tok}"

--- a/tests/services/test_kis_mock_holdings_reconciler.py
+++ b/tests/services/test_kis_mock_holdings_reconciler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import pytest
@@ -10,14 +10,13 @@ import pytest
 from app.services.kis_mock_holdings_reconciler import (
     HoldingsSnapshot,
     LedgerOrderInput,
-    LifecycleTransitionProposal,
     ReconcilerThresholds,
     classify_orders,
 )
 
 
 def _now() -> datetime:
-    return datetime(2026, 5, 4, 9, 30, tzinfo=timezone.utc)
+    return datetime(2026, 5, 4, 9, 30, tzinfo=UTC)
 
 
 def _order(
@@ -204,6 +203,7 @@ def test_terminal_states_are_skipped():
 def test_reconciler_does_not_import_db_or_broker():
     """Reconciler must remain pure; no DB / broker imports."""
     import app.services.kis_mock_holdings_reconciler as mod
+
     src = open(mod.__file__).read()
     forbidden = [
         "from app.core.db",

--- a/tests/services/test_kis_mock_lifecycle_service.py
+++ b/tests/services/test_kis_mock_lifecycle_service.py
@@ -1,0 +1,183 @@
+"""Tests for KISMockLifecycleService (ROB-102)."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from decimal import Decimal
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import KISMockOrderLedger
+from app.services.kis_mock_lifecycle_service import (
+    KISMockLifecycleService,
+    LedgerNotFoundError,
+)
+
+SERVICE_PATH = (
+    Path(__file__).parents[2]
+    / "app/services/kis_mock_lifecycle_service.py"
+)
+
+
+@pytest_asyncio.fixture
+async def seeded_ledger_id(db_session: AsyncSession) -> int:
+    row = KISMockOrderLedger(
+        trade_date=datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc),
+        symbol="005930",
+        instrument_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        quantity=Decimal("10"),
+        price=Decimal("70000"),
+        amount=Decimal("700000"),
+        currency="KRW",
+        order_no="MOCK-1",
+        account_mode="kis_mock",
+        broker="kis",
+        status="accepted",
+        lifecycle_state="accepted",
+        holdings_baseline_qty=Decimal("0"),
+    )
+    db_session.add(row)
+    await db_session.commit()
+    return row.id
+
+
+@pytest.mark.asyncio
+async def test_apply_lifecycle_transition_dry_run_does_not_persist(
+    db_session: AsyncSession, seeded_ledger_id: int
+):
+    svc = KISMockLifecycleService(db_session)
+    summary = await svc.apply_lifecycle_transition(
+        ledger_id=seeded_ledger_id,
+        next_state="fill",
+        reason_code="fill_detected",
+        detail={"observed_holdings_qty": "10", "observed_delta": "10"},
+        dry_run=True,
+    )
+    assert summary["dry_run"] is True
+    assert summary["would_change"] is True
+    assert summary["next_state"] == "fill"
+
+    row = await db_session.get(KISMockOrderLedger, seeded_ledger_id)
+    assert row.lifecycle_state == "accepted"  # unchanged
+    assert row.reconcile_attempts == 0
+    assert row.last_reconcile_detail is None
+
+
+@pytest.mark.asyncio
+async def test_apply_lifecycle_transition_writes_when_not_dry_run(
+    db_session: AsyncSession, seeded_ledger_id: int
+):
+    svc = KISMockLifecycleService(db_session)
+    summary = await svc.apply_lifecycle_transition(
+        ledger_id=seeded_ledger_id,
+        next_state="fill",
+        reason_code="fill_detected",
+        detail={"observed_delta": "10"},
+        dry_run=False,
+    )
+    assert summary["applied"] is True
+
+    row = await db_session.get(KISMockOrderLedger, seeded_ledger_id)
+    assert row.lifecycle_state == "fill"
+    assert row.reconcile_attempts == 1
+    assert row.last_reconcile_detail == {
+        "reason_code": "fill_detected",
+        "observed_delta": "10",
+    }
+
+
+@pytest.mark.asyncio
+async def test_apply_lifecycle_transition_records_reconciled_at_only_for_terminal(
+    db_session: AsyncSession, seeded_ledger_id: int
+):
+    svc = KISMockLifecycleService(db_session)
+    await svc.apply_lifecycle_transition(
+        ledger_id=seeded_ledger_id,
+        next_state="reconciled",
+        reason_code="position_reconciled",
+        detail={},
+        dry_run=False,
+    )
+    row = await db_session.get(KISMockOrderLedger, seeded_ledger_id)
+    assert row.lifecycle_state == "reconciled"
+    assert row.reconciled_at is not None
+
+
+@pytest.mark.asyncio
+async def test_apply_lifecycle_transition_unknown_id_raises(
+    db_session: AsyncSession,
+):
+    svc = KISMockLifecycleService(db_session)
+    with pytest.raises(LedgerNotFoundError):
+        await svc.apply_lifecycle_transition(
+            ledger_id=9_999_999,
+            next_state="pending",
+            reason_code="pending_unconfirmed",
+            detail={},
+            dry_run=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_record_holdings_baseline(
+    db_session: AsyncSession, seeded_ledger_id: int
+):
+    svc = KISMockLifecycleService(db_session)
+    await svc.record_holdings_baseline(
+        ledger_id=seeded_ledger_id, baseline_qty=Decimal("3")
+    )
+    row = await db_session.get(KISMockOrderLedger, seeded_ledger_id)
+    assert row.holdings_baseline_qty == Decimal("3")
+
+
+@pytest.mark.asyncio
+async def test_list_open_orders_returns_only_inflight_and_fill(
+    db_session: AsyncSession, seeded_ledger_id: int
+):
+    # add a terminal row that should be excluded
+    terminal = KISMockOrderLedger(
+        trade_date=datetime(2026, 5, 3, tzinfo=timezone.utc),
+        symbol="000660",
+        instrument_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        quantity=Decimal("1"),
+        price=Decimal("100"),
+        amount=Decimal("100"),
+        currency="KRW",
+        order_no="MOCK-2",
+        account_mode="kis_mock",
+        broker="kis",
+        status="accepted",
+        lifecycle_state="reconciled",
+    )
+    db_session.add(terminal)
+    await db_session.commit()
+
+    svc = KISMockLifecycleService(db_session)
+    rows = await svc.list_open_orders(limit=50)
+    ids = {r.id for r in rows}
+    assert seeded_ledger_id in ids
+    assert terminal.id not in ids
+
+
+def test_service_does_not_call_broker_or_live_paths():
+    """Service must remain record-keeping only. No broker / live imports."""
+    src = SERVICE_PATH.read_text()
+    forbidden = [
+        "KISClient",
+        "from app.services.brokers",
+        "from app.services.order_execution",
+        "from app.services.trade_journal",
+        "from app.services.fill_notification",
+        "from app.tasks.kis",
+    ]
+    for tok in forbidden:
+        assert tok not in src, f"forbidden import: {tok}"

--- a/tests/services/test_kis_mock_lifecycle_service.py
+++ b/tests/services/test_kis_mock_lifecycle_service.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-import ast
-from pathlib import Path
+from datetime import UTC, datetime
 from decimal import Decimal
-from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.review import KISMockOrderLedger
@@ -18,16 +16,13 @@ from app.services.kis_mock_lifecycle_service import (
     LedgerNotFoundError,
 )
 
-SERVICE_PATH = (
-    Path(__file__).parents[2]
-    / "app/services/kis_mock_lifecycle_service.py"
-)
+SERVICE_PATH = Path(__file__).parents[2] / "app/services/kis_mock_lifecycle_service.py"
 
 
 @pytest_asyncio.fixture
 async def seeded_ledger_id(db_session: AsyncSession) -> int:
     row = KISMockOrderLedger(
-        trade_date=datetime(2026, 5, 4, 9, 0, tzinfo=timezone.utc),
+        trade_date=datetime(2026, 5, 4, 9, 0, tzinfo=UTC),
         symbol="005930",
         instrument_type="equity_kr",
         side="buy",
@@ -143,7 +138,7 @@ async def test_list_open_orders_returns_only_inflight_and_fill(
 ):
     # add a terminal row that should be excluded
     terminal = KISMockOrderLedger(
-        trade_date=datetime(2026, 5, 3, tzinfo=timezone.utc),
+        trade_date=datetime(2026, 5, 3, tzinfo=UTC),
         symbol="000660",
         instrument_type="equity_kr",
         side="buy",

--- a/tests/services/test_kis_mock_lifecycle_service.py
+++ b/tests/services/test_kis_mock_lifecycle_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 import pytest_asyncio
@@ -31,7 +32,7 @@ async def seeded_ledger_id(db_session: AsyncSession) -> int:
         price=Decimal("70000"),
         amount=Decimal("700000"),
         currency="KRW",
-        order_no="MOCK-1",
+        order_no=f"MOCK-{uuid4()}",
         account_mode="kis_mock",
         broker="kis",
         status="accepted",
@@ -147,7 +148,7 @@ async def test_list_open_orders_returns_only_inflight_and_fill(
         price=Decimal("100"),
         amount=Decimal("100"),
         currency="KRW",
-        order_no="MOCK-2",
+        order_no=f"MOCK-{uuid4()}",
         account_mode="kis_mock",
         broker="kis",
         status="accepted",

--- a/tests/test_kis_mock_lifecycle_reconciliation_acceptance.py
+++ b/tests/test_kis_mock_lifecycle_reconciliation_acceptance.py
@@ -1,0 +1,98 @@
+"""Acceptance tests for KIS mock lifecycle reconciliation (ROB-102)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests._mcp_tooling_support import build_tools
+
+
+@pytest.mark.asyncio
+async def test_full_reconciliation_cycle_acceptance(monkeypatch):
+    """Verifies that place_order (kis_mock) -> reconciler detect fill -> MCP tool run."""
+    from app.mcp_server.tooling import kis_mock_ledger, order_execution
+    
+    # 1. Setup mocks
+    monkeypatch.setattr(
+        "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
+        lambda: [],
+    )
+    
+    # Mock broker execution
+    monkeypatch.setattr(
+        order_execution,
+        "_execute_order",
+        AsyncMock(return_value={"rt_cd": "0", "odno": "ACC-1", "ord_tmd": "090000"}),
+    )
+    monkeypatch.setattr(
+        order_execution, "_fetch_current_price", AsyncMock(return_value=100.0)
+    )
+    monkeypatch.setattr(
+        order_execution, "_check_balance_and_warn", AsyncMock(return_value=(None, None))
+    )
+    monkeypatch.setattr(
+        order_execution, "_check_daily_order_limit", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(order_execution, "_record_order_history", AsyncMock())
+
+    # Mock DB insert to return a real-looking ID
+    save_ledger_mock = AsyncMock(return_value=555)
+    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save_ledger_mock)
+
+    # Mock Job's dependencies to avoid real DB/Broker
+    mock_ledger_row = AsyncMock()
+    mock_ledger_row.id = 555
+    mock_ledger_row.symbol = "005930"
+    mock_ledger_row.side = "buy"
+    mock_ledger_row.quantity = 10
+    mock_ledger_row.lifecycle_state = "accepted"
+    mock_ledger_row.holdings_baseline_qty = Decimal("0")
+    mock_ledger_row.trade_date = AsyncMock()
+
+    mock_lifecycle_svc = AsyncMock()
+    mock_lifecycle_svc.list_open_orders.return_value = [mock_ledger_row]
+    mock_lifecycle_svc.apply_lifecycle_transition.return_value = {
+        "applied": True, "next_state": "fill"
+    }
+    
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
+        lambda _: mock_lifecycle_svc,
+    )
+    
+    mock_kis = AsyncMock()
+    mock_kis.fetch_my_stocks.return_value = [{"symbol": "005930", "qty": "10"}]
+    monkeypatch.setattr("app.jobs.kis_mock_reconciliation_job.kis", mock_kis)
+
+    # 2. Execution
+    tools = build_tools()
+    
+    # Step A: Place order
+    place_res = await tools["place_order"](
+        symbol="005930",
+        side="buy",
+        quantity=10,
+        price=100.0,
+        account_mode="kis_mock",
+        dry_run=False
+    )
+    assert place_res["success"] is True
+    assert place_res["ledger_id"] == 555
+    # Verify Task 3: lifecycle_state was passed as 'accepted'
+    save_ledger_mock.assert_awaited_once()
+    assert save_ledger_mock.call_args.kwargs["lifecycle_state"] == "accepted"
+
+    # Step B: Run reconciliation tool
+    recon_res = await tools["kis_mock_reconciliation_run"](dry_run=False)
+    assert recon_res["orders_processed"] == 1
+    assert recon_res["transitions_applied"] == 1
+    
+    # 3. Verify final state transition call
+    mock_lifecycle_svc.apply_lifecycle_transition.assert_awaited_once()
+    args = mock_lifecycle_svc.apply_lifecycle_transition.call_args.kwargs
+    assert args["ledger_id"] == 555
+    assert args["next_state"] == "fill"
+    assert args["reason_code"] == "fill_detected"

--- a/tests/test_kis_mock_lifecycle_reconciliation_acceptance.py
+++ b/tests/test_kis_mock_lifecycle_reconciliation_acceptance.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -12,16 +13,15 @@ from tests._mcp_tooling_support import build_tools
 
 @pytest.mark.asyncio
 async def test_full_reconciliation_cycle_acceptance(monkeypatch):
-    """Verifies that place_order (kis_mock) -> reconciler detect fill -> MCP tool run."""
+    """place_order (kis_mock) captures baseline → reconciler detects fill via MCP tool."""
     from app.mcp_server.tooling import kis_mock_ledger, order_execution
-    
-    # 1. Setup mocks
+
     monkeypatch.setattr(
         "app.mcp_server.tooling.orders_registration.validate_kis_mock_config",
         lambda: [],
     )
-    
-    # Mock broker execution
+
+    # Broker / pre-execute path stubs.
     monkeypatch.setattr(
         order_execution,
         "_execute_order",
@@ -31,68 +31,103 @@ async def test_full_reconciliation_cycle_acceptance(monkeypatch):
         order_execution, "_fetch_current_price", AsyncMock(return_value=100.0)
     )
     monkeypatch.setattr(
-        order_execution, "_check_balance_and_warn", AsyncMock(return_value=(None, None))
+        order_execution,
+        "_check_balance_and_warn",
+        AsyncMock(return_value=(None, None)),
     )
     monkeypatch.setattr(
         order_execution, "_check_daily_order_limit", AsyncMock(return_value=True)
     )
     monkeypatch.setattr(order_execution, "_record_order_history", AsyncMock())
 
-    # Mock DB insert to return a real-looking ID
-    save_ledger_mock = AsyncMock(return_value=555)
-    monkeypatch.setattr(kis_mock_ledger, "_save_kis_mock_order_ledger", save_ledger_mock)
+    # ROB-102: pre-order baseline lookup → simulate "no prior position".
+    monkeypatch.setattr(
+        kis_mock_ledger,
+        "_fetch_kis_mock_baseline_qty",
+        AsyncMock(return_value=Decimal("0")),
+    )
 
-    # Mock Job's dependencies to avoid real DB/Broker
-    mock_ledger_row = AsyncMock()
+    # Capture the ledger insert and assert lifecycle_state + baseline propagate.
+    save_ledger_mock = AsyncMock(return_value=555)
+    monkeypatch.setattr(
+        kis_mock_ledger, "_save_kis_mock_order_ledger", save_ledger_mock
+    )
+
+    # Reconciliation: stub the lifecycle service + KIS client (mock holdings).
+    mock_ledger_row = MagicMock()
     mock_ledger_row.id = 555
     mock_ledger_row.symbol = "005930"
     mock_ledger_row.side = "buy"
-    mock_ledger_row.quantity = 10
+    mock_ledger_row.quantity = Decimal("10")
     mock_ledger_row.lifecycle_state = "accepted"
     mock_ledger_row.holdings_baseline_qty = Decimal("0")
-    mock_ledger_row.trade_date = AsyncMock()
+    mock_ledger_row.trade_date = datetime.now(UTC) - timedelta(seconds=10)
 
     mock_lifecycle_svc = AsyncMock()
     mock_lifecycle_svc.list_open_orders.return_value = [mock_ledger_row]
     mock_lifecycle_svc.apply_lifecycle_transition.return_value = {
-        "applied": True, "next_state": "fill"
+        "applied": True,
+        "next_state": "fill",
     }
-    
     monkeypatch.setattr(
         "app.jobs.kis_mock_reconciliation_job.KISMockLifecycleService",
         lambda _: mock_lifecycle_svc,
     )
-    
-    mock_kis = AsyncMock()
-    mock_kis.fetch_my_stocks.return_value = [{"symbol": "005930", "qty": "10"}]
-    monkeypatch.setattr("app.jobs.kis_mock_reconciliation_job.kis", mock_kis)
 
-    # 2. Execution
+    fake_kis = MagicMock()
+    fake_kis.fetch_my_stocks = AsyncMock(
+        side_effect=[
+            [{"pdno": "005930", "hldg_qty": "10"}],  # KR mock holdings post-fill
+            [],  # US mock holdings
+        ]
+    )
+    monkeypatch.setattr(
+        "app.jobs.kis_mock_reconciliation_job.KISClient",
+        lambda *a, **kw: fake_kis,
+    )
+
+    # Use AsyncSessionLocal from production path; reconciler tool only opens a
+    # session and passes it to the job, which we've fully mocked above.
+    fake_session_cm = MagicMock()
+    fake_session_cm.__aenter__ = AsyncMock(return_value=AsyncMock())
+    fake_session_cm.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(
+        kis_mock_ledger,
+        "_order_session_factory",
+        lambda: lambda: fake_session_cm,
+    )
+
     tools = build_tools()
-    
-    # Step A: Place order
+
+    # Step A: place_order writes ledger row with baseline + lifecycle_state.
     place_res = await tools["place_order"](
         symbol="005930",
         side="buy",
         quantity=10,
         price=100.0,
         account_mode="kis_mock",
-        dry_run=False
+        dry_run=False,
     )
     assert place_res["success"] is True
     assert place_res["ledger_id"] == 555
-    # Verify Task 3: lifecycle_state was passed as 'accepted'
     save_ledger_mock.assert_awaited_once()
-    assert save_ledger_mock.call_args.kwargs["lifecycle_state"] == "accepted"
+    save_kwargs = save_ledger_mock.call_args.kwargs
+    assert save_kwargs["lifecycle_state"] == "accepted"
+    assert save_kwargs["holdings_baseline_qty"] == Decimal("0")
 
-    # Step B: Run reconciliation tool
-    recon_res = await tools["kis_mock_reconciliation_run"](dry_run=False)
+    # Step B: dry_run=False without confirm is rejected.
+    rejected = await tools["kis_mock_reconciliation_run"](dry_run=False, confirm=False)
+    assert rejected["success"] is False
+    assert "confirm" in rejected["error"].lower()
+
+    # Step C: dry_run=False, confirm=True applies the fill transition.
+    recon_res = await tools["kis_mock_reconciliation_run"](dry_run=False, confirm=True)
     assert recon_res["orders_processed"] == 1
     assert recon_res["transitions_applied"] == 1
-    
-    # 3. Verify final state transition call
-    mock_lifecycle_svc.apply_lifecycle_transition.assert_awaited_once()
+    assert recon_res["account_mode"] == "kis_mock"
+
     args = mock_lifecycle_svc.apply_lifecycle_transition.call_args.kwargs
     assert args["ledger_id"] == 555
     assert args["next_state"] == "fill"
     assert args["reason_code"] == "fill_detected"
+    assert args["dry_run"] is False

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -546,3 +546,76 @@ async def test_kis_live_path_unchanged_calls_save_order_fill(monkeypatch):
     assert result["success"] is True, result
     save_fill.assert_awaited_once()
     save_ledger.assert_not_awaited()
+
+# ---------------------------------------------------------------------------
+# ROB-102: lifecycle mapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_status_to_lifecycle_state_mapping():
+    """ROB-102: existing 3-value `status` maps to ROB-100 lifecycle states."""
+    from app.mcp_server.tooling.kis_mock_ledger import _status_to_lifecycle_state
+
+    assert _status_to_lifecycle_state("accepted") == "accepted"
+    assert _status_to_lifecycle_state("rejected") == "failed"
+    assert _status_to_lifecycle_state("unknown") == "anomaly"
+    assert _status_to_lifecycle_state(None) == "anomaly"
+    assert _status_to_lifecycle_state("garbage") == "anomaly"
+
+
+@pytest.mark.asyncio
+async def test_save_helper_persists_lifecycle_state(monkeypatch):
+    from app.mcp_server.tooling import kis_mock_ledger
+
+    captured: dict = {}
+
+    class FakeResult:
+        inserted_primary_key = (321,)
+
+    class FakeDB:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            pass
+
+        async def execute(self, stmt):
+            captured["stmt"] = stmt
+            return FakeResult()
+
+        async def commit(self):
+            captured["committed"] = True
+
+    monkeypatch.setattr(
+        kis_mock_ledger, "_order_session_factory", lambda: lambda: FakeDB()
+    )
+
+    new_id = await kis_mock_ledger._save_kis_mock_order_ledger(
+        symbol="005930",
+        instrument_type="equity_kr",
+        side="buy",
+        order_type="limit",
+        quantity=10,
+        price=1000,
+        amount=10000,
+        currency="KRW",
+        order_no="MOCK-1",
+        order_time=None,
+        krx_fwdg_ord_orgno=None,
+        status="accepted",
+        response_code="0",
+        response_message=None,
+        raw_response={"rt_cd": "0"},
+        reason=None,
+        thesis=None,
+        strategy=None,
+        notes=None,
+        lifecycle_state="accepted",
+    )
+    assert new_id == 321
+    # Verify that lifecycle_state is in the insert values
+    params = captured["stmt"].compile().params
+    assert params["lifecycle_state"] == "accepted"
+    
+

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -66,8 +66,7 @@ def test_model_columns_and_constraints():
     assert any("kis_mock_ledger_broker_kis" in (n or "") for n in constraint_names)
     assert any("kis_mock_ledger_status_allowed" in (n or "") for n in constraint_names)
     assert any(
-        "kis_mock_ledger_lifecycle_state_allowed" in (n or "")
-        for n in constraint_names
+        "kis_mock_ledger_lifecycle_state_allowed" in (n or "") for n in constraint_names
     )
 
 
@@ -547,6 +546,7 @@ async def test_kis_live_path_unchanged_calls_save_order_fill(monkeypatch):
     save_fill.assert_awaited_once()
     save_ledger.assert_not_awaited()
 
+
 # ---------------------------------------------------------------------------
 # ROB-102: lifecycle mapping
 # ---------------------------------------------------------------------------
@@ -617,5 +617,3 @@ async def test_save_helper_persists_lifecycle_state(monkeypatch):
     # Verify that lifecycle_state is in the insert values
     params = captured["stmt"].compile().params
     assert params["lifecycle_state"] == "accepted"
-    
-

--- a/tests/test_kis_mock_order_ledger.py
+++ b/tests/test_kis_mock_order_ledger.py
@@ -49,6 +49,12 @@ def test_model_columns_and_constraints():
         "strategy",
         "notes",
         "created_at",
+        # ROB-102 additive columns
+        "lifecycle_state",
+        "holdings_baseline_qty",
+        "reconcile_attempts",
+        "reconciled_at",
+        "last_reconcile_detail",
     } <= cols
     assert KISMockOrderLedger.__table__.schema == "review"
     # Naming convention: ck_%(table_name)s_%(constraint_name)s
@@ -59,6 +65,10 @@ def test_model_columns_and_constraints():
     )
     assert any("kis_mock_ledger_broker_kis" in (n or "") for n in constraint_names)
     assert any("kis_mock_ledger_status_allowed" in (n or "") for n in constraint_names)
+    assert any(
+        "kis_mock_ledger_lifecycle_state_allowed" in (n or "")
+        for n in constraint_names
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes [ROB-102](https://linear.app/mgh3326/issue/ROB-102/kis-mock-order-lifecycle-ledger-and-holdings-based-reconciliation).

Adds lifecycle tracking and a holdings-delta reconciliation worker for KIS official-mock orders, since the KIS mock domestic pending-orders endpoint is unsupported and cash/orderable APIs do not reliably indicate fills.

- **Migration** (`d4f1c5a3e2b1`): adds `lifecycle_state`, `holdings_baseline_qty`, `reconcile_attempts`, `reconciled_at`, `last_reconcile_detail` to `review.kis_mock_order_ledger`. Backfills `lifecycle_state` from the legacy `status` (accepted → accepted, rejected → failed, else → anomaly).
- **Pure reconciler** (`app/services/kis_mock_holdings_reconciler.py`): frozen-dataclass classifier — no DB / broker imports — that maps `(holdings_baseline, current_holdings, accepted_at)` → ROB-100 lifecycle states with fine-grained `reason_code` (fill/partial fill/pending/stale/baseline-missing/snapshot-missing/holdings-mismatch/position-reconciled).
- **Lifecycle service** (`app/services/kis_mock_lifecycle_service.py`): only sanctioned write path. Atomic `apply_lifecycle_transition` with dry-run support; stamps `reconciled_at` only on terminal states.
- **Reconciliation job** (`app/jobs/kis_mock_reconciliation_job.py`): composes mock holdings (`fetch_my_stocks(is_mock=True)`, KR + US) + reconciler + service. Emits ROB-100 `OrderLifecycleEvent` records in the summary. Injectable `kis_client` for tests.
- **Insert path** (`app/mcp_server/tooling/order_execution.py`, `kis_mock_ledger.py`): captures pre-order mock holdings as `holdings_baseline_qty` so the reconciler has a real delta reference. Best-effort; failure leaves it NULL and surfaces as `baseline_missing → anomaly`.
- **MCP tool** `kis_mock_reconciliation_run`: dry-run by default; applying transitions requires both `dry_run=False` and `confirm=True`.
- **Runbook**: `docs/runbooks/kis-mock-reconciliation.md`.

## Lifecycle vocabulary

Public column values follow ROB-100 (`planned, previewed, submitted, accepted, pending, fill, reconciled, stale, failed, anomaly`). Fine-grained meaning lives in `last_reconcile_detail.reason_code`. `anomaly` is an operator hand-off, not terminal success/failure.

## Safety boundaries

- No broker submit/cancel/modify calls.
- No KIS live-account access — `is_mock=True` everywhere.
- Direct SQL writes against `review.kis_mock_order_ledger` are forbidden; use `KISMockLifecycleService`.
- No scheduler/launchd hooks added — invoke manually.

## Test plan

- [x] `make lint` clean
- [x] `make typecheck` clean
- [x] `tests/test_kis_mock_order_ledger.py` (9 tests) — model shape, helper insert, lifecycle_state mapping, backward compat
- [x] `tests/services/test_kis_mock_holdings_reconciler.py` (11 tests) — pure-decision matrix, terminal-state skip, no-DB/broker import guard
- [x] `tests/jobs/test_kis_mock_reconciliation_job.py` (4 tests) — KR + US holdings, lifecycle event emission, no-open-orders no-op
- [x] `tests/mcp_server/test_kis_mock_reconciliation_tool.py` (3 tests) — dry-run default, confirm gate, apply-with-confirm
- [x] `tests/test_kis_mock_lifecycle_reconciliation_acceptance.py` — end-to-end: place_order writes baseline + lifecycle_state → reconciler detects fill via mock holdings (rejects without confirm, applies with confirm)
- [ ] `tests/services/test_kis_mock_lifecycle_service.py` — runs in CI (requires the postgres test fixture)

## Migration

```bash
uv run alembic upgrade head
```

Backfills `lifecycle_state` for any pre-existing rows; existing ledger rows remain readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)