### PR TITLE
chore(ROB-178): add research reports ingest smoke guardrails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,3 +293,6 @@ app/graphify-out/
 frontend/**/node_modules/
 frontend/**/dist/
 frontend/**/.vite/
+
+# ROB-178 smoke scratch — runtime payload/evidence; never commit.
+.smoke-out/

--- a/docs/runbooks/research-reports-integration.md
+++ b/docs/runbooks/research-reports-integration.md
@@ -106,3 +106,46 @@ uv run alembic downgrade -1    # to roll back
 * Research Session integration: wire `ResearchReportsQueryService` into the
   Research Session evidence gather step.
 * Symbol normalization with `symbol_universe` services.
+
+## ROB-178 operations smoke
+
+Manual, metadata-only smoke that exercises news-ingestor → auto_trader research_reports end-to-end. Read-only against production state. No scheduler, no broker, no PDF body, no full extracted text.
+
+Prereqs:
+
+* Two dedicated worktrees (one per repo) on branch `rob-178-research-reports-ingest`.
+* A smoke-only PostgreSQL database (e.g. `auto_trader_rob178_smoke`).
+
+Steps (from the auto_trader worktree):
+
+```bash
+# 1. Generate the live payload from the news-ingestor worktree.
+( cd /Users/mgh3326/worktrees/news-ingestor/rob-178-research-reports-ingest && \
+  uv run news-ingestor research-report kis-truefriend \
+    --pages 1 --rows-per-page 10 --include-detail --export-payload \
+    --output /Users/mgh3326/worktrees/auto_trader/rob-178-research-reports-ingest/.smoke-out/payload_live.json )
+
+# 2. Apply migrations.
+DATABASE_URL=postgresql+asyncpg://localhost/auto_trader_rob178_smoke \
+  uv run alembic upgrade head
+
+# 3. Operator CLI dry-run.
+DATABASE_URL=postgresql+asyncpg://localhost/auto_trader_rob178_smoke \
+  uv run python -m scripts.ingest_research_reports \
+    --file .smoke-out/payload_live.json --dry-run
+
+# 4. Live ingest + idempotent re-ingest + read-back + guardrails.
+DATABASE_URL=postgresql+asyncpg://localhost/auto_trader_rob178_smoke \
+  uv run python scripts/rob178_smoke.py \
+    --payload .smoke-out/payload_live.json \
+    --evidence .smoke-out/evidence.json
+```
+
+Pass criteria:
+
+* `evidence.json -> first_ingest.inserted_count` equals payload `report_count` and `skipped_count == 0`.
+* `evidence.json -> second_ingest_idempotent.inserted_count == 0` and `skipped_count == payload report_count` (idempotent).
+* `evidence.json -> read_back_via_service.citations_sample[*]` excerpts are ≤ 500 chars and contain none of `pdf_body|pdf_text|extracted_text|full_text|article_content|article_body|raw_payload|raw_payload_json`.
+* `evidence.json -> guardrails.full_text_exported_rejected.rejected == true` and `guardrails.forbidden_body_field_rejected.rejected == true`.
+
+Out of scope: `--store` against news-ingestor, `--download-pdf`, `--extract-text`, Prefect deployment activation, broker/order/watch mutation, HTTP ingest endpoint.

--- a/docs/runbooks/research-reports-integration.md
+++ b/docs/runbooks/research-reports-integration.md
@@ -115,15 +115,24 @@ Prereqs:
 
 * Two dedicated worktrees (one per repo) on branch `rob-178-research-reports-ingest`.
 * A smoke-only PostgreSQL database (e.g. `auto_trader_rob178_smoke`).
+* `scripts/rob178_smoke.py` defaults to no-write evidence mode; service write-path ingestion requires `--apply`.
 
 Steps (from the auto_trader worktree):
 
+`$NEWS_INGESTOR_WORKTREE` is the dedicated news-ingestor branch worktree, `$AUTO_TRADER_WORKTREE` is the dedicated auto_trader branch worktree, and `$OUT_DIR` is the auto_trader smoke scratch directory.
+
 ```bash
+export NEWS_INGESTOR_WORKTREE=/path/to/news-ingestor/rob-178-research-reports-ingest
+export AUTO_TRADER_WORKTREE=/path/to/auto_trader/rob-178-research-reports-ingest
+export OUT_DIR="$AUTO_TRADER_WORKTREE/.smoke-out"
+mkdir -p "$OUT_DIR"
+cd "$AUTO_TRADER_WORKTREE"
+
 # 1. Generate the live payload from the news-ingestor worktree.
-( cd /Users/mgh3326/worktrees/news-ingestor/rob-178-research-reports-ingest && \
+( cd "$NEWS_INGESTOR_WORKTREE" && \
   uv run news-ingestor research-report kis-truefriend \
     --pages 1 --rows-per-page 10 --include-detail --export-payload \
-    --output /Users/mgh3326/worktrees/auto_trader/rob-178-research-reports-ingest/.smoke-out/payload_live.json )
+    --output "$OUT_DIR/payload_live.json" )
 
 # 2. Apply migrations.
 DATABASE_URL=postgresql+asyncpg://localhost/auto_trader_rob178_smoke \
@@ -134,9 +143,17 @@ DATABASE_URL=postgresql+asyncpg://localhost/auto_trader_rob178_smoke \
   uv run python -m scripts.ingest_research_reports \
     --file .smoke-out/payload_live.json --dry-run
 
-# 4. Live ingest + idempotent re-ingest + read-back + guardrails.
+# 4. Optional all-in-one dry-run evidence, with no service write-path ingestion.
 DATABASE_URL=postgresql+asyncpg://localhost/auto_trader_rob178_smoke \
   uv run python scripts/rob178_smoke.py \
+    --dry-run \
+    --payload .smoke-out/payload_live.json \
+    --evidence .smoke-out/evidence-dry-run.json
+
+# 5. Live ingest + idempotent re-ingest + read-back + guardrails.
+DATABASE_URL=postgresql+asyncpg://localhost/auto_trader_rob178_smoke \
+  uv run python scripts/rob178_smoke.py \
+    --apply \
     --payload .smoke-out/payload_live.json \
     --evidence .smoke-out/evidence.json
 ```

--- a/scripts/rob178_smoke.py
+++ b/scripts/rob178_smoke.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""ROB-178 research_reports ingest/operations smoke driver.
+
+Metadata-only end-to-end smoke. Does NOT mutate broker/order/watch state. Does
+NOT activate any scheduler. Does NOT accept full PDF body or full extracted
+text. Writes a compact evidence file to .smoke-out/evidence.json.
+
+Run from the auto_trader worktree:
+
+    DATABASE_URL=postgresql+asyncpg://localhost/auto_trader_rob178_smoke \\
+      uv run python scripts/rob178_smoke.py \\
+        --payload .smoke-out/payload_live.json \\
+        --evidence .smoke-out/evidence.json
+
+If --payload is missing or the live file is empty, falls back to the pinned
+fixture at tests/fixtures/rob178_payload_kis_truefriend_smoke.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import copy
+import json
+import logging
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sqlalchemy import select
+
+from app.core.cli import setup_logging_and_sentry
+from app.core.db import AsyncSessionLocal
+from app.models.research_reports import (
+    ResearchReport,
+    ResearchReportIngestionRun,
+)
+from app.schemas.research_reports import ResearchReportIngestionRequest
+from app.services.research_reports.ingestion import ingest_research_reports_v1
+from app.services.research_reports.query_service import (
+    ResearchReportsQueryService,
+)
+
+logger = logging.getLogger("rob178_smoke")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FALLBACK_FIXTURE = (
+    REPO_ROOT / "tests" / "fixtures" / "rob178_payload_kis_truefriend_smoke.json"
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(prog="rob178_smoke")
+    p.add_argument(
+        "--payload",
+        type=Path,
+        default=Path(".smoke-out/payload_live.json"),
+        help="Path to a research-reports.v1 payload JSON.",
+    )
+    p.add_argument(
+        "--evidence",
+        type=Path,
+        default=Path(".smoke-out/evidence.json"),
+        help="Where to write the smoke evidence summary.",
+    )
+    return p.parse_args()
+
+
+def _load_payload(path: Path) -> tuple[Path, dict]:
+    if path.is_file() and path.stat().st_size > 0:
+        return path, json.loads(path.read_text(encoding="utf-8"))
+    logger.warning("payload missing or empty at %s; using pinned fixture", path)
+    return FALLBACK_FIXTURE, json.loads(FALLBACK_FIXTURE.read_text(encoding="utf-8"))
+
+
+def _run_operator_cli(payload_path: Path, *, dry_run: bool) -> dict:
+    cmd = [
+        "uv",
+        "run",
+        "python",
+        "-m",
+        "scripts.ingest_research_reports",
+        "--file",
+        str(payload_path),
+    ]
+    if dry_run:
+        cmd.append("--dry-run")
+    logger.info("operator cli: %s", " ".join(cmd))
+    proc = subprocess.run(
+        cmd, check=True, capture_output=True, text=True, cwd=REPO_ROOT
+    )
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+async def _ingest_via_service(
+    request: ResearchReportIngestionRequest,
+) -> dict:
+    async with AsyncSessionLocal() as db:
+        try:
+            response = await ingest_research_reports_v1(db, request)
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+    return response.model_dump()
+
+
+async def _read_back_via_service() -> dict:
+    async with AsyncSessionLocal() as db:
+        svc = ResearchReportsQueryService(db)
+        result = await svc.find_relevant(limit=20)
+    citations = []
+    for c in result.citations[:3]:
+        citations.append(
+            {
+                "source": c.source,
+                "title": c.title,
+                "analyst": c.analyst,
+                "published_at_text": c.published_at_text,
+                "category": c.category,
+                "detail_url": c.detail_url,
+                "pdf_url": c.pdf_url,
+                "excerpt_len": len(c.excerpt or ""),
+                "symbol_candidates": [
+                    sc.model_dump() for sc in c.symbol_candidates
+                ],
+                "attribution_publisher": c.attribution_publisher,
+                "attribution_copyright_notice": c.attribution_copyright_notice,
+            }
+        )
+    return {"count": result.count, "citations_sample": citations}
+
+
+async def _table_counts() -> dict:
+    async with AsyncSessionLocal() as db:
+        reports = (await db.execute(select(ResearchReport))).scalars().all()
+        runs = (
+            await db.execute(select(ResearchReportIngestionRun))
+        ).scalars().all()
+    return {
+        "research_reports_rows": len(reports),
+        "research_report_ingestion_runs_rows": len(runs),
+    }
+
+
+def _expect_full_text_rejection(payload: dict) -> dict:
+    mutated = copy.deepcopy(payload)
+    mutated["reports"][0]["attribution"]["full_text_exported"] = True
+    try:
+        ResearchReportIngestionRequest.model_validate(mutated)
+    except Exception as exc:
+        return {"rejected": True, "error_class": type(exc).__name__,
+                "error_message": str(exc)[:200]}
+    return {"rejected": False, "error_class": None, "error_message": None}
+
+
+def _expect_forbidden_body_rejection(payload: dict) -> dict:
+    mutated = copy.deepcopy(payload)
+    mutated["reports"][0]["pdf_body"] = "this should be rejected"
+    try:
+        ResearchReportIngestionRequest.model_validate(mutated)
+    except Exception as exc:
+        return {"rejected": True, "error_class": type(exc).__name__,
+                "error_message": str(exc)[:200]}
+    return {"rejected": False, "error_class": None, "error_message": None}
+
+
+def main() -> int:
+    setup_logging_and_sentry(service_name="rob178_smoke")
+    if "DATABASE_URL" not in os.environ:
+        print(
+            "DATABASE_URL must be set to a smoke-only DB url",
+            file=sys.stderr,
+        )
+        return 2
+    args = _parse_args()
+    payload_path, payload = _load_payload(args.payload)
+    request = ResearchReportIngestionRequest.model_validate(payload)
+
+    cli_dry = _run_operator_cli(payload_path, dry_run=True)
+    logger.info("operator cli dry-run: %s", cli_dry)
+
+    first = asyncio.run(_ingest_via_service(request))
+    second = asyncio.run(_ingest_via_service(request))
+    counts = asyncio.run(_table_counts())
+    read_back = asyncio.run(_read_back_via_service())
+
+    full_text_check = _expect_full_text_rejection(payload)
+    forbidden_body_check = _expect_forbidden_body_rejection(payload)
+
+    evidence = {
+        "smoke": "rob-178-research-reports-ingest",
+        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "payload_path": str(payload_path),
+        "payload_run_uuid": payload["research_report_ingestion_run"]["run_uuid"],
+        "payload_report_count": len(payload["reports"]),
+        "operator_cli_dry_run": cli_dry,
+        "first_ingest": first,
+        "second_ingest_idempotent": second,
+        "table_counts_after": counts,
+        "read_back_via_service": read_back,
+        "guardrails": {
+            "full_text_exported_rejected": full_text_check,
+            "forbidden_body_field_rejected": forbidden_body_check,
+        },
+    }
+    args.evidence.parent.mkdir(parents=True, exist_ok=True)
+    args.evidence.write_text(json.dumps(evidence, indent=2, ensure_ascii=False))
+    print(json.dumps(evidence, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rob178_smoke.py
+++ b/scripts/rob178_smoke.py
@@ -26,7 +26,7 @@ import logging
 import os
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from sqlalchemy import select
@@ -46,6 +46,7 @@ from app.services.research_reports.query_service import (
 logger = logging.getLogger("rob178_smoke")
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+SMOKE_OUTPUT_DIR = (REPO_ROOT / ".smoke-out").resolve(strict=False)
 FALLBACK_FIXTURE = (
     REPO_ROOT / "tests" / "fixtures" / "rob178_payload_kis_truefriend_smoke.json"
 )
@@ -66,6 +67,17 @@ def _parse_args() -> argparse.Namespace:
         help="Where to write the smoke evidence summary.",
     )
     return p.parse_args()
+
+
+def _resolve_smoke_output_path(path: Path) -> Path:
+    """Resolve evidence output under the repo-local smoke scratch directory."""
+    candidate = path if path.is_absolute() else REPO_ROOT / path
+    resolved = candidate.resolve(strict=False)
+    try:
+        resolved.relative_to(SMOKE_OUTPUT_DIR)
+    except ValueError as exc:
+        raise SystemExit("--evidence must be under .smoke-out/") from exc
+    return resolved
 
 
 def _load_payload(path: Path) -> tuple[Path, dict]:
@@ -176,6 +188,7 @@ def main() -> int:
         )
         return 2
     args = _parse_args()
+    args.evidence = _resolve_smoke_output_path(args.evidence)
     payload_path, payload = _load_payload(args.payload)
     request = ResearchReportIngestionRequest.model_validate(payload)
 
@@ -192,7 +205,7 @@ def main() -> int:
 
     evidence = {
         "smoke": "rob-178-research-reports-ingest",
-        "captured_at": datetime.now(timezone.utc).isoformat(),
+        "captured_at": datetime.now(UTC).isoformat(),
         "payload_path": str(payload_path),
         "payload_run_uuid": payload["research_report_ingestion_run"]["run_uuid"],
         "payload_report_count": len(payload["reports"]),

--- a/scripts/rob178_smoke.py
+++ b/scripts/rob178_smoke.py
@@ -77,28 +77,20 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Explicitly select the default no-write mode for operator checklists.",
     )
-    p.add_argument(
-        "--allow-evidence-outside",
-        action="store_true",
-        help="Allow --evidence outside the repo-local .smoke-out/ directory.",
-    )
     return p.parse_args()
 
 
-def _resolve_smoke_output_path(path: Path, *, allow_outside: bool) -> Path:
-    """Resolve evidence output and keep it in .smoke-out/ unless overridden."""
+def _resolve_smoke_output_path(path: Path) -> Path:
+    """Resolve evidence output and keep it in the repo-local .smoke-out/ tree."""
     candidate = path if path.is_absolute() else REPO_ROOT / path
     resolved = candidate.resolve(strict=False)
-    if allow_outside:
-        return resolved
     try:
-        resolved.relative_to(SMOKE_OUTPUT_DIR)
+        relative_output = resolved.relative_to(SMOKE_OUTPUT_DIR)
     except ValueError as exc:
-        raise SystemExit(
-            "--evidence must be under .smoke-out/; pass "
-            "--allow-evidence-outside to override"
-        ) from exc
-    return resolved
+        raise SystemExit("--evidence must be under .smoke-out/") from exc
+    if ".." in relative_output.parts:
+        raise SystemExit("--evidence must not contain parent-directory traversal")
+    return SMOKE_OUTPUT_DIR.joinpath(*relative_output.parts)
 
 
 def _load_payload(path: Path) -> tuple[Path, dict]:
@@ -226,9 +218,7 @@ def main() -> int:
             file=sys.stderr,
         )
         return 2
-    args.evidence = _resolve_smoke_output_path(
-        args.evidence, allow_outside=args.allow_evidence_outside
-    )
+    args.evidence = _resolve_smoke_output_path(args.evidence)
     payload_path, payload = _load_payload(args.payload)
     request = ResearchReportIngestionRequest.model_validate(payload)
 

--- a/scripts/rob178_smoke.py
+++ b/scripts/rob178_smoke.py
@@ -20,16 +20,17 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import copy
+import io
 import json
 import logging
 import os
-import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from app.core.cli import setup_logging_and_sentry
 from app.core.db import AsyncSessionLocal
@@ -66,17 +67,37 @@ def _parse_args() -> argparse.Namespace:
         default=Path(".smoke-out/evidence.json"),
         help="Where to write the smoke evidence summary.",
     )
+    p.add_argument(
+        "--apply",
+        action="store_true",
+        help="Execute service write-path ingestion. Default only validates and writes dry-run evidence.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Explicitly select the default no-write mode for operator checklists.",
+    )
+    p.add_argument(
+        "--allow-evidence-outside",
+        action="store_true",
+        help="Allow --evidence outside the repo-local .smoke-out/ directory.",
+    )
     return p.parse_args()
 
 
-def _resolve_smoke_output_path(path: Path) -> Path:
-    """Resolve evidence output under the repo-local smoke scratch directory."""
+def _resolve_smoke_output_path(path: Path, *, allow_outside: bool) -> Path:
+    """Resolve evidence output and keep it in .smoke-out/ unless overridden."""
     candidate = path if path.is_absolute() else REPO_ROOT / path
     resolved = candidate.resolve(strict=False)
+    if allow_outside:
+        return resolved
     try:
         resolved.relative_to(SMOKE_OUTPUT_DIR)
     except ValueError as exc:
-        raise SystemExit("--evidence must be under .smoke-out/") from exc
+        raise SystemExit(
+            "--evidence must be under .smoke-out/; pass "
+            "--allow-evidence-outside to override"
+        ) from exc
     return resolved
 
 
@@ -87,28 +108,43 @@ def _load_payload(path: Path) -> tuple[Path, dict]:
     return FALLBACK_FIXTURE, json.loads(FALLBACK_FIXTURE.read_text(encoding="utf-8"))
 
 
+def _parse_last_json_line(stdout: str) -> dict:
+    """Return the last JSON object emitted by a CLI-style function."""
+    for line in reversed(stdout.splitlines()):
+        if not line.strip():
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    raise RuntimeError(f"operator CLI emitted no JSON object; stdout={stdout!r}")
+
+
 def _run_operator_cli(payload_path: Path, *, dry_run: bool) -> dict:
-    cmd = [
-        "uv",
-        "run",
-        "python",
-        "-m",
-        "scripts.ingest_research_reports",
-        "--file",
-        str(payload_path),
-    ]
+    """Exercise the checked-in operator CLI entrypoint without shelling out."""
+    from scripts.ingest_research_reports import main_async
+
+    argv = ["--file", str(payload_path)]
     if dry_run:
-        cmd.append("--dry-run")
-    logger.info("operator cli: %s", " ".join(cmd))
-    proc = subprocess.run(
-        cmd, check=True, capture_output=True, text=True, cwd=REPO_ROOT
-    )
-    return json.loads(proc.stdout.strip().splitlines()[-1])
+        argv.append("--dry-run")
+    logger.info("operator cli argv: %s", argv)
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+        exit_code = asyncio.run(main_async(argv))
+    output = stdout.getvalue()
+    if exit_code != 0:
+        raise RuntimeError(
+            f"operator CLI failed with exit_code={exit_code}; stdout={output!r}"
+        )
+    return _parse_last_json_line(output)
 
 
 async def _ingest_via_service(
     request: ResearchReportIngestionRequest,
 ) -> dict:
+    """Commit one ingestion pass through the production service boundary."""
     async with AsyncSessionLocal() as db:
         try:
             response = await ingest_research_reports_v1(db, request)
@@ -120,6 +156,7 @@ async def _ingest_via_service(
 
 
 async def _read_back_via_service() -> dict:
+    """Read back a compact citation sample through the query service."""
     async with AsyncSessionLocal() as db:
         svc = ResearchReportsQueryService(db)
         result = await svc.find_relevant(limit=20)
@@ -146,18 +183,18 @@ async def _read_back_via_service() -> dict:
 
 
 async def _table_counts() -> dict:
+    """Return DB-side row counts for the research report smoke tables."""
     async with AsyncSessionLocal() as db:
-        reports = (await db.execute(select(ResearchReport))).scalars().all()
-        runs = (
-            await db.execute(select(ResearchReportIngestionRun))
-        ).scalars().all()
+        reports = await db.scalar(select(func.count(ResearchReport.id)))
+        runs = await db.scalar(select(func.count(ResearchReportIngestionRun.id)))
     return {
-        "research_reports_rows": len(reports),
-        "research_report_ingestion_runs_rows": len(runs),
+        "research_reports_rows": int(reports or 0),
+        "research_report_ingestion_runs_rows": int(runs or 0),
     }
 
 
 def _expect_full_text_rejection(payload: dict) -> dict:
+    """Verify schema validation rejects explicit full-text export flags."""
     mutated = copy.deepcopy(payload)
     mutated["reports"][0]["attribution"]["full_text_exported"] = True
     try:
@@ -169,6 +206,7 @@ def _expect_full_text_rejection(payload: dict) -> dict:
 
 
 def _expect_forbidden_body_rejection(payload: dict) -> dict:
+    """Verify schema validation rejects forbidden body-like fields."""
     mutated = copy.deepcopy(payload)
     mutated["reports"][0]["pdf_body"] = "this should be rejected"
     try:
@@ -180,6 +218,7 @@ def _expect_forbidden_body_rejection(payload: dict) -> dict:
 
 
 def main() -> int:
+    args = _parse_args()
     setup_logging_and_sentry(service_name="rob178_smoke")
     if "DATABASE_URL" not in os.environ:
         print(
@@ -187,18 +226,26 @@ def main() -> int:
             file=sys.stderr,
         )
         return 2
-    args = _parse_args()
-    args.evidence = _resolve_smoke_output_path(args.evidence)
+    args.evidence = _resolve_smoke_output_path(
+        args.evidence, allow_outside=args.allow_evidence_outside
+    )
     payload_path, payload = _load_payload(args.payload)
     request = ResearchReportIngestionRequest.model_validate(payload)
 
     cli_dry = _run_operator_cli(payload_path, dry_run=True)
     logger.info("operator cli dry-run: %s", cli_dry)
 
-    first = asyncio.run(_ingest_via_service(request))
-    second = asyncio.run(_ingest_via_service(request))
-    counts = asyncio.run(_table_counts())
-    read_back = asyncio.run(_read_back_via_service())
+    dry_run = not args.apply
+    if dry_run:
+        first = {"dry_run": True, "inserted_count": 0, "skipped_count": 0}
+        second = {"dry_run": True, "inserted_count": 0, "skipped_count": 0}
+        counts = asyncio.run(_table_counts())
+        read_back = {"dry_run": True, "count": 0, "citations_sample": []}
+    else:
+        first = asyncio.run(_ingest_via_service(request))
+        second = asyncio.run(_ingest_via_service(request))
+        counts = asyncio.run(_table_counts())
+        read_back = asyncio.run(_read_back_via_service())
 
     full_text_check = _expect_full_text_rejection(payload)
     forbidden_body_check = _expect_forbidden_body_rejection(payload)
@@ -206,6 +253,7 @@ def main() -> int:
     evidence = {
         "smoke": "rob-178-research-reports-ingest",
         "captured_at": datetime.now(UTC).isoformat(),
+        "dry_run": dry_run,
         "payload_path": str(payload_path),
         "payload_run_uuid": payload["research_report_ingestion_run"]["run_uuid"],
         "payload_report_count": len(payload["reports"]),
@@ -219,10 +267,26 @@ def main() -> int:
             "forbidden_body_field_rejected": forbidden_body_check,
         },
     }
+    invariants_ok = (
+        bool(full_text_check.get("rejected"))
+        and bool(forbidden_body_check.get("rejected"))
+        and (
+            dry_run
+            or (
+                first.get("inserted_count") == len(payload["reports"])
+                and first.get("skipped_count") == 0
+                and second.get("inserted_count") == 0
+                and second.get("skipped_count") == len(payload["reports"])
+                and read_back.get("count", 0) >= len(payload["reports"])
+            )
+        )
+    )
+    evidence["invariants_ok"] = invariants_ok
+
     args.evidence.parent.mkdir(parents=True, exist_ok=True)
     args.evidence.write_text(json.dumps(evidence, indent=2, ensure_ascii=False))
     print(json.dumps(evidence, indent=2, ensure_ascii=False))
-    return 0
+    return 0 if invariants_ok else 1
 
 
 if __name__ == "__main__":

--- a/scripts/rob178_smoke.py
+++ b/scripts/rob178_smoke.py
@@ -274,10 +274,10 @@ def main() -> int:
     evidence["invariants_ok"] = invariants_ok
 
     args.evidence.parent.mkdir(parents=True, exist_ok=True)
-    # NOSONAR pythonsecurity:S2083 — args.evidence is constrained to the
-    # repo-local .smoke-out/ tree by _resolve_smoke_output_path(), and the
-    # evidence payload contains only Pydantic-validated compact metadata.
-    args.evidence.write_text(json.dumps(evidence, indent=2, ensure_ascii=False))
+    # args.evidence is constrained to the repo-local .smoke-out/ tree by
+    # _resolve_smoke_output_path(), and the evidence payload contains only
+    # Pydantic-validated compact metadata.
+    args.evidence.write_text(json.dumps(evidence, indent=2, ensure_ascii=False))  # NOSONAR pythonsecurity:S2083
     print(json.dumps(evidence, indent=2, ensure_ascii=False))
     return 0 if invariants_ok else 1
 

--- a/scripts/rob178_smoke.py
+++ b/scripts/rob178_smoke.py
@@ -274,6 +274,9 @@ def main() -> int:
     evidence["invariants_ok"] = invariants_ok
 
     args.evidence.parent.mkdir(parents=True, exist_ok=True)
+    # NOSONAR pythonsecurity:S2083 — args.evidence is constrained to the
+    # repo-local .smoke-out/ tree by _resolve_smoke_output_path(), and the
+    # evidence payload contains only Pydantic-validated compact metadata.
     args.evidence.write_text(json.dumps(evidence, indent=2, ensure_ascii=False))
     print(json.dumps(evidence, indent=2, ensure_ascii=False))
     return 0 if invariants_ok else 1

--- a/tests/fixtures/rob178_payload_kis_truefriend_smoke.json
+++ b/tests/fixtures/rob178_payload_kis_truefriend_smoke.json
@@ -1,0 +1,89 @@
+{
+  "research_report_ingestion_run": {
+    "run_uuid": "rob178-smoke-fixture-0001",
+    "payload_version": "research-reports.v1",
+    "source": "kis_truefriend",
+    "started_at": "2026-05-10T00:00:00+00:00",
+    "finished_at": "2026-05-10T00:00:01+00:00",
+    "exported_at": "2026-05-10T00:00:02+00:00",
+    "report_count": 2,
+    "source_counts": {"kis_truefriend": 2},
+    "include_detail": true,
+    "download_pdf": false,
+    "extract_text": false,
+    "errors": [],
+    "copyright_notice": "© Korea Investment & Securities / Truefriend"
+  },
+  "reports": [
+    {
+      "dedup_key": "kis_truefriend:rob178-smoke-1",
+      "report_type": "broker_research",
+      "source": "kis_truefriend",
+      "source_report_id": "rob178-smoke-1",
+      "title": "ROB-178 smoke fixture report 1",
+      "category": "글로벌기업",
+      "analyst": "Smoke Tester",
+      "published_at_text": "2026.05.10",
+      "summary_text": "Synthetic summary used by ROB-178 smoke. No body content.",
+      "detail": {
+        "url": "https://www.truefriend.com/main/research/research/StrategyDetail.jsp?jkGubun=10&id=rob178-smoke-1&category1=05&category2=01",
+        "title": "ROB-178 smoke fixture detail 1",
+        "subtitle": "metadata only",
+        "excerpt": "Bounded excerpt; no full body."
+      },
+      "pdf": {
+        "url": "https://file.truefriend.com/servlet/Download?file_path=research/research05/&file_name=rob178-smoke-1.pdf",
+        "filename": "rob178-smoke-1.pdf",
+        "sha256": null,
+        "size_bytes": null,
+        "page_count": null,
+        "text_length": null
+      },
+      "symbol_candidates": [
+        {"symbol": "AAPL", "market": "us", "source": "ticker_match"}
+      ],
+      "raw_text_policy": "metadata_only",
+      "attribution": {
+        "publisher": "Korea Investment & Securities / Truefriend",
+        "copyright_notice": "© Korea Investment & Securities / Truefriend",
+        "full_text_exported": false,
+        "pdf_body_exported": false
+      }
+    },
+    {
+      "dedup_key": "kis_truefriend:rob178-smoke-2",
+      "report_type": "broker_research",
+      "source": "kis_truefriend",
+      "source_report_id": "rob178-smoke-2",
+      "title": "ROB-178 smoke fixture report 2",
+      "category": "기업분석",
+      "analyst": "Smoke Tester",
+      "published_at_text": "2026.05.10",
+      "summary_text": "Second synthetic report. No body content.",
+      "detail": {
+        "url": "https://www.truefriend.com/main/research/research/StrategyDetail.jsp?jkGubun=10&id=rob178-smoke-2&category1=05&category2=01",
+        "title": "ROB-178 smoke fixture detail 2",
+        "subtitle": "metadata only",
+        "excerpt": "Bounded excerpt; no full body."
+      },
+      "pdf": {
+        "url": "https://file.truefriend.com/servlet/Download?file_path=research/research05/&file_name=rob178-smoke-2.pdf",
+        "filename": "rob178-smoke-2.pdf",
+        "sha256": null,
+        "size_bytes": null,
+        "page_count": null,
+        "text_length": null
+      },
+      "symbol_candidates": [
+        {"symbol": "005930", "market": "kr", "source": "ticker_match"}
+      ],
+      "raw_text_policy": "metadata_only",
+      "attribution": {
+        "publisher": "Korea Investment & Securities / Truefriend",
+        "copyright_notice": "© Korea Investment & Securities / Truefriend",
+        "full_text_exported": false,
+        "pdf_body_exported": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a gitignored `.smoke-out/` scratch path for ROB-178 smoke artifacts.
- Add a pinned synthetic metadata-only `research-reports.v1` fixture and `scripts/rob178_smoke.py` bounded smoke driver.
- Document the dry-run-first local/production metadata ingest smoke checklist for research reports.

## Safety / scope
- Metadata-only: no full PDF body, full extracted report text, raw article HTML, or copyrighted body export.
- Read-only / smoke-oriented integration only; no broker/order/watch/order-intent changes.
- No scheduler activation.
- Planner/reviewer=Claude Code Opus and implementer=Claude Code Sonnet are recorded as preferences from the Kanban workflow; runtime model enforcement is not verified by this PR.

## Validation
- `git diff --check origin/main...HEAD`
- `uv run ruff check scripts/rob178_smoke.py tests/test_research_reports_payload_schemas.py tests/test_research_reports_copyright_guardrails.py tests/test_research_reports_repository.py tests/test_research_reports_ingestion.py tests/test_research_reports_query_service.py tests/test_research_reports_router.py`
- `uv run pytest tests/test_research_reports_payload_schemas.py tests/test_research_reports_copyright_guardrails.py -q` (16 passed)
- `DATABASE_URL=postgresql+asyncpg://localhost/auto_trader_rob178_smoke uv run pytest -m integration tests/test_research_reports_repository.py tests/test_research_reports_ingestion.py tests/test_research_reports_query_service.py tests/test_research_reports_router.py -q` (14 passed, 1 deselected)

Closes ROB-178


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added smoke test runbook for research report ingestion with detailed procedures, validation criteria, data guardrails, and scope definitions.

* **Chores**
  * Added automated smoke test script validating research report ingestion through dry-run and full cycles, including idempotency and payload validation.
  * Added test fixture and updated `.gitignore` to support smoke testing infrastructure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/776)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->