### PR TITLE
feat(ROB-222): add Naver momentum event snapshots

### DIFF
--- a/alembic/versions/2026_05_13_rob222_naver_momentum_event_snapshots.py
+++ b/alembic/versions/2026_05_13_rob222_naver_momentum_event_snapshots.py
@@ -1,0 +1,160 @@
+"""ROB-222 add Naver momentum/theme event snapshot tables.
+
+Revision ID: 20260513_rob222
+Revises: 20260513_rob211k3
+Create Date: 2026-05-13
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "20260513_rob222"
+down_revision = "20260513_rob211k3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "invest_momentum_event_snapshots",
+        sa.Column("id", sa.BigInteger(), sa.Identity(always=False), primary_key=True),
+        sa.Column("snapshot_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("trading_date", sa.Date(), nullable=False),
+        sa.Column("source", sa.String(length=32), nullable=False, server_default="naver_stock"),
+        sa.Column("surface", sa.String(length=80), nullable=False),
+        sa.Column("market", sa.String(length=8), nullable=False, server_default="kr"),
+        sa.Column("trade_type", sa.String(length=16), nullable=True),
+        sa.Column("market_type", sa.String(length=16), nullable=True),
+        sa.Column("order_type", sa.String(length=32), nullable=False),
+        sa.Column("rank", sa.Integer(), nullable=False),
+        sa.Column("symbol", sa.String(length=20), nullable=False),
+        sa.Column("name", sa.Text(), nullable=True),
+        sa.Column("price", sa.Numeric(20, 6), nullable=True),
+        sa.Column("change_amount", sa.Numeric(20, 6), nullable=True),
+        sa.Column("change_rate", sa.Numeric(10, 4), nullable=True),
+        sa.Column("volume", sa.BigInteger(), nullable=True),
+        sa.Column("trade_value", sa.Numeric(30, 2), nullable=True),
+        sa.Column("market_cap", sa.Numeric(30, 2), nullable=True),
+        sa.Column("raw_payload", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("collected_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.CheckConstraint("market = 'kr'", name="ck_invest_momentum_event_snapshots_market"),
+        sa.CheckConstraint("source = 'naver_stock'", name="ck_invest_momentum_event_snapshots_source"),
+        sa.UniqueConstraint(
+            "surface",
+            "snapshot_at",
+            "trade_type",
+            "market_type",
+            "order_type",
+            "symbol",
+            name="uq_invest_momentum_event_snapshots_surface_params_symbol_at",
+        ),
+    )
+    op.create_index(
+        "ix_invest_momentum_event_snapshots_date_order_rank",
+        "invest_momentum_event_snapshots",
+        ["trading_date", "order_type", "rank"],
+    )
+    op.create_index(
+        "ix_invest_momentum_event_snapshots_symbol_date",
+        "invest_momentum_event_snapshots",
+        ["symbol", "trading_date"],
+    )
+    op.create_index(
+        "ix_invest_momentum_event_snapshots_surface_params_at",
+        "invest_momentum_event_snapshots",
+        ["surface", "trade_type", "market_type", "order_type", "snapshot_at"],
+    )
+
+    op.create_table(
+        "invest_theme_event_snapshots",
+        sa.Column("id", sa.BigInteger(), sa.Identity(always=False), primary_key=True),
+        sa.Column("snapshot_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("trading_date", sa.Date(), nullable=False),
+        sa.Column("source", sa.String(length=32), nullable=False, server_default="naver_stock"),
+        sa.Column("surface", sa.String(length=80), nullable=False),
+        sa.Column("market", sa.String(length=8), nullable=False, server_default="kr"),
+        sa.Column("event_kind", sa.String(length=16), nullable=False),
+        sa.Column("source_event_key", sa.String(length=160), nullable=False),
+        sa.Column("naver_theme_no", sa.String(length=40), nullable=True),
+        sa.Column("naver_upjong_code", sa.String(length=40), nullable=True),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("sort_type", sa.String(length=32), nullable=False),
+        sa.Column("rank", sa.Integer(), nullable=True),
+        sa.Column("market_type", sa.String(length=16), nullable=True),
+        sa.Column("change_rate", sa.Numeric(10, 4), nullable=True),
+        sa.Column("trade_value", sa.Numeric(30, 2), nullable=True),
+        sa.Column("market_cap", sa.Numeric(30, 2), nullable=True),
+        sa.Column("stock_count", sa.Integer(), nullable=True),
+        sa.Column("leader_symbols", postgresql.JSONB(astext_type=sa.Text()), server_default=sa.text("'[]'::jsonb"), nullable=False),
+        sa.Column("raw_payload", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("collected_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.CheckConstraint("market = 'kr'", name="ck_invest_theme_event_snapshots_market"),
+        sa.CheckConstraint("source = 'naver_stock'", name="ck_invest_theme_event_snapshots_source"),
+        sa.CheckConstraint("event_kind IN ('theme', 'upjong')", name="ck_invest_theme_event_snapshots_kind"),
+        sa.UniqueConstraint("snapshot_at", "source_event_key", name="uq_invest_theme_event_snapshots_at_key"),
+    )
+    op.create_index(
+        "ix_invest_theme_event_snapshots_date_kind_sort_rank",
+        "invest_theme_event_snapshots",
+        ["trading_date", "event_kind", "sort_type", "rank"],
+    )
+    op.create_index(
+        "ix_invest_theme_event_snapshots_kind_key_at",
+        "invest_theme_event_snapshots",
+        ["event_kind", "source_event_key", "snapshot_at"],
+    )
+
+    op.create_table(
+        "invest_theme_event_snapshot_stocks",
+        sa.Column("id", sa.BigInteger(), sa.Identity(always=False), primary_key=True),
+        sa.Column("theme_snapshot_id", sa.BigInteger(), nullable=False),
+        sa.Column("symbol", sa.String(length=20), nullable=False),
+        sa.Column("name", sa.Text(), nullable=True),
+        sa.Column("rank", sa.Integer(), nullable=True),
+        sa.Column("order_type", sa.String(length=32), nullable=True),
+        sa.Column("price", sa.Numeric(20, 6), nullable=True),
+        sa.Column("change_amount", sa.Numeric(20, 6), nullable=True),
+        sa.Column("change_rate", sa.Numeric(10, 4), nullable=True),
+        sa.Column("volume", sa.BigInteger(), nullable=True),
+        sa.Column("trade_value", sa.Numeric(30, 2), nullable=True),
+        sa.Column("raw_payload", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["theme_snapshot_id"],
+            ["invest_theme_event_snapshots.id"],
+            name="fk_invest_theme_event_snapshot_stocks_theme_snapshot_id",
+            ondelete="CASCADE",
+        ),
+        sa.UniqueConstraint(
+            "theme_snapshot_id",
+            "order_type",
+            "symbol",
+            name="uq_invest_theme_event_snapshot_stocks_parent_order_symbol",
+        ),
+    )
+    op.create_index("ix_invest_theme_event_snapshot_stocks_symbol", "invest_theme_event_snapshot_stocks", ["symbol"])
+    op.create_index(
+        "ix_invest_theme_event_snapshot_stocks_parent_rank",
+        "invest_theme_event_snapshot_stocks",
+        ["theme_snapshot_id", "rank"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_invest_theme_event_snapshot_stocks_parent_rank", table_name="invest_theme_event_snapshot_stocks")
+    op.drop_index("ix_invest_theme_event_snapshot_stocks_symbol", table_name="invest_theme_event_snapshot_stocks")
+    op.drop_table("invest_theme_event_snapshot_stocks")
+    op.drop_index("ix_invest_theme_event_snapshots_kind_key_at", table_name="invest_theme_event_snapshots")
+    op.drop_index("ix_invest_theme_event_snapshots_date_kind_sort_rank", table_name="invest_theme_event_snapshots")
+    op.drop_table("invest_theme_event_snapshots")
+    op.drop_index("ix_invest_momentum_event_snapshots_surface_params_at", table_name="invest_momentum_event_snapshots")
+    op.drop_index("ix_invest_momentum_event_snapshots_symbol_date", table_name="invest_momentum_event_snapshots")
+    op.drop_index("ix_invest_momentum_event_snapshots_date_order_rank", table_name="invest_momentum_event_snapshots")
+    op.drop_table("invest_momentum_event_snapshots")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -316,6 +316,9 @@ class Settings(BaseSettings):
     # ROB-204 — Prefect/manual US screener snapshot writes stay dry-run unless explicitly enabled.
     invest_screener_snapshots_commit_enabled: bool = False
 
+    # ROB-222 — Naver momentum/theme event snapshot writes stay dry-run unless explicitly enabled.
+    invest_momentum_events_commit_enabled: bool = False
+
     # KRX (한국거래소) 정보데이터시스템
     krx_member_id: str | None = None
     krx_password: str | None = None

--- a/app/jobs/invest_momentum_events.py
+++ b/app/jobs/invest_momentum_events.py
@@ -1,0 +1,97 @@
+"""Dry-run-default job boundary for Naver momentum/theme event snapshots."""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+
+from app.core.config import settings
+from app.core.db import AsyncSessionLocal
+from app.services.invest_momentum_events.builder import (
+    BuildPlan,
+    build_payloads_from_naver,
+)
+from app.services.invest_momentum_events.repository import (
+    InvestMomentumEventSnapshotsRepository,
+)
+from app.services.naver_stock.client import NaverStockClient
+
+
+@dataclass(frozen=True)
+class NaverMomentumBuildRequest:
+    trade_types: tuple[str, ...] = ("KRX",)
+    market_types: tuple[str, ...] = ("ALL",)
+    order_types: tuple[str, ...] = ("up", "quantTop", "priceTop", "searchTop")
+    theme_sort_types: tuple[str, ...] = ("changeRate",)
+    page_size: int = 50
+    commit: bool = False
+    today: dt.date | None = None
+
+
+@dataclass(frozen=True)
+class NaverMomentumBuildResult:
+    momentum_rows: int
+    theme_rows: int
+    committed: bool
+    counts_by_surface: dict[str, int] = field(default_factory=dict)
+    warnings: tuple[str, ...] = ()
+    samples: tuple[dict[str, str | int | None], ...] = ()
+
+
+async def run_naver_momentum_build(
+    request: NaverMomentumBuildRequest | None = None, *, fetcher=None
+) -> NaverMomentumBuildResult:
+    request = request or NaverMomentumBuildRequest()
+    should_commit = bool(
+        request.commit and settings.invest_momentum_events_commit_enabled
+    )
+    client = fetcher or NaverStockClient()
+    close_client = fetcher is None
+    try:
+        payloads = await build_payloads_from_naver(
+            client,
+            plan=BuildPlan(
+                trade_types=request.trade_types,
+                market_types=request.market_types,
+                order_types=request.order_types,
+                theme_sort_types=request.theme_sort_types,
+                page_size=request.page_size,
+            ),
+            today=request.today,
+        )
+    finally:
+        if close_client and hasattr(client, "aclose"):
+            await client.aclose()
+
+    if should_commit:
+        async with AsyncSessionLocal() as session:
+            repo = InvestMomentumEventSnapshotsRepository(session)
+            for row in payloads.momentum:
+                await repo.upsert_momentum(row)
+            for row in payloads.themes:
+                await repo.upsert_theme(row)
+            await session.commit()
+
+    samples = tuple(
+        {
+            "symbol": row.symbol,
+            "name": row.name,
+            "rank": row.rank,
+            "orderType": row.order_type,
+        }
+        for row in payloads.momentum[:10]
+    )
+    warnings = payloads.warnings
+    if request.commit and not settings.invest_momentum_events_commit_enabled:
+        warnings = (
+            *warnings,
+            "commit requested but invest_momentum_events_commit_enabled is false; dry-run only",
+        )
+    return NaverMomentumBuildResult(
+        momentum_rows=len(payloads.momentum),
+        theme_rows=len(payloads.themes),
+        committed=should_commit,
+        counts_by_surface=payloads.counts_by_surface,
+        warnings=warnings,
+        samples=samples,
+    )

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,6 +2,11 @@
 from .analysis import StockAnalysisResult, StockInfo
 from .base import Base
 from .execution_ledger import ExecutionLedger, ExecutionLedgerReconcileRun
+from .invest_momentum_event_snapshot import (
+    InvestMomentumEventSnapshot,
+    InvestThemeEventSnapshot,
+    InvestThemeEventSnapshotStock,
+)
 from .investor_flow_snapshot import InvestorFlowSnapshot
 from .kr_symbol_universe import KRSymbolUniverse
 from .manual_holdings import (
@@ -105,6 +110,9 @@ __all__ = [
     "StockInfo",
     "StockAnalysisResult",
     "InvestorFlowSnapshot",
+    "InvestMomentumEventSnapshot",
+    "InvestThemeEventSnapshot",
+    "InvestThemeEventSnapshotStock",
     "KRSymbolUniverse",
     "UpbitSymbolUniverse",
     "USSymbolUniverse",

--- a/app/models/invest_momentum_event_snapshot.py
+++ b/app/models/invest_momentum_event_snapshot.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    CheckConstraint,
+    Date,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+
+class InvestMomentumEventSnapshot(Base):
+    __tablename__ = "invest_momentum_event_snapshots"
+    __table_args__ = (
+        UniqueConstraint(
+            "surface",
+            "snapshot_at",
+            "trade_type",
+            "market_type",
+            "order_type",
+            "symbol",
+            name="uq_invest_momentum_event_snapshots_surface_params_symbol_at",
+        ),
+        CheckConstraint(
+            "market = 'kr'", name="ck_invest_momentum_event_snapshots_market"
+        ),
+        CheckConstraint(
+            "source = 'naver_stock'", name="ck_invest_momentum_event_snapshots_source"
+        ),
+        Index(
+            "ix_invest_momentum_event_snapshots_date_order_rank",
+            "trading_date",
+            "order_type",
+            "rank",
+        ),
+        Index(
+            "ix_invest_momentum_event_snapshots_symbol_date", "symbol", "trading_date"
+        ),
+        Index(
+            "ix_invest_momentum_event_snapshots_surface_params_at",
+            "surface",
+            "trade_type",
+            "market_type",
+            "order_type",
+            "snapshot_at",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    snapshot_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    trading_date: Mapped[date] = mapped_column(Date, nullable=False)
+    source: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="naver_stock"
+    )
+    surface: Mapped[str] = mapped_column(String(80), nullable=False)
+    market: Mapped[str] = mapped_column(String(8), nullable=False, default="kr")
+    trade_type: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    market_type: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    order_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    rank: Mapped[int] = mapped_column(Integer, nullable=False)
+    symbol: Mapped[str] = mapped_column(String(20), nullable=False)
+    name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    price: Mapped[Decimal | None] = mapped_column(Numeric(20, 6), nullable=True)
+    change_amount: Mapped[Decimal | None] = mapped_column(Numeric(20, 6), nullable=True)
+    change_rate: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
+    volume: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    trade_value: Mapped[Decimal | None] = mapped_column(Numeric(30, 2), nullable=True)
+    market_cap: Mapped[Decimal | None] = mapped_column(Numeric(30, 2), nullable=True)
+    raw_payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    collected_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+class InvestThemeEventSnapshot(Base):
+    __tablename__ = "invest_theme_event_snapshots"
+    __table_args__ = (
+        UniqueConstraint(
+            "snapshot_at",
+            "source_event_key",
+            name="uq_invest_theme_event_snapshots_at_key",
+        ),
+        CheckConstraint("market = 'kr'", name="ck_invest_theme_event_snapshots_market"),
+        CheckConstraint(
+            "source = 'naver_stock'", name="ck_invest_theme_event_snapshots_source"
+        ),
+        CheckConstraint(
+            "event_kind IN ('theme', 'upjong')",
+            name="ck_invest_theme_event_snapshots_kind",
+        ),
+        Index(
+            "ix_invest_theme_event_snapshots_date_kind_sort_rank",
+            "trading_date",
+            "event_kind",
+            "sort_type",
+            "rank",
+        ),
+        Index(
+            "ix_invest_theme_event_snapshots_kind_key_at",
+            "event_kind",
+            "source_event_key",
+            "snapshot_at",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    snapshot_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    trading_date: Mapped[date] = mapped_column(Date, nullable=False)
+    source: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="naver_stock"
+    )
+    surface: Mapped[str] = mapped_column(String(80), nullable=False)
+    market: Mapped[str] = mapped_column(String(8), nullable=False, default="kr")
+    event_kind: Mapped[str] = mapped_column(String(16), nullable=False)
+    source_event_key: Mapped[str] = mapped_column(String(160), nullable=False)
+    naver_theme_no: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    naver_upjong_code: Mapped[str | None] = mapped_column(String(40), nullable=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    sort_type: Mapped[str] = mapped_column(String(32), nullable=False)
+    rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    market_type: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    change_rate: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
+    trade_value: Mapped[Decimal | None] = mapped_column(Numeric(30, 2), nullable=True)
+    market_cap: Mapped[Decimal | None] = mapped_column(Numeric(30, 2), nullable=True)
+    stock_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    leader_symbols: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    raw_payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    collected_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    stocks: Mapped[list[InvestThemeEventSnapshotStock]] = relationship(
+        "InvestThemeEventSnapshotStock",
+        back_populates="theme_snapshot",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
+
+
+class InvestThemeEventSnapshotStock(Base):
+    __tablename__ = "invest_theme_event_snapshot_stocks"
+    __table_args__ = (
+        UniqueConstraint(
+            "theme_snapshot_id",
+            "order_type",
+            "symbol",
+            name="uq_invest_theme_event_snapshot_stocks_parent_order_symbol",
+        ),
+        Index("ix_invest_theme_event_snapshot_stocks_symbol", "symbol"),
+        Index(
+            "ix_invest_theme_event_snapshot_stocks_parent_rank",
+            "theme_snapshot_id",
+            "rank",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    theme_snapshot_id: Mapped[int] = mapped_column(
+        BigInteger,
+        ForeignKey("invest_theme_event_snapshots.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    symbol: Mapped[str] = mapped_column(String(20), nullable=False)
+    name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    order_type: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    price: Mapped[Decimal | None] = mapped_column(Numeric(20, 6), nullable=True)
+    change_amount: Mapped[Decimal | None] = mapped_column(Numeric(20, 6), nullable=True)
+    change_rate: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
+    volume: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    trade_value: Mapped[Decimal | None] = mapped_column(Numeric(30, 2), nullable=True)
+    raw_payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    theme_snapshot: Mapped[InvestThemeEventSnapshot] = relationship(
+        "InvestThemeEventSnapshot",
+        back_populates="stocks",
+    )

--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -30,6 +30,13 @@ from app.schemas.invest_feed_research import (
 from app.schemas.invest_fx_dashboard import FxDashboardResponse
 from app.schemas.invest_home import InvestHomeResponse
 from app.schemas.invest_market_dashboard import MarketDashboardResponse
+from app.schemas.invest_momentum_events import (
+    MomentumCoverageResponse,
+    MomentumEventItem,
+    MomentumEventsResponse,
+    ThemeEventItem,
+    ThemeEventsResponse,
+)
 from app.schemas.invest_screener import (
     ScreenerPresetsResponse,
     ScreenerResultsResponse,
@@ -43,6 +50,10 @@ from app.schemas.invest_stock_detail import (
 from app.schemas.investor_flow import InvestorFlowResponse
 from app.services.invest_coverage_service import build_invest_coverage
 from app.services.invest_home_service import InvestHomeService
+from app.services.invest_momentum_events.coverage_service import build_momentum_coverage
+from app.services.invest_momentum_events.repository import (
+    InvestMomentumEventSnapshotsRepository,
+)
 from app.services.invest_screener_snapshots.coverage_service import build_coverage
 from app.services.invest_view_model.account_panel_service import build_account_panel
 from app.services.invest_view_model.calendar_service import build_calendar
@@ -446,3 +457,89 @@ async def screener_snapshots_coverage(
         else None,
         "dataState": report.dataState,
     }
+
+
+@router.get("/momentum/events", response_model=MomentumEventsResponse)
+async def get_momentum_events(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    market: Literal["kr", "us", "crypto"] = Query("kr"),
+    snapshot_date: Annotated[date | None, Query(alias="date")] = None,
+    surface: str | None = Query(None),
+    order_type: Annotated[str | None, Query(alias="orderType")] = None,
+    trade_type: Annotated[str | None, Query(alias="tradeType")] = None,
+    limit: int = Query(50, ge=1, le=100),
+) -> MomentumEventsResponse:
+    """Read-only persisted Naver momentum snapshots; never fetches Naver on request."""
+    if market != "kr":
+        return MomentumEventsResponse(
+            market=market,
+            data_state="unsupported",
+            empty_reason="naver_stock_supports_kr_only",
+            items=[],
+        )
+    rows = await InvestMomentumEventSnapshotsRepository(db).list_momentum_events(
+        trading_date=snapshot_date,
+        surface=surface,
+        order_type=order_type,
+        trade_type=trade_type,
+        limit=limit,
+    )
+    return MomentumEventsResponse(
+        market="kr",
+        data_state="fresh" if rows else "missing",
+        empty_reason=None if rows else "no_naver_momentum_snapshots",
+        items=[MomentumEventItem.model_validate(row) for row in rows],
+    )
+
+
+@router.get("/momentum/themes", response_model=ThemeEventsResponse)
+async def get_momentum_themes(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    market: Literal["kr", "us", "crypto"] = Query("kr"),
+    snapshot_date: Annotated[date | None, Query(alias="date")] = None,
+    event_kind: Annotated[
+        Literal["theme", "upjong"] | None, Query(alias="eventKind")
+    ] = None,
+    sort_type: Annotated[str | None, Query(alias="sortType")] = None,
+    limit: int = Query(50, ge=1, le=100),
+) -> ThemeEventsResponse:
+    """Read-only persisted Naver theme/upjong snapshots; never fetches Naver on request."""
+    if market != "kr":
+        return ThemeEventsResponse(
+            market=market,
+            data_state="unsupported",
+            empty_reason="naver_stock_supports_kr_only",
+            items=[],
+        )
+    rows = await InvestMomentumEventSnapshotsRepository(db).list_theme_events(
+        trading_date=snapshot_date,
+        event_kind=event_kind,
+        sort_type=sort_type,
+        limit=limit,
+    )
+    return ThemeEventsResponse(
+        market="kr",
+        data_state="fresh" if rows else "missing",
+        empty_reason=None if rows else "no_naver_theme_snapshots",
+        items=[ThemeEventItem.model_validate(row) for row in rows],
+    )
+
+
+@router.get("/momentum/coverage", response_model=MomentumCoverageResponse)
+async def momentum_coverage(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    market: Literal["kr", "us", "crypto"] = Query("kr"),
+    as_of: Annotated[date | None, Query(alias="asOf")] = None,
+) -> MomentumCoverageResponse:
+    """Read-only coverage summary for Naver momentum/theme snapshots (ROB-222)."""
+    report = await build_momentum_coverage(db, market=market, as_of=as_of)
+    return MomentumCoverageResponse(
+        market=report.market,
+        as_of=report.asOf,
+        momentum_events=report.momentumEvents,
+        theme_events=report.themeEvents,
+        last_momentum_snapshot_at=report.lastMomentumSnapshotAt,
+        last_theme_snapshot_at=report.lastThemeSnapshotAt,
+        data_state=report.dataState,
+        empty_reason=report.emptyReason,
+    )

--- a/app/schemas/invest_momentum_events.py
+++ b/app/schemas/invest_momentum_events.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MomentumEventItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    snapshot_at: dt.datetime = Field(alias="snapshotAt")
+    trading_date: dt.date = Field(alias="tradingDate")
+    source: str
+    surface: str
+    market: str
+    trade_type: str | None = Field(default=None, alias="tradeType")
+    market_type: str | None = Field(default=None, alias="marketType")
+    order_type: str = Field(alias="orderType")
+    rank: int
+    symbol: str
+    name: str | None = None
+    price: Decimal | None = None
+    change_amount: Decimal | None = Field(default=None, alias="changeAmount")
+    change_rate: Decimal | None = Field(default=None, alias="changeRate")
+    volume: int | None = None
+    trade_value: Decimal | None = Field(default=None, alias="tradeValue")
+    market_cap: Decimal | None = Field(default=None, alias="marketCap")
+
+
+class MomentumEventsResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    market: str
+    data_state: str = Field(alias="dataState")
+    empty_reason: str | None = Field(default=None, alias="emptyReason")
+    items: list[MomentumEventItem]
+
+
+class ThemeEventItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    snapshot_at: dt.datetime = Field(alias="snapshotAt")
+    trading_date: dt.date = Field(alias="tradingDate")
+    source: str
+    surface: str
+    market: str
+    event_kind: Literal["theme", "upjong"] = Field(alias="eventKind")
+    source_event_key: str = Field(alias="sourceEventKey")
+    naver_theme_no: str | None = Field(default=None, alias="naverThemeNo")
+    naver_upjong_code: str | None = Field(default=None, alias="naverUpjongCode")
+    name: str
+    sort_type: str = Field(alias="sortType")
+    rank: int | None = None
+    market_type: str | None = Field(default=None, alias="marketType")
+    change_rate: Decimal | None = Field(default=None, alias="changeRate")
+    trade_value: Decimal | None = Field(default=None, alias="tradeValue")
+    market_cap: Decimal | None = Field(default=None, alias="marketCap")
+    stock_count: int | None = Field(default=None, alias="stockCount")
+    leader_symbols: list[dict[str, Any]] = Field(
+        default_factory=list, alias="leaderSymbols"
+    )
+
+
+class ThemeEventsResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    market: str
+    data_state: str = Field(alias="dataState")
+    empty_reason: str | None = Field(default=None, alias="emptyReason")
+    items: list[ThemeEventItem]
+
+
+class MomentumCoverageResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    market: str
+    as_of: dt.date = Field(alias="asOf")
+    momentum_events: int = Field(alias="momentumEvents")
+    theme_events: int = Field(alias="themeEvents")
+    last_momentum_snapshot_at: dt.datetime | None = Field(
+        default=None, alias="lastMomentumSnapshotAt"
+    )
+    last_theme_snapshot_at: dt.datetime | None = Field(
+        default=None, alias="lastThemeSnapshotAt"
+    )
+    data_state: str = Field(alias="dataState")
+    empty_reason: str | None = Field(default=None, alias="emptyReason")

--- a/app/services/invest_momentum_events/__init__.py
+++ b/app/services/invest_momentum_events/__init__.py
@@ -1,0 +1,1 @@
+"""Persisted Naver momentum/theme event snapshots for /invest."""

--- a/app/services/invest_momentum_events/builder.py
+++ b/app/services/invest_momentum_events/builder.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import datetime as dt
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Protocol
+
+from app.services.invest_momentum_events.models import (
+    MomentumEventUpsert,
+    ThemeEventUpsert,
+)
+from app.services.naver_stock.parser import (
+    parse_domestic_stock_default,
+    parse_upjong_theme_list,
+)
+
+
+class NaverMomentumFetcher(Protocol):
+    async def fetch_domestic_stock_default(self, **kwargs): ...
+    async def fetch_market_theme_list(self, **kwargs): ...
+    async def fetch_market_upjong_list(self, **kwargs): ...
+
+
+@dataclass(frozen=True)
+class BuildPlan:
+    trade_types: tuple[str, ...] = ("KRX",)
+    market_types: tuple[str, ...] = ("ALL",)
+    order_types: tuple[str, ...] = ("up", "quantTop", "priceTop", "searchTop")
+    theme_sort_types: tuple[str, ...] = ("changeRate",)
+    page_size: int = 50
+
+
+@dataclass(frozen=True)
+class BuildPayloads:
+    momentum: tuple[MomentumEventUpsert, ...]
+    themes: tuple[ThemeEventUpsert, ...]
+    counts_by_surface: dict[str, int] = field(default_factory=dict)
+    warnings: tuple[str, ...] = ()
+
+
+def _ensure_aware(ts: dt.datetime) -> dt.datetime:
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=dt.UTC)
+    return ts
+
+
+async def build_payloads_from_naver(
+    fetcher: NaverMomentumFetcher,
+    *,
+    plan: BuildPlan | None = None,
+    snapshot_at: dt.datetime | None = None,
+    today: dt.date | None = None,
+) -> BuildPayloads:
+    plan = plan or BuildPlan()
+    snapshot = _ensure_aware(snapshot_at or dt.datetime.now(dt.UTC))
+    trading_date = today or snapshot.date()
+    warnings: list[str] = []
+    counts: Counter[str] = Counter()
+    momentum: list[MomentumEventUpsert] = []
+    themes: list[ThemeEventUpsert] = []
+
+    for trade_type in plan.trade_types:
+        for market_type in plan.market_types:
+            for order_type in plan.order_types:
+                payload = await fetcher.fetch_domestic_stock_default(
+                    trade_type=trade_type,
+                    market_type=market_type,
+                    order_type=order_type,
+                    start_idx=0,
+                    page_size=plan.page_size,
+                )
+                parsed = parse_domestic_stock_default(payload)
+                warnings.extend(parsed.warnings)
+                for row in parsed.rows:
+                    momentum.append(
+                        MomentumEventUpsert(
+                            snapshot_at=snapshot,
+                            trading_date=trading_date,
+                            surface="domestic_market_stock_default",
+                            trade_type=trade_type,
+                            market_type=market_type,
+                            order_type=order_type,
+                            rank=row.rank or 0,
+                            symbol=row.symbol,
+                            name=row.name,
+                            price=row.price,
+                            change_amount=row.change_amount,
+                            change_rate=row.change_rate,
+                            volume=row.volume,
+                            trade_value=row.trade_value,
+                            market_cap=row.market_cap,
+                            raw_payload=row.raw_payload,
+                        )
+                    )
+                counts[f"stock:{trade_type}:{market_type}:{order_type}"] += len(
+                    parsed.rows
+                )
+
+    for sort_type in plan.theme_sort_types:
+        theme_payload = await fetcher.fetch_market_theme_list(
+            sort_type=sort_type, start_idx=0, page_size=min(plan.page_size, 100)
+        )
+        parsed_themes = parse_upjong_theme_list(theme_payload, event_kind="theme")
+        warnings.extend(parsed_themes.warnings)
+        for row in parsed_themes.rows:
+            themes.append(
+                ThemeEventUpsert(
+                    snapshot_at=snapshot,
+                    trading_date=trading_date,
+                    surface="market_theme_list",
+                    event_kind="theme",
+                    source_event_key=f"theme:{row.source_key}:{sort_type}:ALL",
+                    naver_theme_no=row.naver_theme_no,
+                    name=row.name,
+                    sort_type=sort_type,
+                    rank=row.rank,
+                    market_type="ALL",
+                    change_rate=row.change_rate,
+                    trade_value=row.trade_value,
+                    market_cap=row.market_cap,
+                    stock_count=row.stock_count,
+                    leader_symbols=list(row.leader_symbols),
+                    raw_payload=row.raw_payload,
+                )
+            )
+        counts[f"theme:{sort_type}"] += len(parsed_themes.rows)
+
+        upjong_payload = await fetcher.fetch_market_upjong_list(
+            sort_type=sort_type, start_idx=0, page_size=min(plan.page_size, 100)
+        )
+        parsed_upjong = parse_upjong_theme_list(upjong_payload, event_kind="upjong")
+        warnings.extend(parsed_upjong.warnings)
+        for row in parsed_upjong.rows:
+            themes.append(
+                ThemeEventUpsert(
+                    snapshot_at=snapshot,
+                    trading_date=trading_date,
+                    surface="market_upjong_list",
+                    event_kind="upjong",
+                    source_event_key=f"upjong:{row.source_key}:{sort_type}:ALL",
+                    naver_upjong_code=row.naver_upjong_code,
+                    name=row.name,
+                    sort_type=sort_type,
+                    rank=row.rank,
+                    market_type="ALL",
+                    change_rate=row.change_rate,
+                    trade_value=row.trade_value,
+                    market_cap=row.market_cap,
+                    stock_count=row.stock_count,
+                    leader_symbols=list(row.leader_symbols),
+                    raw_payload=row.raw_payload,
+                )
+            )
+        counts[f"upjong:{sort_type}"] += len(parsed_upjong.rows)
+
+    return BuildPayloads(
+        momentum=tuple(momentum),
+        themes=tuple(themes),
+        counts_by_surface=dict(counts),
+        warnings=tuple(warnings),
+    )

--- a/app/services/invest_momentum_events/coverage_service.py
+++ b/app/services/invest_momentum_events/coverage_service.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.invest_momentum_events.repository import (
+    InvestMomentumEventSnapshotsRepository,
+)
+
+
+@dataclass(frozen=True)
+class MomentumCoverageReport:
+    market: str
+    asOf: dt.date
+    momentumEvents: int
+    themeEvents: int
+    lastMomentumSnapshotAt: dt.datetime | None
+    lastThemeSnapshotAt: dt.datetime | None
+    dataState: str
+    emptyReason: str | None = None
+
+
+async def build_momentum_coverage(
+    db: AsyncSession, *, market: str = "kr", as_of: dt.date | None = None
+) -> MomentumCoverageReport:
+    today = as_of or dt.datetime.now(dt.UTC).date()
+    if market != "kr":
+        return MomentumCoverageReport(
+            market=market,
+            asOf=today,
+            momentumEvents=0,
+            themeEvents=0,
+            lastMomentumSnapshotAt=None,
+            lastThemeSnapshotAt=None,
+            dataState="unsupported",
+            emptyReason="naver_stock_supports_kr_only",
+        )
+    cov = await InvestMomentumEventSnapshotsRepository(db).coverage(as_of=today)
+    total = cov.momentum_count + cov.theme_count
+    state = "fresh" if total else "missing"
+    return MomentumCoverageReport(
+        market="kr",
+        asOf=today,
+        momentumEvents=cov.momentum_count,
+        themeEvents=cov.theme_count,
+        lastMomentumSnapshotAt=cov.last_momentum_snapshot_at,
+        lastThemeSnapshotAt=cov.last_theme_snapshot_at,
+        dataState=state,
+        emptyReason=None if total else "no_naver_momentum_snapshots",
+    )

--- a/app/services/invest_momentum_events/models.py
+++ b/app/services/invest_momentum_events/models.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MomentumEventUpsert(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    snapshot_at: dt.datetime
+    trading_date: dt.date
+    source: str = "naver_stock"
+    surface: str
+    market: str = "kr"
+    trade_type: str | None = None
+    market_type: str | None = None
+    order_type: str
+    rank: int
+    symbol: str
+    name: str | None = None
+    price: Decimal | None = None
+    change_amount: Decimal | None = None
+    change_rate: Decimal | None = None
+    volume: int | None = None
+    trade_value: Decimal | None = None
+    market_cap: Decimal | None = None
+    raw_payload: dict[str, Any] | None = None
+
+
+class ThemeEventStockUpsert(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    name: str | None = None
+    rank: int | None = None
+    order_type: str | None = None
+    price: Decimal | None = None
+    change_amount: Decimal | None = None
+    change_rate: Decimal | None = None
+    volume: int | None = None
+    trade_value: Decimal | None = None
+    raw_payload: dict[str, Any] | None = None
+
+
+class ThemeEventUpsert(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    snapshot_at: dt.datetime
+    trading_date: dt.date
+    source: str = "naver_stock"
+    surface: str
+    market: str = "kr"
+    event_kind: str
+    source_event_key: str
+    naver_theme_no: str | None = None
+    naver_upjong_code: str | None = None
+    name: str
+    sort_type: str
+    rank: int | None = None
+    market_type: str | None = None
+    change_rate: Decimal | None = None
+    trade_value: Decimal | None = None
+    market_cap: Decimal | None = None
+    stock_count: int | None = None
+    leader_symbols: list[dict[str, str | None]] = Field(default_factory=list)
+    raw_payload: dict[str, Any] | None = None
+    stocks: list[ThemeEventStockUpsert] = Field(default_factory=list)

--- a/app/services/invest_momentum_events/repository.py
+++ b/app/services/invest_momentum_events/repository.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invest_momentum_event_snapshot import (
+    InvestMomentumEventSnapshot,
+    InvestThemeEventSnapshot,
+    InvestThemeEventSnapshotStock,
+)
+from app.services.invest_momentum_events.models import (
+    MomentumEventUpsert,
+    ThemeEventStockUpsert,
+    ThemeEventUpsert,
+)
+
+
+@dataclass(frozen=True)
+class SnapshotCoverage:
+    market: str
+    as_of: dt.date
+    momentum_count: int
+    theme_count: int
+    last_momentum_snapshot_at: dt.datetime | None
+    last_theme_snapshot_at: dt.datetime | None
+
+
+class InvestMomentumEventSnapshotsRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def upsert_momentum(self, payload: MomentumEventUpsert) -> None:
+        values = payload.model_dump()
+        stmt = insert(InvestMomentumEventSnapshot).values(**values)
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_invest_momentum_event_snapshots_surface_params_symbol_at",
+            set_={
+                **{
+                    k: stmt.excluded[k]
+                    for k in values
+                    if k
+                    not in {
+                        "surface",
+                        "snapshot_at",
+                        "trade_type",
+                        "market_type",
+                        "order_type",
+                        "symbol",
+                    }
+                },
+                "updated_at": func.now(),
+            },
+        )
+        await self._session.execute(stmt)
+
+    async def upsert_theme(self, payload: ThemeEventUpsert) -> int | None:
+        values = payload.model_dump(exclude={"stocks"})
+        stmt = (
+            insert(InvestThemeEventSnapshot)
+            .values(**values)
+            .returning(InvestThemeEventSnapshot.id)
+        )
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_invest_theme_event_snapshots_at_key",
+            set_={
+                **{
+                    k: stmt.excluded[k]
+                    for k in values
+                    if k not in {"snapshot_at", "source_event_key"}
+                },
+                "updated_at": func.now(),
+            },
+        ).returning(InvestThemeEventSnapshot.id)
+        result = await self._session.execute(stmt)
+        theme_id = result.scalar_one_or_none()
+        if theme_id is not None and payload.stocks:
+            await self.replace_theme_stocks(theme_id, payload.stocks)
+        return theme_id
+
+    async def replace_theme_stocks(
+        self, theme_snapshot_id: int, payloads: list[ThemeEventStockUpsert]
+    ) -> None:
+        await self._session.execute(
+            delete(InvestThemeEventSnapshotStock).where(
+                InvestThemeEventSnapshotStock.theme_snapshot_id == theme_snapshot_id
+            )
+        )
+        for payload in payloads:
+            await self._session.execute(
+                insert(InvestThemeEventSnapshotStock).values(
+                    theme_snapshot_id=theme_snapshot_id, **payload.model_dump()
+                )
+            )
+
+    async def list_momentum_events(
+        self,
+        *,
+        trading_date: dt.date | None = None,
+        surface: str | None = None,
+        order_type: str | None = None,
+        trade_type: str | None = None,
+        limit: int = 50,
+    ) -> list[InvestMomentumEventSnapshot]:
+        conditions = [InvestMomentumEventSnapshot.market == "kr"]
+        if trading_date is not None:
+            conditions.append(InvestMomentumEventSnapshot.trading_date == trading_date)
+        if surface:
+            conditions.append(InvestMomentumEventSnapshot.surface == surface)
+        if order_type:
+            conditions.append(InvestMomentumEventSnapshot.order_type == order_type)
+        if trade_type:
+            conditions.append(InvestMomentumEventSnapshot.trade_type == trade_type)
+
+        latest_result = await self._session.execute(
+            select(func.max(InvestMomentumEventSnapshot.snapshot_at)).where(*conditions)
+        )
+        latest_snapshot_at = latest_result.scalar_one_or_none()
+        if latest_snapshot_at is None:
+            return []
+
+        stmt = (
+            select(InvestMomentumEventSnapshot)
+            .where(
+                *conditions,
+                InvestMomentumEventSnapshot.snapshot_at == latest_snapshot_at,
+            )
+            .order_by(
+                InvestMomentumEventSnapshot.rank.asc(),
+                InvestMomentumEventSnapshot.symbol.asc(),
+            )
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def list_theme_events(
+        self,
+        *,
+        trading_date: dt.date | None = None,
+        event_kind: str | None = None,
+        sort_type: str | None = None,
+        limit: int = 50,
+    ) -> list[InvestThemeEventSnapshot]:
+        conditions = [InvestThemeEventSnapshot.market == "kr"]
+        if trading_date is not None:
+            conditions.append(InvestThemeEventSnapshot.trading_date == trading_date)
+        if event_kind:
+            conditions.append(InvestThemeEventSnapshot.event_kind == event_kind)
+        if sort_type:
+            conditions.append(InvestThemeEventSnapshot.sort_type == sort_type)
+
+        latest_result = await self._session.execute(
+            select(func.max(InvestThemeEventSnapshot.snapshot_at)).where(*conditions)
+        )
+        latest_snapshot_at = latest_result.scalar_one_or_none()
+        if latest_snapshot_at is None:
+            return []
+
+        stmt = (
+            select(InvestThemeEventSnapshot)
+            .where(
+                *conditions, InvestThemeEventSnapshot.snapshot_at == latest_snapshot_at
+            )
+            .order_by(
+                InvestThemeEventSnapshot.rank.asc().nulls_last(),
+                InvestThemeEventSnapshot.name.asc(),
+            )
+            .limit(limit)
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
+    async def coverage(self, *, as_of: dt.date) -> SnapshotCoverage:
+        momentum_result = await self._session.execute(
+            select(
+                func.count().label("count"),
+                func.max(InvestMomentumEventSnapshot.snapshot_at).label("latest"),
+            ).where(
+                InvestMomentumEventSnapshot.trading_date == as_of,
+                InvestMomentumEventSnapshot.market == "kr",
+            )
+        )
+        theme_result = await self._session.execute(
+            select(
+                func.count().label("count"),
+                func.max(InvestThemeEventSnapshot.snapshot_at).label("latest"),
+            ).where(
+                InvestThemeEventSnapshot.trading_date == as_of,
+                InvestThemeEventSnapshot.market == "kr",
+            )
+        )
+        momentum = momentum_result.one()
+        theme = theme_result.one()
+        return SnapshotCoverage(
+            market="kr",
+            as_of=as_of,
+            momentum_count=int(momentum.count or 0),
+            theme_count=int(theme.count or 0),
+            last_momentum_snapshot_at=momentum.latest,
+            last_theme_snapshot_at=theme.latest,
+        )

--- a/app/services/naver_stock/__init__.py
+++ b/app/services/naver_stock/__init__.py
@@ -1,0 +1,21 @@
+"""Fixture-backed seam for Naver revamped stock endpoints."""
+
+from app.services.naver_stock.client import NaverStockClient
+from app.services.naver_stock.parser import (
+    parse_domestic_stock_default,
+    parse_theme_stocklist,
+    parse_upjong_theme_list,
+    sanitize_raw_payload,
+)
+from app.services.naver_stock.types import NaverStockRow, NaverThemeRow, ParseResult
+
+__all__ = [
+    "NaverStockClient",
+    "NaverStockRow",
+    "NaverThemeRow",
+    "ParseResult",
+    "parse_domestic_stock_default",
+    "parse_theme_stocklist",
+    "parse_upjong_theme_list",
+    "sanitize_raw_payload",
+]

--- a/app/services/naver_stock/client.py
+++ b/app/services/naver_stock/client.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+class NaverStockClient:
+    """Small, capped async client for Naver revamped stock JSON endpoints.
+
+    Request handlers must not use this client directly; it is intended for manual
+    dry-run/collection jobs where writes are explicit and approval-gated.
+    """
+
+    BASE_URL = "https://stock.naver.com"
+    MAX_LIST_PAGE_SIZE = 100
+    MAX_STOCKLIST_PAGE_SIZE = 20
+
+    def __init__(
+        self, http_client: httpx.AsyncClient | None = None, *, timeout: float = 10.0
+    ) -> None:
+        self._client = http_client or httpx.AsyncClient(
+            base_url=self.BASE_URL,
+            timeout=timeout,
+            headers={"User-Agent": "auto_trader ROB-222 read-model dry-run/1.0"},
+        )
+        self._owns_client = http_client is None
+
+    async def aclose(self) -> None:
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def _get(self, path: str, params: dict[str, Any]) -> Any:
+        response = await self._client.get(path, params=params)
+        response.raise_for_status()
+        return response.json()
+
+    async def fetch_domestic_stock_default(
+        self,
+        *,
+        trade_type: str = "KRX",
+        market_type: str = "ALL",
+        order_type: str = "up",
+        start_idx: int = 0,
+        page_size: int = 50,
+    ) -> Any:
+        return await self._get(
+            "/api/domestic/market/stock/default",
+            {
+                "tradeType": trade_type,
+                "marketType": market_type,
+                "orderType": order_type,
+                "startIdx": max(0, start_idx),
+                "pageSize": min(page_size, self.MAX_LIST_PAGE_SIZE),
+            },
+        )
+
+    async def fetch_upjong_theme_ranking(self, *, sort_type: str = "changeRate") -> Any:
+        return await self._get(
+            "/api/domestic/home/upjongTheme/ranking", {"sortType": sort_type}
+        )
+
+    async def fetch_market_upjong_list(
+        self, *, sort_type: str = "changeRate", start_idx: int = 0, page_size: int = 100
+    ) -> Any:
+        return await self._get(
+            "/api/domestic/market/upjong/list",
+            {
+                "sortType": sort_type,
+                "startIdx": max(0, start_idx),
+                "pageSize": min(page_size, self.MAX_LIST_PAGE_SIZE),
+            },
+        )
+
+    async def fetch_market_theme_list(
+        self, *, sort_type: str = "changeRate", start_idx: int = 0, page_size: int = 100
+    ) -> Any:
+        return await self._get(
+            "/api/domestic/market/theme/list",
+            {
+                "sortType": sort_type,
+                "startIdx": max(0, start_idx),
+                "pageSize": min(page_size, self.MAX_LIST_PAGE_SIZE),
+            },
+        )
+
+    async def fetch_theme_info(self, theme_no: str, *, market_type: str = "ALL") -> Any:
+        return await self._get(
+            f"/api/domestic/market/theme/{theme_no}/info", {"marketType": market_type}
+        )
+
+    async def fetch_theme_stocklist(
+        self,
+        theme_no: str,
+        *,
+        market_type: str = "ALL",
+        order_type: str = "priceTop",
+        start_idx: int = 0,
+        page_size: int = 20,
+    ) -> Any:
+        return await self._get(
+            f"/api/domestic/market/theme/{theme_no}/stocklist",
+            {
+                "marketType": market_type,
+                "orderType": order_type,
+                "startIdx": max(0, start_idx),
+                "pageSize": min(page_size, self.MAX_STOCKLIST_PAGE_SIZE),
+            },
+        )
+
+    async def fetch_upjong_info(
+        self, upjong_code: str, *, market_type: str = "ALL"
+    ) -> Any:
+        return await self._get(
+            f"/api/domestic/market/upjong/{upjong_code}/info",
+            {"marketType": market_type},
+        )
+
+    async def fetch_upjong_stocklist(
+        self,
+        upjong_code: str,
+        *,
+        market_type: str = "ALL",
+        order_type: str = "priceTop",
+        start_idx: int = 0,
+        page_size: int = 20,
+    ) -> Any:
+        return await self._get(
+            f"/api/domestic/market/upjong/{upjong_code}/stocklist",
+            {
+                "marketType": market_type,
+                "orderType": order_type,
+                "startIdx": max(0, start_idx),
+                "pageSize": min(page_size, self.MAX_STOCKLIST_PAGE_SIZE),
+            },
+        )

--- a/app/services/naver_stock/parser.py
+++ b/app/services/naver_stock/parser.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from app.services.naver_stock.types import NaverStockRow, NaverThemeRow, ParseResult
+
+_DROP_KEYS = {
+    "cookie",
+    "cookies",
+    "headers",
+    "html",
+    "body",
+    "content",
+    "comment",
+    "comments",
+    "discussion",
+    "message",
+    "post",
+    "author",
+    "authorid",
+    "author_id",
+    "userid",
+    "user_id",
+    "usernickname",
+    "nickname",
+    "writer",
+    "tracking",
+    "trackingid",
+    "session",
+    "token",
+}
+
+_LIST_KEYS = ("stocks", "items", "itemList", "list", "result", "data", "contents")
+
+
+def _norm_key(key: str) -> str:
+    return "".join(ch.lower() for ch in key if ch.isalnum() or ch == "_")
+
+
+def sanitize_raw_payload(value: Any, *, depth: int = 0) -> Any:
+    if depth > 4:
+        return None
+    if isinstance(value, Mapping):
+        sanitized: dict[str, Any] = {}
+        for key, child in value.items():
+            key_str = str(key)
+            normalized = _norm_key(key_str)
+            if normalized in _DROP_KEYS or any(
+                term in normalized
+                for term in (
+                    "cookie",
+                    "header",
+                    "author",
+                    "user",
+                    "comment",
+                    "discussion",
+                    "html",
+                )
+            ):
+                continue
+            safe_child = sanitize_raw_payload(child, depth=depth + 1)
+            if safe_child is not None:
+                sanitized[key_str] = safe_child
+        return sanitized
+    if isinstance(value, list):
+        return [
+            item
+            for item in (sanitize_raw_payload(v, depth=depth + 1) for v in value[:20])
+            if item is not None
+        ]
+    if isinstance(value, str):
+        if "<html" in value.lower() or "<body" in value.lower() or len(value) > 500:
+            return None
+        return value
+    if isinstance(value, int | float | bool) or value is None:
+        return value
+    return str(value)
+
+
+def _find_rows(payload: Any) -> list[Mapping[str, Any]]:
+    if isinstance(payload, list):
+        return [row for row in payload if isinstance(row, Mapping)]
+    if not isinstance(payload, Mapping):
+        return []
+    for key in _LIST_KEYS:
+        value = payload.get(key)
+        if isinstance(value, list):
+            return [row for row in value if isinstance(row, Mapping)]
+        if isinstance(value, Mapping):
+            nested = _find_rows(value)
+            if nested:
+                return nested
+    for value in payload.values():
+        if isinstance(value, Mapping):
+            nested = _find_rows(value)
+            if nested:
+                return nested
+    return []
+
+
+def _first(row: Mapping[str, Any], keys: Iterable[str]) -> Any:
+    for key in keys:
+        if key in row and row[key] not in (None, ""):
+            return row[key]
+    return None
+
+
+def _str(row: Mapping[str, Any], keys: Iterable[str]) -> str | None:
+    value = _first(row, keys)
+    return str(value).strip() if value is not None else None
+
+
+def _decimal(row: Mapping[str, Any], keys: Iterable[str]) -> Decimal | None:
+    value = _first(row, keys)
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value).replace(",", "").replace("%", ""))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _int(row: Mapping[str, Any], keys: Iterable[str]) -> int | None:
+    value = _first(row, keys)
+    if value is None:
+        return None
+    try:
+        return int(Decimal(str(value).replace(",", "")))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _symbol(row: Mapping[str, Any]) -> str | None:
+    value = _str(
+        row, ("itemCode", "itemcode", "stockCode", "symbol", "code", "reutersCode")
+    )
+    if not value:
+        return None
+    digits = "".join(ch for ch in value if ch.isdigit())
+    return digits.zfill(6) if digits and len(digits) <= 6 else value.upper()
+
+
+def _stock_from_row(row: Mapping[str, Any], rank_fallback: int) -> NaverStockRow | None:
+    symbol = _symbol(row)
+    if not symbol:
+        return None
+    return NaverStockRow(
+        symbol=symbol,
+        name=_str(row, ("stockName", "itemName", "itemname", "name", "nm")),
+        rank=_int(row, ("rank", "rn", "no", "ranking")) or rank_fallback,
+        price=_decimal(
+            row, ("closePrice", "nowPrice", "nowVal", "price", "tradePrice")
+        ),
+        change_amount=_decimal(
+            row,
+            ("compareToPreviousClosePrice", "changeAmount", "changeVal", "prevChange"),
+        ),
+        change_rate=_decimal(
+            row,
+            ("fluctuationsRatio", "prevChangeRate", "changeRate", "rate", "diffRate"),
+        ),
+        volume=_int(
+            row, ("accumulatedTradingVolume", "tradeVolume", "quant", "volume")
+        ),
+        trade_value=_decimal(
+            row,
+            ("accumulatedTradingValue", "tradeAmount", "tradingValue", "tradeValue"),
+        ),
+        market_cap=_decimal(row, ("marketValue", "marketSum", "marketCap")),
+        raw_payload=sanitize_raw_payload(row) or {},
+    )
+
+
+def parse_domestic_stock_default(payload: Any) -> ParseResult[NaverStockRow]:
+    rows = _find_rows(payload)
+    warnings: list[str] = []
+    parsed: list[NaverStockRow] = []
+    if not rows:
+        return ParseResult(rows=(), warnings=("no stock rows found",))
+    for idx, row in enumerate(rows, start=1):
+        parsed_row = _stock_from_row(row, idx)
+        if parsed_row is None:
+            warnings.append(f"stock row {idx} missing symbol")
+            continue
+        parsed.append(parsed_row)
+    return ParseResult(rows=tuple(parsed), warnings=tuple(warnings))
+
+
+def parse_theme_stocklist(payload: Any) -> ParseResult[NaverStockRow]:
+    return parse_domestic_stock_default(payload)
+
+
+def _leader_symbols(row: Mapping[str, Any]) -> tuple[dict[str, str | None], ...]:
+    raw = _first(row, ("leaderSymbols", "topStocks", "stockList", "stocks"))
+    leaders: list[dict[str, str | None]] = []
+    if isinstance(raw, list):
+        for item in raw[:5]:
+            if not isinstance(item, Mapping):
+                continue
+            leaders.append(
+                {
+                    "symbol": _symbol(item),
+                    "name": _str(item, ("stockName", "itemName", "itemname", "name")),
+                }
+            )
+        return tuple(leaders)
+
+    # Current Naver upjong/theme list rows expose leaders as
+    # "rank,itemcode,itemname|rank,itemcode,itemname".
+    leading_item = _str(row, ("leadingItem",))
+    if leading_item:
+        for item in leading_item.split("|")[:5]:
+            parts = [part.strip() for part in item.split(",")]
+            if len(parts) >= 3:
+                leaders.append(
+                    {"symbol": _symbol({"itemcode": parts[1]}), "name": parts[2]}
+                )
+        return tuple(leaders)
+
+    return ()
+
+
+def parse_upjong_theme_list(
+    payload: Any, *, event_kind: str
+) -> ParseResult[NaverThemeRow]:
+    if event_kind not in {"theme", "upjong"}:
+        raise ValueError("event_kind must be 'theme' or 'upjong'")
+    rows = _find_rows(payload)
+    if not rows:
+        return ParseResult(rows=(), warnings=("no theme/upjong rows found",))
+    parsed: list[NaverThemeRow] = []
+    warnings: list[str] = []
+    for idx, row in enumerate(rows, start=1):
+        theme_no = (
+            _str(row, ("themeNo", "themeCode", "no")) if event_kind == "theme" else None
+        )
+        upjong_code = (
+            _str(row, ("upjongCode", "bizCode", "code", "itemCode", "no"))
+            if event_kind == "upjong"
+            else None
+        )
+        key = theme_no if event_kind == "theme" else upjong_code
+        name = _str(row, ("themeName", "upjongName", "itemname", "itemName", "name"))
+        if not key or not name:
+            warnings.append(f"{event_kind} row {idx} missing key/name")
+            continue
+        parsed.append(
+            NaverThemeRow(
+                event_kind=event_kind,
+                source_key=key,
+                name=name,
+                rank=_int(row, ("rank", "rn", "no")) or idx,
+                naver_theme_no=theme_no,
+                naver_upjong_code=upjong_code,
+                change_rate=_decimal(
+                    row, ("fluctuationsRatio", "changeRate", "rate", "diffRate")
+                ),
+                trade_value=_decimal(
+                    row, ("accumulatedTradingValue", "tradingValue", "tradeValue")
+                ),
+                market_cap=_decimal(
+                    row, ("marketValue", "marketSum", "marketCap", "totalMarketSum")
+                ),
+                stock_count=_int(row, ("stockCount", "count", "itemCount")),
+                leader_symbols=_leader_symbols(row),
+                raw_payload=sanitize_raw_payload(row) or {},
+            )
+        )
+    return ParseResult(rows=tuple(parsed), warnings=tuple(warnings))

--- a/app/services/naver_stock/types.py
+++ b/app/services/naver_stock/types.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ParseResult[T]:
+    rows: tuple[T, ...]
+    warnings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class NaverStockRow:
+    symbol: str
+    name: str | None
+    rank: int | None
+    price: Decimal | None = None
+    change_amount: Decimal | None = None
+    change_rate: Decimal | None = None
+    volume: int | None = None
+    trade_value: Decimal | None = None
+    market_cap: Decimal | None = None
+    raw_payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class NaverThemeRow:
+    event_kind: str
+    source_key: str
+    name: str
+    rank: int | None
+    naver_theme_no: str | None = None
+    naver_upjong_code: str | None = None
+    change_rate: Decimal | None = None
+    trade_value: Decimal | None = None
+    market_cap: Decimal | None = None
+    stock_count: int | None = None
+    leader_symbols: tuple[dict[str, str | None], ...] = ()
+    raw_payload: dict[str, Any] = field(default_factory=dict)

--- a/tests/test_invest_momentum_events.py
+++ b/tests/test_invest_momentum_events.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from sqlalchemy import delete, select
+
+from app.jobs.invest_momentum_events import (
+    NaverMomentumBuildRequest,
+    run_naver_momentum_build,
+)
+from app.models.invest_momentum_event_snapshot import (
+    InvestMomentumEventSnapshot,
+    InvestThemeEventSnapshot,
+    InvestThemeEventSnapshotStock,
+)
+from app.services.invest_momentum_events.coverage_service import build_momentum_coverage
+from app.services.invest_momentum_events.models import (
+    MomentumEventUpsert,
+    ThemeEventUpsert,
+)
+from app.services.invest_momentum_events.repository import (
+    InvestMomentumEventSnapshotsRepository,
+)
+
+SNAPSHOT_AT = dt.datetime(2026, 5, 13, 9, 5, tzinfo=dt.UTC)
+TRADING_DATE = dt.date(2026, 5, 13)
+
+
+class FixtureNaverFetcher:
+    async def fetch_domestic_stock_default(self, **kwargs):
+        return {
+            "result": {
+                "stocks": [
+                    {
+                        "itemcode": "005930",
+                        "itemname": f"삼성전자 {kwargs['order_type']}",
+                        "rank": 1,
+                        "nowPrice": "78500",
+                        "prevChangeRate": "1.55",
+                        "tradeVolume": "14500000",
+                        "tradeAmount": "1138250000000",
+                    }
+                ]
+            }
+        }
+
+    async def fetch_market_theme_list(self, **kwargs):
+        return {
+            "list": [
+                {
+                    "themeNo": "591",
+                    "themeName": "반도체",
+                    "rank": 1,
+                    "changeRate": "3.21",
+                }
+            ]
+        }
+
+    async def fetch_market_upjong_list(self, **kwargs):
+        return {
+            "list": [
+                {
+                    "upjongCode": "G101",
+                    "upjongName": "전기전자",
+                    "rank": 1,
+                    "changeRate": "2.10",
+                }
+            ]
+        }
+
+
+@pytest.mark.asyncio
+async def test_dry_run_job_with_fixture_fetcher_returns_counts_without_db_writes(
+    db_session,
+):
+    dry_run_date = dt.date(2026, 5, 15)
+    result = await run_naver_momentum_build(
+        NaverMomentumBuildRequest(
+            trade_types=("KRX", "NXT"),
+            order_types=("up", "quantTop"),
+            theme_sort_types=("changeRate",),
+            page_size=2,
+            commit=False,
+            today=dry_run_date,
+        ),
+        fetcher=FixtureNaverFetcher(),
+    )
+
+    assert result.committed is False
+    assert result.momentum_rows == 4
+    assert result.theme_rows == 2
+    assert result.counts_by_surface["stock:KRX:ALL:up"] == 1
+    assert result.counts_by_surface["stock:NXT:ALL:quantTop"] == 1
+    assert result.samples[0]["symbol"] == "005930"
+
+    rows = (
+        (
+            await db_session.execute(
+                select(InvestMomentumEventSnapshot).where(
+                    InvestMomentumEventSnapshot.trading_date == dry_run_date
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_repository_upserts_momentum_and_theme_idempotently(db_session):
+    repo = InvestMomentumEventSnapshotsRepository(db_session)
+    momentum = MomentumEventUpsert(
+        snapshot_at=SNAPSHOT_AT,
+        trading_date=TRADING_DATE,
+        surface="domestic_market_stock_default",
+        trade_type="KRX",
+        market_type="ALL",
+        order_type="up",
+        rank=1,
+        symbol="005930",
+        name="삼성전자",
+        price=Decimal("78500"),
+        change_rate=Decimal("1.55"),
+    )
+    await repo.upsert_momentum(momentum)
+    await repo.upsert_momentum(
+        momentum.model_copy(update={"rank": 2, "price": Decimal("78600")})
+    )
+
+    theme = ThemeEventUpsert(
+        snapshot_at=SNAPSHOT_AT,
+        trading_date=TRADING_DATE,
+        surface="market_theme_list",
+        event_kind="theme",
+        source_event_key="theme:591:changeRate:ALL",
+        naver_theme_no="591",
+        name="반도체",
+        sort_type="changeRate",
+        rank=1,
+        market_type="ALL",
+        leader_symbols=[{"symbol": "000660", "name": "SK하이닉스"}],
+    )
+    await repo.upsert_theme(theme)
+    await repo.upsert_theme(theme.model_copy(update={"rank": 3, "stock_count": 12}))
+    await db_session.commit()
+
+    momentum_rows = (
+        (
+            await db_session.execute(
+                select(InvestMomentumEventSnapshot).where(
+                    InvestMomentumEventSnapshot.snapshot_at == SNAPSHOT_AT,
+                    InvestMomentumEventSnapshot.symbol == "005930",
+                    InvestMomentumEventSnapshot.order_type == "up",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(momentum_rows) == 1
+    assert momentum_rows[0].rank == 2
+    assert momentum_rows[0].price == Decimal("78600.000000")
+
+    theme_rows = (
+        (
+            await db_session.execute(
+                select(InvestThemeEventSnapshot).where(
+                    InvestThemeEventSnapshot.snapshot_at == SNAPSHOT_AT,
+                    InvestThemeEventSnapshot.source_event_key
+                    == "theme:591:changeRate:ALL",
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(theme_rows) == 1
+    assert theme_rows[0].rank == 3
+    assert theme_rows[0].stock_count == 12
+
+
+@pytest.mark.asyncio
+async def test_coverage_reports_unsupported_missing_and_fresh(db_session):
+    coverage_date = dt.date(2026, 5, 14)
+    coverage_snapshot_at = dt.datetime(2026, 5, 14, 9, 5, tzinfo=dt.UTC)
+    stale_theme_ids = select(InvestThemeEventSnapshot.id).where(
+        InvestThemeEventSnapshot.trading_date == coverage_date
+    )
+    await db_session.execute(
+        delete(InvestThemeEventSnapshotStock).where(
+            InvestThemeEventSnapshotStock.theme_snapshot_id.in_(stale_theme_ids)
+        )
+    )
+    await db_session.execute(
+        delete(InvestThemeEventSnapshot).where(
+            InvestThemeEventSnapshot.trading_date == coverage_date
+        )
+    )
+    await db_session.execute(
+        delete(InvestMomentumEventSnapshot).where(
+            InvestMomentumEventSnapshot.trading_date == coverage_date
+        )
+    )
+    await db_session.commit()
+
+    unsupported = await build_momentum_coverage(
+        db_session, market="us", as_of=coverage_date
+    )
+    assert unsupported.dataState == "unsupported"
+    assert unsupported.emptyReason == "naver_stock_supports_kr_only"
+
+    missing = await build_momentum_coverage(
+        db_session, market="kr", as_of=coverage_date
+    )
+    assert missing.dataState == "missing"
+
+    repo = InvestMomentumEventSnapshotsRepository(db_session)
+    await repo.upsert_momentum(
+        MomentumEventUpsert(
+            snapshot_at=coverage_snapshot_at,
+            trading_date=coverage_date,
+            surface="domestic_market_stock_default",
+            trade_type="KRX",
+            market_type="ALL",
+            order_type="up",
+            rank=1,
+            symbol="005930",
+        )
+    )
+    await db_session.commit()
+
+    fresh = await build_momentum_coverage(db_session, market="kr", as_of=coverage_date)
+    assert fresh.dataState == "fresh"
+    assert fresh.momentumEvents >= 1
+
+
+def test_no_scheduler_or_broker_order_watch_mutation_imports_in_new_modules():
+    root = Path(__file__).resolve().parents[1]
+    files = [
+        root / "app/jobs/invest_momentum_events.py",
+        *sorted((root / "app/services/invest_momentum_events").glob("*.py")),
+        *sorted((root / "app/services/naver_stock").glob("*.py")),
+    ]
+    text = "\n".join(path.read_text(encoding="utf-8") for path in files)
+
+    forbidden = (
+        "broker.task",
+        "app.core.scheduler",
+        "place_order",
+        "cancel_order",
+        "watch_order_intent",
+        "alpaca_paper_submit_order",
+        "kis_live_place_order",
+    )
+    for token in forbidden:
+        assert token not in text

--- a/tests/test_naver_stock_parser.py
+++ b/tests/test_naver_stock_parser.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.services.naver_stock.parser import (
+    parse_domestic_stock_default,
+    parse_theme_stocklist,
+    parse_upjong_theme_list,
+    sanitize_raw_payload,
+)
+
+
+def _stock_payload(order_type: str) -> dict:
+    return {
+        "result": {
+            "stocks": [
+                {
+                    "itemcode": "5930",
+                    "itemname": f"삼성전자 {order_type}",
+                    "rank": "1",
+                    "nowPrice": "78,500",
+                    "prevChange": "1,200",
+                    "prevChangeRate": "1.55%",
+                    "tradeVolume": "14,500,000",
+                    "tradeAmount": "1138250000000",
+                    "marketSum": "468630000000000",
+                    "marketAlertType": "NONE",
+                    "headers": {"cookie": "drop-me"},
+                    "discussion": "drop community text",
+                }
+            ]
+        }
+    }
+
+
+def test_parse_domestic_stock_default_handles_naver_revamped_keys_for_core_order_types():
+    for order_type in ("up", "quantTop", "priceTop", "searchTop"):
+        parsed = parse_domestic_stock_default(_stock_payload(order_type))
+
+        assert parsed.warnings == ()
+        assert len(parsed.rows) == 1
+        row = parsed.rows[0]
+        assert row.symbol == "005930"
+        assert row.name == f"삼성전자 {order_type}"
+        assert row.rank == 1
+        assert row.price == Decimal("78500")
+        assert row.change_amount == Decimal("1200")
+        assert row.change_rate == Decimal("1.55")
+        assert row.volume == 14_500_000
+        assert row.trade_value == Decimal("1138250000000")
+        assert row.market_cap == Decimal("468630000000000")
+        assert "headers" not in row.raw_payload
+        assert "discussion" not in row.raw_payload
+
+
+def test_parse_theme_and_upjong_lists_and_sanitize_raw_payload():
+    payload = {
+        "data": [
+            {
+                "themeNo": "591",
+                "themeName": "반도체",
+                "rank": 1,
+                "changeRate": "3.21",
+                "totalMarketSum": "1000000000",
+                "stockCount": 12,
+                "leaderSymbols": [
+                    {"itemcode": "000660", "itemname": "SK하이닉스", "userId": "drop"}
+                ],
+                "html": "<html>drop</html>",
+                "comment": "drop ugc",
+            }
+        ]
+    }
+
+    parsed = parse_upjong_theme_list(payload, event_kind="theme")
+
+    assert parsed.warnings == ()
+    row = parsed.rows[0]
+    assert row.source_key == "591"
+    assert row.naver_theme_no == "591"
+    assert row.name == "반도체"
+    assert row.change_rate == Decimal("3.21")
+    assert row.leader_symbols == ({"symbol": "000660", "name": "SK하이닉스"},)
+    assert "html" not in row.raw_payload
+    assert "comment" not in row.raw_payload
+
+    upjong = parse_upjong_theme_list(
+        {"list": [{"upjongCode": "G101", "upjongName": "전기전자"}]},
+        event_kind="upjong",
+    )
+    assert upjong.rows[0].source_key == "G101"
+    assert upjong.rows[0].naver_upjong_code == "G101"
+
+    live_shape_upjong = parse_upjong_theme_list(
+        {
+            "list": [
+                {
+                    "no": "327",
+                    "type": "upjong",
+                    "name": "디스플레이패널",
+                    "changeRate": "10.25",
+                    "totalAccAmount": "526025179",
+                    "totalMarketSum": "7634625",
+                    "leadingItem": "2,034220,LG디스플레이|2,191410,육일씨엔에쓰",
+                }
+            ]
+        },
+        event_kind="upjong",
+    )
+    assert live_shape_upjong.warnings == ()
+    assert live_shape_upjong.rows[0].source_key == "327"
+    assert live_shape_upjong.rows[0].name == "디스플레이패널"
+    assert live_shape_upjong.rows[0].leader_symbols == (
+        {"symbol": "034220", "name": "LG디스플레이"},
+        {"symbol": "191410", "name": "육일씨엔에쓰"},
+    )
+
+
+def test_parse_theme_stocklist_reuses_stock_parser_and_sanitizer():
+    parsed = parse_theme_stocklist(
+        {
+            "itemList": [
+                {"itemCode": "035420", "itemName": "NAVER", "nowPrice": "200000"}
+            ]
+        }
+    )
+    assert parsed.rows[0].symbol == "035420"
+    assert parsed.rows[0].price == Decimal("200000")
+
+
+def test_sanitize_raw_payload_drops_tracking_and_user_generated_fields():
+    sanitized = sanitize_raw_payload(
+        {
+            "safe": "value",
+            "Cookie": "secret",
+            "headers": {"Authorization": "secret"},
+            "authorId": "user-1",
+            "userNickname": "nick",
+            "discussion": "community body",
+            "html": "<body>body</body>",
+            "nested": {"trackingId": "abc", "price": 1},
+        }
+    )
+    assert sanitized == {"safe": "value", "nested": {"price": 1}}


### PR DESCRIPTION
## Summary
- add read-only Naver renewed securities stock/theme/upjong client/parser contracts
- add momentum event snapshot models/repository/builder and dry-run gated job
- expose `/invest/api/momentum-events` read endpoints backed by DB snapshots

## Safety / side effects
- No broker/order/watch-order-intent mutations
- No KIS/Upbit/Alpaca live or paper order submit/cancel/modify paths
- No recurring scheduler activation
- DB writes remain gated by request `commit=true` plus settings `INVEST_MOMENTUM_EVENTS_COMMIT_ENABLED=true`; default is dry-run only
- Migration is additive new ROB-222 tables/indexes only

## Verification
- `uv run pytest tests/test_naver_stock_parser.py tests/test_invest_momentum_events.py -q` — 8 passed, 2 existing Pydantic warnings
- `uv run ruff check app/services/naver_stock/parser.py tests/test_naver_stock_parser.py tests/test_invest_momentum_events.py app/jobs/invest_momentum_events.py app/services/invest_momentum_events app/routers/invest_api.py app/schemas/invest_momentum_events.py app/models/invest_momentum_event_snapshot.py` — pass
- `uv run alembic heads` — `20260513_rob222 (head)`

Closes ROB-222


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Naver Investment Momentum & Theme Events**: Added new API endpoints to query Naver investment momentum events, theme events, and coverage data for Korean market.
* **Event Data Snapshots**: Introduced persistent snapshots of momentum and theme event rankings with configurable commit behavior (dry-run by default).
* **Momentum Build Job**: Added a new job to fetch, process, and store Naver momentum/theme event data with optional database persistence controlled via feature flag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/813)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->