### PR TITLE
chore(W2-2): standardize router pagination via shared Depends helper (5 routers)

### DIFF
--- a/app/routers/news_analysis.py
+++ b/app/routers/news_analysis.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.db import get_db
 from app.models.news import NewsArticle
+from app.routers.pagination import PaginationParams, pagination_params
 from app.schemas.news import (
     BulkCreateResponse,
     NewsAnalysisRequest,
@@ -26,6 +27,8 @@ from app.services.llm_news_service import (
 )
 
 router = APIRouter(prefix="/api/v1/news", tags=["News Analysis"])
+
+_pagination = pagination_params(default_limit=10, max_limit=100)
 
 
 @router.post(
@@ -132,8 +135,7 @@ async def list_news_articles(
     ),
     keyword: str | None = Query(None, description="키워드로 필터링"),
     has_analysis: bool | None = Query(None, description="분석 완료 여부로 필터링"),
-    limit: int = Query(10, ge=1, le=100, description="반환할 뉴스 수"),
-    offset: int = Query(0, ge=0, description="걸러뛸 뉴스 수"),
+    p: PaginationParams = Depends(_pagination),
 ):
     try:
         articles, total = await get_news_articles(
@@ -141,8 +143,8 @@ async def list_news_articles(
             stock_symbol=stock_symbol,
             sentiment=sentiment,
             source=source,
-            limit=limit,
-            offset=offset,
+            limit=p.limit,
+            offset=p.offset,
             hours=hours,
             feed_source=feed_source,
             keyword=keyword,
@@ -150,8 +152,8 @@ async def list_news_articles(
         )
 
         page_info = {
-            "limit": limit,
-            "offset": offset,
+            "limit": p.limit,
+            "offset": p.offset,
             "total": total,
         }
 

--- a/app/routers/news_issues.py
+++ b/app/routers/news_issues.py
@@ -12,10 +12,13 @@ from fastapi import APIRouter, Depends, Query
 
 from app.models.trading import User
 from app.routers.dependencies import get_authenticated_user
+from app.routers.pagination import PaginationParams, pagination_params
 from app.schemas.news_issues import MarketIssuesResponse
 from app.services.news_issue_clustering_service import build_market_issues
 
 router = APIRouter(prefix="/trading", tags=["news-issues"])
+
+_pagination = pagination_params(default_limit=20, max_limit=100)
 
 
 @router.get("/api/news-issues", response_model=MarketIssuesResponse)
@@ -23,8 +26,8 @@ async def get_news_issues(
     current_user: Annotated[User, Depends(get_authenticated_user)],
     market: Literal["all", "kr", "us", "crypto"] = Query("all"),
     window_hours: int = Query(24, ge=1, le=168),
-    limit: int = Query(20, ge=1, le=100),
+    p: PaginationParams = Depends(_pagination),
 ) -> MarketIssuesResponse:
     return await build_market_issues(
-        market=market, window_hours=window_hours, limit=limit
+        market=market, window_hours=window_hours, limit=p.limit
     )

--- a/app/routers/news_radar.py
+++ b/app/routers/news_radar.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, Depends, Query
 
 from app.models.trading import User
 from app.routers.dependencies import get_authenticated_user
+from app.routers.pagination import PaginationParams, pagination_params
 from app.schemas.news_radar import (
     NewsRadarMarket,
     NewsRadarResponse,
@@ -20,6 +21,8 @@ from app.schemas.news_radar import (
 from app.services.news_radar_service import build_news_radar
 
 router = APIRouter(prefix="/trading", tags=["news-radar"])
+
+_pagination = pagination_params(default_limit=50, max_limit=200)
 
 
 @router.get("/api/news-radar", response_model=NewsRadarResponse)
@@ -30,7 +33,7 @@ async def get_news_radar(
     q: str | None = Query(None, max_length=200),
     risk_category: NewsRadarRiskCategory | None = Query(None),
     include_excluded: bool = Query(True),
-    limit: int = Query(50, ge=1, le=200),
+    p: PaginationParams = Depends(_pagination),
 ) -> NewsRadarResponse:
     return await build_news_radar(
         market=market,
@@ -38,5 +41,5 @@ async def get_news_radar(
         q=q,
         risk_category=risk_category,
         include_excluded=include_excluded,
-        limit=limit,
+        limit=p.limit,
     )

--- a/app/routers/pagination.py
+++ b/app/routers/pagination.py
@@ -1,0 +1,100 @@
+"""Shared FastAPI Depends helpers for limit/offset and page/page_size pagination."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from fastapi import Query
+
+
+@dataclass(frozen=True, slots=True)
+class PaginationParams:
+    """Parsed limit + offset query parameters."""
+
+    limit: int
+    offset: int
+
+
+@dataclass(frozen=True, slots=True)
+class PageParams:
+    """Parsed page + page_size query parameters."""
+
+    page: int
+    page_size: int
+
+
+def pagination_params(
+    *,
+    default_limit: int = 50,
+    max_limit: int = 200,
+) -> Callable[..., PaginationParams]:
+    """Return a FastAPI Depends callable for limit/offset pagination.
+
+    Usage::
+
+        dep = pagination_params(default_limit=20, max_limit=100)
+
+        @router.get("/items")
+        async def list_items(p: PaginationParams = dep, ...):
+            ...
+    """
+
+    def _dep(
+        limit: int | None = Query(
+            default=None,
+            ge=1,
+            le=max_limit,
+            description=f"페이지 크기 (최대 {max_limit})",
+        ),
+        offset: int | None = Query(
+            default=None,
+            ge=0,
+            description="건너뛸 항목 수",
+        ),
+    ) -> PaginationParams:
+        return PaginationParams(
+            limit=min(limit if limit is not None else default_limit, max_limit),
+            offset=offset if offset is not None else 0,
+        )
+
+    return _dep
+
+
+def page_params(
+    *,
+    default_size: int = 50,
+    max_size: int = 200,
+) -> Callable[..., PageParams]:
+    """Return a FastAPI Depends callable for page/page_size pagination.
+
+    Usage::
+
+        dep = page_params(default_size=50, max_size=200)
+
+        @router.get("/stocks")
+        async def list_stocks(p: PageParams = dep, ...):
+            ...
+    """
+
+    def _dep(
+        page: int | None = Query(
+            default=None,
+            ge=1,
+            description="페이지 번호 (1부터)",
+        ),
+        page_size: int | None = Query(
+            default=None,
+            ge=1,
+            le=max_size,
+            description=f"페이지 크기 (최대 {max_size})",
+        ),
+    ) -> PageParams:
+        return PageParams(
+            page=page if page is not None else 1,
+            page_size=min(
+                page_size if page_size is not None else default_size, max_size
+            ),
+        )
+
+    return _dep

--- a/app/routers/strategy_events.py
+++ b/app/routers/strategy_events.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.db import get_db
 from app.models.trading import User
 from app.routers.dependencies import get_authenticated_user
+from app.routers.pagination import PaginationParams, pagination_params
 from app.schemas.strategy_events import (
     StrategyEventCreateRequest,
     StrategyEventDetail,
@@ -23,6 +24,8 @@ from app.schemas.strategy_events import (
 from app.services import strategy_event_service
 
 router = APIRouter(prefix="/trading", tags=["strategy-events"])
+
+_pagination = pagination_params(default_limit=50, max_limit=200)
 
 
 @router.post(
@@ -53,16 +56,15 @@ async def list_strategy_events(
     current_user: Annotated[User, Depends(get_authenticated_user)],
     session_uuid: UUID | None = Query(default=None),
     mine: bool = Query(default=False),
-    limit: int = Query(default=50, ge=1, le=200),
-    offset: int = Query(default=0, ge=0),
+    p: PaginationParams = Depends(_pagination),
 ) -> StrategyEventListResponse:
     try:
         return await strategy_event_service.list_strategy_events(
             db,
             session_uuid=session_uuid,
             user_id=current_user.id if mine else None,
-            limit=limit,
-            offset=offset,
+            limit=p.limit,
+            offset=p.offset,
         )
     except strategy_event_service.UnknownSessionUUIDError:
         raise HTTPException(status_code=404, detail="session_uuid_not_found")

--- a/app/routers/trading_decisions.py
+++ b/app/routers/trading_decisions.py
@@ -1,10 +1,9 @@
 """Trading decisions API router."""
 
 from datetime import UTC, datetime
-from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,6 +11,7 @@ from app.core.config import settings
 from app.core.db import get_db
 from app.models.trading import User
 from app.routers.dependencies import get_authenticated_user
+from app.routers.pagination import PaginationParams, pagination_params
 from app.schemas.operator_decision_session import (
     OperatorDecisionRequest,
     OperatorDecisionResponse,
@@ -51,6 +51,8 @@ from app.services.tradingagents_research_service import (
 )
 
 router = APIRouter(prefix="/trading", tags=["trading-decisions"])
+
+_list_pagination = pagination_params(default_limit=50, max_limit=200)
 
 
 def _to_action_detail(action) -> ActionDetail:
@@ -173,8 +175,7 @@ def _to_session_detail(session) -> SessionDetail:
 
 @router.get("/api/decisions", response_model=SessionListResponse)
 async def list_decisions(
-    limit: Annotated[int, Query(ge=1, le=200)] = 50,
-    offset: Annotated[int, Query(ge=0)] = 0,
+    p: PaginationParams = Depends(_list_pagination),
     status: SessionStatusLiteral | None = None,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_authenticated_user),
@@ -182,8 +183,8 @@ async def list_decisions(
     rows, total = await trading_decision_service.list_user_sessions(
         db,
         user_id=current_user.id,
-        limit=limit,
-        offset=offset,
+        limit=p.limit,
+        offset=p.offset,
         status=status,
     )
 
@@ -194,8 +195,8 @@ async def list_decisions(
     return SessionListResponse(
         sessions=sessions,
         total=total,
-        limit=limit,
-        offset=offset,
+        limit=p.limit,
+        offset=p.offset,
     )
 
 

--- a/tests/routers/test_pagination.py
+++ b/tests/routers/test_pagination.py
@@ -1,0 +1,147 @@
+"""Unit tests for app/routers/pagination.py Depends helpers."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers.pagination import (
+    PageParams,
+    PaginationParams,
+    page_params,
+    pagination_params,
+)
+
+# ---------------------------------------------------------------------------
+# PaginationParams unit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pagination_params_defaults():
+    dep = pagination_params(default_limit=20, max_limit=100)
+    result: PaginationParams = dep(limit=None, offset=None)
+    assert result.limit == 20
+    assert result.offset == 0
+
+
+@pytest.mark.unit
+def test_pagination_params_explicit():
+    dep = pagination_params(default_limit=20, max_limit=100)
+    result: PaginationParams = dep(limit=40, offset=10)
+    assert result.limit == 40
+    assert result.offset == 10
+
+
+@pytest.mark.unit
+def test_pagination_params_clamps_to_max():
+    dep = pagination_params(default_limit=20, max_limit=100)
+    result: PaginationParams = dep(limit=9999, offset=0)
+    assert result.limit == 100
+
+
+@pytest.mark.unit
+def test_pagination_params_rejects_negative_limit():
+    app = FastAPI()
+    dep = pagination_params(default_limit=20, max_limit=100)
+
+    @app.get("/items")
+    def list_items(p: PaginationParams = Depends(dep)):
+        return {"limit": p.limit, "offset": p.offset}
+
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/items?limit=-1&offset=0")
+    assert resp.status_code == 422
+
+
+@pytest.mark.unit
+def test_pagination_params_rejects_negative_offset():
+    app = FastAPI()
+    dep = pagination_params(default_limit=20, max_limit=100)
+
+    @app.get("/items")
+    def list_items(p: PaginationParams = Depends(dep)):
+        return {"limit": p.limit, "offset": p.offset}
+
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/items?limit=10&offset=-1")
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# PageParams unit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_page_params_defaults():
+    dep = page_params(default_size=50, max_size=200)
+    result: PageParams = dep(page=None, page_size=None)
+    assert result.page == 1
+    assert result.page_size == 50
+
+
+@pytest.mark.unit
+def test_page_params_explicit():
+    dep = page_params(default_size=50, max_size=200)
+    result: PageParams = dep(page=3, page_size=100)
+    assert result.page == 3
+    assert result.page_size == 100
+
+
+@pytest.mark.unit
+def test_page_params_clamps_size():
+    dep = page_params(default_size=50, max_size=200)
+    result: PageParams = dep(page=1, page_size=9999)
+    assert result.page_size == 200
+
+
+# ---------------------------------------------------------------------------
+# Via FastAPI Depends (full HTTP path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+def test_pagination_via_http_default():
+    app = FastAPI()
+    dep = pagination_params(default_limit=20, max_limit=100)
+
+    @app.get("/items")
+    def list_items(p: PaginationParams = Depends(dep)):
+        return {"limit": p.limit, "offset": p.offset}
+
+    client = TestClient(app)
+    resp = client.get("/items")
+    assert resp.status_code == 200
+    assert resp.json() == {"limit": 20, "offset": 0}
+
+
+@pytest.mark.unit
+def test_pagination_via_http_explicit():
+    app = FastAPI()
+    dep = pagination_params(default_limit=20, max_limit=100)
+
+    @app.get("/items")
+    def list_items(p: PaginationParams = Depends(dep)):
+        return {"limit": p.limit, "offset": p.offset}
+
+    client = TestClient(app)
+    resp = client.get("/items?limit=15&offset=30")
+    assert resp.status_code == 200
+    assert resp.json() == {"limit": 15, "offset": 30}
+
+
+@pytest.mark.unit
+def test_page_params_via_http():
+    app = FastAPI()
+    dep = page_params(default_size=50, max_size=200)
+
+    @app.get("/stocks")
+    def list_stocks(p: PageParams = Depends(dep)):
+        return {"page": p.page, "page_size": p.page_size}
+
+    client = TestClient(app)
+    resp = client.get("/stocks?page=2&page_size=25")
+    assert resp.status_code == 200
+    assert resp.json() == {"page": 2, "page_size": 25}


### PR DESCRIPTION
## Summary
- Add `app/routers/pagination.py` with reusable `pagination_params(default_limit, max_limit)` and `page_params` Depends factories.
- Migrate 5 routers (news_analysis, news_issues, news_radar, strategy_events, trading_decisions) to the shared helper.
- Other routers (invest_api, research_retrospective, screener, n8n, etc.) **deferred to a follow-up PR** to keep this change reviewable. Current 5-router migration was completed via TDD (helper module + 11 unit tests + per-router regression).

Refactor unit: W2-2 (Wave 2, partial scope; remaining 7 routers in follow-up).
Plan: \`docs/superpowers/plans/2026-05-09-refactor-W2-2-router-pagination.md\`

Builds on W1-5 (PaginationMeta/ListResponse) ✅ and W2-4 (n8n.py error helper) ✅.

## Test plan
- [ ] \`uv run pytest tests/routers/test_pagination.py -v\` (11 passed)
- [ ] \`uv run pytest tests/ -k "pagination or news_analysis or news_issues or news_radar or strategy_events or trading_decisions" -v\` (107 passed)
- [ ] \`uv run ruff check . && uv run ruff format --check .\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized pagination handling across multiple API endpoints for consistent behavior.

* **Tests**
  * Added comprehensive test coverage for pagination utilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/756)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->