### PR TITLE
feat(rob-162): tvscreener feed snippet falls back to article_content

### DIFF
--- a/app/services/invest_view_model/feed_news_service.py
+++ b/app/services/invest_view_model/feed_news_service.py
@@ -38,7 +38,6 @@ from app.services.news_entity_matcher import (
 )
 from app.services.news_issue_clustering_service import build_market_issues
 
-
 _TVSCREENER_FEED_SOURCE_PREFIX = "http_tvscreener_news_"
 _SNIPPET_MAX_CHARS = 240
 

--- a/app/services/invest_view_model/feed_news_service.py
+++ b/app/services/invest_view_model/feed_news_service.py
@@ -39,6 +39,35 @@ from app.services.news_entity_matcher import (
 from app.services.news_issue_clustering_service import build_market_issues
 
 
+_TVSCREENER_FEED_SOURCE_PREFIX = "http_tvscreener_news_"
+_SNIPPET_MAX_CHARS = 240
+
+
+def _summary_snippet_for_row(row: object, analysis_summary: str | None) -> str | None:
+    """Return the best available summary snippet for a feed row.
+
+    Priority:
+    1. analysis_summary (AI-generated) if present.
+    2. row.summary (ingested summary) if present.
+    3. For tvscreener rows only: a 240-char excerpt from article_content.
+    4. None otherwise.
+    """
+    if analysis_summary:
+        return analysis_summary
+    if row.summary:  # type: ignore[union-attr]
+        return row.summary
+    feed_source = getattr(row, "feed_source", None) or ""
+    if not feed_source.startswith(_TVSCREENER_FEED_SOURCE_PREFIX):
+        return None
+    content = getattr(row, "article_content", None)
+    if not content:
+        return None
+    cleaned = " ".join(content.split())
+    if len(cleaned) <= _SNIPPET_MAX_CHARS:
+        return cleaned
+    return cleaned[: _SNIPPET_MAX_CHARS - 1].rstrip() + "…"
+
+
 def _encode_cursor(published_at: datetime | None, article_id: int) -> str:
     payload = {
         "p": published_at.isoformat() if published_at else None,
@@ -415,7 +444,7 @@ async def build_feed_news(
                 market=market_typed,
                 relatedSymbols=related,
                 issueId=issue_id_for_article.get(row.id),
-                summarySnippet=analysis_summary or row.summary,
+                summarySnippet=_summary_snippet_for_row(row, analysis_summary),
                 relation=relation,
                 url=row.url,
                 scope=cast(NewsScope, item_scope),

--- a/tests/test_invest_feed_news_tvscreener_enriched.py
+++ b/tests/test_invest_feed_news_tvscreener_enriched.py
@@ -1,0 +1,247 @@
+"""ROB-162 Task 11: feed snippet falls back to article_content for tvscreener rows.
+
+Verifies that when a tvscreener article has article_content but no summary and no
+analysis, the summarySnippet is a 240-char excerpt of article_content.
+
+Also verifies that non-tvscreener (RSS) articles are unaffected.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_NOW = datetime(2026, 5, 10, tzinfo=UTC)
+
+_LONG_CONTENT = (
+    "The Federal Reserve held interest rates steady at its May 2026 meeting, "
+    "signaling a cautious approach amid mixed economic signals. Chair Powell "
+    "emphasized that the committee remains data-dependent and is watching "
+    "inflation and labor market data closely. Markets reacted positively to "
+    "the announcement, with the S&P 500 gaining 1.2 percent on the news. "
+    "Analysts expect the Fed to begin cutting rates in the second half of 2026 "
+    "if inflation continues to moderate toward the 2 percent target. This is "
+    "additional text to push past the 240-character boundary for truncation."
+)
+
+
+def _fake_article(
+    *,
+    id: int,
+    market: str,
+    feed_source: str,
+    title: str,
+    url: str,
+    summary: str | None = None,
+    article_content: str | None = None,
+) -> MagicMock:
+    a = MagicMock()
+    a.id = id
+    a.market = market
+    a.title = title
+    a.source = "Reuters"
+    a.feed_source = feed_source
+    a.article_published_at = _NOW
+    a.stock_symbol = None
+    a.stock_name = None
+    a.summary = summary
+    a.article_content = article_content
+    a.keywords = None
+    a.url = url
+    return a
+
+
+def _fake_relation(article_id: int, market: str, symbol: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        article_id=article_id,
+        market=market,
+        symbol=symbol,
+        display_name=symbol,
+        source="candidate_metadata",
+        matched_term=None,
+        score=0.9,
+        rank=1,
+        raw={},
+    )
+
+
+def _fake_resolver():
+    from app.services.invest_view_model.relation_resolver import RelationResolver
+
+    return RelationResolver(held=set(), watch=set())
+
+
+def _wire_db(rows, relations):
+    """Wire a MagicMock DB with the 3 execute calls used by build_feed_news:
+    1. articles query  -> scalars().all() = rows
+    2. summaries query -> .all() = [] (no analysis results)
+    3. related symbols -> scalars().all() = relations
+    """
+    db = MagicMock()
+
+    article_result = MagicMock()
+    article_result.scalars.return_value.all.return_value = list(rows)
+
+    summary_result = MagicMock()
+    summary_result.all.return_value = []
+
+    related_result = MagicMock()
+    related_result.scalars.return_value.all.return_value = list(relations)
+
+    db.execute = AsyncMock(side_effect=[article_result, summary_result, related_result])
+    return db
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_tvscreener_article_with_content_has_snippet_in_feed(monkeypatch):
+    """tvscreener row with article_content and no summary → summarySnippet = excerpt."""
+    from app.services.invest_view_model import feed_news_service as svc
+
+    rows = [
+        _fake_article(
+            id=1,
+            market="us",
+            feed_source="http_tvscreener_news_us",
+            title="Fed Holds Rates Steady",
+            url="https://www.tradingview.com/news/fed-rates/",
+            summary=None,
+            article_content=_LONG_CONTENT,
+        ),
+    ]
+    relations = [_fake_relation(1, "us", "AAPL")]
+
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=SimpleNamespace(items=[]))
+    )
+
+    response = await svc.build_feed_news(
+        db=_wire_db(rows, relations),
+        resolver=_fake_resolver(),
+        tab="us",
+        limit=20,
+        cursor=None,
+    )
+
+    assert len(response.items) == 1
+    item = response.items[0]
+    assert item.feedSource == "http_tvscreener_news_us"
+    assert item.summarySnippet is not None, (
+        "Expected summarySnippet from article_content but got None"
+    )
+    # Snippet must be at most 240 visible chars (ellipsis counts as 1).
+    assert len(item.summarySnippet) <= 240
+    # Snippet must begin with the start of the content.
+    cleaned = " ".join(_LONG_CONTENT.split())
+    assert cleaned.startswith(item.summarySnippet[:50])
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_tvscreener_article_with_short_content_snippet_no_ellipsis(monkeypatch):
+    """tvscreener row with short article_content → full content, no truncation."""
+    from app.services.invest_view_model import feed_news_service as svc
+
+    short_content = "Apple reports record quarterly revenue."
+    rows = [
+        _fake_article(
+            id=2,
+            market="us",
+            feed_source="http_tvscreener_news_us",
+            title="Apple Revenue Record",
+            url="https://www.tradingview.com/news/aapl-revenue/",
+            summary=None,
+            article_content=short_content,
+        ),
+    ]
+    relations = [_fake_relation(2, "us", "AAPL")]
+
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=SimpleNamespace(items=[]))
+    )
+
+    response = await svc.build_feed_news(
+        db=_wire_db(rows, relations),
+        resolver=_fake_resolver(),
+        tab="us",
+        limit=20,
+        cursor=None,
+    )
+
+    item = response.items[0]
+    assert item.summarySnippet == short_content
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_rss_article_with_content_does_not_get_snippet(monkeypatch):
+    """Non-tvscreener (RSS) article with article_content → summarySnippet still None."""
+    from app.services.invest_view_model import feed_news_service as svc
+
+    rows = [
+        _fake_article(
+            id=3,
+            market="us",
+            feed_source="rss_yahoo_finance_topstories",
+            title="Yahoo Finance RSS Story",
+            url="https://finance.yahoo.com/news/rss-story/",
+            summary=None,
+            article_content=_LONG_CONTENT,
+        ),
+    ]
+
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=SimpleNamespace(items=[]))
+    )
+
+    response = await svc.build_feed_news(
+        db=_wire_db(rows, []),
+        resolver=_fake_resolver(),
+        tab="us",
+        limit=20,
+        cursor=None,
+    )
+
+    assert len(response.items) == 1
+    item = response.items[0]
+    assert item.summarySnippet is None, (
+        f"RSS article should not get snippet from article_content, got: {item.summarySnippet!r}"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_summary_takes_precedence_over_article_content_snippet(monkeypatch):
+    """When row.summary is set, it takes precedence over article_content snippet."""
+    from app.services.invest_view_model import feed_news_service as svc
+
+    rows = [
+        _fake_article(
+            id=4,
+            market="us",
+            feed_source="http_tvscreener_news_us",
+            title="Story with existing summary",
+            url="https://www.tradingview.com/news/with-summary/",
+            summary="Existing short summary.",
+            article_content=_LONG_CONTENT,
+        ),
+    ]
+    relations = [_fake_relation(4, "us", "AAPL")]
+
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=SimpleNamespace(items=[]))
+    )
+
+    response = await svc.build_feed_news(
+        db=_wire_db(rows, relations),
+        resolver=_fake_resolver(),
+        tab="us",
+        limit=20,
+        cursor=None,
+    )
+
+    item = response.items[0]
+    assert item.summarySnippet == "Existing short summary."

--- a/tests/test_news_ingestor_bulk_tvscreener_content.py
+++ b/tests/test_news_ingestor_bulk_tvscreener_content.py
@@ -55,15 +55,14 @@ async def test_tvscreener_bulk_ingest_with_content_persists_article_content(
     assert response.success
     assert response.inserted_count >= 1
 
-    target_url = payload["articles"][0].get("canonical_url") or payload["articles"][0]["url"]
+    target_url = (
+        payload["articles"][0].get("canonical_url") or payload["articles"][0]["url"]
+    )
     result = await db_session.execute(
-        select(NewsArticle.article_content)
-        .where(NewsArticle.url == target_url)
+        select(NewsArticle.article_content).where(NewsArticle.url == target_url)
     )
     article_content = result.scalar_one()
-    assert article_content == (
-        "Quality-gated body text from tvscreener enrichment."
-    )
+    assert article_content == ("Quality-gated body text from tvscreener enrichment.")
 
 
 @pytest.mark.integration
@@ -80,9 +79,10 @@ async def test_tvscreener_bulk_ingest_without_content_leaves_article_content_nul
     response = await ingest_news_ingestor_bulk(request)
     assert response.success
 
-    target_url = payload["articles"][0].get("canonical_url") or payload["articles"][0]["url"]
+    target_url = (
+        payload["articles"][0].get("canonical_url") or payload["articles"][0]["url"]
+    )
     result = await db_session.execute(
-        select(NewsArticle.article_content)
-        .where(NewsArticle.url == target_url)
+        select(NewsArticle.article_content).where(NewsArticle.url == target_url)
     )
     assert result.scalar_one() is None

--- a/tests/test_news_ingestor_bulk_tvscreener_content.py
+++ b/tests/test_news_ingestor_bulk_tvscreener_content.py
@@ -1,0 +1,88 @@
+"""ROB-162 Task 10: lock tvscreener bulk-ingest content field round-trip.
+
+Verifies that:
+  1. When `content` is provided in a NewsBulkIngestRequest, it persists to
+     news_articles.article_content.
+  2. When `content` is absent, news_articles.article_content is NULL.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from app.models.news import NewsArticle
+from app.schemas.news import NewsBulkIngestRequest
+from app.services.llm_news_service import ingest_news_ingestor_bulk
+
+FIXTURE = (
+    Path(__file__).resolve().parent
+    / "fixtures"
+    / "news_ingestor"
+    / "tvscreener_bulk_ingest_sample.json"
+)
+
+
+def _unique_payload(run_uuid: str) -> dict:
+    payload = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    suffix = uuid4().hex[:12]
+    payload["ingestion_run"]["run_uuid"] = run_uuid
+    for index, article in enumerate(payload["articles"]):
+        article["url"] = f"{article['url']}?run={suffix}&i={index}"
+        article["canonical_url"] = article["url"]
+        # Replace fingerprint entirely to stay within 128-char limit.
+        article["fingerprint"] = f"rob162-{suffix}-{index}"
+    return payload
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_tvscreener_bulk_ingest_with_content_persists_article_content(
+    db_session,
+):
+    run_uuid = f"test-rob-162-content-roundtrip-{uuid4().hex}"
+    payload = _unique_payload(run_uuid)
+    payload["articles"][0]["content"] = (
+        "Quality-gated body text from tvscreener enrichment."
+    )
+
+    request = NewsBulkIngestRequest.model_validate(payload)
+    response = await ingest_news_ingestor_bulk(request)
+    assert response.success
+    assert response.inserted_count >= 1
+
+    target_url = payload["articles"][0].get("canonical_url") or payload["articles"][0]["url"]
+    result = await db_session.execute(
+        select(NewsArticle.article_content)
+        .where(NewsArticle.url == target_url)
+    )
+    article_content = result.scalar_one()
+    assert article_content == (
+        "Quality-gated body text from tvscreener enrichment."
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_tvscreener_bulk_ingest_without_content_leaves_article_content_null(
+    db_session,
+):
+    run_uuid = f"test-rob-162-content-null-{uuid4().hex}"
+    payload = _unique_payload(run_uuid)
+    for article in payload["articles"]:
+        article.pop("content", None)
+
+    request = NewsBulkIngestRequest.model_validate(payload)
+    response = await ingest_news_ingestor_bulk(request)
+    assert response.success
+
+    target_url = payload["articles"][0].get("canonical_url") or payload["articles"][0]["url"]
+    result = await db_session.execute(
+        select(NewsArticle.article_content)
+        .where(NewsArticle.url == target_url)
+    )
+    assert result.scalar_one() is None


### PR DESCRIPTION
## Summary

ROB-162 (auto_trader side) — Minimal additive changes to support tvscreener article body enrichment shipped by news-ingestor PR #17.

### Changes

**`app/services/invest_view_model/feed_news_service.py`**
- Added `_summary_snippet_for_row()` helper that extends the `summarySnippet` fallback chain for `feed_source LIKE 'http_tvscreener_news_%'` rows: `analysis_summary → summary → article_content excerpt (240 chars)`
- Non-tvscreener sources (RSS, Naver, browser) are unchanged

### Tests

**`tests/test_news_ingestor_bulk_tvscreener_content.py`**
- Locks the `content` → `article_content` round-trip for tvscreener bulk ingest
- Confirms absent `content` leaves `article_content` NULL (regression guard)

**`tests/test_invest_feed_news_tvscreener_enriched.py`**
- Confirms enriched tvscreener rows show `summarySnippet` from `article_content` excerpt
- Confirms non-tvscreener rows are unaffected

## Safety summary
- No broker/order/watch/order-intent mutations
- No live/paper/KIS/Upbit execution
- No DB schema changes; no destructive updates
- No scheduler change

## Sibling PR
news-ingestor: https://github.com/mgh3326/news-ingestor/pull/17

Closes ROB-162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Improved news feed experience: TVScreener articles now automatically display text snippets extracted from article content (up to 240 characters) when manual summaries are unavailable, ensuring all articles have useful preview text.

## Tests
* Added comprehensive test coverage for feed summary snippet generation across different article sources and article content persistence during bulk ingestion.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/763)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->