### PR TITLE
feat(ROB-113): Research Pipeline Phase 3 MVP — React 페이지 + Timeline

### DIFF
--- a/app/analysis/pipeline.py
+++ b/app/analysis/pipeline.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from datetime import UTC, datetime
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.analysis.debate import build_summary
@@ -32,6 +33,7 @@ async def run_research_session(
     instrument_type: str,
     research_run_id: int | None = None,
     user_id: int | None = None,
+    existing_session_id: int | None = None,
 ) -> int:
     """
     Orchestrates the entire research pipeline: session creation,
@@ -46,16 +48,23 @@ async def run_research_session(
         db=db,
     )
 
-    # 2. Insert ResearchSession(status='open')
-    session = ResearchSession(
-        stock_info_id=stock_info.id,
-        research_run_id=research_run_id,
-        status="open",
-        started_at=datetime.now(UTC),
-    )
-    db.add(session)
-    await db.flush()
-    session_id = session.id
+    # 2. Insert ResearchSession(status='open') or reuse an existing one
+    if existing_session_id is not None:
+        result = await db.execute(
+            select(ResearchSession).where(ResearchSession.id == existing_session_id)
+        )
+        session = result.scalar_one()
+        session_id = session.id
+    else:
+        session = ResearchSession(
+            stock_info_id=stock_info.id,
+            research_run_id=research_run_id,
+            status="open",
+            started_at=datetime.now(UTC),
+        )
+        db.add(session)
+        await db.flush()
+        session_id = session.id
 
     # 3. Run 4 stage analyzers concurrently via asyncio.gather
     ctx = StageContext(

--- a/app/routers/research_pipeline.py
+++ b/app/routers/research_pipeline.py
@@ -110,3 +110,22 @@ async def get_session_summary(
             detail="summary_not_found",
         )
     return summary
+
+
+@router.get(
+    "/symbols/{symbol}/timeline",
+    dependencies=[Depends(check_pipeline_enabled)],
+)
+async def get_symbol_timeline(
+    symbol: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+    days: int = 30,
+) -> dict[str, Any]:
+    if days < 1 or days > 365:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="days_out_of_range",
+        )
+    service = ResearchPipelineService(db)
+    return await service.get_symbol_timeline(symbol, days=days)

--- a/app/routers/research_pipeline.py
+++ b/app/routers/research_pipeline.py
@@ -61,8 +61,18 @@ async def get_session(
     session_id: int,
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_authenticated_user)],
+    include: str | None = None,
 ) -> dict[str, Any]:
     service = ResearchPipelineService(db)
+    if include == "full":
+        full = await service.get_session_full(session_id)
+        if not full:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="session_not_found",
+            )
+        return full
+
     session = await service.get_session(session_id)
     if not session:
         raise HTTPException(

--- a/app/routers/research_pipeline.py
+++ b/app/routers/research_pipeline.py
@@ -15,7 +15,8 @@ from app.schemas.research_pipeline import (
 )
 from app.services.research_pipeline_service import ResearchPipelineService
 
-router = APIRouter(prefix="/api/research-pipeline", tags=["research-pipeline"])
+api_router = APIRouter(prefix="/api/research-pipeline", tags=["research-pipeline"])
+router = APIRouter()
 
 
 def check_pipeline_enabled():
@@ -26,7 +27,7 @@ def check_pipeline_enabled():
         )
 
 
-@router.post(
+@api_router.post(
     "/sessions",
     status_code=status.HTTP_201_CREATED,
     dependencies=[Depends(check_pipeline_enabled)],
@@ -46,7 +47,7 @@ async def create_session(
     )
 
 
-@router.get("/sessions", dependencies=[Depends(check_pipeline_enabled)])
+@api_router.get("/sessions", dependencies=[Depends(check_pipeline_enabled)])
 async def list_sessions(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_authenticated_user)],
@@ -56,7 +57,9 @@ async def list_sessions(
     return await service.list_recent_sessions(limit=limit)
 
 
-@router.get("/sessions/{session_id}", dependencies=[Depends(check_pipeline_enabled)])
+@api_router.get(
+    "/sessions/{session_id}", dependencies=[Depends(check_pipeline_enabled)]
+)
 async def get_session(
     session_id: int,
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -82,7 +85,7 @@ async def get_session(
     return session
 
 
-@router.get(
+@api_router.get(
     "/sessions/{session_id}/stages", dependencies=[Depends(check_pipeline_enabled)]
 )
 async def get_session_stages(
@@ -94,7 +97,7 @@ async def get_session_stages(
     return await service.get_latest_stages(session_id)
 
 
-@router.get(
+@api_router.get(
     "/sessions/{session_id}/summary", dependencies=[Depends(check_pipeline_enabled)]
 )
 async def get_session_summary(
@@ -112,7 +115,7 @@ async def get_session_summary(
     return summary
 
 
-@router.get(
+@api_router.get(
     "/symbols/{symbol}/timeline",
     dependencies=[Depends(check_pipeline_enabled)],
 )
@@ -129,3 +132,10 @@ async def get_symbol_timeline(
         )
     service = ResearchPipelineService(db)
     return await service.get_symbol_timeline(symbol, days=days)
+
+
+# Keep the legacy `/api/research-pipeline` surface from ROB-112 and expose the
+# Trading Decision Workspace alias used by the React app's shared API client
+# (`/trading/api/...`).
+router.include_router(api_router)
+router.include_router(api_router, prefix="/trading")

--- a/app/routers/research_pipeline.py
+++ b/app/routers/research_pipeline.py
@@ -9,6 +9,10 @@ from app.core.config import settings
 from app.core.db import get_db
 from app.models.trading import User
 from app.routers.dependencies import get_authenticated_user
+from app.schemas.research_pipeline import (
+    ResearchSessionCreateRequest,
+    ResearchSessionCreateResponse,
+)
 from app.services.research_pipeline_service import ResearchPipelineService
 
 router = APIRouter(prefix="/api/research-pipeline", tags=["research-pipeline"])
@@ -20,6 +24,26 @@ def check_pipeline_enabled():
             status_code=status.HTTP_403_FORBIDDEN,
             detail="research_pipeline_disabled",
         )
+
+
+@router.post(
+    "/sessions",
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(check_pipeline_enabled)],
+)
+async def create_session(
+    payload: ResearchSessionCreateRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_authenticated_user)],
+) -> ResearchSessionCreateResponse:
+    service = ResearchPipelineService(db)
+    return await service.create_session_and_dispatch(
+        symbol=payload.symbol,
+        name=payload.name,
+        instrument_type=payload.instrument_type,
+        research_run_id=payload.research_run_id,
+        user_id=current_user.id,
+    )
 
 
 @router.get("/sessions", dependencies=[Depends(check_pipeline_enabled)])

--- a/app/schemas/research_pipeline.py
+++ b/app/schemas/research_pipeline.py
@@ -123,3 +123,108 @@ class SummaryOutput(BaseModel):
     raw_payload: dict | None = None
     token_input: int | None = None
     token_output: int | None = None
+
+
+# --- ROB-113 Phase 3 schemas ---
+
+
+class ResearchSessionCreateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str = Field(min_length=1, max_length=64)
+    name: str | None = None
+    instrument_type: Literal["equity_kr", "equity_us", "crypto"]
+    research_run_id: int | None = None
+    triggered_by: Literal["user", "scheduler"] = "user"
+
+
+class ResearchSessionCreateResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: int
+    status: Literal["open", "running", "finalized", "failed", "cancelled"]
+    started_at: datetime
+
+
+class SummaryStageLinkOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    stage_analysis_id: int
+    stage_type: Literal["market", "news", "fundamentals", "social"]
+    direction: Literal["support", "contradict", "context"]
+    weight: float = Field(ge=0.0, le=1.0)
+    rationale: str | None = None
+
+
+class StageAnalysisOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: int
+    stage_type: Literal["market", "news", "fundamentals", "social"]
+    verdict: StageVerdict
+    confidence: int = Field(ge=0, le=100)
+    signals: dict
+    raw_payload: dict | None = None
+    source_freshness: dict | None = None
+    executed_at: datetime
+    snapshot_at: datetime | None = None
+
+
+class ResearchSummaryOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: int
+    session_id: int
+    decision: SummaryDecision
+    confidence: int = Field(ge=0, le=100)
+    bull_arguments: list[dict]
+    bear_arguments: list[dict]
+    price_analysis: dict | None = None
+    reasons: list[str] | None = None
+    detailed_text: str | None = None
+    warnings: list[str] | None = None
+    executed_at: datetime
+    summary_stage_links: list[SummaryStageLinkOut] = Field(default_factory=list)
+
+
+class ResearchSessionOut(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: int
+    stock_info_id: int
+    research_run_id: int | None = None
+    status: str
+    started_at: datetime | None = None
+    finalized_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime | None = None
+    symbol: str | None = None
+    instrument_type: str | None = None
+
+
+class SessionFullResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    session: ResearchSessionOut
+    stages: list[StageAnalysisOut] = Field(default_factory=list)
+    summary: ResearchSummaryOut | None = None
+
+
+class SymbolTimelineEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: int
+    status: str
+    started_at: datetime | None = None
+    finalized_at: datetime | None = None
+    decision: SummaryDecision | None = None
+    confidence: int | None = Field(default=None, ge=0, le=100)
+    stage_verdicts: dict[str, StageVerdict] = Field(default_factory=dict)
+
+
+class SymbolTimelineResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    days: int = Field(ge=1, le=365)
+    entries: list[SymbolTimelineEntry] = Field(default_factory=list)

--- a/app/services/research_pipeline_service.py
+++ b/app/services/research_pipeline_service.py
@@ -182,6 +182,15 @@ class ResearchPipelineService:
         if not summary:
             return None
 
+        stage_ids = [link.stage_analysis_id for link in summary.stage_links]
+        stage_type_by_id: dict[int, str] = {}
+        if stage_ids:
+            stage_rows = await self.db.execute(
+                select(StageAnalysis).where(StageAnalysis.id.in_(stage_ids))
+            )
+            for stage in stage_rows.scalars().all():
+                stage_type_by_id[stage.id] = stage.stage_type
+
         return {
             "id": summary.id,
             "session_id": summary.session_id,
@@ -194,8 +203,16 @@ class ResearchPipelineService:
             "detailed_text": summary.detailed_text,
             "warnings": summary.warnings,
             "executed_at": summary.executed_at,
-            "cited_stage_analysis_ids": [
-                link.stage_analysis_id for link in summary.stage_links
+            "cited_stage_analysis_ids": stage_ids,
+            "summary_stage_links": [
+                {
+                    "stage_analysis_id": link.stage_analysis_id,
+                    "stage_type": stage_type_by_id.get(link.stage_analysis_id, "unknown"),
+                    "direction": link.direction,
+                    "weight": link.weight,
+                    "rationale": link.rationale,
+                }
+                for link in summary.stage_links
             ],
         }
 

--- a/app/services/research_pipeline_service.py
+++ b/app/services/research_pipeline_service.py
@@ -198,9 +198,7 @@ class ResearchPipelineService:
 
         return list(latest_stages.values())
 
-    async def get_symbol_timeline(
-        self, symbol: str, days: int = 30
-    ) -> dict[str, Any]:
+    async def get_symbol_timeline(self, symbol: str, days: int = 30) -> dict[str, Any]:
         from datetime import timedelta
 
         from app.models.analysis import StockInfo
@@ -299,7 +297,9 @@ class ResearchPipelineService:
             "summary_stage_links": [
                 {
                     "stage_analysis_id": link.stage_analysis_id,
-                    "stage_type": stage_type_by_id.get(link.stage_analysis_id, "unknown"),
+                    "stage_type": stage_type_by_id.get(
+                        link.stage_analysis_id, "unknown"
+                    ),
                     "direction": link.direction,
                     "weight": link.weight,
                     "rationale": link.rationale,

--- a/app/services/research_pipeline_service.py
+++ b/app/services/research_pipeline_service.py
@@ -198,6 +198,62 @@ class ResearchPipelineService:
 
         return list(latest_stages.values())
 
+    async def get_symbol_timeline(
+        self, symbol: str, days: int = 30
+    ) -> dict[str, Any]:
+        from datetime import timedelta
+
+        from app.models.analysis import StockInfo
+
+        cutoff = datetime.now(UTC) - timedelta(days=days)
+
+        stock_result = await self.db.execute(
+            select(StockInfo).where(StockInfo.symbol == symbol)
+        )
+        stock_info = stock_result.scalar_one_or_none()
+        if not stock_info:
+            return {"symbol": symbol, "days": days, "entries": []}
+
+        sessions_result = await self.db.execute(
+            select(ResearchSession)
+            .where(ResearchSession.stock_info_id == stock_info.id)
+            .where(ResearchSession.created_at >= cutoff)
+            .options(
+                selectinload(ResearchSession.summaries),
+                selectinload(ResearchSession.stage_analyses),
+            )
+            .order_by(ResearchSession.created_at.desc())
+        )
+        sessions = sessions_result.scalars().all()
+
+        entries = []
+        for s in sessions:
+            latest_summary = (
+                max(s.summaries, key=lambda x: x.executed_at) if s.summaries else None
+            )
+            latest_per_stage: dict[str, Any] = {}
+            for stage in s.stage_analyses:
+                current = latest_per_stage.get(stage.stage_type)
+                if current is None or stage.executed_at > current.executed_at:
+                    latest_per_stage[stage.stage_type] = stage
+
+            entries.append(
+                {
+                    "session_id": s.id,
+                    "status": s.status,
+                    "started_at": s.started_at,
+                    "finalized_at": s.finalized_at,
+                    "decision": latest_summary.decision if latest_summary else None,
+                    "confidence": latest_summary.confidence if latest_summary else None,
+                    "stage_verdicts": {
+                        stype: stage.verdict
+                        for stype, stage in latest_per_stage.items()
+                    },
+                }
+            )
+
+        return {"symbol": symbol, "days": days, "entries": entries}
+
     async def get_latest_summary(self, session_id: int) -> dict[str, Any] | None:
         """Returns latest summary + cited stage_analysis ids."""
         result = await self.db.execute(

--- a/app/services/research_pipeline_service.py
+++ b/app/services/research_pipeline_service.py
@@ -135,6 +135,40 @@ class ResearchPipelineService:
             "updated_at": session.updated_at,
         }
 
+    async def get_session_full(self, session_id: int) -> dict[str, Any] | None:
+        """Returns session header with symbol + instrument_type, all stages, and latest summary."""
+        from app.models.analysis import StockInfo
+
+        session_result = await self.db.execute(
+            select(ResearchSession, StockInfo)
+            .join(StockInfo, ResearchSession.stock_info_id == StockInfo.id)
+            .where(ResearchSession.id == session_id)
+        )
+        row = session_result.first()
+        if not row:
+            return None
+        session, stock_info = row
+
+        stages = await self.get_latest_stages(session_id)
+        summary = await self.get_latest_summary(session_id)
+
+        return {
+            "session": {
+                "id": session.id,
+                "stock_info_id": session.stock_info_id,
+                "research_run_id": session.research_run_id,
+                "status": session.status,
+                "started_at": session.started_at,
+                "finalized_at": session.finalized_at,
+                "created_at": session.created_at,
+                "updated_at": session.updated_at,
+                "symbol": stock_info.symbol,
+                "instrument_type": stock_info.instrument_type,
+            },
+            "stages": stages,
+            "summary": summary,
+        }
+
     async def get_latest_stages(self, session_id: int) -> list[dict[str, Any]]:
         """Returns latest stage row per stage_type."""
         # Use DISTINCT ON or manual grouping to get latest per stage_type
@@ -156,8 +190,10 @@ class ResearchPipelineService:
                     "verdict": stage.verdict,
                     "confidence": stage.confidence,
                     "signals": stage.signals,
+                    "raw_payload": stage.raw_payload,
                     "source_freshness": stage.source_freshness,
                     "executed_at": stage.executed_at,
+                    "snapshot_at": stage.snapshot_at,
                 }
 
         return list(latest_stages.values())

--- a/app/services/research_pipeline_service.py
+++ b/app/services/research_pipeline_service.py
@@ -1,5 +1,8 @@
 """ROB-112 — Research pipeline service."""
 
+import asyncio
+import logging
+from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy import select
@@ -7,7 +10,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.analysis.pipeline import run_research_session
+from app.core.db import AsyncSessionLocal
 from app.models.research_pipeline import ResearchSession, ResearchSummary, StageAnalysis
+from app.schemas.research_pipeline import ResearchSessionCreateResponse
+from app.services.stock_info_service import create_stock_if_not_exists
+
+logger = logging.getLogger(__name__)
 
 
 class ResearchPipelineService:
@@ -34,6 +42,49 @@ class ResearchPipelineService:
             instrument_type=instrument_type,
             research_run_id=research_run_id,
             user_id=user_id,
+        )
+
+    async def create_session_and_dispatch(
+        self,
+        *,
+        symbol: str,
+        name: str | None,
+        instrument_type: str,
+        research_run_id: int | None,
+        user_id: int | None,
+    ) -> ResearchSessionCreateResponse:
+        stock_info = await create_stock_if_not_exists(
+            symbol=symbol,
+            name=name or symbol,
+            instrument_type=instrument_type,
+            db=self.db,
+        )
+        session = ResearchSession(
+            stock_info_id=stock_info.id,
+            research_run_id=research_run_id,
+            status="open",
+            started_at=datetime.now(UTC),
+        )
+        self.db.add(session)
+        await self.db.flush()
+        await self.db.commit()
+        session_id = session.id
+
+        asyncio.create_task(
+            _run_session_in_background(
+                session_id=session_id,
+                symbol=symbol,
+                name=name or symbol,
+                instrument_type=instrument_type,
+                research_run_id=research_run_id,
+                user_id=user_id,
+            )
+        )
+
+        return ResearchSessionCreateResponse(
+            session_id=session_id,
+            status="running",
+            started_at=session.started_at,
         )
 
     async def list_recent_sessions(self, limit: int = 20) -> list[dict[str, Any]]:
@@ -147,3 +198,42 @@ class ResearchPipelineService:
                 link.stage_analysis_id for link in summary.stage_links
             ],
         }
+
+
+async def _run_session_in_background(
+    *,
+    session_id: int,
+    symbol: str,
+    name: str,
+    instrument_type: str,
+    research_run_id: int | None,
+    user_id: int | None,
+) -> None:
+    from app.analysis.pipeline import run_research_session as _run_research_session
+
+    async with AsyncSessionLocal() as db:
+        try:
+            await _run_research_session(
+                db=db,
+                symbol=symbol,
+                name=name,
+                instrument_type=instrument_type,
+                research_run_id=research_run_id,
+                user_id=user_id,
+                existing_session_id=session_id,
+            )
+        except Exception:
+            logger.exception(
+                "research pipeline background run failed session_id=%s", session_id
+            )
+            try:
+                from sqlalchemy import update as sa_update
+
+                await db.execute(
+                    sa_update(ResearchSession)
+                    .where(ResearchSession.id == session_id)
+                    .values(status="failed", finalized_at=datetime.now(UTC))
+                )
+                await db.commit()
+            except Exception:
+                logger.exception("failed to mark session_id=%s failed", session_id)

--- a/frontend/trading-decision/src/__tests__/ResearchHomePage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/ResearchHomePage.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ResearchHomePage from "../pages/ResearchHomePage";
+import {
+  makeCreateResponse,
+  makeSessionListItem,
+} from "../test/fixtures/research";
+import { mockFetch } from "../test/server";
+
+describe("ResearchHomePage", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("renders recent sessions", async () => {
+    mockFetch({
+      "/trading/api/research-pipeline/sessions?limit=20": () =>
+        new Response(JSON.stringify([makeSessionListItem({ id: 1 })])),
+    });
+    render(
+      <MemoryRouter initialEntries={["/research"]}>
+        <Routes>
+          <Route path="/research" element={<ResearchHomePage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(screen.getByText(/세션 시작/)).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("row", { name: /1/ })).toBeInTheDocument();
+  });
+
+  it("submits start form and navigates to detail", async () => {
+    const { calls } = mockFetch({
+      "/trading/api/research-pipeline/sessions?limit=20": () =>
+        new Response(JSON.stringify([])),
+      "/trading/api/research-pipeline/sessions": () =>
+        new Response(
+          JSON.stringify(makeCreateResponse({ session_id: 77 })),
+          { status: 201 },
+        ),
+    });
+    render(
+      <MemoryRouter initialEntries={["/research"]}>
+        <Routes>
+          <Route path="/research" element={<ResearchHomePage />} />
+          <Route
+            path="/research/sessions/:sessionId"
+            element={<div>detail-77</div>}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(screen.getByLabelText(/심볼/)).toBeInTheDocument(),
+    );
+
+    await userEvent.type(screen.getByLabelText(/심볼/), "KRW-BTC");
+    await userEvent.selectOptions(
+      screen.getByLabelText(/종목 유형/),
+      "crypto",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /세션 시작/ }));
+
+    await waitFor(() => expect(screen.getByText("detail-77")).toBeInTheDocument());
+    const post = calls.find((c) => c.method === "POST");
+    expect(post?.url).toContain("/research-pipeline/sessions");
+  });
+});

--- a/frontend/trading-decision/src/__tests__/ResearchSessionDetailPage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/ResearchSessionDetailPage.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ResearchSessionDetailPage from "../pages/ResearchSessionDetailPage";
+import { makeSessionFull } from "../test/fixtures/research";
+import { mockFetch } from "../test/server";
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/research/sessions/:sessionId"
+          element={<ResearchSessionDetailPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("ResearchSessionDetailPage", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("renders summary tab on success", async () => {
+    mockFetch({
+      "/trading/api/research-pipeline/sessions/1?include=full": () =>
+        new Response(JSON.stringify(makeSessionFull())),
+    });
+    renderAt("/research/sessions/1");
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: /종합/ })).toBeInTheDocument(),
+    );
+    expect(screen.getByText("매수")).toBeInTheDocument();
+  });
+
+  it("shows not_found when 404", async () => {
+    mockFetch({
+      "/trading/api/research-pipeline/sessions/999?include=full": () =>
+        new Response(JSON.stringify({ detail: "session_not_found" }), {
+          status: 404,
+        }),
+    });
+    renderAt("/research/sessions/999");
+    await waitFor(() =>
+      expect(screen.getByText(/세션을 찾을 수 없습니다/)).toBeInTheDocument(),
+    );
+  });
+
+  it("switches to social tab and renders placeholder", async () => {
+    mockFetch({
+      "/trading/api/research-pipeline/sessions/1?include=full": () =>
+        new Response(JSON.stringify(makeSessionFull())),
+    });
+    renderAt("/research/sessions/1");
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: /소셜/ })).toBeInTheDocument(),
+    );
+    await userEvent.click(screen.getByRole("tab", { name: /소셜/ }));
+    expect(
+      screen.getByText(/소셜 신호 분석은 준비 중입니다/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders citation sidebar with support direction", async () => {
+    mockFetch({
+      "/trading/api/research-pipeline/sessions/1?include=full": () =>
+        new Response(JSON.stringify(makeSessionFull())),
+    });
+    renderAt("/research/sessions/1");
+    const sidebar = await waitFor(() =>
+      screen.getByRole("complementary", { name: "인용된 단계" }),
+    );
+    expect(within(sidebar).getByText("지지")).toBeInTheDocument();
+    expect(within(sidebar).getByText(/시장/)).toBeInTheDocument();
+  });
+});

--- a/frontend/trading-decision/src/__tests__/SymbolTimelinePage.test.tsx
+++ b/frontend/trading-decision/src/__tests__/SymbolTimelinePage.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import SymbolTimelinePage from "../pages/SymbolTimelinePage";
+import { makeSymbolTimeline } from "../test/fixtures/research";
+import { mockFetch } from "../test/server";
+
+describe("SymbolTimelinePage", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("renders entries and chart", async () => {
+    mockFetch({
+      "/trading/api/research-pipeline/symbols/AAPL/timeline?days=30": () =>
+        new Response(JSON.stringify(makeSymbolTimeline())),
+    });
+    render(
+      <MemoryRouter initialEntries={["/research/symbols/AAPL/timeline"]}>
+        <Routes>
+          <Route
+            path="/research/symbols/:symbol/timeline"
+            element={<SymbolTimelinePage />}
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText("AAPL")).toBeInTheDocument());
+    expect(
+      screen.getByRole("img", { name: /평결 변화 미니 차트/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/매수/)).toBeInTheDocument();
+  });
+});

--- a/frontend/trading-decision/src/__tests__/api.researchPipeline.test.ts
+++ b/frontend/trading-decision/src/__tests__/api.researchPipeline.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createSession,
+  getSession,
+  getSessionFull,
+  getSessionStages,
+  getSessionSummary,
+  getSymbolTimeline,
+  listSessions,
+} from "../api/researchPipeline";
+import {
+  makeCreateResponse,
+  makeSessionFull,
+  makeSessionListItem,
+  makeSymbolTimeline,
+} from "../test/fixtures/research";
+import { mockFetch } from "../test/server";
+
+describe("researchPipeline API client", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("listSessions hits /api/research-pipeline/sessions with limit", async () => {
+    const { calls } = mockFetch({
+      "/trading/api/research-pipeline/sessions?limit=20": () =>
+        new Response(JSON.stringify([makeSessionListItem()])),
+    });
+    const data = await listSessions({ limit: 20 });
+    expect(data).toHaveLength(1);
+    expect(calls[0]?.method).toBe("GET");
+  });
+
+  it("createSession POSTs body and returns session_id", async () => {
+    const { calls } = mockFetch({
+      "/trading/api/research-pipeline/sessions": () =>
+        new Response(JSON.stringify(makeCreateResponse({ session_id: 42 })), {
+          status: 201,
+        }),
+    });
+    const result = await createSession({
+      symbol: "KRW-BTC",
+      instrument_type: "crypto",
+    });
+    expect(result.session_id).toBe(42);
+    expect(calls[0]?.method).toBe("POST");
+    expect(JSON.parse(calls[0]?.body ?? "{}")).toEqual({
+      symbol: "KRW-BTC",
+      instrument_type: "crypto",
+      triggered_by: "user",
+    });
+  });
+
+  it("getSession hits /sessions/:id", async () => {
+    mockFetch({
+      "/trading/api/research-pipeline/sessions/1": () =>
+        new Response(JSON.stringify({ id: 1, status: "running" })),
+    });
+    const data = await getSession(1);
+    expect(data.id).toBe(1);
+  });
+
+  it("getSessionFull hits /sessions/:id?include=full", async () => {
+    const { calls } = mockFetch({
+      "/trading/api/research-pipeline/sessions/1?include=full": () =>
+        new Response(JSON.stringify(makeSessionFull())),
+    });
+    const data = await getSessionFull(1);
+    expect(data.session.id).toBe(1);
+    expect(data.stages).toHaveLength(4);
+    expect(calls[0]?.url).toContain("include=full");
+  });
+
+  it("getSessionStages hits /sessions/:id/stages", async () => {
+    mockFetch({
+      "/trading/api/research-pipeline/sessions/1/stages": () =>
+        new Response(JSON.stringify([])),
+    });
+    const data = await getSessionStages(1);
+    expect(Array.isArray(data)).toBe(true);
+  });
+
+  it("getSessionSummary hits /sessions/:id/summary", async () => {
+    mockFetch({
+      "/trading/api/research-pipeline/sessions/1/summary": () =>
+        new Response(JSON.stringify({ id: 1, decision: "buy", confidence: 80 })),
+    });
+    const data = await getSessionSummary(1);
+    expect(data.decision).toBe("buy");
+  });
+
+  it("getSymbolTimeline hits /symbols/:symbol/timeline?days=30", async () => {
+    const { calls } = mockFetch({
+      "/trading/api/research-pipeline/symbols/AAPL/timeline?days=30": () =>
+        new Response(JSON.stringify(makeSymbolTimeline())),
+    });
+    const data = await getSymbolTimeline("AAPL", 30);
+    expect(data.symbol).toBe("AAPL");
+    expect(calls[0]?.url).toContain("days=30");
+  });
+});

--- a/frontend/trading-decision/src/__tests__/routes.test.tsx
+++ b/frontend/trading-decision/src/__tests__/routes.test.tsx
@@ -29,4 +29,26 @@ describe("trading decision routes", () => {
     const matches = matchRoutes(tradingDecisionRoutes, "/news-radar");
     expect(matches?.at(-1)?.route.path).toBe("/news-radar");
   });
+
+  it("registers /research home route", () => {
+    const matches = matchRoutes(tradingDecisionRoutes, "/research");
+    expect(matches?.at(-1)?.route.path).toBe("/research");
+  });
+
+  it("registers /research/sessions/:sessionId detail route", () => {
+    const matches = matchRoutes(tradingDecisionRoutes, "/research/sessions/42");
+    expect(matches?.at(-1)?.route.path).toBe("/research/sessions/:sessionId");
+    expect(matches?.at(-1)?.params.sessionId).toBe("42");
+  });
+
+  it("registers /research/symbols/:symbol/timeline route", () => {
+    const matches = matchRoutes(
+      tradingDecisionRoutes,
+      "/research/symbols/AAPL/timeline",
+    );
+    expect(matches?.at(-1)?.route.path).toBe(
+      "/research/symbols/:symbol/timeline",
+    );
+    expect(matches?.at(-1)?.params.symbol).toBe("AAPL");
+  });
 });

--- a/frontend/trading-decision/src/__tests__/useResearchSession.test.tsx
+++ b/frontend/trading-decision/src/__tests__/useResearchSession.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useResearchSession } from "../hooks/useResearchSession";
+import { makeSessionFull } from "../test/fixtures/research";
+import { mockFetch } from "../test/server";
+
+describe("useResearchSession", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("loads full session, then polls until finalized and stops", async () => {
+    let call = 0;
+    mockFetch({
+      "/trading/api/research-pipeline/sessions/1?include=full": () => {
+        call += 1;
+        const status = call < 3 ? "running" : "finalized";
+        return new Response(
+          JSON.stringify(
+            makeSessionFull({
+              session: {
+                ...makeSessionFull().session,
+                status,
+              },
+            }),
+          ),
+        );
+      },
+    });
+
+    const { result } = renderHook(() => useResearchSession(1));
+
+    await waitFor(() => expect(result.current.status).toBe("success"));
+    expect(result.current.data?.session.status).toBe("running");
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await waitFor(() =>
+      expect(result.current.data?.session.status).toBe("running"),
+    );
+
+    await vi.advanceTimersByTimeAsync(5000);
+    await waitFor(() =>
+      expect(result.current.data?.session.status).toBe("finalized"),
+    );
+
+    const callsAfterFinalized = call;
+    await vi.advanceTimersByTimeAsync(15000);
+    expect(call).toBe(callsAfterFinalized);
+  });
+
+  it("returns not_found on 404", async () => {
+    mockFetch({
+      "/trading/api/research-pipeline/sessions/999?include=full": () =>
+        new Response(JSON.stringify({ detail: "session_not_found" }), {
+          status: 404,
+        }),
+    });
+    const { result } = renderHook(() => useResearchSession(999));
+    await waitFor(() => expect(result.current.status).toBe("not_found"));
+  });
+});

--- a/frontend/trading-decision/src/api/researchPipeline.ts
+++ b/frontend/trading-decision/src/api/researchPipeline.ts
@@ -1,0 +1,72 @@
+import { apiFetch } from "./client";
+import type {
+  ResearchSessionCreateRequest,
+  ResearchSessionCreateResponse,
+  ResearchSessionFullResponse,
+  ResearchSessionHeader,
+  ResearchSessionListItem,
+  ResearchSummary,
+  StageAnalysis,
+  SymbolTimelineResponse,
+} from "./types";
+
+export function listSessions(args: {
+  limit?: number;
+} = {}): Promise<ResearchSessionListItem[]> {
+  const limit = args.limit ?? 20;
+  return apiFetch<ResearchSessionListItem[]>(
+    `/research-pipeline/sessions?limit=${limit}`,
+  );
+}
+
+export function createSession(
+  body: ResearchSessionCreateRequest,
+): Promise<ResearchSessionCreateResponse> {
+  const payload: ResearchSessionCreateRequest = {
+    triggered_by: "user",
+    ...body,
+  };
+  return apiFetch<ResearchSessionCreateResponse>(
+    "/research-pipeline/sessions",
+    { method: "POST", body: JSON.stringify(payload) },
+  );
+}
+
+export function getSession(sessionId: number): Promise<ResearchSessionHeader> {
+  return apiFetch<ResearchSessionHeader>(
+    `/research-pipeline/sessions/${sessionId}`,
+  );
+}
+
+export function getSessionFull(
+  sessionId: number,
+): Promise<ResearchSessionFullResponse> {
+  return apiFetch<ResearchSessionFullResponse>(
+    `/research-pipeline/sessions/${sessionId}?include=full`,
+  );
+}
+
+export function getSessionStages(
+  sessionId: number,
+): Promise<StageAnalysis[]> {
+  return apiFetch<StageAnalysis[]>(
+    `/research-pipeline/sessions/${sessionId}/stages`,
+  );
+}
+
+export function getSessionSummary(
+  sessionId: number,
+): Promise<ResearchSummary> {
+  return apiFetch<ResearchSummary>(
+    `/research-pipeline/sessions/${sessionId}/summary`,
+  );
+}
+
+export function getSymbolTimeline(
+  symbol: string,
+  days = 30,
+): Promise<SymbolTimelineResponse> {
+  return apiFetch<SymbolTimelineResponse>(
+    `/research-pipeline/symbols/${encodeURIComponent(symbol)}/timeline?days=${days}`,
+  );
+}

--- a/frontend/trading-decision/src/api/types.ts
+++ b/frontend/trading-decision/src/api/types.ts
@@ -857,3 +857,198 @@ export interface NewsRadarResponse {
   excluded_items: NewsRadarItem[];
   source_coverage: NewsRadarSourceCoverage[];
 }
+
+// --- ROB-113 Research Pipeline Phase 3 types ---
+
+export type ResearchSessionStatus =
+  | "open"
+  | "running"
+  | "finalized"
+  | "failed"
+  | "cancelled";
+
+export type StageType = "market" | "news" | "fundamentals" | "social";
+
+export type StageVerdict = "bull" | "bear" | "neutral" | "unavailable";
+
+export type SummaryDecision = "buy" | "hold" | "sell";
+
+export type LinkDirection = "support" | "contradict" | "context";
+
+export type ResearchInstrumentType = "equity_kr" | "equity_us" | "crypto";
+
+export interface ResearchSessionListItem {
+  id: number;
+  stock_info_id: number;
+  status: ResearchSessionStatus | string;
+  created_at: IsoDateTime;
+  decision: SummaryDecision | null;
+  confidence: number | null;
+}
+
+export interface ResearchSessionHeader {
+  id: number;
+  stock_info_id: number;
+  research_run_id: number | null;
+  status: ResearchSessionStatus | string;
+  started_at: IsoDateTime | null;
+  finalized_at: IsoDateTime | null;
+  created_at: IsoDateTime;
+  updated_at: IsoDateTime | null;
+  symbol: string | null;
+  instrument_type: string | null;
+}
+
+export interface MarketSignals {
+  last_close?: number;
+  change_pct?: number;
+  rsi_14?: number;
+  atr_14?: number;
+  volume_ratio_20d?: number;
+  trend?: "uptrend" | "downtrend" | "flat" | "unknown";
+  price_change_pct_1d?: number;
+  price_change_pct_5d?: number;
+  price_change_pct_20d?: number;
+  macd_signal?: string;
+  bollinger_position?: string;
+  supports?: number[];
+  resistances?: number[];
+  trend_short?: string;
+  trend_mid?: string;
+  trend_long?: string;
+  [key: string]: unknown;
+}
+
+export interface NewsSignals {
+  headline_count?: number;
+  sentiment_score?: number;
+  top_themes?: string[];
+  urgent_flags?: string[];
+  articles?: Array<{
+    title?: string;
+    url?: string;
+    source?: string;
+    published_at?: IsoDateTime;
+    sentiment?: "positive" | "negative" | "neutral";
+  }>;
+  [key: string]: unknown;
+}
+
+export interface FundamentalsSignals {
+  per?: number | null;
+  pbr?: number | null;
+  peg?: number | null;
+  ev_ebitda?: number | null;
+  market_cap?: number | null;
+  sector?: string | null;
+  peer_count?: number;
+  relative_per_vs_peers?: number | null;
+  disclosures?: Array<{ title: string; url?: string; reported_at?: IsoDateTime }>;
+  analyst_consensus?: string | null;
+  insider_flow?: string | null;
+  [key: string]: unknown;
+}
+
+export interface SocialSignals {
+  available: boolean;
+  reason: string;
+  phase: string;
+  [key: string]: unknown;
+}
+
+export interface SourceFreshness {
+  newest_age_minutes: number;
+  oldest_age_minutes: number;
+  missing_sources: string[];
+  stale_flags: string[];
+  source_count: number;
+}
+
+export interface StageAnalysis {
+  id: number;
+  stage_type: StageType;
+  verdict: StageVerdict;
+  confidence: number;
+  signals: MarketSignals | NewsSignals | FundamentalsSignals | SocialSignals;
+  raw_payload: Record<string, unknown> | null;
+  source_freshness: SourceFreshness | null;
+  executed_at: IsoDateTime;
+  snapshot_at: IsoDateTime | null;
+}
+
+export interface BullBearArgument {
+  text: string;
+  cited_stage_ids: number[];
+  direction: LinkDirection;
+  weight: number;
+}
+
+export interface PriceAnalysis {
+  appropriate_buy_min?: number | null;
+  appropriate_buy_max?: number | null;
+  appropriate_sell_min?: number | null;
+  appropriate_sell_max?: number | null;
+  buy_hope_min?: number | null;
+  buy_hope_max?: number | null;
+  sell_target_min?: number | null;
+  sell_target_max?: number | null;
+}
+
+export interface SummaryStageLink {
+  stage_analysis_id: number;
+  stage_type: StageType;
+  direction: LinkDirection;
+  weight: number;
+  rationale: string | null;
+}
+
+export interface ResearchSummary {
+  id: number;
+  session_id: number;
+  decision: SummaryDecision;
+  confidence: number;
+  bull_arguments: BullBearArgument[];
+  bear_arguments: BullBearArgument[];
+  price_analysis: PriceAnalysis | null;
+  reasons: string[] | null;
+  detailed_text: string | null;
+  warnings: string[] | null;
+  executed_at: IsoDateTime;
+  summary_stage_links: SummaryStageLink[];
+}
+
+export interface ResearchSessionFullResponse {
+  session: ResearchSessionHeader;
+  stages: StageAnalysis[];
+  summary: ResearchSummary | null;
+}
+
+export interface ResearchSessionCreateRequest {
+  symbol: string;
+  name?: string | null;
+  instrument_type: ResearchInstrumentType;
+  research_run_id?: number | null;
+  triggered_by?: "user" | "scheduler";
+}
+
+export interface ResearchSessionCreateResponse {
+  session_id: number;
+  status: ResearchSessionStatus;
+  started_at: IsoDateTime;
+}
+
+export interface SymbolTimelineEntry {
+  session_id: number;
+  status: ResearchSessionStatus | string;
+  started_at: IsoDateTime | null;
+  finalized_at: IsoDateTime | null;
+  decision: SummaryDecision | null;
+  confidence: number | null;
+  stage_verdicts: Partial<Record<StageType, StageVerdict>>;
+}
+
+export interface SymbolTimelineResponse {
+  symbol: string;
+  days: number;
+  entries: SymbolTimelineEntry[];
+}

--- a/frontend/trading-decision/src/components/CitedStageSidebar.tsx
+++ b/frontend/trading-decision/src/components/CitedStageSidebar.tsx
@@ -1,0 +1,72 @@
+import {
+  LINK_DIRECTION_LABEL,
+  STAGE_TYPE_LABEL,
+} from "../i18n/ko";
+import type { StageAnalysis, SummaryStageLink } from "../api/types";
+
+interface Props {
+  links: SummaryStageLink[];
+  stages: StageAnalysis[];
+  onJumpToStage: (stageType: string) => void;
+}
+
+export default function CitedStageSidebar({
+  links,
+  stages,
+  onJumpToStage,
+}: Props) {
+  if (links.length === 0) {
+    return (
+      <aside aria-label="인용된 단계">
+        <p>인용된 단계가 없습니다.</p>
+      </aside>
+    );
+  }
+
+  const stageById = new Map(stages.map((s) => [s.id, s]));
+  const grouped: Record<string, SummaryStageLink[]> = {
+    support: [],
+    contradict: [],
+    context: [],
+  };
+  for (const link of links) {
+    grouped[link.direction]?.push(link);
+  }
+
+  return (
+    <aside aria-label="인용된 단계">
+      <h3>인용된 단계</h3>
+      {(["support", "contradict", "context"] as const).map((dir) => {
+        const items = grouped[dir];
+        if (!items || items.length === 0) return null;
+        return (
+          <section key={dir}>
+            <h4>{LINK_DIRECTION_LABEL[dir]}</h4>
+            <ul>
+              {items.map((link) => {
+                const stage = stageById.get(link.stage_analysis_id);
+                const isUnavailable =
+                  stage?.verdict === "unavailable" ||
+                  stage?.stage_type === "social";
+                return (
+                  <li key={link.stage_analysis_id}>
+                    <button
+                      type="button"
+                      onClick={() => onJumpToStage(link.stage_type)}
+                      aria-label={`${STAGE_TYPE_LABEL[link.stage_type]} 단계로 이동`}
+                      data-unavailable={isUnavailable ? "true" : undefined}
+                    >
+                      {STAGE_TYPE_LABEL[link.stage_type]}
+                      {link.rationale ? `: ${link.rationale}` : ""}
+                      {" "}({Math.round(link.weight * 100)}%)
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        );
+      })}
+    </aside>
+  );
+}

--- a/frontend/trading-decision/src/components/ResearchFundamentalsTab.tsx
+++ b/frontend/trading-decision/src/components/ResearchFundamentalsTab.tsx
@@ -1,0 +1,72 @@
+import { STAGE_VERDICT_LABEL } from "../i18n/ko";
+import type { FundamentalsSignals, StageAnalysis } from "../api/types";
+
+interface Props {
+  stage: StageAnalysis | null;
+}
+
+function fmt(v: unknown): string {
+  if (v === null || v === undefined || v === "") return "—";
+  return String(v);
+}
+
+export default function ResearchFundamentalsTab({ stage }: Props) {
+  if (!stage) return <p>펀더멘털 단계 데이터가 없습니다.</p>;
+  if (stage.verdict === "unavailable")
+    return <p>펀더멘털 단계 데이터를 가져올 수 없습니다.</p>;
+  const s = stage.signals as FundamentalsSignals;
+
+  return (
+    <div>
+      <header>
+        <span data-verdict={stage.verdict}>
+          {STAGE_VERDICT_LABEL[stage.verdict]}
+        </span>
+        <progress value={stage.confidence} max={100}>
+          {stage.confidence}%
+        </progress>
+      </header>
+
+      <dl>
+        <dt>PER</dt>
+        <dd>{fmt(s.per)}</dd>
+        <dt>PBR</dt>
+        <dd>{fmt(s.pbr)}</dd>
+        <dt>PEG</dt>
+        <dd>{fmt(s.peg)}</dd>
+        <dt>EV/EBITDA</dt>
+        <dd>{fmt(s.ev_ebitda)}</dd>
+        <dt>시가총액</dt>
+        <dd>{fmt(s.market_cap)}</dd>
+        <dt>섹터</dt>
+        <dd>{fmt(s.sector)}</dd>
+        <dt>피어 PER 상대</dt>
+        <dd>{fmt(s.relative_per_vs_peers)}</dd>
+        <dt>애널리스트 컨센서스</dt>
+        <dd>{fmt(s.analyst_consensus)}</dd>
+        <dt>내부자 흐름</dt>
+        <dd>{fmt(s.insider_flow)}</dd>
+      </dl>
+
+      {(s.disclosures?.length ?? 0) > 0 && (
+        <section aria-label="공시">
+          <h4>공시</h4>
+          <ul>
+            {(s.disclosures ?? []).map((d, i) => (
+              <li key={i}>
+                {d.url ? (
+                  <a href={d.url} target="_blank" rel="noreferrer noopener">
+                    {d.title}
+                  </a>
+                ) : (
+                  d.title
+                )}
+                {d.reported_at ? ` · ${d.reported_at}` : ""}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/trading-decision/src/components/ResearchMarketTab.tsx
+++ b/frontend/trading-decision/src/components/ResearchMarketTab.tsx
@@ -1,0 +1,76 @@
+import { STAGE_VERDICT_LABEL } from "../i18n/ko";
+import type { MarketSignals, StageAnalysis } from "../api/types";
+
+interface Props {
+  stage: StageAnalysis | null;
+}
+
+function fmt(v: unknown): string {
+  if (v === null || v === undefined || v === "") return "—";
+  if (typeof v === "number") return v.toString();
+  return String(v);
+}
+
+export default function ResearchMarketTab({ stage }: Props) {
+  if (!stage) return <p>시장 단계 데이터가 없습니다.</p>;
+  if (stage.verdict === "unavailable")
+    return <p>시장 단계 데이터를 가져올 수 없습니다.</p>;
+  const s = stage.signals as MarketSignals;
+
+  return (
+    <div>
+      <header>
+        <span data-verdict={stage.verdict}>
+          {STAGE_VERDICT_LABEL[stage.verdict]}
+        </span>
+        <progress value={stage.confidence} max={100}>
+          {stage.confidence}%
+        </progress>
+      </header>
+
+      <dl>
+        <dt>종가</dt>
+        <dd>{fmt(s.last_close)}</dd>
+        <dt>변동률</dt>
+        <dd>{s.change_pct != null ? `${s.change_pct}%` : "—"}</dd>
+        <dt>RSI(14)</dt>
+        <dd>{fmt(s.rsi_14)}</dd>
+        <dt>ATR(14)</dt>
+        <dd>{fmt(s.atr_14)}</dd>
+        <dt>거래량 비율(20일)</dt>
+        <dd>{fmt(s.volume_ratio_20d)}</dd>
+        <dt>추세</dt>
+        <dd>{fmt(s.trend ?? s.trend_short)}</dd>
+        {s.macd_signal != null && (
+          <>
+            <dt>MACD</dt>
+            <dd>{s.macd_signal}</dd>
+          </>
+        )}
+        {s.bollinger_position != null && (
+          <>
+            <dt>볼린저 위치</dt>
+            <dd>{s.bollinger_position}</dd>
+          </>
+        )}
+      </dl>
+
+      {(s.supports?.length ?? 0) + (s.resistances?.length ?? 0) > 0 && (
+        <section aria-label="지지/저항">
+          <p>
+            지지: {(s.supports ?? []).join(", ") || "—"} · 저항:{" "}
+            {(s.resistances ?? []).join(", ") || "—"}
+          </p>
+        </section>
+      )}
+
+      {stage.source_freshness && (
+        <p>
+          데이터 신선도: {stage.source_freshness.newest_age_minutes}분 전 ~{" "}
+          {stage.source_freshness.oldest_age_minutes}분 전 (
+          {stage.source_freshness.source_count}개 소스)
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/trading-decision/src/components/ResearchNewsTab.tsx
+++ b/frontend/trading-decision/src/components/ResearchNewsTab.tsx
@@ -1,0 +1,80 @@
+import { STAGE_VERDICT_LABEL } from "../i18n/ko";
+import type { NewsSignals, StageAnalysis } from "../api/types";
+
+interface Props {
+  stage: StageAnalysis | null;
+}
+
+function isStale(publishedAt?: string): boolean {
+  if (!publishedAt) return false;
+  const ageMs = Date.now() - new Date(publishedAt).getTime();
+  return ageMs > 6 * 60 * 60 * 1000;
+}
+
+export default function ResearchNewsTab({ stage }: Props) {
+  if (!stage) return <p>뉴스 단계 데이터가 없습니다.</p>;
+  if (stage.verdict === "unavailable")
+    return <p>뉴스 단계 데이터를 가져올 수 없습니다.</p>;
+  const s = stage.signals as NewsSignals;
+
+  const oldest = s.articles?.reduce<string | undefined>((acc, a) => {
+    if (!a.published_at) return acc;
+    if (!acc) return a.published_at;
+    return new Date(a.published_at) < new Date(acc) ? a.published_at : acc;
+  }, undefined);
+
+  return (
+    <div>
+      <header>
+        <span data-verdict={stage.verdict}>
+          {STAGE_VERDICT_LABEL[stage.verdict]}
+        </span>
+        <progress value={stage.confidence} max={100}>
+          {stage.confidence}%
+        </progress>
+      </header>
+
+      <dl>
+        <dt>헤드라인 수</dt>
+        <dd>{s.headline_count ?? "—"}</dd>
+        <dt>감성 점수</dt>
+        <dd>{s.sentiment_score ?? "—"}</dd>
+      </dl>
+
+      {(s.top_themes?.length ?? 0) > 0 && (
+        <section aria-label="주요 테마">
+          <ul>
+            {(s.top_themes ?? []).map((theme) => (
+              <li key={theme}>{theme}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {isStale(oldest) && (
+        <p role="alert">가장 오래된 기사가 6시간을 초과했습니다.</p>
+      )}
+
+      {(s.articles?.length ?? 0) > 0 && (
+        <section aria-label="기사 목록">
+          <ul>
+            {(s.articles ?? []).map((a, i) => (
+              <li key={`${a.url ?? i}`}>
+                {a.url ? (
+                  <a href={a.url} target="_blank" rel="noreferrer noopener">
+                    {a.title ?? a.url}
+                  </a>
+                ) : (
+                  a.title ?? "—"
+                )}
+                {a.source ? ` · ${a.source}` : ""}
+                {a.published_at ? ` · ${a.published_at}` : ""}
+                {a.sentiment ? ` · ${a.sentiment}` : ""}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/trading-decision/src/components/ResearchRawTab.tsx
+++ b/frontend/trading-decision/src/components/ResearchRawTab.tsx
@@ -1,0 +1,24 @@
+import type { ResearchSessionFullResponse } from "../api/types";
+
+interface Props {
+  data: ResearchSessionFullResponse;
+}
+
+export default function ResearchRawTab({ data }: Props) {
+  return (
+    <div>
+      <section aria-label="세션 원본">
+        <h4>session</h4>
+        <pre>{JSON.stringify(data.session, null, 2)}</pre>
+      </section>
+      <section aria-label="단계 원본">
+        <h4>stages</h4>
+        <pre>{JSON.stringify(data.stages, null, 2)}</pre>
+      </section>
+      <section aria-label="요약 원본">
+        <h4>summary</h4>
+        <pre>{JSON.stringify(data.summary, null, 2)}</pre>
+      </section>
+    </div>
+  );
+}

--- a/frontend/trading-decision/src/components/ResearchSocialTab.tsx
+++ b/frontend/trading-decision/src/components/ResearchSocialTab.tsx
@@ -1,0 +1,24 @@
+import type { SocialSignals, StageAnalysis } from "../api/types";
+
+interface Props {
+  stage: StageAnalysis | null;
+}
+
+export default function ResearchSocialTab({ stage }: Props) {
+  const s = stage?.signals as SocialSignals | undefined;
+  if (!stage || !s || s.available === false) {
+    return (
+      <div role="status" aria-label="소셜 단계 준비 중">
+        <p>
+          🔧 소셜 신호 분석은 준비 중입니다. Reddit · X 데이터 수집 인프라 구축
+          후 활성화됩니다.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div>
+      <p>소셜 단계 결과: {stage.verdict}</p>
+    </div>
+  );
+}

--- a/frontend/trading-decision/src/components/ResearchSummaryTab.tsx
+++ b/frontend/trading-decision/src/components/ResearchSummaryTab.tsx
@@ -1,0 +1,114 @@
+import { SUMMARY_DECISION_LABEL } from "../i18n/ko";
+import type { ResearchSessionFullResponse } from "../api/types";
+import CitedStageSidebar from "./CitedStageSidebar";
+
+interface Props {
+  data: ResearchSessionFullResponse;
+  onJumpToStage: (stageType: string) => void;
+}
+
+export default function ResearchSummaryTab({ data, onJumpToStage }: Props) {
+  const summary = data.summary;
+  if (!summary) {
+    return <p>요약이 아직 준비되지 않았습니다.</p>;
+  }
+
+  const price = summary.price_analysis;
+
+  return (
+    <div>
+      <header>
+        <span data-decision={summary.decision}>
+          {SUMMARY_DECISION_LABEL[summary.decision]}
+        </span>
+        <progress
+          value={summary.confidence}
+          max={100}
+          aria-label="신뢰도"
+        >
+          {summary.confidence}%
+        </progress>
+      </header>
+
+      {price ? (
+        <section aria-label="가격 분석">
+          <h3>가격 분석</h3>
+          <dl>
+            {price.appropriate_buy_min != null && (
+              <>
+                <dt>적정 매수 범위</dt>
+                <dd>
+                  {price.appropriate_buy_min} ~ {price.appropriate_buy_max}
+                </dd>
+              </>
+            )}
+            {price.appropriate_sell_min != null && (
+              <>
+                <dt>적정 매도 범위</dt>
+                <dd>
+                  {price.appropriate_sell_min} ~ {price.appropriate_sell_max}
+                </dd>
+              </>
+            )}
+            {price.buy_hope_min != null && (
+              <>
+                <dt>희망 매수 범위</dt>
+                <dd>
+                  {price.buy_hope_min} ~ {price.buy_hope_max}
+                </dd>
+              </>
+            )}
+            {price.sell_target_min != null && (
+              <>
+                <dt>매도 목표 범위</dt>
+                <dd>
+                  {price.sell_target_min} ~ {price.sell_target_max}
+                </dd>
+              </>
+            )}
+          </dl>
+        </section>
+      ) : null}
+
+      <section aria-label="강세/약세 근거">
+        <div>
+          <h3>강세 근거</h3>
+          <ul>
+            {summary.bull_arguments.map((arg, i) => (
+              <li key={`bull-${i}`}>{arg.text}</li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3>약세 근거</h3>
+          <ul>
+            {summary.bear_arguments.map((arg, i) => (
+              <li key={`bear-${i}`}>{arg.text}</li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      {summary.warnings && summary.warnings.length > 0 ? (
+        <section aria-label="경고" role="alert">
+          <h3>경고</h3>
+          <ul>
+            {summary.warnings.map((w, i) => (
+              <li key={i}>{w}</li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <CitedStageSidebar
+        links={summary.summary_stage_links}
+        stages={data.stages}
+        onJumpToStage={onJumpToStage}
+      />
+
+      <button type="button" disabled aria-disabled="true">
+        실행 의사결정 세션으로 승격 (Phase 4 준비 중)
+      </button>
+    </div>
+  );
+}

--- a/frontend/trading-decision/src/components/ResearchTabs.tsx
+++ b/frontend/trading-decision/src/components/ResearchTabs.tsx
@@ -1,0 +1,81 @@
+import { useRef, type KeyboardEvent, type ReactNode } from "react";
+
+export interface TabSpec {
+  id: string;
+  label: string;
+}
+
+interface Props {
+  tabs: TabSpec[];
+  activeId: string;
+  onChange: (id: string) => void;
+  renderPanel: (id: string) => ReactNode;
+  ariaLabel?: string;
+}
+
+export default function ResearchTabs({
+  tabs,
+  activeId,
+  onChange,
+  renderPanel,
+  ariaLabel = "Research detail tabs",
+}: Props) {
+  const tablistRef = useRef<HTMLDivElement>(null);
+
+  function onKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    const idx = tabs.findIndex((t) => t.id === activeId);
+    if (idx < 0) return;
+    let nextIdx: number | null = null;
+    if (event.key === "ArrowRight") nextIdx = (idx + 1) % tabs.length;
+    if (event.key === "ArrowLeft")
+      nextIdx = (idx - 1 + tabs.length) % tabs.length;
+    if (event.key === "Home") nextIdx = 0;
+    if (event.key === "End") nextIdx = tabs.length - 1;
+    if (nextIdx === null) return;
+    event.preventDefault();
+    const next = tabs[nextIdx];
+    if (!next) return;
+    onChange(next.id);
+    const button = tablistRef.current?.querySelector<HTMLButtonElement>(
+      `[data-tab-id="${next.id}"]`,
+    );
+    button?.focus();
+  }
+
+  return (
+    <div>
+      <div role="tablist" aria-label={ariaLabel} ref={tablistRef}>
+        {tabs.map((tab) => {
+          const selected = tab.id === activeId;
+          return (
+            <button
+              key={tab.id}
+              role="tab"
+              type="button"
+              data-tab-id={tab.id}
+              aria-selected={selected}
+              aria-controls={`tabpanel-${tab.id}`}
+              id={`tab-${tab.id}`}
+              tabIndex={selected ? 0 : -1}
+              onClick={() => onChange(tab.id)}
+              onKeyDown={onKeyDown}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+      {tabs.map((tab) => (
+        <div
+          key={tab.id}
+          role="tabpanel"
+          id={`tabpanel-${tab.id}`}
+          aria-labelledby={`tab-${tab.id}`}
+          hidden={tab.id !== activeId}
+        >
+          {tab.id === activeId ? renderPanel(tab.id) : null}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/trading-decision/src/components/VerdictMiniChart.tsx
+++ b/frontend/trading-decision/src/components/VerdictMiniChart.tsx
@@ -1,0 +1,89 @@
+import type { SymbolTimelineEntry } from "../api/types";
+
+interface Props {
+  entries: SymbolTimelineEntry[];
+  width?: number;
+  height?: number;
+}
+
+function decisionScore(decision: SymbolTimelineEntry["decision"]): number {
+  if (decision === "buy") return 1;
+  if (decision === "sell") return -1;
+  return 0;
+}
+
+export default function VerdictMiniChart({
+  entries,
+  width = 480,
+  height = 120,
+}: Props) {
+  const usable = entries
+    .map((e) => ({
+      ...e,
+      ts: e.finalized_at ?? e.started_at,
+    }))
+    .filter((e): e is SymbolTimelineEntry & { ts: string } => Boolean(e.ts))
+    .map((e) => ({
+      ...e,
+      tsMs: new Date(e.ts).getTime(),
+    }))
+    .sort((a, b) => a.tsMs - b.tsMs);
+
+  if (usable.length === 0) {
+    return <p>차트로 표시할 데이터가 없습니다.</p>;
+  }
+
+  const minT = usable[0]!.tsMs;
+  const maxT = usable[usable.length - 1]!.tsMs;
+  const span = maxT - minT || 1;
+
+  const padX = 16;
+  const padY = 16;
+  const innerW = width - padX * 2;
+  const innerH = height - padY * 2;
+
+  function xFor(tsMs: number): number {
+    return padX + (innerW * (tsMs - minT)) / span;
+  }
+  function yFor(score: number): number {
+    return padY + (innerH * (1 - score)) / 2;
+  }
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      role="img"
+      aria-label="평결 변화 미니 차트"
+    >
+      <line
+        x1={padX}
+        x2={width - padX}
+        y1={yFor(0)}
+        y2={yFor(0)}
+        stroke="#9ca3af"
+        strokeDasharray="2 2"
+      />
+      {usable.map((e, i) => {
+        const score = decisionScore(e.decision);
+        const cx = xFor(e.tsMs);
+        const cy = yFor(score);
+        const r = 3 + ((e.confidence ?? 0) / 100) * 5;
+        return (
+          <circle
+            key={e.session_id}
+            cx={cx}
+            cy={cy}
+            r={r}
+            fill={
+              score > 0 ? "#10b981" : score < 0 ? "#ef4444" : "#9ca3af"
+            }
+            opacity={0.4 + ((e.confidence ?? 0) / 100) * 0.6}
+            data-index={i}
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/frontend/trading-decision/src/hooks/useResearchSession.ts
+++ b/frontend/trading-decision/src/hooks/useResearchSession.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ApiError } from "../api/client";
+import { getSessionFull } from "../api/researchPipeline";
+import type { ResearchSessionFullResponse } from "../api/types";
+
+const POLL_INTERVAL_MS = 5000;
+const TERMINAL_STATUSES = new Set(["finalized", "failed", "cancelled"]);
+
+interface State {
+  status: "idle" | "loading" | "success" | "error" | "not_found";
+  data: ResearchSessionFullResponse | null;
+  error: string | null;
+}
+
+export function useResearchSession(sessionId: number): State & {
+  refetch: () => void;
+} {
+  const [state, setState] = useState<State>({
+    status: "idle",
+    data: null,
+    error: null,
+  });
+  const [version, setVersion] = useState(0);
+  const refetch = useCallback(() => setVersion((v) => v + 1), []);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setState((current) => ({ ...current, status: "loading", error: null }));
+
+    async function fetchOnce() {
+      try {
+        const data = await getSessionFull(sessionId);
+        if (cancelled) return;
+        setState({ status: "success", data, error: null });
+
+        if (!TERMINAL_STATUSES.has(data.session.status)) {
+          timerRef.current = setTimeout(fetchOnce, POLL_INTERVAL_MS);
+        }
+      } catch (error: unknown) {
+        if (cancelled) return;
+        if (error instanceof ApiError && error.status === 404) {
+          setState({ status: "not_found", data: null, error: error.detail });
+          return;
+        }
+        setState({
+          status: "error",
+          data: null,
+          error:
+            error instanceof ApiError
+              ? error.detail
+              : "Something went wrong. Try again.",
+        });
+      }
+    }
+
+    fetchOnce();
+
+    return () => {
+      cancelled = true;
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [sessionId, version]);
+
+  return { ...state, refetch };
+}

--- a/frontend/trading-decision/src/hooks/useSymbolTimeline.ts
+++ b/frontend/trading-decision/src/hooks/useSymbolTimeline.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { ApiError } from "../api/client";
+import { getSymbolTimeline } from "../api/researchPipeline";
+import type { SymbolTimelineResponse } from "../api/types";
+
+interface State {
+  status: "idle" | "loading" | "success" | "error" | "not_found";
+  data: SymbolTimelineResponse | null;
+  error: string | null;
+}
+
+export function useSymbolTimeline(symbol: string, days = 30): State {
+  const [state, setState] = useState<State>({
+    status: "idle",
+    data: null,
+    error: null,
+  });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState((c) => ({ ...c, status: "loading", error: null }));
+
+    getSymbolTimeline(symbol, days)
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        setState({ status: "success", data, error: null });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        if (error instanceof ApiError && error.status === 404) {
+          setState({ status: "not_found", data: null, error: error.detail });
+          return;
+        }
+        setState({
+          status: "error",
+          data: null,
+          error:
+            error instanceof ApiError
+              ? error.detail
+              : "Something went wrong. Try again.",
+        });
+      });
+
+    return () => controller.abort();
+  }, [symbol, days]);
+
+  return state;
+}

--- a/frontend/trading-decision/src/i18n/ko.ts
+++ b/frontend/trading-decision/src/i18n/ko.ts
@@ -5,6 +5,7 @@ import type {
   ExecutionReviewStageStatus,
   ExecutionSource,
   InstrumentType,
+  LinkDirection,
   OutcomeHorizon,
   PreopenArtifactReadinessStatus,
   PreopenArtifactStatus,
@@ -17,9 +18,13 @@ import type {
   PreopenQaEvaluatorStatus,
   PreopenQaGrade,
   ProposalKind,
+  ResearchSessionStatus,
   SessionStatus,
   Side,
+  StageType,
+  StageVerdict,
   StrategyEventType,
+  SummaryDecision,
   TrackKind,
   UserResponseValue,
   WorkflowStatus,
@@ -324,4 +329,56 @@ export const COMMON = {
   unknown: "알 수 없음",
   rawData: "원본 데이터 보기",
   somethingWentWrong: "오류가 발생했습니다. 다시 시도해 주세요.",
+} as const;
+
+export const STAGE_TYPE_LABEL: Record<StageType, string> = {
+  market: "시장",
+  news: "뉴스",
+  fundamentals: "펀더멘털",
+  social: "소셜",
+};
+
+export const STAGE_VERDICT_LABEL: Record<StageVerdict, string> = {
+  bull: "강세",
+  bear: "약세",
+  neutral: "중립",
+  unavailable: "준비 중",
+};
+
+export const SUMMARY_DECISION_LABEL: Record<SummaryDecision, string> = {
+  buy: "매수",
+  hold: "보유",
+  sell: "매도",
+};
+
+export const LINK_DIRECTION_LABEL: Record<LinkDirection, string> = {
+  support: "지지",
+  contradict: "반대",
+  context: "맥락",
+};
+
+export const RESEARCH_SESSION_STATUS_LABEL: Record<
+  ResearchSessionStatus,
+  string
+> = {
+  open: "열림",
+  running: "분석 중",
+  finalized: "완료",
+  failed: "실패",
+  cancelled: "취소됨",
+};
+
+export const RESEARCH_TAB_LABEL = {
+  summary: "종합",
+  market: "시장",
+  news: "뉴스",
+  fundamentals: "펀더멘털",
+  social: "소셜",
+  raw: "원본",
+} as const;
+
+export const RESEARCH_INSTRUMENT_TYPE_LABEL = {
+  equity_kr: "국내주식",
+  equity_us: "해외주식",
+  crypto: "암호화폐",
 } as const;

--- a/frontend/trading-decision/src/pages/ResearchHomePage.module.css
+++ b/frontend/trading-decision/src/pages/ResearchHomePage.module.css
@@ -1,0 +1,16 @@
+.page {
+  padding: 16px;
+}
+
+.startCard {
+  border: 1px solid #e5e7eb;
+  padding: 12px;
+  border-radius: 6px;
+  margin-bottom: 16px;
+}
+
+.refreshRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/frontend/trading-decision/src/pages/ResearchHomePage.tsx
+++ b/frontend/trading-decision/src/pages/ResearchHomePage.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { ApiError } from "../api/client";
+import { createSession, listSessions } from "../api/researchPipeline";
+import type {
+  ResearchInstrumentType,
+  ResearchSessionListItem,
+} from "../api/types";
+import {
+  RESEARCH_INSTRUMENT_TYPE_LABEL,
+  RESEARCH_SESSION_STATUS_LABEL,
+  SUMMARY_DECISION_LABEL,
+} from "../i18n/ko";
+import ErrorView from "../components/ErrorView";
+import LoadingView from "../components/LoadingView";
+import styles from "./ResearchHomePage.module.css";
+
+const INSTRUMENT_OPTIONS: ResearchInstrumentType[] = [
+  "equity_kr",
+  "equity_us",
+  "crypto",
+];
+
+interface ListState {
+  status: "idle" | "loading" | "success" | "error";
+  data: ResearchSessionListItem[];
+  error: string | null;
+}
+
+export default function ResearchHomePage() {
+  const navigate = useNavigate();
+  const [list, setList] = useState<ListState>({
+    status: "loading",
+    data: [],
+    error: null,
+  });
+  const [version, setVersion] = useState(0);
+
+  const [symbol, setSymbol] = useState("");
+  const [instrumentType, setInstrumentType] =
+    useState<ResearchInstrumentType>("equity_kr");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setList((c) => ({ ...c, status: "loading", error: null }));
+    listSessions({ limit: 20 })
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        setList({ status: "success", data, error: null });
+      })
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setList({
+          status: "error",
+          data: [],
+          error:
+            error instanceof ApiError
+              ? error.detail
+              : "Something went wrong. Try again.",
+        });
+      });
+    return () => controller.abort();
+  }, [version]);
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!symbol.trim()) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const result = await createSession({
+        symbol: symbol.trim(),
+        instrument_type: instrumentType,
+        triggered_by: "user",
+      });
+      void navigate(`/research/sessions/${result.session_id}`);
+    } catch (error) {
+      setSubmitError(
+        error instanceof ApiError
+          ? error.detail
+          : "Something went wrong. Try again.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className={styles.page}>
+      <h1>리서치 세션</h1>
+
+      <section aria-label="새 세션 시작" className={styles.startCard}>
+        <h2>새 분석 시작</h2>
+        <form onSubmit={onSubmit}>
+          <label>
+            심볼{" "}
+            <input
+              value={symbol}
+              onChange={(e) => setSymbol(e.target.value)}
+              required
+              autoComplete="off"
+            />
+          </label>
+          <label>
+            종목 유형{" "}
+            <select
+              value={instrumentType}
+              onChange={(e) =>
+                setInstrumentType(e.target.value as ResearchInstrumentType)
+              }
+            >
+              {INSTRUMENT_OPTIONS.map((opt) => (
+                <option key={opt} value={opt}>
+                  {RESEARCH_INSTRUMENT_TYPE_LABEL[opt]}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="submit" disabled={submitting}>
+            {submitting ? "시작 중…" : "세션 시작"}
+          </button>
+          {submitError && <p role="alert">{submitError}</p>}
+        </form>
+      </section>
+
+      <section aria-label="최근 세션">
+        <div className={styles.refreshRow}>
+          <h2>최근 세션</h2>
+          <button type="button" onClick={() => setVersion((v) => v + 1)}>
+            새로고침
+          </button>
+        </div>
+        {list.status === "loading" && <LoadingView />}
+        {list.status === "error" && (
+          <ErrorView message={list.error ?? "오류가 발생했습니다."} />
+        )}
+        {list.status === "success" && (
+          <table>
+            <thead>
+              <tr>
+                <th>세션 ID</th>
+                <th>상태</th>
+                <th>생성</th>
+                <th>결정</th>
+                <th>신뢰도</th>
+              </tr>
+            </thead>
+            <tbody>
+              {list.data.map((row) => {
+                const statusLabel =
+                  RESEARCH_SESSION_STATUS_LABEL[
+                    row.status as keyof typeof RESEARCH_SESSION_STATUS_LABEL
+                  ] ?? row.status;
+                return (
+                  <tr key={row.id} aria-label={String(row.id)}>
+                    <td>
+                      <Link to={`/research/sessions/${row.id}`}>{row.id}</Link>
+                    </td>
+                    <td>{statusLabel}</td>
+                    <td>{row.created_at}</td>
+                    <td>
+                      {row.decision
+                        ? SUMMARY_DECISION_LABEL[row.decision]
+                        : "—"}
+                    </td>
+                    <td>{row.confidence != null ? `${row.confidence}%` : "—"}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/frontend/trading-decision/src/pages/ResearchSessionDetailPage.module.css
+++ b/frontend/trading-decision/src/pages/ResearchSessionDetailPage.module.css
@@ -1,0 +1,15 @@
+.page {
+  padding: 16px;
+}
+
+.header {
+  margin-bottom: 16px;
+}
+
+.banner {
+  background: #fef3c7;
+  border: 1px solid #f59e0b;
+  padding: 8px 12px;
+  border-radius: 4px;
+  margin-top: 8px;
+}

--- a/frontend/trading-decision/src/pages/ResearchSessionDetailPage.tsx
+++ b/frontend/trading-decision/src/pages/ResearchSessionDetailPage.tsx
@@ -1,0 +1,103 @@
+import { useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
+import ErrorView from "../components/ErrorView";
+import LoadingView from "../components/LoadingView";
+import ResearchFundamentalsTab from "../components/ResearchFundamentalsTab";
+import ResearchMarketTab from "../components/ResearchMarketTab";
+import ResearchNewsTab from "../components/ResearchNewsTab";
+import ResearchRawTab from "../components/ResearchRawTab";
+import ResearchSocialTab from "../components/ResearchSocialTab";
+import ResearchSummaryTab from "../components/ResearchSummaryTab";
+import ResearchTabs from "../components/ResearchTabs";
+import { useResearchSession } from "../hooks/useResearchSession";
+import {
+  RESEARCH_SESSION_STATUS_LABEL,
+  RESEARCH_TAB_LABEL,
+} from "../i18n/ko";
+import type { StageType } from "../api/types";
+import styles from "./ResearchSessionDetailPage.module.css";
+
+const TABS = [
+  { id: "summary", label: RESEARCH_TAB_LABEL.summary },
+  { id: "market", label: RESEARCH_TAB_LABEL.market },
+  { id: "news", label: RESEARCH_TAB_LABEL.news },
+  { id: "fundamentals", label: RESEARCH_TAB_LABEL.fundamentals },
+  { id: "social", label: RESEARCH_TAB_LABEL.social },
+  { id: "raw", label: RESEARCH_TAB_LABEL.raw },
+] as const;
+
+export default function ResearchSessionDetailPage() {
+  const params = useParams<{ sessionId: string }>();
+  const sessionId = Number(params.sessionId);
+  const validId = Number.isFinite(sessionId) && sessionId > 0;
+  const state = useResearchSession(validId ? sessionId : 0);
+  const [active, setActive] = useState<string>("summary");
+
+  const stagesByType = useMemo(() => {
+    const map: Partial<Record<StageType, NonNullable<typeof state.data>["stages"][number]>> = {};
+    for (const stage of state.data?.stages ?? []) {
+      map[stage.stage_type] = stage;
+    }
+    return map;
+  }, [state.data]);
+
+  if (!validId) return <ErrorView message="잘못된 세션 ID 입니다." />;
+  if (state.status === "loading" || state.status === "idle")
+    return <LoadingView />;
+  if (state.status === "not_found")
+    return <ErrorView message="세션을 찾을 수 없습니다." />;
+  if (state.status === "error" || !state.data)
+    return <ErrorView message={state.error ?? "오류가 발생했습니다."} />;
+
+  const session = state.data.session;
+  const sessionStatusKey = session.status as keyof typeof RESEARCH_SESSION_STATUS_LABEL;
+  const statusLabel =
+    RESEARCH_SESSION_STATUS_LABEL[sessionStatusKey] ?? session.status;
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <h1>
+          {session.symbol ?? `세션 #${session.id}`}{" "}
+          <small>{session.instrument_type ?? ""}</small>
+        </h1>
+        <p>
+          상태: <span data-status={session.status}>{statusLabel}</span>
+          {session.started_at ? ` · 시작 ${session.started_at}` : ""}
+          {session.finalized_at ? ` · 완료 ${session.finalized_at}` : ""}
+        </p>
+        {state.data.summary?.warnings?.length ? (
+          <div role="alert" className={styles.banner}>
+            경고: {state.data.summary.warnings.join(", ")}
+          </div>
+        ) : null}
+      </header>
+
+      <ResearchTabs
+        tabs={[...TABS]}
+        activeId={active}
+        onChange={setActive}
+        renderPanel={(id) => {
+          if (id === "summary")
+            return (
+              <ResearchSummaryTab data={state.data!} onJumpToStage={setActive} />
+            );
+          if (id === "market")
+            return <ResearchMarketTab stage={stagesByType.market ?? null} />;
+          if (id === "news")
+            return <ResearchNewsTab stage={stagesByType.news ?? null} />;
+          if (id === "fundamentals")
+            return (
+              <ResearchFundamentalsTab
+                stage={stagesByType.fundamentals ?? null}
+              />
+            );
+          if (id === "social")
+            return <ResearchSocialTab stage={stagesByType.social ?? null} />;
+          if (id === "raw") return <ResearchRawTab data={state.data!} />;
+          return null;
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/trading-decision/src/pages/SymbolTimelinePage.module.css
+++ b/frontend/trading-decision/src/pages/SymbolTimelinePage.module.css
@@ -1,0 +1,3 @@
+.page {
+  padding: 16px;
+}

--- a/frontend/trading-decision/src/pages/SymbolTimelinePage.tsx
+++ b/frontend/trading-decision/src/pages/SymbolTimelinePage.tsx
@@ -1,0 +1,68 @@
+import { Link, useParams } from "react-router-dom";
+import ErrorView from "../components/ErrorView";
+import LoadingView from "../components/LoadingView";
+import VerdictMiniChart from "../components/VerdictMiniChart";
+import { useSymbolTimeline } from "../hooks/useSymbolTimeline";
+import {
+  RESEARCH_SESSION_STATUS_LABEL,
+  STAGE_TYPE_LABEL,
+  STAGE_VERDICT_LABEL,
+  SUMMARY_DECISION_LABEL,
+} from "../i18n/ko";
+import styles from "./SymbolTimelinePage.module.css";
+
+export default function SymbolTimelinePage() {
+  const params = useParams<{ symbol: string }>();
+  const symbol = params.symbol ?? "";
+  const state = useSymbolTimeline(symbol, 30);
+
+  if (state.status === "loading" || state.status === "idle")
+    return <LoadingView />;
+  if (state.status === "not_found")
+    return <ErrorView message="해당 종목 데이터가 없습니다." />;
+  if (state.status === "error" || !state.data)
+    return <ErrorView message={state.error ?? "오류가 발생했습니다."} />;
+
+  return (
+    <div className={styles.page}>
+      <h1>
+        {state.data.symbol} <small>지난 {state.data.days}일</small>
+      </h1>
+
+      <section aria-label="평결 차트">
+        <VerdictMiniChart entries={state.data.entries} />
+      </section>
+
+      <section aria-label="세션 목록">
+        <ul>
+          {state.data.entries.map((e) => {
+            const statusLabel =
+              RESEARCH_SESSION_STATUS_LABEL[
+                e.status as keyof typeof RESEARCH_SESSION_STATUS_LABEL
+              ] ?? e.status;
+            return (
+              <li key={e.session_id}>
+                <Link to={`/research/sessions/${e.session_id}`}>
+                  세션 #{e.session_id}
+                </Link>{" "}
+                · {statusLabel}
+                {e.decision ? ` · ${SUMMARY_DECISION_LABEL[e.decision]}` : ""}
+                {e.confidence != null ? ` · ${e.confidence}%` : ""}
+                <ul>
+                  {Object.entries(e.stage_verdicts).map(([stype, verdict]) => (
+                    <li key={stype}>
+                      {STAGE_TYPE_LABEL[stype as keyof typeof STAGE_TYPE_LABEL]}:{" "}
+                      {STAGE_VERDICT_LABEL[
+                        verdict as keyof typeof STAGE_VERDICT_LABEL
+                      ] ?? verdict}
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/frontend/trading-decision/src/routes.tsx
+++ b/frontend/trading-decision/src/routes.tsx
@@ -3,6 +3,9 @@ import PreopenPage from "./pages/PreopenPage";
 import NewsRadarPage from "./pages/NewsRadarPage";
 import SessionDetailPage from "./pages/SessionDetailPage";
 import SessionListPage from "./pages/SessionListPage";
+import ResearchHomePage from "./pages/ResearchHomePage";
+import ResearchSessionDetailPage from "./pages/ResearchSessionDetailPage";
+import SymbolTimelinePage from "./pages/SymbolTimelinePage";
 
 const SESSION_UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -26,6 +29,9 @@ export const tradingDecisionRoutes: RouteObject[] = [
   { path: "/preopen", element: <PreopenPage /> },
   { path: "/news-radar", element: <NewsRadarPage /> },
   { path: "/sessions/:sessionUuid", element: <SessionDetailPage /> },
+  { path: "/research", element: <ResearchHomePage /> },
+  { path: "/research/sessions/:sessionId", element: <ResearchSessionDetailPage /> },
+  { path: "/research/symbols/:symbol/timeline", element: <SymbolTimelinePage /> },
   // Backward-compatible alias for UUID session URLs generated before the
   // canonical /sessions/:sessionUuid route was adopted. Keep arbitrary
   // single-segment paths on the list page instead of treating them as sessions.

--- a/frontend/trading-decision/src/test/fixtures/research.ts
+++ b/frontend/trading-decision/src/test/fixtures/research.ts
@@ -1,0 +1,161 @@
+import type {
+  ResearchSessionCreateResponse,
+  ResearchSessionFullResponse,
+  ResearchSessionListItem,
+  ResearchSummary,
+  StageAnalysis,
+  SymbolTimelineResponse,
+} from "../../api/types";
+
+export function makeSessionListItem(
+  overrides: Partial<ResearchSessionListItem> = {},
+): ResearchSessionListItem {
+  return {
+    id: 1,
+    stock_info_id: 99,
+    status: "finalized",
+    created_at: "2026-05-05T00:00:00Z",
+    decision: "buy",
+    confidence: 75,
+    ...overrides,
+  };
+}
+
+export function makeStageAnalysis(
+  overrides: Partial<StageAnalysis> = {},
+): StageAnalysis {
+  return {
+    id: 10,
+    stage_type: "market",
+    verdict: "bull",
+    confidence: 70,
+    signals: { last_close: 100, change_pct: 1.5, trend: "uptrend" },
+    raw_payload: null,
+    source_freshness: null,
+    executed_at: "2026-05-05T00:00:01Z",
+    snapshot_at: null,
+    ...overrides,
+  };
+}
+
+export function makeResearchSummary(
+  overrides: Partial<ResearchSummary> = {},
+): ResearchSummary {
+  return {
+    id: 100,
+    session_id: 1,
+    decision: "buy",
+    confidence: 80,
+    bull_arguments: [
+      {
+        text: "RSI oversold",
+        cited_stage_ids: [10],
+        direction: "support",
+        weight: 0.8,
+      },
+    ],
+    bear_arguments: [],
+    price_analysis: {
+      appropriate_buy_min: 95,
+      appropriate_buy_max: 100,
+      appropriate_sell_min: null,
+      appropriate_sell_max: null,
+      buy_hope_min: null,
+      buy_hope_max: null,
+      sell_target_min: 110,
+      sell_target_max: 120,
+    },
+    reasons: ["short-term momentum"],
+    detailed_text: "buy signal confirmed",
+    warnings: [],
+    executed_at: "2026-05-05T00:00:02Z",
+    summary_stage_links: [
+      {
+        stage_analysis_id: 10,
+        stage_type: "market",
+        direction: "support",
+        weight: 0.8,
+        rationale: "rsi 14 below 30",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+export function makeSessionFull(
+  overrides: Partial<ResearchSessionFullResponse> = {},
+): ResearchSessionFullResponse {
+  return {
+    session: {
+      id: 1,
+      stock_info_id: 99,
+      research_run_id: null,
+      status: "finalized",
+      started_at: "2026-05-05T00:00:00Z",
+      finalized_at: "2026-05-05T00:00:03Z",
+      created_at: "2026-05-05T00:00:00Z",
+      updated_at: null,
+      symbol: "KRW-BTC",
+      instrument_type: "crypto",
+    },
+    stages: [
+      makeStageAnalysis(),
+      makeStageAnalysis({
+        id: 11,
+        stage_type: "news",
+        signals: { headline_count: 5, sentiment_score: 0.4, top_themes: ["earnings"] },
+      }),
+      makeStageAnalysis({
+        id: 12,
+        stage_type: "fundamentals",
+        signals: { per: 12, pbr: 1.5, market_cap: 1_000_000_000 },
+      }),
+      makeStageAnalysis({
+        id: 13,
+        stage_type: "social",
+        verdict: "unavailable",
+        confidence: 0,
+        signals: { available: false, reason: "not_implemented", phase: "placeholder" },
+      }),
+    ],
+    summary: makeResearchSummary(),
+    ...overrides,
+  };
+}
+
+export function makeCreateResponse(
+  overrides: Partial<ResearchSessionCreateResponse> = {},
+): ResearchSessionCreateResponse {
+  return {
+    session_id: 1,
+    status: "running",
+    started_at: "2026-05-05T00:00:00Z",
+    ...overrides,
+  };
+}
+
+export function makeSymbolTimeline(
+  overrides: Partial<SymbolTimelineResponse> = {},
+): SymbolTimelineResponse {
+  return {
+    symbol: "AAPL",
+    days: 30,
+    entries: [
+      {
+        session_id: 11,
+        status: "finalized",
+        started_at: "2026-05-05T00:00:00Z",
+        finalized_at: "2026-05-05T00:00:03Z",
+        decision: "buy",
+        confidence: 70,
+        stage_verdicts: {
+          market: "bull",
+          news: "neutral",
+          fundamentals: "bull",
+          social: "unavailable",
+        },
+      },
+    ],
+    ...overrides,
+  };
+}

--- a/tests/routers/test_research_pipeline_router.py
+++ b/tests/routers/test_research_pipeline_router.py
@@ -200,7 +200,9 @@ async def test_get_session_full_returns_session_stages_summary(override_deps):
             async with AsyncClient(
                 transport=ASGITransport(app=app), base_url="http://test"
             ) as ac:
-                response = await ac.get("/api/research-pipeline/sessions/1?include=full")
+                response = await ac.get(
+                    "/api/research-pipeline/sessions/1?include=full"
+                )
                 assert response.status_code == status.HTTP_200_OK
                 body = response.json()
                 assert body["session"]["id"] == 1

--- a/tests/routers/test_research_pipeline_router.py
+++ b/tests/routers/test_research_pipeline_router.py
@@ -156,3 +156,54 @@ async def test_create_session_403_when_disabled(override_deps):
                 json={"symbol": "KRW-BTC", "instrument_type": "crypto"},
             )
             assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.asyncio
+async def test_get_session_full_returns_session_stages_summary(override_deps):
+    from datetime import UTC, datetime
+
+    full = {
+        "session": {
+            "id": 1,
+            "stock_info_id": 99,
+            "research_run_id": None,
+            "status": "finalized",
+            "started_at": datetime.now(UTC).isoformat(),
+            "finalized_at": datetime.now(UTC).isoformat(),
+            "created_at": datetime.now(UTC).isoformat(),
+            "updated_at": None,
+            "symbol": "KRW-BTC",
+            "instrument_type": "crypto",
+        },
+        "stages": [
+            {
+                "id": 10,
+                "stage_type": "market",
+                "verdict": "bull",
+                "confidence": 70,
+                "signals": {},
+                "raw_payload": None,
+                "source_freshness": None,
+                "executed_at": datetime.now(UTC).isoformat(),
+                "snapshot_at": None,
+            }
+        ],
+        "summary": None,
+    }
+
+    with patch.object(settings, "RESEARCH_PIPELINE_ENABLED", True):
+        with patch(
+            "app.routers.research_pipeline.ResearchPipelineService.get_session_full",
+            new_callable=AsyncMock,
+        ) as mock_service:
+            mock_service.return_value = full
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as ac:
+                response = await ac.get("/api/research-pipeline/sessions/1?include=full")
+                assert response.status_code == status.HTTP_200_OK
+                body = response.json()
+                assert body["session"]["id"] == 1
+                assert len(body["stages"]) == 1
+                assert body["summary"] is None
+                assert mock_service.call_count == 1

--- a/tests/routers/test_research_pipeline_router.py
+++ b/tests/routers/test_research_pipeline_router.py
@@ -109,3 +109,50 @@ async def test_get_session_summary(override_deps):
                 response = await ac.get("/api/research-pipeline/sessions/1/summary")
                 assert response.status_code == status.HTTP_200_OK
                 assert response.json()["decision"] == "buy"
+
+
+@pytest.mark.asyncio
+async def test_create_session_returns_session_id_without_blocking(override_deps):
+    from datetime import UTC, datetime
+
+    from app.schemas.research_pipeline import ResearchSessionCreateResponse
+
+    with patch.object(settings, "RESEARCH_PIPELINE_ENABLED", True):
+        with patch(
+            "app.routers.research_pipeline.ResearchPipelineService.create_session_and_dispatch",
+            new_callable=AsyncMock,
+        ) as mock_service:
+            mock_service.return_value = ResearchSessionCreateResponse(
+                session_id=42,
+                status="running",
+                started_at=datetime.now(UTC),
+            )
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as ac:
+                response = await ac.post(
+                    "/api/research-pipeline/sessions",
+                    json={
+                        "symbol": "KRW-BTC",
+                        "instrument_type": "crypto",
+                        "triggered_by": "user",
+                    },
+                )
+                assert response.status_code == status.HTTP_201_CREATED
+                body = response.json()
+                assert body["session_id"] == 42
+                assert body["status"] == "running"
+                assert mock_service.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_create_session_403_when_disabled(override_deps):
+    with patch.object(settings, "RESEARCH_PIPELINE_ENABLED", False):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as ac:
+            response = await ac.post(
+                "/api/research-pipeline/sessions",
+                json={"symbol": "KRW-BTC", "instrument_type": "crypto"},
+            )
+            assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/tests/routers/test_research_pipeline_router.py
+++ b/tests/routers/test_research_pipeline_router.py
@@ -207,3 +207,46 @@ async def test_get_session_full_returns_session_stages_summary(override_deps):
                 assert len(body["stages"]) == 1
                 assert body["summary"] is None
                 assert mock_service.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_symbol_timeline_returns_recent_sessions(override_deps):
+    from datetime import UTC, datetime
+
+    payload = {
+        "symbol": "AAPL",
+        "days": 30,
+        "entries": [
+            {
+                "session_id": 11,
+                "status": "finalized",
+                "started_at": datetime.now(UTC).isoformat(),
+                "finalized_at": datetime.now(UTC).isoformat(),
+                "decision": "buy",
+                "confidence": 75,
+                "stage_verdicts": {
+                    "market": "bull",
+                    "news": "neutral",
+                    "fundamentals": "bull",
+                    "social": "unavailable",
+                },
+            }
+        ],
+    }
+    with patch.object(settings, "RESEARCH_PIPELINE_ENABLED", True):
+        with patch(
+            "app.routers.research_pipeline.ResearchPipelineService.get_symbol_timeline",
+            new_callable=AsyncMock,
+        ) as mock_service:
+            mock_service.return_value = payload
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as ac:
+                response = await ac.get(
+                    "/api/research-pipeline/symbols/AAPL/timeline?days=30"
+                )
+                assert response.status_code == status.HTTP_200_OK
+                body = response.json()
+                assert body["symbol"] == "AAPL"
+                assert body["entries"][0]["session_id"] == 11
+                assert body["entries"][0]["stage_verdicts"]["market"] == "bull"

--- a/tests/routers/test_research_pipeline_router.py
+++ b/tests/routers/test_research_pipeline_router.py
@@ -61,6 +61,22 @@ async def test_get_sessions_list(override_deps):
 
 
 @pytest.mark.asyncio
+async def test_trading_workspace_alias_get_sessions_list(override_deps):
+    with patch.object(settings, "RESEARCH_PIPELINE_ENABLED", True):
+        with patch(
+            "app.routers.research_pipeline.ResearchPipelineService.list_recent_sessions",
+            new_callable=AsyncMock,
+        ) as mock_service:
+            mock_service.return_value = [{"id": 1, "status": "finalized"}]
+            async with AsyncClient(
+                transport=ASGITransport(app=app), base_url="http://test"
+            ) as ac:
+                response = await ac.get("/trading/api/research-pipeline/sessions")
+                assert response.status_code == status.HTTP_200_OK
+                assert response.json()[0]["id"] == 1
+
+
+@pytest.mark.asyncio
 async def test_get_session_by_id(override_deps):
     with patch.object(settings, "RESEARCH_PIPELINE_ENABLED", True):
         mock_session = {"id": 1, "status": "open", "stock_info_id": 123}

--- a/tests/services/test_research_pipeline_service.py
+++ b/tests/services/test_research_pipeline_service.py
@@ -51,6 +51,7 @@ async def test_create_session_and_dispatch_returns_session_id_without_awaiting_r
 @pytest.mark.asyncio
 async def test_get_latest_summary_includes_summary_stage_links(monkeypatch):
     from datetime import UTC, datetime
+
     from app.models.research_pipeline import (
         ResearchSummary,
         StageAnalysis,

--- a/tests/services/test_research_pipeline_service.py
+++ b/tests/services/test_research_pipeline_service.py
@@ -46,3 +46,60 @@ async def test_create_session_and_dispatch_returns_session_id_without_awaiting_r
         assert result.session_id == 99
         assert result.status in {"running", "open"}
         assert fake_create_task.called, "stage execution must be dispatched async"
+
+
+@pytest.mark.asyncio
+async def test_get_latest_summary_includes_summary_stage_links(monkeypatch):
+    from datetime import UTC, datetime
+    from app.models.research_pipeline import (
+        ResearchSummary,
+        StageAnalysis,
+        SummaryStageLink,
+    )
+
+    fake_link = MagicMock(spec=SummaryStageLink)
+    fake_link.stage_analysis_id = 7
+    fake_link.direction = "support"
+    fake_link.weight = 0.8
+    fake_link.rationale = "rsi oversold"
+
+    fake_stage = MagicMock(spec=StageAnalysis)
+    fake_stage.id = 7
+    fake_stage.stage_type = "market"
+
+    fake_summary = MagicMock(spec=ResearchSummary)
+    fake_summary.id = 1
+    fake_summary.session_id = 10
+    fake_summary.decision = "buy"
+    fake_summary.confidence = 80
+    fake_summary.bull_arguments = []
+    fake_summary.bear_arguments = []
+    fake_summary.price_analysis = None
+    fake_summary.reasons = None
+    fake_summary.detailed_text = None
+    fake_summary.warnings = None
+    fake_summary.executed_at = datetime.now(UTC)
+    fake_summary.stage_links = [fake_link]
+
+    db = MagicMock()
+    summary_result = MagicMock()
+    summary_result.scalar_one_or_none.return_value = fake_summary
+
+    stage_result = MagicMock()
+    stage_result.scalars.return_value.all.return_value = [fake_stage]
+
+    db.execute = AsyncMock(side_effect=[summary_result, stage_result])
+
+    service = ResearchPipelineService(db)
+    result = await service.get_latest_summary(10)
+
+    assert result is not None
+    assert result["summary_stage_links"] == [
+        {
+            "stage_analysis_id": 7,
+            "stage_type": "market",
+            "direction": "support",
+            "weight": 0.8,
+            "rationale": "rsi oversold",
+        }
+    ]

--- a/tests/services/test_research_pipeline_service.py
+++ b/tests/services/test_research_pipeline_service.py
@@ -1,0 +1,48 @@
+"""Service tests for ROB-113 additions."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.research_pipeline_service import ResearchPipelineService
+
+
+@pytest.mark.asyncio
+async def test_create_session_and_dispatch_returns_session_id_without_awaiting_run():
+    db = MagicMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    fake_session = MagicMock()
+    fake_session.id = 99
+    fake_session.status = "running"
+    fake_session.started_at = datetime.now(UTC)
+
+    with (
+        patch(
+            "app.services.research_pipeline_service.create_stock_if_not_exists",
+            new_callable=AsyncMock,
+        ) as fake_create_stock,
+        patch(
+            "app.services.research_pipeline_service.ResearchSession",
+            return_value=fake_session,
+        ),
+        patch(
+            "app.services.research_pipeline_service.asyncio.create_task"
+        ) as fake_create_task,
+    ):
+        fake_create_stock.return_value = MagicMock(id=1)
+        service = ResearchPipelineService(db)
+
+        result = await service.create_session_and_dispatch(
+            symbol="KRW-BTC",
+            name="Bitcoin",
+            instrument_type="crypto",
+            research_run_id=None,
+            user_id=None,
+        )
+
+        assert result.session_id == 99
+        assert result.status in {"running", "open"}
+        assert fake_create_task.called, "stage execution must be dispatched async"


### PR DESCRIPTION
## Summary
- Add `POST /api/research-pipeline/sessions` (background dispatch; HTTP returns immediately).
- Add `GET /sessions/:id?include=full` and `GET /symbols/:symbol/timeline?days=30`; enrich `/sessions/:id/summary` with `summary_stage_links`.
- Frontend: `/trading/decisions/research` (home), `/research/sessions/:sessionId` (6-tab detail with 5s polling, citation sidebar, social placeholder), `/research/symbols/:symbol/timeline` (mini SVG chart). Korean UI labels.

Linear: https://linear.app/mgh3326/issue/ROB-113

## Changes
- Backend endpoints added: `POST /api/research-pipeline/sessions`, `GET /sessions/:id?include=full`, `GET /symbols/:symbol/timeline?days=30`. `GET /sessions/:id/summary` now includes `summary_stage_links`.
- Background runner: `app/services/research_pipeline_service._run_session_in_background` uses a fresh DB session and reuses the synchronously-created `research_sessions` row via `existing_session_id`.
- Frontend routes added: `/research`, `/research/sessions/:sessionId`, `/research/symbols/:symbol/timeline`.
- 34 files changed, +2,615 / -12 lines.
- Migrations: none.
- Feature flags: unchanged. `RESEARCH_PIPELINE_DUAL_WRITE_ENABLED` not touched. Endpoints still gated by `RESEARCH_PIPELINE_ENABLED`.

## Test plan
- [x] `uv run ruff check app/ tests/` — All checks passed
- [x] `uv run ruff format --check app/ tests/` — 890 files already formatted
- [x] `uv run ty check app/ --error-on-warning` — All checks passed
- [x] `uv run pytest tests -k 'research_pipeline'` — 27 passed
- [x] `cd frontend/trading-decision && npm run typecheck` — pass
- [x] `cd frontend/trading-decision && npm test` — 207 tests across 47 files passed
- [x] `cd frontend/trading-decision && npm run build` — built in 353ms
- [x] `cd frontend/trading-decision && RUN_BUNDLE_GREP=1 npm test` — pass
- [ ] Production smoke: start a `KRW-BTC` crypto session at `/trading/decisions/research`, confirm detail page polls and lands on `finalized`
- [ ] Production smoke: visit `/trading/decisions/research/symbols/AAPL/timeline` once at least one finalized AAPL session exists

## Production deployment caution
Background `asyncio.create_task` orphans pipeline execution from the request. Each `/sessions` POST schedules one run that completes within ~60s. If the API process is drained mid-flight (rolling deploy) a dispatched run can be killed; the session is then left at `status='open'` and not auto-marked failed. Acceptable for Phase 3 MVP.

## Side-effect confirmation
- No broker / paper / live order mutations.
- No watch alert or order intent creation.
- No scheduler cadence change; no periodic research generation enabled.
- No direct DB UPDATE/DELETE/backfill outside the new session row INSERT and background `status` finalize/fail UPDATE handled by `app/analysis/pipeline.py`.
- No `RESEARCH_PIPELINE_DUAL_WRITE_ENABLED` toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Start and view research sessions (creation flow, list, detail pages)
  * Multi-tab session detail: Summary, Market, News, Fundamentals, Social, Raw
  * Symbol timeline view with mini-chart and per-session entries
  * Cited-stages sidebar, confidence visuals, localized Korean labels, form validation and error states
  * Client API and hooks for sessions and timelines (auto-polling while running)

* **Tests**
  * Added comprehensive frontend and backend tests covering UI flows, API clients, and service behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->