### PR TITLE
refactor(n8n): slim n8n router by extracting error response helper

### DIFF
--- a/app/routers/n8n.py
+++ b/app/routers/n8n.py
@@ -79,6 +79,7 @@ from app.services.n8n_pending_snapshot_service import (
     resolve_pending_snapshots,
     save_pending_snapshots,
 )
+from app.services.n8n_response_builder import n8n_error_response
 from app.services.n8n_trade_review_service import (
     get_trade_review_stats,
     get_trade_reviews,
@@ -458,11 +459,10 @@ async def post_trade_reviews(
         result = await save_trade_reviews(db, [r.model_dump() for r in body.reviews])
     except Exception as exc:  # noqa: BLE001
         logger.exception("Failed to save trade reviews")
-        return JSONResponse(
-            status_code=500,
-            content=N8nTradeReviewsResponse(
+        return n8n_error_response(
+            N8nTradeReviewsResponse(
                 success=False, saved_count=0, errors=[{"error": str(exc)}]
-            ).model_dump(),
+            )
         )
 
     return N8nTradeReviewsResponse(
@@ -487,15 +487,14 @@ async def get_trade_reviews_endpoint(
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Failed to get trade reviews")
-        return JSONResponse(
-            status_code=500,
-            content=N8nTradeReviewListResponse(
+        return n8n_error_response(
+            N8nTradeReviewListResponse(
                 success=False,
                 period="error",
                 total_count=0,
                 reviews=[],
                 errors=[{"error": str(exc)}],
-            ).model_dump(),
+            )
         )
 
     return N8nTradeReviewListResponse(
@@ -517,13 +516,12 @@ async def get_trade_review_stats_endpoint(
         stats = await get_trade_review_stats(db, period=period, market=market)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Failed to get trade review stats")
-        return JSONResponse(
-            status_code=500,
-            content=N8nTradeReviewStatsResponse(
+        return n8n_error_response(
+            N8nTradeReviewStatsResponse(
                 success=False,
                 stats=N8nTradeReviewStats(period="error"),
                 errors=[{"error": str(exc)}],
-            ).model_dump(),
+            )
         )
 
     return N8nTradeReviewStatsResponse(
@@ -572,11 +570,10 @@ async def post_pending_snapshots(
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Failed to save pending snapshots")
-        return JSONResponse(
-            status_code=500,
-            content=N8nPendingSnapshotsResponse(
+        return n8n_error_response(
+            N8nPendingSnapshotsResponse(
                 success=False, saved_count=0, errors=[{"error": str(exc)}]
-            ).model_dump(),
+            )
         )
 
     return N8nPendingSnapshotsResponse(
@@ -597,11 +594,10 @@ async def patch_pending_resolve(
         )
     except Exception as exc:  # noqa: BLE001
         logger.exception("Failed to resolve pending snapshots")
-        return JSONResponse(
-            status_code=500,
-            content=N8nPendingResolveResponse(
+        return n8n_error_response(
+            N8nPendingResolveResponse(
                 success=False, resolved_count=0, errors=[{"error": str(exc)}]
-            ).model_dump(),
+            )
         )
 
     return N8nPendingResolveResponse(

--- a/app/routers/n8n.py
+++ b/app/routers/n8n.py
@@ -258,7 +258,7 @@ async def get_pending_orders(
             ),
             errors=[{"market": market, "error": str(exc)}],
         )
-        return JSONResponse(status_code=500, content=payload.model_dump())
+        return n8n_error_response(payload)
 
     return N8nPendingOrdersResponse(
         success=bool(result.get("success", True)),
@@ -328,7 +328,7 @@ async def get_market_context(
             ),
             errors=[{"error": str(exc)}],
         )
-        return JSONResponse(status_code=500, content=payload.model_dump())
+        return n8n_error_response(payload)
 
     return N8nMarketContextResponse(
         success=True,
@@ -395,7 +395,7 @@ async def get_daily_brief(
             brief_text="",
             errors=[{"error": str(exc)}],
         )
-        return JSONResponse(status_code=500, content=payload.model_dump())
+        return n8n_error_response(payload)
 
     _spawn_background(save_daily_brief_report(result), name="n8n-daily-brief")
     return N8nDailyBriefResponse(**result)
@@ -439,7 +439,7 @@ async def get_filled_orders(
             orders=[],
             errors=[{"error": str(exc)}],
         )
-        return JSONResponse(status_code=500, content=payload.model_dump())
+        return n8n_error_response(payload)
 
     return N8nFilledOrdersResponse(
         success=True,
@@ -548,7 +548,7 @@ async def get_pending_review_endpoint(
             orders=[],
             errors=[{"error": str(exc)}],
         )
-        return JSONResponse(status_code=500, content=payload.model_dump())
+        return n8n_error_response(payload)
 
     return N8nPendingReviewResponse(
         success=True,
@@ -654,7 +654,7 @@ async def get_crypto_scan(
             ),
             errors=[{"error": str(exc)}],
         )
-        return JSONResponse(status_code=500, content=payload.model_dump())
+        return n8n_error_response(payload)
 
     _spawn_background(save_crypto_scan_report(result), name="n8n-crypto-scan")
     return N8nCryptoScanResponse(
@@ -697,7 +697,7 @@ async def get_kr_morning_report(
             brief_text="",
             errors=[{"error": str(exc)}],
         )
-        return JSONResponse(status_code=500, content=payload.model_dump())
+        return n8n_error_response(payload)
 
     _spawn_background(save_kr_morning_report(result), name="n8n-kr-morning")
     return N8nKrMorningReportResponse(**result)
@@ -740,7 +740,7 @@ async def get_n8n_news(
             discord_body="⚠️ 뉴스를 불러오는 중 오류가 발생했습니다.",
             errors=[{"error": str(exc)}],
         )
-        return JSONResponse(status_code=500, content=payload.model_dump())
+        return n8n_error_response(payload)
 
     return result
 
@@ -763,7 +763,7 @@ async def get_sell_signal_batch(
             results=[],
             errors=[{"error": str(exc)}],
         )
-        return JSONResponse(status_code=500, content=payload.model_dump())
+        return n8n_error_response(payload)
 
     results: list[N8nSellSignalResponse] = []
     top_errors: list[dict[str, object]] = []
@@ -876,7 +876,7 @@ async def get_sell_signal(
             message="",
             errors=[{"error": str(exc)}],
         )
-        return JSONResponse(status_code=500, content=payload.model_dump())
+        return n8n_error_response(payload)
 
     return N8nSellSignalResponse(
         success=True,

--- a/app/services/n8n_response_builder.py
+++ b/app/services/n8n_response_builder.py
@@ -1,0 +1,20 @@
+"""Helpers for building n8n error JSONResponse objects.
+
+Only the JSONResponse(status_code=500) construction is extracted here.
+Error payload (Pydantic model) construction remains in each endpoint
+because field sets differ per response type.
+"""
+
+from __future__ import annotations
+
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+
+def n8n_error_response(payload: BaseModel) -> JSONResponse:
+    """Return a 500 JSONResponse from a pre-built Pydantic error payload.
+
+    The caller is responsible for constructing the payload with
+    success=False and errors=[...] before calling this helper.
+    """
+    return JSONResponse(status_code=500, content=payload.model_dump())

--- a/tests/routers/test_n8n_error_paths.py
+++ b/tests/routers/test_n8n_error_paths.py
@@ -1,0 +1,125 @@
+"""Error-path snapshot tests for app/routers/n8n.py.
+
+These tests ensure that each covered endpoint returns HTTP 500 with
+success=False when the underlying service raises an exception, and
+that response JSON keys are preserved after the refactor.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _make_client() -> TestClient:
+    app = FastAPI()
+    from app.routers.n8n import router
+
+    app.include_router(router)
+    return TestClient(app)
+
+
+@pytest.mark.integration
+class TestN8nErrorPaths:
+    def test_pending_orders_service_error_returns_500(self) -> None:
+        client = _make_client()
+        with patch(
+            "app.routers.n8n.fetch_pending_orders",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("service down"),
+        ):
+            resp = client.get("/api/n8n/pending-orders")
+        assert resp.status_code == 500
+        body = resp.json()
+        assert body["success"] is False
+        assert "orders" in body
+        assert "summary" in body
+        assert any("service down" in str(e) for e in body["errors"])
+
+    def test_filled_orders_service_error_returns_500(self) -> None:
+        client = _make_client()
+        with patch(
+            "app.routers.n8n.fetch_filled_orders",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("fill error"),
+        ):
+            resp = client.get("/api/n8n/filled-orders")
+        assert resp.status_code == 500
+        body = resp.json()
+        assert body["success"] is False
+        assert "orders" in body
+        assert any("fill error" in str(e) for e in body["errors"])
+
+    def test_trade_reviews_post_error_returns_500(self) -> None:
+        client = _make_client()
+        valid_review = {
+            "order_id": "ORD001",
+            "account": "upbit",
+            "symbol": "BTC",
+            "instrument_type": "crypto",
+            "side": "buy",
+            "price": 50000.0,
+            "quantity": 1.0,
+            "total_amount": 50000.0,
+            "filled_at": "2024-01-01T00:00:00",
+            "verdict": "good",
+        }
+        with patch(
+            "app.routers.n8n.save_trade_reviews",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("db error"),
+        ):
+            resp = client.post(
+                "/api/n8n/trade-reviews", json={"reviews": [valid_review]}
+            )
+        assert resp.status_code == 500
+        body = resp.json()
+        assert body["success"] is False
+        assert any("db error" in str(e) for e in body["errors"])
+
+    def test_pending_snapshots_post_error_returns_500(self) -> None:
+        client = _make_client()
+        valid_snapshot = {
+            "symbol": "BTC",
+            "instrument_type": "crypto",
+            "side": "buy",
+            "order_price": 50000.0,
+            "quantity": 1.0,
+            "account": "upbit",
+        }
+        with patch(
+            "app.routers.n8n.save_pending_snapshots",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("snapshot fail"),
+        ):
+            resp = client.post(
+                "/api/n8n/pending-snapshots", json={"snapshots": [valid_snapshot]}
+            )
+        assert resp.status_code == 500
+        body = resp.json()
+        assert body["success"] is False
+        assert any("snapshot fail" in str(e) for e in body["errors"])
+
+    def test_sell_signal_symbol_error_returns_500(self) -> None:
+        client = _make_client()
+        with (
+            patch(
+                "app.routers.n8n.get_sell_condition",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "app.routers.n8n.evaluate_sell_signal",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("signal error"),
+            ),
+        ):
+            resp = client.get("/api/n8n/sell-signal/005930")
+        assert resp.status_code == 500
+        body = resp.json()
+        assert body["success"] is False
+        assert body["symbol"] == "005930"
+        assert any("signal error" in str(e) for e in body["errors"])

--- a/tests/services/test_n8n_response_builder.py
+++ b/tests/services/test_n8n_response_builder.py
@@ -1,0 +1,44 @@
+"""Unit tests for app.services.n8n_response_builder."""
+
+from __future__ import annotations
+
+import json
+
+from pydantic import BaseModel
+
+# Import will FAIL until Task 2 creates the module.
+from app.services.n8n_response_builder import n8n_error_response
+
+
+class _SampleResponse(BaseModel):
+    success: bool
+    errors: list[dict]
+
+
+class TestN8nErrorResponse:
+    def test_returns_500_status_code(self) -> None:
+        payload = _SampleResponse(success=False, errors=[{"error": "boom"}])
+        response = n8n_error_response(payload)
+        assert response.status_code == 500
+
+    def test_content_matches_model_dump(self) -> None:
+        payload = _SampleResponse(success=False, errors=[{"error": "boom"}])
+        response = n8n_error_response(payload)
+        body = json.loads(response.body)
+        assert body == {"success": False, "errors": [{"error": "boom"}]}
+
+    def test_success_false_preserved(self) -> None:
+        payload = _SampleResponse(success=False, errors=[])
+        response = n8n_error_response(payload)
+        body = json.loads(response.body)
+        assert body["success"] is False
+
+    def test_nested_errors_list_preserved(self) -> None:
+        payload = _SampleResponse(
+            success=False,
+            errors=[{"error": "first"}, {"market": "kr", "error": "second"}],
+        )
+        response = n8n_error_response(payload)
+        body = json.loads(response.body)
+        assert len(body["errors"]) == 2
+        assert body["errors"][1]["market"] == "kr"


### PR DESCRIPTION
## Summary
- Extracts `n8n_error_response(payload)` helper to `app/services/n8n_response_builder.py`
- Replaces 15 repeated `JSONResponse(status_code=500, content=payload.model_dump())` calls across all n8n router error paths
- Response JSON shape 100% preserved; no endpoint logic changed
- Adds error-path snapshot tests for 5 representative endpoints

Refactor unit: W2-4 (Wave 2, medium-risk).
Plan: `docs/superpowers/plans/2026-05-09-refactor-W2-4-n8n-router-slim.md`

Follow-up note: W2-2 (router pagination standardization) will also touch `n8n.py` and should rebase on top of this merge.

## Test plan
- [ ] `uv run pytest tests/routers/test_n8n_error_paths.py -v` passes (5 tests)
- [ ] `uv run pytest tests/services/test_n8n_response_builder.py -v` passes (4 tests)
- [ ] All existing n8n-related tests pass without modification
- [ ] `uv run ruff check . && uv run ruff format --check .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)