### PR TITLE
chore(W1-4): consolidate router auth dependency helpers

### DIFF
--- a/app/routers/dependencies.py
+++ b/app/routers/dependencies.py
@@ -11,10 +11,13 @@ from app.core.db import get_db
 from app.models.trading import User
 
 
-async def get_authenticated_user(
-    request: Request, db: AsyncSession = Depends(get_db)
+async def _resolve_user_from_request(
+    request: Request,
+    db: AsyncSession,
+    *,
+    detail: str,
 ) -> User:
-    """Return authenticated user from request state or session."""
+    """Shared auth resolution: state.user → session → 401."""
     user = getattr(request.state, "user", None)
     if user:
         return user
@@ -25,7 +28,16 @@ async def get_authenticated_user(
 
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
-        detail=AUTH_REQUIRED_MESSAGE,
+        detail=detail,
+    )
+
+
+async def get_authenticated_user(
+    request: Request, db: AsyncSession = Depends(get_db)
+) -> User:
+    """Return authenticated user from request state or session."""
+    return await _resolve_user_from_request(
+        request, db, detail=AUTH_REQUIRED_MESSAGE
     )
 
 
@@ -34,14 +46,6 @@ async def get_user_from_request(
     db: AsyncSession = Depends(get_db),
 ) -> User:
     """웹 세션 또는 API 토큰에서 사용자 조회 (symbol-settings 전용)"""
-    if hasattr(request.state, "user") and request.state.user:
-        return request.state.user
-
-    user = await get_current_user_from_session(request, db)
-    if user:
-        return user
-
-    raise HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Authentication required",
+    return await _resolve_user_from_request(
+        request, db, detail="Authentication required"
     )

--- a/app/routers/dependencies.py
+++ b/app/routers/dependencies.py
@@ -36,9 +36,7 @@ async def get_authenticated_user(
     request: Request, db: AsyncSession = Depends(get_db)
 ) -> User:
     """Return authenticated user from request state or session."""
-    return await _resolve_user_from_request(
-        request, db, detail=AUTH_REQUIRED_MESSAGE
-    )
+    return await _resolve_user_from_request(request, db, detail=AUTH_REQUIRED_MESSAGE)
 
 
 async def get_user_from_request(

--- a/tests/routers/test_dependencies.py
+++ b/tests/routers/test_dependencies.py
@@ -1,0 +1,160 @@
+"""Unit tests for app/routers/dependencies.py auth helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(*, state_user=None):
+    """Build a minimal fake Request with controllable state.user."""
+    req = SimpleNamespace()
+    req.state = SimpleNamespace()
+    req.state.user = state_user
+    return req
+
+
+def _make_db():
+    return AsyncMock()
+
+
+# ---------------------------------------------------------------------------
+# get_authenticated_user
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_authenticated_user_returns_state_user():
+    """If request.state.user is set, return it immediately."""
+    from app.routers.dependencies import get_authenticated_user
+
+    fake_user = SimpleNamespace(id=1)
+    request = _make_request(state_user=fake_user)
+
+    result = await get_authenticated_user(request=request, db=_make_db())
+
+    assert result is fake_user
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_authenticated_user_falls_back_to_session():
+    """If state.user is absent but session resolves, return session user."""
+    from app.routers.dependencies import get_authenticated_user
+
+    session_user = SimpleNamespace(id=2)
+    request = _make_request(state_user=None)
+
+    with patch(
+        "app.routers.dependencies.get_current_user_from_session",
+        new=AsyncMock(return_value=session_user),
+    ):
+        result = await get_authenticated_user(request=request, db=_make_db())
+
+    assert result is session_user
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_authenticated_user_raises_401_when_no_user():
+    """If both state.user and session are absent, raise HTTP 401."""
+    from app.routers.dependencies import get_authenticated_user
+
+    request = _make_request(state_user=None)
+
+    with patch(
+        "app.routers.dependencies.get_current_user_from_session",
+        new=AsyncMock(return_value=None),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_authenticated_user(request=request, db=_make_db())
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "로그인이 필요합니다."
+
+
+# ---------------------------------------------------------------------------
+# get_user_from_request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_user_from_request_returns_state_user():
+    """If request.state.user is set, return it immediately."""
+    from app.routers.dependencies import get_user_from_request
+
+    fake_user = SimpleNamespace(id=3)
+    request = _make_request(state_user=fake_user)
+
+    result = await get_user_from_request(request=request, db=_make_db())
+
+    assert result is fake_user
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_user_from_request_falls_back_to_session():
+    """If state.user is absent but session resolves, return session user."""
+    from app.routers.dependencies import get_user_from_request
+
+    session_user = SimpleNamespace(id=4)
+    request = _make_request(state_user=None)
+
+    with patch(
+        "app.routers.dependencies.get_current_user_from_session",
+        new=AsyncMock(return_value=session_user),
+    ):
+        result = await get_user_from_request(request=request, db=_make_db())
+
+    assert result is session_user
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_get_user_from_request_raises_401_when_no_user():
+    """If both state.user and session are absent, raise HTTP 401."""
+    from app.routers.dependencies import get_user_from_request
+
+    request = _make_request(state_user=None)
+
+    with patch(
+        "app.routers.dependencies.get_current_user_from_session",
+        new=AsyncMock(return_value=None),
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await get_user_from_request(request=request, db=_make_db())
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Authentication required"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_two_functions_have_different_401_messages():
+    """Regression: the two functions must keep their distinct error messages."""
+    from app.routers.dependencies import (
+        get_authenticated_user,
+        get_user_from_request,
+    )
+
+    request = _make_request(state_user=None)
+
+    with patch(
+        "app.routers.dependencies.get_current_user_from_session",
+        new=AsyncMock(return_value=None),
+    ):
+        with pytest.raises(HTTPException) as exc_a:
+            await get_authenticated_user(request=request, db=_make_db())
+        with pytest.raises(HTTPException) as exc_b:
+            await get_user_from_request(request=request, db=_make_db())
+
+    assert exc_a.value.detail != exc_b.value.detail


### PR DESCRIPTION
## Summary
- Extract internal `_resolve_user_from_request` helper for the identical auth resolution path shared by `get_authenticated_user()` and `get_user_from_request()`.
- Public function signatures + error message strings preserved (21 call sites unchanged).

Refactor unit: W1-4 (Wave 1, low-risk).
Plan: `docs/superpowers/plans/2026-05-09-refactor-W1-4-router-auth.md`

## Test plan
- [ ] `uv run pytest tests/routers/test_dependencies.py -v`
- [ ] 호출처 21곳 grep 결과 동일 (회귀 없음 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)