### PR TITLE
fix: use live WiseFn calendar endpoint

### DIFF
--- a/app/services/market_events/wisefn_helpers.py
+++ b/app/services/market_events/wisefn_helpers.py
@@ -30,9 +30,16 @@ Row shape returned by `fetch_wisefn_earnings_for_date`:
 
 WiseFn raw JSON response structure (euc-kr encoded bytes, ROB-183 verified):
     Endpoint:
-        https://wisereport.co.kr/GetCalendarAjax.aspx
+        https://www.wisereport.co.kr/wiseCalendar/GetCalendarAjax.aspx
             ?call_typ=2&param1=<YYYYMM>&param2=
     Response: a JSON array of earnings-schedule objects.  Each raw element has:
+        Current fields observed on the live endpoint:
+        - CMP_CD     : KR ticker prefixed with "A" (e.g. "A005930")
+        - CMP_NM_KOR : Korean company name, sometimes suffixed with " (연결)"
+        - WK_DT      : announcement date with weekday (e.g. "2026-05-13 (수)")
+        - VAL05      : fiscal period (e.g. "2026/03(분기)")
+
+        Historical fields still accepted for fixture/backward compatibility:
         - jongcode   : 6-digit KR stock code (string)
         - jongname   : company name (Korean, may be empty)
         - expect_dt  : expected announcement date  YYYYMMDD   (string)
@@ -55,8 +62,8 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-_WISEFN_BASE_URL = "https://wisereport.co.kr"
-_WISEFN_CALENDAR_PATH = "/GetCalendarAjax.aspx"
+_WISEFN_BASE_URL = "https://www.wisereport.co.kr"
+_WISEFN_CALENDAR_PATH = "/wiseCalendar/GetCalendarAjax.aspx"
 _WISEFN_TIMEOUT_SEC = 20.0
 _WISEFN_MAX_RETRIES = 3
 _WISEFN_BACKOFF_BASE_SEC = 1.0
@@ -72,7 +79,11 @@ _TIME_CODE_TO_HINT: dict[str, str] = {
 }
 
 
-def _parse_raw_wisefn_items(raw_list: list[Any]) -> list[dict[str, Any]]:
+def _parse_raw_wisefn_items(
+    raw_list: list[Any],
+    *,
+    as_of_ym: str | None = None,
+) -> list[dict[str, Any]]:
     """Map raw WiseFn response items to the normalized row shape.
 
     Field name lookup is case-insensitive to tolerate minor API drift.
@@ -87,7 +98,15 @@ def _parse_raw_wisefn_items(raw_list: list[Any]) -> list[dict[str, Any]]:
         item: dict[str, str] = {k.lower(): str(v) for k, v in raw.items()}
 
         stock_code = item.get("jongcode", "").strip()
-        corp_name = item.get("jongname", "").strip() or None
+        if not stock_code:
+            stock_code = item.get("cmp_cd", "").strip().removeprefix("A")
+
+        corp_name = item.get("jongname", "").strip()
+        if not corp_name:
+            corp_name = item.get("cmp_nm_kor", "").strip()
+            if corp_name.endswith(" (연결)"):
+                corp_name = corp_name[: -len(" (연결)")].strip()
+        corp_name = corp_name or None
 
         pub_yn = item.get("pub_yn", "N").strip().upper()
         release_type = "released" if pub_yn == "Y" else "scheduled"
@@ -102,6 +121,24 @@ def _parse_raw_wisefn_items(raw_list: list[Any]) -> list[dict[str, Any]]:
                 release_date = datetime.strptime(dt_str, "%Y%m%d").date().isoformat()
             except ValueError:
                 logger.debug("wisefn: bad date %r for %s", dt_str, stock_code)
+        if not release_date:
+            wk_dt = item.get("wk_dt", "").strip()
+            if len(wk_dt) >= 10:
+                try:
+                    release_date = date.fromisoformat(wk_dt[:10]).isoformat()
+                except ValueError:
+                    logger.debug("wisefn: bad WK_DT %r for %s", wk_dt, stock_code)
+        if not release_date and as_of_ym and len(as_of_ym) == 6:
+            day_dt = item.get("day_dt", "").strip()
+            if day_dt.isdigit():
+                try:
+                    release_date = date(
+                        int(as_of_ym[:4]),
+                        int(as_of_ym[4:]),
+                        int(day_dt),
+                    ).isoformat()
+                except ValueError:
+                    logger.debug("wisefn: bad DAY_DT %r for %s", day_dt, stock_code)
 
         if not release_date:
             logger.debug("wisefn: no usable date for item %r; skipping", item)
@@ -110,6 +147,10 @@ def _parse_raw_wisefn_items(raw_list: list[Any]) -> list[dict[str, Any]]:
         fiscal_year: int | None = None
         fiscal_quarter: int | None = None
         gyulsan_ym = item.get("gyulsan_ym", "").strip()
+        if not gyulsan_ym:
+            val05 = item.get("val05", "").strip()
+            if len(val05) >= 7 and val05[4:5] == "/":
+                gyulsan_ym = f"{val05[:4]}{val05[5:7]}"
         if len(gyulsan_ym) == 6:
             try:
                 fy_year = int(gyulsan_ym[:4])
@@ -188,7 +229,7 @@ async def _fetch_calendar_payload(target_date: date) -> dict[str, Any]:
             text = raw_bytes.decode("euc-kr", errors="replace")
             data = json.loads(text)
             raw_list: list[Any] = data if isinstance(data, list) else []
-            items = _parse_raw_wisefn_items(raw_list)
+            items = _parse_raw_wisefn_items(raw_list, as_of_ym=ym)
             logger.info(
                 "wisefn: fetched %d raw items → %d mapped for ym=%s",
                 len(raw_list),

--- a/tests/services/test_market_events_wisefn_helpers.py
+++ b/tests/services/test_market_events_wisefn_helpers.py
@@ -87,6 +87,25 @@ def _to_euc_kr_bytes(data: object) -> bytes:
 
 
 # ---------------------------------------------------------------------------
+# HTTP seam tests (no live WiseFn call)
+# ---------------------------------------------------------------------------
+
+
+def test_wisefn_http_base_url_uses_canonical_www_host():
+    """WiseFn redirects the apex host; use canonical www to avoid 301 retry loops."""
+    from app.services.market_events import wisefn_helpers as wf
+
+    assert wf._WISEFN_BASE_URL == "https://www.wisereport.co.kr"
+
+
+def test_wisefn_http_calendar_path_uses_live_wisecalendar_endpoint():
+    """Live WiseFn calendar JSON is served under /wiseCalendar/ in ROB-183 smoke."""
+    from app.services.market_events import wisefn_helpers as wf
+
+    assert wf._WISEFN_CALENDAR_PATH == "/wiseCalendar/GetCalendarAjax.aspx"
+
+
+# ---------------------------------------------------------------------------
 # Public coroutine tests (patch _fetch_calendar_payload)
 # ---------------------------------------------------------------------------
 
@@ -156,6 +175,42 @@ async def test_fetch_calendar_payload_decodes_euc_kr_and_maps_fields():
     hyundai = next(i for i in items if i["stock_code"] == "005380")
     assert hyundai["release_date"] == "2026-05-14"
     assert hyundai["time_hint"] == "during_market"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fetch_calendar_payload_maps_current_wisecalendar_fields():
+    """Current live /wiseCalendar fields map to normalized earnings rows."""
+    from app.services.market_events import wisefn_helpers as wf
+
+    current_item = [
+        {
+            "CMP_CD": "A005300",
+            "CMP_NM_KOR": "롯데칠성 (연결)",
+            "DAY_DT": "04",
+            "WK_DT": "2026-05-04 (월)",
+            "TERM_TYP": 32,
+            "VAL05": "2026/03(분기)",
+        }
+    ]
+    raw_bytes = _to_euc_kr_bytes(current_item)
+
+    with patch.object(wf, "_http_get_monthly", AsyncMock(return_value=raw_bytes)):
+        payload = await wf._fetch_calendar_payload(date(2026, 5, 4))
+
+    assert payload["as_of_ym"] == "202605"
+    assert payload["items"] == [
+        {
+            "stock_code": "005300",
+            "corp_name": "롯데칠성",
+            "release_date": "2026-05-04",
+            "fiscal_year": 2026,
+            "fiscal_quarter": 1,
+            "release_type": "scheduled",
+            "title": None,
+            "time_hint": "unknown",
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Switch WiseFn earnings-calendar fetches to the live `/wiseCalendar/GetCalendarAjax.aspx` endpoint on canonical `www.wisereport.co.kr`.
- Map the current live WiseFn field shape (`CMP_CD`, `CMP_NM_KOR`, `WK_DT`, `VAL05`) while preserving historical fixture field support.
- Add deterministic unit coverage for the endpoint seam and current live field mapping.

## Test plan
- `uv run pytest tests/services/test_market_events_wisefn_helpers.py tests/services/test_market_events_wisefn_normalizers.py tests/services/test_market_events_wisefn_ingestion.py tests/test_market_events_cli.py -q`
- `uv run ruff check app/services/market_events/wisefn_helpers.py tests/services/test_market_events_wisefn_helpers.py`
- Read-only live fetch/decode smoke: `_fetch_calendar_payload(date.today())` mapped 267 items for `202605`; `fetch_wisefn_earnings_for_date(date.today())` returned 20 rows.

## Safety
- No DB writes, backfill execution, scheduler activation, broker/order/watch/order-intent, live, paper, or mock trading side effects.

ROB-183