### PR TITLE
fix(news): tighten ROB-146 lab quality tuning

### DIFF
--- a/scripts/news_issue_lab.py
+++ b/scripts/news_issue_lab.py
@@ -299,6 +299,13 @@ REGULAR_REPORT_TERMS: tuple[str, ...] = (
     "morning letter",
     "daily",
     "weekly",
+    "macro snapshot",
+    "econ check-up",
+    "fx check-up",
+    "economy monitor",
+    "eps live",
+    "review",
+    "실적 정리",
     "데일리",
     "장마감코멘트",
     "모닝코멘트",
@@ -1434,6 +1441,9 @@ def _quality_finding(
                 "normalized_source_count": issue.get("normalized_source_count"),
                 "markets": issue.get("markets"),
                 "topics": issue.get("topics"),
+                "pre_suppression_rank": issue.get("pre_suppression_rank"),
+                "display_suppressed_reason": issue.get("display_suppressed_reason")
+                or issue.get("suppression_reason"),
             }
         )
     return payload
@@ -1453,8 +1463,12 @@ def suppress_duplicate_top_issues(
     seen_titles: set[str] = set()
     seen_topics: set[str] = set()
     target_len = len(issues)
-    for issue in issues:
+    for fallback_rank, issue in enumerate(issues, start=1):
         clone = dict(issue)
+        clone.setdefault(
+            "pre_suppression_rank",
+            int(clone.get("rank") or fallback_rank),
+        )
         title_key = normalize_text(str(clone.get("title_ko") or "")).lower()
         topic_key = title_key
         if clone.get("topics"):
@@ -1476,6 +1490,7 @@ def suppress_duplicate_top_issues(
         if reason:
             clone["display_suppressed"] = True
             clone["suppression_reason"] = reason
+            clone["display_suppressed_reason"] = reason
             flags = list(clone.get("quality_flags") or [])
             if reason not in flags:
                 flags.append(reason)
@@ -1640,15 +1655,50 @@ def evaluate_quality_gate(
                 "deterministic quality gate must keep LLM rendering disabled",
             )
         )
+    suppressed_warning_count = 0
+    suppressed_audit_count = 0
+    blocking_suppression_reasons = {
+        "duplicate_title_topn",
+        "duplicate_topic_topn",
+        "single_article_topn",
+        "market_mismatch",
+        "crypto_equity_topic",
+    }
     for suppressed in payload.get("suppressed_candidates") or []:
+        pre_rank = int(
+            suppressed.get("pre_suppression_rank")
+            or suppressed.get("rank")
+            or config.top_n + 1
+        )
+        suppression_reason = str(
+            suppressed.get("suppression_reason") or "suppressed_candidate"
+        )
+        severity = (
+            "warn"
+            if pre_rank <= config.top_n
+            and suppression_reason in blocking_suppression_reasons
+            else "info"
+        )
+        if severity == "warn":
+            suppressed_warning_count += 1
+            reason = "candidate originally inside quality top-N was suppressed"
+        else:
+            suppressed_audit_count += 1
+            reason = (
+                "quality candidate suppressed from visible top-N but preserved for audit"
+                if pre_rank <= config.top_n
+                else "deep candidate suppressed from visible top-N but preserved for audit"
+            )
         findings.append(
             _quality_finding(
-                str(suppressed.get("suppression_reason") or "suppressed_candidate"),
-                "warn",
+                suppression_reason,
+                severity,
                 suppressed,
-                "candidate suppressed from visible top-N but preserved for audit",
+                reason,
             )
         )
+    metrics["suppressed_warning_count"] = suppressed_warning_count
+    metrics["suppressed_audit_count"] = suppressed_audit_count
     fail_codes = {
         "duplicate_title_topn",
         "duplicate_topic_topn",
@@ -1661,7 +1711,7 @@ def evaluate_quality_gate(
     status = "pass"
     if any(f["severity"] == "fail" and f["code"] in fail_codes for f in findings):
         status = "fail"
-    elif findings:
+    elif any(f["severity"] == "warn" for f in findings):
         status = "warn"
     return {
         "status": status,
@@ -1799,7 +1849,6 @@ def score_cluster(
     noise_penalty = 0.10 * min(4, yahoo_noise_count)
     if yahoo_noise_count and market_signal_count:
         noise_penalty *= 0.25
-    regular_report_penalty = 0.15 * min(3, regular_report_count)
     duplicate_source_penalty = (
         max(
             0.0,
@@ -1807,13 +1856,38 @@ def score_cluster(
         )
         * 0.30
     )
-    single_source_penalty = 0.14 if normalized_source_count == 1 else 0.0
+    regular_report_penalty = 0.15 * min(3, regular_report_count)
+    mixed_regular_report_penalty = 0.0
+    if regular_report_count and regular_report_count < len(rows):
+        # Mixed report/news clusters are diagnostically useful, but should not
+        # outrank cleaner market issues just because research-category source
+        # families add recency and volume. Keep the base regular_report key
+        # capped for compatibility and expose the extra demotion separately.
+        mixed_regular_report_penalty = 0.10
+        if normalized_source_count >= 2:
+            mixed_regular_report_penalty += 0.10
+        if duplicate_source_penalty:
+            mixed_regular_report_penalty += 0.12
+        if regular_report_count >= 2:
+            mixed_regular_report_penalty += 0.08
+    single_source_penalty = 0.0
+    weak_single_source_penalty = 0.0
+    if normalized_source_count == 1:
+        single_source_penalty = 0.14
+        if len(rows) <= 2:
+            single_source_penalty += 0.08
+            weak_single_source_penalty += 0.10
+        if topic_relevance < 1.0:
+            single_source_penalty += 0.06
+            weak_single_source_penalty += 0.08
     weak_single_article_penalty = 0.28 if len(rows) == 1 else 0.0
     penalties = {
         "noise": min(0.40, noise_penalty),
         "regular_report": min(0.45, regular_report_penalty),
+        "mixed_regular_report": min(0.30, mixed_regular_report_penalty),
         "duplicate_source": min(0.30, duplicate_source_penalty),
-        "single_source": single_source_penalty,
+        "single_source": min(0.28, single_source_penalty),
+        "weak_single_source": min(0.18, weak_single_source_penalty),
         "weak_single_article": weak_single_article_penalty,
     }
     components = {
@@ -2035,7 +2109,7 @@ def render_markdown(payload: dict[str, Any]) -> str:
                 f"- status: `{quality_gate.get('status', '-')}` / top_n: {quality_gate.get('top_n', '-')}",
                 f"- duplicate_title={metrics.get('duplicate_title_count_topn', 0)}, duplicate_topic={metrics.get('duplicate_topic_count_topn', 0)}, single_article={metrics.get('single_article_count_topn', 0)}, single_source={metrics.get('single_source_count_topn', 0)}",
                 f"- market_mismatch={metrics.get('market_mismatch_count_topn', 0)}, source_noise={metrics.get('source_noise_count_topn', 0)}, crypto_equity_topic={metrics.get('crypto_equity_topic_count_topn', 0)}, regular_report={metrics.get('regular_report_leakage_count_topn', 0)}",
-                f"- merge_decisions={metrics.get('merge_decision_count', 0)}, near_misses={metrics.get('merge_rejected_near_misses', 0)}, suppressed={metrics.get('suppressed_candidate_count', 0)}, llm_render_enabled={metrics.get('llm_render_enabled', False)}",
+                f"- merge_decisions={metrics.get('merge_decision_count', 0)}, near_misses={metrics.get('merge_rejected_near_misses', 0)}, suppressed_warn={metrics.get('suppressed_warning_count', 0)}, suppressed_audit={metrics.get('suppressed_audit_count', 0)}, llm_render_enabled={metrics.get('llm_render_enabled', False)}",
             ]
         )
         findings = quality_gate.get("findings") or []

--- a/scripts/news_issue_lab_quality_eval.py
+++ b/scripts/news_issue_lab_quality_eval.py
@@ -116,14 +116,14 @@ def _summary_markdown(summary: dict[str, Any]) -> str:
         f"- window: {summary['window_hours']}h / limit: {summary['limit']} / top: {summary['top']} / quality_top: {summary['quality_top']}",
         "- safety: read-only lab run; LLM disabled; no --store used; no broker/order/watch/order-intent/scheduler/API/UI changes.",
         "",
-        "| market | status | duplicate title | duplicate topic | single article | single source | mismatch | source noise | suppressed | json | markdown |",
-        "|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|",
+        "| market | status | duplicate title | duplicate topic | single article | single source | mismatch | source noise | suppressed warn | suppressed audit | json | markdown |",
+        "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---|---|",
     ]
     for market in summary["markets"]:
         row = summary["results"][market]
         metrics = row["metrics"]
         lines.append(
-            "| {market} | `{status}` | {duplicate_title} | {duplicate_topic} | {single_article} | {single_source} | {mismatch} | {source_noise} | {suppressed} | `{json_path}` | `{markdown_path}` |".format(
+            "| {market} | `{status}` | {duplicate_title} | {duplicate_topic} | {single_article} | {single_source} | {mismatch} | {source_noise} | {suppressed_warn} | {suppressed_audit} | `{json_path}` | `{markdown_path}` |".format(
                 market=market,
                 status=row["status"],
                 duplicate_title=metrics.get("duplicate_title_count_topn", 0),
@@ -132,7 +132,8 @@ def _summary_markdown(summary: dict[str, Any]) -> str:
                 single_source=metrics.get("single_source_count_topn", 0),
                 mismatch=metrics.get("market_mismatch_count_topn", 0),
                 source_noise=metrics.get("source_noise_count_topn", 0),
-                suppressed=metrics.get("suppressed_candidate_count", 0),
+                suppressed_warn=metrics.get("suppressed_warning_count", 0),
+                suppressed_audit=metrics.get("suppressed_audit_count", 0),
                 json_path=row.get("json_path") or "-",
                 markdown_path=row.get("markdown_path") or "-",
             )

--- a/tests/test_news_issue_lab.py
+++ b/tests/test_news_issue_lab.py
@@ -69,6 +69,9 @@ def test_article_normalized_source_key_uses_source_key_fallback() -> None:
     [
         (_article(title="[데일리 마감] 코스피 약보합"), True, False, False),
         (_article(title="Morning Letter: futures higher"), True, False, False),
+        (_article(title="Macro Snapshot: rates and FX Check-up"), True, False, False),
+        (_article(title="EPS LIVE Review: 실적 정리"), True, False, True),
+        (_article(title="Economy Monitor Focus on Week"), True, False, False),
         (
             _article(
                 title="Best travel credit cards for 2026",
@@ -124,6 +127,47 @@ def test_score_cluster_caps_regular_report_penalty() -> None:
     score = lab.score_cluster(_cluster(*range(5)), articles, window_hours=24)
     assert score.penalties["regular_report"] == pytest.approx(0.45)
     assert score.flags["regular_report"] == 5
+
+
+def test_score_cluster_penalizes_mixed_duplicate_regular_report_cluster() -> None:
+    articles = [
+        _article(
+            1, title="Weekly AI data center update", source="browser_naver_research"
+        ),
+        _article(
+            2, title="AI data center stocks rally", source="browser_naver_mainnews"
+        ),
+        _article(
+            3,
+            title="AI data center industry investment",
+            source="browser_naver_research_industry",
+        ),
+    ]
+    score = lab.score_cluster(_cluster(0, 1, 2), articles, window_hours=24)
+    assert score.penalties["duplicate_source"] > 0
+    assert score.penalties["regular_report"] == pytest.approx(0.15)
+    assert score.penalties["mixed_regular_report"] == pytest.approx(0.30)
+
+
+def test_score_cluster_adds_weak_single_source_penalty_only_for_weak_evidence() -> None:
+    weak_articles = [
+        _article(
+            1, title="코스피 전에 대만 주식 알았어야", source="browser_naver_mainnews"
+        ),
+        _article(
+            2, title="대만 수익률 415 한국 코스피", source="browser_naver_mainnews"
+        ),
+    ]
+    strong_articles = [
+        _article(i, title=f"Nasdaq stocks rally on AI earnings {i}", source="reuters")
+        for i in range(1, 5)
+    ]
+    weak = lab.score_cluster(_cluster(0, 1), weak_articles, window_hours=24)
+    strong = lab.score_cluster(_cluster(*range(4)), strong_articles, window_hours=24)
+    assert weak.penalties["single_source"] == pytest.approx(0.28)
+    assert weak.penalties["weak_single_source"] == pytest.approx(0.18)
+    assert strong.penalties["single_source"] == pytest.approx(0.14)
+    assert strong.penalties["weak_single_source"] == pytest.approx(0.0)
 
 
 def test_score_cluster_gives_market_signal_topic_relevance() -> None:
@@ -1726,6 +1770,56 @@ def test_suppress_duplicate_top_issues_preserves_suppressed_candidates() -> None
     assert "duplicate_title_topn" in reasons
     assert "single_article_topn" in reasons
     assert selected[0]["title_ko"] == "AI 데이터센터"
+    assert {item["pre_suppression_rank"] for item in suppressed} == {2, 3}
+
+
+def test_evaluate_quality_gate_deescalates_deep_suppressed_candidate_to_info() -> None:
+    suppressed = _quality_issue("반도체 슈퍼사이클", rank=168, markets=["kr"])
+    suppressed.update(
+        {
+            "display_suppressed": True,
+            "suppression_reason": "duplicate_title_topn",
+            "pre_suppression_rank": 168,
+        }
+    )
+    payload = {
+        "run": {"market": "kr", "quality_top": 5, "llm_render": {"enabled": False}},
+        "issues": [
+            _quality_issue("반도체 슈퍼사이클", rank=1, markets=["kr"]),
+            _quality_issue("미국 증시 최고치", rank=2, markets=["kr"]),
+        ],
+        "suppressed_candidates": [suppressed],
+        "merge_diagnostics": {"decisions": [], "rejected_near_misses": 0},
+    }
+    gate = lab.evaluate_quality_gate(payload, market="kr")
+    finding = gate["findings"][0]
+    assert gate["status"] == "pass"
+    assert finding["severity"] == "info"
+    assert finding["pre_suppression_rank"] == 168
+    assert gate["metrics"]["suppressed_candidate_count"] == 1
+    assert gate["metrics"]["suppressed_audit_count"] == 1
+
+
+def test_evaluate_quality_gate_warns_for_original_topn_suppressed_candidate() -> None:
+    suppressed = _quality_issue("AI 데이터센터", rank=2)
+    suppressed.update(
+        {
+            "display_suppressed": True,
+            "suppression_reason": "duplicate_title_topn",
+            "pre_suppression_rank": 2,
+        }
+    )
+    payload = {
+        "run": {"market": "us", "quality_top": 5, "llm_render": {"enabled": False}},
+        "issues": [_quality_issue("AI 데이터센터", rank=1)],
+        "suppressed_candidates": [suppressed],
+        "merge_diagnostics": {"decisions": [], "rejected_near_misses": 0},
+    }
+    gate = lab.evaluate_quality_gate(payload, market="us")
+    finding = gate["findings"][0]
+    assert gate["status"] == "warn"
+    assert finding["severity"] == "warn"
+    assert gate["metrics"]["suppressed_warning_count"] == 1
 
 
 def test_render_markdown_includes_quality_gate_summary() -> None:
@@ -1745,7 +1839,8 @@ def test_render_markdown_includes_quality_gate_summary() -> None:
             "top_n": 5,
             "metrics": {
                 "single_article_count_topn": 1,
-                "suppressed_candidate_count": 0,
+                "suppressed_warning_count": 0,
+                "suppressed_audit_count": 1,
             },
             "findings": [
                 {
@@ -1762,6 +1857,8 @@ def test_render_markdown_includes_quality_gate_summary() -> None:
     rendered = lab.render_markdown(payload)
     assert "품질 게이트 (ROB-145)" in rendered
     assert "single_article_topn" in rendered
+    assert "suppressed_warn=0" in rendered
+    assert "suppressed_audit=1" in rendered
 
 
 def test_quality_eval_parse_defaults_disable_llm_and_store() -> None:


### PR DESCRIPTION
## Summary
- Tightens `scripts/news_issue_lab.py` lab-only quality scoring for mixed regular-report clusters and weak single-source clusters.
- Preserves pre-suppression ranks and splits suppressed duplicate candidates into warning vs audit semantics so deep audit-only duplicates do not block promotion status.
- Updates `scripts/news_issue_lab_quality_eval.py` summary output and adds focused tests in `tests/test_news_issue_lab.py`.

## Linear / scope
- Linear issue: ROB-146 — news_issue_lab v2: KR quality blocker tuning after ROB-145.
- Base: PR #720 merge commit `d0881d16c1dd71f60911d57b776249ce7441a396`.
- Head: `4dc3f3c5965de7d5e5b0008e2b961fbd8672c021`.

## Artifacts and prior findings
- ROB-145 baseline artifacts:
  - `/tmp/rob145-prod-smoke-20260508T001420Z/summary.md`
  - `/tmp/rob145-prod-smoke-20260508T001420Z/summary.json`
  - `/tmp/rob145-prod-smoke-20260508T001420Z/final_recommendation.md`
  - `/tmp/rob145-prod-smoke-20260508T001420Z/final_recommendation.json`
- ROB-146 K1 read-only baseline artifacts:
  - `/tmp/rob146-baseline-20260508T015924Z/kr.json`
  - `/tmp/rob146-baseline-20260508T015924Z/kr.md`
  - `/tmp/rob146-baseline-20260508T015924Z/all.json`
  - `/tmp/rob146-baseline-20260508T015924Z/all.md`
  - `/tmp/rob146-baseline-20260508T015924Z/rob146_diagnostic_report.md`
  - `/tmp/rob146-baseline-20260508T015924Z/rob146_diagnostic_report.json`
  - `/tmp/rob146-baseline-regression-20260508T020945Z/us.json`
  - `/tmp/rob146-baseline-regression-20260508T020945Z/us.md`
  - `/tmp/rob146-baseline-regression-20260508T020945Z/crypto.json`
  - `/tmp/rob146-baseline-regression-20260508T020945Z/crypto.md`
- K2 partial smoke artifacts:
  - `/tmp/rob146-quality-smoke-20260508T024627Z`
  - `/tmp/rob146-quality-smoke-kr-20260508T030420Z`
- Reviewer artifacts:
  - `/tmp/rob146-review-diff.patch`
  - `/tmp/rob146_opus_review_prompt.md`

## Verification
- `uv run --group test pytest tests/test_news_issue_lab.py -q` → 99 passed, 2 warnings.
- `uv run ruff check scripts/news_issue_lab.py scripts/news_issue_lab_quality_eval.py tests/test_news_issue_lab.py` → passed.
- `uv run ruff format --check scripts/news_issue_lab.py scripts/news_issue_lab_quality_eval.py tests/test_news_issue_lab.py` → passed.
- `git diff --check d0881d16c1dd71f60911d57b776249ce7441a396...HEAD` → passed.
- Focused safety scan by K3 reviewer found no prohibited-scope hits in changed-file added lines.

## Safety boundaries
Allowed scope was limited to news reads, local BGE-M3/lab eval paths, local markdown/json artifacts, lab/experimental scripts, and tests.

No changes were made to:
- broker/order/watch/order-intent/trading mutation paths
- scheduler behavior
- destructive DB writes/updates/deletes/backfills
- production API/UI routing or promotion
- credential/secret printing
- request-time LLM product API behavior
- full article body redistribution

## Promotion / defer recommendation
Code safety and deterministic lab behavior passed K3 review. Production API/UI promotion should still be deferred until a fresh longer all/KR/US/crypto read-only quality smoke completes and artifacts are inspected, because K2's best partial smoke timed out and still reported `kr=warn`/`us=warn` before the full regression could complete.

## CI notes
Required GitHub CI should be treated as merge-blocking. SonarCloud/codecov project results are advisory unless branch protection marks them required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for cluster scoring penalties and quality-gate suppression evaluation with pre-suppression rank validation

* **Refactor**
  * Enhanced suppression diagnostics with richer metrics tracking (pre-suppression ranking and categorized alert levels)
  * Refined scoring penalty logic for improved handling of duplicate and single-source candidates
  * Improved quality metrics reporting with separated suppression warning and audit counts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->