### PR TITLE
fix(news): harden feed matcher URL metadata parsing

### DIFF
--- a/app/services/news_entity_matcher.py
+++ b/app/services/news_entity_matcher.py
@@ -91,6 +91,9 @@ _URL_METADATA_PREFIXES = (
     "source_url:",
     "url:",
     "fingerprint:",
+    "source:",
+    "feed_source:",
+    "publisher:",
 )
 _URL_SCHEME_PREFIXES = (f"{'http'}://", f"{'https'}://")
 
@@ -105,7 +108,13 @@ def _is_url_or_domain_token(token: str) -> bool:
     if any(lowered.startswith(prefix) for prefix in _URL_METADATA_PREFIXES):
         return True
     candidate = lowered if "://" in lowered else f"//{lowered}"
-    hostname = urlsplit(candidate).hostname or ""
+    try:
+        hostname = urlsplit(candidate).hostname or ""
+    except ValueError:
+        # Malformed URL/domain-like metadata should be dropped, not allowed to
+        # crash feed rendering. This includes bracket/IPv6-like fragments from
+        # scraped keywords or source/canonical URL metadata.
+        return True
     if "." not in hostname:
         return False
     labels = hostname.split(".")

--- a/tests/test_news_entity_matcher.py
+++ b/tests/test_news_entity_matcher.py
@@ -117,6 +117,7 @@ def test_match_for_article_drops_malformed_url_like_metadata_without_crashing():
             "canonical_url:https://finance.naver.com/[bad",
             "source_url:http://[malformed",
             "https://finance.naver.com/[broken",
+            "ftp://[malformed",
         ],
         market="kr",
     )

--- a/tests/test_news_entity_matcher.py
+++ b/tests/test_news_entity_matcher.py
@@ -109,6 +109,51 @@ def test_match_for_article_strips_url_metadata_before_matching(field: str):
 
 
 @pytest.mark.unit
+def test_match_for_article_drops_malformed_url_like_metadata_without_crashing():
+    matches = match_symbols_for_article(
+        title="마켓레이더 오전 자료",
+        summary="증권사 시장 요약",
+        keywords=[
+            "canonical_url:https://finance.naver.com/[bad",
+            "source_url:http://[malformed",
+            "https://finance.naver.com/[broken",
+        ],
+        market="kr",
+    )
+
+    assert not any(m.symbol == "035420" for m in matches)
+
+
+@pytest.mark.unit
+def test_match_for_article_keeps_naver_origin_metadata_separate_from_naver_corp():
+    matches = match_symbols_for_article(
+        title="반도체 업황 회복에 삼성전자 강세",
+        summary="증권사 시장 요약",
+        keywords=[
+            "source:browser_naver_research",
+            "canonical_url:https://finance.naver.com/research/company_read.naver?foo=[bad",
+        ],
+        market="kr",
+    )
+    symbols = {m.symbol for m in matches}
+
+    assert "005930" in symbols
+    assert "035420" not in symbols
+
+
+@pytest.mark.unit
+def test_match_for_article_still_matches_naver_when_article_mentions_company():
+    matches = match_symbols_for_article(
+        title="네이버 AI 투자 확대",
+        summary="플랫폼 기업 실적 개선 기대",
+        keywords=["canonical_url:https://finance.naver.com/news/mainnews.naver"],
+        market="kr",
+    )
+
+    assert any(m.symbol == "035420" for m in matches)
+
+
+@pytest.mark.unit
 def test_match_returns_sorted_unique_by_symbol():
     matches = match_symbols("Amazon Amazon AMZN keeps rising", market="us")
     amzn_matches = [m for m in matches if m.symbol == "AMZN"]

--- a/tests/test_news_entity_matcher.py
+++ b/tests/test_news_entity_matcher.py
@@ -117,7 +117,7 @@ def test_match_for_article_drops_malformed_url_like_metadata_without_crashing():
             "canonical_url:https://finance.naver.com/[bad",
             "source_url:http://[malformed",
             "https://finance.naver.com/[broken",
-            "ftp://[malformed",
+            "custom://[malformed",
         ],
         market="kr",
     )


### PR DESCRIPTION
## Summary
- Catch malformed URL/domain tokens in news entity matcher so /invest/api/feed/news does not 500 on invalid bracket/IPv6-like metadata
- Treat source/feed_source/publisher metadata as provenance, not entity text, to avoid source-origin NAVER false positives
- Add unit coverage for malformed metadata, NAVER provenance separation, and real NAVER article matching

## Test Plan
- uv run ruff check app/services/news_entity_matcher.py tests/test_news_entity_matcher.py
- uv run pytest --no-cov -q tests/test_news_entity_matcher.py tests/test_invest_feed_news_router.py
- git diff --check

Safety: no broker/order/watch/order-intent mutations; no DB update/delete/backfill; no scheduler changes; no secrets printed.