### PR TITLE
feat(ROB-209): add venue-aware KIS KR orderbook

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -320,20 +320,31 @@ The error names variables only — never values.
 Parameters:
 - `symbol`: KR equity symbol/code or Upbit market code (required)
 - `market`: defaults to `"kr"`; supports KR aliases (`"kr"`, `"kospi"`, `"kosdaq"`, `"korea"`, `"kis"`, `"equity_kr"`) plus crypto aliases (`"crypto"`, `"upbit"`)
+- `venue`: optional, KR equity only; selects the KIS trading venue for the orderbook. Ignored for crypto. Defaults to `"krx"` (KRX regular session) for backward compatibility.
+
+Venue mapping (KR equity only):
+| `venue` input | Canonical venue | KIS code | Korean label |
+|---|---|---|---|
+| `null`, `""`, `"krx"`, `"regular"`, `"j"` | `krx` | `J` | `KRX` |
+| `"nxt"`, `"ntx"`, `"nx"`, `"afterhours"`, `"extended"` | `nxt` | `NX` | `NXT` |
+| `"unified"`, `"combined"`, `"integrated"`, `"all"`, `"un"`, `"통합"`, `"통합시장"` | `unified` | `UN` | `통합` |
 
 Behavior:
 - KR requests follow the existing KR quote normalization path, including zero-padding numeric codes such as `5930 -> 005930`
 - Crypto orderbook requests require explicit `market="crypto"` (or `"upbit"`) and a raw `KRW-*` symbol such as `KRW-BTC`; plain coins (`BTC`) and non-KRW crypto pairs (`USDT-BTC`) raise an argument error
-- Valid KR requests use KIS `inquire-asking-price-exp-ccn` and return 10-level asks/bids, total residual quantities, expected match metadata, and integer-valued `price`, `quantity`, `total_ask_qty`, `total_bid_qty`, and `spread`
+- Providing a non-blank `venue` with `market="crypto"` raises an argument error
+- Valid KR requests use KIS endpoint `inquire-asking-price-exp-ccn` (TR_ID `FHKST01010200`) and return 10-level asks/bids, total residual quantities, expected match metadata, and integer-valued `price`, `quantity`, `total_ask_qty`, `total_bid_qty`, and `spread`
 - Valid crypto requests use Upbit orderbook data and return the same shared snapshot fields, but `price`, `quantity`, `total_ask_qty`, `total_bid_qty`, and `spread` can be fractional numbers
 - `expected_qty` keeps the public `int | null` contract; when KIS leaves `output2.antc_cnqn` blank or omits it, the response serializes `expected_qty` as `null` instead of inventing a fallback quantity
 - During the NXT session (`16:00`-`20:00` KST), KIS may return `expected_price` while leaving `expected_qty` blank or absent; this is treated as a valid upstream state, not an MCP error
 - Successful responses always include MCP-only derived fields: `pressure`, `pressure_desc`, `spread`, `spread_pct`, `bid_walls`, and `ask_walls`
+- Successful KR responses include venue diagnostics: `venue`, `venue_label`, `kis_market_code`, `source_endpoint`, `source_tr_id`, `is_empty_book`, `requires_final_recheck`, and (when empty) `empty_reason`
 - Successful KR responses use `source: "kis"`, `instrument_type: "equity_kr"`, and return `bid_walls: []`, `ask_walls: []`
 - Successful crypto responses use `source: "upbit"`, `instrument_type: "crypto"`, and may return non-empty wall arrays
 - Invalid input raises; upstream failures for otherwise valid requests return an in-band error payload via the shared MCP error contract. When the underlying exception is a `DomainServiceError`, the payload may also include `error_type`
+- `venue` does not affect order routing or trading venue defaults; this is market-data only. WebSocket streaming for NXT/UN is out of scope for this REST read-only slice.
 
-Response format:
+Response format (KR equity):
 ```json
 {
   "symbol": "005930",
@@ -351,11 +362,28 @@ Response format:
   "expected_price": 70050,
   "expected_qty": null,
   "bid_walls": [],
-  "ask_walls": []
+  "ask_walls": [],
+  "venue": "nxt",
+  "venue_label": "NXT",
+  "kis_market_code": "NX",
+  "source_endpoint": "/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn",
+  "source_tr_id": "FHKST01010200",
+  "is_empty_book": false,
+  "requires_final_recheck": false
 }
 ```
 
 `expected_qty: null` means KIS did not provide `antc_cnqn`; it does not by itself indicate a tool failure.
+
+KR-only diagnostic fields:
+- `venue`: canonical venue name (`"krx"`, `"nxt"`, `"unified"`)
+- `venue_label`: Korean-facing label (`"KRX"`, `"NXT"`, `"통합"`)
+- `kis_market_code`: KIS `FID_COND_MRKT_DIV_CODE` sent to KIS (`"J"`, `"NX"`, `"UN"`)
+- `source_endpoint`: REST endpoint path used
+- `source_tr_id`: KIS TR_ID used
+- `is_empty_book`: `true` when the orderbook returned no asks and no bids
+- `requires_final_recheck`: `true` for empty KR books (caller should re-check before acting on empty depth)
+- `empty_reason`: stable short string (e.g. `"empty_kis_orderbook"`) when `is_empty_book` is `true`; absent when book is non-empty
 
 Derived fields:
 - `pressure` is derived from `bid_ask_ratio` using fixed inclusive boundaries:

--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -320,7 +320,7 @@ The error names variables only — never values.
 Parameters:
 - `symbol`: KR equity symbol/code or Upbit market code (required)
 - `market`: defaults to `"kr"`; supports KR aliases (`"kr"`, `"kospi"`, `"kosdaq"`, `"korea"`, `"kis"`, `"equity_kr"`) plus crypto aliases (`"crypto"`, `"upbit"`)
-- `venue`: optional, KR equity only; selects the KIS trading venue for the orderbook. Ignored for crypto. Defaults to `"krx"` (KRX regular session) for backward compatibility.
+- `venue`: optional, KR equity only; selects the KIS trading venue for the orderbook. Non-blank values are rejected for crypto. Defaults to `"krx"` (KRX regular session) for backward compatibility.
 
 Venue mapping (KR equity only):
 | `venue` input | Canonical venue | KIS code | Korean label |

--- a/app/mcp_server/tooling/market_data_quotes.py
+++ b/app/mcp_server/tooling/market_data_quotes.py
@@ -312,7 +312,7 @@ def _build_orderbook_payload(
     pressure = _classify_orderbook_pressure(snapshot.bid_ask_ratio)
     spread, spread_pct = _calculate_orderbook_spread(snapshot)
     bid_walls, ask_walls = _build_orderbook_walls(snapshot)
-    return {
+    payload: dict[str, Any] = {
         "symbol": snapshot.symbol,
         "instrument_type": snapshot.instrument_type,
         "source": snapshot.source,
@@ -340,6 +340,23 @@ def _build_orderbook_payload(
         "bid_walls": bid_walls,
         "ask_walls": ask_walls,
     }
+    if snapshot.venue is not None:
+        payload["venue"] = snapshot.venue
+    if snapshot.venue_label is not None:
+        payload["venue_label"] = snapshot.venue_label
+    if snapshot.kis_market_code is not None:
+        payload["kis_market_code"] = snapshot.kis_market_code
+    if snapshot.source_endpoint is not None:
+        payload["source_endpoint"] = snapshot.source_endpoint
+    if snapshot.source_tr_id is not None:
+        payload["source_tr_id"] = snapshot.source_tr_id
+    if snapshot.is_empty_book is not None:
+        payload["is_empty_book"] = snapshot.is_empty_book
+    if snapshot.requires_final_recheck is not None:
+        payload["requires_final_recheck"] = snapshot.requires_final_recheck
+    if snapshot.empty_reason is not None:
+        payload["empty_reason"] = snapshot.empty_reason
+    return payload
 
 
 # ---------------------------------------------------------------------------
@@ -904,6 +921,7 @@ async def _get_quote_impl(
 async def _get_orderbook_impl(
     symbol: str | int,
     market: str = "kr",
+    venue: str | None = None,
 ) -> dict[str, Any]:
     """Implementation for get_orderbook tool."""
     requested_market = str(market or "kr").strip() or "kr"
@@ -920,6 +938,8 @@ async def _get_orderbook_impl(
             raise ValueError("symbol is required")
         _, symbol = _resolve_market_type(symbol, "kr")
     elif market_type == "crypto":
+        if venue is not None and str(venue).strip():
+            raise ValueError("venue is only supported for KR equity orderbook")
         symbol = _validate_crypto_orderbook_symbol_input(symbol)
         source = "upbit"
         instrument_type = "crypto"
@@ -930,6 +950,7 @@ async def _get_orderbook_impl(
         snapshot = await market_data_service.get_orderbook(
             symbol,
             "crypto" if market_type == "crypto" else "kr",
+            venue=venue if market_type == "equity_kr" else None,
         )
         return _build_orderbook_payload(snapshot)
     except Exception as exc:
@@ -1051,11 +1072,16 @@ def _register_market_data_tools_impl(mcp: FastMCP) -> None:
         name="get_orderbook",
         description=(
             "Get 10-level orderbook data with total residual quantities and expected match metadata. "
-            "Supports KR equity and KRW crypto markets."
+            "Supports KR equity and KRW crypto markets. "
+            "For KR equity, use venue to select the trading venue: "
+            "'krx' (default, KRX regular session), 'nxt' (NXT after-hours), "
+            "'unified' or '통합' (통합시장). venue applies only to KR equity."
         ),
     )
-    async def get_orderbook(symbol: str | int, market: str = "kr") -> dict[str, Any]:
-        return await _get_orderbook_impl(symbol, market)
+    async def get_orderbook(
+        symbol: str | int, market: str = "kr", venue: str | None = None
+    ) -> dict[str, Any]:
+        return await _get_orderbook_impl(symbol, market, venue)
 
     @mcp.tool(
         name="get_ohlcv",

--- a/app/services/market_data/contracts.py
+++ b/app/services/market_data/contracts.py
@@ -51,6 +51,14 @@ class OrderbookSnapshot:
     bid_ask_ratio: float | None
     expected_price: int | None = None
     expected_qty: int | None = None
+    venue: str | None = None
+    venue_label: str | None = None
+    kis_market_code: str | None = None
+    source_endpoint: str | None = None
+    source_tr_id: str | None = None
+    is_empty_book: bool | None = None
+    requires_final_recheck: bool | None = None
+    empty_reason: str | None = None
 
 
 __all__ = ["Quote", "Candle", "OrderbookLevel", "OrderbookSnapshot"]

--- a/app/services/market_data/service.py
+++ b/app/services/market_data/service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
@@ -183,6 +184,47 @@ def _validate_crypto_orderbook_symbol(symbol: str) -> str:
 
 def _current_kst_datetime() -> dt.datetime:
     return now_kst()
+
+
+@dataclass(frozen=True)
+class KrOrderbookVenue:
+    venue: str
+    kis_market_code: str
+    venue_label: str
+
+
+_KR_VENUE_MAP: dict[str, KrOrderbookVenue] = {
+    "krx": KrOrderbookVenue("krx", "J", "KRX"),
+    "regular": KrOrderbookVenue("krx", "J", "KRX"),
+    "j": KrOrderbookVenue("krx", "J", "KRX"),
+    "nxt": KrOrderbookVenue("nxt", "NX", "NXT"),
+    "ntx": KrOrderbookVenue("nxt", "NX", "NXT"),
+    "nx": KrOrderbookVenue("nxt", "NX", "NXT"),
+    "afterhours": KrOrderbookVenue("nxt", "NX", "NXT"),
+    "extended": KrOrderbookVenue("nxt", "NX", "NXT"),
+    "unified": KrOrderbookVenue("unified", "UN", "통합"),
+    "combined": KrOrderbookVenue("unified", "UN", "통합"),
+    "integrated": KrOrderbookVenue("unified", "UN", "통합"),
+    "all": KrOrderbookVenue("unified", "UN", "통합"),
+    "un": KrOrderbookVenue("unified", "UN", "통합"),
+    "통합": KrOrderbookVenue("unified", "UN", "통합"),
+    "통합시장": KrOrderbookVenue("unified", "UN", "통합"),
+}
+
+_KR_DEFAULT_VENUE = KrOrderbookVenue("krx", "J", "KRX")
+
+_KR_ORDERBOOK_ENDPOINT = "/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn"
+_KR_ORDERBOOK_TR_ID = "FHKST01010200"
+
+
+def _normalize_kr_orderbook_venue(venue: str | None) -> KrOrderbookVenue:
+    if not venue or not venue.strip():
+        return _KR_DEFAULT_VENUE
+    normalized = venue.strip().lower()
+    result = _KR_VENUE_MAP.get(normalized)
+    if result is None:
+        raise ValueError(f"unsupported KR orderbook venue: {venue!r}")
+    return result
 
 
 def _get_orderbook_session_hint(now_kst: dt.datetime | None = None) -> str:
@@ -377,9 +419,13 @@ async def get_quote(symbol: str, market: str) -> Quote:
         raise _map_error(exc) from exc
 
 
-async def get_orderbook(symbol: str, market: str = "kr") -> OrderbookSnapshot:
+async def get_orderbook(
+    symbol: str, market: str = "kr", venue: str | None = None
+) -> OrderbookSnapshot:
     resolved_market = _normalize_market(market)
     if resolved_market == "crypto":
+        if venue is not None and venue.strip():
+            raise ValueError("venue is only supported for KR equity orderbook")
         resolved_symbol = _validate_crypto_orderbook_symbol(symbol)
         try:
             raw = await fetch_orderbook(resolved_symbol)
@@ -415,13 +461,15 @@ async def get_orderbook(symbol: str, market: str = "kr") -> OrderbookSnapshot:
 
     if resolved_market != "equity_kr":
         raise ValueError("get_orderbook only supports KR equity and KRW crypto markets")
+
+    venue_info = _normalize_kr_orderbook_venue(venue)
     resolved_symbol = _normalize_symbol(symbol, resolved_market)
 
     try:
         kis = KISClient()
         output1, output2 = await kis.inquire_orderbook_snapshot(
             code=resolved_symbol,
-            market="J",
+            market=venue_info.kis_market_code,
         )
         expected_price, expected_qty = _extract_expected_match_metadata(
             resolved_symbol,
@@ -429,12 +477,17 @@ async def get_orderbook(symbol: str, market: str = "kr") -> OrderbookSnapshot:
         )
         total_ask_qty = _to_int(output1.get("total_askp_rsqn"))
         total_bid_qty = _to_int(output1.get("total_bidp_rsqn"))
+        asks = _parse_orderbook_levels(output1, "ask")
+        bids = _parse_orderbook_levels(output1, "bid")
+        is_empty_book = not asks and not bids
+        requires_final_recheck = is_empty_book
+        empty_reason = "empty_kis_orderbook" if is_empty_book else None
         return OrderbookSnapshot(
             symbol=resolved_symbol,
             instrument_type="equity_kr",
             source="kis",
-            asks=_parse_orderbook_levels(output1, "ask"),
-            bids=_parse_orderbook_levels(output1, "bid"),
+            asks=asks,
+            bids=bids,
             total_ask_qty=total_ask_qty,
             total_bid_qty=total_bid_qty,
             bid_ask_ratio=(
@@ -442,6 +495,14 @@ async def get_orderbook(symbol: str, market: str = "kr") -> OrderbookSnapshot:
             ),
             expected_price=expected_price,
             expected_qty=expected_qty,
+            venue=venue_info.venue,
+            venue_label=venue_info.venue_label,
+            kis_market_code=venue_info.kis_market_code,
+            source_endpoint=_KR_ORDERBOOK_ENDPOINT,
+            source_tr_id=_KR_ORDERBOOK_TR_ID,
+            is_empty_book=is_empty_book,
+            requires_final_recheck=requires_final_recheck,
+            empty_reason=empty_reason,
         )
     except Exception as exc:
         raise _map_error(exc) from exc

--- a/app/services/market_data/service.py
+++ b/app/services/market_data/service.py
@@ -213,7 +213,9 @@ _KR_VENUE_MAP: dict[str, KrOrderbookVenue] = {
 
 _KR_DEFAULT_VENUE = KrOrderbookVenue("krx", "J", "KRX")
 
-_KR_ORDERBOOK_ENDPOINT = "/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn"
+_KR_ORDERBOOK_ENDPOINT = (
+    "/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn"
+)
 _KR_ORDERBOOK_TR_ID = "FHKST01010200"
 
 

--- a/tests/test_market_data_service.py
+++ b/tests/test_market_data_service.py
@@ -306,6 +306,14 @@ async def test_get_orderbook_parses_kr_snapshot(
         bid_ask_ratio=1.5,
         expected_price=70050,
         expected_qty=42,
+        venue="krx",
+        venue_label="KRX",
+        kis_market_code="J",
+        source_endpoint="/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn",
+        source_tr_id="FHKST01010200",
+        is_empty_book=False,
+        requires_final_recheck=False,
+        empty_reason=None,
     )
     assert type(snapshot.asks[0].price) is int
     assert type(snapshot.asks[0].quantity) is int
@@ -727,6 +735,163 @@ async def test_get_orderbook_rejects_unsupported_markets(market: str) -> None:
         match="get_orderbook only supports KR equity and KRW crypto markets",
     ):
         await market_data_service.get_orderbook("005930", market)
+
+
+# ---------------------------------------------------------------------------
+# Venue-aware KR orderbook tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_orderbook_kr_venue_nxt_passes_nx_to_kis(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DummyKIS:
+        async def inquire_orderbook_snapshot(self, code: str, market: str = "J"):
+            assert code == "005930"
+            assert market == "NX"
+            return (
+                {
+                    "askp1": "70200",
+                    "askp_rsqn1": "10",
+                    "bidp1": "69900",
+                    "bidp_rsqn1": "20",
+                    "total_askp_rsqn": "10",
+                    "total_bidp_rsqn": "20",
+                },
+                None,
+            )
+
+    monkeypatch.setattr(market_data_service, "KISClient", lambda: DummyKIS())
+
+    snapshot = await market_data_service.get_orderbook("005930", "kr", venue="nxt")
+
+    assert snapshot.venue == "nxt"
+    assert snapshot.kis_market_code == "NX"
+    assert snapshot.venue_label == "NXT"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("venue_input", ["unified", "통합", "통합시장", "UN", "un"])
+async def test_get_orderbook_kr_venue_unified_passes_un_to_kis(
+    monkeypatch: pytest.MonkeyPatch, venue_input: str
+) -> None:
+    class DummyKIS:
+        async def inquire_orderbook_snapshot(self, code: str, market: str = "J"):
+            assert market == "UN"
+            return (
+                {
+                    "askp1": "70200",
+                    "askp_rsqn1": "10",
+                    "bidp1": "69900",
+                    "bidp_rsqn1": "20",
+                    "total_askp_rsqn": "10",
+                    "total_bidp_rsqn": "20",
+                },
+                None,
+            )
+
+    monkeypatch.setattr(market_data_service, "KISClient", lambda: DummyKIS())
+
+    snapshot = await market_data_service.get_orderbook("005930", "kr", venue=venue_input)
+
+    assert snapshot.venue == "unified"
+    assert snapshot.kis_market_code == "UN"
+    assert snapshot.venue_label == "통합"
+
+
+@pytest.mark.asyncio
+async def test_get_orderbook_kr_default_still_uses_j(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DummyKIS:
+        async def inquire_orderbook_snapshot(self, code: str, market: str = "J"):
+            assert market == "J"
+            return (
+                {
+                    "askp1": "70200",
+                    "askp_rsqn1": "10",
+                    "bidp1": "69900",
+                    "bidp_rsqn1": "20",
+                    "total_askp_rsqn": "10",
+                    "total_bidp_rsqn": "20",
+                },
+                None,
+            )
+
+    monkeypatch.setattr(market_data_service, "KISClient", lambda: DummyKIS())
+
+    snapshot = await market_data_service.get_orderbook("005930")
+
+    assert snapshot.venue == "krx"
+    assert snapshot.kis_market_code == "J"
+    assert snapshot.venue_label == "KRX"
+
+
+@pytest.mark.asyncio
+async def test_get_orderbook_rejects_unknown_kr_venue() -> None:
+    with pytest.raises(ValueError, match="unsupported KR orderbook venue"):
+        await market_data_service.get_orderbook("005930", "kr", venue="invalid_venue")
+
+
+@pytest.mark.asyncio
+async def test_get_orderbook_crypto_rejects_nonblank_venue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(ValueError, match="venue is only supported for KR equity orderbook"):
+        await market_data_service.get_orderbook("KRW-BTC", "crypto", venue="nxt")
+
+
+@pytest.mark.asyncio
+async def test_get_orderbook_kr_populates_diagnostic_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DummyKIS:
+        async def inquire_orderbook_snapshot(self, code: str, market: str = "J"):
+            return (
+                {
+                    "askp1": "70200",
+                    "askp_rsqn1": "10",
+                    "bidp1": "69900",
+                    "bidp_rsqn1": "20",
+                    "total_askp_rsqn": "10",
+                    "total_bidp_rsqn": "20",
+                },
+                None,
+            )
+
+    monkeypatch.setattr(market_data_service, "KISClient", lambda: DummyKIS())
+
+    snapshot = await market_data_service.get_orderbook("005930", "kr")
+
+    assert snapshot.source_endpoint == "/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn"
+    assert snapshot.source_tr_id == "FHKST01010200"
+    assert snapshot.is_empty_book is False
+    assert snapshot.requires_final_recheck is False
+    assert snapshot.empty_reason is None
+
+
+@pytest.mark.asyncio
+async def test_get_orderbook_kr_empty_book_sets_diagnostics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class DummyKIS:
+        async def inquire_orderbook_snapshot(self, code: str, market: str = "J"):
+            return (
+                {
+                    "total_askp_rsqn": "0",
+                    "total_bidp_rsqn": "0",
+                },
+                None,
+            )
+
+    monkeypatch.setattr(market_data_service, "KISClient", lambda: DummyKIS())
+
+    snapshot = await market_data_service.get_orderbook("005930", "kr", venue="nxt")
+
+    assert snapshot.is_empty_book is True
+    assert snapshot.requires_final_recheck is True
+    assert snapshot.empty_reason == "empty_kis_orderbook"
 
 
 @pytest.mark.asyncio

--- a/tests/test_market_data_service.py
+++ b/tests/test_market_data_service.py
@@ -793,7 +793,9 @@ async def test_get_orderbook_kr_venue_unified_passes_un_to_kis(
 
     monkeypatch.setattr(market_data_service, "KISClient", lambda: DummyKIS())
 
-    snapshot = await market_data_service.get_orderbook("005930", "kr", venue=venue_input)
+    snapshot = await market_data_service.get_orderbook(
+        "005930", "kr", venue=venue_input
+    )
 
     assert snapshot.venue == "unified"
     assert snapshot.kis_market_code == "UN"
@@ -838,7 +840,9 @@ async def test_get_orderbook_rejects_unknown_kr_venue() -> None:
 async def test_get_orderbook_crypto_rejects_nonblank_venue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    with pytest.raises(ValueError, match="venue is only supported for KR equity orderbook"):
+    with pytest.raises(
+        ValueError, match="venue is only supported for KR equity orderbook"
+    ):
         await market_data_service.get_orderbook("KRW-BTC", "crypto", venue="nxt")
 
 
@@ -864,7 +868,10 @@ async def test_get_orderbook_kr_populates_diagnostic_fields(
 
     snapshot = await market_data_service.get_orderbook("005930", "kr")
 
-    assert snapshot.source_endpoint == "/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn"
+    assert (
+        snapshot.source_endpoint
+        == "/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn"
+    )
     assert snapshot.source_tr_id == "FHKST01010200"
     assert snapshot.is_empty_book is False
     assert snapshot.requires_final_recheck is False

--- a/tests/test_mcp_orderbook_tools.py
+++ b/tests/test_mcp_orderbook_tools.py
@@ -103,7 +103,7 @@ async def test_get_orderbook_returns_crypto_payload(
 
     result = await tools["get_orderbook"]("KRW-BTC", market="crypto")
 
-    get_orderbook_mock.assert_awaited_once_with("KRW-BTC", "crypto")
+    get_orderbook_mock.assert_awaited_once_with("KRW-BTC", "crypto", venue=None)
     assert result == {
         "symbol": "KRW-BTC",
         "instrument_type": "crypto",
@@ -403,3 +403,173 @@ async def test_get_orderbook_raises_on_invalid_input() -> None:
         ValueError, match=r"crypto orderbook only supports KRW-\* symbols"
     ):
         await tools["get_orderbook"]("USDT-BTC", market="crypto")
+
+
+# ---------------------------------------------------------------------------
+# Venue-aware MCP orderbook tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_orderbook_kr_venue_nxt_threads_to_service(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.mcp_server.tooling import market_data_quotes
+
+    get_orderbook_mock = AsyncMock(
+        return_value=_make_snapshot(
+            venue="nxt",
+            venue_label="NXT",
+            kis_market_code="NX",
+            source_endpoint="/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn",
+            source_tr_id="FHKST01010200",
+            is_empty_book=False,
+            requires_final_recheck=False,
+            empty_reason=None,
+        )
+    )
+    monkeypatch.setattr(
+        market_data_quotes.market_data_service,
+        "get_orderbook",
+        get_orderbook_mock,
+    )
+    tools = build_tools()
+
+    result = await tools["get_orderbook"]("005930", market="kr", venue="nxt")
+
+    get_orderbook_mock.assert_awaited_once_with("005930", "kr", venue="nxt")
+    assert result["venue"] == "nxt"
+    assert result["venue_label"] == "NXT"
+    assert result["kis_market_code"] == "NX"
+    assert result["source_endpoint"] == "/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn"
+    assert result["source_tr_id"] == "FHKST01010200"
+    assert result["is_empty_book"] is False
+    assert result["requires_final_recheck"] is False
+    assert "empty_reason" not in result
+
+
+@pytest.mark.asyncio
+async def test_get_orderbook_kr_venue_nxt_includes_empty_reason_when_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.mcp_server.tooling import market_data_quotes
+
+    monkeypatch.setattr(
+        market_data_quotes.market_data_service,
+        "get_orderbook",
+        AsyncMock(
+            return_value=_make_snapshot(
+                asks=[],
+                bids=[],
+                total_ask_qty=0,
+                total_bid_qty=0,
+                bid_ask_ratio=None,
+                venue="nxt",
+                venue_label="NXT",
+                kis_market_code="NX",
+                source_endpoint="/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn",
+                source_tr_id="FHKST01010200",
+                is_empty_book=True,
+                requires_final_recheck=True,
+                empty_reason="empty_kis_orderbook",
+            )
+        ),
+    )
+    tools = build_tools()
+
+    result = await tools["get_orderbook"]("005930", market="kr", venue="nxt")
+
+    assert result["is_empty_book"] is True
+    assert result["requires_final_recheck"] is True
+    assert result["empty_reason"] == "empty_kis_orderbook"
+
+
+@pytest.mark.asyncio
+async def test_get_orderbook_kr_default_venue_fields_included(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.mcp_server.tooling import market_data_quotes
+
+    monkeypatch.setattr(
+        market_data_quotes.market_data_service,
+        "get_orderbook",
+        AsyncMock(
+            return_value=_make_snapshot(
+                venue="krx",
+                venue_label="KRX",
+                kis_market_code="J",
+                source_endpoint="/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn",
+                source_tr_id="FHKST01010200",
+                is_empty_book=False,
+                requires_final_recheck=False,
+                empty_reason=None,
+            )
+        ),
+    )
+    tools = build_tools()
+
+    result = await tools["get_orderbook"]("005930")
+
+    assert result["venue"] == "krx"
+    assert result["venue_label"] == "KRX"
+    assert result["kis_market_code"] == "J"
+
+
+@pytest.mark.asyncio
+async def test_get_orderbook_crypto_venue_none_not_forwarded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.mcp_server.tooling import market_data_quotes
+
+    get_orderbook_mock = AsyncMock(
+        return_value=_make_snapshot(
+            symbol="KRW-BTC",
+            instrument_type="crypto",
+            source="upbit",
+            expected_price=None,
+            expected_qty=None,
+        )
+    )
+    monkeypatch.setattr(
+        market_data_quotes.market_data_service,
+        "get_orderbook",
+        get_orderbook_mock,
+    )
+    tools = build_tools()
+
+    await tools["get_orderbook"]("KRW-BTC", market="crypto")
+
+    get_orderbook_mock.assert_awaited_once_with("KRW-BTC", "crypto", venue=None)
+
+
+@pytest.mark.asyncio
+async def test_get_orderbook_crypto_rejects_venue() -> None:
+    tools = build_tools()
+
+    with pytest.raises(ValueError, match="venue is only supported for KR equity orderbook"):
+        await tools["get_orderbook"]("KRW-BTC", market="crypto", venue="nxt")
+
+
+@pytest.mark.asyncio
+async def test_get_orderbook_kr_no_venue_diagnostics_when_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.mcp_server.tooling import market_data_quotes
+
+    monkeypatch.setattr(
+        market_data_quotes.market_data_service,
+        "get_orderbook",
+        AsyncMock(return_value=_make_snapshot()),
+    )
+    tools = build_tools()
+
+    result = await tools["get_orderbook"]("5930")
+
+    assert "venue" not in result
+    assert "venue_label" not in result
+    assert "kis_market_code" not in result
+    assert "source_endpoint" not in result
+    assert "source_tr_id" not in result
+    assert "is_empty_book" not in result
+    assert "requires_final_recheck" not in result
+    assert "empty_reason" not in result

--- a/tests/test_mcp_orderbook_tools.py
+++ b/tests/test_mcp_orderbook_tools.py
@@ -441,7 +441,10 @@ async def test_get_orderbook_kr_venue_nxt_threads_to_service(
     assert result["venue"] == "nxt"
     assert result["venue_label"] == "NXT"
     assert result["kis_market_code"] == "NX"
-    assert result["source_endpoint"] == "/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn"
+    assert (
+        result["source_endpoint"]
+        == "/uapi/domestic-stock/v1/quotations/inquire-asking-price-exp-ccn"
+    )
     assert result["source_tr_id"] == "FHKST01010200"
     assert result["is_empty_book"] is False
     assert result["requires_final_recheck"] is False
@@ -546,7 +549,9 @@ async def test_get_orderbook_crypto_venue_none_not_forwarded(
 async def test_get_orderbook_crypto_rejects_venue() -> None:
     tools = build_tools()
 
-    with pytest.raises(ValueError, match="venue is only supported for KR equity orderbook"):
+    with pytest.raises(
+        ValueError, match="venue is only supported for KR equity orderbook"
+    ):
         await tools["get_orderbook"]("KRW-BTC", market="crypto", venue="nxt")
 
 

--- a/tests/test_services_kis_market_data.py
+++ b/tests/test_services_kis_market_data.py
@@ -931,7 +931,9 @@ class TestKISInquireOrderbook:
         )
         client._request_with_rate_limit = request_mock
 
-        output1, output2 = await client.inquire_orderbook_snapshot("005930", market="NX")
+        output1, output2 = await client.inquire_orderbook_snapshot(
+            "005930", market="NX"
+        )
 
         assert output1 == {"askp1": "70100", "askp_rsqn1": "111"}
         call_kwargs = request_mock.call_args

--- a/tests/test_services_kis_market_data.py
+++ b/tests/test_services_kis_market_data.py
@@ -916,6 +916,32 @@ class TestKISInquireOrderbook:
         assert output1 == {"askp1": "70100", "askp_rsqn1": "111"}
         assert output2 is None
 
+    @pytest.mark.asyncio
+    async def test_inquire_orderbook_snapshot_sends_nx_market_code(self):
+        from app.services.brokers.kis.client import KISClient
+
+        client = KISClient()
+        client._ensure_token = AsyncMock(return_value=None)
+        request_mock = AsyncMock(
+            return_value={
+                "rt_cd": "0",
+                "output1": {"askp1": "70100", "askp_rsqn1": "111"},
+                "output2": {"antc_cnpr": "70200", "antc_cnqn": "500"},
+            }
+        )
+        client._request_with_rate_limit = request_mock
+
+        output1, output2 = await client.inquire_orderbook_snapshot("005930", market="NX")
+
+        assert output1 == {"askp1": "70100", "askp_rsqn1": "111"}
+        call_kwargs = request_mock.call_args
+        params = call_kwargs.kwargs.get("params", {}) or (
+            call_kwargs.args[1] if len(call_kwargs.args) > 1 else {}
+        )
+        body = call_kwargs.kwargs.get("body", {}) or {}
+        sent_payload = {**params, **body}
+        assert sent_payload.get("FID_COND_MRKT_DIV_CODE") == "NX"
+
 
 @pytest.mark.asyncio
 async def test_kis_inquire_short_selling_uses_daily_short_sale_contract(monkeypatch):


### PR DESCRIPTION
## Summary
- Add venue-aware KR orderbook support for KIS KRX/NXT/통합 via FID_COND_MRKT_DIV_CODE.
- Thread optional venue through market-data service and MCP get_orderbook while preserving default KRX/J behavior.
- Add validation/diagnostics and regression coverage, including crypto venue rejection.

## Safety
- Read-only market-data path only.
- No broker order submit/cancel/modify, watch/order-intent creation, scheduler mutation, or DB backfill/update/delete.
- Default behavior remains KRX/J unless a KR venue is explicitly supplied.

## Verification
- uv run ruff check app/services/market_data/contracts.py app/services/market_data/service.py app/mcp_server/tooling/market_data_quotes.py tests/test_market_data_service.py tests/test_mcp_orderbook_tools.py tests/test_services_kis_market_data.py
- uv run pytest tests/test_mcp_orderbook_tools.py tests/test_market_data_service.py tests/test_services_kis_market_data.py -m 'not live'
- uv run pytest tests/test_trading_orderbook_router.py tests/test_research_run_live_refresh_service.py -m 'not live'

Closes ROB-209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `venue` parameter for Korean equity orderbooks to specify trading venues (NXT, unified, KRX). Not applicable to cryptocurrency orders.
  * Enhanced orderbook responses with diagnostic metadata including venue identifiers, market codes, and empty-book status indicators.

* **Documentation**
  * Updated orderbook documentation with venue parameter specifications and behavior details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/794)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->