### PR TITLE
feat(invest): add FX calendar and news filters

### DIFF
--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -21,7 +21,7 @@ from app.schemas.invest_calendar import (
     WeeklySummaryResponse,
 )
 from app.schemas.invest_coverage import CoverageMarket, InvestCoverageResponse
-from app.schemas.invest_feed_news import FeedNewsResponse, FeedTab
+from app.schemas.invest_feed_news import FeedNewsResponse, FeedTab, FeedTopic
 from app.schemas.invest_feed_research import (
     FeedResearchFilters,
     FeedResearchResponse,
@@ -340,6 +340,7 @@ async def get_feed_news(
     limit: int = Query(30, ge=1, le=100),
     cursor: str | None = Query(None),
     include_quotes: Annotated[bool, Query(alias="includeQuotes")] = False,
+    topic: FeedTopic | None = Query(None),
 ) -> FeedNewsResponse:
     home = await service.get_home(user_id=user.id)
     resolver = await build_relation_resolver(
@@ -352,6 +353,7 @@ async def get_feed_news(
         limit=limit,
         cursor=cursor,
         include_quotes=include_quotes,
+        topic=topic,
     )
 
 

--- a/app/schemas/invest_calendar.py
+++ b/app/schemas/invest_calendar.py
@@ -26,6 +26,7 @@ HighlightReason = Literal[
     "near_term",
     "has_values",
 ]
+ImpactTag = Literal["fx", "rates", "inflation", "jobs", "central_bank"]
 
 
 class CalendarRelatedSymbol(BaseModel):
@@ -43,6 +44,10 @@ class CalendarEvent(BaseModel):
     eventType: EventType
     eventTimeLocal: str | None = None
     source: str
+    country: str | None = None
+    currency: str | None = None
+    importance: int | None = None
+    impactTags: list[ImpactTag] = Field(default_factory=list)
     actual: str | None = None
     forecast: str | None = None
     previous: str | None = None

--- a/app/schemas/invest_feed_news.py
+++ b/app/schemas/invest_feed_news.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from app.schemas.news_issues import MarketIssue
 
 FeedTab = Literal["top", "latest", "hot", "holdings", "watchlist", "kr", "us", "crypto"]
+FeedTopic = Literal["fx", "rates"]
 NewsMarket = Literal["kr", "us", "crypto"]
 RelationKind = Literal["held", "watchlist", "both", "none"]
 # ROB-155: article scope — market_wide means broad macro/index/sector article;
@@ -77,6 +78,7 @@ class FeedNewsItem(BaseModel):
     # ROB-155: additive read-layer classification fields; defaults preserve backward compat.
     scope: NewsScope = "symbol_specific"
     tags: list[str] = Field(default_factory=list)
+    topicTags: list[FeedTopic] = Field(default_factory=list)
     category: str | None = None
     noiseReason: str | None = None
 

--- a/app/services/invest_view_model/calendar_service.py
+++ b/app/services/invest_view_model/calendar_service.py
@@ -101,8 +101,26 @@ _RATES_TERMS = (
     "연준",
 )
 _INFLATION_TERMS = ("cpi", "ppi", "pce", "inflation", "price", "물가")
-_JOBS_TERMS = ("nonfarm", "payroll", "unemployment", "jobless", "employment", "고용", "실업")
-_CENTRAL_BANK_TERMS = ("fomc", "fed", "boj", "ecb", "bok", "central bank", "연준", "한국은행", "중앙은행")
+_JOBS_TERMS = (
+    "nonfarm",
+    "payroll",
+    "unemployment",
+    "jobless",
+    "employment",
+    "고용",
+    "실업",
+)
+_CENTRAL_BANK_TERMS = (
+    "fomc",
+    "fed",
+    "boj",
+    "ecb",
+    "bok",
+    "central bank",
+    "연준",
+    "한국은행",
+    "중앙은행",
+)
 
 _MARKET_LITERAL = cast  # alias — used for type narrowing below
 
@@ -133,7 +151,14 @@ def _impact_tags_for_macro(
 ) -> list[ImpactTag]:
     haystack = f"{title} {source} {currency or ''} {country or ''}".lower()
     tags: list[ImpactTag] = []
-    if (currency or "").upper() in {"USD", "KRW", "JPY", "CNY", "EUR", "GBP"} or _contains_any(haystack, _FX_TERMS):
+    if (currency or "").upper() in {
+        "USD",
+        "KRW",
+        "JPY",
+        "CNY",
+        "EUR",
+        "GBP",
+    } or _contains_any(haystack, _FX_TERMS):
         tags.append("fx")
     if _contains_any(haystack, _RATES_TERMS):
         tags.append("rates")

--- a/app/services/invest_view_model/calendar_service.py
+++ b/app/services/invest_view_model/calendar_service.py
@@ -23,6 +23,7 @@ from app.schemas.invest_calendar import (
     CalendarTab,
     EventType,
     HighlightReason,
+    ImpactTag,
 )
 from app.services.invest_view_model.relation_resolver import RelationResolver
 from app.services.market_events.freshness_service import MarketEventsFreshnessService
@@ -64,6 +65,44 @@ _HIGH_IMPACT_TERMS = (
     "생산자물가",
     "소비자물가",
 )
+_FX_TERMS = (
+    "fx",
+    "forex",
+    "exchange rate",
+    "dollar",
+    "usd",
+    "usd/krw",
+    "usdkrw",
+    "원달러",
+    "달러원",
+    "환율",
+    "외환",
+    "yen",
+    "엔화",
+    "eur",
+    "jpy",
+    "dxy",
+)
+_RATES_TERMS = (
+    "rate",
+    "rates",
+    "yield",
+    "treasury",
+    "bond",
+    "fomc",
+    "boj",
+    "ecb",
+    "bok",
+    "금리",
+    "국채",
+    "채권",
+    "기준금리",
+    "한국은행",
+    "연준",
+)
+_INFLATION_TERMS = ("cpi", "ppi", "pce", "inflation", "price", "물가")
+_JOBS_TERMS = ("nonfarm", "payroll", "unemployment", "jobless", "employment", "고용", "실업")
+_CENTRAL_BANK_TERMS = ("fomc", "fed", "boj", "ecb", "bok", "central bank", "연준", "한국은행", "중앙은행")
 
 _MARKET_LITERAL = cast  # alias — used for type narrowing below
 
@@ -79,8 +118,32 @@ def _event_date_key(value: object | None) -> tuple[int, str]:
 def _is_high_impact_macro(event: CalendarEvent) -> bool:
     if event.eventType != "economic":
         return False
-    haystack = f"{event.title} {event.source}".lower()
+    if event.importance == 3:
+        return True
+    haystack = f"{event.title} {event.source} {event.currency or ''} {event.country or ''}".lower()
     return any(term in haystack for term in _HIGH_IMPACT_TERMS)
+
+
+def _contains_any(haystack: str, terms: tuple[str, ...]) -> bool:
+    return any(term.lower() in haystack for term in terms)
+
+
+def _impact_tags_for_macro(
+    *, title: str, source: str, currency: str | None, country: str | None
+) -> list[ImpactTag]:
+    haystack = f"{title} {source} {currency or ''} {country or ''}".lower()
+    tags: list[ImpactTag] = []
+    if (currency or "").upper() in {"USD", "KRW", "JPY", "CNY", "EUR", "GBP"} or _contains_any(haystack, _FX_TERMS):
+        tags.append("fx")
+    if _contains_any(haystack, _RATES_TERMS):
+        tags.append("rates")
+    if _contains_any(haystack, _INFLATION_TERMS):
+        tags.append("inflation")
+    if _contains_any(haystack, _JOBS_TERMS):
+        tags.append("jobs")
+    if _contains_any(haystack, _CENTRAL_BANK_TERMS):
+        tags.append("central_bank")
+    return tags
 
 
 def _rank_calendar_event(
@@ -348,13 +411,28 @@ async def build_calendar(
             event_time.date() if event_time else from_date
         )
 
+        title = _event_title(raw, market=market, etype=etype)
+        source = str(getattr(raw, "source", "") or "")
+        currency = getattr(raw, "currency", None)
+        country = getattr(raw, "country", None)
         ev = CalendarEvent(
             eventId=event_id,
-            title=_event_title(raw, market=market, etype=etype),
+            title=title,
             market=market,
             eventType=etype,
             eventTimeLocal=_format_kst_time(event_time),
-            source=str(getattr(raw, "source", "") or ""),
+            source=source,
+            country=country,
+            currency=currency,
+            importance=getattr(raw, "importance", None),
+            impactTags=_impact_tags_for_macro(
+                title=title,
+                source=source,
+                currency=currency,
+                country=country,
+            )
+            if etype == "economic"
+            else [],
             actual=actual,
             forecast=forecast,
             previous=previous,

--- a/app/services/invest_view_model/feed_news_service.py
+++ b/app/services/invest_view_model/feed_news_service.py
@@ -163,7 +163,9 @@ def _contains_any(haystack: str, terms: tuple[str, ...]) -> bool:
     return any(term.casefold() in lowered for term in terms)
 
 
-def _topic_tags_for_row(row: NewsArticle, analysis_summary: str | None) -> list[FeedTopic]:
+def _topic_tags_for_row(
+    row: NewsArticle, analysis_summary: str | None
+) -> list[FeedTopic]:
     haystack = " ".join(
         part
         for part in (

--- a/app/services/invest_view_model/feed_news_service.py
+++ b/app/services/invest_view_model/feed_news_service.py
@@ -16,6 +16,7 @@ from app.schemas.invest_feed_news import (
     FeedNewsMeta,
     FeedNewsResponse,
     FeedTab,
+    FeedTopic,
     NewsMarket,
     NewsRelatedSymbol,
     NewsScope,
@@ -48,6 +49,46 @@ _SNIPPET_MAX_CHARS = 240
 # (top/hot) even when no related symbol is attached.
 _DEFAULT_TAB_KEEP_SCOPES: frozenset[str] = frozenset(
     {"market_wide", "kr_market_wide", "mixed"}
+)
+
+_FX_TERMS = (
+    "fx",
+    "forex",
+    "exchange rate",
+    "currency",
+    "dollar",
+    "usd",
+    "usd/krw",
+    "usdkrw",
+    "원달러",
+    "달러원",
+    "환율",
+    "외환",
+    "달러",
+    "엔화",
+    "yen",
+    "eur",
+    "jpy",
+    "dxy",
+)
+_RATES_TERMS = (
+    "rate",
+    "rates",
+    "interest rate",
+    "yield",
+    "treasury",
+    "bond",
+    "fomc",
+    "fed",
+    "boj",
+    "ecb",
+    "bok",
+    "금리",
+    "국채",
+    "채권",
+    "기준금리",
+    "연준",
+    "한국은행",
 )
 
 
@@ -115,6 +156,32 @@ def _coerce_keywords(value: object) -> list[str]:
     if isinstance(value, str):
         return [value]
     return []
+
+
+def _contains_any(haystack: str, terms: tuple[str, ...]) -> bool:
+    lowered = haystack.casefold()
+    return any(term.casefold() in lowered for term in terms)
+
+
+def _topic_tags_for_row(row: NewsArticle, analysis_summary: str | None) -> list[FeedTopic]:
+    haystack = " ".join(
+        part
+        for part in (
+            row.title,
+            row.summary,
+            analysis_summary,
+            row.source,
+            row.feed_source,
+            " ".join(_coerce_keywords(getattr(row, "keywords", None))),
+        )
+        if part
+    )
+    tags: list[FeedTopic] = []
+    if _contains_any(haystack, _FX_TERMS):
+        tags.append("fx")
+    if _contains_any(haystack, _RATES_TERMS):
+        tags.append("rates")
+    return tags
 
 
 def _add_related_symbol(
@@ -361,6 +428,7 @@ async def build_feed_news(
     cursor: str | None,
     include_quotes: bool = False,
     symbol_filter: tuple[str, NewsMarket] | None = None,
+    topic: FeedTopic | None = None,
 ) -> FeedNewsResponse:
     market_filter: str | None = None
     if symbol_filter is not None:
@@ -511,6 +579,11 @@ async def build_feed_news(
                 )
             )
         )
+        topic_tags = _topic_tags_for_row(row, analysis_summary)
+        for topic_tag in topic_tags:
+            if topic_tag not in scope_tags:
+                scope_tags.append(topic_tag)
+
         items.append(
             FeedNewsItem(
                 id=row.id,
@@ -532,6 +605,7 @@ async def build_feed_news(
                 url=row.url,
                 scope=cast(NewsScope, item_scope),
                 tags=scope_tags,
+                topicTags=topic_tags,
                 category=item_category,
                 noiseReason=item_noise_reason,
             )
@@ -560,6 +634,9 @@ async def build_feed_news(
                 and not i.relatedSymbols
             )
         ]
+
+    if topic is not None:
+        items = [i for i in items if topic in i.tags or topic in i.topicTags]
 
     # Apply holdings/watchlist filters in-memory.
     empty_reason: str | None = None

--- a/frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopFeedNewsPage.test.tsx
@@ -153,6 +153,17 @@ test("renders dense news rows and reacts to tab change", async () => {
   await waitFor(() => expect(feedApi.fetchFeedNews).toHaveBeenCalledTimes(2));
 });
 
+test("passes FX/rates topic filters to ordinary news calls", async () => {
+  renderPage();
+  await screen.findByTestId("feed-item");
+
+  await userEvent.click(screen.getByTestId("news-topic-fx"));
+
+  await waitFor(() =>
+    expect(feedApi.fetchFeedNews).toHaveBeenLastCalledWith({ tab: "top", limit: 30, topic: "fx" }),
+  );
+});
+
 test("renders research cards from the metadata-only research tab", async () => {
   renderPage();
 

--- a/frontend/invest/src/__tests__/MobileCalendarPage.test.tsx
+++ b/frontend/invest/src/__tests__/MobileCalendarPage.test.tsx
@@ -147,8 +147,11 @@ test("touches an in-month date in the strip and scrolls/highlights that day sect
     const may13 = document.querySelector('[data-day-anchor="2026-05-13"]')!;
     expect(may13).toHaveAttribute("data-selected", "true");
     expect(scrollSpy).toHaveBeenCalled();
-    // The cluster still shows in the May 13 section.
-    expect(within(may13 as HTMLElement).getByText("미국 실적 발표 327건")).toBeInTheDocument();
+    // The cluster still shows in the May 13 section, with the top event rendered
+    // separately and the overflow count reflecting the remaining events.
+    const overflow = within(may13 as HTMLElement).getByTestId("calendar-cluster-overflow");
+    expect(overflow).toHaveTextContent("미국 실적 발표");
+    expect(overflow).toHaveTextContent("326");
   } finally {
     Element.prototype.scrollIntoView = originalScroll;
   }

--- a/frontend/invest/src/api/feedNews.ts
+++ b/frontend/invest/src/api/feedNews.ts
@@ -1,14 +1,18 @@
-import type { FeedNewsResponse, FeedTab } from "../types/feedNews";
+import type { FeedNewsResponse, FeedTab, FeedTopic } from "../types/feedNews";
 
 export async function fetchFeedNews(params: {
   tab: FeedTab;
   limit?: number;
   cursor?: string;
+  includeQuotes?: boolean;
+  topic?: FeedTopic | null;
 }): Promise<FeedNewsResponse> {
   const q = new URLSearchParams();
   q.set("tab", params.tab);
   if (params.limit !== undefined) q.set("limit", String(params.limit));
   if (params.cursor) q.set("cursor", params.cursor);
+  if (params.includeQuotes !== undefined) q.set("includeQuotes", String(params.includeQuotes));
+  if (params.topic) q.set("topic", params.topic);
   const res = await fetch(`/invest/api/feed/news?${q}`, { credentials: "include" });
   if (!res.ok) throw new Error(`feed/news ${res.status}`);
   return res.json();

--- a/frontend/invest/src/components/calendar/EventRow.tsx
+++ b/frontend/invest/src/components/calendar/EventRow.tsx
@@ -1,7 +1,29 @@
 import type { CalendarEventVM } from "./vm";
+import type { ImpactTag } from "../../types/calendar";
 import { formatKstTime } from "./vm";
 import { RegionBadge } from "./RegionBadge";
 import { OwnershipTag } from "./OwnershipTag";
+
+const IMPACT_TAG_LABEL: Record<ImpactTag, string> = {
+  fx: "FX",
+  rates: "금리",
+  inflation: "물가",
+  jobs: "고용",
+  central_bank: "중앙은행",
+};
+
+function ImpactTags({ tags }: { tags: ImpactTag[] | undefined }) {
+  if (!tags || tags.length === 0) return null;
+  return (
+    <div className="calendar-event-row__impact-tags" data-testid="calendar-event-impact-tags">
+      {tags.map((tag) => (
+        <span key={tag} className="calendar-event-row__impact-tag" data-impact-tag={tag}>
+          {IMPACT_TAG_LABEL[tag] ?? tag}
+        </span>
+      ))}
+    </div>
+  );
+}
 
 export function EventRow({ ev }: { ev: CalendarEventVM }) {
   const showFallbackTime =
@@ -29,6 +51,7 @@ export function EventRow({ ev }: { ev: CalendarEventVM }) {
         >
           {timeText}
         </div>
+        <ImpactTags tags={ev.impactTags} />
       </div>
       <div className="calendar-event-row__num calendar-event-row__num--actual" data-released={ev.released ? "true" : "false"}>
         {ev.actual ?? ""}

--- a/frontend/invest/src/components/calendar/vm.ts
+++ b/frontend/invest/src/components/calendar/vm.ts
@@ -6,6 +6,7 @@ import type {
   CalendarEvent,
   HighlightReason,
   CalendarSourceStatus,
+  ImpactTag,
 } from "../../types/calendar";
 
 export type DisplayEventType = "earnings" | "macro" | "other";
@@ -29,6 +30,7 @@ export interface CalendarEventVM {
   badges: string[];
   displayPriority?: number;
   highlightReasons?: HighlightReason[];
+  impactTags?: ImpactTag[];
 }
 
 export interface CalendarClusterVM {
@@ -105,6 +107,7 @@ export function toEventVM(event: CalendarEvent, date: string): CalendarEventVM {
     badges: event.badges,
     displayPriority: event.displayPriority ?? 0,
     highlightReasons: event.highlightReasons ?? [],
+    impactTags: event.impactTags ?? [],
   };
 }
 

--- a/frontend/invest/src/components/news/NewsListItem.tsx
+++ b/frontend/invest/src/components/news/NewsListItem.tsx
@@ -40,6 +40,12 @@ function formatChangeRate(rate: number | null | undefined): string | null {
   return `${sign}${rate.toFixed(2)}%`;
 }
 
+function symbolChangePct(symbol: FeedRelatedSymbol): number | null {
+  if (typeof symbol.changePct === "number" && Number.isFinite(symbol.changePct)) return symbol.changePct;
+  const quoteRate = symbol.quote?.changeRate;
+  return typeof quoteRate === "number" && Number.isFinite(quoteRate) ? quoteRate : null;
+}
+
 function changeRateColor(rate: number): string {
   if (rate > 0) return "var(--gain)";
   if (rate < 0) return "var(--loss)";
@@ -51,7 +57,8 @@ function relationTone(relation: FeedNewsItem["relation"]): "accent" | "kis" {
 }
 
 function SymbolChip({ symbol }: { symbol: FeedRelatedSymbol }) {
-  const rateText = formatChangeRate(symbol.quote?.changeRate);
+  const changePct = symbolChangePct(symbol);
+  const rateText = formatChangeRate(changePct);
   const marketLabel = MARKET_LABEL[symbol.market];
 
   return (
@@ -96,7 +103,7 @@ function SymbolChip({ symbol }: { symbol: FeedRelatedSymbol }) {
           data-testid="feed-item-symbol-change-rate"
           style={{
             fontFamily: "var(--font-sans)",
-            color: changeRateColor(symbol.quote?.changeRate ?? 0),
+            color: changeRateColor(changePct ?? 0),
             fontWeight: 800,
           }}
         >

--- a/frontend/invest/src/components/news/NewsTopicChips.tsx
+++ b/frontend/invest/src/components/news/NewsTopicChips.tsx
@@ -1,0 +1,42 @@
+import type { FeedTopic } from "../../types/feedNews";
+
+const TOPIC_LABEL: Record<FeedTopic, string> = {
+  fx: "환율",
+  rates: "금리",
+};
+
+interface NewsTopicChipsProps {
+  value: FeedTopic | null;
+  onChange: (topic: FeedTopic | null) => void;
+}
+
+export function NewsTopicChips({ value, onChange }: NewsTopicChipsProps) {
+  const topics: FeedTopic[] = ["fx", "rates"];
+  return (
+    <div aria-label="뉴스 주제 필터" style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+      {topics.map((topic) => {
+        const selected = value === topic;
+        return (
+          <button
+            key={topic}
+            type="button"
+            onClick={() => onChange(selected ? null : topic)}
+            data-testid={`news-topic-${topic}`}
+            style={{
+              border: selected ? "1px solid var(--accent)" : "1px solid var(--line)",
+              background: selected ? "rgba(59, 130, 246, 0.14)" : "var(--surface)",
+              color: selected ? "var(--accent)" : "var(--fg-2)",
+              borderRadius: 999,
+              padding: "6px 10px",
+              fontSize: 12,
+              fontWeight: 700,
+              cursor: "pointer",
+            }}
+          >
+            {TOPIC_LABEL[topic]}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
@@ -5,10 +5,11 @@ import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useViewport } from "../../hooks/useViewport";
 import { fetchFeedNews } from "../../api/feedNews";
 import { fetchFeedResearch } from "../../api/feedResearch";
-import type { FeedNewsResponse } from "../../types/feedNews";
+import type { FeedNewsResponse, FeedTopic } from "../../types/feedNews";
 import type { FeedResearchResponse } from "../../types/feedResearch";
 import { NewsTabs, type FeedContentTab } from "../../components/news/NewsTabs";
 import { NewsListItem } from "../../components/news/NewsListItem";
+import { NewsTopicChips } from "../../components/news/NewsTopicChips";
 import { ResearchListItem } from "../../components/news/ResearchListItem";
 import { MobileFeedNewsPage } from "../mobile/MobileFeedNewsPage";
 
@@ -31,6 +32,7 @@ export function FeedNewsRoute() {
 export function DesktopFeedNewsPage() {
   const [searchParams] = useSearchParams();
   const [tab, setTab] = useState<FeedContentTab>("top");
+  const [topic, setTopic] = useState<FeedTopic | null>(null);
   const [data, setData] = useState<FeedNewsResponse | undefined>();
   const [researchData, setResearchData] = useState<FeedResearchResponse | undefined>();
   const [err, setErr] = useState<string | undefined>();
@@ -58,7 +60,7 @@ export function DesktopFeedNewsPage() {
         .catch((e) => !cancel && setErr(String(e?.message ?? e)));
     } else {
       setData(undefined);
-      fetchFeedNews({ tab, limit: 30 })
+      fetchFeedNews({ tab, limit: 30, ...(topic ? { topic } : {}) })
         .then((r) => !cancel && setData(r))
         .catch((e) => !cancel && setErr(String(e?.message ?? e)));
     }
@@ -66,7 +68,7 @@ export function DesktopFeedNewsPage() {
     return () => {
       cancel = true;
     };
-  }, [tab, searchParams]);
+  }, [tab, topic, searchParams]);
 
   const researchMode = tab === "research";
   const issueById = new Map((data?.issues ?? []).map((i) => [i.id, i] as const));
@@ -87,6 +89,7 @@ export function DesktopFeedNewsPage() {
           </header>
 
           <NewsTabs value={tab} onChange={setTab} />
+          {tab !== "research" && <NewsTopicChips value={topic} onChange={setTopic} />}
 
           <div data-testid="feed-center">
             {err && <div style={{ color: "var(--danger)", marginBottom: 12 }}>오류: {err}</div>}

--- a/frontend/invest/src/pages/mobile/MobileFeedNewsPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileFeedNewsPage.tsx
@@ -3,10 +3,11 @@ import { useSearchParams } from "react-router-dom";
 import { MobileShell } from "../../mobile/MobileShell";
 import { fetchFeedNews } from "../../api/feedNews";
 import { fetchFeedResearch } from "../../api/feedResearch";
-import type { FeedNewsResponse } from "../../types/feedNews";
+import type { FeedNewsResponse, FeedTopic } from "../../types/feedNews";
 import type { FeedResearchResponse } from "../../types/feedResearch";
 import { NewsTabs, type FeedContentTab } from "../../components/news/NewsTabs";
 import { NewsListItem } from "../../components/news/NewsListItem";
+import { NewsTopicChips } from "../../components/news/NewsTopicChips";
 import { ResearchListItem } from "../../components/news/ResearchListItem";
 
 function emptyMessage(reason: string | null | undefined): string {
@@ -23,6 +24,7 @@ function getParam(searchParams: URLSearchParams, key: string): string | undefine
 export function MobileFeedNewsPage() {
   const [searchParams] = useSearchParams();
   const [tab, setTab] = useState<FeedContentTab>("top");
+  const [topic, setTopic] = useState<FeedTopic | null>(null);
   const [data, setData] = useState<FeedNewsResponse | undefined>();
   const [researchData, setResearchData] = useState<FeedResearchResponse | undefined>();
   const [err, setErr] = useState<string | undefined>();
@@ -50,7 +52,7 @@ export function MobileFeedNewsPage() {
         .catch((e) => !cancel && setErr(String(e?.message ?? e)));
     } else {
       setData(undefined);
-      fetchFeedNews({ tab, limit: 30 })
+      fetchFeedNews({ tab, limit: 30, ...(topic ? { topic } : {}) })
         .then((r) => !cancel && setData(r))
         .catch((e) => !cancel && setErr(String(e?.message ?? e)));
     }
@@ -58,7 +60,7 @@ export function MobileFeedNewsPage() {
     return () => {
       cancel = true;
     };
-  }, [tab, searchParams]);
+  }, [tab, topic, searchParams]);
 
   const researchMode = tab === "research";
   const issueById = new Map((data?.issues ?? []).map((i) => [i.id, i] as const));
@@ -71,6 +73,7 @@ export function MobileFeedNewsPage() {
     <MobileShell title="뉴스">
       <div data-testid="feed-center" style={{ padding: "14px 16px", display: "flex", flexDirection: "column", gap: 10 }}>
         <NewsTabs value={tab} onChange={setTab} variant="pill-row" />
+        {tab !== "research" && <NewsTopicChips value={topic} onChange={setTopic} />}
 
         {err && <div style={{ color: "var(--danger)" }}>오류: {err}</div>}
         {loading && (

--- a/frontend/invest/src/styles/calendar.css
+++ b/frontend/invest/src/styles/calendar.css
@@ -90,6 +90,24 @@
   margin-top: 2px;
 }
 .calendar-event-row__time[data-released="true"] { color: var(--fg-2); }
+.calendar-event-row__impact-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+.calendar-event-row__impact-tag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  color: var(--accent-press);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: -0.01em;
+}
 .calendar-cluster-row__preview {
   font-size: 12px;
   color: var(--fg-3);

--- a/frontend/invest/src/types/calendar.ts
+++ b/frontend/invest/src/types/calendar.ts
@@ -3,6 +3,7 @@ export type CalendarMarket = "kr" | "us" | "crypto" | "global";
 export type EventType = "earnings" | "economic" | "disclosure" | "crypto" | "other";
 export type CalendarRelation = "held" | "watchlist" | "both" | "none";
 export type CalendarSourceState = "fresh" | "stale" | "failed" | "missing";
+export type ImpactTag = "fx" | "rates" | "inflation" | "jobs" | "central_bank";
 export type HighlightReason = "held" | "watchlist" | "major" | "high_impact" | "near_term" | "has_values";
 export type CalendarDayState =
   | "loaded"
@@ -49,6 +50,10 @@ export interface CalendarEvent {
   eventType: EventType;
   eventTimeLocal?: string | null;
   source: string;
+  country?: string | null;
+  currency?: string | null;
+  importance?: number | null;
+  impactTags?: ImpactTag[];
   actual?: string | null;
   forecast?: string | null;
   previous?: string | null;

--- a/frontend/invest/src/types/feedNews.ts
+++ b/frontend/invest/src/types/feedNews.ts
@@ -1,6 +1,7 @@
 import type { MarketIssue } from "./newsIssues";
 
 export type FeedTab = "top" | "latest" | "hot" | "holdings" | "watchlist" | "kr" | "us" | "crypto";
+export type FeedTopic = "fx" | "rates";
 export type RelationKind = "held" | "watchlist" | "both" | "none";
 export type FeedNewsScope = "market_wide" | "symbol_specific" | "mixed" | "kr_market_wide";
 
@@ -25,6 +26,12 @@ export interface FeedRelatedSymbol {
   matchReason?: string | null;
   matchedTerm?: string | null;
   quote?: FeedRelatedSymbolQuote | null;
+  currentPrice?: number | null;
+  previousClose?: number | null;
+  change?: number | null;
+  changePct?: number | null;
+  quoteSource?: string | null;
+  quoteAsOf?: string | null;
 }
 
 export interface FeedNewsItem {
@@ -54,9 +61,10 @@ export interface FeedNewsItem {
   summarySnippet?: string | null;
   relation: RelationKind;
   url: string;
-  // ROB-155 / ROB-169 — additive read-layer classification.
+  // ROB-155 / ROB-169 / ROB-220 — additive read-layer classification.
   scope?: FeedNewsScope;
   tags?: string[];
+  topicTags?: FeedTopic[];
   category?: string | null;
   noiseReason?: string | null;
 }

--- a/tests/test_invest_calendar_router.py
+++ b/tests/test_invest_calendar_router.py
@@ -27,6 +27,9 @@ def _fake_event(
     previous: object | None = None,
     values: list[object] | None = None,
     source: str = "test",
+    currency: str | None = None,
+    country: str | None = None,
+    importance: int | None = None,
 ):
     e = MagicMock()
     # MarketEventResponse uses source_event_id, not event_id
@@ -40,6 +43,9 @@ def _fake_event(
     e.event_date = ev_date or date(2026, 5, 4)
     e.release_time_utc = release_time_utc
     e.source = source
+    e.currency = currency
+    e.country = country
+    e.importance = importance
     if values is not None:
         e.values = values
     elif actual is not None or forecast is not None or previous is not None:

--- a/tests/test_invest_feed_news_router.py
+++ b/tests/test_invest_feed_news_router.py
@@ -119,6 +119,50 @@ async def test_feed_news_top_tab(monkeypatch) -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_feed_news_topic_filter_keeps_fx_items(monkeypatch) -> None:
+    from app.services.invest_view_model import feed_news_service as svc
+
+    db = MagicMock()
+    scalar_result = MagicMock()
+    scalar_result.scalars.return_value.all.return_value = [
+        _fake_article(
+            id=101,
+            market="kr",
+            symbol="005930",
+            name="삼성전자",
+            title="원달러 환율 상승에 수출주 강세",
+            keywords=["환율", "달러"],
+        ),
+        _fake_article(
+            id=102,
+            market="kr",
+            symbol="000660",
+            name="SK하이닉스",
+            title="국채 금리 하락에 성장주 반등",
+            keywords=["금리", "국채"],
+        ),
+    ]
+    summary_result = MagicMock()
+    summary_result.all.return_value = []
+    db.execute = AsyncMock(
+        side_effect=[scalar_result, summary_result, _empty_related_result()]
+    )
+    monkeypatch.setattr(
+        svc, "build_market_issues", AsyncMock(return_value=MagicMock(items=[]))
+    )
+
+    resolver = RelationResolver()
+    resp = await svc.build_feed_news(
+        db=db, resolver=resolver, tab="top", limit=30, cursor=None, topic="fx"
+    )
+
+    assert [item.id for item in resp.items] == [101]
+    assert resp.items[0].topicTags == ["fx"]
+    assert "fx" in resp.items[0].tags
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_feed_news_holdings_empty_when_no_holdings(monkeypatch) -> None:
     from app.services.invest_view_model import feed_news_service as svc
 


### PR DESCRIPTION
## Summary
- Add FX-impact country/currency/importance metadata and `impactTags` to `/invest/api/calendar` events.
- Add FX/rates topic tagging, API `topic` filtering, and desktop/mobile filter chips for `/invest/feed/news`.
- Keep the slice read-only/additive; no broker/order/watch/scheduler/prod-write paths are introduced.

## Verification
- `pytest tests/test_invest_calendar_router.py tests/services/test_market_events_normalizers.py tests/test_feed_news_kr_filter.py tests/test_invest_feed_news_router.py tests/test_kr_news_relevance_service.py` — 80 passed, 2 warnings
- `cd frontend/invest && npm test -- --run src/__tests__/DesktopFeedNewsPage.test.tsx src/__tests__/NewsTabs.test.tsx src/__tests__/EventRow.test.tsx src/__tests__/SelectedDateEvents.test.tsx src/__tests__/MobileCalendarPage.test.tsx --reporter=verbose` — 5 files / 42 tests passed
- `cd frontend/invest && npm run typecheck` — passed
- `uv run ruff check app/routers/invest_api.py app/schemas/invest_calendar.py app/schemas/invest_feed_news.py app/services/invest_view_model/calendar_service.py app/services/invest_view_model/feed_news_service.py tests/test_invest_calendar_router.py tests/test_invest_feed_news_router.py` — passed
- Safety grep for order/watch/scheduler/prod-write/secrets terms in diff — no matches

Closes ROB-220
