### PR TITLE
feat(ROB-191/ROB-192): add invest investor-flow and coverage dashboard

### DIFF
--- a/alembic/versions/9f1a2b3c4d5e_add_investor_flow_snapshots.py
+++ b/alembic/versions/9f1a2b3c4d5e_add_investor_flow_snapshots.py
@@ -1,0 +1,111 @@
+"""add investor flow snapshots
+
+Revision ID: 9f1a2b3c4d5e
+Revises: 82309c07b8a2
+Create Date: 2026-05-11 09:55:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "9f1a2b3c4d5e"
+down_revision: str | None = "82309c07b8a2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "investor_flow_snapshots",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("market", sa.String(length=8), nullable=False),
+        sa.Column("symbol", sa.String(length=20), nullable=False),
+        sa.Column("snapshot_date", sa.Date(), nullable=False),
+        sa.Column("foreign_net", sa.BigInteger(), nullable=True),
+        sa.Column("institution_net", sa.BigInteger(), nullable=True),
+        sa.Column("individual_net", sa.BigInteger(), nullable=True),
+        sa.Column("foreign_net_buy_rank", sa.Integer(), nullable=True),
+        sa.Column("foreign_net_sell_rank", sa.Integer(), nullable=True),
+        sa.Column("institution_net_buy_rank", sa.Integer(), nullable=True),
+        sa.Column("institution_net_sell_rank", sa.Integer(), nullable=True),
+        sa.Column("double_buy", sa.Boolean(), nullable=False),
+        sa.Column("double_sell", sa.Boolean(), nullable=False),
+        sa.Column("foreign_consecutive_buy_days", sa.Integer(), nullable=True),
+        sa.Column("foreign_consecutive_sell_days", sa.Integer(), nullable=True),
+        sa.Column("institution_consecutive_buy_days", sa.Integer(), nullable=True),
+        sa.Column("institution_consecutive_sell_days", sa.Integer(), nullable=True),
+        sa.Column("individual_consecutive_buy_days", sa.Integer(), nullable=True),
+        sa.Column("individual_consecutive_sell_days", sa.Integer(), nullable=True),
+        sa.Column("source", sa.String(length=32), nullable=False),
+        sa.Column(
+            "collected_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint("market IN ('kr')", name="ck_investor_flow_snapshots_market"),
+        sa.CheckConstraint(
+            "source IN ('naver_finance', 'kis', 'manual')",
+            name="ck_investor_flow_snapshots_source",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "market",
+            "symbol",
+            "snapshot_date",
+            "source",
+            name="uq_investor_flow_snapshots_market_symbol_date_source",
+        ),
+    )
+    op.create_index(
+        "ix_investor_flow_snapshots_market_symbol_date",
+        "investor_flow_snapshots",
+        ["market", "symbol", "snapshot_date"],
+    )
+    op.create_index(
+        "ix_investor_flow_snapshots_market_foreign_rank",
+        "investor_flow_snapshots",
+        ["market", "foreign_net_buy_rank"],
+        postgresql_where=sa.text("foreign_net_buy_rank IS NOT NULL"),
+    )
+    op.create_index(
+        "ix_investor_flow_snapshots_market_institution_rank",
+        "investor_flow_snapshots",
+        ["market", "institution_net_buy_rank"],
+        postgresql_where=sa.text("institution_net_buy_rank IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_investor_flow_snapshots_market_institution_rank",
+        table_name="investor_flow_snapshots",
+        postgresql_where=sa.text("institution_net_buy_rank IS NOT NULL"),
+    )
+    op.drop_index(
+        "ix_investor_flow_snapshots_market_foreign_rank",
+        table_name="investor_flow_snapshots",
+        postgresql_where=sa.text("foreign_net_buy_rank IS NOT NULL"),
+    )
+    op.drop_index(
+        "ix_investor_flow_snapshots_market_symbol_date",
+        table_name="investor_flow_snapshots",
+    )
+    op.drop_table("investor_flow_snapshots")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,7 @@
 # app/models/__init__.py
 from .analysis import StockAnalysisResult, StockInfo
 from .base import Base
+from .investor_flow_snapshot import InvestorFlowSnapshot
 from .kr_symbol_universe import KRSymbolUniverse
 from .manual_holdings import (
     BrokerAccount,
@@ -98,6 +99,7 @@ __all__ = [
     "TradeJournal",
     "StockInfo",
     "StockAnalysisResult",
+    "InvestorFlowSnapshot",
     "KRSymbolUniverse",
     "UpbitSymbolUniverse",
     "USSymbolUniverse",

--- a/app/models/investor_flow_snapshot.py
+++ b/app/models/investor_flow_snapshot.py
@@ -69,13 +69,19 @@ class InvestorFlowSnapshot(Base):
     foreign_net_buy_rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
     foreign_net_sell_rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
     institution_net_buy_rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    institution_net_sell_rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    institution_net_sell_rank: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )
 
     double_buy: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     double_sell: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
-    foreign_consecutive_buy_days: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    foreign_consecutive_sell_days: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    foreign_consecutive_buy_days: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )
+    foreign_consecutive_sell_days: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )
     institution_consecutive_buy_days: Mapped[int | None] = mapped_column(
         Integer, nullable=True
     )

--- a/app/models/investor_flow_snapshot.py
+++ b/app/models/investor_flow_snapshot.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    Date,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class InvestorFlowSnapshot(Base):
+    """Durable KR investor-flow/ranking snapshot for read-only /invest cards."""
+
+    __tablename__ = "investor_flow_snapshots"
+    __table_args__ = (
+        UniqueConstraint(
+            "market",
+            "symbol",
+            "snapshot_date",
+            "source",
+            name="uq_investor_flow_snapshots_market_symbol_date_source",
+        ),
+        CheckConstraint("market IN ('kr')", name="ck_investor_flow_snapshots_market"),
+        CheckConstraint(
+            "source IN ('naver_finance', 'kis', 'manual')",
+            name="ck_investor_flow_snapshots_source",
+        ),
+        Index(
+            "ix_investor_flow_snapshots_market_symbol_date",
+            "market",
+            "symbol",
+            "snapshot_date",
+        ),
+        Index(
+            "ix_investor_flow_snapshots_market_foreign_rank",
+            "market",
+            "foreign_net_buy_rank",
+            postgresql_where=text("foreign_net_buy_rank IS NOT NULL"),
+        ),
+        Index(
+            "ix_investor_flow_snapshots_market_institution_rank",
+            "market",
+            "institution_net_buy_rank",
+            postgresql_where=text("institution_net_buy_rank IS NOT NULL"),
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    market: Mapped[str] = mapped_column(String(8), nullable=False)
+    symbol: Mapped[str] = mapped_column(String(20), nullable=False)
+    snapshot_date: Mapped[date] = mapped_column(Date, nullable=False)
+
+    foreign_net: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    institution_net: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    individual_net: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+
+    foreign_net_buy_rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    foreign_net_sell_rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    institution_net_buy_rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    institution_net_sell_rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    double_buy: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    double_sell: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    foreign_consecutive_buy_days: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    foreign_consecutive_sell_days: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    institution_consecutive_buy_days: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )
+    institution_consecutive_sell_days: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )
+    individual_consecutive_buy_days: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )
+    individual_consecutive_sell_days: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )
+
+    source: Mapped[str] = mapped_column(String(32), nullable=False)
+    collected_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -20,6 +20,7 @@ from app.schemas.invest_calendar import (
     CalendarTab,
     WeeklySummaryResponse,
 )
+from app.schemas.invest_coverage import CoverageMarket, InvestCoverageResponse
 from app.schemas.invest_feed_news import FeedNewsResponse, FeedTab
 from app.schemas.invest_feed_research import (
     FeedResearchFilters,
@@ -38,6 +39,7 @@ from app.schemas.invest_stock_detail import (
     StockDetailResponse,
 )
 from app.schemas.investor_flow import InvestorFlowResponse
+from app.services.invest_coverage_service import build_invest_coverage
 from app.services.invest_home_service import InvestHomeService
 from app.services.invest_screener_snapshots.coverage_service import build_coverage
 from app.services.invest_view_model.account_panel_service import build_account_panel
@@ -109,6 +111,30 @@ async def get_home(
     service: Annotated[InvestHomeService, Depends(get_invest_home_service)],
 ) -> InvestHomeResponse:
     return await service.get_home(user_id=user.id)
+
+
+@router.get("/coverage")
+async def get_invest_coverage(
+    user: Annotated[Any, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    market: CoverageMarket = Query("kr"),
+    symbols: str = Query(
+        "", description="Optional comma-separated symbols for per-symbol coverage"
+    ),
+    as_of: Annotated[date | None, Query(alias="asOf")] = None,
+) -> InvestCoverageResponse:
+    """Read-only Toss-parity data coverage dashboard source (ROB-192)."""
+    _ = user
+    symbol_list = [part.strip() for part in symbols.split(",") if part.strip()]
+    try:
+        return await build_invest_coverage(
+            db,
+            market=market,
+            symbols=symbol_list,
+            as_of=as_of,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.get("/account-panel")

--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -37,12 +37,16 @@ from app.schemas.invest_stock_detail import (
     StockDetailOrdersResponse,
     StockDetailResponse,
 )
+from app.schemas.investor_flow import InvestorFlowResponse
 from app.services.invest_home_service import InvestHomeService
 from app.services.invest_screener_snapshots.coverage_service import build_coverage
 from app.services.invest_view_model.account_panel_service import build_account_panel
 from app.services.invest_view_model.calendar_service import build_calendar
 from app.services.invest_view_model.feed_news_service import build_feed_news
 from app.services.invest_view_model.feed_research_service import build_feed_research
+from app.services.invest_view_model.investor_flow_service import (
+    build_investor_flow_cards,
+)
 from app.services.invest_view_model.relation_resolver import build_relation_resolver
 from app.services.invest_view_model.screener_service import (
     build_screener_presets,
@@ -114,6 +118,29 @@ async def get_account_panel(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> AccountPanelResponse:
     return await build_account_panel(user_id=user.id, db=db, home_service=service)
+
+
+@router.get("/investor-flow")
+async def get_investor_flow(
+    user: Annotated[Any, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    symbols: str = Query("", description="Comma-separated KR symbols"),
+    market: Literal["kr"] = Query("kr"),
+    as_of: Annotated[date | None, Query(alias="asOf")] = None,
+    max_stale_days: Annotated[int, Query(alias="maxStaleDays", ge=0, le=30)] = 1,
+) -> InvestorFlowResponse:
+    _ = user
+    symbol_list = [part.strip() for part in symbols.split(",") if part.strip()]
+    try:
+        return await build_investor_flow_cards(
+            db=db,
+            symbols=symbol_list,
+            market=market,
+            as_of=as_of,
+            max_stale_days=max_stale_days,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 StockDetailMarketParam = Literal["kr", "us", "crypto"]

--- a/app/schemas/invest_coverage.py
+++ b/app/schemas/invest_coverage.py
@@ -1,0 +1,70 @@
+"""ROB-192 — read-only /invest Toss-parity data coverage schemas."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+CoverageState = Literal[
+    "fresh",
+    "stale",
+    "partial",
+    "missing",
+    "unsupported",
+    "error",
+    "provider_unwired",
+]
+CoverageMarket = Literal["kr", "us", "crypto", "all"]
+
+
+class InvestCoverageCounts(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected: int | None = None
+    fresh: int = 0
+    stale: int = 0
+    missing: int = 0
+    partial: int = 0
+    total: int = 0
+
+
+class InvestCoverageSurface(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    surface: str
+    label: str
+    state: CoverageState
+    market: str | None = None
+    sourceOfTruth: str
+    reference: str = "toss"
+    latestAt: datetime | None = None
+    latestDate: date | None = None
+    counts: InvestCoverageCounts = Field(default_factory=InvestCoverageCounts)
+    staleAfterHours: int | None = None
+    warnings: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
+class InvestCoverageSymbol(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    market: str
+    surfaces: dict[str, CoverageState] = Field(default_factory=dict)
+    latestDates: dict[str, date | None] = Field(default_factory=dict)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class InvestCoverageResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    market: CoverageMarket
+    asOf: datetime
+    tradingDate: date
+    states: list[CoverageState]
+    surfaces: list[InvestCoverageSurface]
+    symbols: list[InvestCoverageSymbol] = Field(default_factory=list)
+    gaps: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)

--- a/app/schemas/investor_flow.py
+++ b/app/schemas/investor_flow.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+InvestorFlowDataState = Literal["empty", "missing", "stale", "fresh", "partial"]
+
+
+class InvestorFlowItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    market: Literal["kr"] = "kr"
+    dataState: Literal["missing", "stale", "fresh"]
+    snapshotDate: date | None = None
+    collectedAt: datetime | None = None
+    source: str | None = None
+
+    foreignNet: int | None = None
+    institutionNet: int | None = None
+    individualNet: int | None = None
+
+    foreignNetBuyRank: int | None = None
+    foreignNetSellRank: int | None = None
+    institutionNetBuyRank: int | None = None
+    institutionNetSellRank: int | None = None
+
+    doubleBuy: bool = False
+    doubleSell: bool = False
+
+    foreignConsecutiveBuyDays: int | None = None
+    foreignConsecutiveSellDays: int | None = None
+    institutionConsecutiveBuyDays: int | None = None
+    institutionConsecutiveSellDays: int | None = None
+    individualConsecutiveBuyDays: int | None = None
+    individualConsecutiveSellDays: int | None = None
+
+
+class InvestorFlowResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    market: Literal["kr"] = "kr"
+    asOf: date
+    source: str | None = None
+    dataState: InvestorFlowDataState
+    items: list[InvestorFlowItem] = Field(default_factory=list)

--- a/app/services/invest_coverage_service.py
+++ b/app/services/invest_coverage_service.py
@@ -1,0 +1,821 @@
+"""ROB-192 — read-only Toss-parity data coverage rollup for /invest.
+
+The service only inspects local database/read-model tables. It intentionally does
+not call broker/provider clients, start collectors, or infer buy/sell logic.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.manual_holdings import ManualHolding, MarketType
+from app.models.market_events import MarketEventIngestionPartition
+from app.models.news import NewsArticle, NewsArticleRelatedSymbol, NewsIngestionRun
+from app.models.pending_order import PendingOrder
+from app.models.research_reports import ResearchReport, ResearchReportIngestionRun
+from app.models.us_symbol_universe import USSymbolUniverse
+from app.schemas.invest_coverage import (
+    CoverageMarket,
+    CoverageState,
+    InvestCoverageCounts,
+    InvestCoverageResponse,
+    InvestCoverageSurface,
+    InvestCoverageSymbol,
+)
+from app.services.invest_screener_snapshots.freshness import today_trading_date
+
+SUPPORTED_STATES: list[CoverageState] = [
+    "fresh",
+    "stale",
+    "partial",
+    "missing",
+    "unsupported",
+    "error",
+    "provider_unwired",
+]
+
+
+async def build_invest_coverage(
+    db: AsyncSession,
+    *,
+    market: CoverageMarket = "kr",
+    symbols: list[str] | None = None,
+    as_of: dt.date | None = None,
+) -> InvestCoverageResponse:
+    market_norm = market.lower()
+    if market_norm not in {"kr", "us", "crypto", "all"}:
+        raise ValueError("market must be one of kr, us, crypto, all")
+    symbol_list = _normalize_symbols(symbols or [])
+    trading_day = as_of or today_trading_date(
+        "us" if market_norm == "all" else market_norm
+    )
+    now = dt.datetime.now(dt.UTC)
+
+    surfaces: list[InvestCoverageSurface] = []
+    surfaces.extend(await _symbol_universe_surfaces(db, market_norm))
+    surfaces.extend(await _screener_surfaces(db, market_norm, trading_day))
+    surfaces.extend(await _news_surfaces(db, market_norm, now))
+    surfaces.extend(await _calendar_surfaces(db, market_norm, trading_day, now))
+    surfaces.extend(await _research_report_surfaces(db, market_norm, now))
+    surfaces.extend(await _investor_flow_surfaces(db, market_norm, trading_day))
+    surfaces.extend(await _holdings_surfaces(db, market_norm, now))
+    surfaces.extend(await _pending_order_surfaces(db, market_norm, now))
+    surfaces.extend(await _orderbook_nxt_surfaces(db, market_norm))
+    surfaces.extend(_provider_unwired_surfaces(market_norm))
+
+    symbol_rows = await _symbol_rows(db, market_norm, symbol_list, trading_day)
+    gaps = [
+        f"{surface.surface}: {', '.join(surface.warnings)}"
+        for surface in surfaces
+        if surface.state
+        in {"missing", "partial", "stale", "provider_unwired", "unsupported", "error"}
+        and surface.warnings
+    ]
+
+    return InvestCoverageResponse(
+        market=market_norm,  # type: ignore[arg-type]
+        asOf=now,
+        tradingDate=trading_day,
+        states=SUPPORTED_STATES,
+        surfaces=surfaces,
+        symbols=symbol_rows,
+        gaps=gaps,
+        notes=[
+            "Read-only coverage report; auto_trader DB/read models are source of truth.",
+            "Toss is used only as a parity benchmark/reference, not as a data source.",
+        ],
+    )
+
+
+def _normalize_symbols(symbols: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for symbol in symbols:
+        s = symbol.strip().upper()
+        if s and s not in seen:
+            seen.add(s)
+            out.append(s)
+    return out
+
+
+def _state_from_counts(
+    *, fresh: int, stale: int = 0, expected: int | None = None, total: int | None = None
+) -> CoverageState:
+    observed = fresh + stale if total is None else total
+    if observed == 0:
+        return "missing"
+    if expected is not None and expected > 0 and fresh == 0 and stale == 0:
+        return "missing"
+    if expected is not None and expected > 0 and observed < expected:
+        return "partial" if fresh > 0 else "stale"
+    if stale > 0 and fresh > 0:
+        return "partial"
+    if stale > 0:
+        return "stale"
+    return "fresh"
+
+
+async def _universe_count(db: AsyncSession, market: str) -> int | None:
+    if market == "kr":
+        stmt = (
+            sa.select(sa.func.count())
+            .select_from(KRSymbolUniverse)
+            .where(KRSymbolUniverse.is_active.is_(True))
+        )
+    elif market == "us":
+        stmt = (
+            sa.select(sa.func.count())
+            .select_from(USSymbolUniverse)
+            .where(USSymbolUniverse.is_active.is_(True))
+        )
+    else:
+        return None
+    return int((await db.execute(stmt)).scalar() or 0)
+
+
+async def _symbol_universe_surfaces(
+    db: AsyncSession, market: str
+) -> list[InvestCoverageSurface]:
+    markets = ["kr", "us"] if market == "all" else [market]
+    rows: list[InvestCoverageSurface] = []
+    for m in markets:
+        if m == "crypto":
+            rows.append(
+                InvestCoverageSurface(
+                    surface="symbol_universe",
+                    label="Symbol universe",
+                    market=m,
+                    state="provider_unwired",
+                    sourceOfTruth="upbit_symbol_universe/read_model_gap",
+                    warnings=[
+                        "Crypto universe exists separately and is not wired into /invest parity coverage yet."
+                    ],
+                )
+            )
+            continue
+        expected = await _universe_count(db, m) or 0
+        rows.append(
+            InvestCoverageSurface(
+                surface="symbol_universe",
+                label="Symbol universe",
+                market=m,
+                state="fresh" if expected > 0 else "missing",
+                sourceOfTruth=f"{m}_symbol_universe",
+                counts=InvestCoverageCounts(
+                    expected=expected, fresh=expected, total=expected
+                ),
+                warnings=[]
+                if expected > 0
+                else ["No active symbols found in local universe table."],
+            )
+        )
+    return rows
+
+
+async def _screener_surfaces(
+    db: AsyncSession, market: str, trading_day: dt.date
+) -> list[InvestCoverageSurface]:
+    markets = ["kr", "us"] if market == "all" else [market]
+    rows: list[InvestCoverageSurface] = []
+    for m in markets:
+        if m == "crypto":
+            rows.append(
+                InvestCoverageSurface(
+                    surface="screener_snapshots",
+                    label="Screener snapshots",
+                    market=m,
+                    state="unsupported",
+                    sourceOfTruth="invest_screener_snapshots",
+                    warnings=[
+                        "Screener snapshot read model currently supports KR/US equities only."
+                    ],
+                )
+            )
+            continue
+        expected = await _universe_count(db, m)
+        row = (
+            await db.execute(
+                sa.select(
+                    sa.func.count()
+                    .filter(InvestScreenerSnapshot.snapshot_date == trading_day)
+                    .label("fresh"),
+                    sa.func.count()
+                    .filter(InvestScreenerSnapshot.snapshot_date < trading_day)
+                    .label("stale"),
+                    sa.func.max(InvestScreenerSnapshot.computed_at).label("latest_at"),
+                    sa.func.max(InvestScreenerSnapshot.snapshot_date).label(
+                        "latest_date"
+                    ),
+                ).where(InvestScreenerSnapshot.market == m)
+            )
+        ).one()
+        fresh = int(row.fresh or 0)
+        stale = int(row.stale or 0)
+        missing = max(0, (expected or 0) - fresh - stale) if expected is not None else 0
+        rows.append(
+            InvestCoverageSurface(
+                surface="screener_snapshots",
+                label="Screener snapshots",
+                market=m,
+                state=_state_from_counts(fresh=fresh, stale=stale, expected=expected),
+                sourceOfTruth="invest_screener_snapshots",
+                latestAt=row.latest_at,
+                latestDate=row.latest_date,
+                counts=InvestCoverageCounts(
+                    expected=expected,
+                    fresh=fresh,
+                    stale=stale,
+                    missing=missing,
+                    total=fresh + stale,
+                ),
+                staleAfterHours=36,
+                warnings=[]
+                if fresh
+                else ["No screener snapshots cover the selected trading date."],
+            )
+        )
+    return rows
+
+
+async def _news_surfaces(
+    db: AsyncSession, market: str, now: dt.datetime
+) -> list[InvestCoverageSurface]:
+    markets = ["kr", "us", "crypto"] if market == "all" else [market]
+    rows: list[InvestCoverageSurface] = []
+    # news_articles.article_published_at is a timestamp without timezone.
+    stale_cutoff = now.replace(tzinfo=None) - dt.timedelta(hours=24)
+    for m in markets:
+        run = (
+            await db.execute(
+                sa.select(NewsIngestionRun)
+                .where(NewsIngestionRun.market == m)
+                .order_by(
+                    NewsIngestionRun.finished_at.desc().nullslast(),
+                    NewsIngestionRun.created_at.desc(),
+                )
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        article_row = (
+            await db.execute(
+                sa.select(
+                    sa.func.count()
+                    .filter(NewsArticle.article_published_at >= stale_cutoff)
+                    .label("fresh"),
+                    sa.func.count()
+                    .filter(NewsArticle.article_published_at < stale_cutoff)
+                    .label("stale"),
+                    sa.func.max(NewsArticle.article_published_at).label("latest_at"),
+                ).where(NewsArticle.market == m)
+            )
+        ).one()
+        fresh = int(article_row.fresh or 0)
+        stale = int(article_row.stale or 0)
+        state = _state_from_counts(fresh=fresh, stale=stale)
+        warnings: list[str] = []
+        if run is None:
+            warnings.append("No local news ingestion run found.")
+        elif run.status not in {"success", "dry_run_ok"}:
+            state = "partial" if fresh else "error"
+            warnings.append(f"Latest news ingestion status is {run.status}.")
+        if not fresh:
+            warnings.append("No articles published in the last 24 hours.")
+        rows.append(
+            InvestCoverageSurface(
+                surface="news_feed",
+                label="News feed",
+                market=m,
+                state=state,
+                sourceOfTruth="news_articles/news_ingestion_runs",
+                latestAt=article_row.latest_at or (run.finished_at if run else None),
+                counts=InvestCoverageCounts(
+                    fresh=fresh, stale=stale, total=fresh + stale
+                ),
+                staleAfterHours=24,
+                warnings=warnings,
+            )
+        )
+    return rows
+
+
+async def _calendar_surfaces(
+    db: AsyncSession, market: str, trading_day: dt.date, now: dt.datetime
+) -> list[InvestCoverageSurface]:
+    markets = ["kr", "us", "crypto", "global"] if market == "all" else [market]
+    rows: list[InvestCoverageSurface] = []
+    stale_cutoff = now - dt.timedelta(hours=36)
+    for m in markets:
+        row = (
+            await db.execute(
+                sa.select(
+                    sa.func.count()
+                    .filter(MarketEventIngestionPartition.partition_date >= trading_day)
+                    .label("fresh"),
+                    sa.func.count()
+                    .filter(MarketEventIngestionPartition.partition_date < trading_day)
+                    .label("stale"),
+                    sa.func.max(MarketEventIngestionPartition.finished_at).label(
+                        "latest_at"
+                    ),
+                    sa.func.max(MarketEventIngestionPartition.partition_date).label(
+                        "latest_date"
+                    ),
+                    sa.func.count()
+                    .filter(
+                        MarketEventIngestionPartition.status.notin_(
+                            ["success", "empty"]
+                        )
+                    )
+                    .label("partial"),
+                ).where(MarketEventIngestionPartition.market == m)
+            )
+        ).one()
+        fresh = int(row.fresh or 0)
+        stale = int(row.stale or 0)
+        partial = int(row.partial or 0)
+        latest_at = row.latest_at
+        state = _state_from_counts(fresh=fresh, stale=stale)
+        warnings: list[str] = []
+        if partial:
+            state = "partial" if fresh else "error"
+            warnings.append("One or more calendar partitions are not success/empty.")
+        if latest_at and latest_at < stale_cutoff:
+            state = "stale" if state == "fresh" else state
+            warnings.append(
+                "Latest calendar partition finished more than 36 hours ago."
+            )
+        if not fresh:
+            warnings.append("No calendar partitions cover the selected trading date.")
+        rows.append(
+            InvestCoverageSurface(
+                surface="calendar_events",
+                label="Calendar events",
+                market=m,
+                state=state,
+                sourceOfTruth="market_event_ingestion_partitions/market_events",
+                latestAt=latest_at,
+                latestDate=row.latest_date,
+                counts=InvestCoverageCounts(
+                    fresh=fresh, stale=stale, partial=partial, total=fresh + stale
+                ),
+                staleAfterHours=36,
+                warnings=warnings,
+            )
+        )
+    return rows
+
+
+async def _research_report_surfaces(
+    db: AsyncSession, market: str, now: dt.datetime
+) -> list[InvestCoverageSurface]:
+    if market == "crypto":
+        return [
+            InvestCoverageSurface(
+                surface="research_reports",
+                label="Research reports",
+                market=market,
+                state="unsupported",
+                sourceOfTruth="research_reports",
+                warnings=[
+                    "Broker research reports are equity-only in the local read model."
+                ],
+            )
+        ]
+
+    # Research report metadata is stored as a shared compact feed without a
+    # market column. Report one global row for all equity market selections.
+    # Research report timestamps are timezone-aware in the metadata read model.
+    cutoff = now - dt.timedelta(days=7)
+    latest_run = (
+        await db.execute(
+            sa.select(ResearchReportIngestionRun)
+            .order_by(ResearchReportIngestionRun.finished_at.desc().nullslast())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    report_row = (
+        await db.execute(
+            sa.select(
+                sa.func.count()
+                .filter(ResearchReport.published_at >= cutoff)
+                .label("fresh"),
+                sa.func.count()
+                .filter(ResearchReport.published_at < cutoff)
+                .label("stale"),
+                sa.func.max(ResearchReport.published_at).label("latest_at"),
+            )
+        )
+    ).one()
+    fresh = int(report_row.fresh or 0)
+    stale = int(report_row.stale or 0)
+    warnings = (
+        [] if fresh else ["No research report metadata published in the last 7 days."]
+    )
+    if latest_run is None:
+        warnings.append("No research report ingestion run found.")
+    return [
+        InvestCoverageSurface(
+            surface="research_reports",
+            label="Research reports",
+            market="equity" if market == "all" else market,
+            state=_state_from_counts(fresh=fresh, stale=stale),
+            sourceOfTruth="research_reports/research_report_ingestion_runs",
+            latestAt=report_row.latest_at
+            or (latest_run.finished_at if latest_run else None),
+            counts=InvestCoverageCounts(fresh=fresh, stale=stale, total=fresh + stale),
+            staleAfterHours=168,
+            warnings=warnings,
+            notes=[
+                "Only compact metadata is used; full report bodies are intentionally excluded."
+            ],
+        )
+    ]
+
+
+async def _investor_flow_surfaces(
+    db: AsyncSession, market: str, trading_day: dt.date
+) -> list[InvestCoverageSurface]:
+    if market in {"us", "crypto"}:
+        return [
+            InvestCoverageSurface(
+                surface="investor_flow",
+                label="Investor flow",
+                market=market,
+                state="unsupported",
+                sourceOfTruth="investor_flow_snapshots",
+                warnings=["Investor-flow snapshots currently cover KR equities only."],
+            )
+        ]
+    markets = ["kr"] if market in {"kr", "all"} else []
+    rows: list[InvestCoverageSurface] = []
+    expected = await _universe_count(db, "kr")
+    for m in markets:
+        row = (
+            await db.execute(
+                sa.select(
+                    sa.func.count()
+                    .filter(InvestorFlowSnapshot.snapshot_date >= trading_day)
+                    .label("fresh"),
+                    sa.func.count()
+                    .filter(InvestorFlowSnapshot.snapshot_date < trading_day)
+                    .label("stale"),
+                    sa.func.max(InvestorFlowSnapshot.collected_at).label("latest_at"),
+                    sa.func.max(InvestorFlowSnapshot.snapshot_date).label(
+                        "latest_date"
+                    ),
+                ).where(InvestorFlowSnapshot.market == m)
+            )
+        ).one()
+        fresh = int(row.fresh or 0)
+        stale = int(row.stale or 0)
+        missing = max(0, (expected or 0) - fresh - stale) if expected is not None else 0
+        rows.append(
+            InvestCoverageSurface(
+                surface="investor_flow",
+                label="Investor flow",
+                market=m,
+                state=_state_from_counts(fresh=fresh, stale=stale, expected=expected),
+                sourceOfTruth="investor_flow_snapshots",
+                latestAt=row.latest_at,
+                latestDate=row.latest_date,
+                counts=InvestCoverageCounts(
+                    expected=expected,
+                    fresh=fresh,
+                    stale=stale,
+                    missing=missing,
+                    total=fresh + stale,
+                ),
+                staleAfterHours=36,
+                warnings=[]
+                if fresh
+                else ["No investor-flow snapshots cover the selected trading date."],
+            )
+        )
+    return rows
+
+
+async def _holdings_surfaces(
+    db: AsyncSession, market: str, now: dt.datetime
+) -> list[InvestCoverageSurface]:
+    markets = ["kr", "us", "crypto"] if market == "all" else [market]
+    market_type = {
+        "kr": MarketType.KR,
+        "us": MarketType.US,
+        "crypto": MarketType.CRYPTO,
+    }
+    stale_cutoff = now - dt.timedelta(days=1)
+    rows: list[InvestCoverageSurface] = []
+    for m in markets:
+        row = (
+            await db.execute(
+                sa.select(
+                    sa.func.count()
+                    .filter(ManualHolding.updated_at >= stale_cutoff)
+                    .label("fresh"),
+                    sa.func.count()
+                    .filter(ManualHolding.updated_at < stale_cutoff)
+                    .label("stale"),
+                    sa.func.max(ManualHolding.updated_at).label("latest_at"),
+                ).where(ManualHolding.market_type == market_type[m])
+            )
+        ).one()
+        fresh = int(row.fresh or 0)
+        stale = int(row.stale or 0)
+        rows.append(
+            InvestCoverageSurface(
+                surface="holdings",
+                label="Holdings",
+                market=m,
+                state="fresh"
+                if fresh + stale == 0
+                else _state_from_counts(fresh=fresh, stale=stale),
+                sourceOfTruth="manual_holdings/account_panel_home_read_model",
+                latestAt=row.latest_at,
+                counts=InvestCoverageCounts(
+                    fresh=fresh, stale=stale, total=fresh + stale
+                ),
+                staleAfterHours=24,
+                notes=[
+                    "Empty is OK: the selected market may simply have no locally tracked holdings."
+                ],
+                warnings=[]
+                if stale == 0
+                else ["Some holdings rows have not been updated in the last 24 hours."],
+            )
+        )
+    return rows
+
+
+async def _pending_order_surfaces(
+    db: AsyncSession, market: str, now: dt.datetime
+) -> list[InvestCoverageSurface]:
+    markets = ["kr", "us", "crypto"] if market == "all" else [market]
+    stale_cutoff = now - dt.timedelta(minutes=30)
+    rows: list[InvestCoverageSurface] = []
+    for m in markets:
+        db_markets = [m]
+        if m == "kr":
+            db_markets = ["kr", "equity_kr"]
+        elif m == "us":
+            db_markets = ["us", "equity_us"]
+        row = (
+            await db.execute(
+                sa.select(
+                    sa.func.count()
+                    .filter(PendingOrder.last_seen_at >= stale_cutoff)
+                    .label("fresh"),
+                    sa.func.count()
+                    .filter(PendingOrder.last_seen_at < stale_cutoff)
+                    .label("stale"),
+                    sa.func.max(PendingOrder.last_seen_at).label("latest_at"),
+                ).where(PendingOrder.market.in_(db_markets))
+            )
+        ).one()
+        fresh = int(row.fresh or 0)
+        stale = int(row.stale or 0)
+        rows.append(
+            InvestCoverageSurface(
+                surface="pending_orders",
+                label="Pending orders",
+                market=m,
+                state="fresh"
+                if fresh + stale == 0
+                else _state_from_counts(fresh=fresh, stale=stale),
+                sourceOfTruth="pending_orders",
+                latestAt=row.latest_at,
+                counts=InvestCoverageCounts(
+                    fresh=fresh, stale=stale, total=fresh + stale
+                ),
+                staleAfterHours=1,
+                notes=[
+                    "Empty is OK for read-only order coverage: there may simply be no open orders."
+                ],
+                warnings=[]
+                if stale == 0
+                else [
+                    "Some pending-order rows have not been seen in the last 30 minutes."
+                ],
+            )
+        )
+    return rows
+
+
+async def _orderbook_nxt_surfaces(
+    db: AsyncSession, market: str
+) -> list[InvestCoverageSurface]:
+    markets = ["kr", "us", "crypto"] if market == "all" else [market]
+    rows: list[InvestCoverageSurface] = []
+    for m in markets:
+        if m == "kr":
+            row = (
+                await db.execute(
+                    sa.select(
+                        sa.func.count()
+                        .filter(KRSymbolUniverse.is_active.is_(True))
+                        .label("expected"),
+                        sa.func.count()
+                        .filter(
+                            KRSymbolUniverse.is_active.is_(True),
+                            KRSymbolUniverse.nxt_eligible.is_(True),
+                        )
+                        .label("fresh"),
+                    )
+                )
+            ).one()
+            expected = int(row.expected or 0)
+            nxt_eligible = int(row.fresh or 0)
+            rows.append(
+                InvestCoverageSurface(
+                    surface="orderbook_nxt_capability",
+                    label="Orderbook / NXT capability",
+                    market=m,
+                    state="fresh"
+                    if nxt_eligible > 0
+                    else ("missing" if expected > 0 else "missing"),
+                    sourceOfTruth="kr_symbol_universe.nxt_eligible/get_orderbook_capability",
+                    counts=InvestCoverageCounts(
+                        expected=expected,
+                        fresh=nxt_eligible,
+                        missing=max(0, expected - nxt_eligible),
+                        total=nxt_eligible,
+                    ),
+                    warnings=[]
+                    if nxt_eligible > 0
+                    else [
+                        "No active KR symbols are marked NXT-eligible in the local universe."
+                    ],
+                    notes=[
+                        "KR orderbook capability exists provider-side; this row reports local NXT eligibility coverage, not a quote/order recommendation."
+                    ],
+                )
+            )
+        elif m == "crypto":
+            rows.append(
+                InvestCoverageSurface(
+                    surface="orderbook_nxt_capability",
+                    label="Orderbook / NXT capability",
+                    market=m,
+                    state="provider_unwired",
+                    sourceOfTruth="get_orderbook_provider/read_model_gap",
+                    warnings=[
+                        "KRW crypto orderbook is provider-backed, but no durable local orderbook coverage read model is wired yet."
+                    ],
+                    notes=["NXT is not applicable to crypto."],
+                )
+            )
+        else:
+            rows.append(
+                InvestCoverageSurface(
+                    surface="orderbook_nxt_capability",
+                    label="Orderbook / NXT capability",
+                    market=m,
+                    state="unsupported",
+                    sourceOfTruth="get_orderbook_provider/read_model_gap",
+                    warnings=[
+                        "US orderbook/NXT capability is not supported by the current /invest provider/read-model contract."
+                    ],
+                )
+            )
+    return rows
+
+
+def _provider_unwired_surfaces(market: str) -> list[InvestCoverageSurface]:
+    markets = ["kr", "us", "crypto"] if market == "all" else [market]
+    rows: list[InvestCoverageSurface] = []
+    for m in markets:
+        for surface, label, warning in [
+            (
+                "quotes",
+                "Quotes",
+                "No durable /invest quote snapshot read model is wired; quote calls remain provider-backed elsewhere.",
+            ),
+            (
+                "ohlcv",
+                "OHLCV candles",
+                "No durable /invest OHLCV candle read model is wired for Toss-parity coverage.",
+            ),
+            (
+                "valuation_fundamentals",
+                "Valuation/fundamentals",
+                "No complete durable fundamentals read model is wired for Toss-parity coverage.",
+            ),
+        ]:
+            rows.append(
+                InvestCoverageSurface(
+                    surface=surface,
+                    label=label,
+                    market=m,
+                    state="provider_unwired",
+                    sourceOfTruth="read_model_gap",
+                    warnings=[warning],
+                )
+            )
+    return rows
+
+
+async def _symbol_rows(
+    db: AsyncSession,
+    market: str,
+    symbols: list[str],
+    trading_day: dt.date,
+) -> list[InvestCoverageSymbol]:
+    if not symbols or market not in {"kr", "us"}:
+        return []
+
+    screener_rows = (
+        await db.execute(
+            sa.select(
+                InvestScreenerSnapshot.symbol,
+                sa.func.max(InvestScreenerSnapshot.snapshot_date),
+            )
+            .where(
+                InvestScreenerSnapshot.market == market,
+                InvestScreenerSnapshot.symbol.in_(symbols),
+            )
+            .group_by(InvestScreenerSnapshot.symbol)
+        )
+    ).all()
+    screener_dates = dict(screener_rows)
+
+    investor_dates: dict[str, dt.date | None] = {}
+    if market == "kr":
+        flow_rows = (
+            await db.execute(
+                sa.select(
+                    InvestorFlowSnapshot.symbol,
+                    sa.func.max(InvestorFlowSnapshot.snapshot_date),
+                )
+                .where(
+                    InvestorFlowSnapshot.market == "kr",
+                    InvestorFlowSnapshot.symbol.in_(symbols),
+                )
+                .group_by(InvestorFlowSnapshot.symbol)
+            )
+        ).all()
+        investor_dates = dict(flow_rows)
+
+    news_rows = (
+        await db.execute(
+            sa.select(
+                NewsArticleRelatedSymbol.symbol,
+                sa.func.max(NewsArticle.article_published_at),
+            )
+            .join(NewsArticle, NewsArticle.id == NewsArticleRelatedSymbol.article_id)
+            .where(
+                NewsArticleRelatedSymbol.market == market,
+                NewsArticleRelatedSymbol.symbol.in_(symbols),
+            )
+            .group_by(NewsArticleRelatedSymbol.symbol)
+        )
+    ).all()
+    news_dates = {
+        symbol: latest.date() if latest else None for symbol, latest in news_rows
+    }
+
+    out: list[InvestCoverageSymbol] = []
+    for symbol in symbols:
+        latest_screener = screener_dates.get(symbol)
+        latest_flow = investor_dates.get(symbol)
+        latest_news = news_dates.get(symbol)
+        surfaces: dict[str, CoverageState] = {
+            "screener_snapshots": _date_state(latest_screener, trading_day),
+            "news_feed": "fresh"
+            if latest_news and (trading_day - latest_news).days <= 1
+            else ("stale" if latest_news else "missing"),
+        }
+        latest_dates: dict[str, dt.date | None] = {
+            "screener_snapshots": latest_screener,
+            "news_feed": latest_news,
+        }
+        if market == "kr":
+            surfaces["investor_flow"] = _date_state(latest_flow, trading_day)
+            latest_dates["investor_flow"] = latest_flow
+        else:
+            surfaces["investor_flow"] = "unsupported"
+            latest_dates["investor_flow"] = None
+        out.append(
+            InvestCoverageSymbol(
+                symbol=symbol,
+                market=market,
+                surfaces=surfaces,
+                latestDates=latest_dates,
+                warnings=[
+                    name
+                    for name, state in surfaces.items()
+                    if state in {"missing", "stale", "unsupported"}
+                ],
+            )
+        )
+    return out
+
+
+def _date_state(latest: dt.date | None, trading_day: dt.date) -> CoverageState:
+    if latest is None:
+        return "missing"
+    return "fresh" if latest >= trading_day else "stale"

--- a/app/services/invest_view_model/investor_flow_service.py
+++ b/app/services/invest_view_model/investor_flow_service.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+from app.schemas.investor_flow import InvestorFlowItem, InvestorFlowResponse
+from app.services.investor_flow_snapshots.repository import (
+    InvestorFlowSnapshotsRepository,
+)
+
+
+def _normalize_symbol(symbol: str) -> str:
+    return symbol.strip().upper()
+
+
+def _state_for_snapshot(
+    row: InvestorFlowSnapshot,
+    *,
+    as_of: dt.date,
+    max_stale_days: int,
+) -> str:
+    age_days = (as_of - row.snapshot_date).days
+    if age_days <= max_stale_days:
+        return "fresh"
+    return "stale"
+
+
+def _item_from_snapshot(
+    row: InvestorFlowSnapshot,
+    *,
+    as_of: dt.date,
+    max_stale_days: int,
+) -> InvestorFlowItem:
+    return InvestorFlowItem(
+        symbol=row.symbol,
+        market="kr",
+        dataState=_state_for_snapshot(row, as_of=as_of, max_stale_days=max_stale_days),
+        snapshotDate=row.snapshot_date,
+        collectedAt=row.collected_at,
+        source=row.source,
+        foreignNet=row.foreign_net,
+        institutionNet=row.institution_net,
+        individualNet=row.individual_net,
+        foreignNetBuyRank=row.foreign_net_buy_rank,
+        foreignNetSellRank=row.foreign_net_sell_rank,
+        institutionNetBuyRank=row.institution_net_buy_rank,
+        institutionNetSellRank=row.institution_net_sell_rank,
+        doubleBuy=row.double_buy,
+        doubleSell=row.double_sell,
+        foreignConsecutiveBuyDays=row.foreign_consecutive_buy_days,
+        foreignConsecutiveSellDays=row.foreign_consecutive_sell_days,
+        institutionConsecutiveBuyDays=row.institution_consecutive_buy_days,
+        institutionConsecutiveSellDays=row.institution_consecutive_sell_days,
+        individualConsecutiveBuyDays=row.individual_consecutive_buy_days,
+        individualConsecutiveSellDays=row.individual_consecutive_sell_days,
+    )
+
+
+def _aggregate_state(items: list[InvestorFlowItem]) -> str:
+    if not items:
+        return "empty"
+    states = {item.dataState for item in items}
+    if states == {"fresh"}:
+        return "fresh"
+    if states == {"missing"}:
+        return "missing"
+    if states == {"stale"}:
+        return "stale"
+    return "partial"
+
+
+async def build_investor_flow_cards(
+    *,
+    db: AsyncSession,
+    symbols: list[str],
+    market: str = "kr",
+    as_of: dt.date | None = None,
+    max_stale_days: int = 1,
+) -> InvestorFlowResponse:
+    normalized_market = market.strip().lower()
+    if normalized_market != "kr":
+        raise ValueError("investor_flow only supports market=kr")
+    today = as_of or dt.date.today()
+    normalized_symbols = [_normalize_symbol(symbol) for symbol in symbols if symbol.strip()]
+    if not normalized_symbols:
+        return InvestorFlowResponse(market="kr", asOf=today, dataState="empty", items=[])
+
+    repo = InvestorFlowSnapshotsRepository(db)
+    rows = await repo.latest_by_symbols(
+        market="kr", symbols=normalized_symbols, as_of=today
+    )
+    rows_by_symbol = {row.symbol: row for row in rows}
+
+    items: list[InvestorFlowItem] = []
+    for symbol in normalized_symbols:
+        row = rows_by_symbol.get(symbol)
+        if row is None:
+            items.append(
+                InvestorFlowItem(symbol=symbol, market="kr", dataState="missing")
+            )
+            continue
+        items.append(_item_from_snapshot(row, as_of=today, max_stale_days=max_stale_days))
+
+    sources = sorted({item.source for item in items if item.source})
+    return InvestorFlowResponse(
+        market="kr",
+        asOf=today,
+        source=sources[0] if len(sources) == 1 else None,
+        dataState=_aggregate_state(items),
+        items=items,
+    )

--- a/app/services/invest_view_model/investor_flow_service.py
+++ b/app/services/invest_view_model/investor_flow_service.py
@@ -83,9 +83,13 @@ async def build_investor_flow_cards(
     if normalized_market != "kr":
         raise ValueError("investor_flow only supports market=kr")
     today = as_of or dt.date.today()
-    normalized_symbols = [_normalize_symbol(symbol) for symbol in symbols if symbol.strip()]
+    normalized_symbols = [
+        _normalize_symbol(symbol) for symbol in symbols if symbol.strip()
+    ]
     if not normalized_symbols:
-        return InvestorFlowResponse(market="kr", asOf=today, dataState="empty", items=[])
+        return InvestorFlowResponse(
+            market="kr", asOf=today, dataState="empty", items=[]
+        )
 
     repo = InvestorFlowSnapshotsRepository(db)
     rows = await repo.latest_by_symbols(
@@ -101,7 +105,9 @@ async def build_investor_flow_cards(
                 InvestorFlowItem(symbol=symbol, market="kr", dataState="missing")
             )
             continue
-        items.append(_item_from_snapshot(row, as_of=today, max_stale_days=max_stale_days))
+        items.append(
+            _item_from_snapshot(row, as_of=today, max_stale_days=max_stale_days)
+        )
 
     sources = sorted({item.source for item in items if item.source})
     return InvestorFlowResponse(

--- a/app/services/investor_flow_snapshots/__init__.py
+++ b/app/services/investor_flow_snapshots/__init__.py
@@ -1,0 +1,5 @@
+"""Investor-flow snapshot persistence helpers."""
+
+from .repository import InvestorFlowSnapshotsRepository, InvestorFlowSnapshotUpsert
+
+__all__ = ["InvestorFlowSnapshotUpsert", "InvestorFlowSnapshotsRepository"]

--- a/app/services/investor_flow_snapshots/repository.py
+++ b/app/services/investor_flow_snapshots/repository.py
@@ -92,18 +92,17 @@ class InvestorFlowSnapshotsRepository:
         symbols: Iterable[str],
         as_of: dt.date | None = None,
     ) -> list[InvestorFlowSnapshot]:
-        symbols_list = [_normalize_symbol(symbol) for symbol in symbols if symbol.strip()]
+        symbols_list = [
+            _normalize_symbol(symbol) for symbol in symbols if symbol.strip()
+        ]
         if not symbols_list:
             return []
-        max_date_subq = (
-            select(
-                InvestorFlowSnapshot.symbol.label("symbol"),
-                func.max(InvestorFlowSnapshot.snapshot_date).label("snapshot_date"),
-            )
-            .where(
-                InvestorFlowSnapshot.market == market.strip().lower(),
-                InvestorFlowSnapshot.symbol.in_(symbols_list),
-            )
+        max_date_subq = select(
+            InvestorFlowSnapshot.symbol.label("symbol"),
+            func.max(InvestorFlowSnapshot.snapshot_date).label("snapshot_date"),
+        ).where(
+            InvestorFlowSnapshot.market == market.strip().lower(),
+            InvestorFlowSnapshot.symbol.in_(symbols_list),
         )
         if as_of is not None:
             max_date_subq = max_date_subq.where(
@@ -116,12 +115,12 @@ class InvestorFlowSnapshotsRepository:
             .join(
                 max_date_subq,
                 (InvestorFlowSnapshot.symbol == max_date_subq.c.symbol)
-                & (
-                    InvestorFlowSnapshot.snapshot_date == max_date_subq.c.snapshot_date
-                ),
+                & (InvestorFlowSnapshot.snapshot_date == max_date_subq.c.snapshot_date),
             )
             .where(InvestorFlowSnapshot.market == market.strip().lower())
-            .order_by(InvestorFlowSnapshot.symbol.asc(), InvestorFlowSnapshot.source.asc())
+            .order_by(
+                InvestorFlowSnapshot.symbol.asc(), InvestorFlowSnapshot.source.asc()
+            )
         )
         rows = list(result.scalars().all())
         latest: dict[str, InvestorFlowSnapshot] = {}

--- a/app/services/investor_flow_snapshots/repository.py
+++ b/app/services/investor_flow_snapshots/repository.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Iterable
+
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+
+
+class InvestorFlowSnapshotUpsert(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    market: str
+    symbol: str
+    snapshot_date: dt.date
+    foreign_net: int | None = None
+    institution_net: int | None = None
+    individual_net: int | None = None
+    foreign_net_buy_rank: int | None = None
+    foreign_net_sell_rank: int | None = None
+    institution_net_buy_rank: int | None = None
+    institution_net_sell_rank: int | None = None
+    double_buy: bool | None = None
+    double_sell: bool | None = None
+    foreign_consecutive_buy_days: int | None = None
+    foreign_consecutive_sell_days: int | None = None
+    institution_consecutive_buy_days: int | None = None
+    institution_consecutive_sell_days: int | None = None
+    individual_consecutive_buy_days: int | None = None
+    individual_consecutive_sell_days: int | None = None
+    source: str
+    collected_at: dt.datetime | None = None
+
+
+def _normalize_symbol(symbol: str) -> str:
+    return symbol.strip().upper()
+
+
+def _with_derived_flags(payload: InvestorFlowSnapshotUpsert) -> dict:
+    values = payload.model_dump(exclude_none=True)
+    values["market"] = values["market"].strip().lower()
+    values["symbol"] = _normalize_symbol(values["symbol"])
+    foreign_net = values.get("foreign_net")
+    institution_net = values.get("institution_net")
+    if payload.double_buy is None:
+        values["double_buy"] = bool(
+            foreign_net is not None
+            and institution_net is not None
+            and foreign_net > 0
+            and institution_net > 0
+        )
+    if payload.double_sell is None:
+        values["double_sell"] = bool(
+            foreign_net is not None
+            and institution_net is not None
+            and foreign_net < 0
+            and institution_net < 0
+        )
+    if "collected_at" not in values:
+        values["collected_at"] = dt.datetime.now(dt.UTC)
+    return values
+
+
+class InvestorFlowSnapshotsRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def upsert(self, payload: InvestorFlowSnapshotUpsert) -> None:
+        values = _with_derived_flags(payload)
+        stmt = insert(InvestorFlowSnapshot).values(**values)
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_investor_flow_snapshots_market_symbol_date_source",
+            set_={
+                **{
+                    key: stmt.excluded[key]
+                    for key in values
+                    if key not in {"market", "symbol", "snapshot_date", "source"}
+                },
+                "updated_at": func.now(),
+            },
+        )
+        await self._session.execute(stmt)
+
+    async def latest_by_symbols(
+        self,
+        *,
+        market: str,
+        symbols: Iterable[str],
+        as_of: dt.date | None = None,
+    ) -> list[InvestorFlowSnapshot]:
+        symbols_list = [_normalize_symbol(symbol) for symbol in symbols if symbol.strip()]
+        if not symbols_list:
+            return []
+        max_date_subq = (
+            select(
+                InvestorFlowSnapshot.symbol.label("symbol"),
+                func.max(InvestorFlowSnapshot.snapshot_date).label("snapshot_date"),
+            )
+            .where(
+                InvestorFlowSnapshot.market == market.strip().lower(),
+                InvestorFlowSnapshot.symbol.in_(symbols_list),
+            )
+        )
+        if as_of is not None:
+            max_date_subq = max_date_subq.where(
+                InvestorFlowSnapshot.snapshot_date <= as_of
+            )
+        max_date_subq = max_date_subq.group_by(InvestorFlowSnapshot.symbol).subquery()
+
+        result = await self._session.execute(
+            select(InvestorFlowSnapshot)
+            .join(
+                max_date_subq,
+                (InvestorFlowSnapshot.symbol == max_date_subq.c.symbol)
+                & (
+                    InvestorFlowSnapshot.snapshot_date == max_date_subq.c.snapshot_date
+                ),
+            )
+            .where(InvestorFlowSnapshot.market == market.strip().lower())
+            .order_by(InvestorFlowSnapshot.symbol.asc(), InvestorFlowSnapshot.source.asc())
+        )
+        rows = list(result.scalars().all())
+        latest: dict[str, InvestorFlowSnapshot] = {}
+        for row in rows:
+            # Keep deterministic source precedence if multiple source snapshots exist.
+            latest.setdefault(row.symbol, row)
+        return [latest[symbol] for symbol in symbols_list if symbol in latest]

--- a/docs/invest-coverage-dashboard.md
+++ b/docs/invest-coverage-dashboard.md
@@ -1,0 +1,45 @@
+# ROB-192 /invest Toss-parity coverage
+
+This page documents the read-only coverage dashboard/API added for `/invest`.
+
+Endpoint: `GET /invest/api/coverage`
+
+Query parameters:
+- `market`: `kr`, `us`, `crypto`, or `all` (default `kr`)
+- `symbols`: optional comma-separated symbols for symbol-level diagnostics
+- `asOf`: optional trading date override for deterministic inspection/tests
+
+Contract:
+- Source of truth is local `auto_trader` DB/read-model state.
+- Toss is only a parity/reference benchmark; the endpoint does not read from Toss.
+- The endpoint is read-only: it does not submit/cancel/modify orders, call broker clients, start collectors, run backfills, or generate buy/sell recommendations.
+
+Coverage states:
+- `fresh`: current read-model rows are available.
+- `stale`: only older read-model rows are available.
+- `partial`: some current rows are present, but expected scope is incomplete or an ingestion partition is degraded.
+- `missing`: no local rows are available for the surface.
+- `unsupported`: the surface is intentionally unsupported for the selected market.
+- `provider_unwired`: a Toss-parity data surface exists conceptually, but no durable local `/invest` read model is wired yet.
+- `error`: local ingestion metadata indicates a failed/degraded state with no fresh rows.
+
+Current surfaces:
+- `symbol_universe`: `kr_symbol_universe`, `us_symbol_universe`.
+- `screener_snapshots`: `invest_screener_snapshots`, KR/US only.
+- `news_feed`: `news_articles` and `news_ingestion_runs`.
+- `calendar_events`: `market_event_ingestion_partitions` and calendar read models.
+- `research_reports`: compact `research_reports` metadata; full report bodies remain excluded by policy.
+- `investor_flow`: `investor_flow_snapshots`, KR only.
+- `pending_orders`: `pending_orders`; empty is considered OK because there may be no open orders.
+- `holdings`: local holdings/account-panel foundation; empty is considered OK because a market may have no tracked holdings.
+- `orderbook_nxt_capability`: KR NXT eligibility from `kr_symbol_universe.nxt_eligible`; US is unsupported and crypto orderbook remains provider-backed/unwired.
+- `quotes`, `ohlcv`, `valuation_fundamentals`: explicitly `provider_unwired` until durable read models exist.
+
+Frontend:
+- Route: `/invest/coverage`
+- Nav label: `커버리지`
+- The UI groups counts by state, lists surface-level gaps, and optionally shows symbol-level coverage for screener/news/investor-flow.
+
+Operational notes:
+- Freshness thresholds are intentionally conservative and read-only diagnostics only: news 24h, calendar/screener/investor-flow 36h, research metadata 7d, pending orders 30m last-seen.
+- This dashboard should be used to identify data gaps before implementing Toss-parity product features. It must not become a place for trading recommendation logic.

--- a/frontend/invest/src/api/coverage.ts
+++ b/frontend/invest/src/api/coverage.ts
@@ -1,0 +1,22 @@
+import type { InvestCoverageResponse } from "../types/coverage";
+
+export async function fetchInvestCoverage(params: {
+  market?: "kr" | "us" | "crypto" | "all";
+  symbols?: string;
+  asOf?: string;
+  signal?: AbortSignal;
+} = {}): Promise<InvestCoverageResponse> {
+  const q = new URLSearchParams();
+  if (params.market) q.set("market", params.market);
+  if (params.symbols?.trim()) q.set("symbols", params.symbols.trim());
+  if (params.asOf) q.set("asOf", params.asOf);
+  const suffix = q.toString() ? `?${q.toString()}` : "";
+  const res = await fetch(`/invest/api/coverage${suffix}`, {
+    credentials: "include",
+    signal: params.signal,
+  });
+  if (!res.ok) {
+    throw new Error(`/invest/api/coverage ${res.status}`);
+  }
+  return res.json();
+}

--- a/frontend/invest/src/api/investorFlow.ts
+++ b/frontend/invest/src/api/investorFlow.ts
@@ -1,0 +1,22 @@
+import type { InvestorFlowResponse } from "../types/investorFlow";
+
+export async function fetchInvestorFlow(params: {
+  symbols: string[];
+  market?: "kr";
+  asOf?: string;
+  maxStaleDays?: number;
+  signal?: AbortSignal;
+}): Promise<InvestorFlowResponse> {
+  const q = new URLSearchParams();
+  q.set("symbols", params.symbols.join(","));
+  q.set("market", params.market ?? "kr");
+  if (params.asOf) q.set("asOf", params.asOf);
+  if (params.maxStaleDays !== undefined) q.set("maxStaleDays", String(params.maxStaleDays));
+
+  const res = await fetch(`/invest/api/investor-flow?${q}`, {
+    credentials: "include",
+    signal: params.signal,
+  });
+  if (!res.ok) throw new Error(`investor-flow ${res.status}`);
+  return res.json();
+}

--- a/frontend/invest/src/desktop/DesktopHeader.tsx
+++ b/frontend/invest/src/desktop/DesktopHeader.tsx
@@ -7,6 +7,7 @@ const LINKS: { to: string; label: string; end?: boolean }[] = [
   { to: "/discover", label: "발견" },
   { to: "/signals", label: "시그널" },
   { to: "/calendar", label: "캘린더" },
+  { to: "/coverage", label: "커버리지" },
   { to: "/screener", label: "골라보기" },
 ];
 

--- a/frontend/invest/src/pages/desktop/DesktopCoveragePage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCoveragePage.tsx
@@ -1,0 +1,209 @@
+import { useEffect, useMemo, useState } from "react";
+import { fetchInvestCoverage } from "../../api/coverage";
+import { DesktopShell } from "../../desktop/DesktopShell";
+import { Card } from "../../ds";
+import type { CoverageState, InvestCoverageResponse, InvestCoverageSurface } from "../../types/coverage";
+
+type Market = "kr" | "us" | "crypto" | "all";
+
+const STATE_LABEL: Record<CoverageState, string> = {
+  fresh: "정상",
+  stale: "오래됨",
+  partial: "부분",
+  missing: "없음",
+  unsupported: "미지원",
+  error: "오류",
+  provider_unwired: "미연결",
+};
+
+const STATE_COLOR: Record<CoverageState, string> = {
+  fresh: "#16a34a",
+  stale: "#d97706",
+  partial: "#ca8a04",
+  missing: "#dc2626",
+  unsupported: "#64748b",
+  error: "#b91c1c",
+  provider_unwired: "#7c3aed",
+};
+
+function StatePill({ state }: { state: CoverageState }) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        borderRadius: 999,
+        padding: "3px 8px",
+        fontSize: 12,
+        fontWeight: 800,
+        color: "white",
+        background: STATE_COLOR[state],
+        whiteSpace: "nowrap",
+      }}
+    >
+      {STATE_LABEL[state]}
+    </span>
+  );
+}
+
+function SurfaceRow({ surface }: { surface: InvestCoverageSurface }) {
+  const latest = surface.latestDate ?? surface.latestAt ?? "-";
+  const counts = surface.counts;
+  return (
+    <tr>
+      <td style={{ padding: "12px 10px", borderBottom: "1px solid var(--divider)" }}>
+        <div style={{ fontWeight: 800 }}>{surface.label}</div>
+        <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{surface.surface}</div>
+      </td>
+      <td style={{ padding: "12px 10px", borderBottom: "1px solid var(--divider)" }}>
+        <StatePill state={surface.state} />
+      </td>
+      <td style={{ padding: "12px 10px", borderBottom: "1px solid var(--divider)", color: "var(--fg-2)" }}>
+        {surface.market ?? "-"}
+      </td>
+      <td style={{ padding: "12px 10px", borderBottom: "1px solid var(--divider)", fontFamily: "var(--font-mono)", fontSize: 12 }}>
+        {surface.sourceOfTruth}
+      </td>
+      <td style={{ padding: "12px 10px", borderBottom: "1px solid var(--divider)", color: "var(--fg-2)", fontSize: 12 }}>
+        {latest}
+      </td>
+      <td style={{ padding: "12px 10px", borderBottom: "1px solid var(--divider)", fontSize: 12 }}>
+        <span>fresh {counts.fresh}</span>
+        <span style={{ marginLeft: 8 }}>stale {counts.stale}</span>
+        <span style={{ marginLeft: 8 }}>missing {counts.missing}</span>
+        {counts.expected != null && <span style={{ marginLeft: 8 }}>expected {counts.expected}</span>}
+      </td>
+      <td style={{ padding: "12px 10px", borderBottom: "1px solid var(--divider)", color: "var(--fg-3)", fontSize: 12 }}>
+        {surface.warnings[0] ?? surface.notes[0] ?? "-"}
+      </td>
+    </tr>
+  );
+}
+
+export function CoverageRoute() {
+  const [market, setMarket] = useState<Market>("kr");
+  const [symbols, setSymbols] = useState("005930, AAPL");
+  const [data, setData] = useState<InvestCoverageResponse | undefined>();
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setErr(null);
+    fetchInvestCoverage({ market, symbols, signal: controller.signal })
+      .then((response) => {
+        setData(response);
+        setLoading(false);
+      })
+      .catch((e) => {
+        if (controller.signal.aborted) return;
+        setErr(String(e?.message ?? e));
+        setLoading(false);
+      });
+    return () => controller.abort();
+  }, [market, symbols]);
+
+  const summary = useMemo(() => {
+    const surfaces = data?.surfaces ?? [];
+    return data?.states.map((state) => ({
+      state,
+      count: surfaces.filter((surface) => surface.state === state).length,
+    })) ?? [];
+  }, [data]);
+
+  return (
+    <DesktopShell
+      center={
+        <div style={{ padding: 24, display: "grid", gap: 16 }}>
+        <div>
+          <h1 style={{ margin: 0, fontSize: 26, letterSpacing: "-0.04em" }}>데이터 커버리지</h1>
+          <p style={{ margin: "6px 0 0", color: "var(--fg-2)", fontSize: 14 }}>
+            /invest Toss parity 표면별 freshness와 미연결 read-model을 확인합니다.
+          </p>
+        </div>
+
+        <Card>
+          <div style={{ display: "flex", gap: 12, alignItems: "end", flexWrap: "wrap" }}>
+            <label style={{ display: "grid", gap: 6, fontSize: 12, color: "var(--fg-2)" }}>
+              Market
+              <select value={market} onChange={(e) => setMarket(e.target.value as Market)} style={{ padding: "8px 10px", borderRadius: 8, border: "1px solid var(--border)", background: "var(--surface)" }}>
+                <option value="kr">KR</option>
+                <option value="us">US</option>
+                <option value="crypto">Crypto</option>
+                <option value="all">All</option>
+              </select>
+            </label>
+            <label style={{ display: "grid", gap: 6, fontSize: 12, color: "var(--fg-2)", minWidth: 260 }}>
+              Symbols (optional)
+              <input value={symbols} onChange={(e) => setSymbols(e.target.value)} placeholder="005930, AAPL" style={{ padding: "8px 10px", borderRadius: 8, border: "1px solid var(--border)", background: "var(--surface)" }} />
+            </label>
+            {data && <div style={{ color: "var(--fg-3)", fontSize: 12 }}>asOf {data.asOf} · tradingDate {data.tradingDate}</div>}
+          </div>
+        </Card>
+
+        {loading && <Card>커버리지 로딩 중…</Card>}
+        {err && <Card><span style={{ color: STATE_COLOR.error }}>커버리지 API 오류: {err}</span></Card>}
+
+        {data && !loading && (
+          <>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(130px, 1fr))", gap: 12 }}>
+              {summary.map(({ state, count }) => (
+                <Card key={state}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
+                    <StatePill state={state} />
+                    <strong style={{ fontSize: 22 }}>{count}</strong>
+                  </div>
+                </Card>
+              ))}
+            </div>
+
+            <Card>
+              <div style={{ overflowX: "auto" }}>
+                <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 980 }}>
+                  <thead>
+                    <tr style={{ textAlign: "left", color: "var(--fg-3)", fontSize: 12 }}>
+                      <th style={{ padding: "0 10px 8px" }}>Surface</th>
+                      <th style={{ padding: "0 10px 8px" }}>State</th>
+                      <th style={{ padding: "0 10px 8px" }}>Market</th>
+                      <th style={{ padding: "0 10px 8px" }}>Source of truth</th>
+                      <th style={{ padding: "0 10px 8px" }}>Latest</th>
+                      <th style={{ padding: "0 10px 8px" }}>Counts</th>
+                      <th style={{ padding: "0 10px 8px" }}>Gap / note</th>
+                    </tr>
+                  </thead>
+                  <tbody>{data.surfaces.map((surface, idx) => <SurfaceRow key={`${surface.surface}-${surface.market}-${idx}`} surface={surface} />)}</tbody>
+                </table>
+              </div>
+            </Card>
+
+            {data.symbols.length > 0 && (
+              <Card>
+                <h2 style={{ margin: "0 0 12px", fontSize: 18 }}>Symbol coverage</h2>
+                <div style={{ display: "grid", gap: 10 }}>
+                  {data.symbols.map((symbol) => (
+                    <div key={symbol.symbol} style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+                      <strong style={{ width: 84 }}>{symbol.symbol}</strong>
+                      {Object.entries(symbol.surfaces).map(([name, state]) => <span key={name} style={{ display: "inline-flex", gap: 6, alignItems: "center" }}><span style={{ color: "var(--fg-3)", fontSize: 12 }}>{name}</span><StatePill state={state} /></span>)}
+                    </div>
+                  ))}
+                </div>
+              </Card>
+            )}
+          </>
+        )}
+        </div>
+      }
+      right={
+        <Card>
+          <div style={{ fontWeight: 800, marginBottom: 8 }}>ROB-192 원칙</div>
+          <ul style={{ margin: 0, paddingLeft: 18, color: "var(--fg-2)", fontSize: 13 }}>
+            <li>읽기 전용 DB/read-model 진단</li>
+            <li>Toss는 기준/벤치마크로만 표기</li>
+            <li>매매 추천·주문·백필 없음</li>
+          </ul>
+        </Card>
+      }
+    />
+  );
+}

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -6,6 +6,7 @@ import { FeedNewsRoute } from "./pages/desktop/DesktopFeedNewsPage";
 import { InvestDiscoverRoute } from "./pages/desktop/DesktopDiscoverPage";
 import { SignalsRoute } from "./pages/desktop/DesktopSignalsPage";
 import { CalendarRoute } from "./pages/desktop/DesktopCalendarPage";
+import { CoverageRoute } from "./pages/desktop/DesktopCoveragePage";
 import { DesktopScreenerPage } from "./pages/desktop/DesktopScreenerPage";
 import { StockDetailPage } from "./pages/stock-detail/StockDetailPage";
 
@@ -36,6 +37,7 @@ export const router = createBrowserRouter(
     { path: "/discover/issues/:issueId", element: <DiscoverIssueDetailPage /> },
     { path: "/signals", element: <SignalsRoute /> },
     { path: "/calendar", element: <CalendarRoute /> },
+    { path: "/coverage", element: <CoverageRoute /> },
     { path: "/screener", element: <DesktopScreenerPage /> },
     { path: "/stocks/:market/:symbol", element: <StockDetailPage /> },
 

--- a/frontend/invest/src/types/coverage.ts
+++ b/frontend/invest/src/types/coverage.ts
@@ -1,0 +1,51 @@
+export type CoverageState =
+  | "fresh"
+  | "stale"
+  | "partial"
+  | "missing"
+  | "unsupported"
+  | "error"
+  | "provider_unwired";
+
+export interface InvestCoverageCounts {
+  expected?: number | null;
+  fresh: number;
+  stale: number;
+  missing: number;
+  partial: number;
+  total: number;
+}
+
+export interface InvestCoverageSurface {
+  surface: string;
+  label: string;
+  state: CoverageState;
+  market?: string | null;
+  sourceOfTruth: string;
+  reference: string;
+  latestAt?: string | null;
+  latestDate?: string | null;
+  counts: InvestCoverageCounts;
+  staleAfterHours?: number | null;
+  warnings: string[];
+  notes: string[];
+}
+
+export interface InvestCoverageSymbol {
+  symbol: string;
+  market: string;
+  surfaces: Record<string, CoverageState>;
+  latestDates: Record<string, string | null>;
+  warnings: string[];
+}
+
+export interface InvestCoverageResponse {
+  market: "kr" | "us" | "crypto" | "all";
+  asOf: string;
+  tradingDate: string;
+  states: CoverageState[];
+  surfaces: InvestCoverageSurface[];
+  symbols: InvestCoverageSymbol[];
+  gaps: string[];
+  notes: string[];
+}

--- a/frontend/invest/src/types/investorFlow.ts
+++ b/frontend/invest/src/types/investorFlow.ts
@@ -1,0 +1,33 @@
+export type InvestorFlowDataState = "empty" | "missing" | "stale" | "fresh" | "partial";
+
+export interface InvestorFlowItem {
+  symbol: string;
+  market: "kr";
+  dataState: "missing" | "stale" | "fresh";
+  snapshotDate?: string | null;
+  collectedAt?: string | null;
+  source?: string | null;
+  foreignNet?: number | null;
+  institutionNet?: number | null;
+  individualNet?: number | null;
+  foreignNetBuyRank?: number | null;
+  foreignNetSellRank?: number | null;
+  institutionNetBuyRank?: number | null;
+  institutionNetSellRank?: number | null;
+  doubleBuy: boolean;
+  doubleSell: boolean;
+  foreignConsecutiveBuyDays?: number | null;
+  foreignConsecutiveSellDays?: number | null;
+  institutionConsecutiveBuyDays?: number | null;
+  institutionConsecutiveSellDays?: number | null;
+  individualConsecutiveBuyDays?: number | null;
+  individualConsecutiveSellDays?: number | null;
+}
+
+export interface InvestorFlowResponse {
+  market: "kr";
+  asOf: string;
+  source?: string | null;
+  dataState: InvestorFlowDataState;
+  items: InvestorFlowItem[];
+}

--- a/tests/test_invest_coverage.py
+++ b/tests/test_invest_coverage.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+import sqlalchemy as sa
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.core.db import get_db
+from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.market_events import MarketEventIngestionPartition
+from app.models.news import NewsArticle, NewsArticleRelatedSymbol, NewsIngestionRun
+from app.routers.dependencies import get_authenticated_user
+from app.routers.invest_api import router as invest_api_router
+from app.services.invest_coverage_service import build_invest_coverage
+
+
+@pytest.fixture
+def app(db_session) -> FastAPI:
+    app = FastAPI()
+    app.include_router(invest_api_router)
+    app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=1)
+
+    async def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    return app
+
+
+@pytest.mark.asyncio
+async def test_build_invest_coverage_reports_fresh_partial_and_provider_unwired(
+    db_session,
+):
+    trading_day = dt.date(2026, 5, 11)
+    now = dt.datetime(2026, 5, 11, 8, 0, tzinfo=dt.UTC)
+    now_naive = now.replace(tzinfo=None)
+
+    await db_session.execute(
+        sa.delete(NewsArticleRelatedSymbol).where(NewsArticleRelatedSymbol.id == 9701)
+    )
+    await db_session.execute(sa.delete(NewsArticle).where(NewsArticle.id == 9601))
+    await db_session.execute(
+        sa.delete(NewsIngestionRun).where(NewsIngestionRun.id == 9501)
+    )
+    await db_session.execute(
+        sa.delete(MarketEventIngestionPartition).where(
+            MarketEventIngestionPartition.id == 9401
+        )
+    )
+    await db_session.execute(
+        sa.delete(InvestorFlowSnapshot).where(InvestorFlowSnapshot.id == 9301)
+    )
+    await db_session.execute(
+        sa.delete(InvestScreenerSnapshot).where(
+            InvestScreenerSnapshot.id.in_([9201, 9202])
+        )
+    )
+    await db_session.execute(
+        sa.delete(KRSymbolUniverse).where(
+            KRSymbolUniverse.symbol.in_(["900201", "900202"])
+        )
+    )
+    await db_session.commit()
+
+    db_session.add_all(
+        [
+            KRSymbolUniverse(
+                symbol="900201", name="ROB192 Fresh", exchange="KOSPI", is_active=True
+            ),
+            KRSymbolUniverse(
+                symbol="900202", name="ROB192 Stale", exchange="KOSPI", is_active=True
+            ),
+            InvestScreenerSnapshot(
+                id=9201,
+                market="kr",
+                symbol="900201",
+                snapshot_date=trading_day,
+                latest_close=Decimal("1000"),
+                closes_window=[1000],
+                source="kis",
+                computed_at=now,
+            ),
+            InvestScreenerSnapshot(
+                id=9202,
+                market="kr",
+                symbol="900202",
+                snapshot_date=dt.date(2026, 5, 8),
+                latest_close=Decimal("900"),
+                closes_window=[900],
+                source="kis",
+                computed_at=now - dt.timedelta(days=3),
+            ),
+            InvestorFlowSnapshot(
+                id=9301,
+                market="kr",
+                symbol="900201",
+                snapshot_date=trading_day,
+                source="naver_finance",
+                foreign_net=100,
+                institution_net=50,
+                individual_net=-150,
+                collected_at=now,
+            ),
+            MarketEventIngestionPartition(
+                id=9401,
+                source="test",
+                category="economic",
+                market="kr",
+                partition_date=trading_day,
+                status="success",
+                event_count=1,
+                finished_at=now,
+            ),
+            NewsIngestionRun(
+                id=9501,
+                run_uuid="rob192-news-run",
+                market="kr",
+                feed_set="test",
+                started_at=now_naive,
+                finished_at=now_naive,
+                status="success",
+                source_counts={"test": 1},
+                inserted_count=1,
+                skipped_count=0,
+                created_at=now_naive,
+            ),
+            NewsArticle(
+                id=9601,
+                url="https://example.com/rob192-news",
+                title="ROB192 news",
+                source="test",
+                feed_source="test",
+                market="kr",
+                keywords=[],
+                article_published_at=now_naive,
+                scraped_at=now_naive,
+                created_at=now_naive,
+            ),
+            NewsArticleRelatedSymbol(
+                id=9701,
+                article_id=9601,
+                market="kr",
+                symbol="900201",
+                source="test",
+                created_at=now_naive,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    response = await build_invest_coverage(
+        db_session,
+        market="kr",
+        symbols=["900201", "900202"],
+        as_of=trading_day,
+    )
+
+    by_surface = {
+        (surface.surface, surface.market): surface for surface in response.surfaces
+    }
+    assert by_surface[("screener_snapshots", "kr")].state == "partial"
+    assert by_surface[("investor_flow", "kr")].state == "partial"
+    assert by_surface[("news_feed", "kr")].state == "fresh"
+    assert by_surface[("calendar_events", "kr")].state == "fresh"
+    assert by_surface[("holdings", "kr")].state == "fresh"
+    assert by_surface[("pending_orders", "kr")].state == "fresh"
+    assert by_surface[("orderbook_nxt_capability", "kr")].state == "missing"
+    assert by_surface[("quotes", "kr")].state == "provider_unwired"
+    assert by_surface[("ohlcv", "kr")].state == "provider_unwired"
+    assert response.symbols[0].surfaces["screener_snapshots"] == "fresh"
+    assert response.symbols[1].surfaces["screener_snapshots"] == "stale"
+
+
+@pytest.mark.asyncio
+async def test_invest_coverage_endpoint_is_read_only_and_exposes_gaps(
+    app: FastAPI, db_session
+):
+    before = len(db_session.new)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.get("/invest/api/coverage?market=crypto&symbols=KRW-BTC")
+
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["market"] == "crypto"
+    assert "provider_unwired" in payload["states"]
+    assert any(
+        surface["state"] in {"unsupported", "provider_unwired"}
+        for surface in payload["surfaces"]
+    )
+    assert len(db_session.new) == before

--- a/tests/test_investor_flow_service.py
+++ b/tests/test_investor_flow_service.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from app.core.db import get_db
+from app.routers.dependencies import get_authenticated_user
+from app.routers.invest_api import router as invest_api_router
+from app.services.invest_view_model.investor_flow_service import (
+    build_investor_flow_cards,
+)
+from app.services.investor_flow_snapshots.repository import (
+    InvestorFlowSnapshotsRepository,
+    InvestorFlowSnapshotUpsert,
+)
+
+
+@pytest.fixture
+def app(db_session) -> FastAPI:
+    app = FastAPI()
+    app.include_router(invest_api_router)
+    app.dependency_overrides[get_authenticated_user] = lambda: type(
+        "U", (), {"id": 1}
+    )()
+
+    async def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    return app
+
+
+@pytest.mark.asyncio
+async def test_build_investor_flow_cards_empty_symbols_returns_empty(db_session):
+    response = await build_investor_flow_cards(
+        db=db_session,
+        symbols=[],
+        market="kr",
+        as_of=dt.date(2026, 5, 11),
+    )
+
+    assert response.market == "kr"
+    assert response.dataState == "empty"
+    assert response.items == []
+
+
+@pytest.mark.asyncio
+async def test_build_investor_flow_cards_marks_missing_symbol(db_session):
+    response = await build_investor_flow_cards(
+        db=db_session,
+        symbols=["900193"],
+        market="kr",
+        as_of=dt.date(2026, 5, 11),
+    )
+
+    assert response.dataState == "missing"
+    assert response.items[0].symbol == "900193"
+    assert response.items[0].dataState == "missing"
+    assert response.items[0].source is None
+
+
+@pytest.mark.asyncio
+async def test_build_investor_flow_cards_marks_all_stale(db_session):
+    repo = InvestorFlowSnapshotsRepository(db_session)
+    await repo.upsert(
+        InvestorFlowSnapshotUpsert(
+            market="kr",
+            symbol="900197",
+            snapshot_date=dt.date(2026, 5, 6),
+            foreign_net=-400,
+            institution_net=0,
+            individual_net=400,
+            source="naver_finance",
+            collected_at=dt.datetime(2026, 5, 6, 7, 0, tzinfo=dt.UTC),
+        )
+    )
+    await db_session.commit()
+
+    response = await build_investor_flow_cards(
+        db=db_session,
+        symbols=["900197"],
+        market="kr",
+        as_of=dt.date(2026, 5, 11),
+        max_stale_days=1,
+    )
+
+    assert response.dataState == "stale"
+    assert response.items[0].dataState == "stale"
+    assert response.items[0].snapshotDate == dt.date(2026, 5, 6)
+
+
+@pytest.mark.asyncio
+async def test_build_investor_flow_cards_marks_stale_and_fresh(db_session):
+    repo = InvestorFlowSnapshotsRepository(db_session)
+    await repo.upsert(
+        InvestorFlowSnapshotUpsert(
+            market="kr",
+            symbol="900194",
+            snapshot_date=dt.date(2026, 5, 7),
+            foreign_net=-1_000,
+            institution_net=-2_000,
+            individual_net=3_000,
+            foreign_net_sell_rank=4,
+            institution_net_sell_rank=8,
+            foreign_consecutive_sell_days=2,
+            source="naver_finance",
+            collected_at=dt.datetime(2026, 5, 7, 7, 0, tzinfo=dt.UTC),
+        )
+    )
+    await repo.upsert(
+        InvestorFlowSnapshotUpsert(
+            market="kr",
+            symbol="900195",
+            snapshot_date=dt.date(2026, 5, 11),
+            foreign_net=5_000,
+            institution_net=7_000,
+            individual_net=-12_000,
+            foreign_net_buy_rank=1,
+            institution_net_buy_rank=2,
+            foreign_consecutive_buy_days=5,
+            institution_consecutive_buy_days=3,
+            source="naver_finance",
+            collected_at=dt.datetime(2026, 5, 11, 7, 0, tzinfo=dt.UTC),
+        )
+    )
+    await db_session.commit()
+
+    response = await build_investor_flow_cards(
+        db=db_session,
+        symbols=["900194", "900195"],
+        market="kr",
+        as_of=dt.date(2026, 5, 11),
+        max_stale_days=1,
+    )
+
+    assert response.dataState == "partial"
+    stale, fresh = response.items
+    assert stale.dataState == "stale"
+    assert stale.doubleSell is True
+    assert stale.foreignNetSellRank == 4
+    assert stale.foreignConsecutiveSellDays == 2
+    assert fresh.dataState == "fresh"
+    assert fresh.doubleBuy is True
+    assert fresh.foreignNetBuyRank == 1
+    assert fresh.institutionNetBuyRank == 2
+    assert fresh.foreignConsecutiveBuyDays == 5
+
+
+@pytest.mark.asyncio
+async def test_investor_flow_endpoint_returns_read_only_view_model(app: FastAPI, db_session):
+    repo = InvestorFlowSnapshotsRepository(db_session)
+    await repo.upsert(
+        InvestorFlowSnapshotUpsert(
+            market="kr",
+            symbol="900196",
+            snapshot_date=dt.date.today(),
+            foreign_net=10,
+            institution_net=20,
+            individual_net=-30,
+            source="naver_finance",
+        )
+    )
+    await db_session.commit()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        r = await client.get("/invest/api/investor-flow?symbols=900196&market=kr")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["market"] == "kr"
+    assert body["dataState"] == "fresh"
+    assert body["items"][0]["symbol"] == "900196"
+    assert body["items"][0]["foreignNet"] == 10
+    assert body["items"][0]["doubleBuy"] is True

--- a/tests/test_investor_flow_service.py
+++ b/tests/test_investor_flow_service.py
@@ -150,7 +150,9 @@ async def test_build_investor_flow_cards_marks_stale_and_fresh(db_session):
 
 
 @pytest.mark.asyncio
-async def test_investor_flow_endpoint_returns_read_only_view_model(app: FastAPI, db_session):
+async def test_investor_flow_endpoint_returns_read_only_view_model(
+    app: FastAPI, db_session
+):
     repo = InvestorFlowSnapshotsRepository(db_session)
     await repo.upsert(
         InvestorFlowSnapshotUpsert(
@@ -165,7 +167,9 @@ async def test_investor_flow_endpoint_returns_read_only_view_model(app: FastAPI,
     )
     await db_session.commit()
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t"
+    ) as client:
         r = await client.get("/invest/api/investor-flow?symbols=900196&market=kr")
 
     assert r.status_code == 200

--- a/tests/test_investor_flow_snapshots_repository.py
+++ b/tests/test_investor_flow_snapshots_repository.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+
+from app.services.investor_flow_snapshots.repository import (
+    InvestorFlowSnapshotsRepository,
+    InvestorFlowSnapshotUpsert,
+)
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_latest_by_symbols_returns_fresh_snapshot(db_session):
+    repo = InvestorFlowSnapshotsRepository(db_session)
+    snapshot_date = dt.date(2026, 5, 11)
+
+    await repo.upsert(
+        InvestorFlowSnapshotUpsert(
+            market="kr",
+            symbol="900191",
+            snapshot_date=snapshot_date,
+            foreign_net=1_200_000,
+            institution_net=300_000,
+            individual_net=-1_500_000,
+            foreign_net_buy_rank=7,
+            institution_net_buy_rank=12,
+            foreign_consecutive_buy_days=3,
+            institution_consecutive_buy_days=1,
+            source="naver_finance",
+            collected_at=dt.datetime(2026, 5, 11, 6, 30, tzinfo=dt.UTC),
+        )
+    )
+    await db_session.commit()
+
+    rows = await repo.latest_by_symbols(
+        market="kr", symbols=["900191"], as_of=snapshot_date
+    )
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.symbol == "900191"
+    assert row.foreign_net == 1_200_000
+    assert row.institution_net == 300_000
+    assert row.individual_net == -1_500_000
+    assert row.foreign_net_buy_rank == 7
+    assert row.institution_net_buy_rank == 12
+    assert row.double_buy is True
+    assert row.double_sell is False
+    assert row.foreign_consecutive_buy_days == 3
+    assert row.source == "naver_finance"
+
+
+@pytest.mark.asyncio
+async def test_latest_by_symbols_picks_newest_snapshot_per_symbol(db_session):
+    repo = InvestorFlowSnapshotsRepository(db_session)
+    symbol = "900192"
+    await repo.upsert(
+        InvestorFlowSnapshotUpsert(
+            market="kr",
+            symbol=symbol,
+            snapshot_date=dt.date(2026, 5, 9),
+            foreign_net=-100,
+            institution_net=-200,
+            individual_net=300,
+            source="naver_finance",
+        )
+    )
+    await repo.upsert(
+        InvestorFlowSnapshotUpsert(
+            market="kr",
+            symbol=symbol,
+            snapshot_date=dt.date(2026, 5, 11),
+            foreign_net=100,
+            institution_net=200,
+            individual_net=-300,
+            source="naver_finance",
+        )
+    )
+    await db_session.commit()
+
+    rows = await repo.latest_by_symbols(
+        market="kr", symbols=[symbol], as_of=dt.date(2026, 5, 11)
+    )
+
+    assert len(rows) == 1
+    assert rows[0].snapshot_date == dt.date(2026, 5, 11)
+    assert rows[0].double_buy is True


### PR DESCRIPTION
## Summary
- Integrates ROB-191 investor-flow snapshot storage/service/API foundations.
- Adds ROB-192 read-only /invest coverage dashboard API and desktop route.
- Keeps the sprint scope read-only: no buy/sell recommendation logic and no broker/order mutations.

## Why this PR exists
ROB-193 final acceptance smoke is blocked because `origin/main`/`production` do not yet contain the prerequisite ROB-191 and ROB-192 lanes. This integration PR is the active unblock path before production/current smoke can be valid.

## Risk / Review Notes
- High-risk change: includes Alembic migration `9f1a2b3c4d5e_add_investor_flow_snapshots.py`.
- Requires stronger reviewer attention before merge/deploy.
- Production DB migration/deploy is not performed by this PR creation step and still requires the approved deployment path.

## Verification
- Combined merge check against `origin/main` was clean.
- Targeted lint on combined tree: `uv run ruff check ...` passed.
- Targeted tests on combined tree passed:
  - `uv run --group test python -m pytest tests/test_investor_flow_snapshots_repository.py tests/test_investor_flow_service.py tests/test_invest_coverage.py -q`
  - Result: `9 passed, 2 warnings`
- Alembic heads: single head `9f1a2b3c4d5e`.

## Safety
- No broker/order/watch/order-intent/live/paper trading side effects.
- No production DB writes/backfills/deletes.
- No scheduler activation.

Unblocks follow-up: ROB-193 final /invest acceptance smoke after merge + deploy/migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added coverage dashboard (`/invest/coverage`) to monitor data availability and freshness across multiple data sources for Korean market symbols.
  * Introduced investor flow API endpoint (`/invest/api/investor-flow`) providing net flow metrics for foreign, institutional, and individual investors.
  * New frontend pages and API helpers for accessing coverage and investor flow data.

* **Documentation**
  * Added coverage dashboard guide with freshness thresholds and supported data surfaces.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/785)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->