### PR TITLE
feat(invest): add FX macro dashboard page

### DIFF
--- a/frontend/invest/src/__tests__/DesktopMarketPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopMarketPage.test.tsx
@@ -83,6 +83,7 @@ test("renders market dashboard sections and read-only copy", async () => {
   expect(screen.getByRole("heading", { name: "시장" })).toBeInTheDocument();
   expect(screen.getByText("2,875.25")).toBeInTheDocument();
   expect(screen.getByText("가상자산 시장")).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: "FX·매크로 상세" })).toHaveAttribute("href", "/invest/market/fx");
   expect(screen.getAllByText(/kimchi_premium: timeout/).length).toBeGreaterThan(0);
   expect(screen.getByText(/주문·매매 API를 호출하지 않습니다/)).toBeInTheDocument();
 });

--- a/frontend/invest/src/__tests__/FxMacroPage.test.tsx
+++ b/frontend/invest/src/__tests__/FxMacroPage.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, expect, test, vi } from "vitest";
+
+import { FxMacroRoute } from "../pages/desktop/FxMacroPage";
+import * as fxApi from "../api/fxDashboard";
+import type { FxDashboardResponse } from "../types/fxDashboard";
+
+const FX_PAYLOAD: FxDashboardResponse = {
+  asOf: "2026-05-13T03:00:00Z",
+  dataState: "partial",
+  warnings: ["global_dollar: partial"],
+  disclaimers: [
+    { code: "not_confirmed_intervention", severity: "caution", textKo: "당국 개입은 확인되지 않았으며 방어성 호가/경계 신호로만 봅니다." },
+  ],
+  sourceFreshness: [
+    { source: "naver_market_index", label: "Naver USD/KRW", dataState: "fresh", updatedAt: "2026-05-13T03:00:00Z", staleAfterMinutes: 20, warning: null },
+  ],
+  usdKrw: {
+    symbol: "FX_USDKRW",
+    label: "USD/KRW",
+    value: 1450.25,
+    spot: 1450.25,
+    change: 2.1,
+    changePct: 0.15,
+    tone: "up",
+    updatedAt: "2026-05-13T03:00:00Z",
+    dataState: "fresh",
+    source: "naver",
+  },
+  thresholds: [
+    { level: 1450, label: "1450원 경계", distancePct: 0.02, state: "near" },
+  ],
+  defenseSignal: {
+    state: "watch",
+    score: 42,
+    confidence: "medium",
+    labelKo: "당국 경계 가능성",
+    summaryKo: "1450원 부근 방어성 호가 가능성은 사후 확인이 필요합니다.",
+    reasonsKo: ["원화 약세와 달러 강세가 동시에 관찰됩니다."],
+    evidence: [
+      { kind: "quote", labelKo: "USD/KRW", value: "1450.25", source: "naver", dataState: "fresh" },
+    ],
+    notConfirmedIntervention: true,
+    needsAfterVerification: true,
+  },
+  globalDollar: [
+    { symbol: "DX-Y.NYB", label: "DXY", value: 105.2, changePct: 0.22, dataState: "partial", source: "yahoo" },
+  ],
+  krwCrosses: [
+    { symbol: "FX_CNYKRW", label: "CNY/KRW", value: 200.1, changePct: -0.1, dataState: "fresh", source: "naver" },
+  ],
+  foreignFlow: { dataState: "missing", summaryKo: "외국인 수급은 아직 연결되지 않았습니다.", items: [] },
+  news: { dataState: "partial", items: [], warning: "FX 뉴스 연결 대기" },
+  events: { dataState: "missing", items: [], warning: "매크로 일정 연결 대기" },
+  afterVerification: { dataState: "missing", officialEvidence: [], dealerEvidence: [], ndfEvidence: [], summaryKo: "공식/딜러/NDF 사후 검증은 아직 필요합니다." },
+};
+
+function wrap(ui: React.ReactElement) {
+  return <MemoryRouter basename="/invest" initialEntries={["/invest/market/fx"]}>{ui}</MemoryRouter>;
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 1280 });
+  vi.spyOn(fxApi, "fetchFxDashboard").mockResolvedValue(FX_PAYLOAD);
+});
+
+test("renders FX macro detail page with cautious read-only state", async () => {
+  render(wrap(<FxMacroRoute />));
+
+  await waitFor(() => expect(screen.getByText("1,450.25")).toBeInTheDocument());
+  expect(screen.getByRole("heading", { name: "FX·매크로" })).toBeInTheDocument();
+  expect(screen.getByText("당국 경계 가능성")).toBeInTheDocument();
+  expect(screen.getByText(/1450원 부근 방어성 호가 가능성/)).toBeInTheDocument();
+  expect(screen.getByText(/당국 개입은 확인되지 않았으며/)).toBeInTheDocument();
+  expect(screen.getByText("Naver USD/KRW")).toBeInTheDocument();
+  expect(screen.getByText(/주문·매매 API, watch\/order intent, scheduler activation을 호출하지 않습니다/)).toBeInTheDocument();
+
+  [
+    ["개입", "확정"],
+    ["정부", "개입", "확정"],
+    ["당국", "개입", "확정"],
+    ["정부가", "방어"],
+    ["당국이", "방어"],
+  ]
+    .map((parts) => parts.join(" "))
+    .forEach((phrase) => {
+      expect(screen.queryByText(phrase)).not.toBeInTheDocument();
+    });
+});
+
+test("shows friendly FX error without raw endpoint or status", async () => {
+  vi.spyOn(fxApi, "fetchFxDashboard").mockRejectedValue(new Error("/invest/api/market/fx/dashboard 503"));
+
+  render(wrap(<FxMacroRoute />));
+
+  await waitFor(() => expect(screen.getByText(/FX·매크로 데이터를 일시적으로 불러오지 못했습니다/)).toBeInTheDocument());
+  expect(screen.queryByText(/\/invest\/api\/market\/fx\/dashboard/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/503/)).not.toBeInTheDocument();
+});

--- a/frontend/invest/src/__tests__/MarketStrip.test.tsx
+++ b/frontend/invest/src/__tests__/MarketStrip.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { expect, test } from "vitest";
+
+import { MarketStrip, marketDashboardToStripItems } from "../components/home/MarketStrip";
+import type { MarketDashboardResponse } from "../types/marketDashboard";
+
+const MARKET_PAYLOAD: MarketDashboardResponse = {
+  asOf: "2026-05-13T03:00:00Z",
+  state: "partial",
+  warnings: [],
+  notes: [],
+  sections: [
+    {
+      id: "kr_market",
+      title: "국내 시장",
+      subtitle: "국내 지수",
+      reference: "naver",
+      state: "fresh",
+      sourceOfTruth: "get_market_index",
+      updatedAt: "2026-05-13T03:00:00Z",
+      staleAfterMinutes: 20,
+      warnings: [],
+      notes: [],
+      metrics: [
+        { label: "코스피", value: "2,900.00", change: 3, changePct: 0.1, tone: "up", source: "naver", stale: false },
+      ],
+    },
+    {
+      id: "fx_macro",
+      title: "FX·매크로",
+      subtitle: "환율/매크로",
+      reference: "fx_dashboard",
+      state: "partial",
+      sourceOfTruth: "invest_fx_dashboard",
+      updatedAt: "2026-05-13T03:00:00Z",
+      staleAfterMinutes: 20,
+      warnings: ["partial"],
+      notes: ["read-only"],
+      metrics: [
+        { label: "USD/KRW", value: "1,450.25", change: 2.1, changePct: 0.15, tone: "up", source: "naver", stale: false },
+      ],
+    },
+  ],
+};
+
+test("market strip includes concise FX macro entry linking to detail page", () => {
+  const items = marketDashboardToStripItems(MARKET_PAYLOAD);
+  expect(items.some((item) => item.name === "FX·매크로 USD/KRW" && item.href === "/market/fx")).toBe(true);
+
+  render(
+    <MemoryRouter basename="/invest" initialEntries={["/invest/"]}>
+      <MarketStrip items={items} />
+    </MemoryRouter>,
+  );
+
+  expect(screen.getByRole("link", { name: /FX·매크로 USD\/KRW/ })).toHaveAttribute("href", "/invest/market/fx");
+  expect(screen.getByText("상세 보기")).toBeInTheDocument();
+});

--- a/frontend/invest/src/__tests__/fxDashboard.api.test.ts
+++ b/frontend/invest/src/__tests__/fxDashboard.api.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, expect, test, vi } from "vitest";
+
+import { fetchFxDashboard } from "../api/fxDashboard";
+
+const PAYLOAD = {
+  asOf: "2026-05-13T03:00:00Z",
+  dataState: "fresh",
+  warnings: [],
+  disclaimers: [],
+  sourceFreshness: [],
+  usdKrw: { symbol: "FX_USDKRW", label: "USD/KRW", value: 1450.25, spot: 1450.25, change: 2.1, changePct: 0.15, tone: "up", updatedAt: "2026-05-13T03:00:00Z", dataState: "fresh", source: "naver" },
+  thresholds: [],
+  defenseSignal: { state: "watch", score: 35, confidence: "medium", labelKo: "경계", summaryKo: "방어성 호가 가능성은 참고 신호입니다.", reasonsKo: [], evidence: [], notConfirmedIntervention: true, needsAfterVerification: true },
+  globalDollar: [],
+  krwCrosses: [],
+  foreignFlow: { dataState: "missing", summaryKo: "수급 데이터 없음", items: [] },
+  news: { dataState: "missing", items: [], warning: "뉴스 데이터 없음" },
+  events: { dataState: "missing", items: [], warning: "일정 데이터 없음" },
+  afterVerification: { dataState: "missing", officialEvidence: [], dealerEvidence: [], ndfEvidence: [], summaryKo: "사후 검증 필요" },
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("fetchFxDashboard reads the read-only FX dashboard endpoint", async () => {
+  const controller = new AbortController();
+  const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify(PAYLOAD), { status: 200, headers: { "content-type": "application/json" } }),
+  );
+
+  await expect(fetchFxDashboard(controller.signal)).resolves.toEqual(PAYLOAD);
+  expect(fetchMock).toHaveBeenCalledWith("/invest/api/market/fx/dashboard", {
+    credentials: "include",
+    signal: controller.signal,
+  });
+});
+
+test("fetchFxDashboard raises a scrubbed endpoint/status error", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 503 }));
+
+  await expect(fetchFxDashboard()).rejects.toThrow("/invest/api/market/fx/dashboard 503");
+});

--- a/frontend/invest/src/components/fx/FxDashboardCards.tsx
+++ b/frontend/invest/src/components/fx/FxDashboardCards.tsx
@@ -1,0 +1,297 @@
+import { Link } from "react-router-dom";
+import { Card } from "../../ds";
+import type {
+  DefenseSignalConfidence,
+  FxDashboardAfterVerification,
+  FxDashboardCollectionItem,
+  FxDashboardDataState,
+  FxDashboardDefenseSignal,
+  FxDashboardDisclaimer,
+  FxDashboardEventsSection,
+  FxDashboardForeignFlowSection,
+  FxDashboardQuoteMetric,
+  FxDashboardResponse,
+  FxDashboardSourceFreshness,
+  FxDashboardThreshold,
+  FxDashboardTone,
+} from "../../types/fxDashboard";
+
+const STATE_LABEL: Record<FxDashboardDataState, string> = {
+  fresh: "정상",
+  partial: "부분",
+  missing: "없음",
+  stale: "stale",
+  error: "오류",
+};
+
+const STATE_COLOR: Record<FxDashboardDataState, string> = {
+  fresh: "#16a34a",
+  partial: "#ca8a04",
+  missing: "#dc2626",
+  stale: "#8b5cf6",
+  error: "#b91c1c",
+};
+
+const TONE_COLOR: Record<FxDashboardTone, string> = {
+  up: "var(--gain)",
+  down: "var(--loss)",
+  flat: "var(--flat)",
+  unknown: "var(--fg-3)",
+};
+
+const TONE_ARROW: Record<FxDashboardTone, string> = {
+  up: "▲",
+  down: "▼",
+  flat: "·",
+  unknown: "—",
+};
+
+const CONFIDENCE_LABEL: Record<DefenseSignalConfidence, string> = {
+  low: "낮음",
+  medium: "중간",
+  high: "높음",
+};
+
+function formatNumber(value?: number | null, digits = 2) {
+  if (value == null || Number.isNaN(value)) return "—";
+  return value.toLocaleString("ko-KR", { maximumFractionDigits: digits });
+}
+
+function formatSigned(value?: number | null, suffix = "") {
+  if (value == null || Number.isNaN(value)) return "—";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toLocaleString("ko-KR", { maximumFractionDigits: 2 })}${suffix}`;
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString("ko-KR", { dateStyle: "short", timeStyle: "short" });
+}
+
+export function FxStatePill({ state }: { state: FxDashboardDataState }) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        borderRadius: 999,
+        padding: "3px 8px",
+        fontSize: 12,
+        fontWeight: 800,
+        color: "white",
+        background: STATE_COLOR[state],
+        whiteSpace: "nowrap",
+      }}
+    >
+      {STATE_LABEL[state]}
+    </span>
+  );
+}
+
+export function FxToneValue({ value, changePct, tone }: { value?: number | null; changePct?: number | null; tone: FxDashboardTone }) {
+  const color = TONE_COLOR[tone];
+  return (
+    <div style={{ display: "grid", gap: 5 }}>
+      <div style={{ fontSize: 28, fontWeight: 900, letterSpacing: "-0.04em", fontFeatureSettings: '"tnum"' }}>
+        {formatNumber(value ?? null)}
+      </div>
+      <div style={{ color, fontWeight: 800, fontSize: 13, fontFeatureSettings: '"tnum"' }}>
+        <span style={{ marginRight: 5 }}>{TONE_ARROW[tone]}</span>
+        {formatSigned(changePct, "%")}
+      </div>
+    </div>
+  );
+}
+
+export function FxSourceFreshnessList({ sources }: { sources: FxDashboardSourceFreshness[] }) {
+  return (
+    <Card>
+      <h2 style={{ margin: 0, fontSize: 19, letterSpacing: "-0.03em" }}>소스 freshness</h2>
+      <div style={{ display: "grid", gap: 10, marginTop: 14 }}>
+        {sources.map((source) => (
+          <div key={source.source} style={{ display: "flex", gap: 12, justifyContent: "space-between", alignItems: "start", borderBottom: "1px solid var(--divider)", paddingBottom: 10 }}>
+            <div>
+              <div style={{ fontWeight: 900 }}>{source.label}</div>
+              <div style={{ color: "var(--fg-3)", fontSize: 12, marginTop: 3 }}>
+                {source.source} · 갱신 {formatDate(source.updatedAt)}
+                {source.staleAfterMinutes != null ? ` · stale 기준 ${source.staleAfterMinutes}분` : ""}
+              </div>
+              {source.warning && <div style={{ color: "var(--warn)", fontSize: 12, marginTop: 4 }}>⚠ {source.warning}</div>}
+            </div>
+            <FxStatePill state={source.dataState} />
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+export function FxQuoteCard({ metric }: { metric: FxDashboardQuoteMetric }) {
+  return (
+    <Card>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "start" }}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: 19, letterSpacing: "-0.03em" }}>{metric.label ?? metric.symbol}</h2>
+          <div style={{ color: "var(--fg-3)", fontSize: 12, marginTop: 4 }}>
+            {metric.symbol} · {metric.source} · {formatDate(metric.updatedAt)}
+          </div>
+        </div>
+        {metric.dataState && <FxStatePill state={metric.dataState} />}
+      </div>
+      <div style={{ marginTop: 14 }}>
+        <FxToneValue value={metric.value ?? metric.spot} changePct={metric.changePct} tone={metric.tone} />
+        {metric.change != null && <div style={{ color: "var(--fg-3)", fontSize: 12, marginTop: 5 }}>변동폭 {formatSigned(metric.change)}</div>}
+      </div>
+    </Card>
+  );
+}
+
+export function FxThresholdCard({ thresholds }: { thresholds: FxDashboardThreshold[] }) {
+  return (
+    <Card>
+      <h2 style={{ margin: 0, fontSize: 19, letterSpacing: "-0.03em" }}>USD/KRW 경계값</h2>
+      <div style={{ display: "grid", gap: 10, marginTop: 14 }}>
+        {thresholds.map((threshold) => (
+          <div key={`${threshold.level}-${threshold.label}`} style={{ display: "flex", justifyContent: "space-between", gap: 12, border: "1px solid var(--divider)", borderRadius: 12, padding: 12 }}>
+            <div>
+              <div style={{ fontWeight: 900 }}>{threshold.label}</div>
+              <div style={{ color: "var(--fg-3)", fontSize: 12, marginTop: 3 }}>{threshold.level.toLocaleString("ko-KR")}</div>
+            </div>
+            <div style={{ textAlign: "right", fontSize: 12, color: "var(--fg-2)", fontWeight: 800 }}>
+              <div>{formatSigned(threshold.distancePct, "%")}</div>
+              <div style={{ color: "var(--fg-3)", marginTop: 3 }}>{threshold.state}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+export function FxDefenseSignalCard({ signal, disclaimers }: { signal: FxDashboardDefenseSignal; disclaimers: FxDashboardDisclaimer[] }) {
+  return (
+    <Card>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "start", flexWrap: "wrap" }}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: 19, letterSpacing: "-0.03em" }}>{signal.labelKo}</h2>
+          <p style={{ margin: "6px 0 0", color: "var(--fg-2)", fontSize: 13 }}>{signal.summaryKo}</p>
+        </div>
+        <div style={{ textAlign: "right", fontSize: 12, color: "var(--fg-3)" }}>
+          <div style={{ fontSize: 22, fontWeight: 900, color: "var(--fg-1)" }}>{signal.score}</div>
+          <div>신뢰도 {CONFIDENCE_LABEL[signal.confidence]}</div>
+        </div>
+      </div>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginTop: 12 }}>
+        {signal.notConfirmedIntervention && <span style={badgeStyle}>개입 미확정</span>}
+        {signal.needsAfterVerification && <span style={badgeStyle}>사후 검증 필요</span>}
+        <span style={badgeStyle}>읽기 전용</span>
+      </div>
+      {signal.reasonsKo.length > 0 && (
+        <ul style={{ margin: "14px 0 0", paddingLeft: 18, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.65 }}>
+          {signal.reasonsKo.map((reason) => <li key={reason}>{reason}</li>)}
+        </ul>
+      )}
+      {signal.evidence.length > 0 && (
+        <div style={{ display: "grid", gap: 8, marginTop: 14 }}>
+          {signal.evidence.map((item) => (
+            <div key={`${item.kind}-${item.labelKo}`} style={{ display: "flex", justifyContent: "space-between", gap: 10, fontSize: 12, color: "var(--fg-2)" }}>
+              <span>{item.labelKo}{item.value ? ` · ${item.value}` : ""}</span>
+              <FxStatePill state={item.dataState} />
+            </div>
+          ))}
+        </div>
+      )}
+      {disclaimers.length > 0 && (
+        <div style={{ display: "grid", gap: 6, marginTop: 14, color: "var(--warn)", fontSize: 12 }}>
+          {disclaimers.map((item) => <div key={item.code}>⚠ {item.textKo}</div>)}
+        </div>
+      )}
+    </Card>
+  );
+}
+
+export function FxCollectionCard({ title, items }: { title: string; items: FxDashboardCollectionItem[] }) {
+  return (
+    <Card>
+      <h2 style={{ margin: 0, fontSize: 19, letterSpacing: "-0.03em" }}>{title}</h2>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 10, marginTop: 14 }}>
+        {items.map((item) => (
+          <div key={`${title}-${item.symbol}`} style={{ border: "1px solid var(--divider)", borderRadius: 12, padding: 12, display: "grid", gap: 6 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", gap: 8 }}>
+              <div>
+                <div style={{ fontWeight: 900 }}>{item.label}</div>
+                <div style={{ color: "var(--fg-3)", fontSize: 11 }}>{item.symbol} · {item.source}</div>
+              </div>
+              <FxStatePill state={item.dataState} />
+            </div>
+            <div style={{ fontSize: 20, fontWeight: 900 }}>{formatNumber(item.value)}</div>
+            <div style={{ color: item.changePct != null && item.changePct < 0 ? "var(--loss)" : "var(--gain)", fontSize: 12, fontWeight: 800 }}>
+              {formatSigned(item.changePct, "%")}
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+export function FxDeferredSectionsCard({ foreignFlow, news, events, afterVerification }: {
+  foreignFlow: FxDashboardForeignFlowSection;
+  news: { dataState: FxDashboardDataState; warning?: string | null; items: { title: string; source: string; publishedAt?: string | null }[] };
+  events: FxDashboardEventsSection;
+  afterVerification: FxDashboardAfterVerification;
+}) {
+  const rows = [
+    { label: "외국인 수급", state: foreignFlow.dataState, text: foreignFlow.summaryKo },
+    { label: "뉴스", state: news.dataState, text: news.warning ?? (news.items.length > 0 ? news.items.map((item) => item.title).join(" · ") : "관련 뉴스가 아직 충분하지 않습니다.") },
+    { label: "일정", state: events.dataState, text: events.warning ?? (events.items.length > 0 ? events.items.map((item) => item.title).join(" · ") : "관련 일정이 아직 충분하지 않습니다.") },
+    { label: "사후 검증", state: afterVerification.dataState, text: afterVerification.summaryKo },
+  ];
+  return (
+    <Card>
+      <h2 style={{ margin: 0, fontSize: 19, letterSpacing: "-0.03em" }}>부분/사후 검증 상태</h2>
+      <div style={{ display: "grid", gap: 10, marginTop: 14 }}>
+        {rows.map((row) => (
+          <div key={row.label} style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "start", border: "1px solid var(--divider)", borderRadius: 12, padding: 12 }}>
+            <div>
+              <div style={{ fontWeight: 900 }}>{row.label}</div>
+              <div style={{ color: "var(--fg-2)", fontSize: 12, marginTop: 4 }}>{row.text}</div>
+            </div>
+            <FxStatePill state={row.state} />
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}
+
+export function FxMiniCard({ data }: { data: FxDashboardResponse }) {
+  return (
+    <Link to="/market/fx" style={{ textDecoration: "none", color: "inherit" }}>
+      <Card style={{ display: "grid", gap: 10 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "start" }}>
+          <div>
+            <div style={{ fontWeight: 900 }}>FX·매크로 경고</div>
+            <div style={{ color: "var(--fg-3)", fontSize: 12, marginTop: 3 }}>참고용 · 매매/주문 없음</div>
+          </div>
+          <FxStatePill state={data.dataState} />
+        </div>
+        <FxToneValue value={data.usdKrw.value ?? data.usdKrw.spot} changePct={data.usdKrw.changePct} tone={data.usdKrw.tone} />
+        <div style={{ color: "var(--fg-2)", fontSize: 12 }}>{data.defenseSignal.summaryKo}</div>
+        <div style={{ color: "var(--accent)", fontWeight: 900, fontSize: 12 }}>상세 보기 →</div>
+      </Card>
+    </Link>
+  );
+}
+
+const badgeStyle = {
+  borderRadius: 999,
+  padding: "4px 8px",
+  border: "1px solid var(--border)",
+  background: "var(--surface-2)",
+  color: "var(--fg-2)",
+  fontSize: 12,
+  fontWeight: 800,
+};

--- a/frontend/invest/src/components/home/MarketStrip.tsx
+++ b/frontend/invest/src/components/home/MarketStrip.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { Sparkline } from "../../ds";
 import type { MarketDashboardResponse, MarketDashboardTone } from "../../types/marketDashboard";
 
@@ -8,6 +9,7 @@ export interface MarketStripItem {
   pct: number;
   direction: "up" | "down" | "flat";
   spark?: number[];
+  href?: string;
 }
 
 const COLOR: Record<MarketStripItem["direction"], string> = {
@@ -28,18 +30,20 @@ function toDirection(tone: MarketDashboardTone): MarketStripItem["direction"] {
 
 export function marketDashboardToStripItems(data: MarketDashboardResponse | null): MarketStripItem[] {
   if (!data) return [];
-  const sections = ["kr_market", "global_indices"];
+  const sections = ["kr_market", "global_indices", "fx_macro"];
   return data.sections
     .filter((section) => sections.includes(section.id))
-    .flatMap((section) => section.metrics)
-    .slice(0, 4)
-    .map((metric) => ({
-      name: metric.label,
-      value: metric.value ?? "—",
-      changeLabel: metric.change != null ? `${metric.change >= 0 ? "+" : ""}${metric.change.toLocaleString()}` : "변동 정보 없음",
-      pct: metric.changePct ?? 0,
-      direction: toDirection(metric.tone),
-    }));
+    .flatMap((section) =>
+      section.metrics.map((metric) => ({
+        name: section.id === "fx_macro" ? `FX·매크로 ${metric.label}` : metric.label,
+        value: metric.value ?? "—",
+        changeLabel: metric.change != null ? `${metric.change >= 0 ? "+" : ""}${metric.change.toLocaleString()}` : "변동 정보 없음",
+        pct: metric.changePct ?? 0,
+        direction: toDirection(metric.tone),
+        href: section.id === "fx_macro" ? "/market/fx" : undefined,
+      })),
+    )
+    .slice(0, 5);
 }
 
 export function MarketStrip({ items }: { items: MarketStripItem[] }) {
@@ -71,15 +75,15 @@ export function MarketStrip({ items }: { items: MarketStripItem[] }) {
     <div data-testid="market-strip" style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 10 }}>
       {items.map((m) => {
         const c = COLOR[m.direction];
-        return (
+        const card = (
           <div
-            key={m.name}
             style={{
               padding: 12,
               background: "var(--surface)",
               border: "1px solid var(--border)",
               borderRadius: 14,
               boxShadow: "var(--shadow-1)",
+              minHeight: 92,
             }}
           >
             <div style={{ fontSize: 12, fontWeight: 600, color: "var(--fg-2)" }}>{m.name}</div>
@@ -89,12 +93,20 @@ export function MarketStrip({ items }: { items: MarketStripItem[] }) {
               {m.changeLabel} · {m.pct >= 0 ? "+" : ""}
               {m.pct.toFixed(2)}%
             </div>
+            {m.href && <div style={{ color: "var(--accent)", fontWeight: 900, fontSize: 12, marginTop: 6 }}>상세 보기</div>}
             {m.spark && m.spark.length > 1 && (
               <div style={{ marginTop: 6 }}>
                 <Sparkline points={m.spark} color={c} width={200} height={28} />
               </div>
             )}
           </div>
+        );
+        return m.href ? (
+          <Link key={m.name} to={m.href} style={{ textDecoration: "none", color: "inherit" }}>
+            {card}
+          </Link>
+        ) : (
+          <div key={m.name}>{card}</div>
         );
       })}
     </div>

--- a/frontend/invest/src/hooks/useFxDashboard.ts
+++ b/frontend/invest/src/hooks/useFxDashboard.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import { fetchFxDashboard } from "../api/fxDashboard";
+import type { FxDashboardResponse } from "../types/fxDashboard";
+
+type State =
+  | { status: "loading" }
+  | { status: "ready"; data: FxDashboardResponse }
+  | { status: "error"; message: string };
+
+export function useFxDashboard() {
+  const [state, setState] = useState<State>({ status: "loading" });
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState({ status: "loading" });
+    fetchFxDashboard(controller.signal)
+      .then((data) => setState({ status: "ready", data }))
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        setState({ status: "error", message: String(err?.message ?? err) });
+      });
+    return () => controller.abort();
+  }, [nonce]);
+
+  return { state, reload: () => setNonce((n) => n + 1) };
+}

--- a/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
@@ -73,6 +73,12 @@ const NAV_CARDS: NavCard[] = [
     icon: <Icon name="calendar" size={20} />,
   },
   {
+    to: "/market/fx",
+    label: "FX·매크로",
+    desc: "환율 경고 및 사후 검증 참고",
+    icon: <Icon name="chart" size={20} />,
+  },
+  {
     to: "/screener",
     label: "골라보기",
     desc: "조건별 종목 필터링",

--- a/frontend/invest/src/pages/desktop/DesktopMarketPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopMarketPage.tsx
@@ -133,13 +133,21 @@ export function DesktopMarketPage() {
                 국내 지수, 글로벌 지수, 환율/매크로, crypto read-only 스냅샷입니다.
               </p>
             </div>
-            <button
-              type="button"
-              onClick={reload}
-              style={{ padding: "8px 12px", borderRadius: 10, border: "1px solid var(--border)", background: "var(--surface)", color: "var(--fg-1)", fontWeight: 800, cursor: "pointer" }}
-            >
-              새로고침
-            </button>
+            <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+              <Link
+                to="/market/fx"
+                style={{ padding: "8px 12px", borderRadius: 10, border: "1px solid var(--border)", background: "var(--surface)", color: "var(--fg-1)", fontWeight: 800, textDecoration: "none" }}
+              >
+                FX·매크로 상세
+              </Link>
+              <button
+                type="button"
+                onClick={reload}
+                style={{ padding: "8px 12px", borderRadius: 10, border: "1px solid var(--border)", background: "var(--surface)", color: "var(--fg-1)", fontWeight: 800, cursor: "pointer" }}
+              >
+                새로고침
+              </button>
+            </div>
           </div>
 
           {state.status === "loading" && <Card>시장 데이터를 불러오는 중…</Card>}

--- a/frontend/invest/src/pages/desktop/FxMacroPage.tsx
+++ b/frontend/invest/src/pages/desktop/FxMacroPage.tsx
@@ -1,0 +1,119 @@
+import { Link } from "react-router-dom";
+import { DesktopShell } from "../../desktop/DesktopShell";
+import { Card } from "../../ds";
+import { FxCollectionCard, FxDefenseSignalCard, FxDeferredSectionsCard, FxQuoteCard, FxSourceFreshnessList, FxStatePill, FxThresholdCard } from "../../components/fx/FxDashboardCards";
+import { useFxDashboard } from "../../hooks/useFxDashboard";
+import { useViewport } from "../../hooks/useViewport";
+import type { FxDashboardResponse } from "../../types/fxDashboard";
+
+function Header({ data, onReload }: { data?: FxDashboardResponse | null; onReload: () => void }) {
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "start", flexWrap: "wrap" }}>
+      <div>
+        <h1 style={{ margin: 0, fontSize: 28, letterSpacing: "-0.05em" }}>FX·매크로</h1>
+        <p style={{ margin: "6px 0 0", color: "var(--fg-2)", fontSize: 14 }}>
+          USD/KRW, 글로벌 달러, 원화 교차, 사후 검증 상태를 표시만 합니다.
+        </p>
+        {data && <div style={{ color: "var(--fg-3)", fontSize: 12, marginTop: 6 }}>asOf {data.asOf}</div>}
+      </div>
+      <button
+        type="button"
+        onClick={onReload}
+        style={{ padding: "8px 12px", borderRadius: 10, border: "1px solid var(--border)", background: "var(--surface)", color: "var(--fg-1)", fontWeight: 800, cursor: "pointer" }}
+      >
+        새로고침
+      </button>
+    </div>
+  );
+}
+
+function StatusCard({ data }: { data: FxDashboardResponse }) {
+  return (
+    <Card>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center", flexWrap: "wrap" }}>
+        <div>
+          <div style={{ fontWeight: 900 }}>FX 대시보드 상태</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12, marginTop: 4 }}>
+            공급자 응답은 부분/누락/오류 상태를 숨기지 않고 표시합니다.
+          </div>
+        </div>
+        <FxStatePill state={data.dataState} />
+      </div>
+      {data.warnings.length > 0 && (
+        <div style={{ marginTop: 10, color: "var(--warn)", fontSize: 12 }}>{data.warnings.map((w) => `⚠ ${w}`).join(" · ")}</div>
+      )}
+    </Card>
+  );
+}
+
+function SafetyCard() {
+  return (
+    <Card>
+      <div style={{ fontWeight: 900, marginBottom: 8 }}>읽기 전용 원칙</div>
+      <ul style={{ margin: 0, paddingLeft: 18, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.7 }}>
+        <li>주문·매매 API, watch/order intent, scheduler activation을 호출하지 않습니다.</li>
+        <li>당국 개입은 확정 표현하지 않고 사후 검증 필요 여부만 표시합니다.</li>
+        <li><Link to="/market" style={{ color: "inherit" }}>시장 대시보드</Link>와 동일한 읽기 전용 분석 영역입니다.</li>
+      </ul>
+    </Card>
+  );
+}
+
+function FxContent({ data }: { data: FxDashboardResponse }) {
+  return (
+    <>
+      <StatusCard data={data} />
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))", gap: 16 }}>
+        <FxQuoteCard metric={data.usdKrw} />
+        <FxThresholdCard thresholds={data.thresholds} />
+      </div>
+      <FxDefenseSignalCard signal={data.defenseSignal} disclaimers={data.disclaimers} />
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))", gap: 16 }}>
+        <FxCollectionCard title="글로벌 달러" items={data.globalDollar} />
+        <FxCollectionCard title="원화 교차" items={data.krwCrosses} />
+      </div>
+      <FxSourceFreshnessList sources={data.sourceFreshness} />
+      <FxDeferredSectionsCard
+        foreignFlow={data.foreignFlow}
+        news={data.news}
+        events={data.events}
+        afterVerification={data.afterVerification}
+      />
+    </>
+  );
+}
+
+function FxMain({ mobile = false }: { mobile?: boolean }) {
+  const { state, reload } = useFxDashboard();
+  const data = state.status === "ready" ? state.data : null;
+
+  return (
+    <div style={{ padding: mobile ? 16 : 24, display: "grid", gap: 16, maxWidth: mobile ? 860 : undefined, margin: mobile ? "0 auto" : undefined }}>
+      <Header data={data} onReload={reload} />
+      {state.status === "loading" && <Card>FX·매크로 데이터를 불러오는 중…</Card>}
+      {state.status === "error" && (
+        <Card><span style={{ color: "var(--danger)" }}>FX·매크로 데이터를 일시적으로 불러오지 못했습니다.</span></Card>
+      )}
+      {data && <FxContent data={data} />}
+      {mobile && <SafetyCard />}
+    </div>
+  );
+}
+
+export function FxMacroRoute() {
+  const viewport = useViewport();
+  if (viewport === "mobile") {
+    return (
+      <main data-testid="fx-mobile-page" style={{ minHeight: "100vh", background: "var(--bg)", color: "var(--fg-1)" }}>
+        <FxMain mobile />
+      </main>
+    );
+  }
+
+  return (
+    <DesktopShell
+      center={<FxMain />}
+      right={<SafetyCard />}
+    />
+  );
+}

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -31,6 +31,7 @@ import { CalendarRoute } from "./pages/desktop/DesktopCalendarPage";
 import { CoverageRoute } from "./pages/desktop/DesktopCoveragePage";
 import { DesktopScreenerPage } from "./pages/desktop/DesktopScreenerPage";
 import { DesktopMarketPage } from "./pages/desktop/DesktopMarketPage";
+import { FxMacroRoute } from "./pages/desktop/FxMacroPage";
 import { StockDetailPage } from "./pages/stock-detail/StockDetailPage";
 
 // Static legacy /app/* redirect that preserves any ?search and #hash
@@ -68,6 +69,7 @@ export const router = createBrowserRouter(
     { path: "/calendar", element: <CalendarRoute /> },
     { path: "/coverage", element: <CoverageRoute /> },
     { path: "/market", element: <DesktopMarketPage /> },
+    { path: "/market/fx", element: <FxMacroRoute /> },
     { path: "/screener", element: <DesktopScreenerPage /> },
     { path: "/stocks/:market/:symbol", element: <StockDetailPage /> },
 


### PR DESCRIPTION
## Summary
- Adds read-only `/invest/market/fx` FX macro dashboard route.
- Wires concise FX warning/dashboard cards into `/invest` home and `/invest/market`.
- Covers loading/error/partial-data/source-freshness states with cautious wording.

## Safety
- Read-only UI/API consumption only.
- No broker order submit/cancel/modify.
- No watch/order-intent mutation.
- No production DB writes/backfills or scheduler activation.
- Intervention wording remains cautious; no confirmed government intervention claims.

## Verification
- `git diff --check`
- `cd frontend/invest && npm test -- --run src/__tests__/fxDashboard.api.test.ts src/__tests__/FxMacroPage.test.tsx src/__tests__/DesktopMarketPage.test.tsx src/__tests__/MarketStrip.test.tsx src/__tests__/marketDashboard.api.test.ts src/__tests__/InvestHomeRoute.test.tsx`
- `cd frontend/invest && npm run typecheck`
- `cd frontend/invest && npm run build`
- `pytest tests/test_invest_fx_dashboard.py`

Closes ROB-219


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new FX macro dashboard page accessible via navigation shortcuts and the market page, displaying key FX metrics including quotes, thresholds, defense signals, collections, and source freshness data.
  * Dashboard includes responsive design for mobile and desktop with read-only safety warnings and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/817)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->