### PR TITLE
feat(ROB-202): align invest screener Toss parity

### DIFF
--- a/.hermes/plans/2026-05-12_062231-rob-202-invest-screener-toss-parity.md
+++ b/.hermes/plans/2026-05-12_062231-rob-202-invest-screener-toss-parity.md
@@ -1,0 +1,341 @@
+# ROB-202 Invest Screener Toss Parity Implementation Plan
+
+> **For Hermes:** This is a read-only reconnaissance handoff for the next implementer. Implement with the auto-trader operations workflow and TDD. Do not mutate broker/order/watch/order-intent state.
+
+**Goal:** Align `/invest/screener` `consecutive_gainers` (연속 상승세) with Toss observed behavior: `DAY_5 >= 0`, `주가_연속_상승 >= 5`, sorted by `C_주가등락률_1W DESC`, with a Toss-sized result set (~50-80 rows rather than 20).
+
+**Architecture:** Keep the parity change scoped to the `/invest` view-model/read path first. The durable `invest_screener_snapshots` read model is already the right serving surface for consecutive gainers; adjust its view-model query and preset defaults, then add a read-only diagnostic script to compare auto_trader output with Toss exports/captures. Avoid schema/backfill/scheduler activation unless a later task explicitly approves it.
+
+**Tech Stack:** FastAPI + SQLAlchemy async + Pydantic DTOs + React/Vite frontend + pytest.
+
+---
+
+## Current Context
+
+Reconnaissance was read-only. No repo files were intentionally modified before this plan file.
+
+Key findings:
+
+- `/invest/api/screener/results` is implemented in `app/routers/invest_api.py:397-416` and accepts only `preset` and `market`; no explicit `limit`, `totalCount`, or pagination parameter exists.
+- The response schema in `app/schemas/invest_screener.py:71-80` contains `results` but no `totalCount`, `limit`, or `hasMore`.
+- The frontend `frontend/invest/src/api/screener.ts:13-20` sends only `preset` and `market`.
+- The desktop page `frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx:93-110` displays `results.results.length`; there is no frontend slicing to 20.
+- Current preset mapping in `app/services/invest_view_model/screener_presets.py:94-103` already has:
+  - `min_consecutive_up_days: 5`
+  - `min_week_change_rate: 0.0`
+  - `sort_by: "change_rate"`
+  - `sort_order: "desc"`
+  - `limit: 20`
+- Snapshot-first consecutive-gainers logic lives in `app/services/invest_view_model/screener_service.py:108-182` and currently filters correctly for `consecutive_up_days >= 5` and `week_change_rate >= 0`, but orders by:
+  1. `snapshot_date DESC`
+  2. `consecutive_up_days DESC`
+  3. `week_change_rate DESC NULLS LAST`
+  4. `change_rate DESC NULLS LAST`
+  This does not match Toss rank order, which should prioritize weekly change (`C_주가등락률_1W DESC`) among eligible rows.
+- `_SNAPSHOT_FIRST_LIMIT = 20` in `app/services/invest_view_model/screener_service.py:46`, and the preset also sets `limit: 20`; this is the likely source of the observed count gap.
+- Snapshot metrics are derived in `app/services/invest_screener_snapshots/builder.py` with `_LOOKBACK = 10`, `consecutive_up_days` from strict latest-backward increases, and `week_change_rate` from latest close vs `closes[-5]`.
+- `kr_symbol_universe` currently has only `symbol`, `name`, `exchange`, `nxt_eligible`, `is_active`; no reliable `instrument_type` column is available for excluding ETFs/MMF/TDF/preferred stocks in this path.
+- MCP screening supports `instrument_types` in `app/mcp_server/tooling/screening/common.py`, but that is a public tool contract. Do not casually narrow public defaults while fixing `/invest` Toss parity.
+- Existing tests include:
+  - `tests/test_invest_screener_week_change_filter.py`
+  - `tests/test_invest_screener_presets.py`
+  - `tests/test_invest_view_model_screener_service.py`
+  - `tests/test_invest_screener_snapshots_repository.py`
+  - `tests/test_invest_api_screener_router.py`
+- Existing read-only coverage script: `scripts/diagnose_invest_screener_snapshots.py`.
+
+Claude Code Opus delegation was attempted but unavailable: `claude` returned `Not logged in · Please run /login`.
+
+---
+
+## P0 Acceptance Criteria
+
+1. For KR `consecutive_gainers`, the effective filters are:
+   - `consecutive_up_days >= 5`
+   - `week_change_rate >= 0`
+2. Snapshot-first result rank matches Toss priority:
+   - latest snapshot date remains selected/deduped safely,
+   - within the served candidate set, rows are ordered by `week_change_rate DESC`, then stable tie-breakers.
+3. Default `consecutive_gainers` result count is raised from 20 to a Toss-sized bounded limit (recommend 80) without changing every other preset.
+4. Frontend result count reflects the larger backend result set; no frontend slicing or incorrect “20” assumptions remain.
+5. A read-only diagnostic command can compare auto_trader `consecutive_gainers` output with a Toss symbol list/export and report missing/extra/rank deltas plus row metrics.
+6. Unit/router tests cover filters, sort order, limit behavior, null handling, and response compatibility.
+7. No broker/order/watch/order-intent/live trading mutation, no production DB writes, no backfill `--commit`, no scheduler activation, and no secret logging.
+
+---
+
+## Non-Common Stock Filtering Decision
+
+Do not make ETF/MMF/TDF/preferred/common-stock exclusion a P0 schema/backfill change.
+
+Reasoning:
+
+- `kr_symbol_universe` has no instrument classification field today.
+- `invest_screener_snapshots` also does not carry a reliable instrument type.
+- MCP screening has an `instrument_types` concept, but changing public tool defaults risks unrelated contract changes.
+- Name/suffix heuristics would create false positives/false negatives and make Toss parity look better without a trustworthy data source.
+
+P0 should document and surface this as a known gap in the diagnostic report. P1 can add a proper `instrument_type` source/field/backfill if Toss diffs show non-common products are a material mismatch.
+
+---
+
+## Implementation Plan
+
+### Task 1: Add focused tests for preset limit and Toss sort intent
+
+**Objective:** Lock the desired `consecutive_gainers` defaults before changing implementation.
+
+**Files:**
+- Modify: `tests/test_invest_screener_presets.py`
+- Modify: `tests/test_invest_screener_week_change_filter.py`
+
+**Steps:**
+
+1. Add/extend a test asserting `screening_filters_for("consecutive_gainers", market="kr")` returns:
+   - `min_consecutive_up_days == 5`
+   - `min_week_change_rate == 0.0`
+   - `sort_by == "week_change_rate"`
+   - `sort_order == "desc"`
+   - `limit == 80` (or a named constant if introduced)
+2. Keep the existing US assertions if the same logical preset should stay supported for US, but make sure the test wording says this is logical parity, not proven Toss US parity.
+3. Run:
+   - `uv run pytest tests/test_invest_screener_presets.py tests/test_invest_screener_week_change_filter.py -m unit -q`
+4. Expected before implementation: failures on `sort_by` and `limit`.
+
+### Task 2: Raise only the consecutive-gainers default limit
+
+**Objective:** Return Toss-sized results for this preset without changing all other screener presets.
+
+**Files:**
+- Modify: `app/services/invest_view_model/screener_presets.py:94-103`
+- Modify: `app/services/invest_view_model/screener_service.py:46` if keeping `_SNAPSHOT_FIRST_LIMIT` aligned
+
+**Recommended change:**
+
+- Introduce a named constant near the preset filters, e.g. `CONSECUTIVE_GAINERS_LIMIT = 80`, or keep a local literal with a comment.
+- Change only the `consecutive_gainers` filter from `limit: 20` to `limit: 80`.
+- Change `sort_by` from `"change_rate"` to `"week_change_rate"` so fallback `ScreenerService.list_screening(**filters)` and tests describe the same desired behavior.
+- Consider changing `_SNAPSHOT_FIRST_LIMIT` from 20 to 80 or adding `_CONSECUTIVE_GAINERS_LIMIT = 80`; avoid raising default limits for unrelated paths.
+
+**Caution:** `build_screener_results()` calls `_load_consecutive_gainers_from_snapshots(... limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT))`, so the preset limit already controls snapshot-first behavior. A separate `_SNAPSHOT_FIRST_LIMIT` change is mostly fallback/clarity unless callers omit filters.
+
+### Task 3: Fix snapshot-first rank ordering to weekly change
+
+**Objective:** Match Toss ranking (`C_주가등락률_1W DESC`) after applying the two Toss filters.
+
+**Files:**
+- Modify: `app/services/invest_view_model/screener_service.py:108-182`
+- Test: `tests/test_invest_view_model_screener_service.py`
+
+**Recommended query behavior:**
+
+- Keep filters:
+  - `InvestScreenerSnapshot.market == market`
+  - `InvestScreenerSnapshot.consecutive_up_days >= 5`
+  - `InvestScreenerSnapshot.week_change_rate >= 0`
+- Change ordering so weekly change outranks streak length:
+  - Prefer latest snapshot rows, but avoid letting stale rows for one date outrank fresh rows incorrectly.
+  - Recommended P0 simple ordering:
+    1. `InvestScreenerSnapshot.snapshot_date.desc()`
+    2. `InvestScreenerSnapshot.week_change_rate.desc().nullslast()`
+    3. `InvestScreenerSnapshot.consecutive_up_days.desc().nullslast()`
+    4. `InvestScreenerSnapshot.change_rate.desc().nullslast()`
+    5. `InvestScreenerSnapshot.symbol.asc()`
+- Keep overfetch/dedup (`limit * 4`) if historical duplicate dates exist, but add a test to ensure the final list order is by weekly change among returned latest rows.
+
+**Test shape:**
+
+Use the existing `_FakeSnapshot`, `_FakeSession`, and `_FakeExecuteResult` helpers in `tests/test_invest_view_model_screener_service.py` if possible. Add a test where snapshots have:
+
+- A: `consecutive_up_days=9`, `week_change_rate=1.0`
+- B: `consecutive_up_days=5`, `week_change_rate=8.0`
+- C: `consecutive_up_days=6`, `week_change_rate=3.0`
+
+Expected result order should be B, C, A.
+
+If the fake session cannot inspect SQL ordering, add an integration-style repository/service test with `db_session` and real inserted snapshot rows.
+
+### Task 4: Ensure fallback screening path can sort by week_change_rate
+
+**Objective:** Avoid divergence when snapshot-first has no rows and `screening_service.list_screening(**filters)` is used.
+
+**Files:**
+- Inspect/modify: `app/mcp_server/tooling/screening/common.py`
+- Inspect/modify: the implementation behind `ScreenerService.list_screening()` and `screen_stocks_unified()` (search for `sort_by` handling)
+- Test: `tests/test_invest_screener_week_change_filter.py` or a dedicated screening test
+
+**Steps:**
+
+1. Verify that `sort_by="week_change_rate"` is accepted and actually sorts on row field `week_change_rate`.
+2. If unsupported, add a narrow sort-key mapping for `week_change_rate` without changing public defaults.
+3. Keep `min_week_change_rate` filtering already tested in `tests/test_invest_screener_week_change_filter.py`.
+4. Add a test where fallback rows with week changes 1.0, 8.0, 3.0 are sorted 8.0, 3.0, 1.0 when requested.
+
+**Caution:** This path may involve MCP/public tool behavior. Keep new support additive; do not remove supported sort keys or alter unrelated default sort behavior.
+
+### Task 5: Decide whether to expose totalCount/limit in the API
+
+**Objective:** Avoid unnecessary schema churn while making the UI understandable.
+
+**Recommendation for P0:** Do not add `totalCount`, `limit`, or pagination fields yet unless the implementer confirms a product need.
+
+Reasoning:
+
+- The frontend already displays `results.results.length` at `DesktopScreenerPage.tsx:99`.
+- The response schema currently forbids extra fields; adding fields is additive for TS only if all generated/manual types and tests are updated.
+- Toss parity complaint is likely caused by the backend cap of 20, not a frontend hidden count.
+
+If product wants “80개 중 20개” or load-more behavior, implement as a separate P1 API contract change:
+
+- Add optional `limit` query param to `app/routers/invest_api.py:397-405`.
+- Add `totalCount`, `limit`, `hasMore` to `app/schemas/invest_screener.py` and `frontend/invest/src/types/screener.ts`.
+- Update `fetchScreenerResults()` to pass limit explicitly.
+
+### Task 6: Add a read-only Toss parity diagnostic script
+
+**Objective:** Give K2/operator a repeatable way to quantify parity gaps without DB writes or Toss/browser secrets in logs.
+
+**Files:**
+- Prefer extend: `scripts/diagnose_invest_screener_snapshots.py`
+- Or create: `scripts/diagnose_invest_screener_toss_parity.py`
+- Test: a small unit test for pure diff logic, e.g. `tests/test_invest_screener_toss_parity_diagnostics.py`
+
+**Recommended CLI:**
+
+- `uv run python -m scripts.diagnose_invest_screener_toss_parity --market kr --preset consecutive_gainers --toss-symbols-file /path/to/toss_symbols.csv --limit 80`
+- Input CSV/JSON should accept at least `symbol`, and optionally `rank`, `name`, `week_change_rate`, `consecutive_up_days` if Toss export/capture has them.
+- The script must be read-only. It may query `invest_screener_snapshots` and/or call the local view-model service, but must not write to DB.
+- Output should include:
+  - auto_trader count
+  - Toss count
+  - overlap count
+  - missing-from-auto_trader symbols
+  - extra-in-auto_trader symbols
+  - top rank deltas
+  - for each diff row, auto_trader `week_change_rate`, `consecutive_up_days`, `snapshot_date`, `_screener_snapshot_state` if available
+  - a note that non-common-stock filtering is not P0 unless instrument type is present
+
+**Safety requirements:**
+
+- Do not accept or print Toss cookies/headers/tokens.
+- If an input value looks like a cookie/header/token, redact as `[REDACTED]` or reject.
+- Do not fetch Toss live from the script in P0; consume an operator-provided symbol export/list.
+
+### Task 7: Frontend verification and no-op UI changes
+
+**Objective:** Confirm the frontend naturally renders the larger result set and count.
+
+**Files:**
+- Inspect/test: `frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx`
+- Inspect/test: `frontend/invest/src/desktop/screener/ScreenerFilterBar*`
+- Inspect/test: `frontend/invest/src/desktop/screener/ScreenerResultsTable*`
+- Types: `frontend/invest/src/types/screener.ts`
+
+**Expected P0 result:** likely no frontend code change is needed if response still only has `results` and table can render 80 rows.
+
+**Tests/checks:**
+
+- Add/update a frontend test only if there is an existing test suite around screener components.
+- Ensure no component slices `rows.slice(0, 20)` or hardcodes 20. Use search before changing.
+- Run:
+  - `cd frontend/invest && npm run typecheck`
+  - `cd frontend/invest && npm test -- --run` if test suite is configured and not too broad
+  - `cd frontend/invest && npm run build`
+
+### Task 8: Run targeted backend validation
+
+**Objective:** Prove the parity behavior without live or mutating operations.
+
+Recommended commands from repo root:
+
+```bash
+uv run pytest \
+  tests/test_invest_screener_presets.py \
+  tests/test_invest_screener_week_change_filter.py \
+  tests/test_invest_view_model_screener_service.py \
+  tests/test_invest_api_screener_router.py \
+  -m unit -q
+```
+
+If repository tests require DB fixtures for snapshot ordering:
+
+```bash
+uv run pytest tests/test_invest_screener_snapshots_repository.py tests/test_invest_view_model_screener_service.py -q
+```
+
+Do not run tests marked `live` unless explicitly approved with the repository's `--run-live` convention.
+
+### Task 9: Optional read-only smoke after implementation
+
+**Objective:** Confirm the local read path returns Toss-sized rows and no provider/internal leakage.
+
+Options:
+
+- Unit/service-level smoke with fake rows is enough for PR stage.
+- If a local dev server is already running, call authenticated `/invest/api/screener/results?preset=consecutive_gainers&market=kr` and verify:
+  - row count can exceed 20 when snapshot table has enough rows,
+  - `freshness.dataState` is meaningful,
+  - warnings do not expose provider hostnames, credentials, or internals.
+
+Do not run production backfills, scheduler activation, or any command with `--commit` in this task.
+
+---
+
+## Files Likely to Change
+
+P0 likely changes:
+
+- `app/services/invest_view_model/screener_presets.py`
+  - `consecutive_gainers` `sort_by` -> `week_change_rate`
+  - `consecutive_gainers` `limit` -> 80
+- `app/services/invest_view_model/screener_service.py`
+  - snapshot-first ordering -> weekly change first after snapshot freshness/date
+  - maybe named limit constant
+- `app/mcp_server/tooling/screening/common.py` or related screening implementation
+  - only if fallback sorting does not support `week_change_rate`
+- `scripts/diagnose_invest_screener_toss_parity.py` or `scripts/diagnose_invest_screener_snapshots.py`
+  - read-only parity report
+- `tests/test_invest_screener_presets.py`
+- `tests/test_invest_screener_week_change_filter.py`
+- `tests/test_invest_view_model_screener_service.py`
+- possibly `tests/test_invest_api_screener_router.py`
+- possibly `frontend/invest/src/types/screener.ts` only if API response schema changes (not recommended for P0)
+
+P1/P2 likely changes:
+
+- Add reliable KR instrument classification source/field.
+- Backfill `instrument_type` for KR universe/snapshots after explicit approval.
+- Add `totalCount`/pagination/load-more API and UI if product requires it.
+
+---
+
+## Risks and Open Questions
+
+1. **DAY_5 exact semantics:** `builder.py` currently computes `week_change_rate` using `closes[-5]`. Verify whether this matches Toss `DAY_5` exactly before changing metric derivation. Changing derivation may require snapshot rebuild/backfill and should not be bundled into P0 without evidence.
+2. **Stale vs latest ordering:** If the table contains multiple snapshot dates, `snapshot_date DESC` first is safer for freshness but can still interact with rank parity. The diagnostic should report snapshot dates so this is visible.
+3. **Fallback path support:** `sort_by="week_change_rate"` must be validated in the actual `ScreenerService.list_screening()` path; otherwise snapshot-empty behavior may remain Toss-divergent.
+4. **ETF/MMF/TDF/preferred exclusion:** Important for exact Toss parity, but not safe as P0 without reliable instrument classification.
+5. **Performance:** Increasing default limit to 80 is bounded, but snapshot query overfetch currently uses `limit * 4`; with 80 this is 320 rows, likely acceptable. If slow, add an index only after measuring and with a migration plan.
+6. **Schema churn:** Adding count/pagination fields is additive but touches backend schema, frontend types, tests, and compatibility. Avoid unless necessary.
+
+---
+
+## Suggested K2 Handoff
+
+Implement P0 in this order:
+
+1. Tests for preset defaults and snapshot ordering.
+2. Preset limit/sort change.
+3. Snapshot-first order change.
+4. Fallback `week_change_rate` sort support if missing.
+5. Read-only Toss parity diagnostic script.
+6. Targeted backend tests, frontend typecheck/build if frontend touched.
+
+Safety boundaries for K2:
+
+- No live/paper broker orders.
+- No watch/order-intent mutation.
+- No production DB writes.
+- No backfill `--commit`.
+- No scheduler activation.
+- No secrets/cookies/credentials in output.

--- a/app/mcp_server/tooling/screening/common.py
+++ b/app/mcp_server/tooling/screening/common.py
@@ -786,6 +786,7 @@ def _sort_and_limit(
         "trade_amount": "trade_amount_24h",
         "market_cap": "market_cap",
         "change_rate": "change_rate",
+        "week_change_rate": "week_change_rate",
         "dividend_yield": "dividend_yield",
         "rsi": "rsi",  # crypto only
         "score": "score",

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from app.schemas.invest_screener import ScreenerFilterChip, ScreenerPreset
 
 DEFAULT_PRESET_ID = "consecutive_gainers"
+CONSECUTIVE_GAINERS_LIMIT = 80
 
 
 SCREENER_PRESETS: list[ScreenerPreset] = [
@@ -95,11 +96,11 @@ _SCREENING_FILTERS: dict[str, dict[str, object]] = {
     "consecutive_gainers": {
         "market": "kr",
         "asset_type": "stock",
-        "sort_by": "change_rate",
+        "sort_by": "week_change_rate",
         "sort_order": "desc",
         "min_consecutive_up_days": 5,
         "min_week_change_rate": 0.0,
-        "limit": 20,
+        "limit": CONSECUTIVE_GAINERS_LIMIT,
     },
     "cheap_value": {
         "market": "kr",

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -43,7 +43,7 @@ _KST = ZoneInfo("Asia/Seoul")
 _KR_OPEN = _time(9, 0)
 _KR_CLOSE = _time(15, 30)
 _CACHE_HIT_FRESH_SECONDS = 300
-_SNAPSHOT_FIRST_LIMIT = 20
+_SNAPSHOT_FIRST_LIMIT = 80
 _MAX_WARNING_CHARS = 240
 logger = logging.getLogger(__name__)
 
@@ -127,9 +127,10 @@ async def _load_consecutive_gainers_from_snapshots(
         )
         .order_by(
             InvestScreenerSnapshot.snapshot_date.desc(),
-            InvestScreenerSnapshot.consecutive_up_days.desc(),
             InvestScreenerSnapshot.week_change_rate.desc().nullslast(),
+            InvestScreenerSnapshot.consecutive_up_days.desc(),
             InvestScreenerSnapshot.change_rate.desc().nullslast(),
+            InvestScreenerSnapshot.symbol.asc(),
         )
         .limit(max(limit * 4, limit))
     )
@@ -179,6 +180,14 @@ async def _load_consecutive_gainers_from_snapshots(
         )
         if len(rows) >= limit:
             break
+    rows.sort(
+        key=lambda row: (
+            -(row.get("week_change_rate") or 0.0),
+            -(row.get("consecutive_up_days") or 0),
+            -(row.get("change_rate") or 0.0),
+            str(row.get("symbol") or ""),
+        )
+    )
     return rows
 
 

--- a/scripts/diagnose_invest_screener_toss_parity.py
+++ b/scripts/diagnose_invest_screener_toss_parity.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Read-only Toss parity diagnostic for /invest screener consecutive_gainers.
+
+Consumes an operator-provided Toss symbol export/list and compares it with the
+local invest_screener_snapshots read model. This script never fetches Toss live
+and never writes to the database.
+
+Example:
+    uv run python -m scripts.diagnose_invest_screener_toss_parity \
+      --market kr \
+      --preset consecutive_gainers \
+      --toss-symbols-file /path/to/toss_symbols.csv \
+      --limit 80
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import logging
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import sqlalchemy as sa
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_PRESETS = {"consecutive_gainers"}
+_SENSITIVE_HEADER_RE = re.compile(
+    r"(cookie|authorization|x[-_]?csrf|token|secret|password|session)", re.I
+)
+_SENSITIVE_VALUE_RE = re.compile(
+    r"(bearer\s+[A-Za-z0-9._~+/-]+|cookie\s*:|authorization\s*:|token=|secret=|password=|session=)",
+    re.I,
+)
+_SYMBOL_RE = re.compile(r"^[A-Za-z0-9:._-]{1,24}$")
+_NON_COMMON_STOCK_NOTE = (
+    "ETF/MMF/TDF/preferred-stock exclusion is not applied in this P0 diagnostic "
+    "because the current snapshot/universe read model has no reliable instrument_type."
+)
+
+
+def _strip_exchange_prefix(value: Any) -> str:
+    text = str(value or "").strip().upper()
+    if not text:
+        return ""
+    return text.split(":", maxsplit=1)[-1].strip()
+
+
+def _redact_sensitive(value: Any) -> str:
+    text = str(value or "")
+    return _SENSITIVE_VALUE_RE.sub("[REDACTED]", text)
+
+
+def _reject_if_sensitive(label: str, value: Any) -> None:
+    text = str(value or "")
+    if _SENSITIVE_HEADER_RE.search(label) or _SENSITIVE_VALUE_RE.search(text):
+        raise ValueError(
+            "Toss export must not contain cookies, headers, tokens, or secrets; "
+            "remove sensitive fields and retry."
+        )
+
+
+def _normalize_toss_row(raw: dict[str, Any], fallback_rank: int) -> dict[str, Any] | None:
+    for key, value in raw.items():
+        _reject_if_sensitive(key, value)
+
+    symbol = _strip_exchange_prefix(
+        raw.get("symbol")
+        or raw.get("code")
+        or raw.get("ticker")
+        or raw.get("종목코드")
+        or raw.get("티커")
+    )
+    if not symbol:
+        return None
+    if not _SYMBOL_RE.match(symbol):
+        raise ValueError(f"Invalid symbol in Toss export: {_redact_sensitive(symbol)}")
+
+    rank_raw = raw.get("rank") or raw.get("순위") or fallback_rank
+    try:
+        rank = int(rank_raw)
+    except (TypeError, ValueError):
+        rank = fallback_rank
+
+    return {
+        "rank": rank,
+        "symbol": symbol,
+        "name": str(raw.get("name") or raw.get("종목명") or "").strip() or None,
+        "week_change_rate": _to_float_or_none(
+            raw.get("week_change_rate") or raw.get("C_주가등락률_1W")
+        ),
+        "consecutive_up_days": _to_int_or_none(
+            raw.get("consecutive_up_days") or raw.get("주가_연속_상승")
+        ),
+    }
+
+
+def _to_float_or_none(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(str(value).strip().replace(",", "").replace("%", ""))
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_int_or_none(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(float(str(value).strip().replace(",", "")))
+    except (TypeError, ValueError):
+        return None
+
+
+def load_toss_symbols(path: Path) -> list[dict[str, Any]]:
+    """Load Toss rows from CSV/JSON without accepting any auth material."""
+    raw_text = path.read_text(encoding="utf-8-sig")
+    _reject_if_sensitive("file", raw_text)
+
+    if path.suffix.lower() == ".json":
+        parsed = json.loads(raw_text)
+        if isinstance(parsed, dict):
+            rows = parsed.get("results") or parsed.get("rows") or parsed.get("symbols") or []
+        else:
+            rows = parsed
+        if not isinstance(rows, list):
+            raise ValueError("JSON Toss export must be a list or contain rows/results/symbols")
+        raw_rows = [r if isinstance(r, dict) else {"symbol": r} for r in rows]
+    else:
+        lines = [line.strip() for line in raw_text.splitlines() if line.strip()]
+        first_line = lines[0] if lines else ""
+        # Plain one-symbol-per-line exports are common when an operator copies a
+        # Toss rank list manually. Treat files without delimiters as symbol lists
+        # instead of letting DictReader misinterpret the first symbol as a header.
+        if first_line and "," not in first_line and "\t" not in first_line:
+            raw_rows = [{"symbol": line} for line in lines]
+        else:
+            reader = csv.DictReader(raw_text.splitlines())
+            if not reader.fieldnames:
+                raw_rows = []
+            else:
+                for field in reader.fieldnames:
+                    _reject_if_sensitive(field, "")
+                raw_rows = list(reader)
+
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for idx, row in enumerate(raw_rows, start=1):
+        item = _normalize_toss_row(row, idx)
+        if item is None or item["symbol"] in seen:
+            continue
+        seen.add(item["symbol"])
+        normalized.append(item)
+    return normalized
+
+
+def build_parity_report(
+    auto_rows: list[dict[str, Any]], toss_rows: list[dict[str, Any]], *, limit: int
+) -> dict[str, Any]:
+    auto_rank = {row["symbol"]: idx for idx, row in enumerate(auto_rows, start=1)}
+    toss_rank = {row["symbol"]: int(row.get("rank") or idx) for idx, row in enumerate(toss_rows, start=1)}
+    auto_symbols = set(auto_rank)
+    toss_symbols = set(toss_rank)
+
+    missing = sorted(toss_symbols - auto_symbols, key=lambda symbol: toss_rank[symbol])
+    extra = sorted(auto_symbols - toss_symbols, key=lambda symbol: auto_rank[symbol])
+    overlap = sorted(auto_symbols & toss_symbols, key=lambda symbol: toss_rank[symbol])
+
+    auto_by_symbol = {row["symbol"]: row for row in auto_rows}
+    rank_deltas = [
+        {
+            "symbol": symbol,
+            "tossRank": toss_rank[symbol],
+            "autoTraderRank": auto_rank[symbol],
+            "delta": auto_rank[symbol] - toss_rank[symbol],
+            "autoTraderMetrics": _metrics_for(auto_by_symbol.get(symbol, {})),
+        }
+        for symbol in overlap
+        if auto_rank[symbol] != toss_rank[symbol]
+    ]
+    rank_deltas.sort(key=lambda item: abs(int(item["delta"])), reverse=True)
+
+    return {
+        "preset": "consecutive_gainers",
+        "limit": limit,
+        "autoTraderCount": len(auto_rows),
+        "tossCount": len(toss_rows),
+        "overlapCount": len(overlap),
+        "missingFromAutoTrader": [
+            {"symbol": symbol, "tossRank": toss_rank[symbol]} for symbol in missing
+        ],
+        "extraInAutoTrader": [
+            {
+                "symbol": symbol,
+                "autoTraderRank": auto_rank[symbol],
+                "autoTraderMetrics": _metrics_for(auto_by_symbol.get(symbol, {})),
+            }
+            for symbol in extra
+        ],
+        "topRankDeltas": rank_deltas[:20],
+        "notes": [_NON_COMMON_STOCK_NOTE],
+    }
+
+
+def _metrics_for(row: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "week_change_rate": row.get("week_change_rate"),
+        "consecutive_up_days": row.get("consecutive_up_days"),
+        "change_rate": row.get("change_rate"),
+        "snapshot_date": row.get("snapshot_date"),
+        "_screener_snapshot_state": row.get("_screener_snapshot_state"),
+    }
+
+
+async def load_auto_trader_rows(
+    session: AsyncSession, *, market: str, limit: int
+) -> list[dict[str, Any]]:
+    from app.models.invest_screener_snapshot import InvestScreenerSnapshot
+    from app.services.invest_screener_snapshots.freshness import (
+        classify_state,
+        today_trading_date,
+    )
+
+    today = today_trading_date(market)
+    now = datetime.now(UTC)
+    stmt = (
+        sa.select(InvestScreenerSnapshot)
+        .where(
+            InvestScreenerSnapshot.market == market,
+            InvestScreenerSnapshot.consecutive_up_days >= 5,
+            InvestScreenerSnapshot.week_change_rate >= 0,
+        )
+        .order_by(
+            InvestScreenerSnapshot.snapshot_date.desc(),
+            InvestScreenerSnapshot.week_change_rate.desc().nullslast(),
+            InvestScreenerSnapshot.consecutive_up_days.desc(),
+            InvestScreenerSnapshot.change_rate.desc().nullslast(),
+            InvestScreenerSnapshot.symbol.asc(),
+        )
+        .limit(max(limit * 4, limit))
+    )
+    result = await session.execute(stmt)
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for snap in result.scalars().all():
+        if snap.symbol in seen:
+            continue
+        seen.add(snap.symbol)
+        state = classify_state(
+            snapshot_date=snap.snapshot_date,
+            computed_at=snap.computed_at,
+            closes_window_len=len(snap.closes_window or []),
+            today_trading_date_value=today,
+            now=now,
+        )
+        rows.append(
+            {
+                "symbol": snap.symbol,
+                "week_change_rate": float(snap.week_change_rate)
+                if snap.week_change_rate is not None
+                else None,
+                "consecutive_up_days": snap.consecutive_up_days,
+                "change_rate": float(snap.change_rate)
+                if snap.change_rate is not None
+                else None,
+                "snapshot_date": snap.snapshot_date.isoformat(),
+                "_screener_snapshot_state": state,
+            }
+        )
+        if len(rows) >= limit:
+            break
+    rows.sort(
+        key=lambda row: (
+            -(row.get("week_change_rate") or 0.0),
+            -(row.get("consecutive_up_days") or 0),
+            -(row.get("change_rate") or 0.0),
+            str(row.get("symbol") or ""),
+        )
+    )
+    return rows
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read-only Toss parity diagnostic for /invest screener."
+    )
+    parser.add_argument("--market", choices=["kr"], default="kr")
+    parser.add_argument("--preset", choices=sorted(_SUPPORTED_PRESETS), default="consecutive_gainers")
+    parser.add_argument("--toss-symbols-file", type=Path, required=True)
+    parser.add_argument("--limit", type=int, default=80)
+    return parser.parse_args(argv)
+
+
+async def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.limit <= 0 or args.limit > 500:
+        raise ValueError("--limit must be between 1 and 500")
+
+    from app.core.cli import setup_logging_and_sentry
+    from app.core.db import AsyncSessionLocal
+
+    setup_logging_and_sentry(service_name="diagnose-invest-screener-toss-parity")
+
+    try:
+        toss_rows = load_toss_symbols(args.toss_symbols_file)
+        async with AsyncSessionLocal() as session:
+            auto_rows = await load_auto_trader_rows(
+                session, market=args.market, limit=args.limit
+            )
+        report = build_parity_report(auto_rows, toss_rows, limit=args.limit)
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("diagnose_invest_screener_toss_parity crashed: %s", exc)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/test_invest_api_screener_router.py
+++ b/tests/test_invest_api_screener_router.py
@@ -230,6 +230,9 @@ def test_screener_consecutive_gainers_returns_streak_and_freshness() -> None:
         label = row["metricValueLabel"]
         assert label.endswith("일"), f"Expected N일 label, got: {label}"
         assert int(label[:-1]) >= 5, f"Expected streak >= 5, got: {label}"
-    # Verify the preset passed min_consecutive_up_days=5 to the service
+    # Verify the Toss-parity preset filters passed to the service
     assert stub.calls
     assert stub.calls[0].get("min_consecutive_up_days") == 5
+    assert stub.calls[0].get("min_week_change_rate") == 0.0
+    assert stub.calls[0].get("sort_by") == "week_change_rate"
+    assert stub.calls[0].get("limit") == 80

--- a/tests/test_invest_screener_presets.py
+++ b/tests/test_invest_screener_presets.py
@@ -68,6 +68,17 @@ def test_consecutive_gainers_preset_requests_streak_filter() -> None:
 
 
 @pytest.mark.unit
+def test_consecutive_gainers_preset_matches_toss_rank_and_limit() -> None:
+    filters = screening_filters_for("consecutive_gainers", market="kr")
+
+    assert filters.get("min_consecutive_up_days") == 5
+    assert filters.get("min_week_change_rate") == 0.0
+    assert filters.get("sort_by") == "week_change_rate"
+    assert filters.get("sort_order") == "desc"
+    assert filters.get("limit") == 80
+
+
+@pytest.mark.unit
 def test_consecutive_gainers_chip_says_5_days() -> None:
     preset = get_preset("consecutive_gainers", market="kr")
     assert preset is not None

--- a/tests/test_invest_screener_toss_parity_diagnostics.py
+++ b/tests/test_invest_screener_toss_parity_diagnostics.py
@@ -97,11 +97,16 @@ def test_load_toss_symbols_accepts_csv_and_normalizes_exchange_prefix(tmp_path) 
 @pytest.mark.unit
 def test_load_toss_symbols_accepts_json_symbol_list(tmp_path) -> None:
     path = tmp_path / "toss.json"
-    path.write_text(json.dumps(["005930", {"symbol": "KRX:000660", "rank": 4}]), encoding="utf-8")
+    path.write_text(
+        json.dumps(["005930", {"symbol": "KRX:000660", "rank": 4}]), encoding="utf-8"
+    )
 
     rows = load_toss_symbols(path)
 
-    assert [(row["rank"], row["symbol"]) for row in rows] == [(1, "005930"), (4, "000660")]
+    assert [(row["rank"], row["symbol"]) for row in rows] == [
+        (1, "005930"),
+        (4, "000660"),
+    ]
 
 
 @pytest.mark.unit
@@ -111,7 +116,10 @@ def test_load_toss_symbols_accepts_plain_symbol_list(tmp_path) -> None:
 
     rows = load_toss_symbols(path)
 
-    assert [(row["rank"], row["symbol"]) for row in rows] == [(1, "005930"), (2, "000660")]
+    assert [(row["rank"], row["symbol"]) for row in rows] == [
+        (1, "005930"),
+        (2, "000660"),
+    ]
 
 
 @pytest.mark.unit

--- a/tests/test_invest_screener_toss_parity_diagnostics.py
+++ b/tests/test_invest_screener_toss_parity_diagnostics.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from scripts.diagnose_invest_screener_toss_parity import (
+    build_parity_report,
+    load_toss_symbols,
+)
+
+
+@pytest.mark.unit
+def test_build_parity_report_counts_rank_deltas_and_metrics() -> None:
+    auto_rows = [
+        {
+            "symbol": "222222",
+            "week_change_rate": 8.0,
+            "consecutive_up_days": 5,
+            "snapshot_date": "2026-05-11",
+            "_screener_snapshot_state": "fresh",
+        },
+        {
+            "symbol": "333333",
+            "week_change_rate": 3.0,
+            "consecutive_up_days": 6,
+            "snapshot_date": "2026-05-11",
+            "_screener_snapshot_state": "fresh",
+        },
+        {
+            "symbol": "999999",
+            "week_change_rate": 1.0,
+            "consecutive_up_days": 7,
+            "snapshot_date": "2026-05-11",
+            "_screener_snapshot_state": "fresh",
+        },
+    ]
+    toss_rows = [
+        {"rank": 1, "symbol": "111111"},
+        {"rank": 2, "symbol": "222222"},
+        {"rank": 3, "symbol": "333333"},
+    ]
+
+    report = build_parity_report(auto_rows, toss_rows, limit=80)
+
+    assert report["autoTraderCount"] == 3
+    assert report["tossCount"] == 3
+    assert report["overlapCount"] == 2
+    assert report["missingFromAutoTrader"] == [{"symbol": "111111", "tossRank": 1}]
+    assert report["extraInAutoTrader"][0]["symbol"] == "999999"
+    assert report["topRankDeltas"][0] == {
+        "symbol": "222222",
+        "tossRank": 2,
+        "autoTraderRank": 1,
+        "delta": -1,
+        "autoTraderMetrics": {
+            "week_change_rate": 8.0,
+            "consecutive_up_days": 5,
+            "change_rate": None,
+            "snapshot_date": "2026-05-11",
+            "_screener_snapshot_state": "fresh",
+        },
+    }
+    assert "instrument_type" in report["notes"][0]
+
+
+@pytest.mark.unit
+def test_load_toss_symbols_accepts_csv_and_normalizes_exchange_prefix(tmp_path) -> None:
+    path = tmp_path / "toss.csv"
+    path.write_text(
+        "rank,symbol,name,week_change_rate,consecutive_up_days\n"
+        "1,KRX:005930,삼성전자,8.5%,6\n"
+        "2,000660,SK하이닉스,3.2,5\n",
+        encoding="utf-8",
+    )
+
+    rows = load_toss_symbols(path)
+
+    assert rows == [
+        {
+            "rank": 1,
+            "symbol": "005930",
+            "name": "삼성전자",
+            "week_change_rate": 8.5,
+            "consecutive_up_days": 6,
+        },
+        {
+            "rank": 2,
+            "symbol": "000660",
+            "name": "SK하이닉스",
+            "week_change_rate": 3.2,
+            "consecutive_up_days": 5,
+        },
+    ]
+
+
+@pytest.mark.unit
+def test_load_toss_symbols_accepts_json_symbol_list(tmp_path) -> None:
+    path = tmp_path / "toss.json"
+    path.write_text(json.dumps(["005930", {"symbol": "KRX:000660", "rank": 4}]), encoding="utf-8")
+
+    rows = load_toss_symbols(path)
+
+    assert [(row["rank"], row["symbol"]) for row in rows] == [(1, "005930"), (4, "000660")]
+
+
+@pytest.mark.unit
+def test_load_toss_symbols_accepts_plain_symbol_list(tmp_path) -> None:
+    path = tmp_path / "toss_symbols.txt"
+    path.write_text("KRX:005930\n000660\n", encoding="utf-8")
+
+    rows = load_toss_symbols(path)
+
+    assert [(row["rank"], row["symbol"]) for row in rows] == [(1, "005930"), (2, "000660")]
+
+
+@pytest.mark.unit
+def test_load_toss_symbols_rejects_sensitive_exports(tmp_path) -> None:
+    path = tmp_path / "toss.csv"
+    path.write_text("symbol,authorization\n005930,Bearer abc.def\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must not contain"):
+        load_toss_symbols(path)

--- a/tests/test_invest_screener_week_change_filter.py
+++ b/tests/test_invest_screener_week_change_filter.py
@@ -98,6 +98,22 @@ def test_consecutive_gainers_preset_includes_week_change_filter() -> None:
     assert us_filters["min_week_change_rate"] == 0.0
 
 
+@pytest.mark.unit
+def test_sort_and_limit_supports_week_change_rate() -> None:
+    from app.mcp_server.tooling.screening.common import _sort_and_limit
+
+    rows = [
+        {"symbol": "A", "week_change_rate": 1.0},
+        {"symbol": "B", "week_change_rate": 8.0},
+        {"symbol": "C", "week_change_rate": 3.0},
+        {"symbol": "D", "week_change_rate": None},
+    ]
+
+    out = _sort_and_limit(rows, "week_change_rate", "desc", 3)
+
+    assert [r["symbol"] for r in out] == ["B", "C", "A"]
+
+
 @pytest.mark.asyncio
 async def test_screen_stocks_impl_drops_negative_week_change(monkeypatch) -> None:
     from app.mcp_server.tooling import analysis_screening

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -925,6 +925,69 @@ async def test_build_screener_results_uses_snapshots_before_external_screening()
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_build_screener_results_orders_snapshot_rows_by_week_change() -> None:
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(
+                scalar_rows=[
+                    _FakeSnapshot(
+                        symbol="111111",
+                        consecutive_up_days=9,
+                        week_change_rate=Decimal("1.0"),
+                    ),
+                    _FakeSnapshot(
+                        symbol="222222",
+                        consecutive_up_days=5,
+                        week_change_rate=Decimal("8.0"),
+                    ),
+                    _FakeSnapshot(
+                        symbol="333333",
+                        consecutive_up_days=6,
+                        week_change_rate=Decimal("3.0"),
+                    ),
+                ]
+            ),
+            _FakeExecuteResult(
+                scalar_rows=[
+                    _FakeSnapshot(
+                        symbol="222222",
+                        consecutive_up_days=5,
+                        week_change_rate=Decimal("8.0"),
+                    ),
+                    _FakeSnapshot(
+                        symbol="333333",
+                        consecutive_up_days=6,
+                        week_change_rate=Decimal("3.0"),
+                    ),
+                    _FakeSnapshot(
+                        symbol="111111",
+                        consecutive_up_days=9,
+                        week_change_rate=Decimal("1.0"),
+                    ),
+                ]
+            ),
+            _FakeExecuteResult(),
+        ]
+    )
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched=set()),
+        session=session,
+    )
+
+    assert [row.symbol for row in resp.results] == ["222222", "333333", "111111"]
+    assert [row.metricValueLabel for row in resp.results] == ["5일", "6일", "9일"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_build_screener_results_redacts_external_connection_failures() -> None:
     fake_screening = MagicMock()
     fake_screening.list_screening = AsyncMock(


### PR DESCRIPTION
## Summary

- Aligns `/invest/screener` `consecutive_gainers` with Toss `연속 상승세` parity expectations.
- Sorts snapshot-first rows primarily by 1-week change rate, supports Toss-sized `limit=80`, and keeps freshness/count semantics explicit.
- Adds read-only Toss parity diagnostics/tests for count/top-N/rank-diff style comparison.

## Verification

- `uv run pytest tests/test_invest_screener_presets.py tests/test_invest_screener_week_change_filter.py tests/test_invest_view_model_screener_service.py tests/test_invest_api_screener_router.py tests/test_invest_screener_toss_parity_diagnostics.py -m unit -q`
- `uv run ruff check app/services/invest_view_model/screener_presets.py app/services/invest_view_model/screener_service.py app/mcp_server/tooling/screening/common.py scripts/diagnose_invest_screener_toss_parity.py tests/test_invest_screener_presets.py tests/test_invest_screener_week_change_filter.py tests/test_invest_view_model_screener_service.py tests/test_invest_api_screener_router.py tests/test_invest_screener_toss_parity_diagnostics.py`

## Safety

- Read-only API/UI/query logic only.
- No broker/order/watch/order-intent/live/KIS/Upbit mutations.
- No production DB `--commit` backfill, direct DB update/delete, or scheduler activation.

Closes ROB-202


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Consecutive Gainers screening preset now sorts results by weekly change rate
  * Result limit for Consecutive Gainers preset increased from 20 to 80 items

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/791)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->