### PR TITLE
fix(invest): clarify mobile valuation display

### DIFF
--- a/app/services/invest_home_readers.py
+++ b/app/services/invest_home_readers.py
@@ -156,6 +156,13 @@ class KISHomeReader:
                     if h.currency == "USD" and h.costBasis is not None
                 )
 
+            account_pnl_krw = investment_value_krw - account_cost_basis_krw
+            account_pnl_rate = (
+                account_pnl_krw / account_cost_basis_krw
+                if account_cost_basis_krw > 0
+                else None
+            )
+
             account = Account(
                 accountId="kis_account",
                 displayName="KIS 실계좌",
@@ -164,6 +171,8 @@ class KISHomeReader:
                 includedInHome=True,
                 valueKrw=investment_value_krw,
                 costBasisKrw=account_cost_basis_krw,
+                pnlKrw=account_pnl_krw,
+                pnlRate=account_pnl_rate,
                 cashBalances=CashAmounts(
                     krw=domestic_cash["balance"],
                     usd=margin.get("usd_balance"),
@@ -192,24 +201,61 @@ class UpbitHomeReader:
     def __init__(self, db: AsyncSession) -> None:
         self._db = db
 
+    async def _fetch_current_prices(self, market_codes: list[str]) -> dict[str, float]:
+        """Fetch Upbit prices without letting one delisted code blank the whole batch."""
+
+        try:
+            prices = await fetch_multiple_current_prices(market_codes)
+        except Exception:
+            prices = {}
+
+        missing_codes = [code for code in market_codes if code not in prices]
+        if not missing_codes:
+            return prices
+
+        for code in missing_codes:
+            try:
+                single = await fetch_multiple_current_prices([code])
+            except Exception:
+                continue
+            if code in single:
+                prices[code] = single[code]
+        return prices
+
     async def fetch(self, *, user_id: int) -> _SourceFetchResult:
         try:
             coins = await fetch_my_coins()
             krw_row = next((c for c in coins if c.get("currency") == "KRW"), None)
 
             holdings = []
-            crypto_rows = [c for c in coins if str(c.get("currency")) != "KRW"]
+            crypto_rows = [
+                c
+                for c in coins
+                if str(c.get("currency")) != "KRW"
+                and (float(c.get("balance", 0) or 0) + float(c.get("locked", 0) or 0))
+                > 0
+            ]
             market_codes = [f"KRW-{c.get('currency')}" for c in crypto_rows]
             price_warning: InvestHomeWarning | None = None
             current_prices: dict[str, float] = {}
             if market_codes:
                 try:
-                    current_prices = await fetch_multiple_current_prices(market_codes)
+                    current_prices = await self._fetch_current_prices(market_codes)
                 except Exception as exc:
                     logger.warning("Upbit price fetch failed: %s", exc, exc_info=True)
                     price_warning = InvestHomeWarning(
                         source="upbit",
                         message="코인 평가금액 산출을 위한 현재가 조회에 실패했습니다.",
+                    )
+                missing_price_codes = sorted(set(market_codes) - set(current_prices))
+                if missing_price_codes and price_warning is None:
+                    logger.warning(
+                        "Upbit missing current prices for %s",
+                        ",".join(missing_price_codes),
+                    )
+                    price_warning = InvestHomeWarning(
+                        source="upbit",
+                        message="일부 코인은 현재가가 없어 평가금액에서 제외했습니다.",
                     )
             for c in crypto_rows:
                 currency = str(c.get("currency"))
@@ -250,10 +296,24 @@ class UpbitHomeReader:
                     )
                 )
 
-            coin_value_krw = sum(h.valueKrw for h in holdings if h.valueKrw is not None)
+            priced_holdings = [h for h in holdings if h.valueKrw is not None]
+            coin_value_krw = sum(
+                h.valueKrw for h in priced_holdings if h.valueKrw is not None
+            )
+            priced_cost_vals = [h.costBasis for h in priced_holdings]
             coin_cost_basis_krw = (
-                sum(h.costBasis for h in holdings if h.costBasis is not None)
-                if holdings and all(h.costBasis is not None for h in holdings)
+                sum(v for v in priced_cost_vals if v is not None)
+                if priced_cost_vals and all(v is not None for v in priced_cost_vals)
+                else None
+            )
+            account_pnl_krw = (
+                coin_value_krw - coin_cost_basis_krw
+                if coin_cost_basis_krw is not None
+                else None
+            )
+            account_pnl_rate = (
+                account_pnl_krw / coin_cost_basis_krw
+                if account_pnl_krw is not None and coin_cost_basis_krw > 0
                 else None
             )
             account = Account(
@@ -264,6 +324,8 @@ class UpbitHomeReader:
                 includedInHome=True,
                 valueKrw=coin_value_krw,
                 costBasisKrw=coin_cost_basis_krw,
+                pnlKrw=account_pnl_krw,
+                pnlRate=account_pnl_rate,
                 cashBalances=CashAmounts(
                     krw=float(krw_row.get("balance", 0)) if krw_row else None
                 ),
@@ -323,22 +385,6 @@ class ManualHomeReader:
                 for h in toss_holdings
             ]
 
-            accounts_map: dict[int, Account] = {}
-            for h in toss_holdings:
-                ba = h.broker_account
-                if ba.id not in accounts_map:
-                    accounts_map[ba.id] = Account(
-                        accountId=str(ba.id),
-                        displayName=ba.account_name or "Toss 수동",
-                        source="toss_manual",
-                        accountKind="manual",
-                        includedInHome=True,
-                        valueKrw=0,
-                        costBasisKrw=None,
-                        cashBalances=CashAmounts(),
-                        buyingPower=CashAmounts(),
-                    )
-
             manual_warning = (
                 InvestHomeWarning(
                     source="toss_manual",
@@ -348,7 +394,7 @@ class ManualHomeReader:
                 else None
             )
             return _SourceFetchResult(
-                accounts=list(accounts_map.values()),
+                accounts=[],
                 holdings=holdings,
                 warning=manual_warning,
             )

--- a/app/services/invest_home_service.py
+++ b/app/services/invest_home_service.py
@@ -65,30 +65,67 @@ def build_grouped_holdings(holdings: Iterable[Holding]) -> list[GroupedHolding]:
             cost_basis = sum(v for v in cost_vals if v is not None)
             avg_cost = cost_basis / total_qty
 
-        native_vals = [h.valueNative for h in items]
+        known_native_values = [
+            h.valueNative for h in items if h.valueNative is not None and h.quantity > 0
+        ]
+        known_native_quantities = [
+            h.quantity for h in items if h.valueNative is not None and h.quantity > 0
+        ]
+        inferred_native_unit: float | None = None
+        if known_native_values and sum(known_native_quantities) > 0:
+            inferred_native_unit = sum(known_native_values) / sum(
+                known_native_quantities
+            )
+
+        native_parts: list[float] = []
+        for h in items:
+            if h.valueNative is not None:
+                native_parts.append(h.valueNative)
+            elif inferred_native_unit is not None:
+                native_parts.append(h.quantity * inferred_native_unit)
         value_native: float | None = (
-            sum(v for v in native_vals if v is not None)
-            if all(v is not None for v in native_vals)
-            else None
+            sum(native_parts) if len(native_parts) == len(items) else None
         )
-        krw_vals = [h.valueKrw for h in items]
+
+        fx_rate: float | None = None
+        fx_candidates = [
+            h.valueKrw / h.valueNative
+            for h in items
+            if h.currency == "USD"
+            and h.valueKrw is not None
+            and h.valueNative is not None
+            and h.valueNative > 0
+        ]
+        if fx_candidates:
+            fx_rate = sum(fx_candidates) / len(fx_candidates)
+
+        krw_parts: list[float] = []
+        for h in items:
+            if h.valueKrw is not None:
+                krw_parts.append(h.valueKrw)
+            elif h.currency == "KRW" and inferred_native_unit is not None:
+                krw_parts.append(h.quantity * inferred_native_unit)
+            elif h.currency == "USD" and inferred_native_unit is not None and fx_rate:
+                krw_parts.append(h.quantity * inferred_native_unit * fx_rate)
         value_krw: float | None = (
-            sum(v for v in krw_vals if v is not None)
-            if all(v is not None for v in krw_vals)
-            else None
+            sum(krw_parts) if len(krw_parts) == len(items) else None
         )
+
         pnl_vals = [h.pnlKrw for h in items]
         pnl_krw: float | None = (
             sum(v for v in pnl_vals if v is not None)
             if all(v is not None for v in pnl_vals)
             else None
         )
+        if pnl_krw is None and cost_basis is not None and value_krw is not None:
+            if first.currency == "KRW":
+                pnl_krw = value_krw - cost_basis
+            elif first.currency == "USD" and fx_rate:
+                pnl_krw = value_krw - cost_basis * fx_rate
+
         pnl_rate: float | None = None
-        if cost_basis is not None and cost_basis > 0:
-            if value_native is not None:
-                pnl_rate = (value_native - cost_basis) / cost_basis
-            elif first.currency == "KRW" and value_krw is not None:
-                pnl_rate = (value_krw - cost_basis) / cost_basis
+        if cost_basis is not None and cost_basis > 0 and value_native is not None:
+            pnl_rate = (value_native - cost_basis) / cost_basis
 
         out.append(
             GroupedHolding(

--- a/frontend/invest/src/__tests__/AccountCardList.test.tsx
+++ b/frontend/invest/src/__tests__/AccountCardList.test.tsx
@@ -37,8 +37,8 @@ test("Upbit card does not render a live badge and shows KRW cash + buying power"
     />
   );
   expect(screen.queryByText(/^live$/i)).toBeNull();
-  expect(screen.getByText(/원화 현금/)).toBeInTheDocument();
-  expect(screen.getByText(/원화 매수/)).toBeInTheDocument();
+  expect(screen.getByText(/원화 · 현금/)).toBeInTheDocument();
+  expect(screen.getByText(/원화 · 매수 가능/)).toBeInTheDocument();
 });
 
 test("Toss manual card shows quiet 수동 badge and falls back to '-' when empty", () => {
@@ -65,7 +65,7 @@ test("Toss manual card shows quiet 수동 badge and falls back to '-' when empty
 
 test("buyingPower rendering does not attach onClick handlers", () => {
   render(<AccountCardList accounts={[acct()]} />);
-  const buyingPowerLabel = screen.getByText(/원화 매수/);
+  const buyingPowerLabel = screen.getByText(/원화 · 매수 가능/);
   // buyingPower 행과 그 자식 어디에도 button 또는 onClick 없음
   const cell = buyingPowerLabel.closest('[data-testid="account-card"]')!;
   expect(cell.querySelector("button, [role='button']")).toBeNull();

--- a/frontend/invest/src/components/AccountCardList.tsx
+++ b/frontend/invest/src/components/AccountCardList.tsx
@@ -57,26 +57,26 @@ function AccountCard({ a }: { a: Account }) {
       >
         {a.source === "kis" && (
           <>
-            <Cell k="원화 현금" v={formatKrw(a.cashBalances.krw ?? null)} />
-            <Cell k="달러 현금" v={formatUsd(a.cashBalances.usd ?? null)} />
-            <Cell k="원화 매수" v={formatKrw(a.buyingPower.krw ?? null)} />
-            <Cell k="달러 매수" v={formatUsd(a.buyingPower.usd ?? null)} />
+            <Cell k="원화 · 현금" v={formatKrw(a.cashBalances.krw ?? null)} />
+            <Cell k="달러 · 현금" v={formatUsd(a.cashBalances.usd ?? null)} />
+            <Cell k="원화 · 매수 가능" v={formatKrw(a.buyingPower.krw ?? null)} />
+            <Cell k="달러 · 매수 가능" v={formatUsd(a.buyingPower.usd ?? null)} />
           </>
         )}
         {a.source === "upbit" && (
           <>
-            <Cell k="원화 현금" v={formatKrw(a.cashBalances.krw ?? null)} />
-            <Cell k="원화 매수" v={formatKrw(a.buyingPower.krw ?? null)} />
+            <Cell k="원화 · 현금" v={formatKrw(a.cashBalances.krw ?? null)} />
+            <Cell k="원화 · 매수 가능" v={formatKrw(a.buyingPower.krw ?? null)} />
           </>
         )}
         {isToss && (
           <>
             <Cell
-              k="원화 현금"
+              k="원화 · 현금"
               v={a.cashBalances.krw === undefined ? "-" : formatKrw(a.cashBalances.krw)}
             />
             <Cell
-              k="원화 매수"
+              k="원화 · 매수 가능"
               v={a.buyingPower.krw === undefined ? "-" : formatKrw(a.buyingPower.krw)}
             />
           </>

--- a/frontend/invest/src/components/HeroCard.tsx
+++ b/frontend/invest/src/components/HeroCard.tsx
@@ -23,7 +23,9 @@ export function HeroCard({ summary }: { summary: HomeSummary }) {
         {formatPercent(summary.pnlRate)}
       </div>
       <div className="subtle" style={{ marginTop: 4 }}>
-        원금 {summary.costBasisKrw === null ? "정보 부족" : formatKrw(summary.costBasisKrw)} 기준
+        {summary.costBasisKrw === null
+          ? "원금 산정 불가"
+          : `원금 ${formatKrw(summary.costBasisKrw)} 기준`}
       </div>
     </div>
   );

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -74,6 +74,8 @@ async def test_kis_reader_excludes_cash_from_value_and_converts_usd(
 
     account = result.accounts[0]
     assert account.valueKrw == 720_000 + 220 * 1_300
+    assert account.costBasisKrw == 700_000 + 200 * 1_300
+    assert account.pnlKrw == (720_000 + 220 * 1_300) - (700_000 + 200 * 1_300)
     assert account.cashBalances.krw == 100_000
     assert account.buyingPower.krw == 50_000
     assert account.cashBalances.krw not in (account.valueKrw, account.costBasisKrw)
@@ -111,11 +113,97 @@ async def test_upbit_reader_uses_coin_value_not_krw_cash(
 
     account = result.accounts[0]
     assert account.valueKrw == 10_000_000
+    assert account.costBasisKrw == 8_000_000
+    assert account.pnlKrw == 2_000_000
     assert account.cashBalances.krw == 90_000
     assert account.buyingPower.krw == 90_000
     assert account.valueKrw != account.cashBalances.krw
     assert result.holdings[0].valueKrw == 10_000_000
     assert result.holdings[0].pnlKrw == 2_000_000
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_upbit_reader_falls_back_per_market_and_skips_zero_quantity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _coins() -> list[dict[str, Any]]:
+        return [
+            {"currency": "KRW", "balance": "90000", "locked": "0"},
+            {
+                "currency": "BTC",
+                "balance": "0.1",
+                "locked": "0",
+                "avg_buy_price": "80000000",
+            },
+            {
+                "currency": "XYM",
+                "balance": "0",
+                "locked": "0",
+                "avg_buy_price": "10",
+            },
+            {
+                "currency": "PCI",
+                "balance": "1",
+                "locked": "0",
+                "avg_buy_price": "1000",
+            },
+        ]
+
+    calls: list[list[str]] = []
+
+    async def _prices(markets: list[str]) -> dict[str, float]:
+        calls.append(markets)
+        if markets == ["KRW-BTC", "KRW-PCI"]:
+            return {}
+        if markets == ["KRW-BTC"]:
+            return {"KRW-BTC": 100_000_000.0}
+        return {}
+
+    monkeypatch.setattr(readers, "fetch_my_coins", _coins)
+    monkeypatch.setattr(readers, "fetch_multiple_current_prices", _prices)
+
+    result = await readers.UpbitHomeReader(db=None).fetch(user_id=1)  # type: ignore[arg-type]
+
+    assert [h.symbol for h in result.holdings] == ["BTC", "PCI"]
+    assert calls == [["KRW-BTC", "KRW-PCI"], ["KRW-BTC"], ["KRW-PCI"]]
+    assert result.holdings[0].valueKrw == 10_000_000
+    assert result.accounts[0].valueKrw == 10_000_000
+    assert result.accounts[0].costBasisKrw == 8_000_000
+    assert result.accounts[0].pnlKrw == 2_000_000
+    assert result.warning is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_upbit_reader_does_not_show_loss_when_all_prices_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _coins() -> list[dict[str, Any]]:
+        return [
+            {"currency": "KRW", "balance": "90000", "locked": "0"},
+            {
+                "currency": "PCI",
+                "balance": "1",
+                "locked": "0",
+                "avg_buy_price": "1000",
+            },
+        ]
+
+    async def _prices(markets: list[str]) -> dict[str, float]:
+        assert markets == ["KRW-PCI"]
+        return {}
+
+    monkeypatch.setattr(readers, "fetch_my_coins", _coins)
+    monkeypatch.setattr(readers, "fetch_multiple_current_prices", _prices)
+
+    result = await readers.UpbitHomeReader(db=None).fetch(user_id=1)  # type: ignore[arg-type]
+
+    assert result.accounts[0].valueKrw == 0
+    assert result.accounts[0].costBasisKrw is None
+    assert result.accounts[0].pnlKrw is None
+    assert result.accounts[0].pnlRate is None
+    assert result.warning is not None
 
 
 @pytest.mark.asyncio
@@ -147,8 +235,7 @@ async def test_manual_reader_does_not_fabricate_value_from_cost_basis(
 
     result = await readers.ManualHomeReader(db=None).fetch(user_id=1)  # type: ignore[arg-type]
 
-    assert result.accounts[0].valueKrw == 0
-    assert result.accounts[0].costBasisKrw is None
+    assert result.accounts == []
     assert result.holdings[0].costBasis == 700_000
     assert result.holdings[0].valueKrw is None
     assert result.warning is not None

--- a/tests/test_invest_home_service.py
+++ b/tests/test_invest_home_service.py
@@ -138,6 +138,48 @@ def test_grouped_null_costbasis_propagates() -> None:
 
 
 @pytest.mark.unit
+def test_grouped_infers_manual_value_from_live_same_symbol_price() -> None:
+    kis = _h(
+        holdingId="kis-kakao",
+        source="kis",
+        symbol="035720",
+        market="KR",
+        currency="KRW",
+        quantity=6,
+        averageCost=40_000,
+        costBasis=240_000,
+        valueNative=300_000,
+        valueKrw=300_000,
+        pnlKrw=60_000,
+        pnlRate=0.25,
+    )
+    toss = _h(
+        holdingId="toss-kakao",
+        source="toss_manual",
+        accountKind="manual",
+        symbol="035720",
+        market="KR",
+        currency="KRW",
+        quantity=4,
+        averageCost=45_000,
+        costBasis=180_000,
+        valueNative=None,
+        valueKrw=None,
+        pnlKrw=None,
+        pnlRate=None,
+    )
+
+    grouped = build_grouped_holdings([kis, toss])
+
+    g = grouped[0]
+    assert g.totalQuantity == 10
+    assert g.valueKrw == 500_000
+    assert g.costBasis == 420_000
+    assert g.pnlKrw == 80_000
+    assert g.pnlRate == pytest.approx(80_000 / 420_000)
+
+
+@pytest.mark.unit
 def test_grouped_never_merges_crypto_with_equity() -> None:
     eq = _h(symbol="BTC", market="US", assetType="equity", currency="USD")
     cx = _h(


### PR DESCRIPTION
## Summary
- clarify KIS/Upbit KRW cash and buying-power labels so buying power is not shown as a purchased amount
- hide manual/Toss accounts from invest account cards while keeping manual holdings available for grouped rows
- infer grouped manual holding value from priced same-symbol live holdings and keep Upbit quantity visible even when price/cost data is partial
- make Upbit price lookup more resilient with per-market fallback and warnings for missing prices without fabricating losses

## Validation
- uv run ruff check app/ tests/
- uv run ruff format --check app/ tests/
- uv run ty check app/ --error-on-warning
- uv run --group test pytest tests/test_invest_home_readers.py tests/test_invest_home_service.py tests/test_invest_api_router.py tests/test_invest_app_spa_router_safety.py tests/test_invest_api_router_safety.py tests/test_trading_decisions_spa_router_safety.py -q
- cd frontend/invest && npm run typecheck && npm test -- --run && npm run build

## Safety
- Read-only invest home/API/frontend display changes only
- No order, broker mutation, scheduler, watch, or DB write path changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PnL (Profit/Loss) metrics now displayed for investments in KRW and as a percentage rate across accounts and holdings.
  * Enhanced price data retrieval with intelligent fallback mechanisms.

* **Improvements**
  * Better handling of partial investment data in valuation calculations.
  * Account detail labels reformatted for improved clarity.

* **Behavior Changes**
  * Manual holdings accounts are no longer displayed in home view while preserving holdings data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->