### PR TITLE
fix(news): harden feed matcher malformed URL tokens

### DIFF
--- a/app/services/news_entity_matcher.py
+++ b/app/services/news_entity_matcher.py
@@ -91,6 +91,9 @@ _URL_METADATA_PREFIXES = (
     "source_url:",
     "url:",
     "fingerprint:",
+    "source:",
+    "feed_source:",
+    "publisher:",
 )
 _URL_SCHEME_PREFIXES = (f"{'http'}://", f"{'https'}://")
 
@@ -105,7 +108,13 @@ def _is_url_or_domain_token(token: str) -> bool:
     if any(lowered.startswith(prefix) for prefix in _URL_METADATA_PREFIXES):
         return True
     candidate = lowered if "://" in lowered else f"//{lowered}"
-    hostname = urlsplit(candidate).hostname or ""
+    try:
+        hostname = urlsplit(candidate).hostname or ""
+    except ValueError:
+        # Malformed URL/domain-like metadata should be dropped, not allowed to
+        # crash feed rendering. This includes bracket/IPv6-like fragments from
+        # scraped keywords or source/canonical URL metadata.
+        return True
     if "." not in hostname:
         return False
     labels = hostname.split(".")

--- a/tests/test_invest_feed_news_router.py
+++ b/tests/test_invest_feed_news_router.py
@@ -394,6 +394,48 @@ async def test_feed_news_url_metadata_false_positive_stays_suppressed(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_feed_news_malformed_bracket_token_does_not_crash_matching(
+    monkeypatch,
+) -> None:
+    from app.services.invest_view_model import feed_news_service as svc
+
+    db = MagicMock()
+    scalar_result = MagicMock()
+    scalar_result.scalars.return_value.all.return_value = [
+        _fake_article(
+            id=204,
+            market="kr",
+            symbol=None,
+            title="삼성전자 [malformed",
+            summary="증권사 시장 요약 foo[bar.com",
+            keywords=["[broken", "canonical_url:https://finance.naver.com/[bad"],
+        ),
+    ]
+    summary_result = MagicMock()
+    summary_result.all.return_value = []
+    db.execute = AsyncMock(
+        side_effect=[scalar_result, summary_result, _empty_related_result()]
+    )
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
+    )
+
+    resp = await svc.build_feed_news(
+        db=db,
+        resolver=RelationResolver(watch={("kr", "005930")}),
+        tab="kr",
+        limit=30,
+        cursor=None,
+    )
+
+    assert [(s.market, s.symbol) for s in resp.items[0].relatedSymbols] == [
+        ("kr", "005930")
+    ]
+    assert resp.items[0].relatedSymbols[0].relation == "watchlist"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_feed_news_default_does_not_call_quote_provider(monkeypatch) -> None:
     from app.services.invest_view_model import feed_news_service as svc
 

--- a/tests/test_news_entity_matcher.py
+++ b/tests/test_news_entity_matcher.py
@@ -117,6 +117,8 @@ def test_match_for_article_drops_malformed_url_like_metadata_without_crashing():
             "canonical_url:https://finance.naver.com/[bad",
             "source_url:http://[malformed",
             "https://finance.naver.com/[broken",
+            "[malformed",
+            "foo[bar.com",
         ],
         market="kr",
     )

--- a/tests/test_news_entity_matcher.py
+++ b/tests/test_news_entity_matcher.py
@@ -109,6 +109,51 @@ def test_match_for_article_strips_url_metadata_before_matching(field: str):
 
 
 @pytest.mark.unit
+def test_match_for_article_drops_malformed_url_like_metadata_without_crashing():
+    matches = match_symbols_for_article(
+        title="마켓레이더 오전 자료",
+        summary="증권사 시장 요약",
+        keywords=[
+            "canonical_url:https://finance.naver.com/[bad",
+            "source_url:http://[malformed",
+            "https://finance.naver.com/[broken",
+        ],
+        market="kr",
+    )
+
+    assert not any(m.symbol == "035420" for m in matches)
+
+
+@pytest.mark.unit
+def test_match_for_article_keeps_naver_origin_metadata_separate_from_naver_corp():
+    matches = match_symbols_for_article(
+        title="반도체 업황 회복에 삼성전자 강세",
+        summary="증권사 시장 요약",
+        keywords=[
+            "source:browser_naver_research",
+            "canonical_url:https://finance.naver.com/research/company_read.naver?foo=[bad",
+        ],
+        market="kr",
+    )
+    symbols = {m.symbol for m in matches}
+
+    assert "005930" in symbols
+    assert "035420" not in symbols
+
+
+@pytest.mark.unit
+def test_match_for_article_still_matches_naver_when_article_mentions_company():
+    matches = match_symbols_for_article(
+        title="네이버 AI 투자 확대",
+        summary="플랫폼 기업 실적 개선 기대",
+        keywords=["canonical_url:https://finance.naver.com/news/mainnews.naver"],
+        market="kr",
+    )
+
+    assert any(m.symbol == "035420" for m in matches)
+
+
+@pytest.mark.unit
 def test_match_returns_sorted_unique_by_symbol():
     matches = match_symbols("Amazon Amazon AMZN keeps rising", market="us")
     amzn_matches = [m for m in matches if m.symbol == "AMZN"]


### PR DESCRIPTION
## Summary
- Hardens `news_entity_matcher._is_url_or_domain_token()` so malformed bracket / IPv6-like URL tokens are dropped instead of crashing feed rendering.
- Adds regression coverage for raw malformed bracket tokens in the entity matcher and `build_feed_news()` path.
- Preserves safe degradation: malformed URL/domain-like metadata is ignored while valid article mentions still match related symbols.

## Verification
- RED check: temporarily restored the pre-fix matcher and confirmed both malformed-token regression tests failed with `ValueError: Invalid IPv6 URL`.
- `PUBLIC_API_PATHS='[]' uv run --group test python -m pytest tests/test_news_entity_matcher.py tests/test_invest_feed_news_router.py -q` (34 passed, 2 known Pydantic deprecation warnings)
- `PUBLIC_API_PATHS='[]' uv run ruff format --check app/ tests/`
- `PUBLIC_API_PATHS='[]' uv run ruff check app/ tests/`
- `PUBLIC_API_PATHS='[]' uv run ty check app/ --error-on-warning`
- `git diff --check`

## Safety / non-actions
- No broker/order/watch/live/paper execution.
- No DB mutation/update/delete/backfill.
- No scheduler changes.
- No order/deposit/withdrawal/FX/watch-intent actions.
- No credentials, tokens, or connection strings printed.

## Follow-up
- After merge/deploy, rerun K4 read-only production smoke for `/invest/api/feed/news` and `/trading/api/news-issues` to confirm the production 500 is gone.
