### PR TITLE
fix(alpaca-paper): relax residual position preflight

### DIFF
--- a/app/services/alpaca_paper_anomaly_checks.py
+++ b/app/services/alpaca_paper_anomaly_checks.py
@@ -303,7 +303,8 @@ def build_paper_execution_preflight_report(
         open_orders: Read-only broker open-order snapshot already fetched by
             the caller. Non-terminal rows block a new cycle.
         positions: Read-only position snapshot already fetched by the caller.
-            Any non-zero quantity blocks a new cycle.
+            Non-zero quantities are reported for operator context but do not
+            block exploratory paper-trading cycles.
         approval_packet: Optional preview/approval packet being considered for
             execution. Used for duplicate, stale, and symbol checks.
         expected_signal_symbol: Optional symbol from the signal artifact.
@@ -354,13 +355,13 @@ def build_paper_execution_preflight_report(
             },
         )
 
-    # 2. Residual positions before a new cycle.
+    # 2. Existing positions before a new exploratory paper cycle.
     residual_positions = [p for p in position_rows if _position_qty(p) != Decimal("0")]
     if residual_positions:
         add(
             "residual_position_exists",
-            PaperExecutionAnomalySeverity.block,
-            "Residual Alpaca Paper position exists before starting a new cycle",
+            PaperExecutionAnomalySeverity.warning,
+            "Existing Alpaca Paper positions are present before starting a new cycle",
             {
                 "count": len(residual_positions),
                 "positions": [

--- a/tests/services/test_alpaca_paper_anomaly_checks.py
+++ b/tests/services/test_alpaca_paper_anomaly_checks.py
@@ -83,13 +83,21 @@ def test_open_order_blocks_new_cycle():
 
 
 @pytest.mark.unit
-def test_residual_position_blocks_new_cycle():
+def test_residual_position_is_reported_without_blocking_new_cycle():
     report = build_paper_execution_preflight_report(
-        positions=[{"symbol": "BTCUSD", "qty": "0.001", "asset_class": "crypto"}]
+        positions=[{"symbol": "UBER", "qty": "1", "asset_class": "us_equity"}]
     )
 
-    assert report.should_block is True
+    assert report.status == "pass"
+    assert report.should_block is False
     assert "residual_position_exists" in _check_ids(report)
+    residual = next(
+        a for a in report.anomalies if a.check_id == "residual_position_exists"
+    )
+    assert residual.severity == PaperExecutionAnomalySeverity.warning
+    assert residual.details["positions"] == [
+        {"symbol": "UBER", "qty": "1", "asset_class": "us_equity"}
+    ]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Downgrade Alpaca Paper `residual_position_exists` from blocking anomaly to warning-only context
- Keep existing position details in the preflight report so operators can still see leftover paper holdings
- Update the focused anomaly test to assert residual positions do not block exploratory paper cycles

## Verification
- `env -u PUBLIC_API_PATHS uv run pytest tests/services/test_alpaca_paper_anomaly_checks.py -q`
- `env -u PUBLIC_API_PATHS uv run ruff check app/services/alpaca_paper_anomaly_checks.py tests/services/test_alpaca_paper_anomaly_checks.py`
- `env -u PUBLIC_API_PATHS uv run ruff format --check app/services/alpaca_paper_anomaly_checks.py tests/services/test_alpaca_paper_anomaly_checks.py`

Closes ROB-125


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exploratory trading cycles are no longer blocked when residual positions exist. Instead, a non-blocking warning is issued with details about existing positions to provide context for your trading activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->