### PR TITLE
fix: close yfinance sessions in MCP flows

### DIFF
--- a/app/mcp_server/tooling/analysis_analyze.py
+++ b/app/mcp_server/tooling/analysis_analyze.py
@@ -43,7 +43,7 @@ from app.mcp_server.tooling.shared import (
 )
 from app.mcp_server.tooling.shared import resolve_market_type as _resolve_market_type
 from app.models.research_pipeline import ResearchSession, ResearchSummary
-from app.monitoring import build_yfinance_tracing_session
+from app.monitoring import build_yfinance_tracing_session, close_yfinance_session
 
 logger = logging.getLogger(__name__)
 
@@ -229,7 +229,7 @@ async def _append_market_specific_tasks(
     normalized_symbol: str,
     market_type: str,
     loop: asyncio.AbstractEventLoop,
-) -> None:
+) -> Any | None:
     if market_type == "equity_kr":
         named_tasks.append(
             (
@@ -239,7 +239,7 @@ async def _append_market_specific_tasks(
                 ),
             )
         )
-        return
+        return None
 
     if market_type == "crypto":
         named_tasks.append(
@@ -250,7 +250,7 @@ async def _append_market_specific_tasks(
                 ),
             )
         )
-        return
+        return None
 
     yf_session = build_yfinance_tracing_session()
     yf_ticker = yf.Ticker(normalized_symbol, session=yf_session)
@@ -290,6 +290,7 @@ async def _append_market_specific_tasks(
             ),
         ]
     )
+    return yf_session
 
 
 def _append_sector_peers_task(
@@ -593,18 +594,22 @@ async def analyze_stock_impl(
         ohlcv_df,
     )
     _append_common_tasks(named_tasks, normalized_symbol, ohlcv_df, ohlcv_60d)
-    await _append_market_specific_tasks(
+    yfinance_session_to_close = await _append_market_specific_tasks(
         named_tasks, normalized_symbol, market_type, loop
     )
     _append_sector_peers_task(
         named_tasks, normalized_symbol, market_type, include_peers
     )
 
-    with sentry_sdk.start_span(
-        op="analyze_stock.gather_tasks",
-        name=f"gather tasks {market_type} {normalized_symbol}",
-    ):
-        task_results = await _gather_task_results(named_tasks)
+    try:
+        with sentry_sdk.start_span(
+            op="analyze_stock.gather_tasks",
+            name=f"gather tasks {market_type} {normalized_symbol}",
+        ):
+            task_results = await _gather_task_results(named_tasks)
+    finally:
+        if yfinance_session_to_close is not None:
+            close_yfinance_session(yfinance_session_to_close)
 
     with sentry_sdk.start_span(
         op="analyze_stock.assemble_response",

--- a/app/mcp_server/tooling/analysis_rankings.py
+++ b/app/mcp_server/tooling/analysis_rankings.py
@@ -9,7 +9,7 @@ from typing import Any
 import yfinance as yf
 
 import app.services.brokers.upbit.client as upbit_service
-from app.monitoring import build_yfinance_tracing_session
+from app.monitoring import yfinance_tracing_session
 
 
 async def get_us_rankings_impl(
@@ -24,9 +24,8 @@ async def get_us_rankings_impl(
     }
 
     screener_id = screener_ids.get(ranking_type)
-    session = build_yfinance_tracing_session()
 
-    def fetch_sync():
+    def fetch_sync(session):
         if ranking_type == "market_cap":
             query = yf.EquityQuery(
                 "and",
@@ -46,7 +45,8 @@ async def get_us_rankings_impl(
             )
         return yf.screen(screener_id, session=session)
 
-    results = await asyncio.to_thread(fetch_sync)
+    with yfinance_tracing_session() as session:
+        results = await asyncio.to_thread(fetch_sync, session)
 
     temp_rankings: list[dict[str, Any]] = []
     if isinstance(results, dict):

--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -26,7 +26,7 @@ from app.mcp_server.tooling.shared import (
 from app.mcp_server.tooling.shared import (
     is_korean_equity_code as _is_korean_equity_code,
 )
-from app.monitoring import build_yfinance_tracing_session
+from app.monitoring import yfinance_tracing_session
 from app.services.brokers.kis.client import KISClient
 
 logger = logging.getLogger(__name__)
@@ -682,10 +682,7 @@ async def get_dividends_impl(symbol: str) -> dict[str, Any]:
     if not symbol:
         raise ValueError("symbol is required")
 
-    session = build_yfinance_tracing_session()
-    ticker = yf.Ticker(symbol.upper(), session=session)
-
-    def fetch_sync() -> dict[str, Any]:
+    def fetch_sync(ticker: yf.Ticker) -> dict[str, Any]:
         try:
             info = ticker.info or {}
 
@@ -721,7 +718,9 @@ async def get_dividends_impl(symbol: str) -> dict[str, Any]:
                 "symbol": symbol.upper(),
             }
 
-    return await asyncio.to_thread(fetch_sync)
+    with yfinance_tracing_session() as session:
+        ticker = yf.Ticker(symbol.upper(), session=session)
+        return await asyncio.to_thread(fetch_sync, ticker)
 
 
 async def get_fear_greed_index_impl(days: int = 7) -> dict[str, Any]:

--- a/app/mcp_server/tooling/fundamentals_sources_indices.py
+++ b/app/mcp_server/tooling/fundamentals_sources_indices.py
@@ -10,7 +10,7 @@ import httpx
 import pandas as pd
 import yfinance as yf
 
-from app.monitoring import build_yfinance_tracing_session
+from app.monitoring import yfinance_tracing_session
 
 _INDEX_META: dict[str, dict[str, str]] = {
     "KOSPI": {"name": "코스피", "source": "naver", "naver_code": "KOSPI"},
@@ -120,9 +120,9 @@ async def _fetch_index_us_current(
     yf_ticker: str, name: str, symbol: str
 ) -> dict[str, Any]:
     loop = asyncio.get_running_loop()
-    session = build_yfinance_tracing_session()
-    ticker_obj = yf.Ticker(yf_ticker, session=session)
-    info = await loop.run_in_executor(None, lambda: ticker_obj.fast_info)
+    with yfinance_tracing_session() as session:
+        ticker_obj = yf.Ticker(yf_ticker, session=session)
+        info = await loop.run_in_executor(None, lambda: ticker_obj.fast_info)
 
     current = getattr(info, "last_price", None)
     previous_close = getattr(info, "regular_market_previous_close", None)
@@ -151,7 +151,6 @@ async def _fetch_index_us_history(
     yf_ticker: str, count: int, period: str
 ) -> list[dict[str, Any]]:
     loop = asyncio.get_running_loop()
-    session = build_yfinance_tracing_session()
     period_map = {"day": "1d", "week": "1wk", "month": "1mo"}
     interval = period_map.get(period, "1d")
 
@@ -179,7 +178,8 @@ async def _fetch_index_us_history(
             df.columns = [c.lower() for c in df.columns]
         return df.reset_index(names="date")
 
-    df = await loop.run_in_executor(None, download)
+    with yfinance_tracing_session() as session:
+        df = await loop.run_in_executor(None, download)
     if df.empty:
         return []
 

--- a/app/mcp_server/tooling/fundamentals_sources_yfinance.py
+++ b/app/mcp_server/tooling/fundamentals_sources_yfinance.py
@@ -17,7 +17,11 @@ from app.mcp_server.tooling.fundamentals_sources_finnhub import (
     _get_finnhub_client,
 )
 from app.mcp_server.tooling.shared import normalize_value as _normalize_value
-from app.monitoring import build_yfinance_tracing_session
+from app.monitoring import (
+    build_yfinance_tracing_session,
+    close_yfinance_session,
+    yfinance_tracing_session,
+)
 from app.services.analyst_normalizer import (
     normalize_rating_label,
     rating_to_bucket,
@@ -193,10 +197,7 @@ def _empty_analyst_consensus(current_price: float | None) -> dict[str, Any]:
 async def _fetch_financials_yfinance(
     symbol: str, statement: str, freq: str
 ) -> dict[str, Any]:
-    session = build_yfinance_tracing_session()
-    ticker = yf.Ticker(symbol, session=session)
-
-    def fetch_sync() -> dict[str, Any]:
+    def fetch_sync(ticker: yf.Ticker) -> dict[str, Any]:
         statement_map = {
             "income": "income_stmt",
             "balance": "balance_sheet",
@@ -234,7 +235,9 @@ async def _fetch_financials_yfinance(
 
         return financials
 
-    financials = await asyncio.to_thread(fetch_sync)
+    with yfinance_tracing_session() as session:
+        ticker = yf.Ticker(symbol, session=session)
+        financials = await asyncio.to_thread(fetch_sync, ticker)
 
     return {
         "symbol": symbol.upper(),
@@ -252,9 +255,11 @@ async def _fetch_investment_opinions_yfinance(
     snapshot: _YFinanceSnapshot | None = None,
     session: Any | None = None,
 ) -> dict[str, Any]:
-    if session is None:
-        session = build_yfinance_tracing_session()
-    ticker = yf.Ticker(symbol, session=session)
+    owns_session = session is None and snapshot is None
+    if snapshot is None:
+        if session is None:
+            session = build_yfinance_tracing_session()
+        ticker = yf.Ticker(symbol, session=session)
 
     def _collect() -> tuple[dict[str, Any] | None, Any, Any, dict[str, Any] | None]:
         targets = None
@@ -289,7 +294,11 @@ async def _fetch_investment_opinions_yfinance(
         ud = snapshot.upgrades_downgrades
         info = snapshot.info
     else:
-        targets, trend, ud, info = await asyncio.to_thread(_collect)
+        try:
+            targets, trend, ud, info = await asyncio.to_thread(_collect)
+        finally:
+            if owns_session and session is not None:
+                close_yfinance_session(session)
 
     current_price = _normalize_yahoo_numeric((info or {}).get("currentPrice"))
     opinions: list[dict[str, Any]] = []
@@ -354,6 +363,7 @@ async def _fetch_investment_opinions_yfinance_screen(
     current_price: float | None = None,
     session: Any | None = None,
 ) -> dict[str, Any]:
+    owns_session = session is None
     if session is None:
         session = build_yfinance_tracing_session()
     ticker = yf.Ticker(symbol, session=session)
@@ -373,7 +383,11 @@ async def _fetch_investment_opinions_yfinance_screen(
 
         return targets, recommendations
 
-    targets, trend = await asyncio.to_thread(_collect)
+    try:
+        targets, trend = await asyncio.to_thread(_collect)
+    finally:
+        if owns_session:
+            close_yfinance_session(session)
 
     target_consensus = _build_yahoo_target_consensus(
         targets,
@@ -415,13 +429,20 @@ async def _fetch_valuation_yfinance(
     snapshot: _YFinanceSnapshot | None = None,
     session: Any | None = None,
 ) -> dict[str, Any]:
-    if session is None:
-        session = build_yfinance_tracing_session()
-    ticker = yf.Ticker(symbol, session=session)
+    owns_session = session is None and not (
+        snapshot is not None and snapshot.info is not None
+    )
     if snapshot is not None and snapshot.info is not None:
         info = snapshot.info
     else:
-        info: dict[str, Any] = await asyncio.to_thread(lambda: ticker.info)
+        if session is None:
+            session = build_yfinance_tracing_session()
+        ticker = yf.Ticker(symbol, session=session)
+        try:
+            info: dict[str, Any] = await asyncio.to_thread(lambda: ticker.info)
+        finally:
+            if owns_session:
+                close_yfinance_session(session)
 
     current_price = info.get("currentPrice")
     high_52w = info.get("fiftyTwoWeekHigh")
@@ -545,12 +566,14 @@ async def _fetch_sector_peers_us(
 
     async def _fetch_yf_info(ticker: str) -> tuple[str, dict[str, Any] | None]:
         try:
-            session = build_yfinance_tracing_session()
+            with yfinance_tracing_session() as session:
 
-            def _fetch_info(symbol: str = ticker, yf_session=session) -> dict[str, Any]:
-                return yf.Ticker(symbol, session=yf_session).info
+                def _fetch_info(
+                    symbol: str = ticker, yf_session=session
+                ) -> dict[str, Any]:
+                    return yf.Ticker(symbol, session=yf_session).info
 
-            info: dict[str, Any] = await asyncio.to_thread(_fetch_info)
+                info: dict[str, Any] = await asyncio.to_thread(_fetch_info)
             return (ticker, info)
         except Exception:
             return (ticker, None)

--- a/app/mcp_server/tooling/screening/enrichment.py
+++ b/app/mcp_server/tooling/screening/enrichment.py
@@ -21,7 +21,7 @@ from app.mcp_server.tooling.screening.common import (
     _to_optional_float,
     _to_optional_int,
 )
-from app.monitoring import build_yfinance_tracing_session
+from app.monitoring import build_yfinance_tracing_session, close_yfinance_session
 
 logger = logging.getLogger(__name__)
 
@@ -190,9 +190,7 @@ async def _decorate_screen_rows_with_equity_enrichment(
         )
     finally:
         if yfinance_session is not None:
-            close = getattr(yfinance_session, "close", None)
-            if callable(close):
-                close()
+            close_yfinance_session(yfinance_session)
     return normalized_rows, warnings
 
 

--- a/app/mcp_server/tooling/screening/us.py
+++ b/app/mcp_server/tooling/screening/us.py
@@ -36,7 +36,7 @@ from app.mcp_server.tooling.screening.tvscreener_support import (
     _get_tvscreener_stock_capability_snapshot,
 )
 from app.mcp_server.tooling.shared import error_payload as _error_payload
-from app.monitoring import build_yfinance_tracing_session
+from app.monitoring import yfinance_tracing_session
 from app.services.exchange_rate_service import get_usd_krw_rate
 from app.services.tvscreener_service import (
     TvScreenerError,
@@ -172,17 +172,16 @@ async def _screen_us(
         }
         sort_field = sort_field_map.get(sort_by, "dayvolume")
         fetch_size = min(limit * 3, 150) if max_rsi is not None else limit
-        session = build_yfinance_tracing_session()
-
-        screen_result = await asyncio.to_thread(
-            lambda: yf.screen(
-                query,
-                size=fetch_size,
-                sortField=sort_field,
-                sortAsc=(sort_order == "asc"),
-                session=session,
+        with yfinance_tracing_session() as session:
+            screen_result = await asyncio.to_thread(
+                lambda: yf.screen(
+                    query,
+                    size=fetch_size,
+                    sortField=sort_field,
+                    sortAsc=(sort_order == "asc"),
+                    session=session,
+                )
             )
-        )
 
         if screen_result is None:
             _complete_filters_applied()

--- a/app/monitoring/__init__.py
+++ b/app/monitoring/__init__.py
@@ -1,6 +1,13 @@
 from app.monitoring.yfinance_sentry import (
     SentryTracingCurlSession,
     build_yfinance_tracing_session,
+    close_yfinance_session,
+    yfinance_tracing_session,
 )
 
-__all__ = ["SentryTracingCurlSession", "build_yfinance_tracing_session"]
+__all__ = [
+    "SentryTracingCurlSession",
+    "build_yfinance_tracing_session",
+    "close_yfinance_session",
+    "yfinance_tracing_session",
+]

--- a/app/monitoring/yfinance_sentry.py
+++ b/app/monitoring/yfinance_sentry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -36,4 +38,26 @@ def build_yfinance_tracing_session() -> Session:
     return SentryTracingCurlSession(impersonate="chrome")
 
 
-__all__ = ["SentryTracingCurlSession", "build_yfinance_tracing_session"]
+def close_yfinance_session(session: Any) -> None:
+    """Close a yfinance HTTP session without masking the caller's result/error."""
+    close = getattr(session, "close", None)
+    if callable(close):
+        close()
+
+
+@contextmanager
+def yfinance_tracing_session() -> Iterator[Session]:
+    """Create a traced curl_cffi session and always release its sockets."""
+    session = build_yfinance_tracing_session()
+    try:
+        yield session
+    finally:
+        close_yfinance_session(session)
+
+
+__all__ = [
+    "SentryTracingCurlSession",
+    "build_yfinance_tracing_session",
+    "close_yfinance_session",
+    "yfinance_tracing_session",
+]

--- a/app/services/brokers/yahoo/client.py
+++ b/app/services/brokers/yahoo/client.py
@@ -2,6 +2,8 @@
 import asyncio
 import logging
 import urllib.error
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -10,7 +12,7 @@ import yfinance as yf
 
 from app.core.config import settings
 from app.core.symbol import to_yahoo_symbol
-from app.monitoring import build_yfinance_tracing_session
+from app.monitoring import build_yfinance_tracing_session, close_yfinance_session
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +70,20 @@ def _to_int_or_none(value: Any) -> int | None:
 
 
 _CRUMB_RETRY_MAX = 1
+
+
+@contextmanager
+def yfinance_tracing_session() -> Iterator[Any]:
+    """Create a Yahoo/yfinance session and close it after each attempt.
+
+    Keep this wrapper local so tests and retry paths that monkeypatch
+    build_yfinance_tracing_session still exercise fresh-session behavior.
+    """
+    session = build_yfinance_tracing_session()
+    try:
+        yield session
+    finally:
+        close_yfinance_session(session)
 
 
 def _is_crumb_auth_error(exc: BaseException) -> bool:
@@ -130,17 +146,17 @@ async def _fetch_ohlcv_raw(
 
     last_exc: BaseException | None = None
     for attempt in range(_CRUMB_RETRY_MAX + 1):
-        session = build_yfinance_tracing_session()
         try:
-            df = yf.download(
-                yahoo_ticker,
-                start=start,
-                end=end,
-                interval=period_map[period],
-                progress=False,
-                auto_adjust=False,
-                session=session,
-            )
+            with yfinance_tracing_session() as session:
+                df = yf.download(
+                    yahoo_ticker,
+                    start=start,
+                    end=end,
+                    interval=period_map[period],
+                    progress=False,
+                    auto_adjust=False,
+                    session=session,
+                )
             df = _flatten_cols(df).reset_index(names="date")
             df = (
                 df.assign(date=lambda d: pd.to_datetime(d["date"]).dt.date)
@@ -201,9 +217,9 @@ def _fetch_fast_info_sync(ticker: str) -> dict[str, Any]:
     last_exc: BaseException | None = None
 
     for attempt in range(_CRUMB_RETRY_MAX + 1):
-        session = build_yfinance_tracing_session()
         try:
-            info = yf.Ticker(yahoo_ticker, session=session).fast_info
+            with yfinance_tracing_session() as session:
+                info = yf.Ticker(yahoo_ticker, session=session).fast_info
             return {
                 "symbol": ticker,
                 "previous_close": _to_float_or_none(
@@ -279,9 +295,9 @@ async def fetch_fundamental_info(ticker: str) -> dict:
     def _fetch_sync() -> dict:
         last_exc: BaseException | None = None
         for attempt in range(_CRUMB_RETRY_MAX + 1):
-            session = build_yfinance_tracing_session()
             try:
-                info = yf.Ticker(yahoo_ticker, session=session).info
+                with yfinance_tracing_session() as session:
+                    info = yf.Ticker(yahoo_ticker, session=session).info
                 return {
                     "PER": info.get("trailingPE"),
                     "PBR": info.get("priceToBook"),

--- a/scripts/deploy-native.sh
+++ b/scripts/deploy-native.sh
@@ -39,6 +39,7 @@ SOURCE_REPO="${AUTO_TRADER_SOURCE_REPO:-$HOME/work/auto_trader}"
 SHARED_ENV="${AUTO_TRADER_ENV_FILE:-$BASE/shared/.env.prod.native}"
 LOG_DIR="$BASE/logs"
 PLIST_DIR="${AUTO_TRADER_PLIST_DIR:-$BASE/plists}"
+MCP_NOFILE_LIMIT="${AUTO_TRADER_MCP_NOFILE_LIMIT:-4096}"
 SERVER_HEALTHCHECK="$BASE/scripts/healthcheck-native.sh"
 
 LABELS=(
@@ -64,6 +65,22 @@ require_file() {
     echo "Missing required file: $path" >&2
     exit 78
   fi
+}
+
+apply_mcp_plist_fd_limit() {
+  local plist="$1"
+
+  if [[ "$(basename "$plist")" != com.robinco.auto-trader.mcp*.plist ]]; then
+    return 0
+  fi
+
+  /usr/libexec/PlistBuddy -c 'Delete :SoftResourceLimits:NumberOfFiles' "$plist" 2>/dev/null || true
+  /usr/libexec/PlistBuddy -c 'Delete :HardResourceLimits:NumberOfFiles' "$plist" 2>/dev/null || true
+  /usr/libexec/PlistBuddy -c 'Add :SoftResourceLimits dict' "$plist" 2>/dev/null || true
+  /usr/libexec/PlistBuddy -c 'Add :HardResourceLimits dict' "$plist" 2>/dev/null || true
+  /usr/libexec/PlistBuddy -c "Add :SoftResourceLimits:NumberOfFiles integer $MCP_NOFILE_LIMIT" "$plist"
+  /usr/libexec/PlistBuddy -c "Add :HardResourceLimits:NumberOfFiles integer $MCP_NOFILE_LIMIT" "$plist"
+  plutil -lint "$plist" >/dev/null
 }
 
 build_frontend() {
@@ -112,6 +129,7 @@ restart_services() {
       return 78
     fi
 
+    apply_mcp_plist_fd_limit "$plist"
     install -m 0644 "$plist" "$target"
     launchctl bootout "gui/$uid_num/$label" 2>/dev/null || true
     launchctl bootout "gui/$uid_num" "$target" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Close curl_cffi-backed yfinance sessions in Yahoo quote/OHLCV/fundamentals paths and MCP screening/analysis helpers.
- Add defensive close/contextmanager helpers for yfinance tracing sessions.
- Raise launchd MCP `NumberOfFiles` limit via native deploy script for `com.robinco.auto-trader.mcp*.plist`.

## Test Plan
- `uv run python -m compileall -q app/monitoring app/services/brokers/yahoo app/mcp_server/tooling/...`
- `uv run ruff format --check <changed python files>`
- `uv run ruff check <changed python files>`
- `bash -n scripts/deploy-native.sh`
- `plutil -lint /Users/mgh3326/services/auto_trader/plists/com.robinco.auto-trader.mcp.plist`
- `uv run pytest tests/test_yfinance_sentry.py tests/test_services_yahoo.py tests/test_yahoo_service_cache.py tests/test_mcp_quotes_tools.py tests/test_mcp_fundamentals_tools.py tests/test_screening_us.py tests/test_screening_enrichment.py tests/test_mcp_screen_stocks_filters_and_rsi.py tests/test_mcp_top_stocks.py tests/mcp_server/test_analyze_stock_pipeline_compat.py -q` (272 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved yfinance session resource management with guaranteed cleanup via context managers across multiple modules, ensuring deterministic resource lifecycle handling.

* **Chores**
  * Added configurable file descriptor limits for MCP services in deployment script via `AUTO_TRADER_MCP_NOFILE_LIMIT` environment variable (default: 4096).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->