### PR TITLE
fix: treat forexfactory calendar times as UTC

### DIFF
--- a/app/services/market_events/forexfactory_helpers.py
+++ b/app/services/market_events/forexfactory_helpers.py
@@ -1,8 +1,8 @@
 """Per-day ForexFactory economic-calendar fetch helper (ROB-132).
 
 Fetches `ff_calendar_thisweek.xml` and (when needed) `ff_calendar_nextweek.xml`,
-parses each event into a uniform dict, converts ET wall-clock times to UTC, and
-filters to rows whose ET-day matches the requested target_date.
+parses each event into a uniform dict, treats ForexFactory feed times as UTC,
+and filters to rows whose feed date matches the requested target_date.
 
 Caller passes the resulting rows into
 `app.services.market_events.normalizers.normalize_forexfactory_event_row`.
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 THISWEEK_URL = "https://nfs.faireconomy.media/ff_calendar_thisweek.xml"
 NEXTWEEK_URL = "https://nfs.faireconomy.media/ff_calendar_nextweek.xml"
 ET_TZ = ZoneInfo("America/New_York")
+FOREXFACTORY_FEED_TZ = UTC
 
 RETRIABLE_STATUS = frozenset({429, 500, 502, 503, 504})
 
@@ -250,7 +251,10 @@ def _parse_one_xml(xml_text: str) -> list[dict[str, Any]]:
                 hour,
                 minute,
             )
-            release_utc = release_local.replace(tzinfo=ET_TZ).astimezone(UTC)
+            # ForexFactory's public XML feed emits clock times in UTC/GMT.
+            # Do not interpret them as US/Eastern; doing so shifts high-impact
+            # US releases (for example 12:30pm UTC PPI/CPI) four hours late.
+            release_utc = release_local.replace(tzinfo=FOREXFACTORY_FEED_TZ)
             id_iso = release_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
 
         source_event_id = f"ff::{currency}::{title}::{id_iso}"

--- a/app/services/market_events/normalizers.py
+++ b/app/services/market_events/normalizers.py
@@ -255,7 +255,7 @@ def normalize_forexfactory_event_row(
         "event_date": event_date,
         "release_time_utc": row.get("release_time_utc"),
         "release_time_local": row.get("release_time_local"),
-        "source_timezone": "America/New_York",
+        "source_timezone": "UTC",
         "time_hint": row.get("time_hint_raw") or "unknown",
         "importance": importance,
         "status": status,

--- a/tests/services/test_market_events_forexfactory_helpers.py
+++ b/tests/services/test_market_events_forexfactory_helpers.py
@@ -17,7 +17,7 @@ SAMPLE_XML = """<?xml version="1.0" encoding="UTF-8"?>
     <title>Core CPI m/m</title>
     <country>USD</country>
     <date>05-13-2026</date>
-    <time>8:30am</time>
+    <time>12:30pm</time>
     <impact>High</impact>
     <forecast>0.3%</forecast>
     <previous>0.4%</previous>
@@ -61,14 +61,14 @@ async def test_fetch_forexfactory_for_date_filters_to_target_day():
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_fetch_forexfactory_converts_et_to_utc_and_emits_stable_id():
+async def test_fetch_forexfactory_treats_feed_time_as_utc_and_emits_stable_id():
     from app.services.market_events import forexfactory_helpers as ff
 
     with patch.object(ff, "_fetch_xml_documents", AsyncMock(return_value=[SAMPLE_XML])):
         rows = await ff.fetch_forexfactory_events_for_date(date(2026, 5, 13))
 
     cpi = next(r for r in rows if r["title"] == "Core CPI m/m")
-    # 8:30am ET in May (EDT, UTC-4) -> 12:30 UTC.
+    # ForexFactory XML feed time is already UTC/GMT: 12:30pm -> 12:30 UTC.
     assert cpi["release_time_utc"] == datetime(2026, 5, 13, 12, 30, tzinfo=UTC)
     assert cpi["currency"] == "USD"
     assert cpi["impact"] == "high"

--- a/tests/services/test_market_events_normalizers.py
+++ b/tests/services/test_market_events_normalizers.py
@@ -152,8 +152,8 @@ FF_ROW_HIGH_IMPACT = {
     "country": "US",
     "event_date": date(2026, 5, 13),
     "release_time_utc": datetime(2026, 5, 13, 12, 30, tzinfo=UTC),
-    "release_time_local": datetime(2026, 5, 13, 8, 30),
-    "time_hint_raw": "8:30am",
+    "release_time_local": datetime(2026, 5, 13, 12, 30),
+    "time_hint_raw": "12:30pm",
     "impact": "high",
     "actual": "0.3%",
     "forecast": "0.3%",
@@ -174,7 +174,7 @@ def test_normalize_forexfactory_high_impact_event():
     assert event["title"] == "Core CPI m/m"
     assert event["event_date"] == date(2026, 5, 13)
     assert event["release_time_utc"] == datetime(2026, 5, 13, 12, 30, tzinfo=UTC)
-    assert event["source_timezone"] == "America/New_York"
+    assert event["source_timezone"] == "UTC"
     assert event["importance"] == 3
     assert event["status"] == "released"
     assert event["source"] == "forexfactory"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated market event feed timestamp handling to correctly interpret times as UTC instead of Eastern Time, improving accuracy and consistency in event scheduling and timing information across market data feeds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/807)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->