### PR TITLE
feat(invest): add dark theme tokens, default to dark, sweep hardcoded colors

### DIFF
--- a/frontend/invest/index.html
+++ b/frontend/invest/index.html
@@ -6,7 +6,7 @@
     <meta name="theme-color" content="#0e1116" />
     <title>내 투자 · auto_trader</title>
   </head>
-  <body style="background:#0e1116;color:#f1f3f5;margin:0;">
+  <body style="margin:0;">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/invest/index.html
+++ b/frontend/invest/index.html
@@ -1,12 +1,12 @@
 <!doctype html>
-<html lang="ko">
+<html lang="ko" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-    <meta name="theme-color" content="#0F1115" />
+    <meta name="theme-color" content="#0e1116" />
     <title>내 투자 · auto_trader</title>
   </head>
-  <body style="background:#0F1115;color:#E6E8EB;margin:0;">
+  <body style="background:#0e1116;color:#f1f3f5;margin:0;">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/frontend/invest/src/__tests__/tokens.contract.test.ts
+++ b/frontend/invest/src/__tests__/tokens.contract.test.ts
@@ -5,6 +5,7 @@ import { dirname, resolve } from "node:path";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const TOKENS_CSS = readFileSync(resolve(here, "../styles/tokens.css"), "utf8");
+const INDEX_HTML = readFileSync(resolve(here, "../../index.html"), "utf8");
 
 // Pull the body of the *first* CSS rule whose selector starts with `selector`.
 // We scan brace-by-brace so nested at-rules (`@media (...) { :root:not(...) {} }`)
@@ -99,5 +100,14 @@ describe("tokens.css contract", () => {
     // We expect at most a handful (light --bg, --surface, --fg-on-accent,
     // --accent-fg, dark --fg-on-accent, --accent-fg = 6).
     expect(componentHits.length).toBeLessThanOrEqual(8);
+  });
+
+  it("keeps index.html body color themeable", () => {
+    // Body can set layout-only styles, but themed color/background must come
+    // from tokens.css so data-theme="light" and future toggles are not
+    // overridden by inline dark first-paint styles.
+    const bodyTag = INDEX_HTML.match(/<body\b[^>]*>/i)?.[0] ?? "";
+    expect(bodyTag).not.toMatch(/background\s*:/i);
+    expect(bodyTag).not.toMatch(/color\s*:/i);
   });
 });

--- a/frontend/invest/src/__tests__/tokens.contract.test.ts
+++ b/frontend/invest/src/__tests__/tokens.contract.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const TOKENS_CSS = readFileSync(resolve(here, "../styles/tokens.css"), "utf8");
+
+// Pull the body of the *first* CSS rule whose selector starts with `selector`.
+// We scan brace-by-brace so nested at-rules (`@media (...) { :root:not(...) {} }`)
+// don't trip up a naive `indexOf("}")` search.
+function ruleBody(css: string, selector: string): string {
+  const startIdx = css.indexOf(selector);
+  if (startIdx < 0) throw new Error(`selector not found: ${selector}`);
+  let i = css.indexOf("{", startIdx);
+  if (i < 0) throw new Error(`opening brace not found after: ${selector}`);
+  const bodyStart = i + 1;
+  let depth = 1;
+  i = bodyStart;
+  while (i < css.length && depth > 0) {
+    const ch = css[i];
+    if (ch === "{") depth += 1;
+    else if (ch === "}") depth -= 1;
+    if (depth === 0) break;
+    i += 1;
+  }
+  if (depth !== 0) throw new Error(`unbalanced braces in: ${selector}`);
+  return css.slice(bodyStart, i);
+}
+
+const DARK_REQUIRED_TOKENS = [
+  "--bg",
+  "--bg-alt",
+  "--surface",
+  "--surface-2",
+  "--surface-3",
+  "--fg",
+  "--fg-1",
+  "--fg-2",
+  "--divider",
+  "--border",
+  "--gain",
+  "--loss",
+  "--overlay",
+  "--ai-card-bg",
+] as const;
+
+describe("tokens.css contract", () => {
+  it("declares the [data-theme=\"dark\"] selector", () => {
+    expect(TOKENS_CSS).toMatch(/\[data-theme="dark"\]\s*\{/);
+  });
+
+  it("defines every required dark token under [data-theme=\"dark\"]", () => {
+    const body = ruleBody(TOKENS_CSS, '[data-theme="dark"]');
+    for (const token of DARK_REQUIRED_TOKENS) {
+      // `--token: …;` — must have a non-empty value.
+      const re = new RegExp(`${token.replace(/[-\\^$*+?.()|[\]{}]/g, "\\$&")}\\s*:\\s*[^;]+;`);
+      expect(body, `missing ${token} in [data-theme="dark"]`).toMatch(re);
+    }
+  });
+
+  it("preserves Korean P/L semantics (gain ≠ loss, loss ≠ accent) under dark", () => {
+    const body = ruleBody(TOKENS_CSS, '[data-theme="dark"]');
+    const valueOf = (token: string): string => {
+      const re = new RegExp(`${token}\\s*:\\s*([^;]+);`);
+      const m = body.match(re);
+      if (!m || m[1] == null) throw new Error(`token not found: ${token}`);
+      return m[1].trim();
+    };
+    const gain = valueOf("--gain");
+    const loss = valueOf("--loss");
+    const accent = valueOf("--accent");
+    // ▲ red gain, ▼ blue loss, accent stays a separate brand blue.
+    expect(gain).not.toEqual(loss);
+    expect(loss).not.toEqual(accent);
+  });
+
+  it("keeps the light :root tokens intact (no dark overwrite at root)", () => {
+    const body = ruleBody(TOKENS_CSS, ":root");
+    expect(body).toMatch(/--bg\s*:\s*#ffffff/);
+    expect(body).toMatch(/--fg\s*:\s*#191f28/);
+    // Korean P/L stays red gain / blue loss in light.
+    expect(body).toMatch(/--gain\s*:\s*#f04452/);
+    expect(body).toMatch(/--loss\s*:\s*#2a6df4/);
+  });
+
+  it("OS dark fallback yields to explicit data-theme=\"light\"", () => {
+    // The fallback selector must exclude both data-theme="light" and "dark"
+    // so an explicit theme attribute always wins over OS preference.
+    expect(TOKENS_CSS).toMatch(
+      /@media\s*\(prefers-color-scheme:\s*dark\)\s*\{\s*:root:not\(\[data-theme="light"\]\):not\(\[data-theme="dark"\]\)/,
+    );
+  });
+
+  it("does not leave hardcoded card whites in the global stylesheet itself", () => {
+    // Allowlist: token-file is the only place where #ffffff may legitimately
+    // appear (as the light --bg / --surface value). Keep it out of components.
+    const componentHits = TOKENS_CSS.match(/#ffffff/gi) ?? [];
+    // We expect at most a handful (light --bg, --surface, --fg-on-accent,
+    // --accent-fg, dark --fg-on-accent, --accent-fg = 6).
+    expect(componentHits.length).toBeLessThanOrEqual(8);
+  });
+});

--- a/frontend/invest/src/components/AccountCardList.tsx
+++ b/frontend/invest/src/components/AccountCardList.tsx
@@ -30,8 +30,8 @@ function AccountCard({ a, warnings = [] }: { a: Account; warnings?: InvestHomeWa
             style={{
               padding: "1px 6px",
               borderRadius: 5,
-              background: "#1c1e24",
-              color: "var(--muted)",
+              background: "var(--surface-2)",
+              color: "var(--fg-2)",
               fontSize: 9,
             }}
           >

--- a/frontend/invest/src/components/calendar/AIWeeklyCard.tsx
+++ b/frontend/invest/src/components/calendar/AIWeeklyCard.tsx
@@ -19,8 +19,8 @@ export function AIWeeklyCard({
   return (
     <div
       style={{
-        background: compact ? "var(--surface-2)" : "linear-gradient(135deg, #f4f7ff 0%, #f9fafb 100%)",
-        border: compact ? "none" : "1px solid #e2e9f6",
+        background: compact ? "var(--surface-2)" : "var(--ai-card-bg)",
+        border: compact ? "none" : "1px solid var(--border)",
         borderRadius: 14,
         padding: 16,
       }}

--- a/frontend/invest/src/components/calendar/EventDetailModal.tsx
+++ b/frontend/invest/src/components/calendar/EventDetailModal.tsx
@@ -30,7 +30,7 @@ export function EventDetailModal({
       style={{
         position: "fixed",
         inset: 0,
-        background: "rgba(15, 20, 28, 0.32)",
+        background: "var(--overlay)",
         zIndex: 200,
         display: "grid",
         placeItems: "center",

--- a/frontend/invest/src/components/calendar/OwnershipTag.tsx
+++ b/frontend/invest/src/components/calendar/OwnershipTag.tsx
@@ -6,7 +6,7 @@ const MAP: Record<
 > = {
   holdings: { label: "보유", bg: "var(--gain-soft)", fg: "var(--gain)" },
   watchlist: { label: "관심", bg: "var(--accent-soft)", fg: "var(--accent-press)" },
-  major: { label: "주요", bg: "var(--warn-soft)", fg: "#a06200" },
+  major: { label: "주요", bg: "var(--warn-soft)", fg: "var(--warn)" },
 };
 
 export function OwnershipTag({ own }: { own: DisplayOwnership }) {

--- a/frontend/invest/src/components/calendar/WeekDateStrip.tsx
+++ b/frontend/invest/src/components/calendar/WeekDateStrip.tsx
@@ -56,7 +56,7 @@ export function WeekDateStrip({
                 display: "grid",
                 placeItems: "center",
                 background: isSelected ? "var(--accent)" : "transparent",
-                color: isSelected ? "#fff" : isToday ? "var(--accent)" : "var(--fg-1)",
+                color: isSelected ? "var(--fg-on-accent)" : isToday ? "var(--accent)" : "var(--fg-1)",
                 fontWeight: isSelected || isToday ? 700 : 500,
                 fontSize: 14,
                 fontFeatureSettings: '"tnum"',

--- a/frontend/invest/src/components/discover/DiscoverCalendarCard.tsx
+++ b/frontend/invest/src/components/discover/DiscoverCalendarCard.tsx
@@ -19,9 +19,9 @@ const TAB_LABELS: Record<DiscoverCalendarTab, string> = {
 };
 
 const BADGE_COLORS: Record<string, string> = {
-  held: "var(--accent, #2962ff)",
-  watched: "var(--info, #0288d1)",
-  major: "var(--neutral-strong, #555)",
+  held: "var(--accent)",
+  watched: "var(--info)",
+  major: "var(--fg-3)",
 };
 
 function dayOfMonth(iso: string): number {
@@ -54,11 +54,11 @@ function DayChip({
         borderRadius: 12,
         border: "1px solid var(--surface-2)",
         background: day.is_today
-          ? "var(--accent, #2962ff)"
+          ? "var(--accent)"
           : active
             ? "var(--surface-2)"
             : "transparent",
-        color: day.is_today ? "#fff" : "inherit",
+        color: day.is_today ? "var(--fg-on-accent)" : "inherit",
         fontSize: 12,
         minWidth: 44,
       }}
@@ -70,7 +70,7 @@ function DayChip({
 }
 
 function Badge({ label, priority }: { label: string; priority: string }) {
-  const color = BADGE_COLORS[priority] ?? "var(--neutral-strong, #555)";
+  const color = BADGE_COLORS[priority] ?? "var(--fg-3)";
   return (
     <span
       style={{
@@ -78,7 +78,7 @@ function Badge({ label, priority }: { label: string; priority: string }) {
         padding: "2px 6px",
         borderRadius: 999,
         background: color,
-        color: "#fff",
+        color: "var(--fg-on-accent)",
       }}
     >
       {label}

--- a/frontend/invest/src/components/discover/IssueImpactMap.tsx
+++ b/frontend/invest/src/components/discover/IssueImpactMap.tsx
@@ -3,10 +3,10 @@ import type { CSSProperties } from "react";
 import type { IssueDirection } from "../../types/newsIssues";
 
 const TONE_STYLES: Record<IssueDirection, CSSProperties> = {
-  up: { background: "var(--pill-mix)", color: "var(--pill-mix-fg)" },
-  down: { background: "var(--pill-toss)", color: "var(--pill-toss-fg)" },
-  mixed: { background: "var(--pill-up)", color: "var(--pill-up-fg)" },
-  neutral: { background: "var(--surface-2)", color: "var(--muted)" },
+  up: { background: "var(--gain-soft)", color: "var(--gain)" },
+  down: { background: "var(--loss-soft)", color: "var(--loss)" },
+  mixed: { background: "var(--warn-soft)", color: "var(--warn)" },
+  neutral: { background: "var(--surface-2)", color: "var(--fg-3)" },
 };
 
 const DIRECTION_COPY: Record<IssueDirection, string> = {

--- a/frontend/invest/src/components/home/FilterChips.tsx
+++ b/frontend/invest/src/components/home/FilterChips.tsx
@@ -29,7 +29,7 @@ export function FilterChips({
               border: "none",
               cursor: "pointer",
               background: on ? "var(--fg)" : "var(--surface-2)",
-              color: on ? "#fff" : "var(--fg-2)",
+              color: on ? "var(--bg)" : "var(--fg-2)",
               fontWeight: 600,
               fontSize: 13,
               fontFamily: "inherit",

--- a/frontend/invest/src/components/news/NewsTabs.tsx
+++ b/frontend/invest/src/components/news/NewsTabs.tsx
@@ -40,7 +40,7 @@ export function NewsTabs({
                 borderRadius: 999,
                 cursor: "pointer",
                 background: active ? "var(--fg)" : "var(--surface-2)",
-                color: active ? "#fff" : "var(--fg-2)",
+                color: active ? "var(--bg)" : "var(--fg-2)",
                 fontWeight: 600,
                 fontSize: 12,
                 fontFamily: "inherit",

--- a/frontend/invest/src/desktop/AccountSourceTone.ts
+++ b/frontend/invest/src/desktop/AccountSourceTone.ts
@@ -1,12 +1,14 @@
 import type { AccountSource, AccountSourceVisual, AccountTone } from "../types/invest";
 import type { PillTone } from "../ds";
 
+// Each tone maps onto the design system's source-pill tokens so the
+// account chrome themes correctly under both light and dark.
 const TONE_STYLE: Record<AccountTone, { color: string; bg: string; border: string }> = {
-  navy:   { color: "#dde3ff", bg: "#1e2a55", border: "#3a4a8a" },
-  gray:   { color: "#cfd2da", bg: "#2a2d35", border: "#3a3d45" },
-  purple: { color: "#e7daff", bg: "#3a2660", border: "#624aa0" },
-  green:  { color: "#dcf2e0", bg: "#1f3a2a", border: "#3c6a4d" },
-  dashed: { color: "#dbdee5", bg: "#1e2026", border: "#5a5e6a" },
+  navy:   { color: "var(--pill-kis-fg)",     bg: "var(--pill-kis-bg)",     border: "var(--border)" },
+  gray:   { color: "var(--pill-pension-fg)", bg: "var(--pill-pension-bg)", border: "var(--border)" },
+  purple: { color: "var(--pill-toss-fg)",    bg: "var(--pill-toss-bg)",    border: "var(--border)" },
+  green:  { color: "var(--pill-upbit-fg)",   bg: "var(--pill-upbit-bg)",   border: "var(--border)" },
+  dashed: { color: "var(--pill-paper-fg)",   bg: "var(--pill-paper-bg)",   border: "var(--border)" },
 };
 
 export function styleForVisual(v: AccountSourceVisual) {

--- a/frontend/invest/src/desktop/DesktopHeader.tsx
+++ b/frontend/invest/src/desktop/DesktopHeader.tsx
@@ -34,7 +34,7 @@ export function DesktopHeader() {
             height: 22,
             borderRadius: 6,
             background: "var(--accent)",
-            color: "#fff",
+            color: "var(--fg-on-accent)",
             display: "grid",
             placeItems: "center",
             fontSize: 12,

--- a/frontend/invest/src/desktop/screener/screener.css
+++ b/frontend/invest/src/desktop/screener/screener.css
@@ -35,7 +35,7 @@
 .screener-heart-off { color: var(--fg-4); }
 .screener-empty { padding: 32px; text-align: center; color: var(--fg-3); }
 
-.screener-modal-backdrop { position: fixed; inset: 0; background: rgba(15, 20, 28, 0.32); display: flex; align-items: center; justify-content: center; z-index: 50; }
+.screener-modal-backdrop { position: fixed; inset: 0; background: var(--overlay); display: flex; align-items: center; justify-content: center; z-index: 50; }
 .screener-modal { background: var(--surface); width: 720px; max-width: 90vw; max-height: 80vh; border-radius: 16px; display: flex; flex-direction: column; overflow: hidden; color: var(--fg); box-shadow: var(--shadow-3); }
 .screener-modal-header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; border-bottom: 1px solid var(--divider); }
 .screener-modal-header h3 { margin: 0; font-size: 16px; font-weight: 700; }

--- a/frontend/invest/src/ds/atoms.tsx
+++ b/frontend/invest/src/ds/atoms.tsx
@@ -24,7 +24,7 @@ const PILL_TONES: Record<PillTone, { bg: string; fg: string }> = {
   accent: { bg: "var(--accent-soft)", fg: "var(--accent-press)" },
   gain: { bg: "var(--gain-soft)", fg: "var(--gain)" },
   loss: { bg: "var(--loss-soft)", fg: "var(--loss)" },
-  warn: { bg: "var(--warn-soft)", fg: "#a06200" },
+  warn: { bg: "var(--warn-soft)", fg: "var(--warn)" },
 };
 
 export function Pill({
@@ -62,10 +62,10 @@ const BUTTON_SIZES: Record<ButtonSize, CSSProperties> = {
 };
 
 const BUTTON_VARIANTS: Record<ButtonVariant, CSSProperties> = {
-  primary: { background: "var(--accent)", color: "#fff" },
+  primary: { background: "var(--accent)", color: "var(--fg-on-accent)" },
   secondary: { background: "var(--surface-2)", color: "var(--fg-1)" },
   ghost: { background: "transparent", color: "var(--fg-2)" },
-  danger: { background: "var(--danger)", color: "#fff" },
+  danger: { background: "var(--danger)", color: "var(--fg-on-accent)" },
 };
 
 export function Button({
@@ -111,7 +111,7 @@ export function Card({
     <div
       data-soft={soft || undefined}
       style={{
-        background: soft ? "var(--surface-2)" : "#fff",
+        background: soft ? "var(--surface-2)" : "var(--surface)",
         border: soft ? "none" : "1px solid var(--border)",
         borderRadius: 16,
         boxShadow: soft ? "none" : "var(--shadow-1)",

--- a/frontend/invest/src/main.tsx
+++ b/frontend/invest/src/main.tsx
@@ -1,6 +1,9 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { applyInitialTheme } from "./theme/useTheme";
+
+applyInitialTheme();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/frontend/invest/src/pages/HomePage.tsx
+++ b/frontend/invest/src/pages/HomePage.tsx
@@ -93,8 +93,8 @@ export function HomePage(props?: { state?: InvestHomeState; reload?: () => void 
             padding: 8,
             color: "var(--warn)",
             fontSize: 10,
-            background: "rgba(246,193,119,0.08)",
-            border: "1px solid rgba(246,193,119,0.27)",
+            background: "var(--warn-soft)",
+            border: "1px solid var(--warn-soft)",
             borderRadius: 10,
           }}
         >

--- a/frontend/invest/src/pages/desktop/DesktopCalendarPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCalendarPage.tsx
@@ -300,7 +300,7 @@ function SegPill({ on, children, onClick }: { on: boolean; children: React.React
         borderRadius: 999,
         cursor: "pointer",
         background: on ? "var(--fg)" : "transparent",
-        color: on ? "#fff" : "var(--fg-2)",
+        color: on ? "var(--bg)" : "var(--fg-2)",
         fontWeight: 600,
         fontSize: 13,
         fontFamily: "inherit",

--- a/frontend/invest/src/pages/mobile/MobileCalendarPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileCalendarPage.tsx
@@ -186,7 +186,7 @@ export function MobileCalendarPage() {
                     borderRadius: 999,
                     cursor: "pointer",
                     background: on ? "var(--fg)" : "var(--surface-2)",
-                    color: on ? "#fff" : "var(--fg-2)",
+                    color: on ? "var(--bg)" : "var(--fg-2)",
                     fontWeight: 600,
                     fontSize: 12,
                     fontFamily: "inherit",

--- a/frontend/invest/src/pages/mobile/MobileHomePage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileHomePage.tsx
@@ -320,7 +320,7 @@ function PillButton({ on, onClick, children }: { on: boolean; onClick: () => voi
         borderRadius: 999,
         border: "none",
         background: on ? "var(--fg)" : "var(--surface-2)",
-        color: on ? "#fff" : "var(--fg-2)",
+        color: on ? "var(--bg)" : "var(--fg-2)",
         fontSize: 12,
         fontWeight: 600,
         whiteSpace: "nowrap",

--- a/frontend/invest/src/pages/mobile/MobileSignalsPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileSignalsPage.tsx
@@ -45,7 +45,7 @@ export function MobileSignalsPage() {
                   borderRadius: 999,
                   border: "none",
                   background: active ? "var(--fg)" : "var(--surface-2)",
-                  color: active ? "#fff" : "var(--fg-2)",
+                  color: active ? "var(--bg)" : "var(--fg-2)",
                   fontWeight: 600,
                   fontSize: 12,
                   fontFamily: "inherit",

--- a/frontend/invest/src/styles/tokens.css
+++ b/frontend/invest/src/styles/tokens.css
@@ -3,6 +3,11 @@
    Toss-style Korean fintech: light surfaces, calm grayscale,
    confident blue accent, Korean-fintech P/L color rule
    (▲ red = gain, ▼ blue = loss).
+
+   Token names stay the same across themes; values swap under
+   [data-theme="dark"]. Components read var(--*) only — never
+   hardcode. Explicit data-theme always wins over the
+   prefers-color-scheme fallback.
    ========================================================= */
 
 /* ---------- Webfont: Pretendard (Korean + Latin) ----------
@@ -14,6 +19,8 @@
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.css");
 
 :root {
+  color-scheme: light;
+
   /* ---------------- Color: Surfaces & Ink ---------------- */
   --bg:           #ffffff;   /* page background */
   --bg-alt:       #f9fafb;   /* secondary page bg (broad fields) */
@@ -26,9 +33,13 @@
   --fg:           #191f28;   /* primary text — near-black */
   --fg-1:         #333d4b;   /* secondary text — heading subdued */
   --fg-2:         #4e5968;   /* tertiary text — body label */
-  --fg-3:         #6b7684;   /* muted — metadata, captions (darkened for readability) */
+  --fg-3:         #6b7684;   /* muted — metadata, captions */
   --fg-4:         #8b95a1;   /* placeholder / decorative dots */
   --fg-on-accent: #ffffff;   /* on filled accent */
+
+  /* Compat aliases for legacy var names found in components. */
+  --text:  var(--fg);
+  --muted: var(--fg-3);
 
   /* ---------------- Color: Brand Accent ----------------- */
   /* Toss-style confident blue. Used sparingly for primary
@@ -41,8 +52,8 @@
 
   /* ---------------- Color: P/L (Korean rule) ------------ */
   /* ▲ Red = gain / up.  ▼ Blue = loss / down.
-     Same blue family as the loss color, slightly desaturated
-     to read distinctly from the brand accent. */
+     Loss blue sits in the same family as accent but kept
+     distinguishable so it never collides with brand actions. */
   --gain:         #f04452;   /* up — red */
   --gain-soft:    #ffeaea;
   --loss:         #2a6df4;   /* down — blue */
@@ -63,14 +74,11 @@
   /* ---------------- Color: Source pills ----------------- */
   /* Each broker / source gets a calm tint pair. Subdued so
      long lists of accounts don't visually compete. */
-  /* Subtle — these are secondary identifiers, not theme colors.
-     Backgrounds are very low-saturation tints; foregrounds sit
-     just dark enough to read at 11–12px. */
-  --pill-kis-bg:    #eaf2ff; --pill-kis-fg:    #2a6df4;  /* KIS — small blue */
-  --pill-upbit-bg:  #e8f3ec; --pill-upbit-fg:  #0e8a5f;  /* Upbit — small green */
-  --pill-toss-bg:   #efebf8; --pill-toss-fg:   #5b3aa8;  /* Toss / manual — soft purple */
-  --pill-isa-bg:    #f1ede1; --pill-isa-fg:    #7a6a3a;  /* ISA — muted olive */
-  --pill-pension-bg:#ecedef; --pill-pension-fg:#5f6470;  /* Pension — stone */
+  --pill-kis-bg:    #eaf2ff; --pill-kis-fg:    #2a6df4;  /* KIS */
+  --pill-upbit-bg:  #e8f3ec; --pill-upbit-fg:  #0e8a5f;  /* Upbit */
+  --pill-toss-bg:   #efebf8; --pill-toss-fg:   #5b3aa8;  /* Toss / manual */
+  --pill-isa-bg:    #f1ede1; --pill-isa-fg:    #7a6a3a;  /* ISA */
+  --pill-pension-bg:#ecedef; --pill-pension-fg:#5f6470;  /* Pension */
   --pill-paper-bg:  #eef0f3; --pill-paper-fg:  #4e5968;  /* Paper / mock */
 
   /* ---------------- Type: Family ------------------------ */
@@ -80,12 +88,9 @@
                "Helvetica Neue", "Segoe UI", Roboto, sans-serif;
   --font-mono: "JetBrains Mono", "SF Mono", ui-monospace,
                Menlo, Consolas, monospace;
-  /* Numerals — same family but with tabular figures applied. */
   --font-num: var(--font-sans);
 
   /* ---------------- Type: Scale ------------------------- */
-  /* Body baseline 15px (Toss web). Display sizes are
-     deliberately large for portfolio totals. */
   --text-display:   30px;   /* hero portfolio total (desktop) */
   --text-display-2: 24px;   /* account totals / section hero */
   --text-h1:        22px;   /* page header */
@@ -108,7 +113,6 @@
   --weight-bold:    700;
   --weight-heavy:   800;
 
-  /* Negative tracking on big numbers; positive on small caps */
   --tracking-tight:  -0.02em;
   --tracking-normal: 0;
   --tracking-wide:   0.04em;
@@ -142,12 +146,161 @@
               0 2px 6px rgba(15, 23, 42, 0.04);
   --shadow-focus: 0 0 0 3px rgba(49, 130, 246, 0.25);
 
+  /* ---------------- Overlay / Special surfaces ---------- */
+  --overlay:       rgba(15, 23, 42, 0.45);   /* modal / drawer scrim */
+  --overlay-soft:  rgba(15, 23, 42, 0.20);   /* sheet hint */
+  --backdrop-blur: 8px;
+  --ai-card-bg:    linear-gradient(180deg, #f3f7ff 0%, #ffffff 100%);
+  --ai-card-fg:    var(--accent);
+
   /* ---------------- Motion ------------------------------ */
   --ease-standard: cubic-bezier(0.2, 0.0, 0.0, 1.0);
   --ease-emph:     cubic-bezier(0.2, 0.8, 0.2, 1.0);
   --dur-fast:   120ms;
   --dur-base:   180ms;
   --dur-slow:   240ms;
+}
+
+/* =========================================================
+   DARK THEME — explicit opt-in via [data-theme="dark"].
+   Token names match light; only values change so every
+   component picks up the theme via CSS variables.
+   Korean P/L preserved (▲ red = gain / ▼ blue = loss).
+   Accent blue (cyan-leaning) and loss blue (indigo-leaning)
+   stay separated so they never collide in numeric UI.
+   ========================================================= */
+[data-theme="dark"] {
+  color-scheme: dark;
+
+  /* Surfaces & ink — layered grays, not pure black */
+  --bg:           #0e1116;
+  --bg-alt:       #11151c;
+  --surface:      #161b23;
+  --surface-2:    #1d232d;
+  --surface-3:    #262d38;
+  --divider:      rgba(255, 255, 255, 0.06);
+  --border:       rgba(255, 255, 255, 0.08);
+
+  --fg:           #f1f3f5;
+  --fg-1:         #d6dae0;
+  --fg-2:         #a4abb6;
+  --fg-3:         #7a8290;
+  --fg-4:         #5a6271;
+  --fg-on-accent: #ffffff;
+
+  /* Accent — lift saturation/lightness so it pops on dark
+     and reads distinctly from loss blue */
+  --accent:       #4691ff;
+  --accent-press: #3a82ee;
+  --accent-soft:  rgba(70, 145, 255, 0.16);
+  --accent-fg:    #ffffff;
+
+  /* P/L — loss blue shifts toward indigo so it's clearly
+     different from accent (cyan-blue). */
+  --gain:         #ff5b6b;
+  --gain-soft:    rgba(255, 91, 107, 0.14);
+  --loss:         #5b8cff;
+  --loss-soft:    rgba(91, 140, 255, 0.14);
+  --flat:         #7a8290;
+
+  /* Semantic */
+  --warn:         #f0b03a;
+  --warn-soft:    rgba(240, 176, 58, 0.14);
+  --danger:       #ff6363;
+  --danger-soft:  rgba(255, 99, 99, 0.14);
+  --success:      #2bd28a;
+  --success-soft: rgba(43, 210, 138, 0.14);
+  --info:         #4691ff;
+  --info-soft:    rgba(70, 145, 255, 0.14);
+
+  /* Source pills — soft alpha tints over dark surface,
+     foreground lifted to AA on --surface */
+  --pill-kis-bg:    rgba(70, 145, 255, 0.16);  --pill-kis-fg:    #7eb0ff;
+  --pill-upbit-bg:  rgba(43, 210, 138, 0.14);  --pill-upbit-fg:  #5fdcab;
+  --pill-toss-bg:   rgba(154, 116, 255, 0.16); --pill-toss-fg:   #c0a8ff;
+  --pill-isa-bg:    rgba(196, 166, 82, 0.14);  --pill-isa-fg:    #d4b977;
+  --pill-pension-bg:rgba(255, 255, 255, 0.06); --pill-pension-fg:#a4abb6;
+  --pill-paper-bg:  rgba(255, 255, 255, 0.05); --pill-paper-fg:  #a4abb6;
+
+  /* Elevation — darker drops + 1px inset highlight so cards
+     still feel raised on a dark surface */
+  --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.5),
+              inset 0 1px 0 rgba(255, 255, 255, 0.02);
+  --shadow-2: 0 6px 18px rgba(0, 0, 0, 0.5),
+              inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  --shadow-3: 0 18px 48px rgba(0, 0, 0, 0.6),
+              inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  --shadow-focus: 0 0 0 3px rgba(70, 145, 255, 0.35);
+
+  /* Overlay / special surfaces */
+  --overlay:      rgba(0, 0, 0, 0.65);
+  --overlay-soft: rgba(0, 0, 0, 0.35);
+  --ai-card-bg:   linear-gradient(180deg, rgba(70, 145, 255, 0.10) 0%, rgba(70, 145, 255, 0.02) 100%);
+  --ai-card-fg:   #7eb0ff;
+}
+
+/* =========================================================
+   OS preference fallback — applies ONLY when no explicit
+   data-theme is set on <html>. Explicit data-theme="light"
+   always wins over OS dark mode.
+   ========================================================= */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not([data-theme="dark"]) {
+    color-scheme: dark;
+
+    --bg:           #0e1116;
+    --bg-alt:       #11151c;
+    --surface:      #161b23;
+    --surface-2:    #1d232d;
+    --surface-3:    #262d38;
+    --divider:      rgba(255, 255, 255, 0.06);
+    --border:       rgba(255, 255, 255, 0.08);
+
+    --fg:           #f1f3f5;
+    --fg-1:         #d6dae0;
+    --fg-2:         #a4abb6;
+    --fg-3:         #7a8290;
+    --fg-4:         #5a6271;
+
+    --accent:       #4691ff;
+    --accent-press: #3a82ee;
+    --accent-soft:  rgba(70, 145, 255, 0.16);
+
+    --gain:         #ff5b6b;
+    --gain-soft:    rgba(255, 91, 107, 0.14);
+    --loss:         #5b8cff;
+    --loss-soft:    rgba(91, 140, 255, 0.14);
+    --flat:         #7a8290;
+
+    --warn:         #f0b03a;
+    --warn-soft:    rgba(240, 176, 58, 0.14);
+    --danger:       #ff6363;
+    --danger-soft:  rgba(255, 99, 99, 0.14);
+    --success:      #2bd28a;
+    --success-soft: rgba(43, 210, 138, 0.14);
+    --info:         #4691ff;
+    --info-soft:    rgba(70, 145, 255, 0.14);
+
+    --pill-kis-bg:    rgba(70, 145, 255, 0.16);  --pill-kis-fg:    #7eb0ff;
+    --pill-upbit-bg:  rgba(43, 210, 138, 0.14);  --pill-upbit-fg:  #5fdcab;
+    --pill-toss-bg:   rgba(154, 116, 255, 0.16); --pill-toss-fg:   #c0a8ff;
+    --pill-isa-bg:    rgba(196, 166, 82, 0.14);  --pill-isa-fg:    #d4b977;
+    --pill-pension-bg:rgba(255, 255, 255, 0.06); --pill-pension-fg:#a4abb6;
+    --pill-paper-bg:  rgba(255, 255, 255, 0.05); --pill-paper-fg:  #a4abb6;
+
+    --shadow-1: 0 1px 2px rgba(0, 0, 0, 0.5),
+                inset 0 1px 0 rgba(255, 255, 255, 0.02);
+    --shadow-2: 0 6px 18px rgba(0, 0, 0, 0.5),
+                inset 0 1px 0 rgba(255, 255, 255, 0.03);
+    --shadow-3: 0 18px 48px rgba(0, 0, 0, 0.6),
+                inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    --shadow-focus: 0 0 0 3px rgba(70, 145, 255, 0.35);
+
+    --overlay:      rgba(0, 0, 0, 0.65);
+    --overlay-soft: rgba(0, 0, 0, 0.35);
+    --ai-card-bg:   linear-gradient(180deg, rgba(70, 145, 255, 0.10) 0%, rgba(70, 145, 255, 0.02) 100%);
+    --ai-card-fg:   #7eb0ff;
+  }
 }
 
 /* =========================================================
@@ -197,7 +350,7 @@
 }
 
 /* =========================================================
-   Utility classes (handles for HTML cards / kits)
+   Utility classes
    ========================================================= */
 .num     { font-feature-settings: "tnum"; font-variant-numeric: tabular-nums; }
 .num-big { font-size: var(--text-display); font-weight: var(--weight-bold);

--- a/frontend/invest/src/theme/useTheme.ts
+++ b/frontend/invest/src/theme/useTheme.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+
+export type Theme = "light" | "dark" | "system";
+
+const STORAGE_KEY = "invest-theme";
+const DEFAULT_THEME: Theme = "dark";
+
+export function applyTheme(t: Theme): void {
+  const html = document.documentElement;
+  if (t === "system") {
+    html.removeAttribute("data-theme");
+  } else {
+    html.dataset.theme = t;
+  }
+}
+
+export function readStoredTheme(): Theme {
+  if (typeof localStorage === "undefined") return DEFAULT_THEME;
+  const raw = localStorage.getItem(STORAGE_KEY);
+  return raw === "light" || raw === "dark" || raw === "system" ? raw : DEFAULT_THEME;
+}
+
+// Apply the stored (or default) theme synchronously, before React renders,
+// so the first paint already matches and there is no light/dark flash.
+export function applyInitialTheme(): void {
+  applyTheme(readStoredTheme());
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => readStoredTheme());
+  useEffect(() => {
+    applyTheme(theme);
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(STORAGE_KEY, theme);
+    }
+  }, [theme]);
+  return [theme, setTheme] as const;
+}


### PR DESCRIPTION
## Summary
- Adds the design-system dark token set under `[data-theme="dark"]` in `frontend/invest/src/styles/tokens.css` (loss = indigo `#5b8cff` so it never collides with cyan brand `--accent`; Korean P/L preserved — ▲ red gain / ▼ blue loss).
- Defaults `<html>` to `data-theme="dark"`; `applyInitialTheme()` runs in `main.tsx` before React renders so first paint matches the stored choice (no white flash). Adds `src/theme/useTheme.ts` as the seam for a future Light/Dark toggle.
- Sweeps every remaining hardcoded `#fff` / `rgba(...)` / broken pill ref out of `frontend/invest/src/**` and replaces them with semantic tokens (`--fg-on-accent`, `--bg`, `--ai-card-bg`, `--overlay`, `--warn`, `--surface-*`, source-pill tokens, etc).
- Locks the contract behind a new `tokens.contract.test.ts` (selector exists, all 14 required dark tokens present, `--gain ≠ --loss`, `--loss ≠ --accent`, OS-dark fallback yields to explicit `data-theme="light"`).

## Files touched (23, all under `frontend/invest/`)
- **Tokens & bootstrap**: `src/styles/tokens.css`, `src/theme/useTheme.ts` (new), `src/main.tsx`, `index.html`.
- **Hardcoded color cleanup**: `src/desktop/{DesktopHeader.tsx,AccountSourceTone.ts,screener/screener.css}`, `src/ds/atoms.tsx`, `src/components/{AccountCardList.tsx,home/FilterChips.tsx,news/NewsTabs.tsx,calendar/{AIWeeklyCard.tsx,EventDetailModal.tsx,OwnershipTag.tsx,WeekDateStrip.tsx},discover/{DiscoverCalendarCard.tsx,IssueImpactMap.tsx}}`, `src/pages/HomePage.tsx`, `src/pages/desktop/DesktopCalendarPage.tsx`, `src/pages/mobile/{MobileSignalsPage,MobileHomePage,MobileCalendarPage}.tsx`.
- **Tests**: `src/__tests__/tokens.contract.test.ts` (new).

## Notable hex → token migrations
| Find | Replace |
|---|---|
| `#fff` (text on `--accent`) | `var(--fg-on-accent)` |
| `#fff` (text on inverse `--fg` chip) | `var(--bg)` (proper inversion in dark) |
| `linear-gradient(135deg, #f4f7ff 0%, #f9fafb 100%)` + `1px solid #e2e9f6` | `var(--ai-card-bg)` + `1px solid var(--border)` |
| `rgba(15, 20, 28, 0.32)` modal scrim | `var(--overlay)` |
| `rgba(246,193,119,0.08)` warn banner | `var(--warn-soft)` |
| `#a06200` warn fg | `var(--warn)` |
| `#1c1e24` "수동" tag | `var(--surface-2)` |
| `AccountSourceTone` navy/gray/purple/green/dashed hex palette | source-pill tokens + `var(--border)` |
| Broken `var(--pill-mix)` / `var(--pill-up)` / `var(--pill-toss)` (no `-bg`) in `IssueImpactMap` | `var(--gain-soft)` / `var(--loss-soft)` / `var(--warn-soft)` / `var(--surface-2)` |
| `var(--accent, #2962ff)` / `var(--neutral-strong, #555)` fallback hexes | plain tokens |

Final grep confirms `PASS: no hardcoded hex/rgba in non-token, non-test src`.

## Verification
- `npm ci` — 122 packages, 0 vulnerabilities
- `npm run typecheck` — clean
- `npm test -- --run` — **30 files / 113 tests pass** (107 prior + 6 new contract assertions; existing Stage-3 MobileShell viewport-pin / safe-area / bottom-nav-as-sibling regression tests all still pass)
- `npm run build` — 603 ms, CSS 12.18 kB / 3.25 kB gz, JS 374.45 kB / 110.61 kB gz

## Out of scope (intentional)
- No broker / order / watch / order-intent / scheduler / safety-middleware / MCP-tool / DB-mutation code touched.
- Stage-3 mobile shell viewport-pin + bottom-nav safe-area behavior preserved (regression tests still green).
- Legacy `/invest/app/*` redirects in `routes.tsx` left intact (Stage 6 deletion is a separate PR per `docs/plans/2026-05-09-invest-app-retirement-inventory.md`).
- MarketStrip live-data wiring deferred per the brief's scope guard.
- Light/Dark toggle UI is **not** mounted (only the `useTheme` seam shipped).

## Test plan
- [ ] CI green (typecheck, vitest, vite build).
- [ ] Browser smoke: walk `/invest/`, `/invest/feed/news`, `/invest/discover`, `/invest/signals`, `/invest/calendar`, `/invest/screener` on desktop and mobile viewports.
- [ ] Toggle in devtools: `document.documentElement.dataset.theme = 'light' | 'dark'` then `delete document.documentElement.dataset.theme` (system) — verify no layout shift, hero P/L stays red gain / indigo loss, modal scrim opaque enough, focus ring visible in dark.
- [ ] Confirm legacy `/invest/app/*` URLs still redirect with `?search` and `#hash` preserved.
- [ ] Spot-check that nested-interactive count remains 0 (no DOM structure changes).

## Follow-ups
- Mount the Light/Dark/System toggle UI (header right side, next to the bell) using the `useTheme` hook.
- `pages/HomePage.tsx:182` "포트폴리오로 이동" link is `color: var(--gain)` (red) — pre-existing, unrelated, but should likely be `var(--accent)`.
- Programmatic a11y contrast spot-check (Stark/axe) on `--fg-3` over `--surface` etc.

Co-Authored-By: Paperclip <noreply@paperclip.ing>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dark/light/system theme modes with initial theme applied at startup and persisted across sessions

* **Style**
  * App-wide color updates: components now use theme-aware design tokens for consistent dark-mode appearance
  * Global theme tokens added, plus OS color-scheme fallback

* **Tests**
  * Added token/ theme validation tests to ensure correct theming rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->