### PR TITLE
feat(invest): news + discover + signals + screener polish (Stage 4)

### DIFF
--- a/frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx
@@ -88,7 +88,9 @@ test("renders an issue chip linked to the issue detail page when issueId is pres
   );
   const chip = await screen.findByTestId("feed-item-issue-chip");
   expect(chip).toHaveTextContent("삼성전자 실적 발표");
-  expect(chip).toHaveAttribute("href", "/invest/app/discover/issues/iss-xyz");
+  // Chip points at the canonical /discover route (Stage 4.2). Legacy
+  // /app/discover/issues/:id remains routable for backwards compat.
+  expect(chip).toHaveAttribute("href", "/invest/discover/issues/iss-xyz");
   expect(chip).toHaveAttribute("data-issue-id", "iss-xyz");
 });
 

--- a/frontend/invest/src/__tests__/DesktopSignalsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopSignalsPage.test.tsx
@@ -39,6 +39,10 @@ test("does not render buy/sell CTA buttons", async () => {
     </MemoryRouter>,
   );
   await waitFor(() => expect(screen.getAllByTestId("signal-list-item")).toHaveLength(1));
-  expect(screen.queryByText(/매수/)).not.toBeInTheDocument();
-  expect(screen.queryByText(/매도/)).not.toBeInTheDocument();
+  // The decision label ('매수' / '매도') renders as a decorative status pill
+  // (a <span>, not actionable). The safety guarantee here is that no
+  // role=button is exposed whose accessible name implies an order CTA.
+  expect(screen.queryByRole("button", { name: "매수" })).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: "매도" })).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /매수 주문|매도 주문/ })).not.toBeInTheDocument();
 });

--- a/frontend/invest/src/components/discover/IssueCard.tsx
+++ b/frontend/invest/src/components/discover/IssueCard.tsx
@@ -1,0 +1,121 @@
+import { Link } from "react-router-dom";
+import type { MarketIssue } from "../../types/newsIssues";
+import { Pill } from "../../ds";
+import { describeDirection } from "./severity";
+import { formatRelativeTime } from "../../format/relativeTime";
+
+export function IssueCard({
+  issue,
+  expanded,
+  onToggle,
+  hrefPrefix = "/discover/issues",
+}: {
+  issue: MarketIssue;
+  expanded: boolean;
+  onToggle: () => void;
+  hrefPrefix?: string;
+}) {
+  const dir = describeDirection(issue.direction);
+  const ago = formatRelativeTime(issue.updated_at) ?? "방금";
+
+  return (
+    <li
+      data-testid="issue-card"
+      data-issue-id={issue.id}
+      data-direction={issue.direction}
+      style={{
+        background: "var(--surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 16,
+        boxShadow: "var(--shadow-1)",
+        listStyle: "none",
+      }}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        style={{
+          display: "flex",
+          gap: 14,
+          padding: 16,
+          width: "100%",
+          textAlign: "left",
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          fontFamily: "inherit",
+          color: "var(--fg)",
+        }}
+        aria-expanded={expanded}
+      >
+        <div
+          style={{
+            minWidth: 28,
+            fontSize: 18,
+            fontWeight: 800,
+            color: "var(--fg-3)",
+            fontFeatureSettings: '"tnum"',
+          }}
+          aria-label={`순위 ${issue.rank}`}
+        >
+          {issue.rank}
+        </div>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <span style={{ color: dir.color, fontWeight: 700 }} aria-hidden>
+              {dir.glyph}
+            </span>
+            <Link
+              to={`${hrefPrefix}/${issue.id}`}
+              data-testid="issue-card-detail-link"
+              onClick={(e) => e.stopPropagation()}
+              style={{
+                fontSize: 15,
+                fontWeight: 700,
+                color: "var(--fg)",
+                textDecoration: "none",
+                lineHeight: 1.4,
+              }}
+            >
+              {issue.issue_title}
+            </Link>
+          </div>
+          {issue.subtitle && (
+            <div style={{ fontSize: 13, color: "var(--fg-3)", marginTop: 4, lineHeight: 1.45 }}>{issue.subtitle}</div>
+          )}
+          <div style={{ fontSize: 12, color: "var(--fg-3)", marginTop: 8, display: "flex", gap: 10 }}>
+            <span>{issue.source_count}개 출처</span>
+            <span>· 기사 {issue.article_count}개</span>
+            <span>· {ago}</span>
+          </div>
+
+          {expanded && issue.summary && (
+            <div
+              data-testid="issue-card-summary"
+              style={{
+                marginTop: 12,
+                paddingTop: 12,
+                borderTop: "1px solid var(--divider)",
+                fontSize: 14,
+                color: "var(--fg-1)",
+                lineHeight: 1.6,
+              }}
+            >
+              {issue.summary}
+              {issue.related_symbols.length > 0 && (
+                <div style={{ marginTop: 10, display: "flex", gap: 6, flexWrap: "wrap" }}>
+                  {issue.related_symbols.map((s) => (
+                    <Pill key={`${s.market}:${s.symbol}`} tone="accent" size="sm">
+                      {s.canonical_name}
+                    </Pill>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </button>
+    </li>
+  );
+}

--- a/frontend/invest/src/components/news/NewsCard.tsx
+++ b/frontend/invest/src/components/news/NewsCard.tsx
@@ -1,0 +1,165 @@
+import { Link } from "react-router-dom";
+import type { FeedNewsItem } from "../../types/feedNews";
+import type { MarketIssue } from "../../types/newsIssues";
+import { Pill } from "../../ds";
+
+const RELATION_LABEL: Record<string, string> = {
+  held: "보유",
+  watchlist: "관심",
+  both: "보유·관심",
+};
+
+const MARKET_LABEL: Record<FeedNewsItem["market"], string> = {
+  kr: "KR",
+  us: "US",
+  crypto: "CRYPTO",
+};
+
+interface NewsCardProps {
+  item: FeedNewsItem;
+  issue?: MarketIssue;
+  open: boolean;
+  onToggle: () => void;
+  // Path prefix to the canonical discover route that owns issue detail pages.
+  // The legacy /app/discover/issues/:id path remains reachable while Stage 6
+  // is pending so existing bookmarks keep working, but new internal links
+  // point at /discover/issues/:id.
+  discoverIssueHrefPrefix?: string;
+}
+
+export function NewsCard({
+  item,
+  issue,
+  open,
+  onToggle,
+  discoverIssueHrefPrefix = "/discover/issues",
+}: NewsCardProps) {
+  const relationLabel = item.relation !== "none" ? RELATION_LABEL[item.relation] : null;
+  const relationTone = item.relation === "held" || item.relation === "both" ? "accent" : "kis";
+
+  return (
+    <li
+      data-testid="feed-item"
+      data-relation={item.relation}
+      style={{
+        background: "var(--surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 14,
+        boxShadow: "var(--shadow-1)",
+        padding: 16,
+        listStyle: "none",
+      }}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        style={{
+          background: "none",
+          border: "none",
+          cursor: "pointer",
+          fontFamily: "inherit",
+          color: "var(--fg)",
+          padding: 0,
+          width: "100%",
+          textAlign: "left",
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          {relationLabel && (
+            <Pill tone={relationTone} size="sm">
+              {relationLabel}
+            </Pill>
+          )}
+          <div style={{ fontSize: 15, fontWeight: 700, lineHeight: 1.4, flex: 1, minWidth: 0 }}>{item.title}</div>
+        </div>
+        <div style={{ fontSize: 12, color: "var(--fg-3)", marginTop: 6 }}>
+          {item.publisher ?? "—"} · {MARKET_LABEL[item.market]}
+        </div>
+      </button>
+
+      {issue && (
+        <Link
+          to={`${discoverIssueHrefPrefix}/${issue.id}`}
+          data-testid="feed-item-issue-chip"
+          data-issue-id={issue.id}
+          aria-label={`이슈 링크: ${issue.issue_title}`}
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            marginTop: 8,
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 6,
+            padding: "2px 10px",
+            borderRadius: 999,
+            background: "var(--accent-soft)",
+            color: "var(--accent-press)",
+            fontSize: 11,
+            fontWeight: 600,
+            textDecoration: "none",
+            maxWidth: "100%",
+          }}
+        >
+          <span aria-hidden style={{ fontSize: 9 }}>●</span>
+          <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            이슈 · {issue.issue_title}
+          </span>
+        </Link>
+      )}
+
+      {item.relatedSymbols.length > 0 && (
+        <div
+          data-testid="feed-item-related-symbols"
+          style={{ marginTop: 8, display: "flex", flexWrap: "wrap", gap: 6 }}
+        >
+          {item.relatedSymbols.map((symbol) => (
+            <span
+              key={`${symbol.market}:${symbol.symbol}`}
+              data-testid="feed-item-related-symbol-chip"
+              data-symbol={symbol.symbol}
+              data-market={symbol.market}
+              data-relation={symbol.relation ?? "none"}
+              title={
+                symbol.matchedTerm
+                  ? `${symbol.matchReason ?? "matched"}: ${symbol.matchedTerm}`
+                  : undefined
+              }
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+                padding: "2px 8px",
+                borderRadius: 999,
+                border: "1px solid var(--border)",
+                background: "var(--surface-2)",
+                color: "var(--fg-2)",
+                fontSize: 11,
+                fontFamily: "var(--font-mono)",
+              }}
+            >
+              <strong style={{ color: "var(--fg)", fontWeight: 700 }}>{symbol.symbol}</strong>
+              <span style={{ fontFamily: "var(--font-sans)" }}>{symbol.displayName}</span>
+              {symbol.relation && symbol.relation !== "none" && (
+                <span style={{ fontFamily: "var(--font-sans)" }}>[{symbol.relation}]</span>
+              )}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {open && item.summarySnippet && (
+        <div
+          style={{
+            marginTop: 10,
+            paddingTop: 10,
+            borderTop: "1px solid var(--divider)",
+            fontSize: 13,
+            color: "var(--fg-2)",
+            lineHeight: 1.55,
+          }}
+        >
+          {item.summarySnippet}
+        </div>
+      )}
+    </li>
+  );
+}

--- a/frontend/invest/src/components/news/NewsTabs.tsx
+++ b/frontend/invest/src/components/news/NewsTabs.tsx
@@ -1,0 +1,97 @@
+import type { FeedTab } from "../../types/feedNews";
+
+export const NEWS_TABS: { key: FeedTab; label: string }[] = [
+  { key: "top", label: "주요" },
+  { key: "latest", label: "최신" },
+  { key: "hot", label: "핫이슈" },
+  { key: "holdings", label: "보유" },
+  { key: "watchlist", label: "관심" },
+  { key: "kr", label: "국내" },
+  { key: "us", label: "해외" },
+  { key: "crypto", label: "크립토" },
+];
+
+export function NewsTabs({
+  value,
+  onChange,
+  variant = "underline",
+}: {
+  value: FeedTab;
+  onChange: (tab: FeedTab) => void;
+  variant?: "underline" | "pill-row";
+}) {
+  if (variant === "pill-row") {
+    return (
+      <div
+        data-testid="news-tabs"
+        style={{ display: "flex", gap: 6, overflowX: "auto", paddingBottom: 4 }}
+      >
+        {NEWS_TABS.map((t) => {
+          const active = t.key === value;
+          return (
+            <button
+              key={t.key}
+              data-testid={`tab-${t.key}`}
+              onClick={() => onChange(t.key)}
+              style={{
+                flex: "0 0 auto",
+                padding: "6px 12px",
+                border: "none",
+                borderRadius: 999,
+                cursor: "pointer",
+                background: active ? "var(--fg)" : "var(--surface-2)",
+                color: active ? "#fff" : "var(--fg-2)",
+                fontWeight: 600,
+                fontSize: 12,
+                fontFamily: "inherit",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // Underline tab strip per the bundle's NewsView.jsx.
+  return (
+    <div
+      data-testid="news-tabs"
+      style={{
+        display: "flex",
+        gap: 4,
+        borderBottom: "1px solid var(--divider)",
+        overflowX: "auto",
+      }}
+    >
+      {NEWS_TABS.map((t) => {
+        const active = t.key === value;
+        return (
+          <button
+            key={t.key}
+            data-testid={`tab-${t.key}`}
+            onClick={() => onChange(t.key)}
+            style={{
+              padding: "10px 14px",
+              border: "none",
+              background: "transparent",
+              color: active ? "var(--fg)" : "var(--fg-3)",
+              borderBottom: `2px solid ${active ? "var(--fg)" : "transparent"}`,
+              fontWeight: 600,
+              fontSize: 14,
+              fontFamily: "inherit",
+              cursor: "pointer",
+              marginBottom: -1,
+              whiteSpace: "nowrap",
+              flexShrink: 0,
+            }}
+          >
+            {t.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/invest/src/components/signals/SignalCard.tsx
+++ b/frontend/invest/src/components/signals/SignalCard.tsx
@@ -1,0 +1,129 @@
+import type { SignalCard as SignalCardData } from "../../types/signals";
+import { Pill } from "../../ds";
+import { formatRelativeTime } from "../../format/relativeTime";
+
+const MARKET_LABEL: Record<SignalCardData["market"], string> = {
+  kr: "KR",
+  us: "US",
+  crypto: "CRYPTO",
+};
+
+const DECISION_LABEL: Record<NonNullable<SignalCardData["decisionLabel"]>, string> = {
+  buy: "매수",
+  sell: "매도",
+  hold: "보유",
+  watch: "관찰",
+  neutral: "중립",
+};
+
+const DECISION_TONE: Record<NonNullable<SignalCardData["decisionLabel"]>, "gain" | "loss" | "warn" | "paper"> = {
+  buy: "gain",
+  sell: "loss",
+  hold: "paper",
+  watch: "warn",
+  neutral: "paper",
+};
+
+const RELATION_LABEL: Record<SignalCardData["relation"], string | null> = {
+  held: "보유",
+  watchlist: "관심",
+  both: "보유·관심",
+  none: null,
+};
+
+export function SignalCard({
+  signal,
+  selected,
+  onSelect,
+  variant = "list",
+}: {
+  signal: SignalCardData;
+  selected?: boolean;
+  onSelect?: () => void;
+  variant?: "list" | "grid";
+}) {
+  const decision = signal.decisionLabel ?? "neutral";
+  const tone = DECISION_TONE[decision];
+  const relationLabel = RELATION_LABEL[signal.relation];
+  const ago = formatRelativeTime(signal.generatedAt) ?? "방금";
+
+  const padding = variant === "grid" ? 16 : 12;
+  const titleSize = variant === "grid" ? 15 : 14;
+
+  return (
+    <button
+      type="button"
+      data-testid="signal-list-item"
+      data-relation={signal.relation}
+      data-decision={decision}
+      // Only the signal title flows into the accessible name. The decision /
+      // relation pills inside are decorative status indicators, not order
+      // CTAs — keeping them out of the button's a11y name avoids screen
+      // readers announcing this button as a "매수" action.
+      aria-label={`${signal.title} 시그널 보기`}
+      onClick={onSelect}
+      style={{
+        width: "100%",
+        textAlign: "left",
+        padding,
+        borderRadius: 12,
+        background: selected ? "var(--surface-2)" : "var(--surface)",
+        border: `1px solid ${selected ? "var(--accent)" : "var(--border)"}`,
+        boxShadow: selected ? "var(--shadow-2)" : "var(--shadow-1)",
+        color: "var(--fg)",
+        cursor: onSelect ? "pointer" : "default",
+        fontFamily: "inherit",
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+        transition: "border-color 120ms cubic-bezier(0.2,0,0,1), box-shadow 120ms cubic-bezier(0.2,0,0,1)",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <Pill tone={tone} size="sm">
+          {DECISION_LABEL[decision]}
+        </Pill>
+        {relationLabel && (
+          <Pill tone="accent" size="sm">
+            {relationLabel}
+          </Pill>
+        )}
+        <span style={{ fontSize: 11, color: "var(--fg-3)", marginLeft: "auto" }}>{MARKET_LABEL[signal.market]}</span>
+      </div>
+
+      <div style={{ fontSize: titleSize, fontWeight: 700, lineHeight: 1.4, color: "var(--fg)" }}>
+        {signal.title}
+      </div>
+
+      {signal.summary && (
+        <div
+          style={{
+            fontSize: 12,
+            color: "var(--fg-2)",
+            lineHeight: 1.5,
+            display: "-webkit-box",
+            WebkitBoxOrient: "vertical",
+            WebkitLineClamp: 2,
+            overflow: "hidden",
+          }}
+        >
+          {signal.summary}
+        </div>
+      )}
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          fontSize: 11,
+          color: "var(--fg-3)",
+          fontFeatureSettings: '"tnum"',
+        }}
+      >
+        {signal.confidence != null && <span>신뢰도 {signal.confidence}%</span>}
+        <span>{ago}</span>
+      </div>
+    </button>
+  );
+}

--- a/frontend/invest/src/desktop/DesktopHeader.tsx
+++ b/frontend/invest/src/desktop/DesktopHeader.tsx
@@ -4,9 +4,7 @@ import { Icon } from "../ds";
 const LINKS: { to: string; label: string; end?: boolean }[] = [
   { to: "/", label: "홈", end: true },
   { to: "/feed/news", label: "뉴스" },
-  // 발견 currently points at the legacy mobile route. Stage 4.2 introduces a
-  // canonical /discover and this link switches to it.
-  { to: "/app/discover", label: "발견" },
+  { to: "/discover", label: "발견" },
   { to: "/signals", label: "시그널" },
   { to: "/calendar", label: "캘린더" },
   { to: "/screener", label: "골라보기" },

--- a/frontend/invest/src/desktop/screener/screener.css
+++ b/frontend/invest/src/desktop/screener/screener.css
@@ -1,50 +1,51 @@
 .screener-sidebar { display: flex; flex-direction: column; gap: 16px; padding-right: 8px; }
 .screener-sidebar-section { display: flex; flex-direction: column; gap: 6px; }
-.screener-sidebar-heading { font-size: 11px; color: var(--muted, #8A8F98); text-transform: uppercase; letter-spacing: 0.04em; }
-.screener-sidebar-link { background: transparent; border: 1px dashed var(--surface-2, #1f232b); padding: 8px 10px; text-align: left; border-radius: 6px; color: var(--muted, #8A8F98); cursor: not-allowed; font-size: 13px; }
+.screener-sidebar-heading { font-size: 11px; color: var(--fg-3); text-transform: uppercase; letter-spacing: 0.04em; }
+.screener-sidebar-link { background: transparent; border: 1px dashed var(--border); padding: 8px 10px; text-align: left; border-radius: 6px; color: var(--fg-3); cursor: not-allowed; font-size: 13px; }
 .screener-preset-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 2px; }
-.screener-preset-item, .screener-preset-item-active { width: 100%; text-align: left; background: transparent; border: 0; padding: 8px 10px; border-radius: 6px; display: flex; justify-content: space-between; align-items: center; cursor: pointer; color: var(--text, #E6E8EB); font-size: 13px; }
-.screener-preset-item:hover { background: var(--surface, #181B22); }
-.screener-preset-item-active { background: var(--surface-2, #1f232b); color: #fff; font-weight: 600; }
-.screener-preset-badge { font-size: 10px; background: var(--pill-up, #2a2218); color: var(--pill-up-fg, #f6c177); border-radius: 4px; padding: 2px 6px; }
+.screener-preset-item, .screener-preset-item-active { width: 100%; text-align: left; background: transparent; border: 0; padding: 8px 10px; border-radius: 6px; display: flex; justify-content: space-between; align-items: center; cursor: pointer; color: var(--fg-1); font-size: 13px; font-family: inherit; }
+.screener-preset-item:hover { background: var(--surface-2); }
+.screener-preset-item-active { background: var(--surface-2); color: var(--fg); font-weight: 700; }
+.screener-preset-badge { font-size: 10px; background: var(--accent-soft); color: var(--accent-press); border-radius: 4px; padding: 2px 6px; font-weight: 600; }
 
-.screener-filter-bar { display: flex; flex-direction: column; gap: 12px; padding-bottom: 12px; border-bottom: 1px solid var(--surface-2, #1f232b); margin-bottom: 16px; }
-.screener-filter-title { font-size: 22px; margin: 0; color: var(--text, #E6E8EB); }
-.screener-filter-description { color: var(--muted, #8A8F98); margin: 4px 0 0; font-size: 13px; }
+.screener-filter-bar { display: flex; flex-direction: column; gap: 12px; padding-bottom: 12px; border-bottom: 1px solid var(--divider); margin-bottom: 16px; }
+.screener-filter-title { font-size: 22px; margin: 0; color: var(--fg); font-weight: 800; letter-spacing: -0.02em; }
+.screener-filter-description { color: var(--fg-3); margin: 4px 0 0; font-size: 13px; }
 .screener-chip-row { display: flex; flex-wrap: wrap; gap: 6px; }
-.screener-chip-add { background: var(--surface, #181B22); border: 0; padding: 6px 10px; border-radius: 999px; cursor: pointer; color: var(--text, #E6E8EB); font-size: 12px; }
-.screener-chip { background: var(--surface, #181B22); color: var(--text, #E6E8EB); padding: 6px 10px; border-radius: 999px; font-size: 12px; }
-.screener-chip-detail { color: var(--muted, #8A8F98); margin-left: 4px; }
-.screener-result-count { color: var(--muted, #8A8F98); font-size: 13px; }
-.screener-result-count strong { color: var(--text, #E6E8EB); }
+.screener-chip-add { background: var(--surface-2); border: 0; padding: 6px 10px; border-radius: 999px; cursor: pointer; color: var(--fg-1); font-size: 12px; font-family: inherit; }
+.screener-chip { background: var(--surface-2); color: var(--fg-1); padding: 6px 10px; border-radius: 999px; font-size: 12px; }
+.screener-chip-detail { color: var(--fg-3); margin-left: 4px; }
+.screener-result-count { color: var(--fg-3); font-size: 13px; }
+.screener-result-count strong { color: var(--fg); }
 
-.screener-warnings { list-style: none; padding: 8px 12px; margin: 0 0 12px; background: var(--surface, #181B22); border-radius: 6px; color: var(--warn, #f6c177); font-size: 12px; display: flex; flex-direction: column; gap: 4px; }
+.screener-warnings { list-style: none; padding: 8px 12px; margin: 0 0 12px; background: var(--warn-soft); border: 1px solid var(--border); border-radius: 8px; color: var(--warn); font-size: 12px; display: flex; flex-direction: column; gap: 4px; }
 
-.screener-table { width: 100%; border-collapse: collapse; font-size: 13px; }
-.screener-table th, .screener-table td { padding: 10px 8px; text-align: left; border-bottom: 1px solid var(--surface-2, #1f232b); }
-.screener-table th { color: var(--muted, #8A8F98); font-weight: 500; font-size: 12px; }
+.screener-table { width: 100%; border-collapse: collapse; font-size: 13px; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
+.screener-table th, .screener-table td { padding: 10px 12px; text-align: left; border-bottom: 1px solid var(--divider); }
+.screener-table th { color: var(--fg-3); font-weight: 600; font-size: 12px; background: var(--bg-alt); }
+.screener-table tr:last-child td { border-bottom: 0; }
 .screener-name-cell { display: flex; flex-direction: column; gap: 2px; }
-.screener-symbol-badge { font-size: 11px; color: var(--muted, #8A8F98); }
-.screener-symbol-name { font-weight: 600; color: var(--text, #E6E8EB); }
-.screener-change-up { color: var(--gain, #FF5C5C); }
-.screener-change-down { color: var(--loss, #3B82F6); }
-.screener-change-flat { color: var(--muted, #8A8F98); }
+.screener-symbol-badge { font-size: 11px; color: var(--fg-3); font-family: var(--font-mono); }
+.screener-symbol-name { font-weight: 700; color: var(--fg); }
+.screener-change-up { color: var(--gain); }
+.screener-change-down { color: var(--loss); }
+.screener-change-flat { color: var(--flat); }
 .screener-change-amount { color: inherit; opacity: 0.7; font-size: 11px; margin-left: 4px; }
-.screener-heart-on { color: var(--gain, #FF5C5C); }
-.screener-heart-off { color: var(--surface-2, #1f232b); }
-.screener-empty { padding: 32px; text-align: center; color: var(--muted, #8A8F98); }
+.screener-heart-on { color: var(--gain); }
+.screener-heart-off { color: var(--fg-4); }
+.screener-empty { padding: 32px; text-align: center; color: var(--fg-3); }
 
-.screener-modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; z-index: 50; }
-.screener-modal { background: var(--surface, #181B22); width: 720px; max-width: 90vw; max-height: 80vh; border-radius: 12px; display: flex; flex-direction: column; overflow: hidden; color: var(--text, #E6E8EB); }
-.screener-modal-header { display: flex; justify-content: space-between; align-items: center; padding: 16px; border-bottom: 1px solid var(--surface-2, #1f232b); }
-.screener-modal-header h3 { margin: 0; font-size: 16px; }
-.screener-modal-close { background: transparent; border: 0; color: var(--text, #E6E8EB); cursor: pointer; font-size: 18px; }
-.screener-modal-tabs { display: flex; gap: 4px; padding: 8px 16px; border-bottom: 1px solid var(--surface-2, #1f232b); }
-.screener-modal-tab, .screener-modal-tab-active { background: transparent; border: 0; padding: 6px 10px; border-radius: 6px; color: var(--muted, #8A8F98); cursor: not-allowed; font-size: 13px; }
-.screener-modal-tab-active { color: var(--text, #E6E8EB); font-weight: 600; }
-.screener-modal-body { padding: 16px; overflow-y: auto; flex: 1; }
-.screener-modal-notice { color: var(--muted, #8A8F98); margin: 0 0 12px; font-size: 13px; }
+.screener-modal-backdrop { position: fixed; inset: 0; background: rgba(15, 20, 28, 0.32); display: flex; align-items: center; justify-content: center; z-index: 50; }
+.screener-modal { background: var(--surface); width: 720px; max-width: 90vw; max-height: 80vh; border-radius: 16px; display: flex; flex-direction: column; overflow: hidden; color: var(--fg); box-shadow: var(--shadow-3); }
+.screener-modal-header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; border-bottom: 1px solid var(--divider); }
+.screener-modal-header h3 { margin: 0; font-size: 16px; font-weight: 700; }
+.screener-modal-close { background: var(--surface-2); border: 0; color: var(--fg-1); cursor: pointer; font-size: 18px; width: 32px; height: 32px; border-radius: 8px; display: grid; place-items: center; }
+.screener-modal-tabs { display: flex; gap: 4px; padding: 8px 20px; border-bottom: 1px solid var(--divider); }
+.screener-modal-tab, .screener-modal-tab-active { background: transparent; border: 0; padding: 6px 10px; border-radius: 6px; color: var(--fg-3); cursor: not-allowed; font-size: 13px; font-family: inherit; }
+.screener-modal-tab-active { color: var(--fg); font-weight: 700; }
+.screener-modal-body { padding: 16px 20px; overflow-y: auto; flex: 1; }
+.screener-modal-notice { color: var(--fg-3); margin: 0 0 12px; font-size: 13px; }
 .screener-modal-category-list { list-style: none; padding: 0; margin: 0; display: flex; flex-wrap: wrap; gap: 8px; }
-.screener-modal-category-item { background: var(--surface-2, #1f232b); padding: 6px 10px; border-radius: 999px; font-size: 12px; }
-.screener-modal-footer { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 16px; border-top: 1px solid var(--surface-2, #1f232b); }
-.screener-modal-footer button { background: var(--surface-2, #1f232b); color: var(--muted, #8A8F98); border: 0; padding: 6px 12px; border-radius: 6px; cursor: not-allowed; font-size: 12px; }
+.screener-modal-category-item { background: var(--surface-2); color: var(--fg-1); padding: 6px 10px; border-radius: 999px; font-size: 12px; }
+.screener-modal-footer { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 20px; border-top: 1px solid var(--divider); }
+.screener-modal-footer button { background: var(--surface-2); color: var(--fg-3); border: 0; padding: 6px 12px; border-radius: 8px; cursor: not-allowed; font-size: 12px; font-family: inherit; }

--- a/frontend/invest/src/mobile/MobileBottomNav.tsx
+++ b/frontend/invest/src/mobile/MobileBottomNav.tsx
@@ -9,12 +9,10 @@ interface NavItem {
   end?: boolean;
 }
 
-// 발견 currently routes to the legacy /app/discover path. Stage 4.2 introduces
-// a canonical /discover route and this entry switches over.
 const ITEMS: NavItem[] = [
   { to: "/", label: "홈", icon: "home", end: true },
   { to: "/feed/news", label: "뉴스", icon: "bell" },
-  { to: "/app/discover", label: "발견", icon: "flash" },
+  { to: "/discover", label: "발견", icon: "flash" },
   { to: "/signals", label: "시그널", icon: "chart" },
   { to: "/calendar", label: "캘린더", icon: "calendar" },
 ];

--- a/frontend/invest/src/pages/desktop/DesktopDiscoverPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopDiscoverPage.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { DesktopShell } from "../../desktop/DesktopShell";
+import { RightAccountPanel } from "../../desktop/RightAccountPanel";
+import { useAccountPanel } from "../../desktop/useAccountPanel";
+import { useViewport } from "../../hooks/useViewport";
+import { useNewsIssues } from "../../hooks/useNewsIssues";
+import { sortMarketIssues } from "../../components/discover/severity";
+import { IssueCard } from "../../components/discover/IssueCard";
+import { Card, Icon, Pill } from "../../ds";
+import { MobileDiscoverPage } from "../mobile/MobileDiscoverPage";
+
+export function InvestDiscoverRoute() {
+  return useViewport() === "mobile" ? <MobileDiscoverPage /> : <DesktopDiscoverPage />;
+}
+
+export function DesktopDiscoverPage() {
+  const panel = useAccountPanel();
+  const issues = useNewsIssues({ market: "all", windowHours: 24, limit: 20 });
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  return (
+    <DesktopShell
+      center={
+        <>
+          <header style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16 }}>
+            <div>
+              <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800, letterSpacing: "-0.02em" }}>발견</h1>
+              <p style={{ margin: "4px 0 0", fontSize: 13, color: "var(--fg-3)" }}>
+                뉴스 기반 참고 정보입니다. 매매 추천이 아닙니다.
+              </p>
+            </div>
+            {issues.state.status === "ready" && (
+              <Pill tone="accent">실시간 · {issues.state.data.window_hours}시간 윈도우</Pill>
+            )}
+          </header>
+
+          <Card soft padded style={{ padding: 14, display: "flex", alignItems: "center", gap: 10 }}>
+            <Icon name="info" size={18} />
+            <span style={{ fontSize: 13, color: "var(--fg-2)" }}>
+              AI가 동시에 보도되는 키워드를 묶어 시장 이슈를 실시간으로 정렬합니다.
+            </span>
+          </Card>
+
+          <div data-testid="discover-issues">
+            {issues.state.status === "loading" && (
+              <div style={{ padding: 16, color: "var(--fg-3)" }}>AI 실시간 이슈를 불러오는 중…</div>
+            )}
+            {issues.state.status === "error" && (
+              <div style={{ padding: 16, color: "var(--danger)" }}>
+                AI 실시간 이슈를 잠시 후 다시 시도해 주세요.{" "}
+                <button
+                  type="button"
+                  onClick={issues.reload}
+                  style={{
+                    marginLeft: 8,
+                    padding: "4px 10px",
+                    borderRadius: 8,
+                    border: "1px solid var(--border)",
+                    background: "var(--surface)",
+                    color: "var(--fg-1)",
+                    cursor: "pointer",
+                    fontFamily: "inherit",
+                    fontSize: 12,
+                  }}
+                >
+                  재시도
+                </button>
+                <div style={{ fontSize: 12, color: "var(--fg-3)", marginTop: 4 }}>{issues.state.message}</div>
+              </div>
+            )}
+            {issues.state.status === "ready" && (() => {
+              const sorted = sortMarketIssues(issues.state.data.items);
+              if (sorted.length === 0) {
+                return <div style={{ padding: 16, color: "var(--fg-3)" }}>표시할 이슈가 없습니다.</div>;
+              }
+              return (
+                <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 10 }}>
+                  {sorted.map((issue) => (
+                    <IssueCard
+                      key={issue.id}
+                      issue={issue}
+                      expanded={openId === issue.id}
+                      onToggle={() => setOpenId(openId === issue.id ? null : issue.id)}
+                    />
+                  ))}
+                </ul>
+              );
+            })()}
+          </div>
+        </>
+      }
+      right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} onRefresh={panel.reload} />}
+    />
+  );
+}

--- a/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
@@ -1,16 +1,18 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { RightAccountPanel } from "../../desktop/RightAccountPanel";
 import { useAccountPanel } from "../../desktop/useAccountPanel";
+import { useViewport } from "../../hooks/useViewport";
 import { fetchFeedNews } from "../../api/feedNews";
 import type { FeedNewsResponse, FeedTab } from "../../types/feedNews";
+import { NewsTabs } from "../../components/news/NewsTabs";
+import { NewsCard } from "../../components/news/NewsCard";
+import { MobileFeedNewsPage } from "../mobile/MobileFeedNewsPage";
 
-const TABS: { key: FeedTab; label: string }[] = [
-  { key: "top", label: "주요" }, { key: "latest", label: "최신" }, { key: "hot", label: "핫이슈" },
-  { key: "holdings", label: "보유" }, { key: "watchlist", label: "관심" },
-  { key: "kr", label: "국내" }, { key: "us", label: "해외" }, { key: "crypto", label: "크립토" },
-];
+export function FeedNewsRoute() {
+  const viewport = useViewport();
+  return viewport === "mobile" ? <MobileFeedNewsPage /> : <DesktopFeedNewsPage />;
+}
 
 export function DesktopFeedNewsPage() {
   const panel = useAccountPanel();
@@ -21,153 +23,58 @@ export function DesktopFeedNewsPage() {
 
   useEffect(() => {
     let cancel = false;
-    setData(undefined); setErr(undefined);
+    setData(undefined);
+    setErr(undefined);
     fetchFeedNews({ tab, limit: 30 })
       .then((r) => !cancel && setData(r))
       .catch((e) => !cancel && setErr(String(e?.message ?? e)));
-    return () => { cancel = true; };
+    return () => {
+      cancel = true;
+    };
   }, [tab]);
 
   const issueById = new Map((data?.issues ?? []).map((i) => [i.id, i] as const));
 
   return (
     <DesktopShell
-      left={
-        <nav style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-          {TABS.map((t) => {
-            const active = tab === t.key;
-            return (
-              <button
-                key={t.key}
-                data-testid={`tab-${t.key}`}
-                onClick={() => setTab(t.key)}
-                style={{
-                  textAlign: "left", padding: "6px 10px", borderRadius: 6,
-                  background: active ? "var(--surface-2)" : "transparent",
-                  color: active ? "var(--fg)" : "var(--fg-2)",
-                  fontWeight: active ? 700 : 500,
-                  border: "none", cursor: "pointer", fontSize: 13,
-                }}
-              >
-                {t.label}
-              </button>
-            );
-          })}
-        </nav>
-      }
       center={
-        <div data-testid="feed-center">
-          {err && <div style={{ color: "var(--danger)", marginBottom: 12 }}>오류: {err}</div>}
-          {data?.meta?.emptyReason === "no_holdings" && (
-            <div style={{ padding: 16, color: "var(--fg-3)" }}>보유 종목이 없습니다.</div>
-          )}
-          {data?.meta?.emptyReason === "no_watchlist" && (
-            <div style={{ padding: 16, color: "var(--fg-3)" }}>관심 종목이 없습니다.</div>
-          )}
-          <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 8 }}>
-            {(data?.items ?? []).map((it) => {
-              const open = selectedId === it.id;
-              const linkedIssue = it.issueId ? issueById.get(it.issueId) : undefined;
-              return (
-                <li
-                  key={it.id}
-                  data-testid="feed-item"
-                  data-relation={it.relation}
-                  style={{
-                    padding: 12, borderRadius: 10,
-                    background: "var(--surface)",
-                    border: "1px solid var(--border)",
-                    boxShadow: "var(--shadow-1)",
-                  }}
-                >
-                  <button
-                    onClick={() => setSelectedId(open ? null : it.id)}
-                    style={{ background: "none", border: "none", color: "var(--fg)", textAlign: "left", padding: 0, cursor: "pointer", width: "100%" }}
-                  >
-                    <div style={{ fontSize: 14, fontWeight: 600 }}>{it.title}</div>
-                    <div style={{ fontSize: 11, color: "var(--fg-3)", marginTop: 4 }}>
-                      {it.publisher ?? "—"} · {it.market.toUpperCase()}
-                      {it.relation !== "none" && <span style={{ marginLeft: 8 }}>[{it.relation}]</span>}
-                    </div>
-                  </button>
-                  {linkedIssue && (
-                    <Link
-                      to={`/app/discover/issues/${linkedIssue.id}`}
-                      data-testid="feed-item-issue-chip"
-                      data-issue-id={linkedIssue.id}
-                      aria-label={`이슈 링크: ${linkedIssue.issue_title}`}
-                      onClick={(e) => e.stopPropagation()}
-                      style={{
-                        marginTop: 6,
-                        display: "inline-flex",
-                        alignItems: "center",
-                        gap: 6,
-                        padding: "2px 8px",
-                        borderRadius: 999,
-                        background: "var(--surface-2, #1c1e24)",
-                        color: "#cfd2da",
-                        fontSize: 11,
-                        textDecoration: "none",
-                        maxWidth: "100%",
-                      }}
-                    >
-                      <span aria-hidden style={{ fontSize: 9 }}>●</span>
-                      <span
-                        style={{
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        이슈 · {linkedIssue.issue_title}
-                      </span>
-                    </Link>
-                  )}
-                  {it.relatedSymbols.length > 0 && (
-                    <div
-                      data-testid="feed-item-related-symbols"
-                      style={{ marginTop: 6, display: "flex", flexWrap: "wrap", gap: 6 }}
-                    >
-                      {it.relatedSymbols.map((symbol) => (
-                        <span
-                          key={`${symbol.market}:${symbol.symbol}`}
-                          data-testid="feed-item-related-symbol-chip"
-                          data-symbol={symbol.symbol}
-                          data-market={symbol.market}
-                          data-relation={symbol.relation ?? "none"}
-                          title={
-                            symbol.matchedTerm
-                              ? `${symbol.matchReason ?? "matched"}: ${symbol.matchedTerm}`
-                              : undefined
-                          }
-                          style={{
-                            display: "inline-flex",
-                            alignItems: "center",
-                            gap: 4,
-                            padding: "2px 7px",
-                            borderRadius: 999,
-                            border: "1px solid var(--surface-2, #2a2d35)",
-                            color: "#b8beca",
-                            fontSize: 11,
-                          }}
-                        >
-                          <strong style={{ color: "#e8eaf0", fontWeight: 700 }}>{symbol.symbol}</strong>
-                          <span>{symbol.displayName}</span>
-                          {symbol.relation && symbol.relation !== "none" && <span>[{symbol.relation}]</span>}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                  {open && it.summarySnippet && (
-                    <div style={{ marginTop: 8, fontSize: 13, color: "var(--fg-2)" }}>{it.summarySnippet}</div>
-                  )}
-                </li>
-              );
-            })}
-          </ul>
-        </div>
+        <>
+          <header>
+            <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800, letterSpacing: "-0.02em" }}>뉴스</h1>
+            <p style={{ margin: "4px 0 0", fontSize: 13, color: "var(--fg-3)" }}>
+              보유 · 관심 종목 관련 기사를 우선 보여드립니다.
+            </p>
+          </header>
+
+          <NewsTabs value={tab} onChange={setTab} />
+
+          <div data-testid="feed-center">
+            {err && <div style={{ color: "var(--danger)", marginBottom: 12 }}>오류: {err}</div>}
+            {data?.meta?.emptyReason === "no_holdings" && (
+              <div style={{ padding: 16, color: "var(--fg-3)" }}>보유 종목이 없습니다.</div>
+            )}
+            {data?.meta?.emptyReason === "no_watchlist" && (
+              <div style={{ padding: 16, color: "var(--fg-3)" }}>관심 종목이 없습니다.</div>
+            )}
+            <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 8 }}>
+              {(data?.items ?? []).map((it) => {
+                const open = selectedId === it.id;
+                const linkedIssue = it.issueId ? issueById.get(it.issueId) : undefined;
+                return (
+                  <NewsCard
+                    key={it.id}
+                    item={it}
+                    issue={linkedIssue}
+                    open={open}
+                    onToggle={() => setSelectedId(open ? null : it.id)}
+                  />
+                );
+              })}
+            </ul>
+          </div>
+        </>
       }
-      right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} />}
+      right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} onRefresh={panel.reload} />}
     />
   );
 }

--- a/frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx
@@ -60,7 +60,7 @@ export function DesktopScreenerPage() {
       }
       center={
         <div data-testid="screener-center">
-          {err && <div style={{ color: "#f59e9e", marginBottom: 12 }}>오류: {err}</div>}
+          {err && <div style={{ color: "var(--danger)", marginBottom: 12 }}>오류: {err}</div>}
           {results ? (
             <>
               <ScreenerFilterBar
@@ -80,7 +80,7 @@ export function DesktopScreenerPage() {
               <ScreenerResultsTable rows={results.results} metricLabel={results.metricLabel} />
             </>
           ) : (
-            !err && <div style={{ padding: 16, color: "#9ba0ab" }}>불러오는 중...</div>
+            !err && <div style={{ padding: 16, color: "var(--fg-3)" }}>불러오는 중...</div>
           )}
           <ScreenerFilterModal
             open={modalOpen}

--- a/frontend/invest/src/pages/desktop/DesktopSignalsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopSignalsPage.tsx
@@ -2,8 +2,13 @@ import { useEffect, useState } from "react";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { RightAccountPanel } from "../../desktop/RightAccountPanel";
 import { useAccountPanel } from "../../desktop/useAccountPanel";
+import { useViewport } from "../../hooks/useViewport";
 import { fetchSignals } from "../../api/signals";
-import type { SignalsResponse, SignalTab, SignalCard } from "../../types/signals";
+import type { SignalsResponse, SignalTab, SignalCard as SignalCardData } from "../../types/signals";
+import { SignalCard } from "../../components/signals/SignalCard";
+import { Card, Pill } from "../../ds";
+import { formatRelativeTime } from "../../format/relativeTime";
+import { MobileSignalsPage } from "../mobile/MobileSignalsPage";
 
 const TABS: { key: SignalTab; label: string }[] = [
   { key: "mine", label: "내 투자 / 관심" },
@@ -12,20 +17,28 @@ const TABS: { key: SignalTab; label: string }[] = [
   { key: "crypto", label: "크립토" },
 ];
 
+export function SignalsRoute() {
+  return useViewport() === "mobile" ? <MobileSignalsPage /> : <DesktopSignalsPage />;
+}
+
 export function DesktopSignalsPage() {
   const panel = useAccountPanel();
   const [tab, setTab] = useState<SignalTab>("mine");
   const [data, setData] = useState<SignalsResponse | undefined>();
   const [err, setErr] = useState<string | undefined>();
-  const [selected, setSelected] = useState<SignalCard | null>(null);
+  const [selected, setSelected] = useState<SignalCardData | null>(null);
 
   useEffect(() => {
     let cancel = false;
-    setData(undefined); setErr(undefined); setSelected(null);
+    setData(undefined);
+    setErr(undefined);
+    setSelected(null);
     fetchSignals({ tab, limit: 30 })
       .then((r) => !cancel && setData(r))
       .catch((e) => !cancel && setErr(String(e?.message ?? e)));
-    return () => { cancel = true; };
+    return () => {
+      cancel = true;
+    };
   }, [tab]);
 
   return (
@@ -33,75 +46,106 @@ export function DesktopSignalsPage() {
       left={
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
           <nav style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-            {TABS.map((t) => (
-              <button
-                key={t.key} data-testid={`signal-tab-${t.key}`}
-                onClick={() => setTab(t.key)}
-                style={{
-                  textAlign: "left", padding: "6px 10px", borderRadius: 6,
-                  background: tab === t.key ? "var(--surface-2, #1c1e24)" : "transparent",
-                  color: "#e8eaf0", border: "none", cursor: "pointer", fontSize: 13,
-                }}
-              >
-                {t.label}
-              </button>
-            ))}
-          </nav>
-          {err && <div style={{ color: "#f59e9e" }}>오류: {err}</div>}
-          {data?.meta.emptyReason && <div style={{ fontSize: 12, color: "#9ba0ab" }}>결과 없음 ({data.meta.emptyReason})</div>}
-          <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 6 }}>
-            {(data?.items ?? []).map((s) => (
-              <li key={s.id}>
+            {TABS.map((t) => {
+              const active = tab === t.key;
+              return (
                 <button
-                  data-testid="signal-list-item"
-                  data-relation={s.relation}
-                  onClick={() => setSelected(s)}
+                  key={t.key}
+                  data-testid={`signal-tab-${t.key}`}
+                  onClick={() => setTab(t.key)}
                   style={{
-                    width: "100%", textAlign: "left", padding: 10, borderRadius: 8,
-                    background: selected?.id === s.id ? "var(--surface-2, #1c1e24)" : "var(--surface, #15181f)",
-                    border: "none", color: "#e8eaf0", cursor: "pointer",
+                    textAlign: "left",
+                    padding: "6px 10px",
+                    borderRadius: 8,
+                    background: active ? "var(--surface-2)" : "transparent",
+                    color: active ? "var(--fg)" : "var(--fg-2)",
+                    fontWeight: active ? 700 : 600,
+                    border: "none",
+                    cursor: "pointer",
+                    fontSize: 13,
+                    fontFamily: "inherit",
                   }}
                 >
-                  <div style={{ fontSize: 13, fontWeight: 600 }}>{s.title}</div>
-                  <div style={{ fontSize: 11, color: "#9ba0ab" }}>
-                    {s.market.toUpperCase()} · {s.decisionLabel ?? "neutral"}
-                    {s.confidence != null && ` · ${s.confidence}%`}
-                  </div>
+                  {t.label}
                 </button>
+              );
+            })}
+          </nav>
+          {err && <div style={{ color: "var(--danger)", fontSize: 12 }}>오류: {err}</div>}
+          {data?.meta.emptyReason && (
+            <div style={{ fontSize: 12, color: "var(--fg-3)" }}>결과 없음 ({data.meta.emptyReason})</div>
+          )}
+          <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 8 }}>
+            {(data?.items ?? []).map((s) => (
+              <li key={s.id}>
+                <SignalCard
+                  signal={s}
+                  selected={selected?.id === s.id}
+                  onSelect={() => setSelected(s)}
+                />
               </li>
             ))}
           </ul>
         </div>
       }
       center={
-        <section data-testid="signal-detail" style={{ padding: 24, borderRadius: 12, background: "var(--surface, #15181f)" }}>
+        <Card data-testid="signal-detail" padded={false} style={{ padding: 24 }}>
           {!selected ? (
-            <div style={{ color: "#9ba0ab" }}>시그널을 선택하세요.</div>
+            <div style={{ color: "var(--fg-3)" }}>시그널을 선택하세요.</div>
           ) : (
-            <>
-              <h2 style={{ fontSize: 18, marginTop: 0 }}>{selected.title}</h2>
-              <div style={{ fontSize: 12, color: "#9ba0ab" }}>
-                {selected.market.toUpperCase()} · {selected.decisionLabel ?? "neutral"}
-                {selected.confidence != null && ` · 신뢰도 ${selected.confidence}%`}
-                {` · ${new Date(selected.generatedAt).toLocaleString("ko-KR")}`}
-              </div>
-              {selected.summary && <p style={{ marginTop: 12 }}>{selected.summary}</p>}
-              {selected.rationale && (
-                <details style={{ marginTop: 12 }}>
-                  <summary style={{ cursor: "pointer", color: "#9ba0ab" }}>근거</summary>
-                  <pre style={{ whiteSpace: "pre-wrap", fontSize: 12 }}>{selected.rationale}</pre>
-                </details>
-              )}
-              {selected.relatedSymbols.length > 0 && (
-                <div style={{ marginTop: 12, fontSize: 12, color: "#9ba0ab" }}>
-                  관련 종목: {selected.relatedSymbols.map((r) => r.displayName).join(", ")}
-                </div>
-              )}
-            </>
+            <SignalDetail signal={selected} />
           )}
-        </section>
+        </Card>
       }
-      right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} />}
+      right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} onRefresh={panel.reload} />}
     />
+  );
+}
+
+function SignalDetail({ signal }: { signal: SignalCardData }) {
+  const ago = formatRelativeTime(signal.generatedAt) ?? "방금";
+  return (
+    <div>
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <h2 style={{ fontSize: 20, fontWeight: 800, margin: 0, letterSpacing: "-0.02em" }}>{signal.title}</h2>
+        {signal.relation !== "none" && (
+          <Pill tone="accent" size="sm">
+            {signal.relation === "held" ? "보유" : signal.relation === "watchlist" ? "관심" : "보유·관심"}
+          </Pill>
+        )}
+      </div>
+      <div style={{ fontSize: 12, color: "var(--fg-3)", marginTop: 6, fontFeatureSettings: '"tnum"' }}>
+        {signal.market.toUpperCase()} · {signal.decisionLabel ?? "neutral"}
+        {signal.confidence != null && ` · 신뢰도 ${signal.confidence}%`}
+        {` · ${ago}`}
+      </div>
+      {signal.summary && (
+        <p style={{ marginTop: 14, color: "var(--fg-1)", fontSize: 14, lineHeight: 1.6 }}>{signal.summary}</p>
+      )}
+      {signal.rationale && (
+        <details style={{ marginTop: 14 }}>
+          <summary style={{ cursor: "pointer", color: "var(--fg-2)", fontSize: 13 }}>근거</summary>
+          <pre
+            style={{
+              whiteSpace: "pre-wrap",
+              fontSize: 12,
+              fontFamily: "var(--font-mono)",
+              background: "var(--surface-2)",
+              padding: 12,
+              borderRadius: 8,
+              color: "var(--fg-1)",
+              marginTop: 8,
+            }}
+          >
+            {signal.rationale}
+          </pre>
+        </details>
+      )}
+      {signal.relatedSymbols.length > 0 && (
+        <div style={{ marginTop: 12, fontSize: 12, color: "var(--fg-3)" }}>
+          관련 종목: {signal.relatedSymbols.map((r) => r.displayName).join(", ")}
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/invest/src/pages/mobile/MobileDiscoverPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileDiscoverPage.tsx
@@ -1,0 +1,64 @@
+import { useState } from "react";
+import { MobileShell } from "../../mobile/MobileShell";
+import { useNewsIssues } from "../../hooks/useNewsIssues";
+import { sortMarketIssues } from "../../components/discover/severity";
+import { IssueCard } from "../../components/discover/IssueCard";
+
+export function MobileDiscoverPage() {
+  const issues = useNewsIssues({ market: "all", windowHours: 24, limit: 20 });
+  const [openId, setOpenId] = useState<string | null>(null);
+
+  return (
+    <MobileShell title="발견">
+      <div data-testid="discover-issues" style={{ padding: "14px 16px", display: "flex", flexDirection: "column", gap: 10 }}>
+        <p style={{ margin: 0, fontSize: 12, color: "var(--fg-3)" }}>
+          뉴스 기반 참고 정보입니다. 매매 추천이 아닙니다.
+        </p>
+
+        {issues.state.status === "loading" && (
+          <div style={{ color: "var(--fg-3)" }}>AI 실시간 이슈를 불러오는 중…</div>
+        )}
+        {issues.state.status === "error" && (
+          <div style={{ color: "var(--danger)" }}>
+            잠시 후 다시 시도해 주세요.{" "}
+            <button
+              type="button"
+              onClick={issues.reload}
+              style={{
+                marginLeft: 8,
+                padding: "2px 8px",
+                borderRadius: 6,
+                border: "1px solid var(--border)",
+                background: "var(--surface)",
+                color: "var(--fg-1)",
+                cursor: "pointer",
+                fontFamily: "inherit",
+                fontSize: 11,
+              }}
+            >
+              재시도
+            </button>
+          </div>
+        )}
+        {issues.state.status === "ready" && (() => {
+          const sorted = sortMarketIssues(issues.state.data.items);
+          if (sorted.length === 0) {
+            return <div style={{ color: "var(--fg-3)" }}>표시할 이슈가 없습니다.</div>;
+          }
+          return (
+            <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 10 }}>
+              {sorted.map((issue) => (
+                <IssueCard
+                  key={issue.id}
+                  issue={issue}
+                  expanded={openId === issue.id}
+                  onToggle={() => setOpenId(openId === issue.id ? null : issue.id)}
+                />
+              ))}
+            </ul>
+          );
+        })()}
+      </div>
+    </MobileShell>
+  );
+}

--- a/frontend/invest/src/pages/mobile/MobileFeedNewsPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileFeedNewsPage.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { MobileShell } from "../../mobile/MobileShell";
+import { fetchFeedNews } from "../../api/feedNews";
+import type { FeedNewsResponse, FeedTab } from "../../types/feedNews";
+import { NewsTabs } from "../../components/news/NewsTabs";
+import { NewsCard } from "../../components/news/NewsCard";
+
+export function MobileFeedNewsPage() {
+  const [tab, setTab] = useState<FeedTab>("top");
+  const [data, setData] = useState<FeedNewsResponse | undefined>();
+  const [err, setErr] = useState<string | undefined>();
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancel = false;
+    setData(undefined);
+    setErr(undefined);
+    fetchFeedNews({ tab, limit: 30 })
+      .then((r) => !cancel && setData(r))
+      .catch((e) => !cancel && setErr(String(e?.message ?? e)));
+    return () => {
+      cancel = true;
+    };
+  }, [tab]);
+
+  const issueById = new Map((data?.issues ?? []).map((i) => [i.id, i] as const));
+
+  return (
+    <MobileShell title="뉴스">
+      <div data-testid="feed-center" style={{ padding: "14px 16px", display: "flex", flexDirection: "column", gap: 10 }}>
+        <NewsTabs value={tab} onChange={setTab} variant="pill-row" />
+
+        {err && <div style={{ color: "var(--danger)" }}>오류: {err}</div>}
+        {data?.meta?.emptyReason === "no_holdings" && (
+          <div style={{ color: "var(--fg-3)" }}>보유 종목이 없습니다.</div>
+        )}
+        {data?.meta?.emptyReason === "no_watchlist" && (
+          <div style={{ color: "var(--fg-3)" }}>관심 종목이 없습니다.</div>
+        )}
+
+        <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 10 }}>
+          {(data?.items ?? []).map((it) => {
+            const open = selectedId === it.id;
+            const linkedIssue = it.issueId ? issueById.get(it.issueId) : undefined;
+            return (
+              <NewsCard
+                key={it.id}
+                item={it}
+                issue={linkedIssue}
+                open={open}
+                onToggle={() => setSelectedId(open ? null : it.id)}
+              />
+            );
+          })}
+        </ul>
+      </div>
+    </MobileShell>
+  );
+}

--- a/frontend/invest/src/pages/mobile/MobileSignalsPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileSignalsPage.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+import { MobileShell } from "../../mobile/MobileShell";
+import { fetchSignals } from "../../api/signals";
+import type { SignalsResponse, SignalTab } from "../../types/signals";
+import { SignalCard } from "../../components/signals/SignalCard";
+
+const TABS: { key: SignalTab; label: string }[] = [
+  { key: "mine", label: "내 투자" },
+  { key: "kr", label: "국내" },
+  { key: "us", label: "해외" },
+  { key: "crypto", label: "크립토" },
+];
+
+export function MobileSignalsPage() {
+  const [tab, setTab] = useState<SignalTab>("mine");
+  const [data, setData] = useState<SignalsResponse | undefined>();
+  const [err, setErr] = useState<string | undefined>();
+
+  useEffect(() => {
+    let cancel = false;
+    setData(undefined);
+    setErr(undefined);
+    fetchSignals({ tab, limit: 30 })
+      .then((r) => !cancel && setData(r))
+      .catch((e) => !cancel && setErr(String(e?.message ?? e)));
+    return () => {
+      cancel = true;
+    };
+  }, [tab]);
+
+  return (
+    <MobileShell title="시그널">
+      <div style={{ padding: "14px 16px", display: "flex", flexDirection: "column", gap: 10 }}>
+        <div style={{ display: "flex", gap: 6, overflowX: "auto", paddingBottom: 4 }}>
+          {TABS.map((t) => {
+            const active = t.key === tab;
+            return (
+              <button
+                key={t.key}
+                data-testid={`signal-tab-${t.key}`}
+                onClick={() => setTab(t.key)}
+                style={{
+                  flex: "0 0 auto",
+                  padding: "6px 12px",
+                  borderRadius: 999,
+                  border: "none",
+                  background: active ? "var(--fg)" : "var(--surface-2)",
+                  color: active ? "#fff" : "var(--fg-2)",
+                  fontWeight: 600,
+                  fontSize: 12,
+                  fontFamily: "inherit",
+                  whiteSpace: "nowrap",
+                  cursor: "pointer",
+                }}
+              >
+                {t.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {err && <div style={{ color: "var(--danger)" }}>오류: {err}</div>}
+        {data?.meta.emptyReason && (
+          <div style={{ color: "var(--fg-3)", fontSize: 13 }}>결과 없음 ({data.meta.emptyReason})</div>
+        )}
+
+        <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 10 }}>
+          {(data?.items ?? []).map((s) => (
+            <li key={s.id}>
+              <SignalCard signal={s} variant="grid" />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </MobileShell>
+  );
+}

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -6,6 +6,7 @@ import { HomePage } from "./pages/HomePage";
 import { PaperPlaceholderPage } from "./pages/PaperPlaceholderPage";
 import { InvestHomeRoute } from "./pages/desktop/DesktopHomePage";
 import { FeedNewsRoute } from "./pages/desktop/DesktopFeedNewsPage";
+import { InvestDiscoverRoute } from "./pages/desktop/DesktopDiscoverPage";
 import { DesktopSignalsPage } from "./pages/desktop/DesktopSignalsPage";
 import { DesktopCalendarPage } from "./pages/desktop/DesktopCalendarPage";
 import { DesktopScreenerPage } from "./pages/desktop/DesktopScreenerPage";
@@ -16,6 +17,8 @@ export const router = createBrowserRouter(
     // (DesktopHomePage at >=900px, MobileHomePage below).
     { path: "/", element: <InvestHomeRoute /> },
     { path: "/feed/news", element: <FeedNewsRoute /> },
+    { path: "/discover", element: <InvestDiscoverRoute /> },
+    { path: "/discover/issues/:issueId", element: <DiscoverIssueDetailPage /> },
     { path: "/signals", element: <DesktopSignalsPage /> },
     { path: "/calendar", element: <DesktopCalendarPage /> },
     { path: "/screener", element: <DesktopScreenerPage /> },

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -5,7 +5,7 @@ import { DiscoverPage } from "./pages/DiscoverPage";
 import { HomePage } from "./pages/HomePage";
 import { PaperPlaceholderPage } from "./pages/PaperPlaceholderPage";
 import { InvestHomeRoute } from "./pages/desktop/DesktopHomePage";
-import { DesktopFeedNewsPage } from "./pages/desktop/DesktopFeedNewsPage";
+import { FeedNewsRoute } from "./pages/desktop/DesktopFeedNewsPage";
 import { DesktopSignalsPage } from "./pages/desktop/DesktopSignalsPage";
 import { DesktopCalendarPage } from "./pages/desktop/DesktopCalendarPage";
 import { DesktopScreenerPage } from "./pages/desktop/DesktopScreenerPage";
@@ -15,7 +15,7 @@ export const router = createBrowserRouter(
     // Canonical /invest routes — the home view is responsive
     // (DesktopHomePage at >=900px, MobileHomePage below).
     { path: "/", element: <InvestHomeRoute /> },
-    { path: "/feed/news", element: <DesktopFeedNewsPage /> },
+    { path: "/feed/news", element: <FeedNewsRoute /> },
     { path: "/signals", element: <DesktopSignalsPage /> },
     { path: "/calendar", element: <DesktopCalendarPage /> },
     { path: "/screener", element: <DesktopScreenerPage /> },

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -7,7 +7,7 @@ import { PaperPlaceholderPage } from "./pages/PaperPlaceholderPage";
 import { InvestHomeRoute } from "./pages/desktop/DesktopHomePage";
 import { FeedNewsRoute } from "./pages/desktop/DesktopFeedNewsPage";
 import { InvestDiscoverRoute } from "./pages/desktop/DesktopDiscoverPage";
-import { DesktopSignalsPage } from "./pages/desktop/DesktopSignalsPage";
+import { SignalsRoute } from "./pages/desktop/DesktopSignalsPage";
 import { DesktopCalendarPage } from "./pages/desktop/DesktopCalendarPage";
 import { DesktopScreenerPage } from "./pages/desktop/DesktopScreenerPage";
 
@@ -19,7 +19,7 @@ export const router = createBrowserRouter(
     { path: "/feed/news", element: <FeedNewsRoute /> },
     { path: "/discover", element: <InvestDiscoverRoute /> },
     { path: "/discover/issues/:issueId", element: <DiscoverIssueDetailPage /> },
-    { path: "/signals", element: <DesktopSignalsPage /> },
+    { path: "/signals", element: <SignalsRoute /> },
     { path: "/calendar", element: <DesktopCalendarPage /> },
     { path: "/screener", element: <DesktopScreenerPage /> },
 


### PR DESCRIPTION
## Summary

Stage 4 of the `/invest` design-system migration plan
(`docs/plans/2026-05-08-invest-design-system-migration-implementation-plan.md`),
on top of Stage 3 (#727, already merged).

This polish pass brings four routes onto the design system: News,
canonical Discover, Signals, and Screener. Home (Stages 2 + 3) and
Calendar (Stage 5, separate PR) are not touched here.

### Commits

- **`8a10d74a` Stage 4.1 — News rebuild** (desktop + mobile).
  Drops the left tab rail in favor of an underline tab strip per the
  bundle. New `components/news/{NewsTabs,NewsCard}.tsx` shared between
  desktop and mobile. Sweeps the #722 issue chip + related-symbols dark
  literals (`#cfd2da` / `#b8beca` / `#e8eaf0` / dark surface fallbacks)
  for design tokens. All `feed-item` / `tab-{key}` / `feed-item-issue-chip`
  / `feed-item-related-symbol-chip` testids preserved.

- **`c483b44e` Stage 4.2 — Canonical `/discover`** (desktop + mobile).
  Adds `/discover` and `/discover/issues/:issueId` routes backed by a new
  `InvestDiscoverRoute` viewport dispatcher and a real-app
  `components/discover/IssueCard.tsx` (port of the bundle's IssueRow).
  Internal-link rewires: `DesktopHeader` and `MobileBottomNav` 발견 →
  `/discover`; `NewsCard` issue-chip default href prefix →
  `/discover/issues`. The legacy `/app/discover` route stays mounted
  to the existing `DiscoverPage` for backwards compat (Stage 6 retires
  it via redirect). `DesktopFeedNewsPage.test.tsx` chip-href assertion
  updated to the canonical path.

- **`75676a9a` Stage 4.3 — Signals rebuild** (desktop + mobile).
  Card-based master-detail layout. New
  `components/signals/SignalCard.tsx` translates Korean decision labels
  (매수/매도/보유/관찰/중립) onto tone-colored Pills. The card's
  accessible name is `{title} 시그널 보기` so the decision pill stays
  decorative and screen readers do not announce the button as an
  order CTA. `signal-list-item` testid preserved; `signal-tab-{key}`
  preserved across both desktop tab strip and mobile pill row. Test
  follow-up: `does not render buy/sell CTA buttons` rewritten from
  `queryByText` to `queryByRole('button', { name: ... })` to match
  the actual safety intent.

- **`c3d936a1` Stage 4.4 — Screener light reframe** (token sweep).
  Pure CSS / inline-hex sweep on `screener.css` and `DesktopScreenerPage`.
  No layout / behavior changes. Drops the legacy `--text` / `--muted`
  dark fallbacks (unreadable light gray on white), switches to the
  Stage 1 ink scale, calms the warnings list to `--warn-soft`, and
  brings the modal backdrop in line with the Stage 5 EventDetailModal
  pattern.

### What's NOT in this PR
- Calendar route polish (Stage 5).
- `/invest/app/*` retirement / redirects (Stage 6).
- Backend market-indices feed for the home `MarketStrip` (deferred).

## Test Plan

- [x] `cd frontend/invest && npm run typecheck` — PASS
- [x] `cd frontend/invest && npm test -- --run` — 28 files / 93 tests PASS
      (existing 88 + screener/calendar/discover suites, all green)
- [x] `cd frontend/invest && npm run build` — PASS (`dist/assets/index-*.css 9.35 kB`,
      JS 379 kB)

### Visual smoke

Vite dev base is `/invest/app/`, so `npm run dev` serves the legacy
mobile entry at **`http://127.0.0.1:5174/invest/app/`**. Use the SPA
router from there to reach canonical `/feed/news`, `/discover`,
`/signals`, `/screener`. In production / native deploys the canonical
entry is `/invest/`.

- [ ] `/feed/news`: tab strip is horizontal underline, news cards are
      light surface with shadow, issue chip → `/invest/discover/issues/...`
- [ ] `/discover`: `IssueCard` rows expand on click, title is a link
      to the issue detail page
- [ ] `/signals`: master-detail with card list on left, detail
      panel on center, no actionable buy/sell button labels
- [ ] `/screener`: white surface, soft-gray hover on preset rows,
      table is on a single light card with hairline rows
- [ ] Resize between desktop and mobile on `/feed/news`, `/discover`,
      `/signals` — both surfaces render correctly
- [ ] DesktopHeader 발견 / MobileBottomNav 발견 both target
      `/invest/discover`

## Scope-out / safety

- Read-only frontend work. No broker / order / watch / market-events
  mutation paths touched.
- All hooks (`useInvestHome`, `useAccountPanel`, `useNewsIssues`) and
  types unchanged.
- Legacy `/invest/app/*` routes still work — Stage 6 retires them via
  redirects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added discover page with issue browsing for desktop and mobile
  * Added mobile signals and news pages with tab-based filtering
  
* **Refactor**
  * Restructured desktop news and signals pages with improved card-based layouts
  * Consolidated navigation routes to canonical paths (removed `/app` prefix from discover and signals URLs)

* **Style**
  * Updated design token variables across screener UI for consistent theming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->