### PR TITLE
feat(ROB-214): add invest sell history fill panel

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -412,6 +412,10 @@ class Settings(BaseSettings):
 
     # ROB-211 execution ledger ships inert; commit/backfill activation is a separate approval-gated ops change.
     EXECUTION_LEDGER_COMMIT_ENABLED: bool = False
+    # ROB-214 — recurring reconciliation scheduler remains disabled unless explicitly enabled.
+    execution_ledger_reconcile_scheduler_enabled: bool = False
+    execution_ledger_reconcile_scheduler_cron: str = "*/30 * * * *"
+    execution_ledger_reconcile_scheduler_window_hours: int = 24
 
     trader_agent_id: str = "6b2192cc-14fa-4335-b572-2fe1e0cb54a7"
     paperclip_api_url: str | None = None

--- a/app/services/execution_ledger/normalizers.py
+++ b/app/services/execution_ledger/normalizers.py
@@ -320,6 +320,8 @@ def to_execution_ledger_upsert(
     *,
     broker: str | None = None,
     account_mode: str = "live",
+    source: str = "reconciler",
+    correlation_id: str | None = None,
     source_run_id: uuid.UUID | None = None,
 ) -> ExecutionLedgerUpsert:
     broker_value = broker or (
@@ -347,7 +349,8 @@ def to_execution_ledger_upsert(
         fee_currency=normalized.get("currency"),
         filled_at=_parse_filled_at(normalized.get("filled_at")),
         currency=normalized["currency"],
-        source="reconciler",
+        correlation_id=correlation_id or normalized.get("correlation_id"),
+        source=source,
         source_run_id=source_run_id,
         raw_payload_json=normalized.get("raw_payload_json"),
     )

--- a/app/tasks/__init__.py
+++ b/app/tasks/__init__.py
@@ -1,6 +1,7 @@
 from app.tasks import (
     crypto_pending_order_alert_tasks,
     daily_scan_tasks,
+    execution_ledger,
     intraday_order_review_tasks,
     invest_screener_snapshot_tasks,
     investor_flow_snapshot_tasks,
@@ -21,6 +22,7 @@ from app.tasks import (
 TASKIQ_TASK_MODULES = (
     crypto_pending_order_alert_tasks,
     daily_scan_tasks,
+    execution_ledger,
     intraday_order_review_tasks,
     invest_screener_snapshot_tasks,
     investor_flow_snapshot_tasks,

--- a/app/tasks/execution_ledger.py
+++ b/app/tasks/execution_ledger.py
@@ -1,21 +1,72 @@
-"""Scheduleless manual smoke task for ROB-211 execution ledger reconciliation."""
+"""Execution-ledger reconciliation tasks.
+
+ROB-214 keeps recurring reconciliation inert by default.  Operators must enable
+``execution_ledger_reconcile_scheduler_enabled`` for the scheduler label to be
+registered, and writes still require the independent ``EXECUTION_LEDGER_COMMIT_ENABLED``
+activation flag.
+"""
 
 from __future__ import annotations
 
+from typing import Literal
+
+from app.core.config import settings
 from app.core.db import AsyncSessionLocal
 from app.core.taskiq_broker import broker as taskiq_broker
 from app.services.execution_ledger.reconciler import ExecutionLedgerReconciler
 from app.services.execution_ledger.repository import ExecutionLedgerRepository
 
+ExecutionLedgerBroker = Literal["kis", "upbit"]
+
+
+def _scheduled_reconcile_labels() -> list[dict[str, str]]:
+    if not settings.execution_ledger_reconcile_scheduler_enabled:
+        return []
+    return [
+        {
+            "cron": settings.execution_ledger_reconcile_scheduler_cron,
+            "cron_offset": "Asia/Seoul",
+        }
+    ]
+
+
+async def _run_reconciliation(broker: ExecutionLedgerBroker, window_hours: int) -> dict:
+    async with AsyncSessionLocal() as db:
+        diff = await ExecutionLedgerReconciler(ExecutionLedgerRepository(db)).run(
+            broker,
+            window_hours=window_hours,
+            dry_run=not settings.EXECUTION_LEDGER_COMMIT_ENABLED,
+        )
+        if settings.EXECUTION_LEDGER_COMMIT_ENABLED:
+            await db.commit()
+        else:
+            await db.rollback()
+    return diff.model_dump(mode="json")
+
 
 @taskiq_broker.task(task_name="execution_ledger.reconcile_execution_ledger_smoke")
 async def reconcile_execution_ledger_smoke(broker: str, window_hours: int = 24) -> dict:
-    """Manual-only dry-run smoke. No schedule is registered in this PR."""
+    """Manual smoke. Dry-run unless EXECUTION_LEDGER_COMMIT_ENABLED is true."""
     if broker not in {"kis", "upbit"}:
         raise ValueError("broker must be kis or upbit")
-    async with AsyncSessionLocal() as db:
-        diff = await ExecutionLedgerReconciler(ExecutionLedgerRepository(db)).run(
-            broker, window_hours=window_hours, dry_run=True
-        )
-        await db.rollback()
-    return diff.model_dump(mode="json")
+    return await _run_reconciliation(
+        broker,  # type: ignore[arg-type]
+        window_hours=window_hours,
+    )
+
+
+@taskiq_broker.task(
+    task_name="execution_ledger.reconcile_execution_ledger_recurring",
+    schedule=_scheduled_reconcile_labels(),
+)
+async def reconcile_execution_ledger_recurring() -> dict[str, dict]:
+    """Recurring freshness reconciliation for KIS and Upbit.
+
+    The task is scheduleless by default.  When explicitly enabled, it still runs
+    as dry-run unless EXECUTION_LEDGER_COMMIT_ENABLED is also true.
+    """
+    window_hours = settings.execution_ledger_reconcile_scheduler_window_hours
+    return {
+        "kis": await _run_reconciliation("kis", window_hours=window_hours),
+        "upbit": await _run_reconciliation("upbit", window_hours=window_hours),
+    }

--- a/frontend/invest/src/__tests__/SellHistoryPanel.test.tsx
+++ b/frontend/invest/src/__tests__/SellHistoryPanel.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { SellHistoryPanel } from "../components/my/SellHistoryPanel";
+
+const fetchMock = vi.fn();
+
+const baseResponse = {
+  count: 1,
+  data_state: "fresh",
+  empty_reason: null,
+  source_breakdown: { reconciler: 1, websocket: 0, manual_import: 0 },
+  items: [
+    {
+      id: 5,
+      broker: "kis",
+      account_mode: "live",
+      venue: "krx",
+      instrument_type: "equity_kr",
+      symbol: "000660",
+      raw_symbol: "000660",
+      side: "sell",
+      broker_order_id: "0006421200",
+      fill_seq: 733331392,
+      filled_qty: "1.00000000",
+      filled_price: "1959000.00000000",
+      filled_notional: "1959000.0000",
+      fee_amount: "0.0",
+      fee_currency: "KRW",
+      filled_at: "2026-05-12T00:01:09Z",
+      currency: "KRW",
+      correlation_id: null,
+      source: "reconciler",
+      source_run_id: "run-1",
+      created_at: "2026-05-13T07:20:32Z",
+      updated_at: null,
+    },
+  ],
+};
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue({ ok: true, json: async () => baseResponse });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test("SellHistoryPanel renders sell ledger rows and uses include credentials", async () => {
+  render(<SellHistoryPanel />);
+
+  expect(await screen.findByText("000660")).toBeInTheDocument();
+  expect(screen.getByText("매도 이력")).toBeInTheDocument();
+  expect(screen.getAllByText("₩1,959,000").length).toBeGreaterThan(0);
+  expect(screen.getByText("보정")).toBeInTheDocument();
+  expect(screen.getByText("출처 보정 1")).toBeInTheDocument();
+
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+  expect(url).toContain("/trading/api/invest/fills/sell-history");
+  expect(url).toContain("days=30");
+  expect(init.credentials).toBe("include");
+});
+
+test("SellHistoryPanel refetches with market filter", async () => {
+  render(<SellHistoryPanel />);
+  await screen.findByText("000660");
+
+  await userEvent.click(screen.getByRole("button", { name: "국내" }));
+
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  const [url] = fetchMock.mock.calls[1] as [string, RequestInit];
+  expect(url).toContain("market=kr");
+});

--- a/frontend/invest/src/components/my/SellHistoryPanel.tsx
+++ b/frontend/invest/src/components/my/SellHistoryPanel.tsx
@@ -1,0 +1,229 @@
+import { useEffect, useMemo, useState } from "react";
+import { fetchSellHistory } from "../../api/fills";
+import type { FillListResponse, FillMarket, FillRow } from "../../types/fills";
+
+const MARKET_OPTIONS: { key: FillMarket | "all"; label: string }[] = [
+  { key: "all", label: "전체" },
+  { key: "kr", label: "국내" },
+  { key: "us", label: "미국" },
+  { key: "crypto", label: "코인" },
+];
+
+function toNumber(value: string | number | null | undefined): number | null {
+  if (value == null || value === "") return null;
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function formatMoney(value: string | number | null | undefined, currency: string): string {
+  const n = toNumber(value);
+  if (n == null) return "—";
+  if (currency === "USD") {
+    return `$${n.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  }
+  if (currency === "KRW") {
+    return `₩${Math.round(n).toLocaleString("ko-KR")}`;
+  }
+  return `${n.toLocaleString("ko-KR")} ${currency}`;
+}
+
+function formatQty(row: FillRow): string {
+  const qty = toNumber(row.filled_qty);
+  if (qty == null) return "—";
+  if (row.instrument_type === "crypto") return qty.toLocaleString("ko-KR", { maximumFractionDigits: 8 });
+  return `${qty.toLocaleString("ko-KR", { maximumFractionDigits: 4 })}주`;
+}
+
+function formatDateTime(value: string): string {
+  const dt = new Date(value);
+  if (Number.isNaN(dt.getTime())) return value;
+  return new Intl.DateTimeFormat("ko-KR", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone: "Asia/Seoul",
+  }).format(dt);
+}
+
+function sourceLabel(row: FillRow): string {
+  if (row.source === "websocket") return "실시간";
+  if (row.source === "reconciler") return "보정";
+  if (row.source === "manual_import") return "수동";
+  return row.source;
+}
+
+function sourceBreakdownLabel(data: FillListResponse): string | null {
+  const breakdown = data.source_breakdown;
+  if (!breakdown) return null;
+  const parts = [
+    ["실시간", breakdown.websocket],
+    ["보정", breakdown.reconciler],
+    ["수동", breakdown.manual_import],
+  ].filter(([, count]) => Number(count) > 0);
+  if (parts.length === 0) return null;
+  return parts.map(([label, count]) => `${label} ${count}`).join(" · ");
+}
+
+export function SellHistoryPanel({ compact = false }: { compact?: boolean }) {
+  const [market, setMarket] = useState<FillMarket | "all">("all");
+  const [state, setState] = useState<
+    | { status: "loading" }
+    | { status: "ready"; data: FillListResponse }
+    | { status: "error"; message: string }
+  >({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "loading" });
+    fetchSellHistory({ days: 30, limit: compact ? 8 : 30, market: market === "all" ? undefined : market })
+      .then((data) => {
+        if (!cancelled) setState({ status: "ready", data });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setState({ status: "error", message: err instanceof Error ? err.message : String(err) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [market, compact]);
+
+  const rows = useMemo(() => (state.status === "ready" ? state.data.items : []), [state]);
+  const count = state.status === "ready" ? state.data.count : 0;
+  const dataState = state.status === "ready" ? state.data.data_state : null;
+  const breakdownLabel = state.status === "ready" ? sourceBreakdownLabel(state.data) : null;
+
+  return (
+    <section
+      data-testid="sell-history-panel"
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: 16,
+        background: "var(--surface)",
+        overflow: "hidden",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: compact ? "flex-start" : "center",
+          justifyContent: "space-between",
+          gap: 12,
+          padding: compact ? "14px 14px 10px" : "16px 18px 12px",
+          flexDirection: compact ? "column" : "row",
+        }}
+      >
+        <div>
+          <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <h2 style={{ margin: 0, fontSize: compact ? 16 : 18, letterSpacing: "-0.02em" }}>매도 이력</h2>
+            {dataState && (
+              <span
+                style={{
+                  padding: "2px 7px",
+                  borderRadius: 999,
+                  fontSize: 11,
+                  fontWeight: 700,
+                  color: dataState === "fresh" ? "var(--gain)" : "var(--warn)",
+                  background: dataState === "fresh" ? "var(--gain-soft)" : "var(--warn-soft)",
+                }}
+              >
+                {dataState === "fresh" ? "최신" : dataState === "stale" ? "지연" : "대기"}
+              </span>
+            )}
+          </div>
+          <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--fg-3)" }}>
+            KIS/Upbit 체결 보정 ledger 기준 최근 30일 매도 체결입니다.
+          </p>
+          {breakdownLabel && (
+            <p style={{ margin: "4px 0 0", fontSize: 11, color: "var(--fg-3)" }}>
+              출처 {breakdownLabel}
+            </p>
+          )}
+        </div>
+        <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+          {MARKET_OPTIONS.map((option) => {
+            const active = market === option.key;
+            return (
+              <button
+                key={option.key}
+                type="button"
+                onClick={() => setMarket(option.key)}
+                style={{
+                  border: "none",
+                  borderRadius: 999,
+                  padding: "6px 10px",
+                  fontSize: 12,
+                  fontWeight: 700,
+                  cursor: "pointer",
+                  fontFamily: "inherit",
+                  background: active ? "var(--fg)" : "var(--surface-2)",
+                  color: active ? "var(--bg)" : "var(--fg-2)",
+                }}
+              >
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {state.status === "loading" && (
+        <div style={{ padding: 24, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>매도 이력을 불러오는 중…</div>
+      )}
+
+      {state.status === "error" && (
+        <div role="alert" style={{ padding: 16, color: "var(--danger)", fontSize: 13 }}>
+          매도 이력을 불러오지 못했습니다. {state.message}
+        </div>
+      )}
+
+      {state.status === "ready" && rows.length === 0 && (
+        <div style={{ padding: 24, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>
+          {state.data.empty_reason ?? "최근 30일 매도 체결이 없습니다."}
+        </div>
+      )}
+
+      {state.status === "ready" && rows.length > 0 && (
+        <div style={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", minWidth: compact ? 0 : 720 }}>
+            <thead>
+              <tr style={{ color: "var(--fg-3)", fontSize: 11, textAlign: "left" }}>
+                <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)" }}>일시</th>
+                <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)" }}>종목</th>
+                {!compact && <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)" }}>수량</th>}
+                <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)", textAlign: "right" }}>단가</th>
+                <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)", textAlign: "right" }}>금액</th>
+                {!compact && <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)" }}>출처</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={`${row.broker}-${row.account_mode}-${row.venue}-${row.broker_order_id}-${row.fill_seq}`}>
+                  <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 12, color: "var(--fg-2)", whiteSpace: "nowrap" }}>
+                    {formatDateTime(row.filled_at)}
+                  </td>
+                  <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)" }}>
+                    <div style={{ fontSize: 13, fontWeight: 800 }}>{row.symbol}</div>
+                    <div style={{ marginTop: 2, fontSize: 11, color: "var(--fg-3)" }}>{compact ? formatQty(row) : `${row.broker.toUpperCase()} · ${row.venue}`}</div>
+                  </td>
+                  {!compact && <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13 }}>{formatQty(row)}</td>}
+                  <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, textAlign: "right", fontFeatureSettings: '"tnum"' }}>
+                    {formatMoney(row.filled_price, row.currency)}
+                  </td>
+                  <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, fontWeight: 800, textAlign: "right", fontFeatureSettings: '"tnum"' }}>
+                    {formatMoney(row.filled_notional, row.currency)}
+                  </td>
+                  {!compact && <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 12, color: "var(--fg-3)" }}>{sourceLabel(row)}</td>}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div style={{ padding: "8px 14px", fontSize: 11, color: "var(--fg-3)" }}>
+            총 {count.toLocaleString("ko-KR")}건{count > rows.length ? ` 중 ${rows.length}건 표시` : ""}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/invest/src/pages/desktop/DesktopPortfolioPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopPortfolioPage.tsx
@@ -12,6 +12,7 @@ import { scopeGroupedToSource } from "../../desktop/scopeHoldings";
 import { DesktopHero } from "../../components/home/DesktopHero";
 import { FilterChips } from "../../components/home/FilterChips";
 import { UnifiedHoldingsTable } from "../../components/my/UnifiedHoldingsTable";
+import { SellHistoryPanel } from "../../components/my/SellHistoryPanel";
 import { MobilePortfolioPage } from "../mobile/MobilePortfolioPage";
 import type { AssetCategoryKey } from "../../components/AssetCategoryFilter";
 import type { AccountSource, HomeSummary } from "../../types/invest";
@@ -121,6 +122,7 @@ export function DesktopPortfolioPage() {
                 holdings={filteredScoped}
                 accounts={data.accounts}
               />
+              <SellHistoryPanel />
               {data.meta?.warnings && data.meta.warnings.length > 0 && (
                 <div
                   role="alert"

--- a/frontend/invest/src/pages/mobile/MobilePortfolioPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobilePortfolioPage.tsx
@@ -8,6 +8,7 @@ import { scopeGroupedToSource } from "../../desktop/scopeHoldings";
 import { pillToneForSource } from "../../desktop/AccountSourceTone";
 import { stockDetailPath } from "../../stockDetailPath";
 import { PL, Pill } from "../../ds";
+import { SellHistoryPanel } from "../../components/my/SellHistoryPanel";
 import type { AccountSource, GroupedHolding, HomeSummary, PriceState } from "../../types/invest";
 import type { AssetCategoryKey } from "../../components/AssetCategoryFilter";
 
@@ -295,6 +296,10 @@ export function MobilePortfolioPage() {
                 })}
               </div>
             )}
+          </section>
+
+          <section style={{ padding: "0 16px" }}>
+            <SellHistoryPanel compact />
           </section>
 
           {data.meta?.warnings && data.meta.warnings.length > 0 && (

--- a/tests/test_execution_ledger_tasks.py
+++ b/tests/test_execution_ledger_tasks.py
@@ -42,7 +42,9 @@ def test_reconciliation_task_defaults_to_dry_run_when_commit_gate_disabled(
         def __init__(self, repository: object) -> None:
             captured["repository"] = repository
 
-        async def run(self, broker: str, *, window_hours: int, dry_run: bool) -> FakeDiff:
+        async def run(
+            self, broker: str, *, window_hours: int, dry_run: bool
+        ) -> FakeDiff:
             captured["broker"] = broker
             captured["window_hours"] = window_hours
             captured["dry_run"] = dry_run

--- a/tests/test_execution_ledger_tasks.py
+++ b/tests/test_execution_ledger_tasks.py
@@ -1,0 +1,82 @@
+"""ROB-214 execution-ledger reconciliation task registration tests."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.mark.unit
+def test_execution_ledger_task_module_is_discovered_by_taskiq_init() -> None:
+    import app.tasks as tasks_pkg
+    from app.tasks import execution_ledger
+
+    assert execution_ledger in tasks_pkg.TASKIQ_TASK_MODULES
+
+
+@pytest.mark.unit
+def test_recurring_reconciliation_task_has_no_default_schedule() -> None:
+    from app.tasks.execution_ledger import reconcile_execution_ledger_recurring
+
+    labels = getattr(reconcile_execution_ledger_recurring, "labels", {}) or {}
+    schedule = labels.get("schedule") if isinstance(labels, dict) else None
+
+    assert not schedule, f"Schedule must be empty until approval. Found: {schedule!r}"
+
+
+@pytest.mark.unit
+def test_reconciliation_task_defaults_to_dry_run_when_commit_gate_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.tasks import execution_ledger as mod
+
+    captured: dict[str, object] = {}
+
+    class FakeDiff:
+        def model_dump(self, *, mode: str) -> dict[str, object]:
+            captured["mode"] = mode
+            return {"ok": True}
+
+    class FakeReconciler:
+        def __init__(self, repository: object) -> None:
+            captured["repository"] = repository
+
+        async def run(self, broker: str, *, window_hours: int, dry_run: bool) -> FakeDiff:
+            captured["broker"] = broker
+            captured["window_hours"] = window_hours
+            captured["dry_run"] = dry_run
+            return FakeDiff()
+
+    class FakeRepository:
+        def __init__(self, db: object) -> None:
+            captured["db"] = db
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            return None
+
+        async def commit(self) -> None:  # pragma: no cover - should not be called
+            raise AssertionError("dry-run reconciliation must not commit")
+
+        async def rollback(self) -> None:
+            captured["rolled_back"] = True
+
+    monkeypatch.setattr(mod.settings, "EXECUTION_LEDGER_COMMIT_ENABLED", False)
+    monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: FakeSession())
+    monkeypatch.setattr(mod, "ExecutionLedgerReconciler", FakeReconciler)
+    monkeypatch.setattr(mod, "ExecutionLedgerRepository", FakeRepository)
+
+    result = asyncio.run(
+        mod.reconcile_execution_ledger_smoke(broker="kis", window_hours=6)
+    )
+
+    assert result == {"ok": True}
+    assert captured["broker"] == "kis"
+    assert captured["window_hours"] == 6
+    assert captured["dry_run"] is True
+    assert captured["rolled_back"] is True
+    assert captured["mode"] == "json"

--- a/tests/test_websocket_monitor.py
+++ b/tests/test_websocket_monitor.py
@@ -109,6 +109,194 @@ class TestUnifiedWebSocketMonitor:
         assert send_mock.await_args.kwargs["correlation_id"] == "corr-kis-1"
 
     @pytest.mark.asyncio
+    async def test_on_kis_execution_records_ledger_before_notification(
+        self, mock_settings: None
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        call_order: list[str] = []
+        monitor = UnifiedWebSocketMonitor()
+
+        async def record_side_effect(*args, **kwargs):
+            call_order.append("ledger")
+
+        async def send_side_effect(*args, **kwargs):
+            call_order.append("notify")
+            return _success_result("req-ledger-first")
+
+        record_mock = AsyncMock(side_effect=record_side_effect)
+        send_mock = AsyncMock(side_effect=send_side_effect)
+        monitor._record_execution_ledger_fill = record_mock
+        monitor.openclaw_client.send_fill_notification = send_mock
+
+        event = {
+            "symbol": "005930",
+            "side": "sell",
+            "fill_yn": "2",
+            "filled_price": 70_000,
+            "filled_qty": 10,
+            "market": "kr",
+            "correlation_id": "corr-kis-ledger-1",
+            "order_id": "kis-order-1",
+        }
+        await monitor._on_kis_execution(event)
+
+        record_mock.assert_awaited_once()
+        send_mock.assert_awaited_once()
+        ledger_args = record_mock.await_args.args
+        ledger_kwargs = record_mock.await_args.kwargs
+        assert ledger_args[0] is event
+        assert isinstance(ledger_args[1], FillOrder)
+        assert ledger_kwargs == {"broker": "kis", "correlation_id": "corr-kis-ledger-1"}
+        assert call_order == ["ledger", "notify"]
+
+    @pytest.mark.asyncio
+    async def test_on_upbit_trade_records_ledger_before_notification(
+        self, mock_settings: None
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        call_order: list[str] = []
+        monitor = UnifiedWebSocketMonitor()
+
+        async def record_side_effect(*args, **kwargs):
+            call_order.append("ledger")
+
+        async def send_side_effect(*args, **kwargs):
+            call_order.append("notify")
+            return _success_result("req-upbit-ledger-first")
+
+        record_mock = AsyncMock(side_effect=record_side_effect)
+        send_mock = AsyncMock(side_effect=send_side_effect)
+        monitor._record_execution_ledger_fill = record_mock
+        monitor.openclaw_client.send_fill_notification = send_mock
+
+        event = {
+            "code": "KRW-BTC",
+            "uuid": "upbit-order-1",
+            "ask_bid": "BID",
+            "trade_price": 50_000_000,
+            "trade_volume": 0.1,
+            "state": "trade",
+            "trade_timestamp": 1_700_000_000_000,
+        }
+        await monitor._on_upbit_order(event)
+
+        record_mock.assert_awaited_once()
+        send_mock.assert_awaited_once()
+        ledger_args = record_mock.await_args.args
+        ledger_kwargs = record_mock.await_args.kwargs
+        assert ledger_args[0] is event
+        assert isinstance(ledger_args[1], FillOrder)
+        assert ledger_kwargs == {"broker": "upbit", "correlation_id": "upbit-order-1"}
+        assert call_order == ["ledger", "notify"]
+
+    @pytest.mark.asyncio
+    async def test_record_execution_ledger_fill_is_inert_until_commit_gate(
+        self, mock_settings: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import websocket_monitor as mod
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monkeypatch.setattr(settings, "EXECUTION_LEDGER_COMMIT_ENABLED", False)
+
+        class FailingSession:
+            async def __aenter__(self) -> object:  # pragma: no cover
+                raise AssertionError("disabled websocket ledger path must not open DB")
+
+            async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+                return None
+
+        monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: FailingSession())
+        monitor = UnifiedWebSocketMonitor()
+
+        await monitor._record_execution_ledger_fill(
+            {"order_id": "kis-order-disabled"},
+            FillOrder(
+                symbol="005930",
+                side="ask",
+                filled_price=70_000,
+                filled_qty=1,
+                filled_amount=70_000,
+                filled_at="2026-05-12T00:01:09Z",
+                account="mock",
+                order_id="kis-order-disabled",
+                market_type="kr",
+                currency="KRW",
+            ),
+            broker="kis",
+            correlation_id="corr-disabled",
+        )
+
+    @pytest.mark.asyncio
+    async def test_record_execution_ledger_fill_upserts_when_commit_gate_enabled(
+        self, mock_settings: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import websocket_monitor as mod
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monkeypatch.setattr(settings, "EXECUTION_LEDGER_COMMIT_ENABLED", True)
+        monkeypatch.setattr(settings, "kis_ws_is_mock", False)
+        captured: dict[str, object] = {}
+
+        class FakeSession:
+            async def __aenter__(self) -> object:
+                return self
+
+            async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+                return None
+
+            async def commit(self) -> None:
+                captured["committed"] = True
+
+        class FakeRepository:
+            def __init__(self, db: object) -> None:
+                captured["db"] = db
+
+            async def upsert_fill(self, fill: object) -> tuple[str, int]:
+                captured["fill"] = fill
+                return "inserted", 42
+
+        monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: FakeSession())
+        monkeypatch.setattr(mod, "ExecutionLedgerRepository", FakeRepository)
+        monitor = UnifiedWebSocketMonitor()
+
+        await monitor._record_execution_ledger_fill(
+            {"order_id": "0006421200", "fill_seq": "7", "token": "secret"},
+            FillOrder(
+                symbol="000660",
+                side="ask",
+                filled_price=1_959_000,
+                filled_qty=1,
+                filled_amount=1_959_000,
+                filled_at="2026-05-12T00:01:09Z",
+                account="live",
+                order_id="0006421200",
+                market_type="kr",
+                currency="KRW",
+            ),
+            broker="kis",
+            correlation_id="corr-kis-upsert",
+        )
+
+        fill = captured["fill"]
+        assert captured["committed"] is True
+        assert fill.broker == "kis"
+        assert fill.account_mode == "live"
+        assert fill.venue == "krx"
+        assert fill.instrument_type == "equity_kr"
+        assert fill.symbol == "000660"
+        assert fill.side == "sell"
+        assert fill.broker_order_id == "0006421200"
+        assert fill.fill_seq == 7
+        assert str(fill.filled_qty) == "1"
+        assert str(fill.filled_price) == "1959000"
+        assert fill.currency == "KRW"
+        assert fill.correlation_id == "corr-kis-upsert"
+        assert fill.source == "websocket"
+        assert fill.raw_payload_json["token"] == "[REDACTED]"
+
+    @pytest.mark.asyncio
     async def test_on_kis_execution_forwards_us_currency_for_overseas_fill(
         self, mock_settings: None
     ) -> None:

--- a/tests/test_websocket_monitor.py
+++ b/tests/test_websocket_monitor.py
@@ -192,6 +192,59 @@ class TestUnifiedWebSocketMonitor:
         assert call_order == ["ledger", "notify"]
 
     @pytest.mark.asyncio
+    async def test_on_kis_execution_skips_notification_for_unchanged_ledger_row(
+        self, mock_settings: None
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor()
+        record_mock = AsyncMock(return_value="unchanged")
+        send_mock = AsyncMock(return_value=_success_result("req-duplicate-kis"))
+        monitor._record_execution_ledger_fill = record_mock
+        monitor.openclaw_client.send_fill_notification = send_mock
+
+        event = {
+            "symbol": "005930",
+            "side": "sell",
+            "fill_yn": "2",
+            "filled_price": 70_000,
+            "filled_qty": 10,
+            "market": "kr",
+            "correlation_id": "corr-kis-duplicate",
+            "order_id": "kis-order-duplicate",
+        }
+        await monitor._on_kis_execution(event)
+
+        record_mock.assert_awaited_once()
+        send_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_on_upbit_trade_skips_notification_for_unchanged_ledger_row(
+        self, mock_settings: None
+    ) -> None:
+        from websocket_monitor import UnifiedWebSocketMonitor
+
+        monitor = UnifiedWebSocketMonitor()
+        record_mock = AsyncMock(return_value="unchanged")
+        send_mock = AsyncMock(return_value=_success_result("req-duplicate-upbit"))
+        monitor._record_execution_ledger_fill = record_mock
+        monitor.openclaw_client.send_fill_notification = send_mock
+
+        event = {
+            "code": "KRW-BTC",
+            "uuid": "upbit-order-duplicate",
+            "ask_bid": "BID",
+            "trade_price": 50_000_000,
+            "trade_volume": 0.1,
+            "state": "trade",
+            "trade_timestamp": 1_700_000_000_000,
+        }
+        await monitor._on_upbit_order(event)
+
+        record_mock.assert_awaited_once()
+        send_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_record_execution_ledger_fill_is_inert_until_commit_gate(
         self, mock_settings: None, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -210,7 +263,7 @@ class TestUnifiedWebSocketMonitor:
         monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: FailingSession())
         monitor = UnifiedWebSocketMonitor()
 
-        await monitor._record_execution_ledger_fill(
+        status = await monitor._record_execution_ledger_fill(
             {"order_id": "kis-order-disabled"},
             FillOrder(
                 symbol="005930",
@@ -227,6 +280,8 @@ class TestUnifiedWebSocketMonitor:
             broker="kis",
             correlation_id="corr-disabled",
         )
+
+        assert status is None
 
     @pytest.mark.asyncio
     async def test_record_execution_ledger_fill_upserts_when_commit_gate_enabled(
@@ -261,7 +316,7 @@ class TestUnifiedWebSocketMonitor:
         monkeypatch.setattr(mod, "ExecutionLedgerRepository", FakeRepository)
         monitor = UnifiedWebSocketMonitor()
 
-        await monitor._record_execution_ledger_fill(
+        status = await monitor._record_execution_ledger_fill(
             {"order_id": "0006421200", "fill_seq": "7", "token": "secret"},
             FillOrder(
                 symbol="000660",
@@ -280,6 +335,7 @@ class TestUnifiedWebSocketMonitor:
         )
 
         fill = captured["fill"]
+        assert status == "inserted"
         assert captured["committed"] is True
         assert fill.broker == "kis"
         assert fill.account_mode == "live"

--- a/tests/test_websocket_monitor.py
+++ b/tests/test_websocket_monitor.py
@@ -257,7 +257,9 @@ class TestUnifiedWebSocketMonitor:
             async def __aenter__(self) -> object:  # pragma: no cover
                 raise AssertionError("disabled websocket ledger path must not open DB")
 
-            async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            async def __aexit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> None:
                 return None
 
         monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: FailingSession())
@@ -298,7 +300,9 @@ class TestUnifiedWebSocketMonitor:
             async def __aenter__(self) -> object:
                 return self
 
-            async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            async def __aexit__(
+                self, exc_type: object, exc: object, tb: object
+            ) -> None:
                 return None
 
             async def commit(self) -> None:

--- a/websocket_monitor.py
+++ b/websocket_monitor.py
@@ -7,6 +7,7 @@ Upbit/KIS 체결 WebSocket을 통합하여 OpenClaw Gateway로 체결 알림을 
 
 import argparse
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -14,12 +15,17 @@ import signal
 import sys
 from collections.abc import Callable
 from datetime import UTC, datetime
+from decimal import Decimal
 from pathlib import Path
 from typing import Any, cast
 
 from app.core.config import settings
+from app.core.db import AsyncSessionLocal
 from app.monitoring.sentry import capture_exception, init_sentry
 from app.monitoring.trade_notifier import get_trade_notifier
+from app.schemas.execution_ledger import ExecutionLedgerUpsert
+from app.services.execution_ledger.normalizers import _redact_sensitive_keys
+from app.services.execution_ledger.repository import ExecutionLedgerRepository
 from app.services.fill_notification import (
     FillOrder,
     normalize_kis_fill,
@@ -161,6 +167,12 @@ class UnifiedWebSocketMonitor:
 
         try:
             fill_order = normalize_upbit_fill(order_data)
+            await self._record_execution_ledger_fill(
+                order_data,
+                fill_order,
+                broker="upbit",
+                correlation_id=str(order_data.get("uuid") or "n/a"),
+            )
             await self._send_fill_notification(fill_order)
             logger.info(
                 f"Upbit fill processed: {fill_order.symbol} {fill_order.side} "
@@ -187,6 +199,12 @@ class UnifiedWebSocketMonitor:
                 fill_order.side,
                 fill_order.filled_qty,
                 fill_order.filled_price,
+            )
+            await self._record_execution_ledger_fill(
+                event,
+                fill_order,
+                broker="kis",
+                correlation_id=correlation_id,
             )
             await self._send_fill_notification(
                 fill_order, correlation_id=correlation_id
@@ -232,6 +250,117 @@ class UnifiedWebSocketMonitor:
             return float(value)
         except (TypeError, ValueError):
             return 0.0
+
+    @staticmethod
+    def _ledger_symbol(order: FillOrder) -> str:
+        symbol = order.symbol.strip().upper()
+        if order.market_type == "crypto":
+            for prefix in ("KRW-", "USDT-"):
+                if symbol.startswith(prefix):
+                    return symbol[len(prefix) :]
+        return symbol
+
+    @staticmethod
+    def _ledger_side(order: FillOrder) -> str:
+        return "sell" if order.side in {"ask", "sell"} else "buy"
+
+    @staticmethod
+    def _ledger_instrument_type(order: FillOrder) -> str:
+        if order.market_type == "us":
+            return "equity_us"
+        if order.market_type == "crypto":
+            return "crypto"
+        return "equity_kr"
+
+    @staticmethod
+    def _ledger_fill_seq(event: dict[str, Any], order: FillOrder) -> int:
+        for key in ("fill_seq", "ccld_seq", "ccld_seq_no", "trade_seq"):
+            value = event.get(key)
+            if value not in (None, ""):
+                try:
+                    return int(value)
+                except (TypeError, ValueError):
+                    pass
+        seed = "|".join(
+            str(part or "")
+            for part in (
+                event.get("trade_uuid"),
+                event.get("trade_id"),
+                event.get("uuid"),
+                order.order_id,
+                order.symbol,
+                order.filled_at,
+                order.filled_qty,
+                order.filled_price,
+            )
+        )
+        return int(hashlib.sha256(seed.encode()).hexdigest()[:8], 16) & 2_147_483_647
+
+    async def _record_execution_ledger_fill(
+        self,
+        event: dict[str, Any],
+        order: FillOrder,
+        *,
+        broker: str,
+        correlation_id: str | None = None,
+    ) -> None:
+        """Durably upsert one websocket fill before downstream notification.
+
+        The existing execution-ledger commit flag is the explicit activation gate;
+        when disabled we preserve notification behavior and avoid surprise writes.
+        """
+        if not settings.EXECUTION_LEDGER_COMMIT_ENABLED:
+            logger.info(
+                "Execution ledger websocket insert skipped: commit flag disabled symbol=%s broker=%s",
+                order.symbol,
+                broker,
+            )
+            return
+
+        currency = order.currency or ("USD" if order.market_type == "us" else "KRW")
+        venue = str(
+            event.get("venue")
+            or event.get("ovrs_excg_cd")
+            or event.get("excg_cd")
+            or ("upbit_krw" if broker == "upbit" else "krx")
+        )
+        broker_order_id = str(order.order_id or correlation_id or event.get("order_id") or "")
+        if not broker_order_id:
+            broker_order_id = f"websocket-{self._ledger_fill_seq(event, order)}"
+
+        fill = ExecutionLedgerUpsert(
+            broker=broker,  # type: ignore[arg-type]
+            account_mode="mock" if broker == "kis" and settings.kis_ws_is_mock else "live",
+            venue=venue,
+            instrument_type=self._ledger_instrument_type(order),  # type: ignore[arg-type]
+            symbol=self._ledger_symbol(order),
+            raw_symbol=order.symbol,
+            side=self._ledger_side(order),  # type: ignore[arg-type]
+            broker_order_id=broker_order_id,
+            fill_seq=self._ledger_fill_seq(event, order),
+            filled_qty=Decimal(str(order.filled_qty)),
+            filled_price=Decimal(str(order.filled_price)),
+            filled_notional=Decimal(str(order.filled_amount)) if order.filled_amount else None,
+            fee_amount=None,
+            fee_currency=currency,
+            filled_at=order.filled_at,  # type: ignore[arg-type]
+            currency=currency,  # type: ignore[arg-type]
+            correlation_id=correlation_id,
+            source="websocket",
+            raw_payload_json=_redact_sensitive_keys(event),
+        )
+        async with AsyncSessionLocal() as db:
+            status, row_id = await ExecutionLedgerRepository(db).upsert_fill(fill)
+            await db.commit()
+        logger.info(
+            "Execution ledger websocket upsert committed: broker=%s symbol=%s order_id=%s fill_seq=%s status=%s row_id=%s",
+            broker,
+            fill.symbol,
+            fill.broker_order_id,
+            fill.fill_seq,
+            status,
+            row_id,
+        )
 
     async def _send_fill_notification(
         self, order: FillOrder, *, correlation_id: str | None = None

--- a/websocket_monitor.py
+++ b/websocket_monitor.py
@@ -25,7 +25,10 @@ from app.monitoring.sentry import capture_exception, init_sentry
 from app.monitoring.trade_notifier import get_trade_notifier
 from app.schemas.execution_ledger import ExecutionLedgerUpsert
 from app.services.execution_ledger.normalizers import _redact_sensitive_keys
-from app.services.execution_ledger.repository import ExecutionLedgerRepository
+from app.services.execution_ledger.repository import (
+    ExecutionLedgerRepository,
+    UpsertStatus,
+)
 from app.services.fill_notification import (
     FillOrder,
     normalize_kis_fill,
@@ -167,13 +170,20 @@ class UnifiedWebSocketMonitor:
 
         try:
             fill_order = normalize_upbit_fill(order_data)
-            await self._record_execution_ledger_fill(
+            upsert_status = await self._record_execution_ledger_fill(
                 order_data,
                 fill_order,
                 broker="upbit",
                 correlation_id=str(order_data.get("uuid") or "n/a"),
             )
-            await self._send_fill_notification(fill_order)
+            if upsert_status not in {"updated", "unchanged"}:
+                await self._send_fill_notification(fill_order)
+            else:
+                logger.info(
+                    "Upbit fill notification skipped for duplicate ledger row: symbol=%s status=%s",
+                    fill_order.symbol,
+                    upsert_status,
+                )
             logger.info(
                 f"Upbit fill processed: {fill_order.symbol} {fill_order.side} "
                 f"{fill_order.filled_qty}@{fill_order.filled_price}"
@@ -200,15 +210,23 @@ class UnifiedWebSocketMonitor:
                 fill_order.filled_qty,
                 fill_order.filled_price,
             )
-            await self._record_execution_ledger_fill(
+            upsert_status = await self._record_execution_ledger_fill(
                 event,
                 fill_order,
                 broker="kis",
                 correlation_id=correlation_id,
             )
-            await self._send_fill_notification(
-                fill_order, correlation_id=correlation_id
-            )
+            if upsert_status not in {"updated", "unchanged"}:
+                await self._send_fill_notification(
+                    fill_order, correlation_id=correlation_id
+                )
+            else:
+                logger.info(
+                    "KIS fill notification skipped for duplicate ledger row: correlation_id=%s symbol=%s status=%s",
+                    correlation_id,
+                    fill_order.symbol,
+                    upsert_status,
+                )
             logger.info(
                 f"KIS fill processed: {fill_order.symbol} {fill_order.side} "
                 f"{fill_order.filled_qty}@{fill_order.filled_price}"
@@ -303,7 +321,7 @@ class UnifiedWebSocketMonitor:
         *,
         broker: str,
         correlation_id: str | None = None,
-    ) -> None:
+    ) -> UpsertStatus | None:
         """Durably upsert one websocket fill before downstream notification.
 
         The existing execution-ledger commit flag is the explicit activation gate;
@@ -315,7 +333,7 @@ class UnifiedWebSocketMonitor:
                 order.symbol,
                 broker,
             )
-            return
+            return None
 
         currency = order.currency or ("USD" if order.market_type == "us" else "KRW")
         venue = str(
@@ -361,6 +379,7 @@ class UnifiedWebSocketMonitor:
             status,
             row_id,
         )
+        return status
 
     async def _send_fill_notification(
         self, order: FillOrder, *, correlation_id: str | None = None


### PR DESCRIPTION
## Summary
- Adds `/trading/api/invest/fills/sell-history` read-only sell-history API and execution-ledger freshness metadata for `/invest`.
- Adds the `/invest/my` sell-history panel with provider-safe labels and tests.
- Dedupes websocket fill notifications by suppressing notifications for unchanged/updated execution-ledger upserts while preserving disabled gate behavior.

## Safety / operational boundaries
- No live broker order submit/cancel/modify paths added or exercised.
- No watch/order-intent mutation.
- No production DB commit/backfill or scheduler activation performed.
- Execution-ledger commit remains feature-gated; dry-run/read-only verification only.

## Test plan
- `uv run ruff check app/core/config.py app/services/execution_ledger/normalizers.py app/tasks/__init__.py app/tasks/execution_ledger.py websocket_monitor.py tests/test_websocket_monitor.py tests/test_execution_ledger_tasks.py tests/routers/test_invest_fills_router.py`
- `uv run pytest tests/test_execution_ledger_tasks.py tests/test_websocket_monitor.py tests/routers/test_invest_fills_router.py -q`
- `npm --prefix frontend/invest run typecheck`
- `npm --prefix frontend/invest test -- --run src/__tests__/SellHistoryPanel.test.tsx`

Closes ROB-214


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sell History panel added to desktop and mobile portfolio pages (last 30 days, market filter, compact mode).
  * Recurring execution-ledger reconciliation task with configurable schedule and window.

* **Improvements**
  * Execution-ledger durability gating: ledger writes and notification ordering now respect commit setting.
  * Better source attribution, formatting, and responsive display with loading/error/empty states.

* **Tests**
  * Added unit and integration tests covering reconciliation tasks, websocket ledger behavior, and sell-history UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/809)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->