### PR TITLE
chore(W1-2): extract core/money quantize helpers

### DIFF
--- a/app/core/money.py
+++ b/app/core/money.py
@@ -3,6 +3,7 @@
 All functions use ROUND_HALF_UP and accept Decimal | float | int inputs.
 The str() coercion avoids float binary representation issues.
 """
+
 from __future__ import annotations
 
 from decimal import ROUND_HALF_UP, Decimal

--- a/app/core/money.py
+++ b/app/core/money.py
@@ -1,0 +1,27 @@
+"""Shared Decimal quantization helpers for monetary and quantity values.
+
+All functions use ROUND_HALF_UP and accept Decimal | float | int inputs.
+The str() coercion avoids float binary representation issues.
+"""
+from __future__ import annotations
+
+from decimal import ROUND_HALF_UP, Decimal
+
+_SCALE_MONEY = Decimal("0.0001")
+_SCALE_CRYPTO_QTY = Decimal("0.00000001")
+_SCALE_PCT = Decimal("0.01")
+
+
+def quantize_money(val: Decimal | float | int) -> Decimal:
+    """Quantize a monetary amount to 4 decimal places (ROUND_HALF_UP)."""
+    return Decimal(str(val)).quantize(_SCALE_MONEY, rounding=ROUND_HALF_UP)
+
+
+def quantize_crypto_qty(val: Decimal | float | int) -> Decimal:
+    """Quantize a cryptocurrency quantity to 8 decimal places (ROUND_HALF_UP)."""
+    return Decimal(str(val)).quantize(_SCALE_CRYPTO_QTY, rounding=ROUND_HALF_UP)
+
+
+def quantize_pct(val: Decimal | float | int) -> Decimal:
+    """Quantize a percentage to 2 decimal places (ROUND_HALF_UP)."""
+    return Decimal(str(val)).quantize(_SCALE_PCT, rounding=ROUND_HALF_UP)

--- a/app/services/paper_trading_service.py
+++ b/app/services/paper_trading_service.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, date, datetime, timedelta
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import Decimal
 from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.money import quantize_crypto_qty as _q_crypto_qty
+from app.core.money import quantize_money as _q_money
+from app.core.money import quantize_pct as _q_pct
 from app.core.timezone import now_kst
 from app.models.paper_trading import (
     PaperAccount,
@@ -56,21 +59,6 @@ def calculate_fee(instrument_type: str, side: str, amount: Decimal) -> Decimal:
         return _q_money(amount * Decimal(str(fee_rate)))
 
     raise ValueError(f"Unsupported instrument_type: {instrument_type}")
-
-
-# ---------------------------------------------------------------------------
-# Formatting helpers
-# ---------------------------------------------------------------------------
-def _q_money(val: Decimal | float) -> Decimal:
-    return Decimal(str(val)).quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
-
-
-def _q_crypto_qty(val: Decimal | float) -> Decimal:
-    return Decimal(str(val)).quantize(Decimal("0.00000001"), rounding=ROUND_HALF_UP)
-
-
-def _q_pct(val: Decimal | float) -> Decimal:
-    return Decimal(str(val)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
 # ---------------------------------------------------------------------------
@@ -615,9 +603,9 @@ class PaperTradingService:
 
         daily_return_pct: Decimal | None = None
         if prior is not None and prior.total_equity > 0:
-            daily_return_pct = (
+            daily_return_pct = _q_money(
                 (total_equity / prior.total_equity - Decimal("1")) * Decimal("100")
-            ).quantize(Decimal("0.0001"), rounding=ROUND_HALF_UP)
+            )
 
         if existing_today is None:
             snapshot = PaperDailySnapshot(

--- a/tests/core/test_money.py
+++ b/tests/core/test_money.py
@@ -1,4 +1,5 @@
 """Unit tests for app.core.money quantization helpers."""
+
 from __future__ import annotations
 
 from decimal import Decimal

--- a/tests/core/test_money.py
+++ b/tests/core/test_money.py
@@ -1,0 +1,75 @@
+"""Unit tests for app.core.money quantization helpers."""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+# These imports will FAIL until Task 2 creates the module.
+from app.core.money import quantize_crypto_qty, quantize_money, quantize_pct
+
+
+class TestQuantizeMoney:
+    def test_rounds_to_4dp(self):
+        assert quantize_money(Decimal("1.23456789")) == Decimal("1.2346")
+
+    def test_round_half_up(self):
+        # 1.00005 → rounds up to 1.0001
+        assert quantize_money(Decimal("1.00005")) == Decimal("1.0001")
+
+    def test_accepts_float(self):
+        result = quantize_money(1.5)
+        assert result == Decimal("1.5000")
+        assert isinstance(result, Decimal)
+
+    def test_accepts_int(self):
+        assert quantize_money(100) == Decimal("100.0000")
+
+    def test_zero(self):
+        assert quantize_money(0) == Decimal("0.0000")
+
+    def test_large_value(self):
+        assert quantize_money(Decimal("100000000.1234")) == Decimal("100000000.1234")
+
+    def test_negative(self):
+        assert quantize_money(Decimal("-5.12345")) == Decimal("-5.1235")
+
+
+class TestQuantizeCryptoQty:
+    def test_rounds_to_8dp(self):
+        assert quantize_crypto_qty(Decimal("0.123456789")) == Decimal("0.12345679")
+
+    def test_round_half_up(self):
+        # 0.000000005 → rounds up to 0.00000001
+        assert quantize_crypto_qty(Decimal("0.000000005")) == Decimal("0.00000001")
+
+    def test_accepts_float(self):
+        result = quantize_crypto_qty(0.001)
+        assert isinstance(result, Decimal)
+        assert result == Decimal("0.00100000")
+
+    def test_zero(self):
+        assert quantize_crypto_qty(0) == Decimal("0.00000000")
+
+    def test_large_btc_qty(self):
+        assert quantize_crypto_qty(Decimal("0.00100000")) == Decimal("0.00100000")
+
+
+class TestQuantizePct:
+    def test_rounds_to_2dp(self):
+        assert quantize_pct(Decimal("12.345")) == Decimal("12.35")
+
+    def test_round_half_up(self):
+        # 0.005 → rounds up to 0.01
+        assert quantize_pct(Decimal("0.005")) == Decimal("0.01")
+
+    def test_accepts_float(self):
+        result = quantize_pct(3.14159)
+        assert isinstance(result, Decimal)
+        assert result == Decimal("3.14")
+
+    def test_negative(self):
+        assert quantize_pct(Decimal("-1.235")) == Decimal("-1.24")
+
+    def test_zero(self):
+        assert quantize_pct(0) == Decimal("0.00")

--- a/tests/core/test_money.py
+++ b/tests/core/test_money.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 from decimal import Decimal
 
-import pytest
-
-# These imports will FAIL until Task 2 creates the module.
 from app.core.money import quantize_crypto_qty, quantize_money, quantize_pct
 
 


### PR DESCRIPTION
## Summary
- Extract identical Decimal quantize helpers (`_q_money`, `_q_crypto_qty`, `_q_pct`) into `app/core/money.py` with `ROUND_HALF_UP` consistency.
- Replace 19+ in-file usages in `paper_trading_service.py` and related callers.

Refactor unit: W1-2 (Wave 1, low-risk extraction).
Plan: `docs/superpowers/plans/2026-05-09-refactor-W1-2-core-money.md`

Abstraction-threshold compliance: only identical implementations consolidated; logic-branching helpers remain in their original modules.

## Test plan
- [ ] `uv run pytest tests/core/test_money.py -v`
- [ ] `uv run pytest tests/ -k "paper_trading or money" -v`
- [ ] `uv run ruff check app/core/money.py app/services/paper_trading_service.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated decimal quantization and rounding logic to ensure consistent precision handling for monetary values, cryptocurrency quantities, and percentages throughout the application

* **Tests**
  * Added comprehensive test coverage for quantization and rounding functions, verifying correct decimal precision, proper rounding behavior, and handling of various input types and edge cases

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/742)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->