### PR TITLE
fix(invest): Hermes follow-ups on Stage 4–6 (a11y + canonical detail surface + redirect search/hash)

### DIFF
--- a/frontend/invest/src/__tests__/DiscoverIssueDetailPage.test.tsx
+++ b/frontend/invest/src/__tests__/DiscoverIssueDetailPage.test.tsx
@@ -37,10 +37,10 @@ function makeResponse(items: MarketIssue[], over: Partial<MarketIssuesResponse> 
 
 function renderAt(path: string, state: DiscoverIssueDetailPageProps["state"]) {
   return render(
-    <MemoryRouter initialEntries={[`/invest/app${path}`]} basename="/invest">
+    <MemoryRouter initialEntries={[`/invest${path}`]} basename="/invest">
       <Routes>
         <Route
-          path="/app/discover/issues/:issueId"
+          path="/discover/issues/:issueId"
           element={<DiscoverIssueDetailPage state={state} reload={() => {}} />}
         />
       </Routes>
@@ -70,15 +70,23 @@ test("renders matched issue with impact map, related symbols and article links",
   ).toBeInTheDocument();
 });
 
-test("renders not-found state when id is missing", () => {
+test("renders not-found state when id is missing, with canonical back link", () => {
   renderAt("/discover/issues/missing", { status: "ready", data: makeResponse([]) });
   expect(
     screen.getByText(/이슈를 찾을 수 없습니다. 시간이 지나 목록에서 빠졌을 수 있어요./),
   ).toBeInTheDocument();
+  // The canonical /invest/discover path replaces the legacy /invest/app/discover.
   expect(screen.getByRole("link", { name: "발견으로 돌아가기" })).toHaveAttribute(
     "href",
-    "/invest/app/discover",
+    "/invest/discover",
   );
+});
+
+test("matched-issue back link points at canonical /invest/discover", () => {
+  const matched = makeIssue({ id: "abc" });
+  renderAt("/discover/issues/abc", { status: "ready", data: makeResponse([matched]) });
+  const back = screen.getByTestId("issue-detail-back");
+  expect(back).toHaveAttribute("href", "/invest/discover");
 });
 
 test("renders symbols-empty notice when item has no symbols", () => {

--- a/frontend/invest/src/__tests__/legacyAppRedirects.test.tsx
+++ b/frontend/invest/src/__tests__/legacyAppRedirects.test.tsx
@@ -1,32 +1,55 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { RouterProvider, createMemoryRouter, Navigate, useParams } from "react-router-dom";
+import { RouterProvider, createMemoryRouter, useLocation, useParams } from "react-router-dom";
 
-// Stub the canonical pages with sentinel components so we can assert
-// which route element rendered after a redirect, without pulling in
-// the data-fetching machinery of the real pages.
+// Stub the canonical pages with sentinel components that surface the
+// router's path / search / hash via data-attributes. Tests can then
+// assert the sentinel rendered (correct redirect target) AND that
+// search/hash from the legacy URL survived the redirect.
+function makeSentinel(testId: string) {
+  return function Sentinel() {
+    const { pathname, search, hash } = useLocation();
+    return (
+      <div
+        data-testid={testId}
+        data-pathname={pathname}
+        data-search={search}
+        data-hash={hash}
+      />
+    );
+  };
+}
+
 vi.mock("../pages/desktop/DesktopHomePage", () => ({
-  InvestHomeRoute: () => <div data-testid="canonical-home" />,
+  InvestHomeRoute: makeSentinel("canonical-home"),
 }));
 vi.mock("../pages/desktop/DesktopFeedNewsPage", () => ({
-  FeedNewsRoute: () => <div data-testid="canonical-news" />,
+  FeedNewsRoute: makeSentinel("canonical-news"),
 }));
 vi.mock("../pages/desktop/DesktopDiscoverPage", () => ({
-  InvestDiscoverRoute: () => <div data-testid="canonical-discover" />,
+  InvestDiscoverRoute: makeSentinel("canonical-discover"),
 }));
 vi.mock("../pages/desktop/DesktopSignalsPage", () => ({
-  SignalsRoute: () => <div data-testid="canonical-signals" />,
+  SignalsRoute: makeSentinel("canonical-signals"),
 }));
 vi.mock("../pages/desktop/DesktopCalendarPage", () => ({
-  CalendarRoute: () => <div data-testid="canonical-calendar" />,
+  CalendarRoute: makeSentinel("canonical-calendar"),
 }));
 vi.mock("../pages/desktop/DesktopScreenerPage", () => ({
-  DesktopScreenerPage: () => <div data-testid="canonical-screener" />,
+  DesktopScreenerPage: makeSentinel("canonical-screener"),
 }));
 vi.mock("../pages/DiscoverIssueDetailPage", () => ({
   DiscoverIssueDetailPage: () => {
     const { issueId } = useParams();
-    return <div data-testid="canonical-issue-detail" data-issue-id={issueId} />;
+    const { search, hash } = useLocation();
+    return (
+      <div
+        data-testid="canonical-issue-detail"
+        data-issue-id={issueId}
+        data-search={search}
+        data-hash={hash}
+      />
+    );
   },
 }));
 
@@ -35,11 +58,7 @@ afterEach(() => {
 });
 
 async function renderRoute(initialPath: string) {
-  // Re-import the router fresh per case so each test starts from the
-  // initialEntries we provide rather than carrying state across tests.
   const { router: realRouter } = await import("../routes");
-  // The real router is a browser router; for jsdom we recreate the
-  // same route table on a memory router with the user's entry.
   const routes = realRouter.routes;
   const memory = createMemoryRouter(routes, {
     basename: "/invest",
@@ -78,6 +97,34 @@ describe("legacy /invest/app/* redirects", () => {
   it("unknown /app path falls through to the catch-all -> /", async () => {
     await renderRoute("/app/something-unknown");
     await waitFor(() => expect(screen.getByTestId("canonical-home")).toBeInTheDocument());
+  });
+});
+
+describe("legacy /invest/app/* redirects preserve query and hash", () => {
+  it("/app?market=kr -> / preserves ?market=kr", async () => {
+    await renderRoute("/app?market=kr");
+    const home = await waitFor(() => screen.getByTestId("canonical-home"));
+    expect(home.getAttribute("data-search")).toBe("?market=kr");
+  });
+
+  it("/app/discover?market=kr&window=24 -> /discover preserves the full search string", async () => {
+    await renderRoute("/app/discover?market=kr&window=24");
+    const discover = await waitFor(() => screen.getByTestId("canonical-discover"));
+    expect(discover.getAttribute("data-search")).toBe("?market=kr&window=24");
+  });
+
+  it("/app/discover/issues/:id?market=kr#article-3 -> canonical detail preserves both search and hash", async () => {
+    await renderRoute("/app/discover/issues/abc?market=kr#article-3");
+    const detail = await waitFor(() => screen.getByTestId("canonical-issue-detail"));
+    expect(detail.getAttribute("data-issue-id")).toBe("abc");
+    expect(detail.getAttribute("data-search")).toBe("?market=kr");
+    expect(detail.getAttribute("data-hash")).toBe("#article-3");
+  });
+
+  it("/app/paper?variant=cycle -> / preserves the search", async () => {
+    await renderRoute("/app/paper?variant=cycle");
+    const home = await waitFor(() => screen.getByTestId("canonical-home"));
+    expect(home.getAttribute("data-search")).toBe("?variant=cycle");
   });
 });
 

--- a/frontend/invest/src/components/discover/IssueCard.tsx
+++ b/frontend/invest/src/components/discover/IssueCard.tsx
@@ -1,9 +1,14 @@
 import { Link } from "react-router-dom";
 import type { MarketIssue } from "../../types/newsIssues";
-import { Pill } from "../../ds";
+import { Icon, Pill } from "../../ds";
 import { describeDirection } from "./severity";
 import { formatRelativeTime } from "../../format/relativeTime";
 
+// IssueCard renders an <article> (non-interactive) containing two
+// sibling interactive elements: a <Link> on the title (navigates to
+// the issue detail page) and a <button> that toggles the inline
+// summary. The two sit at the same level in the DOM, so there is no
+// nested-interactive HTML violation.
 export function IssueCard({
   issue,
   expanded,
@@ -17,9 +22,10 @@ export function IssueCard({
 }) {
   const dir = describeDirection(issue.direction);
   const ago = formatRelativeTime(issue.updated_at) ?? "방금";
+  const summaryId = `issue-card-summary-${issue.id}`;
 
   return (
-    <li
+    <article
       data-testid="issue-card"
       data-issue-id={issue.id}
       data-direction={issue.direction}
@@ -28,25 +34,15 @@ export function IssueCard({
         border: "1px solid var(--border)",
         borderRadius: 16,
         boxShadow: "var(--shadow-1)",
-        listStyle: "none",
       }}
     >
-      <button
-        type="button"
-        onClick={onToggle}
+      <div
         style={{
           display: "flex",
           gap: 14,
           padding: 16,
-          width: "100%",
-          textAlign: "left",
-          background: "none",
-          border: "none",
-          cursor: "pointer",
-          fontFamily: "inherit",
-          color: "var(--fg)",
+          alignItems: "flex-start",
         }}
-        aria-expanded={expanded}
       >
         <div
           style={{
@@ -55,6 +51,7 @@ export function IssueCard({
             fontWeight: 800,
             color: "var(--fg-3)",
             fontFeatureSettings: '"tnum"',
+            paddingTop: 2,
           }}
           aria-label={`순위 ${issue.rank}`}
         >
@@ -69,7 +66,6 @@ export function IssueCard({
             <Link
               to={`${hrefPrefix}/${issue.id}`}
               data-testid="issue-card-detail-link"
-              onClick={(e) => e.stopPropagation()}
               style={{
                 fontSize: 15,
                 fontWeight: 700,
@@ -82,40 +78,69 @@ export function IssueCard({
             </Link>
           </div>
           {issue.subtitle && (
-            <div style={{ fontSize: 13, color: "var(--fg-3)", marginTop: 4, lineHeight: 1.45 }}>{issue.subtitle}</div>
+            <div style={{ fontSize: 13, color: "var(--fg-3)", marginTop: 4, lineHeight: 1.45 }}>
+              {issue.subtitle}
+            </div>
           )}
           <div style={{ fontSize: 12, color: "var(--fg-3)", marginTop: 8, display: "flex", gap: 10 }}>
             <span>{issue.source_count}개 출처</span>
             <span>· 기사 {issue.article_count}개</span>
             <span>· {ago}</span>
           </div>
+        </div>
 
-          {expanded && issue.summary && (
-            <div
-              data-testid="issue-card-summary"
-              style={{
-                marginTop: 12,
-                paddingTop: 12,
-                borderTop: "1px solid var(--divider)",
-                fontSize: 14,
-                color: "var(--fg-1)",
-                lineHeight: 1.6,
-              }}
-            >
-              {issue.summary}
-              {issue.related_symbols.length > 0 && (
-                <div style={{ marginTop: 10, display: "flex", gap: 6, flexWrap: "wrap" }}>
-                  {issue.related_symbols.map((s) => (
-                    <Pill key={`${s.market}:${s.symbol}`} tone="accent" size="sm">
-                      {s.canonical_name}
-                    </Pill>
-                  ))}
-                </div>
-              )}
+        <button
+          type="button"
+          data-testid="issue-card-toggle"
+          aria-expanded={expanded}
+          aria-controls={summaryId}
+          aria-label={expanded ? `${issue.issue_title} 요약 접기` : `${issue.issue_title} 요약 더보기`}
+          onClick={onToggle}
+          style={{
+            width: 32,
+            height: 32,
+            border: "none",
+            borderRadius: 8,
+            background: "var(--surface-2)",
+            color: "var(--fg-2)",
+            cursor: "pointer",
+            display: "grid",
+            placeItems: "center",
+            flexShrink: 0,
+            transform: expanded ? "rotate(90deg)" : "none",
+            transition: "transform 120ms cubic-bezier(0.2,0,0,1)",
+            fontFamily: "inherit",
+          }}
+        >
+          <Icon name="chev" size={14} />
+        </button>
+      </div>
+
+      {expanded && issue.summary && (
+        <div
+          id={summaryId}
+          data-testid="issue-card-summary"
+          style={{
+            margin: "0 16px 16px",
+            paddingTop: 12,
+            borderTop: "1px solid var(--divider)",
+            fontSize: 14,
+            color: "var(--fg-1)",
+            lineHeight: 1.6,
+          }}
+        >
+          {issue.summary}
+          {issue.related_symbols.length > 0 && (
+            <div style={{ marginTop: 10, display: "flex", gap: 6, flexWrap: "wrap" }}>
+              {issue.related_symbols.map((s) => (
+                <Pill key={`${s.market}:${s.symbol}`} tone="accent" size="sm">
+                  {s.canonical_name}
+                </Pill>
+              ))}
             </div>
           )}
         </div>
-      </button>
-    </li>
+      )}
+    </article>
   );
 }

--- a/frontend/invest/src/pages/DiscoverIssueDetailPage.tsx
+++ b/frontend/invest/src/pages/DiscoverIssueDetailPage.tsx
@@ -1,17 +1,36 @@
 // frontend/invest/src/pages/DiscoverIssueDetailPage.tsx
 import { Link, useParams } from "react-router-dom";
-import { AppShell } from "../components/AppShell";
-import { BottomNav } from "../components/BottomNav";
-import { IssueImpactMap } from "../components/discover/IssueImpactMap";
-import { RelatedSymbolsList } from "../components/discover/RelatedSymbolsList";
+import { DesktopHeader } from "../desktop/DesktopHeader";
+import { MobileShell } from "../mobile/MobileShell";
+import { useViewport } from "../hooks/useViewport";
+import { Card, Pill } from "../ds";
 import { describeDirection } from "../components/discover/severity";
 import { formatRelativeTime } from "../format/relativeTime";
 import { useNewsIssues, type NewsIssuesState } from "../hooks/useNewsIssues";
+import type {
+  IssueDirection,
+  MarketIssue,
+  MarketIssueRelatedSymbol,
+} from "../types/newsIssues";
 
 export interface DiscoverIssueDetailPageProps {
   state?: NewsIssuesState;
   reload?: () => void;
 }
+
+const DIRECTION_TONE: Record<IssueDirection, "gain" | "loss" | "warn" | "paper"> = {
+  up: "gain",
+  down: "loss",
+  mixed: "warn",
+  neutral: "paper",
+};
+
+const DIRECTION_COPY: Record<IssueDirection, string> = {
+  up: "관련 종목·섹터에 긍정 모멘텀으로 해석될 수 있어요.",
+  down: "관련 종목·섹터에 부담 요인으로 해석될 수 있어요.",
+  mixed: "수혜와 부담이 함께 나타날 수 있어 가격 반응을 나눠 봐야 해요.",
+  neutral: "방향성은 아직 뚜렷하지 않아 추가 뉴스 확인이 필요해요.",
+};
 
 export function DiscoverIssueDetailPage(props: DiscoverIssueDetailPageProps = {}) {
   const params = useParams<{ issueId: string }>();
@@ -27,114 +46,305 @@ export function DiscoverIssueDetailPage(props: DiscoverIssueDetailPageProps = {}
   const reload = props.reload ?? live.reload;
   const issueId = params.issueId ?? "";
 
-  if (state.status === "loading") {
+  return (
+    <DetailShell>
+      <IssueDetailBody state={state} reload={reload} issueId={issueId} />
+    </DetailShell>
+  );
+}
+
+function DetailShell({ children }: { children: React.ReactNode }) {
+  const viewport = useViewport();
+  if (viewport === "mobile") {
     return (
-      <AppShell>
-        <div className="subtle">불러오는 중…</div>
-        <BottomNav />
-      </AppShell>
+      <MobileShell title="이슈">
+        <div style={{ padding: "16px 16px 32px" }}>{children}</div>
+      </MobileShell>
     );
+  }
+  return (
+    <div style={{ minHeight: "100vh", background: "var(--bg-alt)" }}>
+      <DesktopHeader />
+      <main
+        style={{
+          maxWidth: 800,
+          margin: "0 auto",
+          padding: "24px 28px 64px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 16,
+        }}
+      >
+        {children}
+      </main>
+    </div>
+  );
+}
+
+function IssueDetailBody({
+  state,
+  reload,
+  issueId,
+}: {
+  state: NewsIssuesState;
+  reload: () => void;
+  issueId: string;
+}) {
+  if (state.status === "loading") {
+    return <div style={{ color: "var(--fg-3)" }}>불러오는 중…</div>;
   }
   if (state.status === "error") {
     return (
-      <AppShell>
-        <div>잠시 후 다시 시도해 주세요.</div>
-        <button type="button" onClick={reload}>
+      <div>
+        <div style={{ color: "var(--danger)", marginBottom: 8 }}>잠시 후 다시 시도해 주세요.</div>
+        <button
+          type="button"
+          onClick={reload}
+          style={{
+            padding: "6px 12px",
+            borderRadius: 8,
+            border: "1px solid var(--border)",
+            background: "var(--surface)",
+            color: "var(--fg-1)",
+            cursor: "pointer",
+            fontFamily: "inherit",
+            fontSize: 12,
+          }}
+        >
           재시도
         </button>
-        <div className="subtle">{state.message}</div>
-        <BottomNav />
-      </AppShell>
+        <div style={{ fontSize: 12, color: "var(--fg-3)", marginTop: 8 }}>{state.message}</div>
+      </div>
     );
   }
 
   const item = state.data.items.find((i) => i.id === issueId);
   if (!item) {
     return (
-      <AppShell>
-        <div style={{ padding: 16 }}>
-          <p>이슈를 찾을 수 없습니다. 시간이 지나 목록에서 빠졌을 수 있어요.</p>
-          <Link
-            to="/app/discover"
-            style={{ color: "var(--accent, #7eb6ff)", fontWeight: 700 }}
-          >
-            발견으로 돌아가기
-          </Link>
-        </div>
-        <BottomNav />
-      </AppShell>
+      <div>
+        <p style={{ marginTop: 0, color: "var(--fg-1)" }}>
+          이슈를 찾을 수 없습니다. 시간이 지나 목록에서 빠졌을 수 있어요.
+        </p>
+        <Link
+          to="/discover"
+          style={{ color: "var(--accent-press)", fontWeight: 700, textDecoration: "none" }}
+        >
+          발견으로 돌아가기
+        </Link>
+      </div>
     );
   }
 
+  return <IssueDetailView item={item} />;
+}
+
+function IssueDetailView({ item }: { item: MarketIssue }) {
   const indicator = describeDirection(item.direction);
   const time = formatRelativeTime(item.updated_at);
 
   return (
-    <AppShell>
-      <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-        <Link to="/app/discover" className="subtle" style={{ textDecoration: "none" }}>
-          ← 발견
-        </Link>
-        <header style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
-            <span
-              aria-label={indicator.label}
-              role="img"
-              style={{ color: indicator.color }}
-            >
-              {indicator.glyph}
-            </span>
-            <h1 style={{ margin: 0, fontSize: 18, fontWeight: 800 }}>{item.issue_title}</h1>
-          </div>
-          {item.summary && (
-            <p className="subtle" style={{ margin: 0 }}>{item.summary}</p>
-          )}
-          <div className="subtle" style={{ display: "flex", gap: 8, fontSize: 11 }}>
-            <span>{item.source_count}개 출처</span>
-            <span>· 기사 {item.article_count}개</span>
-            {time && <span>· {time}</span>}
-          </div>
-        </header>
-        <IssueImpactMap direction={item.direction} sectors={item.related_sectors} />
-        <RelatedSymbolsList symbols={item.related_symbols} />
-        <section aria-labelledby="articles-heading" style={{ marginTop: 16 }}>
-          <h2 id="articles-heading" style={{ margin: 0, fontSize: 14, fontWeight: 700 }}>
-            관련 뉴스
-          </h2>
-          {item.articles.length > 0 ? (
-            <ul style={{ listStyle: "none", margin: "8px 0 0", padding: 0, display: "flex", flexDirection: "column", gap: 8 }}>
-              {item.articles.map((article) => (
-                <li key={article.id} style={{ padding: 12, background: "var(--surface)", border: "1px solid var(--surface-2)", borderRadius: 12 }}>
-                  <a href={article.url} target="_blank" rel="noreferrer" style={{ color: "var(--text)", textDecoration: "none", fontWeight: 700 }}>
-                    {article.title}
-                  </a>
-                  <div className="subtle" style={{ marginTop: 4, fontSize: 11 }}>
-                    {article.source ?? article.feed_source ?? "출처 미상"}
-                  </div>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <div className="subtle" style={{ marginTop: 8 }}>관련 뉴스 원문 링크가 없습니다.</div>
-          )}
-        </section>
-        <section
-          style={{
-            marginTop: 16,
-            padding: 12,
-            background: "var(--surface)",
-            border: "1px solid var(--surface-2)",
-            borderRadius: 12,
-            fontSize: 12,
-          }}
-        >
-          <strong style={{ display: "block", marginBottom: 4 }}>꼭 알아두세요</strong>
-          <span className="subtle">
-            이 화면은 read-only 정보입니다. 매수/매도 주문이나 자동 추천을 제공하지 않습니다.
+    <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+      <Link
+        to="/discover"
+        data-testid="issue-detail-back"
+        style={{
+          fontSize: 12,
+          color: "var(--fg-3)",
+          textDecoration: "none",
+          fontWeight: 600,
+          alignSelf: "flex-start",
+        }}
+      >
+        ← 발견
+      </Link>
+
+      <header style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+          <span aria-label={indicator.label} role="img" style={{ color: indicator.color, fontWeight: 700 }}>
+            {indicator.glyph}
           </span>
-        </section>
-      </div>
-      <BottomNav />
-    </AppShell>
+          <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800, letterSpacing: "-0.02em" }}>
+            {item.issue_title}
+          </h1>
+        </div>
+        {item.summary && (
+          <p style={{ margin: 0, fontSize: 14, color: "var(--fg-2)", lineHeight: 1.6 }}>{item.summary}</p>
+        )}
+        <div style={{ display: "flex", gap: 8, fontSize: 11, color: "var(--fg-3)" }}>
+          <span>{item.source_count}개 출처</span>
+          <span>· 기사 {item.article_count}개</span>
+          {time && <span>· {time}</span>}
+        </div>
+      </header>
+
+      <ImpactSection direction={item.direction} sectors={item.related_sectors} />
+      <RelatedSymbolsSection symbols={item.related_symbols} />
+      <ArticlesSection articles={item.articles} />
+
+      <Card soft padded style={{ padding: 12, fontSize: 12 }}>
+        <strong style={{ display: "block", marginBottom: 4, color: "var(--fg)" }}>꼭 알아두세요</strong>
+        <span style={{ color: "var(--fg-3)" }}>
+          이 화면은 read-only 정보입니다. 매수/매도 주문이나 자동 추천을 제공하지 않습니다.
+        </span>
+      </Card>
+    </div>
   );
 }
+
+function ImpactSection({
+  direction,
+  sectors,
+}: {
+  direction: IssueDirection;
+  sectors: readonly string[];
+}) {
+  const labels = sectors.length > 0 ? sectors : ["관련 시장"];
+  const tone = DIRECTION_TONE[direction];
+  const copy = DIRECTION_COPY[direction];
+  return (
+    <section aria-labelledby="impact-heading">
+      <h2 id="impact-heading" style={{ margin: 0, fontSize: 14, fontWeight: 700, color: "var(--fg)" }}>
+        어떤 영향을 줄까?
+      </h2>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 8,
+          marginTop: 8,
+        }}
+      >
+        {labels.map((label) => (
+          <div
+            key={label}
+            style={{
+              display: "flex",
+              gap: 8,
+              alignItems: "center",
+              flexWrap: "wrap",
+              padding: "10px 14px",
+              borderRadius: 12,
+              background:
+                tone === "gain"
+                  ? "var(--gain-soft)"
+                  : tone === "loss"
+                    ? "var(--loss-soft)"
+                    : tone === "warn"
+                      ? "var(--warn-soft)"
+                      : "var(--surface-2)",
+              fontSize: 13,
+            }}
+          >
+            <strong style={{ color: "var(--fg)" }}>{label}</strong>
+            <span style={{ color: "var(--fg-2)" }}>{copy}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ marginTop: 12, fontSize: 11, color: "var(--fg-3)" }}>
+        뉴스 기반 참고 정보이며 매매 추천이 아닙니다.
+      </div>
+    </section>
+  );
+}
+
+function RelatedSymbolsSection({ symbols }: { symbols: readonly MarketIssueRelatedSymbol[] }) {
+  return (
+    <section aria-labelledby="symbols-heading">
+      <h2 id="symbols-heading" style={{ margin: 0, fontSize: 14, fontWeight: 700, color: "var(--fg)" }}>
+        관련 종목
+      </h2>
+      {symbols.length > 0 ? (
+        <ul
+          style={{
+            listStyle: "none",
+            padding: 0,
+            margin: "8px 0 0",
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+          }}
+        >
+          {symbols.map((sym) => (
+            <li
+              key={`${sym.market}:${sym.symbol}`}
+              style={{
+                padding: "10px 12px",
+                background: "var(--surface)",
+                border: "1px solid var(--border)",
+                borderRadius: 12,
+                fontSize: 13,
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                gap: 10,
+              }}
+            >
+              <strong style={{ color: "var(--fg)" }}>{sym.canonical_name || sym.symbol}</strong>
+              <span style={{ color: "var(--fg-3)", fontSize: 12, display: "flex", gap: 6, alignItems: "center" }}>
+                <span style={{ fontFamily: "var(--font-mono)" }}>{sym.symbol}</span>
+                <span aria-hidden style={{ width: 2, height: 2, background: "var(--fg-4)", borderRadius: 999 }} />
+                <span>{sym.mention_count}회 언급</span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div style={{ fontSize: 12, color: "var(--fg-3)", marginTop: 8 }}>관련 종목 분석은 준비 중입니다.</div>
+      )}
+    </section>
+  );
+}
+
+function ArticlesSection({
+  articles,
+}: {
+  articles: readonly MarketIssue["articles"][number][];
+}) {
+  return (
+    <section aria-labelledby="articles-heading">
+      <h2 id="articles-heading" style={{ margin: 0, fontSize: 14, fontWeight: 700, color: "var(--fg)" }}>
+        관련 뉴스
+      </h2>
+      {articles.length > 0 ? (
+        <ul
+          style={{
+            listStyle: "none",
+            margin: "8px 0 0",
+            padding: 0,
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+          }}
+        >
+          {articles.map((article) => (
+            <li
+              key={article.id}
+              style={{
+                padding: 12,
+                background: "var(--surface)",
+                border: "1px solid var(--border)",
+                borderRadius: 12,
+                boxShadow: "var(--shadow-1)",
+              }}
+            >
+              <a
+                href={article.url}
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: "var(--fg)", textDecoration: "none", fontWeight: 700, fontSize: 14 }}
+              >
+                {article.title}
+              </a>
+              <div style={{ marginTop: 4, fontSize: 11, color: "var(--fg-3)" }}>
+                {article.source ?? article.feed_source ?? "출처 미상"}
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div style={{ fontSize: 12, color: "var(--fg-3)", marginTop: 8 }}>관련 뉴스 원문 링크가 없습니다.</div>
+      )}
+    </section>
+  );
+}
+

--- a/frontend/invest/src/pages/desktop/DesktopDiscoverPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopDiscoverPage.tsx
@@ -74,7 +74,7 @@ export function DesktopDiscoverPage() {
                 return <div style={{ padding: 16, color: "var(--fg-3)" }}>표시할 이슈가 없습니다.</div>;
               }
               return (
-                <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 10 }}>
+                <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
                   {sorted.map((issue) => (
                     <IssueCard
                       key={issue.id}
@@ -83,7 +83,7 @@ export function DesktopDiscoverPage() {
                       onToggle={() => setOpenId(openId === issue.id ? null : issue.id)}
                     />
                   ))}
-                </ul>
+                </div>
               );
             })()}
           </div>

--- a/frontend/invest/src/pages/mobile/MobileDiscoverPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileDiscoverPage.tsx
@@ -46,7 +46,7 @@ export function MobileDiscoverPage() {
             return <div style={{ color: "var(--fg-3)" }}>표시할 이슈가 없습니다.</div>;
           }
           return (
-            <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 10 }}>
+            <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
               {sorted.map((issue) => (
                 <IssueCard
                   key={issue.id}
@@ -55,7 +55,7 @@ export function MobileDiscoverPage() {
                   onToggle={() => setOpenId(openId === issue.id ? null : issue.id)}
                 />
               ))}
-            </ul>
+            </div>
           );
         })()}
       </div>

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -1,5 +1,5 @@
 // frontend/invest/src/routes.tsx
-import { createBrowserRouter, Navigate, useParams } from "react-router-dom";
+import { createBrowserRouter, Navigate, useLocation, useParams } from "react-router-dom";
 import { DiscoverIssueDetailPage } from "./pages/DiscoverIssueDetailPage";
 import { InvestHomeRoute } from "./pages/desktop/DesktopHomePage";
 import { FeedNewsRoute } from "./pages/desktop/DesktopFeedNewsPage";
@@ -8,12 +8,21 @@ import { SignalsRoute } from "./pages/desktop/DesktopSignalsPage";
 import { CalendarRoute } from "./pages/desktop/DesktopCalendarPage";
 import { DesktopScreenerPage } from "./pages/desktop/DesktopScreenerPage";
 
-// Stage 6: redirect dynamic legacy /app/discover/issues/:issueId path
-// to the canonical /discover/issues/:issueId, preserving the issueId
-// param so external bookmarks survive the rename.
+// Static legacy /app/* redirect that preserves any ?search and #hash
+// from the source URL so market-scoped or anchor-scoped bookmarks
+// (e.g. /invest/app/discover?market=kr) keep their context after the
+// hop to canonical.
+function RedirectWithSearch({ to }: { to: string }) {
+  const { search, hash } = useLocation();
+  return <Navigate to={`${to}${search}${hash}`} replace />;
+}
+
+// Same idea for the dynamic /app/discover/issues/:issueId case —
+// preserve the param plus search/hash on the canonical path.
 function DiscoverIssueRedirect() {
   const { issueId } = useParams();
-  return <Navigate to={`/discover/issues/${issueId ?? ""}`} replace />;
+  const { search, hash } = useLocation();
+  return <Navigate to={`/discover/issues/${issueId ?? ""}${search}${hash}`} replace />;
 }
 
 export const router = createBrowserRouter(
@@ -32,10 +41,11 @@ export const router = createBrowserRouter(
     // /invest/* siblings. The legacy components remain in-tree (not
     // mounted) for one release cycle; deletion lands in a follow-up
     // PR per docs/plans/2026-05-09-invest-app-retirement-inventory.md.
-    { path: "/app", element: <Navigate to="/" replace /> },
-    { path: "/app/paper", element: <Navigate to="/" replace /> },
-    { path: "/app/paper/:variant", element: <Navigate to="/" replace /> },
-    { path: "/app/discover", element: <Navigate to="/discover" replace /> },
+    // Each redirect preserves the original ?search and #hash.
+    { path: "/app", element: <RedirectWithSearch to="/" /> },
+    { path: "/app/paper", element: <RedirectWithSearch to="/" /> },
+    { path: "/app/paper/:variant", element: <RedirectWithSearch to="/" /> },
+    { path: "/app/discover", element: <RedirectWithSearch to="/discover" /> },
     { path: "/app/discover/issues/:issueId", element: <DiscoverIssueRedirect /> },
 
     { path: "*", element: <Navigate to="/" replace /> },


### PR DESCRIPTION
## Summary

Three small fixes in response to Hermes's follow-up review of the
merged Stage 4–6 PRs (#728, #729, #730). None are merge-rollback
blockers; each addresses a concrete defect observed during post-merge
inspection.

### Commits

- **`c5f2d448` IssueCard a11y nesting** — the Discover `IssueCard`
  previously rendered `<button onClick={onToggle}><Link …/></button>`,
  which violates the rule against nested interactive elements. Split
  into `<article>` + sibling `<Link>` (title → detail page) +
  `<button>` (chevron toggle for inline summary). The toggle button
  carries `aria-expanded` and `aria-controls` pointing at the
  summary block's id; its `aria-label` spells out the action so AT
  doesn't announce a bare chevron. Parents
  (`DesktopDiscoverPage`/`MobileDiscoverPage`) swap their `<ul>`
  for a flex `<div>` since `<article>` is no longer a list-item child.

- **`e075fb7d` Canonical detail surface for `/discover/issues/:issueId`** —
  the canonical detail page still mounted inside the legacy `AppShell`
  + `BottomNav` and its 'back to discover' links pointed at the
  legacy `/app/discover` URL. Rewritten to use `DesktopHeader` on
  desktop and `MobileShell` on mobile, with both back links pointing
  at canonical `/discover`. `IssueImpactMap` and `RelatedSymbolsList`
  are inlined as small token-driven sections (`--gain-soft` /
  `--loss-soft` / `--warn-soft` / `--surface-2` for impact pills),
  removing one of the last consumers blocking the Stage 6 deletion
  follow-up. Test asserts the canonical back-link href
  (`/invest/discover`) on both the not-found and matched-issue
  paths.

- **`598bb018` Redirect search/hash preservation** — the Stage 6
  legacy redirects used a static `<Navigate to="/canonical">` which
  dropped any source `?search` and `#hash`. A user with a market-
  scoped bookmark like `/invest/app/discover?market=kr` would lose
  the market context after the redirect. Replaced with a
  `<RedirectWithSearch>` wrapper that reads `useLocation()` and
  appends the search + hash; `<DiscoverIssueRedirect>` does the
  same for the dynamic `:issueId` case. The catch-all `*` -> `/`
  redirect is intentionally NOT preserved (unknown paths shouldn't
  drag arbitrary state forward).

## Test Plan

- [x] `cd frontend/invest && npm run typecheck` — PASS
- [x] `cd frontend/invest && npm test -- --run` — **29 files / 107 tests** PASS
      (102 prior + 1 detail back-link + 4 search/hash preservation)
- [x] `cd frontend/invest && npm run build` — PASS
      (`dist/assets/index-*.css 9.35 kB`, JS 374 kB)

### What Hermes asked for vs. what landed

| Hermes ask | Where |
|---|---|
| IssueCard `button>Link` nesting → `article + Link/button` siblings | `c5f2d448` |
| Canonical detail surface (drop legacy AppShell/BottomNav, fix `/app/discover` back link) | `e075fb7d` |
| Preserve `?market=kr` etc. on `/app/discover/issues/:id` redirect | `598bb018` |

### Visual smoke

- [ ] `/invest/discover` — clicking the title navigates to detail; clicking
      the chevron toggles the inline summary in place; tab order /
      screen-reader order is sensible
- [ ] `/invest/discover/issues/:id` — desktop renders inside
      `DesktopHeader`, mobile inside `MobileShell`; back link reads
      '발견' and goes to `/invest/discover`
- [ ] Visiting `/invest/app/discover?market=kr` redirects to
      `/invest/discover?market=kr` — query string preserved
- [ ] Visiting `/invest/app/discover/issues/abc?market=kr#article-3`
      lands on `/invest/discover/issues/abc?market=kr#article-3` —
      both search AND hash preserved

## Scope-out / safety

- Read-only frontend work; no broker / order / watch / market-events
  mutation paths touched.
- All hooks and types unchanged.
- Legacy `IssueImpactMap` and `RelatedSymbolsList` components are no
  longer imported by canonical pages but stay on disk for the
  Stage 6 deletion follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved redirect handling that preserves query parameters and URL hashes when navigating legacy paths.
  * Enhanced responsive layout for issue detail pages across mobile and desktop.

* **Improvements**
  * Better accessibility and semantic structure for issue cards with improved interactive elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->