### PR TITLE
fix(ROB-170): normalize snapshot date cells

### DIFF
--- a/app/services/invest_screener_snapshots/builder.py
+++ b/app/services/invest_screener_snapshots/builder.py
@@ -79,6 +79,34 @@ def _market_type_and_source(market: str) -> tuple[str, str]:
     raise ValueError(f"unsupported market: {market}")
 
 
+def _coerce_snapshot_date(value: Any, fallback: dt.date) -> dt.date:
+    if isinstance(value, dt.datetime):
+        return value.date()
+    if isinstance(value, dt.date):
+        return value
+
+    to_pydatetime = getattr(value, "to_pydatetime", None)
+    if callable(to_pydatetime):
+        converted = to_pydatetime()
+        if isinstance(converted, dt.datetime):
+            return converted.date()
+        if isinstance(converted, dt.date):
+            return converted
+
+    if value is None:
+        return fallback
+
+    try:
+        return dt.datetime.fromisoformat(str(value)).date()
+    except ValueError:
+        logger.warning(
+            "unable to coerce snapshot_date value=%r; using fallback=%s",
+            value,
+            fallback,
+        )
+        return fallback
+
+
 async def build_snapshot_for_symbol(
     *, market: str, symbol: str, today: dt.date
 ) -> SnapshotUpsert | None:
@@ -99,7 +127,11 @@ async def build_snapshot_for_symbol(
         return None
 
     metrics = derive_metrics(closes)
-    snapshot_date = df["date"].iloc[-1].date() if "date" in df.columns else today
+    snapshot_date = (
+        _coerce_snapshot_date(df["date"].iloc[-1], today)
+        if "date" in df.columns
+        else today
+    )
     daily_volume = (
         int(df["volume"].iloc[-1])
         if "volume" in df.columns and df["volume"].iloc[-1] is not None

--- a/tests/test_invest_screener_snapshots_builder.py
+++ b/tests/test_invest_screener_snapshots_builder.py
@@ -70,6 +70,29 @@ async def test_build_snapshot_for_symbol_kr(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_build_snapshot_for_symbol_accepts_python_date_cells(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "date": [dt.date(2026, 5, day) for day in range(1, 11)],
+            "close": [100, 101, 102, 103, 104, 105, 106, 107, 108, 110],
+            "volume": [1_000_000] * 10,
+        }
+    )
+    fetcher = AsyncMock(return_value=df)
+    monkeypatch.setattr(
+        "app.services.invest_screener_snapshots.builder._fetch_ohlcv_for_indicators",
+        fetcher,
+    )
+
+    payload = await build_snapshot_for_symbol(
+        market="kr", symbol="005930", today=dt.date(2026, 5, 10)
+    )
+
+    assert payload is not None
+    assert payload.snapshot_date == dt.date(2026, 5, 10)
+
+
+@pytest.mark.asyncio
 async def test_build_snapshot_for_symbol_returns_none_on_empty_df(monkeypatch):
     fetcher = AsyncMock(return_value=pd.DataFrame())
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- Fixes ROB-170 K9 dry-run blocker by normalizing OHLCV date cells that may already be `datetime.date`.
- Keeps snapshot builder behavior narrow: supports `datetime`, `date`, pandas-like `to_pydatetime()`, ISO strings, and falls back to the requested date only if coercion fails.
- Adds a regression test for Python `datetime.date` cells from the KR OHLCV path.

## Safety / scope
- Code-only snapshot builder fix and unit regression test.
- No production DB backfill commit.
- No scheduler activation.
- No broker/order/watch/order-intent mutations.

## Verification
- `uv run ruff format app/services/invest_screener_snapshots/builder.py tests/test_invest_screener_snapshots_builder.py`
- `uv run ruff check app/services/invest_screener_snapshots/builder.py tests/test_invest_screener_snapshots_builder.py`
- `uv run --with pytest --with pytest-asyncio pytest tests/test_invest_screener_snapshots_builder.py tests/test_build_invest_screener_snapshots_cli.py -q` → 10 passed
- `uv run --with pytest --with pytest-asyncio pytest tests/test_invest_screener_snapshots_builder.py tests/test_build_invest_screener_snapshots_cli.py tests/test_invest_screener_snapshots_repository.py tests/test_invest_screener_snapshots_freshness.py tests/test_invest_screener_snapshots_enrichment.py tests/test_invest_screener_snapshots_followup_wiring.py tests/test_build_invest_screener_snapshots_full_universe.py -q` → 35 passed
- Local production-env dry-run sample without `--commit`: `uv run python -m scripts.build_invest_screener_snapshots --market kr --limit 20 --batch-size 20 --concurrency 4` → built 20/20 snapshots, no rows written.

Follow-up after merge/deploy: rerun K9 full KR dry-run without `--commit`; only request explicit approval for bounded `--commit` after dry-run passes.
