### PR TITLE
chore(W1-8): consolidate n8n compound formatters into n8n_formatting

### DIFF
--- a/app/services/n8n_daily_brief_service.py
+++ b/app/services/n8n_daily_brief_service.py
@@ -38,6 +38,11 @@ from app.services.cio_coin_briefing.prompts.gate_phrases import (
     PATH_SECTION_AB_REPEAT,
 )
 from app.services.n8n_formatting import (
+    _fmt_days,
+    _fmt_krw,
+    _fmt_pct,
+    _format_g2_lines,
+    _format_unverified_amounts,
     fmt_amount,
     fmt_date_with_weekday,
     fmt_pnl,
@@ -504,24 +509,6 @@ def _build_brief_text(
     return "\n".join(lines)
 
 
-def _fmt_krw(value: float | int | None) -> str:
-    if value is None:
-        return "-"
-    return f"{float(value):,.0f} KRW"
-
-
-def _fmt_pct(value: float | int | None) -> str:
-    if value is None:
-        return "-"
-    return f"{float(value):.1f}%"
-
-
-def _fmt_days(value: float | int | None) -> str:
-    if value is None:
-        return "-"
-    return f"{float(value):.2f}일"
-
-
 def _extract_followup_context(
     payload: BoardBriefContext | dict[str, Any],
 ) -> BoardBriefContext:
@@ -597,17 +584,6 @@ def _route_fail_closed(
         gate_results=None,
         generated_at=generated_at,
     )
-
-
-def _format_unverified_amounts(ctx: BoardBriefContext) -> set[str]:
-    if not ctx.unverified_cap:
-        return set()
-    amount = ctx.unverified_cap.amount
-    return {
-        f"{amount:,.0f}",
-        f"{amount:.0f}",
-        _fmt_krw(amount),
-    }
 
 
 def _gate_passed(gate: GateResult | N8nG2GatePayload | None) -> bool:
@@ -875,10 +851,6 @@ def _funding_verified(
         (board_response and board_response.manual_cash_verified)
         or (ctx.unverified_cap and ctx.unverified_cap.verified_by_boss_today)
     )
-
-
-def _format_g2_lines(lines: list[str], *, amount: float, days: int) -> list[str]:
-    return [line.format(amount=f"{amount:,.0f}", days=days) for line in lines]
 
 
 def resolve_funding_intent(

--- a/app/services/n8n_formatting.py
+++ b/app/services/n8n_formatting.py
@@ -170,6 +170,48 @@ def fmt_pnl(pct: float | None) -> str:
     return f"{pct:.1f}%"
 
 
+# ---------------------------------------------------------------------------
+# Internal helpers (not in __all__) — moved from n8n_daily_brief_service
+# ---------------------------------------------------------------------------
+
+
+def _fmt_krw(value: float | int | None) -> str:
+    if value is None:
+        return "-"
+    return f"{float(value):,.0f} KRW"
+
+
+def _fmt_pct(value: float | int | None) -> str:
+    if value is None:
+        return "-"
+    return f"{float(value):.1f}%"
+
+
+def _fmt_days(value: float | int | None) -> str:
+    if value is None:
+        return "-"
+    return f"{float(value):.2f}일"
+
+
+def _format_unverified_amounts(ctx: Any) -> set[str]:
+    """Return the set of formatted strings for ctx.unverified_cap.amount.
+
+    Accepts BoardBriefContext (typed as Any to avoid a heavy schema import).
+    """
+    if not ctx.unverified_cap:
+        return set()
+    amount = ctx.unverified_cap.amount
+    return {
+        f"{amount:,.0f}",
+        f"{amount:.0f}",
+        _fmt_krw(amount),
+    }
+
+
+def _format_g2_lines(lines: list[str], *, amount: float, days: int) -> list[str]:
+    return [line.format(amount=f"{amount:,.0f}", days=days) for line in lines]
+
+
 __all__ = [
     "fmt_price",
     "fmt_gap",

--- a/tests/services/test_n8n_formatting_extended.py
+++ b/tests/services/test_n8n_formatting_extended.py
@@ -1,0 +1,70 @@
+"""Tests for extended formatter helpers moved from n8n_daily_brief_service."""
+
+from __future__ import annotations
+
+from app.services.n8n_formatting import (
+    _fmt_days,
+    _fmt_krw,
+    _fmt_pct,
+    _format_g2_lines,
+)
+
+
+class TestFmtKrw:
+    def test_none_returns_dash(self) -> None:
+        assert _fmt_krw(None) == "-"
+
+    def test_zero(self) -> None:
+        assert _fmt_krw(0.0) == "0 KRW"
+
+    def test_positive_float(self) -> None:
+        # f"{1234.5:,.0f}" uses banker's rounding → 1,234
+        assert _fmt_krw(1234.5) == "1,234 KRW"
+
+    def test_integer_input(self) -> None:
+        assert _fmt_krw(1000) == "1,000 KRW"
+
+
+class TestFmtPct:
+    def test_none_returns_dash(self) -> None:
+        assert _fmt_pct(None) == "-"
+
+    def test_decimal(self) -> None:
+        assert _fmt_pct(1.567) == "1.6%"
+
+    def test_zero(self) -> None:
+        assert _fmt_pct(0.0) == "0.0%"
+
+    def test_integer_input(self) -> None:
+        assert _fmt_pct(5) == "5.0%"
+
+
+class TestFmtDays:
+    def test_none_returns_dash(self) -> None:
+        assert _fmt_days(None) == "-"
+
+    def test_float(self) -> None:
+        assert _fmt_days(3.5) == "3.50일"
+
+    def test_integer_input(self) -> None:
+        assert _fmt_days(7) == "7.00일"
+
+
+class TestFormatG2Lines:
+    def test_template_substitution(self) -> None:
+        lines = ["{amount}원 / {days}일"]
+        result = _format_g2_lines(lines, amount=10000, days=7)
+        assert result == ["10,000원 / 7일"]
+
+    def test_multiple_lines(self) -> None:
+        lines = ["{amount}원", "{days}일 남음"]
+        result = _format_g2_lines(lines, amount=5000, days=3)
+        assert result == ["5,000원", "3일 남음"]
+
+    def test_empty_list(self) -> None:
+        assert _format_g2_lines([], amount=1000, days=1) == []
+
+    def test_line_without_placeholders(self) -> None:
+        lines = ["고정 텍스트"]
+        result = _format_g2_lines(lines, amount=1000, days=1)
+        assert result == ["고정 텍스트"]


### PR DESCRIPTION
## Summary
- Move pure-function compound formatters (`_fmt_krw`, `_fmt_pct`, `_fmt_days`, `_format_unverified_amounts`, `_format_g2_lines`) from `n8n_daily_brief_service.py` into `n8n_formatting.py`.
- `_format_unverified_amounts` typed as `Any` in `n8n_formatting.py` to avoid heavy schema import; runtime behaviour unchanged.
- Closures depending on service-instance state are kept in place (no improper extraction).
- Router `app/routers/n8n.py` is **unchanged** (handled in W2-4).

Refactor unit: W1-8 (Wave 1, low-risk).
Plan: `docs/superpowers/plans/2026-05-09-refactor-W1-8-n8n-formatting.md`

## Test plan
- [x] `uv run pytest tests/services/test_n8n_formatting_extended.py -v` → 15 passed
- [x] `uv run pytest tests/ -k "n8n" -x -q` → 275 passed, 1 skipped
- [x] `uv run ruff check app/services/n8n_formatting.py app/services/n8n_daily_brief_service.py tests/services/test_n8n_formatting_extended.py` → all checks passed
- [x] No changes to `app/routers/n8n.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)