### PR TITLE
refactor(quality): dedupe portfolio weights & finnhub earnings (CPD)

### DIFF
--- a/app/mcp_server/tooling/fundamentals_sources_finnhub.py
+++ b/app/mcp_server/tooling/fundamentals_sources_finnhub.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import datetime
 import logging
 from typing import Any
 
@@ -177,58 +176,11 @@ async def _fetch_earnings_calendar_finnhub(
     from_date: str | None = None,
     to_date: str | None = None,
 ) -> dict[str, Any]:
-    client = _get_finnhub_client()
+    from app.services.market_events.finnhub_helpers import (
+        fetch_earnings_calendar_finnhub,
+    )
 
-    if not from_date:
-        from_date = datetime.date.today().isoformat()
-    if not to_date:
-        to_date = (datetime.date.today() + datetime.timedelta(days=30)).isoformat()
-
-    def fetch_sync() -> dict[str, Any]:
-        return client.earnings_calendar(
-            symbol=symbol.upper() if symbol else "",
-            _from=from_date,
-            to=to_date,
-        )
-
-    result = await asyncio.to_thread(fetch_sync)
-
-    if not result or not result.get("earningsCalendar"):
-        return {
-            "symbol": symbol,
-            "instrument_type": "equity_us",
-            "source": "finnhub",
-            "from_date": from_date,
-            "to_date": to_date,
-            "count": 0,
-            "earnings": [],
-        }
-
-    earnings = []
-    for item in result.get("earningsCalendar", []):
-        earnings.append(
-            {
-                "symbol": item.get("symbol", ""),
-                "date": item.get("date"),
-                "hour": item.get("hour", ""),
-                "eps_estimate": item.get("epsEstimate"),
-                "eps_actual": item.get("epsActual"),
-                "revenue_estimate": item.get("revenueEstimate"),
-                "revenue_actual": item.get("revenueActual"),
-                "quarter": item.get("quarter"),
-                "year": item.get("year"),
-            }
-        )
-
-    return {
-        "symbol": symbol,
-        "instrument_type": "equity_us",
-        "source": "finnhub",
-        "from_date": from_date,
-        "to_date": to_date,
-        "count": len(earnings),
-        "earnings": earnings,
-    }
+    return await fetch_earnings_calendar_finnhub(symbol, from_date, to_date)
 
 
 __all__ = [

--- a/app/services/portfolio_decision_service.py
+++ b/app/services/portfolio_decision_service.py
@@ -13,6 +13,7 @@ from app.mcp_server.tooling.fundamentals._support_resistance import (
 from app.mcp_server.tooling.market_data_quotes import _get_indicators_impl
 from app.models.portfolio_decision_run import PortfolioDecisionRun
 from app.schemas.portfolio_decision import PortfolioDecisionSlateResponse
+from app.services.portfolio_weights import build_weights as _build_portfolio_weights
 
 logger = logging.getLogger(__name__)
 
@@ -174,7 +175,7 @@ class PortfolioDecisionService:
             journal = journals.get(symbol)
             context = contexts.get(position_key) or self._empty_market_context()
 
-            weights = self._build_weights(positions, p)
+            weights = _build_portfolio_weights(positions, p)
             group = self._build_symbol_group(p, journal, context, weights)
             symbol_groups.append(group)
             self._add_group_to_summary(summary_counts, market_type, group)
@@ -792,59 +793,3 @@ class PortfolioDecisionService:
 
     def _default_execution_boundary(self) -> dict[str, Any]:
         return dict(DEFAULT_EXECUTION_BOUNDARY)
-
-    def _round_pct(self, value: float | None) -> float | None:
-        if value is None:
-            return None
-        return round(value, 1)
-
-    def _build_weights(
-        self,
-        positions: list[dict[str, Any]],
-        base: dict[str, Any],
-    ) -> dict[str, float | None]:
-        def get_eval_krw(p: dict) -> float | None:
-            market_type = str(p.get("market_type") or "").upper()
-            val = p.get("evaluation_krw")
-            if val is not None:
-                return float(val)
-            if market_type == "US":
-                return None
-            return float(p.get("evaluation", 0) or 0)
-
-        base_evaluation_krw = get_eval_krw(base)
-        if base_evaluation_krw in (None, 0):
-            return {"portfolio_weight_pct": None, "market_weight_pct": None}
-
-        portfolio_values = [get_eval_krw(p) for p in positions]
-        total_portfolio_eval_krw = (
-            sum(value for value in portfolio_values if value is not None)
-            if all(value is not None for value in portfolio_values)
-            else None
-        )
-
-        market_type = base.get("market_type")
-        same_market_values = [
-            get_eval_krw(p) for p in positions if p.get("market_type") == market_type
-        ]
-        total_same_market_eval_krw = (
-            sum(value for value in same_market_values if value is not None)
-            if all(value is not None for value in same_market_values)
-            else None
-        )
-
-        portfolio_weight = (
-            (base_evaluation_krw / total_portfolio_eval_krw) * 100
-            if total_portfolio_eval_krw not in (None, 0)
-            else None
-        )
-        market_weight = (
-            (base_evaluation_krw / total_same_market_eval_krw) * 100
-            if total_same_market_eval_krw not in (None, 0)
-            else None
-        )
-
-        return {
-            "portfolio_weight_pct": self._round_pct(portfolio_weight),
-            "market_weight_pct": self._round_pct(market_weight),
-        }

--- a/app/services/portfolio_position_detail_service.py
+++ b/app/services/portfolio_position_detail_service.py
@@ -10,6 +10,7 @@ from app.mcp_server.tooling.fundamentals._valuation import (
 )
 from app.mcp_server.tooling.market_data_quotes import _get_indicators_impl
 from app.mcp_server.tooling.orders_history import get_order_history_impl
+from app.services.portfolio_weights import build_weights as _build_portfolio_weights
 
 
 class PortfolioPositionDetailNotFoundError(Exception):
@@ -51,7 +52,7 @@ class PortfolioPositionDetailService:
             current_price=base.get("current_price"),
         )
 
-        weights = self._build_weights(positions, base)
+        weights = _build_portfolio_weights(positions, base)
         indicators = await self._fetch_action_inputs(
             market_type=str(market_type).upper(), symbol=symbol
         )
@@ -84,62 +85,6 @@ class PortfolioPositionDetailService:
             "journal": journal,
             "weights": weights,
             "action_summary": action_summary,
-        }
-
-    def _round_pct(self, value: float | None) -> float | None:
-        if value is None:
-            return None
-        return round(value, 1)
-
-    def _build_weights(
-        self,
-        positions: list[dict[str, Any]],
-        base: dict[str, Any],
-    ) -> dict[str, float | None]:
-        def get_eval_krw(p: dict) -> float | None:
-            market_type = str(p.get("market_type") or "").upper()
-            val = p.get("evaluation_krw")
-            if val is not None:
-                return float(val)
-            if market_type == "US":
-                return None
-            return float(p.get("evaluation", 0) or 0)
-
-        base_evaluation_krw = get_eval_krw(base)
-        if base_evaluation_krw in (None, 0):
-            return {"portfolio_weight_pct": None, "market_weight_pct": None}
-
-        portfolio_values = [get_eval_krw(p) for p in positions]
-        total_portfolio_eval_krw = (
-            sum(value for value in portfolio_values if value is not None)
-            if all(value is not None for value in portfolio_values)
-            else None
-        )
-
-        market_type = base.get("market_type")
-        same_market_values = [
-            get_eval_krw(p) for p in positions if p.get("market_type") == market_type
-        ]
-        total_same_market_eval_krw = (
-            sum(value for value in same_market_values if value is not None)
-            if all(value is not None for value in same_market_values)
-            else None
-        )
-
-        portfolio_weight = (
-            (base_evaluation_krw / total_portfolio_eval_krw) * 100
-            if total_portfolio_eval_krw not in (None, 0)
-            else None
-        )
-        market_weight = (
-            (base_evaluation_krw / total_same_market_eval_krw) * 100
-            if total_same_market_eval_krw not in (None, 0)
-            else None
-        )
-
-        return {
-            "portfolio_weight_pct": self._round_pct(portfolio_weight),
-            "market_weight_pct": self._round_pct(market_weight),
         }
 
     async def _fetch_action_inputs(

--- a/app/services/portfolio_weights.py
+++ b/app/services/portfolio_weights.py
@@ -1,0 +1,62 @@
+"""Shared weight-computation helpers for portfolio services."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def round_pct(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return round(value, 1)
+
+
+def build_weights(
+    positions: list[dict[str, Any]],
+    base: dict[str, Any],
+) -> dict[str, float | None]:
+    def get_eval_krw(p: dict) -> float | None:
+        market_type = str(p.get("market_type") or "").upper()
+        val = p.get("evaluation_krw")
+        if val is not None:
+            return float(val)
+        if market_type == "US":
+            return None
+        return float(p.get("evaluation", 0) or 0)
+
+    base_evaluation_krw = get_eval_krw(base)
+    if base_evaluation_krw in (None, 0):
+        return {"portfolio_weight_pct": None, "market_weight_pct": None}
+
+    portfolio_values = [get_eval_krw(p) for p in positions]
+    total_portfolio_eval_krw = (
+        sum(value for value in portfolio_values if value is not None)
+        if all(value is not None for value in portfolio_values)
+        else None
+    )
+
+    market_type = base.get("market_type")
+    same_market_values = [
+        get_eval_krw(p) for p in positions if p.get("market_type") == market_type
+    ]
+    total_same_market_eval_krw = (
+        sum(value for value in same_market_values if value is not None)
+        if all(value is not None for value in same_market_values)
+        else None
+    )
+
+    portfolio_weight = (
+        (base_evaluation_krw / total_portfolio_eval_krw) * 100
+        if total_portfolio_eval_krw not in (None, 0)
+        else None
+    )
+    market_weight = (
+        (base_evaluation_krw / total_same_market_eval_krw) * 100
+        if total_same_market_eval_krw not in (None, 0)
+        else None
+    )
+
+    return {
+        "portfolio_weight_pct": round_pct(portfolio_weight),
+        "market_weight_pct": round_pct(market_weight),
+    }

--- a/tests/test_portfolio_position_detail_service.py
+++ b/tests/test_portfolio_position_detail_service.py
@@ -10,6 +10,7 @@ from app.services.portfolio_position_detail_service import (
     PortfolioPositionDetailNotFoundError,
     PortfolioPositionDetailService,
 )
+from app.services.portfolio_weights import build_weights as _build_portfolio_weights
 
 
 @pytest.mark.unit
@@ -1265,9 +1266,8 @@ async def test_get_page_payload_builds_compact_action_reason() -> None:
             "_fetch_action_inputs",
             AsyncMock(return_value={"rsi": 36.0}),
         ),
-        patch.object(
-            service,
-            "_build_weights",
+        patch(
+            "app.services.portfolio_position_detail_service._build_portfolio_weights",
             return_value={"portfolio_weight_pct": 6.8, "market_weight_pct": 10.6},
         ),
     ):
@@ -1337,10 +1337,7 @@ def test_build_weights_prefers_evaluation_krw_for_portfolio_weight():
 
     # total = 10M + 2.6M = 12.6M
     # weight = 2.6M / 12.6M * 100 = 20.63... -> 20.6
-    service = PortfolioPositionDetailService(
-        overview_service=MagicMock(), dashboard_service=MagicMock()
-    )
-    weights = service._build_weights(positions, base)
+    weights = _build_portfolio_weights(positions, base)
 
     assert weights["portfolio_weight_pct"] == pytest.approx(20.6)
 
@@ -1352,10 +1349,7 @@ def test_build_weights_returns_none_when_us_position_lacks_krw_normalization():
     ]
     base = positions[1]
 
-    service = PortfolioPositionDetailService(
-        overview_service=MagicMock(), dashboard_service=MagicMock()
-    )
-    weights = service._build_weights(positions, base)
+    weights = _build_portfolio_weights(positions, base)
 
     assert weights["portfolio_weight_pct"] is None
     assert weights["market_weight_pct"] is None


### PR DESCRIPTION
## Summary
- 두 곳에서 SonarCloud CPD가 잡던 약 50줄 중복 블록 제거 (프로덕션 코드만)
- finnhub earnings calendar fetch (52줄): MCP tooling이 service 헬퍼로 위임
- portfolio weight 계산 (55줄): `app/services/portfolio_weights` 모듈로 추출

## Details
1. `app/mcp_server/tooling/fundamentals_sources_finnhub.py` 의 `_fetch_earnings_calendar_finnhub` 본문을 `app/services/market_events/finnhub_helpers.fetch_earnings_calendar_finnhub` 호출로 교체
2. `PortfolioDecisionService._round_pct/_build_weights` 와 `PortfolioPositionDetailService._round_pct/_build_weights` (둘 다 동일) 를 새 모듈 `app/services/portfolio_weights` 의 순수 함수 `round_pct` / `build_weights` 로 추출. 양 서비스는 import 후 호출.
3. `tests/test_portfolio_position_detail_service.py` — `service._build_weights(...)` 직접 호출 2건과 `patch.object(service, "_build_weights", ...)` 1건을 모듈 함수 직접 호출/import 경로 patch 로 갱신.

동작 변경 없음. diff: +75 / -176.

## Test plan
- [x] `uv run ruff check app/` — clean
- [x] `uv run pytest tests/test_portfolio_position_detail_service.py tests/test_portfolio_overview_service.py tests/test_merged_portfolio_service.py tests/services/test_market_events_ingestion.py tests/test_mcp_fundamentals_tools.py -q` → 285 passed
- [ ] CI 게이트(lint/test/security/sonarcloud) 통과 확인

## Notes
- 누적 `duplicated_lines_density` 3.4% 중 약 107줄 (~0.9%) 감소 예상
- 후속: portfolio Jinja 템플릿 macro 추출(약 200줄, UI 검증 필요), `analysis_analyze`/`analysis_screening` 50줄 등은 별도 PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Centralized portfolio weight calculation logic into a shared utility module, eliminating duplicate implementations across services for improved code maintainability.
  * Refactored earnings calendar fetching to delegate to a shared helper function.

* **Tests**
  * Updated test suite to align with refactored weight calculation implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->