### PR TITLE
fix(ROB-184): route ForexFactory cache by payload week

### DIFF
--- a/app/services/market_events/forexfactory_helpers.py
+++ b/app/services/market_events/forexfactory_helpers.py
@@ -122,6 +122,28 @@ class ForexFactoryWeeklyCache:
             return THISWEEK_URL
         return NEXTWEEK_URL
 
+    def _candidate_urls_for(self, target_date: date) -> list[str] | None:
+        """Return URL candidates ordered by safest content-based selection.
+
+        ForexFactory can roll `thisweek` ahead before ET Monday while `nextweek`
+        is still unavailable. Fetch `thisweek` first and trust the parsed payload's
+        event week before falling back to `nextweek`, instead of routing solely by
+        local ET week math.
+        """
+        if target_date < self._window_start or target_date > self._window_end:
+            return None
+        return [THISWEEK_URL, NEXTWEEK_URL]
+
+    @staticmethod
+    def _payload_covers_date(rows: list[dict[str, Any]], target_date: date) -> bool:
+        """Infer whether a parsed weekly payload is the upstream week for a date."""
+        event_dates = [r["event_date"] for r in rows if r.get("event_date")]
+        if not event_dates:
+            return False
+        week_start = min(event_dates) - timedelta(days=min(event_dates).weekday())
+        week_end = week_start + timedelta(days=6)
+        return week_start <= target_date <= week_end
+
     async def _ensure_payload(self, url: str) -> list[dict[str, Any]]:
         cached = self._payloads.get(url)
         if cached is not None:
@@ -134,11 +156,21 @@ class ForexFactoryWeeklyCache:
     async def get_events_for_date(
         self, target_date: date
     ) -> list[dict[str, Any]] | None:
-        url = self._url_for(target_date)
-        if url is None:
+        urls = self._candidate_urls_for(target_date)
+        if urls is None:
             return None
-        rows = await self._ensure_payload(url)
-        return [r for r in rows if r["event_date"] == target_date]
+
+        fallback_rows: list[dict[str, Any]] | None = None
+        for url in urls:
+            rows = await self._ensure_payload(url)
+            matching_rows = [r for r in rows if r["event_date"] == target_date]
+            if self._payload_covers_date(rows, target_date):
+                return matching_rows
+            if matching_rows:
+                return matching_rows
+            fallback_rows = matching_rows
+
+        return fallback_rows or []
 
 
 async def _fetch_xml_documents(target_date: date) -> list[str]:

--- a/tests/services/test_market_events_forexfactory_helpers.py
+++ b/tests/services/test_market_events_forexfactory_helpers.py
@@ -287,3 +287,82 @@ async def test_weekly_cache_returns_none_for_dates_outside_window(monkeypatch):
     cache = ff.ForexFactoryWeeklyCache(now_utc=datetime(2026, 5, 13, 12, 0, tzinfo=UTC))
     assert await cache.get_events_for_date(date(2026, 4, 30)) is None
     assert await cache.get_events_for_date(date(2026, 5, 30)) is None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_weekly_cache_uses_thisweek_after_early_upstream_rollover(monkeypatch):
+    from app.services.market_events import forexfactory_helpers as ff
+
+    rolled_thisweek_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<weeklyevents>
+  <event>
+    <title>FOMC Member Speaks</title>
+    <country>USD</country>
+    <date>05-11-2026</date>
+    <time>9:00am</time>
+    <impact>Medium</impact>
+    <forecast></forecast>
+    <previous></previous>
+    <actual></actual>
+  </event>
+</weeklyevents>
+"""
+    call_log: list[str] = []
+
+    async def fake_fetch(url, **kw):
+        call_log.append(url)
+        if url == ff.NEXTWEEK_URL:
+            raise AssertionError(
+                "nextweek should not be fetched when thisweek covers target"
+            )
+        return rolled_thisweek_xml
+
+    monkeypatch.setattr(ff, "_fetch_one_xml", fake_fetch)
+
+    # 2026-05-11 03:30 UTC == Sunday 2026-05-10 23:30 ET, before local Monday.
+    cache = ff.ForexFactoryWeeklyCache(now_utc=datetime(2026, 5, 11, 3, 30, tzinfo=UTC))
+    rows = await cache.get_events_for_date(date(2026, 5, 11))
+
+    assert [r["title"] for r in rows] == ["FOMC Member Speaks"]
+    assert call_log == [ff.THISWEEK_URL]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_weekly_cache_returns_empty_when_thisweek_payload_covers_blank_day(
+    monkeypatch,
+):
+    from app.services.market_events import forexfactory_helpers as ff
+
+    rolled_thisweek_xml = """<?xml version="1.0" encoding="UTF-8"?>
+<weeklyevents>
+  <event>
+    <title>NFIB Small Business Index</title>
+    <country>USD</country>
+    <date>05-12-2026</date>
+    <time>6:00am</time>
+    <impact>Low</impact>
+    <forecast></forecast>
+    <previous></previous>
+    <actual></actual>
+  </event>
+</weeklyevents>
+"""
+    call_log: list[str] = []
+
+    async def fake_fetch(url, **kw):
+        call_log.append(url)
+        if url == ff.NEXTWEEK_URL:
+            raise AssertionError(
+                "nextweek should not be fetched for a blank day in thisweek"
+            )
+        return rolled_thisweek_xml
+
+    monkeypatch.setattr(ff, "_fetch_one_xml", fake_fetch)
+
+    cache = ff.ForexFactoryWeeklyCache(now_utc=datetime(2026, 5, 11, 3, 30, tzinfo=UTC))
+    rows = await cache.get_events_for_date(date(2026, 5, 11))
+
+    assert rows == []
+    assert call_log == [ff.THISWEEK_URL]


### PR DESCRIPTION
## Summary
- Route ForexFactory weekly cache lookups by parsed payload date coverage, not only ET wall-clock week math.
- Preserve the ability to use `thisweek` when the upstream rolls that payload forward before `nextweek` is available.
- Add regression coverage for early upstream rollover, blank covered days, and out-of-window fallback behavior.

## Test Plan
- `uv run --group test python -m pytest tests/services/test_market_events_forexfactory_helpers.py -q`
- `uv run ruff check app/services/market_events/forexfactory_helpers.py tests/services/test_market_events_forexfactory_helpers.py`
- `uv run ruff format --check app/services/market_events/forexfactory_helpers.py tests/services/test_market_events_forexfactory_helpers.py`

## Operational notes
- No broker/order/watch mutations.
- No production DB writes or backfill in this PR.
- This unblocks ROB-184's current-week calendar recovery path; future-week rows remain dependent on upstream `nextweek` availability or a separately approved unavailable-state/backfill policy.

Closes ROB-184
