### PR TITLE
fix(invest): normalize screener row mapping

### DIFF
--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -27,6 +27,9 @@ from app.services.invest_view_model.screener_presets import (
     screening_filters_for,
 )
 
+_VALID_MARKETS = {"kr", "us", "crypto"}
+_KR_ABSURD_MARKET_CAP_KRW = 10_000_000_000_000_000
+
 
 class _ScreeningServiceProto(Protocol):
     async def list_screening(self, /, **kwargs: Any) -> dict[str, Any]: ...
@@ -84,6 +87,90 @@ def _format_market_cap_kr(market_cap: float | None) -> str:
     return f"{eok:,.0f}억원"
 
 
+def _clean_text(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _normalize_market(raw: Any) -> str:
+    market = _clean_text(raw).lower()
+    return market if market in _VALID_MARKETS else "kr"
+
+
+def _normalize_symbol(row: dict[str, Any], market: str) -> tuple[str, list[str]]:
+    symbol = ""
+    for key in ("symbol", "code", "short_code", "ticker"):
+        symbol = _clean_text(row.get(key))
+        if symbol:
+            break
+
+    if not symbol:
+        return "", ["종목코드 데이터 준비중"]
+
+    if market == "kr":
+        _, sep, suffix = symbol.rpartition(":")
+        if sep and suffix.isdigit() and len(suffix) == 6:
+            symbol = suffix
+        return symbol, []
+
+    return symbol.upper(), []
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        cleaned = value.strip().replace(",", "")
+        if not cleaned:
+            return None
+        try:
+            return float(cleaned)
+        except ValueError:
+            return None
+    return None
+
+
+def _market_cap_from_market_cap_field(value: float | None, market: str) -> float | None:
+    if value is None or value <= 0:
+        return None
+    if value >= 1_000_000_000_000:
+        return value
+    if market == "kr":
+        return value * 100_000_000
+    return None
+
+
+def _normalize_market_cap_krw(
+    row: dict[str, Any], market: str
+) -> tuple[float | None, list[str]]:
+    """Return display-safe KRW market cap plus row warnings.
+
+    Upstream screener rows can mix `market_cap_krw` (already KRW) with
+    source-dependent `market_cap` units. Values above 10,000조 KRW are
+    implausible for a single screener row, so prefer a plausible fallback or
+    hide the label instead of rendering absurd values such as 414,671.4조원.
+    """
+    market_cap_krw = _coerce_float(row.get("market_cap_krw"))
+    market_cap = _coerce_float(row.get("market_cap"))
+    fallback = _market_cap_from_market_cap_field(market_cap, market)
+
+    if market_cap_krw is not None and market_cap_krw > 0:
+        if market_cap_krw <= _KR_ABSURD_MARKET_CAP_KRW:
+            return market_cap_krw, []
+        if fallback is not None and fallback <= _KR_ABSURD_MARKET_CAP_KRW:
+            return fallback, ["시가총액 단위 보정됨"]
+        return None, ["시가총액 데이터 확인 필요"]
+
+    if fallback is not None and fallback <= _KR_ABSURD_MARKET_CAP_KRW:
+        return fallback, []
+    if fallback is not None:
+        return None, ["시가총액 데이터 확인 필요"]
+    return None, []
+
+
 def _format_volume(volume: float | None) -> str:
     if volume is None:
         return "-"
@@ -133,20 +220,20 @@ async def build_screener_results(
 
     results: list[ScreenerResultRow] = []
     for idx, row in enumerate(rows, start=1):
-        symbol = str(row.get("symbol") or "")
-        market = str(row.get("market") or "kr").lower()
-        if market not in ("kr", "us", "crypto"):
-            market = "kr"
+        market = _normalize_market(row.get("market"))
+        symbol, symbol_warnings = _normalize_symbol(row, market)
+        market_cap, market_cap_warnings = _normalize_market_cap_krw(row, market)
         change_pct_label, direction = _format_change_pct(row.get("change_rate"))
         metric_label, metric_warnings = _metric_value_label(preset_id, row)
         relation = resolver.relation(market, symbol)
         is_watched = relation in ("watchlist", "both")
+        row_warnings = symbol_warnings + market_cap_warnings + metric_warnings
         results.append(
             ScreenerResultRow(
                 rank=idx,
                 symbol=symbol,
                 market=market,  # type: ignore[arg-type]
-                name=str(row.get("name") or symbol),
+                name=_clean_text(row.get("name")) or symbol,
                 logoUrl=row.get("logo_url"),
                 isWatched=is_watched,
                 priceLabel=_format_price(row.get("close") or row.get("price")),
@@ -154,13 +241,11 @@ async def build_screener_results(
                 changeAmountLabel=_format_change_amount(row.get("change_amount")),
                 changeDirection=direction,
                 category=str(row.get("sector") or row.get("category") or "-"),
-                marketCapLabel=_format_market_cap_kr(
-                    row.get("market_cap_krw") or row.get("market_cap")
-                ),
+                marketCapLabel=_format_market_cap_kr(market_cap),
                 volumeLabel=_format_volume(row.get("volume")),
                 analystLabel=str(row.get("analyst_label") or "-"),
                 metricValueLabel=metric_label,
-                warnings=metric_warnings,
+                warnings=row_warnings,
             )
         )
 

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -136,10 +136,15 @@ def _coerce_float(value: Any) -> float | None:
 def _market_cap_from_market_cap_field(value: float | None, market: str) -> float | None:
     if value is None or value <= 0:
         return None
+    if market == "kr":
+        # KR upstream rows can contain either KRW (TradingView-style) or 억원
+        # (KRX-style). A KRW market cap under 1조 is still plausible, so don't
+        # require a 1조 threshold before treating the value as already-KRW.
+        if value >= 100_000_000:
+            return value
+        return value * 100_000_000
     if value >= 1_000_000_000_000:
         return value
-    if market == "kr":
-        return value * 100_000_000
     return None
 
 

--- a/tests/test_invest_api_screener_router.py
+++ b/tests/test_invest_api_screener_router.py
@@ -99,6 +99,34 @@ def test_screener_results_endpoint_happy_path() -> None:
 
 
 @pytest.mark.unit
+def test_screener_results_endpoint_normalizes_code_only_row() -> None:
+    stub = _StubScreening(
+        payload={
+            "results": [
+                {
+                    "code": "005930",
+                    "name": "삼성전자",
+                    "market": "kr",
+                    "sector": "반도체",
+                    "market_cap_krw": 478_000_000_000_000,
+                    "close": 80_000,
+                    "change_rate": 1.23,
+                    "change_amount": 970,
+                    "volume": 12_345_678,
+                }
+            ],
+            "warnings": [],
+        }
+    )
+    client = TestClient(_build_app(stub_screening=stub))
+    r = client.get("/invest/api/screener/results?preset=consecutive_gainers")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["results"][0]["symbol"] == "005930"
+    assert body["results"][0]["marketCapLabel"] == "478.0조원"
+
+
+@pytest.mark.unit
 def test_screener_results_endpoint_unknown_preset_returns_empty_with_warning() -> None:
     stub = _StubScreening()
     client = TestClient(_build_app(stub_screening=stub))

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -277,6 +277,38 @@ async def test_build_screener_results_uses_market_cap_fallback_when_krw_is_absur
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_build_screener_results_uses_sub_1t_krw_market_cap_fallback() -> None:
+    """Over-scaled KRW rows should not hide plausible sub-1조 KRW fallback values."""
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "123456",
+                    "market": "kr",
+                    "market_cap_krw": 80_000_000_000_000_000_000,
+                    "market_cap": 800_000_000_000,
+                    "change_rate": 1.23,
+                    "volume": 12_345_678,
+                }
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched=set())
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    assert resp.results[0].marketCapLabel == "8,000억원"
+    assert "시가총액 단위 보정됨" in resp.results[0].warnings
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_build_screener_results_dashes_absurd_market_cap_without_fallback() -> (
     None
 ):

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -52,8 +52,10 @@ def _stub_screening_rows() -> list[dict[str, Any]]:
 class _FakeResolver:
     def __init__(self, watched: set[tuple[str, str]]) -> None:
         self._w = watched
+        self.calls: list[tuple[str, str]] = []
 
     def relation(self, market: str, symbol: str) -> str:
+        self.calls.append((market, symbol))
         return "watchlist" if (market, symbol) in self._w else "none"
 
 
@@ -170,3 +172,177 @@ async def test_build_screener_results_screening_warnings_propagate() -> None:
 
     assert "KIS quote service degraded" in resp.warnings
     assert resp.results == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_uses_code_when_symbol_missing() -> None:
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "code": "005930",
+                    "name": "삼성전자",
+                    "market": "kr",
+                    "sector": "반도체",
+                    "market_cap_krw": 478_000_000_000_000,
+                    "close": 80_000,
+                    "change_rate": 1.23,
+                    "change_amount": 970,
+                    "volume": 12_345_678,
+                }
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched={("kr", "005930")})
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    assert resp.results[0].symbol == "005930"
+    assert resp.results[0].name == "삼성전자"
+    assert resp.results[0].marketCapLabel == "478.0조원"
+    assert resp.results[0].isWatched is True
+    assert resolver.calls == [("kr", "005930")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_normalizes_kr_exchange_prefixed_symbol() -> None:
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "KRX:005930",
+                    "market": "kr",
+                    "market_cap_krw": 478_000_000_000_000,
+                    "change_rate": 1.23,
+                    "volume": 12_345_678,
+                }
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched=set())
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    assert resp.results[0].symbol == "005930"
+    assert resp.results[0].name == "005930"
+    assert resolver.calls == [("kr", "005930")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_uses_market_cap_fallback_when_krw_is_absurd() -> (
+    None
+):
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "005930",
+                    "market": "kr",
+                    "market_cap_krw": 414_671_400_000_000_000,
+                    "market_cap": 4_146_714,
+                    "change_rate": 1.23,
+                    "volume": 12_345_678,
+                }
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched=set())
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    assert resp.results[0].marketCapLabel == "414.7조원"
+    assert "시가총액 단위 보정됨" in resp.results[0].warnings
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_dashes_absurd_market_cap_without_fallback() -> (
+    None
+):
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "005930",
+                    "market": "kr",
+                    "market_cap_krw": 414_671_400_000_000_000,
+                    "change_rate": 1.23,
+                    "volume": 12_345_678,
+                }
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched=set())
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    assert resp.results[0].marketCapLabel == "-"
+    assert "시가총액 데이터 확인 필요" in resp.results[0].warnings
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_keeps_results_contract_preferred_over_stocks() -> (
+    None
+):
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "code": "005930",
+                    "market": "kr",
+                    "market_cap_krw": 478_000_000_000_000,
+                    "change_rate": 1.23,
+                    "volume": 12_345_678,
+                }
+            ],
+            "stocks": [
+                {
+                    "symbol": "000000",
+                    "market": "kr",
+                    "market_cap_krw": 1_000_000_000,
+                    "change_rate": -1.0,
+                    "volume": 1,
+                }
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched=set())
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    assert len(resp.results) == 1
+    assert resp.results[0].symbol == "005930"

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from app.schemas.invest_screener import ScreenerResultsResponse
+from app.services.invest_view_model import screener_service
 from app.services.invest_view_model.screener_service import (
     build_screener_presets,
     build_screener_results,
@@ -378,3 +379,274 @@ async def test_build_screener_results_keeps_results_contract_preferred_over_stoc
 
     assert len(resp.results) == 1
     assert resp.results[0].symbol == "005930"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_warns_when_symbol_missing() -> None:
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "name": "이름만 있는 행",
+                    "market": "unsupported",
+                    "market_cap_krw": "",
+                    "market_cap": object(),
+                    "change_rate": None,
+                    "volume": None,
+                }
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched=set())
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    row = resp.results[0]
+    assert row.symbol == ""
+    assert row.market == "kr"
+    assert row.changePctLabel == "-"
+    assert row.changeDirection == "flat"
+    assert row.volumeLabel == "-"
+    assert "종목코드 데이터 준비중" in row.warnings
+    assert resolver.calls == [("kr", "")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_normalizes_us_symbol_and_market_cap() -> None:
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "MSFT",
+                    "name": "Microsoft",
+                    "market": "us",
+                    "market_cap": 900_000_000_000,
+                    "change_rate": 0,
+                    "volume": 10,
+                },
+                {
+                    "symbol": "aapl",
+                    "name": "Apple",
+                    "market": "us",
+                    "market_cap": 2_900_000_000_000,
+                    "change_rate": 0,
+                    "volume": 10,
+                },
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched={("us", "AAPL")})
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    row = resp.results[1]
+    assert resp.results[0].symbol == "MSFT"
+    assert resp.results[0].marketCapLabel == "-"
+    assert row.symbol == "AAPL"
+    assert row.market == "us"
+    assert row.marketCapLabel == "2.9조원"
+    assert row.changePctLabel == "0.00%"
+    assert row.changeDirection == "flat"
+    assert row.isWatched is True
+    assert resolver.calls == [("us", "MSFT"), ("us", "AAPL")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_coerces_string_market_cap_values() -> None:
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "005930",
+                    "market": "kr",
+                    "market_cap_krw": "478,000,000,000,000",
+                    "market_cap": "ignored-invalid",
+                    "change_rate": 1.23,
+                    "volume": 12_345_678,
+                },
+                {
+                    "symbol": "000660",
+                    "market": "kr",
+                    "market_cap_krw": "too-large",
+                    "market_cap": "4,146,714",
+                    "change_rate": 1.0,
+                    "volume": 10,
+                },
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched=set())
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    assert resp.results[0].marketCapLabel == "478.0조원"
+    assert resp.results[0].warnings == []
+    assert resp.results[1].marketCapLabel == "414.7조원"
+    assert resp.results[1].warnings == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_warns_when_only_market_cap_fallback_is_absurd() -> (
+    None
+):
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "999999",
+                    "market": "kr",
+                    "market_cap": 20_000_000_000_000_000,
+                    "change_rate": 1.23,
+                    "volume": 1,
+                }
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched=set())
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    assert resp.results[0].marketCapLabel == "-"
+    assert "시가총액 데이터 확인 필요" in resp.results[0].warnings
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("preset_id", "field", "value", "expected"),
+    [
+        ("cheap_value", "per", 8.25, "8.2"),
+        ("steady_dividend", "dividend_yield", 3.456, "3.46%"),
+        ("oversold_recovery", "rsi", 29.94, "29.9"),
+        ("high_volume_momentum", "volume", 1_234_567, "1,234,567"),
+    ],
+)
+async def test_build_screener_results_formats_preset_metrics(
+    preset_id: str, field: str, value: float, expected: str
+) -> None:
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "005930",
+                    "market": "kr",
+                    "market_cap_krw": 478_000_000_000_000,
+                    "change_rate": 1.23,
+                    "volume": value if field == "volume" else 12_345_678,
+                    field: value,
+                }
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched=set())
+
+    resp = await build_screener_results(
+        preset_id=preset_id,
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    assert resp.results[0].metricValueLabel == expected
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_handles_missing_metric_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delitem(
+        screener_service._METRIC_FIELD,
+        "consecutive_gainers",
+    )
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "005930",
+                    "market": "kr",
+                    "market_cap_krw": 478_000_000_000_000,
+                    "change_rate": 1.23,
+                    "volume": 12_345_678,
+                }
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched=set())
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    assert resp.results[0].metricValueLabel == "-"
+    assert resp.results[0].warnings == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_formats_unmapped_metric_as_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(
+        screener_service._METRIC_FIELD,
+        "consecutive_gainers",
+        "custom_score",
+    )
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "005930",
+                    "market": "kr",
+                    "market_cap_krw": 478_000_000_000_000,
+                    "change_rate": 1.23,
+                    "volume": 12_345_678,
+                    "custom_score": "A+",
+                }
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched=set())
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    assert resp.results[0].metricValueLabel == "A+"


### PR DESCRIPTION
## Summary
- Normalize /invest screener row identifiers so upstream `code` values populate UI stock codes when `symbol` is absent.
- Harden KR market-cap display mapping against over-scaled `market_cap_krw` inputs that previously rendered unrealistic 조원 labels.
- Preserve the read-only /invest screener path and existing import-safety boundary.

## Verification
- `uv run --group test pytest tests/test_invest_view_model_screener_service.py tests/test_invest_api_screener_router.py tests/test_invest_view_model_safety.py -q` — 18 passed, 2 warnings.
- `uv run --group test pytest tests/test_screener_service.py tests/integration/test_screener_e2e.py tests/test_invest_screener_presets.py tests/test_invest_screener_schemas.py tests/test_invest_view_model_screener_service.py tests/test_invest_api_screener_router.py tests/test_invest_view_model_safety.py -q` — 54 passed, 4 warnings.
- `uv run ruff check app/services/invest_view_model/screener_service.py tests/test_invest_view_model_screener_service.py tests/test_invest_api_screener_router.py` — passed.
- `uv run ruff format --check app/services/invest_view_model/screener_service.py tests/test_invest_view_model_screener_service.py tests/test_invest_api_screener_router.py` — passed.
- `git diff --check origin/main...HEAD` — passed.

## Safety
- Read-only /invest surface only.
- No broker/order/watch/order-intent, scheduler/worker, DB mutation/backfill/delete, Toss credentials/dependencies, or buy/sell CTA changes.

Closes ROB-149


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced screener result data processing with improved normalization of ticker symbols, market indicators, and market-cap values.
  * Added automatic warnings for data inconsistencies or implausible values to improve data quality awareness.

* **Tests**
  * Expanded test coverage for screener result normalization, symbol fallbacks, and edge-case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->