### PR TITLE
feat(invest): localize screener markets

### DIFF
--- a/app/mcp_server/tooling/screening/kr.py
+++ b/app/mcp_server/tooling/screening/kr.py
@@ -388,11 +388,13 @@ async def _normalize_kr_results(
             row, current_price=_to_optional_float(row.get("price"))
         )
 
+        krx_name = _clean_text(base.get("name"))
+        display_name = krx_name or _pick_display_name(row) or code
         stock: dict[str, Any] = {
             "symbol": code,
             "short_code": code,
             "code": base.get("code") or code,
-            "name": _pick_display_name(row),
+            "name": display_name,
             "price": _to_optional_float(row.get("price")),
             "rsi": _to_optional_float(row.get("relative_strength_index_14")),
             "adx": _to_optional_float(row.get("average_directional_index_14")),
@@ -444,7 +446,7 @@ async def _normalize_kr_results(
             stock["market_cap_krw"] = market_cap * 100_000_000
         stock["instrument_type"] = classify_kr_instrument(
             code,
-            stock.get("name") or base.get("name"),
+            display_name,
             _get_first_present(row, "subtype", "type"),
         )
 

--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -7,7 +7,7 @@ import 하지 않는다. order / watch / scheduler / mutation 경로 import 금�
 from __future__ import annotations
 
 from datetime import date
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -185,6 +185,7 @@ async def get_screener_results_endpoint(
     service: Annotated[InvestHomeService, Depends(get_invest_home_service)],
     screening_service: Annotated[Any, Depends(get_screener_service_dep)],
     preset: str = Query(..., min_length=1),
+    market: Literal["kr", "us"] = Query("kr"),
 ) -> ScreenerResultsResponse:
     home = await service.get_home(user_id=user.id)
     resolver = await build_relation_resolver(
@@ -194,4 +195,5 @@ async def get_screener_results_endpoint(
         preset_id=preset,
         screening_service=screening_service,
         resolver=resolver,
+        market=market,
     )

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -24,9 +24,9 @@ SCREENER_PRESETS: list[ScreenerPreset] = [
         filterChips=[
             ScreenerFilterChip(label="국내", detail=None),
             ScreenerFilterChip(label="주가등락률", detail="1주일 전 보다 · 0% 이상"),
-            ScreenerFilterChip(label="주가 연속상승", detail="5일 이상 연속"),
+            ScreenerFilterChip(label="주가 연속상승", detail="최신 일봉 기준"),
         ],
-        metricLabel="주가등락률",
+        metricLabel="연속상승",
         market="kr",
     ),
     ScreenerPreset(
@@ -145,18 +145,45 @@ _SCREENING_FILTERS: dict[str, dict[str, object]] = {
 }
 
 
-def preset_definitions() -> list[ScreenerPreset]:
-    """Return a copy of the static preset list."""
-    return list(SCREENER_PRESETS)
+def _market_chip(market: str) -> ScreenerFilterChip:
+    return ScreenerFilterChip(label="미국" if market == "us" else "국내", detail=None)
 
 
-def get_preset(preset_id: str) -> ScreenerPreset | None:
+def _with_market(preset: ScreenerPreset, market: str) -> ScreenerPreset:
+    chips = list(preset.filterChips)
+    if chips:
+        chips[0] = _market_chip(market)
+    else:
+        chips = [_market_chip(market)]
+    return preset.model_copy(update={"market": market, "filterChips": chips})
+
+
+def preset_definitions(market: str = "kr") -> list[ScreenerPreset]:
+    """Return preset definitions localized for the requested market."""
+    normalized_market = "us" if market == "us" else "kr"
+    return [_with_market(p, normalized_market) for p in SCREENER_PRESETS]
+
+
+def get_preset(preset_id: str, market: str = "kr") -> ScreenerPreset | None:
+    normalized_market = "us" if market == "us" else "kr"
     for p in SCREENER_PRESETS:
         if p.id == preset_id:
-            return p
+            return _with_market(p, normalized_market)
     return None
 
 
-def screening_filters_for(preset_id: str) -> dict[str, object]:
-    """Return the screening service kwargs for a preset, or {} if unknown."""
-    return dict(_SCREENING_FILTERS.get(preset_id, {}))
+def screening_filters_for(preset_id: str, market: str = "kr") -> dict[str, object]:
+    """Return screening service kwargs for a preset/market, or {} if unknown."""
+    filters = dict(_SCREENING_FILTERS.get(preset_id, {}))
+    if not filters:
+        return {}
+    normalized_market = "us" if market == "us" else "kr"
+    filters["market"] = normalized_market
+    if normalized_market == "us":
+        # The US screening path supports PER/dividend/RSI/volume/change filters,
+        # but not the KR-specific PBR constraint used by this logical preset.
+        filters.pop("max_pbr", None)
+        if preset_id == "growth_expectation":
+            # US engine expects market cap in USD, not KRW.
+            filters["min_market_cap"] = 1_000_000_000.0
+    return filters

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -181,7 +181,6 @@ def _normalize_market_cap_krw(
     return None, []
 
 
-
 def _format_market_cap_us(market_cap: float | None) -> str:
     if market_cap is None or market_cap <= 0:
         return "-"
@@ -203,6 +202,7 @@ def _format_market_cap(row: dict[str, Any], market: str) -> tuple[str, list[str]
     market_cap, warnings = _normalize_market_cap_krw(row, market)
     return _format_market_cap_kr(market_cap), warnings
 
+
 def _format_volume(volume: float | None) -> str:
     if volume is None:
         return "-"
@@ -215,7 +215,9 @@ def calculate_consecutive_up_days(closes: Sequence[float | int | None]) -> int |
     if len(values) < 2:
         return None
     streak = 0
-    for current, previous in zip(reversed(values[1:]), reversed(values[:-1]), strict=False):
+    for current, previous in zip(
+        reversed(values[1:]), reversed(values[:-1]), strict=False
+    ):
         if current > previous:
             streak += 1
             continue
@@ -297,9 +299,14 @@ async def build_screener_results(
                 name=_clean_text(row.get("name")) or symbol,
                 logoUrl=row.get("logo_url"),
                 isWatched=is_watched,
-                priceLabel=_format_price(row.get("close") or row.get("price") or row.get("current_price"), market),
+                priceLabel=_format_price(
+                    row.get("close") or row.get("price") or row.get("current_price"),
+                    market,
+                ),
                 changePctLabel=change_pct_label,
-                changeAmountLabel=_format_change_amount(row.get("change_amount"), market),
+                changeAmountLabel=_format_change_amount(
+                    row.get("change_amount"), market
+                ),
                 changeDirection=direction,
                 category=str(row.get("sector") or row.get("category") or "-"),
                 marketCapLabel=market_cap_label,

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -12,6 +12,7 @@ modules — see tests/test_invest_view_model_safety.py.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any, Protocol
 
 from app.schemas.invest_screener import (
@@ -41,13 +42,13 @@ class _ResolverProto(Protocol):
 
 def build_screener_presets() -> ScreenerPresetsResponse:
     return ScreenerPresetsResponse(
-        presets=preset_definitions(),
+        presets=preset_definitions("kr"),
         selectedPresetId=DEFAULT_PRESET_ID,
     )
 
 
 _METRIC_FIELD: dict[str, str] = {
-    "consecutive_gainers": "change_rate",
+    "consecutive_gainers": "consecutive_up_days",
     "cheap_value": "per",
     "steady_dividend": "dividend_yield",
     "oversold_recovery": "rsi",
@@ -64,16 +65,20 @@ def _format_change_pct(rate: float | None) -> tuple[str, ChangeDirection]:
     return f"{sign}{rate:.2f}%", direction
 
 
-def _format_change_amount(amount: float | None, currency: str = "원") -> str:
+def _format_change_amount(amount: float | None, market: str = "kr") -> str:
     if amount is None:
         return "-"
-    sign = "+" if amount > 0 else ""
-    return f"{sign}{int(amount):,}{currency}"
+    sign = "+" if amount > 0 else "-" if amount < 0 else ""
+    if market == "us":
+        return f"{sign}${abs(float(amount)):,.2f}"
+    return f"{sign}{abs(int(amount)):,}원"
 
 
-def _format_price(close: float | None) -> str:
+def _format_price(close: float | None, market: str = "kr") -> str:
     if close is None:
         return "-"
+    if market == "us":
+        return f"${float(close):,.2f}"
     return f"{int(close):,}원"
 
 
@@ -176,10 +181,54 @@ def _normalize_market_cap_krw(
     return None, []
 
 
+
+def _format_market_cap_us(market_cap: float | None) -> str:
+    if market_cap is None or market_cap <= 0:
+        return "-"
+    if market_cap >= 1_000_000_000_000:
+        return f"${market_cap / 1_000_000_000_000:.2f}T"
+    if market_cap >= 1_000_000_000:
+        return f"${market_cap / 1_000_000_000:.1f}B"
+    if market_cap >= 1_000_000:
+        return f"${market_cap / 1_000_000:.1f}M"
+    return f"${market_cap:,.0f}"
+
+
+def _format_market_cap(row: dict[str, Any], market: str) -> tuple[str, list[str]]:
+    if market == "us":
+        market_cap = _coerce_float(row.get("market_cap_usd"))
+        if market_cap is None:
+            market_cap = _coerce_float(row.get("market_cap"))
+        return _format_market_cap_us(market_cap), []
+    market_cap, warnings = _normalize_market_cap_krw(row, market)
+    return _format_market_cap_kr(market_cap), warnings
+
 def _format_volume(volume: float | None) -> str:
     if volume is None:
         return "-"
     return f"{int(volume):,}"
+
+
+def calculate_consecutive_up_days(closes: Sequence[float | int | None]) -> int | None:
+    values = [_coerce_float(v) for v in closes]
+    values = [v for v in values if v is not None]
+    if len(values) < 2:
+        return None
+    streak = 0
+    for current, previous in zip(reversed(values[1:]), reversed(values[:-1]), strict=False):
+        if current > previous:
+            streak += 1
+            continue
+        break
+    return streak
+
+
+def _enrich_consecutive_up_days(preset_id: str, row: dict[str, Any]) -> None:
+    if preset_id != "consecutive_gainers" or row.get("consecutive_up_days") is not None:
+        return
+    history = row.get("daily_closes") or row.get("close_history") or row.get("closes")
+    if isinstance(history, Sequence) and not isinstance(history, (str, bytes)):
+        row["consecutive_up_days"] = calculate_consecutive_up_days(history)
 
 
 def _metric_value_label(preset_id: str, row: dict[str, Any]) -> tuple[str, list[str]]:
@@ -188,7 +237,11 @@ def _metric_value_label(preset_id: str, row: dict[str, Any]) -> tuple[str, list[
         return "-", []
     value = row.get(field)
     if value is None:
+        if field == "consecutive_up_days":
+            return "-", ["연속상승 데이터 준비중"]
         return "-", [f"{field.upper()} 데이터 준비중"]
+    if field == "consecutive_up_days":
+        return f"{int(value)}일", []
     if field == "change_rate":
         sign = "+" if value > 0 else ""
         return f"{sign}{value:.2f}%", []
@@ -205,8 +258,10 @@ async def build_screener_results(
     preset_id: str,
     screening_service: _ScreeningServiceProto,
     resolver: _ResolverProto,
+    market: str = "kr",
 ) -> ScreenerResultsResponse:
-    preset = get_preset(preset_id)
+    requested_market = "us" if market == "us" else "kr"
+    preset = get_preset(preset_id, requested_market)
     if preset is None:
         return ScreenerResultsResponse(
             presetId=preset_id,
@@ -218,17 +273,18 @@ async def build_screener_results(
             warnings=[f"알 수 없는 프리셋: {preset_id}"],
         )
 
-    filters = screening_filters_for(preset_id)
+    filters = screening_filters_for(preset_id, requested_market)
     raw = await screening_service.list_screening(**filters)
     rows: list[dict[str, Any]] = list(raw.get("results") or raw.get("stocks") or [])
     upstream_warnings: list[str] = list(raw.get("warnings") or [])
 
     results: list[ScreenerResultRow] = []
     for idx, row in enumerate(rows, start=1):
-        market = _normalize_market(row.get("market"))
+        market = _normalize_market(row.get("market") or requested_market)
         symbol, symbol_warnings = _normalize_symbol(row, market)
-        market_cap, market_cap_warnings = _normalize_market_cap_krw(row, market)
+        market_cap_label, market_cap_warnings = _format_market_cap(row, market)
         change_pct_label, direction = _format_change_pct(row.get("change_rate"))
+        _enrich_consecutive_up_days(preset_id, row)
         metric_label, metric_warnings = _metric_value_label(preset_id, row)
         relation = resolver.relation(market, symbol)
         is_watched = relation in ("watchlist", "both")
@@ -241,12 +297,12 @@ async def build_screener_results(
                 name=_clean_text(row.get("name")) or symbol,
                 logoUrl=row.get("logo_url"),
                 isWatched=is_watched,
-                priceLabel=_format_price(row.get("close") or row.get("price")),
+                priceLabel=_format_price(row.get("close") or row.get("price") or row.get("current_price"), market),
                 changePctLabel=change_pct_label,
-                changeAmountLabel=_format_change_amount(row.get("change_amount")),
+                changeAmountLabel=_format_change_amount(row.get("change_amount"), market),
                 changeDirection=direction,
                 category=str(row.get("sector") or row.get("category") or "-"),
-                marketCapLabel=_format_market_cap_kr(market_cap),
+                marketCapLabel=market_cap_label,
                 volumeLabel=_format_volume(row.get("volume")),
                 analystLabel=str(row.get("analyst_label") or "-"),
                 metricValueLabel=metric_label,

--- a/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
@@ -16,7 +16,7 @@ const PRESETS = {
       description: "일주일 연속 상승세를 보이는 주식",
       badges: ["인기"],
       filterChips: [{ label: "주가등락률", detail: "1주일 전 보다 · 0% 이상" }],
-      metricLabel: "주가등락률", market: "kr" as const,
+      metricLabel: "연속상승", market: "kr" as const,
     },
     {
       id: "cheap_value", name: "아직 저렴한 가치주",
@@ -35,14 +35,14 @@ const ROW = {
   priceLabel: "80,000원", changePctLabel: "+1.23%", changeAmountLabel: "+970원",
   changeDirection: "up" as const, category: "반도체",
   marketCapLabel: "478조원", volumeLabel: "12,345,678",
-  analystLabel: "구매", metricValueLabel: "+1.23%", warnings: [],
+  analystLabel: "구매", metricValueLabel: "5일", warnings: [],
 };
 
 const RESULTS_GAINERS = {
   presetId: "consecutive_gainers", title: "연속 상승세",
   description: "일주일 연속 상승세를 보이는 주식",
   filterChips: [{ label: "주가등락률", detail: "1주일 전 보다 · 0% 이상" }],
-  metricLabel: "주가등락률", results: [ROW], warnings: [],
+  metricLabel: "연속상승", results: [ROW], warnings: [],
 };
 
 const RESULTS_VALUE = {
@@ -74,9 +74,24 @@ beforeEach(() => {
     tab: "kr", asOf: new Date().toISOString(), items: [], meta: { warnings: [] },
   });
   vi.spyOn(screenerApi, "fetchScreenerPresets").mockResolvedValue(PRESETS);
-  vi.spyOn(screenerApi, "fetchScreenerResults").mockImplementation(async (id: string) =>
-    id === "cheap_value" ? RESULTS_VALUE : RESULTS_GAINERS,
-  );
+  vi.spyOn(screenerApi, "fetchScreenerResults").mockImplementation(async (id: string, market = "kr") => {
+    if (market === "us") {
+      return {
+        ...RESULTS_VALUE,
+        title: "미국 가치주",
+        results: [{
+          ...ROW,
+          symbol: "AAPL",
+          market: "us" as const,
+          name: "Apple Inc.",
+          priceLabel: "$210.40",
+          marketCapLabel: "$3.20T",
+          category: "Technology",
+        }],
+      };
+    }
+    return id === "cheap_value" ? RESULTS_VALUE : RESULTS_GAINERS;
+  });
 });
 
 test("renders the default preset and switches when another preset is clicked", async () => {
@@ -87,8 +102,8 @@ test("renders the default preset and switches when another preset is clicked", a
   await waitFor(() =>
     expect(screen.getByText("PER, PBR 모두 낮은 저평가 종목")).toBeInTheDocument(),
   );
-  expect(screenerApi.fetchScreenerResults).toHaveBeenCalledWith("consecutive_gainers");
-  expect(screenerApi.fetchScreenerResults).toHaveBeenCalledWith("cheap_value");
+  expect(screenerApi.fetchScreenerResults).toHaveBeenCalledWith("consecutive_gainers", "kr");
+  expect(screenerApi.fetchScreenerResults).toHaveBeenCalledWith("cheap_value", "kr");
 });
 
 test("shows an empty-state message when results are empty", async () => {
@@ -99,4 +114,15 @@ test("shows an empty-state message when results are empty", async () => {
   await waitFor(() =>
     expect(screen.getByText(/표시할 종목이 없습니다/)).toBeInTheDocument(),
   );
+});
+
+
+test("switches to the US market", async () => {
+  render(wrap(<DesktopScreenerPage />));
+  await waitFor(() => expect(screen.getByText("삼성전자")).toBeInTheDocument());
+
+  await userEvent.click(screen.getByRole("button", { name: "미국" }));
+
+  await waitFor(() => expect(screen.getByText("Apple Inc.")).toBeInTheDocument());
+  expect(screenerApi.fetchScreenerResults).toHaveBeenCalledWith("consecutive_gainers", "us");
 });

--- a/frontend/invest/src/api/screener.ts
+++ b/frontend/invest/src/api/screener.ts
@@ -1,5 +1,6 @@
 import type {
   ScreenerPresetsResponse,
+  ScreenerMarket,
   ScreenerResultsResponse,
 } from "../types/screener";
 
@@ -11,8 +12,9 @@ export async function fetchScreenerPresets(): Promise<ScreenerPresetsResponse> {
 
 export async function fetchScreenerResults(
   presetId: string,
+  market: Extract<ScreenerMarket, "kr" | "us"> = "kr",
 ): Promise<ScreenerResultsResponse> {
-  const q = new URLSearchParams({ preset: presetId });
+  const q = new URLSearchParams({ preset: presetId, market });
   const res = await fetch(`/invest/api/screener/results?${q}`, { credentials: "include" });
   if (!res.ok) throw new Error(`screener/results ${res.status}`);
   return res.json();

--- a/frontend/invest/src/desktop/screener/screener.css
+++ b/frontend/invest/src/desktop/screener/screener.css
@@ -49,3 +49,28 @@
 .screener-modal-category-item { background: var(--surface-2); color: var(--fg-1); padding: 6px 10px; border-radius: 999px; font-size: 12px; }
 .screener-modal-footer { display: flex; justify-content: flex-end; gap: 8px; padding: 12px 20px; border-top: 1px solid var(--divider); }
 .screener-modal-footer button { background: var(--surface-2); color: var(--fg-3); border: 0; padding: 6px 12px; border-radius: 8px; cursor: not-allowed; font-size: 12px; font-family: inherit; }
+
+.screener-market-toggle {
+  display: inline-flex;
+  gap: 4px;
+  padding: 4px;
+  margin: 0 0 12px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--bg-2);
+}
+
+.screener-market-toggle button {
+  border: 0;
+  border-radius: 999px;
+  padding: 7px 14px;
+  background: transparent;
+  color: var(--fg-2);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.screener-market-toggle button.is-active {
+  background: var(--fg);
+  color: var(--bg);
+}

--- a/frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx
@@ -7,6 +7,7 @@ import { ScreenerResultsTable } from "../../desktop/screener/ScreenerResultsTabl
 import { ScreenerFilterModal } from "../../desktop/screener/ScreenerFilterModal";
 import { fetchScreenerPresets, fetchScreenerResults } from "../../api/screener";
 import type {
+  ScreenerMarket,
   ScreenerPresetsResponse,
   ScreenerResultsResponse,
 } from "../../types/screener";
@@ -15,6 +16,7 @@ import "../../desktop/screener/screener.css";
 export function DesktopScreenerPage() {
   const [presets, setPresets] = useState<ScreenerPresetsResponse | undefined>();
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selectedMarket, setSelectedMarket] = useState<Extract<ScreenerMarket, "kr" | "us">>("kr");
   const [results, setResults] = useState<ScreenerResultsResponse | undefined>();
   const [err, setErr] = useState<string | undefined>();
   const [modalOpen, setModalOpen] = useState(false);
@@ -37,7 +39,7 @@ export function DesktopScreenerPage() {
     let cancel = false;
     setResults(undefined);
     setErr(undefined);
-    fetchScreenerResults(selectedId)
+    fetchScreenerResults(selectedId, selectedMarket)
       .then((r) => {
         if (cancel) return;
         setErr(undefined);
@@ -45,7 +47,7 @@ export function DesktopScreenerPage() {
       })
       .catch((e) => !cancel && setErr(String(e?.message ?? e)));
     return () => { cancel = true; };
-  }, [selectedId]);
+  }, [selectedId, selectedMarket]);
 
   return (
     <DesktopShell
@@ -58,6 +60,24 @@ export function DesktopScreenerPage() {
       }
       center={
         <div data-testid="screener-center">
+          <div className="screener-market-toggle" role="group" aria-label="시장 선택">
+            <button
+              type="button"
+              className={selectedMarket === "kr" ? "is-active" : ""}
+              aria-pressed={selectedMarket === "kr"}
+              onClick={() => setSelectedMarket("kr")}
+            >
+              국내
+            </button>
+            <button
+              type="button"
+              className={selectedMarket === "us" ? "is-active" : ""}
+              aria-pressed={selectedMarket === "us"}
+              onClick={() => setSelectedMarket("us")}
+            >
+              미국
+            </button>
+          </div>
           {err && <div style={{ color: "var(--danger)", marginBottom: 12 }}>오류: {err}</div>}
           {results ? (
             <>

--- a/tests/test_invest_api_screener_router.py
+++ b/tests/test_invest_api_screener_router.py
@@ -144,3 +144,34 @@ def test_screener_results_endpoint_requires_preset_param() -> None:
     client = TestClient(_build_app(stub_screening=stub))
     r = client.get("/invest/api/screener/results")
     assert r.status_code == 422  # missing required query param
+
+
+@pytest.mark.unit
+def test_screener_results_endpoint_forwards_market_query() -> None:
+    stub = _StubScreening(
+        payload={
+            "results": [
+                {
+                    "symbol": "AAPL",
+                    "name": "Apple Inc.",
+                    "market": "us",
+                    "sector": "Technology",
+                    "market_cap_usd": 3_200_000_000_000,
+                    "current_price": 210.4,
+                    "change_rate": 1.5,
+                    "change_amount": 3.1,
+                    "volume": 50_000_000,
+                    "per": 32.1,
+                }
+            ],
+            "warnings": [],
+        }
+    )
+    client = TestClient(_build_app(stub_screening=stub))
+    r = client.get("/invest/api/screener/results?preset=cheap_value&market=us")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["results"][0]["market"] == "us"
+    assert body["results"][0]["marketCapLabel"] == "$3.20T"
+    assert stub.calls and stub.calls[0]["market"] == "us"

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -101,7 +101,9 @@ async def test_build_screener_results_consecutive_gainers_happy_path() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_build_screener_results_forwards_us_market_and_formats_us_labels() -> None:
+async def test_build_screener_results_forwards_us_market_and_formats_us_labels() -> (
+    None
+):
     fake_screening = MagicMock()
     fake_screening.list_screening = AsyncMock(
         return_value={
@@ -161,7 +163,9 @@ async def test_build_screener_results_forwards_us_market_and_formats_us_labels()
 @pytest.mark.unit
 def test_calculate_consecutive_up_days_counts_latest_streak() -> None:
     assert screener_service.calculate_consecutive_up_days([100, 101, 102, 103]) == 3
-    assert screener_service.calculate_consecutive_up_days([100, 101, 100, 102, 103]) == 2
+    assert (
+        screener_service.calculate_consecutive_up_days([100, 101, 100, 102, 103]) == 2
+    )
     assert screener_service.calculate_consecutive_up_days([100, 101, 101, 102]) == 1
     assert screener_service.calculate_consecutive_up_days([100]) is None
 

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -26,6 +26,7 @@ def _stub_screening_rows() -> list[dict[str, Any]]:
             "close": 80_000,
             "change_rate": 1.23,
             "change_amount": 970,
+            "consecutive_up_days": 5,
             "volume": 12_345_678,
             "per": 14.0,
             "pbr": 1.2,
@@ -41,6 +42,7 @@ def _stub_screening_rows() -> list[dict[str, Any]]:
             "close": 45_000,
             "change_rate": -0.5,
             "change_amount": -200,
+            "consecutive_up_days": 4,
             "volume": 3_000_000,
             "per": None,
             "pbr": None,
@@ -85,7 +87,7 @@ async def test_build_screener_results_consecutive_gainers_happy_path() -> None:
 
     assert resp.presetId == "consecutive_gainers"
     assert resp.title == "연속 상승세"
-    assert resp.metricLabel == "주가등락률"
+    assert resp.metricLabel == "연속상승"
     assert len(resp.results) == 2
     assert resp.results[0].rank == 1
     assert resp.results[0].symbol == "005930"
@@ -95,6 +97,97 @@ async def test_build_screener_results_consecutive_gainers_happy_path() -> None:
     assert resp.results[1].symbol == "035720"
     assert resp.results[1].isWatched is False
     assert resp.results[1].changeDirection == "down"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_forwards_us_market_and_formats_us_labels() -> None:
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "AAPL",
+                    "name": "Apple Inc.",
+                    "market": "us",
+                    "sector": "Technology",
+                    "market_cap_usd": 3_200_000_000_000,
+                    "current_price": 210.4,
+                    "change_rate": 1.5,
+                    "change_amount": 3.1,
+                    "volume": 50_000_000,
+                    "per": 32.1,
+                    "pbr": 48.0,
+                    "dividend_yield": 0.5,
+                },
+                {
+                    "symbol": "msft",
+                    "name": "Microsoft Corp.",
+                    "market": "us",
+                    "sector": "Technology",
+                    "market_cap": 2_900_000_000_000,
+                    "current_price": 400.0,
+                    "change_rate": -0.25,
+                    "change_amount": -1.23,
+                    "volume": 20_000_000,
+                    "per": 30.0,
+                },
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched={("us", "AAPL")})
+
+    resp = await build_screener_results(
+        preset_id="cheap_value",
+        screening_service=fake_screening,
+        resolver=resolver,
+        market="us",
+    )
+
+    fake_screening.list_screening.assert_awaited_once()
+    assert fake_screening.list_screening.await_args.kwargs["market"] == "us"
+    assert resp.results[0].market == "us"
+    assert resp.results[0].marketCapLabel == "$3.20T"
+    assert resp.results[0].priceLabel == "$210.40"
+    assert resp.results[0].changeAmountLabel == "+$3.10"
+    assert resp.results[0].isWatched is True
+    assert resp.results[1].symbol == "MSFT"
+    assert resp.results[1].marketCapLabel == "$2.90T"
+    assert resp.results[1].changeAmountLabel == "-$1.23"
+    assert resolver.calls == [("us", "AAPL"), ("us", "MSFT")]
+
+
+@pytest.mark.unit
+def test_calculate_consecutive_up_days_counts_latest_streak() -> None:
+    assert screener_service.calculate_consecutive_up_days([100, 101, 102, 103]) == 3
+    assert screener_service.calculate_consecutive_up_days([100, 101, 100, 102, 103]) == 2
+    assert screener_service.calculate_consecutive_up_days([100, 101, 101, 102]) == 1
+    assert screener_service.calculate_consecutive_up_days([100]) is None
+
+
+@pytest.mark.unit
+def test_consecutive_up_metric_prefers_consecutive_days() -> None:
+    row_warnings: list[str] = []
+    assert (
+        screener_service._metric_value_label(
+            "consecutive_gainers",
+            {"symbol": "005930", "consecutive_up_days": 6, "change_rate": 2.4},
+        )[0]
+        == "6일"
+    )
+    assert row_warnings == []
+
+
+@pytest.mark.unit
+def test_consecutive_up_metric_warns_when_history_unavailable() -> None:
+    label, warnings = screener_service._metric_value_label(
+        "consecutive_gainers",
+        {"symbol": "005930", "change_rate": 2.4},
+    )
+
+    assert label == "-"
+    assert warnings == ["연속상승 데이터 준비중"]
 
 
 @pytest.mark.unit
@@ -455,10 +548,10 @@ async def test_build_screener_results_normalizes_us_symbol_and_market_cap() -> N
 
     row = resp.results[1]
     assert resp.results[0].symbol == "MSFT"
-    assert resp.results[0].marketCapLabel == "-"
+    assert resp.results[0].marketCapLabel == "$900.0B"
     assert row.symbol == "AAPL"
     assert row.market == "us"
-    assert row.marketCapLabel == "2.9조원"
+    assert row.marketCapLabel == "$2.90T"
     assert row.changePctLabel == "0.00%"
     assert row.changeDirection == "flat"
     assert row.isWatched is True
@@ -501,9 +594,9 @@ async def test_build_screener_results_coerces_string_market_cap_values() -> None
     )
 
     assert resp.results[0].marketCapLabel == "478.0조원"
-    assert resp.results[0].warnings == []
+    assert resp.results[0].warnings == ["연속상승 데이터 준비중"]
     assert resp.results[1].marketCapLabel == "414.7조원"
-    assert resp.results[1].warnings == []
+    assert resp.results[1].warnings == ["연속상승 데이터 준비중"]
 
 
 @pytest.mark.unit

--- a/tests/test_mcp_screen_stocks_kr.py
+++ b/tests/test_mcp_screen_stocks_kr.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 
 from typing import Any
 
+import pandas as pd
 import pytest
 
 from app.mcp_server.tooling import analysis_screening
+from app.mcp_server.tooling.screening import kr as kr_screening
 from tests._mcp_screen_stocks_support import (
     TestScreenStocksFundamentalsExpansion,
     TestScreenStocksKR,
@@ -217,3 +219,42 @@ async def test_screen_stocks_crypto_strategy_preserves_explicit_sort(
     assert called["max_rsi"] == pytest.approx(30.0)
     assert called["sort_by"] == "rsi"
     assert called["sort_order"] == "desc"
+
+
+@pytest.mark.asyncio
+async def test_normalize_kr_results_prefers_krx_canonical_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_fetch_stock_all_cached(*, market: str) -> list[dict[str, Any]]:
+        return [
+            {
+                "code": "005930",
+                "short_code": "005930",
+                "name": "삼성전자",
+                "market": market,
+            }
+        ]
+
+    async def fake_fetch_valuation_all_cached(*, market: str) -> dict[str, dict[str, Any]]:
+        return {}
+
+    monkeypatch.setattr(kr_screening, "fetch_stock_all_cached", fake_fetch_stock_all_cached)
+    monkeypatch.setattr(
+        kr_screening, "fetch_valuation_all_cached", fake_fetch_valuation_all_cached
+    )
+
+    df = pd.DataFrame(
+        [
+            {
+                "symbol": "KRX:005930",
+                "name": "Samsung Electronics",
+                "description": "Samsung Electronics",
+                "price": 80_000,
+            }
+        ]
+    )
+
+    rows = await kr_screening._normalize_kr_results(df, market="kr")
+
+    assert rows[0]["name"] == "삼성전자"
+    assert rows[0]["instrument_type"] == "common"

--- a/tests/test_mcp_screen_stocks_kr.py
+++ b/tests/test_mcp_screen_stocks_kr.py
@@ -235,10 +235,14 @@ async def test_normalize_kr_results_prefers_krx_canonical_name(
             }
         ]
 
-    async def fake_fetch_valuation_all_cached(*, market: str) -> dict[str, dict[str, Any]]:
+    async def fake_fetch_valuation_all_cached(
+        *, market: str
+    ) -> dict[str, dict[str, Any]]:
         return {}
 
-    monkeypatch.setattr(kr_screening, "fetch_stock_all_cached", fake_fetch_stock_all_cached)
+    monkeypatch.setattr(
+        kr_screening, "fetch_stock_all_cached", fake_fetch_stock_all_cached
+    )
     monkeypatch.setattr(
         kr_screening, "fetch_valuation_all_cached", fake_fetch_valuation_all_cached
     )

--- a/tests/test_tvscreener_stocks.py
+++ b/tests/test_tvscreener_stocks.py
@@ -155,7 +155,7 @@ async def test_screen_kr_uses_market_korea_and_public_symbol_name_mapping(
     assert kwargs["country"] is None
     assert result["error"] is None
     assert [stock["symbol"] for stock in result["stocks"]] == ["005930", "000660"]
-    assert result["stocks"][0]["name"] == "Samsung Electronics Co., Ltd."
+    assert result["stocks"][0]["name"] == "삼성전자"
 
 
 @pytest.mark.asyncio
@@ -590,7 +590,7 @@ async def test_screen_kr_falls_back_to_name_when_description_missing(
     ):
         result = await _screen_kr_via_tvscreener(limit=1)
 
-    assert result["stocks"][0]["name"] == "005930"
+    assert result["stocks"][0]["name"] == "삼성전자"
 
 
 class TestStockScreeningIntegration:


### PR DESCRIPTION
## Summary
- Add market-aware /invest/screener support for KR and US results.
- Prefer Korean KRX canonical names for KR rows and keep US rows in USD-oriented formatting.
- Replace the duplicated rightmost change-rate-like metric with consecutive-up-days semantics and a data-unavailable fallback.
- Add desktop KR/US toggle wiring through the frontend API client and server-side preset mapping.

## Verification
- `uv run pytest tests/test_invest_view_model_screener_service.py tests/test_invest_api_screener_router.py tests/test_mcp_screen_stocks_kr.py -q` — 68 passed, 4 warnings.
- `uv run ruff check app/mcp_server/tooling/screening/kr.py app/routers/invest_api.py app/services/invest_view_model/screener_presets.py app/services/invest_view_model/screener_service.py tests/test_invest_api_screener_router.py tests/test_invest_view_model_screener_service.py tests/test_mcp_screen_stocks_kr.py` — passed.
- `uv run pytest tests/test_screening_entrypoint.py tests/test_invest_api_router_safety.py tests/test_invest_view_model_safety.py -q` — 9 passed, 2 warnings.
- `cd frontend/invest && npm run typecheck` — passed.
- `cd frontend/invest && npm test -- --run DesktopScreenerPage.test.tsx` — 1 file / 3 tests passed.
- `cd frontend/invest && npm run build` — passed.

## Safety / non-actions
- Read-only screener/API/frontend scope only.
- No broker/order/watch/order-intent mutation.
- No live/paper/generic/KIS/Upbit order action.
- No DB update/delete/backfill or scheduler change.
- Toss was used only as an IA/UX reference; no Toss API calls.
- No credentials, tokens, connection strings, or account values printed.

## Notes
- Reviewer PASS from ROB-159 kanban parent task verified KR name preference, market=kr|us compatibility, non-duplicated consecutive-gainers behavior, USD/KRW formatting, and read-only safety boundary.
- Claude Code Opus review was attempted but local Claude CLI was not logged in; review used current runtime plus independent subagent.

Closes ROB-159


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added market selection toggle to screener—users can now switch between Korean and US stock markets.
  * Market-specific formatting for prices and market caps (KRW/USD currency symbols, appropriate decimal places).

* **Improvements**
  * Updated screener preset labels and filter criteria for better accuracy across markets.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/747)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->