### PR TITLE
fix: strip HTML from news radar snippets

### DIFF
--- a/app/services/news_radar_service.py
+++ b/app/services/news_radar_service.py
@@ -6,7 +6,9 @@ Read-only. No DB writes. No broker calls. No mutation.
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
+from html import unescape
 from typing import Any
 
 from app.schemas.news import NewsReadinessResponse, NewsSourceCoverage
@@ -51,6 +53,21 @@ _SECTION_ORDER: tuple[NewsRadarRiskCategory, ...] = (
 _BRIEFING_INCLUDE_THRESHOLD = 40
 _AGGREGATE_MARKETS = ("kr", "us", "crypto")
 _MAX_INTERNAL_FETCH_LIMIT = 500
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _plain_text(value: Any, *, max_length: int | None = None) -> str | None:
+    if value is None:
+        return None
+    text = unescape(str(value))
+    text = _HTML_TAG_RE.sub(" ", text)
+    text = _WHITESPACE_RE.sub(" ", text).strip()
+    if not text:
+        return None
+    if max_length is not None and len(text) > max_length:
+        return text[: max_length - 1].rstrip() + "…"
+    return text
 
 
 def _field(article: Any, name: str) -> Any:
@@ -120,12 +137,10 @@ def _classification_to_item(
 ) -> NewsRadarItem:
     article_id = _field(article, "id")
     symbol = _field(article, "stock_symbol")
-    snippet = _field(article, "summary")
-    if isinstance(snippet, str) and len(snippet) > 280:
-        snippet = snippet[:277] + "…"
+    snippet = _plain_text(_field(article, "summary"), max_length=280)
     return NewsRadarItem(
         id=str(article_id) if article_id is not None else _field(article, "url") or "",
-        title=str(_field(article, "title") or ""),
+        title=_plain_text(_field(article, "title")) or "",
         source=_field(article, "source"),
         feed_source=_field(article, "feed_source"),
         url=str(_field(article, "url") or ""),

--- a/frontend/trading-decision/src/__tests__/components/NewsRiskHeadlineCard.test.tsx
+++ b/frontend/trading-decision/src/__tests__/components/NewsRiskHeadlineCard.test.tsx
@@ -35,4 +35,21 @@ describe("NewsRiskHeadlineCard", () => {
     expect(screen.getByText(/shipping/)).toBeInTheDocument();
     expect(screen.getByText(/uae/)).toBeInTheDocument();
   });
+
+  it("strips HTML from API-provided title and snippets before display", () => {
+    const item = makeNewsRadarItem({
+      title: "<b>Bitcoin</b> around $80K",
+      snippet:
+        '<p><a rel="nofollow" href="https://bitcoinmagazine.com">Bitcoin Magazine</a><br /> <img src="https://example.test/image.jpg" />Risk assets &amp; oil move.</p>',
+    });
+    render(<NewsRiskHeadlineCard item={item} />);
+
+    expect(
+      screen.getByRole("link", { name: "Bitcoin around $80K" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Bitcoin Magazine Risk assets & oil move."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/<p>|href=|src=/i)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/trading-decision/src/components/NewsRiskHeadlineCard.module.css
+++ b/frontend/trading-decision/src/components/NewsRiskHeadlineCard.module.css
@@ -6,6 +6,8 @@
   display: grid;
   gap: 8px;
   background: var(--color-surface, #ffffff);
+  min-width: 0;
+  overflow: hidden;
 }
 .severity_high { border-left: 4px solid #d94f4f; }
 .severity_medium { border-left: 4px solid #d9a64f; }
@@ -13,10 +15,10 @@
 .header { display: flex; justify-content: space-between; gap: 8px; }
 .severity { font-weight: 600; text-transform: uppercase; font-size: 12px; }
 .inclusion { font-size: 12px; color: #6b7280; }
-.title { font-weight: 600; color: inherit; text-decoration: none; }
+.title { font-weight: 600; color: inherit; text-decoration: none; overflow-wrap: anywhere; }
 .title:hover { text-decoration: underline; }
-.meta { font-size: 12px; color: #6b7280; margin: 0; }
-.snippet { margin: 0; font-size: 13px; }
+.meta { font-size: 12px; color: #6b7280; margin: 0; overflow-wrap: anywhere; }
+.snippet { margin: 0; font-size: 13px; overflow-wrap: anywhere; }
 .chips { display: flex; flex-wrap: wrap; gap: 6px; padding: 0; margin: 0; list-style: none; }
 .chip {
   font-size: 11px;

--- a/frontend/trading-decision/src/components/NewsRiskHeadlineCard.tsx
+++ b/frontend/trading-decision/src/components/NewsRiskHeadlineCard.tsx
@@ -13,8 +13,43 @@ const SEVERITY_LABEL: Record<NewsRadarItem["severity"], string> = {
   low: "Low",
 };
 
+const ENTITY_MAP: Record<string, string> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  nbsp: " ",
+  quot: '\"',
+};
+
+function decodeHtmlEntities(value: string): string {
+  return value.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (match, entity: string) => {
+    const normalized = entity.toLowerCase();
+    if (normalized.startsWith("#x")) {
+      return String.fromCodePoint(Number.parseInt(normalized.slice(2), 16));
+    }
+    if (normalized.startsWith("#")) {
+      return String.fromCodePoint(Number.parseInt(normalized.slice(1), 10));
+    }
+    return ENTITY_MAP[normalized] ?? match;
+  });
+}
+
+function stripHtml(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+  const text = decodeHtmlEntities(value)
+    .replace(/<[^>]*>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return text || null;
+}
+
 export default function NewsRiskHeadlineCard({ item }: NewsRiskHeadlineCardProps) {
   const sourceLabel = item.source ?? item.feed_source ?? "—";
+  const title = stripHtml(item.title) ?? item.title;
+  const snippet = stripHtml(item.snippet);
   const inclusionLabel = item.included_in_briefing
     ? "In briefing"
     : "Collected · not in briefing";
@@ -33,13 +68,13 @@ export default function NewsRiskHeadlineCard({ item }: NewsRiskHeadlineCardProps
         rel="noreferrer noopener"
         target="_blank"
       >
-        {item.title}
+        {title}
       </a>
       <p className={styles.meta}>
         {sourceLabel} · {formatDateTime(item.published_at)} ·{" "}
         {item.market || "—"}
       </p>
-      {item.snippet ? <p className={styles.snippet}>{item.snippet}</p> : null}
+      {snippet ? <p className={styles.snippet}>{snippet}</p> : null}
       {item.themes.length > 0 ? (
         <ul aria-label="themes" className={styles.chips}>
           {item.themes.map((t) => (

--- a/tests/test_news_radar_service.py
+++ b/tests/test_news_radar_service.py
@@ -358,3 +358,84 @@ async def test_service_aggregates_all_market_readiness(
     assert response.readiness.status == "stale"
     assert response.readiness.source_count == 3
     assert "crypto: news readiness is not ready" in response.readiness.warnings
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_service_returns_plain_text_snippets_for_html_summaries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services import news_radar_service
+    from app.services.market_news_briefing_formatter import (
+        BriefingItem,
+        BriefingRelevance,
+        BriefingSection,
+        MarketNewsBriefing,
+    )
+
+    html_article = FakeArticle(
+        id=9,
+        title="<b>Iran</b> oil shock",
+        url="https://example.test/html",
+        market="crypto",
+        source="Bitcoin Magazine",
+        summary=(
+            '<p><a rel="nofollow" href="https://bitcoinmagazine.com">'
+            'Bitcoin Magazine</a><br /> <img src="https://example.test/image.jpg" />'
+            "Bitcoin bounces as Iran strike unsettles risk assets &amp; oil.</p>"
+        ),
+        article_published_at=_now() - timedelta(hours=1),
+    )
+
+    async def fake_get_news_articles(**_: Any) -> tuple[list[Any], int]:
+        return ([html_article], 1)
+
+    async def fake_get_news_readiness(**_: Any) -> NewsReadinessResponse:
+        return _readiness()
+
+    def fake_format_market_news_briefing(articles, market, limit=None):
+        item = BriefingItem(
+            article=articles[0],
+            relevance=BriefingRelevance(
+                score=80,
+                section_id="geo",
+                section_title="Geo",
+                include_in_briefing=True,
+                matched_terms=["iran"],
+            ),
+        )
+        return MarketNewsBriefing(
+            market=market,
+            sections=[BriefingSection(section_id="geo", title="Geo", items=[item])],
+            excluded=[],
+            summary={},
+        )
+
+    monkeypatch.setattr(news_radar_service, "get_news_articles", fake_get_news_articles)
+    monkeypatch.setattr(
+        news_radar_service, "get_news_readiness", fake_get_news_readiness
+    )
+    monkeypatch.setattr(
+        news_radar_service,
+        "format_market_news_briefing",
+        fake_format_market_news_briefing,
+    )
+
+    response = await news_radar_service.build_news_radar(
+        market="crypto",
+        hours=24,
+        q=None,
+        risk_category=None,
+        include_excluded=True,
+        limit=50,
+    )
+
+    item = response.items[0]
+    assert item.title == "Iran oil shock"
+    assert item.snippet is not None
+    assert "<" not in item.snippet
+    assert "href=" not in item.snippet
+    assert "src=" not in item.snippet
+    assert "&amp;" not in item.snippet
+    assert "Bitcoin Magazine" in item.snippet
+    assert "risk assets & oil" in item.snippet


### PR DESCRIPTION
## Summary
- Strip HTML tags/entities from News Radar titles and snippets before returning API items
- Add frontend defensive stripping so raw feed HTML cannot leak into cards
- Constrain card text overflow for long URLs/feed snippets

## Test Plan
- `uv run ruff check app/services/news_radar_service.py tests/test_news_radar_service.py`
- `uv run ruff format --check app/services/news_radar_service.py tests/test_news_radar_service.py`
- `uv run pytest tests/test_news_radar_classifier.py tests/test_schema_news_radar.py tests/test_news_radar_service.py tests/test_router_news_radar.py tests/test_news_radar_readonly_imports.py -q`
- `npm test -- --run src/__tests__/components/NewsRiskHeadlineCard.test.tsx src/__tests__/api.newsRadar.test.ts src/__tests__/hooks/useNewsRadar.test.tsx src/__tests__/NewsRadarPage.test.tsx`
- `npm run build`

## Safety
- Read-only display fix only
- No broker/order/scheduler/DB mutation paths changed
