### PR TITLE
chore(W2-1): centralize mcp market normalization helpers

### DIFF
--- a/app/mcp_server/tooling/fundamentals/_helpers.py
+++ b/app/mcp_server/tooling/fundamentals/_helpers.py
@@ -1,53 +1,21 @@
-"""Shared helpers for fundamentals tool handlers."""
+"""Shared helpers for fundamentals tool handlers.
+
+All market normalization logic now lives in
+``app.mcp_server.tooling.market_normalization``. This module re-exports
+for backward compatibility with ``_financials.py``, ``_news.py``,
+``_profiles.py``, ``_valuation.py`` that import from here.
+"""
 
 from __future__ import annotations
 
-from app.mcp_server.tooling.shared import (
-    is_crypto_market as _is_crypto_market,
+from app.mcp_server.tooling.market_normalization import (
+    detect_equity_market,
+    normalize_equity_market,
+    normalize_market_with_crypto,
 )
-from app.mcp_server.tooling.shared import (
-    is_korean_equity_code as _is_korean_equity_code,
-)
 
-# Alias sets for market string normalization
-_KR_ALIASES = frozenset(
-    {"kr", "krx", "korea", "kospi", "kosdaq", "kis", "equity_kr", "naver"}
-)
-_US_ALIASES = frozenset({"us", "usa", "nyse", "nasdaq", "yahoo", "equity_us"})
-_CRYPTO_ALIASES = frozenset({"crypto", "upbit", "krw", "usdt"})
-
-
-def normalize_equity_market(market: str) -> str:
-    """Normalize a market string to 'kr' or 'us'. Raises ValueError otherwise."""
-    m = market.strip().lower()
-    if m in _KR_ALIASES:
-        return "kr"
-    if m in _US_ALIASES:
-        return "us"
-    raise ValueError("market must be 'us' or 'kr'")
-
-
-def normalize_market_with_crypto(market: str) -> str:
-    """Normalize a market string to 'kr', 'us', or 'crypto'. Raises ValueError otherwise."""
-    m = market.strip().lower()
-    if m in _CRYPTO_ALIASES:
-        return "crypto"
-    if m in _KR_ALIASES:
-        return "kr"
-    if m in _US_ALIASES:
-        return "us"
-    raise ValueError("market must be 'us', 'kr', or 'crypto'")
-
-
-def detect_equity_market(symbol: str, market: str | None) -> str:
-    """Auto-detect equity market from symbol, or normalize explicit market.
-
-    Returns 'kr' or 'us'. Raises ValueError for crypto symbols.
-    """
-    if market is not None:
-        return normalize_equity_market(market)
-    if _is_crypto_market(symbol):
-        raise ValueError("not available for cryptocurrencies")
-    if _is_korean_equity_code(symbol):
-        return "kr"
-    return "us"
+__all__ = [
+    "detect_equity_market",
+    "normalize_equity_market",
+    "normalize_market_with_crypto",
+]

--- a/app/mcp_server/tooling/market_normalization.py
+++ b/app/mcp_server/tooling/market_normalization.py
@@ -1,0 +1,71 @@
+"""Canonical market detection and normalization helpers for MCP tools.
+
+All market-related detection and normalization functions are gathered here.
+``app.mcp_server.tooling.shared`` continues to re-export the core subset
+(``is_korean_equity_code``, ``is_crypto_market``, ``is_us_equity_symbol``,
+``normalize_market``, ``resolve_market_type``) for backward compatibility.
+"""
+
+from __future__ import annotations
+
+from app.mcp_server.tooling.shared import (
+    is_crypto_market,
+    is_korean_equity_code,
+    is_us_equity_symbol,
+    normalize_market,
+    resolve_market_type,
+)
+
+_KR_ALIASES = frozenset(
+    {"kr", "krx", "korea", "kospi", "kosdaq", "kis", "equity_kr", "naver"}
+)
+_US_ALIASES = frozenset({"us", "usa", "nyse", "nasdaq", "yahoo", "equity_us"})
+_CRYPTO_ALIASES = frozenset({"crypto", "upbit", "krw", "usdt"})
+
+
+def normalize_equity_market(market: str) -> str:
+    """Normalize a market string to 'kr' or 'us'. Raises ValueError for crypto/unknown."""
+    m = market.strip().lower()
+    if m in _KR_ALIASES:
+        return "kr"
+    if m in _US_ALIASES:
+        return "us"
+    raise ValueError("market must be 'us' or 'kr'")
+
+
+def normalize_market_with_crypto(market: str) -> str:
+    """Normalize a market string to 'kr', 'us', or 'crypto'. Raises ValueError otherwise."""
+    m = market.strip().lower()
+    if m in _CRYPTO_ALIASES:
+        return "crypto"
+    if m in _KR_ALIASES:
+        return "kr"
+    if m in _US_ALIASES:
+        return "us"
+    raise ValueError("market must be 'us', 'kr', or 'crypto'")
+
+
+def detect_equity_market(symbol: str, market: str | None) -> str:
+    """Auto-detect equity market from symbol, or normalize explicit market.
+
+    Returns 'kr' or 'us'. Raises ValueError for crypto symbols or unknown market.
+    """
+    if market is not None:
+        return normalize_equity_market(market)
+    if is_crypto_market(symbol):
+        raise ValueError("not available for cryptocurrencies")
+    if is_korean_equity_code(symbol):
+        return "kr"
+    return "us"
+
+
+__all__ = [
+    "detect_equity_market",
+    "is_crypto_market",
+    "is_korean_equity_code",
+    "is_us_equity_symbol",
+    "normalize_equity_market",
+    "normalize_market",
+    "normalize_market_with_crypto",
+    "resolve_market_type",
+]

--- a/tests/mcp_server/test_market_normalization.py
+++ b/tests/mcp_server/test_market_normalization.py
@@ -1,0 +1,282 @@
+"""Unit tests for app/mcp_server/tooling/market_normalization.py"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestIsKoreanEquityCode:
+    def test_standard_6char_code(self):
+        from app.mcp_server.tooling.market_normalization import is_korean_equity_code
+
+        assert is_korean_equity_code("005930") is True
+        assert is_korean_equity_code("035420") is True
+
+    def test_a_prefixed_7char_code(self):
+        from app.mcp_server.tooling.market_normalization import is_korean_equity_code
+
+        assert is_korean_equity_code("A196170") is True
+
+    def test_us_ticker_rejected(self):
+        from app.mcp_server.tooling.market_normalization import is_korean_equity_code
+
+        assert is_korean_equity_code("AAPL") is False
+        assert is_korean_equity_code("TSLA") is False
+
+    def test_crypto_symbol_rejected(self):
+        from app.mcp_server.tooling.market_normalization import is_korean_equity_code
+
+        assert is_korean_equity_code("KRW-BTC") is False
+
+    def test_empty_string_rejected(self):
+        from app.mcp_server.tooling.market_normalization import is_korean_equity_code
+
+        assert is_korean_equity_code("") is False
+
+    def test_5char_code_rejected(self):
+        from app.mcp_server.tooling.market_normalization import is_korean_equity_code
+
+        assert is_korean_equity_code("05930") is False
+
+
+class TestIsCryptoMarket:
+    def test_krw_prefix(self):
+        from app.mcp_server.tooling.market_normalization import is_crypto_market
+
+        assert is_crypto_market("KRW-BTC") is True
+        assert is_crypto_market("KRW-ETH") is True
+
+    def test_usdt_prefix(self):
+        from app.mcp_server.tooling.market_normalization import is_crypto_market
+
+        assert is_crypto_market("USDT-BTC") is True
+
+    def test_lowercase_recognized(self):
+        from app.mcp_server.tooling.market_normalization import is_crypto_market
+
+        assert is_crypto_market("krw-btc") is True
+
+    def test_kr_equity_rejected(self):
+        from app.mcp_server.tooling.market_normalization import is_crypto_market
+
+        assert is_crypto_market("005930") is False
+
+    def test_us_equity_rejected(self):
+        from app.mcp_server.tooling.market_normalization import is_crypto_market
+
+        assert is_crypto_market("AAPL") is False
+
+
+class TestIsUsEquitySymbol:
+    def test_standard_ticker(self):
+        from app.mcp_server.tooling.market_normalization import is_us_equity_symbol
+
+        assert is_us_equity_symbol("AAPL") is True
+        assert is_us_equity_symbol("TSLA") is True
+
+    def test_dot_share_class(self):
+        from app.mcp_server.tooling.market_normalization import is_us_equity_symbol
+
+        assert is_us_equity_symbol("BRK.B") is True
+
+    def test_crypto_rejected(self):
+        from app.mcp_server.tooling.market_normalization import is_us_equity_symbol
+
+        assert is_us_equity_symbol("KRW-BTC") is False
+
+    def test_empty_string_rejected(self):
+        from app.mcp_server.tooling.market_normalization import is_us_equity_symbol
+
+        assert is_us_equity_symbol("") is False
+
+
+class TestNormalizeMarket:
+    @pytest.mark.parametrize(
+        "alias,expected",
+        [
+            ("kr", "equity_kr"),
+            ("krx", "equity_kr"),
+            ("kospi", "equity_kr"),
+            ("kosdaq", "equity_kr"),
+            ("kis", "equity_kr"),
+            ("equity_kr", "equity_kr"),
+            ("us", "equity_us"),
+            ("usa", "equity_us"),
+            ("nasdaq", "equity_us"),
+            ("equity_us", "equity_us"),
+            ("crypto", "crypto"),
+            ("upbit", "crypto"),
+            ("krw", "crypto"),
+        ],
+    )
+    def test_known_aliases(self, alias, expected):
+        from app.mcp_server.tooling.market_normalization import normalize_market
+
+        assert normalize_market(alias) == expected
+
+    def test_none_returns_none(self):
+        from app.mcp_server.tooling.market_normalization import normalize_market
+
+        assert normalize_market(None) is None
+
+    def test_empty_string_returns_none(self):
+        from app.mcp_server.tooling.market_normalization import normalize_market
+
+        assert normalize_market("") is None
+
+    def test_unknown_alias_returns_none(self):
+        from app.mcp_server.tooling.market_normalization import normalize_market
+
+        assert normalize_market("unknown") is None
+
+
+class TestResolveMarketType:
+    def test_crypto_with_explicit_market(self):
+        from app.mcp_server.tooling.market_normalization import resolve_market_type
+
+        market_type, symbol = resolve_market_type("KRW-BTC", "crypto")
+        assert market_type == "crypto"
+        assert symbol == "KRW-BTC"
+
+    def test_kr_equity_with_explicit_market(self):
+        from app.mcp_server.tooling.market_normalization import resolve_market_type
+
+        market_type, symbol = resolve_market_type("005930", "kr")
+        assert market_type == "equity_kr"
+        assert symbol == "005930"
+
+    def test_us_equity_with_explicit_market(self):
+        from app.mcp_server.tooling.market_normalization import resolve_market_type
+
+        market_type, symbol = resolve_market_type("AAPL", "us")
+        assert market_type == "equity_us"
+        assert symbol == "AAPL"
+
+    def test_autodetect_crypto_by_symbol(self):
+        from app.mcp_server.tooling.market_normalization import resolve_market_type
+
+        market_type, _ = resolve_market_type("KRW-ETH", None)
+        assert market_type == "crypto"
+
+    def test_autodetect_kr_by_symbol(self):
+        from app.mcp_server.tooling.market_normalization import resolve_market_type
+
+        market_type, _ = resolve_market_type("035420", None)
+        assert market_type == "equity_kr"
+
+    def test_autodetect_us_by_symbol(self):
+        from app.mcp_server.tooling.market_normalization import resolve_market_type
+
+        market_type, _ = resolve_market_type("TSLA", None)
+        assert market_type == "equity_us"
+
+
+class TestNormalizeEquityMarket:
+    def test_kr_aliases(self):
+        from app.mcp_server.tooling.market_normalization import normalize_equity_market
+
+        assert normalize_equity_market("kr") == "kr"
+        assert normalize_equity_market("kospi") == "kr"
+        assert normalize_equity_market("equity_kr") == "kr"
+
+    def test_us_aliases(self):
+        from app.mcp_server.tooling.market_normalization import normalize_equity_market
+
+        assert normalize_equity_market("us") == "us"
+        assert normalize_equity_market("nasdaq") == "us"
+        assert normalize_equity_market("equity_us") == "us"
+
+    def test_crypto_raises_value_error(self):
+        from app.mcp_server.tooling.market_normalization import normalize_equity_market
+
+        with pytest.raises(ValueError):
+            normalize_equity_market("crypto")
+
+    def test_unknown_raises_value_error(self):
+        from app.mcp_server.tooling.market_normalization import normalize_equity_market
+
+        with pytest.raises(ValueError):
+            normalize_equity_market("unknown")
+
+
+class TestNormalizeMarketWithCrypto:
+    def test_crypto_aliases(self):
+        from app.mcp_server.tooling.market_normalization import (
+            normalize_market_with_crypto,
+        )
+
+        assert normalize_market_with_crypto("crypto") == "crypto"
+        assert normalize_market_with_crypto("upbit") == "crypto"
+
+    def test_kr_aliases(self):
+        from app.mcp_server.tooling.market_normalization import (
+            normalize_market_with_crypto,
+        )
+
+        assert normalize_market_with_crypto("kr") == "kr"
+
+    def test_us_aliases(self):
+        from app.mcp_server.tooling.market_normalization import (
+            normalize_market_with_crypto,
+        )
+
+        assert normalize_market_with_crypto("us") == "us"
+
+    def test_unknown_raises_value_error(self):
+        from app.mcp_server.tooling.market_normalization import (
+            normalize_market_with_crypto,
+        )
+
+        with pytest.raises(ValueError):
+            normalize_market_with_crypto("unknown")
+
+
+class TestDetectEquityMarket:
+    def test_explicit_market_kr(self):
+        from app.mcp_server.tooling.market_normalization import detect_equity_market
+
+        assert detect_equity_market("005930", "kr") == "kr"
+
+    def test_explicit_market_us(self):
+        from app.mcp_server.tooling.market_normalization import detect_equity_market
+
+        assert detect_equity_market("AAPL", "us") == "us"
+
+    def test_autodetect_kr_from_symbol(self):
+        from app.mcp_server.tooling.market_normalization import detect_equity_market
+
+        assert detect_equity_market("005930", None) == "kr"
+
+    def test_autodetect_us_from_symbol(self):
+        from app.mcp_server.tooling.market_normalization import detect_equity_market
+
+        assert detect_equity_market("TSLA", None) == "us"
+
+    def test_crypto_symbol_raises_value_error(self):
+        from app.mcp_server.tooling.market_normalization import detect_equity_market
+
+        with pytest.raises(ValueError):
+            detect_equity_market("KRW-BTC", None)
+
+
+class TestBackwardCompatShared:
+    def test_is_korean_equity_code_importable_from_shared(self):
+        from app.mcp_server.tooling.shared import is_korean_equity_code
+
+        assert is_korean_equity_code("005930") is True
+
+    def test_is_crypto_market_importable_from_shared(self):
+        from app.mcp_server.tooling.shared import is_crypto_market
+
+        assert is_crypto_market("KRW-BTC") is True
+
+    def test_normalize_market_importable_from_shared(self):
+        from app.mcp_server.tooling.shared import normalize_market
+
+        assert normalize_market("kr") == "equity_kr"
+
+    def test_resolve_market_type_importable_from_shared(self):
+        from app.mcp_server.tooling.shared import resolve_market_type
+
+        market_type, _ = resolve_market_type("005930", None)
+        assert market_type == "equity_kr"


### PR DESCRIPTION
## Summary
- Add \`app/mcp_server/tooling/market_normalization.py\` as canonical module for market detection/normalization helpers.
- Re-exports the 5 functions defined in \`shared.py\` (\`is_korean_equity_code\`, \`is_crypto_market\`, \`is_us_equity_symbol\`, \`normalize_market\`, \`resolve_market_type\`).
- Moves \`normalize_equity_market\`, \`normalize_market_with_crypto\`, \`detect_equity_market\` from \`fundamentals/_helpers.py\` into the canonical module; \`_helpers.py\` now is a thin re-export layer.
- Call sites (_financials, _news, _profiles, _valuation) unchanged — backward compat preserved.

Refactor unit: W2-1 (Wave 2 final, medium-risk).
Plan: \`docs/superpowers/plans/2026-05-09-refactor-W2-1-mcp-market-normalization.md\`

Builds on W1-7 + W1-9 ✅.

## Test plan
- [x] \`uv run pytest tests/mcp_server/test_market_normalization.py -v\` (54 passed)
- [x] \`uv run pytest tests/mcp_server/ -v\` (106 passed)
- [x] \`uv run python -c "import app.mcp_server.tooling"\` (smoke OK)
- [x] \`uv run ruff check . && uv run ruff format --check .\` (modified files clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized market detection and normalization logic into a dedicated module for improved code organization and maintainability.

* **Tests**
  * Added comprehensive test coverage for market detection and normalization utilities, including equity and crypto market validation scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/758)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->