### PR TITLE
feat(invest): finance calendar enhancement (Stage 5)

### DIFF
--- a/frontend/invest/src/components/calendar/AIWeeklyCard.tsx
+++ b/frontend/invest/src/components/calendar/AIWeeklyCard.tsx
@@ -1,0 +1,80 @@
+import type { WeeklySummaryResponse } from "../../types/calendar";
+import { Icon } from "../../ds";
+import { SparkleIcon } from "./SparkleIcon";
+
+export function AIWeeklyCard({
+  summary,
+  loading,
+  onOpen,
+  compact = false,
+}: {
+  summary?: WeeklySummaryResponse;
+  loading?: boolean;
+  onOpen: () => void;
+  compact?: boolean;
+}) {
+  const headline = summary?.sections[0]?.title ?? "이번주 AI 요약";
+  const subline = summary?.sections[0]?.body?.slice(0, 80) ?? "이번주 주요 일정 요약을 확인하세요.";
+
+  return (
+    <div
+      style={{
+        background: compact ? "var(--surface-2)" : "linear-gradient(135deg, #f4f7ff 0%, #f9fafb 100%)",
+        border: compact ? "none" : "1px solid #e2e9f6",
+        borderRadius: 14,
+        padding: 16,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          fontSize: 12,
+          fontWeight: 700,
+          color: "var(--accent-press)",
+          marginBottom: 8,
+        }}
+      >
+        <SparkleIcon /> 이번주 AI 요약
+      </div>
+      <div
+        style={{
+          fontSize: 14,
+          fontWeight: 700,
+          color: "var(--fg)",
+          lineHeight: 1.45,
+          letterSpacing: "-0.01em",
+        }}
+      >
+        {loading ? "요약을 불러오는 중…" : headline}
+      </div>
+      {!loading && (
+        <div style={{ fontSize: 12, color: "var(--fg-2)", marginTop: 6, lineHeight: 1.5 }}>
+          {subline}
+        </div>
+      )}
+      <button
+        type="button"
+        data-testid="open-weekly-summary"
+        onClick={onOpen}
+        style={{
+          marginTop: 12,
+          padding: 0,
+          border: "none",
+          background: "transparent",
+          cursor: "pointer",
+          color: "var(--accent-press)",
+          fontWeight: 600,
+          fontSize: 12,
+          fontFamily: "inherit",
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 2,
+        }}
+      >
+        자세히 보기 <Icon name="chev" size={12} />
+      </button>
+    </div>
+  );
+}

--- a/frontend/invest/src/components/calendar/EmptyEventState.tsx
+++ b/frontend/invest/src/components/calendar/EmptyEventState.tsx
@@ -1,0 +1,31 @@
+import { Icon } from "../../ds";
+
+export function EmptyEventState({ message = "이번 주는 일정이 없어요" }: { message?: string }) {
+  return (
+    <div
+      data-testid="calendar-empty"
+      style={{
+        padding: "32px 16px",
+        textAlign: "center",
+        color: "var(--fg-3)",
+        fontSize: 13,
+      }}
+    >
+      <div
+        style={{
+          width: 40,
+          height: 40,
+          borderRadius: 999,
+          background: "var(--surface-2)",
+          display: "grid",
+          placeItems: "center",
+          margin: "0 auto 8px",
+          color: "var(--fg-2)",
+        }}
+      >
+        <Icon name="calendar" size={18} />
+      </div>
+      {message}
+    </div>
+  );
+}

--- a/frontend/invest/src/components/calendar/EventDetailModal.tsx
+++ b/frontend/invest/src/components/calendar/EventDetailModal.tsx
@@ -1,0 +1,138 @@
+import { useEffect } from "react";
+import type { WeeklySummaryResponse } from "../../types/calendar";
+import { SparkleIcon } from "./SparkleIcon";
+
+export function EventDetailModal({
+  summary,
+  loading,
+  error,
+  onClose,
+}: {
+  summary?: WeeklySummaryResponse;
+  loading?: boolean;
+  error?: string;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="이번주 AI 요약"
+      onClick={onClose}
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "rgba(15, 20, 28, 0.32)",
+        zIndex: 200,
+        display: "grid",
+        placeItems: "center",
+        padding: 24,
+      }}
+    >
+      <div
+        data-testid="weekly-summary"
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: "var(--surface)",
+          borderRadius: 20,
+          width: "min(820px, 100%)",
+          maxHeight: "calc(100vh - 48px)",
+          overflowY: "auto",
+          boxShadow: "var(--shadow-3)",
+        }}
+      >
+        <header
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            padding: "20px 28px 12px",
+          }}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              fontSize: 13,
+              fontWeight: 700,
+              color: "var(--accent-press)",
+            }}
+          >
+            <SparkleIcon size={16} />
+            이번주 AI 요약
+          </div>
+          <button
+            type="button"
+            aria-label="닫기"
+            onClick={onClose}
+            style={{
+              width: 32,
+              height: 32,
+              border: "none",
+              background: "var(--surface-2)",
+              borderRadius: 8,
+              cursor: "pointer",
+              color: "var(--fg-1)",
+              fontSize: 16,
+              fontFamily: "inherit",
+            }}
+          >
+            ✕
+          </button>
+        </header>
+
+        <div style={{ padding: "0 28px 24px", display: "flex", flexDirection: "column", gap: 18 }}>
+          {loading && <div style={{ color: "var(--fg-3)" }}>요약을 불러오는 중…</div>}
+          {error && <div style={{ color: "var(--danger)" }}>요약을 불러오지 못했습니다. ({error})</div>}
+          {summary && summary.partial && (
+            <div style={{ fontSize: 12, color: "var(--fg-3)" }}>
+              일부 일자가 비어있습니다: {summary.missingDates.join(", ")}
+            </div>
+          )}
+          {summary?.sections.map((section, i) => (
+            <article key={i}>
+              <h3
+                style={{
+                  margin: 0,
+                  fontSize: 15,
+                  fontWeight: 800,
+                  color: "var(--fg)",
+                  letterSpacing: "-0.01em",
+                }}
+              >
+                {section.title}
+              </h3>
+              <div style={{ fontSize: 11, color: "var(--fg-3)", marginTop: 4 }}>
+                {section.date} · {section.reportType}
+                {section.market ? ` · ${section.market.toUpperCase()}` : ""}
+              </div>
+              <p
+                style={{
+                  margin: "8px 0 0",
+                  fontSize: 13,
+                  color: "var(--fg-2)",
+                  lineHeight: 1.65,
+                  whiteSpace: "pre-wrap",
+                }}
+              >
+                {section.body}
+              </p>
+            </article>
+          ))}
+          {summary && summary.sections.length === 0 && !loading && !error && (
+            <div style={{ color: "var(--fg-3)" }}>이번 주 요약이 아직 준비되지 않았습니다.</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/invest/src/components/calendar/EventRow.tsx
+++ b/frontend/invest/src/components/calendar/EventRow.tsx
@@ -1,0 +1,80 @@
+import type { CalendarEventVM } from "./vm";
+import { RegionBadge } from "./RegionBadge";
+import { OwnershipTag } from "./OwnershipTag";
+
+export function EventRow({ ev }: { ev: CalendarEventVM }) {
+  return (
+    <article
+      data-testid="calendar-event"
+      data-event-id={ev.id}
+      data-event-type={ev.type}
+      data-relation={ev.own ?? "none"}
+      style={{
+        display: "grid",
+        gridTemplateColumns: "44px minmax(0, 1fr) 76px 76px 76px",
+        alignItems: "center",
+        gap: 10,
+        padding: "10px 12px",
+        borderRadius: 10,
+        background: "transparent",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 12,
+          fontWeight: 700,
+          color: "var(--fg-1)",
+          fontFeatureSettings: '"tnum"',
+        }}
+      >
+        {ev.monthDay}
+      </div>
+      <div style={{ minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+          <RegionBadge region={ev.region} />
+          <span
+            style={{
+              fontSize: 14,
+              fontWeight: 600,
+              color: "var(--fg)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              minWidth: 0,
+              flex: 1,
+            }}
+          >
+            {ev.title}
+          </span>
+          <OwnershipTag own={ev.own} />
+        </div>
+        <div
+          style={{
+            fontSize: 11,
+            color: ev.released ? "var(--fg-2)" : "var(--fg-3)",
+            marginTop: 2,
+          }}
+        >
+          {ev.time ?? (ev.released ? "발표 완료" : "발표 예정")}
+        </div>
+      </div>
+      <div
+        style={{
+          textAlign: "right",
+          fontWeight: 700,
+          color: ev.released ? "var(--fg)" : "var(--fg-3)",
+          fontSize: 13,
+          fontFeatureSettings: '"tnum"',
+        }}
+      >
+        {ev.actual ?? "—"}
+      </div>
+      <div style={{ textAlign: "right", color: "var(--fg-2)", fontSize: 13, fontFeatureSettings: '"tnum"' }}>
+        {ev.forecast ?? "—"}
+      </div>
+      <div style={{ textAlign: "right", color: "var(--fg-3)", fontSize: 13, fontFeatureSettings: '"tnum"' }}>
+        {ev.previous ?? "—"}
+      </div>
+    </article>
+  );
+}

--- a/frontend/invest/src/components/calendar/OwnershipTag.tsx
+++ b/frontend/invest/src/components/calendar/OwnershipTag.tsx
@@ -1,0 +1,31 @@
+import type { DisplayOwnership } from "./vm";
+
+const MAP: Record<
+  Exclude<DisplayOwnership, null>,
+  { label: string; bg: string; fg: string }
+> = {
+  holdings: { label: "보유", bg: "var(--gain-soft)", fg: "var(--gain)" },
+  watchlist: { label: "관심", bg: "var(--accent-soft)", fg: "var(--accent-press)" },
+  major: { label: "주요", bg: "var(--warn-soft)", fg: "#a06200" },
+};
+
+export function OwnershipTag({ own }: { own: DisplayOwnership }) {
+  if (!own) return null;
+  const t = MAP[own];
+  return (
+    <span
+      style={{
+        fontSize: 11,
+        fontWeight: 600,
+        color: t.fg,
+        background: t.bg,
+        padding: "1px 6px",
+        borderRadius: 4,
+        marginLeft: 6,
+        flexShrink: 0,
+      }}
+    >
+      {t.label}
+    </span>
+  );
+}

--- a/frontend/invest/src/components/calendar/RegionBadge.tsx
+++ b/frontend/invest/src/components/calendar/RegionBadge.tsx
@@ -1,0 +1,33 @@
+import type { DisplayRegion } from "./vm";
+
+const STYLES: Record<
+  DisplayRegion,
+  { bg: string; fg: string; label: string }
+> = {
+  us: { bg: "var(--accent-soft)", fg: "var(--accent-press)", label: "US" },
+  kr: { bg: "var(--surface-2)", fg: "var(--fg-1)", label: "KR" },
+};
+
+export function RegionBadge({ region, size = "sm" }: { region: DisplayRegion; size?: "sm" | "md" }) {
+  const t = STYLES[region];
+  const s =
+    size === "sm"
+      ? { fontSize: 10, padding: "1px 5px", borderRadius: 4 }
+      : { fontSize: 11, padding: "2px 6px", borderRadius: 5 };
+  return (
+    <span
+      style={{
+        ...s,
+        background: t.bg,
+        color: t.fg,
+        fontWeight: 700,
+        fontFamily: "var(--font-mono)",
+        letterSpacing: "0.04em",
+        flexShrink: 0,
+        display: "inline-block",
+      }}
+    >
+      {t.label}
+    </span>
+  );
+}

--- a/frontend/invest/src/components/calendar/SparkleIcon.tsx
+++ b/frontend/invest/src/components/calendar/SparkleIcon.tsx
@@ -1,0 +1,7 @@
+export function SparkleIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor" style={{ flexShrink: 0 }} aria-hidden>
+      <path d="M12 2l1.7 5.3L19 9l-5.3 1.7L12 16l-1.7-5.3L5 9l5.3-1.7L12 2zM18 14l.8 2.5L21 17l-2.2.5L18 20l-.8-2.5L15 17l2.2-.5L18 14z" />
+    </svg>
+  );
+}

--- a/frontend/invest/src/components/calendar/WeekDateStrip.tsx
+++ b/frontend/invest/src/components/calendar/WeekDateStrip.tsx
@@ -1,0 +1,75 @@
+import type { CalendarDay } from "../../types/calendar";
+import { dayOfWeekLabel } from "./vm";
+
+export function WeekDateStrip({
+  days,
+  selectedDate,
+  onSelect,
+  today,
+}: {
+  days: CalendarDay[];
+  selectedDate: string;
+  onSelect: (date: string) => void;
+  today?: string;
+}) {
+  return (
+    <div
+      data-testid="week-date-strip"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "repeat(7, 1fr)",
+        gap: 4,
+        textAlign: "center",
+      }}
+    >
+      {days.map((d) => {
+        const day = Number.parseInt(d.date.slice(8, 10), 10);
+        const dow = dayOfWeekLabel(d.date);
+        const isSelected = d.date === selectedDate;
+        const isToday = today != null && d.date === today;
+        const eventCount = d.events.length + d.clusters.length;
+        return (
+          <button
+            key={d.date}
+            type="button"
+            data-testid={`day-${d.date}`}
+            onClick={() => onSelect(d.date)}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: 4,
+              padding: "8px 4px",
+              border: "none",
+              background: isSelected ? "var(--surface-2)" : "transparent",
+              borderRadius: 8,
+              cursor: "pointer",
+              fontFamily: "inherit",
+            }}
+          >
+            <span style={{ fontSize: 11, color: "var(--fg-3)", fontWeight: 600 }}>{dow}</span>
+            <span
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: 999,
+                display: "grid",
+                placeItems: "center",
+                background: isSelected ? "var(--accent)" : "transparent",
+                color: isSelected ? "#fff" : isToday ? "var(--accent)" : "var(--fg-1)",
+                fontWeight: isSelected || isToday ? 700 : 500,
+                fontSize: 14,
+                fontFeatureSettings: '"tnum"',
+              }}
+            >
+              {day}
+            </span>
+            {eventCount > 0 && (
+              <span style={{ fontSize: 10, color: "var(--fg-3)", fontWeight: 600 }}>{eventCount}</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/invest/src/components/calendar/vm.ts
+++ b/frontend/invest/src/components/calendar/vm.ts
@@ -1,0 +1,81 @@
+import type { CalendarEvent } from "../../types/calendar";
+
+export type DisplayEventType = "earnings" | "macro" | "other";
+export type DisplayRegion = "kr" | "us";
+export type DisplayOwnership = "holdings" | "watchlist" | "major" | null;
+
+export interface CalendarEventVM {
+  id: string;
+  date: string;
+  dayOfMonth: number;
+  monthDay: string;
+  type: DisplayEventType;
+  region: DisplayRegion;
+  title: string;
+  time: string | null;
+  released: boolean;
+  actual: string | null;
+  forecast: string | null;
+  previous: string | null;
+  own: DisplayOwnership;
+  badges: string[];
+}
+
+export function mapEventType(eventType: CalendarEvent["eventType"]): DisplayEventType {
+  if (eventType === "earnings") return "earnings";
+  if (eventType === "economic") return "macro";
+  return "other";
+}
+
+export function mapMarketToRegion(market: CalendarEvent["market"]): DisplayRegion {
+  return market === "kr" ? "kr" : "us";
+}
+
+export function mapOwnership(event: CalendarEvent): DisplayOwnership {
+  if (event.badges.includes("major")) return "major";
+  if (event.relation === "held" || event.relation === "both") return "holdings";
+  if (event.relation === "watchlist") return "watchlist";
+  return null;
+}
+
+export function toEventVM(event: CalendarEvent, date: string): CalendarEventVM {
+  const day = Number.parseInt(date.slice(8, 10), 10);
+  const month = Number.parseInt(date.slice(5, 7), 10);
+  return {
+    id: event.eventId,
+    date,
+    dayOfMonth: day,
+    monthDay: `${month}/${day}`,
+    type: mapEventType(event.eventType),
+    region: mapMarketToRegion(event.market),
+    title: event.title,
+    time: event.eventTimeLocal ?? null,
+    released: event.actual != null,
+    actual: event.actual ?? null,
+    forecast: event.forecast ?? null,
+    previous: event.previous ?? null,
+    own: mapOwnership(event),
+    badges: event.badges,
+  };
+}
+
+export function computeWeekLabel(fromDate: string): string {
+  const [, monthStr, dayStr] = fromDate.split("-");
+  const month = Number.parseInt(monthStr ?? "0", 10);
+  const day = Number.parseInt(dayStr ?? "0", 10);
+  const weekOfMonth = Math.floor((day - 1) / 7) + 1;
+  return `${month}월 ${weekOfMonth}주차`;
+}
+
+export function shortDateLabel(date: string): string {
+  const [, monthStr, dayStr] = date.split("-");
+  const month = Number.parseInt(monthStr ?? "0", 10);
+  const day = Number.parseInt(dayStr ?? "0", 10);
+  return `${month}/${day}`;
+}
+
+export function dayOfWeekLabel(date: string): string {
+  const labels = ["일", "월", "화", "수", "목", "금", "토"];
+  const idx = new Date(`${date}T00:00:00`).getDay();
+  return labels[idx] ?? "";
+}

--- a/frontend/invest/src/pages/desktop/DesktopCalendarPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCalendarPage.tsx
@@ -2,18 +2,42 @@ import { useEffect, useMemo, useState } from "react";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { RightAccountPanel } from "../../desktop/RightAccountPanel";
 import { useAccountPanel } from "../../desktop/useAccountPanel";
+import { useViewport } from "../../hooks/useViewport";
 import { fetchCalendar, fetchWeeklySummary } from "../../api/calendar";
 import type { CalendarResponse, WeeklySummaryResponse } from "../../types/calendar";
+import { Card, Icon } from "../../ds";
+import { WeekDateStrip } from "../../components/calendar/WeekDateStrip";
+import { AIWeeklyCard } from "../../components/calendar/AIWeeklyCard";
+import { EventRow } from "../../components/calendar/EventRow";
+import { EmptyEventState } from "../../components/calendar/EmptyEventState";
+import { EventDetailModal } from "../../components/calendar/EventDetailModal";
+import {
+  computeWeekLabel,
+  toEventVM,
+  type CalendarEventVM,
+  type DisplayEventType,
+  type DisplayRegion,
+} from "../../components/calendar/vm";
+import { MobileCalendarPage } from "../mobile/MobileCalendarPage";
 
 function startOfWeek(d: Date): Date {
   const out = new Date(d);
-  const day = (out.getDay() + 6) % 7; // Mon=0
+  const day = (out.getDay() + 6) % 7; // Mon = 0
   out.setDate(out.getDate() - day);
   out.setHours(0, 0, 0, 0);
   return out;
 }
 
-function fmt(d: Date) { return d.toISOString().slice(0, 10); }
+function fmt(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+type TypeFilter = "all" | DisplayEventType;
+type RegionFilter = "all" | DisplayRegion;
+
+export function CalendarRoute() {
+  return useViewport() === "mobile" ? <MobileCalendarPage /> : <DesktopCalendarPage />;
+}
 
 export function DesktopCalendarPage() {
   const panel = useAccountPanel();
@@ -23,107 +47,268 @@ export function DesktopCalendarPage() {
     e.setDate(e.getDate() + 6);
     return e;
   }, [weekStart]);
-  const [selectedDate, setSelectedDate] = useState<string>(fmt(new Date()));
+  const today = fmt(new Date());
+  const [selectedDate, setSelectedDate] = useState<string>(today);
   const [calendar, setCalendar] = useState<CalendarResponse | undefined>();
+  const [calendarErr, setCalendarErr] = useState<string | undefined>();
   const [summary, setSummary] = useState<WeeklySummaryResponse | undefined>();
+  const [summaryErr, setSummaryErr] = useState<string | undefined>();
+  const [summaryLoading, setSummaryLoading] = useState(false);
   const [showSummary, setShowSummary] = useState(false);
-  const [err, setErr] = useState<string | undefined>();
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+  const [regionFilter, setRegionFilter] = useState<RegionFilter>("all");
 
   useEffect(() => {
     let cancel = false;
-    setErr(undefined);
+    setCalendar(undefined);
+    setCalendarErr(undefined);
     fetchCalendar({ fromDate: fmt(weekStart), toDate: fmt(weekEnd), tab: "all" })
       .then((r) => !cancel && setCalendar(r))
-      .catch((e) => !cancel && setErr(String(e?.message ?? e)));
-    return () => { cancel = true; };
+      .catch((e) => !cancel && setCalendarErr(String(e?.message ?? e)));
+    return () => {
+      cancel = true;
+    };
   }, [weekStart, weekEnd]);
 
   useEffect(() => {
     if (!showSummary) return;
-    fetchWeeklySummary(fmt(weekStart)).then(setSummary).catch((e) => setErr(String(e?.message ?? e)));
+    if (summary && summary.weekStart === fmt(weekStart)) return;
+    let cancel = false;
+    setSummary(undefined);
+    setSummaryErr(undefined);
+    setSummaryLoading(true);
+    fetchWeeklySummary(fmt(weekStart))
+      .then((r) => {
+        if (cancel) return;
+        setSummary(r);
+        setSummaryLoading(false);
+      })
+      .catch((e) => {
+        if (cancel) return;
+        setSummaryErr(String(e?.message ?? e));
+        setSummaryLoading(false);
+      });
+    return () => {
+      cancel = true;
+    };
+    // summary identity check above is intentional; we want a fresh fetch when weekStart changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [showSummary, weekStart]);
 
   const days = calendar?.days ?? [];
-  const selectedDay = days.find((d) => d.date === selectedDate);
+  const allEventsVM: CalendarEventVM[] = useMemo(() => {
+    const out: CalendarEventVM[] = [];
+    for (const d of days) {
+      for (const e of d.events) out.push(toEventVM(e, d.date));
+    }
+    return out;
+  }, [days]);
+
+  const filteredEvents = useMemo(() => {
+    return allEventsVM.filter((e) => {
+      if (typeFilter !== "all" && e.type !== typeFilter) return false;
+      if (regionFilter !== "all" && e.region !== regionFilter) return false;
+      return true;
+    });
+  }, [allEventsVM, typeFilter, regionFilter]);
+
+  const eventsBySelectedDate = useMemo(
+    () => filteredEvents.filter((e) => e.date === selectedDate),
+    [filteredEvents, selectedDate],
+  );
+
+  const weekLabel = computeWeekLabel(fmt(weekStart));
 
   return (
-    <DesktopShell
-      center={
-        <div>
-          <header style={{ display: "flex", gap: 8, alignItems: "center", marginBottom: 16 }}>
-            <button onClick={() => setWeekStart((w) => { const n = new Date(w); n.setDate(n.getDate() - 7); return n; })}>이전 주</button>
-            <strong>{fmt(weekStart)} ~ {fmt(weekEnd)}</strong>
-            <button onClick={() => setWeekStart((w) => { const n = new Date(w); n.setDate(n.getDate() + 7); return n; })}>다음 주</button>
-            <button data-testid="open-weekly-summary" onClick={() => setShowSummary((s) => !s)} style={{ marginLeft: "auto" }}>
-              이번주 AI 요약 {showSummary ? "닫기" : "열기"}
-            </button>
-          </header>
+    <>
+      <DesktopShell
+      left={
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <Card style={{ padding: 16 }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
+              <div style={{ fontSize: 14, fontWeight: 700, letterSpacing: "-0.01em" }}>{weekLabel}</div>
+              <div style={{ display: "flex", gap: 4 }}>
+                <button
+                  type="button"
+                  aria-label="이전 주"
+                  data-testid="calendar-prev-week"
+                  onClick={() =>
+                    setWeekStart((w) => {
+                      const n = new Date(w);
+                      n.setDate(n.getDate() - 7);
+                      return n;
+                    })
+                  }
+                  style={navBtnStyle}
+                >
+                  <Icon name="chev" size={14} />
+                </button>
+                <button
+                  type="button"
+                  aria-label="다음 주"
+                  data-testid="calendar-next-week"
+                  onClick={() =>
+                    setWeekStart((w) => {
+                      const n = new Date(w);
+                      n.setDate(n.getDate() + 7);
+                      return n;
+                    })
+                  }
+                  style={{ ...navBtnStyle, transform: "scaleX(-1)" }}
+                >
+                  <Icon name="chev" size={14} />
+                </button>
+              </div>
+            </div>
+            <WeekDateStrip
+              days={days}
+              selectedDate={selectedDate}
+              onSelect={setSelectedDate}
+              today={today}
+            />
+          </Card>
 
-          {err && <div style={{ color: "#f59e9e", marginBottom: 12 }}>오류: {err}</div>}
-
-          <div style={{ display: "flex", gap: 4, marginBottom: 16 }}>
-            {days.map((d) => (
-              <button
-                key={d.date}
-                data-testid={`day-${d.date}`}
-                onClick={() => setSelectedDate(d.date)}
-                style={{
-                  flex: 1, padding: "8px 4px", borderRadius: 6,
-                  background: selectedDate === d.date ? "var(--surface-2, #1c1e24)" : "var(--surface, #15181f)",
-                  border: "none", color: "#e8eaf0", cursor: "pointer", fontSize: 12,
-                }}
-              >
-                {d.date.slice(5)}
-                <div style={{ fontSize: 10, color: "#9ba0ab" }}>{d.events.length + d.clusters.length}</div>
-              </button>
-            ))}
-          </div>
-
-          <section data-testid="day-events" style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-            {selectedDay?.clusters.map((c) => (
-              <details key={c.clusterId} style={{ padding: 12, borderRadius: 10, background: "var(--surface, #15181f)" }}>
-                <summary style={{ cursor: "pointer" }}>{c.label} · {c.eventCount}건</summary>
-                <ul style={{ listStyle: "none", padding: 0, margin: 0, marginTop: 8 }}>
-                  {c.topEvents.map((ev) => (
-                    <li key={ev.eventId} style={{ fontSize: 13 }}>{ev.title}</li>
-                  ))}
-                </ul>
-              </details>
-            ))}
-            {selectedDay?.events.map((ev) => (
-              <article key={ev.eventId} data-testid="calendar-event" data-relation={ev.relation} style={{ padding: 12, borderRadius: 10, background: "var(--surface, #15181f)" }}>
-                <div style={{ display: "flex", justifyContent: "space-between", fontSize: 13, fontWeight: 600 }}>
-                  <span>{ev.title}</span>
-                  <span style={{ color: "#9ba0ab", fontSize: 11 }}>{ev.market.toUpperCase()} · {ev.eventType}</span>
-                </div>
-                {ev.badges.length > 0 && (
-                  <div style={{ marginTop: 4, fontSize: 11, color: "#9ba0ab" }}>{ev.badges.join(" · ")}</div>
-                )}
-              </article>
-            ))}
-            {selectedDay && selectedDay.events.length === 0 && selectedDay.clusters.length === 0 && (
-              <div style={{ padding: 16, color: "#9ba0ab" }}>해당 날짜 이벤트 없음</div>
-            )}
-          </section>
-
-          {showSummary && (
-            <section data-testid="weekly-summary" style={{ marginTop: 16, padding: 16, borderRadius: 12, background: "var(--surface, #15181f)" }}>
-              <h3 style={{ marginTop: 0 }}>이번주 AI 요약</h3>
-              {!summary && <div>로딩 중…</div>}
-              {summary && summary.partial && (
-                <div style={{ fontSize: 12, color: "#9ba0ab" }}>일부 일자가 비어있습니다: {summary.missingDates.join(", ")}</div>
-              )}
-              {summary?.sections.map((sec, i) => (
-                <article key={i} style={{ marginTop: 12 }}>
-                  <h4 style={{ margin: 0, fontSize: 14 }}>{sec.title}</h4>
-                  <pre style={{ whiteSpace: "pre-wrap", fontSize: 12, color: "#cfd2da" }}>{sec.body}</pre>
-                </article>
-              ))}
-            </section>
-          )}
+          <AIWeeklyCard
+            summary={summary}
+            loading={summaryLoading}
+            onOpen={() => setShowSummary(true)}
+            compact
+          />
         </div>
       }
-      right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} />}
-    />
+      center={
+        <>
+          <header>
+            <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800, letterSpacing: "-0.02em" }}>캘린더</h1>
+            <p style={{ margin: "4px 0 0", fontSize: 13, color: "var(--fg-3)" }}>
+              실적·경제지표·주요 이벤트를 한 주 단위로 확인하세요.
+            </p>
+          </header>
+
+          <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+            <FilterGroup>
+              {([
+                ["all", "전체"],
+                ["macro", "경제지표"],
+                ["earnings", "실적"],
+              ] as const).map(([k, l]) => (
+                <SegPill key={k} on={typeFilter === k} onClick={() => setTypeFilter(k)}>
+                  {l}
+                </SegPill>
+              ))}
+            </FilterGroup>
+            <FilterGroup>
+              {([
+                ["all", "전체"],
+                ["kr", "국내"],
+                ["us", "해외"],
+              ] as const).map(([k, l]) => (
+                <SegPill key={k} on={regionFilter === k} onClick={() => setRegionFilter(k)}>
+                  {l}
+                </SegPill>
+              ))}
+            </FilterGroup>
+          </div>
+
+          {calendarErr && <div style={{ color: "var(--danger)" }}>오류: {calendarErr}</div>}
+
+          <Card style={{ padding: "16px 6px" }}>
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "44px minmax(0, 1fr) 76px 76px 76px",
+                alignItems: "center",
+                gap: 10,
+                padding: "0 14px 10px",
+                borderBottom: "1px solid var(--divider)",
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 14,
+                  fontWeight: 800,
+                  color: "var(--fg)",
+                  letterSpacing: "-0.01em",
+                  gridColumn: "1 / 3",
+                }}
+              >
+                {selectedDate}
+              </div>
+              <div style={{ textAlign: "right", fontSize: 11, fontWeight: 600, color: "var(--fg-3)", letterSpacing: "0.04em" }}>
+                발표
+              </div>
+              <div style={{ textAlign: "right", fontSize: 11, fontWeight: 600, color: "var(--fg-3)", letterSpacing: "0.04em" }}>
+                예측
+              </div>
+              <div style={{ textAlign: "right", fontSize: 11, fontWeight: 600, color: "var(--fg-3)", letterSpacing: "0.04em" }}>
+                이전
+              </div>
+            </div>
+
+            <div data-testid="day-events" style={{ paddingTop: 4 }}>
+              {eventsBySelectedDate.length === 0 ? (
+                <EmptyEventState message="해당 날짜에는 일정이 없습니다." />
+              ) : (
+                eventsBySelectedDate.map((ev) => <EventRow key={ev.id} ev={ev} />)
+              )}
+            </div>
+          </Card>
+        </>
+      }
+      right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} onRefresh={panel.reload} />}
+      />
+      {showSummary && (
+        <EventDetailModal
+          summary={summary}
+          loading={summaryLoading}
+          error={summaryErr}
+          onClose={() => setShowSummary(false)}
+        />
+      )}
+    </>
+  );
+}
+
+const navBtnStyle: React.CSSProperties = {
+  width: 24,
+  height: 24,
+  border: "none",
+  background: "transparent",
+  borderRadius: 6,
+  cursor: "pointer",
+  color: "var(--fg-2)",
+  display: "grid",
+  placeItems: "center",
+};
+
+function FilterGroup({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ display: "inline-flex", padding: 3, background: "var(--surface-2)", borderRadius: 999 }}>
+      {children}
+    </div>
+  );
+}
+
+function SegPill({ on, children, onClick }: { on: boolean; children: React.ReactNode; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        padding: "6px 14px",
+        border: "none",
+        borderRadius: 999,
+        cursor: "pointer",
+        background: on ? "var(--fg)" : "transparent",
+        color: on ? "#fff" : "var(--fg-2)",
+        fontWeight: 600,
+        fontSize: 13,
+        fontFamily: "inherit",
+        whiteSpace: "nowrap",
+        flexShrink: 0,
+      }}
+    >
+      {children}
+    </button>
   );
 }

--- a/frontend/invest/src/pages/mobile/MobileCalendarPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileCalendarPage.tsx
@@ -1,0 +1,269 @@
+import { useEffect, useMemo, useState } from "react";
+import { MobileShell } from "../../mobile/MobileShell";
+import { fetchCalendar, fetchWeeklySummary } from "../../api/calendar";
+import type { CalendarResponse, WeeklySummaryResponse } from "../../types/calendar";
+import { Icon } from "../../ds";
+import { WeekDateStrip } from "../../components/calendar/WeekDateStrip";
+import { EmptyEventState } from "../../components/calendar/EmptyEventState";
+import { EventDetailModal } from "../../components/calendar/EventDetailModal";
+import { RegionBadge } from "../../components/calendar/RegionBadge";
+import { OwnershipTag } from "../../components/calendar/OwnershipTag";
+import { SparkleIcon } from "../../components/calendar/SparkleIcon";
+import {
+  computeWeekLabel,
+  toEventVM,
+  type CalendarEventVM,
+  type DisplayEventType,
+} from "../../components/calendar/vm";
+
+function startOfWeek(d: Date): Date {
+  const out = new Date(d);
+  const day = (out.getDay() + 6) % 7;
+  out.setDate(out.getDate() - day);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+function fmt(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+type TypeFilter = "all" | DisplayEventType;
+
+export function MobileCalendarPage() {
+  const [weekStart, setWeekStart] = useState<Date>(() => startOfWeek(new Date()));
+  const weekEnd = useMemo(() => {
+    const e = new Date(weekStart);
+    e.setDate(e.getDate() + 6);
+    return e;
+  }, [weekStart]);
+  const today = fmt(new Date());
+  const [selectedDate, setSelectedDate] = useState<string>(today);
+  const [calendar, setCalendar] = useState<CalendarResponse | undefined>();
+  const [calendarErr, setCalendarErr] = useState<string | undefined>();
+  const [summary, setSummary] = useState<WeeklySummaryResponse | undefined>();
+  const [summaryErr, setSummaryErr] = useState<string | undefined>();
+  const [summaryLoading, setSummaryLoading] = useState(false);
+  const [showSummary, setShowSummary] = useState(false);
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+
+  useEffect(() => {
+    let cancel = false;
+    setCalendar(undefined);
+    setCalendarErr(undefined);
+    fetchCalendar({ fromDate: fmt(weekStart), toDate: fmt(weekEnd), tab: "all" })
+      .then((r) => !cancel && setCalendar(r))
+      .catch((e) => !cancel && setCalendarErr(String(e?.message ?? e)));
+    return () => {
+      cancel = true;
+    };
+  }, [weekStart, weekEnd]);
+
+  useEffect(() => {
+    if (!showSummary) return;
+    if (summary && summary.weekStart === fmt(weekStart)) return;
+    let cancel = false;
+    setSummary(undefined);
+    setSummaryErr(undefined);
+    setSummaryLoading(true);
+    fetchWeeklySummary(fmt(weekStart))
+      .then((r) => {
+        if (cancel) return;
+        setSummary(r);
+        setSummaryLoading(false);
+      })
+      .catch((e) => {
+        if (cancel) return;
+        setSummaryErr(String(e?.message ?? e));
+        setSummaryLoading(false);
+      });
+    return () => {
+      cancel = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showSummary, weekStart]);
+
+  const days = calendar?.days ?? [];
+  const allVM: CalendarEventVM[] = useMemo(() => {
+    const out: CalendarEventVM[] = [];
+    for (const d of days) {
+      for (const e of d.events) out.push(toEventVM(e, d.date));
+    }
+    return out;
+  }, [days]);
+  const filtered = useMemo(
+    () => (typeFilter === "all" ? allVM : allVM.filter((e) => e.type === typeFilter)),
+    [allVM, typeFilter],
+  );
+  const eventsForSelected = useMemo(
+    () => filtered.filter((e) => e.date === selectedDate),
+    [filtered, selectedDate],
+  );
+
+  const weekLabel = computeWeekLabel(fmt(weekStart));
+
+  return (
+    <>
+      <MobileShell title="캘린더">
+        <div style={{ padding: "12px 16px 24px", display: "flex", flexDirection: "column", gap: 14 }}>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+            <button
+              type="button"
+              data-testid="calendar-prev-week"
+              aria-label="이전 주"
+              onClick={() =>
+                setWeekStart((w) => {
+                  const n = new Date(w);
+                  n.setDate(n.getDate() - 7);
+                  return n;
+                })
+              }
+              style={iconBtn}
+            >
+              <Icon name="chev" size={16} />
+            </button>
+            <div style={{ fontSize: 14, fontWeight: 700 }}>{weekLabel}</div>
+            <button
+              type="button"
+              data-testid="calendar-next-week"
+              aria-label="다음 주"
+              onClick={() =>
+                setWeekStart((w) => {
+                  const n = new Date(w);
+                  n.setDate(n.getDate() + 7);
+                  return n;
+                })
+              }
+              style={{ ...iconBtn, transform: "scaleX(-1)" }}
+            >
+              <Icon name="chev" size={16} />
+            </button>
+          </div>
+
+          <WeekDateStrip days={days} selectedDate={selectedDate} onSelect={setSelectedDate} today={today} />
+
+          <button
+            type="button"
+            data-testid="open-weekly-summary"
+            onClick={() => setShowSummary(true)}
+            style={{
+              border: "none",
+              background: "var(--surface-2)",
+              padding: "10px 14px",
+              borderRadius: 12,
+              cursor: "pointer",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 8,
+              fontFamily: "inherit",
+              fontSize: 13,
+              fontWeight: 700,
+              color: "var(--accent-press)",
+              alignSelf: "flex-start",
+            }}
+          >
+            <SparkleIcon size={14} />
+            이번주 AI 요약
+            <Icon name="chev" size={12} />
+          </button>
+
+          <div style={{ display: "flex", gap: 6 }}>
+            {([
+              ["all", "전체"],
+              ["macro", "경제지표"],
+              ["earnings", "실적"],
+            ] as const).map(([k, l]) => {
+              const on = typeFilter === k;
+              return (
+                <button
+                  key={k}
+                  type="button"
+                  onClick={() => setTypeFilter(k)}
+                  style={{
+                    flex: "0 0 auto",
+                    padding: "6px 12px",
+                    border: "none",
+                    borderRadius: 999,
+                    cursor: "pointer",
+                    background: on ? "var(--fg)" : "var(--surface-2)",
+                    color: on ? "#fff" : "var(--fg-2)",
+                    fontWeight: 600,
+                    fontSize: 12,
+                    fontFamily: "inherit",
+                  }}
+                >
+                  {l}
+                </button>
+              );
+            })}
+          </div>
+
+          {calendarErr && <div style={{ color: "var(--danger)" }}>오류: {calendarErr}</div>}
+
+          <div data-testid="day-events" style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+            {eventsForSelected.length === 0 ? (
+              <EmptyEventState message="해당 날짜에는 일정이 없습니다." />
+            ) : (
+              eventsForSelected.map((ev) => (
+                <article
+                  key={ev.id}
+                  data-testid="calendar-event"
+                  data-event-id={ev.id}
+                  data-event-type={ev.type}
+                  data-relation={ev.own ?? "none"}
+                  style={{
+                    display: "flex",
+                    gap: 12,
+                    padding: "10px 0",
+                    borderBottom: "1px solid var(--divider)",
+                  }}
+                >
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+                      <RegionBadge region={ev.region} />
+                      <span style={{ fontSize: 14, fontWeight: 600, color: "var(--fg)" }}>{ev.title}</span>
+                      <OwnershipTag own={ev.own} />
+                    </div>
+                    <div
+                      style={{
+                        fontSize: 12,
+                        color: ev.released ? "var(--fg-2)" : "var(--fg-3)",
+                        marginTop: 2,
+                        fontFeatureSettings: '"tnum"',
+                      }}
+                    >
+                      {ev.actual != null && `발표 ${ev.actual} · `}
+                      {ev.forecast != null && `예측 ${ev.forecast} · `}
+                      {ev.previous != null && `이전 ${ev.previous}`}
+                      {ev.actual == null && ev.forecast == null && ev.previous == null && (ev.time ?? "발표 예정")}
+                    </div>
+                  </div>
+                </article>
+              ))
+            )}
+          </div>
+        </div>
+      </MobileShell>
+      {showSummary && (
+        <EventDetailModal
+          summary={summary}
+          loading={summaryLoading}
+          error={summaryErr}
+          onClose={() => setShowSummary(false)}
+        />
+      )}
+    </>
+  );
+}
+
+const iconBtn: React.CSSProperties = {
+  width: 32,
+  height: 32,
+  border: "none",
+  background: "var(--surface-2)",
+  borderRadius: 8,
+  cursor: "pointer",
+  color: "var(--fg-1)",
+  display: "grid",
+  placeItems: "center",
+};

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -8,7 +8,7 @@ import { InvestHomeRoute } from "./pages/desktop/DesktopHomePage";
 import { FeedNewsRoute } from "./pages/desktop/DesktopFeedNewsPage";
 import { InvestDiscoverRoute } from "./pages/desktop/DesktopDiscoverPage";
 import { SignalsRoute } from "./pages/desktop/DesktopSignalsPage";
-import { DesktopCalendarPage } from "./pages/desktop/DesktopCalendarPage";
+import { CalendarRoute } from "./pages/desktop/DesktopCalendarPage";
 import { DesktopScreenerPage } from "./pages/desktop/DesktopScreenerPage";
 
 export const router = createBrowserRouter(
@@ -20,7 +20,7 @@ export const router = createBrowserRouter(
     { path: "/discover", element: <InvestDiscoverRoute /> },
     { path: "/discover/issues/:issueId", element: <DiscoverIssueDetailPage /> },
     { path: "/signals", element: <SignalsRoute /> },
-    { path: "/calendar", element: <DesktopCalendarPage /> },
+    { path: "/calendar", element: <CalendarRoute /> },
     { path: "/screener", element: <DesktopScreenerPage /> },
 
     // Legacy /invest/app/* surface — preserved until Stage 6 retires it.


### PR DESCRIPTION
## Summary

Stage 5 of the `/invest` design-system migration plan, on top of
Stage 4 (#728, merged).

The Calendar route now uses the bundle's polished week-rail layout
on desktop and ships a responsive mobile sibling under the canonical
`/calendar` route. The page keeps the real
`/trading/api/market-events/range` data shape — the API delivers
a week range, so this stage builds a week-as-the-unit experience
rather than faking a month grid that the backend cannot back; a
month-grid mode can be layered on later when the API gains a
month-spanning fetch.

### What's added
- **`components/calendar/vm.ts`** — `CalendarEventVM` + `toEventVM`
  mapping `CalendarEvent` → display shape (`region` from `market`,
  `type` from `eventType`, `own` from `relation` + `badges`,
  raw `actual` / `forecast` / `previous` strings preserved).
- **`components/calendar/`** primitives — `WeekDateStrip`,
  `AIWeeklyCard`, `EventRow`, `EventDetailModal`, `RegionBadge`,
  `OwnershipTag`, `EmptyEventState`, `SparkleIcon`. All tokenized.
- **`pages/desktop/DesktopCalendarPage.tsx`** — 220 / 1fr / 320 grid
  with the week-label header + `WeekDateStrip` + `AIWeeklyCard` on
  the left rail; filters (전체/경제지표/실적 + 전체/국내/해외) and
  the day-events Card with `발표 / 예측 / 이전` columns in the
  center. Exports `CalendarRoute` viewport dispatcher.
- **`pages/mobile/MobileCalendarPage.tsx`** — week strip +
  AI-summary trigger + filter pills + day-grouped event rows
  under `MobileShell`.
- **`routes.tsx`** — `/calendar` → `CalendarRoute`.

### Existing test preserved
`__tests__/DesktopCalendarPage.test.tsx` still asserts:
- 7 elements with `data-testid="day-{YYYY-MM-DD}"`
- A `data-testid="open-weekly-summary"` trigger
- After click, `data-testid="weekly-summary"` element

All three contracts hold under the rebuild — no test changes needed.

### Out of scope
- Month-grid view (deferred until API exposes a month-spanning fetch).
- Per-event detail modal (`EventDetailModal` is reserved for the
  weekly summary; per-event detail can come in a follow-up if the
  API gains a richer per-event payload).

## Test Plan

- [x] `cd frontend/invest && npm run typecheck` — PASS
- [x] `cd frontend/invest && npm test -- --run` — 28 files / 93 tests PASS
- [x] `cd frontend/invest && npm run build` — PASS (`dist/assets/index-*.css 9.35 kB`,
      JS 393 kB)

### Visual smoke

`http://127.0.0.1:5174/invest/app/` (Vite dev base) → SPA navigate to
`/calendar`:
- [ ] Desktop ≥1200px: left-rail week label + 7-cell strip + AI summary
      preview; center filter row + day-events card
- [ ] Mobile <900px: title bar + chev nav for prev/next week + week
      strip + AI summary button + filter pills + day events
- [ ] Click `이번주 AI 요약` opens modal; ESC and backdrop click both
      close it
- [ ] Filter pills (경제지표 / 실적, 국내 / 해외) prune the event list
      consistently between desktop and mobile

## Scope-out / safety

- Read-only frontend work. No broker / order / watch / market-events
  mutation paths touched.
- All hooks (`useAccountPanel`, calendar API helpers) and types
  unchanged.