### PR TITLE
feat(market-events): add TradingView economic calendar provider

### DIFF
--- a/app/services/invest_view_model/calendar_service.py
+++ b/app/services/invest_view_model/calendar_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, date, datetime, timedelta
 from decimal import Decimal, InvalidOperation
 from typing import cast
@@ -205,6 +206,64 @@ def _event_title(raw: object, *, market: CalendarMarket, etype: EventType) -> st
     return "시장 이벤트"
 
 
+def _source_priority(source: str | None) -> int:
+    """Provider preference for duplicate /invest calendar rows.
+
+    TradingView economic-calendar rows currently carry cleaner actual/forecast/
+    previous values than ForexFactory for the same macro release.  ForexFactory
+    remains useful as fallback and for rows TradingView does not provide.
+    """
+    if (source or "").lower() == "tradingview":
+        return 20
+    if (source or "").lower() == "forexfactory":
+        return 10
+    return 0
+
+
+def _normalize_economic_title(title: str | None) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", (title or "").lower()).strip()
+
+
+def _economic_dedupe_key(
+    ev: CalendarEvent, ev_date: date
+) -> tuple[str, date, str] | None:
+    """Return a narrow duplicate key for global macro events only."""
+    if ev.eventType != "economic" or ev.market != "global":
+        return None
+    normalized_title = _normalize_economic_title(ev.title)
+    if not normalized_title:
+        return None
+    return ("economic", ev_date, normalized_title)
+
+
+def _dedupe_calendar_events(
+    events: list[CalendarEvent], ev_date: date
+) -> list[CalendarEvent]:
+    """Deduplicate same-day economic/global provider duplicates.
+
+    The de-duplication is intentionally applied after conversion to the invest
+    calendar DTO so provider fallback is preserved: if TradingView is missing,
+    the ForexFactory row remains; if both are present for the same release,
+    TradingView wins regardless of query order.
+    """
+    deduped: list[CalendarEvent] = []
+    key_to_index: dict[tuple[str, date, str], int] = {}
+    for ev in events:
+        key = _economic_dedupe_key(ev, ev_date)
+        if key is None:
+            deduped.append(ev)
+            continue
+        existing_idx = key_to_index.get(key)
+        if existing_idx is None:
+            key_to_index[key] = len(deduped)
+            deduped.append(ev)
+            continue
+        existing = deduped[existing_idx]
+        if _source_priority(ev.source) > _source_priority(existing.source):
+            deduped[existing_idx] = ev
+    return deduped
+
+
 async def build_calendar(
     *,
     db: AsyncSession,
@@ -285,8 +344,9 @@ async def build_calendar(
 
     days: list[CalendarDay] = []
     for d in _date_range(from_date, to_date):
+        events = _dedupe_calendar_events(by_day.get(d, []), d)
         events = _sort_calendar_events(
-            [_with_priority(ev, target_date=d) for ev in by_day.get(d, [])]
+            [_with_priority(ev, target_date=d) for ev in events]
         )
         summary = _build_day_summary(events)
         clusters: list[CalendarCluster] = []

--- a/app/services/market_events/ingestion.py
+++ b/app/services/market_events/ingestion.py
@@ -345,3 +345,71 @@ async def ingest_economic_events_for_date(
             partition_date=target_date,
             error=exc,
         )
+
+
+async def ingest_tradingview_economic_events_for_date(
+    db: AsyncSession,
+    target_date: date,
+    fetch_rows: Callable[[date], Awaitable[list[dict[str, Any]]]] | None = None,
+) -> IngestionRunResult:
+    """Ingest TradingView economic-calendar events for one day.
+
+    `fetch_rows` is an optional injection point. Default uses
+    `app.services.market_events.tradingview_helpers.fetch_tradingview_events_for_date`.
+    """
+    if fetch_rows is None:
+        from app.services.market_events.tradingview_helpers import (
+            fetch_tradingview_events_for_date as _default_fetch,
+        )
+
+        fetch_rows = _default_fetch
+
+    source = "tradingview"
+    category = "economic"
+    market = "global"
+    repo = MarketEventsRepository(db)
+    partition = await repo.get_or_create_partition(
+        source=source,
+        category=category,
+        market=market,
+        partition_date=target_date,
+    )
+    await repo.mark_partition_running(partition)
+
+    try:
+        from app.services.market_events.normalizers import (
+            normalize_tradingview_event_row,
+        )
+
+        rows = await fetch_rows(target_date)
+        upserted = 0
+        for row in rows:
+            try:
+                event_dict, value_dicts = normalize_tradingview_event_row(row)
+            except ValueError as exc:
+                logger.warning(
+                    "skipping unparseable tradingview row: %s (%s)", row, exc
+                )
+                continue
+            await repo.upsert_event_with_values(event_dict, value_dicts)
+            upserted += 1
+
+        await repo.mark_partition_succeeded(partition, event_count=upserted)
+        return IngestionRunResult(
+            source=source,
+            category=category,
+            market=market,
+            partition_date=target_date,
+            status="succeeded",
+            event_count=upserted,
+        )
+    except Exception as exc:
+        logger.exception("tradingview ingestion failed for %s", target_date)
+        return await _mark_failed_after_exception(
+            db,
+            source=source,
+            category=category,
+            market=market,
+            partition_date=target_date,
+            error=exc,
+        )

--- a/app/services/market_events/normalizers.py
+++ b/app/services/market_events/normalizers.py
@@ -374,3 +374,91 @@ def normalize_wisefn_earnings_row(
         "raw_payload_json": _row_to_jsonable(row),
     }
     return event, []
+
+
+_TV_IMPORTANCE_MAP: dict[int, int] = {1: 1, 2: 2, 3: 3}
+
+
+def normalize_tradingview_event_row(
+    row: dict[str, Any],
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    """Normalize one TradingView economic-calendar row into MarketEvent + values dicts.
+
+    The row shape is produced by
+    `app.services.market_events.tradingview_helpers.fetch_tradingview_events_for_date`.
+    Fields: id/title/country/date_utc/period/actual/forecast/previous/unit/
+            source/source_url/ticker/importance/_raw
+    """
+    title = (row.get("title") or "").strip()
+    date_utc = row.get("date_utc")
+    if not title or date_utc is None:
+        raise ValueError("tradingview row missing title or date_utc")
+
+    event_date = date_utc.date()
+    country = row.get("country")
+
+    importance_raw = row.get("importance")
+    importance: int | None = None
+    if importance_raw is not None:
+        try:
+            importance = _TV_IMPORTANCE_MAP.get(int(importance_raw))
+        except (ValueError, TypeError):
+            importance = None
+
+    event_id = row.get("id")
+    if event_id:
+        source_event_id = str(event_id)
+    else:
+        ts = date_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+        source_event_id = f"tv::{country}::{title}::{ts}"
+
+    actual_raw = row.get("actual")
+    status = "released" if actual_raw not in (None, "", "-") else "scheduled"
+
+    raw_payload_json: dict[str, Any] = dict(row.get("_raw") or row)
+    raw_payload_json.pop("_raw", None)
+    raw_payload_json.pop("date_utc", None)
+
+    event = {
+        "category": "economic",
+        "market": "global",
+        "country": country,
+        "currency": None,
+        "symbol": row.get("ticker") or None,
+        "company_name": None,
+        "title": title,
+        "event_date": event_date,
+        "release_time_utc": date_utc,
+        "release_time_local": None,
+        "source_timezone": "UTC",
+        "time_hint": "unknown",
+        "importance": importance,
+        "status": status,
+        "source": "tradingview",
+        "source_event_id": source_event_id,
+        "source_url": row.get("source_url"),
+        "fiscal_year": None,
+        "fiscal_quarter": None,
+        "raw_payload_json": raw_payload_json,
+    }
+
+    period = row.get("period") or None
+    unit = row.get("unit") or None
+    actual_dec = _to_decimal(actual_raw)
+    forecast_dec = _to_decimal(row.get("forecast"))
+    previous_dec = _to_decimal(row.get("previous"))
+
+    values: list[dict[str, Any]] = []
+    if any(v is not None for v in (actual_dec, forecast_dec, previous_dec)):
+        values.append(
+            {
+                "metric_name": "actual",
+                "period": period,
+                "actual": actual_dec,
+                "forecast": forecast_dec,
+                "previous": previous_dec,
+                "unit": unit,
+            }
+        )
+
+    return event, values

--- a/app/services/market_events/taxonomy.py
+++ b/app/services/market_events/taxonomy.py
@@ -41,6 +41,7 @@ SOURCES: frozenset[str] = frozenset(
         "token_unlocks",
         "forexfactory",
         "wisefn",
+        "tradingview",
     }
 )
 

--- a/app/services/market_events/tradingview_helpers.py
+++ b/app/services/market_events/tradingview_helpers.py
@@ -1,0 +1,126 @@
+"""Per-day TradingView economic-calendar fetch helper (ROB-210).
+
+Fetches events from the TradingView economic-calendar endpoint, parses the JSON
+response, and filters to rows whose UTC-day matches the requested target_date.
+
+The endpoint is treated as an internal web endpoint, not an official public API.
+ForexFactory remains the fallback/cross-check source.
+
+Caller passes the resulting rows into
+`app.services.market_events.normalizers.normalize_tradingview_event_row`.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, date, datetime
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+TRADINGVIEW_CALENDAR_URL = "https://economic-calendar.tradingview.com/events"
+
+
+async def _fetch_tradingview_raw(from_date: date, to_date: date) -> Any:
+    """Fetch raw JSON payload from TradingView economic-calendar endpoint.
+
+    Kept as a module-level seam for tests to patch.
+    """
+    params = {
+        "from": f"{from_date.isoformat()}T00:00:00Z",
+        "to": f"{to_date.isoformat()}T23:59:59Z",
+        "country": "all",
+    }
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        response = await client.get(TRADINGVIEW_CALENDAR_URL, params=params)
+        response.raise_for_status()
+        return response.json()
+
+
+def _parse_tv_date(value: Any) -> datetime | None:
+    """Parse TradingView date field: Unix timestamp (int/float) or ISO string."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(value, tz=UTC)
+        except (OSError, ValueError, OverflowError):
+            return None
+    s = str(value).strip()
+    if not s:
+        return None
+    for fmt in (
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%dT%H:%M:%S.%fZ",
+        "%Y-%m-%dT%H:%M:%S+00:00",
+    ):
+        try:
+            return datetime.strptime(s, fmt).replace(tzinfo=UTC)
+        except ValueError:
+            continue
+    try:
+        dt = datetime.fromisoformat(s)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt.astimezone(UTC)
+    except ValueError:
+        return None
+
+
+def _parse_tv_rows(payload: Any) -> list[dict[str, Any]]:
+    """Extract and normalize event rows from TradingView response payload."""
+    if isinstance(payload, list):
+        items = payload
+    elif isinstance(payload, dict):
+        items = payload.get("result") or payload.get("data") or []
+        if not isinstance(items, list):
+            items = []
+    else:
+        items = []
+
+    rows: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        dt = _parse_tv_date(item.get("date"))
+        if dt is None:
+            continue
+        rows.append(
+            {
+                "id": item.get("id"),
+                "title": (item.get("title") or "").strip(),
+                "country": item.get("country"),
+                "date_utc": dt,
+                "period": item.get("period"),
+                "actual": item.get("actual"),
+                "forecast": item.get("forecast"),
+                "previous": item.get("previous"),
+                "unit": item.get("unit"),
+                "source": item.get("source"),
+                "source_url": item.get("source_url"),
+                "ticker": item.get("ticker"),
+                "importance": item.get("importance"),
+                "_raw": dict(item),
+            }
+        )
+    return rows
+
+
+async def fetch_tradingview_events_for_date(
+    target_date: date,
+) -> list[dict[str, Any]]:
+    """Return TradingView economic-calendar rows whose UTC-day == target_date.
+
+    Raises on network/HTTP errors so the caller can mark the partition failed.
+    Returns [] on JSON parse problems so one bad day doesn't block others.
+    """
+    try:
+        payload = await _fetch_tradingview_raw(target_date, target_date)
+    except Exception as exc:
+        logger.warning("tradingview fetch failed for %s: %s", target_date, exc)
+        raise
+
+    rows = _parse_tv_rows(payload)
+    return [r for r in rows if r["date_utc"].date() == target_date]

--- a/scripts/ingest_market_events.py
+++ b/scripts/ingest_market_events.py
@@ -51,6 +51,7 @@ from app.services.market_events.ingestion import (
     ingest_economic_events_for_date,
     ingest_kr_disclosures_for_date,
     ingest_kr_earnings_wisefn_for_date,
+    ingest_tradingview_economic_events_for_date,
     ingest_us_earnings_for_date,
 )
 
@@ -62,6 +63,7 @@ SUPPORTED = {
     ("dart", "disclosure", "kr"): ingest_kr_disclosures_for_date,
     ("forexfactory", "economic", "global"): ingest_economic_events_for_date,
     ("wisefn", "earnings", "kr"): ingest_kr_earnings_wisefn_for_date,
+    ("tradingview", "economic", "global"): ingest_tradingview_economic_events_for_date,
 }
 
 
@@ -101,7 +103,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--source",
         default="finnhub",
-        choices=["finnhub", "dart", "forexfactory", "wisefn"],
+        choices=["finnhub", "dart", "forexfactory", "wisefn", "tradingview"],
     )
     parser.add_argument(
         "--category",

--- a/tests/services/test_tradingview_helpers.py
+++ b/tests/services/test_tradingview_helpers.py
@@ -85,7 +85,9 @@ SAMPLE_TV_PAYLOAD_LIST = [
 async def test_fetch_tradingview_filters_to_target_day():
     from app.services.market_events import tradingview_helpers as tv
 
-    with patch.object(tv, "_fetch_tradingview_raw", AsyncMock(return_value=SAMPLE_TV_PAYLOAD)):
+    with patch.object(
+        tv, "_fetch_tradingview_raw", AsyncMock(return_value=SAMPLE_TV_PAYLOAD)
+    ):
         rows = await tv.fetch_tradingview_events_for_date(date(2026, 5, 13))
 
     assert len(rows) == 2
@@ -98,7 +100,9 @@ async def test_fetch_tradingview_filters_to_target_day():
 async def test_fetch_tradingview_excludes_other_days():
     from app.services.market_events import tradingview_helpers as tv
 
-    with patch.object(tv, "_fetch_tradingview_raw", AsyncMock(return_value=SAMPLE_TV_PAYLOAD)):
+    with patch.object(
+        tv, "_fetch_tradingview_raw", AsyncMock(return_value=SAMPLE_TV_PAYLOAD)
+    ):
         rows = await tv.fetch_tradingview_events_for_date(date(2026, 5, 14))
 
     assert len(rows) == 1
@@ -110,7 +114,9 @@ async def test_fetch_tradingview_excludes_other_days():
 async def test_fetch_tradingview_parses_utc_datetime():
     from app.services.market_events import tradingview_helpers as tv
 
-    with patch.object(tv, "_fetch_tradingview_raw", AsyncMock(return_value=SAMPLE_TV_PAYLOAD)):
+    with patch.object(
+        tv, "_fetch_tradingview_raw", AsyncMock(return_value=SAMPLE_TV_PAYLOAD)
+    ):
         rows = await tv.fetch_tradingview_events_for_date(date(2026, 5, 13))
 
     cpi = next(r for r in rows if r["title"] == "Core CPI m/m")
@@ -126,7 +132,9 @@ async def test_fetch_tradingview_parses_utc_datetime():
 async def test_fetch_tradingview_accepts_list_payload():
     from app.services.market_events import tradingview_helpers as tv
 
-    with patch.object(tv, "_fetch_tradingview_raw", AsyncMock(return_value=SAMPLE_TV_PAYLOAD_LIST)):
+    with patch.object(
+        tv, "_fetch_tradingview_raw", AsyncMock(return_value=SAMPLE_TV_PAYLOAD_LIST)
+    ):
         rows = await tv.fetch_tradingview_events_for_date(date(2026, 5, 13))
 
     assert len(rows) == 1
@@ -151,7 +159,12 @@ def test_parse_tv_rows_skips_items_without_parseable_date():
 
     payload = {
         "result": [
-            {"id": "ok", "title": "Good Event", "date": "2026-05-13T12:30:00Z", "country": "US"},
+            {
+                "id": "ok",
+                "title": "Good Event",
+                "date": "2026-05-13T12:30:00Z",
+                "country": "US",
+            },
             {"id": "bad", "title": "No Date"},
             {"id": "bad2", "title": "Garbage Date", "date": "not-a-date"},
         ]

--- a/tests/services/test_tradingview_helpers.py
+++ b/tests/services/test_tradingview_helpers.py
@@ -1,0 +1,191 @@
+"""TradingView fetch helper tests (ROB-210).
+
+All tests use fixture payloads — no live network calls in CI.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+SAMPLE_TV_PAYLOAD = {
+    "result": [
+        {
+            "id": "4b8e4f00-0e49-4a4a-b6e2-111111111111",
+            "title": "Core CPI m/m",
+            "country": "US",
+            "date": "2026-05-13T12:30:00Z",
+            "period": "Apr",
+            "actual": "0.3",
+            "forecast": "0.3",
+            "previous": "0.4",
+            "unit": "%",
+            "source": "Bureau of Labor Statistics",
+            "source_url": "https://www.bls.gov/cpi/",
+            "ticker": None,
+            "importance": 3,
+        },
+        {
+            "id": "4b8e4f00-0e49-4a4a-b6e2-222222222222",
+            "title": "Industrial Production m/m",
+            "country": "DE",
+            "date": "2026-05-13T06:00:00Z",
+            "period": "Mar",
+            "actual": None,
+            "forecast": "-0.5",
+            "previous": "1.2",
+            "unit": "%",
+            "source": "Destatis",
+            "source_url": "https://www.destatis.de/",
+            "ticker": None,
+            "importance": 2,
+        },
+        {
+            "id": "4b8e4f00-0e49-4a4a-b6e2-333333333333",
+            "title": "Bank Holiday",
+            "country": "JP",
+            "date": "2026-05-14T00:00:00Z",
+            "period": None,
+            "actual": None,
+            "forecast": None,
+            "previous": None,
+            "unit": None,
+            "source": None,
+            "source_url": None,
+            "ticker": None,
+            "importance": 0,
+        },
+    ],
+    "status": "ok",
+}
+
+SAMPLE_TV_PAYLOAD_LIST = [
+    {
+        "id": "abc-123",
+        "title": "GDP Growth Rate",
+        "country": "US",
+        "date": "2026-05-13T12:30:00Z",
+        "period": "Q1",
+        "actual": "2.5",
+        "forecast": "2.4",
+        "previous": "2.3",
+        "unit": "%",
+        "source": "BEA",
+        "source_url": None,
+        "ticker": None,
+        "importance": 3,
+    }
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fetch_tradingview_filters_to_target_day():
+    from app.services.market_events import tradingview_helpers as tv
+
+    with patch.object(tv, "_fetch_tradingview_raw", AsyncMock(return_value=SAMPLE_TV_PAYLOAD)):
+        rows = await tv.fetch_tradingview_events_for_date(date(2026, 5, 13))
+
+    assert len(rows) == 2
+    titles = {r["title"] for r in rows}
+    assert titles == {"Core CPI m/m", "Industrial Production m/m"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fetch_tradingview_excludes_other_days():
+    from app.services.market_events import tradingview_helpers as tv
+
+    with patch.object(tv, "_fetch_tradingview_raw", AsyncMock(return_value=SAMPLE_TV_PAYLOAD)):
+        rows = await tv.fetch_tradingview_events_for_date(date(2026, 5, 14))
+
+    assert len(rows) == 1
+    assert rows[0]["title"] == "Bank Holiday"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fetch_tradingview_parses_utc_datetime():
+    from app.services.market_events import tradingview_helpers as tv
+
+    with patch.object(tv, "_fetch_tradingview_raw", AsyncMock(return_value=SAMPLE_TV_PAYLOAD)):
+        rows = await tv.fetch_tradingview_events_for_date(date(2026, 5, 13))
+
+    cpi = next(r for r in rows if r["title"] == "Core CPI m/m")
+    assert cpi["date_utc"] == datetime(2026, 5, 13, 12, 30, tzinfo=UTC)
+    assert cpi["country"] == "US"
+    assert cpi["importance"] == 3
+    assert cpi["unit"] == "%"
+    assert cpi["id"] == "4b8e4f00-0e49-4a4a-b6e2-111111111111"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fetch_tradingview_accepts_list_payload():
+    from app.services.market_events import tradingview_helpers as tv
+
+    with patch.object(tv, "_fetch_tradingview_raw", AsyncMock(return_value=SAMPLE_TV_PAYLOAD_LIST)):
+        rows = await tv.fetch_tradingview_events_for_date(date(2026, 5, 13))
+
+    assert len(rows) == 1
+    assert rows[0]["title"] == "GDP Growth Rate"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fetch_tradingview_raises_on_network_error():
+    from app.services.market_events import tradingview_helpers as tv
+
+    with patch.object(
+        tv, "_fetch_tradingview_raw", AsyncMock(side_effect=TimeoutError("timeout"))
+    ):
+        with pytest.raises(TimeoutError):
+            await tv.fetch_tradingview_events_for_date(date(2026, 5, 13))
+
+
+@pytest.mark.unit
+def test_parse_tv_rows_skips_items_without_parseable_date():
+    from app.services.market_events.tradingview_helpers import _parse_tv_rows
+
+    payload = {
+        "result": [
+            {"id": "ok", "title": "Good Event", "date": "2026-05-13T12:30:00Z", "country": "US"},
+            {"id": "bad", "title": "No Date"},
+            {"id": "bad2", "title": "Garbage Date", "date": "not-a-date"},
+        ]
+    }
+    rows = _parse_tv_rows(payload)
+    assert len(rows) == 1
+    assert rows[0]["title"] == "Good Event"
+
+
+@pytest.mark.unit
+def test_parse_tv_date_handles_unix_timestamp():
+    from app.services.market_events.tradingview_helpers import _parse_tv_date
+
+    # 2026-05-13T12:30:00Z as Unix timestamp
+    ts = datetime(2026, 5, 13, 12, 30, tzinfo=UTC).timestamp()
+    result = _parse_tv_date(int(ts))
+    assert result is not None
+    assert result.year == 2026
+    assert result.month == 5
+    assert result.day == 13
+    assert result.tzinfo == UTC
+
+
+@pytest.mark.unit
+def test_parse_tv_date_handles_iso_string():
+    from app.services.market_events.tradingview_helpers import _parse_tv_date
+
+    result = _parse_tv_date("2026-05-13T12:30:00Z")
+    assert result == datetime(2026, 5, 13, 12, 30, tzinfo=UTC)
+
+
+@pytest.mark.unit
+def test_parse_tv_date_returns_none_for_none():
+    from app.services.market_events.tradingview_helpers import _parse_tv_date
+
+    assert _parse_tv_date(None) is None
+    assert _parse_tv_date("") is None

--- a/tests/services/test_tradingview_ingestion.py
+++ b/tests/services/test_tradingview_ingestion.py
@@ -1,0 +1,202 @@
+"""TradingView ingestion orchestration tests (ROB-210).
+
+All tests use injected fetch_rows — no live network calls.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date
+from datetime import datetime as _dt
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, select
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _clean_market_events(db_session):
+    from app.models.market_events import (
+        MarketEvent,
+        MarketEventIngestionPartition,
+        MarketEventValue,
+    )
+
+    await db_session.execute(delete(MarketEventValue))
+    await db_session.execute(delete(MarketEvent))
+    await db_session.execute(delete(MarketEventIngestionPartition))
+    await db_session.commit()
+    yield
+
+
+TV_ROW = {
+    "id": "4b8e4f00-0e49-4a4a-b6e2-111111111111",
+    "title": "Core CPI m/m",
+    "country": "US",
+    "date_utc": _dt(2026, 5, 13, 12, 30, tzinfo=UTC),
+    "period": "Apr",
+    "actual": "0.3",
+    "forecast": "0.3",
+    "previous": "0.4",
+    "unit": "%",
+    "source": "Bureau of Labor Statistics",
+    "source_url": "https://www.bls.gov/cpi/",
+    "ticker": None,
+    "importance": 3,
+    "_raw": {
+        "id": "4b8e4f00-0e49-4a4a-b6e2-111111111111",
+        "title": "Core CPI m/m",
+        "country": "US",
+        "date": "2026-05-13T12:30:00Z",
+        "period": "Apr",
+        "actual": "0.3",
+        "forecast": "0.3",
+        "previous": "0.4",
+        "unit": "%",
+        "source": "Bureau of Labor Statistics",
+        "source_url": "https://www.bls.gov/cpi/",
+        "ticker": None,
+        "importance": 3,
+    },
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_ingest_tradingview_economic_events_succeeds(db_session):
+    from app.models.market_events import (
+        MarketEvent,
+        MarketEventIngestionPartition,
+        MarketEventValue,
+    )
+    from app.services.market_events import ingestion
+
+    async def fake_fetch(d):
+        assert d == date(2026, 5, 13)
+        return [TV_ROW]
+
+    result = await ingestion.ingest_tradingview_economic_events_for_date(
+        db_session, date(2026, 5, 13), fetch_rows=fake_fetch
+    )
+    await db_session.commit()
+
+    assert result.status == "succeeded"
+    assert result.event_count == 1
+    assert result.source == "tradingview"
+    assert result.category == "economic"
+    assert result.market == "global"
+
+    events = (await db_session.execute(select(MarketEvent))).scalars().all()
+    assert len(events) == 1
+    e = events[0]
+    assert e.category == "economic"
+    assert e.market == "global"
+    assert e.source == "tradingview"
+    assert e.country == "US"
+    assert e.title == "Core CPI m/m"
+    assert e.importance == 3
+    assert e.status == "released"
+    assert e.source_event_id == "4b8e4f00-0e49-4a4a-b6e2-111111111111"
+    assert e.source_url == "https://www.bls.gov/cpi/"
+
+    values = (await db_session.execute(select(MarketEventValue))).scalars().all()
+    assert len(values) == 1
+    assert values[0].metric_name == "actual"
+    assert values[0].unit == "%"
+
+    parts = (
+        (await db_session.execute(select(MarketEventIngestionPartition)))
+        .scalars()
+        .all()
+    )
+    assert len(parts) == 1
+    assert parts[0].source == "tradingview"
+    assert parts[0].category == "economic"
+    assert parts[0].market == "global"
+    assert parts[0].status == "succeeded"
+    assert parts[0].event_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_ingest_tradingview_economic_events_is_idempotent(db_session):
+    from app.models.market_events import MarketEvent
+    from app.services.market_events import ingestion
+
+    async def fake_fetch(d):
+        return [TV_ROW]
+
+    for _ in range(2):
+        await ingestion.ingest_tradingview_economic_events_for_date(
+            db_session, date(2026, 5, 13), fetch_rows=fake_fetch
+        )
+        await db_session.commit()
+
+    events = (await db_session.execute(select(MarketEvent))).scalars().all()
+    assert len(events) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_ingest_tradingview_economic_events_records_failure(db_session):
+    from app.models.market_events import MarketEventIngestionPartition
+    from app.services.market_events import ingestion
+
+    async def boom(d):
+        raise TimeoutError("tradingview fetch timed out")
+
+    result = await ingestion.ingest_tradingview_economic_events_for_date(
+        db_session, date(2026, 5, 13), fetch_rows=boom
+    )
+    await db_session.commit()
+
+    assert result.status == "failed"
+    assert "timed out" in (result.error or "")
+
+    parts = (
+        (await db_session.execute(select(MarketEventIngestionPartition)))
+        .scalars()
+        .all()
+    )
+    assert len(parts) == 1
+    assert parts[0].status == "failed"
+    assert parts[0].retry_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_ingest_tradingview_skips_unparseable_rows(db_session):
+    from app.models.market_events import MarketEvent
+    from app.services.market_events import ingestion
+
+    bad_row = {**TV_ROW, "title": ""}  # will raise ValueError in normalizer
+
+    async def fake_fetch(d):
+        return [bad_row, TV_ROW]
+
+    result = await ingestion.ingest_tradingview_economic_events_for_date(
+        db_session, date(2026, 5, 13), fetch_rows=fake_fetch
+    )
+    await db_session.commit()
+
+    assert result.status == "succeeded"
+    assert result.event_count == 1
+
+    events = (await db_session.execute(select(MarketEvent))).scalars().all()
+    assert len(events) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_ingest_tradingview_empty_fetch_succeeds_with_zero_count(db_session):
+    from app.services.market_events import ingestion
+
+    async def fake_fetch(d):
+        return []
+
+    result = await ingestion.ingest_tradingview_economic_events_for_date(
+        db_session, date(2026, 5, 13), fetch_rows=fake_fetch
+    )
+    await db_session.commit()
+
+    assert result.status == "succeeded"
+    assert result.event_count == 0

--- a/tests/services/test_tradingview_normalizer.py
+++ b/tests/services/test_tradingview_normalizer.py
@@ -1,0 +1,215 @@
+"""TradingView normalizer unit tests (ROB-210)."""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from decimal import Decimal
+
+import pytest
+
+TV_ROW_HIGH_IMPORTANCE = {
+    "id": "4b8e4f00-0e49-4a4a-b6e2-111111111111",
+    "title": "Core CPI m/m",
+    "country": "US",
+    "date_utc": datetime(2026, 5, 13, 12, 30, tzinfo=UTC),
+    "period": "Apr",
+    "actual": "0.3",
+    "forecast": "0.3",
+    "previous": "0.4",
+    "unit": "%",
+    "source": "Bureau of Labor Statistics",
+    "source_url": "https://www.bls.gov/cpi/",
+    "ticker": None,
+    "importance": 3,
+    "_raw": {
+        "id": "4b8e4f00-0e49-4a4a-b6e2-111111111111",
+        "title": "Core CPI m/m",
+        "country": "US",
+        "date": "2026-05-13T12:30:00Z",
+        "period": "Apr",
+        "actual": "0.3",
+        "forecast": "0.3",
+        "previous": "0.4",
+        "unit": "%",
+        "source": "Bureau of Labor Statistics",
+        "source_url": "https://www.bls.gov/cpi/",
+        "ticker": None,
+        "importance": 3,
+    },
+}
+
+TV_ROW_SCHEDULED = {
+    "id": "4b8e4f00-0e49-4a4a-b6e2-222222222222",
+    "title": "Industrial Production m/m",
+    "country": "DE",
+    "date_utc": datetime(2026, 5, 13, 6, 0, tzinfo=UTC),
+    "period": "Mar",
+    "actual": None,
+    "forecast": "-0.5",
+    "previous": "1.2",
+    "unit": "%",
+    "source": "Destatis",
+    "source_url": None,
+    "ticker": None,
+    "importance": 2,
+    "_raw": {
+        "id": "4b8e4f00-0e49-4a4a-b6e2-222222222222",
+        "title": "Industrial Production m/m",
+        "country": "DE",
+        "date": "2026-05-13T06:00:00Z",
+        "period": "Mar",
+        "actual": None,
+        "forecast": "-0.5",
+        "previous": "1.2",
+        "unit": "%",
+        "source": "Destatis",
+        "source_url": None,
+        "ticker": None,
+        "importance": 2,
+    },
+}
+
+
+@pytest.mark.unit
+def test_normalize_tradingview_released_event():
+    from app.services.market_events.normalizers import normalize_tradingview_event_row
+
+    event, values = normalize_tradingview_event_row(TV_ROW_HIGH_IMPORTANCE)
+
+    assert event["category"] == "economic"
+    assert event["market"] == "global"
+    assert event["country"] == "US"
+    assert event["title"] == "Core CPI m/m"
+    assert event["event_date"] == date(2026, 5, 13)
+    assert event["release_time_utc"] == datetime(2026, 5, 13, 12, 30, tzinfo=UTC)
+    assert event["source_timezone"] == "UTC"
+    assert event["time_hint"] == "unknown"
+    assert event["importance"] == 3
+    assert event["status"] == "released"
+    assert event["source"] == "tradingview"
+    assert event["source_event_id"] == "4b8e4f00-0e49-4a4a-b6e2-111111111111"
+    assert event["source_url"] == "https://www.bls.gov/cpi/"
+    assert event["fiscal_year"] is None
+    assert event["fiscal_quarter"] is None
+    assert event["symbol"] is None
+    assert event["currency"] is None
+
+
+@pytest.mark.unit
+def test_normalize_tradingview_released_event_produces_values():
+    from app.services.market_events.normalizers import normalize_tradingview_event_row
+
+    _, values = normalize_tradingview_event_row(TV_ROW_HIGH_IMPORTANCE)
+
+    assert len(values) == 1
+    v = values[0]
+    assert v["metric_name"] == "actual"
+    assert v["period"] == "Apr"
+    assert v["actual"] == Decimal("0.3")
+    assert v["forecast"] == Decimal("0.3")
+    assert v["previous"] == Decimal("0.4")
+    assert v["unit"] == "%"
+
+
+@pytest.mark.unit
+def test_normalize_tradingview_scheduled_when_no_actual():
+    from app.services.market_events.normalizers import normalize_tradingview_event_row
+
+    event, values = normalize_tradingview_event_row(TV_ROW_SCHEDULED)
+
+    assert event["status"] == "scheduled"
+    assert event["importance"] == 2
+    assert len(values) == 1
+    v = values[0]
+    assert v["actual"] is None
+    assert v["forecast"] == Decimal("-0.5")
+    assert v["previous"] == Decimal("1.2")
+
+
+@pytest.mark.unit
+def test_normalize_tradingview_scheduled_when_actual_is_dash():
+    from app.services.market_events.normalizers import normalize_tradingview_event_row
+
+    row = {**TV_ROW_HIGH_IMPORTANCE, "actual": "-"}
+    event, _ = normalize_tradingview_event_row(row)
+    assert event["status"] == "scheduled"
+
+
+@pytest.mark.unit
+def test_normalize_tradingview_importance_mapping():
+    from app.services.market_events.normalizers import normalize_tradingview_event_row
+
+    for raw, expected in [(1, 1), (2, 2), (3, 3), (0, None), (-1, None), (None, None)]:
+        row = {**TV_ROW_HIGH_IMPORTANCE, "importance": raw}
+        event, _ = normalize_tradingview_event_row(row)
+        assert event["importance"] == expected, f"importance={raw}"
+
+
+@pytest.mark.unit
+def test_normalize_tradingview_emits_no_values_when_all_blank():
+    from app.services.market_events.normalizers import normalize_tradingview_event_row
+
+    row = {**TV_ROW_HIGH_IMPORTANCE, "actual": None, "forecast": None, "previous": None}
+    _, values = normalize_tradingview_event_row(row)
+    assert values == []
+
+
+@pytest.mark.unit
+def test_normalize_tradingview_requires_title_and_date_utc():
+    from app.services.market_events.normalizers import normalize_tradingview_event_row
+
+    with pytest.raises(ValueError):
+        normalize_tradingview_event_row({**TV_ROW_HIGH_IMPORTANCE, "title": ""})
+
+    with pytest.raises(ValueError):
+        normalize_tradingview_event_row({**TV_ROW_HIGH_IMPORTANCE, "date_utc": None})
+
+
+@pytest.mark.unit
+def test_normalize_tradingview_fallback_source_event_id_when_no_id():
+    from app.services.market_events.normalizers import normalize_tradingview_event_row
+
+    row = {**TV_ROW_HIGH_IMPORTANCE, "id": None}
+    event, _ = normalize_tradingview_event_row(row)
+    assert event["source_event_id"].startswith("tv::US::Core CPI m/m::")
+    assert "2026-05-13T12:30:00Z" in event["source_event_id"]
+
+
+@pytest.mark.unit
+def test_normalize_tradingview_ticker_becomes_symbol():
+    from app.services.market_events.normalizers import normalize_tradingview_event_row
+
+    row = {**TV_ROW_HIGH_IMPORTANCE, "ticker": "AAPL"}
+    event, _ = normalize_tradingview_event_row(row)
+    assert event["symbol"] == "AAPL"
+
+
+@pytest.mark.unit
+def test_normalize_tradingview_raw_payload_excludes_internal_fields():
+    from app.services.market_events.normalizers import normalize_tradingview_event_row
+
+    event, _ = normalize_tradingview_event_row(TV_ROW_HIGH_IMPORTANCE)
+
+    raw = event["raw_payload_json"]
+    assert "_raw" not in raw
+    assert "date_utc" not in raw
+    assert raw["id"] == "4b8e4f00-0e49-4a4a-b6e2-111111111111"
+    assert raw["title"] == "Core CPI m/m"
+
+
+@pytest.mark.unit
+def test_normalize_tradingview_period_none_when_missing():
+    from app.services.market_events.normalizers import normalize_tradingview_event_row
+
+    row = {**TV_ROW_HIGH_IMPORTANCE, "period": None}
+    _, values = normalize_tradingview_event_row(row)
+    assert values[0]["period"] is None
+
+
+@pytest.mark.unit
+def test_normalize_tradingview_unit_none_when_missing():
+    from app.services.market_events.normalizers import normalize_tradingview_event_row
+
+    row = {**TV_ROW_HIGH_IMPORTANCE, "unit": None}
+    _, values = normalize_tradingview_event_row(row)
+    assert values[0]["unit"] is None

--- a/tests/test_invest_calendar_router.py
+++ b/tests/test_invest_calendar_router.py
@@ -26,6 +26,7 @@ def _fake_event(
     forecast: object | None = None,
     previous: object | None = None,
     values: list[object] | None = None,
+    source: str = "test",
 ):
     e = MagicMock()
     # MarketEventResponse uses source_event_id, not event_id
@@ -38,7 +39,7 @@ def _fake_event(
     e.title = f"event {event_id}" if title is None else title
     e.event_date = ev_date or date(2026, 5, 4)
     e.release_time_utc = release_time_utc
-    e.source = "test"
+    e.source = source
     if values is not None:
         e.values = values
     elif actual is not None or forecast is not None or previous is not None:
@@ -438,3 +439,100 @@ async def test_calendar_marks_loaded_when_events_present(monkeypatch) -> None:
         tab="all",
     )
     assert resp.days[0].dataState == "loaded"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_calendar_prefers_tradingview_over_forexfactory_duplicate(
+    monkeypatch,
+) -> None:
+    from app.services.invest_view_model import calendar_service as svc
+
+    fake_resp = MagicMock()
+    fake_resp.events = [
+        _fake_event(
+            event_id="ff-cpi",
+            category="economic",
+            market="global",
+            source="forexfactory",
+            title="US CPI",
+            actual=None,
+            forecast="0.3",
+            previous="0.2",
+        ),
+        _fake_event(
+            event_id="tv-cpi",
+            category="economic",
+            market="global",
+            source="tradingview",
+            title="US CPI",
+            actual="0.4",
+            forecast="0.3",
+            previous="0.2",
+        ),
+    ]
+    fake_query_service = MagicMock()
+    fake_query_service.list_for_range = AsyncMock(return_value=fake_resp)
+    monkeypatch.setattr(svc, "MarketEventsQueryService", lambda db: fake_query_service)
+    _patch_freshness(monkeypatch, svc, date(2026, 5, 4), date(2026, 5, 4))
+
+    resp = await svc.build_calendar(
+        db=MagicMock(),
+        resolver=RelationResolver(),
+        from_date=date(2026, 5, 4),
+        to_date=date(2026, 5, 4),
+        tab="economic",
+    )
+
+    events = resp.days[0].events
+    assert len(events) == 1
+    assert events[0].eventId == "tv-cpi"
+    assert events[0].source == "tradingview"
+    assert events[0].actual == "0.4"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_calendar_keeps_forexfactory_when_tradingview_missing(
+    monkeypatch,
+) -> None:
+    from app.services.invest_view_model import calendar_service as svc
+
+    fake_resp = MagicMock()
+    fake_resp.events = [
+        _fake_event(
+            event_id="ff-cpi",
+            category="economic",
+            market="global",
+            source="forexfactory",
+            title="US CPI",
+            actual=None,
+            forecast="0.3",
+            previous="0.2",
+        ),
+        _fake_event(
+            event_id="ff-jobs",
+            category="economic",
+            market="global",
+            source="forexfactory",
+            title="US Nonfarm Payrolls",
+            actual="175",
+            forecast="170",
+            previous="165",
+        ),
+    ]
+    fake_query_service = MagicMock()
+    fake_query_service.list_for_range = AsyncMock(return_value=fake_resp)
+    monkeypatch.setattr(svc, "MarketEventsQueryService", lambda db: fake_query_service)
+    _patch_freshness(monkeypatch, svc, date(2026, 5, 4), date(2026, 5, 4))
+
+    resp = await svc.build_calendar(
+        db=MagicMock(),
+        resolver=RelationResolver(),
+        from_date=date(2026, 5, 4),
+        to_date=date(2026, 5, 4),
+        tab="economic",
+    )
+
+    event_ids = [event.eventId for event in resp.days[0].events]
+    assert event_ids == ["ff-cpi", "ff-jobs"]

--- a/tests/test_market_events_cli.py
+++ b/tests/test_market_events_cli.py
@@ -410,3 +410,53 @@ async def test_cli_dry_run_does_not_call_forexfactory_fetch(monkeypatch):
     )
     assert rc == 0
     assert called["n"] == 0
+
+
+@pytest.mark.unit
+def test_parse_args_accepts_tradingview_economic_global():
+    from scripts.ingest_market_events import parse_args
+
+    ns = parse_args(
+        [
+            "--source",
+            "tradingview",
+            "--category",
+            "economic",
+            "--market",
+            "global",
+            "--from-date",
+            "2026-05-13",
+            "--to-date",
+            "2026-05-13",
+            "--dry-run",
+        ]
+    )
+    assert ns.source == "tradingview"
+    assert ns.category == "economic"
+    assert ns.market == "global"
+    assert ns.dry_run is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_run_ingest_dispatches_tradingview_economic_global(
+    db_session, monkeypatch
+):
+    from scripts import ingest_market_events as cli
+
+    fake = AsyncMock(
+        return_value=type("R", (), {"status": "succeeded", "event_count": 2})()
+    )
+    monkeypatch.setitem(cli.SUPPORTED, ("tradingview", "economic", "global"), fake)
+
+    rc = await cli.run_ingest(
+        db=db_session,
+        source="tradingview",
+        category="economic",
+        market="global",
+        from_date=date(2026, 5, 13),
+        to_date=date(2026, 5, 13),
+        dry_run=False,
+    )
+    assert rc == 0
+    fake.assert_awaited_once_with(db_session, date(2026, 5, 13))


### PR DESCRIPTION
## Summary
- Add a TradingView economic-calendar provider/normalizer for macro events.
- Preserve structured `actual`, `forecast`, `previous`, `period`, `unit`, `ticker`, and provider metadata.
- Wire TradingView ingestion into the market-events CLI and prefer TradingView rows in `/invest/calendar` while keeping ForexFactory as fallback/cross-check.

## Scope / safety
- No broker/order/watch/order-intent/live/paper trading side effects.
- No production DB writes, production backfill, or recurring scheduler activation in this PR.
- TradingView endpoint is treated as an internal web endpoint, not an official public API.

## Local verification
- `uv run pytest tests/services/test_tradingview_helpers.py tests/services/test_tradingview_normalizer.py tests/services/test_tradingview_ingestion.py tests/test_market_events_cli.py tests/test_invest_calendar_router.py -m "not live"`
- `uv run ruff check app/services/market_events/tradingview_helpers.py app/services/market_events/ingestion.py app/services/market_events/normalizers.py app/services/invest_view_model/calendar_service.py scripts/ingest_market_events.py tests/services/test_tradingview_helpers.py tests/services/test_tradingview_normalizer.py tests/services/test_tradingview_ingestion.py tests/test_market_events_cli.py tests/test_invest_calendar_router.py`
- `uv run ruff format --check app/services/market_events/tradingview_helpers.py app/services/market_events/ingestion.py app/services/market_events/normalizers.py app/services/invest_view_model/calendar_service.py scripts/ingest_market_events.py tests/services/test_tradingview_helpers.py tests/services/test_tradingview_normalizer.py tests/services/test_tradingview_ingestion.py tests/test_market_events_cli.py tests/test_invest_calendar_router.py`

Linear: ROB-210


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ingesting TradingView economic calendar events.
  * Calendar now deduplicates same-day economic events from multiple providers and prefers TradingView over ForexFactory when duplicates occur.

* **Tests**
  * Added unit and integration tests covering TradingView fetching, normalization, ingestion, deduplication, idempotency, error handling, and calendar integration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/801)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->