### PR TITLE
ROB-227: add crypto insight snapshot adapters

### DIFF
--- a/alembic/versions/20260513_rob227_add_crypto_insight_snapshots.py
+++ b/alembic/versions/20260513_rob227_add_crypto_insight_snapshots.py
@@ -1,0 +1,106 @@
+"""add crypto insight snapshots
+
+Revision ID: 20260513_rob227
+Revises: 20260513_rob222
+Create Date: 2026-05-13 22:30:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260513_rob227"
+down_revision: str | None = "20260513_rob222"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "crypto_insight_snapshots",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, nullable=False),
+        sa.Column("metric", sa.String(length=48), nullable=False),
+        sa.Column("provider", sa.String(length=32), nullable=False),
+        sa.Column("symbol", sa.String(length=32), nullable=True),
+        sa.Column("value", sa.Numeric(24, 10), nullable=True),
+        sa.Column("unit", sa.String(length=16), nullable=True),
+        sa.Column("label", sa.String(length=80), nullable=True),
+        sa.Column("snapshot_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("source_url", sa.Text(), nullable=True),
+        sa.Column("freshness_seconds", sa.Integer(), nullable=True),
+        sa.Column(
+            "raw_payload", postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "uq_crypto_insight_snapshots_global_identity",
+        "crypto_insight_snapshots",
+        ["metric", "provider", "snapshot_at"],
+        unique=True,
+        postgresql_where=sa.text("symbol IS NULL"),
+    )
+    op.create_index(
+        "uq_crypto_insight_snapshots_symbol_identity",
+        "crypto_insight_snapshots",
+        ["metric", "provider", "symbol", "snapshot_at"],
+        unique=True,
+        postgresql_where=sa.text("symbol IS NOT NULL"),
+    )
+    op.create_index(
+        "ix_crypto_insight_snapshots_metric_at",
+        "crypto_insight_snapshots",
+        ["metric", "snapshot_at"],
+    )
+    op.create_index(
+        "ix_crypto_insight_snapshots_provider_at",
+        "crypto_insight_snapshots",
+        ["provider", "snapshot_at"],
+    )
+    op.create_index(
+        "ix_crypto_insight_snapshots_symbol_metric_at",
+        "crypto_insight_snapshots",
+        ["symbol", "metric", "snapshot_at"],
+        postgresql_where=sa.text("symbol IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_crypto_insight_snapshots_symbol_metric_at",
+        table_name="crypto_insight_snapshots",
+    )
+    op.drop_index(
+        "ix_crypto_insight_snapshots_provider_at",
+        table_name="crypto_insight_snapshots",
+    )
+    op.drop_index(
+        "ix_crypto_insight_snapshots_metric_at",
+        table_name="crypto_insight_snapshots",
+    )
+    op.drop_index(
+        "uq_crypto_insight_snapshots_symbol_identity",
+        table_name="crypto_insight_snapshots",
+    )
+    op.drop_index(
+        "uq_crypto_insight_snapshots_global_identity",
+        table_name="crypto_insight_snapshots",
+    )
+    op.drop_table("crypto_insight_snapshots")

--- a/app/jobs/crypto_insight_snapshots.py
+++ b/app/jobs/crypto_insight_snapshots.py
@@ -1,0 +1,113 @@
+"""Dry-run-first job runner for crypto_insight_snapshots rows.
+
+No TaskIQ schedule is registered here; scheduler activation requires a separate
+operator approval after dry-run evidence.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections import Counter
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+from app.core.db import AsyncSessionLocal
+from app.models.crypto_insight_snapshot import CryptoInsightSnapshot
+from app.services.crypto_insight_snapshots.builder import (
+    DEFAULT_PROVIDERS,
+    build_crypto_insight_snapshots,
+)
+from app.services.crypto_insight_snapshots.repository import (
+    CryptoInsightSnapshotsRepository,
+    CryptoInsightSnapshotUpsert,
+)
+
+
+@dataclass(frozen=True)
+class CryptoInsightSnapshotSample:
+    metric: str
+    provider: str
+    symbol: str | None
+    value: Decimal | None
+    unit: str | None
+    snapshot_at: dt.datetime
+
+
+@dataclass(frozen=True)
+class CryptoInsightSnapshotRefreshResult:
+    snapshots_built: int
+    committed: bool
+    started_at: dt.datetime
+    finished_at: dt.datetime
+    providers: tuple[str, ...]
+    samples: tuple[CryptoInsightSnapshotSample, ...] = ()
+    snapshot_at_distribution: dict[str, int] = field(default_factory=dict)
+    warnings: tuple[str, ...] = ()
+
+
+def _sample(payload: CryptoInsightSnapshotUpsert) -> CryptoInsightSnapshotSample:
+    return CryptoInsightSnapshotSample(
+        metric=payload.metric,
+        provider=payload.provider,
+        symbol=payload.symbol,
+        value=payload.value,
+        unit=payload.unit,
+        snapshot_at=payload.snapshot_at,
+    )
+
+
+async def _commit_payloads(payloads: list[CryptoInsightSnapshotUpsert]) -> None:
+    async with AsyncSessionLocal() as session:
+        await CryptoInsightSnapshotsRepository(session).upsert(payloads)
+        await session.commit()
+
+
+async def refresh_crypto_insight_snapshots(
+    *,
+    dry_run: bool = True,
+    providers: list[str] | tuple[str, ...] | None = None,
+    symbols: list[str] | tuple[str, ...] | None = None,
+    limit: int | None = None,
+    confirm: bool = False,
+) -> CryptoInsightSnapshotRefreshResult:
+    if not dry_run and not confirm:
+        raise ValueError("confirm=True is required when dry_run=False")
+    started_at = dt.datetime.now(dt.UTC).replace(microsecond=0)
+    provider_tuple = tuple(p.strip().lower() for p in (providers or ()) if p.strip())
+    effective_providers = provider_tuple or DEFAULT_PROVIDERS
+    symbol_tuple = tuple(s.strip().upper() for s in (symbols or ()) if s.strip())
+    if limit is not None:
+        symbol_tuple = symbol_tuple[: max(0, limit)]
+
+    build = await build_crypto_insight_snapshots(
+        now=started_at,
+        providers=provider_tuple or None,
+        symbols=symbol_tuple or None,
+    )
+    payloads = list(
+        build.payloads[:limit]
+        if limit is not None and not symbol_tuple
+        else build.payloads
+    )
+    if not dry_run and payloads:
+        await _commit_payloads(payloads)
+    distribution = Counter(payload.snapshot_at.isoformat() for payload in payloads)
+    finished_at = dt.datetime.now(dt.UTC).replace(microsecond=0)
+    return CryptoInsightSnapshotRefreshResult(
+        snapshots_built=len(payloads),
+        committed=not dry_run,
+        started_at=started_at,
+        finished_at=finished_at,
+        providers=effective_providers,
+        samples=tuple(_sample(payload) for payload in payloads[:10]),
+        snapshot_at_distribution=dict(sorted(distribution.items())),
+        warnings=build.warnings,
+    )
+
+
+__all__ = [
+    "CryptoInsightSnapshot",
+    "CryptoInsightSnapshotRefreshResult",
+    "CryptoInsightSnapshotSample",
+    "refresh_crypto_insight_snapshots",
+]

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,7 @@
 # app/models/__init__.py
 from .analysis import StockAnalysisResult, StockInfo
 from .base import Base
+from .crypto_insight_snapshot import CryptoInsightSnapshot
 from .execution_ledger import ExecutionLedger, ExecutionLedgerReconcileRun
 from .invest_momentum_event_snapshot import (
     InvestMomentumEventSnapshot,
@@ -86,6 +87,7 @@ __all__ = [
     "Base",
     "ExecutionLedger",
     "ExecutionLedgerReconcileRun",
+    "CryptoInsightSnapshot",
     "Exchange",
     "Instrument",
     "User",

--- a/app/models/crypto_insight_snapshot.py
+++ b/app/models/crypto_insight_snapshot.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class CryptoInsightSnapshot(Base):
+    __tablename__ = "crypto_insight_snapshots"
+    __table_args__ = (
+        Index(
+            "uq_crypto_insight_snapshots_global_identity",
+            "metric",
+            "provider",
+            "snapshot_at",
+            unique=True,
+            postgresql_where="(symbol IS NULL)",
+        ),
+        Index(
+            "uq_crypto_insight_snapshots_symbol_identity",
+            "metric",
+            "provider",
+            "symbol",
+            "snapshot_at",
+            unique=True,
+            postgresql_where="(symbol IS NOT NULL)",
+        ),
+        Index("ix_crypto_insight_snapshots_metric_at", "metric", "snapshot_at"),
+        Index("ix_crypto_insight_snapshots_provider_at", "provider", "snapshot_at"),
+        Index(
+            "ix_crypto_insight_snapshots_symbol_metric_at",
+            "symbol",
+            "metric",
+            "snapshot_at",
+            postgresql_where="(symbol IS NOT NULL)",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    metric: Mapped[str] = mapped_column(String(48), nullable=False)
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    symbol: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    value: Mapped[Decimal | None] = mapped_column(Numeric(24, 10), nullable=True)
+    unit: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    label: Mapped[str | None] = mapped_column(String(80), nullable=True)
+    snapshot_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False
+    )
+    source_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    freshness_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    raw_payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/app/services/crypto_insight_snapshots/__init__.py
+++ b/app/services/crypto_insight_snapshots/__init__.py
@@ -1,0 +1,17 @@
+from app.services.crypto_insight_snapshots.repository import (
+    CryptoInsightSnapshotsRepository,
+    CryptoInsightSnapshotUpsert,
+    get_latest_crypto_insight,
+    list_latest_crypto_insights,
+    redact_sensitive_payload,
+    upsert_crypto_insight_snapshots,
+)
+
+__all__ = [
+    "CryptoInsightSnapshotsRepository",
+    "CryptoInsightSnapshotUpsert",
+    "get_latest_crypto_insight",
+    "list_latest_crypto_insights",
+    "redact_sensitive_payload",
+    "upsert_crypto_insight_snapshots",
+]

--- a/app/services/crypto_insight_snapshots/builder.py
+++ b/app/services/crypto_insight_snapshots/builder.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from app.services.crypto_insight_snapshots.repository import (
+    CryptoInsightSnapshotUpsert,
+    redact_sensitive_payload,
+)
+from app.services.external.crypto_insights import (
+    CryptoInsightMetric,
+    CryptoInsightProviderResult,
+    coinglass_api_key_from_env,
+    fetch_alternative_me_fear_greed,
+    fetch_binance_funding_rates,
+    fetch_coingecko_global,
+    fetch_coinglass_open_interest_poc,
+    fetch_defillama_reference,
+    fetch_tokenomist_unlocks_poc,
+    fetch_tradingview_crypto_breadth_reference,
+    tokenomist_api_key_from_env,
+)
+
+DEFAULT_PROVIDERS = ("alternative_me", "coingecko", "binance")
+POC_PROVIDERS = ("defillama", "coinglass", "tokenomist", "tradingview")
+ProviderFetcher = Callable[[], Awaitable[CryptoInsightProviderResult]]
+
+
+@dataclass(frozen=True)
+class CryptoInsightBuildResult:
+    payloads: tuple[CryptoInsightSnapshotUpsert, ...]
+    warnings: tuple[str, ...] = ()
+
+
+def _metric_to_payload(metric: CryptoInsightMetric) -> CryptoInsightSnapshotUpsert:
+    return CryptoInsightSnapshotUpsert(
+        metric=metric.metric,
+        provider=metric.provider,
+        symbol=metric.symbol,
+        value=metric.value,
+        unit=metric.unit,
+        label=metric.label,
+        snapshot_at=metric.observed_at.astimezone(dt.UTC).replace(microsecond=0),
+        source_url=metric.source_url,
+        freshness_seconds=metric.freshness_seconds,
+        raw_payload=redact_sensitive_payload(metric.raw_payload),
+    )
+
+
+def _provider_fetcher(
+    provider: str,
+    *,
+    symbols: Sequence[str],
+    now: dt.datetime | None,
+) -> ProviderFetcher:
+    provider_norm = provider.strip().lower()
+    if provider_norm == "alternative_me":
+        return lambda: fetch_alternative_me_fear_greed(now=now)
+    if provider_norm == "coingecko":
+        return lambda: fetch_coingecko_global(now=now)
+    if provider_norm == "binance":
+        funding_symbols = tuple(symbols or ("BTCUSDT", "ETHUSDT"))
+        return lambda: fetch_binance_funding_rates(funding_symbols, now=now)
+    if provider_norm == "defillama":
+        return lambda: fetch_defillama_reference(now=now)
+    if provider_norm == "coinglass":
+        return lambda: fetch_coinglass_open_interest_poc(
+            api_key=coinglass_api_key_from_env()
+        )
+    if provider_norm == "tokenomist":
+        return lambda: fetch_tokenomist_unlocks_poc(
+            api_key=tokenomist_api_key_from_env()
+        )
+    if provider_norm in {"tradingview", "tvscreener"}:
+        return fetch_tradingview_crypto_breadth_reference
+    raise ValueError(f"unsupported crypto insight provider: {provider}")
+
+
+async def build_crypto_insight_snapshots(
+    *,
+    now: dt.datetime | None = None,
+    providers: Sequence[str] | None = None,
+    symbols: Sequence[str] | None = None,
+    concurrency: int = 3,
+    provider_fetchers: dict[str, ProviderFetcher] | None = None,
+) -> CryptoInsightBuildResult:
+    provider_names = tuple(
+        p.strip().lower() for p in (providers or DEFAULT_PROVIDERS) if p.strip()
+    )
+    if not provider_names:
+        return CryptoInsightBuildResult(
+            payloads=(), warnings=("no providers requested",)
+        )
+    symbol_list = tuple(s.strip().upper() for s in (symbols or ()) if s.strip())
+    fetchers: dict[str, ProviderFetcher] = {}
+    warnings: list[str] = []
+    for provider in provider_names:
+        try:
+            fetchers[provider] = (provider_fetchers or {}).get(
+                provider
+            ) or _provider_fetcher(provider, symbols=symbol_list, now=now)
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(f"{provider}: {exc}")
+    sem = asyncio.Semaphore(max(1, concurrency))
+
+    async def _run(
+        provider: str, fetcher: ProviderFetcher
+    ) -> CryptoInsightProviderResult:
+        async with sem:
+            try:
+                return await fetcher()
+            except Exception as exc:  # noqa: BLE001
+                return CryptoInsightProviderResult(warnings=(f"{provider}: {exc}",))
+
+    results = await asyncio.gather(
+        *(_run(provider, fetcher) for provider, fetcher in fetchers.items())
+    )
+    payloads: list[CryptoInsightSnapshotUpsert] = []
+    for result in results:
+        payloads.extend(_metric_to_payload(metric) for metric in result.metrics)
+        warnings.extend(result.warnings)
+    return CryptoInsightBuildResult(payloads=tuple(payloads), warnings=tuple(warnings))
+
+
+def build_result_to_dict(result: CryptoInsightBuildResult) -> dict[str, Any]:
+    return {
+        "payloads": len(result.payloads),
+        "warnings": list(result.warnings),
+        "metrics": [
+            {
+                "metric": payload.metric,
+                "provider": payload.provider,
+                "symbol": payload.symbol,
+                "snapshot_at": payload.snapshot_at.isoformat(),
+            }
+            for payload in result.payloads
+        ],
+    }

--- a/app/services/crypto_insight_snapshots/repository.py
+++ b/app/services/crypto_insight_snapshots/repository.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Iterable, Sequence
+from decimal import Decimal
+from typing import Any
+
+import sqlalchemy as sa
+from pydantic import BaseModel, ConfigDict, field_validator
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.crypto_insight_snapshot import CryptoInsightSnapshot
+
+SENSITIVE_KEY_FRAGMENTS = ("key", "secret", "token", "password", "authorization")
+_MAX_RAW_ITEMS = 64
+_MAX_RAW_STRING = 500
+
+
+class CryptoInsightSnapshotUpsert(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    metric: str
+    provider: str
+    symbol: str | None = None
+    value: Decimal | None = None
+    unit: str | None = None
+    label: str | None = None
+    snapshot_at: dt.datetime
+    source_url: str | None = None
+    freshness_seconds: int | None = None
+    raw_payload: dict[str, Any] | None = None
+
+    @field_validator("metric", "provider")
+    @classmethod
+    def _required_slug(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if not normalized:
+            raise ValueError("value must not be empty")
+        return normalized
+
+    @field_validator("symbol")
+    @classmethod
+    def _normalize_symbol(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip().upper()
+        return normalized or None
+
+    @field_validator("unit")
+    @classmethod
+    def _normalize_unit(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip().lower()
+        return normalized or None
+
+    @field_validator("label")
+    @classmethod
+    def _normalize_label(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        return normalized or None
+
+
+def redact_sensitive_payload(payload: dict[str, Any] | None) -> dict[str, Any] | None:
+    if payload is None:
+        return None
+
+    def _redact(value: Any, *, key: str | None = None) -> Any:
+        if key and any(fragment in key.lower() for fragment in SENSITIVE_KEY_FRAGMENTS):
+            return "[REDACTED]"
+        if isinstance(value, dict):
+            return {
+                str(child_key)[:120]: _redact(child_value, key=str(child_key))
+                for child_key, child_value in list(value.items())[:_MAX_RAW_ITEMS]
+            }
+        if isinstance(value, list):
+            return [_redact(item) for item in value[:_MAX_RAW_ITEMS]]
+        if isinstance(value, str):
+            return value[:_MAX_RAW_STRING]
+        if isinstance(value, int | float | bool) or value is None:
+            return value
+        return str(value)[:_MAX_RAW_STRING]
+
+    return _redact(payload)
+
+
+def _normal_payload(row: CryptoInsightSnapshotUpsert) -> dict[str, Any]:
+    values = row.model_dump()
+    values["snapshot_at"] = (
+        values["snapshot_at"].astimezone(dt.UTC).replace(microsecond=0)
+    )
+    values["raw_payload"] = redact_sensitive_payload(values.get("raw_payload"))
+    return values
+
+
+def _matches_identity(values: dict[str, Any]) -> sa.ColumnElement[bool]:
+    symbol = values.get("symbol")
+    symbol_clause = (
+        CryptoInsightSnapshot.symbol.is_(None)
+        if symbol is None
+        else CryptoInsightSnapshot.symbol == symbol
+    )
+    return sa.and_(
+        CryptoInsightSnapshot.metric == values["metric"],
+        CryptoInsightSnapshot.provider == values["provider"],
+        symbol_clause,
+        CryptoInsightSnapshot.snapshot_at == values["snapshot_at"],
+    )
+
+
+class CryptoInsightSnapshotsRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def upsert(self, rows: Iterable[CryptoInsightSnapshotUpsert]) -> int:
+        count = 0
+        for row in rows:
+            values = _normal_payload(row)
+            existing = (
+                await self._session.execute(
+                    select(CryptoInsightSnapshot)
+                    .where(_matches_identity(values))
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            if existing is None:
+                self._session.add(CryptoInsightSnapshot(**values))
+            else:
+                for key in (
+                    "value",
+                    "unit",
+                    "label",
+                    "source_url",
+                    "freshness_seconds",
+                    "raw_payload",
+                ):
+                    setattr(existing, key, values[key])
+                existing.updated_at = dt.datetime.now(dt.UTC)
+            count += 1
+        if count:
+            await self._session.flush()
+        return count
+
+    async def list_latest(
+        self,
+        *,
+        metrics: Sequence[str] | None = None,
+        providers: Sequence[str] | None = None,
+        symbols: Sequence[str | None] | None = None,
+        limit_per_metric: int = 1,
+    ) -> list[CryptoInsightSnapshot]:
+        stmt = select(CryptoInsightSnapshot)
+        if metrics:
+            stmt = stmt.where(
+                CryptoInsightSnapshot.metric.in_([m.strip().lower() for m in metrics])
+            )
+        if providers:
+            stmt = stmt.where(
+                CryptoInsightSnapshot.provider.in_(
+                    [p.strip().lower() for p in providers]
+                )
+            )
+        if symbols is not None:
+            clauses = []
+            normalized_symbols = [s.strip().upper() if s else None for s in symbols]
+            if None in normalized_symbols:
+                clauses.append(CryptoInsightSnapshot.symbol.is_(None))
+            concrete = [s for s in normalized_symbols if s]
+            if concrete:
+                clauses.append(CryptoInsightSnapshot.symbol.in_(concrete))
+            stmt = stmt.where(sa.or_(*clauses) if clauses else sa.false())
+        stmt = stmt.order_by(
+            CryptoInsightSnapshot.metric,
+            CryptoInsightSnapshot.provider,
+            CryptoInsightSnapshot.symbol.nullsfirst(),
+            CryptoInsightSnapshot.snapshot_at.desc(),
+            CryptoInsightSnapshot.id.desc(),
+        )
+        result = await self._session.execute(stmt)
+        rows = list(result.scalars().all())
+        if limit_per_metric <= 0:
+            return []
+        seen: dict[tuple[str, str, str | None], int] = {}
+        latest: list[CryptoInsightSnapshot] = []
+        for row in rows:
+            key = (row.metric, row.provider, row.symbol)
+            current = seen.get(key, 0)
+            if current >= limit_per_metric:
+                continue
+            latest.append(row)
+            seen[key] = current + 1
+        return latest
+
+    async def get_latest(
+        self,
+        metric: str,
+        *,
+        provider: str | None = None,
+        symbol: str | None = None,
+    ) -> CryptoInsightSnapshot | None:
+        stmt = select(CryptoInsightSnapshot).where(
+            CryptoInsightSnapshot.metric == metric.strip().lower()
+        )
+        if provider:
+            stmt = stmt.where(
+                CryptoInsightSnapshot.provider == provider.strip().lower()
+            )
+        if symbol is None:
+            stmt = stmt.where(CryptoInsightSnapshot.symbol.is_(None))
+        else:
+            stmt = stmt.where(CryptoInsightSnapshot.symbol == symbol.strip().upper())
+        stmt = stmt.order_by(
+            CryptoInsightSnapshot.snapshot_at.desc(), CryptoInsightSnapshot.id.desc()
+        ).limit(1)
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+
+async def upsert_crypto_insight_snapshots(
+    session: AsyncSession, payloads: Iterable[CryptoInsightSnapshotUpsert]
+) -> int:
+    return await CryptoInsightSnapshotsRepository(session).upsert(payloads)
+
+
+async def list_latest_crypto_insights(
+    session: AsyncSession,
+    *,
+    metrics: Sequence[str] | None = None,
+    providers: Sequence[str] | None = None,
+    symbols: Sequence[str | None] | None = None,
+    limit_per_metric: int = 1,
+) -> list[CryptoInsightSnapshot]:
+    return await CryptoInsightSnapshotsRepository(session).list_latest(
+        metrics=metrics,
+        providers=providers,
+        symbols=symbols,
+        limit_per_metric=limit_per_metric,
+    )
+
+
+async def get_latest_crypto_insight(
+    session: AsyncSession,
+    metric: str,
+    *,
+    provider: str | None = None,
+    symbol: str | None = None,
+) -> CryptoInsightSnapshot | None:
+    return await CryptoInsightSnapshotsRepository(session).get_latest(
+        metric, provider=provider, symbol=symbol
+    )

--- a/app/services/crypto_insight_snapshots/service.py
+++ b/app/services/crypto_insight_snapshots/service.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.crypto_insight_snapshot import CryptoInsightSnapshot
+from app.services.crypto_insight_snapshots.repository import (
+    CryptoInsightSnapshotsRepository,
+)
+
+
+async def latest_crypto_insight_sources(
+    session: AsyncSession,
+    *,
+    metrics: Sequence[str] | None = None,
+    providers: Sequence[str] | None = None,
+    symbols: Sequence[str | None] | None = None,
+    limit_per_metric: int = 1,
+) -> list[CryptoInsightSnapshot]:
+    """Read latest cached crypto insight snapshots for /invest view-models.
+
+    This service intentionally stays DB-only. Live provider fallback remains in the
+    existing market dashboard services until a separate UI contract asks for more.
+    """
+    return await CryptoInsightSnapshotsRepository(session).list_latest(
+        metrics=metrics,
+        providers=providers,
+        symbols=symbols,
+        limit_per_metric=limit_per_metric,
+    )

--- a/app/services/external/crypto_insights.py
+++ b/app/services/external/crypto_insights.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import datetime as dt
+import os
+from collections.abc import Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+import httpx
+
+ALTERNATIVE_ME_FNG_URL = "https://api.alternative.me/fng/"
+COINGECKO_GLOBAL_URL = "https://api.coingecko.com/api/v3/global"
+BINANCE_FUNDING_URL = "https://fapi.binance.com/fapi/v1/premiumIndex"
+DEFILLAMA_PROTOCOL_URL = "https://api.llama.fi/protocol/{slug}"
+DEFILLAMA_STABLECOINS_URL = "https://stablecoins.llama.fi/stablecoins"
+COINGLASS_OPEN_INTEREST_URL = (
+    "https://open-api-v4.coinglass.com/api/futures/openInterest/ohlc-history"
+)
+TOKENOMIST_UNLOCKS_URL = "https://api.tokenomist.ai/v1/unlocks"
+TRADINGVIEW_REFERENCE_URL = (
+    "https://www.tradingview.com/markets/cryptocurrencies/prices-all/"
+)
+
+
+@dataclass(frozen=True)
+class CryptoInsightMetric:
+    metric: str
+    provider: str
+    symbol: str | None
+    value: Decimal | None
+    unit: str | None
+    label: str | None
+    source_url: str
+    observed_at: dt.datetime
+    freshness_seconds: int | None
+    raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CryptoInsightProviderResult:
+    metrics: tuple[CryptoInsightMetric, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
+def _utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.UTC).replace(microsecond=0)
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _freshness_from_unix(value: Any, now: dt.datetime) -> int | None:
+    try:
+        timestamp = int(value)
+    except Exception:  # noqa: BLE001
+        return None
+    observed = dt.datetime.fromtimestamp(timestamp, tz=dt.UTC)
+    return max(0, int((now - observed).total_seconds()))
+
+
+async def fetch_alternative_me_fear_greed(
+    client: httpx.AsyncClient | None = None,
+    *,
+    now: dt.datetime | None = None,
+) -> CryptoInsightProviderResult:
+    observed_at = (now or _utc_now()).astimezone(dt.UTC).replace(microsecond=0)
+    close_client = client is None
+    http = client or httpx.AsyncClient(timeout=10.0)
+    try:
+        response = await http.get(ALTERNATIVE_ME_FNG_URL, params={"limit": 2})
+        response.raise_for_status()
+        payload = response.json()
+        rows = payload.get("data") or []
+        if not rows:
+            return CryptoInsightProviderResult(
+                warnings=("alternative_me: empty fear/greed payload",)
+            )
+        current = rows[0]
+        value = _decimal(current.get("value"))
+        timestamp = current.get("timestamp")
+        freshness = _freshness_from_unix(timestamp, observed_at)
+        if timestamp is not None:
+            try:
+                observed_at = dt.datetime.fromtimestamp(int(timestamp), tz=dt.UTC)
+            except Exception:  # noqa: BLE001
+                pass
+        return CryptoInsightProviderResult(
+            metrics=(
+                CryptoInsightMetric(
+                    metric="fear_greed",
+                    provider="alternative_me",
+                    symbol=None,
+                    value=value,
+                    unit="score",
+                    label=current.get("value_classification"),
+                    source_url=ALTERNATIVE_ME_FNG_URL,
+                    observed_at=observed_at,
+                    freshness_seconds=freshness,
+                    raw_payload={
+                        "current": current,
+                        "previous": rows[1] if len(rows) > 1 else None,
+                    },
+                ),
+            )
+        )
+    except Exception as exc:  # noqa: BLE001
+        return CryptoInsightProviderResult(warnings=(f"alternative_me: {exc}",))
+    finally:
+        if close_client:
+            await http.aclose()
+
+
+async def fetch_coingecko_global(
+    client: httpx.AsyncClient | None = None,
+    *,
+    now: dt.datetime | None = None,
+) -> CryptoInsightProviderResult:
+    observed_at = (now or _utc_now()).astimezone(dt.UTC).replace(microsecond=0)
+    close_client = client is None
+    http = client or httpx.AsyncClient(timeout=10.0)
+    try:
+        response = await http.get(COINGECKO_GLOBAL_URL)
+        response.raise_for_status()
+        payload = response.json()
+        data = payload.get("data") or {}
+        cap_pct = data.get("market_cap_percentage") or {}
+        metrics = [
+            CryptoInsightMetric(
+                metric="btc_dominance",
+                provider="coingecko",
+                symbol="BTC",
+                value=_decimal(cap_pct.get("btc")),
+                unit="%",
+                label=None,
+                source_url=COINGECKO_GLOBAL_URL,
+                observed_at=observed_at,
+                freshness_seconds=0,
+                raw_payload={"market_cap_percentage": cap_pct},
+            ),
+            CryptoInsightMetric(
+                metric="global_market_cap_change_24h",
+                provider="coingecko",
+                symbol=None,
+                value=_decimal(data.get("market_cap_change_percentage_24h_usd")),
+                unit="%",
+                label=None,
+                source_url=COINGECKO_GLOBAL_URL,
+                observed_at=observed_at,
+                freshness_seconds=0,
+                raw_payload={
+                    "market_cap_change_percentage_24h_usd": data.get(
+                        "market_cap_change_percentage_24h_usd"
+                    )
+                },
+            ),
+        ]
+        return CryptoInsightProviderResult(
+            metrics=tuple(m for m in metrics if m.value is not None)
+        )
+    except Exception as exc:  # noqa: BLE001
+        return CryptoInsightProviderResult(warnings=(f"coingecko: {exc}",))
+    finally:
+        if close_client:
+            await http.aclose()
+
+
+async def fetch_binance_funding_rates(
+    symbols: Sequence[str] = ("BTCUSDT", "ETHUSDT"),
+    client: httpx.AsyncClient | None = None,
+    *,
+    now: dt.datetime | None = None,
+) -> CryptoInsightProviderResult:
+    observed_at = (now or _utc_now()).astimezone(dt.UTC).replace(microsecond=0)
+    close_client = client is None
+    http = client or httpx.AsyncClient(timeout=10.0)
+    metrics: list[CryptoInsightMetric] = []
+    warnings: list[str] = []
+    try:
+        for symbol in [s.strip().upper() for s in symbols if s.strip()]:
+            try:
+                response = await http.get(
+                    BINANCE_FUNDING_URL, params={"symbol": symbol}
+                )
+                response.raise_for_status()
+                payload = response.json()
+                rate = _decimal(payload.get("lastFundingRate"))
+                label = None
+                if rate is not None:
+                    label = (
+                        "longs pay shorts"
+                        if rate > 0
+                        else "shorts pay longs"
+                        if rate < 0
+                        else "neutral"
+                    )
+                metrics.append(
+                    CryptoInsightMetric(
+                        metric="funding_rate",
+                        provider="binance",
+                        symbol=symbol,
+                        value=rate,
+                        unit="ratio",
+                        label=label,
+                        source_url=BINANCE_FUNDING_URL,
+                        observed_at=observed_at,
+                        freshness_seconds=_freshness_from_unix(
+                            (payload.get("time") or 0) // 1000
+                            if isinstance(payload.get("time"), int)
+                            else None,
+                            observed_at,
+                        ),
+                        raw_payload=payload,
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001
+                warnings.append(f"binance:{symbol}: {exc}")
+    finally:
+        if close_client:
+            await http.aclose()
+    return CryptoInsightProviderResult(metrics=tuple(metrics), warnings=tuple(warnings))
+
+
+async def fetch_defillama_reference(
+    client: httpx.AsyncClient | None = None,
+    *,
+    protocol_slugs: Sequence[str] = ("bitcoin", "ethereum"),
+    now: dt.datetime | None = None,
+) -> CryptoInsightProviderResult:
+    observed_at = (now or _utc_now()).astimezone(dt.UTC).replace(microsecond=0)
+    close_client = client is None
+    http = client or httpx.AsyncClient(timeout=10.0)
+    metrics: list[CryptoInsightMetric] = []
+    warnings: list[str] = []
+    try:
+        for slug in [s.strip().lower() for s in protocol_slugs if s.strip()]:
+            try:
+                url = DEFILLAMA_PROTOCOL_URL.format(slug=slug)
+                response = await http.get(url)
+                response.raise_for_status()
+                payload = response.json()
+                metrics.append(
+                    CryptoInsightMetric(
+                        metric="tvl",
+                        provider="defillama",
+                        symbol=(payload.get("symbol") or slug).upper(),
+                        value=_decimal(payload.get("tvl")),
+                        unit="usd",
+                        label=payload.get("name"),
+                        source_url=url,
+                        observed_at=observed_at,
+                        freshness_seconds=0,
+                        raw_payload={
+                            "name": payload.get("name"),
+                            "symbol": payload.get("symbol"),
+                            "tvl": payload.get("tvl"),
+                        },
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001
+                warnings.append(f"defillama:{slug}: {exc}")
+        try:
+            response = await http.get(
+                DEFILLAMA_STABLECOINS_URL, params={"includePrices": "false"}
+            )
+            response.raise_for_status()
+            payload = response.json()
+            total = payload.get("totalCirculatingUSD") or payload.get(
+                "totalCirculating"
+            )
+            metrics.append(
+                CryptoInsightMetric(
+                    metric="stablecoin_supply",
+                    provider="defillama",
+                    symbol=None,
+                    value=_decimal(total),
+                    unit="usd",
+                    label="stablecoins circulating",
+                    source_url=DEFILLAMA_STABLECOINS_URL,
+                    observed_at=observed_at,
+                    freshness_seconds=0,
+                    raw_payload={"totalCirculatingUSD": total},
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(f"defillama:stablecoins: {exc}")
+    finally:
+        if close_client:
+            await http.aclose()
+    return CryptoInsightProviderResult(
+        metrics=tuple(m for m in metrics if m.value is not None),
+        warnings=tuple(warnings),
+    )
+
+
+async def fetch_coinglass_open_interest_poc(
+    *,
+    api_key: str | None = None,
+) -> CryptoInsightProviderResult:
+    if not api_key:
+        return CryptoInsightProviderResult(
+            warnings=("coinglass: disabled (missing API key)",)
+        )
+    return CryptoInsightProviderResult(
+        warnings=("coinglass: PoC adapter defined but not enabled by default",)
+    )
+
+
+async def fetch_tokenomist_unlocks_poc(
+    *,
+    api_key: str | None = None,
+) -> CryptoInsightProviderResult:
+    if not api_key:
+        return CryptoInsightProviderResult(
+            warnings=("tokenomist: disabled (missing API key)",)
+        )
+    return CryptoInsightProviderResult(
+        warnings=("tokenomist: PoC adapter defined but not enabled by default",)
+    )
+
+
+async def fetch_tradingview_crypto_breadth_reference() -> CryptoInsightProviderResult:
+    return CryptoInsightProviderResult(
+        metrics=(
+            CryptoInsightMetric(
+                metric="tv_crypto_breadth",
+                provider="tradingview",
+                symbol=None,
+                value=None,
+                unit="count",
+                label="reference-only: existing tvscreener path preserved",
+                source_url=TRADINGVIEW_REFERENCE_URL,
+                observed_at=_utc_now(),
+                freshness_seconds=None,
+                raw_payload={"status": "reference_only", "replace_tvscreener": False},
+            ),
+        ),
+        warnings=("tradingview: reference adapter only; not a tvscreener replacement",),
+    )
+
+
+def coinglass_api_key_from_env() -> str | None:
+    return os.getenv("COINGLASS_API_KEY") or os.getenv("COINGLASS_API_SECRET")
+
+
+def tokenomist_api_key_from_env() -> str | None:
+    return os.getenv("TOKENOMIST_API_KEY")

--- a/tests/test_crypto_insight_external_adapters.py
+++ b/tests/test_crypto_insight_external_adapters.py
@@ -1,0 +1,126 @@
+import datetime as dt
+from decimal import Decimal
+
+import httpx
+import pytest
+
+from app.services.external.crypto_insights import (
+    CryptoInsightProviderResult,
+    fetch_alternative_me_fear_greed,
+    fetch_binance_funding_rates,
+    fetch_coingecko_global,
+    fetch_coinglass_open_interest_poc,
+    fetch_defillama_reference,
+    fetch_tokenomist_unlocks_poc,
+    fetch_tradingview_crypto_breadth_reference,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _client(handler):
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+async def test_alternative_me_adapter_maps_fear_greed_metric():
+    def handler(request):
+        assert request.url.host == "api.alternative.me"
+        return httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "value": "72",
+                        "value_classification": "Greed",
+                        "timestamp": "1778620000",
+                    },
+                    {
+                        "value": "65",
+                        "value_classification": "Greed",
+                        "timestamp": "1778533600",
+                    },
+                ]
+            },
+        )
+
+    async with _client(handler) as client:
+        result = await fetch_alternative_me_fear_greed(
+            client, now=dt.datetime(2026, 5, 13, tzinfo=dt.UTC)
+        )
+
+    assert result.warnings == ()
+    assert len(result.metrics) == 1
+    metric = result.metrics[0]
+    assert metric.metric == "fear_greed"
+    assert metric.provider == "alternative_me"
+    assert metric.value == Decimal("72")
+    assert metric.label == "Greed"
+
+
+async def test_coingecko_adapter_maps_global_metrics():
+    def handler(request):
+        assert request.url.host == "api.coingecko.com"
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "market_cap_percentage": {"btc": 58.12},
+                    "market_cap_change_percentage_24h_usd": -1.7,
+                }
+            },
+        )
+
+    async with _client(handler) as client:
+        result = await fetch_coingecko_global(client)
+
+    assert {metric.metric for metric in result.metrics} == {
+        "btc_dominance",
+        "global_market_cap_change_24h",
+    }
+
+
+async def test_binance_adapter_maps_public_funding_rate():
+    def handler(request):
+        assert request.url.params["symbol"] == "BTCUSDT"
+        return httpx.Response(
+            200,
+            json={
+                "symbol": "BTCUSDT",
+                "lastFundingRate": "0.0001",
+                "time": 1778620000000,
+            },
+        )
+
+    async with _client(handler) as client:
+        result = await fetch_binance_funding_rates(["BTCUSDT"], client)
+
+    assert result.warnings == ()
+    assert result.metrics[0].metric == "funding_rate"
+    assert result.metrics[0].label == "longs pay shorts"
+
+
+async def test_defillama_adapter_maps_tvl_and_stablecoin_metrics():
+    def handler(request):
+        if request.url.host == "api.llama.fi":
+            return httpx.Response(
+                200, json={"name": "Ethereum", "symbol": "ETH", "tvl": 123}
+            )
+        return httpx.Response(200, json={"totalCirculatingUSD": 456})
+
+    async with _client(handler) as client:
+        result = await fetch_defillama_reference(client, protocol_slugs=["ethereum"])
+
+    assert {metric.metric for metric in result.metrics} == {"tvl", "stablecoin_supply"}
+
+
+async def test_optional_poc_adapters_are_non_fatal_without_credentials():
+    assert (await fetch_coinglass_open_interest_poc()).warnings == (
+        "coinglass: disabled (missing API key)",
+    )
+    assert (await fetch_tokenomist_unlocks_poc()).warnings == (
+        "tokenomist: disabled (missing API key)",
+    )
+    tv_result = await fetch_tradingview_crypto_breadth_reference()
+    assert isinstance(tv_result, CryptoInsightProviderResult)
+    assert tv_result.metrics[0].provider == "tradingview"
+    assert tv_result.metrics[0].raw_payload["replace_tvscreener"] is False

--- a/tests/test_crypto_insight_snapshot_job.py
+++ b/tests/test_crypto_insight_snapshot_job.py
@@ -1,0 +1,89 @@
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.jobs.crypto_insight_snapshots import refresh_crypto_insight_snapshots
+from app.services.crypto_insight_snapshots.builder import (
+    DEFAULT_PROVIDERS,
+    CryptoInsightBuildResult,
+)
+from app.services.crypto_insight_snapshots.repository import CryptoInsightSnapshotUpsert
+
+pytestmark = pytest.mark.asyncio
+
+
+def _payload():
+    return CryptoInsightSnapshotUpsert(
+        metric="fear_greed",
+        provider="alternative_me",
+        value=Decimal("70"),
+        unit="score",
+        label="Greed",
+        snapshot_at=dt.datetime(2026, 5, 13, tzinfo=dt.UTC),
+        source_url="https://api.alternative.me/fng/",
+        raw_payload={"value": "70"},
+    )
+
+
+async def test_refresh_crypto_insight_snapshots_dry_run_does_not_commit(monkeypatch):
+    committed = False
+
+    async def fake_build(**kwargs):
+        return CryptoInsightBuildResult(payloads=(_payload(),), warnings=("ok",))
+
+    async def fake_commit(payloads):
+        nonlocal committed
+        committed = True
+
+    monkeypatch.setattr(
+        "app.jobs.crypto_insight_snapshots.build_crypto_insight_snapshots", fake_build
+    )
+    monkeypatch.setattr(
+        "app.jobs.crypto_insight_snapshots._commit_payloads", fake_commit
+    )
+
+    result = await refresh_crypto_insight_snapshots(
+        dry_run=True, providers=["alternative_me"]
+    )
+
+    assert result.snapshots_built == 1
+    assert result.committed is False
+    assert committed is False
+    assert result.warnings == ("ok",)
+
+
+async def test_refresh_crypto_insight_snapshots_requires_confirm_for_write(monkeypatch):
+    async def fake_build(**kwargs):
+        return CryptoInsightBuildResult(payloads=(_payload(),), warnings=())
+
+    monkeypatch.setattr(
+        "app.jobs.crypto_insight_snapshots.build_crypto_insight_snapshots", fake_build
+    )
+
+    with pytest.raises(ValueError, match="confirm=True"):
+        await refresh_crypto_insight_snapshots(dry_run=False, confirm=False)
+
+
+async def test_refresh_crypto_insight_snapshots_commits_when_confirmed(monkeypatch):
+    committed_count = 0
+
+    async def fake_build(**kwargs):
+        return CryptoInsightBuildResult(payloads=(_payload(),), warnings=())
+
+    async def fake_commit(payloads):
+        nonlocal committed_count
+        committed_count = len(payloads)
+
+    monkeypatch.setattr(
+        "app.jobs.crypto_insight_snapshots.build_crypto_insight_snapshots", fake_build
+    )
+    monkeypatch.setattr(
+        "app.jobs.crypto_insight_snapshots._commit_payloads", fake_commit
+    )
+
+    result = await refresh_crypto_insight_snapshots(dry_run=False, confirm=True)
+
+    assert result.committed is True
+    assert committed_count == 1
+    assert result.providers == DEFAULT_PROVIDERS

--- a/tests/test_crypto_insight_snapshot_model.py
+++ b/tests/test_crypto_insight_snapshot_model.py
@@ -1,0 +1,23 @@
+from app.models import CryptoInsightSnapshot
+
+
+def test_crypto_insight_snapshot_model_shape():
+    assert CryptoInsightSnapshot.__tablename__ == "crypto_insight_snapshots"
+    columns = CryptoInsightSnapshot.__table__.columns
+    for name in (
+        "metric",
+        "provider",
+        "symbol",
+        "value",
+        "unit",
+        "label",
+        "snapshot_at",
+        "source_url",
+        "freshness_seconds",
+        "raw_payload",
+    ):
+        assert name in columns
+    index_names = {index.name for index in CryptoInsightSnapshot.__table__.indexes}
+    assert "ix_crypto_insight_snapshots_metric_at" in index_names
+    assert "uq_crypto_insight_snapshots_global_identity" in index_names
+    assert "uq_crypto_insight_snapshots_symbol_identity" in index_names

--- a/tests/test_crypto_insight_snapshots_builder.py
+++ b/tests/test_crypto_insight_snapshots_builder.py
@@ -1,0 +1,71 @@
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.services.crypto_insight_snapshots.builder import build_crypto_insight_snapshots
+from app.services.external.crypto_insights import (
+    CryptoInsightMetric,
+    CryptoInsightProviderResult,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_builder_converts_provider_metrics_to_snapshot_payloads():
+    observed_at = dt.datetime(2026, 5, 13, tzinfo=dt.UTC)
+
+    async def fake_provider():
+        return CryptoInsightProviderResult(
+            metrics=(
+                CryptoInsightMetric(
+                    metric="fear_greed",
+                    provider="alternative_me",
+                    symbol=None,
+                    value=Decimal("70"),
+                    unit="score",
+                    label="Greed",
+                    source_url="https://api.alternative.me/fng/",
+                    observed_at=observed_at,
+                    freshness_seconds=1,
+                    raw_payload={"token": "synthetic"},
+                ),
+            ),
+            warnings=("sample warning",),
+        )
+
+    result = await build_crypto_insight_snapshots(
+        providers=["alternative_me"],
+        provider_fetchers={"alternative_me": fake_provider},
+    )
+
+    assert len(result.payloads) == 1
+    assert result.payloads[0].metric == "fear_greed"
+    assert result.payloads[0].provider == "alternative_me"
+    assert result.payloads[0].snapshot_at == observed_at
+    assert result.payloads[0].raw_payload == {"token": "[REDACTED]"}
+    assert result.warnings == ("sample warning",)
+
+
+async def test_builder_reports_unknown_provider_as_warning():
+    result = await build_crypto_insight_snapshots(providers=["unknown_provider"])
+
+    assert result.payloads == ()
+    assert "unsupported crypto insight provider" in result.warnings[0]
+
+
+async def test_builder_uses_requested_binance_symbols(monkeypatch):
+    captured = {}
+
+    async def fake_binance(symbols, **kwargs):
+        captured["symbols"] = symbols
+        return CryptoInsightProviderResult()
+
+    monkeypatch.setattr(
+        "app.services.crypto_insight_snapshots.builder.fetch_binance_funding_rates",
+        fake_binance,
+    )
+
+    await build_crypto_insight_snapshots(providers=["binance"], symbols=["solusdt"])
+
+    assert captured["symbols"] == ("SOLUSDT",)

--- a/tests/test_crypto_insight_snapshots_repository.py
+++ b/tests/test_crypto_insight_snapshots_repository.py
@@ -1,0 +1,74 @@
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from app.services.crypto_insight_snapshots.repository import (
+    CryptoInsightSnapshotsRepository,
+    CryptoInsightSnapshotUpsert,
+    redact_sensitive_payload,
+)
+
+
+def _payload(value: str = "1.23", *, snapshot_at: dt.datetime | None = None):
+    return CryptoInsightSnapshotUpsert(
+        metric="funding_rate",
+        provider="binance",
+        symbol="btcusdt",
+        value=Decimal(value),
+        unit="ratio",
+        label="longs pay shorts",
+        snapshot_at=snapshot_at or dt.datetime(2026, 5, 13, tzinfo=dt.UTC),
+        source_url="https://fapi.binance.com/fapi/v1/premiumIndex",
+        freshness_seconds=10,
+        raw_payload={"api_key": "abc123", "nested": {"Authorization": "Bearer value"}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_inserts_and_updates_existing_snapshot(db_session):
+    repo = CryptoInsightSnapshotsRepository(db_session)
+    inserted = await repo.upsert([_payload("1.23")])
+    updated = await repo.upsert([_payload("2.34")])
+    await db_session.commit()
+
+    latest = await repo.get_latest("funding_rate", provider="binance", symbol="BTCUSDT")
+
+    assert inserted == 1
+    assert updated == 1
+    assert latest is not None
+    assert latest.value == Decimal("2.3400000000")
+    assert latest.raw_payload["api_key"] == "[REDACTED]"
+    assert latest.raw_payload["nested"]["Authorization"] == "[REDACTED]"
+
+
+@pytest.mark.asyncio
+async def test_list_latest_returns_newest_per_metric_provider_symbol(db_session):
+    repo = CryptoInsightSnapshotsRepository(db_session)
+    older = dt.datetime(2026, 5, 12, tzinfo=dt.UTC)
+    newer = dt.datetime(2026, 5, 13, tzinfo=dt.UTC)
+    await repo.upsert(
+        [_payload("1.0", snapshot_at=older), _payload("2.0", snapshot_at=newer)]
+    )
+    await db_session.commit()
+
+    rows = await repo.list_latest(metrics=["funding_rate"], providers=["binance"])
+
+    assert len(rows) == 1
+    assert rows[0].snapshot_at == newer
+    assert rows[0].symbol == "BTCUSDT"
+
+
+def test_redact_sensitive_payload_bounds_and_redacts():
+    redacted = redact_sensitive_payload(
+        {
+            "token_value": "secret-token",
+            "safe": "x" * 700,
+            "items": list(range(100)),
+        }
+    )
+
+    assert redacted is not None
+    assert redacted["token_value"] == "[REDACTED]"
+    assert len(redacted["safe"]) == 500
+    assert len(redacted["items"]) == 64


### PR DESCRIPTION
## Summary
- Add `crypto_insight_snapshots` schema/model/repository and DB-first snapshot service scaffolding.
- Add optional, disabled-by-default external crypto insight adapters/PoCs for Alternative.me, CoinGecko/DeFiLlama-style global metrics, Binance funding, CoinGlass, Tokenomist, and TradingView reference boundaries without replacing existing tvscreener paths.
- Add a dry-run/confirm-gated snapshot job and regression tests for model, repository, builder, job, and adapter behavior.

## Safety / scope
- Read-only data/reference integration only; no broker/order/watch/order-intent mutations.
- Snapshot writes remain explicit `dry_run=False` + `confirm=True` gated.
- No scheduler activation, production DB backfill/delete, or live trading action included.

## Verification
- `uv run pytest tests/test_crypto_insight_snapshot_model.py tests/test_crypto_insight_snapshots_repository.py tests/test_crypto_insight_external_adapters.py tests/test_crypto_insight_snapshots_builder.py tests/test_crypto_insight_snapshot_job.py -q` — 15 passed
- `uv run pytest tests/test_invest_screener_presets.py tests/test_invest_view_model_screener_service.py tests/test_tvscreener_crypto.py tests/test_tvscreener_capabilities.py -q` — 64 passed
- `uv run ruff check <ROB-227 changed files>` — passed
- `uv run ruff format --check <ROB-227 changed files>` — passed
- `uv run alembic heads` — `20260513_rob227 (head)`
- Live builder-only probe for `alternative_me`, `coingecko`, `binance` returned 4 source-labeled payloads and no warnings; no DB commit.

Closes ROB-227
