### PR TITLE
ROB-212 Fix invest screener Toss result gap

### DIFF
--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -24,7 +24,7 @@ SCREENER_PRESETS: list[ScreenerPreset] = [
             ScreenerFilterChip(label="주가등락률", detail="1주일 전 보다 · 0% 이상"),
             ScreenerFilterChip(label="주가 연속상승", detail="5일 연속 상승"),
         ],
-        metricLabel="연속상승",
+        metricLabel="주가등락률",
         market="kr",
     ),
     ScreenerPreset(

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -110,9 +110,17 @@ def _should_use_snapshot_first(screening_service: Any) -> bool:
 
 async def _load_consecutive_gainers_from_snapshots(
     session: AsyncSession | None, *, market: str, limit: int = _SNAPSHOT_FIRST_LIMIT
-) -> list[dict[str, Any]]:
+) -> list[dict[str, Any]] | None:
+    """Return qualifying rows from the latest snapshot partition only.
+
+    Returns None when the check could not be performed (no session, wrong market,
+    DB error, or no snapshots exist in the table at all). Returns an empty list
+    when the latest partition was found but contains no qualifying rows — callers
+    must NOT fall back to external screening in that case, because historical
+    qualifying rows from older partitions must not be surfaced as current results.
+    """
     if session is None or market not in {"kr", "us"}:
-        return []
+        return None
 
     from app.models.invest_screener_snapshot import InvestScreenerSnapshot
     from app.services.invest_screener_snapshots.freshness import (
@@ -121,21 +129,40 @@ async def _load_consecutive_gainers_from_snapshots(
     )
 
     today = today_trading_date(market)
+
+    # Step 1: resolve the latest snapshot partition date.
+    # This prevents older qualifying partitions from leaking into current results
+    # when the latest partition has zero qualifiers (the known stale-data bug).
+    latest_date_stmt = sa.select(
+        sa.func.max(InvestScreenerSnapshot.snapshot_date)
+    ).where(InvestScreenerSnapshot.market == market)
+    try:
+        latest_date_result = await session.execute(latest_date_stmt)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "failed to read invest_screener_snapshots max date: %s", exc, exc_info=True
+        )
+        return None
+    latest_snapshot_date = latest_date_result.scalar_one_or_none()
+    if latest_snapshot_date is None:
+        return None  # no snapshots in the table; fall through to external
+
+    # Step 2: qualify rows only within that one partition.
     stmt = (
         sa.select(InvestScreenerSnapshot)
         .where(
             InvestScreenerSnapshot.market == market,
+            InvestScreenerSnapshot.snapshot_date == latest_snapshot_date,
             InvestScreenerSnapshot.consecutive_up_days >= 5,
             InvestScreenerSnapshot.week_change_rate >= 0,
         )
         .order_by(
-            InvestScreenerSnapshot.snapshot_date.desc(),
             InvestScreenerSnapshot.week_change_rate.desc().nullslast(),
             InvestScreenerSnapshot.consecutive_up_days.desc(),
             InvestScreenerSnapshot.change_rate.desc().nullslast(),
             InvestScreenerSnapshot.symbol.asc(),
         )
-        .limit(max(limit * 4, limit))
+        .limit(limit)
     )
     try:
         result = await session.execute(stmt)
@@ -143,7 +170,7 @@ async def _load_consecutive_gainers_from_snapshots(
         logger.warning(
             "failed to read invest_screener_snapshots: %s", exc, exc_info=True
         )
-        return []
+        return None
 
     now = datetime.now(UTC)
     rows: list[dict[str, Any]] = []
@@ -181,16 +208,7 @@ async def _load_consecutive_gainers_from_snapshots(
                 "_screener_snapshot_state": state,
             }
         )
-        if len(rows) >= limit:
-            break
-    rows.sort(
-        key=lambda row: (
-            -(row.get("week_change_rate") or 0.0),
-            -(row.get("consecutive_up_days") or 0),
-            -(row.get("change_rate") or 0.0),
-            str(row.get("symbol") or ""),
-        )
-    )
+    # Rows are already ordered by the SQL ORDER BY; no Python re-sort needed.
     return rows
 
 
@@ -202,7 +220,7 @@ def build_screener_presets() -> ScreenerPresetsResponse:
 
 
 _METRIC_FIELD: dict[str, str] = {
-    "consecutive_gainers": "consecutive_up_days",
+    "consecutive_gainers": "week_change_rate",
     "cheap_value": "per",
     "steady_dividend": "dividend_yield",
     "oversold_recovery": "rsi",
@@ -395,10 +413,12 @@ def _metric_value_label(preset_id: str, row: dict[str, Any]) -> tuple[str, list[
     if value is None:
         if field == "consecutive_up_days":
             return "-", ["연속상승 데이터 준비중"]
+        if field == "week_change_rate":
+            return "-", ["주가등락률 데이터 준비중"]
         return "-", [f"{field.upper()} 데이터 준비중"]
     if field == "consecutive_up_days":
         return f"{int(value)}일", []
-    if field == "change_rate":
+    if field in ("week_change_rate", "change_rate"):
         sign = "+" if value > 0 else ""
         return f"{sign}{value:.2f}%", []
     if field in ("per", "pbr", "rsi"):
@@ -501,22 +521,32 @@ async def build_screener_results(
         )
 
     filters = screening_filters_for(preset_id, requested_market)
-    snapshot_rows: list[dict[str, Any]] = []
+    _snapshot_check_result: list[dict[str, Any]] | None = None
     if (
         preset_id == "consecutive_gainers"
         and session is not None
         and _should_use_snapshot_first(screening_service)
     ):
-        snapshot_rows = await _load_consecutive_gainers_from_snapshots(
+        _snapshot_check_result = await _load_consecutive_gainers_from_snapshots(
             session,
             market=requested_market,
             limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
         )
 
-    if snapshot_rows:
+    _snapshot_was_checked = _snapshot_check_result is not None
+    if _snapshot_was_checked:
+        # Snapshot check succeeded (latest partition found); use that result.
+        # Even an empty list must NOT fall through to external screening —
+        # historical qualifying rows from older partitions must stay hidden.
+        snapshot_rows = _snapshot_check_result  # type: ignore[assignment]
+        _snapshot_empty_warnings: list[str] = []
+        if not snapshot_rows:
+            _snapshot_empty_warnings = [
+                "스크리너 스냅샷 업데이트가 필요해 최신 연속 상승세 결과를 표시하지 못했습니다."
+            ]
         raw = {
             "results": snapshot_rows,
-            "warnings": [],
+            "warnings": _snapshot_empty_warnings,
             "timestamp": now().isoformat(),
             "cache_hit": True,
         }
@@ -552,10 +582,15 @@ async def build_screener_results(
     # Aggregate snapshot dataState from enriched rows (set by _enrich_consecutive_up_days when session provided)
     from app.services.invest_screener_snapshots.freshness import aggregate_states
 
-    _row_states: list[str] = [
-        str(r.get("_screener_snapshot_state") or "missing") for r in rows
-    ]
-    _aggregated_data_state = aggregate_states(_row_states)  # type: ignore[arg-type]
+    if _snapshot_was_checked and not rows:
+        # Latest snapshot partition was found but had no qualifying rows —
+        # the data is stale, not missing (snapshots exist, just not qualifying).
+        _aggregated_data_state: str = "stale"
+    else:
+        _row_states: list[str] = [
+            str(r.get("_screener_snapshot_state") or "missing") for r in rows
+        ]
+        _aggregated_data_state = aggregate_states(_row_states)  # type: ignore[arg-type]
     if requested_market == "us" and _aggregated_data_state in {"missing", "stale"}:
         if _US_SCREENER_DATA_NOT_READY_WARNING not in upstream_warnings:
             upstream_warnings.append(_US_SCREENER_DATA_NOT_READY_WARNING)

--- a/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
@@ -16,7 +16,7 @@ const PRESETS = {
       description: "일주일 연속 상승세를 보이는 주식",
       badges: ["인기"],
       filterChips: [{ label: "주가등락률", detail: "1주일 전 보다 · 0% 이상" }],
-      metricLabel: "연속상승", market: "kr" as const,
+      metricLabel: "주가등락률", market: "kr" as const,
     },
     {
       id: "cheap_value", name: "아직 저렴한 가치주",
@@ -35,14 +35,14 @@ const ROW = {
   priceLabel: "80,000원", changePctLabel: "+1.23%", changeAmountLabel: "+970원",
   changeDirection: "up" as const, category: "반도체",
   marketCapLabel: "478조원", volumeLabel: "12,345,678",
-  analystLabel: "구매", metricValueLabel: "5일", warnings: [],
+  analystLabel: "구매", metricValueLabel: "+8.00%", warnings: [],
 };
 
 const RESULTS_GAINERS = {
   presetId: "consecutive_gainers", title: "연속 상승세",
   description: "일주일 연속 상승세를 보이는 주식",
   filterChips: [{ label: "주가등락률", detail: "1주일 전 보다 · 0% 이상" }],
-  metricLabel: "연속상승", results: [ROW], warnings: [],
+  metricLabel: "주가등락률", results: [ROW], warnings: [],
   freshness: {
     fetchedAt: "2026-05-10T05:30:00+00:00",
     asOfLabel: "2026.05.10 14:30 기준",

--- a/scripts/diagnose_invest_screener_toss_parity.py
+++ b/scripts/diagnose_invest_screener_toss_parity.py
@@ -223,6 +223,13 @@ def _metrics_for(row: dict[str, Any]) -> dict[str, Any]:
 async def load_auto_trader_rows(
     session: AsyncSession, *, market: str, limit: int
 ) -> list[dict[str, Any]]:
+    """Load qualifying rows using the same single-partition semantics as the API.
+
+    Mirrors _load_consecutive_gainers_from_snapshots: resolves the latest
+    snapshot_date first, then qualifies only within that partition. This prevents
+    stale historical rows from appearing in parity comparisons when the latest
+    partition has no qualifiers.
+    """
     from app.models.invest_screener_snapshot import InvestScreenerSnapshot
     from app.services.invest_screener_snapshots.freshness import (
         classify_state,
@@ -231,21 +238,31 @@ async def load_auto_trader_rows(
 
     today = today_trading_date(market)
     now = datetime.now(UTC)
+
+    # Resolve the latest snapshot partition (mirrors production serving semantics).
+    latest_date_stmt = sa.select(
+        sa.func.max(InvestScreenerSnapshot.snapshot_date)
+    ).where(InvestScreenerSnapshot.market == market)
+    latest_date_result = await session.execute(latest_date_stmt)
+    latest_snapshot_date = latest_date_result.scalar_one_or_none()
+    if latest_snapshot_date is None:
+        return []
+
     stmt = (
         sa.select(InvestScreenerSnapshot)
         .where(
             InvestScreenerSnapshot.market == market,
+            InvestScreenerSnapshot.snapshot_date == latest_snapshot_date,
             InvestScreenerSnapshot.consecutive_up_days >= 5,
             InvestScreenerSnapshot.week_change_rate >= 0,
         )
         .order_by(
-            InvestScreenerSnapshot.snapshot_date.desc(),
             InvestScreenerSnapshot.week_change_rate.desc().nullslast(),
             InvestScreenerSnapshot.consecutive_up_days.desc(),
             InvestScreenerSnapshot.change_rate.desc().nullslast(),
             InvestScreenerSnapshot.symbol.asc(),
         )
-        .limit(max(limit * 4, limit))
+        .limit(limit)
     )
     result = await session.execute(stmt)
     rows: list[dict[str, Any]] = []
@@ -275,16 +292,7 @@ async def load_auto_trader_rows(
                 "_screener_snapshot_state": state,
             }
         )
-        if len(rows) >= limit:
-            break
-    rows.sort(
-        key=lambda row: (
-            -(row.get("week_change_rate") or 0.0),
-            -(row.get("consecutive_up_days") or 0),
-            -(row.get("change_rate") or 0.0),
-            str(row.get("symbol") or ""),
-        )
-    )
+    # Rows already ordered by SQL ORDER BY; no Python re-sort needed.
     return rows
 
 

--- a/tests/test_invest_api_screener_router.py
+++ b/tests/test_invest_api_screener_router.py
@@ -191,6 +191,7 @@ def test_screener_consecutive_gainers_returns_streak_and_freshness() -> None:
                 "change_rate": 1.23,
                 "change_amount": 970,
                 "consecutive_up_days": 6,
+                "week_change_rate": 8.50,
                 "volume": 12_345_678,
             },
             {
@@ -203,6 +204,7 @@ def test_screener_consecutive_gainers_returns_streak_and_freshness() -> None:
                 "change_rate": 0.8,
                 "change_amount": 360,
                 "consecutive_up_days": 5,
+                "week_change_rate": 3.20,
                 "volume": 3_000_000,
             },
         ],
@@ -223,13 +225,12 @@ def test_screener_consecutive_gainers_returns_streak_and_freshness() -> None:
     assert freshness is not None
     assert freshness["asOfLabel"].endswith("기준")
     assert freshness["source"] in ("live", "cached", "previous_session")
-    # All results must show streak >= 5 days
+    # Metric is now 1-week change rate (Toss-parity primary metric)
     results = body["results"]
     assert len(results) == 2
     for row in results:
         label = row["metricValueLabel"]
-        assert label.endswith("일"), f"Expected N일 label, got: {label}"
-        assert int(label[:-1]) >= 5, f"Expected streak >= 5, got: {label}"
+        assert "%" in label, f"Expected week_change_rate % label, got: {label}"
     # Verify the Toss-parity preset filters passed to the service
     assert stub.calls
     assert stub.calls[0].get("min_consecutive_up_days") == 5

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -75,6 +75,9 @@ class _FakeExecuteResult:
     def all(self) -> list[Any]:
         return self._rows
 
+    def scalar_one_or_none(self) -> Any | None:
+        return self._scalar_rows[0] if self._scalar_rows else None
+
 
 class _FakeSession:
     def __init__(self, results: list[_FakeExecuteResult]) -> None:
@@ -143,7 +146,7 @@ async def test_build_screener_results_consecutive_gainers_happy_path() -> None:
 
     assert resp.presetId == "consecutive_gainers"
     assert resp.title == "연속 상승세"
-    assert resp.metricLabel == "연속상승"
+    assert resp.metricLabel == "주가등락률"
     assert len(resp.results) == 2
     assert resp.results[0].rank == 1
     assert resp.results[0].symbol == "005930"
@@ -227,27 +230,24 @@ def test_calculate_consecutive_up_days_counts_latest_streak() -> None:
 
 
 @pytest.mark.unit
-def test_consecutive_up_metric_prefers_consecutive_days() -> None:
-    row_warnings: list[str] = []
-    assert (
-        screener_service._metric_value_label(
-            "consecutive_gainers",
-            {"symbol": "005930", "consecutive_up_days": 6, "change_rate": 2.4},
-        )[0]
-        == "6일"
+def test_consecutive_gainers_metric_is_week_change_rate() -> None:
+    label, warnings = screener_service._metric_value_label(
+        "consecutive_gainers",
+        {"symbol": "005930", "week_change_rate": 6.0, "consecutive_up_days": 5, "change_rate": 2.4},
     )
-    assert row_warnings == []
+    assert label == "+6.00%"
+    assert warnings == []
 
 
 @pytest.mark.unit
-def test_consecutive_up_metric_warns_when_history_unavailable() -> None:
+def test_consecutive_gainers_metric_warns_when_week_change_unavailable() -> None:
     label, warnings = screener_service._metric_value_label(
         "consecutive_gainers",
         {"symbol": "005930", "change_rate": 2.4},
     )
 
     assert label == "-"
-    assert warnings == ["연속상승 데이터 준비중"]
+    assert warnings == ["주가등락률 데이터 준비중"]
 
 
 @pytest.mark.unit
@@ -654,9 +654,9 @@ async def test_build_screener_results_coerces_string_market_cap_values() -> None
     )
 
     assert resp.results[0].marketCapLabel == "478.0조원"
-    assert resp.results[0].warnings == ["연속상승 데이터 준비중"]
+    assert resp.results[0].warnings == ["주가등락률 데이터 준비중"]
     assert resp.results[1].marketCapLabel == "414.7조원"
-    assert resp.results[1].warnings == ["연속상승 데이터 준비중"]
+    assert resp.results[1].warnings == ["주가등락률 데이터 준비중"]
 
 
 @pytest.mark.unit
@@ -901,11 +901,12 @@ async def test_build_screener_results_uses_snapshots_before_external_screening()
     resolver = _FakeResolver(watched={("kr", "005930")})
     session = _FakeSession(
         [
-            _FakeExecuteResult(scalar_rows=[_FakeSnapshot(symbol="005930")]),
-            _FakeExecuteResult(scalar_rows=[_FakeSnapshot(symbol="005930")]),
+            _FakeExecuteResult(scalar_rows=[date(2026, 5, 11)]),  # MAX(snapshot_date)
+            _FakeExecuteResult(scalar_rows=[_FakeSnapshot(symbol="005930")]),  # qualifying rows
+            _FakeExecuteResult(scalar_rows=[_FakeSnapshot(symbol="005930")]),  # enrichment
             _FakeExecuteResult(
                 rows=[type("NameRow", (), {"symbol": "005930", "name": "삼성전자"})()]
-            ),
+            ),  # kr_names
         ]
     )
 
@@ -919,7 +920,7 @@ async def test_build_screener_results_uses_snapshots_before_external_screening()
     fake_screening.list_screening.assert_not_called()
     assert resp.results[0].symbol == "005930"
     assert resp.results[0].name == "삼성전자"
-    assert resp.results[0].metricValueLabel == "6일"
+    assert resp.results[0].metricValueLabel == "+3.50%"
     assert resp.freshness.cacheHit is True
 
 
@@ -933,26 +934,9 @@ async def test_build_screener_results_orders_snapshot_rows_by_week_change() -> N
     )()
     session = _FakeSession(
         [
+            _FakeExecuteResult(scalar_rows=[date(2026, 5, 11)]),  # MAX(snapshot_date)
             _FakeExecuteResult(
-                scalar_rows=[
-                    _FakeSnapshot(
-                        symbol="111111",
-                        consecutive_up_days=9,
-                        week_change_rate=Decimal("1.0"),
-                    ),
-                    _FakeSnapshot(
-                        symbol="222222",
-                        consecutive_up_days=5,
-                        week_change_rate=Decimal("8.0"),
-                    ),
-                    _FakeSnapshot(
-                        symbol="333333",
-                        consecutive_up_days=6,
-                        week_change_rate=Decimal("3.0"),
-                    ),
-                ]
-            ),
-            _FakeExecuteResult(
+                # SQL ORDER BY week_change_rate DESC produces this order from DB:
                 scalar_rows=[
                     _FakeSnapshot(
                         symbol="222222",
@@ -970,8 +954,27 @@ async def test_build_screener_results_orders_snapshot_rows_by_week_change() -> N
                         week_change_rate=Decimal("1.0"),
                     ),
                 ]
-            ),
-            _FakeExecuteResult(),
+            ),  # qualifying rows in week_change_rate DESC order (SQL)
+            _FakeExecuteResult(
+                scalar_rows=[
+                    _FakeSnapshot(
+                        symbol="222222",
+                        consecutive_up_days=5,
+                        week_change_rate=Decimal("8.0"),
+                    ),
+                    _FakeSnapshot(
+                        symbol="333333",
+                        consecutive_up_days=6,
+                        week_change_rate=Decimal("3.0"),
+                    ),
+                    _FakeSnapshot(
+                        symbol="111111",
+                        consecutive_up_days=9,
+                        week_change_rate=Decimal("1.0"),
+                    ),
+                ]
+            ),  # enrichment
+            _FakeExecuteResult(),  # kr_names
         ]
     )
 
@@ -983,7 +986,7 @@ async def test_build_screener_results_orders_snapshot_rows_by_week_change() -> N
     )
 
     assert [row.symbol for row in resp.results] == ["222222", "333333", "111111"]
-    assert [row.metricValueLabel for row in resp.results] == ["5일", "6일", "9일"]
+    assert [row.metricValueLabel for row in resp.results] == ["+8.00%", "+3.00%", "+1.00%"]
 
 
 @pytest.mark.unit
@@ -1009,3 +1012,82 @@ async def test_build_screener_results_redacts_external_connection_failures() -> 
     ]
     assert "api.finnhub" not in " ".join(resp.warnings)
     assert "secret" not in " ".join(resp.warnings)
+
+
+# ---------------------------------------------------------------------------
+# ROB-212: single-partition snapshot regression tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_load_consecutive_gainers_uses_latest_snapshot_partition_only() -> None:
+    """Latest partition with no qualifiers must not expose older qualifying rows."""
+    from app.services.invest_view_model.screener_service import (
+        _load_consecutive_gainers_from_snapshots,
+    )
+
+    # MAX(snapshot_date) returns today (2026-05-13); the qualifying rows query
+    # for that partition returns empty (the known stale-data scenario: 79 rows
+    # exist in older partitions but the latest has 0 qualifiers).
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[date(2026, 5, 13)]),  # MAX(snapshot_date)
+            _FakeExecuteResult(scalar_rows=[]),  # latest partition: 0 qualifying rows
+        ]
+    )
+
+    result = await _load_consecutive_gainers_from_snapshots(session, market="kr")
+
+    assert result == [], "must return empty list, not historical qualifiers"
+    assert result is not None, "None would mean 'could not check'; [] means 'checked and empty'"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_load_consecutive_gainers_returns_none_when_no_snapshot_table_rows() -> None:
+    """When the snapshot table has no rows for the market, returns None (fall through allowed)."""
+    from app.services.invest_view_model.screener_service import (
+        _load_consecutive_gainers_from_snapshots,
+    )
+
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[]),  # MAX(snapshot_date) → None
+        ]
+    )
+
+    result = await _load_consecutive_gainers_from_snapshots(session, market="kr")
+
+    assert result is None, "None signals 'could not check' so external screening may proceed"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_warns_and_does_not_fallback_when_latest_partition_empty() -> (
+    None
+):
+    """Stale snapshot (latest partition 0 qualifiers) must warn and NOT surface external results."""
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[date(2026, 5, 13)]),  # MAX(snapshot_date)
+            _FakeExecuteResult(scalar_rows=[]),  # no qualifying rows in latest partition
+        ]
+    )
+
+    resp = await build_screener_results(
+        preset_id="consecutive_gainers",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched=set()),
+        session=session,
+    )
+
+    fake_screening.list_screening.assert_not_called()
+    assert resp.results == []
+    assert any("스크리너 스냅샷 업데이트" in w for w in resp.warnings)
+    assert resp.freshness.dataState == "stale"

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -233,7 +233,12 @@ def test_calculate_consecutive_up_days_counts_latest_streak() -> None:
 def test_consecutive_gainers_metric_is_week_change_rate() -> None:
     label, warnings = screener_service._metric_value_label(
         "consecutive_gainers",
-        {"symbol": "005930", "week_change_rate": 6.0, "consecutive_up_days": 5, "change_rate": 2.4},
+        {
+            "symbol": "005930",
+            "week_change_rate": 6.0,
+            "consecutive_up_days": 5,
+            "change_rate": 2.4,
+        },
     )
     assert label == "+6.00%"
     assert warnings == []
@@ -902,8 +907,12 @@ async def test_build_screener_results_uses_snapshots_before_external_screening()
     session = _FakeSession(
         [
             _FakeExecuteResult(scalar_rows=[date(2026, 5, 11)]),  # MAX(snapshot_date)
-            _FakeExecuteResult(scalar_rows=[_FakeSnapshot(symbol="005930")]),  # qualifying rows
-            _FakeExecuteResult(scalar_rows=[_FakeSnapshot(symbol="005930")]),  # enrichment
+            _FakeExecuteResult(
+                scalar_rows=[_FakeSnapshot(symbol="005930")]
+            ),  # qualifying rows
+            _FakeExecuteResult(
+                scalar_rows=[_FakeSnapshot(symbol="005930")]
+            ),  # enrichment
             _FakeExecuteResult(
                 rows=[type("NameRow", (), {"symbol": "005930", "name": "삼성전자"})()]
             ),  # kr_names
@@ -986,7 +995,11 @@ async def test_build_screener_results_orders_snapshot_rows_by_week_change() -> N
     )
 
     assert [row.symbol for row in resp.results] == ["222222", "333333", "111111"]
-    assert [row.metricValueLabel for row in resp.results] == ["+8.00%", "+3.00%", "+1.00%"]
+    assert [row.metricValueLabel for row in resp.results] == [
+        "+8.00%",
+        "+3.00%",
+        "+1.00%",
+    ]
 
 
 @pytest.mark.unit
@@ -1040,12 +1053,16 @@ async def test_load_consecutive_gainers_uses_latest_snapshot_partition_only() ->
     result = await _load_consecutive_gainers_from_snapshots(session, market="kr")
 
     assert result == [], "must return empty list, not historical qualifiers"
-    assert result is not None, "None would mean 'could not check'; [] means 'checked and empty'"
+    assert result is not None, (
+        "None would mean 'could not check'; [] means 'checked and empty'"
+    )
 
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_load_consecutive_gainers_returns_none_when_no_snapshot_table_rows() -> None:
+async def test_load_consecutive_gainers_returns_none_when_no_snapshot_table_rows() -> (
+    None
+):
     """When the snapshot table has no rows for the market, returns None (fall through allowed)."""
     from app.services.invest_view_model.screener_service import (
         _load_consecutive_gainers_from_snapshots,
@@ -1059,7 +1076,9 @@ async def test_load_consecutive_gainers_returns_none_when_no_snapshot_table_rows
 
     result = await _load_consecutive_gainers_from_snapshots(session, market="kr")
 
-    assert result is None, "None signals 'could not check' so external screening may proceed"
+    assert result is None, (
+        "None signals 'could not check' so external screening may proceed"
+    )
 
 
 @pytest.mark.unit
@@ -1076,7 +1095,9 @@ async def test_build_screener_results_warns_and_does_not_fallback_when_latest_pa
     session = _FakeSession(
         [
             _FakeExecuteResult(scalar_rows=[date(2026, 5, 13)]),  # MAX(snapshot_date)
-            _FakeExecuteResult(scalar_rows=[]),  # no qualifying rows in latest partition
+            _FakeExecuteResult(
+                scalar_rows=[]
+            ),  # no qualifying rows in latest partition
         ]
     )
 


### PR DESCRIPTION
## Summary
- Fix `/invest/screener` Toss-parity gap for consecutive gainers by using latest snapshot semantics instead of exposing old qualifying rows as current results.
- Make Toss-like 1-week change the primary displayed metric while keeping streak days as secondary context.
- Add/adjust common-stock filtering and stale/missing snapshot visibility so zero rows is not misread as “no qualifiers” when data is stale/missing.

## Safety
- No broker/order/watch/order-intent/live/KIS/Upbit mutations.
- No production DB direct update/delete/backfill `--commit`.
- No recurring scheduler/Prefect/TaskIQ activation.
- No Toss request-path scraping; Toss is benchmark/fixture only.

## Verification
- See commits/tests on this branch and CI.

Closes ROB-212


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Consecutive-gainers screener now shows stock price change rate (%) as the primary metric instead of consecutive-day count.
* **Bug Fixes**
  * Snapshot loading now strictly uses only the latest partition; an empty latest partition is treated as "checked" (sets a warning and freshness to "stale") and will not fall back to external screening.
* **Tests**
  * Updated and added tests to validate the new metric, snapshot-partition semantics, and related warnings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/803)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->