### PR TITLE
chore(W1-6): extract portfolio indicator card builders to dedicated module

### DIFF
--- a/app/services/portfolio_indicator_cards.py
+++ b/app/services/portfolio_indicator_cards.py
@@ -46,9 +46,7 @@ def build_stoch_rsi_card(k: Any, d: Any) -> dict[str, str] | None:
     }
 
 
-def build_macd_card(
-    macd: Any, signal: Any, histogram: Any
-) -> dict[str, str] | None:
+def build_macd_card(macd: Any, signal: Any, histogram: Any) -> dict[str, str] | None:
     if not isinstance(macd, (int, float)) or not isinstance(signal, (int, float)):
         return None
     bullish = macd >= signal

--- a/app/services/portfolio_indicator_cards.py
+++ b/app/services/portfolio_indicator_cards.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "build_rsi_card",
+    "build_stoch_rsi_card",
+    "build_macd_card",
+    "build_bollinger_card",
+    "build_ema_card",
+    "build_sma_card",
+]
+
+
+def build_rsi_card(rsi_14: Any) -> dict[str, str] | None:
+    if not isinstance(rsi_14, (int, float)):
+        return None
+    if rsi_14 < 30:
+        tone, meaning = "oversold", "과매도"
+    elif rsi_14 > 70:
+        tone, meaning = "overbought", "과매수"
+    else:
+        tone, meaning = "neutral", "중립"
+    return {
+        "label": "RSI(14)",
+        "value": f"{rsi_14:.1f}",
+        "tone": tone,
+        "description": meaning,
+    }
+
+
+def build_stoch_rsi_card(k: Any, d: Any) -> dict[str, str] | None:
+    if not isinstance(k, (int, float)) or not isinstance(d, (int, float)):
+        return None
+    if k < 20 and d < 20:
+        description, tone = "과매도 구간", "oversold"
+    elif k > 80 and d > 80:
+        description, tone = "과매수 구간", "overbought"
+    else:
+        description, tone = "중립 구간", "neutral"
+    return {
+        "label": "Stoch RSI",
+        "value": f"K {k:.1f} / D {d:.1f}",
+        "tone": tone,
+        "description": description,
+    }
+
+
+def build_macd_card(
+    macd: Any, signal: Any, histogram: Any
+) -> dict[str, str] | None:
+    if not isinstance(macd, (int, float)) or not isinstance(signal, (int, float)):
+        return None
+    bullish = macd >= signal
+    return {
+        "label": "MACD",
+        "value": "Bullish" if bullish else "Bearish",
+        "tone": "bullish" if bullish else "bearish",
+        "description": (
+            f"MACD {macd:.2f} / Signal {signal:.2f}"
+            + (
+                f" / Hist {histogram:.2f}"
+                if isinstance(histogram, (int, float))
+                else ""
+            )
+        ),
+    }
+
+
+def build_bollinger_card(
+    price: Any, upper: Any, middle: Any, lower: Any
+) -> dict[str, str] | None:
+    if not all(isinstance(v, (int, float)) for v in (price, upper, middle, lower)):
+        return None
+    if abs(price - lower) <= abs(price - upper) and abs(price - lower) <= abs(
+        price - middle
+    ):
+        description, tone = "하단 근처", "oversold"
+    elif abs(price - upper) < abs(price - middle):
+        description, tone = "상단 근처", "overbought"
+    else:
+        description, tone = "중단 근처", "neutral"
+    return {
+        "label": "Bollinger",
+        "value": description,
+        "tone": tone,
+        "description": f"상단 {upper:.2f} / 중단 {middle:.2f} / 하단 {lower:.2f}",
+    }
+
+
+def build_ema_card(
+    price: Any, ema20: Any, ema60: Any, ema200: Any
+) -> dict[str, str] | None:
+    if not isinstance(price, (int, float)) or not isinstance(ema20, (int, float)):
+        return None
+    if (
+        isinstance(ema60, (int, float))
+        and isinstance(ema200, (int, float))
+        and price > ema20 > ema60 > ema200
+    ):
+        tone, description = "bullish", "상방 정렬"
+    elif (
+        isinstance(ema60, (int, float))
+        and isinstance(ema200, (int, float))
+        and price < ema20 < ema60 < ema200
+    ):
+        tone, description = "bearish", "하방 정렬"
+    else:
+        tone, description = "neutral", "혼조"
+    return {
+        "label": "EMA",
+        "value": description,
+        "tone": tone,
+        "description": (
+            f"20 {ema20:.2f}"
+            + (f" / 60 {ema60:.2f}" if isinstance(ema60, (int, float)) else "")
+            + (f" / 200 {ema200:.2f}" if isinstance(ema200, (int, float)) else "")
+        ),
+    }
+
+
+def build_sma_card(
+    price: Any, sma20: Any, sma60: Any, sma200: Any
+) -> dict[str, str] | None:
+    if not isinstance(price, (int, float)) or not isinstance(sma20, (int, float)):
+        return None
+    if (
+        isinstance(sma60, (int, float))
+        and isinstance(sma200, (int, float))
+        and price > sma20 > sma60 > sma200
+    ):
+        tone, description = "bullish", "상방 정렬"
+    elif (
+        isinstance(sma60, (int, float))
+        and isinstance(sma200, (int, float))
+        and price < sma20 < sma60 < sma200
+    ):
+        tone, description = "bearish", "하방 정렬"
+    else:
+        tone, description = "neutral", "혼조"
+    return {
+        "label": "SMA",
+        "value": description,
+        "tone": tone,
+        "description": (
+            f"20 {sma20:.2f}"
+            + (f" / 60 {sma60:.2f}" if isinstance(sma60, (int, float)) else "")
+            + (f" / 200 {sma200:.2f}" if isinstance(sma200, (int, float)) else "")
+        ),
+    }

--- a/app/services/portfolio_position_detail_service.py
+++ b/app/services/portfolio_position_detail_service.py
@@ -10,6 +10,14 @@ from app.mcp_server.tooling.fundamentals._valuation import (
 )
 from app.mcp_server.tooling.market_data_quotes import _get_indicators_impl
 from app.mcp_server.tooling.orders_history import get_order_history_impl
+from app.services.portfolio_indicator_cards import (
+    build_bollinger_card,
+    build_ema_card,
+    build_macd_card,
+    build_rsi_card,
+    build_sma_card,
+    build_stoch_rsi_card,
+)
 from app.services.portfolio_weights import build_weights as _build_portfolio_weights
 
 
@@ -385,138 +393,6 @@ class PortfolioPositionDetailService:
             "opinions": payload.get("opinions") or [],
         }
 
-    def _build_rsi_card(self, rsi_14: Any) -> dict[str, str] | None:
-        if not isinstance(rsi_14, (int, float)):
-            return None
-        if rsi_14 < 30:
-            tone, meaning = "oversold", "과매도"
-        elif rsi_14 > 70:
-            tone, meaning = "overbought", "과매수"
-        else:
-            tone, meaning = "neutral", "중립"
-        return {
-            "label": "RSI(14)",
-            "value": f"{rsi_14:.1f}",
-            "tone": tone,
-            "description": meaning,
-        }
-
-    def _build_stoch_rsi_card(self, k: Any, d: Any) -> dict[str, str] | None:
-        if not isinstance(k, (int, float)) or not isinstance(d, (int, float)):
-            return None
-        if k < 20 and d < 20:
-            description, tone = "과매도 구간", "oversold"
-        elif k > 80 and d > 80:
-            description, tone = "과매수 구간", "overbought"
-        else:
-            description, tone = "중립 구간", "neutral"
-        return {
-            "label": "Stoch RSI",
-            "value": f"K {k:.1f} / D {d:.1f}",
-            "tone": tone,
-            "description": description,
-        }
-
-    def _build_macd_card(
-        self, macd: Any, signal: Any, histogram: Any
-    ) -> dict[str, str] | None:
-        if not isinstance(macd, (int, float)) or not isinstance(signal, (int, float)):
-            return None
-        bullish = macd >= signal
-        return {
-            "label": "MACD",
-            "value": "Bullish" if bullish else "Bearish",
-            "tone": "bullish" if bullish else "bearish",
-            "description": (
-                f"MACD {macd:.2f} / Signal {signal:.2f}"
-                + (
-                    f" / Hist {histogram:.2f}"
-                    if isinstance(histogram, (int, float))
-                    else ""
-                )
-            ),
-        }
-
-    def _build_bollinger_card(
-        self, price: Any, upper: Any, middle: Any, lower: Any
-    ) -> dict[str, str] | None:
-        if not all(isinstance(v, (int, float)) for v in (price, upper, middle, lower)):
-            return None
-        if abs(price - lower) <= abs(price - upper) and abs(price - lower) <= abs(
-            price - middle
-        ):
-            description, tone = "하단 근처", "oversold"
-        elif abs(price - upper) < abs(price - middle):
-            description, tone = "상단 근처", "overbought"
-        else:
-            description, tone = "중단 근처", "neutral"
-        return {
-            "label": "Bollinger",
-            "value": description,
-            "tone": tone,
-            "description": f"상단 {upper:.2f} / 중단 {middle:.2f} / 하단 {lower:.2f}",
-        }
-
-    def _build_ema_card(
-        self, price: Any, ema20: Any, ema60: Any, ema200: Any
-    ) -> dict[str, str] | None:
-        if not isinstance(price, (int, float)) or not isinstance(ema20, (int, float)):
-            return None
-        if (
-            isinstance(ema60, (int, float))
-            and isinstance(ema200, (int, float))
-            and price > ema20 > ema60 > ema200
-        ):
-            tone, description = "bullish", "상방 정렬"
-        elif (
-            isinstance(ema60, (int, float))
-            and isinstance(ema200, (int, float))
-            and price < ema20 < ema60 < ema200
-        ):
-            tone, description = "bearish", "하방 정렬"
-        else:
-            tone, description = "neutral", "혼조"
-        return {
-            "label": "EMA",
-            "value": description,
-            "tone": tone,
-            "description": (
-                f"20 {ema20:.2f}"
-                + (f" / 60 {ema60:.2f}" if isinstance(ema60, (int, float)) else "")
-                + (f" / 200 {ema200:.2f}" if isinstance(ema200, (int, float)) else "")
-            ),
-        }
-
-    def _build_sma_card(
-        self, price: Any, sma20: Any, sma60: Any, sma200: Any
-    ) -> dict[str, str] | None:
-        if not isinstance(price, (int, float)) or not isinstance(sma20, (int, float)):
-            return None
-        if (
-            isinstance(sma60, (int, float))
-            and isinstance(sma200, (int, float))
-            and price > sma20 > sma60 > sma200
-        ):
-            tone, description = "bullish", "상방 정렬"
-        elif (
-            isinstance(sma60, (int, float))
-            and isinstance(sma200, (int, float))
-            and price < sma20 < sma60 < sma200
-        ):
-            tone, description = "bearish", "하방 정렬"
-        else:
-            tone, description = "neutral", "혼조"
-        return {
-            "label": "SMA",
-            "value": description,
-            "tone": tone,
-            "description": (
-                f"20 {sma20:.2f}"
-                + (f" / 60 {sma60:.2f}" if isinstance(sma60, (int, float)) else "")
-                + (f" / 200 {sma200:.2f}" if isinstance(sma200, (int, float)) else "")
-            ),
-        }
-
     def _build_indicator_summary_cards(
         self, payload: dict[str, Any]
     ) -> list[dict[str, str]]:
@@ -524,19 +400,19 @@ class PortfolioPositionDetailService:
         price = payload.get("price")
         cards: list[dict[str, str]] = []
 
-        rsi_card = self._build_rsi_card(
+        rsi_card = build_rsi_card(
             rsi_14=(indicators.get("rsi") or {}).get("14"),
         )
         if rsi_card:
             cards.append(rsi_card)
 
         stoch = indicators.get("stoch_rsi") or {}
-        stoch_card = self._build_stoch_rsi_card(k=stoch.get("k"), d=stoch.get("d"))
+        stoch_card = build_stoch_rsi_card(k=stoch.get("k"), d=stoch.get("d"))
         if stoch_card:
             cards.append(stoch_card)
 
         macd = indicators.get("macd") or {}
-        macd_card = self._build_macd_card(
+        macd_card = build_macd_card(
             macd=macd.get("macd"),
             signal=macd.get("signal"),
             histogram=macd.get("histogram"),
@@ -545,7 +421,7 @@ class PortfolioPositionDetailService:
             cards.append(macd_card)
 
         bollinger = indicators.get("bollinger") or {}
-        bollinger_card = self._build_bollinger_card(
+        bollinger_card = build_bollinger_card(
             price=price,
             upper=bollinger.get("upper"),
             middle=bollinger.get("middle"),
@@ -555,7 +431,7 @@ class PortfolioPositionDetailService:
             cards.append(bollinger_card)
 
         ema = indicators.get("ema") or {}
-        ema_card = self._build_ema_card(
+        ema_card = build_ema_card(
             price=price,
             ema20=ema.get("20"),
             ema60=ema.get("60"),
@@ -565,7 +441,7 @@ class PortfolioPositionDetailService:
             cards.append(ema_card)
 
         sma = indicators.get("sma") or {}
-        sma_card = self._build_sma_card(
+        sma_card = build_sma_card(
             price=price,
             sma20=sma.get("20"),
             sma60=sma.get("60"),

--- a/tests/services/test_portfolio_indicator_cards.py
+++ b/tests/services/test_portfolio_indicator_cards.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from app.services.portfolio_indicator_cards import (
+    build_bollinger_card,
+    build_ema_card,
+    build_macd_card,
+    build_rsi_card,
+    build_sma_card,
+    build_stoch_rsi_card,
+)
+
+
+class TestBuildRsiCard:
+    def test_none_returns_none(self) -> None:
+        assert build_rsi_card(None) is None
+
+    def test_string_returns_none(self) -> None:
+        assert build_rsi_card("x") is None
+
+    def test_oversold(self) -> None:
+        card = build_rsi_card(25.0)
+        assert card == {
+            "label": "RSI(14)",
+            "value": "25.0",
+            "tone": "oversold",
+            "description": "과매도",
+        }
+
+    def test_overbought(self) -> None:
+        card = build_rsi_card(75.0)
+        assert card is not None
+        assert card["tone"] == "overbought"
+        assert card["description"] == "과매수"
+
+    def test_neutral(self) -> None:
+        card = build_rsi_card(50.0)
+        assert card is not None
+        assert card["tone"] == "neutral"
+        assert card["description"] == "중립"
+
+
+class TestBuildStochRsiCard:
+    def test_k_none_returns_none(self) -> None:
+        assert build_stoch_rsi_card(None, 50.0) is None
+
+    def test_d_none_returns_none(self) -> None:
+        assert build_stoch_rsi_card(50.0, None) is None
+
+    def test_oversold(self) -> None:
+        card = build_stoch_rsi_card(10.0, 15.0)
+        assert card is not None
+        assert card["tone"] == "oversold"
+
+    def test_overbought(self) -> None:
+        card = build_stoch_rsi_card(85.0, 90.0)
+        assert card is not None
+        assert card["tone"] == "overbought"
+
+    def test_neutral(self) -> None:
+        card = build_stoch_rsi_card(50.0, 50.0)
+        assert card is not None
+        assert card["tone"] == "neutral"
+
+    def test_value_format(self) -> None:
+        card = build_stoch_rsi_card(10.0, 15.0)
+        assert card is not None
+        assert card["value"] == "K 10.0 / D 15.0"
+
+
+class TestBuildMacdCard:
+    def test_macd_none_returns_none(self) -> None:
+        assert build_macd_card(None, 1.0, 0.5) is None
+
+    def test_signal_none_returns_none(self) -> None:
+        assert build_macd_card(1.0, None, 0.5) is None
+
+    def test_bullish(self) -> None:
+        card = build_macd_card(1.0, 0.5, 0.5)
+        assert card is not None
+        assert card["tone"] == "bullish"
+        assert card["value"] == "Bullish"
+
+    def test_bearish(self) -> None:
+        card = build_macd_card(0.5, 1.0, None)
+        assert card is not None
+        assert card["tone"] == "bearish"
+        assert "Hist" not in card["description"]
+
+    def test_histogram_included_when_valid(self) -> None:
+        card = build_macd_card(1.0, 0.5, 0.3)
+        assert card is not None
+        assert "Hist" in card["description"]
+
+
+class TestBuildBollingerCard:
+    def test_price_none_returns_none(self) -> None:
+        assert build_bollinger_card(None, 110.0, 100.0, 90.0) is None
+
+    def test_upper_none_returns_none(self) -> None:
+        assert build_bollinger_card(100.0, None, 100.0, 90.0) is None
+
+    def test_oversold_near_lower(self) -> None:
+        card = build_bollinger_card(91.0, 110.0, 100.0, 90.0)
+        assert card is not None
+        assert card["tone"] == "oversold"
+
+    def test_overbought_near_upper(self) -> None:
+        card = build_bollinger_card(109.0, 110.0, 100.0, 90.0)
+        assert card is not None
+        assert card["tone"] == "overbought"
+
+    def test_neutral_near_middle(self) -> None:
+        card = build_bollinger_card(100.0, 110.0, 100.0, 90.0)
+        assert card is not None
+        assert card["tone"] == "neutral"
+
+    def test_description_format(self) -> None:
+        card = build_bollinger_card(91.0, 110.0, 100.0, 90.0)
+        assert card is not None
+        assert "110.00" in card["description"]
+        assert "100.00" in card["description"]
+        assert "90.00" in card["description"]
+
+
+class TestBuildEmaCard:
+    def test_price_none_returns_none(self) -> None:
+        assert build_ema_card(None, 100.0, 90.0, 80.0) is None
+
+    def test_ema20_none_returns_none(self) -> None:
+        assert build_ema_card(120.0, None, 90.0, 80.0) is None
+
+    def test_bullish_full_alignment(self) -> None:
+        card = build_ema_card(120.0, 110.0, 100.0, 90.0)
+        assert card is not None
+        assert card["tone"] == "bullish"
+        assert card["label"] == "EMA"
+
+    def test_bearish_full_alignment(self) -> None:
+        card = build_ema_card(80.0, 90.0, 100.0, 110.0)
+        assert card is not None
+        assert card["tone"] == "bearish"
+
+    def test_neutral_mixed(self) -> None:
+        card = build_ema_card(100.0, 110.0, 90.0, 80.0)
+        assert card is not None
+        assert card["tone"] == "neutral"
+
+
+class TestBuildSmaCard:
+    def test_price_none_returns_none(self) -> None:
+        assert build_sma_card(None, 100.0, 90.0, 80.0) is None
+
+    def test_sma20_none_returns_none(self) -> None:
+        assert build_sma_card(120.0, None, 90.0, 80.0) is None
+
+    def test_bullish_full_alignment(self) -> None:
+        card = build_sma_card(120.0, 110.0, 100.0, 90.0)
+        assert card is not None
+        assert card["tone"] == "bullish"
+        assert card["label"] == "SMA"
+
+    def test_bearish_full_alignment(self) -> None:
+        card = build_sma_card(80.0, 90.0, 100.0, 110.0)
+        assert card is not None
+        assert card["tone"] == "bearish"
+
+    def test_neutral_mixed(self) -> None:
+        card = build_sma_card(100.0, 110.0, 90.0, 80.0)
+        assert card is not None
+        assert card["tone"] == "neutral"
+
+    def test_label_is_sma_not_ema(self) -> None:
+        card = build_sma_card(120.0, 110.0, 100.0, 90.0)
+        assert card is not None
+        assert card["label"] == "SMA"

--- a/tests/test_portfolio_position_detail_service.py
+++ b/tests/test_portfolio_position_detail_service.py
@@ -6,6 +6,14 @@ import pytest
 
 import app.services.portfolio_position_detail_service as detail_service_module
 from app.mcp_server.tooling import orders_history
+from app.services.portfolio_indicator_cards import (
+    build_bollinger_card,
+    build_ema_card,
+    build_macd_card,
+    build_rsi_card,
+    build_sma_card,
+    build_stoch_rsi_card,
+)
 from app.services.portfolio_position_detail_service import (
     PortfolioPositionDetailNotFoundError,
     PortfolioPositionDetailService,
@@ -1406,113 +1414,74 @@ async def test_get_page_payload_summary_includes_evaluation_krw() -> None:
 
 class TestBuildRsiCard:
     def test_oversold(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        card = service._build_rsi_card(rsi_14=25.0)
+        card = build_rsi_card(rsi_14=25.0)
         assert card is not None
         assert card["tone"] == "oversold"
         assert card["label"] == "RSI(14)"
 
     def test_overbought(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        card = service._build_rsi_card(rsi_14=75.0)
+        card = build_rsi_card(rsi_14=75.0)
         assert card is not None
         assert card["tone"] == "overbought"
 
     def test_neutral(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        card = service._build_rsi_card(rsi_14=50.0)
+        card = build_rsi_card(rsi_14=50.0)
         assert card is not None
         assert card["tone"] == "neutral"
 
     def test_none_when_not_numeric(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        assert service._build_rsi_card(rsi_14=None) is None
-        assert service._build_rsi_card(rsi_14="bad") is None
+        assert build_rsi_card(rsi_14=None) is None
+        assert build_rsi_card(rsi_14="bad") is None
 
 
 class TestBuildStochRsiCard:
     def test_oversold(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        card = service._build_stoch_rsi_card(k=15.0, d=10.0)
+        card = build_stoch_rsi_card(k=15.0, d=10.0)
         assert card is not None
         assert card["tone"] == "oversold"
 
     def test_overbought(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        card = service._build_stoch_rsi_card(k=85.0, d=90.0)
+        card = build_stoch_rsi_card(k=85.0, d=90.0)
         assert card is not None
         assert card["tone"] == "overbought"
 
     def test_none_when_incomplete(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        assert service._build_stoch_rsi_card(k=50.0, d=None) is None
+        assert build_stoch_rsi_card(k=50.0, d=None) is None
 
 
 class TestBuildMacdCard:
     def test_bullish(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        card = service._build_macd_card(macd=1.5, signal=1.0, histogram=0.5)
+        card = build_macd_card(macd=1.5, signal=1.0, histogram=0.5)
         assert card is not None
         assert card["tone"] == "bullish"
 
     def test_bearish(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        card = service._build_macd_card(macd=0.5, signal=1.0, histogram=-0.5)
+        card = build_macd_card(macd=0.5, signal=1.0, histogram=-0.5)
         assert card is not None
         assert card["tone"] == "bearish"
 
     def test_none_when_missing(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        assert service._build_macd_card(macd=None, signal=1.0, histogram=0.5) is None
+        assert build_macd_card(macd=None, signal=1.0, histogram=0.5) is None
 
 
 class TestBuildBollingerCard:
     def test_near_lower(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        card = service._build_bollinger_card(
+        card = build_bollinger_card(
             price=101.0, upper=120.0, middle=110.0, lower=100.0
         )
         assert card is not None
         assert card["tone"] == "oversold"
 
     def test_near_upper(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        card = service._build_bollinger_card(
+        card = build_bollinger_card(
             price=119.0, upper=120.0, middle=110.0, lower=100.0
         )
         assert card is not None
         assert card["tone"] == "overbought"
 
     def test_none_when_missing(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
         assert (
-            service._build_bollinger_card(
+            build_bollinger_card(
                 price=110.0, upper=None, middle=110.0, lower=100.0
             )
             is None
@@ -1521,10 +1490,7 @@ class TestBuildBollingerCard:
 
 class TestBuildEmaCard:
     def test_bullish_alignment(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        card = service._build_ema_card(
+        card = build_ema_card(
             price=210.0, ema20=200.0, ema60=180.0, ema200=150.0
         )
         assert card is not None
@@ -1532,41 +1498,29 @@ class TestBuildEmaCard:
         assert card["value"] == "상방 정렬"
 
     def test_bearish_alignment(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        card = service._build_ema_card(
+        card = build_ema_card(
             price=100.0, ema20=120.0, ema60=150.0, ema200=180.0
         )
         assert card is not None
         assert card["tone"] == "bearish"
 
     def test_none_when_price_missing(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
         assert (
-            service._build_ema_card(price=None, ema20=100.0, ema60=90.0, ema200=80.0)
+            build_ema_card(price=None, ema20=100.0, ema60=90.0, ema200=80.0)
             is None
         )
 
 
 class TestBuildSmaCard:
     def test_bullish_alignment(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
-        card = service._build_sma_card(
+        card = build_sma_card(
             price=210.0, sma20=200.0, sma60=180.0, sma200=150.0
         )
         assert card is not None
         assert card["tone"] == "bullish"
 
     def test_none_when_sma20_missing(self):
-        service = PortfolioPositionDetailService(
-            overview_service=MagicMock(), dashboard_service=MagicMock()
-        )
         assert (
-            service._build_sma_card(price=100.0, sma20=None, sma60=90.0, sma200=80.0)
+            build_sma_card(price=100.0, sma20=None, sma60=90.0, sma200=80.0)
             is None
         )

--- a/tests/test_portfolio_position_detail_service.py
+++ b/tests/test_portfolio_position_detail_service.py
@@ -1466,61 +1466,43 @@ class TestBuildMacdCard:
 
 class TestBuildBollingerCard:
     def test_near_lower(self):
-        card = build_bollinger_card(
-            price=101.0, upper=120.0, middle=110.0, lower=100.0
-        )
+        card = build_bollinger_card(price=101.0, upper=120.0, middle=110.0, lower=100.0)
         assert card is not None
         assert card["tone"] == "oversold"
 
     def test_near_upper(self):
-        card = build_bollinger_card(
-            price=119.0, upper=120.0, middle=110.0, lower=100.0
-        )
+        card = build_bollinger_card(price=119.0, upper=120.0, middle=110.0, lower=100.0)
         assert card is not None
         assert card["tone"] == "overbought"
 
     def test_none_when_missing(self):
         assert (
-            build_bollinger_card(
-                price=110.0, upper=None, middle=110.0, lower=100.0
-            )
+            build_bollinger_card(price=110.0, upper=None, middle=110.0, lower=100.0)
             is None
         )
 
 
 class TestBuildEmaCard:
     def test_bullish_alignment(self):
-        card = build_ema_card(
-            price=210.0, ema20=200.0, ema60=180.0, ema200=150.0
-        )
+        card = build_ema_card(price=210.0, ema20=200.0, ema60=180.0, ema200=150.0)
         assert card is not None
         assert card["tone"] == "bullish"
         assert card["value"] == "상방 정렬"
 
     def test_bearish_alignment(self):
-        card = build_ema_card(
-            price=100.0, ema20=120.0, ema60=150.0, ema200=180.0
-        )
+        card = build_ema_card(price=100.0, ema20=120.0, ema60=150.0, ema200=180.0)
         assert card is not None
         assert card["tone"] == "bearish"
 
     def test_none_when_price_missing(self):
-        assert (
-            build_ema_card(price=None, ema20=100.0, ema60=90.0, ema200=80.0)
-            is None
-        )
+        assert build_ema_card(price=None, ema20=100.0, ema60=90.0, ema200=80.0) is None
 
 
 class TestBuildSmaCard:
     def test_bullish_alignment(self):
-        card = build_sma_card(
-            price=210.0, sma20=200.0, sma60=180.0, sma200=150.0
-        )
+        card = build_sma_card(price=210.0, sma20=200.0, sma60=180.0, sma200=150.0)
         assert card is not None
         assert card["tone"] == "bullish"
 
     def test_none_when_sma20_missing(self):
-        assert (
-            build_sma_card(price=100.0, sma20=None, sma60=90.0, sma200=80.0)
-            is None
-        )
+        assert build_sma_card(price=100.0, sma20=None, sma60=90.0, sma200=80.0) is None


### PR DESCRIPTION
## Summary
- Move 6 `_build_*_card()` functions (RSI, StochRSI, MACD, Bollinger, EMA, SMA) from `portfolio_position_detail_service.py` into new `app/services/portfolio_indicator_cards.py`.
- Each builder kept as separate function (no parameterization) per abstraction threshold rule.
- Existing detail service updated to import and call standalone functions directly.
- Existing `TestBuild*Card` tests in `test_portfolio_position_detail_service.py` updated to call module-level functions (no `service` instance needed).

Refactor unit: W1-6 (Wave 1, low-risk extraction).
Plan: `docs/superpowers/plans/2026-05-09-refactor-W1-6-portfolio-indicator-cards.md`

## Test plan
- [ ] `uv run pytest tests/services/test_portfolio_indicator_cards.py -v`
- [ ] `uv run pytest tests/ -k "portfolio_position_detail" -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)