### PR TITLE
feat(rob-163): opt-in tvscreener readiness coverage

### DIFF
--- a/app/routers/news_analysis.py
+++ b/app/routers/news_analysis.py
@@ -104,11 +104,16 @@ async def get_news_readiness_status(
         le=1440,
         description="Freshness threshold before news is considered stale",
     ),
+    include_tvscreener: bool = Query(
+        False,
+        description="Include tvscreener sources in source_coverage (opt-in; does not affect preopen contract)",
+    ),
 ):
     try:
         return await get_news_readiness(
             market=market,
             max_age_minutes=max_age_minutes,
+            include_tvscreener=include_tvscreener,
         )
     except Exception as e:
         raise HTTPException(

--- a/app/services/llm_news_service.py
+++ b/app/services/llm_news_service.py
@@ -416,7 +416,11 @@ async def _build_source_coverage(
         extra_sources = _TVSCREENER_FEED_SOURCES_BY_MARKET.get(market, ())
     feed_sources = list(
         dict.fromkeys(
-            [*source_counts.keys(), *_CORE_FEED_SOURCES_BY_MARKET.get(market, ()), *extra_sources]
+            [
+                *source_counts.keys(),
+                *_CORE_FEED_SOURCES_BY_MARKET.get(market, ()),
+                *extra_sources,
+            ]
         )
     )
     if not feed_sources:

--- a/app/services/llm_news_service.py
+++ b/app/services/llm_news_service.py
@@ -45,6 +45,12 @@ _CORE_FEED_SOURCES_BY_MARKET: dict[str, tuple[str, ...]] = {
     ),
 }
 
+_TVSCREENER_FEED_SOURCES_BY_MARKET: dict[str, tuple[str, ...]] = {
+    "kr": ("http_tvscreener_news_kr",),
+    "us": ("http_tvscreener_news_us",),
+    "crypto": ("http_tvscreener_news_crypto",),
+}
+
 
 async def create_news_article(
     title: str,
@@ -402,11 +408,15 @@ async def _build_source_coverage(
     *,
     market: str,
     source_counts: dict[str, int],
+    include_tvscreener: bool = False,
 ) -> list[NewsSourceCoverage]:
     """Summarize per-feed storage freshness for readiness dashboards."""
+    extra_sources: tuple[str, ...] = ()
+    if include_tvscreener:
+        extra_sources = _TVSCREENER_FEED_SOURCES_BY_MARKET.get(market, ())
     feed_sources = list(
         dict.fromkeys(
-            [*source_counts.keys(), *_CORE_FEED_SOURCES_BY_MARKET.get(market, ())]
+            [*source_counts.keys(), *_CORE_FEED_SOURCES_BY_MARKET.get(market, ()), *extra_sources]
         )
     )
     if not feed_sources:
@@ -520,6 +530,7 @@ async def get_news_readiness(
     *,
     market: str = "kr",
     max_age_minutes: int = 180,
+    include_tvscreener: bool = False,
     db: AsyncSession | None = None,
 ) -> NewsReadinessResponse:
     """Return latest news ingestion freshness for readiness/preopen checks."""
@@ -552,6 +563,7 @@ async def get_news_readiness(
             session,
             market=market,
             source_counts=latest_run.source_counts if latest_run else {},
+            include_tvscreener=include_tvscreener,
         )
 
         return _news_readiness_payload(

--- a/tests/test_news_readiness_contract.py
+++ b/tests/test_news_readiness_contract.py
@@ -347,12 +347,16 @@ class TestGetNewsReadinessStatusWhitelist:
 
         result = _news_readiness_payload(
             market="us",
-            latest_run=_make_run(market="us", source_counts={"rss_yahoo_finance_topstories": 5}),
+            latest_run=_make_run(
+                market="us", source_counts={"rss_yahoo_finance_topstories": 5}
+            ),
             latest_article_published_at=None,
             max_age_minutes=180,
             source_coverage=[],
         )
-        assert all(c.feed_source != "http_tvscreener_news_us" for c in result.source_coverage)
+        assert all(
+            c.feed_source != "http_tvscreener_news_us" for c in result.source_coverage
+        )
 
     async def test_build_source_coverage_includes_tvscreener_when_opted_in(self):
         """include_tvscreener=True appends tvscreener entries to source_coverage."""
@@ -365,7 +369,9 @@ class TestGetNewsReadinessStatusWhitelist:
                         class M:
                             def all(self):
                                 return []
+
                         return M()
+
                 return Rows()
 
         coverage = await svc._build_source_coverage(

--- a/tests/test_news_readiness_contract.py
+++ b/tests/test_news_readiness_contract.py
@@ -340,3 +340,41 @@ class TestGetNewsReadinessStatusWhitelist:
 
         assert result.is_ready is True
         assert result.latest_status == "partial"
+
+    async def test_news_readiness_default_excludes_tvscreener_coverage(self):
+        """Default behavior matches ROB-61 contract: no tvscreener entries in source_coverage."""
+        from app.services.llm_news_service import _news_readiness_payload
+
+        result = _news_readiness_payload(
+            market="us",
+            latest_run=_make_run(market="us", source_counts={"rss_yahoo_finance_topstories": 5}),
+            latest_article_published_at=None,
+            max_age_minutes=180,
+            source_coverage=[],
+        )
+        assert all(c.feed_source != "http_tvscreener_news_us" for c in result.source_coverage)
+
+    async def test_build_source_coverage_includes_tvscreener_when_opted_in(self):
+        """include_tvscreener=True appends tvscreener entries to source_coverage."""
+        from app.services import llm_news_service as svc
+
+        class FakeSession:
+            async def execute(self, query):
+                class Rows:
+                    def mappings(self):
+                        class M:
+                            def all(self):
+                                return []
+                        return M()
+                return Rows()
+
+        coverage = await svc._build_source_coverage(
+            FakeSession(),
+            market="us",
+            source_counts={"rss_yahoo_finance_topstories": 1},
+            include_tvscreener=True,
+        )
+        feed_sources = [c.feed_source for c in coverage]
+        assert "http_tvscreener_news_us" in feed_sources, (
+            "include_tvscreener=True must include tvscreener feed_source in coverage"
+        )


### PR DESCRIPTION
## Summary
- Add opt-in `include_tvscreener` readiness coverage so existing preopen readiness behavior remains unchanged by default.
- Include tvscreener only when explicitly requested, preserving the current non-tvscreener source contract.
- Add contract tests for default exclusion and opt-in inclusion.

## Safety / Scope
- No broker/order/watch/order-intent/KIS/Upbit/Alpaca execution paths touched.
- No DB schema/data mutations and no scheduler cadence changes.
- This is readiness/view-model coverage only.

## Tests
- `/Users/mgh3326/work/auto_trader/.venv/bin/python -m pytest -q tests/test_news_readiness_contract.py tests/test_news_ingestor_bulk.py tests/test_news_ingestor_bulk_tvscreener.py tests/test_news_ingestor_bulk_tvscreener_content.py` → 73 passed

Linear: ROB-163
