### PR TITLE
ROB-136: Add lab-only Korean LLM issue rendering

### DIFF
--- a/docs/runbooks/news-issue-lab.md
+++ b/docs/runbooks/news-issue-lab.md
@@ -149,3 +149,51 @@ Markdown output gains a `## 클러스터 병합 진단 (ROB-135)` section with m
 
 - Topic-label rules can still cosmetically mislabel Yahoo credit-card titles ("Gold" → 금·원자재). The merge pass does not depend on those labels being correct, but operators may see odd-looking topic agreement signals on noise rows. Existing `noise_penalty` continues to downrank them.
 - Yahoo plural/singular term mismatches (e.g., `credit cards` vs `credit card`) are unchanged in this scope.
+
+
+## Korean LLM rendering (ROB-136)
+
+ROB-136 keeps Korean issue-card rendering inside this lab CLI only. It does not add production API, UI, MCP, scheduler, broker, order, watch, or request-time LLM behavior.
+
+### Default no-LLM mode
+
+LLM rendering is disabled by default. The default path is deterministic and uses the rule-based card plus fallback metadata:
+
+```bash
+uv run python scripts/news_issue_lab.py   --market all --window-hours 24 --limit 240 --top 12   --embedding-endpoint http://127.0.0.1:10631/v1/embeddings   --embedding-model BAAI/bge-m3   --compare-v1 --merge-clusters   --format json   --output /tmp/rob136_news_issue_lab_no_llm.json
+```
+
+`--no-llm` is an explicit alias for the same deterministic mode.
+
+### Optional LLM smoke
+
+Use `--llm-render` only for an operator-confirmed local/OpenAI-compatible endpoint and start with a small `--llm-max-render`. Run without `--store` first and inspect the markdown or JSON output before persisting any lab result.
+
+```bash
+uv run python scripts/news_issue_lab.py   --market all --window-hours 24 --limit 240 --top 12   --embedding-endpoint http://127.0.0.1:10631/v1/embeddings   --embedding-model BAAI/bge-m3   --compare-v1 --merge-clusters   --llm-render   --llm-endpoint http://127.0.0.1:8000   --llm-model <local-openai-compatible-model>   --llm-max-render 5   --format json   --output /tmp/rob136_news_issue_lab_llm_top5.json
+```
+
+### Schema and fallback
+
+The renderer validates that each LLM response is a JSON object with:
+
+- `title_ko`
+- `subtitle_ko`
+- `direction` (`up`, `down`, or `neutral`)
+- `summary_ko`
+- `impact_points`
+- `related_symbols`
+- `confidence`
+
+Malformed JSON, missing fields, wrong types, empty title/subtitle/summary, invalid direction/confidence, length/cardinality violations, unknown related symbols, low Korean-script ratio, or investment-advice phrases such as 매수/매도/추천/목표가 cause deterministic fallback. Fallback cards keep the rule-based title/subtitle/direction, add a schema-complete Korean summary and impact points, set `confidence=0.0`, and record `render_status=fallback` plus `render_rejection_reason`.
+
+### Diagnostics and storage
+
+Run-level diagnostics live at `payload.run.llm_render` and include enabled/provider/model/prompt version, requested count, ok/fallback/skipped counts, rejection counts, and total latency. Each issue payload records `render_status`, `render_model`, `render_prompt_version`, `render_input_hash`, `render_rejection_reason`, `render_latency_ms`, `summary_ko`, `impact_points`, and `confidence`. Existing lab result columns continue to receive the final top-level rendered-or-fallback `title_ko`, `subtitle_ko`, and `direction`; no DDL is required.
+
+### Safety reminders
+
+- Do not send or store full article bodies; prompts are built from cluster metadata, titles, source/feed_source, timestamps, short summaries/excerpts, topics, related symbols, and ranking/merge diagnostics only.
+- Do not print credentials, tokens, cookies, DSNs, or Authorization values.
+- Do not run `--store` until no-store markdown/JSON output has been reviewed.
+- Do not wire this renderer into production API/UI/MCP request paths without a separate issue and review.

--- a/docs/runbooks/news-issue-lab.md
+++ b/docs/runbooks/news-issue-lab.md
@@ -6,14 +6,14 @@
 
 ## Required non-mutating smoke
 
-Run the lab against the MacBook server DB and local BGE-M3 endpoint without storing results:
+Run the lab against the MacBook server DB and local BGE-M3 endpoint without storing results. The CLI default `--batch-size 16` is intentionally conservative for the local embedding server; keep it unless the server has been separately load-tested.
 
 ```bash
 uv run python scripts/news_issue_lab.py \
   --market all --window-hours 24 --limit 240 --top 12 \
   --embedding-endpoint http://127.0.0.1:10631/v1/embeddings \
   --embedding-model BAAI/bge-m3 \
-  --compare-v1 \
+  --compare-v1 --merge-clusters \
   --output /tmp/news_issue_lab_v2_24h_all_240.md
 ```
 
@@ -87,3 +87,65 @@ JSON output adds the same data under top-level `v1_vs_v2`.
 - Do not redistribute or store full article bodies; use titles, summaries, sources, URLs, and metadata only.
 - Do not print credentials, tokens, or connection strings.
 - Do not run `--store` until markdown/json non-store smoke output is visually acceptable.
+
+## 클러스터 병합 (ROB-135)
+
+The merge pass runs after the per-article clustering and before the V2 ranking. It fuses near-duplicate clusters that share a topic, symbol, or strong lexical/embedding overlap, so the top-N stops being dominated by single-article topic-tied entries (the ROB-134 baseline showed many ties at 0.5053).
+
+### Default behavior
+
+- Merge pass is **on** by default. To reproduce ROB-134 exactly, pass `--no-merge-clusters`.
+- Defaults: `--merge-rep-threshold 0.86`, `--merge-token-jaccard 0.30`, `--merge-rep-articles 3`; topic-label agreement also has a calibrated low-rep safety valve at `topic_rep_threshold=0.43` for the ROB-134 duplicate-title baseline.
+- Merge requires `rep_sim >= rep_threshold` AND at least one of `topic_agree`, `symbol_agree`, `token_jaccard >= token_jaccard_threshold`. Strong embedding similarity (≥ 0.93) plus minimal lexical overlap also merges. When two clusters have the same rule-based topic label, `rep_sim >= 0.43` is sufficient after the normal anti-merge guardrails, because the local BGE-M3 representative vectors score Korean/English same-topic headlines lower than the original 0.86 plan assumption.
+- Anti-merge guardrails block: zero-token-overlap noise, oversized fused clusters (>25 articles), and source-diverse clusters with disagreeing topic labels.
+
+### Smoke commands
+
+```bash
+# merged output (default)
+uv run python scripts/news_issue_lab.py \
+  --market all --window-hours 24 --limit 240 --top 12 \
+  --embedding-endpoint http://127.0.0.1:10631/v1/embeddings \
+  --embedding-model BAAI/bge-m3 \
+  --compare-v1 --merge-clusters \
+  --output /tmp/rob135_news_issue_lab_v2_24h_all_240_merged.md
+
+# JSON variant
+uv run python scripts/news_issue_lab.py \
+  --market all --window-hours 24 --limit 240 --top 12 \
+  --embedding-endpoint http://127.0.0.1:10631/v1/embeddings \
+  --embedding-model BAAI/bge-m3 \
+  --compare-v1 --merge-clusters --format json \
+  --output /tmp/rob135_news_issue_lab_v2_24h_all_240_merged.json
+
+# baseline (ROB-134 behavior)
+uv run python scripts/news_issue_lab.py \
+  --market all --window-hours 24 --limit 240 --top 12 \
+  --embedding-endpoint http://127.0.0.1:10631/v1/embeddings \
+  --embedding-model BAAI/bge-m3 \
+  --compare-v1 --no-merge-clusters --format json \
+  --output /tmp/rob135_news_issue_lab_v2_24h_all_240_baseline.json
+```
+
+### Diagnostics
+
+Every issue payload gains:
+
+- `merge_member_count`
+- `merged_cluster_ids`
+
+The top-level payload gains:
+
+- `merge_diagnostics.enabled`
+- `merge_diagnostics.merge_before_count`
+- `merge_diagnostics.merge_after_count`
+- `merge_diagnostics.rejected_near_misses`
+- `merge_diagnostics.thresholds`
+- `merge_diagnostics.decisions[]` (each with `absorber_cid`, `absorbed_cid`, `rep_sim`, `token_jaccard`, `source_overlap`, `topic_agree`, `symbol_agree`, `decision`, `reason`, `absorber_title`, `absorbed_title`)
+
+Markdown output gains a `## 클러스터 병합 진단 (ROB-135)` section with merged-cluster and rejected-near-miss tables.
+
+### Known limits (out of scope for ROB-135)
+
+- Topic-label rules can still cosmetically mislabel Yahoo credit-card titles ("Gold" → 금·원자재). The merge pass does not depend on those labels being correct, but operators may see odd-looking topic agreement signals on noise rows. Existing `noise_penalty` continues to downrank them.
+- Yahoo plural/singular term mismatches (e.g., `credit cards` vs `credit card`) are unchanged in this scope.

--- a/docs/runbooks/news-issue-lab.md
+++ b/docs/runbooks/news-issue-lab.md
@@ -1,0 +1,89 @@
+# News Issue Lab v2 diagnostics runbook
+
+## Purpose
+
+`scripts/news_issue_lab.py` is an experimental operator lab for inspecting Toss-like market news issue candidates from existing `news_articles` rows. ROB-134 adds filtering and ranking diagnostics before any LLM rendering or production read-layer promotion.
+
+## Required non-mutating smoke
+
+Run the lab against the MacBook server DB and local BGE-M3 endpoint without storing results:
+
+```bash
+uv run python scripts/news_issue_lab.py \
+  --market all --window-hours 24 --limit 240 --top 12 \
+  --embedding-endpoint http://127.0.0.1:10631/v1/embeddings \
+  --embedding-model BAAI/bge-m3 \
+  --compare-v1 \
+  --output /tmp/news_issue_lab_v2_24h_all_240.md
+```
+
+Structured JSON inspection variant:
+
+```bash
+uv run python scripts/news_issue_lab.py \
+  --market all --window-hours 24 --limit 240 --top 12 \
+  --embedding-endpoint http://127.0.0.1:10631/v1/embeddings \
+  --embedding-model BAAI/bge-m3 \
+  --compare-v1 --format json \
+  --output /tmp/news_issue_lab_v2_24h_all_240.json
+```
+
+## Score formula summary
+
+V2 ranks clusters by a scalar score and keeps diagnostics in every issue payload:
+
+```text
+score =
+  0.40 * source_diversity_norm
++ 0.25 * article_count_norm
++ 0.20 * recency_norm
++ 0.15 * topic_relevance
+- min(0.40, noise_penalty)
+- min(0.45, regular_report_penalty)
+- min(0.30, duplicate_source_penalty)
+```
+
+Default behavior penalizes noisy and regular-report clusters rather than hard-dropping them. Use `--drop-regular-reports` only for explicit tuning when clusters with at least 50% regular-report titles should be removed from the displayed V2 ranking.
+
+Weights can be tuned with:
+
+```bash
+--weights diversity=0.40,volume=0.25,recency=0.20,relevance=0.15
+```
+
+Weights must include exactly `diversity`, `volume`, `recency`, and `relevance`, be non-negative, and sum to 1.0.
+
+## Raw vs normalized source counts
+
+`raw_source_count` counts original source/feed keys. `normalized_source_count` collapses equivalent source families before scoring. In ROB-134, all `browser_naver_research_*` variants normalize to `browser_naver_research` so many research-house crawler keys do not inflate independent-source diversity.
+
+Every issue includes:
+
+- `source_counts.raw`
+- `source_counts.normalized`
+- `raw_source_count`
+- `normalized_source_count`
+- `score_components`, `score_weighted`, and `score_penalties`
+
+The top-level payload also includes raw and normalized source distribution maps for the full fetched article set.
+
+## v1/v2 comparison
+
+Add `--compare-v1` to preserve the legacy ranking for diagnostics. Markdown output includes:
+
+- side-by-side top-N rank table
+- downranked/excluded clusters and their dominant penalty
+- promoted clusters and score components
+- V2 top-N diagnostics table
+
+JSON output adds the same data under top-level `v1_vs_v2`.
+
+## Safety boundaries
+
+- Lab-only scope; do not promote this ranking into production services without a later issue.
+- Do not add LLM rendering in ROB-134.
+- Do not run broker/order/watch/scheduler/trading mutations.
+- Do not perform destructive DB changes.
+- Do not redistribute or store full article bodies; use titles, summaries, sources, URLs, and metadata only.
+- Do not print credentials, tokens, or connection strings.
+- Do not run `--store` until markdown/json non-store smoke output is visually acceptable.

--- a/scripts/news_issue_lab.py
+++ b/scripts/news_issue_lab.py
@@ -2207,6 +2207,11 @@ async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
     return payload
 
 
+def write_output_file(path: str, rendered: str) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(rendered)
+
+
 async def async_main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     payload = await build_payload(args)
@@ -2218,8 +2223,7 @@ async def async_main(argv: list[str] | None = None) -> int:
         else render_markdown(payload)
     )
     if args.output:
-        with open(args.output, "w", encoding="utf-8") as f:
-            f.write(rendered)
+        write_output_file(args.output, rendered)
     else:
         print(rendered)
     return 0

--- a/scripts/news_issue_lab.py
+++ b/scripts/news_issue_lab.py
@@ -229,6 +229,65 @@ STOPWORDS = {
     "분석",
 }
 
+RESEARCH_HOUSE_PREFIXES: tuple[str, ...] = ("browser_naver_research",)
+MARKET_SIGNAL_TERMS: tuple[str, ...] = (
+    "fed",
+    "federal reserve",
+    "fomc",
+    "cpi",
+    "treasury",
+    "yield",
+    "s&p",
+    "s&p 500",
+    "nasdaq",
+    "earnings",
+    "shares",
+    "stock",
+    "stocks",
+    "analyst",
+    "revenue",
+    "profit",
+    "연준",
+    "금리",
+    "실적",
+    "증시",
+    "주식",
+)
+YAHOO_PERSONAL_FINANCE_TERMS: tuple[str, ...] = (
+    "card",
+    "credit card",
+    "travel",
+    "mortgage",
+    "savings",
+    "savings account",
+    "loan",
+    "insurance",
+    "personal finance",
+    "apy",
+    "home buyer",
+    "home buyers",
+)
+REGULAR_REPORT_TERMS: tuple[str, ...] = (
+    "morning letter",
+    "daily",
+    "weekly",
+    "데일리",
+    "장마감코멘트",
+    "모닝코멘트",
+    "전략공감",
+    "이슈코멘트",
+    "주간",
+)
+
+
+def normalize_source_key(source_key: str | None) -> str:
+    if not source_key:
+        return "unknown"
+    for prefix in RESEARCH_HOUSE_PREFIXES:
+        if source_key == prefix or source_key.startswith(prefix + "_"):
+            return prefix
+    return source_key
+
 
 @dataclass(frozen=True)
 class Article:
@@ -246,6 +305,10 @@ class Article:
     @property
     def source_key(self) -> str:
         return self.feed_source or self.source or "unknown"
+
+    @property
+    def normalized_source_key(self) -> str:
+        return normalize_source_key(self.source_key)
 
     @property
     def text_for_embedding(self) -> str:
@@ -290,7 +353,25 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--format", choices=["markdown", "json"], default="markdown")
     parser.add_argument("--output", help="optional output file path")
-    return parser.parse_args(argv)
+    parser.add_argument(
+        "--compare-v1",
+        action="store_true",
+        help="include legacy v1 vs v2 ranking diagnostics",
+    )
+    parser.add_argument(
+        "--weights",
+        help="score weights as diversity=0.40,volume=0.25,recency=0.20,relevance=0.15",
+    )
+    parser.add_argument(
+        "--drop-regular-reports",
+        action="store_true",
+        help="hard-drop clusters where regular reports are at least half of titles",
+    )
+    args = parser.parse_args(argv)
+    for name in ("window_hours", "limit", "top", "batch_size"):
+        if getattr(args, name) <= 0:
+            parser.error(f"--{name.replace('_', '-')} must be positive")
+    return args
 
 
 def normalize_text(s: str) -> str:
@@ -389,11 +470,242 @@ def cluster_articles(
 def keyword_matches(text_blob: str, keyword: str) -> bool:
     keyword_l = keyword.lower()
     if re.search(r"[가-힣]", keyword_l):
+        if len(keyword_l) <= 1:
+            return bool(
+                re.search(rf"(?<![가-힣]){re.escape(keyword_l)}(?![가-힣])", text_blob)
+            )
         return keyword_l in text_blob
     # Avoid substring false positives such as "ai" in "daily" or "ether" in "together".
     return bool(
         re.search(rf"(?<![a-z0-9]){re.escape(keyword_l)}(?![a-z0-9])", text_blob)
     )
+
+
+@dataclass(frozen=True)
+class TitleFlags:
+    is_regular_report: bool
+    is_yahoo_personal_finance: bool
+    has_market_signal: bool
+
+
+@dataclass(frozen=True)
+class ScoreWeights:
+    diversity: float = 0.40
+    volume: float = 0.25
+    recency: float = 0.20
+    relevance: float = 0.15
+
+
+DEFAULT_WEIGHTS = ScoreWeights()
+
+
+@dataclass(frozen=True)
+class ScoreBreakdown:
+    score: float
+    components: dict[str, float]
+    weighted: dict[str, float]
+    penalties: dict[str, float]
+    raw_source_count: int
+    normalized_source_count: int
+    flags: dict[str, int]
+
+
+def _round_score(value: float) -> float:
+    return round(float(value), 4)
+
+
+def _article_blob(article: Article) -> str:
+    return f"{article.title} {article.summary or ''}".lower()
+
+
+def _has_any_keyword(text_blob: str, terms: tuple[str, ...]) -> bool:
+    return any(keyword_matches(text_blob, term) for term in terms)
+
+
+def classify_title(article: Article) -> TitleFlags:
+    blob = _article_blob(article)
+    has_market_signal = _has_any_keyword(blob, MARKET_SIGNAL_TERMS)
+    is_regular_report = _has_any_keyword(blob, REGULAR_REPORT_TERMS)
+    source_blob = article.source_key.lower()
+    has_pf_term = _has_any_keyword(blob, YAHOO_PERSONAL_FINANCE_TERMS)
+    is_yahoo_personal_finance = has_pf_term and "yahoo" in source_blob
+    return TitleFlags(
+        is_regular_report=is_regular_report,
+        is_yahoo_personal_finance=is_yahoo_personal_finance,
+        has_market_signal=has_market_signal,
+    )
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def parse_weights(value: str | None) -> ScoreWeights:
+    if not value:
+        return DEFAULT_WEIGHTS
+    allowed = {"diversity", "volume", "recency", "relevance"}
+    parsed: dict[str, float] = {}
+    for part in value.split(","):
+        if not part.strip():
+            continue
+        if "=" not in part:
+            raise ValueError(f"invalid weight item: {part!r}")
+        key, raw_value = [x.strip() for x in part.split("=", 1)]
+        if key not in allowed:
+            raise ValueError(f"unknown weight key: {key}")
+        try:
+            weight = float(raw_value)
+        except ValueError as exc:
+            raise ValueError(f"invalid weight value for {key}: {raw_value}") from exc
+        if weight < 0:
+            raise ValueError(f"weight must be non-negative: {key}")
+        parsed[key] = weight
+    missing = allowed - parsed.keys()
+    if missing:
+        raise ValueError(f"missing weight keys: {', '.join(sorted(missing))}")
+    total = sum(parsed.values())
+    if not math.isclose(total, 1.0, abs_tol=0.001):
+        raise ValueError(f"weights must sum to 1.0, got {total:.4f}")
+    return ScoreWeights(
+        diversity=parsed["diversity"],
+        volume=parsed["volume"],
+        recency=parsed["recency"],
+        relevance=parsed["relevance"],
+    )
+
+
+def _topic_relevance(rows: list[Article]) -> float:
+    text_blob = "\n".join([a.title + " " + (a.summary or "") for a in rows]).lower()
+    for _, _, keys in TOPIC_RULES:
+        if any(keyword_matches(text_blob, key) for key in keys):
+            return 1.0
+    return 0.5 if _has_any_keyword(text_blob, MARKET_SIGNAL_TERMS) else 0.0
+
+
+def score_cluster(
+    cluster: dict[str, Any],
+    articles: list[Article],
+    *,
+    window_hours: int,
+    weights: ScoreWeights = DEFAULT_WEIGHTS,
+) -> ScoreBreakdown:
+    rows = [articles[i] for i in cluster["indices"]]
+    raw_sources = {a.source_key for a in rows}
+    normalized_sources = {a.normalized_source_key for a in rows}
+    raw_source_count = len(raw_sources)
+    normalized_source_count = len(normalized_sources)
+    newest = max(
+        (
+            _parse_datetime(a.published_at) or _parse_datetime(a.scraped_at)
+            for a in rows
+        ),
+        default=None,
+    )
+    now = datetime.now(UTC)
+    newest_age_minutes = (
+        ((now - newest).total_seconds() / 60) if newest else window_hours * 60
+    )
+    source_diversity_norm = min(1.0, normalized_source_count / 5)
+    article_count_norm = min(1.0, math.log1p(len(rows)) / math.log(10))
+    recency_norm = min(
+        1.0,
+        max(0.0, 1.0 - newest_age_minutes / max(window_hours * 60, 1)),
+    )
+    topic_relevance = _topic_relevance(rows)
+    flags_by_article = [classify_title(a) for a in rows]
+    yahoo_noise_count = sum(f.is_yahoo_personal_finance for f in flags_by_article)
+    regular_report_count = sum(f.is_regular_report for f in flags_by_article)
+    market_signal_count = sum(f.has_market_signal for f in flags_by_article)
+    noise_penalty = 0.10 * min(4, yahoo_noise_count)
+    if yahoo_noise_count and market_signal_count:
+        noise_penalty *= 0.25
+    regular_report_penalty = 0.15 * min(3, regular_report_count)
+    duplicate_source_penalty = (
+        max(
+            0.0,
+            1.0 - normalized_source_count / max(1, raw_source_count),
+        )
+        * 0.30
+    )
+    penalties = {
+        "noise": min(0.40, noise_penalty),
+        "regular_report": min(0.45, regular_report_penalty),
+        "duplicate_source": min(0.30, duplicate_source_penalty),
+    }
+    components = {
+        "source_diversity_norm": source_diversity_norm,
+        "article_count_norm": article_count_norm,
+        "recency_norm": recency_norm,
+        "topic_relevance": topic_relevance,
+    }
+    weighted = {
+        "source_diversity": source_diversity_norm * weights.diversity,
+        "article_count": article_count_norm * weights.volume,
+        "recency": recency_norm * weights.recency,
+        "topic_relevance": topic_relevance * weights.relevance,
+    }
+    score = max(0.0, sum(weighted.values()) - sum(penalties.values()))
+    return ScoreBreakdown(
+        score=_round_score(score),
+        components={k: _round_score(v) for k, v in components.items()},
+        weighted={k: _round_score(v) for k, v in weighted.items()},
+        penalties={k: _round_score(v) for k, v in penalties.items()},
+        raw_source_count=raw_source_count,
+        normalized_source_count=normalized_source_count,
+        flags={
+            "yahoo_personal_finance": int(yahoo_noise_count),
+            "regular_report": int(regular_report_count),
+            "market_signal": int(market_signal_count),
+        },
+    )
+
+
+def rank_clusters_v2(
+    clusters: list[dict[str, Any]],
+    articles: list[Article],
+    *,
+    window_hours: int,
+    weights: ScoreWeights = DEFAULT_WEIGHTS,
+) -> list[tuple[dict[str, Any], ScoreBreakdown]]:
+    ranked = [
+        (
+            cluster,
+            score_cluster(
+                cluster, articles, window_hours=window_hours, weights=weights
+            ),
+        )
+        for cluster in clusters
+    ]
+    return sorted(
+        ranked,
+        key=lambda item: (
+            item[1].score,
+            item[1].normalized_source_count,
+            len(item[0]["indices"]),
+            float(item[0].get("best_similarity", 0.0)),
+        ),
+        reverse=True,
+    )
+
+
+def _breakdown_payload(score_breakdown: ScoreBreakdown) -> dict[str, Any]:
+    return {
+        "score": score_breakdown.score,
+        "score_components": score_breakdown.components,
+        "score_weighted": score_breakdown.weighted,
+        "score_penalties": score_breakdown.penalties,
+        "raw_source_count": score_breakdown.raw_source_count,
+        "normalized_source_count": score_breakdown.normalized_source_count,
+        "flags": score_breakdown.flags,
+    }
 
 
 def infer_topic(articles: list[Article]) -> tuple[str, str, list[str]]:
@@ -428,10 +740,14 @@ def infer_direction(articles: list[Article]) -> str:
 
 
 def summarize_cluster(
-    cluster: dict[str, Any], articles: list[Article], rank: int
+    cluster: dict[str, Any],
+    articles: list[Article],
+    rank: int,
+    score_breakdown: ScoreBreakdown | None = None,
 ) -> dict[str, Any]:
     rows = [articles[i] for i in cluster["indices"]]
     source_counts = Counter(a.source_key for a in rows)
+    normalized_source_counts = Counter(a.normalized_source_key for a in rows)
     markets = sorted({a.market for a in rows})
     related_symbols = []
     seen = set()
@@ -456,6 +772,13 @@ def summarize_cluster(
         for a in rows[:8]
     ]
     issue_key_raw = "|".join([title, subtitle, ",".join(str(a.id) for a in rows[:8])])
+    if score_breakdown is None:
+        score_breakdown = score_cluster(
+            cluster,
+            articles,
+            window_hours=24,
+            weights=DEFAULT_WEIGHTS,
+        )
     return {
         "rank": rank,
         "cluster_key": hashlib.sha1(issue_key_raw.encode()).hexdigest()[:16],
@@ -463,9 +786,19 @@ def summarize_cluster(
         "subtitle_ko": subtitle,
         "direction": direction,
         "article_count": len(rows),
-        "source_count": len(source_counts),
+        "source_count": score_breakdown.normalized_source_count,
         "representative_sources": representative,
-        "source_counts": dict(source_counts),
+        "source_counts": {
+            "raw": dict(source_counts),
+            "normalized": dict(normalized_source_counts),
+        },
+        "raw_source_count": score_breakdown.raw_source_count,
+        "normalized_source_count": score_breakdown.normalized_source_count,
+        "score": score_breakdown.score,
+        "score_components": score_breakdown.components,
+        "score_weighted": score_breakdown.weighted,
+        "score_penalties": score_breakdown.penalties,
+        "flags": score_breakdown.flags,
         "markets": markets,
         "related_symbols": related_symbols[:10],
         "topics": topics[:8],
@@ -504,7 +837,8 @@ def render_markdown(payload: dict[str, Any]) -> str:
             [
                 f"### {issue['rank']}. {arrow.get(issue['direction'], '◆')} {issue['title_ko']}",
                 f"- 부제: {issue['subtitle_ko']}",
-                f"- 출처/기사: {issue['source_count']}개 출처 · {issue['article_count']}개 기사",
+                f"- 출처/기사: raw {issue.get('raw_source_count', issue['source_count'])}개 → normalized {issue.get('normalized_source_count', issue['source_count'])}개 · {issue['article_count']}개 기사",
+                f"- 점수: {issue.get('score', 0):.4f} / components={issue.get('score_components', {})} / penalties={issue.get('score_penalties', {})}",
                 f"- 대표 출처: {', '.join(issue['representative_sources']) or '-'}",
                 f"- 시장: {', '.join(issue['markets'])}",
                 f"- 토픽: {', '.join(issue['topics']) or '-'}",
@@ -528,6 +862,167 @@ def render_markdown(payload: dict[str, Any]) -> str:
             src = article.get("feed_source") or article.get("source") or "unknown"
             lines.append(f"  - [{src}] {article['title']}")
         lines.append("")
+    if payload.get("v1_vs_v2"):
+        lines.append(
+            render_comparison_markdown(
+                payload, [], [], top=meta.get("top", len(payload["issues"]))
+            ).rstrip()
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _dominant_penalty(issue: dict[str, Any]) -> str:
+    penalties = issue.get("score_penalties") or {}
+    if not penalties:
+        return "-"
+    key, value = max(penalties.items(), key=lambda item: item[1])
+    return f"{key}={value:.4f}"
+
+
+def _comparison_payload(
+    ranked_v1: list[dict[str, Any]],
+    ranked_v2: list[tuple[dict[str, Any], ScoreBreakdown]],
+    articles: list[Article],
+    *,
+    top: int,
+) -> dict[str, Any]:
+    v1_issues = [
+        summarize_cluster(cluster, articles, rank=i + 1)
+        for i, cluster in enumerate(ranked_v1)
+    ]
+    v2_issues = [
+        summarize_cluster(cluster, articles, rank=i + 1, score_breakdown=breakdown)
+        for i, (cluster, breakdown) in enumerate(ranked_v2)
+    ]
+    v1_by_key = {issue["cluster_key"]: issue for issue in v1_issues}
+    v2_by_key = {issue["cluster_key"]: issue for issue in v2_issues}
+    keys = list(
+        dict.fromkeys(
+            [i["cluster_key"] for i in v1_issues[:top]]
+            + [i["cluster_key"] for i in v2_issues[:top]]
+        )
+    )
+    side_by_side = []
+    for key in keys:
+        v1 = v1_by_key.get(key)
+        v2 = v2_by_key.get(key)
+        side_by_side.append(
+            {
+                "cluster_key": key,
+                "title_ko": (v2 or v1 or {}).get("title_ko", "-"),
+                "rank_v1": v1.get("rank") if v1 else None,
+                "rank_v2": v2.get("rank") if v2 else None,
+                "delta": (v1.get("rank") - v2.get("rank")) if v1 and v2 else None,
+            }
+        )
+    downranked = []
+    for issue in v1_issues[:top]:
+        v2 = v2_by_key.get(issue["cluster_key"])
+        if not v2 or v2["rank"] > top:
+            downranked.append(
+                {
+                    "cluster_key": issue["cluster_key"],
+                    "title_ko": issue["title_ko"],
+                    "rank_v1": issue["rank"],
+                    "rank_v2": v2.get("rank") if v2 else None,
+                    "dominant_penalty": _dominant_penalty(v2 or issue),
+                    "representative_titles": [
+                        a["title"] for a in issue["representative_articles"][:3]
+                    ],
+                }
+            )
+    promoted = []
+    for issue in v2_issues[:top]:
+        v1 = v1_by_key.get(issue["cluster_key"])
+        if not v1 or v1["rank"] > top:
+            promoted.append(
+                {
+                    "cluster_key": issue["cluster_key"],
+                    "title_ko": issue["title_ko"],
+                    "rank_v1": v1.get("rank") if v1 else None,
+                    "rank_v2": issue["rank"],
+                    "score": issue["score"],
+                    "score_components": issue["score_components"],
+                    "representative_sources": issue["representative_sources"],
+                }
+            )
+    return {
+        "side_by_side": side_by_side,
+        "downranked_or_excluded": downranked,
+        "promoted": promoted,
+        "v2_top_diagnostics": [
+            {
+                "rank": issue["rank"],
+                "cluster_key": issue["cluster_key"],
+                "title_ko": issue["title_ko"],
+                "score": issue["score"],
+                "score_components": issue["score_components"],
+                "score_penalties": issue["score_penalties"],
+                "raw_source_count": issue["raw_source_count"],
+                "normalized_source_count": issue["normalized_source_count"],
+                "article_count": issue["article_count"],
+            }
+            for issue in v2_issues[:top]
+        ],
+    }
+
+
+def render_comparison_markdown(
+    payload_v2: dict[str, Any],
+    ranked_v1: list[dict[str, Any]],
+    ranked_v2: list[tuple[dict[str, Any], ScoreBreakdown]],
+    *,
+    top: int,
+) -> str:
+    comparison = payload_v2.get("v1_vs_v2") or {
+        "side_by_side": [],
+        "downranked_or_excluded": [],
+        "promoted": [],
+        "v2_top_diagnostics": [],
+    }
+    lines = [
+        "",
+        "## v1 vs v2 comparison",
+        "",
+        "### Top-N rank table",
+        "",
+        "| cluster | title | rank_v1 | rank_v2 | delta |",
+        "|---|---|---:|---:|---:|",
+    ]
+    for row in comparison["side_by_side"][: top * 2]:
+        lines.append(
+            f"| `{row['cluster_key']}` | {row['title_ko']} | {row.get('rank_v1') or '-'} | {row.get('rank_v2') or '-'} | {row.get('delta') if row.get('delta') is not None else '-'} |"
+        )
+    lines.extend(["", "### Downranked/excluded clusters", ""])
+    for row in comparison["downranked_or_excluded"][:top]:
+        titles = "; ".join(row.get("representative_titles") or [])
+        lines.append(
+            f"- `{row['cluster_key']}` {row['title_ko']} (v1={row.get('rank_v1')}, v2={row.get('rank_v2') or '-'}) dominant_penalty={row.get('dominant_penalty', '-')} titles={titles}"
+        )
+    if not comparison["downranked_or_excluded"]:
+        lines.append("- none")
+    lines.extend(["", "### Promoted clusters", ""])
+    for row in comparison["promoted"][:top]:
+        lines.append(
+            f"- `{row['cluster_key']}` {row['title_ko']} (v1={row.get('rank_v1') or '-'}, v2={row.get('rank_v2')}) score={row.get('score')} components={row.get('score_components')} sources={', '.join(row.get('representative_sources') or [])}"
+        )
+    if not comparison["promoted"]:
+        lines.append("- none")
+    lines.extend(
+        [
+            "",
+            "### V2 top-N diagnostics",
+            "",
+            "| rank | score | div | vol | rec | rel | noise | regular | duplicate | raw | normalized | articles |",
+            "|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for row in comparison["v2_top_diagnostics"][:top]:
+        comp = row.get("score_components") or {}
+        penalties = row.get("score_penalties") or {}
+        lines.append(
+            f"| {row['rank']} | {row['score']:.4f} | {comp.get('source_diversity_norm', 0):.4f} | {comp.get('article_count_norm', 0):.4f} | {comp.get('recency_norm', 0):.4f} | {comp.get('topic_relevance', 0):.4f} | {penalties.get('noise', 0):.4f} | {penalties.get('regular_report', 0):.4f} | {penalties.get('duplicate_source', 0):.4f} | {row.get('raw_source_count')} | {row.get('normalized_source_count')} | {row.get('article_count')} |"
+        )
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -690,6 +1185,7 @@ async def store_payload(payload: dict[str, Any]) -> None:
 
 
 async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    weights = parse_weights(getattr(args, "weights", None))
     articles = await fetch_articles(args.market, args.window_hours, args.limit)
     if not articles:
         raise RuntimeError("no news_articles rows matched the requested window/market")
@@ -705,29 +1201,63 @@ async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
         )
     embedding_dim = len(vectors[0]) if vectors else 0
     clusters = cluster_articles(articles, vectors, args.threshold)
-    ranked = rank_clusters(clusters, articles)
+    ranked_v1 = rank_clusters(clusters, articles)
+    ranked_v2 = rank_clusters_v2(
+        clusters,
+        articles,
+        window_hours=args.window_hours,
+        weights=weights,
+    )
+    if getattr(args, "drop_regular_reports", False):
+        ranked_v2 = [
+            (cluster, breakdown)
+            for cluster, breakdown in ranked_v2
+            if breakdown.flags.get("regular_report", 0)
+            / max(1, len(cluster["indices"]))
+            < 0.5
+        ]
     issues = [
-        summarize_cluster(cluster, articles, rank=i + 1)
-        for i, cluster in enumerate(ranked[: args.top])
+        summarize_cluster(cluster, articles, rank=i + 1, score_breakdown=breakdown)
+        for i, (cluster, breakdown) in enumerate(ranked_v2[: args.top])
     ]
-    source_counts = Counter(a.source_key for a in articles)
-    return {
+    raw_source_counts = Counter(a.source_key for a in articles)
+    normalized_source_counts = Counter(a.normalized_source_key for a in articles)
+    payload = {
         "run": {
             "run_uuid": str(uuid.uuid4()),
             "created_at": datetime.now(UTC).isoformat(),
             "market": args.market,
             "window_hours": args.window_hours,
             "article_limit": args.limit,
+            "top": args.top,
             "article_count": len(articles),
             "cluster_count": len(clusters),
             "threshold": args.threshold,
             "dedupe_threshold": args.dedupe_threshold,
             "embedding_model": args.embedding_model,
             "embedding_dim": embedding_dim,
+            "score_weights": {
+                "diversity": weights.diversity,
+                "volume": weights.volume,
+                "recency": weights.recency,
+                "relevance": weights.relevance,
+            },
+            "drop_regular_reports": bool(getattr(args, "drop_regular_reports", False)),
         },
-        "source_counts": dict(source_counts),
+        "source_counts": {
+            "raw": dict(raw_source_counts),
+            "normalized": dict(normalized_source_counts),
+        },
         "issues": issues,
     }
+    if getattr(args, "compare_v1", False):
+        payload["v1_vs_v2"] = _comparison_payload(
+            ranked_v1,
+            ranked_v2,
+            articles,
+            top=args.top,
+        )
+    return payload
 
 
 async def async_main(argv: list[str] | None = None) -> int:

--- a/scripts/news_issue_lab.py
+++ b/scripts/news_issue_lab.py
@@ -21,6 +21,7 @@ import re
 import sys
 import uuid
 from collections import Counter
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -347,7 +348,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--embedding-endpoint", default=DEFAULT_BGE_ENDPOINT)
     parser.add_argument("--embedding-model", default=DEFAULT_BGE_MODEL)
-    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--batch-size", type=int, default=16)
     parser.add_argument(
         "--store", action="store_true", help="store run/result payloads in lab tables"
     )
@@ -367,10 +368,47 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="hard-drop clusters where regular reports are at least half of titles",
     )
+    parser.add_argument(
+        "--merge-clusters",
+        dest="merge_clusters",
+        action="store_true",
+        default=True,
+        help="merge near-duplicate clusters before ranking (default: on)",
+    )
+    parser.add_argument(
+        "--no-merge-clusters",
+        dest="merge_clusters",
+        action="store_false",
+        help="disable the cluster merge pass (preserve ROB-134 behavior)",
+    )
+    parser.add_argument(
+        "--merge-rep-threshold",
+        type=float,
+        default=MERGE_REP_THRESHOLD,
+        help="cosine similarity threshold for cluster representative merge",
+    )
+    parser.add_argument(
+        "--merge-token-jaccard",
+        type=float,
+        default=MERGE_TOKEN_JACCARD,
+        help="token-Jaccard threshold required alongside rep-sim merge",
+    )
+    parser.add_argument(
+        "--merge-rep-articles",
+        type=int,
+        default=3,
+        help="articles per cluster used to build the representative text",
+    )
     args = parser.parse_args(argv)
     for name in ("window_hours", "limit", "top", "batch_size"):
         if getattr(args, name) <= 0:
             parser.error(f"--{name.replace('_', '-')} must be positive")
+    if not (0.0 < args.merge_rep_threshold <= 1.0):
+        parser.error("--merge-rep-threshold must be in (0.0, 1.0]")
+    if not (0.0 <= args.merge_token_jaccard <= 1.0):
+        parser.error("--merge-token-jaccard must be in [0.0, 1.0]")
+    if args.merge_rep_articles <= 0:
+        parser.error("--merge-rep-articles must be positive")
     return args
 
 
@@ -467,6 +505,257 @@ def cluster_articles(
     return clusters
 
 
+MERGE_REP_THRESHOLD = 0.86
+MERGE_TOKEN_JACCARD = 0.30
+MERGE_STRONG_REP_THRESHOLD = 0.93
+MERGE_TOPIC_REP_THRESHOLD = 0.43
+MERGE_MIN_TOKEN_FLOOR = 0.20
+MERGE_MAX_CLUSTER_SIZE = 25
+
+
+def build_cluster_representative(
+    cluster: dict[str, Any],
+    articles: list[Article],
+    *,
+    max_articles: int = 3,
+) -> str:
+    rows = [articles[i] for i in cluster["indices"]]
+    chosen = sorted(
+        rows,
+        key=lambda a: (
+            0 if a.stock_symbol else 1,
+            -len(a.summary or ""),
+            a.id,
+        ),
+    )[:max_articles]
+    parts: list[str] = []
+    for a in chosen:
+        parts.append(a.title)
+        if a.stock_symbol:
+            parts.append(a.stock_symbol)
+        if a.stock_name:
+            parts.append(a.stock_name)
+    label = cluster_topic_label(rows)
+    if label:
+        parts.append(label)
+    markets = sorted({articles[i].market for i in cluster["indices"]})
+    parts.extend(markets)
+    return " | ".join(p for p in parts if p)
+
+
+def _evaluate_merge_pair(
+    absorber: dict[str, Any],
+    absorbed: dict[str, Any],
+    articles: list[Article],
+    *,
+    rep_sim: float,
+    absorber_cid: int,
+    absorbed_cid: int,
+    rep_threshold: float = MERGE_REP_THRESHOLD,
+    token_jaccard_threshold: float = MERGE_TOKEN_JACCARD,
+) -> MergeDecision:
+    abs_rows = [articles[i] for i in absorber["indices"]]
+    add_rows = [articles[i] for i in absorbed["indices"]]
+    abs_tokens = absorber.get("tokens") or set()
+    add_tokens = absorbed.get("tokens") or set()
+    if abs_tokens or add_tokens:
+        token_jaccard = len(abs_tokens & add_tokens) / max(
+            1, len(abs_tokens | add_tokens)
+        )
+    else:
+        token_jaccard = 0.0
+    abs_srcs = {a.normalized_source_key for a in abs_rows}
+    add_srcs = {a.normalized_source_key for a in add_rows}
+    if abs_srcs and add_srcs:
+        source_overlap = len(abs_srcs & add_srcs) / max(
+            1, min(len(abs_srcs), len(add_srcs))
+        )
+    else:
+        source_overlap = 0.0
+    abs_label = cluster_topic_label(abs_rows)
+    add_label = cluster_topic_label(add_rows)
+    topic_agree = bool(abs_label and abs_label == add_label)
+    abs_syms = {a.stock_symbol for a in abs_rows if a.stock_symbol}
+    add_syms = {a.stock_symbol for a in add_rows if a.stock_symbol}
+    symbol_agree = bool(abs_syms & add_syms)
+    abs_title = abs_label or (abs_rows[0].title if abs_rows else "-")
+    add_title = add_label or (add_rows[0].title if add_rows else "-")
+
+    def _build(decision: str, reason: str) -> MergeDecision:
+        return MergeDecision(
+            absorber_cid=absorber_cid,
+            absorbed_cid=absorbed_cid,
+            rep_sim=round(float(rep_sim), 4),
+            token_jaccard=round(float(token_jaccard), 4),
+            source_overlap=round(float(source_overlap), 4),
+            topic_agree=topic_agree,
+            symbol_agree=symbol_agree,
+            decision=decision,
+            reason=reason,
+            absorber_title=abs_title,
+            absorbed_title=add_title,
+        )
+
+    if len(absorber["indices"]) + len(absorbed["indices"]) > MERGE_MAX_CLUSTER_SIZE:
+        return _build("rejected", "max_cluster_size")
+    if not topic_agree and len(abs_srcs | add_srcs) > 5:
+        return _build("rejected", "wide_source_no_topic")
+    if not topic_agree and not symbol_agree and token_jaccard < MERGE_MIN_TOKEN_FLOOR:
+        return _build("rejected", "below_token_floor_no_topic")
+    if rep_sim >= MERGE_STRONG_REP_THRESHOLD and token_jaccard >= 0.10:
+        return _build("merged", "strong_rep")
+    if rep_sim >= rep_threshold and topic_agree:
+        return _build("merged", "topic+rep")
+    if rep_sim >= rep_threshold and symbol_agree:
+        return _build("merged", "symbol+rep")
+    if rep_sim >= rep_threshold and token_jaccard >= token_jaccard_threshold:
+        return _build("merged", "jaccard+rep")
+    if topic_agree and rep_sim >= MERGE_TOPIC_REP_THRESHOLD:
+        return _build("merged", "topic+low_rep")
+    if rep_sim < rep_threshold:
+        return _build("rejected", "rep_sim_below_threshold")
+    return _build("rejected", "no_supporting_signal")
+
+
+def merge_clusters(
+    clusters: list[dict[str, Any]],
+    articles: list[Article],
+    embedder: Callable[[list[str]], list[list[float]]] | None,
+    *,
+    rep_threshold: float,
+    token_jaccard_threshold: float,
+    rep_articles: int,
+    enabled: bool = True,
+) -> tuple[list[dict[str, Any]], MergeDiagnostics]:
+    diag = MergeDiagnostics(
+        enabled=enabled,
+        merge_before_count=len(clusters),
+        thresholds={
+            "rep_threshold": float(rep_threshold),
+            "token_jaccard_threshold": float(token_jaccard_threshold),
+            "strong_rep_threshold": MERGE_STRONG_REP_THRESHOLD,
+            "topic_rep_threshold": MERGE_TOPIC_REP_THRESHOLD,
+            "min_token_floor": MERGE_MIN_TOKEN_FLOOR,
+            "max_cluster_size": float(MERGE_MAX_CLUSTER_SIZE),
+            "rep_articles": float(rep_articles),
+        },
+    )
+    if not enabled or len(clusters) <= 1 or embedder is None:
+        diag.merge_after_count = len(clusters)
+        return clusters, diag
+
+    cids = [min(articles[idx].id for idx in c["indices"]) for c in clusters]
+    reps = [
+        build_cluster_representative(c, articles, max_articles=rep_articles)
+        for c in clusters
+    ]
+    rep_vectors = embedder(reps)
+
+    order = sorted(
+        range(len(clusters)),
+        key=lambda i: (
+            -len(clusters[i]["indices"]),
+            -len({articles[k].normalized_source_key for k in clusters[i]["indices"]}),
+            cids[i],
+        ),
+    )
+
+    parent = list(range(len(clusters)))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def component_members(root: int) -> list[int]:
+        return [idx for idx in range(len(clusters)) if find(idx) == root]
+
+    def component_cluster(root: int) -> dict[str, Any]:
+        all_indices: list[int] = []
+        all_vectors: list[list[float]] = []
+        all_tokens: set[str] = set()
+        best_sim = 0.0
+        for member in component_members(root):
+            all_indices.extend(clusters[member]["indices"])
+            all_vectors.extend(clusters[member]["vectors"])
+            all_tokens.update(clusters[member].get("tokens") or set())
+            best_sim = max(
+                best_sim, float(clusters[member].get("best_similarity", 0.0))
+            )
+        return {
+            "indices": sorted(set(all_indices)),
+            "vectors": all_vectors,
+            "tokens": all_tokens,
+            "best_similarity": best_sim,
+        }
+
+    def component_cid(root: int) -> int:
+        return min(cids[member] for member in component_members(root))
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra == rb:
+            return
+        parent[rb] = ra
+
+    rejected_near_misses = 0
+    for pos, i in enumerate(order):
+        for j in order[pos + 1 :]:
+            ri, rj = find(i), find(j)
+            if ri == rj:
+                continue
+            absorber_c, absorbed_c = component_cluster(ri), component_cluster(rj)
+            sim = cosine(rep_vectors[ri], rep_vectors[rj])
+            decision = _evaluate_merge_pair(
+                absorber_c,
+                absorbed_c,
+                articles,
+                rep_sim=sim,
+                absorber_cid=component_cid(ri),
+                absorbed_cid=component_cid(rj),
+                rep_threshold=rep_threshold,
+                token_jaccard_threshold=token_jaccard_threshold,
+            )
+            if decision.decision == "merged":
+                union(ri, rj)
+                diag.decisions.append(decision)
+            elif sim >= rep_threshold - 0.05:
+                rejected_near_misses += 1
+                diag.decisions.append(decision)
+
+    groups: dict[int, list[int]] = {}
+    for i in range(len(clusters)):
+        groups.setdefault(find(i), []).append(i)
+
+    merged_clusters: list[dict[str, Any]] = []
+    for _root, members in sorted(groups.items(), key=lambda kv: cids[kv[0]]):
+        members_sorted = sorted(members, key=lambda i: cids[i])
+        all_indices: list[int] = []
+        all_vectors: list[list[float]] = []
+        all_tokens: set[str] = set()
+        best_sim = 0.0
+        for m in members_sorted:
+            all_indices.extend(clusters[m]["indices"])
+            all_vectors.extend(clusters[m]["vectors"])
+            all_tokens.update(clusters[m].get("tokens") or set())
+            best_sim = max(best_sim, float(clusters[m].get("best_similarity", 0.0)))
+        merged_clusters.append(
+            {
+                "indices": sorted(set(all_indices)),
+                "vectors": all_vectors,
+                "centroid": centroid(all_vectors),
+                "tokens": all_tokens,
+                "best_similarity": best_sim,
+                "merged_cluster_ids": sorted(cids[m] for m in members_sorted),
+            }
+        )
+
+    diag.merge_after_count = len(merged_clusters)
+    diag.rejected_near_misses = rejected_near_misses
+    return merged_clusters, diag
+
+
 def keyword_matches(text_blob: str, keyword: str) -> bool:
     keyword_l = keyword.lower()
     if re.search(r"[가-힣]", keyword_l):
@@ -508,6 +797,37 @@ class ScoreBreakdown:
     raw_source_count: int
     normalized_source_count: int
     flags: dict[str, int]
+
+
+@dataclass(frozen=True)
+class MergeDecision:
+    absorber_cid: int
+    absorbed_cid: int
+    rep_sim: float
+    token_jaccard: float
+    source_overlap: float
+    topic_agree: bool
+    symbol_agree: bool
+    decision: str  # "merged" | "rejected"
+    reason: str
+    absorber_title: str
+    absorbed_title: str
+
+
+@dataclass
+class MergeDiagnostics:
+    enabled: bool = False
+    merge_before_count: int = 0
+    merge_after_count: int = 0
+    rejected_near_misses: int = 0
+    thresholds: dict[str, float] = None  # type: ignore[assignment]
+    decisions: list[MergeDecision] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.thresholds is None:
+            self.thresholds = {}
+        if self.decisions is None:
+            self.decisions = []
 
 
 def _round_score(value: float) -> float:
@@ -582,11 +902,21 @@ def parse_weights(value: str | None) -> ScoreWeights:
     )
 
 
-def _topic_relevance(rows: list[Article]) -> float:
+def cluster_topic_label(rows: list[Article]) -> str | None:
+    """Return the matching TOPIC_RULES title for the cluster, or None if no rule matches."""
+    if not rows:
+        return None
     text_blob = "\n".join([a.title + " " + (a.summary or "") for a in rows]).lower()
-    for _, _, keys in TOPIC_RULES:
+    for title, _, keys in TOPIC_RULES:
         if any(keyword_matches(text_blob, key) for key in keys):
-            return 1.0
+            return title
+    return None
+
+
+def _topic_relevance(rows: list[Article]) -> float:
+    if cluster_topic_label(rows) is not None:
+        return 1.0
+    text_blob = "\n".join([a.title + " " + (a.summary or "") for a in rows]).lower()
     return 0.5 if _has_any_keyword(text_blob, MARKET_SIGNAL_TERMS) else 0.0
 
 
@@ -779,6 +1109,10 @@ def summarize_cluster(
             window_hours=24,
             weights=DEFAULT_WEIGHTS,
         )
+    merged_cluster_ids = list(
+        cluster.get("merged_cluster_ids")
+        or [min(articles[i].id for i in cluster["indices"])]
+    )
     return {
         "rank": rank,
         "cluster_key": hashlib.sha1(issue_key_raw.encode()).hexdigest()[:16],
@@ -804,6 +1138,8 @@ def summarize_cluster(
         "topics": topics[:8],
         "cluster_similarity": round(float(cluster.get("best_similarity", 0.0)), 4),
         "representative_articles": representative_articles,
+        "merge_member_count": len(merged_cluster_ids),
+        "merged_cluster_ids": merged_cluster_ids,
     }
 
 
@@ -857,10 +1193,51 @@ def render_markdown(payload: dict[str, Any]) -> str:
                     )
                 )
             )
+        member_count = issue.get("merge_member_count", 1)
+        if member_count > 1:
+            cids_str = ", ".join(str(c) for c in issue.get("merged_cluster_ids") or [])
+            lines.append(f"- 병합: {member_count}개 클러스터 통합 (cids: {cids_str})")
         lines.append("- 대표 기사:")
         for article in issue["representative_articles"][:4]:
             src = article.get("feed_source") or article.get("source") or "unknown"
             lines.append(f"  - [{src}] {article['title']}")
+        lines.append("")
+    merge_diag = payload.get("merge_diagnostics") or {}
+    if merge_diag.get("enabled") and merge_diag.get("decisions"):
+        lines.extend(
+            [
+                "## 클러스터 병합 진단 (ROB-135)",
+                "",
+                f"- 병합 전 클러스터: {merge_diag['merge_before_count']}개 → 병합 후: {merge_diag['merge_after_count']}개 (-{merge_diag['merge_before_count'] - merge_diag['merge_after_count']})",
+                f"- 병합 임계값: rep≥{merge_diag['thresholds'].get('rep_threshold')}, token-jaccard≥{merge_diag['thresholds'].get('token_jaccard_threshold')}, strong-rep≥{merge_diag['thresholds'].get('strong_rep_threshold')}",
+                f"- 거부된 근접 병합: {merge_diag.get('rejected_near_misses', 0)}건",
+                "",
+                "### 병합된 클러스터 (상위 10건)",
+                "",
+                "| absorber | absorbed | rep_sim | token_jaccard | topic | symbol | reason |",
+                "|---|---|---:|---:|:--:|:--:|---|",
+            ]
+        )
+        merged_decisions = [
+            d for d in merge_diag["decisions"] if d.get("decision") == "merged"
+        ]
+        for d in merged_decisions[:10]:
+            lines.append(
+                f"| `{d['absorber_title']}` | `{d['absorbed_title']}` | "
+                f"{d['rep_sim']:.4f} | {d['token_jaccard']:.4f} | "
+                f"{'✓' if d['topic_agree'] else '-'} | "
+                f"{'✓' if d['symbol_agree'] else '-'} | {d['reason']} |"
+            )
+        rejected = [
+            d for d in merge_diag["decisions"] if d.get("decision") == "rejected"
+        ]
+        if rejected:
+            lines.extend(["", "### 거부된 근접 병합 (참고)", ""])
+            for d in rejected[:10]:
+                lines.append(
+                    f"- `{d['absorber_title']}` ↔ `{d['absorbed_title']}` "
+                    f"rep_sim={d['rep_sim']:.4f} reason={d['reason']}"
+                )
         lines.append("")
     if payload.get("v1_vs_v2"):
         lines.append(
@@ -1201,6 +1578,31 @@ async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
         )
     embedding_dim = len(vectors[0]) if vectors else 0
     clusters = cluster_articles(articles, vectors, args.threshold)
+    clusters_before_merge = clusters
+
+    def _embedder(texts: list[str]) -> list[list[float]]:
+        rep_vectors: list[list[float]] = []
+        for i in range(0, len(texts), args.batch_size):
+            rep_vectors.extend(
+                embed_batch(
+                    args.embedding_endpoint,
+                    args.embedding_model,
+                    texts[i : i + args.batch_size],
+                )
+            )
+        return rep_vectors
+
+    clusters, merge_diag = merge_clusters(
+        clusters,
+        articles,
+        _embedder,
+        rep_threshold=getattr(args, "merge_rep_threshold", MERGE_REP_THRESHOLD),
+        token_jaccard_threshold=getattr(
+            args, "merge_token_jaccard", MERGE_TOKEN_JACCARD
+        ),
+        rep_articles=getattr(args, "merge_rep_articles", 3),
+        enabled=bool(getattr(args, "merge_clusters", True)),
+    )
     ranked_v1 = rank_clusters(clusters, articles)
     ranked_v2 = rank_clusters_v2(
         clusters,
@@ -1232,6 +1634,7 @@ async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             "top": args.top,
             "article_count": len(articles),
             "cluster_count": len(clusters),
+            "cluster_count_before_merge": len(clusters_before_merge),
             "threshold": args.threshold,
             "dedupe_threshold": args.dedupe_threshold,
             "embedding_model": args.embedding_model,
@@ -1243,12 +1646,46 @@ async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
                 "relevance": weights.relevance,
             },
             "drop_regular_reports": bool(getattr(args, "drop_regular_reports", False)),
+            "merge_clusters": bool(getattr(args, "merge_clusters", True)),
+            "merge_rep_threshold": float(
+                getattr(args, "merge_rep_threshold", MERGE_REP_THRESHOLD)
+            ),
+            "merge_token_jaccard": float(
+                getattr(args, "merge_token_jaccard", MERGE_TOKEN_JACCARD)
+            ),
+            "merge_rep_articles": int(getattr(args, "merge_rep_articles", 3)),
         },
         "source_counts": {
             "raw": dict(raw_source_counts),
             "normalized": dict(normalized_source_counts),
         },
         "issues": issues,
+        "merge_diagnostics": {
+            "enabled": merge_diag.enabled,
+            "merge_before_count": merge_diag.merge_before_count,
+            "merge_after_count": merge_diag.merge_after_count,
+            "rejected_near_misses": merge_diag.rejected_near_misses,
+            "thresholds": merge_diag.thresholds,
+            "decisions": [
+                {
+                    "absorber_cid": d.absorber_cid,
+                    "absorbed_cid": d.absorbed_cid,
+                    "rep_sim": d.rep_sim,
+                    "token_jaccard": d.token_jaccard,
+                    "source_overlap": d.source_overlap,
+                    "topic_agree": d.topic_agree,
+                    "symbol_agree": d.symbol_agree,
+                    "decision": d.decision,
+                    "reason": d.reason,
+                    "absorber_title": d.absorber_title,
+                    "absorbed_title": d.absorbed_title,
+                }
+                for d in sorted(
+                    merge_diag.decisions,
+                    key=lambda x: (x.absorber_cid, x.absorbed_cid),
+                )
+            ],
+        },
     }
     if getattr(args, "compare_v1", False):
         payload["v1_vs_v2"] = _comparison_payload(

--- a/scripts/news_issue_lab.py
+++ b/scripts/news_issue_lab.py
@@ -19,6 +19,7 @@ import json
 import math
 import re
 import sys
+import time
 import uuid
 from collections import Counter
 from collections.abc import Callable
@@ -33,6 +34,31 @@ from app.core.db import AsyncSessionLocal
 
 DEFAULT_BGE_ENDPOINT = "http://127.0.0.1:10631/v1/embeddings"
 DEFAULT_BGE_MODEL = "BAAI/bge-m3"
+
+DEFAULT_LLM_TIMEOUT = 30
+RENDER_PROMPT_VERSION = "rob136-v1"
+RENDER_MAX_ARTICLES = 6
+RENDER_SUMMARY_EXCERPT_MAX = 200
+RENDER_MAX_IMPACT_POINTS = 4
+
+BANNED_RENDER_PHRASES: tuple[str, ...] = (
+    "매수",
+    "매도",
+    "추천",
+    "지금 사",
+    "지금 팔",
+    "목표가",
+    "투자의견",
+    "사야",
+    "팔아야",
+    "buy now",
+    "sell now",
+    "recommend",
+    "target price",
+    "price target",
+    "should buy",
+    "should sell",
+)
 
 POSITIVE_TERMS = {
     "최대",
@@ -399,6 +425,47 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=3,
         help="articles per cluster used to build the representative text",
     )
+    # ROB-136: Korean LLM rendering flags
+    parser.add_argument(
+        "--llm-render",
+        dest="llm_render",
+        action="store_true",
+        default=False,
+        help="enable Korean LLM rendering (ROB-136)",
+    )
+    parser.add_argument(
+        "--no-llm",
+        dest="llm_render",
+        action="store_false",
+        help="disable LLM rendering (default behavior)",
+    )
+    parser.add_argument(
+        "--llm-endpoint",
+        default=None,
+        help="OpenAI-compatible LLM base URL (required when --llm-render)",
+    )
+    parser.add_argument(
+        "--llm-model",
+        default=None,
+        help="LLM model name (required when --llm-render)",
+    )
+    parser.add_argument(
+        "--llm-timeout",
+        type=int,
+        default=DEFAULT_LLM_TIMEOUT,
+        help="LLM request timeout in seconds [1..120]",
+    )
+    parser.add_argument(
+        "--llm-max-render",
+        type=int,
+        default=None,
+        help="maximum number of issues to LLM-render (default: all top-N)",
+    )
+    parser.add_argument(
+        "--llm-prompt-version",
+        default=RENDER_PROMPT_VERSION,
+        help="prompt version label stored in diagnostics",
+    )
     args = parser.parse_args(argv)
     for name in ("window_hours", "limit", "top", "batch_size"):
         if getattr(args, name) <= 0:
@@ -409,6 +476,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         parser.error("--merge-token-jaccard must be in [0.0, 1.0]")
     if args.merge_rep_articles <= 0:
         parser.error("--merge-rep-articles must be positive")
+    if args.llm_render and not args.llm_endpoint:
+        parser.error("--llm-render requires --llm-endpoint")
+    if args.llm_render and not args.llm_model:
+        parser.error("--llm-render requires --llm-model")
+    if not (1 <= args.llm_timeout <= 120):
+        parser.error("--llm-timeout must be in [1, 120]")
+    if args.llm_max_render is not None and args.llm_max_render <= 0:
+        parser.error("--llm-max-render must be positive")
+    if args.llm_max_render is not None and args.llm_max_render > args.top:
+        parser.error("--llm-max-render must be <= --top")
     return args
 
 
@@ -450,7 +527,7 @@ def embed_batch(
     req = request.Request(
         endpoint,
         data=json.dumps(payload).encode(),
-        headers={"Content-Type": "application/json", "Authorization": "Bearer local"},
+        headers={"Content-Type": "application/json"},
         method="POST",
     )
     with request.urlopen(req, timeout=timeout) as resp:
@@ -462,6 +539,383 @@ def embed_batch(
             f"embedding count mismatch: expected={len(texts)} actual={len(vectors)}"
         )
     return vectors
+
+
+# ---------------------------------------------------------------------------
+# ROB-136: Korean LLM rendering infrastructure
+# ---------------------------------------------------------------------------
+
+
+class LLMRenderError(Exception):
+    """Raised by LLM providers when a render call cannot be completed.
+
+    The ``reason`` attribute names the rejection category for diagnostics.
+    """
+
+    def __init__(self, reason: str, message: str = "") -> None:
+        super().__init__(message or reason)
+        self.reason = reason
+
+
+class NullLLMRenderProvider:
+    """Default provider — never calls the network; always signals llm_disabled."""
+
+    def render(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        *,
+        model: str | None = None,
+        timeout: int = DEFAULT_LLM_TIMEOUT,
+    ) -> str:
+        raise LLMRenderError("llm_disabled", "LLM rendering is disabled")
+
+
+class OpenAICompatibleLLMRenderProvider:
+    """POSTs to /v1/chat/completions; returns choices[0].message.content."""
+
+    def __init__(self, endpoint: str) -> None:
+        if not endpoint.endswith("/v1/chat/completions"):
+            endpoint = endpoint.rstrip("/") + "/v1/chat/completions"
+        self._endpoint = endpoint
+
+    def render(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+        *,
+        model: str | None = None,
+        timeout: int = DEFAULT_LLM_TIMEOUT,
+    ) -> str:
+        payload = {
+            "model": model or "default",
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            "temperature": 0.2,
+        }
+        req = request.Request(
+            self._endpoint,
+            data=json.dumps(payload, ensure_ascii=False).encode(),
+            headers={
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        try:
+            with request.urlopen(req, timeout=timeout) as resp:
+                data = json.load(resp)
+        except Exception as exc:
+            # Keep provider diagnostics secret-safe: never surface request headers,
+            # tokens, cookies, or endpoint-provided detail strings from exceptions.
+            raise LLMRenderError("http_error") from exc
+        try:
+            return data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise LLMRenderError("response_parse_error", str(exc)) from exc
+
+
+def make_llm_provider(
+    args: Any,
+) -> NullLLMRenderProvider | OpenAICompatibleLLMRenderProvider:
+    if getattr(args, "llm_render", False) and getattr(args, "llm_endpoint", None):
+        return OpenAICompatibleLLMRenderProvider(args.llm_endpoint)
+    return NullLLMRenderProvider()
+
+
+_LLM_SYSTEM_PROMPT = """You are a Korean financial-news issue-card renderer.
+Return only a JSON object — no markdown fences, no extra text.
+Write short Toss-like Korean issue-card copy based only on the provided cluster metadata.
+Do not add facts, prices, forecasts, or recommendations not present in the input.
+Never use investment advice or recommendation language."""
+
+
+def build_render_prompt(issue: dict[str, Any]) -> tuple[str, str, dict[str, Any]]:
+    """Return (system_prompt, user_json_string, input_dict)."""
+    articles_raw = issue.get("representative_articles") or []
+    rep_articles = []
+    for a in articles_raw[:RENDER_MAX_ARTICLES]:
+        excerpt: str | None = None
+        if a.get("summary"):
+            excerpt = str(a["summary"])[:RENDER_SUMMARY_EXCERPT_MAX]
+        rep_articles.append(
+            {
+                "title": a.get("title", ""),
+                "source": a.get("source"),
+                "feed_source": a.get("feed_source"),
+                "market": a.get("market"),
+                "published_at": a.get("published_at"),
+                "scraped_at": a.get("scraped_at"),
+                **({"summary_excerpt": excerpt} if excerpt else {}),
+            }
+        )
+
+    input_dict: dict[str, Any] = {
+        "rule_based_card": {
+            "title_ko": issue.get("title_ko", ""),
+            "subtitle_ko": issue.get("subtitle_ko", ""),
+            "direction": issue.get("direction", "neutral"),
+            "topics": issue.get("topics") or [],
+            "markets": issue.get("markets") or [],
+        },
+        "stats": {
+            "rank": issue.get("rank", 0),
+            "article_count": issue.get("article_count", 0),
+            "raw_source_count": issue.get("raw_source_count", 0),
+            "normalized_source_count": issue.get("normalized_source_count", 0),
+            "score": issue.get("score", 0.0),
+            "score_components": issue.get("score_components") or {},
+            "score_penalties": issue.get("score_penalties") or {},
+            "flags": issue.get("flags") or {},
+            "merge_member_count": issue.get("merge_member_count", 1),
+        },
+        "related_symbols": issue.get("related_symbols") or [],
+        "representative_articles": rep_articles,
+    }
+    user_prompt = json.dumps(input_dict, ensure_ascii=False, indent=2)
+    return _LLM_SYSTEM_PROMPT, user_prompt, input_dict
+
+
+def compute_render_input_hash(input_dict: dict[str, Any]) -> str:
+    return hashlib.sha256(
+        json.dumps(input_dict, sort_keys=True, ensure_ascii=False).encode()
+    ).hexdigest()[:32]
+
+
+def _hangul_ratio(text: str) -> float:
+    if not text:
+        return 0.0
+    hangul_count = sum(1 for ch in text if "가" <= ch <= "힣")
+    return hangul_count / len(text)
+
+
+def validate_render_response(
+    raw: str,
+    *,
+    allowed_symbols: set[str],
+) -> dict[str, Any]:
+    """Parse and validate an LLM render response; raise ValueError on any rejection."""
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("parse_error") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError("parse_error")
+
+    required_fields = {
+        "title_ko": str,
+        "subtitle_ko": str,
+        "direction": str,
+        "summary_ko": str,
+        "impact_points": list,
+        "related_symbols": list,
+        "confidence": (int, float),
+    }
+    for field, expected_type in required_fields.items():
+        if field not in data:
+            raise ValueError("schema_missing_field")
+        if not isinstance(data[field], expected_type):
+            raise ValueError("schema_type_error")
+
+    for field in ("title_ko", "subtitle_ko", "summary_ko"):
+        if not data[field].strip():
+            raise ValueError("empty_field")
+
+    if data["direction"] not in ("up", "down", "neutral"):
+        raise ValueError("invalid_direction")
+
+    confidence = float(data["confidence"])
+    if not (0.0 <= confidence <= 1.0):
+        raise ValueError("invalid_confidence")
+
+    if len(data["title_ko"]) > 32:
+        raise ValueError("length_violation")
+    if len(data["subtitle_ko"]) > 60:
+        raise ValueError("length_violation")
+    if not (80 <= len(data["summary_ko"]) <= 280):
+        raise ValueError("length_violation")
+
+    impact_points = data["impact_points"]
+    if not impact_points or len(impact_points) > RENDER_MAX_IMPACT_POINTS:
+        raise ValueError("schema_cardinality_error")
+    for pt in impact_points:
+        if not isinstance(pt, str):
+            raise ValueError("schema_type_error")
+        if len(pt) > 120:
+            raise ValueError("length_violation")
+
+    for sym_entry in data["related_symbols"]:
+        if not isinstance(sym_entry, dict):
+            raise ValueError("schema_type_error")
+        sym = sym_entry.get("symbol", "")
+        if sym and sym not in allowed_symbols:
+            raise ValueError("symbol_unknown")
+
+    if _hangul_ratio(data["summary_ko"]) < 0.3:
+        raise ValueError("script_ratio_low")
+
+    check_text = " ".join(
+        [
+            data["title_ko"],
+            data["subtitle_ko"],
+            data["summary_ko"],
+            *impact_points,
+        ]
+    ).lower()
+    for phrase in BANNED_RENDER_PHRASES:
+        if phrase.lower() in check_text:
+            raise ValueError("banned_phrase")
+
+    return data
+
+
+def fallback_render(issue: dict[str, Any], rejection_reason: str) -> dict[str, Any]:
+    """Return a deterministic, schema-complete card using rule-based issue fields."""
+    topics = issue.get("topics") or []
+    article_count = issue.get("article_count", 0)
+    markets = issue.get("markets") or []
+    rep_sources = issue.get("representative_sources") or []
+    related_symbols = (issue.get("related_symbols") or [])[:6]
+    merge_member_count = issue.get("merge_member_count", 1)
+
+    topic_str = topics[0] if topics else "관련 이슈"
+    sources_str = (
+        ", ".join(str(s) for s in rep_sources[:3]) if rep_sources else "다수 출처"
+    )
+    market_str = "·".join(sorted({str(m) for m in markets})) if markets else "시장"
+
+    summary_ko = (
+        f"여러 출처에서 {topic_str} 관련 기사 {article_count}건이 확인됐습니다. "
+        f"대표 출처는 {sources_str}이며, 시장 영향은 추가 확인이 필요합니다."
+    )
+
+    impact_points: list[str] = [
+        f"{market_str} 시장에서 관련 동향이 포착됐습니다.",
+    ]
+    if issue.get("normalized_source_count", 0) >= 2:
+        impact_points.append(
+            f"정규화 출처 {issue['normalized_source_count']}개에서 보도됐습니다."
+        )
+    if merge_member_count > 1:
+        impact_points.append(f"{merge_member_count}개 클러스터가 통합된 이슈입니다.")
+    if related_symbols:
+        sym_names = ", ".join(
+            s.get("name") or s.get("symbol", "") for s in related_symbols[:3] if s
+        )
+        if sym_names:
+            impact_points.append(f"관련 종목: {sym_names}")
+
+    return {
+        "title_ko": issue.get("title_ko", ""),
+        "subtitle_ko": issue.get("subtitle_ko", ""),
+        "direction": issue.get("direction", "neutral"),
+        "summary_ko": summary_ko,
+        "impact_points": impact_points[:RENDER_MAX_IMPACT_POINTS],
+        "related_symbols": related_symbols,
+        "confidence": 0.0,
+        "render_status": "fallback",
+        "render_rejection_reason": rejection_reason,
+    }
+
+
+def render_top_issues(
+    issues: list[dict[str, Any]],
+    *,
+    provider: NullLLMRenderProvider | OpenAICompatibleLLMRenderProvider,
+    llm_enabled: bool,
+    model: str | None,
+    timeout: int,
+    prompt_version: str,
+    max_render: int,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Render (or fallback) each issue card; return updated issues and diagnostics."""
+    ok_count = 0
+    fallback_count = 0
+    skipped_count = 0
+    rejection_counts: dict[str, int] = {}
+    total_latency_ms = 0
+    provider_name = (
+        "openai_compatible"
+        if isinstance(provider, OpenAICompatibleLLMRenderProvider)
+        else "null"
+    )
+
+    rendered_issues: list[dict[str, Any]] = []
+    for issue in issues:
+        issue = dict(issue)
+        rank = issue.get("rank", 0)
+        allowed_symbols = {
+            s.get("symbol", "")
+            for s in (issue.get("related_symbols") or [])
+            if s.get("symbol")
+        }
+
+        system_prompt, user_prompt, input_dict = build_render_prompt(issue)
+        input_hash = compute_render_input_hash(input_dict)
+        base_render_meta = {
+            "render_prompt_version": prompt_version,
+            "render_input_hash": input_hash,
+            "render_model": model,
+        }
+
+        if not llm_enabled or rank > max_render:
+            reason = "llm_disabled" if not llm_enabled else "llm_skipped"
+            card = fallback_render(issue, reason)
+            issue.update(card)
+            issue.update(base_render_meta)
+            issue["render_latency_ms"] = 0
+            if rank > max_render:
+                skipped_count += 1
+            else:
+                fallback_count += 1
+            rejection_counts[reason] = rejection_counts.get(reason, 0) + 1
+            rendered_issues.append(issue)
+            continue
+
+        t0 = time.monotonic()
+        try:
+            raw = provider.render(
+                system_prompt, user_prompt, model=model, timeout=timeout
+            )
+            validated = validate_render_response(raw, allowed_symbols=allowed_symbols)
+            latency_ms = int((time.monotonic() - t0) * 1000)
+            total_latency_ms += latency_ms
+            issue.update(validated)
+            issue["render_status"] = "ok"
+            issue["render_rejection_reason"] = None
+            issue["render_model"] = model
+            issue.update(base_render_meta)
+            issue["render_latency_ms"] = latency_ms
+            ok_count += 1
+        except (LLMRenderError, ValueError) as exc:
+            latency_ms = int((time.monotonic() - t0) * 1000)
+            total_latency_ms += latency_ms
+            reason = exc.reason if isinstance(exc, LLMRenderError) else str(exc)
+            card = fallback_render(issue, reason)
+            issue.update(card)
+            issue.update(base_render_meta)
+            issue["render_latency_ms"] = latency_ms
+            fallback_count += 1
+            rejection_counts[reason] = rejection_counts.get(reason, 0) + 1
+
+        rendered_issues.append(issue)
+
+    render_diag: dict[str, Any] = {
+        "enabled": llm_enabled,
+        "provider": provider_name,
+        "model": model,
+        "prompt_version": prompt_version,
+        "max_render": max_render,
+        "requested": len(issues),
+        "ok": ok_count,
+        "fallback": fallback_count,
+        "skipped": skipped_count,
+        "rejection_counts": rejection_counts,
+        "total_latency_ms": total_latency_ms,
+    }
+    return rendered_issues, render_diag
 
 
 def cluster_articles(
@@ -1096,6 +1550,7 @@ def summarize_cluster(
             "feed_source": a.feed_source,
             "market": a.market,
             "stock_symbol": a.stock_symbol,
+            "summary": a.summary,
             "published_at": a.published_at,
             "scraped_at": a.scraped_at,
         }
@@ -1156,6 +1611,17 @@ def rank_clusters(
 
 def render_markdown(payload: dict[str, Any]) -> str:
     meta = payload["run"]
+    llm_render_diag = meta.get("llm_render")
+    llm_render_line = ""
+    if llm_render_diag:
+        llm_render_line = (
+            f"- LLM render: ok={llm_render_diag['ok']}, "
+            f"fallback={llm_render_diag['fallback']}, "
+            f"skipped={llm_render_diag['skipped']} "
+            f"(provider={llm_render_diag['provider']}, "
+            f"model={llm_render_diag['model']}, "
+            f"prompt={llm_render_diag['prompt_version']})"
+        )
     lines = [
         "# News Issue Lab PoC",
         "",
@@ -1163,16 +1629,42 @@ def render_markdown(payload: dict[str, Any]) -> str:
         f"- market: `{meta['market']}` / window: {meta['window_hours']}h / articles: {meta['article_count']} / clusters: {meta['cluster_count']}",
         f"- embedding: `{meta['embedding_model']}` ({meta['embedding_dim']}d) / threshold: {meta['threshold']}",
         "- note: 기사 본문은 출력/저장하지 않고 제목·요약·메타데이터 기반으로만 실험했습니다.",
-        "",
-        "## 실시간 이슈 후보",
-        "",
     ]
+    if llm_render_line:
+        lines.append(llm_render_line)
+    lines.extend(["", "## 실시간 이슈 후보", ""])
     arrow = {"up": "▲", "down": "▼", "neutral": "◆"}
     for issue in payload["issues"]:
         lines.extend(
             [
                 f"### {issue['rank']}. {arrow.get(issue['direction'], '◆')} {issue['title_ko']}",
+            ]
+        )
+        render_status = issue.get("render_status")
+        if render_status == "ok":
+            confidence = issue.get("confidence", 0.0)
+            render_model = issue.get("render_model") or "-"
+            lines.append(
+                f"- 렌더: ok · model={render_model} · confidence={confidence:.2f}"
+            )
+        elif render_status == "fallback":
+            rejection_reason = issue.get("render_rejection_reason") or "unknown"
+            lines.append(f"- 렌더: fallback(rule-based, reason={rejection_reason})")
+        lines.extend(
+            [
                 f"- 부제: {issue['subtitle_ko']}",
+            ]
+        )
+        summary_ko = issue.get("summary_ko")
+        if summary_ko:
+            lines.append(f"- 요약: {summary_ko}")
+        impact_points = issue.get("impact_points") or []
+        if impact_points:
+            lines.append("- 영향:")
+            for pt in impact_points:
+                lines.append(f"  - {pt}")
+        lines.extend(
+            [
                 f"- 출처/기사: raw {issue.get('raw_source_count', issue['source_count'])}개 → normalized {issue.get('normalized_source_count', issue['source_count'])}개 · {issue['article_count']}개 기사",
                 f"- 점수: {issue.get('score', 0):.4f} / components={issue.get('score_components', {})} / penalties={issue.get('score_penalties', {})}",
                 f"- 대표 출처: {', '.join(issue['representative_sources']) or '-'}",
@@ -1622,6 +2114,17 @@ async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
         summarize_cluster(cluster, articles, rank=i + 1, score_breakdown=breakdown)
         for i, (cluster, breakdown) in enumerate(ranked_v2[: args.top])
     ]
+    # ROB-136: Korean LLM rendering pass
+    llm_provider = make_llm_provider(args)
+    issues, render_diag = render_top_issues(
+        issues,
+        provider=llm_provider,
+        llm_enabled=bool(getattr(args, "llm_render", False)),
+        model=getattr(args, "llm_model", None),
+        timeout=int(getattr(args, "llm_timeout", DEFAULT_LLM_TIMEOUT)),
+        prompt_version=str(getattr(args, "llm_prompt_version", RENDER_PROMPT_VERSION)),
+        max_render=int(getattr(args, "llm_max_render", None) or args.top),
+    )
     raw_source_counts = Counter(a.source_key for a in articles)
     normalized_source_counts = Counter(a.normalized_source_key for a in articles)
     payload = {
@@ -1654,6 +2157,7 @@ async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
                 getattr(args, "merge_token_jaccard", MERGE_TOKEN_JACCARD)
             ),
             "merge_rep_articles": int(getattr(args, "merge_rep_articles", 3)),
+            "llm_render": render_diag,
         },
         "source_counts": {
             "raw": dict(raw_source_counts),

--- a/scripts/news_issue_lab.py
+++ b/scripts/news_issue_lab.py
@@ -1,0 +1,762 @@
+#!/usr/bin/env python3
+"""Toss-like Korean real-time news issue lab.
+
+This is an operator-facing PoC script. It reads existing ``news_articles`` rows,
+uses the local BGE-M3 OpenAI-compatible embedding endpoint for clustering, renders
+short Korean issue titles/subtitles with rule-based fallbacks, and optionally
+stores the lab run/result payloads in dedicated experimental tables.
+
+It intentionally does not touch broker/order/watch/scheduler state and does not
+store or print article bodies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import math
+import re
+import sys
+import uuid
+from collections import Counter
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+from urllib import request
+
+from sqlalchemy import text
+
+from app.core.db import AsyncSessionLocal
+
+DEFAULT_BGE_ENDPOINT = "http://127.0.0.1:10631/v1/embeddings"
+DEFAULT_BGE_MODEL = "BAAI/bge-m3"
+
+POSITIVE_TERMS = {
+    "최대",
+    "상승",
+    "급등",
+    "호황",
+    "개선",
+    "성장",
+    "돌파",
+    "최고",
+    "흑자",
+    "호실적",
+    "surge",
+    "rally",
+    "record",
+    "beats",
+    "beat",
+    "growth",
+    "upgrade",
+    "bull",
+    "profit",
+    "gain",
+    "higher",
+    "strong",
+    "breakthrough",
+    "upside",
+    "boost",
+    "jumps",
+    "skyrocketing",
+}
+NEGATIVE_TERMS = {
+    "하락",
+    "급락",
+    "위험",
+    "우려",
+    "부진",
+    "손실",
+    "적자",
+    "약세",
+    "압박",
+    "관세",
+    "전쟁",
+    "slump",
+    "falls",
+    "drop",
+    "crash",
+    "loss",
+    "risk",
+    "warning",
+    "miss",
+    "cuts",
+    "downgrade",
+    "weak",
+    "pressure",
+    "tariff",
+    "selloff",
+    "slides",
+    "probe",
+    "lawsuit",
+}
+
+TOPIC_RULES: list[tuple[str, str, tuple[str, ...]]] = [
+    (
+        "카카오 실적",
+        "플랫폼 성장·수익성 개선",
+        ("카카오", "kakao", "카카오페이", "카카오뱅크"),
+    ),
+    (
+        "반도체 슈퍼사이클",
+        "AI 수요·메모리 호황",
+        (
+            "반도체",
+            "sk하이닉스",
+            "삼성전자",
+            "hynix",
+            "semiconductor",
+            "chip",
+            "memory",
+            "nvidia",
+        ),
+    ),
+    ("비트코인 강세", "기관 자금·위험자산 선호", ("bitcoin", "btc", "비트코인")),
+    (
+        "이더리움·알트코인",
+        "네트워크 업그레이드·ETF 기대",
+        ("ethereum", "ether", "eth", "이더리움", "altcoin"),
+    ),
+    (
+        "미국 금리·연준",
+        "정책 기대와 채권금리 변화",
+        ("fed", "federal reserve", "fomc", "rate", "treasury", "yield", "연준", "금리"),
+    ),
+    (
+        "미국 증시 최고치",
+        "기술주 강세·실적 기대",
+        ("s&p", "nasdaq", "dow", "wall street", "stock market", "미국 증시", "나스닥"),
+    ),
+    (
+        "유가 변동",
+        "중동 리스크·에너지 수급",
+        ("oil", "crude", "opec", "유가", "원유", "energy"),
+    ),
+    (
+        "AI 데이터센터",
+        "전력·인프라 투자 확대",
+        (
+            "ai",
+            "artificial intelligence",
+            "data center",
+            "datacenter",
+            "데이터센터",
+            "인공지능",
+        ),
+    ),
+    (
+        "전기차·배터리",
+        "수요 둔화와 공급망 재편",
+        ("ev", "electric vehicle", "battery", "tesla", "lucid", "전기차", "배터리"),
+    ),
+    (
+        "부동산·리츠",
+        "금리 민감 업종 재평가",
+        ("reit", "property", "realty", "mortgage", "부동산", "리츠"),
+    ),
+    (
+        "금·원자재",
+        "안전자산 수요와 광산주 움직임",
+        ("gold", "silver", "mining", "copper", "금", "은", "원자재"),
+    ),
+    (
+        "기업 실적 발표",
+        "분기 실적과 가이던스 영향",
+        (
+            "earnings",
+            "results",
+            "quarter",
+            "revenue",
+            "profit",
+            "실적",
+            "매출",
+            "영업이익",
+        ),
+    ),
+    (
+        "M&A·사업재편",
+        "인수합병과 분사 이슈",
+        (
+            "acquire",
+            "acquisition",
+            "merger",
+            "spin off",
+            "spin-off",
+            "인수",
+            "합병",
+            "분사",
+        ),
+    ),
+]
+
+STOPWORDS = {
+    "the",
+    "and",
+    "for",
+    "with",
+    "from",
+    "that",
+    "this",
+    "why",
+    "what",
+    "into",
+    "amid",
+    "after",
+    "before",
+    "stock",
+    "stocks",
+    "shares",
+    "inc",
+    "corp",
+    "ltd",
+    "company",
+    "today",
+    "now",
+    "best",
+    "buy",
+    "top",
+    "증시",
+    "시장",
+    "오늘",
+    "관련",
+    "뉴스",
+    "기자",
+    "서울",
+    "종목",
+    "투자",
+    "분석",
+}
+
+
+@dataclass(frozen=True)
+class Article:
+    id: int
+    title: str
+    summary: str | None
+    market: str
+    feed_source: str | None
+    source: str | None
+    stock_symbol: str | None
+    stock_name: str | None
+    published_at: str | None
+    scraped_at: str | None
+
+    @property
+    def source_key(self) -> str:
+        return self.feed_source or self.source or "unknown"
+
+    @property
+    def text_for_embedding(self) -> str:
+        parts = [self.title]
+        if self.summary:
+            parts.append(self.summary[:300])
+        parts.extend([self.market, self.source_key])
+        if self.stock_symbol:
+            parts.append(self.stock_symbol)
+        if self.stock_name:
+            parts.append(self.stock_name)
+        return " | ".join(p for p in parts if p)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Toss-like news issue lab using local BGE-M3 embeddings"
+    )
+    parser.add_argument(
+        "--market", default="all", choices=["all", "kr", "us", "crypto"]
+    )
+    parser.add_argument("--window-hours", type=int, default=24)
+    parser.add_argument("--limit", type=int, default=240)
+    parser.add_argument("--top", type=int, default=12)
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.78,
+        help="cosine similarity threshold for same-issue clusters",
+    )
+    parser.add_argument(
+        "--dedupe-threshold",
+        type=float,
+        default=0.90,
+        help="near-duplicate boost threshold",
+    )
+    parser.add_argument("--embedding-endpoint", default=DEFAULT_BGE_ENDPOINT)
+    parser.add_argument("--embedding-model", default=DEFAULT_BGE_MODEL)
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument(
+        "--store", action="store_true", help="store run/result payloads in lab tables"
+    )
+    parser.add_argument("--format", choices=["markdown", "json"], default="markdown")
+    parser.add_argument("--output", help="optional output file path")
+    return parser.parse_args(argv)
+
+
+def normalize_text(s: str) -> str:
+    return re.sub(r"\s+", " ", s or "").strip()
+
+
+def tokenize(text_value: str) -> list[str]:
+    raw = re.findall(
+        r"[A-Za-z][A-Za-z0-9&.-]{2,}|[가-힣]{2,}|\d+만?", text_value.lower()
+    )
+    return [t for t in raw if t not in STOPWORDS and len(t) >= 2]
+
+
+def cosine(a: list[float], b: list[float]) -> float:
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b, strict=False):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na <= 0 or nb <= 0:
+        return 0.0
+    return dot / math.sqrt(na * nb)
+
+
+def centroid(vectors: list[list[float]]) -> list[float]:
+    if not vectors:
+        return []
+    n = len(vectors)
+    return [sum(v[i] for v in vectors) / n for i in range(len(vectors[0]))]
+
+
+def embed_batch(
+    endpoint: str, model: str, texts: list[str], timeout: int = 180
+) -> list[list[float]]:
+    payload = {"model": model, "input": texts}
+    req = request.Request(
+        endpoint,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer local"},
+        method="POST",
+    )
+    with request.urlopen(req, timeout=timeout) as resp:
+        data = json.load(resp)
+    rows = sorted(data.get("data") or [], key=lambda row: row.get("index", 0))
+    vectors = [row.get("embedding") or [] for row in rows]
+    if len(vectors) != len(texts):
+        raise RuntimeError(
+            f"embedding count mismatch: expected={len(texts)} actual={len(vectors)}"
+        )
+    return vectors
+
+
+def cluster_articles(
+    articles: list[Article], vectors: list[list[float]], threshold: float
+) -> list[dict[str, Any]]:
+    clusters: list[dict[str, Any]] = []
+    for idx, article in enumerate(articles):
+        vec = vectors[idx]
+        best_i = None
+        best_sim = -1.0
+        article_tokens = set(tokenize(article.text_for_embedding))
+        for c_i, cluster in enumerate(clusters):
+            sim = cosine(vec, cluster["centroid"])
+            # tiny lexical/entity boost so same ticker/topic titles stick together
+            overlap = len(article_tokens & cluster["tokens"]) / max(
+                len(article_tokens | cluster["tokens"]), 1
+            )
+            adjusted = sim + min(overlap * 0.08, 0.05)
+            if adjusted > best_sim:
+                best_sim = adjusted
+                best_i = c_i
+        if best_i is not None and best_sim >= threshold:
+            cluster = clusters[best_i]
+            cluster["indices"].append(idx)
+            cluster["vectors"].append(vec)
+            cluster["centroid"] = centroid(cluster["vectors"])
+            cluster["tokens"].update(article_tokens)
+            cluster["best_similarity"] = max(
+                cluster.get("best_similarity", 0.0), best_sim
+            )
+        else:
+            clusters.append(
+                {
+                    "indices": [idx],
+                    "vectors": [vec],
+                    "centroid": vec,
+                    "tokens": set(article_tokens),
+                    "best_similarity": 1.0,
+                }
+            )
+    return clusters
+
+
+def keyword_matches(text_blob: str, keyword: str) -> bool:
+    keyword_l = keyword.lower()
+    if re.search(r"[가-힣]", keyword_l):
+        return keyword_l in text_blob
+    # Avoid substring false positives such as "ai" in "daily" or "ether" in "together".
+    return bool(
+        re.search(rf"(?<![a-z0-9]){re.escape(keyword_l)}(?![a-z0-9])", text_blob)
+    )
+
+
+def infer_topic(articles: list[Article]) -> tuple[str, str, list[str]]:
+    text_blob = "\n".join([a.title + " " + (a.summary or "") for a in articles]).lower()
+    matched: list[str] = []
+    for title, subtitle, keys in TOPIC_RULES:
+        hits = [k for k in keys if keyword_matches(text_blob, k)]
+        if hits:
+            matched.extend(hits[:3])
+            return title, subtitle, sorted(set(matched))
+    counts = Counter(tokenize(text_blob))
+    top_tokens = [t for t, _ in counts.most_common(5)]
+    if not top_tokens:
+        return "주요 시장 이슈", "여러 출처에서 반복 언급", []
+    if re.search(r"[가-힣]", top_tokens[0]):
+        title = " ".join(top_tokens[:2])
+    else:
+        title = f"{top_tokens[0].upper()} 이슈 부각"
+    subtitle = " · ".join(top_tokens[1:4]) if len(top_tokens) > 1 else "시장 언급 증가"
+    return title[:32], subtitle[:40], top_tokens
+
+
+def infer_direction(articles: list[Article]) -> str:
+    blob = " ".join([a.title + " " + (a.summary or "") for a in articles]).lower()
+    pos = sum(1 for t in POSITIVE_TERMS if t.lower() in blob)
+    neg = sum(1 for t in NEGATIVE_TERMS if t.lower() in blob)
+    if pos > neg:
+        return "up"
+    if neg > pos:
+        return "down"
+    return "neutral"
+
+
+def summarize_cluster(
+    cluster: dict[str, Any], articles: list[Article], rank: int
+) -> dict[str, Any]:
+    rows = [articles[i] for i in cluster["indices"]]
+    source_counts = Counter(a.source_key for a in rows)
+    markets = sorted({a.market for a in rows})
+    related_symbols = []
+    seen = set()
+    for a in rows:
+        if a.stock_symbol and a.stock_symbol not in seen:
+            related_symbols.append({"symbol": a.stock_symbol, "name": a.stock_name})
+            seen.add(a.stock_symbol)
+    title, subtitle, topics = infer_topic(rows)
+    direction = infer_direction(rows)
+    representative = sorted(source_counts, key=lambda k: (-source_counts[k], k))[:5]
+    representative_articles = [
+        {
+            "id": a.id,
+            "title": a.title,
+            "source": a.source,
+            "feed_source": a.feed_source,
+            "market": a.market,
+            "stock_symbol": a.stock_symbol,
+            "published_at": a.published_at,
+            "scraped_at": a.scraped_at,
+        }
+        for a in rows[:8]
+    ]
+    issue_key_raw = "|".join([title, subtitle, ",".join(str(a.id) for a in rows[:8])])
+    return {
+        "rank": rank,
+        "cluster_key": hashlib.sha1(issue_key_raw.encode()).hexdigest()[:16],
+        "title_ko": title,
+        "subtitle_ko": subtitle,
+        "direction": direction,
+        "article_count": len(rows),
+        "source_count": len(source_counts),
+        "representative_sources": representative,
+        "source_counts": dict(source_counts),
+        "markets": markets,
+        "related_symbols": related_symbols[:10],
+        "topics": topics[:8],
+        "cluster_similarity": round(float(cluster.get("best_similarity", 0.0)), 4),
+        "representative_articles": representative_articles,
+    }
+
+
+def rank_clusters(
+    clusters: list[dict[str, Any]], articles: list[Article]
+) -> list[dict[str, Any]]:
+    def score(cluster: dict[str, Any]) -> tuple[int, int, float]:
+        rows = [articles[i] for i in cluster["indices"]]
+        source_count = len({a.source_key for a in rows})
+        return (source_count, len(rows), float(cluster.get("best_similarity", 0.0)))
+
+    return sorted(clusters, key=score, reverse=True)
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    meta = payload["run"]
+    lines = [
+        "# News Issue Lab PoC",
+        "",
+        f"- run_uuid: `{meta['run_uuid']}`",
+        f"- market: `{meta['market']}` / window: {meta['window_hours']}h / articles: {meta['article_count']} / clusters: {meta['cluster_count']}",
+        f"- embedding: `{meta['embedding_model']}` ({meta['embedding_dim']}d) / threshold: {meta['threshold']}",
+        "- note: 기사 본문은 출력/저장하지 않고 제목·요약·메타데이터 기반으로만 실험했습니다.",
+        "",
+        "## 실시간 이슈 후보",
+        "",
+    ]
+    arrow = {"up": "▲", "down": "▼", "neutral": "◆"}
+    for issue in payload["issues"]:
+        lines.extend(
+            [
+                f"### {issue['rank']}. {arrow.get(issue['direction'], '◆')} {issue['title_ko']}",
+                f"- 부제: {issue['subtitle_ko']}",
+                f"- 출처/기사: {issue['source_count']}개 출처 · {issue['article_count']}개 기사",
+                f"- 대표 출처: {', '.join(issue['representative_sources']) or '-'}",
+                f"- 시장: {', '.join(issue['markets'])}",
+                f"- 토픽: {', '.join(issue['topics']) or '-'}",
+            ]
+        )
+        if issue["related_symbols"]:
+            lines.append(
+                "- 관련 종목: "
+                + ", ".join(
+                    filter(
+                        None,
+                        [
+                            s.get("name") or s.get("symbol")
+                            for s in issue["related_symbols"]
+                        ],
+                    )
+                )
+            )
+        lines.append("- 대표 기사:")
+        for article in issue["representative_articles"][:4]:
+            src = article.get("feed_source") or article.get("source") or "unknown"
+            lines.append(f"  - [{src}] {article['title']}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+async def fetch_articles(market: str, window_hours: int, limit: int) -> list[Article]:
+    market_clause = "" if market == "all" else "and market = :market"
+    stmt = text(
+        f"""
+        select id, title, summary, market, feed_source, source, stock_symbol, stock_name,
+               article_published_at, scraped_at
+        from news_articles
+        where scraped_at >= now() - (:window_hours * interval '1 hour')
+          and title is not null and title <> ''
+          {market_clause}
+        order by scraped_at desc, article_published_at desc nulls last
+        limit :limit
+        """
+    )
+    params = {"market": market, "window_hours": window_hours, "limit": limit}
+    async with AsyncSessionLocal() as db:
+        rows = (await db.execute(stmt, params)).mappings().all()
+    articles: list[Article] = []
+    for row in rows:
+        articles.append(
+            Article(
+                id=row["id"],
+                title=normalize_text(row["title"]),
+                summary=normalize_text(row["summary"]) if row["summary"] else None,
+                market=row["market"] or "unknown",
+                feed_source=row["feed_source"],
+                source=row["source"],
+                stock_symbol=row["stock_symbol"],
+                stock_name=row["stock_name"],
+                published_at=row["article_published_at"].isoformat()
+                if row["article_published_at"]
+                else None,
+                scraped_at=row["scraped_at"].isoformat() if row["scraped_at"] else None,
+            )
+        )
+    return articles
+
+
+async def ensure_lab_tables() -> None:
+    async with AsyncSessionLocal() as db:
+        await db.execute(
+            text(
+                """
+                create table if not exists news_issue_lab_runs (
+                    run_uuid text primary key,
+                    created_at timestamptz not null default now(),
+                    market text not null,
+                    window_hours integer not null,
+                    article_limit integer not null,
+                    cluster_threshold double precision not null,
+                    embedding_model text not null,
+                    embedding_dim integer not null,
+                    article_count integer not null,
+                    cluster_count integer not null,
+                    source_counts jsonb not null,
+                    payload jsonb not null
+                )
+                """
+            )
+        )
+        await db.execute(
+            text(
+                """
+                create table if not exists news_issue_lab_results (
+                    id bigserial primary key,
+                    run_uuid text not null references news_issue_lab_runs(run_uuid) on delete cascade,
+                    rank integer not null,
+                    cluster_key text not null,
+                    title_ko text not null,
+                    subtitle_ko text,
+                    direction text not null,
+                    article_count integer not null,
+                    source_count integer not null,
+                    representative_sources jsonb not null,
+                    related_symbols jsonb not null,
+                    topics jsonb not null,
+                    payload jsonb not null,
+                    created_at timestamptz not null default now(),
+                    unique (run_uuid, rank)
+                )
+                """
+            )
+        )
+        await db.commit()
+
+
+async def store_payload(payload: dict[str, Any]) -> None:
+    await ensure_lab_tables()
+    run = payload["run"]
+    async with AsyncSessionLocal() as db:
+        await db.execute(
+            text(
+                """
+                insert into news_issue_lab_runs (
+                    run_uuid, market, window_hours, article_limit, cluster_threshold,
+                    embedding_model, embedding_dim, article_count, cluster_count,
+                    source_counts, payload
+                ) values (
+                    :run_uuid, :market, :window_hours, :article_limit, :cluster_threshold,
+                    :embedding_model, :embedding_dim, :article_count, :cluster_count,
+                    cast(:source_counts as jsonb), cast(:payload as jsonb)
+                )
+                on conflict (run_uuid) do nothing
+                """
+            ),
+            {
+                "run_uuid": run["run_uuid"],
+                "market": run["market"],
+                "window_hours": run["window_hours"],
+                "article_limit": run["article_limit"],
+                "cluster_threshold": run["threshold"],
+                "embedding_model": run["embedding_model"],
+                "embedding_dim": run["embedding_dim"],
+                "article_count": run["article_count"],
+                "cluster_count": run["cluster_count"],
+                "source_counts": json.dumps(
+                    payload["source_counts"], ensure_ascii=False
+                ),
+                "payload": json.dumps(payload, ensure_ascii=False),
+            },
+        )
+        for issue in payload["issues"]:
+            await db.execute(
+                text(
+                    """
+                    insert into news_issue_lab_results (
+                        run_uuid, rank, cluster_key, title_ko, subtitle_ko, direction,
+                        article_count, source_count, representative_sources, related_symbols,
+                        topics, payload
+                    ) values (
+                        :run_uuid, :rank, :cluster_key, :title_ko, :subtitle_ko, :direction,
+                        :article_count, :source_count, cast(:representative_sources as jsonb),
+                        cast(:related_symbols as jsonb), cast(:topics as jsonb), cast(:payload as jsonb)
+                    )
+                    """
+                ),
+                {
+                    "run_uuid": run["run_uuid"],
+                    "rank": issue["rank"],
+                    "cluster_key": issue["cluster_key"],
+                    "title_ko": issue["title_ko"],
+                    "subtitle_ko": issue["subtitle_ko"],
+                    "direction": issue["direction"],
+                    "article_count": issue["article_count"],
+                    "source_count": issue["source_count"],
+                    "representative_sources": json.dumps(
+                        issue["representative_sources"], ensure_ascii=False
+                    ),
+                    "related_symbols": json.dumps(
+                        issue["related_symbols"], ensure_ascii=False
+                    ),
+                    "topics": json.dumps(issue["topics"], ensure_ascii=False),
+                    "payload": json.dumps(issue, ensure_ascii=False),
+                },
+            )
+        await db.commit()
+
+
+async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    articles = await fetch_articles(args.market, args.window_hours, args.limit)
+    if not articles:
+        raise RuntimeError("no news_articles rows matched the requested window/market")
+    vectors: list[list[float]] = []
+    for i in range(0, len(articles), args.batch_size):
+        batch = articles[i : i + args.batch_size]
+        vectors.extend(
+            embed_batch(
+                args.embedding_endpoint,
+                args.embedding_model,
+                [a.text_for_embedding for a in batch],
+            )
+        )
+    embedding_dim = len(vectors[0]) if vectors else 0
+    clusters = cluster_articles(articles, vectors, args.threshold)
+    ranked = rank_clusters(clusters, articles)
+    issues = [
+        summarize_cluster(cluster, articles, rank=i + 1)
+        for i, cluster in enumerate(ranked[: args.top])
+    ]
+    source_counts = Counter(a.source_key for a in articles)
+    return {
+        "run": {
+            "run_uuid": str(uuid.uuid4()),
+            "created_at": datetime.now(UTC).isoformat(),
+            "market": args.market,
+            "window_hours": args.window_hours,
+            "article_limit": args.limit,
+            "article_count": len(articles),
+            "cluster_count": len(clusters),
+            "threshold": args.threshold,
+            "dedupe_threshold": args.dedupe_threshold,
+            "embedding_model": args.embedding_model,
+            "embedding_dim": embedding_dim,
+        },
+        "source_counts": dict(source_counts),
+        "issues": issues,
+    }
+
+
+async def async_main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    payload = await build_payload(args)
+    if args.store:
+        await store_payload(payload)
+    rendered = (
+        json.dumps(payload, ensure_ascii=False, indent=2)
+        if args.format == "json"
+        else render_markdown(payload)
+    )
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(rendered)
+    else:
+        print(rendered)
+    return 0
+
+
+def main() -> None:
+    try:
+        raise SystemExit(asyncio.run(async_main()))
+    except BrokenPipeError:
+        raise SystemExit(0)
+    except Exception as exc:  # pragma: no cover - operator-facing CLI final guard
+        print(f"news_issue_lab failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/news_issue_lab.py
+++ b/scripts/news_issue_lab.py
@@ -26,7 +26,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
-from urllib import request
+from urllib import error, request
 
 from sqlalchemy import text
 
@@ -604,9 +604,15 @@ class OpenAICompatibleLLMRenderProvider:
             method="POST",
         )
         try:
-            with request.urlopen(req, timeout=timeout) as resp:
+            with request.urlopen(req, timeout) as resp:
                 data = json.load(resp)
-        except Exception as exc:
+        except (
+            error.URLError,
+            TimeoutError,
+            OSError,
+            json.JSONDecodeError,
+            RuntimeError,
+        ) as exc:
             # Keep provider diagnostics secret-safe: never surface request headers,
             # tokens, cookies, or endpoint-provided detail strings from exceptions.
             raise LLMRenderError("http_error") from exc
@@ -1570,7 +1576,7 @@ def summarize_cluster(
     )
     return {
         "rank": rank,
-        "cluster_key": hashlib.sha1(issue_key_raw.encode()).hexdigest()[:16],
+        "cluster_key": hashlib.sha256(issue_key_raw.encode("utf-8")).hexdigest()[:16],
         "title_ko": title,
         "subtitle_ko": subtitle,
         "direction": direction,

--- a/tests/test_news_issue_lab.py
+++ b/tests/test_news_issue_lab.py
@@ -305,3 +305,664 @@ async def test_build_payload_compare_v1_json_block_and_drop_regular_reports(
     )
     rendered = lab.render_comparison_markdown(payload, [], [], top=12)
     assert "## v1 vs v2 comparison" in rendered
+
+
+# ---------------------------------------------------------------------------
+# ROB-135 tests
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_topic_label_returns_topic_title_when_rule_matches() -> None:
+    rows = [_article(title="SK하이닉스 300만원 전망 반도체 강세")]
+    assert lab.cluster_topic_label(rows) == "반도체 슈퍼사이클"
+
+
+def test_cluster_topic_label_returns_none_when_no_rule_matches() -> None:
+    rows = [_article(title="Generic uneventful headline")]
+    assert lab.cluster_topic_label(rows) is None
+
+
+def test_cluster_topic_label_handles_empty_rows() -> None:
+    assert lab.cluster_topic_label([]) is None
+
+
+def test_merge_decision_dataclass_holds_all_signals() -> None:
+    decision = lab.MergeDecision(
+        absorber_cid=1,
+        absorbed_cid=2,
+        rep_sim=0.91,
+        token_jaccard=0.4,
+        source_overlap=0.5,
+        topic_agree=True,
+        symbol_agree=False,
+        decision="merged",
+        reason="topic+rep",
+        absorber_title="X",
+        absorbed_title="Y",
+    )
+    assert decision.decision == "merged"
+    assert decision.rep_sim == 0.91
+
+
+def test_merge_diagnostics_dataclass_defaults_to_disabled() -> None:
+    diag = lab.MergeDiagnostics()
+    assert diag.enabled is False
+    assert diag.merge_before_count == 0
+    assert diag.merge_after_count == 0
+    assert diag.decisions == []
+
+
+def test_merge_constants_have_expected_defaults() -> None:
+    assert lab.MERGE_REP_THRESHOLD == 0.86
+    assert lab.MERGE_TOKEN_JACCARD == 0.30
+    assert lab.MERGE_STRONG_REP_THRESHOLD == 0.93
+    assert lab.MERGE_TOPIC_REP_THRESHOLD == 0.43
+    assert lab.MERGE_MIN_TOKEN_FLOOR == 0.20
+    assert lab.MERGE_MAX_CLUSTER_SIZE == 25
+
+
+def test_build_cluster_representative_uses_top_titles_and_topic_label() -> None:
+    articles = [
+        _article(1, title="삼성전자 반도체 호황 진입", source="naver"),
+        _article(2, title="SK하이닉스 메모리 강세", source="hankyung"),
+        _article(3, title="Random unrelated headline", source="other"),
+    ]
+    cluster = {"indices": [0, 1, 2], "tokens": set()}
+    rep = lab.build_cluster_representative(cluster, articles, max_articles=2)
+    assert "삼성전자" in rep
+    assert "반도체 슈퍼사이클" in rep
+    assert "Random unrelated headline" not in rep
+
+
+def test_build_cluster_representative_prefers_symbol_bearing_articles() -> None:
+    a1 = lab.Article(
+        id=1,
+        title="Generic",
+        summary=None,
+        market="us",
+        feed_source="x",
+        source="x",
+        stock_symbol=None,
+        stock_name=None,
+        published_at=None,
+        scraped_at=None,
+    )
+    a2 = lab.Article(
+        id=2,
+        title="Apple Q4",
+        summary=None,
+        market="us",
+        feed_source="y",
+        source="y",
+        stock_symbol="AAPL",
+        stock_name="Apple",
+        published_at=None,
+        scraped_at=None,
+    )
+    cluster = {"indices": [0, 1]}
+    rep = lab.build_cluster_representative(cluster, [a1, a2], max_articles=1)
+    assert "AAPL" in rep
+    assert "Apple Q4" in rep
+
+
+def test_build_cluster_representative_is_deterministic() -> None:
+    articles = [_article(i, title=f"t{i}", source=f"s{i}") for i in range(1, 5)]
+    cluster = {"indices": [0, 1, 2, 3]}
+    rep1 = lab.build_cluster_representative(cluster, articles, max_articles=2)
+    rep2 = lab.build_cluster_representative(cluster, articles, max_articles=2)
+    assert rep1 == rep2
+
+
+def _make_cluster_for_merge(
+    indices: list[int], tokens: set[str], best_similarity: float = 1.0
+) -> dict[str, object]:
+    return {
+        "indices": indices,
+        "tokens": tokens,
+        "best_similarity": best_similarity,
+    }
+
+
+def test_evaluate_merge_pair_merges_topic_match_with_high_rep_sim() -> None:
+    articles = [
+        _article(1, title="삼성전자 반도체 호황", source="a"),
+        _article(2, title="SK하이닉스 메모리 강세", source="b"),
+    ]
+    a = _make_cluster_for_merge([0], {"삼성전자", "반도체"})
+    b = _make_cluster_for_merge([1], {"sk하이닉스", "반도체"})
+    decision = lab._evaluate_merge_pair(
+        a,
+        b,
+        articles,
+        rep_sim=0.88,
+        absorber_cid=1,
+        absorbed_cid=2,
+    )
+    assert decision.decision == "merged"
+    assert decision.topic_agree is True
+    assert decision.reason in {
+        "topic+rep",
+        "symbol+rep",
+        "jaccard+rep",
+        "strong_rep",
+    }
+
+
+def test_evaluate_merge_pair_allows_calibrated_topic_low_rep_match() -> None:
+    articles = [
+        _article(1, title="삼성전자 반도체 호황", source="a"),
+        _article(2, title="SK하이닉스 메모리 강세", source="b"),
+    ]
+    a = _make_cluster_for_merge([0], {"삼성전자"})
+    b = _make_cluster_for_merge([1], {"sk하이닉스"})
+    decision = lab._evaluate_merge_pair(
+        a,
+        b,
+        articles,
+        rep_sim=lab.MERGE_TOPIC_REP_THRESHOLD,
+        absorber_cid=1,
+        absorbed_cid=2,
+    )
+    assert decision.decision == "merged"
+    assert decision.reason == "topic+low_rep"
+    assert decision.topic_agree is True
+
+
+def test_evaluate_merge_pair_rejects_low_token_floor_without_topic() -> None:
+    articles = [
+        _article(1, title="Random foo bar", source="a"),
+        _article(2, title="Totally other baz", source="b"),
+    ]
+    a = _make_cluster_for_merge([0], {"random", "foo"})
+    b = _make_cluster_for_merge([1], {"totally", "baz"})
+    decision = lab._evaluate_merge_pair(
+        a,
+        b,
+        articles,
+        rep_sim=0.88,
+        absorber_cid=1,
+        absorbed_cid=2,
+    )
+    assert decision.decision == "rejected"
+    assert "below_token_floor" in decision.reason or "no_topic" in decision.reason
+
+
+def test_evaluate_merge_pair_rejects_when_rep_sim_too_low() -> None:
+    articles = [
+        _article(1, title="비트코인 강세", source="a"),
+        _article(2, title="유가 변동성 확대", source="b"),
+    ]
+    a = _make_cluster_for_merge([0], {"x"})
+    b = _make_cluster_for_merge([1], {"x"})
+    decision = lab._evaluate_merge_pair(
+        a,
+        b,
+        articles,
+        rep_sim=0.50,
+        absorber_cid=1,
+        absorbed_cid=2,
+    )
+    assert decision.decision == "rejected"
+
+
+def test_evaluate_merge_pair_strong_rep_with_some_jaccard_merges() -> None:
+    articles = [
+        _article(1, title="Apple Q4 earnings", source="a"),
+        _article(2, title="애플 4분기 실적", source="b"),
+    ]
+    a = _make_cluster_for_merge([0], {"apple", "earnings"})
+    b = _make_cluster_for_merge([1], {"애플", "실적"})
+    decision = lab._evaluate_merge_pair(
+        a,
+        b,
+        articles,
+        rep_sim=0.95,
+        absorber_cid=1,
+        absorbed_cid=2,
+    )
+    assert decision.decision == "merged"
+
+
+def test_merge_clusters_fuses_two_topic_tied_single_article_clusters() -> None:
+    articles = [
+        _article(1, title="삼성전자 반도체 슈퍼사이클 진입", source="naver"),
+        _article(2, title="SK하이닉스 반도체 호황 지속", source="hankyung"),
+    ]
+    clusters = [
+        {
+            "indices": [0],
+            "vectors": [[1.0, 0.0]],
+            "centroid": [1.0, 0.0],
+            "tokens": set(lab.tokenize(articles[0].text_for_embedding)),
+            "best_similarity": 1.0,
+        },
+        {
+            "indices": [1],
+            "vectors": [[0.99, 0.0]],
+            "centroid": [0.99, 0.0],
+            "tokens": set(lab.tokenize(articles[1].text_for_embedding)),
+            "best_similarity": 1.0,
+        },
+    ]
+
+    def fake_embedder(texts: list[str]) -> list[list[float]]:
+        return [[1.0, 0.0] for _ in texts]
+
+    merged, diag = lab.merge_clusters(
+        clusters,
+        articles,
+        fake_embedder,
+        rep_threshold=0.86,
+        token_jaccard_threshold=0.30,
+        rep_articles=2,
+    )
+    assert len(merged) == 1
+    assert sorted(merged[0]["indices"]) == [0, 1]
+    assert diag.merge_before_count == 2
+    assert diag.merge_after_count == 1
+    assert any(d.decision == "merged" for d in diag.decisions)
+
+
+def test_merge_clusters_respects_max_size_across_transitive_merges() -> None:
+    articles = [
+        _article(i + 1, title=f"삼성전자 반도체 슈퍼사이클 {i}", source=f"s{i % 3}")
+        for i in range(30)
+    ]
+    clusters = [
+        {
+            "indices": list(range(0, 20)),
+            "vectors": [[1.0, 0.0] for _ in range(20)],
+            "centroid": [1.0, 0.0],
+            "tokens": {"삼성전자", "반도체"},
+            "best_similarity": 1.0,
+        },
+        {
+            "indices": list(range(20, 25)),
+            "vectors": [[1.0, 0.0] for _ in range(5)],
+            "centroid": [1.0, 0.0],
+            "tokens": {"삼성전자", "반도체"},
+            "best_similarity": 1.0,
+        },
+        {
+            "indices": list(range(25, 30)),
+            "vectors": [[1.0, 0.0] for _ in range(5)],
+            "centroid": [1.0, 0.0],
+            "tokens": {"삼성전자", "반도체"},
+            "best_similarity": 1.0,
+        },
+    ]
+
+    def fake_embedder(texts: list[str]) -> list[list[float]]:
+        return [[1.0, 0.0] for _ in texts]
+
+    merged, diag = lab.merge_clusters(
+        clusters,
+        articles,
+        fake_embedder,
+        rep_threshold=0.86,
+        token_jaccard_threshold=0.30,
+        rep_articles=2,
+    )
+
+    assert (
+        max(len(cluster["indices"]) for cluster in merged) == lab.MERGE_MAX_CLUSTER_SIZE
+    )
+    assert sorted(len(cluster["indices"]) for cluster in merged) == [5, 25]
+    assert any(d.reason == "max_cluster_size" for d in diag.decisions)
+
+
+def test_merge_clusters_keeps_unrelated_topics_separate() -> None:
+    articles = [
+        _article(1, title="비트코인 신고가 돌파", source="a"),
+        _article(2, title="유가 변동성 확대", source="b"),
+    ]
+    clusters = [
+        {
+            "indices": [0],
+            "vectors": [[1.0, 0.0]],
+            "centroid": [1.0, 0.0],
+            "tokens": set(lab.tokenize(articles[0].text_for_embedding)),
+            "best_similarity": 1.0,
+        },
+        {
+            "indices": [1],
+            "vectors": [[0.0, 1.0]],
+            "centroid": [0.0, 1.0],
+            "tokens": set(lab.tokenize(articles[1].text_for_embedding)),
+            "best_similarity": 1.0,
+        },
+    ]
+
+    def fake_embedder(texts: list[str]) -> list[list[float]]:
+        return [[1.0, 0.0] if "비트코인" in t else [0.0, 1.0] for t in texts]
+
+    merged, diag = lab.merge_clusters(
+        clusters,
+        articles,
+        fake_embedder,
+        rep_threshold=0.86,
+        token_jaccard_threshold=0.30,
+        rep_articles=2,
+    )
+    assert len(merged) == 2
+    assert diag.merge_after_count == 2
+
+
+def test_merge_clusters_disabled_path_returns_inputs_with_diag_disabled() -> None:
+    articles = [_article(1)]
+    clusters = [
+        {
+            "indices": [0],
+            "vectors": [[1.0]],
+            "centroid": [1.0],
+            "tokens": set(),
+            "best_similarity": 1.0,
+        }
+    ]
+    merged, diag = lab.merge_clusters(
+        clusters,
+        articles,
+        embedder=None,
+        rep_threshold=0.86,
+        token_jaccard_threshold=0.30,
+        rep_articles=2,
+        enabled=False,
+    )
+    assert merged is clusters
+    assert diag.enabled is False
+
+
+def test_merge_clusters_is_deterministic_under_input_reordering() -> None:
+    articles = [
+        _article(1, title="삼성전자 반도체 슈퍼사이클", source="naver"),
+        _article(2, title="SK하이닉스 반도체 강세", source="hankyung"),
+        _article(3, title="비트코인 강세", source="coindesk"),
+    ]
+
+    def base_clusters() -> list[dict]:
+        return [
+            {
+                "indices": [0],
+                "vectors": [[1.0, 0.0]],
+                "centroid": [1.0, 0.0],
+                "tokens": set(lab.tokenize(articles[0].text_for_embedding)),
+                "best_similarity": 1.0,
+            },
+            {
+                "indices": [1],
+                "vectors": [[1.0, 0.0]],
+                "centroid": [1.0, 0.0],
+                "tokens": set(lab.tokenize(articles[1].text_for_embedding)),
+                "best_similarity": 1.0,
+            },
+            {
+                "indices": [2],
+                "vectors": [[0.0, 1.0]],
+                "centroid": [0.0, 1.0],
+                "tokens": set(lab.tokenize(articles[2].text_for_embedding)),
+                "best_similarity": 1.0,
+            },
+        ]
+
+    def embedder(texts: list[str]) -> list[list[float]]:
+        return [[1.0, 0.0] if "반도체" in t else [0.0, 1.0] for t in texts]
+
+    forward, _ = lab.merge_clusters(
+        base_clusters(),
+        articles,
+        embedder,
+        rep_threshold=0.86,
+        token_jaccard_threshold=0.30,
+        rep_articles=2,
+    )
+    reversed_inputs = list(reversed(base_clusters()))
+    backward, _ = lab.merge_clusters(
+        reversed_inputs,
+        articles,
+        embedder,
+        rep_threshold=0.86,
+        token_jaccard_threshold=0.30,
+        rep_articles=2,
+    )
+    assert sorted(tuple(sorted(c["indices"])) for c in forward) == sorted(
+        tuple(sorted(c["indices"])) for c in backward
+    )
+
+
+def test_summarize_cluster_includes_merge_member_count_and_ids() -> None:
+    articles = [_article(1), _article(2)]
+    cluster = {
+        "indices": [0, 1],
+        "vectors": [[1.0, 0.0], [1.0, 0.0]],
+        "centroid": [1.0, 0.0],
+        "tokens": set(),
+        "best_similarity": 1.0,
+        "merged_cluster_ids": [1, 2],
+    }
+    issue = lab.summarize_cluster(cluster, articles, rank=1)
+    assert issue["merge_member_count"] == 2
+    assert issue["merged_cluster_ids"] == [1, 2]
+
+
+def test_summarize_cluster_handles_unmerged_cluster() -> None:
+    articles = [_article(1)]
+    cluster = {
+        "indices": [0],
+        "vectors": [[1.0]],
+        "centroid": [1.0],
+        "tokens": set(),
+        "best_similarity": 1.0,
+    }
+    issue = lab.summarize_cluster(cluster, articles, rank=1)
+    assert issue["merge_member_count"] == 1
+    assert issue["merged_cluster_ids"] == [1]
+
+
+@pytest.mark.asyncio
+async def test_build_payload_runs_merge_pass_and_emits_run_diag(monkeypatch) -> None:
+    articles = [
+        _article(1, title="삼성전자 반도체 슈퍼사이클", source="naver"),
+        _article(2, title="SK하이닉스 반도체 호황", source="hankyung"),
+        _article(3, title="비트코인 강세 지속", source="coindesk"),
+    ]
+
+    async def fake_fetch_articles(market, window_hours, limit):
+        return articles
+
+    call_count = {"i": 0}
+
+    def fake_embed(endpoint, model, texts):
+        call_count["i"] += 1
+        if call_count["i"] == 1:
+            return [[1.0, 0.0] if "반도체" in t else [0.0, 1.0] for t in texts]
+        return [[1.0, 0.0] if "반도체" in t else [0.0, 1.0] for t in texts]
+
+    monkeypatch.setattr(lab, "fetch_articles", fake_fetch_articles)
+    monkeypatch.setattr(lab, "embed_batch", fake_embed)
+
+    args = Namespace(
+        market="all",
+        window_hours=24,
+        limit=240,
+        top=12,
+        threshold=0.0,
+        dedupe_threshold=0.90,
+        embedding_endpoint="http://127.0.0.1:10631/v1/embeddings",
+        embedding_model="BAAI/bge-m3",
+        batch_size=32,
+        compare_v1=False,
+        weights=None,
+        drop_regular_reports=False,
+        merge_clusters=True,
+        merge_rep_threshold=0.86,
+        merge_token_jaccard=0.30,
+        merge_rep_articles=3,
+    )
+    payload = await lab.build_payload(args)
+    assert "merge_diagnostics" in payload
+    assert payload["merge_diagnostics"]["enabled"] is True
+    assert (
+        payload["run"]["cluster_count_before_merge"] >= payload["run"]["cluster_count"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_payload_no_merge_flag_disables_merge(monkeypatch) -> None:
+    articles = [
+        _article(1, title="삼성전자 반도체", source="a"),
+        _article(2, title="비트코인 강세", source="b"),
+    ]
+
+    async def fake_fetch_articles(market, window_hours, limit):
+        return articles
+
+    monkeypatch.setattr(lab, "fetch_articles", fake_fetch_articles)
+    monkeypatch.setattr(
+        lab,
+        "embed_batch",
+        lambda endpoint, model, texts: [[1.0, 0.0] for _ in texts],
+    )
+
+    args = Namespace(
+        market="all",
+        window_hours=24,
+        limit=240,
+        top=12,
+        threshold=0.78,
+        dedupe_threshold=0.90,
+        embedding_endpoint="http://127.0.0.1:10631/v1/embeddings",
+        embedding_model="BAAI/bge-m3",
+        batch_size=32,
+        compare_v1=False,
+        weights=None,
+        drop_regular_reports=False,
+        merge_clusters=False,
+        merge_rep_threshold=0.86,
+        merge_token_jaccard=0.30,
+        merge_rep_articles=3,
+    )
+    payload = await lab.build_payload(args)
+    assert payload["merge_diagnostics"]["enabled"] is False
+    assert (
+        payload["run"]["cluster_count_before_merge"] == payload["run"]["cluster_count"]
+    )
+
+
+def test_parse_args_accepts_merge_flags_and_defaults() -> None:
+    args = lab.parse_args([])
+    assert args.merge_clusters is True
+    assert args.merge_rep_threshold == 0.86
+    assert args.merge_token_jaccard == 0.30
+    assert args.merge_rep_articles == 3
+    args2 = lab.parse_args(["--no-merge-clusters", "--merge-rep-threshold", "0.9"])
+    assert args2.merge_clusters is False
+    assert args2.merge_rep_threshold == 0.9
+
+
+def test_parse_args_rejects_invalid_merge_thresholds() -> None:
+    with pytest.raises(SystemExit):
+        lab.parse_args(["--merge-rep-threshold", "1.5"])
+    with pytest.raises(SystemExit):
+        lab.parse_args(["--merge-token-jaccard", "-0.1"])
+    with pytest.raises(SystemExit):
+        lab.parse_args(["--merge-rep-articles", "0"])
+
+
+def test_render_markdown_includes_merge_section_when_decisions_present() -> None:
+    payload = {
+        "run": {
+            "run_uuid": "r-1",
+            "market": "all",
+            "window_hours": 24,
+            "article_count": 3,
+            "cluster_count": 2,
+            "embedding_model": "BAAI/bge-m3",
+            "embedding_dim": 1024,
+            "threshold": 0.78,
+            "cluster_count_before_merge": 4,
+        },
+        "issues": [
+            {
+                "rank": 1,
+                "direction": "neutral",
+                "title_ko": "반도체 슈퍼사이클",
+                "subtitle_ko": "x",
+                "raw_source_count": 2,
+                "normalized_source_count": 2,
+                "source_count": 2,
+                "article_count": 2,
+                "score": 0.5,
+                "score_components": {},
+                "score_penalties": {},
+                "representative_sources": [],
+                "markets": ["kr"],
+                "topics": [],
+                "related_symbols": [],
+                "representative_articles": [],
+                "merge_member_count": 3,
+                "merged_cluster_ids": [1, 2, 3],
+            }
+        ],
+        "merge_diagnostics": {
+            "enabled": True,
+            "merge_before_count": 4,
+            "merge_after_count": 2,
+            "rejected_near_misses": 1,
+            "thresholds": {
+                "rep_threshold": 0.86,
+                "token_jaccard_threshold": 0.30,
+                "strong_rep_threshold": 0.93,
+                "min_token_floor": 0.20,
+                "max_cluster_size": 25,
+                "rep_articles": 3,
+            },
+            "decisions": [
+                {
+                    "absorber_cid": 1,
+                    "absorbed_cid": 2,
+                    "rep_sim": 0.87,
+                    "token_jaccard": 0.41,
+                    "source_overlap": 0.5,
+                    "topic_agree": True,
+                    "symbol_agree": False,
+                    "decision": "merged",
+                    "reason": "topic+rep",
+                    "absorber_title": "반도체 슈퍼사이클",
+                    "absorbed_title": "반도체 슈퍼사이클",
+                }
+            ],
+        },
+    }
+    md = lab.render_markdown(payload)
+    assert "## 클러스터 병합 진단" in md
+    assert "병합 전 클러스터: 4" in md
+    assert "병합 후" in md
+    assert "반도체 슈퍼사이클" in md
+    assert "병합: 3개 클러스터 통합" in md
+
+
+def test_render_markdown_skips_merge_section_when_disabled() -> None:
+    payload = {
+        "run": {
+            "run_uuid": "r-1",
+            "market": "all",
+            "window_hours": 24,
+            "article_count": 1,
+            "cluster_count": 1,
+            "embedding_model": "BAAI/bge-m3",
+            "embedding_dim": 1024,
+            "threshold": 0.78,
+            "cluster_count_before_merge": 1,
+        },
+        "issues": [],
+        "merge_diagnostics": {
+            "enabled": False,
+            "merge_before_count": 1,
+            "merge_after_count": 1,
+            "rejected_near_misses": 0,
+            "thresholds": {},
+            "decisions": [],
+        },
+    }
+    md = lab.render_markdown(payload)
+    assert "## 클러스터 병합 진단" not in md

--- a/tests/test_news_issue_lab.py
+++ b/tests/test_news_issue_lab.py
@@ -969,6 +969,44 @@ def test_render_markdown_skips_merge_section_when_disabled() -> None:
     assert "## 클러스터 병합 진단" not in md
 
 
+def test_render_markdown_backwards_compatible_without_llm_render_block() -> None:
+    payload = {
+        "run": {
+            "run_uuid": "pre-rob136",
+            "market": "all",
+            "window_hours": 24,
+            "article_count": 1,
+            "cluster_count": 1,
+            "embedding_model": "BAAI/bge-m3",
+            "embedding_dim": 1024,
+            "threshold": 0.78,
+        },
+        "issues": [
+            {
+                "rank": 1,
+                "direction": "neutral",
+                "title_ko": "기존 카드",
+                "subtitle_ko": "LLM 진단 블록 없음",
+                "article_count": 1,
+                "source_count": 1,
+                "raw_source_count": 1,
+                "normalized_source_count": 1,
+                "representative_sources": ["rss_test"],
+                "markets": ["kr"],
+                "topics": ["테스트"],
+                "related_symbols": [],
+                "representative_articles": [],
+            }
+        ],
+    }
+
+    md = lab.render_markdown(payload)
+
+    assert "기존 카드" in md
+    assert "LLM 렌더링 진단" not in md
+    assert "render_status" not in md
+
+
 def _render_issue(**overrides) -> dict[str, object]:
     issue: dict[str, object] = {
         "rank": 1,

--- a/tests/test_news_issue_lab.py
+++ b/tests/test_news_issue_lab.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from argparse import Namespace
 from datetime import UTC, datetime, timedelta
 
@@ -966,3 +967,564 @@ def test_render_markdown_skips_merge_section_when_disabled() -> None:
     }
     md = lab.render_markdown(payload)
     assert "## 클러스터 병합 진단" not in md
+
+
+def _render_issue(**overrides) -> dict[str, object]:
+    issue: dict[str, object] = {
+        "rank": 1,
+        "cluster_key": "cluster-1",
+        "title_ko": "반도체 공급망",
+        "subtitle_ko": "AI 수요와 공급망 점검",
+        "direction": "neutral",
+        "article_count": 3,
+        "source_count": 2,
+        "raw_source_count": 3,
+        "normalized_source_count": 2,
+        "score": 0.72,
+        "score_components": {"source_diversity_norm": 0.4},
+        "score_penalties": {},
+        "flags": {},
+        "representative_sources": ["naver", "hankyung"],
+        "source_counts": {"raw": {"naver": 2}, "normalized": {"naver": 2}},
+        "markets": ["kr"],
+        "topics": ["반도체", "AI"],
+        "related_symbols": [{"symbol": "005930", "name": "삼성전자"}],
+        "representative_articles": [
+            {
+                "title": "삼성전자 반도체 공급망 점검",
+                "source": "naver",
+                "feed_source": "browser_naver_mainnews",
+                "market": "kr",
+                "summary": "AI 서버 수요와 메모리 공급망에 관한 짧은 요약입니다." * 10,
+                "published_at": "2026-05-07T09:00:00+09:00",
+                "scraped_at": "2026-05-07T09:01:00+09:00",
+                "body": "이 필드는 프롬프트에 들어가면 안 됩니다.",
+            }
+        ],
+        "merge_member_count": 2,
+        "merged_cluster_ids": [1, 2],
+    }
+    issue.update(overrides)
+    return issue
+
+
+def _valid_render_card(**overrides) -> dict[str, object]:
+    card: dict[str, object] = {
+        "title_ko": "반도체 공급망 점검",
+        "subtitle_ko": "AI 수요와 메모리 공급 논의",
+        "direction": "neutral",
+        "summary_ko": "여러 국내 매체가 AI 서버 수요와 메모리 공급망 관련 동향을 함께 다뤘습니다. 기사들은 기업별 가격 전망보다 업황 변화와 공급망 점검 필요성을 중심으로 전하고 있어 추가 확인이 필요한 이슈입니다.",
+        "impact_points": ["메모리 업황 관련 뉴스 흐름을 점검할 필요가 있습니다."],
+        "related_symbols": [{"symbol": "005930", "name": "삼성전자"}],
+        "confidence": 0.7,
+    }
+    card.update(overrides)
+    return card
+
+
+class _FakeHTTPResponse:
+    def __init__(self, data: dict[str, object]) -> None:
+        self._data = data
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def read(self, *_args, **_kwargs) -> bytes:
+        return json.dumps(self._data).encode()
+
+
+def test_null_llm_provider_raises_disabled_reason() -> None:
+    provider = lab.NullLLMRenderProvider()
+    with pytest.raises(lab.LLMRenderError) as exc:
+        provider.render("system", "user")
+    assert exc.value.reason == "llm_disabled"
+
+
+def test_http_llm_provider_extracts_openai_compatible_message(monkeypatch) -> None:
+    captured = {}
+
+    def fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        captured["timeout"] = timeout
+        return _FakeHTTPResponse(
+            {"choices": [{"message": {"content": '{"ok": true}'}}]}
+        )
+
+    monkeypatch.setattr(lab.request, "urlopen", fake_urlopen)
+    provider = lab.OpenAICompatibleLLMRenderProvider("http://127.0.0.1:8000")
+    assert provider.render("system", "user", model="local", timeout=7) == '{"ok": true}'
+    assert captured == {
+        "url": "http://127.0.0.1:8000/v1/chat/completions",
+        "timeout": 7,
+    }
+
+
+def test_http_llm_provider_wraps_http_errors_without_printing_headers(
+    monkeypatch,
+) -> None:
+    def fake_urlopen(_req, _timeout):
+        raise RuntimeError("Authorization: [REDACTED]")
+
+    monkeypatch.setattr(lab.request, "urlopen", fake_urlopen)
+    provider = lab.OpenAICompatibleLLMRenderProvider("http://127.0.0.1:8000")
+    with pytest.raises(lab.LLMRenderError) as exc:
+        provider.render("system", "user")
+    assert exc.value.reason == "http_error"
+    assert "[REDACTED]" not in str(exc.value)
+    assert "Authorization" not in str(exc.value)
+
+
+def test_build_render_prompt_includes_only_safe_metadata() -> None:
+    _system, user_prompt, prompt_input = lab.build_render_prompt(_render_issue())
+    assert "삼성전자 반도체 공급망 점검" in user_prompt
+    assert prompt_input["stats"]["article_count"] == 3
+    assert prompt_input["related_symbols"] == [{"symbol": "005930", "name": "삼성전자"}]
+    assert "body" not in user_prompt
+    assert "이 필드는 프롬프트에 들어가면 안 됩니다" not in user_prompt
+
+
+def test_build_render_prompt_truncates_summary_excerpt() -> None:
+    _system, _user_prompt, prompt_input = lab.build_render_prompt(_render_issue())
+    excerpt = prompt_input["representative_articles"][0]["summary_excerpt"]
+    assert len(excerpt) == lab.RENDER_SUMMARY_EXCERPT_MAX
+
+
+def test_compute_render_input_hash_is_stable_for_key_order() -> None:
+    assert lab.compute_render_input_hash(
+        {"b": 2, "a": {"y": 1, "x": 0}}
+    ) == lab.compute_render_input_hash({"a": {"x": 0, "y": 1}, "b": 2})
+
+
+def test_validate_render_response_accepts_valid_card() -> None:
+    card = lab.validate_render_response(
+        json.dumps(_valid_render_card(), ensure_ascii=False), allowed_symbols={"005930"}
+    )
+    assert card["title_ko"] == "반도체 공급망 점검"
+
+
+@pytest.mark.parametrize(
+    ("raw", "reason"),
+    [
+        ("not json", "parse_error"),
+        (
+            json.dumps(_valid_render_card(title_ko=""), ensure_ascii=False),
+            "empty_field",
+        ),
+        (json.dumps({"title_ko": "x"}, ensure_ascii=False), "schema_missing_field"),
+        (
+            json.dumps(
+                _valid_render_card(summary_ko="지금 사야 합니다. " * 20),
+                ensure_ascii=False,
+            ),
+            "banned_phrase",
+        ),
+        (
+            json.dumps(
+                _valid_render_card(
+                    related_symbols=[{"symbol": "000000", "name": "가짜"}]
+                ),
+                ensure_ascii=False,
+            ),
+            "symbol_unknown",
+        ),
+        (
+            json.dumps(_valid_render_card(direction="sideways"), ensure_ascii=False),
+            "invalid_direction",
+        ),
+        (
+            json.dumps(_valid_render_card(confidence=1.5), ensure_ascii=False),
+            "invalid_confidence",
+        ),
+    ],
+)
+def test_validate_render_response_rejects_invalid_cards(raw: str, reason: str) -> None:
+    with pytest.raises(ValueError, match=reason):
+        lab.validate_render_response(raw, allowed_symbols={"005930"})
+
+
+def test_fallback_render_returns_schema_complete_card() -> None:
+    card = lab.fallback_render(_render_issue(), "llm_disabled")
+    assert card["title_ko"] == "반도체 공급망"
+    assert card["subtitle_ko"] == "AI 수요와 공급망 점검"
+    assert card["direction"] == "neutral"
+    assert card["render_status"] == "fallback"
+    assert card["render_rejection_reason"] == "llm_disabled"
+    assert card["confidence"] == 0.0
+    assert card["summary_ko"]
+    assert card["impact_points"]
+    assert "body" not in json.dumps(card, ensure_ascii=False)
+
+
+class _Provider:
+    def __init__(self, raw: str) -> None:
+        self.raw = raw
+        self.calls = 0
+
+    def render(self, *_args, **_kwargs) -> str:
+        self.calls += 1
+        return self.raw
+
+
+def test_render_top_issues_no_llm_marks_all_fallback() -> None:
+    rendered, diag = lab.render_top_issues(
+        [_render_issue()],
+        provider=lab.NullLLMRenderProvider(),
+        llm_enabled=False,
+        model=None,
+        timeout=1,
+        prompt_version="rob136-v1",
+        max_render=1,
+    )
+    assert rendered[0]["render_status"] == "fallback"
+    assert rendered[0]["render_rejection_reason"] == "llm_disabled"
+    assert diag["fallback"] == 1
+    assert diag["rejection_counts"] == {"llm_disabled": 1}
+
+
+def test_render_top_issues_valid_provider_marks_ok_and_overrides_card_fields() -> None:
+    provider = _Provider(
+        json.dumps(_valid_render_card(title_ko="AI 반도체 수요"), ensure_ascii=False)
+    )
+    rendered, diag = lab.render_top_issues(
+        [_render_issue()],
+        provider=provider,
+        llm_enabled=True,
+        model="local-model",
+        timeout=1,
+        prompt_version="rob136-v1",
+        max_render=1,
+    )
+    assert rendered[0]["title_ko"] == "AI 반도체 수요"
+    assert rendered[0]["render_status"] == "ok"
+    assert rendered[0]["render_model"] == "local-model"
+    assert len(rendered[0]["render_input_hash"]) == 32
+    assert diag["ok"] == 1
+    assert diag["fallback"] == 0
+
+
+@pytest.mark.parametrize(
+    ("raw", "reason"),
+    [
+        ("not json", "parse_error"),
+        (
+            json.dumps(_valid_render_card(title_ko=""), ensure_ascii=False),
+            "empty_field",
+        ),
+        (json.dumps({"title_ko": "x"}, ensure_ascii=False), "schema_missing_field"),
+        (
+            json.dumps(
+                _valid_render_card(summary_ko="매수 추천 문구입니다. " * 20),
+                ensure_ascii=False,
+            ),
+            "banned_phrase",
+        ),
+    ],
+)
+def test_render_top_issues_falls_back_on_invalid_provider_output(
+    raw: str, reason: str
+) -> None:
+    rendered, diag = lab.render_top_issues(
+        [_render_issue()],
+        provider=_Provider(raw),
+        llm_enabled=True,
+        model="local-model",
+        timeout=1,
+        prompt_version="rob136-v1",
+        max_render=1,
+    )
+    assert rendered[0]["render_status"] == "fallback"
+    assert rendered[0]["render_rejection_reason"] == reason
+    assert diag["fallback"] == 1
+    assert diag["rejection_counts"][reason] == 1
+
+
+def test_render_top_issues_respects_llm_max_render() -> None:
+    provider = _Provider(json.dumps(_valid_render_card(), ensure_ascii=False))
+    rendered, diag = lab.render_top_issues(
+        [_render_issue(rank=1), _render_issue(rank=2, cluster_key="cluster-2")],
+        provider=provider,
+        llm_enabled=True,
+        model="local-model",
+        timeout=1,
+        prompt_version="rob136-v1",
+        max_render=1,
+    )
+    assert provider.calls == 1
+    assert rendered[0]["render_status"] == "ok"
+    assert rendered[1]["render_status"] == "fallback"
+    assert rendered[1]["render_rejection_reason"] == "llm_skipped"
+    assert diag["ok"] == 1
+    assert diag["skipped"] == 1
+
+
+def test_parse_args_defaults_disable_llm_render() -> None:
+    args = lab.parse_args([])
+    assert args.llm_render is False
+    assert args.llm_timeout == lab.DEFAULT_LLM_TIMEOUT
+
+
+def test_parse_args_requires_endpoint_and_model_when_llm_render_enabled() -> None:
+    with pytest.raises(SystemExit):
+        lab.parse_args(["--llm-render", "--llm-model", "local"])
+    with pytest.raises(SystemExit):
+        lab.parse_args(["--llm-render", "--llm-endpoint", "http://127.0.0.1:8000"])
+
+
+def test_parse_args_accepts_llm_render_config() -> None:
+    args = lab.parse_args(
+        [
+            "--llm-render",
+            "--llm-endpoint",
+            "http://127.0.0.1:8000",
+            "--llm-model",
+            "local",
+            "--llm-timeout",
+            "10",
+            "--llm-max-render",
+            "2",
+            "--top",
+            "3",
+        ]
+    )
+    assert args.llm_render is True
+    assert args.llm_endpoint == "http://127.0.0.1:8000"
+    assert args.llm_model == "local"
+    assert args.llm_timeout == 10
+    assert args.llm_max_render == 2
+
+
+def test_parse_args_rejects_invalid_llm_values() -> None:
+    with pytest.raises(SystemExit):
+        lab.parse_args(["--llm-timeout", "0"])
+    with pytest.raises(SystemExit):
+        lab.parse_args(["--llm-max-render", "0"])
+    with pytest.raises(SystemExit):
+        lab.parse_args(["--top", "2", "--llm-max-render", "3"])
+
+
+@pytest.mark.asyncio
+async def test_build_payload_no_llm_render_adds_fallback_render_metadata(
+    monkeypatch,
+) -> None:
+    articles = [_article(1, title="삼성전자 반도체 공급망", source="naver")]
+
+    async def fake_fetch_articles(_market, _window_hours, _limit):
+        return articles
+
+    monkeypatch.setattr(lab, "fetch_articles", fake_fetch_articles)
+    monkeypatch.setattr(
+        lab, "embed_batch", lambda endpoint, model, texts: [[1.0, 0.0] for _ in texts]
+    )
+    args = Namespace(
+        market="all",
+        window_hours=24,
+        limit=10,
+        top=3,
+        threshold=0.78,
+        dedupe_threshold=0.90,
+        embedding_endpoint="http://127.0.0.1:10631/v1/embeddings",
+        embedding_model="BAAI/bge-m3",
+        batch_size=16,
+        compare_v1=False,
+        weights=None,
+        drop_regular_reports=False,
+        merge_clusters=False,
+        merge_rep_threshold=0.86,
+        merge_token_jaccard=0.30,
+        merge_rep_articles=3,
+        llm_render=False,
+        llm_endpoint=None,
+        llm_model=None,
+        llm_timeout=30,
+        llm_max_render=None,
+        llm_prompt_version="rob136-v1",
+    )
+    payload = await lab.build_payload(args)
+    assert payload["run"]["llm_render"]["enabled"] is False
+    assert payload["run"]["llm_render"]["fallback"] == 1
+    assert payload["issues"][0]["render_status"] == "fallback"
+    assert payload["issues"][0]["summary_ko"]
+
+
+@pytest.mark.asyncio
+async def test_build_payload_llm_render_uses_mock_provider_and_reports_counts(
+    monkeypatch,
+) -> None:
+    articles = [_article(1, title="삼성전자 반도체 공급망", source="naver")]
+    provider = _Provider(
+        json.dumps(
+            _valid_render_card(title_ko="AI 반도체 수요", related_symbols=[]),
+            ensure_ascii=False,
+        )
+    )
+
+    async def fake_fetch_articles(_market, _window_hours, _limit):
+        return articles
+
+    monkeypatch.setattr(lab, "fetch_articles", fake_fetch_articles)
+    monkeypatch.setattr(
+        lab, "embed_batch", lambda endpoint, model, texts: [[1.0, 0.0] for _ in texts]
+    )
+    monkeypatch.setattr(lab, "make_llm_provider", lambda _args: provider)
+    args = Namespace(
+        market="all",
+        window_hours=24,
+        limit=10,
+        top=3,
+        threshold=0.78,
+        dedupe_threshold=0.90,
+        embedding_endpoint="http://127.0.0.1:10631/v1/embeddings",
+        embedding_model="BAAI/bge-m3",
+        batch_size=16,
+        compare_v1=False,
+        weights=None,
+        drop_regular_reports=False,
+        merge_clusters=False,
+        merge_rep_threshold=0.86,
+        merge_token_jaccard=0.30,
+        merge_rep_articles=3,
+        llm_render=True,
+        llm_endpoint="http://127.0.0.1:8000",
+        llm_model="local-model",
+        llm_timeout=30,
+        llm_max_render=1,
+        llm_prompt_version="rob136-v1",
+    )
+    payload = await lab.build_payload(args)
+    assert payload["run"]["llm_render"]["enabled"] is True
+    assert payload["run"]["llm_render"]["ok"] == 1
+    assert payload["issues"][0]["title_ko"] == "AI 반도체 수요"
+    assert payload["issues"][0]["render_status"] == "ok"
+
+
+def test_render_markdown_includes_llm_success_fallback_counts() -> None:
+    payload = {
+        "run": {
+            "run_uuid": "r-1",
+            "market": "all",
+            "window_hours": 24,
+            "article_count": 1,
+            "cluster_count": 1,
+            "embedding_model": "BAAI/bge-m3",
+            "embedding_dim": 1024,
+            "threshold": 0.78,
+            "llm_render": {
+                "ok": 1,
+                "fallback": 1,
+                "skipped": 0,
+                "provider": "openai_compatible",
+                "model": "local-model",
+                "prompt_version": "rob136-v1",
+            },
+        },
+        "issues": [
+            {
+                **_render_issue(),
+                "source_count": 2,
+                "render_status": "ok",
+                "render_model": "local-model",
+                "render_rejection_reason": None,
+                "summary_ko": "여러 국내 매체가 AI 서버 수요와 메모리 공급망 관련 동향을 함께 다뤘습니다.",
+                "impact_points": ["메모리 업황 관련 뉴스 흐름을 점검합니다."],
+                "confidence": 0.7,
+            },
+            {
+                **_render_issue(rank=2, cluster_key="cluster-2"),
+                "source_count": 2,
+                "render_status": "fallback",
+                "render_rejection_reason": "llm_disabled",
+                "summary_ko": "규칙 기반 요약입니다.",
+                "impact_points": ["추가 확인이 필요합니다."],
+                "confidence": 0.0,
+            },
+        ],
+    }
+    md = lab.render_markdown(payload)
+    assert "LLM render: ok=1, fallback=1, skipped=0" in md
+    assert "렌더: ok · model=local-model · confidence=0.70" in md
+    assert "요약:" in md
+    assert "영향:" in md
+    assert "fallback(rule-based, reason=llm_disabled)" in md
+
+
+@pytest.mark.asyncio
+async def test_store_payload_persists_render_metadata_in_issue_payload(
+    monkeypatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        async def execute(self, _stmt, params=None):
+            if params:
+                calls.append(params)
+
+        async def commit(self) -> None:
+            return None
+
+    payload = {
+        "run": {
+            "run_uuid": "run-1",
+            "market": "all",
+            "window_hours": 24,
+            "article_limit": 10,
+            "threshold": 0.78,
+            "embedding_model": "BAAI/bge-m3",
+            "embedding_dim": 1024,
+            "article_count": 1,
+            "cluster_count": 1,
+            "llm_render": {"ok": 1, "fallback": 0},
+        },
+        "source_counts": {"raw": {"naver": 1}, "normalized": {"naver": 1}},
+        "issues": [
+            {
+                **_render_issue(),
+                "source_count": 2,
+                "title_ko": "렌더된 제목",
+                "subtitle_ko": "렌더된 부제",
+                "direction": "up",
+                "render_status": "ok",
+                "summary_ko": "렌더 메타데이터가 포함된 요약입니다.",
+                "impact_points": ["영향 포인트"],
+                "confidence": 0.8,
+            }
+        ],
+    }
+
+    async def fake_ensure_lab_tables() -> None:
+        return None
+
+    monkeypatch.setattr(lab, "ensure_lab_tables", fake_ensure_lab_tables)
+    monkeypatch.setattr(lab, "AsyncSessionLocal", lambda: FakeSession())
+    await lab.store_payload(payload)
+    issue_params = calls[1]
+    issue_payload = json.loads(issue_params["payload"])
+    assert issue_payload["render_status"] == "ok"
+    assert issue_params["title_ko"] == "렌더된 제목"
+    assert issue_params["subtitle_ko"] == "렌더된 부제"
+    assert issue_params["direction"] == "up"
+
+
+def test_news_issue_lab_renderer_not_imported_by_app_modules() -> None:
+    from pathlib import Path
+
+    forbidden = (
+        "from scripts.news_issue_lab import render_top_issues",
+        "from scripts.news_issue_lab import OpenAICompatibleLLMRenderProvider",
+        "from scripts.news_issue_lab import validate_render_response",
+    )
+    app_root = Path(__file__).resolve().parents[1] / "app"
+    offenders = []
+    for path in app_root.rglob("*.py"):
+        text = path.read_text()
+        if any(token in text for token in forbidden):
+            offenders.append(str(path.relative_to(app_root.parent)))
+    assert offenders == []

--- a/tests/test_news_issue_lab.py
+++ b/tests/test_news_issue_lab.py
@@ -113,7 +113,7 @@ def test_score_cluster_reports_normalized_source_counts_and_duplicate_penalty() 
 def test_score_cluster_caps_diversity_at_five_source_families() -> None:
     articles = [_article(i, source=f"source_{i}") for i in range(1, 7)]
     score = lab.score_cluster(_cluster(*range(6)), articles, window_hours=24)
-    assert score.components["source_diversity_norm"] == 1.0
+    assert score.components["source_diversity_norm"] == pytest.approx(1.0)
 
 
 def test_score_cluster_caps_regular_report_penalty() -> None:
@@ -122,7 +122,7 @@ def test_score_cluster_caps_regular_report_penalty() -> None:
         for i in range(1, 6)
     ]
     score = lab.score_cluster(_cluster(*range(5)), articles, window_hours=24)
-    assert score.penalties["regular_report"] == 0.45
+    assert score.penalties["regular_report"] == pytest.approx(0.45)
     assert score.flags["regular_report"] == 5
 
 
@@ -140,7 +140,7 @@ def test_score_cluster_caps_future_recency_at_one() -> None:
         )
     ]
     score = lab.score_cluster(_cluster(0), articles, window_hours=24)
-    assert score.components["recency_norm"] == 1.0
+    assert score.components["recency_norm"] == pytest.approx(1.0)
 
 
 def test_keyword_matches_does_not_match_single_syllable_korean_inside_words() -> None:
@@ -342,7 +342,7 @@ def test_merge_decision_dataclass_holds_all_signals() -> None:
         absorbed_title="Y",
     )
     assert decision.decision == "merged"
-    assert decision.rep_sim == 0.91
+    assert decision.rep_sim == pytest.approx(0.91)
 
 
 def test_merge_diagnostics_dataclass_defaults_to_disabled() -> None:
@@ -354,11 +354,11 @@ def test_merge_diagnostics_dataclass_defaults_to_disabled() -> None:
 
 
 def test_merge_constants_have_expected_defaults() -> None:
-    assert lab.MERGE_REP_THRESHOLD == 0.86
-    assert lab.MERGE_TOKEN_JACCARD == 0.30
-    assert lab.MERGE_STRONG_REP_THRESHOLD == 0.93
-    assert lab.MERGE_TOPIC_REP_THRESHOLD == 0.43
-    assert lab.MERGE_MIN_TOKEN_FLOOR == 0.20
+    assert lab.MERGE_REP_THRESHOLD == pytest.approx(0.86)
+    assert lab.MERGE_TOKEN_JACCARD == pytest.approx(0.30)
+    assert lab.MERGE_STRONG_REP_THRESHOLD == pytest.approx(0.93)
+    assert lab.MERGE_TOPIC_REP_THRESHOLD == pytest.approx(0.43)
+    assert lab.MERGE_MIN_TOKEN_FLOOR == pytest.approx(0.20)
     assert lab.MERGE_MAX_CLUSTER_SIZE == 25
 
 
@@ -852,12 +852,12 @@ async def test_build_payload_no_merge_flag_disables_merge(monkeypatch) -> None:
 def test_parse_args_accepts_merge_flags_and_defaults() -> None:
     args = lab.parse_args([])
     assert args.merge_clusters is True
-    assert args.merge_rep_threshold == 0.86
-    assert args.merge_token_jaccard == 0.30
+    assert args.merge_rep_threshold == pytest.approx(0.86)
+    assert args.merge_token_jaccard == pytest.approx(0.30)
     assert args.merge_rep_articles == 3
     args2 = lab.parse_args(["--no-merge-clusters", "--merge-rep-threshold", "0.9"])
     assert args2.merge_clusters is False
-    assert args2.merge_rep_threshold == 0.9
+    assert args2.merge_rep_threshold == pytest.approx(0.9)
 
 
 def test_parse_args_rejects_invalid_merge_thresholds() -> None:
@@ -1152,7 +1152,7 @@ def test_fallback_render_returns_schema_complete_card() -> None:
     assert card["direction"] == "neutral"
     assert card["render_status"] == "fallback"
     assert card["render_rejection_reason"] == "llm_disabled"
-    assert card["confidence"] == 0.0
+    assert card["confidence"] == pytest.approx(0.0)
     assert card["summary_ko"]
     assert card["impact_points"]
     assert "body" not in json.dumps(card, ensure_ascii=False)

--- a/tests/test_news_issue_lab.py
+++ b/tests/test_news_issue_lab.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from scripts import news_issue_lab as lab
+
+
+def _article(
+    id: int = 1,
+    title: str = "Nasdaq closes at record on AI earnings",
+    *,
+    source: str = "reuters",
+    feed_source: str | None = None,
+    summary: str | None = None,
+    published_at: str | None = None,
+    scraped_at: str | None = None,
+) -> lab.Article:
+    now = datetime.now(UTC).isoformat()
+    return lab.Article(
+        id=id,
+        title=title,
+        summary=summary,
+        market="us",
+        feed_source=feed_source or source,
+        source=source,
+        stock_symbol=None,
+        stock_name=None,
+        published_at=published_at or now,
+        scraped_at=scraped_at or now,
+    )
+
+
+def _cluster(*indices: int, best_similarity: float = 1.0) -> dict[str, object]:
+    return {"indices": list(indices), "best_similarity": best_similarity}
+
+
+def test_normalize_source_key_collapses_naver_research_house_variants() -> None:
+    assert (
+        lab.normalize_source_key("browser_naver_research") == "browser_naver_research"
+    )
+    assert (
+        lab.normalize_source_key("browser_naver_research_daishin")
+        == "browser_naver_research"
+    )
+    assert (
+        lab.normalize_source_key("browser_naver_research_yuanta_securities")
+        == "browser_naver_research"
+    )
+    assert (
+        lab.normalize_source_key("rss_yahoo_finance_topstories")
+        == "rss_yahoo_finance_topstories"
+    )
+    assert lab.normalize_source_key("") == "unknown"
+    assert lab.normalize_source_key(None) == "unknown"
+
+
+def test_article_normalized_source_key_uses_source_key_fallback() -> None:
+    article = _article(feed_source="browser_naver_research_daishin", source="naver")
+    assert article.source_key == "browser_naver_research_daishin"
+    assert article.normalized_source_key == "browser_naver_research"
+
+
+@pytest.mark.parametrize(
+    ("article", "regular", "noise", "market_signal"),
+    [
+        (_article(title="[데일리 마감] 코스피 약보합"), True, False, False),
+        (_article(title="Morning Letter: futures higher"), True, False, False),
+        (
+            _article(
+                title="Best travel credit cards for 2026",
+                feed_source="rss_yahoo_finance_topstories",
+            ),
+            False,
+            True,
+            False,
+        ),
+        (
+            _article(
+                title="Fed minutes spook card-issuer stocks",
+                feed_source="rss_yahoo_finance_topstories",
+            ),
+            False,
+            True,
+            True,
+        ),
+        (_article(title="Nasdaq closes at record on AI earnings"), False, False, True),
+    ],
+)
+def test_classify_title_flags_regular_reports_noise_and_market_signals(
+    article: lab.Article, regular: bool, noise: bool, market_signal: bool
+) -> None:
+    flags = lab.classify_title(article)
+    assert flags.is_regular_report is regular
+    assert flags.is_yahoo_personal_finance is noise
+    assert flags.has_market_signal is market_signal
+
+
+def test_score_cluster_reports_normalized_source_counts_and_duplicate_penalty() -> None:
+    articles = [
+        _article(1, source="browser_naver_research_daishin"),
+        _article(2, source="browser_naver_research_yuanta"),
+    ]
+    score = lab.score_cluster(_cluster(0, 1), articles, window_hours=24)
+    assert score.raw_source_count == 2
+    assert score.normalized_source_count == 1
+    assert score.penalties["duplicate_source"] > 0
+
+
+def test_score_cluster_caps_diversity_at_five_source_families() -> None:
+    articles = [_article(i, source=f"source_{i}") for i in range(1, 7)]
+    score = lab.score_cluster(_cluster(*range(6)), articles, window_hours=24)
+    assert score.components["source_diversity_norm"] == 1.0
+
+
+def test_score_cluster_caps_regular_report_penalty() -> None:
+    articles = [
+        _article(i, title=f"Morning Letter daily market note {i}", source=f"s{i}")
+        for i in range(1, 6)
+    ]
+    score = lab.score_cluster(_cluster(*range(5)), articles, window_hours=24)
+    assert score.penalties["regular_report"] == 0.45
+    assert score.flags["regular_report"] == 5
+
+
+def test_score_cluster_gives_market_signal_topic_relevance() -> None:
+    articles = [_article(title="Treasury yields rise as CPI reshapes Fed bets")]
+    score = lab.score_cluster(_cluster(0), articles, window_hours=24)
+    assert score.components["topic_relevance"] >= 0.5
+
+
+def test_score_cluster_caps_future_recency_at_one() -> None:
+    articles = [
+        _article(
+            title="Nasdaq earnings stocks rally",
+            published_at=(datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+        )
+    ]
+    score = lab.score_cluster(_cluster(0), articles, window_hours=24)
+    assert score.components["recency_norm"] == 1.0
+
+
+def test_keyword_matches_does_not_match_single_syllable_korean_inside_words() -> None:
+    assert not lab.keyword_matches("외국인 매도에도 코스피 최고치", "은")
+    assert lab.keyword_matches("금 가격 상승", "금")
+
+
+def test_score_increases_or_preserves_when_fresh_source_is_added() -> None:
+    old_article = _article(
+        1,
+        title="Nasdaq earnings lift stocks",
+        source="reuters",
+        published_at=(datetime.now(UTC) - timedelta(hours=10)).isoformat(),
+    )
+    fresh_article = _article(
+        2,
+        title="Nasdaq earnings lift stocks again",
+        source="bloomberg",
+        published_at=datetime.now(UTC).isoformat(),
+    )
+    one = lab.score_cluster(_cluster(0), [old_article], window_hours=24)
+    two = lab.score_cluster(
+        _cluster(0, 1), [old_article, fresh_article], window_hours=24
+    )
+    assert two.score >= one.score
+
+
+def test_rank_clusters_v2_sorts_by_score_then_source_and_article_counts() -> None:
+    articles = [
+        _article(1, title="Generic market item", source="a"),
+        _article(2, title="Nasdaq earnings stocks rally", source="b"),
+        _article(3, title="Nasdaq earnings stocks rally again", source="c"),
+    ]
+    ranked = lab.rank_clusters_v2(
+        [_cluster(0), _cluster(1, 2)], articles, window_hours=24
+    )
+    assert ranked[0][0]["indices"] == [1, 2]
+    assert ranked[0][1].normalized_source_count == 2
+
+
+def test_summarize_cluster_includes_score_diagnostics_and_source_counts() -> None:
+    articles = [_article(source="browser_naver_research_daishin")]
+    breakdown = lab.score_cluster(_cluster(0), articles, window_hours=24)
+    issue = lab.summarize_cluster(
+        _cluster(0), articles, rank=1, score_breakdown=breakdown
+    )
+    assert issue["score"] == breakdown.score
+    assert "score_components" in issue
+    assert "score_weighted" in issue
+    assert "score_penalties" in issue
+    assert issue["source_counts"]["normalized"] == {"browser_naver_research": 1}
+    assert issue["raw_source_count"] == 1
+    assert issue["normalized_source_count"] == 1
+
+
+def test_render_markdown_includes_score_and_raw_normalized_source_counts() -> None:
+    payload = {
+        "run": {
+            "run_uuid": "run-1",
+            "market": "all",
+            "window_hours": 24,
+            "article_count": 1,
+            "cluster_count": 1,
+            "embedding_model": "BAAI/bge-m3",
+            "embedding_dim": 1024,
+            "threshold": 0.78,
+        },
+        "issues": [
+            {
+                "rank": 1,
+                "direction": "neutral",
+                "title_ko": "테스트",
+                "subtitle_ko": "부제",
+                "raw_source_count": 2,
+                "normalized_source_count": 1,
+                "source_count": 1,
+                "article_count": 3,
+                "score": 0.5,
+                "score_components": {"source_diversity_norm": 0.2},
+                "score_penalties": {"duplicate_source": 0.15},
+                "representative_sources": ["a", "b"],
+                "markets": ["us"],
+                "topics": [],
+                "related_symbols": [],
+                "representative_articles": [],
+            }
+        ],
+    }
+    rendered = lab.render_markdown(payload)
+    assert "raw 2개 → normalized 1개" in rendered
+    assert "점수: 0.5000" in rendered
+    assert "duplicate_source" in rendered
+
+
+def test_parse_weights_accepts_complete_normalized_weights() -> None:
+    weights = lab.parse_weights("diversity=0.5,volume=0.2,recency=0.2,relevance=0.1")
+    assert weights == lab.ScoreWeights(
+        diversity=0.5, volume=0.2, recency=0.2, relevance=0.1
+    )
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "diversity=1.0,volume=0,recency=0,relevance=0,unknown=0",
+        "diversity=-0.1,volume=0.5,recency=0.3,relevance=0.3",
+        "diversity=0.5,volume=0.5,recency=0.5,relevance=0.5",
+    ],
+)
+def test_parse_weights_rejects_invalid_weights(raw: str) -> None:
+    with pytest.raises(ValueError):
+        lab.parse_weights(raw)
+
+
+def test_parse_args_rejects_non_positive_counts() -> None:
+    with pytest.raises(SystemExit):
+        lab.parse_args(["--batch-size", "0"])
+
+
+@pytest.mark.asyncio
+async def test_build_payload_compare_v1_json_block_and_drop_regular_reports(
+    monkeypatch,
+) -> None:
+    articles = [
+        _article(1, title="Morning Letter daily market note", source="a"),
+        _article(2, title="Nasdaq earnings stocks rally", source="b"),
+        _article(3, title="Nasdaq earnings stocks rally again", source="c"),
+    ]
+
+    async def fake_fetch_articles(
+        market: str, window_hours: int, limit: int
+    ) -> list[lab.Article]:
+        return articles
+
+    monkeypatch.setattr(lab, "fetch_articles", fake_fetch_articles)
+    monkeypatch.setattr(
+        lab,
+        "embed_batch",
+        lambda endpoint, model, texts: [[1.0, 0.0] for _ in texts],
+    )
+    args = Namespace(
+        market="all",
+        window_hours=24,
+        limit=240,
+        top=12,
+        threshold=0.0,
+        dedupe_threshold=0.90,
+        embedding_endpoint="http://127.0.0.1:10631/v1/embeddings",
+        embedding_model="BAAI/bge-m3",
+        batch_size=32,
+        compare_v1=True,
+        weights=None,
+        drop_regular_reports=True,
+    )
+    payload = await lab.build_payload(args)
+    assert "v1_vs_v2" in payload
+    assert payload["run"]["top"] == 12
+    assert payload["source_counts"]["raw"] == {"a": 1, "b": 1, "c": 1}
+    assert payload["source_counts"]["normalized"] == {"a": 1, "b": 1, "c": 1}
+    assert all(
+        issue["flags"]["regular_report"] / issue["article_count"] < 0.5
+        for issue in payload["issues"]
+    )
+    rendered = lab.render_comparison_markdown(payload, [], [], top=12)
+    assert "## v1 vs v2 comparison" in rendered


### PR DESCRIPTION
## Summary
- Adds optional `--llm-render` support to the experimental `scripts/news_issue_lab.py` only, with OpenAI-compatible chat completion provider and `--no-llm` deterministic default.
- Validates Korean issue-card JSON, rejects malformed/advice-like/low-quality output, and falls back to deterministic Korean cards with secret-safe diagnostics.
- Records run/item render diagnostics in lab payloads and documents no-store/operator runbook usage.

## Verification
- `git diff --check`
- `uv run ruff check scripts/news_issue_lab.py tests/test_news_issue_lab.py`
- `uv run ruff format --check scripts/news_issue_lab.py tests/test_news_issue_lab.py`
- `uv run ruff format --preview --check docs/runbooks/news-issue-lab.md`
- `uv run pytest tests/test_news_issue_lab.py -q` → 81 passed, 2 unrelated Pydantic deprecation warnings
- `uv run pytest tests/test_news_issue_clustering.py -q` → 6 passed, 2 unrelated Pydantic deprecation warnings

## Smoke note
- No-LLM CLI smoke against `http://127.0.0.1:10631/v1/embeddings` was attempted after code validation but the local embedding service returned `HTTP Error 401: Unauthorized`; no credentials or tokens were printed and no lab results were stored.

Refs ROB-136


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced News Issue Lab v2 CLI tool for intelligent news article clustering and ranking
  * Added optional cluster-merge capability to combine near-duplicate articles with configurable thresholds
  * Added Korean LLM rendering support for structured issue-card generation with automatic fallback to rule-based rendering
  * Support for Markdown and JSON output formats with optional v1-vs-v2 comparison diagnostics

* **Documentation**
  * Added comprehensive runbook documenting News Issue Lab v2 workflow, safety constraints, and diagnostic features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->