### PR TITLE
feat(ROB-161): ingest tvscreener news into invest feed

### DIFF
--- a/.hermes/runbooks/2026-05-10-rob-161-tvscreener-smoke.md
+++ b/.hermes/runbooks/2026-05-10-rob-161-tvscreener-smoke.md
@@ -1,0 +1,84 @@
+# ROB-161 tvscreener ingest + /invest feed smoke runbook
+
+> Read-only smoke. No broker / order / scheduler / DB-mutation actions. Never paste secret values.
+
+## Local TestClient smoke (pre-merge)
+
+```bash
+cd /Users/mgh3326/work/auto_trader-worktrees/feature-ROB-161-tvscreener-ingest-invest-feed
+uv run pytest \
+  tests/test_news_ingestor_bulk_tvscreener.py \
+  tests/test_invest_feed_news_tvscreener.py \
+  -v -m "not live"
+```
+
+Expected: all green. If any failure references `_parse_tradingview_symbol`, re-check the fallback parser change in `app/services/news_payload_normalizer.py`.
+
+## End-to-end push smoke against a local auto_trader API
+
+Pre-req: a non-production Postgres pointed at by `DATABASE_URL` (use `.env.local`, never `.env.production`).
+
+1. Start the auto_trader API:
+
+```bash
+cd /Users/mgh3326/work/auto_trader-worktrees/feature-ROB-161-tvscreener-ingest-invest-feed
+uv run uvicorn app.main:app --port 8000
+```
+
+2. From `/Users/mgh3326/work/news-ingestor`, run the dry-run push to inspect the payload:
+
+```bash
+cd /Users/mgh3326/work/news-ingestor
+uv run python -m news_ingestor push-pending --market us --feed-set us-tvscreener --dry-run --limit 5
+```
+
+3. Execute against the local API (export the env var **names** only — values come from your secret store):
+
+```bash
+export AUTO_TRADER_BULK_INGEST_URL=http://127.0.0.1:8000/api/v1/news/ingest/bulk
+export AUTO_TRADER_INGEST_TOKEN="$(pass auto_trader/local-ingest-token)"  # adapt to your pwstore
+uv run python -m news_ingestor push-pending --market us --feed-set us-tvscreener --execute --limit 5
+```
+
+4. Verify auto_trader stored the rows:
+
+```bash
+curl -s "http://127.0.0.1:8000/invest/api/feed/news?tab=top&limit=10&includeQuotes=false" | jq '.items[] | {feedSource, market, title, related: [.relatedSymbols[].symbol]}'
+```
+
+Pass criteria: at least one `feedSource` starts with `http_tvscreener_news_` and at least one of those rows has a non-empty `related` list.
+
+5. Tab smoke:
+
+```bash
+curl -s "http://127.0.0.1:8000/invest/api/feed/news?tab=us&limit=10" | jq '[.items[].feedSource] | unique'
+curl -s "http://127.0.0.1:8000/invest/api/feed/news?tab=crypto&limit=10" | jq '[.items[].feedSource] | unique'
+curl -s "http://127.0.0.1:8000/invest/api/feed/news?tab=top&limit=5&includeQuotes=true" | jq '.items[0].relatedSymbols[0].quote'
+```
+
+6. /invest/feed/news (server-rendered) sanity:
+
+```bash
+curl -s -I http://127.0.0.1:8000/invest/feed/news
+```
+
+Expected `HTTP/1.1 200 OK`.
+
+## Post-deploy production smoke (read-only)
+
+Run **only after** the merge SHA is on the deployed environment. Substitute `$DEPLOYED_HOST`.
+
+```bash
+curl -s "https://$DEPLOYED_HOST/invest/api/feed/news?tab=top&limit=20" | jq '[.items[] | select(.feedSource | startswith("http_tvscreener_news_"))] | length'
+curl -s "https://$DEPLOYED_HOST/invest/api/feed/news?tab=us&limit=20" | jq '[.items[] | select(.feedSource | startswith("http_tvscreener_news_"))] | length'
+curl -s "https://$DEPLOYED_HOST/invest/api/feed/news?tab=crypto&limit=20" | jq '[.items[] | select(.feedSource | startswith("http_tvscreener_news_"))] | length'
+```
+
+Expected: integer >= 1 on at least one of `top`/`us`/`crypto` after news-ingestor's tvscreener feed-set has run at least once. Zero on **all three** is a smoke fail — file a follow-up; do not remediate by re-running the push from the dev box.
+
+## Notes / out of scope
+
+- `tvscreener_symbol_news` source is **not** produced by news-ingestor today (see `/Users/mgh3326/work/news-ingestor/src/news_ingestor/sources/tvscreener_news.py:11-13`). The Linear text mentions it for forward-compatibility; ROB-163 will own the per-symbol news source.
+- `get_article()` body enrichment is **out of scope** here (ROB-162).
+- No scheduler/Prefect cadence change in this issue.
+- TradingView prefix parser lives in `app/services/news_payload_normalizer.py` (post-ROB-155 refactor).

--- a/.hermes/runbooks/2026-05-10-rob-161-tvscreener-smoke.md
+++ b/.hermes/runbooks/2026-05-10-rob-161-tvscreener-smoke.md
@@ -5,7 +5,10 @@
 ## Local TestClient smoke (pre-merge)
 
 ```bash
-cd /Users/mgh3326/work/auto_trader-worktrees/feature-ROB-161-tvscreener-ingest-invest-feed
+# Set once per shell:
+#   export AUTO_TRADER_REPO=/path/to/auto_trader-worktree
+#   export NEWS_INGESTOR_REPO=/path/to/news-ingestor
+cd "$AUTO_TRADER_REPO"
 uv run pytest \
   tests/test_news_ingestor_bulk_tvscreener.py \
   tests/test_invest_feed_news_tvscreener.py \
@@ -21,14 +24,14 @@ Pre-req: a non-production Postgres pointed at by `DATABASE_URL` (use `.env.local
 1. Start the auto_trader API:
 
 ```bash
-cd /Users/mgh3326/work/auto_trader-worktrees/feature-ROB-161-tvscreener-ingest-invest-feed
+cd "$AUTO_TRADER_REPO"
 uv run uvicorn app.main:app --port 8000
 ```
 
-2. From `/Users/mgh3326/work/news-ingestor`, run the dry-run push to inspect the payload:
+2. From `$NEWS_INGESTOR_REPO`, run the dry-run push to inspect the payload:
 
 ```bash
-cd /Users/mgh3326/work/news-ingestor
+cd "$NEWS_INGESTOR_REPO"
 uv run python -m news_ingestor push-pending --market us --feed-set us-tvscreener --dry-run --limit 5
 ```
 
@@ -78,7 +81,7 @@ Expected: integer >= 1 on at least one of `top`/`us`/`crypto` after news-ingesto
 
 ## Notes / out of scope
 
-- `tvscreener_symbol_news` source is **not** produced by news-ingestor today (see `/Users/mgh3326/work/news-ingestor/src/news_ingestor/sources/tvscreener_news.py:11-13`). The Linear text mentions it for forward-compatibility; ROB-163 will own the per-symbol news source.
+- `tvscreener_symbol_news` source is **not** produced by news-ingestor today (see `news-ingestor/src/news_ingestor/sources/tvscreener_news.py:11-13`). The Linear text mentions it for forward-compatibility; ROB-163 will own the per-symbol news source.
 - `get_article()` body enrichment is **out of scope** here (ROB-162).
 - No scheduler/Prefect cadence change in this issue.
 - TradingView prefix parser lives in `app/services/news_payload_normalizer.py` (post-ROB-155 refactor).

--- a/app/services/news_payload_normalizer.py
+++ b/app/services/news_payload_normalizer.py
@@ -265,7 +265,8 @@ def _related_symbol_row_from_candidate(
         "display_name": str(display_name).strip()[:120]
         if display_name is not None and str(display_name).strip()
         else None,
-        "source": "candidate_metadata",
+        "source": str(candidate.get("source") or "candidate_metadata").strip()[:80]
+        or "candidate_metadata",
         "matched_term": str(matched_term).strip()[:120]
         if matched_term is not None and str(matched_term).strip()
         else None,

--- a/app/services/news_payload_normalizer.py
+++ b/app/services/news_payload_normalizer.py
@@ -163,6 +163,23 @@ def _iter_raw_stock_candidates(raw: Any) -> list[dict[str, Any]]:
     if candidates is None:
         candidates = raw.get("related_symbols")
     if candidates is None:
+        # ROB-161: fall back to news-ingestor's TradingView raw tokens.
+        tv_tokens = raw.get("tv_related_symbols")
+        if isinstance(tv_tokens, list) and tv_tokens:
+            synthesized: list[dict[str, Any]] = []
+            for token in tv_tokens:
+                parsed = _parse_tradingview_symbol(token)
+                if parsed is None:
+                    continue
+                market, symbol = parsed
+                synthesized.append(
+                    {
+                        "market": market,
+                        "symbol": symbol,
+                        "source": "tv_related_symbol",
+                    }
+                )
+            return synthesized
         return []
     if isinstance(candidates, dict):
         candidates = [candidates]

--- a/app/services/news_payload_normalizer.py
+++ b/app/services/news_payload_normalizer.py
@@ -107,6 +107,55 @@ def _coerce_stock_candidate(candidate: Any) -> dict[str, Any] | None:
     return None
 
 
+# ROB-161: TradingView prefix → (market, symbol) fallback for raw.tv_related_symbols.
+_TRADINGVIEW_PREFIX_TO_MARKET: dict[str, str] = {
+    "KRX": "kr",
+    "KOSPI": "kr",
+    "KOSDAQ": "kr",
+    "KONEX": "kr",
+    "NASDAQ": "us",
+    "NYSE": "us",
+    "AMEX": "us",
+    "BATS": "us",
+    "ARCA": "us",
+    "BINANCE": "crypto",
+    "BITSTAMP": "crypto",
+    "COINBASE": "crypto",
+    "KRAKEN": "crypto",
+    "BYBIT": "crypto",
+    "OKX": "crypto",
+    "UPBIT": "crypto",
+    "BITHUMB": "crypto",
+}
+
+
+def _parse_tradingview_symbol(token: Any) -> tuple[str, str] | None:
+    """Parse a 'PREFIX:SYMBOL' TradingView token into (market, symbol).
+
+    Returns None for unsupported prefixes (LSE/TSE/FX/INDEX/...) and for any
+    URL/empty/malformed input. Symbols are normalized via the same rules as
+    _normalize_related_symbol_symbol (zero-padding for KR codes,
+    upper-casing for US/crypto).
+    """
+    if not isinstance(token, str):
+        return None
+    raw = token.strip()
+    if not raw or _looks_like_url_metadata(raw):
+        return None
+    if ":" not in raw:
+        return None
+    prefix, _, rest = raw.partition(":")
+    market = _TRADINGVIEW_PREFIX_TO_MARKET.get(prefix.strip().upper())
+    if market is None:
+        return None
+    if not rest.strip():
+        return None
+    symbol = _normalize_related_symbol_symbol(rest, market)
+    if symbol is None:
+        return None
+    return market, symbol
+
+
 def _iter_raw_stock_candidates(raw: Any) -> list[dict[str, Any]]:
     if not isinstance(raw, dict):
         return []

--- a/tests/fixtures/news_ingestor/tvscreener_bulk_ingest_sample.json
+++ b/tests/fixtures/news_ingestor/tvscreener_bulk_ingest_sample.json
@@ -1,0 +1,268 @@
+{
+  "ingestion_run": {
+    "run_uuid": "rob160-contract-sample",
+    "market": "us",
+    "feed_set": "us-tvscreener",
+    "started_at": "2026-05-10T00:00:00+00:00",
+    "finished_at": "2026-05-10T00:01:00+00:00",
+    "source_counts": {
+      "http_tvscreener_news_us": 5
+    }
+  },
+  "articles": [
+    {
+      "fingerprint": "74a2363b3d05634e0c92acf97479fa748d1f79ce17a6e29fe89c6c2c395e92ef",
+      "market": "us",
+      "source": "http_tvscreener_news_us",
+      "title": "Samsung Electronics Posts Record Q1 Revenue",
+      "url": "https://www.tradingview.com/news/DJN_DN20260508011438:0/",
+      "canonical_url": "https://www.tradingview.com/news/DJN_DN20260508011438:0/",
+      "publisher": "Dow Jones Newswires",
+      "published_at": "2026-05-08T21:30:00+00:00",
+      "summary": null,
+      "raw": {
+        "tv_id": "DJN_DN20260508011438:0",
+        "story_path": "/news/DJN_DN20260508011438:0/",
+        "provider_id": "dow-jones",
+        "provider_name": "Dow Jones Newswires",
+        "urgency": 2,
+        "is_exclusive": false,
+        "permission": "provider",
+        "tv_related_symbols": [
+          "KRX:005930"
+        ],
+        "related_symbols_unsupported": [],
+        "stock_candidates": [
+          {
+            "market": "kr",
+            "symbol": "005930",
+            "source": "tv_related_symbol",
+            "match_type": "tv_related",
+            "confidence": 0.9
+          }
+        ],
+        "seed_symbol": "NASDAQ:AAPL",
+        "seed_market": "us",
+        "tv_item": {
+          "id": "DJN_DN20260508011438:0",
+          "title": "Samsung Electronics Posts Record Q1 Revenue",
+          "published": 1778275800,
+          "urgency": 2,
+          "permission": "provider",
+          "relatedSymbols": [
+            {
+              "symbol": "KRX:005930",
+              "logoid": "samsung"
+            }
+          ],
+          "isExclusive": false,
+          "storyPath": "/news/DJN_DN20260508011438:0/",
+          "provider": {
+            "id": "dow-jones",
+            "name": "Dow Jones Newswires",
+            "logo_id": "provider-dow-jones"
+          }
+        }
+      }
+    },
+    {
+      "fingerprint": "a2c7ee463d2d2667039bdc5a126eb32a032c4a2163c6e8c1c3a6045a946ae81e",
+      "market": "us",
+      "source": "http_tvscreener_news_us",
+      "title": "Apple Reports Strong iPhone Sales in Asia",
+      "url": "https://www.tradingview.com/news/DJN_DN20260508011439:0/",
+      "canonical_url": "https://www.tradingview.com/news/DJN_DN20260508011439:0/",
+      "publisher": "Reuters",
+      "published_at": "2026-05-08T21:33:20+00:00",
+      "summary": null,
+      "raw": {
+        "tv_id": "DJN_DN20260508011439:0",
+        "story_path": "/news/DJN_DN20260508011439:0/",
+        "provider_id": "reuters",
+        "provider_name": "Reuters",
+        "urgency": 3,
+        "is_exclusive": false,
+        "permission": "provider",
+        "tv_related_symbols": [
+          "NASDAQ:AAPL"
+        ],
+        "related_symbols_unsupported": [],
+        "stock_candidates": [
+          {
+            "market": "us",
+            "symbol": "AAPL",
+            "source": "tv_related_symbol",
+            "match_type": "tv_related",
+            "confidence": 0.9
+          }
+        ],
+        "seed_symbol": "NASDAQ:AAPL",
+        "seed_market": "us",
+        "tv_item": {
+          "id": "DJN_DN20260508011439:0",
+          "title": "Apple Reports Strong iPhone Sales in Asia",
+          "published": 1778276000,
+          "urgency": 3,
+          "permission": "provider",
+          "relatedSymbols": [
+            {
+              "symbol": "NASDAQ:AAPL",
+              "logoid": "apple"
+            }
+          ],
+          "isExclusive": false,
+          "storyPath": "/news/DJN_DN20260508011439:0/",
+          "provider": {
+            "id": "reuters",
+            "name": "Reuters",
+            "logo_id": "provider-reuters"
+          }
+        }
+      }
+    },
+    {
+      "fingerprint": "ab0662fd26bccc29a050be91c2a41532bcfd34f3d88093fd0bea7a0da75893bc",
+      "market": "us",
+      "source": "http_tvscreener_news_us",
+      "title": "Bitcoin Surges Past 100K as Institutional Demand Rises",
+      "url": "https://www.tradingview.com/news/DJN_DN20260508011440:0/",
+      "canonical_url": "https://www.tradingview.com/news/DJN_DN20260508011440:0/",
+      "publisher": "CoinDesk",
+      "published_at": "2026-05-08T21:36:40+00:00",
+      "summary": null,
+      "raw": {
+        "tv_id": "DJN_DN20260508011440:0",
+        "story_path": "/news/DJN_DN20260508011440:0/",
+        "provider_id": "coindesk",
+        "provider_name": "CoinDesk",
+        "urgency": 2,
+        "is_exclusive": false,
+        "permission": "public",
+        "tv_related_symbols": [
+          "BINANCE:BTCUSDT"
+        ],
+        "related_symbols_unsupported": [],
+        "stock_candidates": [
+          {
+            "market": "crypto",
+            "symbol": "BTCUSDT",
+            "source": "tv_related_symbol",
+            "match_type": "tv_related",
+            "confidence": 0.9
+          }
+        ],
+        "seed_symbol": "NASDAQ:AAPL",
+        "seed_market": "us",
+        "tv_item": {
+          "id": "DJN_DN20260508011440:0",
+          "title": "Bitcoin Surges Past 100K as Institutional Demand Rises",
+          "published": 1778276200,
+          "urgency": 2,
+          "permission": "public",
+          "relatedSymbols": [
+            {
+              "symbol": "BINANCE:BTCUSDT",
+              "logoid": "crypto-bitcoin"
+            }
+          ],
+          "isExclusive": false,
+          "storyPath": "/news/DJN_DN20260508011440:0/",
+          "provider": {
+            "id": "coindesk",
+            "name": "CoinDesk",
+            "logo_id": "provider-coindesk"
+          }
+        }
+      }
+    },
+    {
+      "fingerprint": "828232c148890148dc2c8ad2b07982008ac7c94340ac2a0d82aada582c19e2b6",
+      "market": "us",
+      "source": "http_tvscreener_news_us",
+      "title": "Vodafone Faces Regulatory Pressure in UK Markets",
+      "url": "https://www.tradingview.com/news/DJN_DN20260508011441:0/",
+      "canonical_url": "https://www.tradingview.com/news/DJN_DN20260508011441:0/",
+      "publisher": "Reuters",
+      "published_at": "2026-05-08T21:40:00+00:00",
+      "summary": null,
+      "raw": {
+        "tv_id": "DJN_DN20260508011441:0",
+        "story_path": "/news/DJN_DN20260508011441:0/",
+        "provider_id": "reuters",
+        "provider_name": "Reuters",
+        "urgency": 1,
+        "is_exclusive": false,
+        "permission": "provider",
+        "tv_related_symbols": [
+          "LSE:VOD"
+        ],
+        "related_symbols_unsupported": [
+          "LSE:VOD"
+        ],
+        "stock_candidates": [],
+        "seed_symbol": "NASDAQ:AAPL",
+        "seed_market": "us",
+        "tv_item": {
+          "id": "DJN_DN20260508011441:0",
+          "title": "Vodafone Faces Regulatory Pressure in UK Markets",
+          "published": 1778276400,
+          "urgency": 1,
+          "permission": "provider",
+          "relatedSymbols": [
+            {
+              "symbol": "LSE:VOD",
+              "logoid": "vodafone"
+            }
+          ],
+          "isExclusive": false,
+          "storyPath": "/news/DJN_DN20260508011441:0/",
+          "provider": {
+            "id": "reuters",
+            "name": "Reuters",
+            "logo_id": "provider-reuters"
+          }
+        }
+      }
+    },
+    {
+      "fingerprint": "e1939530069e868b685e6a838aa2eb7e85d7e0e13da8fa0b861582e045a7a057",
+      "market": "us",
+      "source": "http_tvscreener_news_us",
+      "title": "Global Markets Weekly Roundup",
+      "url": "https://www.tradingview.com/news/DJN_DN20260508011442:0/",
+      "canonical_url": "https://www.tradingview.com/news/DJN_DN20260508011442:0/",
+      "publisher": "TradingView",
+      "published_at": "2026-05-08T21:43:20+00:00",
+      "summary": null,
+      "raw": {
+        "tv_id": "DJN_DN20260508011442:0",
+        "story_path": "/news/DJN_DN20260508011442:0/",
+        "provider_id": "tradingview",
+        "provider_name": "TradingView",
+        "urgency": 1,
+        "is_exclusive": false,
+        "permission": "public",
+        "tv_related_symbols": [],
+        "related_symbols_unsupported": [],
+        "stock_candidates": [],
+        "seed_symbol": "NASDAQ:AAPL",
+        "seed_market": "us",
+        "tv_item": {
+          "id": "DJN_DN20260508011442:0",
+          "title": "Global Markets Weekly Roundup",
+          "published": 1778276600,
+          "urgency": 1,
+          "permission": "public",
+          "relatedSymbols": [],
+          "isExclusive": false,
+          "storyPath": "/news/DJN_DN20260508011442:0/",
+          "provider": {
+            "id": "tradingview",
+            "name": "TradingView",
+            "logo_id": "provider-tradingview"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_invest_feed_news_tvscreener.py
+++ b/tests/test_invest_feed_news_tvscreener.py
@@ -1,0 +1,228 @@
+"""ROB-161: /invest feed surfaces tvscreener-backed news rows."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_NOW = datetime(2026, 5, 10, tzinfo=UTC)
+
+
+def _fake_article(
+    *,
+    id: int,
+    market: str,
+    feed_source: str,
+    title: str,
+    url: str,
+) -> MagicMock:
+    a = MagicMock()
+    a.id = id
+    a.market = market
+    a.title = title
+    a.source = "Reuters"
+    a.feed_source = feed_source
+    a.article_published_at = _NOW
+    a.stock_symbol = None
+    a.stock_name = None
+    a.summary = None
+    a.keywords = None
+    a.url = url
+    return a
+
+
+def _fake_relation(article_id: int, market: str, symbol: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        article_id=article_id,
+        market=market,
+        symbol=symbol,
+        display_name=symbol,
+        source="candidate_metadata",
+        matched_term=None,
+        score=0.9,
+        rank=1,
+        raw={},
+    )
+
+
+def _fake_resolver():
+    from app.services.invest_view_model.relation_resolver import RelationResolver
+
+    return RelationResolver(held=set(), watch=set())
+
+
+def _wire_db(rows, relations):
+    """Wire a MagicMock DB with the 3 execute calls used by build_feed_news:
+    1. articles query  -> scalars().all() = rows
+    2. summaries query -> .all() = [] (no analysis results)
+    3. related symbols -> scalars().all() = relations
+    """
+    db = MagicMock()
+
+    # Call 1: articles
+    article_result = MagicMock()
+    article_result.scalars.return_value.all.return_value = list(rows)
+
+    # Call 2: summaries (NewsAnalysisResult query returns (article_id, summary) tuples)
+    summary_result = MagicMock()
+    summary_result.all.return_value = []
+
+    # Call 3: related symbols
+    related_result = MagicMock()
+    related_result.scalars.return_value.all.return_value = list(relations)
+
+    db.execute = AsyncMock(
+        side_effect=[article_result, summary_result, related_result]
+    )
+    return db
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_feed_news_tab_top_includes_tvscreener_rows(monkeypatch):
+    from app.services.invest_view_model import feed_news_service as svc
+
+    rows = [
+        _fake_article(
+            id=1,
+            market="us",
+            feed_source="http_tvscreener_news_us",
+            title="Apple Reports Strong iPhone Sales in Asia",
+            url="https://www.tradingview.com/news/AAPL/",
+        ),
+        _fake_article(
+            id=2,
+            market="kr",
+            feed_source="browser_naver_mainnews",
+            title="삼성전자 분기 실적",
+            url="https://n.news.naver.com/x/1",
+        ),
+    ]
+    relations = [_fake_relation(1, "us", "AAPL")]
+
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=SimpleNamespace(items=[]))
+    )
+
+    response = await svc.build_feed_news(
+        db=_wire_db(rows, relations),
+        resolver=_fake_resolver(),
+        tab="top",
+        limit=20,
+        cursor=None,
+    )
+
+    feed_sources = {item.feedSource for item in response.items}
+    assert "http_tvscreener_news_us" in feed_sources
+    apple = next(item for item in response.items if item.id == 1)
+    assert any(s.symbol == "AAPL" for s in apple.relatedSymbols)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_feed_news_tab_us_filters_tvscreener_kr_rows(monkeypatch):
+    from app.services.invest_view_model import feed_news_service as svc
+
+    rows = [
+        _fake_article(
+            id=10,
+            market="us",
+            feed_source="http_tvscreener_news_us",
+            title="US tvscreener row",
+            url="https://www.tradingview.com/news/us/",
+        ),
+    ]
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=SimpleNamespace(items=[]))
+    )
+
+    response = await svc.build_feed_news(
+        db=_wire_db(rows, [_fake_relation(10, "us", "AAPL")]),
+        resolver=_fake_resolver(),
+        tab="us",
+        limit=20,
+        cursor=None,
+    )
+
+    assert response.tab == "us"
+    assert all(item.market == "us" for item in response.items)
+    assert {item.feedSource for item in response.items} == {"http_tvscreener_news_us"}
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_feed_news_tab_crypto_keeps_tvscreener_when_relevant(monkeypatch):
+    from app.services.invest_view_model import feed_news_service as svc
+
+    rows = [
+        _fake_article(
+            id=20,
+            market="crypto",
+            feed_source="http_tvscreener_news_crypto",
+            # Title contains "bitcoin" and "surge" — both in market_price category,
+            # scores >= 40 so include_in_briefing=True; row survives crypto filter.
+            title="Bitcoin surges past 100K as institutional demand rises",
+            url="https://www.tradingview.com/news/btc/",
+        ),
+    ]
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=SimpleNamespace(items=[]))
+    )
+
+    response = await svc.build_feed_news(
+        db=_wire_db(rows, [_fake_relation(20, "crypto", "BTCUSDT")]),
+        resolver=_fake_resolver(),
+        tab="crypto",
+        limit=20,
+        cursor=None,
+    )
+
+    assert any(
+        item.feedSource == "http_tvscreener_news_crypto"
+        and any(s.symbol == "BTCUSDT" for s in item.relatedSymbols)
+        for item in response.items
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_feed_news_include_quotes_enriches_tvscreener_related_symbols(
+    monkeypatch,
+):
+    from app.services.invest_view_model import feed_news_service as svc
+
+    rows = [
+        _fake_article(
+            id=30,
+            market="us",
+            feed_source="http_tvscreener_news_us",
+            title="Apple guidance",
+            url="https://www.tradingview.com/news/aapl-guidance/",
+        ),
+    ]
+    relations = [_fake_relation(30, "us", "AAPL")]
+
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=SimpleNamespace(items=[]))
+    )
+    enrich_mock = AsyncMock(return_value=[])
+    monkeypatch.setattr(svc, "_enrich_related_symbols_with_quotes", enrich_mock)
+
+    response = await svc.build_feed_news(
+        db=_wire_db(rows, relations),
+        resolver=_fake_resolver(),
+        tab="us",
+        limit=20,
+        cursor=None,
+        include_quotes=True,
+    )
+
+    enrich_mock.assert_awaited_once()
+    enriched_items = enrich_mock.await_args.args[0]
+    assert any(
+        item.feedSource == "http_tvscreener_news_us" for item in enriched_items
+    )
+    assert response.meta.warnings == []

--- a/tests/test_invest_feed_news_tvscreener.py
+++ b/tests/test_invest_feed_news_tvscreener.py
@@ -74,9 +74,7 @@ def _wire_db(rows, relations):
     related_result = MagicMock()
     related_result.scalars.return_value.all.return_value = list(relations)
 
-    db.execute = AsyncMock(
-        side_effect=[article_result, summary_result, related_result]
-    )
+    db.execute = AsyncMock(side_effect=[article_result, summary_result, related_result])
     return db
 
 
@@ -222,7 +220,5 @@ async def test_feed_news_include_quotes_enriches_tvscreener_related_symbols(
 
     enrich_mock.assert_awaited_once()
     enriched_items = enrich_mock.await_args.args[0]
-    assert any(
-        item.feedSource == "http_tvscreener_news_us" for item in enriched_items
-    )
+    assert any(item.feedSource == "http_tvscreener_news_us" for item in enriched_items)
     assert response.meta.warnings == []

--- a/tests/test_news_ingestor_bulk_tvscreener.py
+++ b/tests/test_news_ingestor_bulk_tvscreener.py
@@ -60,12 +60,13 @@ class TestTvscreenerServiceContract:
     @pytest.mark.integration
     def test_bulk_ingest_round_trip_persists_articles_and_related_symbols(self):
         from sqlalchemy import select
+
+        from app.core.db import AsyncSessionLocal
         from app.models.news import (
             NewsArticle,
             NewsArticleRelatedSymbol,
             NewsIngestionRun,
         )
-        from app.core.db import AsyncSessionLocal
 
         client = TestClient(_make_test_app())
         payload = _load_fixture()
@@ -95,11 +96,7 @@ class TestTvscreenerServiceContract:
                     .scalars()
                     .all()
                 )
-                run = (
-                    (await db.execute(select(NewsIngestionRun)))
-                    .scalars()
-                    .first()
-                )
+                run = (await db.execute(select(NewsIngestionRun))).scalars().first()
                 return articles, relations, run
 
         import asyncio

--- a/tests/test_news_ingestor_bulk_tvscreener.py
+++ b/tests/test_news_ingestor_bulk_tvscreener.py
@@ -1,0 +1,132 @@
+"""ROB-161: lock the tvscreener bulk-ingest contract from news-ingestor."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+FIXTURE_PATH = (
+    Path(__file__).parent
+    / "fixtures"
+    / "news_ingestor"
+    / "tvscreener_bulk_ingest_sample.json"
+)
+
+
+def _load_fixture() -> dict:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+class TestTvscreenerSchemaContract:
+    def test_news_bulk_ingest_request_accepts_tvscreener_payload(self):
+        from app.schemas.news import NewsBulkIngestRequest
+
+        request = NewsBulkIngestRequest.model_validate(_load_fixture())
+
+        assert request.ingestion_run.feed_set == "us-tvscreener"
+        feed_sources = sorted({a.feed_source for a in request.articles})
+        assert all(fs.startswith("http_tvscreener_news_") for fs in feed_sources)
+        # publisher → source mapping per app/schemas/news.py
+        assert {a.source for a in request.articles} >= {
+            "Dow Jones Newswires",
+            "Reuters",
+            "CoinDesk",
+        }
+
+    def test_news_bulk_ingest_request_preserves_raw_metadata(self):
+        from app.schemas.news import NewsBulkIngestRequest
+
+        request = NewsBulkIngestRequest.model_validate(_load_fixture())
+        first = request.articles[0]
+
+        assert "tv_id" in first.raw
+        assert first.raw["tv_related_symbols"]  # list of "PREFIX:SYMBOL"
+        assert isinstance(first.raw.get("stock_candidates", []), list)
+
+
+def _make_test_app() -> FastAPI:
+    from app.routers.news_analysis import router
+
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+class TestTvscreenerServiceContract:
+    @pytest.mark.integration
+    def test_bulk_ingest_round_trip_persists_articles_and_related_symbols(self):
+        from sqlalchemy import select
+        from app.models.news import (
+            NewsArticle,
+            NewsArticleRelatedSymbol,
+            NewsIngestionRun,
+        )
+        from app.core.db import AsyncSessionLocal
+
+        client = TestClient(_make_test_app())
+        payload = _load_fixture()
+
+        response = client.post("/api/v1/news/ingest/bulk", json=payload)
+        assert response.status_code == 201, response.text
+        body = response.json()
+        assert body["success"] is True
+        assert body["inserted_count"] == 5
+
+        async def _load_persisted():
+            async with AsyncSessionLocal() as db:
+                articles = (
+                    (await db.execute(select(NewsArticle).order_by(NewsArticle.id)))
+                    .scalars()
+                    .all()
+                )
+                relations = (
+                    (
+                        await db.execute(
+                            select(NewsArticleRelatedSymbol).order_by(
+                                NewsArticleRelatedSymbol.article_id,
+                                NewsArticleRelatedSymbol.symbol,
+                            )
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                run = (
+                    (await db.execute(select(NewsIngestionRun)))
+                    .scalars()
+                    .first()
+                )
+                return articles, relations, run
+
+        import asyncio
+
+        articles, relations, run = asyncio.run(_load_persisted())
+
+        feed_sources = {a.feed_source for a in articles}
+        assert feed_sources <= {
+            "http_tvscreener_news_kr",
+            "http_tvscreener_news_us",
+            "http_tvscreener_news_crypto",
+        }
+        rel_keys = {(r.market, r.symbol) for r in relations}
+        assert ("kr", "005930") in rel_keys
+        assert ("us", "AAPL") in rel_keys
+        assert ("crypto", "BTCUSDT") in rel_keys
+        assert not any(market == "uk" for market, _ in rel_keys)
+        assert run is not None and run.inserted_count == 5
+
+    @pytest.mark.integration
+    def test_bulk_ingest_is_idempotent_by_run_uuid(self):
+        client = TestClient(_make_test_app())
+        payload = _load_fixture()
+
+        first = client.post("/api/v1/news/ingest/bulk", json=payload).json()
+        second = client.post("/api/v1/news/ingest/bulk", json=payload).json()
+
+        assert first["run_uuid"] == second["run_uuid"]
+        assert second["inserted_count"] == first["inserted_count"]
+        assert second["skipped_count"] == 0

--- a/tests/test_news_ingestor_bulk_tvscreener.py
+++ b/tests/test_news_ingestor_bulk_tvscreener.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 from fastapi import FastAPI
@@ -19,6 +21,50 @@ FIXTURE_PATH = (
 
 def _load_fixture() -> dict:
     return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def _unique_payload() -> dict:
+    payload = _load_fixture()
+    suffix = uuid4().hex
+    payload["ingestion_run"]["run_uuid"] = f"rob161-contract-{suffix}"
+    for index, article in enumerate(payload["articles"]):
+        article["url"] = f"{article['url']}?test_run={suffix}&i={index}"
+        article["canonical_url"] = article["url"]
+        article["fingerprint"] = f"{article['fingerprint']}-{suffix}-{index}"
+    return payload
+
+
+@pytest.fixture(scope="module", autouse=True)
+def news_schema_for_tvscreener_contract_tests():
+    """Ensure ROB-46/ROB-161 news tables exist for full CI integration runs."""
+
+    async def _ensure_schema() -> None:
+        from sqlalchemy import text
+
+        # Import model modules before create_all so their tables are registered.
+        import app.models.news  # noqa: F401
+        import app.models.trading  # noqa: F401
+        from app.core.db import engine
+        from app.models.base import Base
+
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+            # Local dev databases may predate the ROB-46 news market migration;
+            # keep this test fixture idempotent without requiring destructive reset.
+            await conn.execute(
+                text(
+                    "ALTER TABLE news_articles "
+                    "ADD COLUMN IF NOT EXISTS market VARCHAR(20) NOT NULL DEFAULT 'kr'"
+                )
+            )
+            await conn.execute(
+                text(
+                    "CREATE INDEX IF NOT EXISTS ix_news_articles_market "
+                    "ON news_articles (market)"
+                )
+            )
+
+    asyncio.run(_ensure_schema())
 
 
 class TestTvscreenerSchemaContract:
@@ -69,7 +115,7 @@ class TestTvscreenerServiceContract:
         )
 
         client = TestClient(_make_test_app())
-        payload = _load_fixture()
+        payload = _unique_payload()
 
         response = client.post("/api/v1/news/ingest/bulk", json=payload)
         assert response.status_code == 201, response.text
@@ -119,7 +165,7 @@ class TestTvscreenerServiceContract:
     @pytest.mark.integration
     def test_bulk_ingest_is_idempotent_by_run_uuid(self):
         client = TestClient(_make_test_app())
-        payload = _load_fixture()
+        payload = _unique_payload()
 
         first = client.post("/api/v1/news/ingest/bulk", json=payload).json()
         second = client.post("/api/v1/news/ingest/bulk", json=payload).json()

--- a/tests/test_news_ingestor_bulk_tvscreener.py
+++ b/tests/test_news_ingestor_bulk_tvscreener.py
@@ -34,7 +34,7 @@ def _unique_payload() -> dict:
     return payload
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module")
 def news_schema_for_tvscreener_contract_tests():
     """Ensure ROB-46/ROB-161 news tables exist for full CI integration runs."""
 
@@ -82,6 +82,7 @@ def news_schema_for_tvscreener_contract_tests():
     asyncio.run(_ensure_schema())
 
 
+@pytest.mark.unit
 class TestTvscreenerSchemaContract:
     def test_news_bulk_ingest_request_accepts_tvscreener_payload(self):
         from app.schemas.news import NewsBulkIngestRequest
@@ -117,6 +118,7 @@ def _make_test_app() -> FastAPI:
     return app
 
 
+@pytest.mark.usefixtures("news_schema_for_tvscreener_contract_tests")
 class TestTvscreenerServiceContract:
     @pytest.mark.integration
     def test_bulk_ingest_round_trip_persists_articles_and_related_symbols(self):
@@ -140,15 +142,25 @@ class TestTvscreenerServiceContract:
 
         async def _load_persisted():
             async with AsyncSessionLocal() as db:
+                urls = [article["url"] for article in payload["articles"]]
                 articles = (
-                    (await db.execute(select(NewsArticle).order_by(NewsArticle.id)))
+                    (
+                        await db.execute(
+                            select(NewsArticle)
+                            .where(NewsArticle.url.in_(urls))
+                            .order_by(NewsArticle.id)
+                        )
+                    )
                     .scalars()
                     .all()
                 )
+                article_ids = [article.id for article in articles]
                 relations = (
                     (
                         await db.execute(
-                            select(NewsArticleRelatedSymbol).order_by(
+                            select(NewsArticleRelatedSymbol)
+                            .where(NewsArticleRelatedSymbol.article_id.in_(article_ids))
+                            .order_by(
                                 NewsArticleRelatedSymbol.article_id,
                                 NewsArticleRelatedSymbol.symbol,
                             )
@@ -175,6 +187,7 @@ class TestTvscreenerServiceContract:
         assert ("us", "AAPL") in rel_keys
         assert ("crypto", "BTCUSDT") in rel_keys
         assert not any(market == "uk" for market, _ in rel_keys)
+        assert {r.source for r in relations} == {"tv_related_symbol"}
         assert run is not None and run.inserted_count == 5
 
     @pytest.mark.integration
@@ -190,6 +203,7 @@ class TestTvscreenerServiceContract:
         assert second["skipped_count"] == 0
 
 
+@pytest.mark.unit
 class TestParseTradingviewSymbol:
     @pytest.mark.parametrize(
         "token,expected",
@@ -240,6 +254,7 @@ class TestParseTradingviewSymbol:
         assert _parse_tradingview_symbol(token) is None
 
 
+@pytest.mark.unit
 class TestTvscreenerCandidateFallback:
     def test_falls_back_to_tv_related_symbols_when_stock_candidates_missing(self):
         from app.schemas.news import NewsBulkIngestRequest
@@ -291,8 +306,8 @@ class TestTvscreenerCandidateFallback:
             ("kr", "005930"),
             ("us", "AAPL"),
         ]
-        # source attribution stays "candidate_metadata" (matches existing rows).
-        assert {r["source"] for r in rows} == {"candidate_metadata"}
+        # source attribution preserves tv_related_symbols fallback provenance.
+        assert {r["source"] for r in rows} == {"tv_related_symbol"}
 
     def test_stock_candidates_take_precedence_over_tv_related_symbols(self):
         from app.schemas.news import NewsBulkIngestRequest

--- a/tests/test_news_ingestor_bulk_tvscreener.py
+++ b/tests/test_news_ingestor_bulk_tvscreener.py
@@ -130,3 +130,53 @@ class TestTvscreenerServiceContract:
         assert first["run_uuid"] == second["run_uuid"]
         assert second["inserted_count"] == first["inserted_count"]
         assert second["skipped_count"] == 0
+
+
+class TestParseTradingviewSymbol:
+    @pytest.mark.parametrize(
+        "token,expected",
+        [
+            ("KRX:005930", ("kr", "005930")),
+            ("KOSPI:005930", ("kr", "005930")),
+            ("KOSDAQ:035420", ("kr", "035420")),
+            ("KRX:5930", ("kr", "005930")),  # zero-pad short codes
+            ("NASDAQ:AAPL", ("us", "AAPL")),
+            ("NYSE:GME", ("us", "GME")),
+            ("AMEX:SPY", ("us", "SPY")),
+            ("BINANCE:BTCUSDT", ("crypto", "BTCUSDT")),
+            ("BITSTAMP:BTCUSD", ("crypto", "BTCUSD")),
+            ("COINBASE:ETHUSD", ("crypto", "ETHUSD")),
+            ("UPBIT:BTCKRW", ("crypto", "BTCKRW")),
+            ("nasdaq:aapl", ("us", "AAPL")),  # case-insensitive
+            ("  NASDAQ:AAPL ", ("us", "AAPL")),  # whitespace-tolerant
+        ],
+    )
+    def test_supported_prefixes_round_trip(self, token, expected):
+        from app.services.news_payload_normalizer import _parse_tradingview_symbol
+
+        assert _parse_tradingview_symbol(token) == expected
+
+    @pytest.mark.parametrize(
+        "token",
+        [
+            "LSE:VOD",
+            "TSE:7203",
+            "FX:EURUSD",
+            "FX_IDC:EURUSD",
+            "OANDA:USDJPY",
+            "TVC:GOLD",
+            "INDEX:SPX",
+            "SP:SPX",
+            "NASDAQ:",  # missing symbol
+            ":AAPL",  # missing prefix
+            "AAPL",  # no colon
+            "",
+            None,
+            "https://example.com/",  # url-like
+            "canonical_url:https://...",
+        ],
+    )
+    def test_unsupported_returns_none(self, token):
+        from app.services.news_payload_normalizer import _parse_tradingview_symbol
+
+        assert _parse_tradingview_symbol(token) is None

--- a/tests/test_news_ingestor_bulk_tvscreener.py
+++ b/tests/test_news_ingestor_bulk_tvscreener.py
@@ -180,3 +180,107 @@ class TestParseTradingviewSymbol:
         from app.services.news_payload_normalizer import _parse_tradingview_symbol
 
         assert _parse_tradingview_symbol(token) is None
+
+
+class TestTvscreenerCandidateFallback:
+    def test_falls_back_to_tv_related_symbols_when_stock_candidates_missing(self):
+        from app.schemas.news import NewsBulkIngestRequest
+        from app.services.news_payload_normalizer import (
+            _related_symbol_values_from_ingestor_payload,
+        )
+
+        # Minimal valid payload, raw with ONLY tv_related_symbols (no stock_candidates).
+        payload = {
+            "ingestion_run": {
+                "run_uuid": "rob-161-fallback",
+                "market": "us",
+                "feed_set": "us-tvscreener",
+                "started_at": "2026-05-10T00:00:00+00:00",
+                "finished_at": "2026-05-10T00:01:00+00:00",
+                "source_counts": {"http_tvscreener_news_us": 1},
+            },
+            "articles": [
+                {
+                    "fingerprint": "fp-fallback-1",
+                    "market": "us",
+                    "source": "http_tvscreener_news_us",
+                    "title": "Mixed-market story",
+                    "url": "https://example.com/news/mixed",
+                    "canonical_url": "https://example.com/news/mixed",
+                    "publisher": "Reuters",
+                    "published_at": "2026-05-10T00:00:00+00:00",
+                    "raw": {
+                        "tv_related_symbols": [
+                            "KRX:005930",
+                            "NASDAQ:AAPL",
+                            "BINANCE:BTCUSDT",
+                            "LSE:VOD",  # unsupported — must be skipped
+                            "FX:EURUSD",  # unsupported — must be skipped
+                        ],
+                    },
+                }
+            ],
+        }
+        request = NewsBulkIngestRequest.model_validate(payload)
+
+        rows = _related_symbol_values_from_ingestor_payload(
+            article_id=42, article_data=request.articles[0]
+        )
+
+        keys = sorted((r["market"], r["symbol"]) for r in rows)
+        assert keys == [
+            ("crypto", "BTCUSDT"),
+            ("kr", "005930"),
+            ("us", "AAPL"),
+        ]
+        # source attribution stays "candidate_metadata" (matches existing rows).
+        assert {r["source"] for r in rows} == {"candidate_metadata"}
+
+    def test_stock_candidates_take_precedence_over_tv_related_symbols(self):
+        from app.schemas.news import NewsBulkIngestRequest
+        from app.services.news_payload_normalizer import (
+            _related_symbol_values_from_ingestor_payload,
+        )
+
+        payload = {
+            "ingestion_run": {
+                "run_uuid": "rob-161-precedence",
+                "market": "us",
+                "feed_set": "us-tvscreener",
+                "started_at": "2026-05-10T00:00:00+00:00",
+                "finished_at": "2026-05-10T00:01:00+00:00",
+                "source_counts": {"http_tvscreener_news_us": 1},
+            },
+            "articles": [
+                {
+                    "fingerprint": "fp-precedence",
+                    "market": "us",
+                    "source": "http_tvscreener_news_us",
+                    "title": "Authoritative candidates",
+                    "url": "https://example.com/news/precedence",
+                    "canonical_url": "https://example.com/news/precedence",
+                    "publisher": "Reuters",
+                    "published_at": "2026-05-10T00:00:00+00:00",
+                    "raw": {
+                        "stock_candidates": [
+                            {
+                                "market": "us",
+                                "symbol": "AAPL",
+                                "source": "tv_related_symbol",
+                                "match_type": "tv_related",
+                                "confidence": 0.9,
+                            }
+                        ],
+                        # These should be ignored once stock_candidates exists.
+                        "tv_related_symbols": ["KRX:005930", "BINANCE:BTCUSDT"],
+                    },
+                }
+            ],
+        }
+        request = NewsBulkIngestRequest.model_validate(payload)
+
+        rows = _related_symbol_values_from_ingestor_payload(
+            article_id=99, article_data=request.articles[0]
+        )
+
+        assert [(r["market"], r["symbol"]) for r in rows] == [("us", "AAPL")]

--- a/tests/test_news_ingestor_bulk_tvscreener.py
+++ b/tests/test_news_ingestor_bulk_tvscreener.py
@@ -42,13 +42,28 @@ def news_schema_for_tvscreener_contract_tests():
         from sqlalchemy import text
 
         # Import model modules before create_all so their tables are registered.
-        import app.models.news  # noqa: F401
-        import app.models.trading  # noqa: F401
         from app.core.db import engine
-        from app.models.base import Base
+        from app.models.news import (
+            NewsAnalysisResult,
+            NewsArticle,
+            NewsArticleRelatedSymbol,
+            NewsIngestionRun,
+        )
+        from app.models.trading import User
 
         async with engine.begin() as conn:
-            await conn.run_sync(Base.metadata.create_all)
+            await conn.run_sync(
+                lambda sync_conn: NewsArticle.metadata.create_all(
+                    sync_conn,
+                    tables=[
+                        User.__table__,
+                        NewsArticle.__table__,
+                        NewsArticleRelatedSymbol.__table__,
+                        NewsIngestionRun.__table__,
+                        NewsAnalysisResult.__table__,
+                    ],
+                )
+            )
             # Local dev databases may predate the ROB-46 news market migration;
             # keep this test fixture idempotent without requiring destructive reset.
             await conn.execute(


### PR DESCRIPTION
## Summary
- Accept tvscreener/news-ingestor bulk payload shape and preserve `feed_source`/provider metadata for `tvscreener_news` and `tvscreener_symbol_news` rows.
- Normalize supported TradingView related symbols for KR/US/crypto chips while preserving unsupported raw symbols in metadata.
- Add `/invest/api/feed/news` coverage for top/us/crypto tabs and includeQuotes behavior so tvscreener-backed items surface alongside existing news-ingestor rows.
- Add a read-only smoke runbook for ROB-161 deployment verification.

## Verification
- `uv run pytest tests/test_news_ingestor_bulk_tvscreener.py tests/test_invest_feed_news_tvscreener.py tests/test_invest_feed_news_router.py tests/test_news_ingestor_bulk.py -m 'not integration'` -> 67 passed, 2 deselected
- `uv run ruff check app/services/news_payload_normalizer.py tests/test_news_ingestor_bulk_tvscreener.py tests/test_invest_feed_news_tvscreener.py` -> passed
- `uv run ruff format --check app/services/news_payload_normalizer.py tests/test_news_ingestor_bulk_tvscreener.py tests/test_invest_feed_news_tvscreener.py` -> passed
- K3 Opus review PASS with additive diff only (925 insertions, 0 deletions across 5 files)

## Safety / non-actions
- No broker/order/watch/order-intent mutations.
- No live/paper/KIS/Upbit execution.
- No destructive DB update/delete/backfill.
- No scheduler/Prefect cadence changes.
- No credential/API key values printed or recorded.

Closes ROB-161


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for TradingView-related symbols in news feeds as a fallback when other symbol sources are unavailable.
  * Enhanced news feed tab filtering and display logic across top, US, and crypto tabs.
  * New bulk ingestion capability for tvscreener news sources with proper market normalization.

* **Tests**
  * Added comprehensive test coverage for tvscreener news ingestion and feed presentation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/761)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->