### PR TITLE
fix(ROB-211): bound execution fill_seq hashes to int32

### DIFF
--- a/app/services/execution_ledger/normalizers.py
+++ b/app/services/execution_ledger/normalizers.py
@@ -24,6 +24,13 @@ SENSITIVE_KEY_MARKERS = (
 
 # Upbit order states that represent at least a partial execution
 UPBIT_FILL_STATES: frozenset[str] = frozenset({"done", "cancel"})
+# PostgreSQL Integer columns are signed int32; hash-derived fill_seq values must
+# stay inside that range or classify/upsert lookups fail before any commit.
+MAX_SQL_INT32 = 2_147_483_647
+
+
+def _stable_int32_hash(seed: str) -> int:
+    return int(hashlib.sha256(str(seed).encode()).hexdigest()[:8], 16) & MAX_SQL_INT32
 
 
 def _strip_crypto_prefix(symbol: str) -> str:
@@ -81,7 +88,7 @@ def _redact_sensitive_keys(payload: Any) -> Any:
 
 def _upbit_trade_fill_seq(trade_uuid: str) -> int:
     """Stable fill_seq derived from Upbit trade uuid (SHA-256 truncated)."""
-    return int(hashlib.sha256(str(trade_uuid).encode()).hexdigest()[:8], 16)
+    return _stable_int32_hash(str(trade_uuid))
 
 
 def _normalize_upbit_filled(order: dict[str, Any]) -> dict[str, Any] | None:
@@ -228,7 +235,7 @@ def _domestic_fill_seq(order: dict[str, Any]) -> int:
     seed = "|".join(
         str(order.get(k, "")) for k in ("ord_dt", "ord_tmd", "ccld_tmd", "ccld_qty")
     )
-    return int(hashlib.sha256(seed.encode()).hexdigest()[:8], 16)
+    return _stable_int32_hash(seed)
 
 
 def _overseas_fill_seq(order: dict[str, Any]) -> int:
@@ -248,7 +255,7 @@ def _overseas_fill_seq(order: dict[str, Any]) -> int:
     seed = "|".join(
         str(order.get(k, "")) for k in ("ord_dt", "ord_tmd", "ft_ccld_qty", "odno")
     )
-    return int(hashlib.sha256(seed.encode()).hexdigest()[:8], 16)
+    return _stable_int32_hash(seed)
 
 
 def _normalize_kis_domestic_filled(order: dict[str, Any]) -> dict[str, Any] | None:

--- a/tests/services/execution_ledger/test_normalizers.py
+++ b/tests/services/execution_ledger/test_normalizers.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from decimal import Decimal
 
 from app.services.execution_ledger.normalizers import (
+    MAX_SQL_INT32,
+    _domestic_fill_seq,
     _normalize_kis_domestic_filled,
     _normalize_kis_overseas_filled,
     _normalize_upbit_filled,
@@ -232,9 +234,9 @@ def test_overseas_fill_seq_hashes_when_ccld_seq_missing() -> None:
     }
     seq_a = _overseas_fill_seq(order_a)
     seq_b = _overseas_fill_seq(order_b)
-    # Both must be non-negative integers
-    assert seq_a >= 0
-    assert seq_b >= 0
+    # Both must be non-negative PostgreSQL int32 values
+    assert 0 <= seq_a <= MAX_SQL_INT32
+    assert 0 <= seq_b <= MAX_SQL_INT32
     # Different inputs must produce different hashes
     assert seq_a != seq_b
 
@@ -254,7 +256,7 @@ def test_kis_overseas_normalizer_uses_hash_fill_seq_when_no_ccld_seq() -> None:
     }
     normalized = _normalize_kis_overseas_filled(order)
     assert normalized is not None
-    assert normalized["fill_seq"] > 0  # hash, not 0
+    assert 0 < normalized["fill_seq"] <= MAX_SQL_INT32  # hash, not 0
 
 
 def test_kis_overseas_normalizer_two_fills_same_order_different_fill_seq() -> None:
@@ -277,6 +279,34 @@ def test_kis_overseas_normalizer_two_fills_same_order_different_fill_seq() -> No
     assert n2 is not None
     assert n1["order_id"] == n2["order_id"]
     assert n1["fill_seq"] != n2["fill_seq"]
+
+
+def test_hash_derived_fill_seq_values_fit_postgresql_integer() -> None:
+    assert 0 <= _upbit_trade_fill_seq("trade-cancel-1") <= MAX_SQL_INT32
+    assert (
+        0
+        <= _overseas_fill_seq(
+            {
+                "ord_dt": "20260513",
+                "ord_tmd": "140000",
+                "ft_ccld_qty": "2",
+                "odno": "us-order-2",
+            }
+        )
+        <= MAX_SQL_INT32
+    )
+    assert (
+        0
+        <= _domestic_fill_seq(
+            {
+                "ord_dt": "20260513",
+                "ord_tmd": "093000",
+                "ccld_tmd": "093001",
+                "ccld_qty": "1",
+            }
+        )
+        <= MAX_SQL_INT32
+    )
 
 
 def test_kis_domestic_normalizer_maps_sell_execution() -> None:


### PR DESCRIPTION
## Summary
- Bound hash-derived execution ledger fill_seq values to signed PostgreSQL int32 range
- Keeps KIS/Upbit dry-run classify/upsert lookups from failing before commit with out-of-range hashed fill_seq values
- Added regression coverage for Upbit, KIS domestic, and KIS overseas hash fallback fill_seq values

## Verification
- `uv run --group dev ruff check app/services/execution_ledger/normalizers.py tests/services/execution_ledger/test_normalizers.py`
- `uv run --group test pytest tests/services/execution_ledger/test_normalizers.py tests/services/execution_ledger/test_repository.py tests/services/execution_ledger/test_reconciler.py tests/routers/test_invest_fills_router.py -q`

## Production finding
- Found during ROB-211 production dry-run smoke: KIS dry-run failed with asyncpg int32 overflow for fill_seq value `4175931288`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized execution ledger fill sequence calculations to ensure values remain within valid database bounds, preventing potential data processing errors during trade handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/805)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->