### PR TITLE
Fix trading action page runtime data

### DIFF
--- a/app/services/candidate_screening_service.py
+++ b/app/services/candidate_screening_service.py
@@ -88,7 +88,7 @@ class CandidateScreeningService:
         candidates: list[ScreenedCandidate] = []
         for r in rows:
             symbol = str(r.get("symbol") or "")
-            warnings = list(r.get("warnings") or [])
+            warnings = _row_warnings(r)
             if exclude_warnings and warnings:
                 continue
             candidates.append(
@@ -97,10 +97,12 @@ class CandidateScreeningService:
                     name=r.get("name"),
                     market=r.get("market"),
                     instrument_type=r.get("instrument_type"),
-                    price=_to_float(r.get("price")),
+                    price=_to_float(_pick_first(r, "price", "close", "current_price")),
                     change_rate=_to_float(r.get("change_rate")),
-                    volume=_to_float(r.get("volume")),
-                    trade_amount_24h=_to_float(r.get("trade_amount_24h")),
+                    volume=_to_float(_pick_first(r, "volume", "volume_24h")),
+                    trade_amount_24h=_to_float(
+                        _pick_first(r, "trade_amount_24h", "trade_amount")
+                    ),
                     volume_ratio=_to_float(r.get("volume_ratio")),
                     rsi=_to_float(r.get("rsi")),
                     market_cap=_to_float(r.get("market_cap")),
@@ -112,7 +114,7 @@ class CandidateScreeningService:
                 )
             )
 
-        rsi_enrichment = raw.get("rsi_enrichment") or {}
+        rsi_enrichment = _rsi_enrichment(raw)
         return CandidateScreenResponse(
             generated_at=datetime.now(UTC).isoformat(),
             market=market,
@@ -127,7 +129,7 @@ class CandidateScreeningService:
 
     async def _load_held_symbols(self, user_id: int, market: str) -> set[str]:
         try:
-            from app.services.kis import KISClient
+            from app.services.brokers.kis import KISClient
             from app.services.merged_portfolio_service import MergedPortfolioService
         except ImportError:
             return set()
@@ -157,6 +159,34 @@ class CandidateScreeningService:
                 pass
 
         return held
+
+
+def _pick_first(row: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = row.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _row_warnings(row: dict[str, Any]) -> list[str]:
+    warnings = list(row.get("warnings") or [])
+    market_warning = row.get("market_warning")
+    if market_warning and str(market_warning) not in warnings:
+        warnings.append(str(market_warning))
+    return warnings
+
+
+def _rsi_enrichment(raw: dict[str, Any]) -> dict[str, Any]:
+    direct = raw.get("rsi_enrichment")
+    if isinstance(direct, dict):
+        return direct
+    meta = raw.get("meta")
+    if isinstance(meta, dict):
+        nested = meta.get("rsi_enrichment")
+        if isinstance(nested, dict):
+            return nested
+    return {}
 
 
 def _to_float(value: Any) -> float | None:

--- a/app/services/portfolio_action_service.py
+++ b/app/services/portfolio_action_service.py
@@ -35,9 +35,11 @@ class PortfolioActionService:
         user_id: int,
         market_filter: str | None = None,
     ) -> PortfolioActionsResponse:
-        holdings, total_value = await self._load_holdings(user_id, market_filter)
+        holdings, total_value, load_warnings = await self._load_holdings(
+            user_id, market_filter
+        )
         candidates: list[PortfolioActionCandidate] = []
-        warnings: list[str] = []
+        warnings: list[str] = list(load_warnings)
 
         for holding in holdings:
             quantity = float(getattr(holding, "quantity", 0.0) or 0.0)
@@ -50,8 +52,10 @@ class PortfolioActionService:
 
             evaluation = float(getattr(holding, "evaluation", 0.0) or 0.0)
             weight = (evaluation / total_value * 100.0) if total_value else None
+            market_value = _normalize_market(getattr(holding, "market_type", None))
             profit_rate = getattr(holding, "profit_loss_rate", None)
-            market_value = getattr(holding.market_type, "value", "KR")
+            if profit_rate is None:
+                profit_rate = getattr(holding, "profit_rate", None)
 
             summary = await self._load_latest_summary(symbol)
             journal_status = await self._load_journal_status(symbol)
@@ -105,27 +109,33 @@ class PortfolioActionService:
 
     async def _load_holdings(
         self, user_id: int, market_filter: str | None
-    ) -> tuple[list[Any], float]:
-        from app.services.kis import KISClient
+    ) -> tuple[list[Any], float, list[str]]:
+        from app.services.brokers.kis import KISClient
         from app.services.merged_portfolio_service import MergedPortfolioService
 
         service = MergedPortfolioService(self.db)
-        kis_client = KISClient()
         holdings: list[Any] = []
+        warnings: list[str] = []
 
         if market_filter in (None, "KR"):
-            holdings.extend(
-                await service.get_merged_portfolio_domestic(user_id, kis_client)
-            )
+            try:
+                holdings.extend(
+                    await service.get_merged_portfolio_domestic(user_id, KISClient())
+                )
+            except Exception as exc:
+                warnings.append(f"KR holdings unavailable: {type(exc).__name__}")
         if market_filter in (None, "US"):
-            holdings.extend(
-                await service.get_merged_portfolio_overseas(user_id, kis_client)
-            )
+            try:
+                holdings.extend(
+                    await service.get_merged_portfolio_overseas(user_id, KISClient())
+                )
+            except Exception as exc:
+                warnings.append(f"US holdings unavailable: {type(exc).__name__}")
         if market_filter in (None, "CRYPTO"):
             holdings.extend(await self._load_crypto_holdings(user_id))
 
         total = sum(float(getattr(h, "evaluation", 0.0) or 0.0) for h in holdings)
-        return holdings, total
+        return holdings, total, warnings
 
     async def _load_crypto_holdings(self, user_id: int) -> list[Any]:
         try:
@@ -183,3 +193,13 @@ class PortfolioActionService:
         if snapshot is None:
             return "missing"
         return "present"
+
+
+def _normalize_market(value: Any) -> str:
+    raw = getattr(value, "value", value)
+    text = str(raw or "KR").strip().lower()
+    if text in {"crypto", "cr", "coin"}:
+        return "CRYPTO"
+    if text in {"us", "usa", "overseas"}:
+        return "US"
+    return "KR"

--- a/tests/services/test_candidate_screening_service.py
+++ b/tests/services/test_candidate_screening_service.py
@@ -16,14 +16,16 @@ async def test_wraps_screen_stocks_and_annotates_held(monkeypatch) -> None:
                 {
                     "symbol": "KRW-BTC",
                     "name": "비트코인",
+                    "close": 123.4,
+                    "volume_24h": 123456.0,
                     "trade_amount_24h": 0.0,
                     "volume_ratio": None,
                     "rsi": 28.5,
-                    "warnings": ["KRW-BTC ticker not found"],
+                    "market_warning": "KRW-BTC ticker not found",
                 },
                 {"symbol": "KRW-ETH", "name": "이더리움", "rsi": 32.1},
             ],
-            "rsi_enrichment": {"attempted": 0, "succeeded": 0},
+            "meta": {"rsi_enrichment": {"attempted": 2, "succeeded": 1}},
             "warnings": ["rsi_enrichment_skipped"],
         }
     )
@@ -41,9 +43,13 @@ async def test_wraps_screen_stocks_and_annotates_held(monkeypatch) -> None:
     assert res.total == 2
     btc = next(c for c in res.candidates if c.symbol == "KRW-BTC")
     eth = next(c for c in res.candidates if c.symbol == "KRW-ETH")
+    assert btc.price == 123.4
+    assert btc.volume == 123456.0
     assert btc.is_held is True
     assert eth.is_held is False
     assert "rsi_enrichment_skipped" in res.warnings
+    assert res.rsi_enrichment_attempted == 2
+    assert res.rsi_enrichment_succeeded == 1
     assert any("KRW-BTC" in w for w in btc.data_warnings)
 
 

--- a/tests/services/test_portfolio_action_service.py
+++ b/tests/services/test_portfolio_action_service.py
@@ -15,10 +15,11 @@ async def test_aggregates_holdings_with_research_and_journal(monkeypatch) -> Non
 
     h = MagicMock(
         ticker="KRW-SOL",
-        market_type=MagicMock(value="CRYPTO"),
+        market_type="crypto",
         quantity=10.0,
         evaluation=2_975_000.0,
-        profit_loss_rate=-12.25,
+        profit_loss_rate=None,
+        profit_rate=-0.1225,
         current_price=297_500.0,
         instrument_type="crypto",
     )
@@ -27,7 +28,7 @@ async def test_aggregates_holdings_with_research_and_journal(monkeypatch) -> Non
 
     service = PortfolioActionService(db)
     monkeypatch.setattr(
-        service, "_load_holdings", AsyncMock(return_value=(holdings, 10_000_000.0))
+        service, "_load_holdings", AsyncMock(return_value=(holdings, 10_000_000.0, []))
     )
     monkeypatch.setattr(
         service,
@@ -52,6 +53,8 @@ async def test_aggregates_holdings_with_research_and_journal(monkeypatch) -> Non
     assert result.total == 1
     candidate = result.candidates[0]
     assert candidate.symbol == "KRW-SOL"
+    assert candidate.market == "CRYPTO"
+    assert candidate.profit_rate == -0.1225
     assert candidate.latest_research_session_id == 32
     assert candidate.summary_decision == "hold"
     assert candidate.candidate_action in {"trim", "hold", "watch"}
@@ -65,8 +68,31 @@ async def test_skips_zero_quantity_holdings(monkeypatch) -> None:
     holdings = [MagicMock(ticker="ZERO", quantity=0.0)]
     service = PortfolioActionService(db)
     monkeypatch.setattr(
-        service, "_load_holdings", AsyncMock(return_value=(holdings, 0.0))
+        service, "_load_holdings", AsyncMock(return_value=(holdings, 0.0, []))
     )
 
     result = await service.build_action_board(user_id=1)
     assert result.total == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_load_holdings_keeps_crypto_when_kis_unavailable(monkeypatch) -> None:
+    db = MagicMock()
+    crypto_holding = MagicMock(ticker="KRW-BTC", quantity=1.0, evaluation=100.0)
+    service = PortfolioActionService(db)
+    monkeypatch.setattr(
+        service, "_load_crypto_holdings", AsyncMock(return_value=[crypto_holding])
+    )
+
+    def raise_kis_error():
+        raise RuntimeError("KIS config unavailable")
+
+    monkeypatch.setattr("app.services.brokers.kis.KISClient", raise_kis_error)
+
+    holdings, total, warnings = await service._load_holdings(1, None)
+
+    assert holdings == [crypto_holding]
+    assert total == 100.0
+    assert any(w.startswith("KR holdings unavailable") for w in warnings)
+    assert any(w.startswith("US holdings unavailable") for w in warnings)


### PR DESCRIPTION
## Summary
- Fix Candidate Discovery field mapping for screen_stocks rows that use close/volume_24h/trade_amount aliases and nested RSI enrichment metadata
- Include per-row market_warning in Candidate Discovery warnings so warning filtering works
- Fix Portfolio Action Board KIS import path and make KR/US holding-load failures non-fatal so crypto/manual data can still render
- Normalize holding market values and fall back to profit_rate when profit_loss_rate is absent

## Verification
- uv run ruff check app/ tests/
- uv run ruff format --check app/ tests/
- git diff --check
- uv run --group test pytest tests/services/test_candidate_screening_service.py tests/services/test_portfolio_action_service.py tests/routers/test_candidate_discovery.py tests/routers/test_portfolio_actions.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling and warning collection during holdings and candidate data loading across multiple market sources.
  * Enhanced fallback mechanisms for extracting price, volume, and other candidate data fields when primary sources are unavailable.

* **Improvements**
  * Strengthened system robustness when certain market data integrations are temporarily unavailable.
  * More comprehensive warning tracking to better inform users of data quality or retrieval issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->