### PR TITLE
fix(ROB-170): prefer latest screener snapshot

### DIFF
--- a/app/mcp_server/tooling/screening/enrichment.py
+++ b/app/mcp_server/tooling/screening/enrichment.py
@@ -115,7 +115,17 @@ async def _hydrate_from_snapshots(
     fetched = await repo.get_fresh(
         market=market, symbols=[s for s in symbols if s], on_or_after=dt.date.min
     )
-    by_symbol = {row.symbol: row for row in fetched}
+    by_symbol: dict[str, Any] = {}
+    for snapshot in fetched:
+        existing = by_symbol.get(snapshot.symbol)
+        if existing is None or (
+            snapshot.snapshot_date,
+            snapshot.computed_at or dt.datetime.min.replace(tzinfo=dt.UTC),
+        ) > (
+            existing.snapshot_date,
+            existing.computed_at or dt.datetime.min.replace(tzinfo=dt.UTC),
+        ):
+            by_symbol[snapshot.symbol] = snapshot
 
     now = dt.datetime.now(dt.UTC)
     for row in rows:

--- a/tests/test_invest_screener_snapshots_enrichment.py
+++ b/tests/test_invest_screener_snapshots_enrichment.py
@@ -20,10 +20,11 @@ from app.services.invest_screener_snapshots.repository import (
 async def test_enrichment_reads_from_snapshot_when_fresh(db_session, monkeypatch):
     repo = InvestScreenerSnapshotsRepository(db_session)
     today = dt.date(2026, 5, 9)
+    symbol = "900001"
     await repo.upsert(
         SnapshotUpsert(
             market="kr",
-            symbol="005930",
+            symbol=symbol,
             snapshot_date=today,
             latest_close=Decimal("78500"),
             prev_close=Decimal("77900"),
@@ -44,9 +45,48 @@ async def test_enrichment_reads_from_snapshot_when_fresh(db_session, monkeypatch
         enrichment, "today_trading_date", lambda market, now=None: today
     )
 
-    rows = [{"market": "kr", "code": "005930"}]
+    rows = [{"market": "kr", "code": symbol}]
     await enrichment._enrich_consecutive_up_days(rows, market="kr", session=db_session)
     assert rows[0]["consecutive_up_days"] == 4
+    assert rows[0]["_screener_snapshot_state"] == "fresh"
+    fetcher.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enrichment_uses_latest_snapshot_when_history_exists(
+    db_session, monkeypatch
+):
+    repo = InvestScreenerSnapshotsRepository(db_session)
+    older = dt.date(2026, 5, 8)
+    latest = dt.date(2026, 5, 9)
+    symbol = "900002"
+    for snapshot_date, up_days in [(older, 2), (latest, 5)]:
+        await repo.upsert(
+            SnapshotUpsert(
+                market="kr",
+                symbol=symbol,
+                snapshot_date=snapshot_date,
+                latest_close=Decimal("78500"),
+                prev_close=Decimal("77900"),
+                change_amount=Decimal("600"),
+                change_rate=Decimal("0.7702"),
+                consecutive_up_days=up_days,
+                week_change_rate=Decimal("2.1"),
+                closes_window=[77000, 77100, 77400, 77900, 78500],
+                source="kis",
+            )
+        )
+    await db_session.commit()
+
+    fetcher = AsyncMock()
+    monkeypatch.setattr(enrichment, "_fetch_ohlcv_for_indicators", fetcher)
+    monkeypatch.setattr(
+        enrichment, "today_trading_date", lambda market, now=None: latest
+    )
+
+    rows = [{"market": "kr", "code": symbol}]
+    await enrichment._enrich_consecutive_up_days(rows, market="kr", session=db_session)
+    assert rows[0]["consecutive_up_days"] == 5
     assert rows[0]["_screener_snapshot_state"] == "fresh"
     fetcher.assert_not_called()
 

--- a/tests/test_invest_screener_snapshots_model.py
+++ b/tests/test_invest_screener_snapshots_model.py
@@ -13,16 +13,28 @@ from app.models.invest_screener_snapshot import InvestScreenerSnapshot
 
 @pytest_asyncio.fixture(autouse=True)
 async def _clean_snapshots(db_session):
-    await db_session.execute(delete(InvestScreenerSnapshot))
+    test_symbols = {"910001", "910002", "BTC"}
+    await db_session.execute(
+        delete(InvestScreenerSnapshot).where(
+            InvestScreenerSnapshot.symbol.in_(test_symbols)
+        )
+    )
     await db_session.commit()
     yield
+    await db_session.rollback()
+    await db_session.execute(
+        delete(InvestScreenerSnapshot).where(
+            InvestScreenerSnapshot.symbol.in_(test_symbols)
+        )
+    )
+    await db_session.commit()
 
 
 @pytest.mark.asyncio
 async def test_insert_round_trip(db_session):
     snap = InvestScreenerSnapshot(
         market="kr",
-        symbol="005930",
+        symbol="910001",
         snapshot_date=dt.date(2026, 5, 9),
         latest_close=Decimal("78500"),
         prev_close=Decimal("77900"),
@@ -39,7 +51,7 @@ async def test_insert_round_trip(db_session):
 
     result = await db_session.execute(
         sa.select(InvestScreenerSnapshot).where(
-            InvestScreenerSnapshot.symbol == "005930"
+            InvestScreenerSnapshot.symbol == "910001"
         )
     )
     fetched = result.scalar_one()
@@ -51,7 +63,7 @@ async def test_insert_round_trip(db_session):
 async def test_unique_constraint(db_session):
     base = {
         "market": "kr",
-        "symbol": "005930",
+        "symbol": "910002",
         "snapshot_date": dt.date(2026, 5, 9),
         "latest_close": Decimal("78500"),
         "closes_window": [78500],

--- a/tests/test_invest_screener_snapshots_repository.py
+++ b/tests/test_invest_screener_snapshots_repository.py
@@ -12,9 +12,12 @@ from app.services.invest_screener_snapshots.repository import (
 @pytest.mark.asyncio
 async def test_upsert_inserts_then_updates(db_session):
     repo = InvestScreenerSnapshotsRepository(db_session)
+    # Use a synthetic numeric KR-like symbol: some full-suite fixtures clean up
+    # non-market-shaped tickers, and this test commits mid-test to verify upsert.
+    symbol = "900101"
     payload = SnapshotUpsert(
         market="kr",
-        symbol="005930",
+        symbol=symbol,
         snapshot_date=dt.date(2026, 5, 9),
         latest_close=Decimal("78500"),
         prev_close=Decimal("77900"),
@@ -34,7 +37,7 @@ async def test_upsert_inserts_then_updates(db_session):
     await db_session.commit()
 
     rows = await repo.get_fresh(
-        market="kr", symbols=["005930"], on_or_after=dt.date(2026, 5, 9)
+        market="kr", symbols=[symbol], on_or_after=dt.date(2026, 5, 9)
     )
     assert len(rows) == 1
     assert rows[0].consecutive_up_days == 4


### PR DESCRIPTION
## Summary
- Fix ROB-170 enrichment hydration to dedupe multi-day snapshot history by latest snapshot_date/computed_at per symbol
- Add regression coverage for stale+fresh snapshot rows for the same KR symbol

## Test
- uv run --group test pytest tests/test_invest_screener_snapshots_enrichment.py -q

Safety: read/model path only; no broker/order/watch/order-intent mutations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved snapshot selection logic to ensure enrichment data always uses the most recent information per symbol, preventing stale data from being applied during stock screening updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/772)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->