### PR TITLE
feat(ROB-180): add research feed cards

### DIFF
--- a/frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx
@@ -5,8 +5,10 @@ import { MemoryRouter } from "react-router-dom";
 import { DesktopFeedNewsPage } from "../pages/desktop/DesktopFeedNewsPage";
 import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
 import * as feedApi from "../api/feedNews";
+import * as feedResearchApi from "../api/feedResearch";
 import * as panelApi from "../api/accountPanel";
 import type { FeedNewsResponse } from "../types/feedNews";
+import type { FeedResearchResponse } from "../types/feedResearch";
 
 function feedResponse(overrides: Partial<FeedNewsResponse> = {}): FeedNewsResponse {
   return {
@@ -80,6 +82,35 @@ function feedResponse(overrides: Partial<FeedNewsResponse> = {}): FeedNewsRespon
   };
 }
 
+function researchResponse(overrides: Partial<FeedResearchResponse> = {}): FeedResearchResponse {
+  return {
+    tab: "latest",
+    asOf: new Date().toISOString(),
+    nextCursor: null,
+    items: [
+      {
+        id: 1,
+        source: "kis_research",
+        title: "삼성전자 2Q 프리뷰",
+        analyst: "홍길동",
+        publishedAt: "2026-05-10T00:00:00Z",
+        publishedAtText: "2026.05.10",
+        category: "기업분석",
+        detailUrl: "https://example.com/research/1",
+        pdfUrl: "https://example.com/research/1.pdf",
+        excerpt: "영업이익 추정치와 목표가 변경 요약",
+        symbolCandidates: [{ symbol: "005930", market: "kr", name: "삼성전자", confidence: 0.97 }],
+        attributionPublisher: "Korea Investment & Securities",
+        attributionCopyrightNotice: "© Korea Investment",
+        market: "kr",
+        relation: "watch",
+      },
+    ],
+    meta: { limit: 30, appliedFilters: {} },
+    ...overrides,
+  };
+}
+
 function renderPage() {
   return render(
     <AccountPanelProvider>
@@ -100,6 +131,7 @@ beforeEach(() => {
     meta: { warnings: [], watchlistAvailable: true },
   });
   vi.spyOn(feedApi, "fetchFeedNews").mockResolvedValue(feedResponse());
+  vi.spyOn(feedResearchApi, "fetchFeedResearch").mockResolvedValue(researchResponse());
 });
 
 test("renders dense news rows and reacts to tab change", async () => {
@@ -119,6 +151,113 @@ test("renders dense news rows and reacts to tab change", async () => {
 
   await userEvent.click(screen.getByTestId("tab-latest"));
   await waitFor(() => expect(feedApi.fetchFeedNews).toHaveBeenCalledTimes(2));
+});
+
+test("renders research cards from the metadata-only research tab", async () => {
+  renderPage();
+
+  await screen.findByTestId("feed-item");
+  await userEvent.click(screen.getByTestId("tab-research"));
+
+  await waitFor(() => expect(feedResearchApi.fetchFeedResearch).toHaveBeenCalledWith({
+    tab: "latest",
+    limit: 30,
+    source: undefined,
+    symbol: undefined,
+    analyst: undefined,
+    category: undefined,
+    query: undefined,
+    fromDate: undefined,
+    toDate: undefined,
+  }));
+  expect(feedApi.fetchFeedNews).not.toHaveBeenCalledWith(expect.objectContaining({ tab: "research" }));
+
+  const row = await screen.findByTestId("research-feed-item");
+  expect(row).toHaveTextContent("리서치");
+  expect(row).toHaveTextContent("kis_research");
+  expect(row).toHaveTextContent("기업분석");
+  expect(row).toHaveTextContent("홍길동");
+  expect(row).toHaveTextContent("영업이익 추정치와 목표가 변경 요약");
+  expect(row).toHaveTextContent("Korea Investment & Securities");
+  expect(row).toHaveTextContent("© Korea Investment");
+  expect(screen.getByRole("link", { name: "삼성전자 2Q 프리뷰" })).toHaveAttribute(
+    "href",
+    "https://example.com/research/1",
+  );
+  expect(screen.getByRole("link", { name: "원문 PDF" })).toHaveAttribute(
+    "href",
+    "https://example.com/research/1.pdf",
+  );
+  const chip = screen.getByTestId("research-symbol-chip");
+  expect(chip).toHaveAttribute("data-symbol", "005930");
+  expect(chip).toHaveAttribute("data-market", "kr");
+  expect(chip).toHaveTextContent("005930");
+  expect(chip).toHaveTextContent("· KR");
+  expect(chip).toHaveTextContent("삼성전자");
+  expect(row.querySelectorAll("button a, a button, button button, a a")).toHaveLength(0);
+});
+
+test("renders research-specific empty state", async () => {
+  vi.spyOn(feedResearchApi, "fetchFeedResearch").mockResolvedValue(researchResponse({ items: [] }));
+
+  renderPage();
+  await screen.findByTestId("feed-item");
+  await userEvent.click(screen.getByTestId("tab-research"));
+
+  expect(await screen.findByTestId("feed-research-empty")).toHaveTextContent("표시할 리서치 리포트가 없습니다.");
+});
+
+test("research cards ignore unsafe links and tolerate unknown candidate markets", async () => {
+  vi.spyOn(feedResearchApi, "fetchFeedResearch").mockResolvedValue(researchResponse({
+    items: [
+      {
+        id: 2,
+        source: "kis_research",
+        title: "안전 링크 검증 리서치",
+        publishedAtText: "2026.05.10",
+        detailUrl: "javascript:alert(1)",
+        pdfUrl: "data:text/plain,report",
+        excerpt: "링크 프로토콜과 시장 값을 방어적으로 처리합니다.",
+        symbolCandidates: [{ symbol: "TEST", market: null }],
+        relation: "none",
+      },
+    ],
+  }));
+
+  renderPage();
+  await screen.findByTestId("feed-item");
+  await userEvent.click(screen.getByTestId("tab-research"));
+
+  const row = await screen.findByTestId("research-feed-item");
+  expect(row).toHaveTextContent("안전 링크 검증 리서치");
+  expect(screen.queryByRole("link", { name: "안전 링크 검증 리서치" })).not.toBeInTheDocument();
+  expect(screen.queryByRole("link", { name: "원문 PDF" })).not.toBeInTheDocument();
+  const chip = screen.getByTestId("research-symbol-chip");
+  expect(chip).toHaveAttribute("data-symbol", "TEST");
+  expect(chip).not.toHaveAttribute("data-market");
+  expect(chip).toHaveTextContent("UNKNOWN");
+});
+
+test("passes research URL filters without changing ordinary news calls", async () => {
+  render(
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/feed/news?symbol=005930&category=기업분석"]}>
+        <DesktopFeedNewsPage />
+      </MemoryRouter>
+    </AccountPanelProvider>,
+  );
+
+  await screen.findByTestId("feed-item");
+  await userEvent.click(screen.getByTestId("tab-research"));
+
+  await waitFor(() =>
+    expect(feedResearchApi.fetchFeedResearch).toHaveBeenCalledWith(expect.objectContaining({
+      tab: "latest",
+      symbol: "005930",
+      category: "기업분석",
+    })),
+  );
+  expect(feedApi.fetchFeedNews).toHaveBeenCalledWith({ tab: "top", limit: 30 });
 });
 
 test("renders an issue chip linked to the issue detail page when issueId is present", async () => {

--- a/frontend/invest/src/__tests__/MobileFeedResearchPage.test.tsx
+++ b/frontend/invest/src/__tests__/MobileFeedResearchPage.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, expect, test, vi } from "vitest";
+import * as feedApi from "../api/feedNews";
+import * as feedResearchApi from "../api/feedResearch";
+import { MobileFeedNewsPage } from "../pages/mobile/MobileFeedNewsPage";
+import type { FeedNewsResponse } from "../types/feedNews";
+import type { FeedResearchResponse } from "../types/feedResearch";
+
+function feedResponse(): FeedNewsResponse {
+  return {
+    tab: "top",
+    asOf: "2026-05-10T00:00:00Z",
+    issues: [],
+    items: [
+      {
+        id: 1,
+        title: "모바일 뉴스",
+        market: "kr",
+        sourceMarket: "kr",
+        relatedSymbols: [],
+        relation: "none",
+        url: "https://example.com/news/1",
+      },
+    ],
+    meta: { warnings: [] },
+  };
+}
+
+function researchResponse(): FeedResearchResponse {
+  return {
+    tab: "latest",
+    asOf: "2026-05-10T00:00:00Z",
+    items: [
+      {
+        id: 1,
+        source: "kis_research",
+        title: "모바일 리서치",
+        analyst: "홍길동",
+        publishedAtText: "2026.05.10",
+        category: "산업분석",
+        detailUrl: "https://example.com/research/mobile",
+        pdfUrl: "https://example.com/research/mobile.pdf",
+        excerpt: "모바일에서도 compact citation만 표시합니다.",
+        symbolCandidates: [{ symbol: "000660", market: "kr", displayName: "SK하이닉스" }],
+        attributionPublisher: "Korea Investment & Securities",
+        relation: "mine",
+      },
+    ],
+    meta: { limit: 30, appliedFilters: {} },
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter basename="/invest" initialEntries={["/invest/feed/news"]}>
+      <MobileFeedNewsPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.spyOn(feedApi, "fetchFeedNews").mockResolvedValue(feedResponse());
+  vi.spyOn(feedResearchApi, "fetchFeedResearch").mockResolvedValue(researchResponse());
+});
+
+test("renders research cards in the mobile feed seam", async () => {
+  renderPage();
+
+  expect(await screen.findByText("모바일 뉴스")).toBeInTheDocument();
+  await userEvent.click(screen.getByTestId("tab-research"));
+
+  await waitFor(() => expect(feedResearchApi.fetchFeedResearch).toHaveBeenCalledWith(expect.objectContaining({ tab: "latest", limit: 30 })));
+  expect(feedApi.fetchFeedNews).toHaveBeenCalledTimes(1);
+
+  const row = await screen.findByTestId("research-feed-item");
+  expect(row).toHaveTextContent("모바일 리서치");
+  expect(row).toHaveTextContent("리서치");
+  expect(row).toHaveTextContent("산업분석");
+  expect(row).toHaveTextContent("홍길동");
+  expect(row).toHaveTextContent("보유");
+  expect(row).toHaveTextContent("모바일에서도 compact citation만 표시합니다.");
+  expect(screen.getByRole("link", { name: "모바일 리서치" })).toHaveAttribute(
+    "href",
+    "https://example.com/research/mobile",
+  );
+  expect(screen.getByRole("link", { name: "원문 PDF" })).toHaveAttribute(
+    "href",
+    "https://example.com/research/mobile.pdf",
+  );
+  const chip = screen.getByTestId("research-symbol-chip");
+  expect(chip).toHaveAttribute("data-symbol", "000660");
+  expect(chip).toHaveAttribute("data-market", "kr");
+  expect(chip).toHaveTextContent("SK하이닉스");
+  expect(row.querySelectorAll("button a, a button, button button, a a")).toHaveLength(0);
+});

--- a/frontend/invest/src/__tests__/NewsTabs.test.tsx
+++ b/frontend/invest/src/__tests__/NewsTabs.test.tsx
@@ -12,6 +12,7 @@ describe("NewsTabs", () => {
     expect(screen.getByTestId("tab-top")).toHaveTextContent("주요뉴스");
     expect(screen.getByTestId("tab-latest")).toHaveTextContent("최신뉴스");
     expect(screen.getByTestId("tab-hot")).toHaveTextContent("급상승뉴스");
+    expect(screen.getByTestId("tab-research")).toHaveTextContent("리서치");
 
     expect(screen.queryByTestId("tab-kr")).not.toBeInTheDocument();
     expect(screen.queryByTestId("tab-us")).not.toBeInTheDocument();
@@ -25,6 +26,7 @@ describe("NewsTabs", () => {
       "top",
       "latest",
       "hot",
+      "research",
     ]);
     expect(SECONDARY_NEWS_TABS.map((t) => t.key)).toEqual(["kr", "us", "crypto"]);
     expect(NEWS_TABS.map((t) => t.key)).toEqual([
@@ -33,6 +35,7 @@ describe("NewsTabs", () => {
       "top",
       "latest",
       "hot",
+      "research",
       "kr",
       "us",
       "crypto",

--- a/frontend/invest/src/__tests__/feedResearch.api.test.ts
+++ b/frontend/invest/src/__tests__/feedResearch.api.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { fetchFeedResearch } from "../api/feedResearch";
+import type { FeedResearchResponse } from "../types/feedResearch";
+
+const response: FeedResearchResponse = {
+  tab: "latest",
+  asOf: "2026-05-10T00:00:00Z",
+  items: [],
+  nextCursor: null,
+  meta: { limit: 30, appliedFilters: {} },
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test("calls feed research API with credentials and camel-case filters", async () => {
+  const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => response });
+  vi.stubGlobal("fetch", fetchMock);
+
+  await expect(
+    fetchFeedResearch({
+      tab: "latest",
+      limit: 30,
+      cursor: "cursor-1",
+      source: "kis_research",
+      symbol: "005930",
+      analyst: "홍길동",
+      category: "기업분석",
+      query: "반도체",
+      fromDate: "2026-05-01",
+      toDate: "2026-05-10",
+    }),
+  ).resolves.toEqual(response);
+
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  const [url, init] = fetchMock.mock.calls[0]!;
+  expect(init).toEqual({ credentials: "include" });
+  expect(String(url)).toMatch(/^\/invest\/api\/feed\/research\?/);
+  const params = new URLSearchParams(String(url).split("?")[1]);
+  expect(params.get("tab")).toBe("latest");
+  expect(params.get("limit")).toBe("30");
+  expect(params.get("cursor")).toBe("cursor-1");
+  expect(params.get("source")).toBe("kis_research");
+  expect(params.get("symbol")).toBe("005930");
+  expect(params.get("analyst")).toBe("홍길동");
+  expect(params.get("category")).toBe("기업분석");
+  expect(params.get("query")).toBe("반도체");
+  expect(params.get("fromDate")).toBe("2026-05-01");
+  expect(params.get("toDate")).toBe("2026-05-10");
+  expect(params.has("from_date")).toBe(false);
+  expect(params.has("to_date")).toBe(false);
+});
+
+test("rejects non-OK responses with endpoint and status", async () => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+
+  await expect(fetchFeedResearch({ tab: "latest" })).rejects.toThrow("feed/research 401");
+});

--- a/frontend/invest/src/api/feedResearch.ts
+++ b/frontend/invest/src/api/feedResearch.ts
@@ -1,0 +1,29 @@
+import type { FeedResearchResponse, FeedResearchTab } from "../types/feedResearch";
+
+export async function fetchFeedResearch(params: {
+  tab: FeedResearchTab;
+  limit?: number;
+  cursor?: string;
+  source?: string;
+  symbol?: string;
+  analyst?: string;
+  category?: string;
+  query?: string;
+  fromDate?: string;
+  toDate?: string;
+}): Promise<FeedResearchResponse> {
+  const q = new URLSearchParams();
+  q.set("tab", params.tab);
+  if (params.limit !== undefined) q.set("limit", String(params.limit));
+  if (params.cursor) q.set("cursor", params.cursor);
+  if (params.source) q.set("source", params.source);
+  if (params.symbol) q.set("symbol", params.symbol);
+  if (params.analyst) q.set("analyst", params.analyst);
+  if (params.category) q.set("category", params.category);
+  if (params.query) q.set("query", params.query);
+  if (params.fromDate) q.set("fromDate", params.fromDate);
+  if (params.toDate) q.set("toDate", params.toDate);
+  const res = await fetch(`/invest/api/feed/research?${q}`, { credentials: "include" });
+  if (!res.ok) throw new Error(`feed/research ${res.status}`);
+  return res.json();
+}

--- a/frontend/invest/src/components/news/NewsTabs.tsx
+++ b/frontend/invest/src/components/news/NewsTabs.tsx
@@ -1,11 +1,14 @@
 import type { FeedTab } from "../../types/feedNews";
 
-export const PRIMARY_NEWS_TABS: { key: FeedTab; label: string }[] = [
+export type FeedContentTab = FeedTab | "research";
+
+export const PRIMARY_NEWS_TABS: { key: FeedContentTab; label: string }[] = [
   { key: "holdings", label: "보유주식" },
   { key: "watchlist", label: "관심주식" },
   { key: "top", label: "주요뉴스" },
   { key: "latest", label: "최신뉴스" },
   { key: "hot", label: "급상승뉴스" },
+  { key: "research", label: "리서치" },
 ];
 
 export const SECONDARY_NEWS_TABS: { key: FeedTab; label: string }[] = [
@@ -14,7 +17,7 @@ export const SECONDARY_NEWS_TABS: { key: FeedTab; label: string }[] = [
   { key: "crypto", label: "크립토" },
 ];
 
-export const NEWS_TABS: { key: FeedTab; label: string }[] = [
+export const NEWS_TABS: { key: FeedContentTab; label: string }[] = [
   ...PRIMARY_NEWS_TABS,
   ...SECONDARY_NEWS_TABS,
 ];
@@ -24,8 +27,8 @@ export function NewsTabs({
   onChange,
   variant = "underline",
 }: {
-  value: FeedTab;
-  onChange: (tab: FeedTab) => void;
+  value: FeedContentTab;
+  onChange: (tab: FeedContentTab) => void;
   variant?: "underline" | "pill-row";
 }) {
   const visibleTabs = PRIMARY_NEWS_TABS;

--- a/frontend/invest/src/components/news/ResearchListItem.tsx
+++ b/frontend/invest/src/components/news/ResearchListItem.tsx
@@ -1,0 +1,245 @@
+import { formatRelativeTime } from "../../format/relativeTime";
+import { Pill } from "../../ds";
+import type { FeedResearchItem, ResearchMarket, ResearchSymbolCandidate } from "../../types/feedResearch";
+
+const MARKET_LABEL: Record<ResearchMarket, string> = {
+  kr: "KR",
+  us: "US",
+  crypto: "CRYPTO",
+};
+
+const RELATION_LABEL = {
+  mine: "보유",
+  watch: "관심",
+} as const;
+
+interface ResearchListItemProps {
+  item: FeedResearchItem;
+  variant?: "desktop" | "mobile";
+}
+
+function clean(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function displayDate(item: FeedResearchItem): string {
+  return formatRelativeTime(item.publishedAt) ?? clean(item.publishedAtText) ?? "시간 미상";
+}
+
+function displaySymbol(candidate: ResearchSymbolCandidate): string | null {
+  return clean(candidate.displayName) ?? clean(candidate.name);
+}
+
+function displayMarketLabel(market: ResearchSymbolCandidate["market"]): string {
+  if (market === "kr" || market === "us" || market === "crypto") return MARKET_LABEL[market];
+  return clean(market) ?? "UNKNOWN";
+}
+
+function safeExternalUrl(value: string | null | undefined): string | null {
+  const trimmed = clean(value);
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "https:" || url.protocol === "http:" ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+function SymbolCandidateChip({ candidate }: { candidate: ResearchSymbolCandidate }) {
+  const marketLabel = displayMarketLabel(candidate.market);
+  const market = clean(candidate.market);
+  const name = displaySymbol(candidate);
+  return (
+    <span
+      data-testid="research-symbol-chip"
+      data-symbol={candidate.symbol}
+      data-market={market ?? undefined}
+      title={clean(candidate.reason) ?? clean(candidate.source) ?? undefined}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 5,
+        minHeight: 24,
+        padding: "2px 8px",
+        borderRadius: 999,
+        border: "1px solid var(--border)",
+        background: "var(--surface-2)",
+        color: "var(--fg-2)",
+        fontSize: 11,
+        fontFamily: "var(--font-mono)",
+        whiteSpace: "nowrap",
+      }}
+    >
+      <strong style={{ color: "var(--fg)", fontWeight: 800 }}>{candidate.symbol}</strong>
+      <span style={{ color: "var(--fg-3)", fontFamily: "var(--font-sans)" }}>· {marketLabel}</span>
+      {name && (
+        <span style={{ fontFamily: "var(--font-sans)", overflow: "hidden", textOverflow: "ellipsis" }}>{name}</span>
+      )}
+    </span>
+  );
+}
+
+export function ResearchListItem({ item, variant = "desktop" }: ResearchListItemProps) {
+  const source = clean(item.source) ?? "출처 미상";
+  const category = clean(item.category);
+  const analyst = clean(item.analyst);
+  const excerpt = clean(item.excerpt);
+  const relationLabel = item.relation === "none" ? null : RELATION_LABEL[item.relation];
+  const attributionPublisher = clean(item.attributionPublisher);
+  const attributionNotice = clean(item.attributionCopyrightNotice);
+  const title = clean(item.title) ?? "제목 없는 리서치";
+  const symbolCandidates = item.symbolCandidates ?? [];
+  const detailUrl = safeExternalUrl(item.detailUrl);
+  const pdfUrl = safeExternalUrl(item.pdfUrl);
+
+  return (
+    <li data-testid="research-feed-item" data-relation={item.relation} style={{ listStyle: "none" }}>
+      <article
+        style={{
+          background: "var(--surface)",
+          border: "1px solid var(--border)",
+          borderRadius: 16,
+          boxShadow: "var(--shadow-1)",
+          padding: variant === "mobile" ? "12px 13px" : "13px 15px",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
+              flexWrap: "wrap",
+              color: "var(--fg-3)",
+              fontSize: 12,
+              lineHeight: 1.35,
+            }}
+          >
+            <Pill tone="accent" size="sm">리서치</Pill>
+            <span>{source}</span>
+            {category && (
+              <>
+                <span aria-hidden>·</span>
+                <span>{category}</span>
+              </>
+            )}
+            {analyst && (
+              <>
+                <span aria-hidden>·</span>
+                <span>{analyst}</span>
+              </>
+            )}
+            <span aria-hidden>·</span>
+            <span>{displayDate(item)}</span>
+            {relationLabel && <Pill tone="kis" size="sm">{relationLabel}</Pill>}
+          </div>
+
+          <div style={{ display: "flex", alignItems: "flex-start", gap: 12 }}>
+            <div
+              aria-hidden
+              style={{
+                flex: "0 0 auto",
+                width: variant === "mobile" ? 52 : 60,
+                height: variant === "mobile" ? 52 : 60,
+                borderRadius: 14,
+                background: "linear-gradient(135deg, var(--accent-soft), var(--surface-2))",
+                border: "1px solid var(--border)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "var(--accent-press)",
+                fontSize: 18,
+                fontWeight: 800,
+              }}
+            >
+              R
+            </div>
+            {detailUrl ? (
+              <a
+                href={detailUrl}
+                target="_blank"
+                rel="noreferrer"
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  color: "var(--fg)",
+                  fontSize: variant === "mobile" ? 15 : 16,
+                  fontWeight: 800,
+                  lineHeight: 1.38,
+                  letterSpacing: "-0.02em",
+                  textDecoration: "none",
+                }}
+              >
+                {title}
+              </a>
+            ) : (
+              <strong
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  color: "var(--fg)",
+                  fontSize: variant === "mobile" ? 15 : 16,
+                  fontWeight: 800,
+                  lineHeight: 1.38,
+                  letterSpacing: "-0.02em",
+                }}
+              >
+                {title}
+              </strong>
+            )}
+          </div>
+
+          {excerpt && (
+            <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.55 }}>{excerpt}</p>
+          )}
+
+          {(pdfUrl || symbolCandidates.length > 0) && (
+            <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+              {pdfUrl && (
+                <a
+                  href={pdfUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    minHeight: 24,
+                    padding: "2px 10px",
+                    borderRadius: 999,
+                    background: "var(--surface-2)",
+                    border: "1px solid var(--border)",
+                    color: "var(--fg-2)",
+                    fontSize: 12,
+                    fontWeight: 700,
+                    textDecoration: "none",
+                  }}
+                >
+                  원문 PDF
+                </a>
+              )}
+              {symbolCandidates.map((candidate) => (
+                <SymbolCandidateChip key={`${candidate.market}:${candidate.symbol}`} candidate={candidate} />
+              ))}
+            </div>
+          )}
+
+          {(attributionPublisher || attributionNotice) && (
+            <footer
+              style={{
+                borderTop: "1px solid var(--divider)",
+                paddingTop: 8,
+                color: "var(--fg-3)",
+                fontSize: 11,
+                lineHeight: 1.45,
+              }}
+            >
+              {[attributionPublisher, attributionNotice].filter(Boolean).join(" · ")}
+            </footer>
+          )}
+        </div>
+      </article>
+    </li>
+  );
+}

--- a/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
@@ -1,11 +1,15 @@
 import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useViewport } from "../../hooks/useViewport";
 import { fetchFeedNews } from "../../api/feedNews";
-import type { FeedNewsResponse, FeedTab } from "../../types/feedNews";
-import { NewsTabs } from "../../components/news/NewsTabs";
+import { fetchFeedResearch } from "../../api/feedResearch";
+import type { FeedNewsResponse } from "../../types/feedNews";
+import type { FeedResearchResponse } from "../../types/feedResearch";
+import { NewsTabs, type FeedContentTab } from "../../components/news/NewsTabs";
 import { NewsListItem } from "../../components/news/NewsListItem";
+import { ResearchListItem } from "../../components/news/ResearchListItem";
 import { MobileFeedNewsPage } from "../mobile/MobileFeedNewsPage";
 
 function emptyMessage(reason: string | null | undefined): string {
@@ -15,32 +19,61 @@ function emptyMessage(reason: string | null | undefined): string {
   return "표시할 뉴스가 없습니다.";
 }
 
+function getParam(searchParams: URLSearchParams, key: string): string | undefined {
+  return searchParams.get(key)?.trim() || undefined;
+}
+
 export function FeedNewsRoute() {
   const viewport = useViewport();
   return viewport === "mobile" ? <MobileFeedNewsPage /> : <DesktopFeedNewsPage />;
 }
 
 export function DesktopFeedNewsPage() {
-  const [tab, setTab] = useState<FeedTab>("top");
+  const [searchParams] = useSearchParams();
+  const [tab, setTab] = useState<FeedContentTab>("top");
   const [data, setData] = useState<FeedNewsResponse | undefined>();
+  const [researchData, setResearchData] = useState<FeedResearchResponse | undefined>();
   const [err, setErr] = useState<string | undefined>();
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
   useEffect(() => {
     let cancel = false;
-    setData(undefined);
     setErr(undefined);
-    fetchFeedNews({ tab, limit: 30 })
-      .then((r) => !cancel && setData(r))
-      .catch((e) => !cancel && setErr(String(e?.message ?? e)));
+    setSelectedId(null);
+
+    if (tab === "research") {
+      setResearchData(undefined);
+      fetchFeedResearch({
+        tab: "latest",
+        limit: 30,
+        source: getParam(searchParams, "source"),
+        symbol: getParam(searchParams, "symbol"),
+        analyst: getParam(searchParams, "analyst"),
+        category: getParam(searchParams, "category"),
+        query: getParam(searchParams, "query"),
+        fromDate: getParam(searchParams, "fromDate"),
+        toDate: getParam(searchParams, "toDate"),
+      })
+        .then((r) => !cancel && setResearchData(r))
+        .catch((e) => !cancel && setErr(String(e?.message ?? e)));
+    } else {
+      setData(undefined);
+      fetchFeedNews({ tab, limit: 30 })
+        .then((r) => !cancel && setData(r))
+        .catch((e) => !cancel && setErr(String(e?.message ?? e)));
+    }
+
     return () => {
       cancel = true;
     };
-  }, [tab]);
+  }, [tab, searchParams]);
 
+  const researchMode = tab === "research";
   const issueById = new Map((data?.issues ?? []).map((i) => [i.id, i] as const));
-  const loading = !data && !err;
-  const empty = Boolean(data && data.items.length === 0);
+  const loading = researchMode ? !researchData && !err : !data && !err;
+  const empty = researchMode
+    ? Boolean(researchData && researchData.items.length === 0)
+    : Boolean(data && data.items.length === 0);
 
   return (
     <DesktopShell
@@ -49,7 +82,7 @@ export function DesktopFeedNewsPage() {
           <header>
             <h1 style={{ margin: 0, fontSize: 22, fontWeight: 800, letterSpacing: "-0.02em" }}>뉴스</h1>
             <p style={{ margin: "4px 0 0", fontSize: 13, color: "var(--fg-3)" }}>
-              보유 · 관심 종목 관련 기사를 우선 보여드립니다.
+              보유 · 관심 종목 관련 기사와 리서치 자료를 우선 보여드립니다.
             </p>
           </header>
 
@@ -58,30 +91,38 @@ export function DesktopFeedNewsPage() {
           <div data-testid="feed-center">
             {err && <div style={{ color: "var(--danger)", marginBottom: 12 }}>오류: {err}</div>}
             {loading && (
-              <div data-testid="feed-news-loading" style={{ padding: 16, color: "var(--fg-3)" }}>
-                최신 뉴스를 불러오는 중입니다…
+              <div data-testid={researchMode ? "feed-research-loading" : "feed-news-loading"} style={{ padding: 16, color: "var(--fg-3)" }}>
+                {researchMode ? "리서치 자료를 불러오는 중입니다…" : "최신 뉴스를 불러오는 중입니다…"}
               </div>
             )}
             {empty && (
-              <div data-testid="feed-news-empty" style={{ padding: 16, color: "var(--fg-3)" }}>
-                {emptyMessage(data?.meta?.emptyReason)}
+              <div data-testid={researchMode ? "feed-research-empty" : "feed-news-empty"} style={{ padding: 16, color: "var(--fg-3)" }}>
+                {researchMode ? "표시할 리서치 리포트가 없습니다." : emptyMessage(data?.meta?.emptyReason)}
               </div>
             )}
-            <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 8 }}>
-              {(data?.items ?? []).map((it) => {
-                const open = selectedId === it.id;
-                const linkedIssue = it.issueId ? issueById.get(it.issueId) : undefined;
-                return (
-                  <NewsListItem
-                    key={it.id}
-                    item={it}
-                    issue={linkedIssue}
-                    open={open}
-                    onToggle={() => setSelectedId(open ? null : it.id)}
-                  />
-                );
-              })}
-            </ul>
+            {researchMode ? (
+              <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 8 }}>
+                {(researchData?.items ?? []).map((it) => (
+                  <ResearchListItem key={it.id} item={it} />
+                ))}
+              </ul>
+            ) : (
+              <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 8 }}>
+                {(data?.items ?? []).map((it) => {
+                  const open = selectedId === it.id;
+                  const linkedIssue = it.issueId ? issueById.get(it.issueId) : undefined;
+                  return (
+                    <NewsListItem
+                      key={it.id}
+                      item={it}
+                      issue={linkedIssue}
+                      open={open}
+                      onToggle={() => setSelectedId(open ? null : it.id)}
+                    />
+                  );
+                })}
+              </ul>
+            )}
           </div>
         </>
       }

--- a/frontend/invest/src/pages/mobile/MobileFeedNewsPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileFeedNewsPage.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { MobileShell } from "../../mobile/MobileShell";
 import { fetchFeedNews } from "../../api/feedNews";
-import type { FeedNewsResponse, FeedTab } from "../../types/feedNews";
-import { NewsTabs } from "../../components/news/NewsTabs";
+import { fetchFeedResearch } from "../../api/feedResearch";
+import type { FeedNewsResponse } from "../../types/feedNews";
+import type { FeedResearchResponse } from "../../types/feedResearch";
+import { NewsTabs, type FeedContentTab } from "../../components/news/NewsTabs";
 import { NewsListItem } from "../../components/news/NewsListItem";
+import { ResearchListItem } from "../../components/news/ResearchListItem";
 
 function emptyMessage(reason: string | null | undefined): string {
   if (reason === "no_holdings") return "보유 종목이 없습니다.";
@@ -12,27 +16,56 @@ function emptyMessage(reason: string | null | undefined): string {
   return "표시할 뉴스가 없습니다.";
 }
 
+function getParam(searchParams: URLSearchParams, key: string): string | undefined {
+  return searchParams.get(key)?.trim() || undefined;
+}
+
 export function MobileFeedNewsPage() {
-  const [tab, setTab] = useState<FeedTab>("top");
+  const [searchParams] = useSearchParams();
+  const [tab, setTab] = useState<FeedContentTab>("top");
   const [data, setData] = useState<FeedNewsResponse | undefined>();
+  const [researchData, setResearchData] = useState<FeedResearchResponse | undefined>();
   const [err, setErr] = useState<string | undefined>();
   const [selectedId, setSelectedId] = useState<number | null>(null);
 
   useEffect(() => {
     let cancel = false;
-    setData(undefined);
     setErr(undefined);
-    fetchFeedNews({ tab, limit: 30 })
-      .then((r) => !cancel && setData(r))
-      .catch((e) => !cancel && setErr(String(e?.message ?? e)));
+    setSelectedId(null);
+
+    if (tab === "research") {
+      setResearchData(undefined);
+      fetchFeedResearch({
+        tab: "latest",
+        limit: 30,
+        source: getParam(searchParams, "source"),
+        symbol: getParam(searchParams, "symbol"),
+        analyst: getParam(searchParams, "analyst"),
+        category: getParam(searchParams, "category"),
+        query: getParam(searchParams, "query"),
+        fromDate: getParam(searchParams, "fromDate"),
+        toDate: getParam(searchParams, "toDate"),
+      })
+        .then((r) => !cancel && setResearchData(r))
+        .catch((e) => !cancel && setErr(String(e?.message ?? e)));
+    } else {
+      setData(undefined);
+      fetchFeedNews({ tab, limit: 30 })
+        .then((r) => !cancel && setData(r))
+        .catch((e) => !cancel && setErr(String(e?.message ?? e)));
+    }
+
     return () => {
       cancel = true;
     };
-  }, [tab]);
+  }, [tab, searchParams]);
 
+  const researchMode = tab === "research";
   const issueById = new Map((data?.issues ?? []).map((i) => [i.id, i] as const));
-  const loading = !data && !err;
-  const empty = Boolean(data && data.items.length === 0);
+  const loading = researchMode ? !researchData && !err : !data && !err;
+  const empty = researchMode
+    ? Boolean(researchData && researchData.items.length === 0)
+    : Boolean(data && data.items.length === 0);
 
   return (
     <MobileShell title="뉴스">
@@ -41,32 +74,40 @@ export function MobileFeedNewsPage() {
 
         {err && <div style={{ color: "var(--danger)" }}>오류: {err}</div>}
         {loading && (
-          <div data-testid="feed-news-loading" style={{ color: "var(--fg-3)" }}>
-            최신 뉴스를 불러오는 중입니다…
+          <div data-testid={researchMode ? "feed-research-loading" : "feed-news-loading"} style={{ color: "var(--fg-3)" }}>
+            {researchMode ? "리서치 자료를 불러오는 중입니다…" : "최신 뉴스를 불러오는 중입니다…"}
           </div>
         )}
         {empty && (
-          <div data-testid="feed-news-empty" style={{ color: "var(--fg-3)" }}>
-            {emptyMessage(data?.meta?.emptyReason)}
+          <div data-testid={researchMode ? "feed-research-empty" : "feed-news-empty"} style={{ color: "var(--fg-3)" }}>
+            {researchMode ? "표시할 리서치 리포트가 없습니다." : emptyMessage(data?.meta?.emptyReason)}
           </div>
         )}
 
-        <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 10 }}>
-          {(data?.items ?? []).map((it) => {
-            const open = selectedId === it.id;
-            const linkedIssue = it.issueId ? issueById.get(it.issueId) : undefined;
-            return (
-              <NewsListItem
-                key={it.id}
-                item={it}
-                issue={linkedIssue}
-                open={open}
-                onToggle={() => setSelectedId(open ? null : it.id)}
-                variant="mobile"
-              />
-            );
-          })}
-        </ul>
+        {researchMode ? (
+          <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 10 }}>
+            {(researchData?.items ?? []).map((it) => (
+              <ResearchListItem key={it.id} item={it} variant="mobile" />
+            ))}
+          </ul>
+        ) : (
+          <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 10 }}>
+            {(data?.items ?? []).map((it) => {
+              const open = selectedId === it.id;
+              const linkedIssue = it.issueId ? issueById.get(it.issueId) : undefined;
+              return (
+                <NewsListItem
+                  key={it.id}
+                  item={it}
+                  issue={linkedIssue}
+                  open={open}
+                  onToggle={() => setSelectedId(open ? null : it.id)}
+                  variant="mobile"
+                />
+              );
+            })}
+          </ul>
+        )}
       </div>
     </MobileShell>
   );

--- a/frontend/invest/src/types/feedResearch.ts
+++ b/frontend/invest/src/types/feedResearch.ts
@@ -1,0 +1,54 @@
+export type FeedResearchTab = "top" | "latest" | "mine" | "watchlist" | "holdings" | "kr" | "us";
+export type ResearchRelation = "mine" | "watch" | "none";
+export type ResearchMarket = "kr" | "us" | "crypto";
+
+export interface ResearchSymbolCandidate {
+  symbol: string;
+  market?: ResearchMarket | string | null;
+  name?: string | null;
+  displayName?: string | null;
+  confidence?: number | null;
+  source?: string | null;
+  reason?: string | null;
+}
+
+export interface FeedResearchItem {
+  id: number;
+  source: string;
+  title?: string | null;
+  analyst?: string | null;
+  publishedAtText?: string | null;
+  publishedAt?: string | null;
+  category?: string | null;
+  detailUrl?: string | null;
+  pdfUrl?: string | null;
+  excerpt?: string | null;
+  symbolCandidates: ResearchSymbolCandidate[];
+  attributionPublisher?: string | null;
+  attributionCopyrightNotice?: string | null;
+  market?: ResearchMarket | null;
+  relation: ResearchRelation;
+}
+
+export interface FeedResearchAppliedFilters {
+  source?: string | null;
+  symbol?: string | null;
+  analyst?: string | null;
+  category?: string | null;
+  query?: string | null;
+  fromDate?: string | null;
+  toDate?: string | null;
+}
+
+export interface FeedResearchMeta {
+  limit: number;
+  appliedFilters: FeedResearchAppliedFilters;
+}
+
+export interface FeedResearchResponse {
+  tab: FeedResearchTab;
+  asOf: string;
+  items: FeedResearchItem[];
+  nextCursor?: string | null;
+  meta: FeedResearchMeta;
+}


### PR DESCRIPTION
## Summary
- Adds metadata-only research/report cards to `/invest/feed/news` alongside the existing news feed.
- Wires `/invest/api/feed/research` into desktop/mobile feed pages with safe external detail/PDF links.
- Adds regression coverage for API mapping, desktop/mobile rendering, tab selection, and safe-link behavior.

## Verification
- Parent reviewer t_4f26ece6 approved commit `cc42fea198acdb6d171cfe9469748a4bdcd91866` with no findings.
- `cd frontend/invest && npm run typecheck` passed.
- `cd frontend/invest && npm test -- --run src/__tests__/feedResearch.api.test.ts src/__tests__/DesktopFeedNewsPage.test.tsx src/__tests__/MobileFeedResearchPage.test.tsx src/__tests__/NewsTabs.test.tsx` passed (4 files / 19 tests).
- `cd frontend/invest && npm run build` passed.
- `cd frontend/invest && npm run test -- --run` passed (52 files / 259 tests; pre-existing React act warnings in HomePage tests only).
- `git diff --check $(git merge-base HEAD ssh-origin/main)...HEAD` passed.
- Static safety scans found no broker/order/watch/order-intent/scheduler path changes and no forbidden full report body/raw HTML rendering.

## Safety / non-actions
- Read-only / metadata-first integration only.
- Does not store or render full PDF body, full extracted report text, raw copyrighted report body, or raw article HTML.
- Does not mutate broker, order, watch, order-intent, or scheduler paths.
- No scheduler activation.
- Planner/reviewer preference: Claude Code Opus preferred; implementer preference: Claude Code Sonnet preferred. Verified runtime enforcement was not available in the parent review because local Claude Code auth reported not logged in, so verification used Hermes direct inspection/tests plus an independent sub-review.

Closes ROB-180
