### PR TITLE
fix(calendar): promote PPI macro highlights

### DIFF
--- a/app/services/invest_view_model/calendar_service.py
+++ b/app/services/invest_view_model/calendar_service.py
@@ -41,7 +41,29 @@ _EVENT_TYPE_ORDER: dict[EventType, int] = {
     "other": 4,
 }
 _MARKET_ORDER: dict[CalendarMarket, int] = {"kr": 0, "us": 1, "global": 2, "crypto": 3}
-_HIGH_IMPACT_TERMS = ("cpi", "fomc", "nonfarm", "payroll", "pce", "gdp", "금리", "고용")
+_HIGH_IMPACT_TERMS = (
+    "cpi",
+    "core cpi",
+    "ppi",
+    "core ppi",
+    "producer price",
+    "producer prices",
+    "fomc",
+    "fed interest rate",
+    "interest rate decision",
+    "nonfarm",
+    "payroll",
+    "unemployment rate",
+    "jobless claims",
+    "pce",
+    "gdp",
+    "retail sales",
+    "ism",
+    "금리",
+    "고용",
+    "생산자물가",
+    "소비자물가",
+)
 
 _MARKET_LITERAL = cast  # alias — used for type narrowing below
 

--- a/tests/test_invest_calendar_router.py
+++ b/tests/test_invest_calendar_router.py
@@ -256,6 +256,80 @@ async def test_calendar_cluster_top_events_and_summary_are_priority_aware(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("event_id", "title", "market", "value_fields", "tab"),
+    [
+        (
+            "us-ppi",
+            "USD PPI m/m",
+            "us",
+            {"actual": "0.5", "forecast": "0.3", "previous": "0.2"},
+            "all",
+        ),
+        (
+            "producer-prices",
+            "US Producer Price Index",
+            "global",
+            {"forecast": "0.3"},
+            "economic",
+        ),
+    ],
+)
+async def test_calendar_promotes_ppi_terms_in_dense_economic_cluster(
+    monkeypatch,
+    event_id: str,
+    title: str,
+    market: str,
+    value_fields: dict[str, str],
+    tab: str,
+) -> None:
+    from app.services.invest_view_model import calendar_service as svc
+
+    fake_resp = MagicMock()
+    fake_resp.events = [
+        *[
+            _fake_event(
+                event_id=f"routine-{i}",
+                category="economic",
+                market=market,
+                title=f"routine macro {i}",
+            )
+            for i in range(12)
+        ],
+        _fake_event(
+            event_id=event_id,
+            category="economic",
+            market=market,
+            title=title,
+            **value_fields,
+        ),
+    ]
+    fake_query_service = MagicMock(list_for_range=AsyncMock(return_value=fake_resp))
+    monkeypatch.setattr(svc, "MarketEventsQueryService", lambda db: fake_query_service)
+    _patch_freshness(monkeypatch, svc, date(2026, 5, 4), date(2026, 5, 4))
+
+    resp = await svc.build_calendar(
+        db=MagicMock(),
+        resolver=RelationResolver(),
+        from_date=date(2026, 5, 4),
+        to_date=date(2026, 5, 4),
+        tab=tab,
+    )
+
+    day = resp.days[0]
+    top = day.clusters[0].topEvents[0]
+    assert len(day.clusters) == 1
+    assert day.clusters[0].eventType == "economic"
+    assert day.clusters[0].market == market
+    assert top.eventId == event_id
+    assert "high_impact" in top.highlightReasons
+    assert "has_values" in top.highlightReasons
+    assert day.summary is not None
+    assert day.summary.highlightEventIds[0] == event_id
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_calendar_polishes_blank_kr_title_kst_time_and_values(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- add PPI / Producer Price Index and related USD macro phrases to calendar high-impact detection
- ensure dense economic clusters promote high-impact PPI rows into `topEvents` and day summaries
- add regression coverage for both `PPI` abbreviation and `Producer Price` title forms

## Test Plan
- `uv run pytest tests/test_invest_calendar_router.py -q`
- `uv run ruff check app/ tests/`
- `uv run ruff format --check app/ tests/`
- `uv run ty check app/ --error-on-warning`

## Notes
- Full local CI-style pytest was attempted after `uv sync --group test`, but this MacBook's local `test_db` schema is stale (missing existing columns such as `review.kis_mock_order_ledger.lifecycle_state` and trading decision columns), causing unrelated DB-schema failures. Targeted calendar tests and full lint/type gates pass.
- No broker/order/watch mutations; code/test-only calendar display priority change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved economic event recognition to detect a broader range of high-impact announcements, including additional CPI/PPI variants, producer-price phrasing, FOMC/interest-rate wording, labor/growth terms, and extra Korean keywords.

* **Tests**
  * Added parameterized tests verifying calendar clustering and promotion of high-impact PPI-related events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/808)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->