### PR TITLE
feat(ROB-203): add invest coverage actionability diagnostics

### DIFF
--- a/.hermes/plans/2026-05-12_063549-rob-203-coverage-actionability-plan.md
+++ b/.hermes/plans/2026-05-12_063549-rob-203-coverage-actionability-plan.md
@@ -1,0 +1,582 @@
+# ROB-203 /invest Coverage Actionability + All-Market Symbol Drilldown Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task. This planner task is read-only except for this plan artifact.
+
+**Goal:** Make `/invest/coverage` and `/invest/api/coverage?market=all&symbols=005930,AAPL,MSFT` actionable by returning symbol-level diagnostics across KR/US, exposing coverage-to-work-queue metadata, rendering that metadata in the UI, and documenting approval gates.
+
+**Architecture:** Extend the existing ROB-201 coverage contract rather than introducing a new coverage system. Keep the endpoint read-only: it inspects only local `auto_trader` DB/read-model state, labels Toss/Naver as reference/candidate signals, and maps coverage states to recommended work-queue actions without triggering backfills, schedulers, broker calls, watch/order intents, or production DB writes.
+
+**Tech Stack:** FastAPI + Pydantic v2 schemas, SQLAlchemy async sessions, pytest/httpx backend tests, React/TypeScript frontend under `frontend/invest`, Vitest/React Testing Library for targeted frontend tests, markdown docs.
+
+---
+
+## Current Context and Important Findings
+
+1. The active worktree is:
+   `/Users/mgh3326/worktrees/auto_trader/rob-203-coverage-actionability`
+
+2. Current branch is:
+   `feature/rob-203-coverage-actionability`
+
+3. The active branch currently appears to be based on `origin/main` and does **not** contain the ROB-201 invest coverage implementation. Searches in this worktree found no `app/schemas/invest_coverage.py`, no `app/services/invest_coverage_service.py`, and no frontend coverage page/API files.
+
+4. The existing coverage implementation is on:
+   `origin/kanban/ROB-201-naver-coverage`
+
+5. ROB-201 files inspected from that branch:
+   - `app/schemas/invest_coverage.py`
+   - `app/services/invest_coverage_service.py`
+   - `app/routers/invest_api.py`
+   - `tests/test_invest_coverage.py`
+   - `frontend/invest/src/api/coverage.ts`
+   - `frontend/invest/src/types/coverage.ts`
+   - `frontend/invest/src/pages/desktop/DesktopCoveragePage.tsx`
+   - `frontend/invest/src/__tests__/routes.test.tsx`
+   - `docs/invest-coverage-dashboard.md`
+   - `docs/superpowers/plans/2026-05-11-rob-201-naver-coverage-contract.md`
+
+6. Primary discovered backend bug in ROB-201 code:
+   `build_invest_coverage(..., market="all", symbols=[...])` accepts `market="all"`, but `_symbol_rows(db, market, symbols, trading_day)` starts with:
+
+   ```python
+   if not symbols or market not in {"kr", "us"}:
+       return []
+   ```
+
+   Therefore `/invest/api/coverage?market=all&symbols=005930,AAPL,MSFT` returns no symbol rows even though the top-level market contract supports `all`.
+
+7. Claude Code Opus delegation was attempted but unavailable in this runtime:
+   - Command: `claude -p --model opus --permission-mode plan --max-turns 20 < /tmp/rob-203-planner-prompt.md`
+   - Result: exit code 1, `Not logged in · Please run /login`
+   - Actual planner model for this handoff: Hermes `planner` profile using the current CLI model, not Claude Code Opus.
+
+---
+
+## Safety and Approval Gates
+
+Keep these gates explicit in implementation, tests, docs, Linear comments, and review handoff:
+
+1. Read-only only for this issue:
+   - No production DB writes.
+   - No backfills.
+   - No scheduler/TaskIQ/Prefect activation.
+   - No broker/KIS/Upbit/Alpaca calls.
+   - No order submit/cancel/modify.
+   - No watch-alert or order-intent mutations.
+   - No request-path scraping.
+
+2. Source-of-truth boundaries:
+   - `auto_trader` DB/read models remain source of truth.
+   - KIS/Upbit/news-ingestor owned ingest paths remain source-of-truth inputs where already designed.
+   - Toss is a parity/reference benchmark only.
+   - Naver remains candidate/reference only; never set `sourceOfTruth` to `naver_finance`, `naver_research`, or Naver discussion data.
+
+3. Any future production remediation from coverage output must be separately approved:
+   - Bounded data backfill approval.
+   - Scheduler activation approval.
+   - Broker/order approval if a future unrelated workflow reaches trading execution.
+
+---
+
+## Branch Integration Strategy
+
+### Task 1: Bring ROB-201 coverage baseline into the ROB-203 worktree
+
+**Objective:** Make the ROB-203 branch contain the already planned/implemented ROB-201 coverage contract before applying ROB-203 deltas.
+
+**Files expected from ROB-201 baseline:**
+- Create/modify: `app/schemas/invest_coverage.py`
+- Create/modify: `app/services/invest_coverage_service.py`
+- Modify: `app/routers/invest_api.py`
+- Create/modify: `tests/test_invest_coverage.py`
+- Create/modify: `frontend/invest/src/api/coverage.ts`
+- Create/modify: `frontend/invest/src/types/coverage.ts`
+- Create/modify: `frontend/invest/src/pages/desktop/DesktopCoveragePage.tsx`
+- Modify: frontend routing/navigation files that register `/invest/coverage` from ROB-201
+- Create/modify: `docs/invest-coverage-dashboard.md`
+
+**Implementation guidance:**
+- Prefer merging/cherry-picking the ROB-201 branch or rebasing ROB-203 on a main commit that already includes ROB-201, if available.
+- If ROB-201 is not merged, explicitly apply the ROB-201 coverage files first, then commit as a baseline before ROB-203-specific changes.
+- Do not silently reimplement ROB-201 from memory; preserve the schema and Naver candidate semantics already reviewed in ROB-201.
+
+**Verification:**
+
+Run after baseline is present:
+
+```bash
+pytest tests/test_invest_coverage.py -q
+```
+
+Expected before ROB-203 changes: ROB-201 tests pass, but there should be no coverage yet for `market=all&symbols=005930,AAPL,MSFT`.
+
+---
+
+## Backend Contract Plan
+
+### Task 2: Add actionability metadata to coverage schemas
+
+**Objective:** Make coverage output directly mappable to a safe work queue without executing work.
+
+**File:**
+- Modify: `app/schemas/invest_coverage.py`
+
+**Add narrow, explicit metadata fields. Suggested schema additions:**
+
+```python
+CoverageActionPriority = Literal["none", "low", "medium", "high", "blocked"]
+CoverageActionKind = Literal[
+    "none",
+    "monitor",
+    "investigate",
+    "repair_read_model",
+    "backfill_candidate",
+    "scheduler_candidate",
+    "provider_contract_needed",
+    "unsupported_no_action",
+]
+CoverageApprovalGate = Literal[
+    "none",
+    "code_review",
+    "production_db_write_approval",
+    "scheduler_activation_approval",
+    "broker_order_approval",
+]
+
+class CoverageActionability(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    priority: CoverageActionPriority = "none"
+    action: CoverageActionKind = "none"
+    queue: str | None = None
+    approvalGates: list[CoverageApprovalGate] = Field(default_factory=list)
+    reason: str | None = None
+    safeByDefault: bool = True
+```
+
+Then attach it to both surface-level and symbol-level diagnostics:
+
+```python
+class InvestCoverageSurface(BaseModel):
+    ...
+    actionability: CoverageActionability = Field(default_factory=CoverageActionability)
+
+class InvestCoverageSymbol(BaseModel):
+    ...
+    actionability: CoverageActionability = Field(default_factory=CoverageActionability)
+```
+
+**Design rules:**
+- `fresh` -> `priority="none"`, `action="monitor"` or `none`, no gates.
+- `partial`/`stale` -> usually `priority="medium"`, `action="repair_read_model"` or `backfill_candidate"`, gate `production_db_write_approval` if remediation would write production rows.
+- `missing` -> usually `priority="high"`, `action="backfill_candidate"` for existing read models or `provider_contract_needed` if the durable model is not defined.
+- `provider_unwired` -> `priority="blocked"`, `action="provider_contract_needed"`, gate `code_review`; do not imply immediate backfill.
+- `unsupported` -> `priority="none"`, `action="unsupported_no_action"`, no remediation unless product scope changes.
+- `error` -> `priority="high"`, `action="investigate"`, gate depends on the concrete surface.
+
+**Testing:**
+- Add Pydantic schema tests in `tests/test_invest_coverage.py` that instantiate `InvestCoverageSurface` and `InvestCoverageSymbol` with actionability.
+- Assert `extra="forbid"` still catches unexpected fields if there is an existing style for that in tests.
+
+---
+
+### Task 3: Add a helper to derive actionability from surface state
+
+**Objective:** Centralize state-to-queue mapping so backend, tests, UI, and docs stay consistent.
+
+**File:**
+- Modify: `app/services/invest_coverage_service.py`
+
+**Suggested helper:**
+
+```python
+def _actionability_for_surface(
+    *,
+    surface: str,
+    state: CoverageState,
+    market: str | None,
+    source_of_truth: str,
+) -> CoverageActionability:
+    ...
+```
+
+**Behavior:**
+- Return an explicit `CoverageActionability` for every `InvestCoverageSurface`.
+- Include a `queue` string such as:
+  - `invest-data-read-models`
+  - `news-ingestor`
+  - `market-events-ingestion`
+  - `research-report-ingestion`
+  - `provider-contract`
+  - `none`
+- Include `approvalGates` only for actions that require approval before execution.
+- Never perform the action from this helper.
+
+**Recommended queue mapping:**
+- `symbol_universe` -> `invest-data-read-models`
+- `screener_snapshots` -> `invest-screener-snapshots`
+- `news_feed` -> `news-ingestor`
+- `calendar_events` -> `market-events-ingestion`
+- `research_reports` -> `research-report-ingestion`
+- `investor_flow` -> `investor-flow-ingestion`
+- `holdings` -> `account-panel-read-model`
+- `pending_orders` -> `order-reconciliation-read-model`
+- `orderbook_nxt_capability` -> `kr-symbol-universe` for KR missing, otherwise `none`/unsupported
+- `quotes`, `ohlcv`, `valuation_fundamentals` -> `provider-contract` until durable read models exist
+
+**Testing:**
+- Unit-test representative mappings through `build_invest_coverage`, not just the private helper.
+- Assert no actionability field suggests immediate execution or omits approval gates for DB-write/scheduler candidate actions.
+
+---
+
+### Task 4: Fix all-market symbol partitioning
+
+**Objective:** Make `/invest/api/coverage?market=all&symbols=005930,AAPL,MSFT` return KR and US symbol rows.
+
+**File:**
+- Modify: `app/services/invest_coverage_service.py`
+
+**Recommended approach:**
+
+1. Keep `_normalize_symbols` unchanged unless needed.
+2. Replace the early-return-only logic in `_symbol_rows` with a market expansion layer:
+
+```python
+async def _symbol_rows(db, market, symbols, trading_day):
+    if not symbols:
+        return []
+    if market == "all":
+        return await _symbol_rows_all_markets(db, symbols, trading_day)
+    if market not in {"kr", "us"}:
+        return [_unsupported_symbol_row(symbol, market) for symbol in symbols]
+    return await _symbol_rows_for_market(db, market, symbols, trading_day)
+```
+
+3. Extract the existing KR/US logic into `_symbol_rows_for_market(...)`.
+4. Implement `_symbol_rows_all_markets(...)` by partitioning the requested symbols:
+   - Symbols matching KR universe (`kr_symbol_universe.symbol`) -> KR.
+   - Symbols matching US universe (`us_symbol_universe.symbol`) -> US.
+   - If a symbol is not found in either universe, use safe heuristics only as a fallback:
+     - six digits -> KR
+     - uppercase alphabetic ticker like `AAPL`/`MSFT` -> US
+     - `KRW-` or crypto-looking symbols -> unsupported/crypto row if a crypto symbol row contract is desired; otherwise warn that symbol-level diagnostics are not implemented for crypto.
+5. Preserve request order in `response.symbols`.
+6. Preserve current KR semantics:
+   - `investor_flow` supported for KR.
+   - `naver_investor_flow` included for KR as candidate/reference diagnostic.
+7. Preserve current US semantics:
+   - `investor_flow` unsupported.
+   - `naver_investor_flow` unsupported.
+8. Do not query external providers or scrape Naver/Toss.
+
+**Expected result for the acceptance URL:**
+- `005930` row with `market="kr"`.
+- `AAPL` row with `market="us"`.
+- `MSFT` row with `market="us"`.
+- Rows may have `missing`/`stale` states depending on local fixture/test rows, but rows must exist.
+- KR row includes `naver_investor_flow` state.
+- US rows include `investor_flow="unsupported"` and `naver_investor_flow="unsupported"`.
+
+---
+
+### Task 5: Add backend tests for all-market symbol diagnostics
+
+**Objective:** Lock the ROB-203 acceptance URL into tests.
+
+**File:**
+- Modify: `tests/test_invest_coverage.py`
+
+**Add test:**
+
+```python
+@pytest.mark.asyncio
+async def test_coverage_endpoint_market_all_returns_partitioned_symbol_rows(
+    app: FastAPI, db_session
+):
+    ...
+```
+
+**Fixture setup guidance:**
+- Use synthetic IDs/symbols if hard-coded real symbols collide with seeded data; however at least one endpoint-level test should use the literal acceptance query `005930,AAPL,MSFT`.
+- Insert or ensure universe rows for:
+  - `KRSymbolUniverse(symbol="005930", ...)`
+  - `USSymbolUniverse(symbol="AAPL", ...)`
+  - `USSymbolUniverse(symbol="MSFT", ...)`
+- Insert fresh/stale `InvestScreenerSnapshot` rows for at least one KR and one US symbol.
+- Insert `InvestorFlowSnapshot` for `005930` with `source="naver_finance"` to verify Naver candidate/reference symbol state stays KR-only.
+- Insert `NewsArticle` + `NewsArticleRelatedSymbol` rows for one KR and one US symbol if the current symbol-row contract should mark `news_feed` fresh.
+
+**Assertions:**
+
+```python
+r = await client.get("/invest/api/coverage?market=all&symbols=005930,AAPL,MSFT&asOf=2026-05-11")
+assert r.status_code == 200
+payload = r.json()
+assert payload["market"] == "all"
+by_symbol = {row["symbol"]: row for row in payload["symbols"]}
+assert set(by_symbol) == {"005930", "AAPL", "MSFT"}
+assert by_symbol["005930"]["market"] == "kr"
+assert by_symbol["AAPL"]["market"] == "us"
+assert by_symbol["MSFT"]["market"] == "us"
+assert "naver_investor_flow" in by_symbol["005930"]["surfaces"]
+assert by_symbol["AAPL"]["surfaces"]["investor_flow"] == "unsupported"
+assert by_symbol["MSFT"]["surfaces"]["naver_investor_flow"] == "unsupported"
+assert all("actionability" in row for row in payload["symbols"])
+```
+
+**Also add service-level test if useful:**
+- Directly call `build_invest_coverage(db_session, market="all", symbols=[...], as_of=...)` and assert row ordering matches requested symbol order.
+
+---
+
+## Frontend Plan
+
+### Task 6: Extend TypeScript coverage types
+
+**Objective:** Match backend actionability contract in the frontend.
+
+**File:**
+- Modify: `frontend/invest/src/types/coverage.ts`
+
+**Add types matching backend literals:**
+
+```ts
+export type CoverageActionPriority = "none" | "low" | "medium" | "high" | "blocked";
+export type CoverageActionKind =
+  | "none"
+  | "monitor"
+  | "investigate"
+  | "repair_read_model"
+  | "backfill_candidate"
+  | "scheduler_candidate"
+  | "provider_contract_needed"
+  | "unsupported_no_action";
+export type CoverageApprovalGate =
+  | "none"
+  | "code_review"
+  | "production_db_write_approval"
+  | "scheduler_activation_approval"
+  | "broker_order_approval";
+
+export interface CoverageActionability {
+  priority: CoverageActionPriority;
+  action: CoverageActionKind;
+  queue?: string | null;
+  approvalGates: CoverageApprovalGate[];
+  reason?: string | null;
+  safeByDefault: boolean;
+}
+```
+
+Attach to:
+- `InvestCoverageSurface.actionability`
+- `InvestCoverageSymbol.actionability`
+
+---
+
+### Task 7: Render actionability and Naver readiness in coverage UI
+
+**Objective:** Make `/invest/coverage` an actionable queue view while remaining read-only.
+
+**File:**
+- Modify: `frontend/invest/src/pages/desktop/DesktopCoveragePage.tsx`
+
+**UI changes:**
+1. Keep existing state pills.
+2. Keep existing `sourceCandidates` readiness chips for Naver/Toss references.
+3. Add an `Actionability` column to the surface table showing:
+   - priority pill
+   - action kind
+   - queue name
+   - approval gates as small chips
+4. In symbol coverage rows, include:
+   - symbol market (`kr`/`us`/`crypto`/unknown)
+   - actionability priority/action if not `none`
+   - warnings if any
+5. Keep right-rail safety principles visible and update them from ROB-201 to ROB-203 wording:
+   - source-of-truth is local DB/read-models
+   - Toss/Naver are reference/candidate only
+   - no orders/backfills/schedulers from this page
+
+**Copy guidance:**
+- Avoid wording like “run backfill now” or “execute”.
+- Prefer “후보”, “검토”, “승인 필요”, “대기열”.
+- Naver chips should be labeled as candidate/reference readiness, not authoritative health.
+
+---
+
+### Task 8: Add targeted frontend tests
+
+**Objective:** Ensure the UI actually renders states, Naver readiness, and actionability metadata.
+
+**Files:**
+- Modify/create: `frontend/invest/src/__tests__/coverage.test.tsx` if coverage-specific tests exist or can be added.
+- Otherwise extend `frontend/invest/src/__tests__/routes.test.tsx` minimally for route registration and render smoke.
+
+**Test cases:**
+1. Mock `fetchInvestCoverage` response with:
+   - one `fresh` surface
+   - one `provider_unwired` surface with `actionability.priority="blocked"`
+   - one Naver source candidate with readiness `request_time_only`
+   - symbol rows for `005930`, `AAPL`, `MSFT`
+2. Assert rendered text includes:
+   - state labels (`정상`, `미연결`, etc.)
+   - `naver_finance`
+   - readiness label (`request-time` or localized equivalent)
+   - action queue (`provider-contract` or localized label)
+   - approval gate (`code_review` or localized label)
+   - all three symbols.
+
+**Verification commands:**
+- Inspect `frontend/invest/package.json` for exact test script.
+- Likely commands:
+
+```bash
+cd frontend/invest
+npm test -- --run coverage
+npm run typecheck
+```
+
+If the repo uses a different script, record the exact command in handoff.
+
+---
+
+## Documentation Plan
+
+### Task 9: Update coverage docs with work-queue mapping and approval gates
+
+**Objective:** Make the intended use of coverage output explicit and safe.
+
+**File:**
+- Modify: `docs/invest-coverage-dashboard.md`
+
+**Add sections:**
+1. “Actionability metadata” explaining `priority`, `action`, `queue`, `approvalGates`, `safeByDefault`.
+2. “Coverage state to work queue mapping” table:
+
+| State | Meaning | Default action | Approval gate |
+| --- | --- | --- | --- |
+| fresh | current read-model rows exist | monitor/no action | none |
+| stale | old rows exist | investigate or backfill candidate | production DB write approval before any backfill |
+| partial | some expected rows exist | repair read model/backfill candidate | production DB write approval before any backfill |
+| missing | no local rows exist | investigate/backfill candidate/provider contract | approval depends on queue |
+| unsupported | intentionally out of scope | no action | none |
+| provider_unwired | concept exists but durable read model absent | provider contract/code work | code review; later DB/scheduler approval if added |
+| error | ingestion metadata failed/degraded | investigate | depends on remediation |
+
+3. “All-market symbol diagnostics” documenting:
+   - `market=all&symbols=005930,AAPL,MSFT` partitions symbols by KR/US universe/heuristic.
+   - KR rows can include `naver_investor_flow` as candidate/reference state.
+   - US rows mark investor-flow/Naver investor-flow unsupported.
+
+4. “Approval gates” restating no production writes/backfills/schedulers/broker actions without separate explicit approval.
+
+5. “Naver/Toss semantics”:
+   - Toss: benchmark/reference only.
+   - Naver: candidate/reference only.
+   - Neither becomes `sourceOfTruth`.
+
+---
+
+## Validation Plan
+
+Run all commands from:
+`/Users/mgh3326/worktrees/auto_trader/rob-203-coverage-actionability`
+
+### Backend validation
+
+```bash
+pytest tests/test_invest_coverage.py -q
+```
+
+If imports or DB fixtures require broader context, run the narrow node first:
+
+```bash
+pytest tests/test_invest_coverage.py::test_coverage_endpoint_market_all_returns_partitioned_symbol_rows -q
+```
+
+Expected: all coverage tests pass and the new all-market symbol test proves rows for `005930`, `AAPL`, `MSFT`.
+
+### Frontend validation
+
+First inspect scripts:
+
+```bash
+cd frontend/invest
+npm run
+```
+
+Then run likely commands:
+
+```bash
+npm run typecheck
+npm test -- --run
+```
+
+If there is a coverage-specific test file:
+
+```bash
+npm test -- --run coverage
+```
+
+Expected: TypeScript passes and the coverage UI test confirms state chips, Naver readiness chips, actionability metadata, and symbol rows render.
+
+### Read-only/manual smoke
+
+If a local app/test client is available, perform only read-only GET smoke:
+
+```bash
+curl 'http://127.0.0.1:<port>/invest/api/coverage?market=all&symbols=005930,AAPL,MSFT'
+```
+
+Expected JSON:
+- `market: "all"`
+- `symbols` contains rows for `005930`, `AAPL`, `MSFT`
+- each surface/symbol has `actionability`
+- no Naver source candidate has become `sourceOfTruth`
+
+Do not run any production write, backfill, scheduler, or broker command as part of this issue.
+
+---
+
+## Risks and Mitigations
+
+1. **ROB-201 branch dependency:** The current ROB-203 worktree lacks coverage baseline files. Mitigate by integrating ROB-201 first or rebasing after ROB-201 merge before coding ROB-203 deltas.
+
+2. **Symbol market ambiguity under `market=all`:** Some symbols may not exist in local universe tables. Mitigate with universe-first partitioning and conservative fallback heuristics; preserve request order and warning text for unresolved symbols.
+
+3. **Crypto symbol-level scope creep:** ROB-201 `_symbol_rows` only supports KR/US. Keep crypto unsupported unless there is already a durable crypto symbol diagnostic contract.
+
+4. **Actionability becoming execution:** Avoid buttons or language that implies the dashboard can run backfills/schedulers/orders. Metadata is advisory/work-queue only.
+
+5. **Naver semantics regression:** Tests must assert `sourceOfTruth != "naver_finance"` and Naver remains in `sourceCandidates`/references only.
+
+6. **Frontend test brittleness:** Keep tests focused on visible contract text and chips, not exact layout/CSS.
+
+---
+
+## Recommended Implementation Order
+
+1. Integrate ROB-201 baseline into this worktree.
+2. Run ROB-201 coverage backend tests to establish baseline.
+3. Add backend schema actionability metadata and tests.
+4. Add actionability helper/mapping in the service.
+5. Fix `market=all` symbol partitioning and preserve order.
+6. Add endpoint/service tests for `market=all&symbols=005930,AAPL,MSFT`.
+7. Extend frontend TypeScript types.
+8. Render actionability metadata in `DesktopCoveragePage.tsx`.
+9. Add frontend coverage render tests.
+10. Update docs with work-queue mapping and approval gates.
+11. Run targeted backend/frontend validation.
+12. Post evidence to Linear/Kanban and hand off to review.
+
+---
+
+## Handoff Notes for Implementer
+
+- This is a read-only coverage/actionability issue, not a data-repair issue.
+- If you find empty production data while testing, do not backfill it in this task. Report it as a candidate action with the appropriate approval gate.
+- If you need to run a local server for smoke, keep it local and read-only.
+- If any command would source production env, ensure it does not print secrets and do not run write/backfill/scheduler paths.
+- Record actual tool/model used because Claude Code Opus was not available to the planner runtime.

--- a/app/schemas/invest_coverage.py
+++ b/app/schemas/invest_coverage.py
@@ -30,6 +30,42 @@ CoverageCandidateReadiness = Literal[
     "not_wired",
 ]
 CoverageCandidateKind = Literal["secondary_source", "reference", "candidate"]
+CoverageActionPriority = Literal["none", "low", "medium", "high", "blocked"]
+CoverageActionKind = Literal[
+    "none",
+    "monitor",
+    "investigate",
+    "repair_read_model",
+    "backfill_candidate",
+    "scheduler_candidate",
+    "provider_contract_needed",
+    "unsupported_no_action",
+]
+CoverageApprovalGate = Literal[
+    "none",
+    "code_review",
+    "production_db_write_approval",
+    "scheduler_activation_approval",
+    "broker_order_approval",
+]
+
+
+class CoverageActionability(BaseModel):
+    """Advisory mapping from coverage state to a safe work queue.
+
+    This metadata is intentionally descriptive only. It must never trigger a
+    backfill, scheduler activation, broker call, watch mutation, or order side
+    effect from the coverage request path.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    priority: CoverageActionPriority = "none"
+    action: CoverageActionKind = "none"
+    queue: str | None = None
+    approvalGates: list[CoverageApprovalGate] = Field(default_factory=list)
+    reason: str | None = None
+    safeByDefault: bool = True
 
 
 class InvestCoverageCounts(BaseModel):
@@ -75,6 +111,7 @@ class InvestCoverageSurface(BaseModel):
     warnings: list[str] = Field(default_factory=list)
     notes: list[str] = Field(default_factory=list)
     sourceCandidates: list[CoverageSourceCandidate] = Field(default_factory=list)
+    actionability: CoverageActionability = Field(default_factory=CoverageActionability)
 
 
 class InvestCoverageSymbol(BaseModel):
@@ -85,6 +122,7 @@ class InvestCoverageSymbol(BaseModel):
     surfaces: dict[str, CoverageState] = Field(default_factory=dict)
     latestDates: dict[str, date | None] = Field(default_factory=dict)
     warnings: list[str] = Field(default_factory=list)
+    actionability: CoverageActionability = Field(default_factory=CoverageActionability)
 
 
 class InvestCoverageResponse(BaseModel):

--- a/app/services/invest_coverage_service.py
+++ b/app/services/invest_coverage_service.py
@@ -205,7 +205,11 @@ def _actionability_for_surface(
     if queue in _SCHEDULER_QUEUES:
         gates.append("scheduler_activation_approval")
     if state == "missing":
-        action = "backfill_candidate" if queue != "provider-contract" else "provider_contract_needed"
+        action = (
+            "backfill_candidate"
+            if queue != "provider-contract"
+            else "provider_contract_needed"
+        )
         priority = "high"
     else:
         action = "repair_read_model"
@@ -219,7 +223,9 @@ def _actionability_for_surface(
     )
 
 
-def _actionability_for_symbol(surfaces: dict[str, CoverageState]) -> CoverageActionability:
+def _actionability_for_symbol(
+    surfaces: dict[str, CoverageState],
+) -> CoverageActionability:
     actionable_states = {
         name: state
         for name, state in surfaces.items()
@@ -252,7 +258,10 @@ def _actionability_for_symbol(surfaces: dict[str, CoverageState]) -> CoverageAct
             priority="high",
             action="backfill_candidate",
             queue="invest-data-read-models",
-            approvalGates=["production_db_write_approval", "scheduler_activation_approval"],
+            approvalGates=[
+                "production_db_write_approval",
+                "scheduler_activation_approval",
+            ],
             reason="One or more symbol diagnostics are missing; this is a candidate only, not an execution trigger.",
         )
     return CoverageActionability(
@@ -1207,9 +1216,7 @@ def _unsupported_symbol_row(symbol: str, market: str) -> InvestCoverageSymbol:
         "investor_flow": "unsupported",
         "naver_investor_flow": "unsupported",
     }
-    latest_dates: dict[str, dt.date | None] = {
-        surface: None for surface in surfaces
-    }
+    latest_dates: dict[str, dt.date | None] = dict.fromkeys(surfaces)
     display_market = market if market in {"crypto", "unknown"} else market
     return InvestCoverageSymbol(
         symbol=symbol,

--- a/app/services/invest_coverage_service.py
+++ b/app/services/invest_coverage_service.py
@@ -21,6 +21,8 @@ from app.models.pending_order import PendingOrder
 from app.models.research_reports import ResearchReport, ResearchReportIngestionRun
 from app.models.us_symbol_universe import USSymbolUniverse
 from app.schemas.invest_coverage import (
+    CoverageActionability,
+    CoverageApprovalGate,
     CoverageCandidateKind,
     CoverageCandidateReadiness,
     CoverageMarket,
@@ -71,6 +73,13 @@ async def build_invest_coverage(
     surfaces.extend(await _pending_order_surfaces(db, market_norm, now))
     surfaces.extend(await _orderbook_nxt_surfaces(db, market_norm))
     surfaces.extend(_provider_unwired_surfaces(market_norm))
+    for surface in surfaces:
+        surface.actionability = _actionability_for_surface(
+            surface=surface.surface,
+            state=surface.state,
+            market=surface.market,
+            source_of_truth=surface.sourceOfTruth,
+        )
 
     symbol_rows = await _symbol_rows(db, market_norm, symbol_list, trading_day)
     gaps = [
@@ -123,6 +132,136 @@ def _state_from_counts(
     if stale > 0:
         return "stale"
     return "fresh"
+
+
+_SURFACE_QUEUE: dict[str, str] = {
+    "symbol_universe": "invest-data-read-models",
+    "screener_snapshots": "invest-screener-snapshots",
+    "news_feed": "news-ingestor",
+    "calendar_events": "market-events-ingestion",
+    "research_reports": "research-report-ingestion",
+    "investor_flow": "investor-flow-ingestion",
+    "holdings": "account-panel-read-model",
+    "pending_orders": "order-reconciliation-read-model",
+    "orderbook_nxt_capability": "kr-symbol-universe",
+    "quotes": "provider-contract",
+    "ohlcv": "provider-contract",
+    "valuation_fundamentals": "provider-contract",
+}
+
+
+_SCHEDULER_QUEUES = {
+    "invest-screener-snapshots",
+    "news-ingestor",
+    "market-events-ingestion",
+    "research-report-ingestion",
+    "investor-flow-ingestion",
+}
+
+
+def _actionability_for_surface(
+    *,
+    surface: str,
+    state: CoverageState,
+    market: str | None,
+    source_of_truth: str,
+) -> CoverageActionability:
+    """Return advisory remediation metadata without executing remediation."""
+
+    queue = _SURFACE_QUEUE.get(surface, "invest-data-read-models")
+    market_label = market or "all"
+    if state == "fresh":
+        return CoverageActionability(
+            priority="none",
+            action="monitor",
+            queue="none",
+            reason=f"{surface} coverage for {market_label} is fresh.",
+        )
+    if state == "unsupported":
+        return CoverageActionability(
+            priority="none",
+            action="unsupported_no_action",
+            queue="none",
+            reason=f"{surface} is intentionally unsupported for {market_label} in the current /invest contract.",
+        )
+    if state == "provider_unwired":
+        return CoverageActionability(
+            priority="blocked",
+            action="provider_contract_needed",
+            queue="provider-contract",
+            approvalGates=["code_review"],
+            reason=f"{surface} has no durable read-model/provider contract wired yet; sourceOfTruth={source_of_truth}.",
+        )
+    if state == "error":
+        return CoverageActionability(
+            priority="high",
+            action="investigate",
+            queue=queue,
+            approvalGates=["code_review"],
+            reason=f"{surface} coverage needs investigation before remediation.",
+        )
+
+    gates: list[CoverageApprovalGate] = ["production_db_write_approval"]
+    if queue in _SCHEDULER_QUEUES:
+        gates.append("scheduler_activation_approval")
+    if state == "missing":
+        action = "backfill_candidate" if queue != "provider-contract" else "provider_contract_needed"
+        priority = "high"
+    else:
+        action = "repair_read_model"
+        priority = "medium"
+    return CoverageActionability(
+        priority=priority,
+        action=action,
+        queue=queue,
+        approvalGates=gates,
+        reason=f"{surface} is {state} for {market_label}; remediation is advisory and requires approval before writes or scheduler changes.",
+    )
+
+
+def _actionability_for_symbol(surfaces: dict[str, CoverageState]) -> CoverageActionability:
+    actionable_states = {
+        name: state
+        for name, state in surfaces.items()
+        if state not in {"fresh", "unsupported"}
+    }
+    if not actionable_states:
+        if surfaces and all(state == "unsupported" for state in surfaces.values()):
+            return CoverageActionability(
+                priority="none",
+                action="unsupported_no_action",
+                queue="none",
+                reason="No symbol-level remediation is available for unsupported surfaces.",
+            )
+        return CoverageActionability(
+            priority="none",
+            action="monitor",
+            queue="none",
+            reason="Symbol-level diagnostics are fresh or intentionally unsupported.",
+        )
+    if "provider_unwired" in actionable_states.values():
+        return CoverageActionability(
+            priority="blocked",
+            action="provider_contract_needed",
+            queue="provider-contract",
+            approvalGates=["code_review"],
+            reason="One or more symbol diagnostics need a provider/read-model contract before remediation.",
+        )
+    if "missing" in actionable_states.values():
+        return CoverageActionability(
+            priority="high",
+            action="backfill_candidate",
+            queue="invest-data-read-models",
+            approvalGates=["production_db_write_approval", "scheduler_activation_approval"],
+            reason="One or more symbol diagnostics are missing; this is a candidate only, not an execution trigger.",
+        )
+    return CoverageActionability(
+        priority="medium",
+        action="repair_read_model",
+        queue="invest-data-read-models",
+        approvalGates=["production_db_write_approval"],
+        reason="One or more symbol diagnostics are stale/partial; remediation needs separate approval.",
+    )
 
 
 async def _naver_finance_investor_flow_candidate(
@@ -864,9 +1003,21 @@ async def _symbol_rows(
     symbols: list[str],
     trading_day: dt.date,
 ) -> list[InvestCoverageSymbol]:
-    if not symbols or market not in {"kr", "us"}:
+    if not symbols:
         return []
+    if market == "all":
+        return await _symbol_rows_all_markets(db, symbols, trading_day)
+    if market not in {"kr", "us"}:
+        return [_unsupported_symbol_row(symbol, market) for symbol in symbols]
+    return await _symbol_rows_for_market(db, market, symbols, trading_day)
 
+
+async def _symbol_rows_for_market(
+    db: AsyncSession,
+    market: str,
+    symbols: list[str],
+    trading_day: dt.date,
+) -> list[InvestCoverageSymbol]:
     screener_rows = (
         await db.execute(
             sa.select(
@@ -972,9 +1123,104 @@ async def _symbol_rows(
                     for name, state in surfaces.items()
                     if state in {"missing", "stale", "unsupported"}
                 ],
+                actionability=_actionability_for_symbol(surfaces),
             )
         )
     return out
+
+
+async def _symbol_rows_all_markets(
+    db: AsyncSession,
+    symbols: list[str],
+    trading_day: dt.date,
+) -> list[InvestCoverageSymbol]:
+    market_by_symbol = await _resolve_symbol_markets(db, symbols)
+    partitioned: dict[str, list[str]] = {"kr": [], "us": []}
+    unsupported: dict[str, InvestCoverageSymbol] = {}
+    for symbol in symbols:
+        resolved_market = market_by_symbol.get(symbol)
+        if resolved_market in partitioned:
+            partitioned[resolved_market].append(symbol)
+        else:
+            unsupported[symbol] = _unsupported_symbol_row(
+                symbol, resolved_market or "unknown"
+            )
+
+    rows_by_symbol: dict[str, InvestCoverageSymbol] = {}
+    for resolved_market, market_symbols in partitioned.items():
+        if not market_symbols:
+            continue
+        for row in await _symbol_rows_for_market(
+            db, resolved_market, market_symbols, trading_day
+        ):
+            rows_by_symbol[row.symbol] = row
+    rows_by_symbol.update(unsupported)
+    return [rows_by_symbol[symbol] for symbol in symbols if symbol in rows_by_symbol]
+
+
+async def _resolve_symbol_markets(
+    db: AsyncSession, symbols: list[str]
+) -> dict[str, str]:
+    kr_symbols = {
+        symbol
+        for (symbol,) in (
+            await db.execute(
+                sa.select(KRSymbolUniverse.symbol).where(
+                    KRSymbolUniverse.symbol.in_(symbols),
+                    KRSymbolUniverse.is_active.is_(True),
+                )
+            )
+        ).all()
+    }
+    us_symbols = {
+        symbol
+        for (symbol,) in (
+            await db.execute(
+                sa.select(USSymbolUniverse.symbol).where(
+                    USSymbolUniverse.symbol.in_(symbols),
+                    USSymbolUniverse.is_active.is_(True),
+                )
+            )
+        ).all()
+    }
+    resolved: dict[str, str] = {}
+    for symbol in symbols:
+        if symbol in kr_symbols:
+            resolved[symbol] = "kr"
+        elif symbol in us_symbols:
+            resolved[symbol] = "us"
+        elif symbol.isdigit() and len(symbol) == 6:
+            resolved[symbol] = "kr"
+        elif symbol.isalpha() and symbol.upper() == symbol:
+            resolved[symbol] = "us"
+        elif symbol.startswith("KRW-"):
+            resolved[symbol] = "crypto"
+        else:
+            resolved[symbol] = "unknown"
+    return resolved
+
+
+def _unsupported_symbol_row(symbol: str, market: str) -> InvestCoverageSymbol:
+    surfaces: dict[str, CoverageState] = {
+        "screener_snapshots": "unsupported",
+        "news_feed": "unsupported",
+        "investor_flow": "unsupported",
+        "naver_investor_flow": "unsupported",
+    }
+    latest_dates: dict[str, dt.date | None] = {
+        surface: None for surface in surfaces
+    }
+    display_market = market if market in {"crypto", "unknown"} else market
+    return InvestCoverageSymbol(
+        symbol=symbol,
+        market=display_market,
+        surfaces=surfaces,
+        latestDates=latest_dates,
+        warnings=[
+            f"symbol-level diagnostics are not implemented for {display_market} symbols"
+        ],
+        actionability=_actionability_for_symbol(surfaces),
+    )
 
 
 def _date_state(latest: dt.date | None, trading_day: dt.date) -> CoverageState:

--- a/docs/invest-coverage-dashboard.md
+++ b/docs/invest-coverage-dashboard.md
@@ -1,6 +1,6 @@
-# ROB-192 /invest Toss-parity coverage
+# ROB-203 /invest coverage actionability
 
-This page documents the read-only coverage dashboard/API added for `/invest`.
+This page documents the read-only coverage dashboard/API for `/invest`.
 
 Endpoint: `GET /invest/api/coverage`
 
@@ -12,7 +12,8 @@ Query parameters:
 Contract:
 - Source of truth is local `auto_trader` DB/read-model state.
 - Toss is only a parity/reference benchmark; the endpoint does not read from Toss.
-- The endpoint is read-only: it does not submit/cancel/modify orders, call broker clients, start collectors, run backfills, or generate buy/sell recommendations.
+- Naver is only a candidate/reference signal where already represented by owned read models or explicitly marked as request-time/unwired readiness.
+- The endpoint is read-only: it does not submit/cancel/modify orders, call broker clients, start collectors, run backfills, activate schedulers, or generate buy/sell recommendations.
 
 Coverage states:
 - `fresh`: current read-model rows are available.
@@ -20,7 +21,7 @@ Coverage states:
 - `partial`: some current rows are present, but expected scope is incomplete or an ingestion partition is degraded.
 - `missing`: no local rows are available for the surface.
 - `unsupported`: the surface is intentionally unsupported for the selected market.
-- `provider_unwired`: a Toss-parity data surface exists conceptually, but no durable local `/invest` read model is wired yet.
+- `provider_unwired`: a Toss/Naver-parity data surface exists conceptually, but no durable local `/invest` read model is wired yet.
 - `error`: local ingestion metadata indicates a failed/degraded state with no fresh rows.
 
 Current surfaces:
@@ -35,11 +36,83 @@ Current surfaces:
 - `orderbook_nxt_capability`: KR NXT eligibility from `kr_symbol_universe.nxt_eligible`; US is unsupported and crypto orderbook remains provider-backed/unwired.
 - `quotes`, `ohlcv`, `valuation_fundamentals`: explicitly `provider_unwired` until durable read models exist.
 
-Frontend:
+## Actionability metadata
+
+Every surface and symbol diagnostic includes an `actionability` object. This object is advisory metadata for planning work; it is not an execution command.
+
+Fields:
+- `priority`: `none`, `low`, `medium`, `high`, or `blocked`.
+- `action`: `none`, `monitor`, `investigate`, `repair_read_model`, `backfill_candidate`, `scheduler_candidate`, `provider_contract_needed`, or `unsupported_no_action`.
+- `queue`: suggested work queue, for example `invest-screener-snapshots`, `news-ingestor`, `market-events-ingestion`, `research-report-ingestion`, `investor-flow-ingestion`, or `provider-contract`.
+- `approvalGates`: required approvals before any future remediation is executed.
+- `reason`: short human-readable explanation.
+- `safeByDefault`: always indicates this dashboard path is safe-by-default/read-only.
+
+The dashboard must not render buttons or copy implying “run backfill now”, “activate scheduler”, or “place order”. Use it to decide what work should be planned next.
+
+## Coverage state to work queue mapping
+
+| State | Meaning | Default action | Approval gate |
+| --- | --- | --- | --- |
+| `fresh` | Current local read-model rows exist | monitor/no action | none |
+| `stale` | Only old local rows exist | investigate or repair read model | production DB write approval before any backfill |
+| `partial` | Some expected rows exist | repair read model/backfill candidate | production DB write approval before any backfill |
+| `missing` | No local rows exist | investigate, backfill candidate, or provider contract | production DB write approval and scheduler activation approval when remediation writes or schedules jobs |
+| `unsupported` | Intentionally out of scope | unsupported/no action | none |
+| `provider_unwired` | Concept exists but durable read model/provider contract is absent | provider contract/code work | code review; later DB/scheduler approval if added |
+| `error` | Ingestion metadata failed/degraded | investigate | depends on remediation |
+
+Representative queues:
+- `symbol_universe` -> `invest-data-read-models`
+- `screener_snapshots` -> `invest-screener-snapshots`
+- `news_feed` -> `news-ingestor`
+- `calendar_events` -> `market-events-ingestion`
+- `research_reports` -> `research-report-ingestion`
+- `investor_flow` -> `investor-flow-ingestion`
+- `holdings` -> `account-panel-read-model`
+- `pending_orders` -> `order-reconciliation-read-model`
+- `quotes`, `ohlcv`, `valuation_fundamentals` -> `provider-contract`
+
+## All-market symbol diagnostics
+
+`GET /invest/api/coverage?market=all&symbols=005930,AAPL,MSFT` partitions requested symbols across KR and US diagnostics while preserving request order.
+
+Resolution rules:
+- Prefer `kr_symbol_universe.symbol` and `us_symbol_universe.symbol` matches.
+- Fallback to six-digit numeric symbols as KR.
+- Fallback to uppercase alphabetic tickers such as `AAPL`/`MSFT` as US.
+- Crypto-style symbols such as `KRW-BTC` are returned as unsupported symbol rows until a durable crypto symbol diagnostic contract exists.
+
+Expected semantics:
+- `005930` returns a KR row and may include `naver_investor_flow` as a candidate/reference diagnostic.
+- `AAPL` and `MSFT` return US rows.
+- US rows mark `investor_flow` and `naver_investor_flow` as `unsupported`.
+- Each row includes `actionability`; missing/stale diagnostics remain candidates only and do not execute remediation.
+
+## Naver/Toss semantics
+
+- `sourceOfTruth` must remain owned local DB/read-models such as KIS/Upbit/news-ingestor-derived tables.
+- Toss remains a UI/parity/reference benchmark only.
+- Naver remains candidate/reference/readiness metadata only.
+- Naver discussion data is aggregate-signal-only and must not clone/display public community text.
+- Neither Toss nor Naver should become `sourceOfTruth` in this contract.
+
+## Frontend
+
 - Route: `/invest/coverage`
 - Nav label: `커버리지`
-- The UI groups counts by state, lists surface-level gaps, and optionally shows symbol-level coverage for screener/news/investor-flow.
+- The UI groups counts by state, lists surface-level gaps, shows Naver/Toss candidate readiness chips, renders actionability priority/action/queue/approval gates, and optionally shows symbol-level coverage for screener/news/investor-flow.
+
+## Approval gates
+
+Any production remediation discovered from coverage output requires a separate approval packet and task. This issue does not approve:
+- production DB writes or backfills;
+- scheduler/TaskIQ/Prefect activation or unpause;
+- broker/KIS/Upbit/Alpaca calls;
+- order submit/cancel/modify;
+- watch-alert or order-intent mutations;
+- live scraping in request paths.
 
 Operational notes:
 - Freshness thresholds are intentionally conservative and read-only diagnostics only: news 24h, calendar/screener/investor-flow 36h, research metadata 7d, pending orders 30m last-seen.
-- This dashboard should be used to identify data gaps before implementing Toss-parity product features. It must not become a place for trading recommendation logic.
+- This dashboard should be used to identify data gaps before implementing Toss/Naver-parity product features. It must not become a place for trading recommendation logic.

--- a/frontend/invest/src/__tests__/DesktopCoveragePage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopCoveragePage.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, expect, test, vi } from "vitest";
+
+import * as coverageApi from "../api/coverage";
+import { CoverageRoute } from "../pages/desktop/DesktopCoveragePage";
+import type { InvestCoverageResponse } from "../types/coverage";
+
+const BASE_ACTIONABILITY = {
+  priority: "none" as const,
+  action: "monitor" as const,
+  queue: "none",
+  approvalGates: [],
+  reason: "fresh",
+  safeByDefault: true,
+};
+
+const COVERAGE_PAYLOAD: InvestCoverageResponse = {
+  market: "all",
+  asOf: "2026-05-11T08:00:00Z",
+  tradingDate: "2026-05-11",
+  states: ["fresh", "provider_unwired", "unsupported"],
+  surfaces: [
+    {
+      surface: "news_feed",
+      label: "News feed",
+      market: "all",
+      state: "fresh",
+      sourceOfTruth: "news_ingestor",
+      references: ["toss", "naver"],
+      latestAt: "2026-05-11T08:00:00Z",
+      staleAfterHours: 24,
+      counts: { fresh: 3, stale: 0, missing: 0, partial: 0, total: 3 },
+      warnings: [],
+      notes: [],
+      sourceCandidates: [
+        {
+          name: "naver_finance",
+          surface: "news_feed",
+          kind: "candidate",
+          readiness: "request_time_only",
+          latestAt: null,
+          counts: null,
+          warnings: [],
+          notes: ["reference only"],
+        },
+      ],
+      actionability: BASE_ACTIONABILITY,
+    },
+    {
+      surface: "quotes",
+      label: "Quotes",
+      market: "all",
+      state: "provider_unwired",
+      sourceOfTruth: "provider_contract",
+      references: ["toss", "naver"],
+      latestAt: null,
+      staleAfterHours: null,
+      counts: { fresh: 0, stale: 0, missing: 1, partial: 0, total: 1 },
+      warnings: ["durable read model missing"],
+      notes: [],
+      sourceCandidates: [],
+      actionability: {
+        priority: "blocked",
+        action: "provider_contract_needed",
+        queue: "provider-contract",
+        approvalGates: ["code_review"],
+        reason: "contract needed",
+        safeByDefault: true,
+      },
+    },
+  ],
+  symbols: [
+    {
+      symbol: "005930",
+      market: "kr",
+      surfaces: { screener_snapshots: "fresh", naver_investor_flow: "fresh" },
+      latestDates: { screener_snapshots: "2026-05-11", naver_investor_flow: "2026-05-11" },
+      warnings: [],
+      actionability: BASE_ACTIONABILITY,
+    },
+    {
+      symbol: "AAPL",
+      market: "us",
+      surfaces: { screener_snapshots: "fresh", investor_flow: "unsupported" },
+      latestDates: { screener_snapshots: "2026-05-11", investor_flow: null },
+      warnings: ["investor_flow"],
+      actionability: BASE_ACTIONABILITY,
+    },
+    {
+      symbol: "MSFT",
+      market: "us",
+      surfaces: { screener_snapshots: "missing", naver_investor_flow: "unsupported" },
+      latestDates: { screener_snapshots: null, naver_investor_flow: null },
+      warnings: ["screener_snapshots"],
+      actionability: {
+        priority: "high",
+        action: "backfill_candidate",
+        queue: "invest-data-read-models",
+        approvalGates: ["production_db_write_approval", "scheduler_activation_approval"],
+        reason: "candidate only",
+        safeByDefault: true,
+      },
+    },
+  ],
+  gaps: [],
+  notes: ["read-only coverage dashboard"],
+};
+
+function wrap(ui: React.ReactElement) {
+  return <MemoryRouter basename="/invest" initialEntries={["/invest/coverage"]}>{ui}</MemoryRouter>;
+}
+
+beforeEach(() => {
+  vi.spyOn(coverageApi, "fetchInvestCoverage").mockResolvedValue(COVERAGE_PAYLOAD);
+});
+
+test("renders coverage actionability, candidate readiness, and all-market symbols", async () => {
+  render(wrap(<CoverageRoute />));
+
+  await waitFor(() => expect(screen.getByRole("heading", { name: "데이터 커버리지" })).toBeInTheDocument());
+  await waitFor(() => expect(screen.getByText(/naver_finance/)).toBeInTheDocument());
+
+  expect(screen.getByText(/request-time/)).toBeInTheDocument();
+  expect(screen.getByText(/provider-contract/)).toBeInTheDocument();
+  expect(screen.getByText(/code_review/)).toBeInTheDocument();
+  expect(screen.getByText("005930")).toBeInTheDocument();
+  expect(screen.getByText("AAPL")).toBeInTheDocument();
+  expect(screen.getByText("MSFT")).toBeInTheDocument();
+  expect(screen.getByText(/production_db_write_approval/)).toBeInTheDocument();
+  expect(screen.getByText(/advisory metadata/)).toBeInTheDocument();
+});

--- a/frontend/invest/src/pages/desktop/DesktopCoveragePage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCoveragePage.tsx
@@ -3,6 +3,7 @@ import { fetchInvestCoverage } from "../../api/coverage";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { Card } from "../../ds";
 import type {
+  CoverageActionability,
   CoverageCandidateReadiness,
   CoverageState,
   InvestCoverageResponse,
@@ -46,6 +47,60 @@ const READINESS_COLOR: Record<CoverageCandidateReadiness, string> = {
   aggregate_only_blocked: "#9333ea",
   not_wired: "#64748b",
 };
+
+const ACTION_PRIORITY_LABEL: Record<CoverageActionability["priority"], string> = {
+  none: "관찰",
+  low: "낮음",
+  medium: "중간",
+  high: "높음",
+  blocked: "차단",
+};
+
+const ACTION_PRIORITY_COLOR: Record<CoverageActionability["priority"], string> = {
+  none: "#64748b",
+  low: "#0ea5e9",
+  medium: "#ca8a04",
+  high: "#dc2626",
+  blocked: "#7c3aed",
+};
+
+const ACTION_LABEL: Record<CoverageActionability["action"], string> = {
+  none: "조치 없음",
+  monitor: "모니터링",
+  investigate: "조사 필요",
+  repair_read_model: "read-model 보수 후보",
+  backfill_candidate: "백필 후보",
+  scheduler_candidate: "스케줄 후보",
+  provider_contract_needed: "provider 계약 필요",
+  unsupported_no_action: "미지원 · 조치 없음",
+};
+
+function ActionabilityBadge({ actionability }: { actionability: CoverageActionability }) {
+  const gates = actionability.approvalGates.filter((gate) => gate !== "none");
+  return (
+    <div style={{ display: "grid", gap: 4, minWidth: 180 }}>
+      <span
+        title={actionability.reason ?? undefined}
+        style={{
+          display: "inline-flex",
+          width: "fit-content",
+          borderRadius: 999,
+          padding: "3px 8px",
+          fontSize: 12,
+          fontWeight: 800,
+          color: "white",
+          background: ACTION_PRIORITY_COLOR[actionability.priority],
+        }}
+      >
+        {ACTION_PRIORITY_LABEL[actionability.priority]} · {ACTION_LABEL[actionability.action]}
+      </span>
+      <span style={{ color: "var(--fg-3)", fontSize: 12 }}>
+        queue {actionability.queue ?? "none"}
+        {gates.length > 0 ? ` · gate ${gates.join(", ")}` : " · no gate"}
+      </span>
+    </div>
+  );
+}
 
 function StatePill({ state }: { state: CoverageState }) {
   return (
@@ -116,6 +171,9 @@ function SurfaceRow({ surface }: { surface: InvestCoverageSurface }) {
         <span style={{ marginLeft: 8 }}>stale {counts.stale}</span>
         <span style={{ marginLeft: 8 }}>missing {counts.missing}</span>
         {counts.expected != null && <span style={{ marginLeft: 8 }}>expected {counts.expected}</span>}
+      </td>
+      <td style={{ padding: "12px 10px", borderBottom: "1px solid var(--divider)", fontSize: 12 }}>
+        <ActionabilityBadge actionability={surface.actionability} />
       </td>
       <td style={{ padding: "12px 10px", borderBottom: "1px solid var(--divider)", color: "var(--fg-3)", fontSize: 12 }}>
         {surface.warnings[0] ?? surface.notes[0] ?? "-"}
@@ -204,7 +262,7 @@ export function CoverageRoute() {
 
             <Card>
               <div style={{ overflowX: "auto" }}>
-                <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 980 }}>
+                <table style={{ width: "100%", borderCollapse: "collapse", minWidth: 1160 }}>
                   <thead>
                     <tr style={{ textAlign: "left", color: "var(--fg-3)", fontSize: 12 }}>
                       <th style={{ padding: "0 10px 8px" }}>Surface</th>
@@ -213,6 +271,7 @@ export function CoverageRoute() {
                       <th style={{ padding: "0 10px 8px" }}>Source of truth</th>
                       <th style={{ padding: "0 10px 8px" }}>Latest</th>
                       <th style={{ padding: "0 10px 8px" }}>Counts</th>
+                      <th style={{ padding: "0 10px 8px" }}>Actionability</th>
                       <th style={{ padding: "0 10px 8px" }}>Gap / note</th>
                     </tr>
                   </thead>
@@ -228,7 +287,9 @@ export function CoverageRoute() {
                   {data.symbols.map((symbol) => (
                     <div key={symbol.symbol} style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
                       <strong style={{ width: 84 }}>{symbol.symbol}</strong>
+                      <span style={{ color: "var(--fg-3)", fontSize: 12 }}>{symbol.market}</span>
                       {Object.entries(symbol.surfaces).map(([name, state]) => <span key={name} style={{ display: "inline-flex", gap: 6, alignItems: "center" }}><span style={{ color: "var(--fg-3)", fontSize: 12 }}>{name}</span><StatePill state={state} /></span>)}
+                      <ActionabilityBadge actionability={symbol.actionability} />
                     </div>
                   ))}
                 </div>
@@ -245,6 +306,7 @@ export function CoverageRoute() {
             <li>source-of-truth는 로컬 DB/read-model만</li>
             <li>Toss/Naver는 기준·후보 신호로만 표기</li>
             <li>매매 추천·주문·백필·요청 중 스크래핑 없음</li>
+            <li>Actionability는 승인 게이트를 표시하는 advisory metadata이며 실행 버튼이 아님</li>
           </ul>
         </Card>
       }

--- a/frontend/invest/src/types/coverage.ts
+++ b/frontend/invest/src/types/coverage.ts
@@ -16,6 +16,34 @@ export type CoverageCandidateReadiness =
 
 export type CoverageCandidateKind = "secondary_source" | "reference" | "candidate";
 
+export type CoverageActionPriority = "none" | "low" | "medium" | "high" | "blocked";
+
+export type CoverageActionKind =
+  | "none"
+  | "monitor"
+  | "investigate"
+  | "repair_read_model"
+  | "backfill_candidate"
+  | "scheduler_candidate"
+  | "provider_contract_needed"
+  | "unsupported_no_action";
+
+export type CoverageApprovalGate =
+  | "none"
+  | "code_review"
+  | "production_db_write_approval"
+  | "scheduler_activation_approval"
+  | "broker_order_approval";
+
+export interface CoverageActionability {
+  priority: CoverageActionPriority;
+  action: CoverageActionKind;
+  queue?: string | null;
+  approvalGates: CoverageApprovalGate[];
+  reason?: string | null;
+  safeByDefault: boolean;
+}
+
 export interface InvestCoverageCounts {
   expected?: number | null;
   fresh: number;
@@ -51,6 +79,7 @@ export interface InvestCoverageSurface {
   warnings: string[];
   notes: string[];
   sourceCandidates: CoverageSourceCandidate[];
+  actionability: CoverageActionability;
 }
 
 export interface InvestCoverageSymbol {
@@ -59,6 +88,7 @@ export interface InvestCoverageSymbol {
   surfaces: Record<string, CoverageState>;
   latestDates: Record<string, string | null>;
   warnings: string[];
+  actionability: CoverageActionability;
 }
 
 export interface InvestCoverageResponse {

--- a/tests/test_invest_coverage.py
+++ b/tests/test_invest_coverage.py
@@ -214,10 +214,17 @@ async def test_build_invest_coverage_reports_fresh_partial_and_provider_unwired(
     assert by_surface[("quotes", "kr")].state == "provider_unwired"
     assert by_surface[("ohlcv", "kr")].state == "provider_unwired"
     assert by_surface[("screener_snapshots", "kr")].actionability.priority == "medium"
-    assert by_surface[("screener_snapshots", "kr")].actionability.action == "repair_read_model"
-    assert by_surface[("orderbook_nxt_capability", "kr")].actionability.priority == "high"
+    assert (
+        by_surface[("screener_snapshots", "kr")].actionability.action
+        == "repair_read_model"
+    )
+    assert (
+        by_surface[("orderbook_nxt_capability", "kr")].actionability.priority == "high"
+    )
     assert by_surface[("quotes", "kr")].actionability.priority == "blocked"
-    assert by_surface[("quotes", "kr")].actionability.action == "provider_contract_needed"
+    assert (
+        by_surface[("quotes", "kr")].actionability.action == "provider_contract_needed"
+    )
     assert response.symbols[0].surfaces["screener_snapshots"] == "fresh"
     assert response.symbols[1].surfaces["screener_snapshots"] == "stale"
     assert response.symbols[1].actionability.priority == "high"
@@ -230,22 +237,34 @@ async def test_all_market_symbol_drilldown_resolves_per_symbol_market(db_session
     now_naive = now.replace(tzinfo=None)
 
     await db_session.execute(
-        sa.delete(NewsArticleRelatedSymbol).where(NewsArticleRelatedSymbol.id.in_([9720, 9721]))
+        sa.delete(NewsArticleRelatedSymbol).where(
+            NewsArticleRelatedSymbol.id.in_([9720, 9721])
+        )
     )
-    await db_session.execute(sa.delete(NewsArticle).where(NewsArticle.id.in_([9620, 9621])))
+    await db_session.execute(
+        sa.delete(NewsArticle).where(NewsArticle.id.in_([9620, 9621]))
+    )
     await db_session.execute(
         sa.delete(InvestScreenerSnapshot).where(
             InvestScreenerSnapshot.id.in_([9220, 9221])
         )
     )
-    await db_session.execute(sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol == "900230"))
-    await db_session.execute(sa.delete(USSymbolUniverse).where(USSymbolUniverse.symbol == "ROB203"))
+    await db_session.execute(
+        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol == "900230")
+    )
+    await db_session.execute(
+        sa.delete(USSymbolUniverse).where(USSymbolUniverse.symbol == "ROB203")
+    )
     await db_session.commit()
 
     db_session.add_all(
         [
-            KRSymbolUniverse(symbol="900230", name="ROB203 KR", exchange="KOSPI", is_active=True),
-            USSymbolUniverse(symbol="ROB203", exchange="NASDAQ", name_en="ROB203 US", is_active=True),
+            KRSymbolUniverse(
+                symbol="900230", name="ROB203 KR", exchange="KOSPI", is_active=True
+            ),
+            USSymbolUniverse(
+                symbol="ROB203", exchange="NASDAQ", name_en="ROB203 US", is_active=True
+            ),
             InvestScreenerSnapshot(
                 id=9220,
                 market="kr",

--- a/tests/test_invest_coverage.py
+++ b/tests/test_invest_coverage.py
@@ -15,9 +15,14 @@ from app.models.investor_flow_snapshot import InvestorFlowSnapshot
 from app.models.kr_symbol_universe import KRSymbolUniverse
 from app.models.market_events import MarketEventIngestionPartition
 from app.models.news import NewsArticle, NewsArticleRelatedSymbol, NewsIngestionRun
+from app.models.us_symbol_universe import USSymbolUniverse
 from app.routers.dependencies import get_authenticated_user
 from app.routers.invest_api import router as invest_api_router
-from app.schemas.invest_coverage import CoverageSourceCandidate, InvestCoverageSurface
+from app.schemas.invest_coverage import (
+    CoverageActionability,
+    CoverageSourceCandidate,
+    InvestCoverageSurface,
+)
 from app.services.invest_coverage_service import build_invest_coverage
 
 
@@ -42,6 +47,13 @@ def test_coverage_surface_accepts_source_candidates_and_references_list():
     assert surface.references == ["toss", "naver"]
     assert surface.sourceCandidates[0].readiness == "live"
     assert surface.sourceCandidates[0].kind == "secondary_source"
+    assert surface.actionability.safeByDefault is True
+    assert surface.actionability.approvalGates == []
+
+
+def test_coverage_actionability_rejects_unexpected_fields():
+    with pytest.raises(ValueError):
+        CoverageActionability(unexpected="run-now")  # type: ignore[call-arg]
 
 
 @pytest.fixture
@@ -201,8 +213,184 @@ async def test_build_invest_coverage_reports_fresh_partial_and_provider_unwired(
     assert by_surface[("orderbook_nxt_capability", "kr")].state == "missing"
     assert by_surface[("quotes", "kr")].state == "provider_unwired"
     assert by_surface[("ohlcv", "kr")].state == "provider_unwired"
+    assert by_surface[("screener_snapshots", "kr")].actionability.priority == "medium"
+    assert by_surface[("screener_snapshots", "kr")].actionability.action == "repair_read_model"
+    assert by_surface[("orderbook_nxt_capability", "kr")].actionability.priority == "high"
+    assert by_surface[("quotes", "kr")].actionability.priority == "blocked"
+    assert by_surface[("quotes", "kr")].actionability.action == "provider_contract_needed"
     assert response.symbols[0].surfaces["screener_snapshots"] == "fresh"
     assert response.symbols[1].surfaces["screener_snapshots"] == "stale"
+    assert response.symbols[1].actionability.priority == "high"
+
+
+@pytest.mark.asyncio
+async def test_all_market_symbol_drilldown_resolves_per_symbol_market(db_session):
+    trading_day = dt.date(2026, 5, 11)
+    now = dt.datetime(2026, 5, 11, 8, 0, tzinfo=dt.UTC)
+    now_naive = now.replace(tzinfo=None)
+
+    await db_session.execute(
+        sa.delete(NewsArticleRelatedSymbol).where(NewsArticleRelatedSymbol.id.in_([9720, 9721]))
+    )
+    await db_session.execute(sa.delete(NewsArticle).where(NewsArticle.id.in_([9620, 9621])))
+    await db_session.execute(
+        sa.delete(InvestScreenerSnapshot).where(
+            InvestScreenerSnapshot.id.in_([9220, 9221])
+        )
+    )
+    await db_session.execute(sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol == "900230"))
+    await db_session.execute(sa.delete(USSymbolUniverse).where(USSymbolUniverse.symbol == "ROB203"))
+    await db_session.commit()
+
+    db_session.add_all(
+        [
+            KRSymbolUniverse(symbol="900230", name="ROB203 KR", exchange="KOSPI", is_active=True),
+            USSymbolUniverse(symbol="ROB203", exchange="NASDAQ", name_en="ROB203 US", is_active=True),
+            InvestScreenerSnapshot(
+                id=9220,
+                market="kr",
+                symbol="900230",
+                snapshot_date=trading_day,
+                latest_close=Decimal("1000"),
+                closes_window=[1000],
+                source="kis",
+                computed_at=now,
+            ),
+            InvestScreenerSnapshot(
+                id=9221,
+                market="us",
+                symbol="ROB203",
+                snapshot_date=trading_day,
+                latest_close=Decimal("20"),
+                closes_window=[20],
+                source="yahoo",
+                computed_at=now,
+            ),
+            NewsArticle(
+                id=9620,
+                url="https://example.com/rob203-kr",
+                title="ROB203 KR news",
+                source="test",
+                feed_source="test",
+                market="kr",
+                keywords=[],
+                article_published_at=now_naive,
+                scraped_at=now_naive,
+                created_at=now_naive,
+            ),
+            NewsArticle(
+                id=9621,
+                url="https://example.com/rob203-us",
+                title="ROB203 US news",
+                source="test",
+                feed_source="test",
+                market="us",
+                keywords=[],
+                article_published_at=now_naive,
+                scraped_at=now_naive,
+                created_at=now_naive,
+            ),
+            NewsArticleRelatedSymbol(
+                id=9720,
+                article_id=9620,
+                market="kr",
+                symbol="900230",
+                source="test",
+                created_at=now_naive,
+            ),
+            NewsArticleRelatedSymbol(
+                id=9721,
+                article_id=9621,
+                market="us",
+                symbol="ROB203",
+                source="test",
+                created_at=now_naive,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    response = await build_invest_coverage(
+        db_session,
+        market="all",
+        symbols=["900230", "ROB203", "KRW-BTC"],
+        as_of=trading_day,
+    )
+
+    by_symbol = {row.symbol: row for row in response.symbols}
+    assert [row.symbol for row in response.symbols] == ["900230", "ROB203", "KRW-BTC"]
+    assert by_symbol["900230"].market == "kr"
+    assert by_symbol["ROB203"].market == "us"
+    assert by_symbol["KRW-BTC"].market == "crypto"
+    assert by_symbol["900230"].surfaces["screener_snapshots"] == "fresh"
+    assert by_symbol["ROB203"].surfaces["screener_snapshots"] == "fresh"
+    assert by_symbol["KRW-BTC"].actionability.action == "unsupported_no_action"
+
+
+@pytest.mark.asyncio
+async def test_coverage_endpoint_market_all_returns_partitioned_symbol_rows(
+    app: FastAPI, db_session
+):
+    trading_day = dt.date(2026, 5, 11)
+    now = dt.datetime(2026, 5, 11, 8, 0, tzinfo=dt.UTC)
+
+    await db_session.execute(
+        sa.delete(InvestorFlowSnapshot).where(InvestorFlowSnapshot.id == 9320)
+    )
+    await db_session.commit()
+    await db_session.merge(
+        KRSymbolUniverse(
+            symbol="005930", name="삼성전자", exchange="KOSPI", is_active=True
+        )
+    )
+    await db_session.merge(
+        USSymbolUniverse(
+            symbol="AAPL", exchange="NASDAQ", name_en="Apple Inc.", is_active=True
+        )
+    )
+    await db_session.merge(
+        USSymbolUniverse(
+            symbol="MSFT", exchange="NASDAQ", name_en="Microsoft", is_active=True
+        )
+    )
+    db_session.add(
+        InvestorFlowSnapshot(
+            id=9320,
+            market="kr",
+            symbol="005930",
+            snapshot_date=trading_day,
+            source="naver_finance",
+            foreign_net=100,
+            institution_net=50,
+            individual_net=-150,
+            collected_at=now,
+        )
+    )
+    await db_session.commit()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        r = await client.get(
+            "/invest/api/coverage?market=all&symbols=005930,AAPL,MSFT&asOf=2026-05-11"
+        )
+
+    assert r.status_code == 200
+    payload = r.json()
+    assert payload["market"] == "all"
+    by_symbol = {row["symbol"]: row for row in payload["symbols"]}
+    assert set(by_symbol) == {"005930", "AAPL", "MSFT"}
+    assert [row["symbol"] for row in payload["symbols"]] == ["005930", "AAPL", "MSFT"]
+    assert by_symbol["005930"]["market"] == "kr"
+    assert by_symbol["AAPL"]["market"] == "us"
+    assert by_symbol["MSFT"]["market"] == "us"
+    assert "naver_investor_flow" in by_symbol["005930"]["surfaces"]
+    assert by_symbol["AAPL"]["surfaces"]["investor_flow"] == "unsupported"
+    assert by_symbol["MSFT"]["surfaces"]["naver_investor_flow"] == "unsupported"
+    assert all("actionability" in row for row in payload["symbols"])
+    assert all(
+        surface["sourceOfTruth"] != "naver_finance" for surface in payload["surfaces"]
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds coverage actionability and all-market symbol drilldown diagnostics for `/invest/api/coverage`.
- Surfaces advisory queue/backfill/approval-gate metadata in the Invest desktop coverage UI.
- Documents read-only interpretation and operator-gated follow-up boundaries.

## Safety
- Read-only coverage/API/frontend/docs polish only.
- No broker/order/watch/order-intent side effects.
- No production DB writes, backfills, or scheduler activation.
- Production write/backfill/scheduler activation remains operator-approval gated.

## Verification
- `uv run pytest tests/test_invest_coverage.py -q` — 11 passed; 2 existing Pydantic V2 warnings in `app/auth/schemas.py`.
- `cd frontend/invest && npm test -- --run DesktopCoveragePage` — 1 passed.
- `cd frontend/invest && npm run typecheck` — passed.
- `cd frontend/invest && npm run build` — passed.

Linear: ROB-203
