### PR TITLE
feat(invest): redirect legacy /invest/app/* to canonical /invest/* (Stage 6)

### DIFF
--- a/docs/plans/2026-05-09-invest-app-retirement-inventory.md
+++ b/docs/plans/2026-05-09-invest-app-retirement-inventory.md
@@ -1,0 +1,112 @@
+# `/invest/app/*` retirement inventory
+
+Companion to `docs/plans/2026-05-08-invest-design-system-migration-implementation-plan.md`.
+
+This Stage 6 doc inventories the legacy `/invest/app/*` mobile-only
+routes and components, defines the redirect rules being shipped now,
+and lists the files queued for deletion in a follow-up PR after a
+soak window.
+
+## Legacy → canonical redirects (this PR)
+
+The Stage 6 PR ships only the redirect rules. Legacy components stay
+mounted on the legacy import paths so the redirect hop is purely a URL
+shape — no behaviour change for users who land on a legacy URL via a
+bookmark or external link.
+
+| Legacy URL                                         | Redirect target                          |
+| -------------------------------------------------- | ---------------------------------------- |
+| `/invest/app`                                      | `/invest/`                               |
+| `/invest/app/discover`                             | `/invest/discover`                       |
+| `/invest/app/discover/issues/:issueId`             | `/invest/discover/issues/:issueId`       |
+| `/invest/app/paper`                                | `/invest/`                               |
+| `/invest/app/paper/:variant`                       | `/invest/`                               |
+
+Notes:
+- The wildcard `*` route (kept) still redirects unknown paths to `/`.
+- React-Router's `<Navigate replace>` is used for every redirect so
+  history doesn't get polluted with the legacy URL.
+- For the dynamic `/app/discover/issues/:issueId` redirect we render a
+  `<DiscoverIssueRedirect>` shim that reads the param and emits the
+  canonical path; static redirects use plain `<Navigate to=…>`.
+
+## Legacy components — preserved this PR, candidate for deletion
+
+These files are no longer reachable from the live router after the
+redirects ship, but stay in-tree for one release cycle so any
+downstream tooling or external bookmarks have time to migrate. The
+deletion happens in a separate later PR.
+
+```
+frontend/invest/src/pages/HomePage.tsx
+frontend/invest/src/pages/DiscoverPage.tsx
+frontend/invest/src/pages/DiscoverIssueDetailPage.tsx     # also reachable from canonical /discover/issues/:issueId — keep
+frontend/invest/src/pages/PaperPlaceholderPage.tsx
+
+frontend/invest/src/components/AppShell.tsx
+frontend/invest/src/components/HeroCard.tsx               # superseded by components/home/DesktopHero.tsx + MobileHomePage inline hero
+frontend/invest/src/components/AccountCardList.tsx
+frontend/invest/src/components/AccountSelector.tsx
+frontend/invest/src/components/AssetCategoryFilter.tsx    # AssetCategoryKey is exported from here; keep until consumers move to a shared types module
+frontend/invest/src/components/HoldingRow.tsx             # superseded by components/home/HoldingsTable.tsx
+frontend/invest/src/components/BottomNav.tsx              # superseded by mobile/MobileBottomNav.tsx
+
+frontend/invest/src/components/discover/AiIssueCard.tsx
+frontend/invest/src/components/discover/AiIssueTicker.tsx
+frontend/invest/src/components/discover/CategoryShortcutRail.tsx
+frontend/invest/src/components/discover/DiscoverCalendarCard.tsx
+frontend/invest/src/components/discover/DiscoverHeader.tsx
+frontend/invest/src/components/discover/IssueImpactMap.tsx
+frontend/invest/src/components/discover/RelatedSymbolsList.tsx
+```
+
+`DiscoverIssueDetailPage` is **kept** because the canonical
+`/discover/issues/:issueId` route reuses the same component.
+
+`AssetCategoryFilter` is **kept** until Stage 6 follow-up because
+`AssetCategoryKey` (its exported type) is consumed by
+`components/home/FilterChips`, `pages/desktop/DesktopHomePage`,
+`pages/mobile/MobileHomePage`, and `desktop/LeftContextRail`. The
+follow-up will move that type into a shared `types/filters.ts`.
+
+`severity.ts` (under `components/discover/`) is **kept** —
+`pages/desktop/DesktopDiscoverPage` and `pages/mobile/MobileDiscoverPage`
+both consume `describeDirection` and `sortMarketIssues`.
+
+## Legacy tests — preserved this PR, candidate for update/deletion
+
+```
+frontend/invest/src/__tests__/HomePage.test.tsx           # tests the legacy /app HomePage
+frontend/invest/src/__tests__/AccountCardList.test.tsx
+frontend/invest/src/__tests__/HoldingRow.test.tsx
+frontend/invest/src/__tests__/BottomNav.test.tsx
+frontend/invest/src/__tests__/AiIssueCard.test.tsx
+frontend/invest/src/__tests__/AiIssueTicker.test.tsx       # if present
+frontend/invest/src/__tests__/DiscoverPage.test.tsx
+frontend/invest/src/__tests__/DiscoverCalendarCard.test.tsx
+frontend/invest/src/__tests__/IssueImpactMap.test.tsx
+frontend/invest/src/__tests__/RelatedSymbolsList.test.tsx
+```
+
+These will be deleted with their corresponding components, or
+rewritten to target the canonical equivalents in the same follow-up.
+
+## Open questions
+
+- **`/app/paper`** — currently redirects to `/`. The placeholder
+  was an internal stub; if the team wants to expose a dedicated
+  `/invest/paper` surface (paper trading), open a separate ticket
+  and add the canonical route there.
+- **Soak window length** — recommend at least one full release cycle
+  before the deletion PR.
+
+## Deletion PR — separate, deferred
+
+Track as a follow-up issue. Steps for the cleanup PR:
+
+1. Delete the components + pages listed above.
+2. Move `AssetCategoryKey` from `components/AssetCategoryFilter.tsx`
+   to `types/filters.ts`; update consumers.
+3. Delete or rewrite the legacy tests.
+4. Run `npm run typecheck && npm test -- --run && npm run build`.
+5. Verify the canonical routes still work end-to-end.

--- a/frontend/invest/src/__tests__/legacyAppRedirects.test.tsx
+++ b/frontend/invest/src/__tests__/legacyAppRedirects.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RouterProvider, createMemoryRouter, Navigate, useParams } from "react-router-dom";
+
+// Stub the canonical pages with sentinel components so we can assert
+// which route element rendered after a redirect, without pulling in
+// the data-fetching machinery of the real pages.
+vi.mock("../pages/desktop/DesktopHomePage", () => ({
+  InvestHomeRoute: () => <div data-testid="canonical-home" />,
+}));
+vi.mock("../pages/desktop/DesktopFeedNewsPage", () => ({
+  FeedNewsRoute: () => <div data-testid="canonical-news" />,
+}));
+vi.mock("../pages/desktop/DesktopDiscoverPage", () => ({
+  InvestDiscoverRoute: () => <div data-testid="canonical-discover" />,
+}));
+vi.mock("../pages/desktop/DesktopSignalsPage", () => ({
+  SignalsRoute: () => <div data-testid="canonical-signals" />,
+}));
+vi.mock("../pages/desktop/DesktopCalendarPage", () => ({
+  CalendarRoute: () => <div data-testid="canonical-calendar" />,
+}));
+vi.mock("../pages/desktop/DesktopScreenerPage", () => ({
+  DesktopScreenerPage: () => <div data-testid="canonical-screener" />,
+}));
+vi.mock("../pages/DiscoverIssueDetailPage", () => ({
+  DiscoverIssueDetailPage: () => {
+    const { issueId } = useParams();
+    return <div data-testid="canonical-issue-detail" data-issue-id={issueId} />;
+  },
+}));
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+async function renderRoute(initialPath: string) {
+  // Re-import the router fresh per case so each test starts from the
+  // initialEntries we provide rather than carrying state across tests.
+  const { router: realRouter } = await import("../routes");
+  // The real router is a browser router; for jsdom we recreate the
+  // same route table on a memory router with the user's entry.
+  const routes = realRouter.routes;
+  const memory = createMemoryRouter(routes, {
+    basename: "/invest",
+    initialEntries: [`/invest${initialPath}`],
+  });
+  return render(<RouterProvider router={memory} />);
+}
+
+describe("legacy /invest/app/* redirects", () => {
+  it("/app -> /", async () => {
+    await renderRoute("/app");
+    await waitFor(() => expect(screen.getByTestId("canonical-home")).toBeInTheDocument());
+  });
+
+  it("/app/discover -> /discover", async () => {
+    await renderRoute("/app/discover");
+    await waitFor(() => expect(screen.getByTestId("canonical-discover")).toBeInTheDocument());
+  });
+
+  it("/app/discover/issues/:id -> /discover/issues/:id (preserving the id param)", async () => {
+    await renderRoute("/app/discover/issues/iss-xyz");
+    const detail = await waitFor(() => screen.getByTestId("canonical-issue-detail"));
+    expect(detail.getAttribute("data-issue-id")).toBe("iss-xyz");
+  });
+
+  it("/app/paper -> /", async () => {
+    await renderRoute("/app/paper");
+    await waitFor(() => expect(screen.getByTestId("canonical-home")).toBeInTheDocument());
+  });
+
+  it("/app/paper/:variant -> /", async () => {
+    await renderRoute("/app/paper/cycle");
+    await waitFor(() => expect(screen.getByTestId("canonical-home")).toBeInTheDocument());
+  });
+
+  it("unknown /app path falls through to the catch-all -> /", async () => {
+    await renderRoute("/app/something-unknown");
+    await waitFor(() => expect(screen.getByTestId("canonical-home")).toBeInTheDocument());
+  });
+});
+
+describe("canonical routes still resolve", () => {
+  it("/ renders the canonical home", async () => {
+    await renderRoute("/");
+    await waitFor(() => expect(screen.getByTestId("canonical-home")).toBeInTheDocument());
+  });
+
+  it("/discover renders the canonical discover", async () => {
+    await renderRoute("/discover");
+    await waitFor(() => expect(screen.getByTestId("canonical-discover")).toBeInTheDocument());
+  });
+
+  it("/calendar renders the canonical calendar", async () => {
+    await renderRoute("/calendar");
+    await waitFor(() => expect(screen.getByTestId("canonical-calendar")).toBeInTheDocument());
+  });
+});

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -1,15 +1,20 @@
 // frontend/invest/src/routes.tsx
-import { createBrowserRouter, Navigate } from "react-router-dom";
+import { createBrowserRouter, Navigate, useParams } from "react-router-dom";
 import { DiscoverIssueDetailPage } from "./pages/DiscoverIssueDetailPage";
-import { DiscoverPage } from "./pages/DiscoverPage";
-import { HomePage } from "./pages/HomePage";
-import { PaperPlaceholderPage } from "./pages/PaperPlaceholderPage";
 import { InvestHomeRoute } from "./pages/desktop/DesktopHomePage";
 import { FeedNewsRoute } from "./pages/desktop/DesktopFeedNewsPage";
 import { InvestDiscoverRoute } from "./pages/desktop/DesktopDiscoverPage";
 import { SignalsRoute } from "./pages/desktop/DesktopSignalsPage";
 import { CalendarRoute } from "./pages/desktop/DesktopCalendarPage";
 import { DesktopScreenerPage } from "./pages/desktop/DesktopScreenerPage";
+
+// Stage 6: redirect dynamic legacy /app/discover/issues/:issueId path
+// to the canonical /discover/issues/:issueId, preserving the issueId
+// param so external bookmarks survive the rename.
+function DiscoverIssueRedirect() {
+  const { issueId } = useParams();
+  return <Navigate to={`/discover/issues/${issueId ?? ""}`} replace />;
+}
 
 export const router = createBrowserRouter(
   [
@@ -23,12 +28,15 @@ export const router = createBrowserRouter(
     { path: "/calendar", element: <CalendarRoute /> },
     { path: "/screener", element: <DesktopScreenerPage /> },
 
-    // Legacy /invest/app/* surface — preserved until Stage 6 retires it.
-    { path: "/app", element: <HomePage /> },
-    { path: "/app/paper", element: <PaperPlaceholderPage /> },
-    { path: "/app/paper/:variant", element: <PaperPlaceholderPage /> },
-    { path: "/app/discover", element: <DiscoverPage /> },
-    { path: "/app/discover/issues/:issueId", element: <DiscoverIssueDetailPage /> },
+    // Stage 6: legacy /invest/app/* URLs redirect to their canonical
+    // /invest/* siblings. The legacy components remain in-tree (not
+    // mounted) for one release cycle; deletion lands in a follow-up
+    // PR per docs/plans/2026-05-09-invest-app-retirement-inventory.md.
+    { path: "/app", element: <Navigate to="/" replace /> },
+    { path: "/app/paper", element: <Navigate to="/" replace /> },
+    { path: "/app/paper/:variant", element: <Navigate to="/" replace /> },
+    { path: "/app/discover", element: <Navigate to="/discover" replace /> },
+    { path: "/app/discover/issues/:issueId", element: <DiscoverIssueRedirect /> },
 
     { path: "*", element: <Navigate to="/" replace /> },
   ],


### PR DESCRIPTION
## Summary

Stage 6 of the `/invest` design-system migration plan, on top of
Stage 5 (#729, merged). This PR retires the legacy `/invest/app/*`
mobile-only IA in **redirect form** — external bookmarks keep working,
the legacy components are no longer reachable from the live router
(and no longer pulled into the production bundle), and the explicit
deletion is queued for a follow-up PR after a soak window.

### Redirect rules (in `routes.tsx`)

| Legacy URL | Redirect target |
|---|---|
| `/invest/app` | `/invest/` |
| `/invest/app/discover` | `/invest/discover` |
| `/invest/app/discover/issues/:issueId` | `/invest/discover/issues/:issueId` (param preserved) |
| `/invest/app/paper` | `/invest/` |
| `/invest/app/paper/:variant` | `/invest/` |

Every redirect uses `<Navigate replace>` so the legacy URL doesn't
pollute back-button history. The `:issueId` case uses a tiny
`<DiscoverIssueRedirect>` shim that reads the param via `useParams()`
and emits the canonical path.

### Bundle size win

Dropping the legacy page imports from `routes.tsx` (the components
remain on disk but are no longer pulled by the live router) cut the
production bundle from **393 kB → 373 kB JS**. Components stay
on disk for one release cycle so downstream tooling has time to
migrate; deletion is staged as a separate later PR per the inventory
doc.

### Inventory + soak plan

- **`docs/plans/2026-05-09-invest-app-retirement-inventory.md`** —
  full catalog of legacy files, legacy tests, what stays, what goes,
  and the soak-window plan for the deletion PR. `AssetCategoryFilter`
  and `DiscoverIssueDetailPage` are explicitly **kept** (consumed by
  canonical surfaces).

### Internal-link recap

External bookmarks are the only consumers that hit `/app/*` after
this PR ships. All in-app links to legacy paths were already migrated
to canonical equivalents in Stage 4.2 (`DesktopHeader` 발견,
`MobileBottomNav` 발견, `NewsCard` issue chip). The catch-all
`/app/*` redirect makes any straggler safe.

## Test Plan

- [x] `cd frontend/invest && npm run typecheck` — PASS
- [x] `cd frontend/invest && npm test -- --run` — 29 files / **102
      tests PASS** (93 prior + 9 new redirect tests; legacy
      `HomePage` / `BottomNav` / `DiscoverPage` component-level tests
      still pass against the unmounted-but-in-tree components)
- [x] `cd frontend/invest && npm run build` — PASS
      (`dist/assets/index-*.css 9.35 kB`, JS 373 kB)

### New redirect test

`frontend/invest/src/__tests__/legacyAppRedirects.test.tsx` mocks the
canonical pages with sentinel components and renders the live
`routes.tsx` route table on a memory router, asserting every legacy
URL lands on the right canonical sentinel after redirect, plus that
canonical `/` / `/discover` / `/calendar` still resolve.

### Visual smoke

`http://127.0.0.1:5174/invest/app/` (Vite dev base) → SPA test:
- [ ] Visiting `/invest/app/` redirects to `/invest/`
- [ ] Visiting `/invest/app/discover` redirects to `/invest/discover`
- [ ] Visiting `/invest/app/discover/issues/some-id` redirects to
      `/invest/discover/issues/some-id` and the issue detail page
      receives the right param
- [ ] No internal link in the live UI still points at `/invest/app/...`

## Scope-out / safety

- Read-only frontend work. No broker / order / watch / market-events
  mutation paths touched.
- All hooks and types unchanged.
- Legacy components stay on disk; deletion is a separate later PR
  after a soak window.

## What's next

This is the last "build" stage of the migration plan. Remaining:

1. **Soak window** — let the redirects sit for one release cycle so
   external tooling and bookmarks can settle.
2. **Deletion PR** — delete the legacy components + tests per the
   inventory doc; move `AssetCategoryKey` to a shared types module;
   re-run typecheck / tests / build. Track as a follow-up issue.