### PR TITLE
fix(ROB-186): surface calendar highlight rows

### DIFF
--- a/app/schemas/invest_calendar.py
+++ b/app/schemas/invest_calendar.py
@@ -18,6 +18,14 @@ EventType = Literal["earnings", "economic", "disclosure", "crypto", "other"]
 RelationKind = Literal["held", "watchlist", "both", "none"]
 Badge = Literal["holdings", "watchlist", "major"]
 CalendarTab = Literal["all", "economic", "earnings", "disclosure", "crypto"]
+HighlightReason = Literal[
+    "held",
+    "watchlist",
+    "major",
+    "high_impact",
+    "near_term",
+    "has_values",
+]
 
 
 class CalendarRelatedSymbol(BaseModel):
@@ -41,6 +49,8 @@ class CalendarEvent(BaseModel):
     relatedSymbols: list[CalendarRelatedSymbol] = Field(default_factory=list)
     relation: RelationKind = "none"
     badges: list[Badge] = Field(default_factory=list)
+    displayPriority: int = 0
+    highlightReasons: list[HighlightReason] = Field(default_factory=list)
 
 
 class CalendarCluster(BaseModel):
@@ -53,12 +63,21 @@ class CalendarCluster(BaseModel):
     topEvents: list[CalendarEvent] = Field(default_factory=list)
 
 
+class CalendarDaySummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    headline: str | None = None
+    highlightEventIds: list[str] = Field(default_factory=list)
+    overflowCount: int = 0
+    overflowLabel: str | None = None
+
+
 class CalendarDay(BaseModel):
     model_config = ConfigDict(extra="forbid")
     date: date
     events: list[CalendarEvent] = Field(default_factory=list)
     clusters: list[CalendarCluster] = Field(default_factory=list)
     dataState: CalendarDayState = "loaded"
+    summary: CalendarDaySummary | None = None
 
 
 class CalendarMeta(BaseModel):

--- a/app/services/invest_view_model/calendar_service.py
+++ b/app/services/invest_view_model/calendar_service.py
@@ -11,6 +11,7 @@ from app.schemas.invest_calendar import (
     Badge,
     CalendarCluster,
     CalendarDay,
+    CalendarDaySummary,
     CalendarEvent,
     CalendarMarket,
     CalendarMeta,
@@ -18,15 +19,111 @@ from app.schemas.invest_calendar import (
     CalendarResponse,
     CalendarTab,
     EventType,
+    HighlightReason,
 )
 from app.services.invest_view_model.relation_resolver import RelationResolver
 from app.services.market_events.freshness_service import MarketEventsFreshnessService
 from app.services.market_events.query_service import MarketEventsQueryService
 
 CLUSTER_THRESHOLD = 10
+DAY_HIGHLIGHT_LIMIT = 5
+CLUSTER_TOP_EVENT_LIMIT = 5
+
+_EVENT_TYPE_ORDER: dict[EventType, int] = {
+    "economic": 0,
+    "earnings": 1,
+    "disclosure": 2,
+    "crypto": 3,
+    "other": 4,
+}
+_MARKET_ORDER: dict[CalendarMarket, int] = {"kr": 0, "us": 1, "global": 2, "crypto": 3}
+_HIGH_IMPACT_TERMS = ("cpi", "fomc", "nonfarm", "payroll", "pce", "gdp", "금리", "고용")
 
 _MARKET_LITERAL = cast  # alias — used for type narrowing below
 
+
+
+def _event_date_key(value: datetime | None) -> tuple[int, str]:
+    if value is None:
+        return (1, "")
+    return (0, value.isoformat())
+
+
+def _is_high_impact_macro(event: CalendarEvent) -> bool:
+    if event.eventType != "economic":
+        return False
+    haystack = f"{event.title} {event.source}".lower()
+    return any(term in haystack for term in _HIGH_IMPACT_TERMS)
+
+
+def _rank_calendar_event(
+    event: CalendarEvent,
+    *,
+    target_date: date,
+    today: date | None = None,
+) -> tuple[int, list[HighlightReason]]:
+    score = 0
+    reasons: list[HighlightReason] = []
+    if event.relation in ("held", "both"):
+        score += 1000
+        reasons.append("held")
+    if event.relation in ("watchlist", "both"):
+        score += 700
+        reasons.append("watchlist")
+    if "major" in event.badges:
+        score += 500
+        reasons.append("major")
+    if _is_high_impact_macro(event):
+        score += 400
+        reasons.append("high_impact")
+    ref_today = today or date.today()
+    if target_date in (ref_today, ref_today + timedelta(days=1)):
+        score += 100
+        reasons.append("near_term")
+    if event.actual is not None or event.forecast is not None or event.previous is not None:
+        score += 50
+        reasons.append("has_values")
+    return score, reasons
+
+
+def _sort_key(event: CalendarEvent) -> tuple[int, int, tuple[int, str], int, int, str, str]:
+    return (
+        -event.displayPriority,
+        _EVENT_TYPE_ORDER.get(event.eventType, 99),
+        _event_date_key(event.eventTimeLocal),
+        _MARKET_ORDER.get(event.market, 99),
+        0 if event.title else 1,
+        event.title.lower(),
+        event.eventId,
+    )
+
+
+def _with_priority(event: CalendarEvent, *, target_date: date) -> CalendarEvent:
+    score, reasons = _rank_calendar_event(event, target_date=target_date)
+    return event.model_copy(update={"displayPriority": score, "highlightReasons": reasons})
+
+
+def _sort_calendar_events(events: list[CalendarEvent]) -> list[CalendarEvent]:
+    return sorted(events, key=_sort_key)
+
+
+def _build_day_summary(all_events: list[CalendarEvent]) -> CalendarDaySummary | None:
+    total = len(all_events)
+    if total == 0:
+        return None
+    highlights = _sort_calendar_events(all_events)[:DAY_HIGHLIGHT_LIMIT]
+    highlight_ids = [ev.eventId for ev in highlights]
+    overflow = max(total - len(highlight_ids), 0)
+    overflow_label = f"그 외 {overflow}개" if overflow else None
+    headline = f"주요 일정 {len(highlight_ids)}개"
+    if overflow_label:
+        headline = f"{headline} · {overflow_label}"
+    return CalendarDaySummary(
+        headline=headline,
+        highlightEventIds=highlight_ids,
+        overflowCount=overflow,
+        overflowLabel=overflow_label,
+    )
 
 def _normalize_event_type(value: str | None) -> EventType:
     v = (value or "").lower()
@@ -134,15 +231,17 @@ async def build_calendar(
 
     days: list[CalendarDay] = []
     for d in _date_range(from_date, to_date):
-        events = by_day.get(d, [])
+        events = _sort_calendar_events([_with_priority(ev, target_date=d) for ev in by_day.get(d, [])])
+        summary = _build_day_summary(events)
         clusters: list[CalendarCluster] = []
         if len(events) > CLUSTER_THRESHOLD:
             grouped: dict[tuple[EventType, CalendarMarket], list[CalendarEvent]] = {}
             for ev in events:
                 grouped.setdefault((ev.eventType, ev.market), []).append(ev)
             kept: list[CalendarEvent] = []
-            for (etype, market), group in grouped.items():
-                if len(group) > 5:
+            for (etype, market), group in sorted(grouped.items(), key=lambda item: (_EVENT_TYPE_ORDER.get(item[0][0], 99), _MARKET_ORDER.get(item[0][1], 99))):
+                group = _sort_calendar_events(group)
+                if len(group) > CLUSTER_TOP_EVENT_LIMIT:
                     clusters.append(
                         CalendarCluster(
                             clusterId=f"{d.isoformat()}:{etype}:{market}",
@@ -150,7 +249,7 @@ async def build_calendar(
                             eventType=etype,
                             market=market,
                             eventCount=len(group),
-                            topEvents=group[:5],
+                            topEvents=group[:CLUSTER_TOP_EVENT_LIMIT],
                         )
                     )
                 else:
@@ -163,6 +262,7 @@ async def build_calendar(
                 events=events,
                 clusters=clusters,
                 dataState=day_state,
+                summary=summary,
             )
         )
 

--- a/app/services/invest_view_model/calendar_service.py
+++ b/app/services/invest_view_model/calendar_service.py
@@ -42,7 +42,6 @@ _HIGH_IMPACT_TERMS = ("cpi", "fomc", "nonfarm", "payroll", "pce", "gdp", "금리
 _MARKET_LITERAL = cast  # alias — used for type narrowing below
 
 
-
 def _event_date_key(value: datetime | None) -> tuple[int, str]:
     if value is None:
         return (1, "")
@@ -80,13 +79,19 @@ def _rank_calendar_event(
     if target_date in (ref_today, ref_today + timedelta(days=1)):
         score += 100
         reasons.append("near_term")
-    if event.actual is not None or event.forecast is not None or event.previous is not None:
+    if (
+        event.actual is not None
+        or event.forecast is not None
+        or event.previous is not None
+    ):
         score += 50
         reasons.append("has_values")
     return score, reasons
 
 
-def _sort_key(event: CalendarEvent) -> tuple[int, int, tuple[int, str], int, int, str, str]:
+def _sort_key(
+    event: CalendarEvent,
+) -> tuple[int, int, tuple[int, str], int, int, str, str]:
     return (
         -event.displayPriority,
         _EVENT_TYPE_ORDER.get(event.eventType, 99),
@@ -100,7 +105,9 @@ def _sort_key(event: CalendarEvent) -> tuple[int, int, tuple[int, str], int, int
 
 def _with_priority(event: CalendarEvent, *, target_date: date) -> CalendarEvent:
     score, reasons = _rank_calendar_event(event, target_date=target_date)
-    return event.model_copy(update={"displayPriority": score, "highlightReasons": reasons})
+    return event.model_copy(
+        update={"displayPriority": score, "highlightReasons": reasons}
+    )
 
 
 def _sort_calendar_events(events: list[CalendarEvent]) -> list[CalendarEvent]:
@@ -124,6 +131,7 @@ def _build_day_summary(all_events: list[CalendarEvent]) -> CalendarDaySummary | 
         overflowCount=overflow,
         overflowLabel=overflow_label,
     )
+
 
 def _normalize_event_type(value: str | None) -> EventType:
     v = (value or "").lower()
@@ -231,7 +239,9 @@ async def build_calendar(
 
     days: list[CalendarDay] = []
     for d in _date_range(from_date, to_date):
-        events = _sort_calendar_events([_with_priority(ev, target_date=d) for ev in by_day.get(d, [])])
+        events = _sort_calendar_events(
+            [_with_priority(ev, target_date=d) for ev in by_day.get(d, [])]
+        )
         summary = _build_day_summary(events)
         clusters: list[CalendarCluster] = []
         if len(events) > CLUSTER_THRESHOLD:
@@ -239,7 +249,13 @@ async def build_calendar(
             for ev in events:
                 grouped.setdefault((ev.eventType, ev.market), []).append(ev)
             kept: list[CalendarEvent] = []
-            for (etype, market), group in sorted(grouped.items(), key=lambda item: (_EVENT_TYPE_ORDER.get(item[0][0], 99), _MARKET_ORDER.get(item[0][1], 99))):
+            for (etype, market), group in sorted(
+                grouped.items(),
+                key=lambda item: (
+                    _EVENT_TYPE_ORDER.get(item[0][0], 99),
+                    _MARKET_ORDER.get(item[0][1], 99),
+                ),
+            ):
                 group = _sort_calendar_events(group)
                 if len(group) > CLUSTER_TOP_EVENT_LIMIT:
                     clusters.append(

--- a/frontend/invest/src/__tests__/SelectedDateEvents.test.tsx
+++ b/frontend/invest/src/__tests__/SelectedDateEvents.test.tsx
@@ -16,7 +16,7 @@ function evt(id: string, title: string): CalendarEventVM {
     id, date: "2026-05-11", dayOfMonth: 11, monthDay: "5/11",
     type: "earnings", region: "us", title,
     time: null, released: false, actual: null, forecast: null, previous: null,
-    own: null, badges: [],
+    own: null, badges: [], displayPriority: 0, highlightReasons: [],
   };
 }
 
@@ -73,6 +73,23 @@ describe("SelectedDateEvents", () => {
     expect(root).toHaveAttribute("data-selected-date", "2026-05-11");
     expect(root).toHaveTextContent("5월 11일 월요일 일정");
     expect(root).toHaveTextContent("327건");
+  });
+
+  test("renders neutral day summary and overflow label when provided", () => {
+    render(
+      <SelectedDateEvents
+        {...baseProps}
+        events={[evt("e1", "AAPL earnings"), evt("e2", "MSFT earnings")]}
+        summary={{
+          headline: "주요 일정 2개 · 그 외 7개",
+          highlightEventIds: ["e1", "e2"],
+          overflowCount: 7,
+          overflowLabel: "그 외 7개",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("calendar-day-summary")).toHaveTextContent("주요 일정 2개 · 그 외 7개");
+    expect(screen.getByText(/2026-05-11 · 2건 · 그 외 7개/)).toBeInTheDocument();
   });
 
   test("loading + populated together still shows skeleton (loading wins)", () => {

--- a/frontend/invest/src/__tests__/SelectedDateEvents.test.tsx
+++ b/frontend/invest/src/__tests__/SelectedDateEvents.test.tsx
@@ -115,4 +115,31 @@ describe("SelectedDateEvents", () => {
     expect(screen.getByTestId("calendar-error")).toBeInTheDocument();
     expect(screen.queryByText("stale")).not.toBeInTheDocument();
   });
+
+  test("heavy cluster renders topEvents as primary EventRow rows before overflow indicator", () => {
+    render(
+      <SelectedDateEvents
+        {...baseProps}
+        clusters={[
+          {
+            id: "c1", date: "2026-05-11", dayOfMonth: 11, monthDay: "5/11",
+            type: "earnings", region: "us", title: "미국 실적 발표 284건",
+            count: 284, topEvents: [evt("held", "AAPL 실적"), evt("watched", "MSFT 실적")],
+          },
+        ]}
+      />,
+    );
+    const list = screen.getByTestId("day-events");
+    // topEvents must render as first-class EventRow instances
+    const eventRows = within(list).getAllByTestId("calendar-event");
+    expect(eventRows).toHaveLength(2);
+    expect(eventRows[0]).toHaveTextContent("AAPL 실적");
+    expect(eventRows[1]).toHaveTextContent("MSFT 실적");
+    // overflow indicator shows remaining count as secondary context
+    const overflow = within(list).getByTestId("calendar-cluster-overflow");
+    expect(overflow).toHaveTextContent("미국 실적 발표");
+    expect(overflow).toHaveTextContent("282건");
+    // raw aggregate ClusterRow must NOT be the primary content
+    expect(within(list).queryByTestId("calendar-cluster")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/invest/src/components/calendar/ClusterEventRows.tsx
+++ b/frontend/invest/src/components/calendar/ClusterEventRows.tsx
@@ -1,0 +1,32 @@
+import { Fragment } from "react";
+import { EventRow } from "./EventRow";
+import type { CalendarClusterVM } from "./vm";
+
+export function ClusterEventRows({ clusters }: { clusters: CalendarClusterVM[] }) {
+  return (
+    <>
+      {clusters.map((cluster) => (
+        <Fragment key={cluster.id}>
+          {cluster.topEvents.map((event) => (
+            <EventRow key={event.id} ev={event} />
+          ))}
+          {cluster.count > cluster.topEvents.length ? <ClusterOverflow cluster={cluster} /> : null}
+        </Fragment>
+      ))}
+    </>
+  );
+}
+
+function ClusterOverflow({ cluster }: { cluster: CalendarClusterVM }) {
+  const overflowCount = cluster.count - cluster.topEvents.length;
+  const baseLabel = cluster.title.replace(/\s+\d+건$/, "");
+  return (
+    <div
+      className="calendar-cluster-overflow"
+      data-testid="calendar-cluster-overflow"
+      data-cluster-id={cluster.id}
+    >
+      {baseLabel} · 그 외 {overflowCount}건
+    </div>
+  );
+}

--- a/frontend/invest/src/components/calendar/DaySection.tsx
+++ b/frontend/invest/src/components/calendar/DaySection.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import { ClusterRow } from "./ClusterRow";
+import { ClusterEventRows } from "./ClusterEventRows";
 import { EventRow } from "./EventRow";
 import type { CalendarClusterVM, CalendarEventVM } from "./vm";
 import { dayEmptyLabel, dayHeaderLabel, dayTotalLabel } from "./vm";
@@ -46,9 +46,7 @@ export const DaySection = forwardRef<HTMLElement, DaySectionProps>(function DayS
         <div className="calendar-day-section__empty">{dayEmptyLabel()}</div>
       ) : (
         <div className="calendar-day-section__body">
-          {clusters.map((c) => (
-            <ClusterRow key={c.id} cluster={c} />
-          ))}
+          <ClusterEventRows clusters={clusters} />
           {events.map((ev) => (
             <EventRow key={ev.id} ev={ev} />
           ))}

--- a/frontend/invest/src/components/calendar/SelectedDateEvents.tsx
+++ b/frontend/invest/src/components/calendar/SelectedDateEvents.tsx
@@ -1,7 +1,7 @@
 import { ClusterRow } from "./ClusterRow";
 import { EventRow } from "./EventRow";
 import { EmptyEventState } from "./EmptyEventState";
-import type { CalendarClusterVM, CalendarEventVM } from "./vm";
+import type { CalendarClusterVM, CalendarDaySummaryVM, CalendarEventVM } from "./vm";
 
 export interface SelectedDateEventsProps {
   dateLabel: string;
@@ -11,6 +11,7 @@ export interface SelectedDateEventsProps {
   emptyMessage: string;
   loading?: boolean;
   error?: string | null;
+  summary?: CalendarDaySummaryVM | null;
 }
 
 export function SelectedDateEvents({
@@ -21,6 +22,7 @@ export function SelectedDateEvents({
   emptyMessage,
   loading = false,
   error = null,
+  summary = null,
 }: SelectedDateEventsProps) {
   const total = events.length + clusters.reduce((s, c) => s + c.count, 0);
 
@@ -33,9 +35,14 @@ export function SelectedDateEvents({
       <div className="calendar-selected-date__header">
         <h2 className="calendar-selected-date__label">{dateLabel}</h2>
         <span className="calendar-selected-date__meta">
-          {dateIso} · {total}건
+          {dateIso} · {total}건{summary?.overflowLabel ? ` · ${summary.overflowLabel}` : ""}
         </span>
       </div>
+      {!loading && !error && summary?.headline ? (
+        <div data-testid="calendar-day-summary" className="calendar-selected-date__summary">
+          {summary.headline}
+        </div>
+      ) : null}
       <div data-testid="day-events" className="calendar-selected-date__list">
         {loading ? (
           <SkeletonRows />

--- a/frontend/invest/src/components/calendar/SelectedDateEvents.tsx
+++ b/frontend/invest/src/components/calendar/SelectedDateEvents.tsx
@@ -1,4 +1,4 @@
-import { ClusterRow } from "./ClusterRow";
+import { ClusterEventRows } from "./ClusterEventRows";
 import { EventRow } from "./EventRow";
 import { EmptyEventState } from "./EmptyEventState";
 import type { CalendarClusterVM, CalendarDaySummaryVM, CalendarEventVM } from "./vm";
@@ -52,9 +52,7 @@ export function SelectedDateEvents({
           <EmptyEventState message={emptyMessage} />
         ) : (
           <>
-            {clusters.map((c) => (
-              <ClusterRow key={c.id} cluster={c} />
-            ))}
+            <ClusterEventRows clusters={clusters} />
             {events.map((ev) => (
               <EventRow key={ev.id} ev={ev} />
             ))}

--- a/frontend/invest/src/components/calendar/vm.ts
+++ b/frontend/invest/src/components/calendar/vm.ts
@@ -2,7 +2,9 @@ import type {
   CalendarCluster,
   CalendarDay,
   CalendarDayState,
+  CalendarDaySummary,
   CalendarEvent,
+  HighlightReason,
   CalendarSourceStatus,
 } from "../../types/calendar";
 
@@ -25,6 +27,8 @@ export interface CalendarEventVM {
   previous: string | null;
   own: DisplayOwnership;
   badges: string[];
+  displayPriority?: number;
+  highlightReasons?: HighlightReason[];
 }
 
 export interface CalendarClusterVM {
@@ -74,8 +78,12 @@ export function toEventVM(event: CalendarEvent, date: string): CalendarEventVM {
     previous: event.previous ?? null,
     own: mapOwnership(event),
     badges: event.badges,
+    displayPriority: event.displayPriority ?? 0,
+    highlightReasons: event.highlightReasons ?? [],
   };
 }
+
+export type CalendarDaySummaryVM = CalendarDaySummary;
 
 export function calendarDayEventCount(day: CalendarDay): number {
   return day.events.length + day.clusters.reduce((sum, cluster) => sum + cluster.eventCount, 0);

--- a/frontend/invest/src/pages/desktop/DesktopCalendarPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCalendarPage.tsx
@@ -3,7 +3,7 @@ import { DesktopShell } from "../../desktop/DesktopShell";
 import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useViewport } from "../../hooks/useViewport";
 import { fetchCalendar, fetchWeeklySummary } from "../../api/calendar";
-import type { CalendarResponse, WeeklySummaryResponse } from "../../types/calendar";
+import type { CalendarDaySummary, CalendarResponse, WeeklySummaryResponse } from "../../types/calendar";
 import { Card } from "../../ds";
 import { AIWeeklyCard } from "../../components/calendar/AIWeeklyCard";
 import { CalendarMonthHeader } from "../../components/calendar/CalendarMonthHeader";
@@ -36,6 +36,7 @@ interface FilteredDay {
   events: CalendarEventVM[];
   clusters: CalendarClusterVM[];
   total: number;
+  summary?: CalendarDaySummary | null;
 }
 
 export function CalendarRoute() {
@@ -128,7 +129,7 @@ export function DesktopCalendarPage() {
         .filter((cluster) => matchesFilters(cluster, typeFilter, regionFilter));
       const total = events.length + clusters.reduce((sum, c) => sum + c.count, 0);
       if (total === 0) continue;
-      map.set(d.date, { events, clusters, total });
+      map.set(d.date, { events, clusters, total, summary: d.summary });
     }
     return map;
   }, [calendar?.days, typeFilter, regionFilter]);

--- a/frontend/invest/src/pages/mobile/MobileCalendarPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileCalendarPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { MobileShell } from "../../mobile/MobileShell";
 import { fetchCalendar, fetchWeeklySummary } from "../../api/calendar";
-import type { CalendarResponse, WeeklySummaryResponse } from "../../types/calendar";
+import type { CalendarDaySummary, CalendarResponse, WeeklySummaryResponse } from "../../types/calendar";
 import { Icon } from "../../ds";
 import { CalendarMonthHeader } from "../../components/calendar/CalendarMonthHeader";
 import { CalendarSourceButton } from "../../components/calendar/CalendarSourceButton";

--- a/frontend/invest/src/styles/calendar.css
+++ b/frontend/invest/src/styles/calendar.css
@@ -98,6 +98,13 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.calendar-cluster-overflow {
+  grid-column: 1 / -1;
+  padding: 8px 12px;
+  font-size: 12px;
+  color: var(--fg-3);
+  border-bottom: 1px solid var(--border);
+}
 .calendar-event-row__num {
   text-align: right;
   font-size: 13px;

--- a/frontend/invest/src/styles/calendar.css
+++ b/frontend/invest/src/styles/calendar.css
@@ -161,6 +161,16 @@
   color: var(--fg-3);
   font-feature-settings: "tnum";
 }
+.calendar-selected-date__summary {
+  margin: 0 6px 2px;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: var(--surface-2);
+  color: var(--fg-2);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
 .calendar-selected-date__list {
   display: flex;
   flex-direction: column;

--- a/frontend/invest/src/types/calendar.ts
+++ b/frontend/invest/src/types/calendar.ts
@@ -3,6 +3,7 @@ export type CalendarMarket = "kr" | "us" | "crypto" | "global";
 export type EventType = "earnings" | "economic" | "disclosure" | "crypto" | "other";
 export type CalendarRelation = "held" | "watchlist" | "both" | "none";
 export type CalendarSourceState = "fresh" | "stale" | "failed" | "missing";
+export type HighlightReason = "held" | "watchlist" | "major" | "high_impact" | "near_term" | "has_values";
 export type CalendarDayState =
   | "loaded"
   | "empty"
@@ -54,6 +55,8 @@ export interface CalendarEvent {
   relatedSymbols: CalendarRelatedSymbol[];
   relation: CalendarRelation;
   badges: ("holdings" | "watchlist" | "major")[];
+  displayPriority?: number;
+  highlightReasons?: HighlightReason[];
 }
 
 export interface CalendarCluster {
@@ -65,11 +68,19 @@ export interface CalendarCluster {
   topEvents: CalendarEvent[];
 }
 
+export interface CalendarDaySummary {
+  headline?: string | null;
+  highlightEventIds: string[];
+  overflowCount: number;
+  overflowLabel?: string | null;
+}
+
 export interface CalendarDay {
   date: string;
   events: CalendarEvent[];
   clusters: CalendarCluster[];
   dataState: CalendarDayState;
+  summary?: CalendarDaySummary | null;
 }
 
 export interface CalendarResponse {

--- a/tests/test_invest_calendar_router.py
+++ b/tests/test_invest_calendar_router.py
@@ -129,7 +129,9 @@ async def test_calendar_clusters_when_over_threshold(monkeypatch) -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_calendar_prioritizes_held_watchlist_and_value_events(monkeypatch) -> None:
+async def test_calendar_prioritizes_held_watchlist_and_value_events(
+    monkeypatch,
+) -> None:
     from app.services.invest_view_model import calendar_service as svc
 
     fake_resp = MagicMock()
@@ -157,30 +159,59 @@ async def test_calendar_prioritizes_held_watchlist_and_value_events(monkeypatch)
     )
 
     events = resp.days[0].events
-    assert [event.eventId for event in events] == ["held", "watched", "valued", "ordinary"]
-    assert events[0].displayPriority > events[1].displayPriority > events[2].displayPriority
+    assert [event.eventId for event in events] == [
+        "held",
+        "watched",
+        "valued",
+        "ordinary",
+    ]
+    assert (
+        events[0].displayPriority
+        > events[1].displayPriority
+        > events[2].displayPriority
+    )
     assert events[0].highlightReasons == ["held"]
     assert events[1].highlightReasons == ["watchlist"]
     assert events[2].highlightReasons == ["has_values"]
     assert resp.days[0].summary is not None
-    assert resp.days[0].summary.highlightEventIds == ["held", "watched", "valued", "ordinary"]
+    assert resp.days[0].summary.highlightEventIds == [
+        "held",
+        "watched",
+        "valued",
+        "ordinary",
+    ]
     assert resp.days[0].summary.overflowCount == 0
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_calendar_cluster_top_events_and_summary_are_priority_aware(monkeypatch) -> None:
+async def test_calendar_cluster_top_events_and_summary_are_priority_aware(
+    monkeypatch,
+) -> None:
     from app.services.invest_view_model import calendar_service as svc
 
     fake_resp = MagicMock()
     fake_resp.events = [
         *[
-            _fake_event(event_id=f"ordinary-{i}", category="earnings", market="us", symbol=f"ZZZ{i}")
+            _fake_event(
+                event_id=f"ordinary-{i}",
+                category="earnings",
+                market="us",
+                symbol=f"ZZZ{i}",
+            )
             for i in range(12)
         ],
-        _fake_event(event_id="watched", category="earnings", market="us", symbol="MSFT"),
+        _fake_event(
+            event_id="watched", category="earnings", market="us", symbol="MSFT"
+        ),
         _fake_event(event_id="held", category="earnings", market="us", symbol="AAPL"),
-        _fake_event(event_id="valued", category="earnings", market="us", symbol="TSLA", actual="2.34"),
+        _fake_event(
+            event_id="valued",
+            category="earnings",
+            market="us",
+            symbol="TSLA",
+            actual="2.34",
+        ),
     ]
     fake_query_service = MagicMock()
     fake_query_service.list_for_range = AsyncMock(return_value=fake_resp)
@@ -200,8 +231,10 @@ async def test_calendar_cluster_top_events_and_summary_are_priority_aware(monkey
     )
 
     day = resp.days[0]
-    assert day.events == []
     assert len(day.clusters) == 1
+    assert (
+        len(day.clusters[0].topEvents) == 5
+    )  # top events available for primary row rendering
     assert [event.eventId for event in day.clusters[0].topEvents[:3]] == [
         "held",
         "watched",

--- a/tests/test_invest_calendar_router.py
+++ b/tests/test_invest_calendar_router.py
@@ -18,6 +18,10 @@ def _fake_event(
     category: str = "earnings",
     symbol: str | None = None,
     ev_date: date | None = None,
+    title: str | None = None,
+    actual: str | None = None,
+    forecast: str | None = None,
+    previous: str | None = None,
 ):
     e = MagicMock()
     # MarketEventResponse uses source_event_id, not event_id
@@ -27,11 +31,18 @@ def _fake_event(
     e.category = category
     e.symbol = symbol
     e.company_name = symbol
-    e.title = f"event {event_id}"
+    e.title = title or f"event {event_id}"
     e.event_date = ev_date or date(2026, 5, 4)
     e.release_time_utc = None
     e.source = "test"
-    e.values = []
+    if actual is not None or forecast is not None or previous is not None:
+        value = MagicMock()
+        value.actual = actual
+        value.forecast = forecast
+        value.previous = previous
+        e.values = [value]
+    else:
+        e.values = []
     return e
 
 
@@ -114,6 +125,93 @@ async def test_calendar_clusters_when_over_threshold(monkeypatch) -> None:
     )
     assert len(resp.days[0].clusters) == 1
     assert resp.days[0].clusters[0].eventCount == 15
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_calendar_prioritizes_held_watchlist_and_value_events(monkeypatch) -> None:
+    from app.services.invest_view_model import calendar_service as svc
+
+    fake_resp = MagicMock()
+    fake_resp.events = [
+        _fake_event(event_id="ordinary", symbol="ZZZZ"),
+        _fake_event(event_id="watched", symbol="MSFT"),
+        _fake_event(event_id="held", symbol="AAPL"),
+        _fake_event(event_id="valued", symbol="TSLA", forecast="1.23"),
+    ]
+    fake_query_service = MagicMock()
+    fake_query_service.list_for_range = AsyncMock(return_value=fake_resp)
+    monkeypatch.setattr(svc, "MarketEventsQueryService", lambda db: fake_query_service)
+    _patch_freshness(monkeypatch, svc, date(2026, 5, 4), date(2026, 5, 4))
+
+    resolver = RelationResolver(
+        held={("us", "AAPL")},
+        watch={("us", "MSFT")},
+    )
+    resp = await svc.build_calendar(
+        db=MagicMock(),
+        resolver=resolver,
+        from_date=date(2026, 5, 4),
+        to_date=date(2026, 5, 4),
+        tab="all",
+    )
+
+    events = resp.days[0].events
+    assert [event.eventId for event in events] == ["held", "watched", "valued", "ordinary"]
+    assert events[0].displayPriority > events[1].displayPriority > events[2].displayPriority
+    assert events[0].highlightReasons == ["held"]
+    assert events[1].highlightReasons == ["watchlist"]
+    assert events[2].highlightReasons == ["has_values"]
+    assert resp.days[0].summary is not None
+    assert resp.days[0].summary.highlightEventIds == ["held", "watched", "valued", "ordinary"]
+    assert resp.days[0].summary.overflowCount == 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_calendar_cluster_top_events_and_summary_are_priority_aware(monkeypatch) -> None:
+    from app.services.invest_view_model import calendar_service as svc
+
+    fake_resp = MagicMock()
+    fake_resp.events = [
+        *[
+            _fake_event(event_id=f"ordinary-{i}", category="earnings", market="us", symbol=f"ZZZ{i}")
+            for i in range(12)
+        ],
+        _fake_event(event_id="watched", category="earnings", market="us", symbol="MSFT"),
+        _fake_event(event_id="held", category="earnings", market="us", symbol="AAPL"),
+        _fake_event(event_id="valued", category="earnings", market="us", symbol="TSLA", actual="2.34"),
+    ]
+    fake_query_service = MagicMock()
+    fake_query_service.list_for_range = AsyncMock(return_value=fake_resp)
+    monkeypatch.setattr(svc, "MarketEventsQueryService", lambda db: fake_query_service)
+    _patch_freshness(monkeypatch, svc, date(2026, 5, 4), date(2026, 5, 4))
+
+    resolver = RelationResolver(
+        held={("us", "AAPL")},
+        watch={("us", "MSFT")},
+    )
+    resp = await svc.build_calendar(
+        db=MagicMock(),
+        resolver=resolver,
+        from_date=date(2026, 5, 4),
+        to_date=date(2026, 5, 4),
+        tab="all",
+    )
+
+    day = resp.days[0]
+    assert day.events == []
+    assert len(day.clusters) == 1
+    assert [event.eventId for event in day.clusters[0].topEvents[:3]] == [
+        "held",
+        "watched",
+        "valued",
+    ]
+    assert day.summary is not None
+    assert day.summary.highlightEventIds[:3] == ["held", "watched", "valued"]
+    assert day.summary.overflowCount == 10
+    assert day.summary.overflowLabel == "그 외 10개"
+    assert day.summary.headline == "주요 일정 5개 · 그 외 10개"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Prioritizes `/invest/calendar` rows so held/watch/major/high-signal events surface before long-tail rows.
- Adds calendar day summaries/overflow metadata and cluster `topEvents` to the API/view-model contract.
- Renders clustered `topEvents` as first-class event rows with compact overflow text so high-priority highlights are visible instead of hidden inside a raw cluster count.
- Rebases onto current `github/main` and preserves the monthly calendar timeline introduced by the latest main branch.

## Test plan
- `uv run ruff check app/schemas/invest_calendar.py app/services/invest_view_model/calendar_service.py tests/test_invest_calendar_router.py`
- `uv run --group test python -m pytest -q -m unit tests/test_invest_calendar_router.py`
- `cd frontend/invest && npm test -- --run SelectedDateEvents`
- `cd frontend/invest && npm run typecheck`
- `cd frontend/invest && npm run build`

## Safety
- No broker/order/watch/order-intent/live/paper trading side effects.
- No production DB writes, backfills, deletes, or scheduler activation.
- Work performed only in the explicit issue worktree: `/Users/mgh3326/worktrees/auto_trader/rob-186-calendar-highlight-vm`.

Closes ROB-186


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented smart event prioritization for calendar displays—events are now ranked based on relevance (held items, watchlist status, major impact, timing, and data availability).
  * Added calendar day summaries with headlines and intelligent overflow handling to better organize events when viewing a specific date.
  * Enhanced cluster rendering to display top-priority events directly alongside overflow indicators for better visibility.

* **Style**
  * Added new styling for day summaries and event overflow displays within the calendar interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/787)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->