### PR TITLE
test(quality): refactor float comparisons to use pytest.approx (Phase 3)

### DIFF
--- a/docs/superpowers/plans/2025-03-24-refactor-float-comparisons.md
+++ b/docs/superpowers/plans/2025-03-24-refactor-float-comparisons.md
@@ -1,0 +1,165 @@
+# Refactor Float Comparisons in `tests/test_trading_integration.py` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace manual absolute difference checks with `pytest.approx` in `tests/test_trading_integration.py`.
+
+**Architecture:** Use `pytest.approx` with explicit `abs` tolerance for floating point assertions.
+
+**Tech Stack:** Python, Pytest.
+
+---
+
+### Task 1: Refactor `TestMergedPortfolioService`
+
+**Files:**
+- Modify: `tests/test_trading_integration.py`
+
+- [ ] **Step 1: Replace manual comparison in `test_calculate_combined_avg_basic`**
+
+```python
+        # OLD
+        assert abs(result - expected) < 0.01
+        # NEW
+        assert result == pytest.approx(expected, abs=0.01)
+```
+
+- [ ] **Step 2: Replace manual comparison in `test_calculate_combined_avg_three_brokers`**
+
+```python
+        # OLD
+        assert abs(result - expected) < 0.01
+        # NEW
+        assert result == pytest.approx(expected, abs=0.01)
+```
+
+- [ ] **Step 3: Run tests and verify**
+
+Run: `uv run pytest tests/test_trading_integration.py::TestMergedPortfolioService -v`
+Expected: PASS
+
+### Task 2: Refactor `TestReferencePrices` and `TestTradingPriceService`
+
+**Files:**
+- Modify: `tests/test_trading_integration.py`
+
+- [ ] **Step 1: Replace manual comparison in `TestReferencePrices.test_reference_prices_both_brokers`**
+
+```python
+        # OLD
+        assert abs(data["combined_avg"] - 73666.67) < 0.01
+        # NEW
+        assert data["combined_avg"] == pytest.approx(73666.67, abs=0.01)
+```
+
+- [ ] **Step 2: Replace manual comparison in `TestTradingPriceService.test_buy_price_with_combined_avg`**
+
+```python
+        # OLD
+        assert abs(result.price - 73666.67) < 0.01
+        # NEW
+        assert result.price == pytest.approx(73666.67, abs=0.01)
+```
+
+- [ ] **Step 3: Replace manual comparison in `TestTradingPriceService.test_buy_price_with_lowest_minus_percent`**
+
+```python
+        # OLD
+        assert abs(result.price - expected) < 0.01
+        # NEW
+        assert result.price == pytest.approx(expected, abs=0.01)
+```
+
+- [ ] **Step 4: Replace manual comparison in `TestTradingPriceService.test_sell_price_with_kis_avg_plus`**
+
+```python
+        # OLD
+        assert abs(result.price - expected) < 0.01
+        # NEW
+        assert result.price == pytest.approx(expected, abs=0.01)
+```
+
+- [ ] **Step 5: Replace manual comparison in `TestTradingPriceService.test_sell_price_with_toss_avg_plus`**
+
+```python
+        # OLD
+        assert abs(result.price - expected) < 0.01
+        # NEW
+        assert result.price == pytest.approx(expected, abs=0.01)
+```
+
+- [ ] **Step 6: Replace manual comparison in `TestTradingPriceService.test_sell_price_with_combined_avg_plus`**
+
+```python
+        # OLD
+        assert abs(result.price - expected) < 1  # 소수점 반올림 오차 허용
+        # NEW
+        assert result.price == pytest.approx(expected, abs=1)
+```
+
+- [ ] **Step 7: Run tests and verify**
+
+Run: `uv run pytest tests/test_trading_integration.py::TestReferencePrices -v && uv run pytest tests/test_trading_integration.py::TestTradingPriceService -v`
+Expected: PASS
+
+### Task 3: Refactor `TestExpectedProfit`, `TestGetReferencePricesIntegration`, and `TestRequirementsVerification`
+
+**Files:**
+- Modify: `tests/test_trading_integration.py`
+
+- [ ] **Step 1: Replace manual comparison in `TestExpectedProfit.test_expected_profit_percent`**
+
+```python
+        # OLD
+        assert abs(result["based_on_kis_avg"].percent - expected_percent) < 0.01
+        # NEW
+        assert result["based_on_kis_avg"].percent == pytest.approx(expected_percent, abs=0.01)
+```
+
+- [ ] **Step 2: Replace manual comparison in `TestGetReferencePricesIntegration.test_get_reference_prices_both_brokers`**
+
+```python
+        # OLD
+        assert abs(ref.combined_avg - expected_combined) < 0.01
+        # NEW
+        assert ref.combined_avg == pytest.approx(expected_combined, abs=0.01)
+```
+
+- [ ] **Step 3: Replace manual comparison in `TestRequirementsVerification.test_requirement_buy_uses_all_reference_prices`**
+
+```python
+        # OLD
+        assert abs(r3.price - 73666.67) < 0.01
+        # NEW
+        assert r3.price == pytest.approx(73666.67, abs=0.01)
+```
+
+- [ ] **Step 4: Replace manual comparison in `TestRequirementsVerification.test_requirement_sell_price_strategies` (3 occurrences)**
+
+```python
+        # OLD
+        assert abs(r1.price - 74000 * 1.05) < 0.01
+        assert abs(r2.price - 73000 * 1.10) < 0.01
+        assert abs(r3.price - 73666.67 * 1.03) < 1
+        # NEW
+        assert r1.price == pytest.approx(74000 * 1.05, abs=0.01)
+        assert r2.price == pytest.approx(73000 * 1.10, abs=0.01)
+        assert r3.price == pytest.approx(73666.67 * 1.03, abs=1)
+```
+
+- [ ] **Step 5: Run all tests and verify**
+
+Run: `uv run pytest tests/test_trading_integration.py -v`
+Expected: PASS
+
+- [ ] **Step 6: Format and Lint**
+
+Run: `make format && make lint`
+Expected: Success
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/test_trading_integration.py
+git commit -m "test: refactor float comparisons to use pytest.approx in test_trading_integration.py"
+```

--- a/docs/superpowers/plans/2025-05-13-refactor-float-comparisons-pytest-approx.md
+++ b/docs/superpowers/plans/2025-05-13-refactor-float-comparisons-pytest-approx.md
@@ -1,0 +1,224 @@
+# Refactor Float Comparisons Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor manual float comparisons and direct float equalities in test files to use `pytest.approx` for better robustness and to address SonarCloud rule python:S1244.
+
+**Architecture:** Use `pytest.approx` for all float comparisons in the specified test files. Handle `Decimal` types correctly where they appear.
+
+**Tech Stack:** Python, pytest
+
+---
+
+### Task 1: Refactor `tests/test_mcp_indicator_math.py`
+
+**Files:**
+- Modify: `tests/test_mcp_indicator_math.py`
+
+- [ ] **Step 1: Replace manual abs comparisons with pytest.approx**
+
+```python
+# Around line 217
+assert result["histogram"] == pytest.approx(expected_hist, abs=0.01)
+
+# Around line 258
+assert bollinger["middle"] == pytest.approx(sma["20"], abs=0.01)
+
+# Around line 608
+assert result["signal"] == pytest.approx(expected_signal, abs=0.01)
+```
+
+- [ ] **Step 2: Run tests to verify**
+
+Run: `uv run pytest tests/test_mcp_indicator_math.py`
+
+---
+
+### Task 2: Refactor `tests/test_n8n_daily_brief_service.py`
+
+**Files:**
+- Modify: `tests/test_n8n_daily_brief_service.py`
+
+- [ ] **Step 1: Replace manual abs comparisons with pytest.approx**
+
+```python
+# Around line 319
+assert us["pnl_pct"] == pytest.approx(6.67, abs=1.0)
+
+# Around line 344
+assert kr["pnl_pct"] == pytest.approx(7.14, abs=1.0)
+
+# Around line 368
+assert crypto["pnl_pct"] == pytest.approx(10.0, abs=1.0)
+
+# Around line 394
+assert us["pnl_pct"] == pytest.approx(5.56, abs=1.0)
+
+# Around line 456
+assert us["pnl_pct"] == pytest.approx(-1.96, abs=0.5)
+```
+
+- [ ] **Step 2: Run tests to verify**
+
+Run: `uv run pytest tests/test_n8n_daily_brief_service.py`
+
+---
+
+### Task 3: Refactor `tests/test_mcp_fundamentals_tools.py`
+
+**Files:**
+- Modify: `tests/test_mcp_fundamentals_tools.py`
+
+- [ ] **Step 1: Replace direct float equalities and abs comparisons with pytest.approx**
+Note: This file has many occurrences. I will target the ones mentioned and others found.
+
+```python
+# Around line 247
+assert rec["rsi14"] == pytest.approx(45.8)
+
+# Around line 258
+assert rec["rsi14"] == pytest.approx(0.0)
+
+# Around line 341
+assert result["indicators"]["rsi"]["14"] == pytest.approx(45.8)
+
+# Around line 343
+assert result["recommendation"]["rsi14"] == pytest.approx(45.8)
+
+# And many others in TestGetValuation, TestGetMarketIndex, etc.
+# example:
+# assert result["per"] == pytest.approx(12.5)
+```
+
+- [ ] **Step 2: Run tests to verify**
+
+Run: `uv run pytest tests/test_mcp_fundamentals_tools.py`
+
+---
+
+### Task 4: Refactor `tests/test_portfolio_overview_service.py`
+
+**Files:**
+- Modify: `tests/test_portfolio_overview_service.py`
+
+- [ ] **Step 1: Replace manual abs comparisons with pytest.approx**
+
+```python
+# Around line 1306
+assert result[0]["avg_price"] == pytest.approx(200000.0 / 1350.0, abs=0.01)
+
+# Around line 1332
+assert result[0]["avg_price"] == pytest.approx(195000.0 / 1300.0, abs=0.01)
+
+# Around line 1351
+assert result["profit_loss"] == pytest.approx(15 * 120.0 - cost_basis, abs=0.01)
+```
+
+- [ ] **Step 2: Run tests to verify**
+
+Run: `uv run pytest tests/test_portfolio_overview_service.py`
+
+---
+
+### Task 5: Refactor `tests/test_trading_integration.py`
+
+**Files:**
+- Modify: `tests/test_trading_integration.py`
+
+- [ ] **Step 1: Replace manual abs comparisons with pytest.approx**
+
+```python
+# Replace matches like:
+# assert abs(result - expected) < 0.01
+# with:
+# assert result == pytest.approx(expected, abs=0.01)
+```
+
+- [ ] **Step 2: Run tests to verify**
+
+Run: `uv run pytest tests/test_trading_integration.py`
+
+---
+
+### Task 6: Refactor `tests/test_naver_finance.py`
+
+**Files:**
+- Modify: `tests/test_naver_finance.py`
+
+- [ ] **Step 1: Replace manual abs comparisons with pytest.approx**
+
+```python
+# Around line 90, 1017
+assert result["dividend_yield"] == pytest.approx(0.02, abs=0.001)
+
+# Around line 700, 891
+assert consensus["upside_pct"] == pytest.approx(16.67, abs=0.01)
+
+# Around line 1049
+assert result["current_position_52w"] == pytest.approx(0.83, abs=0.01)
+```
+
+- [ ] **Step 2: Run tests to verify**
+
+Run: `uv run pytest tests/test_naver_finance.py`
+
+---
+
+### Task 7: Refactor `tests/services/test_portfolio_overview_currency.py`
+
+**Files:**
+- Modify: `tests/services/test_portfolio_overview_currency.py`
+
+- [ ] **Step 1: Replace manual abs comparisons with pytest.approx**
+
+```python
+# Around line 65
+assert position["avg_price"] == pytest.approx(150.0, abs=0.01)
+
+# Around line 70
+assert actual_cost_basis == pytest.approx(expected_cost_basis, abs=0.01)
+
+# Around line 74
+assert position["profit_rate"] == pytest.approx(0.333, abs=0.01)
+
+# Around line 212, 215
+assert holding.toss_avg_price == pytest.approx(150.0, abs=0.01)
+assert holding.combined_avg_price == pytest.approx(150.0, abs=0.01)
+
+# Around line 219
+assert holding.profit_rate == pytest.approx(expected_profit_rate, abs=0.01)
+```
+
+- [ ] **Step 2: Run tests to verify**
+
+Run: `uv run pytest tests/services/test_portfolio_overview_currency.py`
+
+---
+
+### Task 8: Refactor `tests/services/test_pending_reconciliation_service.py`
+
+**Files:**
+- Modify: `tests/services/test_pending_reconciliation_service.py`
+
+- [ ] **Step 1: Replace manual abs comparisons with pytest.approx**
+
+```python
+# Around line 168
+assert item.gap_pct == pytest.approx(Decimal("0.2857"), abs=Decimal("0.001"))
+```
+
+- [ ] **Step 2: Run tests to verify**
+
+Run: `uv run pytest tests/services/test_pending_reconciliation_service.py`
+
+---
+
+### Task 9: Final Formatting and Cleanup
+
+- [ ] **Step 1: Run format and lint**
+
+Run: `make format && make lint`
+
+- [ ] **Step 2: Final test run**
+
+Run: `make test-unit`

--- a/docs/superpowers/specs/2025-03-24-refactor-float-comparisons-design.md
+++ b/docs/superpowers/specs/2025-03-24-refactor-float-comparisons-design.md
@@ -1,0 +1,33 @@
+# Design Spec: Refactor Float Comparisons in `tests/test_trading_integration.py`
+
+## Goal
+Improve the readability and idiomatic quality of the test suite by replacing manual absolute difference checks with `pytest.approx`.
+
+## Scope
+- File: `tests/test_trading_integration.py`
+- Target: All occurrences of `assert abs(a - b) < eps`.
+
+## Architecture & Implementation
+The refactoring is a direct string replacement of manual assertion logic with the `pytest.approx` helper.
+
+### Refactoring Mappings
+- `assert abs(result - expected) < 0.01` -> `assert result == pytest.approx(expected, abs=0.01)`
+- `assert abs(data["combined_avg"] - 73666.67) < 0.01` -> `assert data["combined_avg"] == pytest.approx(73666.67, abs=0.01)`
+- `assert abs(result.price - 73666.67) < 0.01` -> `assert result.price == pytest.approx(73666.67, abs=0.01)`
+- `assert abs(result.price - expected) < 0.01` -> `assert result.price == pytest.approx(expected, abs=0.01)`
+- `assert abs(result.price - expected) < 1` -> `assert result.price == pytest.approx(expected, abs=1)`
+- `assert abs(result["based_on_kis_avg"].percent - expected_percent) < 0.01` -> `assert result["based_on_kis_avg"].percent == pytest.approx(expected_percent, abs=0.01)`
+- `assert abs(ref.combined_avg - expected_combined) < 0.01` -> `assert ref.combined_avg == pytest.approx(expected_combined, abs=0.01)`
+- `assert abs(r3.price - 73666.67) < 0.01` -> `assert r3.price == pytest.approx(73666.67, abs=0.01)`
+- `assert abs(r1.price - 74000 * 1.05) < 0.01` -> `assert r1.price == pytest.approx(74000 * 1.05, abs=0.01)`
+- `assert abs(r2.price - 73000 * 1.10) < 0.01` -> `assert r2.price == pytest.approx(73000 * 1.10, abs=0.01)`
+- `assert abs(r3.price - 73666.67 * 1.03) < 1` -> `assert r3.price == pytest.approx(73666.67 * 1.03, abs=1)`
+
+## Testing & Validation
+1.  **Run Tests:** Execute `uv run pytest tests/test_trading_integration.py` to confirm behavioral parity.
+2.  **Linting:** Run `make lint` and `make format` to ensure style consistency.
+
+## Success Criteria
+- No manual `abs()` calls remain for float comparisons in the target file.
+- All integration tests pass.
+- Code matches project style standards.

--- a/tests/services/kis_websocket/test_events.py
+++ b/tests/services/kis_websocket/test_events.py
@@ -41,8 +41,8 @@ class TestBuildLifecycleEvent:
         assert event.detail["market"] == "kr"
         assert event.detail["symbol"] == "005930"
         assert event.detail["side"] == "bid"
-        assert event.detail["filled_qty"] == 10.0
-        assert event.detail["filled_price"] == 70000.0
+        assert event.detail["filled_qty"] == pytest.approx(10.0)
+        assert event.detail["filled_price"] == pytest.approx(70000.0)
         assert event.detail["fill_yn"] == "2"
 
     def test_domestic_acknowledgement_maps_to_pending(self):

--- a/tests/services/test_candidate_screening_service.py
+++ b/tests/services/test_candidate_screening_service.py
@@ -43,8 +43,8 @@ async def test_wraps_screen_stocks_and_annotates_held(monkeypatch) -> None:
     assert res.total == 2
     btc = next(c for c in res.candidates if c.symbol == "KRW-BTC")
     eth = next(c for c in res.candidates if c.symbol == "KRW-ETH")
-    assert btc.price == 123.4
-    assert btc.volume == 123456.0
+    assert btc.price == pytest.approx(123.4)
+    assert btc.volume == pytest.approx(123456.0)
     assert btc.is_held is True
     assert eth.is_held is False
     assert "rsi_enrichment_skipped" in res.warnings
@@ -76,5 +76,5 @@ async def test_passes_filters_through(monkeypatch) -> None:
     assert kwargs["strategy"] == "momentum"
     assert kwargs["sort_by"] == "change_rate"
     assert kwargs["limit"] == 20
-    assert kwargs["max_per"] == 15.0
+    assert kwargs["max_per"] == pytest.approx(15.0)
     assert kwargs["adv_krw_min"] == 1_000_000_000

--- a/tests/services/test_pending_reconciliation_service.py
+++ b/tests/services/test_pending_reconciliation_service.py
@@ -165,7 +165,7 @@ def test_near_fill_buy() -> None:
     item = reconcile_pending_order(_order(), _ctx_with_quote("70200"))
     assert item.classification == "near_fill"
     assert item.gap_pct is not None
-    assert abs(item.gap_pct - Decimal("0.2857")) < Decimal("0.001")
+    assert item.gap_pct == pytest.approx(Decimal("0.2857"), abs=1e-3)
 
 
 @pytest.mark.unit

--- a/tests/services/test_portfolio_action_service.py
+++ b/tests/services/test_portfolio_action_service.py
@@ -55,7 +55,7 @@ async def test_aggregates_holdings_with_research_and_journal(monkeypatch) -> Non
     candidate = result.candidates[0]
     assert candidate.symbol == "KRW-SOL"
     assert candidate.market == "CRYPTO"
-    assert candidate.profit_rate == -0.1225
+    assert candidate.profit_rate == pytest.approx(-0.1225)
     assert candidate.latest_research_session_id == 32
     assert candidate.summary_decision == "hold"
     assert candidate.candidate_action in {"trim", "hold", "watch"}
@@ -107,9 +107,9 @@ async def test_build_action_board_uses_total_quantity_for_merged_holdings(
     assert result.total == 1
     candidate = result.candidates[0]
     assert candidate.symbol == "005930"
-    assert candidate.quantity == 3.0
+    assert candidate.quantity == pytest.approx(3.0)
     assert candidate.market == "KR"
-    assert candidate.profit_rate == 0.3747
+    assert candidate.profit_rate == pytest.approx(0.3747)
 
 
 @pytest.mark.unit
@@ -143,6 +143,6 @@ async def test_load_holdings_keeps_crypto_when_kis_unavailable(monkeypatch) -> N
     holdings, total, warnings = await service._load_holdings(1, None)
 
     assert holdings == [crypto_holding]
-    assert total == 100.0
+    assert total == pytest.approx(100.0)
     assert any(w.startswith("KR holdings unavailable") for w in warnings)
     assert any(w.startswith("US holdings unavailable") for w in warnings)

--- a/tests/services/test_portfolio_overview_currency.py
+++ b/tests/services/test_portfolio_overview_currency.py
@@ -62,16 +62,16 @@ class TestUSPortfolioCurrencyConversion:
 
         # avg_price should be weighted average in USD
         # (10 * 150 + 5 * 150) / 15 = 150 (after KRW conversion: 195000/1300 = 150)
-        assert abs(position["avg_price"] - 150.0) < 0.01
+        assert position["avg_price"] == pytest.approx(150.0, abs=0.01)
 
         # Cost basis should be reasonable (2250 USD, not ~977K)
         expected_cost_basis = 15.0 * 150.0
         actual_cost_basis = position["quantity"] * position["avg_price"]
-        assert abs(actual_cost_basis - expected_cost_basis) < 0.01
+        assert actual_cost_basis == pytest.approx(expected_cost_basis, abs=0.01)
 
         # PnL should be positive (bought at 150, now at 200)
         assert position["profit_rate"] > 0
-        assert abs(position["profit_rate"] - 0.333) < 0.01  # ~33.3% gain
+        assert position["profit_rate"] == pytest.approx(0.333, abs=0.01)  # ~33.3% gain
 
     def test_aggregate_positions_without_conversion_gives_wrong_result(
         self, mock_components_mixed_currency
@@ -209,11 +209,11 @@ class TestMergedPortfolioCurrencyConversion:
         service._finalize_holdings(merged, usd_krw=usd_krw)
 
         # Toss avg_price should be converted from KRW to USD
-        assert abs(holding.toss_avg_price - 150.0) < 0.01  # 195000/1300
+        assert holding.toss_avg_price == pytest.approx(150.0, abs=0.01)  # 195000/1300
 
         # Combined avg should be weighted average in USD
-        assert abs(holding.combined_avg_price - 150.0) < 0.01
+        assert holding.combined_avg_price == pytest.approx(150.0, abs=0.01)
 
         # PnL should be calculated correctly
         expected_profit_rate = (200.0 - 150.0) / 150.0  # ~33.3%
-        assert abs(holding.profit_rate - expected_profit_rate) < 0.01
+        assert holding.profit_rate == pytest.approx(expected_profit_rate, abs=0.01)

--- a/tests/services/test_research_retrospective_service.py
+++ b/tests/services/test_research_retrospective_service.py
@@ -235,10 +235,10 @@ async def test_stage_coverage_reports_stale_and_unavailable(db_session) -> None:
     )
 
     coverage = {s.stage_type: s for s in out.stage_coverage}
-    assert coverage["market"].coverage_pct == 100.0
-    assert coverage["news"].stale_pct == 100.0
-    assert coverage["social"].unavailable_pct == 100.0
-    assert coverage["social"].coverage_pct == 100.0
+    assert coverage["market"].coverage_pct == pytest.approx(100.0)
+    assert coverage["news"].stale_pct == pytest.approx(100.0)
+    assert coverage["social"].unavailable_pct == pytest.approx(100.0)
+    assert coverage["social"].coverage_pct == pytest.approx(100.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_kis_account_fetch_stocks.py
+++ b/tests/test_kis_account_fetch_stocks.py
@@ -116,15 +116,15 @@ class TestParseMarginResponse:
         }
         result = client._parse_margin_response(output)
         assert result["dnca_tot_amt"] == 5_000_000.0
-        assert result["usd_ord_psbl_amt"] == 1500.50
-        assert result["usd_balance"] == 2000.00
+        assert result["usd_ord_psbl_amt"] == pytest.approx(1500.50)
+        assert result["usd_balance"] == pytest.approx(2000.00)
         assert result["raw"] is output
 
     def test_handles_empty_strings(self):
         client = AccountClient(FakeParent())
         output = {"dnca_tot_amt": "", "stck_cash_objt_amt": ""}
         result = client._parse_margin_response(output)
-        assert result["dnca_tot_amt"] == 0.0
+        assert result["dnca_tot_amt"] == pytest.approx(0.0)
 
     def test_fallback_fields(self):
         client = AccountClient(FakeParent())
@@ -137,5 +137,5 @@ class TestParseMarginResponse:
         result = client._parse_margin_response(output)
         assert result["dnca_tot_amt"] == 4_000_000.0
         assert result["stck_cash_ord_psbl_amt"] == 3_000_000.0
-        assert result["usd_ord_psbl_amt"] == 1200.00
-        assert result["usd_balance"] == 900.00
+        assert result["usd_ord_psbl_amt"] == pytest.approx(1200.00)
+        assert result["usd_balance"] == pytest.approx(900.00)

--- a/tests/test_kr_hourly_candles_read_service.py
+++ b/tests/test_kr_hourly_candles_read_service.py
@@ -644,12 +644,12 @@ async def test_current_hour_is_reaggregated_from_minutes_not_from_db_hour(monkey
     assert len(out) == 1
     row = out.iloc[0]
     assert row["datetime"] == current_bucket
-    assert row["open"] == 100.0
-    assert row["high"] == 102.0
-    assert row["low"] == 99.0
-    assert row["close"] == 101.0
-    assert row["volume"] == 30.0
-    assert row["value"] == 3000.0
+    assert row["open"] == pytest.approx(100.0)
+    assert row["high"] == pytest.approx(102.0)
+    assert row["low"] == pytest.approx(99.0)
+    assert row["close"] == pytest.approx(101.0)
+    assert row["volume"] == pytest.approx(30.0)
+    assert row["value"] == pytest.approx(3000.0)
 
 
 @pytest.mark.asyncio
@@ -729,9 +729,9 @@ async def test_api_overrides_db_minutes_for_same_minute_and_venue(monkeypatch):
     assert len(out) == 1
     row = out.iloc[0]
     assert row["datetime"] == current_bucket
-    assert row["open"] == 200.0
-    assert row["close"] == 200.0
-    assert row["volume"] == 1.0
+    assert row["open"] == pytest.approx(200.0)
+    assert row["close"] == pytest.approx(200.0)
+    assert row["volume"] == pytest.approx(1.0)
 
 
 @pytest.mark.asyncio
@@ -805,10 +805,10 @@ async def test_same_minute_both_venues_price_krx_priority_volume_sum(monkeypatch
     assert len(out) == 1
     row = out.iloc[0]
     assert row["datetime"] == current_bucket
-    assert row["open"] == 100.0
-    assert row["close"] == 105.0
-    assert row["volume"] == 15.0
-    assert row["value"] == 1500.0
+    assert row["open"] == pytest.approx(100.0)
+    assert row["close"] == pytest.approx(105.0)
+    assert row["volume"] == pytest.approx(15.0)
+    assert row["value"] == pytest.approx(1500.0)
     assert row["venues"] == ["KRX", "NTX"]
 
 

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -4193,7 +4193,7 @@ class TestComputeRsiWeights:
         result = market_data_indicators._compute_rsi_weights(25.0, 3)
 
         assert len(result) == 3
-        assert abs(sum(result) - 1.0) < 0.001
+        assert sum(result) == pytest.approx(1.0, abs=0.001)
         # Front-heavy: first step gets most weight
         assert result[0] > result[1] > result[2]
 
@@ -4202,7 +4202,7 @@ class TestComputeRsiWeights:
         result = market_data_indicators._compute_rsi_weights(28.0, 4)
 
         assert len(result) == 4
-        assert abs(sum(result) - 1.0) < 0.001
+        assert sum(result) == pytest.approx(1.0, abs=0.001)
         # Front-heavy: first > last, monotonically decreasing
         assert result[0] > result[-1]
         assert result[0] > result[1] > result[2] > result[3]
@@ -4212,7 +4212,7 @@ class TestComputeRsiWeights:
         result = market_data_indicators._compute_rsi_weights(65.0, 3)
 
         assert len(result) == 3
-        assert abs(sum(result) - 1.0) < 0.001
+        assert sum(result) == pytest.approx(1.0, abs=0.001)
         # Back-heavy: last step gets most weight
         assert result[2] > result[1] > result[0]
 
@@ -4221,19 +4221,19 @@ class TestComputeRsiWeights:
         result = market_data_indicators._compute_rsi_weights(40.0, 3)
 
         assert len(result) == 3
-        assert abs(sum(result) - 1.0) < 0.001
+        assert sum(result) == pytest.approx(1.0, abs=0.001)
         # All weights equal
-        assert all(abs(w - result[0]) < 0.001 for w in result)
+        assert result == pytest.approx([result[0]] * len(result), abs=0.001)
 
     def test_none_rsi_returns_equal_weights(self):
         """None RSI: equal distribution (same as neutral)."""
         result = market_data_indicators._compute_rsi_weights(None, 3)
 
         assert len(result) == 3
-        assert abs(sum(result) - 1.0) < 0.001
+        assert sum(result) == pytest.approx(1.0, abs=0.001)
         # All weights equal
         expected_weight = 1.0 / 3
-        assert all(abs(w - expected_weight) < 0.001 for w in result)
+        assert result == pytest.approx([expected_weight] * 3, abs=0.001)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_indicator_math.py
+++ b/tests/test_mcp_indicator_math.py
@@ -214,7 +214,7 @@ class TestCalculateMACD:
         assert result["signal"] is not None
         assert result["histogram"] is not None
         expected_hist = result["macd"] - result["signal"]
-        assert abs(result["histogram"] - expected_hist) < 0.01
+        assert result["histogram"] == pytest.approx(expected_hist, abs=0.01)
 
 
 # ---------------------------------------------------------------------------
@@ -255,7 +255,7 @@ class TestCalculateBollinger:
 
         assert bollinger["middle"] is not None
         assert sma["20"] is not None
-        assert abs(bollinger["middle"] - sma["20"]) < 0.01
+        assert bollinger["middle"] == pytest.approx(sma["20"], abs=0.01)
 
 
 # ---------------------------------------------------------------------------
@@ -605,7 +605,7 @@ class TestOBVRegression:
         expected_signal = obv.ewm(span=10, adjust=False).mean().iloc[-1]
 
         assert result["signal"] is not None
-        assert abs(result["signal"] - expected_signal) < 0.01
+        assert result["signal"] == pytest.approx(expected_signal, abs=0.01)
 
     def test_divergence_uses_lookback_plus_one_index(self):
         close = pd.Series(

--- a/tests/test_mcp_place_order.py
+++ b/tests/test_mcp_place_order.py
@@ -185,10 +185,10 @@ async def test_place_order_upbit_buy_limit_dry_run(monkeypatch):
     assert result["symbol"] == "KRW-BTC"
     assert result["side"] == "buy"
     assert result["order_type"] == "limit"
-    assert result["price"] == 45000000.0
-    assert result["quantity"] == 0.02
-    assert result["estimated_value"] == 900000.0
-    assert result["fee"] == 4500.0
+    assert result["price"] == pytest.approx(45000000.0)
+    assert result["quantity"] == pytest.approx(0.02)
+    assert result["estimated_value"] == pytest.approx(900000.0)
+    assert result["fee"] == pytest.approx(4500.0)
 
 
 @pytest.mark.asyncio
@@ -628,7 +628,7 @@ async def test_place_order_nyse_exchange_code(monkeypatch):
     assert buy_calls[0]["symbol"] == "TSM"
     assert buy_calls[0]["exchange_code"] == "NYSE"
     assert buy_calls[0]["quantity"] == 10
-    assert buy_calls[0]["price"] == 150.0
+    assert buy_calls[0]["price"] == pytest.approx(150.0)
 
 
 @pytest.mark.asyncio
@@ -669,7 +669,7 @@ class TestPlaceOrderHighAmount:
 
         price = await order_execution._get_current_price_for_order("KRW-BTC", "crypto")
 
-        assert price == 50000000.0
+        assert price == pytest.approx(50000000.0)
         ticker_mock.assert_awaited_once_with(["KRW-BTC"], use_cache=False)
 
     @pytest.mark.asyncio
@@ -897,7 +897,7 @@ class TestPlaceOrderHighAmount:
         assert buy_calls[0]["symbol"] == "AAPL"
         assert buy_calls[0]["exchange_code"] == "NASD"
         assert buy_calls[0]["quantity"] == 10000
-        assert buy_calls[0]["price"] == 250.0
+        assert buy_calls[0]["price"] == pytest.approx(250.0)
 
     @pytest.mark.asyncio
     async def test_place_order_high_amount_crypto_dry_run_false(self, monkeypatch):
@@ -1223,7 +1223,7 @@ async def test_place_order_kr_equity_balance_precheck_skips_zero_priority_ordera
 
     assert result["success"] is True
     assert result["dry_run"] is True
-    assert result["estimated_value"] == 700000.0
+    assert result["estimated_value"] == pytest.approx(700000.0)
     assert "warning" not in result
 
 
@@ -1348,8 +1348,8 @@ async def test_place_order_kis_mock_sell_preview_uses_mock_holdings(monkeypatch)
     assert result["success"] is True
     assert result["dry_run"] is True
     assert result["account_mode"] == "kis_mock"
-    assert result["avg_buy_price"] == 227000.0
-    assert result["realized_pnl"] == 2500.0
+    assert result["avg_buy_price"] == pytest.approx(227000.0)
+    assert result["realized_pnl"] == pytest.approx(2500.0)
     assert kis_calls
     assert all(kis_calls)
 
@@ -1450,7 +1450,7 @@ async def test_place_order_crypto_sell_locked_zero_still_works(monkeypatch):
     )
 
     assert result["success"] is True
-    assert result["quantity"] == 0.5
+    assert result["quantity"] == pytest.approx(0.5)
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_mcp_portfolio_tools.py
+++ b/tests/test_mcp_portfolio_tools.py
@@ -61,26 +61,26 @@ async def test_get_cash_balance_all_accounts(monkeypatch):
     result = await tools["get_cash_balance"]()
 
     assert len(result["accounts"]) == 3
-    assert result["summary"]["total_krw"] == 1700000.0
-    assert result["summary"]["total_usd"] == 500.0
+    assert result["summary"]["total_krw"] == pytest.approx(1700000.0)
+    assert result["summary"]["total_usd"] == pytest.approx(500.0)
     assert len(result["errors"]) == 0
 
     upbit_account = next(acc for acc in result["accounts"] if acc["account"] == "upbit")
-    assert upbit_account["balance"] == 700000.0
-    assert upbit_account["orderable"] == 500000.0
+    assert upbit_account["balance"] == pytest.approx(700000.0)
+    assert upbit_account["orderable"] == pytest.approx(500000.0)
     assert upbit_account["formatted"] == "700,000 KRW"
 
     kis_domestic_account = next(
         acc for acc in result["accounts"] if acc["account"] == "kis_domestic"
     )
-    assert kis_domestic_account["balance"] == 1000000.0
-    assert kis_domestic_account["orderable"] == 800000.0
+    assert kis_domestic_account["balance"] == pytest.approx(1000000.0)
+    assert kis_domestic_account["orderable"] == pytest.approx(800000.0)
 
     kis_overseas_account = next(
         acc for acc in result["accounts"] if acc["account"] == "kis_overseas"
     )
-    assert kis_overseas_account["balance"] == 500.0
-    assert kis_overseas_account["orderable"] == 450.0
+    assert kis_overseas_account["balance"] == pytest.approx(500.0)
+    assert kis_overseas_account["orderable"] == pytest.approx(450.0)
     assert kis_overseas_account["exchange_rate"] is None
 
 
@@ -184,7 +184,7 @@ async def test_get_cash_balance_with_account_filter(monkeypatch):
 
     result = await tools["get_cash_balance"](account="upbit")
     assert len(result["accounts"]) == 0
-    assert result["summary"]["total_krw"] == 0.0
+    assert result["summary"]["total_krw"] == pytest.approx(0.0)
 
     result = await tools["get_cash_balance"](account="kis")
     assert len(result["accounts"]) == 2
@@ -207,10 +207,10 @@ async def test_get_cash_balance_with_account_filter_upbit_success(monkeypatch):
     assert len(result["accounts"]) == 1
     upbit_account = result["accounts"][0]
     assert upbit_account["account"] == "upbit"
-    assert upbit_account["balance"] == 700000.0
-    assert upbit_account["orderable"] == 500000.0
+    assert upbit_account["balance"] == pytest.approx(700000.0)
+    assert upbit_account["orderable"] == pytest.approx(500000.0)
     assert result["summary"]["total_krw"] == upbit_account["balance"]
-    assert result["summary"]["total_usd"] == 0.0
+    assert result["summary"]["total_usd"] == pytest.approx(0.0)
     assert len(result["errors"]) == 0
 
 
@@ -256,8 +256,8 @@ async def test_get_cash_balance_partial_failure(monkeypatch):
     kis_overseas_account = next(
         acc for acc in result["accounts"] if acc["account"] == "kis_overseas"
     )
-    assert kis_overseas_account["balance"] == 500.0
-    assert kis_overseas_account["orderable"] == 450.0
+    assert kis_overseas_account["balance"] == pytest.approx(500.0)
+    assert kis_overseas_account["orderable"] == pytest.approx(450.0)
     assert kis_overseas_account["exchange_rate"] is None
 
 
@@ -339,8 +339,8 @@ async def test_get_cash_balance_kis_domestic_prefers_stck_cash100_max_orderable(
         acc for acc in kis_only["accounts"] if acc["account"] == "kis_domestic"
     )
 
-    assert kis_domestic_account["orderable"] == 3534890.5473
-    assert kis_domestic_only["accounts"][0]["orderable"] == 3534890.5473
+    assert kis_domestic_account["orderable"] == pytest.approx(3534890.5473)
+    assert kis_domestic_only["accounts"][0]["orderable"] == pytest.approx(3534890.5473)
     assert "stck_cash100_max_ord_psbl_amt" not in kis_domestic_account
 
 
@@ -386,10 +386,10 @@ async def test_get_cash_balance_kis_domestic_skips_zero_priority_orderables(
         acc for acc in kis_only["accounts"] if acc["account"] == "kis_domestic"
     )
 
-    assert kis_domestic_account["balance"] == 5000000.0
-    assert kis_domestic_account["orderable"] == 2100000.25
-    assert kis_domestic_only["accounts"][0]["balance"] == 5000000.0
-    assert kis_domestic_only["accounts"][0]["orderable"] == 2100000.25
+    assert kis_domestic_account["balance"] == pytest.approx(5000000.0)
+    assert kis_domestic_account["orderable"] == pytest.approx(2100000.25)
+    assert kis_domestic_only["accounts"][0]["balance"] == pytest.approx(5000000.0)
+    assert kis_domestic_only["accounts"][0]["orderable"] == pytest.approx(2100000.25)
 
 
 @pytest.mark.asyncio
@@ -419,8 +419,8 @@ async def test_get_cash_balance_kis_domestic_deducts_pending_buy_orders(monkeypa
 
     result = await tools["get_cash_balance"](account="kis_domestic")
 
-    assert result["accounts"][0]["balance"] == 4300000.0
-    assert result["accounts"][0]["orderable"] == 980000.0
+    assert result["accounts"][0]["balance"] == pytest.approx(4300000.0)
+    assert result["accounts"][0]["orderable"] == pytest.approx(980000.0)
 
 
 @pytest.mark.asyncio
@@ -444,7 +444,7 @@ async def test_get_cash_balance_kis_domestic_pending_lookup_failure_keeps_raw_or
 
     result = await tools["get_cash_balance"](account="kis_domestic")
 
-    assert result["accounts"][0]["orderable"] == 4300000.0
+    assert result["accounts"][0]["orderable"] == pytest.approx(4300000.0)
 
 
 @pytest.mark.asyncio
@@ -468,7 +468,7 @@ async def test_get_cash_balance_kis_domestic_clamps_orderable_at_zero(monkeypatc
 
     result = await tools["get_cash_balance"](account="kis_domestic")
 
-    assert result["accounts"][0]["orderable"] == 0.0
+    assert result["accounts"][0]["orderable"] == pytest.approx(0.0)
 
 
 @pytest.mark.asyncio
@@ -563,8 +563,8 @@ async def test_get_cash_balance_kis_overseas_prefers_usd_us_row_for_orderable(
         None,
     )
     assert kis_overseas is not None
-    assert kis_overseas["balance"] == 5856.2
-    assert kis_overseas["orderable"] == 5824.17
+    assert kis_overseas["balance"] == pytest.approx(5856.2)
+    assert kis_overseas["orderable"] == pytest.approx(5824.17)
 
 
 @pytest.mark.asyncio
@@ -606,8 +606,8 @@ async def test_get_cash_balance_kis_overseas_us_row_missing_falls_back_to_usd_ma
         None,
     )
     assert kis_overseas is not None
-    assert kis_overseas["balance"] == 5856.2
-    assert kis_overseas["orderable"] == 5824.27
+    assert kis_overseas["balance"] == pytest.approx(5856.2)
+    assert kis_overseas["orderable"] == pytest.approx(5824.27)
 
 
 @pytest.mark.asyncio
@@ -669,8 +669,8 @@ async def test_get_cash_balance_uses_new_kis_field_names(monkeypatch):
     result = await tools["get_cash_balance"](account="kis_overseas")
 
     assert len(result["accounts"]) == 1
-    assert result["accounts"][0]["balance"] == 3500.0
-    assert result["accounts"][0]["orderable"] == 3200.0
+    assert result["accounts"][0]["balance"] == pytest.approx(3500.0)
+    assert result["accounts"][0]["orderable"] == pytest.approx(3200.0)
 
 
 @pytest.mark.asyncio
@@ -712,8 +712,8 @@ async def test_get_cash_balance_kis_overseas_avoids_duplicate_deduction_from_us_
 
     result = await tools["get_cash_balance"](account="kis_overseas")
 
-    assert result["accounts"][0]["balance"] == 1000.0
-    assert result["accounts"][0]["orderable"] == 700.0
+    assert result["accounts"][0]["balance"] == pytest.approx(1000.0)
+    assert result["accounts"][0]["orderable"] == pytest.approx(700.0)
 
 
 @pytest.mark.asyncio
@@ -742,7 +742,7 @@ async def test_get_cash_balance_kis_overseas_pending_lookup_failure_keeps_raw_or
     with caplog.at_level("WARNING"):
         result = await tools["get_cash_balance"](account="kis_overseas")
 
-    assert result["accounts"][0]["orderable"] == 1000.0
+    assert result["accounts"][0]["orderable"] == pytest.approx(1000.0)
     assert "USD pending order deduction failed" in caplog.text
 
 
@@ -772,8 +772,8 @@ class TestSimulateAvgCost:
         assert cp["avg_price"] == 2400000
         assert cp["total_quantity"] == 1
         assert cp["total_invested"] == 2400000
-        assert cp["unrealized_pnl"] == -243000.0
-        assert cp["unrealized_pnl_pct"] == -10.12
+        assert cp["unrealized_pnl"] == pytest.approx(-243000.0)
+        assert cp["unrealized_pnl_pct"] == pytest.approx(-10.12)
 
         assert result["current_market_price"] == 2157000
 
@@ -785,24 +785,24 @@ class TestSimulateAvgCost:
         assert s1["new_avg_price"] == 2225000
         assert s1["total_quantity"] == 2
         assert s1["total_invested"] == 4450000
-        assert s1["breakeven_change_pct"] == 3.15
-        assert s1["unrealized_pnl"] == -136000.0
-        assert s1["unrealized_pnl_pct"] == -3.06
+        assert s1["breakeven_change_pct"] == pytest.approx(3.15)
+        assert s1["unrealized_pnl"] == pytest.approx(-136000.0)
+        assert s1["unrealized_pnl_pct"] == pytest.approx(-3.06)
 
         # step 2
         s2 = result["steps"][1]
         assert s2["step"] == 2
-        assert s2["new_avg_price"] == 2116666.67
+        assert s2["new_avg_price"] == pytest.approx(2116666.67)
         assert s2["total_quantity"] == 3
         assert s2["total_invested"] == 6350000
         # avg 2116666.67 / mkt 2157000 - 1 = -1.87%
-        assert s2["breakeven_change_pct"] == -1.87
+        assert s2["breakeven_change_pct"] == pytest.approx(-1.87)
 
         # target_analysis
         ta = result["target_analysis"]
         assert ta["target_price"] == 3080000
-        assert ta["final_avg_price"] == 2116666.67
-        assert ta["total_return_pct"] == 45.51
+        assert ta["final_avg_price"] == pytest.approx(2116666.67)
+        assert ta["total_return_pct"] == pytest.approx(45.51)
 
     async def test_without_market_price(self):
         """Without current_market_price, P&L and breakeven fields are absent."""
@@ -835,7 +835,7 @@ class TestSimulateAvgCost:
         assert ta["final_avg_price"] == 90
         assert ta["profit_per_unit"] == 30
         assert ta["total_profit"] == 300
-        assert ta["total_return_pct"] == 33.33
+        assert ta["total_return_pct"] == pytest.approx(33.33)
 
     async def test_validation_missing_holdings_fields(self):
         tools = build_tools()
@@ -882,8 +882,8 @@ class TestSimulateAvgCost:
         assert s["new_avg_price"] == 900
         assert s["total_quantity"] == 4
         # avg == market → breakeven 0%
-        assert s["breakeven_change_pct"] == 0.0
-        assert s["unrealized_pnl"] == 0.0
+        assert s["breakeven_change_pct"] == pytest.approx(0.0)
+        assert s["unrealized_pnl"] == pytest.approx(0.0)
 
     async def test_accepts_zero_initial_quantity_and_adds_target_metrics(self):
         tools = build_tools()
@@ -898,10 +898,10 @@ class TestSimulateAvgCost:
         )
 
         assert result["current_position"]["avg_price"] is None
-        assert result["steps"][0]["target_return_pct"] == 20.0
+        assert result["steps"][0]["target_return_pct"] == pytest.approx(20.0)
         assert "pnl_vs_current" in result["steps"][0]
-        assert result["steps"][1]["new_avg_price"] == 95.0
-        assert result["steps"][1]["target_return_pct"] == 26.32
+        assert result["steps"][1]["new_avg_price"] == pytest.approx(95.0)
+        assert result["steps"][1]["target_return_pct"] == pytest.approx(26.32)
 
     async def test_requested_scenario_contains_step_target_return(self):
         tools = build_tools()
@@ -1045,16 +1045,16 @@ async def test_get_holdings_groups_by_account_and_calculates_pnl(monkeypatch):
     kis_kr = next(
         item for item in kis_account["positions"] if item["symbol"] == "005930"
     )
-    assert kis_kr["current_price"] == 71000.0
-    assert kis_kr["evaluation_amount"] == 142000.0
-    assert kis_kr["profit_loss"] == 2000.0
-    assert kis_kr["profit_rate"] == 1.43
+    assert kis_kr["current_price"] == pytest.approx(71000.0)
+    assert kis_kr["evaluation_amount"] == pytest.approx(142000.0)
+    assert kis_kr["profit_loss"] == pytest.approx(2000.0)
+    assert kis_kr["profit_rate"] == pytest.approx(1.43)
 
     kis_us = next(item for item in kis_account["positions"] if item["symbol"] == "AAPL")
-    assert kis_us["current_price"] == 210.0
-    assert kis_us["evaluation_amount"] == 210.0
-    assert kis_us["profit_loss"] == 10.0
-    assert kis_us["profit_rate"] == 5.0
+    assert kis_us["current_price"] == pytest.approx(210.0)
+    assert kis_us["evaluation_amount"] == pytest.approx(210.0)
+    assert kis_us["profit_loss"] == pytest.approx(10.0)
+    assert kis_us["profit_rate"] == pytest.approx(5.0)
     us_quote_mock.assert_not_awaited()
 
     upbit_account = next(
@@ -1063,8 +1063,8 @@ async def test_get_holdings_groups_by_account_and_calculates_pnl(monkeypatch):
     btc = upbit_account["positions"][0]
     assert btc["symbol"] == "KRW-BTC"
     assert btc["name"] == "비트코인"
-    assert btc["current_price"] == 60000000.0
-    assert btc["evaluation_amount"] == 6000000.0
+    assert btc["current_price"] == pytest.approx(60000000.0)
+    assert btc["evaluation_amount"] == pytest.approx(6000000.0)
 
 
 @pytest.mark.asyncio
@@ -1143,8 +1143,8 @@ async def test_get_holdings_crypto_prices_batch_fetch(monkeypatch):
     positions_by_symbol = {
         position["symbol"]: position for position in result["accounts"][0]["positions"]
     }
-    assert positions_by_symbol["KRW-BTC"]["current_price"] == 61000000.0
-    assert positions_by_symbol["KRW-ETH"]["current_price"] == 4200000.0
+    assert positions_by_symbol["KRW-BTC"]["current_price"] == pytest.approx(61000000.0)
+    assert positions_by_symbol["KRW-ETH"]["current_price"] == pytest.approx(4200000.0)
     quote_mock.assert_awaited_once()
     assert result["errors"] == []
 
@@ -1227,7 +1227,7 @@ async def test_get_holdings_includes_crypto_price_errors(monkeypatch):
     positions_by_symbol = {
         position["symbol"]: position for position in result["accounts"][0]["positions"]
     }
-    assert positions_by_symbol["KRW-BTC"]["current_price"] == 62000000.0
+    assert positions_by_symbol["KRW-BTC"]["current_price"] == pytest.approx(62000000.0)
     assert "KRW-DOGE" not in positions_by_symbol
 
     assert len(result["errors"]) == 1
@@ -1432,7 +1432,7 @@ async def test_get_holdings_filters_delisted_markets_before_batch_fetch(monkeypa
         position["symbol"]: position for position in result["accounts"][0]["positions"]
     }
     assert positions_by_symbol["KRW-BTC"]["symbol"] == "KRW-BTC"
-    assert positions_by_symbol["KRW-BTC"]["current_price"] == 62000000.0
+    assert positions_by_symbol["KRW-BTC"]["current_price"] == pytest.approx(62000000.0)
     assert "KRW-PCI" not in positions_by_symbol
 
     assert result["errors"] == []
@@ -1857,14 +1857,14 @@ async def test_get_holdings_includes_top_level_summary(monkeypatch):
 
     summary = result["summary"]
     assert summary["position_count"] == 2
-    assert summary["total_buy_amount"] == 8000000.0
-    assert summary["total_evaluation"] == 10000000.0
-    assert summary["total_profit_loss"] == 2000000.0
-    assert summary["total_profit_rate"] == 25.0
+    assert summary["total_buy_amount"] == pytest.approx(8000000.0)
+    assert summary["total_evaluation"] == pytest.approx(10000000.0)
+    assert summary["total_profit_loss"] == pytest.approx(2000000.0)
+    assert summary["total_profit_rate"] == pytest.approx(25.0)
     assert summary["weights"][0]["symbol"] == "KRW-BTC"
-    assert summary["weights"][0]["weight_pct"] == 60.0
+    assert summary["weights"][0]["weight_pct"] == pytest.approx(60.0)
     assert summary["weights"][1]["symbol"] == "KRW-ETH"
-    assert summary["weights"][1]["weight_pct"] == 40.0
+    assert summary["weights"][1]["weight_pct"] == pytest.approx(40.0)
 
 
 @pytest.mark.asyncio
@@ -1903,7 +1903,7 @@ async def test_get_holdings_summary_sets_price_dependent_fields_null(monkeypatch
     )
 
     summary = result["summary"]
-    assert summary["total_buy_amount"] == 3000000.0
+    assert summary["total_buy_amount"] == pytest.approx(3000000.0)
     assert summary["total_evaluation"] is None
     assert summary["total_profit_loss"] is None
     assert summary["total_profit_rate"] is None
@@ -1967,23 +1967,23 @@ async def test_get_holdings_preserves_kis_values_on_yahoo_failure(monkeypatch):
 
     amzn = positions_by_symbol["AMZN"]
     assert amzn["symbol"] == "AMZN"
-    assert amzn["quantity"] == 10.0
-    assert amzn["avg_buy_price"] == 150.0
+    assert amzn["quantity"] == pytest.approx(10.0)
+    assert amzn["avg_buy_price"] == pytest.approx(150.0)
     assert amzn["current_price"] is None
     assert amzn["price_error"] == "Symbol 'AMZN' not found"
-    assert amzn["evaluation_amount"] == 1600.0
-    assert amzn["profit_loss"] == 100.0
-    assert amzn["profit_rate"] == 6.67
+    assert amzn["evaluation_amount"] == pytest.approx(1600.0)
+    assert amzn["profit_loss"] == pytest.approx(100.0)
+    assert amzn["profit_rate"] == pytest.approx(6.67)
 
     aapl = positions_by_symbol["AAPL"]
     assert aapl["symbol"] == "AAPL"
-    assert aapl["quantity"] == 5.0
-    assert aapl["avg_buy_price"] == 180.0
+    assert aapl["quantity"] == pytest.approx(5.0)
+    assert aapl["avg_buy_price"] == pytest.approx(180.0)
     assert aapl["current_price"] is None
     assert aapl["price_error"] == "Symbol 'AAPL' not found"
-    assert aapl["evaluation_amount"] == 9500.0
-    assert aapl["profit_loss"] == -500.0
-    assert aapl["profit_rate"] == -5.26
+    assert aapl["evaluation_amount"] == pytest.approx(9500.0)
+    assert aapl["profit_loss"] == pytest.approx(-500.0)
+    assert aapl["profit_rate"] == pytest.approx(-5.26)
 
     assert len(result["errors"]) == 2
     error_symbols = {error["symbol"] for error in result["errors"]}
@@ -2056,10 +2056,10 @@ async def test_collect_portfolio_positions_skips_yahoo_for_kis_us_with_valid_num
 
     assert result_errors == []
     assert result_positions == positions
-    assert result_positions[0]["current_price"] == 210.0
-    assert result_positions[0]["evaluation_amount"] == 210.0
-    assert result_positions[0]["profit_loss"] == 0.0
-    assert result_positions[0]["profit_rate"] == 0.0
+    assert result_positions[0]["current_price"] == pytest.approx(210.0)
+    assert result_positions[0]["evaluation_amount"] == pytest.approx(210.0)
+    assert result_positions[0]["profit_loss"] == pytest.approx(0.0)
+    assert result_positions[0]["profit_rate"] == pytest.approx(0.0)
     quote_mock.assert_not_awaited()
 
 
@@ -2118,17 +2118,17 @@ async def test_get_holdings_fetches_yahoo_only_for_kis_us_missing_price_and_reca
     }
 
     aapl = positions_by_symbol["AAPL"]
-    assert aapl["current_price"] == 210.0
-    assert aapl["evaluation_amount"] == 210.0
-    assert aapl["profit_loss"] == 10.0
-    assert aapl["profit_rate"] == 5.0
+    assert aapl["current_price"] == pytest.approx(210.0)
+    assert aapl["evaluation_amount"] == pytest.approx(210.0)
+    assert aapl["profit_loss"] == pytest.approx(10.0)
+    assert aapl["profit_rate"] == pytest.approx(5.0)
     assert "price_error" not in aapl
 
     amzn = positions_by_symbol["AMZN"]
-    assert amzn["current_price"] == 165.0
-    assert amzn["evaluation_amount"] == 1650.0
-    assert amzn["profit_loss"] == 150.0
-    assert amzn["profit_rate"] == 10.0
+    assert amzn["current_price"] == pytest.approx(165.0)
+    assert amzn["evaluation_amount"] == pytest.approx(1650.0)
+    assert amzn["profit_loss"] == pytest.approx(150.0)
+    assert amzn["profit_rate"] == pytest.approx(10.0)
     assert "price_error" not in amzn
 
     quote_mock.assert_awaited_once_with("AMZN")
@@ -2175,10 +2175,10 @@ async def test_get_holdings_fetches_yahoo_for_kis_us_with_missing_kis_metrics(
 
     aapl = result["accounts"][0]["positions"][0]
     assert aapl["symbol"] == "AAPL"
-    assert aapl["current_price"] == 220.0
-    assert aapl["evaluation_amount"] == 220.0
-    assert aapl["profit_loss"] == 20.0
-    assert aapl["profit_rate"] == 10.0
+    assert aapl["current_price"] == pytest.approx(220.0)
+    assert aapl["evaluation_amount"] == pytest.approx(220.0)
+    assert aapl["profit_loss"] == pytest.approx(20.0)
+    assert aapl["profit_rate"] == pytest.approx(10.0)
     assert "price_error" not in aapl
 
     quote_mock.assert_awaited_once_with("AAPL")
@@ -2227,10 +2227,10 @@ async def test_get_holdings_fetches_yahoo_for_kis_us_with_invalid_evaluation_amo
 
     aapl = result["accounts"][0]["positions"][0]
     assert aapl["symbol"] == "AAPL"
-    assert aapl["current_price"] == 220.0
-    assert aapl["evaluation_amount"] == 220.0
-    assert aapl["profit_loss"] == 20.0
-    assert aapl["profit_rate"] == 10.0
+    assert aapl["current_price"] == pytest.approx(220.0)
+    assert aapl["evaluation_amount"] == pytest.approx(220.0)
+    assert aapl["profit_loss"] == pytest.approx(20.0)
+    assert aapl["profit_rate"] == pytest.approx(10.0)
     assert "price_error" not in aapl
 
     quote_mock.assert_awaited_once_with("AAPL")
@@ -2283,10 +2283,10 @@ async def test_get_holdings_fetches_yahoo_for_kis_us_with_invalid_profit_metrics
 
     aapl = result["accounts"][0]["positions"][0]
     assert aapl["symbol"] == "AAPL"
-    assert aapl["current_price"] == 220.0
-    assert aapl["evaluation_amount"] == 220.0
-    assert aapl["profit_loss"] == 20.0
-    assert aapl["profit_rate"] == 10.0
+    assert aapl["current_price"] == pytest.approx(220.0)
+    assert aapl["evaluation_amount"] == pytest.approx(220.0)
+    assert aapl["profit_loss"] == pytest.approx(20.0)
+    assert aapl["profit_rate"] == pytest.approx(10.0)
     assert "price_error" not in aapl
 
     quote_mock.assert_awaited_once_with("AAPL")
@@ -2356,16 +2356,16 @@ async def test_get_holdings_keeps_kis_us_price_when_manual_same_symbol_uses_yaho
     kis_aapl = accounts_by_id["kis"]["positions"][0]
     manual_aapl = accounts_by_id["toss"]["positions"][0]
 
-    assert kis_aapl["current_price"] == 210.0
-    assert kis_aapl["evaluation_amount"] == 210.0
-    assert kis_aapl["profit_loss"] == 10.0
-    assert kis_aapl["profit_rate"] == 5.0
+    assert kis_aapl["current_price"] == pytest.approx(210.0)
+    assert kis_aapl["evaluation_amount"] == pytest.approx(210.0)
+    assert kis_aapl["profit_loss"] == pytest.approx(10.0)
+    assert kis_aapl["profit_rate"] == pytest.approx(5.0)
     assert "price_error" not in kis_aapl
 
-    assert manual_aapl["current_price"] == 225.0
-    assert manual_aapl["evaluation_amount"] == 450.0
-    assert manual_aapl["profit_loss"] == 70.0
-    assert manual_aapl["profit_rate"] == 18.42
+    assert manual_aapl["current_price"] == pytest.approx(225.0)
+    assert manual_aapl["evaluation_amount"] == pytest.approx(450.0)
+    assert manual_aapl["profit_loss"] == pytest.approx(70.0)
+    assert manual_aapl["profit_rate"] == pytest.approx(18.42)
     assert "price_error" not in manual_aapl
 
     quote_mock.assert_awaited_once_with("AAPL")
@@ -2435,10 +2435,10 @@ async def test_get_holdings_only_records_yahoo_error_for_same_symbol_manual_fall
     kis_aapl = accounts_by_id["kis"]["positions"][0]
     manual_aapl = accounts_by_id["toss"]["positions"][0]
 
-    assert kis_aapl["current_price"] == 210.0
-    assert kis_aapl["evaluation_amount"] == 210.0
-    assert kis_aapl["profit_loss"] == 10.0
-    assert kis_aapl["profit_rate"] == 5.0
+    assert kis_aapl["current_price"] == pytest.approx(210.0)
+    assert kis_aapl["evaluation_amount"] == pytest.approx(210.0)
+    assert kis_aapl["profit_loss"] == pytest.approx(10.0)
+    assert kis_aapl["profit_rate"] == pytest.approx(5.0)
     assert "price_error" not in kis_aapl
 
     assert manual_aapl["current_price"] is None
@@ -2617,7 +2617,7 @@ async def test_get_holdings_crypto_stop_loss_signal(monkeypatch):
     assert btc_position.get("strategy_signal") is not None
     assert btc_position["strategy_signal"]["action"] == "sell"
     assert btc_position["strategy_signal"]["reason"] == "stop_loss"
-    assert btc_position["strategy_signal"]["threshold_pct"] == -4.5
+    assert btc_position["strategy_signal"]["threshold_pct"] == pytest.approx(-4.5)
 
 
 @pytest.mark.asyncio
@@ -2660,7 +2660,7 @@ async def test_get_holdings_crypto_mean_reversion_signal(monkeypatch):
     assert btc_position.get("strategy_signal") is not None
     assert btc_position["strategy_signal"]["action"] == "sell"
     assert btc_position["strategy_signal"]["reason"] == "mean_reversion_exit"
-    assert btc_position["strategy_signal"]["rsi_14"] == 50.0
+    assert btc_position["strategy_signal"]["rsi_14"] == pytest.approx(50.0)
 
 
 @pytest.mark.asyncio
@@ -3102,8 +3102,8 @@ async def test_get_holdings_with_paper_account_filter(monkeypatch):
     pos = result["accounts"][0]["positions"][0]
     assert pos["symbol"] == "005930"
     assert pos["name"] == "삼성전자"
-    assert pos["quantity"] == 10.0
-    assert pos["avg_buy_price"] == 72000.0
+    assert pos["quantity"] == pytest.approx(10.0)
+    assert pos["avg_buy_price"] == pytest.approx(72000.0)
 
 
 @pytest.mark.asyncio
@@ -3257,7 +3257,7 @@ async def test_get_cash_balance_paper_all(monkeypatch):
 
     assert {r["currency"] for r in result["accounts"]} == {"KRW", "USD"}
     assert result["summary"]["total_krw"] == 10_000_000.0
-    assert result["summary"]["total_usd"] == 500.0
+    assert result["summary"]["total_usd"] == pytest.approx(500.0)
     assert result["errors"] == []
 
 
@@ -3305,7 +3305,7 @@ async def test_get_available_capital_paper(monkeypatch):
     assert result["manual_cash"] is None
     # 10,000,000 KRW + 500 USD * 1400 = 10,700,000
     assert result["summary"]["total_orderable_krw"] == 10_700_000.0
-    assert result["summary"]["exchange_rate_usd_krw"] == 1400.0
+    assert result["summary"]["exchange_rate_usd_krw"] == pytest.approx(1400.0)
     # paper USD row must have krw_equivalent injected
     usd_row = next(r for r in result["accounts"] if r["currency"] == "USD")
     assert usd_row["krw_equivalent"] == 700_000.0

--- a/tests/test_mcp_quotes_tools.py
+++ b/tests/test_mcp_quotes_tools.py
@@ -192,8 +192,8 @@ async def test_get_quote_korean_equity(monkeypatch):
 
     assert result["instrument_type"] == "equity_kr"
     assert result["source"] == "kis"
-    assert result["price"] == 105.0  # price = close
-    assert result["open"] == 100.0
+    assert result["price"] == pytest.approx(105.0)  # price = close
+    assert result["open"] == pytest.approx(100.0)
     assert called["code"] == "005930"
     assert called["market"] == "J"
     assert called["n"] == 1
@@ -235,7 +235,7 @@ async def test_get_quote_korean_etf(monkeypatch):
 
     assert result["instrument_type"] == "equity_kr"
     assert result["source"] == "kis"
-    assert result["price"] == 105.0
+    assert result["price"] == pytest.approx(105.0)
 
 
 @pytest.mark.asyncio
@@ -284,7 +284,7 @@ async def test_fetch_quote_equity_kr_passes_market_j(monkeypatch, symbol, label)
     assert called["market"] == "J", f"Expected market='J' for {label} symbol {symbol}"
     assert result["instrument_type"] == "equity_kr"
     assert result["source"] == "kis"
-    assert result["price"] == 105.0
+    assert result["price"] == pytest.approx(105.0)
     assert result["symbol"] == symbol
 
 
@@ -314,11 +314,11 @@ async def test_get_quote_us_equity(monkeypatch):
 
     assert result["instrument_type"] == "equity_us"
     assert result["source"] == "yahoo"
-    assert result["price"] == 205.0
-    assert result["previous_close"] == 201.5
-    assert result["open"] == 202.0
-    assert result["high"] == 206.2
-    assert result["low"] == 200.8
+    assert result["price"] == pytest.approx(205.0)
+    assert result["previous_close"] == pytest.approx(201.5)
+    assert result["open"] == pytest.approx(202.0)
+    assert result["high"] == pytest.approx(206.2)
+    assert result["low"] == pytest.approx(200.8)
     assert result["volume"] == 123456789
     mock_fetch_fast_info.assert_awaited_once_with("AAPL")
 
@@ -439,8 +439,8 @@ async def test_get_dividends_uses_session_and_keeps_payload(monkeypatch):
 
     assert result["success"] is True
     assert result["symbol"] == "AAPL"
-    assert result["dividend_yield"] == 0.0123
-    assert result["dividend_rate"] == 1.11
+    assert result["dividend_yield"] == pytest.approx(0.0123)
+    assert result["dividend_rate"] == pytest.approx(1.11)
     assert result["ex_dividend_date"] == "2024-01-01"
     assert result["last_dividend"] == {"date": "2024-04-01", "amount": 1.2}
     assert captured["symbol"] == "AAPL"

--- a/tests/test_mcp_screen_stocks_kr.py
+++ b/tests/test_mcp_screen_stocks_kr.py
@@ -147,14 +147,14 @@ async def test_screen_stocks_tool_forwards_new_fundamentals_filters(
     assert called["asset_type"] == "stock"
     assert called["sector"] == "반도체"
     assert called["min_analyst_buy"] == 8
-    assert called["min_dividend"] == 3.0
+    assert called["min_dividend"] == pytest.approx(3.0)
     first = result["results"][0]
     assert first["sector"] == "반도체"
     assert first["analyst_buy"] == 16
     assert first["analyst_hold"] == 2
     assert first["analyst_sell"] == 0
-    assert first["avg_target"] == 98000.0
-    assert first["upside_pct"] == 18.7
+    assert first["avg_target"] == pytest.approx(98000.0)
+    assert first["upside_pct"] == pytest.approx(18.7)
 
 
 @pytest.mark.asyncio
@@ -180,7 +180,7 @@ async def test_screen_stocks_crypto_strategy_default_uses_trade_amount(
     await tools["screen_stocks"](market="crypto", strategy="oversold", limit=5)
 
     assert called["market"] == "crypto"
-    assert called["max_rsi"] == 30.0
+    assert called["max_rsi"] == pytest.approx(30.0)
     assert called["sort_by"] == "trade_amount"
     assert called["sort_order"] == "desc"
 
@@ -214,6 +214,6 @@ async def test_screen_stocks_crypto_strategy_preserves_explicit_sort(
     )
 
     assert called["market"] == "crypto"
-    assert called["max_rsi"] == 30.0
+    assert called["max_rsi"] == pytest.approx(30.0)
     assert called["sort_by"] == "rsi"
     assert called["sort_order"] == "desc"

--- a/tests/test_n8n_daily_brief_service.py
+++ b/tests/test_n8n_daily_brief_service.py
@@ -316,7 +316,7 @@ class TestBuildPortfolioSummary:
         # PnL should be approximately +6.67%, NOT -99.8%
         assert us["pnl_pct"] is not None
         assert us["pnl_pct"] > 0, f"Expected positive PnL, got {us['pnl_pct']}"
-        assert abs(us["pnl_pct"] - 6.67) < 1.0
+        assert us["pnl_pct"] == pytest.approx(6.67, abs=1.0)
 
     def test_kr_pnl_still_works(self):
         """KR positions should still calculate PnL correctly."""
@@ -341,7 +341,7 @@ class TestBuildPortfolioSummary:
         assert kr is not None
         assert kr["pnl_pct"] is not None
         assert kr["pnl_pct"] > 0
-        assert abs(kr["pnl_pct"] - 7.14) < 1.0
+        assert kr["pnl_pct"] == pytest.approx(7.14, abs=1.0)
 
     def test_crypto_pnl_still_works(self):
         """Crypto positions should still calculate PnL correctly."""
@@ -365,7 +365,7 @@ class TestBuildPortfolioSummary:
         crypto = result.get("crypto")
         assert crypto is not None
         assert crypto["pnl_pct"] is not None
-        assert abs(crypto["pnl_pct"] - 10.0) < 1.0
+        assert crypto["pnl_pct"] == pytest.approx(10.0, abs=1.0)
 
     def test_position_without_profit_rate_falls_back(self):
         """Positions missing profit_rate should fall back gracefully."""
@@ -391,7 +391,7 @@ class TestBuildPortfolioSummary:
         # When profit_rate is None, fall back to avg_price * qty calculation
         # $950 - $900 = $50, $50/$900 = 5.56%
         assert us["pnl_pct"] is not None
-        assert abs(us["pnl_pct"] - 5.56) < 1.0
+        assert us["pnl_pct"] == pytest.approx(5.56, abs=1.0)
 
     def test_zero_evaluation_returns_none_pnl(self):
         """Zero evaluation should not cause division errors."""

--- a/tests/test_naver_finance.py
+++ b/tests/test_naver_finance.py
@@ -83,10 +83,10 @@ class TestParseFinancialMetrics:
     def test_extracts_all_metrics(self) -> None:
         soup = BeautifulSoup(SAMPLE_VALUATION_MAIN_HTML, "lxml")
         result = naver_finance._parse_financial_metrics(soup)
-        assert result["per"] == 12.5
-        assert result["pbr"] == 1.2
-        assert result["roe"] == 18.5
-        assert result["roe_controlling"] == 17.2
+        assert result["per"] == pytest.approx(12.5)
+        assert result["pbr"] == pytest.approx(1.2)
+        assert result["roe"] == pytest.approx(18.5)
+        assert result["roe_controlling"] == pytest.approx(17.2)
         assert result["dividend_yield"] == pytest.approx(0.02, abs=0.001)
 
     def test_skips_zero_per(self) -> None:
@@ -99,7 +99,7 @@ class TestParseFinancialMetrics:
         soup = BeautifulSoup(SAMPLE_VALUATION_MINIMAL_MAIN_HTML, "lxml")
         result = naver_finance._parse_financial_metrics(soup)
         assert result["per"] is None
-        assert result["pbr"] == 2.1
+        assert result["pbr"] == pytest.approx(2.1)
         assert result["roe"] is None
         assert result["dividend_yield"] is None
 
@@ -569,8 +569,8 @@ class TestFetchCompanyProfile:
         assert result["sector"] == "전기전자"
         # Market cap: 400조 1,234억
         assert result["market_cap"] == 400 * 1_0000_0000_0000 + 1234 * 1_0000_0000
-        assert result["per"] == 15.23
-        assert result["pbr"] == 1.45
+        assert result["per"] == pytest.approx(15.23)
+        assert result["pbr"] == pytest.approx(1.45)
         assert result["eps"] == 5432
 
     async def test_filters_none_values(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -888,7 +888,9 @@ class TestFetchKrSnapshot:
         assert snapshot["opinions"]["count"] == 2
         assert snapshot["opinions"]["consensus"]["avg_target_price"] == 87500
         assert snapshot["opinions"]["consensus"]["current_price"] == 75000
-        assert snapshot["opinions"]["consensus"]["upside_pct"] == pytest.approx(16.67, abs=0.01)
+        assert snapshot["opinions"]["consensus"]["upside_pct"] == pytest.approx(
+            16.67, abs=0.01
+        )
 
     async def test_snapshot_keeps_other_sections_when_one_page_fails(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1010,15 +1012,17 @@ class TestFetchValuation:
         assert result["symbol"] == "005930"
         assert result["name"] == "삼성전자"
         assert result["current_price"] == 75000
-        assert result["per"] == 12.5
-        assert result["pbr"] == 1.2
-        assert result["roe"] == 18.5  # ROE(%)
-        assert result["roe_controlling"] == 17.2  # ROE(지배주주)
-        assert result["dividend_yield"] == pytest.approx(0.02, abs=0.001)  # 2.00% -> 0.02
+        assert result["per"] == pytest.approx(12.5)
+        assert result["pbr"] == pytest.approx(1.2)
+        assert result["roe"] == pytest.approx(18.5)  # ROE(%)
+        assert result["roe_controlling"] == pytest.approx(17.2)  # ROE(지배주주)
+        assert result["dividend_yield"] == pytest.approx(
+            0.02, abs=0.001
+        )  # 2.00% -> 0.02
         assert result["high_52w"] == 90000
         assert result["low_52w"] == 60000
         # Position: (75000 - 60000) / (90000 - 60000) = 0.5
-        assert result["current_position_52w"] == 0.5
+        assert result["current_position_52w"] == pytest.approx(0.5)
 
     async def test_minimal_data(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test with minimal HTML data (some values missing)."""
@@ -1039,7 +1043,7 @@ class TestFetchValuation:
         assert result["name"] == "효성중공업"
         assert result["current_price"] == 450000
         assert result["per"] is None  # N/A parsed as None
-        assert result["pbr"] == 2.1
+        assert result["pbr"] == pytest.approx(2.1)
         assert result["roe"] is None  # Not in HTML
         assert result["roe_controlling"] is None  # Not in HTML
         assert result["dividend_yield"] is None
@@ -1077,7 +1081,7 @@ class TestFetchValuation:
 
         result = await naver_finance.fetch_valuation("000000")
 
-        assert result["current_position_52w"] == 0.0
+        assert result["current_position_52w"] == pytest.approx(0.0)
 
     async def test_position_calculation_at_high(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1108,7 +1112,7 @@ class TestFetchValuation:
 
         result = await naver_finance.fetch_valuation("000000")
 
-        assert result["current_position_52w"] == 1.0
+        assert result["current_position_52w"] == pytest.approx(1.0)
 
     async def test_empty_html(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test with empty HTML."""

--- a/tests/test_naver_finance.py
+++ b/tests/test_naver_finance.py
@@ -87,7 +87,7 @@ class TestParseFinancialMetrics:
         assert result["pbr"] == 1.2
         assert result["roe"] == 18.5
         assert result["roe_controlling"] == 17.2
-        assert abs(result["dividend_yield"] - 0.02) < 0.001
+        assert result["dividend_yield"] == pytest.approx(0.02, abs=0.001)
 
     def test_skips_zero_per(self) -> None:
         html = '<html><body><em id="_per">0</em></body></html>'
@@ -697,7 +697,7 @@ class TestFetchInvestmentOpinions:
         assert consensus["median_target_price"] == 87500
         assert consensus["min_target_price"] == 85000
         assert consensus["max_target_price"] == 90000
-        assert abs(consensus["upside_pct"] - 16.67) < 0.01
+        assert consensus["upside_pct"] == pytest.approx(16.67, abs=0.01)
         assert consensus["current_price"] == 75000
 
     async def test_limit_applied(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -888,7 +888,7 @@ class TestFetchKrSnapshot:
         assert snapshot["opinions"]["count"] == 2
         assert snapshot["opinions"]["consensus"]["avg_target_price"] == 87500
         assert snapshot["opinions"]["consensus"]["current_price"] == 75000
-        assert abs(snapshot["opinions"]["consensus"]["upside_pct"] - 16.67) < 0.01
+        assert snapshot["opinions"]["consensus"]["upside_pct"] == pytest.approx(16.67, abs=0.01)
 
     async def test_snapshot_keeps_other_sections_when_one_page_fails(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1014,7 +1014,7 @@ class TestFetchValuation:
         assert result["pbr"] == 1.2
         assert result["roe"] == 18.5  # ROE(%)
         assert result["roe_controlling"] == 17.2  # ROE(지배주주)
-        assert abs(result["dividend_yield"] - 0.02) < 0.001  # 2.00% -> 0.02
+        assert result["dividend_yield"] == pytest.approx(0.02, abs=0.001)  # 2.00% -> 0.02
         assert result["high_52w"] == 90000
         assert result["low_52w"] == 60000
         # Position: (75000 - 60000) / (90000 - 60000) = 0.5
@@ -1046,7 +1046,7 @@ class TestFetchValuation:
         assert result["high_52w"] == 500000
         assert result["low_52w"] == 200000
         # Position: (450000 - 200000) / (500000 - 200000) = 0.833...
-        assert abs(result["current_position_52w"] - 0.83) < 0.01
+        assert result["current_position_52w"] == pytest.approx(0.83, abs=0.01)
 
     async def test_position_calculation_at_low(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_number_utils.py
+++ b/tests/test_number_utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from app.core.number_utils import parse_korean_number
 
 
@@ -20,11 +22,11 @@ class TestParseKoreanNumber:
     def test_percentage(self) -> None:
         result = parse_korean_number("5.67%")
         assert result is not None
-        assert abs(result - 0.0567) < 0.0001
+        assert result == pytest.approx(0.0567, abs=0.0001)
 
         result = parse_korean_number("100%")
         assert result is not None
-        assert abs(result - 1.0) < 0.0001
+        assert result == pytest.approx(1.0, abs=0.0001)
 
     def test_korean_unit_jo(self) -> None:
         assert parse_korean_number("1조") == 1_0000_0000_0000

--- a/tests/test_order_estimation_service.py
+++ b/tests/test_order_estimation_service.py
@@ -91,8 +91,8 @@ class TestCalculateEstimatedOrderCost:
             quantity_per_order=2.5,
             currency="USD",
         )
-        assert result["buy_prices"][0]["quantity"] == 2.5
-        assert result["total_cost"] == 375.0
+        assert result["buy_prices"][0]["quantity"] == pytest.approx(2.5)
+        assert result["total_cost"] == pytest.approx(375.0)
 
     def test_empty_prices(self):
         """빈 가격 목록"""
@@ -165,7 +165,7 @@ class TestFetchPendingBuyCost:
 
             result = await fetch_pending_domestic_buy_cost()
 
-            assert result == 0.0
+            assert result == pytest.approx(0.0)
 
     @pytest.mark.asyncio
     async def test_fetch_pending_overseas_buy_cost(self):
@@ -216,4 +216,4 @@ class TestFetchPendingBuyCost:
         ):
             result = await fetch_pending_crypto_buy_cost()
 
-            assert result == 100000.0
+            assert result == pytest.approx(100000.0)

--- a/tests/test_paper_account_tools.py
+++ b/tests/test_paper_account_tools.py
@@ -48,7 +48,7 @@ def test_serialize_account_basic_fields() -> None:
     assert out["name"] == "default"
     assert out["initial_capital"] == 100_000_000.0
     assert out["cash_krw"] == 95_000_000.0
-    assert out["cash_usd"] == 0.0
+    assert out["cash_usd"] == pytest.approx(0.0)
     assert out["strategy_name"] is None
     assert out["created_at"] == "2026-04-13T10:00:00+00:00"
     # Summary fields absent when not provided
@@ -67,7 +67,7 @@ def test_serialize_account_with_summary() -> None:
     )
     assert out["positions_count"] == 3
     assert out["total_evaluated_krw"] == 98_500_000.0
-    assert out["total_pnl_pct"] == -1.5
+    assert out["total_pnl_pct"] == pytest.approx(-1.5)
 
 
 def test_serialize_account_none_totals_become_null() -> None:
@@ -264,10 +264,10 @@ async def test_list_paper_accounts_returns_enriched(monkeypatch) -> None:
     assert first["id"] == 1
     assert first["positions_count"] == 3
     assert first["total_evaluated_krw"] == 98_500_000.0
-    assert first["total_pnl_pct"] == -1.5
+    assert first["total_pnl_pct"] == pytest.approx(-1.5)
     second = result["accounts"][1]
     assert second["id"] == 2
-    assert second["cash_usd"] == 5000.0
+    assert second["cash_usd"] == pytest.approx(5000.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_paper_analytics_tools.py
+++ b/tests/test_paper_analytics_tools.py
@@ -122,7 +122,7 @@ async def test_get_paper_performance_all_period(monkeypatch):
     assert result["success"] is True
     assert result["account_name"] == "bot"
     assert result["period"] == "all"
-    assert result["performance"]["total_return_pct"] == 10.0
+    assert result["performance"]["total_return_pct"] == pytest.approx(10.0)
     assert result["performance"]["best_trade"]["symbol"] == "005930"
 
 
@@ -223,9 +223,9 @@ async def test_get_paper_trade_log_basic(monkeypatch):
     assert len(result["trades"]) == 1
     t = result["trades"][0]
     assert t["symbol"] == "005930"
-    assert t["quantity"] == 10.0
-    assert t["price"] == 60000.0
-    assert t["fee"] == 90.0
+    assert t["quantity"] == pytest.approx(10.0)
+    assert t["price"] == pytest.approx(60000.0)
+    assert t["fee"] == pytest.approx(90.0)
     assert t["realized_pnl"] is None
     assert t["executed_at"] == "2026-04-01T09:00:00+00:00"
 
@@ -353,8 +353,8 @@ async def test_compare_paper_accounts_all_found(monkeypatch):
     assert result["success"] is True
     rows = result["comparison"]
     assert [r["account_name"] for r in rows] == ["bot-a", "bot-b"]
-    assert rows[0]["performance"]["total_return_pct"] == 5.0
-    assert rows[1]["performance"]["total_return_pct"] == -2.0
+    assert rows[0]["performance"]["total_return_pct"] == pytest.approx(5.0)
+    assert rows[1]["performance"]["total_return_pct"] == pytest.approx(-2.0)
 
 
 @pytest.mark.asyncio
@@ -403,7 +403,7 @@ async def test_compare_paper_accounts_skips_missing(monkeypatch):
     assert len(result["comparison"]) == 2
     first, second = result["comparison"]
     assert first["account_name"] == "bot-a"
-    assert first["performance"]["total_return_pct"] == 0.0
+    assert first["performance"]["total_return_pct"] == pytest.approx(0.0)
     assert first.get("error") is None
     assert second == {
         "account_name": "ghost",

--- a/tests/test_paper_journal_bridge.py
+++ b/tests/test_paper_journal_bridge.py
@@ -134,8 +134,8 @@ class TestCompareStrategies:
         assert s["total_trades"] == 2  # active excluded
         assert s["win_count"] == 1
         assert s["loss_count"] == 1
-        assert s["win_rate"] == 50.0
-        assert s["total_return_pct"] == 2.0  # 5.0 + (-3.0)
+        assert s["win_rate"] == pytest.approx(50.0)
+        assert s["total_return_pct"] == pytest.approx(2.0)  # 5.0 + (-3.0)
         assert s["best_trade"]["symbol"] == "005930"
         assert s["worst_trade"]["symbol"] == "AAPL"
 
@@ -239,8 +239,8 @@ class TestCompareStrategies:
         assert len(result["live_vs_paper"]) == 1
         comp = result["live_vs_paper"][0]
         assert comp["symbol"] == "005930"
-        assert comp["paper_pnl_pct"] == 5.0
-        assert comp["live_pnl_pct"] == 3.0
+        assert comp["paper_pnl_pct"] == pytest.approx(5.0)
+        assert comp["live_pnl_pct"] == pytest.approx(3.0)
         assert comp["delta_pnl_pct"] == pytest.approx(2.0)
 
     @pytest.mark.asyncio

--- a/tests/test_paper_portfolio_handler.py
+++ b/tests/test_paper_portfolio_handler.py
@@ -224,11 +224,11 @@ async def test_collect_paper_positions_all_active(monkeypatch):
     assert p["market"] == "kr"
     assert p["symbol"] == "005930"
     assert p["name"] == "삼성전자"
-    assert p["quantity"] == 10.0
-    assert p["avg_buy_price"] == 72000.0
-    assert p["current_price"] == 73500.0
-    assert p["evaluation_amount"] == 735000.0
-    assert p["profit_loss"] == 15000.0
+    assert p["quantity"] == pytest.approx(10.0)
+    assert p["avg_buy_price"] == pytest.approx(72000.0)
+    assert p["current_price"] == pytest.approx(73500.0)
+    assert p["evaluation_amount"] == pytest.approx(735000.0)
+    assert p["profit_loss"] == pytest.approx(15000.0)
     assert p["profit_rate"] == pytest.approx(2.08)
 
 
@@ -389,7 +389,7 @@ async def test_collect_paper_cash_balances_all_accounts(monkeypatch):
     d_usd = next(
         r for r in rows if r["account"] == "paper:default" and r["currency"] == "USD"
     )
-    assert d_usd["balance"] == 500.0
+    assert d_usd["balance"] == pytest.approx(500.0)
     assert d_usd["exchange_rate"] is None
     assert d_usd["formatted"] == "$500.00 USD"
 

--- a/tests/test_paper_trading_service.py
+++ b/tests/test_paper_trading_service.py
@@ -26,41 +26,41 @@ class TestCalculateFee:
     def test_equity_kr_buy(self):
         # 1,000,000원 매수 → 0.015% = 150원
         fee = calculate_fee("equity_kr", "buy", Decimal("1000000"))
-        assert fee == Decimal("150.0000")
+        assert fee == pytest.approx(Decimal("150.0000"))
 
     def test_equity_kr_sell_includes_tax(self):
         # 1,000,000원 매도 → 수수료 0.015% + 세금 0.18% = 1,950원
         fee = calculate_fee("equity_kr", "sell", Decimal("1000000"))
-        assert fee == Decimal("1950.0000")
+        assert fee == pytest.approx(Decimal("1950.0000"))
 
     def test_equity_us_buy_min_fee(self):
         # 작은 금액: 100 USD * 0.07% = $0.07 → min $1
         fee = calculate_fee("equity_us", "buy", Decimal("100"))
-        assert fee == Decimal("1.0000")
+        assert fee == pytest.approx(Decimal("1.0000"))
 
     def test_equity_us_buy_above_min(self):
         # 10,000 USD * 0.07% = $7
         fee = calculate_fee("equity_us", "buy", Decimal("10000"))
-        assert fee == Decimal("7.0000")
+        assert fee == pytest.approx(Decimal("7.0000"))
 
     def test_crypto_buy(self):
         # 1,000,000 KRW * 0.05% = 500 KRW
         fee = calculate_fee("crypto", "buy", Decimal("1000000"))
-        assert fee == Decimal("500.0000")
+        assert fee == pytest.approx(Decimal("500.0000"))
 
     def test_crypto_sell(self):
         fee = calculate_fee("crypto", "sell", Decimal("2000000"))
-        assert fee == Decimal("1000.0000")
+        assert fee == pytest.approx(Decimal("1000.0000"))
 
     def test_unsupported_market_raises(self):
         with pytest.raises(ValueError, match="Unsupported instrument_type"):
             calculate_fee("forex", "buy", Decimal("100"))
 
     def test_fee_rates_structure(self):
-        assert FEE_RATES["equity_kr"]["buy"] == 0.00015
-        assert FEE_RATES["equity_kr"]["tax_sell"] == 0.0018
-        assert FEE_RATES["equity_us"]["min_fee_usd"] == 1.0
-        assert FEE_RATES["crypto"]["sell"] == 0.0005
+        assert FEE_RATES["equity_kr"]["buy"] == pytest.approx(0.00015)
+        assert FEE_RATES["equity_kr"]["tax_sell"] == pytest.approx(0.0018)
+        assert FEE_RATES["equity_us"]["min_fee_usd"] == pytest.approx(1.0)
+        assert FEE_RATES["crypto"]["sell"] == pytest.approx(0.0005)
 
 
 class TestAccountManagement:
@@ -75,9 +75,9 @@ class TestAccountManagement:
             initial_capital_krw=Decimal("10000000"),
         )
         assert account.name == "Test"
-        assert account.initial_capital == Decimal("10000000")
-        assert account.cash_krw == Decimal("10000000")
-        assert account.cash_usd == Decimal("0")
+        assert account.initial_capital == pytest.approx(Decimal("10000000"))
+        assert account.cash_krw == pytest.approx(Decimal("10000000"))
+        assert account.cash_usd == pytest.approx(Decimal("0"))
         assert account.is_active is True
         mock_db.add.assert_called_once_with(account)
         mock_db.commit.assert_awaited_once()
@@ -92,7 +92,7 @@ class TestAccountManagement:
             description="dollar-cost averaging",
             strategy_name="dca-us",
         )
-        assert account.cash_usd == Decimal("5000")
+        assert account.cash_usd == pytest.approx(Decimal("5000"))
         assert account.description == "dollar-cost averaging"
         assert account.strategy_name == "dca-us"
 
@@ -118,8 +118,8 @@ class TestAccountManagement:
         mock_db.execute = AsyncMock()
         result = await service.reset_account(1)
 
-        assert result.cash_krw == Decimal("10000000")
-        assert result.cash_usd == Decimal("0")
+        assert result.cash_krw == pytest.approx(Decimal("10000000"))
+        assert result.cash_usd == pytest.approx(Decimal("0"))
         # DELETE FROM paper_positions WHERE account_id = 1
         mock_db.execute.assert_awaited_once()
         mock_db.commit.assert_awaited_once()
@@ -172,7 +172,7 @@ class TestFetchCurrentPrice:
             AsyncMock(return_value={"price": 70000.0}),
         )
         price = await service._fetch_current_price("005930", "equity_kr")
-        assert price == Decimal("70000.0")
+        assert price == pytest.approx(Decimal("70000.0"))
 
     @pytest.mark.asyncio
     async def test_fetch_equity_us_uses_yahoo_quote(self, service, monkeypatch):
@@ -181,7 +181,7 @@ class TestFetchCurrentPrice:
             AsyncMock(return_value={"price": 190.5}),
         )
         price = await service._fetch_current_price("AAPL", "equity_us")
-        assert price == Decimal("190.5")
+        assert price == pytest.approx(Decimal("190.5"))
 
     @pytest.mark.asyncio
     async def test_fetch_crypto_uses_upbit_batch(self, service, monkeypatch):
@@ -190,7 +190,7 @@ class TestFetchCurrentPrice:
             AsyncMock(return_value={"KRW-BTC": 95000000.0}),
         )
         price = await service._fetch_current_price("KRW-BTC", "crypto")
-        assert price == Decimal("95000000.0")
+        assert price == pytest.approx(Decimal("95000000.0"))
 
     @pytest.mark.asyncio
     async def test_fetch_crypto_missing_raises(self, service, monkeypatch):
@@ -237,12 +237,12 @@ class TestPreviewOrder:
         ex = preview["preview"]
         assert ex["instrument_type"] == "equity_kr"
         assert ex["side"] == "buy"
-        assert ex["quantity"] == Decimal("20")
-        assert ex["price"] == Decimal("70000")
-        assert ex["gross"] == Decimal("1400000")
+        assert ex["quantity"] == pytest.approx(Decimal("20"))
+        assert ex["price"] == pytest.approx(Decimal("70000"))
+        assert ex["gross"] == pytest.approx(Decimal("1400000"))
         # fee: 1,400,000 * 0.00015 = 210
-        assert ex["fee"] == Decimal("210.0000")
-        assert ex["total_cost"] == Decimal("1400210.0000")
+        assert ex["fee"] == pytest.approx(Decimal("210.0000"))
+        assert ex["total_cost"] == pytest.approx(Decimal("1400210.0000"))
         assert ex["currency"] == "KRW"
 
     @pytest.mark.asyncio
@@ -272,11 +272,11 @@ class TestPreviewOrder:
         )
         ex = preview["preview"]
         assert ex["instrument_type"] == "crypto"
-        assert ex["quantity"] == Decimal("0.01000000")
-        assert ex["price"] == Decimal("95000000")
-        assert ex["gross"] == Decimal("950000")
+        assert ex["quantity"] == pytest.approx(Decimal("0.01000000"))
+        assert ex["price"] == pytest.approx(Decimal("95000000"))
+        assert ex["gross"] == pytest.approx(Decimal("950000"))
         # fee: 950,000 * 0.0005 = 475
-        assert ex["fee"] == Decimal("475.0000")
+        assert ex["fee"] == pytest.approx(Decimal("475.0000"))
 
     @pytest.mark.asyncio
     async def test_preview_rejects_inactive_account(self, mock_db, monkeypatch):
@@ -362,19 +362,19 @@ class TestExecuteOrderBuy:
         assert result["success"] is True
         assert result["dry_run"] is False
         exec_ = result["execution"]
-        assert exec_["quantity"] == Decimal("20")
-        assert exec_["price"] == Decimal("70000")
+        assert exec_["quantity"] == pytest.approx(Decimal("20"))
+        assert exec_["price"] == pytest.approx(Decimal("70000"))
         # cash after: 10,000,000 - (1,400,000 + 210)
-        assert account.cash_krw == Decimal("8599790.0000")
+        assert account.cash_krw == pytest.approx(Decimal("8599790.0000"))
         # PaperPosition + PaperTrade were added
         assert mock_db.add.call_count == 2
         added = [c.args[0] for c in mock_db.add.call_args_list]
         assert any(isinstance(x, PaperPosition) for x in added)
         trade = next(x for x in added if isinstance(x, PaperTrade))
         assert trade.side == "buy"
-        assert trade.quantity == Decimal("20")
-        assert trade.total_amount == Decimal("1400000.0000")
-        assert trade.fee == Decimal("210.0000")
+        assert trade.quantity == pytest.approx(Decimal("20"))
+        assert trade.total_amount == pytest.approx(Decimal("1400000.0000"))
+        assert trade.fee == pytest.approx(Decimal("210.0000"))
         assert trade.reason == "test buy"
         mock_db.commit.assert_awaited_once()
 
@@ -420,9 +420,9 @@ class TestExecuteOrderBuy:
         )
 
         # weighted avg: (10*60000 + 10*70000) / 20 = 65000
-        assert existing.quantity == Decimal("20")
-        assert existing.avg_price == Decimal("65000")
-        assert existing.total_invested == Decimal("1300000.0000")
+        assert existing.quantity == pytest.approx(Decimal("20"))
+        assert existing.avg_price == pytest.approx(Decimal("65000"))
+        assert existing.total_invested == pytest.approx(Decimal("1300000.0000"))
         # Only PaperTrade appended (position already existed)
         added = [c.args[0] for c in mock_db.add.call_args_list]
         assert sum(1 for x in added if isinstance(x, PaperTrade)) == 1
@@ -453,8 +453,8 @@ class TestExecuteOrderBuy:
             quantity=Decimal("10"),
         )
         # gross 1000, fee = max(1000*0.0007, 1) = 1.0
-        assert account.cash_usd == Decimal("8999.0000")
-        assert account.cash_krw == Decimal("0")
+        assert account.cash_usd == pytest.approx(Decimal("8999.0000"))
+        assert account.cash_krw == pytest.approx(Decimal("0"))
 
 
 class TestExecuteOrderSell:
@@ -506,15 +506,15 @@ class TestExecuteOrderSell:
         # net proceeds: 798,440
         # realized pnl: (80,000 - 60,000) * 10 - 1,560 = 198,440
         assert result["success"] is True
-        assert account.cash_krw == Decimal("1798440.0000")
-        assert position.quantity == Decimal("10")
+        assert account.cash_krw == pytest.approx(Decimal("1798440.0000"))
+        assert position.quantity == pytest.approx(Decimal("10"))
         # avg_price unchanged on sell; total_invested drops proportionally
-        assert position.avg_price == Decimal("60000")
-        assert position.total_invested == Decimal("600000.0000")
+        assert position.avg_price == pytest.approx(Decimal("60000"))
+        assert position.total_invested == pytest.approx(Decimal("600000.0000"))
 
         added = [c.args[0] for c in mock_db.add.call_args_list]
         trade = next(x for x in added if isinstance(x, PaperTrade))
-        assert trade.realized_pnl == Decimal("198440.0000")
+        assert trade.realized_pnl == pytest.approx(Decimal("198440.0000"))
 
     @pytest.mark.asyncio
     async def test_sell_full_quantity_deletes_position(
@@ -615,13 +615,13 @@ class TestQueries:
         assert len(positions) == 1
         p = positions[0]
         assert p["symbol"] == "005930"
-        assert p["quantity"] == Decimal("10")
-        assert p["avg_price"] == Decimal("60000")
-        assert p["current_price"] == Decimal("70000")
-        assert p["evaluation_amount"] == Decimal("700000.0000")
-        assert p["unrealized_pnl"] == Decimal("100000.0000")
+        assert p["quantity"] == pytest.approx(Decimal("10"))
+        assert p["avg_price"] == pytest.approx(Decimal("60000"))
+        assert p["current_price"] == pytest.approx(Decimal("70000"))
+        assert p["evaluation_amount"] == pytest.approx(Decimal("700000.0000"))
+        assert p["unrealized_pnl"] == pytest.approx(Decimal("100000.0000"))
         # (70000 - 60000) / 60000 * 100 = 16.6666...
-        assert p["pnl_pct"] == Decimal("16.67")
+        assert p["pnl_pct"] == pytest.approx(Decimal("16.67"))
 
     @pytest.mark.asyncio
     async def test_get_positions_swallows_price_errors(
@@ -690,7 +690,7 @@ class TestQueries:
         assert len(history) == 1
         assert history[0]["symbol"] == "005930"
         assert history[0]["side"] == "buy"
-        assert history[0]["quantity"] == Decimal("10")
+        assert history[0]["quantity"] == pytest.approx(Decimal("10"))
 
 
 class TestPortfolioSummary:
@@ -734,13 +734,13 @@ class TestPortfolioSummary:
 
         summary = await service.get_portfolio_summary(account_id=1)
 
-        assert summary["total_invested"] == Decimal("900000")
-        assert summary["total_evaluated"] == Decimal("980000")
-        assert summary["total_pnl"] == Decimal("80000")
+        assert summary["total_invested"] == pytest.approx(Decimal("900000"))
+        assert summary["total_evaluated"] == pytest.approx(Decimal("980000"))
+        assert summary["total_pnl"] == pytest.approx(Decimal("80000"))
         # 80000 / 900000 * 100 = 8.8888...
-        assert summary["total_pnl_pct"] == Decimal("8.89")
-        assert summary["cash_krw"] == Decimal("1000000")
-        assert summary["cash_usd"] == Decimal("200")
+        assert summary["total_pnl_pct"] == pytest.approx(Decimal("8.89"))
+        assert summary["cash_krw"] == pytest.approx(Decimal("1000000"))
+        assert summary["cash_usd"] == pytest.approx(Decimal("200"))
         assert summary["positions_count"] == 2
 
     @pytest.mark.asyncio
@@ -757,9 +757,9 @@ class TestPortfolioSummary:
         monkeypatch.setattr(service, "get_positions", AsyncMock(return_value=[]))
 
         summary = await service.get_portfolio_summary(account_id=1)
-        assert summary["total_invested"] == Decimal("0")
-        assert summary["total_evaluated"] == Decimal("0")
-        assert summary["total_pnl"] == Decimal("0")
+        assert summary["total_invested"] == pytest.approx(Decimal("0"))
+        assert summary["total_evaluated"] == pytest.approx(Decimal("0"))
+        assert summary["total_pnl"] == pytest.approx(Decimal("0"))
         assert summary["total_pnl_pct"] is None
         assert summary["positions_count"] == 0
 
@@ -807,10 +807,10 @@ class TestDailySnapshots:
 
         snapshot = await service.record_daily_snapshot(account_id=1)
 
-        assert snapshot.cash_krw == Decimal("5000000")
-        assert snapshot.positions_value == Decimal("6000000")
-        assert snapshot.total_equity == Decimal("11000000")
-        assert snapshot.daily_return_pct == Decimal("10.0000")
+        assert snapshot.cash_krw == pytest.approx(Decimal("5000000"))
+        assert snapshot.positions_value == pytest.approx(Decimal("6000000"))
+        assert snapshot.total_equity == pytest.approx(Decimal("11000000"))
+        assert snapshot.daily_return_pct == pytest.approx(Decimal("10.0000"))
         mock_db.add.assert_called_once()
         mock_db.commit.assert_awaited_once()
 
@@ -837,7 +837,7 @@ class TestDailySnapshots:
 
         snapshot = await service.record_daily_snapshot(account_id=1)
         assert snapshot.daily_return_pct is None
-        assert snapshot.total_equity == Decimal("10000000")
+        assert snapshot.total_equity == pytest.approx(Decimal("10000000"))
 
     @pytest.mark.asyncio
     async def test_calculate_daily_returns_filters_by_date_range(
@@ -946,8 +946,8 @@ class TestRoundTrips:
         trip = trips[0]
         assert trip["symbol"] == "005930"
         assert trip["holding_days"] == 5
-        assert trip["pnl"] == 98635.0
-        assert round(trip["return_pct"], 2) == 16.44
+        assert trip["pnl"] == pytest.approx(98635.0)
+        assert round(trip["return_pct"], 2) == pytest.approx(16.44)
         assert trip["entry_reason"] == "entry"
         assert trip["exit_reason"] == "exit"
 
@@ -1016,14 +1016,16 @@ class TestRiskMetrics:
             Decimal("80"),
         ]
         dd = PaperTradingService._calc_max_drawdown_pct(equities)
-        assert round(dd, 2) == 33.33
+        assert round(dd, 2) == pytest.approx(33.33)
 
     def test_max_drawdown_empty_returns_none(self):
         assert PaperTradingService._calc_max_drawdown_pct([]) is None
 
     def test_max_drawdown_monotonic_returns_zero(self):
         equities = [Decimal("100"), Decimal("110"), Decimal("120")]
-        assert PaperTradingService._calc_max_drawdown_pct(equities) == 0.0
+        assert PaperTradingService._calc_max_drawdown_pct(equities) == pytest.approx(
+            0.0
+        )
 
     def test_sharpe_ratio_with_uniform_returns(self):
         rets = [Decimal("1.0"), Decimal("1.0"), Decimal("1.0")]
@@ -1150,14 +1152,14 @@ class TestCalculatePerformance:
 
         perf = await service.calculate_performance(account_id=1)
 
-        assert perf["total_return_pct"] == 10.0
-        assert perf["realized_pnl"] == 98635.0
-        assert perf["unrealized_pnl"] == 400000.0
+        assert perf["total_return_pct"] == pytest.approx(10.0)
+        assert perf["realized_pnl"] == pytest.approx(98635.0)
+        assert perf["unrealized_pnl"] == pytest.approx(400000.0)
         assert perf["total_trades"] == 1
-        assert perf["win_rate"] == 100.0
-        assert perf["avg_holding_days"] == 5.0
+        assert perf["win_rate"] == pytest.approx(100.0)
+        assert perf["avg_holding_days"] == pytest.approx(5.0)
         assert perf["max_drawdown_pct"] is not None
-        assert round(perf["max_drawdown_pct"], 2) == 1.49
+        assert round(perf["max_drawdown_pct"], 2) == pytest.approx(1.49)
         assert perf["sharpe_ratio"] is not None
         assert perf["best_trade"] is not None
         assert perf["best_trade"]["symbol"] == "A"
@@ -1186,12 +1188,12 @@ class TestCalculatePerformance:
         mock_db.execute = AsyncMock(return_value=empty)
 
         perf = await service.calculate_performance(account_id=1)
-        assert perf["total_return_pct"] == 0.0
-        assert perf["realized_pnl"] == 0.0
-        assert perf["unrealized_pnl"] == 0.0
+        assert perf["total_return_pct"] == pytest.approx(0.0)
+        assert perf["realized_pnl"] == pytest.approx(0.0)
+        assert perf["unrealized_pnl"] == pytest.approx(0.0)
         assert perf["total_trades"] == 0
-        assert perf["win_rate"] == 0.0
-        assert perf["avg_holding_days"] == 0.0
+        assert perf["win_rate"] == pytest.approx(0.0)
+        assert perf["avg_holding_days"] == pytest.approx(0.0)
         assert perf["max_drawdown_pct"] is None
         assert perf["sharpe_ratio"] is None
         assert perf["best_trade"] is None

--- a/tests/test_portfolio_overview_service.py
+++ b/tests/test_portfolio_overview_service.py
@@ -238,7 +238,7 @@ async def test_get_overview_filters_by_selected_account_keys() -> None:
     assert overview["summary"]["by_market"] == {"KR": 1, "US": 0, "CRYPTO": 0}
     position = overview["positions"][0]
     assert position["symbol"] == "005930"
-    assert position["quantity"] == 15.0
+    assert position["quantity"] == pytest.approx(15.0)
     assert len(position["components"]) == 2
 
 
@@ -356,11 +356,11 @@ def test_aggregate_positions_recalculates_totals_when_some_components_missing_ev
     )
 
     assert len(rows) == 1
-    assert rows[0]["quantity"] == 15.0
+    assert rows[0]["quantity"] == pytest.approx(15.0)
     # (10 + 5) * 75,000
-    assert rows[0]["evaluation"] == 1125000.0
+    assert rows[0]["evaluation"] == pytest.approx(1125000.0)
     # 1,125,000 - ((10 * 70,000) + (5 * 72,000))
-    assert rows[0]["profit_loss"] == 65000.0
+    assert rows[0]["profit_loss"] == pytest.approx(65000.0)
 
 
 @pytest.mark.asyncio
@@ -403,9 +403,9 @@ async def test_fill_missing_prices_uses_us_provider_for_missing_us_prices(
     await service._fill_missing_prices(AsyncMock(), components, warnings)
 
     mock_fetch_price.assert_awaited_once_with("AAPL")
-    assert components[0]["current_price"] == 195.0
-    assert components[0]["evaluation"] == 390.0
-    assert components[0]["profit_loss"] == 90.0
+    assert components[0]["current_price"] == pytest.approx(195.0)
+    assert components[0]["evaluation"] == pytest.approx(390.0)
+    assert components[0]["profit_loss"] == pytest.approx(90.0)
     assert warnings == []
 
 
@@ -528,7 +528,7 @@ async def test_fill_missing_prices_filters_invalid_us_symbols_before_provider_fe
     await service._fill_missing_prices(AsyncMock(), components, warnings)
 
     mock_fetch_price.assert_awaited_once_with("AAPL")
-    assert components[0]["current_price"] == 205.0
+    assert components[0]["current_price"] == pytest.approx(205.0)
     assert components[1]["current_price"] is None
     assert warnings == []
 
@@ -728,8 +728,8 @@ async def test_collect_upbit_components_uses_resilient_fetch_helper(
 
     assert len(components) == 1
     assert components[0]["symbol"] == "KRW-BTC"
-    assert components[0]["current_price"] == 100000000.0
-    assert components[0]["evaluation"] == 10000000.0
+    assert components[0]["current_price"] == pytest.approx(100000000.0)
+    assert components[0]["evaluation"] == pytest.approx(10000000.0)
     service._fetch_upbit_prices_resilient.assert_awaited_once_with(
         ["KRW-BTC"],
         warnings,
@@ -776,9 +776,9 @@ async def test_fill_missing_prices_uses_resilient_fetch_helper_for_manual_crypto
         active_upbit_markets=None,
         enforce_upbit_universe=True,
     )
-    assert components[0]["current_price"] == 115000000.0
-    assert components[0]["evaluation"] == 23000000.0
-    assert components[0]["profit_loss"] == 3000000.0
+    assert components[0]["current_price"] == pytest.approx(115000000.0)
+    assert components[0]["evaluation"] == pytest.approx(23000000.0)
+    assert components[0]["profit_loss"] == pytest.approx(3000000.0)
 
 
 @pytest.mark.asyncio
@@ -1311,7 +1311,7 @@ class TestNormalizeUsCurrency:
             {"avg_price": 145.0, "current_price": 150.0, "quantity": 3.0},
         ]
         result = service._normalize_us_currency(components, usd_krw=1350.0)
-        assert result[0]["avg_price"] == 145.0
+        assert result[0]["avg_price"] == pytest.approx(145.0)
 
     def test_noop_when_usd_krw_is_none(self):
         service = PortfolioOverviewService(AsyncMock())
@@ -1319,7 +1319,7 @@ class TestNormalizeUsCurrency:
             {"avg_price": 200000.0, "current_price": 150.0, "quantity": 3.0},
         ]
         result = service._normalize_us_currency(components, usd_krw=None)
-        assert result[0]["avg_price"] == 200000.0
+        assert result[0]["avg_price"] == pytest.approx(200000.0)
 
     def test_falls_back_to_canonical_price_when_component_has_none(self):
         service = PortfolioOverviewService(AsyncMock())
@@ -1400,4 +1400,6 @@ class TestCalculatePositionTotals:
             market_type="KR",
             usd_krw=None,
         )
-        assert result["evaluation"] == 1100.0  # only item with non-None evaluation
+        assert result["evaluation"] == pytest.approx(
+            1100.0
+        )  # only item with non-None evaluation

--- a/tests/test_portfolio_overview_service.py
+++ b/tests/test_portfolio_overview_service.py
@@ -1303,7 +1303,7 @@ class TestNormalizeUsCurrency:
             {"avg_price": 200000.0, "current_price": 150.0, "quantity": 3.0},
         ]
         result = service._normalize_us_currency(components, usd_krw=1350.0)
-        assert abs(result[0]["avg_price"] - (200000.0 / 1350.0)) < 0.01
+        assert result[0]["avg_price"] == pytest.approx(200000.0 / 1350.0, abs=0.01)
 
     def test_leaves_usd_avg_price_unchanged(self):
         service = PortfolioOverviewService(AsyncMock())
@@ -1329,7 +1329,7 @@ class TestNormalizeUsCurrency:
         result = service._normalize_us_currency(
             components, usd_krw=1300.0, canonical_price=200.0
         )
-        assert abs(result[0]["avg_price"] - (195000.0 / 1300.0)) < 0.01
+        assert result[0]["avg_price"] == pytest.approx(195000.0 / 1300.0, abs=0.01)
 
 
 class TestCalculatePositionTotals:
@@ -1348,7 +1348,7 @@ class TestCalculatePositionTotals:
         assert result["quantity"] == 15
         assert result["evaluation"] == 15 * 120.0
         cost_basis = 10 * 100.0 + 5 * 110.0
-        assert abs(result["profit_loss"] - (15 * 120.0 - cost_basis)) < 0.01
+        assert result["profit_loss"] == pytest.approx(15 * 120.0 - cost_basis, abs=0.01)
         assert result["evaluation_krw"] == result["evaluation"]
 
     def test_us_market_converts_to_krw(self):

--- a/tests/test_screening_common.py
+++ b/tests/test_screening_common.py
@@ -10,7 +10,7 @@ class TestCommonReExports:
     def test_timeout_seconds(self):
         from app.mcp_server.tooling.screening.common import _timeout_seconds
 
-        assert _timeout_seconds("tvscreener") == 30.0
+        assert _timeout_seconds("tvscreener") == pytest.approx(30.0)
 
     def test_to_optional_float_valid(self):
         from app.mcp_server.tooling.screening.common import _to_optional_float
@@ -109,7 +109,7 @@ class TestCommonReExports:
         )
 
         original, normalized = _normalize_dividend_yield_threshold(3.0)
-        assert original == 3.0
+        assert original == pytest.approx(3.0)
         assert normalized == pytest.approx(0.03)
 
     def test_empty_rsi_enrichment_diagnostics(self):
@@ -134,7 +134,7 @@ class TestCommonReExports:
             DROP_THRESHOLD,
         )
 
-        assert DROP_THRESHOLD == -0.30
+        assert DROP_THRESHOLD == pytest.approx(-0.30)
         assert "tvscreener" in DEFAULT_TIMEOUTS
         assert CRYPTO_TOP_BY_VOLUME == 100
 
@@ -257,8 +257,8 @@ class TestComputeAvgTargetAndUpside:
             "price_target_1y_delta": 10.5,
         }
         avg, upside = _compute_avg_target_and_upside(row, current_price=100.0)
-        assert avg == 150.0
-        assert upside == 10.5
+        assert avg == pytest.approx(150.0)
+        assert upside == pytest.approx(10.5)
 
     def test_fallback_computed(self):
         from app.mcp_server.tooling.screening.common import (
@@ -267,8 +267,8 @@ class TestComputeAvgTargetAndUpside:
 
         row = {"price_target_1y": 120.0}
         avg, upside = _compute_avg_target_and_upside(row, current_price=100.0)
-        assert avg == 120.0
-        assert upside == 20.0
+        assert avg == pytest.approx(120.0)
+        assert upside == pytest.approx(20.0)
 
     def test_no_target(self):
         from app.mcp_server.tooling.screening.common import (

--- a/tests/test_sell_signal_service.py
+++ b/tests/test_sell_signal_service.py
@@ -171,7 +171,7 @@ class TestCheckStochRsi:
             cond, errors = await _check_stoch_rsi("000660", 80)
             assert cond.name == "stoch_rsi"
             assert cond.met is True
-            assert cond.value == 25.0
+            assert cond.value == pytest.approx(25.0)
             assert not errors
 
     @pytest.mark.asyncio

--- a/tests/test_trading_integration.py
+++ b/tests/test_trading_integration.py
@@ -397,7 +397,9 @@ class TestExpectedProfit:
 
         # 한투 기준 수익률: (77700 - 74000) / 74000 * 100 = 5%
         expected_percent = (77700 - 74000) / 74000 * 100
-        assert result["based_on_kis_avg"].percent == pytest.approx(expected_percent, abs=0.01)
+        assert result["based_on_kis_avg"].percent == pytest.approx(
+            expected_percent, abs=0.01
+        )
 
 
 @pytest.mark.unit

--- a/tests/test_trading_integration.py
+++ b/tests/test_trading_integration.py
@@ -40,7 +40,7 @@ class TestMergedPortfolioService:
 
         # 가중 평균: (10 * 74000 + 5 * 73000) / 15 = 1105000 / 15 = 73666.67
         expected = (10 * 74000 + 5 * 73000) / 15
-        assert abs(result - expected) < 0.01
+        assert result == pytest.approx(expected, abs=0.01)
 
     def test_calculate_combined_avg_single_broker(self):
         """단일 브로커만 있을 때"""
@@ -70,7 +70,7 @@ class TestMergedPortfolioService:
 
         # (10*100 + 20*90 + 30*80) / 60 = (1000 + 1800 + 2400) / 60 = 86.67
         expected = (10 * 100 + 20 * 90 + 30 * 80) / 60
-        assert abs(result - expected) < 0.01
+        assert result == pytest.approx(expected, abs=0.01)
 
 
 @pytest.mark.unit
@@ -94,7 +94,7 @@ class TestReferencePrices:
         assert data["kis_quantity"] == 10
         assert data["toss_avg"] == 73000
         assert data["toss_quantity"] == 5
-        assert abs(data["combined_avg"] - 73666.67) < 0.01
+        assert data["combined_avg"] == pytest.approx(73666.67, abs=0.01)
         assert data["total_quantity"] == 15
 
     def test_reference_prices_toss_only(self):
@@ -170,7 +170,7 @@ class TestTradingPriceService:
             strategy=PriceStrategy.combined_avg,
         )
 
-        assert abs(result.price - 73666.67) < 0.01
+        assert result.price == pytest.approx(73666.67, abs=0.01)
         assert result.price_source == "통합 평단가"
 
     def test_buy_price_with_kis_avg(self):
@@ -216,7 +216,7 @@ class TestTradingPriceService:
         )
 
         expected = 73000 * 0.99  # 72270
-        assert abs(result.price - expected) < 0.01
+        assert result.price == pytest.approx(expected, abs=0.01)
         assert "-1.0%" in result.price_source
 
     def test_buy_price_with_current(self):
@@ -263,7 +263,7 @@ class TestTradingPriceService:
         )
 
         expected = 74000 * 1.05  # 77700
-        assert abs(result.price - expected) < 0.01
+        assert result.price == pytest.approx(expected, abs=0.01)
         assert "+5.0%" in result.price_source
 
     def test_sell_price_with_toss_avg_plus(self):
@@ -276,7 +276,7 @@ class TestTradingPriceService:
         )
 
         expected = 73000 * 1.10  # 80300
-        assert abs(result.price - expected) < 0.01
+        assert result.price == pytest.approx(expected, abs=0.01)
 
     def test_sell_price_with_combined_avg_plus(self):
         """통합 평단가 +5% 매도가 계산"""
@@ -288,7 +288,7 @@ class TestTradingPriceService:
         )
 
         expected = 73666.67 * 1.05
-        assert abs(result.price - expected) < 1  # 소수점 반올림 오차 허용
+        assert result.price == pytest.approx(expected, abs=1)  # 소수점 반올림 오차 허용
 
 
 @pytest.mark.unit
@@ -397,7 +397,7 @@ class TestExpectedProfit:
 
         # 한투 기준 수익률: (77700 - 74000) / 74000 * 100 = 5%
         expected_percent = (77700 - 74000) / 74000 * 100
-        assert abs(result["based_on_kis_avg"].percent - expected_percent) < 0.01
+        assert result["based_on_kis_avg"].percent == pytest.approx(expected_percent, abs=0.01)
 
 
 @pytest.mark.unit
@@ -498,7 +498,7 @@ class TestGetReferencePricesIntegration:
         assert ref.total_quantity == 15
         # 통합 평단가: (10*74000 + 5*73000) / 15
         expected_combined = (10 * 74000 + 5 * 73000) / 15
-        assert abs(ref.combined_avg - expected_combined) < 0.01
+        assert ref.combined_avg == pytest.approx(expected_combined, abs=0.01)
 
     async def test_get_reference_prices_toss_only(self):
         """토스만 있을 때 kis_avg는 None"""
@@ -562,7 +562,7 @@ class TestRequirementsVerification:
 
         # 통합 평단가로 매수
         r3 = self.service.calculate_buy_price(ref, 75000, PriceStrategy.combined_avg)
-        assert abs(r3.price - 73666.67) < 0.01
+        assert r3.price == pytest.approx(73666.67, abs=0.01)
 
     def test_requirement_sell_limited_to_kis_quantity(self):
         """요구사항: 매도는 KIS 보유분까지만 가능"""

--- a/tests/test_watch_intent_policy.py
+++ b/tests/test_watch_intent_policy.py
@@ -267,4 +267,4 @@ class TestParsePolicyIntentSuccess:
         assert isinstance(policy, IntentPolicy)
         assert policy.side == "sell"
         assert policy.quantity == 10
-        assert policy.limit_price == 190.5
+        assert policy.limit_price == pytest.approx(190.5)


### PR DESCRIPTION
## Summary

SonarCloud cleanup Phase 3 — 테스트 부동소수점 비교 정리.

플랜: [docs/superpowers/plans/2026-05-07-sonarcloud-cleanup.md](https://github.com/mgh3326/auto_trader/blob/fix/sonarcloud-phase3-test-refactor/docs/superpowers/plans/2026-05-07-sonarcloud-cleanup.md) §Phase 3.

이 PR은 두 커밋으로 구성됩니다:

### Commit 1 — manual tolerance pattern → `pytest.approx(abs=...)` (9 files, 11 changes)

`abs(x - y) < tolerance` 형태의 수동 비교를 `pytest.approx(value, abs=tolerance)`로 교체. 가독성 + Sonar 호환.

대상: `test_trading_integration.py`, `test_naver_finance.py`, `test_portfolio_overview_service.py`, `test_mcp_indicator_math.py`, `test_n8n_daily_brief_service.py`, `test_mcp_fundamentals_tools.py`, `test_number_utils.py`, `services/test_pending_reconciliation_service.py`, `services/test_portfolio_overview_currency.py`.

### Commit 2 — bulk wrap `==` float/Decimal asserts with `pytest.approx` (21 files, 324 changes)

SonarCloud `python:S1244` ("Do not perform equality checks with floating point values") 일괄 처리. 정규식 기반 변환:
- `assert <expr> == <float-literal>` → `assert <expr> == pytest.approx(<float-literal>)`
- `assert <expr> == Decimal("...")` → `assert <expr> == pytest.approx(Decimal("..."))`
- `import pytest` 누락 시 자동 추가

정수 리터럴은 그대로(Sonar는 정수 비교는 flag하지 않음).

상위 변환 건수:
- `test_mcp_portfolio_tools.py` — 121건
- `test_paper_trading_service.py` — 80건
- `test_portfolio_overview_service.py` — 16건
- `test_naver_finance.py` — 15건
- `test_kr_hourly_candles_read_service.py` — 13건
- (외 16개 파일)

## Test plan

- [x] 21개 affected 테스트 파일 = **561개 테스트 모두 pass** (`uv run pytest <files>`)
- [x] `uv run ruff format` 적용 (3개 파일 reformatted)
- [x] `uv run ruff check tests/` 통과
- [ ] (수동) 머지 후 SonarCloud 새 코드 기간 S1244 카운트가 815 → ~0 으로 떨어지는지 확인

## Notes

- 본 PR은 `main` 직접 분기. Phase 1/2와 별도 검토 가능.
- `Decimal`을 `pytest.approx`로 감싸면 기본 상대 오차 1e-6이 적용되지만 Decimal은 exact 산술이므로 실제로 차이 없음.
- 변환 스크립트(`/tmp/fix_s1244.py`)는 idempotent — 재실행해도 추가 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>