### PR TITLE
chore(W1-9): consolidate mcp shared.py optional-type converters

### DIFF
--- a/app/mcp_server/tooling/analysis_screen_crypto.py
+++ b/app/mcp_server/tooling/analysis_screen_crypto.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import datetime
-import math
 from typing import Any, TypedDict
+
+from app.mcp_server.tooling.shared import _to_optional_float
 
 type CryptoCandidate = dict[str, Any]
 type CryptoFiltersApplied = dict[str, Any]
@@ -30,18 +31,6 @@ class CoinGeckoPayload(TypedDict, total=False):
     age_seconds: float | None
     stale: bool
     error: str | None
-
-
-def _to_optional_float(value: Any) -> float | None:
-    if value is None:
-        return None
-    try:
-        number = float(value)
-    except (TypeError, ValueError):
-        return None
-    if math.isnan(number):
-        return None
-    return number
 
 
 def _extract_market_symbol(symbol: Any) -> str | None:

--- a/app/mcp_server/tooling/screening/common.py
+++ b/app/mcp_server/tooling/screening/common.py
@@ -11,6 +11,8 @@ from typing import Any
 
 import httpx
 
+from app.mcp_server.tooling.shared import _to_optional_float, _to_optional_int
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -106,33 +108,6 @@ async def _with_timeout(
 # ---------------------------------------------------------------------------
 # Converters
 # ---------------------------------------------------------------------------
-
-
-def _to_optional_float(value: Any) -> float | None:
-    if value is None:
-        return None
-    try:
-        number = float(value)
-    except (TypeError, ValueError):
-        return None
-    if math.isnan(number):
-        return None
-    return number
-
-
-def _to_optional_int(value: Any) -> int | None:
-    if value is None:
-        return None
-    try:
-        number = float(value)
-    except (TypeError, ValueError):
-        return None
-    if math.isnan(number):
-        return None
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return None
 
 
 def _rank_priority(rank: int | None) -> int:

--- a/app/mcp_server/tooling/shared.py
+++ b/app/mcp_server/tooling/shared.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import datetime
 import logging
+import math
 import re
 from typing import Any
 
@@ -229,6 +230,35 @@ def to_float(value: Any, default: float = 0.0) -> float:
         return float(value)
     except Exception:
         return default
+
+
+def _to_optional_float(value: Any) -> float | None:
+    """Convert value to float; return None for None, empty string, or NaN."""
+    if value is None or value == "":
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(number):
+        return None
+    return number
+
+
+def _to_optional_int(value: Any) -> int | None:
+    """Convert value to int; return None for None, empty string, or NaN intermediate."""
+    if value is None or value == "":
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(number):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def to_optional_float(value: Any) -> float | None:
@@ -901,6 +931,8 @@ __all__ = [
     "to_optional_float",
     "to_optional_int",
     "to_int",
+    "_to_optional_float",
+    "_to_optional_int",
     # Error payload
     "error_payload",
     # Account normalization

--- a/tests/mcp_server/test_shared_converters.py
+++ b/tests/mcp_server/test_shared_converters.py
@@ -1,0 +1,51 @@
+"""Unit tests for NaN-safe private converters in shared.py."""
+
+from __future__ import annotations
+
+from app.mcp_server.tooling.shared import _to_optional_float, _to_optional_int
+
+
+class TestToOptionalFloat:
+    def test_none_returns_none(self):
+        assert _to_optional_float(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _to_optional_float("") is None
+
+    def test_nan_string_returns_none(self):
+        assert _to_optional_float("nan") is None
+
+    def test_nan_float_returns_none(self):
+        assert _to_optional_float(float("nan")) is None
+
+    def test_valid_string_float(self):
+        assert _to_optional_float("3.14") == 3.14
+
+    def test_int_converts_to_float(self):
+        assert _to_optional_float(42) == 42.0
+
+    def test_invalid_string_returns_none(self):
+        assert _to_optional_float("not_a_number") is None
+
+
+class TestToOptionalInt:
+    def test_none_returns_none(self):
+        assert _to_optional_int(None) is None
+
+    def test_empty_string_returns_none(self):
+        assert _to_optional_int("") is None
+
+    def test_nan_string_returns_none(self):
+        assert _to_optional_int("nan") is None
+
+    def test_nan_float_returns_none(self):
+        assert _to_optional_int(float("nan")) is None
+
+    def test_valid_string_int(self):
+        assert _to_optional_int("3") == 3
+
+    def test_float_truncates_to_int(self):
+        assert _to_optional_int(3.7) == 3
+
+    def test_invalid_string_returns_none(self):
+        assert _to_optional_int("bad") is None


### PR DESCRIPTION
## Summary
- Move `_to_optional_float` / `_to_optional_int` (NaN-safe variants) from `mcp_server/tooling/screening/common.py` into `mcp_server/tooling/shared.py`.
- Add `import math` to shared.py for NaN handling. screening/common.py imports from shared after the move.
- Remove duplicate `_to_optional_float` from `analysis_screen_crypto.py` and import from shared.py instead.
- Remove unused `import math` from `analysis_screen_crypto.py`.

Refactor unit: W1-9 (Wave 1 leftover, low-risk extraction).
Plan: `docs/superpowers/plans/2026-05-09-refactor-W1-9-mcp-type-converters.md`

Note: W1-7 (shared.py holdings split) is the follow-up and must be merged AFTER this PR.

## Test plan
- [ ] `uv run pytest tests/mcp_server/test_shared_converters.py -v`
- [ ] `uv run pytest tests/ -k "screening or shared" -v`
- [ ] `uv run ruff check . && uv run ruff format --check .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)