### PR TITLE
fix(ROB-122): restore watch alert router delivery resilience

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -347,7 +347,11 @@ class Settings(BaseSettings):
 
     # N8N Fill Notification webhook (replaces OPENCLAW_THREAD_* for fills)
     N8N_FILL_WEBHOOK_URL: str = ""
-    # N8N Watch Alert webhook (replaces OpenClaw watch alert route)
+    # Watch Alert router (Phase 0 of ROB-122 — transport-neutral seam).
+    # When set, takes precedence over N8N_WATCH_ALERT_WEBHOOK_URL.
+    # N8N_WATCH_ALERT_WEBHOOK_URL is the deprecated backward-compat fallback.
+    WATCH_ALERT_ROUTER_URL: str = ""
+    # N8N Watch Alert webhook (deprecated fallback for WATCH_ALERT_ROUTER_URL).
     N8N_WATCH_ALERT_WEBHOOK_URL: str = ""
 
     # MCP caller identity fallback for non-HTTP/manual runs

--- a/app/jobs/watch_proximity_monitor.py
+++ b/app/jobs/watch_proximity_monitor.py
@@ -99,7 +99,7 @@ class OpenClawProximityNotifier:
             }
             for result in results
         ]
-        return await self._client.send_watch_alert_to_n8n(
+        return await self._client.send_watch_alert_to_router(
             message=message,
             market=market,
             triggered=triggered,

--- a/app/jobs/watch_scanner.py
+++ b/app/jobs/watch_scanner.py
@@ -275,7 +275,7 @@ class WatchScanner:
         correlation_id = str(uuid4())
         as_of = Timestamp.now("UTC").isoformat()
         try:
-            return await self._openclaw.send_watch_alert_to_n8n(
+            return await self._openclaw.send_watch_alert_to_router(
                 message=message,
                 market=market,
                 triggered=triggered,
@@ -304,6 +304,7 @@ class WatchScanner:
                     "status": "skipped",
                     "skipped": True,
                     "reason": "market_closed",
+                    "failed_lookups": 0,
                 }
             return {
                 "market": normalized_market,
@@ -311,89 +312,101 @@ class WatchScanner:
                 "reason": "no_watch_records",
                 "alerts_sent": 0,
                 "details": [],
+                "failed_lookups": 0,
             }
 
         triggered: list[dict[str, object]] = []
         intents: list[dict[str, object]] = []
         triggered_fields: list[str] = []
+        failed_lookups = 0
         kst_date = now_kst().date().isoformat()
 
         for watch in watches:
-            target_kind = str(watch.get("target_kind") or "asset").strip().lower()
-            if not market_open and target_kind != "fx":
-                continue
-            symbol = str(watch.get("symbol") or "").strip().upper()
-            condition_type = str(watch.get("condition_type") or "").strip().lower()
-            field = str(watch.get("field") or "")
-            threshold = self._to_float(watch.get("threshold"))
-
-            if not symbol or not condition_type or not field or threshold is None:
-                continue
-
             try:
-                metric, operator = condition_type.rsplit("_", 1)
-            except ValueError:
-                continue
+                target_kind = str(watch.get("target_kind") or "asset").strip().lower()
+                if not market_open and target_kind != "fx":
+                    continue
+                symbol = str(watch.get("symbol") or "").strip().upper()
+                condition_type = str(watch.get("condition_type") or "").strip().lower()
+                field = str(watch.get("field") or "")
+                threshold = self._to_float(watch.get("threshold"))
 
-            current = await self._get_current_value(
-                target_kind=target_kind,
-                metric=metric,
-                symbol=symbol,
-                market=normalized_market,
-            )
+                if not symbol or not condition_type or not field or threshold is None:
+                    continue
 
-            if not self._is_triggered(current, operator, threshold):
-                continue
+                try:
+                    metric, operator = condition_type.rsplit("_", 1)
+                except ValueError:
+                    continue
 
-            try:
-                policy = parse_policy(
-                    market=normalized_market,
+                current = await self._get_current_value(
                     target_kind=target_kind,
-                    condition_type=condition_type,
-                    raw_payload=watch.get("raw_payload"),
+                    metric=metric,
+                    symbol=symbol,
+                    market=normalized_market,
                 )
-            except WatchPolicyError as exc:
+
+                if not self._is_triggered(current, operator, threshold):
+                    continue
+
+                try:
+                    policy = parse_policy(
+                        market=normalized_market,
+                        target_kind=target_kind,
+                        condition_type=condition_type,
+                        raw_payload=watch.get("raw_payload"),
+                    )
+                except WatchPolicyError as exc:
+                    logger.warning(
+                        "Skipping watch with invalid policy: market=%s field=%s code=%s",
+                        normalized_market,
+                        field,
+                        exc.code,
+                    )
+                    continue
+
+                if isinstance(policy, NotifyOnlyPolicy):
+                    triggered.append(
+                        {
+                            "target_kind": target_kind,
+                            "symbol": symbol,
+                            "condition_type": condition_type,
+                            "threshold": threshold,
+                            "current": current,
+                        }
+                    )
+                    triggered_fields.append(field)
+                    continue
+
+                assert isinstance(policy, IntentPolicy)
+                async with self._intent_session() as (db, factory):
+                    service = factory(db)
+                    emission = await service.emit_intent(
+                        watch={
+                            "market": normalized_market,
+                            "target_kind": target_kind,
+                            "symbol": symbol,
+                            "condition_type": condition_type,
+                            "threshold": Decimal(str(threshold)),
+                            "threshold_key": str(threshold),
+                        },
+                        policy=policy,
+                        triggered_value=Decimal(str(current)),
+                        kst_date=kst_date,
+                        correlation_id=uuid4().hex,
+                    )
+                intents.append(emission.to_alert_dict())
+                if emission.status in {"previewed", "dedupe_hit"}:
+                    triggered_fields.append(field)
+            except Exception as exc:
                 logger.warning(
-                    "Skipping watch with invalid policy: market=%s field=%s code=%s",
+                    "Watch lookup failed (continuing): market=%s symbol=%s error=%s",
                     normalized_market,
-                    field,
-                    exc.code,
+                    str(watch.get("symbol") or "").strip().upper(),
+                    exc,
                 )
+                failed_lookups += 1
                 continue
-
-            if isinstance(policy, NotifyOnlyPolicy):
-                triggered.append(
-                    {
-                        "target_kind": target_kind,
-                        "symbol": symbol,
-                        "condition_type": condition_type,
-                        "threshold": threshold,
-                        "current": current,
-                    }
-                )
-                triggered_fields.append(field)
-                continue
-
-            assert isinstance(policy, IntentPolicy)
-            async with self._intent_session() as (db, factory):
-                service = factory(db)
-                emission = await service.emit_intent(
-                    watch={
-                        "market": normalized_market,
-                        "target_kind": target_kind,
-                        "symbol": symbol,
-                        "condition_type": condition_type,
-                        "threshold": Decimal(str(threshold)),
-                        "threshold_key": str(threshold),
-                    },
-                    policy=policy,
-                    triggered_value=Decimal(str(current)),
-                    kst_date=kst_date,
-                    correlation_id=uuid4().hex,
-                )
-            intents.append(emission.to_alert_dict())
-            if emission.status in {"previewed", "dedupe_hit"}:
-                triggered_fields.append(field)
 
         if not triggered and not intents:
             if not market_open:
@@ -402,6 +415,7 @@ class WatchScanner:
                     "status": "skipped",
                     "skipped": True,
                     "reason": "market_closed",
+                    "failed_lookups": failed_lookups,
                 }
             return {
                 "market": normalized_market,
@@ -409,6 +423,7 @@ class WatchScanner:
                 "reason": "no_triggered_alerts",
                 "alerts_sent": 0,
                 "details": [],
+                "failed_lookups": failed_lookups,
             }
 
         message = self._build_batched_message(
@@ -433,6 +448,7 @@ class WatchScanner:
                 "reason": result.reason,
                 "alerts_sent": 0,
                 "details": [message],
+                "failed_lookups": failed_lookups,
             }
 
         for field in triggered_fields:
@@ -444,12 +460,28 @@ class WatchScanner:
             "request_id": result.request_id,
             "alerts_sent": len(triggered) + len(intents),
             "details": [message],
+            "failed_lookups": failed_lookups,
         }
 
     async def run(self) -> dict[str, dict[str, object]]:
         results: dict[str, dict[str, object]] = {}
         for market in ("crypto", "kr", "us"):
-            market_result = await self.scan_market(market)
+            try:
+                market_result = await self.scan_market(market)
+            except Exception as exc:
+                logger.error(
+                    "scan_market raised unexpectedly: market=%s error=%s",
+                    market,
+                    exc,
+                )
+                market_result = {
+                    "market": market,
+                    "status": "failed",
+                    "reason": "scan_aborted",
+                    "alerts_sent": 0,
+                    "details": [],
+                    "failed_lookups": 0,
+                }
             results[market] = dict(market_result)
         return results
 

--- a/app/services/openclaw_client.py
+++ b/app/services/openclaw_client.py
@@ -122,6 +122,18 @@ def _build_n8n_fill_payload(
     }
 
 
+def _resolve_watch_alert_url() -> str:
+    """Resolve the watch-alert router URL.
+
+    WATCH_ALERT_ROUTER_URL wins when set; otherwise falls through to the
+    deprecated N8N_WATCH_ALERT_WEBHOOK_URL for backward compatibility.
+    """
+    router = settings.WATCH_ALERT_ROUTER_URL.strip()
+    if router:
+        return router
+    return settings.N8N_WATCH_ALERT_WEBHOOK_URL.strip()
+
+
 class OpenClawClient:
     """Client for OpenClaw Gateway webhook (POST /hooks/agent)."""
 
@@ -378,7 +390,7 @@ class OpenClawClient:
 
         return result
 
-    async def send_watch_alert_to_n8n(
+    async def send_watch_alert_to_router(
         self,
         *,
         message: str,
@@ -389,17 +401,17 @@ class OpenClawClient:
         intents: list[dict[str, Any]] | None = None,
     ) -> WatchAlertDeliveryResult:
         request_id = str(uuid4())
-        n8n_webhook_url = settings.N8N_WATCH_ALERT_WEBHOOK_URL.strip()
+        router_url = _resolve_watch_alert_url()
 
-        if not n8n_webhook_url:
+        if not router_url:
             logger.debug(
-                "N8N watch alert skipped: correlation_id=%s market=%s reason=n8n_webhook_not_configured",
+                "Watch alert router skipped: correlation_id=%s market=%s reason=router_not_configured",
                 correlation_id,
                 market,
             )
             return WatchAlertDeliveryResult(
                 status="skipped",
-                reason="n8n_webhook_not_configured",
+                reason="router_not_configured",
             )
 
         payload = {
@@ -418,7 +430,7 @@ class OpenClawClient:
                 attempt_number = attempt.retry_state.attempt_number
                 with attempt:
                     logger.info(
-                        "N8N watch alert send start: correlation_id=%s request_id=%s market=%s attempt=%s",
+                        "Watch alert router send start: correlation_id=%s request_id=%s market=%s attempt=%s",
                         correlation_id,
                         request_id,
                         market,
@@ -427,14 +439,14 @@ class OpenClawClient:
                     try:
                         async with httpx.AsyncClient(timeout=10) as cli:
                             res = await cli.post(
-                                n8n_webhook_url,
+                                router_url,
                                 json=payload,
                                 headers=headers,
                             )
                             _ = res.raise_for_status()
                     except Exception as exc:
                         logger.warning(
-                            "N8N watch alert attempt failed: correlation_id=%s request_id=%s market=%s attempt=%s error=%s",
+                            "Watch alert router attempt failed: correlation_id=%s request_id=%s market=%s attempt=%s error=%s",
                             correlation_id,
                             request_id,
                             market,
@@ -443,7 +455,7 @@ class OpenClawClient:
                         )
                         raise
                     logger.info(
-                        "N8N watch alert sent: correlation_id=%s request_id=%s market=%s attempt=%s status=%s",
+                        "Watch alert router sent: correlation_id=%s request_id=%s market=%s attempt=%s status=%s",
                         correlation_id,
                         request_id,
                         market,
@@ -456,7 +468,7 @@ class OpenClawClient:
                     )
         except RetryError as exc:
             logger.error(
-                "N8N watch alert failed after retries: correlation_id=%s request_id=%s market=%s error=%s",
+                "Watch alert router failed after retries: correlation_id=%s request_id=%s market=%s error=%s",
                 correlation_id,
                 request_id,
                 market,
@@ -464,7 +476,7 @@ class OpenClawClient:
             )
         except Exception as exc:
             logger.error(
-                "N8N watch alert error: correlation_id=%s request_id=%s market=%s error=%s",
+                "Watch alert router error: correlation_id=%s request_id=%s market=%s error=%s",
                 correlation_id,
                 request_id,
                 market,
@@ -480,7 +492,7 @@ class OpenClawClient:
         *,
         mirror_to_telegram: bool = True,
     ) -> str | None:
-        # Deprecated: watch category is replaced by send_watch_alert_to_n8n (ROB-171)
+        # Deprecated: watch category is replaced by send_watch_alert_to_router (ROB-171)
         if not settings.OPENCLAW_ENABLED:
             logger.debug("OpenClaw disabled, skipping %s alert", category)
             return None
@@ -549,7 +561,7 @@ class OpenClawClient:
         )
 
     async def send_watch_alert(self, message: str) -> str | None:
-        # Deprecated: replaced by send_watch_alert_to_n8n (ROB-171)
+        # Deprecated: replaced by send_watch_alert_to_router (ROB-171)
         return await self._send_market_alert(message, category="watch")
 
 

--- a/docs/plans/ROB-122-watch-alert-router-plan.md
+++ b/docs/plans/ROB-122-watch-alert-router-plan.md
@@ -1,0 +1,673 @@
+# ROB-122 Watch Alert Router Implementation Plan
+
+> **For agentic workers:** Implement this plan task-by-task in the assigned ROB-122 worktree/branch. Use the repository's normal Hermes/AoE workflow: planner/reviewer = Opus, implementer = Sonnet, one implementer editing at a time. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore reliable delivery of `scan.watch_alerts` (so a single Yahoo/yfinance quote failure can no longer abort the whole scan) and rename the delivery seam from `*_n8n` / `N8N_WATCH_ALERT_WEBHOOK_URL` to a transport-neutral router seam (`WATCH_ALERT_ROUTER_URL`) with backward compatibility, paving the way for an eventual Prefect-side webhook receiver without coupling this PR to it.
+
+**Architecture:** Scope this PR (Phase 0) to the auto_trader side only — per-watch resilience + router rename. Keep the existing n8n webhook (`paperclip-watch-alert.json`) as the active receiver until a follow-up PR brings the Prefect-side webhook receiver online. Initial router transport (Phase 1, follow-up PR) is a webhook receiver in `~/services/prefect`, not DB outbox or direct deployment-run, because it preserves the immediate-alert latency budget, mirrors the existing n8n contract for an easy A/B cutover via a single env var, and stays out of the auto_trader hot path. Hermes/LLM follow-up is explicitly *not* on the synchronous alert path; it is a Phase 2 async flow on the Prefect side.
+
+**Tech Stack:** Python 3.13, FastAPI/httpx, taskiq, pytest, Pydantic-Settings; Prefect 3.6 for Phase 1 follow-up.
+
+---
+
+## 1. Current code path and failure modes
+
+### 1.1 Code path
+
+1. **Schedule** — `app/tasks/watch_scan_tasks.py:run_watch_scan_task` runs every 5 min (`*/5 * * * *`, Asia/Seoul) via taskiq.
+2. **Scanner.run()** — `app/jobs/watch_scanner.py:WatchScanner.run` iterates markets `("crypto", "kr", "us")`, calling `scan_market(market)` sequentially.
+3. **Per-watch loop** — `scan_market` enumerates `WatchAlertService.get_watches_for_market`, then for each watch calls `_get_current_value` → `_get_price` / `_get_rsi` / `_get_trade_value` / `_get_index_price` / `_get_fx_price`, all of which delegate to `app/services/market_data.get_quote` / `get_ohlcv`.
+4. **Trigger evaluation** — `_is_triggered(current, operator, threshold)` decides; on hit the watch is added to `triggered`/`intents` lists.
+5. **Delivery** — `_send_alert` builds a UUID `correlation_id`, posts JSON to `OpenClawClient.send_watch_alert_to_n8n`, which POSTs `{alert_type, correlation_id, as_of, market, triggered, intents, message}` to `settings.N8N_WATCH_ALERT_WEBHOOK_URL` with up to 4 attempts (1 + 3 retries, 1→2→4 s exponential). The `_send_alert` wrapper also catches all exceptions and converts them to `WatchAlertDeliveryResult(status="failed", reason="request_failed")`.
+6. **Removal** — On `status == "success"`, each triggered field is removed via `WatchAlertService.trigger_and_remove`. On non-success, watches are kept for the next cycle.
+7. **Receiver** — `n8n/workflows/paperclip-watch-alert.json` validates, dedupes (6 h cooldown), branches by market, posts to Discord, then writes `sentMap` only on Discord success (ROB-178 hardening).
+
+### 1.2 Failure modes
+
+| # | Symptom | Root cause | Where it surfaces |
+|---|---------|------------|-------------------|
+| **A** | One Yahoo/yfinance failure aborts the entire scan task — including unrelated crypto/kr watches still in queue. | `app/jobs/watch_scanner.py:_get_price` for `market == "us"` raises `RuntimeError("US watch price fetch failed for ... invalid close")` when `market_data.get_quote` returns no close, and `market_data.get_quote(equity_us, …)` itself raises `SymbolNotFoundError`. The exception escapes the `for watch in watches:` loop in `scan_market`, escapes `scan_market`, and escapes `run()`. Whichever markets had not yet been scanned are silently skipped. | `tests/test_watch_scanner.py::test_get_price_us_raises_when_yahoo_fails` documents the current raise contract. |
+| **B** | RSI / trade-value / OHLCV transient failures abort the scan with the same blast radius as **A**. | `_get_rsi` and `_get_trade_value` use `market_data_service.get_ohlcv` / `get_quote` and propagate raw exceptions. | Same loop, same lack of per-watch boundary. |
+| **C** | n8n outage or Discord persistent 5xx silently drops the alert until the operator notices missing Discord notifications. | Delivery is single-receiver. `_send_alert` returns `failed` and watches are kept, but if Sentry/log review is delayed the operator has no proactive signal. | `OpenClawClient.send_watch_alert_to_n8n` retry exhaustion. (Out of scope for Phase 0; tracked for Phase 1.) |
+| **D** | Naming lock-in: env var `N8N_WATCH_ALERT_WEBHOOK_URL` and method `send_watch_alert_to_n8n` make the receiver swap a code change instead of a config change. | The seam is named after the implementation, not the role. | `app/core/config.py:351`, `app/services/openclaw_client.py:381`, `tests/test_openclaw_client.py`. |
+
+The fix for **A**/**B** is a per-watch try/except boundary inside `scan_market` so a single symbol's lookup failure becomes a counted, logged event and the loop continues. The fix for **D** is to introduce `WATCH_ALERT_ROUTER_URL` (preferred), fall back to `N8N_WATCH_ALERT_WEBHOOK_URL` (back-compat), and rename the client method to a transport-neutral name. **C** is addressed in Phase 1 by the Prefect-side receiver, which can fan out to alternative sinks (Telegram already mirrored elsewhere) and emit its own observability.
+
+---
+
+## 2. Initial router transport choice
+
+We pick **Option 1: webhook receiver** for the eventual Prefect-side router.
+
+### Tradeoff matrix
+
+| Option | Latency from trigger to Discord | Auto-trader code surface | Operability / rollback | Fits "Hermes is follow-up only" | Verdict |
+|---|---|---|---|---|---|
+| **(1) Webhook receiver** (Prefect-side FastAPI/Prefect-webhook-trigger HTTP endpoint mirroring the n8n contract). | < 1 s, equivalent to n8n today. | One env-var flip to point `WATCH_ALERT_ROUTER_URL` at it; client/method rename only. | Operator can roll back to n8n by re-pointing the env var to `N8N_WATCH_ALERT_WEBHOOK_URL` and re-deploying. | Yes — receiver returns 200 immediately after Discord; Hermes is a separate flow spawned async. | **Chosen.** |
+| **(2) DB outbox polling** (auto_trader writes pending alerts to Postgres; Prefect polls and dispatches). | Bounded by poll interval; ≥ 5 s realistic; loses the "immediate" property. | New `watch_alert_outbox` table, migration, writer, reconciliation. | Highest durability but the largest change set — Postgres schema changes are also the highest-blast-radius rollbacks. | Yes, but the latency cost is real. | Rejected — overkill for current volume; the existing 4-attempt retry + n8n `sentMap` already gives at-least-once with reasonable durability. Revisit only if Phase 1 reveals real durability gaps. |
+| **(3) Direct Prefect deployment run via API** (auto_trader calls `POST /api/deployments/{id}/create_flow_run`). | Cold-start of Prefect deployment run: seconds to tens of seconds. | Auto-trader gains a Prefect API auth dependency and library. | Rollback also requires code changes (HTTP client → Prefect API client switch). | Yes, but per-flow-run overhead is heavy for a 5-min cron. | Rejected — wrong tool for synchronous alerts; correct tool for the *Hermes follow-up* flow in Phase 2. |
+
+### Migration path
+
+- **Phase 0 (this plan, this PR)** — Resilience fix in auto_trader + rename seam to `WATCH_ALERT_ROUTER_URL` with `N8N_WATCH_ALERT_WEBHOOK_URL` as fallback. n8n workflow stays the active receiver. **No Prefect repo changes.**
+- **Phase 1 (follow-up PR, NOT in this plan's scope)** — `~/services/prefect` adds a webhook receiver flow + handler that consumes the same JSON contract and forwards to Discord. Operator points `WATCH_ALERT_ROUTER_URL` at it; n8n stays warm as a fallback. Verified for ≥ 2 weeks against the n8n side-by-side via Discord comparison. The receiver layout sketch (for reference, do **not** create in this PR):
+  - `~/services/prefect/flows/auto_trader/watch_alert_router.py` — new `@flow` + FastAPI/HTTP receiver entrypoint.
+  - `~/services/prefect/src/robin_automation/watch_alert_router.py` — validation/dedupe/Discord forward (mirrors `paperclip-watch-alert.json` JS).
+  - `~/services/prefect/tests/test_watch_alert_router.py`.
+  - Optional `launchd` plist for the receiver process.
+- **Phase 2 (follow-up PR)** — Hermes async follow-up flow spawned from inside the Prefect receiver after Discord is sent. Auto-trader still untouched.
+- **Phase 3 (cleanup PR)** — Once Phase 1 is stable for ≥ 2 weeks, decommission `paperclip-watch-alert.json` and drop the `N8N_WATCH_ALERT_WEBHOOK_URL` fallback. Out of scope here.
+
+---
+
+## 3. Files to change in this PR (Phase 0)
+
+### 3.1 auto_trader (in scope)
+
+- **Modify** `app/core/config.py` — add `WATCH_ALERT_ROUTER_URL: str = ""` next to `N8N_WATCH_ALERT_WEBHOOK_URL`. Both fields kept; resolution helper lives in `openclaw_client.py`.
+- **Modify** `app/services/openclaw_client.py` — rename `send_watch_alert_to_n8n` → `send_watch_alert_to_router`; introduce private `_resolve_watch_alert_url()` that returns `WATCH_ALERT_ROUTER_URL` if non-empty, else `N8N_WATCH_ALERT_WEBHOOK_URL`. Update all log strings from `"N8N watch alert ..."` to `"Watch alert router ..."` so log breadcrumbs reflect the new naming. Adjust the `request_failed` reason code on the 0-URL skip to `router_not_configured` (was `n8n_webhook_not_configured`).
+- **Modify** `app/jobs/watch_scanner.py` —
+  1. Update `_send_alert` to call `send_watch_alert_to_router`.
+  2. Wrap the per-watch evaluation block (everything from `_get_current_value` through `policy`/`emission`) in `try/except Exception` so a single failed lookup is logged + counted but does not abort the loop. Accumulate `failed_lookups: list[dict[str, str]]` and surface a `failed_lookups` count in the per-market result dict for observability. Re-raise nothing.
+  3. Inside the `for market in (...)` loop in `run`, also wrap each `scan_market` call in `try/except Exception`, return a `{"status": "failed", "reason": "scan_aborted"}` per-market entry, and continue with the next market. Belt-and-suspenders so even a non-watch error (e.g. WatchAlertService Redis blip) cannot kill the cron.
+- **Modify** `env.example` — add a `WATCH_ALERT_ROUTER_URL=` line above `N8N_WATCH_ALERT_WEBHOOK_URL=` with a comment that `N8N_WATCH_ALERT_WEBHOOK_URL` is the deprecated fallback.
+
+### 3.2 auto_trader tests (in scope)
+
+- **Modify** `tests/test_openclaw_client.py` —
+  - Rename three tests (`test_send_watch_alert_to_n8n_*`) to `test_send_watch_alert_to_router_*`.
+  - Update method calls and `WATCH_ALERT_ROUTER_URL` env-var references.
+  - Add `test_send_watch_alert_to_router_prefers_router_url_over_legacy` (both set → router wins).
+  - Add `test_send_watch_alert_to_router_falls_back_to_legacy_n8n_url` (only `N8N_WATCH_ALERT_WEBHOOK_URL` set → uses it).
+  - Update the skipped-reason assertion to `router_not_configured`.
+- **Modify** `tests/test_watch_scanner.py` —
+  - Replace `test_get_price_us_raises_when_yahoo_fails` with `test_scan_market_us_yahoo_failure_does_not_abort_other_watches`. (The helper `_get_price` itself may keep raising; the scan loop is what needs to keep going. The new test sets up two `us` watches where the first raises and the second triggers, and asserts the second's alert was sent and the first was reported as a failed lookup but did NOT short-circuit the loop.)
+  - Add `test_run_continues_other_markets_when_scan_market_raises` (defense-in-depth for the `run()` wrapper).
+  - Add `test_scan_market_records_failed_lookups_in_result` (per-market dict contains `failed_lookups` count).
+  - Update `_FakeOpenClawClient.send_watch_alert_to_n8n` → `send_watch_alert_to_router`, adjust `monkeypatch` calls accordingly.
+
+### 3.3 Out of scope for this PR (documented for traceability)
+
+- `~/services/prefect/flows/auto_trader/watch_alert_router.py` — Phase 1.
+- `~/services/prefect/src/robin_automation/watch_alert_router.py` — Phase 1.
+- `~/services/prefect/tests/test_watch_alert_router.py` — Phase 1.
+- `n8n/workflows/paperclip-watch-alert.json` — unchanged in Phase 0; decommissioned in Phase 3.
+- `tests/test_n8n_watch_alert_workflow.py` — unchanged in Phase 0; deleted in Phase 3.
+- `app/tasks/watch_scan_tasks.py` cron — unchanged. Scheduler change is an explicit non-goal.
+
+---
+
+## 4. Minimum safe deliverable
+
+**Phase 0 = this PR**, which is independently shippable and delivers the reliability fix (the actual user-visible bug) without depending on the Prefect router being online. Concretely the MSD is:
+
+1. The per-watch `try/except` boundary in `scan_market` (fixes the **A/B** failure modes).
+2. The `run()`-level `try/except` boundary (defense in depth).
+3. The `WATCH_ALERT_ROUTER_URL` env var + `_resolve_watch_alert_url` helper with fallback to `N8N_WATCH_ALERT_WEBHOOK_URL`.
+4. The `send_watch_alert_to_n8n` → `send_watch_alert_to_router` rename and log-string update.
+5. Test updates above.
+
+If even this PR is too large for one review, the smaller MSD-of-MSD is **just (1)+(2)+test changes** — leave the rename for a second PR. The router rename is a non-functional change and can ride alone safely once the resilience fix is in.
+
+---
+
+## 5. Non-goals and hard stops
+
+This PR MUST NOT:
+
+- Place or modify any live, paper, or mock orders. **No `dry_run=False`.** Watch scanner does not directly place orders, and the `WatchOrderIntentService.emit_intent` path is left exactly as-is — the only change near it is the surrounding try/except, which preserves its current return semantics.
+- Mutate any broker/order/Alpaca/KIS/Upbit endpoint. The `OpenClawClient` method-rename touches *only* the watch-alert delivery seam; `send_fill_notification`, `request_analysis`, `send_scan_alert`, and `send_watch_alert` (deprecated) are left alone.
+- Change any watch threshold, condition, dedupe window, or `WatchAlertService` schema.
+- Print or log any secret, token, DSN, API key, or Redis password. Test fixtures use placeholder URLs (e.g. `http://127.0.0.1:5678/webhook/watch-alert`). Operator env files are not read or written by this plan.
+- Touch the taskiq cron schedule (`*/5 * * * *` Asia/Seoul) in `app/tasks/watch_scan_tasks.py`. Scheduler changes are explicitly out of scope.
+- Add a Prefect dependency to `auto_trader`. The Prefect-side receiver is a follow-up PR in `~/services/prefect`.
+- Modify `n8n/workflows/paperclip-watch-alert.json` or its tests. The receiver is unchanged in Phase 0.
+- Introduce backward-compat shims beyond the documented `N8N_WATCH_ALERT_WEBHOOK_URL` fallback. No re-export aliases for the old method name; just rename and update callers/tests in one go (per CLAUDE.md "avoid backwards-compatibility hacks").
+
+---
+
+## 6. TDD step-by-step implementation
+
+Branch: `feature/ROB-122-watch-alert-router`. Use the active Kanban/AoE workspace if one is already assigned. If creating a fresh local worktree manually, use the canonical repo paths below.
+
+### Setup
+
+- [ ] **Step 0.1: Create the worktree**
+
+```bash
+cd /Users/mgh3326/work/auto_trader && git switch main && git pull
+git worktree add /Users/mgh3326/work/auto_trader-worktrees/feature-ROB-122-watch-alert-router -b feature/ROB-122-watch-alert-router main
+cd /Users/mgh3326/work/auto_trader-worktrees/feature-ROB-122-watch-alert-router
+uv sync --all-groups
+```
+
+Expected: worktree exists; `uv sync` succeeds.
+
+- [ ] **Step 0.2: Establish baseline test pass**
+
+Run: `uv run pytest tests/test_watch_scanner.py tests/test_openclaw_client.py tests/test_watch_alerts.py tests/test_mcp_watch_alerts.py tests/test_watch_scan_tasks.py -v`
+
+Expected: all green on `main`. Record the count for comparison.
+
+### Task 1: Per-watch resilience in `scan_market`
+
+**Files:**
+- Modify: `app/jobs/watch_scanner.py`
+- Test: `tests/test_watch_scanner.py`
+
+- [ ] **Step 1.1: Write the failing test for per-watch resilience**
+
+Append to `tests/test_watch_scanner.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_scan_market_us_yahoo_failure_does_not_abort_other_watches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = WatchScanner()
+    scanner._watch_service = _FakeWatchService()
+    scanner._watch_service._rows_by_market["us"] = [
+        {
+            "target_kind": "asset",
+            "symbol": "BADTKR",
+            "condition_type": "price_below",
+            "threshold": 100.0,
+            "field": "asset:BADTKR:price_below:100",
+        },
+        {
+            "target_kind": "asset",
+            "symbol": "AAPL",
+            "condition_type": "price_below",
+            "threshold": 200.0,
+            "field": "asset:AAPL:price_below:200",
+        },
+    ]
+    scanner._openclaw = _FakeOpenClawClient(status="success")
+
+    monkeypatch.setattr(scanner, "_is_market_open", lambda market: True)
+
+    async def _price_side_effect(symbol: str, market: str) -> float:
+        if symbol == "BADTKR":
+            raise RuntimeError("US watch price fetch failed for BADTKR: invalid close")
+        return 150.0
+
+    monkeypatch.setattr(scanner, "_get_price", AsyncMock(side_effect=_price_side_effect))
+
+    result = await scanner.scan_market("us")
+
+    assert result["alerts_sent"] == 1
+    assert result["status"] == "success"
+    assert result.get("failed_lookups") == 1
+    assert scanner._watch_service.removed_fields == [
+        ("us", "asset:AAPL:price_below:200"),
+    ]
+```
+
+- [ ] **Step 1.2: Run the new test and confirm it fails**
+
+Run: `uv run pytest tests/test_watch_scanner.py::test_scan_market_us_yahoo_failure_does_not_abort_other_watches -v`
+
+Expected: FAIL — `RuntimeError("US watch price fetch failed for BADTKR ...")` propagates out of `scan_market`.
+
+- [ ] **Step 1.3: Implement the per-watch try/except**
+
+In `app/jobs/watch_scanner.py:scan_market`, inside the `for watch in watches:` loop, wrap the work from `target_kind = ...` through the end of the loop body in `try/except Exception`. On exception, log a warning with `symbol`, `market`, and the exception, increment a local `failed_lookups` counter, and `continue`. After the loop, surface `failed_lookups` in every return dict (including the `success`, `skipped`, and `failed` branches). Sketch:
+
+```python
+async def scan_market(self, market: str) -> dict[str, object]:
+    normalized_market = str(market).strip().lower()
+    market_open = self._is_market_open(normalized_market)
+
+    watches = await self._watch_service.get_watches_for_market(normalized_market)
+    if not watches:
+        # ... unchanged early-return branches; add failed_lookups=0 to each ...
+
+    triggered: list[dict[str, object]] = []
+    intents: list[dict[str, object]] = []
+    triggered_fields: list[str] = []
+    failed_lookups = 0
+    kst_date = now_kst().date().isoformat()
+
+    for watch in watches:
+        try:
+            # ... existing per-watch body, unchanged ...
+        except Exception as exc:
+            logger.warning(
+                "Watch lookup failed (continuing): market=%s symbol=%s error=%s",
+                normalized_market,
+                str(watch.get("symbol") or "").strip().upper(),
+                exc,
+            )
+            failed_lookups += 1
+            continue
+
+    if not triggered and not intents:
+        # ... existing early-return; include failed_lookups in dict ...
+
+    # ... existing send_alert + return; include failed_lookups in success and failed dicts ...
+```
+
+Every return dict from `scan_market` MUST include the key `"failed_lookups"` (int).
+
+- [ ] **Step 1.4: Run the new test and confirm it passes**
+
+Run: `uv run pytest tests/test_watch_scanner.py::test_scan_market_us_yahoo_failure_does_not_abort_other_watches -v`
+
+Expected: PASS.
+
+- [ ] **Step 1.5: Re-run the full watch scanner suite to catch regressions**
+
+Run: `uv run pytest tests/test_watch_scanner.py -v`
+
+Expected: every test from step 0.2 still passes. Two existing tests will likely break because they assert `result["reason"] == "no_triggered_alerts"` etc. without `failed_lookups`; those need a one-line update to add `result["failed_lookups"] == 0`. Update only those tests; do not change behavior under test.
+
+- [ ] **Step 1.6: Replace the deprecated raise-contract test**
+
+Remove `test_get_price_us_raises_when_yahoo_fails` (the helper-level raise contract is no longer load-bearing). The helper may still raise; that is fine because the scanner now catches. We only assert behavior at the public boundary (`scan_market`).
+
+- [ ] **Step 1.7: Commit**
+
+```bash
+git add app/jobs/watch_scanner.py tests/test_watch_scanner.py
+git commit -m "$(cat <<'EOF'
+fix(ROB-122): isolate watch lookup failures per-symbol in scan_market
+
+Yahoo/yfinance failures on a single US watch were aborting scan.watch_alerts
+entirely, silently dropping unrelated crypto/kr triggers. Wrap per-watch
+evaluation in try/except, count failed_lookups, continue the loop.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+EOF
+)"
+```
+
+### Task 2: Defense-in-depth wrapper around `scan_market` calls in `run()`
+
+**Files:**
+- Modify: `app/jobs/watch_scanner.py`
+- Test: `tests/test_watch_scanner.py`
+
+- [ ] **Step 2.1: Write the failing test for `run()` resilience**
+
+Append:
+
+```python
+@pytest.mark.asyncio
+async def test_run_continues_other_markets_when_scan_market_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = WatchScanner()
+    scanner._watch_service = _FakeWatchService(rows=[])
+    scanner._openclaw = _FakeOpenClawClient(status="success")
+
+    original_scan_market = scanner.scan_market
+
+    async def _scan_market(market: str) -> dict[str, object]:
+        if market == "us":
+            raise RuntimeError("simulated unexpected scanner error")
+        return await original_scan_market(market)
+
+    monkeypatch.setattr(scanner, "scan_market", _scan_market)
+    monkeypatch.setattr(scanner, "_is_market_open", lambda market: True)
+    monkeypatch.setattr(scanner, "_get_price", AsyncMock(return_value=None))
+
+    result = await scanner.run()
+
+    assert set(result.keys()) == {"crypto", "kr", "us"}
+    assert result["us"]["status"] == "failed"
+    assert result["us"]["reason"] == "scan_aborted"
+    assert result["crypto"]["alerts_sent"] == 0
+    assert result["kr"]["alerts_sent"] == 0
+```
+
+- [ ] **Step 2.2: Run and confirm failure**
+
+Run: `uv run pytest tests/test_watch_scanner.py::test_run_continues_other_markets_when_scan_market_raises -v`
+
+Expected: FAIL — `RuntimeError` escapes `run()`.
+
+- [ ] **Step 2.3: Implement the `run()` wrapper**
+
+```python
+async def run(self) -> dict[str, dict[str, object]]:
+    results: dict[str, dict[str, object]] = {}
+    for market in ("crypto", "kr", "us"):
+        try:
+            market_result = await self.scan_market(market)
+        except Exception as exc:
+            logger.error(
+                "scan_market raised unexpectedly: market=%s error=%s",
+                market,
+                exc,
+            )
+            market_result = {
+                "market": market,
+                "status": "failed",
+                "reason": "scan_aborted",
+                "alerts_sent": 0,
+                "details": [],
+                "failed_lookups": 0,
+            }
+        results[market] = dict(market_result)
+    return results
+```
+
+- [ ] **Step 2.4: Confirm pass**
+
+Run: `uv run pytest tests/test_watch_scanner.py -v`
+
+Expected: all green.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add app/jobs/watch_scanner.py tests/test_watch_scanner.py
+git commit -m "$(cat <<'EOF'
+fix(ROB-122): trap unexpected scan_market errors in WatchScanner.run
+
+Defense-in-depth: even if scan_market raises (Redis blip, watch service
+failure, etc.), surface the failure as one market entry and keep the
+remaining markets running.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+EOF
+)"
+```
+
+### Task 3: Add `WATCH_ALERT_ROUTER_URL` config
+
+**Files:**
+- Modify: `app/core/config.py`
+- Modify: `env.example`
+- Test: covered by Task 4 OpenClaw tests.
+
+- [ ] **Step 3.1: Add the setting**
+
+In `app/core/config.py`, near the existing `N8N_WATCH_ALERT_WEBHOOK_URL: str = ""` line:
+
+```python
+    # Watch Alert router (Phase 0 of ROB-122 — transport-neutral seam).
+    # When set, takes precedence over N8N_WATCH_ALERT_WEBHOOK_URL.
+    # N8N_WATCH_ALERT_WEBHOOK_URL is the deprecated backward-compat fallback.
+    WATCH_ALERT_ROUTER_URL: str = ""
+    # N8N Watch Alert webhook (deprecated fallback for WATCH_ALERT_ROUTER_URL).
+    N8N_WATCH_ALERT_WEBHOOK_URL: str = ""
+```
+
+- [ ] **Step 3.2: Update `env.example`**
+
+In `env.example`, replace the existing `N8N_WATCH_ALERT_WEBHOOK_URL=` block with:
+
+```bash
+# Watch Alert Router URL (transport-neutral seam, ROB-122).
+# 예시: http://127.0.0.1:5678/webhook/watch-alert  또는  Prefect 라우터 URL
+WATCH_ALERT_ROUTER_URL=
+# Deprecated fallback when WATCH_ALERT_ROUTER_URL is unset.
+N8N_WATCH_ALERT_WEBHOOK_URL=
+```
+
+- [ ] **Step 3.3: Sanity-run the settings load**
+
+Run: `uv run python -c "from app.core.config import settings; print('router=', repr(settings.WATCH_ALERT_ROUTER_URL), ' legacy=', repr(settings.N8N_WATCH_ALERT_WEBHOOK_URL))"`
+
+Expected: both print as empty strings (or whatever is in `.env`). **Do not echo any other settings.** If the operator's `.env` happens to have a non-empty value, treat the displayed value as `[REDACTED]` when discussing it.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add app/core/config.py env.example
+git commit -m "$(cat <<'EOF'
+feat(ROB-122): add WATCH_ALERT_ROUTER_URL with N8N_WATCH_ALERT_WEBHOOK_URL fallback
+
+Introduces a transport-neutral router seam so the watch alert receiver can be
+swapped (n8n today, Prefect-side webhook receiver in a follow-up) by env var
+alone. Backward-compatible: empty router URL falls through to the legacy n8n
+URL.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+EOF
+)"
+```
+
+### Task 4: Rename `send_watch_alert_to_n8n` → `send_watch_alert_to_router`
+
+**Files:**
+- Modify: `app/services/openclaw_client.py`
+- Modify: `app/jobs/watch_scanner.py`
+- Test: `tests/test_openclaw_client.py`
+- Test: `tests/test_watch_scanner.py`
+
+- [ ] **Step 4.1: Write failing tests for router URL resolution**
+
+Add to `tests/test_openclaw_client.py` (next to the existing watch alert tests):
+
+```python
+@pytest.mark.asyncio
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_watch_alert_to_router_prefers_router_url_over_legacy(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        settings,
+        "WATCH_ALERT_ROUTER_URL",
+        "http://127.0.0.1:9999/router/watch-alert",
+    )
+    monkeypatch.setattr(
+        settings,
+        "N8N_WATCH_ALERT_WEBHOOK_URL",
+        "http://127.0.0.1:5678/webhook/watch-alert",
+    )
+
+    mock_cli = AsyncMock()
+    mock_res = MagicMock(status_code=200)
+    mock_res.raise_for_status.return_value = None
+    mock_cli.post.return_value = mock_res
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    result = await OpenClawClient().send_watch_alert_to_router(
+        message="m",
+        market="kr",
+        triggered=[{"symbol": "X", "condition_type": "price_below"}],
+        as_of="2026-04-17T00:00:00Z",
+        correlation_id="corr-prefer-router",
+    )
+
+    assert result.status == "success"
+    assert mock_cli.post.call_args.args[0] == "http://127.0.0.1:9999/router/watch-alert"
+
+
+@pytest.mark.asyncio
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_watch_alert_to_router_falls_back_to_legacy_n8n_url(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "WATCH_ALERT_ROUTER_URL", "")
+    monkeypatch.setattr(
+        settings,
+        "N8N_WATCH_ALERT_WEBHOOK_URL",
+        "http://127.0.0.1:5678/webhook/watch-alert",
+    )
+
+    mock_cli = AsyncMock()
+    mock_res = MagicMock(status_code=200)
+    mock_res.raise_for_status.return_value = None
+    mock_cli.post.return_value = mock_res
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    result = await OpenClawClient().send_watch_alert_to_router(
+        message="m",
+        market="kr",
+        triggered=[{"symbol": "X", "condition_type": "price_below"}],
+        as_of="2026-04-17T00:00:00Z",
+        correlation_id="corr-fallback",
+    )
+
+    assert result.status == "success"
+    assert mock_cli.post.call_args.args[0] == "http://127.0.0.1:5678/webhook/watch-alert"
+
+
+@pytest.mark.asyncio
+async def test_send_watch_alert_to_router_skips_when_no_url_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "WATCH_ALERT_ROUTER_URL", "")
+    monkeypatch.setattr(settings, "N8N_WATCH_ALERT_WEBHOOK_URL", "")
+
+    result = await OpenClawClient().send_watch_alert_to_router(
+        message="m",
+        market="crypto",
+        triggered=[{"symbol": "BTC", "condition_type": "price_above"}],
+        as_of="2026-04-17T00:00:00Z",
+        correlation_id="corr-skip",
+    )
+
+    assert result.status == "skipped"
+    assert result.reason == "router_not_configured"
+```
+
+Also rename the three existing `test_send_watch_alert_to_n8n_*` tests to `test_send_watch_alert_to_router_*`, switch them to set `WATCH_ALERT_ROUTER_URL` (not `N8N_WATCH_ALERT_WEBHOOK_URL`), call `send_watch_alert_to_router`, and update the skipped reason assertion from `n8n_webhook_not_configured` to `router_not_configured`.
+
+- [ ] **Step 4.2: Run and confirm failure**
+
+Run: `uv run pytest tests/test_openclaw_client.py -v -k "watch_alert_to_router"`
+
+Expected: every new test FAILs because `send_watch_alert_to_router` does not exist yet.
+
+- [ ] **Step 4.3: Implement the rename**
+
+In `app/services/openclaw_client.py`:
+
+```python
+def _resolve_watch_alert_url() -> str:
+    """Resolve the watch-alert router URL.
+
+    WATCH_ALERT_ROUTER_URL wins when set; otherwise falls through to the
+    deprecated N8N_WATCH_ALERT_WEBHOOK_URL for backward compatibility.
+    """
+    router = settings.WATCH_ALERT_ROUTER_URL.strip()
+    if router:
+        return router
+    return settings.N8N_WATCH_ALERT_WEBHOOK_URL.strip()
+```
+
+Rename `send_watch_alert_to_n8n` to `send_watch_alert_to_router`. Replace the body's URL load (`n8n_webhook_url = settings.N8N_WATCH_ALERT_WEBHOOK_URL.strip()`) with `router_url = _resolve_watch_alert_url()`. Replace the skipped-reason `"n8n_webhook_not_configured"` with `"router_not_configured"`. Replace all `"N8N watch alert ..."` log strings with `"Watch alert router ..."`.
+
+- [ ] **Step 4.4: Update the only caller**
+
+In `app/jobs/watch_scanner.py:_send_alert`, change `self._openclaw.send_watch_alert_to_n8n(...)` to `self._openclaw.send_watch_alert_to_router(...)`.
+
+In `tests/test_watch_scanner.py`, rename `_FakeOpenClawClient.send_watch_alert_to_n8n` to `send_watch_alert_to_router`. Update any `monkeypatch.setattr(scanner._openclaw, "send_watch_alert_to_n8n", ...)` to use `send_watch_alert_to_router`. Update assertions that check `result["reason"] == "n8n_webhook_not_configured"` to `"router_not_configured"`.
+
+- [ ] **Step 4.5: Run the full suite**
+
+Run: `uv run pytest tests/test_openclaw_client.py tests/test_watch_scanner.py tests/test_watch_alerts.py tests/test_mcp_watch_alerts.py tests/test_watch_scan_tasks.py -v`
+
+Expected: all green.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add app/services/openclaw_client.py app/jobs/watch_scanner.py tests/test_openclaw_client.py tests/test_watch_scanner.py
+git commit -m "$(cat <<'EOF'
+refactor(ROB-122): rename send_watch_alert_to_n8n -> send_watch_alert_to_router
+
+Transport-neutral seam. Resolves URL from WATCH_ALERT_ROUTER_URL first, then
+N8N_WATCH_ALERT_WEBHOOK_URL for backward compatibility. Skipped reason renamed
+to router_not_configured. Log strings updated.
+
+Co-Authored-By: Paperclip <noreply@paperclip.ing>
+EOF
+)"
+```
+
+### Task 5: Final guardrails
+
+- [ ] **Step 5.1: Verify nothing else imports the old name**
+
+Run: `rg "send_watch_alert_to_n8n|n8n_webhook_not_configured" app tests`
+
+Expected: zero hits. If there are stragglers, fix them and add to the previous commit (or amend if not yet pushed).
+
+- [ ] **Step 5.2: Lint + typecheck**
+
+Run: `make lint && make typecheck`
+
+Expected: green.
+
+- [ ] **Step 5.3: Full watch-related test suite**
+
+Run: `uv run pytest tests/test_watch_scanner.py tests/test_openclaw_client.py tests/test_watch_alerts.py tests/test_mcp_watch_alerts.py tests/test_watch_scan_tasks.py tests/test_n8n_watch_alert_workflow.py -v`
+
+Expected: all green. The n8n workflow test is unchanged in this PR and must still pass since the JSON contract `OpenClawClient` posts is identical.
+
+- [ ] **Step 5.4: Push and open PR**
+
+```bash
+git push -u origin feature/ROB-122-watch-alert-router
+gh pr create --base main --title "fix(ROB-122): resilient watch alerts + WATCH_ALERT_ROUTER_URL seam" --body "..."
+```
+
+---
+
+## 7. Smoke / rollback / observability
+
+### 7.1 Pre-merge smoke (local, no live order paths)
+
+1. **Unit + integration tests** — `uv run pytest tests/test_watch_scanner.py tests/test_openclaw_client.py tests/test_watch_alerts.py tests/test_mcp_watch_alerts.py tests/test_watch_scan_tasks.py tests/test_n8n_watch_alert_workflow.py -v`. Expect all green.
+2. **Settings load** — `uv run python -c "from app.core.config import settings; assert hasattr(settings, 'WATCH_ALERT_ROUTER_URL'); print('OK')"`. Expect `OK`. Do not print any actual URL values.
+3. **Manual scan dry-run** (operator only, in a non-prod shell) — temporarily set `WATCH_ALERT_ROUTER_URL` to a local httpbin (`http://127.0.0.1:8080/post`) and run `uv run python -c "import asyncio; from app.jobs.watch_scanner import WatchScanner; print(asyncio.run(WatchScanner().run()))"` against a Redis with a single dummy watch. Confirm the request reaches httpbin with the expected JSON contract. Confirm crypto/kr/us all return dicts with `failed_lookups` keys. Tear down the test watch via the manage_watch_alerts MCP tool. **Do not** test against production Redis or production Discord.
+
+### 7.2 Post-merge smoke (operator)
+
+1. Deploy with `WATCH_ALERT_ROUTER_URL` empty so the deprecated `N8N_WATCH_ALERT_WEBHOOK_URL` fallback path is exercised. Confirm the next 5-min `scan.watch_alerts` cron tick logs `"Watch alert router send start"` (new log line) and that Discord still receives alerts unchanged.
+2. After the second successful tick, confirm Sentry / log dashboard for any `failed_lookups` warnings — if a US Yahoo failure occurs, the warning must appear without `scan_market` aborting.
+
+### 7.3 Rollback
+
+Pure code rollback: `git revert <merge-sha>`. No DB migration, no schema change, no infra change — single revert is sufficient.
+
+Operationally, rollback at the env-var layer is also free: if a future Phase 1 cutover misbehaves, the operator simply unsets `WATCH_ALERT_ROUTER_URL` and the code falls back to `N8N_WATCH_ALERT_WEBHOOK_URL` automatically on the next scan — no redeploy required.
+
+### 7.4 Observability hooks (already covered, no new code in Phase 0)
+
+- `logger.warning("Watch lookup failed (continuing): market=%s symbol=%s error=%s", ...)` — emitted per failed lookup. Surfaces in existing log infra and Sentry breadcrumbs.
+- `logger.info("Watch alert router send start: ... attempt=%s", ...)` — emitted on each delivery attempt.
+- `logger.info("Watch alert router sent: ... status=%s", ...)` — emitted on success.
+- `logger.error("Watch alert router failed after retries: ...", ...)` — emitted on retry exhaustion.
+- Per-market result dicts now include `failed_lookups` integer; surface this in Phase 1 dashboards.
+- Existing Sentry config (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`) is unchanged — uncaught exceptions in `run()` are now caught and converted to a per-market failure dict, but the underlying log line is still ERROR-level.
+
+---
+
+## 8. Acceptance criteria
+
+A reviewer should be able to confirm all of the following before approving:
+
+1. `tests/test_watch_scanner.py::test_scan_market_us_yahoo_failure_does_not_abort_other_watches` exists, passes, and asserts that **two watches** are evaluated even when the first raises.
+2. `tests/test_watch_scanner.py::test_run_continues_other_markets_when_scan_market_raises` exists and passes.
+3. `WatchScanner.scan_market` returns a dict that always contains a `failed_lookups: int` key, and `WatchScanner.run` returns `{"crypto": ..., "kr": ..., "us": ...}` even when individual markets fail.
+4. `app/core/config.py` defines `WATCH_ALERT_ROUTER_URL: str = ""` and keeps `N8N_WATCH_ALERT_WEBHOOK_URL: str = ""`.
+5. `OpenClawClient.send_watch_alert_to_router` exists; `send_watch_alert_to_n8n` does **not**. URL resolution prefers `WATCH_ALERT_ROUTER_URL`.
+6. `tests/test_openclaw_client.py` includes `test_send_watch_alert_to_router_prefers_router_url_over_legacy`, `test_send_watch_alert_to_router_falls_back_to_legacy_n8n_url`, and `test_send_watch_alert_to_router_skips_when_no_url_configured`, all passing.
+7. `rg "send_watch_alert_to_n8n|n8n_webhook_not_configured" app tests` returns zero results.
+8. `tests/test_n8n_watch_alert_workflow.py` is unchanged and still passes (proves the JSON contract on the wire is byte-compatible).
+9. `app/tasks/watch_scan_tasks.py` is unchanged (no scheduler change).
+10. `make lint && make typecheck && uv run pytest tests/test_watch_scanner.py tests/test_openclaw_client.py tests/test_watch_alerts.py tests/test_mcp_watch_alerts.py tests/test_watch_scan_tasks.py tests/test_n8n_watch_alert_workflow.py` all green.
+11. PR description explicitly calls out non-goals (no Prefect changes in this PR; no order side effects; no scheduler change).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** every numbered item in the planner prompt has a section above. (1) §1, (2) §2, (3) §3, (4) §4, (5) §5, (6) §6, (7) §7, (8) this file is at the requested path.
+- **Placeholders:** none — every step has either exact code, an exact command, or an exact file diff target.
+- **Type consistency:** `failed_lookups` is `int` everywhere it appears; `WatchAlertDeliveryResult` field names are unchanged; the renamed method keeps the same kwarg signature as the original (`message`, `market`, `triggered`, `as_of`, `correlation_id`, `intents`).
+- **Hard stops verified:** no live/paper/mock order calls anywhere in the diff; no schema migrations; no scheduler change; n8n workflow JSON untouched; all test URLs are loopback placeholders.

--- a/docs/plans/ROB-122-watch-alert-router-review.md
+++ b/docs/plans/ROB-122-watch-alert-router-review.md
@@ -1,0 +1,123 @@
+# ROB-122 Watch Alert Router — Reviewer Report (Phase 0)
+
+- **Reviewer:** Claude Code Opus (independent reviewer)
+- **Branch:** `feature/ROB-122-watch-alert-router`
+- **Implementer commit:** `9ecb64b0` — `fix(ROB-122): isolate watch alert failures and add router seam`
+- **Base:** `main` @ `67434624`
+- **Verdict:** **PASS**
+
+---
+
+## 1. Acceptance criteria coverage
+
+| AC | Status | Evidence |
+|---|---|---|
+| US watch scan continues after quote lookup failures | ✅ | `app/jobs/watch_scanner.py:324-409` wraps the entire per-watch evaluation in `try/except Exception`, increments a `failed_lookups` counter, logs at WARNING, and `continue`s. `app/jobs/watch_scanner.py:466-485` adds a defense-in-depth `try/except` around `scan_market(market)` inside `run()` so any unexpected error in one market produces a `{"status": "failed", "reason": "scan_aborted"}` entry and the next market still runs. Tests `test_scan_market_us_yahoo_failure_does_not_abort_other_watches`, `test_run_continues_other_markets_when_scan_market_raises`, `test_scan_market_records_failed_lookups_in_result` exercise both layers. |
+| `WATCH_ALERT_ROUTER_URL` with backward-compat fallback to `N8N_WATCH_ALERT_WEBHOOK_URL` | ✅ | `app/services/openclaw_client.py:125-134` (`_resolve_watch_alert_url`) prefers `WATCH_ALERT_ROUTER_URL` and falls back to `N8N_WATCH_ALERT_WEBHOOK_URL`. `app/core/config.py:347-355` declares both fields with `""` defaults; `env.example:122-127` documents them with the legacy var marked deprecated. Tests `test_send_watch_alert_to_router_prefers_router_url_over_legacy` and `test_send_watch_alert_to_router_falls_back_to_legacy_n8n_url` lock in the precedence. |
+| Production/staging configurable for new route without n8n | ✅ | The router URL is a free-form HTTP endpoint; the receiver is implementation-neutral. Operator can point `WATCH_ALERT_ROUTER_URL` at any service that accepts the documented JSON contract (`{alert_type, correlation_id, as_of, market, triggered, intents, message}`). |
+| Prefect receives/routes synthetic event OR documented Phase 0 stop | ✅ | Plan §2.50–§2.59 explicitly scopes this PR to Phase 0 (auto_trader router contract only). Phase 1 Prefect receiver, Phase 2 Hermes follow-up, Phase 3 cleanup are documented as out-of-scope follow-ups in `docs/plans/ROB-122-watch-alert-router-plan.md`. The ROB-122 acceptance criteria summary explicitly permits "Phase 0 may intentionally stop at the auto_trader router contract if clearly documented". |
+| Hermes follow-up optional/config-gated, separated from immediate alert | ✅ | No Hermes/LLM coupling on the synchronous alert path. `OpenClawClient.send_watch_alert_to_router` only POSTs the JSON contract. Plan §2 explicitly relegates Hermes follow-up to Phase 2 inside the Prefect receiver. |
+| Tests cover scanner failure isolation, config fallback, delivery results, payload contract | ✅ | See §2 verification evidence below. |
+| No broker/order mutation; secrets not printed | ✅ | See §4 Safety review. |
+
+---
+
+## 2. Verification evidence
+
+Commands run from the worktree:
+
+```text
+$ git status --short --branch
+## feature/ROB-122-watch-alert-router
+
+$ git diff main...HEAD --stat
+ app/core/config.py                            |   6 +-
+ app/jobs/watch_proximity_monitor.py           |   2 +-
+ app/jobs/watch_scanner.py                     | 172 ++++---
+ app/services/openclaw_client.py               |  38 +-
+ docs/plans/ROB-122-watch-alert-router-plan.md | 673 ++++++++++++++++++++++++++
+ env.example                                   |   6 +-
+ tests/test_openclaw_client.py                 |  95 +++-
+ tests/test_watch_scanner.py                   | 126 ++++-
+ 8 files changed, 1009 insertions(+), 109 deletions(-)
+
+$ uv run pytest tests/test_watch_scanner.py tests/test_openclaw_client.py -q
+... 47 passed, 11 skipped, 2 warnings in 1.94s
+
+$ uv run pytest tests/test_watch_alerts.py tests/test_mcp_watch_alerts.py tests/test_watch_scan_tasks.py -q
+... 18 passed, 2 warnings in 2.90s
+
+$ uv run ruff check app/jobs/watch_scanner.py app/services/openclaw_client.py app/core/config.py app/jobs/watch_proximity_monitor.py tests/test_watch_scanner.py tests/test_openclaw_client.py
+All checks passed!
+
+$ uv run ruff format --check app/jobs/watch_scanner.py app/services/openclaw_client.py app/core/config.py app/jobs/watch_proximity_monitor.py tests/test_watch_scanner.py tests/test_openclaw_client.py
+6 files already formatted
+```
+
+The reviewer did not run live broker/order calls, deploys, schedulers, or the Prefect receiver. Only read-only inspection and unit tests were executed.
+
+### Test meaningfulness audit
+
+- `test_scan_market_us_yahoo_failure_does_not_abort_other_watches` (`tests/test_watch_scanner.py:328-368`) seeds *two* watch rows on `us`, makes the first symbol's `_get_price` raise, asserts the second symbol still triggers (`alerts_sent == 1`, `failed_lookups == 1`) and that *only* the surviving field is removed from the watch service. This is a real isolation test, not a tautology.
+- `test_run_continues_other_markets_when_scan_market_raises` (`tests/test_watch_scanner.py:371-396`) monkeypatches `scan_market` to raise on `us` and asserts `crypto`/`kr` still produced result entries and `us` is reported as `status="failed", reason="scan_aborted"`. Exercises the outer `run()` wrapper directly.
+- `test_scan_market_records_failed_lookups_in_result` (`tests/test_watch_scanner.py:399-441`) asserts the `failed_lookups` counter is surfaced in the per-market dict even when no alert is sent. Good for downstream observability.
+- `test_send_watch_alert_to_router_prefers_router_url_over_legacy` and `test_send_watch_alert_to_router_falls_back_to_legacy_n8n_url` (`tests/test_openclaw_client.py:1335-1408`) assert the exact target URL the HTTP client receives, so the precedence is observable end-to-end and not just a getter unit test.
+- `test_send_watch_alert_to_router_skips_when_no_url_configured` updates the skipped reason from `n8n_webhook_not_configured` to `router_not_configured`, and `tests/test_watch_scanner.py:test_scan_market_keeps_watch_records_when_n8n_delivery_skipped` (kept) confirms the scanner does *not* remove watches on `router_not_configured` skip.
+
+---
+
+## 3. Cross-cutting consistency
+
+- The `OpenClawClient.send_watch_alert_to_n8n` → `send_watch_alert_to_router` rename is fully propagated:
+  - `app/jobs/watch_scanner.py:278`
+  - `app/jobs/watch_proximity_monitor.py:102` (this caller was not listed in the plan §3.1 but had to be updated because of the method rename — correctly done)
+  - `tests/test_watch_scanner.py` `_FakeOpenClawClient.send_watch_alert_to_router`
+  - `tests/test_openclaw_client.py` (4 tests renamed + 2 new tests added)
+  - Deprecated `_send_market_alert(category="watch")` and `send_watch_alert(message)` legacy paths kept untouched as planned; their inline comments now reference `send_watch_alert_to_router`.
+- `grep` confirms zero remaining `send_watch_alert_to_n8n` references in `app/` and `tests/`. Surviving mentions in `docs/superpowers/specs/`, `docs/superpowers/plans/`, `docs/plans/ROB-16-*`, and `n8n/README.md` are historical plans/specs and not load-bearing on runtime behavior.
+
+---
+
+## 4. Safety review
+
+- **Broker/order mutation:** None. Diff is limited to (a) per-watch try/except boundaries, (b) URL resolution helper, (c) HTTP POST seam rename. The `WatchOrderIntentService.emit_intent` path is untouched. No `dry_run=False`, no Alpaca / KIS / Upbit calls, no scheduler edits.
+- **Secrets:** No real secrets in the diff. Tests use placeholder URLs (`http://127.0.0.1:5678/webhook/watch-alert`, `http://127.0.0.1:9999/router/watch-alert`) and obvious placeholder strings (`test-token`, `cb-token`). The router URL is read from settings and only printed in payload-target form during HTTP `post()`; it is never logged. Config docstring and `env.example` describe roles, not values.
+- **Logging:** New log strings (`"Watch alert router send start/sent/failed/error"`) include `correlation_id`, `request_id`, `market`, attempt number, and exception object only — no secret material. The skipped-reason code (`router_not_configured`) is a stable enum, not a URL.
+- **Network:** No new outbound destinations. Behavior with `WATCH_ALERT_ROUTER_URL=""` and `N8N_WATCH_ALERT_WEBHOOK_URL` set is byte-for-byte the legacy n8n path (verified via `test_send_watch_alert_to_router_falls_back_to_legacy_n8n_url` + `test_send_watch_alert_to_router_posts_payload` payload assertion).
+
+---
+
+## 5. Non-blocking notes / risks
+
+These are **not** blockers; they are observations for the implementer / next phase.
+
+1. **`tests/conftest.py:74-76`** sets only `N8N_WATCH_ALERT_WEBHOOK_URL` to `""` for tests; it does not also default `WATCH_ALERT_ROUTER_URL`. In practice the Pydantic field default is `""`, so the test environment behaves correctly today, but adding `"WATCH_ALERT_ROUTER_URL": ""` next to the existing line would make the intent explicit and immune to future env-leak surprises in CI containers. *(Documentation/hygiene only — not a correctness issue.)*
+2. **`app/jobs/watch_scanner.py:401-409`** catches `Exception` per watch. The current scope is correct — it is the user-visible bug fix. As a follow-up, consider also incrementing a metric/counter (Prometheus or otherwise) so a watch silently failing for many cycles is visible without grepping warnings. Could be picked up alongside the Phase 1 receiver work.
+3. **`app/jobs/watch_proximity_monitor.py:102`** was renamed to `send_watch_alert_to_router` correctly even though it was not enumerated in plan §3.1. This is the right decision (mandatory because of the method rename) and the existing proximity monitor tests would have caught a missed rename, but the plan should mention this caller in any retrospective so future readers don't think the rename is incomplete.
+4. **`docs/plans/ROB-122-watch-alert-router-plan.md` line 32** still references "`app/core/config.py:351`, `app/services/openclaw_client.py:381`" — historical line numbers from before this PR's edits. Cosmetic only; the plan is otherwise consistent with the implementation.
+
+---
+
+## 6. Production activation steps requiring explicit operator approval
+
+The following steps are **not** done by this PR and **must** be approved separately before any production rollout:
+
+1. **Set `WATCH_ALERT_ROUTER_URL` in production/staging `.env.prod`.** Until set, the legacy `N8N_WATCH_ALERT_WEBHOOK_URL` fallback continues to deliver to n8n exactly as today. Any cutover to a new receiver is a config change, not a code change — but it is still a config change in a privileged environment.
+2. **Bring the Phase 1 Prefect-side webhook receiver online** before pointing `WATCH_ALERT_ROUTER_URL` at it. Until that receiver exists and has been verified for ≥ 2 weeks of side-by-side delivery against n8n (per plan §2 migration path), the legacy n8n webhook should remain the active receiver.
+3. **Hermes/LLM follow-up flow (Phase 2)** is intentionally out of scope here and requires its own design + approval inside `~/services/prefect`. It must remain async and decoupled from the synchronous alert path.
+4. **Decommission of `paperclip-watch-alert.json` and removal of `N8N_WATCH_ALERT_WEBHOOK_URL`** is Phase 3 and requires explicit approval after Phase 1 stability is demonstrated.
+5. **Scheduler / cron changes** (`app/tasks/watch_scan_tasks.py` 5-min taskiq cron) are explicitly out of scope. Any frequency, deploy, or scheduler activation change requires a separate ticket and approval.
+6. **No broker activation** is implied or enabled by this PR. The watch-order-intent path is unchanged; any move from `dry_run=True` to live order placement is gated elsewhere and remains so.
+
+---
+
+## 7. Final AOE status block
+
+```
+AOE_STATUS: review_passed
+AOE_ISSUE: ROB-122
+AOE_ROLE: reviewer
+AOE_AGENT: claude-code-opus
+AOE_REPORT_PATH: docs/plans/ROB-122-watch-alert-router-review.md
+AOE_NEXT: pr_ci_or_deploy
+```

--- a/env.example
+++ b/env.example
@@ -120,8 +120,10 @@ OPENCLAW_SCREENER_CALLBACK_URL=http://localhost:8000/api/screener/callback
 # n8n에 "Fill Notification" 워크플로우를 생성하면 자동으로 생성되는 URL
 # 예시: http://localhost:5678/webhook/fill-notification
 N8N_FILL_WEBHOOK_URL=
-# n8n Watch Alert Webhook URL (watch alert → n8n-first route)
-# 예시: http://localhost:5678/webhook/watch-alert
+# Watch Alert Router URL (transport-neutral seam, ROB-122).
+# 예시: http://127.0.0.1:5678/webhook/watch-alert  또는  Prefect 라우터 URL
+WATCH_ALERT_ROUTER_URL=
+# Deprecated fallback when WATCH_ALERT_ROUTER_URL is unset.
 N8N_WATCH_ALERT_WEBHOOK_URL=
 
 # ========================================

--- a/tests/test_openclaw_client.py
+++ b/tests/test_openclaw_client.py
@@ -1216,12 +1216,13 @@ async def test_send_watch_alert_success(
 
 
 @pytest.mark.asyncio
-async def test_send_watch_alert_to_n8n_skips_when_webhook_missing(
+async def test_send_watch_alert_to_router_skips_when_no_url_configured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(settings, "WATCH_ALERT_ROUTER_URL", "")
     monkeypatch.setattr(settings, "N8N_WATCH_ALERT_WEBHOOK_URL", "")
 
-    result = await OpenClawClient().send_watch_alert_to_n8n(
+    result = await OpenClawClient().send_watch_alert_to_router(
         message="watch message",
         market="crypto",
         triggered=[{"symbol": "BTC", "condition_type": "price_above"}],
@@ -1230,21 +1231,22 @@ async def test_send_watch_alert_to_n8n_skips_when_webhook_missing(
     )
 
     assert result.status == "skipped"
-    assert result.reason == "n8n_webhook_not_configured"
+    assert result.reason == "router_not_configured"
     assert result.request_id is None
 
 
 @pytest.mark.asyncio
 @patch("app.services.openclaw_client.httpx.AsyncClient")
-async def test_send_watch_alert_to_n8n_posts_payload(
+async def test_send_watch_alert_to_router_posts_payload(
     mock_httpx_client_cls: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         settings,
-        "N8N_WATCH_ALERT_WEBHOOK_URL",
+        "WATCH_ALERT_ROUTER_URL",
         "http://127.0.0.1:5678/webhook/watch-alert",
     )
+    monkeypatch.setattr(settings, "N8N_WATCH_ALERT_WEBHOOK_URL", "")
 
     mock_cli = AsyncMock()
     mock_res = MagicMock(status_code=200)
@@ -1256,7 +1258,7 @@ async def test_send_watch_alert_to_n8n_posts_payload(
     mock_client_instance.__aexit__.return_value = None
     mock_httpx_client_cls.return_value = mock_client_instance
 
-    result = await OpenClawClient().send_watch_alert_to_n8n(
+    result = await OpenClawClient().send_watch_alert_to_router(
         message="watch summary",
         market="kr",
         triggered=[
@@ -1295,15 +1297,16 @@ async def test_send_watch_alert_to_n8n_posts_payload(
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("zero_delay_openclaw_retry_wait")
 @patch("app.services.openclaw_client.httpx.AsyncClient")
-async def test_send_watch_alert_to_n8n_returns_failed_on_retries_exhausted(
+async def test_send_watch_alert_to_router_returns_failed_on_retries_exhausted(
     mock_httpx_client_cls: MagicMock,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         settings,
-        "N8N_WATCH_ALERT_WEBHOOK_URL",
+        "WATCH_ALERT_ROUTER_URL",
         "http://127.0.0.1:5678/webhook/watch-alert",
     )
+    monkeypatch.setattr(settings, "N8N_WATCH_ALERT_WEBHOOK_URL", "")
 
     mock_cli = AsyncMock()
     mock_res_fail = MagicMock()
@@ -1315,7 +1318,7 @@ async def test_send_watch_alert_to_n8n_returns_failed_on_retries_exhausted(
     mock_client_instance.__aexit__.return_value = None
     mock_httpx_client_cls.return_value = mock_client_instance
 
-    result = await OpenClawClient().send_watch_alert_to_n8n(
+    result = await OpenClawClient().send_watch_alert_to_router(
         message="watch summary",
         market="crypto",
         triggered=[{"symbol": "BTC", "condition_type": "price_above"}],
@@ -1327,6 +1330,80 @@ async def test_send_watch_alert_to_n8n_returns_failed_on_retries_exhausted(
     assert result.reason == "request_failed"
     assert result.request_id is None
     assert mock_cli.post.call_count == 4
+
+
+@pytest.mark.asyncio
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_watch_alert_to_router_prefers_router_url_over_legacy(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        settings,
+        "WATCH_ALERT_ROUTER_URL",
+        "http://127.0.0.1:9999/router/watch-alert",
+    )
+    monkeypatch.setattr(
+        settings,
+        "N8N_WATCH_ALERT_WEBHOOK_URL",
+        "http://127.0.0.1:5678/webhook/watch-alert",
+    )
+
+    mock_cli = AsyncMock()
+    mock_res = MagicMock(status_code=200)
+    mock_res.raise_for_status.return_value = None
+    mock_cli.post.return_value = mock_res
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    result = await OpenClawClient().send_watch_alert_to_router(
+        message="m",
+        market="kr",
+        triggered=[{"symbol": "X", "condition_type": "price_below"}],
+        as_of="2026-04-17T00:00:00Z",
+        correlation_id="corr-prefer-router",
+    )
+
+    assert result.status == "success"
+    assert mock_cli.post.call_args.args[0] == "http://127.0.0.1:9999/router/watch-alert"
+
+
+@pytest.mark.asyncio
+@patch("app.services.openclaw_client.httpx.AsyncClient")
+async def test_send_watch_alert_to_router_falls_back_to_legacy_n8n_url(
+    mock_httpx_client_cls: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "WATCH_ALERT_ROUTER_URL", "")
+    monkeypatch.setattr(
+        settings,
+        "N8N_WATCH_ALERT_WEBHOOK_URL",
+        "http://127.0.0.1:5678/webhook/watch-alert",
+    )
+
+    mock_cli = AsyncMock()
+    mock_res = MagicMock(status_code=200)
+    mock_res.raise_for_status.return_value = None
+    mock_cli.post.return_value = mock_res
+    mock_client_instance = AsyncMock()
+    mock_client_instance.__aenter__.return_value = mock_cli
+    mock_client_instance.__aexit__.return_value = None
+    mock_httpx_client_cls.return_value = mock_client_instance
+
+    result = await OpenClawClient().send_watch_alert_to_router(
+        message="m",
+        market="kr",
+        triggered=[{"symbol": "X", "condition_type": "price_below"}],
+        as_of="2026-04-17T00:00:00Z",
+        correlation_id="corr-fallback",
+    )
+
+    assert result.status == "success"
+    assert (
+        mock_cli.post.call_args.args[0] == "http://127.0.0.1:5678/webhook/watch-alert"
+    )
 
 
 def test_watch_alert_delivery_result_enforces_request_id_contract() -> None:

--- a/tests/test_watch_scanner.py
+++ b/tests/test_watch_scanner.py
@@ -44,7 +44,7 @@ class _FakeOpenClawClient:
         self.messages.append(message)
         return "watch-1" if self._status == "success" else None
 
-    async def send_watch_alert_to_n8n(
+    async def send_watch_alert_to_router(
         self,
         *,
         message: str,
@@ -62,7 +62,7 @@ class _FakeOpenClawClient:
         if self._status == "skipped":
             return WatchAlertDeliveryResult(
                 status="skipped",
-                reason="n8n_webhook_not_configured",
+                reason="router_not_configured",
             )
         return WatchAlertDeliveryResult(status="failed", reason="request_failed")
 
@@ -256,6 +256,7 @@ async def test_run_scans_all_markets_and_skips_closed_market(
         "status": "skipped",
         "skipped": True,
         "reason": "market_closed",
+        "failed_lookups": 0,
     }
     assert result["crypto"]["alerts_sent"] == 0
     assert result["kr"]["alerts_sent"] == 0
@@ -324,20 +325,117 @@ async def test_get_price_and_rsi_use_market_specific_sources(
 
 
 @pytest.mark.asyncio
-async def test_get_price_us_raises_when_yahoo_fails(
+async def test_scan_market_us_yahoo_failure_does_not_abort_other_watches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from app.jobs import watch_scanner as watch_scanner_module
-
     scanner = WatchScanner()
+    scanner._watch_service = _FakeWatchService()
+    scanner._watch_service._rows_by_market["us"] = [
+        {
+            "target_kind": "asset",
+            "symbol": "BADTKR",
+            "condition_type": "price_below",
+            "threshold": 100.0,
+            "field": "asset:BADTKR:price_below:100",
+        },
+        {
+            "target_kind": "asset",
+            "symbol": "AAPL",
+            "condition_type": "price_below",
+            "threshold": 200.0,
+            "field": "asset:AAPL:price_below:200",
+        },
+    ]
+    scanner._openclaw = _FakeOpenClawClient(status="success")
+
+    monkeypatch.setattr(scanner, "_is_market_open", lambda market: True)
+
+    async def _price_side_effect(symbol: str, market: str) -> float:
+        if symbol == "BADTKR":
+            raise RuntimeError("US watch price fetch failed for BADTKR: invalid close")
+        return 150.0
+
     monkeypatch.setattr(
-        watch_scanner_module.market_data_service,
-        "get_quote",
-        AsyncMock(side_effect=RuntimeError("timeout")),
+        scanner, "_get_price", AsyncMock(side_effect=_price_side_effect)
     )
 
-    with pytest.raises(RuntimeError, match="timeout"):
-        await scanner._get_price("AAPL", "us")
+    result = await scanner.scan_market("us")
+
+    assert result["alerts_sent"] == 1
+    assert result["status"] == "success"
+    assert result.get("failed_lookups") == 1
+    assert scanner._watch_service.removed_fields == [
+        ("us", "asset:AAPL:price_below:200"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_run_continues_other_markets_when_scan_market_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = WatchScanner()
+    scanner._watch_service = _FakeWatchService(rows=[])
+    scanner._openclaw = _FakeOpenClawClient(status="success")
+
+    original_scan_market = scanner.scan_market
+
+    async def _scan_market(market: str) -> dict[str, object]:
+        if market == "us":
+            raise RuntimeError("simulated unexpected scanner error")
+        return await original_scan_market(market)
+
+    monkeypatch.setattr(scanner, "scan_market", _scan_market)
+    monkeypatch.setattr(scanner, "_is_market_open", lambda market: True)
+    monkeypatch.setattr(scanner, "_get_price", AsyncMock(return_value=None))
+
+    result = await scanner.run()
+
+    assert set(result.keys()) == {"crypto", "kr", "us"}
+    assert result["us"]["status"] == "failed"
+    assert result["us"]["reason"] == "scan_aborted"
+    assert result["crypto"]["alerts_sent"] == 0
+    assert result["kr"]["alerts_sent"] == 0
+
+
+@pytest.mark.asyncio
+async def test_scan_market_records_failed_lookups_in_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scanner = WatchScanner()
+    scanner._watch_service = _FakeWatchService()
+    scanner._watch_service._rows_by_market["crypto"] = [
+        {
+            "target_kind": "asset",
+            "symbol": "BTC",
+            "condition_type": "price_below",
+            "threshold": 100.0,
+            "field": "asset:BTC:price_below:100",
+        },
+        {
+            "target_kind": "asset",
+            "symbol": "ETH",
+            "condition_type": "price_below",
+            "threshold": 50.0,
+            "field": "asset:ETH:price_below:50",
+        },
+    ]
+    scanner._openclaw = _FakeOpenClawClient(status="success")
+
+    monkeypatch.setattr(scanner, "_is_market_open", lambda market: True)
+
+    async def _price_side_effect(symbol: str, market: str) -> float:
+        raise RuntimeError(f"simulated failure for {symbol}")
+
+    monkeypatch.setattr(
+        scanner, "_get_price", AsyncMock(side_effect=_price_side_effect)
+    )
+
+    result = await scanner.scan_market("crypto")
+
+    assert "failed_lookups" in result
+    assert result["failed_lookups"] == 2
+    assert result["status"] == "skipped"
+    assert result["reason"] == "no_triggered_alerts"
 
 
 @pytest.mark.asyncio
@@ -448,7 +546,7 @@ async def test_scan_market_keeps_watch_records_when_n8n_delivery_skipped(
 
     assert result["alerts_sent"] == 0
     assert result["status"] == "skipped"
-    assert result["reason"] == "n8n_webhook_not_configured"
+    assert result["reason"] == "router_not_configured"
     assert scanner._watch_service.removed_fields == []
 
 
@@ -502,14 +600,16 @@ class TestScannerWithCreateOrderIntent:
 
         monkeypatch.setattr(scanner, "_intent_session", fake_session)
 
-        # Patch send_watch_alert_to_n8n to capture intents
+        # Patch send_watch_alert_to_router to capture intents
         captured_intents = []
 
-        async def fake_send_n8n(**kwargs):
+        async def fake_send_router(**kwargs):
             captured_intents.extend(kwargs.get("intents", []))
             return WatchAlertDeliveryResult(status="success", request_id="watch-1")
 
-        monkeypatch.setattr(scanner._openclaw, "send_watch_alert_to_n8n", fake_send_n8n)
+        monkeypatch.setattr(
+            scanner._openclaw, "send_watch_alert_to_router", fake_send_router
+        )
 
         result = await scanner.scan_market("kr")
 


### PR DESCRIPTION
## Summary
- Restores watch scanner resilience by isolating per-watch lookup/evaluation/emission failures and continuing later watches/markets.
- Adds the transport-neutral watch-alert router seam (`WATCH_ALERT_ROUTER_URL`) while keeping `N8N_WATCH_ALERT_WEBHOOK_URL` as a backward-compatible fallback.
- Renames the OpenClaw watch-alert sender to `send_watch_alert_to_router`, updates the proximity monitor caller, and documents Phase 0/Phase 1 boundaries in plan/review notes.

## Scope / phase boundary
- Phase 0 only: auto_trader scanner resilience + generic router config seam.
- No Prefect receiver, scheduler activation, production env changes, n8n workflow changes, or Hermes follow-up flow activation in this PR.
- Prefect webhook receiver and Hermes async follow-up remain follow-up phases requiring explicit operator approval before activation.

## Verification
- `uv run ruff check app/jobs/watch_scanner.py app/services/openclaw_client.py app/core/config.py app/jobs/watch_proximity_monitor.py tests/test_watch_scanner.py tests/test_openclaw_client.py`
- `uv run ruff format --check app/jobs/watch_scanner.py app/services/openclaw_client.py app/core/config.py app/jobs/watch_proximity_monitor.py tests/test_watch_scanner.py tests/test_openclaw_client.py`
- `uv run pytest tests/test_watch_scanner.py tests/test_openclaw_client.py tests/test_watch_alerts.py tests/test_mcp_watch_alerts.py tests/test_watch_scan_tasks.py -q` (65 passed, 11 skipped, 2 warnings)
- `make lint`
- `make typecheck`
- Claude Code Opus review passed; report committed at `docs/plans/ROB-122-watch-alert-router-review.md`.

## Safety / non-actions
- No live broker orders.
- No paper/mock order side effects.
- No `dry_run=False` trading calls.
- No watch threshold changes.
- No production env/scheduler activation.
- No secrets, tokens, account ids, or connection strings are included in this PR body.

Closes ROB-122
