### PR TITLE
feat(invest): /invest home is responsive (Stage 3)

### DIFF
--- a/frontend/invest/src/__tests__/InvestHomeRoute.test.tsx
+++ b/frontend/invest/src/__tests__/InvestHomeRoute.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { InvestHomeRoute } from "../pages/desktop/DesktopHomePage";
+
+// Stub the data hooks so the page renders its loading branch synchronously —
+// we only care about which shell is picked here.
+vi.mock("../hooks/useInvestHome", () => ({
+  useInvestHome: () => ({ state: { status: "loading" }, reload: () => {} }),
+}));
+vi.mock("../desktop/useAccountPanel", () => ({
+  useAccountPanel: () => ({ data: undefined, error: undefined, loading: true, reload: () => {} }),
+}));
+
+function setWidth(w: number) {
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: w });
+}
+
+describe("InvestHomeRoute responsive dispatch", () => {
+  it("renders the desktop shell at >= 900px", () => {
+    setWidth(1280);
+    render(
+      <MemoryRouter basename="/invest" initialEntries={["/invest/"]}>
+        <InvestHomeRoute />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("desktop-shell")).toBeInTheDocument();
+    expect(screen.queryByTestId("mobile-shell")).toBeNull();
+  });
+
+  it("renders the mobile shell below 900px", () => {
+    setWidth(600);
+    render(
+      <MemoryRouter basename="/invest" initialEntries={["/invest/"]}>
+        <InvestHomeRoute />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("mobile-shell")).toBeInTheDocument();
+    expect(screen.queryByTestId("desktop-shell")).toBeNull();
+  });
+});

--- a/frontend/invest/src/__tests__/MobileBottomNav.test.tsx
+++ b/frontend/invest/src/__tests__/MobileBottomNav.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { MobileBottomNav } from "../mobile/MobileBottomNav";
+
+function renderAt(path: string) {
+  const router = createMemoryRouter(
+    [{ path: "*", element: <MobileBottomNav /> }],
+    { initialEntries: [`/invest${path}`], basename: "/invest" },
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe("MobileBottomNav", () => {
+  it("renders all five canonical tabs", () => {
+    renderAt("/");
+    expect(screen.getByRole("link", { name: /홈/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /뉴스/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /발견/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /시그널/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /캘린더/ })).toBeInTheDocument();
+  });
+
+  it("뉴스 link points to /invest/feed/news", () => {
+    renderAt("/");
+    expect(screen.getByRole("link", { name: /뉴스/ })).toHaveAttribute("href", "/invest/feed/news");
+  });
+
+  it("highlights active tab via --fg color", () => {
+    renderAt("/feed/news");
+    const link = screen.getByRole("link", { name: /뉴스/ });
+    expect(link.getAttribute("style") ?? "").toContain("color: var(--fg)");
+  });
+});

--- a/frontend/invest/src/__tests__/MobileShell.test.tsx
+++ b/frontend/invest/src/__tests__/MobileShell.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { MobileShell } from "../mobile/MobileShell";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const STYLES_CSS = readFileSync(resolve(here, "../styles.css"), "utf8");
+
+function ruleBody(css: string, selector: string): string {
+  const start = css.indexOf(selector + " {");
+  if (start < 0) throw new Error(`selector not found: ${selector}`);
+  const open = css.indexOf("{", start);
+  const close = css.indexOf("}", open);
+  return css.slice(open + 1, close);
+}
+
+function LongChild() {
+  return (
+    <div data-testid="long-content">
+      {Array.from({ length: 200 }).map((_, i) => (
+        <p key={i} style={{ height: 20 }}>row {i}</p>
+      ))}
+    </div>
+  );
+}
+
+function renderShell() {
+  return render(
+    <MemoryRouter basename="/invest" initialEntries={["/invest/"]}>
+      <MobileShell title="홈">
+        <LongChild />
+      </MobileShell>
+    </MemoryRouter>,
+  );
+}
+
+describe("MobileShell layout contract", () => {
+  it("places the bottom nav as a sibling of the scroll region (never inside it)", () => {
+    renderShell();
+    const shell = screen.getByTestId("mobile-shell");
+    const scroll = screen.getByTestId("mobile-shell-scroll");
+    const nav = screen.getByTestId("mobile-bottom-nav");
+
+    // Both scroll region and bottom nav are direct children of the shell.
+    expect(scroll.parentElement).toBe(shell);
+    expect(nav.parentElement).toBe(shell);
+    // Long content is rendered inside the scroll region, not below the nav.
+    expect(scroll.contains(screen.getByTestId("long-content"))).toBe(true);
+    // Nav is a sibling that follows the scroll region in DOM order.
+    expect(scroll.contains(nav)).toBe(false);
+    expect(scroll.compareDocumentPosition(nav) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("uses the .mobile-shell + .mobile-shell__scroll classes", () => {
+    renderShell();
+    expect(screen.getByTestId("mobile-shell").className).toBe("mobile-shell");
+    expect(screen.getByTestId("mobile-shell-scroll").className).toBe("mobile-shell__scroll");
+  });
+});
+
+describe("MobileShell CSS contract", () => {
+  it(".mobile-shell pins height to viewport (100vh fallback + 100dvh) and clips overflow", () => {
+    const body = ruleBody(STYLES_CSS, ".mobile-shell");
+    expect(body).toMatch(/height:\s*100vh/);
+    expect(body).toMatch(/height:\s*100dvh/);
+    expect(body).toMatch(/max-height:\s*100vh/);
+    expect(body).toMatch(/max-height:\s*100dvh/);
+    expect(body).toMatch(/display:\s*flex/);
+    expect(body).toMatch(/flex-direction:\s*column/);
+    expect(body).toMatch(/overflow:\s*hidden/);
+  });
+
+  it(".mobile-shell__scroll uses flex: 1 + min-height: 0 + overflow-y: auto", () => {
+    const body = ruleBody(STYLES_CSS, ".mobile-shell__scroll");
+    expect(body).toMatch(/flex:\s*1/);
+    expect(body).toMatch(/min-height:\s*0/);
+    expect(body).toMatch(/overflow-y:\s*auto/);
+  });
+
+  it("MobileBottomNav uses .mobile-bottom-nav with safe-area-inset-bottom padding", () => {
+    renderShell();
+    const nav = screen.getByTestId("mobile-bottom-nav");
+    expect(nav.className).toContain("mobile-bottom-nav");
+    // jsdom doesn't apply CSS files, so we assert on the rule itself.
+    const body = ruleBody(STYLES_CSS, ".mobile-bottom-nav");
+    expect(body).toMatch(/padding-bottom:\s*max\(8px,\s*env\(safe-area-inset-bottom/);
+    // flexShrink: 0 still inline (atomic, jsdom-safe).
+    expect(nav.getAttribute("style") ?? "").toContain("flex-shrink: 0");
+  });
+});

--- a/frontend/invest/src/__tests__/useViewport.test.tsx
+++ b/frontend/invest/src/__tests__/useViewport.test.tsx
@@ -1,0 +1,40 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { useViewport } from "../hooks/useViewport";
+
+function setWidth(w: number) {
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: w });
+}
+
+afterEach(() => setWidth(1280));
+
+describe("useViewport", () => {
+  it("returns 'mobile' under 900px", () => {
+    setWidth(600);
+    const { result } = renderHook(() => useViewport());
+    expect(result.current).toBe("mobile");
+  });
+
+  it("returns 'compact' between 900 and 1199", () => {
+    setWidth(1024);
+    const { result } = renderHook(() => useViewport());
+    expect(result.current).toBe("compact");
+  });
+
+  it("returns 'desktop' at 1200 and above", () => {
+    setWidth(1280);
+    const { result } = renderHook(() => useViewport());
+    expect(result.current).toBe("desktop");
+  });
+
+  it("updates when window resizes", () => {
+    setWidth(1280);
+    const { result } = renderHook(() => useViewport());
+    expect(result.current).toBe("desktop");
+    act(() => {
+      setWidth(500);
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(result.current).toBe("mobile");
+  });
+});

--- a/frontend/invest/src/hooks/useViewport.ts
+++ b/frontend/invest/src/hooks/useViewport.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+export type Viewport = "mobile" | "compact" | "desktop";
+
+const MOBILE_MAX = 900;
+const COMPACT_MAX = 1200;
+
+function detect(): Viewport {
+  if (typeof window === "undefined") return "desktop";
+  const w = window.innerWidth;
+  if (w < MOBILE_MAX) return "mobile";
+  if (w < COMPACT_MAX) return "compact";
+  return "desktop";
+}
+
+export function useViewport(): Viewport {
+  const [vp, setVp] = useState<Viewport>(() => detect());
+  useEffect(() => {
+    function onResize() {
+      setVp(detect());
+    }
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  return vp;
+}

--- a/frontend/invest/src/mobile/MobileBottomNav.tsx
+++ b/frontend/invest/src/mobile/MobileBottomNav.tsx
@@ -1,0 +1,59 @@
+import { NavLink } from "react-router-dom";
+import { Icon } from "../ds";
+import type { IconName } from "../ds";
+
+interface NavItem {
+  to: string;
+  label: string;
+  icon: IconName;
+  end?: boolean;
+}
+
+// 발견 currently routes to the legacy /app/discover path. Stage 4.2 introduces
+// a canonical /discover route and this entry switches over.
+const ITEMS: NavItem[] = [
+  { to: "/", label: "홈", icon: "home", end: true },
+  { to: "/feed/news", label: "뉴스", icon: "bell" },
+  { to: "/app/discover", label: "발견", icon: "flash" },
+  { to: "/signals", label: "시그널", icon: "chart" },
+  { to: "/calendar", label: "캘린더", icon: "calendar" },
+];
+
+export function MobileBottomNav() {
+  return (
+    <nav
+      data-testid="mobile-bottom-nav"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(5, 1fr)",
+        borderTop: "1px solid var(--divider)",
+        background: "var(--surface)",
+        padding: "6px 0 8px",
+        flexShrink: 0,
+      }}
+    >
+      {ITEMS.map((it) => (
+        <NavLink
+          key={it.to}
+          to={it.to}
+          end={it.end}
+          style={({ isActive }) => ({
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: 2,
+            background: "none",
+            border: "none",
+            padding: 6,
+            textDecoration: "none",
+            color: isActive ? "var(--fg)" : "var(--fg-3)",
+            fontWeight: isActive ? 700 : 600,
+          })}
+        >
+          <Icon name={it.icon} size={20} />
+          <span style={{ fontSize: 10 }}>{it.label}</span>
+        </NavLink>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/invest/src/mobile/MobileBottomNav.tsx
+++ b/frontend/invest/src/mobile/MobileBottomNav.tsx
@@ -23,12 +23,12 @@ export function MobileBottomNav() {
   return (
     <nav
       data-testid="mobile-bottom-nav"
+      className="mobile-bottom-nav"
       style={{
         display: "grid",
         gridTemplateColumns: "repeat(5, 1fr)",
         borderTop: "1px solid var(--divider)",
         background: "var(--surface)",
-        padding: "6px 0 8px",
         flexShrink: 0,
       }}
     >

--- a/frontend/invest/src/mobile/MobileShell.tsx
+++ b/frontend/invest/src/mobile/MobileShell.tsx
@@ -4,18 +4,11 @@ import { MobileBottomNav } from "./MobileBottomNav";
 
 export function MobileShell({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <div
-      data-testid="mobile-shell"
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        flexDirection: "column",
-        background: "var(--bg)",
-        color: "var(--fg)",
-      }}
-    >
+    <div data-testid="mobile-shell" className="mobile-shell">
       <MobileTopBar title={title} />
-      <div style={{ flex: 1, overflow: "auto" }}>{children}</div>
+      <div data-testid="mobile-shell-scroll" className="mobile-shell__scroll">
+        {children}
+      </div>
       <MobileBottomNav />
     </div>
   );

--- a/frontend/invest/src/mobile/MobileShell.tsx
+++ b/frontend/invest/src/mobile/MobileShell.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+import { MobileTopBar } from "./MobileTopBar";
+import { MobileBottomNav } from "./MobileBottomNav";
+
+export function MobileShell({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div
+      data-testid="mobile-shell"
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        background: "var(--bg)",
+        color: "var(--fg)",
+      }}
+    >
+      <MobileTopBar title={title} />
+      <div style={{ flex: 1, overflow: "auto" }}>{children}</div>
+      <MobileBottomNav />
+    </div>
+  );
+}

--- a/frontend/invest/src/mobile/MobileTopBar.tsx
+++ b/frontend/invest/src/mobile/MobileTopBar.tsx
@@ -1,0 +1,28 @@
+import { Icon } from "../ds";
+
+export function MobileTopBar({ title }: { title: string }) {
+  return (
+    <div
+      data-testid="mobile-top-bar"
+      style={{
+        height: 48,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "0 16px",
+        borderBottom: "1px solid var(--divider)",
+        background: "var(--surface)",
+        flexShrink: 0,
+        position: "sticky",
+        top: 0,
+        zIndex: 5,
+      }}
+    >
+      <div style={{ fontSize: 16, fontWeight: 700, letterSpacing: "-0.02em" }}>{title}</div>
+      <div aria-hidden style={{ display: "flex", gap: 6, color: "var(--fg-3)" }}>
+        <Icon name="search" size={18} />
+        <Icon name="bell" size={18} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
@@ -5,13 +5,22 @@ import type { AccountFilterKey } from "../../desktop/LeftContextRail";
 import { RightAccountPanel } from "../../desktop/RightAccountPanel";
 import { useAccountPanel } from "../../desktop/useAccountPanel";
 import { useInvestHome } from "../../hooks/useInvestHome";
+import { useViewport } from "../../hooks/useViewport";
 import { scopeGroupedToSource } from "../../desktop/scopeHoldings";
 import { DesktopHero } from "../../components/home/DesktopHero";
 import { MarketStrip } from "../../components/home/MarketStrip";
 import { HoldingsTable } from "../../components/home/HoldingsTable";
 import { FilterChips } from "../../components/home/FilterChips";
+import { MobileHomePage } from "../mobile/MobileHomePage";
 import type { AssetCategoryKey } from "../../components/AssetCategoryFilter";
 import type { AccountSource, HomeSummary } from "../../types/invest";
+
+// Single canonical /invest home — picks the desktop or mobile renderer
+// from the same data hooks based on viewport width.
+export function InvestHomeRoute() {
+  const viewport = useViewport();
+  return viewport === "mobile" ? <MobileHomePage /> : <DesktopHomePage />;
+}
 
 export function DesktopHomePage() {
   const home = useInvestHome();

--- a/frontend/invest/src/pages/mobile/MobileHomePage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileHomePage.tsx
@@ -1,0 +1,334 @@
+import { useMemo, useState } from "react";
+import { MobileShell } from "../../mobile/MobileShell";
+import { useInvestHome } from "../../hooks/useInvestHome";
+import { useAccountPanel } from "../../desktop/useAccountPanel";
+import { scopeGroupedToSource } from "../../desktop/scopeHoldings";
+import { pillToneForSource } from "../../desktop/AccountSourceTone";
+import { PL, Pill } from "../../ds";
+import type { AccountSource, GroupedHolding, HomeSummary } from "../../types/invest";
+import type { AssetCategoryKey } from "../../components/AssetCategoryFilter";
+
+function fmtKrw(v: number | null | undefined): string {
+  if (v == null) return "—";
+  return `₩${Math.round(v).toLocaleString("ko-KR")}`;
+}
+
+function fmtUsd(v: number | null | undefined): string {
+  if (v == null) return "—";
+  return `$${v.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function fmtQty(qty: number, assetType: GroupedHolding["assetType"]): string {
+  if (assetType === "crypto") return `${qty}`;
+  return `${qty.toLocaleString("ko-KR")}주`;
+}
+
+const CATEGORIES: { key: AssetCategoryKey; label: string }[] = [
+  { key: "all", label: "전체" },
+  { key: "kr_stock", label: "한국주식" },
+  { key: "us_stock", label: "해외주식" },
+  { key: "crypto", label: "코인" },
+];
+
+export function MobileHomePage() {
+  const home = useInvestHome();
+  const panel = useAccountPanel();
+  const [account, setAccount] = useState<"all" | AccountSource>("all");
+  const [category, setCategory] = useState<AssetCategoryKey>("all");
+
+  const data = home.state.status === "ready" ? home.state.data : null;
+
+  const scopedGrouped = useMemo(() => {
+    if (!data) return [];
+    if (account === "all") return data.groupedHoldings;
+    return scopeGroupedToSource(data.groupedHoldings, account);
+  }, [data, account]);
+
+  const filteredScoped = useMemo(() => {
+    return category === "all"
+      ? scopedGrouped
+      : scopedGrouped.filter((g) => g.assetCategory === category);
+  }, [scopedGrouped, category]);
+
+  const summary: HomeSummary | null = useMemo(() => {
+    if (!data) return null;
+    if (account === "all") return data.homeSummary;
+    const acct = data.accounts.find((a) => a.source === account);
+    if (!acct) return data.homeSummary;
+    return {
+      includedSources: [acct.source],
+      excludedSources: [],
+      totalValueKrw: acct.valueKrw,
+      costBasisKrw: acct.costBasisKrw,
+      pnlKrw: acct.pnlKrw,
+      pnlRate: acct.pnlRate,
+    };
+  }, [data, account]);
+
+  return (
+    <MobileShell title="홈">
+      {home.state.status === "loading" && (
+        <div style={{ padding: 32, color: "var(--fg-3)", textAlign: "center" }}>불러오는 중…</div>
+      )}
+      {home.state.status === "error" && (
+        <div style={{ padding: 16, color: "var(--danger)" }}>
+          잠시 후 다시 시도해 주세요.{" "}
+          <button
+            type="button"
+            onClick={home.reload}
+            style={{
+              marginLeft: 8,
+              padding: "4px 10px",
+              borderRadius: 8,
+              border: "1px solid var(--border)",
+              background: "var(--surface)",
+              color: "var(--fg-1)",
+              cursor: "pointer",
+              fontFamily: "inherit",
+              fontSize: 12,
+            }}
+          >
+            재시도
+          </button>
+        </div>
+      )}
+
+      {data && summary && (
+        <div style={{ display: "flex", flexDirection: "column", gap: 14, padding: "14px 0 16px" }}>
+          {/* Hero — single column on mobile */}
+          <section style={{ padding: "0 16px" }} data-testid="mobile-hero">
+            <div style={{ fontSize: 13, fontWeight: 600, color: "var(--fg-3)" }}>
+              내 투자 포트폴리오
+              {account === "all" && data.accounts.length > 0 && ` · ${data.accounts.length}개 계좌`}
+            </div>
+            <div
+              style={{
+                fontSize: 28,
+                fontWeight: 700,
+                marginTop: 2,
+                letterSpacing: "-0.02em",
+                fontFeatureSettings: '"tnum"',
+              }}
+            >
+              {fmtKrw(summary.totalValueKrw)}
+            </div>
+            {summary.pnlKrw != null && summary.pnlRate != null ? (
+              <div style={{ marginTop: 2 }}>
+                <PL value={summary.pnlKrw} pct={summary.pnlRate * 100} size={13} />
+              </div>
+            ) : (
+              <div style={{ marginTop: 2, fontSize: 13, color: "var(--fg-3)" }}>—</div>
+            )}
+            {summary.costBasisKrw != null && (
+              <div style={{ fontSize: 12, color: "var(--fg-3)", marginTop: 4 }}>
+                원금 {fmtKrw(summary.costBasisKrw)}
+              </div>
+            )}
+          </section>
+
+          {/* Account selector — 전체 + per-source pills */}
+          {data.accounts.length > 0 && (
+            <section style={{ padding: "0 16px" }} data-testid="mobile-account-row">
+              <div style={{ display: "flex", gap: 6, overflowX: "auto", paddingBottom: 4 }}>
+                <PillButton on={account === "all"} onClick={() => setAccount("all")}>
+                  전체
+                </PillButton>
+                {data.accounts.map((a) => (
+                  <PillButton
+                    key={a.accountId}
+                    on={account === a.source}
+                    onClick={() => setAccount(a.source)}
+                  >
+                    {a.displayName}
+                  </PillButton>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Category filter chips */}
+          <section style={{ padding: "0 16px" }}>
+            <div style={{ display: "flex", gap: 6, overflowX: "auto", paddingBottom: 4 }}>
+              {CATEGORIES.map((c) => (
+                <PillButton
+                  key={c.key}
+                  on={category === c.key}
+                  onClick={() => setCategory(c.key)}
+                >
+                  {c.label}
+                </PillButton>
+              ))}
+            </div>
+          </section>
+
+          {/* Holdings list */}
+          <section style={{ padding: "0 16px" }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8 }}>
+              <h3 style={{ margin: 0, fontSize: 13, fontWeight: 700, color: "var(--fg)" }}>보유 종목</h3>
+            </div>
+            {filteredScoped.length === 0 ? (
+              <div data-testid="mobile-holdings-empty" style={{ padding: 32, textAlign: "center", color: "var(--fg-3)", fontSize: 13 }}>
+                해당 조건에 보유 종목이 없습니다.
+              </div>
+            ) : (
+              <div style={{ display: "flex", flexDirection: "column" }}>
+                {filteredScoped.map((h) => {
+                  const tone = h.includedSources[0] ? pillToneForSource(h.includedSources[0]) : "paper";
+                  const usd = h.currency === "USD";
+                  const value = h.valueNative ?? h.valueKrw;
+                  return (
+                    <div
+                      key={h.groupId}
+                      data-testid="mobile-holdings-row"
+                      data-category={h.assetCategory}
+                      style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 10,
+                        padding: "10px 0",
+                        borderBottom: "1px solid var(--divider)",
+                      }}
+                    >
+                      <div
+                        aria-hidden
+                        style={{
+                          width: 32,
+                          height: 32,
+                          borderRadius: 8,
+                          flexShrink: 0,
+                          background: `var(--pill-${tone}-bg)`,
+                          color: `var(--pill-${tone}-fg)`,
+                          display: "grid",
+                          placeItems: "center",
+                          fontWeight: 700,
+                          fontSize: 12,
+                        }}
+                      >
+                        {h.displayName.slice(0, 1)}
+                      </div>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div
+                          style={{
+                            fontSize: 14,
+                            fontWeight: 700,
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                            color: "var(--fg)",
+                          }}
+                        >
+                          {h.displayName}
+                        </div>
+                        <div style={{ display: "flex", alignItems: "center", gap: 6, marginTop: 1 }}>
+                          <span style={{ fontSize: 11, color: "var(--fg-3)", fontFeatureSettings: '"tnum"' }}>
+                            {fmtQty(h.totalQuantity, h.assetType)}
+                          </span>
+                          <Pill tone={tone} size="sm">
+                            {tone.toUpperCase()}
+                          </Pill>
+                        </div>
+                      </div>
+                      <div style={{ textAlign: "right", fontFeatureSettings: '"tnum"' }}>
+                        <div style={{ fontSize: 14, fontWeight: 700, color: "var(--fg)" }}>
+                          {usd ? fmtUsd(value) : fmtKrw(value)}
+                        </div>
+                        {h.pnlRate != null ? (
+                          <div
+                            style={{
+                              fontSize: 12,
+                              fontWeight: 700,
+                              color: h.pnlRate >= 0 ? "var(--gain)" : "var(--loss)",
+                            }}
+                          >
+                            <span style={{ fontSize: 9, marginRight: 2 }}>{h.pnlRate >= 0 ? "▲" : "▼"}</span>
+                            {h.pnlRate >= 0 ? "+" : ""}
+                            {(h.pnlRate * 100).toFixed(2)}%
+                          </div>
+                        ) : (
+                          <div style={{ fontSize: 12, color: "var(--fg-3)" }}>—</div>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+
+          {data.meta?.warnings && data.meta.warnings.length > 0 && (
+            <div
+              role="alert"
+              style={{
+                margin: "0 16px",
+                padding: "10px 14px",
+                color: "var(--warn)",
+                background: "var(--warn-soft)",
+                borderRadius: 12,
+                fontSize: 12,
+              }}
+            >
+              {data.meta.warnings.map((w) => `⚠ ${w.source}: ${w.message}`).join(" · ")}
+            </div>
+          )}
+
+          {panel.error && (
+            <div
+              role="alert"
+              style={{
+                margin: "0 16px",
+                padding: "10px 14px",
+                color: "var(--danger)",
+                background: "var(--danger-soft)",
+                borderRadius: 12,
+                fontSize: 12,
+              }}
+            >
+              계좌 정보를 불러오지 못했습니다.{" "}
+              <button
+                type="button"
+                onClick={panel.reload}
+                style={{
+                  marginLeft: 8,
+                  padding: "2px 8px",
+                  borderRadius: 6,
+                  border: "1px solid var(--border)",
+                  background: "var(--surface)",
+                  color: "var(--fg-1)",
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                  fontSize: 11,
+                }}
+              >
+                재시도
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </MobileShell>
+  );
+}
+
+function PillButton({ on, onClick, children }: { on: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        flex: "0 0 auto",
+        padding: "6px 12px",
+        borderRadius: 999,
+        border: "none",
+        background: on ? "var(--fg)" : "var(--surface-2)",
+        color: on ? "#fff" : "var(--fg-2)",
+        fontSize: 12,
+        fontWeight: 600,
+        whiteSpace: "nowrap",
+        cursor: "pointer",
+        fontFamily: "inherit",
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -4,7 +4,7 @@ import { DiscoverIssueDetailPage } from "./pages/DiscoverIssueDetailPage";
 import { DiscoverPage } from "./pages/DiscoverPage";
 import { HomePage } from "./pages/HomePage";
 import { PaperPlaceholderPage } from "./pages/PaperPlaceholderPage";
-import { DesktopHomePage } from "./pages/desktop/DesktopHomePage";
+import { InvestHomeRoute } from "./pages/desktop/DesktopHomePage";
 import { DesktopFeedNewsPage } from "./pages/desktop/DesktopFeedNewsPage";
 import { DesktopSignalsPage } from "./pages/desktop/DesktopSignalsPage";
 import { DesktopCalendarPage } from "./pages/desktop/DesktopCalendarPage";
@@ -12,12 +12,15 @@ import { DesktopScreenerPage } from "./pages/desktop/DesktopScreenerPage";
 
 export const router = createBrowserRouter(
   [
-    { path: "/", element: <DesktopHomePage /> },
+    // Canonical /invest routes — the home view is responsive
+    // (DesktopHomePage at >=900px, MobileHomePage below).
+    { path: "/", element: <InvestHomeRoute /> },
     { path: "/feed/news", element: <DesktopFeedNewsPage /> },
     { path: "/signals", element: <DesktopSignalsPage /> },
     { path: "/calendar", element: <DesktopCalendarPage /> },
     { path: "/screener", element: <DesktopScreenerPage /> },
 
+    // Legacy /invest/app/* surface — preserved until Stage 6 retires it.
     { path: "/app", element: <HomePage /> },
     { path: "/app/paper", element: <PaperPlaceholderPage /> },
     { path: "/app/paper/:variant", element: <PaperPlaceholderPage /> },

--- a/frontend/invest/src/styles.css
+++ b/frontend/invest/src/styles.css
@@ -38,3 +38,45 @@ body,
   color: var(--fg-3);
   font-size: var(--text-tiny);
 }
+
+/* ---------- Mobile shell (responsive /invest home) ----------
+   Pins the shell to the viewport so the bottom nav stays anchored
+   even when the scrollable content is taller than the viewport.
+   - height pair: 100vh fallback for legacy browsers, 100dvh for
+     modern (excludes browser chrome that comes/goes on iOS Safari
+     scroll), so the latter wins where supported.
+   - overflow: hidden on the shell prevents the page itself from
+     scrolling — only the inner scroll region scrolls.
+   - .mobile-shell__scroll uses flex: 1 + min-height: 0 so the
+     flex child is allowed to shrink below its content height,
+     which is what gives the bottom nav its fixed slot.
+   ---------------------------------------------------------- */
+.mobile-shell {
+  height: 100vh;
+  height: 100dvh;
+  max-height: 100vh;
+  max-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+.mobile-shell__scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Bottom nav lives outside the scroll region (see .mobile-shell). The
+   bottom padding respects env(safe-area-inset-bottom) so the nav lifts
+   off the iOS home-indicator gesture bar where the inset is exposed,
+   while still keeping a sane minimum on devices that don't expose it. */
+.mobile-bottom-nav {
+  padding-top: 6px;
+  padding-bottom: 8px;
+  padding-bottom: max(8px, env(safe-area-inset-bottom, 0px));
+}


### PR DESCRIPTION
## Summary

Stage 3 of the `/invest` design-system migration plan
(`docs/plans/2026-05-08-invest-design-system-migration-implementation-plan.md`),
on top of Stage 2 (#726, already merged).

The canonical `/invest` home is now responsive — narrow viewports
render the mobile layout from `MobileView.jsx`, ≥900px keeps the
desktop view from Stage 2. Both surfaces share the same `useInvestHome`
+ `useAccountPanel` data hooks and the `scopeGroupedToSource` helper,
so account/category filtering produces the same scoped slice on
either side.

### What's added
- **`hooks/useViewport.ts`** — returns `'mobile' | 'compact' | 'desktop'`
  from `window.innerWidth` (<900 / 900–1199 / ≥1200), wired to a
  resize listener. 4 unit tests including a resize transition.
- **`mobile/MobileShell.tsx`** + `MobileTopBar.tsx` + `MobileBottomNav.tsx`
  — port of the bundle's mobile chrome. Sticky 48px top bar on
  `--surface`, scrollable content, 5-tab bottom nav. NavLinks use
  `--fg` (active) / `--fg-3` (inactive) per the Stage 1 token contract.
  3 unit tests on the bottom nav.
- **`pages/mobile/MobileHomePage.tsx`** — full mobile home view:
  hero portfolio summary, horizontally-scrolling account selector
  pills, category filter chips, holdings list with avatar tiles +
  source pills + Korean P/L convention. `data-testid` hooks:
  `mobile-hero`, `mobile-account-row`, `mobile-holdings-row`,
  `mobile-holdings-empty`. Empty / error / warning states use the
  Stage 1 tokens.
- **`pages/desktop/DesktopHomePage.tsx`** — exports a new
  `InvestHomeRoute` dispatcher next to the existing
  `DesktopHomePage`. Dispatcher reads `useViewport()` and picks
  `MobileHomePage` on mobile, `DesktopHomePage` otherwise.
- **`routes.tsx`** — `/` now wires to `InvestHomeRoute`. Legacy
  `/app` still renders the old `HomePage` for backwards compat;
  Stage 6 retires it via redirects.
- **`__tests__/InvestHomeRoute.test.tsx`** — mocks the data hooks
  so the dispatcher renders its loading branch synchronously, then
  asserts `desktop-shell` at 1280px and `mobile-shell` at 600px.

### Out of scope (deferred)
- Stages 4 / 5 add canonical responsive renderers for `/feed/news`,
  `/discover`, `/signals`, `/calendar`. Those routes still render
  desktop-only in this PR.
- Stage 6 wires legacy `/app/*` redirects.
- News-route dark literals from #722 are left for Stage 4.1.

## Test Plan

- [x] `cd frontend/invest && npm run typecheck` — PASS
- [x] `cd frontend/invest && npm test -- --run` — 27 files / 88 tests PASS
      (existing 79 + 9 new across useViewport, MobileBottomNav, InvestHomeRoute)
- [x] `cd frontend/invest && npm run build` — PASS (`dist/assets/index-*.css 8.84 kB`,
      JS 367 kB)

### Visual smoke

Vite dev base is `/invest/app/`, so `npm run dev` serves at
**`http://127.0.0.1:5174/invest/app/`** (legacy mobile entry). The
canonical responsive home is reached by client-routing from there
to `/`. In production / native deploys the canonical entry is
`/invest/`.

- [ ] Open `npm run dev` → `http://127.0.0.1:5174/invest/app/` → SPA
      navigate to `/` → resize between <900px and ≥1200px → confirm
      shell swap (mobile bottom nav vs. desktop 3-column)
- [ ] Same account / category filter scoping behaves consistently
      across mobile + desktop (relies on `scopeGroupedToSource`)
- [ ] Korean P/L convention preserved (red ▲ gain, blue ▼ loss)

## Scope-out / safety

- Read-only frontend work. No broker / order / watch / market-events
  mutation paths touched.
- All hooks (`useInvestHome`, `useAccountPanel`) and types unchanged.
- Legacy `/invest/app` still works for backwards compat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added responsive viewport detection and routing that switches between mobile and desktop layouts
  - New mobile UI: Home page, top bar (search/notifications), bottom navigation for quick access

* **Style**
  - Mobile shell styles and scroll layout with safe-area inset support

* **Tests**
  - Added tests covering viewport detection, mobile shell/layout, bottom navigation, and responsive rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->