### PR TITLE
feat(invest): add FX macro dashboard contract

### DIFF
--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -27,6 +27,7 @@ from app.schemas.invest_feed_research import (
     FeedResearchResponse,
     FeedResearchTab,
 )
+from app.schemas.invest_fx_dashboard import FxDashboardResponse
 from app.schemas.invest_home import InvestHomeResponse
 from app.schemas.invest_market_dashboard import MarketDashboardResponse
 from app.schemas.invest_screener import (
@@ -47,6 +48,7 @@ from app.services.invest_view_model.account_panel_service import build_account_p
 from app.services.invest_view_model.calendar_service import build_calendar
 from app.services.invest_view_model.feed_news_service import build_feed_news
 from app.services.invest_view_model.feed_research_service import build_feed_research
+from app.services.invest_view_model.fx_dashboard_service import build_fx_dashboard
 from app.services.invest_view_model.investor_flow_service import (
     build_investor_flow_cards,
 )
@@ -124,6 +126,15 @@ async def get_market_dashboard(
     """Read-only Naver-style market/index dashboard source (ROB-198)."""
     _ = user
     return await build_market_dashboard()
+
+
+@router.get("/market/fx/dashboard")
+async def get_fx_dashboard(
+    user: Annotated[Any, Depends(get_authenticated_user)],
+) -> FxDashboardResponse:
+    """Read-only FX·macro dashboard contract fixture (ROB-216)."""
+    _ = user
+    return await build_fx_dashboard()
 
 
 @router.get("/coverage")

--- a/app/schemas/invest_fx_dashboard.py
+++ b/app/schemas/invest_fx_dashboard.py
@@ -1,0 +1,179 @@
+"""ROB-216 — strict read-only /invest FX·macro dashboard contract."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+FxDashboardDataState = Literal["fresh", "partial", "missing", "stale", "error"]
+FxDashboardTone = Literal["up", "down", "flat", "unknown"]
+DefenseSignalState = Literal[
+    "none",
+    "watch",
+    "elevated",
+    "after_verification_required",
+]
+DefenseSignalConfidence = Literal["low", "medium", "high"]
+FxDisclaimerSeverity = Literal["info", "caution", "warning"]
+FxDashboardThresholdState = Literal["watch", "near", "breached"]
+
+
+class FxDashboardSourceFreshness(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    label: str
+    dataState: FxDashboardDataState
+    updatedAt: datetime | None = None
+    staleAfterMinutes: int | None = Field(default=None, ge=0)
+    warning: str | None = None
+
+
+class FxDashboardDisclaimer(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: str
+    severity: FxDisclaimerSeverity
+    textKo: str
+
+
+class FxDashboardQuoteMetric(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    label: str | None = None
+    value: float | None = None
+    spot: float | None = None
+    change: float | None = None
+    changePct: float | None = None
+    tone: FxDashboardTone = "unknown"
+    updatedAt: datetime | None = None
+    dataState: FxDashboardDataState | None = None
+    source: str
+
+
+class FxDashboardThreshold(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    level: float
+    label: str
+    distancePct: float
+    state: FxDashboardThresholdState
+
+
+class FxDashboardEvidenceItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str
+    labelKo: str
+    value: str | None = None
+    source: str
+    dataState: FxDashboardDataState
+
+
+class FxDashboardDefenseSignal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    state: DefenseSignalState
+    score: int = Field(ge=0, le=100)
+    confidence: DefenseSignalConfidence
+    labelKo: str
+    summaryKo: str
+    reasonsKo: list[str] = Field(default_factory=list)
+    evidence: list[FxDashboardEvidenceItem] = Field(default_factory=list)
+    notConfirmedIntervention: bool
+    needsAfterVerification: bool
+
+
+class FxDashboardCollectionItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    label: str
+    value: float | None = None
+    changePct: float | None = None
+    dataState: FxDashboardDataState
+    source: str
+
+
+class FxDashboardForeignFlowItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    label: str
+    value: str | None = None
+    source: str
+    dataState: FxDashboardDataState
+
+
+class FxDashboardForeignFlowSection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    dataState: FxDashboardDataState
+    summaryKo: str
+    items: list[FxDashboardForeignFlowItem] = Field(default_factory=list)
+
+
+class FxDashboardNewsItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str
+    source: str
+    publishedAt: datetime | None = None
+    url: str | None = None
+    dataState: FxDashboardDataState = "fresh"
+
+
+class FxDashboardNewsSection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    dataState: FxDashboardDataState
+    items: list[FxDashboardNewsItem] = Field(default_factory=list)
+    warning: str | None = None
+
+
+class FxDashboardEventItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: str
+    startsAt: datetime | None = None
+    source: str
+    dataState: FxDashboardDataState = "fresh"
+
+
+class FxDashboardEventsSection(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    dataState: FxDashboardDataState
+    items: list[FxDashboardEventItem] = Field(default_factory=list)
+    warning: str | None = None
+
+
+class FxDashboardAfterVerification(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    dataState: FxDashboardDataState
+    officialEvidence: list[FxDashboardEvidenceItem] = Field(default_factory=list)
+    dealerEvidence: list[FxDashboardEvidenceItem] = Field(default_factory=list)
+    ndfEvidence: list[FxDashboardEvidenceItem] = Field(default_factory=list)
+    summaryKo: str
+
+
+class FxDashboardResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    asOf: datetime
+    dataState: FxDashboardDataState
+    warnings: list[str] = Field(default_factory=list)
+    disclaimers: list[FxDashboardDisclaimer] = Field(default_factory=list)
+    sourceFreshness: list[FxDashboardSourceFreshness] = Field(default_factory=list)
+    usdKrw: FxDashboardQuoteMetric
+    thresholds: list[FxDashboardThreshold] = Field(default_factory=list)
+    defenseSignal: FxDashboardDefenseSignal
+    globalDollar: list[FxDashboardCollectionItem] = Field(default_factory=list)
+    krwCrosses: list[FxDashboardCollectionItem] = Field(default_factory=list)
+    foreignFlow: FxDashboardForeignFlowSection
+    news: FxDashboardNewsSection
+    events: FxDashboardEventsSection
+    afterVerification: FxDashboardAfterVerification

--- a/app/services/invest_view_model/fx_dashboard_service.py
+++ b/app/services/invest_view_model/fx_dashboard_service.py
@@ -1,0 +1,195 @@
+"""ROB-216 — deterministic fixture service for /invest FX·macro dashboard."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from app.schemas.invest_fx_dashboard import (
+    FxDashboardAfterVerification,
+    FxDashboardCollectionItem,
+    FxDashboardDefenseSignal,
+    FxDashboardDisclaimer,
+    FxDashboardEventsSection,
+    FxDashboardEvidenceItem,
+    FxDashboardForeignFlowSection,
+    FxDashboardNewsSection,
+    FxDashboardQuoteMetric,
+    FxDashboardResponse,
+    FxDashboardSourceFreshness,
+    FxDashboardThreshold,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _distance_pct(*, level: float, spot: float) -> float:
+    return round(((level - spot) / spot) * 100, 2)
+
+
+async def build_fx_dashboard(*, as_of: datetime | None = None) -> FxDashboardResponse:
+    """Return the initial read-only FX dashboard contract fixture.
+
+    This K1 slice intentionally avoids live provider calls, broker clients,
+    database writes, scheduler activation, and watch/order intent creation. Later
+    ROB-217/218/220 lanes can replace individual deferred sources while keeping
+    the sourceFreshness envelope stable.
+    """
+    resolved_as_of = as_of or _now()
+    if resolved_as_of.tzinfo is None:
+        resolved_as_of = resolved_as_of.replace(tzinfo=UTC)
+
+    spot_updated_at = resolved_as_of - timedelta(minutes=3)
+    stale_updated_at = resolved_as_of - timedelta(hours=12)
+    spot = 1498.70
+
+    freshness = [
+        FxDashboardSourceFreshness(
+            source="fixture_usdkrw_spot",
+            label="USD/KRW 현물",
+            dataState="fresh",
+            updatedAt=spot_updated_at,
+            staleAfterMinutes=10,
+            warning=None,
+        ),
+        FxDashboardSourceFreshness(
+            source="fixture_global_dollar",
+            label="글로벌 달러 비교",
+            dataState="stale",
+            updatedAt=stale_updated_at,
+            staleAfterMinutes=60,
+            warning="DXY/CNH/JPY/EUR live provider는 ROB-217에서 연결",
+        ),
+        FxDashboardSourceFreshness(
+            source="official_after_verification",
+            label="사후 검증 자료",
+            dataState="missing",
+            updatedAt=None,
+            staleAfterMinutes=None,
+            warning="공식/딜러/NDF 근거가 없으면 확정 표현 금지",
+        ),
+    ]
+
+    defense_evidence = [
+        FxDashboardEvidenceItem(
+            kind="price",
+            labelKo="USD/KRW spot",
+            value=f"{spot:.2f}",
+            source="fixture_usdkrw_spot",
+            dataState="fresh",
+        )
+    ]
+
+    return FxDashboardResponse(
+        asOf=resolved_as_of,
+        dataState="partial",
+        warnings=[
+            "usdkrw_spot: fixture provider; live provider not wired",
+            "DXY/CNH/JPY/EUR/NDF/flow/news/calendar providers are deferred to ROB-217/218/220",
+        ],
+        disclaimers=[
+            FxDashboardDisclaimer(
+                code="not_confirmed_intervention",
+                severity="caution",
+                textKo="이 신호는 방어성 매도/수급 의심을 정리한 참고 지표이며 당국의 확정 개입 근거가 아닙니다. 공식 발표·딜러 코멘트·NDF 등 사후 검증이 필요합니다.",
+            )
+        ],
+        sourceFreshness=freshness,
+        usdKrw=FxDashboardQuoteMetric(
+            symbol="USDKRW",
+            spot=spot,
+            change=3.2,
+            changePct=0.21,
+            tone="up",
+            updatedAt=spot_updated_at,
+            source="fixture_usdkrw_spot",
+        ),
+        thresholds=[
+            FxDashboardThreshold(
+                level=1450,
+                label="주의",
+                distancePct=_distance_pct(level=1450, spot=spot),
+                state="watch",
+            ),
+            FxDashboardThreshold(
+                level=1500,
+                label="심리적 저항/당국 경계",
+                distancePct=_distance_pct(level=1500, spot=spot),
+                state="near",
+            ),
+        ],
+        defenseSignal=FxDashboardDefenseSignal(
+            state="watch",
+            score=42,
+            confidence="low",
+            labelKo="당국 경계감/방어성 수급 의심",
+            summaryKo="1500원 부근 접근으로 경계 신호는 있으나 확정 개입 근거는 없습니다.",
+            reasonsKo=[
+                "1500원 근접",
+                "글로벌 달러 비교 일부 미수집",
+                "사후 검증 자료 없음",
+            ],
+            evidence=defense_evidence,
+            notConfirmedIntervention=True,
+            needsAfterVerification=True,
+        ),
+        globalDollar=[
+            FxDashboardCollectionItem(
+                symbol="DXY",
+                label="달러인덱스",
+                value=None,
+                changePct=None,
+                dataState="missing",
+                source="deferred",
+            ),
+            FxDashboardCollectionItem(
+                symbol="USDCNH",
+                label="달러/위안",
+                value=None,
+                changePct=None,
+                dataState="missing",
+                source="deferred",
+            ),
+        ],
+        krwCrosses=[
+            FxDashboardCollectionItem(
+                symbol="CNYKRW",
+                label="위안/원",
+                value=None,
+                changePct=None,
+                dataState="missing",
+                source="deferred",
+            ),
+            FxDashboardCollectionItem(
+                symbol="JPYKRW",
+                label="엔/원",
+                value=None,
+                changePct=None,
+                dataState="missing",
+                source="deferred",
+            ),
+        ],
+        foreignFlow=FxDashboardForeignFlowSection(
+            dataState="missing",
+            summaryKo="외국인 수급 연결은 후속 작업입니다.",
+            items=[],
+        ),
+        news=FxDashboardNewsSection(
+            dataState="missing",
+            items=[],
+            warning="FX/당국 발언 뉴스 필터는 ROB-220에서 연결",
+        ),
+        events=FxDashboardEventsSection(
+            dataState="missing",
+            items=[],
+            warning="FX macro calendar linkage는 ROB-220에서 연결",
+        ),
+        afterVerification=FxDashboardAfterVerification(
+            dataState="missing",
+            officialEvidence=[],
+            dealerEvidence=[],
+            ndfEvidence=[],
+            summaryKo="공식 발표·딜러 코멘트·NDF 근거가 확인되기 전까지 확정 개입으로 표현하지 않습니다.",
+        ),
+    )

--- a/frontend/invest/src/api/fxDashboard.ts
+++ b/frontend/invest/src/api/fxDashboard.ts
@@ -1,0 +1,9 @@
+import type { FxDashboardResponse } from "../types/fxDashboard";
+
+export async function fetchFxDashboard(signal?: AbortSignal): Promise<FxDashboardResponse> {
+  const res = await fetch("/invest/api/market/fx/dashboard", { credentials: "include", signal });
+  if (!res.ok) {
+    throw new Error(`/invest/api/market/fx/dashboard ${res.status}`);
+  }
+  return res.json();
+}

--- a/frontend/invest/src/types/fxDashboard.ts
+++ b/frontend/invest/src/types/fxDashboard.ts
@@ -1,0 +1,135 @@
+export type FxDashboardDataState = "fresh" | "partial" | "missing" | "stale" | "error";
+export type FxDashboardTone = "up" | "down" | "flat" | "unknown";
+export type DefenseSignalState = "none" | "watch" | "elevated" | "after_verification_required";
+export type DefenseSignalConfidence = "low" | "medium" | "high";
+export type FxDisclaimerSeverity = "info" | "caution" | "warning";
+export type FxDashboardThresholdState = "watch" | "near" | "breached";
+
+export type FxDashboardSourceFreshness = {
+  source: string;
+  label: string;
+  dataState: FxDashboardDataState;
+  updatedAt?: string | null;
+  staleAfterMinutes?: number | null;
+  warning?: string | null;
+};
+
+export type FxDashboardDisclaimer = {
+  code: string;
+  severity: FxDisclaimerSeverity;
+  textKo: string;
+};
+
+export type FxDashboardQuoteMetric = {
+  symbol: string;
+  label?: string | null;
+  value?: number | null;
+  spot?: number | null;
+  change?: number | null;
+  changePct?: number | null;
+  tone: FxDashboardTone;
+  updatedAt?: string | null;
+  dataState?: FxDashboardDataState | null;
+  source: string;
+};
+
+export type FxDashboardThreshold = {
+  level: number;
+  label: string;
+  distancePct: number;
+  state: FxDashboardThresholdState;
+};
+
+export type FxDashboardEvidenceItem = {
+  kind: string;
+  labelKo: string;
+  value?: string | null;
+  source: string;
+  dataState: FxDashboardDataState;
+};
+
+export type FxDashboardDefenseSignal = {
+  state: DefenseSignalState;
+  score: number;
+  confidence: DefenseSignalConfidence;
+  labelKo: string;
+  summaryKo: string;
+  reasonsKo: string[];
+  evidence: FxDashboardEvidenceItem[];
+  notConfirmedIntervention: boolean;
+  needsAfterVerification: boolean;
+};
+
+export type FxDashboardCollectionItem = {
+  symbol: string;
+  label: string;
+  value?: number | null;
+  changePct?: number | null;
+  dataState: FxDashboardDataState;
+  source: string;
+};
+
+export type FxDashboardForeignFlowItem = {
+  label: string;
+  value?: string | null;
+  source: string;
+  dataState: FxDashboardDataState;
+};
+
+export type FxDashboardForeignFlowSection = {
+  dataState: FxDashboardDataState;
+  summaryKo: string;
+  items: FxDashboardForeignFlowItem[];
+};
+
+export type FxDashboardNewsItem = {
+  title: string;
+  source: string;
+  publishedAt?: string | null;
+  url?: string | null;
+  dataState: FxDashboardDataState;
+};
+
+export type FxDashboardNewsSection = {
+  dataState: FxDashboardDataState;
+  items: FxDashboardNewsItem[];
+  warning?: string | null;
+};
+
+export type FxDashboardEventItem = {
+  title: string;
+  startsAt?: string | null;
+  source: string;
+  dataState: FxDashboardDataState;
+};
+
+export type FxDashboardEventsSection = {
+  dataState: FxDashboardDataState;
+  items: FxDashboardEventItem[];
+  warning?: string | null;
+};
+
+export type FxDashboardAfterVerification = {
+  dataState: FxDashboardDataState;
+  officialEvidence: FxDashboardEvidenceItem[];
+  dealerEvidence: FxDashboardEvidenceItem[];
+  ndfEvidence: FxDashboardEvidenceItem[];
+  summaryKo: string;
+};
+
+export type FxDashboardResponse = {
+  asOf: string;
+  dataState: FxDashboardDataState;
+  warnings: string[];
+  disclaimers: FxDashboardDisclaimer[];
+  sourceFreshness: FxDashboardSourceFreshness[];
+  usdKrw: FxDashboardQuoteMetric;
+  thresholds: FxDashboardThreshold[];
+  defenseSignal: FxDashboardDefenseSignal;
+  globalDollar: FxDashboardCollectionItem[];
+  krwCrosses: FxDashboardCollectionItem[];
+  foreignFlow: FxDashboardForeignFlowSection;
+  news: FxDashboardNewsSection;
+  events: FxDashboardEventsSection;
+  afterVerification: FxDashboardAfterVerification;
+};

--- a/tests/test_invest_fx_dashboard.py
+++ b/tests/test_invest_fx_dashboard.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.routers import invest_api
+from app.routers.dependencies import get_authenticated_user
+from app.routers.invest_api import router as invest_api_router
+from app.schemas.invest_fx_dashboard import FxDashboardResponse
+from app.services.invest_view_model.fx_dashboard_service import build_fx_dashboard
+
+
+def _contains_key(payload: Any, forbidden: set[str]) -> bool:
+    if isinstance(payload, dict):
+        return any(key in forbidden or _contains_key(value, forbidden) for key, value in payload.items())
+    if isinstance(payload, list):
+        return any(_contains_key(item, forbidden) for item in payload)
+    return False
+
+
+def _safe_text(payload: Any) -> str:
+    if isinstance(payload, str):
+        return payload
+    if isinstance(payload, dict):
+        return " ".join(_safe_text(value) for value in payload.values())
+    if isinstance(payload, list):
+        return " ".join(_safe_text(item) for item in payload)
+    return ""
+
+
+def _sample_payload() -> dict[str, Any]:
+    return {
+        "asOf": datetime(2026, 5, 13, 8, 58, 16, tzinfo=UTC),
+        "dataState": "partial",
+        "warnings": ["usdkrw_spot: fixture provider; live provider not wired"],
+        "disclaimers": [
+            {
+                "code": "not_confirmed_intervention",
+                "severity": "caution",
+                "textKo": "이 신호는 방어성 매도/수급 의심을 정리한 참고 지표이며 당국 개입 확정 근거가 아닙니다. 공식 발표·딜러 코멘트·NDF 등 사후 검증이 필요합니다.",
+            }
+        ],
+        "sourceFreshness": [
+            {
+                "source": "fixture_usdkrw_spot",
+                "label": "USD/KRW 현물",
+                "dataState": "fresh",
+                "updatedAt": datetime(2026, 5, 13, 8, 55, tzinfo=UTC),
+                "staleAfterMinutes": 10,
+                "warning": None,
+            },
+            {
+                "source": "official_after_verification",
+                "label": "사후 검증 자료",
+                "dataState": "missing",
+                "updatedAt": None,
+                "staleAfterMinutes": None,
+                "warning": "공식/딜러/NDF 근거가 없으면 확정 표현 금지",
+            },
+        ],
+        "usdKrw": {
+            "symbol": "USDKRW",
+            "spot": 1498.7,
+            "change": 3.2,
+            "changePct": 0.21,
+            "tone": "up",
+            "updatedAt": datetime(2026, 5, 13, 8, 55, tzinfo=UTC),
+            "source": "fixture_usdkrw_spot",
+        },
+        "thresholds": [
+            {"level": 1450, "label": "주의", "distancePct": 3.36, "state": "watch"},
+            {"level": 1500, "label": "심리적 저항/당국 경계", "distancePct": -0.09, "state": "near"},
+        ],
+        "defenseSignal": {
+            "state": "watch",
+            "score": 42,
+            "confidence": "low",
+            "labelKo": "당국 경계감/방어성 수급 의심",
+            "summaryKo": "1500원 부근 접근으로 경계 신호는 있으나 확정 개입 근거는 없습니다.",
+            "reasonsKo": ["1500원 근접", "글로벌 달러 비교 일부 미수집", "사후 검증 자료 없음"],
+            "evidence": [
+                {
+                    "kind": "price",
+                    "labelKo": "USD/KRW spot",
+                    "value": "1498.70",
+                    "source": "fixture_usdkrw_spot",
+                    "dataState": "fresh",
+                }
+            ],
+            "notConfirmedIntervention": True,
+            "needsAfterVerification": True,
+        },
+        "globalDollar": [
+            {
+                "symbol": "DXY",
+                "label": "달러인덱스",
+                "value": None,
+                "changePct": None,
+                "dataState": "missing",
+                "source": "deferred",
+            }
+        ],
+        "krwCrosses": [
+            {
+                "symbol": "CNYKRW",
+                "label": "위안/원",
+                "value": None,
+                "changePct": None,
+                "dataState": "missing",
+                "source": "deferred",
+            }
+        ],
+        "foreignFlow": {"dataState": "missing", "summaryKo": "외국인 수급 연결은 후속 작업입니다.", "items": []},
+        "news": {"dataState": "missing", "items": [], "warning": "FX/당국 발언 뉴스 필터는 ROB-220에서 연결"},
+        "events": {"dataState": "missing", "items": [], "warning": "FX macro calendar linkage는 ROB-220에서 연결"},
+        "afterVerification": {
+            "dataState": "missing",
+            "officialEvidence": [],
+            "dealerEvidence": [],
+            "ndfEvidence": [],
+            "summaryKo": "공식 발표·딜러 코멘트·NDF 근거가 확인되기 전까지 확정 개입으로 표현하지 않습니다.",
+        },
+    }
+
+
+@pytest.mark.unit
+def test_fx_dashboard_schema_forbids_unknown_fields() -> None:
+    payload = _sample_payload()
+    payload["unexpected"] = True
+
+    with pytest.raises(ValidationError):
+        FxDashboardResponse.model_validate(payload)
+
+
+@pytest.mark.unit
+def test_fx_dashboard_contract_contains_cautious_disclaimer_shape() -> None:
+    response = FxDashboardResponse.model_validate(_sample_payload())
+
+    assert response.defenseSignal.notConfirmedIntervention is True
+    assert response.defenseSignal.needsAfterVerification is True
+    assert response.disclaimers[0].code == "not_confirmed_intervention"
+    caution_copy = response.disclaimers[0].textKo
+    assert "확정" in caution_copy
+    assert "아닙니다" in caution_copy
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_fx_dashboard_fixture_has_partial_provider_states() -> None:
+    response = await build_fx_dashboard(as_of=datetime(2026, 5, 13, 8, 58, 16, tzinfo=UTC))
+
+    assert response.dataState == "partial"
+    freshness_states = {item.dataState for item in response.sourceFreshness}
+    assert "fresh" in freshness_states
+    assert freshness_states & {"missing", "stale"}
+    assert 0 <= response.defenseSignal.score <= 100
+    assert response.news.dataState == "missing"
+    assert response.events.dataState == "missing"
+    assert response.afterVerification.dataState == "missing"
+    assert "개입 확정" not in _safe_text(response.model_dump())
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    app = FastAPI()
+    app.include_router(invest_api_router)
+    app.dependency_overrides[get_authenticated_user] = lambda: type("U", (), {"id": 1})()
+
+    async def _stub_dashboard() -> FxDashboardResponse:
+        return await build_fx_dashboard(as_of=datetime(2026, 5, 13, 8, 58, 16, tzinfo=UTC))
+
+    monkeypatch.setattr(invest_api, "build_fx_dashboard", _stub_dashboard)
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_get_fx_dashboard_returns_read_only_payload(client: TestClient) -> None:
+    response = client.get("/invest/api/market/fx/dashboard")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["dataState"] == "partial"
+    assert body["sourceFreshness"]
+    assert body["defenseSignal"]["notConfirmedIntervention"] is True
+    assert body["defenseSignal"]["needsAfterVerification"] is True
+    assert body["disclaimers"][0]["code"] == "not_confirmed_intervention"
+    assert not _contains_key(
+        body,
+        {"order_id", "client_order_id", "watch_order", "approval_issue_id"},
+    )

--- a/tests/test_invest_fx_dashboard.py
+++ b/tests/test_invest_fx_dashboard.py
@@ -17,7 +17,10 @@ from app.services.invest_view_model.fx_dashboard_service import build_fx_dashboa
 
 def _contains_key(payload: Any, forbidden: set[str]) -> bool:
     if isinstance(payload, dict):
-        return any(key in forbidden or _contains_key(value, forbidden) for key, value in payload.items())
+        return any(
+            key in forbidden or _contains_key(value, forbidden)
+            for key, value in payload.items()
+        )
     if isinstance(payload, list):
         return any(_contains_key(item, forbidden) for item in payload)
     return False
@@ -74,7 +77,12 @@ def _sample_payload() -> dict[str, Any]:
         },
         "thresholds": [
             {"level": 1450, "label": "주의", "distancePct": 3.36, "state": "watch"},
-            {"level": 1500, "label": "심리적 저항/당국 경계", "distancePct": -0.09, "state": "near"},
+            {
+                "level": 1500,
+                "label": "심리적 저항/당국 경계",
+                "distancePct": -0.09,
+                "state": "near",
+            },
         ],
         "defenseSignal": {
             "state": "watch",
@@ -82,7 +90,11 @@ def _sample_payload() -> dict[str, Any]:
             "confidence": "low",
             "labelKo": "당국 경계감/방어성 수급 의심",
             "summaryKo": "1500원 부근 접근으로 경계 신호는 있으나 확정 개입 근거는 없습니다.",
-            "reasonsKo": ["1500원 근접", "글로벌 달러 비교 일부 미수집", "사후 검증 자료 없음"],
+            "reasonsKo": [
+                "1500원 근접",
+                "글로벌 달러 비교 일부 미수집",
+                "사후 검증 자료 없음",
+            ],
             "evidence": [
                 {
                     "kind": "price",
@@ -115,9 +127,21 @@ def _sample_payload() -> dict[str, Any]:
                 "source": "deferred",
             }
         ],
-        "foreignFlow": {"dataState": "missing", "summaryKo": "외국인 수급 연결은 후속 작업입니다.", "items": []},
-        "news": {"dataState": "missing", "items": [], "warning": "FX/당국 발언 뉴스 필터는 ROB-220에서 연결"},
-        "events": {"dataState": "missing", "items": [], "warning": "FX macro calendar linkage는 ROB-220에서 연결"},
+        "foreignFlow": {
+            "dataState": "missing",
+            "summaryKo": "외국인 수급 연결은 후속 작업입니다.",
+            "items": [],
+        },
+        "news": {
+            "dataState": "missing",
+            "items": [],
+            "warning": "FX/당국 발언 뉴스 필터는 ROB-220에서 연결",
+        },
+        "events": {
+            "dataState": "missing",
+            "items": [],
+            "warning": "FX macro calendar linkage는 ROB-220에서 연결",
+        },
         "afterVerification": {
             "dataState": "missing",
             "officialEvidence": [],
@@ -152,7 +176,9 @@ def test_fx_dashboard_contract_contains_cautious_disclaimer_shape() -> None:
 @pytest.mark.unit
 @pytest.mark.asyncio
 async def test_build_fx_dashboard_fixture_has_partial_provider_states() -> None:
-    response = await build_fx_dashboard(as_of=datetime(2026, 5, 13, 8, 58, 16, tzinfo=UTC))
+    response = await build_fx_dashboard(
+        as_of=datetime(2026, 5, 13, 8, 58, 16, tzinfo=UTC)
+    )
 
     assert response.dataState == "partial"
     freshness_states = {item.dataState for item in response.sourceFreshness}
@@ -169,10 +195,14 @@ async def test_build_fx_dashboard_fixture_has_partial_provider_states() -> None:
 def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     app = FastAPI()
     app.include_router(invest_api_router)
-    app.dependency_overrides[get_authenticated_user] = lambda: type("U", (), {"id": 1})()
+    app.dependency_overrides[get_authenticated_user] = lambda: type(
+        "U", (), {"id": 1}
+    )()
 
     async def _stub_dashboard() -> FxDashboardResponse:
-        return await build_fx_dashboard(as_of=datetime(2026, 5, 13, 8, 58, 16, tzinfo=UTC))
+        return await build_fx_dashboard(
+            as_of=datetime(2026, 5, 13, 8, 58, 16, tzinfo=UTC)
+        )
 
     monkeypatch.setattr(invest_api, "build_fx_dashboard", _stub_dashboard)
     return TestClient(app)


### PR DESCRIPTION
## Summary
- add read-only `/invest/api/market/fx/dashboard` contract schemas and service fixture for FX·macro dashboard foundation
- wire the route under `/invest/api/market/fx/dashboard`
- add frontend API/types for the dashboard response contract
- cover partial provider states, source freshness, warnings, defenseSignal, and cautious Korean disclaimer text

## Safety
- read-only `/invest` analysis contract only
- no broker order submit/cancel/modify paths touched
- no watch/order intent creation
- no production DB writes, backfills, or scheduler activation

## Verification
- PASS: `uv run ruff format --check app/ tests/`
- PASS: `uv run pytest tests/test_invest_fx_dashboard.py -q` (4 passed, 2 existing Pydantic warnings)
- PASS: `cd frontend/invest && npm run typecheck`
- KNOWN/UNRELATED: `cd frontend/invest && npm test -- --run` currently has deterministic calendar test failures in unrelated ROB-185 calendar suites; this PR does not touch calendar files. Failures assert old `calendar-cluster` / exact cluster text while current UI renders `calendar-cluster-overflow` and split overflow copy.

Closes ROB-216


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched FX Dashboard with currency market metrics, threshold alerts, defense signals with confidence levels, foreign flow data, news, and events sections. Includes data freshness indicators and risk disclaimers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/810)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->