### PR TITLE
refactor(core): extract to_float into app/core/normalizers.py

### DIFF
--- a/app/core/normalizers.py
+++ b/app/core/normalizers.py
@@ -1,0 +1,31 @@
+"""Shared value-normalization helpers used across service modules.
+
+Each function is a pure utility with no side effects. Only helpers with
+identical implementations in 2+ modules are extracted here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def to_float(value: Any, *, default: float = 0.0) -> float:
+    """Convert *value* to float, returning *default* on None, empty-string, or error.
+
+    The keyword-only *default* parameter prevents accidental positional misuse.
+
+    >>> to_float("3.14")
+    3.14
+    >>> to_float(None)
+    0.0
+    >>> to_float("", default=-1.0)
+    -1.0
+    >>> to_float("bad")
+    0.0
+    """
+    if value in (None, ""):
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default

--- a/app/services/account/service.py
+++ b/app/services/account/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from app.core.async_rate_limiter import RateLimitExceededError
+from app.core.normalizers import to_float as _to_float
 from app.services.account.contracts import CashBalance, MarginSnapshot, Position
 from app.services.brokers.kis.client import (
     KISClient,
@@ -31,15 +32,6 @@ def _normalize_market(market: str | None) -> str | None:
     if resolved is None:
         raise ValidationError(f"Unsupported market: {market}")
     return resolved
-
-
-def _to_float(value: Any, *, default: float = 0.0) -> float:
-    if value in (None, ""):
-        return default
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return default
 
 
 def _map_error(exc: Exception) -> Exception:

--- a/app/services/portfolio_overview_service.py
+++ b/app/services/portfolio_overview_service.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 import app.services.brokers.upbit.client as upbit_service
 import app.services.brokers.yahoo.client as yahoo_service
+from app.core.normalizers import to_float as _to_float
 from app.core.symbol import to_db_symbol
 from app.mcp_server.tooling.shared import min_order_krw
 from app.models.manual_holdings import MarketType
@@ -30,15 +31,6 @@ _MARKET_US = "US"
 _MARKET_CRYPTO = "CRYPTO"
 _MARKET_ORDER = {_MARKET_KR: 0, _MARKET_US: 1, _MARKET_CRYPTO: 2}
 _UPBIT_PRICE_BATCH_SIZE = 50
-
-
-def _to_float(value: Any, *, default: float = 0.0) -> float:
-    if value in (None, ""):
-        return default
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return default
 
 
 def _kis_percent_to_decimal(value: Any) -> float | None:

--- a/tests/core/test_normalizers.py
+++ b/tests/core/test_normalizers.py
@@ -1,0 +1,55 @@
+"""Unit tests for app.core.normalizers.to_float."""
+
+from __future__ import annotations
+
+import pytest
+
+# This import will FAIL until Task 2 creates the module.
+from app.core.normalizers import to_float
+
+
+class TestToFloat:
+    def test_none_returns_default(self):
+        assert to_float(None) == 0.0
+
+    def test_empty_string_returns_default(self):
+        assert to_float("") == 0.0
+
+    def test_custom_default_on_none(self):
+        assert to_float(None, default=-1.0) == -1.0
+
+    def test_custom_default_on_empty_string(self):
+        assert to_float("", default=99.0) == 99.0
+
+    def test_int_value(self):
+        assert to_float(42) == 42.0
+
+    def test_float_value(self):
+        assert to_float(3.14) == pytest.approx(3.14)
+
+    def test_string_float(self):
+        assert to_float("1234.56") == pytest.approx(1234.56)
+
+    def test_decimal_string(self):
+        assert to_float("0.00100000") == pytest.approx(0.001)
+
+    def test_bad_string_returns_default(self):
+        assert to_float("bad") == 0.0
+
+    def test_bad_string_custom_default(self):
+        assert to_float("n/a", default=-99.0) == -99.0
+
+    def test_zero_string(self):
+        assert to_float("0") == 0.0
+
+    def test_negative_string(self):
+        assert to_float("-5.5") == pytest.approx(-5.5)
+
+    def test_default_is_keyword_only(self):
+        # Calling with positional second arg must raise TypeError
+        with pytest.raises(TypeError):
+            to_float("1.0", 99.0)  # type: ignore[call-arg]
+
+    def test_list_returns_default(self):
+        # Unconvertible type — returns default
+        assert to_float([1, 2], default=-1.0) == -1.0


### PR DESCRIPTION
## Summary
- Adds `app/core/normalizers.py` with `to_float(Any, *, default=0.0) -> float` (keyword-only default, `""` + `None` guard, `TypeError|ValueError` catch)
- Removes the identical private `_to_float` from `portfolio_overview_service.py` and `account/service.py`; replaces both with `from app.core.normalizers import to_float as _to_float` so all existing call sites are unchanged
- 14 new unit tests in `tests/core/test_normalizers.py`

**Not extracted** (different logic per abstraction-threshold rule):
`_normalize_market_type` (fill_notification vs portfolio_overview differ in alias table and output case),
`_normalize_symbol` (each file has domain-specific logic),
`_safe_text_or_none` / `_parse_datetime` / `_parse_timestamp` (each defined in exactly one file).

## Test plan
- [ ] `uv run pytest tests/core/test_normalizers.py -v` → 14 passed
- [ ] `uv run pytest tests/test_portfolio_overview_service.py tests/test_services_account_service.py -v` → all passed
- [ ] `grep "def _to_float" app/services/portfolio_overview_service.py app/services/account/service.py` → no output

🤖 Generated with [Claude Code](https://claude.com/claude-code)