### PR TITLE
feat(ROB-221): add FX sensitivity card to stock detail

### DIFF
--- a/app/schemas/invest_stock_detail.py
+++ b/app/schemas/invest_stock_detail.py
@@ -43,6 +43,14 @@ AnalysisDecision = Literal["buy", "hold", "sell"]
 DiscussionSignalStatus = Literal["fixture_backed_poc", "no_go_pending_review"]
 DiscussionSignalMomentum = Literal["rising", "flat", "falling", "unknown"]
 DiscussionSignalFreshness = Literal["fixture", "stale", "missing"]
+FxSensitivityStatus = Literal[
+    "available",
+    "not_applicable",
+    "missing_holding",
+    "missing_native_value",
+    "missing_fx_rate",
+]
+FxSensitivityBasis = Literal["portfolio_value", "fallback_quote", "not_applicable"]
 
 
 class CapabilityFlag(BaseModel):
@@ -236,6 +244,42 @@ class StockDetailHolding(BaseModel):
     priceState: PriceStateLiteral = "live"
 
 
+class StockDetailFxScenario(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rateMovePct: float
+    estimatedKrwImpact: float | None = None
+    estimatedValueKrw: float | None = None
+    label: str
+
+
+class StockDetailFxSensitivity(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: Literal["stock_detail_fx_sensitivity"] = "stock_detail_fx_sensitivity"
+    status: FxSensitivityStatus
+    currencyPair: Literal["USD/KRW"] | None = None
+    baseFxRate: float | None = None
+    holdingValueNative: float | None = None
+    holdingValueKrw: float | None = None
+    basis: FxSensitivityBasis = "not_applicable"
+    scenarios: list[StockDetailFxScenario] = Field(default_factory=list)
+    caution: str
+
+    @model_validator(mode="after")
+    def enforce_status_shape(self) -> StockDetailFxSensitivity:
+        if self.status == "available":
+            if self.currencyPair != "USD/KRW" or self.baseFxRate is None:
+                raise ValueError("available FX sensitivity requires USD/KRW rate")
+            if self.holdingValueNative is None or self.holdingValueNative <= 0:
+                raise ValueError("available FX sensitivity requires positive native value")
+            if not self.scenarios:
+                raise ValueError("available FX sensitivity requires scenarios")
+        elif self.scenarios:
+            raise ValueError("unavailable FX sensitivity must not expose scenarios")
+        return self
+
+
 class StockDetailLatestAnalysis(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -292,6 +336,7 @@ class StockDetailResponse(BaseModel):
     naverEnrichment: StockDetailNaverEnrichment | None = None
     discussionSignal: StockDetailDiscussionSignal | None = None
     holding: StockDetailHolding | None = None
+    fxSensitivity: StockDetailFxSensitivity | None = None
     latestAnalysis: StockDetailLatestAnalysis | None = None
     orderbookSupport: StockDetailOrderbookSupport
     orderbook: StockDetailOrderbook | None = None

--- a/app/schemas/invest_stock_detail.py
+++ b/app/schemas/invest_stock_detail.py
@@ -272,7 +272,9 @@ class StockDetailFxSensitivity(BaseModel):
             if self.currencyPair != "USD/KRW" or self.baseFxRate is None:
                 raise ValueError("available FX sensitivity requires USD/KRW rate")
             if self.holdingValueNative is None or self.holdingValueNative <= 0:
-                raise ValueError("available FX sensitivity requires positive native value")
+                raise ValueError(
+                    "available FX sensitivity requires positive native value"
+                )
             if not self.scenarios:
                 raise ValueError("available FX sensitivity requires scenarios")
         elif self.scenarios:

--- a/app/services/invest_view_model/stock_detail_service.py
+++ b/app/services/invest_view_model/stock_detail_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -57,22 +58,30 @@ async def _run_optional_block(
     return None
 
 
+@dataclass(frozen=True, slots=True)
+class StockDetailProviders:
+    resolver: Resolver = resolve_symbol
+    quote: Provider = _none_provider
+    screener: Provider = _none_provider
+    valuation: Provider = _none_provider
+    holding: Provider = _none_provider
+    latest_analysis: Provider = _none_provider
+    orderbook: Provider = _none_provider
+    fx_rate: Provider = get_usd_krw_quote
+    naver_enrichment: Provider = build_naver_stock_detail_poc
+    discussion_signal: Provider = build_naver_discussion_signal_poc
+
+
+DEFAULT_STOCK_DETAIL_PROVIDERS = StockDetailProviders()
+
+
 async def build_stock_detail(
     *,
     user_id: int | str,
     market: NewsMarket,
     symbol: str,
-    db: AsyncSession,
-    resolver: Resolver = resolve_symbol,
-    quote_provider: Provider = _none_provider,
-    screener_provider: Provider = _none_provider,
-    valuation_provider: Provider = _none_provider,
-    holding_provider: Provider = _none_provider,
-    latest_analysis_provider: Provider = _none_provider,
-    orderbook_provider: Provider = _none_provider,
-    fx_rate_provider: Provider = get_usd_krw_quote,
-    naver_enrichment_provider: Provider = build_naver_stock_detail_poc,
-    discussion_signal_provider: Provider = build_naver_discussion_signal_poc,
+    db: Any,
+    providers: StockDetailProviders = DEFAULT_STOCK_DETAIL_PROVIDERS,
 ) -> StockDetailResponse:
     """Build the read-only above-the-fold stock-detail view-model.
 
@@ -82,43 +91,43 @@ async def build_stock_detail(
     not perform request-time external fetches or writes.
     """
 
-    resolved = await resolver(market, symbol, db)
+    resolved = await providers.resolver(market, symbol, db)
     warnings: list[str] = []
 
     quote_task = _run_optional_block(
-        "quote", quote_provider(market, resolved.symbol_db, db), warnings
+        "quote", providers.quote(market, resolved.symbol_db, db), warnings
     )
     screener_task = _run_optional_block(
         "screener_snapshot",
-        screener_provider(market, resolved.symbol_db, db),
+        providers.screener(market, resolved.symbol_db, db),
         warnings,
     )
     valuation_task = _run_optional_block(
-        "valuation", valuation_provider(market, resolved.symbol_db, db), warnings
+        "valuation", providers.valuation(market, resolved.symbol_db, db), warnings
     )
     holding_task = _run_optional_block(
         "holding",
-        holding_provider(user_id, market, resolved.symbol_db, db),
+        providers.holding(user_id, market, resolved.symbol_db, db),
         warnings,
     )
     latest_analysis_task = _run_optional_block(
         "latest_analysis",
-        latest_analysis_provider(market, resolved.symbol_db, db),
+        providers.latest_analysis(market, resolved.symbol_db, db),
         warnings,
     )
     naver_enrichment_task = _run_optional_block(
         "naver_enrichment",
-        naver_enrichment_provider(market, resolved.symbol_db, db),
+        providers.naver_enrichment(market, resolved.symbol_db, db),
         warnings,
     )
     discussion_signal_task = _run_optional_block(
         "discussion_signal",
-        discussion_signal_provider(market, resolved.symbol_db, db),
+        providers.discussion_signal(market, resolved.symbol_db, db),
         warnings,
     )
     if market == "kr":
         orderbook_task = _run_optional_block(
-            "orderbook", orderbook_provider(market, resolved.symbol_db, db), warnings
+            "orderbook", providers.orderbook(market, resolved.symbol_db, db), warnings
         )
     else:
         orderbook_task = _none_provider()
@@ -183,7 +192,7 @@ async def build_stock_detail(
         market=market, currency=resolved.currency, holding=holding
     ):
         fx_rate = await _run_optional_block(
-            "fx_sensitivity", fx_rate_provider(), warnings
+            "fx_sensitivity", providers.fx_rate(), warnings
         )
     fx_sensitivity = _build_fx_sensitivity(
         market=market,
@@ -284,4 +293,4 @@ def _build_fx_sensitivity(
     )
 
 
-__all__ = ["build_stock_detail"]
+__all__ = ["StockDetailProviders", "build_stock_detail"]

--- a/app/services/invest_view_model/stock_detail_service.py
+++ b/app/services/invest_view_model/stock_detail_service.py
@@ -11,6 +11,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.schemas.invest_feed_news import NewsMarket
 from app.schemas.invest_stock_detail import (
     StockDetailDiscussionSignal,
+    StockDetailFxScenario,
+    StockDetailFxSensitivity,
     StockDetailHolding,
     StockDetailLatestAnalysis,
     StockDetailNaverEnrichment,
@@ -20,6 +22,7 @@ from app.schemas.invest_stock_detail import (
     default_capabilities_for_market,
     orderbook_support_for_market,
 )
+from app.services.exchange_rate_service import get_usd_krw_quote
 from app.services.invest_view_model.naver_discussion_signal_poc import (
     build_naver_discussion_signal_poc,
 )
@@ -67,6 +70,7 @@ async def build_stock_detail(
     holding_provider: Provider = _none_provider,
     latest_analysis_provider: Provider = _none_provider,
     orderbook_provider: Provider = _none_provider,
+    fx_rate_provider: Provider = get_usd_krw_quote,
     naver_enrichment_provider: Provider = build_naver_stock_detail_poc,
     discussion_signal_provider: Provider = build_naver_discussion_signal_poc,
 ) -> StockDetailResponse:
@@ -174,6 +178,20 @@ async def build_stock_detail(
     if orderbook is not None and not isinstance(orderbook, StockDetailOrderbook):
         orderbook = StockDetailOrderbook.model_validate(orderbook)
 
+    fx_rate = None
+    if _should_fetch_fx_rate(
+        market=market, currency=resolved.currency, holding=holding
+    ):
+        fx_rate = await _run_optional_block(
+            "fx_sensitivity", fx_rate_provider(), warnings
+        )
+    fx_sensitivity = _build_fx_sensitivity(
+        market=market,
+        currency=resolved.currency,
+        holding=holding,
+        fx_rate=fx_rate,
+    )
+
     return StockDetailResponse(
         symbol=resolved.symbol_db,
         market=market,
@@ -189,11 +207,80 @@ async def build_stock_detail(
         naverEnrichment=naver_enrichment,
         discussionSignal=discussion_signal,
         holding=holding,
+        fxSensitivity=fx_sensitivity,
         latestAnalysis=latest_analysis,
         orderbookSupport=orderbook_support,
         orderbook=orderbook,
         capabilities=capabilities,
         meta={"computedAt": datetime.now(UTC), "warnings": warnings},
+    )
+
+
+def _should_fetch_fx_rate(
+    *, market: NewsMarket, currency: str, holding: StockDetailHolding | None
+) -> bool:
+    if market != "us" and currency != "USD":
+        return False
+    return holding is not None and (holding.valueNative or 0) > 0
+
+
+def _build_fx_sensitivity(
+    *,
+    market: NewsMarket,
+    currency: str,
+    holding: StockDetailHolding | None,
+    fx_rate: float | None,
+) -> StockDetailFxSensitivity:
+    caution = (
+        "환율 민감도는 USD/KRW 1% 변동을 보유 평가액에 단순 적용한 가정치이며, "
+        "투자 판단을 대신하는 지표가 아닙니다."
+    )
+    if market != "us" and currency != "USD":
+        return StockDetailFxSensitivity(
+            status="not_applicable",
+            basis="not_applicable",
+            caution="KRW 자산은 별도 USD/KRW 환율 민감도 계산을 표시하지 않습니다.",
+        )
+    if holding is None:
+        return StockDetailFxSensitivity(
+            status="missing_holding",
+            basis="not_applicable",
+            caution="보유 수량이 없어 환율 민감도 계산을 표시하지 않습니다.",
+        )
+    if holding.valueNative is None or holding.valueNative <= 0:
+        return StockDetailFxSensitivity(
+            status="missing_native_value",
+            holdingValueKrw=holding.valueKrw,
+            basis="not_applicable",
+            caution="USD 보유 평가액이 없어 환율 민감도 계산을 표시하지 않습니다.",
+        )
+    if fx_rate is None or fx_rate <= 0:
+        return StockDetailFxSensitivity(
+            status="missing_fx_rate",
+            holdingValueNative=holding.valueNative,
+            holdingValueKrw=holding.valueKrw,
+            basis="not_applicable",
+            caution="USD/KRW 환율을 확인하지 못해 환율 민감도 계산을 표시하지 않습니다.",
+        )
+
+    scenarios = [
+        StockDetailFxScenario(
+            rateMovePct=move_pct,
+            estimatedKrwImpact=holding.valueNative * fx_rate * (move_pct / 100),
+            estimatedValueKrw=holding.valueNative * fx_rate * (1 + move_pct / 100),
+            label=f"USD/KRW {move_pct:+.0f}%",
+        )
+        for move_pct in (-1.0, 1.0)
+    ]
+    return StockDetailFxSensitivity(
+        status="available",
+        currencyPair="USD/KRW",
+        baseFxRate=fx_rate,
+        holdingValueNative=holding.valueNative,
+        holdingValueKrw=holding.valueKrw,
+        basis="portfolio_value",
+        scenarios=scenarios,
+        caution=caution,
     )
 
 

--- a/frontend/invest/src/__tests__/StockDetailPage.test.tsx
+++ b/frontend/invest/src/__tests__/StockDetailPage.test.tsx
@@ -89,6 +89,30 @@ const aboveFold: StockDetailResponse = {
     includedSources: ["kis"],
     priceState: "live",
   },
+  fxSensitivity: {
+    source: "stock_detail_fx_sensitivity",
+    status: "available",
+    currencyPair: "USD/KRW",
+    baseFxRate: 1360,
+    holdingValueNative: 422.68,
+    holdingValueKrw: 575000,
+    basis: "portfolio_value",
+    scenarios: [
+      {
+        rateMovePct: -1,
+        estimatedKrwImpact: -5748.448,
+        estimatedValueKrw: 569096.352,
+        label: "USD/KRW -1%",
+      },
+      {
+        rateMovePct: 1,
+        estimatedKrwImpact: 5748.448,
+        estimatedValueKrw: 580593.248,
+        label: "USD/KRW +1%",
+      },
+    ],
+    caution: "환율 민감도는 USD/KRW 1% 변동을 보유 평가액에 단순 적용한 가정치입니다.",
+  },
   latestAnalysis: {
     id: 11,
     modelName: "committee",
@@ -183,6 +207,9 @@ test("renders the QQQM stock detail shell from the read-only backend contract", 
   expect(screen.getByText("$211.34")).toBeInTheDocument();
   expect(screen.getByText("+1.06%")).toBeInTheDocument();
   expect(screen.getByTestId("stock-detail-holding")).toHaveTextContent("2주");
+  expect(screen.getByTestId("stock-detail-fx-sensitivity")).toHaveTextContent("환율 민감도");
+  expect(screen.getByTestId("stock-detail-fx-sensitivity")).toHaveTextContent("USD/KRW");
+  expect(screen.getByTestId("stock-detail-fx-sensitivity")).toHaveTextContent("+₩5,748");
   expect(screen.getByTestId("stock-detail-profile")).toHaveTextContent("ETF");
   expect(screen.getByTestId("stock-detail-analysis")).toHaveTextContent("hold");
   expect(screen.getByTestId("stock-detail-naver-poc")).toHaveTextContent("Naver 원천 데이터 PoC");
@@ -219,4 +246,40 @@ test("omits the Naver PoC card when the backend has no safe enrichment map", asy
 
   expect(await screen.findByTestId("stock-detail-shell")).toBeInTheDocument();
   expect(screen.queryByTestId("stock-detail-naver-poc")).not.toBeInTheDocument();
+});
+
+test("renders conservative fallback text when FX sensitivity is not applicable", async () => {
+  vi.mocked(stockApi.fetchStockDetail).mockResolvedValue({
+    ...aboveFold,
+    market: "kr",
+    symbol: "005930",
+    displayName: "삼성전자",
+    exchange: "KOSPI",
+    currency: "KRW",
+    fxSensitivity: {
+      source: "stock_detail_fx_sensitivity",
+      status: "not_applicable",
+      currencyPair: null,
+      baseFxRate: null,
+      holdingValueNative: null,
+      holdingValueKrw: null,
+      basis: "not_applicable",
+      scenarios: [],
+      caution: "KRW 자산은 별도 USD/KRW 환율 민감도 계산을 표시하지 않습니다.",
+    },
+  });
+
+  renderPage();
+
+  expect(await screen.findByTestId("stock-detail-fx-sensitivity")).toHaveTextContent("환율 민감도");
+  expect(screen.getByTestId("stock-detail-fx-sensitivity")).toHaveTextContent("KRW 자산은 별도 USD/KRW 환율 민감도 계산을 표시하지 않습니다.");
+});
+
+test("omits the FX sensitivity card when the backend returns null", async () => {
+  vi.mocked(stockApi.fetchStockDetail).mockResolvedValue({ ...aboveFold, fxSensitivity: null });
+
+  renderPage();
+
+  expect(await screen.findByTestId("stock-detail-shell")).toBeInTheDocument();
+  expect(screen.queryByTestId("stock-detail-fx-sensitivity")).not.toBeInTheDocument();
 });

--- a/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
+++ b/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../api/stockDetail";
 import type {
   StockDetailCandlesResponse,
+  StockDetailFxSensitivity,
   StockDetailMarket,
   StockDetailNewsResponse,
   StockDetailOrdersResponse,
@@ -24,6 +25,18 @@ function fmtPct(v: number | null | undefined): string {
 
 function fmtQty(v: number): string {
   return `${v.toLocaleString("ko-KR", { maximumFractionDigits: 6 })}주`;
+}
+
+function fmtKrwSigned(v: number | null | undefined): string {
+  if (v == null) return "−";
+  const rounded = Math.round(v);
+  const sign = rounded > 0 ? "+" : rounded < 0 ? "−" : "";
+  return `${sign}₩${Math.abs(rounded).toLocaleString("ko-KR")}`;
+}
+
+function fmtRate(v: number | null | undefined): string {
+  if (v == null) return "−";
+  return v.toLocaleString("ko-KR", { maximumFractionDigits: 2 });
 }
 
 function marketLabel(market: StockDetailMarket): string {
@@ -105,6 +118,41 @@ function HoldingCard({ data }: { data: StockDetailResponse }) {
       ) : (
         <p style={{ margin: 0, color: "var(--fg-3)" }}>보유 수량이 없습니다.</p>
       )}
+    </Card>
+  );
+}
+
+function FxSensitivityCard({ data }: { data: StockDetailFxSensitivity | null }) {
+  if (!data) return null;
+  const isAvailable = data.status === "available";
+  const basisLabel = data.basis === "portfolio_value" ? "보유 평가금액 기준" : "가정 기준";
+  return (
+    <Card data-testid="stock-detail-fx-sensitivity" soft>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+        <div>
+          <h2 style={{ margin: "0 0 6px", fontSize: 16 }}>환율 민감도</h2>
+          <p style={{ margin: 0, color: "var(--fg-3)", fontSize: 12 }}>
+            {isAvailable ? `${data.currencyPair} ${fmtRate(data.baseFxRate)} · ${basisLabel}` : data.caution}
+          </p>
+        </div>
+        <Pill tone={isAvailable ? "accent" : "paper"}>가정</Pill>
+      </div>
+      {isAvailable ? (
+        <div style={{ marginTop: 12, display: "grid", gridTemplateColumns: "repeat(2, minmax(0, 1fr))", gap: 10 }}>
+          {data.scenarios.map((scenario) => (
+            <div key={scenario.label} style={{ border: "1px solid var(--line)", borderRadius: 14, padding: 12 }}>
+              <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{scenario.label}</div>
+              <div style={{ marginTop: 4, fontWeight: 800, color: (scenario.estimatedKrwImpact ?? 0) >= 0 ? "var(--gain)" : "var(--loss)" }}>
+                {fmtKrwSigned(scenario.estimatedKrwImpact)}
+              </div>
+              <div style={{ marginTop: 4, color: "var(--fg-3)", fontSize: 12 }}>
+                추정 평가액 {scenario.estimatedValueKrw == null ? "−" : `₩${Math.round(scenario.estimatedValueKrw).toLocaleString("ko-KR")}`}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {isAvailable ? <p style={{ margin: "10px 0 0", color: "var(--fg-3)", fontSize: 12 }}>{data.caution}</p> : null}
     </Card>
   );
 }
@@ -301,6 +349,7 @@ export function StockDetailPage() {
               <HeaderCard data={data} />
               <TradeGuardrail data={data} />
               <HoldingCard data={data} />
+              <FxSensitivityCard data={data.fxSensitivity} />
               <ChartCard candles={candles} />
               <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}>
                 <OrderbookCard data={data} />

--- a/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
+++ b/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
@@ -30,7 +30,9 @@ function fmtQty(v: number): string {
 function fmtKrwSigned(v: number | null | undefined): string {
   if (v == null) return "−";
   const rounded = Math.round(v);
-  const sign = rounded > 0 ? "+" : rounded < 0 ? "−" : "";
+  let sign = "";
+  if (rounded > 0) sign = "+";
+  if (rounded < 0) sign = "−";
   return `${sign}₩${Math.abs(rounded).toLocaleString("ko-KR")}`;
 }
 
@@ -122,7 +124,7 @@ function HoldingCard({ data }: { data: StockDetailResponse }) {
   );
 }
 
-function FxSensitivityCard({ data }: { data: StockDetailFxSensitivity | null }) {
+function FxSensitivityCard({ data }: Readonly<{ data: StockDetailFxSensitivity | null }>) {
   if (!data) return null;
   const isAvailable = data.status === "available";
   const basisLabel = data.basis === "portfolio_value" ? "보유 평가금액 기준" : "가정 기준";

--- a/frontend/invest/src/types/stockDetail.ts
+++ b/frontend/invest/src/types/stockDetail.ts
@@ -21,6 +21,13 @@ export type NaverEndpointStatus =
   | "error";
 export type OrderSide = "buy" | "sell" | string;
 export type AnalysisDecision = "buy" | "hold" | "sell";
+export type FxSensitivityStatus =
+  | "available"
+  | "not_applicable"
+  | "missing_holding"
+  | "missing_native_value"
+  | "missing_fx_rate";
+export type FxSensitivityBasis = "portfolio_value" | "fallback_quote" | "not_applicable";
 
 export interface CapabilityFlag {
   supported: boolean;
@@ -109,6 +116,25 @@ export interface StockDetailHolding {
   priceState: PriceState;
 }
 
+export interface StockDetailFxScenario {
+  rateMovePct: number;
+  estimatedKrwImpact: number | null;
+  estimatedValueKrw: number | null;
+  label: string;
+}
+
+export interface StockDetailFxSensitivity {
+  source: "stock_detail_fx_sensitivity";
+  status: FxSensitivityStatus;
+  currencyPair: "USD/KRW" | null;
+  baseFxRate: number | null;
+  holdingValueNative: number | null;
+  holdingValueKrw: number | null;
+  basis: FxSensitivityBasis;
+  scenarios: StockDetailFxScenario[];
+  caution: string;
+}
+
 export interface StockDetailLatestAnalysis {
   id: number;
   modelName: string | null;
@@ -149,6 +175,7 @@ export interface StockDetailResponse {
   valuation: StockDetailValuation | null;
   naverEnrichment: StockDetailNaverEnrichment | null;
   holding: StockDetailHolding | null;
+  fxSensitivity: StockDetailFxSensitivity | null;
   latestAnalysis: StockDetailLatestAnalysis | null;
   orderbookSupport: StockDetailOrderbookSupport;
   orderbook: StockDetailOrderbook | null;

--- a/tests/market_events_test_helpers.py
+++ b/tests/market_events_test_helpers.py
@@ -1,0 +1,57 @@
+"""Shared market-events test helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from sqlalchemy import delete, select
+
+
+async def clean_non_tradingview_market_events(db_session) -> None:
+    """Remove mutable market-events fixture rows while preserving TradingView seed data."""
+    from app.models.market_events import (
+        MarketEvent,
+        MarketEventIngestionPartition,
+        MarketEventValue,
+    )
+
+    non_tradingview_events = select(MarketEvent.id).where(
+        MarketEvent.source != "tradingview"
+    )
+    await db_session.execute(
+        delete(MarketEventValue).where(
+            MarketEventValue.event_id.in_(non_tradingview_events)
+        )
+    )
+    await db_session.execute(
+        delete(MarketEvent).where(MarketEvent.source != "tradingview")
+    )
+    await db_session.execute(
+        delete(MarketEventIngestionPartition).where(
+            MarketEventIngestionPartition.source != "tradingview"
+        )
+    )
+    await db_session.commit()
+
+
+def build_market_events_app(*, authenticated: bool = True, user_id: int = 7) -> FastAPI:
+    """Build a FastAPI app with the market-events router and optional auth override."""
+    from app.core.db import AsyncSessionLocal, get_db
+    from app.routers import market_events
+    from app.routers.dependencies import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(market_events.router)
+
+    if authenticated:
+        app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(
+            id=user_id
+        )
+
+    async def _override_get_db():
+        async with AsyncSessionLocal() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = _override_get_db
+    return app

--- a/tests/services/test_market_events_query_service.py
+++ b/tests/services/test_market_events_query_service.py
@@ -7,34 +7,13 @@ from decimal import Decimal
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import delete, select
+
+from tests.market_events_test_helpers import clean_non_tradingview_market_events
 
 
 @pytest_asyncio.fixture(autouse=True)
 async def _clean_market_events(db_session):
-    from app.models.market_events import (
-        MarketEvent,
-        MarketEventIngestionPartition,
-        MarketEventValue,
-    )
-
-    non_tradingview_events = select(MarketEvent.id).where(
-        MarketEvent.source != "tradingview"
-    )
-    await db_session.execute(
-        delete(MarketEventValue).where(
-            MarketEventValue.event_id.in_(non_tradingview_events)
-        )
-    )
-    await db_session.execute(
-        delete(MarketEvent).where(MarketEvent.source != "tradingview")
-    )
-    await db_session.execute(
-        delete(MarketEventIngestionPartition).where(
-            MarketEventIngestionPartition.source != "tradingview"
-        )
-    )
-    await db_session.commit()
+    await clean_non_tradingview_market_events(db_session)
     yield
 
 

--- a/tests/services/test_market_events_query_service.py
+++ b/tests/services/test_market_events_query_service.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -18,9 +18,22 @@ async def _clean_market_events(db_session):
         MarketEventValue,
     )
 
-    await db_session.execute(delete(MarketEventValue))
-    await db_session.execute(delete(MarketEvent))
-    await db_session.execute(delete(MarketEventIngestionPartition))
+    non_tradingview_events = select(MarketEvent.id).where(
+        MarketEvent.source != "tradingview"
+    )
+    await db_session.execute(
+        delete(MarketEventValue).where(
+            MarketEventValue.event_id.in_(non_tradingview_events)
+        )
+    )
+    await db_session.execute(
+        delete(MarketEvent).where(MarketEvent.source != "tradingview")
+    )
+    await db_session.execute(
+        delete(MarketEventIngestionPartition).where(
+            MarketEventIngestionPartition.source != "tradingview"
+        )
+    )
     await db_session.commit()
     yield
 

--- a/tests/services/test_tradingview_ingestion.py
+++ b/tests/services/test_tradingview_ingestion.py
@@ -21,9 +21,22 @@ async def _clean_market_events(db_session):
         MarketEventValue,
     )
 
-    await db_session.execute(delete(MarketEventValue))
-    await db_session.execute(delete(MarketEvent))
-    await db_session.execute(delete(MarketEventIngestionPartition))
+    tradingview_events = select(MarketEvent.id).where(
+        MarketEvent.source == "tradingview"
+    )
+    await db_session.execute(
+        delete(MarketEventValue).where(
+            MarketEventValue.event_id.in_(tradingview_events)
+        )
+    )
+    await db_session.execute(
+        delete(MarketEvent).where(MarketEvent.source == "tradingview")
+    )
+    await db_session.execute(
+        delete(MarketEventIngestionPartition).where(
+            MarketEventIngestionPartition.source == "tradingview"
+        )
+    )
     await db_session.commit()
     yield
 
@@ -85,7 +98,15 @@ async def test_ingest_tradingview_economic_events_succeeds(db_session):
     assert result.category == "economic"
     assert result.market == "global"
 
-    events = (await db_session.execute(select(MarketEvent))).scalars().all()
+    events = (
+        (
+            await db_session.execute(
+                select(MarketEvent).where(MarketEvent.source == "tradingview")
+            )
+        )
+        .scalars()
+        .all()
+    )
     assert len(events) == 1
     e = events[0]
     assert e.category == "economic"
@@ -98,13 +119,27 @@ async def test_ingest_tradingview_economic_events_succeeds(db_session):
     assert e.source_event_id == "4b8e4f00-0e49-4a4a-b6e2-111111111111"
     assert e.source_url == "https://www.bls.gov/cpi/"
 
-    values = (await db_session.execute(select(MarketEventValue))).scalars().all()
+    values = (
+        (
+            await db_session.execute(
+                select(MarketEventValue).where(MarketEventValue.event_id == e.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
     assert len(values) == 1
     assert values[0].metric_name == "actual"
     assert values[0].unit == "%"
 
     parts = (
-        (await db_session.execute(select(MarketEventIngestionPartition)))
+        (
+            await db_session.execute(
+                select(MarketEventIngestionPartition).where(
+                    MarketEventIngestionPartition.source == "tradingview"
+                )
+            )
+        )
         .scalars()
         .all()
     )
@@ -131,7 +166,15 @@ async def test_ingest_tradingview_economic_events_is_idempotent(db_session):
         )
         await db_session.commit()
 
-    events = (await db_session.execute(select(MarketEvent))).scalars().all()
+    events = (
+        (
+            await db_session.execute(
+                select(MarketEvent).where(MarketEvent.source == "tradingview")
+            )
+        )
+        .scalars()
+        .all()
+    )
     assert len(events) == 1
 
 
@@ -153,7 +196,13 @@ async def test_ingest_tradingview_economic_events_records_failure(db_session):
     assert "timed out" in (result.error or "")
 
     parts = (
-        (await db_session.execute(select(MarketEventIngestionPartition)))
+        (
+            await db_session.execute(
+                select(MarketEventIngestionPartition).where(
+                    MarketEventIngestionPartition.source == "tradingview"
+                )
+            )
+        )
         .scalars()
         .all()
     )
@@ -181,7 +230,15 @@ async def test_ingest_tradingview_skips_unparseable_rows(db_session):
     assert result.status == "succeeded"
     assert result.event_count == 1
 
-    events = (await db_session.execute(select(MarketEvent))).scalars().all()
+    events = (
+        (
+            await db_session.execute(
+                select(MarketEvent).where(MarketEvent.source == "tradingview")
+            )
+        )
+        .scalars()
+        .all()
+    )
     assert len(events) == 1
 
 

--- a/tests/test_invest_stock_detail_schemas.py
+++ b/tests/test_invest_stock_detail_schemas.py
@@ -10,6 +10,7 @@ from app.schemas.invest_stock_detail import (
     StockDetailCapabilities,
     StockDetailDiscussionSignal,
     StockDetailDiscussionSignalMetric,
+    StockDetailFxSensitivity,
     StockDetailHolding,
     StockDetailOrderbook,
     StockDetailOrderbookLevel,
@@ -32,7 +33,9 @@ def _base_response(**overrides):
         "screenerSnapshot": None,
         "valuation": None,
         "naverEnrichment": None,
+        "discussionSignal": None,
         "holding": None,
+        "fxSensitivity": None,
         "latestAnalysis": None,
         "orderbookSupport": {"supported": False, "reason": "kr_unavailable"},
         "orderbook": None,
@@ -240,6 +243,84 @@ def test_discussion_signal_wired_into_stock_detail_response():
     assert response.discussionSignal.liveFetchEnabled is False
     assert response.discussionSignal.activityRank == 5
     assert response.discussionSignal.momentum == "rising"
+
+
+def test_fx_sensitivity_available_contract_accepts_scenarios():
+    response = StockDetailResponse.model_validate(
+        _base_response(
+            market="us",
+            symbol="QQQM",
+            currency="USD",
+            assetCategory="us_stock",
+            orderbookSupport={"supported": False, "reason": "us_unsupported"},
+            capabilities=default_capabilities_for_market("us"),
+            fxSensitivity={
+                "status": "available",
+                "currencyPair": "USD/KRW",
+                "baseFxRate": 1360.0,
+                "holdingValueNative": 422.68,
+                "holdingValueKrw": 575000.0,
+                "basis": "portfolio_value",
+                "scenarios": [
+                    {
+                        "rateMovePct": -1.0,
+                        "estimatedKrwImpact": -5748.448,
+                        "estimatedValueKrw": 569096.352,
+                        "label": "USD/KRW -1%",
+                    },
+                    {
+                        "rateMovePct": 1.0,
+                        "estimatedKrwImpact": 5748.448,
+                        "estimatedValueKrw": 580593.248,
+                        "label": "USD/KRW +1%",
+                    },
+                ],
+                "caution": "환율 민감도는 가정치입니다.",
+            },
+        )
+    )
+
+    assert response.fxSensitivity is not None
+    assert response.fxSensitivity.status == "available"
+    assert response.fxSensitivity.scenarios[1].estimatedKrwImpact == pytest.approx(
+        5748.448
+    )
+
+
+def test_fx_sensitivity_available_requires_rate_and_native_value():
+    with pytest.raises(ValidationError, match="requires USD/KRW rate"):
+        StockDetailFxSensitivity(
+            status="available",
+            currencyPair=None,
+            holdingValueNative=10,
+            scenarios=[{"rateMovePct": 1, "label": "USD/KRW +1%"}],
+            caution="x",
+        )
+
+    with pytest.raises(ValidationError, match="requires positive native value"):
+        StockDetailFxSensitivity(
+            status="available",
+            currencyPair="USD/KRW",
+            baseFxRate=1360,
+            holdingValueNative=0,
+            scenarios=[{"rateMovePct": 1, "label": "USD/KRW +1%"}],
+            caution="x",
+        )
+
+
+def test_fx_sensitivity_unavailable_rejects_scenarios():
+    with pytest.raises(ValidationError, match="must not expose scenarios"):
+        StockDetailFxSensitivity(
+            status="not_applicable",
+            scenarios=[{"rateMovePct": 1, "label": "USD/KRW +1%"}],
+            caution="x",
+        )
+
+
+def test_fx_sensitivity_null_for_kr_response_is_valid():
+    response = StockDetailResponse.model_validate(_base_response(fxSensitivity=None))
+
+    assert response.fxSensitivity is None
 
 
 def test_orderbook_required_iff_supported():

--- a/tests/test_market_events_discover_calendar_router.py
+++ b/tests/test_market_events_discover_calendar_router.py
@@ -8,7 +8,7 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -19,9 +19,22 @@ async def _clean(db_session):
         MarketEventValue,
     )
 
-    await db_session.execute(delete(MarketEventValue))
-    await db_session.execute(delete(MarketEvent))
-    await db_session.execute(delete(MarketEventIngestionPartition))
+    non_tradingview_events = select(MarketEvent.id).where(
+        MarketEvent.source != "tradingview"
+    )
+    await db_session.execute(
+        delete(MarketEventValue).where(
+            MarketEventValue.event_id.in_(non_tradingview_events)
+        )
+    )
+    await db_session.execute(
+        delete(MarketEvent).where(MarketEvent.source != "tradingview")
+    )
+    await db_session.execute(
+        delete(MarketEventIngestionPartition).where(
+            MarketEventIngestionPartition.source != "tradingview"
+        )
+    )
     await db_session.commit()
     yield
 

--- a/tests/test_market_events_discover_calendar_router.py
+++ b/tests/test_market_events_discover_calendar_router.py
@@ -2,63 +2,25 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy import delete, select
+
+from tests.market_events_test_helpers import (
+    build_market_events_app,
+    clean_non_tradingview_market_events,
+)
 
 
 @pytest_asyncio.fixture(autouse=True)
 async def _clean(db_session):
-    from app.models.market_events import (
-        MarketEvent,
-        MarketEventIngestionPartition,
-        MarketEventValue,
-    )
-
-    non_tradingview_events = select(MarketEvent.id).where(
-        MarketEvent.source != "tradingview"
-    )
-    await db_session.execute(
-        delete(MarketEventValue).where(
-            MarketEventValue.event_id.in_(non_tradingview_events)
-        )
-    )
-    await db_session.execute(
-        delete(MarketEvent).where(MarketEvent.source != "tradingview")
-    )
-    await db_session.execute(
-        delete(MarketEventIngestionPartition).where(
-            MarketEventIngestionPartition.source != "tradingview"
-        )
-    )
-    await db_session.commit()
+    await clean_non_tradingview_market_events(db_session)
     yield
-
-
-def _app() -> FastAPI:
-    from app.core.db import AsyncSessionLocal, get_db
-    from app.routers import market_events
-    from app.routers.dependencies import get_authenticated_user
-
-    app = FastAPI()
-    app.include_router(market_events.router)
-    app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=7)
-
-    async def _override_get_db():
-        async with AsyncSessionLocal() as session:
-            yield session
-
-    app.dependency_overrides[get_db] = _override_get_db
-    return app
 
 
 @pytest.mark.integration
 def test_discover_calendar_returns_grouped_days(db_session):
-    with TestClient(_app()) as client:
+    with TestClient(build_market_events_app()) as client:
         r = client.get(
             "/trading/api/market-events/discover-calendar"
             "?from_date=2026-05-04&to_date=2026-05-10&today=2026-05-07&tab=all"
@@ -77,7 +39,7 @@ def test_discover_calendar_returns_grouped_days(db_session):
 
 @pytest.mark.integration
 def test_discover_calendar_validates_date_order(db_session):
-    with TestClient(_app()) as client:
+    with TestClient(build_market_events_app()) as client:
         r = client.get(
             "/trading/api/market-events/discover-calendar"
             "?from_date=2026-05-10&to_date=2026-05-04&today=2026-05-07"
@@ -87,7 +49,7 @@ def test_discover_calendar_validates_date_order(db_session):
 
 @pytest.mark.integration
 def test_discover_calendar_rejects_unknown_tab(db_session):
-    with TestClient(_app()) as client:
+    with TestClient(build_market_events_app()) as client:
         r = client.get(
             "/trading/api/market-events/discover-calendar"
             "?from_date=2026-05-04&to_date=2026-05-10&today=2026-05-07&tab=bogus"
@@ -97,11 +59,7 @@ def test_discover_calendar_rejects_unknown_tab(db_session):
 
 @pytest.mark.integration
 def test_discover_calendar_requires_auth():
-    from app.routers import market_events
-
-    app = FastAPI()
-    app.include_router(market_events.router)
-    with TestClient(app) as client:
+    with TestClient(build_market_events_app(authenticated=False)) as client:
         r = client.get(
             "/trading/api/market-events/discover-calendar"
             "?from_date=2026-05-04&to_date=2026-05-10&today=2026-05-07"

--- a/tests/test_market_events_router.py
+++ b/tests/test_market_events_router.py
@@ -8,7 +8,7 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -19,9 +19,22 @@ async def _clean_market_events(db_session):
         MarketEventValue,
     )
 
-    await db_session.execute(delete(MarketEventValue))
-    await db_session.execute(delete(MarketEvent))
-    await db_session.execute(delete(MarketEventIngestionPartition))
+    non_tradingview_events = select(MarketEvent.id).where(
+        MarketEvent.source != "tradingview"
+    )
+    await db_session.execute(
+        delete(MarketEventValue).where(
+            MarketEventValue.event_id.in_(non_tradingview_events)
+        )
+    )
+    await db_session.execute(
+        delete(MarketEvent).where(MarketEvent.source != "tradingview")
+    )
+    await db_session.execute(
+        delete(MarketEventIngestionPartition).where(
+            MarketEventIngestionPartition.source != "tradingview"
+        )
+    )
     await db_session.commit()
     yield
 

--- a/tests/test_market_events_router.py
+++ b/tests/test_market_events_router.py
@@ -2,66 +2,26 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 import pytest
 import pytest_asyncio
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy import delete, select
+
+from tests.market_events_test_helpers import (
+    build_market_events_app,
+    clean_non_tradingview_market_events,
+)
 
 
 @pytest_asyncio.fixture(autouse=True)
 async def _clean_market_events(db_session):
-    from app.models.market_events import (
-        MarketEvent,
-        MarketEventIngestionPartition,
-        MarketEventValue,
-    )
-
-    non_tradingview_events = select(MarketEvent.id).where(
-        MarketEvent.source != "tradingview"
-    )
-    await db_session.execute(
-        delete(MarketEventValue).where(
-            MarketEventValue.event_id.in_(non_tradingview_events)
-        )
-    )
-    await db_session.execute(
-        delete(MarketEvent).where(MarketEvent.source != "tradingview")
-    )
-    await db_session.execute(
-        delete(MarketEventIngestionPartition).where(
-            MarketEventIngestionPartition.source != "tradingview"
-        )
-    )
-    await db_session.commit()
+    await clean_non_tradingview_market_events(db_session)
     yield
-
-
-def _app() -> FastAPI:
-    from app.core.db import get_db
-    from app.routers import market_events
-    from app.routers.dependencies import get_authenticated_user
-
-    app = FastAPI()
-    app.include_router(market_events.router)
-    app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(id=7)
-
-    async def _override_get_db():
-        from app.core.db import AsyncSessionLocal
-
-        async with AsyncSessionLocal() as session:
-            yield session
-
-    app.dependency_overrides[get_db] = _override_get_db
-    return app
 
 
 @pytest.mark.integration
 def test_get_today_events_returns_empty_when_no_data(db_session):
     """Smoke test: route exists, returns empty events when DB has none."""
-    with TestClient(_app()) as client:
+    with TestClient(build_market_events_app()) as client:
         response = client.get(
             "/trading/api/market-events/today?on_date=2026-05-07",
         )
@@ -74,12 +34,7 @@ def test_get_today_events_returns_empty_when_no_data(db_session):
 @pytest.mark.integration
 def test_get_today_events_unauthorized_without_override():
     """Without dependency override, real auth dependency rejects unauthenticated request."""
-    from app.routers import market_events
-
-    app = FastAPI()
-    app.include_router(market_events.router)
-    # Do not override get_authenticated_user — it should reject calls without a token.
-    with TestClient(app) as client:
+    with TestClient(build_market_events_app(authenticated=False)) as client:
         response = client.get(
             "/trading/api/market-events/today?on_date=2026-05-07",
         )
@@ -88,7 +43,7 @@ def test_get_today_events_unauthorized_without_override():
 
 @pytest.mark.integration
 def test_get_range_events_validates_date_order(db_session):
-    with TestClient(_app()) as client:
+    with TestClient(build_market_events_app()) as client:
         response = client.get(
             "/trading/api/market-events/range?from_date=2026-05-08&to_date=2026-05-07",
         )
@@ -98,7 +53,7 @@ def test_get_range_events_validates_date_order(db_session):
 @pytest.mark.integration
 def test_get_today_events_filters_by_category_economic(db_session):
     """Smoke test: passing category=economic does not 400 and filters correctly."""
-    with TestClient(_app()) as client:
+    with TestClient(build_market_events_app()) as client:
         response = client.get(
             "/trading/api/market-events/today?on_date=2026-05-13&category=economic&market=global",
         )
@@ -110,7 +65,7 @@ def test_get_today_events_filters_by_category_economic(db_session):
 
 @pytest.mark.integration
 def test_get_today_events_rejects_unknown_category(db_session):
-    with TestClient(_app()) as client:
+    with TestClient(build_market_events_app()) as client:
         response = client.get(
             "/trading/api/market-events/today?on_date=2026-05-13&category=bogus",
         )

--- a/tests/test_naver_discussion_signal_poc.py
+++ b/tests/test_naver_discussion_signal_poc.py
@@ -8,7 +8,10 @@ from app.schemas.invest_stock_detail import StockDetailDiscussionSignal
 from app.services.invest_view_model.naver_discussion_signal_poc import (
     build_naver_discussion_signal_poc,
 )
-from app.services.invest_view_model.stock_detail_service import build_stock_detail
+from app.services.invest_view_model.stock_detail_service import (
+    StockDetailProviders,
+    build_stock_detail,
+)
 from app.services.invest_view_model.stock_detail_symbol_resolver import ResolvedSymbol
 
 
@@ -59,7 +62,7 @@ async def test_build_stock_detail_wires_discussion_signal_for_kr():
         market="kr",
         symbol="005930",
         db=SimpleNamespace(),
-        resolver=resolve_kr,
+        providers=StockDetailProviders(resolver=resolve_kr),
     )
 
     assert response.discussionSignal is not None
@@ -85,7 +88,7 @@ async def test_build_stock_detail_omits_discussion_signal_for_crypto():
         market="crypto",
         symbol="KRW-BTC",
         db=SimpleNamespace(),
-        resolver=resolve_crypto,
+        providers=StockDetailProviders(resolver=resolve_crypto),
     )
 
     assert response.discussionSignal is None

--- a/tests/test_stock_detail_service.py
+++ b/tests/test_stock_detail_service.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
 
 from app.schemas.invest_stock_detail import StockDetailHolding, StockDetailOrderbook
-from app.services.invest_view_model.stock_detail_service import build_stock_detail
+from app.services.invest_view_model.stock_detail_service import (
+    StockDetailProviders,
+    build_stock_detail,
+)
 from app.services.invest_view_model.stock_detail_symbol_resolver import ResolvedSymbol
 
 
@@ -53,7 +57,7 @@ async def test_build_stock_detail_declares_us_orderbook_unsupported():
         market="us",
         symbol="BRK-B",
         db=SimpleNamespace(),
-        resolver=_resolve_us,
+        providers=StockDetailProviders(resolver=_resolve_us),
     )
 
     assert response.symbol == "BRK.B"
@@ -77,6 +81,7 @@ async def test_build_stock_detail_declares_us_orderbook_unsupported():
 @pytest.mark.asyncio
 async def test_build_stock_detail_maps_holding_and_kr_orderbook_when_available():
     async def holding_provider(user_id, market, symbol, db):
+        await asyncio.sleep(0)
         return StockDetailHolding(
             totalQuantity=2,
             averageCost=70000,
@@ -100,6 +105,7 @@ async def test_build_stock_detail_maps_holding_and_kr_orderbook_when_available()
 
     async def fx_rate_provider():
         nonlocal fx_rate_called
+        await asyncio.sleep(0)
         fx_rate_called = True
         return 1360.0
 
@@ -108,10 +114,12 @@ async def test_build_stock_detail_maps_holding_and_kr_orderbook_when_available()
         market="kr",
         symbol="005930",
         db=SimpleNamespace(),
-        resolver=_resolve_kr,
-        holding_provider=holding_provider,
-        orderbook_provider=orderbook_provider,
-        fx_rate_provider=fx_rate_provider,
+        providers=StockDetailProviders(
+            resolver=_resolve_kr,
+            holding=holding_provider,
+            orderbook=orderbook_provider,
+            fx_rate=fx_rate_provider,
+        ),
     )
 
     assert response.holding is not None
@@ -137,7 +145,7 @@ async def test_build_stock_detail_omits_naver_poc_for_crypto():
         market="crypto",
         symbol="KRW-BTC",
         db=SimpleNamespace(),
-        resolver=_resolve_crypto,
+        providers=StockDetailProviders(resolver=_resolve_crypto),
     )
 
     assert response.market == "crypto"
@@ -150,6 +158,7 @@ async def test_build_stock_detail_omits_naver_poc_for_crypto():
 @pytest.mark.asyncio
 async def test_build_stock_detail_adds_fx_sensitivity_for_us_holding():
     async def holding_provider(user_id, market, symbol, db):
+        await asyncio.sleep(0)
         return StockDetailHolding(
             totalQuantity=2,
             averageCost=200,
@@ -163,6 +172,7 @@ async def test_build_stock_detail_adds_fx_sensitivity_for_us_holding():
         )
 
     async def fx_rate_provider():
+        await asyncio.sleep(0)
         return 1360.0
 
     response = await build_stock_detail(
@@ -170,15 +180,17 @@ async def test_build_stock_detail_adds_fx_sensitivity_for_us_holding():
         market="us",
         symbol="BRK-B",
         db=SimpleNamespace(),
-        resolver=_resolve_us,
-        holding_provider=holding_provider,
-        fx_rate_provider=fx_rate_provider,
+        providers=StockDetailProviders(
+            resolver=_resolve_us,
+            holding=holding_provider,
+            fx_rate=fx_rate_provider,
+        ),
     )
 
     assert response.fxSensitivity is not None
     assert response.fxSensitivity.status == "available"
-    assert response.fxSensitivity.baseFxRate == 1360.0
-    assert response.fxSensitivity.holdingValueNative == 422.68
+    assert response.fxSensitivity.baseFxRate == pytest.approx(1360.0)
+    assert response.fxSensitivity.holdingValueNative == pytest.approx(422.68)
     assert [scenario.rateMovePct for scenario in response.fxSensitivity.scenarios] == [
         -1.0,
         1.0,
@@ -197,6 +209,7 @@ async def test_build_stock_detail_adds_fx_sensitivity_for_us_holding():
 @pytest.mark.asyncio
 async def test_build_stock_detail_degrades_when_us_fx_provider_fails():
     async def holding_provider(user_id, market, symbol, db):
+        await asyncio.sleep(0)
         return StockDetailHolding(
             totalQuantity=2,
             averageCost=200,
@@ -210,6 +223,7 @@ async def test_build_stock_detail_degrades_when_us_fx_provider_fails():
         )
 
     async def fx_rate_provider():
+        await asyncio.sleep(0)
         raise RuntimeError("provider unavailable")
 
     response = await build_stock_detail(
@@ -217,9 +231,11 @@ async def test_build_stock_detail_degrades_when_us_fx_provider_fails():
         market="us",
         symbol="BRK-B",
         db=SimpleNamespace(),
-        resolver=_resolve_us,
-        holding_provider=holding_provider,
-        fx_rate_provider=fx_rate_provider,
+        providers=StockDetailProviders(
+            resolver=_resolve_us,
+            holding=holding_provider,
+            fx_rate=fx_rate_provider,
+        ),
     )
 
     assert response.fxSensitivity is not None

--- a/tests/test_stock_detail_service.py
+++ b/tests/test_stock_detail_service.py
@@ -58,6 +58,10 @@ async def test_build_stock_detail_declares_us_orderbook_unsupported():
 
     assert response.symbol == "BRK.B"
     assert response.market == "us"
+    assert response.fxSensitivity is not None
+    assert response.fxSensitivity.status == "missing_holding"
+    assert "매수" not in response.fxSensitivity.caution
+    assert "매도" not in response.fxSensitivity.caution
     assert response.naverEnrichment is not None
     assert response.naverEnrichment.naverCode == "BRK.B"
     assert response.naverEnrichment.liveFetchEnabled is False
@@ -92,6 +96,13 @@ async def test_build_stock_detail_maps_holding_and_kr_orderbook_when_available()
             bids=[{"price": 71100, "quantity": 12}],
         )
 
+    fx_rate_called = False
+
+    async def fx_rate_provider():
+        nonlocal fx_rate_called
+        fx_rate_called = True
+        return 1360.0
+
     response = await build_stock_detail(
         user_id=1,
         market="kr",
@@ -100,10 +111,15 @@ async def test_build_stock_detail_maps_holding_and_kr_orderbook_when_available()
         resolver=_resolve_kr,
         holding_provider=holding_provider,
         orderbook_provider=orderbook_provider,
+        fx_rate_provider=fx_rate_provider,
     )
 
     assert response.holding is not None
     assert response.holding.totalQuantity == 2
+    assert response.fxSensitivity is not None
+    assert response.fxSensitivity.status == "not_applicable"
+    assert response.fxSensitivity.scenarios == []
+    assert fx_rate_called is False
     assert response.naverEnrichment is not None
     assert response.naverEnrichment.naverCode == "005930"
     assert (
@@ -125,5 +141,88 @@ async def test_build_stock_detail_omits_naver_poc_for_crypto():
     )
 
     assert response.market == "crypto"
+    assert response.fxSensitivity is not None
+    assert response.fxSensitivity.status == "not_applicable"
     assert response.naverEnrichment is None
     assert response.orderbookSupport.supported is False
+
+
+@pytest.mark.asyncio
+async def test_build_stock_detail_adds_fx_sensitivity_for_us_holding():
+    async def holding_provider(user_id, market, symbol, db):
+        return StockDetailHolding(
+            totalQuantity=2,
+            averageCost=200,
+            costBasis=400,
+            valueNative=422.68,
+            valueKrw=575000,
+            pnlKrw=30000,
+            pnlRate=0.055,
+            includedSources=["kis"],
+            priceState="live",
+        )
+
+    async def fx_rate_provider():
+        return 1360.0
+
+    response = await build_stock_detail(
+        user_id=1,
+        market="us",
+        symbol="BRK-B",
+        db=SimpleNamespace(),
+        resolver=_resolve_us,
+        holding_provider=holding_provider,
+        fx_rate_provider=fx_rate_provider,
+    )
+
+    assert response.fxSensitivity is not None
+    assert response.fxSensitivity.status == "available"
+    assert response.fxSensitivity.baseFxRate == 1360.0
+    assert response.fxSensitivity.holdingValueNative == 422.68
+    assert [scenario.rateMovePct for scenario in response.fxSensitivity.scenarios] == [
+        -1.0,
+        1.0,
+    ]
+    assert response.fxSensitivity.scenarios[0].estimatedKrwImpact == pytest.approx(
+        -5748.448
+    )
+    assert response.fxSensitivity.scenarios[1].estimatedKrwImpact == pytest.approx(
+        5748.448
+    )
+    assert "매수" not in response.fxSensitivity.caution
+    assert "매도" not in response.fxSensitivity.caution
+    assert "추천" not in response.fxSensitivity.caution
+
+
+@pytest.mark.asyncio
+async def test_build_stock_detail_degrades_when_us_fx_provider_fails():
+    async def holding_provider(user_id, market, symbol, db):
+        return StockDetailHolding(
+            totalQuantity=2,
+            averageCost=200,
+            costBasis=400,
+            valueNative=422.68,
+            valueKrw=575000,
+            pnlKrw=30000,
+            pnlRate=0.055,
+            includedSources=["kis"],
+            priceState="live",
+        )
+
+    async def fx_rate_provider():
+        raise RuntimeError("provider unavailable")
+
+    response = await build_stock_detail(
+        user_id=1,
+        market="us",
+        symbol="BRK-B",
+        db=SimpleNamespace(),
+        resolver=_resolve_us,
+        holding_provider=holding_provider,
+        fx_rate_provider=fx_rate_provider,
+    )
+
+    assert response.fxSensitivity is not None
+    assert response.fxSensitivity.status == "missing_fx_rate"
+    assert response.fxSensitivity.scenarios == []
+    assert "fx_sensitivity_unavailable" in response.meta.warnings


### PR DESCRIPTION
## Summary
- add read-only FX sensitivity schema/service data for invest stock detail pages
- render conservative FX sensitivity card for KR/US/crypto examples with fallback messaging
- add backend and frontend tests for the new card contract

## Safety
- Read-only /invest analysis/UI only
- No broker submit/cancel/modify paths
- No watch/order-intent creation
- No production DB writes/backfills or scheduler activation
- Copy avoids buy/sell recommendation language and uses cautious FX wording

## Verification
- uv run pytest tests/test_invest_stock_detail_schemas.py tests/test_stock_detail_service.py tests/test_stock_detail_capability_contract.py -q
- npm test -- --run src/__tests__/StockDetailPage.test.tsx
- npm run typecheck
- npm run build
- uv run ruff check app/schemas/invest_stock_detail.py app/services/invest_view_model/stock_detail_service.py tests/test_invest_stock_detail_schemas.py tests/test_stock_detail_service.py
- git diff --check origin/main...HEAD

Closes ROB-221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FX sensitivity added to stock detail: USD/KRW ±1% scenarios with estimated KRW impacts, signed formatting, caution text, and conditional display when data is missing or not applicable.

* **Tests**
  * Added coverage for FX sensitivity generation, provider failure handling, and UX/visibility cases.
  * Tightened market-events test fixtures and introduced shared helpers to scope cleanup by event source.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/812)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->