### PR TITLE
chore(W2-5): clarify tasks/ vs jobs/ boundary for 2 violations

### DIFF
--- a/app/jobs/intraday_order_review.py
+++ b/app/jobs/intraday_order_review.py
@@ -1,0 +1,102 @@
+"""Intraday order review orchestration — scheduler-agnostic.
+
+Trading hours helpers and market-specific review logic live here.
+TaskIQ schedule declarations belong in app/tasks/intraday_order_review_tasks.py.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from app.core.timezone import now_kst
+from app.services.n8n_pending_orders_service import fetch_pending_orders
+
+logger = logging.getLogger(__name__)
+
+
+def is_kr_trading_hours(dt: datetime) -> bool:
+    """Return True if dt is within KR market hours (09:00-15:30 KST, Mon-Fri)."""
+    if dt.weekday() >= 5:
+        return False
+    time_val = dt.hour * 100 + dt.minute
+    return 900 <= time_val <= 1530
+
+
+def is_us_trading_hours(dt: datetime) -> bool:
+    """Return True if dt is within US market hours (23:30-06:00 KST, Mon-Fri)."""
+    if dt.weekday() >= 5:
+        return False
+    return dt.hour >= 23 or dt.hour < 6
+
+
+async def run_crypto_order_review() -> dict[str, object]:
+    """Review pending crypto orders at scheduled intraday checkpoints."""
+    as_of = now_kst()
+    logger.info("Starting intraday crypto order review at %s", as_of)
+    result = await fetch_pending_orders(
+        market="crypto",
+        include_current_price=True,
+        include_indicators=True,
+        as_of=as_of,
+    )
+    order_count = result.get("summary", {}).get("total", 0)
+    logger.info("Crypto intraday review complete: %s pending orders", order_count)
+    return {
+        "market": "crypto",
+        "as_of": as_of.isoformat(),
+        "order_count": order_count,
+        "orders": [
+            {
+                "symbol": order.get("symbol"),
+                "side": order.get("side"),
+                "gap_pct": order.get("gap_pct"),
+                "indicators": order.get("indicators"),
+            }
+            for order in result.get("orders", [])
+        ],
+    }
+
+
+async def run_kr_order_review() -> dict[str, object]:
+    """Review pending KR stock orders at scheduled intraday checkpoints."""
+    as_of = now_kst()
+    if not is_kr_trading_hours(as_of):
+        logger.info("Skipping KR intraday review: outside trading hours")
+        return {"market": "kr", "skipped": True, "reason": "outside_trading_hours"}
+    logger.info("Starting intraday KR order review at %s", as_of)
+    result = await fetch_pending_orders(
+        market="kr",
+        include_current_price=True,
+        include_indicators=False,
+        as_of=as_of,
+    )
+    order_count = result.get("summary", {}).get("total", 0)
+    logger.info("KR intraday review complete: %s pending orders", order_count)
+    return {
+        "market": "kr",
+        "as_of": as_of.isoformat(),
+        "order_count": order_count,
+    }
+
+
+async def run_us_order_review() -> dict[str, object]:
+    """Review pending US stock orders at scheduled intraday checkpoints."""
+    as_of = now_kst()
+    if not is_us_trading_hours(as_of):
+        logger.info("Skipping US intraday review: outside trading hours")
+        return {"market": "us", "skipped": True, "reason": "outside_trading_hours"}
+    logger.info("Starting intraday US order review at %s", as_of)
+    result = await fetch_pending_orders(
+        market="us",
+        include_current_price=True,
+        include_indicators=False,
+        as_of=as_of,
+    )
+    order_count = result.get("summary", {}).get("total", 0)
+    logger.info("US intraday review complete: %s pending orders", order_count)
+    return {
+        "market": "us",
+        "as_of": as_of.isoformat(),
+        "order_count": order_count,
+    }

--- a/app/jobs/pending_order_sync.py
+++ b/app/jobs/pending_order_sync.py
@@ -1,0 +1,35 @@
+"""Pending order sync orchestration — scheduler-agnostic.
+
+All broker venue adapter logic and DB session management live here.
+TaskIQ task declaration belongs in app/tasks/pending_orders.py.
+"""
+
+from __future__ import annotations
+
+from app.core.db import AsyncSessionLocal
+from app.services.pending_order_sync_service import PendingOrderSyncService
+
+
+async def run_pending_order_sync(user_id: int) -> dict[str, int]:
+    """Sync pending orders from all supported brokers for a given user.
+
+    Both adapters intentionally raise NotImplementedError to fail closed —
+    returning [] would look like an empty broker snapshot and could delete
+    existing local pending-order rows as 'vanished'.
+    """
+    async with AsyncSessionLocal() as db:
+        service = PendingOrderSyncService(db)
+
+        class KISAdapter:
+            async def fetch_open_orders(self):
+                raise NotImplementedError("KIS pending-order snapshot unsupported")
+
+        class UpbitAdapter:
+            async def fetch_open_orders(self):
+                raise NotImplementedError("Upbit pending-order snapshot unsupported")
+
+        venues = {
+            "kis_mock": KISAdapter(),
+            "upbit": UpbitAdapter(),
+        }
+        return await service.sync_all_venues(user_id=user_id, venues=venues)

--- a/app/tasks/intraday_order_review_tasks.py
+++ b/app/tasks/intraday_order_review_tasks.py
@@ -1,15 +1,27 @@
-"""Background tasks for intraday order review."""
+"""Intraday order review TaskIQ task declarations.
+
+Schedule-facing thin wrappers only. All logic lives in
+app/jobs/intraday_order_review.
+"""
 
 from __future__ import annotations
 
-import logging
-from datetime import datetime
-
 from app.core.taskiq_broker import broker
-from app.core.timezone import now_kst
-from app.services.n8n_pending_orders_service import fetch_pending_orders
+from app.jobs.intraday_order_review import (
+    is_kr_trading_hours as _is_kr_trading_hours,
+)
+from app.jobs.intraday_order_review import (
+    is_us_trading_hours as _is_us_trading_hours,
+)
+from app.jobs.intraday_order_review import (
+    run_crypto_order_review,
+    run_kr_order_review,
+    run_us_order_review,
+)
 
-logger = logging.getLogger(__name__)
+# Re-export private aliases so existing tests importing from this module continue to work.
+_is_kr_trading_hours = _is_kr_trading_hours  # noqa: PLW0127
+_is_us_trading_hours = _is_us_trading_hours  # noqa: PLW0127
 
 
 @broker.task(
@@ -20,33 +32,7 @@ logger = logging.getLogger(__name__)
 )
 async def intraday_crypto_order_review() -> dict[str, object]:
     """Intraday order review for crypto market (14:00, 21:00 KST)."""
-    as_of = now_kst()
-    logger.info(f"Starting intraday crypto order review at {as_of}")
-
-    result = await fetch_pending_orders(
-        market="crypto",
-        include_current_price=True,
-        include_indicators=True,
-        as_of=as_of,
-    )
-
-    order_count = result.get("summary", {}).get("total", 0)
-    logger.info(f"Crypto intraday review complete: {order_count} pending orders")
-
-    return {
-        "market": "crypto",
-        "as_of": as_of.isoformat(),
-        "order_count": order_count,
-        "orders": [
-            {
-                "symbol": order.get("symbol"),
-                "side": order.get("side"),
-                "gap_pct": order.get("gap_pct"),
-                "indicators": order.get("indicators"),
-            }
-            for order in result.get("orders", [])
-        ],
-    }
+    return await run_crypto_order_review()
 
 
 @broker.task(
@@ -57,29 +43,7 @@ async def intraday_crypto_order_review() -> dict[str, object]:
 )
 async def intraday_kr_order_review() -> dict[str, object]:
     """Intraday order review for Korean stock market (10:00, 14:00 KST, Mon-Fri)."""
-    as_of = now_kst()
-
-    if not _is_kr_trading_hours(as_of):
-        logger.info("Skipping KR intraday review: outside trading hours")
-        return {"market": "kr", "skipped": True, "reason": "outside_trading_hours"}
-
-    logger.info(f"Starting intraday KR order review at {as_of}")
-
-    result = await fetch_pending_orders(
-        market="kr",
-        include_current_price=True,
-        include_indicators=False,
-        as_of=as_of,
-    )
-
-    order_count = result.get("summary", {}).get("total", 0)
-    logger.info(f"KR intraday review complete: {order_count} pending orders")
-
-    return {
-        "market": "kr",
-        "as_of": as_of.isoformat(),
-        "order_count": order_count,
-    }
+    return await run_kr_order_review()
 
 
 @broker.task(
@@ -90,47 +54,7 @@ async def intraday_kr_order_review() -> dict[str, object]:
 )
 async def intraday_us_order_review() -> dict[str, object]:
     """Intraday order review for US stock market (00:30, 04:00 KST, Mon-Fri)."""
-    as_of = now_kst()
-
-    if not _is_us_trading_hours(as_of):
-        logger.info("Skipping US intraday review: outside trading hours")
-        return {"market": "us", "skipped": True, "reason": "outside_trading_hours"}
-
-    logger.info(f"Starting intraday US order review at {as_of}")
-
-    result = await fetch_pending_orders(
-        market="us",
-        include_current_price=True,
-        include_indicators=False,
-        as_of=as_of,
-    )
-
-    order_count = result.get("summary", {}).get("total", 0)
-    logger.info(f"US intraday review complete: {order_count} pending orders")
-
-    return {
-        "market": "us",
-        "as_of": as_of.isoformat(),
-        "order_count": order_count,
-    }
-
-
-def _is_kr_trading_hours(dt: datetime) -> bool:
-    """Check if current time is within KR market hours (09:00-15:30 KST)."""
-    if dt.weekday() >= 5:
-        return False
-    hour = dt.hour
-    minute = dt.minute
-    time_val = hour * 100 + minute
-    return 900 <= time_val <= 1530
-
-
-def _is_us_trading_hours(dt: datetime) -> bool:
-    """Check if current time is within US market hours (23:30-06:00 KST)."""
-    if dt.weekday() >= 5:
-        return False
-    hour = dt.hour
-    return hour >= 23 or hour < 6
+    return await run_us_order_review()
 
 
 __all__ = [

--- a/app/tasks/pending_orders.py
+++ b/app/tasks/pending_orders.py
@@ -2,35 +2,11 @@
 
 from __future__ import annotations
 
-import logging
-
-from app.core.db import AsyncSessionLocal
 from app.core.taskiq_broker import broker
-from app.services.pending_order_sync_service import PendingOrderSyncService
-
-logger = logging.getLogger(__name__)
+from app.jobs.pending_order_sync import run_pending_order_sync
 
 
 @broker.task(task_name="sync_pending_orders_all_venues")
 async def sync_pending_orders_all_venues(user_id: int) -> dict[str, int]:
     """Sync pending orders from all supported brokers."""
-    async with AsyncSessionLocal() as db:
-        service = PendingOrderSyncService(db)
-
-        # Placeholder adapters must fail closed. Returning [] from an unsupported
-        # adapter would look like a complete empty broker snapshot and could
-        # delete existing local pending-order rows as "vanished".
-        class KISAdapter:
-            async def fetch_open_orders(self):
-                raise NotImplementedError("KIS pending-order snapshot unsupported")
-
-        class UpbitAdapter:
-            async def fetch_open_orders(self):
-                raise NotImplementedError("Upbit pending-order snapshot unsupported")
-
-        venues = {
-            "kis_mock": KISAdapter(),
-            "upbit": UpbitAdapter(),
-        }
-
-        return await service.sync_all_venues(user_id=user_id, venues=venues)
+    return await run_pending_order_sync(user_id=user_id)

--- a/tests/test_intraday_order_review_jobs.py
+++ b/tests/test_intraday_order_review_jobs.py
@@ -1,0 +1,142 @@
+"""Unit tests for app.jobs.intraday_order_review (jobs/ layer).
+
+These test the orchestration functions directly, independent of TaskIQ.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Imports will FAIL until Task 2 creates the module.
+from app.jobs.intraday_order_review import (
+    is_kr_trading_hours,
+    is_us_trading_hours,
+    run_crypto_order_review,
+    run_kr_order_review,
+    run_us_order_review,
+)
+
+
+class TestTradingHoursHelpers:
+    def test_kr_trading_hours_open_on_weekday(self) -> None:
+        dt = datetime(2026, 3, 16, 10, 0)  # Monday 10:00
+        assert is_kr_trading_hours(dt) is True
+
+    def test_kr_trading_hours_closed_on_weekend(self) -> None:
+        dt = datetime(2026, 3, 15, 10, 0)  # Sunday
+        assert is_kr_trading_hours(dt) is False
+
+    def test_kr_trading_hours_closed_before_open(self) -> None:
+        dt = datetime(2026, 3, 16, 8, 0)  # Monday 08:00
+        assert is_kr_trading_hours(dt) is False
+
+    def test_kr_trading_hours_closed_after_close(self) -> None:
+        dt = datetime(2026, 3, 16, 16, 0)  # Monday 16:00
+        assert is_kr_trading_hours(dt) is False
+
+    def test_us_trading_hours_open_late_night(self) -> None:
+        dt = datetime(2026, 3, 16, 0, 30)  # Monday 00:30 KST
+        assert is_us_trading_hours(dt) is True
+
+    def test_us_trading_hours_open_early_morning(self) -> None:
+        dt = datetime(2026, 3, 16, 4, 0)  # Monday 04:00 KST
+        assert is_us_trading_hours(dt) is True
+
+    def test_us_trading_hours_closed_daytime(self) -> None:
+        dt = datetime(2026, 3, 16, 12, 0)  # Monday 12:00 KST
+        assert is_us_trading_hours(dt) is False
+
+    def test_us_trading_hours_closed_on_weekend(self) -> None:
+        dt = datetime(2026, 3, 15, 0, 30)  # Sunday
+        assert is_us_trading_hours(dt) is False
+
+
+class TestRunCryptoOrderReview:
+    @pytest.mark.asyncio
+    async def test_returns_order_count_and_orders(self) -> None:
+        mock_result = {
+            "summary": {"total": 2},
+            "orders": [
+                {
+                    "symbol": "KRW-BTC",
+                    "side": "buy",
+                    "gap_pct": -1.5,
+                    "indicators": {"rsi_14": 48.0},
+                }
+            ],
+        }
+        with patch(
+            "app.jobs.intraday_order_review.fetch_pending_orders",
+            AsyncMock(return_value=mock_result),
+        ):
+            result = await run_crypto_order_review()
+        assert result["market"] == "crypto"
+        assert result["order_count"] == 2
+        assert len(result["orders"]) == 1
+        assert result["orders"][0]["symbol"] == "KRW-BTC"
+
+    @pytest.mark.asyncio
+    async def test_calls_fetch_with_correct_params(self) -> None:
+        with patch(
+            "app.jobs.intraday_order_review.fetch_pending_orders",
+            AsyncMock(return_value={"summary": {"total": 0}, "orders": []}),
+        ) as mock_fetch:
+            await run_crypto_order_review()
+        call_kwargs = mock_fetch.call_args.kwargs
+        assert call_kwargs["market"] == "crypto"
+        assert call_kwargs["include_current_price"] is True
+        assert call_kwargs["include_indicators"] is True
+
+
+class TestRunKrOrderReview:
+    @pytest.mark.asyncio
+    async def test_skips_outside_trading_hours(self) -> None:
+        # Patch now_kst to return a Sunday
+        fake_dt = datetime(2026, 3, 15, 10, 0)  # Sunday
+        with patch("app.jobs.intraday_order_review.now_kst", return_value=fake_dt):
+            result = await run_kr_order_review()
+        assert result["skipped"] is True
+        assert result["reason"] == "outside_trading_hours"
+
+    @pytest.mark.asyncio
+    async def test_runs_during_trading_hours(self) -> None:
+        fake_dt = datetime(2026, 3, 16, 10, 0)  # Monday 10:00
+        mock_result = {"summary": {"total": 3}, "orders": []}
+        with (
+            patch("app.jobs.intraday_order_review.now_kst", return_value=fake_dt),
+            patch(
+                "app.jobs.intraday_order_review.fetch_pending_orders",
+                AsyncMock(return_value=mock_result),
+            ),
+        ):
+            result = await run_kr_order_review()
+        assert result["market"] == "kr"
+        assert result["order_count"] == 3
+
+
+class TestRunUsOrderReview:
+    @pytest.mark.asyncio
+    async def test_skips_outside_trading_hours(self) -> None:
+        fake_dt = datetime(2026, 3, 16, 12, 0)  # Monday noon KST
+        with patch("app.jobs.intraday_order_review.now_kst", return_value=fake_dt):
+            result = await run_us_order_review()
+        assert result["skipped"] is True
+        assert result["reason"] == "outside_trading_hours"
+
+    @pytest.mark.asyncio
+    async def test_runs_during_trading_hours(self) -> None:
+        fake_dt = datetime(2026, 3, 16, 0, 30)  # Monday 00:30 KST
+        mock_result = {"summary": {"total": 1}, "orders": []}
+        with (
+            patch("app.jobs.intraday_order_review.now_kst", return_value=fake_dt),
+            patch(
+                "app.jobs.intraday_order_review.fetch_pending_orders",
+                AsyncMock(return_value=mock_result),
+            ),
+        ):
+            result = await run_us_order_review()
+        assert result["market"] == "us"
+        assert result["order_count"] == 1

--- a/tests/test_intraday_order_review_tasks.py
+++ b/tests/test_intraday_order_review_tasks.py
@@ -54,7 +54,7 @@ class TestIntradayCryptoReview:
         }
 
         with patch(
-            "app.tasks.intraday_order_review_tasks.fetch_pending_orders",
+            "app.jobs.intraday_order_review.fetch_pending_orders",
             AsyncMock(return_value=mock_result),
         ):
             result = await intraday_crypto_order_review()


### PR DESCRIPTION
## Summary
- Move business logic from `app/tasks/intraday_order_review_tasks.py` (trading hours helpers + review runner) into `app/jobs/intraday_order_review.py`.
- Move service wiring from `app/tasks/pending_orders.py` into `app/jobs/pending_order_sync.py`.
- Existing tasks remain as thin scheduler-facing wrappers via re-export aliases (backward compat preserved).
- Other 10 task files following the correct pattern are untouched.

Refactor unit: W2-5 (Wave 2, low-risk structural cleanup).
Plan: `docs/superpowers/plans/2026-05-09-refactor-W2-5-tasks-jobs-boundary.md`

## Test plan
- [ ] `uv run pytest tests/ -k "tasks or jobs or pending_order or intraday_order" -v`
- [ ] Import smoke: `python -c "import app.tasks; import app.jobs"`
- [ ] Cron/Prefect deployment yaml unchanged
- [ ] `uv run ruff check . && uv run ruff format --check .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)