### PR TITLE
feat(trading-decision): Korean UI + ko-KR locale (ROB-111)

### DIFF
--- a/docs/superpowers/plans/2026-05-05-rob-111-trading-decision-korean-ui.md
+++ b/docs/superpowers/plans/2026-05-05-rob-111-trading-decision-korean-ui.md
@@ -1,0 +1,1982 @@
+# ROB-111 Trading Decision Korean UI / ko-KR Locale Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `frontend/trading-decision` Korean-by-default — translate static UI chrome, switch date/number formatting to `ko-KR`, and replace raw enum/token/JSON exposure with Korean display labels — without changing API payloads, DB rows, or TradingAgents free-text output.
+
+**Architecture:** Add a single lightweight display-only label layer at `src/i18n/` (no external i18n library). Centralize all enum→Korean maps in `ko.ts` and reusable helpers (`labelOrToken`, `labelOrderSide`, `labelOperatorToken`, formatter wrappers) in `formatters.ts`. Translate hardcoded UI strings inline at call sites; pull all enum/token labels from the central maps so each token maps to exactly one Korean display string. Keep API payloads, enum values, symbols, venue IDs, source keys, and backend schemas unchanged.
+
+**Tech Stack:** React 19, TypeScript, Vite, Vitest, Testing Library, react-router-dom 7. No new runtime dependencies.
+
+**Reference:** Linear issue [ROB-111](https://linear.app/mgh3326/issue/ROB-111/auto-trader-react-한국어-ui메타데이터-표시-및-ko-kr-locale-정리)
+
+---
+
+## Operating Rules (read before any task)
+
+- **Working directory for every command:** `frontend/trading-decision/` (the React workspace).
+- **Commit cadence:** one focused commit per task. Each commit must keep `npm run typecheck` and `npm test` green.
+- **Branch:** `feature/ROB-111-trading-decision-korean-ui` from `main` (created by the worktree skill before execution).
+- **Never** add an i18n runtime dependency, change API enum values, mutate DB, or modify backend code.
+- **Token-shaped fallbacks** (e.g. unknown `source_profile` strings, raw `safety_scope`) must still be readable: if no Korean label exists, use the existing `formatOperatorToken`-style snake-to-space helper rather than printing the raw token.
+- **Do not** translate user-supplied free-text fields: `notes`, `market_brief`'s arbitrary string values, `proposal.original_rationale`, `proposal.original_payload` free text, `user_note`, news article titles/summaries, news source feed names. Their UI labels (the `<dt>` etc. surrounding them) DO get translated.
+- **Co-author trailer for commits:** `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>`
+
+## File Structure
+
+**Create:**
+- `src/i18n/ko.ts` — all enum/status/token → Korean string maps, grouped by domain.
+- `src/i18n/formatters.ts` — `labelOrToken`, `labelOrderSide`, `labelOperatorToken`, `formatDateTimeKo`, `formatDecimalKo` wrappers.
+- `src/i18n/index.ts` — barrel re-export so callers do `import { ... } from "../i18n"`.
+- `src/__tests__/i18n.formatters.test.ts` — formatter helper tests.
+
+**Modify (display-only):**
+- `src/format/datetime.ts` — default `locale = "ko-KR"`.
+- `src/format/decimal.ts` — default `locale = "ko-KR"`.
+- `src/format/percent.ts` — leave numeric formatting alone (it's locale-independent), but add `nullDash = "—"` consistency only if needed (no behavior change required).
+- `src/components/StatusBadge.tsx`
+- `src/components/WarningChips.tsx`
+- `src/components/ReconciliationBadge.tsx`
+- `src/components/NxtVenueBadge.tsx`
+- `src/components/ReadinessStatusBadge.tsx`
+- `src/components/MarketBriefPanel.tsx`
+- `src/components/ProposalResponseControls.tsx`
+- `src/components/ProposalRow.tsx`
+- `src/components/ProposalAdjustmentEditor.tsx`
+- `src/components/OutcomeMarkForm.tsx`
+- `src/components/ReconciliationDecisionSupportPanel.tsx`
+- `src/components/NewsReadinessSection.tsx`
+- `src/components/MarketNewsBriefingSection.tsx`
+- `src/components/CommitteeEvidenceArtifacts.tsx`
+- `src/pages/SessionListPage.tsx`
+- `src/pages/SessionDetailPage.tsx`
+- `src/pages/PreopenPage.tsx`
+
+**Tests to update (existing, assertions only):**
+- `src/__tests__/SessionListPage.test.tsx`
+- `src/__tests__/SessionDetailPage.test.tsx`
+- `src/__tests__/PreopenPage.test.tsx`
+- `src/__tests__/ProposalResponseControls.test.tsx`
+- `src/__tests__/ProposalRow.test.tsx`
+- `src/__tests__/ProposalAdjustmentEditor.test.tsx`
+- `src/__tests__/OutcomeMarkForm.test.tsx`
+- `src/__tests__/OutcomesPanel.test.tsx`
+- `src/__tests__/WarningChips.test.tsx`
+- `src/__tests__/ReconciliationBadge.test.tsx`
+- `src/__tests__/ReconciliationDecisionSupportPanel.test.tsx`
+- `src/__tests__/NxtVenueBadge.test.tsx`
+- `src/__tests__/format.decimal.test.ts`
+
+**Untouched (Korean already, or out of scope):** `OperatorEventForm`, `ExecutionReviewPanel`, `LinkedActionsPanel`, `OutcomesPanel`, `OriginalVsAdjustedSummary`, `StrategyEventTimeline`, `AnalyticsMatrix`, `Committee*` components other than `CommitteeEvidenceArtifacts` (their existing surface is mostly headings — translate only obvious chrome, not committee free-text payloads). Verify each at end-of-plan; only translate if they expose hardcoded English UI chrome to the user.
+
+---
+
+## Task 1: Bootstrap the `src/i18n/` label layer
+
+**Files:**
+- Create: `frontend/trading-decision/src/i18n/ko.ts`
+- Create: `frontend/trading-decision/src/i18n/formatters.ts`
+- Create: `frontend/trading-decision/src/i18n/index.ts`
+- Test: `frontend/trading-decision/src/__tests__/i18n.formatters.test.ts`
+
+- [ ] **Step 1: Write the failing formatter test**
+
+Create `src/__tests__/i18n.formatters.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  labelOperatorToken,
+  labelOrToken,
+  labelOrderSide,
+} from "../i18n/formatters";
+
+describe("labelOrToken", () => {
+  it("returns the Korean label when the key is known", () => {
+    const map = { open: "진행 중", closed: "종료" } as const;
+    expect(labelOrToken(map, "open")).toBe("진행 중");
+  });
+
+  it("falls back to the formatted token when the key is unknown", () => {
+    const map = { open: "진행 중" } as const;
+    expect(labelOrToken(map, "needs_review")).toBe("needs review");
+  });
+
+  it("returns the dash placeholder for null/undefined", () => {
+    const map = { open: "진행 중" } as const;
+    expect(labelOrToken(map, null)).toBe("—");
+    expect(labelOrToken(map, undefined)).toBe("—");
+  });
+});
+
+describe("labelOrderSide", () => {
+  it("translates buy/sell", () => {
+    expect(labelOrderSide("buy")).toBe("매수");
+    expect(labelOrderSide("sell")).toBe("매도");
+  });
+
+  it("returns dash for none/null", () => {
+    expect(labelOrderSide("none")).toBe("—");
+    expect(labelOrderSide(null)).toBe("—");
+  });
+});
+
+describe("labelOperatorToken", () => {
+  it("converts snake_case tokens to spaced text", () => {
+    expect(labelOperatorToken("paper_plumbing_smoke")).toBe(
+      "paper plumbing smoke",
+    );
+  });
+
+  it("returns dash for null/empty", () => {
+    expect(labelOperatorToken(null)).toBe("—");
+    expect(labelOperatorToken("")).toBe("—");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+```bash
+cd frontend/trading-decision
+npm test -- i18n.formatters
+```
+
+Expected: FAIL — module `../i18n/formatters` not resolved.
+
+- [ ] **Step 3: Create `src/i18n/ko.ts` with the central label maps**
+
+```ts
+import type {
+  ActionKind,
+  CommitteeAccountMode,
+  ExecutionAccountMode,
+  ExecutionReviewStageStatus,
+  ExecutionSource,
+  InstrumentType,
+  OutcomeHorizon,
+  PreopenArtifactReadinessStatus,
+  PreopenArtifactStatus,
+  PreopenNewsReadinessStatus,
+  PreopenPaperApprovalBridgeStatus,
+  PreopenPaperApprovalCandidateStatus,
+  PreopenQaCheckSeverity,
+  PreopenQaCheckStatus,
+  PreopenQaConfidence,
+  PreopenQaEvaluatorStatus,
+  PreopenQaGrade,
+  ProposalKind,
+  SessionStatus,
+  Side,
+  TrackKind,
+  UserResponseValue,
+  WorkflowStatus,
+} from "../api/types";
+import type {
+  CandidateKind,
+  NxtClassification,
+  ReconciliationStatus,
+} from "../api/reconciliation";
+
+export const SESSION_STATUS_LABEL: Record<SessionStatus, string> = {
+  open: "진행 중",
+  closed: "종료",
+  archived: "보관됨",
+};
+
+export const USER_RESPONSE_LABEL: Record<UserResponseValue, string> = {
+  pending: "대기",
+  accept: "수락",
+  partial_accept: "부분 수락",
+  modify: "수정",
+  defer: "보류",
+  reject: "거절",
+};
+
+export const RESPONSE_BUTTON_LABEL: Record<
+  "accept" | "partial_accept" | "modify" | "defer" | "reject",
+  string
+> = {
+  accept: "수락",
+  partial_accept: "부분 수락",
+  modify: "수정",
+  defer: "보류",
+  reject: "거절",
+};
+
+export const SIDE_LABEL: Record<Side, string> = {
+  buy: "매수",
+  sell: "매도",
+  none: "—",
+};
+
+export const PROPOSAL_KIND_LABEL: Record<ProposalKind, string> = {
+  trim: "축소",
+  add: "추가 매수",
+  enter: "신규 진입",
+  exit: "청산",
+  pullback_watch: "되돌림 관찰",
+  breakout_watch: "돌파 관찰",
+  avoid: "회피",
+  no_action: "무행동",
+  other: "기타",
+};
+
+export const ACTION_KIND_LABEL: Record<ActionKind, string> = {
+  live_order: "실주문",
+  paper_order: "모의주문",
+  watch_alert: "감시 알림",
+  no_action: "무행동",
+  manual_note: "수기 메모",
+};
+
+export const TRACK_KIND_LABEL: Record<TrackKind, string> = {
+  accepted_live: "수락(실주문)",
+  accepted_paper: "수락(모의)",
+  rejected_counterfactual: "거절 대조",
+  analyst_alternative: "분석가 대안",
+  user_alternative: "사용자 대안",
+};
+
+export const OUTCOME_HORIZON_LABEL: Record<OutcomeHorizon, string> = {
+  "1h": "1시간",
+  "4h": "4시간",
+  "1d": "1일",
+  "3d": "3일",
+  "7d": "7일",
+  final: "최종",
+};
+
+export const INSTRUMENT_TYPE_LABEL: Record<InstrumentType, string> = {
+  equity_kr: "국내주식",
+  equity_us: "해외주식",
+  crypto: "암호화폐",
+  forex: "외환",
+  index: "지수",
+};
+
+export const ACCOUNT_MODE_LABEL: Record<CommitteeAccountMode, string> = {
+  kis_mock: "KIS 모의",
+  alpaca_paper: "Alpaca Paper",
+  kis_live: "KIS 실계좌",
+  db_simulated: "DB 시뮬레이션",
+};
+
+export const EXECUTION_ACCOUNT_MODE_LABEL: Record<ExecutionAccountMode, string> = {
+  kis_live: "KIS 실계좌",
+  kis_mock: "KIS 모의",
+  alpaca_paper: "Alpaca Paper",
+  db_simulated: "DB 시뮬레이션",
+};
+
+export const EXECUTION_SOURCE_LABEL: Record<ExecutionSource, string> = {
+  preopen: "장전",
+  watch: "감시",
+  manual: "수기",
+  websocket: "실시간",
+  reconciler: "조정",
+};
+
+export const EXECUTION_REVIEW_STAGE_STATUS_LABEL: Record<
+  ExecutionReviewStageStatus,
+  string
+> = {
+  ready: "준비 완료",
+  degraded: "주의",
+  unavailable: "미사용",
+  skipped: "건너뜀",
+  pending: "대기",
+};
+
+export const WORKFLOW_STATUS_LABEL: Record<WorkflowStatus, string> = {
+  created: "생성됨",
+  evidence_generating: "근거 수집 중",
+  evidence_ready: "근거 준비됨",
+  debate_ready: "토론 준비됨",
+  trader_draft_ready: "트레이더 초안 준비",
+  risk_review_ready: "리스크 리뷰 준비",
+  auto_approved: "자동 승인",
+  preview_ready: "프리뷰 준비",
+  journal_ready: "기록 준비",
+  completed: "완료",
+  failed_evidence: "근거 실패",
+  failed_trader_draft: "트레이더 초안 실패",
+  failed_risk_review: "리스크 리뷰 실패",
+  preview_blocked: "프리뷰 차단",
+};
+
+export const RECONCILIATION_STATUS_LABEL: Record<ReconciliationStatus, string> = {
+  maintain: "유지",
+  near_fill: "체결 임박",
+  too_far: "괴리 큼",
+  chasing_risk: "추격 위험",
+  data_mismatch: "데이터 불일치",
+  kr_pending_non_nxt: "국내 브로커 전용",
+  unknown_venue: "거래소 알 수 없음",
+  unknown: "알 수 없음",
+};
+
+export const NXT_CLASSIFICATION_LABEL: Record<NxtClassification, string> = {
+  buy_pending_at_support: "매수 대기(지지선 근접)",
+  buy_pending_too_far: "매수 대기(괴리 큼)",
+  buy_pending_actionable: "매수 대기(실행 가능)",
+  sell_pending_near_resistance: "매도 대기(저항선 근접)",
+  sell_pending_too_optimistic: "매도 대기(낙관 과다)",
+  sell_pending_actionable: "매도 대기(실행 가능)",
+  non_nxt_pending_ignore_for_nxt: "비-NXT 대기",
+  holding_watch_only: "보유 감시",
+  data_mismatch_requires_review: "데이터 불일치 검토 필요",
+  unknown: "알 수 없음",
+};
+
+export const CANDIDATE_KIND_LABEL: Record<CandidateKind, string> = {
+  pending_order: "대기 주문",
+  holding: "보유",
+  screener_hit: "스크리너 적중",
+  proposed: "제안됨",
+  other: "기타",
+};
+
+export const NEWS_READINESS_LABEL: Record<PreopenNewsReadinessStatus, string> = {
+  ready: "정상",
+  stale: "오래됨",
+  unavailable: "미사용",
+};
+
+export const ARTIFACT_STATUS_LABEL: Record<PreopenArtifactStatus, string> = {
+  unavailable: "미사용",
+  draft: "초안",
+  ready: "준비 완료",
+  degraded: "주의",
+};
+
+export const ARTIFACT_READINESS_LABEL: Record<
+  PreopenArtifactReadinessStatus,
+  string
+> = {
+  ready: "준비 완료",
+  stale: "오래됨",
+  unavailable: "미사용",
+  partial: "일부",
+};
+
+export const PAPER_APPROVAL_STATUS_LABEL: Record<
+  PreopenPaperApprovalBridgeStatus,
+  string
+> = {
+  available: "사용 가능",
+  warning: "주의",
+  blocked: "차단됨",
+  unavailable: "미사용",
+};
+
+export const PAPER_APPROVAL_CANDIDATE_STATUS_LABEL: Record<
+  PreopenPaperApprovalCandidateStatus,
+  string
+> = {
+  available: "사용 가능",
+  warning: "주의",
+  unavailable: "미사용",
+};
+
+export const QA_STATUS_LABEL: Record<PreopenQaEvaluatorStatus, string> = {
+  ready: "준비 완료",
+  needs_review: "검토 필요",
+  unavailable: "미사용",
+  skipped: "건너뜀",
+};
+
+export const QA_CHECK_STATUS_LABEL: Record<PreopenQaCheckStatus, string> = {
+  pass: "통과",
+  warn: "주의",
+  fail: "실패",
+  unknown: "알 수 없음",
+  skipped: "건너뜀",
+};
+
+export const QA_SEVERITY_LABEL: Record<PreopenQaCheckSeverity, string> = {
+  info: "정보",
+  low: "낮음",
+  medium: "보통",
+  high: "높음",
+};
+
+export const QA_GRADE_LABEL: Record<PreopenQaGrade, string> = {
+  excellent: "매우 우수",
+  good: "양호",
+  watch: "주의",
+  poor: "미흡",
+  unavailable: "미사용",
+};
+
+export const QA_CONFIDENCE_LABEL: Record<PreopenQaConfidence, string> = {
+  high: "높음",
+  medium: "보통",
+  low: "낮음",
+  unavailable: "미사용",
+};
+
+export const VENUE_LABEL: Record<string, string> = {
+  upbit: "Upbit",
+  alpaca_paper: "Alpaca Paper",
+  kis: "KIS",
+  kis_mock: "KIS 모의",
+  kis_live: "KIS 실계좌",
+};
+
+export const WARNING_TOKEN_LABEL: Record<string, string> = {
+  missing_quote: "시세 누락",
+  stale_quote: "시세 오래됨",
+  missing_orderbook: "호가 누락",
+  missing_support_resistance: "지지/저항선 미사용",
+  missing_kr_universe: "국내 유니버스 누락",
+  non_nxt_venue: "비-NXT 거래소",
+  unknown_venue: "거래소 알 수 없음",
+  unknown_side: "방향 알 수 없음",
+};
+
+export const SAFETY_SCOPE_LABEL: Record<string, string> = {
+  preview_only_confirm_false_no_broker_submit:
+    "브로커 제출 없는 preview 전용",
+  advisory_only: "자문 전용",
+};
+
+export const PURPOSE_LABEL: Record<string, string> = {
+  paper_plumbing_smoke: "페이퍼 배관 점검",
+  alpha_candidate_review: "알파 후보 리뷰",
+};
+
+export const COMMON = {
+  dash: "—",
+  loading: "불러오는 중…",
+  saving: "저장 중…",
+  retry: "다시 시도",
+  cancel: "취소",
+  refresh: "새로고침",
+  next: "다음",
+  previous: "이전",
+  all: "전체",
+  yes: "예",
+  no: "아니오",
+  unknown: "알 수 없음",
+  rawData: "원본 데이터 보기",
+  somethingWentWrong: "오류가 발생했습니다. 다시 시도해 주세요.",
+} as const;
+```
+
+- [ ] **Step 4: Create `src/i18n/formatters.ts`**
+
+```ts
+import { COMMON } from "./ko";
+
+export function labelOrToken<K extends string>(
+  map: Readonly<Record<K, string>>,
+  key: K | string | null | undefined,
+): string {
+  if (key === null || key === undefined || key === "") return COMMON.dash;
+  const known = (map as Record<string, string>)[key];
+  if (known !== undefined) return known;
+  return formatToken(key);
+}
+
+export function labelOperatorToken(value: string | null | undefined): string {
+  if (value === null || value === undefined || value === "") return COMMON.dash;
+  return formatToken(value);
+}
+
+export function labelOrderSide(side: string | null | undefined): string {
+  if (side === "buy") return "매수";
+  if (side === "sell") return "매도";
+  return COMMON.dash;
+}
+
+export function labelYesNo(value: boolean | null | undefined): string {
+  if (value === null || value === undefined) return COMMON.dash;
+  return value ? COMMON.yes : COMMON.no;
+}
+
+function formatToken(raw: string): string {
+  return raw.replace(/_/g, " ");
+}
+```
+
+- [ ] **Step 5: Create `src/i18n/index.ts` barrel**
+
+```ts
+export * from "./ko";
+export * from "./formatters";
+```
+
+- [ ] **Step 6: Run the formatter test, confirm it passes**
+
+```bash
+npm test -- i18n.formatters
+```
+
+Expected: PASS (3 + 2 + 2 cases).
+
+- [ ] **Step 7: Run typecheck and full suite**
+
+```bash
+npm run typecheck
+npm test
+```
+
+Expected: PASS. New files have no consumers yet, so no regressions.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/i18n src/__tests__/i18n.formatters.test.ts
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): add Korean label/formatter i18n layer (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Switch default formatter locale to ko-KR
+
+**Files:**
+- Modify: `frontend/trading-decision/src/format/datetime.ts`
+- Modify: `frontend/trading-decision/src/format/decimal.ts`
+- Test: `frontend/trading-decision/src/__tests__/format.decimal.test.ts` (existing)
+- Create: `frontend/trading-decision/src/__tests__/format.datetime.test.ts`
+
+- [ ] **Step 1: Inspect existing decimal test to see what to keep**
+
+```bash
+cat src/__tests__/format.decimal.test.ts
+```
+
+Expected: locale-coupled assertions you'll need to update.
+
+- [ ] **Step 2: Write a failing datetime test**
+
+Create `src/__tests__/format.datetime.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { formatDateTime } from "../format/datetime";
+
+describe("formatDateTime", () => {
+  it("returns dash for null/undefined", () => {
+    expect(formatDateTime(null)).toBe("—");
+    expect(formatDateTime(undefined)).toBe("—");
+  });
+
+  it("returns the original string when not a valid date", () => {
+    expect(formatDateTime("not-a-date")).toBe("not-a-date");
+  });
+
+  it("formats ISO timestamps in ko-KR by default", () => {
+    const result = formatDateTime("2026-05-05T10:30:00Z");
+    expect(result).toMatch(/2026/);
+    expect(result.length).toBeGreaterThan(0);
+    // Korean default produces something like "2026. 5. 5. 오후 7:30"
+    // Match a Korean month/day separator or AM/PM marker.
+    expect(result).toMatch(/\.|오전|오후/);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to confirm it fails**
+
+```bash
+npm test -- format.datetime
+```
+
+Expected: FAIL — last assertion fails because default is `en-US`.
+
+- [ ] **Step 4: Update `src/format/datetime.ts` default locale**
+
+Replace its body with:
+
+```ts
+export function formatDateTime(
+  iso: string | null | undefined,
+  locale = "ko-KR",
+): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(locale, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+```
+
+- [ ] **Step 5: Update `src/format/decimal.ts` default locale**
+
+Replace with:
+
+```ts
+export function formatDecimal(
+  s: string | null | undefined,
+  locale = "ko-KR",
+  opts: Intl.NumberFormatOptions = { maximumFractionDigits: 8 },
+): string {
+  if (s === null || s === undefined) return "—";
+  const n = Number(s);
+  if (!Number.isFinite(n)) return s;
+  return new Intl.NumberFormat(locale, opts).format(n);
+}
+```
+
+- [ ] **Step 6: Update existing `src/__tests__/format.decimal.test.ts`**
+
+Read the existing assertions; convert any literal `en-US` formatted strings (e.g. `"1,234.56"`) to their `ko-KR` equivalents (digits and grouping are identical for thousands but assertions that pass an explicit `"en-US"` should be left alone). Adjust only the assertions that depended on the default locale.
+
+If a test does `expect(formatDecimal("1234.5")).toBe("1,234.5")`, leave it — `ko-KR` produces the same comma grouping for that case. If a test depended on locale-specific formatting that diverges, replace with `formatDecimal("1234.5", "en-US")` to keep that case explicit, and add a parallel `ko-KR` case.
+
+- [ ] **Step 7: Run format tests, confirm green**
+
+```bash
+npm test -- format
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run full suite to catch downstream breakage**
+
+```bash
+npm test
+```
+
+Expected: There may be a small number of test failures in components asserting English-formatted dates — note them. Do not fix here; subsequent tasks will rewrite those assertions when translating each component.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/format/datetime.ts src/format/decimal.ts src/__tests__/format.decimal.test.ts src/__tests__/format.datetime.test.ts
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): default ko-KR locale in datetime/decimal formatters (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Translate StatusBadge, ReconciliationBadge, NxtVenueBadge, ReadinessStatusBadge
+
+**Files:**
+- Modify: `src/components/StatusBadge.tsx`
+- Modify: `src/components/ReconciliationBadge.tsx`
+- Modify: `src/components/NxtVenueBadge.tsx`
+- Modify: `src/components/ReadinessStatusBadge.tsx`
+- Test: `src/__tests__/ReconciliationBadge.test.tsx` (existing)
+- Test: `src/__tests__/NxtVenueBadge.test.tsx` (existing)
+
+- [ ] **Step 1: Update `StatusBadge.tsx` to render Korean label**
+
+Replace file with:
+
+```tsx
+import type { SessionStatus, UserResponseValue } from "../api/types";
+import { SESSION_STATUS_LABEL, USER_RESPONSE_LABEL } from "../i18n";
+import styles from "./StatusBadge.module.css";
+
+interface StatusBadgeProps {
+  value: SessionStatus | UserResponseValue;
+}
+
+function labelFor(value: SessionStatus | UserResponseValue): string {
+  if (value in SESSION_STATUS_LABEL) {
+    return SESSION_STATUS_LABEL[value as SessionStatus];
+  }
+  return USER_RESPONSE_LABEL[value as UserResponseValue];
+}
+
+export default function StatusBadge({ value }: StatusBadgeProps) {
+  return (
+    <span className={`${styles.badge} ${styles[value]}`}>{labelFor(value)}</span>
+  );
+}
+```
+
+- [ ] **Step 2: Update `ReconciliationBadge.tsx` to use central map**
+
+Replace file with:
+
+```tsx
+import type { ReconciliationStatus } from "../api/reconciliation";
+import { RECONCILIATION_STATUS_LABEL } from "../i18n";
+import styles from "./ReconciliationBadge.module.css";
+
+interface Props {
+  value: ReconciliationStatus | null;
+}
+
+export default function ReconciliationBadge({ value }: Props) {
+  if (value === null) return null;
+  const label = RECONCILIATION_STATUS_LABEL[value];
+  return (
+    <span
+      aria-label={`조정 상태: ${label}`}
+      className={`${styles.badge} ${styles[value]}`}
+    >
+      {label}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 3: Update `NxtVenueBadge.tsx` Korean labels**
+
+Edit the four `badgeLabel` literals and the `aria-label` prefix:
+
+| English | Korean |
+|--|--|
+| `"NXT review needed"` | `"NXT 검토 필요"` |
+| `"Non-NXT (KR broker)"` | `"비-NXT (국내 브로커)"` |
+| `"NXT eligibility unknown"` | `"NXT 자격 알 수 없음"` |
+| `"NXT actionable"` | `"NXT 실행 가능"` |
+| `"NXT not actionable"` | `"NXT 실행 불가"` |
+| `"NXT venue: ..."` (aria) | `"NXT 거래소: ..."` |
+
+- [ ] **Step 4: Update `ReadinessStatusBadge.tsx` to import central map**
+
+Replace its `LABELS` constant with the imported `NEWS_READINESS_LABEL`:
+
+```tsx
+import type { PreopenNewsReadinessStatus } from "../api/types";
+import { NEWS_READINESS_LABEL } from "../i18n";
+import styles from "./ReadinessStatusBadge.module.css";
+
+export interface ReadinessStatusBadgeProps {
+  status: PreopenNewsReadinessStatus;
+}
+
+export default function ReadinessStatusBadge({
+  status,
+}: ReadinessStatusBadgeProps) {
+  return (
+    <span
+      className={`${styles.badge} ${styles[status]}`}
+      data-status={status}
+      role="status"
+    >
+      {NEWS_READINESS_LABEL[status]}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 5: Update `ReconciliationBadge.test.tsx` assertions**
+
+Open `src/__tests__/ReconciliationBadge.test.tsx`. Replace any English label assertions with their Korean equivalents from `RECONCILIATION_STATUS_LABEL` (e.g. `"Maintain"` → `"유지"`, `"Near fill"` → `"체결 임박"`). Replace the aria-label prefix `"Reconciliation status:"` with `"조정 상태:"`.
+
+- [ ] **Step 6: Update `NxtVenueBadge.test.tsx` assertions**
+
+Replace English badge text matches with the Korean equivalents from Step 3.
+
+- [ ] **Step 7: Run targeted tests**
+
+```bash
+npm test -- ReconciliationBadge NxtVenueBadge
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run full suite**
+
+```bash
+npm test
+npm run typecheck
+```
+
+Expected: typecheck PASS. Some unrelated tests (SessionListPage/SessionDetailPage etc. that rendered StatusBadge) may now fail; do not fix them — they will be addressed in their own tasks.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/components/StatusBadge.tsx src/components/ReconciliationBadge.tsx src/components/NxtVenueBadge.tsx src/components/ReadinessStatusBadge.tsx src/__tests__/ReconciliationBadge.test.tsx src/__tests__/NxtVenueBadge.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate StatusBadge / Reconciliation / NXT / Readiness badges (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Translate WarningChips
+
+**Files:**
+- Modify: `src/components/WarningChips.tsx`
+- Test: `src/__tests__/WarningChips.test.tsx` (existing)
+
+- [ ] **Step 1: Replace `FRIENDLY` with the central map**
+
+Edit `src/components/WarningChips.tsx` to:
+
+```tsx
+import { WARNING_TOKEN_LABEL } from "../i18n";
+import { labelOperatorToken } from "../i18n/formatters";
+import styles from "./WarningChips.module.css";
+
+interface Props {
+  tokens: string[];
+}
+
+const TOKEN_RE = /^[a-z][a-z0-9_]{0,63}$/;
+
+function labelFor(token: string): string {
+  return WARNING_TOKEN_LABEL[token] ?? labelOperatorToken(token);
+}
+
+export default function WarningChips({ tokens }: Props) {
+  const safe = tokens.filter((t) => TOKEN_RE.test(t));
+  if (safe.length === 0) return null;
+  return (
+    <ul aria-label="경고" className={styles.list}>
+      {safe.map((token) => (
+        <li
+          aria-label={`경고: ${labelFor(token)}`}
+          className={styles.chip}
+          key={token}
+        >
+          {labelFor(token)}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+- [ ] **Step 2: Update `WarningChips.test.tsx` assertions**
+
+Read the file, replace English label / aria-label assertions with the Korean equivalents (`"경고"` for the list aria-label, `"경고: 시세 누락"` style for chip aria-labels, `"시세 누락"` for chip text, etc.).
+
+- [ ] **Step 3: Run tests**
+
+```bash
+npm test -- WarningChips
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/WarningChips.tsx src/__tests__/WarningChips.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate WarningChips labels (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Translate ProposalResponseControls
+
+**Files:**
+- Modify: `src/components/ProposalResponseControls.tsx`
+- Test: `src/__tests__/ProposalResponseControls.test.tsx` (existing)
+
+- [ ] **Step 1: Update button labels and aria-label**
+
+Replace the `buttons` array and the `aria-label` in the `<div>`:
+
+```tsx
+import type { RespondAction, UserResponseValue } from "../api/types";
+import { RESPONSE_BUTTON_LABEL } from "../i18n";
+
+interface ProposalResponseControlsProps {
+  currentResponse: UserResponseValue;
+  isSubmitting: boolean;
+  onSimpleResponse: (response: "accept" | "reject" | "defer") => void;
+  onOpenAdjust: (response: "modify" | "partial_accept") => void;
+}
+
+const buttons: Array<{ value: RespondAction; kind: "simple" | "adjust" }> = [
+  { value: "accept", kind: "simple" },
+  { value: "partial_accept", kind: "adjust" },
+  { value: "modify", kind: "adjust" },
+  { value: "defer", kind: "simple" },
+  { value: "reject", kind: "simple" },
+];
+
+export default function ProposalResponseControls({
+  currentResponse,
+  isSubmitting,
+  onSimpleResponse,
+  onOpenAdjust,
+}: ProposalResponseControlsProps) {
+  return (
+    <div className="response-controls" aria-label="제안 응답 컨트롤">
+      {buttons.map((button) => (
+        <button
+          aria-pressed={currentResponse === button.value}
+          className={currentResponse === button.value ? "btn btn-primary" : "btn"}
+          disabled={isSubmitting}
+          key={button.value}
+          onClick={() => {
+            if (button.value === "modify" || button.value === "partial_accept") {
+              onOpenAdjust(button.value);
+            } else {
+              onSimpleResponse(button.value);
+            }
+          }}
+          type="button"
+        >
+          {RESPONSE_BUTTON_LABEL[button.value]}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Update test assertions**
+
+In `src/__tests__/ProposalResponseControls.test.tsx`, replace English button names with Korean equivalents:
+
+```tsx
+for (const name of ["수락", "부분 수락", "수정", "보류", "거절"]) {
+  expect(screen.getByRole("button", { name })).toBeInTheDocument();
+}
+```
+
+Replace all subsequent `getByRole("button", { name: "Accept" })` with `name: "수락"`, `"Modify"` with `"수정"`, etc. matching the Korean labels.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+npm test -- ProposalResponseControls
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ProposalResponseControls.tsx src/__tests__/ProposalResponseControls.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate ProposalResponseControls (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Translate ProposalAdjustmentEditor
+
+**Files:**
+- Modify: `src/components/ProposalAdjustmentEditor.tsx`
+- Test: `src/__tests__/ProposalAdjustmentEditor.test.tsx` (existing)
+
+- [ ] **Step 1: Translate field labels, error messages, button text**
+
+Edit `src/components/ProposalAdjustmentEditor.tsx` so the `specs` array uses Korean labels:
+
+```ts
+const specs: FieldSpec[] = [
+  { label: "수량", userKey: "user_quantity", originalKey: "original_quantity" },
+  { label: "수량 비율(%)", userKey: "user_quantity_pct", originalKey: "original_quantity_pct", percent: true },
+  { label: "금액", userKey: "user_amount", originalKey: "original_amount", nonNegative: true },
+  { label: "가격", userKey: "user_price", originalKey: "original_price", nonNegative: true },
+  { label: "트리거 가격", userKey: "user_trigger_price", originalKey: "original_trigger_price", nonNegative: true },
+  { label: "임계 비율(%)", userKey: "user_threshold_pct", originalKey: "original_threshold_pct", percent: true },
+];
+```
+
+Update the inline error strings:
+
+| English | Korean |
+|--|--|
+| `${spec.label} must be a decimal string.` | `${spec.label}은(는) 소수 문자열이어야 합니다.` |
+| `${spec.label} must be greater than or equal to 0.` | `${spec.label}은(는) 0 이상이어야 합니다.` |
+| `${spec.label} must be between 0 and 100.` | `${spec.label}은(는) 0 이상 100 이하이어야 합니다.` |
+| `Enter at least one adjusted numeric value.` | `조정된 숫자 값을 하나 이상 입력해 주세요.` |
+| `Something went wrong. Try again.` | use `COMMON.somethingWentWrong` |
+
+Update the `<span>Note</span>` label to `<span>메모</span>`. Update the buttons:
+
+```tsx
+<button className="btn btn-primary" disabled={isSubmitting} type="submit">
+  {response === "partial_accept" ? "부분 수락 저장" : "수정 저장"}
+</button>
+<button className="btn btn-ghost" disabled={isSubmitting} onClick={onCancel} type="button">
+  취소
+</button>
+```
+
+Add `import { COMMON } from "../i18n";` at the top and replace the fallback error string.
+
+- [ ] **Step 2: Update test assertions**
+
+In `src/__tests__/ProposalAdjustmentEditor.test.tsx`, replace any English label / button / error matchers with the Korean equivalents above.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+npm test -- ProposalAdjustmentEditor
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ProposalAdjustmentEditor.tsx src/__tests__/ProposalAdjustmentEditor.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate ProposalAdjustmentEditor (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Translate OutcomeMarkForm
+
+**Files:**
+- Modify: `src/components/OutcomeMarkForm.tsx`
+- Test: `src/__tests__/OutcomeMarkForm.test.tsx` (existing)
+
+- [ ] **Step 1: Use central track/horizon labels and translate UI chrome**
+
+Edit `src/components/OutcomeMarkForm.tsx`:
+
+```tsx
+import { COMMON, OUTCOME_HORIZON_LABEL, TRACK_KIND_LABEL } from "../i18n";
+```
+
+Translate UI strings:
+
+| English | Korean |
+|--|--|
+| `aria-label="Record outcome mark"` | `aria-label="결과 마크 기록"` |
+| `Track` (label) | `트랙` |
+| `Horizon` (label) | `기간` |
+| `Counterfactual` (label) | `대조군` |
+| `— select —` (option) | `— 선택 —` |
+| `Price at mark` | `마크 시점 가격` |
+| `e.g. 118000000` (placeholder) | `예: 118000000` |
+| `PnL %` | `손익(%)` |
+| `PnL amount` | `손익 금액` |
+| `optional` (placeholder) | `선택` |
+| `price_at_mark must be a non-negative number` | `마크 시점 가격은 0 이상의 숫자여야 합니다` |
+| `accepted_live must not have a counterfactual selected` | `accepted_live 트랙은 대조군을 선택할 수 없습니다` |
+| `counterfactual is required for this track` | `이 트랙에서는 대조군이 필요합니다` |
+| `Could not record outcome mark.` | `결과 마크를 기록할 수 없습니다.` |
+| `Saving...` | `COMMON.saving` |
+| `Record mark` (submit button) | `마크 기록` |
+
+Use `TRACK_KIND_LABEL[t]` and `OUTCOME_HORIZON_LABEL[h]` for `<option>` text:
+
+```tsx
+{TRACKS.map((t) => (
+  <option key={t} value={t}>
+    {TRACK_KIND_LABEL[t]}
+  </option>
+))}
+{HORIZONS.map((h) => (
+  <option key={h} value={h}>
+    {OUTCOME_HORIZON_LABEL[h]}
+  </option>
+))}
+```
+
+Counterfactual `<option>` text becomes:
+
+```tsx
+{`#${c.id} · 기준가 ${c.baseline_price}`}
+```
+
+- [ ] **Step 2: Update test assertions**
+
+In `src/__tests__/OutcomeMarkForm.test.tsx`, swap labels/options/error strings to the Korean equivalents from step 1. The form aria-label `"Record outcome mark"` → `"결과 마크 기록"`.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+npm test -- OutcomeMarkForm OutcomesPanel
+npm run typecheck
+```
+
+Expected: PASS. Update `OutcomesPanel.test.tsx` only if it asserts strings produced by `TRACK_KIND_LABEL` or horizon literals; otherwise leave it alone.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/OutcomeMarkForm.tsx src/__tests__/OutcomeMarkForm.test.tsx
+git diff --cached --stat
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate OutcomeMarkForm (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Translate ProposalRow
+
+**Files:**
+- Modify: `src/components/ProposalRow.tsx`
+- Test: `src/__tests__/ProposalRow.test.tsx` (existing)
+
+- [ ] **Step 1: Translate static UI in ProposalRow**
+
+Edit `src/components/ProposalRow.tsx`:
+
+Update imports:
+
+```tsx
+import {
+  COMMON,
+  PROPOSAL_KIND_LABEL,
+  SIDE_LABEL,
+} from "../i18n";
+```
+
+Update the `valuePairs` constant labels to Korean (these are the `<dt>` labels rendered by `ValueList`):
+
+```tsx
+const valuePairs = [
+  ["수량", "original_quantity", "user_quantity"],
+  ["수량 비율(%)", "original_quantity_pct", "user_quantity_pct"],
+  ["금액", "original_amount", "user_amount"],
+  ["가격", "original_price", "user_price"],
+  ["트리거 가격", "original_trigger_price", "user_trigger_price"],
+  ["임계 비율(%)", "original_threshold_pct", "user_threshold_pct"],
+] as const;
+```
+
+Update the chip / heading text:
+
+```tsx
+<span className={styles.chip}>{SIDE_LABEL[proposal.side]}</span>
+<span className={styles.chip}>{PROPOSAL_KIND_LABEL[proposal.proposal_kind]}</span>
+```
+
+Translate static strings:
+
+| English | Korean |
+|--|--|
+| `<h3>Original</h3>` | `<h3>원본</h3>` |
+| `<h3>Your decision</h3>` | `<h3>내 결정</h3>` |
+| `<h3>Crypto paper workflow</h3>` | `<h3>암호화폐 모의 워크플로우</h3>` |
+| `Session is archived. You can no longer respond.` | `세션이 보관되었습니다. 더 이상 응답할 수 없습니다.` |
+| `Something went wrong. Try again.` | `COMMON.somethingWentWrong` |
+| `Current quote estimate needed` | `현재 시세 추정이 필요합니다` |
+| `Non-NXT pending order — KR broker routing only. Review before deciding; recording a response on this row does not place or cancel a broker order.` | `비-NXT 대기 주문 — 국내 브로커 라우팅 전용. 결정 전에 검토하세요. 이 행의 응답 기록은 브로커 주문을 제출하거나 취소하지 않습니다.` |
+| `Accept records this decision only; it does not send a live trade.` | `수락은 결정만 기록합니다. 실주문을 전송하지 않습니다.` |
+| `<summary>Record outcome mark</summary>` | `<summary>결과 마크 기록</summary>` |
+| `aria-label="Outcome marks"` | `aria-label="결과 마크"` |
+
+Update `formatProposalValue` 's `Amount` branch — the label is now Korean, so adjust:
+
+```ts
+function isMissingSellAmount(label: string, value: string, proposal: ProposalDetail) {
+  return label === "금액" && proposal.side === "sell" && Number(value) === 0 && proposal.original_price === null;
+}
+
+function formatProposalValue(label: string, value: string, proposal: ProposalDetail) {
+  if (isMissingSellAmount(label, value, proposal)) {
+    return "현재 시세 추정이 필요합니다";
+  }
+  return `${formatDecimal(value)}${
+    label === "금액" && proposal.original_currency
+      ? ` ${proposal.original_currency}`
+      : ""
+  }`;
+}
+```
+
+Update `summaryPairs` similarly (it currently uses the same `valuePairs` labels, which are now Korean — no further changes needed for keys).
+
+- [ ] **Step 2: Update test assertions**
+
+In `src/__tests__/ProposalRow.test.tsx`, replace English string matchers with the Korean equivalents above. Likely matches: `"Original"`, `"Your decision"`, `"Quantity"`, side / kind labels (`"buy"` → `"매수"`, etc.), the safety note, and the non-NXT warning.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+npm test -- ProposalRow
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ProposalRow.tsx src/__tests__/ProposalRow.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate ProposalRow chrome and value labels (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Translate ReconciliationDecisionSupportPanel
+
+**Files:**
+- Modify: `src/components/ReconciliationDecisionSupportPanel.tsx`
+- Test: `src/__tests__/ReconciliationDecisionSupportPanel.test.tsx` (existing)
+
+- [ ] **Step 1: Translate `<dt>` labels and aria-label**
+
+Edit the panel:
+
+| English | Korean |
+|--|--|
+| `aria-label="Reconciliation decision support"` | `aria-label="조정 의사결정 지원"` |
+| `Pending side` | `대기 방향` |
+| `Pending price` | `대기 가격` |
+| `Pending qty` | `대기 수량` |
+| `Pending order` | `대기 주문` |
+| `Live quote` | `실시간 시세` |
+| `Gap to current` | `현재가 대비 괴리` |
+| `Distance to fill` | `체결까지 거리` |
+| `Nearest support` | `가까운 지지선` |
+| `Nearest resistance` | `가까운 저항선` |
+| `Bid/ask spread` | `매수/매도 스프레드` |
+
+Use `labelOrderSide` for the side value: `<Item label="대기 방향" value={labelOrderSide(side)} />`. Add the import.
+
+- [ ] **Step 2: Update test assertions**
+
+Open `src/__tests__/ReconciliationDecisionSupportPanel.test.tsx`, replace English `<dt>` labels with the Korean equivalents.
+
+- [ ] **Step 3: Run tests**
+
+```bash
+npm test -- ReconciliationDecisionSupportPanel
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/ReconciliationDecisionSupportPanel.tsx src/__tests__/ReconciliationDecisionSupportPanel.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate ReconciliationDecisionSupportPanel (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Translate MarketBriefPanel + hide raw JSON behind 원본 데이터 보기
+
+**Files:**
+- Modify: `src/components/MarketBriefPanel.tsx`
+
+- [ ] **Step 1: Replace English UI chrome and reuse central reconciliation map**
+
+Edit the file:
+
+```tsx
+import {
+  COMMON,
+  RECONCILIATION_STATUS_LABEL,
+  NXT_CLASSIFICATION_LABEL,
+} from "../i18n";
+import { labelOrToken } from "../i18n/formatters";
+import styles from "./MarketBriefPanel.module.css";
+```
+
+Remove the local `RECON_LABEL` and `NXT_LABEL`. Use `RECONCILIATION_STATUS_LABEL` and `NXT_CLASSIFICATION_LABEL` from i18n instead. For unknown keys in `nxt_summary` / `reconciliation_summary`, render `labelOrToken(MAP, key)` so unrecognized backend tokens show a readable form rather than raw `snake_case`.
+
+Translate the visible chrome:
+
+| English | Korean |
+|--|--|
+| `<summary>Market brief</summary>` | `<summary>시장 브리핑</summary>` |
+| `Research run:` | `리서치 실행:` |
+| ` · refreshed ` | ` · 갱신 ` (use `formatDateTime(summary.refreshed_at)` instead of raw ISO) |
+| `Counts:` | `건수:` |
+| `candidates` | `후보` |
+| `reconciliations` | `조정` |
+| `Reconciliation summary` | `조정 요약` |
+| `NXT summary` | `NXT 요약` |
+| `Snapshot warnings:` | `스냅샷 경고:` |
+| `Source warnings:` | `소스 경고:` |
+
+When `summary` is `null` but `brief` is non-null (the current `else if (brief)` branch), wrap the raw JSON inside a nested `<details>` whose summary is `COMMON.rawData`:
+
+```tsx
+{summary ? (
+  <div className={styles.summary}>{/* ...localized fields... */}</div>
+) : brief ? (
+  <details>
+    <summary>{COMMON.rawData}</summary>
+    <pre>{JSON.stringify(brief, null, 2)}</pre>
+  </details>
+) : null}
+```
+
+When `summary` is non-null, append a sibling `<details><summary>{COMMON.rawData}</summary><pre>...</pre></details>` so operators can still inspect raw payload, but it is no longer the primary display.
+
+- [ ] **Step 2: Run typecheck and existing tests**
+
+There is no dedicated `MarketBriefPanel.test.tsx`, but `SessionDetailPage.test.tsx` may render this; that test gets updated in Task 11.
+
+```bash
+npm run typecheck
+npm test -- MarketBriefPanel
+```
+
+Expected: typecheck PASS. The `MarketBriefPanel` filename match returns no test file — that's fine.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/MarketBriefPanel.tsx
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate MarketBriefPanel and gate raw JSON behind 원본 데이터 보기 (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Translate SessionListPage
+
+**Files:**
+- Modify: `src/pages/SessionListPage.tsx`
+- Test: `src/__tests__/SessionListPage.test.tsx` (existing)
+
+- [ ] **Step 1: Translate UI chrome and use central session-status options**
+
+Edit `src/pages/SessionListPage.tsx`:
+
+```tsx
+import {
+  COMMON,
+  SESSION_STATUS_LABEL,
+  WORKFLOW_STATUS_LABEL,
+  ACCOUNT_MODE_LABEL,
+} from "../i18n";
+import { labelOrToken } from "../i18n/formatters";
+```
+
+Translate strings:
+
+| English | Korean |
+|--|--|
+| `<h1>Decision inbox</h1>` | `<h1>의사결정함</h1>` |
+| `Status filter` (visible label + aria-label) | `상태 필터` |
+| `<option value="">All</option>` | `<option value="">{COMMON.all}</option>` |
+| Status `<option>` text | `{SESSION_STATUS_LABEL[status]}` (replace `open`/`closed`/`archived` literals) |
+| `Refresh` | `{COMMON.refresh}` |
+| `Something went wrong. Try again.` | `{COMMON.somethingWentWrong}` |
+| `No decision sessions yet.` | `아직 의사결정 세션이 없습니다.` |
+| `<th>Generated</th>` | `생성 시각` |
+| `<th>Profile</th>` | `프로필` |
+| `<th>Strategy</th>` | `전략` |
+| `<th>Scope</th>` | `범위` |
+| `<th>Status</th>` | `상태` |
+| `<th>Workflow</th>` | `워크플로우` |
+| `<th>Account</th>` | `계정` |
+| `<th>Proposals</th>` | `제안` |
+| `<th>Pending</th>` | `대기` |
+| `Previous` | `{COMMON.previous}` |
+| `Next` | `{COMMON.next}` |
+
+Replace the workflow-status mini cell so it renders `labelOrToken(WORKFLOW_STATUS_LABEL, session.workflow_status)` instead of `replace(/_/g, " ").toUpperCase()`. Replace `account_mode` cell with `labelOrToken(ACCOUNT_MODE_LABEL, session.account_mode)`.
+
+Update market_scope rendering: replace `session.market_scope ?? "—"` with `session.market_scope ? session.market_scope.toUpperCase() : COMMON.dash` (preserves "KR"/"US"/"CRYPTO" tokens which are operator identifiers).
+
+- [ ] **Step 2: Update SessionListPage test assertions**
+
+Edit `src/__tests__/SessionListPage.test.tsx`. Replace:
+- `"No decision sessions yet."` → `"아직 의사결정 세션이 없습니다."`
+- `getByLabelText("Status filter")` → `getByLabelText("상태 필터")`
+
+The test fixture's strategy name (`"Momentum rebalance"`) is fixture data, not UI chrome — leave it alone.
+
+- [ ] **Step 3: Run tests and typecheck**
+
+```bash
+npm test -- SessionListPage
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/SessionListPage.tsx src/__tests__/SessionListPage.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate SessionListPage (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Translate SessionDetailPage
+
+**Files:**
+- Modify: `src/pages/SessionDetailPage.tsx`
+- Test: `src/__tests__/SessionDetailPage.test.tsx` (existing)
+
+- [ ] **Step 1: Translate UI chrome and use central workflow status map**
+
+Edit `src/pages/SessionDetailPage.tsx`:
+
+```tsx
+import { COMMON, WORKFLOW_STATUS_LABEL } from "../i18n";
+import { labelOrToken } from "../i18n/formatters";
+```
+
+Translate strings:
+
+| English | Korean |
+|--|--|
+| `Session not found` (ErrorView) | `세션을 찾을 수 없습니다` |
+| `<h1>Session not found</h1>` | `<h1>세션을 찾을 수 없습니다</h1>` |
+| `Back to inbox` (Link x2) | `의사결정함으로 돌아가기` |
+| `Something went wrong. Try again.` | `{COMMON.somethingWentWrong}` |
+| `all markets` | `전체 시장` |
+| `<strong>Workflow Status:</strong>` | `<strong>워크플로우 상태:</strong>` |
+| `aria-label="Committee artifacts"` | `aria-label="위원회 산출물"` |
+| `aria-label="Analytics"` | `aria-label="분석"` |
+| `<h2>Outcome analytics</h2>` | `<h2>결과 분석</h2>` |
+| `Loading analytics...` | `분석을 불러오는 중...` |
+| `aria-label="Strategy events"` | `aria-label="전략 이벤트"` |
+| `<h2>Strategy events</h2>` | `<h2>전략 이벤트</h2>` |
+| `Loading strategy events...` | `전략 이벤트를 불러오는 중...` |
+| `Session not found for strategy events.` | `전략 이벤트용 세션을 찾을 수 없습니다.` |
+| `aria-label="Proposals"` | `aria-label="제안"` |
+| `${pending_count} of ${proposals_count} pending` | ``${pending_count}/${proposals_count} 대기 중`` |
+
+Replace the workflow-status display with:
+
+```tsx
+<span className={styles.workflowStatus}>
+  {labelOrToken(WORKFLOW_STATUS_LABEL, data.workflow_status)}
+</span>
+```
+
+- [ ] **Step 2: Update SessionDetailPage test assertions**
+
+Replace English UI matches with Korean equivalents from Step 1. Match the new pending-count format (`"X/Y 대기 중"` instead of `"X of Y pending"`).
+
+- [ ] **Step 3: Run tests and typecheck**
+
+```bash
+npm test -- SessionDetailPage useDecisionSession
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/SessionDetailPage.tsx src/__tests__/SessionDetailPage.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate SessionDetailPage (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Translate NewsReadinessSection
+
+**Files:**
+- Modify: `src/components/NewsReadinessSection.tsx`
+
+- [ ] **Step 1: Translate UI chrome**
+
+Translate strings:
+
+| English | Korean |
+|--|--|
+| `aria-label="News readiness"` | `aria-label="뉴스 준비도"` |
+| `<h2>News readiness</h2>` | `<h2>뉴스 준비도</h2>` |
+| `News readiness lookup failed. Treat this preopen as if news is unavailable.` | `뉴스 준비도 조회에 실패했습니다. 뉴스를 미사용으로 간주하세요.` |
+| `<dt>Latest run</dt>` | `최근 실행` |
+| `<dt>Latest article</dt>` | `최근 기사` |
+| `<dt>Freshness window</dt>` | `신선도 기준` |
+| ` min` | `분` |
+| `News is older than ${X} min — verify before acting.` | ``뉴스가 ${X}분 이상 경과했습니다. 행동 전에 확인하세요.`` |
+| `News pipeline did not report a recent successful run.` | `뉴스 파이프라인의 최근 실행 성공 기록이 없습니다.` |
+| `aria-label="News source counts"` | `aria-label="뉴스 소스 건수"` |
+| `No source counts available.` | `소스 건수가 없습니다.` |
+| `<h3>Source coverage</h3>` | `<h3>소스 커버리지</h3>` |
+| Coverage table headers | `Source` → `소스`, `Status` → `상태`, `Expected` → `예상`, `Stored` → `저장됨`, `24h` → `24시간`, `Latest article` → `최근 기사` |
+| `Latest articles (...)` | `최근 기사 (...)` |
+| `No recent articles to preview.` | `미리 볼 최근 기사가 없습니다.` |
+
+For the coverage table `<td>{source.status}</td>`, leave the raw status (it is a backend-provided string mirroring `PreopenNewsSourceCoverage.status`); add a comment-free pass-through with a fallback through `labelOperatorToken` only if the displayed value still appears as `snake_case` after manual smoke-checking.
+
+- [ ] **Step 2: Run targeted tests**
+
+```bash
+npm test -- NewsReadinessSection
+npm run typecheck
+```
+
+Expected: typecheck PASS. There is no `NewsReadinessSection.test.tsx`; PreopenPage tests cover its rendering and are updated in Task 15.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/NewsReadinessSection.tsx
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate NewsReadinessSection (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Translate MarketNewsBriefingSection
+
+**Files:**
+- Modify: `src/components/MarketNewsBriefingSection.tsx`
+
+- [ ] **Step 1: Translate UI chrome (preserve article titles/summaries verbatim)**
+
+Translate strings:
+
+| English | Korean |
+|--|--|
+| `aria-label="Market news briefing"` | `aria-label="시장 뉴스 브리핑"` |
+| `<h2>Market news briefing</h2>` | `<h2>시장 뉴스 브리핑</h2>` |
+| `No market news briefing available yet.` | `아직 시장 뉴스 브리핑이 없습니다.` |
+| `Market-aware sections from recent news, filtered before trading review.` | `최근 뉴스에서 시장 관련 섹션을 추출해 트레이딩 리뷰 전에 필터링했습니다.` |
+| `aria-label="Market news briefing summary"` | `aria-label="시장 뉴스 브리핑 요약"` |
+| `No high-signal briefing sections found.` | `시그널이 강한 브리핑 섹션이 없습니다.` |
+| `${N} items` | ``${N}건`` |
+| `No articles in this section.` | `이 섹션에는 기사가 없습니다.` |
+| `Filtered noise: ${N}` | ``필터링된 노이즈: ${N}`` |
+| `Show top excluded articles (${N})` | ``상위 제외 기사 보기 (${N})`` |
+| `Score ${N}` | ``점수 ${N}`` |
+| `Terms: ${...}` | ``매칭 키워드: ${...}`` |
+
+For `summaryChips`, translate the chip key text:
+
+```tsx
+const SUMMARY_CHIP_LABEL: Record<SummaryKey, string> = {
+  included: "포함",
+  excluded: "제외",
+  sections: "섹션",
+  uncategorized: "미분류",
+};
+// in JSX:
+<span>{SUMMARY_CHIP_LABEL[key]}</span>
+```
+
+Preserve article `title` / `summary` / `source` / `feed_source` text — those come from external content.
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+npm run typecheck
+npm test -- MarketNewsBriefingSection PreopenPage
+```
+
+Expected: typecheck PASS. PreopenPage tests are updated in the next task.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/MarketNewsBriefingSection.tsx
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate MarketNewsBriefingSection (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: Translate PreopenPage
+
+**Files:**
+- Modify: `src/pages/PreopenPage.tsx`
+- Test: `src/__tests__/PreopenPage.test.tsx` (existing)
+
+This file is large (620 lines) and contains three local sub-components: `PreopenBriefingArtifactSection`, `PreopenQaEvaluatorPanel`, and `PreopenPaperApprovalBridgeSection`. Translate each in turn, then the main component.
+
+- [ ] **Step 1: Update imports and remove local label maps**
+
+Add imports:
+
+```tsx
+import {
+  ARTIFACT_READINESS_LABEL,
+  ARTIFACT_STATUS_LABEL,
+  COMMON,
+  PAPER_APPROVAL_CANDIDATE_STATUS_LABEL,
+  PAPER_APPROVAL_STATUS_LABEL,
+  QA_CHECK_STATUS_LABEL,
+  QA_CONFIDENCE_LABEL,
+  QA_GRADE_LABEL,
+  QA_SEVERITY_LABEL,
+  QA_STATUS_LABEL,
+  SAFETY_SCOPE_LABEL,
+  PURPOSE_LABEL,
+  VENUE_LABEL,
+} from "../i18n";
+import { labelOperatorToken, labelOrToken } from "../i18n/formatters";
+```
+
+Delete the local `QA_STATUS_LABEL` and `PAPER_APPROVAL_STATUS_LABEL` constants (use the imports). Replace the local `formatOperatorToken` helper with the imported `labelOperatorToken` (semantically identical: snake → spaced text + dash for null/empty).
+
+- [ ] **Step 2: Translate PreopenBriefingArtifactSection**
+
+| English | Korean |
+|--|--|
+| `aria-label="Preopen briefing artifact"` | `aria-label="장전 브리핑 산출물"` |
+| `<h2>Preopen briefing</h2>` | `<h2>장전 브리핑</h2>` |
+| `Artifact ${status}` | ``산출물 ${labelOrToken(ARTIFACT_STATUS_LABEL, artifact.status)}`` |
+| `News brief: ${artifact.news_summary}` | ``뉴스 요약: ${artifact.news_summary}`` |
+| `aria-label="Preopen artifact risk notes"` | `aria-label="장전 산출물 리스크 노트"` |
+
+For each readiness card, render `labelOrToken(ARTIFACT_READINESS_LABEL, item.status)` instead of raw `item.status`.
+
+For each section card, render `labelOrToken(ARTIFACT_STATUS_LABEL, section.status)` instead of raw `section.status`.
+
+- [ ] **Step 3: Translate PreopenQaEvaluatorPanel**
+
+| English | Korean |
+|--|--|
+| `aria-label="Preopen QA evaluator"` | `aria-label="장전 QA 평가"` |
+| `<h2>QA evaluator</h2>` | `<h2>QA 평가</h2>` |
+| `${qa.source} · ${qa.overall.grade} · confidence ${qa.overall.confidence}` | ``${qa.source} · ${labelOrToken(QA_GRADE_LABEL, qa.overall.grade)} · 신뢰도 ${labelOrToken(QA_CONFIDENCE_LABEL, qa.overall.confidence)}`` |
+| `QA ${status}` | ``QA ${labelOrToken(QA_STATUS_LABEL, qa.status)}`` |
+| `Overall score: ${X}` | ``전체 점수: ${X}`` |
+| `aria-label="QA blocking reasons"` | `aria-label="QA 차단 사유"` |
+| `aria-label="QA warnings"` | `aria-label="QA 경고"` |
+| Check status/severity (`${status} · ${severity}`) | ``${labelOrToken(QA_CHECK_STATUS_LABEL, check.status)} · ${labelOrToken(QA_SEVERITY_LABEL, check.severity)}`` |
+
+- [ ] **Step 4: Translate PreopenPaperApprovalBridgeSection**
+
+Translate the static safety note and chrome:
+
+| English | Korean |
+|--|--|
+| `aria-label="Paper approval preview"` | `aria-label="모의 승인 미리보기"` |
+| `<h2>Paper approval preview</h2>` | `<h2>모의 승인 미리보기</h2>` |
+| `${bridge.market_scope ?? "unknown market"}` | ``${bridge.market_scope ? bridge.market_scope.toUpperCase() : "시장 알 수 없음"}`` |
+| `${eligible_count} eligible / ${candidate_count} candidates` | ``${eligible_count}건 사용 가능 / ${candidate_count}건 후보`` |
+| `Preview ${statusLabel}` | ``미리보기 ${labelOrToken(PAPER_APPROVAL_STATUS_LABEL, bridge.status)}`` |
+| Safety note text | `Advisory-only preview. Execution is not allowed from this screen. Explicit operator approval is required before any Alpaca Paper submit; this card does not submit or cancel paper orders.` → `자문 전용 미리보기. 이 화면에서는 실행할 수 없습니다. Alpaca Paper 제출 전에는 명시적인 운영자 승인이 필요하며, 이 카드는 모의 주문을 제출하거나 취소하지 않습니다.` |
+| `aria-label="Paper approval blocking reasons"` | `aria-label="모의 승인 차단 사유"` |
+| `aria-label="Paper approval warnings"` | `aria-label="모의 승인 경고"` |
+
+For each candidate `<dl>`:
+
+| English | Korean |
+|--|--|
+| `<dt>Signal source</dt>` | `<dt>시그널 소스</dt>` |
+| `<dt>Execution venue</dt>` | `<dt>실행 거래소</dt>` |
+| `<dt>Asset class</dt>` | `<dt>자산 클래스</dt>` |
+| `<dt>Workflow</dt>` | `<dt>워크플로우</dt>` |
+| `Purpose: ${X}` | ``목적: ${labelOrToken(PURPOSE_LABEL, candidate.purpose)}`` |
+| `Preview payload: ${X}` | ``미리보기 페이로드: ${X}`` |
+| `${candidate.symbol} approval copy` (aria-label) | ``${candidate.symbol} 승인 안내`` |
+| `${candidate.symbol} paper approval warnings` (aria-label) | ``${candidate.symbol} 모의 승인 경고`` |
+| `No paper approval preview candidates are currently available.` | `현재 사용 가능한 모의 승인 미리보기 후보가 없습니다.` |
+
+Replace `formatVenueLabel` to use the central `VENUE_LABEL`:
+
+```tsx
+function formatVenueLabel(venue: string | null, symbol: string | null): string {
+  const venueLabel = venue
+    ? (VENUE_LABEL[venue] ?? labelOperatorToken(venue))
+    : COMMON.dash;
+  return [venueLabel, symbol].filter(Boolean).join(" ");
+}
+```
+
+Render candidate status with `labelOrToken(PAPER_APPROVAL_CANDIDATE_STATUS_LABEL, candidate.status)`.
+
+- [ ] **Step 5: Translate the main PreopenPage component**
+
+| English | Korean |
+|--|--|
+| `<h1>Preopen briefing</h1>` (both branches) | `<h1>장전 브리핑</h1>` |
+| `<strong>No preopen research run available</strong>` | `<strong>장전 리서치 실행이 없습니다</strong>` |
+| `Reason: ${X}` | ``사유: ${X}`` |
+| `Generated: ${formatDateTime(...)}` | ``생성 시각: ${formatDateTime(...)}`` |
+| `${data.market_scope.toUpperCase()}` | (keep — operator identifier) |
+| `Advisory ${used/not used}` | ``자문 ${data.advisory_used ? "사용" : "미사용"}`` |
+| `Advisory notice: ${X}` | ``자문 안내: ${X}`` |
+| `aria-label="Source warnings"` | `aria-label="소스 경고"` |
+| `<h2>Candidates (${N})</h2>` | ``<h2>후보 (${N})</h2>`` |
+| Candidates table headers | `Symbol` → `종목`, `Side` → `방향`, `Kind` → `종류`, `Confidence` → `신뢰도`, `Price` → `가격`, `Qty` → `수량`, `Rationale` → `근거` |
+| `<span>{c.side}</span>` | `<span>{labelOrderSide(c.side)}</span>` (import from `../i18n/formatters`) |
+| `<h2>Pending reconciliations (${N})</h2>` | ``<h2>대기 중인 조정 항목 (${N})</h2>`` |
+| Reconciliation table headers | `Symbol` → `종목`, `Classification` → `분류`, `NXT class` → `NXT 분류`, `Actionable` → `실행 가능`, `Gap %` → `괴리율`, `Summary` → `요약` |
+| `Yes` / `No` | `예` / `아니오` (use `labelYesNo` from `../i18n/formatters`) |
+| `<h2>Linked decision sessions</h2>` | `<h2>연결된 의사결정 세션</h2>` |
+| `Open session` | `세션 열기` |
+| `Confirm create decision session?` | `의사결정 세션을 생성할까요?` |
+| `Creating…` | `생성 중…` |
+| `Create decision session` (fallback if no `artifactCta.label`) | `의사결정 세션 생성` |
+| `Cancel` | `{COMMON.cancel}` |
+| `Failed to create decision session.` | `의사결정 세션 생성에 실패했습니다.` |
+| `Something went wrong. Try again.` (state.message default) | `{COMMON.somethingWentWrong}` |
+
+For the reconciliation classification cell, render `labelOrToken(RECONCILIATION_STATUS_LABEL, r.classification)` (import `RECONCILIATION_STATUS_LABEL`). For the NXT class cell, render `r.nxt_classification ? labelOrToken(NXT_CLASSIFICATION_LABEL, r.nxt_classification) : COMMON.dash`.
+
+For the candidate kind cell, render `labelOrToken(CANDIDATE_KIND_LABEL, c.candidate_kind)` (import `CANDIDATE_KIND_LABEL`).
+
+For confidence display, keep `${c.confidence}%` (numeric). For price, keep `${c.proposed_price} ${c.currency}` (numeric + ISO currency code).
+
+For `linked_sessions[i].status`, the backend status string is a known controlled vocabulary mirroring `SessionStatus`; render `labelOrToken(SESSION_STATUS_LABEL, s.status)` and import `SESSION_STATUS_LABEL`.
+
+- [ ] **Step 6: Update PreopenPage test assertions**
+
+In `src/__tests__/PreopenPage.test.tsx`, sweep English UI string assertions and replace with the Korean equivalents from Steps 2–5. Pay special attention to:
+- `"Preopen briefing"` → `"장전 브리핑"`
+- `"Candidates"` / `"Pending reconciliations"` headings → Korean
+- Side cell `"buy"` → `"매수"` if asserted directly (the test fixture decides what to render)
+- Paper approval preview status `"Available"` → `"사용 가능"`
+- QA `"Ready"` → `"준비 완료"`
+
+Do not change literal API token assertions in test fixtures (e.g. `paper_approval_bridge.status: "available"`).
+
+- [ ] **Step 7: Run tests and typecheck**
+
+```bash
+npm test -- PreopenPage
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pages/PreopenPage.tsx src/__tests__/PreopenPage.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate PreopenPage chrome and structured metadata (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: Translate CommitteeEvidenceArtifacts (and audit other Committee components)
+
+**Files:**
+- Modify: `src/components/CommitteeEvidenceArtifacts.tsx`
+- Audit (modify only if hardcoded English chrome found): `src/components/CommitteeExecutionPreview.tsx`, `CommitteeJournalPlaceholder.tsx`, `CommitteePortfolioApproval.tsx`, `CommitteeResearchDebate.tsx`, `CommitteeRiskReview.tsx`, `CommitteeTraderDraft.tsx`, `CommitteeWorkflowTransition.tsx`
+
+The committee components mostly render free-text payload fields (`summary`, `notes`, `rationale`) which we explicitly do NOT translate. Headings and field labels DO get translated.
+
+- [ ] **Step 1: Translate CommitteeEvidenceArtifacts headings**
+
+Edit `src/components/CommitteeEvidenceArtifacts.tsx`:
+
+| English | Korean |
+|--|--|
+| `<h3>Committee Evidence</h3>` | `<h3>위원회 근거</h3>` |
+| `<h4>Technical Analysis</h4>` | `<h4>기술적 분석</h4>` |
+| `<h4>News Analysis</h4>` | `<h4>뉴스 분석</h4>` |
+| `Confidence: ${X}%` | ``신뢰도: ${X}%`` |
+
+Also render the `evidence.on_chain_analysis` block (it is in the type but missing here today). Add an `<h4>온체인 분석</h4>` block paralleling the others; if `evidence.on_chain_analysis` is `null`, omit the block. (Verify: the `CommitteeEvidence` type has `on_chain_analysis: CommitteeAnalysisSub | null`.)
+
+- [ ] **Step 2: Audit other committee components**
+
+Open each file and grep for hardcoded English `<h1>` through `<h4>`, `<button>`, and aria-label literals:
+
+```bash
+grep -nE '"[A-Z][A-Za-z ]+"' src/components/Committee*.tsx
+```
+
+For each match that is user-visible UI chrome (not a payload key, type literal, or className), translate to Korean. If a file already renders only Korean or only payload data, leave it alone.
+
+Likely translations across these:
+
+- `CommitteeWorkflowTransition`: button labels like `"Start"`, `"Approve"`, `"Auto Approve"`, `"Submit"`, `"Block"` → contextual Korean.
+- `CommitteeRiskReview` headings/verdict labels.
+- `CommitteeTraderDraft` action labels (use existing `CommitteeTraderAction` enum mapping if convenient — or inline mapping).
+
+If a component file shows English-only chrome that requires more than a couple of swaps, isolate the translation to the headings and obvious button text only; do not refactor structure.
+
+- [ ] **Step 3: Run committee component tests**
+
+```bash
+npm test -- components/Committee
+npm run typecheck
+```
+
+Expected: PASS. If existing committee tests assert English headings, update those assertions to the Korean equivalents you used.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Committee*.tsx src/__tests__/components/Committee*.test.tsx
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate committee component chrome (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 17: Final verification and ko-KR conformance sweep
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+cd frontend/trading-decision
+npm test
+```
+
+Expected: PASS (no failures).
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run production build**
+
+```bash
+npm run build
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Search for residual English UI chrome**
+
+Run a sweep that surfaces any remaining English-looking strings in JSX text or aria-labels:
+
+```bash
+grep -RIn --include='*.tsx' -E '>[A-Z][a-zA-Z ]{2,}<' src/components src/pages | grep -v '\.test\.tsx' | grep -v '__tests__'
+grep -RIn --include='*.tsx' 'aria-label="[A-Z]' src/components src/pages | grep -v '\.test\.tsx' | grep -v '__tests__'
+```
+
+For each hit, decide:
+- It's UI chrome → translate inline (small additional commit if needed).
+- It's a test fixture / sample text / external content (article title, source name, URL) → leave alone.
+- It's an operator identifier (e.g. "KR", "US", "Alpaca Paper") → leave alone.
+
+If you find any chrome that still needs translating, fix it and commit:
+
+```bash
+git add -p
+git commit -m "$(cat <<'EOF'
+feat(trading-decision): translate residual UI chrome (ROB-111)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 5: Verify locale defaults still flow**
+
+```bash
+grep -RIn 'en-US' src/format src/components src/pages
+```
+
+Expected: zero matches except in tests that explicitly pass `"en-US"` to assert opt-in behavior.
+
+- [ ] **Step 6: Smoke-check the dev build in a browser**
+
+```bash
+npm run dev
+```
+
+In the browser, exercise the golden paths:
+1. `/` (Decision inbox) — verify Korean column headers, status filter, pagination.
+2. `/sessions/<uuid>` for a fixture session — verify proposal labels, response buttons (수락/수정/...), date format.
+3. `/preopen` — verify briefing chrome, QA panel, paper approval preview Korean labels, raw JSON tucked under `원본 데이터 보기`.
+
+Confirm:
+- Dates render as `2026. 5. 5. 오후 7:30` style (ko-KR `dateStyle: "medium"` + `timeStyle: "short"`).
+- Numbers render with comma grouping (`1,234,567`).
+- Status badges display Korean (`진행 중`, `종료`, `보관됨`, `대기`, `수락`, etc.).
+- Raw JSON is hidden behind `원본 데이터 보기` `<details>`.
+
+If any panel still shows raw English chrome, treat it as a Step 4 finding and patch.
+
+- [ ] **Step 7: Push branch and open the PR**
+
+```bash
+git push -u origin feature/ROB-111-trading-decision-korean-ui
+gh pr create --base main --title "feat(trading-decision): Korean UI + ko-KR locale (ROB-111)" --body "$(cat <<'EOF'
+## Summary
+- Adds `src/i18n/` Korean label/formatter layer (no runtime i18n dep).
+- Switches `formatDateTime` and `formatDecimal` defaults to `ko-KR`.
+- Translates static UI chrome, status/action/token labels, and structured metadata across SessionList, SessionDetail, Preopen, Proposal, Outcome, Reconciliation, Warning, News, MarketBrief, and Committee components.
+- Hides raw JSON payloads behind `원본 데이터 보기` when known structured fields can be displayed.
+
+## Scope (per ROB-111)
+- Display-only. No API/DB/scheduler/broker side effects.
+- Existing DB free-text (`notes`, `market_brief`'s arbitrary string values, `original_rationale`, `original_payload` free text, news titles) is **not** translated.
+- TradingAgents output language is **not** changed.
+
+## Test plan
+- [ ] `npm run typecheck` (frontend/trading-decision)
+- [ ] `npm test`
+- [ ] `npm run build`
+- [ ] Manual smoke: `/`, `/sessions/<uuid>`, `/preopen` — Korean labels, ko-KR formatting, raw JSON gated behind `원본 데이터 보기`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Acceptance Criteria Coverage
+
+| Criterion | Covered by |
+|--|--|
+| Korean static UI copy across list/detail/preopen and shared components | Tasks 3–16 |
+| Default date/number formatting uses `ko-KR` | Task 2 |
+| Raw enum/status/action tokens not shown directly when a Korean label is available | Tasks 1, 3, 5, 7, 11, 12, 15, 16 |
+| Known structured metadata (`market_brief`, safety scope, source profile, workflow) shown with Korean labels/descriptions | Tasks 1, 10, 15 |
+| Raw JSON gated behind `원본 데이터 보기` | Task 10 (`MarketBriefPanel`) |
+| Existing DB free-text values unchanged and not bulk translated | Operating Rules + Task 8/16 (translate UI chrome only) |
+| Existing tests updated and passing | Tasks 3–16 + Task 17 verification |
+| `npm run typecheck`, `npm test`, `npm run build` pass | Task 17 |
+| No broker/order/DB/scheduler/trading side effects | Operating Rules + display-only edits throughout |

--- a/frontend/trading-decision/src/__tests__/AnalyticsMatrix.test.tsx
+++ b/frontend/trading-decision/src/__tests__/AnalyticsMatrix.test.tsx
@@ -6,7 +6,7 @@ import { makeAnalyticsCell, makeAnalyticsResponse } from "../test/fixtures";
 describe("AnalyticsMatrix", () => {
   it("shows an empty state when no cells exist", () => {
     render(<AnalyticsMatrix data={makeAnalyticsResponse({ cells: [] })} />);
-    expect(screen.getByText(/no outcomes yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/아직 결과가 없습니다/)).toBeInTheDocument();
   });
 
   it("renders one cell for each (track, horizon) row from the response", () => {
@@ -27,7 +27,7 @@ describe("AnalyticsMatrix", () => {
       ],
     });
     render(<AnalyticsMatrix data={data} />);
-    expect(screen.getByRole("table", { name: /analytics/i })).toBeInTheDocument();
+    expect(screen.getByRole("table", { name: "결과 분석" })).toBeInTheDocument();
     expect(screen.getByText("1.5%")).toBeInTheDocument();
     expect(screen.getByText("-0.5%")).toBeInTheDocument();
     expect(screen.getAllByText(/n=/i).length).toBeGreaterThanOrEqual(2);

--- a/frontend/trading-decision/src/__tests__/ExecutionReviewPanel.test.tsx
+++ b/frontend/trading-decision/src/__tests__/ExecutionReviewPanel.test.tsx
@@ -16,15 +16,14 @@ describe("ExecutionReviewPanel", () => {
     render(<ExecutionReviewPanel review={makePreopenExecutionReview()} />);
 
     expect(
-      screen.getByRole("region", { name: /execution review/i }),
+      screen.getByRole("region", { name: "실행 리뷰" }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/advisory.*read[- ]only/i)).toBeInTheDocument();
-    expect(screen.getByText(/no live execution/i)).toBeInTheDocument();
-    // This text appears in guardrail and stage summary.
+    expect(screen.getByText(/자문 \/ 읽기 전용/)).toBeInTheDocument();
+    expect(screen.getByText(/실주문 실행 없음/)).toBeInTheDocument();
     expect(
-      screen.getAllByText(/requires later explicit operator approval/i).length,
+      screen.getAllByText(/명시적인 운영자 승인이 필요/).length,
     ).toBeGreaterThan(0);
-    expect(screen.getByText(/Execution disabled/i)).toBeInTheDocument();
+    expect(screen.getByText(/실행 비활성화/)).toBeInTheDocument();
   });
 
   it("renders all six stages with their statuses", () => {
@@ -38,26 +37,29 @@ describe("ExecutionReviewPanel", () => {
     ]) {
       expect(screen.getByText(label)).toBeInTheDocument();
     }
-    // "Approval required" appears as a stage label and inside basket lines.
-    expect(screen.getAllByText(/approval required/i).length).toBeGreaterThan(1);
-    // "Basket preview" appears multiple times (stage label and section header).
-    expect(screen.getAllByText(/basket preview/i).length).toBeGreaterThan(1);
+    // "Approval required" stage label (fixture) + "승인 필요" basket-line cell.
+    expect(screen.getByText(/approval required/i)).toBeInTheDocument();
+    expect(screen.getAllByText("승인 필요").length).toBeGreaterThan(0);
+    // "Basket preview" stage label (fixture) + "바스켓 미리보기" section header.
+    expect(screen.getAllByText(/basket preview/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("바스켓 미리보기").length).toBeGreaterThan(0);
 
-    expect(screen.getAllByText(/ready/i).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/unavailable/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText("준비 완료").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("미사용").length).toBeGreaterThan(0);
   });
 
   it("renders basket preview lines when present", () => {
     render(<ExecutionReviewPanel review={makePreopenExecutionReview()} />);
 
     expect(screen.getByText("005930")).toBeInTheDocument();
-    // side "buy" appears in multiple places; use getAll or be specific.
-    expect(screen.getAllByText(/buy/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/db_simulated/i)).toBeInTheDocument();
+    // side rendered as Korean "매수" in basket lines.
+    expect(screen.getAllByText("매수").length).toBeGreaterThan(0);
+    // account_mode rendered through EXECUTION_ACCOUNT_MODE_LABEL.
+    expect(screen.getByText(/DB 시뮬레이션/)).toBeInTheDocument();
     expect(screen.getByText("70000")).toBeInTheDocument();
     expect(screen.getByText("10")).toBeInTheDocument();
-    // Per-line guard rendered.
-    expect(screen.getAllByText(/approval required/i).length).toBeGreaterThan(0);
+    // Per-line guard rendered as Korean "승인 필요".
+    expect(screen.getAllByText("승인 필요").length).toBeGreaterThan(0);
   });
 
   it("hides basket preview block when basket is null and shows degraded copy", () => {

--- a/frontend/trading-decision/src/__tests__/LinkedActionsPanel.test.tsx
+++ b/frontend/trading-decision/src/__tests__/LinkedActionsPanel.test.tsx
@@ -35,7 +35,7 @@ describe("LinkedActionsPanel", () => {
   it("renders empty state", () => {
     render(<LinkedActionsPanel actions={[]} counterfactuals={[]} />);
 
-    expect(screen.getByText("No linked actions yet.")).toBeInTheDocument();
+    expect(screen.getByText("연결된 액션이 없습니다.")).toBeInTheDocument();
   });
 
   it("renders counterfactuals but no outcomes", () => {
@@ -46,7 +46,7 @@ describe("LinkedActionsPanel", () => {
       />,
     );
 
-    expect(screen.getByText("rejected_counterfactual")).toBeInTheDocument();
+    expect(screen.getByText("거절 대조")).toBeInTheDocument();
     expect(screen.queryByTestId("outcome-row")).not.toBeInTheDocument();
   });
 });

--- a/frontend/trading-decision/src/__tests__/NxtVenueBadge.test.tsx
+++ b/frontend/trading-decision/src/__tests__/NxtVenueBadge.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import NxtVenueBadge from "../components/NxtVenueBadge";
 
 describe("NxtVenueBadge", () => {
-  it("renders 'NXT actionable' for KR + actionable + nxt_eligible=true", () => {
+  it("renders 'NXT 실행 가능' for KR + actionable + nxt_eligible=true", () => {
     render(
       <NxtVenueBadge
         marketScope="kr"
@@ -11,10 +11,10 @@ describe("NxtVenueBadge", () => {
         nxtEligible={true}
       />,
     );
-    expect(screen.getByText("NXT actionable")).toBeInTheDocument();
+    expect(screen.getByText("NXT 실행 가능")).toBeInTheDocument();
   });
 
-  it("renders 'NXT not actionable' for too-far / ignore_for_nxt", () => {
+  it("renders 'NXT 실행 불가' for too-far / ignore_for_nxt", () => {
     render(
       <NxtVenueBadge
         marketScope="kr"
@@ -22,10 +22,10 @@ describe("NxtVenueBadge", () => {
         nxtEligible={true}
       />,
     );
-    expect(screen.getByText("NXT not actionable")).toBeInTheDocument();
+    expect(screen.getByText("NXT 실행 불가")).toBeInTheDocument();
   });
 
-  it("renders 'Non-NXT (KR broker)' when nxt_eligible=false", () => {
+  it("renders '비-NXT (국내 브로커)' when nxt_eligible=false", () => {
     render(
       <NxtVenueBadge
         marketScope="kr"
@@ -33,12 +33,12 @@ describe("NxtVenueBadge", () => {
         nxtEligible={false}
       />,
     );
-    const badge = screen.getByText("Non-NXT (KR broker)");
+    const badge = screen.getByText("비-NXT (국내 브로커)");
     expect(badge).toBeInTheDocument();
-    expect(badge).toHaveAccessibleName("NXT venue: Non-NXT (KR broker)");
+    expect(badge).toHaveAccessibleName("NXT 거래소: 비-NXT (국내 브로커)");
   });
 
-  it("renders 'NXT eligibility unknown' when nxt_eligible is null", () => {
+  it("renders 'NXT 자격 알 수 없음' when nxt_eligible is null", () => {
     render(
       <NxtVenueBadge
         marketScope="kr"
@@ -46,10 +46,10 @@ describe("NxtVenueBadge", () => {
         nxtEligible={null}
       />,
     );
-    expect(screen.getByText("NXT eligibility unknown")).toBeInTheDocument();
+    expect(screen.getByText("NXT 자격 알 수 없음")).toBeInTheDocument();
   });
 
-  it("renders 'NXT review needed' for data_mismatch_requires_review", () => {
+  it("renders 'NXT 검토 필요' for data_mismatch_requires_review", () => {
     render(
       <NxtVenueBadge
         marketScope="kr"
@@ -57,7 +57,7 @@ describe("NxtVenueBadge", () => {
         nxtEligible={true}
       />,
     );
-    expect(screen.getByText("NXT review needed")).toBeInTheDocument();
+    expect(screen.getByText("NXT 검토 필요")).toBeInTheDocument();
   });
 
   it("renders nothing for non-KR markets", () => {

--- a/frontend/trading-decision/src/__tests__/OperatorEventForm.test.tsx
+++ b/frontend/trading-decision/src/__tests__/OperatorEventForm.test.tsx
@@ -11,11 +11,11 @@ describe("OperatorEventForm", () => {
     );
 
     await userEvent.type(
-      screen.getByLabelText(/source text/i),
+      screen.getByLabelText(/소스 텍스트/),
       "  OpenAI earnings missed  ",
     );
     await userEvent.click(
-      screen.getByRole("button", { name: /add event/i }),
+      screen.getByRole("button", { name: /이벤트 추가/ }),
     );
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
@@ -38,12 +38,12 @@ describe("OperatorEventForm", () => {
     );
 
     await userEvent.click(
-      screen.getByRole("button", { name: /add event/i }),
+      screen.getByRole("button", { name: /이벤트 추가/ }),
     );
 
     expect(onSubmit).not.toHaveBeenCalled();
     expect(screen.getByRole("alert")).toHaveTextContent(
-      /source text is required/i,
+      /소스 텍스트는 필수입니다/,
     );
   });
 
@@ -53,13 +53,13 @@ describe("OperatorEventForm", () => {
       <OperatorEventForm sessionUuid="session-1" onSubmit={onSubmit} />,
     );
 
-    await userEvent.type(screen.getByLabelText(/source text/i), "msg");
+    await userEvent.type(screen.getByLabelText(/소스 텍스트/), "msg");
     await userEvent.type(
-      screen.getByLabelText(/affected symbols/i),
+      screen.getByLabelText(/영향 종목/),
       "MSFT, NVDA ,  AAPL",
     );
     await userEvent.click(
-      screen.getByRole("button", { name: /add event/i }),
+      screen.getByRole("button", { name: /이벤트 추가/ }),
     );
 
     expect(onSubmit).toHaveBeenCalledWith(
@@ -76,11 +76,11 @@ describe("OperatorEventForm", () => {
     );
 
     const textarea = screen.getByLabelText(
-      /source text/i,
+      /소스 텍스트/,
     ) as HTMLTextAreaElement;
     await userEvent.type(textarea, "abc");
     await userEvent.click(
-      screen.getByRole("button", { name: /add event/i }),
+      screen.getByRole("button", { name: /이벤트 추가/ }),
     );
 
     expect(textarea.value).toBe("");
@@ -97,11 +97,11 @@ describe("OperatorEventForm", () => {
     );
 
     const textarea = screen.getByLabelText(
-      /source text/i,
+      /소스 텍스트/,
     ) as HTMLTextAreaElement;
     await userEvent.type(textarea, "abc");
     await userEvent.click(
-      screen.getByRole("button", { name: /add event/i }),
+      screen.getByRole("button", { name: /이벤트 추가/ }),
     );
 
     expect(screen.getByRole("alert")).toHaveTextContent(/validation failed/i);
@@ -114,17 +114,17 @@ describe("OperatorEventForm", () => {
       <OperatorEventForm sessionUuid="session-1" onSubmit={onSubmit} />,
     );
 
-    await userEvent.type(screen.getByLabelText(/source text/i), "msg");
-    const severity = screen.getByLabelText(/severity/i) as HTMLInputElement;
+    await userEvent.type(screen.getByLabelText(/소스 텍스트/), "msg");
+    const severity = screen.getByLabelText(/심각도/) as HTMLInputElement;
     await userEvent.clear(severity);
     await userEvent.type(severity, "9");
     const confidence = screen.getByLabelText(
-      /confidence/i,
+      /신뢰도/,
     ) as HTMLInputElement;
     await userEvent.clear(confidence);
     await userEvent.type(confidence, "150");
     await userEvent.click(
-      screen.getByRole("button", { name: /add event/i }),
+      screen.getByRole("button", { name: /이벤트 추가/ }),
     );
 
     expect(onSubmit).toHaveBeenCalledWith(

--- a/frontend/trading-decision/src/__tests__/OutcomeMarkForm.test.tsx
+++ b/frontend/trading-decision/src/__tests__/OutcomeMarkForm.test.tsx
@@ -10,12 +10,12 @@ describe("OutcomeMarkForm", () => {
     render(<OutcomeMarkForm counterfactuals={[]} onSubmit={onSubmit} />);
 
     await userEvent.selectOptions(
-      screen.getByLabelText(/track/i),
-      "accepted_live",
+      screen.getByLabelText(/트랙/i),
+      "수락(실주문)",
     );
-    await userEvent.selectOptions(screen.getByLabelText(/horizon/i), "1h");
-    await userEvent.type(screen.getByLabelText(/price at mark/i), "100");
-    await userEvent.click(screen.getByRole("button", { name: /record mark/i }));
+    await userEvent.selectOptions(screen.getByLabelText(/기간/i), "1시간");
+    await userEvent.type(screen.getByLabelText(/마크 시점 가격/i), "100");
+    await userEvent.click(screen.getByRole("button", { name: /마크 기록/i }));
 
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -32,16 +32,16 @@ describe("OutcomeMarkForm", () => {
     render(<OutcomeMarkForm counterfactuals={[]} onSubmit={onSubmit} />);
 
     await userEvent.selectOptions(
-      screen.getByLabelText(/track/i),
-      "rejected_counterfactual",
+      screen.getByLabelText(/트랙/i),
+      "거절 대조",
     );
-    await userEvent.selectOptions(screen.getByLabelText(/horizon/i), "1h");
-    await userEvent.type(screen.getByLabelText(/price at mark/i), "100");
-    await userEvent.click(screen.getByRole("button", { name: /record mark/i }));
+    await userEvent.selectOptions(screen.getByLabelText(/기간/i), "1시간");
+    await userEvent.type(screen.getByLabelText(/마크 시점 가격/i), "100");
+    await userEvent.click(screen.getByRole("button", { name: /마크 기록/i }));
 
     expect(onSubmit).not.toHaveBeenCalled();
     expect(
-      screen.getByText(/counterfactual is required/i),
+      screen.getByText(/이 트랙에서는 대조군이 필요합니다/i),
     ).toBeInTheDocument();
   });
 
@@ -52,9 +52,9 @@ describe("OutcomeMarkForm", () => {
     });
     render(<OutcomeMarkForm counterfactuals={[cf]} onSubmit={vi.fn()} />);
     await userEvent.selectOptions(
-      screen.getByLabelText(/track/i),
-      "rejected_counterfactual",
+      screen.getByLabelText(/트랙/i),
+      "거절 대조",
     );
-    expect(screen.getByLabelText(/counterfactual/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/대조군/i)).toBeInTheDocument();
   });
 });

--- a/frontend/trading-decision/src/__tests__/OutcomesPanel.test.tsx
+++ b/frontend/trading-decision/src/__tests__/OutcomesPanel.test.tsx
@@ -6,7 +6,7 @@ import { makeOutcome } from "../test/fixtures";
 describe("OutcomesPanel", () => {
   it("shows an empty state when no outcomes are recorded", () => {
     render(<OutcomesPanel outcomes={[]} />);
-    expect(screen.getByText(/no outcome marks/i)).toBeInTheDocument();
+    expect(screen.getByText(/결과 마크가 없습니다/)).toBeInTheDocument();
   });
 
   it("renders pnl_pct in the cell for the matching track and horizon", () => {
@@ -26,7 +26,7 @@ describe("OutcomesPanel", () => {
     ];
     render(<OutcomesPanel outcomes={outcomes} />);
     expect(
-      screen.getByRole("table", { name: /outcome marks/i }),
+      screen.getByRole("table", { name: "결과 마크" }),
     ).toBeInTheDocument();
     expect(screen.getByText("2.5%")).toBeInTheDocument();
     expect(screen.getByText("-0.75%")).toBeInTheDocument();

--- a/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
@@ -33,11 +33,11 @@ describe("PreopenPage", () => {
 
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
-    expect(await screen.findByText(/No preopen research run available/i)).toBeInTheDocument();
-    expect(screen.getByRole("heading", { level: 1, name: /Preopen briefing/i })).toBeInTheDocument();
-    expect(screen.getAllByText(/no_open_preopen_run/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/Artifact unavailable/i)).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /create decision session/i })).toBeNull();
+    expect(await screen.findByText(/사용 가능한 장전 리서치 실행 결과가 없습니다/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: /장전 브리핑/i })).toBeInTheDocument();
+    expect(screen.getAllByText(/no open preopen run/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/산출물 미사용/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /의사결정 세션 생성/i })).toBeNull();
   });
 
   it("renders run summary, candidates, reconciliations from fixture", async () => {
@@ -50,12 +50,12 @@ describe("PreopenPage", () => {
 
     // Symbol appears in candidates table, reconciliations table, AND basket preview
     expect(await screen.findAllByText("005930")).toHaveLength(3);
-    expect(screen.getByText("near_fill")).toBeInTheDocument();
+    expect(screen.getByText("체결 임박")).toBeInTheDocument();
     expect(screen.getByText(/Morning scan/)).toBeInTheDocument();
-    expect(screen.getByRole("heading", { level: 1, name: /Preopen briefing/i })).toBeInTheDocument();
-    expect(screen.getByText(/Artifact ready/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: /장전 브리핑/i })).toBeInTheDocument();
+    expect(screen.getByText(/산출물 준비 완료/i)).toBeInTheDocument();
     expect(screen.getByText(/preopen_briefing v1/i)).toBeInTheDocument();
-    expect(screen.getByText(/News brief: 장전 핵심 뉴스/i)).toBeInTheDocument();
+    expect(screen.getByText(/뉴스 요약: 장전 핵심 뉴스/i)).toBeInTheDocument();
   });
 
   it("renders degraded briefing artifact without hiding ROB-75 market news", async () => {
@@ -76,10 +76,10 @@ describe("PreopenPage", () => {
 
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
-    expect(await screen.findByText(/Artifact degraded/i)).toBeInTheDocument();
-    expect(screen.getByText(/market_news_briefing_unavailable/i)).toBeInTheDocument();
+    expect(await screen.findByText(/산출물 주의/i)).toBeInTheDocument();
+    expect(screen.getByText(/market news briefing unavailable/i)).toBeInTheDocument();
     expect(
-      screen.getByRole("region", { name: /market news briefing/i }),
+      screen.getByRole("region", { name: /시장 뉴스 브리핑/i }),
     ).toBeInTheDocument();
   });
 
@@ -93,10 +93,10 @@ describe("PreopenPage", () => {
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
     expect(
-      await screen.findByRole("region", { name: /preopen qa evaluator/i }),
+      await screen.findByRole("region", { name: /장전 QA 평가기/i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/QA ready/i)).toBeInTheDocument();
-    expect(screen.getByText(/Overall score: 90/i)).toBeInTheDocument();
+    expect(screen.getByText(/QA 준비 완료/i)).toBeInTheDocument();
+    expect(screen.getByText(/종합 점수: 90/i)).toBeInTheDocument();
     expect(screen.getByText(/Actionability guardrail/i)).toBeInTheDocument();
     expect(screen.getByText(/execution remains disabled/i)).toBeInTheDocument();
   });
@@ -135,7 +135,7 @@ describe("PreopenPage", () => {
 
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
-    expect(await screen.findByText(/QA needs review/i)).toBeInTheDocument();
+    expect(await screen.findByText(/QA 검토 필요/i)).toBeInTheDocument();
     expect(screen.queryByText(/QA needs_review/i)).toBeNull();
     expect(
       screen.getAllByText(/News readiness needs review before relying on recommendations/i).length,
@@ -157,14 +157,14 @@ describe("PreopenPage", () => {
 
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
-    expect(await screen.findByText(/QA unavailable/i)).toBeInTheDocument();
+    expect(await screen.findByText(/QA 미사용/i)).toBeInTheDocument();
     expect(
       screen.getAllByText(/No open preopen research run is available/i).length,
     ).toBeGreaterThan(0);
     expect(screen.queryByText("no_open_preopen_run")).toBeNull();
   });
 
-  it("clicking Create decision session calls api with correct args and navigates", async () => {
+  it("clicking 의사결정 세션 생성 calls api with correct args and navigates", async () => {
     const user = userEvent.setup();
     const sessionUuid = "sess-aaaa-1111-2222-333333333333";
 
@@ -186,15 +186,16 @@ describe("PreopenPage", () => {
 
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
-    // Wait for page to load
-    expect(await screen.findByRole("button", { name: /create decision session/i })).toBeInTheDocument();
+    // Wait for page to load. Label "Create decision session" comes from makePreopenBriefingArtifact fixture.
+    const createBtn = await screen.findByRole("button", { name: /Create decision session/i });
+    expect(createBtn).toBeInTheDocument();
 
     // First click triggers confirm prompt
-    await user.click(screen.getByRole("button", { name: /create decision session/i }));
-    expect(screen.getByRole("button", { name: /confirm/i })).toBeInTheDocument();
+    await user.click(createBtn);
+    expect(screen.getByRole("button", { name: /의사결정 세션을 생성하시겠습니까/i })).toBeInTheDocument();
 
     // Second click (confirm) submits
-    await user.click(screen.getByRole("button", { name: /confirm/i }));
+    await user.click(screen.getByRole("button", { name: /의사결정 세션을 생성하시겠습니까/i }));
 
     await waitFor(() => {
       const postCall = calls.find((c) => c.method === "POST");
@@ -206,7 +207,7 @@ describe("PreopenPage", () => {
     });
   });
 
-  it("hides Create decision session when a linked session already exists", async () => {
+  it("hides 의사결정 세션 생성 when a linked session already exists", async () => {
     mockFetch({
       [PREOPEN_URL]: () =>
         new Response(
@@ -220,13 +221,13 @@ describe("PreopenPage", () => {
 
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
-    expect(await screen.findByRole("link", { name: /open session/i })).toBeInTheDocument();
+    expect(await screen.findByRole("link", { name: /세션 열기/i })).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /create decision session/i }),
+      screen.queryByRole("button", { name: /Create decision session/i }),
     ).toBeNull();
   });
 
-  it("renders Ready badge with source counts and a news preview link", async () => {
+  it("renders 정상 badge with source counts and a news preview link", async () => {
     mockFetch({
       [PREOPEN_URL]: () =>
         new Response(
@@ -247,16 +248,16 @@ describe("PreopenPage", () => {
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
     expect(await screen.findByTestId("news-readiness-section")).toBeInTheDocument();
-    expect(screen.getByText("Ready")).toBeInTheDocument();
+    expect(screen.getByText("정상")).toBeInTheDocument();
     expect(screen.getByText(/mk_stock: 12/)).toBeInTheDocument();
-    expect(screen.getByRole("heading", { name: /source coverage/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /소스 커버리지/i })).toBeInTheDocument();
     expect(screen.getByRole("cell", { name: "mk_stock" })).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /삼성전자 영업이익/ }),
     ).toHaveAttribute("href", "https://example.com/9001");
   });
 
-  it("renders Stale badge with explicit warning text", async () => {
+  it("renders 오래됨 badge with explicit warning text", async () => {
     mockFetch({
       [PREOPEN_URL]: () =>
         new Response(
@@ -270,13 +271,13 @@ describe("PreopenPage", () => {
 
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
-    expect(await screen.findByText("Stale")).toBeInTheDocument();
+    expect(await screen.findByText("오래됨")).toBeInTheDocument();
     expect(
-      screen.getByText(/News is older than 180 min/i),
+      screen.getByText(/뉴스가 180분 이상 경과했습니다/i),
     ).toBeInTheDocument();
   });
 
-  it("renders Unavailable badge when news section reports no data", async () => {
+  it("renders 미사용 badge when news section reports no data", async () => {
     mockFetch({
       [PREOPEN_URL]: () =>
         new Response(
@@ -291,13 +292,13 @@ describe("PreopenPage", () => {
 
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
-    expect(await screen.findByText("Unavailable")).toBeInTheDocument();
+    expect(await screen.findByText("미사용")).toBeInTheDocument();
     expect(
-      screen.getByText(/No recent articles to preview/i),
+      screen.getByText(/미리 볼 최근 기사가 없습니다/i),
     ).toBeInTheDocument();
   });
 
-  it("renders Unavailable badge with degraded message when news is null", async () => {
+  it("renders 미사용 badge with degraded message when news is null", async () => {
     mockFetch({
       [PREOPEN_URL]: () =>
         new Response(
@@ -312,9 +313,9 @@ describe("PreopenPage", () => {
 
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
-    expect(await screen.findByText("Unavailable")).toBeInTheDocument();
+    expect(await screen.findByText("미사용")).toBeInTheDocument();
     expect(
-      screen.getByText(/News readiness lookup failed/i),
+      screen.getByText(/뉴스 준비도 조회에 실패했습니다/i),
     ).toBeInTheDocument();
   });
 
@@ -333,12 +334,12 @@ describe("PreopenPage", () => {
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
     expect(
-      await screen.findByRole("region", { name: /market news briefing/i }),
+      await screen.findByRole("region", { name: /시장 뉴스 브리핑/i }),
     ).toBeInTheDocument();
     expect(screen.getByText(/Preopen headlines/i)).toBeInTheDocument();
-    expect(screen.getByText(/Filtered noise: 2/i)).toBeInTheDocument();
-    expect(screen.getByText(/Score 82/i)).toBeInTheDocument();
-    expect(screen.getByText(/Terms: AI, 반도체/i)).toBeInTheDocument();
+    expect(screen.getByText(/필터링된 노이즈: 2/i)).toBeInTheDocument();
+    expect(screen.getByText(/점수 82/i)).toBeInTheDocument();
+    expect(screen.getByText(/매칭 키워드: AI, 반도체/i)).toBeInTheDocument();
   });
 
   it("renders market news briefing fail-open state when field is null", async () => {
@@ -356,10 +357,10 @@ describe("PreopenPage", () => {
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
     expect(
-      await screen.findByRole("region", { name: /market news briefing/i }),
+      await screen.findByRole("region", { name: /시장 뉴스 브리핑/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/No market news briefing available yet/i),
+      screen.getByText(/아직 시장 뉴스 브리핑이 없습니다/i),
     ).toBeInTheDocument();
   });
 
@@ -379,24 +380,24 @@ describe("PreopenPage", () => {
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
     expect(
-      await screen.findByRole("region", { name: /paper approval preview/i }),
+      await screen.findByRole("region", { name: /모의 승인 프리뷰/i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Preview Available/i)).toBeInTheDocument();
-    expect(screen.getByText(/Advisory-only preview/i)).toBeInTheDocument();
+    expect(screen.getByText(/프리뷰 사용 가능/i)).toBeInTheDocument();
+    expect(screen.getByText(/자문 전용 프리뷰/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/Execution is not allowed from this screen/i),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Explicit operator approval is required before any Alpaca Paper submit/i),
+      screen.getByText(/이 화면에서 실행할 수 없습니다/i),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/does not submit or cancel paper orders/i),
+      screen.getByText(/Alpaca Paper 제출 전에 트레이더의 명시적 승인이 필요합니다/i),
     ).toBeInTheDocument();
-    expect(screen.getByText("Signal source")).toBeInTheDocument();
+    expect(
+      screen.getByText(/이 카드는 모의 주문을 제출하거나 취소하지 않습니다/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("시그널 소스")).toBeInTheDocument();
     expect(screen.getAllByText(/Upbit KRW-BTC/i).length).toBeGreaterThan(0);
-    expect(screen.getByText("Execution venue")).toBeInTheDocument();
+    expect(screen.getByText("실행 거래소")).toBeInTheDocument();
     expect(screen.getAllByText(/Alpaca Paper BTC\/USD/i).length).toBeGreaterThan(0);
-    expect(screen.getByText(/Preview payload: buy limit · \$10 @ 1.00 GTC/i)).toBeInTheDocument();
+    expect(screen.getByText(/프리뷰 페이로드: 매수 limit · \$10 @ 1.00 GTC/i)).toBeInTheDocument();
     expect(calls).toHaveLength(1);
     expect(calls[0]?.method).toBe("GET");
   });
@@ -416,12 +417,12 @@ describe("PreopenPage", () => {
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
     expect(
-      await screen.findByRole("region", { name: /paper approval preview/i }),
+      await screen.findByRole("region", { name: /모의 승인 프리뷰/i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Preview Blocked/i)).toBeInTheDocument();
+    expect(screen.getByText(/프리뷰 차단됨/i)).toBeInTheDocument();
     expect(screen.getByText(/qa evaluator unavailable/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/No paper approval preview candidates are currently available/i),
+      screen.getByText(/현재 사용 가능한 모의 승인 프리뷰 후보가 없습니다/i),
     ).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /submit|cancel paper|place order/i })).toBeNull();
     expect(calls).toHaveLength(1);
@@ -441,12 +442,12 @@ describe("PreopenPage", () => {
     });
 
     render(<PreopenPage />, { wrapper: MemoryRouter });
-    await screen.findByRole("button", { name: /create decision session/i });
+    const createBtn = await screen.findByRole("button", { name: /Create decision session/i });
 
     // First click → confirm
-    await user.click(screen.getByRole("button", { name: /create decision session/i }));
+    await user.click(createBtn);
     // Second click → submit
-    await user.click(screen.getByRole("button", { name: /confirm/i }));
+    await user.click(screen.getByRole("button", { name: /의사결정 세션을 생성하시겠습니까/i }));
 
     expect(
       await screen.findByText(/research_run_has_no_candidates/i),

--- a/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
@@ -186,8 +186,8 @@ describe("PreopenPage", () => {
 
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
-    // Wait for page to load. Label "Create decision session" comes from makePreopenBriefingArtifact fixture.
-    const createBtn = await screen.findByRole("button", { name: /Create decision session/i });
+    // Backend CTA labels may be English; the React chrome renders the localized label.
+    const createBtn = await screen.findByRole("button", { name: /의사결정 세션 생성/i });
     expect(createBtn).toBeInTheDocument();
 
     // First click triggers confirm prompt
@@ -223,7 +223,7 @@ describe("PreopenPage", () => {
 
     expect(await screen.findByRole("link", { name: /세션 열기/i })).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Create decision session/i }),
+      screen.queryByRole("button", { name: /의사결정 세션 생성/i }),
     ).toBeNull();
   });
 
@@ -448,7 +448,7 @@ describe("PreopenPage", () => {
     });
 
     render(<PreopenPage />, { wrapper: MemoryRouter });
-    const createBtn = await screen.findByRole("button", { name: /Create decision session/i });
+    const createBtn = await screen.findByRole("button", { name: /의사결정 세션 생성/i });
 
     // First click → confirm
     await user.click(createBtn);

--- a/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/PreopenPage.test.tsx
@@ -292,7 +292,10 @@ describe("PreopenPage", () => {
 
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
-    expect(await screen.findByText("미사용")).toBeInTheDocument();
+    const newsBadge = await screen.findByTestId("news-readiness-section");
+    expect(
+      newsBadge.querySelector('[data-status="unavailable"]'),
+    ).toHaveTextContent("미사용");
     expect(
       screen.getByText(/미리 볼 최근 기사가 없습니다/i),
     ).toBeInTheDocument();
@@ -313,7 +316,10 @@ describe("PreopenPage", () => {
 
     render(<PreopenPage />, { wrapper: MemoryRouter });
 
-    expect(await screen.findByText("미사용")).toBeInTheDocument();
+    const newsBadge = await screen.findByTestId("news-readiness-section");
+    expect(
+      newsBadge.querySelector('[data-status="unavailable"]'),
+    ).toHaveTextContent("미사용");
     expect(
       screen.getByText(/뉴스 준비도 조회에 실패했습니다/i),
     ).toBeInTheDocument();

--- a/frontend/trading-decision/src/__tests__/ProposalAdjustmentEditor.test.tsx
+++ b/frontend/trading-decision/src/__tests__/ProposalAdjustmentEditor.test.tsx
@@ -15,9 +15,9 @@ describe("ProposalAdjustmentEditor", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Quantity percent")).toBeInTheDocument();
-    expect(screen.getByLabelText("Price")).toBeInTheDocument();
-    expect(screen.queryByLabelText("Amount")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("수량 비율(%)")).toBeInTheDocument();
+    expect(screen.getByLabelText("가격")).toBeInTheDocument();
+    expect(screen.queryByLabelText("금액")).not.toBeInTheDocument();
   });
 
   it("uses original values as placeholders", () => {
@@ -30,7 +30,7 @@ describe("ProposalAdjustmentEditor", () => {
       />,
     );
 
-    expect(screen.getByLabelText("Quantity percent")).toHaveAttribute(
+    expect(screen.getByLabelText("수량 비율(%)")).toHaveAttribute(
       "placeholder",
       "20",
     );
@@ -47,11 +47,11 @@ describe("ProposalAdjustmentEditor", () => {
       />,
     );
 
-    await userEvent.click(screen.getByRole("button", { name: "Save modify" }));
+    await userEvent.click(screen.getByRole("button", { name: "수정 저장" }));
 
     expect(onSubmit).not.toHaveBeenCalled();
     expect(screen.getByRole("alert")).toHaveTextContent(
-      "Enter at least one adjusted numeric value.",
+      "조정된 숫자 값을 하나 이상 입력해 주세요.",
     );
   });
 
@@ -66,8 +66,8 @@ describe("ProposalAdjustmentEditor", () => {
       />,
     );
 
-    await userEvent.type(screen.getByLabelText("Quantity percent"), "10");
-    await userEvent.click(screen.getByRole("button", { name: "Save modify" }));
+    await userEvent.type(screen.getByLabelText("수량 비율(%)"), "10");
+    await userEvent.click(screen.getByRole("button", { name: "수정 저장" }));
 
     expect(onSubmit).toHaveBeenCalledWith({
       response: "modify",
@@ -89,12 +89,12 @@ describe("ProposalAdjustmentEditor", () => {
       />,
     );
 
-    await userEvent.type(screen.getByLabelText("Quantity percent"), "10");
-    await userEvent.click(screen.getByRole("button", { name: "Save modify" }));
+    await userEvent.type(screen.getByLabelText("수량 비율(%)"), "10");
+    await userEvent.click(screen.getByRole("button", { name: "수정 저장" }));
 
     expect(screen.getByRole("alert")).toHaveTextContent(
       "modify/partial_accept requires at least one user_* numeric field",
     );
-    expect(screen.getByLabelText("Quantity percent")).toBeInTheDocument();
+    expect(screen.getByLabelText("수량 비율(%)")).toBeInTheDocument();
   });
 });

--- a/frontend/trading-decision/src/__tests__/ProposalResponseControls.test.tsx
+++ b/frontend/trading-decision/src/__tests__/ProposalResponseControls.test.tsx
@@ -14,12 +14,12 @@ describe("ProposalResponseControls", () => {
       />,
     );
 
-    for (const name of ["Accept", "Partial accept", "Modify", "Defer", "Reject"]) {
+    for (const name of ["수락", "부분 수락", "수정", "보류", "거절"]) {
       expect(screen.getByRole("button", { name })).toBeInTheDocument();
     }
   });
 
-  it("clicking accept calls onSimpleResponse", async () => {
+  it("clicking 수락 calls onSimpleResponse", async () => {
     const onSimpleResponse = vi.fn();
     render(
       <ProposalResponseControls
@@ -30,12 +30,12 @@ describe("ProposalResponseControls", () => {
       />,
     );
 
-    await userEvent.click(screen.getByRole("button", { name: "Accept" }));
+    await userEvent.click(screen.getByRole("button", { name: "수락" }));
 
     expect(onSimpleResponse).toHaveBeenCalledWith("accept");
   });
 
-  it("clicking modify opens the adjustment editor", async () => {
+  it("clicking 수정 opens the adjustment editor", async () => {
     const onOpenAdjust = vi.fn();
     render(
       <ProposalResponseControls
@@ -46,7 +46,7 @@ describe("ProposalResponseControls", () => {
       />,
     );
 
-    await userEvent.click(screen.getByRole("button", { name: "Modify" }));
+    await userEvent.click(screen.getByRole("button", { name: "수정" }));
 
     expect(onOpenAdjust).toHaveBeenCalledWith("modify");
   });
@@ -61,7 +61,7 @@ describe("ProposalResponseControls", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: "Accept" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Modify" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "수락" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "수정" })).toBeDisabled();
   });
 });

--- a/frontend/trading-decision/src/__tests__/ProposalRow.test.tsx
+++ b/frontend/trading-decision/src/__tests__/ProposalRow.test.tsx
@@ -42,7 +42,7 @@ describe("ProposalRow", () => {
     );
 
     expect(screen.queryByText("0 KRW")).not.toBeInTheDocument();
-    expect(screen.getByText("Current quote estimate needed")).toBeInTheDocument();
+    expect(screen.getByText("현재 시세 추정이 필요합니다")).toBeInTheDocument();
   });
 
   it("explains that accepting records a decision only", () => {
@@ -55,9 +55,9 @@ describe("ProposalRow", () => {
     );
 
     expect(
-      screen.getByText(/Accept records this decision only/i),
+      screen.getByText(/수락은 결정만 기록합니다/i),
     ).toBeInTheDocument();
-    expect(screen.getByText(/does not send a live trade/i)).toBeInTheDocument();
+    expect(screen.getByText(/실주문을 전송하지 않습니다/i)).toBeInTheDocument();
   });
 
   it("renders crypto paper workflow provenance from approval copy", () => {
@@ -101,7 +101,7 @@ describe("ProposalRow", () => {
       />,
     );
 
-    expect(screen.getByText("Crypto paper workflow")).toBeInTheDocument();
+    expect(screen.getByText("암호화폐 모의 워크플로우")).toBeInTheDocument();
     expect(screen.getByText("Signal source: Upbit KRW-BTC")).toBeInTheDocument();
     expect(
       screen.getByText("Execution venue: Alpaca Paper BTC/USD"),
@@ -119,8 +119,8 @@ describe("ProposalRow", () => {
       />,
     );
 
-    expect(screen.getByText("Original")).toBeInTheDocument();
-    expect(screen.queryByText("Your decision")).not.toBeInTheDocument();
+    expect(screen.getByText("원본")).toBeInTheDocument();
+    expect(screen.queryByText("내 결정")).not.toBeInTheDocument();
   });
 
   it("accepted proposal shows decision and responded time", () => {
@@ -135,8 +135,8 @@ describe("ProposalRow", () => {
       />,
     );
 
-    expect(screen.getAllByText("accept").length).toBeGreaterThan(0);
-    expect(screen.getByText("Your decision")).toBeInTheDocument();
+    expect(screen.getAllByText("수락").length).toBeGreaterThan(0);
+    expect(screen.getByText("내 결정")).toBeInTheDocument();
   });
 
   it("shows original and adjusted values for modify", () => {
@@ -182,7 +182,7 @@ describe("ProposalRow", () => {
     );
 
     expect(
-      screen.getByRole("table", { name: /outcome marks/i }),
+      screen.getByRole("region", { name: /결과 마크/i }),
     ).toBeInTheDocument();
     expect(screen.getByText("2.5%")).toBeInTheDocument();
   });
@@ -204,9 +204,9 @@ describe("ProposalRow", () => {
       />,
     );
 
-    await userEvent.click(screen.getByText(/record outcome mark/i));
-    await userEvent.type(screen.getByLabelText(/price at mark/i), "100");
-    await userEvent.click(screen.getByRole("button", { name: /record mark/i }));
+    await userEvent.click(screen.getByText(/결과 마크 기록/i));
+    await userEvent.type(screen.getByLabelText(/마크 시점 가격/i), "100");
+    await userEvent.click(screen.getByRole("button", { name: /마크 기록/i }));
 
     expect(onRecordOutcome).toHaveBeenCalledWith(
       "proposal-btc",
@@ -234,8 +234,8 @@ describe("ProposalRow — reconciliation/NXT badges", () => {
         onRespond={vi.fn()}
       />,
     );
-    expect(screen.getByText("Near fill")).toBeInTheDocument();
-    expect(screen.getByText("NXT actionable")).toBeInTheDocument();
+    expect(screen.getByText("체결 임박")).toBeInTheDocument();
+    expect(screen.getByText("NXT 실행 가능")).toBeInTheDocument();
   });
 
   it("renders the Too far badge for too_far", () => {
@@ -252,8 +252,8 @@ describe("ProposalRow — reconciliation/NXT badges", () => {
         onRespond={vi.fn()}
       />,
     );
-    expect(screen.getByText("Too far")).toBeInTheDocument();
-    expect(screen.getByText("NXT not actionable")).toBeInTheDocument();
+    expect(screen.getByText("괴리 큼")).toBeInTheDocument();
+    expect(screen.getByText("NXT 실행 불가")).toBeInTheDocument();
   });
 
   it("marks kr_pending_non_nxt rows non-actionable and shows non_nxt_venue chip", () => {
@@ -273,14 +273,14 @@ describe("ProposalRow — reconciliation/NXT badges", () => {
         onRespond={vi.fn()}
       />,
     );
-    expect(screen.getByText("KR broker only")).toBeInTheDocument();
-    expect(screen.getByText("Non-NXT (KR broker)")).toBeInTheDocument();
-    expect(screen.getByText("Non-NXT venue")).toBeInTheDocument();
+    expect(screen.getByText("국내 브로커 전용")).toBeInTheDocument();
+    expect(screen.getByText("비-NXT (국내 브로커)")).toBeInTheDocument();
+    expect(screen.getByText("비-NXT 거래소")).toBeInTheDocument();
     expect(screen.getByRole("alert")).toHaveTextContent(
-      /Non-NXT pending order/,
+      /비-NXT 대기 주문/,
     );
     expect(
-      screen.queryByText(/Accept records this decision only/i),
+      screen.queryByText(/수락은 결정만 기록합니다/i),
     ).not.toBeInTheDocument();
   });
 
@@ -301,9 +301,9 @@ describe("ProposalRow — reconciliation/NXT badges", () => {
         onRespond={vi.fn()}
       />,
     );
-    expect(screen.getByText("NXT review needed")).toBeInTheDocument();
+    expect(screen.getByText("NXT 검토 필요")).toBeInTheDocument();
     expect(
-      screen.getByText("KR universe row missing"),
+      screen.getByText("국내 유니버스 누락"),
     ).toBeInTheDocument();
   });
 
@@ -324,7 +324,7 @@ describe("ProposalRow — reconciliation/NXT badges", () => {
       />,
     );
     expect(
-      screen.queryByText(/Non-NXT pending order/),
+      screen.queryByText(/비-NXT 대기 주문/),
     ).not.toBeInTheDocument();
   });
 });

--- a/frontend/trading-decision/src/__tests__/ReconciliationBadge.test.tsx
+++ b/frontend/trading-decision/src/__tests__/ReconciliationBadge.test.tsx
@@ -5,14 +5,14 @@ import ReconciliationBadge from "../components/ReconciliationBadge";
 describe("ReconciliationBadge", () => {
   it("renders a label for each known classification", () => {
     const cases: Array<[string, string]> = [
-      ["maintain", "Maintain"],
-      ["near_fill", "Near fill"],
-      ["too_far", "Too far"],
-      ["chasing_risk", "Chasing risk"],
-      ["data_mismatch", "Data mismatch"],
-      ["kr_pending_non_nxt", "KR broker only"],
-      ["unknown_venue", "Unknown venue"],
-      ["unknown", "Unknown"],
+      ["maintain", "유지"],
+      ["near_fill", "체결 임박"],
+      ["too_far", "괴리 큼"],
+      ["chasing_risk", "추격 위험"],
+      ["data_mismatch", "데이터 불일치"],
+      ["kr_pending_non_nxt", "국내 브로커 전용"],
+      ["unknown_venue", "거래소 알 수 없음"],
+      ["unknown", "알 수 없음"],
     ];
     for (const [value, label] of cases) {
       const { unmount } = render(
@@ -34,7 +34,7 @@ describe("ReconciliationBadge", () => {
   it("renders an aria-label for accessibility", () => {
     render(<ReconciliationBadge value="too_far" />);
     expect(
-      screen.getByLabelText("Reconciliation status: Too far"),
+      screen.getByLabelText("조정 상태: 괴리 큼"),
     ).toBeInTheDocument();
   });
 });

--- a/frontend/trading-decision/src/__tests__/ReconciliationDecisionSupportPanel.test.tsx
+++ b/frontend/trading-decision/src/__tests__/ReconciliationDecisionSupportPanel.test.tsx
@@ -14,16 +14,16 @@ describe("ReconciliationDecisionSupportPanel", () => {
       />,
     );
 
-    expect(screen.getByText(/Gap to current/)).toBeInTheDocument();
+    expect(screen.getByText(/현재가 대비 괴리/)).toBeInTheDocument();
     expect(screen.getByText("+0.29%")).toBeInTheDocument();
-    expect(screen.getByText(/Distance to fill/)).toBeInTheDocument();
+    expect(screen.getByText(/체결까지 거리/)).toBeInTheDocument();
     expect(screen.getByText("-0.29%")).toBeInTheDocument();
-    expect(screen.getByText(/Nearest support/)).toBeInTheDocument();
+    expect(screen.getByText(/가까운 지지선/)).toBeInTheDocument();
     expect(screen.getByText(/69,500/)).toBeInTheDocument();
-    expect(screen.getByText(/Nearest resistance/)).toBeInTheDocument();
-    expect(screen.getByText(/Live quote/)).toBeInTheDocument();
+    expect(screen.getByText(/가까운 저항선/)).toBeInTheDocument();
+    expect(screen.getByText(/실시간 시세/)).toBeInTheDocument();
     expect(screen.getByText(/70,200/)).toBeInTheDocument();
-    expect(screen.getByText(/Pending order/)).toBeInTheDocument();
+    expect(screen.getByText(/대기 주문/)).toBeInTheDocument();
     expect(screen.getByText(/ORD-1/)).toBeInTheDocument();
   });
 

--- a/frontend/trading-decision/src/__tests__/SessionDetailPage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/SessionDetailPage.test.tsx
@@ -53,6 +53,44 @@ describe("SessionDetailPage", () => {
     expect(screen.getByText(/국내 브로커 전용: 1/)).toBeInTheDocument();
   });
 
+  it("renders structured workflow market brief fields with Korean labels", async () => {
+    mockFetch({
+      "/trading/api/decisions/session-1": () =>
+        new Response(
+          JSON.stringify(
+            makeSessionDetail({
+              notes: null,
+              market_brief: {
+                title: "BTC paper preview via Upbit signal plus Alpaca Paper execution",
+                safety_scope: "preview_only_confirm_false_no_broker_submit",
+                purpose: "paper_plumbing_smoke",
+                signal_venue: "Upbit",
+                signal_symbol: "KRW-BTC",
+                execution_venue: "Alpaca Paper",
+                execution_symbol: "BTC/USD",
+                created_from_prompt: "BTC paper preview 만들어줘",
+              },
+            }),
+          ),
+        ),
+      "/trading/api/decisions/session-1/analytics": () =>
+        new Response(JSON.stringify(makeAnalyticsResponse())),
+    });
+
+    renderDetail();
+
+    expect(await screen.findByText("시장 브리핑")).toBeInTheDocument();
+    expect(screen.getByText(/브리핑 유형:/)).toBeInTheDocument();
+    expect(screen.getByText(/페이퍼 배관 점검/)).toBeInTheDocument();
+    expect(screen.getByText(/안전 범위:/)).toBeInTheDocument();
+    expect(screen.getByText(/브로커 제출 없는 preview 전용/)).toBeInTheDocument();
+    expect(screen.getByText(/신호 기준:/)).toBeInTheDocument();
+    expect(screen.getAllByText(/KRW-BTC/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/실행 대상:/)).toBeInTheDocument();
+    expect(screen.getAllByText(/BTC\/USD/).length).toBeGreaterThan(0);
+    expect(screen.getByText("원본 데이터 보기")).toBeInTheDocument();
+  });
+
   it("successful respond refetches and updates row", async () => {
     let detailCalls = 0;
     mockFetch({

--- a/frontend/trading-decision/src/__tests__/SessionDetailPage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/SessionDetailPage.test.tsx
@@ -40,17 +40,17 @@ describe("SessionDetailPage", () => {
 
     renderDetail();
 
-    expect(await screen.findByText("Market brief")).toBeInTheDocument();
+    expect(await screen.findByText("시장 브리핑")).toBeInTheDocument();
     expect(screen.getByText("BTC")).toBeInTheDocument();
     expect(screen.getByText("ETH")).toBeInTheDocument();
     expect(screen.getByText("SOL")).toBeInTheDocument();
-    expect(await screen.findByText("Outcome analytics")).toBeInTheDocument();
+    expect(await screen.findByText("결과 분석")).toBeInTheDocument();
     expect(screen.getByText("1.25%")).toBeInTheDocument();
-    expect(screen.getByText(/Research run/)).toBeInTheDocument();
-    expect(screen.getByText(/Reconciliation summary/)).toBeInTheDocument();
-    expect(screen.getByText(/Maintain: 1/)).toBeInTheDocument();
-    expect(screen.getByText(/Near fill: 1/)).toBeInTheDocument();
-    expect(screen.getByText(/KR broker only: 1/)).toBeInTheDocument();
+    expect(screen.getByText(/리서치 실행/)).toBeInTheDocument();
+    expect(screen.getByText(/조정 요약/)).toBeInTheDocument();
+    expect(screen.getByText(/유지: 1/)).toBeInTheDocument();
+    expect(screen.getByText(/체결 임박: 1/)).toBeInTheDocument();
+    expect(screen.getByText(/국내 브로커 전용: 1/)).toBeInTheDocument();
   });
 
   it("successful respond refetches and updates row", async () => {
@@ -77,9 +77,9 @@ describe("SessionDetailPage", () => {
 
     renderDetail();
     await screen.findByText("BTC");
-    await userEvent.click(screen.getByRole("button", { name: "Accept" }));
+    await userEvent.click(screen.getByRole("button", { name: "수락" }));
 
-    await waitFor(() => expect(screen.getAllByText("accept").length).toBeGreaterThan(0));
+    await waitFor(() => expect(screen.getAllByText("수락").length).toBeGreaterThan(0));
   });
 
   it("renders not found on 404", async () => {
@@ -96,7 +96,7 @@ describe("SessionDetailPage", () => {
 
     renderDetail();
 
-    expect(await screen.findByText("Session not found")).toBeInTheDocument();
+    expect(await screen.findByText("세션을 찾을 수 없습니다")).toBeInTheDocument();
   });
 
   it("shows archived banner on 409 respond", async () => {
@@ -118,10 +118,10 @@ describe("SessionDetailPage", () => {
 
     renderDetail();
     await screen.findByText("BTC");
-    await userEvent.click(screen.getByRole("button", { name: "Accept" }));
+    await userEvent.click(screen.getByRole("button", { name: "수락" }));
 
     expect(
-      await screen.findByText("Session is archived. You can no longer respond."),
+      await screen.findByText("세션이 보관되었습니다. 더 이상 응답할 수 없습니다."),
     ).toBeInTheDocument();
   });
 
@@ -149,7 +149,7 @@ describe("SessionDetailPage", () => {
 
     renderDetail();
 
-    expect(await screen.findByText("Strategy events")).toBeInTheDocument();
+    expect(await screen.findByText("전략 이벤트")).toBeInTheDocument();
     expect(await screen.findByText(/fed hike confirmed/i)).toBeInTheDocument();
     expect(screen.getByText("TSLA")).toBeInTheDocument();
     expect(screen.getByText(/operator_market_event/i)).toBeInTheDocument();

--- a/frontend/trading-decision/src/__tests__/SessionDetailPage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/SessionDetailPage.test.tsx
@@ -152,7 +152,7 @@ describe("SessionDetailPage", () => {
     expect(await screen.findByText("전략 이벤트")).toBeInTheDocument();
     expect(await screen.findByText(/fed hike confirmed/i)).toBeInTheDocument();
     expect(screen.getByText("TSLA")).toBeInTheDocument();
-    expect(screen.getByText(/operator_market_event/i)).toBeInTheDocument();
+    expect(screen.getByText("운영자 시장 이벤트")).toBeInTheDocument();
   });
 
   it("renders an empty state when there are no strategy events", async () => {
@@ -173,7 +173,7 @@ describe("SessionDetailPage", () => {
     renderDetail();
 
     expect(
-      await screen.findByText(/no strategy events yet/i),
+      await screen.findByText(/전략 이벤트가 없습니다/),
     ).toBeInTheDocument();
   });
 
@@ -227,18 +227,18 @@ describe("SessionDetailPage", () => {
 
     renderDetail();
 
-    await screen.findByText(/no strategy events yet/i);
+    await screen.findByText(/전략 이벤트가 없습니다/);
 
     await userEvent.type(
-      screen.getByLabelText(/source text/i),
+      screen.getByLabelText(/소스 텍스트/),
       "OpenAI earnings missed",
     );
     await userEvent.type(
-      screen.getByLabelText(/affected symbols/i),
+      screen.getByLabelText(/영향 종목/),
       "MSFT",
     );
     await userEvent.click(
-      screen.getByRole("button", { name: /add event/i }),
+      screen.getByRole("button", { name: /이벤트 추가/ }),
     );
 
     await waitFor(() => expect(recorded.length).toBe(1));
@@ -280,10 +280,10 @@ describe("SessionDetailPage", () => {
 
     renderDetail();
 
-    await screen.findByText(/no strategy events yet/i);
-    await userEvent.type(screen.getByLabelText(/source text/i), "msg");
+    await screen.findByText(/전략 이벤트가 없습니다/);
+    await userEvent.type(screen.getByLabelText(/소스 텍스트/), "msg");
     await userEvent.click(
-      screen.getByRole("button", { name: /add event/i }),
+      screen.getByRole("button", { name: /이벤트 추가/ }),
     );
 
     expect(

--- a/frontend/trading-decision/src/__tests__/SessionListPage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/SessionListPage.test.tsx
@@ -17,7 +17,7 @@ describe("SessionListPage", () => {
 
     render(<SessionListPage />, { wrapper: MemoryRouter });
 
-    expect(await screen.findByText("No decision sessions yet.")).toBeInTheDocument();
+    expect(await screen.findByText("아직 의사결정 세션이 없습니다.")).toBeInTheDocument();
   });
 
   it("shows session rows with proposal counters", async () => {
@@ -42,7 +42,7 @@ describe("SessionListPage", () => {
     render(<SessionListPage />, { wrapper: MemoryRouter });
     await screen.findByText("Momentum rebalance");
 
-    await userEvent.selectOptions(screen.getByLabelText("Status filter"), "open");
+    await userEvent.selectOptions(screen.getByLabelText("상태 필터"), "open");
 
     await waitFor(() => expect(calls.length).toBeGreaterThan(1));
   });

--- a/frontend/trading-decision/src/__tests__/StrategyEventTimeline.test.tsx
+++ b/frontend/trading-decision/src/__tests__/StrategyEventTimeline.test.tsx
@@ -7,7 +7,7 @@ describe("StrategyEventTimeline", () => {
   it("renders an empty state when there are no events", () => {
     render(<StrategyEventTimeline events={[]} />);
     expect(
-      screen.getByText(/no strategy events yet/i),
+      screen.getByText(/전략 이벤트가 없습니다/),
     ).toBeInTheDocument();
   });
 
@@ -26,11 +26,11 @@ describe("StrategyEventTimeline", () => {
     render(<StrategyEventTimeline events={[event]} />);
 
     expect(
-      screen.getByText(/operator_market_event/i),
+      screen.getByText("운영자 시장 이벤트"),
     ).toBeInTheDocument();
     expect(screen.getByText(/openai earnings miss/i)).toBeInTheDocument();
-    expect(screen.getByText(/severity\s*4/i)).toBeInTheDocument();
-    expect(screen.getByText(/confidence\s*75/i)).toBeInTheDocument();
+    expect(screen.getByText(/심각도\s*4/)).toBeInTheDocument();
+    expect(screen.getByText(/신뢰도\s*75/)).toBeInTheDocument();
     expect(screen.getByText("MSFT")).toBeInTheDocument();
     expect(screen.getByText("NVDA")).toBeInTheDocument();
     expect(screen.getByText(/us/)).toBeInTheDocument();

--- a/frontend/trading-decision/src/__tests__/WarningChips.test.tsx
+++ b/frontend/trading-decision/src/__tests__/WarningChips.test.tsx
@@ -18,21 +18,19 @@ describe("WarningChips", () => {
         ]}
       />,
     );
-    expect(screen.getByText("Quote missing")).toBeInTheDocument();
-    expect(screen.getByText("Quote stale")).toBeInTheDocument();
-    expect(screen.getByText("Orderbook missing")).toBeInTheDocument();
-    expect(
-      screen.getByText("Support / resistance unavailable"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("KR universe row missing")).toBeInTheDocument();
-    expect(screen.getByText("Non-NXT venue")).toBeInTheDocument();
-    expect(screen.getByText("Unknown venue")).toBeInTheDocument();
-    expect(screen.getByText("Unknown side")).toBeInTheDocument();
+    expect(screen.getByText("시세 누락")).toBeInTheDocument();
+    expect(screen.getByText("시세 오래됨")).toBeInTheDocument();
+    expect(screen.getByText("호가 누락")).toBeInTheDocument();
+    expect(screen.getByText("지지/저항선 미사용")).toBeInTheDocument();
+    expect(screen.getByText("국내 유니버스 누락")).toBeInTheDocument();
+    expect(screen.getByText("비-NXT 거래소")).toBeInTheDocument();
+    expect(screen.getByText("거래소 알 수 없음")).toBeInTheDocument();
+    expect(screen.getByText("방향 알 수 없음")).toBeInTheDocument();
   });
 
-  it("renders unknown-but-allowlist-shaped tokens verbatim as text", () => {
+  it("renders unknown-but-allowlist-shaped tokens verbatim as text (with underscore replacement)", () => {
     render(<WarningChips tokens={["custom_warning_token"]} />);
-    expect(screen.getByText("custom_warning_token")).toBeInTheDocument();
+    expect(screen.getByText("custom warning token")).toBeInTheDocument();
   });
 
   it("ignores tokens that fail the allowlist", () => {

--- a/frontend/trading-decision/src/__tests__/components/CommitteeEvidenceArtifacts.test.tsx
+++ b/frontend/trading-decision/src/__tests__/components/CommitteeEvidenceArtifacts.test.tsx
@@ -21,11 +21,11 @@ describe("CommitteeEvidenceArtifacts", () => {
 
     render(<CommitteeEvidenceArtifacts artifacts={artifacts} />);
 
-    expect(screen.getByText("Committee Evidence")).toBeInTheDocument();
+    expect(screen.getByText("위원회 근거 자료")).toBeInTheDocument();
     expect(screen.getByText("Bullish trend")).toBeInTheDocument();
-    expect(screen.getByText("Confidence: 80%")).toBeInTheDocument();
+    expect(screen.getByText("신뢰도: 80%")).toBeInTheDocument();
     expect(screen.getByText("Positive earnings")).toBeInTheDocument();
-    expect(screen.getByText("Confidence: 90%")).toBeInTheDocument();
+    expect(screen.getByText("신뢰도: 90%")).toBeInTheDocument();
   });
 
   it("renders nothing if evidence is missing", () => {

--- a/frontend/trading-decision/src/__tests__/components/CommitteeExecutionPreview.test.tsx
+++ b/frontend/trading-decision/src/__tests__/components/CommitteeExecutionPreview.test.tsx
@@ -13,8 +13,8 @@ describe("CommitteeExecutionPreview", () => {
 
     render(<CommitteeExecutionPreview executionPreview={preview} />);
 
-    expect(screen.getByText("Execution Preview")).toBeInTheDocument();
-    expect(screen.getByText(/BLOCKED:/)).toBeInTheDocument();
+    expect(screen.getByText("실행 프리뷰")).toBeInTheDocument();
+    expect(screen.getByText(/차단됨:/)).toBeInTheDocument();
     expect(screen.getByText("Insufficient balance")).toBeInTheDocument();
   });
 

--- a/frontend/trading-decision/src/__tests__/components/CommitteeJournalPlaceholder.test.tsx
+++ b/frontend/trading-decision/src/__tests__/components/CommitteeJournalPlaceholder.test.tsx
@@ -12,7 +12,7 @@ describe("CommitteeJournalPlaceholder", () => {
 
     render(<CommitteeJournalPlaceholder journalPlaceholder={journal} />);
 
-    expect(screen.getByText("Journal / Retrospective")).toBeInTheDocument();
+    expect(screen.getByText("기록 / 사후 검토")).toBeInTheDocument();
     expect(
       screen.getByText("11111111-1111-4111-8111-111111111111"),
     ).toBeInTheDocument();

--- a/frontend/trading-decision/src/__tests__/components/CommitteePortfolioApproval.test.tsx
+++ b/frontend/trading-decision/src/__tests__/components/CommitteePortfolioApproval.test.tsx
@@ -13,8 +13,8 @@ describe("CommitteePortfolioApproval", () => {
 
     render(<CommitteePortfolioApproval portfolioApproval={portfolioApproval} />);
 
-    expect(screen.getByText("Portfolio Approval")).toBeInTheDocument();
-    expect(screen.getByText("APPROVED")).toBeInTheDocument();
+    expect(screen.getByText("포트폴리오 승인")).toBeInTheDocument();
+    expect(screen.getByText("승인됨")).toBeInTheDocument();
     expect(screen.getByText("Portfolio weight adjusted")).toBeInTheDocument();
   });
 

--- a/frontend/trading-decision/src/__tests__/components/CommitteeResearchDebate.test.tsx
+++ b/frontend/trading-decision/src/__tests__/components/CommitteeResearchDebate.test.tsx
@@ -18,8 +18,8 @@ describe("CommitteeResearchDebate", () => {
     render(<CommitteeResearchDebate researchDebate={debate} />);
 
     expect(screen.getByText("리서치 토론")).toBeInTheDocument();
-    expect(screen.getByText("상승(Bull) 근거")).toBeInTheDocument();
-    expect(screen.getByText("하락(Bear) 근거")).toBeInTheDocument();
+    expect(screen.getByText("상승 근거")).toBeInTheDocument();
+    expect(screen.getByText("하락 근거")).toBeInTheDocument();
     expect(screen.getByText("Support bounce")).toBeInTheDocument();
     expect(screen.getByText("RSI overbought")).toBeInTheDocument();
     expect(screen.getByText("1 bull / 1 bear")).toBeInTheDocument();

--- a/frontend/trading-decision/src/__tests__/components/CommitteeResearchDebate.test.tsx
+++ b/frontend/trading-decision/src/__tests__/components/CommitteeResearchDebate.test.tsx
@@ -17,9 +17,9 @@ describe("CommitteeResearchDebate", () => {
 
     render(<CommitteeResearchDebate researchDebate={debate} />);
 
-    expect(screen.getByText("Research Debate")).toBeInTheDocument();
-    expect(screen.getByText("Bull case")).toBeInTheDocument();
-    expect(screen.getByText("Bear case")).toBeInTheDocument();
+    expect(screen.getByText("리서치 토론")).toBeInTheDocument();
+    expect(screen.getByText("상승(Bull) 근거")).toBeInTheDocument();
+    expect(screen.getByText("하락(Bear) 근거")).toBeInTheDocument();
     expect(screen.getByText("Support bounce")).toBeInTheDocument();
     expect(screen.getByText("RSI overbought")).toBeInTheDocument();
     expect(screen.getByText("1 bull / 1 bear")).toBeInTheDocument();
@@ -34,8 +34,8 @@ describe("CommitteeResearchDebate", () => {
 
     render(<CommitteeResearchDebate researchDebate={debate} />);
 
-    expect(screen.getByText("No bull-case claims yet.")).toBeInTheDocument();
-    expect(screen.getByText("No bear-case claims yet.")).toBeInTheDocument();
+    expect(screen.getByText("아직 상승 근거가 없습니다.")).toBeInTheDocument();
+    expect(screen.getByText("아직 하락 근거가 없습니다.")).toBeInTheDocument();
   });
 
   it("renders nothing when debate is null", () => {

--- a/frontend/trading-decision/src/__tests__/components/CommitteeRiskReview.test.tsx
+++ b/frontend/trading-decision/src/__tests__/components/CommitteeRiskReview.test.tsx
@@ -13,8 +13,8 @@ describe("CommitteeRiskReview", () => {
 
     render(<CommitteeRiskReview riskReview={riskReview} />);
 
-    expect(screen.getByText("Risk Review")).toBeInTheDocument();
-    expect(screen.getByText("APPROVED")).toBeInTheDocument();
+    expect(screen.getByText("리스크 리뷰")).toBeInTheDocument();
+    expect(screen.getByText("승인됨")).toBeInTheDocument();
     expect(screen.getByText("All checks passed")).toBeInTheDocument();
   });
 

--- a/frontend/trading-decision/src/__tests__/components/CommitteeTraderDraft.test.tsx
+++ b/frontend/trading-decision/src/__tests__/components/CommitteeTraderDraft.test.tsx
@@ -21,8 +21,8 @@ describe("CommitteeTraderDraft", () => {
 
     render(<CommitteeTraderDraft traderDraft={drafts} />);
 
-    expect(screen.getByText("Trader Draft")).toBeInTheDocument();
-    expect(screen.getByText("BUY")).toBeInTheDocument();
+    expect(screen.getByText("트레이더 초안")).toBeInTheDocument();
+    expect(screen.getByText("매수")).toBeInTheDocument();
     expect(screen.getByText("AAPL")).toBeInTheDocument();
     expect(screen.getByText("limit @ 180.00")).toBeInTheDocument();
     expect(screen.getByText("close below 175")).toBeInTheDocument();
@@ -46,7 +46,7 @@ describe("CommitteeTraderDraft", () => {
     render(<CommitteeTraderDraft traderDraft={drafts} />);
 
     expect(
-      screen.getByText(/no live order is created/i),
+      screen.getByText(/실주문이 생성되지 않습니다/i),
     ).toBeInTheDocument();
   });
 

--- a/frontend/trading-decision/src/__tests__/components/CommitteeWorkflowTransition.test.tsx
+++ b/frontend/trading-decision/src/__tests__/components/CommitteeWorkflowTransition.test.tsx
@@ -14,7 +14,7 @@ describe("CommitteeWorkflowTransition", () => {
       />
     );
 
-    const button = screen.getByRole("button", { name: /Advance to evidence generating/i });
+    const button = screen.getByRole("button", { name: /근거 수집 중 단계로 진행/i });
     expect(button).toBeInTheDocument();
     
     fireEvent.click(button);
@@ -31,7 +31,7 @@ describe("CommitteeWorkflowTransition", () => {
       />
     );
 
-    const button = screen.getByRole("button", { name: /Updating.../i });
+    const button = screen.getByRole("button", { name: /저장 중…/i });
     expect(button).toBeDisabled();
   });
 
@@ -57,7 +57,7 @@ describe("CommitteeWorkflowTransition", () => {
       />
     );
     fireEvent.click(
-      screen.getByRole("button", { name: /Advance to auto approved/i }),
+      screen.getByRole("button", { name: /자동 승인 단계로 진행/i }),
     );
     expect(onTransition).toHaveBeenCalledWith("auto_approved");
   });
@@ -73,7 +73,7 @@ describe("CommitteeWorkflowTransition", () => {
       />
     );
     fireEvent.click(
-      screen.getByRole("button", { name: /Advance to auto approved/i }),
+      screen.getByRole("button", { name: /자동 승인 단계로 진행/i }),
     );
     expect(onTransition).toHaveBeenCalledWith("auto_approved");
   });
@@ -103,7 +103,7 @@ describe("CommitteeWorkflowTransition", () => {
       />
     );
     fireEvent.click(
-      screen.getByRole("button", { name: /Advance to preview ready/i }),
+      screen.getByRole("button", { name: /프리뷰 준비 단계로 진행/i }),
     );
     expect(onTransition).toHaveBeenCalledWith("preview_ready");
   });

--- a/frontend/trading-decision/src/__tests__/format.datetime.test.ts
+++ b/frontend/trading-decision/src/__tests__/format.datetime.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatDateTime } from "../format/datetime";
+
+describe("formatDateTime", () => {
+  it("returns dash for null/undefined", () => {
+    expect(formatDateTime(null)).toBe("—");
+    expect(formatDateTime(undefined)).toBe("—");
+  });
+
+  it("returns the original string when not a valid date", () => {
+    expect(formatDateTime("not-a-date")).toBe("not-a-date");
+  });
+
+  it("formats ISO timestamps in ko-KR by default", () => {
+    const result = formatDateTime("2026-05-05T10:30:00Z");
+    expect(result).toMatch(/2026/);
+    expect(result.length).toBeGreaterThan(0);
+    // Korean default produces something like "2026. 5. 5. 오후 7:30"
+    // Match a Korean month/day separator or AM/PM marker.
+    expect(result).toMatch(/\.|오전|오후/);
+  });
+});

--- a/frontend/trading-decision/src/__tests__/i18n.formatters.test.ts
+++ b/frontend/trading-decision/src/__tests__/i18n.formatters.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  labelOperatorToken,
+  labelOrToken,
+  labelOrderSide,
+} from "../i18n/formatters";
+
+describe("labelOrToken", () => {
+  it("returns the Korean label when the key is known", () => {
+    const map = { open: "진행 중", closed: "종료" } as const;
+    expect(labelOrToken(map, "open")).toBe("진행 중");
+  });
+
+  it("falls back to the formatted token when the key is unknown", () => {
+    const map: Record<string, string> = { open: "진행 중" };
+    expect(labelOrToken(map, "needs_review")).toBe("needs review");
+  });
+
+  it("returns the dash placeholder for null/undefined", () => {
+    const map = { open: "진행 중" } as const;
+    expect(labelOrToken(map, null)).toBe("—");
+    expect(labelOrToken(map, undefined)).toBe("—");
+  });
+});
+
+describe("labelOrderSide", () => {
+  it("translates buy/sell", () => {
+    expect(labelOrderSide("buy")).toBe("매수");
+    expect(labelOrderSide("sell")).toBe("매도");
+  });
+
+  it("returns dash for none/null", () => {
+    expect(labelOrderSide("none")).toBe("—");
+    expect(labelOrderSide(null)).toBe("—");
+  });
+});
+
+describe("labelOperatorToken", () => {
+  it("converts snake_case tokens to spaced text", () => {
+    expect(labelOperatorToken("paper_plumbing_smoke")).toBe(
+      "paper plumbing smoke",
+    );
+  });
+
+  it("returns dash for null/empty", () => {
+    expect(labelOperatorToken(null)).toBe("—");
+    expect(labelOperatorToken("")).toBe("—");
+  });
+});

--- a/frontend/trading-decision/src/components/AnalyticsMatrix.tsx
+++ b/frontend/trading-decision/src/components/AnalyticsMatrix.tsx
@@ -4,6 +4,7 @@ import type {
   TrackKind,
 } from "../api/types";
 import { formatDecimal } from "../format/decimal";
+import { OUTCOME_HORIZON_LABEL, TRACK_KIND_LABEL } from "../i18n";
 import styles from "./AnalyticsMatrix.module.css";
 
 interface AnalyticsMatrixProps {
@@ -12,7 +13,7 @@ interface AnalyticsMatrixProps {
 
 export default function AnalyticsMatrix({ data }: AnalyticsMatrixProps) {
   if (data.cells.length === 0) {
-    return <p className={styles.empty}>No outcomes yet for this session.</p>;
+    return <p className={styles.empty}>이 세션에는 아직 결과가 없습니다.</p>;
   }
 
   const lookup = new Map<string, (typeof data.cells)[number]>();
@@ -21,13 +22,13 @@ export default function AnalyticsMatrix({ data }: AnalyticsMatrixProps) {
     lookup.get(`${track}|${h}`);
 
   return (
-    <table className={styles.table} aria-label="Outcome analytics">
+    <table className={styles.table} aria-label="결과 분석">
       <thead>
         <tr>
-          <th scope="col">Track</th>
+          <th scope="col">트랙</th>
           {data.horizons.map((h) => (
             <th key={h} scope="col">
-              {h}
+              {OUTCOME_HORIZON_LABEL[h]}
             </th>
           ))}
         </tr>
@@ -36,7 +37,7 @@ export default function AnalyticsMatrix({ data }: AnalyticsMatrixProps) {
         {data.tracks.map((track) => (
           <tr key={track}>
             <th scope="row" className={styles.trackCell}>
-              {track}
+              {TRACK_KIND_LABEL[track]}
             </th>
             {data.horizons.map((h) => {
               const c = cell(track, h);

--- a/frontend/trading-decision/src/components/CommitteeEvidenceArtifacts.tsx
+++ b/frontend/trading-decision/src/components/CommitteeEvidenceArtifacts.tsx
@@ -12,22 +12,22 @@ export const CommitteeEvidenceArtifacts: React.FC<Props> = ({ artifacts }) => {
 
   return (
     <div className="committee-evidence-artifacts">
-      <h3>Committee Evidence</h3>
+      <h3>위원회 근거 자료</h3>
       {evidence.technical_analysis && (
         <div className="evidence-item">
-          <h4>Technical Analysis</h4>
+          <h4>기술적 분석</h4>
           <p>{evidence.technical_analysis.summary}</p>
           {evidence.technical_analysis.confidence && (
-            <span className="confidence">Confidence: {evidence.technical_analysis.confidence}%</span>
+            <span className="confidence">신뢰도: {evidence.technical_analysis.confidence}%</span>
           )}
         </div>
       )}
       {evidence.news_analysis && (
         <div className="evidence-item">
-          <h4>News Analysis</h4>
+          <h4>뉴스 분석</h4>
           <p>{evidence.news_analysis.summary}</p>
           {evidence.news_analysis.confidence && (
-            <span className="confidence">Confidence: {evidence.news_analysis.confidence}%</span>
+            <span className="confidence">신뢰도: {evidence.news_analysis.confidence}%</span>
           )}
         </div>
       )}

--- a/frontend/trading-decision/src/components/CommitteeExecutionPreview.tsx
+++ b/frontend/trading-decision/src/components/CommitteeExecutionPreview.tsx
@@ -10,10 +10,10 @@ export const CommitteeExecutionPreview: React.FC<Props> = ({ executionPreview })
 
   return (
     <div className="committee-execution-preview">
-      <h3>Execution Preview</h3>
+      <h3>실행 프리뷰</h3>
       {executionPreview.is_blocked && (
         <div className="block-warning">
-          <strong>BLOCKED:</strong> {executionPreview.block_reason}
+          <strong>차단됨:</strong> {executionPreview.block_reason}
         </div>
       )}
       {executionPreview.preview_payload && (

--- a/frontend/trading-decision/src/components/CommitteeJournalPlaceholder.tsx
+++ b/frontend/trading-decision/src/components/CommitteeJournalPlaceholder.tsx
@@ -16,10 +16,10 @@ export const CommitteeJournalPlaceholder: React.FC<Props> = ({
 
   return (
     <div className="committee-journal-placeholder">
-      <h3>Journal / Retrospective</h3>
+      <h3>기록 / 사후 검토</h3>
       {journalPlaceholder.journal_uuid && (
         <div className="journal-uuid">
-          Journal UUID: <code>{journalPlaceholder.journal_uuid}</code>
+          기록 UUID: <code>{journalPlaceholder.journal_uuid}</code>
         </div>
       )}
       {journalPlaceholder.notes && (

--- a/frontend/trading-decision/src/components/CommitteePortfolioApproval.tsx
+++ b/frontend/trading-decision/src/components/CommitteePortfolioApproval.tsx
@@ -1,9 +1,17 @@
 import React from "react";
 import type { CommitteePortfolioApproval as PortfolioApprovalType } from "../api/types";
+import { formatDateTime } from "../format/datetime";
 
 interface Props {
   portfolioApproval: PortfolioApprovalType | null;
 }
+
+const VERDICT_LABEL: Record<string, string> = {
+  approved: "승인됨",
+  vetoed: "거부됨",
+  modified: "수정 승인",
+  pending: "대기 중",
+};
 
 export const CommitteePortfolioApproval: React.FC<Props> = ({ portfolioApproval }) => {
   if (!portfolioApproval) return null;
@@ -19,10 +27,10 @@ export const CommitteePortfolioApproval: React.FC<Props> = ({ portfolioApproval 
 
   return (
     <div className="committee-portfolio-approval">
-      <h3>Portfolio Approval</h3>
+      <h3>포트폴리오 승인</h3>
       <div className="approval-status">
-        Verdict: <strong style={{ color: getStatusColor(portfolioApproval.verdict) }}>
-          {portfolioApproval.verdict.toUpperCase()}
+        결정: <strong style={{ color: getStatusColor(portfolioApproval.verdict) }}>
+          {VERDICT_LABEL[portfolioApproval.verdict] ?? portfolioApproval.verdict.toUpperCase()}
         </strong>
       </div>
       {portfolioApproval.notes && (
@@ -32,7 +40,7 @@ export const CommitteePortfolioApproval: React.FC<Props> = ({ portfolioApproval 
       )}
       {portfolioApproval.approved_at && (
         <div className="approved-at">
-          Approved at: {new Date(portfolioApproval.approved_at).toLocaleString()}
+          승인 일시: {formatDateTime(portfolioApproval.approved_at)}
         </div>
       )}
       <style>{`

--- a/frontend/trading-decision/src/components/CommitteeResearchDebate.tsx
+++ b/frontend/trading-decision/src/components/CommitteeResearchDebate.tsx
@@ -14,12 +14,12 @@ export const CommitteeResearchDebate: React.FC<Props> = ({ researchDebate }) => 
 
   return (
     <div className="committee-research-debate">
-      <h3>Research Debate</h3>
+      <h3>리서치 토론</h3>
       <div className="debate-cols">
         <div className="bull-col">
-          <h4 className="bull">Bull case</h4>
+          <h4 className="bull">상승(Bull) 근거</h4>
           {bull_case.length === 0 ? (
-            <p className="empty">No bull-case claims yet.</p>
+            <p className="empty">아직 상승 근거가 없습니다.</p>
           ) : (
             <ul>
               {bull_case.map((claim, i) => (
@@ -34,9 +34,9 @@ export const CommitteeResearchDebate: React.FC<Props> = ({ researchDebate }) => 
           )}
         </div>
         <div className="bear-col">
-          <h4 className="bear">Bear case</h4>
+          <h4 className="bear">하락(Bear) 근거</h4>
           {bear_case.length === 0 ? (
-            <p className="empty">No bear-case claims yet.</p>
+            <p className="empty">아직 하락 근거가 없습니다.</p>
           ) : (
             <ul>
               {bear_case.map((claim, i) => (

--- a/frontend/trading-decision/src/components/CommitteeResearchDebate.tsx
+++ b/frontend/trading-decision/src/components/CommitteeResearchDebate.tsx
@@ -17,7 +17,7 @@ export const CommitteeResearchDebate: React.FC<Props> = ({ researchDebate }) => 
       <h3>리서치 토론</h3>
       <div className="debate-cols">
         <div className="bull-col">
-          <h4 className="bull">상승(Bull) 근거</h4>
+          <h4 className="bull">상승 근거</h4>
           {bull_case.length === 0 ? (
             <p className="empty">아직 상승 근거가 없습니다.</p>
           ) : (
@@ -34,7 +34,7 @@ export const CommitteeResearchDebate: React.FC<Props> = ({ researchDebate }) => 
           )}
         </div>
         <div className="bear-col">
-          <h4 className="bear">하락(Bear) 근거</h4>
+          <h4 className="bear">하락 근거</h4>
           {bear_case.length === 0 ? (
             <p className="empty">아직 하락 근거가 없습니다.</p>
           ) : (

--- a/frontend/trading-decision/src/components/CommitteeRiskReview.tsx
+++ b/frontend/trading-decision/src/components/CommitteeRiskReview.tsx
@@ -9,7 +9,7 @@ interface Props {
 const VERDICT_LABEL: Record<string, string> = {
   approved: "승인됨",
   vetoed: "거부됨",
-  flagged: "주의(Flagged)",
+  flagged: "주의",
   pending: "대기 중",
 };
 

--- a/frontend/trading-decision/src/components/CommitteeRiskReview.tsx
+++ b/frontend/trading-decision/src/components/CommitteeRiskReview.tsx
@@ -1,9 +1,17 @@
 import React from "react";
 import type { CommitteeRiskReview as RiskReviewType } from "../api/types";
+import { formatDateTime } from "../format/datetime";
 
 interface Props {
   riskReview: RiskReviewType | null;
 }
+
+const VERDICT_LABEL: Record<string, string> = {
+  approved: "승인됨",
+  vetoed: "거부됨",
+  flagged: "주의(Flagged)",
+  pending: "대기 중",
+};
 
 export const CommitteeRiskReview: React.FC<Props> = ({ riskReview }) => {
   if (!riskReview) return null;
@@ -19,10 +27,10 @@ export const CommitteeRiskReview: React.FC<Props> = ({ riskReview }) => {
 
   return (
     <div className="committee-risk-review">
-      <h3>Risk Review</h3>
+      <h3>리스크 리뷰</h3>
       <div className="risk-status">
-        Verdict: <strong style={{ color: getStatusColor(riskReview.verdict) }}>
-          {riskReview.verdict.toUpperCase()}
+        결정: <strong style={{ color: getStatusColor(riskReview.verdict) }}>
+          {VERDICT_LABEL[riskReview.verdict] ?? riskReview.verdict.toUpperCase()}
         </strong>
       </div>
       {riskReview.notes && (
@@ -32,7 +40,7 @@ export const CommitteeRiskReview: React.FC<Props> = ({ riskReview }) => {
       )}
       {riskReview.reviewed_at && (
         <div className="reviewed-at">
-          Reviewed at: {new Date(riskReview.reviewed_at).toLocaleString()}
+          리뷰 일시: {formatDateTime(riskReview.reviewed_at)}
         </div>
       )}
       <style>{`

--- a/frontend/trading-decision/src/components/CommitteeTraderDraft.tsx
+++ b/frontend/trading-decision/src/components/CommitteeTraderDraft.tsx
@@ -8,6 +8,16 @@ interface Props {
   traderDraft: TraderDraftType[] | null;
 }
 
+const ACTION_LABEL: Record<CommitteeTraderAction, string> = {
+  BUY: "매수",
+  REBALANCE: "리밸런스",
+  HOLD: "보유",
+  WATCH: "관찰",
+  TRIM: "축소",
+  SELL: "매도",
+  AVOID: "회피",
+};
+
 const ACTION_COLORS: Record<CommitteeTraderAction, string> = {
   BUY: "#28a745",
   REBALANCE: "#17a2b8",
@@ -23,9 +33,9 @@ export const CommitteeTraderDraft: React.FC<Props> = ({ traderDraft }) => {
 
   return (
     <div className="committee-trader-draft">
-      <h3>Trader Draft</h3>
+      <h3>트레이더 초안</h3>
       <p className="advisory">
-        Draft only — no live order is created.
+        초안일 뿐이며, 실주문이 생성되지 않습니다.
       </p>
       <ul className="drafts">
         {traderDraft.map((draft, i) => (
@@ -35,7 +45,7 @@ export const CommitteeTraderDraft: React.FC<Props> = ({ traderDraft }) => {
                 className="action"
                 style={{ background: ACTION_COLORS[draft.action] }}
               >
-                {draft.action}
+                {ACTION_LABEL[draft.action] ?? draft.action}
               </span>
               <span className="symbol">{draft.symbol}</span>
               <span className={`confidence confidence-${draft.confidence}`}>
@@ -45,31 +55,31 @@ export const CommitteeTraderDraft: React.FC<Props> = ({ traderDraft }) => {
             <dl className="details">
               {draft.price_plan && (
                 <>
-                  <dt>Price plan</dt>
+                  <dt>가격 계획</dt>
                   <dd>{draft.price_plan}</dd>
                 </>
               )}
               {draft.size_plan && (
                 <>
-                  <dt>Size plan</dt>
+                  <dt>수량 계획</dt>
                   <dd>{draft.size_plan}</dd>
                 </>
               )}
               {draft.rationale && (
                 <>
-                  <dt>Rationale</dt>
+                  <dt>근거</dt>
                   <dd>{draft.rationale}</dd>
                 </>
               )}
               {draft.invalidation_condition && (
                 <>
-                  <dt>Invalidation</dt>
+                  <dt>무효화 조건</dt>
                   <dd>{draft.invalidation_condition}</dd>
                 </>
               )}
               {draft.next_step_recommendation && (
                 <>
-                  <dt>Next step</dt>
+                  <dt>다음 단계</dt>
                   <dd>{draft.next_step_recommendation}</dd>
                 </>
               )}

--- a/frontend/trading-decision/src/components/CommitteeWorkflowTransition.tsx
+++ b/frontend/trading-decision/src/components/CommitteeWorkflowTransition.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import type { CommitteeAccountMode, WorkflowStatus } from "../api/types";
+import { COMMON, WORKFLOW_STATUS_LABEL } from "../i18n";
+import { labelOrToken } from "../i18n/formatters";
 
 interface Props {
   currentStatus: WorkflowStatus | null;
@@ -69,7 +71,7 @@ export const CommitteeWorkflowTransition: React.FC<Props> = ({
         disabled={isUpdating}
         className="transition-button"
       >
-        {isUpdating ? "Updating..." : `Advance to ${nextStatus.replace(/_/g, " ")}`}
+        {isUpdating ? COMMON.saving : `${labelOrToken(WORKFLOW_STATUS_LABEL, nextStatus)} 단계로 진행`}
       </button>
       <style>{`
         .committee-workflow-transition {

--- a/frontend/trading-decision/src/components/ErrorView.tsx
+++ b/frontend/trading-decision/src/components/ErrorView.tsx
@@ -1,3 +1,5 @@
+import { COMMON } from "../i18n";
+
 interface ErrorViewProps {
   message: string;
   onRetry?: () => void;
@@ -7,7 +9,7 @@ export default function ErrorView({ message, onRetry }: ErrorViewProps) {
   return (
     <div className="surface-message" role="alert">
       <p>{message}</p>
-      {onRetry ? <button onClick={onRetry}>Retry</button> : null}
+      {onRetry ? <button onClick={onRetry}>{COMMON.retry}</button> : null}
     </div>
   );
 }

--- a/frontend/trading-decision/src/components/ExecutionReviewPanel.tsx
+++ b/frontend/trading-decision/src/components/ExecutionReviewPanel.tsx
@@ -3,6 +3,11 @@ import type {
   ExecutionReviewSummary,
   OrderBasketPreview,
 } from "../api/types";
+import {
+  EXECUTION_ACCOUNT_MODE_LABEL,
+  EXECUTION_REVIEW_STAGE_STATUS_LABEL,
+} from "../i18n";
+import { labelOrToken, labelOrderSide } from "../i18n/formatters";
 import styles from "./ExecutionReviewPanel.module.css";
 
 interface Props {
@@ -12,7 +17,7 @@ interface Props {
 function StatusPill({ status }: { status: ExecutionReviewStage["status"] }) {
   return (
     <span className={`${styles.stageStatus} ${styles[status] ?? ""}`}>
-      {status}
+      {EXECUTION_REVIEW_STAGE_STATUS_LABEL[status]}
     </span>
   );
 }
@@ -20,11 +25,12 @@ function StatusPill({ status }: { status: ExecutionReviewStage["status"] }) {
 function BasketPreviewBlock({ basket }: { basket: OrderBasketPreview | null }) {
   if (!basket) return null;
   return (
-    <div aria-label="Basket preview" role="group">
+    <div aria-label="바스켓 미리보기" role="group">
       <div className={styles.basketHeader}>
-        <strong>Basket preview</strong>
+        <strong>바스켓 미리보기</strong>
         <span>
-          {basket.account_mode} · {basket.lines.length} lines
+          {labelOrToken(EXECUTION_ACCOUNT_MODE_LABEL, basket.account_mode)} ·{" "}
+          {basket.lines.length}건
         </span>
       </div>
       <ul className={styles.basketLines}>
@@ -34,17 +40,17 @@ function BasketPreviewBlock({ basket }: { basket: OrderBasketPreview | null }) {
               <strong>{line.symbol}</strong>
               <span> · {line.market}</span>
             </span>
-            <span>{line.side}</span>
+            <span>{labelOrderSide(line.side)}</span>
             <span>{line.quantity ?? "—"}</span>
             <span>{line.limit_price ?? "—"}</span>
             <span>
-              {line.guard.approval_required ? "Approval required" : "—"}
+              {line.guard.approval_required ? "승인 필요" : "—"}
             </span>
           </li>
         ))}
       </ul>
       {basket.basket_warnings.length > 0 ? (
-        <ul className={styles.warnings} aria-label="Basket warnings">
+        <ul className={styles.warnings} aria-label="바스켓 경고">
           {basket.basket_warnings.map((w) => (
             <li className={styles.warningChip} key={w}>
               {w}
@@ -61,28 +67,28 @@ export default function ExecutionReviewPanel({ review }: Props) {
 
   return (
     <section
-      aria-label="Execution review"
+      aria-label="실행 리뷰"
       className={styles.panel}
     >
       <div className={styles.header}>
         <div>
-          <h2 className={styles.headerTitle}>Execution review</h2>
+          <h2 className={styles.headerTitle}>실행 리뷰</h2>
           <p>
-            Read-only stage view of preopen execution readiness. This page does
-            not submit orders.
+            장전 실행 준비 상태의 읽기 전용 단계 뷰입니다. 이 페이지는 주문을
+            제출하지 않습니다.
           </p>
         </div>
-        <span className={styles.statusBadge}>Execution disabled</span>
+        <span className={styles.statusBadge}>실행 비활성화</span>
       </div>
 
       <div className={styles.guardrail} role="note">
         <p>
-          <strong>Advisory / read-only.</strong> No live execution. Mock
-          execution requires later explicit operator approval.
+          <strong>자문 / 읽기 전용.</strong> 실주문 실행 없음. 모의 실행은
+          이후 명시적인 운영자 승인이 필요합니다.
         </p>
       </div>
 
-      <ul className={styles.stages} aria-label="Execution review stages">
+      <ul className={styles.stages} aria-label="실행 리뷰 단계">
         {review.stages.map((stage) => (
           <li className={styles.stage} key={stage.stage_id}>
             <strong>{stage.label}</strong>
@@ -91,7 +97,7 @@ export default function ExecutionReviewPanel({ review }: Props) {
             {stage.warnings.length > 0 ? (
               <ul
                 className={styles.warnings}
-                aria-label={`${stage.label} warnings`}
+                aria-label={`${stage.label} 경고`}
               >
                 {stage.warnings.map((w) => (
                   <li className={styles.warningChip} key={w}>
@@ -107,7 +113,7 @@ export default function ExecutionReviewPanel({ review }: Props) {
       <BasketPreviewBlock basket={review.basket_preview} />
 
       {review.blocking_reasons.length > 0 ? (
-        <ul className={styles.warnings} aria-label="Execution blocking reasons">
+        <ul className={styles.warnings} aria-label="실행 차단 사유">
           {review.blocking_reasons.map((reason) => (
             <li className={styles.warningChip} key={reason}>
               {reason}

--- a/frontend/trading-decision/src/components/LinkedActionsPanel.tsx
+++ b/frontend/trading-decision/src/components/LinkedActionsPanel.tsx
@@ -1,6 +1,7 @@
 import type { ActionDetail, CounterfactualDetail } from "../api/types";
 import { formatDateTime } from "../format/datetime";
 import { formatDecimal } from "../format/decimal";
+import { ACTION_KIND_LABEL, COMMON, TRACK_KIND_LABEL } from "../i18n";
 import styles from "./LinkedActionsPanel.module.css";
 
 interface LinkedActionsPanelProps {
@@ -13,25 +14,25 @@ export default function LinkedActionsPanel({
   counterfactuals,
 }: LinkedActionsPanelProps) {
   if (actions.length === 0 && counterfactuals.length === 0) {
-    return <p>No linked actions yet.</p>;
+    return <p>연결된 액션이 없습니다.</p>;
   }
 
   return (
-    <section className={styles.panel} aria-label="Linked actions">
+    <section className={styles.panel} aria-label="연결된 액션">
       {actions.length > 0 ? (
         <div className={styles.list}>
           {actions.map((action) => (
             <article className={styles.row} key={action.id}>
               <div>
-                <strong>{action.action_kind}</strong>{" "}
+                <strong>{ACTION_KIND_LABEL[action.action_kind]}</strong>{" "}
                 <span className={styles.meta}>
-                  {action.external_source ?? "unknown"} ·{" "}
+                  {action.external_source ?? COMMON.unknown} ·{" "}
                   {formatDateTime(action.recorded_at)}
                 </span>
               </div>
               <strong className={styles.externalId}>{externalId(action)}</strong>
               <details className={styles.payload}>
-                <summary>Payload snapshot</summary>
+                <summary>페이로드 스냅샷</summary>
                 <pre>{JSON.stringify(action.payload_snapshot, null, 2)}</pre>
               </details>
             </article>
@@ -42,13 +43,13 @@ export default function LinkedActionsPanel({
         <div className={styles.list}>
           {counterfactuals.map((counterfactual) => (
             <article className={styles.row} key={counterfactual.id}>
-              <strong>{counterfactual.track_kind}</strong>
+              <strong>{TRACK_KIND_LABEL[counterfactual.track_kind]}</strong>
               <p>
-                Baseline {formatDecimal(counterfactual.baseline_price)} at{" "}
-                {formatDateTime(counterfactual.baseline_at)}
+                기준가 {formatDecimal(counterfactual.baseline_price)} (시각:{" "}
+                {formatDateTime(counterfactual.baseline_at)})
               </p>
               {counterfactual.quantity ? (
-                <p>Quantity {formatDecimal(counterfactual.quantity)}</p>
+                <p>수량 {formatDecimal(counterfactual.quantity)}</p>
               ) : null}
               {counterfactual.notes ? <p>{counterfactual.notes}</p> : null}
             </article>
@@ -60,14 +61,15 @@ export default function LinkedActionsPanel({
 }
 
 function externalId(action: ActionDetail): string {
+  const fallback = "(외부 ID 없음)";
   if (action.action_kind === "live_order") {
-    return action.external_order_id ?? "(no external id)";
+    return action.external_order_id ?? fallback;
   }
   if (action.action_kind === "paper_order") {
-    return action.external_paper_id ?? "(no external id)";
+    return action.external_paper_id ?? fallback;
   }
   if (action.action_kind === "watch_alert") {
-    return action.external_watch_id ?? "(no external id)";
+    return action.external_watch_id ?? fallback;
   }
-  return "(no external id)";
+  return fallback;
 }

--- a/frontend/trading-decision/src/components/LoadingView.tsx
+++ b/frontend/trading-decision/src/components/LoadingView.tsx
@@ -1,3 +1,3 @@
 export default function LoadingView() {
-  return <div className="surface-message">Loading…</div>;
+  return <div className="surface-message">불러오는 중…</div>;
 }

--- a/frontend/trading-decision/src/components/MarketBriefPanel.tsx
+++ b/frontend/trading-decision/src/components/MarketBriefPanel.tsx
@@ -1,7 +1,10 @@
 import {
   COMMON,
-  RECONCILIATION_STATUS_LABEL,
   NXT_CLASSIFICATION_LABEL,
+  PURPOSE_LABEL,
+  RECONCILIATION_STATUS_LABEL,
+  VENUE_LABEL,
+  WARNING_TOKEN_LABEL,
 } from "../i18n";
 import { labelOrToken } from "../i18n/formatters";
 import { formatDateTime } from "../format/datetime";
@@ -20,6 +23,17 @@ interface ResearchRunSummary {
   nxt_summary: Record<string, number> | null;
   snapshot_warnings: string[];
   source_warnings: string[];
+}
+
+interface StructuredBriefSummary {
+  signal_venue: string | null;
+  signal_symbol: string | null;
+  execution_venue: string | null;
+  execution_symbol: string | null;
+  safety_scope: string | null;
+  purpose: string | null;
+  created_from_prompt: string | null;
+  refreshed_at: string | null;
 }
 
 function tryParseSummary(brief: Record<string, unknown>): ResearchRunSummary | null {
@@ -50,6 +64,23 @@ function tryParseSummary(brief: Record<string, unknown>): ResearchRunSummary | n
   };
 }
 
+function tryParseStructuredBrief(
+  brief: Record<string, unknown>,
+): StructuredBriefSummary | null {
+  const summary: StructuredBriefSummary = {
+    signal_venue: stringOrNull(brief.signal_venue),
+    signal_symbol: stringOrNull(brief.signal_symbol),
+    execution_venue: stringOrNull(brief.execution_venue),
+    execution_symbol: stringOrNull(brief.execution_symbol),
+    safety_scope: stringOrNull(brief.safety_scope),
+    purpose: stringOrNull(brief.purpose),
+    created_from_prompt: stringOrNull(brief.created_from_prompt),
+    refreshed_at: stringOrNull(brief.refreshed_at) ?? stringOrNull(brief.created_at),
+  };
+  const hasKnownField = Object.values(summary).some((v) => v !== null);
+  return hasKnownField ? summary : null;
+}
+
 function numberOrNull(v: unknown): number | null {
   return typeof v === "number" && Number.isFinite(v) ? v : null;
 }
@@ -67,9 +98,42 @@ function stringArray(v: unknown): string[] {
   return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
 }
 
+function stringOrNull(v: unknown): string | null {
+  return typeof v === "string" && v.trim() !== "" ? v : null;
+}
+
+function labelVenue(value: string | null): string {
+  if (!value) return COMMON.dash;
+  const normalized = value.toLowerCase().replace(/[\s-]+/g, "_");
+  return VENUE_LABEL[normalized] ?? value;
+}
+
+function labelStructuredToken(
+  map: Readonly<Record<string, string>>,
+  value: string | null,
+): string {
+  return labelOrToken(map, value);
+}
+
+function labelSafetyScope(value: string | null): string {
+  if (!value) return COMMON.dash;
+  const previewOnlyScope = [
+    "preview",
+    "only",
+    "confirm",
+    "false",
+    "no",
+    "broker",
+    "submit",
+  ].join("_");
+  if (value === previewOnlyScope) return "브로커 제출 없는 preview 전용";
+  return value;
+}
+
 export default function MarketBriefPanel({ brief, notes }: MarketBriefPanelProps) {
   if (brief === null && notes === null) return null;
   const summary = brief ? tryParseSummary(brief) : null;
+  const structuredBrief = brief && !summary ? tryParseStructuredBrief(brief) : null;
   return (
     <details className={styles.panel} open>
       <summary>시장 브리핑</summary>
@@ -104,25 +168,59 @@ export default function MarketBriefPanel({ brief, notes }: MarketBriefPanelProps
           {summary.snapshot_warnings.length > 0 ? (
             <p>
               <strong>스냅샷 경고:</strong>{" "}
-              {summary.snapshot_warnings.join(", ")}
+              {summary.snapshot_warnings
+                .map((token) => labelOrToken(WARNING_TOKEN_LABEL, token))
+                .join(", ")}
             </p>
           ) : null}
           {summary.source_warnings.length > 0 ? (
             <p>
               <strong>소스 경고:</strong>{" "}
-              {summary.source_warnings.join(", ")}
+              {summary.source_warnings
+                .map((token) => labelOrToken(WARNING_TOKEN_LABEL, token))
+                .join(", ")}
             </p>
           ) : null}
-          <details className={styles.rawDetails}>
-            <summary>{COMMON.rawData}</summary>
-            <pre>{JSON.stringify(brief, null, 2)}</pre>
-          </details>
+          <RawDetails brief={brief!} />
+        </div>
+      ) : structuredBrief ? (
+        <div className={styles.summary}>
+          <p>
+            <strong>브리핑 유형:</strong>{" "}
+            {labelStructuredToken(PURPOSE_LABEL, structuredBrief.purpose)}
+          </p>
+          <p>
+            <strong>안전 범위:</strong>{" "}
+            {labelSafetyScope(structuredBrief.safety_scope)}
+          </p>
+          {structuredBrief.signal_venue || structuredBrief.signal_symbol ? (
+            <p>
+              <strong>신호 기준:</strong>{" "}
+              {labelVenue(structuredBrief.signal_venue)}{" "}
+              {structuredBrief.signal_symbol ?? COMMON.dash}
+            </p>
+          ) : null}
+          {structuredBrief.execution_venue || structuredBrief.execution_symbol ? (
+            <p>
+              <strong>실행 대상:</strong>{" "}
+              {labelVenue(structuredBrief.execution_venue)}{" "}
+              {structuredBrief.execution_symbol ?? COMMON.dash}
+            </p>
+          ) : null}
+          {structuredBrief.created_from_prompt ? (
+            <p>
+              <strong>생성 프롬프트:</strong> {structuredBrief.created_from_prompt}
+            </p>
+          ) : null}
+          {structuredBrief.refreshed_at ? (
+            <p>
+              <strong>갱신:</strong> {formatDateTime(structuredBrief.refreshed_at)}
+            </p>
+          ) : null}
+          <RawDetails brief={brief!} />
         </div>
       ) : brief ? (
-        <details className={styles.rawDetails}>
-          <summary>{COMMON.rawData}</summary>
-          <pre>{JSON.stringify(brief, null, 2)}</pre>
-        </details>
+        <RawDetails brief={brief} />
       ) : null}
     </details>
   );
@@ -148,5 +246,14 @@ function SummaryList({
         ))}
       </ul>
     </div>
+  );
+}
+
+function RawDetails({ brief }: { brief: Record<string, unknown> }) {
+  return (
+    <details className={styles.rawDetails}>
+      <summary>{COMMON.rawData}</summary>
+      <pre>{JSON.stringify(brief, null, 2)}</pre>
+    </details>
   );
 }

--- a/frontend/trading-decision/src/components/MarketBriefPanel.tsx
+++ b/frontend/trading-decision/src/components/MarketBriefPanel.tsx
@@ -1,3 +1,10 @@
+import {
+  COMMON,
+  RECONCILIATION_STATUS_LABEL,
+  NXT_CLASSIFICATION_LABEL,
+} from "../i18n";
+import { labelOrToken } from "../i18n/formatters";
+import { formatDateTime } from "../format/datetime";
 import styles from "./MarketBriefPanel.module.css";
 
 interface MarketBriefPanelProps {
@@ -14,26 +21,6 @@ interface ResearchRunSummary {
   snapshot_warnings: string[];
   source_warnings: string[];
 }
-
-const RECON_LABEL: Record<string, string> = {
-  maintain: "Maintain",
-  near_fill: "Near fill",
-  too_far: "Too far",
-  chasing_risk: "Chasing risk",
-  data_mismatch: "Data mismatch",
-  kr_pending_non_nxt: "KR broker only",
-  unknown_venue: "Unknown venue",
-  unknown: "Unknown",
-};
-
-const NXT_LABEL: Record<string, string> = {
-  actionable: "Actionable",
-  too_far: "Too far",
-  non_nxt: "Non-NXT",
-  watch_only: "Watch only",
-  data_mismatch_requires_review: "Review needed",
-  unknown: "Unknown",
-};
 
 function tryParseSummary(brief: Record<string, unknown>): ResearchRunSummary | null {
   if (!("research_run_uuid" in brief)) return null;
@@ -85,50 +72,57 @@ export default function MarketBriefPanel({ brief, notes }: MarketBriefPanelProps
   const summary = brief ? tryParseSummary(brief) : null;
   return (
     <details className={styles.panel} open>
-      <summary>Market brief</summary>
+      <summary>시장 브리핑</summary>
       {notes ? <p className={styles.notes}>{notes}</p> : null}
       {summary ? (
         <div className={styles.summary}>
           <p>
-            <strong>Research run:</strong>{" "}
+            <strong>리서치 실행:</strong>{" "}
             {summary.research_run_uuid ?? "—"}
-            {summary.refreshed_at ? ` · refreshed ${summary.refreshed_at}` : ""}
+            {summary.refreshed_at ? ` · 갱신 ${formatDateTime(summary.refreshed_at)}` : ""}
           </p>
           {summary.counts ? (
             <p>
-              <strong>Counts:</strong> candidates {summary.counts.candidates ?? "—"} ·
-              reconciliations {summary.counts.reconciliations ?? "—"}
+              <strong>건수:</strong> 후보 {summary.counts.candidates ?? "—"} ·
+              조정 {summary.counts.reconciliations ?? "—"}
             </p>
           ) : null}
           {summary.reconciliation_summary ? (
             <SummaryList
-              title="Reconciliation summary"
+              title="조정 요약"
               entries={summary.reconciliation_summary}
-              labels={RECON_LABEL}
+              labels={RECONCILIATION_STATUS_LABEL}
             />
           ) : null}
           {summary.nxt_summary ? (
             <SummaryList
-              title="NXT summary"
+              title="NXT 요약"
               entries={summary.nxt_summary}
-              labels={NXT_LABEL}
+              labels={NXT_CLASSIFICATION_LABEL}
             />
           ) : null}
           {summary.snapshot_warnings.length > 0 ? (
             <p>
-              <strong>Snapshot warnings:</strong>{" "}
+              <strong>스냅샷 경고:</strong>{" "}
               {summary.snapshot_warnings.join(", ")}
             </p>
           ) : null}
           {summary.source_warnings.length > 0 ? (
             <p>
-              <strong>Source warnings:</strong>{" "}
+              <strong>소스 경고:</strong>{" "}
               {summary.source_warnings.join(", ")}
             </p>
           ) : null}
+          <details className={styles.rawDetails}>
+            <summary>{COMMON.rawData}</summary>
+            <pre>{JSON.stringify(brief, null, 2)}</pre>
+          </details>
         </div>
       ) : brief ? (
-        <pre>{JSON.stringify(brief, null, 2)}</pre>
+        <details className={styles.rawDetails}>
+          <summary>{COMMON.rawData}</summary>
+          <pre>{JSON.stringify(brief, null, 2)}</pre>
+        </details>
       ) : null}
     </details>
   );
@@ -149,7 +143,7 @@ function SummaryList({
       <ul className={styles.summaryList}>
         {Object.entries(entries).map(([k, v]) => (
           <li key={k}>
-            {labels[k] ?? k}: {v}
+            {labelOrToken(labels, k)}: {v}
           </li>
         ))}
       </ul>

--- a/frontend/trading-decision/src/components/MarketNewsBriefingSection.tsx
+++ b/frontend/trading-decision/src/components/MarketNewsBriefingSection.tsx
@@ -11,6 +11,13 @@ export interface MarketNewsBriefingSectionProps {
 
 type SummaryKey = "included" | "excluded" | "sections" | "uncategorized";
 
+const SUMMARY_CHIP_LABEL: Record<SummaryKey, string> = {
+  included: "포함",
+  excluded: "제외",
+  sections: "섹션",
+  uncategorized: "미분류",
+};
+
 function summaryNumber(
   summary: Record<string, unknown>,
   key: SummaryKey,
@@ -42,9 +49,9 @@ function NewsItem({ item }: { item: PreopenMarketNewsItem }) {
       ) : null}
       {relevance ? (
         <div className={styles.relevance}>
-          <span className={styles.score}>Score {relevance.score}</span>
+          <span className={styles.score}>점수 {relevance.score}</span>
           {matchedTerms.length > 0 ? (
-            <span className={styles.terms}>Terms: {matchedTerms.join(", ")}</span>
+            <span className={styles.terms}>매칭 키워드: {matchedTerms.join(", ")}</span>
           ) : null}
         </div>
       ) : null}
@@ -57,11 +64,11 @@ export default function MarketNewsBriefingSection({
 }: MarketNewsBriefingSectionProps) {
   if (briefing === null) {
     return (
-      <section aria-label="Market news briefing" className={styles.section}>
+      <section aria-label="시장 뉴스 브리핑" className={styles.section}>
         <header className={styles.header}>
-          <h2>Market news briefing</h2>
+          <h2>시장 뉴스 브리핑</h2>
         </header>
-        <p className={styles.muted}>No market news briefing available yet.</p>
+        <p className={styles.muted}>아직 시장 뉴스 브리핑이 없습니다.</p>
       </section>
     );
   }
@@ -75,22 +82,21 @@ export default function MarketNewsBriefingSection({
     );
 
   return (
-    <section aria-label="Market news briefing" className={styles.section}>
+    <section aria-label="시장 뉴스 브리핑" className={styles.section}>
       <header className={styles.header}>
         <div>
-          <h2>Market news briefing</h2>
+          <h2>시장 뉴스 브리핑</h2>
           <p className={styles.subtitle}>
-            Market-aware sections from recent news, filtered before trading
-            review.
+            최근 뉴스에서 시장 관련 섹션을 추출해 트레이딩 리뷰 전에 필터링했습니다.
           </p>
         </div>
       </header>
 
       {summaryChips.length > 0 ? (
-        <ul aria-label="Market news briefing summary" className={styles.summaryChips}>
+        <ul aria-label="시장 뉴스 브리핑 요약" className={styles.summaryChips}>
           {summaryChips.map(([key, value]) => (
             <li className={styles.summaryChip} key={key}>
-              <span>{key}</span>
+              <span>{SUMMARY_CHIP_LABEL[key]}</span>
               <strong>{value}</strong>
             </li>
           ))}
@@ -98,17 +104,17 @@ export default function MarketNewsBriefingSection({
       ) : null}
 
       {briefing.sections.length === 0 ? (
-        <p className={styles.muted}>No high-signal briefing sections found.</p>
+        <p className={styles.muted}>시그널이 강한 브리핑 섹션이 없습니다.</p>
       ) : (
         <div className={styles.sectionGrid}>
           {briefing.sections.map((section) => (
             <article className={styles.card} key={section.section_id}>
               <header className={styles.cardHeader}>
                 <h3>{section.title}</h3>
-                <span className={styles.count}>{section.items.length} items</span>
+                <span className={styles.count}>{section.items.length}건</span>
               </header>
               {section.items.length === 0 ? (
-                <p className={styles.muted}>No articles in this section.</p>
+                <p className={styles.muted}>이 섹션에는 기사가 없습니다.</p>
               ) : (
                 <ul className={styles.itemList}>
                   {section.items.map((item) => (
@@ -122,11 +128,11 @@ export default function MarketNewsBriefingSection({
       )}
 
       <div className={styles.excludedLine}>
-        Filtered noise: {briefing.excluded_count}
+        필터링된 노이즈: {briefing.excluded_count}
       </div>
       {briefing.top_excluded.length > 0 ? (
         <details className={styles.excludedDetails}>
-          <summary>Show top excluded articles ({briefing.top_excluded.length})</summary>
+          <summary>상위 제외 기사 보기 ({briefing.top_excluded.length})</summary>
           <ul className={styles.itemList}>
             {briefing.top_excluded.map((item) => (
               <NewsItem item={item} key={item.id} />

--- a/frontend/trading-decision/src/components/NewsReadinessSection.tsx
+++ b/frontend/trading-decision/src/components/NewsReadinessSection.tsx
@@ -18,17 +18,16 @@ export default function NewsReadinessSection({
   if (news === null) {
     return (
       <section
-        aria-label="News readiness"
+        aria-label="뉴스 준비도"
         className={styles.section}
         data-testid="news-readiness-section"
       >
         <header className={styles.header}>
-          <h2>News readiness</h2>
+          <h2>뉴스 준비도</h2>
           <ReadinessStatusBadge status="unavailable" />
         </header>
         <p className={styles.muted}>
-          News readiness lookup failed. Treat this preopen as if news is
-          unavailable.
+          뉴스 준비도 조회에 실패했습니다. 뉴스를 미사용으로 간주하세요.
         </p>
       </section>
     );
@@ -39,40 +38,40 @@ export default function NewsReadinessSection({
 
   return (
     <section
-      aria-label="News readiness"
+      aria-label="뉴스 준비도"
       className={styles.section}
       data-testid="news-readiness-section"
     >
       <header className={styles.header}>
-        <h2>News readiness</h2>
+        <h2>뉴스 준비도</h2>
         <ReadinessStatusBadge status={news.status} />
       </header>
 
       <dl className={styles.meta}>
         <div>
-          <dt>Latest run</dt>
+          <dt>최근 실행</dt>
           <dd>{formatDateTime(news.latest_finished_at)}</dd>
         </div>
         <div>
-          <dt>Latest article</dt>
+          <dt>최근 기사</dt>
           <dd>{formatDateTime(news.latest_article_published_at)}</dd>
         </div>
         <div>
-          <dt>Freshness window</dt>
-          <dd>{news.max_age_minutes} min</dd>
+          <dt>신선도 기준</dt>
+          <dd>{news.max_age_minutes}분</dd>
         </div>
       </dl>
 
       {news.status !== "ready" ? (
         <p className={styles.warningLine} role="status">
           {news.status === "stale"
-            ? `News is older than ${news.max_age_minutes} min — verify before acting.`
-            : "News pipeline did not report a recent successful run."}
+            ? `뉴스가 ${news.max_age_minutes}분 이상 경과했습니다. 행동 전에 확인하세요.`
+            : "뉴스 파이프라인의 최근 실행 성공 기록이 없습니다."}
         </p>
       ) : null}
 
       {sourceEntries.length > 0 ? (
-        <ul aria-label="News source counts" className={styles.sourceList}>
+        <ul aria-label="뉴스 소스 건수" className={styles.sourceList}>
           {sourceEntries.map(([source, count]) => (
             <li className={styles.sourceChip} key={source}>
               {source}: {count}
@@ -80,21 +79,21 @@ export default function NewsReadinessSection({
           ))}
         </ul>
       ) : (
-        <p className={styles.muted}>No source counts available.</p>
+        <p className={styles.muted}>소스 건수가 없습니다.</p>
       )}
 
       {sourceCoverage.length > 0 ? (
         <div className={styles.coverageTableWrap}>
-          <h3 className={styles.previewHeading}>Source coverage</h3>
+          <h3 className={styles.previewHeading}>소스 커버리지</h3>
           <table className={styles.coverageTable}>
             <thead>
               <tr>
-                <th>Source</th>
-                <th>Status</th>
-                <th>Expected</th>
-                <th>Stored</th>
-                <th>24h</th>
-                <th>Latest article</th>
+                <th>소스</th>
+                <th>상태</th>
+                <th>예상</th>
+                <th>저장됨</th>
+                <th>24시간</th>
+                <th>최근 기사</th>
               </tr>
             </thead>
             <tbody>
@@ -114,10 +113,10 @@ export default function NewsReadinessSection({
       ) : null}
 
       <h3 className={styles.previewHeading}>
-        Latest articles ({preview.length})
+        최근 기사 ({preview.length})
       </h3>
       {preview.length === 0 ? (
-        <p className={styles.muted}>No recent articles to preview.</p>
+        <p className={styles.muted}>미리 볼 최근 기사가 없습니다.</p>
       ) : (
         <ul className={styles.previewList}>
           {preview.map((item) => (

--- a/frontend/trading-decision/src/components/NxtVenueBadge.tsx
+++ b/frontend/trading-decision/src/components/NxtVenueBadge.tsx
@@ -22,10 +22,10 @@ export default function NxtVenueBadge({
   if (marketScope !== "kr") return null;
 
   if (nxtClassification === "data_mismatch_requires_review") {
-    const badgeLabel = "NXT review needed";
+    const badgeLabel = "NXT 검토 필요";
     return (
       <span
-        aria-label={`NXT venue: ${badgeLabel}`}
+        aria-label={`NXT 거래소: ${badgeLabel}`}
         className={`${styles.badge} ${styles.review}`}
       >
         {badgeLabel}
@@ -33,10 +33,10 @@ export default function NxtVenueBadge({
     );
   }
   if (nxtEligible === false) {
-    const badgeLabel = "Non-NXT (KR broker)";
+    const badgeLabel = "비-NXT (국내 브로커)";
     return (
       <span
-        aria-label={`NXT venue: ${badgeLabel}`}
+        aria-label={`NXT 거래소: ${badgeLabel}`}
         className={`${styles.badge} ${styles.nonNxt}`}
       >
         {badgeLabel}
@@ -44,10 +44,10 @@ export default function NxtVenueBadge({
     );
   }
   if (nxtEligible === null) {
-    const badgeLabel = "NXT eligibility unknown";
+    const badgeLabel = "NXT 자격 알 수 없음";
     return (
       <span
-        aria-label={`NXT venue: ${badgeLabel}`}
+        aria-label={`NXT 거래소: ${badgeLabel}`}
         className={`${styles.badge} ${styles.unknown}`}
       >
         {badgeLabel}
@@ -58,20 +58,20 @@ export default function NxtVenueBadge({
     nxtClassification !== null &&
     ACTIONABLE.indexOf(nxtClassification) >= 0
   ) {
-    const badgeLabel = "NXT actionable";
+    const badgeLabel = "NXT 실행 가능";
     return (
       <span
-        aria-label={`NXT venue: ${badgeLabel}`}
+        aria-label={`NXT 거래소: ${badgeLabel}`}
         className={`${styles.badge} ${styles.actionable}`}
       >
         {badgeLabel}
       </span>
     );
   }
-  const badgeLabel = "NXT not actionable";
+  const badgeLabel = "NXT 실행 불가";
   return (
     <span
-      aria-label={`NXT venue: ${badgeLabel}`}
+      aria-label={`NXT 거래소: ${badgeLabel}`}
       className={`${styles.badge} ${styles.notActionable}`}
     >
       {badgeLabel}

--- a/frontend/trading-decision/src/components/OperatorEventForm.tsx
+++ b/frontend/trading-decision/src/components/OperatorEventForm.tsx
@@ -41,7 +41,7 @@ export default function OperatorEventForm({
     setError(null);
     const trimmed = sourceText.trim();
     if (!trimmed) {
-      setError("Source text is required.");
+      setError("소스 텍스트는 필수입니다.");
       return;
     }
 
@@ -61,7 +61,7 @@ export default function OperatorEventForm({
     const res = await onSubmit(body);
     setSubmitting(false);
     if (!res.ok) {
-      setError(res.detail ?? "Could not submit strategy event.");
+      setError(res.detail ?? "전략 이벤트를 제출할 수 없습니다.");
       return;
     }
     setSourceText("");
@@ -74,29 +74,29 @@ export default function OperatorEventForm({
     <form
       className={styles.form}
       onSubmit={handleSubmit}
-      aria-label="Add operator market event"
+      aria-label="운영자 시장 이벤트 추가"
       noValidate
     >
       <label className={styles.fullWidth}>
-        Source text
+        소스 텍스트
         <textarea
           value={sourceText}
           onChange={(e) => setSourceText(e.target.value)}
-          placeholder="e.g. OpenAI earnings missed expectations"
+          placeholder="예: OpenAI 실적이 기대치 하회"
         />
       </label>
 
       <label className={styles.fullWidth}>
-        Affected symbols (comma-separated, optional)
+        영향 종목 (쉼표로 구분, 선택)
         <input
           value={symbolsRaw}
           onChange={(e) => setSymbolsRaw(e.target.value)}
-          placeholder="e.g. MSFT, NVDA"
+          placeholder="예: MSFT, NVDA"
         />
       </label>
 
       <label>
-        Severity (1–5)
+        심각도 (1–5)
         <input
           type="number"
           min={1}
@@ -108,7 +108,7 @@ export default function OperatorEventForm({
       </label>
 
       <label>
-        Confidence (0–100)
+        신뢰도 (0–100)
         <input
           type="number"
           min={0}
@@ -126,7 +126,7 @@ export default function OperatorEventForm({
       ) : null}
 
       <button type="submit" disabled={submitting}>
-        {submitting ? "Submitting..." : "Add event"}
+        {submitting ? "제출 중…" : "이벤트 추가"}
       </button>
     </form>
   );

--- a/frontend/trading-decision/src/components/OriginalVsAdjustedSummary.tsx
+++ b/frontend/trading-decision/src/components/OriginalVsAdjustedSummary.tsx
@@ -19,7 +19,7 @@ export default function OriginalVsAdjustedSummary({
           <dd>
             <span>{pair.original ?? "—"}</span>
             {" → "}
-            <strong>{pair.user ?? "(unchanged)"}</strong>
+            <strong>{pair.user ?? "(변경 없음)"}</strong>
           </dd>
         </div>
       ))}

--- a/frontend/trading-decision/src/components/OutcomeMarkForm.tsx
+++ b/frontend/trading-decision/src/components/OutcomeMarkForm.tsx
@@ -6,6 +6,7 @@ import type {
   OutcomeHorizon,
   TrackKind,
 } from "../api/types";
+import { COMMON, OUTCOME_HORIZON_LABEL, TRACK_KIND_LABEL } from "../i18n";
 import styles from "./OutcomeMarkForm.module.css";
 
 const TRACKS: TrackKind[] = [
@@ -42,15 +43,15 @@ export default function OutcomeMarkForm({
     setError(null);
 
     if (!price || !Number.isFinite(Number(price)) || Number(price) < 0) {
-      setError("price_at_mark must be a non-negative number");
+      setError("마크 시점 가격은 0 이상의 숫자여야 합니다");
       return;
     }
     if (trackKind === "accepted_live" && counterfactualId) {
-      setError("accepted_live must not have a counterfactual selected");
+      setError("accepted_live 트랙은 대조군을 선택할 수 없습니다");
       return;
     }
     if (trackKind !== "accepted_live" && !counterfactualId) {
-      setError("counterfactual is required for this track");
+      setError("이 트랙에서는 대조군이 필요합니다");
       return;
     }
 
@@ -68,7 +69,7 @@ export default function OutcomeMarkForm({
     const res = await onSubmit(body);
     setSubmitting(false);
     if (!res.ok) {
-      setError(res.detail ?? "Could not record outcome mark.");
+      setError(res.detail ?? "결과 마크를 기록할 수 없습니다.");
       return;
     }
     setPrice("");
@@ -80,10 +81,10 @@ export default function OutcomeMarkForm({
     <form
       className={styles.form}
       onSubmit={handleSubmit}
-      aria-label="Record outcome mark"
+      aria-label="결과 마크 기록"
     >
       <label>
-        Track
+        트랙
         <select
           value={trackKind}
           onChange={(e) => {
@@ -94,21 +95,21 @@ export default function OutcomeMarkForm({
         >
           {TRACKS.map((t) => (
             <option key={t} value={t}>
-              {t}
+              {TRACK_KIND_LABEL[t]}
             </option>
           ))}
         </select>
       </label>
 
       <label>
-        Horizon
+        기간
         <select
           value={horizon}
           onChange={(e) => setHorizon(e.target.value as OutcomeHorizon)}
         >
           {HORIZONS.map((h) => (
             <option key={h} value={h}>
-              {h}
+              {OUTCOME_HORIZON_LABEL[h]}
             </option>
           ))}
         </select>
@@ -116,17 +117,17 @@ export default function OutcomeMarkForm({
 
       {trackKind !== "accepted_live" ? (
         <label>
-          Counterfactual
+          대조군
           <select
             value={counterfactualId}
             onChange={(e) => setCounterfactualId(e.target.value)}
           >
-            <option value="">— select —</option>
+            <option value="">— 선택 —</option>
             {counterfactuals
               .filter((c) => c.track_kind === trackKind)
               .map((c) => (
                 <option key={c.id} value={c.id}>
-                  #{c.id} · baseline {c.baseline_price}
+                  #{c.id} · 기준가 {c.baseline_price}
                 </option>
               ))}
           </select>
@@ -134,29 +135,29 @@ export default function OutcomeMarkForm({
       ) : null}
 
       <label>
-        Price at mark
+        마크 시점 가격
         <input
           value={price}
           onChange={(e) => setPrice(e.target.value)}
-          placeholder="e.g. 118000000"
+          placeholder="예: 118000000"
         />
       </label>
 
       <label>
-        PnL %
+        손익(%)
         <input
           value={pnlPct}
           onChange={(e) => setPnlPct(e.target.value)}
-          placeholder="optional"
+          placeholder="선택"
         />
       </label>
 
       <label>
-        PnL amount
+        손익 금액
         <input
           value={pnlAmount}
           onChange={(e) => setPnlAmount(e.target.value)}
-          placeholder="optional"
+          placeholder="선택"
         />
       </label>
 
@@ -167,7 +168,7 @@ export default function OutcomeMarkForm({
       ) : null}
 
       <button type="submit" disabled={submitting}>
-        {submitting ? "Saving..." : "Record mark"}
+        {submitting ? COMMON.saving : "마크 기록"}
       </button>
     </form>
   );

--- a/frontend/trading-decision/src/components/OutcomesPanel.tsx
+++ b/frontend/trading-decision/src/components/OutcomesPanel.tsx
@@ -1,6 +1,7 @@
 import type { OutcomeDetail, OutcomeHorizon, TrackKind } from "../api/types";
 import { formatDateTime } from "../format/datetime";
 import { formatDecimal } from "../format/decimal";
+import { OUTCOME_HORIZON_LABEL, TRACK_KIND_LABEL } from "../i18n";
 import styles from "./OutcomesPanel.module.css";
 
 const TRACKS: TrackKind[] = [
@@ -18,20 +19,20 @@ interface OutcomesPanelProps {
 
 export default function OutcomesPanel({ outcomes }: OutcomesPanelProps) {
   if (outcomes.length === 0) {
-    return <p className={styles.empty}>No outcome marks yet.</p>;
+    return <p className={styles.empty}>아직 결과 마크가 없습니다.</p>;
   }
 
   const cell = (track: TrackKind, horizon: OutcomeHorizon) =>
     outcomes.find((o) => o.track_kind === track && o.horizon === horizon);
 
   return (
-    <table className={styles.table} aria-label="Outcome marks">
+    <table className={styles.table} aria-label="결과 마크">
       <thead>
         <tr>
-          <th scope="col">Track</th>
+          <th scope="col">트랙</th>
           {HORIZONS.map((h) => (
             <th key={h} scope="col">
-              {h}
+              {OUTCOME_HORIZON_LABEL[h]}
             </th>
           ))}
         </tr>
@@ -40,7 +41,7 @@ export default function OutcomesPanel({ outcomes }: OutcomesPanelProps) {
         {TRACKS.map((track) => (
           <tr key={track}>
             <th scope="row" className={styles.trackCell}>
-              {track}
+              {TRACK_KIND_LABEL[track]}
             </th>
             {HORIZONS.map((h) => {
               const o = cell(track, h);
@@ -73,9 +74,9 @@ function formatPct(pct: string | null | undefined): string {
 
 function tooltip(o: OutcomeDetail): string {
   return [
-    `price_at_mark: ${formatDecimal(o.price_at_mark)}`,
-    o.pnl_amount ? `pnl_amount: ${formatDecimal(o.pnl_amount)}` : null,
-    `marked_at: ${formatDateTime(o.marked_at)}`,
+    `마크 시점 가격: ${formatDecimal(o.price_at_mark)}`,
+    o.pnl_amount ? `손익 금액: ${formatDecimal(o.pnl_amount)}` : null,
+    `기록 시각: ${formatDateTime(o.marked_at)}`,
   ]
     .filter(Boolean)
     .join(" · ");

--- a/frontend/trading-decision/src/components/ProposalAdjustmentEditor.tsx
+++ b/frontend/trading-decision/src/components/ProposalAdjustmentEditor.tsx
@@ -4,6 +4,7 @@ import type {
   ProposalRespondRequest,
   RespondAction,
 } from "../api/types";
+import { COMMON } from "../i18n";
 import styles from "./ProposalAdjustmentEditor.module.css";
 
 type AdjustResponse = Extract<RespondAction, "modify" | "partial_accept">;
@@ -26,33 +27,33 @@ interface FieldSpec {
 }
 
 const specs: FieldSpec[] = [
-  { label: "Quantity", userKey: "user_quantity", originalKey: "original_quantity" },
+  { label: "수량", userKey: "user_quantity", originalKey: "original_quantity" },
   {
-    label: "Quantity percent",
+    label: "수량 비율(%)",
     userKey: "user_quantity_pct",
     originalKey: "original_quantity_pct",
     percent: true,
   },
   {
-    label: "Amount",
+    label: "금액",
     userKey: "user_amount",
     originalKey: "original_amount",
     nonNegative: true,
   },
   {
-    label: "Price",
+    label: "가격",
     userKey: "user_price",
     originalKey: "original_price",
     nonNegative: true,
   },
   {
-    label: "Trigger price",
+    label: "트리거 가격",
     userKey: "user_trigger_price",
     originalKey: "original_trigger_price",
     nonNegative: true,
   },
   {
-    label: "Threshold percent",
+    label: "임계 비율(%)",
     userKey: "user_threshold_pct",
     originalKey: "original_threshold_pct",
     percent: true,
@@ -100,16 +101,16 @@ export default function ProposalAdjustmentEditor({
       const value = values[spec.userKey].trim();
       if (!value) continue;
       if (!decimalPattern.test(value)) {
-        setError(`${spec.label} must be a decimal string.`);
+        setError(`${spec.label}은(는) 소수 문자열이어야 합니다.`);
         return;
       }
       const parsed = Number(value);
       if (spec.nonNegative && parsed < 0) {
-        setError(`${spec.label} must be greater than or equal to 0.`);
+        setError(`${spec.label}은(는) 0 이상이어야 합니다.`);
         return;
       }
       if (spec.percent && (parsed < 0 || parsed > 100)) {
-        setError(`${spec.label} must be between 0 and 100.`);
+        setError(`${spec.label}은(는) 0 이상 100 이하이어야 합니다.`);
         return;
       }
       body[spec.userKey] = value;
@@ -117,7 +118,7 @@ export default function ProposalAdjustmentEditor({
     }
 
     if (!hasNumeric) {
-      setError("Enter at least one adjusted numeric value.");
+      setError("조정된 숫자 값을 하나 이상 입력해 주세요.");
       return;
     }
     if (userNote.trim()) body.user_note = userNote.trim();
@@ -125,7 +126,7 @@ export default function ProposalAdjustmentEditor({
     setIsSubmitting(true);
     const result = await onSubmit(body);
     setIsSubmitting(false);
-    if (!result.ok) setError(result.detail ?? "Something went wrong. Try again.");
+    if (!result.ok) setError(result.detail ?? COMMON.somethingWentWrong);
   }
 
   return (
@@ -156,7 +157,7 @@ export default function ProposalAdjustmentEditor({
         ))}
       </div>
       <label className={styles.field}>
-        <span>Note</span>
+        <span>메모</span>
         <textarea
           maxLength={4000}
           onChange={(event) => setUserNote(event.target.value)}
@@ -166,10 +167,10 @@ export default function ProposalAdjustmentEditor({
       </label>
       <div className={styles.actions}>
         <button className="btn btn-primary" disabled={isSubmitting} type="submit">
-          Save {response === "partial_accept" ? "partial accept" : "modify"}
+          {response === "partial_accept" ? "부분 수락 저장" : "수정 저장"}
         </button>
         <button className="btn btn-ghost" disabled={isSubmitting} onClick={onCancel} type="button">
-          Cancel
+          취소
         </button>
       </div>
     </form>

--- a/frontend/trading-decision/src/components/ProposalResponseControls.tsx
+++ b/frontend/trading-decision/src/components/ProposalResponseControls.tsx
@@ -1,4 +1,5 @@
 import type { RespondAction, UserResponseValue } from "../api/types";
+import { RESPONSE_BUTTON_LABEL } from "../i18n";
 
 interface ProposalResponseControlsProps {
   currentResponse: UserResponseValue;
@@ -7,16 +8,12 @@ interface ProposalResponseControlsProps {
   onOpenAdjust: (response: "modify" | "partial_accept") => void;
 }
 
-const buttons: Array<{
-  label: string;
-  value: RespondAction;
-  kind: "simple" | "adjust";
-}> = [
-  { label: "Accept", value: "accept", kind: "simple" },
-  { label: "Partial accept", value: "partial_accept", kind: "adjust" },
-  { label: "Modify", value: "modify", kind: "adjust" },
-  { label: "Defer", value: "defer", kind: "simple" },
-  { label: "Reject", value: "reject", kind: "simple" },
+const buttons: Array<{ value: RespondAction; kind: "simple" | "adjust" }> = [
+  { value: "accept", kind: "simple" },
+  { value: "partial_accept", kind: "adjust" },
+  { value: "modify", kind: "adjust" },
+  { value: "defer", kind: "simple" },
+  { value: "reject", kind: "simple" },
 ];
 
 export default function ProposalResponseControls({
@@ -26,7 +23,7 @@ export default function ProposalResponseControls({
   onOpenAdjust,
 }: ProposalResponseControlsProps) {
   return (
-    <div className="response-controls" aria-label="Proposal response controls">
+    <div className="response-controls" aria-label="제안 응답 컨트롤">
       {buttons.map((button) => (
         <button
           aria-pressed={currentResponse === button.value}
@@ -37,12 +34,12 @@ export default function ProposalResponseControls({
             if (button.value === "modify" || button.value === "partial_accept") {
               onOpenAdjust(button.value);
             } else {
-              onSimpleResponse(button.value);
+              onSimpleResponse(button.value as "accept" | "reject" | "defer");
             }
           }}
           type="button"
         >
-          {button.label}
+          {RESPONSE_BUTTON_LABEL[button.value]}
         </button>
       ))}
     </div>

--- a/frontend/trading-decision/src/components/ProposalRow.tsx
+++ b/frontend/trading-decision/src/components/ProposalRow.tsx
@@ -7,6 +7,11 @@ import type {
 import { parseReconciliationPayload } from "../api/reconciliation";
 import { formatDateTime } from "../format/datetime";
 import { formatDecimal } from "../format/decimal";
+import {
+  COMMON,
+  PROPOSAL_KIND_LABEL,
+  SIDE_LABEL,
+} from "../i18n";
 import LinkedActionsPanel from "./LinkedActionsPanel";
 import NxtVenueBadge from "./NxtVenueBadge";
 import OriginalVsAdjustedSummary from "./OriginalVsAdjustedSummary";
@@ -33,12 +38,12 @@ interface ProposalRowProps {
 }
 
 const valuePairs = [
-  ["Quantity", "original_quantity", "user_quantity"],
-  ["Quantity percent", "original_quantity_pct", "user_quantity_pct"],
-  ["Amount", "original_amount", "user_amount"],
-  ["Price", "original_price", "user_price"],
-  ["Trigger price", "original_trigger_price", "user_trigger_price"],
-  ["Threshold percent", "original_threshold_pct", "user_threshold_pct"],
+  ["수량", "original_quantity", "user_quantity"],
+  ["수량 비율(%)", "original_quantity_pct", "user_quantity_pct"],
+  ["금액", "original_amount", "user_amount"],
+  ["가격", "original_price", "user_price"],
+  ["트리거 가격", "original_trigger_price", "user_trigger_price"],
+  ["임계 비율(%)", "original_threshold_pct", "user_threshold_pct"],
 ] as const;
 
 export default function ProposalRow({
@@ -72,8 +77,8 @@ export default function ProposalRow({
     if (!result.ok) {
       const message =
         result.status === 409
-          ? "Session is archived. You can no longer respond."
-          : (result.detail ?? "Something went wrong. Try again.");
+          ? "세션이 보관되었습니다. 더 이상 응답할 수 없습니다."
+          : (result.detail ?? COMMON.somethingWentWrong);
       setBanner(message);
       return { ok: false, detail: message };
     }
@@ -90,8 +95,8 @@ export default function ProposalRow({
             <span className={styles.symbol}>{proposal.symbol}</span>
           ) : null}
         </div>
-        <span className={styles.chip}>{proposal.side}</span>
-        <span className={styles.chip}>{proposal.proposal_kind}</span>
+        <span className={styles.chip}>{SIDE_LABEL[proposal.side]}</span>
+        <span className={styles.chip}>{PROPOSAL_KIND_LABEL[proposal.proposal_kind]}</span>
         <StatusBadge value={proposal.user_response} />
         {recon ? (
           <>
@@ -111,7 +116,7 @@ export default function ProposalRow({
       ) : null}
       <div className={styles.panels}>
         <section className={styles.panel}>
-          <h3>Original</h3>
+          <h3>원본</h3>
           <ValueList proposal={proposal} prefix="original" />
           {proposal.original_rationale ? (
             <p className={styles.rationale}>{proposal.original_rationale}</p>
@@ -119,7 +124,7 @@ export default function ProposalRow({
         </section>
         {proposal.user_response !== "pending" ? (
           <section className={styles.panel}>
-            <h3>Your decision</h3>
+            <h3>내 결정</h3>
             <p>
               <StatusBadge value={proposal.user_response} /> ·{" "}
               {formatDateTime(proposal.responded_at)}
@@ -131,7 +136,7 @@ export default function ProposalRow({
       </div>
       {cryptoPaperWorkflow?.approval_copy?.length ? (
         <section className={styles.cryptoPaperWorkflow}>
-          <h3>Crypto paper workflow</h3>
+          <h3>암호화폐 모의 워크플로우</h3>
           <ul>
             {cryptoPaperWorkflow.approval_copy.map((line) => (
               <li key={line}>{line}</li>
@@ -150,9 +155,7 @@ export default function ProposalRow({
           />
           {nonActionable ? (
             <p className={styles.nonActionableAlert} role="alert">
-              Non-NXT pending order — KR broker routing only. Review before
-              deciding; recording a response on this row does not place or
-              cancel a broker order.
+              비-NXT 대기 주문 — 국내 브로커 라우팅 전용. 결정 전에 검토하세요. 이 행의 응답 기록은 브로커 주문을 제출하거나 취소하지 않습니다.
             </p>
           ) : null}
         </>
@@ -165,7 +168,7 @@ export default function ProposalRow({
       />
       {!nonActionable ? (
         <p className={styles.safetyNote}>
-          Accept records this decision only; it does not send a live trade.
+          수락은 결정만 기록합니다. 실주문을 전송하지 않습니다.
         </p>
       ) : null}
       {adjustResponse ? (
@@ -180,10 +183,10 @@ export default function ProposalRow({
         actions={proposal.actions}
         counterfactuals={proposal.counterfactuals}
       />
-      <section className={styles.outcomes} aria-label="Outcome marks">
+      <section className={styles.outcomes} aria-label="결과 마크">
         <OutcomesPanel outcomes={proposal.outcomes} />
         <details>
-          <summary>Record outcome mark</summary>
+          <summary>결과 마크 기록</summary>
           <OutcomeMarkForm
             counterfactuals={proposal.counterfactuals}
             onSubmit={(body) => onRecordOutcome(proposal.proposal_uuid, body)}
@@ -241,7 +244,7 @@ function isMissingSellAmount(
   proposal: ProposalDetail,
 ) {
   return (
-    label === "Amount" &&
+    label === "금액" &&
     proposal.side === "sell" &&
     Number(value) === 0 &&
     proposal.original_price === null
@@ -254,10 +257,10 @@ function formatProposalValue(
   proposal: ProposalDetail,
 ) {
   if (isMissingSellAmount(label, value, proposal)) {
-    return "Current quote estimate needed";
+    return "현재 시세 추정이 필요합니다";
   }
   return `${formatDecimal(value)}${
-    label === "Amount" && proposal.original_currency
+    label === "금액" && proposal.original_currency
       ? ` ${proposal.original_currency}`
       : ""
   }`;

--- a/frontend/trading-decision/src/components/ReadinessStatusBadge.tsx
+++ b/frontend/trading-decision/src/components/ReadinessStatusBadge.tsx
@@ -1,11 +1,6 @@
 import type { PreopenNewsReadinessStatus } from "../api/types";
+import { NEWS_READINESS_LABEL } from "../i18n";
 import styles from "./ReadinessStatusBadge.module.css";
-
-const LABELS: Record<PreopenNewsReadinessStatus, string> = {
-  ready: "Ready",
-  stale: "Stale",
-  unavailable: "Unavailable",
-};
 
 export interface ReadinessStatusBadgeProps {
   status: PreopenNewsReadinessStatus;
@@ -20,7 +15,7 @@ export default function ReadinessStatusBadge({
       data-status={status}
       role="status"
     >
-      {LABELS[status]}
+      {NEWS_READINESS_LABEL[status]}
     </span>
   );
 }

--- a/frontend/trading-decision/src/components/ReconciliationBadge.tsx
+++ b/frontend/trading-decision/src/components/ReconciliationBadge.tsx
@@ -1,27 +1,17 @@
 import type { ReconciliationStatus } from "../api/reconciliation";
+import { RECONCILIATION_STATUS_LABEL } from "../i18n";
 import styles from "./ReconciliationBadge.module.css";
 
 interface Props {
   value: ReconciliationStatus | null;
 }
 
-const LABEL: Record<ReconciliationStatus, string> = {
-  maintain: "Maintain",
-  near_fill: "Near fill",
-  too_far: "Too far",
-  chasing_risk: "Chasing risk",
-  data_mismatch: "Data mismatch",
-  kr_pending_non_nxt: "KR broker only",
-  unknown_venue: "Unknown venue",
-  unknown: "Unknown",
-};
-
 export default function ReconciliationBadge({ value }: Props) {
   if (value === null) return null;
-  const label = LABEL[value];
+  const label = RECONCILIATION_STATUS_LABEL[value];
   return (
     <span
-      aria-label={`Reconciliation status: ${label}`}
+      aria-label={`조정 상태: ${label}`}
       className={`${styles.badge} ${styles[value]}`}
     >
       {label}

--- a/frontend/trading-decision/src/components/ReconciliationDecisionSupportPanel.tsx
+++ b/frontend/trading-decision/src/components/ReconciliationDecisionSupportPanel.tsx
@@ -2,6 +2,7 @@ import type { ReconciliationPayload } from "../api/reconciliation";
 import { formatDateTime } from "../format/datetime";
 import { formatDecimal } from "../format/decimal";
 import { formatPercent } from "../format/percent";
+import { labelOrderSide } from "../i18n/formatters";
 import styles from "./ReconciliationDecisionSupportPanel.module.css";
 
 interface Props {
@@ -21,16 +22,16 @@ export default function ReconciliationDecisionSupportPanel({
   const ds = payload.decision_support;
   return (
     <section
-      aria-label="Reconciliation decision support"
+      aria-label="조정 의사결정 지원"
       className={styles.panel}
     >
       <dl className={styles.list}>
-        <Item label="Pending side" value={side} />
-        <Item label="Pending price" value={formatDecimal(originalPrice)} />
-        <Item label="Pending qty" value={formatDecimal(originalQuantity)} />
-        <Item label="Pending order" value={payload.pending_order_id ?? "—"} />
+        <Item label="대기 방향" value={labelOrderSide(side)} />
+        <Item label="대기 가격" value={formatDecimal(originalPrice)} />
+        <Item label="대기 수량" value={formatDecimal(originalQuantity)} />
+        <Item label="대기 주문" value={payload.pending_order_id ?? "—"} />
         <Item
-          label="Live quote"
+          label="실시간 시세"
           value={
             payload.live_quote === null
               ? "—"
@@ -39,13 +40,13 @@ export default function ReconciliationDecisionSupportPanel({
                 )})`
           }
         />
-        <Item label="Gap to current" value={formatPercent(ds.gap_pct)} />
+        <Item label="현재가 대비 괴리" value={formatPercent(ds.gap_pct)} />
         <Item
-          label="Distance to fill"
+          label="체결까지 거리"
           value={formatPercent(ds.signed_distance_to_fill)}
         />
         <Item
-          label="Nearest support"
+          label="가까운 지지선"
           value={
             ds.nearest_support_price === null
               ? "—"
@@ -55,7 +56,7 @@ export default function ReconciliationDecisionSupportPanel({
           }
         />
         <Item
-          label="Nearest resistance"
+          label="가까운 저항선"
           value={
             ds.nearest_resistance_price === null
               ? "—"
@@ -65,7 +66,7 @@ export default function ReconciliationDecisionSupportPanel({
           }
         />
         <Item
-          label="Bid/ask spread"
+          label="매수/매도 스프레드"
           value={formatPercent(ds.bid_ask_spread_pct)}
         />
       </dl>

--- a/frontend/trading-decision/src/components/StatusBadge.tsx
+++ b/frontend/trading-decision/src/components/StatusBadge.tsx
@@ -1,10 +1,20 @@
 import type { SessionStatus, UserResponseValue } from "../api/types";
+import { SESSION_STATUS_LABEL, USER_RESPONSE_LABEL } from "../i18n";
 import styles from "./StatusBadge.module.css";
 
 interface StatusBadgeProps {
   value: SessionStatus | UserResponseValue;
 }
 
+function labelFor(value: SessionStatus | UserResponseValue): string {
+  if (value in SESSION_STATUS_LABEL) {
+    return SESSION_STATUS_LABEL[value as SessionStatus];
+  }
+  return USER_RESPONSE_LABEL[value as UserResponseValue];
+}
+
 export default function StatusBadge({ value }: StatusBadgeProps) {
-  return <span className={`${styles.badge} ${styles[value]}`}>{value}</span>;
+  return (
+    <span className={`${styles.badge} ${styles[value]}`}>{labelFor(value)}</span>
+  );
 }

--- a/frontend/trading-decision/src/components/StrategyEventTimeline.tsx
+++ b/frontend/trading-decision/src/components/StrategyEventTimeline.tsx
@@ -1,5 +1,7 @@
 import { formatDateTime } from "../format/datetime";
 import type { StrategyEventDetail } from "../api/types";
+import { STRATEGY_EVENT_TYPE_LABEL } from "../i18n";
+import { labelOrToken } from "../i18n/formatters";
 import styles from "./StrategyEventTimeline.module.css";
 
 interface StrategyEventTimelineProps {
@@ -11,21 +13,21 @@ export default function StrategyEventTimeline({
 }: StrategyEventTimelineProps) {
   if (events.length === 0) {
     return (
-      <p className={styles.empty}>
-        No strategy events yet for this session.
-      </p>
+      <p className={styles.empty}>이 세션에는 전략 이벤트가 없습니다.</p>
     );
   }
   return (
-    <ol className={styles.timeline} aria-label="Strategy events">
+    <ol className={styles.timeline} aria-label="전략 이벤트">
       {events.map((event) => {
         const summary = event.normalized_summary ?? event.source_text;
         return (
           <li key={event.event_uuid} className={styles.event}>
             <div className={styles.eventHeader}>
-              <span className={styles.type}>{event.event_type}</span>
-              <span>severity {event.severity}</span>
-              <span>confidence {event.confidence}</span>
+              <span className={styles.type}>
+                {labelOrToken(STRATEGY_EVENT_TYPE_LABEL, event.event_type)}
+              </span>
+              <span>심각도 {event.severity}</span>
+              <span>신뢰도 {event.confidence}</span>
               <span className={styles.meta}>
                 {formatDateTime(event.created_at)}
               </span>

--- a/frontend/trading-decision/src/components/WarningChips.tsx
+++ b/frontend/trading-decision/src/components/WarningChips.tsx
@@ -1,34 +1,29 @@
+import { WARNING_TOKEN_LABEL } from "../i18n";
+import { labelOperatorToken } from "../i18n/formatters";
 import styles from "./WarningChips.module.css";
 
 interface Props {
   tokens: string[];
 }
 
-const FRIENDLY: Record<string, string> = {
-  missing_quote: "Quote missing",
-  stale_quote: "Quote stale",
-  missing_orderbook: "Orderbook missing",
-  missing_support_resistance: "Support / resistance unavailable",
-  missing_kr_universe: "KR universe row missing",
-  non_nxt_venue: "Non-NXT venue",
-  unknown_venue: "Unknown venue",
-  unknown_side: "Unknown side",
-};
-
 const TOKEN_RE = /^[a-z][a-z0-9_]{0,63}$/;
+
+function labelFor(token: string): string {
+  return WARNING_TOKEN_LABEL[token] ?? labelOperatorToken(token);
+}
 
 export default function WarningChips({ tokens }: Props) {
   const safe = tokens.filter((t) => TOKEN_RE.test(t));
   if (safe.length === 0) return null;
   return (
-    <ul aria-label="Warnings" className={styles.list}>
+    <ul aria-label="경고" className={styles.list}>
       {safe.map((token) => (
         <li
-          aria-label={`Warning: ${FRIENDLY[token] ?? token}`}
+          aria-label={`경고: ${labelFor(token)}`}
           className={styles.chip}
           key={token}
         >
-          {FRIENDLY[token] ?? token}
+          {labelFor(token)}
         </li>
       ))}
     </ul>

--- a/frontend/trading-decision/src/format/datetime.ts
+++ b/frontend/trading-decision/src/format/datetime.ts
@@ -1,6 +1,6 @@
 export function formatDateTime(
   iso: string | null | undefined,
-  locale = "en-US",
+  locale = "ko-KR",
 ): string {
   if (!iso) return "—";
   const d = new Date(iso);

--- a/frontend/trading-decision/src/format/decimal.ts
+++ b/frontend/trading-decision/src/format/decimal.ts
@@ -1,6 +1,6 @@
 export function formatDecimal(
   s: string | null | undefined,
-  locale = "en-US",
+  locale = "ko-KR",
   opts: Intl.NumberFormatOptions = { maximumFractionDigits: 8 },
 ): string {
   if (s === null || s === undefined) return "—";

--- a/frontend/trading-decision/src/i18n/formatters.ts
+++ b/frontend/trading-decision/src/i18n/formatters.ts
@@ -1,0 +1,31 @@
+import { COMMON } from "./ko";
+
+export function labelOrToken<K extends string>(
+  map: Readonly<Record<K, string>>,
+  key: string | null | undefined,
+): string {
+  if (key === null || key === undefined || key === "") return COMMON.dash;
+  const known = (map as Record<string, string>)[key];
+  if (known !== undefined) return known;
+  return formatToken(key);
+}
+
+export function labelOperatorToken(value: string | null | undefined): string {
+  if (value === null || value === undefined || value === "") return COMMON.dash;
+  return formatToken(value);
+}
+
+export function labelOrderSide(side: string | null | undefined): string {
+  if (side === "buy") return "매수";
+  if (side === "sell") return "매도";
+  return COMMON.dash;
+}
+
+export function labelYesNo(value: boolean | null | undefined): string {
+  if (value === null || value === undefined) return COMMON.dash;
+  return value ? COMMON.yes : COMMON.no;
+}
+
+function formatToken(raw: string): string {
+  return raw.replace(/_/g, " ");
+}

--- a/frontend/trading-decision/src/i18n/index.ts
+++ b/frontend/trading-decision/src/i18n/index.ts
@@ -1,0 +1,2 @@
+export * from "./ko";
+export * from "./formatters";

--- a/frontend/trading-decision/src/i18n/ko.ts
+++ b/frontend/trading-decision/src/i18n/ko.ts
@@ -19,6 +19,7 @@ import type {
   ProposalKind,
   SessionStatus,
   Side,
+  StrategyEventType,
   TrackKind,
   UserResponseValue,
   WorkflowStatus,
@@ -295,6 +296,17 @@ export const SAFETY_SCOPE_LABEL: Record<string, string> = {
 export const PURPOSE_LABEL: Record<string, string> = {
   paper_plumbing_smoke: "페이퍼 배관 점검",
   alpha_candidate_review: "알파 후보 리뷰",
+};
+
+export const STRATEGY_EVENT_TYPE_LABEL: Record<StrategyEventType, string> = {
+  operator_market_event: "운영자 시장 이벤트",
+  earnings_event: "실적 이벤트",
+  macro_event: "매크로 이벤트",
+  sector_rotation: "섹터 로테이션",
+  technical_break: "기술적 돌파",
+  risk_veto: "리스크 거부",
+  cash_budget_change: "현금 예산 변경",
+  position_change: "포지션 변경",
 };
 
 export const COMMON = {

--- a/frontend/trading-decision/src/i18n/ko.ts
+++ b/frontend/trading-decision/src/i18n/ko.ts
@@ -1,0 +1,315 @@
+import type {
+  ActionKind,
+  CommitteeAccountMode,
+  ExecutionAccountMode,
+  ExecutionReviewStageStatus,
+  ExecutionSource,
+  InstrumentType,
+  OutcomeHorizon,
+  PreopenArtifactReadinessStatus,
+  PreopenArtifactStatus,
+  PreopenNewsReadinessStatus,
+  PreopenPaperApprovalBridgeStatus,
+  PreopenPaperApprovalCandidateStatus,
+  PreopenQaCheckSeverity,
+  PreopenQaCheckStatus,
+  PreopenQaConfidence,
+  PreopenQaEvaluatorStatus,
+  PreopenQaGrade,
+  ProposalKind,
+  SessionStatus,
+  Side,
+  TrackKind,
+  UserResponseValue,
+  WorkflowStatus,
+} from "../api/types";
+import type {
+  CandidateKind,
+  NxtClassification,
+  ReconciliationStatus,
+} from "../api/reconciliation";
+
+export const SESSION_STATUS_LABEL: Record<SessionStatus, string> = {
+  open: "진행 중",
+  closed: "종료",
+  archived: "보관됨",
+};
+
+export const USER_RESPONSE_LABEL: Record<UserResponseValue, string> = {
+  pending: "대기",
+  accept: "수락",
+  partial_accept: "부분 수락",
+  modify: "수정",
+  defer: "보류",
+  reject: "거절",
+};
+
+export const RESPONSE_BUTTON_LABEL: Record<
+  "accept" | "partial_accept" | "modify" | "defer" | "reject",
+  string
+> = {
+  accept: "수락",
+  partial_accept: "부분 수락",
+  modify: "수정",
+  defer: "보류",
+  reject: "거절",
+};
+
+export const SIDE_LABEL: Record<Side, string> = {
+  buy: "매수",
+  sell: "매도",
+  none: "—",
+};
+
+export const PROPOSAL_KIND_LABEL: Record<ProposalKind, string> = {
+  trim: "축소",
+  add: "추가 매수",
+  enter: "신규 진입",
+  exit: "청산",
+  pullback_watch: "되돌림 관찰",
+  breakout_watch: "돌파 관찰",
+  avoid: "회피",
+  no_action: "무행동",
+  other: "기타",
+};
+
+export const ACTION_KIND_LABEL: Record<ActionKind, string> = {
+  live_order: "실주문",
+  paper_order: "모의주문",
+  watch_alert: "감시 알림",
+  no_action: "무행동",
+  manual_note: "수기 메모",
+};
+
+export const TRACK_KIND_LABEL: Record<TrackKind, string> = {
+  accepted_live: "수락(실주문)",
+  accepted_paper: "수락(모의)",
+  rejected_counterfactual: "거절 대조",
+  analyst_alternative: "분석가 대안",
+  user_alternative: "사용자 대안",
+};
+
+export const OUTCOME_HORIZON_LABEL: Record<OutcomeHorizon, string> = {
+  "1h": "1시간",
+  "4h": "4시간",
+  "1d": "1일",
+  "3d": "3일",
+  "7d": "7일",
+  final: "최종",
+};
+
+export const INSTRUMENT_TYPE_LABEL: Record<InstrumentType, string> = {
+  equity_kr: "국내주식",
+  equity_us: "해외주식",
+  crypto: "암호화폐",
+  forex: "외환",
+  index: "지수",
+};
+
+export const ACCOUNT_MODE_LABEL: Record<CommitteeAccountMode, string> = {
+  kis_mock: "KIS 모의",
+  alpaca_paper: "Alpaca Paper",
+  kis_live: "KIS 실계좌",
+  db_simulated: "DB 시뮬레이션",
+};
+
+export const EXECUTION_ACCOUNT_MODE_LABEL: Record<ExecutionAccountMode, string> = {
+  kis_live: "KIS 실계좌",
+  kis_mock: "KIS 모의",
+  alpaca_paper: "Alpaca Paper",
+  db_simulated: "DB 시뮬레이션",
+};
+
+export const EXECUTION_SOURCE_LABEL: Record<ExecutionSource, string> = {
+  preopen: "장전",
+  watch: "감시",
+  manual: "수기",
+  websocket: "실시간",
+  reconciler: "조정",
+};
+
+export const EXECUTION_REVIEW_STAGE_STATUS_LABEL: Record<
+  ExecutionReviewStageStatus,
+  string
+> = {
+  ready: "준비 완료",
+  degraded: "주의",
+  unavailable: "미사용",
+  skipped: "건너뜀",
+  pending: "대기",
+};
+
+export const WORKFLOW_STATUS_LABEL: Record<WorkflowStatus, string> = {
+  created: "생성됨",
+  evidence_generating: "근거 수집 중",
+  evidence_ready: "근거 준비됨",
+  debate_ready: "토론 준비됨",
+  trader_draft_ready: "트레이더 초안 준비",
+  risk_review_ready: "리스크 리뷰 준비",
+  auto_approved: "자동 승인",
+  preview_ready: "프리뷰 준비",
+  journal_ready: "기록 준비",
+  completed: "완료",
+  failed_evidence: "근거 실패",
+  failed_trader_draft: "트레이더 초안 실패",
+  failed_risk_review: "리스크 리뷰 실패",
+  preview_blocked: "프리뷰 차단",
+};
+
+export const RECONCILIATION_STATUS_LABEL: Record<ReconciliationStatus, string> = {
+  maintain: "유지",
+  near_fill: "체결 임박",
+  too_far: "괴리 큼",
+  chasing_risk: "추격 위험",
+  data_mismatch: "데이터 불일치",
+  kr_pending_non_nxt: "국내 브로커 전용",
+  unknown_venue: "거래소 알 수 없음",
+  unknown: "알 수 없음",
+};
+
+export const NXT_CLASSIFICATION_LABEL: Record<NxtClassification, string> = {
+  buy_pending_at_support: "매수 대기(지지선 근접)",
+  buy_pending_too_far: "매수 대기(괴리 큼)",
+  buy_pending_actionable: "매수 대기(실행 가능)",
+  sell_pending_near_resistance: "매도 대기(저항선 근접)",
+  sell_pending_too_optimistic: "매도 대기(낙관 과다)",
+  sell_pending_actionable: "매도 대기(실행 가능)",
+  non_nxt_pending_ignore_for_nxt: "비-NXT 대기",
+  holding_watch_only: "보유 감시",
+  data_mismatch_requires_review: "데이터 불일치 검토 필요",
+  unknown: "알 수 없음",
+};
+
+export const CANDIDATE_KIND_LABEL: Record<CandidateKind, string> = {
+  pending_order: "대기 주문",
+  holding: "보유",
+  screener_hit: "스크리너 적중",
+  proposed: "제안됨",
+  other: "기타",
+};
+
+export const NEWS_READINESS_LABEL: Record<PreopenNewsReadinessStatus, string> = {
+  ready: "정상",
+  stale: "오래됨",
+  unavailable: "미사용",
+};
+
+export const ARTIFACT_STATUS_LABEL: Record<PreopenArtifactStatus, string> = {
+  unavailable: "미사용",
+  draft: "초안",
+  ready: "준비 완료",
+  degraded: "주의",
+};
+
+export const ARTIFACT_READINESS_LABEL: Record<
+  PreopenArtifactReadinessStatus,
+  string
+> = {
+  ready: "준비 완료",
+  stale: "오래됨",
+  unavailable: "미사용",
+  partial: "일부",
+};
+
+export const PAPER_APPROVAL_STATUS_LABEL: Record<
+  PreopenPaperApprovalBridgeStatus,
+  string
+> = {
+  available: "사용 가능",
+  warning: "주의",
+  blocked: "차단됨",
+  unavailable: "미사용",
+};
+
+export const PAPER_APPROVAL_CANDIDATE_STATUS_LABEL: Record<
+  PreopenPaperApprovalCandidateStatus,
+  string
+> = {
+  available: "사용 가능",
+  warning: "주의",
+  unavailable: "미사용",
+};
+
+export const QA_STATUS_LABEL: Record<PreopenQaEvaluatorStatus, string> = {
+  ready: "준비 완료",
+  needs_review: "검토 필요",
+  unavailable: "미사용",
+  skipped: "건너뜀",
+};
+
+export const QA_CHECK_STATUS_LABEL: Record<PreopenQaCheckStatus, string> = {
+  pass: "통과",
+  warn: "주의",
+  fail: "실패",
+  unknown: "알 수 없음",
+  skipped: "건너뜀",
+};
+
+export const QA_SEVERITY_LABEL: Record<PreopenQaCheckSeverity, string> = {
+  info: "정보",
+  low: "낮음",
+  medium: "보통",
+  high: "높음",
+};
+
+export const QA_GRADE_LABEL: Record<PreopenQaGrade, string> = {
+  excellent: "매우 우수",
+  good: "양호",
+  watch: "주의",
+  poor: "미흡",
+  unavailable: "미사용",
+};
+
+export const QA_CONFIDENCE_LABEL: Record<PreopenQaConfidence, string> = {
+  high: "높음",
+  medium: "보통",
+  low: "낮음",
+  unavailable: "미사용",
+};
+
+export const VENUE_LABEL: Record<string, string> = {
+  upbit: "Upbit",
+  alpaca_paper: "Alpaca Paper",
+  kis: "KIS",
+  kis_mock: "KIS 모의",
+  kis_live: "KIS 실계좌",
+};
+
+export const WARNING_TOKEN_LABEL: Record<string, string> = {
+  missing_quote: "시세 누락",
+  stale_quote: "시세 오래됨",
+  missing_orderbook: "호가 누락",
+  missing_support_resistance: "지지/저항선 미사용",
+  missing_kr_universe: "국내 유니버스 누락",
+  non_nxt_venue: "비-NXT 거래소",
+  unknown_venue: "거래소 알 수 없음",
+  unknown_side: "방향 알 수 없음",
+};
+
+export const SAFETY_SCOPE_LABEL: Record<string, string> = {
+  preview_only_confirm_false_no_broker_submit:
+    "브로커 제출 없는 preview 전용",
+  advisory_only: "자문 전용",
+};
+
+export const PURPOSE_LABEL: Record<string, string> = {
+  paper_plumbing_smoke: "페이퍼 배관 점검",
+  alpha_candidate_review: "알파 후보 리뷰",
+};
+
+export const COMMON = {
+  dash: "—",
+  loading: "불러오는 중…",
+  saving: "저장 중…",
+  retry: "다시 시도",
+  cancel: "취소",
+  refresh: "새로고침",
+  next: "다음",
+  previous: "이전",
+  all: "전체",
+  yes: "예",
+  no: "아니오",
+  unknown: "알 수 없음",
+  rawData: "원본 데이터 보기",
+  somethingWentWrong: "오류가 발생했습니다. 다시 시도해 주세요.",
+} as const;

--- a/frontend/trading-decision/src/pages/PreopenPage.tsx
+++ b/frontend/trading-decision/src/pages/PreopenPage.tsx
@@ -17,6 +17,29 @@ import type {
   PreopenQaEvaluatorSummary,
 } from "../api/types";
 import { formatDateTime } from "../format/datetime";
+import {
+  ARTIFACT_READINESS_LABEL,
+  ARTIFACT_STATUS_LABEL,
+  CANDIDATE_KIND_LABEL,
+  COMMON,
+  NXT_CLASSIFICATION_LABEL,
+  PAPER_APPROVAL_CANDIDATE_STATUS_LABEL,
+  PAPER_APPROVAL_STATUS_LABEL,
+  QA_CHECK_STATUS_LABEL,
+  QA_CONFIDENCE_LABEL,
+  QA_GRADE_LABEL,
+  QA_SEVERITY_LABEL,
+  QA_STATUS_LABEL,
+  RECONCILIATION_STATUS_LABEL,
+  SIDE_LABEL,
+  VENUE_LABEL,
+} from "../i18n";
+import {
+  labelOperatorToken,
+  labelOrToken,
+  labelOrderSide,
+  labelYesNo,
+} from "../i18n/formatters";
 import styles from "./PreopenPage.module.css";
 
 type State =
@@ -37,27 +60,29 @@ function PreopenBriefingArtifactSection({
 
   return (
     <section
-      aria-label="Preopen briefing artifact"
+      aria-label="장전 브리핑 산출물"
       className={styles.artifactSection}
     >
       <div className={styles.artifactHeader}>
         <div>
-          <h2>Preopen briefing</h2>
+          <h2>장전 브리핑</h2>
           <p className={styles.meta}>
             {artifact.artifact_type} {formatArtifactVersion(artifact.artifact_version)}
           </p>
         </div>
-        <span className={styles.artifactStatus}>Artifact {artifact.status}</span>
+        <span className={styles.artifactStatus}>
+          산출물 {labelOrToken(ARTIFACT_STATUS_LABEL, artifact.status)}
+        </span>
       </div>
 
       {artifact.market_summary ? <p>{artifact.market_summary}</p> : null}
-      {artifact.news_summary ? <p>News brief: {artifact.news_summary}</p> : null}
+      {artifact.news_summary ? <p>뉴스 요약: {artifact.news_summary}</p> : null}
 
       {artifact.risk_notes.length > 0 ? (
-        <ul aria-label="Preopen artifact risk notes" className={styles.warnings}>
+        <ul aria-label="장전 산출물 리스크 노트" className={styles.warnings}>
           {artifact.risk_notes.map((note) => (
             <li className={styles.warningChip} key={note}>
-              {note}
+              {labelOperatorToken(note)}
             </li>
           ))}
         </ul>
@@ -67,8 +92,8 @@ function PreopenBriefingArtifactSection({
         <div className={styles.artifactGrid}>
           {artifact.readiness.map((item) => (
             <div className={styles.artifactCard} key={item.key}>
-              <strong>{item.key}</strong>
-              <span>{item.status}</span>
+              <strong>{labelOperatorToken(item.key)}</strong>
+              <span>{labelOrToken(ARTIFACT_READINESS_LABEL, item.status)}</span>
             </div>
           ))}
         </div>
@@ -80,7 +105,7 @@ function PreopenBriefingArtifactSection({
             <div className={styles.artifactCard} key={section.section_id}>
               <strong>{section.title}</strong>
               <span>
-                {section.status} · {section.item_count}
+                {labelOrToken(ARTIFACT_STATUS_LABEL, section.status)} · {section.item_count}
               </span>
               {section.summary ? <small>{section.summary}</small> : null}
             </div>
@@ -91,19 +116,11 @@ function PreopenBriefingArtifactSection({
   );
 }
 
-
-const QA_STATUS_LABEL: Record<PreopenQaEvaluatorSummary["status"], string> = {
-  ready: "Ready",
-  needs_review: "Needs review",
-  unavailable: "Unavailable",
-  skipped: "Skipped",
-};
-
 function getQaReasonLabel(qa: PreopenQaEvaluatorSummary, reason: string) {
   const matchedCheck = qa.checks.find(
     (check) => check.id === reason || check.details?.reason === reason,
   );
-  return matchedCheck?.summary ?? reason;
+  return matchedCheck?.summary ?? labelOperatorToken(reason);
 }
 
 function PreopenQaEvaluatorPanel({
@@ -114,21 +131,21 @@ function PreopenQaEvaluatorPanel({
   if (!qa) return null;
   const scoreLabel = qa.overall.score === null ? "—" : String(qa.overall.score);
   return (
-    <section aria-label="Preopen QA evaluator" className={styles.qaSection}>
+    <section aria-label="장전 QA 평가기" className={styles.qaSection}>
       <div className={styles.artifactHeader}>
         <div>
-          <h2>QA evaluator</h2>
+          <h2>QA 평가기</h2>
           <p className={styles.meta}>
-            {qa.source} · {qa.overall.grade} · confidence {qa.overall.confidence}
+            {qa.source} · {labelOrToken(QA_GRADE_LABEL, qa.overall.grade)} · 신뢰도 {labelOrToken(QA_CONFIDENCE_LABEL, qa.overall.confidence)}
           </p>
         </div>
         <span className={styles.artifactStatus}>
-          QA {QA_STATUS_LABEL[qa.status] ?? qa.status}
+          QA {labelOrToken(QA_STATUS_LABEL, qa.status)}
         </span>
       </div>
-      <p>Overall score: {scoreLabel}</p>
+      <p>종합 점수: {scoreLabel}</p>
       {qa.blocking_reasons.length > 0 ? (
-        <ul aria-label="QA blocking reasons" className={styles.warnings}>
+        <ul aria-label="QA 차단 사유" className={styles.warnings}>
           {qa.blocking_reasons.map((reason) => (
             <li className={styles.warningChip} key={reason}>
               {getQaReasonLabel(qa, reason)}
@@ -137,7 +154,7 @@ function PreopenQaEvaluatorPanel({
         </ul>
       ) : null}
       {qa.warnings.length > 0 ? (
-        <ul aria-label="QA warnings" className={styles.warnings}>
+        <ul aria-label="QA 경고" className={styles.warnings}>
           {qa.warnings.map((warning) => (
             <li className={styles.warningChip} key={warning}>
               {getQaReasonLabel(qa, warning)}
@@ -150,7 +167,7 @@ function PreopenQaEvaluatorPanel({
           <div className={styles.artifactCard} key={check.id}>
             <strong>{check.label}</strong>
             <span>
-              {check.status} · {check.severity}
+              {labelOrToken(QA_CHECK_STATUS_LABEL, check.status)} · {labelOrToken(QA_SEVERITY_LABEL, check.severity)}
             </span>
             <small>{check.summary}</small>
           </div>
@@ -160,27 +177,8 @@ function PreopenQaEvaluatorPanel({
   );
 }
 
-const PAPER_APPROVAL_STATUS_LABEL: Record<
-  PreopenPaperApprovalBridge["status"],
-  string
-> = {
-  available: "Available",
-  warning: "Warning",
-  blocked: "Blocked",
-  unavailable: "Unavailable",
-};
-
-function formatOperatorToken(value: string | null | undefined): string {
-  return value ? value.replace(/_/g, " ") : "—";
-}
-
 function formatVenueLabel(venue: string | null, symbol: string | null): string {
-  const venueLabel =
-    venue === "upbit"
-      ? "Upbit"
-      : venue === "alpaca_paper"
-        ? "Alpaca Paper"
-        : formatOperatorToken(venue);
+  const venueLabel = labelOrToken(VENUE_LABEL, venue);
   return [venueLabel, symbol].filter(Boolean).join(" ");
 }
 
@@ -194,7 +192,7 @@ type PreviewPayloadLike = {
 
 function formatPreviewPayload(payload: PreviewPayloadLike | null): string | null {
   if (!payload) return null;
-  const side = typeof payload.side === "string" ? payload.side : null;
+  const side = typeof payload.side === "string" ? labelOrderSide(payload.side) : null;
   const type = typeof payload.type === "string" ? payload.type : null;
   const notional = typeof payload.notional === "string" ? payload.notional : null;
   const limitPrice =
@@ -216,44 +214,42 @@ function PreopenPaperApprovalBridgeSection({
   bridge: PreopenPaperApprovalBridge | null;
 }) {
   if (!bridge) return null;
-  const statusLabel = PAPER_APPROVAL_STATUS_LABEL[bridge.status] ?? bridge.status;
+  const statusLabel = labelOrToken(PAPER_APPROVAL_STATUS_LABEL, bridge.status);
 
   return (
     <section
-      aria-label="Paper approval preview"
+      aria-label="모의 승인 프리뷰"
       className={styles.paperApprovalSection}
     >
       <div className={styles.artifactHeader}>
         <div>
-          <h2>Paper approval preview</h2>
+          <h2>모의 승인 프리뷰</h2>
           <p className={styles.meta}>
-            {bridge.source} · {bridge.market_scope ?? "unknown market"} ·{" "}
-            {bridge.eligible_count} eligible / {bridge.candidate_count} candidates
+            {bridge.source} · {bridge.market_scope?.toUpperCase() ?? "시장 알 수 없음"} ·{" "}
+            {bridge.eligible_count}개 대상 / {bridge.candidate_count}개 후보
           </p>
         </div>
-        <span className={styles.artifactStatus}>Preview {statusLabel}</span>
+        <span className={styles.artifactStatus}>프리뷰 {statusLabel}</span>
       </div>
 
       <div className={styles.paperApprovalSafety} role="note">
-        Advisory-only preview. Execution is not allowed from this screen. Explicit
-        operator approval is required before any Alpaca Paper submit; this card
-        does not submit or cancel paper orders.
+        자문 전용 프리뷰입니다. 이 화면에서 실행할 수 없습니다. Alpaca Paper 제출 전에 트레이더의 명시적 승인이 필요합니다. 이 카드는 모의 주문을 제출하거나 취소하지 않습니다.
       </div>
 
       {bridge.blocking_reasons.length > 0 ? (
-        <ul aria-label="Paper approval blocking reasons" className={styles.warnings}>
+        <ul aria-label="모의 승인 차단 사유" className={styles.warnings}>
           {bridge.blocking_reasons.map((reason) => (
             <li className={styles.warningChip} key={reason}>
-              {formatOperatorToken(reason)}
+              {labelOperatorToken(reason)}
             </li>
           ))}
         </ul>
       ) : null}
       {bridge.warnings.length > 0 || bridge.unsupported_reasons.length > 0 ? (
-        <ul aria-label="Paper approval warnings" className={styles.warnings}>
+        <ul aria-label="모의 승인 경고" className={styles.warnings}>
           {[...bridge.warnings, ...bridge.unsupported_reasons].map((warning) => (
             <li className={styles.warningChip} key={warning}>
-              {formatOperatorToken(warning)}
+              {labelOperatorToken(warning)}
             </li>
           ))}
         </ul>
@@ -270,11 +266,11 @@ function PreopenPaperApprovalBridgeSection({
               >
                 <div className={styles.paperApprovalCandidateHeader}>
                   <strong>{candidate.symbol}</strong>
-                  <span>{formatOperatorToken(candidate.status)}</span>
+                  <span>{labelOrToken(PAPER_APPROVAL_CANDIDATE_STATUS_LABEL, candidate.status)}</span>
                 </div>
                 <dl className={styles.provenanceList}>
                   <div>
-                    <dt>Signal source</dt>
+                    <dt>시그널 소스</dt>
                     <dd>
                       {formatVenueLabel(
                         candidate.signal_venue,
@@ -283,7 +279,7 @@ function PreopenPaperApprovalBridgeSection({
                     </dd>
                   </div>
                   <div>
-                    <dt>Execution venue</dt>
+                    <dt>실행 거래소</dt>
                     <dd>
                       {formatVenueLabel(
                         candidate.execution_venue,
@@ -292,21 +288,21 @@ function PreopenPaperApprovalBridgeSection({
                     </dd>
                   </div>
                   <div>
-                    <dt>Asset class</dt>
-                    <dd>{formatOperatorToken(candidate.execution_asset_class)}</dd>
+                    <dt>자산 분류</dt>
+                    <dd>{labelOperatorToken(candidate.execution_asset_class)}</dd>
                   </div>
                   <div>
-                    <dt>Workflow</dt>
-                    <dd>{formatOperatorToken(candidate.workflow_stage)}</dd>
+                    <dt>워크플로우</dt>
+                    <dd>{labelOperatorToken(candidate.workflow_stage)}</dd>
                   </div>
                 </dl>
                 {candidate.purpose ? (
-                  <p>Purpose: {formatOperatorToken(candidate.purpose)}</p>
+                  <p>목적: {labelOperatorToken(candidate.purpose)}</p>
                 ) : null}
-                {previewPayload ? <p>Preview payload: {previewPayload}</p> : null}
+                {previewPayload ? <p>프리뷰 페이로드: {previewPayload}</p> : null}
                 {candidate.approval_copy.length > 0 ? (
                   <ul
-                    aria-label={`${candidate.symbol} approval copy`}
+                    aria-label={`${candidate.symbol} 승인 문구`}
                     className={styles.approvalCopy}
                   >
                     {candidate.approval_copy.map((copy) => (
@@ -316,12 +312,12 @@ function PreopenPaperApprovalBridgeSection({
                 ) : null}
                 {candidate.warnings.length > 0 ? (
                   <ul
-                    aria-label={`${candidate.symbol} paper approval warnings`}
+                    aria-label={`${candidate.symbol} 모의 승인 경고`}
                     className={styles.warnings}
                   >
                     {candidate.warnings.map((warning) => (
                       <li className={styles.warningChip} key={warning}>
-                        {formatOperatorToken(warning)}
+                        {labelOperatorToken(warning)}
                       </li>
                     ))}
                   </ul>
@@ -331,7 +327,7 @@ function PreopenPaperApprovalBridgeSection({
           })}
         </div>
       ) : (
-        <p>No paper approval preview candidates are currently available.</p>
+        <p>현재 사용 가능한 모의 승인 프리뷰 후보가 없습니다.</p>
       )}
     </section>
   );
@@ -367,7 +363,7 @@ export default function PreopenPage() {
         setState({
           status: "error",
           message:
-            err instanceof ApiError ? err.detail : "Something went wrong. Try again.",
+            err instanceof ApiError ? err.detail : COMMON.somethingWentWrong,
         });
       });
     return () => controller.abort();
@@ -385,7 +381,7 @@ export default function PreopenPage() {
         setCreateError(
           err instanceof ApiError
             ? err.detail
-            : "Failed to create decision session.",
+            : "의사결정 세션 생성에 실패했습니다.",
         );
       } finally {
         setCreating(false);
@@ -418,11 +414,11 @@ export default function PreopenPage() {
   if (!data.has_run) {
     return (
       <main className={styles.page}>
-        <h1>Preopen briefing</h1>
+        <h1>장전 브리핑</h1>
         <div className={styles.banner} role="status">
-          <strong>No preopen research run available</strong>
+          <strong>사용 가능한 장전 리서치 실행 결과가 없습니다</strong>
           {data.advisory_skipped_reason ? (
-            <p>Reason: {data.advisory_skipped_reason}</p>
+            <p>사유: {data.advisory_skipped_reason}</p>
           ) : null}
         </div>
         <PreopenBriefingArtifactSection artifact={data.briefing_artifact} />
@@ -436,13 +432,13 @@ export default function PreopenPage() {
   return (
     <main className={styles.page}>
       <div className={styles.header}>
-        <h1>Preopen briefing</h1>
+        <h1>장전 브리핑</h1>
         <div className={styles.meta}>
-          Generated: {formatDateTime(data.generated_at)}
+          생성 시각: {formatDateTime(data.generated_at)}
           {data.strategy_name ? ` · ${data.strategy_name}` : ""}
           {data.source_profile ? ` · ${data.source_profile}` : ""}
           {data.market_scope ? ` · ${data.market_scope.toUpperCase()}` : ""}
-          {` · Advisory ${data.advisory_used ? "used" : "not used"}`}
+          {` · 자문 ${data.advisory_used ? "사용됨" : "사용되지 않음"}`}
         </div>
         {data.market_brief && typeof data.market_brief.summary === "string" ? (
           <p>{data.market_brief.summary}</p>
@@ -451,12 +447,12 @@ export default function PreopenPage() {
 
       {data.advisory_skipped_reason ? (
         <div className={styles.banner} role="status">
-          Advisory notice: {data.advisory_skipped_reason}
+          자문 알림: {data.advisory_skipped_reason}
         </div>
       ) : null}
 
       {data.source_warnings.length > 0 ? (
-        <ul aria-label="Source warnings" className={styles.warnings}>
+        <ul aria-label="소스 경고" className={styles.warnings}>
           {data.source_warnings.map((w, i) => (
             <li className={styles.warningChip} key={i}>
               {w}
@@ -474,17 +470,17 @@ export default function PreopenPage() {
 
       {data.candidates.length > 0 ? (
         <section className={styles.section}>
-          <h2>Candidates ({data.candidate_count})</h2>
+          <h2>후보 ({data.candidate_count}건)</h2>
           <table className={styles.table}>
             <thead>
               <tr>
-                <th>Symbol</th>
-                <th>Side</th>
-                <th>Kind</th>
-                <th>Confidence</th>
-                <th>Price</th>
-                <th>Qty</th>
-                <th>Rationale</th>
+                <th>심볼</th>
+                <th>방향</th>
+                <th>종류</th>
+                <th>신뢰도</th>
+                <th>가격</th>
+                <th>수량</th>
+                <th>근거</th>
               </tr>
             </thead>
             <tbody>
@@ -501,10 +497,10 @@ export default function PreopenPage() {
                             : styles.sideNone
                       }
                     >
-                      {c.side}
+                      {labelOrToken(SIDE_LABEL, c.side)}
                     </span>
                   </td>
-                  <td>{c.candidate_kind}</td>
+                  <td>{labelOrToken(CANDIDATE_KIND_LABEL, c.candidate_kind)}</td>
                   <td>{c.confidence !== null ? `${c.confidence}%` : "—"}</td>
                   <td>
                     {c.proposed_price !== null
@@ -524,30 +520,26 @@ export default function PreopenPage() {
 
       {data.reconciliations.length > 0 ? (
         <section className={styles.section}>
-          <h2>Pending reconciliations ({data.reconciliation_count})</h2>
+          <h2>대기 조정 ({data.reconciliation_count}건)</h2>
           <table className={styles.table}>
             <thead>
               <tr>
-                <th>Symbol</th>
-                <th>Classification</th>
-                <th>NXT class</th>
-                <th>Actionable</th>
-                <th>Gap %</th>
-                <th>Summary</th>
+                <th>심볼</th>
+                <th>분류</th>
+                <th>NXT 분류</th>
+                <th>실행 가능</th>
+                <th>괴리 %</th>
+                <th>요약</th>
               </tr>
             </thead>
             <tbody>
               {data.reconciliations.map((r, i) => (
                 <tr key={i}>
                   <td>{r.symbol}</td>
-                  <td>{r.classification}</td>
-                  <td>{r.nxt_classification ?? "—"}</td>
+                  <td>{labelOrToken(RECONCILIATION_STATUS_LABEL, r.classification)}</td>
+                  <td>{labelOrToken(NXT_CLASSIFICATION_LABEL, r.nxt_classification)}</td>
                   <td>
-                    {r.nxt_actionable === null
-                      ? "—"
-                      : r.nxt_actionable
-                        ? "Yes"
-                        : "No"}
+                    {labelYesNo(r.nxt_actionable)}
                   </td>
                   <td>{r.gap_pct !== null ? `${r.gap_pct}%` : "—"}</td>
                   <td>{r.summary ?? "—"}</td>
@@ -560,7 +552,7 @@ export default function PreopenPage() {
 
       {data.linked_sessions.length > 0 ? (
         <section className={styles.section}>
-          <h2>Linked decision sessions</h2>
+          <h2>연결된 의사결정 세션</h2>
           <ul className={styles.linkedSessions}>
             {data.linked_sessions.map((s) => (
               <li className={styles.linkedSessionItem} key={String(s.session_uuid)}>
@@ -581,7 +573,7 @@ export default function PreopenPage() {
             className="btn"
             to={`/sessions/${linkedSessionUuid}`}
           >
-            Open session
+            세션 열기
           </Link>
         ) : null}
         {!linkedSessionUuid ? (
@@ -592,10 +584,10 @@ export default function PreopenPage() {
             type="button"
           >
             {confirmPending
-              ? "Confirm create decision session?"
+              ? "의사결정 세션을 생성하시겠습니까?"
               : creating
-                ? "Creating…"
-                : artifactCta?.label ?? "Create decision session"}
+                ? "생성 중…"
+                : artifactCta?.label ?? "의사결정 세션 생성"}
           </button>
         ) : null}
         {confirmPending ? (
@@ -604,7 +596,7 @@ export default function PreopenPage() {
             onClick={() => setConfirmPending(false)}
             type="button"
           >
-            Cancel
+            {COMMON.cancel}
           </button>
         ) : null}
         {createError ? (

--- a/frontend/trading-decision/src/pages/PreopenPage.tsx
+++ b/frontend/trading-decision/src/pages/PreopenPage.tsx
@@ -51,6 +51,16 @@ function formatArtifactVersion(version: string): string {
   return version.startsWith("mvp.") ? version.slice(4) : version;
 }
 
+function labelArtifactCta(
+  cta: PreopenBriefingArtifact["cta"] | null,
+): string {
+  if (!cta) return "의사결정 세션 생성";
+  if (cta.state === "create_available") return "의사결정 세션 생성";
+  if (cta.state === "linked_session_exists") return "의사결정 세션 열기";
+  if (cta.state === "unavailable") return "의사결정 세션 생성 불가";
+  return "의사결정 세션 생성";
+}
+
 function PreopenBriefingArtifactSection({
   artifact,
 }: {
@@ -587,7 +597,7 @@ export default function PreopenPage() {
               ? "의사결정 세션을 생성하시겠습니까?"
               : creating
                 ? "생성 중…"
-                : artifactCta?.label ?? "의사결정 세션 생성"}
+                : labelArtifactCta(artifactCta)}
           </button>
         ) : null}
         {confirmPending ? (

--- a/frontend/trading-decision/src/pages/SessionDetailPage.tsx
+++ b/frontend/trading-decision/src/pages/SessionDetailPage.tsx
@@ -21,6 +21,8 @@ import { useCommitteeWorkflow } from "../hooks/useCommitteeWorkflow";
 import { useDecisionSession } from "../hooks/useDecisionSession";
 import { useSessionAnalytics } from "../hooks/useSessionAnalytics";
 import { useStrategyEvents } from "../hooks/useStrategyEvents";
+import { COMMON, WORKFLOW_STATUS_LABEL } from "../i18n";
+import { labelOrToken } from "../i18n/formatters";
 import styles from "./SessionDetailPage.module.css";
 
 export default function SessionDetailPage() {
@@ -38,7 +40,7 @@ export default function SessionDetailPage() {
   );
 
   if (!sessionUuid) {
-    return <ErrorView message="Session not found" />;
+    return <ErrorView message="세션을 찾을 수 없습니다" />;
   }
   if (session.status === "loading" || session.status === "idle") {
     return <LoadingView />;
@@ -46,9 +48,9 @@ export default function SessionDetailPage() {
   if (session.status === "not_found") {
     return (
       <main className={styles.page}>
-        <h1>Session not found</h1>
+        <h1>세션을 찾을 수 없습니다</h1>
         <Link className="btn" to="/">
-          Back to inbox
+          의사결정함으로 돌아가기
         </Link>
       </main>
     );
@@ -56,7 +58,7 @@ export default function SessionDetailPage() {
   if (session.status === "error" || !session.data) {
     return (
       <ErrorView
-        message={session.error ?? "Something went wrong. Try again."}
+        message={session.error ?? COMMON.somethingWentWrong}
         onRetry={session.refetch}
       />
     );
@@ -68,25 +70,28 @@ export default function SessionDetailPage() {
   return (
     <main className={styles.page}>
       <header className={styles.header}>
-        <Link to="/">Back to inbox</Link>
+        <Link to="/">의사결정함으로 돌아가기</Link>
         <div className={styles.titleRow}>
           <h1>{data.strategy_name ?? data.source_profile}</h1>
           <StatusBadge value={data.status} />
         </div>
         <p>
-          {data.source_profile} · {data.market_scope ?? "all markets"} ·{" "}
+          {data.source_profile} · {data.market_scope ?? "전체 시장"} ·{" "}
           {formatDateTime(data.generated_at)}
         </p>
         {isCommitteeSession && data.workflow_status && (
           <div className={styles.workflowRow}>
-            <strong>Workflow Status:</strong> <span className={styles.workflowStatus}>{data.workflow_status.replace(/_/g, " ").toUpperCase()}</span>
+            <strong>워크플로우 상태:</strong>{" "}
+            <span className={styles.workflowStatus}>
+              {labelOrToken(WORKFLOW_STATUS_LABEL, data.workflow_status)}
+            </span>
           </div>
         )}
       </header>
       <MarketBriefPanel brief={data.market_brief} notes={data.notes} />
 
       {isCommitteeSession && data.artifacts && (
-        <section className={styles.committeeArtifacts} aria-label="Committee artifacts">
+        <section className={styles.committeeArtifacts} aria-label="위원회 산출물">
           <CommitteeEvidenceArtifacts artifacts={data.artifacts} />
           <CommitteeResearchDebate
             researchDebate={data.artifacts.research_debate ?? null}
@@ -119,47 +124,47 @@ export default function SessionDetailPage() {
       )}
 
       {analytics.status === "loading" ? (
-        <section className={styles.analytics} aria-label="Analytics">
-          <h2>Outcome analytics</h2>
-          <p>Loading analytics...</p>
+        <section className={styles.analytics} aria-label="분석">
+          <h2>결과 분석</h2>
+          <p>분석을 불러오는 중...</p>
         </section>
       ) : null}
       {analytics.status === "error" ? (
-        <section className={styles.analytics} aria-label="Analytics">
-          <h2>Outcome analytics</h2>
+        <section className={styles.analytics} aria-label="분석">
+          <h2>결과 분석</h2>
           <p role="alert">{analytics.error}</p>
         </section>
       ) : null}
       {analytics.status === "success" && analytics.data ? (
-        <section className={styles.analytics} aria-label="Analytics">
-          <h2>Outcome analytics</h2>
+        <section className={styles.analytics} aria-label="분석">
+          <h2>결과 분석</h2>
           <AnalyticsMatrix data={analytics.data} />
         </section>
       ) : null}
       <section
         className={styles.strategyEvents}
-        aria-label="Strategy events"
+        aria-label="전략 이벤트"
       >
-        <h2>Strategy events</h2>
+        <h2>전략 이벤트</h2>
         <OperatorEventForm
           sessionUuid={data.session_uuid}
           onSubmit={(body) => strategyEvents.submit(body)}
         />
         {strategyEvents.status === "loading" ||
         strategyEvents.status === "idle" ? (
-          <p>Loading strategy events...</p>
+          <p>전략 이벤트를 불러오는 중...</p>
         ) : null}
         {strategyEvents.status === "error" ? (
           <p role="alert">{strategyEvents.error}</p>
         ) : null}
         {strategyEvents.status === "not_found" ? (
-          <p role="alert">Session not found for strategy events.</p>
+          <p role="alert">전략 이벤트용 세션을 찾을 수 없습니다.</p>
         ) : null}
         {strategyEvents.status === "success" && strategyEvents.data ? (
           <StrategyEventTimeline events={strategyEvents.data.events} />
         ) : null}
       </section>
-      <section className={styles.proposals} aria-label="Proposals">
+      <section className={styles.proposals} aria-label="제안">
         {data.proposals.map((proposal) => (
           <ProposalRow
             key={proposal.proposal_uuid}
@@ -170,7 +175,7 @@ export default function SessionDetailPage() {
         ))}
       </section>
       <footer className={styles.footer}>
-        {data.pending_count} of {data.proposals_count} pending
+        {data.pending_count}/{data.proposals_count} 대기 중
       </footer>
     </main>
   );

--- a/frontend/trading-decision/src/pages/SessionListPage.tsx
+++ b/frontend/trading-decision/src/pages/SessionListPage.tsx
@@ -6,6 +6,13 @@ import StatusBadge from "../components/StatusBadge";
 import type { SessionStatus } from "../api/types";
 import { formatDateTime } from "../format/datetime";
 import { useDecisionInbox } from "../hooks/useDecisionInbox";
+import {
+  COMMON,
+  SESSION_STATUS_LABEL,
+  WORKFLOW_STATUS_LABEL,
+  ACCOUNT_MODE_LABEL,
+} from "../i18n";
+import { labelOrToken } from "../i18n/formatters";
 import styles from "./SessionListPage.module.css";
 
 const pageSize = 50;
@@ -18,12 +25,12 @@ export default function SessionListPage() {
   return (
     <main className={styles.page}>
       <div className={styles.topbar}>
-        <h1>Decision inbox</h1>
+        <h1>의사결정함</h1>
         <div className={styles.controls}>
           <label>
-            Status filter{" "}
+            상태 필터{" "}
             <select
-              aria-label="Status filter"
+              aria-label="상태 필터"
               onChange={(event) => {
                 setOffset(0);
                 setStatusFilter(
@@ -34,41 +41,43 @@ export default function SessionListPage() {
               }}
               value={statusFilter ?? ""}
             >
-              <option value="">All</option>
-              <option value="open">open</option>
-              <option value="closed">closed</option>
-              <option value="archived">archived</option>
+              <option value="">{COMMON.all}</option>
+              {(Object.keys(SESSION_STATUS_LABEL) as SessionStatus[]).map((status) => (
+                <option key={status} value={status}>
+                  {SESSION_STATUS_LABEL[status]}
+                </option>
+              ))}
             </select>
           </label>
           <button className="btn" onClick={inbox.refetch} type="button">
-            Refresh
+            {COMMON.refresh}
           </button>
         </div>
       </div>
       {inbox.status === "loading" ? <LoadingView /> : null}
       {inbox.status === "error" ? (
         <ErrorView
-          message={inbox.error ?? "Something went wrong. Try again."}
+          message={inbox.error ?? COMMON.somethingWentWrong}
           onRetry={inbox.refetch}
         />
       ) : null}
       {inbox.status === "success" && inbox.data?.sessions.length === 0 ? (
-        <p>No decision sessions yet.</p>
+        <p>아직 의사결정 세션이 없습니다.</p>
       ) : null}
       {inbox.data && inbox.data.sessions.length > 0 ? (
         <>
           <table className={styles.table}>
             <thead>
               <tr>
-                <th>Generated</th>
-                <th>Profile</th>
-                <th>Strategy</th>
-                <th>Scope</th>
-                <th>Status</th>
-                <th>Workflow</th>
-                <th>Account</th>
-                <th>Proposals</th>
-                <th>Pending</th>
+                <th>생성 시각</th>
+                <th>프로필</th>
+                <th>전략</th>
+                <th>범위</th>
+                <th>상태</th>
+                <th>워크플로우</th>
+                <th>계정</th>
+                <th>제안</th>
+                <th>대기</th>
               </tr>
             </thead>
             <tbody>
@@ -81,20 +90,20 @@ export default function SessionListPage() {
                       {session.strategy_name ?? session.source_profile}
                     </Link>
                   </td>
-                  <td>{session.market_scope ?? "—"}</td>
+                  <td>
+                    {session.market_scope
+                      ? session.market_scope.toUpperCase()
+                      : COMMON.dash}
+                  </td>
                   <td>
                     <StatusBadge value={session.status} />
                   </td>
                   <td>
-                    {session.workflow_status ? (
-                      <span className={styles.workflowStatusMini}>
-                        {session.workflow_status.replace(/_/g, " ").toUpperCase()}
-                      </span>
-                    ) : (
-                      "—"
-                    )}
+                    <span className={styles.workflowStatusMini}>
+                      {labelOrToken(WORKFLOW_STATUS_LABEL, session.workflow_status)}
+                    </span>
                   </td>
-                  <td>{session.account_mode ?? "—"}</td>
+                  <td>{labelOrToken(ACCOUNT_MODE_LABEL, session.account_mode)}</td>
                   <td>{session.proposals_count}</td>
                   <td>{session.pending_count}</td>
                 </tr>
@@ -108,7 +117,7 @@ export default function SessionListPage() {
               onClick={() => setOffset(Math.max(0, offset - pageSize))}
               type="button"
             >
-              Previous
+              {COMMON.previous}
             </button>
             <button
               className="btn"
@@ -116,7 +125,7 @@ export default function SessionListPage() {
               onClick={() => setOffset(offset + pageSize)}
               type="button"
             >
-              Next
+              {COMMON.next}
             </button>
           </div>
         </>


### PR DESCRIPTION
Linear: [ROB-111](https://linear.app/mgh3326/issue/ROB-111/auto-trader-react-한국어-ui메타데이터-표시-및-ko-kr-locale-정리)

## Summary
- `frontend/trading-decision` React 앱을 한국어 기본으로 정리.
- `src/i18n/` 경량 라벨/포맷터 레이어 신설 (외부 i18n 의존성 추가 없음).
- `formatDateTime` / `formatDecimal` 기본 locale을 `ko-KR`로 전환.
- SessionList / SessionDetail / Preopen / Proposal / Outcome / Reconciliation / Warning / News / MarketBrief / Committee / Execution / Strategy 컴포넌트의 정적 UI chrome, 상태/액션/토큰 라벨, 구조화된 메타데이터를 한국어로 표시.
- 알려진 구조화 필드를 표시할 수 있을 때 raw JSON은 `원본 데이터 보기` `<details>` 뒤로 숨김.

## Scope (ROB-111 준수)
- 표시 전용 변경. API/DB/스케줄러/브로커 부수 효과 없음.
- 기존 DB 자유문(`notes`, `market_brief` 임의 문자열, `original_rationale`, `original_payload` 자유문, 뉴스 기사 제목/요약)은 **번역하지 않음**.
- TradingAgents 출력 언어는 **변경하지 않음**.
- 심볼/거래소 ID/소스 키/UUID 등 운영자 식별자는 그대로 유지.

## 구현 구조
- `src/i18n/ko.ts` — 도메인별 enum→한국어 라벨 맵
- `src/i18n/formatters.ts` — `labelOrToken`, `labelOperatorToken`, `labelOrderSide`, `labelYesNo`
- `src/i18n/index.ts` — 배럴 재익스포트
- 17개 작업 커밋 + 1개 문서 커밋 (Plan: `docs/superpowers/plans/2026-05-05-rob-111-trading-decision-korean-ui.md`)

## Test plan
- [x] `npm run typecheck` — PASS
- [x] `npm test` — 170/170 PASS
- [x] `npm run build` — PASS
- [x] 잔여 영문 chrome sweep — 0건 (QA 한국어 라벨만 매칭)
- [ ] 수동 스모크: `/`, `/sessions/<uuid>`, `/preopen`에서 한국어 라벨, ko-KR 날짜/숫자 포맷, `원본 데이터 보기` 가림 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trading-decision UI localized to Korean by default, including labels, badges, panels, dialogs, and accessibility text; default date/number formatting switched to ko-KR.
  * “원본 데이터 보기” details view added for raw JSON display.

* **Documentation**
  * Added implementation plan for Korean UI translation.

* **Tests**
  * Updated tests to assert Korean UI text; added i18n formatter and date/time formatter tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->