### PR TITLE
feat(news): add ROB-145 quality gate eval

### DIFF
--- a/scripts/news_issue_lab.py
+++ b/scripts/news_issue_lab.py
@@ -17,6 +17,7 @@ import asyncio
 import hashlib
 import json
 import math
+import os
 import re
 import sys
 import time
@@ -380,6 +381,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument("--embedding-endpoint", default=DEFAULT_BGE_ENDPOINT)
     parser.add_argument("--embedding-model", default=DEFAULT_BGE_MODEL)
+    parser.add_argument(
+        "--embedding-api-key",
+        default=os.getenv("EMBEDDING_API_KEY"),
+        help="optional bearer token for secured OpenAI-compatible embedding endpoints; defaults to EMBEDDING_API_KEY",
+    )
     parser.add_argument("--batch-size", type=int, default=16)
     parser.add_argument(
         "--store", action="store_true", help="store run/result payloads in lab tables"
@@ -527,13 +533,20 @@ def centroid(vectors: list[list[float]]) -> list[float]:
 
 
 def embed_batch(
-    endpoint: str, model: str, texts: list[str], timeout: int = 180
+    endpoint: str,
+    model: str,
+    texts: list[str],
+    timeout: int = 180,
+    api_key: str | None = None,
 ) -> list[list[float]]:
     payload = {"model": model, "input": texts}
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
     req = request.Request(
         endpoint,
         data=json.dumps(payload).encode(),
-        headers={"Content-Type": "application/json"},
+        headers=headers,
         method="POST",
     )
     with request.urlopen(req, timeout=timeout) as resp:
@@ -2469,6 +2482,7 @@ async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
                 args.embedding_endpoint,
                 args.embedding_model,
                 [a.text_for_embedding for a in batch],
+                api_key=getattr(args, "embedding_api_key", None),
             )
         )
     embedding_dim = len(vectors[0]) if vectors else 0
@@ -2483,6 +2497,7 @@ async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
                     args.embedding_endpoint,
                     args.embedding_model,
                     texts[i : i + args.batch_size],
+                    api_key=getattr(args, "embedding_api_key", None),
                 )
             )
         return rep_vectors

--- a/scripts/news_issue_lab.py
+++ b/scripts/news_issue_lab.py
@@ -361,6 +361,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--limit", type=int, default=240)
     parser.add_argument("--top", type=int, default=12)
     parser.add_argument(
+        "--quality-top",
+        type=int,
+        default=5,
+        help="top-N window used for deterministic ROB-145 quality gate diagnostics",
+    )
+    parser.add_argument(
         "--threshold",
         type=float,
         default=0.78,
@@ -467,7 +473,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="prompt version label stored in diagnostics",
     )
     args = parser.parse_args(argv)
-    for name in ("window_hours", "limit", "top", "batch_size"):
+    for name in ("window_hours", "limit", "top", "quality_top", "batch_size"):
         if getattr(args, name) <= 0:
             parser.error(f"--{name.replace('_', '-')} must be positive")
     if not (0.0 < args.merge_rep_threshold <= 1.0):
@@ -1290,6 +1296,369 @@ class MergeDiagnostics:
             self.decisions = []
 
 
+@dataclass(frozen=True)
+class QualityGateConfig:
+    top_n: int = 5
+    max_duplicate_title_in_top: int = 0
+    max_duplicate_topic_in_top: int = 0
+    max_single_article_top_count: int = 0
+    max_market_mismatch_top_count: int = 0
+    max_source_noise_top_count: int = 0
+    crypto_equity_topic_fail: bool = True
+
+
+GENERIC_EQUITY_TOPICS_FOR_CRYPTO: set[str] = {
+    "미국 증시 최고치",
+    "기업 실적 발표",
+    "반도체 슈퍼사이클",
+    "AI 데이터센터",
+    "부동산·리츠",
+}
+CRYPTO_NATIVE_TERMS: tuple[str, ...] = (
+    "bitcoin",
+    "btc",
+    "비트코인",
+    "ethereum",
+    "ether",
+    "eth",
+    "이더리움",
+    "crypto",
+    "cryptocurrency",
+    "blockchain",
+    "블록체인",
+    "token",
+    "토큰",
+    "stablecoin",
+    "스테이블코인",
+    "coinbase",
+    "coindesk",
+    "cointelegraph",
+    "etf",
+    "defi",
+    "solana",
+    "솔라나",
+)
+SOURCE_NOISE_TERMS: tuple[str, ...] = (
+    "yahoo finance",
+    "naver mainnews",
+    "browser_naver_mainnews",
+    "rss_yahoo_finance_topstories",
+    "topstories",
+    "mainnews",
+)
+
+
+def _asdict_dataclass(obj: Any) -> dict[str, Any]:
+    return {
+        name: getattr(obj, name) for name in getattr(obj, "__dataclass_fields__", {})
+    }
+
+
+def _issue_text_blob(issue: dict[str, Any]) -> str:
+    parts: list[str] = [
+        str(issue.get("title_ko") or ""),
+        str(issue.get("subtitle_ko") or ""),
+        " ".join(str(t) for t in issue.get("topics") or []),
+        " ".join(str(s) for s in issue.get("representative_sources") or []),
+    ]
+    for article in issue.get("representative_articles") or []:
+        parts.extend(
+            [
+                str(article.get("title") or ""),
+                str(article.get("source") or ""),
+                str(article.get("feed_source") or ""),
+                str(article.get("stock_symbol") or ""),
+            ]
+        )
+    return "\n".join(parts).lower()
+
+
+def issue_has_source_noise(issue: dict[str, Any]) -> bool:
+    title_blob = (
+        f"{issue.get('title_ko') or ''} {issue.get('subtitle_ko') or ''}".lower()
+    )
+    return any(term in title_blob for term in SOURCE_NOISE_TERMS)
+
+
+def issue_has_crypto_native_evidence(issue: dict[str, Any]) -> bool:
+    blob = _issue_text_blob(issue)
+    return any(keyword_matches(blob, term) for term in CRYPTO_NATIVE_TERMS)
+
+
+def issue_market_mismatch(issue: dict[str, Any], requested_market: str) -> bool:
+    if requested_market == "all":
+        return False
+    issue_markets = set(issue.get("markets") or [])
+    if issue_markets and not (
+        requested_market in issue_markets or "all" in issue_markets
+    ):
+        return True
+    if requested_market == "crypto":
+        title = str(issue.get("title_ko") or "")
+        topics = {str(t) for t in (issue.get("topics") or [])}
+        if (
+            title in GENERIC_EQUITY_TOPICS_FOR_CRYPTO
+            or topics & GENERIC_EQUITY_TOPICS_FOR_CRYPTO
+        ) and not issue_has_crypto_native_evidence(issue):
+            return True
+    return False
+
+
+def _quality_finding(
+    code: str,
+    severity: str,
+    issue: dict[str, Any] | None,
+    reason: str,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"code": code, "severity": severity, "reason": reason}
+    if issue:
+        payload.update(
+            {
+                "rank": issue.get("rank"),
+                "title_ko": issue.get("title_ko"),
+                "cluster_key": issue.get("cluster_key"),
+                "article_count": issue.get("article_count"),
+                "normalized_source_count": issue.get("normalized_source_count"),
+                "markets": issue.get("markets"),
+                "topics": issue.get("topics"),
+            }
+        )
+    return payload
+
+
+def suppress_duplicate_top_issues(
+    issues: list[dict[str, Any]],
+    *,
+    top_n: int,
+    requested_market: str,
+    config: QualityGateConfig | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Keep visible top-N cleaner while preserving suppressed candidates for audit."""
+    config = config or QualityGateConfig(top_n=top_n)
+    selected: list[dict[str, Any]] = []
+    suppressed: list[dict[str, Any]] = []
+    seen_titles: set[str] = set()
+    seen_topics: set[str] = set()
+    target_len = len(issues)
+    for issue in issues:
+        clone = dict(issue)
+        title_key = normalize_text(str(clone.get("title_ko") or "")).lower()
+        topic_key = title_key
+        if clone.get("topics"):
+            topic_key = normalize_text(str(clone["topics"][0])).lower()
+        reason = None
+        in_quality_window = len(selected) < top_n
+        if in_quality_window and title_key and title_key in seen_titles:
+            reason = "duplicate_title_topn"
+        elif in_quality_window and topic_key and topic_key in seen_topics:
+            reason = "duplicate_topic_topn"
+        elif in_quality_window and int(clone.get("article_count") or 0) <= 1:
+            reason = "single_article_topn"
+        elif (
+            in_quality_window
+            and requested_market == "crypto"
+            and issue_market_mismatch(clone, requested_market)
+        ):
+            reason = "crypto_equity_topic"
+        if reason:
+            clone["display_suppressed"] = True
+            clone["suppression_reason"] = reason
+            flags = list(clone.get("quality_flags") or [])
+            if reason not in flags:
+                flags.append(reason)
+            clone["quality_flags"] = flags
+            suppressed.append(clone)
+            continue
+        clone.setdefault("display_suppressed", False)
+        clone.setdefault("quality_flags", [])
+        selected.append(clone)
+        if len(selected) <= top_n:
+            if title_key:
+                seen_titles.add(title_key)
+            if topic_key:
+                seen_topics.add(topic_key)
+    if suppressed and len(selected) < target_len:
+        selected.extend(suppressed[: target_len - len(selected)])
+    for rank, issue in enumerate(selected, start=1):
+        issue["rank"] = rank
+    return selected, suppressed
+
+
+def evaluate_quality_gate(
+    payload: dict[str, Any],
+    *,
+    market: str | None = None,
+    config: QualityGateConfig | None = None,
+) -> dict[str, Any]:
+    market = market or payload.get("run", {}).get("market", "all")
+    config = config or QualityGateConfig(
+        top_n=int(payload.get("run", {}).get("quality_top", 5))
+    )
+    top_issues = list(payload.get("issues") or [])[: config.top_n]
+    findings: list[dict[str, Any]] = []
+    metrics = {
+        "duplicate_title_count_topn": 0,
+        "duplicate_topic_count_topn": 0,
+        "single_article_count_topn": 0,
+        "single_source_count_topn": 0,
+        "market_mismatch_count_topn": 0,
+        "regular_report_leakage_count_topn": 0,
+        "source_noise_count_topn": 0,
+        "crypto_equity_topic_count_topn": 0,
+        "merge_decision_count": 0,
+        "merge_rejected_near_misses": 0,
+        "llm_render_enabled": False,
+        "suppressed_candidate_count": len(payload.get("suppressed_candidates") or []),
+    }
+    seen_titles: set[str] = set()
+    seen_topics: set[str] = set()
+    for issue in top_issues:
+        flags = list(issue.get("quality_flags") or [])
+        title_key = normalize_text(str(issue.get("title_ko") or "")).lower()
+        topic_key = title_key
+        if issue.get("topics"):
+            topic_key = normalize_text(str(issue["topics"][0])).lower()
+        if title_key and title_key in seen_titles:
+            metrics["duplicate_title_count_topn"] += 1
+            findings.append(
+                _quality_finding(
+                    "duplicate_title_topn",
+                    "fail",
+                    issue,
+                    "duplicate title_ko inside quality top-N",
+                )
+            )
+            flags.append("duplicate_title_topn")
+        if topic_key and topic_key in seen_topics:
+            metrics["duplicate_topic_count_topn"] += 1
+            findings.append(
+                _quality_finding(
+                    "duplicate_topic_topn",
+                    "fail",
+                    issue,
+                    "duplicate topic inside quality top-N",
+                )
+            )
+            flags.append("duplicate_topic_topn")
+        if title_key:
+            seen_titles.add(title_key)
+        if topic_key:
+            seen_topics.add(topic_key)
+        if int(issue.get("article_count") or 0) <= 1:
+            metrics["single_article_count_topn"] += 1
+            findings.append(
+                _quality_finding(
+                    "single_article_topn",
+                    "fail",
+                    issue,
+                    "single-article issue reached quality top-N",
+                )
+            )
+            flags.append("single_article_topn")
+        if (
+            int(issue.get("normalized_source_count") or issue.get("source_count") or 0)
+            <= 1
+        ):
+            metrics["single_source_count_topn"] += 1
+            findings.append(
+                _quality_finding(
+                    "single_source_topn",
+                    "warn",
+                    issue,
+                    "single normalized source in quality top-N",
+                )
+            )
+            flags.append("single_source_topn")
+        if issue_market_mismatch(issue, market):
+            metrics["market_mismatch_count_topn"] += 1
+            code = "crypto_equity_topic" if market == "crypto" else "market_mismatch"
+            if code == "crypto_equity_topic":
+                metrics["crypto_equity_topic_count_topn"] += 1
+            findings.append(
+                _quality_finding(
+                    code, "fail", issue, f"issue does not fit requested market={market}"
+                )
+            )
+            flags.append(code)
+        if int((issue.get("flags") or {}).get("regular_report", 0)) > 0:
+            metrics["regular_report_leakage_count_topn"] += 1
+            findings.append(
+                _quality_finding(
+                    "regular_report_leakage",
+                    "warn",
+                    issue,
+                    "regular-report/transcript flag present in quality top-N",
+                )
+            )
+            flags.append("regular_report_leakage")
+        if issue_has_source_noise(issue):
+            metrics["source_noise_count_topn"] += 1
+            findings.append(
+                _quality_finding(
+                    "source_name_noise",
+                    "fail",
+                    issue,
+                    "source/feed name appears in rendered title/subtitle",
+                )
+            )
+            flags.append("source_name_noise")
+        issue["quality_flags"] = sorted(set(flags))
+        if issue["quality_flags"]:
+            issue["quality_notes"] = issue.get("quality_notes") or [
+                "; ".join(issue["quality_flags"])
+            ]
+    merge_diag = payload.get("merge_diagnostics") or {}
+    decisions = merge_diag.get("decisions") or []
+    metrics["merge_decision_count"] = sum(
+        1 for d in decisions if d.get("decision") == "merged"
+    )
+    metrics["merge_rejected_near_misses"] = int(
+        merge_diag.get("rejected_near_misses")
+        or sum(1 for d in decisions if d.get("decision") == "rejected")
+    )
+    llm_diag = payload.get("run", {}).get("llm_render") or {}
+    metrics["llm_render_enabled"] = bool(llm_diag.get("enabled"))
+    if metrics["llm_render_enabled"]:
+        findings.append(
+            _quality_finding(
+                "llm_enabled_for_eval",
+                "fail",
+                None,
+                "deterministic quality gate must keep LLM rendering disabled",
+            )
+        )
+    for suppressed in payload.get("suppressed_candidates") or []:
+        findings.append(
+            _quality_finding(
+                str(suppressed.get("suppression_reason") or "suppressed_candidate"),
+                "warn",
+                suppressed,
+                "candidate suppressed from visible top-N but preserved for audit",
+            )
+        )
+    fail_codes = {
+        "duplicate_title_topn",
+        "duplicate_topic_topn",
+        "single_article_topn",
+        "market_mismatch",
+        "crypto_equity_topic",
+        "source_name_noise",
+        "llm_enabled_for_eval",
+    }
+    status = "pass"
+    if any(f["severity"] == "fail" and f["code"] in fail_codes for f in findings):
+        status = "fail"
+    elif findings:
+        status = "warn"
+    return {
+        "status": status,
+        "top_n": config.top_n,
+        "metrics": metrics,
+        "thresholds": _asdict_dataclass(config),
+        "findings": findings,
+    }
+
+
 def _round_score(value: float) -> float:
     return round(float(value), 4)
 
@@ -1425,10 +1794,14 @@ def score_cluster(
         )
         * 0.30
     )
+    single_source_penalty = 0.14 if normalized_source_count == 1 else 0.0
+    weak_single_article_penalty = 0.28 if len(rows) == 1 else 0.0
     penalties = {
         "noise": min(0.40, noise_penalty),
         "regular_report": min(0.45, regular_report_penalty),
         "duplicate_source": min(0.30, duplicate_source_penalty),
+        "single_source": single_source_penalty,
+        "weak_single_article": weak_single_article_penalty,
     }
     components = {
         "source_diversity_norm": source_diversity_norm,
@@ -1638,6 +2011,29 @@ def render_markdown(payload: dict[str, Any]) -> str:
     ]
     if llm_render_line:
         lines.append(llm_render_line)
+    quality_gate = payload.get("quality_gate") or {}
+    if quality_gate:
+        metrics = quality_gate.get("metrics") or {}
+        lines.extend(
+            [
+                "",
+                "## 품질 게이트 (ROB-145)",
+                "",
+                f"- status: `{quality_gate.get('status', '-')}` / top_n: {quality_gate.get('top_n', '-')}",
+                f"- duplicate_title={metrics.get('duplicate_title_count_topn', 0)}, duplicate_topic={metrics.get('duplicate_topic_count_topn', 0)}, single_article={metrics.get('single_article_count_topn', 0)}, single_source={metrics.get('single_source_count_topn', 0)}",
+                f"- market_mismatch={metrics.get('market_mismatch_count_topn', 0)}, source_noise={metrics.get('source_noise_count_topn', 0)}, crypto_equity_topic={metrics.get('crypto_equity_topic_count_topn', 0)}, regular_report={metrics.get('regular_report_leakage_count_topn', 0)}",
+                f"- merge_decisions={metrics.get('merge_decision_count', 0)}, near_misses={metrics.get('merge_rejected_near_misses', 0)}, suppressed={metrics.get('suppressed_candidate_count', 0)}, llm_render_enabled={metrics.get('llm_render_enabled', False)}",
+            ]
+        )
+        findings = quality_gate.get("findings") or []
+        if findings:
+            lines.append("- findings:")
+            for finding in findings[:10]:
+                rank = finding.get("rank")
+                title = finding.get("title_ko") or "run"
+                lines.append(
+                    f"  - {finding.get('severity')}:{finding.get('code')} rank={rank} title={title} — {finding.get('reason')}"
+                )
     lines.extend(["", "## 실시간 이슈 후보", ""])
     arrow = {"up": "▲", "down": "▼", "neutral": "◆"}
     for issue in payload["issues"]:
@@ -1673,6 +2069,7 @@ def render_markdown(payload: dict[str, Any]) -> str:
             [
                 f"- 출처/기사: raw {issue.get('raw_source_count', issue['source_count'])}개 → normalized {issue.get('normalized_source_count', issue['source_count'])}개 · {issue['article_count']}개 기사",
                 f"- 점수: {issue.get('score', 0):.4f} / components={issue.get('score_components', {})} / penalties={issue.get('score_penalties', {})}",
+                f"- 품질 플래그: {', '.join(issue.get('quality_flags') or []) or '-'}",
                 f"- 대표 출처: {', '.join(issue['representative_sources']) or '-'}",
                 f"- 시장: {', '.join(issue['markets'])}",
                 f"- 토픽: {', '.join(issue['topics']) or '-'}",
@@ -2116,10 +2513,18 @@ async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             / max(1, len(cluster["indices"]))
             < 0.5
         ]
-    issues = [
+    quality_top = int(getattr(args, "quality_top", 5))
+    pre_quality_issues = [
         summarize_cluster(cluster, articles, rank=i + 1, score_breakdown=breakdown)
-        for i, (cluster, breakdown) in enumerate(ranked_v2[: args.top])
+        for i, (cluster, breakdown) in enumerate(ranked_v2)
     ]
+    issues, suppressed_candidates = suppress_duplicate_top_issues(
+        pre_quality_issues,
+        top_n=quality_top,
+        requested_market=args.market,
+        config=QualityGateConfig(top_n=quality_top),
+    )
+    issues = issues[: args.top]
     # ROB-136: Korean LLM rendering pass
     llm_provider = make_llm_provider(args)
     issues, render_diag = render_top_issues(
@@ -2141,6 +2546,7 @@ async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             "window_hours": args.window_hours,
             "article_limit": args.limit,
             "top": args.top,
+            "quality_top": quality_top,
             "article_count": len(articles),
             "cluster_count": len(clusters),
             "cluster_count_before_merge": len(clusters_before_merge),
@@ -2170,6 +2576,7 @@ async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             "normalized": dict(normalized_source_counts),
         },
         "issues": issues,
+        "suppressed_candidates": suppressed_candidates,
         "merge_diagnostics": {
             "enabled": merge_diag.enabled,
             "merge_before_count": merge_diag.merge_before_count,
@@ -2197,6 +2604,9 @@ async def build_payload(args: argparse.Namespace) -> dict[str, Any]:
             ],
         },
     }
+    payload["quality_gate"] = evaluate_quality_gate(
+        payload, market=args.market, config=QualityGateConfig(top_n=quality_top)
+    )
     if getattr(args, "compare_v1", False):
         payload["v1_vs_v2"] = _comparison_payload(
             ranked_v1,

--- a/scripts/news_issue_lab_quality_eval.py
+++ b/scripts/news_issue_lab_quality_eval.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Read-only ROB-145 quality gate runner for news_issue_lab.
+
+This wrapper only calls the lab payload builder with --no-llm/--store disabled,
+then writes local JSON/markdown artifacts. It does not mutate DB rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from scripts import news_issue_lab as lab
+
+VALID_MARKETS = ("all", "kr", "us", "crypto")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="ROB-145 read-only news_issue_lab quality gate evaluator"
+    )
+    parser.add_argument("--markets", default="all,kr,us,crypto")
+    parser.add_argument("--window-hours", type=int, default=24)
+    parser.add_argument("--limit", type=int, default=240)
+    parser.add_argument("--top", type=int, default=12)
+    parser.add_argument("--quality-top", type=int, default=5)
+    parser.add_argument("--threshold", type=float, default=0.78)
+    parser.add_argument("--dedupe-threshold", type=float, default=0.90)
+    parser.add_argument("--embedding-endpoint", default=lab.DEFAULT_BGE_ENDPOINT)
+    parser.add_argument("--embedding-model", default=lab.DEFAULT_BGE_MODEL)
+    parser.add_argument("--batch-size", type=int, default=16)
+    parser.add_argument(
+        "--compare-v1", dest="compare_v1", action="store_true", default=True
+    )
+    parser.add_argument("--no-compare-v1", dest="compare_v1", action="store_false")
+    parser.add_argument(
+        "--merge-clusters", dest="merge_clusters", action="store_true", default=True
+    )
+    parser.add_argument(
+        "--no-merge-clusters", dest="merge_clusters", action="store_false"
+    )
+    parser.add_argument("--drop-regular-reports", action="store_true")
+    parser.add_argument("--output-dir", default=None)
+    parser.add_argument(
+        "--format", choices=["json", "markdown", "both"], default="both"
+    )
+    parser.add_argument("--fail-on-quality-fail", action="store_true")
+    args = parser.parse_args(argv)
+    markets = [m.strip() for m in args.markets.split(",") if m.strip()]
+    invalid = sorted(set(markets) - set(VALID_MARKETS))
+    if invalid:
+        parser.error(f"invalid markets: {', '.join(invalid)}")
+    if not markets:
+        parser.error("--markets must include at least one market")
+    for name in ("window_hours", "limit", "top", "quality_top", "batch_size"):
+        if getattr(args, name) <= 0:
+            parser.error(f"--{name.replace('_', '-')} must be positive")
+    args.markets = markets
+    return args
+
+
+def _lab_args(args: argparse.Namespace, market: str) -> argparse.Namespace:
+    return lab.parse_args(
+        [
+            "--market",
+            market,
+            "--window-hours",
+            str(args.window_hours),
+            "--limit",
+            str(args.limit),
+            "--top",
+            str(args.top),
+            "--quality-top",
+            str(args.quality_top),
+            "--threshold",
+            str(args.threshold),
+            "--dedupe-threshold",
+            str(args.dedupe_threshold),
+            "--embedding-endpoint",
+            args.embedding_endpoint,
+            "--embedding-model",
+            args.embedding_model,
+            "--batch-size",
+            str(args.batch_size),
+            "--no-llm",
+            *(["--compare-v1"] if args.compare_v1 else []),
+            *(["--merge-clusters"] if args.merge_clusters else ["--no-merge-clusters"]),
+            *(["--drop-regular-reports"] if args.drop_regular_reports else []),
+            "--format",
+            "json",
+        ]
+    )
+
+
+def _summary_markdown(summary: dict[str, Any]) -> str:
+    lines = [
+        "# ROB-145 news_issue_lab quality eval",
+        "",
+        f"- created_at: `{summary['created_at']}`",
+        f"- overall_status: `{summary['overall_status']}`",
+        f"- window: {summary['window_hours']}h / limit: {summary['limit']} / top: {summary['top']} / quality_top: {summary['quality_top']}",
+        "- safety: read-only lab run; LLM disabled; no --store used; no broker/order/watch/order-intent/scheduler/API/UI changes.",
+        "",
+        "| market | status | duplicate title | duplicate topic | single article | single source | mismatch | source noise | suppressed | json | markdown |",
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|",
+    ]
+    for market in summary["markets"]:
+        row = summary["results"][market]
+        metrics = row["metrics"]
+        lines.append(
+            "| {market} | `{status}` | {duplicate_title} | {duplicate_topic} | {single_article} | {single_source} | {mismatch} | {source_noise} | {suppressed} | `{json_path}` | `{markdown_path}` |".format(
+                market=market,
+                status=row["status"],
+                duplicate_title=metrics.get("duplicate_title_count_topn", 0),
+                duplicate_topic=metrics.get("duplicate_topic_count_topn", 0),
+                single_article=metrics.get("single_article_count_topn", 0),
+                single_source=metrics.get("single_source_count_topn", 0),
+                mismatch=metrics.get("market_mismatch_count_topn", 0),
+                source_noise=metrics.get("source_noise_count_topn", 0),
+                suppressed=metrics.get("suppressed_candidate_count", 0),
+                json_path=row.get("json_path") or "-",
+                markdown_path=row.get("markdown_path") or "-",
+            )
+        )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _worst_status(statuses: list[str]) -> str:
+    order = {"pass": 0, "warn": 1, "fail": 2}
+    return max(statuses, key=lambda s: order.get(s, 2)) if statuses else "fail"
+
+
+async def async_main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    created_at = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    output_dir = Path(
+        args.output_dir or f"/tmp/news_issue_lab_quality_eval_{created_at}"
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    summary: dict[str, Any] = {
+        "created_at": datetime.now(UTC).isoformat(),
+        "window_hours": args.window_hours,
+        "limit": args.limit,
+        "top": args.top,
+        "quality_top": args.quality_top,
+        "markets": args.markets,
+        "output_dir": str(output_dir),
+        "results": {},
+    }
+    statuses: list[str] = []
+    for market in args.markets:
+        payload = await lab.build_payload(_lab_args(args, market))
+        quality = payload.get("quality_gate") or {}
+        status = str(quality.get("status") or "fail")
+        statuses.append(status)
+        json_path = output_dir / f"{market}.json"
+        markdown_path = output_dir / f"{market}.md"
+        if args.format in {"json", "both"}:
+            json_path.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8"
+            )
+        if args.format in {"markdown", "both"}:
+            markdown_path.write_text(lab.render_markdown(payload), encoding="utf-8")
+        summary["results"][market] = {
+            "status": status,
+            "metrics": quality.get("metrics") or {},
+            "finding_count": len(quality.get("findings") or []),
+            "json_path": str(json_path) if args.format in {"json", "both"} else None,
+            "markdown_path": str(markdown_path)
+            if args.format in {"markdown", "both"}
+            else None,
+        }
+    summary["overall_status"] = _worst_status(statuses)
+    summary_json = output_dir / "summary.json"
+    summary_md = output_dir / "summary.md"
+    summary_json.write_text(
+        json.dumps(summary, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    summary_md.write_text(_summary_markdown(summary), encoding="utf-8")
+    print(summary_md)
+    if args.fail_on_quality_fail and summary["overall_status"] == "fail":
+        return 2
+    return 0
+
+
+def main() -> None:
+    try:
+        raise SystemExit(asyncio.run(async_main()))
+    except BrokenPipeError:
+        raise SystemExit(0)
+    except Exception as exc:  # pragma: no cover - operator-facing final guard
+        print(f"news_issue_lab_quality_eval failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/news_issue_lab_quality_eval.py
+++ b/scripts/news_issue_lab_quality_eval.py
@@ -33,6 +33,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--dedupe-threshold", type=float, default=0.90)
     parser.add_argument("--embedding-endpoint", default=lab.DEFAULT_BGE_ENDPOINT)
     parser.add_argument("--embedding-model", default=lab.DEFAULT_BGE_MODEL)
+    parser.add_argument(
+        "--embedding-api-key",
+        default=None,
+        help="optional bearer token forwarded to news_issue_lab; defaults there to EMBEDDING_API_KEY",
+    )
     parser.add_argument("--batch-size", type=int, default=16)
     parser.add_argument(
         "--compare-v1", dest="compare_v1", action="store_true", default=True
@@ -85,6 +90,11 @@ def _lab_args(args: argparse.Namespace, market: str) -> argparse.Namespace:
             args.embedding_endpoint,
             "--embedding-model",
             args.embedding_model,
+            *(
+                ["--embedding-api-key", args.embedding_api_key]
+                if args.embedding_api_key
+                else []
+            ),
             "--batch-size",
             str(args.batch_size),
             "--no-llm",

--- a/tests/test_news_issue_lab.py
+++ b/tests/test_news_issue_lab.py
@@ -1566,3 +1566,211 @@ def test_news_issue_lab_renderer_not_imported_by_app_modules() -> None:
         if any(token in text for token in forbidden):
             offenders.append(str(path.relative_to(app_root.parent)))
     assert offenders == []
+
+
+def _quality_issue(
+    title: str,
+    *,
+    rank: int = 1,
+    article_count: int = 2,
+    normalized_source_count: int = 2,
+    markets: list[str] | None = None,
+    topics: list[str] | None = None,
+    flags: dict[str, int] | None = None,
+    representative_articles: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    return {
+        "rank": rank,
+        "cluster_key": f"key-{rank}-{title}",
+        "title_ko": title,
+        "subtitle_ko": "테스트 부제",
+        "direction": "neutral",
+        "article_count": article_count,
+        "source_count": normalized_source_count,
+        "raw_source_count": normalized_source_count,
+        "normalized_source_count": normalized_source_count,
+        "score": 0.5,
+        "score_components": {},
+        "score_penalties": {},
+        "flags": flags or {},
+        "representative_sources": [f"source-{rank}"],
+        "source_counts": {"raw": {}, "normalized": {}},
+        "markets": markets or ["us"],
+        "related_symbols": [],
+        "topics": topics or [title],
+        "representative_articles": representative_articles or [],
+    }
+
+
+def test_evaluate_quality_gate_passes_clean_top5() -> None:
+    payload = {
+        "run": {"market": "us", "quality_top": 5, "llm_render": {"enabled": False}},
+        "issues": [
+            _quality_issue("반도체 슈퍼사이클", rank=1),
+            _quality_issue("미국 금리·연준", rank=2),
+            _quality_issue("전기차·배터리", rank=3),
+            _quality_issue("금·원자재", rank=4),
+            _quality_issue("M&A·사업재편", rank=5),
+        ],
+        "merge_diagnostics": {"decisions": [], "rejected_near_misses": 0},
+    }
+    gate = lab.evaluate_quality_gate(payload, market="us")
+    assert gate["status"] == "pass"
+    assert gate["metrics"]["duplicate_title_count_topn"] == 0
+
+
+def test_evaluate_quality_gate_flags_duplicate_single_source_and_single_article() -> (
+    None
+):
+    payload = {
+        "run": {"market": "us", "quality_top": 5, "llm_render": {"enabled": False}},
+        "issues": [
+            _quality_issue("AI 데이터센터", rank=1, normalized_source_count=1),
+            _quality_issue(
+                "AI 데이터센터", rank=2, article_count=1, normalized_source_count=1
+            ),
+        ],
+        "merge_diagnostics": {"decisions": [], "rejected_near_misses": 0},
+    }
+    gate = lab.evaluate_quality_gate(payload, market="us")
+    codes = {finding["code"] for finding in gate["findings"]}
+    assert gate["status"] == "fail"
+    assert "duplicate_title_topn" in codes
+    assert "single_article_topn" in codes
+    assert "single_source_topn" in codes
+
+
+def test_evaluate_quality_gate_flags_crypto_equity_pollution_and_llm_enabled() -> None:
+    payload = {
+        "run": {"market": "crypto", "quality_top": 5, "llm_render": {"enabled": True}},
+        "issues": [
+            _quality_issue(
+                "미국 증시 최고치",
+                rank=1,
+                markets=["crypto"],
+                topics=["미국 증시 최고치"],
+                representative_articles=[
+                    {"title": "Nasdaq and Wall Street stocks reach records"}
+                ],
+            )
+        ],
+        "merge_diagnostics": {"decisions": [], "rejected_near_misses": 0},
+    }
+    gate = lab.evaluate_quality_gate(payload, market="crypto")
+    codes = {finding["code"] for finding in gate["findings"]}
+    assert gate["status"] == "fail"
+    assert "crypto_equity_topic" in codes
+    assert "llm_enabled_for_eval" in codes
+
+
+def test_suppress_duplicate_top_issues_preserves_suppressed_candidates() -> None:
+    issues = [
+        _quality_issue("AI 데이터센터", rank=1),
+        _quality_issue("AI 데이터센터", rank=2),
+        _quality_issue("비트코인 강세", rank=3, article_count=1),
+        _quality_issue("미국 금리·연준", rank=4),
+    ]
+    selected, suppressed = lab.suppress_duplicate_top_issues(
+        issues, top_n=3, requested_market="us"
+    )
+    reasons = {item["suppression_reason"] for item in suppressed}
+    assert "duplicate_title_topn" in reasons
+    assert "single_article_topn" in reasons
+    assert selected[0]["title_ko"] == "AI 데이터센터"
+
+
+def test_render_markdown_includes_quality_gate_summary() -> None:
+    payload = {
+        "run": {
+            "run_uuid": "run-1",
+            "market": "all",
+            "window_hours": 24,
+            "article_count": 1,
+            "cluster_count": 1,
+            "embedding_model": "BAAI/bge-m3",
+            "embedding_dim": 1024,
+            "threshold": 0.78,
+        },
+        "quality_gate": {
+            "status": "fail",
+            "top_n": 5,
+            "metrics": {
+                "single_article_count_topn": 1,
+                "suppressed_candidate_count": 0,
+            },
+            "findings": [
+                {
+                    "severity": "fail",
+                    "code": "single_article_topn",
+                    "rank": 1,
+                    "title_ko": "테스트",
+                    "reason": "single",
+                }
+            ],
+        },
+        "issues": [_quality_issue("테스트", rank=1, article_count=1)],
+    }
+    rendered = lab.render_markdown(payload)
+    assert "품질 게이트 (ROB-145)" in rendered
+    assert "single_article_topn" in rendered
+
+
+def test_quality_eval_parse_defaults_disable_llm_and_store() -> None:
+    from scripts import news_issue_lab_quality_eval as quality_eval
+
+    args = quality_eval.parse_args([])
+    assert args.markets == ["all", "kr", "us", "crypto"]
+    lab_args = quality_eval._lab_args(args, "crypto")
+    assert lab_args.llm_render is False
+    assert lab_args.store is False
+    assert lab_args.compare_v1 is True
+    assert lab_args.quality_top == 5
+
+
+@pytest.mark.asyncio
+async def test_quality_eval_writes_summary_and_market_artifacts(
+    monkeypatch, tmp_path
+) -> None:
+    from scripts import news_issue_lab_quality_eval as quality_eval
+
+    async def fake_build_payload(args):
+        return {
+            "run": {
+                "run_uuid": f"run-{args.market}",
+                "market": args.market,
+                "window_hours": 24,
+                "article_count": 1,
+                "cluster_count": 1,
+                "embedding_model": "BAAI/bge-m3",
+                "embedding_dim": 1024,
+                "threshold": 0.78,
+            },
+            "quality_gate": {
+                "status": "pass",
+                "top_n": 5,
+                "metrics": {},
+                "findings": [],
+            },
+            "issues": [_quality_issue("테스트", rank=1)],
+        }
+
+    monkeypatch.setattr(quality_eval.lab, "build_payload", fake_build_payload)
+    code = await quality_eval.async_main(
+        ["--markets", "all,crypto", "--output-dir", str(tmp_path), "--format", "both"]
+    )
+    assert code == 0
+    assert (tmp_path / "all.json").exists()
+    assert (tmp_path / "crypto.md").exists()
+    summary = json.loads((tmp_path / "summary.json").read_text(encoding="utf-8"))
+    assert summary["overall_status"] == "pass"
+
+
+def test_news_issue_lab_quality_eval_not_imported_by_app_modules() -> None:
+    from pathlib import Path
+
+    forbidden = "news_issue_lab_quality_eval"
+    offenders = []
+    for path in Path("app").rglob("*.py"):
+        if forbidden in path.read_text(encoding="utf-8", errors="ignore"):
+            offenders.append(str(path))
+    assert offenders == []

--- a/tests/test_news_issue_lab.py
+++ b/tests/test_news_issue_lab.py
@@ -279,7 +279,7 @@ async def test_build_payload_compare_v1_json_block_and_drop_regular_reports(
     monkeypatch.setattr(
         lab,
         "embed_batch",
-        lambda endpoint, model, texts: [[1.0, 0.0] for _ in texts],
+        lambda endpoint, model, texts, **_kwargs: [[1.0, 0.0] for _ in texts],
     )
     args = Namespace(
         market="all",
@@ -772,7 +772,7 @@ async def test_build_payload_runs_merge_pass_and_emits_run_diag(monkeypatch) -> 
 
     call_count = {"i": 0}
 
-    def fake_embed(endpoint, model, texts):
+    def fake_embed(endpoint, model, texts, **_kwargs):
         call_count["i"] += 1
         if call_count["i"] == 1:
             return [[1.0, 0.0] if "반도체" in t else [0.0, 1.0] for t in texts]
@@ -821,7 +821,7 @@ async def test_build_payload_no_merge_flag_disables_merge(monkeypatch) -> None:
     monkeypatch.setattr(
         lab,
         "embed_batch",
-        lambda endpoint, model, texts: [[1.0, 0.0] for _ in texts],
+        lambda endpoint, model, texts, **_kwargs: [[1.0, 0.0] for _ in texts],
     )
 
     args = Namespace(
@@ -1072,6 +1072,51 @@ class _FakeHTTPResponse:
 
     def read(self, *_args, **_kwargs) -> bytes:
         return json.dumps(self._data).encode()
+
+
+def test_embed_batch_adds_optional_authorization_header(monkeypatch) -> None:
+    captured = {}
+
+    def fake_urlopen(req, timeout):
+        captured["url"] = req.full_url
+        captured["timeout"] = timeout
+        captured["headers"] = dict(req.header_items())
+        captured["body"] = json.loads(req.data.decode())
+        return _FakeHTTPResponse({"data": [{"index": 0, "embedding": [1.0, 2.0]}]})
+
+    monkeypatch.setattr(lab.request, "urlopen", fake_urlopen)
+
+    assert lab.embed_batch(
+        "http://127.0.0.1:8000/v1/embeddings",
+        "local-bge",
+        ["시장 뉴스"],
+        timeout=9,
+        api_key="placeholder-credential",
+    ) == [[1.0, 2.0]]
+    assert captured == {
+        "url": "http://127.0.0.1:8000/v1/embeddings",
+        "timeout": 9,
+        "headers": {
+            "Content-type": "application/json",
+            "Authorization": "Bearer placeholder-credential",
+        },
+        "body": {"model": "local-bge", "input": ["시장 뉴스"]},
+    }
+
+
+def test_embed_batch_omits_authorization_header_without_api_key(monkeypatch) -> None:
+    captured = {}
+
+    def fake_urlopen(req, timeout):
+        captured["headers"] = dict(req.header_items())
+        return _FakeHTTPResponse({"data": [{"index": 0, "embedding": [1.0]}]})
+
+    monkeypatch.setattr(lab.request, "urlopen", fake_urlopen)
+
+    assert lab.embed_batch(
+        "http://127.0.0.1:8000/v1/embeddings", "local-bge", ["뉴스"]
+    ) == [[1.0]]
+    assert "Authorization" not in captured["headers"]
 
 
 def test_null_llm_provider_raises_disabled_reason() -> None:
@@ -1354,7 +1399,9 @@ async def test_build_payload_no_llm_render_adds_fallback_render_metadata(
 
     monkeypatch.setattr(lab, "fetch_articles", fake_fetch_articles)
     monkeypatch.setattr(
-        lab, "embed_batch", lambda endpoint, model, texts: [[1.0, 0.0] for _ in texts]
+        lab,
+        "embed_batch",
+        lambda endpoint, model, texts, **_kwargs: [[1.0, 0.0] for _ in texts],
     )
     args = Namespace(
         market="all",
@@ -1404,7 +1451,9 @@ async def test_build_payload_llm_render_uses_mock_provider_and_reports_counts(
 
     monkeypatch.setattr(lab, "fetch_articles", fake_fetch_articles)
     monkeypatch.setattr(
-        lab, "embed_batch", lambda endpoint, model, texts: [[1.0, 0.0] for _ in texts]
+        lab,
+        "embed_batch",
+        lambda endpoint, model, texts, **_kwargs: [[1.0, 0.0] for _ in texts],
     )
     monkeypatch.setattr(lab, "make_llm_provider", lambda _args: provider)
     args = Namespace(
@@ -1725,6 +1774,11 @@ def test_quality_eval_parse_defaults_disable_llm_and_store() -> None:
     assert lab_args.store is False
     assert lab_args.compare_v1 is True
     assert lab_args.quality_top == 5
+    assert lab_args.embedding_api_key is None
+
+    api_args = quality_eval.parse_args(["--embedding-api-key", "local-test-key"])
+    api_lab_args = quality_eval._lab_args(api_args, "crypto")
+    assert api_lab_args.embedding_api_key == "local-test-key"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds a deterministic, lab-only quality gate eval CLI for `news_issue_lab` v2 across all/kr/us/crypto.
- Tunes top-N quality suppression/diagnostics for duplicate labels, source/feed noise, single-article clusters, and crypto/equity taxonomy bleed.
- Adds optional secured embedding endpoint support without printing credentials.

## Quality artifacts
- Plan: `/Users/mgh3326/work/auto_trader-worktrees/feature-ROB-145-news-issue-v2-quality-gate/.hermes/plans/2026-05-08_081347-rob-145-news-issue-v2-quality-gate.md`
- Baseline report: `/tmp/rob145-baseline/report.md`
- Baseline payloads: `/tmp/rob145-baseline/all.json`, `/tmp/rob145-baseline/kr.json`, `/tmp/rob145-baseline/us.json`, `/tmp/rob145-baseline/crypto.json`
- Baseline markdown: `/tmp/rob145-baseline/all.md`, `/tmp/rob145-baseline/kr.md`, `/tmp/rob145-baseline/us.md`, `/tmp/rob145-baseline/crypto.md`
- Reviewer evidence comment: Linear ROB-145 comment `2ae81866-1749-4b37-817b-9ba77dff3fd7`

## Test commands/results
- `uv run pytest tests/test_news_issue_lab.py` → 92 passed, 2 existing Pydantic deprecation warnings
- `uv run ruff check scripts/news_issue_lab.py scripts/news_issue_lab_quality_eval.py tests/test_news_issue_lab.py` → passed
- `uv run ruff format --check scripts/news_issue_lab.py scripts/news_issue_lab_quality_eval.py tests/test_news_issue_lab.py` → passed
- `git diff --check` → passed
- `git diff --check origin/main...HEAD` → passed
- `dummy-env --help` smoke for `scripts/news_issue_lab.py` and `scripts/news_issue_lab_quality_eval.py` → passed; embedding API key options visible without using real secrets

## Safety boundaries
Allowed:
- Read `news_articles`
- Call local BGE-M3 endpoint
- Run lab/eval scripts
- Write local markdown/json artifacts
- Edit lab/experimental scripts and tests

Prohibited and verified absent:
- Broker/order/watch/order-intent mutation
- Scheduler changes
- Destructive DB writes/updates/deletes/backfills
- Production API/UI promotion
- Credential/secret output
- Full article body redistribution
- Request-time LLM in product API

LLM rendering remains optional/default-off. The quality eval path stays deterministic and forces `--no-llm`/no store behavior.

## Promote/defer recommendation status
- Recommendation: defer production API/UI promotion until K5 MacBook read-only production quality smoke generates final all/kr/us/crypto artifacts and confirms the acceptance gates.
- This PR is lab/eval-only and does not include API/UI connection.
