### PR TITLE
Fix portfolio action board merged holding quantities

### DIFF
--- a/app/services/portfolio_action_service.py
+++ b/app/services/portfolio_action_service.py
@@ -42,7 +42,7 @@ class PortfolioActionService:
         warnings: list[str] = list(load_warnings)
 
         for holding in holdings:
-            quantity = float(getattr(holding, "quantity", 0.0) or 0.0)
+            quantity = _holding_quantity(holding)
             if quantity <= 0.0:
                 continue
 
@@ -153,7 +153,7 @@ class PortfolioActionService:
         from sqlalchemy import select
         from sqlalchemy.orm import selectinload
 
-        from app.models.stock_info import StockInfo
+        from app.models.analysis import StockInfo
 
         stmt = (
             select(ResearchSession)
@@ -193,6 +193,24 @@ class PortfolioActionService:
         if snapshot is None:
             return "missing"
         return "present"
+
+
+def _holding_quantity(value: Any) -> float:
+    """Return the displayed position quantity for heterogeneous holding DTOs.
+
+    MergedPortfolioService.MergedHolding exposes ``total_quantity`` instead of
+    ``quantity``; Upbit/manual DTOs may expose ``quantity`` directly.
+    """
+
+    for attr in ("quantity", "total_quantity"):
+        raw = getattr(value, attr, None)
+        if raw is None:
+            continue
+        try:
+            return float(raw or 0.0)
+        except (TypeError, ValueError):
+            continue
+    return 0.0
 
 
 def _normalize_market(value: Any) -> str:

--- a/tests/services/test_portfolio_action_service.py
+++ b/tests/services/test_portfolio_action_service.py
@@ -1,5 +1,6 @@
 """ROB-116 — PortfolioActionService aggregation tests."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -73,6 +74,55 @@ async def test_skips_zero_quantity_holdings(monkeypatch) -> None:
 
     result = await service.build_action_board(user_id=1)
     assert result.total == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_action_board_uses_total_quantity_for_merged_holdings(
+    monkeypatch,
+) -> None:
+    db = MagicMock()
+    holding = SimpleNamespace(
+        ticker="005930",
+        name="삼성전자",
+        market_type="KR",
+        total_quantity=3,
+        evaluation=804_000.0,
+        profit_rate=0.3747,
+        instrument_type="stock",
+    )
+    service = PortfolioActionService(db)
+    monkeypatch.setattr(
+        service,
+        "_load_holdings",
+        AsyncMock(return_value=([holding], 10_000_000.0, [])),
+    )
+    monkeypatch.setattr(service, "_load_latest_summary", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        service, "_load_journal_status", AsyncMock(return_value="missing")
+    )
+
+    result = await service.build_action_board(user_id=1)
+
+    assert result.total == 1
+    candidate = result.candidates[0]
+    assert candidate.symbol == "005930"
+    assert candidate.quantity == 3.0
+    assert candidate.market == "KR"
+    assert candidate.profit_rate == 0.3747
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_load_latest_summary_imports_stock_info_model() -> None:
+    db = MagicMock()
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = None
+    db.execute = AsyncMock(return_value=result)
+    service = PortfolioActionService(db)
+
+    assert await service._load_latest_summary("005930") is None
+    db.execute.assert_awaited_once()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- render MergedPortfolioService holdings by using total_quantity fallback when quantity is absent
- fix PortfolioActionService latest summary import path so populated holdings do not crash research lookup
- add regression coverage for merged holdings and StockInfo import path

## Verification
- uv run ruff check app/services/portfolio_action_service.py tests/services/test_portfolio_action_service.py
- uv run ruff format --check app/services/portfolio_action_service.py tests/services/test_portfolio_action_service.py
- uv run --group test pytest tests/services/test_portfolio_action_service.py -q
- uv run ruff check app/ tests/
- uv run ruff format --check app/ tests/
- git diff --check
- uv run --group test pytest tests/services/test_portfolio_action_service.py tests/routers/test_portfolio_actions.py -q
- production-env service smoke from local branch: all market total=53, KR total=27, US total=26

## Safety
Read-only service mapping fix only. No broker/order/watch/order-intent/scheduler/Alembic/DB mutation.