### PR TITLE
fix(ROB-170): shield screener from upstream DNS failures

### DIFF
--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -12,12 +12,14 @@ modules — see tests/test_invest_view_model_safety.py.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime
 from datetime import time as _time
 from typing import Any, Literal, Protocol
 from zoneinfo import ZoneInfo
 
+import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.schemas.invest_screener import (
@@ -41,6 +43,9 @@ _KST = ZoneInfo("Asia/Seoul")
 _KR_OPEN = _time(9, 0)
 _KR_CLOSE = _time(15, 30)
 _CACHE_HIT_FRESH_SECONDS = 300
+_SNAPSHOT_FIRST_LIMIT = 20
+_MAX_WARNING_CHARS = 240
+logger = logging.getLogger(__name__)
 
 
 class _ScreeningServiceProto(Protocol):
@@ -49,6 +54,132 @@ class _ScreeningServiceProto(Protocol):
 
 class _ResolverProto(Protocol):
     def relation(self, market: str, symbol: str) -> str: ...
+
+
+def _safe_warning(message: Any) -> str:
+    text = _clean_text(message)
+    if not text:
+        return "스크리너 데이터 소스가 일시적으로 응답하지 않습니다."
+    noisy_markers = (
+        "HTTPSConnectionPool(",
+        "ConnectionError",
+        "ConnectError",
+        "NameResolutionError",
+        "nodename nor servname",
+        "Could not resolve host",
+        "getaddrinfo()",
+        "Max retries exceeded",
+        "api.finnhub.io",
+        "scanner.tradingview.com",
+        "query1.finance.yahoo.com",
+        "query2.finance.yahoo.com",
+        "token=",
+    )
+    if any(marker in text for marker in noisy_markers):
+        return "외부 시세/스크리너 데이터 소스 연결이 일시적으로 불안정해 일부 결과를 갱신하지 못했습니다."
+    if len(text) > _MAX_WARNING_CHARS:
+        return text[: _MAX_WARNING_CHARS - 1].rstrip() + "…"
+    return text
+
+
+def _safe_warnings(messages: Sequence[Any]) -> list[str]:
+    warnings: list[str] = []
+    for message in messages:
+        warning = _safe_warning(message)
+        if warning not in warnings:
+            warnings.append(warning)
+    return warnings
+
+
+def _external_failure_warning(exc: BaseException) -> str:
+    # Keep provider hostnames/tokens out of logs and user-facing warnings; the
+    # error class is enough to diagnose transient DNS/network failures here.
+    logger.warning("invest screener upstream failed: %s", type(exc).__name__)
+    return "외부 시세/스크리너 데이터 소스 연결이 일시적으로 불안정해 캐시된 결과만 표시합니다."
+
+
+def _should_use_snapshot_first(screening_service: Any) -> bool:
+    return (
+        screening_service.__class__.__name__ == "ScreenerService"
+        and screening_service.__class__.__module__ == "app.services.screener_service"
+    )
+
+
+async def _load_consecutive_gainers_from_snapshots(
+    session: AsyncSession | None, *, market: str, limit: int = _SNAPSHOT_FIRST_LIMIT
+) -> list[dict[str, Any]]:
+    if session is None or market not in {"kr", "us"}:
+        return []
+
+    from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+    from app.services.invest_screener_snapshots.freshness import (
+        classify_state,
+        today_trading_date,
+    )
+
+    today = today_trading_date(market)
+    stmt = (
+        sa.select(InvestScreenerSnapshot)
+        .where(
+            InvestScreenerSnapshot.market == market,
+            InvestScreenerSnapshot.consecutive_up_days >= 5,
+            InvestScreenerSnapshot.week_change_rate >= 0,
+        )
+        .order_by(
+            InvestScreenerSnapshot.snapshot_date.desc(),
+            InvestScreenerSnapshot.consecutive_up_days.desc(),
+            InvestScreenerSnapshot.week_change_rate.desc().nullslast(),
+            InvestScreenerSnapshot.change_rate.desc().nullslast(),
+        )
+        .limit(max(limit * 4, limit))
+    )
+    try:
+        result = await session.execute(stmt)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "failed to read invest_screener_snapshots: %s", exc, exc_info=True
+        )
+        return []
+
+    now = datetime.now(UTC)
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for snap in result.scalars().all():
+        if snap.symbol in seen:
+            continue
+        seen.add(snap.symbol)
+        state = classify_state(
+            snapshot_date=snap.snapshot_date,
+            computed_at=snap.computed_at,
+            closes_window_len=len(snap.closes_window or []),
+            today_trading_date_value=today,
+            now=now,
+        )
+        rows.append(
+            {
+                "symbol": snap.symbol,
+                "market": market,
+                "close": float(snap.latest_close)
+                if snap.latest_close is not None
+                else None,
+                "change_rate": float(snap.change_rate)
+                if snap.change_rate is not None
+                else None,
+                "change_amount": float(snap.change_amount)
+                if snap.change_amount is not None
+                else None,
+                "consecutive_up_days": snap.consecutive_up_days,
+                "week_change_rate": float(snap.week_change_rate)
+                if snap.week_change_rate is not None
+                else None,
+                "volume": snap.daily_volume,
+                "daily_closes": list(snap.closes_window or []),
+                "_screener_snapshot_state": state,
+            }
+        )
+        if len(rows) >= limit:
+            break
+    return rows
 
 
 def build_screener_presets() -> ScreenerPresetsResponse:
@@ -358,9 +489,37 @@ async def build_screener_results(
         )
 
     filters = screening_filters_for(preset_id, requested_market)
-    raw = await screening_service.list_screening(**filters)
+    snapshot_rows: list[dict[str, Any]] = []
+    if (
+        preset_id == "consecutive_gainers"
+        and session is not None
+        and _should_use_snapshot_first(screening_service)
+    ):
+        snapshot_rows = await _load_consecutive_gainers_from_snapshots(
+            session,
+            market=requested_market,
+            limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
+        )
+
+    if snapshot_rows:
+        raw = {
+            "results": snapshot_rows,
+            "warnings": [],
+            "timestamp": now().isoformat(),
+            "cache_hit": True,
+        }
+    else:
+        try:
+            raw = await screening_service.list_screening(**filters)
+        except Exception as exc:  # noqa: BLE001
+            raw = {
+                "results": [],
+                "warnings": [_external_failure_warning(exc)],
+                "timestamp": datetime.now(UTC).isoformat(),
+                "cache_hit": False,
+            }
     rows: list[dict[str, Any]] = list(raw.get("results") or raw.get("stocks") or [])
-    upstream_warnings: list[str] = list(raw.get("warnings") or [])
+    upstream_warnings: list[str] = _safe_warnings(list(raw.get("warnings") or []))
 
     # ROB-170 follow-up: snapshot-first hydration runs at the view-model layer so
     # the session reaches _enrich_consecutive_up_days. Without this call the

--- a/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
@@ -127,6 +127,20 @@ test("shows an empty-state message when results are empty", async () => {
 });
 
 
+test("shows a friendly message when screener results fail", async () => {
+  vi.spyOn(screenerApi, "fetchScreenerResults").mockRejectedValue(
+    new Error("screener/results 500"),
+  );
+
+  render(wrap(<DesktopScreenerPage />));
+
+  await waitFor(() =>
+    expect(screen.getByText(/스크리너 데이터를 일시적으로 불러오지 못했습니다/)).toBeInTheDocument(),
+  );
+  expect(screen.queryByText(/screener\/results 500/)).not.toBeInTheDocument();
+});
+
+
 test("switches to the US market", async () => {
   render(wrap(<DesktopScreenerPage />));
   await waitFor(() => expect(screen.getByText("삼성전자")).toBeInTheDocument());

--- a/frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx
@@ -14,6 +14,16 @@ import type {
 } from "../../types/screener";
 import "../../desktop/screener/screener.css";
 
+function screenerErrorMessage(error: unknown): string {
+  const text = error instanceof Error ? error.message : String(error ?? "");
+  if (
+    /Failed to fetch|NetworkError|Load failed|screener\/results \d{3}|screener\/presets \d{3}/i.test(text)
+  ) {
+    return "스크리너 데이터를 일시적으로 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.";
+  }
+  return text || "스크리너 데이터를 일시적으로 불러오지 못했습니다.";
+}
+
 export function DesktopScreenerPage() {
   const [presets, setPresets] = useState<ScreenerPresetsResponse | undefined>();
   const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -31,7 +41,7 @@ export function DesktopScreenerPage() {
         setPresets(r);
         setSelectedId(r.selectedPresetId ?? r.presets[0]?.id ?? null);
       })
-      .catch((e) => !cancel && setErr(String(e?.message ?? e)));
+      .catch((e) => !cancel && setErr(screenerErrorMessage(e)));
     return () => { cancel = true; };
   }, []);
 
@@ -46,7 +56,7 @@ export function DesktopScreenerPage() {
         setErr(undefined);
         setResults(r);
       })
-      .catch((e) => !cancel && setErr(String(e?.message ?? e)));
+      .catch((e) => !cancel && setErr(screenerErrorMessage(e)));
     return () => { cancel = true; };
   }, [selectedId, selectedMarket]);
 

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+from decimal import Decimal
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -51,6 +52,60 @@ def _stub_screening_rows() -> list[dict[str, Any]]:
             "rsi": None,
         },
     ]
+
+
+class _FakeScalarResult:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+
+class _FakeExecuteResult:
+    def __init__(
+        self, *, scalar_rows: list[Any] | None = None, rows: list[Any] | None = None
+    ) -> None:
+        self._scalar_rows = scalar_rows or []
+        self._rows = rows or []
+
+    def scalars(self) -> _FakeScalarResult:
+        return _FakeScalarResult(self._scalar_rows)
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+
+class _FakeSession:
+    def __init__(self, results: list[_FakeExecuteResult]) -> None:
+        self.results = list(results)
+        self.calls = 0
+
+    async def execute(self, stmt: Any) -> _FakeExecuteResult:  # noqa: ARG002
+        self.calls += 1
+        if not self.results:
+            return _FakeExecuteResult()
+        return self.results.pop(0)
+
+
+class _FakeSnapshot:
+    def __init__(self, **kwargs: Any) -> None:
+        self.market = kwargs.get("market", "kr")
+        self.symbol = kwargs["symbol"]
+        self.snapshot_date = kwargs.get("snapshot_date", date(2026, 5, 11))
+        self.latest_close = kwargs.get("latest_close", Decimal("80000"))
+        self.prev_close = kwargs.get("prev_close", Decimal("79000"))
+        self.change_amount = kwargs.get("change_amount", Decimal("1000"))
+        self.change_rate = kwargs.get("change_rate", Decimal("1.2658"))
+        self.consecutive_up_days = kwargs.get("consecutive_up_days", 6)
+        self.week_change_rate = kwargs.get("week_change_rate", Decimal("3.5"))
+        self.closes_window = kwargs.get(
+            "closes_window", [76000, 77000, 78000, 79000, 80000]
+        )
+        self.daily_volume = kwargs.get("daily_volume", 1234567)
+        self.computed_at = kwargs.get(
+            "computed_at", datetime(2026, 5, 11, 0, 30, tzinfo=UTC)
+        )
 
 
 class _FakeResolver:
@@ -821,3 +876,73 @@ async def test_build_screener_results_emits_freshness_previous_session_when_mark
     )
     assert resp.freshness.source == "previous_session"
     assert resp.freshness.relativeLabel == "전 거래일 기준"
+
+
+class _FakeProductionScreening:
+    __module__ = "app.services.screener_service"
+    __name__ = "ScreenerService"
+
+    def __init__(self) -> None:
+        self.list_screening = AsyncMock(
+            side_effect=AssertionError("external call should be skipped")
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_uses_snapshots_before_external_screening() -> (
+    None
+):
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+    resolver = _FakeResolver(watched={("kr", "005930")})
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[_FakeSnapshot(symbol="005930")]),
+            _FakeExecuteResult(scalar_rows=[_FakeSnapshot(symbol="005930")]),
+            _FakeExecuteResult(
+                rows=[type("NameRow", (), {"symbol": "005930", "name": "삼성전자"})()]
+            ),
+        ]
+    )
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+        session=session,
+    )
+
+    fake_screening.list_screening.assert_not_called()
+    assert resp.results[0].symbol == "005930"
+    assert resp.results[0].name == "삼성전자"
+    assert resp.results[0].metricValueLabel == "6일"
+    assert resp.freshness.cacheHit is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_redacts_external_connection_failures() -> None:
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        side_effect=ConnectionError(
+            "HTTPSConnectionPool(host='api.finnhub.io', port=443): token=secret Max retries exceeded"
+        )
+    )
+    resolver = _FakeResolver(watched=set())
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=resolver,
+    )
+
+    assert resp.results == []
+    assert resp.warnings == [
+        "외부 시세/스크리너 데이터 소스 연결이 일시적으로 불안정해 캐시된 결과만 표시합니다."
+    ]
+    assert "api.finnhub" not in " ".join(resp.warnings)
+    assert "secret" not in " ".join(resp.warnings)


### PR DESCRIPTION
## Summary
- Use `invest_screener_snapshots` before external screening for the production consecutive-gainers path, so transient provider DNS/API failures do not collapse `/invest/screener`.
- Sanitize upstream connection warnings to a Korean cache-only message without provider hostnames or secrets.
- Prefer KR universe Korean names for KR rows and add a frontend-friendly screener fetch error message.

## Verification
- `uv run --group dev ruff check app/services/invest_view_model/screener_service.py tests/test_invest_view_model_screener_service.py tests/test_invest_api_screener_router.py`
- `uv run --group test pytest tests/test_invest_view_model_screener_service.py tests/test_invest_api_screener_router.py -q`
- `npm test -- DesktopScreenerPage.test.tsx --run`
- `npm run typecheck`
- `npm run build`
- Independent pre-commit review passed: no security concerns, no logic errors.

## Safety
- Read-model/UI only.
- No broker/order/watch/order-intent mutations.
- No scheduler activation or production DB writes.

Follow-up for ROB-170 production smoke after merge/deploy.
