### PR TITLE
feat(invest): expose crypto screener market

### DIFF
--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -414,8 +414,9 @@ async def get_feed_research(
 @router.get("/screener/presets")
 async def get_screener_presets_endpoint(
     user: Annotated[Any, Depends(get_authenticated_user)],
+    market: Literal["kr", "us", "crypto"] = Query("kr"),
 ) -> ScreenerPresetsResponse:
-    return build_screener_presets()
+    return build_screener_presets(market=market)
 
 
 @router.get("/screener/results")
@@ -425,7 +426,7 @@ async def get_screener_results_endpoint(
     service: Annotated[InvestHomeService, Depends(get_invest_home_service)],
     screening_service: Annotated[Any, Depends(get_screener_service_dep)],
     preset: str = Query(..., min_length=1),
-    market: Literal["kr", "us"] = Query("kr"),
+    market: Literal["kr", "us", "crypto"] = Query("kr"),
 ) -> ScreenerResultsResponse:
     home = await service.get_home(user_id=user.id)
     resolver = await build_relation_resolver(

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -11,6 +11,7 @@ from app.schemas.invest_screener import ScreenerFilterChip, ScreenerPreset
 
 DEFAULT_PRESET_ID = "consecutive_gainers"
 CONSECUTIVE_GAINERS_LIMIT = 80
+CRYPTO_DEFAULT_PRESET_ID = "crypto_high_volume"
 
 
 SCREENER_PRESETS: list[ScreenerPreset] = [
@@ -92,6 +93,46 @@ SCREENER_PRESETS: list[ScreenerPreset] = [
 ]
 
 
+CRYPTO_SCREENER_PRESETS: list[ScreenerPreset] = [
+    ScreenerPreset(
+        id="crypto_high_volume",
+        name="거래대금 상위 코인",
+        description="Upbit 거래대금이 큰 가상자산",
+        badges=["가상자산"],
+        filterChips=[
+            ScreenerFilterChip(label="가상자산", detail=None),
+            ScreenerFilterChip(label="거래대금", detail="24시간 상위"),
+        ],
+        metricLabel="거래대금",
+        market="crypto",
+    ),
+    ScreenerPreset(
+        id="crypto_oversold",
+        name="저RSI 반등 후보",
+        description="RSI가 낮아 과매도 구간에 가까운 가상자산",
+        badges=[],
+        filterChips=[
+            ScreenerFilterChip(label="가상자산", detail=None),
+            ScreenerFilterChip(label="RSI", detail="35 이하"),
+        ],
+        metricLabel="RSI",
+        market="crypto",
+    ),
+    ScreenerPreset(
+        id="crypto_momentum",
+        name="상승률 상위 코인",
+        description="단기 상승률이 높은 Upbit 가상자산",
+        badges=[],
+        filterChips=[
+            ScreenerFilterChip(label="가상자산", detail=None),
+            ScreenerFilterChip(label="등락률", detail="상위"),
+        ],
+        metricLabel="등락률",
+        market="crypto",
+    ),
+]
+
+
 _SCREENING_FILTERS: dict[str, dict[str, object]] = {
     "consecutive_gainers": {
         "market": "kr",
@@ -142,11 +183,36 @@ _SCREENING_FILTERS: dict[str, dict[str, object]] = {
         "min_market_cap": 1_000_000_000_000.0,
         "limit": 20,
     },
+    "crypto_high_volume": {
+        "market": "crypto",
+        "sort_by": "volume",
+        "sort_order": "desc",
+        "limit": 20,
+    },
+    "crypto_oversold": {
+        "market": "crypto",
+        "sort_by": "rsi",
+        "sort_order": "asc",
+        "max_rsi": 35.0,
+        "limit": 20,
+    },
+    "crypto_momentum": {
+        "market": "crypto",
+        "sort_by": "change_rate",
+        "sort_order": "desc",
+        "limit": 20,
+    },
 }
 
 
 def _market_chip(market: str) -> ScreenerFilterChip:
-    return ScreenerFilterChip(label="미국" if market == "us" else "국내", detail=None)
+    if market == "us":
+        label = "미국"
+    elif market == "crypto":
+        label = "가상자산"
+    else:
+        label = "국내"
+    return ScreenerFilterChip(label=label, detail=None)
 
 
 def _with_market(preset: ScreenerPreset, market: str) -> ScreenerPreset:
@@ -158,15 +224,24 @@ def _with_market(preset: ScreenerPreset, market: str) -> ScreenerPreset:
     return preset.model_copy(update={"market": market, "filterChips": chips})
 
 
+def _normalize_requested_market(market: str) -> str:
+    return market if market in {"kr", "us", "crypto"} else "kr"
+
+
 def preset_definitions(market: str = "kr") -> list[ScreenerPreset]:
     """Return preset definitions localized for the requested market."""
-    normalized_market = "us" if market == "us" else "kr"
+    normalized_market = _normalize_requested_market(market)
+    if normalized_market == "crypto":
+        return [_with_market(p, "crypto") for p in CRYPTO_SCREENER_PRESETS]
     return [_with_market(p, normalized_market) for p in SCREENER_PRESETS]
 
 
 def get_preset(preset_id: str, market: str = "kr") -> ScreenerPreset | None:
-    normalized_market = "us" if market == "us" else "kr"
-    for p in SCREENER_PRESETS:
+    normalized_market = _normalize_requested_market(market)
+    catalog = (
+        CRYPTO_SCREENER_PRESETS if normalized_market == "crypto" else SCREENER_PRESETS
+    )
+    for p in catalog:
         if p.id == preset_id:
             return _with_market(p, normalized_market)
     return None
@@ -177,7 +252,15 @@ def screening_filters_for(preset_id: str, market: str = "kr") -> dict[str, objec
     filters = dict(_SCREENING_FILTERS.get(preset_id, {}))
     if not filters:
         return {}
-    normalized_market = "us" if market == "us" else "kr"
+    normalized_market = _normalize_requested_market(market)
+    crypto_ids = {p.id for p in CRYPTO_SCREENER_PRESETS}
+    if normalized_market == "crypto":
+        if preset_id not in crypto_ids:
+            return {}
+        filters["market"] = "crypto"
+        return filters
+    if preset_id in crypto_ids:
+        return {}
     filters["market"] = normalized_market
     if normalized_market == "us":
         # The US screening path supports PER/dividend/RSI/volume/change filters,

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -30,6 +30,7 @@ from app.schemas.invest_screener import (
     ScreenerResultsResponse,
 )
 from app.services.invest_view_model.screener_presets import (
+    CRYPTO_DEFAULT_PRESET_ID,
     DEFAULT_PRESET_ID,
     get_preset,
     preset_definitions,
@@ -317,10 +318,13 @@ async def _load_consecutive_gainers_from_snapshots(
     return rows
 
 
-def build_screener_presets() -> ScreenerPresetsResponse:
+def build_screener_presets(market: str = "kr") -> ScreenerPresetsResponse:
+    requested_market = _normalize_market(market)
     return ScreenerPresetsResponse(
-        presets=preset_definitions("kr"),
-        selectedPresetId=DEFAULT_PRESET_ID,
+        presets=preset_definitions(requested_market),
+        selectedPresetId=CRYPTO_DEFAULT_PRESET_ID
+        if requested_market == "crypto"
+        else DEFAULT_PRESET_ID,
     )
 
 
@@ -331,6 +335,9 @@ _METRIC_FIELD: dict[str, str] = {
     "oversold_recovery": "rsi",
     "high_volume_momentum": "volume",
     "growth_expectation": "change_rate",
+    "crypto_high_volume": "trade_amount_24h",
+    "crypto_oversold": "rsi",
+    "crypto_momentum": "change_rate",
 }
 
 
@@ -349,6 +356,32 @@ def _format_change_amount(amount: float | None, market: str = "kr") -> str:
     if market == "us":
         return f"{sign}${abs(float(amount)):,.2f}"
     return f"{sign}{abs(int(amount)):,}원"
+
+
+def _is_krw_crypto_symbol(symbol: str) -> bool:
+    return symbol.upper().startswith("KRW-")
+
+
+def _format_crypto_price(close: float | None, symbol: str) -> str:
+    if close is None:
+        return "-"
+    if _is_krw_crypto_symbol(symbol):
+        if close >= 1:
+            return f"{float(close):,.0f}원"
+        return f"{float(close):,.4f}원"
+    return f"${float(close):,.4f}"
+
+
+def _format_crypto_change_amount(amount: float | None, symbol: str) -> str:
+    if amount is None:
+        return "-"
+    sign = "+" if amount > 0 else "-" if amount < 0 else ""
+    value = abs(float(amount))
+    if _is_krw_crypto_symbol(symbol):
+        if value >= 1:
+            return f"{sign}{value:,.0f}원"
+        return f"{sign}{value:,.4f}원"
+    return f"{sign}${value:,.4f}"
 
 
 def _format_price(close: float | None, market: str = "kr") -> str:
@@ -471,7 +504,7 @@ def _format_market_cap_us(market_cap: float | None) -> str:
 
 
 def _format_market_cap(row: dict[str, Any], market: str) -> tuple[str, list[str]]:
-    if market == "us":
+    if market in {"us", "crypto"}:
         market_cap = _coerce_float(row.get("market_cap_usd"))
         if market_cap is None:
             market_cap = _coerce_float(row.get("market_cap"))
@@ -484,6 +517,26 @@ def _format_volume(volume: float | None) -> str:
     if volume is None:
         return "-"
     return f"{int(volume):,}"
+
+
+def _format_volume_label(row: dict[str, Any], market: str) -> str:
+    if market == "crypto":
+        for key in ("trade_amount_24h", "value_traded", "volume_24h_usd", "volume"):
+            value = _coerce_float(row.get(key))
+            if value is not None:
+                return _format_volume(value)
+        return "-"
+    return _format_volume(_coerce_float(row.get("volume")))
+
+
+def _metric_raw_value(field: str, row: dict[str, Any]) -> Any:
+    if field == "trade_amount_24h":
+        for key in ("trade_amount_24h", "value_traded", "volume_24h_usd", "volume"):
+            value = row.get(key)
+            if value is not None:
+                return value
+        return None
+    return row.get(field)
 
 
 def calculate_consecutive_up_days(closes: Sequence[float | int | None]) -> int | None:
@@ -514,7 +567,7 @@ def _metric_value_label(preset_id: str, row: dict[str, Any]) -> tuple[str, list[
     field = _METRIC_FIELD.get(preset_id)
     if not field:
         return "-", []
-    value = row.get(field)
+    value = _metric_raw_value(field, row)
     if value is None:
         if field == "consecutive_up_days":
             return "-", ["연속상승 데이터 준비중"]
@@ -530,8 +583,8 @@ def _metric_value_label(preset_id: str, row: dict[str, Any]) -> tuple[str, list[
         return f"{float(value):.1f}", []
     if field == "dividend_yield":
         return f"{float(value):.2f}%", []
-    if field == "volume":
-        return f"{int(value):,}", []
+    if field in ("volume", "trade_amount_24h"):
+        return f"{int(float(value)):,}", []
     return str(value), []
 
 
@@ -605,7 +658,7 @@ async def build_screener_results(
     now: Callable[[], datetime] = lambda: datetime.now(UTC),
     session: AsyncSession | None = None,
 ) -> ScreenerResultsResponse:
-    requested_market = "us" if market == "us" else "kr"
+    requested_market = _normalize_market(market)
     preset = get_preset(preset_id, requested_market)
     if preset is None:
         freshness = _build_freshness(
@@ -747,18 +800,31 @@ async def build_screener_results(
                 name=_kr_names.get(symbol) or _clean_text(row.get("name")) or symbol,
                 logoUrl=row.get("logo_url"),
                 isWatched=is_watched,
-                priceLabel=_format_price(
-                    row.get("close") or row.get("price") or row.get("current_price"),
+                priceLabel=_format_crypto_price(
+                    _coerce_float(
+                        row.get("close") or row.get("price") or row.get("current_price")
+                    ),
+                    symbol,
+                )
+                if market == "crypto"
+                else _format_price(
+                    _coerce_float(
+                        row.get("close") or row.get("price") or row.get("current_price")
+                    ),
                     market,
                 ),
                 changePctLabel=change_pct_label,
-                changeAmountLabel=_format_change_amount(
-                    row.get("change_amount"), market
+                changeAmountLabel=_format_crypto_change_amount(
+                    _coerce_float(row.get("change_amount")), symbol
+                )
+                if market == "crypto"
+                else _format_change_amount(
+                    _coerce_float(row.get("change_amount")), market
                 ),
                 changeDirection=direction,
                 category=str(row.get("sector") or row.get("category") or "-"),
                 marketCapLabel=market_cap_label,
-                volumeLabel=_format_volume(row.get("volume")),
+                volumeLabel=_format_volume_label(row, market),
                 analystLabel=str(row.get("analyst_label") or "-"),
                 metricValueLabel=metric_label,
                 warnings=row_warnings,

--- a/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
@@ -62,6 +62,37 @@ const RESULTS_VALUE = {
   results: [{ ...ROW, metricValueLabel: "14.0" }],
 };
 
+const CRYPTO_PRESETS = {
+  presets: [
+    {
+      id: "crypto_high_volume", name: "거래대금 상위 코인",
+      description: "Upbit 거래대금이 큰 가상자산",
+      badges: ["가상자산"],
+      filterChips: [{ label: "거래대금", detail: "24시간 상위" }],
+      metricLabel: "거래대금", market: "crypto" as const,
+    },
+  ],
+  selectedPresetId: "crypto_high_volume",
+};
+
+const CRYPTO_RESULTS = {
+  ...RESULTS_GAINERS,
+  presetId: "crypto_high_volume", title: "거래대금 상위 코인",
+  description: "Upbit 거래대금이 큰 가상자산",
+  filterChips: [{ label: "거래대금", detail: "24시간 상위" }],
+  metricLabel: "거래대금",
+  results: [{
+    ...ROW,
+    symbol: "KRW-BTC",
+    market: "crypto" as const,
+    name: "Bitcoin",
+    priceLabel: "150,000,000원",
+    marketCapLabel: "$2.10T",
+    category: "Crypto",
+    metricValueLabel: "120,000,000,000",
+  }],
+};
+
 function wrap(ui: React.ReactElement) {
   return (
     <AccountPanelProvider>
@@ -81,8 +112,13 @@ beforeEach(() => {
   vi.spyOn(signalsApi, "fetchSignals").mockResolvedValue({
     tab: "kr", asOf: new Date().toISOString(), items: [], meta: { warnings: [] },
   });
-  vi.spyOn(screenerApi, "fetchScreenerPresets").mockResolvedValue(PRESETS);
+  vi.spyOn(screenerApi, "fetchScreenerPresets").mockImplementation(async (market = "kr") => {
+    return market === "crypto" ? CRYPTO_PRESETS : PRESETS;
+  });
   vi.spyOn(screenerApi, "fetchScreenerResults").mockImplementation(async (id: string, market = "kr") => {
+    if (market === "crypto") {
+      return CRYPTO_RESULTS;
+    }
     if (market === "us") {
       return {
         ...RESULTS_VALUE,
@@ -150,4 +186,16 @@ test("switches to the US market", async () => {
 
   await waitFor(() => expect(screen.getByText("Apple Inc.")).toBeInTheDocument());
   expect(screenerApi.fetchScreenerResults).toHaveBeenCalledWith("consecutive_gainers", "us");
+});
+
+
+test("switches to the crypto market", async () => {
+  render(wrap(<DesktopScreenerPage />));
+  await waitFor(() => expect(screen.getByText("삼성전자")).toBeInTheDocument());
+
+  await userEvent.click(screen.getByRole("button", { name: "가상자산" }));
+
+  await waitFor(() => expect(screen.getByText("Bitcoin")).toBeInTheDocument());
+  expect(screenerApi.fetchScreenerPresets).toHaveBeenCalledWith("crypto");
+  expect(screenerApi.fetchScreenerResults).toHaveBeenCalledWith("crypto_high_volume", "crypto");
 });

--- a/frontend/invest/src/api/screener.ts
+++ b/frontend/invest/src/api/screener.ts
@@ -4,15 +4,18 @@ import type {
   ScreenerResultsResponse,
 } from "../types/screener";
 
-export async function fetchScreenerPresets(): Promise<ScreenerPresetsResponse> {
-  const res = await fetch("/invest/api/screener/presets", { credentials: "include" });
+export async function fetchScreenerPresets(
+  market: ScreenerMarket = "kr",
+): Promise<ScreenerPresetsResponse> {
+  const q = new URLSearchParams({ market });
+  const res = await fetch(`/invest/api/screener/presets?${q}`, { credentials: "include" });
   if (!res.ok) throw new Error(`screener/presets ${res.status}`);
   return res.json();
 }
 
 export async function fetchScreenerResults(
   presetId: string,
-  market: Extract<ScreenerMarket, "kr" | "us"> = "kr",
+  market: ScreenerMarket = "kr",
 ): Promise<ScreenerResultsResponse> {
   const q = new URLSearchParams({ preset: presetId, market });
   const res = await fetch(`/invest/api/screener/results?${q}`, { credentials: "include" });

--- a/frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx
@@ -27,14 +27,18 @@ function screenerErrorMessage(error: unknown): string {
 export function DesktopScreenerPage() {
   const [presets, setPresets] = useState<ScreenerPresetsResponse | undefined>();
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [selectedMarket, setSelectedMarket] = useState<Extract<ScreenerMarket, "kr" | "us">>("kr");
+  const [selectedMarket, setSelectedMarket] = useState<ScreenerMarket>("kr");
   const [results, setResults] = useState<ScreenerResultsResponse | undefined>();
   const [err, setErr] = useState<string | undefined>();
   const [modalOpen, setModalOpen] = useState(false);
 
   useEffect(() => {
     let cancel = false;
-    fetchScreenerPresets()
+    setErr(undefined);
+    setPresets(undefined);
+    setSelectedId(null);
+    setResults(undefined);
+    fetchScreenerPresets(selectedMarket)
       .then((r) => {
         if (cancel) return;
         setErr(undefined);
@@ -43,7 +47,7 @@ export function DesktopScreenerPage() {
       })
       .catch((e) => !cancel && setErr(screenerErrorMessage(e)));
     return () => { cancel = true; };
-  }, []);
+  }, [selectedMarket]);
 
   useEffect(() => {
     if (!selectedId) return;
@@ -59,6 +63,14 @@ export function DesktopScreenerPage() {
       .catch((e) => !cancel && setErr(screenerErrorMessage(e)));
     return () => { cancel = true; };
   }, [selectedId, selectedMarket]);
+
+  const handleMarketChange = (market: ScreenerMarket) => {
+    if (market === selectedMarket) return;
+    setPresets(undefined);
+    setSelectedId(null);
+    setResults(undefined);
+    setSelectedMarket(market);
+  };
 
   return (
     <DesktopShell
@@ -76,7 +88,7 @@ export function DesktopScreenerPage() {
               type="button"
               className={selectedMarket === "kr" ? "is-active" : ""}
               aria-pressed={selectedMarket === "kr"}
-              onClick={() => setSelectedMarket("kr")}
+              onClick={() => handleMarketChange("kr")}
             >
               국내
             </button>
@@ -84,9 +96,17 @@ export function DesktopScreenerPage() {
               type="button"
               className={selectedMarket === "us" ? "is-active" : ""}
               aria-pressed={selectedMarket === "us"}
-              onClick={() => setSelectedMarket("us")}
+              onClick={() => handleMarketChange("us")}
             >
               미국
+            </button>
+            <button
+              type="button"
+              className={selectedMarket === "crypto" ? "is-active" : ""}
+              aria-pressed={selectedMarket === "crypto"}
+              onClick={() => handleMarketChange("crypto")}
+            >
+              가상자산
             </button>
           </div>
           {err && <div style={{ color: "var(--danger)", marginBottom: 12 }}>오류: {err}</div>}

--- a/tests/test_invest_screener_presets.py
+++ b/tests/test_invest_screener_presets.py
@@ -84,3 +84,37 @@ def test_consecutive_gainers_chip_says_5_days() -> None:
     assert preset is not None
     chip_details = [c.detail for c in preset.filterChips if c.detail]
     assert any("5일 연속 상승" in d for d in chip_details)
+
+
+@pytest.mark.unit
+def test_crypto_preset_definitions_are_crypto_scoped() -> None:
+    presets = preset_definitions("crypto")
+
+    assert [p.id for p in presets] == [
+        "crypto_high_volume",
+        "crypto_oversold",
+        "crypto_momentum",
+    ]
+    assert all(p.market == "crypto" for p in presets)
+    assert all(p.filterChips[0].label == "가상자산" for p in presets)
+
+
+@pytest.mark.unit
+def test_crypto_screening_filters_are_read_only_market_filters() -> None:
+    high_volume = screening_filters_for("crypto_high_volume", "crypto")
+    oversold = screening_filters_for("crypto_oversold", "crypto")
+    momentum = screening_filters_for("crypto_momentum", "crypto")
+
+    assert high_volume == {
+        "market": "crypto",
+        "sort_by": "volume",
+        "sort_order": "desc",
+        "limit": 20,
+    }
+    assert oversold["market"] == "crypto"
+    assert oversold["sort_by"] == "rsi"
+    assert oversold["max_rsi"] == pytest.approx(35.0)
+    assert momentum["market"] == "crypto"
+    assert momentum["sort_by"] == "change_rate"
+    assert screening_filters_for("consecutive_gainers", "crypto") == {}
+    assert screening_filters_for("crypto_high_volume", "kr") == {}

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -224,6 +224,74 @@ async def test_build_screener_results_forwards_us_market_and_formats_us_labels()
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_presets_returns_crypto_presets() -> None:
+    resp = build_screener_presets("crypto")
+
+    assert resp.selectedPresetId == "crypto_high_volume"
+    assert [p.id for p in resp.presets] == [
+        "crypto_high_volume",
+        "crypto_oversold",
+        "crypto_momentum",
+    ]
+    assert all(p.market == "crypto" for p in resp.presets)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_forwards_crypto_market_and_formats_crypto_labels() -> (
+    None
+):
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "KRW-BTC",
+                    "name": "Bitcoin",
+                    "market": "crypto",
+                    "category": "Crypto",
+                    "market_cap_usd": 2_100_000_000_000,
+                    "current_price": 150_000_000,
+                    "change_rate": 2.5,
+                    "change_amount": 1_250_000,
+                    "trade_amount_24h": 120_000_000_000,
+                }
+            ],
+            "warnings": [],
+        }
+    )
+    resolver = _FakeResolver(watched={("crypto", "KRW-BTC")})
+
+    resp = await build_screener_results(
+        preset_id="crypto_high_volume",
+        screening_service=fake_screening,
+        resolver=resolver,
+        market="crypto",
+    )
+
+    fake_screening.list_screening.assert_awaited_once()
+    assert fake_screening.list_screening.await_args.kwargs == {
+        "market": "crypto",
+        "sort_by": "volume",
+        "sort_order": "desc",
+        "limit": 20,
+    }
+    row = resp.results[0]
+    assert resp.presetId == "crypto_high_volume"
+    assert row.market == "crypto"
+    assert row.symbol == "KRW-BTC"
+    assert row.name == "Bitcoin"
+    assert row.priceLabel == "150,000,000원"
+    assert row.changeAmountLabel == "+1,250,000원"
+    assert row.marketCapLabel == "$2.10T"
+    assert row.volumeLabel == "120,000,000,000"
+    assert row.metricValueLabel == "120,000,000,000"
+    assert row.isWatched is True
+    assert resolver.calls == [("crypto", "KRW-BTC")]
+
+
+@pytest.mark.unit
 def test_calculate_consecutive_up_days_counts_latest_streak() -> None:
     assert screener_service.calculate_consecutive_up_days([100, 101, 102, 103]) == 3
     assert (


### PR DESCRIPTION
## Summary
- add `market=crypto` screener preset support for the `/invest` view-model read path
- map crypto screener rows from the existing read-only tvscreener/Upbit enrichment contract into desktop screener cards/table rows
- expose crypto source/freshness labels in the frontend screener market selector and tests

## Safety
- Read-only `/invest` GET/API and UI wiring only
- No broker, order, watch, order-intent, scheduler, backfill, or production DB mutations
- No Upbit/KIS/Alpaca order submit/cancel/modify calls

## Verification
- `pytest -q tests/test_invest_screener_presets.py tests/test_invest_view_model_screener_service.py tests/test_invest_view_model_safety.py` (51 passed, 2 warnings)
- `ruff check app/routers/invest_api.py app/services/invest_view_model/screener_presets.py app/services/invest_view_model/screener_service.py tests/test_invest_screener_presets.py tests/test_invest_view_model_screener_service.py`
- `cd frontend/invest && npm test -- --run src/__tests__/DesktopScreenerPage.test.tsx` (5 passed)
- `cd frontend/invest && npm run typecheck`
- `git diff --check`
- Safety grep for broker/order/watch/order-intent/scheduler/backfill/secret patterns: no matches

Closes ROB-224


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Cryptocurrency market support added to screener with dedicated presets
* Market selector expanded to include crypto option (KR, US, Crypto)
* Implemented crypto-specific formatting for prices, 24-hour trade volumes, and performance metrics
* New crypto screener presets available with specialized filtering options for digital assets

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/816)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->