### PR TITLE
chore(W1-5): add reusable PaginationMeta and ListResponse schemas

### DIFF
--- a/app/schemas/pagination.py
+++ b/app/schemas/pagination.py
@@ -1,0 +1,45 @@
+"""Shared pagination primitives.
+
+Usage (라우터에서):
+    from app.schemas.pagination import ListResponse, PaginationMeta
+
+    meta = PaginationMeta(
+        total=total_count,
+        limit=limit,
+        offset=offset,
+        has_more=(offset + limit) < total_count,
+    )
+    return ListResponse[MyItemSchema](items=rows, pagination=meta)
+
+Note:
+    has_more 계산은 호출 쪽(라우터/서비스)의 책임이다.
+    이 모듈은 계산 로직 없이 단순 선언만 제공한다.
+
+후속:
+    W2-2 에서 기존 라우터/스키마를 ListResponse 기반으로 마이그레이션.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class PaginationMeta(BaseModel):
+    """페이지네이션 메타데이터."""
+
+    total: int = Field(..., ge=0, description="전체 항목 수")
+    limit: int = Field(..., ge=1, description="페이지당 최대 항목 수")
+    offset: int = Field(..., ge=0, description="조회 시작 오프셋")
+    has_more: bool = Field(..., description="다음 페이지 존재 여부")
+
+
+class ListResponse[T](BaseModel):
+    """제네릭 목록 응답 래퍼.
+
+    Example::
+
+        ListResponse[UserSchema](items=users, pagination=meta)
+    """
+
+    items: list[T]
+    pagination: PaginationMeta

--- a/tests/schemas/test_pagination.py
+++ b/tests/schemas/test_pagination.py
@@ -1,0 +1,148 @@
+"""Unit tests for app/schemas/pagination — PaginationMeta and ListResponse."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+# ---------------------------------------------------------------------------
+# PaginationMeta
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pagination_meta_valid():
+    from app.schemas.pagination import PaginationMeta
+
+    meta = PaginationMeta(total=100, limit=10, offset=0, has_more=True)
+
+    assert meta.total == 100
+    assert meta.limit == 10
+    assert meta.offset == 0
+    assert meta.has_more is True
+
+
+@pytest.mark.unit
+def test_pagination_meta_has_more_false():
+    from app.schemas.pagination import PaginationMeta
+
+    meta = PaginationMeta(total=5, limit=10, offset=0, has_more=False)
+
+    assert meta.has_more is False
+
+
+@pytest.mark.unit
+def test_pagination_meta_serializes_to_dict():
+    from app.schemas.pagination import PaginationMeta
+
+    meta = PaginationMeta(total=50, limit=20, offset=20, has_more=True)
+    d = meta.model_dump()
+
+    assert d == {"total": 50, "limit": 20, "offset": 20, "has_more": True}
+
+
+@pytest.mark.unit
+def test_pagination_meta_deserializes_from_dict():
+    from app.schemas.pagination import PaginationMeta
+
+    meta = PaginationMeta.model_validate(
+        {"total": 3, "limit": 10, "offset": 0, "has_more": False}
+    )
+
+    assert meta.total == 3
+
+
+@pytest.mark.unit
+def test_pagination_meta_rejects_negative_total():
+    from app.schemas.pagination import PaginationMeta
+
+    with pytest.raises(ValidationError):
+        PaginationMeta(total=-1, limit=10, offset=0, has_more=False)
+
+
+@pytest.mark.unit
+def test_pagination_meta_rejects_negative_limit():
+    from app.schemas.pagination import PaginationMeta
+
+    with pytest.raises(ValidationError):
+        PaginationMeta(total=10, limit=0, offset=0, has_more=False)
+
+
+@pytest.mark.unit
+def test_pagination_meta_rejects_negative_offset():
+    from app.schemas.pagination import PaginationMeta
+
+    with pytest.raises(ValidationError):
+        PaginationMeta(total=10, limit=10, offset=-1, has_more=False)
+
+
+# ---------------------------------------------------------------------------
+# ListResponse[T]
+# ---------------------------------------------------------------------------
+
+
+class _Item(BaseModel):
+    id: int
+    name: str
+
+
+@pytest.mark.unit
+def test_list_response_instantiation():
+    from app.schemas.pagination import ListResponse, PaginationMeta
+
+    meta = PaginationMeta(total=2, limit=10, offset=0, has_more=False)
+    response = ListResponse[_Item](
+        items=[_Item(id=1, name="a"), _Item(id=2, name="b")],
+        pagination=meta,
+    )
+
+    assert len(response.items) == 2
+    assert response.items[0].id == 1
+    assert response.pagination.total == 2
+
+
+@pytest.mark.unit
+def test_list_response_empty_items():
+    from app.schemas.pagination import ListResponse, PaginationMeta
+
+    meta = PaginationMeta(total=0, limit=10, offset=0, has_more=False)
+    response = ListResponse[_Item](items=[], pagination=meta)
+
+    assert response.items == []
+
+
+@pytest.mark.unit
+def test_list_response_serializes_to_dict():
+    from app.schemas.pagination import ListResponse, PaginationMeta
+
+    meta = PaginationMeta(total=1, limit=10, offset=0, has_more=False)
+    response = ListResponse[_Item](
+        items=[_Item(id=99, name="z")],
+        pagination=meta,
+    )
+    d = response.model_dump()
+
+    assert d["items"] == [{"id": 99, "name": "z"}]
+    assert d["pagination"]["total"] == 1
+
+
+@pytest.mark.unit
+def test_list_response_json_schema_generated():
+    """Pydantic v2 must be able to generate JSON schema for a concrete generic."""
+    from app.schemas.pagination import ListResponse
+
+    schema = ListResponse[_Item].model_json_schema()
+
+    assert "properties" in schema
+    assert "items" in schema["properties"]
+    assert "pagination" in schema["properties"]
+
+
+@pytest.mark.unit
+def test_list_response_rejects_non_list_items():
+    from app.schemas.pagination import ListResponse, PaginationMeta
+
+    meta = PaginationMeta(total=1, limit=10, offset=0, has_more=False)
+
+    with pytest.raises((ValidationError, TypeError)):
+        ListResponse[_Item](items="not-a-list", pagination=meta)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- Add `app/schemas/pagination.py` with reusable `PaginationMeta` and `ListResponse[T]` (Pydantic v2 generic) base schemas.
- Purely additive — existing routers/schemas unchanged. Migration to these bases is a follow-up (W2-2).

Refactor unit: W1-5 (Wave 1, low-risk additive).
Plan: `docs/superpowers/plans/2026-05-09-refactor-W1-5-pagination-schema.md`

## Test plan
- [ ] `uv run pytest tests/schemas/test_pagination.py -v`
- [ ] `PaginationMeta` 직렬화/역직렬화 검증
- [ ] `ListResponse[T]` 제네릭 인스턴스 생성 + JSON schema 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)