### PR TITLE
feat(invest): Toss-style persistent right rail panel with tabs (ROB-150)

### DIFF
--- a/frontend/invest/package-lock.json
+++ b/frontend/invest/package-lock.json
@@ -458,9 +458,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -478,9 +475,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -498,9 +492,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -518,9 +509,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -538,9 +526,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -558,9 +543,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1414,9 +1396,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1438,9 +1417,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1462,9 +1438,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1486,9 +1459,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/invest/package-lock.json
+++ b/frontend/invest/package-lock.json
@@ -458,6 +458,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -475,6 +478,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -492,6 +498,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -509,6 +518,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -526,6 +538,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -543,6 +558,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1396,6 +1414,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1417,6 +1438,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1438,6 +1462,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1459,6 +1486,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/invest/src/App.tsx
+++ b/frontend/invest/src/App.tsx
@@ -1,8 +1,13 @@
 import { RouterProvider } from "react-router-dom";
 import { router } from "./routes";
+import { AccountPanelProvider } from "./desktop/AccountPanelProvider";
 import "./styles/tokens.css";
 import "./styles.css";
 
 export default function App() {
-  return <RouterProvider router={router} />;
+  return (
+    <AccountPanelProvider>
+      <RouterProvider router={router} />
+    </AccountPanelProvider>
+  );
 }

--- a/frontend/invest/src/__tests__/AccountPanelProvider.test.tsx
+++ b/frontend/invest/src/__tests__/AccountPanelProvider.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { vi, test, expect, beforeEach } from "vitest";
+import { AccountPanelProvider, useAccountPanelContext } from "../desktop/AccountPanelProvider";
+import * as panelApi from "../api/accountPanel";
+import type { AccountPanelResponse } from "../types/invest";
+
+const MOCK_RESP: AccountPanelResponse = {
+  homeSummary: {
+    includedSources: ["kis"],
+    excludedSources: [],
+    totalValueKrw: 2_000_000,
+    pnlKrw: 100_000,
+    pnlRate: 0.05,
+  },
+  accounts: [],
+  groupedHoldings: [],
+  watchSymbols: [],
+  sourceVisuals: [],
+  meta: { warnings: [], watchlistAvailable: true },
+};
+
+function StatusChild() {
+  const ctx = useAccountPanelContext();
+  if (ctx.loading) return <div data-testid="loading">loading</div>;
+  if (ctx.error) return <div data-testid="error">{ctx.error}</div>;
+  return <div data-testid="ready">{ctx.data?.homeSummary.totalValueKrw}</div>;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("provides loaded data after fetch resolves", async () => {
+  vi.spyOn(panelApi, "fetchAccountPanel").mockResolvedValue(MOCK_RESP);
+  render(
+    <AccountPanelProvider>
+      <StatusChild />
+    </AccountPanelProvider>,
+  );
+  expect(screen.getByTestId("loading")).toBeInTheDocument();
+  await waitFor(() => expect(screen.getByTestId("ready")).toBeInTheDocument());
+  expect(screen.getByTestId("ready").textContent).toBe("2000000");
+});
+
+test("shows error state when fetch fails", async () => {
+  vi.spyOn(panelApi, "fetchAccountPanel").mockRejectedValue(new Error("network error"));
+  render(
+    <AccountPanelProvider>
+      <StatusChild />
+    </AccountPanelProvider>,
+  );
+  await waitFor(() => expect(screen.getByTestId("error")).toBeInTheDocument());
+  expect(screen.getByTestId("error").textContent).toContain("network error");
+});
+
+test("throws when used outside provider", () => {
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  expect(() => render(<StatusChild />)).toThrow();
+  consoleError.mockRestore();
+});

--- a/frontend/invest/src/__tests__/DesktopCalendarPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopCalendarPage.test.tsx
@@ -3,14 +3,29 @@ import userEvent from "@testing-library/user-event";
 import { vi, beforeEach, test, expect } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { DesktopCalendarPage } from "../pages/desktop/DesktopCalendarPage";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
 import * as calApi from "../api/calendar";
 import * as panelApi from "../api/accountPanel";
+import * as signalsApi from "../api/signals";
+
+function wrap(ui: React.ReactElement) {
+  return (
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/calendar"]}>
+        {ui}
+      </MemoryRouter>
+    </AccountPanelProvider>
+  );
+}
 
 beforeEach(() => {
   vi.spyOn(panelApi, "fetchAccountPanel").mockResolvedValue({
     homeSummary: { includedSources: [], excludedSources: [], totalValueKrw: 0 },
     accounts: [], groupedHoldings: [], watchSymbols: [], sourceVisuals: [],
     meta: { warnings: [], watchlistAvailable: true },
+  });
+  vi.spyOn(signalsApi, "fetchSignals").mockResolvedValue({
+    tab: "kr", asOf: new Date().toISOString(), items: [], meta: { warnings: [] },
   });
   vi.spyOn(calApi, "fetchCalendar").mockResolvedValue({
     tab: "all", fromDate: "2026-05-04", toDate: "2026-05-10",
@@ -29,11 +44,7 @@ beforeEach(() => {
 });
 
 test("renders week rail and weekly summary toggle", async () => {
-  render(
-    <MemoryRouter basename="/invest" initialEntries={["/invest/calendar"]}>
-      <DesktopCalendarPage />
-    </MemoryRouter>,
-  );
+  render(wrap(<DesktopCalendarPage />));
   await waitFor(() => expect(screen.getAllByTestId(/^day-\d{4}-/)).toHaveLength(7));
   await userEvent.click(screen.getByTestId("open-weekly-summary"));
   await waitFor(() => expect(screen.getByTestId("weekly-summary")).toBeInTheDocument());

--- a/frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx
@@ -3,14 +3,29 @@ import userEvent from "@testing-library/user-event";
 import { vi, beforeEach, test, expect } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { DesktopFeedNewsPage } from "../pages/desktop/DesktopFeedNewsPage";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
 import * as feedApi from "../api/feedNews";
 import * as panelApi from "../api/accountPanel";
+import * as signalsApi from "../api/signals";
+
+function wrap(ui: React.ReactElement) {
+  return (
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/feed/news"]}>
+        {ui}
+      </MemoryRouter>
+    </AccountPanelProvider>
+  );
+}
 
 beforeEach(() => {
   vi.spyOn(panelApi, "fetchAccountPanel").mockResolvedValue({
     homeSummary: { includedSources: [], excludedSources: [], totalValueKrw: 0 },
     accounts: [], groupedHoldings: [], watchSymbols: [], sourceVisuals: [],
     meta: { warnings: [], watchlistAvailable: true },
+  });
+  vi.spyOn(signalsApi, "fetchSignals").mockResolvedValue({
+    tab: "kr", asOf: new Date().toISOString(), items: [], meta: { warnings: [] },
   });
   vi.spyOn(feedApi, "fetchFeedNews").mockResolvedValue({
     tab: "top",
@@ -70,22 +85,14 @@ beforeEach(() => {
 });
 
 test("renders news items and reacts to tab change", async () => {
-  render(
-    <MemoryRouter basename="/invest" initialEntries={["/invest/feed/news"]}>
-      <DesktopFeedNewsPage />
-    </MemoryRouter>,
-  );
+  render(wrap(<DesktopFeedNewsPage />));
   await waitFor(() => expect(screen.getAllByTestId("feed-item")).toHaveLength(1));
   await userEvent.click(screen.getByTestId("tab-latest"));
   await waitFor(() => expect(feedApi.fetchFeedNews).toHaveBeenCalledTimes(2));
 });
 
 test("renders an issue chip linked to the issue detail page when issueId is present", async () => {
-  render(
-    <MemoryRouter basename="/invest" initialEntries={["/invest/feed/news"]}>
-      <DesktopFeedNewsPage />
-    </MemoryRouter>,
-  );
+  render(wrap(<DesktopFeedNewsPage />));
   const chip = await screen.findByTestId("feed-item-issue-chip");
   expect(chip).toHaveTextContent("삼성전자 실적 발표");
   // Chip points at the canonical /discover route (Stage 4.2). Legacy
@@ -96,11 +103,7 @@ test("renders an issue chip linked to the issue detail page when issueId is pres
 
 
 test("renders related symbol chips as read-only badges", async () => {
-  render(
-    <MemoryRouter basename="/invest" initialEntries={["/invest/feed/news"]}>
-      <DesktopFeedNewsPage />
-    </MemoryRouter>,
-  );
+  render(wrap(<DesktopFeedNewsPage />));
   const chip = await screen.findByTestId("feed-item-related-symbol-chip");
   expect(chip).toHaveTextContent("005930");
   expect(chip).toHaveTextContent("삼성전자");

--- a/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
@@ -4,8 +4,10 @@ import { vi, beforeEach, test, expect } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 
 import { DesktopScreenerPage } from "../pages/desktop/DesktopScreenerPage";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
 import * as screenerApi from "../api/screener";
 import * as panelApi from "../api/accountPanel";
+import * as signalsApi from "../api/signals";
 
 const PRESETS = {
   presets: [
@@ -52,11 +54,24 @@ const RESULTS_VALUE = {
   results: [{ ...ROW, metricValueLabel: "14.0" }],
 };
 
+function wrap(ui: React.ReactElement) {
+  return (
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/screener"]}>
+        {ui}
+      </MemoryRouter>
+    </AccountPanelProvider>
+  );
+}
+
 beforeEach(() => {
   vi.spyOn(panelApi, "fetchAccountPanel").mockResolvedValue({
     homeSummary: { includedSources: [], excludedSources: [], totalValueKrw: 0 },
     accounts: [], groupedHoldings: [], watchSymbols: [], sourceVisuals: [],
     meta: { warnings: [], watchlistAvailable: true },
+  });
+  vi.spyOn(signalsApi, "fetchSignals").mockResolvedValue({
+    tab: "kr", asOf: new Date().toISOString(), items: [], meta: { warnings: [] },
   });
   vi.spyOn(screenerApi, "fetchScreenerPresets").mockResolvedValue(PRESETS);
   vi.spyOn(screenerApi, "fetchScreenerResults").mockImplementation(async (id: string) =>
@@ -65,11 +80,7 @@ beforeEach(() => {
 });
 
 test("renders the default preset and switches when another preset is clicked", async () => {
-  render(
-    <MemoryRouter basename="/invest" initialEntries={["/invest/screener"]}>
-      <DesktopScreenerPage />
-    </MemoryRouter>,
-  );
+  render(wrap(<DesktopScreenerPage />));
   await waitFor(() => expect(screen.getByText("삼성전자")).toBeInTheDocument());
 
   await userEvent.click(screen.getByTestId("screener-preset-cheap_value"));
@@ -84,11 +95,7 @@ test("shows an empty-state message when results are empty", async () => {
   vi.spyOn(screenerApi, "fetchScreenerResults").mockResolvedValue({
     ...RESULTS_GAINERS, results: [],
   });
-  render(
-    <MemoryRouter basename="/invest" initialEntries={["/invest/screener"]}>
-      <DesktopScreenerPage />
-    </MemoryRouter>,
-  );
+  render(wrap(<DesktopScreenerPage />));
   await waitFor(() =>
     expect(screen.getByText(/표시할 종목이 없습니다/)).toBeInTheDocument(),
   );

--- a/frontend/invest/src/__tests__/DesktopSignalsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopSignalsPage.test.tsx
@@ -2,8 +2,19 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { vi, beforeEach, test, expect } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { DesktopSignalsPage } from "../pages/desktop/DesktopSignalsPage";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
 import * as signalsApi from "../api/signals";
 import * as panelApi from "../api/accountPanel";
+
+function wrap(ui: React.ReactElement) {
+  return (
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/signals"]}>
+        {ui}
+      </MemoryRouter>
+    </AccountPanelProvider>
+  );
+}
 
 beforeEach(() => {
   vi.spyOn(panelApi, "fetchAccountPanel").mockResolvedValue({
@@ -23,21 +34,13 @@ beforeEach(() => {
 });
 
 test("renders signal list and shows empty default detail", async () => {
-  render(
-    <MemoryRouter basename="/invest" initialEntries={["/invest/signals"]}>
-      <DesktopSignalsPage />
-    </MemoryRouter>,
-  );
+  render(wrap(<DesktopSignalsPage />));
   await waitFor(() => expect(screen.getAllByTestId("signal-list-item")).toHaveLength(1));
   expect(screen.getByText("시그널을 선택하세요.")).toBeInTheDocument();
 });
 
 test("does not render buy/sell CTA buttons", async () => {
-  render(
-    <MemoryRouter basename="/invest" initialEntries={["/invest/signals"]}>
-      <DesktopSignalsPage />
-    </MemoryRouter>,
-  );
+  render(wrap(<DesktopSignalsPage />));
   await waitFor(() => expect(screen.getAllByTestId("signal-list-item")).toHaveLength(1));
   // The decision label ('매수' / '매도') renders as a decorative status pill
   // (a <span>, not actionable). The safety guarantee here is that no

--- a/frontend/invest/src/__tests__/RightRemotePanel.test.tsx
+++ b/frontend/invest/src/__tests__/RightRemotePanel.test.tsx
@@ -81,6 +81,7 @@ test("renders the tabbed right remote panel", async () => {
   expect(screen.getByRole("tab", { name: "관심" })).toBeInTheDocument();
   expect(screen.getByRole("tab", { name: "최근 본" })).toBeInTheDocument();
   expect(screen.getByRole("tab", { name: "실시간" })).toBeInTheDocument();
+  await waitFor(() => expect(screen.getByTestId("portfolio-panel")).toBeInTheDocument());
 });
 
 test("portfolio tab shows holdings after data loads", async () => {

--- a/frontend/invest/src/__tests__/RightRemotePanel.test.tsx
+++ b/frontend/invest/src/__tests__/RightRemotePanel.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { vi, beforeEach, test, expect } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { RightRemotePanel } from "../desktop/RightRemotePanel";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
+import * as panelApi from "../api/accountPanel";
+import * as signalsApi from "../api/signals";
+import type { AccountPanelResponse } from "../types/invest";
+
+const PANEL_RESP: AccountPanelResponse = {
+  homeSummary: {
+    includedSources: ["kis"],
+    excludedSources: [],
+    totalValueKrw: 5_000_000,
+    pnlKrw: 250_000,
+    pnlRate: 0.05,
+  },
+  accounts: [
+    {
+      accountId: "k1",
+      displayName: "KIS Live",
+      source: "kis",
+      accountKind: "live",
+      includedInHome: true,
+      valueKrw: 5_000_000,
+      cashBalances: { krw: 100_000 },
+      buyingPower: { krw: 100_000 },
+    },
+  ],
+  groupedHoldings: [
+    {
+      groupId: "g1",
+      symbol: "005930",
+      market: "KR",
+      assetType: "equity",
+      assetCategory: "kr_stock",
+      displayName: "삼성전자",
+      currency: "KRW",
+      totalQuantity: 10,
+      valueKrw: 800_000,
+      pnlKrw: 40_000,
+      pnlRate: 0.05,
+      priceState: "live",
+      includedSources: ["kis"],
+      sourceBreakdown: [],
+    },
+  ],
+  watchSymbols: [
+    { symbol: "AAPL", market: "us", displayName: "Apple Inc." },
+  ],
+  sourceVisuals: [{ source: "kis", tone: "navy", badge: "Live", displayName: "KIS" }],
+  meta: { warnings: [], watchlistAvailable: true },
+};
+
+function renderPanel() {
+  return render(
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/"]}>
+        <RightRemotePanel />
+      </MemoryRouter>
+    </AccountPanelProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.spyOn(panelApi, "fetchAccountPanel").mockResolvedValue(PANEL_RESP);
+  vi.spyOn(signalsApi, "fetchSignals").mockResolvedValue({
+    tab: "kr",
+    asOf: new Date().toISOString(),
+    items: [],
+    meta: { warnings: [] },
+  });
+  localStorage.clear();
+});
+
+test("renders the tabbed right remote panel", async () => {
+  renderPanel();
+  expect(screen.getByTestId("right-remote-panel")).toBeInTheDocument();
+  expect(screen.getByRole("tab", { name: "내 투자" })).toBeInTheDocument();
+  expect(screen.getByRole("tab", { name: "관심" })).toBeInTheDocument();
+  expect(screen.getByRole("tab", { name: "최근 본" })).toBeInTheDocument();
+  expect(screen.getByRole("tab", { name: "실시간" })).toBeInTheDocument();
+});
+
+test("portfolio tab shows holdings after data loads", async () => {
+  renderPanel();
+  await waitFor(() => expect(screen.getByTestId("portfolio-panel")).toBeInTheDocument());
+  expect(screen.getByText("삼성전자")).toBeInTheDocument();
+  expect(screen.getByText("₩800,000")).toBeInTheDocument();
+});
+
+test("watchlist tab shows watch symbols", async () => {
+  renderPanel();
+  await waitFor(() => expect(screen.getByTestId("portfolio-panel")).toBeInTheDocument());
+  await userEvent.click(screen.getByRole("tab", { name: "관심" }));
+  expect(screen.getByTestId("watchlist-panel")).toBeInTheDocument();
+  expect(screen.getByText("Apple Inc.")).toBeInTheDocument();
+});
+
+test("recent tab shows empty state initially", async () => {
+  renderPanel();
+  await userEvent.click(screen.getByRole("tab", { name: "최근 본" }));
+  expect(screen.getByTestId("recent-panel-empty")).toBeInTheDocument();
+});
+
+test("portfolio tab shows empty holdings gracefully", async () => {
+  vi.spyOn(panelApi, "fetchAccountPanel").mockResolvedValue({
+    ...PANEL_RESP,
+    groupedHoldings: [],
+  });
+  renderPanel();
+  await waitFor(() => expect(screen.getByTestId("holdings-empty")).toBeInTheDocument());
+});
+
+test("does not render order CTA buttons", async () => {
+  renderPanel();
+  await waitFor(() => expect(screen.getByTestId("portfolio-panel")).toBeInTheDocument());
+  expect(screen.queryByRole("button", { name: "매수" })).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: "매도" })).not.toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /주문/ })).not.toBeInTheDocument();
+});

--- a/frontend/invest/src/__tests__/recentSymbols.test.ts
+++ b/frontend/invest/src/__tests__/recentSymbols.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, test, expect } from "vitest";
+import { loadRecentSymbols, recordRecentSymbol } from "../desktop/recentSymbols";
+
+const KEY = "invest.recentSymbols.v1";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test("returns empty array when nothing stored", () => {
+  expect(loadRecentSymbols()).toEqual([]);
+});
+
+test("records and loads a symbol", () => {
+  recordRecentSymbol({
+    symbol: "005930",
+    market: "kr",
+    displayName: "삼성전자",
+    lastViewedAt: "2026-05-09T10:00:00Z",
+    source: "right-panel",
+  });
+  const items = loadRecentSymbols();
+  expect(items).toHaveLength(1);
+  expect(items[0]?.symbol).toBe("005930");
+});
+
+test("dedupes by market+symbol, keeps newest first", () => {
+  recordRecentSymbol({ symbol: "A", market: "us", displayName: "A Inc", lastViewedAt: "2026-01-01T00:00:00Z" });
+  recordRecentSymbol({ symbol: "B", market: "us", displayName: "B Inc", lastViewedAt: "2026-01-02T00:00:00Z" });
+  recordRecentSymbol({ symbol: "A", market: "us", displayName: "A Inc", lastViewedAt: "2026-01-03T00:00:00Z" });
+  const items = loadRecentSymbols();
+  expect(items).toHaveLength(2);
+  expect(items[0]?.symbol).toBe("A");
+  expect(items[1]?.symbol).toBe("B");
+});
+
+test("handles corrupt localStorage gracefully", () => {
+  localStorage.setItem(KEY, "not json");
+  expect(loadRecentSymbols()).toEqual([]);
+});
+
+test("handles invalid array entries gracefully", () => {
+  localStorage.setItem(KEY, JSON.stringify([{ bad: true }, { symbol: "X", market: "us", displayName: "X", lastViewedAt: "t" }]));
+  const items = loadRecentSymbols();
+  expect(items).toHaveLength(1);
+  expect(items[0]?.symbol).toBe("X");
+});

--- a/frontend/invest/src/desktop/AccountPanelProvider.tsx
+++ b/frontend/invest/src/desktop/AccountPanelProvider.tsx
@@ -1,0 +1,78 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+import type { AccountPanelResponse } from "../types/invest";
+import { fetchAccountPanel } from "../api/accountPanel";
+
+export interface AccountPanelContextValue {
+  data: AccountPanelResponse | undefined;
+  error: string | undefined;
+  loading: boolean;
+  refreshing: boolean;
+  lastLoadedAt: number | undefined;
+  reload: () => void;
+}
+
+const AccountPanelContext = createContext<AccountPanelContextValue | null>(null);
+
+export function AccountPanelProvider({ children }: { children: ReactNode }) {
+  const [data, setData] = useState<AccountPanelResponse | undefined>();
+  const [error, setError] = useState<string | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [lastLoadedAt, setLastLoadedAt] = useState<number | undefined>();
+  const [tick, setTick] = useState(0);
+  const hasFetched = useRef(false);
+
+  useEffect(() => {
+    let cancel = false;
+    setError(undefined);
+    if (!hasFetched.current) {
+      setLoading(true);
+    } else {
+      setRefreshing(true);
+    }
+    fetchAccountPanel()
+      .then((r) => {
+        if (cancel) return;
+        setData(r);
+        setLoading(false);
+        setRefreshing(false);
+        setLastLoadedAt(Date.now());
+        hasFetched.current = true;
+      })
+      .catch((e: unknown) => {
+        if (cancel) return;
+        const msg = e instanceof Error ? e.message : String(e);
+        setError(msg);
+        setLoading(false);
+        setRefreshing(false);
+        hasFetched.current = true;
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [tick]);
+
+  const reload = useCallback(() => setTick((t) => t + 1), []);
+
+  return (
+    <AccountPanelContext.Provider
+      value={{ data, error, loading, refreshing, lastLoadedAt, reload }}
+    >
+      {children}
+    </AccountPanelContext.Provider>
+  );
+}
+
+export function useAccountPanelContext(): AccountPanelContextValue {
+  const ctx = useContext(AccountPanelContext);
+  if (!ctx) throw new Error("useAccountPanelContext must be used within AccountPanelProvider");
+  return ctx;
+}

--- a/frontend/invest/src/desktop/AccountPanelProvider.tsx
+++ b/frontend/invest/src/desktop/AccountPanelProvider.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -21,7 +22,7 @@ export interface AccountPanelContextValue {
 
 const AccountPanelContext = createContext<AccountPanelContextValue | null>(null);
 
-export function AccountPanelProvider({ children }: { children: ReactNode }) {
+export function AccountPanelProvider({ children }: Readonly<{ children: ReactNode }>) {
   const [data, setData] = useState<AccountPanelResponse | undefined>();
   const [error, setError] = useState<string | undefined>();
   const [loading, setLoading] = useState(true);
@@ -33,10 +34,10 @@ export function AccountPanelProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     let cancel = false;
     setError(undefined);
-    if (!hasFetched.current) {
-      setLoading(true);
-    } else {
+    if (hasFetched.current) {
       setRefreshing(true);
+    } else {
+      setLoading(true);
     }
     fetchAccountPanel()
       .then((r) => {
@@ -61,11 +62,13 @@ export function AccountPanelProvider({ children }: { children: ReactNode }) {
   }, [tick]);
 
   const reload = useCallback(() => setTick((t) => t + 1), []);
+  const value = useMemo(
+    () => ({ data, error, loading, refreshing, lastLoadedAt, reload }),
+    [data, error, loading, refreshing, lastLoadedAt, reload],
+  );
 
   return (
-    <AccountPanelContext.Provider
-      value={{ data, error, loading, refreshing, lastLoadedAt, reload }}
-    >
+    <AccountPanelContext.Provider value={value}>
       {children}
     </AccountPanelContext.Provider>
   );

--- a/frontend/invest/src/desktop/RightRemotePanel.tsx
+++ b/frontend/invest/src/desktop/RightRemotePanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, type CSSProperties, type ReactNode } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAccountPanel } from "./useAccountPanel";
 import { loadRecentSymbols, recordRecentSymbol } from "./recentSymbols";
@@ -38,6 +38,75 @@ function fmtPct(v?: number | null): string {
   const pct = v * 100;
   const sign = pct >= 0 ? "+" : "";
   return `${sign}${pct.toFixed(2)}%`;
+}
+
+const ROW_BUTTON_STYLE: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  padding: "8px 0",
+  width: "100%",
+  background: "transparent",
+  border: "none",
+  borderBottom: "1px solid var(--divider)",
+  cursor: "pointer",
+  textAlign: "left",
+  fontFamily: "inherit",
+};
+
+const ROW_TITLE_STYLE: CSSProperties = {
+  fontSize: 13,
+  fontWeight: 600,
+  lineHeight: 1.3,
+  color: "var(--fg)",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+};
+
+const ROW_META_STYLE: CSSProperties = {
+  fontSize: 11,
+  color: "var(--fg-3)",
+  fontFamily: "var(--font-mono)",
+};
+
+function SymbolRow({
+  displayName,
+  market,
+  symbol,
+  onClick,
+  disabled = false,
+  right,
+  meta,
+}: Readonly<{
+  displayName: string;
+  market?: MarketKey;
+  symbol?: string;
+  onClick: () => void;
+  disabled?: boolean;
+  right?: ReactNode;
+  meta?: ReactNode;
+}>) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      style={{
+        ...ROW_BUTTON_STYLE,
+        alignItems: right ? "center" : ROW_BUTTON_STYLE.alignItems,
+        cursor: disabled ? "default" : "pointer",
+      }}
+    >
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div style={ROW_TITLE_STYLE}>{displayName}</div>
+        <div style={ROW_META_STYLE}>
+          {meta ?? (market && symbol ? `${MARKET_LABEL[market]} · ${symbol}` : symbol)}
+        </div>
+      </div>
+      {right}
+    </button>
+  );
 }
 
 function TabBar({
@@ -183,8 +252,10 @@ function PortfolioPanel({ onNavigate }: Readonly<{ onNavigate: NavigateToSymbol 
               const mk = marketKey(h.market);
               return (
                 <li key={h.groupId}>
-                  <button
-                    type="button"
+                  <SymbolRow
+                    displayName={h.displayName}
+                    market={mk}
+                    symbol={h.symbol}
                     onClick={() => {
                       const sym: RecentInvestSymbol = {
                         symbol: h.symbol,
@@ -198,57 +269,27 @@ function PortfolioPanel({ onNavigate }: Readonly<{ onNavigate: NavigateToSymbol 
                         sym,
                       );
                     }}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: 8,
-                      padding: "8px 0",
-                      width: "100%",
-                      background: "transparent",
-                      border: "none",
-                      borderBottom: "1px solid var(--divider)",
-                      cursor: "pointer",
-                      textAlign: "left",
-                      fontFamily: "inherit",
-                    }}
-                  >
-                    <div style={{ minWidth: 0, flex: 1 }}>
-                      <div
-                        style={{
-                          fontSize: 13,
-                          fontWeight: 600,
-                          lineHeight: 1.3,
-                          color: "var(--fg)",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis",
-                          whiteSpace: "nowrap",
-                        }}
-                      >
-                        {h.displayName}
-                      </div>
-                      <div style={{ fontSize: 11, color: "var(--fg-3)", fontFamily: "var(--font-mono)" }}>
-                        {MARKET_LABEL[mk]} · {h.symbol}
-                      </div>
-                    </div>
-                    <div style={{ textAlign: "right", flexShrink: 0 }}>
-                      <div style={{ fontSize: 12, fontWeight: 600, fontFeatureSettings: '"tnum"' }}>
-                        {fmtKrw(h.valueKrw)}
-                      </div>
-                      {h.pnlRate == null ? (
-                        <div style={{ fontSize: 11, color: "var(--fg-3)" }}>—</div>
-                      ) : (
-                        <div
-                          style={{
-                            fontSize: 11,
-                            color: h.pnlRate >= 0 ? "var(--gain)" : "var(--loss)",
-                            fontFeatureSettings: '"tnum"',
-                          }}
-                        >
-                          {fmtPct(h.pnlRate)}
+                    right={(
+                      <div style={{ textAlign: "right", flexShrink: 0 }}>
+                        <div style={{ fontSize: 12, fontWeight: 600, fontFeatureSettings: '"tnum"' }}>
+                          {fmtKrw(h.valueKrw)}
                         </div>
-                      )}
-                    </div>
-                  </button>
+                        {h.pnlRate == null ? (
+                          <div style={{ fontSize: 11, color: "var(--fg-3)" }}>—</div>
+                        ) : (
+                          <div
+                            style={{
+                              fontSize: 11,
+                              color: h.pnlRate >= 0 ? "var(--gain)" : "var(--loss)",
+                              fontFeatureSettings: '"tnum"',
+                            }}
+                          >
+                            {fmtPct(h.pnlRate)}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  />
                 </li>
               );
             })}
@@ -315,8 +356,10 @@ function WatchRow({
   onNavigate: NavigateToSymbol;
 }>) {
   return (
-    <button
-      type="button"
+    <SymbolRow
+      displayName={w.displayName}
+      market={w.market}
+      symbol={w.symbol}
       onClick={() => {
         const sym: RecentInvestSymbol = {
           symbol: w.symbol,
@@ -330,44 +373,12 @@ function WatchRow({
           sym,
         );
       }}
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 8,
-        padding: "8px 0",
-        width: "100%",
-        background: "transparent",
-        border: "none",
-        borderBottom: "1px solid var(--divider)",
-        cursor: "pointer",
-        textAlign: "left",
-        fontFamily: "inherit",
-      }}
-    >
-      <div style={{ minWidth: 0, flex: 1 }}>
-        <div
-          style={{
-            fontSize: 13,
-            fontWeight: 600,
-            lineHeight: 1.3,
-            color: "var(--fg)",
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {w.displayName}
-        </div>
-        <div style={{ fontSize: 11, color: "var(--fg-3)", fontFamily: "var(--font-mono)" }}>
-          {MARKET_LABEL[w.market]} · {w.symbol}
-        </div>
-      </div>
-      {w.note && (
+      right={w.note ? (
         <div style={{ fontSize: 11, color: "var(--fg-3)", flexShrink: 0, maxWidth: 60, textAlign: "right" }}>
           {w.note}
         </div>
-      )}
-    </button>
+      ) : undefined}
+    />
   );
 }
 
@@ -401,49 +412,18 @@ function RecentPanel({
         const ago = formatRelativeTime(r.lastViewedAt) ?? "";
         return (
           <li key={`${r.market}:${r.symbol}`}>
-            <button
-              type="button"
+            <SymbolRow
+              displayName={r.displayName}
+              market={r.market}
+              symbol={r.symbol}
               onClick={() => {
                 onNavigate(
                   `/signals?symbol=${encodeURIComponent(r.symbol)}&market=${r.market}`,
                   { ...r, lastViewedAt: new Date().toISOString() },
                 );
               }}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: 8,
-                padding: "8px 0",
-                width: "100%",
-                background: "transparent",
-                border: "none",
-                borderBottom: "1px solid var(--divider)",
-                cursor: "pointer",
-                textAlign: "left",
-                fontFamily: "inherit",
-              }}
-            >
-              <div style={{ minWidth: 0, flex: 1 }}>
-                <div
-                  style={{
-                    fontSize: 13,
-                    fontWeight: 600,
-                    color: "var(--fg)",
-                    overflow: "hidden",
-                    textOverflow: "ellipsis",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {r.displayName}
-                </div>
-                <div style={{ fontSize: 11, color: "var(--fg-3)", fontFamily: "var(--font-mono)" }}>
-                  {MARKET_LABEL[r.market]} · {r.symbol}
-                </div>
-              </div>
-              {ago && (
-                <div style={{ fontSize: 11, color: "var(--fg-3)", flexShrink: 0 }}>{ago}</div>
-              )}
-            </button>
+              right={ago ? <div style={{ fontSize: 11, color: "var(--fg-3)", flexShrink: 0 }}>{ago}</div> : undefined}
+            />
           </li>
         );
       })}
@@ -556,8 +536,10 @@ function RealtimePanel({
             const pillTone = decisionTone(s.decisionLabel);
             return (
               <li key={s.id}>
-                <button
-                  type="button"
+                <SymbolRow
+                  displayName={displayName}
+                  symbol={symbol}
+                  disabled={!symbol}
                   onClick={() => {
                     if (!symbol) return;
                     const sym: RecentInvestSymbol = {
@@ -572,45 +554,14 @@ function RealtimePanel({
                       sym,
                     );
                   }}
-                  disabled={!symbol}
-                  style={{
-                    display: "flex",
-                    alignItems: "flex-start",
-                    gap: 8,
-                    padding: "8px 0",
-                    width: "100%",
-                    background: "transparent",
-                    border: "none",
-                    borderBottom: "1px solid var(--divider)",
-                    cursor: symbol ? "pointer" : "default",
-                    textAlign: "left",
-                    fontFamily: "inherit",
-                  }}
-                >
-                  <div style={{ minWidth: 0, flex: 1 }}>
-                    <div
-                      style={{
-                        fontSize: 12,
-                        fontWeight: 600,
-                        color: "var(--fg)",
-                        overflow: "hidden",
-                        textOverflow: "ellipsis",
-                        whiteSpace: "nowrap",
-                      }}
-                    >
-                      {displayName}
-                    </div>
-                    <div style={{ fontSize: 11, color: "var(--fg-3)", marginTop: 2 }}>
+                  meta={(
+                    <>
                       {symbol && <span style={{ fontFamily: "var(--font-mono)", marginRight: 4 }}>{symbol}</span>}
                       {ago}
-                    </div>
-                  </div>
-                  {decLabel && (
-                    <Pill tone={pillTone} size="sm">
-                      {decLabel}
-                    </Pill>
+                    </>
                   )}
-                </button>
+                  right={decLabel ? <Pill tone={pillTone} size="sm">{decLabel}</Pill> : undefined}
+                />
               </li>
             );
           })}

--- a/frontend/invest/src/desktop/RightRemotePanel.tsx
+++ b/frontend/invest/src/desktop/RightRemotePanel.tsx
@@ -1,0 +1,648 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAccountPanel } from "./useAccountPanel";
+import { loadRecentSymbols, recordRecentSymbol } from "./recentSymbols";
+import type { RecentInvestSymbol } from "./recentSymbols";
+import { Button, Card, Icon, PL, Pill } from "../ds";
+import { fetchSignals } from "../api/signals";
+import type { SignalCard } from "../types/signals";
+import type { GroupedHolding, WatchSymbol } from "../types/invest";
+import { formatRelativeTime } from "../format/relativeTime";
+
+type RightPanelTab = "portfolio" | "watchlist" | "recent" | "realtime";
+
+const TABS: { key: RightPanelTab; label: string }[] = [
+  { key: "portfolio", label: "내 투자" },
+  { key: "watchlist", label: "관심" },
+  { key: "recent", label: "최근 본" },
+  { key: "realtime", label: "실시간" },
+];
+
+const MARKET_LABEL: Record<"kr" | "us" | "crypto", string> = {
+  kr: "KR",
+  us: "US",
+  crypto: "CRYPTO",
+};
+
+function fmtKrw(v?: number | null): string {
+  if (v == null) return "—";
+  return `₩${Math.round(v).toLocaleString("ko-KR")}`;
+}
+
+function fmtPct(v?: number | null): string {
+  if (v == null) return "—";
+  const pct = v * 100;
+  const sign = pct >= 0 ? "+" : "";
+  return `${sign}${pct.toFixed(2)}%`;
+}
+
+function TabBar({
+  active,
+  onChange,
+}: {
+  active: RightPanelTab;
+  onChange: (tab: RightPanelTab) => void;
+}) {
+  return (
+    <div
+      role="tablist"
+      style={{
+        display: "flex",
+        borderBottom: "1px solid var(--divider)",
+        marginBottom: 12,
+      }}
+    >
+      {TABS.map((t) => {
+        const isActive = t.key === active;
+        return (
+          <button
+            key={t.key}
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onChange(t.key)}
+            style={{
+              flex: 1,
+              padding: "8px 0",
+              border: "none",
+              borderBottom: isActive ? "2px solid var(--fg)" : "2px solid transparent",
+              background: "transparent",
+              color: isActive ? "var(--fg)" : "var(--fg-3)",
+              fontWeight: isActive ? 700 : 500,
+              fontSize: 12,
+              fontFamily: "inherit",
+              cursor: "pointer",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {t.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function PortfolioPanel({ onNavigate }: { onNavigate: (path: string, sym: RecentInvestSymbol) => void }) {
+  const { data, error, loading, refreshing, reload } = useAccountPanel();
+
+  if (loading) {
+    return (
+      <div data-testid="portfolio-panel-skeleton" style={{ padding: 8, color: "var(--fg-3)", fontSize: 13 }}>
+        불러오는 중…
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div data-testid="portfolio-panel-error" style={{ padding: 8, color: "var(--danger)", fontSize: 13 }}>
+        계좌 정보를 불러오지 못했습니다.
+        <button
+          type="button"
+          onClick={reload}
+          style={{
+            display: "block",
+            marginTop: 8,
+            padding: "4px 10px",
+            borderRadius: 8,
+            border: "1px solid var(--border)",
+            background: "var(--surface)",
+            color: "var(--fg-1)",
+            cursor: "pointer",
+            fontFamily: "inherit",
+            fontSize: 12,
+          }}
+        >
+          재시도
+        </button>
+      </div>
+    );
+  }
+
+  const { homeSummary, groupedHoldings } = data;
+  const sorted = [...groupedHoldings].sort(
+    (a, b) => (b.valueKrw ?? 0) - (a.valueKrw ?? 0),
+  );
+
+  const marketKey = (m: GroupedHolding["market"]): "kr" | "us" | "crypto" => {
+    if (m === "KR") return "kr";
+    if (m === "US") return "us";
+    return "crypto";
+  };
+
+  return (
+    <div data-testid="portfolio-panel" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <Card style={{ padding: 14 }}>
+        <div style={{ fontSize: 11, color: "var(--fg-3)", fontWeight: 500 }}>총 자산</div>
+        <div
+          style={{
+            fontSize: 22,
+            fontWeight: 700,
+            letterSpacing: "-0.02em",
+            marginTop: 2,
+            fontFeatureSettings: '"tnum"',
+          }}
+        >
+          {fmtKrw(homeSummary.totalValueKrw)}
+        </div>
+        {homeSummary.pnlKrw != null && homeSummary.pnlRate != null ? (
+          <div style={{ marginTop: 4 }}>
+            <PL value={homeSummary.pnlKrw} pct={homeSummary.pnlRate * 100} size={12} />
+          </div>
+        ) : (
+          <div style={{ marginTop: 4, fontSize: 12, color: "var(--fg-3)" }}>—</div>
+        )}
+        <div style={{ display: "flex", gap: 6, marginTop: 12 }}>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={reload}
+            style={{ flex: 1, justifyContent: "center" }}
+          >
+            <Icon name="refresh" size={13} />
+            {refreshing ? "새로고침 중…" : "새로고침"}
+          </Button>
+        </div>
+      </Card>
+
+      <div>
+        <div style={{ fontSize: 11, fontWeight: 600, color: "var(--fg-3)", marginBottom: 6 }}>
+          내 종목 현황
+        </div>
+        {sorted.length === 0 ? (
+          <div data-testid="holdings-empty" style={{ fontSize: 12, color: "var(--fg-3)", padding: "8px 0" }}>
+            보유 종목이 없습니다.
+          </div>
+        ) : (
+          <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column" }}>
+            {sorted.map((h) => {
+              const mk = marketKey(h.market);
+              return (
+                <li key={h.groupId}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const sym: RecentInvestSymbol = {
+                        symbol: h.symbol,
+                        market: mk,
+                        displayName: h.displayName,
+                        lastViewedAt: new Date().toISOString(),
+                        source: "right-panel",
+                      };
+                      onNavigate(
+                        `/signals?symbol=${encodeURIComponent(h.symbol)}&market=${mk}`,
+                        sym,
+                      );
+                    }}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      padding: "8px 0",
+                      width: "100%",
+                      background: "transparent",
+                      border: "none",
+                      borderBottom: "1px solid var(--divider)",
+                      cursor: "pointer",
+                      textAlign: "left",
+                      fontFamily: "inherit",
+                    }}
+                  >
+                    <div style={{ minWidth: 0, flex: 1 }}>
+                      <div
+                        style={{
+                          fontSize: 13,
+                          fontWeight: 600,
+                          lineHeight: 1.3,
+                          color: "var(--fg)",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          whiteSpace: "nowrap",
+                        }}
+                      >
+                        {h.displayName}
+                      </div>
+                      <div style={{ fontSize: 11, color: "var(--fg-3)", fontFamily: "var(--font-mono)" }}>
+                        {MARKET_LABEL[mk]} · {h.symbol}
+                      </div>
+                    </div>
+                    <div style={{ textAlign: "right", flexShrink: 0 }}>
+                      <div style={{ fontSize: 12, fontWeight: 600, fontFeatureSettings: '"tnum"' }}>
+                        {fmtKrw(h.valueKrw)}
+                      </div>
+                      {h.pnlRate != null ? (
+                        <div
+                          style={{
+                            fontSize: 11,
+                            color: h.pnlRate >= 0 ? "var(--gain)" : "var(--loss)",
+                            fontFeatureSettings: '"tnum"',
+                          }}
+                        >
+                          {fmtPct(h.pnlRate)}
+                        </div>
+                      ) : (
+                        <div style={{ fontSize: 11, color: "var(--fg-3)" }}>—</div>
+                      )}
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function WatchlistPanel({ onNavigate }: { onNavigate: (path: string, sym: RecentInvestSymbol) => void }) {
+  const { data, error, loading } = useAccountPanel();
+
+  if (loading) {
+    return (
+      <div data-testid="watchlist-panel-skeleton" style={{ padding: 8, color: "var(--fg-3)", fontSize: 13 }}>
+        불러오는 중…
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div data-testid="watchlist-panel-error" style={{ padding: 8, color: "var(--danger)", fontSize: 13 }}>
+        관심 종목을 불러오지 못했습니다.
+      </div>
+    );
+  }
+
+  if (!data.meta.watchlistAvailable) {
+    return (
+      <div style={{ padding: 8, fontSize: 13, color: "var(--fg-3)" }}>
+        관심 종목 데이터를 사용할 수 없습니다.
+      </div>
+    );
+  }
+
+  const { watchSymbols } = data;
+
+  return (
+    <div data-testid="watchlist-panel">
+      {watchSymbols.length === 0 ? (
+        <div data-testid="watchlist-panel-empty" style={{ fontSize: 13, color: "var(--fg-3)", padding: "8px 0" }}>
+          등록된 관심 종목이 없습니다.
+        </div>
+      ) : (
+        <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column" }}>
+          {watchSymbols.map((w) => (
+            <li key={`${w.market}:${w.symbol}`}>
+              <WatchRow w={w} onNavigate={onNavigate} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function WatchRow({
+  w,
+  onNavigate,
+}: {
+  w: WatchSymbol;
+  onNavigate: (path: string, sym: RecentInvestSymbol) => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        const sym: RecentInvestSymbol = {
+          symbol: w.symbol,
+          market: w.market,
+          displayName: w.displayName,
+          lastViewedAt: new Date().toISOString(),
+          source: "right-panel",
+        };
+        onNavigate(
+          `/feed/news?symbol=${encodeURIComponent(w.symbol)}&market=${w.market}`,
+          sym,
+        );
+      }}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: "8px 0",
+        width: "100%",
+        background: "transparent",
+        border: "none",
+        borderBottom: "1px solid var(--divider)",
+        cursor: "pointer",
+        textAlign: "left",
+        fontFamily: "inherit",
+      }}
+    >
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div
+          style={{
+            fontSize: 13,
+            fontWeight: 600,
+            lineHeight: 1.3,
+            color: "var(--fg)",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {w.displayName}
+        </div>
+        <div style={{ fontSize: 11, color: "var(--fg-3)", fontFamily: "var(--font-mono)" }}>
+          {MARKET_LABEL[w.market]} · {w.symbol}
+        </div>
+      </div>
+      {w.note && (
+        <div style={{ fontSize: 11, color: "var(--fg-3)", flexShrink: 0, maxWidth: 60, textAlign: "right" }}>
+          {w.note}
+        </div>
+      )}
+    </button>
+  );
+}
+
+function RecentPanel({
+  onNavigate,
+  refreshKey,
+}: {
+  onNavigate: (path: string, sym: RecentInvestSymbol) => void;
+  refreshKey: number;
+}) {
+  const [recents, setRecents] = useState<RecentInvestSymbol[]>([]);
+
+  useEffect(() => {
+    setRecents(loadRecentSymbols());
+  }, [refreshKey]);
+
+  if (recents.length === 0) {
+    return (
+      <div data-testid="recent-panel-empty" style={{ fontSize: 13, color: "var(--fg-3)", padding: "8px 0" }}>
+        최근 본 종목이 없습니다. 종목을 클릭하면 여기에 기록됩니다.
+      </div>
+    );
+  }
+
+  return (
+    <ul
+      data-testid="recent-panel"
+      style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column" }}
+    >
+      {recents.map((r) => {
+        const ago = formatRelativeTime(r.lastViewedAt) ?? "";
+        return (
+          <li key={`${r.market}:${r.symbol}`}>
+            <button
+              type="button"
+              onClick={() => {
+                onNavigate(
+                  `/signals?symbol=${encodeURIComponent(r.symbol)}&market=${r.market}`,
+                  { ...r, lastViewedAt: new Date().toISOString() },
+                );
+              }}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                padding: "8px 0",
+                width: "100%",
+                background: "transparent",
+                border: "none",
+                borderBottom: "1px solid var(--divider)",
+                cursor: "pointer",
+                textAlign: "left",
+                fontFamily: "inherit",
+              }}
+            >
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <div
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 600,
+                    color: "var(--fg)",
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {r.displayName}
+                </div>
+                <div style={{ fontSize: 11, color: "var(--fg-3)", fontFamily: "var(--font-mono)" }}>
+                  {MARKET_LABEL[r.market]} · {r.symbol}
+                </div>
+              </div>
+              {ago && (
+                <div style={{ fontSize: 11, color: "var(--fg-3)", flexShrink: 0 }}>{ago}</div>
+              )}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+type RealtimeSubTab = "kr" | "us" | "crypto";
+
+const REALTIME_TABS: { key: RealtimeSubTab; label: string }[] = [
+  { key: "kr", label: "국내" },
+  { key: "us", label: "해외" },
+  { key: "crypto", label: "코인" },
+];
+
+const DECISION_LABEL: Record<string, string> = {
+  buy: "매수",
+  sell: "매도",
+  hold: "보유",
+  watch: "주시",
+  neutral: "중립",
+};
+
+function RealtimePanel({
+  onNavigate,
+}: {
+  onNavigate: (path: string, sym: RecentInvestSymbol) => void;
+}) {
+  const [subTab, setSubTab] = useState<RealtimeSubTab>("kr");
+  const [items, setItems] = useState<SignalCard[]>([]);
+  const [err, setErr] = useState<string | undefined>();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let cancel = false;
+    setLoading(true);
+    setErr(undefined);
+    fetchSignals({ tab: subTab, limit: 10 })
+      .then((r) => {
+        if (cancel) return;
+        setItems(r.items);
+        setLoading(false);
+      })
+      .catch((e: unknown) => {
+        if (cancel) return;
+        const msg = e instanceof Error ? e.message : String(e);
+        setErr(msg);
+        setLoading(false);
+      });
+    return () => {
+      cancel = true;
+    };
+  }, [subTab]);
+
+  return (
+    <div data-testid="realtime-panel">
+      <div style={{ fontSize: 11, color: "var(--fg-3)", marginBottom: 8 }}>
+        최근 신호 (참고용, 실시간 스트림 아님)
+      </div>
+      <div style={{ display: "flex", gap: 4, marginBottom: 10 }}>
+        {REALTIME_TABS.map((t) => {
+          const on = t.key === subTab;
+          return (
+            <button
+              key={t.key}
+              type="button"
+              onClick={() => setSubTab(t.key)}
+              style={{
+                padding: "4px 10px",
+                borderRadius: 999,
+                border: "1px solid var(--border)",
+                background: on ? "var(--fg)" : "transparent",
+                color: on ? "var(--bg)" : "var(--fg-2)",
+                fontWeight: on ? 700 : 500,
+                fontSize: 11,
+                fontFamily: "inherit",
+                cursor: "pointer",
+              }}
+            >
+              {t.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {loading && (
+        <div style={{ fontSize: 13, color: "var(--fg-3)", padding: "8px 0" }}>불러오는 중…</div>
+      )}
+      {err && !loading && (
+        <div style={{ fontSize: 12, color: "var(--danger)" }}>오류: {err}</div>
+      )}
+      {!loading && !err && items.length === 0 && (
+        <div data-testid="realtime-empty" style={{ fontSize: 13, color: "var(--fg-3)", padding: "8px 0" }}>
+          최근 신호가 없습니다.
+        </div>
+      )}
+      {!loading && (
+        <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column" }}>
+          {items.map((s) => {
+            const primarySym = s.relatedSymbols[0];
+            const market = (primarySym?.market ?? subTab) as "kr" | "us" | "crypto";
+            const symbol = primarySym?.symbol ?? "";
+            const displayName = primarySym?.displayName ?? s.title;
+            const ago = formatRelativeTime(s.generatedAt) ?? "";
+            const decLabel = s.decisionLabel ? (DECISION_LABEL[s.decisionLabel] ?? s.decisionLabel) : null;
+            return (
+              <li key={s.id}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (!symbol) return;
+                    const sym: RecentInvestSymbol = {
+                      symbol,
+                      market,
+                      displayName,
+                      lastViewedAt: new Date().toISOString(),
+                      source: "right-panel",
+                    };
+                    onNavigate(
+                      `/signals?symbol=${encodeURIComponent(symbol)}&market=${market}`,
+                      sym,
+                    );
+                  }}
+                  disabled={!symbol}
+                  style={{
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: 8,
+                    padding: "8px 0",
+                    width: "100%",
+                    background: "transparent",
+                    border: "none",
+                    borderBottom: "1px solid var(--divider)",
+                    cursor: symbol ? "pointer" : "default",
+                    textAlign: "left",
+                    fontFamily: "inherit",
+                  }}
+                >
+                  <div style={{ minWidth: 0, flex: 1 }}>
+                    <div
+                      style={{
+                        fontSize: 12,
+                        fontWeight: 600,
+                        color: "var(--fg)",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {displayName}
+                    </div>
+                    <div style={{ fontSize: 11, color: "var(--fg-3)", marginTop: 2 }}>
+                      {symbol && <span style={{ fontFamily: "var(--font-mono)", marginRight: 4 }}>{symbol}</span>}
+                      {ago}
+                    </div>
+                  </div>
+                  {decLabel && (
+                    <Pill
+                      tone={
+                        s.decisionLabel === "buy"
+                          ? "accent"
+                          : s.decisionLabel === "sell"
+                            ? "loss"
+                            : "paper"
+                      }
+                      size="sm"
+                    >
+                      {decLabel}
+                    </Pill>
+                  )}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export function RightRemotePanel() {
+  const [activeTab, setActiveTab] = useState<RightPanelTab>("portfolio");
+  const [recentRefreshKey, setRecentRefreshKey] = useState(0);
+  const navigate = useNavigate();
+
+  const handleNavigate = useCallback(
+    (path: string, sym: RecentInvestSymbol) => {
+      recordRecentSymbol(sym);
+      setRecentRefreshKey((k) => k + 1);
+      navigate(path);
+    },
+    [navigate],
+  );
+
+  return (
+    <div data-testid="right-remote-panel">
+      <TabBar active={activeTab} onChange={setActiveTab} />
+      {activeTab === "portfolio" && <PortfolioPanel onNavigate={handleNavigate} />}
+      {activeTab === "watchlist" && <WatchlistPanel onNavigate={handleNavigate} />}
+      {activeTab === "recent" && (
+        <RecentPanel onNavigate={handleNavigate} refreshKey={recentRefreshKey} />
+      )}
+      {activeTab === "realtime" && <RealtimePanel onNavigate={handleNavigate} />}
+    </div>
+  );
+}

--- a/frontend/invest/src/desktop/RightRemotePanel.tsx
+++ b/frontend/invest/src/desktop/RightRemotePanel.tsx
@@ -3,13 +3,17 @@ import { useNavigate } from "react-router-dom";
 import { useAccountPanel } from "./useAccountPanel";
 import { loadRecentSymbols, recordRecentSymbol } from "./recentSymbols";
 import type { RecentInvestSymbol } from "./recentSymbols";
-import { Button, Card, Icon, PL, Pill } from "../ds";
+import { Button, Card, Icon, PL as ProfitLoss, Pill } from "../ds";
+import type { PillTone } from "../ds";
 import { fetchSignals } from "../api/signals";
 import type { SignalCard } from "../types/signals";
 import type { GroupedHolding, WatchSymbol } from "../types/invest";
 import { formatRelativeTime } from "../format/relativeTime";
 
 type RightPanelTab = "portfolio" | "watchlist" | "recent" | "realtime";
+type RealtimeSubTab = "kr" | "us" | "crypto";
+type MarketKey = "kr" | "us" | "crypto";
+type NavigateToSymbol = (path: string, sym: RecentInvestSymbol) => void;
 
 const TABS: { key: RightPanelTab; label: string }[] = [
   { key: "portfolio", label: "내 투자" },
@@ -18,7 +22,7 @@ const TABS: { key: RightPanelTab; label: string }[] = [
   { key: "realtime", label: "실시간" },
 ];
 
-const MARKET_LABEL: Record<"kr" | "us" | "crypto", string> = {
+const MARKET_LABEL: Record<MarketKey, string> = {
   kr: "KR",
   us: "US",
   crypto: "CRYPTO",
@@ -39,10 +43,10 @@ function fmtPct(v?: number | null): string {
 function TabBar({
   active,
   onChange,
-}: {
+}: Readonly<{
   active: RightPanelTab;
   onChange: (tab: RightPanelTab) => void;
-}) {
+}>) {
   return (
     <div
       role="tablist"
@@ -82,7 +86,7 @@ function TabBar({
   );
 }
 
-function PortfolioPanel({ onNavigate }: { onNavigate: (path: string, sym: RecentInvestSymbol) => void }) {
+function PortfolioPanel({ onNavigate }: Readonly<{ onNavigate: NavigateToSymbol }>) {
   const { data, error, loading, refreshing, reload } = useAccountPanel();
 
   if (loading) {
@@ -96,7 +100,7 @@ function PortfolioPanel({ onNavigate }: { onNavigate: (path: string, sym: Recent
   if (error || !data) {
     return (
       <div data-testid="portfolio-panel-error" style={{ padding: 8, color: "var(--danger)", fontSize: 13 }}>
-        계좌 정보를 불러오지 못했습니다.
+        <div>계좌 정보를 불러오지 못했습니다.</div>
         <button
           type="button"
           onClick={reload}
@@ -124,7 +128,7 @@ function PortfolioPanel({ onNavigate }: { onNavigate: (path: string, sym: Recent
     (a, b) => (b.valueKrw ?? 0) - (a.valueKrw ?? 0),
   );
 
-  const marketKey = (m: GroupedHolding["market"]): "kr" | "us" | "crypto" => {
+  const marketKey = (m: GroupedHolding["market"]): MarketKey => {
     if (m === "KR") return "kr";
     if (m === "US") return "us";
     return "crypto";
@@ -147,7 +151,7 @@ function PortfolioPanel({ onNavigate }: { onNavigate: (path: string, sym: Recent
         </div>
         {homeSummary.pnlKrw != null && homeSummary.pnlRate != null ? (
           <div style={{ marginTop: 4 }}>
-            <PL value={homeSummary.pnlKrw} pct={homeSummary.pnlRate * 100} size={12} />
+            <ProfitLoss value={homeSummary.pnlKrw} pct={homeSummary.pnlRate * 100} size={12} />
           </div>
         ) : (
           <div style={{ marginTop: 4, fontSize: 12, color: "var(--fg-3)" }}>—</div>
@@ -230,7 +234,9 @@ function PortfolioPanel({ onNavigate }: { onNavigate: (path: string, sym: Recent
                       <div style={{ fontSize: 12, fontWeight: 600, fontFeatureSettings: '"tnum"' }}>
                         {fmtKrw(h.valueKrw)}
                       </div>
-                      {h.pnlRate != null ? (
+                      {h.pnlRate == null ? (
+                        <div style={{ fontSize: 11, color: "var(--fg-3)" }}>—</div>
+                      ) : (
                         <div
                           style={{
                             fontSize: 11,
@@ -240,8 +246,6 @@ function PortfolioPanel({ onNavigate }: { onNavigate: (path: string, sym: Recent
                         >
                           {fmtPct(h.pnlRate)}
                         </div>
-                      ) : (
-                        <div style={{ fontSize: 11, color: "var(--fg-3)" }}>—</div>
                       )}
                     </div>
                   </button>
@@ -255,7 +259,7 @@ function PortfolioPanel({ onNavigate }: { onNavigate: (path: string, sym: Recent
   );
 }
 
-function WatchlistPanel({ onNavigate }: { onNavigate: (path: string, sym: RecentInvestSymbol) => void }) {
+function WatchlistPanel({ onNavigate }: Readonly<{ onNavigate: NavigateToSymbol }>) {
   const { data, error, loading } = useAccountPanel();
 
   if (loading) {
@@ -306,10 +310,10 @@ function WatchlistPanel({ onNavigate }: { onNavigate: (path: string, sym: Recent
 function WatchRow({
   w,
   onNavigate,
-}: {
+}: Readonly<{
   w: WatchSymbol;
-  onNavigate: (path: string, sym: RecentInvestSymbol) => void;
-}) {
+  onNavigate: NavigateToSymbol;
+}>) {
   return (
     <button
       type="button"
@@ -370,10 +374,10 @@ function WatchRow({
 function RecentPanel({
   onNavigate,
   refreshKey,
-}: {
-  onNavigate: (path: string, sym: RecentInvestSymbol) => void;
+}: Readonly<{
+  onNavigate: NavigateToSymbol;
   refreshKey: number;
-}) {
+}>) {
   const [recents, setRecents] = useState<RecentInvestSymbol[]>([]);
 
   useEffect(() => {
@@ -447,8 +451,6 @@ function RecentPanel({
   );
 }
 
-type RealtimeSubTab = "kr" | "us" | "crypto";
-
 const REALTIME_TABS: { key: RealtimeSubTab; label: string }[] = [
   { key: "kr", label: "국내" },
   { key: "us", label: "해외" },
@@ -463,11 +465,17 @@ const DECISION_LABEL: Record<string, string> = {
   neutral: "중립",
 };
 
+function decisionTone(decision?: string | null): PillTone {
+  if (decision === "buy") return "accent";
+  if (decision === "sell") return "loss";
+  return "paper";
+}
+
 function RealtimePanel({
   onNavigate,
-}: {
-  onNavigate: (path: string, sym: RecentInvestSymbol) => void;
-}) {
+}: Readonly<{
+  onNavigate: NavigateToSymbol;
+}>) {
   const [subTab, setSubTab] = useState<RealtimeSubTab>("kr");
   const [items, setItems] = useState<SignalCard[]>([]);
   const [err, setErr] = useState<string | undefined>();
@@ -540,11 +548,12 @@ function RealtimePanel({
         <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column" }}>
           {items.map((s) => {
             const primarySym = s.relatedSymbols[0];
-            const market = (primarySym?.market ?? subTab) as "kr" | "us" | "crypto";
+            const market = (primarySym?.market ?? subTab) as MarketKey;
             const symbol = primarySym?.symbol ?? "";
             const displayName = primarySym?.displayName ?? s.title;
             const ago = formatRelativeTime(s.generatedAt) ?? "";
             const decLabel = s.decisionLabel ? (DECISION_LABEL[s.decisionLabel] ?? s.decisionLabel) : null;
+            const pillTone = decisionTone(s.decisionLabel);
             return (
               <li key={s.id}>
                 <button
@@ -597,16 +606,7 @@ function RealtimePanel({
                     </div>
                   </div>
                   {decLabel && (
-                    <Pill
-                      tone={
-                        s.decisionLabel === "buy"
-                          ? "accent"
-                          : s.decisionLabel === "sell"
-                            ? "loss"
-                            : "paper"
-                      }
-                      size="sm"
-                    >
+                    <Pill tone={pillTone} size="sm">
                       {decLabel}
                     </Pill>
                   )}

--- a/frontend/invest/src/desktop/recentSymbols.ts
+++ b/frontend/invest/src/desktop/recentSymbols.ts
@@ -1,0 +1,45 @@
+const KEY = "invest.recentSymbols.v1";
+const MAX = 30;
+
+export interface RecentInvestSymbol {
+  symbol: string;
+  market: "kr" | "us" | "crypto";
+  displayName: string;
+  lastViewedAt: string;
+  source?: "right-panel" | "signals" | "discover" | "feed-news" | "screener";
+}
+
+function isValidEntry(item: unknown): item is RecentInvestSymbol {
+  if (typeof item !== "object" || item === null) return false;
+  const o = item as Record<string, unknown>;
+  return (
+    typeof o["symbol"] === "string" &&
+    typeof o["market"] === "string" &&
+    typeof o["displayName"] === "string" &&
+    typeof o["lastViewedAt"] === "string"
+  );
+}
+
+export function loadRecentSymbols(): RecentInvestSymbol[] {
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return (parsed as unknown[]).filter(isValidEntry);
+  } catch {
+    return [];
+  }
+}
+
+export function recordRecentSymbol(sym: RecentInvestSymbol): void {
+  try {
+    const existing = loadRecentSymbols().filter(
+      (r) => !(r.symbol === sym.symbol && r.market === sym.market),
+    );
+    const next = [sym, ...existing].slice(0, MAX);
+    localStorage.setItem(KEY, JSON.stringify(next));
+  } catch {
+    // localStorage unavailable or full — ignore silently
+  }
+}

--- a/frontend/invest/src/desktop/useAccountPanel.ts
+++ b/frontend/invest/src/desktop/useAccountPanel.ts
@@ -1,21 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
-import type { AccountPanelResponse } from "../types/invest";
-import { fetchAccountPanel } from "../api/accountPanel";
+import { useAccountPanelContext } from "./AccountPanelProvider";
 
 export function useAccountPanel() {
-  const [data, setData] = useState<AccountPanelResponse | undefined>();
-  const [error, setError] = useState<string | undefined>();
-  const [loading, setLoading] = useState(true);
-  const [tick, setTick] = useState(0);
-  useEffect(() => {
-    let cancel = false;
-    setError(undefined);
-    setLoading(true);
-    fetchAccountPanel()
-      .then((r) => { if (!cancel) { setData(r); setLoading(false); } })
-      .catch((e) => { if (!cancel) { setError(String(e?.message ?? e)); setLoading(false); } });
-    return () => { cancel = true; };
-  }, [tick]);
-  const reload = useCallback(() => setTick((t) => t + 1), []);
-  return { data, error, loading, reload };
+  return useAccountPanelContext();
 }

--- a/frontend/invest/src/pages/desktop/DesktopCalendarPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCalendarPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { DesktopShell } from "../../desktop/DesktopShell";
-import { RightAccountPanel } from "../../desktop/RightAccountPanel";
-import { useAccountPanel } from "../../desktop/useAccountPanel";
+import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useViewport } from "../../hooks/useViewport";
 import { fetchCalendar, fetchWeeklySummary } from "../../api/calendar";
 import type { CalendarResponse, WeeklySummaryResponse } from "../../types/calendar";
@@ -40,7 +39,6 @@ export function CalendarRoute() {
 }
 
 export function DesktopCalendarPage() {
-  const panel = useAccountPanel();
   const [weekStart, setWeekStart] = useState<Date>(() => startOfWeek(new Date()));
   const weekEnd = useMemo(() => {
     const e = new Date(weekStart);
@@ -255,7 +253,7 @@ export function DesktopCalendarPage() {
           </Card>
         </>
       }
-      right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} onRefresh={panel.reload} />}
+      right={<RightRemotePanel />}
       />
       {showSummary && (
         <EventDetailModal

--- a/frontend/invest/src/pages/desktop/DesktopDiscoverPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopDiscoverPage.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { DesktopShell } from "../../desktop/DesktopShell";
-import { RightAccountPanel } from "../../desktop/RightAccountPanel";
-import { useAccountPanel } from "../../desktop/useAccountPanel";
+import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useViewport } from "../../hooks/useViewport";
 import { useNewsIssues } from "../../hooks/useNewsIssues";
 import { sortMarketIssues } from "../../components/discover/severity";
@@ -14,7 +13,6 @@ export function InvestDiscoverRoute() {
 }
 
 export function DesktopDiscoverPage() {
-  const panel = useAccountPanel();
   const issues = useNewsIssues({ market: "all", windowHours: 24, limit: 20 });
   const [openId, setOpenId] = useState<string | null>(null);
 
@@ -89,7 +87,7 @@ export function DesktopDiscoverPage() {
           </div>
         </>
       }
-      right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} onRefresh={panel.reload} />}
+      right={<RightRemotePanel />}
     />
   );
 }

--- a/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { DesktopShell } from "../../desktop/DesktopShell";
-import { RightAccountPanel } from "../../desktop/RightAccountPanel";
-import { useAccountPanel } from "../../desktop/useAccountPanel";
+import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useViewport } from "../../hooks/useViewport";
 import { fetchFeedNews } from "../../api/feedNews";
 import type { FeedNewsResponse, FeedTab } from "../../types/feedNews";
@@ -15,7 +14,6 @@ export function FeedNewsRoute() {
 }
 
 export function DesktopFeedNewsPage() {
-  const panel = useAccountPanel();
   const [tab, setTab] = useState<FeedTab>("top");
   const [data, setData] = useState<FeedNewsResponse | undefined>();
   const [err, setErr] = useState<string | undefined>();
@@ -74,7 +72,7 @@ export function DesktopFeedNewsPage() {
           </div>
         </>
       }
-      right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} onRefresh={panel.reload} />}
+      right={<RightRemotePanel />}
     />
   );
 }

--- a/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
@@ -2,8 +2,7 @@ import { useMemo, useState } from "react";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { LeftContextRail } from "../../desktop/LeftContextRail";
 import type { AccountFilterKey } from "../../desktop/LeftContextRail";
-import { RightAccountPanel } from "../../desktop/RightAccountPanel";
-import { useAccountPanel } from "../../desktop/useAccountPanel";
+import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useInvestHome } from "../../hooks/useInvestHome";
 import { useViewport } from "../../hooks/useViewport";
 import { scopeGroupedToSource } from "../../desktop/scopeHoldings";
@@ -24,7 +23,6 @@ export function InvestHomeRoute() {
 
 export function DesktopHomePage() {
   const home = useInvestHome();
-  const panel = useAccountPanel();
   const [account, setAccount] = useState<AccountFilterKey>("all");
   const [category, setCategory] = useState<AssetCategoryKey>("all");
 
@@ -132,14 +130,7 @@ export function DesktopHomePage() {
           )}
         </>
       }
-      right={
-        <RightAccountPanel
-          data={panel.data}
-          loading={panel.loading}
-          error={panel.error}
-          onRefresh={panel.reload}
-        />
-      }
+      right={<RightRemotePanel />}
     />
   );
 }

--- a/frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { DesktopShell } from "../../desktop/DesktopShell";
-import { RightAccountPanel } from "../../desktop/RightAccountPanel";
-import { useAccountPanel } from "../../desktop/useAccountPanel";
+import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { ScreenerPresetSidebar } from "../../desktop/screener/ScreenerPresetSidebar";
 import { ScreenerFilterBar } from "../../desktop/screener/ScreenerFilterBar";
 import { ScreenerResultsTable } from "../../desktop/screener/ScreenerResultsTable";
@@ -14,7 +13,6 @@ import type {
 import "../../desktop/screener/screener.css";
 
 export function DesktopScreenerPage() {
-  const panel = useAccountPanel();
   const [presets, setPresets] = useState<ScreenerPresetsResponse | undefined>();
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [results, setResults] = useState<ScreenerResultsResponse | undefined>();
@@ -89,7 +87,7 @@ export function DesktopScreenerPage() {
           />
         </div>
       }
-      right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} />}
+      right={<RightRemotePanel />}
     />
   );
 }

--- a/frontend/invest/src/pages/desktop/DesktopSignalsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopSignalsPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { DesktopShell } from "../../desktop/DesktopShell";
-import { RightAccountPanel } from "../../desktop/RightAccountPanel";
-import { useAccountPanel } from "../../desktop/useAccountPanel";
+import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useViewport } from "../../hooks/useViewport";
 import { fetchSignals } from "../../api/signals";
 import type { SignalsResponse, SignalTab, SignalCard as SignalCardData } from "../../types/signals";
@@ -22,7 +21,6 @@ export function SignalsRoute() {
 }
 
 export function DesktopSignalsPage() {
-  const panel = useAccountPanel();
   const [tab, setTab] = useState<SignalTab>("mine");
   const [data, setData] = useState<SignalsResponse | undefined>();
   const [err, setErr] = useState<string | undefined>();
@@ -97,7 +95,7 @@ export function DesktopSignalsPage() {
           )}
         </Card>
       }
-      right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} onRefresh={panel.reload} />}
+      right={<RightRemotePanel />}
     />
   );
 }


### PR DESCRIPTION
## Summary

- **Persistent account panel data**: Adds `AccountPanelProvider` context so the right panel fetches `/invest/api/account-panel` once on app init. Route navigation between `/invest`, `/feed/news`, `/discover`, `/signals`, `/calendar`, `/screener` no longer triggers a re-fetch or skeleton flicker while data is already loaded. Manual refresh still issues a new request (`reload()`). Separate `loading` (first fetch) vs `refreshing` (subsequent) state.
- **Tabbed right remote panel** (`RightRemotePanel`): Replaces the flat `RightAccountPanel` in all 6 desktop pages with a 4-tab rail — `내 투자`, `관심`, `최근 본`, `실시간` — without changing central route.
  - `내 투자`: `groupedHoldings` sorted by valueKrw descending + `homeSummary` total/P\L. Click → `/signals?symbol=…&market=…` (read-only, no order mutation).
  - `관심`: `watchSymbols` list. Click → `/feed/news?symbol=…&market=…`.
  - `최근 본`: localStorage-backed (`invest.recentSymbols.v1`, max 30, dedup by market+symbol, newest first). Click → `/signals?symbol=…`. Corrupt/missing storage handled gracefully.
  - `실시간`: Snapshot of `/invest/api/signals` (not true streaming; labelled accordingly). Subtabs 국내/해외/코인. Click → `/signals?symbol=…` + records recent.
- All symbol clicks use React Router `useNavigate` (no full reload), record into recent symbols, never place/preview/cancel orders.
- All 6 desktop pages simplified: removed per-page `useAccountPanel()` + `RightAccountPanel` imports.

## Test plan

- [x] `npm run typecheck` — no errors
- [x] `npm test -- --run` — 128 tests pass (33 test files), including 3 new test files: `AccountPanelProvider.test.tsx`, `RightRemotePanel.test.tsx`, `recentSymbols.test.ts`
- [x] `npm run build` — clean build (381 kB JS, no errors)
- [x] `git diff --check` — no trailing-whitespace issues
- [ ] Manual smoke (delegated — no running dev server in this run): navigate between pages, confirm right panel doesn't skeleton on route change; switch tabs; click held/watch/realtime symbol; check recent panel shows clicked symbols

## Safety / Non-goals

- No broker, KIS/Upbit, order placement, order preview, or scheduler mutations
- No Toss API scraping or authenticated data storage
- No websocket/true realtime — signals snapshot clearly labelled
- `/invest/app/*` legacy routes unchanged
- `RightAccountPanel.tsx` kept in-tree (used by existing tests); desktop pages migrated to `RightRemotePanel`
- Backend (`app/routers/invest_api.py`) untouched — backend tests skipped

Linear: ROB-150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a right-side panel with portfolio, watchlist, recent symbols, and realtime market tabs.
  * Implemented automatic tracking of recently viewed symbols.

* **Refactor**
  * Restructured account panel management with improved centralized state handling across the app.

* **Tests**
  * Added comprehensive test coverage for new components and utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->