### PR TITLE
feat(invest): score USDKRW 1500 defense signal

### DIFF
--- a/app/services/invest_view_model/fx_dashboard_service.py
+++ b/app/services/invest_view_model/fx_dashboard_service.py
@@ -7,7 +7,6 @@ from datetime import UTC, datetime, timedelta
 from app.schemas.invest_fx_dashboard import (
     FxDashboardAfterVerification,
     FxDashboardCollectionItem,
-    FxDashboardDefenseSignal,
     FxDashboardDisclaimer,
     FxDashboardEventsSection,
     FxDashboardEvidenceItem,
@@ -17,6 +16,11 @@ from app.schemas.invest_fx_dashboard import (
     FxDashboardResponse,
     FxDashboardSourceFreshness,
     FxDashboardThreshold,
+)
+from app.services.invest_view_model.fx_defense_signal import (
+    DefenseScoringInput,
+    _score_defense_signal,
+    _threshold_state,
 )
 
 
@@ -71,22 +75,38 @@ async def build_fx_dashboard(*, as_of: datetime | None = None) -> FxDashboardRes
         ),
     ]
 
-    defense_evidence = [
+    news_context = [
         FxDashboardEvidenceItem(
-            kind="price",
-            labelKo="USD/KRW spot",
-            value=f"{spot:.2f}",
-            source="fixture_usdkrw_spot",
-            dataState="fresh",
+            kind="news_context",
+            labelKo="환율/당국 경계 뉴스 context-only fixture",
+            value="1500원 경계감 관련 보도는 참고 맥락으로만 사용",
+            source="fixture_fx_news_context",
+            dataState="stale",
         )
     ]
+    defense_signal = _score_defense_signal(
+        DefenseScoringInput(
+            spot=spot,
+            recent_high=1499.80,
+            recent_close_or_last=spot,
+            rejected_within_minutes=30,
+            global_dollar_change_pct=0.24,
+            usdcnh_change_pct=0.16,
+            usd_jpy_change_pct=0.08,
+            krw_cross_change_pcts={"CNYKRW": -0.06, "JPYKRW": None},
+            news_context=news_context,
+            authority_context=[],
+            after_verification_has_strong_evidence=False,
+        )
+    )
 
     return FxDashboardResponse(
         asOf=resolved_as_of,
         dataState="partial",
         warnings=[
             "usdkrw_spot: fixture provider; live provider not wired",
-            "DXY/CNH/JPY/EUR/NDF/flow/news/calendar providers are deferred to ROB-217/218/220",
+            "DXY/CNH/JPY/EUR/NDF/flow/news/calendar providers are deferred to ROB-217/220",
+            "ROB-218 defenseSignal scoring is deterministic fixture scoring, not confirmed intervention evidence",
         ],
         disclaimers=[
             FxDashboardDisclaimer(
@@ -116,50 +136,36 @@ async def build_fx_dashboard(*, as_of: datetime | None = None) -> FxDashboardRes
                 level=1500,
                 label="심리적 저항/당국 경계",
                 distancePct=_distance_pct(level=1500, spot=spot),
-                state="near",
+                state=_threshold_state(level=1500, spot=spot),
             ),
         ],
-        defenseSignal=FxDashboardDefenseSignal(
-            state="watch",
-            score=42,
-            confidence="low",
-            labelKo="당국 경계감/방어성 수급 의심",
-            summaryKo="1500원 부근 접근으로 경계 신호는 있으나 확정 개입 근거는 없습니다.",
-            reasonsKo=[
-                "1500원 근접",
-                "글로벌 달러 비교 일부 미수집",
-                "사후 검증 자료 없음",
-            ],
-            evidence=defense_evidence,
-            notConfirmedIntervention=True,
-            needsAfterVerification=True,
-        ),
+        defenseSignal=defense_signal,
         globalDollar=[
             FxDashboardCollectionItem(
                 symbol="DXY",
                 label="달러인덱스",
-                value=None,
-                changePct=None,
-                dataState="missing",
-                source="deferred",
+                value=105.40,
+                changePct=0.24,
+                dataState="stale",
+                source="fixture_global_dollar",
             ),
             FxDashboardCollectionItem(
                 symbol="USDCNH",
                 label="달러/위안",
-                value=None,
-                changePct=None,
-                dataState="missing",
-                source="deferred",
+                value=7.24,
+                changePct=0.16,
+                dataState="stale",
+                source="fixture_global_dollar",
             ),
         ],
         krwCrosses=[
             FxDashboardCollectionItem(
                 symbol="CNYKRW",
                 label="위안/원",
-                value=None,
-                changePct=None,
-                dataState="missing",
-                source="deferred",
+                value=207.10,
+                changePct=-0.06,
+                dataState="stale",
+                source="fixture_krw_crosses",
             ),
             FxDashboardCollectionItem(
                 symbol="JPYKRW",

--- a/app/services/invest_view_model/fx_defense_signal.py
+++ b/app/services/invest_view_model/fx_defense_signal.py
@@ -162,11 +162,16 @@ def _score_rejection(
             dataState="fresh",
         )
     )
+    window_suffix = (
+        f" ({scoring_input.rejected_within_minutes}분 이내)"
+        if scoring_input.rejected_within_minutes is not None
+        else ""
+    )
     if high >= 1499.5 and pullback >= 2.0:
-        reasons.append("1500원 직전 상단 꼬리/되밀림")
+        reasons.append(f"1500원 직전 상단 꼬리/되밀림{window_suffix}")
         return 25
     if high >= 1498.0 and pullback >= 1.0:
-        reasons.append("1500원 부근 되밀림")
+        reasons.append(f"1500원 부근 되밀림{window_suffix}")
         return 15
     return 0
 
@@ -239,22 +244,25 @@ def _score_context(
     reasons: list[str],
     evidence: list[FxDashboardEvidenceItem],
 ) -> int:
-    points = 0
+    """Attach news/authority context without letting context-only evidence score.
+
+    ROB-218 treats news, authority comments, dealer context, and NDF references as
+    explanatory evidence for the user-facing card. Price/rejection/divergence
+    drive the deterministic score; context changes confidence wording only via
+    ``after_verification_has_strong_evidence`` in ``_map_signal``.
+    """
     if scoring_input.news_context:
-        points = max(points, 5)
         reasons.append("환율/당국 경계 뉴스 확인")
         evidence.extend(scoring_input.news_context)
 
     if scoring_input.authority_context:
         evidence.extend(scoring_input.authority_context)
         if scoring_input.after_verification_has_strong_evidence:
-            points = max(points, 15)
             reasons.append("사후 검증 근거 일부 확인")
         else:
-            points = max(points, 5)
             reasons.append("공식/딜러/NDF 사후 근거 확인 필요")
 
-    return min(points, 15)
+    return 0
 
 
 def _map_signal(
@@ -299,9 +307,6 @@ def _is_global_dollar_firm(scoring_input: DefenseScoringInput) -> bool:
 
 
 def _usdkrw_failed_near_1500(scoring_input: DefenseScoringInput) -> bool:
-    spot = scoring_input.spot
-    if spot is not None and 0 <= scoring_input.threshold - spot <= 5:
-        return True
     high = scoring_input.recent_high
     close = scoring_input.recent_close_or_last
     return high is not None and close is not None and high >= 1498.0 and close < high

--- a/app/services/invest_view_model/fx_defense_signal.py
+++ b/app/services/invest_view_model/fx_defense_signal.py
@@ -1,0 +1,318 @@
+"""Pure ROB-218 USD/KRW 1500 defense-signal scoring helpers.
+
+The scorer is intentionally deterministic and side-effect free. It transforms
+already-collected dashboard inputs into the existing FX dashboard transport
+schema; it does not call providers, databases, broker/order tooling, or
+schedulers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.schemas.invest_fx_dashboard import (
+    FxDashboardDefenseSignal,
+    FxDashboardEvidenceItem,
+)
+
+DEFENSE_THRESHOLD_LEVEL = 1500.0
+NEAR_THRESHOLD_DISTANCE_PCT = 0.75
+
+
+@dataclass(frozen=True)
+class DefenseScoringInput:
+    spot: float | None
+    threshold: float = DEFENSE_THRESHOLD_LEVEL
+    recent_high: float | None = None
+    recent_close_or_last: float | None = None
+    rejected_within_minutes: int | None = None
+    global_dollar_change_pct: float | None = None
+    usdcnh_change_pct: float | None = None
+    usd_jpy_change_pct: float | None = None
+    krw_cross_change_pcts: dict[str, float | None] = field(default_factory=dict)
+    news_context: list[FxDashboardEvidenceItem] = field(default_factory=list)
+    authority_context: list[FxDashboardEvidenceItem] = field(default_factory=list)
+    after_verification_has_strong_evidence: bool = False
+
+
+def _threshold_state(*, level: float, spot: float | None) -> str:
+    """Classify proximity to a dashboard threshold.
+
+    For the 1500 USD/KRW defense level, ``near`` covers the 0.75% band below
+    the level and ``breached`` covers spot at/above the level. Missing spot is
+    treated as watch so the caller can separately mark source freshness.
+    """
+    if spot is None:
+        return "watch"
+    if spot >= level:
+        return "breached"
+    if 0 <= level - spot <= level * (NEAR_THRESHOLD_DISTANCE_PCT / 100):
+        return "near"
+    return "watch"
+
+
+def _score_defense_signal(scoring_input: DefenseScoringInput) -> FxDashboardDefenseSignal:
+    reasons: list[str] = []
+    evidence: list[FxDashboardEvidenceItem] = []
+    score = 0
+
+    threshold = scoring_input.threshold
+    spot = scoring_input.spot
+
+    if spot is None:
+        reasons.append("USD/KRW 현물 미수집")
+        evidence.append(
+            FxDashboardEvidenceItem(
+                kind="price",
+                labelKo="USD/KRW 현물 미수집",
+                value=None,
+                source="fixture_usdkrw_spot",
+                dataState="missing",
+            )
+        )
+    else:
+        gap = threshold - spot
+        evidence.append(
+            FxDashboardEvidenceItem(
+                kind="price",
+                labelKo="USD/KRW spot",
+                value=f"{spot:.2f}",
+                source="fixture_usdkrw_spot",
+                dataState="fresh",
+            )
+        )
+        if spot >= threshold:
+            score += 35
+            reasons.append("1500원 상향 돌파")
+        elif 0 <= gap <= 1.5:
+            score += 30
+            reasons.append("1500원 1.5원 이내 근접")
+        elif 1.5 < gap <= 5:
+            score += 22
+            reasons.append("1500원 5원 이내 근접")
+        elif 5 < gap <= 15:
+            score += 12
+            reasons.append("1500원 감시권 접근")
+
+    rejection_points = _score_rejection(scoring_input, reasons, evidence)
+    score += rejection_points
+
+    divergence_points = _score_divergence(scoring_input, reasons, evidence)
+    score += divergence_points
+
+    context_points = _score_context(scoring_input, reasons, evidence)
+    score += context_points
+
+    score = min(score, 100)
+    state, confidence, label, summary = _map_signal(score, scoring_input)
+
+    if not scoring_input.after_verification_has_strong_evidence:
+        evidence.append(
+            FxDashboardEvidenceItem(
+                kind="missing_context",
+                labelKo="공식/딜러/NDF 사후 검증 자료 미수집",
+                value=None,
+                source="official_after_verification",
+                dataState="missing",
+            )
+        )
+        if "사후 검증 자료 없음" not in reasons:
+            reasons.append("사후 검증 자료 없음")
+
+    return FxDashboardDefenseSignal(
+        state=state,
+        score=score,
+        confidence=confidence,
+        labelKo=label,
+        summaryKo=summary,
+        reasonsKo=reasons,
+        evidence=evidence,
+        notConfirmedIntervention=True,
+        needsAfterVerification=state != "none" or not scoring_input.after_verification_has_strong_evidence,
+    )
+
+
+def _score_rejection(
+    scoring_input: DefenseScoringInput,
+    reasons: list[str],
+    evidence: list[FxDashboardEvidenceItem],
+) -> int:
+    high = scoring_input.recent_high
+    close = scoring_input.recent_close_or_last
+    if high is None or close is None:
+        reasons.append("상단 꼬리 판단 자료 미수집")
+        evidence.append(
+            FxDashboardEvidenceItem(
+                kind="rejection",
+                labelKo="1500원 부근 상단 꼬리/되밀림 자료 미수집",
+                value=None,
+                source="fixture_usdkrw_intraday",
+                dataState="missing",
+            )
+        )
+        return 0
+
+    pullback = high - close
+    evidence.append(
+        FxDashboardEvidenceItem(
+            kind="rejection",
+            labelKo="1500원 부근 고점 대비 되밀림",
+            value=f"high {high:.2f} / last {close:.2f} / pullback {pullback:.2f}",
+            source="fixture_usdkrw_intraday",
+            dataState="fresh",
+        )
+    )
+    if high >= 1499.5 and pullback >= 2.0:
+        reasons.append("1500원 직전 상단 꼬리/되밀림")
+        return 25
+    if high >= 1498.0 and pullback >= 1.0:
+        reasons.append("1500원 부근 되밀림")
+        return 15
+    return 0
+
+
+def _score_divergence(
+    scoring_input: DefenseScoringInput,
+    reasons: list[str],
+    evidence: list[FxDashboardEvidenceItem],
+) -> int:
+    points = 0
+    dollar_firm = _is_global_dollar_firm(scoring_input)
+    usdkrw_failed_near = _usdkrw_failed_near_1500(scoring_input)
+    missing_global = (
+        scoring_input.global_dollar_change_pct is None
+        and scoring_input.usdcnh_change_pct is None
+        and scoring_input.usd_jpy_change_pct is None
+    )
+    missing_crosses = not scoring_input.krw_cross_change_pcts or all(
+        value is None for value in scoring_input.krw_cross_change_pcts.values()
+    )
+
+    if dollar_firm and usdkrw_failed_near:
+        points += 15
+        reasons.append("글로벌 달러 강세 대비 USD/KRW 상단 제한")
+        evidence.append(
+            FxDashboardEvidenceItem(
+                kind="divergence",
+                labelKo="글로벌 달러 강세 대비 USD/KRW 상단 제한",
+                value=_format_global_dollar_value(scoring_input),
+                source="fixture_global_dollar",
+                dataState="stale",
+            )
+        )
+
+    negative_crosses = [
+        symbol
+        for symbol, value in scoring_input.krw_cross_change_pcts.items()
+        if value is not None and value < 0
+    ]
+    if dollar_firm and len(negative_crosses) >= 2:
+        points += 10
+        reasons.append("원화 교차환율 동반 강세")
+        evidence.append(
+            FxDashboardEvidenceItem(
+                kind="divergence",
+                labelKo="원화 교차환율 동반 강세",
+                value=", ".join(negative_crosses),
+                source="fixture_krw_crosses",
+                dataState="stale",
+            )
+        )
+
+    if missing_global or missing_crosses:
+        reasons.append("글로벌 달러/원화 교차 비교 일부 미수집")
+        evidence.append(
+            FxDashboardEvidenceItem(
+                kind="missing_context",
+                labelKo="글로벌 달러/원화 교차 비교 일부 미수집",
+                value=None,
+                source="fixture_global_dollar",
+                dataState="missing",
+            )
+        )
+
+    return min(points, 25)
+
+
+def _score_context(
+    scoring_input: DefenseScoringInput,
+    reasons: list[str],
+    evidence: list[FxDashboardEvidenceItem],
+) -> int:
+    points = 0
+    if scoring_input.news_context:
+        points = max(points, 5)
+        reasons.append("환율/당국 경계 뉴스 확인")
+        evidence.extend(scoring_input.news_context)
+
+    if scoring_input.authority_context:
+        evidence.extend(scoring_input.authority_context)
+        if scoring_input.after_verification_has_strong_evidence:
+            points = max(points, 15)
+            reasons.append("사후 검증 근거 일부 확인")
+        else:
+            points = max(points, 5)
+            reasons.append("공식/딜러/NDF 사후 근거 확인 필요")
+
+    return min(points, 15)
+
+
+def _map_signal(
+    score: int,
+    scoring_input: DefenseScoringInput,
+) -> tuple[str, str, str, str]:
+    if score < 20:
+        return (
+            "none",
+            "low",
+            "방어 신호 낮음",
+            "1500원 방어성 수급 신호는 낮습니다.",
+        )
+    if score < 45:
+        return (
+            "watch",
+            "low",
+            "당국 경계감/방어성 수급 감시",
+            "1500원 접근으로 당국 경계감/방어성 수급 감시는 필요하지만 확정 개입 근거는 없습니다.",
+        )
+    if score < 70:
+        return (
+            "elevated",
+            "high" if scoring_input.after_verification_has_strong_evidence else "medium",
+            "1500원 부근 방어성 오퍼 의심",
+            "1500원 부근 가격 되밀림과 비교 지표가 겹쳐 방어성 오퍼 가능성이 높아졌지만 확정 개입으로 볼 수는 없습니다.",
+        )
+    return (
+        "after_verification_required",
+        "high" if scoring_input.after_verification_has_strong_evidence else "medium",
+        "사후 검증 필요한 방어성 수급 신호",
+        "1500원 부근 방어성 수급 신호가 강하지만 공식 발표·딜러 코멘트·NDF 등 사후 검증 전까지 확정 개입으로 표현하지 않습니다.",
+    )
+
+
+def _is_global_dollar_firm(scoring_input: DefenseScoringInput) -> bool:
+    global_dollar = scoring_input.global_dollar_change_pct
+    usdcnh = scoring_input.usdcnh_change_pct
+    return (global_dollar is not None and global_dollar >= 0.2) or (
+        usdcnh is not None and usdcnh >= 0.15
+    )
+
+
+def _usdkrw_failed_near_1500(scoring_input: DefenseScoringInput) -> bool:
+    spot = scoring_input.spot
+    if spot is not None and 0 <= scoring_input.threshold - spot <= 5:
+        return True
+    high = scoring_input.recent_high
+    close = scoring_input.recent_close_or_last
+    return high is not None and close is not None and high >= 1498.0 and close < high
+
+
+def _format_global_dollar_value(scoring_input: DefenseScoringInput) -> str | None:
+    parts: list[str] = []
+    if scoring_input.global_dollar_change_pct is not None:
+        parts.append(f"DXY {scoring_input.global_dollar_change_pct:+.2f}%")
+    if scoring_input.usdcnh_change_pct is not None:
+        parts.append(f"USDCNH {scoring_input.usdcnh_change_pct:+.2f}%")
+    if scoring_input.usd_jpy_change_pct is not None:
+        parts.append(f"USDJPY {scoring_input.usd_jpy_change_pct:+.2f}%")
+    return ", ".join(parts) if parts else None

--- a/app/services/invest_view_model/fx_defense_signal.py
+++ b/app/services/invest_view_model/fx_defense_signal.py
@@ -51,7 +51,9 @@ def _threshold_state(*, level: float, spot: float | None) -> str:
     return "watch"
 
 
-def _score_defense_signal(scoring_input: DefenseScoringInput) -> FxDashboardDefenseSignal:
+def _score_defense_signal(
+    scoring_input: DefenseScoringInput,
+) -> FxDashboardDefenseSignal:
     reasons: list[str] = []
     evidence: list[FxDashboardEvidenceItem] = []
     score = 0
@@ -128,7 +130,8 @@ def _score_defense_signal(scoring_input: DefenseScoringInput) -> FxDashboardDefe
         reasonsKo=reasons,
         evidence=evidence,
         notConfirmedIntervention=True,
-        needsAfterVerification=state != "none" or not scoring_input.after_verification_has_strong_evidence,
+        needsAfterVerification=state != "none"
+        or not scoring_input.after_verification_has_strong_evidence,
     )
 
 
@@ -286,7 +289,9 @@ def _map_signal(
     if score < 70:
         return (
             "elevated",
-            "high" if scoring_input.after_verification_has_strong_evidence else "medium",
+            "high"
+            if scoring_input.after_verification_has_strong_evidence
+            else "medium",
             "1500원 부근 방어성 오퍼 의심",
             "1500원 부근 가격 되밀림과 비교 지표가 겹쳐 방어성 오퍼 가능성이 높아졌지만 확정 개입으로 볼 수는 없습니다.",
         )

--- a/tests/test_invest_fx_dashboard.py
+++ b/tests/test_invest_fx_dashboard.py
@@ -11,8 +11,13 @@ from pydantic import ValidationError
 from app.routers import invest_api
 from app.routers.dependencies import get_authenticated_user
 from app.routers.invest_api import router as invest_api_router
-from app.schemas.invest_fx_dashboard import FxDashboardResponse
+from app.schemas.invest_fx_dashboard import FxDashboardEvidenceItem, FxDashboardResponse
 from app.services.invest_view_model.fx_dashboard_service import build_fx_dashboard
+from app.services.invest_view_model.fx_defense_signal import (
+    DefenseScoringInput,
+    _score_defense_signal,
+    _threshold_state,
+)
 
 
 def _contains_key(payload: Any, forbidden: set[str]) -> bool:
@@ -34,6 +39,18 @@ def _safe_text(payload: Any) -> str:
     if isinstance(payload, list):
         return " ".join(_safe_text(item) for item in payload)
     return ""
+
+
+def _assert_no_confirmed_intervention_claim(payload: Any) -> None:
+    text = _safe_text(payload)
+    for unsafe_fragment in (
+        "개입 확정",
+        "정부 개입 확정",
+        "당국 개입 확정",
+        "정부가 방어",
+        "당국이 방어",
+    ):
+        assert unsafe_fragment not in text
 
 
 def _sample_payload() -> dict[str, Any]:
@@ -174,6 +191,126 @@ def test_fx_dashboard_contract_contains_cautious_disclaimer_shape() -> None:
 
 
 @pytest.mark.unit
+def test_fx_defense_signal_scores_near_1500_rejection_as_elevated() -> None:
+    signal = _score_defense_signal(
+        DefenseScoringInput(
+            spot=1497.8,
+            recent_high=1499.8,
+            recent_close_or_last=1496.9,
+            global_dollar_change_pct=0.25,
+            usdcnh_change_pct=None,
+            krw_cross_change_pcts={},
+        )
+    )
+
+    assert signal.state == "elevated"
+    assert 60 <= signal.score < 70
+    assert signal.confidence == "medium"
+    assert signal.reasonsKo[:3] == [
+        "1500원 5원 이내 근접",
+        "1500원 직전 상단 꼬리/되밀림",
+        "글로벌 달러 강세 대비 USD/KRW 상단 제한",
+    ]
+    assert signal.notConfirmedIntervention is True
+    assert signal.needsAfterVerification is True
+    _assert_no_confirmed_intervention_claim(signal.model_dump())
+
+
+@pytest.mark.unit
+def test_fx_defense_signal_does_not_score_missing_cross_market_data_as_evidence() -> None:
+    signal = _score_defense_signal(
+        DefenseScoringInput(
+            spot=1498.7,
+            recent_high=None,
+            recent_close_or_last=None,
+            global_dollar_change_pct=None,
+            usdcnh_change_pct=None,
+            usd_jpy_change_pct=None,
+            krw_cross_change_pcts={},
+        )
+    )
+
+    assert signal.state == "watch"
+    assert signal.score == 30
+    assert signal.confidence == "low"
+    assert "글로벌 달러 강세 대비 USD/KRW 상단 제한" not in signal.reasonsKo
+    assert "글로벌 달러/원화 교차 비교 일부 미수집" in signal.reasonsKo
+    assert any(
+        item.kind == "missing_context" and item.dataState == "missing"
+        for item in signal.evidence
+    )
+
+
+@pytest.mark.unit
+def test_fx_defense_signal_requires_after_verification_for_high_score_without_confirming_intervention() -> None:
+    signal = _score_defense_signal(
+        DefenseScoringInput(
+            spot=1500.2,
+            recent_high=1502.0,
+            recent_close_or_last=1499.6,
+            global_dollar_change_pct=0.32,
+            usdcnh_change_pct=0.22,
+            krw_cross_change_pcts={"CNYKRW": -0.18, "JPYKRW": -0.11},
+            authority_context=[
+                FxDashboardEvidenceItem(
+                    kind="authority_context",
+                    labelKo="당국 경계 발언 context-only fixture",
+                    value="변동성 경계 발언은 참고 맥락으로만 사용",
+                    source="fixture_authority_context",
+                    dataState="fresh",
+                )
+            ],
+            after_verification_has_strong_evidence=False,
+        )
+    )
+
+    assert signal.state == "after_verification_required"
+    assert signal.score >= 70
+    assert signal.confidence == "medium"
+    assert signal.notConfirmedIntervention is True
+    assert signal.needsAfterVerification is True
+    assert "사후 검증" in signal.summaryKo
+    _assert_no_confirmed_intervention_claim(signal.model_dump())
+
+
+@pytest.mark.unit
+def test_fx_defense_signal_strong_context_stays_cautious_without_missing_conflict() -> None:
+    signal = _score_defense_signal(
+        DefenseScoringInput(
+            spot=1500.2,
+            recent_high=1502.0,
+            recent_close_or_last=1499.6,
+            global_dollar_change_pct=0.32,
+            krw_cross_change_pcts={"CNYKRW": -0.18, "JPYKRW": -0.11},
+            authority_context=[
+                FxDashboardEvidenceItem(
+                    kind="authority_context",
+                    labelKo="딜러/NDF 사후 검증 context fixture",
+                    value="사후 근거 일부 확인 테스트",
+                    source="fixture_authority_context",
+                    dataState="fresh",
+                )
+            ],
+            after_verification_has_strong_evidence=True,
+        )
+    )
+
+    assert signal.confidence == "high"
+    assert signal.notConfirmedIntervention is True
+    assert "사후 검증 근거 일부 확인" in signal.reasonsKo
+    assert "사후 검증 자료 없음" not in signal.reasonsKo
+    _assert_no_confirmed_intervention_claim(signal.model_dump())
+
+
+@pytest.mark.unit
+def test_fx_threshold_state_for_1500_near_and_breached() -> None:
+    assert _threshold_state(level=1500, spot=1488.8) == "near"
+    assert _threshold_state(level=1500, spot=1488.7) == "watch"
+    assert _threshold_state(level=1500, spot=1500.0) == "breached"
+    assert _threshold_state(level=1500, spot=1501.2) == "breached"
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_build_fx_dashboard_fixture_has_partial_provider_states() -> None:
     response = await build_fx_dashboard(
@@ -188,7 +325,13 @@ async def test_build_fx_dashboard_fixture_has_partial_provider_states() -> None:
     assert response.news.dataState == "missing"
     assert response.events.dataState == "missing"
     assert response.afterVerification.dataState == "missing"
-    assert "개입 확정" not in _safe_text(response.model_dump())
+    assert response.defenseSignal.state == "elevated"
+    assert response.defenseSignal.notConfirmedIntervention is True
+    assert response.defenseSignal.needsAfterVerification is True
+    assert "1500원 1.5원 이내 근접" in response.defenseSignal.reasonsKo
+    assert "1500원 부근 되밀림" in response.defenseSignal.reasonsKo
+    assert "글로벌 달러 강세 대비 USD/KRW 상단 제한" in response.defenseSignal.reasonsKo
+    _assert_no_confirmed_intervention_claim(response.model_dump())
 
 
 @pytest.fixture
@@ -221,5 +364,13 @@ def test_get_fx_dashboard_returns_read_only_payload(client: TestClient) -> None:
     assert body["disclaimers"][0]["code"] == "not_confirmed_intervention"
     assert not _contains_key(
         body,
-        {"order_id", "client_order_id", "watch_order", "approval_issue_id"},
+        {
+            "order_id",
+            "client_order_id",
+            "watch_order",
+            "approval_issue_id",
+            "order_intent",
+        },
     )
+    assert "dry_run=false" not in _safe_text(body)
+    _assert_no_confirmed_intervention_claim(body)

--- a/tests/test_invest_fx_dashboard.py
+++ b/tests/test_invest_fx_dashboard.py
@@ -311,6 +311,62 @@ def test_fx_threshold_state_for_1500_near_and_breached() -> None:
 
 
 @pytest.mark.unit
+def test_fx_defense_signal_does_not_score_context_only_evidence() -> None:
+    base = DefenseScoringInput(
+        spot=1498.7,
+        recent_high=None,
+        recent_close_or_last=None,
+        global_dollar_change_pct=None,
+        krw_cross_change_pcts={},
+    )
+    with_context = DefenseScoringInput(
+        spot=1498.7,
+        recent_high=None,
+        recent_close_or_last=None,
+        global_dollar_change_pct=None,
+        krw_cross_change_pcts={},
+        news_context=[
+            FxDashboardEvidenceItem(
+                kind="news_context",
+                labelKo="환율/당국 경계 뉴스 context-only fixture",
+                value="참고 맥락",
+                source="fixture_fx_news_context",
+                dataState="stale",
+            )
+        ],
+        authority_context=[
+            FxDashboardEvidenceItem(
+                kind="authority_context",
+                labelKo="당국 경계 발언 context-only fixture",
+                value="참고 맥락",
+                source="fixture_authority_context",
+                dataState="fresh",
+            )
+        ],
+    )
+
+    assert _score_defense_signal(base).score == _score_defense_signal(with_context).score
+    assert "환율/당국 경계 뉴스 확인" in _score_defense_signal(with_context).reasonsKo
+
+
+@pytest.mark.unit
+def test_fx_defense_signal_requires_rejection_for_divergence_score() -> None:
+    signal = _score_defense_signal(
+        DefenseScoringInput(
+            spot=1498.7,
+            recent_high=None,
+            recent_close_or_last=None,
+            global_dollar_change_pct=0.25,
+            usdcnh_change_pct=0.16,
+            krw_cross_change_pcts={},
+        )
+    )
+
+    assert signal.score == 30
+    assert "글로벌 달러 강세 대비 USD/KRW 상단 제한" not in signal.reasonsKo
+
+
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_build_fx_dashboard_fixture_has_partial_provider_states() -> None:
     response = await build_fx_dashboard(
@@ -329,7 +385,10 @@ async def test_build_fx_dashboard_fixture_has_partial_provider_states() -> None:
     assert response.defenseSignal.notConfirmedIntervention is True
     assert response.defenseSignal.needsAfterVerification is True
     assert "1500원 1.5원 이내 근접" in response.defenseSignal.reasonsKo
-    assert "1500원 부근 되밀림" in response.defenseSignal.reasonsKo
+    assert any(
+        reason.startswith("1500원 부근 되밀림")
+        for reason in response.defenseSignal.reasonsKo
+    )
     assert "글로벌 달러 강세 대비 USD/KRW 상단 제한" in response.defenseSignal.reasonsKo
     _assert_no_confirmed_intervention_claim(response.model_dump())
 

--- a/tests/test_invest_fx_dashboard.py
+++ b/tests/test_invest_fx_dashboard.py
@@ -217,7 +217,9 @@ def test_fx_defense_signal_scores_near_1500_rejection_as_elevated() -> None:
 
 
 @pytest.mark.unit
-def test_fx_defense_signal_does_not_score_missing_cross_market_data_as_evidence() -> None:
+def test_fx_defense_signal_does_not_score_missing_cross_market_data_as_evidence() -> (
+    None
+):
     signal = _score_defense_signal(
         DefenseScoringInput(
             spot=1498.7,
@@ -242,7 +244,9 @@ def test_fx_defense_signal_does_not_score_missing_cross_market_data_as_evidence(
 
 
 @pytest.mark.unit
-def test_fx_defense_signal_requires_after_verification_for_high_score_without_confirming_intervention() -> None:
+def test_fx_defense_signal_requires_after_verification_for_high_score_without_confirming_intervention() -> (
+    None
+):
     signal = _score_defense_signal(
         DefenseScoringInput(
             spot=1500.2,
@@ -274,7 +278,9 @@ def test_fx_defense_signal_requires_after_verification_for_high_score_without_co
 
 
 @pytest.mark.unit
-def test_fx_defense_signal_strong_context_stays_cautious_without_missing_conflict() -> None:
+def test_fx_defense_signal_strong_context_stays_cautious_without_missing_conflict() -> (
+    None
+):
     signal = _score_defense_signal(
         DefenseScoringInput(
             spot=1500.2,
@@ -345,7 +351,9 @@ def test_fx_defense_signal_does_not_score_context_only_evidence() -> None:
         ],
     )
 
-    assert _score_defense_signal(base).score == _score_defense_signal(with_context).score
+    assert (
+        _score_defense_signal(base).score == _score_defense_signal(with_context).score
+    )
     assert "환율/당국 경계 뉴스 확인" in _score_defense_signal(with_context).reasonsKo
 
 


### PR DESCRIPTION
## Summary
- Adds deterministic USD/KRW 1500 defense-signal scoring for `/invest` FX dashboard data.
- Scores proximity, failed/rejected moves near 1500, and cross-market divergence only when actual rejection is present.
- Keeps news/authority evidence as context-only reasons/evidence, with cautious copy and `notConfirmedIntervention=true` semantics.

## Safety
- Read-only `/invest` analysis/UI slice only.
- No broker submit/cancel/modify calls.
- No watch/order intent creation.
- No production DB writes/backfills or scheduler activation.
- Does not claim confirmed government intervention.

## Verification
- `uv run pytest tests/test_invest_api_router_safety.py tests/test_invest_fx_dashboard.py -q` — 13 passed, 2 warnings.
- `uv run ruff check app/services/invest_view_model/fx_defense_signal.py app/services/invest_view_model/fx_dashboard_service.py tests/test_invest_fx_dashboard.py` — All checks passed.
- `git diff --check origin/main...HEAD` — passed.

Closes ROB-218


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * FX dashboard defense signal now uses deterministic scoring (replacing prior hard-coded placeholders) for more reliable USD/KRW 1500 threshold behavior.

* **Improvements**
  * Defense signal aggregates spot, rejection, divergence and contextual evidence and returns clearer state, confidence and Korean-facing text.

* **Tests**
  * Expanded unit and integration tests covering scoring scenarios, thresholds, context handling and dashboard payload invariants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/811)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->