### PR TITLE
fix(invest-screener): return KR streak results

### DIFF
--- a/app/mcp_server/tooling/analysis_tool_handlers.py
+++ b/app/mcp_server/tooling/analysis_tool_handlers.py
@@ -636,7 +636,18 @@ async def screen_stocks_impl(
         instrument_types=normalized_request["instrument_types"],
         exclude_sectors=normalized_request["exclude_sectors"],
     )
-    # Use unified screening with automatic data source selection
+    # Use unified screening with automatic data source selection.  Streak filtering
+    # happens after OHLCV enrichment, so fetch a wider candidate pool first;
+    # otherwise the preset can return 0 simply because the first page had no
+    # qualifying streak rows.
+    query_limit = limit
+    if (
+        min_consecutive_up_days is not None
+        and normalized_market in {"kr", "kospi", "kosdaq", "konex", "all", "us"}
+        and normalized_asset_type in {None, "stock"}
+    ):
+        query_limit = min(limit * 5, 100)
+
     result = await analysis_screening.screen_stocks_unified(
         market=normalized_market,
         asset_type=normalized_asset_type,
@@ -651,7 +662,7 @@ async def screen_stocks_impl(
         max_rsi=max_rsi,
         sort_by=normalized_sort_by,
         sort_order=normalized_sort_order,
-        limit=limit,
+        limit=query_limit,
         exclude_sectors=exclude_sectors,
         instrument_types=instrument_types,
         adv_krw_min=adv_krw_min,
@@ -669,7 +680,15 @@ async def screen_stocks_impl(
         rows: list[dict[str, Any]] = list(result.get("results") or [])
         await _enrich_consecutive_up_days(rows, market=normalized_market)
         rows = _apply_min_consecutive_up_days(rows, threshold=min_consecutive_up_days)
-        result = {**result, "results": rows}
+        filters_applied = dict(result.get("filters_applied") or {})
+        if filters_applied:
+            filters_applied["limit"] = limit
+        result = {
+            **result,
+            "filters_applied": filters_applied or result.get("filters_applied"),
+            "results": rows[:limit],
+            "total_count": len(rows),
+        }
     return result
 
 

--- a/app/mcp_server/tooling/screening/enrichment.py
+++ b/app/mcp_server/tooling/screening/enrichment.py
@@ -33,6 +33,28 @@ _STREAK_LOOKBACK_DEFAULT = 10
 _STREAK_CONCURRENCY = 4
 
 
+def _streak_symbol(row: dict[str, Any]) -> str | None:
+    """Return the symbol field accepted by OHLCV fetchers for streak checks.
+
+    KR tvscreener rows are normalized with ``code`` instead of ``symbol``;
+    US/other rows may use ``symbol`` or ``ticker``.  Without this fallback the
+    post-screen streak enrichment silently skips all KR rows and the
+    ``min_consecutive_up_days`` filter drops every result.
+    """
+    for key in ("symbol", "code", "short_code", "ticker"):
+        raw = row.get(key)
+        if raw is None:
+            continue
+        symbol = str(raw).strip()
+        if not symbol:
+            continue
+        _, sep, suffix = symbol.rpartition(":")
+        if sep and suffix:
+            symbol = suffix
+        return symbol
+    return None
+
+
 async def _enrich_consecutive_up_days(
     rows: list[dict[str, Any]],
     *,
@@ -45,13 +67,13 @@ async def _enrich_consecutive_up_days(
     sem = asyncio.Semaphore(_STREAK_CONCURRENCY)
 
     async def _enrich_one(row: dict[str, Any]) -> None:
-        symbol = row.get("symbol")
+        symbol = _streak_symbol(row)
         if not symbol or row.get("consecutive_up_days") is not None:
             return
         async with sem:
             try:
                 df = await _fetch_ohlcv_for_indicators(
-                    str(symbol), market_type, count=lookback
+                    symbol, market_type, count=lookback
                 )
             except Exception:
                 return

--- a/app/mcp_server/tooling/screening/entrypoint.py
+++ b/app/mcp_server/tooling/screening/entrypoint.py
@@ -210,6 +210,7 @@ async def screen_stocks_unified(
         and (
             normalized_request["sector"] is not None
             or normalized_request["min_analyst_buy"] is not None
+            or normalized_request.get("min_consecutive_up_days") is not None
         )
     )
     can_avoid_overfetch = normalized_asset_type in {None, "stock"} and (

--- a/tests/test_screening_consecutive_up_days.py
+++ b/tests/test_screening_consecutive_up_days.py
@@ -41,6 +41,36 @@ async def test_enrich_consecutive_up_days_uses_daily_closes() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_enrich_consecutive_up_days_uses_kr_code_rows() -> None:
+    from app.mcp_server.tooling.screening.enrichment import (
+        _enrich_consecutive_up_days,
+    )
+
+    rows: list[dict] = [
+        {"code": "005930", "market": "KOSPI"},
+        {"code": "KRX:035720", "market": "KOSPI"},
+    ]
+    seen: list[str] = []
+
+    async def fake_fetch(
+        symbol: str, market_type: str, count: int = 10
+    ) -> pd.DataFrame:
+        seen.append(symbol)
+        assert market_type == "equity_kr"
+        return pd.DataFrame({"close": [100, 101, 102, 103, 104, 105]})
+
+    with patch(
+        "app.mcp_server.tooling.screening.enrichment._fetch_ohlcv_for_indicators",
+        side_effect=fake_fetch,
+    ):
+        await _enrich_consecutive_up_days(rows, market="kr", lookback=10)
+
+    assert seen == ["005930", "035720"]
+    assert [row["consecutive_up_days"] for row in rows] == [5, 5]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_enrich_consecutive_up_days_tolerates_per_row_failure() -> None:
     from app.mcp_server.tooling.screening.enrichment import (
         _enrich_consecutive_up_days,
@@ -82,3 +112,50 @@ def test_apply_min_consecutive_up_days_filter_drops_rows_below_threshold() -> No
     ]
     out = _apply_min_consecutive_up_days(rows, threshold=5)
     assert [r["symbol"] for r in out] == ["A"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_screen_stocks_impl_overfetches_before_streak_filter() -> None:
+    from app.mcp_server.tooling import analysis_tool_handlers
+
+    requested_limits: list[int] = []
+
+    async def fake_screen_stocks_unified(**kwargs):
+        requested_limits.append(kwargs["limit"])
+        rows = [
+            {"code": f"{idx:06d}", "market": "KOSPI"} for idx in range(kwargs["limit"])
+        ]
+        return {"results": rows, "total_count": len(rows)}
+
+    async def fake_fetch(
+        symbol: str, market_type: str, count: int = 10
+    ) -> pd.DataFrame:
+        idx = int(symbol)
+        if idx >= 20:
+            return pd.DataFrame({"close": [100, 101, 102, 103, 104, 105]})
+        return pd.DataFrame({"close": [100, 101, 100, 101, 100, 101]})
+
+    with (
+        patch(
+            "app.mcp_server.tooling.analysis_screening.screen_stocks_unified",
+            side_effect=fake_screen_stocks_unified,
+        ),
+        patch(
+            "app.mcp_server.tooling.screening.enrichment._fetch_ohlcv_for_indicators",
+            side_effect=fake_fetch,
+        ),
+    ):
+        result = await analysis_tool_handlers.screen_stocks_impl(
+            market="kr",
+            asset_type="stock",
+            sort_by="change_rate",
+            sort_order="desc",
+            min_consecutive_up_days=5,
+            limit=20,
+        )
+
+    assert requested_limits == [100]
+    assert len(result["results"]) == 20
+    assert result["total_count"] == 80
+    assert result["results"][0]["code"] == "000020"


### PR DESCRIPTION
## Summary
- Fix KR screener streak enrichment to use `code` rows from tvscreener, not only `symbol`.
- Overfetch before applying `min_consecutive_up_days` so `/invest/screener` does not return 0 just because the first page has no 5-day streak matches.
- Add regression tests for KR `code` rows and post-enrichment overfetch.

## Verification
- `uv run --group test pytest tests/test_screening_consecutive_up_days.py -q`
- `uv run ruff check app/mcp_server/tooling/analysis_tool_handlers.py app/mcp_server/tooling/screening/enrichment.py app/mcp_server/tooling/screening/entrypoint.py tests/test_screening_consecutive_up_days.py`
- `uv run ruff format --check app/mcp_server/tooling/analysis_tool_handlers.py app/mcp_server/tooling/screening/enrichment.py app/mcp_server/tooling/screening/entrypoint.py tests/test_screening_consecutive_up_days.py`
- Local prod-env smoke from worktree: `min_consecutive_up_days=5, limit=20` returns 3 rows (LG 7일, 주성엔지니어링 5일, 삼성화재우 5일).

## Safety
Read-only screening calculation/API behavior only. No broker/order/watch mutations, no DB writes, no scheduler changes.
