### PR TITLE
chore(W1-3): extract scripts CLI bootstrap to app/core/cli

### DIFF
--- a/app/core/cli.py
+++ b/app/core/cli.py
@@ -1,0 +1,51 @@
+"""Shared CLI bootstrap helpers for auto_trader scripts.
+
+Provides:
+- setup_logging_and_sentry: logging.basicConfig + init_sentry in one call
+- run_async_job: common try/except wrapper for sync-style async jobs
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from app.core.config import settings
+from app.monitoring.sentry import capture_exception, init_sentry
+
+__all__ = ["run_async_job", "setup_logging_and_sentry"]
+
+_logger = logging.getLogger(__name__)
+
+
+def setup_logging_and_sentry(service_name: str) -> None:
+    """Configure root logger and initialize Sentry for a CLI service.
+
+    Always applies .upper() to settings.LOG_LEVEL; unknown levels fall back to INFO.
+    """
+    logging.basicConfig(
+        level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    init_sentry(service_name=service_name)
+
+
+async def run_async_job(
+    coro_factory: Callable[[], Awaitable[int]],
+    *,
+    process: str,
+) -> int:
+    """Run an async job coroutine, capturing exceptions to Sentry.
+
+    Returns the integer exit code from coro_factory, or 1 on exception.
+    SystemExit and KeyboardInterrupt are NOT caught.
+
+    Usage:
+        return await run_async_job(_job, process="sync_kr_candles")
+    """
+    try:
+        return await coro_factory()
+    except Exception as exc:
+        capture_exception(exc, process=process)
+        _logger.error("%s crashed: %s", process, exc, exc_info=True)
+        return 1

--- a/scripts/ingest_freqtrade_report.py
+++ b/scripts/ingest_freqtrade_report.py
@@ -9,9 +9,9 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from app.core.config import settings
+from app.core.cli import setup_logging_and_sentry
 from app.core.db import AsyncSessionLocal
-from app.monitoring.sentry import capture_exception, init_sentry
+from app.monitoring.sentry import capture_exception
 from app.services.research_ingestion_service import ingest_summary_payload
 
 logger = logging.getLogger(__name__)
@@ -59,11 +59,7 @@ async def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
 
-    logging.basicConfig(
-        level=getattr(logging, settings.LOG_LEVEL, logging.INFO),
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
-    init_sentry(service_name="research-ingestion")
+    setup_logging_and_sentry(service_name="research-ingestion")
 
     gate_config = {
         "minimum_trade_count": args.minimum_trade_count,

--- a/scripts/ingest_market_events.py
+++ b/scripts/ingest_market_events.py
@@ -29,9 +29,9 @@ from datetime import date, timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
+from app.core.cli import setup_logging_and_sentry
 from app.core.db import AsyncSessionLocal
-from app.monitoring.sentry import capture_exception, init_sentry
+from app.monitoring.sentry import capture_exception
 from app.services.market_events.ingestion import (
     ingest_economic_events_for_date,
     ingest_kr_disclosures_for_date,
@@ -154,11 +154,7 @@ async def run_ingest(
 
 
 async def main(argv: list[str] | None = None) -> int:
-    logging.basicConfig(
-        level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
-    init_sentry(service_name="market-events-ingest")
+    setup_logging_and_sentry(service_name="market-events-ingest")
     ns = parse_args(argv)
 
     try:

--- a/scripts/ingest_research_reports.py
+++ b/scripts/ingest_research_reports.py
@@ -19,9 +19,9 @@ import json
 import logging
 from pathlib import Path
 
-from app.core.config import settings
+from app.core.cli import setup_logging_and_sentry
 from app.core.db import AsyncSessionLocal
-from app.monitoring.sentry import capture_exception, init_sentry
+from app.monitoring.sentry import capture_exception
 from app.schemas.research_reports import ResearchReportIngestionRequest
 from app.services.research_reports.ingestion import ingest_research_reports_v1
 
@@ -43,11 +43,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 async def main_async(argv: list[str] | None = None) -> int:
-    logging.basicConfig(
-        level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
-    init_sentry(service_name="ingest-research-reports")
+    setup_logging_and_sentry(service_name="ingest-research-reports")
     ns = parse_args(argv)
 
     if not ns.file.is_file():

--- a/scripts/sync_kr_candles.py
+++ b/scripts/sync_kr_candles.py
@@ -6,9 +6,8 @@ import argparse
 import asyncio
 import logging
 
-from app.core.config import settings
+from app.core.cli import run_async_job, setup_logging_and_sentry
 from app.jobs.kr_candles import run_kr_candles_sync
-from app.monitoring.sentry import capture_exception, init_sentry
 
 logger = logging.getLogger(__name__)
 
@@ -41,30 +40,21 @@ def _build_parser() -> argparse.ArgumentParser:
 async def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
+    setup_logging_and_sentry(service_name="kr-candles-sync")
 
-    logging.basicConfig(
-        level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
-    init_sentry(service_name="kr-candles-sync")
-
-    try:
+    async def _job() -> int:
         result = await run_kr_candles_sync(
             mode=args.mode,
             sessions=max(args.sessions, 1),
             user_id=args.user_id,
         )
-    except Exception as exc:
-        capture_exception(exc, process="sync_kr_candles")
-        logger.error("KR candles sync crashed: %s", exc, exc_info=True)
-        return 1
+        if result.get("status") != "completed":
+            logger.error("KR candles sync failed: %s", result)
+            return 1
+        logger.info("KR candles sync completed: %s", result)
+        return 0
 
-    if result.get("status") != "completed":
-        logger.error("KR candles sync failed: %s", result)
-        return 1
-
-    logger.info("KR candles sync completed: %s", result)
-    return 0
+    return await run_async_job(_job, process="sync_kr_candles")
 
 
 if __name__ == "__main__":

--- a/scripts/sync_kr_symbol_universe.py
+++ b/scripts/sync_kr_symbol_universe.py
@@ -5,33 +5,24 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from app.core.config import settings
+from app.core.cli import run_async_job, setup_logging_and_sentry
 from app.jobs.kr_symbol_universe import run_kr_symbol_universe_sync
-from app.monitoring.sentry import capture_exception, init_sentry
 
 logger = logging.getLogger(__name__)
 
 
 async def main() -> int:
-    logging.basicConfig(
-        level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
-    init_sentry(service_name="kr-symbol-universe-sync")
+    setup_logging_and_sentry(service_name="kr-symbol-universe-sync")
 
-    try:
+    async def _job() -> int:
         result = await run_kr_symbol_universe_sync()
-    except Exception as exc:
-        capture_exception(exc, process="sync_kr_symbol_universe")
-        logger.error("KR symbol universe sync crashed: %s", exc, exc_info=True)
-        return 1
+        if result.get("status") != "completed":
+            logger.error("KR symbol universe sync failed: %s", result)
+            return 1
+        logger.info("KR symbol universe sync completed: %s", result)
+        return 0
 
-    if result.get("status") != "completed":
-        logger.error("KR symbol universe sync failed: %s", result)
-        return 1
-
-    logger.info("KR symbol universe sync completed: %s", result)
-    return 0
+    return await run_async_job(_job, process="sync_kr_symbol_universe")
 
 
 if __name__ == "__main__":

--- a/scripts/sync_upbit_symbol_universe.py
+++ b/scripts/sync_upbit_symbol_universe.py
@@ -5,33 +5,24 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from app.core.config import settings
+from app.core.cli import run_async_job, setup_logging_and_sentry
 from app.jobs.upbit_symbol_universe import run_upbit_symbol_universe_sync
-from app.monitoring.sentry import capture_exception, init_sentry
 
 logger = logging.getLogger(__name__)
 
 
 async def main() -> int:
-    logging.basicConfig(
-        level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
-    init_sentry(service_name="upbit-symbol-universe-sync")
+    setup_logging_and_sentry(service_name="upbit-symbol-universe-sync")
 
-    try:
+    async def _job() -> int:
         result = await run_upbit_symbol_universe_sync()
-    except Exception as exc:
-        capture_exception(exc, process="sync_upbit_symbol_universe")
-        logger.error("Upbit symbol universe sync crashed: %s", exc, exc_info=True)
-        return 1
+        if result.get("status") != "completed":
+            logger.error("Upbit symbol universe sync failed: %s", result)
+            return 1
+        logger.info("Upbit symbol universe sync completed: %s", result)
+        return 0
 
-    if result.get("status") != "completed":
-        logger.error("Upbit symbol universe sync failed: %s", result)
-        return 1
-
-    logger.info("Upbit symbol universe sync completed: %s", result)
-    return 0
+    return await run_async_job(_job, process="sync_upbit_symbol_universe")
 
 
 if __name__ == "__main__":

--- a/scripts/sync_us_candles.py
+++ b/scripts/sync_us_candles.py
@@ -7,9 +7,8 @@ import asyncio
 import logging
 from typing import cast
 
-from app.core.config import settings
+from app.core.cli import run_async_job, setup_logging_and_sentry
 from app.jobs.us_candles import run_us_candles_sync
-from app.monitoring.sentry import capture_exception, init_sentry
 
 logger = logging.getLogger(__name__)
 
@@ -45,30 +44,21 @@ async def main(argv: list[str] | None = None) -> int:
     mode = cast(str, args.mode)
     sessions = cast(int, args.sessions)
     user_id = cast(int, args.user_id)
+    setup_logging_and_sentry(service_name="us-candles-sync")
 
-    logging.basicConfig(
-        level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
-    _ = init_sentry(service_name="us-candles-sync")
-
-    try:
+    async def _job() -> int:
         result = await run_us_candles_sync(
             mode=mode,
             sessions=max(sessions, 1),
             user_id=user_id,
         )
-    except Exception as exc:
-        capture_exception(exc, process="sync_us_candles")
-        logger.error("US candles sync crashed: %s", exc, exc_info=True)
-        return 1
+        if result.get("status") != "completed":
+            logger.error("US candles sync failed: %s", result)
+            return 1
+        logger.info("US candles sync completed: %s", result)
+        return 0
 
-    if result.get("status") != "completed":
-        logger.error("US candles sync failed: %s", result)
-        return 1
-
-    logger.info("US candles sync completed: %s", result)
-    return 0
+    return await run_async_job(_job, process="sync_us_candles")
 
 
 if __name__ == "__main__":

--- a/scripts/sync_us_symbol_universe.py
+++ b/scripts/sync_us_symbol_universe.py
@@ -5,33 +5,24 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from app.core.config import settings
+from app.core.cli import run_async_job, setup_logging_and_sentry
 from app.jobs.us_symbol_universe import run_us_symbol_universe_sync
-from app.monitoring.sentry import capture_exception, init_sentry
 
 logger = logging.getLogger(__name__)
 
 
 async def main() -> int:
-    logging.basicConfig(
-        level=getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO),
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    )
-    init_sentry(service_name="us-symbol-universe-sync")
+    setup_logging_and_sentry(service_name="us-symbol-universe-sync")
 
-    try:
+    async def _job() -> int:
         result = await run_us_symbol_universe_sync()
-    except Exception as exc:
-        capture_exception(exc, process="sync_us_symbol_universe")
-        logger.error("US symbol universe sync crashed: %s", exc, exc_info=True)
-        return 1
+        if result.get("status") != "completed":
+            logger.error("US symbol universe sync failed: %s", result)
+            return 1
+        logger.info("US symbol universe sync completed: %s", result)
+        return 0
 
-    if result.get("status") != "completed":
-        logger.error("US symbol universe sync failed: %s", result)
-        return 1
-
-    logger.info("US symbol universe sync completed: %s", result)
-    return 0
+    return await run_async_job(_job, process="sync_us_symbol_universe")
 
 
 if __name__ == "__main__":

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -1,0 +1,120 @@
+# tests/core/test_cli.py
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.unit
+class TestSetupLoggingAndSentry:
+    def test_calls_basicConfig_with_service_name_format(self, monkeypatch):
+        """setup_logging_and_sentry가 service_name을 포함한 format으로 basicConfig를 호출하는지 확인."""
+        from app.core import cli
+
+        mock_basic = MagicMock()
+        monkeypatch.setattr(logging, "basicConfig", mock_basic)
+        monkeypatch.setattr(cli, "init_sentry", MagicMock())
+        monkeypatch.setattr(cli.settings, "LOG_LEVEL", "DEBUG")
+
+        cli.setup_logging_and_sentry(service_name="test-svc")
+
+        mock_basic.assert_called_once()
+        _, kwargs = mock_basic.call_args
+        assert kwargs["level"] == logging.DEBUG
+        assert "%(asctime)s" in kwargs["format"]
+        assert "%(name)s" in kwargs["format"]
+        assert "%(levelname)s" in kwargs["format"]
+        assert "%(message)s" in kwargs["format"]
+
+    def test_calls_init_sentry_with_service_name(self, monkeypatch):
+        """setup_logging_and_sentry가 init_sentry를 service_name=<name>으로 호출하는지 확인."""
+        from app.core import cli
+
+        mock_sentry = MagicMock()
+        monkeypatch.setattr(logging, "basicConfig", MagicMock())
+        monkeypatch.setattr(cli, "init_sentry", mock_sentry)
+        monkeypatch.setattr(cli.settings, "LOG_LEVEL", "INFO")
+
+        cli.setup_logging_and_sentry(service_name="my-service")
+
+        mock_sentry.assert_called_once_with(service_name="my-service")
+
+    def test_log_level_uppercased(self, monkeypatch):
+        """settings.LOG_LEVEL 소문자도 올바른 레벨로 변환되는지 확인."""
+        from app.core import cli
+
+        mock_basic = MagicMock()
+        monkeypatch.setattr(logging, "basicConfig", mock_basic)
+        monkeypatch.setattr(cli, "init_sentry", MagicMock())
+        monkeypatch.setattr(cli.settings, "LOG_LEVEL", "warning")
+
+        cli.setup_logging_and_sentry(service_name="svc")
+
+        _, kwargs = mock_basic.call_args
+        assert kwargs["level"] == logging.WARNING
+
+    def test_unknown_log_level_falls_back_to_info(self, monkeypatch):
+        """알 수 없는 LOG_LEVEL은 logging.INFO로 폴백하는지 확인."""
+        from app.core import cli
+
+        mock_basic = MagicMock()
+        monkeypatch.setattr(logging, "basicConfig", mock_basic)
+        monkeypatch.setattr(cli, "init_sentry", MagicMock())
+        monkeypatch.setattr(cli.settings, "LOG_LEVEL", "INVALID_LEVEL")
+
+        cli.setup_logging_and_sentry(service_name="svc")
+
+        _, kwargs = mock_basic.call_args
+        assert kwargs["level"] == logging.INFO
+
+
+@pytest.mark.unit
+class TestRunAsyncJob:
+    @pytest.mark.asyncio
+    async def test_returns_zero_on_success(self):
+        """coro_factory가 0 반환 시 run_async_job도 0 반환."""
+        from app.core.cli import run_async_job
+
+        result = await run_async_job(AsyncMock(return_value=0), process="test_proc")
+
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_nonzero_on_job_failure(self):
+        """coro_factory가 1 반환 시 run_async_job도 1 반환."""
+        from app.core.cli import run_async_job
+
+        result = await run_async_job(AsyncMock(return_value=1), process="test_proc")
+
+        assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_captures_exception_and_returns_one(self, monkeypatch):
+        """coro_factory 예외 발생 시 capture_exception 호출 + exit 1 반환."""
+        from app.core import cli
+
+        mock_capture = MagicMock()
+        monkeypatch.setattr(cli, "capture_exception", mock_capture)
+
+        exc = RuntimeError("boom")
+
+        async def _fail() -> int:
+            raise exc
+
+        result = await cli.run_async_job(_fail, process="sync_test")
+
+        assert result == 1
+        mock_capture.assert_called_once_with(exc, process="sync_test")
+
+    @pytest.mark.asyncio
+    async def test_does_not_swallow_system_exit(self):
+        """SystemExit은 capture하지 않고 전파되는지 확인."""
+        from app.core.cli import run_async_job
+
+        async def _sys_exit() -> int:
+            raise SystemExit(2)
+
+        with pytest.raises(SystemExit):
+            await run_async_job(_sys_exit, process="test_proc")

--- a/tests/core/test_cli.py
+++ b/tests/core/test_cli.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 

--- a/tests/test_kr_candles_sync.py
+++ b/tests/test_kr_candles_sync.py
@@ -227,9 +227,10 @@ async def test_task_payload_failure(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.asyncio
 async def test_script_main_exit_codes(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.core.cli as _cli
     from scripts import sync_kr_candles
 
-    monkeypatch.setattr(sync_kr_candles, "init_sentry", lambda **_: None)
+    monkeypatch.setattr(_cli, "init_sentry", lambda **_: None)
     monkeypatch.setattr(
         sync_kr_candles,
         "run_kr_candles_sync",
@@ -247,7 +248,7 @@ async def test_script_main_exit_codes(monkeypatch: pytest.MonkeyPatch) -> None:
     assert failed_status_code == 1
 
     capture_mock = MagicMock()
-    monkeypatch.setattr(sync_kr_candles, "capture_exception", capture_mock)
+    monkeypatch.setattr(_cli, "capture_exception", capture_mock)
     monkeypatch.setattr(
         sync_kr_candles,
         "run_kr_candles_sync",

--- a/tests/test_kr_symbol_universe_sync.py
+++ b/tests/test_kr_symbol_universe_sync.py
@@ -496,7 +496,9 @@ async def test_task_returns_failure_payload_on_exception(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_script_main_returns_zero_on_success(monkeypatch):
-    monkeypatch.setattr(sync_kr_symbol_universe, "init_sentry", lambda **_: None)
+    import app.core.cli as _cli
+
+    monkeypatch.setattr(_cli, "init_sentry", lambda **_: None)
     monkeypatch.setattr(
         sync_kr_symbol_universe,
         "run_kr_symbol_universe_sync",
@@ -510,7 +512,9 @@ async def test_script_main_returns_zero_on_success(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_script_main_returns_nonzero_on_failed_status(monkeypatch):
-    monkeypatch.setattr(sync_kr_symbol_universe, "init_sentry", lambda **_: None)
+    import app.core.cli as _cli
+
+    monkeypatch.setattr(_cli, "init_sentry", lambda **_: None)
     monkeypatch.setattr(
         sync_kr_symbol_universe,
         "run_kr_symbol_universe_sync",
@@ -524,9 +528,11 @@ async def test_script_main_returns_nonzero_on_failed_status(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_script_main_returns_nonzero_on_exception(monkeypatch):
+    import app.core.cli as _cli
+
     capture_mock = MagicMock()
-    monkeypatch.setattr(sync_kr_symbol_universe, "init_sentry", lambda **_: None)
-    monkeypatch.setattr(sync_kr_symbol_universe, "capture_exception", capture_mock)
+    monkeypatch.setattr(_cli, "init_sentry", lambda **_: None)
+    monkeypatch.setattr(_cli, "capture_exception", capture_mock)
     monkeypatch.setattr(
         sync_kr_symbol_universe,
         "run_kr_symbol_universe_sync",

--- a/tests/test_upbit_symbol_universe_sync.py
+++ b/tests/test_upbit_symbol_universe_sync.py
@@ -266,7 +266,9 @@ async def test_task_returns_failure_payload_on_exception(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_script_main_returns_zero_on_success(monkeypatch):
-    monkeypatch.setattr(sync_upbit_symbol_universe, "init_sentry", lambda **_: None)
+    import app.core.cli as _cli
+
+    monkeypatch.setattr(_cli, "init_sentry", lambda **_: None)
     monkeypatch.setattr(
         sync_upbit_symbol_universe,
         "run_upbit_symbol_universe_sync",
@@ -280,7 +282,9 @@ async def test_script_main_returns_zero_on_success(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_script_main_returns_nonzero_on_failed_status(monkeypatch):
-    monkeypatch.setattr(sync_upbit_symbol_universe, "init_sentry", lambda **_: None)
+    import app.core.cli as _cli
+
+    monkeypatch.setattr(_cli, "init_sentry", lambda **_: None)
     monkeypatch.setattr(
         sync_upbit_symbol_universe,
         "run_upbit_symbol_universe_sync",
@@ -294,9 +298,11 @@ async def test_script_main_returns_nonzero_on_failed_status(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_script_main_returns_nonzero_on_exception(monkeypatch):
+    import app.core.cli as _cli
+
     capture_mock = MagicMock()
-    monkeypatch.setattr(sync_upbit_symbol_universe, "init_sentry", lambda **_: None)
-    monkeypatch.setattr(sync_upbit_symbol_universe, "capture_exception", capture_mock)
+    monkeypatch.setattr(_cli, "init_sentry", lambda **_: None)
+    monkeypatch.setattr(_cli, "capture_exception", capture_mock)
     monkeypatch.setattr(
         sync_upbit_symbol_universe,
         "run_upbit_symbol_universe_sync",

--- a/tests/test_us_candles_sync.py
+++ b/tests/test_us_candles_sync.py
@@ -1407,10 +1407,11 @@ def test_us_task_schedule_metadata() -> None:
 
 @pytest.mark.asyncio
 async def test_us_script_main_exit_codes(monkeypatch: pytest.MonkeyPatch) -> None:
+    import app.core.cli as _cli
     from scripts import sync_us_candles
 
     success_mock = AsyncMock(return_value={"status": "completed", "rows_upserted": 1})
-    monkeypatch.setattr(sync_us_candles, "init_sentry", lambda **_: None)
+    monkeypatch.setattr(_cli, "init_sentry", lambda **_: None)
     monkeypatch.setattr(
         sync_us_candles,
         "run_us_candles_sync",
@@ -1431,7 +1432,7 @@ async def test_us_script_main_exit_codes(monkeypatch: pytest.MonkeyPatch) -> Non
     assert failed_status_code == 1
 
     capture_mock = MagicMock()
-    monkeypatch.setattr(sync_us_candles, "capture_exception", capture_mock)
+    monkeypatch.setattr(_cli, "capture_exception", capture_mock)
     monkeypatch.setattr(
         sync_us_candles,
         "run_us_candles_sync",

--- a/tests/test_us_symbol_universe_sync.py
+++ b/tests/test_us_symbol_universe_sync.py
@@ -240,7 +240,9 @@ async def test_task_returns_failure_payload_on_exception(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_script_main_returns_zero_on_success(monkeypatch):
-    monkeypatch.setattr(sync_us_symbol_universe, "init_sentry", lambda **_: None)
+    import app.core.cli as _cli
+
+    monkeypatch.setattr(_cli, "init_sentry", lambda **_: None)
     monkeypatch.setattr(
         sync_us_symbol_universe,
         "run_us_symbol_universe_sync",
@@ -254,7 +256,9 @@ async def test_script_main_returns_zero_on_success(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_script_main_returns_nonzero_on_failed_status(monkeypatch):
-    monkeypatch.setattr(sync_us_symbol_universe, "init_sentry", lambda **_: None)
+    import app.core.cli as _cli
+
+    monkeypatch.setattr(_cli, "init_sentry", lambda **_: None)
     monkeypatch.setattr(
         sync_us_symbol_universe,
         "run_us_symbol_universe_sync",
@@ -268,9 +272,11 @@ async def test_script_main_returns_nonzero_on_failed_status(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_script_main_returns_nonzero_on_exception(monkeypatch):
+    import app.core.cli as _cli
+
     capture_mock = MagicMock()
-    monkeypatch.setattr(sync_us_symbol_universe, "init_sentry", lambda **_: None)
-    monkeypatch.setattr(sync_us_symbol_universe, "capture_exception", capture_mock)
+    monkeypatch.setattr(_cli, "init_sentry", lambda **_: None)
+    monkeypatch.setattr(_cli, "capture_exception", capture_mock)
     monkeypatch.setattr(
         sync_us_symbol_universe,
         "run_us_symbol_universe_sync",


### PR DESCRIPTION
## Summary
- Extract identical logging+sentry bootstrap and async runner pattern from 8 sync/ingest scripts into `app/core/cli.py`.
- Migrate sync_kr_candles, sync_us_candles, sync_*_symbol_universe (3개), ingest_market_events, ingest_research_reports, ingest_freqtrade_report.

Refactor unit: W1-3 (Wave 1, low-risk).
Plan: `docs/superpowers/plans/2026-05-09-refactor-W1-3-cli-bootstrap.md`

Per-script CLI argument differences are preserved in each script (no logic-branch parameterization). Only identical bootstrap consolidated.

`ingest_*` scripts: `setup_logging_and_sentry` only (exception paths differ per script, `run_async_job` not applied).

## Test plan
- [ ] `uv run pytest tests/core/test_cli.py -v` → 8 passed
- [ ] All 8 scripts importable without error
- [ ] `--help` 출력 정상 (시그니처 보존 확인)
- [ ] Cron/deployment yaml 변경 불필요 검증
- [ ] `uv run ruff check app/core/cli.py` → no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)