### PR TITLE
chore(W1-7): split mcp shared.py holdings helpers into portfolio_helpers

### DIFF
--- a/app/mcp_server/tooling/portfolio_helpers.py
+++ b/app/mcp_server/tooling/portfolio_helpers.py
@@ -1,0 +1,188 @@
+"""Holdings-specific helpers for portfolio MCP tools.
+
+These helpers were extracted from shared.py to keep shared.py limited to
+cross-cutting utilities (market detection, type converters, error payloads).
+
+The sole primary consumer is portfolio_holdings.py; min_order_krw is also
+used by portfolio_overview_service.py.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.mcp_server.tooling.shared import (
+    DEFAULT_MINIMUM_VALUES,
+    normalize_position_symbol,
+    to_float,
+)
+
+
+def position_to_output(position: dict[str, Any]) -> dict[str, Any]:
+    output = {
+        "symbol": position["symbol"],
+        "name": position["name"],
+        "market": position["market"],
+        "quantity": position["quantity"],
+        "avg_buy_price": position["avg_buy_price"],
+        "current_price": position["current_price"],
+        "evaluation_amount": position["evaluation_amount"],
+        "profit_loss": position["profit_loss"],
+        "profit_rate": position["profit_rate"],
+        "dust": bool(position.get("dust", False)),
+    }
+    if "price_error" in position:
+        output["price_error"] = position["price_error"]
+    if "strategy_signal" in position:
+        output["strategy_signal"] = position["strategy_signal"]
+    return output
+
+
+def value_for_minimum_filter(position: dict[str, Any]) -> float:
+    evaluation_amount = position.get("evaluation_amount")
+    if evaluation_amount is not None:
+        return to_float(evaluation_amount, default=0.0)
+
+    quantity = to_float(position.get("quantity"))
+    current_price = to_float(position.get("current_price"))
+    if current_price <= 0:
+        return 0.0
+    return quantity * current_price
+
+
+def min_order_krw(symbol: str) -> float:
+    """Return KRW minimum order threshold for crypto positions.
+
+    Upbit KRW markets share a fixed minimum order amount in current policy.
+    The ``symbol`` parameter is intentionally retained for future per-market
+    extensions without changing the public function signature.
+    """
+    _ = symbol
+    return DEFAULT_MINIMUM_VALUES["crypto"]
+
+
+def format_filter_threshold(value: float) -> str:
+    return f"{value:g}"
+
+
+def build_holdings_summary(
+    positions: list[dict[str, Any]], include_current_price: bool
+) -> dict[str, Any]:
+    total_buy_amount = round(
+        sum(
+            to_float(position.get("avg_buy_price")) * to_float(position.get("quantity"))
+            for position in positions
+        ),
+        2,
+    )
+
+    if not include_current_price:
+        return {
+            "total_buy_amount": total_buy_amount,
+            "total_evaluation": None,
+            "total_profit_loss": None,
+            "total_profit_rate": None,
+            "position_count": len(positions),
+            "weights": None,
+        }
+
+    total_evaluation = round(
+        sum(to_float(position.get("evaluation_amount")) for position in positions),
+        2,
+    )
+    total_profit_loss = round(
+        sum(to_float(position.get("profit_loss")) for position in positions),
+        2,
+    )
+    total_profit_rate = (
+        round((total_profit_loss / total_buy_amount) * 100, 2)
+        if total_buy_amount > 0
+        else None
+    )
+
+    weights: list[dict[str, Any]] = []
+    if total_evaluation > 0:
+        for position in positions:
+            evaluation = to_float(position.get("evaluation_amount"))
+            if evaluation <= 0:
+                continue
+            weights.append(
+                {
+                    "symbol": position.get("symbol"),
+                    "name": position.get("name"),
+                    "weight_pct": round((evaluation / total_evaluation) * 100, 2),
+                }
+            )
+        weights.sort(key=lambda item: to_float(item.get("weight_pct")), reverse=True)
+
+    return {
+        "total_buy_amount": total_buy_amount,
+        "total_evaluation": total_evaluation,
+        "total_profit_loss": total_profit_loss,
+        "total_profit_rate": total_profit_rate,
+        "position_count": len(positions),
+        "weights": weights,
+    }
+
+
+def is_position_symbol_match(
+    *,
+    position_symbol: str,
+    query_symbol: str,
+    instrument_type: str,
+) -> bool:
+    if instrument_type == "crypto":
+        pos_norm = normalize_position_symbol(position_symbol, "crypto")
+        query_norm = normalize_position_symbol(query_symbol, "crypto")
+        if pos_norm == query_norm:
+            return True
+        pos_base = pos_norm.split("-", 1)[-1]
+        query_base = query_norm.split("-", 1)[-1]
+        return pos_base == query_base
+
+    if instrument_type == "equity_us":
+        from app.core.symbol import to_db_symbol
+
+        return (
+            to_db_symbol(position_symbol).upper() == to_db_symbol(query_symbol).upper()
+        )
+
+    return position_symbol.upper() == query_symbol.upper()
+
+
+def recalculate_profit_fields(position: dict[str, Any]) -> None:
+    current_price = position.get("current_price")
+    quantity = to_float(position.get("quantity"))
+    avg_buy_price = to_float(position.get("avg_buy_price"))
+
+    if current_price is None or quantity <= 0:
+        position["current_price"] = None
+        position["evaluation_amount"] = None
+        position["profit_loss"] = None
+        position["profit_rate"] = None
+        return
+
+    current_price = to_float(current_price)
+    position["current_price"] = current_price
+    position["evaluation_amount"] = round(current_price * quantity, 2)
+
+    if avg_buy_price > 0:
+        profit_loss = (current_price - avg_buy_price) * quantity
+        position["profit_loss"] = round(profit_loss, 2)
+        position["profit_rate"] = round(
+            ((current_price - avg_buy_price) / avg_buy_price) * 100, 2
+        )
+    else:
+        position["profit_loss"] = None
+        position["profit_rate"] = None
+
+
+__all__ = [
+    "position_to_output",
+    "value_for_minimum_filter",
+    "min_order_krw",
+    "format_filter_threshold",
+    "build_holdings_summary",
+    "is_position_symbol_match",
+    "recalculate_profit_fields",
+]

--- a/app/mcp_server/tooling/portfolio_holdings.py
+++ b/app/mcp_server/tooling/portfolio_holdings.py
@@ -33,6 +33,27 @@ from app.mcp_server.tooling.portfolio_cash import (
 from app.mcp_server.tooling.portfolio_cash import (
     get_cash_balance_impl as _get_cash_balance_impl,
 )
+from app.mcp_server.tooling.portfolio_helpers import (
+    build_holdings_summary as _build_holdings_summary,
+)
+from app.mcp_server.tooling.portfolio_helpers import (
+    format_filter_threshold as _format_filter_threshold,
+)
+from app.mcp_server.tooling.portfolio_helpers import (
+    is_position_symbol_match as _is_position_symbol_match,
+)
+from app.mcp_server.tooling.portfolio_helpers import (
+    min_order_krw as _min_order_krw,
+)
+from app.mcp_server.tooling.portfolio_helpers import (
+    position_to_output as _position_to_output,
+)
+from app.mcp_server.tooling.portfolio_helpers import (
+    recalculate_profit_fields as _recalculate_profit_fields,
+)
+from app.mcp_server.tooling.portfolio_helpers import (
+    value_for_minimum_filter as _value_for_minimum_filter,
+)
 from app.mcp_server.tooling.shared import (
     DEFAULT_MINIMUM_VALUES as _DEFAULT_MINIMUM_VALUES,
 )
@@ -44,19 +65,10 @@ from app.mcp_server.tooling.shared import (
     UPBIT_TICKER_BATCH_SIZE as _UPBIT_TICKER_BATCH_SIZE,
 )
 from app.mcp_server.tooling.shared import (
-    build_holdings_summary as _build_holdings_summary,
-)
-from app.mcp_server.tooling.shared import (
     canonical_account_id as _canonical_account_id,
 )
 from app.mcp_server.tooling.shared import (
-    format_filter_threshold as _format_filter_threshold,
-)
-from app.mcp_server.tooling.shared import (
     instrument_to_manual_market_type as _instrument_to_manual_market_type,
-)
-from app.mcp_server.tooling.shared import (
-    is_position_symbol_match as _is_position_symbol_match,
 )
 from app.mcp_server.tooling.shared import (
     logger,
@@ -68,9 +80,6 @@ from app.mcp_server.tooling.shared import (
     match_account_filter as _match_account_filter,
 )
 from app.mcp_server.tooling.shared import (
-    min_order_krw as _min_order_krw,
-)
-from app.mcp_server.tooling.shared import (
     normalize_account_filter as _normalize_account_filter,
 )
 from app.mcp_server.tooling.shared import (
@@ -80,12 +89,6 @@ from app.mcp_server.tooling.shared import (
     parse_holdings_market_filter as _parse_holdings_market_filter,
 )
 from app.mcp_server.tooling.shared import (
-    position_to_output as _position_to_output,
-)
-from app.mcp_server.tooling.shared import (
-    recalculate_profit_fields as _recalculate_profit_fields,
-)
-from app.mcp_server.tooling.shared import (
     resolve_market_type as _resolve_market_type,
 )
 from app.mcp_server.tooling.shared import (
@@ -93,9 +96,6 @@ from app.mcp_server.tooling.shared import (
 )
 from app.mcp_server.tooling.shared import (
     to_optional_float as _to_optional_float,
-)
-from app.mcp_server.tooling.shared import (
-    value_for_minimum_filter as _value_for_minimum_filter,
 )
 from app.services.brokers.kis.client import KISClient
 from app.services.crypto_voting_signals import CryptoVotingSignals, VotingResult

--- a/app/mcp_server/tooling/shared.py
+++ b/app/mcp_server/tooling/shared.py
@@ -447,163 +447,6 @@ def normalize_position_symbol(symbol: str, instrument_type: str) -> str:
     return normalized
 
 
-def position_to_output(position: dict[str, Any]) -> dict[str, Any]:
-    output = {
-        "symbol": position["symbol"],
-        "name": position["name"],
-        "market": position["market"],
-        "quantity": position["quantity"],
-        "avg_buy_price": position["avg_buy_price"],
-        "current_price": position["current_price"],
-        "evaluation_amount": position["evaluation_amount"],
-        "profit_loss": position["profit_loss"],
-        "profit_rate": position["profit_rate"],
-        "dust": bool(position.get("dust", False)),
-    }
-    if "price_error" in position:
-        output["price_error"] = position["price_error"]
-    if "strategy_signal" in position:
-        output["strategy_signal"] = position["strategy_signal"]
-    return output
-
-
-def value_for_minimum_filter(position: dict[str, Any]) -> float:
-    evaluation_amount = position.get("evaluation_amount")
-    if evaluation_amount is not None:
-        return to_float(evaluation_amount, default=0.0)
-
-    quantity = to_float(position.get("quantity"))
-    current_price = to_float(position.get("current_price"))
-    if current_price <= 0:
-        return 0.0
-    return quantity * current_price
-
-
-def min_order_krw(symbol: str) -> float:
-    """Return KRW minimum order threshold for crypto positions.
-
-    Upbit KRW markets share a fixed minimum order amount in current policy.
-    The ``symbol`` parameter is intentionally retained for future per-market
-    extensions without changing the public function signature.
-    """
-    _ = symbol
-    return DEFAULT_MINIMUM_VALUES["crypto"]
-
-
-def format_filter_threshold(value: float) -> str:
-    return f"{value:g}"
-
-
-def build_holdings_summary(
-    positions: list[dict[str, Any]], include_current_price: bool
-) -> dict[str, Any]:
-    total_buy_amount = round(
-        sum(
-            to_float(position.get("avg_buy_price")) * to_float(position.get("quantity"))
-            for position in positions
-        ),
-        2,
-    )
-
-    if not include_current_price:
-        return {
-            "total_buy_amount": total_buy_amount,
-            "total_evaluation": None,
-            "total_profit_loss": None,
-            "total_profit_rate": None,
-            "position_count": len(positions),
-            "weights": None,
-        }
-
-    total_evaluation = round(
-        sum(to_float(position.get("evaluation_amount")) for position in positions),
-        2,
-    )
-    total_profit_loss = round(
-        sum(to_float(position.get("profit_loss")) for position in positions),
-        2,
-    )
-    total_profit_rate = (
-        round((total_profit_loss / total_buy_amount) * 100, 2)
-        if total_buy_amount > 0
-        else None
-    )
-
-    weights: list[dict[str, Any]] = []
-    if total_evaluation > 0:
-        for position in positions:
-            evaluation = to_float(position.get("evaluation_amount"))
-            if evaluation <= 0:
-                continue
-            weights.append(
-                {
-                    "symbol": position.get("symbol"),
-                    "name": position.get("name"),
-                    "weight_pct": round((evaluation / total_evaluation) * 100, 2),
-                }
-            )
-        weights.sort(key=lambda item: to_float(item.get("weight_pct")), reverse=True)
-
-    return {
-        "total_buy_amount": total_buy_amount,
-        "total_evaluation": total_evaluation,
-        "total_profit_loss": total_profit_loss,
-        "total_profit_rate": total_profit_rate,
-        "position_count": len(positions),
-        "weights": weights,
-    }
-
-
-def is_position_symbol_match(
-    *,
-    position_symbol: str,
-    query_symbol: str,
-    instrument_type: str,
-) -> bool:
-    if instrument_type == "crypto":
-        pos_norm = normalize_position_symbol(position_symbol, "crypto")
-        query_norm = normalize_position_symbol(query_symbol, "crypto")
-        if pos_norm == query_norm:
-            return True
-        pos_base = pos_norm.split("-", 1)[-1]
-        query_base = query_norm.split("-", 1)[-1]
-        return pos_base == query_base
-
-    if instrument_type == "equity_us":
-        return (
-            to_db_symbol(position_symbol).upper() == to_db_symbol(query_symbol).upper()
-        )
-
-    return position_symbol.upper() == query_symbol.upper()
-
-
-def recalculate_profit_fields(position: dict[str, Any]) -> None:
-    current_price = position.get("current_price")
-    quantity = to_float(position.get("quantity"))
-    avg_buy_price = to_float(position.get("avg_buy_price"))
-
-    if current_price is None or quantity <= 0:
-        position["current_price"] = None
-        position["evaluation_amount"] = None
-        position["profit_loss"] = None
-        position["profit_rate"] = None
-        return
-
-    current_price = to_float(current_price)
-    position["current_price"] = current_price
-    position["evaluation_amount"] = round(current_price * quantity, 2)
-
-    if avg_buy_price > 0:
-        profit_loss = (current_price - avg_buy_price) * quantity
-        position["profit_loss"] = round(profit_loss, 2)
-        position["profit_rate"] = round(
-            ((current_price - avg_buy_price) / avg_buy_price) * 100, 2
-        )
-    else:
-        position["profit_loss"] = None
-        position["profit_rate"] = None
-
-
 # ---------------------------------------------------------------------------
 # Recommendation Builder
 # ---------------------------------------------------------------------------
@@ -940,18 +783,11 @@ __all__ = [
     "canonical_account_id",
     "normalize_account_filter",
     "match_account_filter",
-    # Holdings helpers
+    # Holdings helpers (market/type converters remain here; position helpers moved to portfolio_helpers)
     "parse_holdings_market_filter",
     "manual_market_to_instrument_type",
     "instrument_to_manual_market_type",
     "normalize_position_symbol",
-    "position_to_output",
-    "value_for_minimum_filter",
-    "min_order_krw",
-    "format_filter_threshold",
-    "build_holdings_summary",
-    "is_position_symbol_match",
-    "recalculate_profit_fields",
     # Recommendation builder
     "build_recommendation_for_equity",
     # Logger

--- a/app/services/portfolio_overview_service.py
+++ b/app/services/portfolio_overview_service.py
@@ -12,7 +12,7 @@ import app.services.brokers.upbit.client as upbit_service
 import app.services.brokers.yahoo.client as yahoo_service
 from app.core.normalizers import to_float as _to_float
 from app.core.symbol import to_db_symbol
-from app.mcp_server.tooling.shared import min_order_krw
+from app.mcp_server.tooling.portfolio_helpers import min_order_krw
 from app.models.manual_holdings import MarketType
 from app.services.brokers.kis.client import KISClient
 from app.services.exchange_rate_service import get_usd_krw_rate

--- a/tests/mcp_server/test_portfolio_helpers.py
+++ b/tests/mcp_server/test_portfolio_helpers.py
@@ -1,0 +1,113 @@
+"""Unit tests for app.mcp_server.tooling.portfolio_helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.mcp_server.tooling.portfolio_helpers import (
+    build_holdings_summary,
+    min_order_krw,
+    position_to_output,
+    recalculate_profit_fields,
+)
+
+
+class TestBuildHoldingsSummary:
+    def test_empty_no_current_price(self) -> None:
+        result = build_holdings_summary([], include_current_price=False)
+        assert result["total_buy_amount"] == 0
+        assert result["position_count"] == 0
+        assert result["weights"] is None
+        assert result["total_evaluation"] is None
+
+    def test_empty_with_current_price(self) -> None:
+        result = build_holdings_summary([], include_current_price=True)
+        assert result["total_evaluation"] == 0
+        assert result["weights"] == []
+        assert result["position_count"] == 0
+
+    def test_single_position_with_current_price(self) -> None:
+        positions = [
+            {
+                "symbol": "KRW-BTC",
+                "name": "Bitcoin",
+                "avg_buy_price": 1000,
+                "quantity": 2,
+                "evaluation_amount": 2100,
+                "profit_loss": 100,
+                "profit_rate": 5.0,
+            }
+        ]
+        result = build_holdings_summary(positions, include_current_price=True)
+        assert result["total_buy_amount"] == 2000
+        assert result["total_evaluation"] == 2100
+        assert result["total_profit_loss"] == 100
+        assert result["total_profit_rate"] == pytest.approx(5.0, rel=1e-3)
+        assert result["position_count"] == 1
+
+
+class TestRecalculateProfitFields:
+    def test_no_current_price_clears_fields(self) -> None:
+        position: dict = {
+            "current_price": None,
+            "quantity": 10,
+            "avg_buy_price": 1000,
+        }
+        recalculate_profit_fields(position)
+        assert position["evaluation_amount"] is None
+        assert position["profit_loss"] is None
+        assert position["profit_rate"] is None
+
+    def test_normal_profit_calculation(self) -> None:
+        position: dict = {
+            "current_price": 1100,
+            "quantity": 2,
+            "avg_buy_price": 1000,
+        }
+        recalculate_profit_fields(position)
+        assert position["evaluation_amount"] == pytest.approx(2200.0)
+        assert position["profit_loss"] == pytest.approx(200.0)
+        assert position["profit_rate"] == pytest.approx(10.0)
+
+
+class TestMinOrderKrw:
+    def test_krw_btc_returns_5000(self) -> None:
+        assert min_order_krw("KRW-BTC") == 5000.0
+
+    def test_other_symbol_same_default(self) -> None:
+        assert min_order_krw("KRW-ETH") == 5000.0
+
+
+class TestPositionToOutput:
+    def test_required_fields_present(self) -> None:
+        position = {
+            "symbol": "KRW-BTC",
+            "name": "Bitcoin",
+            "market": "crypto",
+            "quantity": 1,
+            "avg_buy_price": 50000000,
+            "current_price": 52000000,
+            "evaluation_amount": 52000000,
+            "profit_loss": 2000000,
+            "profit_rate": 4.0,
+        }
+        output = position_to_output(position)
+        assert output["symbol"] == "KRW-BTC"
+        assert output["dust"] is False
+        assert "evaluation_amount" in output
+        assert "profit_rate" in output
+
+    def test_dust_defaults_false(self) -> None:
+        position = {
+            "symbol": "KRW-ETH",
+            "name": "Ethereum",
+            "market": "crypto",
+            "quantity": 0,
+            "avg_buy_price": 0,
+            "current_price": 0,
+            "evaluation_amount": 0,
+            "profit_loss": 0,
+            "profit_rate": 0,
+        }
+        output = position_to_output(position)
+        assert output["dust"] is False

--- a/tests/test_dust_accounting.py
+++ b/tests/test_dust_accounting.py
@@ -96,14 +96,20 @@ async def test_list_holdings_marks_crypto_dust_and_keeps_non_crypto_false(monkey
 
 
 def test_min_order_krw_returns_fixed_crypto_minimum():
-    from app.mcp_server.tooling import shared
+    from app.mcp_server.tooling import portfolio_helpers, shared
 
-    assert shared.min_order_krw("KRW-BTC") == shared.DEFAULT_MINIMUM_VALUES["crypto"]
-    assert shared.min_order_krw("KRW-ETH") == shared.DEFAULT_MINIMUM_VALUES["crypto"]
+    assert (
+        portfolio_helpers.min_order_krw("KRW-BTC")
+        == shared.DEFAULT_MINIMUM_VALUES["crypto"]
+    )
+    assert (
+        portfolio_helpers.min_order_krw("KRW-ETH")
+        == shared.DEFAULT_MINIMUM_VALUES["crypto"]
+    )
 
 
 def test_position_to_output_includes_dust_with_false_default():
-    from app.mcp_server.tooling.shared import position_to_output
+    from app.mcp_server.tooling.portfolio_helpers import position_to_output
 
     base = {
         "symbol": "KRW-BTC",


### PR DESCRIPTION
## Summary
- Move 7 holdings-specific helpers (`build_holdings_summary`, `position_to_output`, `recalculate_profit_fields`, `min_order_krw`, `value_for_minimum_filter`, `format_filter_threshold`, `is_position_symbol_match`) from `app/mcp_server/tooling/shared.py` into new `app/mcp_server/tooling/portfolio_helpers.py`.
- `shared.py` reserved for cross-cutting utilities (market detection, type converters, error payloads). 
- Sole consumer is `portfolio_holdings.py` (with `min_order_krw` also used by `portfolio_overview_service.py`); call sites updated.

Refactor unit: W1-7 (Wave 1 leftover, follow-up to W1-9).
Plan: `docs/superpowers/plans/2026-05-09-refactor-W1-7-mcp-shared-holdings-split.md`

Build on top of W1-9 (already merged).

## Test plan
- [x] `uv run pytest tests/mcp_server/ -v` — 52 passed
- [x] Import smoke: `python -c "import app.mcp_server.tooling"` — OK
- [x] `uv run ruff check . && uv run ruff format --check .` — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)