### PR TITLE
fix: send TradingView calendar browser origin headers

### DIFF
--- a/app/services/market_events/tradingview_helpers.py
+++ b/app/services/market_events/tradingview_helpers.py
@@ -21,6 +21,17 @@ import httpx
 logger = logging.getLogger(__name__)
 
 TRADINGVIEW_CALENDAR_URL = "https://economic-calendar.tradingview.com/events"
+TRADINGVIEW_CALENDAR_HEADERS = {
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "en-US,en;q=0.9,ko;q=0.8",
+    "Origin": "https://www.tradingview.com",
+    "Referer": "https://www.tradingview.com/economic-calendar/",
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/124.0.0.0 Safari/537.36"
+    ),
+}
 
 
 async def _fetch_tradingview_raw(from_date: date, to_date: date) -> Any:
@@ -34,7 +45,11 @@ async def _fetch_tradingview_raw(from_date: date, to_date: date) -> Any:
         "country": "all",
     }
     async with httpx.AsyncClient(timeout=15.0) as client:
-        response = await client.get(TRADINGVIEW_CALENDAR_URL, params=params)
+        response = await client.get(
+            TRADINGVIEW_CALENDAR_URL,
+            params=params,
+            headers=TRADINGVIEW_CALENDAR_HEADERS,
+        )
         response.raise_for_status()
         return response.json()
 

--- a/tests/services/test_tradingview_helpers.py
+++ b/tests/services/test_tradingview_helpers.py
@@ -153,6 +153,46 @@ async def test_fetch_tradingview_raises_on_network_error():
             await tv.fetch_tradingview_events_for_date(date(2026, 5, 13))
 
 
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_fetch_tradingview_raw_sends_browser_origin_headers():
+    from app.services.market_events import tradingview_helpers as tv
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"status": "ok", "result": []}
+
+    class FakeClient:
+        def __init__(self):
+            self.calls = []
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, *, params=None, headers=None):
+            self.calls.append({"url": url, "params": params, "headers": headers})
+            return FakeResponse()
+
+    fake_client = FakeClient()
+    with patch.object(tv.httpx, "AsyncClient", return_value=fake_client):
+        payload = await tv._fetch_tradingview_raw(date(2026, 5, 13), date(2026, 5, 13))
+
+    assert payload == {"status": "ok", "result": []}
+    assert fake_client.calls[0]["url"] == tv.TRADINGVIEW_CALENDAR_URL
+    assert fake_client.calls[0]["headers"]["Origin"] == "https://www.tradingview.com"
+    assert (
+        fake_client.calls[0]["headers"]["Referer"]
+        == "https://www.tradingview.com/economic-calendar/"
+    )
+    assert "Mozilla/5.0" in fake_client.calls[0]["headers"]["User-Agent"]
+
+
 @pytest.mark.unit
 def test_parse_tv_rows_skips_items_without_parseable_date():
     from app.services.market_events.tradingview_helpers import _parse_tv_rows


### PR DESCRIPTION
## Summary
- Adds TradingView economic-calendar request headers (`Origin`, `Referer`, UA, Accept) required by the endpoint.
- Adds a regression unit test asserting the helper sends browser-origin headers.

## Root cause
The endpoint returns HTTP 403 for bare server-side requests. A minimal curl probe showed the same URL returns HTTP 200 when `Origin: https://www.tradingview.com` and `Referer: https://www.tradingview.com/economic-calendar/` are present.

## Verification
- `uv run --group test pytest tests/services/test_tradingview_helpers.py -q` → 10 passed
- `uv run --group dev ruff check app/services/market_events/tradingview_helpers.py tests/services/test_tradingview_helpers.py` → passed
- Live read-only helper probe returned `status ok count 111` for 2026-05-13

## Safety
Read-only provider request change only. No broker/order/watch mutations, no production DB writes, no backfill, no scheduler activation.

Refs ROB-210


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of TradingView market event data fetching by enhancing request compatibility.

* **Tests**
  * Added validation for market event data retrieval requests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/802)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->