### PR TITLE
feat(invest): add account-scoped right panel filters

### DIFF
--- a/frontend/invest/src/__tests__/RightRemotePanel.test.tsx
+++ b/frontend/invest/src/__tests__/RightRemotePanel.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { vi, beforeEach, test, expect } from "vitest";
 import { MemoryRouter } from "react-router-dom";
@@ -10,11 +10,12 @@ import type { AccountPanelResponse } from "../types/invest";
 
 const PANEL_RESP: AccountPanelResponse = {
   homeSummary: {
-    includedSources: ["kis"],
+    includedSources: ["kis", "upbit", "toss_manual"],
     excludedSources: [],
-    totalValueKrw: 5_000_000,
-    pnlKrw: 250_000,
-    pnlRate: 0.05,
+    totalValueKrw: 10_100_000,
+    costBasisKrw: 9_200_000,
+    pnlKrw: 900_000,
+    pnlRate: 900_000 / 9_200_000,
   },
   accounts: [
     {
@@ -23,33 +24,94 @@ const PANEL_RESP: AccountPanelResponse = {
       source: "kis",
       accountKind: "live",
       includedInHome: true,
-      valueKrw: 5_000_000,
-      cashBalances: { krw: 100_000 },
-      buyingPower: { krw: 100_000 },
+      valueKrw: 1_244_000,
+      cashBalances: { krw: 100_000, usd: 25.5 },
+      buyingPower: { krw: 100_000, usd: 25.5 },
+    },
+    {
+      accountId: "u1",
+      displayName: "Upbit",
+      source: "upbit",
+      accountKind: "live",
+      includedInHome: true,
+      valueKrw: 8_500_000,
+      cashBalances: { krw: 50_000 },
+      buyingPower: { krw: 50_000 },
     },
   ],
   groupedHoldings: [
     {
-      groupId: "g1",
-      symbol: "005930",
-      market: "KR",
+      groupId: "US:equity:USD:TSLA",
+      symbol: "TSLA",
+      market: "US",
       assetType: "equity",
-      assetCategory: "kr_stock",
-      displayName: "삼성전자",
-      currency: "KRW",
-      totalQuantity: 10,
-      valueKrw: 800_000,
-      pnlKrw: 40_000,
-      pnlRate: 0.05,
+      assetCategory: "us_stock",
+      displayName: "Tesla",
+      currency: "USD",
+      totalQuantity: 6,
+      averageCost: 200,
+      costBasis: 1200,
+      valueNative: 1200,
+      valueKrw: 1_600_000,
+      pnlKrw: 0,
+      pnlRate: 0,
       priceState: "live",
-      includedSources: ["kis"],
+      includedSources: ["kis", "toss_manual"],
+      sourceBreakdown: [
+        {
+          holdingId: "h1",
+          accountId: "k1",
+          source: "kis",
+          quantity: 4,
+          averageCost: 234,
+          costBasis: 936,
+          valueNative: 924,
+          valueKrw: 1_244_000,
+          pnlKrw: -16_000,
+          pnlRate: -16_000 / 936,
+        },
+        {
+          holdingId: "h2",
+          accountId: "manual-1",
+          source: "toss_manual",
+          quantity: 2,
+          averageCost: 132,
+          costBasis: 264,
+          valueNative: 276,
+          valueKrw: 356_000,
+          pnlKrw: 16_000,
+          pnlRate: 16_000 / 264,
+        },
+      ],
+    },
+    {
+      groupId: "CRYPTO:crypto:KRW:BTC",
+      symbol: "KRW-BTC",
+      market: "CRYPTO",
+      assetType: "crypto",
+      assetCategory: "crypto",
+      displayName: "비트코인",
+      currency: "KRW",
+      totalQuantity: 0.1,
+      averageCost: 80_000_000,
+      costBasis: 8_000_000,
+      valueNative: 8_500_000,
+      valueKrw: 8_500_000,
+      pnlKrw: 500_000,
+      pnlRate: 0.0625,
+      priceState: "live",
+      includedSources: ["upbit"],
       sourceBreakdown: [],
     },
   ],
   watchSymbols: [
     { symbol: "AAPL", market: "us", displayName: "Apple Inc." },
   ],
-  sourceVisuals: [{ source: "kis", tone: "navy", badge: "Live", displayName: "KIS" }],
+  sourceVisuals: [
+    { source: "kis", tone: "navy", badge: "Live", displayName: "KIS" },
+    { source: "upbit", tone: "green", badge: "Crypto", displayName: "Upbit" },
+    { source: "toss_manual", tone: "gray", badge: "Manual", displayName: "Toss/manual" },
+  ],
   meta: { warnings: [], watchlistAvailable: true },
 };
 
@@ -64,6 +126,7 @@ function renderPanel() {
 }
 
 beforeEach(() => {
+  vi.restoreAllMocks();
   vi.spyOn(panelApi, "fetchAccountPanel").mockResolvedValue(PANEL_RESP);
   vi.spyOn(signalsApi, "fetchSignals").mockResolvedValue({
     tab: "kr",
@@ -84,11 +147,66 @@ test("renders the tabbed right remote panel", async () => {
   await waitFor(() => expect(screen.getByTestId("portfolio-panel")).toBeInTheDocument());
 });
 
-test("portfolio tab shows holdings after data loads", async () => {
+test("portfolio tab shows account cash card, filters, and all-account holdings after data loads", async () => {
   renderPanel();
   await waitFor(() => expect(screen.getByTestId("portfolio-panel")).toBeInTheDocument());
-  expect(screen.getByText("삼성전자")).toBeInTheDocument();
-  expect(screen.getByText("₩800,000")).toBeInTheDocument();
+  const cashCard = screen.getByTestId("account-cash-card");
+  expect(within(cashCard).getByText("전체")).toBeInTheDocument();
+  expect(within(cashCard).getByText("₩150,000")).toBeInTheDocument();
+  expect(within(cashCard).getByText("$25.5")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "전체" })).toHaveAttribute("aria-pressed", "true");
+  expect(screen.getByRole("button", { name: "KIS" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Upbit" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Toss/manual" })).toBeInTheDocument();
+  expect(screen.getByText("전체 보유종목")).toBeInTheDocument();
+  expect(screen.getByText("비트코인")).toBeInTheDocument();
+  expect(screen.getByText("Tesla")).toBeInTheDocument();
+  expect(screen.getByText("₩10,100,000")).toBeInTheDocument();
+});
+
+test("KIS filter recomputes totals and rows without refetching account panel", async () => {
+  const user = userEvent.setup();
+  const fetchSpy = vi.spyOn(panelApi, "fetchAccountPanel").mockResolvedValue(PANEL_RESP);
+  renderPanel();
+  await waitFor(() => expect(screen.getByTestId("portfolio-panel")).toBeInTheDocument());
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+  await user.click(screen.getByRole("button", { name: "KIS" }));
+
+  expect(screen.getByRole("button", { name: "KIS" })).toHaveAttribute("aria-pressed", "true");
+  expect(screen.getByText("KIS 보유종목")).toBeInTheDocument();
+  expect(screen.getByText("Tesla")).toBeInTheDocument();
+  expect(screen.queryByText("비트코인")).not.toBeInTheDocument();
+  expect(screen.getAllByText("₩1,244,000")).toHaveLength(2);
+  expect(screen.getByText((_, node) => node?.textContent === "투자원금 ₩1,260,000")).toBeInTheDocument();
+  expect(screen.getByTestId("pl")).toHaveAttribute("data-dir", "down");
+  const cashCard = screen.getByTestId("account-cash-card");
+  expect(within(cashCard).getByText("₩100,000")).toBeInTheDocument();
+  expect(within(cashCard).getByText("$25.5")).toBeInTheDocument();
+  expect(fetchSpy).toHaveBeenCalledTimes(1);
+});
+
+test("Upbit and Toss/manual filters scope holdings and cash independently", async () => {
+  const user = userEvent.setup();
+  renderPanel();
+  await waitFor(() => expect(screen.getByTestId("portfolio-panel")).toBeInTheDocument());
+
+  await user.click(screen.getByRole("button", { name: "Upbit" }));
+  expect(screen.getByText("Upbit 보유종목")).toBeInTheDocument();
+  expect(screen.getByText("비트코인")).toBeInTheDocument();
+  expect(screen.queryByText("Tesla")).not.toBeInTheDocument();
+  expect(screen.getAllByText("₩8,500,000")).toHaveLength(2);
+  expect(screen.getByText((_, node) => node?.textContent === "투자원금 ₩8,000,000")).toBeInTheDocument();
+  let cashCard = screen.getByTestId("account-cash-card");
+  expect(within(cashCard).getByText("₩50,000")).toBeInTheDocument();
+
+  await user.click(screen.getByRole("button", { name: "Toss/manual" }));
+  expect(screen.getByText("Toss/manual 보유종목")).toBeInTheDocument();
+  expect(screen.getByText("Tesla")).toBeInTheDocument();
+  expect(screen.queryByText("비트코인")).not.toBeInTheDocument();
+  expect(screen.getAllByText("₩356,000")).toHaveLength(2);
+  cashCard = screen.getByTestId("account-cash-card");
+  expect(within(cashCard).getByText("현금 정보 없음")).toBeInTheDocument();
 });
 
 test("watchlist tab shows watch symbols", async () => {
@@ -108,6 +226,7 @@ test("recent tab shows empty state initially", async () => {
 test("portfolio tab shows empty holdings gracefully", async () => {
   vi.spyOn(panelApi, "fetchAccountPanel").mockResolvedValue({
     ...PANEL_RESP,
+    homeSummary: { ...PANEL_RESP.homeSummary, totalValueKrw: 0, costBasisKrw: null, pnlKrw: null, pnlRate: null },
     groupedHoldings: [],
   });
   renderPanel();

--- a/frontend/invest/src/__tests__/scopeHoldings.test.ts
+++ b/frontend/invest/src/__tests__/scopeHoldings.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { scopeGroupedToSource } from "../desktop/scopeHoldings";
-import type { GroupedHolding } from "../types/invest";
+import {
+  buildAccountFilterOptions,
+  buildScopedPortfolioPanel,
+  scopeGroupedToSource,
+} from "../desktop/scopeHoldings";
+import type { AccountPanelResponse, GroupedHolding } from "../types/invest";
 
 const baseGroup: GroupedHolding = {
   groupId: "US:equity:USD:TSLA",
@@ -47,6 +51,73 @@ const baseGroup: GroupedHolding = {
   ],
 };
 
+const upbitGroup: GroupedHolding = {
+  groupId: "CRYPTO:crypto:KRW:BTC",
+  symbol: "KRW-BTC",
+  market: "CRYPTO",
+  assetType: "crypto",
+  assetCategory: "crypto",
+  displayName: "비트코인",
+  currency: "KRW",
+  totalQuantity: 0.1,
+  averageCost: 80_000_000,
+  costBasis: 8_000_000,
+  valueNative: 8_500_000,
+  valueKrw: 8_500_000,
+  pnlKrw: 500_000,
+  pnlRate: 0.0625,
+  priceState: "live",
+  includedSources: ["upbit"],
+  sourceBreakdown: [],
+};
+
+const panelResponse: AccountPanelResponse = {
+  homeSummary: {
+    includedSources: ["kis", "upbit", "toss_manual"],
+    excludedSources: [],
+    totalValueKrw: 10_100_000,
+    costBasisKrw: 9_200_000,
+    pnlKrw: 900_000,
+    pnlRate: 900_000 / 9_200_000,
+  },
+  accounts: [
+    {
+      accountId: "kis-1",
+      displayName: "KIS Live",
+      source: "kis",
+      accountKind: "live",
+      includedInHome: true,
+      valueKrw: 1_244_000,
+      costBasisKrw: 1_260_000,
+      pnlKrw: -16_000,
+      pnlRate: -16_000 / 1_260_000,
+      cashBalances: { krw: 100_000, usd: 25.5 },
+      buyingPower: { krw: 100_000, usd: 25.5 },
+    },
+    {
+      accountId: "upbit-1",
+      displayName: "Upbit",
+      source: "upbit",
+      accountKind: "live",
+      includedInHome: true,
+      valueKrw: 8_500_000,
+      costBasisKrw: 8_000_000,
+      pnlKrw: 500_000,
+      pnlRate: 0.0625,
+      cashBalances: { krw: 50_000 },
+      buyingPower: { krw: 50_000 },
+    },
+  ],
+  groupedHoldings: [baseGroup, upbitGroup],
+  watchSymbols: [],
+  sourceVisuals: [
+    { source: "kis", tone: "navy", badge: "Live", displayName: "KIS" },
+    { source: "upbit", tone: "green", badge: "Crypto", displayName: "Upbit" },
+    { source: "toss_manual", tone: "gray", badge: "Manual", displayName: "Toss/manual" },
+  ],
+  meta: { warnings: [], watchlistAvailable: true },
+};
+
 describe("scopeGroupedToSource", () => {
   it("returns single-source groups unchanged when the source matches", () => {
     const single: GroupedHolding = {
@@ -70,7 +141,7 @@ describe("scopeGroupedToSource", () => {
     expect(sliced.valueKrw).toBe(1_244_000);
     expect(sliced.pnlKrw).toBe(-16_000);
     expect(sliced.averageCost).toBe(234);
-    expect(sliced.pnlRate).toBeCloseTo(-16_000 / 936);
+    expect(sliced.pnlRate).toBeCloseTo((924 - 936) / 936);
     expect(sliced.sourceBreakdown).toHaveLength(1);
     expect(sliced.sourceBreakdown[0]!.source).toBe("kis");
   });
@@ -87,5 +158,51 @@ describe("scopeGroupedToSource", () => {
     };
     const out = scopeGroupedToSource([orphan], "kis");
     expect(out).toEqual([]);
+  });
+});
+
+describe("buildScopedPortfolioPanel", () => {
+  it("keeps all-account rows and home summary totals for all", () => {
+    const scoped = buildScopedPortfolioPanel(panelResponse, "all");
+    expect(scoped.selected.label).toBe("전체");
+    expect(scoped.groupedHoldings).toBe(panelResponse.groupedHoldings);
+    expect(scoped.totalValueKrw).toBe(10_100_000);
+    expect(scoped.costBasisKrw).toBe(9_200_000);
+    expect(scoped.pnlKrw).toBe(900_000);
+    expect(scoped.cashBalances).toEqual({ krw: 150_000, usd: 25.5 });
+  });
+
+  it("builds filter options from accounts and holding-only manual sources", () => {
+    const options = buildAccountFilterOptions(panelResponse);
+    expect(options.map((option) => option.key)).toEqual(["all", "kis", "upbit", "toss_manual"]);
+    expect(options.map((option) => option.label)).toEqual(["전체", "KIS", "Upbit", "Toss/manual"]);
+    expect(options.find((option) => option.key === "toss_manual")?.cashBalances).toEqual({ krw: null, usd: null });
+  });
+
+  it("recomputes KIS totals and cash from sourceBreakdown only", () => {
+    const scoped = buildScopedPortfolioPanel(panelResponse, "kis");
+    expect(scoped.groupedHoldings).toHaveLength(1);
+    expect(scoped.groupedHoldings[0]!.includedSources).toEqual(["kis"]);
+    expect(scoped.totalValueKrw).toBe(1_244_000);
+    expect(scoped.costBasisKrw).toBe(1_260_000);
+    expect(scoped.pnlKrw).toBe(-16_000);
+    expect(scoped.pnlRate).toBeCloseTo(-16_000 / 1_260_000);
+    expect(scoped.cashBalances).toEqual({ krw: 100_000, usd: 25.5 });
+  });
+
+  it("recomputes Upbit totals independently from all-account totals", () => {
+    const scoped = buildScopedPortfolioPanel(panelResponse, "upbit");
+    expect(scoped.groupedHoldings.map((group) => group.symbol)).toEqual(["KRW-BTC"]);
+    expect(scoped.totalValueKrw).toBe(8_500_000);
+    expect(scoped.costBasisKrw).toBe(8_000_000);
+    expect(scoped.pnlKrw).toBe(500_000);
+    expect(scoped.pnlRate).toBeCloseTo(0.0625);
+    expect(scoped.cashBalances).toEqual({ krw: 50_000, usd: null });
+  });
+
+  it("falls back to all for missing selected keys", () => {
+    const scoped = buildScopedPortfolioPanel(panelResponse, "alpaca_paper");
+    expect(scoped.selected.key).toBe("all");
+    expect(scoped.totalValueKrw).toBe(panelResponse.homeSummary.totalValueKrw);
   });
 });

--- a/frontend/invest/src/desktop/RightRemotePanel.tsx
+++ b/frontend/invest/src/desktop/RightRemotePanel.tsx
@@ -7,6 +7,7 @@ import { Button, Card, Icon, PL as ProfitLoss, Pill } from "../ds";
 import type { PillTone } from "../ds";
 import { fetchSignals } from "../api/signals";
 import type { SignalCard } from "../types/signals";
+import { buildScopedPortfolioPanel, type AccountFilterKey } from "./scopeHoldings";
 import type { GroupedHolding, WatchSymbol } from "../types/invest";
 import { formatRelativeTime } from "../format/relativeTime";
 
@@ -38,6 +39,11 @@ function fmtPct(v?: number | null): string {
   const pct = v * 100;
   const sign = pct >= 0 ? "+" : "";
   return `${sign}${pct.toFixed(2)}%`;
+}
+
+function fmtUsd(v?: number | null): string {
+  if (v == null) return "—";
+  return `$${v.toLocaleString("en-US", { maximumFractionDigits: 2 })}`;
 }
 
 const ROW_BUTTON_STYLE: CSSProperties = {
@@ -157,6 +163,7 @@ function TabBar({
 
 function PortfolioPanel({ onNavigate }: Readonly<{ onNavigate: NavigateToSymbol }>) {
   const { data, error, loading, refreshing, reload } = useAccountPanel();
+  const [selectedAccountKey, setSelectedAccountKey] = useState<AccountFilterKey>("all");
 
   if (loading) {
     return (
@@ -192,8 +199,12 @@ function PortfolioPanel({ onNavigate }: Readonly<{ onNavigate: NavigateToSymbol 
     );
   }
 
-  const { homeSummary, groupedHoldings } = data;
-  const sorted = [...groupedHoldings].sort(
+  const scopedForKey = buildScopedPortfolioPanel(data, selectedAccountKey);
+  const selectedKey = scopedForKey.selected.key;
+  const scoped = selectedKey === selectedAccountKey
+    ? scopedForKey
+    : buildScopedPortfolioPanel(data, selectedKey);
+  const sorted = [...scoped.groupedHoldings].sort(
     (a, b) => (b.valueKrw ?? 0) - (a.valueKrw ?? 0),
   );
 
@@ -203,10 +214,61 @@ function PortfolioPanel({ onNavigate }: Readonly<{ onNavigate: NavigateToSymbol 
     return "crypto";
   };
 
+  const sectionLabel = `${scoped.selected.label} 보유종목`;
+  const hasCash = scoped.cashBalances.krw != null || scoped.cashBalances.usd != null;
+
   return (
     <div data-testid="portfolio-panel" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+      <Card data-testid="account-cash-card" style={{ padding: 14 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "baseline" }}>
+          <div style={{ fontSize: 11, color: "var(--fg-3)", fontWeight: 600 }}>선택 계좌</div>
+          <div style={{ fontSize: 12, color: "var(--fg)", fontWeight: 700 }}>{scoped.selected.label}</div>
+        </div>
+        {hasCash ? (
+          <div style={{ display: "grid", gap: 4, marginTop: 10 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12 }}>
+              <span style={{ color: "var(--fg-3)" }}>원화 현금</span>
+              <span style={{ fontWeight: 700, fontFeatureSettings: '"tnum"' }}>{fmtKrw(scoped.cashBalances.krw)}</span>
+            </div>
+            <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12 }}>
+              <span style={{ color: "var(--fg-3)" }}>달러 현금</span>
+              <span style={{ fontWeight: 700, fontFeatureSettings: '"tnum"' }}>{fmtUsd(scoped.cashBalances.usd)}</span>
+            </div>
+          </div>
+        ) : (
+          <div style={{ marginTop: 10, fontSize: 12, color: "var(--fg-3)" }}>현금 정보 없음</div>
+        )}
+      </Card>
+
+      <div aria-label="계좌 필터" style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+        {scoped.options.map((option) => {
+          const isActive = option.key === selectedKey;
+          return (
+            <button
+              key={option.key}
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => setSelectedAccountKey(option.key)}
+              style={{
+                padding: "5px 10px",
+                borderRadius: 999,
+                border: "1px solid var(--border)",
+                background: isActive ? "var(--fg)" : "var(--surface)",
+                color: isActive ? "var(--bg)" : "var(--fg-2)",
+                fontWeight: isActive ? 700 : 500,
+                fontSize: 11,
+                fontFamily: "inherit",
+                cursor: "pointer",
+              }}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+
       <Card style={{ padding: 14 }}>
-        <div style={{ fontSize: 11, color: "var(--fg-3)", fontWeight: 500 }}>총 자산</div>
+        <div style={{ fontSize: 11, color: "var(--fg-3)", fontWeight: 500 }}>투자 평가액</div>
         <div
           style={{
             fontSize: 22,
@@ -216,11 +278,14 @@ function PortfolioPanel({ onNavigate }: Readonly<{ onNavigate: NavigateToSymbol 
             fontFeatureSettings: '"tnum"',
           }}
         >
-          {fmtKrw(homeSummary.totalValueKrw)}
+          {fmtKrw(scoped.totalValueKrw)}
         </div>
-        {homeSummary.pnlKrw != null && homeSummary.pnlRate != null ? (
+        <div style={{ marginTop: 4, fontSize: 12, color: "var(--fg-3)" }}>
+          투자원금 {fmtKrw(scoped.costBasisKrw)}
+        </div>
+        {scoped.pnlKrw != null && scoped.pnlRate != null ? (
           <div style={{ marginTop: 4 }}>
-            <ProfitLoss value={homeSummary.pnlKrw} pct={homeSummary.pnlRate * 100} size={12} />
+            <ProfitLoss value={scoped.pnlKrw} pct={scoped.pnlRate * 100} size={12} />
           </div>
         ) : (
           <div style={{ marginTop: 4, fontSize: 12, color: "var(--fg-3)" }}>—</div>
@@ -240,11 +305,11 @@ function PortfolioPanel({ onNavigate }: Readonly<{ onNavigate: NavigateToSymbol 
 
       <div>
         <div style={{ fontSize: 11, fontWeight: 600, color: "var(--fg-3)", marginBottom: 6 }}>
-          내 종목 현황
+          {sectionLabel}
         </div>
         {sorted.length === 0 ? (
           <div data-testid="holdings-empty" style={{ fontSize: 12, color: "var(--fg-3)", padding: "8px 0" }}>
-            보유 종목이 없습니다.
+            {selectedKey === "all" ? "보유 종목이 없습니다." : "선택한 계좌에 표시할 보유종목이 없습니다."}
           </div>
         ) : (
           <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column" }}>

--- a/frontend/invest/src/desktop/scopeHoldings.ts
+++ b/frontend/invest/src/desktop/scopeHoldings.ts
@@ -1,4 +1,41 @@
-import type { AccountSource, GroupedHolding } from "../types/invest";
+import type { AccountPanelResponse, AccountSource, CashAmounts, GroupedHolding } from "../types/invest";
+
+export type AccountFilterKey = "all" | AccountSource;
+
+export interface AccountFilterOption {
+  key: AccountFilterKey;
+  label: string;
+  source?: AccountSource;
+  cashBalances: CashAmounts;
+  totalValueKrw: number;
+  costBasisKrw: number | null;
+  pnlKrw: number | null;
+  pnlRate: number | null;
+  holdingCount: number;
+}
+
+export interface ScopedPortfolioPanel {
+  selected: AccountFilterOption;
+  options: AccountFilterOption[];
+  groupedHoldings: GroupedHolding[];
+  totalValueKrw: number;
+  costBasisKrw: number | null;
+  pnlKrw: number | null;
+  pnlRate: number | null;
+  cashBalances: CashAmounts;
+}
+
+const SOURCE_LABELS: Partial<Record<AccountSource, string>> = {
+  kis: "KIS",
+  upbit: "Upbit",
+  toss_manual: "Toss/manual",
+  pension_manual: "연금/manual",
+  isa_manual: "ISA/manual",
+  kis_mock: "KIS Mock",
+  kiwoom_mock: "Kiwoom Mock",
+  alpaca_paper: "Alpaca Paper",
+  db_simulated: "DB simulated",
+};
 
 // When the user filters the home view to a single source/account, the grouped
 // rows must be reduced to that source's slice so the table totals match the
@@ -47,8 +84,8 @@ export function scopeGroupedToSource(
 
     const averageCost = qtyForAvg > 0 ? costSum / qtyForAvg : null;
     const pnlRate =
-      pnlKrw != null && costBasis != null && costBasis !== 0
-        ? pnlKrw / costBasis
+      valueNative != null && costBasis != null && costBasis !== 0
+        ? (valueNative - costBasis) / costBasis
         : null;
 
     out.push({
@@ -65,4 +102,127 @@ export function scopeGroupedToSource(
     });
   }
   return out;
+}
+
+function sourceLabel(response: AccountPanelResponse, source: AccountSource): string {
+  if (SOURCE_LABELS[source]) return SOURCE_LABELS[source]!;
+  const visual = response.sourceVisuals.find((v) => v.source === source);
+  if (visual?.displayName) return visual.displayName;
+  const account = response.accounts.find((a) => a.source === source);
+  if (account?.displayName) return account.displayName;
+  return source;
+}
+
+function sumCash(accounts: AccountPanelResponse["accounts"]): CashAmounts {
+  let krw: number | null = null;
+  let usd: number | null = null;
+  for (const account of accounts) {
+    const accountKrw = account.cashBalances?.krw;
+    const accountUsd = account.cashBalances?.usd;
+    if (accountKrw != null) krw = (krw ?? 0) + accountKrw;
+    if (accountUsd != null) usd = (usd ?? 0) + accountUsd;
+  }
+  return { krw, usd };
+}
+
+function groupCostBasisKrw(group: GroupedHolding): number | null {
+  if (group.costBasis == null) return null;
+  if (group.currency === "KRW") return group.costBasis;
+  if (group.currency === "USD") {
+    if (group.valueKrw != null && group.pnlKrw != null) return group.valueKrw - group.pnlKrw;
+    if (group.valueKrw != null && group.valueNative != null && group.valueNative > 0) {
+      return group.costBasis * (group.valueKrw / group.valueNative);
+    }
+  }
+  return null;
+}
+
+function summarizeHoldings(groups: GroupedHolding[]): Pick<AccountFilterOption, "totalValueKrw" | "costBasisKrw" | "pnlKrw" | "pnlRate" | "holdingCount"> {
+  let totalValueKrw = 0;
+  let costBasisKrw: number | null = null;
+  let pnlKrw: number | null = null;
+
+  for (const group of groups) {
+    if (group.valueKrw != null) totalValueKrw += group.valueKrw;
+    const groupCostKrw = groupCostBasisKrw(group);
+    if (groupCostKrw != null) costBasisKrw = (costBasisKrw ?? 0) + groupCostKrw;
+    if (group.pnlKrw != null) pnlKrw = (pnlKrw ?? 0) + group.pnlKrw;
+  }
+
+  const pnlRate =
+    pnlKrw != null && costBasisKrw != null && costBasisKrw > 0
+      ? pnlKrw / costBasisKrw
+      : null;
+
+  return {
+    totalValueKrw,
+    costBasisKrw,
+    pnlKrw,
+    pnlRate,
+    holdingCount: groups.length,
+  };
+}
+
+function optionFor(response: AccountPanelResponse, key: AccountFilterKey): AccountFilterOption {
+  if (key === "all") {
+    return {
+      key: "all",
+      label: "전체",
+      cashBalances: sumCash(response.accounts),
+      totalValueKrw: response.homeSummary.totalValueKrw,
+      costBasisKrw: response.homeSummary.costBasisKrw ?? null,
+      pnlKrw: response.homeSummary.pnlKrw ?? null,
+      pnlRate: response.homeSummary.pnlRate ?? null,
+      holdingCount: response.groupedHoldings.length,
+    };
+  }
+
+  const scoped = scopeGroupedToSource(response.groupedHoldings, key);
+  const summary = summarizeHoldings(scoped);
+  return {
+    key,
+    source: key,
+    label: sourceLabel(response, key),
+    cashBalances: sumCash(response.accounts.filter((a) => a.source === key)),
+    ...summary,
+  };
+}
+
+export function buildAccountFilterOptions(response: AccountPanelResponse): AccountFilterOption[] {
+  const sources = new Set<AccountSource>();
+  for (const account of response.accounts) {
+    sources.add(account.source);
+  }
+  for (const holding of response.groupedHoldings) {
+    for (const source of holding.includedSources) {
+      sources.add(source);
+    }
+  }
+
+  return [
+    optionFor(response, "all"),
+    ...Array.from(sources).map((source) => optionFor(response, source)),
+  ];
+}
+
+export function buildScopedPortfolioPanel(
+  response: AccountPanelResponse,
+  selectedKey: AccountFilterKey,
+): ScopedPortfolioPanel {
+  const options = buildAccountFilterOptions(response);
+  const selected = options.find((option) => option.key === selectedKey) ?? options[0]!;
+  const groupedHoldings = selected.key === "all"
+    ? response.groupedHoldings
+    : scopeGroupedToSource(response.groupedHoldings, selected.key);
+
+  return {
+    selected,
+    options,
+    groupedHoldings,
+    totalValueKrw: selected.totalValueKrw,
+    costBasisKrw: selected.costBasisKrw,
+    pnlKrw: selected.pnlKrw,
+    pnlRate: selected.pnlRate,
+    cashBalances: selected.cashBalances,
+  };
 }


### PR DESCRIPTION
## Summary
- add account cash card and source/account filter pills to the persistent /invest right panel
- scope holdings, total value, KRW cost basis, P&L, and empty states to the selected source
- preserve AccountPanelProvider payload reuse: local filter clicks do not refetch account-panel data
- keep changes frontend-only/read-only; no broker/order/watch/DB/scheduler paths touched

## Reviewer safety fix
- reviewer adjusted source-scoped cost basis and P&L math so USD holdings are converted to KRW before showing 투자원금/P&L summary values, avoiding native USD cost being formatted as KRW

## Test plan
- git diff --check
- cd frontend/invest && npm test -- --run src/__tests__/scopeHoldings.test.ts src/__tests__/RightRemotePanel.test.tsx
- cd frontend/invest && npm run typecheck
- cd frontend/invest && npm test -- --run
- cd frontend/invest && npm run build

Closes ROB-156
