### PR TITLE
fix(invest): unify feed news right panel

### DIFF
--- a/frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx
@@ -104,6 +104,10 @@ beforeEach(() => {
 test("renders dense news rows and reacts to tab change", async () => {
   renderPage();
 
+  expect(await screen.findByTestId("right-remote-panel")).toBeInTheDocument();
+  expect(screen.getByRole("tab", { name: "내 투자" })).toHaveAttribute("aria-selected", "true");
+  expect(screen.getByRole("tab", { name: "관심" })).toBeInTheDocument();
+
   const row = await screen.findByTestId("feed-item");
   expect(row).toHaveTextContent("n1");
   expect(row).toHaveTextContent("Reuters");

--- a/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { DesktopShell } from "../../desktop/DesktopShell";
-import { RightAccountPanel } from "../../desktop/RightAccountPanel";
-import { useAccountPanel } from "../../desktop/useAccountPanel";
+import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useViewport } from "../../hooks/useViewport";
 import { fetchFeedNews } from "../../api/feedNews";
 import type { FeedNewsResponse, FeedTab } from "../../types/feedNews";
@@ -22,7 +21,6 @@ export function FeedNewsRoute() {
 }
 
 export function DesktopFeedNewsPage() {
-  const panel = useAccountPanel();
   const [tab, setTab] = useState<FeedTab>("top");
   const [data, setData] = useState<FeedNewsResponse | undefined>();
   const [err, setErr] = useState<string | undefined>();
@@ -87,7 +85,7 @@ export function DesktopFeedNewsPage() {
           </div>
         </>
       }
-      right={<RightAccountPanel data={panel.data} loading={panel.loading} error={panel.error} onRefresh={panel.reload} />}
+      right={<RightRemotePanel />}
     />
   );
 }


### PR DESCRIPTION
## Summary
- use the same persistent Toss-like RightRemotePanel on /invest/feed/news as /invest/discover
- remove the page-local legacy RightAccountPanel path from feed/news
- add a regression assertion that the feed/news page renders the shared right panel tabs

## Verification
- npm run test -- --run src/__tests__/DesktopFeedNewsPage.test.tsx src/__tests__/RightRemotePanel.test.tsx
- npm run typecheck
- npm run build

## Safety
- frontend-only display/shell change
- no broker/order/watch/live/paper execution
- no DB mutation or scheduler change