### PR TITLE
feat(rob-127): add /invest/app discover tab with news radar

### DIFF
--- a/docs/superpowers/plans/2026-05-07-rob-127-invest-discover-tab.md
+++ b/docs/superpowers/plans/2026-05-07-rob-127-invest-discover-tab.md
@@ -1,0 +1,2053 @@
+# ROB-127: Invest Discover Tab MVP — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Toss-style read-only "발견(Discover)" tab to the existing `/invest/app` React/Vite app. Wire BottomNav, build the AI realtime issue list and detail page, all backed by the existing read-only `GET /trading/api/news-radar` endpoint.
+
+**Architecture:** Reuse the established `useInvestHome` pattern — fetch wrapper + `useState`/`useEffect` hook returning `{ state, reload }` with a discriminated union (`loading | error | ready`). Pages accept optional `{ state?, reload? }` props for fixture-based testing. The detail page refetches `/trading/api/news-radar` and finds the matching `id` (no shared cache, no SWR/React Query). All copy in Korean. Read-only — no broker/order/watch/scheduler/DB mutation imports anywhere.
+
+**Tech Stack:** React 19, React Router 7 (`createBrowserRouter` with `basename: "/invest/app"`, `NavLink`), TypeScript 6, Vite 8, Vitest 4 + Testing Library. Existing CSS variables in `frontend/invest/src/styles.css` (dark mobile shell).
+
+**Spec:** [`docs/superpowers/specs/2026-05-07-rob-127-invest-discover-tab-design.md`](../specs/2026-05-07-rob-127-invest-discover-tab-design.md)
+
+**Branch:** `auto-trader-investapp-ai-mvp` (current worktree, no new branch).
+
+---
+
+## File Map
+
+### New files (`frontend/invest/src/`)
+
+| Path                                                      | Responsibility                                                                |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `types/newsRadar.ts`                                      | TS mirror of `app/schemas/news_radar.py`                                       |
+| `api/newsRadar.ts`                                        | Single fetch wrapper for `/trading/api/news-radar`                            |
+| `hooks/useNewsRadar.ts`                                   | `useState`/`useEffect` hook returning `{ state, reload }`                     |
+| `format/relativeTime.ts`                                  | `formatRelativeTime(date, now?)` → `5분 전` / `1시간 전` / `2일 전`            |
+| `components/discover/severity.ts`                         | Severity → indicator label/color mapping + bucket-count helper                  |
+| `components/discover/impactMap.ts`                        | `IMPACT_MAP: Record<NewsRadarRiskCategory, ImpactPill[]>` constant              |
+| `components/discover/AiIssueCard.tsx`                     | Single card (rank, indicator, title, subtitle, related-news count, time, link) |
+| `components/discover/AiIssueTicker.tsx`                   | Section heading + disclaimer for the AI issue list                             |
+| `components/discover/DiscoverHeader.tsx`                  | "발견" header text                                                              |
+| `components/discover/CategoryShortcutRail.tsx`            | Static disabled chips (해외주식 / 국내주식 / 옵션 / 채권)                      |
+| `components/discover/TodayEventCard.tsx`                  | Static placeholder card                                                        |
+| `components/discover/IssueImpactMap.tsx`                  | "어떤 영향을 줄까?" pills based on `risk_category`                              |
+| `components/discover/RelatedSymbolsList.tsx`              | Symbol chips or "준비 중" fallback                                             |
+| `pages/DiscoverPage.tsx`                                  | List page composition + state branching                                        |
+| `pages/DiscoverIssueDetailPage.tsx`                       | Detail page (find by id, fallback, impact, symbols, disclaimer)                |
+
+### Modified files
+
+| Path                                                      | Change                                                                  |
+| --------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `frontend/invest/src/routes.tsx`                          | Register `/discover` and `/discover/issues/:issueId`                     |
+| `frontend/invest/src/components/BottomNav.tsx`            | Replace `alert("준비 중")` with `NavLink` (증권/발견) + disabled (관심/피드) |
+
+### New tests (`frontend/invest/src/__tests__/`)
+
+| Path                                       | Coverage                                                                |
+| ------------------------------------------ | ----------------------------------------------------------------------- |
+| `relativeTime.test.ts`                     | unit: 분/시간/일 boundaries, future fallback, null                       |
+| `severity.test.ts`                         | unit: bucket count, severity → indicator mapping                         |
+| `BottomNav.test.tsx`                       | 발견 NavLink href, 관심/피드 aria-disabled + click no-op                 |
+| `AiIssueCard.test.tsx`                     | rendering: title/subtitle/related-news count/time/indicator/link href    |
+| `IssueImpactMap.test.tsx`                  | known category → pills; unknown/null → 안내 문구                          |
+| `RelatedSymbolsList.test.tsx`              | symbols present → chips; empty → 준비 중                                 |
+| `DiscoverPage.test.tsx`                    | list rendering (sorted), loading, error, empty, stale-readiness banner   |
+| `DiscoverIssueDetailPage.test.tsx`         | id match → detail; not-found → 안내 + back link; loading/error           |
+| `routes.test.tsx`                          | router exposes `/discover` and `/discover/issues/:issueId`                |
+
+---
+
+## Conventions
+
+- **Imports**: relative paths, mirroring `HomePage.tsx`.
+- **Styles**: prefer CSS variables (`var(--bg)`, `var(--surface)`, `var(--text)`, `var(--muted)`, `var(--gain)`, `var(--loss)`, `var(--warn)`). Inline `style={{}}` is fine — matches existing pattern. New ad-hoc class names allowed if reused.
+- **Korean copy**: never overstate causality. Disclaimer line on every detail-screen impact area: `뉴스 기반 참고 정보이며 매매 추천이 아닙니다.`
+- **No broker/order/watch/scheduler/LLM imports** anywhere.
+- **Commits**: Conventional Commits style matching repo (`feat(rob-127): ...`, `test(rob-127): ...`, `refactor(rob-127): ...`). One small focused commit per task. The `Co-Authored-By` trailer used in this repo is **not** required for these commits — match the recent style (no trailer, e.g. commit `af4d2384`).
+
+---
+
+## Task 1: TypeScript types for NewsRadar
+
+**Files:**
+- Create: `frontend/invest/src/types/newsRadar.ts`
+
+- [ ] **Step 1: Write the type definitions**
+
+```ts
+// frontend/invest/src/types/newsRadar.ts
+export type NewsRadarReadinessStatus = "ready" | "stale" | "unavailable";
+export type NewsRadarSeverity = "high" | "medium" | "low";
+export type NewsRadarRiskCategory =
+  | "geopolitical_oil"
+  | "macro_policy"
+  | "crypto_security"
+  | "earnings_bigtech"
+  | "korea_market";
+export type NewsRadarMarket = "all" | "kr" | "us" | "crypto";
+
+export interface NewsRadarReadiness {
+  status: NewsRadarReadinessStatus;
+  latest_scraped_at: string | null;
+  latest_published_at: string | null;
+  recent_6h_count: number;
+  recent_24h_count: number;
+  source_count: number;
+  stale: boolean;
+  max_age_minutes: number;
+  warnings: string[];
+}
+
+export interface NewsRadarSummary {
+  high_risk_count: number;
+  total_count: number;
+  included_in_briefing_count: number;
+  excluded_but_collected_count: number;
+}
+
+export interface NewsRadarSourceCoverage {
+  feed_source: string;
+  recent_6h: number;
+  recent_24h: number;
+  latest_published_at: string | null;
+  latest_scraped_at: string | null;
+  status: string;
+}
+
+export interface NewsRadarItem {
+  id: string;
+  title: string;
+  source: string | null;
+  feed_source: string | null;
+  url: string;
+  published_at: string | null;
+  market: string;
+  risk_category: NewsRadarRiskCategory | null;
+  severity: NewsRadarSeverity;
+  themes: string[];
+  symbols: string[];
+  included_in_briefing: boolean;
+  briefing_reason: string | null;
+  briefing_score: number;
+  snippet: string | null;
+  matched_terms: string[];
+}
+
+export interface NewsRadarSection {
+  section_id: NewsRadarRiskCategory;
+  title: string;
+  severity: NewsRadarSeverity;
+  items: NewsRadarItem[];
+}
+
+export interface NewsRadarResponse {
+  market: NewsRadarMarket;
+  as_of: string;
+  readiness: NewsRadarReadiness;
+  summary: NewsRadarSummary;
+  sections: NewsRadarSection[];
+  items: NewsRadarItem[];
+  excluded_items: NewsRadarItem[];
+  source_coverage: NewsRadarSourceCoverage[];
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd frontend/invest && npm run typecheck`
+Expected: PASS (no output beyond tsc summary).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/invest/src/types/newsRadar.ts
+git commit -m "feat(rob-127): add NewsRadar TypeScript types"
+```
+
+---
+
+## Task 2: API client `fetchNewsRadar`
+
+**Files:**
+- Create: `frontend/invest/src/api/newsRadar.ts`
+- Test: `frontend/invest/src/__tests__/newsRadar.api.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// frontend/invest/src/__tests__/newsRadar.api.test.ts
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { fetchNewsRadar } from "../api/newsRadar";
+import type { NewsRadarResponse } from "../types/newsRadar";
+
+const baseResponse: NewsRadarResponse = {
+  market: "all",
+  as_of: "2026-05-07T00:00:00Z",
+  readiness: {
+    status: "ready",
+    latest_scraped_at: null,
+    latest_published_at: null,
+    recent_6h_count: 0,
+    recent_24h_count: 0,
+    source_count: 0,
+    stale: false,
+    max_age_minutes: 0,
+    warnings: [],
+  },
+  summary: {
+    high_risk_count: 0,
+    total_count: 0,
+    included_in_briefing_count: 0,
+    excluded_but_collected_count: 0,
+  },
+  sections: [],
+  items: [],
+  excluded_items: [],
+  source_coverage: [],
+};
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test("fetchNewsRadar uses default query params and credentials", async () => {
+  fetchMock.mockResolvedValueOnce({ ok: true, json: async () => baseResponse });
+
+  await fetchNewsRadar();
+
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  const [url, init] = fetchMock.mock.calls[0];
+  expect(url).toBe(
+    "/trading/api/news-radar?market=all&hours=24&include_excluded=true&limit=20",
+  );
+  expect(init).toMatchObject({ credentials: "include" });
+});
+
+test("fetchNewsRadar throws on non-ok response", async () => {
+  fetchMock.mockResolvedValueOnce({ ok: false, status: 503, json: async () => ({}) });
+  await expect(fetchNewsRadar()).rejects.toThrow(/503/);
+});
+
+test("fetchNewsRadar overrides params", async () => {
+  fetchMock.mockResolvedValueOnce({ ok: true, json: async () => baseResponse });
+  await fetchNewsRadar({ market: "kr", hours: 12, limit: 5, includeExcluded: false });
+  const [url] = fetchMock.mock.calls[0];
+  expect(url).toBe(
+    "/trading/api/news-radar?market=kr&hours=12&include_excluded=false&limit=5",
+  );
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cd frontend/invest && npm test -- newsRadar.api`
+Expected: FAIL — `Cannot find module '../api/newsRadar'`.
+
+- [ ] **Step 3: Implement the API client**
+
+```ts
+// frontend/invest/src/api/newsRadar.ts
+import type { NewsRadarMarket, NewsRadarResponse } from "../types/newsRadar";
+
+export interface FetchNewsRadarParams {
+  market?: NewsRadarMarket;
+  hours?: number;
+  limit?: number;
+  includeExcluded?: boolean;
+}
+
+export async function fetchNewsRadar(
+  params: FetchNewsRadarParams = {},
+  signal?: AbortSignal,
+): Promise<NewsRadarResponse> {
+  const qs = new URLSearchParams({
+    market: params.market ?? "all",
+    hours: String(params.hours ?? 24),
+    include_excluded: String(params.includeExcluded ?? true),
+    limit: String(params.limit ?? 20),
+  });
+  const res = await fetch(`/trading/api/news-radar?${qs.toString()}`, {
+    credentials: "include",
+    signal,
+  });
+  if (!res.ok) {
+    throw new Error(`/trading/api/news-radar ${res.status}`);
+  }
+  return (await res.json()) as NewsRadarResponse;
+}
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+Run: `cd frontend/invest && npm test -- newsRadar.api`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/invest/src/api/newsRadar.ts frontend/invest/src/__tests__/newsRadar.api.test.ts
+git commit -m "feat(rob-127): add /trading/api/news-radar fetch wrapper"
+```
+
+---
+
+## Task 3: `useNewsRadar` hook
+
+**Files:**
+- Create: `frontend/invest/src/hooks/useNewsRadar.ts`
+
+(Hook is mirror of `useInvestHome.ts`. We rely on the API client tests + page-level tests to exercise behavior; per repo convention `useInvestHome` does not have its own dedicated test, so we skip a dedicated hook unit test here.)
+
+- [ ] **Step 1: Implement the hook**
+
+```ts
+// frontend/invest/src/hooks/useNewsRadar.ts
+import { useEffect, useState } from "react";
+import { fetchNewsRadar, type FetchNewsRadarParams } from "../api/newsRadar";
+import type { NewsRadarResponse } from "../types/newsRadar";
+
+export type NewsRadarState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; data: NewsRadarResponse };
+
+export function useNewsRadar(params: FetchNewsRadarParams = {}) {
+  const [state, setState] = useState<NewsRadarState>({ status: "loading" });
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState({ status: "loading" });
+    fetchNewsRadar(params, controller.signal)
+      .then((data) => setState({ status: "ready", data }))
+      .catch((e) => {
+        if (controller.signal.aborted) return;
+        setState({ status: "error", message: e?.message ?? "failed" });
+      });
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tick]);
+
+  return { state, reload: () => setTick((t) => t + 1) };
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd frontend/invest && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/invest/src/hooks/useNewsRadar.ts
+git commit -m "feat(rob-127): add useNewsRadar hook"
+```
+
+---
+
+## Task 4: `formatRelativeTime` utility
+
+**Files:**
+- Create: `frontend/invest/src/format/relativeTime.ts`
+- Test: `frontend/invest/src/__tests__/relativeTime.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// frontend/invest/src/__tests__/relativeTime.test.ts
+import { expect, test } from "vitest";
+import { formatRelativeTime } from "../format/relativeTime";
+
+const NOW = new Date("2026-05-07T12:00:00Z");
+
+test("returns '방금' for under 1 minute", () => {
+  expect(formatRelativeTime("2026-05-07T11:59:30Z", NOW)).toBe("방금");
+});
+
+test("returns minutes for under 1 hour", () => {
+  expect(formatRelativeTime("2026-05-07T11:55:00Z", NOW)).toBe("5분 전");
+});
+
+test("returns hours for under 1 day", () => {
+  expect(formatRelativeTime("2026-05-07T09:00:00Z", NOW)).toBe("3시간 전");
+});
+
+test("returns days for over 24 hours", () => {
+  expect(formatRelativeTime("2026-05-05T12:00:00Z", NOW)).toBe("2일 전");
+});
+
+test("returns null when input is null", () => {
+  expect(formatRelativeTime(null, NOW)).toBeNull();
+});
+
+test("returns null when input is in the future", () => {
+  expect(formatRelativeTime("2026-05-07T12:30:00Z", NOW)).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cd frontend/invest && npm test -- relativeTime`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// frontend/invest/src/format/relativeTime.ts
+export function formatRelativeTime(
+  iso: string | null | undefined,
+  now: Date = new Date(),
+): string | null {
+  if (!iso) return null;
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) return null;
+  const deltaMs = now.getTime() - then.getTime();
+  if (deltaMs < 0) return null;
+  const minutes = Math.floor(deltaMs / 60_000);
+  if (minutes < 1) return "방금";
+  if (minutes < 60) return `${minutes}분 전`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}시간 전`;
+  const days = Math.floor(hours / 24);
+  return `${days}일 전`;
+}
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+Run: `cd frontend/invest && npm test -- relativeTime`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/invest/src/format/relativeTime.ts frontend/invest/src/__tests__/relativeTime.test.ts
+git commit -m "feat(rob-127): add formatRelativeTime utility"
+```
+
+---
+
+## Task 5: Severity indicator + bucket-count helpers
+
+**Files:**
+- Create: `frontend/invest/src/components/discover/severity.ts`
+- Test: `frontend/invest/src/__tests__/severity.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// frontend/invest/src/__tests__/severity.test.ts
+import { expect, test } from "vitest";
+import {
+  countByRiskCategory,
+  describeSeverity,
+  sortIssueItems,
+} from "../components/discover/severity";
+import type { NewsRadarItem } from "../types/newsRadar";
+
+function makeItem(overrides: Partial<NewsRadarItem>): NewsRadarItem {
+  return {
+    id: "x",
+    title: "t",
+    source: null,
+    feed_source: null,
+    url: "",
+    published_at: null,
+    market: "all",
+    risk_category: null,
+    severity: "low",
+    themes: [],
+    symbols: [],
+    included_in_briefing: false,
+    briefing_reason: null,
+    briefing_score: 0,
+    snippet: null,
+    matched_terms: [],
+    ...overrides,
+  };
+}
+
+test("describeSeverity maps to indicator label", () => {
+  expect(describeSeverity("high").label).toBe("강한 이슈");
+  expect(describeSeverity("medium").label).toBe("관심 이슈");
+  expect(describeSeverity("low").label).toBe("참고");
+});
+
+test("countByRiskCategory groups items by risk_category", () => {
+  const items = [
+    makeItem({ id: "1", risk_category: "macro_policy" }),
+    makeItem({ id: "2", risk_category: "macro_policy" }),
+    makeItem({ id: "3", risk_category: "geopolitical_oil" }),
+    makeItem({ id: "4", risk_category: null }),
+  ];
+  const counts = countByRiskCategory(items);
+  expect(counts.macro_policy).toBe(2);
+  expect(counts.geopolitical_oil).toBe(1);
+  expect(counts.uncategorized).toBe(1);
+});
+
+test("sortIssueItems orders by severity then briefing_score then published_at", () => {
+  const items = [
+    makeItem({ id: "a", severity: "low", briefing_score: 10, published_at: "2026-05-07T10:00:00Z" }),
+    makeItem({ id: "b", severity: "high", briefing_score: 5, published_at: "2026-05-07T08:00:00Z" }),
+    makeItem({ id: "c", severity: "high", briefing_score: 9, published_at: "2026-05-07T08:00:00Z" }),
+    makeItem({ id: "d", severity: "medium", briefing_score: 0, published_at: "2026-05-07T11:00:00Z" }),
+  ];
+  expect(sortIssueItems(items).map((i) => i.id)).toEqual(["c", "b", "d", "a"]);
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cd frontend/invest && npm test -- severity`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// frontend/invest/src/components/discover/severity.ts
+import type { NewsRadarItem, NewsRadarSeverity } from "../../types/newsRadar";
+
+export interface SeverityDescriptor {
+  label: string;
+  color: string;
+  glyph: "▲" | "■" | "·";
+}
+
+export function describeSeverity(severity: NewsRadarSeverity): SeverityDescriptor {
+  switch (severity) {
+    case "high":
+      return { label: "강한 이슈", color: "var(--gain)", glyph: "▲" };
+    case "medium":
+      return { label: "관심 이슈", color: "var(--muted)", glyph: "■" };
+    case "low":
+    default:
+      return { label: "참고", color: "var(--muted)", glyph: "·" };
+  }
+}
+
+export type RiskBucketKey =
+  | "geopolitical_oil"
+  | "macro_policy"
+  | "crypto_security"
+  | "earnings_bigtech"
+  | "korea_market"
+  | "uncategorized";
+
+export function countByRiskCategory(items: NewsRadarItem[]): Record<RiskBucketKey, number> {
+  const out: Record<RiskBucketKey, number> = {
+    geopolitical_oil: 0,
+    macro_policy: 0,
+    crypto_security: 0,
+    earnings_bigtech: 0,
+    korea_market: 0,
+    uncategorized: 0,
+  };
+  for (const item of items) {
+    const key = (item.risk_category ?? "uncategorized") as RiskBucketKey;
+    out[key] = (out[key] ?? 0) + 1;
+  }
+  return out;
+}
+
+const SEVERITY_RANK: Record<NewsRadarSeverity, number> = { high: 3, medium: 2, low: 1 };
+
+export function sortIssueItems(items: NewsRadarItem[]): NewsRadarItem[] {
+  return [...items].sort((a, b) => {
+    const sev = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+    if (sev !== 0) return sev;
+    if (b.briefing_score !== a.briefing_score) return b.briefing_score - a.briefing_score;
+    const at = a.published_at ? Date.parse(a.published_at) : 0;
+    const bt = b.published_at ? Date.parse(b.published_at) : 0;
+    return bt - at;
+  });
+}
+
+export function relatedNewsCount(
+  item: NewsRadarItem,
+  buckets: Record<RiskBucketKey, number>,
+): number {
+  const key = (item.risk_category ?? "uncategorized") as RiskBucketKey;
+  return buckets[key] ?? 0;
+}
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+Run: `cd frontend/invest && npm test -- severity`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/invest/src/components/discover/severity.ts frontend/invest/src/__tests__/severity.test.ts
+git commit -m "feat(rob-127): add severity descriptor and bucket-count helpers"
+```
+
+---
+
+## Task 6: Impact map constant
+
+**Files:**
+- Create: `frontend/invest/src/components/discover/impactMap.ts`
+
+- [ ] **Step 1: Implement (no test — pure data, will be exercised by IssueImpactMap test in Task 11)**
+
+```ts
+// frontend/invest/src/components/discover/impactMap.ts
+import type { NewsRadarRiskCategory } from "../../types/newsRadar";
+
+export type ImpactTone = "positive" | "negative" | "watch";
+
+export interface ImpactPill {
+  theme: string;
+  tone: ImpactTone;
+  note: string;
+}
+
+export const IMPACT_MAP: Record<NewsRadarRiskCategory, ImpactPill[]> = {
+  geopolitical_oil: [
+    { theme: "원유/에너지", tone: "watch", note: "변동성/수혜 가능" },
+    { theme: "항공/운송", tone: "negative", note: "비용 압박 가능" },
+    { theme: "금/방산", tone: "positive", note: "방어적 선호 가능" },
+  ],
+  macro_policy: [
+    { theme: "금리 민감 성장주", tone: "negative", note: "부담 가능" },
+    { theme: "금융", tone: "watch", note: "금리/스프레드 영향" },
+  ],
+  earnings_bigtech: [
+    { theme: "AI/반도체", tone: "watch", note: "수요/실적 민감" },
+    { theme: "나스닥", tone: "watch", note: "투자심리 영향" },
+  ],
+  crypto_security: [
+    { theme: "가상자산", tone: "negative", note: "보안/규제 리스크" },
+  ],
+  korea_market: [
+    { theme: "국내 증시", tone: "watch", note: "수급/정책/환율 영향" },
+  ],
+};
+
+export function lookupImpact(category: NewsRadarRiskCategory | null): ImpactPill[] | null {
+  if (!category) return null;
+  return IMPACT_MAP[category] ?? null;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `cd frontend/invest && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/invest/src/components/discover/impactMap.ts
+git commit -m "feat(rob-127): add deterministic risk-category impact map"
+```
+
+---
+
+## Task 7: `BottomNav` rework with NavLink + disabled tabs
+
+**Files:**
+- Modify: `frontend/invest/src/components/BottomNav.tsx`
+- Test: `frontend/invest/src/__tests__/BottomNav.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/invest/src/__tests__/BottomNav.test.tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { expect, test, vi } from "vitest";
+import { BottomNav } from "../components/BottomNav";
+
+function renderAt(path: string) {
+  const router = createMemoryRouter(
+    [{ path: "*", element: <BottomNav /> }],
+    { initialEntries: [path], basename: "/invest/app" },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+test("발견 link points to /invest/app/discover", () => {
+  renderAt("/");
+  const link = screen.getByRole("link", { name: "발견" });
+  expect(link).toHaveAttribute("href", "/invest/app/discover");
+});
+
+test("증권 link points to /invest/app", () => {
+  renderAt("/");
+  const link = screen.getByRole("link", { name: "증권" });
+  expect(link).toHaveAttribute("href", "/invest/app/");
+});
+
+test("관심 and 피드 are aria-disabled and do not call alert when clicked", async () => {
+  const user = userEvent.setup();
+  const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+  renderAt("/");
+
+  const watch = screen.getByRole("button", { name: "관심" });
+  const feed = screen.getByRole("button", { name: "피드" });
+  expect(watch).toHaveAttribute("aria-disabled", "true");
+  expect(feed).toHaveAttribute("aria-disabled", "true");
+
+  await user.click(watch);
+  await user.click(feed);
+  expect(alertSpy).not.toHaveBeenCalled();
+  alertSpy.mockRestore();
+});
+
+test("BottomNav highlights active tab", () => {
+  renderAt("/discover");
+  const link = screen.getByRole("link", { name: "발견" });
+  // active uses var(--text), inactive uses var(--muted)
+  expect(link.getAttribute("style") ?? "").toContain("color: var(--text)");
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cd frontend/invest && npm test -- BottomNav`
+Expected: FAIL — current `BottomNav` renders `<button>` only, no links.
+
+- [ ] **Step 3: Replace `BottomNav.tsx`**
+
+```tsx
+// frontend/invest/src/components/BottomNav.tsx
+import type { CSSProperties } from "react";
+import { NavLink } from "react-router-dom";
+
+const ROW_STYLE: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-around",
+  paddingTop: 8,
+  borderTop: "1px solid var(--surface-2)",
+  color: "var(--muted)",
+  fontSize: 10,
+  position: "sticky",
+  bottom: 0,
+  background: "var(--bg)",
+};
+
+const TAB_BASE: CSSProperties = {
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  padding: 8,
+  fontSize: 10,
+  textDecoration: "none",
+};
+
+const DISABLED_STYLE: CSSProperties = {
+  ...TAB_BASE,
+  color: "var(--muted)",
+  opacity: 0.5,
+  cursor: "not-allowed",
+};
+
+function activeStyle(isActive: boolean): CSSProperties {
+  return {
+    ...TAB_BASE,
+    color: isActive ? "var(--text)" : "var(--muted)",
+  };
+}
+
+export function BottomNav() {
+  return (
+    <div style={ROW_STYLE}>
+      <NavLink to="/" end style={({ isActive }) => activeStyle(isActive)}>
+        증권
+      </NavLink>
+      <button
+        type="button"
+        aria-disabled="true"
+        disabled
+        style={DISABLED_STYLE}
+        tabIndex={-1}
+      >
+        관심
+      </button>
+      <NavLink to="/discover" style={({ isActive }) => activeStyle(isActive)}>
+        발견
+      </NavLink>
+      <button
+        type="button"
+        aria-disabled="true"
+        disabled
+        style={DISABLED_STYLE}
+        tabIndex={-1}
+      >
+        피드
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+Run: `cd frontend/invest && npm test -- BottomNav`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/invest/src/components/BottomNav.tsx frontend/invest/src/__tests__/BottomNav.test.tsx
+git commit -m "feat(rob-127): wire BottomNav 발견 to /discover and disable inactive tabs"
+```
+
+---
+
+## Task 8: Static discover sub-components (header, category rail, today event, ticker)
+
+**Files:**
+- Create: `frontend/invest/src/components/discover/DiscoverHeader.tsx`
+- Create: `frontend/invest/src/components/discover/CategoryShortcutRail.tsx`
+- Create: `frontend/invest/src/components/discover/TodayEventCard.tsx`
+- Create: `frontend/invest/src/components/discover/AiIssueTicker.tsx`
+
+(These are static presentational components. They are exercised by the page-level test in Task 12 — no dedicated unit tests.)
+
+- [ ] **Step 1: Implement DiscoverHeader**
+
+```tsx
+// frontend/invest/src/components/discover/DiscoverHeader.tsx
+export function DiscoverHeader() {
+  return (
+    <div style={{ paddingTop: 4 }}>
+      <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800 }}>발견</h1>
+      <div className="subtle" style={{ marginTop: 4 }}>
+        뉴스 기반 참고 정보입니다. 매매 추천이 아닙니다.
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Implement CategoryShortcutRail**
+
+```tsx
+// frontend/invest/src/components/discover/CategoryShortcutRail.tsx
+const CATEGORIES = ["해외주식", "국내주식", "옵션", "채권"] as const;
+
+export function CategoryShortcutRail() {
+  return (
+    <div
+      role="list"
+      aria-label="카테고리"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(4, 1fr)",
+        gap: 8,
+      }}
+    >
+      {CATEGORIES.map((label) => (
+        <div
+          key={label}
+          role="listitem"
+          aria-disabled="true"
+          style={{
+            padding: 12,
+            background: "var(--surface)",
+            border: "1px solid var(--surface-2)",
+            borderRadius: 12,
+            color: "var(--muted)",
+            fontSize: 12,
+            textAlign: "center",
+            opacity: 0.6,
+          }}
+        >
+          {label}
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Implement TodayEventCard (placeholder per design — does not consume news-radar data)**
+
+```tsx
+// frontend/invest/src/components/discover/TodayEventCard.tsx
+export function TodayEventCard() {
+  return (
+    <section
+      aria-labelledby="today-event-heading"
+      style={{
+        padding: 16,
+        background: "var(--surface)",
+        border: "1px solid var(--surface-2)",
+        borderRadius: 14,
+      }}
+    >
+      <h2
+        id="today-event-heading"
+        style={{ margin: 0, fontSize: 14, fontWeight: 700 }}
+      >
+        오늘의 주요 이벤트
+      </h2>
+      <div className="subtle" style={{ marginTop: 6 }}>
+        경제 캘린더는 준비 중입니다.
+      </div>
+      <div className="subtle" style={{ marginTop: 4 }}>
+        실적/지표 일정은 후속 업데이트에서 제공됩니다.
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Implement AiIssueTicker (section header above the issue list)**
+
+```tsx
+// frontend/invest/src/components/discover/AiIssueTicker.tsx
+export function AiIssueTicker({ asOf }: { asOf?: string | null }) {
+  return (
+    <header style={{ marginTop: 8 }}>
+      <h2 style={{ margin: 0, fontSize: 16, fontWeight: 700 }}>
+        AI 실시간 이슈
+      </h2>
+      <div className="subtle" style={{ marginTop: 4 }}>
+        뉴스 기반으로 정리된 참고 정보입니다.
+        {asOf ? ` 기준: ${new Date(asOf).toLocaleString("ko-KR")}` : ""}
+      </div>
+    </header>
+  );
+}
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `cd frontend/invest && npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/invest/src/components/discover/DiscoverHeader.tsx \
+        frontend/invest/src/components/discover/CategoryShortcutRail.tsx \
+        frontend/invest/src/components/discover/TodayEventCard.tsx \
+        frontend/invest/src/components/discover/AiIssueTicker.tsx
+git commit -m "feat(rob-127): add static discover header, category rail, today-event, ticker"
+```
+
+---
+
+## Task 9: `AiIssueCard` component
+
+**Files:**
+- Create: `frontend/invest/src/components/discover/AiIssueCard.tsx`
+- Test: `frontend/invest/src/__tests__/AiIssueCard.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/invest/src/__tests__/AiIssueCard.test.tsx
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { expect, test } from "vitest";
+import { AiIssueCard } from "../components/discover/AiIssueCard";
+import type { NewsRadarItem } from "../types/newsRadar";
+
+const item: NewsRadarItem = {
+  id: "abc",
+  title: "Fed 금리 동결 시사",
+  source: "Reuters",
+  feed_source: "reuters",
+  url: "https://example.com/news/1",
+  published_at: "2026-05-07T11:30:00Z",
+  market: "us",
+  risk_category: "macro_policy",
+  severity: "high",
+  themes: ["rates"],
+  symbols: ["SPY"],
+  included_in_briefing: true,
+  briefing_reason: null,
+  briefing_score: 80,
+  snippet: "위원회는 현재 정책 유지를 시사",
+  matched_terms: ["fomc"],
+};
+
+test("renders rank, title, snippet, related news count, indicator and link", () => {
+  render(
+    <MemoryRouter basename="/invest/app">
+      <AiIssueCard
+        rank={1}
+        item={item}
+        relatedCount={3}
+        now={new Date("2026-05-07T12:00:00Z")}
+      />
+    </MemoryRouter>,
+  );
+
+  expect(screen.getByText("1")).toBeInTheDocument();
+  expect(screen.getByText("Fed 금리 동결 시사")).toBeInTheDocument();
+  expect(screen.getByText(/위원회는 현재 정책 유지를 시사/)).toBeInTheDocument();
+  expect(screen.getByText("관련 뉴스 3개")).toBeInTheDocument();
+  expect(screen.getByText("30분 전")).toBeInTheDocument();
+  expect(screen.getByLabelText("강한 이슈")).toBeInTheDocument();
+  expect(screen.getByRole("link")).toHaveAttribute(
+    "href",
+    "/invest/app/discover/issues/abc",
+  );
+});
+
+test("falls back to themes when snippet is missing", () => {
+  render(
+    <MemoryRouter basename="/invest/app">
+      <AiIssueCard
+        rank={2}
+        item={{ ...item, snippet: null, themes: ["fomc", "rates"] }}
+        relatedCount={1}
+        now={new Date("2026-05-07T12:00:00Z")}
+      />
+    </MemoryRouter>,
+  );
+  expect(screen.getByText(/fomc, rates/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cd frontend/invest && npm test -- AiIssueCard`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```tsx
+// frontend/invest/src/components/discover/AiIssueCard.tsx
+import { Link } from "react-router-dom";
+import { formatRelativeTime } from "../../format/relativeTime";
+import type { NewsRadarItem } from "../../types/newsRadar";
+import { describeSeverity } from "./severity";
+
+export interface AiIssueCardProps {
+  rank: number;
+  item: NewsRadarItem;
+  relatedCount: number;
+  now?: Date;
+}
+
+function buildSubtitle(item: NewsRadarItem): string {
+  if (item.snippet && item.snippet.trim().length > 0) return item.snippet;
+  if (item.themes.length > 0) return item.themes.join(", ");
+  if (item.matched_terms.length > 0) return item.matched_terms.join(", ");
+  return "";
+}
+
+export function AiIssueCard({ rank, item, relatedCount, now }: AiIssueCardProps) {
+  const indicator = describeSeverity(item.severity);
+  const time = formatRelativeTime(item.published_at, now);
+  const subtitle = buildSubtitle(item);
+  return (
+    <Link
+      to={`/discover/issues/${item.id}`}
+      style={{
+        display: "flex",
+        gap: 12,
+        padding: 14,
+        background: "var(--surface)",
+        border: "1px solid var(--surface-2)",
+        borderRadius: 14,
+        color: "var(--text)",
+        textDecoration: "none",
+      }}
+    >
+      <div
+        style={{
+          minWidth: 24,
+          fontWeight: 800,
+          color: "var(--muted)",
+          fontSize: 16,
+        }}
+      >
+        {rank}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span
+            aria-label={indicator.label}
+            role="img"
+            style={{ color: indicator.color, fontSize: 12 }}
+          >
+            {indicator.glyph}
+          </span>
+          <span style={{ fontWeight: 700, fontSize: 14 }}>{item.title}</span>
+        </div>
+        {subtitle && (
+          <div
+            className="subtle"
+            style={{
+              marginTop: 4,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {subtitle}
+          </div>
+        )}
+        <div
+          className="subtle"
+          style={{ marginTop: 6, display: "flex", gap: 8, fontSize: 11 }}
+        >
+          <span>관련 뉴스 {relatedCount}개</span>
+          {time && <span>· {time}</span>}
+        </div>
+      </div>
+    </Link>
+  );
+}
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+Run: `cd frontend/invest && npm test -- AiIssueCard`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/invest/src/components/discover/AiIssueCard.tsx \
+        frontend/invest/src/__tests__/AiIssueCard.test.tsx
+git commit -m "feat(rob-127): add AiIssueCard with related-news count and severity indicator"
+```
+
+---
+
+## Task 10: `IssueImpactMap` component
+
+**Files:**
+- Create: `frontend/invest/src/components/discover/IssueImpactMap.tsx`
+- Test: `frontend/invest/src/__tests__/IssueImpactMap.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/invest/src/__tests__/IssueImpactMap.test.tsx
+import { render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { IssueImpactMap } from "../components/discover/IssueImpactMap";
+
+test("renders impact pills for known risk_category", () => {
+  render(<IssueImpactMap category="geopolitical_oil" />);
+  expect(screen.getByText("원유/에너지")).toBeInTheDocument();
+  expect(screen.getByText("항공/운송")).toBeInTheDocument();
+  expect(screen.getByText("금/방산")).toBeInTheDocument();
+});
+
+test("renders fallback notice when category is null", () => {
+  render(<IssueImpactMap category={null} />);
+  expect(
+    screen.getByText("이 이슈에 대한 영향 분석은 준비 중입니다."),
+  ).toBeInTheDocument();
+});
+
+test("includes disclaimer", () => {
+  render(<IssueImpactMap category="macro_policy" />);
+  expect(
+    screen.getByText("뉴스 기반 참고 정보이며 매매 추천이 아닙니다."),
+  ).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cd frontend/invest && npm test -- IssueImpactMap`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```tsx
+// frontend/invest/src/components/discover/IssueImpactMap.tsx
+import type { CSSProperties } from "react";
+import type { NewsRadarRiskCategory } from "../../types/newsRadar";
+import { lookupImpact, type ImpactPill, type ImpactTone } from "./impactMap";
+
+const TONE_STYLES: Record<ImpactTone, CSSProperties> = {
+  positive: { background: "var(--pill-mix)", color: "var(--pill-mix-fg)" },
+  negative: { background: "var(--pill-toss)", color: "var(--pill-toss-fg)" },
+  watch: { background: "var(--pill-up)", color: "var(--pill-up-fg)" },
+};
+
+export function IssueImpactMap({ category }: { category: NewsRadarRiskCategory | null }) {
+  const pills = lookupImpact(category);
+  return (
+    <section aria-labelledby="impact-heading" style={{ marginTop: 16 }}>
+      <h2 id="impact-heading" style={{ margin: 0, fontSize: 14, fontWeight: 700 }}>
+        어떤 영향을 줄까?
+      </h2>
+      {pills && pills.length > 0 ? (
+        <ul
+          style={{
+            listStyle: "none",
+            padding: 0,
+            margin: "8px 0 0",
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+          }}
+        >
+          {pills.map((pill) => (
+            <ImpactRow key={pill.theme} pill={pill} />
+          ))}
+        </ul>
+      ) : (
+        <div className="subtle" style={{ marginTop: 8 }}>
+          이 이슈에 대한 영향 분석은 준비 중입니다.
+        </div>
+      )}
+      <div className="subtle" style={{ marginTop: 12, fontSize: 11 }}>
+        뉴스 기반 참고 정보이며 매매 추천이 아닙니다.
+      </div>
+    </section>
+  );
+}
+
+function ImpactRow({ pill }: { pill: ImpactPill }) {
+  return (
+    <li
+      style={{
+        display: "flex",
+        gap: 8,
+        alignItems: "center",
+        padding: "8px 12px",
+        borderRadius: 999,
+        ...TONE_STYLES[pill.tone],
+        fontSize: 12,
+      }}
+    >
+      <strong>{pill.theme}</strong>
+      <span style={{ opacity: 0.85 }}>{pill.note}</span>
+    </li>
+  );
+}
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+Run: `cd frontend/invest && npm test -- IssueImpactMap`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/invest/src/components/discover/IssueImpactMap.tsx \
+        frontend/invest/src/__tests__/IssueImpactMap.test.tsx
+git commit -m "feat(rob-127): add IssueImpactMap with deterministic risk-category mapping"
+```
+
+---
+
+## Task 11: `RelatedSymbolsList` component
+
+**Files:**
+- Create: `frontend/invest/src/components/discover/RelatedSymbolsList.tsx`
+- Test: `frontend/invest/src/__tests__/RelatedSymbolsList.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/invest/src/__tests__/RelatedSymbolsList.test.tsx
+import { render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { RelatedSymbolsList } from "../components/discover/RelatedSymbolsList";
+
+test("renders symbol chips when symbols are present", () => {
+  render(<RelatedSymbolsList symbols={["AAPL", "MSFT"]} />);
+  expect(screen.getByText("AAPL")).toBeInTheDocument();
+  expect(screen.getByText("MSFT")).toBeInTheDocument();
+});
+
+test("renders prep notice when symbols are empty", () => {
+  render(<RelatedSymbolsList symbols={[]} />);
+  expect(screen.getByText("관련 종목 분석은 준비 중입니다.")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cd frontend/invest && npm test -- RelatedSymbolsList`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```tsx
+// frontend/invest/src/components/discover/RelatedSymbolsList.tsx
+export function RelatedSymbolsList({ symbols }: { symbols: string[] }) {
+  return (
+    <section aria-labelledby="symbols-heading" style={{ marginTop: 16 }}>
+      <h2 id="symbols-heading" style={{ margin: 0, fontSize: 14, fontWeight: 700 }}>
+        관련 종목
+      </h2>
+      {symbols.length > 0 ? (
+        <ul
+          style={{
+            listStyle: "none",
+            padding: 0,
+            margin: "8px 0 0",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 6,
+          }}
+        >
+          {symbols.map((sym) => (
+            <li
+              key={sym}
+              style={{
+                padding: "4px 10px",
+                background: "var(--surface-2)",
+                color: "var(--text)",
+                borderRadius: 999,
+                fontSize: 12,
+                fontWeight: 600,
+              }}
+            >
+              {sym}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="subtle" style={{ marginTop: 8 }}>
+          관련 종목 분석은 준비 중입니다.
+        </div>
+      )}
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+Run: `cd frontend/invest && npm test -- RelatedSymbolsList`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/invest/src/components/discover/RelatedSymbolsList.tsx \
+        frontend/invest/src/__tests__/RelatedSymbolsList.test.tsx
+git commit -m "feat(rob-127): add RelatedSymbolsList with empty-state fallback"
+```
+
+---
+
+## Task 12: `DiscoverPage`
+
+**Files:**
+- Create: `frontend/invest/src/pages/DiscoverPage.tsx`
+- Test: `frontend/invest/src/__tests__/DiscoverPage.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/invest/src/__tests__/DiscoverPage.test.tsx
+import type { ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { expect, test, vi } from "vitest";
+import { DiscoverPage } from "../pages/DiscoverPage";
+import type { NewsRadarItem, NewsRadarResponse } from "../types/newsRadar";
+
+function makeItem(over: Partial<NewsRadarItem>): NewsRadarItem {
+  return {
+    id: "i",
+    title: "t",
+    source: null,
+    feed_source: null,
+    url: "",
+    published_at: null,
+    market: "all",
+    risk_category: null,
+    severity: "low",
+    themes: [],
+    symbols: [],
+    included_in_briefing: false,
+    briefing_reason: null,
+    briefing_score: 0,
+    snippet: null,
+    matched_terms: [],
+    ...over,
+  };
+}
+
+function makeResponse(items: NewsRadarItem[], over: Partial<NewsRadarResponse> = {}): NewsRadarResponse {
+  return {
+    market: "all",
+    as_of: "2026-05-07T12:00:00Z",
+    readiness: {
+      status: "ready",
+      latest_scraped_at: null,
+      latest_published_at: null,
+      recent_6h_count: 0,
+      recent_24h_count: 0,
+      source_count: 0,
+      stale: false,
+      max_age_minutes: 0,
+      warnings: [],
+    },
+    summary: {
+      high_risk_count: 0,
+      total_count: items.length,
+      included_in_briefing_count: 0,
+      excluded_but_collected_count: 0,
+    },
+    sections: [],
+    items,
+    excluded_items: [],
+    source_coverage: [],
+    ...over,
+  };
+}
+
+function renderWith(node: ReactNode) {
+  return render(<MemoryRouter basename="/invest/app">{node}</MemoryRouter>);
+}
+
+test("renders sorted issue cards with related-news counts", () => {
+  const items = [
+    makeItem({ id: "a", title: "낮은 이슈", severity: "low",
+               risk_category: "macro_policy", briefing_score: 1 }),
+    makeItem({ id: "b", title: "높은 이슈", severity: "high",
+               risk_category: "macro_policy", briefing_score: 2,
+               published_at: "2026-05-07T11:55:00Z" }),
+    makeItem({ id: "c", title: "지정학", severity: "high",
+               risk_category: "geopolitical_oil", briefing_score: 5,
+               published_at: "2026-05-07T11:00:00Z" }),
+  ];
+  renderWith(
+    <DiscoverPage state={{ status: "ready", data: makeResponse(items) }} reload={() => {}} />,
+  );
+
+  const titles = screen.getAllByRole("link").map((a) => a.textContent ?? "");
+  expect(titles[0]).toContain("지정학");
+  expect(titles[1]).toContain("높은 이슈");
+  expect(titles[2]).toContain("낮은 이슈");
+  // macro_policy bucket has 2 items, geopolitical_oil has 1.
+  expect(screen.getAllByText("관련 뉴스 2개").length).toBeGreaterThanOrEqual(2);
+  expect(screen.getByText("관련 뉴스 1개")).toBeInTheDocument();
+});
+
+test("renders loading state", () => {
+  renderWith(<DiscoverPage state={{ status: "loading" }} reload={() => {}} />);
+  expect(screen.getByText("불러오는 중…")).toBeInTheDocument();
+});
+
+test("renders error state with retry", () => {
+  const reload = vi.fn();
+  renderWith(<DiscoverPage state={{ status: "error", message: "boom" }} reload={reload} />);
+  expect(screen.getByText("잠시 후 다시 시도해 주세요.")).toBeInTheDocument();
+  expect(screen.getByText(/boom/)).toBeInTheDocument();
+  screen.getByRole("button", { name: "재시도" }).click();
+  expect(reload).toHaveBeenCalled();
+});
+
+test("renders empty state when items list is empty", () => {
+  renderWith(
+    <DiscoverPage
+      state={{ status: "ready", data: makeResponse([]) }}
+      reload={() => {}}
+    />,
+  );
+  expect(screen.getByText("표시할 이슈가 없습니다.")).toBeInTheDocument();
+});
+
+test("renders stale readiness banner", () => {
+  renderWith(
+    <DiscoverPage
+      state={{
+        status: "ready",
+        data: makeResponse([], {
+          readiness: {
+            status: "stale",
+            latest_scraped_at: null,
+            latest_published_at: null,
+            recent_6h_count: 0,
+            recent_24h_count: 0,
+            source_count: 0,
+            stale: true,
+            max_age_minutes: 120,
+            warnings: [],
+          },
+        }),
+      }}
+      reload={() => {}}
+    />,
+  );
+  expect(
+    screen.getByText("데이터가 최신이 아닐 수 있습니다."),
+  ).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cd frontend/invest && npm test -- DiscoverPage`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement DiscoverPage**
+
+```tsx
+// frontend/invest/src/pages/DiscoverPage.tsx
+import { AppShell } from "../components/AppShell";
+import { BottomNav } from "../components/BottomNav";
+import { AiIssueCard } from "../components/discover/AiIssueCard";
+import { AiIssueTicker } from "../components/discover/AiIssueTicker";
+import { CategoryShortcutRail } from "../components/discover/CategoryShortcutRail";
+import { DiscoverHeader } from "../components/discover/DiscoverHeader";
+import { TodayEventCard } from "../components/discover/TodayEventCard";
+import {
+  countByRiskCategory,
+  relatedNewsCount,
+  sortIssueItems,
+} from "../components/discover/severity";
+import { useNewsRadar, type NewsRadarState } from "../hooks/useNewsRadar";
+
+export interface DiscoverPageProps {
+  state?: NewsRadarState;
+  reload?: () => void;
+}
+
+export function DiscoverPage(props: DiscoverPageProps = {}) {
+  const live = useNewsRadar({
+    market: "all",
+    hours: 24,
+    includeExcluded: true,
+    limit: 20,
+  });
+  const state = props.state ?? live.state;
+  const reload = props.reload ?? live.reload;
+
+  if (state.status === "loading") {
+    return (
+      <AppShell>
+        <div className="subtle">불러오는 중…</div>
+        <BottomNav />
+      </AppShell>
+    );
+  }
+  if (state.status === "error") {
+    return (
+      <AppShell>
+        <div>잠시 후 다시 시도해 주세요.</div>
+        <button type="button" onClick={reload}>
+          재시도
+        </button>
+        <div className="subtle">{state.message}</div>
+        <BottomNav />
+      </AppShell>
+    );
+  }
+
+  const { data } = state;
+  const sorted = sortIssueItems(data.items);
+  const buckets = countByRiskCategory(data.items);
+  const isStale = data.readiness.status === "stale";
+
+  return (
+    <AppShell>
+      <DiscoverHeader />
+      <CategoryShortcutRail />
+      <TodayEventCard />
+      <AiIssueTicker asOf={data.as_of} />
+      {isStale && (
+        <div
+          role="status"
+          style={{
+            padding: 8,
+            background: "rgba(246,193,119,0.08)",
+            border: "1px solid rgba(246,193,119,0.27)",
+            color: "var(--warn)",
+            borderRadius: 10,
+            fontSize: 11,
+          }}
+        >
+          데이터가 최신이 아닐 수 있습니다.
+        </div>
+      )}
+      {sorted.length === 0 ? (
+        <div className="subtle">표시할 이슈가 없습니다.</div>
+      ) : (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 10,
+            flex: 1,
+            overflowY: "auto",
+          }}
+        >
+          {sorted.map((item, idx) => (
+            <AiIssueCard
+              key={item.id}
+              rank={idx + 1}
+              item={item}
+              relatedCount={relatedNewsCount(item, buckets)}
+            />
+          ))}
+        </div>
+      )}
+      <BottomNav />
+    </AppShell>
+  );
+}
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+Run: `cd frontend/invest && npm test -- DiscoverPage`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/invest/src/pages/DiscoverPage.tsx \
+        frontend/invest/src/__tests__/DiscoverPage.test.tsx
+git commit -m "feat(rob-127): add DiscoverPage with sorted issue list and state branches"
+```
+
+---
+
+## Task 13: `DiscoverIssueDetailPage`
+
+**Files:**
+- Create: `frontend/invest/src/pages/DiscoverIssueDetailPage.tsx`
+- Test: `frontend/invest/src/__tests__/DiscoverIssueDetailPage.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/invest/src/__tests__/DiscoverIssueDetailPage.test.tsx
+import type { ComponentProps } from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { expect, test } from "vitest";
+import { DiscoverIssueDetailPage } from "../pages/DiscoverIssueDetailPage";
+import type { NewsRadarItem, NewsRadarResponse } from "../types/newsRadar";
+
+function makeItem(over: Partial<NewsRadarItem>): NewsRadarItem {
+  return {
+    id: "i",
+    title: "t",
+    source: null,
+    feed_source: null,
+    url: "",
+    published_at: null,
+    market: "all",
+    risk_category: null,
+    severity: "low",
+    themes: [],
+    symbols: [],
+    included_in_briefing: false,
+    briefing_reason: null,
+    briefing_score: 0,
+    snippet: null,
+    matched_terms: [],
+    ...over,
+  };
+}
+
+function response(items: NewsRadarItem[]): NewsRadarResponse {
+  return {
+    market: "all",
+    as_of: "2026-05-07T12:00:00Z",
+    readiness: {
+      status: "ready",
+      latest_scraped_at: null,
+      latest_published_at: null,
+      recent_6h_count: 0,
+      recent_24h_count: 0,
+      source_count: 0,
+      stale: false,
+      max_age_minutes: 0,
+      warnings: [],
+    },
+    summary: {
+      high_risk_count: 0,
+      total_count: items.length,
+      included_in_briefing_count: 0,
+      excluded_but_collected_count: 0,
+    },
+    sections: [],
+    items,
+    excluded_items: [],
+    source_coverage: [],
+  };
+}
+
+function renderAt(path: string, state: ComponentProps<typeof DiscoverIssueDetailPage>["state"]) {
+  return render(
+    <MemoryRouter initialEntries={[path]} basename="/invest/app">
+      <Routes>
+        <Route
+          path="/discover/issues/:issueId"
+          element={<DiscoverIssueDetailPage state={state} reload={() => {}} />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+test("renders matched issue with impact map and related symbols", () => {
+  const matched = makeItem({
+    id: "abc",
+    title: "Fed 금리",
+    snippet: "정책 유지",
+    risk_category: "macro_policy",
+    symbols: ["SPY"],
+    severity: "high",
+    published_at: "2026-05-07T11:30:00Z",
+    source: "Reuters",
+  });
+  renderAt("/discover/issues/abc", { status: "ready", data: response([matched]) });
+
+  expect(screen.getByText("Fed 금리")).toBeInTheDocument();
+  expect(screen.getByText("정책 유지")).toBeInTheDocument();
+  expect(screen.getByText("금리 민감 성장주")).toBeInTheDocument();
+  expect(screen.getByText("SPY")).toBeInTheDocument();
+  expect(
+    screen.getByText("뉴스 기반 참고 정보이며 매매 추천이 아닙니다."),
+  ).toBeInTheDocument();
+});
+
+test("renders not-found state when id is missing", () => {
+  renderAt("/discover/issues/missing", { status: "ready", data: response([]) });
+  expect(
+    screen.getByText("이슈를 찾을 수 없습니다. 시간이 지나 목록에서 빠졌을 수 있어요."),
+  ).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: "발견으로 돌아가기" })).toHaveAttribute(
+    "href",
+    "/invest/app/discover",
+  );
+});
+
+test("renders symbols-empty notice when item has no symbols", () => {
+  const matched = makeItem({ id: "abc", title: "T", symbols: [] });
+  renderAt("/discover/issues/abc", { status: "ready", data: response([matched]) });
+  expect(screen.getByText("관련 종목 분석은 준비 중입니다.")).toBeInTheDocument();
+});
+
+test("renders loading and error states", () => {
+  renderAt("/discover/issues/abc", { status: "loading" });
+  expect(screen.getByText("불러오는 중…")).toBeInTheDocument();
+
+  // re-render with error
+  renderAt("/discover/issues/abc", { status: "error", message: "boom" });
+  expect(screen.getByText("잠시 후 다시 시도해 주세요.")).toBeInTheDocument();
+  expect(screen.getByText(/boom/)).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cd frontend/invest && npm test -- DiscoverIssueDetailPage`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```tsx
+// frontend/invest/src/pages/DiscoverIssueDetailPage.tsx
+import { Link, useParams } from "react-router-dom";
+import { AppShell } from "../components/AppShell";
+import { BottomNav } from "../components/BottomNav";
+import { IssueImpactMap } from "../components/discover/IssueImpactMap";
+import { RelatedSymbolsList } from "../components/discover/RelatedSymbolsList";
+import { describeSeverity } from "../components/discover/severity";
+import { formatRelativeTime } from "../format/relativeTime";
+import { useNewsRadar, type NewsRadarState } from "../hooks/useNewsRadar";
+
+export interface DiscoverIssueDetailPageProps {
+  state?: NewsRadarState;
+  reload?: () => void;
+}
+
+export function DiscoverIssueDetailPage(props: DiscoverIssueDetailPageProps = {}) {
+  const params = useParams<{ issueId: string }>();
+  const live = useNewsRadar({
+    market: "all",
+    hours: 24,
+    includeExcluded: true,
+    limit: 20,
+  });
+  const state = props.state ?? live.state;
+  const reload = props.reload ?? live.reload;
+  const issueId = params.issueId ?? "";
+
+  if (state.status === "loading") {
+    return (
+      <AppShell>
+        <div className="subtle">불러오는 중…</div>
+        <BottomNav />
+      </AppShell>
+    );
+  }
+  if (state.status === "error") {
+    return (
+      <AppShell>
+        <div>잠시 후 다시 시도해 주세요.</div>
+        <button type="button" onClick={reload}>
+          재시도
+        </button>
+        <div className="subtle">{state.message}</div>
+        <BottomNav />
+      </AppShell>
+    );
+  }
+
+  const item = state.data.items.find((i) => i.id === issueId);
+  if (!item) {
+    return (
+      <AppShell>
+        <div>이슈를 찾을 수 없습니다. 시간이 지나 목록에서 빠졌을 수 있어요.</div>
+        <Link
+          to="/discover"
+          style={{ color: "var(--accent, #7eb6ff)", fontWeight: 700 }}
+        >
+          발견으로 돌아가기
+        </Link>
+        <BottomNav />
+      </AppShell>
+    );
+  }
+
+  const indicator = describeSeverity(item.severity);
+  const time = formatRelativeTime(item.published_at);
+
+  return (
+    <AppShell>
+      <Link to="/discover" className="subtle" style={{ textDecoration: "none" }}>
+        ← 발견
+      </Link>
+      <header style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span
+            aria-label={indicator.label}
+            role="img"
+            style={{ color: indicator.color }}
+          >
+            {indicator.glyph}
+          </span>
+          <h1 style={{ margin: 0, fontSize: 18, fontWeight: 800 }}>{item.title}</h1>
+        </div>
+        {item.snippet && (
+          <p className="subtle" style={{ margin: 0 }}>{item.snippet}</p>
+        )}
+        <div className="subtle" style={{ display: "flex", gap: 8, fontSize: 11 }}>
+          {item.source && <span>{item.source}</span>}
+          {time && <span>· {time}</span>}
+        </div>
+      </header>
+      <IssueImpactMap category={item.risk_category} />
+      <RelatedSymbolsList symbols={item.symbols} />
+      <section
+        style={{
+          marginTop: 16,
+          padding: 12,
+          background: "var(--surface)",
+          border: "1px solid var(--surface-2)",
+          borderRadius: 12,
+          fontSize: 12,
+        }}
+      >
+        <strong style={{ display: "block", marginBottom: 4 }}>꼭 알아두세요</strong>
+        <span className="subtle">
+          이 화면은 read-only 정보입니다. 매수/매도 주문이나 자동 추천을 제공하지 않습니다.
+        </span>
+      </section>
+      <BottomNav />
+    </AppShell>
+  );
+}
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+Run: `cd frontend/invest && npm test -- DiscoverIssueDetailPage`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/invest/src/pages/DiscoverIssueDetailPage.tsx \
+        frontend/invest/src/__tests__/DiscoverIssueDetailPage.test.tsx
+git commit -m "feat(rob-127): add DiscoverIssueDetailPage with id matching and fallback"
+```
+
+---
+
+## Task 14: Register routes
+
+**Files:**
+- Modify: `frontend/invest/src/routes.tsx`
+- Test: `frontend/invest/src/__tests__/routes.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// frontend/invest/src/__tests__/routes.test.tsx
+import { expect, test } from "vitest";
+import { router } from "../routes";
+
+function pathsOf(routes: any[]): string[] {
+  const out: string[] = [];
+  for (const r of routes) {
+    if (r.path) out.push(r.path);
+    if (r.children) out.push(...pathsOf(r.children));
+  }
+  return out;
+}
+
+test("router exposes /discover and /discover/issues/:issueId", () => {
+  const paths = pathsOf((router as any).routes);
+  expect(paths).toContain("/discover");
+  expect(paths).toContain("/discover/issues/:issueId");
+});
+
+test("router still exposes / and /paper", () => {
+  const paths = pathsOf((router as any).routes);
+  expect(paths).toContain("/");
+  expect(paths).toContain("/paper");
+  expect(paths).toContain("/paper/:variant");
+});
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+Run: `cd frontend/invest && npm test -- routes`
+Expected: FAIL — `/discover` not present.
+
+- [ ] **Step 3: Update `routes.tsx`**
+
+```tsx
+// frontend/invest/src/routes.tsx
+import { createBrowserRouter, Navigate } from "react-router-dom";
+import { DiscoverIssueDetailPage } from "./pages/DiscoverIssueDetailPage";
+import { DiscoverPage } from "./pages/DiscoverPage";
+import { HomePage } from "./pages/HomePage";
+import { PaperPlaceholderPage } from "./pages/PaperPlaceholderPage";
+
+export const router = createBrowserRouter(
+  [
+    { path: "/", element: <HomePage /> },
+    { path: "/paper", element: <PaperPlaceholderPage /> },
+    { path: "/paper/:variant", element: <PaperPlaceholderPage /> },
+    { path: "/discover", element: <DiscoverPage /> },
+    { path: "/discover/issues/:issueId", element: <DiscoverIssueDetailPage /> },
+    { path: "*", element: <Navigate to="/" replace /> },
+  ],
+  { basename: "/invest/app" },
+);
+```
+
+- [ ] **Step 4: Run test, expect pass**
+
+Run: `cd frontend/invest && npm test -- routes`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/invest/src/routes.tsx frontend/invest/src/__tests__/routes.test.tsx
+git commit -m "feat(rob-127): register /discover and /discover/issues/:issueId routes"
+```
+
+---
+
+## Task 15: Full verification + read-only safety check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck**
+
+Run: `cd frontend/invest && npm run typecheck`
+Expected: PASS (no errors).
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cd frontend/invest && npm test`
+Expected: ALL test files pass. Take note of total counts.
+
+- [ ] **Step 3: Build**
+
+Run: `cd frontend/invest && npm run build`
+Expected: Build completes; bundle written to `frontend/invest/dist/`.
+
+- [ ] **Step 4: Read-only safety grep**
+
+Run from repo root:
+```bash
+grep -rE "broker_|order_intent|watch_service|scheduler|app/workers|llm_" frontend/invest/src/components/discover frontend/invest/src/pages/Discover* frontend/invest/src/api/newsRadar.ts frontend/invest/src/hooks/useNewsRadar.ts || echo "OK: no forbidden imports"
+```
+Expected: prints `OK: no forbidden imports`.
+
+- [ ] **Step 5: Backend lint sanity (no Python files were added, but confirm clean tree)**
+
+Run from repo root:
+```bash
+git diff --check
+```
+Expected: no whitespace errors.
+
+- [ ] **Step 6: Smoke check in dev server (optional, manual)**
+
+Run: `cd frontend/invest && npm run dev`
+- Open `http://localhost:<port>/invest/app/`
+- Tap `발견` in BottomNav → `/invest/app/discover` loads.
+- Card click → `/invest/app/discover/issues/<id>` loads.
+- Refresh detail URL directly → still loads (refetch path).
+- Confirm `관심`, `피드` buttons are dim and not clickable.
+
+- [ ] **Step 7: Final commit (if any cleanup remained)**
+
+If steps 1–6 produced no diff, skip. Otherwise:
+```bash
+git add -A
+git commit -m "chore(rob-127): final cleanup after verification"
+```
+
+---
+
+## Spec Coverage Map
+
+| Spec section / AC                                                                                  | Task(s)              |
+| -------------------------------------------------------------------------------------------------- | -------------------- |
+| `/invest/app/discover` route renders mobile dark UI                                                | 12, 14               |
+| BottomNav 발견 navigates and shows active state                                                     | 7                    |
+| BottomNav 관심/피드 disabled, no alert                                                              | 7                    |
+| `오늘 이벤트` placeholder card                                                                      | 8 (TodayEventCard)    |
+| `AI 실시간 이슈` list with title/subtitle/related-news count/time/severity                          | 5, 9, 12              |
+| Loading / error / empty states do not break                                                        | 12 (DiscoverPage tests) |
+| Card click → `/discover/issues/:issueId`                                                            | 9 (link), 14         |
+| Detail: summary, source/time, deterministic impact map, symbols-if-present, disclaimer              | 6, 10, 11, 13         |
+| `RelatedSymbolsList` empty fallback (no fake symbols)                                              | 11, 13                |
+| Tests cover route registration, list rendering, detail rendering, empty/error                      | 7, 9, 10, 11, 12, 13, 14 |
+| Read-only safety boundary maintained (no broker/order/watch/scheduler/LLM imports)                  | 15 (grep)             |
+| Spec decision: bucket-count display labeled "관련 뉴스 n개"                                          | 5, 9, 12              |
+| Spec decision: detail page refetches news-radar (no shared cache)                                  | 13                    |
+| Spec decision: Today Event = pure placeholder, no news-radar coupling                               | 8                    |
+| Spec decision: BottomNav inactive tabs disabled (not alert)                                        | 7                    |
+
+## Out-of-scope reminder
+
+Do **not** add in this plan or any task above:
+- broker submit / cancel / modify / replace
+- order preview / approval / order-intent / watch creation
+- scheduler / worker activation
+- DB migration / backfill / direct SQL
+- new LLM call / new scheduled job
+- economic calendar provider integration
+- realtime websocket / chart
+- news clustering / source merging
+- automated related-symbol recommendation

--- a/docs/superpowers/specs/2026-05-07-rob-127-invest-discover-tab-design.md
+++ b/docs/superpowers/specs/2026-05-07-rob-127-invest-discover-tab-design.md
@@ -1,0 +1,313 @@
+# ROB-127: /invest/app 토스 발견탭 스타일 뉴스 기반 AI 실시간 이슈 MVP — Design
+
+- **Linear**: [ROB-127](https://linear.app/mgh3326/issue/ROB-127/auto-trader-investapp-토스-발견탭-스타일-뉴스-기반-ai-실시간-이슈-mvp)
+- **Branch**: `auto-trader-investapp-ai-mvp` (현재 워크트리, 신규 브랜치 생성하지 않음)
+- **Status**: Design approved (2026-05-07)
+- **Owner**: 광현 (Claude Code) — Hermes/AoE 자동 구현 없음
+
+## 1. 목적
+
+`/invest/app`에 토스증권 `발견` 탭을 참고한 **read-only MVP**를 추가한다. 이번 이슈에서는 신규 AI/이벤트 생성 기능을 만들지 않고, 이미 존재하는 read-only 엔드포인트 `GET /trading/api/news-radar`를 단일 데이터 소스로 사용해 화면 뼈대를 우선 만든다.
+
+## 2. 안전 경계 (Non-goals)
+
+이번 이슈에서 **하지 않는다**:
+
+- broker submit / cancel / modify / replace
+- order preview / approval / order-intent / watch 생성
+- scheduler / worker 활성화 또는 주기 변경
+- DB migration / backfill / direct row update
+- 신규 LLM 호출 / 새로운 AI 요약 생성 job
+- 경제지표 / 실적 캘린더 provider 연동
+- 실시간 websocket / chart 구현
+- 뉴스 클러스터링 / 출처 병합 정확도 보장
+- 관련 종목 자동 추천 / 분석 기능
+
+신규 import 금지: `app/services/broker_*`, `app/services/order_*`, `app/services/watch_*`, `app/scheduler/*`, `app/workers/*`, `app/services/llm_*` 류.
+
+## 3. 데이터 소스
+
+### 3.1 백엔드 엔드포인트
+
+`GET /trading/api/news-radar?market=all&hours=24&include_excluded=true&limit=20`
+
+- **인증**: 기존 invest 화면과 동일하게 cookie 기반 (`credentials: "include"`).
+- **응답 스키마**: `app/schemas/news_radar.py::NewsRadarResponse`
+- **주요 필드**: `readiness`, `summary`, `sections`, `items`, `excluded_items`, `source_coverage`, `as_of`
+- **신규 backend API 만들지 않는다.** invest 화면에 맞는 view-model 매핑은 프론트 표시층에서만 처리.
+
+### 3.2 상세 페이지 데이터 페칭 결정
+
+상세 페이지 `/discover/issues/:issueId`는 **항상 `/trading/api/news-radar`를 다시 호출**해서 `id` 매칭으로 항목을 찾는다.
+
+- 직접 URL 진입 / 새로고침 / 공유 링크 안전.
+- React Router `state` 전달 / Context / SWR / React Query 도입하지 않는다.
+- 리스트와 상세는 동일 hook (`useNewsRadar`)을 재사용. 상세 페이지에서 받은 응답에서 `id === issueId`인 항목을 찾고, 없으면 빈/오류 상태로 표시.
+
+## 4. Routes
+
+`frontend/invest/src/routes.tsx`는 `basename: "/invest/app"`을 유지하고 다음 경로 추가:
+
+| Path                                       | Element                       | Note                              |
+| ------------------------------------------ | ----------------------------- | --------------------------------- |
+| `/`                                        | `HomePage`                    | 기존 ROB-123 홈 (변경 없음)       |
+| `/paper`                                   | `PaperPlaceholderPage`        | 기존 (변경 없음)                  |
+| `/paper/:variant`                          | `PaperPlaceholderPage`        | 기존 (변경 없음)                  |
+| `/discover`                                | **`DiscoverPage` (신규)**     | AI 실시간 이슈 리스트              |
+| `/discover/issues/:issueId`                | **`DiscoverIssueDetailPage` (신규)** | 이슈 상세                  |
+| `*`                                        | `Navigate to="/" replace`     | 기존 catch-all (변경 없음)        |
+
+## 5. BottomNav 변경
+
+`frontend/invest/src/components/BottomNav.tsx` 4개 탭 처리:
+
+| 라벨   | 동작                                                       |
+| ------ | ---------------------------------------------------------- |
+| 증권   | `NavLink to="/"` (active 시 강조)                           |
+| 관심   | `<button disabled aria-disabled="true">` + dim 스타일       |
+| 발견   | `NavLink to="/discover"` (active 시 강조)                   |
+| 피드   | `<button disabled aria-disabled="true">` + dim 스타일       |
+
+- `alert("준비 중")` 호출은 모두 제거.
+- active 표시는 `NavLink`의 `isActive` 콜백으로 색상만 강조 (`var(--text)` vs `var(--muted)`).
+- disabled 탭은 `cursor: "not-allowed"` + `opacity: 0.5`, 클릭 핸들러 없음.
+
+## 6. 파일 구조
+
+신규/수정 파일 (Linear spec 기준 + 본 design doc에서 확정한 항목):
+
+### 6.1 신규 파일
+
+```
+frontend/invest/src/
+├── api/
+│   └── newsRadar.ts                          # fetch wrapper
+├── hooks/
+│   └── useNewsRadar.ts                       # state hook (loading/error/ready)
+├── types/
+│   └── newsRadar.ts                          # NewsRadarResponse / NewsRadarItem TS mirror
+├── pages/
+│   ├── DiscoverPage.tsx                      # 발견 메인
+│   └── DiscoverIssueDetailPage.tsx           # 이슈 상세
+├── components/discover/
+│   ├── DiscoverHeader.tsx                    # 상단 "발견" 헤더
+│   ├── CategoryShortcutRail.tsx              # 해외주식/국내주식/옵션/채권 (모두 비활성)
+│   ├── TodayEventCard.tsx                    # placeholder ("경제 캘린더 준비 중")
+│   ├── AiIssueTicker.tsx                     # "AI 실시간 이슈" 섹션 헤더 + 안내
+│   ├── AiIssueCard.tsx                       # 카드 1개 (rank, indicator, 제목, 부제, 관련 뉴스 n개, 시간)
+│   ├── IssueImpactMap.tsx                    # "어떤 영향을 줄까?" deterministic mapping
+│   └── RelatedSymbolsList.tsx                # 관련 종목 (item.symbols 있을 때만)
+└── format/
+    └── relativeTime.ts                       # published_at → "5분 전" 류 (선택, 새로 만들거나 기존 utils에 추가)
+```
+
+### 6.2 수정 파일
+
+```
+frontend/invest/src/
+├── routes.tsx                                # /discover, /discover/issues/:issueId 추가
+└── components/
+    └── BottomNav.tsx                         # NavLink + disabled tabs
+```
+
+### 6.3 신규 테스트
+
+```
+frontend/invest/src/__tests__/
+├── DiscoverPage.test.tsx                     # list rendering, empty, error, loading
+├── DiscoverIssueDetailPage.test.tsx          # detail rendering, not-found, related symbols absent → 안내
+├── BottomNav.test.tsx                        # 발견 NavLink 동작, disabled 탭 클릭 무시
+└── newsRadar.mapping.test.tsx                # bucket count, severity → indicator, impact map mapping (옵션)
+```
+
+## 7. View-model 매핑
+
+### 7.1 카드 매핑 (`NewsRadarItem` → `AiIssueCardProps`)
+
+| 카드 필드          | 소스                                                                 |
+| ------------------ | -------------------------------------------------------------------- |
+| `rank`             | 정렬 후 인덱스 (1-base). 정렬키: `severity` (high>medium>low) → `briefing_score` desc → `published_at` desc |
+| `title`            | `item.title`                                                          |
+| `subtitle`         | `item.snippet` (없으면 `item.themes.join(", ") || item.matched_terms.join(", ")`) |
+| `relatedNewsCount` | **같은 `risk_category` bucket의 item count** (응답 전체 `items` 기준) |
+| `relativeTime`     | `published_at` → `5분 전` / `1시간 전` 류                              |
+| `indicator`        | `severity`: `high` → 빨강 삼각형, `medium` → 회색 indicator, `low` → 약한 회색 dot. **상승/하락 의미가 아니라 "뉴스 강도"로 라벨링.** |
+| `detailHref`       | `/discover/issues/${item.id}`                                         |
+
+**UI 문구**: 카드 하단에 `관련 뉴스 ${n}개` (또는 `관련 이슈 ${n}개`). "출처 ${n}개"처럼 source merging이 일어난 듯한 표현은 피한다.
+
+**정렬 안정성**: 동일 severity / score / published_at일 때 입력 순서 유지 (Array.prototype.sort는 stable).
+
+### 7.2 Today Event card (placeholder)
+
+`TodayEventCard`는 본 MVP에서 **순수 placeholder**:
+
+- 제목: `오늘의 주요 이벤트`
+- 본문: `경제 캘린더는 준비 중입니다.`
+- subtle 안내: `이번 분기 실적/지표 일정은 후속 업데이트에서 제공됩니다.`
+- AI 실시간 이슈 리스트와 의미 중복을 피하기 위해 `news-radar` 데이터를 끌어쓰지 않는다.
+
+### 7.3 Impact map (deterministic)
+
+`IssueImpactMap`은 `item.risk_category`로 키를 잡아 정해진 영향 테마 pill 리스트를 보여준다. 매핑은 frontend constant로 둔다 (LLM 호출 없음):
+
+```ts
+// 예: frontend/invest/src/components/discover/impactMap.ts (또는 IssueImpactMap.tsx 내부)
+const IMPACT_MAP: Record<NewsRadarRiskCategory, ImpactPill[]> = {
+  geopolitical_oil: [
+    { theme: "원유/에너지", tone: "watch", note: "변동성/수혜 가능" },
+    { theme: "항공/운송",   tone: "negative", note: "비용 압박 가능" },
+    { theme: "금/방산",     tone: "positive", note: "방어적 선호 가능" },
+  ],
+  macro_policy: [
+    { theme: "금리 민감 성장주", tone: "negative", note: "부담 가능" },
+    { theme: "금융",            tone: "watch",    note: "금리/스프레드 영향" },
+  ],
+  earnings_bigtech: [
+    { theme: "AI/반도체", tone: "watch",    note: "수요/실적 민감" },
+    { theme: "나스닥",    tone: "watch",    note: "투자심리 영향" },
+  ],
+  crypto_security: [
+    { theme: "가상자산", tone: "negative", note: "보안/규제 리스크" },
+  ],
+  korea_market: [
+    { theme: "국내 증시", tone: "watch", note: "수급/정책/환율 영향" },
+  ],
+};
+```
+
+`risk_category`가 `null` 또는 매핑에 없는 값이면 영향 맵 대신 안내 문구만 표시: `이 이슈에 대한 영향 분석은 준비 중입니다.`
+
+각 카드 하단에 면책 표시: `뉴스 기반 참고 정보이며 매매 추천이 아닙니다.`
+
+### 7.4 RelatedSymbolsList
+
+- `item.symbols.length > 0`이면 심볼 ticker 리스트로 표시 (단순 chip, 클릭 동작은 이번 이슈에서 만들지 않거나 placeholder no-op).
+- `item.symbols.length === 0`이면 `관련 종목 분석은 준비 중입니다.` 문구 한 줄로 대체.
+- 임의 종목을 만들지 않는다. analyzer 호출도 하지 않는다.
+
+## 8. Hook / API 디자인
+
+### 8.1 `frontend/invest/src/api/newsRadar.ts`
+
+```ts
+import type { NewsRadarResponse } from "../types/newsRadar";
+
+export async function fetchNewsRadar(
+  params: { market?: "all" | "kr" | "us" | "crypto"; hours?: number; limit?: number; includeExcluded?: boolean } = {},
+  signal?: AbortSignal,
+): Promise<NewsRadarResponse> {
+  const qs = new URLSearchParams({
+    market: params.market ?? "all",
+    hours: String(params.hours ?? 24),
+    include_excluded: String(params.includeExcluded ?? true),
+    limit: String(params.limit ?? 20),
+  });
+  const res = await fetch(`/trading/api/news-radar?${qs.toString()}`, {
+    credentials: "include",
+    signal,
+  });
+  if (!res.ok) throw new Error(`/trading/api/news-radar ${res.status}`);
+  return (await res.json()) as NewsRadarResponse;
+}
+```
+
+### 8.2 `frontend/invest/src/hooks/useNewsRadar.ts`
+
+`useInvestHome`와 동일한 형태:
+
+```ts
+export type NewsRadarState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; data: NewsRadarResponse };
+
+export function useNewsRadar(): { state: NewsRadarState; reload: () => void };
+```
+
+DiscoverPage / DiscoverIssueDetailPage 모두 동일 hook을 사용. 상세 페이지는 `state.data.items.find((i) => i.id === issueId)`로 항목을 찾고, 없으면 "이슈를 찾을 수 없습니다." 빈 상태 표시.
+
+### 8.3 페이지 testability
+
+`DiscoverPage`와 `DiscoverIssueDetailPage`는 `HomePage`처럼 optional props (`{ state?, reload? }`)를 받는다. 테스트에서 hook을 우회하고 fixture를 직접 주입하기 위함.
+
+## 9. 상태 처리
+
+| 상태       | 화면                                                                    |
+| ---------- | ----------------------------------------------------------------------- |
+| loading    | "불러오는 중…" subtle 텍스트 (AppShell 안)                                |
+| error      | 사용자에게 "잠시 후 다시 시도해 주세요." + 재시도 버튼 + `state.message` |
+| empty      | `items.length === 0` → "표시할 이슈가 없습니다." + readiness 안내 (선택)   |
+| ready      | 카드 리스트                                                              |
+| readiness=stale | 리스트 위에 "데이터가 최신이 아닐 수 있습니다." 작은 배지            |
+| readiness=unavailable | 에러와 동일 처리                                              |
+
+상세 페이지에서 `find` 결과가 없을 때:
+
+- `이슈를 찾을 수 없습니다. 시간이 지나 목록에서 빠졌을 수 있어요.` + `발견으로 돌아가기` 버튼 (`Link to="/discover"`).
+
+## 10. 테스트 계획
+
+Vitest + Testing Library. 모든 fetch는 monkeypatch / `vi.mock` 또는 page-level prop 주입으로 처리.
+
+**필수 커버리지**:
+
+1. **routes 등록**: `/discover`, `/discover/issues/:issueId` 가 router에 존재하고 catch-all 보다 먼저 매칭됨.
+2. **BottomNav**: `발견`이 `<a href="/invest/app/discover">`로 렌더 / 클릭. `관심`, `피드`는 `aria-disabled="true"` 보유 + 클릭해도 `alert`/navigate 없음.
+3. **DiscoverPage list rendering**: fixture 주입 → 카드 N개 / 정렬 / 관련 뉴스 카운트 / 상대시간 표시 확인.
+4. **DiscoverPage 상태**: loading / error / empty 각 한 케이스.
+5. **DiscoverIssueDetailPage rendering**: id 매칭 성공, impact map pill 렌더, related symbols (있는 케이스 / 없는 케이스 모두).
+6. **DiscoverIssueDetailPage not-found**: id 매칭 실패 → 안내 문구 + 돌아가기 링크.
+7. **(선택) 매핑 단위 테스트**: severity → indicator, risk_category → impact pills.
+
+## 11. Acceptance criteria 매핑
+
+| Linear AC                                                                                            | 구현 위치                                                                       |
+| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `/invest/app/discover` route가 열리고 모바일 다크 UI로 렌더                                          | `routes.tsx` + `DiscoverPage` (AppShell 사용)                                   |
+| BottomNav `발견`이 `/discover`로 이동하고 active 표시                                                 | `BottomNav.tsx` (NavLink isActive)                                              |
+| `오늘 이벤트` 카드 존재, 캘린더 미연동 시 명확히 표시                                                | `TodayEventCard` placeholder                                                    |
+| `AI 실시간 이슈` 리스트, news-radar 기반 제목/부제/출처/시간/강도                                     | `DiscoverPage` + `AiIssueCard` (관련 뉴스 n개, 상대시간, severity indicator)    |
+| API loading / error / empty 깨지지 않음                                                              | `useNewsRadar` 상태 분기 + 테스트                                                |
+| 카드 클릭 → `/discover/issues/:issueId` 진입                                                         | `AiIssueCard` `<Link>`                                                           |
+| 상세: 요약, 출처/시간, 영향 맵, 관련 symbols(있을 때만), 안내 문구                                    | `DiscoverIssueDetailPage` + `IssueImpactMap` + `RelatedSymbolsList`             |
+| `RelatedSymbolsList`: symbols 없으면 "관련 종목 분석은 준비 중입니다"                                  | `RelatedSymbolsList` 분기                                                        |
+| 프론트 테스트 route / list / detail / empty / error 커버                                              | `__tests__/DiscoverPage.test.tsx`, `DiscoverIssueDetailPage.test.tsx`, `BottomNav.test.tsx` |
+| read-only 안전 경계 유지, 신규 order/broker/watch/scheduler import 없음                              | grep 검증 + 신규 파일 review                                                     |
+
+## 12. 검증 명령
+
+```bash
+cd frontend/invest
+npm run typecheck
+npm test
+npm run build
+```
+
+선택적 backend safety check:
+
+```bash
+# repo root에서
+uv run ruff check app/ tests/
+uv run ruff format --check app/ tests/
+git diff --check
+```
+
+## 13. 결정 요약 (브레인스토밍 응답)
+
+| 결정                              | 선택                                                                                  |
+| --------------------------------- | ------------------------------------------------------------------------------------- |
+| 카드 "출처 수" 표시               | (b) 같은 `risk_category` bucket의 item count. UI 라벨은 `관련 뉴스 n개`로 표현.        |
+| 상세 페이지 데이터 소스           | (b) 항상 `/trading/api/news-radar` 재호출 후 `id` 매칭. SWR/React Query 미도입.        |
+| `오늘 이벤트` 카드                | (a) 순수 placeholder. news-radar 데이터 끌어오지 않음.                                  |
+| BottomNav 비활성 탭               | (b) `disabled` + `aria-disabled` + dim. `alert` 제거, 클릭 무시.                        |
+| 브랜치                            | 신규 브랜치 생성하지 않음. 현재 워크트리 `auto-trader-investapp-ai-mvp` 위에서 진행. |
+
+## 14. Out-of-scope (후속 이슈 후보)
+
+- 경제지표 / 실적 캘린더 provider 연동
+- 뉴스 클러스터 (출처 병합) 백엔드 기능
+- 관련 종목 자동 분석 / 추천
+- 실시간 시세 / 차트 / websocket
+- `관심`, `피드` 탭 기능
+- `해외주식/국내주식/옵션/채권` 카테고리 카드 라우팅

--- a/frontend/invest/src/__tests__/AiIssueCard.test.tsx
+++ b/frontend/invest/src/__tests__/AiIssueCard.test.tsx
@@ -1,0 +1,63 @@
+// frontend/invest/src/__tests__/AiIssueCard.test.tsx
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { expect, test } from "vitest";
+import { AiIssueCard } from "../components/discover/AiIssueCard";
+import type { NewsRadarItem } from "../types/newsRadar";
+
+const item: NewsRadarItem = {
+  id: "abc",
+  title: "Fed 금리 동결 시사",
+  source: "Reuters",
+  feed_source: "reuters",
+  url: "https://example.com/news/1",
+  published_at: "2026-05-07T11:30:00Z",
+  market: "us",
+  risk_category: "macro_policy",
+  severity: "high",
+  themes: ["rates"],
+  symbols: ["SPY"],
+  included_in_briefing: true,
+  briefing_reason: null,
+  briefing_score: 80,
+  snippet: "위원회는 현재 정책 유지를 시사",
+  matched_terms: ["fomc"],
+};
+
+test("renders rank, title, snippet, related news count, indicator and link", () => {
+  render(
+    <MemoryRouter basename="/invest/app" initialEntries={["/invest/app/"]}>
+      <AiIssueCard
+        rank={1}
+        item={item}
+        relatedCount={3}
+        now={new Date("2026-05-07T12:00:00Z")}
+      />
+    </MemoryRouter>,
+  );
+
+  expect(screen.getByText("1")).toBeInTheDocument();
+  expect(screen.getByText("Fed 금리 동결 시사")).toBeInTheDocument();
+  expect(screen.getByText(/위원회는 현재 정책 유지를 시사/)).toBeInTheDocument();
+  expect(screen.getByText(/관련 뉴스 3개/)).toBeInTheDocument();
+  expect(screen.getByText(/30분 전/)).toBeInTheDocument();
+  expect(screen.getByLabelText("강한 이슈")).toBeInTheDocument();
+  expect(screen.getByRole("link")).toHaveAttribute(
+    "href",
+    "/invest/app/discover/issues/abc",
+  );
+});
+
+test("falls back to themes when snippet is missing", () => {
+  render(
+    <MemoryRouter basename="/invest/app" initialEntries={["/invest/app/"]}>
+      <AiIssueCard
+        rank={2}
+        item={{ ...item, snippet: null, themes: ["fomc", "rates"] }}
+        relatedCount={1}
+        now={new Date("2026-05-07T12:00:00Z")}
+      />
+    </MemoryRouter>,
+  );
+  expect(screen.getByText(/fomc, rates/)).toBeInTheDocument();
+});

--- a/frontend/invest/src/__tests__/BottomNav.test.tsx
+++ b/frontend/invest/src/__tests__/BottomNav.test.tsx
@@ -1,0 +1,49 @@
+// frontend/invest/src/__tests__/BottomNav.test.tsx
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { expect, test, vi } from "vitest";
+import { BottomNav } from "../components/BottomNav";
+
+function renderAt(path: string) {
+  const router = createMemoryRouter(
+    [{ path: "*", element: <BottomNav /> }],
+    { initialEntries: [`/invest/app${path}`], basename: "/invest/app" },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+test("발견 link points to /invest/app/discover", () => {
+  renderAt("/");
+  const link = screen.getByRole("link", { name: "발견" });
+  expect(link).toHaveAttribute("href", "/invest/app/discover");
+});
+
+test("증권 link points to /invest/app", () => {
+  renderAt("/");
+  const link = screen.getByRole("link", { name: "증권" });
+  expect(link).toHaveAttribute("href", "/invest/app");
+});
+
+test("관심 and 피드 are aria-disabled and do not call alert when clicked", async () => {
+  const user = userEvent.setup();
+  const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+  renderAt("/");
+
+  const watch = screen.getByRole("button", { name: "관심" });
+  const feed = screen.getByRole("button", { name: "피드" });
+  expect(watch).toHaveAttribute("aria-disabled", "true");
+  expect(feed).toHaveAttribute("aria-disabled", "true");
+
+  await user.click(watch);
+  await user.click(feed);
+  expect(alertSpy).not.toHaveBeenCalled();
+  alertSpy.mockRestore();
+});
+
+test("BottomNav highlights active tab", () => {
+  renderAt("/discover");
+  const link = screen.getByRole("link", { name: "발견" });
+  // active uses var(--text), inactive uses var(--muted)
+  expect(link.getAttribute("style") ?? "").toContain("color: var(--text)");
+});

--- a/frontend/invest/src/__tests__/BottomNav.test.tsx
+++ b/frontend/invest/src/__tests__/BottomNav.test.tsx
@@ -27,7 +27,7 @@ test("증권 link points to /invest/app", () => {
 
 test("관심 and 피드 are aria-disabled and do not call alert when clicked", async () => {
   const user = userEvent.setup();
-  const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+  const alertSpy = vi.spyOn(globalThis, "alert").mockImplementation(() => {});
   renderAt("/");
 
   const watch = screen.getByRole("button", { name: "관심" });

--- a/frontend/invest/src/__tests__/DiscoverIssueDetailPage.test.tsx
+++ b/frontend/invest/src/__tests__/DiscoverIssueDetailPage.test.tsx
@@ -1,0 +1,119 @@
+// frontend/invest/src/__tests__/DiscoverIssueDetailPage.test.tsx
+import type { ComponentProps } from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { expect, test } from "vitest";
+import { DiscoverIssueDetailPage } from "../pages/DiscoverIssueDetailPage";
+import type { NewsRadarItem, NewsRadarResponse } from "../types/newsRadar";
+
+function makeItem(over: Partial<NewsRadarItem>): NewsRadarItem {
+  return {
+    id: "i",
+    title: "t",
+    source: null,
+    feed_source: null,
+    url: "",
+    published_at: null,
+    market: "all",
+    risk_category: null,
+    severity: "low",
+    themes: [],
+    symbols: [],
+    included_in_briefing: false,
+    briefing_reason: null,
+    briefing_score: 0,
+    snippet: null,
+    matched_terms: [],
+    ...over,
+  };
+}
+
+function response(items: NewsRadarItem[]): NewsRadarResponse {
+  return {
+    market: "all",
+    as_of: "2026-05-07T12:00:00Z",
+    readiness: {
+      status: "ready",
+      latest_scraped_at: null,
+      latest_published_at: null,
+      recent_6h_count: 0,
+      recent_24h_count: 0,
+      source_count: 0,
+      stale: false,
+      max_age_minutes: 0,
+      warnings: [],
+    },
+    summary: {
+      high_risk_count: 0,
+      total_count: items.length,
+      included_in_briefing_count: 0,
+      excluded_but_collected_count: 0,
+    },
+    sections: [],
+    items,
+    excluded_items: [],
+    source_coverage: [],
+  };
+}
+
+function renderAt(path: string, state: ComponentProps<typeof DiscoverIssueDetailPage>["state"]) {
+  return render(
+    <MemoryRouter initialEntries={[`/invest/app${path}`]} basename="/invest/app">
+      <Routes>
+        <Route
+          path="/discover/issues/:issueId"
+          element={<DiscoverIssueDetailPage state={state} reload={() => {}} />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+test("renders matched issue with impact map and related symbols", () => {
+  const matched = makeItem({
+    id: "abc",
+    title: "Fed 금리",
+    snippet: "정책 유지",
+    risk_category: "macro_policy",
+    symbols: ["SPY"],
+    severity: "high",
+    published_at: "2026-05-07T11:30:00Z",
+    source: "Reuters",
+  });
+  renderAt("/discover/issues/abc", { status: "ready", data: response([matched]) });
+
+  expect(screen.getByText("Fed 금리")).toBeInTheDocument();
+  expect(screen.getByText("정책 유지")).toBeInTheDocument();
+  expect(screen.getByText("금리 민감 성장주")).toBeInTheDocument();
+  expect(screen.getByText("SPY")).toBeInTheDocument();
+  expect(
+    screen.getByText(/뉴스 기반 참고 정보이며 매매 추천이 아닙니다./),
+  ).toBeInTheDocument();
+});
+
+test("renders not-found state when id is missing", () => {
+  renderAt("/discover/issues/missing", { status: "ready", data: response([]) });
+  expect(
+    screen.getByText(/이슈를 찾을 수 없습니다. 시간이 지나 목록에서 빠졌을 수 있어요./),
+  ).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: "발견으로 돌아가기" })).toHaveAttribute(
+    "href",
+    "/invest/app/discover",
+  );
+});
+
+test("renders symbols-empty notice when item has no symbols", () => {
+  const matched = makeItem({ id: "abc", title: "T", symbols: [] });
+  renderAt("/discover/issues/abc", { status: "ready", data: response([matched]) });
+  expect(screen.getByText("관련 종목 분석은 준비 중입니다.")).toBeInTheDocument();
+});
+
+test("renders loading and error states", () => {
+  renderAt("/discover/issues/abc", { status: "loading" });
+  expect(screen.getByText("불러오는 중…")).toBeInTheDocument();
+
+  // re-render with error
+  renderAt("/discover/issues/abc", { status: "error", message: "boom" });
+  expect(screen.getByText("잠시 후 다시 시도해 주세요.")).toBeInTheDocument();
+  expect(screen.getByText(/boom/)).toBeInTheDocument();
+});

--- a/frontend/invest/src/__tests__/DiscoverIssueDetailPage.test.tsx
+++ b/frontend/invest/src/__tests__/DiscoverIssueDetailPage.test.tsx
@@ -1,9 +1,8 @@
 // frontend/invest/src/__tests__/DiscoverIssueDetailPage.test.tsx
-import type { ComponentProps } from "react";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { expect, test } from "vitest";
-import { DiscoverIssueDetailPage } from "../pages/DiscoverIssueDetailPage";
+import { DiscoverIssueDetailPage, type DiscoverIssueDetailPageProps } from "../pages/DiscoverIssueDetailPage";
 import type { NewsRadarItem, NewsRadarResponse } from "../types/newsRadar";
 
 function makeItem(over: Partial<NewsRadarItem>): NewsRadarItem {
@@ -56,7 +55,7 @@ function response(items: NewsRadarItem[]): NewsRadarResponse {
   };
 }
 
-function renderAt(path: string, state: ComponentProps<typeof DiscoverIssueDetailPage>["state"]) {
+function renderAt(path: string, state: DiscoverIssueDetailPageProps["state"]) {
   return render(
     <MemoryRouter initialEntries={[`/invest/app${path}`]} basename="/invest/app">
       <Routes>

--- a/frontend/invest/src/__tests__/DiscoverPage.test.tsx
+++ b/frontend/invest/src/__tests__/DiscoverPage.test.tsx
@@ -1,0 +1,137 @@
+// frontend/invest/src/__tests__/DiscoverPage.test.tsx
+import type { ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { expect, test, vi } from "vitest";
+import { DiscoverPage } from "../pages/DiscoverPage";
+import type { NewsRadarItem, NewsRadarResponse } from "../types/newsRadar";
+
+function makeItem(over: Partial<NewsRadarItem>): NewsRadarItem {
+  return {
+    id: "i",
+    title: "t",
+    source: null,
+    feed_source: null,
+    url: "",
+    published_at: null,
+    market: "all",
+    risk_category: null,
+    severity: "low",
+    themes: [],
+    symbols: [],
+    included_in_briefing: false,
+    briefing_reason: null,
+    briefing_score: 0,
+    snippet: null,
+    matched_terms: [],
+    ...over,
+  };
+}
+
+function makeResponse(items: NewsRadarItem[], over: Partial<NewsRadarResponse> = {}): NewsRadarResponse {
+  return {
+    market: "all",
+    as_of: "2026-05-07T12:00:00Z",
+    readiness: {
+      status: "ready",
+      latest_scraped_at: null,
+      latest_published_at: null,
+      recent_6h_count: 0,
+      recent_24h_count: 0,
+      source_count: 0,
+      stale: false,
+      max_age_minutes: 0,
+      warnings: [],
+    },
+    summary: {
+      high_risk_count: 0,
+      total_count: items.length,
+      included_in_briefing_count: 0,
+      excluded_but_collected_count: 0,
+    },
+    sections: [],
+    items,
+    excluded_items: [],
+    source_coverage: [],
+    ...over,
+  };
+}
+
+function renderWith(node: ReactNode) {
+  return render(<MemoryRouter basename="/invest/app" initialEntries={["/invest/app/discover"]} >{node}</MemoryRouter>);
+}
+
+test("renders sorted issue cards with related-news counts", () => {
+  const items = [
+    makeItem({ id: "a", title: "낮은 이슈", severity: "low",
+               risk_category: "macro_policy", briefing_score: 1 }),
+    makeItem({ id: "b", title: "높은 이슈", severity: "high",
+               risk_category: "macro_policy", briefing_score: 2,
+               published_at: "2026-05-07T11:55:00Z" }),
+    makeItem({ id: "c", title: "지정학", severity: "high",
+               risk_category: "geopolitical_oil", briefing_score: 5,
+               published_at: "2026-05-07T11:00:00Z" }),
+  ];
+  renderWith(
+    <DiscoverPage state={{ status: "ready", data: makeResponse(items) }} reload={() => {}} />,
+  );
+
+  const titles = screen.getAllByRole("link").map((a) => a.textContent ?? "");
+  expect(titles[0]).toContain("지정학");
+  expect(titles[1]).toContain("높은 이슈");
+  expect(titles[2]).toContain("낮은 이슈");
+  // macro_policy bucket has 2 items, geopolitical_oil has 1.
+  expect(screen.getAllByText(/관련 뉴스 2개/).length).toBeGreaterThanOrEqual(2);
+  expect(screen.getByText(/관련 뉴스 1개/)).toBeInTheDocument();
+});
+
+test("renders loading state", () => {
+  renderWith(<DiscoverPage state={{ status: "loading" }} reload={() => {}} />);
+  expect(screen.getByText("불러오는 중…")).toBeInTheDocument();
+});
+
+test("renders error state with retry", () => {
+  const reload = vi.fn();
+  renderWith(<DiscoverPage state={{ status: "error", message: "boom" }} reload={reload} />);
+  expect(screen.getByText("잠시 후 다시 시도해 주세요.")).toBeInTheDocument();
+  expect(screen.getByText(/boom/)).toBeInTheDocument();
+  screen.getByRole("button", { name: "재시도" }).click();
+  expect(reload).toHaveBeenCalled();
+});
+
+test("renders empty state when items list is empty", () => {
+  renderWith(
+    <DiscoverPage
+      state={{ status: "ready", data: makeResponse([]) }}
+      reload={() => {}}
+    />,
+  );
+  expect(screen.getByText("표시할 이슈가 없습니다.")).toBeInTheDocument();
+});
+
+test("renders stale readiness banner", () => {
+  renderWith(
+    <DiscoverPage
+      state={{
+        status: "ready",
+        data: makeResponse([], {
+          readiness: {
+            status: "stale",
+            latest_scraped_at: null,
+            latest_published_at: null,
+            recent_6h_count: 0,
+            recent_24h_count: 0,
+            source_count: 0,
+            stale: true,
+            max_age_minutes: 120,
+            warnings: [],
+          },
+        }),
+      }}
+      reload={() => {}}
+    />,
+  );
+  expect(
+    screen.getByText("데이터가 최신이 아닐 수 있습니다."),
+  ).toBeInTheDocument();
+});

--- a/frontend/invest/src/__tests__/HomePage.test.tsx
+++ b/frontend/invest/src/__tests__/HomePage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { HomePage } from "../pages/HomePage";
 import type { InvestHomeResponse } from "../types/invest";
 
@@ -69,12 +70,20 @@ const data: InvestHomeResponse = {
 };
 
 test("renders meta.warnings as a single line", () => {
-  render(<HomePage state={{ status: "ready", data }} reload={() => {}} />);
+  render(
+    <MemoryRouter basename="/invest/app" initialEntries={["/invest/app/"]}>
+      <HomePage state={{ status: "ready", data }} reload={() => {}} />
+    </MemoryRouter>
+  );
   expect(screen.getByText(/cache only/)).toBeInTheDocument();
 });
 
 test("activeSource toggles between groupedHoldings and raw holdings", () => {
-  render(<HomePage state={{ status: "ready", data }} reload={() => {}} />);
+  render(
+    <MemoryRouter basename="/invest/app" initialEntries={["/invest/app/"]}>
+      <HomePage state={{ status: "ready", data }} reload={() => {}} />
+    </MemoryRouter>
+  );
   expect(screen.getByTestId("grouped-row")).toBeInTheDocument();
   fireEvent.click(screen.getByRole("button", { name: "Toss 수동" }));
   expect(screen.queryByTestId("grouped-row")).toBeNull();
@@ -83,19 +92,21 @@ test("activeSource toggles between groupedHoldings and raw holdings", () => {
 
 test("renders empty account state with portfolio deeplink", () => {
   render(
-    <HomePage
-      state={{
-        status: "ready",
-        data: {
-          ...data,
-          accounts: [],
-          holdings: [],
-          groupedHoldings: [],
-          meta: { warnings: [] },
-        },
-      }}
-      reload={() => {}}
-    />,
+    <MemoryRouter basename="/invest/app" initialEntries={["/invest/app/"]}>
+      <HomePage
+        state={{
+          status: "ready",
+          data: {
+            ...data,
+            accounts: [],
+            holdings: [],
+            groupedHoldings: [],
+            meta: { warnings: [] },
+          },
+        }}
+        reload={() => {}}
+      />
+    </MemoryRouter>
   );
 
   expect(screen.getByText("연결된 계좌가 없습니다")).toBeInTheDocument();

--- a/frontend/invest/src/__tests__/IssueImpactMap.test.tsx
+++ b/frontend/invest/src/__tests__/IssueImpactMap.test.tsx
@@ -1,0 +1,25 @@
+// frontend/invest/src/__tests__/IssueImpactMap.test.tsx
+import { render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { IssueImpactMap } from "../components/discover/IssueImpactMap";
+
+test("renders impact pills for known risk_category", () => {
+  render(<IssueImpactMap category="geopolitical_oil" />);
+  expect(screen.getByText("원유/에너지")).toBeInTheDocument();
+  expect(screen.getByText("항공/운송")).toBeInTheDocument();
+  expect(screen.getByText("금/방산")).toBeInTheDocument();
+});
+
+test("renders fallback notice when category is null", () => {
+  render(<IssueImpactMap category={null} />);
+  expect(
+    screen.getByText("이 이슈에 대한 영향 분석은 준비 중입니다."),
+  ).toBeInTheDocument();
+});
+
+test("includes disclaimer", () => {
+  render(<IssueImpactMap category="macro_policy" />);
+  expect(
+    screen.getByText("뉴스 기반 참고 정보이며 매매 추천이 아닙니다."),
+  ).toBeInTheDocument();
+});

--- a/frontend/invest/src/__tests__/RelatedSymbolsList.test.tsx
+++ b/frontend/invest/src/__tests__/RelatedSymbolsList.test.tsx
@@ -1,0 +1,15 @@
+// frontend/invest/src/__tests__/RelatedSymbolsList.test.tsx
+import { render, screen } from "@testing-library/react";
+import { expect, test } from "vitest";
+import { RelatedSymbolsList } from "../components/discover/RelatedSymbolsList";
+
+test("renders symbol chips when symbols are present", () => {
+  render(<RelatedSymbolsList symbols={["AAPL", "MSFT"]} />);
+  expect(screen.getByText("AAPL")).toBeInTheDocument();
+  expect(screen.getByText("MSFT")).toBeInTheDocument();
+});
+
+test("renders prep notice when symbols are empty", () => {
+  render(<RelatedSymbolsList symbols={[]} />);
+  expect(screen.getByText("관련 종목 분석은 준비 중입니다.")).toBeInTheDocument();
+});

--- a/frontend/invest/src/__tests__/newsRadar.api.test.ts
+++ b/frontend/invest/src/__tests__/newsRadar.api.test.ts
@@ -1,0 +1,68 @@
+// frontend/invest/src/__tests__/newsRadar.api.test.ts
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { fetchNewsRadar } from "../api/newsRadar";
+import type { NewsRadarResponse } from "../types/newsRadar";
+
+const baseResponse: NewsRadarResponse = {
+  market: "all",
+  as_of: "2026-05-07T00:00:00Z",
+  readiness: {
+    status: "ready",
+    latest_scraped_at: null,
+    latest_published_at: null,
+    recent_6h_count: 0,
+    recent_24h_count: 0,
+    source_count: 0,
+    stale: false,
+    max_age_minutes: 0,
+    warnings: [],
+  },
+  summary: {
+    high_risk_count: 0,
+    total_count: 0,
+    included_in_briefing_count: 0,
+    excluded_but_collected_count: 0,
+  },
+  sections: [],
+  items: [],
+  excluded_items: [],
+  source_coverage: [],
+};
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test("fetchNewsRadar uses default query params and credentials", async () => {
+  fetchMock.mockResolvedValueOnce({ ok: true, json: async () => baseResponse });
+
+  await fetchNewsRadar();
+
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  const [url, init] = fetchMock.mock.calls[0];
+  expect(url).toBe(
+    "/trading/api/news-radar?market=all&hours=24&include_excluded=true&limit=20",
+  );
+  expect(init).toMatchObject({ credentials: "include" });
+});
+
+test("fetchNewsRadar throws on non-ok response", async () => {
+  fetchMock.mockResolvedValueOnce({ ok: false, status: 503, json: async () => ({}) });
+  await expect(fetchNewsRadar()).rejects.toThrow(/503/);
+});
+
+test("fetchNewsRadar overrides params", async () => {
+  fetchMock.mockResolvedValueOnce({ ok: true, json: async () => baseResponse });
+  await fetchNewsRadar({ market: "kr", hours: 12, limit: 5, includeExcluded: false });
+  const [url] = fetchMock.mock.calls[0];
+  expect(url).toBe(
+    "/trading/api/news-radar?market=kr&hours=12&include_excluded=false&limit=5",
+  );
+});

--- a/frontend/invest/src/__tests__/newsRadar.api.test.ts
+++ b/frontend/invest/src/__tests__/newsRadar.api.test.ts
@@ -46,7 +46,7 @@ test("fetchNewsRadar uses default query params and credentials", async () => {
   await fetchNewsRadar();
 
   expect(fetchMock).toHaveBeenCalledTimes(1);
-  const [url, init] = fetchMock.mock.calls[0];
+  const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
   expect(url).toBe(
     "/trading/api/news-radar?market=all&hours=24&include_excluded=true&limit=20",
   );
@@ -61,7 +61,7 @@ test("fetchNewsRadar throws on non-ok response", async () => {
 test("fetchNewsRadar overrides params", async () => {
   fetchMock.mockResolvedValueOnce({ ok: true, json: async () => baseResponse });
   await fetchNewsRadar({ market: "kr", hours: 12, limit: 5, includeExcluded: false });
-  const [url] = fetchMock.mock.calls[0];
+  const [url] = fetchMock.mock.calls[0] as [string];
   expect(url).toBe(
     "/trading/api/news-radar?market=kr&hours=12&include_excluded=false&limit=5",
   );

--- a/frontend/invest/src/__tests__/relativeTime.test.ts
+++ b/frontend/invest/src/__tests__/relativeTime.test.ts
@@ -1,0 +1,29 @@
+// frontend/invest/src/__tests__/relativeTime.test.ts
+import { expect, test } from "vitest";
+import { formatRelativeTime } from "../format/relativeTime";
+
+const NOW = new Date("2026-05-07T12:00:00Z");
+
+test("returns '방금' for under 1 minute", () => {
+  expect(formatRelativeTime("2026-05-07T11:59:30Z", NOW)).toBe("방금");
+});
+
+test("returns minutes for under 1 hour", () => {
+  expect(formatRelativeTime("2026-05-07T11:55:00Z", NOW)).toBe("5분 전");
+});
+
+test("returns hours for under 1 day", () => {
+  expect(formatRelativeTime("2026-05-07T09:00:00Z", NOW)).toBe("3시간 전");
+});
+
+test("returns days for over 24 hours", () => {
+  expect(formatRelativeTime("2026-05-05T12:00:00Z", NOW)).toBe("2일 전");
+});
+
+test("returns null when input is null", () => {
+  expect(formatRelativeTime(null, NOW)).toBeNull();
+});
+
+test("returns null when input is in the future", () => {
+  expect(formatRelativeTime("2026-05-07T12:30:00Z", NOW)).toBeNull();
+});

--- a/frontend/invest/src/__tests__/routes.test.tsx
+++ b/frontend/invest/src/__tests__/routes.test.tsx
@@ -1,0 +1,25 @@
+// frontend/invest/src/__tests__/routes.test.tsx
+import { expect, test } from "vitest";
+import { router } from "../routes";
+
+function pathsOf(routes: any[]): string[] {
+  const out: string[] = [];
+  for (const r of routes) {
+    if (r.path) out.push(r.path);
+    if (r.children) out.push(...pathsOf(r.children));
+  }
+  return out;
+}
+
+test("router exposes /discover and /discover/issues/:issueId", () => {
+  const paths = pathsOf((router as any).routes);
+  expect(paths).toContain("/discover");
+  expect(paths).toContain("/discover/issues/:issueId");
+});
+
+test("router still exposes / and /paper", () => {
+  const paths = pathsOf((router as any).routes);
+  expect(paths).toContain("/");
+  expect(paths).toContain("/paper");
+  expect(paths).toContain("/paper/:variant");
+});

--- a/frontend/invest/src/__tests__/severity.test.ts
+++ b/frontend/invest/src/__tests__/severity.test.ts
@@ -1,0 +1,59 @@
+// frontend/invest/src/__tests__/severity.test.ts
+import { expect, test } from "vitest";
+import {
+  countByRiskCategory,
+  describeSeverity,
+  sortIssueItems,
+} from "../components/discover/severity";
+import type { NewsRadarItem } from "../types/newsRadar";
+
+function makeItem(overrides: Partial<NewsRadarItem>): NewsRadarItem {
+  return {
+    id: "x",
+    title: "t",
+    source: null,
+    feed_source: null,
+    url: "",
+    published_at: null,
+    market: "all",
+    risk_category: null,
+    severity: "low",
+    themes: [],
+    symbols: [],
+    included_in_briefing: false,
+    briefing_reason: null,
+    briefing_score: 0,
+    snippet: null,
+    matched_terms: [],
+    ...overrides,
+  };
+}
+
+test("describeSeverity maps to indicator label", () => {
+  expect(describeSeverity("high").label).toBe("강한 이슈");
+  expect(describeSeverity("medium").label).toBe("관심 이슈");
+  expect(describeSeverity("low").label).toBe("참고");
+});
+
+test("countByRiskCategory groups items by risk_category", () => {
+  const items = [
+    makeItem({ id: "1", risk_category: "macro_policy" }),
+    makeItem({ id: "2", risk_category: "macro_policy" }),
+    makeItem({ id: "3", risk_category: "geopolitical_oil" }),
+    makeItem({ id: "4", risk_category: null }),
+  ];
+  const counts = countByRiskCategory(items);
+  expect(counts.macro_policy).toBe(2);
+  expect(counts.geopolitical_oil).toBe(1);
+  expect(counts.uncategorized).toBe(1);
+});
+
+test("sortIssueItems orders by severity then briefing_score then published_at", () => {
+  const items = [
+    makeItem({ id: "a", severity: "low", briefing_score: 10, published_at: "2026-05-07T10:00:00Z" }),
+    makeItem({ id: "b", severity: "high", briefing_score: 5, published_at: "2026-05-07T08:00:00Z" }),
+    makeItem({ id: "c", severity: "high", briefing_score: 9, published_at: "2026-05-07T08:00:00Z" }),
+    makeItem({ id: "d", severity: "medium", briefing_score: 0, published_at: "2026-05-07T11:00:00Z" }),
+  ];
+  expect(sortIssueItems(items).map((i) => i.id)).toEqual(["c", "b", "d", "a"]);
+});

--- a/frontend/invest/src/api/newsRadar.ts
+++ b/frontend/invest/src/api/newsRadar.ts
@@ -1,0 +1,29 @@
+// frontend/invest/src/api/newsRadar.ts
+import type { NewsRadarMarket, NewsRadarResponse } from "../types/newsRadar";
+
+export interface FetchNewsRadarParams {
+  market?: NewsRadarMarket;
+  hours?: number;
+  limit?: number;
+  includeExcluded?: boolean;
+}
+
+export async function fetchNewsRadar(
+  params: FetchNewsRadarParams = {},
+  signal?: AbortSignal,
+): Promise<NewsRadarResponse> {
+  const qs = new URLSearchParams({
+    market: params.market ?? "all",
+    hours: String(params.hours ?? 24),
+    include_excluded: String(params.includeExcluded ?? true),
+    limit: String(params.limit ?? 20),
+  });
+  const res = await fetch(`/trading/api/news-radar?${qs.toString()}`, {
+    credentials: "include",
+    signal,
+  });
+  if (!res.ok) {
+    throw new Error(`/trading/api/news-radar ${res.status}`);
+  }
+  return (await res.json()) as NewsRadarResponse;
+}

--- a/frontend/invest/src/components/BottomNav.tsx
+++ b/frontend/invest/src/components/BottomNav.tsx
@@ -1,37 +1,69 @@
-const TABS = ["증권", "관심", "발견", "피드"];
+// frontend/invest/src/components/BottomNav.tsx
+import type { CSSProperties } from "react";
+import { NavLink } from "react-router-dom";
+
+const ROW_STYLE: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-around",
+  paddingTop: 8,
+  borderTop: "1px solid var(--surface-2)",
+  color: "var(--muted)",
+  fontSize: 10,
+  position: "sticky",
+  bottom: 0,
+  background: "var(--bg)",
+};
+
+const TAB_BASE: CSSProperties = {
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  padding: 8,
+  fontSize: 10,
+  textDecoration: "none",
+};
+
+const DISABLED_STYLE: CSSProperties = {
+  ...TAB_BASE,
+  color: "var(--muted)",
+  opacity: 0.5,
+  cursor: "not-allowed",
+};
+
+function activeStyle(isActive: boolean): CSSProperties {
+  return {
+    ...TAB_BASE,
+    color: isActive ? "var(--text)" : "var(--muted)",
+  };
+}
 
 export function BottomNav() {
   return (
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "space-around",
-        paddingTop: 8,
-        borderTop: "1px solid var(--surface-2)",
-        color: "var(--muted)",
-        fontSize: 10,
-        position: "sticky",
-        bottom: 0,
-        background: "var(--bg)",
-      }}
-    >
-      {TABS.map((label, i) => (
-        <button
-          key={label}
-          type="button"
-          onClick={() => alert("준비 중")}
-          style={{
-            background: "none",
-            border: "none",
-            color: i === 0 ? "var(--text)" : "var(--muted)",
-            cursor: "pointer",
-            padding: 8,
-            fontSize: 10,
-          }}
-        >
-          {label}
-        </button>
-      ))}
+    <div style={ROW_STYLE}>
+      <NavLink to="/" end style={({ isActive }) => activeStyle(isActive)}>
+        증권
+      </NavLink>
+      <button
+        type="button"
+        aria-disabled="true"
+        disabled
+        style={DISABLED_STYLE}
+        tabIndex={-1}
+      >
+        관심
+      </button>
+      <NavLink to="/discover" style={({ isActive }) => activeStyle(isActive)}>
+        발견
+      </NavLink>
+      <button
+        type="button"
+        aria-disabled="true"
+        disabled
+        style={DISABLED_STYLE}
+        tabIndex={-1}
+      >
+        피드
+      </button>
     </div>
   );
 }

--- a/frontend/invest/src/components/discover/AiIssueCard.tsx
+++ b/frontend/invest/src/components/discover/AiIssueCard.tsx
@@ -4,12 +4,12 @@ import { formatRelativeTime } from "../../format/relativeTime";
 import type { NewsRadarItem } from "../../types/newsRadar";
 import { describeSeverity } from "./severity";
 
-export interface AiIssueCardProps {
+export type AiIssueCardProps = Readonly<{
   rank: number;
   item: NewsRadarItem;
   relatedCount: number;
   now?: Date;
-}
+}>;
 
 function buildSubtitle(item: NewsRadarItem): string {
   if (item.snippet && item.snippet.trim().length > 0) return item.snippet;

--- a/frontend/invest/src/components/discover/AiIssueCard.tsx
+++ b/frontend/invest/src/components/discover/AiIssueCard.tsx
@@ -1,0 +1,83 @@
+// frontend/invest/src/components/discover/AiIssueCard.tsx
+import { Link } from "react-router-dom";
+import { formatRelativeTime } from "../../format/relativeTime";
+import type { NewsRadarItem } from "../../types/newsRadar";
+import { describeSeverity } from "./severity";
+
+export interface AiIssueCardProps {
+  rank: number;
+  item: NewsRadarItem;
+  relatedCount: number;
+  now?: Date;
+}
+
+function buildSubtitle(item: NewsRadarItem): string {
+  if (item.snippet && item.snippet.trim().length > 0) return item.snippet;
+  if (item.themes.length > 0) return item.themes.join(", ");
+  if (item.matched_terms.length > 0) return item.matched_terms.join(", ");
+  return "";
+}
+
+export function AiIssueCard({ rank, item, relatedCount, now }: AiIssueCardProps) {
+  const indicator = describeSeverity(item.severity);
+  const time = formatRelativeTime(item.published_at, now);
+  const subtitle = buildSubtitle(item);
+  return (
+    <Link
+      to={`/discover/issues/${item.id}`}
+      style={{
+        display: "flex",
+        gap: 12,
+        padding: 14,
+        background: "var(--surface)",
+        border: "1px solid var(--surface-2)",
+        borderRadius: 14,
+        color: "var(--text)",
+        textDecoration: "none",
+      }}
+    >
+      <div
+        style={{
+          minWidth: 24,
+          fontWeight: 800,
+          color: "var(--muted)",
+          fontSize: 16,
+        }}
+      >
+        {rank}
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span
+            aria-label={indicator.label}
+            role="img"
+            style={{ color: indicator.color, fontSize: 12 }}
+          >
+            {indicator.glyph}
+          </span>
+          <span style={{ fontWeight: 700, fontSize: 14 }}>{item.title}</span>
+        </div>
+        {subtitle && (
+          <div
+            className="subtle"
+            style={{
+              marginTop: 4,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {subtitle}
+          </div>
+        )}
+        <div
+          className="subtle"
+          style={{ marginTop: 6, display: "flex", gap: 8, fontSize: 11 }}
+        >
+          <span>관련 뉴스 {relatedCount}개</span>
+          {time && <span>· {time}</span>}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/frontend/invest/src/components/discover/AiIssueTicker.tsx
+++ b/frontend/invest/src/components/discover/AiIssueTicker.tsx
@@ -1,5 +1,9 @@
 // frontend/invest/src/components/discover/AiIssueTicker.tsx
-export function AiIssueTicker({ asOf }: { asOf?: string | null }) {
+type AiIssueTickerProps = Readonly<{
+  asOf?: string | null;
+}>;
+
+export function AiIssueTicker({ asOf }: AiIssueTickerProps) {
   return (
     <header style={{ marginTop: 8 }}>
       <h2 style={{ margin: 0, fontSize: 16, fontWeight: 700 }}>

--- a/frontend/invest/src/components/discover/AiIssueTicker.tsx
+++ b/frontend/invest/src/components/discover/AiIssueTicker.tsx
@@ -1,0 +1,14 @@
+// frontend/invest/src/components/discover/AiIssueTicker.tsx
+export function AiIssueTicker({ asOf }: { asOf?: string | null }) {
+  return (
+    <header style={{ marginTop: 8 }}>
+      <h2 style={{ margin: 0, fontSize: 16, fontWeight: 700 }}>
+        AI 실시간 이슈
+      </h2>
+      <div className="subtle" style={{ marginTop: 4 }}>
+        뉴스 기반으로 정리된 참고 정보입니다.
+        {asOf ? ` 기준: ${new Date(asOf).toLocaleString("ko-KR")}` : ""}
+      </div>
+    </header>
+  );
+}

--- a/frontend/invest/src/components/discover/CategoryShortcutRail.tsx
+++ b/frontend/invest/src/components/discover/CategoryShortcutRail.tsx
@@ -1,0 +1,36 @@
+// frontend/invest/src/components/discover/CategoryShortcutRail.tsx
+const CATEGORIES = ["해외주식", "국내주식", "옵션", "채권"] as const;
+
+export function CategoryShortcutRail() {
+  return (
+    <div
+      role="list"
+      aria-label="카테고리"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(4, 1fr)",
+        gap: 8,
+      }}
+    >
+      {CATEGORIES.map((label) => (
+        <div
+          key={label}
+          role="listitem"
+          aria-disabled="true"
+          style={{
+            padding: 12,
+            background: "var(--surface)",
+            border: "1px solid var(--surface-2)",
+            borderRadius: 12,
+            color: "var(--muted)",
+            fontSize: 12,
+            textAlign: "center",
+            opacity: 0.6,
+          }}
+        >
+          {label}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/invest/src/components/discover/CategoryShortcutRail.tsx
+++ b/frontend/invest/src/components/discover/CategoryShortcutRail.tsx
@@ -3,20 +3,20 @@ const CATEGORIES = ["해외주식", "국내주식", "옵션", "채권"] as const
 
 export function CategoryShortcutRail() {
   return (
-    <div
-      role="list"
+    <ul
       aria-label="카테고리"
       style={{
         display: "grid",
         gridTemplateColumns: "repeat(4, 1fr)",
         gap: 8,
+        listStyle: "none",
+        margin: 0,
+        padding: 0,
       }}
     >
       {CATEGORIES.map((label) => (
-        <div
+        <li
           key={label}
-          role="listitem"
-          aria-disabled="true"
           style={{
             padding: 12,
             background: "var(--surface)",
@@ -29,8 +29,8 @@ export function CategoryShortcutRail() {
           }}
         >
           {label}
-        </div>
+        </li>
       ))}
-    </div>
+    </ul>
   );
 }

--- a/frontend/invest/src/components/discover/DiscoverHeader.tsx
+++ b/frontend/invest/src/components/discover/DiscoverHeader.tsx
@@ -1,0 +1,11 @@
+// frontend/invest/src/components/discover/DiscoverHeader.tsx
+export function DiscoverHeader() {
+  return (
+    <div style={{ paddingTop: 4 }}>
+      <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800 }}>발견</h1>
+      <div className="subtle" style={{ marginTop: 4 }}>
+        뉴스 기반 참고 정보입니다. 매매 추천이 아닙니다.
+      </div>
+    </div>
+  );
+}

--- a/frontend/invest/src/components/discover/IssueImpactMap.tsx
+++ b/frontend/invest/src/components/discover/IssueImpactMap.tsx
@@ -1,0 +1,63 @@
+// frontend/invest/src/components/discover/IssueImpactMap.tsx
+import type { CSSProperties } from "react";
+import type { NewsRadarRiskCategory } from "../../types/newsRadar";
+import { lookupImpact, type ImpactPill, type ImpactTone } from "./impactMap";
+
+const TONE_STYLES: Record<ImpactTone, CSSProperties> = {
+  positive: { background: "var(--pill-mix)", color: "var(--pill-mix-fg)" },
+  negative: { background: "var(--pill-toss)", color: "var(--pill-toss-fg)" },
+  watch: { background: "var(--pill-up)", color: "var(--pill-up-fg)" },
+};
+
+export function IssueImpactMap({ category }: { category: NewsRadarRiskCategory | null }) {
+  const pills = lookupImpact(category);
+  return (
+    <section aria-labelledby="impact-heading" style={{ marginTop: 16 }}>
+      <h2 id="impact-heading" style={{ margin: 0, fontSize: 14, fontWeight: 700 }}>
+        어떤 영향을 줄까?
+      </h2>
+      {pills && pills.length > 0 ? (
+        <ul
+          style={{
+            listStyle: "none",
+            padding: 0,
+            margin: "8px 0 0",
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+          }}
+        >
+          {pills.map((pill) => (
+            <ImpactRow key={pill.theme} pill={pill} />
+          ))}
+        </ul>
+      ) : (
+        <div className="subtle" style={{ marginTop: 8 }}>
+          이 이슈에 대한 영향 분석은 준비 중입니다.
+        </div>
+      )}
+      <div className="subtle" style={{ marginTop: 12, fontSize: 11 }}>
+        뉴스 기반 참고 정보이며 매매 추천이 아닙니다.
+      </div>
+    </section>
+  );
+}
+
+function ImpactRow({ pill }: { pill: ImpactPill }) {
+  return (
+    <li
+      style={{
+        display: "flex",
+        gap: 8,
+        alignItems: "center",
+        padding: "8px 12px",
+        borderRadius: 999,
+        ...TONE_STYLES[pill.tone],
+        fontSize: 12,
+      }}
+    >
+      <strong>{pill.theme}</strong>
+      <span style={{ opacity: 0.85 }}>{pill.note}</span>
+    </li>
+  );
+}

--- a/frontend/invest/src/components/discover/IssueImpactMap.tsx
+++ b/frontend/invest/src/components/discover/IssueImpactMap.tsx
@@ -9,7 +9,15 @@ const TONE_STYLES: Record<ImpactTone, CSSProperties> = {
   watch: { background: "var(--pill-up)", color: "var(--pill-up-fg)" },
 };
 
-export function IssueImpactMap({ category }: { category: NewsRadarRiskCategory | null }) {
+type IssueImpactMapProps = Readonly<{
+  category: NewsRadarRiskCategory | null;
+}>;
+
+type ImpactRowProps = Readonly<{
+  pill: ImpactPill;
+}>;
+
+export function IssueImpactMap({ category }: IssueImpactMapProps) {
   const pills = lookupImpact(category);
   return (
     <section aria-labelledby="impact-heading" style={{ marginTop: 16 }}>
@@ -43,7 +51,7 @@ export function IssueImpactMap({ category }: { category: NewsRadarRiskCategory |
   );
 }
 
-function ImpactRow({ pill }: { pill: ImpactPill }) {
+function ImpactRow({ pill }: ImpactRowProps) {
   return (
     <li
       style={{

--- a/frontend/invest/src/components/discover/RelatedSymbolsList.tsx
+++ b/frontend/invest/src/components/discover/RelatedSymbolsList.tsx
@@ -1,0 +1,42 @@
+// frontend/invest/src/components/discover/RelatedSymbolsList.tsx
+export function RelatedSymbolsList({ symbols }: { symbols: string[] }) {
+  return (
+    <section aria-labelledby="symbols-heading" style={{ marginTop: 16 }}>
+      <h2 id="symbols-heading" style={{ margin: 0, fontSize: 14, fontWeight: 700 }}>
+        관련 종목
+      </h2>
+      {symbols.length > 0 ? (
+        <ul
+          style={{
+            listStyle: "none",
+            padding: 0,
+            margin: "8px 0 0",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 6,
+          }}
+        >
+          {symbols.map((sym) => (
+            <li
+              key={sym}
+              style={{
+                padding: "4px 10px",
+                background: "var(--surface-2)",
+                color: "var(--text)",
+                borderRadius: 999,
+                fontSize: 12,
+                fontWeight: 600,
+              }}
+            >
+              {sym}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="subtle" style={{ marginTop: 8 }}>
+          관련 종목 분석은 준비 중입니다.
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/invest/src/components/discover/RelatedSymbolsList.tsx
+++ b/frontend/invest/src/components/discover/RelatedSymbolsList.tsx
@@ -1,5 +1,9 @@
 // frontend/invest/src/components/discover/RelatedSymbolsList.tsx
-export function RelatedSymbolsList({ symbols }: { symbols: string[] }) {
+type RelatedSymbolsListProps = Readonly<{
+  symbols: readonly string[];
+}>;
+
+export function RelatedSymbolsList({ symbols }: RelatedSymbolsListProps) {
   return (
     <section aria-labelledby="symbols-heading" style={{ marginTop: 16 }}>
       <h2 id="symbols-heading" style={{ margin: 0, fontSize: 14, fontWeight: 700 }}>

--- a/frontend/invest/src/components/discover/TodayEventCard.tsx
+++ b/frontend/invest/src/components/discover/TodayEventCard.tsx
@@ -1,0 +1,27 @@
+// frontend/invest/src/components/discover/TodayEventCard.tsx
+export function TodayEventCard() {
+  return (
+    <section
+      aria-labelledby="today-event-heading"
+      style={{
+        padding: 16,
+        background: "var(--surface)",
+        border: "1px solid var(--surface-2)",
+        borderRadius: 14,
+      }}
+    >
+      <h2
+        id="today-event-heading"
+        style={{ margin: 0, fontSize: 14, fontWeight: 700 }}
+      >
+        오늘의 주요 이벤트
+      </h2>
+      <div className="subtle" style={{ marginTop: 6 }}>
+        경제 캘린더는 준비 중입니다.
+      </div>
+      <div className="subtle" style={{ marginTop: 4 }}>
+        실적/지표 일정은 후속 업데이트에서 제공됩니다.
+      </div>
+    </section>
+  );
+}

--- a/frontend/invest/src/components/discover/impactMap.ts
+++ b/frontend/invest/src/components/discover/impactMap.ts
@@ -1,0 +1,37 @@
+// frontend/invest/src/components/discover/impactMap.ts
+import type { NewsRadarRiskCategory } from "../../types/newsRadar";
+
+export type ImpactTone = "positive" | "negative" | "watch";
+
+export interface ImpactPill {
+  theme: string;
+  tone: ImpactTone;
+  note: string;
+}
+
+export const IMPACT_MAP: Record<NewsRadarRiskCategory, ImpactPill[]> = {
+  geopolitical_oil: [
+    { theme: "원유/에너지", tone: "watch", note: "변동성/수혜 가능" },
+    { theme: "항공/운송", tone: "negative", note: "비용 압박 가능" },
+    { theme: "금/방산", tone: "positive", note: "방어적 선호 가능" },
+  ],
+  macro_policy: [
+    { theme: "금리 민감 성장주", tone: "negative", note: "부담 가능" },
+    { theme: "금융", tone: "watch", note: "금리/스프레드 영향" },
+  ],
+  earnings_bigtech: [
+    { theme: "AI/반도체", tone: "watch", note: "수요/실적 민감" },
+    { theme: "나스닥", tone: "watch", note: "투자심리 영향" },
+  ],
+  crypto_security: [
+    { theme: "가상자산", tone: "negative", note: "보안/규제 리스크" },
+  ],
+  korea_market: [
+    { theme: "국내 증시", tone: "watch", note: "수급/정책/환율 영향" },
+  ],
+};
+
+export function lookupImpact(category: NewsRadarRiskCategory | null): ImpactPill[] | null {
+  if (!category) return null;
+  return IMPACT_MAP[category] ?? null;
+}

--- a/frontend/invest/src/components/discover/severity.ts
+++ b/frontend/invest/src/components/discover/severity.ts
@@ -1,0 +1,65 @@
+// frontend/invest/src/components/discover/severity.ts
+import type { NewsRadarItem, NewsRadarSeverity } from "../../types/newsRadar";
+
+export interface SeverityDescriptor {
+  label: string;
+  color: string;
+  glyph: "▲" | "■" | "·";
+}
+
+export function describeSeverity(severity: NewsRadarSeverity): SeverityDescriptor {
+  switch (severity) {
+    case "high":
+      return { label: "강한 이슈", color: "var(--gain)", glyph: "▲" };
+    case "medium":
+      return { label: "관심 이슈", color: "var(--muted)", glyph: "■" };
+    case "low":
+    default:
+      return { label: "참고", color: "var(--muted)", glyph: "·" };
+  }
+}
+
+export type RiskBucketKey =
+  | "geopolitical_oil"
+  | "macro_policy"
+  | "crypto_security"
+  | "earnings_bigtech"
+  | "korea_market"
+  | "uncategorized";
+
+export function countByRiskCategory(items: NewsRadarItem[]): Record<RiskBucketKey, number> {
+  const out: Record<RiskBucketKey, number> = {
+    geopolitical_oil: 0,
+    macro_policy: 0,
+    crypto_security: 0,
+    earnings_bigtech: 0,
+    korea_market: 0,
+    uncategorized: 0,
+  };
+  for (const item of items) {
+    const key = (item.risk_category ?? "uncategorized") as RiskBucketKey;
+    out[key] = (out[key] ?? 0) + 1;
+  }
+  return out;
+}
+
+const SEVERITY_RANK: Record<NewsRadarSeverity, number> = { high: 3, medium: 2, low: 1 };
+
+export function sortIssueItems(items: NewsRadarItem[]): NewsRadarItem[] {
+  return [...items].sort((a, b) => {
+    const sev = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
+    if (sev !== 0) return sev;
+    if (b.briefing_score !== a.briefing_score) return b.briefing_score - a.briefing_score;
+    const at = a.published_at ? Date.parse(a.published_at) : 0;
+    const bt = b.published_at ? Date.parse(b.published_at) : 0;
+    return bt - at;
+  });
+}
+
+export function relatedNewsCount(
+  item: NewsRadarItem,
+  buckets: Record<RiskBucketKey, number>,
+): number {
+  const key = (item.risk_category ?? "uncategorized") as RiskBucketKey;
+  return buckets[key] ?? 0;
+}

--- a/frontend/invest/src/format/relativeTime.ts
+++ b/frontend/invest/src/format/relativeTime.ts
@@ -1,0 +1,18 @@
+// frontend/invest/src/format/relativeTime.ts
+export function formatRelativeTime(
+  iso: string | null | undefined,
+  now: Date = new Date(),
+): string | null {
+  if (!iso) return null;
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) return null;
+  const deltaMs = now.getTime() - then.getTime();
+  if (deltaMs < 0) return null;
+  const minutes = Math.floor(deltaMs / 60_000);
+  if (minutes < 1) return "방금";
+  if (minutes < 60) return `${minutes}분 전`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}시간 전`;
+  const days = Math.floor(hours / 24);
+  return `${days}일 전`;
+}

--- a/frontend/invest/src/hooks/useNewsRadar.ts
+++ b/frontend/invest/src/hooks/useNewsRadar.ts
@@ -1,0 +1,29 @@
+// frontend/invest/src/hooks/useNewsRadar.ts
+import { useEffect, useState } from "react";
+import { fetchNewsRadar, type FetchNewsRadarParams } from "../api/newsRadar";
+import type { NewsRadarResponse } from "../types/newsRadar";
+
+export type NewsRadarState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; data: NewsRadarResponse };
+
+export function useNewsRadar(params: FetchNewsRadarParams = {}) {
+  const [state, setState] = useState<NewsRadarState>({ status: "loading" });
+  const [tick, setTick] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState({ status: "loading" });
+    fetchNewsRadar(params, controller.signal)
+      .then((data) => setState({ status: "ready", data }))
+      .catch((e) => {
+        if (controller.signal.aborted) return;
+        setState({ status: "error", message: e?.message ?? "failed" });
+      });
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tick]);
+
+  return { state, reload: () => setTick((t) => t + 1) };
+}

--- a/frontend/invest/src/pages/DiscoverIssueDetailPage.tsx
+++ b/frontend/invest/src/pages/DiscoverIssueDetailPage.tsx
@@ -1,0 +1,116 @@
+// frontend/invest/src/pages/DiscoverIssueDetailPage.tsx
+import { Link, useParams } from "react-router-dom";
+import { AppShell } from "../components/AppShell";
+import { BottomNav } from "../components/BottomNav";
+import { IssueImpactMap } from "../components/discover/IssueImpactMap";
+import { RelatedSymbolsList } from "../components/discover/RelatedSymbolsList";
+import { describeSeverity } from "../components/discover/severity";
+import { formatRelativeTime } from "../format/relativeTime";
+import { useNewsRadar, type NewsRadarState } from "../hooks/useNewsRadar";
+
+export interface DiscoverIssueDetailPageProps {
+  state?: NewsRadarState;
+  reload?: () => void;
+}
+
+export function DiscoverIssueDetailPage(props: DiscoverIssueDetailPageProps = {}) {
+  const params = useParams<{ issueId: string }>();
+  const live = useNewsRadar({
+    market: "all",
+    hours: 24,
+    includeExcluded: true,
+    limit: 20,
+  });
+  const state = props.state ?? live.state;
+  const reload = props.reload ?? live.reload;
+  const issueId = params.issueId ?? "";
+
+  if (state.status === "loading") {
+    return (
+      <AppShell>
+        <div className="subtle">불러오는 중…</div>
+        <BottomNav />
+      </AppShell>
+    );
+  }
+  if (state.status === "error") {
+    return (
+      <AppShell>
+        <div>잠시 후 다시 시도해 주세요.</div>
+        <button type="button" onClick={reload}>
+          재시도
+        </button>
+        <div className="subtle">{state.message}</div>
+        <BottomNav />
+      </AppShell>
+    );
+  }
+
+  const item = state.data.items.find((i) => i.id === issueId);
+  if (!item) {
+    return (
+      <AppShell>
+        <div style={{ padding: 16 }}>
+          <p>이슈를 찾을 수 없습니다. 시간이 지나 목록에서 빠졌을 수 있어요.</p>
+          <Link
+            to="/discover"
+            style={{ color: "var(--accent, #7eb6ff)", fontWeight: 700 }}
+          >
+            발견으로 돌아가기
+          </Link>
+        </div>
+        <BottomNav />
+      </AppShell>
+    );
+  }
+
+  const indicator = describeSeverity(item.severity);
+  const time = formatRelativeTime(item.published_at);
+
+  return (
+    <AppShell>
+      <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <Link to="/discover" className="subtle" style={{ textDecoration: "none" }}>
+          ← 발견
+        </Link>
+        <header style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <span
+              aria-label={indicator.label}
+              role="img"
+              style={{ color: indicator.color }}
+            >
+              {indicator.glyph}
+            </span>
+            <h1 style={{ margin: 0, fontSize: 18, fontWeight: 800 }}>{item.title}</h1>
+          </div>
+          {item.snippet && (
+            <p className="subtle" style={{ margin: 0 }}>{item.snippet}</p>
+          )}
+          <div className="subtle" style={{ display: "flex", gap: 8, fontSize: 11 }}>
+            {item.source && <span>{item.source}</span>}
+            {time && <span>· {time}</span>}
+          </div>
+        </header>
+        <IssueImpactMap category={item.risk_category} />
+        <RelatedSymbolsList symbols={item.symbols} />
+        <section
+          style={{
+            marginTop: 16,
+            padding: 12,
+            background: "var(--surface)",
+            border: "1px solid var(--surface-2)",
+            borderRadius: 12,
+            fontSize: 12,
+          }}
+        >
+          <strong style={{ display: "block", marginBottom: 4 }}>꼭 알아두세요</strong>
+          <span className="subtle">
+            이 화면은 read-only 정보입니다. 매수/매도 주문이나 자동 추천을 제공하지 않습니다.
+          </span>
+        </section>
+      </div>
+      <BottomNav />
+    </AppShell>
+  );
+}

--- a/frontend/invest/src/pages/DiscoverPage.tsx
+++ b/frontend/invest/src/pages/DiscoverPage.tsx
@@ -1,0 +1,103 @@
+// frontend/invest/src/pages/DiscoverPage.tsx
+import { AppShell } from "../components/AppShell";
+import { BottomNav } from "../components/BottomNav";
+import { AiIssueCard } from "../components/discover/AiIssueCard";
+import { AiIssueTicker } from "../components/discover/AiIssueTicker";
+import { CategoryShortcutRail } from "../components/discover/CategoryShortcutRail";
+import { DiscoverHeader } from "../components/discover/DiscoverHeader";
+import { TodayEventCard } from "../components/discover/TodayEventCard";
+import {
+  countByRiskCategory,
+  relatedNewsCount,
+  sortIssueItems,
+} from "../components/discover/severity";
+import { useNewsRadar, type NewsRadarState } from "../hooks/useNewsRadar";
+
+export interface DiscoverPageProps {
+  state?: NewsRadarState;
+  reload?: () => void;
+}
+
+export function DiscoverPage(props: DiscoverPageProps = {}) {
+  const live = useNewsRadar({
+    market: "all",
+    hours: 24,
+    includeExcluded: true,
+    limit: 20,
+  });
+  const state = props.state ?? live.state;
+  const reload = props.reload ?? live.reload;
+
+  if (state.status === "loading") {
+    return (
+      <AppShell>
+        <div className="subtle">불러오는 중…</div>
+        <BottomNav />
+      </AppShell>
+    );
+  }
+  if (state.status === "error") {
+    return (
+      <AppShell>
+        <div>잠시 후 다시 시도해 주세요.</div>
+        <button type="button" onClick={reload}>
+          재시도
+        </button>
+        <div className="subtle">{state.message}</div>
+        <BottomNav />
+      </AppShell>
+    );
+  }
+
+  const { data } = state;
+  const sorted = sortIssueItems(data.items);
+  const buckets = countByRiskCategory(data.items);
+  const isStale = data.readiness.status === "stale";
+
+  return (
+    <AppShell>
+      <DiscoverHeader />
+      <CategoryShortcutRail />
+      <TodayEventCard />
+      <AiIssueTicker asOf={data.as_of} />
+      {isStale && (
+        <div
+          role="status"
+          style={{
+            padding: 8,
+            background: "rgba(246,193,119,0.08)",
+            border: "1px solid rgba(246,193,119,0.27)",
+            color: "var(--warn)",
+            borderRadius: 10,
+            fontSize: 11,
+          }}
+        >
+          데이터가 최신이 아닐 수 있습니다.
+        </div>
+      )}
+      {sorted.length === 0 ? (
+        <div className="subtle">표시할 이슈가 없습니다.</div>
+      ) : (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 10,
+            flex: 1,
+            overflowY: "auto",
+          }}
+        >
+          {sorted.map((item, idx) => (
+            <AiIssueCard
+              key={item.id}
+              rank={idx + 1}
+              item={item}
+              relatedCount={relatedNewsCount(item, buckets)}
+            />
+          ))}
+        </div>
+      )}
+      <BottomNav />
+    </AppShell>
+  );
+}

--- a/frontend/invest/src/pages/DiscoverPage.tsx
+++ b/frontend/invest/src/pages/DiscoverPage.tsx
@@ -61,8 +61,8 @@ export function DiscoverPage(props: DiscoverPageProps = {}) {
       <TodayEventCard />
       <AiIssueTicker asOf={data.as_of} />
       {isStale && (
-        <div
-          role="status"
+        <output
+          aria-live="polite"
           style={{
             padding: 8,
             background: "rgba(246,193,119,0.08)",
@@ -73,7 +73,7 @@ export function DiscoverPage(props: DiscoverPageProps = {}) {
           }}
         >
           데이터가 최신이 아닐 수 있습니다.
-        </div>
+        </output>
       )}
       {sorted.length === 0 ? (
         <div className="subtle">표시할 이슈가 없습니다.</div>

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -1,4 +1,7 @@
+// frontend/invest/src/routes.tsx
 import { createBrowserRouter, Navigate } from "react-router-dom";
+import { DiscoverIssueDetailPage } from "./pages/DiscoverIssueDetailPage";
+import { DiscoverPage } from "./pages/DiscoverPage";
 import { HomePage } from "./pages/HomePage";
 import { PaperPlaceholderPage } from "./pages/PaperPlaceholderPage";
 
@@ -7,7 +10,9 @@ export const router = createBrowserRouter(
     { path: "/", element: <HomePage /> },
     { path: "/paper", element: <PaperPlaceholderPage /> },
     { path: "/paper/:variant", element: <PaperPlaceholderPage /> },
+    { path: "/discover", element: <DiscoverPage /> },
+    { path: "/discover/issues/:issueId", element: <DiscoverIssueDetailPage /> },
     { path: "*", element: <Navigate to="/" replace /> },
   ],
-  { basename: "/invest/app" }
+  { basename: "/invest/app" },
 );

--- a/frontend/invest/src/types/newsRadar.ts
+++ b/frontend/invest/src/types/newsRadar.ts
@@ -1,0 +1,75 @@
+// frontend/invest/src/types/newsRadar.ts
+export type NewsRadarReadinessStatus = "ready" | "stale" | "unavailable";
+export type NewsRadarSeverity = "high" | "medium" | "low";
+export type NewsRadarRiskCategory =
+  | "geopolitical_oil"
+  | "macro_policy"
+  | "crypto_security"
+  | "earnings_bigtech"
+  | "korea_market";
+export type NewsRadarMarket = "all" | "kr" | "us" | "crypto";
+
+export interface NewsRadarReadiness {
+  status: NewsRadarReadinessStatus;
+  latest_scraped_at: string | null;
+  latest_published_at: string | null;
+  recent_6h_count: number;
+  recent_24h_count: number;
+  source_count: number;
+  stale: boolean;
+  max_age_minutes: number;
+  warnings: string[];
+}
+
+export interface NewsRadarSummary {
+  high_risk_count: number;
+  total_count: number;
+  included_in_briefing_count: number;
+  excluded_but_collected_count: number;
+}
+
+export interface NewsRadarSourceCoverage {
+  feed_source: string;
+  recent_6h: number;
+  recent_24h: number;
+  latest_published_at: string | null;
+  latest_scraped_at: string | null;
+  status: string;
+}
+
+export interface NewsRadarItem {
+  id: string;
+  title: string;
+  source: string | null;
+  feed_source: string | null;
+  url: string;
+  published_at: string | null;
+  market: string;
+  risk_category: NewsRadarRiskCategory | null;
+  severity: NewsRadarSeverity;
+  themes: string[];
+  symbols: string[];
+  included_in_briefing: boolean;
+  briefing_reason: string | null;
+  briefing_score: number;
+  snippet: string | null;
+  matched_terms: string[];
+}
+
+export interface NewsRadarSection {
+  section_id: NewsRadarRiskCategory;
+  title: string;
+  severity: NewsRadarSeverity;
+  items: NewsRadarItem[];
+}
+
+export interface NewsRadarResponse {
+  market: NewsRadarMarket;
+  as_of: string;
+  readiness: NewsRadarReadiness;
+  summary: NewsRadarSummary;
+  sections: NewsRadarSection[];
+  items: NewsRadarItem[];
+  excluded_items: NewsRadarItem[];
+  source_coverage: NewsRadarSourceCoverage[];
+}


### PR DESCRIPTION
## Summary
- Add Toss-style read-only `발견(Discover)` tab to `/invest/app` backed by the existing `GET /trading/api/news-radar` endpoint (no broker / order / watch / scheduler / DB / LLM mutations introduced).
- Wire `BottomNav`: `발견` → `/discover` via `NavLink`; `관심` / `피드` rendered as `aria-disabled` instead of the previous `alert("준비 중")`.
- Discover list page sorts items by severity → briefing_score → published_at, shows per-card `관련 뉴스 N개` (same `risk_category` bucket count) and severity indicator. Loading / error / empty / stale-readiness states all handled.
- Detail page (`/discover/issues/:issueId`) refetches `news-radar` and matches by `id` (no shared cache, no SWR/React Query). Renders deterministic risk-category impact map, related symbols (or `관련 종목 분석은 준비 중입니다.` fallback when `item.symbols` is empty), and disclaimer.
- Spec: [`docs/superpowers/specs/2026-05-07-rob-127-invest-discover-tab-design.md`](docs/superpowers/specs/2026-05-07-rob-127-invest-discover-tab-design.md). Plan: [`docs/superpowers/plans/2026-05-07-rob-127-invest-discover-tab.md`](docs/superpowers/plans/2026-05-07-rob-127-invest-discover-tab.md). Linear: [ROB-127](https://linear.app/mgh3326/issue/ROB-127).

## Test plan
- [x] `cd frontend/invest && npm run typecheck` — passes
- [x] `cd frontend/invest && npm test` — 13 files / 44 tests passing
- [x] `cd frontend/invest && npm run build` — vite build succeeds (305 kB / 96 kB gzip)
- [x] Read-only safety grep (`broker_|order_intent|watch_service|scheduler|app/workers|llm_`) on new discover code — clean
- [x] `git diff --check` — no whitespace issues
- [ ] Manual smoke: `npm run dev`, tap `발견` → list → card → detail; refresh detail URL directly; confirm `관심` / `피드` are dim/non-clickable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Discover tab showcasing AI-curated market issues with real-time severity indicators, impact assessment, and related stock symbols.
  * Issue detail pages providing comprehensive impact analysis, risk categorization, and market context information.
  * Category shortcuts and issue ranking for streamlined browsing.

* **Documentation**
  * Added design specification for the Discover feature.

* **Tests**
  * Comprehensive test coverage for all new Discover functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->