### PR TITLE
feat(invest): /invest desktop shell + home polish (Stage 2)

### DIFF
--- a/frontend/invest/src/__tests__/scopeHoldings.test.ts
+++ b/frontend/invest/src/__tests__/scopeHoldings.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { scopeGroupedToSource } from "../desktop/scopeHoldings";
+import type { GroupedHolding } from "../types/invest";
+
+const baseGroup: GroupedHolding = {
+  groupId: "US:equity:USD:TSLA",
+  symbol: "TSLA",
+  market: "US",
+  assetType: "equity",
+  assetCategory: "us_stock",
+  displayName: "Tesla",
+  currency: "USD",
+  totalQuantity: 6,
+  averageCost: 200,
+  costBasis: 1200,
+  valueNative: 1200,
+  valueKrw: 1_600_000,
+  pnlKrw: 0,
+  pnlRate: 0,
+  priceState: "live",
+  includedSources: ["kis", "toss_manual"],
+  sourceBreakdown: [
+    {
+      holdingId: "h1",
+      accountId: "kis-1",
+      source: "kis",
+      quantity: 4,
+      averageCost: 234,
+      costBasis: 936,
+      valueNative: 924,
+      valueKrw: 1_244_000,
+      pnlKrw: -16_000,
+      pnlRate: -0.012,
+    },
+    {
+      holdingId: "h2",
+      accountId: "toss-1",
+      source: "toss_manual",
+      quantity: 2,
+      averageCost: 132,
+      costBasis: 264,
+      valueNative: 276,
+      valueKrw: 356_000,
+      pnlKrw: 16_000,
+      pnlRate: 0.06,
+    },
+  ],
+};
+
+describe("scopeGroupedToSource", () => {
+  it("returns single-source groups unchanged when the source matches", () => {
+    const single: GroupedHolding = {
+      ...baseGroup,
+      includedSources: ["toss_manual"],
+      sourceBreakdown: [baseGroup.sourceBreakdown[1]!],
+    };
+    const out = scopeGroupedToSource([single], "toss_manual");
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe(single);
+  });
+
+  it("recomputes totals from sourceBreakdown for multi-source groups", () => {
+    const out = scopeGroupedToSource([baseGroup], "kis");
+    expect(out).toHaveLength(1);
+    const sliced = out[0]!;
+    expect(sliced.includedSources).toEqual(["kis"]);
+    expect(sliced.totalQuantity).toBe(4);
+    expect(sliced.costBasis).toBe(936);
+    expect(sliced.valueNative).toBe(924);
+    expect(sliced.valueKrw).toBe(1_244_000);
+    expect(sliced.pnlKrw).toBe(-16_000);
+    expect(sliced.averageCost).toBe(234);
+    expect(sliced.pnlRate).toBeCloseTo(-16_000 / 936);
+    expect(sliced.sourceBreakdown).toHaveLength(1);
+    expect(sliced.sourceBreakdown[0]!.source).toBe("kis");
+  });
+
+  it("omits groups whose includedSources do not contain the source", () => {
+    const out = scopeGroupedToSource([baseGroup], "upbit");
+    expect(out).toEqual([]);
+  });
+
+  it("skips multi-source groups with empty sourceBreakdown rather than misrepresenting them", () => {
+    const orphan: GroupedHolding = {
+      ...baseGroup,
+      sourceBreakdown: [],
+    };
+    const out = scopeGroupedToSource([orphan], "kis");
+    expect(out).toEqual([]);
+  });
+});

--- a/frontend/invest/src/components/home/DesktopHero.tsx
+++ b/frontend/invest/src/components/home/DesktopHero.tsx
@@ -1,5 +1,5 @@
 import type { GroupedHolding, HomeSummary } from "../../types/invest";
-import { Button, Card, Icon, PL } from "../../ds";
+import { Card, PL } from "../../ds";
 
 const CATEGORY_LABEL: Record<string, string> = {
   kr_stock: "한국주식",
@@ -47,41 +47,29 @@ export function DesktopHero({
 
   return (
     <Card data-testid="hero-card" style={{ padding: 24 }}>
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12 }}>
-        <div style={{ minWidth: 0 }}>
-          <div style={{ fontSize: 13, color: "var(--fg-3)", fontWeight: 500 }}>{subtitle}</div>
-          <div
-            style={{
-              fontSize: "clamp(28px, 2.2vw, 32px)",
-              fontWeight: 700,
-              letterSpacing: "-0.025em",
-              marginTop: 2,
-              fontFeatureSettings: '"tnum"',
-            }}
-          >
-            {fmtKrw(summary.totalValueKrw)}
-          </div>
-          {summary.pnlKrw != null && summary.pnlRate != null ? (
-            <div style={{ marginTop: 2 }}>
-              <PL value={summary.pnlKrw} pct={summary.pnlRate * 100} size={14} />
-            </div>
-          ) : (
-            <div style={{ marginTop: 2, fontSize: 14, color: "var(--fg-3)" }}>—</div>
-          )}
-          <div style={{ fontSize: 12, color: "var(--fg-3)", marginTop: 4 }}>
-            {summary.costBasisKrw != null ? `원금 ${fmtKrw(summary.costBasisKrw)}` : "원금 산정 불가"}
-            {asOfLabel ? ` · ${asOfLabel} 업데이트` : ""}
-          </div>
+      <div style={{ minWidth: 0 }}>
+        <div style={{ fontSize: 13, color: "var(--fg-3)", fontWeight: 500 }}>{subtitle}</div>
+        <div
+          style={{
+            fontSize: "clamp(28px, 2.2vw, 32px)",
+            fontWeight: 700,
+            letterSpacing: "-0.025em",
+            marginTop: 2,
+            fontFeatureSettings: '"tnum"',
+          }}
+        >
+          {fmtKrw(summary.totalValueKrw)}
         </div>
-        <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
-          <Button size="sm" variant="secondary">
-            <Icon name="chart" size={14} />
-            차트
-          </Button>
-          <Button size="sm" variant="primary">
-            <Icon name="plus" size={14} />
-            주문
-          </Button>
+        {summary.pnlKrw != null && summary.pnlRate != null ? (
+          <div style={{ marginTop: 2 }}>
+            <PL value={summary.pnlKrw} pct={summary.pnlRate * 100} size={14} />
+          </div>
+        ) : (
+          <div style={{ marginTop: 2, fontSize: 14, color: "var(--fg-3)" }}>—</div>
+        )}
+        <div style={{ fontSize: 12, color: "var(--fg-3)", marginTop: 4 }}>
+          {summary.costBasisKrw != null ? `원금 ${fmtKrw(summary.costBasisKrw)}` : "원금 산정 불가"}
+          {asOfLabel ? ` · ${asOfLabel} 업데이트` : ""}
         </div>
       </div>
 

--- a/frontend/invest/src/components/home/DesktopHero.tsx
+++ b/frontend/invest/src/components/home/DesktopHero.tsx
@@ -1,0 +1,114 @@
+import type { GroupedHolding, HomeSummary } from "../../types/invest";
+import { Button, Card, Icon, PL } from "../../ds";
+
+const CATEGORY_LABEL: Record<string, string> = {
+  kr_stock: "한국주식",
+  us_stock: "해외주식",
+  crypto: "코인",
+};
+
+function fmtKrw(v?: number | null): string {
+  if (v == null) return "—";
+  return `₩${Math.round(v).toLocaleString("ko-KR")}`;
+}
+
+function fmtKrwShort(v?: number | null): string {
+  if (v == null) return "—";
+  if (v >= 1e8) return `₩${(v / 1e8).toFixed(2)}억`;
+  if (v >= 1e4) return `₩${(v / 1e4).toFixed(0)}만`;
+  return `₩${Math.round(v).toLocaleString("ko-KR")}`;
+}
+
+function buildBreakdown(holdings: GroupedHolding[]) {
+  const totals = new Map<string, number>();
+  for (const h of holdings) {
+    if (h.valueKrw == null) continue;
+    totals.set(h.assetCategory, (totals.get(h.assetCategory) ?? 0) + h.valueKrw);
+  }
+  const ordered = ["kr_stock", "us_stock", "crypto"];
+  return ordered
+    .filter((k) => totals.has(k))
+    .map((k) => ({ key: k, label: CATEGORY_LABEL[k] ?? k, value: totals.get(k) ?? 0 }));
+}
+
+export function DesktopHero({
+  summary,
+  accountCount,
+  holdings,
+  asOfLabel,
+}: {
+  summary: HomeSummary;
+  accountCount: number;
+  holdings: GroupedHolding[];
+  asOfLabel?: string;
+}) {
+  const breakdown = buildBreakdown(holdings);
+  const subtitle = `내 투자 포트폴리오${accountCount > 0 ? ` · ${accountCount}개 계좌` : ""}`;
+
+  return (
+    <Card data-testid="hero-card" style={{ padding: 24 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12 }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontSize: 13, color: "var(--fg-3)", fontWeight: 500 }}>{subtitle}</div>
+          <div
+            style={{
+              fontSize: "clamp(28px, 2.2vw, 32px)",
+              fontWeight: 700,
+              letterSpacing: "-0.025em",
+              marginTop: 2,
+              fontFeatureSettings: '"tnum"',
+            }}
+          >
+            {fmtKrw(summary.totalValueKrw)}
+          </div>
+          {summary.pnlKrw != null && summary.pnlRate != null ? (
+            <div style={{ marginTop: 2 }}>
+              <PL value={summary.pnlKrw} pct={summary.pnlRate * 100} size={14} />
+            </div>
+          ) : (
+            <div style={{ marginTop: 2, fontSize: 14, color: "var(--fg-3)" }}>—</div>
+          )}
+          <div style={{ fontSize: 12, color: "var(--fg-3)", marginTop: 4 }}>
+            {summary.costBasisKrw != null ? `원금 ${fmtKrw(summary.costBasisKrw)}` : "원금 산정 불가"}
+            {asOfLabel ? ` · ${asOfLabel} 업데이트` : ""}
+          </div>
+        </div>
+        <div style={{ display: "flex", gap: 8, flexShrink: 0 }}>
+          <Button size="sm" variant="secondary">
+            <Icon name="chart" size={14} />
+            차트
+          </Button>
+          <Button size="sm" variant="primary">
+            <Icon name="plus" size={14} />
+            주문
+          </Button>
+        </div>
+      </div>
+
+      {breakdown.length > 0 && (
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: `repeat(${breakdown.length}, 1fr)`,
+            gap: 24,
+            marginTop: 18,
+            paddingTop: 16,
+            borderTop: "1px solid var(--divider)",
+          }}
+        >
+          {breakdown.map((b) => (
+            <div key={b.key} data-testid="hero-breakdown" data-category={b.key}>
+              <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, color: "var(--fg-3)" }}>
+                <span aria-hidden style={{ width: 5, height: 5, borderRadius: 999, background: "var(--fg-4)" }} />
+                {b.label}
+              </div>
+              <div style={{ fontSize: 17, fontWeight: 700, marginTop: 2, fontFeatureSettings: '"tnum"' }}>
+                {fmtKrwShort(b.value)}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/invest/src/components/home/FilterChips.tsx
+++ b/frontend/invest/src/components/home/FilterChips.tsx
@@ -1,0 +1,47 @@
+import type { AssetCategoryKey } from "../AssetCategoryFilter";
+
+const OPTIONS: { key: AssetCategoryKey; label: string }[] = [
+  { key: "all", label: "전체" },
+  { key: "kr_stock", label: "한국주식" },
+  { key: "us_stock", label: "해외주식" },
+  { key: "crypto", label: "코인" },
+];
+
+export function FilterChips({
+  value,
+  onChange,
+}: {
+  value: AssetCategoryKey;
+  onChange: (v: AssetCategoryKey) => void;
+}) {
+  return (
+    <div data-testid="home-filter-chips" style={{ display: "flex", gap: 6 }}>
+      {OPTIONS.map(({ key, label }) => {
+        const on = value === key;
+        return (
+          <button
+            key={key}
+            type="button"
+            onClick={() => onChange(key)}
+            style={{
+              padding: "6px 14px",
+              borderRadius: 999,
+              border: "none",
+              cursor: "pointer",
+              background: on ? "var(--fg)" : "var(--surface-2)",
+              color: on ? "#fff" : "var(--fg-2)",
+              fontWeight: 600,
+              fontSize: 13,
+              fontFamily: "inherit",
+              whiteSpace: "nowrap",
+              flexShrink: 0,
+              transition: "all 120ms cubic-bezier(0.2,0,0,1)",
+            }}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/invest/src/components/home/HoldingsTable.tsx
+++ b/frontend/invest/src/components/home/HoldingsTable.tsx
@@ -15,12 +15,9 @@ function fmtUsd(v: number | null | undefined): string {
   return `$${v.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
 
-function fmtQty(qty: number, market: GroupedHolding["market"], assetType: GroupedHolding["assetType"]): string {
-  if (assetType === "crypto") {
-    return `${qty}`;
-  }
-  if (market === "KR") return `${qty.toLocaleString("ko-KR")}주`;
-  return `${qty.toLocaleString("ko-KR")} shares`;
+function fmtQty(qty: number, _market: GroupedHolding["market"], assetType: GroupedHolding["assetType"]): string {
+  if (assetType === "crypto") return `${qty}`;
+  return `${qty.toLocaleString("ko-KR")}주`;
 }
 
 export function HoldingsTable({

--- a/frontend/invest/src/components/home/HoldingsTable.tsx
+++ b/frontend/invest/src/components/home/HoldingsTable.tsx
@@ -1,0 +1,165 @@
+import type { GroupedHolding } from "../../types/invest";
+import { Pill } from "../../ds";
+import { pillToneForSource } from "../../desktop/AccountSourceTone";
+import type { AssetCategoryKey } from "../AssetCategoryFilter";
+
+const COLS = "minmax(0,1.8fr) 100px 120px 140px 100px";
+
+function fmtKrw(v: number | null | undefined): string {
+  if (v == null) return "—";
+  return `₩${Math.round(v).toLocaleString("ko-KR")}`;
+}
+
+function fmtUsd(v: number | null | undefined): string {
+  if (v == null) return "—";
+  return `$${v.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function fmtQty(qty: number, market: GroupedHolding["market"], assetType: GroupedHolding["assetType"]): string {
+  if (assetType === "crypto") {
+    return `${qty}`;
+  }
+  if (market === "KR") return `${qty.toLocaleString("ko-KR")}주`;
+  return `${qty.toLocaleString("ko-KR")} shares`;
+}
+
+export function HoldingsTable({
+  holdings,
+  filter,
+}: {
+  holdings: GroupedHolding[];
+  filter: AssetCategoryKey;
+}) {
+  const items = filter === "all" ? holdings : holdings.filter((h) => h.assetCategory === filter);
+
+  return (
+    <div
+      data-testid="holdings-table"
+      style={{
+        background: "var(--surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 16,
+        boxShadow: "var(--shadow-1)",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: COLS,
+          padding: "12px 22px",
+          fontSize: 12,
+          fontWeight: 600,
+          color: "var(--fg-3)",
+          borderBottom: "1px solid var(--divider)",
+        }}
+      >
+        <div>종목</div>
+        <div style={{ textAlign: "right" }}>수량</div>
+        <div style={{ textAlign: "right" }}>평단</div>
+        <div style={{ textAlign: "right" }}>평가금액</div>
+        <div style={{ textAlign: "right" }}>수익률</div>
+      </div>
+
+      {items.length === 0 ? (
+        <div data-testid="holdings-empty" style={{ padding: 32, textAlign: "center", color: "var(--fg-3)", fontSize: 13 }}>
+          해당 조건에 보유 종목이 없습니다.
+        </div>
+      ) : (
+        items.map((h, i) => {
+          const usd = h.currency === "USD";
+          const dir = (h.pnlRate ?? 0) >= 0 ? "up" : "down";
+          const color = dir === "up" ? "var(--gain)" : "var(--loss)";
+          const arrow = dir === "up" ? "▲" : "▼";
+          const tone = h.includedSources[0] ? pillToneForSource(h.includedSources[0]) : "paper";
+          const value = h.valueNative ?? h.valueKrw;
+          return (
+            <div
+              key={h.groupId}
+              data-testid="holdings-row"
+              data-category={h.assetCategory}
+              style={{
+                display: "grid",
+                gridTemplateColumns: COLS,
+                alignItems: "center",
+                padding: "16px 22px",
+                borderTop: i === 0 ? "none" : "1px solid var(--divider)",
+                fontFeatureSettings: '"tnum"',
+                fontSize: 14,
+              }}
+            >
+              <div style={{ display: "flex", alignItems: "center", gap: 12, minWidth: 0 }}>
+                <div
+                  aria-hidden
+                  style={{
+                    width: 36,
+                    height: 36,
+                    borderRadius: 10,
+                    flexShrink: 0,
+                    background: `var(--pill-${tone}-bg)`,
+                    color: `var(--pill-${tone}-fg)`,
+                    display: "grid",
+                    placeItems: "center",
+                    fontWeight: 700,
+                    fontSize: 13,
+                  }}
+                >
+                  {h.displayName.slice(0, 1)}
+                </div>
+                <div style={{ minWidth: 0 }}>
+                  <div
+                    style={{
+                      fontSize: 14,
+                      fontWeight: 700,
+                      color: "var(--fg)",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {h.displayName}
+                  </div>
+                  <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 2 }}>
+                    <span style={{ fontSize: 11, color: "var(--fg-3)", fontFamily: "var(--font-mono)" }}>{h.symbol}</span>
+                    <span aria-hidden style={{ width: 2, height: 2, background: "var(--fg-4)", borderRadius: 999 }} />
+                    <Pill tone={tone} size="sm">
+                      {tone.toUpperCase()}
+                    </Pill>
+                  </div>
+                </div>
+              </div>
+
+              <div style={{ textAlign: "right", color: "var(--fg-1)", fontWeight: 500 }}>
+                {fmtQty(h.totalQuantity, h.market, h.assetType)}
+              </div>
+
+              <div style={{ textAlign: "right", color: "var(--fg-2)", fontWeight: 500 }}>
+                {usd ? fmtUsd(h.averageCost) : fmtKrw(h.averageCost)}
+                {usd && <span style={{ fontSize: 10, color: "var(--fg-3)", marginLeft: 4 }}>USD</span>}
+              </div>
+
+              <div style={{ textAlign: "right" }}>
+                <div style={{ fontWeight: 700, color: "var(--fg)" }}>
+                  {usd ? fmtUsd(value) : fmtKrw(value)}
+                </div>
+                <div style={{ fontSize: 11, color: "var(--fg-3)", marginTop: 1 }}>{usd ? "USD" : "KRW"}</div>
+              </div>
+
+              <div style={{ textAlign: "right", color, fontWeight: 700 }}>
+                {h.pnlRate != null ? (
+                  <>
+                    <span style={{ fontSize: 10, marginRight: 3 }}>{arrow}</span>
+                    {h.pnlRate >= 0 ? "+" : ""}
+                    {(h.pnlRate * 100).toFixed(2)}%
+                  </>
+                ) : (
+                  <span style={{ color: "var(--fg-3)" }}>—</span>
+                )}
+              </div>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/frontend/invest/src/components/home/MarketStrip.tsx
+++ b/frontend/invest/src/components/home/MarketStrip.tsx
@@ -1,0 +1,82 @@
+import { Sparkline } from "../../ds";
+
+export interface MarketStripItem {
+  name: string;
+  value: string;
+  changeLabel: string;
+  pct: number;
+  direction: "up" | "down" | "flat";
+  spark?: number[];
+}
+
+const COLOR: Record<MarketStripItem["direction"], string> = {
+  up: "var(--gain)",
+  down: "var(--loss)",
+  flat: "var(--flat)",
+};
+
+const ARROW: Record<MarketStripItem["direction"], string> = {
+  up: "▲",
+  down: "▼",
+  flat: "·",
+};
+
+export function MarketStrip({ items }: { items: MarketStripItem[] }) {
+  if (items.length === 0) {
+    // Backend hookup is deferred; render a 4-up muted placeholder so the
+    // section does not collapse in dev.
+    return (
+      <div data-testid="market-strip-placeholder" style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 10 }}>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            style={{
+              padding: 12,
+              background: "var(--surface)",
+              border: "1px solid var(--border)",
+              borderRadius: 14,
+              boxShadow: "var(--shadow-1)",
+              minHeight: 92,
+            }}
+          >
+            <div style={{ fontSize: 12, fontWeight: 600, color: "var(--fg-3)" }}>지수 정보</div>
+            <div style={{ fontSize: 12, color: "var(--fg-3)", marginTop: 8 }}>곧 제공 예정</div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="market-strip" style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 10 }}>
+      {items.map((m) => {
+        const c = COLOR[m.direction];
+        return (
+          <div
+            key={m.name}
+            style={{
+              padding: 12,
+              background: "var(--surface)",
+              border: "1px solid var(--border)",
+              borderRadius: 14,
+              boxShadow: "var(--shadow-1)",
+            }}
+          >
+            <div style={{ fontSize: 12, fontWeight: 600, color: "var(--fg-2)" }}>{m.name}</div>
+            <div style={{ fontSize: 16, fontWeight: 700, marginTop: 2, fontFeatureSettings: '"tnum"' }}>{m.value}</div>
+            <div style={{ fontSize: 12, color: c, fontWeight: 600, marginTop: 1, fontFeatureSettings: '"tnum"' }}>
+              <span style={{ marginRight: 4 }}>{ARROW[m.direction]}</span>
+              {m.changeLabel} · {m.pct >= 0 ? "+" : ""}
+              {m.pct.toFixed(2)}%
+            </div>
+            {m.spark && m.spark.length > 1 && (
+              <div style={{ marginTop: 6 }}>
+                <Sparkline points={m.spark} color={c} width={200} height={28} />
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/invest/src/desktop/AccountSourceTone.ts
+++ b/frontend/invest/src/desktop/AccountSourceTone.ts
@@ -1,4 +1,5 @@
-import type { AccountSourceVisual, AccountTone } from "../types/invest";
+import type { AccountSource, AccountSourceVisual, AccountTone } from "../types/invest";
+import type { PillTone } from "../ds";
 
 const TONE_STYLE: Record<AccountTone, { color: string; bg: string; border: string }> = {
   navy:   { color: "#dde3ff", bg: "#1e2a55", border: "#3a4a8a" },
@@ -24,4 +25,20 @@ export function visualBySource(
   source: string,
 ): AccountSourceVisual | undefined {
   return visuals.find((v) => v.source === source);
+}
+
+const SOURCE_TO_PILL: Record<AccountSource, PillTone> = {
+  kis: "kis",
+  kis_mock: "kis",
+  upbit: "upbit",
+  toss_manual: "toss",
+  isa_manual: "isa",
+  pension_manual: "pension",
+  alpaca_paper: "paper",
+  kiwoom_mock: "paper",
+  db_simulated: "paper",
+};
+
+export function pillToneForSource(source: AccountSource): PillTone {
+  return SOURCE_TO_PILL[source] ?? "paper";
 }

--- a/frontend/invest/src/desktop/DesktopHeader.tsx
+++ b/frontend/invest/src/desktop/DesktopHeader.tsx
@@ -1,8 +1,12 @@
 import { NavLink } from "react-router-dom";
+import { Icon } from "../ds";
 
-const LINKS = [
+const LINKS: { to: string; label: string; end?: boolean }[] = [
   { to: "/", label: "홈", end: true },
   { to: "/feed/news", label: "뉴스" },
+  // 발견 currently points at the legacy mobile route. Stage 4.2 introduces a
+  // canonical /discover and this link switches to it.
+  { to: "/app/discover", label: "발견" },
   { to: "/signals", label: "시그널" },
   { to: "/calendar", label: "캘린더" },
   { to: "/screener", label: "골라보기" },
@@ -10,22 +14,147 @@ const LINKS = [
 
 export function DesktopHeader() {
   return (
-    <header style={{ display: "flex", gap: 24, padding: "12px 32px", borderBottom: "1px solid var(--divider)", background: "var(--surface)" }}>
-      <div style={{ fontWeight: 700, fontSize: 16 }}>auto_trader</div>
-      <nav style={{ display: "flex", gap: 16 }}>
+    <header
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 28,
+        padding: "0 28px",
+        height: 56,
+        background: "var(--surface)",
+        borderBottom: "1px solid var(--divider)",
+        position: "sticky",
+        top: 0,
+        zIndex: 5,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8, fontWeight: 700, fontSize: 17, letterSpacing: "-0.02em" }}>
+        <span
+          aria-hidden
+          style={{
+            width: 22,
+            height: 22,
+            borderRadius: 6,
+            background: "var(--accent)",
+            color: "#fff",
+            display: "grid",
+            placeItems: "center",
+            fontSize: 12,
+            fontWeight: 800,
+          }}
+        >
+          A
+        </span>
+        auto_trader
+      </div>
+
+      <nav style={{ display: "flex", gap: 2, marginLeft: 8 }}>
         {LINKS.map((l) => (
           <NavLink
-            key={l.to} to={l.to} end={l.end}
+            key={l.to}
+            to={l.to}
+            end={l.end}
             style={({ isActive }) => ({
+              padding: "8px 14px",
+              borderRadius: 8,
+              textDecoration: "none",
               color: isActive ? "var(--fg)" : "var(--fg-2)",
-              textDecoration: "none", fontSize: 14, padding: "4px 8px",
               fontWeight: isActive ? 700 : 600,
+              fontSize: 14,
+              whiteSpace: "nowrap",
+              flexShrink: 0,
+              position: "relative",
+              transition: "color 120ms cubic-bezier(0.2,0,0,1)",
             })}
           >
-            {l.label}
+            {({ isActive }) => (
+              <>
+                {l.label}
+                {isActive && (
+                  <span
+                    aria-hidden
+                    style={{
+                      position: "absolute",
+                      left: 14,
+                      right: 14,
+                      bottom: -17,
+                      height: 2,
+                      background: "var(--fg)",
+                      borderRadius: 2,
+                    }}
+                  />
+                )}
+              </>
+            )}
           </NavLink>
         ))}
       </nav>
+
+      <div style={{ flex: 1 }} />
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: "8px 12px",
+          background: "var(--surface-2)",
+          borderRadius: 10,
+          width: 280,
+          color: "var(--fg-3)",
+        }}
+      >
+        <Icon name="search" size={16} />
+        <span style={{ fontSize: 13, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", flex: 1 }}>종목, 뉴스 검색…</span>
+        <span
+          style={{
+            marginLeft: "auto",
+            fontFamily: "var(--font-mono)",
+            fontSize: 11,
+            padding: "1px 5px",
+            borderRadius: 4,
+            background: "var(--surface)",
+            border: "1px solid var(--border)",
+          }}
+        >
+          ⌘K
+        </span>
+      </div>
+
+      <button
+        type="button"
+        aria-label="알림"
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: 10,
+          border: "none",
+          background: "var(--surface-2)",
+          cursor: "pointer",
+          color: "var(--fg-1)",
+          display: "grid",
+          placeItems: "center",
+        }}
+      >
+        <Icon name="bell" size={18} />
+      </button>
+
+      <div
+        aria-hidden
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: 999,
+          background: "var(--surface-3)",
+          color: "var(--fg-1)",
+          display: "grid",
+          placeItems: "center",
+          fontWeight: 700,
+          fontSize: 13,
+        }}
+      >
+        MG
+      </div>
     </header>
   );
 }

--- a/frontend/invest/src/desktop/DesktopShell.tsx
+++ b/frontend/invest/src/desktop/DesktopShell.tsx
@@ -2,24 +2,38 @@ import type { ReactNode } from "react";
 import { DesktopHeader } from "./DesktopHeader";
 
 export function DesktopShell({
-  left, center, right,
-}: { left?: ReactNode; center: ReactNode; right: ReactNode }) {
+  left,
+  center,
+  right,
+}: {
+  left?: ReactNode;
+  center: ReactNode;
+  right: ReactNode;
+}) {
   return (
     <div data-testid="desktop-shell" style={{ minHeight: "100vh", background: "var(--bg-alt)", color: "var(--fg)" }}>
       <DesktopHeader />
       <div
         style={{
           display: "grid",
-          gridTemplateColumns: left ? "240px minmax(0,1fr) 320px" : "minmax(0,1fr) 320px",
+          gridTemplateColumns: left ? "220px minmax(0,1fr) 320px" : "minmax(0,1fr) 320px",
           gap: 24,
-          padding: "24px 32px",
+          padding: "24px 28px 64px",
           maxWidth: 1440,
           margin: "0 auto",
         }}
       >
         {left ? <aside style={{ minWidth: 0 }}>{left}</aside> : null}
-        <main style={{ minWidth: 0 }}>{center}</main>
-        <aside style={{ position: "sticky", top: 24, alignSelf: "start", maxHeight: "calc(100vh - 48px)", overflowY: "auto" }}>
+        <main style={{ minWidth: 0, display: "flex", flexDirection: "column", gap: 16 }}>{center}</main>
+        <aside
+          style={{
+            position: "sticky",
+            top: 80,
+            alignSelf: "start",
+            maxHeight: "calc(100vh - 96px)",
+            overflowY: "auto",
+          }}
+        >
           {right}
         </aside>
       </div>

--- a/frontend/invest/src/desktop/LeftContextRail.tsx
+++ b/frontend/invest/src/desktop/LeftContextRail.tsx
@@ -1,0 +1,137 @@
+import type { Account } from "../types/invest";
+import { pillToneForSource } from "./AccountSourceTone";
+import type { AssetCategoryKey } from "../components/AssetCategoryFilter";
+
+interface ItemProps {
+  label: string;
+  toneDot?: string;
+  value?: string;
+  active?: boolean;
+  onClick?: () => void;
+}
+
+function Item({ label, toneDot, value, active, onClick }: ItemProps) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: "9px 10px",
+        borderRadius: 10,
+        border: "none",
+        background: active ? "var(--surface-2)" : "transparent",
+        color: "var(--fg-1)",
+        fontFamily: "inherit",
+        fontSize: 13,
+        fontWeight: 600,
+        textAlign: "left",
+        cursor: "pointer",
+        whiteSpace: "nowrap",
+        width: "100%",
+      }}
+    >
+      {toneDot ? (
+        <span
+          aria-hidden
+          style={{ width: 6, height: 6, borderRadius: 999, background: toneDot, flexShrink: 0 }}
+        />
+      ) : (
+        <span aria-hidden style={{ width: 6, height: 6, borderRadius: 2, background: "var(--fg-2)", flexShrink: 0 }} />
+      )}
+      <span style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}>{label}</span>
+      {value != null && (
+        <span style={{ fontSize: 11, color: "var(--fg-3)", fontFeatureSettings: '"tnum"', fontWeight: 500 }}>{value}</span>
+      )}
+    </button>
+  );
+}
+
+const SectionLabel = ({ children }: { children: React.ReactNode }) => (
+  <div
+    style={{
+      fontSize: 11,
+      fontWeight: 700,
+      color: "var(--fg-3)",
+      letterSpacing: "0.06em",
+      padding: "0 10px 8px",
+      textTransform: "none",
+    }}
+  >
+    {children}
+  </div>
+);
+
+function fmtMillion(v: number | null | undefined): string {
+  if (v == null) return "—";
+  return `₩${(v / 1e6).toFixed(1)}M`;
+}
+
+const CATEGORIES: { key: AssetCategoryKey; label: string }[] = [
+  { key: "all", label: "전체" },
+  { key: "kr_stock", label: "한국주식" },
+  { key: "us_stock", label: "해외주식" },
+  { key: "crypto", label: "코인" },
+];
+
+export type AccountFilterKey = "all" | string;
+
+export function LeftContextRail({
+  accounts,
+  totalKrw,
+  account,
+  onAccount,
+  category,
+  onCategory,
+}: {
+  accounts: Account[];
+  totalKrw: number;
+  account: AccountFilterKey;
+  onAccount: (k: AccountFilterKey) => void;
+  category: AssetCategoryKey;
+  onCategory: (c: AssetCategoryKey) => void;
+}) {
+  return (
+    <aside data-testid="left-context-rail" style={{ display: "flex", flexDirection: "column", gap: 18, paddingTop: 4 }}>
+      <div>
+        <SectionLabel>계좌별 보기</SectionLabel>
+        <div style={{ display: "flex", flexDirection: "column", gap: 1 }}>
+          <Item
+            label="전체"
+            value={fmtMillion(totalKrw)}
+            active={account === "all"}
+            onClick={() => onAccount("all")}
+          />
+          {accounts.map((a) => {
+            const tone = pillToneForSource(a.source);
+            return (
+              <Item
+                key={a.accountId}
+                label={a.displayName}
+                toneDot={`var(--pill-${tone}-fg)`}
+                value={fmtMillion(a.valueKrw)}
+                active={account === a.source}
+                onClick={() => onAccount(a.source)}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      <div>
+        <SectionLabel>카테고리</SectionLabel>
+        <div style={{ display: "flex", flexDirection: "column", gap: 1 }}>
+          {CATEGORIES.map((c) => (
+            <Item
+              key={c.key}
+              label={c.label}
+              active={category === c.key}
+              onClick={() => onCategory(c.key)}
+            />
+          ))}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/frontend/invest/src/desktop/RightAccountPanel.tsx
+++ b/frontend/invest/src/desktop/RightAccountPanel.tsx
@@ -32,10 +32,12 @@ export function RightAccountPanel({
   data,
   error,
   loading,
+  onRefresh,
 }: {
   data?: AccountPanelResponse;
   error?: string;
   loading?: boolean;
+  onRefresh?: () => void;
 }) {
   if (loading || (!data && !error)) {
     return (
@@ -76,16 +78,19 @@ export function RightAccountPanel({
         ) : (
           <div style={{ marginTop: 4, fontSize: 13, color: "var(--fg-3)" }}>—</div>
         )}
-        <div style={{ display: "flex", gap: 6, marginTop: 14 }}>
-          <Button size="sm" variant="primary" style={{ flex: 1, justifyContent: "center" }}>
-            <Icon name="plus" size={14} />
-            계좌 추가
-          </Button>
-          <Button size="sm" variant="secondary" style={{ flex: 1, justifyContent: "center" }}>
-            <Icon name="refresh" size={14} />
-            새로고침
-          </Button>
-        </div>
+        {onRefresh && (
+          <div style={{ display: "flex", gap: 6, marginTop: 14 }}>
+            <Button
+              size="sm"
+              variant="secondary"
+              onClick={onRefresh}
+              style={{ flex: 1, justifyContent: "center" }}
+            >
+              <Icon name="refresh" size={14} />
+              새로고침
+            </Button>
+          </div>
+        )}
       </Card>
 
       <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>

--- a/frontend/invest/src/desktop/RightAccountPanel.tsx
+++ b/frontend/invest/src/desktop/RightAccountPanel.tsx
@@ -1,13 +1,19 @@
-import type { AccountPanelResponse } from "../types/invest";
-import { styleForVisual, visualBySource } from "./AccountSourceTone";
+import type { AccountPanelResponse, WatchSymbol } from "../types/invest";
+import { Button, Card, Icon, PL, Pill } from "../ds";
+import { pillToneForSource, visualBySource } from "./AccountSourceTone";
 
-function fmtKrw(v?: number | null) {
-  if (v == null) return "-";
+function fmtKrw(v?: number | null): string {
+  if (v == null) return "—";
   return `₩${Math.round(v).toLocaleString("ko-KR")}`;
 }
 
-function fmtPct(v?: number | null) {
-  if (v == null) return "-";
+function fmtUsd(v?: number | null): string {
+  if (v == null) return "—";
+  return `$${v.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function fmtPct(v?: number | null): string {
+  if (v == null) return "—";
   return `${(v * 100).toFixed(2)}%`;
 }
 
@@ -16,11 +22,27 @@ function plColor(rate: number | null | undefined): string {
   return rate >= 0 ? "var(--gain)" : "var(--loss)";
 }
 
+const MARKET_LABEL: Record<WatchSymbol["market"], string> = {
+  kr: "KR",
+  us: "US",
+  crypto: "CRYPTO",
+};
+
 export function RightAccountPanel({
-  data, error, loading,
-}: { data?: AccountPanelResponse; error?: string; loading?: boolean }) {
+  data,
+  error,
+  loading,
+}: {
+  data?: AccountPanelResponse;
+  error?: string;
+  loading?: boolean;
+}) {
   if (loading || (!data && !error)) {
-    return <div data-testid="right-panel-skeleton" style={{ padding: 16 }}>로딩 중…</div>;
+    return (
+      <div data-testid="right-panel-skeleton" style={{ padding: 16, color: "var(--fg-3)" }}>
+        로딩 중…
+      </div>
+    );
   }
   if (error || !data) {
     return (
@@ -29,64 +51,163 @@ export function RightAccountPanel({
       </div>
     );
   }
-  const totals = data.homeSummary;
-  return (
-    <div data-testid="right-panel" style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-      <section style={{ padding: 16, borderRadius: 12, background: "var(--surface)", border: "1px solid var(--border)", boxShadow: "var(--shadow-1)" }}>
-        <div style={{ fontSize: 12, color: "var(--fg-3)" }}>총 자산 (KRW)</div>
-        <div style={{ fontSize: 24, fontWeight: 700 }}>{fmtKrw(totals.totalValueKrw)}</div>
-        <div style={{ fontSize: 12, color: plColor(totals.pnlRate) }}>
-          {fmtKrw(totals.pnlKrw)} · {fmtPct(totals.pnlRate)}
-        </div>
-      </section>
 
-      <section style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+  const totals = data.homeSummary;
+
+  return (
+    <div data-testid="right-panel" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <Card style={{ padding: 18 }}>
+        <div style={{ fontSize: 12, color: "var(--fg-3)", fontWeight: 500 }}>총 자산 (KRW)</div>
+        <div
+          style={{
+            fontSize: 26,
+            fontWeight: 700,
+            letterSpacing: "-0.02em",
+            marginTop: 2,
+            fontFeatureSettings: '"tnum"',
+          }}
+        >
+          {fmtKrw(totals.totalValueKrw)}
+        </div>
+        {totals.pnlKrw != null && totals.pnlRate != null ? (
+          <div style={{ marginTop: 4 }}>
+            <PL value={totals.pnlKrw} pct={totals.pnlRate * 100} size={13} />
+          </div>
+        ) : (
+          <div style={{ marginTop: 4, fontSize: 13, color: "var(--fg-3)" }}>—</div>
+        )}
+        <div style={{ display: "flex", gap: 6, marginTop: 14 }}>
+          <Button size="sm" variant="primary" style={{ flex: 1, justifyContent: "center" }}>
+            <Icon name="plus" size={14} />
+            계좌 추가
+          </Button>
+          <Button size="sm" variant="secondary" style={{ flex: 1, justifyContent: "center" }}>
+            <Icon name="refresh" size={14} />
+            새로고침
+          </Button>
+        </div>
+      </Card>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
         {data.accounts.length === 0 ? (
           <div style={{ padding: 12, color: "var(--fg-3)", fontSize: 12 }}>등록된 계좌가 없습니다.</div>
         ) : (
           data.accounts.map((a) => {
-            const v = visualBySource(data.sourceVisuals, a.source);
-            const style = v ? styleForVisual(v) : undefined;
-            const noBalance = (a.valueKrw ?? 0) === 0 && !a.cashBalances.krw && !a.cashBalances.usd;
+            const visual = visualBySource(data.sourceVisuals, a.source);
+            const tone = pillToneForSource(a.source);
+            const krw = a.cashBalances.krw;
+            const usd = a.cashBalances.usd;
+            const noBalance = (a.valueKrw ?? 0) === 0 && !krw && !usd;
             return (
               <article
                 key={a.accountId}
                 data-testid="right-panel-account"
                 data-source={a.source}
-                style={{ padding: 12, borderRadius: 10, ...style }}
+                style={{
+                  padding: 14,
+                  borderRadius: 14,
+                  background: "var(--surface-2)",
+                }}
               >
-                <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", fontSize: 12 }}>
-                  <span>{a.displayName}</span>
-                  {v && <span style={{ fontSize: 10, padding: "1px 6px", borderRadius: 4, background: "var(--surface-2)" }}>{v.badge}</span>}
+                <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
+                  <span
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 600,
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      minWidth: 0,
+                      color: "var(--fg-1)",
+                    }}
+                  >
+                    {a.displayName}
+                  </span>
+                  <Pill tone={tone} size="sm">
+                    {visual?.badge ?? tone.toUpperCase()}
+                  </Pill>
                 </header>
-                <div style={{ fontSize: 16, fontWeight: 700, marginTop: 4 }}>{fmtKrw(a.valueKrw)}</div>
-                <div style={{ fontSize: 11, color: plColor(a.pnlRate) }}>
-                  {fmtKrw(a.pnlKrw)} · {fmtPct(a.pnlRate)}
+                <div style={{ fontSize: 18, fontWeight: 700, marginTop: 6, fontFeatureSettings: '"tnum"' }}>
+                  {fmtKrw(a.valueKrw)}
                 </div>
-                {noBalance && <div style={{ fontSize: 11, color: "var(--fg-3)", marginTop: 4 }}>잔고 없음</div>}
+                {a.pnlKrw != null && a.pnlRate != null ? (
+                  <div style={{ marginTop: 2 }}>
+                    <PL value={a.pnlKrw} pct={a.pnlRate * 100} size={12} />
+                  </div>
+                ) : (
+                  <div style={{ marginTop: 2, fontSize: 12, color: "var(--fg-3)" }}>—</div>
+                )}
+                {(krw != null || usd != null) && (
+                  <div
+                    style={{
+                      display: "grid",
+                      gridTemplateColumns: "1fr auto",
+                      gap: "2px 8px",
+                      fontSize: 11,
+                      marginTop: 8,
+                      paddingTop: 8,
+                      borderTop: "1px solid var(--surface-3)",
+                      color: "var(--fg-2)",
+                    }}
+                  >
+                    {krw != null && (
+                      <>
+                        <span style={{ color: "var(--fg-3)" }}>원화 잔고</span>
+                        <span style={{ fontFeatureSettings: '"tnum"' }}>{fmtKrw(krw)}</span>
+                      </>
+                    )}
+                    {usd != null && (
+                      <>
+                        <span style={{ color: "var(--fg-3)" }}>달러 잔고</span>
+                        <span style={{ fontFeatureSettings: '"tnum"' }}>{fmtUsd(usd)}</span>
+                      </>
+                    )}
+                  </div>
+                )}
+                {noBalance && (
+                  <div style={{ marginTop: 6, fontSize: 11, color: "var(--fg-3)" }}>잔고 없음</div>
+                )}
               </article>
             );
           })
         )}
-      </section>
+      </div>
 
-      <section>
-        <div style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 4 }}>관심 종목</div>
+      <Card style={{ padding: 16 }}>
+        <div style={{ fontSize: 12, color: "var(--fg-3)", marginBottom: 8, fontWeight: 600 }}>관심 종목</div>
         {!data.meta.watchlistAvailable ? (
           <div style={{ fontSize: 12, color: "var(--fg-3)" }}>관심 종목 데이터를 불러올 수 없습니다.</div>
         ) : data.watchSymbols.length === 0 ? (
-          <div data-testid="watchlist-empty" style={{ fontSize: 12, color: "var(--fg-3)" }}>등록된 관심 종목이 없습니다.</div>
+          <div data-testid="watchlist-empty" style={{ fontSize: 12, color: "var(--fg-3)" }}>
+            등록된 관심 종목이 없습니다.
+          </div>
         ) : (
-          <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 4 }}>
+          <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column" }}>
             {data.watchSymbols.slice(0, 8).map((w) => (
-              <li key={`${w.market}:${w.symbol}`} style={{ fontSize: 12 }}>
-                <span style={{ color: "var(--fg-3)", marginRight: 6 }}>{w.market.toUpperCase()}</span>
-                {w.displayName}
+              <li
+                key={`${w.market}:${w.symbol}`}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "8px 0",
+                  borderBottom: "1px solid var(--divider)",
+                }}
+              >
+                <div style={{ minWidth: 0, flex: 1 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600, lineHeight: 1.3, color: "var(--fg)" }}>
+                    {w.displayName}
+                  </div>
+                  <div style={{ fontSize: 11, color: "var(--fg-3)", fontFamily: "var(--font-mono)" }}>
+                    {MARKET_LABEL[w.market]} · {w.symbol}
+                  </div>
+                </div>
+                {w.note && <div style={{ fontSize: 11, color: "var(--fg-3)" }}>{w.note}</div>}
               </li>
             ))}
           </ul>
         )}
-      </section>
+      </Card>
     </div>
   );
 }

--- a/frontend/invest/src/desktop/scopeHoldings.ts
+++ b/frontend/invest/src/desktop/scopeHoldings.ts
@@ -1,0 +1,68 @@
+import type { AccountSource, GroupedHolding } from "../types/invest";
+
+// When the user filters the home view to a single source/account, the grouped
+// rows must be reduced to that source's slice so the table totals match the
+// hero summary and the breakdown chips. We rely on `sourceBreakdown` to do the
+// recomputation; if a multi-source group lacks breakdown data we skip it
+// rather than misrepresent the full group's totals as a single source.
+export function scopeGroupedToSource(
+  groups: GroupedHolding[],
+  source: AccountSource,
+): GroupedHolding[] {
+  const out: GroupedHolding[] = [];
+  for (const g of groups) {
+    if (!g.includedSources.includes(source)) continue;
+
+    // Single-source group — the slice equals the whole group.
+    if (g.includedSources.length === 1) {
+      out.push(g);
+      continue;
+    }
+
+    const slices = g.sourceBreakdown.filter((b) => b.source === source);
+    if (slices.length === 0) {
+      // Multi-source group with no breakdown — cannot safely slice.
+      continue;
+    }
+
+    let totalQuantity = 0;
+    let costBasis: number | null = null;
+    let valueNative: number | null = null;
+    let valueKrw: number | null = null;
+    let pnlKrw: number | null = null;
+    let qtyForAvg = 0;
+    let costSum = 0;
+
+    for (const b of slices) {
+      totalQuantity += b.quantity;
+      if (b.costBasis != null) costBasis = (costBasis ?? 0) + b.costBasis;
+      if (b.valueNative != null) valueNative = (valueNative ?? 0) + b.valueNative;
+      if (b.valueKrw != null) valueKrw = (valueKrw ?? 0) + b.valueKrw;
+      if (b.pnlKrw != null) pnlKrw = (pnlKrw ?? 0) + b.pnlKrw;
+      if (b.averageCost != null && b.quantity > 0) {
+        costSum += b.averageCost * b.quantity;
+        qtyForAvg += b.quantity;
+      }
+    }
+
+    const averageCost = qtyForAvg > 0 ? costSum / qtyForAvg : null;
+    const pnlRate =
+      pnlKrw != null && costBasis != null && costBasis !== 0
+        ? pnlKrw / costBasis
+        : null;
+
+    out.push({
+      ...g,
+      totalQuantity,
+      averageCost,
+      costBasis,
+      valueNative,
+      valueKrw,
+      pnlKrw,
+      pnlRate,
+      includedSources: [source],
+      sourceBreakdown: slices,
+    });
+  }
+  return out;
+}

--- a/frontend/invest/src/desktop/useAccountPanel.ts
+++ b/frontend/invest/src/desktop/useAccountPanel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { AccountPanelResponse } from "../types/invest";
 import { fetchAccountPanel } from "../api/accountPanel";
 
@@ -6,12 +6,16 @@ export function useAccountPanel() {
   const [data, setData] = useState<AccountPanelResponse | undefined>();
   const [error, setError] = useState<string | undefined>();
   const [loading, setLoading] = useState(true);
+  const [tick, setTick] = useState(0);
   useEffect(() => {
     let cancel = false;
+    setError(undefined);
+    setLoading(true);
     fetchAccountPanel()
       .then((r) => { if (!cancel) { setData(r); setLoading(false); } })
       .catch((e) => { if (!cancel) { setError(String(e?.message ?? e)); setLoading(false); } });
     return () => { cancel = true; };
-  }, []);
-  return { data, error, loading };
+  }, [tick]);
+  const reload = useCallback(() => setTick((t) => t + 1), []);
+  return { data, error, loading, reload };
 }

--- a/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
@@ -1,18 +1,118 @@
+import { useMemo, useState } from "react";
 import { DesktopShell } from "../../desktop/DesktopShell";
+import { LeftContextRail } from "../../desktop/LeftContextRail";
+import type { AccountFilterKey } from "../../desktop/LeftContextRail";
 import { RightAccountPanel } from "../../desktop/RightAccountPanel";
 import { useAccountPanel } from "../../desktop/useAccountPanel";
+import { useInvestHome } from "../../hooks/useInvestHome";
+import { DesktopHero } from "../../components/home/DesktopHero";
+import { MarketStrip } from "../../components/home/MarketStrip";
+import { HoldingsTable } from "../../components/home/HoldingsTable";
+import { FilterChips } from "../../components/home/FilterChips";
+import type { AssetCategoryKey } from "../../components/AssetCategoryFilter";
 
 export function DesktopHomePage() {
+  const home = useInvestHome();
   const panel = useAccountPanel();
+  const [account, setAccount] = useState<AccountFilterKey>("all");
+  const [category, setCategory] = useState<AssetCategoryKey>("all");
+
+  const data = home.state.status === "ready" ? home.state.data : null;
+
+  const filteredGrouped = useMemo(() => {
+    if (!data) return [];
+    return data.groupedHoldings.filter((g) => {
+      const accountMatch = account === "all" || g.includedSources.includes(account as never);
+      const categoryMatch = category === "all" || g.assetCategory === category;
+      return accountMatch && categoryMatch;
+    });
+  }, [data, account, category]);
+
+  const summary = useMemo(() => {
+    if (!data) return null;
+    if (account === "all") return data.homeSummary;
+    const acct = data.accounts.find((a) => a.source === account);
+    if (!acct) return data.homeSummary;
+    return {
+      includedSources: [acct.source],
+      excludedSources: [],
+      totalValueKrw: acct.valueKrw,
+      costBasisKrw: acct.costBasisKrw,
+      pnlKrw: acct.pnlKrw,
+      pnlRate: acct.pnlRate,
+    };
+  }, [data, account]);
+
   return (
     <DesktopShell
+      left={
+        <LeftContextRail
+          accounts={data?.accounts ?? []}
+          totalKrw={data?.homeSummary.totalValueKrw ?? 0}
+          account={account}
+          onAccount={setAccount}
+          category={category}
+          onCategory={setCategory}
+        />
+      }
       center={
-        <section style={{ padding: 24, borderRadius: 12, background: "var(--surface, #15181f)" }}>
-          <h1 style={{ fontSize: 18, marginTop: 0 }}>/invest 데스크톱 (read-only)</h1>
-          <p style={{ color: "#9ba0ab", fontSize: 13 }}>
-            상단 네비게이션에서 뉴스, 시그널, 캘린더로 이동하세요.
-          </p>
-        </section>
+        <>
+          {home.state.status === "loading" && (
+            <div style={{ padding: 32, color: "var(--fg-3)", textAlign: "center" }}>불러오는 중…</div>
+          )}
+          {home.state.status === "error" && (
+            <div style={{ padding: 16, color: "var(--danger)" }}>
+              잠시 후 다시 시도해 주세요.{" "}
+              <button
+                type="button"
+                onClick={home.reload}
+                style={{
+                  marginLeft: 8,
+                  padding: "4px 10px",
+                  borderRadius: 8,
+                  border: "1px solid var(--border)",
+                  background: "var(--surface)",
+                  color: "var(--fg-1)",
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                  fontSize: 12,
+                }}
+              >
+                재시도
+              </button>
+            </div>
+          )}
+
+          {data && summary && (
+            <>
+              <DesktopHero
+                summary={summary}
+                accountCount={data.accounts.length}
+                holdings={data.groupedHoldings}
+              />
+              <MarketStrip items={[]} />
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: 4 }}>
+                <h2 style={{ margin: 0, fontSize: 18, fontWeight: 700, letterSpacing: "-0.01em" }}>보유 종목</h2>
+                <FilterChips value={category} onChange={setCategory} />
+              </div>
+              <HoldingsTable holdings={filteredGrouped} filter="all" />
+              {data.meta?.warnings && data.meta.warnings.length > 0 && (
+                <div
+                  role="alert"
+                  style={{
+                    padding: "10px 14px",
+                    color: "var(--warn)",
+                    background: "var(--warn-soft)",
+                    borderRadius: 12,
+                    fontSize: 12,
+                  }}
+                >
+                  {data.meta.warnings.map((w) => `⚠ ${w.source}: ${w.message}`).join(" · ")}
+                </div>
+              )}
+            </>
+          )}
+        </>
       }
       right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} />}
     />

--- a/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
@@ -5,11 +5,13 @@ import type { AccountFilterKey } from "../../desktop/LeftContextRail";
 import { RightAccountPanel } from "../../desktop/RightAccountPanel";
 import { useAccountPanel } from "../../desktop/useAccountPanel";
 import { useInvestHome } from "../../hooks/useInvestHome";
+import { scopeGroupedToSource } from "../../desktop/scopeHoldings";
 import { DesktopHero } from "../../components/home/DesktopHero";
 import { MarketStrip } from "../../components/home/MarketStrip";
 import { HoldingsTable } from "../../components/home/HoldingsTable";
 import { FilterChips } from "../../components/home/FilterChips";
 import type { AssetCategoryKey } from "../../components/AssetCategoryFilter";
+import type { AccountSource, HomeSummary } from "../../types/invest";
 
 export function DesktopHomePage() {
   const home = useInvestHome();
@@ -19,16 +21,23 @@ export function DesktopHomePage() {
 
   const data = home.state.status === "ready" ? home.state.data : null;
 
-  const filteredGrouped = useMemo(() => {
+  // Account scope must propagate to every surface that shows holdings totals
+  // (hero breakdown + table) so the user sees one consistent view of the
+  // selected slice. The summary number itself comes from the API account
+  // record, which represents the account's authoritative total.
+  const scopedGrouped = useMemo(() => {
     if (!data) return [];
-    return data.groupedHoldings.filter((g) => {
-      const accountMatch = account === "all" || g.includedSources.includes(account as never);
-      const categoryMatch = category === "all" || g.assetCategory === category;
-      return accountMatch && categoryMatch;
-    });
-  }, [data, account, category]);
+    if (account === "all") return data.groupedHoldings;
+    return scopeGroupedToSource(data.groupedHoldings, account as AccountSource);
+  }, [data, account]);
 
-  const summary = useMemo(() => {
+  const filteredScoped = useMemo(() => {
+    return category === "all"
+      ? scopedGrouped
+      : scopedGrouped.filter((g) => g.assetCategory === category);
+  }, [scopedGrouped, category]);
+
+  const summary: HomeSummary | null = useMemo(() => {
     if (!data) return null;
     if (account === "all") return data.homeSummary;
     const acct = data.accounts.find((a) => a.source === account);
@@ -87,15 +96,15 @@ export function DesktopHomePage() {
             <>
               <DesktopHero
                 summary={summary}
-                accountCount={data.accounts.length}
-                holdings={data.groupedHoldings}
+                accountCount={account === "all" ? data.accounts.length : 1}
+                holdings={scopedGrouped}
               />
               <MarketStrip items={[]} />
               <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: 4 }}>
                 <h2 style={{ margin: 0, fontSize: 18, fontWeight: 700, letterSpacing: "-0.01em" }}>보유 종목</h2>
                 <FilterChips value={category} onChange={setCategory} />
               </div>
-              <HoldingsTable holdings={filteredGrouped} filter="all" />
+              <HoldingsTable holdings={filteredScoped} filter="all" />
               {data.meta?.warnings && data.meta.warnings.length > 0 && (
                 <div
                   role="alert"
@@ -114,7 +123,14 @@ export function DesktopHomePage() {
           )}
         </>
       }
-      right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} />}
+      right={
+        <RightAccountPanel
+          data={panel.data}
+          loading={panel.loading}
+          error={panel.error}
+          onRefresh={panel.reload}
+        />
+      }
     />
   );
 }


### PR DESCRIPTION
## Summary

Stage 2 of the `/invest` design-system migration plan
(`docs/plans/2026-05-08-invest-design-system-migration-implementation-plan.md`),
on top of Stage 1 (#725, already merged).

This rebuild brings the **desktop `/` route** in line with
`HomeView.jsx` + `DesktopChrome.jsx` from the design bundle while
keeping every API hook and `data-testid` contract intact.

### Components rebuilt / added
- **`DesktopHeader`** — sticky 56px row, blue 'A' square mark + wordmark,
  five primary nav links (홈/뉴스/발견/시그널/캘린더) plus 골라보기,
  active underline indicator, ⌘K search field, bell, avatar.
- **`LeftContextRail`** _(new)_ — 계좌별 보기 + 카테고리 sections.
  Account dots use `pillToneForSource()` to derive the brand pill tone
  per account source. Lifted state for account + category.
- **`RightAccountPanel`** — total card with PL atom and 계좌 추가 /
  새로고침 buttons; per-account block with source pill, KRW value, PL,
  KRW/USD cash grid; watch list with monospace symbols. All five
  pre-existing testids preserved.
- **`DesktopShell`** — 220 / 1fr / 320 grid, `--bg-alt` page bg, sticky
  right rail at `top: 80` (clears the new sticky header).
- **`components/home/`** _(new)_ — `DesktopHero`, `MarketStrip`,
  `FilterChips`, `HoldingsTable`. Hero builds a 3-up asset-class
  breakdown from `groupedHoldings`. Holdings table renders the avatar
  tile + name + symbol/source pill + qty/avg/valuation/% with the
  Korean P/L convention (red ▲ gain, blue ▼ loss).
- **`DesktopHomePage`** — composes the above, drives off
  `useInvestHome()` + `useAccountPanel()`, lifts account/category
  filters, recomputes the hero summary when the user picks a single
  account.

### Deferred (intentional)
- **`MarketStrip`** renders a muted 4-up placeholder until the backend
  ships market indices on `useInvestHome`. Per the plan, the data
  hookup can land in a later stage.
- The `발견` nav link points at the legacy `/app/discover` route until
  Stage 4.2 introduces a canonical `/discover`.
- News-route dark literals introduced by #722 (issue chip + related
  symbols) stay until Stage 4.1's full News rebuild — out of this PR's
  scope per Hermes's previous 'keep the fix narrow' guidance.

## Test Plan

- [x] `cd frontend/invest && npm run typecheck` — PASS
- [x] `cd frontend/invest && npm test -- --run` — 23 files / 75 tests PASS
      (incl. the existing `RightAccountPanel`, `DesktopShell`, `HomePage`,
      `DesktopFeedNewsPage`, calendar/screener suites)
- [x] `cd frontend/invest && npm run build` — PASS (`dist/assets/index-*.css 8.84 kB`,
      JS bundle 358 kB)

### Visual smoke

Vite dev base is `/invest/app/`, so `npm run dev` serves at
**`http://127.0.0.1:5174/invest/app/`** (legacy mobile entry). The
desktop home is reached by client-routing from there to `/`. In
production / native deploys the canonical entry is `/invest/`.

- [ ] Open `npm run dev` → land on `/invest/app/` → use SPA router to
      reach desktop `/` → confirm 3-column shell with sticky right rail
- [ ] Verify hero `data-testid='hero-card'` renders, breakdown chips
      show kr_stock / us_stock / crypto totals
- [ ] Account filter (rail) recomputes hero summary; category filter
      (rail or chips) prunes holdings table
- [ ] Korean P/L convention preserved everywhere (red ▲ / blue ▼)

## Scope-out / safety

- Read-only frontend work. No broker / order / watch / market-events
  mutation paths touched.
- All hooks (`useInvestHome`, `useAccountPanel`) and types unchanged.
- Mobile `/invest/app` shell is untouched in this PR — Stage 3
  introduces the responsive mobile renderers under canonical routes.
- Stages 3–6 follow in separate PRs per the plan.