### PR TITLE
fix(quality): wrap residual S1244 sites with underscore literals (Phase 7)

### DIFF
--- a/tests/_mcp_screen_stocks_support.py
+++ b/tests/_mcp_screen_stocks_support.py
@@ -265,8 +265,8 @@ class TestScreenStocksKRRegression:
         )
 
         assert result["returned_count"] == 2
-        assert result["results"][0]["change_rate"] == 2.5
-        assert result["results"][-1]["change_rate"] == -1.2
+        assert result["results"][0]["change_rate"] == pytest.approx(2.5)
+        assert result["results"][-1]["change_rate"] == pytest.approx(-1.2)
 
     @pytest.mark.asyncio
     async def test_submarket_routing_kospi_and_kosdaq(self, monkeypatch):
@@ -398,9 +398,9 @@ class TestScreenStocksKRRegression:
         )
 
         merged = {item["code"]: item for item in result["results"]}
-        assert merged["005930"]["per"] == 12.5
-        assert merged["005930"]["pbr"] == 1.2
-        assert merged["005930"]["dividend_yield"] == 0.0256
+        assert merged["005930"]["per"] == pytest.approx(12.5)
+        assert merged["005930"]["pbr"] == pytest.approx(1.2)
+        assert merged["005930"]["dividend_yield"] == pytest.approx(0.0256)
         assert merged["000660"]["per"] is None
         assert merged["000660"]["pbr"] is None
         assert merged["000660"]["dividend_yield"] is None
@@ -713,19 +713,19 @@ class TestScreenStocksTvScreenerContract:
         assert result["total_count"] == 3
         assert result["returned_count"] == 1
         assert result["results"][0]["code"] == "005930"
-        assert result["results"][0]["close"] == 70000.0
-        assert result["results"][0]["change_rate"] == 2.5
+        assert result["results"][0]["close"] == pytest.approx(70000.0)
+        assert result["results"][0]["change_rate"] == pytest.approx(2.5)
         assert result["results"][0]["market"] == "KOSPI"
         assert result["results"][0]["market_cap"] == 4800000
-        assert result["results"][0]["per"] == 12.5
-        assert result["results"][0]["pbr"] == 1.2
-        assert result["results"][0]["dividend_yield"] == 0.0256
-        assert result["results"][0]["adx"] == 24.8
+        assert result["results"][0]["per"] == pytest.approx(12.5)
+        assert result["results"][0]["pbr"] == pytest.approx(1.2)
+        assert result["results"][0]["dividend_yield"] == pytest.approx(0.0256)
+        assert result["results"][0]["adx"] == pytest.approx(24.8)
         assert result["filters_applied"]["sort_order"] == "desc"
         assert result["filters_applied"]["min_market_cap"] == 300000
-        assert result["filters_applied"]["max_per"] == 15.0
-        assert result["filters_applied"]["max_pbr"] == 2.0
-        assert result["filters_applied"]["min_dividend_yield"] == 0.02
+        assert result["filters_applied"]["max_per"] == pytest.approx(15.0)
+        assert result["filters_applied"]["max_pbr"] == pytest.approx(2.0)
+        assert result["filters_applied"]["min_dividend_yield"] == pytest.approx(0.02)
         assert result["meta"]["source"] == "tvscreener"
         assert result["meta"]["rsi_enrichment"]["error_samples"] == []
 
@@ -789,17 +789,17 @@ class TestScreenStocksTvScreenerContract:
         assert result["total_count"] == 4
         assert result["returned_count"] == 1
         assert result["results"][0]["code"] == "AAPL"
-        assert result["results"][0]["close"] == 175.5
-        assert result["results"][0]["change_rate"] == 1.2
+        assert result["results"][0]["close"] == pytest.approx(175.5)
+        assert result["results"][0]["change_rate"] == pytest.approx(1.2)
         assert result["results"][0]["market"] == "us"
         assert result["results"][0]["market_cap"] == 2800000000000
-        assert result["results"][0]["per"] == 28.5
-        assert result["results"][0]["dividend_yield"] == 0.005
-        assert result["results"][0]["adx"] == 31.4
+        assert result["results"][0]["per"] == pytest.approx(28.5)
+        assert result["results"][0]["dividend_yield"] == pytest.approx(0.005)
+        assert result["results"][0]["adx"] == pytest.approx(31.4)
         assert result["filters_applied"]["sort_order"] == "asc"
         assert result["filters_applied"]["min_market_cap"] == 1000000000
-        assert result["filters_applied"]["max_per"] == 30.0
-        assert result["filters_applied"]["min_dividend_yield"] == 0.004
+        assert result["filters_applied"]["max_per"] == pytest.approx(30.0)
+        assert result["filters_applied"]["min_dividend_yield"] == pytest.approx(0.004)
         assert result["meta"]["source"] == "tvscreener"
 
     @pytest.mark.asyncio
@@ -861,8 +861,8 @@ class TestScreenStocksTvScreenerContract:
         )
 
         assert result["meta"]["source"] == "tvscreener"
-        assert result["results"][0]["rsi"] == 41.2
-        assert result["results"][0]["adx"] == 23.5
+        assert result["results"][0]["rsi"] == pytest.approx(41.2)
+        assert result["results"][0]["adx"] == pytest.approx(23.5)
         assert result["meta"]["rsi_enrichment"]["error_samples"] == []
 
     @pytest.mark.asyncio
@@ -922,7 +922,7 @@ class TestScreenStocksTvScreenerContract:
         )
 
         assert result["meta"]["source"] == "tvscreener"
-        assert result["results"][0]["adx"] == 31.4
+        assert result["results"][0]["adx"] == pytest.approx(31.4)
 
     @pytest.mark.asyncio
     async def test_kr_tvscreener_enriched_rows_preserve_sector_and_analyst_fields(
@@ -1111,8 +1111,8 @@ class TestScreenStocksTvScreenerContract:
         assert first["analyst_buy"] == 18
         assert first["analyst_hold"] == 4
         assert first["analyst_sell"] == 1
-        assert first["avg_target"] == 210.0
-        assert first["upside_pct"] == 19.66
+        assert first["avg_target"] == pytest.approx(210.0)
+        assert first["upside_pct"] == pytest.approx(19.66)
 
     @pytest.mark.asyncio
     async def test_us_enrichment_fallback_only_runs_for_rows_missing_tvscreener_fields(
@@ -1168,13 +1168,13 @@ class TestScreenStocksTvScreenerContract:
         assert fetch_enrichment.await_args.args[0] == "MSFT"
         assert rows[0]["sector"] == "Technology"
         assert rows[0]["analyst_buy"] == 20
-        assert rows[0]["avg_target"] == 225.0
+        assert rows[0]["avg_target"] == pytest.approx(225.0)
         assert rows[1]["sector"] == "Software"
         assert rows[1]["analyst_buy"] == 16
         assert rows[1]["analyst_hold"] == 5
         assert rows[1]["analyst_sell"] == 1
-        assert rows[1]["avg_target"] == 470.0
-        assert rows[1]["upside_pct"] == 14.63
+        assert rows[1]["avg_target"] == pytest.approx(470.0)
+        assert rows[1]["upside_pct"] == pytest.approx(14.63)
 
     @pytest.mark.asyncio
     async def test_us_enrichment_fallback_preserves_existing_tvscreener_values(
@@ -1221,8 +1221,8 @@ class TestScreenStocksTvScreenerContract:
         assert rows[0]["analyst_buy"] == 18
         assert rows[0]["analyst_hold"] == 4
         assert rows[0]["analyst_sell"] == 1
-        assert rows[0]["avg_target"] == 220.0
-        assert rows[0]["upside_pct"] == 10.0
+        assert rows[0]["avg_target"] == pytest.approx(220.0)
+        assert rows[0]["upside_pct"] == pytest.approx(10.0)
 
     @pytest.mark.asyncio
     async def test_us_category_preserves_acronym_case_for_tvscreener_filter(
@@ -1386,7 +1386,7 @@ class TestScreenStocksTvScreenerContract:
         async def mock_screen_kr_via_tvscreener(**kwargs):
             assert kwargs["market"] == "kr"
             assert kwargs["asset_type"] == "stock"
-            assert kwargs["max_rsi"] == 35.0
+            assert kwargs["max_rsi"] == pytest.approx(35.0)
             return {
                 "stocks": [
                     {
@@ -1441,8 +1441,8 @@ class TestScreenStocksTvScreenerContract:
         )
 
         assert result["meta"]["source"] == "tvscreener"
-        assert result["results"][0]["rsi"] == 32.0
-        assert result["results"][0]["adx"] == 21.5
+        assert result["results"][0]["rsi"] == pytest.approx(32.0)
+        assert result["results"][0]["adx"] == pytest.approx(21.5)
 
     @pytest.mark.asyncio
     async def test_us_stock_request_with_max_rsi_still_uses_tvscreener(
@@ -1451,7 +1451,7 @@ class TestScreenStocksTvScreenerContract:
         async def mock_screen_us_via_tvscreener(**kwargs):
             assert kwargs["market"] == "us"
             assert kwargs["asset_type"] is None
-            assert kwargs["max_rsi"] == 40.0
+            assert kwargs["max_rsi"] == pytest.approx(40.0)
             return {
                 "stocks": [
                     {
@@ -1504,8 +1504,8 @@ class TestScreenStocksTvScreenerContract:
         )
 
         assert result["meta"]["source"] == "tvscreener"
-        assert result["results"][0]["rsi"] == 35.2
-        assert result["results"][0]["adx"] == 31.4
+        assert result["results"][0]["rsi"] == pytest.approx(35.2)
+        assert result["results"][0]["adx"] == pytest.approx(31.4)
 
     @pytest.mark.asyncio
     async def test_us_tvscreener_error_falls_back_to_legacy_path(self, monkeypatch):
@@ -1527,7 +1527,7 @@ class TestScreenStocksTvScreenerContract:
 
         async def mock_screen_us(**kwargs):
             assert kwargs["market"] == "us"
-            assert kwargs["max_rsi"] == 40.0
+            assert kwargs["max_rsi"] == pytest.approx(40.0)
             return {
                 "results": [
                     {
@@ -1930,8 +1930,8 @@ class TestScreenStocksCrypto:
         first = result["results"][0]
         assert first["symbol"] == "KRW-BTC"
         assert first["name"] == "비트코인"
-        assert first["trade_amount_24h"] == 900_000_000_000.0
-        assert first["volume_24h"] == 12_345.0
+        assert first["trade_amount_24h"] == pytest.approx(900_000_000_000.0)
+        assert first["volume_24h"] == pytest.approx(12_345.0)
         assert first["market_cap"] == 3_000_000_000_000_000
         assert first["market_cap_rank"] == 1
         assert first["rsi_bucket"] == 45
@@ -2078,18 +2078,20 @@ class TestScreenStocksFundamentalsExpansion:
 
         assert captured["sector"] == "Technology"
         assert captured["min_analyst_buy"] == 10
-        assert captured["min_dividend"] == 2.5
+        assert captured["min_dividend"] == pytest.approx(2.5)
         first = result["results"][0]
         assert first["sector"] == "Technology"
         assert first["analyst_buy"] == 18
         assert first["analyst_hold"] == 6
         assert first["analyst_sell"] == 1
-        assert first["avg_target"] == 245.0
-        assert first["upside_pct"] == 12.4
+        assert first["avg_target"] == pytest.approx(245.0)
+        assert first["upside_pct"] == pytest.approx(12.4)
         assert result["filters_applied"]["sector"] == "Technology"
         assert result["filters_applied"]["min_analyst_buy"] == 10
-        assert result["filters_applied"]["min_dividend_input"] == 2.5
-        assert result["filters_applied"]["min_dividend_normalized"] == 0.025
+        assert result["filters_applied"]["min_dividend_input"] == pytest.approx(2.5)
+        assert result["filters_applied"]["min_dividend_normalized"] == pytest.approx(
+            0.025
+        )
 
     @pytest.mark.asyncio
     async def test_us_plain_tvscreener_requests_enrich_only_limited_rows(
@@ -2178,8 +2180,8 @@ class TestScreenStocksFundamentalsExpansion:
         assert result["meta"]["source"] == "tvscreener"
         assert result["results"][0]["sector"] == "Technology"
         assert result["results"][0]["analyst_buy"] == 12
-        assert result["results"][0]["avg_target"] == 250.0
-        assert result["results"][1]["upside_pct"] == 10.0
+        assert result["results"][0]["avg_target"] == pytest.approx(250.0)
+        assert result["results"][1]["upside_pct"] == pytest.approx(10.0)
 
     @pytest.mark.asyncio
     async def test_kr_sector_and_analyst_filters_apply_after_overfetch_enrichment(
@@ -3029,7 +3031,7 @@ class TestScreenStocksRsiLogging:
         assert called_symbols, "OHLCV fetch should be called for RSI enrichment"
         assert called_symbols[0][0] == "005930"
         assert called_symbols[0][1] == "equity_kr"
-        assert result["results"][0]["rsi"] == 42.0
+        assert result["results"][0]["rsi"] == pytest.approx(42.0)
 
     @pytest.mark.asyncio
     async def test_crypto_rsi_falls_back_to_market_field(self, monkeypatch, caplog):
@@ -3692,8 +3694,12 @@ class TestScreenStocksDividendYieldNormalization:
         )
 
         assert result is not None
-        assert result["filters_applied"]["min_dividend_yield_input"] == 0.03
-        assert result["filters_applied"]["min_dividend_yield_normalized"] == 0.03
+        assert result["filters_applied"]["min_dividend_yield_input"] == pytest.approx(
+            0.03
+        )
+        assert result["filters_applied"][
+            "min_dividend_yield_normalized"
+        ] == pytest.approx(0.03)
 
     @pytest.mark.asyncio
     async def test_kr_dividend_yield_normalization_percent_input(
@@ -3727,8 +3733,12 @@ class TestScreenStocksDividendYieldNormalization:
         )
 
         assert result is not None
-        assert result["filters_applied"]["min_dividend_yield_input"] == 3.0
-        assert result["filters_applied"]["min_dividend_yield_normalized"] == 0.03
+        assert result["filters_applied"]["min_dividend_yield_input"] == pytest.approx(
+            3.0
+        )
+        assert result["filters_applied"][
+            "min_dividend_yield_normalized"
+        ] == pytest.approx(0.03)
 
     @pytest.mark.asyncio
     async def test_kr_dividend_yield_normalization_one_percent_input(
@@ -3762,8 +3772,12 @@ class TestScreenStocksDividendYieldNormalization:
         )
 
         assert result is not None
-        assert result["filters_applied"]["min_dividend_yield_input"] == 1.0
-        assert result["filters_applied"]["min_dividend_yield_normalized"] == 0.01
+        assert result["filters_applied"]["min_dividend_yield_input"] == pytest.approx(
+            1.0
+        )
+        assert result["filters_applied"][
+            "min_dividend_yield_normalized"
+        ] == pytest.approx(0.01)
 
     @pytest.mark.asyncio
     async def test_kr_dividend_yield_equivalence(self, mock_krx_stocks, monkeypatch):
@@ -3811,8 +3825,12 @@ class TestScreenStocksDividendYieldNormalization:
             result_decimal["filters_applied"]["min_dividend_yield_normalized"]
             == result_percent["filters_applied"]["min_dividend_yield_normalized"]
         )
-        assert result_decimal["filters_applied"]["min_dividend_yield_input"] == 0.03
-        assert result_percent["filters_applied"]["min_dividend_yield_input"] == 3.0
+        assert result_decimal["filters_applied"][
+            "min_dividend_yield_input"
+        ] == pytest.approx(0.03)
+        assert result_percent["filters_applied"][
+            "min_dividend_yield_input"
+        ] == pytest.approx(3.0)
 
     @pytest.mark.asyncio
     async def test_kr_dividend_yield_none_input(self, mock_krx_stocks, monkeypatch):

--- a/tests/backtest/test_fetch_data.py
+++ b/tests/backtest/test_fetch_data.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest import mock
 
 import pandas as pd
+import pytest
 
 backtest_dir = Path(__file__).resolve().parent.parent.parent / "backtest"
 spec = importlib.util.spec_from_file_location(
@@ -289,8 +290,8 @@ class TestDataQuality:
             }
         )
         result = fetch_data._validate_data_quality(df, "1h")
-        assert result["missing_pct"] == 0.0
-        assert result["max_gap_hours"] == 0.0
+        assert result["missing_pct"] == pytest.approx(0.0)
+        assert result["max_gap_hours"] == pytest.approx(0.0)
         assert result["total_bars"] == 24
 
     def test_validate_1h_with_gap(self):
@@ -344,7 +345,7 @@ class TestDataQuality:
         )
         result = fetch_data._validate_data_quality(df, "1h")
         assert result["total_bars"] == 1
-        assert result["missing_pct"] == 0.0
+        assert result["missing_pct"] == pytest.approx(0.0)
 
 
 class TestMinuteCandleFetch:

--- a/tests/backtest/test_orchestrator.py
+++ b/tests/backtest/test_orchestrator.py
@@ -3,6 +3,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 # Add backtest directory to path for imports
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "backtest"))
 
@@ -28,7 +30,7 @@ def test_get_best_cv_score_reads_only_keep_rows(tmp_path: Path) -> None:
         ],
     )
 
-    assert orchestrator.get_best_cv_score(results_path) == 4.4
+    assert orchestrator.get_best_cv_score(results_path) == pytest.approx(4.4)
 
 
 def test_read_last_result_row_returns_latest_entry(tmp_path: Path) -> None:
@@ -45,7 +47,7 @@ def test_read_last_result_row_returns_latest_entry(tmp_path: Path) -> None:
 
     assert result is not None
     assert result.experiment == "exp11"
-    assert result.cv_score == 4.3
+    assert result.cv_score == pytest.approx(4.3)
     assert result.status == "revert"
     assert result.description == "beta"
 
@@ -65,7 +67,7 @@ def test_read_best_result_row_returns_top_kept_entry(tmp_path: Path) -> None:
 
     assert result is not None
     assert result.experiment == "exp12"
-    assert result.cv_score == 4.5
+    assert result.cv_score == pytest.approx(4.5)
     assert result.status == "kept"
     assert result.description == "gamma"
 

--- a/tests/backtest/test_prepare.py
+++ b/tests/backtest/test_prepare.py
@@ -103,7 +103,7 @@ class TestContractConstants:
 
     def test_slippage_bps_constant(self):
         """Test that SLIPPAGE_BPS matches approved value."""
-        assert prepare.SLIPPAGE_BPS == 2.0
+        assert prepare.SLIPPAGE_BPS == pytest.approx(2.0)
 
     def test_lookback_bars_constant(self):
         """Test that LOOKBACK_BARS matches approved value."""
@@ -145,7 +145,7 @@ class TestContractDataclasses:
             weight=0.5,
             reason="RSI oversold",
         )
-        assert signal.weight == 0.5
+        assert signal.weight == pytest.approx(0.5)
         assert signal.reason == "RSI oversold"
 
     def test_portfolio_state_has_equity_and_date(self):
@@ -159,7 +159,7 @@ class TestContractDataclasses:
             date="2025-04-01",
             trade_log=[],
         )
-        assert state.equity == 150000.0
+        assert state.equity == pytest.approx(150000.0)
         assert state.date == "2025-04-01"
 
     def test_backtest_result_has_win_rate_pct_and_backtest_seconds(self):
@@ -177,8 +177,8 @@ class TestContractDataclasses:
             equity_curve=[100000.0, 105000.0],
             equity_dates=["2025-04-01", "2025-04-02"],
         )
-        assert result.win_rate_pct == 0.6
-        assert result.backtest_seconds == 1.23
+        assert result.win_rate_pct == pytest.approx(0.6)
+        assert result.backtest_seconds == pytest.approx(1.23)
         assert result.equity_dates == ["2025-04-01", "2025-04-02"]
 
 
@@ -511,8 +511,8 @@ class TestFeeAwarePnL:
 
         assert result.num_trades == 2
         assert result.trade_log[1]["realized_pnl"] < 0
-        assert result.win_rate_pct == 0.0
-        assert result.profit_factor == 0.0
+        assert result.win_rate_pct == pytest.approx(0.0)
+        assert result.profit_factor == pytest.approx(0.0)
 
     def test_buy_fee_affects_cost_basis(self, tmp_path, monkeypatch):
         """Test that buy-side fees affect the eventual realized PnL."""
@@ -684,7 +684,7 @@ class TestExecutionCosts:
         trade = result.trade_log[0]
         cost = trade["price"] * trade["quantity"]
         weight = cost / initial_value
-        assert pytest.approx(weight, abs=0.05) == 0.5
+        assert pytest.approx(weight, abs=0.05) == pytest.approx(0.5)
 
     def test_partial_sell_sizing(self):
         """Test partial sell sizing using weight as fraction of position."""
@@ -921,7 +921,7 @@ class TestRunBacktest:
         result = prepare.run_backtest(data, strategy)
 
         assert len(result.equity_curve) == 4  # Initial + 3 days
-        assert result.equity_curve[0] == 10_000_000.0  # Initial capital
+        assert result.equity_curve[0] == pytest.approx(10_000_000.0)  # Initial capital
         assert result.equity_dates == [
             "2025-04-01",
             "2025-04-01",
@@ -1317,8 +1317,8 @@ class TestCVResult:
             min_score=0.5,
             cv_score=0.855,
         )
-        assert result.mean_score == 1.167
-        assert result.cv_score == 0.855
+        assert result.mean_score == pytest.approx(1.167)
+        assert result.cv_score == pytest.approx(0.855)
         assert len(result.fold_scores) == 3
         assert result.fold_indices == [0, 1, 2]
 
@@ -1392,7 +1392,7 @@ class TestCrossValidate:
                 return []
 
         result = prepare.cross_validate(DummyStrategy, folds=empty_folds)
-        assert result.cv_score == -999.0
+        assert result.cv_score == pytest.approx(-999.0)
         assert result.fold_scores == []
         assert result.fold_indices == []
 

--- a/tests/backtest/test_rsi_data_loader.py
+++ b/tests/backtest/test_rsi_data_loader.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "backtest"))
 
@@ -45,8 +46,8 @@ class TestNormalizeCandles:
         df = normalize_candles(raw)
         assert len(df) == 1
         assert df.iloc[0]["datetime"] == "2024-01-01T09:00:00"
-        assert df.iloc[0]["close"] == 105.0
-        assert df.iloc[0]["value"] == 5000.0
+        assert df.iloc[0]["close"] == pytest.approx(105.0)
+        assert df.iloc[0]["value"] == pytest.approx(5000.0)
 
     def test_sorts_by_datetime_ascending(self):
         raw = [
@@ -97,7 +98,7 @@ class TestMergeWithExisting:
         assert len(result) == 2
         # New data should overwrite existing for same datetime
         row = result[result["datetime"] == "2024-01-01T09:00:00"]
-        assert row.iloc[0]["close"] == 101.0
+        assert row.iloc[0]["close"] == pytest.approx(101.0)
 
 
 class TestLoadCandles:

--- a/tests/backtest/test_rsi_metrics.py
+++ b/tests/backtest/test_rsi_metrics.py
@@ -71,7 +71,7 @@ class TestSharpe:
     def test_flat_equity_zero_sharpe(self):
         result = _make_result([100, 100, 100, 100])
         m = compute_metrics(result)
-        assert m.sharpe == 0.0
+        assert m.sharpe == pytest.approx(0.0)
 
     def test_positive_sharpe_for_steady_gains(self):
         curve = [10_000_000 + i * 10_000 for i in range(100)]

--- a/tests/backtest/test_strategy.py
+++ b/tests/backtest/test_strategy.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pytest
 
 # Add backtest directory to path for imports
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "backtest"))
@@ -286,7 +287,7 @@ class TestIndicatorHelpers:
         volumes = np.array([1000.0] * 20 + [2000.0])
         avg_vol = indicators._calc_average_volume(volumes, lookback=20)
         assert avg_vol is not None
-        assert avg_vol == 1050.0  # Average of 20 1000s and 1 2000
+        assert avg_vol == pytest.approx(1050.0)  # Average of 20 1000s and 1 2000
 
     def test_calc_average_volume_insufficient_history_returns_none(self):
         """Test average volume returns None with insufficient history."""
@@ -1165,12 +1166,12 @@ class TestParamsConfig:
         assert strategy.PARAMS["rsi_period_slow"] == 14
         assert strategy.PARAMS["rsi_oversold"] == 30
         assert strategy.PARAMS["rsi_exit"] == 55
-        assert strategy.PARAMS["bb_std"] == 1.5
+        assert strategy.PARAMS["bb_std"] == pytest.approx(1.5)
         assert strategy.PARAMS["min_votes"] == 4
         assert strategy.PARAMS["min_weighted_buy_votes"] == 4
         assert strategy.PARAMS["min_sell_votes"] == 2
         assert strategy.PARAMS["max_positions"] == 5
-        assert strategy.PARAMS["position_size"] == 0.10
+        assert strategy.PARAMS["position_size"] == pytest.approx(0.10)
 
     def test_min_history_bars_calculation(self):
         """Test MIN_HISTORY_BARS matches the prior warmup requirement."""
@@ -1271,8 +1272,8 @@ class TestSignalRegistry:
             momentum=2.0,
             avg_volume=1100.0,
         )
-        assert ctx.rsi_slow == 28.0
-        assert ctx.current_close == 102.0
+        assert ctx.rsi_slow == pytest.approx(28.0)
+        assert ctx.current_close == pytest.approx(102.0)
 
 
 class TestStrategyContractFreezing:
@@ -1416,7 +1417,7 @@ class TestStrategyContractFreezing:
         assert len(buy_signals) == 1
         # Strong reversion should use 0.15 weight
         assert buy_signals[0].weight == strategy.STRONG_REVERSION_POSITION_SIZE
-        assert buy_signals[0].weight == 0.15
+        assert buy_signals[0].weight == pytest.approx(0.15)
 
     def test_symbol_specific_weight_btc_hot_stall_trend(self, monkeypatch):
         """Test BTC hot-stall trend position size."""
@@ -1464,7 +1465,7 @@ class TestStrategyContractFreezing:
         assert len(buy_signals) == 1
         # BTC hot-stall trend should use 0.0025 weight
         assert buy_signals[0].weight == strategy.BTC_HOT_STALL_TREND_POSITION_SIZE
-        assert buy_signals[0].weight == 0.0025
+        assert buy_signals[0].weight == pytest.approx(0.0025)
 
     def test_symbol_specific_weight_dot_mild_reversion(self, monkeypatch):
         """Test DOT mild reversion position size."""
@@ -1514,7 +1515,7 @@ class TestStrategyContractFreezing:
         assert len(buy_signals) == 1
         # DOT mild reversion should use 0.00015625 weight
         assert buy_signals[0].weight == strategy.DOT_MILD_REVERSION_POSITION_SIZE
-        assert buy_signals[0].weight == 0.00015625
+        assert buy_signals[0].weight == pytest.approx(0.00015625)
 
     def test_symbol_specific_weight_avax_pure_trend(self, monkeypatch):
         """Test AVAX pure trend position size."""
@@ -1562,7 +1563,7 @@ class TestStrategyContractFreezing:
         assert len(buy_signals) == 1
         # AVAX pure trend should use 0.04 weight
         assert buy_signals[0].weight == strategy.AVAX_TREND_POSITION_SIZE
-        assert buy_signals[0].weight == 0.04
+        assert buy_signals[0].weight == pytest.approx(0.04)
 
     def test_buy_uses_symbol_weight_resolver(self, monkeypatch):
         """Test that on_bar delegates final buy sizing to _resolve_symbol_buy_weight."""
@@ -1609,7 +1610,7 @@ class TestStrategyContractFreezing:
         buy_signals = [s for s in signals if s.action == "buy"]
 
         assert len(buy_signals) == 1
-        assert buy_signals[0].weight == 0.123
+        assert buy_signals[0].weight == pytest.approx(0.123)
 
     def test_cooldown_blocks_reentry_after_stop_loss(self, monkeypatch):
         """Test that cooldown blocks re-entry after stop-loss exit."""

--- a/tests/integration/test_screener_e2e.py
+++ b/tests/integration/test_screener_e2e.py
@@ -206,7 +206,7 @@ def test_screener_list_min_volume_e2e(
     assert [item["code"] for item in body["results"]] == ["MSFT", "NVDA"]
     assert body["returned_count"] == 2
     assert body["total_count"] == 3
-    assert body["filters_applied"]["min_volume"] == 1000.0
+    assert body["filters_applied"]["min_volume"] == pytest.approx(1000.0)
 
     await_args = screen_mock.await_args
     assert await_args is not None

--- a/tests/models/test_trading_decision_service.py
+++ b/tests/models/test_trading_decision_service.py
@@ -144,7 +144,7 @@ async def test_create_session_with_btc_eth_sol_proposals() -> None:
             symbols = {p.symbol for p in added}
             assert symbols == {"KRW-BTC", "KRW-ETH", "KRW-SOL"}
             btc = next(p for p in added if p.symbol == "KRW-BTC")
-            assert btc.original_quantity_pct == Decimal("20.0000")
+            assert btc.original_quantity_pct == pytest.approx(Decimal("20.0000"))
             assert btc.user_response == UserResponse.pending
     finally:
         await _cleanup_user(user_id)
@@ -191,8 +191,8 @@ async def test_modify_btc_proposal_20_to_10() -> None:
             )
             await session.commit()
 
-            assert updated.original_quantity_pct == Decimal("20.0000")
-            assert updated.user_quantity_pct == Decimal("10.0000")
+            assert updated.original_quantity_pct == pytest.approx(Decimal("20.0000"))
+            assert updated.user_quantity_pct == pytest.approx(Decimal("10.0000"))
             assert updated.user_response == UserResponse.modify
             assert updated.responded_at is not None
     finally:
@@ -494,7 +494,7 @@ async def test_record_1h_and_1d_outcome_marks() -> None:
             assert m1.horizon == OutcomeHorizon.h1
             assert m2.horizon == OutcomeHorizon.d1
             assert m1.pnl_pct is not None
-            assert m2.price_at_mark == Decimal("95000000")
+            assert m2.price_at_mark == pytest.approx(Decimal("95000000"))
     finally:
         await _cleanup_user(user_id)
 
@@ -581,8 +581,8 @@ async def test_aggregate_session_outcomes_groups_by_track_and_horizon() -> None:
             live_1h = keyed[(TrackKind.accepted_live.value, OutcomeHorizon.h1.value)]
             assert live_1h.outcome_count == 2
             assert live_1h.proposal_count == 2
-            assert live_1h.mean_pnl_pct == Decimal("2.0000")
-            assert live_1h.sum_pnl_amount == Decimal("20.0000")
+            assert live_1h.mean_pnl_pct == pytest.approx(Decimal("2.0000"))
+            assert live_1h.sum_pnl_amount == pytest.approx(Decimal("20.0000"))
 
             rej_1d = keyed[
                 (TrackKind.rejected_counterfactual.value, OutcomeHorizon.d1.value)

--- a/tests/services/kis_websocket/test_parsers.py
+++ b/tests/services/kis_websocket/test_parsers.py
@@ -37,8 +37,8 @@ def test_parse_overseas_execution(client):
 
     assert result is not None
     assert result["symbol"] == "AAPL"
-    assert result["filled_qty"] == 5.0
-    assert result["filled_price"] == 150.25
+    assert result["filled_qty"] == pytest.approx(5.0)
+    assert result["filled_price"] == pytest.approx(150.25)
     assert result["market"] == "us"
 
 
@@ -154,10 +154,10 @@ class TestH0GSCNI0SyntheticContract:
         assert result["market"] == "us"
         assert result["symbol"] == "TSLA"
         assert result["side"] == "bid"
-        assert result["filled_qty"] == 10.0
-        assert result["filled_price"] == 248.50
-        assert result["filled_amount"] == 2485.0
-        assert result["order_qty"] == 10.0
+        assert result["filled_qty"] == pytest.approx(10.0)
+        assert result["filled_price"] == pytest.approx(248.50)
+        assert result["filled_amount"] == pytest.approx(2485.0)
+        assert result["order_qty"] == pytest.approx(10.0)
         assert result["currency"] == "USD"
         assert result["execution_status"] == "filled"
         assert client._is_execution_event(result) is True
@@ -176,9 +176,9 @@ class TestH0GSCNI0SyntheticContract:
         assert result is not None
         assert result["symbol"] == "AAPL"
         assert result["side"] == "ask"
-        assert result["filled_qty"] == 5.0
-        assert result["filled_price"] == 175.25
-        assert result["order_qty"] == 10.0
+        assert result["filled_qty"] == pytest.approx(5.0)
+        assert result["filled_price"] == pytest.approx(175.25)
+        assert result["order_qty"] == pytest.approx(10.0)
         assert result["currency"] == "USD"
         assert result["execution_status"] == "partial"
         assert client._is_execution_event(result) is True

--- a/tests/services/test_alpaca_paper_roundtrip_report_service.py
+++ b/tests/services/test_alpaca_paper_roundtrip_report_service.py
@@ -235,11 +235,11 @@ async def test_build_report_by_correlation_returns_complete_read_only_report():
     assert report.qa_result.briefing_artifact_run_uuid == str(_BRIEFING_UUID)
     assert report.approval_packet.preview_payload == {"symbol": "BTCUSD", "side": "buy"}
     assert report.buy_leg is not None
-    assert report.buy_leg.fill.filled_qty == Decimal("0.001")
+    assert report.buy_leg.fill.filled_qty == pytest.approx(Decimal("0.001"))
     assert report.sell_leg is not None
-    assert report.sell_leg.fill.filled_avg_price == Decimal("51000")
+    assert report.sell_leg.fill.filled_avg_price == pytest.approx(Decimal("51000"))
     assert report.final_position.source == "ledger_snapshot"
-    assert report.final_position.qty == Decimal("0")
+    assert report.final_position.qty == pytest.approx(Decimal("0"))
     assert report.open_orders.source == "missing"
     assert report.anomalies.should_block is False
     assert report.safety.read_only is True

--- a/tests/services/test_kis_mock_lifecycle_service.py
+++ b/tests/services/test_kis_mock_lifecycle_service.py
@@ -130,7 +130,7 @@ async def test_record_holdings_baseline(
         ledger_id=seeded_ledger_id, baseline_qty=Decimal("3")
     )
     row = await db_session.get(KISMockOrderLedger, seeded_ledger_id)
-    assert row.holdings_baseline_qty == Decimal("3")
+    assert row.holdings_baseline_qty == pytest.approx(Decimal("3"))
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_order_preview_session_service.py
+++ b/tests/services/test_order_preview_session_service.py
@@ -187,7 +187,7 @@ async def test_refresh_recomputes_dry_run(db_session) -> None:
         "legs": [{"leg_index": 0, "estimated_value": "200", "estimated_fee": "0.2"}],
     }
     refreshed = await service.refresh_preview(user_id=1, preview_uuid=out.preview_uuid)
-    assert refreshed.legs[0].estimated_value == Decimal("200")
+    assert refreshed.legs[0].estimated_value == pytest.approx(Decimal("200"))
 
 
 @pytest.mark.unit

--- a/tests/services/test_paper_approval_packet.py
+++ b/tests/services/test_paper_approval_packet.py
@@ -92,14 +92,14 @@ def test_packet_constructs_with_max_notional():
     packet = _make_packet()
     assert packet.signal_symbol == "KRW-BTC"
     assert packet.execution_symbol == "BTC/USD"
-    assert packet.max_notional == Decimal("10")
+    assert packet.max_notional == pytest.approx(Decimal("10"))
     assert packet.max_qty is None
 
 
 @pytest.mark.unit
 def test_packet_constructs_with_max_qty():
     packet = _make_packet(max_notional=None, max_qty=Decimal("0.001"))
-    assert packet.max_qty == Decimal("0.001")
+    assert packet.max_qty == pytest.approx(Decimal("0.001"))
     assert packet.max_notional is None
 
 

--- a/tests/services/test_pending_order_sync_service.py
+++ b/tests/services/test_pending_order_sync_service.py
@@ -75,7 +75,7 @@ async def test_pending_order_sync_upserts_correctly(db_session):
     stmt = select(PendingOrder).where(PendingOrder.broker_order_id == "ORD-1")
     order = (await db_session.execute(stmt)).scalar_one()
     assert order.symbol == "BTC"
-    assert order.quantity == Decimal("0.1")
+    assert order.quantity == pytest.approx(Decimal("0.1"))
 
     # Sync again with update
     broker.orders[0]["status"] = "partial_fill"
@@ -85,7 +85,7 @@ async def test_pending_order_sync_upserts_correctly(db_session):
 
     await db_session.refresh(order)
     assert order.status == "partial_fill"
-    assert order.filled_quantity == Decimal("0.05")
+    assert order.filled_quantity == pytest.approx(Decimal("0.05"))
 
     # Sync with deletion after a successful complete empty snapshot.
     broker.orders = []

--- a/tests/services/test_pending_reconciliation_service.py
+++ b/tests/services/test_pending_reconciliation_service.py
@@ -220,7 +220,7 @@ def test_stale_quote_warning_still_classifies() -> None:
 def test_decision_support_includes_gap_and_signed_distance() -> None:
     item = reconcile_pending_order(_order(), _ctx_with_quote("68000"))
     ds = item.decision_support
-    assert ds["current_price"] == Decimal("68000")
+    assert ds["current_price"] == pytest.approx(Decimal("68000"))
     assert ds["gap_pct"] is not None
     assert ds["signed_distance_to_fill"] is not None
 

--- a/tests/services/test_portfolio_overview_currency.py
+++ b/tests/services/test_portfolio_overview_currency.py
@@ -58,7 +58,7 @@ class TestUSPortfolioCurrencyConversion:
         position = positions[0]
 
         # Total quantity should be 15 (10 + 5)
-        assert position["quantity"] == 15.0
+        assert position["quantity"] == pytest.approx(15.0)
 
         # avg_price should be weighted average in USD
         # (10 * 150 + 5 * 150) / 15 = 150 (after KRW conversion: 195000/1300 = 150)
@@ -115,10 +115,10 @@ class TestUSPortfolioCurrencyConversion:
 
         assert len(positions) == 1
         pos = positions[0]
-        assert pos["evaluation"] == 2000.0
-        assert pos["evaluation_krw"] == 2600000.0
-        assert pos["profit_loss"] == 500.0
-        assert pos["profit_loss_krw"] == 650000.0
+        assert pos["evaluation"] == pytest.approx(2000.0)
+        assert pos["evaluation_krw"] == pytest.approx(2600000.0)
+        assert pos["profit_loss"] == pytest.approx(500.0)
+        assert pos["profit_loss_krw"] == pytest.approx(650000.0)
 
     def test_aggregate_positions_copies_evaluation_krw_for_kr_and_crypto_positions(
         self,
@@ -147,8 +147,8 @@ class TestUSPortfolioCurrencyConversion:
 
         assert len(positions) == 1
         pos = positions[0]
-        assert pos["evaluation"] == 750000.0
-        assert pos["evaluation_krw"] == 750000.0
+        assert pos["evaluation"] == pytest.approx(750000.0)
+        assert pos["evaluation_krw"] == pytest.approx(750000.0)
 
     def test_aggregate_positions_handles_missing_usd_krw_for_us_positions(self):
         """Test that US positions have None for evaluation_krw when usd_krw is missing."""
@@ -175,7 +175,7 @@ class TestUSPortfolioCurrencyConversion:
 
         assert len(positions) == 1
         pos = positions[0]
-        assert pos["evaluation"] == 2000.0
+        assert pos["evaluation"] == pytest.approx(2000.0)
         assert pos["evaluation_krw"] is None
 
 

--- a/tests/services/test_research_run_service_unit.py
+++ b/tests/services/test_research_run_service_unit.py
@@ -170,7 +170,7 @@ async def test_attach_pending_reconciliations_json_safes_decision_support() -> N
     )
 
     assert items[0].id == 1
-    assert items[0].gap_pct == Decimal("0.20")
+    assert items[0].gap_pct == pytest.approx(Decimal("0.20"))
     assert items[0].decision_support == {"current_price": "70140"}
 
 

--- a/tests/test_ai_markdown_service.py
+++ b/tests/test_ai_markdown_service.py
@@ -158,8 +158,8 @@ class TestAIMarkdownService:
         # 10M + 2.6M + 4M = 16.6M
         assert summary["total_evaluation"] == 16_600_000
         # US weight: 2.6M / 16.6M * 100 = 15.66... -> 15.7
-        assert round(summary["allocation"]["US"], 1) == 15.7
-        assert round(sum(summary["allocation"].values()), 1) == 100.0
+        assert round(summary["allocation"]["US"], 1) == pytest.approx(15.7)
+        assert round(sum(summary["allocation"].values()), 1) == pytest.approx(100.0)
 
     def test_format_top_holdings_uses_normalized_krw_for_sorting_and_display(
         self, service

--- a/tests/test_alpaca_paper_orders_tools.py
+++ b/tests/test_alpaca_paper_orders_tools.py
@@ -34,8 +34,8 @@ def test_module_exposes_expected_surface() -> None:
     assert callable(_orders_mod.set_alpaca_paper_orders_service_factory)
     assert callable(_orders_mod.reset_alpaca_paper_orders_service_factory)
     assert callable(_orders_mod.register_alpaca_paper_orders_tools)
-    assert _orders_mod.SUBMIT_MAX_QTY == Decimal("5")
-    assert _orders_mod.SUBMIT_MAX_NOTIONAL_USD == Decimal("1000")
+    assert _orders_mod.SUBMIT_MAX_QTY == pytest.approx(Decimal("5"))
+    assert _orders_mod.SUBMIT_MAX_NOTIONAL_USD == pytest.approx(Decimal("1000"))
 
 
 class FakeOrdersService(FakeAlpacaPaperService):
@@ -125,8 +125,8 @@ async def test_submit_with_confirm_calls_service_once(
     assert len(submit_calls) == 1
     sent = submit_calls[0][1]["request"]
     assert sent.symbol == "AAPL"
-    assert sent.qty == Decimal("1")
-    assert sent.limit_price == Decimal("1.00")
+    assert sent.qty == pytest.approx(Decimal("1"))
+    assert sent.limit_price == pytest.approx(Decimal("1.00"))
     assert sent.client_order_id.startswith("rob73-")
 
 
@@ -212,8 +212,8 @@ async def test_crypto_submit_with_confirm_calls_service_once(
         "request"
     ]
     assert sent.symbol == "BTC/USD"
-    assert sent.notional == Decimal("10")
-    assert sent.limit_price == Decimal("50000")
+    assert sent.notional == pytest.approx(Decimal("10"))
+    assert sent.limit_price == pytest.approx(Decimal("50000"))
     assert sent.side == "buy"
     assert sent.type == "limit"
     assert sent.time_in_force == "gtc"

--- a/tests/test_analyst_normalizer.py
+++ b/tests/test_analyst_normalizer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from app.services.analyst_normalizer import (
     build_consensus,
     is_strong_buy,
@@ -147,7 +149,7 @@ class TestBuildConsensus:
         assert consensus["total_count"] == 3
         assert consensus["avg_target_price"] == 101
         assert consensus["current_price"] == 90
-        assert consensus["upside_pct"] == 12.22
+        assert consensus["upside_pct"] == pytest.approx(12.22)
 
     def test_mixed_consensus(self) -> None:
         opinions = [
@@ -228,7 +230,7 @@ class TestBuildConsensus:
         opinions = [{"rating": "Buy", "target_price": 110}]
         consensus = build_consensus(opinions, 100)
 
-        assert consensus["upside_pct"] == 10.0
+        assert consensus["upside_pct"] == pytest.approx(10.0)
 
     def test_upside_percentage_none_without_current_price(self) -> None:
         opinions = [{"rating": "Buy", "target_price": 100}]

--- a/tests/test_crypto_composite_score.py
+++ b/tests/test_crypto_composite_score.py
@@ -685,8 +685,8 @@ class TestCryptoScreenStocksTvScreenerContract:
 
         item = result["results"][0]
         assert item["name"] == "비트코인"
-        assert item["trade_amount_24h"] == 900_000_000_000.0
-        assert item["volume_24h"] == 10_000.0
+        assert item["trade_amount_24h"] == pytest.approx(900_000_000_000.0)
+        assert item["volume_24h"] == pytest.approx(10_000.0)
         assert "rsi_bucket" in item
         assert "volume_ratio" in item
         assert "candle_type" in item

--- a/tests/test_execution_event.py
+++ b/tests/test_execution_event.py
@@ -47,7 +47,7 @@ class TestExecutionEventSerialization:
         test_decimal = Decimal("12345.67")
         result = _serialize_for_redis(test_decimal)
 
-        assert result == 12345.67
+        assert result == pytest.approx(12345.67)
 
     def test_serialize_string(self):
         """문자열 그대로 반환 테스트"""

--- a/tests/test_fundamentals_sources_naver.py
+++ b/tests/test_fundamentals_sources_naver.py
@@ -16,4 +16,4 @@ def test_coerce_optional_number_treats_missing_and_nan_values_as_none() -> None:
 
 def test_coerce_optional_number_preserves_real_numbers() -> None:
     assert _coerce_optional_number(12) == 12
-    assert _coerce_optional_number(12.5) == 12.5
+    assert _coerce_optional_number(12.5) == pytest.approx(12.5)

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -139,8 +139,8 @@ async def test_kis_reader_overseas_margin_fallback(
 
     account = result.accounts[0]
     # Fallback should have picked up 50.0 and 40.0
-    assert account.cashBalances.usd == 50.0
-    assert account.buyingPower.usd == 40.0
+    assert account.cashBalances.usd == pytest.approx(50.0)
+    assert account.buyingPower.usd == pytest.approx(40.0)
 
 
 @pytest.mark.asyncio
@@ -189,8 +189,8 @@ async def test_kis_reader_overseas_margin_fallback_without_us_holdings(
     result = await readers.KISHomeReader(db=None).fetch(user_id=1)  # type: ignore[arg-type]
 
     account = result.accounts[0]
-    assert account.cashBalances.usd == 49.25
-    assert account.buyingPower.usd == 49.25
+    assert account.cashBalances.usd == pytest.approx(49.25)
+    assert account.buyingPower.usd == pytest.approx(49.25)
     assert result.warning is None
 
 
@@ -408,8 +408,8 @@ async def test_manual_reader_valuates_with_quote_service(
 
     h = result.holdings[0]
     assert h.symbol == "005930"
-    assert h.valueKrw == 720_000.0
-    assert h.pnlKrw == 20_000.0
+    assert h.valueKrw == pytest.approx(720_000.0)
+    assert h.pnlKrw == pytest.approx(20_000.0)
     assert h.priceState == "live"
     assert result.warning is None
 

--- a/tests/test_kis_account_fetch_stocks.py
+++ b/tests/test_kis_account_fetch_stocks.py
@@ -115,7 +115,7 @@ class TestParseMarginResponse:
             "frcr_dncl_amt_2": "2000.00",
         }
         result = client._parse_margin_response(output)
-        assert result["dnca_tot_amt"] == 5_000_000.0
+        assert result["dnca_tot_amt"] == pytest.approx(5_000_000.0)
         assert result["usd_ord_psbl_amt"] == pytest.approx(1500.50)
         assert result["usd_balance"] == pytest.approx(2000.00)
         assert result["raw"] is output
@@ -135,7 +135,7 @@ class TestParseMarginResponse:
             "FRCR_DNCL_AMT_2": "900.00",
         }
         result = client._parse_margin_response(output)
-        assert result["dnca_tot_amt"] == 4_000_000.0
-        assert result["stck_cash_ord_psbl_amt"] == 3_000_000.0
+        assert result["dnca_tot_amt"] == pytest.approx(4_000_000.0)
+        assert result["stck_cash_ord_psbl_amt"] == pytest.approx(3_000_000.0)
         assert result["usd_ord_psbl_amt"] == pytest.approx(1200.00)
         assert result["usd_balance"] == pytest.approx(900.00)

--- a/tests/test_kis_manual_holdings_integration.py
+++ b/tests/test_kis_manual_holdings_integration.py
@@ -659,8 +659,8 @@ class TestTossRecommendationNotification:
         assert notification_sent[0]["korean_name"] == "한국전력"
         assert notification_sent[0]["decision"] == "buy"
         assert notification_sent[0]["confidence"] == 75
-        assert notification_sent[0]["appropriate_buy_min"] == 23000.0
-        assert notification_sent[0]["appropriate_sell_max"] == 30000.0
+        assert notification_sent[0]["appropriate_buy_min"] == pytest.approx(23000.0)
+        assert notification_sent[0]["appropriate_sell_max"] == pytest.approx(30000.0)
 
     @pytest.mark.asyncio
     async def test_send_toss_price_recommendation_with_sell_decision(self, monkeypatch):
@@ -723,8 +723,8 @@ class TestTossRecommendationNotification:
         # 가격 제안 알림이 발송되어야 함
         assert len(notification_sent) == 1
         assert notification_sent[0]["decision"] == "sell"
-        assert notification_sent[0]["appropriate_sell_min"] == 26000.0
-        assert notification_sent[0]["appropriate_sell_max"] == 28000.0
+        assert notification_sent[0]["appropriate_sell_min"] == pytest.approx(26000.0)
+        assert notification_sent[0]["appropriate_sell_max"] == pytest.approx(28000.0)
 
     @pytest.mark.asyncio
     async def test_send_toss_price_recommendation_with_hold_decision(self, monkeypatch):
@@ -786,8 +786,8 @@ class TestTossRecommendationNotification:
         # hold 결정이어도 알림이 발송되어야 함 (AI 결정과 무관)
         assert len(notification_sent) == 1
         assert notification_sent[0]["decision"] == "hold"
-        assert notification_sent[0]["appropriate_buy_min"] == 23000.0
-        assert notification_sent[0]["appropriate_sell_max"] == 28000.0
+        assert notification_sent[0]["appropriate_buy_min"] == pytest.approx(23000.0)
+        assert notification_sent[0]["appropriate_sell_max"] == pytest.approx(28000.0)
 
     @pytest.mark.asyncio
     async def test_send_toss_price_recommendation_parses_json_reasons(

--- a/tests/test_kis_market_adapters_helpers.py
+++ b/tests/test_kis_market_adapters_helpers.py
@@ -1,4 +1,6 @@
 # tests/test_kis_market_adapters_helpers.py
+import pytest
+
 from app.jobs.kis_market_adapters import (
     extract_domestic_stock_info,
     extract_overseas_stock_info,
@@ -19,8 +21,8 @@ class TestExtractDomesticStockInfo:
         ctx = extract_domestic_stock_info(stock)
         assert ctx.symbol == "005930"
         assert ctx.name == "삼성전자"
-        assert ctx.avg_price == 50000.0
-        assert ctx.current_price == 51000.0
+        assert ctx.avg_price == pytest.approx(50000.0)
+        assert ctx.current_price == pytest.approx(51000.0)
         assert ctx.qty == 10
         assert ctx.is_manual is False
         assert ctx.exchange_code is None
@@ -63,8 +65,8 @@ class TestExtractOverseasStockInfo:
         ctx = extract_overseas_stock_info(stock)
         assert ctx.symbol == "AAPL"
         assert ctx.name == "애플"
-        assert ctx.avg_price == 170.0
-        assert ctx.current_price == 175.0
+        assert ctx.avg_price == pytest.approx(170.0)
+        assert ctx.current_price == pytest.approx(175.0)
         assert ctx.qty == 10
         assert ctx.is_manual is False
         assert ctx.exchange_code == "NASD"

--- a/tests/test_kis_ohlcv_cache.py
+++ b/tests/test_kis_ohlcv_cache.py
@@ -171,7 +171,7 @@ async def test_get_candles_refreshes_when_cached_rows_are_stale(monkeypatch):
     raw_fetcher.assert_awaited_once_with(2)
     assert len(result) == 2
     assert result["date"].max() == fresh["date"].max()
-    assert result.iloc[-1]["close"] == 201.5
+    assert result.iloc[-1]["close"] == pytest.approx(201.5)
 
 
 @pytest.mark.asyncio

--- a/tests/test_manual_holdings_service.py
+++ b/tests/test_manual_holdings_service.py
@@ -45,7 +45,7 @@ async def test_create_holding(mock_db, monkeypatch):
     # Verify
     assert holding.ticker == "AAPL"
     assert holding.quantity == 10
-    assert holding.avg_price == 150.0
+    assert holding.avg_price == pytest.approx(150.0)
 
     # Verify DB interactions
     mock_db.add.assert_called_once()

--- a/tests/test_market_data_service.py
+++ b/tests/test_market_data_service.py
@@ -964,7 +964,7 @@ async def test_get_short_interest_drops_rows_with_malformed_dates(
             "total_amount": 1200,
         }
     ]
-    assert result["avg_short_ratio"] == 2.5
+    assert result["avg_short_ratio"] == pytest.approx(2.5)
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_indicator_tools.py
+++ b/tests/test_mcp_indicator_tools.py
@@ -157,7 +157,7 @@ async def test_get_indicators_crypto_uses_ticker_price(monkeypatch):
     result = await tools["get_indicators"]("KRW-BTC", indicators=["rsi"])
 
     assert "error" not in result
-    assert result["price"] == 123456789.0
+    assert result["price"] == pytest.approx(123456789.0)
     ticker_mock.assert_awaited_once_with(["KRW-BTC"])
 
 
@@ -639,7 +639,7 @@ async def test_get_support_resistance_clusters_levels(monkeypatch):
     result = await tools["get_support_resistance"]("KRW-BTC")
 
     assert result["symbol"] == "KRW-BTC"
-    assert result["current_price"] == 100.0
+    assert result["current_price"] == pytest.approx(100.0)
     assert result["supports"]
     assert result["resistances"]
 

--- a/tests/test_mcp_portfolio_tools.py
+++ b/tests/test_mcp_portfolio_tools.py
@@ -2815,7 +2815,7 @@ async def test_get_holdings_strategy_signal_reuses_portfolio_snapshot_price(
     btc_position = result["accounts"][0]["positions"][0]
 
     assert price_fetch_count == 1
-    assert btc_position["current_price"] == 47_000_000.0
+    assert btc_position["current_price"] == pytest.approx(47_000_000.0)
     assert btc_position["strategy_signal"]["reason"] == "stop_loss"
 
 
@@ -3256,7 +3256,7 @@ async def test_get_cash_balance_paper_all(monkeypatch):
     result = await tools["get_cash_balance"](account="paper")
 
     assert {r["currency"] for r in result["accounts"]} == {"KRW", "USD"}
-    assert result["summary"]["total_krw"] == 10_000_000.0
+    assert result["summary"]["total_krw"] == pytest.approx(10_000_000.0)
     assert result["summary"]["total_usd"] == pytest.approx(500.0)
     assert result["errors"] == []
 
@@ -3277,7 +3277,7 @@ async def test_get_cash_balance_paper_named(monkeypatch):
     result = await tools["get_cash_balance"](account="paper:day")
 
     assert all(r["account"] == "paper:day" for r in result["accounts"])
-    assert result["summary"]["total_krw"] == 1_000_000.0
+    assert result["summary"]["total_krw"] == pytest.approx(1_000_000.0)
 
 
 @pytest.mark.asyncio
@@ -3304,8 +3304,8 @@ async def test_get_available_capital_paper(monkeypatch):
 
     assert result["manual_cash"] is None
     # 10,000,000 KRW + 500 USD * 1400 = 10,700,000
-    assert result["summary"]["total_orderable_krw"] == 10_700_000.0
+    assert result["summary"]["total_orderable_krw"] == pytest.approx(10_700_000.0)
     assert result["summary"]["exchange_rate_usd_krw"] == pytest.approx(1400.0)
     # paper USD row must have krw_equivalent injected
     usd_row = next(r for r in result["accounts"] if r["currency"] == "USD")
-    assert usd_row["krw_equivalent"] == 700_000.0
+    assert usd_row["krw_equivalent"] == pytest.approx(700_000.0)

--- a/tests/test_mcp_screen_stocks_crypto.py
+++ b/tests/test_mcp_screen_stocks_crypto.py
@@ -159,8 +159,8 @@ class TestScreenStocksCrypto:
         first = result["results"][0]
         assert first["symbol"] == "KRW-BTC"
         assert first["name"] == "비트코인"
-        assert first["trade_amount_24h"] == 900_000_000_000.0
-        assert first["volume_24h"] == 12_345.0
+        assert first["trade_amount_24h"] == pytest.approx(900_000_000_000.0)
+        assert first["volume_24h"] == pytest.approx(12_345.0)
         assert first["market_cap"] == 3_000_000_000_000_000
         assert first["market_cap_rank"] == 1
         assert first["rsi_bucket"] == 45

--- a/tests/test_mcp_screen_stocks_filters_and_rsi.py
+++ b/tests/test_mcp_screen_stocks_filters_and_rsi.py
@@ -338,8 +338,12 @@ class TestScreenStocksDividendYieldNormalization:
         )
 
         assert result is not None
-        assert result["filters_applied"]["min_dividend_yield_input"] == 0.03
-        assert result["filters_applied"]["min_dividend_yield_normalized"] == 0.03
+        assert result["filters_applied"]["min_dividend_yield_input"] == pytest.approx(
+            0.03
+        )
+        assert result["filters_applied"][
+            "min_dividend_yield_normalized"
+        ] == pytest.approx(0.03)
 
     @pytest.mark.asyncio
     async def test_kr_dividend_yield_normalization_percent_input(
@@ -370,8 +374,12 @@ class TestScreenStocksDividendYieldNormalization:
         )
 
         assert result is not None
-        assert result["filters_applied"]["min_dividend_yield_input"] == 3.0
-        assert result["filters_applied"]["min_dividend_yield_normalized"] == 0.03
+        assert result["filters_applied"]["min_dividend_yield_input"] == pytest.approx(
+            3.0
+        )
+        assert result["filters_applied"][
+            "min_dividend_yield_normalized"
+        ] == pytest.approx(0.03)
 
     @pytest.mark.asyncio
     async def test_kr_dividend_yield_normalization_one_percent_input(
@@ -402,8 +410,12 @@ class TestScreenStocksDividendYieldNormalization:
         )
 
         assert result is not None
-        assert result["filters_applied"]["min_dividend_yield_input"] == 1.0
-        assert result["filters_applied"]["min_dividend_yield_normalized"] == 0.01
+        assert result["filters_applied"]["min_dividend_yield_input"] == pytest.approx(
+            1.0
+        )
+        assert result["filters_applied"][
+            "min_dividend_yield_normalized"
+        ] == pytest.approx(0.01)
 
     @pytest.mark.asyncio
     async def test_kr_dividend_yield_equivalence(self, mock_krx_stocks, monkeypatch):
@@ -447,8 +459,12 @@ class TestScreenStocksDividendYieldNormalization:
             result_decimal["filters_applied"]["min_dividend_yield_normalized"]
             == result_percent["filters_applied"]["min_dividend_yield_normalized"]
         )
-        assert result_decimal["filters_applied"]["min_dividend_yield_input"] == 0.03
-        assert result_percent["filters_applied"]["min_dividend_yield_input"] == 3.0
+        assert result_decimal["filters_applied"][
+            "min_dividend_yield_input"
+        ] == pytest.approx(0.03)
+        assert result_percent["filters_applied"][
+            "min_dividend_yield_input"
+        ] == pytest.approx(3.0)
 
     @pytest.mark.asyncio
     async def test_kr_dividend_yield_none_input(self, mock_krx_stocks, monkeypatch):

--- a/tests/test_mcp_sentry_middleware.py
+++ b/tests/test_mcp_sentry_middleware.py
@@ -66,7 +66,7 @@ class TestTruncateForSentry:
 
     def test_non_container_passthrough(self):
         assert _truncate_for_sentry(42) == 42
-        assert _truncate_for_sentry(3.14) == 3.14
+        assert _truncate_for_sentry(3.14) == pytest.approx(3.14)
         assert _truncate_for_sentry(None) is None
         assert _truncate_for_sentry(True) is True
 

--- a/tests/test_mcp_trade_journal.py
+++ b/tests/test_mcp_trade_journal.py
@@ -643,7 +643,7 @@ class TestUpdateTradeJournal:
 
         assert result["success"] is True
         assert journal.status == "closed"
-        assert journal.exit_price == Decimal("200.0")
+        assert journal.exit_price == pytest.approx(Decimal("200.0"))
         assert journal.exit_reason == "target_reached"
         assert journal.exit_date is not None
         # pnl_pct = (200 / 175.5 - 1) * 100 ≈ 13.96
@@ -1079,7 +1079,7 @@ class TestCloseJournalsOnSell:
             )
 
         assert first.status == "closed"
-        assert first.exit_price == Decimal("130.0")
+        assert first.exit_price == pytest.approx(Decimal("130.0"))
         assert second.status == "active"
         assert second.exit_price is None
         assert result == {
@@ -1133,7 +1133,7 @@ class TestCloseJournalsOnSell:
         assert null_qty_journal.exit_reason == "sold_via_place_order"
         assert result["journals_closed"] == 1
         # No weighted PnL since quantity is None
-        assert result["total_pnl_pct"] == 0.0
+        assert result["total_pnl_pct"] == pytest.approx(0.0)
 
     @pytest.mark.asyncio
     async def test_close_journals_on_sell_fully_consumes_multiple(self) -> None:

--- a/tests/test_mcp_watch_alerts.py
+++ b/tests/test_mcp_watch_alerts.py
@@ -94,7 +94,7 @@ async def test_manage_watch_alerts_add_maps_metric_operator(
     assert result["symbol"] == "BTC"
     assert fake_service.add_calls[0][2] == "price_below"
     assert result["condition_type"] == "price_below"
-    assert result["threshold"] == 90000000.0
+    assert result["threshold"] == pytest.approx(90000000.0)
     assert fake_service.closed is True
 
 

--- a/tests/test_merged_portfolio_service.py
+++ b/tests/test_merged_portfolio_service.py
@@ -52,7 +52,7 @@ class TestCalculateCombinedAvg:
         """단일 보유 정보의 평단가"""
         holdings = [HoldingInfo(broker="kis", quantity=100, avg_price=50000)]
         result = MergedPortfolioService.calculate_combined_avg(holdings)
-        assert result == 50000.0
+        assert result == pytest.approx(50000.0)
 
     def test_multiple_holdings_same_avg(self):
         """동일 평단가 다중 보유"""
@@ -61,7 +61,7 @@ class TestCalculateCombinedAvg:
             HoldingInfo(broker="toss", quantity=100, avg_price=50000),
         ]
         result = MergedPortfolioService.calculate_combined_avg(holdings)
-        assert result == 50000.0
+        assert result == pytest.approx(50000.0)
 
     def test_multiple_holdings_different_avg(self):
         """다른 평단가 다중 보유 - 가중 평균 계산"""
@@ -71,18 +71,18 @@ class TestCalculateCombinedAvg:
         ]
         # 총 금액: 14,000,000 / 총 수량: 300 = 46,666.67
         result = MergedPortfolioService.calculate_combined_avg(holdings)
-        assert round(result, 2) == 46666.67
+        assert round(result, 2) == pytest.approx(46666.67)
 
     def test_empty_holdings(self):
         """빈 보유 목록"""
         result = MergedPortfolioService.calculate_combined_avg([])
-        assert result == 0.0
+        assert result == pytest.approx(0.0)
 
     def test_zero_quantity(self):
         """수량이 0인 경우"""
         holdings = [HoldingInfo(broker="kis", quantity=0, avg_price=50000)]
         result = MergedPortfolioService.calculate_combined_avg(holdings)
-        assert result == 0.0
+        assert result == pytest.approx(0.0)
 
 
 class TestGetOrCreateHolding:
@@ -97,7 +97,7 @@ class TestGetOrCreateHolding:
         assert holding.ticker == "005930"
         assert holding.name == "삼성전자"
         assert holding.market_type == "KR"
-        assert holding.current_price == 77800.0
+        assert holding.current_price == pytest.approx(77800.0)
         assert "005930" in merged
 
     def test_get_existing_holding(self):
@@ -114,7 +114,7 @@ class TestGetOrCreateHolding:
             merged, "005930", "삼성전자", MarketType.KR, 77800.0
         )
         assert holding is existing
-        assert holding.current_price == 77800.0  # 현재가 업데이트
+        assert holding.current_price == pytest.approx(77800.0)  # 현재가 업데이트
 
     def test_get_existing_holding_no_price_update(self):
         """기존 종목 조회 - 현재가 미전달 시 유지"""
@@ -129,7 +129,7 @@ class TestGetOrCreateHolding:
         holding = MergedPortfolioService._get_or_create_holding(
             merged, "005930", "삼성전자", MarketType.KR
         )
-        assert holding.current_price == 77000.0  # 현재가 유지
+        assert holding.current_price == pytest.approx(77000.0)  # 현재가 유지
 
 
 class TestApplyKISHoldings:
@@ -157,11 +157,11 @@ class TestApplyKISHoldings:
         holding = merged["005930"]
         assert holding.name == "삼성전자"
         assert holding.kis_quantity == 100
-        assert holding.kis_avg_price == 70000.0
-        assert holding.current_price == 77800.0
-        assert holding.evaluation == 7780000.0
-        assert holding.profit_loss == 780000.0
-        assert holding.profit_rate == 11.14
+        assert holding.kis_avg_price == pytest.approx(70000.0)
+        assert holding.current_price == pytest.approx(77800.0)
+        assert holding.evaluation == pytest.approx(7780000.0)
+        assert holding.profit_loss == pytest.approx(780000.0)
+        assert holding.profit_rate == pytest.approx(11.14)
         assert len(holding.holdings) == 1
         assert holding.holdings[0].broker == "kis"
 
@@ -187,8 +187,8 @@ class TestApplyKISHoldings:
         holding = merged["AAPL"]
         assert holding.name == "Apple Inc"
         assert holding.kis_quantity == 10
-        assert holding.current_price == 175.0
-        assert holding.profit_rate == 16.67
+        assert holding.current_price == pytest.approx(175.0)
+        assert holding.profit_rate == pytest.approx(16.67)
 
 
 class TestApplyManualHoldings:
@@ -220,7 +220,7 @@ class TestApplyManualHoldings:
         holding = merged["005380"]
         assert holding.name == "현대차"
         assert holding.toss_quantity == 50
-        assert holding.toss_avg_price == 220000.0
+        assert holding.toss_avg_price == pytest.approx(220000.0)
         assert len(holding.holdings) == 1
         assert holding.holdings[0].broker == "toss"
 
@@ -290,7 +290,7 @@ class TestFetchMissingPrices:
             merged, MarketType.KR, mock_kis_client
         )
 
-        assert merged["005380"].current_price == 230000.0
+        assert merged["005380"].current_price == pytest.approx(230000.0)
         mock_kis_client.inquire_price.assert_called_once_with("005380")
 
     @pytest.mark.asyncio
@@ -358,7 +358,7 @@ class TestFetchMissingPrices:
         )
 
         # 현재가는 0으로 유지
-        assert merged["005380"].current_price == 0.0
+        assert merged["005380"].current_price == pytest.approx(0.0)
 
     @pytest.mark.asyncio
     async def test_fetch_multiple_missing_prices(
@@ -393,8 +393,8 @@ class TestFetchMissingPrices:
             merged, MarketType.KR, mock_kis_client
         )
 
-        assert merged["005380"].current_price == 230000.0
-        assert merged["010140"].current_price == 21800.0
+        assert merged["005380"].current_price == pytest.approx(230000.0)
+        assert merged["010140"].current_price == pytest.approx(21800.0)
         assert mock_kis_client.inquire_price.call_count == 2
 
 
@@ -440,7 +440,7 @@ class TestFinalizeHoldings:
 
         holding = merged["005930"]
         # (100 * 70000 + 50 * 76000) / 150 = 10,800,000 / 150 = 72000
-        assert holding.combined_avg_price == 72000.0
+        assert holding.combined_avg_price == pytest.approx(72000.0)
 
     def test_calculate_evaluation_and_profit(self, merged_portfolio_service):
         """평가금액 및 손익 계산"""
@@ -461,11 +461,11 @@ class TestFinalizeHoldings:
 
         holding = merged["005930"]
         # 평가금액: 77800 * 150 = 11,670,000
-        assert holding.evaluation == 11670000.0
+        assert holding.evaluation == pytest.approx(11670000.0)
         # 손익: (77800 - 72000) * 150 = 870,000
-        assert holding.profit_loss == 870000.0
+        assert holding.profit_loss == pytest.approx(870000.0)
         # 수익률: (77800 - 72000) / 72000 = 0.0806
-        assert round(holding.profit_rate, 4) == 0.0806
+        assert round(holding.profit_rate, 4) == pytest.approx(0.0806)
 
     def test_skip_calculation_without_price(self, merged_portfolio_service):
         """현재가가 없으면 평가금액 계산하지 않음"""
@@ -484,9 +484,9 @@ class TestFinalizeHoldings:
         merged_portfolio_service._finalize_holdings(merged)
 
         holding = merged["005380"]
-        assert holding.evaluation == 0.0
-        assert holding.profit_loss == 0.0
-        assert holding.profit_rate == 0.0
+        assert holding.evaluation == pytest.approx(0.0)
+        assert holding.profit_loss == pytest.approx(0.0)
+        assert holding.profit_rate == pytest.approx(0.0)
 
 
 class TestBuildMergedPortfolio:
@@ -528,13 +528,13 @@ class TestBuildMergedPortfolio:
         assert len(result) == 1
         holding = result[0]
         assert holding.ticker == "005380"
-        assert holding.current_price == 230000.0
+        assert holding.current_price == pytest.approx(230000.0)
         assert holding.toss_quantity == 50
         assert holding.total_quantity == 50
         # 평가금액: 230000 * 50 = 11,500,000
-        assert holding.evaluation == 11500000.0
+        assert holding.evaluation == pytest.approx(11500000.0)
         # 손익: (230000 - 220000) * 50 = 500,000
-        assert holding.profit_loss == 500000.0
+        assert holding.profit_loss == pytest.approx(500000.0)
 
     @pytest.mark.asyncio
     async def test_mixed_kis_and_toss_holdings(
@@ -584,12 +584,12 @@ class TestBuildMergedPortfolio:
 
         # 삼성전자 - KIS에서 현재가 제공됨
         samsung = next(h for h in result if h.ticker == "005930")
-        assert samsung.current_price == 77800.0
+        assert samsung.current_price == pytest.approx(77800.0)
         assert samsung.kis_quantity == 100
 
         # 현대차 - KIS API로 현재가 조회됨
         hyundai = next(h for h in result if h.ticker == "005380")
-        assert hyundai.current_price == 230000.0
+        assert hyundai.current_price == pytest.approx(230000.0)
         assert hyundai.toss_quantity == 50
 
 
@@ -609,11 +609,11 @@ class TestReferencePrices:
 
         result = ref.to_dict()
 
-        assert result["kis_avg"] == 70000.0
+        assert result["kis_avg"] == pytest.approx(70000.0)
         assert result["kis_quantity"] == 100
-        assert result["toss_avg"] == 75000.0
+        assert result["toss_avg"] == pytest.approx(75000.0)
         assert result["toss_quantity"] == 50
-        assert result["combined_avg"] == 71666.67
+        assert result["combined_avg"] == pytest.approx(71666.67)
         assert result["total_quantity"] == 150
 
 
@@ -647,8 +647,8 @@ class TestMergedHoldingToDict:
 
         assert result["ticker"] == "005930"
         assert result["name"] == "삼성전자"
-        assert result["current_price"] == 77800.0
-        assert result["evaluation"] == 11670000.0
+        assert result["current_price"] == pytest.approx(77800.0)
+        assert result["evaluation"] == pytest.approx(11670000.0)
         assert result["analysis_id"] == 123
         assert len(result["holdings"]) == 1
 
@@ -683,7 +683,7 @@ class TestFetchMissingPricesOverseas:
             merged, MarketType.US, mock_kis_client
         )
 
-        assert merged["CONY"].current_price == 18.50
+        assert merged["CONY"].current_price == pytest.approx(18.50)
         mock_kis_client.inquire_overseas_price.assert_called_once_with("CONY")
 
     @pytest.mark.asyncio
@@ -721,8 +721,8 @@ class TestFetchMissingPricesOverseas:
             merged, MarketType.US, mock_kis_client
         )
 
-        assert merged["CONY"].current_price == 18.50
-        assert merged["BRK-B"].current_price == 474.17
+        assert merged["CONY"].current_price == pytest.approx(18.50)
+        assert merged["BRK-B"].current_price == pytest.approx(474.17)
         assert mock_kis_client.inquire_overseas_price.call_count == 2
 
     @pytest.mark.asyncio
@@ -773,4 +773,4 @@ class TestFetchMissingPricesOverseas:
         )
 
         # 현재가는 0으로 유지
-        assert merged["INVALID"].current_price == 0.0
+        assert merged["INVALID"].current_price == pytest.approx(0.0)

--- a/tests/test_n8n_api.py
+++ b/tests/test_n8n_api.py
@@ -163,7 +163,7 @@ class TestExchangeRateService:
 
         rate = await service.get_usd_krw_rate()
 
-        assert rate == 1350.5
+        assert rate == pytest.approx(1350.5)
         assert calls == [
             {"url": "https://open.er-api.com/v6/latest/USD", "timeout": 10}
         ]
@@ -188,7 +188,7 @@ class TestExchangeRateService:
 
         rate = await service.get_usd_krw_rate()
 
-        assert rate == 1400.0
+        assert rate == pytest.approx(1400.0)
 
     @pytest.mark.asyncio
     async def test_refetches_after_ttl_expires(
@@ -224,9 +224,9 @@ class TestExchangeRateService:
 
         rate = await service.get_usd_krw_rate()
 
-        assert rate == 1412.25
+        assert rate == pytest.approx(1412.25)
         assert calls == ["https://open.er-api.com/v6/latest/USD"]
-        assert service._cache["usd_krw"]["rate"] == 1412.25
+        assert service._cache["usd_krw"]["rate"] == pytest.approx(1412.25)
         assert service._cache["usd_krw"]["expires_at"] > 0
 
     @pytest.mark.asyncio
@@ -515,7 +515,7 @@ class TestN8nPendingOrdersService:
                 market="crypto", include_current_price=True
             )
 
-        assert result["orders"][0]["gap_pct"] == 5.0
+        assert result["orders"][0]["gap_pct"] == pytest.approx(5.0)
 
     @pytest.mark.asyncio
     async def test_age_hours_and_days(self) -> None:
@@ -651,7 +651,7 @@ class TestN8nPendingOrdersService:
         ):
             result = await fetch_pending_orders(market="us", include_current_price=True)
 
-        assert result["orders"][0]["amount_krw"] == 280_000.0
+        assert result["orders"][0]["amount_krw"] == pytest.approx(280_000.0)
 
     @pytest.mark.asyncio
     async def test_exchange_rate_failure_preserves_us_order_and_records_error(
@@ -725,8 +725,8 @@ class TestN8nPendingOrdersService:
         assert summary["total"] == 2
         assert summary["buy_count"] == 1
         assert summary["sell_count"] == 1
-        assert summary["total_buy_krw"] == 0.0
-        assert summary["total_sell_krw"] == 60_000.0
+        assert summary["total_buy_krw"] == pytest.approx(0.0)
+        assert summary["total_sell_krw"] == pytest.approx(60_000.0)
 
     @pytest.mark.asyncio
     async def test_min_amount_keeps_us_orders_with_null_amount_krw(self) -> None:
@@ -812,8 +812,8 @@ class TestN8nPendingOrdersService:
         assert summary["total"] == 2
         assert summary["buy_count"] == 1
         assert summary["sell_count"] == 1
-        assert summary["total_buy_krw"] == 50_000.0
-        assert summary["total_sell_krw"] == 60_000.0
+        assert summary["total_buy_krw"] == pytest.approx(50_000.0)
+        assert summary["total_sell_krw"] == pytest.approx(60_000.0)
 
     @pytest.mark.asyncio
     async def test_side_filter_passthrough(self) -> None:
@@ -1097,7 +1097,7 @@ class TestN8nPendingOrdersEndpoint:
             )
 
         assert mock_service.call_args.kwargs["market"] == "crypto"
-        assert mock_service.call_args.kwargs["min_amount"] == 10.0
+        assert mock_service.call_args.kwargs["min_amount"] == pytest.approx(10.0)
         assert mock_service.call_args.kwargs["include_current_price"] is False
         assert mock_service.call_args.kwargs["side"] is None
         assert mock_service.call_args.kwargs["as_of"].microsecond == 0
@@ -1265,9 +1265,9 @@ class TestN8nPendingOrdersEndpoint:
         assert data["summary"]["title"].startswith("📋")
 
         # Backward compatibility: raw fields still present
-        assert order["order_price"] == 70000.0
-        assert order["gap_pct"] == 1.43
-        assert data["summary"]["total_buy_krw"] == 700000.0
+        assert order["order_price"] == pytest.approx(70000.0)
+        assert order["gap_pct"] == pytest.approx(1.43)
+        assert data["summary"]["total_buy_krw"] == pytest.approx(700000.0)
 
 
 class TestN8nKrMorningReportEndpoint:

--- a/tests/test_n8n_filled_orders_indicators.py
+++ b/tests/test_n8n_filled_orders_indicators.py
@@ -177,7 +177,7 @@ class TestEnrichWithIndicators:
         ):
             result = await _enrich_with_indicators(orders)
 
-        assert result[0]["indicators"]["rsi_14"] == 42.0
+        assert result[0]["indicators"]["rsi_14"] == pytest.approx(42.0)
         assert result[0]["indicators"]["fear_greed"] == 25
         assert result[1]["indicators"]["fear_greed"] == 25
 
@@ -371,8 +371,8 @@ class TestEnrichWithIndicators:
             call("KRW-BTC", "crypto"),
             call("USDT-BTC", "crypto"),
         ]
-        assert result[0]["indicators"]["rsi_14"] == 10.0
-        assert result[1]["indicators"]["rsi_14"] == 20.0
+        assert result[0]["indicators"]["rsi_14"] == pytest.approx(10.0)
+        assert result[1]["indicators"]["rsi_14"] == pytest.approx(20.0)
 
 
 @pytest.mark.unit
@@ -418,7 +418,7 @@ class TestFilledOrderSchema:
             indicators=indicators,
         )
         assert item.indicators is not None
-        assert item.indicators.rsi_14 == 42.3
+        assert item.indicators.rsi_14 == pytest.approx(42.3)
 
 
 @pytest.mark.unit

--- a/tests/test_ohlcv_cache_common.py
+++ b/tests/test_ohlcv_cache_common.py
@@ -14,10 +14,10 @@ class TestToJsonValue:
         assert common._to_json_value(float("nan")) is None
 
     def test_int_returns_float(self):
-        assert common._to_json_value(42) == 42.0
+        assert common._to_json_value(42) == pytest.approx(42.0)
 
     def test_float_passthrough(self):
-        assert common._to_json_value(3.14) == 3.14
+        assert common._to_json_value(3.14) == pytest.approx(3.14)
 
     def test_string_passthrough(self):
         assert common._to_json_value("hello") == "hello"

--- a/tests/test_paper_account_tools.py
+++ b/tests/test_paper_account_tools.py
@@ -46,8 +46,8 @@ def test_serialize_account_basic_fields() -> None:
     out = _serialize_account(acc)
     assert out["id"] == 1
     assert out["name"] == "default"
-    assert out["initial_capital"] == 100_000_000.0
-    assert out["cash_krw"] == 95_000_000.0
+    assert out["initial_capital"] == pytest.approx(100_000_000.0)
+    assert out["cash_krw"] == pytest.approx(95_000_000.0)
     assert out["cash_usd"] == pytest.approx(0.0)
     assert out["strategy_name"] is None
     assert out["created_at"] == "2026-04-13T10:00:00+00:00"
@@ -66,7 +66,7 @@ def test_serialize_account_with_summary() -> None:
         total_pnl_pct=Decimal("-1.50"),
     )
     assert out["positions_count"] == 3
-    assert out["total_evaluated_krw"] == 98_500_000.0
+    assert out["total_evaluated_krw"] == pytest.approx(98_500_000.0)
     assert out["total_pnl_pct"] == pytest.approx(-1.5)
 
 
@@ -129,8 +129,8 @@ async def test_create_paper_account_success(monkeypatch) -> None:
     assert result["success"] is True
     assert result["account"]["id"] == 42
     assert result["account"]["name"] == "bot-1"
-    assert result["account"]["initial_capital"] == 50_000_000.0
-    assert result["account"]["cash_krw"] == 50_000_000.0
+    assert result["account"]["initial_capital"] == pytest.approx(50_000_000.0)
+    assert result["account"]["cash_krw"] == pytest.approx(50_000_000.0)
     assert result["account"]["description"] == "test"
 
 
@@ -263,7 +263,7 @@ async def test_list_paper_accounts_returns_enriched(monkeypatch) -> None:
     first = result["accounts"][0]
     assert first["id"] == 1
     assert first["positions_count"] == 3
-    assert first["total_evaluated_krw"] == 98_500_000.0
+    assert first["total_evaluated_krw"] == pytest.approx(98_500_000.0)
     assert first["total_pnl_pct"] == pytest.approx(-1.5)
     second = result["accounts"][1]
     assert second["id"] == 2
@@ -317,7 +317,7 @@ async def test_reset_paper_account_success(monkeypatch) -> None:
     svc.reset_account.assert_awaited_once_with(7)
     assert result["success"] is True
     assert result["account"]["id"] == 7
-    assert result["account"]["cash_krw"] == 100_000_000.0
+    assert result["account"]["cash_krw"] == pytest.approx(100_000_000.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_paper_portfolio_handler.py
+++ b/tests/test_paper_portfolio_handler.py
@@ -382,8 +382,8 @@ async def test_collect_paper_cash_balances_all_accounts(monkeypatch):
     d_krw = next(
         r for r in rows if r["account"] == "paper:default" and r["currency"] == "KRW"
     )
-    assert d_krw["balance"] == 10_000_000.0
-    assert d_krw["orderable"] == 10_000_000.0
+    assert d_krw["balance"] == pytest.approx(10_000_000.0)
+    assert d_krw["orderable"] == pytest.approx(10_000_000.0)
     assert d_krw["broker"] == "paper"
     assert d_krw["formatted"] == "10,000,000 KRW"
     d_usd = next(

--- a/tests/test_portfolio_dashboard_router.py
+++ b/tests/test_portfolio_dashboard_router.py
@@ -193,8 +193,10 @@ def test_portfolio_overview_api_merges_batch_journal_snapshots() -> None:
 
     assert response.status_code == 200
     payload = response.json()
-    assert payload["positions"][0]["journal"]["target_price"] == 165.0
-    assert payload["positions"][0]["journal"]["target_distance_pct"] == 3.12
+    assert payload["positions"][0]["journal"]["target_price"] == pytest.approx(165.0)
+    assert payload["positions"][0]["journal"]["target_distance_pct"] == pytest.approx(
+        3.12
+    )
     fake_dashboard.get_journals_batch.assert_awaited_once_with(
         ["AAPL"],
         current_prices={"AAPL": 160.0},
@@ -218,7 +220,9 @@ def test_portfolio_enrich_api_returns_only_requested_positions() -> None:
     assert payload["success"] is True
     assert len(payload["positions"]) == 1
     assert payload["positions"][0]["symbol"] == "AAPL"
-    assert payload["positions"][0]["journal"]["target_distance_pct"] == 3.12
+    assert payload["positions"][0]["journal"]["target_distance_pct"] == pytest.approx(
+        3.12
+    )
 
     fake_service.enrich_manual_positions.assert_awaited_once_with(
         user_id=7,
@@ -334,10 +338,10 @@ def test_portfolio_journal_api_returns_detail_payload() -> None:
     assert response.status_code == 200
     payload = response.json()
     assert payload["symbol"] == "AAPL"
-    assert payload["target_price"] == 165.0
-    assert payload["stop_loss"] == 135.0
-    assert payload["target_distance_pct"] == 10.0
-    assert payload["stop_distance_pct"] == -10.0
+    assert payload["target_price"] == pytest.approx(165.0)
+    assert payload["stop_loss"] == pytest.approx(135.0)
+    assert payload["target_distance_pct"] == pytest.approx(10.0)
+    assert payload["stop_distance_pct"] == pytest.approx(-10.0)
 
     fake_dashboard.get_latest_journal_snapshot.assert_awaited_once_with(
         "AAPL", current_price=160.0
@@ -367,7 +371,7 @@ def test_portfolio_cash_api_returns_dashboard_cash_summary() -> None:
     assert "upbit_krw" in payload["accounts"]
     assert "manual_cash" in payload
     assert "summary" in payload
-    assert payload["summary"]["total_available_krw"] == 3570000.0
+    assert payload["summary"]["total_available_krw"] == pytest.approx(3570000.0)
 
     fake_dashboard.get_cash_snapshot.assert_awaited_once()
 

--- a/tests/test_portfolio_dashboard_service.py
+++ b/tests/test_portfolio_dashboard_service.py
@@ -52,10 +52,10 @@ async def test_get_latest_journal_snapshot_adds_distance_fields(monkeypatch):
 
     assert result is not None
     assert result["symbol"] == "AAPL"
-    assert result["target_price"] == 110.0
-    assert result["stop_loss"] == 90.0
-    assert result["target_distance_pct"] == 10.0
-    assert result["stop_distance_pct"] == -10.0
+    assert result["target_price"] == pytest.approx(110.0)
+    assert result["stop_loss"] == pytest.approx(90.0)
+    assert result["target_distance_pct"] == pytest.approx(10.0)
+    assert result["stop_distance_pct"] == pytest.approx(-10.0)
 
 
 @pytest.mark.asyncio
@@ -141,24 +141,24 @@ async def test_get_cash_snapshot_maps_available_capital_to_dashboard_shape(monke
 
     assert accounts["kis_krw"]["broker"] == "kis"
     assert accounts["kis_krw"]["currency"] == "KRW"
-    assert accounts["kis_krw"]["balance"] == 1000000.0
-    assert accounts["kis_krw"]["orderable"] == 900000.0
+    assert accounts["kis_krw"]["balance"] == pytest.approx(1000000.0)
+    assert accounts["kis_krw"]["orderable"] == pytest.approx(900000.0)
 
     assert accounts["kis_usd"]["broker"] == "kis"
     assert accounts["kis_usd"]["currency"] == "USD"
-    assert accounts["kis_usd"]["balance"] == 1000.0
-    assert accounts["kis_usd"]["orderable"] == 900.0
+    assert accounts["kis_usd"]["balance"] == pytest.approx(1000.0)
+    assert accounts["kis_usd"]["orderable"] == pytest.approx(900.0)
 
     assert accounts["upbit_krw"]["broker"] == "upbit"
     assert accounts["upbit_krw"]["currency"] == "KRW"
-    assert accounts["upbit_krw"]["balance"] == 500000.0
+    assert accounts["upbit_krw"]["balance"] == pytest.approx(500000.0)
 
-    assert result["manual_cash"]["amount"] == 1000000.0
+    assert result["manual_cash"]["amount"] == pytest.approx(1000000.0)
     assert result["manual_cash"]["updated_at"] == "2026-04-01T00:00:00+00:00"
     assert result["manual_cash"]["stale_warning"] is False
 
-    assert result["summary"]["total_available_krw"] == 3570000.0
-    assert result["summary"]["exchange_rate_usd_krw"] == 1300.0
+    assert result["summary"]["total_available_krw"] == pytest.approx(3570000.0)
+    assert result["summary"]["exchange_rate_usd_krw"] == pytest.approx(1300.0)
     assert "as_of" in result["summary"]
 
 
@@ -297,8 +297,8 @@ async def test_get_journals_batch_returns_latest_active_or_draft_per_symbol() ->
 
     assert sorted(result) == ["AAPL", "MSFT"]
     assert result["AAPL"]["strategy"] == "trend"
-    assert result["AAPL"]["target_price"] == 170.0
-    assert result["MSFT"]["target_price"] == 330.0
+    assert result["AAPL"]["target_price"] == pytest.approx(170.0)
+    assert result["MSFT"]["target_price"] == pytest.approx(330.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_portfolio_position_detail_service.py
+++ b/tests/test_portfolio_position_detail_service.py
@@ -87,7 +87,7 @@ async def test_get_page_payload_returns_summary_components_and_journal() -> None
     assert payload["summary"]["symbol"] == "NVDA"
     assert payload["summary"]["account_count"] == 2
     assert payload["journal"]["strategy"] == "trend"
-    assert payload["summary"]["target_distance_pct"] == 9.85
+    assert payload["summary"]["target_distance_pct"] == pytest.approx(9.85)
 
 
 @pytest.mark.unit
@@ -153,7 +153,7 @@ async def test_get_indicators_payload_builds_summary_cards(
 
     payload = await service.get_indicators_payload(market_type="us", symbol="NVDA")
 
-    assert payload["price"] == 100.0
+    assert payload["price"] == pytest.approx(100.0)
     assert len(payload["summary_cards"]) >= 5
     assert payload["summary_cards"][0]["label"] == "RSI(14)"
     assert payload["summary_cards"][0]["tone"] == "oversold"
@@ -190,8 +190,8 @@ async def test_get_opinions_payload_flattens_consensus_fields(
     payload = await service.get_opinions_payload(market_type="us", symbol="NVDA")
 
     assert payload["supported"] is True
-    assert payload["avg_target_price"] == 155.0
-    assert payload["upside_pct"] == 12.3
+    assert payload["avg_target_price"] == pytest.approx(155.0)
+    assert payload["upside_pct"] == pytest.approx(12.3)
     assert payload["buy_count"] == 8
     assert payload["opinions"][0]["firm"] == "Alpha Research"
 
@@ -284,8 +284,8 @@ async def test_get_page_payload_includes_weights_and_action_summary() -> None:
             user_id=7, market_type="us", symbol="NVDA"
         )
 
-    assert payload["weights"]["portfolio_weight_pct"] == 10.0
-    assert payload["weights"]["market_weight_pct"] == 22.5
+    assert payload["weights"]["portfolio_weight_pct"] == pytest.approx(10.0)
+    assert payload["weights"]["market_weight_pct"] == pytest.approx(22.5)
     assert payload["action_summary"]["status"] == "관망"
     assert "비중 큼" in payload["action_summary"]["tags"]
     assert "목표가까지 여유" in payload["action_summary"]["tags"]
@@ -703,8 +703,8 @@ async def test_get_orders_payload_splits_recent_fills_and_pending_orders(
 
     assert payload["summary"]["last_fill"]["side"] == "buy"
     assert payload["summary"]["pending_count"] == 1
-    assert payload["recent_fills"][0]["amount"] == 452.0
-    assert payload["pending_orders"][0]["remaining_quantity"] == 1.5
+    assert payload["recent_fills"][0]["amount"] == pytest.approx(452.0)
+    assert payload["pending_orders"][0]["remaining_quantity"] == pytest.approx(1.5)
 
 
 @pytest.mark.unit
@@ -748,8 +748,8 @@ async def test_get_orders_payload_prefers_filled_timestamp_and_avg_price(
     payload = await service.get_orders_payload(market_type="us", symbol="NVDA")
 
     assert payload["summary"]["last_fill"]["ordered_at"] == "2026-04-01T09:19:00+09:00"
-    assert payload["recent_fills"][0]["price"] == 455.5
-    assert payload["recent_fills"][0]["amount"] == 911.0
+    assert payload["recent_fills"][0]["price"] == pytest.approx(455.5)
+    assert payload["recent_fills"][0]["amount"] == pytest.approx(911.0)
 
 
 @pytest.mark.unit
@@ -1342,7 +1342,7 @@ def test_build_weights_prefers_evaluation_krw_for_portfolio_weight():
     )
     weights = service._build_weights(positions, base)
 
-    assert weights["portfolio_weight_pct"] == 20.6
+    assert weights["portfolio_weight_pct"] == pytest.approx(20.6)
 
 
 def test_build_weights_returns_none_when_us_position_lacks_krw_normalization():
@@ -1404,9 +1404,9 @@ async def test_get_page_payload_summary_includes_evaluation_krw() -> None:
         )
 
     summary = payload["summary"]
-    assert summary["evaluation"] == 1700.0
-    assert summary["evaluation_krw"] == 2_295_000.0
-    assert summary["profit_loss_krw"] == 270_000.0
+    assert summary["evaluation"] == pytest.approx(1700.0)
+    assert summary["evaluation_krw"] == pytest.approx(2_295_000.0)
+    assert summary["profit_loss_krw"] == pytest.approx(270_000.0)
     assert payload["exchange_rate"] == {"usd_krw": 1350.0}
 
 

--- a/tests/test_preopen_dashboard_service.py
+++ b/tests/test_preopen_dashboard_service.py
@@ -215,7 +215,7 @@ async def test_maps_candidates_and_reconciliations():
     assert result.candidates[0].side == "buy"
     assert result.candidates[1].side == "sell"
     assert result.reconciliations[0].symbol == "005930"
-    assert result.reconciliations[0].gap_pct == Decimal("0.50")
+    assert result.reconciliations[0].gap_pct == pytest.approx(Decimal("0.50"))
     assert result.run_uuid == run.run_uuid
     assert result.briefing_artifact is not None
     assert result.briefing_artifact.status == "ready"

--- a/tests/test_redis_token_manager.py
+++ b/tests/test_redis_token_manager.py
@@ -374,7 +374,7 @@ class TestRedisTokenManagerToken:
             assert await manager.get_token() is None
 
         assert manager._local_token is None
-        assert manager._local_expires_at == 0.0
+        assert manager._local_expires_at == pytest.approx(0.0)
 
     @pytest.mark.asyncio
     async def test_local_token_within_expiry_buffer_is_invalid(self):

--- a/tests/test_research_backtest_parser.py
+++ b/tests/test_research_backtest_parser.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.services.research_backtest_parser import parse_backtest_summary
 
 
@@ -16,4 +18,4 @@ def test_parse_backtest_summary_reads_required_fields() -> None:
 
     assert parsed.run_id == "run-1"
     assert parsed.total_trades == 25
-    assert float(parsed.profit_factor) == 1.4
+    assert float(parsed.profit_factor) == pytest.approx(1.4)

--- a/tests/test_screenshot_holdings.py
+++ b/tests/test_screenshot_holdings.py
@@ -172,7 +172,7 @@ async def test_update_manual_holdings_calculate_avg_buy_price():
         eval_amount=1500000, profit_loss=100000, quantity=10
     )
 
-    assert avg_price == 140000.0
+    assert avg_price == pytest.approx(140000.0)
 
 
 @pytest.mark.asyncio
@@ -184,7 +184,7 @@ async def test_update_manual_holdings_calculate_avg_buy_price_zero_quantity():
         eval_amount=0, profit_loss=0, quantity=0
     )
 
-    assert avg_price == 0.0
+    assert avg_price == pytest.approx(0.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_sell_signal_service.py
+++ b/tests/test_sell_signal_service.py
@@ -59,7 +59,7 @@ class TestFetchCurrentPrice:
         kis = AsyncMock()
         kis.inquire_price.return_value = pd.DataFrame({"close": [1_150_000.0]})
         price, err = await _fetch_current_price(kis, "000660")
-        assert price == 1_150_000.0
+        assert price == pytest.approx(1_150_000.0)
         assert err is None
 
     @pytest.mark.asyncio
@@ -113,7 +113,7 @@ class TestCheckTrailingStop:
         cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
         assert cond.name == "trailing_stop"
         assert cond.met is True
-        assert price == 1_100_000.0
+        assert price == pytest.approx(1_100_000.0)
         assert not errors
 
     @pytest.mark.asyncio
@@ -129,7 +129,7 @@ class TestCheckTrailingStop:
         kis.inquire_price.return_value = pd.DataFrame({"close": [1_200_000.0]})
         cond, price, errors = await _check_trailing_stop(kis, "000660", 1_150_000)
         assert cond.met is False
-        assert price == 1_200_000.0
+        assert price == pytest.approx(1_200_000.0)
 
     @pytest.mark.asyncio
     async def test_not_met_when_price_unavailable(self):

--- a/tests/test_services_account_service.py
+++ b/tests/test_services_account_service.py
@@ -29,8 +29,8 @@ async def test_get_cash_equity_kr_prefers_stck_cash100_max_orderable(monkeypatch
     assert len(balances) == 1
     assert balances[0].market == "equity_kr"
     assert balances[0].currency == "KRW"
-    assert balances[0].balance == 5000000.0
-    assert balances[0].orderable == 3534890.5473
+    assert balances[0].balance == pytest.approx(5000000.0)
+    assert balances[0].orderable == pytest.approx(3534890.5473)
     assert balances[0].source == "kis"
 
 
@@ -60,6 +60,6 @@ async def test_get_cash_equity_kr_skips_zero_priority_orderables(monkeypatch):
     assert len(balances) == 1
     assert balances[0].market == "equity_kr"
     assert balances[0].currency == "KRW"
-    assert balances[0].balance == 5000000.0
-    assert balances[0].orderable == 2100000.25
+    assert balances[0].balance == pytest.approx(5000000.0)
+    assert balances[0].orderable == pytest.approx(2100000.25)
     assert balances[0].source == "kis"

--- a/tests/test_services_kis_logging.py
+++ b/tests/test_services_kis_logging.py
@@ -181,7 +181,7 @@ class TestKISFailureLogging:
             for record in caplog.records
             if record.levelno == logging.WARNING
         )
-        assert result["dnca_tot_amt"] == 500000.0
+        assert result["dnca_tot_amt"] == pytest.approx(500000.0)
 
     @pytest.mark.asyncio
     @patch("app.services.brokers.kis.base.httpx.AsyncClient")

--- a/tests/test_toss_notification.py
+++ b/tests/test_toss_notification.py
@@ -388,10 +388,10 @@ class TestTossNotificationData:
 
         assert data.kis_quantity is None
         assert data.kis_avg_price is None
-        assert data.recommended_price == 0.0
+        assert data.recommended_price == pytest.approx(0.0)
         assert data.recommended_quantity == 1
-        assert data.expected_profit == 0.0
-        assert data.profit_percent == 0.0
+        assert data.expected_profit == pytest.approx(0.0)
+        assert data.profit_percent == pytest.approx(0.0)
         assert data.currency == "원"
         assert data.market_type == "국내주식"
 
@@ -936,8 +936,8 @@ class TestIntegrationScenarios:
         )
         assert call_kwargs["toss_quantity"] == 10
         assert call_kwargs["kis_quantity"] == 5
-        assert call_kwargs["toss_avg_price"] == 52000.0
-        assert call_kwargs["kis_avg_price"] == 48000.0
+        assert call_kwargs["toss_avg_price"] == pytest.approx(52000.0)
+        assert call_kwargs["kis_avg_price"] == pytest.approx(48000.0)
 
     @pytest.mark.asyncio
     async def test_scenario_kis_only_no_notification(
@@ -1013,6 +1013,6 @@ class TestIntegrationScenarios:
             mock_trade_notifier.notify_toss_sell_recommendation.call_args.kwargs
         )
         # Expected profit: (55000 - 50000) / 50000 * 100 = 10%
-        assert call_kwargs["profit_percent"] == 10.0
+        assert call_kwargs["profit_percent"] == pytest.approx(10.0)
         # Expected amount: (55000 - 50000) * 5 = 25000
-        assert call_kwargs["expected_profit"] == 25000.0
+        assert call_kwargs["expected_profit"] == pytest.approx(25000.0)

--- a/tests/test_trading_integration.py
+++ b/tests/test_trading_integration.py
@@ -56,7 +56,7 @@ class TestMergedPortfolioService:
         """보유 종목이 없을 때"""
         result = MergedPortfolioService.calculate_combined_avg([])
 
-        assert result == 0.0
+        assert result == pytest.approx(0.0)
 
     def test_calculate_combined_avg_three_brokers(self):
         """3개 브로커 보유 시"""

--- a/tests/test_tvscreener_crypto.py
+++ b/tests/test_tvscreener_crypto.py
@@ -241,10 +241,12 @@ async def test_screen_crypto_via_tvscreener_uses_upbit_value_traded_contract(
     ]
     assert result["meta"]["source"] == "tvscreener"
     assert [item["symbol"] for item in result["results"]] == ["KRW-ETH", "KRW-BTC"]
-    assert result["results"][0]["trade_amount_24h"] == 1_200_000_000_000.0
-    assert result["results"][0]["volume_24h"] == 9_500.0
+    assert result["results"][0]["trade_amount_24h"] == pytest.approx(
+        1_200_000_000_000.0
+    )
+    assert result["results"][0]["volume_24h"] == pytest.approx(9_500.0)
     assert result["results"][0]["adx"] == pytest.approx(18.7)
-    assert result["results"][0]["market_cap"] == 1_200_000_000_000_000.0
+    assert result["results"][0]["market_cap"] == pytest.approx(1_200_000_000_000_000.0)
 
 
 @pytest.mark.asyncio
@@ -325,7 +327,7 @@ async def test_screen_crypto_via_tvscreener_prefers_value_traded_over_usd_volume
 
     first = result["results"][0]
     assert first["symbol"] == "KRW-BTC"
-    assert first["trade_amount_24h"] == 900_000_000_000.0
+    assert first["trade_amount_24h"] == pytest.approx(900_000_000_000.0)
     assert first["volume_24h"] == pytest.approx(777.0)
 
 
@@ -536,7 +538,7 @@ async def test_finalize_crypto_screen_preserves_existing_market_cap_when_coingec
     )
 
     first = result["results"][0]
-    assert first["market_cap"] == 2_500_000_000_000_000.0
+    assert first["market_cap"] == pytest.approx(2_500_000_000_000_000.0)
     assert first["market_cap_rank"] == 1
 
 

--- a/tests/test_tvscreener_stocks.py
+++ b/tests/test_tvscreener_stocks.py
@@ -329,8 +329,8 @@ async def test_screen_us_queries_and_maps_optional_analyst_fields(
     assert result["stocks"][0]["analyst_buy"] == 22
     assert result["stocks"][0]["analyst_hold"] == 14
     assert result["stocks"][0]["analyst_sell"] == 2
-    assert result["stocks"][0]["avg_target"] == 205.0
-    assert result["stocks"][0]["upside_pct"] == 16.81
+    assert result["stocks"][0]["avg_target"] == pytest.approx(205.0)
+    assert result["stocks"][0]["upside_pct"] == pytest.approx(16.81)
 
 
 @pytest.mark.asyncio
@@ -414,9 +414,9 @@ async def test_screen_kr_joins_requested_submarket_and_valuation_data(
     stock = result["stocks"][0]
     assert stock["market"] == "KOSPI"
     assert stock["market_cap"] == 4800000
-    assert stock["per"] == 12.5
-    assert stock["pbr"] == 1.2
-    assert stock["dividend_yield"] == 0.0256
+    assert stock["per"] == pytest.approx(12.5)
+    assert stock["pbr"] == pytest.approx(1.2)
+    assert stock["dividend_yield"] == pytest.approx(0.0256)
 
 
 @pytest.mark.asyncio
@@ -502,9 +502,9 @@ async def test_screen_us_adds_valuation_filters_and_applies_missing_value_backst
     ]
     assert result["count"] == 1
     assert [stock["symbol"] for stock in result["stocks"]] == ["AAPL"]
-    assert result["stocks"][0]["market_cap"] == 2_800_000_000_000.0
-    assert result["stocks"][0]["per"] == 28.5
-    assert result["stocks"][0]["dividend_yield"] == 0.005
+    assert result["stocks"][0]["market_cap"] == pytest.approx(2_800_000_000_000.0)
+    assert result["stocks"][0]["per"] == pytest.approx(28.5)
+    assert result["stocks"][0]["dividend_yield"] == pytest.approx(0.005)
 
 
 @pytest.mark.asyncio
@@ -544,7 +544,7 @@ async def test_screen_us_drops_rows_without_usable_price(
 
     assert result["count"] == 1
     assert [stock["symbol"] for stock in result["stocks"]] == ["AAPL"]
-    assert result["stocks"][0]["price"] == 175.5
+    assert result["stocks"][0]["price"] == pytest.approx(175.5)
 
 
 @pytest.mark.asyncio

--- a/tests/test_watch_order_intent_preview_builder.py
+++ b/tests/test_watch_order_intent_preview_builder.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+import pytest
+
 from app.services.watch_intent_policy import IntentPolicy
 from app.services.watch_order_intent_preview_builder import (
     IntentBuildFailure,
@@ -55,13 +57,13 @@ class TestKrQuantitySuccess:
         assert line.account_mode == "kis_mock"
         assert line.execution_source == "watch"
         assert line.lifecycle_state == "previewed"
-        assert line.quantity == Decimal("1")
-        assert line.limit_price == Decimal("70000")
-        assert line.notional == Decimal("70000")
+        assert line.quantity == pytest.approx(Decimal("1"))
+        assert line.limit_price == pytest.approx(Decimal("70000"))
+        assert line.notional == pytest.approx(Decimal("70000"))
         assert line.currency == "KRW"
         assert line.guard.execution_allowed is False
         assert line.guard.approval_required is True
-        assert result.notional_krw_evaluated == Decimal("70000")
+        assert result.notional_krw_evaluated == pytest.approx(Decimal("70000"))
         assert result.fx_usd_krw_used is None
 
     def test_static_limit_price_override_used(self) -> None:
@@ -73,9 +75,9 @@ class TestKrQuantitySuccess:
             kst_date="2026-05-04",
         )
         assert isinstance(result, IntentBuildSuccess)
-        assert result.preview_line.limit_price == Decimal("69000")
-        assert result.preview_line.notional == Decimal("138000")
-        assert result.notional_krw_evaluated == Decimal("138000")
+        assert result.preview_line.limit_price == pytest.approx(Decimal("69000"))
+        assert result.preview_line.notional == pytest.approx(Decimal("138000"))
+        assert result.notional_krw_evaluated == pytest.approx(Decimal("138000"))
 
 
 class TestKrNotionalKrwSizing:
@@ -89,8 +91,8 @@ class TestKrNotionalKrwSizing:
         )
         assert isinstance(result, IntentBuildSuccess)
         # floor(141000 / 70000) == 2
-        assert result.preview_line.quantity == Decimal("2")
-        assert result.preview_line.notional == Decimal("140000")
+        assert result.preview_line.quantity == pytest.approx(Decimal("2"))
+        assert result.preview_line.notional == pytest.approx(Decimal("140000"))
 
     def test_notional_krw_floor_below_one_is_qty_zero_failure(self) -> None:
         result = build_preview(
@@ -116,11 +118,11 @@ class TestUsWithFxAndCap:
         assert isinstance(result, IntentBuildSuccess)
         line = result.preview_line
         assert line.currency == "USD"
-        assert line.limit_price == Decimal("180")
-        assert line.notional == Decimal("1800")
+        assert line.limit_price == pytest.approx(Decimal("180"))
+        assert line.notional == pytest.approx(Decimal("1800"))
         # 10 * 180 * 1400 = 2_520_000
-        assert result.notional_krw_evaluated == Decimal("2520000")
-        assert result.fx_usd_krw_used == Decimal("1400")
+        assert result.notional_krw_evaluated == pytest.approx(Decimal("2520000"))
+        assert result.fx_usd_krw_used == pytest.approx(Decimal("1400"))
 
     def test_us_without_fx_quote_is_fx_unavailable_failure(self) -> None:
         result = build_preview(
@@ -144,5 +146,5 @@ class TestUsWithFxAndCap:
         assert isinstance(result, IntentBuildFailure)
         assert result.blocked_by == "max_notional_krw_cap"
         # Failure still records evaluated KRW so the ledger row carries it
-        assert result.notional_krw_evaluated == Decimal("2520000")
-        assert result.fx_usd_krw_used == Decimal("1400")
+        assert result.notional_krw_evaluated == pytest.approx(Decimal("2520000"))
+        assert result.fx_usd_krw_used == pytest.approx(Decimal("1400"))

--- a/tests/test_websocket_monitor.py
+++ b/tests/test_websocket_monitor.py
@@ -569,7 +569,7 @@ class TestUnifiedWebSocketMonitor:
             last_pingpong_at="2026-03-09T14:01:10+00:00",
         )
 
-        assert monitor._health_log_interval_seconds == 123.0
+        assert monitor._health_log_interval_seconds == pytest.approx(123.0)
 
         caplog.set_level("INFO")
         monitor._log_health_status(force=True)
@@ -819,7 +819,7 @@ class TestAutoReconnect:
         monitor = UnifiedWebSocketMonitor(mode="upbit")
         monitor._reconnect_delay_seconds = 5.0
 
-        assert monitor._reconnect_delay_seconds == 5.0
+        assert monitor._reconnect_delay_seconds == pytest.approx(5.0)
 
     def test_heartbeat_path_configurable(
         self, mock_settings: None, monkeypatch: pytest.MonkeyPatch
@@ -839,7 +839,7 @@ class TestAutoReconnect:
 
         monkeypatch.setenv("WS_MONITOR_HEARTBEAT_INTERVAL_SECONDS", "30")
         monitor = UnifiedWebSocketMonitor()
-        assert monitor._heartbeat_interval_seconds == 30.0
+        assert monitor._heartbeat_interval_seconds == pytest.approx(30.0)
 
     def test_health_log_interval_defaults_to_five_minutes(
         self, mock_settings: None, monkeypatch: pytest.MonkeyPatch
@@ -848,7 +848,7 @@ class TestAutoReconnect:
 
         monkeypatch.delenv("WS_MONITOR_HEALTH_LOG_INTERVAL_SECONDS", raising=False)
         monitor = UnifiedWebSocketMonitor()
-        assert monitor._health_log_interval_seconds == 300.0
+        assert monitor._health_log_interval_seconds == pytest.approx(300.0)
 
     @pytest.mark.asyncio
     async def test_supervisor_exits_on_stop_before_start(

--- a/tests/test_yfinance_sentry.py
+++ b/tests/test_yfinance_sentry.py
@@ -247,7 +247,7 @@ class TestYahooRetryOnCrumbError:
         monkeypatch.setattr("app.services.brokers.yahoo.client.yf.Ticker", fake_ticker)
 
         result = _fetch_fast_info_sync("BRK.B")
-        assert result["close"] == 101.5
+        assert result["close"] == pytest.approx(101.5)
         assert call_count == 2
         assert len(sessions_created) == 2  # fresh session for retry
 
@@ -340,5 +340,5 @@ class TestFetchFundamentalInfoRetry:
         monkeypatch.setattr("app.services.brokers.yahoo.client.yf.Ticker", fake_ticker)
 
         result = await fetch_fundamental_info("AAPL")
-        assert result["PER"] == 25.0
+        assert result["PER"] == pytest.approx(25.0)
         assert call_count == 2


### PR DESCRIPTION
## Summary

SonarCloud Quality Gate cleanup — 잔여 330 S1244를 일괄 처리.

Phase 6 후에도 main scan은 330건의 python:S1244를 표시 (Reliability C). 원인은 transformer 정규식이 underscore-separated 숫자 리터럴 (\`100_000_000.0\`, \`Decimal(\"1_000_000\")\`) 을 매치하지 못했기 때문.

이 PR은 정규식을 보완해 \`tests/\` 트리 전체에 재실행.

## Changes

- 343 S1244 사이트 → \`pytest.approx()\` 일괄 래핑 (60 files)
- Phase 6에서 빠뜨렸던 nested 디렉토리도 포함: \`tests/services/\`, \`tests/backtest/\`, \`tests/models/\`
- 2개 파일은 transformer의 자동 import 삽입이 multi-line \`from ... import (...)\` 블록 안에 들어가 syntax error → 수동 수정:
  - \`tests/test_kis_market_adapters_helpers.py\`
  - \`tests/test_analyst_normalizer.py\`

## Test plan

- [x] 60개 변경 파일 (\`_mcp_screen_stocks_support.py\` 제외) → 1284 pass / 2 skip
- [x] \`uv run ruff format\` 적용 (4 reformatted)
- [x] \`uv run ruff check --fix\` 적용 (6 import-order fixes)
- [ ] (수동) main 머지 후 SonarCloud 새 코드 기간 Reliability=A 확인

\`tests/_mcp_screen_stocks_support.py\` 의 pre-existing 8건 실패는 본 PR과 무관 — pytest의 \`python_files\` glob (\`test_*.py\`)이 underscore-prefix 파일을 수집하지 않으므로 CI에 영향 없음.

## Quality Gate 진행 상황

| 조건 | Phase 6 후 | Phase 7 후 (예상) |
|---|---|---|
| Reliability Rating | C (330 MAJOR) | **A** ✓ |
| Hotspots Reviewed | 98.6% (사용자 진행 중) | (사용자 진행 중) |
| Duplications 3.78% (≤ 3.0%) | ❌ | ❌ 별도 작업 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* **Tests** - Updated 50+ test files across backtest, service, and integration tests to use `pytest.approx()` for floating-point and decimal comparisons instead of exact equality checks. This improves test robustness against minor numeric representation differences while maintaining all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->