### PR TITLE
fix(rob-169): filter KR society noise from discovery feeds

### DIFF
--- a/app/services/invest_view_model/feed_news_service.py
+++ b/app/services/invest_view_model/feed_news_service.py
@@ -482,12 +482,13 @@ async def build_feed_news(
             )
         )
 
-    # ROB-155 / ROB-169: drop very-low-relevance rows on tab-scoped feeds. We
-    # never drop on broader tabs (top/latest/holdings/watchlist) — frontends
-    # can choose to render with reduced styling using `noiseReason`.
+    # ROB-155 / ROB-169: drop very-low-relevance rows on public discovery feeds
+    # when there is no symbol chip to anchor them. This keeps top/latest/default
+    # free of pure KR society/crime/noise while preserving market-wide KR rows
+    # that score as investment-relevant.
     if tab == "crypto":
         items = [i for i in items if not (i.noiseReason and not i.relatedSymbols)]
-    elif tab == "kr":
+    elif tab in ("top", "latest", "hot", "kr"):
         items = [
             i
             for i in items

--- a/tests/test_feed_news_kr_filter.py
+++ b/tests/test_feed_news_kr_filter.py
@@ -161,23 +161,20 @@ async def test_kr_society_article_suppresses_issue_chip(monkeypatch) -> None:
         svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[issue]))
     )
 
-    # On the "top" tab the row is NOT dropped (only the kr tab applies the
-    # filter), but the issueId must be suppressed because the row is noise.
+    # Public discovery tabs drop confirmed KR society/crime/noise rows when
+    # there is no symbol chip to anchor the item, so no issue chip is exposed.
     resp = await svc.build_feed_news(
         db=db, resolver=RelationResolver(), tab="top", limit=30, cursor=None
     )
 
-    assert [i.id for i in resp.items] == [303]
-    assert resp.items[0].issueId is None
-    assert resp.items[0].noiseReason == "kr_society"
+    assert [i.id for i in resp.items] == []
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_kr_top_tab_does_not_drop_kr_society_rows(monkeypatch) -> None:
-    """The kr-tab filter only fires on tab=='kr'; other tabs keep the row but
-    still flag noiseReason so the frontend can choose to render or hide it.
-    """
+@pytest.mark.parametrize("tab", ["top", "latest"])
+async def test_kr_discovery_tabs_drop_kr_society_rows(monkeypatch, tab) -> None:
+    """The default/top/latest feeds must not surface pure KR society noise."""
     from app.services.invest_view_model import feed_news_service as svc
 
     db = MagicMock()
@@ -200,11 +197,10 @@ async def test_kr_top_tab_does_not_drop_kr_society_rows(monkeypatch) -> None:
     )
 
     resp = await svc.build_feed_news(
-        db=db, resolver=RelationResolver(), tab="top", limit=30, cursor=None
+        db=db, resolver=RelationResolver(), tab=tab, limit=30, cursor=None
     )
 
-    assert [i.id for i in resp.items] == [304]
-    assert resp.items[0].noiseReason == "kr_society"
+    assert [i.id for i in resp.items] == []
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Drops confirmed KR society/crime/noise rows without symbol chips from top/latest/hot feeds, not only the kr tab
- Keeps KR market-wide no-symbol investment rows intact
- Adds top/latest regression coverage after production smoke found the 광주 여고생 crime article still surfaced on default/top/latest

## Test Plan
- uv run pytest tests/test_feed_news_kr_filter.py tests/test_kr_news_relevance_service.py tests/test_invest_feed_news_router.py -q
- uv run ruff check app/services/invest_view_model/feed_news_service.py tests/test_feed_news_kr_filter.py

Follow-up to PR #768 / ROB-169.