### PR TITLE
fix(ROB-187): polish calendar event labels and values

### DIFF
--- a/app/schemas/invest_calendar.py
+++ b/app/schemas/invest_calendar.py
@@ -41,7 +41,7 @@ class CalendarEvent(BaseModel):
     title: str
     market: CalendarMarket
     eventType: EventType
-    eventTimeLocal: datetime | None = None
+    eventTimeLocal: str | None = None
     source: str
     actual: str | None = None
     forecast: str | None = None

--- a/app/services/invest_view_model/calendar_service.py
+++ b/app/services/invest_view_model/calendar_service.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from datetime import UTC, date, datetime, timedelta
+from decimal import Decimal, InvalidOperation
 from typing import cast
+from zoneinfo import ZoneInfo
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -28,6 +30,7 @@ from app.services.market_events.query_service import MarketEventsQueryService
 CLUSTER_THRESHOLD = 10
 DAY_HIGHLIGHT_LIMIT = 5
 CLUSTER_TOP_EVENT_LIMIT = 5
+KST = ZoneInfo("Asia/Seoul")
 
 _EVENT_TYPE_ORDER: dict[EventType, int] = {
     "economic": 0,
@@ -42,10 +45,12 @@ _HIGH_IMPACT_TERMS = ("cpi", "fomc", "nonfarm", "payroll", "pce", "gdp", "금리
 _MARKET_LITERAL = cast  # alias — used for type narrowing below
 
 
-def _event_date_key(value: datetime | None) -> tuple[int, str]:
+def _event_date_key(value: object | None) -> tuple[int, str]:
     if value is None:
         return (1, "")
-    return (0, value.isoformat())
+    if isinstance(value, datetime):
+        return (0, value.isoformat())
+    return (0, str(value))
 
 
 def _is_high_impact_macro(event: CalendarEvent) -> bool:
@@ -147,6 +152,59 @@ def _normalize_market(value: str | None) -> CalendarMarket:
     return "global"
 
 
+def _format_calendar_value(value: object) -> str | None:
+    if value is None:
+        return None
+    try:
+        decimal_value = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        text = str(value).strip()
+        return text or None
+    if decimal_value.is_zero():
+        return "0"
+    normalized = decimal_value.normalize()
+    text = format(normalized, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text
+
+
+def _format_kst_time(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    aware = value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    kst = aware.astimezone(KST)
+    hour = kst.hour
+    minute = kst.minute
+    period = "오전" if hour < 12 else "오후"
+    hour12 = hour % 12 or 12
+    minute_text = f" {minute}분" if minute else ""
+    return f"{kst.month}월 {kst.day}일 {period} {hour12}시{minute_text} KST"
+
+
+def _event_title(raw: object, *, market: CalendarMarket, etype: EventType) -> str:
+    title = str(getattr(raw, "title", "") or "").strip()
+    if title:
+        return title
+    company_name = str(getattr(raw, "company_name", "") or "").strip()
+    symbol = str(getattr(raw, "symbol", "") or "").strip()
+    if company_name and symbol and company_name != symbol:
+        entity = f"{company_name}({symbol})"
+    else:
+        entity = company_name or symbol
+    if entity and etype == "earnings":
+        return f"{entity} 실적 발표"
+    if entity:
+        return entity
+    if etype == "earnings" and market == "kr":
+        return "국내 기업 실적 발표"
+    if etype == "earnings" and market == "us":
+        return "미국 기업 실적 발표"
+    if etype == "economic":
+        return "경제지표 발표"
+    return "시장 이벤트"
+
+
 async def build_calendar(
     *,
     db: AsyncSession,
@@ -199,31 +257,22 @@ async def build_calendar(
         # actual/forecast/previous live in values[], not at top level
         raw_values = getattr(raw, "values", None) or []
         first_val = raw_values[0] if raw_values else None
-        actual = (
-            str(getattr(first_val, "actual", None))
-            if first_val and getattr(first_val, "actual", None) is not None
-            else None
-        )
-        forecast = (
-            str(getattr(first_val, "forecast", None))
-            if first_val and getattr(first_val, "forecast", None) is not None
-            else None
-        )
-        previous = (
-            str(getattr(first_val, "previous", None))
-            if first_val and getattr(first_val, "previous", None) is not None
-            else None
-        )
+        actual = _format_calendar_value(getattr(first_val, "actual", None))
+        forecast = _format_calendar_value(getattr(first_val, "forecast", None))
+        previous = _format_calendar_value(getattr(first_val, "previous", None))
 
         # MarketEventResponse has 'release_time_utc', not 'event_time_local'
         event_time = getattr(raw, "release_time_utc", None)
+        ev_date = getattr(raw, "event_date", None) or (
+            event_time.date() if event_time else from_date
+        )
 
         ev = CalendarEvent(
             eventId=event_id,
-            title=str(getattr(raw, "title", "") or ""),
+            title=_event_title(raw, market=market, etype=etype),
             market=market,
             eventType=etype,
-            eventTimeLocal=event_time,
+            eventTimeLocal=_format_kst_time(event_time),
             source=str(getattr(raw, "source", "") or ""),
             actual=actual,
             forecast=forecast,
@@ -231,9 +280,6 @@ async def build_calendar(
             relatedSymbols=related,
             relation=relation,  # type: ignore[arg-type]
             badges=badges,
-        )
-        ev_date = getattr(raw, "event_date", None) or (
-            ev.eventTimeLocal.date() if ev.eventTimeLocal else from_date
         )
         by_day.setdefault(ev_date, []).append(ev)
 

--- a/frontend/invest/src/__tests__/calendarKstAndDateLabel.test.ts
+++ b/frontend/invest/src/__tests__/calendarKstAndDateLabel.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "vitest";
 import {
   clampSelectedDateToMonth,
+  formatCalendarValue,
+  formatEventTitle,
   formatKstTime,
   relativeDayPrefix,
   selectedDateLabelWithRelative,
@@ -12,11 +14,45 @@ describe("ROB-166 KST + relative-date helpers", () => {
     expect(formatKstTime("  오전 8시  ")).toBe("오전 8시");
   });
 
+  test("formatKstTime localizes ISO timestamps to KST text", () => {
+    expect(formatKstTime("2026-05-07T16:30:00Z")).toBe("5월 8일 오전 1시 30분 KST");
+  });
+
   test("formatKstTime falls back to a single stable placeholder when null/empty", () => {
     expect(formatKstTime(null)).toBe("발표 예정 · KST");
     expect(formatKstTime(undefined)).toBe("발표 예정 · KST");
     expect(formatKstTime("")).toBe("발표 예정 · KST");
     expect(formatKstTime("   ")).toBe("발표 예정 · KST");
+  });
+
+  test("formatCalendarValue removes API decimal padding", () => {
+    expect(formatCalendarValue("1.16000000")).toBe("1.16");
+    expect(formatCalendarValue("0.28490000")).toBe("0.2849");
+    expect(formatCalendarValue("2.00000000")).toBe("2");
+    expect(formatCalendarValue("QoQ")).toBe("QoQ");
+  });
+
+  test("formatEventTitle supplies KR earnings fallback labels", () => {
+    expect(formatEventTitle({
+      eventId: "wise:005930:2026Q1",
+      title: "",
+      market: "kr",
+      eventType: "earnings",
+      source: "wisefn",
+      relatedSymbols: [{ symbol: "005930", market: "kr", displayName: "삼성전자" }],
+      relation: "none",
+      badges: [],
+    })).toBe("삼성전자(005930) 실적 발표");
+    expect(formatEventTitle({
+      eventId: "wise:unknown",
+      title: " ",
+      market: "kr",
+      eventType: "earnings",
+      source: "wisefn",
+      relatedSymbols: [],
+      relation: "none",
+      badges: [],
+    })).toBe("국내 기업 실적 발표");
   });
 
   test("relativeDayPrefix names today/tomorrow, otherwise null", () => {

--- a/frontend/invest/src/components/calendar/EventRow.tsx
+++ b/frontend/invest/src/components/calendar/EventRow.tsx
@@ -6,7 +6,7 @@ import { OwnershipTag } from "./OwnershipTag";
 export function EventRow({ ev }: { ev: CalendarEventVM }) {
   const showFallbackTime =
     ev.time == null && ev.actual == null && ev.forecast == null && ev.previous == null;
-  const timeText = ev.time ?? (ev.released ? "발표 완료" : showFallbackTime ? formatKstTime(null) : "발표 예정");
+  const timeText = ev.time != null ? formatKstTime(ev.time) : (ev.released ? "발표 완료" : showFallbackTime ? formatKstTime(null) : "발표 예정");
 
   return (
     <article

--- a/frontend/invest/src/components/calendar/vm.ts
+++ b/frontend/invest/src/components/calendar/vm.ts
@@ -60,6 +60,31 @@ export function mapOwnership(event: CalendarEvent): DisplayOwnership {
   return null;
 }
 
+export function formatCalendarValue(value: string | null | undefined): string | null {
+  const trimmed = (value ?? "").trim();
+  if (trimmed.length === 0) return null;
+  if (!/^[+-]?\d+(?:\.\d+)?$/.test(trimmed)) return trimmed;
+  const [integerPart = "", fractionPart = ""] = trimmed.split(".");
+  const cleanedFraction = fractionPart.replace(/0+$/, "");
+  return cleanedFraction.length === 0 ? integerPart : `${integerPart}.${cleanedFraction}`;
+}
+
+export function formatEventTitle(event: CalendarEvent): string {
+  const title = event.title.trim();
+  if (title.length > 0) return title;
+  const primarySymbol = event.relatedSymbols[0];
+  if (primarySymbol) {
+    const entity = primarySymbol.displayName && primarySymbol.displayName !== primarySymbol.symbol
+      ? `${primarySymbol.displayName}(${primarySymbol.symbol})`
+      : primarySymbol.symbol;
+    return event.eventType === "earnings" ? `${entity} 실적 발표` : entity;
+  }
+  if (event.eventType === "earnings" && event.market === "kr") return "국내 기업 실적 발표";
+  if (event.eventType === "earnings" && event.market === "us") return "미국 기업 실적 발표";
+  if (event.eventType === "economic") return "경제지표 발표";
+  return "시장 이벤트";
+}
+
 export function toEventVM(event: CalendarEvent, date: string): CalendarEventVM {
   const day = Number.parseInt(date.slice(8, 10), 10);
   const month = Number.parseInt(date.slice(5, 7), 10);
@@ -70,12 +95,12 @@ export function toEventVM(event: CalendarEvent, date: string): CalendarEventVM {
     monthDay: `${month}/${day}`,
     type: mapEventType(event.eventType),
     region: mapMarketToRegion(event.market),
-    title: event.title,
+    title: formatEventTitle(event),
     time: event.eventTimeLocal ?? null,
     released: event.actual != null,
-    actual: event.actual ?? null,
-    forecast: event.forecast ?? null,
-    previous: event.previous ?? null,
+    actual: formatCalendarValue(event.actual),
+    forecast: formatCalendarValue(event.forecast),
+    previous: formatCalendarValue(event.previous),
     own: mapOwnership(event),
     badges: event.badges,
     displayPriority: event.displayPriority ?? 0,
@@ -232,8 +257,18 @@ export function selectedDateLabel(dateIso: string): string {
  */
 export function formatKstTime(eventTimeLocal: string | null | undefined): string {
   const trimmed = (eventTimeLocal ?? "").trim();
-  if (trimmed.length > 0) return trimmed;
-  return "발표 예정 · KST";
+  if (trimmed.length === 0) return "발표 예정 · KST";
+  const parsed = new Date(trimmed);
+  if (!Number.isNaN(parsed.getTime()) && /T|Z|[+-]\d{2}:?\d{2}$/.test(trimmed)) {
+    const kst = new Date(parsed.getTime() + 9 * 60 * 60 * 1000);
+    const hour = kst.getUTCHours();
+    const minute = kst.getUTCMinutes();
+    const period = hour < 12 ? "오전" : "오후";
+    const hour12 = hour % 12 || 12;
+    const minuteText = minute === 0 ? "" : ` ${minute}분`;
+    return `${kst.getUTCMonth() + 1}월 ${kst.getUTCDate()}일 ${period} ${hour12}시${minuteText} KST`;
+  }
+  return trimmed;
 }
 
 /** "오늘" if dateIso === todayIso, "내일" if dateIso === todayIso + 1d, else null. */

--- a/tests/test_invest_calendar_router.py
+++ b/tests/test_invest_calendar_router.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, date, datetime
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -17,11 +18,14 @@ def _fake_event(
     market: str = "us",
     category: str = "earnings",
     symbol: str | None = None,
-    ev_date: date | None = None,
+    company_name: str | None = None,
     title: str | None = None,
-    actual: str | None = None,
-    forecast: str | None = None,
-    previous: str | None = None,
+    ev_date: date | None = None,
+    release_time_utc: datetime | None = None,
+    actual: object | None = None,
+    forecast: object | None = None,
+    previous: object | None = None,
+    values: list[object] | None = None,
 ):
     e = MagicMock()
     # MarketEventResponse uses source_event_id, not event_id
@@ -30,12 +34,14 @@ def _fake_event(
     e.market = market
     e.category = category
     e.symbol = symbol
-    e.company_name = symbol
-    e.title = title or f"event {event_id}"
+    e.company_name = company_name if company_name is not None else symbol
+    e.title = f"event {event_id}" if title is None else title
     e.event_date = ev_date or date(2026, 5, 4)
-    e.release_time_utc = None
+    e.release_time_utc = release_time_utc
     e.source = "test"
-    if actual is not None or forecast is not None or previous is not None:
+    if values is not None:
+        e.values = values
+    elif actual is not None or forecast is not None or previous is not None:
         value = MagicMock()
         value.actual = actual
         value.forecast = forecast
@@ -245,6 +251,51 @@ async def test_calendar_cluster_top_events_and_summary_are_priority_aware(
     assert day.summary.overflowCount == 10
     assert day.summary.overflowLabel == "그 외 10개"
     assert day.summary.headline == "주요 일정 5개 · 그 외 10개"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_calendar_polishes_blank_kr_title_kst_time_and_values(
+    monkeypatch,
+) -> None:
+    from app.services.invest_view_model import calendar_service as svc
+
+    value = MagicMock()
+    value.actual = Decimal("1.16000000")
+    value.forecast = Decimal("0.28490000")
+    value.previous = Decimal("2.00000000")
+    fake_resp = MagicMock()
+    fake_resp.events = [
+        _fake_event(
+            event_id="wise:005930:2026Q1",
+            category="earnings",
+            market="kr",
+            symbol="005930",
+            company_name="삼성전자",
+            title="",
+            release_time_utc=datetime(2026, 5, 7, 16, 30, tzinfo=UTC),
+            values=[value],
+        )
+    ]
+    fake_query_service = MagicMock()
+    fake_query_service.list_for_range = AsyncMock(return_value=fake_resp)
+    monkeypatch.setattr(svc, "MarketEventsQueryService", lambda db: fake_query_service)
+    _patch_freshness(monkeypatch, svc, date(2026, 5, 4), date(2026, 5, 4))
+
+    resp = await svc.build_calendar(
+        db=MagicMock(),
+        resolver=RelationResolver(),
+        from_date=date(2026, 5, 4),
+        to_date=date(2026, 5, 4),
+        tab="all",
+    )
+
+    event = resp.days[0].events[0]
+    assert event.title == "삼성전자(005930) 실적 발표"
+    assert event.eventTimeLocal == "5월 8일 오전 1시 30분 KST"
+    assert event.actual == "1.16"
+    assert event.forecast == "0.2849"
+    assert event.previous == "2"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Polish `/invest/calendar` event labels so KR earnings/top-event rows never render blank titles and use company/ticker fallbacks where needed.
- Normalize economic event display times to Korean/KST and trim raw/padded values before frontend rendering.
- Preserve 31-day grouped timeline rendering, event rows, overflow labels, and auth protection.

## Verification
- `uv run pytest tests/test_invest_calendar_router.py -q` (8 passed)
- `npm test -- --run src/__tests__/calendarKstAndDateLabel.test.ts` (8 passed)
- `uv run ruff check app/schemas/invest_calendar.py app/services/invest_view_model/calendar_service.py tests/test_invest_calendar_router.py`
- `npm run typecheck`
- `npm run build`
- Local visual/API smoke: `evidence/rob187-local-calendar-polish-smoke.json` reported API 200, 31 days, 170 event rows, 32 overflow labels, 0 blank titles, 0 raw ISO matches, 0 padded values, 0 freshness banners/errors.

## Safety
- No broker/order/watch/order-intent/live/paper trading side effects.
- No production DB write/backfill/delete.
- No scheduler activation.

Closes ROB-187
