### PR TITLE
fix: stabilize filled order history collection

### DIFF
--- a/app/services/brokers/kis/overseas_orders.py
+++ b/app/services/brokers/kis/overseas_orders.py
@@ -629,18 +629,30 @@ class OverseasOrderClient:
 
                 if js.get("msg_cd") in constants.RETRYABLE_MSG_CODES:
                     transient_retry_count += 1
+                    error_msg = f"{js.get('msg_cd')} {js.get('msg1')}"
                     if transient_retry_count < constants.RETRYABLE_MAX_ATTEMPTS:
                         logging.warning(
-                            "해외주식 체결조회 transient 에러 (시도 %d/%d): %s %s",
+                            "해외주식 체결조회 transient 에러 (시도 %d/%d, page=%d, accumulated=%d): %s",
                             transient_retry_count,
                             constants.RETRYABLE_MAX_ATTEMPTS,
-                            js.get("msg_cd"),
-                            js.get("msg1"),
+                            page,
+                            len(all_orders),
+                            error_msg,
                         )
                         await asyncio.sleep(
                             constants.RETRYABLE_BASE_DELAY * transient_retry_count
                         )
                         continue
+
+                    if all_orders:
+                        logging.warning(
+                            "해외주식 체결조회 연속조회 중 transient 에러가 반복되어 "
+                            "누적 %d건을 반환합니다 (page=%d): %s",
+                            len(all_orders),
+                            page,
+                            error_msg,
+                        )
+                        break
 
                 error_msg = f"{js.get('msg_cd')} {js.get('msg1')}"
                 logging.error(f"해외주식 체결조회 실패: {error_msg}")

--- a/app/services/brokers/upbit/orders.py
+++ b/app/services/brokers/upbit/orders.py
@@ -191,19 +191,34 @@ async def place_market_buy_order(market: str, price: str) -> dict[str, Any]:
 
 
 async def fetch_closed_orders(
-    market: str | None = None, limit: int = 20
+    market: str | None = None,
+    limit: int = 20,
+    page: int = 1,
+    states: list[str] | None = None,
+    order_by: str = "desc",
 ) -> list[dict[str, Any]]:
-    """체결 완료 주문 목록 조회.
+    """체결/취소 완료 주문 목록 조회.
 
     Args:
         market: 마켓코드 필터 (옵션), None이면 전체 조회
-        limit: 반환할 건수 (기본값 20)
+        limit: 반환할 건수 (Upbit page size, 최대 100)
+        page: 페이지 번호 (1부터 시작)
+        states: 조회 상태 목록. 기본값은 ["done", "cancel"]
+        order_by: 정렬 방향 ("asc" 또는 "desc")
 
     Returns:
-        체결 주문 목록 (list of dict)
+        체결/취소 주문 목록 (list of dict)
     """
     url = f"{_client.UPBIT_REST}/orders/closed"
-    params: dict[str, Any] = {"states[]": ["done", "cancel"], "limit": limit}
+    capped_limit = max(1, min(int(limit), 100))
+    normalized_page = max(1, int(page))
+    normalized_states = states or ["done", "cancel"]
+    params: dict[str, Any] = {
+        "states[]": normalized_states,
+        "limit": capped_limit,
+        "page": normalized_page,
+        "order_by": order_by,
+    }
     if market:
         params["market"] = market
 

--- a/app/services/n8n_filled_orders_service.py
+++ b/app/services/n8n_filled_orders_service.py
@@ -16,7 +16,6 @@ from app.services.n8n_filled_orders_indicators import _enrich_with_indicators
 logger = logging.getLogger(__name__)
 
 _EQUITY_QUOTE_CONCURRENCY = 5
-_US_EXCHANGES = ("NASD", "NYSE", "AMEX")
 
 
 def _strip_crypto_prefix(symbol: str) -> str:
@@ -206,22 +205,25 @@ async def _fetch_kis_overseas_filled(days: int) -> tuple[list[dict], list[dict]]
         all_orders: list[dict] = []
         seen_order_ids: set[str] = set()
 
-        for exchange in _US_EXCHANGES:
-            try:
-                raw_orders = await kis.inquire_daily_order_overseas(
-                    start_date=start_date,
-                    end_date=end_date,
-                    symbol="%",
-                    exchange_code=exchange,
-                    side="00",
-                )
-                for raw in raw_orders or []:
-                    normalized = _normalize_kis_overseas_filled(raw)
-                    if normalized and normalized["order_id"] not in seen_order_ids:
-                        seen_order_ids.add(normalized["order_id"])
-                        all_orders.append(normalized)
-            except Exception as exc:
-                logger.warning("KIS overseas %s fetch failed: %s", exchange, exc)
+        # KIS overseas daily-order inquiry treats NASD as a US-wide history
+        # selector in practice: rows may include NYSE/AMEX via ovrs_excg_cd.
+        # Calling NASD/NYSE/AMEX separately produces duplicates and increases
+        # the chance of SYDB0050 while following continuation pages.
+        try:
+            raw_orders = await kis.inquire_daily_order_overseas(
+                start_date=start_date,
+                end_date=end_date,
+                symbol="%",
+                exchange_code="NASD",
+                side="00",
+            )
+            for raw in raw_orders or []:
+                normalized = _normalize_kis_overseas_filled(raw)
+                if normalized and normalized["order_id"] not in seen_order_ids:
+                    seen_order_ids.add(normalized["order_id"])
+                    all_orders.append(normalized)
+        except Exception as exc:
+            logger.warning("KIS overseas US-wide fetch failed: %s", exc)
 
         return all_orders, []
     except Exception as exc:

--- a/tests/test_kis_overseas_orders_retry.py
+++ b/tests/test_kis_overseas_orders_retry.py
@@ -74,6 +74,39 @@ class TestOverseasOrdersTransientRetry:
             )
 
     @pytest.mark.asyncio
+    async def test_returns_accumulated_rows_when_continuation_sydb0050_persists(
+        self, _mock_overseas_orders
+    ):
+        instance, parent = _mock_overseas_orders
+
+        first_page = {
+            "rt_cd": "0",
+            "output1": [{"odno": "001", "pdno": "AAPL"}],
+            "ctx_area_fk200": "FK_NEXT",
+            "ctx_area_nk200": "NK_NEXT",
+        }
+        transient_response = {
+            "rt_cd": "1",
+            "msg_cd": "SYDB0050",
+            "msg1": "조회이후에 자료가 변경되었습니다.(다시 조회하세요)",
+        }
+        parent._request_with_rate_limit = AsyncMock(
+            side_effect=[
+                first_page,
+                transient_response,
+                transient_response,
+                transient_response,
+            ]
+        )
+
+        result = await instance.inquire_daily_order_overseas(
+            start_date="20260317", end_date="20260317"
+        )
+
+        assert result == [{"odno": "001", "pdno": "AAPL"}]
+        assert parent._request_with_rate_limit.call_count == 4
+
+    @pytest.mark.asyncio
     async def test_non_retryable_error_raises_immediately(self, _mock_overseas_orders):
         instance, parent = _mock_overseas_orders
 

--- a/tests/test_n8n_filled_orders_service.py
+++ b/tests/test_n8n_filled_orders_service.py
@@ -1,0 +1,52 @@
+"""Tests for filled-orders aggregation service."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.mark.unit
+class TestKISOverseasFilledOrdersFetch:
+    @pytest.mark.asyncio
+    async def test_uses_single_us_wide_history_query_and_dedupes(self, monkeypatch):
+        from app.services import n8n_filled_orders_service as svc
+
+        fake_kis = MagicMock()
+        fake_kis.inquire_daily_order_overseas = AsyncMock(
+            return_value=[
+                {
+                    "odno": "US-1",
+                    "pdno": "UBER",
+                    "sll_buy_dvsn_cd": "01",
+                    "ft_ccld_qty": "4",
+                    "ft_ccld_unpr3": "77.37",
+                    "ft_ccld_amt3": "309.48",
+                    "ord_dt": "20260506",
+                    "ord_tmd": "230005",
+                },
+                {
+                    "odno": "US-1",
+                    "pdno": "UBER",
+                    "sll_buy_dvsn_cd": "01",
+                    "ft_ccld_qty": "4",
+                    "ft_ccld_unpr3": "77.37",
+                    "ft_ccld_amt3": "309.48",
+                    "ord_dt": "20260506",
+                    "ord_tmd": "230005",
+                },
+            ]
+        )
+        monkeypatch.setattr(svc, "KISClient", lambda: fake_kis)
+
+        orders, errors = await svc._fetch_kis_overseas_filled(days=7)
+
+        assert errors == []
+        assert [order["order_id"] for order in orders] == ["US-1"]
+        fake_kis.inquire_daily_order_overseas.assert_awaited_once()
+        assert (
+            fake_kis.inquire_daily_order_overseas.await_args.kwargs["exchange_code"]
+            == "NASD"
+        )
+        assert fake_kis.inquire_daily_order_overseas.await_args.kwargs["symbol"] == "%"

--- a/tests/test_upbit_orders.py
+++ b/tests/test_upbit_orders.py
@@ -1,0 +1,38 @@
+"""Tests for Upbit order query helpers."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.unit
+class TestUpbitClosedOrders:
+    @pytest.mark.asyncio
+    async def test_closed_orders_passes_pagination_and_state_filters(self, monkeypatch):
+        from app.services.brokers.upbit import orders
+
+        request = AsyncMock(return_value=[])
+        monkeypatch.setattr(orders._client, "_request_with_auth", request)
+
+        result = await orders.fetch_closed_orders(
+            market="KRW-BTC",
+            limit=500,
+            page=3,
+            states=["done"],
+            order_by="asc",
+        )
+
+        assert result == []
+        request.assert_awaited_once()
+        method, url = request.await_args.args
+        assert method == "GET"
+        assert url.endswith("/orders/closed")
+        assert request.await_args.kwargs["query_params"] == {
+            "states[]": ["done"],
+            "limit": 100,
+            "page": 3,
+            "order_by": "asc",
+            "market": "KRW-BTC",
+        }


### PR DESCRIPTION
## Summary
- Preserve accumulated KIS overseas filled-history rows when `SYDB0050` repeats on continuation pages.
- Query KIS overseas US filled history once with the observed `NASD` US-wide selector and dedupe normalized rows.
- Extend Upbit `fetch_closed_orders` with `page`, `states`, `order_by`, and safe limit clamping for future ledger backfills.
- Add focused regression tests for KIS overseas continuation handling, filled-order aggregation, and Upbit closed-order parameters.

## Why
This is the first stabilization slice before building a durable execution ledger for KIS domestic, KIS overseas, and Upbit fills. The ledger needs reliable broker-history collection first, especially for REST reconciliation after websocket notification gaps.

## Verification
- `uv run python -m py_compile app/services/brokers/kis/overseas_orders.py app/services/n8n_filled_orders_service.py app/services/brokers/upbit/orders.py tests/test_kis_overseas_orders_retry.py tests/test_n8n_filled_orders_service.py tests/test_upbit_orders.py`
- `uv run ruff format --check app/services/brokers/kis/overseas_orders.py app/services/brokers/upbit/orders.py app/services/n8n_filled_orders_service.py tests/test_kis_overseas_orders_retry.py tests/test_n8n_filled_orders_service.py tests/test_upbit_orders.py`
- `uv run ruff check app/services/brokers/kis/overseas_orders.py app/services/brokers/upbit/orders.py app/services/n8n_filled_orders_service.py tests/test_kis_overseas_orders_retry.py tests/test_n8n_filled_orders_service.py tests/test_upbit_orders.py`
- `uv run --group test python -m pytest tests/test_kis_overseas_orders_retry.py tests/test_n8n_filled_orders_service.py tests/test_upbit_orders.py -q`

## Safety
- No broker order submission/cancel/modify path changed.
- No DB migration or data mutation in this PR.
- This only improves read-only order/fill history collection and test coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upbit order retrieval now supports pagination and filtering options (limit, page, states, order_by).

* **Improvements**
  * KIS overseas order retrieval now gracefully returns accumulated orders when transient errors persist beyond retry limits, rather than failing entirely.
  * Simplified N8N filled orders service with optimized exchange query logic.

* **Tests**
  * Added test coverage for KIS transient error handling and Upbit order pagination features.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/800)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->