### PR TITLE
fix(quality): wrap residual S1244 sites + suppress S5796 FP (Phase 6)

### DIFF
--- a/tests/test_alpaca_paper_fill_reconcile_smoke.py
+++ b/tests/test_alpaca_paper_fill_reconcile_smoke.py
@@ -206,7 +206,7 @@ async def test_collect_preflight_snapshot_filters_execution_symbol() -> None:
     )
 
     assert snapshot.account_status == "active"
-    assert snapshot.buying_power == Decimal("100")
+    assert snapshot.buying_power == pytest.approx(Decimal("100"))
     assert snapshot.open_order_count == 1
     assert snapshot.execution_symbol_open_order_count == 0
     assert snapshot.position_count == 1

--- a/tests/test_alpaca_paper_service_methods.py
+++ b/tests/test_alpaca_paper_service_methods.py
@@ -129,9 +129,9 @@ async def test_get_account_returns_snapshot():
     account = await svc.get_account()
 
     assert account.id == "acct-001"
-    assert account.buying_power == Decimal("100000")
-    assert account.cash == Decimal("50000")
-    assert account.portfolio_value == Decimal("150000")
+    assert account.buying_power == pytest.approx(Decimal("100000"))
+    assert account.cash == pytest.approx(Decimal("50000"))
+    assert account.portfolio_value == pytest.approx(Decimal("150000"))
     assert account.status == "ACTIVE"
     transport.request.assert_called_once_with("GET", "/v2/account")
 
@@ -144,8 +144,8 @@ async def test_get_cash_returns_cash_balance():
 
     cash = await svc.get_cash()
 
-    assert cash.cash == Decimal("50000")
-    assert cash.buying_power == Decimal("100000")
+    assert cash.cash == pytest.approx(Decimal("50000"))
+    assert cash.buying_power == pytest.approx(Decimal("100000"))
     transport.request.assert_called_once_with("GET", "/v2/account")
 
 

--- a/tests/test_analysis_screen_core.py
+++ b/tests/test_analysis_screen_core.py
@@ -18,8 +18,8 @@ def test_to_optional_float_treats_nan_values_as_missing() -> None:
 
 
 def test_to_optional_float_preserves_normal_numbers() -> None:
-    assert _to_optional_float(12) == 12.0
-    assert _to_optional_float("12.5") == 12.5
+    assert _to_optional_float(12) == pytest.approx(12.0)
+    assert _to_optional_float("12.5") == pytest.approx(12.5)
 
 
 def test_to_optional_int_treats_nan_values_as_missing() -> None:

--- a/tests/test_async_rate_limiter.py
+++ b/tests/test_async_rate_limiter.py
@@ -141,12 +141,12 @@ class TestAsyncSlidingWindowRateLimiter:
 
         assert stats["name"] == "test_stats"
         assert stats["rate"] == 10
-        assert stats["period"] == 1.0
+        assert stats["period"] == pytest.approx(1.0)
         assert stats["total_requests"] == 0
         assert stats["throttled_requests"] == 0
-        assert stats["throttle_rate"] == 0.0
-        assert stats["total_wait_time"] == 0.0
-        assert stats["avg_wait_time"] == 0.0
+        assert stats["throttle_rate"] == pytest.approx(0.0)
+        assert stats["total_wait_time"] == pytest.approx(0.0)
+        assert stats["avg_wait_time"] == pytest.approx(0.0)
         assert stats["current_window_count"] == 0
 
     @pytest.mark.asyncio
@@ -173,7 +173,7 @@ class TestAsyncSlidingWindowRateLimiter:
 
         assert limiter._total_requests == 0
         assert limiter._throttled_requests == 0
-        assert limiter._total_wait_time == 0.0
+        assert limiter._total_wait_time == pytest.approx(0.0)
 
     @pytest.mark.asyncio
     async def test_callback_exception_does_not_break_acquire(self):
@@ -224,13 +224,13 @@ class TestPerApiRateLimiters:
     async def test_get_limiter_uses_custom_rate_and_period(self):
         limiter = await get_limiter("kis", "CUSTOM_RATE", rate=5, period=2.0)
         assert limiter.rate == 5
-        assert limiter.period == 2.0
+        assert limiter.period == pytest.approx(2.0)
 
     @pytest.mark.asyncio
     async def test_get_limiter_uses_default_when_not_specified(self):
         limiter = await get_limiter("kis", "DEFAULT_RATE")
         assert limiter.rate == 19  # Default for KIS
-        assert limiter.period == 1.0
+        assert limiter.period == pytest.approx(1.0)
 
     @pytest.mark.asyncio
     async def test_get_all_limiters_returns_copy(self):

--- a/tests/test_candles_sync_common.py
+++ b/tests/test_candles_sync_common.py
@@ -46,7 +46,7 @@ class TestParseFloat:
     def test_parses_int(self) -> None:
         from app.services.candles_sync_common import parse_float
 
-        assert parse_float(42) == 42.0
+        assert parse_float(42) == pytest.approx(42.0)
 
     def test_returns_none_for_none(self) -> None:
         from app.services.candles_sync_common import parse_float

--- a/tests/test_crypto_composite_score.py
+++ b/tests/test_crypto_composite_score.py
@@ -134,14 +134,14 @@ class TestCandleCoefficient:
         coef, ctype = calculate_candle_coefficient(
             open_price=100.0, high=110.0, low=95.0, close=108.0
         )
-        assert coef == 1.0
+        assert coef == pytest.approx(1.0)
         assert ctype == BULLISH
 
     def test_bearish_strong_candle(self):
         coef, ctype = calculate_candle_coefficient(
             open_price=110.0, high=112.0, low=90.0, close=92.0
         )
-        assert coef == 0.0
+        assert coef == pytest.approx(0.0)
         assert ctype == BEARISH_STRONG
 
     def test_bullish_with_long_lower_shadow_prioritizes_bullish(self):
@@ -155,37 +155,37 @@ class TestCandleCoefficient:
         coef, ctype = calculate_candle_coefficient(
             open_price=open_price, high=high, low=low, close=close
         )
-        assert coef == 1.0
+        assert coef == pytest.approx(1.0)
         assert ctype == BULLISH
 
     def test_hammer_candle(self):
         coef, ctype = calculate_candle_coefficient(
             open_price=101.0, high=105.0, low=80.0, close=100.0
         )
-        assert coef == 0.8
+        assert coef == pytest.approx(0.8)
         assert ctype == HAMMER
 
     def test_bearish_normal_candle(self):
         coef, ctype = calculate_candle_coefficient(
             open_price=100.0, high=105.0, low=90.0, close=95.0
         )
-        assert coef == 0.5
+        assert coef == pytest.approx(0.5)
         assert ctype == BEARISH_NORMAL
 
     def test_flat_candle_zero_range(self):
         coef, ctype = calculate_candle_coefficient(
             open_price=100.0, high=100.0, low=100.0, close=100.0
         )
-        assert coef == 0.5
+        assert coef == pytest.approx(0.5)
         assert ctype == FLAT
 
     def test_none_values_return_flat(self):
         coef, ctype = calculate_candle_coefficient(None, 100.0, 90.0, 95.0)
-        assert coef == 0.5
+        assert coef == pytest.approx(0.5)
         assert ctype == FLAT
 
         coef, ctype = calculate_candle_coefficient(100.0, None, 90.0, 95.0)
-        assert coef == 0.5
+        assert coef == pytest.approx(0.5)
         assert ctype == FLAT
 
 
@@ -196,63 +196,63 @@ class TestVolumeScore:
 
     def test_high_ratio_capped_at_100(self):
         score = calculate_volume_score(10000.0, 1000.0)
-        assert score == 100.0
+        assert score == pytest.approx(100.0)
 
     def test_none_today_volume(self):
         score = calculate_volume_score(None, 1000.0)
-        assert score == 0.0
+        assert score == pytest.approx(0.0)
 
     def test_none_avg_volume(self):
         score = calculate_volume_score(1000.0, None)
-        assert score == 0.0
+        assert score == pytest.approx(0.0)
 
     def test_zero_avg_volume(self):
         score = calculate_volume_score(1000.0, 0.0)
-        assert score == 0.0
+        assert score == pytest.approx(0.0)
 
 
 class TestTrendScore:
     def test_uptrend_plus_di_greater(self):
         score = calculate_trend_score(adx=25.0, plus_di=30.0, minus_di=20.0)
-        assert score == 90.0
+        assert score == pytest.approx(90.0)
 
     def test_weak_trend_adx_below_35(self):
         score = calculate_trend_score(adx=25.0, plus_di=20.0, minus_di=30.0)
-        assert score == 60.0
+        assert score == pytest.approx(60.0)
 
     def test_moderate_trend_adx_35_to_50(self):
         score = calculate_trend_score(adx=40.0, plus_di=20.0, minus_di=30.0)
-        assert score == 30.0
+        assert score == pytest.approx(30.0)
 
     def test_strong_trend_adx_above_50(self):
         score = calculate_trend_score(adx=55.0, plus_di=20.0, minus_di=30.0)
-        assert score == 10.0
+        assert score == pytest.approx(10.0)
 
     def test_none_adx_returns_conservative(self):
         score = calculate_trend_score(adx=None, plus_di=20.0, minus_di=30.0)
-        assert score == 30.0
+        assert score == pytest.approx(30.0)
 
     def test_none_di_with_low_adx(self):
         score = calculate_trend_score(adx=25.0, plus_di=None, minus_di=None)
-        assert score == 60.0
+        assert score == pytest.approx(60.0)
 
 
 class TestRsiScore:
     def test_low_rsi_oversold(self):
         score = calculate_rsi_score(20.0)
-        assert score == 80.0
+        assert score == pytest.approx(80.0)
 
     def test_high_rsi_overbought(self):
         score = calculate_rsi_score(80.0)
-        assert score == 20.0
+        assert score == pytest.approx(20.0)
 
     def test_neutral_rsi(self):
         score = calculate_rsi_score(50.0)
-        assert score == 50.0
+        assert score == pytest.approx(50.0)
 
     def test_none_rsi_returns_neutral(self):
         score = calculate_rsi_score(None)
-        assert score == 50.0
+        assert score == pytest.approx(50.0)
 
 
 class TestCompositeScore:
@@ -333,12 +333,12 @@ class TestCalculate20dAvgVolume:
     def test_calculates_average(self):
         df = pd.DataFrame({"volume": [100.0] * 20})
         avg = calculate_20d_avg_volume(df)
-        assert avg == 100.0
+        assert avg == pytest.approx(100.0)
 
     def test_uses_last_20_days(self):
         df = pd.DataFrame({"volume": [50.0] * 10 + [100.0] * 20})
         avg = calculate_20d_avg_volume(df)
-        assert avg == 100.0
+        assert avg == pytest.approx(100.0)
 
     def test_returns_none_for_empty_df(self):
         df = pd.DataFrame()
@@ -362,10 +362,10 @@ class TestExtractCandleValues:
             }
         )
         o, h, lo, c = extract_candle_values(df, -2)
-        assert o == 105.0
-        assert h == 110.0
-        assert lo == 100.0
-        assert c == 108.0
+        assert o == pytest.approx(105.0)
+        assert h == pytest.approx(110.0)
+        assert lo == pytest.approx(100.0)
+        assert c == pytest.approx(108.0)
 
     def test_fallback_to_last_candle(self):
         df = pd.DataFrame(
@@ -377,8 +377,8 @@ class TestExtractCandleValues:
             }
         )
         o, h, lo, c = extract_candle_values(df, -1)
-        assert o == 100.0
-        assert h == 105.0
+        assert o == pytest.approx(100.0)
+        assert h == pytest.approx(105.0)
 
     def test_returns_none_for_missing_columns(self):
         df = pd.DataFrame({"close": [100.0] * 5})

--- a/tests/test_crypto_voting_integration.py
+++ b/tests/test_crypto_voting_integration.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from app.services.crypto_voting_signals import CryptoVotingSignals
 
@@ -40,12 +41,12 @@ class TestVotingBacktestConsistency:
         assert MACD_SLOW == 26
         assert MACD_SIGNAL == 9
         assert BB_PERIOD == 15
-        assert BB_STD == 2.0
+        assert BB_STD == pytest.approx(2.0)
         assert EMA_FAST == 8
         assert EMA_SLOW == 24
         assert MOMENTUM_PERIOD == 5
         assert VOLUME_LOOKBACK == 20
-        assert VOLUME_THRESHOLD == 1.5
+        assert VOLUME_THRESHOLD == pytest.approx(1.5)
 
     def test_bull_signal_count_is_six(self):
         evaluator = CryptoVotingSignals()

--- a/tests/test_execution_contracts.py
+++ b/tests/test_execution_contracts.py
@@ -193,9 +193,9 @@ class TestOrderPreviewLine:
             rationale=["RSI oversold", "above MA20"],
             correlation_id="decision_run_abc123",
         )
-        assert line.quantity == Decimal("10")
-        assert line.limit_price == Decimal("70000")
-        assert line.notional == Decimal("700000")
+        assert line.quantity == pytest.approx(Decimal("10"))
+        assert line.limit_price == pytest.approx(Decimal("70000"))
+        assert line.notional == pytest.approx(Decimal("700000"))
         assert line.currency == "KRW"
         assert line.correlation_id == "decision_run_abc123"
 

--- a/tests/test_fill_notification.py
+++ b/tests/test_fill_notification.py
@@ -27,7 +27,7 @@ class TestNormalizeUpbitFill:
         assert order.symbol == "KRW-BTC"
         assert order.side == "bid"
         assert order.filled_price == 50_000_000
-        assert order.filled_qty == 0.1
+        assert order.filled_qty == pytest.approx(0.1)
         assert order.filled_amount == 5_000_000
         assert order.account == "upbit"
         assert order.market_type == "crypto"
@@ -90,9 +90,9 @@ class TestNormalizeKisFill:
 
         assert order.symbol == "AAPL"
         assert order.side == "ask"
-        assert order.filled_price == 195.5
+        assert order.filled_price == pytest.approx(195.5)
         assert order.filled_qty == 2
-        assert order.filled_amount == 391.0
+        assert order.filled_amount == pytest.approx(391.0)
         assert order.order_id == "US-ORDER-1234"
         assert order.account == "kis"
         assert order.market_type == "us"

--- a/tests/test_kis_base_rate_limit.py
+++ b/tests/test_kis_base_rate_limit.py
@@ -35,7 +35,7 @@ class TestCalculateRetryDelay:
     def test_uses_retry_after_when_positive(self):
         client = _make_client()
         delay = client._calculate_retry_delay(attempt=0, retry_after=2.5)
-        assert delay == 2.5
+        assert delay == pytest.approx(2.5)
 
     def test_exponential_backoff_when_no_retry_after(self):
         client = _make_client()

--- a/tests/test_kis_mock_lifecycle_reconciliation_acceptance.py
+++ b/tests/test_kis_mock_lifecycle_reconciliation_acceptance.py
@@ -113,7 +113,7 @@ async def test_full_reconciliation_cycle_acceptance(monkeypatch):
     save_ledger_mock.assert_awaited_once()
     save_kwargs = save_ledger_mock.call_args.kwargs
     assert save_kwargs["lifecycle_state"] == "accepted"
-    assert save_kwargs["holdings_baseline_qty"] == Decimal("0")
+    assert save_kwargs["holdings_baseline_qty"] == pytest.approx(Decimal("0"))
 
     # Step B: dry_run=False without confirm is rejected.
     rejected = await tools["kis_mock_reconciliation_run"](dry_run=False, confirm=False)

--- a/tests/test_kis_order_ops.py
+++ b/tests/test_kis_order_ops.py
@@ -77,7 +77,7 @@ class TestOverseasOrderOps:
             kis, "AAPL", "buy", 1, 175.99, exchange_code="NASD"
         )
         call_args = kis.order_overseas_stock.call_args
-        assert call_args.kwargs["price"] == 175.99
+        assert call_args.kwargs["price"] == pytest.approx(175.99)
 
     @pytest.mark.asyncio
     async def test_adjust_sell_qty_reduces_when_account_has_less(self):

--- a/tests/test_kis_rankings.py
+++ b/tests/test_kis_rankings.py
@@ -320,9 +320,9 @@ class TestKISRankingAPIParams:
         )
 
         assert len(result) == 3
-        assert float(result[0]["prdy_ctrt"]) == 5.0
-        assert float(result[1]["prdy_ctrt"]) == 3.0
-        assert float(result[2]["prdy_ctrt"]) == 1.5
+        assert float(result[0]["prdy_ctrt"]) == pytest.approx(5.0)
+        assert float(result[1]["prdy_ctrt"]) == pytest.approx(3.0)
+        assert float(result[2]["prdy_ctrt"]) == pytest.approx(1.5)
 
     async def test_api_error_handling(self, monkeypatch):
         """API 에러 시 RuntimeError가 발생하는지 검증"""
@@ -763,7 +763,7 @@ class TestKISRankingDirection:
         assert req["params"]["FID_RANK_SORT_CLS_CODE"] == "3"
         assert req["params"]["FID_PRC_CLS_CODE"] == "0"
         assert len(result) == 1
-        assert float(result[0]["prdy_ctrt"]) == -3.0
+        assert float(result[0]["prdy_ctrt"]) == pytest.approx(-3.0)
 
     async def test_fluctuation_rank_down_strict_negative_filtering(self, monkeypatch):
         captured_requests = []
@@ -819,8 +819,8 @@ class TestKISRankingDirection:
         assert len(captured_requests) == 1
         assert len(result) == 2
         assert all(float(r["prdy_ctrt"]) < 0 for r in result)
-        assert float(result[0]["prdy_ctrt"]) == -3.0
-        assert float(result[1]["prdy_ctrt"]) == -1.5
+        assert float(result[0]["prdy_ctrt"]) == pytest.approx(-3.0)
+        assert float(result[1]["prdy_ctrt"]) == pytest.approx(-1.5)
 
     async def test_fluctuation_rank_down_returns_empty_when_no_negatives(
         self, monkeypatch

--- a/tests/test_kis_tasks.py
+++ b/tests/test_kis_tasks.py
@@ -670,8 +670,8 @@ def test_run_per_domestic_stock_automation_refreshes_holdings(monkeypatch):
     assert sell_calls, "매도 단계가 호출되어야 합니다."
     # 매수 이후 최신 잔고(12주)와 갱신된 가격을 사용해야 한다.
     assert sell_calls[0]["qty"] == 12
-    assert sell_calls[0]["avg_price"] == 50500.0
-    assert sell_calls[0]["current_price"] == 51500.0
+    assert sell_calls[0]["avg_price"] == pytest.approx(50500.0)
+    assert sell_calls[0]["current_price"] == pytest.approx(51500.0)
 
 
 def test_execute_overseas_buy_order_fetches_price_for_new_symbol(monkeypatch):
@@ -723,8 +723,10 @@ def test_execute_overseas_buy_order_fetches_price_for_new_symbol(monkeypatch):
 
     assert result["success"] is True
     assert captured["symbol"] == "AAPL"
-    assert captured["avg_price"] == 0.0  # 신규 매수이므로 평단가는 0으로 전달
-    assert captured["current_price"] == 123.45
+    assert captured["avg_price"] == pytest.approx(
+        0.0
+    )  # 신규 매수이므로 평단가는 0으로 전달
+    assert captured["current_price"] == pytest.approx(123.45)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_kis_trading_service.py
+++ b/tests/test_kis_trading_service.py
@@ -1413,7 +1413,7 @@ class TestSinglePriceLevelSmartSelection:
             assert result["orders_placed"] == 1
             # 신규 진입이므로 max(160) 사용
             call_args = mock_kis_client.order_overseas_stock.call_args
-            assert call_args.kwargs["price"] == 160.0
+            assert call_args.kwargs["price"] == pytest.approx(160.0)
 
     @pytest.mark.asyncio
     async def test_overseas_single_level_uses_min_when_max_below_avg(
@@ -1470,4 +1470,4 @@ class TestSinglePriceLevelSmartSelection:
             assert result["orders_placed"] == 1
             # max(155) < avg(180) 이므로 min(150) 사용
             call_args = mock_kis_client.order_overseas_stock.call_args
-            assert call_args.kwargs["price"] == 150.0
+            assert call_args.kwargs["price"] == pytest.approx(150.0)

--- a/tests/test_mcp_available_capital.py
+++ b/tests/test_mcp_available_capital.py
@@ -62,7 +62,7 @@ async def test_get_available_capital_aggregates_accounts_and_manual_cash(monkeyp
     assert result["accounts"][0]["account"] == "upbit"
     assert result["accounts"][1]["account"] == "kis_domestic"
     assert result["accounts"][2]["account"] == "kis_overseas"
-    assert result["accounts"][2].get("krw_equivalent") == 130000.0
+    assert result["accounts"][2].get("krw_equivalent") == pytest.approx(130000.0)
 
     assert result["manual_cash"]["amount"] == 15000000
     assert result["manual_cash"]["stale_warning"] is False
@@ -71,7 +71,7 @@ async def test_get_available_capital_aggregates_accounts_and_manual_cash(monkeyp
         result["summary"]["total_orderable_krw"]
         == 1000000.0 + 2000000.0 + 130000.0 + 15000000.0
     )
-    assert result["summary"]["exchange_rate_usd_krw"] == 1300.0
+    assert result["summary"]["exchange_rate_usd_krw"] == pytest.approx(1300.0)
     assert result["summary"]["as_of"] == "2026-04-01T09:00:00+00:00"
 
     assert result["errors"] == []
@@ -112,7 +112,7 @@ async def test_get_available_capital_excludes_manual_when_flag_disabled(monkeypa
     result = await get_available_capital_impl(include_manual=False)
 
     assert result["manual_cash"] is None
-    assert result["summary"]["total_orderable_krw"] == 1000000.0
+    assert result["summary"]["total_orderable_krw"] == pytest.approx(1000000.0)
 
 
 @pytest.mark.asyncio
@@ -146,7 +146,7 @@ async def test_get_available_capital_handles_missing_manual_cash(monkeypatch):
     result = await get_available_capital_impl()
 
     assert result["manual_cash"] is None
-    assert result["summary"]["total_orderable_krw"] == 1000000.0
+    assert result["summary"]["total_orderable_krw"] == pytest.approx(1000000.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_fundamentals_tools.py
+++ b/tests/test_mcp_fundamentals_tools.py
@@ -244,7 +244,7 @@ class TestAnalyzeStock:
         }
         rec = shared.build_recommendation_for_equity(analysis, "equity_us")
         assert rec is not None
-        assert rec["rsi14"] == 45.8
+        assert rec["rsi14"] == pytest.approx(45.8)
 
     async def test_build_recommendation_for_equity_keeps_zero_rsi(self):
         """Test that rsi14=0.0 is NOT treated as missing."""
@@ -255,7 +255,7 @@ class TestAnalyzeStock:
         }
         rec = shared.build_recommendation_for_equity(analysis, "equity_us")
         assert rec is not None
-        assert rec["rsi14"] == 0.0
+        assert rec["rsi14"] == pytest.approx(0.0)
 
     async def test_apply_common_results_normalizes_indicator_wrapper(self):
         """Test that _apply_common_results flattens provider-style indicator payload."""
@@ -338,9 +338,9 @@ class TestAnalyzeStock:
         result = await tools["analyze_stock"]("AAPL", market="us")
 
         # Verify indicators shape is normalized (flat indicator map)
-        assert result["indicators"]["rsi"]["14"] == 45.8
+        assert result["indicators"]["rsi"]["14"] == pytest.approx(45.8)
         # Verify recommendation.rsi14 tracks the indicator value
-        assert result["recommendation"]["rsi14"] == 45.8
+        assert result["recommendation"]["rsi14"] == pytest.approx(45.8)
         assert result["recommendation"]["rsi14"] == result["indicators"]["rsi"]["14"]
 
     @pytest.mark.parametrize("symbol", ["AAPL", "MSFT"])
@@ -701,7 +701,7 @@ async def test_get_correlation_tool_uses_analysis_screening_correlation_alias(
 
     assert result["success"] is True
     assert result["symbols"] == ["AAPL", "MSFT"]
-    assert result["correlation_matrix"][0][1] == 0.42
+    assert result["correlation_matrix"][0][1] == pytest.approx(0.42)
 
 
 # ---------------------------------------------------------------------------
@@ -758,14 +758,14 @@ class TestGetValuation:
         assert result["symbol"] == "005930"
         assert result["name"] == "삼성전자"
         assert result["current_price"] == 75000
-        assert result["per"] == 12.5
-        assert result["pbr"] == 1.2
-        assert result["roe"] == 18.5
-        assert result["roe_controlling"] == 17.2
-        assert result["dividend_yield"] == 0.02
+        assert result["per"] == pytest.approx(12.5)
+        assert result["pbr"] == pytest.approx(1.2)
+        assert result["roe"] == pytest.approx(18.5)
+        assert result["roe_controlling"] == pytest.approx(17.2)
+        assert result["dividend_yield"] == pytest.approx(0.02)
         assert result["high_52w"] == 90000
         assert result["low_52w"] == 60000
-        assert result["current_position_52w"] == 0.5
+        assert result["current_position_52w"] == pytest.approx(0.5)
         assert result["instrument_type"] == "equity_kr"
         assert result["source"] == "naver"
 
@@ -795,14 +795,14 @@ class TestGetValuation:
 
         assert result["symbol"] == "AAPL"
         assert result["name"] == "Apple Inc."
-        assert result["current_price"] == 185.5
-        assert result["per"] == 28.5
-        assert result["pbr"] == 45.2
-        assert result["roe"] == 147.3
-        assert result["dividend_yield"] == 0.005
-        assert result["high_52w"] == 199.62
-        assert result["low_52w"] == 164.08
-        assert result["current_position_52w"] == 0.6
+        assert result["current_price"] == pytest.approx(185.5)
+        assert result["per"] == pytest.approx(28.5)
+        assert result["pbr"] == pytest.approx(45.2)
+        assert result["roe"] == pytest.approx(147.3)
+        assert result["dividend_yield"] == pytest.approx(0.005)
+        assert result["high_52w"] == pytest.approx(199.62)
+        assert result["low_52w"] == pytest.approx(164.08)
+        assert result["current_position_52w"] == pytest.approx(0.6)
         assert result["instrument_type"] == "equity_us"
         assert result["source"] == "yfinance"
 
@@ -832,7 +832,7 @@ class TestGetValuation:
 
         assert result["symbol"] == "NVDA"
         assert result["instrument_type"] == "equity_us"
-        assert result["roe"] == 85.0
+        assert result["roe"] == pytest.approx(85.0)
 
     async def test_rejects_crypto_symbol(self):
         """Test that crypto symbol raises ValueError."""
@@ -876,7 +876,7 @@ class TestGetValuation:
         assert result["symbol"] == "298040"
         assert result["per"] is None
         assert result["roe"] is None
-        assert result["current_position_52w"] == 0.83
+        assert result["current_position_52w"] == pytest.approx(0.83)
 
     async def test_error_handling(self, monkeypatch):
         """Test error handling when fetch fails."""
@@ -971,8 +971,8 @@ class TestGetShortInterest:
         assert len(result["short_data"]) == 2
         assert result["short_data"][0]["date"] == "2024-01-15"
         assert result["short_data"][0]["short_amount"] == 1_000_000_000
-        assert result["short_data"][0]["short_ratio"] == 5.0
-        assert result["avg_short_ratio"] == 5.17
+        assert result["short_data"][0]["short_ratio"] == pytest.approx(5.0)
+        assert result["avg_short_ratio"] == pytest.approx(5.17)
         assert "short_balance" not in result
 
     async def test_rejects_us_equity(self):
@@ -1144,12 +1144,12 @@ class TestGetKimchiPremium:
         result = await tools["get_kimchi_premium"]("BTC")
 
         assert result["source"] == "upbit+binance"
-        assert result["exchange_rate"] == 1450.0
+        assert result["exchange_rate"] == pytest.approx(1450.0)
         assert result["count"] == 1
         item = result["data"][0]
         assert item["symbol"] == "BTC"
         assert item["upbit_krw"] == 150_000_000
-        assert item["binance_usdt"] == 102000.50
+        assert item["binance_usdt"] == pytest.approx(102000.50)
         # (150_000_000 - 102000.50*1450) / (102000.50*1450) * 100
         expected_premium = round(
             (150_000_000 - 102000.50 * 1450) / (102000.50 * 1450) * 100, 2
@@ -1186,7 +1186,7 @@ class TestGetKimchiPremium:
         symbols = [d["symbol"] for d in result]
         assert symbols == ["BTC", "ETH"]
         assert result[0]["upbit_price"] == 150_000_000
-        assert result[0]["binance_price"] == 102000.0
+        assert result[0]["binance_price"] == pytest.approx(102000.0)
         assert "premium_pct" in result[0]
 
     async def test_strips_krw_prefix(self, monkeypatch):
@@ -1293,12 +1293,12 @@ class TestGetFundingRate:
         result = await tools["get_funding_rate"]("BTC")
 
         assert result["symbol"] == "BTCUSDT"
-        assert result["current_funding_rate"] == 0.0001
-        assert result["current_funding_rate_pct"] == 0.01
+        assert result["current_funding_rate"] == pytest.approx(0.0001)
+        assert result["current_funding_rate_pct"] == pytest.approx(0.01)
         assert result["next_funding_time"] is not None
         assert len(result["funding_history"]) == 2
-        assert result["funding_history"][0]["rate"] == 0.0001
-        assert result["funding_history"][0]["rate_pct"] == 0.01
+        assert result["funding_history"][0]["rate"] == pytest.approx(0.0001)
+        assert result["funding_history"][0]["rate_pct"] == pytest.approx(0.01)
         assert result["avg_funding_rate_pct"] is not None
         assert "interpretation" in result
 
@@ -1429,7 +1429,7 @@ class TestGetFundingRate:
         assert isinstance(result, list)
         assert len(result) == 2
         assert result[0]["symbol"] == "BTC"
-        assert result[0]["funding_rate"] == 0.0001
+        assert result[0]["funding_rate"] == pytest.approx(0.0001)
         assert result[0]["next_funding_time"] is not None
         assert "interpretation" in result[0]
 
@@ -1502,7 +1502,7 @@ class TestGetFundingRate:
 
         result = await tools["get_funding_rate"]("BTC", limit=2)
 
-        assert result["avg_funding_rate_pct"] == 0.03
+        assert result["avg_funding_rate_pct"] == pytest.approx(0.03)
 
     async def test_empty_history(self, monkeypatch):
         tools = build_tools()
@@ -1681,14 +1681,14 @@ class TestGetMarketIndex:
         idx = result["indices"][0]
         assert idx["symbol"] == "KOSPI"
         assert idx["name"] == "코스피"
-        assert idx["current"] == 2450.50
-        assert idx["change"] == -45.30
-        assert idx["change_pct"] == -1.82
+        assert idx["current"] == pytest.approx(2450.50)
+        assert idx["change"] == pytest.approx(-45.30)
+        assert idx["change_pct"] == pytest.approx(-1.82)
         assert idx["source"] == "naver"
         # open/high/low come from the first price record
-        assert idx["open"] == 2390.0
-        assert idx["high"] == 2420.0
-        assert idx["low"] == 2380.0
+        assert idx["open"] == pytest.approx(2390.0)
+        assert idx["high"] == pytest.approx(2420.0)
+        assert idx["low"] == pytest.approx(2380.0)
 
         assert "history" in result
         assert len(result["history"]) == 3
@@ -1707,8 +1707,8 @@ class TestGetMarketIndex:
         idx = result["indices"][0]
         assert idx["symbol"] == "NASDAQ"
         assert idx["name"] == "NASDAQ Composite"
-        assert idx["current"] == 17500.0
-        assert idx["change"] == 100.0
+        assert idx["current"] == pytest.approx(17500.0)
+        assert idx["change"] == pytest.approx(100.0)
         assert idx["change_pct"] == pytest.approx(0.57, abs=0.01)
         assert idx["source"] == "yfinance"
 
@@ -2154,8 +2154,8 @@ class TestGetSectorPeers:
 
         assert comp["target_per_rank"] == "1/3"
         assert comp["target_pbr_rank"] == "2/3"
-        assert comp["avg_per"] == 30.0
-        assert comp["avg_pbr"] == 6.0
+        assert comp["avg_per"] == pytest.approx(30.0)
+        assert comp["avg_pbr"] == pytest.approx(6.0)
 
 
 @pytest.mark.asyncio
@@ -2276,7 +2276,7 @@ class TestGetCryptoProfile:
         assert result_first["market_cap_rank"] == 1
         assert result_first["total_volume_24h"] == 50_000_000_000_000
         assert result_first["ath"] == 140_000_000
-        assert result_first["price_change_percentage_7d"] == 2.5
+        assert result_first["price_change_percentage_7d"] == pytest.approx(2.5)
         assert "<" not in (result_first["description"] or "")
         assert result_second["symbol"] == "BTC"
         assert detail_calls["count"] == 1
@@ -2797,9 +2797,9 @@ class TestGetInvestmentOpinions:
         result = await tools["get_investment_opinions"]("AAPL", market="us")
 
         assert result["symbol"] == "AAPL"
-        assert result["consensus"]["avg_target_price"] == 195.5
-        assert result["consensus"]["current_price"] == 185.5
-        assert result["consensus"]["upside_pct"] == 5.4
+        assert result["consensus"]["avg_target_price"] == pytest.approx(195.5)
+        assert result["consensus"]["current_price"] == pytest.approx(185.5)
+        assert result["consensus"]["upside_pct"] == pytest.approx(5.4)
 
     async def test_us_market_skips_upside_when_avg_target_not_numeric(
         self, monkeypatch
@@ -2827,7 +2827,7 @@ class TestGetInvestmentOpinions:
         )
 
         assert result["consensus"]["avg_target_price"] is None
-        assert result["consensus"]["current_price"] == 185.5
+        assert result["consensus"]["current_price"] == pytest.approx(185.5)
         assert result["consensus"]["upside_pct"] is None
 
     async def test_us_market_uses_recommendation_trend_counts_and_normalized_targets(
@@ -2882,12 +2882,12 @@ class TestGetInvestmentOpinions:
         assert result["consensus"]["sell_count"] == 5
         assert result["consensus"]["strong_buy_count"] == 5
         assert result["consensus"]["total_count"] == 25
-        assert result["consensus"]["avg_target_price"] == 200.0
-        assert result["consensus"]["median_target_price"] == 198.0
-        assert result["consensus"]["min_target_price"] == 180.0
-        assert result["consensus"]["max_target_price"] == 220.0
-        assert result["consensus"]["current_price"] == 185.0
-        assert result["consensus"]["upside_pct"] == 8.11
+        assert result["consensus"]["avg_target_price"] == pytest.approx(200.0)
+        assert result["consensus"]["median_target_price"] == pytest.approx(198.0)
+        assert result["consensus"]["min_target_price"] == pytest.approx(180.0)
+        assert result["consensus"]["max_target_price"] == pytest.approx(220.0)
+        assert result["consensus"]["current_price"] == pytest.approx(185.0)
+        assert result["consensus"]["upside_pct"] == pytest.approx(8.11)
 
     async def test_us_market_returns_warning_for_unavailable_yahoo_consensus(
         self, monkeypatch
@@ -2976,12 +2976,12 @@ class TestGetInvestmentOpinions:
             )
         )
 
-        assert result["consensus"]["avg_target_price"] == 200.0
-        assert result["consensus"]["median_target_price"] == 198.0
-        assert result["consensus"]["min_target_price"] == 180.0
-        assert result["consensus"]["max_target_price"] == 220.0
-        assert result["consensus"]["current_price"] == 185.0
-        assert result["consensus"]["upside_pct"] == 8.11
+        assert result["consensus"]["avg_target_price"] == pytest.approx(200.0)
+        assert result["consensus"]["median_target_price"] == pytest.approx(198.0)
+        assert result["consensus"]["min_target_price"] == pytest.approx(180.0)
+        assert result["consensus"]["max_target_price"] == pytest.approx(220.0)
+        assert result["consensus"]["current_price"] == pytest.approx(185.0)
+        assert result["consensus"]["upside_pct"] == pytest.approx(8.11)
 
     async def test_us_market_keeps_partial_recommendation_counts_unavailable(
         self, monkeypatch
@@ -3025,8 +3025,8 @@ class TestGetInvestmentOpinions:
         assert result["consensus"]["sell_count"] is None
         assert result["consensus"]["strong_buy_count"] is None
         assert result["consensus"]["total_count"] is None
-        assert result["consensus"]["avg_target_price"] == 200.0
-        assert result["consensus"]["current_price"] == 185.0
+        assert result["consensus"]["avg_target_price"] == pytest.approx(200.0)
+        assert result["consensus"]["current_price"] == pytest.approx(185.0)
 
 
 @pytest.mark.asyncio
@@ -3330,7 +3330,7 @@ class TestScreenEnrichmentHelpers:
         assert decorated[1]["sector"] is None
         assert decorated[1]["analyst_buy"] is None
         assert decorated[2]["sector"] == "Technology"
-        assert decorated[2]["avg_target"] == 250.0
+        assert decorated[2]["avg_target"] == pytest.approx(250.0)
         assert decorated[3]["sector"] is None
         assert decorated[3]["analyst_buy"] is None
         assert warnings == ["kr:035420: RuntimeError: kr enrichment failed"]
@@ -4020,13 +4020,19 @@ class TestParseNaverNum:
         assert fundamentals_sources_common._parse_naver_int(None) is None
 
     def test_numeric(self):
-        assert fundamentals_sources_common._parse_naver_num(1234.5) == 1234.5
-        assert fundamentals_sources_common._parse_naver_num(100) == 100.0
+        assert fundamentals_sources_common._parse_naver_num(1234.5) == pytest.approx(
+            1234.5
+        )
+        assert fundamentals_sources_common._parse_naver_num(100) == pytest.approx(100.0)
         assert fundamentals_sources_common._parse_naver_int(42) == 42
 
     def test_string_with_commas(self):
-        assert fundamentals_sources_common._parse_naver_num("2,450.50") == 2450.50
-        assert fundamentals_sources_common._parse_naver_num("-45.30") == -45.30
+        assert fundamentals_sources_common._parse_naver_num(
+            "2,450.50"
+        ) == pytest.approx(2450.50)
+        assert fundamentals_sources_common._parse_naver_num("-45.30") == pytest.approx(
+            -45.30
+        )
         assert fundamentals_sources_common._parse_naver_int("450,000,000") == 450000000
 
     def test_invalid_string(self):

--- a/tests/test_mcp_order_tools.py
+++ b/tests/test_mcp_order_tools.py
@@ -209,7 +209,7 @@ async def test_get_order_history_pending_crypto(monkeypatch):
     assert order["symbol"] == "KRW-BTC"
     assert order["side"] == "buy"
     assert order["status"] == "pending"
-    assert order["remaining_qty"] == 0.001
+    assert order["remaining_qty"] == pytest.approx(0.001)
 
 
 @pytest.mark.asyncio
@@ -1755,8 +1755,8 @@ async def test_get_order_history_us_pending_uppercase_fields(monkeypatch):
     assert order["ordered_qty"] == 100
     assert order["filled_qty"] == 60
     assert order["remaining_qty"] == 40
-    assert order["ordered_price"] == 195.5
-    assert order["filled_avg_price"] == 196.0
+    assert order["ordered_price"] == pytest.approx(195.5)
+    assert order["filled_avg_price"] == pytest.approx(196.0)
     assert order["ordered_at"] == "20250210 093000"
     assert order["currency"] == "USD"
 

--- a/tests/test_mcp_recommend_flow.py
+++ b/tests/test_mcp_recommend_flow.py
@@ -190,7 +190,7 @@ class TestRecommendStocksIntegration:
             "strategy": "growth",
         }
         assert result["recommendations"][0]["reason"] == "phase seam"
-        assert result["remaining_budget"] == 400.0
+        assert result["remaining_budget"] == pytest.approx(400.0)
         assert result["strategy"] == "growth"
 
     @pytest.mark.asyncio
@@ -1427,6 +1427,6 @@ class TestScreenUsBehavior:
         first = result["results"][0]
         assert first["code"] == "IVDA"
         assert first["name"] == "Iveda Solutions"
-        assert first["close"] == 5.12
+        assert first["close"] == pytest.approx(5.12)
         assert first["volume"] == 1_234_567
         assert first["market_cap"] == 500_000_000

--- a/tests/test_mcp_recommend_scoring.py
+++ b/tests/test_mcp_recommend_scoring.py
@@ -21,13 +21,13 @@ from tests._mcp_tooling_support import build_tools
 
 class TestScoringFunctions:
     def test_calc_rsi_score_handles_none(self):
-        assert calc_rsi_score(None) == 50.0
+        assert calc_rsi_score(None) == pytest.approx(50.0)
 
     def test_calc_valuation_score_handles_none(self):
-        assert calc_valuation_score(None, None) == 50.0
+        assert calc_valuation_score(None, None) == pytest.approx(50.0)
 
     def test_calc_momentum_score_handles_none(self):
-        assert calc_momentum_score(None) == 50.0
+        assert calc_momentum_score(None) == pytest.approx(50.0)
 
     def test_calc_dividend_score_accepts_percent_input(self):
         score_decimal = calc_dividend_score(0.05)
@@ -246,7 +246,7 @@ class TestCandidateNormalization:
             "acc_trade_volume_24h": 12345,
         }
         normalized_from_acc = normalize_candidate(item_with_acc_trade_volume, "crypto")
-        assert normalized_from_acc["volume_24h"] == 12345.0
+        assert normalized_from_acc["volume_24h"] == pytest.approx(12345.0)
 
         item_with_volume_only = {
             "symbol": "KRW-ETH",
@@ -254,4 +254,4 @@ class TestCandidateNormalization:
             "volume": 6789,
         }
         normalized_from_volume = normalize_candidate(item_with_volume_only, "crypto")
-        assert normalized_from_volume["volume_24h"] == 6789.0
+        assert normalized_from_volume["volume_24h"] == pytest.approx(6789.0)

--- a/tests/test_mcp_screen_stocks_tvscreener_contract.py
+++ b/tests/test_mcp_screen_stocks_tvscreener_contract.py
@@ -123,19 +123,19 @@ class TestScreenStocksTvScreenerContract:
         assert result["total_count"] == 3
         assert result["returned_count"] == 1
         assert result["results"][0]["code"] == "005930"
-        assert result["results"][0]["close"] == 70000.0
-        assert result["results"][0]["change_rate"] == 2.5
+        assert result["results"][0]["close"] == pytest.approx(70000.0)
+        assert result["results"][0]["change_rate"] == pytest.approx(2.5)
         assert result["results"][0]["market"] == "KOSPI"
         assert result["results"][0]["market_cap"] == 4800000
-        assert result["results"][0]["per"] == 12.5
-        assert result["results"][0]["pbr"] == 1.2
-        assert result["results"][0]["dividend_yield"] == 0.0256
-        assert result["results"][0]["adx"] == 24.8
+        assert result["results"][0]["per"] == pytest.approx(12.5)
+        assert result["results"][0]["pbr"] == pytest.approx(1.2)
+        assert result["results"][0]["dividend_yield"] == pytest.approx(0.0256)
+        assert result["results"][0]["adx"] == pytest.approx(24.8)
         assert result["filters_applied"]["sort_order"] == "desc"
         assert result["filters_applied"]["min_market_cap"] == 300000
-        assert result["filters_applied"]["max_per"] == 15.0
-        assert result["filters_applied"]["max_pbr"] == 2.0
-        assert result["filters_applied"]["min_dividend_yield"] == 0.02
+        assert result["filters_applied"]["max_per"] == pytest.approx(15.0)
+        assert result["filters_applied"]["max_pbr"] == pytest.approx(2.0)
+        assert result["filters_applied"]["min_dividend_yield"] == pytest.approx(0.02)
         assert result["meta"]["source"] == "tvscreener"
         assert result["meta"]["rsi_enrichment"]["error_samples"] == []
 
@@ -200,17 +200,17 @@ class TestScreenStocksTvScreenerContract:
         assert result["total_count"] == 4
         assert result["returned_count"] == 1
         assert result["results"][0]["code"] == "AAPL"
-        assert result["results"][0]["close"] == 175.5
-        assert result["results"][0]["change_rate"] == 1.2
+        assert result["results"][0]["close"] == pytest.approx(175.5)
+        assert result["results"][0]["change_rate"] == pytest.approx(1.2)
         assert result["results"][0]["market"] == "us"
         assert result["results"][0]["market_cap"] == 2800000000000
-        assert result["results"][0]["per"] == 28.5
-        assert result["results"][0]["dividend_yield"] == 0.005
-        assert result["results"][0]["adx"] == 31.4
+        assert result["results"][0]["per"] == pytest.approx(28.5)
+        assert result["results"][0]["dividend_yield"] == pytest.approx(0.005)
+        assert result["results"][0]["adx"] == pytest.approx(31.4)
         assert result["filters_applied"]["sort_order"] == "asc"
         assert result["filters_applied"]["min_market_cap"] == 1000000000
-        assert result["filters_applied"]["max_per"] == 30.0
-        assert result["filters_applied"]["min_dividend_yield"] == 0.004
+        assert result["filters_applied"]["max_per"] == pytest.approx(30.0)
+        assert result["filters_applied"]["min_dividend_yield"] == pytest.approx(0.004)
         assert result["meta"]["source"] == "tvscreener"
 
     @pytest.mark.asyncio
@@ -273,8 +273,8 @@ class TestScreenStocksTvScreenerContract:
         )
 
         assert result["meta"]["source"] == "tvscreener"
-        assert result["results"][0]["rsi"] == 41.2
-        assert result["results"][0]["adx"] == 23.5
+        assert result["results"][0]["rsi"] == pytest.approx(41.2)
+        assert result["results"][0]["adx"] == pytest.approx(23.5)
         assert result["meta"]["rsi_enrichment"]["error_samples"] == []
 
     @pytest.mark.asyncio
@@ -335,7 +335,7 @@ class TestScreenStocksTvScreenerContract:
         )
 
         assert result["meta"]["source"] == "tvscreener"
-        assert result["results"][0]["adx"] == 31.4
+        assert result["results"][0]["adx"] == pytest.approx(31.4)
 
     @pytest.mark.asyncio
     async def test_kr_stock_request_with_max_rsi_still_uses_tvscreener(
@@ -344,7 +344,7 @@ class TestScreenStocksTvScreenerContract:
         async def mock_screen_kr_via_tvscreener(**kwargs):
             assert kwargs["market"] == "kr"
             assert kwargs["asset_type"] == "stock"
-            assert kwargs["max_rsi"] == 35.0
+            assert kwargs["max_rsi"] == pytest.approx(35.0)
             return {
                 "stocks": [
                     {
@@ -400,8 +400,8 @@ class TestScreenStocksTvScreenerContract:
         )
 
         assert result["meta"]["source"] == "tvscreener"
-        assert result["results"][0]["rsi"] == 32.0
-        assert result["results"][0]["adx"] == 21.5
+        assert result["results"][0]["rsi"] == pytest.approx(32.0)
+        assert result["results"][0]["adx"] == pytest.approx(21.5)
 
     @pytest.mark.asyncio
     async def test_us_stock_request_with_max_rsi_still_uses_tvscreener(
@@ -410,7 +410,7 @@ class TestScreenStocksTvScreenerContract:
         async def mock_screen_us_via_tvscreener(**kwargs):
             assert kwargs["market"] == "us"
             assert kwargs["asset_type"] is None
-            assert kwargs["max_rsi"] == 40.0
+            assert kwargs["max_rsi"] == pytest.approx(40.0)
             return {
                 "stocks": [
                     {
@@ -464,8 +464,8 @@ class TestScreenStocksTvScreenerContract:
         )
 
         assert result["meta"]["source"] == "tvscreener"
-        assert result["results"][0]["rsi"] == 35.2
-        assert result["results"][0]["adx"] == 31.4
+        assert result["results"][0]["rsi"] == pytest.approx(35.2)
+        assert result["results"][0]["adx"] == pytest.approx(31.4)
 
     @pytest.mark.asyncio
     async def test_us_tvscreener_error_falls_back_to_legacy_path(self, monkeypatch):
@@ -487,7 +487,7 @@ class TestScreenStocksTvScreenerContract:
 
         async def mock_screen_us(**kwargs):
             assert kwargs["market"] == "us"
-            assert kwargs["max_rsi"] == 40.0
+            assert kwargs["max_rsi"] == pytest.approx(40.0)
             return {
                 "results": [
                     {
@@ -939,7 +939,7 @@ class TestScreenStocksTvScreenerContract:
         )
 
         assert result["meta"]["source"] == "tvscreener"
-        assert result["results"][0]["adx"] == 23.5
+        assert result["results"][0]["adx"] == pytest.approx(23.5)
 
     @pytest.mark.asyncio
     async def test_kr_request_falls_back_to_legacy_when_capability_unverified(

--- a/tests/test_mcp_shared_utils.py
+++ b/tests/test_mcp_shared_utils.py
@@ -135,17 +135,17 @@ class TestNormalizeValue:
 
     def test_timedelta_returns_seconds(self):
         td = pd.Timedelta(hours=1, minutes=30)
-        assert shared.normalize_value(td) == 5400.0
+        assert shared.normalize_value(td) == pytest.approx(5400.0)
 
     def test_numpy_scalar_returns_python_type(self):
         import numpy as np
 
         assert shared.normalize_value(np.int64(42)) == 42
-        assert shared.normalize_value(np.float64(3.14)) == 3.14
+        assert shared.normalize_value(np.float64(3.14)) == pytest.approx(3.14)
 
     def test_regular_values_pass_through(self):
         assert shared.normalize_value(42) == 42
-        assert shared.normalize_value(3.14) == 3.14
+        assert shared.normalize_value(3.14) == pytest.approx(3.14)
         assert shared.normalize_value("hello") == "hello"
 
 

--- a/tests/test_mcp_top_stocks.py
+++ b/tests/test_mcp_top_stocks.py
@@ -90,7 +90,7 @@ class TestMCPTopStocks:
         assert result["rankings"][0]["rank"] == 1
         assert result["rankings"][0]["symbol"] == "005930"
         assert result["rankings"][0]["name"] == "삼성전자"
-        assert result["rankings"][0]["change_rate"] == 2.5
+        assert result["rankings"][0]["change_rate"] == pytest.approx(2.5)
         assert result["source"] == "kis"
 
     async def test_kr_volume_rank_fallback_to_mksc_shrn_iscd(self, monkeypatch):
@@ -188,7 +188,7 @@ class TestMCPTopStocks:
         assert len(result["rankings"]) == 1
         assert result["rankings"][0]["symbol"] == "900210"
         assert result["rankings"][0]["name"] == "KODEX 200"
-        assert result["rankings"][0]["change_rate"] == 5.0
+        assert result["rankings"][0]["change_rate"] == pytest.approx(5.0)
 
     async def test_kr_market_cap_ranking_fallback_to_mksc_shrn_iscd(self, monkeypatch):
         """market_cap 랭킹에서 mksc_shrn_iscd fallback 테스트"""
@@ -269,7 +269,7 @@ class TestMCPTopStocks:
 
         assert result["ranking_type"] == "gainers"
         assert len(result["rankings"]) == 1
-        assert result["rankings"][0]["change_rate"] == 5.0
+        assert result["rankings"][0]["change_rate"] == pytest.approx(5.0)
 
     async def test_kr_losers_routing(self, monkeypatch):
         tools = build_tools()
@@ -296,7 +296,7 @@ class TestMCPTopStocks:
 
         assert result["ranking_type"] == "losers"
         assert len(result["rankings"]) == 1
-        assert result["rankings"][0]["change_rate"] == -3.0
+        assert result["rankings"][0]["change_rate"] == pytest.approx(-3.0)
 
     async def test_kr_foreigners_routing(self, monkeypatch):
         tools = build_tools()
@@ -616,7 +616,7 @@ class TestMCPTopStocks:
         assert result["ranking_type"] == "gainers"
         assert len(result["rankings"]) == 2
         assert result["rankings"][0]["symbol"] == "KRW-ETH"
-        assert result["rankings"][0]["change_rate"] == 5.0
+        assert result["rankings"][0]["change_rate"] == pytest.approx(5.0)
 
     async def test_crypto_rankings_losers_sort(self, monkeypatch):
         tools = build_tools()
@@ -652,7 +652,7 @@ class TestMCPTopStocks:
         assert result["ranking_type"] == "losers"
         assert len(result["rankings"]) == 2
         assert result["rankings"][0]["symbol"] == "KRW-BTC"
-        assert result["rankings"][0]["change_rate"] == -1.0
+        assert result["rankings"][0]["change_rate"] == pytest.approx(-1.0)
 
     async def test_crypto_ratio_to_percent_conversion(self, monkeypatch):
         tools = build_tools()
@@ -678,7 +678,7 @@ class TestMCPTopStocks:
             market="crypto", ranking_type="volume", limit=1
         )
 
-        assert result["rankings"][0]["change_rate"] == 2.5
+        assert result["rankings"][0]["change_rate"] == pytest.approx(2.5)
 
     async def test_upstream_exception_returns_error_payload(self, monkeypatch):
         tools = build_tools()
@@ -752,12 +752,12 @@ class TestMCPTopStocks:
         assert result["rankings"][0]["symbol"] == "005930"
         assert result["rankings"][0]["name"] == "삼성전자"
         assert result["rankings"][0]["volume"] == 5000000
-        assert result["rankings"][0]["trade_amount"] == 400000000000.0
+        assert result["rankings"][0]["trade_amount"] == pytest.approx(400000000000.0)
 
         assert result["rankings"][1]["symbol"] == "005380"
         assert result["rankings"][1]["name"] == "LG전자"
         assert result["rankings"][1]["volume"] == 3000000
-        assert result["rankings"][1]["trade_amount"] == 360000000000.0
+        assert result["rankings"][1]["trade_amount"] == pytest.approx(360000000000.0)
 
 
 @pytest.mark.asyncio
@@ -798,8 +798,8 @@ class TestMCPLosers:
         assert result["ranking_type"] == "losers"
         assert len(result["rankings"]) == 2
         assert all(float(r["change_rate"]) < 0 for r in result["rankings"])
-        assert float(result["rankings"][0]["change_rate"]) == -3.0
-        assert float(result["rankings"][1]["change_rate"]) == -2.0
+        assert float(result["rankings"][0]["change_rate"]) == pytest.approx(-3.0)
+        assert float(result["rankings"][1]["change_rate"]) == pytest.approx(-2.0)
 
     async def test_get_top_stocks_kr_gainers_returns_positives(self, monkeypatch):
         tools = build_tools()
@@ -932,7 +932,7 @@ class TestMCPRegressionTests:
         assert result["ranking_type"] == "gainers"
         assert len(result["rankings"]) == 2
         assert result["rankings"][0]["symbol"] == "005930"
-        assert float(result["rankings"][0]["change_rate"]) == 5.0
+        assert float(result["rankings"][0]["change_rate"]) == pytest.approx(5.0)
 
     async def test_us_losers_unchanged(self, monkeypatch):
         """US losers should return only negatives, sorted by change_rate ascending"""
@@ -1009,6 +1009,10 @@ class TestMCPRegressionTests:
         assert len(result["rankings"]) == 2
         # Sorted by change_rate ascending: -0.02 before -0.01
         assert result["rankings"][0]["symbol"] == "KRW-ETH"
-        assert result["rankings"][0]["change_rate"] == -2.0  # -0.02 * 100
+        assert result["rankings"][0]["change_rate"] == pytest.approx(
+            -2.0
+        )  # -0.02 * 100
         assert result["rankings"][1]["symbol"] == "KRW-BTC"
-        assert result["rankings"][1]["change_rate"] == -1.0  # -0.01 * 100
+        assert result["rankings"][1]["change_rate"] == pytest.approx(
+            -1.0
+        )  # -0.01 * 100

--- a/tests/test_n8n_crypto_scan_service.py
+++ b/tests/test_n8n_crypto_scan_service.py
@@ -385,7 +385,7 @@ class TestFetchCryptoScan:
         btc = next(c for c in result["coins"] if c["symbol"] == "KRW-BTC")
         assert btc["crash"] is not None
         assert btc["crash"]["triggered"] is True
-        assert btc["crash"]["threshold"] == 0.06  # top 10 threshold
+        assert btc["crash"]["threshold"] == pytest.approx(0.06)  # top 10 threshold
 
     @pytest.mark.asyncio
     async def test_sma_cross_detection(self) -> None:

--- a/tests/test_n8n_kr_morning_report.py
+++ b/tests/test_n8n_kr_morning_report.py
@@ -118,7 +118,7 @@ async def test_fetch_kr_morning_report_groups_kis_and_toss_kr_holdings():
     assert result["holdings"]["kis"]["total_count"] == 1
     assert result["holdings"]["toss"]["total_count"] == 1
     assert result["holdings"]["combined"]["total_count"] == 2
-    assert result["cash_balance"]["kis_krw"] == 45000.0
+    assert result["cash_balance"]["kis_krw"] == pytest.approx(45000.0)
     assert result["cash_balance"]["toss_krw"] is None
     assert result["cash_balance"]["toss_krw_fmt"] == "수동 관리"
 
@@ -474,7 +474,7 @@ async def test_fetch_kr_morning_report_default_screening_uses_oversold_semantics
     kwargs = screen_mock.await_args.kwargs
     assert kwargs["sort_by"] == "rsi"
     assert kwargs["sort_order"] == "asc"
-    assert kwargs["max_rsi"] == 30.0
+    assert kwargs["max_rsi"] == pytest.approx(30.0)
 
 
 @pytest.mark.asyncio
@@ -501,7 +501,7 @@ async def test_fetch_kr_morning_report_explicit_oversold_matches_default_semanti
     kwargs = screen_mock.await_args.kwargs
     assert kwargs["sort_by"] == "rsi"
     assert kwargs["sort_order"] == "asc"
-    assert kwargs["max_rsi"] == 30.0
+    assert kwargs["max_rsi"] == pytest.approx(30.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_n8n_market_context.py
+++ b/tests/test_n8n_market_context.py
@@ -148,8 +148,10 @@ class TestMarketContextEndpoint:
             assert response.status_code == 200
             data = response.json()
 
-            assert data["market_overview"]["btc_dominance"] == 61.5
-            assert data["market_overview"]["total_market_cap_change_24h"] == 2.3
+            assert data["market_overview"]["btc_dominance"] == pytest.approx(61.5)
+            assert data["market_overview"][
+                "total_market_cap_change_24h"
+            ] == pytest.approx(2.3)
 
     @pytest.mark.integration
     @pytest.mark.asyncio
@@ -485,8 +487,8 @@ class TestBtcDominanceService:
         ):
             result = await fetch_btc_dominance()
             assert result is not None
-            assert result["btc_dominance"] == 61.2
-            assert result["total_market_cap_change_24h"] == 2.3
+            assert result["btc_dominance"] == pytest.approx(61.2)
+            assert result["total_market_cap_change_24h"] == pytest.approx(2.3)
 
     @pytest.mark.asyncio
     async def test_fetch_btc_dominance_handles_error(self) -> None:

--- a/tests/test_number_utils.py
+++ b/tests/test_number_utils.py
@@ -16,8 +16,8 @@ class TestParseKoreanNumber:
         assert parse_korean_number("1,234,567") == 1234567
 
     def test_simple_float(self) -> None:
-        assert parse_korean_number("12.34") == 12.34
-        assert parse_korean_number("1,234.56") == 1234.56
+        assert parse_korean_number("12.34") == pytest.approx(12.34)
+        assert parse_korean_number("1,234.56") == pytest.approx(1234.56)
 
     def test_percentage(self) -> None:
         result = parse_korean_number("5.67%")
@@ -51,7 +51,7 @@ class TestParseKoreanNumber:
 
     def test_negative_number_with_minus(self) -> None:
         assert parse_korean_number("-1,234") == -1234
-        assert parse_korean_number("-5.67") == -5.67
+        assert parse_korean_number("-5.67") == pytest.approx(-5.67)
 
     def test_negative_number_with_arrow(self) -> None:
         assert parse_korean_number("▼1,234") == -1234

--- a/tests/test_paper_order_handler.py
+++ b/tests/test_paper_order_handler.py
@@ -85,7 +85,7 @@ class TestPlacePaperOrderDryRun:
         service.create_account.assert_awaited_once()
         call_kwargs = service.create_account.await_args.kwargs
         assert call_kwargs["name"] == "default"
-        assert call_kwargs["initial_capital_krw"] == Decimal("100000000")
+        assert call_kwargs["initial_capital_krw"] == pytest.approx(Decimal("100000000"))
         service.preview_order.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -263,7 +263,7 @@ class TestPlacePaperOrderExecute:
         assert result["account_type"] == "paper"
         assert result["paper_account"] == "default"
         assert result["preview"]["symbol"] == "005930"
-        assert result["execution"]["quantity"] == Decimal("10")
+        assert result["execution"]["quantity"] == pytest.approx(Decimal("10"))
         assert result["message"] == "[Paper] Order placed successfully"
         service.execute_order.assert_awaited_once()
         kwargs = service.execute_order.await_args.kwargs

--- a/tests/test_paper_trading_model.py
+++ b/tests/test_paper_trading_model.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from decimal import Decimal
 
+import pytest
+
 from app.models.paper_trading import PaperAccount, PaperPosition, PaperTrade
 from app.models.trading import InstrumentType
 
@@ -17,8 +19,8 @@ class TestPaperAccountModel:
             cash_krw=Decimal("10000000"),
         )
         assert account.name == "기본 모의계좌"
-        assert account.initial_capital == Decimal("10000000")
-        assert account.cash_krw == Decimal("10000000")
+        assert account.initial_capital == pytest.approx(Decimal("10000000"))
+        assert account.cash_krw == pytest.approx(Decimal("10000000"))
 
     def test_create_full_account(self) -> None:
         account = PaperAccount(
@@ -53,7 +55,7 @@ class TestPaperPositionModel:
         assert position.account_id == 1
         assert position.symbol == "KRW-BTC"
         assert position.instrument_type == InstrumentType.crypto
-        assert position.quantity == Decimal("0.00123456")
+        assert position.quantity == pytest.approx(Decimal("0.00123456"))
 
     def test_table_args(self) -> None:
         assert PaperPosition.__table_args__[-1] == {"schema": "paper"}
@@ -95,7 +97,7 @@ class TestPaperTradeModel:
             realized_pnl=Decimal("244.12"),
             executed_at=datetime.now(UTC),
         )
-        assert trade.realized_pnl == Decimal("244.12")
+        assert trade.realized_pnl == pytest.approx(Decimal("244.12"))
 
     def test_table_args(self) -> None:
         assert PaperTrade.__table_args__[-1] == {"schema": "paper"}
@@ -118,5 +120,5 @@ def test_paper_daily_snapshot_constructor() -> None:
         daily_return_pct=Decimal("0.25"),
     )
     assert snap.account_id == 1
-    assert snap.total_equity == Decimal("1500000")
-    assert snap.daily_return_pct == Decimal("0.25")
+    assert snap.total_equity == pytest.approx(Decimal("1500000"))
+    assert snap.daily_return_pct == pytest.approx(Decimal("0.25"))

--- a/tests/test_portfolio_position_detail_router.py
+++ b/tests/test_portfolio_position_detail_router.py
@@ -223,7 +223,7 @@ def test_position_detail_indicators_api_returns_payload() -> None:
     response = client.get("/portfolio/api/positions/us/NVDA/indicators")
 
     assert response.status_code == 200
-    assert response.json()["indicators"]["rsi"]["14"] == 28.4
+    assert response.json()["indicators"]["rsi"]["14"] == pytest.approx(28.4)
 
 
 @pytest.mark.unit
@@ -252,8 +252,8 @@ def test_position_detail_orders_api_returns_payload() -> None:
     assert response.status_code == 200
     data = response.json()
     assert data["summary"]["pending_count"] == 1
-    assert data["recent_fills"][0]["amount"] == 455.5
-    assert data["pending_orders"][0]["remaining_quantity"] == 1.5
+    assert data["recent_fills"][0]["amount"] == pytest.approx(455.5)
+    assert data["pending_orders"][0]["remaining_quantity"] == pytest.approx(1.5)
 
 
 @pytest.mark.unit

--- a/tests/test_research_run_decision_session_schemas.py
+++ b/tests/test_research_run_decision_session_schemas.py
@@ -117,9 +117,11 @@ def test_live_refresh_snapshot_round_trips_decimal_as_string():
     round_tripped = LiveRefreshSnapshot.model_validate_json(json_payload)
 
     assert round_tripped == snapshot
-    assert round_tripped.quote_by_symbol["AAPL"].price == Decimal("123.4500")
-    assert round_tripped.cash_balances["USD"] == Decimal("1000.75")
-    assert round_tripped.holdings_by_symbol["AAPL"] == Decimal("3.500")
+    assert round_tripped.quote_by_symbol["AAPL"].price == pytest.approx(
+        Decimal("123.4500")
+    )
+    assert round_tripped.cash_balances["USD"] == pytest.approx(Decimal("1000.75"))
+    assert round_tripped.holdings_by_symbol["AAPL"] == pytest.approx(Decimal("3.500"))
 
 
 @pytest.mark.unit

--- a/tests/test_screening_common.py
+++ b/tests/test_screening_common.py
@@ -194,7 +194,9 @@ class TestFilterByMinAnalystBuy:
         from app.mcp_server.tooling.screening.common import _filter_by_min_analyst_buy
 
         stocks = [{"analyst_buy": 5}, {"analyst_buy": 1}]
-        assert _filter_by_min_analyst_buy(stocks, None) is stocks
+        # NOSONAR python:S5796 — intentionally testing object identity:
+        # function should return the same list (no copy) when threshold is None.
+        assert _filter_by_min_analyst_buy(stocks, None) is stocks  # NOSONAR
 
     def test_filters_below_threshold(self):
         from app.mcp_server.tooling.screening.common import _filter_by_min_analyst_buy

--- a/tests/test_screenshot_holdings_service_resolution.py
+++ b/tests/test_screenshot_holdings_service_resolution.py
@@ -242,7 +242,7 @@ async def test_avg_buy_price_direct_input(
 
     assert result["success"] is True
     holding = result["holdings"][0]
-    assert holding["avg_buy_price"] == 3500000.0
+    assert holding["avg_buy_price"] == pytest.approx(3500000.0)
     assert holding["resolution_method"] == "direct"
 
 
@@ -270,7 +270,7 @@ async def test_avg_buy_price_calculated_from_eval_profit_qty(
 
     assert result["success"] is True
     holding = result["holdings"][0]
-    assert holding["avg_buy_price"] == 2900000.0
+    assert holding["avg_buy_price"] == pytest.approx(2900000.0)
 
 
 @pytest.mark.asyncio
@@ -654,7 +654,7 @@ async def test_calculate_avg_buy_price_zero_quantity(service):
     avg_price = await service._calculate_avg_buy_price(
         eval_amount=1000000, profit_loss=100000, quantity=0
     )
-    assert avg_price == 0.0
+    assert avg_price == pytest.approx(0.0)
 
 
 @pytest.mark.asyncio
@@ -663,7 +663,7 @@ async def test_calculate_avg_buy_price_normal(service):
     avg_price = await service._calculate_avg_buy_price(
         eval_amount=1500000, profit_loss=100000, quantity=10
     )
-    assert avg_price == 140000.0
+    assert avg_price == pytest.approx(140000.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_sentry_init.py
+++ b/tests/test_sentry_init.py
@@ -80,8 +80,8 @@ def test_init_sentry_uses_build_vcs_ref_release_with_fastapi(monkeypatch):
     assert kwargs["dsn"] == "https://public@example.ingest.sentry.io/1"
     assert kwargs["environment"] == "development"
     assert kwargs["release"] == expected_release
-    assert kwargs["traces_sample_rate"] == 1.0
-    assert kwargs["profiles_sample_rate"] == 1.0
+    assert kwargs["traces_sample_rate"] == pytest.approx(1.0)
+    assert kwargs["profiles_sample_rate"] == pytest.approx(1.0)
     assert kwargs["send_default_pii"] is True
     assert kwargs["before_send_transaction"] is sentry_module._before_send_transaction
     mock_run.assert_not_called()

--- a/tests/test_services_kis_client.py
+++ b/tests/test_services_kis_client.py
@@ -123,8 +123,8 @@ class TestKISService:
         with patch.object(client, "_ensure_token"):
             result = await client.inquire_domestic_cash_balance(is_mock=False)
 
-        assert result["dnca_tot_amt"] == 1140000.0
-        assert result["stck_cash_ord_psbl_amt"] == 1110000.0
+        assert result["dnca_tot_amt"] == pytest.approx(1140000.0)
+        assert result["stck_cash_ord_psbl_amt"] == pytest.approx(1110000.0)
         assert result["raw"]["dnca_tot_amt"] == "1140000"
 
         call_args = mock_client.get.call_args
@@ -165,8 +165,8 @@ class TestKISService:
         with patch.object(client, "_ensure_token"):
             result = await client.inquire_domestic_cash_balance(is_mock=False)
 
-        assert result["dnca_tot_amt"] == 1140000.0
-        assert result["stck_cash_ord_psbl_amt"] == 950000.0
+        assert result["dnca_tot_amt"] == pytest.approx(1140000.0)
+        assert result["stck_cash_ord_psbl_amt"] == pytest.approx(950000.0)
 
     @pytest.mark.asyncio
     @patch("app.services.brokers.kis.base.httpx.AsyncClient")
@@ -239,10 +239,10 @@ class TestKISService:
         assert len(result) == 1
         assert result[0]["natn_name"] == "미국"
         assert result[0]["crcy_cd"] == "USD"
-        assert result[0]["frcr_dncl_amt1"] == 5856.2
-        assert result[0]["frcr_ord_psbl_amt1"] == 0.0
-        assert result[0]["frcr_gnrl_ord_psbl_amt"] == 5824.17
-        assert result[0]["itgr_ord_psbl_amt"] == 5824.27
+        assert result[0]["frcr_dncl_amt1"] == pytest.approx(5856.2)
+        assert result[0]["frcr_ord_psbl_amt1"] == pytest.approx(0.0)
+        assert result[0]["frcr_gnrl_ord_psbl_amt"] == pytest.approx(5824.17)
+        assert result[0]["itgr_ord_psbl_amt"] == pytest.approx(5824.27)
 
     @pytest.mark.asyncio
     @patch("app.services.brokers.kis.base.httpx.AsyncClient")
@@ -284,10 +284,10 @@ class TestKISService:
             result = await client.inquire_overseas_margin(is_mock=False)
 
         assert len(result) == 1
-        assert result[0]["frcr_dncl_amt1"] == 0.0
-        assert result[0]["frcr_ord_psbl_amt1"] == 0.0
-        assert result[0]["frcr_gnrl_ord_psbl_amt"] == 0.0
-        assert result[0]["itgr_ord_psbl_amt"] == 0.0
+        assert result[0]["frcr_dncl_amt1"] == pytest.approx(0.0)
+        assert result[0]["frcr_ord_psbl_amt1"] == pytest.approx(0.0)
+        assert result[0]["frcr_gnrl_ord_psbl_amt"] == pytest.approx(0.0)
+        assert result[0]["itgr_ord_psbl_amt"] == pytest.approx(0.0)
 
 
 class TestKISIntegratedMarginParams:
@@ -377,7 +377,7 @@ class TestKISIntegratedMarginParams:
 
         result = await client.inquire_integrated_margin()
 
-        assert result["stck_cash100_max_ord_psbl_amt"] == 3534890.5473
+        assert result["stck_cash100_max_ord_psbl_amt"] == pytest.approx(3534890.5473)
 
     @pytest.mark.asyncio
     @patch("app.services.brokers.kis.base.httpx.AsyncClient")
@@ -430,9 +430,9 @@ class TestKISIntegratedMarginParams:
         second_call_params = mock_client.get.call_args_list[1].kwargs["params"]
         assert second_call_params["CMA_EVLU_AMT_ICLD_YN"] == "Y"
 
-        assert result["dnca_tot_amt"] == 1000000.0
-        assert result["stck_cash_objt_amt"] == 850000.0
-        assert result["stck_itgr_cash100_ord_psbl_amt"] == 800000.0
+        assert result["dnca_tot_amt"] == pytest.approx(1000000.0)
+        assert result["stck_cash_objt_amt"] == pytest.approx(850000.0)
+        assert result["stck_itgr_cash100_ord_psbl_amt"] == pytest.approx(800000.0)
 
     @pytest.mark.asyncio
     @patch("app.services.brokers.kis.base.httpx.AsyncClient")
@@ -468,8 +468,8 @@ class TestKISIntegratedMarginParams:
 
         result = await client.inquire_integrated_margin()
 
-        assert result["stck_cash_objt_amt"] == 0.0
-        assert result["stck_itgr_cash100_ord_psbl_amt"] == 0.0
+        assert result["stck_cash_objt_amt"] == pytest.approx(0.0)
+        assert result["stck_itgr_cash100_ord_psbl_amt"] == pytest.approx(0.0)
 
     def test_extract_domestic_cash_summary_from_integrated_margin(self):
         from app.services.brokers.kis.client import (
@@ -487,8 +487,8 @@ class TestKISIntegratedMarginParams:
             }
         )
 
-        assert summary["balance"] == 777000.0
-        assert summary["orderable"] == 555000.0
+        assert summary["balance"] == pytest.approx(777000.0)
+        assert summary["orderable"] == pytest.approx(555000.0)
         assert summary["raw"]["stck_cash_objt_amt"] == "777000"
 
     def test_extract_domestic_cash_summary_prefers_stck_cash100_max_orderable(self):
@@ -509,8 +509,8 @@ class TestKISIntegratedMarginParams:
             }
         )
 
-        assert summary["balance"] == 5000000.0
-        assert summary["orderable"] == 3534890.5473
+        assert summary["balance"] == pytest.approx(5000000.0)
+        assert summary["orderable"] == pytest.approx(3534890.5473)
 
     def test_extract_domestic_cash_summary_falls_back_to_stck_cash_ord_psbl_amt(self):
         from app.services.brokers.kis.client import (
@@ -528,7 +528,7 @@ class TestKISIntegratedMarginParams:
             }
         )
 
-        assert summary["orderable"] == 2100000.25
+        assert summary["orderable"] == pytest.approx(2100000.25)
 
     def test_extract_domestic_cash_summary_skips_zero_priority_orderables_for_lower_positive(
         self,
@@ -552,8 +552,8 @@ class TestKISIntegratedMarginParams:
             }
         )
 
-        assert summary["balance"] == 5000000.0
-        assert summary["orderable"] == 2100000.25
+        assert summary["balance"] == pytest.approx(5000000.0)
+        assert summary["orderable"] == pytest.approx(2100000.25)
 
     def test_extract_domestic_cash_summary_returns_zero_when_all_orderables_zero(self):
         from app.services.brokers.kis.client import (
@@ -575,8 +575,8 @@ class TestKISIntegratedMarginParams:
             }
         )
 
-        assert summary["balance"] == 0.0
-        assert summary["orderable"] == 0.0
+        assert summary["balance"] == pytest.approx(0.0)
+        assert summary["orderable"] == pytest.approx(0.0)
 
     def test_extract_domestic_cash_summary_falls_back_to_stck_cash_objt_amt(self):
         from app.services.brokers.kis.client import (
@@ -592,4 +592,4 @@ class TestKISIntegratedMarginParams:
             }
         )
 
-        assert summary["orderable"] == 5000000.0
+        assert summary["orderable"] == pytest.approx(5000000.0)

--- a/tests/test_services_kis_market_data.py
+++ b/tests/test_services_kis_market_data.py
@@ -62,7 +62,7 @@ class TestKISOverseasDailyPrice:
             "close",
             "volume",
         ]
-        assert float(result.iloc[-1]["close"]) == 193.8
+        assert float(result.iloc[-1]["close"]) == pytest.approx(193.8)
 
         params = mock_client.get.call_args.kwargs["params"]
         assert params["GUBN"] == "0"
@@ -1428,7 +1428,7 @@ class TestBuildOhlcvDataframe:
             "value",
         ]
         assert df.iloc[0]["datetime"] == pd.Timestamp("2026-02-19 10:00:00")
-        assert df.iloc[0]["close"] == 70100.0
+        assert df.iloc[0]["close"] == pytest.approx(70100.0)
         assert df.iloc[0]["volume"] == 100
 
     def test_deduplicates_by_datetime(self):
@@ -1606,5 +1606,5 @@ class TestBuildOhlcvDataframe:
 
         assert len(df) == 2
         assert df.iloc[0]["datetime"] == pd.Timestamp("2026-02-19 09:30:00")
-        assert df.iloc[0]["close"] == 180.5
+        assert df.iloc[0]["close"] == pytest.approx(180.5)
         assert df.iloc[1]["volume"] == 80

--- a/tests/test_services_krx.py
+++ b/tests/test_services_krx.py
@@ -322,7 +322,7 @@ class TestKRXChangeRate:
         result = await krx.fetch_stock_all(market="STK")
 
         assert len(result) == 1
-        assert result[0]["change_rate"] == 2.5
+        assert result[0]["change_rate"] == pytest.approx(2.5)
         assert result[0]["change_price"] == 2000
 
     @pytest.mark.asyncio
@@ -361,7 +361,7 @@ class TestKRXChangeRate:
         result = await krx.fetch_stock_all(market="STK")
 
         assert len(result) == 1
-        assert result[0]["change_rate"] == -1.2
+        assert result[0]["change_rate"] == pytest.approx(-1.2)
         assert result[0]["change_price"] == -1800
 
     @pytest.mark.asyncio
@@ -400,8 +400,8 @@ class TestKRXChangeRate:
         result = await krx.fetch_stock_all(market="STK")
 
         assert len(result) == 1
-        assert result[0]["change_rate"] == 0.0
-        assert result[0]["change_price"] == 0.0
+        assert result[0]["change_rate"] == pytest.approx(0.0)
+        assert result[0]["change_price"] == pytest.approx(0.0)
 
     @pytest.mark.asyncio
     async def test_etf_parse_change_rate_positive(self, monkeypatch):
@@ -438,7 +438,7 @@ class TestKRXChangeRate:
         result = await krx.fetch_etf_all()
 
         assert len(result) == 1
-        assert result[0]["change_rate"] == 1.5
+        assert result[0]["change_rate"] == pytest.approx(1.5)
         assert result[0]["change_price"] == 700
 
 
@@ -491,18 +491,18 @@ class TestKRXValuation:
         result = await krx.fetch_valuation_all(market="ALL")
 
         assert len(result) == 3
-        assert result["005930"]["per"] == 12.5
-        assert result["005930"]["pbr"] == 1.2
+        assert result["005930"]["per"] == pytest.approx(12.5)
+        assert result["005930"]["pbr"] == pytest.approx(1.2)
         assert result["005930"]["eps"] == 6400
         assert result["005930"]["bps"] == 66000
-        assert result["005930"]["dividend_yield"] == 0.0256
+        assert result["005930"]["dividend_yield"] == pytest.approx(0.0256)
         assert result["000660"]["per"] is None
         assert result["000660"]["pbr"] is None
         assert result["035420"]["per"] is None
-        assert result["035420"]["pbr"] == 0.8
+        assert result["035420"]["pbr"] == pytest.approx(0.8)
         assert result["035420"]["eps"] == 12000
         assert result["035420"]["bps"] == 80000
-        assert result["035420"]["dividend_yield"] == 0.035
+        assert result["035420"]["dividend_yield"] == pytest.approx(0.035)
 
     @pytest.mark.asyncio
     async def test_valuation_cache_key_format(self, monkeypatch):
@@ -838,7 +838,7 @@ class TestKRXValuationCacheRecovery:
         result = await krx.fetch_valuation_all(market="ALL")
 
         assert "005930" in result
-        assert result["005930"]["per"] == 12.5
+        assert result["005930"]["per"] == pytest.approx(12.5)
 
     @pytest.mark.asyncio
     async def test_valuation_cache_new_format_with_isu_srt_cd(self, monkeypatch):
@@ -880,7 +880,7 @@ class TestKRXValuationCacheRecovery:
         assert len(result) == 2
         assert "005930" in result
         assert "000660" in result
-        assert result["005930"]["per"] == 12.5
+        assert result["005930"]["per"] == pytest.approx(12.5)
         assert not fetch_called, "Should use cache, not call API"
 
     @pytest.mark.asyncio
@@ -919,7 +919,7 @@ class TestKRXValuationCacheRecovery:
         cached_entry = captured_cache_data[0]  # NOSONAR
         assert isinstance(cached_entry, dict)
         assert cached_entry["ISU_SRT_CD"] == "005930"
-        assert cached_entry["per"] == 12.5
+        assert cached_entry["per"] == pytest.approx(12.5)
 
 
 class TestGetStockNameByCode:

--- a/tests/test_services_upbit.py
+++ b/tests/test_services_upbit.py
@@ -149,8 +149,8 @@ class TestUpbitService:
 
         summary = await upbit_service_module.fetch_krw_cash_summary()
 
-        assert summary["balance"] == 700000.0
-        assert summary["orderable"] == 500000.0
+        assert summary["balance"] == pytest.approx(700000.0)
+        assert summary["orderable"] == pytest.approx(500000.0)
         assert summary["balance"] == summary["orderable"] + 200000.0
 
     @pytest.mark.asyncio
@@ -166,7 +166,7 @@ class TestUpbitService:
 
         result = await upbit_service_module.fetch_krw_orderable_balance()
 
-        assert result == 500000.0
+        assert result == pytest.approx(500000.0)
         mock_summary.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/test_symbol_trade_settings.py
+++ b/tests/test_symbol_trade_settings.py
@@ -101,7 +101,7 @@ class TestCalculateEstimatedOrderCost:
         )
 
         # USD는 소수점 유지
-        assert result["buy_prices"][0]["quantity"] == 2.5
+        assert result["buy_prices"][0]["quantity"] == pytest.approx(2.5)
 
 
 class TestSymbolTradeSettingsService:
@@ -306,7 +306,7 @@ class TestGetBuyQuantityFunctions:
                 fallback_amount=100000,
             )
 
-            assert result == 0.001
+            assert result == pytest.approx(0.001)
 
     @pytest.mark.asyncio
     async def test_get_buy_quantity_for_crypto_without_settings(self):

--- a/tests/test_trade_journal_model.py
+++ b/tests/test_trade_journal_model.py
@@ -45,8 +45,8 @@ class TestTradeJournalModel:
             account="kis",
         )
         assert journal.strategy == "momentum"
-        assert journal.target_price == Decimal("200.00")
-        assert journal.stop_loss == Decimal("160.00")
+        assert journal.target_price == pytest.approx(Decimal("200.00"))
+        assert journal.stop_loss == pytest.approx(Decimal("160.00"))
         assert journal.min_hold_days == 14
         assert journal.indicators_snapshot == {"rsi_14": 42, "adx": 25}
 

--- a/tests/test_tvscreener_crypto.py
+++ b/tests/test_tvscreener_crypto.py
@@ -243,7 +243,7 @@ async def test_screen_crypto_via_tvscreener_uses_upbit_value_traded_contract(
     assert [item["symbol"] for item in result["results"]] == ["KRW-ETH", "KRW-BTC"]
     assert result["results"][0]["trade_amount_24h"] == 1_200_000_000_000.0
     assert result["results"][0]["volume_24h"] == 9_500.0
-    assert result["results"][0]["adx"] == 18.7
+    assert result["results"][0]["adx"] == pytest.approx(18.7)
     assert result["results"][0]["market_cap"] == 1_200_000_000_000_000.0
 
 
@@ -326,7 +326,7 @@ async def test_screen_crypto_via_tvscreener_prefers_value_traded_over_usd_volume
     first = result["results"][0]
     assert first["symbol"] == "KRW-BTC"
     assert first["trade_amount_24h"] == 900_000_000_000.0
-    assert first["volume_24h"] == 777.0
+    assert first["volume_24h"] == pytest.approx(777.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_upbit_service.py
+++ b/tests/test_upbit_service.py
@@ -37,7 +37,7 @@ async def test_fetch_multiple_tickers_keeps_comma_unescaped(monkeypatch):
 def test_get_upbit_rate_limit_candles_wildcard_is_fixed():
     rate, period = upbit._get_upbit_rate_limit(upbit.UPBIT_CANDLES_RATE_LIMIT_KEY)
     assert rate == 10
-    assert period == 1.0
+    assert period == pytest.approx(1.0)
 
 
 @pytest.mark.parametrize(
@@ -115,7 +115,7 @@ async def test_request_json_uses_candles_wildcard_limiter_key(monkeypatch):
     assert captured["provider"] == "upbit"
     assert captured["api_key"] == upbit.UPBIT_CANDLES_RATE_LIMIT_KEY
     assert captured["rate"] == 10
-    assert captured["period"] == 1.0
+    assert captured["period"] == pytest.approx(1.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_watch_scanner.py
+++ b/tests/test_watch_scanner.py
@@ -290,9 +290,9 @@ async def test_get_price_and_rsi_use_market_specific_sources(
         watch_scanner_module.market_data_service, "get_ohlcv", mock_get_ohlcv
     )
 
-    assert await scanner._get_price("005930", "kr") == 55000.0
-    assert await scanner._get_price("AMZN", "us") == 190.0
-    assert await scanner._get_price("BTC", "crypto") == 91000000.0
+    assert await scanner._get_price("005930", "kr") == pytest.approx(55000.0)
+    assert await scanner._get_price("AMZN", "us") == pytest.approx(190.0)
+    assert await scanner._get_price("BTC", "crypto") == pytest.approx(91000000.0)
 
     kr_rsi = await scanner._get_rsi("005930", "kr")
     us_rsi = await scanner._get_rsi("AMZN", "us")
@@ -483,7 +483,7 @@ async def test_watch_scanner_uses_market_data_domain_service(
         raising=False,
     )
 
-    assert await scanner._get_price("BTC", "crypto") == 91000000.0
+    assert await scanner._get_price("BTC", "crypto") == pytest.approx(91000000.0)
     assert await scanner._get_rsi("BTC", "crypto") is not None
 
     domain_get_quote.assert_awaited_once_with(symbol="KRW-BTC", market="crypto")


### PR DESCRIPTION
## Summary

SonarCloud Quality Gate cleanup — 잔여 575 S1244 + 1 S5796 일괄 처리.

Phase 3 스캔 이후에도 main의 새 코드 기간 scan은 575건의 python:S1244 (MAJOR float `==`) 가 남아 있어 Reliability Rating C로 표시되고 있었습니다. 원인:
1. Phase 3 이후 추가된 새 테스트 파일들에 동일 패턴 존재
2. Phase 3의 21-file scope 밖에 있던 파일들

이 PR은 transformer를 \`tests/\` 트리 전체에 재실행해 누락 사이트를 일괄 처리합니다.

## Changes

### 1. 283 S1244 사이트 — \`pytest.approx()\` 일괄 래핑 (42 files)

신규/누락된 파일 포함, \`assert <expr> == <float|Decimal(...)>\` 형태를 모두 \`pytest.approx()\`로 래핑.

주요 파일:
- \`test_portfolio_dashboard_service.py\` (13건)
- \`test_portfolio_position_detail_service.py\` (11건)
- \`test_kr_hourly_candles_read_service.py\` (11건)
- \`test_paper_account_tools.py\` (8건)
- \`test_portfolio_position_detail_router.py\` (3건)
- ... 그 외 37개 파일

### 2. python:S5796 false positive (1 site)

\`tests/test_screening_common.py:197\`:
\`\`\`python
assert _filter_by_min_analyst_buy(stocks, None) is stocks
\`\`\`
이 \`is\` 비교는 \"동일 list 객체를 그대로 반환하는지(복사 안 하는지)\" 를 검증하는 의도. \`==\`로 바꾸면 테스트 의미가 사라짐. NOSONAR 주석으로 suppress.

## Test plan

- [x] \`uv run pytest <43 changed files>\` — 1057 pass, 1 skipped
- [x] \`uv run ruff format\` 적용 (5 reformatted)
- [x] \`uv run ruff check\` 통과 (1 import-order auto-fix)
- [ ] (수동) main 머지 후 SonarCloud 새 코드 기간 Reliability=A 확인

## Quality Gate 진행 상황

| 조건 | Phase 5 후 | Phase 6 후 (예상) |
|---|---|---|
| Reliability Rating | C (575 MAJOR) | **A** ✓ |
| Duplications 3.86% (≤ 3.0%) | ❌ | ❌ 별도 작업 |
| Hotspots Reviewed (≥ 100%) | 14.9% (진행중) | (사용자 진행중) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>