### PR TITLE
fix: scope Alpaca Paper preflight checks

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -137,7 +137,12 @@ names only:
 `alpaca_paper_execution_preflight_check` is a read-only runner gate for the
 later automated paper cycle. It reads recent ledger rows and accepts optional
 caller-supplied read-only `open_orders`, `positions`, and `approval_packet`
-snapshots, then returns severity-classified anomalies plus `should_block`. ROB-93
+snapshots, then returns severity-classified anomalies plus `should_block`. Scoped
+callers may pass `lifecycle_correlation_id`, `client_order_id`, `candidate_uuid`,
+`briefing_artifact_run_uuid`, or an `approval_packet` containing those keys; the
+tool then reads only matching ledger rows and returns `scoped_by` so decision
+sessions do not get blocked by unrelated recent ETH/SOL/BTC rows. Calls without
+scope keep the broad recent-ledger safety behavior for global runners. ROB-93
 checks include unexpected open orders, residual positions, duplicate
 `client_order_id`, filled buys without linked sells, filled sells without a zero
 final position snapshot, ledger/order/fill mismatches, stale previews/approval

--- a/app/mcp_server/tooling/alpaca_paper_ledger_read.py
+++ b/app/mcp_server/tooling/alpaca_paper_ledger_read.py
@@ -27,6 +27,17 @@ def _session_factory() -> async_sessionmaker[AsyncSession]:
     return cast(async_sessionmaker[AsyncSession], cast(object, AsyncSessionLocal))
 
 
+def _clean_scope_value(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _packet_scope_value(packet: dict[str, Any] | None, key: str) -> str | None:
+    if not isinstance(packet, dict):
+        return None
+    return _clean_scope_value(packet.get(key))
+
+
 def _row_to_dict(row: Any) -> dict[str, Any]:
     if row is None:
         return {}
@@ -116,13 +127,25 @@ async def alpaca_paper_execution_preflight_check(
     expected_signal_symbol: str | None = None,
     expected_execution_symbol: str | None = None,
     stale_after_minutes: int = 30,
+    lifecycle_correlation_id: str | None = None,
+    client_order_id: str | None = None,
+    candidate_uuid: str | None = None,
+    briefing_artifact_run_uuid: str | None = None,
+    session_uuid: str | None = None,
 ) -> dict[str, Any]:
     """Run read-only Alpaca Paper execution anomaly checks.
 
-    The tool reads recent ledger rows and combines them with optional caller-
-    supplied read-only broker snapshots. It never submits, cancels, repairs, or
-    writes data. The returned ``should_block`` field is intended for runner
-    preflight gates.
+    The tool reads recent or scope-specific ledger rows and combines them with
+    optional caller-supplied read-only broker snapshots. It never submits,
+    cancels, repairs, or writes data. The returned ``should_block`` field is
+    intended for runner preflight gates.
+
+    When a correlation/candidate/client/briefing scope is provided directly or
+    via approval_packet, stale and symbol-context checks evaluate only rows in
+    that scope. Calls without scope preserve the global recent-ledger safety
+    behavior used by broad cycle runners. ``session_uuid`` is surfaced as a
+    response scope marker for decision-session callers; ledger scoping still
+    uses correlation/provenance keys because the Alpaca ledger has no session FK.
     """
     if limit < 1:
         raise ValueError("limit must be >= 1")
@@ -130,9 +153,47 @@ async def alpaca_paper_execution_preflight_check(
     if stale_after_minutes < 1:
         raise ValueError("stale_after_minutes must be >= 1")
 
+    scope = {
+        "lifecycle_correlation_id": _clean_scope_value(lifecycle_correlation_id)
+        or _packet_scope_value(approval_packet, "lifecycle_correlation_id"),
+        "client_order_id": _clean_scope_value(client_order_id)
+        or _packet_scope_value(approval_packet, "client_order_id"),
+        "candidate_uuid": _clean_scope_value(candidate_uuid)
+        or _packet_scope_value(approval_packet, "candidate_uuid"),
+        "briefing_artifact_run_uuid": _clean_scope_value(briefing_artifact_run_uuid)
+        or _packet_scope_value(approval_packet, "briefing_artifact_run_uuid")
+        or _packet_scope_value(approval_packet, "artifact_id"),
+        "session_uuid": _clean_scope_value(session_uuid)
+        or _packet_scope_value(approval_packet, "session_uuid")
+        or _packet_scope_value(approval_packet, "decision_session_uuid"),
+    }
+    scoped_by: dict[str, str] | None = None
+
     async with _session_factory()() as db:
         svc = AlpacaPaperLedgerService(db)
-        rows = await svc.list_recent(limit=limit)
+        if scope["lifecycle_correlation_id"]:
+            scoped_by = {
+                "kind": "lifecycle_correlation_id",
+                "value": scope["lifecycle_correlation_id"],
+            }
+            rows = await svc.list_by_correlation_id(scope["lifecycle_correlation_id"])
+        elif scope["client_order_id"]:
+            scoped_by = {"kind": "client_order_id", "value": scope["client_order_id"]}
+            row = await svc.get_by_client_order_id(scope["client_order_id"])
+            rows = [row] if row is not None else []
+        elif scope["candidate_uuid"]:
+            scoped_by = {"kind": "candidate_uuid", "value": scope["candidate_uuid"]}
+            rows = await svc.list_by_candidate_uuid(uuid.UUID(scope["candidate_uuid"]))
+        elif scope["briefing_artifact_run_uuid"]:
+            scoped_by = {
+                "kind": "briefing_artifact_run_uuid",
+                "value": scope["briefing_artifact_run_uuid"],
+            }
+            rows = await svc.list_by_briefing_artifact_run_uuid(
+                uuid.UUID(scope["briefing_artifact_run_uuid"])
+            )
+        else:
+            rows = await svc.list_recent(limit=limit)
 
     report = build_paper_execution_preflight_report(
         ledger_rows=rows,
@@ -151,6 +212,8 @@ async def alpaca_paper_execution_preflight_check(
             "source": "alpaca_paper_execution_preflight",
             "read_only": True,
             "limit": limit,
+            "scoped_by": scoped_by,
+            "session_uuid": scope["session_uuid"],
         }
     )
     return data
@@ -280,6 +343,8 @@ def register_alpaca_paper_ledger_read_tools(mcp: FastMCP) -> None:
         description=(
             "Read-only Alpaca Paper execution anomaly preflight. Returns "
             "severity-classified findings and should_block for cycle runners. "
+            "Supports direct or approval_packet-derived correlation/client/"
+            "candidate/briefing/session scope to avoid unrelated ledger rows. "
             "No broker mutation and no repair writes."
         ),
     )(alpaca_paper_execution_preflight_check)

--- a/app/services/alpaca_paper_anomaly_checks.py
+++ b/app/services/alpaca_paper_anomaly_checks.py
@@ -150,6 +150,75 @@ def _source_client_order_ids(row: Any) -> set[str]:
     return ids
 
 
+def _packet_value(packet: Any, key: str) -> Any:
+    if isinstance(packet, dict):
+        return packet.get(key)
+    return getattr(packet, key, None)
+
+
+def _scope_value(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _preflight_scope_from_packet(packet: Any) -> dict[str, str]:
+    """Extract stable per-order/session scope keys from an approval packet.
+
+    ``lifecycle_correlation_id`` is the preferred ledger scope. Candidate and
+    briefing UUIDs cover preopen/decision-session provenance, and
+    ``client_order_id`` keeps duplicate/idempotency checks tied to the packet.
+    """
+    scope: dict[str, str] = {}
+    for key in (
+        "lifecycle_correlation_id",
+        "candidate_uuid",
+        "briefing_artifact_run_uuid",
+        "artifact_id",
+    ):
+        value = _scope_value(_packet_value(packet, key))
+        if value:
+            scope[key] = value
+
+    # A packet's new client_order_id alone is not enough to narrow historical
+    # ledger checks; otherwise a broad preflight with a candidate packet would
+    # accidentally skip unrelated open round-trip anomalies. Once a stable
+    # correlation/session/provenance key exists, include the client ID as an
+    # additional match key for mixed old/new ledger rows.
+    client_order_id = _scope_value(_packet_value(packet, "client_order_id"))
+    if scope and client_order_id:
+        scope["client_order_id"] = client_order_id
+    return scope
+
+
+def _row_matches_preflight_scope(row: Any, scope: dict[str, str]) -> bool:
+    """Return whether a ledger row belongs to the selected packet scope.
+
+    The matching is intentionally OR-based across stable provenance keys because
+    older rows may have only client_order_id/correlation while newer rows may
+    carry candidate or briefing UUID provenance.
+    """
+    if not scope:
+        return True
+
+    checks = {
+        "lifecycle_correlation_id": _scope_value(_get(row, "lifecycle_correlation_id")),
+        "client_order_id": _scope_value(_get(row, "client_order_id")),
+        "candidate_uuid": _scope_value(_get(row, "candidate_uuid")),
+        "briefing_artifact_run_uuid": _scope_value(
+            _get(row, "briefing_artifact_run_uuid")
+        ),
+    }
+    # The packet artifact_id is commonly the same value as
+    # briefing_artifact_run_uuid for preopen approval packets.
+    if (
+        scope.get("artifact_id")
+        and checks.get("briefing_artifact_run_uuid") == scope["artifact_id"]
+    ):
+        return True
+
+    return any(checks.get(key) == value for key, value in scope.items())
+
+
 def _is_open_order(order: dict[str, Any]) -> bool:
     status = str(order.get("status") or "").lower()
     if not status:
@@ -230,10 +299,16 @@ def build_paper_execution_preflight_report(
         stale_after_minutes: Preview/approval max age before blocking.
     """
     checked_at = _as_aware_utc(now) or datetime.now(UTC)
-    ledger = list(ledger_rows)
+    unscoped_ledger = list(ledger_rows)
     orders = list(open_orders)
     position_rows = list(positions)
     packet = approval_packet or {}
+    preflight_scope = _preflight_scope_from_packet(packet)
+    ledger = [
+        row
+        for row in unscoped_ledger
+        if _row_matches_preflight_scope(row, preflight_scope)
+    ]
     anomalies: list[PaperExecutionAnomaly] = []
 
     def add(
@@ -474,6 +549,7 @@ def build_paper_execution_preflight_report(
         anomalies=tuple(anomalies),
         counts={
             "ledger_rows": len(ledger),
+            "unscoped_ledger_rows": len(unscoped_ledger),
             "open_orders": len(orders),
             "positions": len(position_rows),
             "block": sum(

--- a/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
+++ b/tests/mcp_server/test_alpaca_paper_ledger_read_tools.py
@@ -51,7 +51,9 @@ def _fake_row(**kwargs):
     return ns
 
 
-def _mock_svc(*, row=None, rows=None, corr_rows=None):
+def _mock_svc(
+    *, row=None, rows=None, corr_rows=None, candidate_rows=None, briefing_rows=None
+):
     svc = AsyncMock()
     svc.get_by_client_order_id = AsyncMock(return_value=row)
     svc.list_recent = AsyncMock(
@@ -59,6 +61,12 @@ def _mock_svc(*, row=None, rows=None, corr_rows=None):
     )
     svc.list_by_correlation_id = AsyncMock(
         return_value=corr_rows if corr_rows is not None else []
+    )
+    svc.list_by_candidate_uuid = AsyncMock(
+        return_value=candidate_rows if candidate_rows is not None else []
+    )
+    svc.list_by_briefing_artifact_run_uuid = AsyncMock(
+        return_value=briefing_rows if briefing_rows is not None else []
     )
     return svc
 
@@ -223,6 +231,42 @@ async def test_execution_preflight_check_returns_blocking_report(monkeypatch):
     assert result["should_block"] is True
     assert result["anomalies"][0]["check_id"] == "unexpected_open_orders"
     mock_svc.list_recent.assert_awaited_once_with(limit=20)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_execution_preflight_check_uses_approval_packet_correlation_scope(
+    monkeypatch,
+):
+    import app.mcp_server.tooling.alpaca_paper_ledger_read as mod
+
+    row = _fake_row(
+        client_order_id="btc-preview",
+        lifecycle_correlation_id="corr-btc",
+        lifecycle_state="previewed",
+    )
+    mock_svc = _mock_svc(corr_rows=[row])
+    _patch_ledger_service(monkeypatch, mod, mock_svc)
+
+    result = await mod.alpaca_paper_execution_preflight_check(
+        approval_packet={
+            "client_order_id": "btc-submit",
+            "lifecycle_correlation_id": "corr-btc",
+            "signal_symbol": "KRW-BTC",
+            "execution_symbol": "BTC/USD",
+            "session_uuid": "0b3bbeb4-c0fc-4316-beed-3a871e17f7da",
+        },
+        expected_signal_symbol="KRW-BTC",
+        expected_execution_symbol="BTC/USD",
+    )
+
+    assert result["scoped_by"] == {
+        "kind": "lifecycle_correlation_id",
+        "value": "corr-btc",
+    }
+    assert result["session_uuid"] == "0b3bbeb4-c0fc-4316-beed-3a871e17f7da"
+    mock_svc.list_by_correlation_id.assert_awaited_once_with("corr-btc")
+    mock_svc.list_recent.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_alpaca_paper_anomaly_checks.py
+++ b/tests/services/test_alpaca_paper_anomaly_checks.py
@@ -16,6 +16,7 @@ from app.services.alpaca_paper_anomaly_checks import (
 def _row(**kwargs):
     defaults = {
         "client_order_id": "rob93-buy-001",
+        "lifecycle_correlation_id": "corr-btc",
         "side": "buy",
         "lifecycle_state": "filled",
         "order_status": "filled",
@@ -252,3 +253,98 @@ def test_report_to_dict_is_operator_readable():
     assert data["should_block"] is True
     assert data["counts"]["block"] == 1
     assert data["anomalies"][0]["check_id"] == "unexpected_open_orders"
+
+
+@pytest.mark.unit
+def test_scoped_preflight_ignores_unrelated_stale_and_symbol_rows():
+    now = datetime(2026, 5, 3, 12, 0, tzinfo=UTC)
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(
+                client_order_id="eth-preview-old",
+                lifecycle_correlation_id="corr-eth",
+                lifecycle_state="previewed",
+                order_status=None,
+                execution_symbol="ETHUSD",
+                signal_symbol="KRW-ETH",
+                filled_qty=None,
+                created_at=now - timedelta(minutes=90),
+            ),
+            _row(
+                client_order_id="btc-preview-fresh",
+                lifecycle_correlation_id="corr-btc",
+                lifecycle_state="previewed",
+                order_status=None,
+                execution_symbol="BTCUSD",
+                signal_symbol="KRW-BTC",
+                filled_qty=None,
+                created_at=now - timedelta(minutes=5),
+            ),
+        ],
+        approval_packet={
+            "client_order_id": "btc-submit",
+            "lifecycle_correlation_id": "corr-btc",
+            "signal_symbol": "KRW-BTC",
+            "execution_symbol": "BTC/USD",
+        },
+        now=now,
+        stale_after_minutes=30,
+    )
+
+    assert report.status == "pass"
+    assert report.should_block is False
+    assert _check_ids(report) == {"preflight_clean"}
+    assert report.counts["ledger_rows"] == 1
+    assert report.counts["unscoped_ledger_rows"] == 2
+
+
+@pytest.mark.unit
+def test_scoped_preflight_still_blocks_stale_row_inside_same_correlation():
+    now = datetime(2026, 5, 3, 12, 0, tzinfo=UTC)
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(
+                client_order_id="btc-preview-old",
+                lifecycle_correlation_id="corr-btc",
+                lifecycle_state="previewed",
+                order_status=None,
+                filled_qty=None,
+                created_at=now - timedelta(minutes=90),
+            )
+        ],
+        approval_packet={
+            "client_order_id": "btc-submit",
+            "lifecycle_correlation_id": "corr-btc",
+        },
+        now=now,
+        stale_after_minutes=30,
+    )
+
+    assert report.should_block is True
+    assert "stale_preview_or_approval_packet" in _check_ids(report)
+
+
+@pytest.mark.unit
+def test_scoped_preflight_still_blocks_symbol_mismatch_inside_same_correlation():
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(
+                client_order_id="btc-preview-wrong-symbol",
+                lifecycle_correlation_id="corr-btc",
+                lifecycle_state="previewed",
+                order_status=None,
+                signal_symbol="KRW-SOL",
+                execution_symbol="SOLUSD",
+                filled_qty=None,
+            )
+        ],
+        approval_packet={
+            "client_order_id": "btc-submit",
+            "lifecycle_correlation_id": "corr-btc",
+            "signal_symbol": "KRW-BTC",
+            "execution_symbol": "BTC/USD",
+        },
+    )
+
+    assert report.should_block is True
+    assert "signal_execution_symbol_mismatch" in _check_ids(report)


### PR DESCRIPTION
## Summary
- Scope Alpaca Paper preflight ledger reads by lifecycle correlation/client/candidate/briefing keys from explicit args or approval_packet.
- Filter service-level stale and symbol-context checks to packet provenance scope while preserving broad recent-ledger behavior when no scope exists.
- Return scoped_by/session_uuid metadata and document the MCP contract.

## Safety
- Read-only preflight only.
- No broker submit/cancel/modify/replace.
- No live trading route or DB mutation.

## Tests
- `uv run ruff format --check app/ tests/`
- `uv run ruff check app/services/alpaca_paper_anomaly_checks.py app/mcp_server/tooling/alpaca_paper_ledger_read.py tests/services/test_alpaca_paper_anomaly_checks.py tests/mcp_server/test_alpaca_paper_ledger_read_tools.py`
- `uv run pytest tests/services/test_alpaca_paper_anomaly_checks.py tests/mcp_server/test_alpaca_paper_ledger_read_tools.py -q`

Linear: ROB-108
