### PR TITLE
fix(invest): render calendar clusters by week

### DIFF
--- a/frontend/invest/src/__tests__/DesktopCalendarPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopCalendarPage.test.tsx
@@ -1,12 +1,13 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { vi, beforeEach, test, expect } from "vitest";
+import { vi, beforeEach, afterEach, test, expect } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { DesktopCalendarPage } from "../pages/desktop/DesktopCalendarPage";
 import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
 import * as calApi from "../api/calendar";
 import * as panelApi from "../api/accountPanel";
 import * as signalsApi from "../api/signals";
+import type { CalendarEvent, CalendarResponse } from "../types/calendar";
 
 function wrap(ui: React.ReactElement) {
   return (
@@ -18,7 +19,79 @@ function wrap(ui: React.ReactElement) {
   );
 }
 
+function event(overrides: Partial<CalendarEvent> & Pick<CalendarEvent, "eventId" | "title" | "market" | "eventType">): CalendarEvent {
+  return {
+    source: "fixture",
+    relatedSymbols: [],
+    relation: "none",
+    badges: [],
+    ...overrides,
+  };
+}
+
+const calendarFixture: CalendarResponse = {
+  tab: "all",
+  fromDate: "2026-05-11",
+  toDate: "2026-05-17",
+  asOf: "2026-05-11T03:00:00.000Z",
+  days: [
+    {
+      date: "2026-05-11",
+      events: [
+        event({
+          eventId: "evt-aapl-direct",
+          title: "AAPL earnings direct",
+          market: "us",
+          eventType: "earnings",
+          eventTimeLocal: "오후 9시 발표 예정",
+        }),
+      ],
+      clusters: [],
+    },
+    { date: "2026-05-12", events: [], clusters: [] },
+    {
+      date: "2026-05-13",
+      events: [],
+      clusters: [
+        {
+          clusterId: "cluster-us-earnings-2026-05-13",
+          label: "US earnings",
+          eventType: "earnings",
+          market: "us",
+          eventCount: 327,
+          topEvents: [
+            event({ eventId: "evt-aapl-top", title: "AAPL earnings", market: "us", eventType: "earnings" }),
+            event({ eventId: "evt-msft-top", title: "MSFT earnings", market: "us", eventType: "earnings" }),
+          ],
+        },
+      ],
+    },
+    { date: "2026-05-14", events: [], clusters: [] },
+    {
+      date: "2026-05-15",
+      events: [],
+      clusters: [
+        {
+          clusterId: "cluster-global-macro-2026-05-15",
+          label: "Global macro",
+          eventType: "economic",
+          market: "global",
+          eventCount: 4,
+          topEvents: [
+            event({ eventId: "evt-cpi", title: "US CPI", market: "us", eventType: "economic" }),
+          ],
+        },
+      ],
+    },
+    { date: "2026-05-16", events: [], clusters: [] },
+    { date: "2026-05-17", events: [], clusters: [] },
+  ],
+  meta: { warnings: [] },
+};
+
 beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["Date"] });
+  vi.setSystemTime(new Date("2026-05-11T12:00:00+09:00"));
   vi.spyOn(panelApi, "fetchAccountPanel").mockResolvedValue({
     homeSummary: { includedSources: [], excludedSources: [], totalValueKrw: 0 },
     accounts: [], groupedHoldings: [], watchSymbols: [], sourceVisuals: [],
@@ -27,25 +100,73 @@ beforeEach(() => {
   vi.spyOn(signalsApi, "fetchSignals").mockResolvedValue({
     tab: "kr", asOf: new Date().toISOString(), items: [], meta: { warnings: [] },
   });
-  vi.spyOn(calApi, "fetchCalendar").mockResolvedValue({
-    tab: "all", fromDate: "2026-05-04", toDate: "2026-05-10",
-    asOf: new Date().toISOString(),
-    days: Array.from({ length: 7 }).map((_, i) => ({
-      date: `2026-05-${String(4 + i).padStart(2, "0")}`,
-      events: i === 0 ? [{ eventId: "e1", title: "AAPL earnings", market: "us", eventType: "earnings", source: "finnhub", relatedSymbols: [], relation: "none", badges: [] }] : [],
-      clusters: [],
-    })),
-    meta: { warnings: [] },
-  });
+  vi.spyOn(calApi, "fetchCalendar").mockResolvedValue(calendarFixture);
   vi.spyOn(calApi, "fetchWeeklySummary").mockResolvedValue({
-    weekStart: "2026-05-04", asOf: new Date().toISOString(),
+    weekStart: "2026-05-11", asOf: new Date().toISOString(),
     sections: [], partial: false, missingDates: [],
   });
 });
 
-test("renders week rail and weekly summary toggle", async () => {
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+test("fetches target week and renders week rail and weekly summary toggle", async () => {
+  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
   render(wrap(<DesktopCalendarPage />));
+
+  await waitFor(() => {
+    expect(calApi.fetchCalendar).toHaveBeenCalledWith({ fromDate: "2026-05-11", toDate: "2026-05-17", tab: "all" });
+  });
   await waitFor(() => expect(screen.getAllByTestId(/^day-\d{4}-/)).toHaveLength(7));
-  await userEvent.click(screen.getByTestId("open-weekly-summary"));
+
+  await user.click(screen.getByTestId("open-weekly-summary"));
   await waitFor(() => expect(screen.getByTestId("weekly-summary")).toBeInTheDocument());
+});
+
+test("week strip sums cluster eventCount", async () => {
+  render(wrap(<DesktopCalendarPage />));
+
+  await waitFor(() => expect(screen.getByTestId("day-2026-05-13")).toBeInTheDocument());
+  expect(within(screen.getByTestId("day-2026-05-13")).getByText("327")).toBeInTheDocument();
+});
+
+test("renders cluster-only days in the week grouped list", async () => {
+  render(wrap(<DesktopCalendarPage />));
+
+  const clusterDay = await screen.findByTestId("calendar-day-section-2026-05-13");
+  expect(clusterDay).toHaveAttribute("data-selected", "false");
+  expect(within(clusterDay).getByTestId("calendar-cluster")).toBeInTheDocument();
+  expect(within(clusterDay).getByText("미국 실적 발표 327건")).toBeInTheDocument();
+  expect(within(clusterDay).getByText(/AAPL earnings/)).toBeInTheDocument();
+  expect(within(clusterDay).getByText(/MSFT earnings/)).toBeInTheDocument();
+  expect(screen.queryByTestId("calendar-empty")).not.toBeInTheDocument();
+});
+
+test("renders direct events and clusters from different dates together", async () => {
+  render(wrap(<DesktopCalendarPage />));
+
+  expect(await screen.findByTestId("calendar-day-section-2026-05-11")).toBeInTheDocument();
+  expect(await screen.findByTestId("calendar-day-section-2026-05-13")).toBeInTheDocument();
+  expect(screen.getByText("AAPL earnings direct")).toBeInTheDocument();
+  expect(screen.getByText("미국 실적 발표 327건")).toBeInTheDocument();
+});
+
+test("type and region filters apply to clusters", async () => {
+  const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+  render(wrap(<DesktopCalendarPage />));
+
+  expect(await screen.findByText("미국 실적 발표 327건")).toBeInTheDocument();
+
+  await user.click(screen.getByRole("button", { name: "경제지표" }));
+  expect(screen.queryByText("미국 실적 발표 327건")).not.toBeInTheDocument();
+  expect(screen.getByText("글로벌 경제지표 4건")).toBeInTheDocument();
+
+  await user.click(screen.getByRole("button", { name: "실적" }));
+  expect(screen.getByText("미국 실적 발표 327건")).toBeInTheDocument();
+  expect(screen.queryByText("글로벌 경제지표 4건")).not.toBeInTheDocument();
+
+  await user.click(screen.getByRole("button", { name: "국내" }));
+  expect(screen.getByTestId("calendar-empty")).toHaveTextContent("선택한 필터에 해당하는 이번 주 일정이 없습니다.");
 });

--- a/frontend/invest/src/components/calendar/ClusterRow.tsx
+++ b/frontend/invest/src/components/calendar/ClusterRow.tsx
@@ -1,0 +1,65 @@
+import type { CalendarClusterVM } from "./vm";
+import { RegionBadge } from "./RegionBadge";
+
+export function ClusterRow({ cluster }: { cluster: CalendarClusterVM }) {
+  const preview = cluster.topEvents.map((event) => event.title).join(" · ");
+
+  return (
+    <article
+      data-testid="calendar-cluster"
+      data-cluster-id={cluster.id}
+      data-event-type={cluster.type}
+      data-region={cluster.region}
+      style={{
+        display: "grid",
+        gridTemplateColumns: "44px minmax(0, 1fr) 76px 76px 76px",
+        alignItems: "center",
+        gap: 10,
+        padding: "12px",
+        borderRadius: 10,
+        background: "var(--surface-2)",
+      }}
+    >
+      <div
+        style={{
+          fontSize: 12,
+          fontWeight: 700,
+          color: "var(--fg-1)",
+          fontFeatureSettings: '"tnum"',
+        }}
+      >
+        {cluster.monthDay}
+      </div>
+      <div style={{ minWidth: 0, gridColumn: "2 / 6" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, minWidth: 0 }}>
+          <RegionBadge region={cluster.region} />
+          <span
+            style={{
+              fontSize: 14,
+              fontWeight: 700,
+              color: "var(--fg)",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+              minWidth: 0,
+            }}
+          >
+            {cluster.title}
+          </span>
+        </div>
+        <div
+          style={{
+            fontSize: 12,
+            color: "var(--fg-3)",
+            marginTop: 4,
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {preview ? `${preview}${cluster.count > cluster.topEvents.length ? " 외" : ""}` : "상세 일정 묶음"}
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/frontend/invest/src/components/calendar/WeekDateStrip.tsx
+++ b/frontend/invest/src/components/calendar/WeekDateStrip.tsx
@@ -1,5 +1,5 @@
 import type { CalendarDay } from "../../types/calendar";
-import { dayOfWeekLabel } from "./vm";
+import { calendarDayEventCount, dayOfWeekLabel } from "./vm";
 
 export function WeekDateStrip({
   days,
@@ -27,7 +27,7 @@ export function WeekDateStrip({
         const dow = dayOfWeekLabel(d.date);
         const isSelected = d.date === selectedDate;
         const isToday = today != null && d.date === today;
-        const eventCount = d.events.length + d.clusters.length;
+        const eventCount = calendarDayEventCount(d);
         return (
           <button
             key={d.date}

--- a/frontend/invest/src/components/calendar/vm.ts
+++ b/frontend/invest/src/components/calendar/vm.ts
@@ -1,4 +1,4 @@
-import type { CalendarEvent } from "../../types/calendar";
+import type { CalendarCluster, CalendarDay, CalendarEvent } from "../../types/calendar";
 
 export type DisplayEventType = "earnings" | "macro" | "other";
 export type DisplayRegion = "kr" | "us";
@@ -19,6 +19,18 @@ export interface CalendarEventVM {
   previous: string | null;
   own: DisplayOwnership;
   badges: string[];
+}
+
+export interface CalendarClusterVM {
+  id: string;
+  date: string;
+  dayOfMonth: number;
+  monthDay: string;
+  type: DisplayEventType;
+  region: DisplayRegion;
+  title: string;
+  count: number;
+  topEvents: CalendarEventVM[];
 }
 
 export function mapEventType(eventType: CalendarEvent["eventType"]): DisplayEventType {
@@ -57,6 +69,48 @@ export function toEventVM(event: CalendarEvent, date: string): CalendarEventVM {
     own: mapOwnership(event),
     badges: event.badges,
   };
+}
+
+export function calendarDayEventCount(day: CalendarDay): number {
+  return day.events.length + day.clusters.reduce((sum, cluster) => sum + cluster.eventCount, 0);
+}
+
+export function toClusterVM(cluster: CalendarCluster, date: string): CalendarClusterVM {
+  const day = Number.parseInt(date.slice(8, 10), 10);
+  const month = Number.parseInt(date.slice(5, 7), 10);
+  const type = mapEventType(cluster.eventType);
+  const region = mapMarketToRegion(cluster.market);
+  const count = cluster.eventCount;
+  return {
+    id: cluster.clusterId,
+    date,
+    dayOfMonth: day,
+    monthDay: `${month}/${day}`,
+    type,
+    region,
+    title: formatClusterTitle({ label: cluster.label, eventType: cluster.eventType, market: cluster.market, count }),
+    count,
+    topEvents: cluster.topEvents.map((event) => toEventVM(event, date)),
+  };
+}
+
+function formatClusterTitle({
+  label,
+  eventType,
+  market,
+  count,
+}: {
+  label: string;
+  eventType: CalendarCluster["eventType"];
+  market: CalendarCluster["market"];
+  count: number;
+}): string {
+  if (eventType === "earnings" && market === "us") return `미국 실적 발표 ${count}건`;
+  if (eventType === "earnings" && market === "kr") return `국내 실적 발표 ${count}건`;
+  if (eventType === "economic" && market === "global") return `글로벌 경제지표 ${count}건`;
+  if (eventType === "economic") return `해외 경제지표 ${count}건`;
+  if (eventType === "disclosure" && market === "kr") return `국내 공시 ${count}건`;
+  return `${label} ${count}건`;
 }
 
 export function computeWeekLabel(fromDate: string): string {

--- a/frontend/invest/src/desktop/DesktopShell.tsx
+++ b/frontend/invest/src/desktop/DesktopShell.tsx
@@ -5,18 +5,23 @@ export function DesktopShell({
   left,
   center,
   right,
+  leftColumnWidth = 220,
 }: {
   left?: ReactNode;
   center: ReactNode;
   right: ReactNode;
+  leftColumnWidth?: number | string;
 }) {
+  const resolvedLeftColumnWidth =
+    typeof leftColumnWidth === "number" ? `${leftColumnWidth}px` : leftColumnWidth;
+
   return (
     <div data-testid="desktop-shell" style={{ minHeight: "100vh", background: "var(--bg-alt)", color: "var(--fg)" }}>
       <DesktopHeader />
       <div
         style={{
           display: "grid",
-          gridTemplateColumns: left ? "220px minmax(0,1fr) 320px" : "minmax(0,1fr) 320px",
+          gridTemplateColumns: left ? `${resolvedLeftColumnWidth} minmax(0,1fr) 320px` : "minmax(0,1fr) 320px",
           gap: 24,
           padding: "24px 28px 64px",
           maxWidth: 1440,

--- a/frontend/invest/src/pages/desktop/DesktopCalendarPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCalendarPage.tsx
@@ -8,11 +8,15 @@ import { Card, Icon } from "../../ds";
 import { WeekDateStrip } from "../../components/calendar/WeekDateStrip";
 import { AIWeeklyCard } from "../../components/calendar/AIWeeklyCard";
 import { EventRow } from "../../components/calendar/EventRow";
+import { ClusterRow } from "../../components/calendar/ClusterRow";
 import { EmptyEventState } from "../../components/calendar/EmptyEventState";
 import { EventDetailModal } from "../../components/calendar/EventDetailModal";
 import {
   computeWeekLabel,
+  dayOfWeekLabel,
+  toClusterVM,
   toEventVM,
+  type CalendarClusterVM,
   type CalendarEventVM,
   type DisplayEventType,
   type DisplayRegion,
@@ -28,11 +32,23 @@ function startOfWeek(d: Date): Date {
 }
 
 function fmt(d: Date): string {
-  return d.toISOString().slice(0, 10);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }
 
 type TypeFilter = "all" | DisplayEventType;
 type RegionFilter = "all" | DisplayRegion;
+
+type CalendarDaySection = {
+  date: string;
+  label: string;
+  isSelected: boolean;
+  events: CalendarEventVM[];
+  clusters: CalendarClusterVM[];
+  totalCount: number;
+};
 
 export function CalendarRoute() {
   return useViewport() === "mobile" ? <MobileCalendarPage /> : <DesktopCalendarPage />;
@@ -94,166 +110,196 @@ export function DesktopCalendarPage() {
   }, [showSummary, weekStart]);
 
   const days = calendar?.days ?? [];
-  const allEventsVM: CalendarEventVM[] = useMemo(() => {
-    const out: CalendarEventVM[] = [];
+  const daySections: CalendarDaySection[] = useMemo(() => {
+    const sections: CalendarDaySection[] = [];
     for (const d of days) {
-      for (const e of d.events) out.push(toEventVM(e, d.date));
+      const events = d.events
+        .map((event) => toEventVM(event, d.date))
+        .filter((event) => matchesFilters(event, typeFilter, regionFilter));
+      const clusters = d.clusters
+        .map((cluster) => toClusterVM(cluster, d.date))
+        .filter((cluster) => matchesFilters(cluster, typeFilter, regionFilter));
+      if (events.length === 0 && clusters.length === 0) continue;
+      const dayOfMonth = Number.parseInt(d.date.slice(8, 10), 10);
+      sections.push({
+        date: d.date,
+        label: `${dayOfMonth} ${dayOfWeekLabel(d.date)}`,
+        isSelected: d.date === selectedDate,
+        events,
+        clusters,
+        totalCount: events.length + clusters.reduce((sum, cluster) => sum + cluster.count, 0),
+      });
     }
-    return out;
-  }, [days]);
-
-  const filteredEvents = useMemo(() => {
-    return allEventsVM.filter((e) => {
-      if (typeFilter !== "all" && e.type !== typeFilter) return false;
-      if (regionFilter !== "all" && e.region !== regionFilter) return false;
-      return true;
-    });
-  }, [allEventsVM, typeFilter, regionFilter]);
-
-  const eventsBySelectedDate = useMemo(
-    () => filteredEvents.filter((e) => e.date === selectedDate),
-    [filteredEvents, selectedDate],
-  );
+    return sections;
+  }, [days, regionFilter, selectedDate, typeFilter]);
 
   const weekLabel = computeWeekLabel(fmt(weekStart));
 
   return (
     <>
       <DesktopShell
-      left={
-        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-          <Card style={{ padding: 16 }}>
-            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
-              <div style={{ fontSize: 14, fontWeight: 700, letterSpacing: "-0.01em" }}>{weekLabel}</div>
-              <div style={{ display: "flex", gap: 4 }}>
-                <button
-                  type="button"
-                  aria-label="이전 주"
-                  data-testid="calendar-prev-week"
-                  onClick={() =>
-                    setWeekStart((w) => {
-                      const n = new Date(w);
-                      n.setDate(n.getDate() - 7);
-                      return n;
-                    })
-                  }
-                  style={navBtnStyle}
-                >
-                  <Icon name="chev" size={14} />
-                </button>
-                <button
-                  type="button"
-                  aria-label="다음 주"
-                  data-testid="calendar-next-week"
-                  onClick={() =>
-                    setWeekStart((w) => {
-                      const n = new Date(w);
-                      n.setDate(n.getDate() + 7);
-                      return n;
-                    })
-                  }
-                  style={{ ...navBtnStyle, transform: "scaleX(-1)" }}
-                >
-                  <Icon name="chev" size={14} />
-                </button>
+        leftColumnWidth={300}
+        left={
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <Card style={{ padding: 16 }}>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
+                <div style={{ fontSize: 14, fontWeight: 700, letterSpacing: "-0.01em" }}>{weekLabel}</div>
+                <div style={{ display: "flex", gap: 4 }}>
+                  <button
+                    type="button"
+                    aria-label="이전 주"
+                    data-testid="calendar-prev-week"
+                    onClick={() =>
+                      setWeekStart((w) => {
+                        const n = new Date(w);
+                        n.setDate(n.getDate() - 7);
+                        return n;
+                      })
+                    }
+                    style={navBtnStyle}
+                  >
+                    <Icon name="chev" size={14} />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label="다음 주"
+                    data-testid="calendar-next-week"
+                    onClick={() =>
+                      setWeekStart((w) => {
+                        const n = new Date(w);
+                        n.setDate(n.getDate() + 7);
+                        return n;
+                      })
+                    }
+                    style={{ ...navBtnStyle, transform: "scaleX(-1)" }}
+                  >
+                    <Icon name="chev" size={14} />
+                  </button>
+                </div>
               </div>
-            </div>
-            <WeekDateStrip
-              days={days}
-              selectedDate={selectedDate}
-              onSelect={setSelectedDate}
-              today={today}
+              <WeekDateStrip
+                days={days}
+                selectedDate={selectedDate}
+                onSelect={setSelectedDate}
+                today={today}
+              />
+            </Card>
+
+            <AIWeeklyCard
+              summary={summary}
+              loading={summaryLoading}
+              onOpen={() => setShowSummary(true)}
+              compact
             />
-          </Card>
-
-          <AIWeeklyCard
-            summary={summary}
-            loading={summaryLoading}
-            onOpen={() => setShowSummary(true)}
-            compact
-          />
-        </div>
-      }
-      center={
-        <>
-          <header>
-            <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800, letterSpacing: "-0.02em" }}>캘린더</h1>
-            <p style={{ margin: "4px 0 0", fontSize: 13, color: "var(--fg-3)" }}>
-              실적·경제지표·주요 이벤트를 한 주 단위로 확인하세요.
-            </p>
-          </header>
-
-          <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
-            <FilterGroup>
-              {([
-                ["all", "전체"],
-                ["macro", "경제지표"],
-                ["earnings", "실적"],
-              ] as const).map(([k, l]) => (
-                <SegPill key={k} on={typeFilter === k} onClick={() => setTypeFilter(k)}>
-                  {l}
-                </SegPill>
-              ))}
-            </FilterGroup>
-            <FilterGroup>
-              {([
-                ["all", "전체"],
-                ["kr", "국내"],
-                ["us", "해외"],
-              ] as const).map(([k, l]) => (
-                <SegPill key={k} on={regionFilter === k} onClick={() => setRegionFilter(k)}>
-                  {l}
-                </SegPill>
-              ))}
-            </FilterGroup>
           </div>
+        }
+        center={
+          <>
+            <header>
+              <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800, letterSpacing: "-0.02em" }}>캘린더</h1>
+              <p style={{ margin: "4px 0 0", fontSize: 13, color: "var(--fg-3)" }}>
+                실적·경제지표·주요 이벤트를 한 주 단위로 확인하세요.
+              </p>
+            </header>
 
-          {calendarErr && <div style={{ color: "var(--danger)" }}>오류: {calendarErr}</div>}
+            <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+              <FilterGroup>
+                {([
+                  ["all", "전체"],
+                  ["macro", "경제지표"],
+                  ["earnings", "실적"],
+                ] as const).map(([k, l]) => (
+                  <SegPill key={k} on={typeFilter === k} onClick={() => setTypeFilter(k)}>
+                    {l}
+                  </SegPill>
+                ))}
+              </FilterGroup>
+              <FilterGroup>
+                {([
+                  ["all", "전체"],
+                  ["kr", "국내"],
+                  ["us", "해외"],
+                ] as const).map(([k, l]) => (
+                  <SegPill key={k} on={regionFilter === k} onClick={() => setRegionFilter(k)}>
+                    {l}
+                  </SegPill>
+                ))}
+              </FilterGroup>
+            </div>
 
-          <Card style={{ padding: "16px 6px" }}>
-            <div
-              style={{
-                display: "grid",
-                gridTemplateColumns: "44px minmax(0, 1fr) 76px 76px 76px",
-                alignItems: "center",
-                gap: 10,
-                padding: "0 14px 10px",
-                borderBottom: "1px solid var(--divider)",
-              }}
-            >
+            {calendarErr && <div style={{ color: "var(--danger)" }}>오류: {calendarErr}</div>}
+
+            <Card style={{ padding: "16px 6px" }}>
               <div
                 style={{
-                  fontSize: 14,
-                  fontWeight: 800,
-                  color: "var(--fg)",
-                  letterSpacing: "-0.01em",
-                  gridColumn: "1 / 3",
+                  display: "grid",
+                  gridTemplateColumns: "44px minmax(0, 1fr) 76px 76px 76px",
+                  alignItems: "center",
+                  gap: 10,
+                  padding: "0 14px 10px",
+                  borderBottom: "1px solid var(--divider)",
                 }}
               >
-                {selectedDate}
+                <div
+                  style={{
+                    fontSize: 14,
+                    fontWeight: 800,
+                    color: "var(--fg)",
+                    letterSpacing: "-0.01em",
+                    gridColumn: "1 / 3",
+                  }}
+                >
+                  {weekLabel} 일정
+                </div>
+                <div style={{ textAlign: "right", fontSize: 11, fontWeight: 600, color: "var(--fg-3)", letterSpacing: "0.04em" }}>
+                  발표
+                </div>
+                <div style={{ textAlign: "right", fontSize: 11, fontWeight: 600, color: "var(--fg-3)", letterSpacing: "0.04em" }}>
+                  예측
+                </div>
+                <div style={{ textAlign: "right", fontSize: 11, fontWeight: 600, color: "var(--fg-3)", letterSpacing: "0.04em" }}>
+                  이전
+                </div>
               </div>
-              <div style={{ textAlign: "right", fontSize: 11, fontWeight: 600, color: "var(--fg-3)", letterSpacing: "0.04em" }}>
-                발표
-              </div>
-              <div style={{ textAlign: "right", fontSize: 11, fontWeight: 600, color: "var(--fg-3)", letterSpacing: "0.04em" }}>
-                예측
-              </div>
-              <div style={{ textAlign: "right", fontSize: 11, fontWeight: 600, color: "var(--fg-3)", letterSpacing: "0.04em" }}>
-                이전
-              </div>
-            </div>
 
-            <div data-testid="day-events" style={{ paddingTop: 4 }}>
-              {eventsBySelectedDate.length === 0 ? (
-                <EmptyEventState message="해당 날짜에는 일정이 없습니다." />
-              ) : (
-                eventsBySelectedDate.map((ev) => <EventRow key={ev.id} ev={ev} />)
-              )}
-            </div>
-          </Card>
-        </>
-      }
-      right={<RightRemotePanel />}
+              <div data-testid="day-events" style={{ paddingTop: 4 }}>
+                {daySections.length === 0 ? (
+                  <EmptyEventState message="선택한 필터에 해당하는 이번 주 일정이 없습니다." />
+                ) : (
+                  daySections.map((section) => (
+                    <section
+                      key={section.date}
+                      data-testid={`calendar-day-section-${section.date}`}
+                      data-selected={section.isSelected ? "true" : "false"}
+                      style={{ padding: "12px 8px 4px" }}
+                    >
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "baseline",
+                          gap: 8,
+                          padding: "0 6px 8px",
+                        }}
+                      >
+                        <h2 style={{ margin: 0, fontSize: 15, fontWeight: 800, color: "var(--fg)" }}>
+                          {section.label}
+                        </h2>
+                        <span style={{ fontSize: 12, color: "var(--fg-3)", fontFeatureSettings: '"tnum"' }}>
+                          {section.date} · {section.totalCount}건
+                        </span>
+                      </div>
+                      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                        {section.clusters.map((cluster) => <ClusterRow key={cluster.id} cluster={cluster} />)}
+                        {section.events.map((ev) => <EventRow key={ev.id} ev={ev} />)}
+                      </div>
+                    </section>
+                  ))
+                )}
+              </div>
+            </Card>
+          </>
+        }
+        right={<RightRemotePanel />}
       />
       {showSummary && (
         <EventDetailModal
@@ -265,6 +311,16 @@ export function DesktopCalendarPage() {
       )}
     </>
   );
+}
+
+function matchesFilters(
+  item: { type: DisplayEventType; region: DisplayRegion },
+  typeFilter: TypeFilter,
+  regionFilter: RegionFilter,
+): boolean {
+  if (typeFilter !== "all" && item.type !== typeFilter) return false;
+  if (regionFilter !== "all" && item.region !== regionFilter) return false;
+  return true;
 }
 
 const navBtnStyle: React.CSSProperties = {


### PR DESCRIPTION
## Summary
- Fixes `/invest/calendar` desktop shell overflow by allowing a calendar-specific wider left column while preserving the default desktop shell width for other pages.
- Renders backend-provided `CalendarDay.clusters` and `topEvents` in week-grouped day sections instead of a selected-day-only event list.
- Corrects day strip counts to display `events.length + sum(cluster.eventCount)`, so high-volume cluster days are visible.
- Adds ROB-158 frontend regression coverage for the 2026-05-11..2026-05-17 target week, including a cluster-only US earnings day with 327 events and filter behavior.

Linear: ROB-158

## Backend / data-source note
Immediate backend/view-model changes were not required: the existing API contract already exposes `clusters`, `eventCount`, and `topEvents` for calendar days.

Deferred P3 follow-ups requiring separate approval:
- ForexFactory weekly cache/backfill design.
- Korean earnings schedule source.
- Earnings-call/richer event details.

## Safety boundaries
- No DB mutation, UPDATE/DELETE, backfill, or data migration.
- No scheduler or ingestion automation changes.
- No broker/order/watch/order-intent/live/paper execution paths touched.

## Test plan
- `cd frontend/invest && npm test -- --run src/__tests__/DesktopCalendarPage.test.tsx`
- `cd frontend/invest && npm run typecheck`
- `cd frontend/invest && npm run build`

Closes ROB-158


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clustered event grouping in calendar display with region badges and event previews
  * Calendar now shows all days of the week with organized event sections instead of single-date view
  * Enhanced filtering capabilities that apply to both individual events and clustered events
  * Improved event count aggregation and day labeling display

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/739)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->