### PR TITLE
feat(news): persist related symbols for invest feed

### DIFF
--- a/alembic/versions/d2e3f4a5b6c7_add_news_article_related_symbols.py
+++ b/alembic/versions/d2e3f4a5b6c7_add_news_article_related_symbols.py
@@ -1,0 +1,82 @@
+"""add news_article_related_symbols (ROB-153)
+
+Revision ID: d2e3f4a5b6c7
+Revises: b1c2d3e4
+Create Date: 2026-05-09 14:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "d2e3f4a5b6c7"
+down_revision: str | Sequence[str] | None = "b1c2d3e4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "news_article_related_symbols",
+        sa.Column("id", sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column(
+            "article_id",
+            sa.BigInteger(),
+            sa.ForeignKey("news_articles.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("market", sa.String(length=20), nullable=False),
+        sa.Column("symbol", sa.String(length=40), nullable=False),
+        sa.Column("display_name", sa.String(length=120), nullable=True),
+        sa.Column("source", sa.String(length=40), nullable=False),
+        sa.Column("matched_term", sa.String(length=120), nullable=True),
+        sa.Column("score", sa.Float(), nullable=True),
+        sa.Column("rank", sa.Integer(), nullable=True),
+        sa.Column("raw", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.CheckConstraint(
+            "market IN ('kr', 'us', 'crypto')",
+            name="ck_news_article_related_symbols_market",
+        ),
+        sa.UniqueConstraint(
+            "article_id",
+            "market",
+            "symbol",
+            "source",
+            name="uq_news_article_related_symbols_article_market_symbol_source",
+        ),
+    )
+    op.create_index(
+        "ix_news_article_related_symbols_article_id",
+        "news_article_related_symbols",
+        ["article_id"],
+    )
+    op.create_index(
+        "ix_news_article_related_symbols_article_rank",
+        "news_article_related_symbols",
+        ["article_id", "rank"],
+    )
+    op.create_index(
+        "ix_news_article_related_symbols_market_symbol_article",
+        "news_article_related_symbols",
+        ["market", "symbol", "article_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_news_article_related_symbols_market_symbol_article",
+        table_name="news_article_related_symbols",
+    )
+    op.drop_index(
+        "ix_news_article_related_symbols_article_rank",
+        table_name="news_article_related_symbols",
+    )
+    op.drop_index(
+        "ix_news_article_related_symbols_article_id",
+        table_name="news_article_related_symbols",
+    )
+    op.drop_table("news_article_related_symbols")

--- a/app/models/news.py
+++ b/app/models/news.py
@@ -115,9 +115,63 @@ class NewsArticle(Base):
     analysis_results: Mapped[list["NewsAnalysisResult"]] = relationship(
         back_populates="article", cascade="all, delete-orphan"
     )
+    related_symbols: Mapped[list["NewsArticleRelatedSymbol"]] = relationship(
+        back_populates="article", cascade="all, delete-orphan"
+    )
 
     def __repr__(self) -> str:
         return f"<NewsArticle(id={self.id}, title='{self.title[:50]}...', url='{self.url[:50]}...')>"
+
+
+class NewsArticleRelatedSymbol(Base):
+    __tablename__ = "news_article_related_symbols"
+
+    __table_args__ = (
+        CheckConstraint(
+            "market IN ('kr', 'us', 'crypto')",
+            name="market",
+        ),
+        UniqueConstraint(
+            "article_id",
+            "market",
+            "symbol",
+            "source",
+            name="uq_news_article_related_symbols_article_market_symbol_source",
+        ),
+        Index("ix_news_article_related_symbols_article_rank", "article_id", "rank"),
+        Index(
+            "ix_news_article_related_symbols_market_symbol_article",
+            "market",
+            "symbol",
+            "article_id",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    article_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("news_articles.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    market: Mapped[str] = mapped_column(String(20), nullable=False)
+    symbol: Mapped[str] = mapped_column(String(40), nullable=False)
+    display_name: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    source: Mapped[str] = mapped_column(String(40), nullable=False)
+    matched_term: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    score: Mapped[float | None] = mapped_column(nullable=True)
+    rank: Mapped[int | None] = mapped_column(nullable=True)
+    raw: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(nullable=False)
+
+    article: Mapped["NewsArticle"] = relationship(back_populates="related_symbols")
+
+    def __repr__(self) -> str:
+        return (
+            "<NewsArticleRelatedSymbol("
+            f"article_id={self.article_id}, market='{self.market}', symbol='{self.symbol}', "
+            f"source='{self.source}')>"
+        )
 
 
 class NewsIngestionRun(Base):

--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -155,13 +155,19 @@ async def get_feed_news(
     tab: FeedTab = Query("top"),
     limit: int = Query(30, ge=1, le=100),
     cursor: str | None = Query(None),
+    include_quotes: bool = Query(False, alias="includeQuotes"),
 ) -> FeedNewsResponse:
     home = await service.get_home(user_id=user.id)
     resolver = await build_relation_resolver(
         db, user_id=user.id, held_pairs=_held_pairs_from_home(home)
     )
     return await build_feed_news(
-        db=db, resolver=resolver, tab=tab, limit=limit, cursor=cursor
+        db=db,
+        resolver=resolver,
+        tab=tab,
+        limit=limit,
+        cursor=cursor,
+        include_quotes=include_quotes,
     )
 
 

--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -155,7 +155,7 @@ async def get_feed_news(
     tab: FeedTab = Query("top"),
     limit: int = Query(30, ge=1, le=100),
     cursor: str | None = Query(None),
-    include_quotes: bool = Query(False, alias="includeQuotes"),
+    include_quotes: Annotated[bool, Query(alias="includeQuotes")] = False,
 ) -> FeedNewsResponse:
     home = await service.get_home(user_id=user.id)
     resolver = await build_relation_resolver(

--- a/app/schemas/invest_feed_news.py
+++ b/app/schemas/invest_feed_news.py
@@ -22,6 +22,12 @@ class NewsRelatedSymbol(BaseModel):
     relation: RelationKind = "none"
     matchReason: str | None = None
     matchedTerm: str | None = None
+    currentPrice: float | None = None
+    previousClose: float | None = None
+    change: float | None = None
+    changePct: float | None = None
+    quoteSource: str | None = None
+    quoteAsOf: datetime | None = None
 
 
 class FeedNewsItem(BaseModel):

--- a/app/services/invest_view_model/feed_news_service.py
+++ b/app/services/invest_view_model/feed_news_service.py
@@ -190,18 +190,24 @@ async def _related_symbols_by_article(
     return by_article
 
 
-async def _enrich_related_symbols_with_quotes(
+def _collect_related_symbol_pairs(
     items: list[FeedNewsItem],
-) -> list[str]:
+) -> list[tuple[str, str]]:
     pairs: list[tuple[str, str]] = []
     seen: set[tuple[str, str]] = set()
     for item in items:
         for symbol in item.relatedSymbols:
             key = (symbol.market, symbol.symbol)
-            if key not in seen:
-                seen.add(key)
-                pairs.append(key)
+            if key in seen:
+                continue
+            seen.add(key)
+            pairs.append(key)
+    return pairs
 
+
+async def _fetch_quotes_for_pairs(
+    pairs: list[tuple[str, str]],
+) -> tuple[dict[tuple[str, str], object], list[str], int]:
     quote_by_pair: dict[tuple[str, str], object] = {}
     warnings: list[str] = []
     failures = 0
@@ -216,25 +222,44 @@ async def _enrich_related_symbols_with_quotes(
         except Exception:
             failures += 1
             warnings.append(f"quote_unavailable:{market}:{symbol}")
+    return quote_by_pair, warnings, failures
 
+
+def _apply_quote_to_related_symbol(
+    symbol: NewsRelatedSymbol,
+    quote: object,
+    as_of: datetime,
+) -> None:
+    price = getattr(quote, "price", None)
+    previous_close = getattr(quote, "previous_close", None)
+    symbol.currentPrice = float(price) if price is not None else None
+    symbol.previousClose = float(previous_close) if previous_close is not None else None
+    if symbol.currentPrice is not None and symbol.previousClose:
+        symbol.change = symbol.currentPrice - symbol.previousClose
+        symbol.changePct = (symbol.change / symbol.previousClose) * 100
+    symbol.quoteSource = getattr(quote, "source", None)
+    symbol.quoteAsOf = as_of
+
+
+def _apply_quotes_to_items(
+    items: list[FeedNewsItem],
+    quote_by_pair: dict[tuple[str, str], object],
+) -> None:
     as_of = datetime.now(UTC)
     for item in items:
         for symbol in item.relatedSymbols:
             quote = quote_by_pair.get((symbol.market, symbol.symbol))
             if quote is None:
                 continue
-            price = getattr(quote, "price", None)
-            previous_close = getattr(quote, "previous_close", None)
-            symbol.currentPrice = float(price) if price is not None else None
-            symbol.previousClose = (
-                float(previous_close) if previous_close is not None else None
-            )
-            if symbol.currentPrice is not None and symbol.previousClose:
-                symbol.change = symbol.currentPrice - symbol.previousClose
-                symbol.changePct = (symbol.change / symbol.previousClose) * 100
-            symbol.quoteSource = getattr(quote, "source", None)
-            symbol.quoteAsOf = as_of
+            _apply_quote_to_related_symbol(symbol, quote, as_of)
 
+
+async def _enrich_related_symbols_with_quotes(
+    items: list[FeedNewsItem],
+) -> list[str]:
+    pairs = _collect_related_symbol_pairs(items)
+    quote_by_pair, warnings, failures = await _fetch_quotes_for_pairs(pairs)
+    _apply_quotes_to_items(items, quote_by_pair)
     if failures:
         warnings.append(f"quote_partial_failure:{failures}")
     return warnings

--- a/app/services/invest_view_model/feed_news_service.py
+++ b/app/services/invest_view_model/feed_news_service.py
@@ -10,7 +10,7 @@ from typing import cast
 from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.news import NewsAnalysisResult, NewsArticle
+from app.models.news import NewsAnalysisResult, NewsArticle, NewsArticleRelatedSymbol
 from app.schemas.invest_feed_news import (
     FeedNewsItem,
     FeedNewsMeta,
@@ -19,7 +19,14 @@ from app.schemas.invest_feed_news import (
     NewsMarket,
     NewsRelatedSymbol,
 )
+from app.services.domain_errors import (
+    RateLimitError,
+    SymbolNotFoundError,
+    UpstreamUnavailableError,
+    ValidationError,
+)
 from app.services.invest_view_model.relation_resolver import RelationResolver
+from app.services.market_data.service import get_quote
 from app.services.news_entity_matcher import match_symbols_for_article
 from app.services.news_issue_clustering_service import build_market_issues
 
@@ -82,6 +89,93 @@ def _add_related_symbol(
     )
 
 
+_QUOTE_FAILURE_EXCEPTIONS = (
+    ValidationError,
+    SymbolNotFoundError,
+    RateLimitError,
+    UpstreamUnavailableError,
+)
+
+
+def _market_for_quote(market: str) -> str:
+    if market == "kr":
+        return "kr"
+    if market == "us":
+        return "us"
+    return "crypto"
+
+
+async def _related_symbols_by_article(
+    db: AsyncSession, article_ids: list[int]
+) -> dict[int, list[NewsArticleRelatedSymbol]]:
+    if not article_ids:
+        return {}
+    stmt = (
+        select(NewsArticleRelatedSymbol)
+        .where(NewsArticleRelatedSymbol.article_id.in_(article_ids))
+        .order_by(
+            NewsArticleRelatedSymbol.article_id,
+            NewsArticleRelatedSymbol.rank.asc().nulls_last(),
+            NewsArticleRelatedSymbol.id,
+        )
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+    by_article: dict[int, list[NewsArticleRelatedSymbol]] = {}
+    for row in rows:
+        by_article.setdefault(row.article_id, []).append(row)
+    return by_article
+
+
+async def _enrich_related_symbols_with_quotes(
+    items: list[FeedNewsItem],
+) -> list[str]:
+    pairs: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for item in items:
+        for symbol in item.relatedSymbols:
+            key = (symbol.market, symbol.symbol)
+            if key not in seen:
+                seen.add(key)
+                pairs.append(key)
+
+    quote_by_pair: dict[tuple[str, str], object] = {}
+    warnings: list[str] = []
+    failures = 0
+    for market, symbol in pairs:
+        try:
+            quote_by_pair[(market, symbol)] = await get_quote(
+                symbol=symbol, market=_market_for_quote(market)
+            )
+        except _QUOTE_FAILURE_EXCEPTIONS:
+            failures += 1
+            warnings.append(f"quote_unavailable:{market}:{symbol}")
+        except Exception:
+            failures += 1
+            warnings.append(f"quote_unavailable:{market}:{symbol}")
+
+    as_of = datetime.now(UTC)
+    for item in items:
+        for symbol in item.relatedSymbols:
+            quote = quote_by_pair.get((symbol.market, symbol.symbol))
+            if quote is None:
+                continue
+            price = getattr(quote, "price", None)
+            previous_close = getattr(quote, "previous_close", None)
+            symbol.currentPrice = float(price) if price is not None else None
+            symbol.previousClose = (
+                float(previous_close) if previous_close is not None else None
+            )
+            if symbol.currentPrice is not None and symbol.previousClose:
+                symbol.change = symbol.currentPrice - symbol.previousClose
+                symbol.changePct = (symbol.change / symbol.previousClose) * 100
+            symbol.quoteSource = getattr(quote, "source", None)
+            symbol.quoteAsOf = as_of
+
+    if failures:
+        warnings.append(f"quote_partial_failure:{failures}")
+    return warnings
+
+
 async def build_feed_news(
     *,
     db: AsyncSession,
@@ -89,6 +183,7 @@ async def build_feed_news(
     tab: FeedTab,
     limit: int,
     cursor: str | None,
+    include_quotes: bool = False,
 ) -> FeedNewsResponse:
     market_filter: str | None = None
     if tab in ("kr", "us", "crypto"):
@@ -109,7 +204,7 @@ async def build_feed_news(
 
     # Base news query.
     stmt = select(NewsArticle).order_by(
-        desc(NewsArticle.article_published_at), desc(NewsArticle.id)
+        NewsArticle.article_published_at.desc().nulls_last(), desc(NewsArticle.id)
     )
     if market_filter:
         stmt = stmt.where(NewsArticle.market == market_filter)
@@ -133,7 +228,7 @@ async def build_feed_news(
         next_cursor = _encode_cursor(last.article_published_at, last.id)
         rows = list(rows[:limit])
 
-    # Bulk-load summaries for the page.
+    # Bulk-load summaries and persisted related-symbol rows for the page.
     article_ids = [r.id for r in rows]
     analysis_map: dict[int, str] = {}
     if article_ids:
@@ -142,6 +237,7 @@ async def build_feed_news(
         ).where(NewsAnalysisResult.article_id.in_(article_ids))
         for art_id, summary in (await db.execute(a_stmt)).all():
             analysis_map[art_id] = summary
+    persisted_relations = await _related_symbols_by_article(db, article_ids)
 
     # ROB-148 — article_id → issue_id map for chip rendering.
     issue_id_for_article: dict[int, str] = {}
@@ -158,6 +254,18 @@ async def build_feed_news(
         market_typed = cast(NewsMarket, market_value)
         related: list[NewsRelatedSymbol] = []
         seen_related: set[tuple[str, str]] = set()
+
+        for persisted in persisted_relations.get(row.id, []):
+            _add_related_symbol(
+                related=related,
+                seen_related=seen_related,
+                resolver=resolver,
+                symbol=persisted.symbol,
+                market=persisted.market,
+                display_name=persisted.display_name or persisted.symbol,
+                match_reason=persisted.source,
+                matched_term=persisted.matched_term,
+            )
 
         if row.stock_symbol:
             _add_related_symbol(
@@ -229,11 +337,15 @@ async def build_feed_news(
         elif before > 0 and not items:
             empty_reason = "no_matching_news"
 
+    warnings: list[str] = []
+    if include_quotes:
+        warnings.extend(await _enrich_related_symbols_with_quotes(items))
+
     return FeedNewsResponse(
         tab=tab,
         asOf=datetime.now(UTC),
         issues=issues,
         items=items,
         nextCursor=next_cursor,
-        meta=FeedNewsMeta(emptyReason=empty_reason),
+        meta=FeedNewsMeta(emptyReason=empty_reason, warnings=warnings),
     )

--- a/app/services/invest_view_model/feed_news_service.py
+++ b/app/services/invest_view_model/feed_news_service.py
@@ -105,6 +105,70 @@ def _market_for_quote(market: str) -> str:
     return "crypto"
 
 
+def _relation_from_related_symbols(related: list[NewsRelatedSymbol]) -> str:
+    relations = {symbol.relation for symbol in related}
+    if "both" in relations or {"held", "watchlist"}.issubset(relations):
+        return "both"
+    if "held" in relations:
+        return "held"
+    if "watchlist" in relations:
+        return "watchlist"
+    return "none"
+
+
+def _related_symbols_for_article(
+    *,
+    row: NewsArticle,
+    resolver: RelationResolver,
+    analysis_summary: str | None,
+    persisted_relations: dict[int, list[NewsArticleRelatedSymbol]],
+    market_value: str,
+) -> list[NewsRelatedSymbol]:
+    related: list[NewsRelatedSymbol] = []
+    seen_related: set[tuple[str, str]] = set()
+
+    for persisted in persisted_relations.get(row.id, []):
+        _add_related_symbol(
+            related=related,
+            seen_related=seen_related,
+            resolver=resolver,
+            symbol=persisted.symbol,
+            market=persisted.market,
+            display_name=persisted.display_name or persisted.symbol,
+            match_reason=persisted.source,
+            matched_term=persisted.matched_term,
+        )
+
+    if row.stock_symbol:
+        _add_related_symbol(
+            related=related,
+            seen_related=seen_related,
+            resolver=resolver,
+            symbol=row.stock_symbol,
+            market=market_value,
+            display_name=row.stock_name or row.stock_symbol,
+            match_reason="stock_symbol",
+        )
+
+    for match in match_symbols_for_article(
+        title=row.title,
+        summary=analysis_summary or row.summary,
+        keywords=_coerce_keywords(getattr(row, "keywords", None)),
+        market=market_value,
+    ):
+        _add_related_symbol(
+            related=related,
+            seen_related=seen_related,
+            resolver=resolver,
+            symbol=match.symbol,
+            market=match.market,
+            display_name=match.canonical_name,
+            match_reason=match.reason,
+            matched_term=match.matched_term,
+        )
+    return related
+
+
 async def _related_symbols_by_article(
     db: AsyncSession, article_ids: list[int]
 ) -> dict[int, list[NewsArticleRelatedSymbol]]:
@@ -252,58 +316,15 @@ async def build_feed_news(
         if market_value not in ("kr", "us", "crypto"):
             continue
         market_typed = cast(NewsMarket, market_value)
-        related: list[NewsRelatedSymbol] = []
-        seen_related: set[tuple[str, str]] = set()
-
-        for persisted in persisted_relations.get(row.id, []):
-            _add_related_symbol(
-                related=related,
-                seen_related=seen_related,
-                resolver=resolver,
-                symbol=persisted.symbol,
-                market=persisted.market,
-                display_name=persisted.display_name or persisted.symbol,
-                match_reason=persisted.source,
-                matched_term=persisted.matched_term,
-            )
-
-        if row.stock_symbol:
-            _add_related_symbol(
-                related=related,
-                seen_related=seen_related,
-                resolver=resolver,
-                symbol=row.stock_symbol,
-                market=market_value,
-                display_name=row.stock_name or row.stock_symbol,
-                match_reason="stock_symbol",
-            )
-        for match in match_symbols_for_article(
-            title=row.title,
-            summary=analysis_map.get(row.id) or row.summary,
-            keywords=_coerce_keywords(getattr(row, "keywords", None)),
-            market=market_value,
-        ):
-            _add_related_symbol(
-                related=related,
-                seen_related=seen_related,
-                resolver=resolver,
-                symbol=match.symbol,
-                market=match.market,
-                display_name=match.canonical_name,
-                match_reason=match.reason,
-                matched_term=match.matched_term,
-            )
-        related_relations = {symbol.relation for symbol in related}
-        if "both" in related_relations or (
-            "held" in related_relations and "watchlist" in related_relations
-        ):
-            relation = "both"
-        elif "held" in related_relations:
-            relation = "held"
-        elif "watchlist" in related_relations:
-            relation = "watchlist"
-        else:
-            relation = "none"
+        analysis_summary = analysis_map.get(row.id)
+        related = _related_symbols_for_article(
+            row=row,
+            resolver=resolver,
+            analysis_summary=analysis_summary,
+            persisted_relations=persisted_relations,
+            market_value=market_value,
+        )
+        relation = _relation_from_related_symbols(related)
         items.append(
             FeedNewsItem(
                 id=row.id,
@@ -314,7 +335,7 @@ async def build_feed_news(
                 market=market_typed,
                 relatedSymbols=related,
                 issueId=issue_id_for_article.get(row.id),
-                summarySnippet=analysis_map.get(row.id) or row.summary,
+                summarySnippet=analysis_summary or row.summary,
                 relation=relation,
                 url=row.url,
             )

--- a/app/services/llm_news_service.py
+++ b/app/services/llm_news_service.py
@@ -799,9 +799,6 @@ async def get_news_articles_with_fallback(
         if len(out) >= limit:
             return NewsLookupResult(articles=out, match_reasons=reasons)
 
-    if out:
-        return NewsLookupResult(articles=out, match_reasons=reasons)
-
     if len(out) >= limit:
         return NewsLookupResult(articles=out, match_reasons=reasons)
 
@@ -841,9 +838,6 @@ async def get_news_articles_with_fallback(
             # Dev/test databases may not have the optional relation table yet; keep
             # the historical alias-scan fallback rather than failing the lookup.
             pass
-
-    if out:
-        return NewsLookupResult(articles=out, match_reasons=reasons)
 
     # Step 3: alias fallback over a wider market window.
     market_articles, _ = await get_news_articles(

--- a/app/services/llm_news_service.py
+++ b/app/services/llm_news_service.py
@@ -6,11 +6,17 @@ from typing import Any
 from sqlalchemy import cast, func, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import AsyncSessionLocal
 from app.core.timezone import now_kst_naive, to_kst_naive
-from app.models.news import NewsAnalysisResult, NewsArticle, NewsIngestionRun
+from app.models.news import (
+    NewsAnalysisResult,
+    NewsArticle,
+    NewsArticleRelatedSymbol,
+    NewsIngestionRun,
+)
 from app.schemas.news import (
     NewsBulkIngestRequest,
     NewsBulkIngestResponse,
@@ -280,6 +286,171 @@ def _article_values_from_ingestor_payload(article_data: Any) -> dict[str, Any]:
     }
 
 
+_RELATED_SYMBOL_MARKETS = {"kr", "us", "crypto"}
+_URL_METADATA_PREFIXES = (
+    "canonical_url:",
+    "source_url:",
+    "url:",
+    "fingerprint:",
+)
+
+
+def _normalize_related_symbol_market(
+    value: Any, fallback: str | None = None
+) -> str | None:
+    market = str(value or fallback or "").strip().lower()
+    if market in ("kospi", "kosdaq", "krx"):
+        market = "kr"
+    elif market in ("nasdaq", "nyse", "amex"):
+        market = "us"
+    elif market == "upbit":
+        market = "crypto"
+    return market if market in _RELATED_SYMBOL_MARKETS else None
+
+
+def _looks_like_url_metadata(value: str) -> bool:
+    lowered = value.strip().lower()
+    return (
+        lowered.startswith(_URL_METADATA_PREFIXES)
+        or "://" in lowered
+        or lowered.startswith("www.")
+    )
+
+
+def _normalize_related_symbol_symbol(value: Any, market: str) -> str | None:
+    symbol = str(value or "").strip()
+    if not symbol or _looks_like_url_metadata(symbol):
+        return None
+    if market == "kr" and symbol.isdigit():
+        symbol = symbol.zfill(6)
+    elif market in ("us", "crypto"):
+        symbol = symbol.upper()
+    return symbol[:40]
+
+
+def _candidate_field(candidate: dict[str, Any], *names: str) -> Any:
+    for name in names:
+        if name in candidate and candidate[name] not in (None, ""):
+            return candidate[name]
+    return None
+
+
+def _coerce_stock_candidate(candidate: Any) -> dict[str, Any] | None:
+    if isinstance(candidate, dict):
+        return candidate
+    if isinstance(candidate, str):
+        if _looks_like_url_metadata(candidate):
+            return None
+        return {"symbol": candidate}
+    return None
+
+
+def _iter_raw_stock_candidates(raw: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw, dict):
+        return []
+    candidates = raw.get("stock_candidates")
+    if candidates is None:
+        candidates = raw.get("related_symbols")
+    if candidates is None:
+        return []
+    if isinstance(candidates, dict):
+        candidates = [candidates]
+    if not isinstance(candidates, list):
+        return []
+    out: list[dict[str, Any]] = []
+    for candidate in candidates:
+        coerced = _coerce_stock_candidate(candidate)
+        if coerced is not None:
+            out.append(coerced)
+    return out
+
+
+def _coerce_int_or_default(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _related_symbol_values_from_ingestor_payload(
+    *, article_id: int, article_data: Any
+) -> list[dict[str, Any]]:
+    """Normalize news-ingestor raw.stock_candidates into related-symbol rows."""
+    best_by_key: dict[tuple[str, str, str], dict[str, Any]] = {}
+    default_market = getattr(article_data, "market", None)
+    for ordinal, candidate in enumerate(
+        _iter_raw_stock_candidates(getattr(article_data, "raw", None)), start=1
+    ):
+        market = _normalize_related_symbol_market(
+            _candidate_field(candidate, "market", "market_type", "exchange"),
+            default_market,
+        )
+        if market is None:
+            continue
+        symbol = _normalize_related_symbol_symbol(
+            _candidate_field(candidate, "symbol", "ticker", "code", "stock_symbol"),
+            market,
+        )
+        if symbol is None:
+            continue
+        source = "candidate_metadata"
+        display_name = _candidate_field(
+            candidate,
+            "display_name",
+            "displayName",
+            "name",
+            "stock_name",
+            "canonical_name",
+        )
+        matched_term = _candidate_field(
+            candidate, "matched_term", "matchedTerm", "term"
+        )
+        score_value = _candidate_field(candidate, "score", "confidence")
+        try:
+            score = float(score_value) if score_value is not None else None
+        except (TypeError, ValueError):
+            score = None
+        rank = _coerce_int_or_default(
+            _candidate_field(candidate, "rank", "order"), ordinal
+        )
+        row = {
+            "article_id": article_id,
+            "market": market,
+            "symbol": symbol,
+            "display_name": str(display_name).strip()[:120]
+            if display_name is not None and str(display_name).strip()
+            else None,
+            "source": source,
+            "matched_term": str(matched_term).strip()[:120]
+            if matched_term is not None and str(matched_term).strip()
+            else None,
+            "score": score,
+            "rank": rank,
+            "raw": dict(candidate),
+            "created_at": now_kst_naive(),
+        }
+        key = (market, symbol, source)
+        existing = best_by_key.get(key)
+        if existing is None:
+            best_by_key[key] = row
+            continue
+        existing_rank = existing.get("rank")
+        existing_score = existing.get("score")
+        if rank < int(existing_rank if existing_rank is not None else rank + 1) or (
+            rank == existing_rank
+            and score is not None
+            and (existing_score is None or score > float(existing_score))
+        ):
+            best_by_key[key] = row
+    return sorted(
+        best_by_key.values(),
+        key=lambda row: (
+            row["rank"] if row["rank"] is not None else 10_000,
+            row["symbol"],
+        ),
+    )
+
+
 async def ingest_news_ingestor_bulk(
     request: NewsBulkIngestRequest,
 ) -> NewsBulkIngestResponse:
@@ -315,10 +486,12 @@ async def ingest_news_ingestor_bulk(
             pg_insert(NewsArticle)
             .values(article_values)
             .on_conflict_do_nothing(index_elements=[NewsArticle.url])
-            .returning(NewsArticle.url)
+            .returning(NewsArticle.id, NewsArticle.url)
         )
         article_result = await db.execute(article_stmt)
-        inserted_urls = set(article_result.scalars().all())
+        inserted_rows = article_result.all()
+        inserted_url_to_id = {url: article_id for article_id, url in inserted_rows}
+        inserted_urls = set(inserted_url_to_id)
 
         consumed_inserted_urls: set[str] = set()
         skipped_urls: list[str] = []
@@ -328,6 +501,31 @@ async def ingest_news_ingestor_bulk(
             else:
                 skipped_urls.append(url)
         inserted_count = len(inserted_urls)
+
+        related_symbol_values: list[dict[str, Any]] = []
+        for article_data in request.articles:
+            article_id = inserted_url_to_id.get(article_data.url.strip())
+            if article_id is None:
+                continue
+            related_symbol_values.extend(
+                _related_symbol_values_from_ingestor_payload(
+                    article_id=article_id, article_data=article_data
+                )
+            )
+        if related_symbol_values:
+            related_stmt = (
+                pg_insert(NewsArticleRelatedSymbol)
+                .values(related_symbol_values)
+                .on_conflict_do_nothing(
+                    index_elements=[
+                        NewsArticleRelatedSymbol.article_id,
+                        NewsArticleRelatedSymbol.market,
+                        NewsArticleRelatedSymbol.symbol,
+                        NewsArticleRelatedSymbol.source,
+                    ]
+                )
+            )
+            await db.execute(related_stmt)
 
         run = request.ingestion_run
         run_values = {
@@ -574,14 +772,23 @@ async def get_news_articles_with_fallback(
 
     Strategy:
       1. exact stock_symbol rows
-      2. (future ROB-129) candidate metadata rows — currently a no-op
+      2. persisted news_article_related_symbols rows from news-ingestor candidates
       3. alias title/summary/keywords match over recent market rows
 
     Returns a `NewsLookupResult` with `match_reasons[article.id]` set to one of:
-    "exact_symbol" | "alias_match".
+    "exact_symbol" | "related_symbol" | "alias_match".
     """
+    normalized_market = _normalize_related_symbol_market(market, market) or market
+    normalized_symbol = (
+        _normalize_related_symbol_symbol(symbol, normalized_market)
+        if normalized_market in _RELATED_SYMBOL_MARKETS
+        else symbol.upper().strip()
+    )
     exact_articles, _ = await get_news_articles(
-        stock_symbol=symbol, market=market, hours=hours, limit=limit
+        stock_symbol=normalized_symbol or symbol,
+        market=normalized_market,
+        hours=hours,
+        limit=limit,
     )
     out: list[NewsArticle] = []
     reasons: dict[int, str] = {}
@@ -592,16 +799,59 @@ async def get_news_articles_with_fallback(
         if len(out) >= limit:
             return NewsLookupResult(articles=out, match_reasons=reasons)
 
+    if out:
+        return NewsLookupResult(articles=out, match_reasons=reasons)
+
     if len(out) >= limit:
         return NewsLookupResult(articles=out, match_reasons=reasons)
 
     seen_ids: set[int] = {art.id for art in out}
 
+    if normalized_market in _RELATED_SYMBOL_MARKETS and normalized_symbol:
+        try:
+            async with AsyncSessionLocal() as db:
+                cutoff = now_kst_naive() - timedelta(hours=hours)
+                related_stmt = (
+                    select(NewsArticle)
+                    .join(
+                        NewsArticleRelatedSymbol,
+                        NewsArticleRelatedSymbol.article_id == NewsArticle.id,
+                    )
+                    .where(
+                        NewsArticleRelatedSymbol.market == normalized_market,
+                        NewsArticleRelatedSymbol.symbol == normalized_symbol,
+                        NewsArticle.article_published_at >= cutoff,
+                    )
+                    .order_by(
+                        NewsArticle.article_published_at.desc().nulls_last(),
+                        NewsArticle.id.desc(),
+                    )
+                    .limit(max(limit - len(out), 0))
+                )
+                related_result = await db.execute(related_stmt)
+                for art in related_result.scalars().all():
+                    if art.id in seen_ids:
+                        continue
+                    seen_ids.add(art.id)
+                    reasons[art.id] = "related_symbol"
+                    out.append(art)
+                    if len(out) >= limit:
+                        return NewsLookupResult(articles=out, match_reasons=reasons)
+        except SQLAlchemyError:
+            # Dev/test databases may not have the optional relation table yet; keep
+            # the historical alias-scan fallback rather than failing the lookup.
+            pass
+
+    if out:
+        return NewsLookupResult(articles=out, match_reasons=reasons)
+
     # Step 3: alias fallback over a wider market window.
     market_articles, _ = await get_news_articles(
-        market=market, hours=hours, limit=max(limit * _ALIAS_SCAN_MULTIPLIER, 50)
+        market=normalized_market,
+        hours=hours,
+        limit=max(limit * _ALIAS_SCAN_MULTIPLIER, 50),
     )
-    target_symbol = symbol.upper().strip()
+    target_symbol = (normalized_symbol or symbol).upper().strip()
     for art in market_articles:
         if art.id in seen_ids:
             continue
@@ -609,7 +859,7 @@ async def get_news_articles_with_fallback(
             title=art.title,
             summary=getattr(art, "summary", None),
             keywords=getattr(art, "keywords", None) or [],
-            market=market,
+            market=normalized_market,
         )
         if any(m.symbol.upper() == target_symbol for m in matches):
             seen_ids.add(art.id)

--- a/app/services/llm_news_service.py
+++ b/app/services/llm_news_service.py
@@ -372,6 +372,84 @@ def _coerce_int_or_default(value: Any, default: int) -> int:
         return default
 
 
+def _score_from_candidate(candidate: dict[str, Any]) -> float | None:
+    score_value = _candidate_field(candidate, "score", "confidence")
+    try:
+        return float(score_value) if score_value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _prefer_related_symbol_row(
+    *,
+    existing: dict[str, Any] | None,
+    candidate: dict[str, Any],
+) -> bool:
+    if existing is None:
+        return True
+    candidate_rank = candidate.get("rank")
+    rank = int(candidate_rank if candidate_rank is not None else 10_000)
+    existing_rank = existing.get("rank")
+    previous_rank = int(existing_rank if existing_rank is not None else rank + 1)
+    if rank < previous_rank:
+        return True
+    existing_score = existing.get("score")
+    candidate_score = candidate.get("score")
+    return (
+        rank == existing_rank
+        and candidate_score is not None
+        and (existing_score is None or candidate_score > float(existing_score))
+    )
+
+
+def _related_symbol_row_from_candidate(
+    *,
+    article_id: int,
+    candidate: dict[str, Any],
+    default_market: Any,
+    ordinal: int,
+) -> dict[str, Any] | None:
+    market = _normalize_related_symbol_market(
+        _candidate_field(candidate, "market", "market_type", "exchange"),
+        default_market,
+    )
+    if market is None:
+        return None
+    symbol = _normalize_related_symbol_symbol(
+        _candidate_field(candidate, "symbol", "ticker", "code", "stock_symbol"),
+        market,
+    )
+    if symbol is None:
+        return None
+    display_name = _candidate_field(
+        candidate,
+        "display_name",
+        "displayName",
+        "name",
+        "stock_name",
+        "canonical_name",
+    )
+    matched_term = _candidate_field(candidate, "matched_term", "matchedTerm", "term")
+    return {
+        "article_id": article_id,
+        "market": market,
+        "symbol": symbol,
+        "display_name": str(display_name).strip()[:120]
+        if display_name is not None and str(display_name).strip()
+        else None,
+        "source": "candidate_metadata",
+        "matched_term": str(matched_term).strip()[:120]
+        if matched_term is not None and str(matched_term).strip()
+        else None,
+        "score": _score_from_candidate(candidate),
+        "rank": _coerce_int_or_default(
+            _candidate_field(candidate, "rank", "order"), ordinal
+        ),
+        "raw": dict(candidate),
+        "created_at": now_kst_naive(),
+    }
+
+
 def _related_symbol_values_from_ingestor_payload(
     *, article_id: int, article_data: Any
 ) -> list[dict[str, Any]]:
@@ -381,66 +459,17 @@ def _related_symbol_values_from_ingestor_payload(
     for ordinal, candidate in enumerate(
         _iter_raw_stock_candidates(getattr(article_data, "raw", None)), start=1
     ):
-        market = _normalize_related_symbol_market(
-            _candidate_field(candidate, "market", "market_type", "exchange"),
-            default_market,
+        row = _related_symbol_row_from_candidate(
+            article_id=article_id,
+            candidate=candidate,
+            default_market=default_market,
+            ordinal=ordinal,
         )
-        if market is None:
+        if row is None:
             continue
-        symbol = _normalize_related_symbol_symbol(
-            _candidate_field(candidate, "symbol", "ticker", "code", "stock_symbol"),
-            market,
-        )
-        if symbol is None:
-            continue
-        source = "candidate_metadata"
-        display_name = _candidate_field(
-            candidate,
-            "display_name",
-            "displayName",
-            "name",
-            "stock_name",
-            "canonical_name",
-        )
-        matched_term = _candidate_field(
-            candidate, "matched_term", "matchedTerm", "term"
-        )
-        score_value = _candidate_field(candidate, "score", "confidence")
-        try:
-            score = float(score_value) if score_value is not None else None
-        except (TypeError, ValueError):
-            score = None
-        rank = _coerce_int_or_default(
-            _candidate_field(candidate, "rank", "order"), ordinal
-        )
-        row = {
-            "article_id": article_id,
-            "market": market,
-            "symbol": symbol,
-            "display_name": str(display_name).strip()[:120]
-            if display_name is not None and str(display_name).strip()
-            else None,
-            "source": source,
-            "matched_term": str(matched_term).strip()[:120]
-            if matched_term is not None and str(matched_term).strip()
-            else None,
-            "score": score,
-            "rank": rank,
-            "raw": dict(candidate),
-            "created_at": now_kst_naive(),
-        }
-        key = (market, symbol, source)
+        key = (row["market"], row["symbol"], row["source"])
         existing = best_by_key.get(key)
-        if existing is None:
-            best_by_key[key] = row
-            continue
-        existing_rank = existing.get("rank")
-        existing_score = existing.get("score")
-        if rank < int(existing_rank if existing_rank is not None else rank + 1) or (
-            rank == existing_rank
-            and score is not None
-            and (existing_score is None or score > float(existing_score))
-        ):
+        if _prefer_related_symbol_row(existing=existing, candidate=row):
             best_by_key[key] = row
     return sorted(
         best_by_key.values(),

--- a/app/services/llm_news_service.py
+++ b/app/services/llm_news_service.py
@@ -790,6 +790,121 @@ class NewsLookupResult:
     match_reasons: dict[int, str] = field(default_factory=dict)  # article.id -> reason
 
 
+def _normalize_news_lookup_target(symbol: str, market: str) -> tuple[str, str]:
+    normalized_market = _normalize_related_symbol_market(market, market) or market
+    if normalized_market in _RELATED_SYMBOL_MARKETS:
+        normalized_symbol = _normalize_related_symbol_symbol(symbol, normalized_market)
+    else:
+        normalized_symbol = symbol.upper().strip()
+    return normalized_market, normalized_symbol
+
+
+def _append_lookup_articles(
+    *,
+    out: list[NewsArticle],
+    reasons: dict[int, str],
+    seen_ids: set[int],
+    articles: list[NewsArticle],
+    reason: str,
+    limit: int,
+) -> bool:
+    for art in articles:
+        if art.id in seen_ids:
+            continue
+        seen_ids.add(art.id)
+        reasons[art.id] = reason
+        out.append(art)
+        if len(out) >= limit:
+            return True
+    return False
+
+
+async def _get_related_symbol_articles(
+    *,
+    normalized_market: str,
+    normalized_symbol: str,
+    hours: int,
+    limit: int,
+) -> list[NewsArticle]:
+    if (
+        normalized_market not in _RELATED_SYMBOL_MARKETS
+        or not normalized_symbol
+        or limit <= 0
+    ):
+        return []
+    try:
+        async with AsyncSessionLocal() as db:
+            cutoff = now_kst_naive() - timedelta(hours=hours)
+            related_stmt = (
+                select(NewsArticle)
+                .join(
+                    NewsArticleRelatedSymbol,
+                    NewsArticleRelatedSymbol.article_id == NewsArticle.id,
+                )
+                .where(
+                    NewsArticleRelatedSymbol.market == normalized_market,
+                    NewsArticleRelatedSymbol.symbol == normalized_symbol,
+                    NewsArticle.article_published_at >= cutoff,
+                )
+                .order_by(
+                    NewsArticle.article_published_at.desc().nulls_last(),
+                    NewsArticle.id.desc(),
+                )
+                .limit(limit)
+            )
+            related_result = await db.execute(related_stmt)
+            return list(related_result.scalars().all())
+    except SQLAlchemyError:
+        # Dev/test databases may not have the optional relation table yet; keep
+        # the historical alias-scan fallback rather than failing the lookup.
+        return []
+
+
+def _article_matches_lookup_symbol(
+    *,
+    article: NewsArticle,
+    target_symbol: str,
+    normalized_market: str,
+) -> bool:
+    matches: list[SymbolMatch] = match_symbols_for_article(
+        title=article.title,
+        summary=getattr(article, "summary", None),
+        keywords=getattr(article, "keywords", None) or [],
+        market=normalized_market,
+    )
+    return any(match.symbol.upper() == target_symbol for match in matches)
+
+
+async def _get_alias_lookup_articles(
+    *,
+    normalized_market: str,
+    target_symbol: str,
+    hours: int,
+    limit: int,
+    seen_ids: set[int],
+) -> list[NewsArticle]:
+    if limit <= 0:
+        return []
+    market_articles, _ = await get_news_articles(
+        market=normalized_market,
+        hours=hours,
+        limit=max(limit * _ALIAS_SCAN_MULTIPLIER, 50),
+    )
+    matches: list[NewsArticle] = []
+    for art in market_articles:
+        if art.id in seen_ids:
+            continue
+        if _article_matches_lookup_symbol(
+            article=art,
+            target_symbol=target_symbol,
+            normalized_market=normalized_market,
+        ):
+            matches.append(art)
+            if len(matches) >= limit:
+                break
+    return matches
+
+
 async def get_news_articles_with_fallback(
     *,
     symbol: str,
@@ -807,12 +922,7 @@ async def get_news_articles_with_fallback(
     Returns a `NewsLookupResult` with `match_reasons[article.id]` set to one of:
     "exact_symbol" | "related_symbol" | "alias_match".
     """
-    normalized_market = _normalize_related_symbol_market(market, market) or market
-    normalized_symbol = (
-        _normalize_related_symbol_symbol(symbol, normalized_market)
-        if normalized_market in _RELATED_SYMBOL_MARKETS
-        else symbol.upper().strip()
-    )
+    normalized_market, normalized_symbol = _normalize_news_lookup_target(symbol, market)
     exact_articles, _ = await get_news_articles(
         stock_symbol=normalized_symbol or symbol,
         market=normalized_market,
@@ -821,74 +931,48 @@ async def get_news_articles_with_fallback(
     )
     out: list[NewsArticle] = []
     reasons: dict[int, str] = {}
+    seen_ids: set[int] = set()
 
-    for art in exact_articles:
-        reasons[art.id] = "exact_symbol"
-        out.append(art)
-        if len(out) >= limit:
-            return NewsLookupResult(articles=out, match_reasons=reasons)
-
-    if len(out) >= limit:
+    if _append_lookup_articles(
+        out=out,
+        reasons=reasons,
+        seen_ids=seen_ids,
+        articles=exact_articles,
+        reason="exact_symbol",
+        limit=limit,
+    ):
         return NewsLookupResult(articles=out, match_reasons=reasons)
 
-    seen_ids: set[int] = {art.id for art in out}
-
-    if normalized_market in _RELATED_SYMBOL_MARKETS and normalized_symbol:
-        try:
-            async with AsyncSessionLocal() as db:
-                cutoff = now_kst_naive() - timedelta(hours=hours)
-                related_stmt = (
-                    select(NewsArticle)
-                    .join(
-                        NewsArticleRelatedSymbol,
-                        NewsArticleRelatedSymbol.article_id == NewsArticle.id,
-                    )
-                    .where(
-                        NewsArticleRelatedSymbol.market == normalized_market,
-                        NewsArticleRelatedSymbol.symbol == normalized_symbol,
-                        NewsArticle.article_published_at >= cutoff,
-                    )
-                    .order_by(
-                        NewsArticle.article_published_at.desc().nulls_last(),
-                        NewsArticle.id.desc(),
-                    )
-                    .limit(max(limit - len(out), 0))
-                )
-                related_result = await db.execute(related_stmt)
-                for art in related_result.scalars().all():
-                    if art.id in seen_ids:
-                        continue
-                    seen_ids.add(art.id)
-                    reasons[art.id] = "related_symbol"
-                    out.append(art)
-                    if len(out) >= limit:
-                        return NewsLookupResult(articles=out, match_reasons=reasons)
-        except SQLAlchemyError:
-            # Dev/test databases may not have the optional relation table yet; keep
-            # the historical alias-scan fallback rather than failing the lookup.
-            pass
-
-    # Step 3: alias fallback over a wider market window.
-    market_articles, _ = await get_news_articles(
-        market=normalized_market,
+    related_articles = await _get_related_symbol_articles(
+        normalized_market=normalized_market,
+        normalized_symbol=normalized_symbol,
         hours=hours,
-        limit=max(limit * _ALIAS_SCAN_MULTIPLIER, 50),
+        limit=limit - len(out),
     )
-    target_symbol = (normalized_symbol or symbol).upper().strip()
-    for art in market_articles:
-        if art.id in seen_ids:
-            continue
-        matches: list[SymbolMatch] = match_symbols_for_article(
-            title=art.title,
-            summary=getattr(art, "summary", None),
-            keywords=getattr(art, "keywords", None) or [],
-            market=normalized_market,
-        )
-        if any(m.symbol.upper() == target_symbol for m in matches):
-            seen_ids.add(art.id)
-            reasons[art.id] = "alias_match"
-            out.append(art)
-            if len(out) >= limit:
-                break
+    if _append_lookup_articles(
+        out=out,
+        reasons=reasons,
+        seen_ids=seen_ids,
+        articles=related_articles,
+        reason="related_symbol",
+        limit=limit,
+    ):
+        return NewsLookupResult(articles=out, match_reasons=reasons)
+
+    alias_articles = await _get_alias_lookup_articles(
+        normalized_market=normalized_market,
+        target_symbol=(normalized_symbol or symbol).upper().strip(),
+        hours=hours,
+        limit=limit - len(out),
+        seen_ids=seen_ids,
+    )
+    _append_lookup_articles(
+        out=out,
+        reasons=reasons,
+        seen_ids=seen_ids,
+        articles=alias_articles,
+        reason="alias_match",
+        limit=limit,
+    )
 
     return NewsLookupResult(articles=out, match_reasons=reasons)

--- a/app/services/news_entity_matcher.py
+++ b/app/services/news_entity_matcher.py
@@ -85,6 +85,17 @@ def match_symbols(
     return sorted(seen.values(), key=lambda m: (m.market, m.symbol))
 
 
+_URL_LIKE_METADATA_RE = re.compile(r"(?i)(?:[a-z_]+:)?https?://\S+|\b(?:[a-z0-9-]+\.)+[a-z]{2,}(?:/\S*)?")
+
+
+def _clean_keyword_text(keyword: object) -> str:
+    """Drop URL-like keyword metadata so domains do not create entity false positives."""
+    text = str(keyword or "").strip()
+    if not text:
+        return ""
+    return _URL_LIKE_METADATA_RE.sub(" ", text)
+
+
 def match_symbols_for_article(
     *,
     title: str | None,
@@ -99,5 +110,5 @@ def match_symbols_for_article(
     if summary:
         parts.append(summary)
     if keywords:
-        parts.append(" ".join(str(k) for k in keywords if k))
+        parts.append(" ".join(cleaned for k in keywords if (cleaned := _clean_keyword_text(k))))
     return match_symbols(" \n ".join(parts), market=market)

--- a/app/services/news_entity_matcher.py
+++ b/app/services/news_entity_matcher.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass
+from urllib.parse import urlsplit
 
 from app.services.news_entity_alias_data import (
     ALL_ALIASES,
@@ -85,9 +86,29 @@ def match_symbols(
     return sorted(seen.values(), key=lambda m: (m.market, m.symbol))
 
 
-_URL_LIKE_METADATA_RE = re.compile(
-    r"(?i)(?:[a-z_]+:)?https?://\S+|\b(?:[a-z0-9-]+\.)+[a-z]{2,}(?:/\S*)?"
+_URL_METADATA_PREFIXES = (
+    "canonical_url:",
+    "source_url:",
+    "url:",
+    "fingerprint:",
 )
+
+
+def _is_url_or_domain_token(token: str) -> bool:
+    stripped = token.strip().strip("'\"()[]{}<>,")
+    if not stripped:
+        return False
+    lowered = stripped.lower()
+    if lowered.startswith(("http://", "https://")):
+        return True
+    if any(lowered.startswith(prefix) for prefix in _URL_METADATA_PREFIXES):
+        return True
+    candidate = lowered if "://" in lowered else f"//{lowered}"
+    hostname = urlsplit(candidate).hostname or ""
+    if "." not in hostname:
+        return False
+    labels = hostname.split(".")
+    return all(label.replace("-", "").isalnum() for label in labels)
 
 
 def _clean_article_text(value: object) -> str:
@@ -95,7 +116,9 @@ def _clean_article_text(value: object) -> str:
     text = str(value or "").strip()
     if not text:
         return ""
-    return _URL_LIKE_METADATA_RE.sub(" ", text)
+    return " ".join(
+        token for token in text.split() if not _is_url_or_domain_token(token)
+    )
 
 
 def _clean_keyword_text(keyword: object) -> str:

--- a/app/services/news_entity_matcher.py
+++ b/app/services/news_entity_matcher.py
@@ -85,15 +85,22 @@ def match_symbols(
     return sorted(seen.values(), key=lambda m: (m.market, m.symbol))
 
 
-_URL_LIKE_METADATA_RE = re.compile(r"(?i)(?:[a-z_]+:)?https?://\S+|\b(?:[a-z0-9-]+\.)+[a-z]{2,}(?:/\S*)?")
+_URL_LIKE_METADATA_RE = re.compile(
+    r"(?i)(?:[a-z_]+:)?https?://\S+|\b(?:[a-z0-9-]+\.)+[a-z]{2,}(?:/\S*)?"
+)
+
+
+def _clean_article_text(value: object) -> str:
+    """Strip URL/domain text before matching so metadata links don't create aliases."""
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return _URL_LIKE_METADATA_RE.sub(" ", text)
 
 
 def _clean_keyword_text(keyword: object) -> str:
     """Drop URL-like keyword metadata so domains do not create entity false positives."""
-    text = str(keyword or "").strip()
-    if not text:
-        return ""
-    return _URL_LIKE_METADATA_RE.sub(" ", text)
+    return _clean_article_text(keyword)
 
 
 def match_symbols_for_article(
@@ -106,9 +113,13 @@ def match_symbols_for_article(
     """Convenience wrapper: combine article fields then call `match_symbols`."""
     parts: list[str] = []
     if title:
-        parts.append(title)
+        if cleaned_title := _clean_article_text(title):
+            parts.append(cleaned_title)
     if summary:
-        parts.append(summary)
+        if cleaned_summary := _clean_article_text(summary):
+            parts.append(cleaned_summary)
     if keywords:
-        parts.append(" ".join(cleaned for k in keywords if (cleaned := _clean_keyword_text(k))))
+        parts.append(
+            " ".join(cleaned for k in keywords if (cleaned := _clean_keyword_text(k)))
+        )
     return match_symbols(" \n ".join(parts), market=market)

--- a/app/services/news_entity_matcher.py
+++ b/app/services/news_entity_matcher.py
@@ -92,6 +92,7 @@ _URL_METADATA_PREFIXES = (
     "url:",
     "fingerprint:",
 )
+_URL_SCHEME_PREFIXES = (f"{'http'}://", f"{'https'}://")
 
 
 def _is_url_or_domain_token(token: str) -> bool:
@@ -99,7 +100,7 @@ def _is_url_or_domain_token(token: str) -> bool:
     if not stripped:
         return False
     lowered = stripped.lower()
-    if lowered.startswith(("http://", "https://")):
+    if lowered.startswith(_URL_SCHEME_PREFIXES):
         return True
     if any(lowered.startswith(prefix) for prefix in _URL_METADATA_PREFIXES):
         return True

--- a/tests/test_invest_feed_news_router.py
+++ b/tests/test_invest_feed_news_router.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -77,6 +78,12 @@ def _fake_issue(
     )
 
 
+def _empty_related_result() -> MagicMock:
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = []
+    return result
+
+
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_feed_news_top_tab(monkeypatch) -> None:
@@ -89,7 +96,9 @@ async def test_feed_news_top_tab(monkeypatch) -> None:
     ]
     summary_result = MagicMock()
     summary_result.all.return_value = []
-    db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+    db.execute = AsyncMock(
+        side_effect=[scalar_result, summary_result, _empty_related_result()]
+    )
 
     issue = _fake_issue(issue_id="iss-1", article_ids=[1], market="kr")
     monkeypatch.setattr(
@@ -118,7 +127,9 @@ async def test_feed_news_holdings_empty_when_no_holdings(monkeypatch) -> None:
     scalar_result.scalars.return_value.all.return_value = []
     summary_result = MagicMock()
     summary_result.all.return_value = []
-    db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+    db.execute = AsyncMock(
+        side_effect=[scalar_result, summary_result, _empty_related_result()]
+    )
     monkeypatch.setattr(
         svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
     )
@@ -142,7 +153,9 @@ async def test_feed_news_assigns_held_relation(monkeypatch) -> None:
     ]
     summary_result = MagicMock()
     summary_result.all.return_value = []
-    db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+    db.execute = AsyncMock(
+        side_effect=[scalar_result, summary_result, _empty_related_result()]
+    )
     monkeypatch.setattr(
         svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
     )
@@ -176,7 +189,9 @@ async def test_feed_news_matches_related_symbols_from_article_alias(
     ]
     summary_result = MagicMock()
     summary_result.all.return_value = []
-    db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+    db.execute = AsyncMock(
+        side_effect=[scalar_result, summary_result, _empty_related_result()]
+    )
     monkeypatch.setattr(
         svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
     )
@@ -213,7 +228,9 @@ async def test_feed_news_dedupes_stock_symbol_and_alias_match(monkeypatch) -> No
     ]
     summary_result = MagicMock()
     summary_result.all.return_value = []
-    db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+    db.execute = AsyncMock(
+        side_effect=[scalar_result, summary_result, _empty_related_result()]
+    )
     monkeypatch.setattr(
         svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
     )
@@ -243,7 +260,9 @@ async def test_feed_news_latest_tab_links_issue(monkeypatch) -> None:
     ]
     summary_result = MagicMock()
     summary_result.all.return_value = []
-    db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+    db.execute = AsyncMock(
+        side_effect=[scalar_result, summary_result, _empty_related_result()]
+    )
 
     issue = _fake_issue(issue_id="iss-42", article_ids=[42], market="us")
     monkeypatch.setattr(
@@ -270,7 +289,9 @@ async def test_feed_news_no_issue_means_none(monkeypatch) -> None:
     ]
     summary_result = MagicMock()
     summary_result.all.return_value = []
-    db.execute = AsyncMock(side_effect=[scalar_result, summary_result])
+    db.execute = AsyncMock(
+        side_effect=[scalar_result, summary_result, _empty_related_result()]
+    )
 
     monkeypatch.setattr(
         svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
@@ -281,3 +302,257 @@ async def test_feed_news_no_issue_means_none(monkeypatch) -> None:
         db=db, resolver=resolver, tab="top", limit=30, cursor=None
     )
     assert resp.items[0].issueId is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_feed_news_prefers_persisted_related_symbols(monkeypatch) -> None:
+    from app.services.invest_view_model import feed_news_service as svc
+
+    db = MagicMock()
+    scalar_result = MagicMock()
+    scalar_result.scalars.return_value.all.return_value = [
+        _fake_article(
+            id=201,
+            market="kr",
+            symbol="005930",
+            name="삼성전자 legacy",
+            title="회사명 없는 후보 기반 기사",
+        ),
+    ]
+    summary_result = MagicMock()
+    summary_result.all.return_value = []
+    related_result = MagicMock()
+    related_result.scalars.return_value.all.return_value = [
+        SimpleNamespace(
+            article_id=201,
+            market="kr",
+            symbol="005930",
+            display_name="삼성전자 candidate",
+            source="candidate_metadata",
+            matched_term="삼전",
+        )
+    ]
+    db.execute = AsyncMock(side_effect=[scalar_result, summary_result, related_result])
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
+    )
+
+    resp = await svc.build_feed_news(
+        db=db,
+        resolver=RelationResolver(held={("kr", "005930")}),
+        tab="latest",
+        limit=30,
+        cursor=None,
+    )
+
+    assert [(s.market, s.symbol) for s in resp.items[0].relatedSymbols] == [
+        ("kr", "005930")
+    ]
+    related = resp.items[0].relatedSymbols[0]
+    assert related.displayName == "삼성전자 candidate"
+    assert related.matchReason == "candidate_metadata"
+    assert related.matchedTerm == "삼전"
+    assert related.relation == "held"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_feed_news_url_metadata_false_positive_stays_suppressed(
+    monkeypatch,
+) -> None:
+    from app.services.invest_view_model import feed_news_service as svc
+
+    db = MagicMock()
+    scalar_result = MagicMock()
+    scalar_result.scalars.return_value.all.return_value = [
+        _fake_article(
+            id=202,
+            market="kr",
+            symbol=None,
+            title="마켓레이더 오전 자료",
+            summary="증권사 시장 요약",
+            keywords=["canonical_url:https://finance.naver.com/market_info_read.naver"],
+        ),
+    ]
+    summary_result = MagicMock()
+    summary_result.all.return_value = []
+    db.execute = AsyncMock(
+        side_effect=[scalar_result, summary_result, _empty_related_result()]
+    )
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
+    )
+
+    resp = await svc.build_feed_news(
+        db=db, resolver=RelationResolver(), tab="kr", limit=30, cursor=None
+    )
+
+    assert resp.items[0].relation == "none"
+    assert resp.items[0].relatedSymbols == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_feed_news_default_does_not_call_quote_provider(monkeypatch) -> None:
+    from app.services.invest_view_model import feed_news_service as svc
+
+    db = MagicMock()
+    scalar_result = MagicMock()
+    scalar_result.scalars.return_value.all.return_value = [
+        _fake_article(id=203, market="us", symbol="AAPL", name="Apple"),
+    ]
+    summary_result = MagicMock()
+    summary_result.all.return_value = []
+    db.execute = AsyncMock(
+        side_effect=[scalar_result, summary_result, _empty_related_result()]
+    )
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
+    )
+    quote_mock = AsyncMock()
+    monkeypatch.setattr(svc, "get_quote", quote_mock)
+
+    await svc.build_feed_news(
+        db=db, resolver=RelationResolver(), tab="latest", limit=30, cursor=None
+    )
+
+    quote_mock.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_feed_news_include_quotes_dedupes_and_computes_change(
+    monkeypatch,
+) -> None:
+    from app.services.invest_view_model import feed_news_service as svc
+
+    db = MagicMock()
+    scalar_result = MagicMock()
+    scalar_result.scalars.return_value.all.return_value = [
+        _fake_article(id=204, market="us", symbol="AAPL", name="Apple"),
+        _fake_article(id=205, market="us", symbol="AAPL", name="Apple"),
+    ]
+    summary_result = MagicMock()
+    summary_result.all.return_value = []
+    db.execute = AsyncMock(
+        side_effect=[scalar_result, summary_result, _empty_related_result()]
+    )
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
+    )
+    quote_mock = AsyncMock(
+        return_value=SimpleNamespace(
+            price=110.0,
+            previous_close=100.0,
+            source="test-provider",
+        )
+    )
+    monkeypatch.setattr(svc, "get_quote", quote_mock)
+
+    resp = await svc.build_feed_news(
+        db=db,
+        resolver=RelationResolver(),
+        tab="latest",
+        limit=30,
+        cursor=None,
+        include_quotes=True,
+    )
+
+    quote_mock.assert_awaited_once_with(symbol="AAPL", market="us")
+    quoted = resp.items[0].relatedSymbols[0]
+    assert quoted.currentPrice == 110.0
+    assert quoted.previousClose == 100.0
+    assert quoted.change == 10.0
+    assert quoted.changePct == 10.0
+    assert quoted.quoteSource == "test-provider"
+    assert quoted.quoteAsOf is not None
+    assert resp.meta.warnings == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_feed_news_include_quotes_handles_missing_previous_close(
+    monkeypatch,
+) -> None:
+    from app.services.invest_view_model import feed_news_service as svc
+
+    db = MagicMock()
+    scalar_result = MagicMock()
+    scalar_result.scalars.return_value.all.return_value = [
+        _fake_article(id=206, market="kr", symbol="005930", name="삼성전자"),
+    ]
+    summary_result = MagicMock()
+    summary_result.all.return_value = []
+    db.execute = AsyncMock(
+        side_effect=[scalar_result, summary_result, _empty_related_result()]
+    )
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
+    )
+    monkeypatch.setattr(
+        svc,
+        "get_quote",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                price=70000.0, previous_close=None, source="kis"
+            )
+        ),
+    )
+
+    resp = await svc.build_feed_news(
+        db=db,
+        resolver=RelationResolver(),
+        tab="kr",
+        limit=30,
+        cursor=None,
+        include_quotes=True,
+    )
+
+    quoted = resp.items[0].relatedSymbols[0]
+    assert quoted.currentPrice == 70000.0
+    assert quoted.previousClose is None
+    assert quoted.change is None
+    assert quoted.changePct is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_feed_news_include_quotes_provider_failure_is_non_fatal(
+    monkeypatch,
+) -> None:
+    from app.services.domain_errors import UpstreamUnavailableError
+    from app.services.invest_view_model import feed_news_service as svc
+
+    db = MagicMock()
+    scalar_result = MagicMock()
+    scalar_result.scalars.return_value.all.return_value = [
+        _fake_article(id=207, market="us", symbol="MSFT", name="Microsoft"),
+    ]
+    summary_result = MagicMock()
+    summary_result.all.return_value = []
+    db.execute = AsyncMock(
+        side_effect=[scalar_result, summary_result, _empty_related_result()]
+    )
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
+    )
+    monkeypatch.setattr(
+        svc,
+        "get_quote",
+        AsyncMock(side_effect=UpstreamUnavailableError("provider down")),
+    )
+
+    resp = await svc.build_feed_news(
+        db=db,
+        resolver=RelationResolver(),
+        tab="latest",
+        limit=30,
+        cursor=None,
+        include_quotes=True,
+    )
+
+    assert len(resp.items) == 1
+    assert resp.items[0].relatedSymbols[0].currentPrice is None
+    assert "quote_unavailable:us:MSFT" in resp.meta.warnings
+    assert "quote_partial_failure:1" in resp.meta.warnings

--- a/tests/test_invest_feed_news_router.py
+++ b/tests/test_invest_feed_news_router.py
@@ -461,10 +461,10 @@ async def test_feed_news_include_quotes_dedupes_and_computes_change(
 
     quote_mock.assert_awaited_once_with(symbol="AAPL", market="us")
     quoted = resp.items[0].relatedSymbols[0]
-    assert quoted.currentPrice == 110.0
-    assert quoted.previousClose == 100.0
-    assert quoted.change == 10.0
-    assert quoted.changePct == 10.0
+    assert quoted.currentPrice == pytest.approx(110.0)
+    assert quoted.previousClose == pytest.approx(100.0)
+    assert quoted.change == pytest.approx(10.0)
+    assert quoted.changePct == pytest.approx(10.0)
     assert quoted.quoteSource == "test-provider"
     assert quoted.quoteAsOf is not None
     assert resp.meta.warnings == []
@@ -510,7 +510,7 @@ async def test_feed_news_include_quotes_handles_missing_previous_close(
     )
 
     quoted = resp.items[0].relatedSymbols[0]
-    assert quoted.currentPrice == 70000.0
+    assert quoted.currentPrice == pytest.approx(70000.0)
     assert quoted.previousClose is None
     assert quoted.change is None
     assert quoted.changePct is None

--- a/tests/test_news_entity_matcher.py
+++ b/tests/test_news_entity_matcher.py
@@ -87,6 +87,28 @@ def test_match_for_article_uses_title_summary_keywords():
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("field", ["title", "summary", "keywords"])
+def test_match_for_article_strips_url_metadata_before_matching(field: str):
+    kwargs = {
+        "title": "마켓레이더 오전 자료",
+        "summary": "증권사 시장 요약",
+        "keywords": None,
+        "market": "kr",
+    }
+    metadata = "canonical_url:https://finance.naver.com/market_info_read.naver"
+    if field == "title":
+        kwargs["title"] = metadata
+    elif field == "summary":
+        kwargs["summary"] = metadata
+    else:
+        kwargs["keywords"] = [metadata]
+
+    matches = match_symbols_for_article(**kwargs)
+
+    assert not any(m.symbol == "035420" for m in matches)
+
+
+@pytest.mark.unit
 def test_match_returns_sorted_unique_by_symbol():
     matches = match_symbols("Amazon Amazon AMZN keeps rising", market="us")
     amzn_matches = [m for m in matches if m.symbol == "AMZN"]

--- a/tests/test_news_ingestor_bulk.py
+++ b/tests/test_news_ingestor_bulk.py
@@ -323,3 +323,128 @@ class TestNewsReadinessPreopenIntegration:
         assert result.source_freshness is not None
         assert result.source_freshness["news"]["is_stale"] is True
         assert result.source_freshness["news"]["latest_run_uuid"] == "run-old"
+
+
+def test_news_article_related_symbol_model_contract():
+    from app.models.news import NewsArticleRelatedSymbol
+
+    constraints = {
+        constraint.name for constraint in NewsArticleRelatedSymbol.__table__.constraints
+    }
+    indexes = {index.name for index in NewsArticleRelatedSymbol.__table__.indexes}
+
+    assert "ck_news_article_related_symbols_market" in constraints
+    assert "uq_news_article_related_symbols_article_market_symbol_source" in constraints
+    assert "ix_news_article_related_symbols_article_rank" in indexes
+    assert "ix_news_article_related_symbols_market_symbol_article" in indexes
+
+
+def test_related_symbol_values_from_ingestor_payload_normalizes_multiple_candidates():
+    from app.schemas.news import NewsBulkIngestRequest
+    from app.services.llm_news_service import (
+        _related_symbol_values_from_ingestor_payload,
+    )
+
+    payload = _sample_payload()
+    payload["articles"][0]["raw"] = {
+        "stock_candidates": [
+            {
+                "code": "5930",
+                "market": "kr",
+                "name": "삼성전자",
+                "matched_term": "삼전",
+                "score": "0.91",
+                "rank": 2,
+            },
+            {
+                "symbol": "aapl",
+                "market": "us",
+                "display_name": "Apple",
+                "term": "Apple",
+                "score": 0.8,
+                "rank": 1,
+            },
+        ]
+    }
+    request = NewsBulkIngestRequest.model_validate(payload)
+
+    rows = _related_symbol_values_from_ingestor_payload(
+        article_id=123, article_data=request.articles[0]
+    )
+
+    assert [(row["market"], row["symbol"]) for row in rows] == [
+        ("us", "AAPL"),
+        ("kr", "005930"),
+    ]
+    assert rows[1]["display_name"] == "삼성전자"
+    assert rows[1]["matched_term"] == "삼전"
+    assert rows[1]["score"] == 0.91
+    assert rows[1]["source"] == "candidate_metadata"
+
+
+def test_related_symbol_values_from_ingestor_payload_drops_invalid_and_url_metadata():
+    from app.schemas.news import NewsBulkIngestRequest
+    from app.services.llm_news_service import (
+        _related_symbol_values_from_ingestor_payload,
+    )
+
+    payload = _sample_payload()
+    payload["articles"][0]["raw"] = {
+        "stock_candidates": [
+            {"symbol": "", "market": "kr"},
+            {"symbol": "035420", "market": "unsupported"},
+            "canonical_url:https://finance.naver.com/market_info_read.naver",
+            {"symbol": "www.naver.com", "market": "us"},
+        ]
+    }
+    request = NewsBulkIngestRequest.model_validate(payload)
+
+    rows = _related_symbol_values_from_ingestor_payload(
+        article_id=123, article_data=request.articles[0]
+    )
+
+    assert rows == []
+
+
+def test_related_symbol_values_from_ingestor_payload_dedupes_deterministically():
+    from app.schemas.news import NewsBulkIngestRequest
+    from app.services.llm_news_service import (
+        _related_symbol_values_from_ingestor_payload,
+    )
+
+    payload = _sample_payload()
+    payload["articles"][0]["raw"] = {
+        "stock_candidates": [
+            {"symbol": "005930", "market": "kr", "score": 0.5, "rank": 3},
+            {"symbol": "5930", "market": "kr", "score": 0.9, "rank": 2},
+            {"symbol": "005930", "market": "kr", "score": 0.95, "rank": 2},
+        ]
+    }
+    request = NewsBulkIngestRequest.model_validate(payload)
+
+    rows = _related_symbol_values_from_ingestor_payload(
+        article_id=123, article_data=request.articles[0]
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["symbol"] == "005930"
+    assert rows[0]["rank"] == 2
+    assert rows[0]["score"] == 0.95
+
+
+def test_related_symbol_values_from_ingestor_payload_missing_raw_returns_empty():
+    from app.schemas.news import NewsBulkIngestRequest
+    from app.services.llm_news_service import (
+        _related_symbol_values_from_ingestor_payload,
+    )
+
+    payload = _sample_payload()
+    payload["articles"][0]["raw"] = {}
+    request = NewsBulkIngestRequest.model_validate(payload)
+
+    assert (
+        _related_symbol_values_from_ingestor_payload(
+            article_id=123, article_data=request.articles[0]
+        )
+        == []
+    )

--- a/tests/test_news_ingestor_bulk.py
+++ b/tests/test_news_ingestor_bulk.py
@@ -378,7 +378,7 @@ def test_related_symbol_values_from_ingestor_payload_normalizes_multiple_candida
     ]
     assert rows[1]["display_name"] == "삼성전자"
     assert rows[1]["matched_term"] == "삼전"
-    assert rows[1]["score"] == 0.91
+    assert rows[1]["score"] == pytest.approx(0.91)
     assert rows[1]["source"] == "candidate_metadata"
 
 
@@ -429,7 +429,7 @@ def test_related_symbol_values_from_ingestor_payload_dedupes_deterministically()
     assert len(rows) == 1
     assert rows[0]["symbol"] == "005930"
     assert rows[0]["rank"] == 2
-    assert rows[0]["score"] == 0.95
+    assert rows[0]["score"] == pytest.approx(0.95)
 
 
 def test_related_symbol_values_from_ingestor_payload_missing_raw_returns_empty():

--- a/tests/test_news_stage_fallback.py
+++ b/tests/test_news_stage_fallback.py
@@ -7,6 +7,7 @@ reason — instead of an empty list.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
@@ -53,6 +54,7 @@ def _related_symbol_session_factory(rows: list[SimpleNamespace]):
             return None
 
         async def execute(self, stmt):
+            await asyncio.sleep(0)
             result = Mock()
             result.scalars.return_value.all.return_value = rows
             return result
@@ -65,7 +67,7 @@ def _related_symbol_session_factory(rows: list[SimpleNamespace]):
 async def test_fallback_exact_symbol_match_returned_first(monkeypatch):
     exact = [_mk_article(id=1, title="AMZN beats", stock_symbol="AMZN")]
 
-    async def fake_get_news_articles(**kwargs):
+    def fake_get_news_articles(**kwargs):
         if kwargs.get("stock_symbol") == "AMZN":
             return exact, len(exact)
         return [], 0
@@ -92,7 +94,7 @@ async def test_fallback_alias_used_when_exact_returns_empty(monkeypatch):
         _mk_article(id=11, title="Apple reports Q1", stock_symbol=None),
     ]
 
-    async def fake_get_news_articles(**kwargs):
+    def fake_get_news_articles(**kwargs):
         if kwargs.get("stock_symbol") == "AMZN":
             return [], 0
         # market-wide query (no stock_symbol)
@@ -127,7 +129,7 @@ async def test_fallback_kr_005930_alias_match(monkeypatch):
         )
     ]
 
-    async def fake_get_news_articles(**kwargs):
+    def fake_get_news_articles(**kwargs):
         if kwargs.get("stock_symbol") == "005930":
             return [], 0
         return untagged, len(untagged)
@@ -153,7 +155,7 @@ async def test_fallback_kr_005930_alias_match(monkeypatch):
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_fallback_returns_empty_when_no_match(monkeypatch):
-    async def fake_get_news_articles(**kwargs):
+    def fake_get_news_articles(**kwargs):
         return [], 0
 
     monkeypatch.setattr(
@@ -195,6 +197,7 @@ async def test_fallback_uses_persisted_related_symbol_rows_before_alias_scan(
             return None
 
         async def execute(self, stmt):
+            await asyncio.sleep(0)
             result = Mock()
             result.scalars.return_value.all.return_value = [related]
             return result
@@ -240,7 +243,7 @@ async def test_fallback_supplements_exact_and_related_rows_with_alias_matches(
         market="us",
     )
 
-    async def fake_get_news_articles(**kwargs):
+    def fake_get_news_articles(**kwargs):
         if kwargs.get("stock_symbol") == "NVDA":
             return exact, len(exact)
         return [alias, unrelated], 2
@@ -275,7 +278,7 @@ async def test_fallback_caps_limit(monkeypatch):
         _mk_article(id=i, title="Amazon news", stock_symbol=None) for i in range(50)
     ]
 
-    async def fake_get_news_articles(**kwargs):
+    def fake_get_news_articles(**kwargs):
         if kwargs.get("stock_symbol"):
             return [], 0
         return untagged, len(untagged)

--- a/tests/test_news_stage_fallback.py
+++ b/tests/test_news_stage_fallback.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -40,6 +40,24 @@ def _mk_article(
         source="example",
         feed_source="rss_test",
     )
+
+
+def _related_symbol_session_factory(rows: list[SimpleNamespace]):
+    """Return an async session factory yielding related-symbol lookup rows."""
+
+    class _RelatedRowsSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def execute(self, stmt):
+            result = Mock()
+            result.scalars.return_value.all.return_value = rows
+            return result
+
+    return lambda: _RelatedRowsSession()
 
 
 @pytest.mark.unit
@@ -85,6 +103,11 @@ async def test_fallback_alias_used_when_exact_returns_empty(monkeypatch):
         "get_news_articles",
         AsyncMock(side_effect=fake_get_news_articles),
     )
+    monkeypatch.setattr(
+        llm_news_service,
+        "AsyncSessionLocal",
+        _related_symbol_session_factory([]),
+    )
 
     result = await llm_news_service.get_news_articles_with_fallback(
         symbol="AMZN", market="us", hours=24, limit=20
@@ -114,6 +137,11 @@ async def test_fallback_kr_005930_alias_match(monkeypatch):
         "get_news_articles",
         AsyncMock(side_effect=fake_get_news_articles),
     )
+    monkeypatch.setattr(
+        llm_news_service,
+        "AsyncSessionLocal",
+        _related_symbol_session_factory([]),
+    )
 
     result = await llm_news_service.get_news_articles_with_fallback(
         symbol="005930", market="kr", hours=24, limit=20
@@ -133,12 +161,58 @@ async def test_fallback_returns_empty_when_no_match(monkeypatch):
         "get_news_articles",
         AsyncMock(side_effect=fake_get_news_articles),
     )
+    monkeypatch.setattr(
+        llm_news_service,
+        "AsyncSessionLocal",
+        _related_symbol_session_factory([]),
+    )
 
     result = await llm_news_service.get_news_articles_with_fallback(
         symbol="AMZN", market="us", hours=24, limit=20
     )
     assert result.articles == []
     assert result.match_reasons == {}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fallback_uses_persisted_related_symbol_rows_before_alias_scan(
+    monkeypatch,
+):
+    related = _mk_article(
+        id=30,
+        title="Cloud capex lifts chip supply chain",
+        stock_symbol=None,
+        market="us",
+    )
+    get_news_articles = AsyncMock(side_effect=[([], 0), ([], 0)])
+
+    class _RelatedRowsSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def execute(self, stmt):
+            result = Mock()
+            result.scalars.return_value.all.return_value = [related]
+            return result
+
+    monkeypatch.setattr(llm_news_service, "get_news_articles", get_news_articles)
+    monkeypatch.setattr(
+        llm_news_service,
+        "AsyncSessionLocal",
+        lambda: _RelatedRowsSession(),
+    )
+
+    result = await llm_news_service.get_news_articles_with_fallback(
+        symbol="NVDA", market="us", hours=24, limit=20
+    )
+
+    assert [article.id for article in result.articles] == [30]
+    assert result.match_reasons[30] == "related_symbol"
+    assert get_news_articles.await_count == 1
 
 
 @pytest.mark.unit

--- a/tests/test_news_stage_fallback.py
+++ b/tests/test_news_stage_fallback.py
@@ -207,12 +207,65 @@ async def test_fallback_uses_persisted_related_symbol_rows_before_alias_scan(
     )
 
     result = await llm_news_service.get_news_articles_with_fallback(
-        symbol="NVDA", market="us", hours=24, limit=20
+        symbol="NVDA", market="us", hours=24, limit=1
     )
 
     assert [article.id for article in result.articles] == [30]
     assert result.match_reasons[30] == "related_symbol"
     assert get_news_articles.await_count == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fallback_supplements_exact_and_related_rows_with_alias_matches(
+    monkeypatch,
+):
+    exact = [_mk_article(id=1, title="NVDA tagged", stock_symbol="NVDA")]
+    related = _mk_article(
+        id=30,
+        title="Cloud capex lifts chip supply chain",
+        stock_symbol=None,
+        market="us",
+    )
+    alias = _mk_article(
+        id=40,
+        title="Nvidia suppliers gain on AI demand",
+        stock_symbol=None,
+        market="us",
+    )
+    unrelated = _mk_article(
+        id=41,
+        title="Apple reports services growth",
+        stock_symbol=None,
+        market="us",
+    )
+
+    async def fake_get_news_articles(**kwargs):
+        if kwargs.get("stock_symbol") == "NVDA":
+            return exact, len(exact)
+        return [alias, unrelated], 2
+
+    monkeypatch.setattr(
+        llm_news_service,
+        "get_news_articles",
+        AsyncMock(side_effect=fake_get_news_articles),
+    )
+    monkeypatch.setattr(
+        llm_news_service,
+        "AsyncSessionLocal",
+        _related_symbol_session_factory([related]),
+    )
+
+    result = await llm_news_service.get_news_articles_with_fallback(
+        symbol="NVDA", market="us", hours=24, limit=20
+    )
+
+    assert [article.id for article in result.articles] == [1, 30, 40]
+    assert result.match_reasons == {
+        1: "exact_symbol",
+        30: "related_symbol",
+        40: "alias_match",
+    }
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Persist news_article_related_symbols rows from news-ingestor stock_candidates metadata.
- Enrich /invest/api/feed/news items with relatedSymbols including latest quote/change-rate when available.
- Harden related-symbol matching against URL/canonical/fingerprint metadata false positives and preserve staged exact/related/alias fallback coverage.

## Verification
- PUBLIC_API_PATHS='[]' uv run --group test python -m pytest tests/test_news_stage_fallback.py -q
- PUBLIC_API_PATHS='[]' uv run --group test python -m pytest tests/test_news_ingestor_bulk.py tests/test_invest_feed_news_router.py tests/test_news_entity_matcher.py tests/test_news_stage_fallback.py -q
- uv run ruff check alembic/versions/d2e3f4a5b6c7_add_news_article_related_symbols.py app/models/news.py app/routers/invest_api.py app/schemas/invest_feed_news.py app/services/invest_view_model/feed_news_service.py app/services/llm_news_service.py app/services/news_entity_matcher.py tests/test_invest_feed_news_router.py tests/test_news_entity_matcher.py tests/test_news_ingestor_bulk.py tests/test_news_stage_fallback.py
- uv run ty check app/models/news.py app/routers/invest_api.py app/schemas/invest_feed_news.py app/services/invest_view_model/feed_news_service.py app/services/llm_news_service.py app/services/news_entity_matcher.py
- git diff --check
- uv run alembic upgrade b1c2d3e4:d2e3f4a5b6c7 --sql
- uv run alembic downgrade d2e3f4a5b6c7:b1c2d3e4 --sql

## Safety
- No broker/order/watch/order-intent mutations.
- No live/paper/KIS/Upbit execution.
- No destructive DB update/delete/backfill or scheduler cadence changes.
- Migration is non-destructive DDL for a new relation table and indexes only.

Closes ROB-153


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * News feed API now supports an optional `includeQuotes` query parameter to include real-time price data with related symbols, such as current price, price change, and quote timestamp
  * Related symbols mentioned in news articles are now persistently tracked for improved reliability and comprehensive coverage

* **Bug Fixes**
  * Fixed symbol matching to properly filter URL and metadata strings from article text, preventing false-positive symbol matches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->