### PR TITLE
feat(invest): link news cards to clustered issues (ROB-148)

### DIFF
--- a/app/schemas/invest_feed_news.py
+++ b/app/schemas/invest_feed_news.py
@@ -19,6 +19,9 @@ class NewsRelatedSymbol(BaseModel):
     symbol: str
     market: NewsMarket
     displayName: str
+    relation: RelationKind = "none"
+    matchReason: str | None = None
+    matchedTerm: str | None = None
 
 
 class FeedNewsItem(BaseModel):

--- a/app/services/invest_view_model/feed_news_service.py
+++ b/app/services/invest_view_model/feed_news_service.py
@@ -54,16 +54,18 @@ async def build_feed_news(
     if tab in ("kr", "us", "crypto"):
         market_filter = tab
 
-    # Hot issues for top tab.
-    issues = []
-    if tab in ("top", "hot"):
-        try:
-            issues_resp = await build_market_issues(
-                market="all", window_hours=24, limit=10
-            )
-            issues = issues_resp.items
-        except Exception:
-            issues = []
+    # Build market issues for the relevant window so each news item can be
+    # linked to its clustered issue (ROB-148). For market-scoped tabs we
+    # filter by that market; for other tabs we cluster across markets so
+    # items from any market can be linked.
+    issues_market = market_filter or "all"
+    try:
+        issues_resp = await build_market_issues(
+            market=issues_market, window_hours=24, limit=20
+        )
+        issues = issues_resp.items
+    except Exception:
+        issues = []
 
     # Base news query.
     stmt = select(NewsArticle).order_by(
@@ -101,6 +103,13 @@ async def build_feed_news(
         for art_id, summary in (await db.execute(a_stmt)).all():
             analysis_map[art_id] = summary
 
+    # ROB-148 — article_id → issue_id map for chip rendering.
+    issue_id_for_article: dict[int, str] = {}
+    for issue in issues:
+        for article in issue.articles:
+            # Keep the highest-ranked issue per article.
+            issue_id_for_article.setdefault(article.id, issue.id)
+
     items: list[FeedNewsItem] = []
     for row in rows:
         market_value = (row.market or "kr").lower()
@@ -129,6 +138,7 @@ async def build_feed_news(
                 publishedAt=row.article_published_at,
                 market=cast(NewsMarket, market_value),
                 relatedSymbols=related,
+                issueId=issue_id_for_article.get(row.id),
                 summarySnippet=analysis_map.get(row.id) or row.summary,
                 relation=relation,
                 url=row.url,

--- a/app/services/invest_view_model/feed_news_service.py
+++ b/app/services/invest_view_model/feed_news_service.py
@@ -20,6 +20,7 @@ from app.schemas.invest_feed_news import (
     NewsRelatedSymbol,
 )
 from app.services.invest_view_model.relation_resolver import RelationResolver
+from app.services.news_entity_matcher import match_symbols_for_article
 from app.services.news_issue_clustering_service import build_market_issues
 
 
@@ -40,6 +41,45 @@ def _decode_cursor(cursor: str | None) -> tuple[datetime | None, int | None]:
         return (datetime.fromisoformat(p) if p else None, payload.get("i"))
     except Exception:
         return None, None
+
+
+def _coerce_keywords(value: object) -> list[str]:
+    if not value:
+        return []
+    if isinstance(value, list | tuple | set):
+        return [str(item) for item in value if item]
+    if isinstance(value, str):
+        return [value]
+    return []
+
+
+def _add_related_symbol(
+    *,
+    related: list[NewsRelatedSymbol],
+    seen_related: set[tuple[str, str]],
+    resolver: RelationResolver,
+    symbol: str | None,
+    market: str,
+    display_name: str | None,
+    match_reason: str | None,
+    matched_term: str | None = None,
+) -> None:
+    if not symbol or market not in ("kr", "us", "crypto"):
+        return
+    key = (market, symbol)
+    if key in seen_related:
+        return
+    seen_related.add(key)
+    related.append(
+        NewsRelatedSymbol(
+            symbol=symbol,
+            market=cast(NewsMarket, market),
+            displayName=display_name or symbol,
+            relation=resolver.relation(market, symbol),
+            matchReason=match_reason,
+            matchedTerm=matched_term,
+        )
+    )
 
 
 async def build_feed_news(
@@ -115,20 +155,47 @@ async def build_feed_news(
         market_value = (row.market or "kr").lower()
         if market_value not in ("kr", "us", "crypto"):
             continue
+        market_typed = cast(NewsMarket, market_value)
         related: list[NewsRelatedSymbol] = []
+        seen_related: set[tuple[str, str]] = set()
+
         if row.stock_symbol:
-            related.append(
-                NewsRelatedSymbol(
-                    symbol=row.stock_symbol,
-                    market=cast(NewsMarket, market_value),
-                    displayName=row.stock_name or row.stock_symbol,
-                )
+            _add_related_symbol(
+                related=related,
+                seen_related=seen_related,
+                resolver=resolver,
+                symbol=row.stock_symbol,
+                market=market_value,
+                display_name=row.stock_name or row.stock_symbol,
+                match_reason="stock_symbol",
             )
-        relation = (
-            resolver.relation(market_value, row.stock_symbol)
-            if row.stock_symbol
-            else "none"
-        )
+        for match in match_symbols_for_article(
+            title=row.title,
+            summary=analysis_map.get(row.id) or row.summary,
+            keywords=_coerce_keywords(getattr(row, "keywords", None)),
+            market=market_value,
+        ):
+            _add_related_symbol(
+                related=related,
+                seen_related=seen_related,
+                resolver=resolver,
+                symbol=match.symbol,
+                market=match.market,
+                display_name=match.canonical_name,
+                match_reason=match.reason,
+                matched_term=match.matched_term,
+            )
+        related_relations = {symbol.relation for symbol in related}
+        if "both" in related_relations or (
+            "held" in related_relations and "watchlist" in related_relations
+        ):
+            relation = "both"
+        elif "held" in related_relations:
+            relation = "held"
+        elif "watchlist" in related_relations:
+            relation = "watchlist"
+        else:
+            relation = "none"
         items.append(
             FeedNewsItem(
                 id=row.id,
@@ -136,7 +203,7 @@ async def build_feed_news(
                 publisher=row.source,
                 feedSource=row.feed_source,
                 publishedAt=row.article_published_at,
-                market=cast(NewsMarket, market_value),
+                market=market_typed,
                 relatedSymbols=related,
                 issueId=issue_id_for_article.get(row.id),
                 summarySnippet=analysis_map.get(row.id) or row.summary,

--- a/docs/superpowers/plans/2026-05-08-rob-148-link-news-issues-to-cards.md
+++ b/docs/superpowers/plans/2026-05-08-rob-148-link-news-issues-to-cards.md
@@ -1,0 +1,486 @@
+# ROB-148 — Link News-Related Stock Issues to News Cards
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Populate `FeedNewsItem.issueId` on `/invest/api/feed/news` items by mapping each article to its clustered market issue, then render an issue chip (with title + direction + link to issue detail) on the desktop news cards.
+
+**Architecture:** In `feed_news_service.build_feed_news`, always build `MarketIssue`s for the relevant market window (currently only `top`/`hot` build them); compute an `article_id → issue_id` map from `MarketIssue.articles[*].id`; populate `FeedNewsItem.issueId` from the map; return the `MarketIssue[]` on every tab so the frontend can join client-side. The desktop news card renders an issue chip using that join.
+
+**Tech Stack:** Python 3.13 + Pydantic + SQLAlchemy async + FastAPI on the backend; React 18 + TypeScript + Vitest + Testing Library on the frontend.
+
+**Branch / Worktree:** Working directory `/Users/robin/.superset/worktrees/auto_trader/invest-feed-rob-146` on branch `invest-feed-rob-146` (already an isolated worktree).
+
+---
+
+## File Structure
+
+**Modify:**
+- `app/services/invest_view_model/feed_news_service.py` — add `_collect_issues_for_market` helper, build article→issue map, populate `issueId` on each item, and return `issues` for all tabs (not just `top`/`hot`).
+- `tests/test_invest_feed_news_router.py` — add coverage for `issueId` population and for issues being returned on non-top tabs.
+- `frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx` — render an issue chip (link to `/app/discover/issues/{issueId}`) when an item has `issueId` and a matching issue exists in `data.issues`.
+- `frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx` — assert chip renders + links to the issue detail page.
+
+**Already-correct (no edits required):**
+- `app/schemas/invest_feed_news.py` — `FeedNewsItem.issueId` field already exists; `FeedNewsResponse.issues` already exists.
+- `frontend/invest/src/types/feedNews.ts` — `issueId?: string | null` already declared; `issues: MarketIssue[]` already declared.
+
+---
+
+## Task 1: Backend — populate issueId and return issues for all tabs
+
+**Files:**
+- Modify: `app/services/invest_view_model/feed_news_service.py`
+
+- [ ] **Step 1.1: Update `build_feed_news` to always build market issues**
+
+  Replace the existing block
+
+  ```python
+      # Hot issues for top tab.
+      issues = []
+      if tab in ("top", "hot"):
+          try:
+              issues_resp = await build_market_issues(
+                  market="all", window_hours=24, limit=10
+              )
+              issues = issues_resp.items
+          except Exception:
+              issues = []
+  ```
+
+  with
+
+  ```python
+      # Build market issues for the relevant window so each news item can be
+      # linked to its clustered issue (ROB-148). For market-scoped tabs we
+      # filter by that market; for other tabs we cluster across markets so
+      # items from any market can be linked.
+      issues_market = market_filter or "all"
+      try:
+          issues_resp = await build_market_issues(
+              market=issues_market, window_hours=24, limit=20
+          )
+          issues = issues_resp.items
+      except Exception:
+          issues = []
+  ```
+
+- [ ] **Step 1.2: Build the article→issue map and populate `issueId`**
+
+  Insert the following block immediately after `analysis_map` is populated and before the `items: list[FeedNewsItem] = []` line:
+
+  ```python
+      # ROB-148 — article_id → issue_id map for chip rendering.
+      issue_id_for_article: dict[int, str] = {}
+      for issue in issues:
+          for article in issue.articles:
+              # Keep the highest-ranked issue per article.
+              issue_id_for_article.setdefault(article.id, issue.id)
+  ```
+
+  Then, in the `FeedNewsItem(...)` constructor inside the `for row in rows:` loop, add the `issueId` field:
+
+  ```python
+          items.append(
+              FeedNewsItem(
+                  id=row.id,
+                  title=row.title,
+                  publisher=row.source,
+                  feedSource=row.feed_source,
+                  publishedAt=row.article_published_at,
+                  market=cast(NewsMarket, market_value),
+                  relatedSymbols=related,
+                  issueId=issue_id_for_article.get(row.id),
+                  summarySnippet=analysis_map.get(row.id) or row.summary,
+                  relation=relation,
+                  url=row.url,
+              )
+          )
+  ```
+
+- [ ] **Step 1.3: Confirm `meta.warnings` still empty / unchanged**
+
+  No change. The `FeedNewsMeta(emptyReason=empty_reason)` call at the bottom remains as-is.
+
+---
+
+## Task 2: Backend tests
+
+**Files:**
+- Modify: `tests/test_invest_feed_news_router.py`
+
+- [ ] **Step 2.1: Add `_fake_issue` helper at top of test file (after `_fake_article`)**
+
+  Add the helper:
+
+  ```python
+  def _fake_issue(*, issue_id: str, article_ids: list[int], market: str = "kr") -> MagicMock:
+      issue = MagicMock()
+      issue.id = issue_id
+      issue.market = market
+      issue.articles = [MagicMock(id=aid) for aid in article_ids]
+      return issue
+  ```
+
+- [ ] **Step 2.2: Update `test_feed_news_top_tab` to assert `issueId` is populated when an issue covers the article**
+
+  Replace the existing `test_feed_news_top_tab` function body so that the mocked `build_market_issues` returns an issue covering article id `1`, and assert `resp.items[0].issueId == "iss-1"` and `resp.issues[0].id == "iss-1"`:
+
+  ```python
+  @pytest.mark.unit
+  @pytest.mark.asyncio
+  async def test_feed_news_top_tab(monkeypatch) -> None:
+      from app.services.invest_view_model import feed_news_service as svc
+
+      db = MagicMock()
+      scalar_result = MagicMock()
+      scalar_result.scalars.return_value.all.return_value = [
+          _fake_article(id=1, market="kr"),
+      ]
+      summary_result = MagicMock()
+      summary_result.all.return_value = []
+      db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+
+      issue = _fake_issue(issue_id="iss-1", article_ids=[1], market="kr")
+      monkeypatch.setattr(
+          svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[issue]))
+      )
+
+      resolver = RelationResolver()
+      resp = await svc.build_feed_news(
+          db=db, resolver=resolver, tab="top", limit=30, cursor=None
+      )
+      assert resp.tab == "top"
+      assert len(resp.items) == 1
+      assert resp.items[0].id == 1
+      assert resp.items[0].issueId == "iss-1"
+      assert resp.items[0].relation == "none"
+      assert [i.id for i in resp.issues] == ["iss-1"]
+  ```
+
+- [ ] **Step 2.3: Add a new test asserting `issueId` is also populated on the `latest` tab**
+
+  Add at the bottom of the file:
+
+  ```python
+  @pytest.mark.unit
+  @pytest.mark.asyncio
+  async def test_feed_news_latest_tab_links_issue(monkeypatch) -> None:
+      from app.services.invest_view_model import feed_news_service as svc
+
+      db = MagicMock()
+      scalar_result = MagicMock()
+      scalar_result.scalars.return_value.all.return_value = [
+          _fake_article(id=42, market="us", symbol="AAPL", name="Apple"),
+      ]
+      summary_result = MagicMock()
+      summary_result.all.return_value = []
+      db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+
+      issue = _fake_issue(issue_id="iss-42", article_ids=[42], market="us")
+      monkeypatch.setattr(
+          svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[issue]))
+      )
+
+      resolver = RelationResolver()
+      resp = await svc.build_feed_news(
+          db=db, resolver=resolver, tab="latest", limit=30, cursor=None
+      )
+      assert resp.items[0].issueId == "iss-42"
+      assert [i.id for i in resp.issues] == ["iss-42"]
+  ```
+
+- [ ] **Step 2.4: Add a test asserting `issueId` is `None` when no issue covers the article**
+
+  Add at the bottom of the file:
+
+  ```python
+  @pytest.mark.unit
+  @pytest.mark.asyncio
+  async def test_feed_news_no_issue_means_none(monkeypatch) -> None:
+      from app.services.invest_view_model import feed_news_service as svc
+
+      db = MagicMock()
+      scalar_result = MagicMock()
+      scalar_result.scalars.return_value.all.return_value = [
+          _fake_article(id=99, market="kr"),
+      ]
+      summary_result = MagicMock()
+      summary_result.all.return_value = []
+      db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+
+      monkeypatch.setattr(
+          svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
+      )
+
+      resolver = RelationResolver()
+      resp = await svc.build_feed_news(
+          db=db, resolver=resolver, tab="top", limit=30, cursor=None
+      )
+      assert resp.items[0].issueId is None
+  ```
+
+- [ ] **Step 2.5: Run backend tests**
+
+  ```bash
+  uv run pytest tests/test_invest_feed_news_router.py -v
+  ```
+
+  Expected: all tests in this file pass (the existing 3 + 2 new = 5 total, with the existing `test_feed_news_holdings_empty_when_no_holdings` and `test_feed_news_assigns_held_relation` still passing).
+
+  If any unrelated test in the same file fails because `build_market_issues` is no longer guarded by `tab in ("top", "hot")`, patch `svc.build_market_issues` with `AsyncMock(return_value=MagicMock(items=[]))` in those tests too. (`test_feed_news_holdings_empty_when_no_holdings` and `test_feed_news_assigns_held_relation` already do, but verify.)
+
+---
+
+## Task 3: Frontend — render issue chip on news cards
+
+**Files:**
+- Modify: `frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx`
+
+- [ ] **Step 3.1: Add `Link` import**
+
+  At the top of the file, add:
+
+  ```tsx
+  import { Link } from "react-router-dom";
+  ```
+
+- [ ] **Step 3.2: Build an issue lookup map and render chip when item has a matching issue**
+
+  Inside the component, just before the `return` statement, add:
+
+  ```tsx
+    const issueById = new Map((data?.issues ?? []).map((i) => [i.id, i] as const));
+  ```
+
+  Then, inside the `(data?.items ?? []).map((it) => { ... })` block, replace the inner `<div style={{ fontSize: 11, color: "#9ba0ab", marginTop: 4 }}>` line with an expanded version that also renders the issue chip:
+
+  ```tsx
+                    <div style={{ fontSize: 11, color: "#9ba0ab", marginTop: 4 }}>
+                      {it.publisher ?? "—"} · {it.market.toUpperCase()}
+                      {it.relation !== "none" && <span style={{ marginLeft: 8 }}>[{it.relation}]</span>}
+                    </div>
+                    {it.issueId && issueById.get(it.issueId) && (
+                      <Link
+                        to={`/app/discover/issues/${it.issueId}`}
+                        data-testid="feed-item-issue-chip"
+                        data-issue-id={it.issueId}
+                        onClick={(e) => e.stopPropagation()}
+                        style={{
+                          marginTop: 6,
+                          display: "inline-flex",
+                          alignItems: "center",
+                          gap: 6,
+                          padding: "2px 8px",
+                          borderRadius: 999,
+                          background: "var(--surface-2, #1c1e24)",
+                          color: "#cfd2da",
+                          fontSize: 11,
+                          textDecoration: "none",
+                          maxWidth: "100%",
+                        }}
+                      >
+                        <span aria-hidden style={{ fontSize: 9 }}>●</span>
+                        <span
+                          style={{
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                          }}
+                        >
+                          이슈 · {issueById.get(it.issueId)!.issue_title}
+                        </span>
+                      </Link>
+                    )}
+  ```
+
+  Note: the chip must be rendered **outside** the existing `<button>` element (which is the title click area) — place it directly inside the `<li>`, after the `<button>`, but before the `{open && it.summarySnippet && ...}` summary expansion. This avoids nesting an interactive `<Link>` inside a `<button>` (invalid HTML).
+
+  Concretely the resulting `<li>` body should look like:
+
+  ```tsx
+                <li ...>
+                  <button ...>
+                    {/* title + meta */}
+                  </button>
+                  {it.issueId && issueById.get(it.issueId) && (
+                    <Link ... />
+                  )}
+                  {open && it.summarySnippet && (
+                    <div ... />
+                  )}
+                </li>
+  ```
+
+---
+
+## Task 4: Frontend tests
+
+**Files:**
+- Modify: `frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx`
+
+- [ ] **Step 4.1: Update the mocked `fetchFeedNews` response to include an issue and link the item to it**
+
+  Replace the `vi.spyOn(feedApi, "fetchFeedNews")...` block in `beforeEach` with:
+
+  ```tsx
+    vi.spyOn(feedApi, "fetchFeedNews").mockResolvedValue({
+      tab: "top",
+      asOf: new Date().toISOString(),
+      issues: [
+        {
+          id: "iss-xyz",
+          market: "kr",
+          rank: 1,
+          issue_title: "삼성전자 실적 발표",
+          subtitle: null,
+          direction: "up",
+          source_count: 3,
+          article_count: 2,
+          updated_at: new Date().toISOString(),
+          summary: null,
+          related_symbols: [],
+          related_sectors: [],
+          articles: [
+            {
+              id: 1,
+              title: "n1",
+              url: "x",
+              source: "Reuters",
+              feed_source: null,
+              published_at: null,
+              summary: null,
+              matched_terms: [],
+            },
+          ],
+          signals: { recency_score: 1, source_diversity_score: 1, mention_score: 1 },
+        },
+      ],
+      items: [
+        {
+          id: 1,
+          title: "n1",
+          market: "kr",
+          relatedSymbols: [],
+          relation: "none",
+          url: "x",
+          publisher: "Reuters",
+          issueId: "iss-xyz",
+        },
+      ],
+      meta: { warnings: [] },
+    });
+  ```
+
+- [ ] **Step 4.2: Add a test asserting the issue chip renders with the expected title and link**
+
+  Add to the test file, after the existing `test("renders news items and reacts to tab change", ...)` block:
+
+  ```tsx
+  test("renders an issue chip linked to the issue detail page when issueId is present", async () => {
+    render(
+      <MemoryRouter basename="/invest" initialEntries={["/invest/feed/news"]}>
+        <DesktopFeedNewsPage />
+      </MemoryRouter>,
+    );
+    const chip = await screen.findByTestId("feed-item-issue-chip");
+    expect(chip).toHaveTextContent("삼성전자 실적 발표");
+    expect(chip).toHaveAttribute("href", "/invest/app/discover/issues/iss-xyz");
+    expect(chip).toHaveAttribute("data-issue-id", "iss-xyz");
+  });
+  ```
+
+- [ ] **Step 4.3: Run the frontend tests**
+
+  ```bash
+  cd frontend/invest && npm test -- --run DesktopFeedNewsPage.test.tsx
+  ```
+
+  Expected: both tests pass.
+
+---
+
+## Task 5: Verification, lint, format, commit
+
+- [ ] **Step 5.1: Run all relevant Python tests**
+
+  ```bash
+  uv run pytest tests/test_invest_feed_news_router.py tests/test_invest_view_model_safety.py -v
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 5.2: Run backend lint + format**
+
+  ```bash
+  make lint
+  make format
+  ```
+
+  Expected: no errors.
+
+- [ ] **Step 5.3: Run all frontend invest tests**
+
+  ```bash
+  cd frontend/invest && npm test -- --run
+  ```
+
+  Expected: all pass.
+
+- [ ] **Step 5.4: Commit**
+
+  ```bash
+  git add app/services/invest_view_model/feed_news_service.py \
+          tests/test_invest_feed_news_router.py \
+          frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx \
+          frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx \
+          docs/superpowers/plans/2026-05-08-rob-148-link-news-issues-to-cards.md
+  git commit -m "$(cat <<'EOF'
+  feat(invest): link news cards to clustered issues (ROB-148)
+
+  - feed_news_service builds market issues for every tab and maps
+    article_id -> issue_id so FeedNewsItem.issueId is populated
+  - DesktopFeedNewsPage renders an issue chip per news card linking
+    to /app/discover/issues/:issueId
+
+  Read-only path; no broker / order / watch mutations.
+
+  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+  EOF
+  )"
+  ```
+
+- [ ] **Step 5.5: Push and open PR**
+
+  ```bash
+  git push -u origin invest-feed-rob-146
+  gh pr create --base main --title "feat(invest): link news cards to clustered issues (ROB-148)" --body "$(cat <<'EOF'
+  ## Summary
+  - Populate `FeedNewsItem.issueId` on `/invest/api/feed/news` by joining each article into the clustered `MarketIssue.articles` from `build_market_issues`.
+  - Return the `issues` array on every tab (not just `top`/`hot`) so the desktop feed can render a chip per news card.
+  - Render an issue chip on each desktop news card linking to `/app/discover/issues/:issueId`.
+
+  Closes ROB-148.
+
+  ## Test plan
+  - [x] `uv run pytest tests/test_invest_feed_news_router.py -v`
+  - [x] `cd frontend/invest && npm test -- --run DesktopFeedNewsPage.test.tsx`
+  - [x] `make lint`
+
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+  EOF
+  )"
+  ```
+
+  Expected: PR URL printed; capture for the final report.
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage: every news card now exposes the linked issue both in API (`issueId`) and UI (chip). ✓
+- Placeholder scan: every step has concrete code/commands; no TBDs. ✓
+- Type consistency: `issueId` field name used in backend Pydantic model, frontend type, and chip rendering matches. `MarketIssue.id` (string) is the join key. ✓
+- Existing test `test_feed_news_holdings_empty_when_no_holdings` already passes `MagicMock(items=[])` for `build_market_issues`, so it remains compatible after Task 1.1's removal of the `tab in ("top", "hot")` guard. ✓
+- The chip is rendered **outside** the title `<button>` to avoid nesting interactive elements (HTML validity / a11y). ✓
+- Read-only invariant from project CLAUDE.md preserved: only view-model service + frontend changes; no broker / order / watch mutations. ✓

--- a/frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx
@@ -13,9 +13,50 @@ beforeEach(() => {
     meta: { warnings: [], watchlistAvailable: true },
   });
   vi.spyOn(feedApi, "fetchFeedNews").mockResolvedValue({
-    tab: "top", asOf: new Date().toISOString(), issues: [], items: [
-      { id: 1, title: "n1", market: "kr", relatedSymbols: [], relation: "none", url: "x", publisher: "Reuters" },
-    ], meta: { warnings: [] },
+    tab: "top",
+    asOf: new Date().toISOString(),
+    issues: [
+      {
+        id: "iss-xyz",
+        market: "kr",
+        rank: 1,
+        issue_title: "삼성전자 실적 발표",
+        subtitle: null,
+        direction: "up",
+        source_count: 3,
+        article_count: 2,
+        updated_at: new Date().toISOString(),
+        summary: null,
+        related_symbols: [],
+        related_sectors: [],
+        articles: [
+          {
+            id: 1,
+            title: "n1",
+            url: "x",
+            source: "Reuters",
+            feed_source: null,
+            published_at: null,
+            summary: null,
+            matched_terms: [],
+          },
+        ],
+        signals: { recency_score: 1, source_diversity_score: 1, mention_score: 1 },
+      },
+    ],
+    items: [
+      {
+        id: 1,
+        title: "n1",
+        market: "kr",
+        relatedSymbols: [],
+        relation: "none",
+        url: "x",
+        publisher: "Reuters",
+        issueId: "iss-xyz",
+      },
+    ],
+    meta: { warnings: [] },
   });
 });
 
@@ -28,4 +69,16 @@ test("renders news items and reacts to tab change", async () => {
   await waitFor(() => expect(screen.getAllByTestId("feed-item")).toHaveLength(1));
   await userEvent.click(screen.getByTestId("tab-latest"));
   await waitFor(() => expect(feedApi.fetchFeedNews).toHaveBeenCalledTimes(2));
+});
+
+test("renders an issue chip linked to the issue detail page when issueId is present", async () => {
+  render(
+    <MemoryRouter basename="/invest" initialEntries={["/invest/feed/news"]}>
+      <DesktopFeedNewsPage />
+    </MemoryRouter>,
+  );
+  const chip = await screen.findByTestId("feed-item-issue-chip");
+  expect(chip).toHaveTextContent("삼성전자 실적 발표");
+  expect(chip).toHaveAttribute("href", "/invest/app/discover/issues/iss-xyz");
+  expect(chip).toHaveAttribute("data-issue-id", "iss-xyz");
 });

--- a/frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx
@@ -49,8 +49,17 @@ beforeEach(() => {
         id: 1,
         title: "n1",
         market: "kr",
-        relatedSymbols: [],
-        relation: "none",
+        relatedSymbols: [
+          {
+            symbol: "005930",
+            market: "kr",
+            displayName: "삼성전자",
+            relation: "watchlist",
+            matchReason: "alias_dict",
+            matchedTerm: "삼성전자",
+          },
+        ],
+        relation: "watchlist",
         url: "x",
         publisher: "Reuters",
         issueId: "iss-xyz",
@@ -81,4 +90,20 @@ test("renders an issue chip linked to the issue detail page when issueId is pres
   expect(chip).toHaveTextContent("삼성전자 실적 발표");
   expect(chip).toHaveAttribute("href", "/invest/app/discover/issues/iss-xyz");
   expect(chip).toHaveAttribute("data-issue-id", "iss-xyz");
+});
+
+
+test("renders related symbol chips as read-only badges", async () => {
+  render(
+    <MemoryRouter basename="/invest" initialEntries={["/invest/feed/news"]}>
+      <DesktopFeedNewsPage />
+    </MemoryRouter>,
+  );
+  const chip = await screen.findByTestId("feed-item-related-symbol-chip");
+  expect(chip).toHaveTextContent("005930");
+  expect(chip).toHaveTextContent("삼성전자");
+  expect(chip).toHaveAttribute("data-symbol", "005930");
+  expect(chip).toHaveAttribute("data-market", "kr");
+  expect(chip).toHaveAttribute("data-relation", "watchlist");
+  expect(chip.tagName.toLowerCase()).toBe("span");
 });

--- a/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { RightAccountPanel } from "../../desktop/RightAccountPanel";
 import { useAccountPanel } from "../../desktop/useAccountPanel";
@@ -26,6 +27,8 @@ export function DesktopFeedNewsPage() {
       .catch((e) => !cancel && setErr(String(e?.message ?? e)));
     return () => { cancel = true; };
   }, [tab]);
+
+  const issueById = new Map((data?.issues ?? []).map((i) => [i.id, i] as const));
 
   return (
     <DesktopShell
@@ -59,6 +62,7 @@ export function DesktopFeedNewsPage() {
           <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 8 }}>
             {(data?.items ?? []).map((it) => {
               const open = selectedId === it.id;
+              const linkedIssue = it.issueId ? issueById.get(it.issueId) : undefined;
               return (
                 <li
                   key={it.id}
@@ -76,6 +80,39 @@ export function DesktopFeedNewsPage() {
                       {it.relation !== "none" && <span style={{ marginLeft: 8 }}>[{it.relation}]</span>}
                     </div>
                   </button>
+                  {linkedIssue && (
+                    <Link
+                      to={`/app/discover/issues/${linkedIssue.id}`}
+                      data-testid="feed-item-issue-chip"
+                      data-issue-id={linkedIssue.id}
+                      aria-label={`이슈 링크: ${linkedIssue.issue_title}`}
+                      onClick={(e) => e.stopPropagation()}
+                      style={{
+                        marginTop: 6,
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 6,
+                        padding: "2px 8px",
+                        borderRadius: 999,
+                        background: "var(--surface-2, #1c1e24)",
+                        color: "#cfd2da",
+                        fontSize: 11,
+                        textDecoration: "none",
+                        maxWidth: "100%",
+                      }}
+                    >
+                      <span aria-hidden style={{ fontSize: 9 }}>●</span>
+                      <span
+                        style={{
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        이슈 · {linkedIssue.issue_title}
+                      </span>
+                    </Link>
+                  )}
                   {open && it.summarySnippet && (
                     <div style={{ marginTop: 8, fontSize: 13, color: "#cfd2da" }}>{it.summarySnippet}</div>
                   )}

--- a/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
@@ -113,6 +113,41 @@ export function DesktopFeedNewsPage() {
                       </span>
                     </Link>
                   )}
+                  {it.relatedSymbols.length > 0 && (
+                    <div
+                      data-testid="feed-item-related-symbols"
+                      style={{ marginTop: 6, display: "flex", flexWrap: "wrap", gap: 6 }}
+                    >
+                      {it.relatedSymbols.map((symbol) => (
+                        <span
+                          key={`${symbol.market}:${symbol.symbol}`}
+                          data-testid="feed-item-related-symbol-chip"
+                          data-symbol={symbol.symbol}
+                          data-market={symbol.market}
+                          data-relation={symbol.relation ?? "none"}
+                          title={
+                            symbol.matchedTerm
+                              ? `${symbol.matchReason ?? "matched"}: ${symbol.matchedTerm}`
+                              : undefined
+                          }
+                          style={{
+                            display: "inline-flex",
+                            alignItems: "center",
+                            gap: 4,
+                            padding: "2px 7px",
+                            borderRadius: 999,
+                            border: "1px solid var(--surface-2, #2a2d35)",
+                            color: "#b8beca",
+                            fontSize: 11,
+                          }}
+                        >
+                          <strong style={{ color: "#e8eaf0", fontWeight: 700 }}>{symbol.symbol}</strong>
+                          <span>{symbol.displayName}</span>
+                          {symbol.relation && symbol.relation !== "none" && <span>[{symbol.relation}]</span>}
+                        </span>
+                      ))}
+                    </div>
+                  )}
                   {open && it.summarySnippet && (
                     <div style={{ marginTop: 8, fontSize: 13, color: "#cfd2da" }}>{it.summarySnippet}</div>
                   )}

--- a/frontend/invest/src/types/feedNews.ts
+++ b/frontend/invest/src/types/feedNews.ts
@@ -7,6 +7,9 @@ export interface FeedRelatedSymbol {
   symbol: string;
   market: "kr" | "us" | "crypto";
   displayName: string;
+  relation?: RelationKind;
+  matchReason?: string | null;
+  matchedTerm?: string | null;
 }
 
 export interface FeedNewsItem {

--- a/tests/test_invest_feed_news_router.py
+++ b/tests/test_invest_feed_news_router.py
@@ -7,7 +7,15 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from app.schemas.news_issues import (
+    IssueSignals,
+    MarketIssue,
+    MarketIssueArticle,
+    MarketIssueMarket,
+)
 from app.services.invest_view_model.relation_resolver import RelationResolver
+
+_NOW = datetime(2026, 5, 1, tzinfo=UTC)
 
 
 def _fake_article(
@@ -24,12 +32,45 @@ def _fake_article(
     a.title = f"news {id}"
     a.source = "Reuters"
     a.feed_source = "rss_test"
-    a.article_published_at = published_at or datetime(2026, 5, 1, tzinfo=UTC)
+    a.article_published_at = published_at or _NOW
     a.stock_symbol = symbol
     a.stock_name = name
     a.summary = "snippet"
     a.url = f"https://example.com/{id}"
     return a
+
+
+def _fake_issue(
+    *, issue_id: str, article_ids: list[int], market: MarketIssueMarket = "kr"
+) -> MarketIssue:
+    articles = [
+        MarketIssueArticle(
+            id=aid,
+            title=f"article {aid}",
+            url=f"https://example.com/{aid}",
+            source="Reuters",
+            feed_source="rss_test",
+            published_at=_NOW,
+        )
+        for aid in article_ids
+    ]
+    return MarketIssue(
+        id=issue_id,
+        market=market,
+        rank=1,
+        issue_title=f"Issue {issue_id}",
+        subtitle=None,
+        direction="neutral",
+        source_count=1,
+        article_count=len(article_ids),
+        updated_at=_NOW,
+        articles=articles,
+        signals=IssueSignals(
+            recency_score=0.5,
+            source_diversity_score=0.5,
+            mention_score=0.5,
+        ),
+    )
 
 
 @pytest.mark.unit
@@ -46,8 +87,9 @@ async def test_feed_news_top_tab(monkeypatch) -> None:
     summary_result.all.return_value = []
     db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
 
+    issue = _fake_issue(issue_id="iss-1", article_ids=[1], market="kr")
     monkeypatch.setattr(
-        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
+        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[issue]))
     )
 
     resolver = RelationResolver()
@@ -57,7 +99,9 @@ async def test_feed_news_top_tab(monkeypatch) -> None:
     assert resp.tab == "top"
     assert len(resp.items) == 1
     assert resp.items[0].id == 1
+    assert resp.items[0].issueId == "iss-1"
     assert resp.items[0].relation == "none"
+    assert [i.id for i in resp.issues] == ["iss-1"]
 
 
 @pytest.mark.unit
@@ -71,6 +115,9 @@ async def test_feed_news_holdings_empty_when_no_holdings(monkeypatch) -> None:
     summary_result = MagicMock()
     summary_result.all.return_value = []
     db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
+    )
 
     resolver = RelationResolver()
     resp = await svc.build_feed_news(
@@ -101,3 +148,55 @@ async def test_feed_news_assigns_held_relation(monkeypatch) -> None:
         db=db, resolver=resolver, tab="holdings", limit=30, cursor=None
     )
     assert resp.items[0].relation == "held"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_feed_news_latest_tab_links_issue(monkeypatch) -> None:
+    from app.services.invest_view_model import feed_news_service as svc
+
+    db = MagicMock()
+    scalar_result = MagicMock()
+    scalar_result.scalars.return_value.all.return_value = [
+        _fake_article(id=42, market="us", symbol="AAPL", name="Apple"),
+    ]
+    summary_result = MagicMock()
+    summary_result.all.return_value = []
+    db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+
+    issue = _fake_issue(issue_id="iss-42", article_ids=[42], market="us")
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[issue]))
+    )
+
+    resolver = RelationResolver()
+    resp = await svc.build_feed_news(
+        db=db, resolver=resolver, tab="latest", limit=30, cursor=None
+    )
+    assert resp.items[0].issueId == "iss-42"
+    assert [i.id for i in resp.issues] == ["iss-42"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_feed_news_no_issue_means_none(monkeypatch) -> None:
+    from app.services.invest_view_model import feed_news_service as svc
+
+    db = MagicMock()
+    scalar_result = MagicMock()
+    scalar_result.scalars.return_value.all.return_value = [
+        _fake_article(id=99, market="kr"),
+    ]
+    summary_result = MagicMock()
+    summary_result.all.return_value = []
+    db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
+    )
+
+    resolver = RelationResolver()
+    resp = await svc.build_feed_news(
+        db=db, resolver=resolver, tab="top", limit=30, cursor=None
+    )
+    assert resp.items[0].issueId is None

--- a/tests/test_invest_feed_news_router.py
+++ b/tests/test_invest_feed_news_router.py
@@ -25,17 +25,21 @@ def _fake_article(
     symbol: str | None = None,
     name: str | None = None,
     published_at: datetime | None = None,
+    title: str | None = None,
+    summary: str | None = None,
+    keywords: list[str] | None = None,
 ) -> MagicMock:
     a = MagicMock()
     a.id = id
     a.market = market
-    a.title = f"news {id}"
+    a.title = title or f"news {id}"
     a.source = "Reuters"
     a.feed_source = "rss_test"
     a.article_published_at = published_at or _NOW
     a.stock_symbol = symbol
     a.stock_name = name
-    a.summary = "snippet"
+    a.summary = summary or "snippet"
+    a.keywords = keywords
     a.url = f"https://example.com/{id}"
     return a
 
@@ -148,6 +152,83 @@ async def test_feed_news_assigns_held_relation(monkeypatch) -> None:
         db=db, resolver=resolver, tab="holdings", limit=30, cursor=None
     )
     assert resp.items[0].relation == "held"
+    assert resp.items[0].relatedSymbols[0].relation == "held"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_feed_news_matches_related_symbols_from_article_alias(
+    monkeypatch,
+) -> None:
+    from app.services.invest_view_model import feed_news_service as svc
+
+    db = MagicMock()
+    scalar_result = MagicMock()
+    scalar_result.scalars.return_value.all.return_value = [
+        _fake_article(
+            id=20,
+            market="kr",
+            symbol=None,
+            name=None,
+            title="삼성전자 반도체 실적 기대감 확대",
+            keywords=["반도체", "삼전"],
+        ),
+    ]
+    summary_result = MagicMock()
+    summary_result.all.return_value = []
+    db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
+    )
+
+    resolver = RelationResolver(watch={("kr", "005930")})
+    resp = await svc.build_feed_news(
+        db=db, resolver=resolver, tab="latest", limit=30, cursor=None
+    )
+
+    assert resp.items[0].relation == "watchlist"
+    assert [(s.market, s.symbol) for s in resp.items[0].relatedSymbols] == [
+        ("kr", "005930")
+    ]
+    assert resp.items[0].relatedSymbols[0].displayName == "삼성전자"
+    assert resp.items[0].relatedSymbols[0].relation == "watchlist"
+    assert resp.items[0].relatedSymbols[0].matchReason == "alias_dict"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_feed_news_dedupes_stock_symbol_and_alias_match(monkeypatch) -> None:
+    from app.services.invest_view_model import feed_news_service as svc
+
+    db = MagicMock()
+    scalar_result = MagicMock()
+    scalar_result.scalars.return_value.all.return_value = [
+        _fake_article(
+            id=21,
+            market="us",
+            symbol="AAPL",
+            name="Apple Inc.",
+            title="Apple shares rise after iPhone update",
+        ),
+    ]
+    summary_result = MagicMock()
+    summary_result.all.return_value = []
+    db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
+    )
+
+    resolver = RelationResolver(held={("us", "AAPL")})
+    resp = await svc.build_feed_news(
+        db=db, resolver=resolver, tab="latest", limit=30, cursor=None
+    )
+
+    assert resp.items[0].relation == "held"
+    assert [(s.market, s.symbol) for s in resp.items[0].relatedSymbols] == [
+        ("us", "AAPL")
+    ]
+    assert resp.items[0].relatedSymbols[0].displayName == "Apple Inc."
+    assert resp.items[0].relatedSymbols[0].matchReason == "stock_symbol"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Populate `FeedNewsItem.issueId` on `/invest/api/feed/news` by joining each article into the clustered `MarketIssue.articles` returned from `build_market_issues`.
- Return the `issues` array on every tab so the desktop feed can render an issue chip per news card.
- Populate `relatedSymbols` with existing `stock_symbol` fallback plus ROB-146 deterministic `match_symbols_for_article()` alias/name/ticker matching over title/summary/keywords.
- Render read-only related-symbol chips on each desktop news card, including held/watchlist relation metadata without any broker/order/watch mutation path.

Closes ROB-148.

Plan: `docs/superpowers/plans/2026-05-08-rob-148-link-news-issues-to-cards.md`.

Read-only path: no broker / order / watch mutations.

## Test plan
- [x] `uv run ruff check app/services/invest_view_model/feed_news_service.py app/schemas/invest_feed_news.py tests/test_invest_feed_news_router.py`
- [x] `uv run ruff format --check app/services/invest_view_model/feed_news_service.py app/schemas/invest_feed_news.py tests/test_invest_feed_news_router.py`
- [x] `uv run pytest --no-cov -q tests/test_invest_feed_news_router.py`
- [x] `uv run pytest --no-cov -q tests/test_invest_feed_news_router.py tests/test_news_issue_clustering.py tests/test_router_news_issues.py tests/test_invest_view_model_safety.py`
- [x] `uv run bandit -q -r app/services/invest_view_model/feed_news_service.py`
- [x] `cd frontend/invest && npm run typecheck`
- [x] `cd frontend/invest && npm test -- DesktopFeedNewsPage.test.tsx`
- [x] `cd frontend/invest && npm test -- --run`
- [x] `cd frontend/invest && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * News items now display issue chips linked to market issue details pages.
  * Related symbols are enriched with match metadata (reason, matched term) and relationship context.
  * News feed items are automatically associated with relevant market issues for the selected time window.

* **Tests**
  * Added comprehensive test coverage for issue linking, symbol matching, and relation behavior in the feed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->