### PR TITLE
feat(invest): add read-only crypto dashboard

### DIFF
--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -21,6 +21,7 @@ from app.schemas.invest_calendar import (
     WeeklySummaryResponse,
 )
 from app.schemas.invest_coverage import CoverageMarket, InvestCoverageResponse
+from app.schemas.invest_crypto import CryptoDashboardResponse
 from app.schemas.invest_feed_news import FeedNewsResponse, FeedTab, FeedTopic
 from app.schemas.invest_feed_research import (
     FeedResearchFilters,
@@ -57,6 +58,9 @@ from app.services.invest_momentum_events.repository import (
 from app.services.invest_screener_snapshots.coverage_service import build_coverage
 from app.services.invest_view_model.account_panel_service import build_account_panel
 from app.services.invest_view_model.calendar_service import build_calendar
+from app.services.invest_view_model.crypto_dashboard_service import (
+    build_crypto_dashboard,
+)
 from app.services.invest_view_model.feed_news_service import build_feed_news
 from app.services.invest_view_model.feed_research_service import build_feed_research
 from app.services.invest_view_model.fx_dashboard_service import build_fx_dashboard
@@ -146,6 +150,26 @@ async def get_fx_dashboard(
     """Read-only FX·macro dashboard contract fixture (ROB-216)."""
     _ = user
     return await build_fx_dashboard()
+
+
+@router.get("/crypto/dashboard")
+async def get_crypto_dashboard(
+    user: Annotated[Any, Depends(get_authenticated_user)],
+    service: Annotated[InvestHomeService, Depends(get_invest_home_service)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    limit: int = Query(20, ge=1, le=50),
+) -> CryptoDashboardResponse:
+    """Read-only crypto dashboard; never syncs or mutates broker/order state."""
+    home = await service.get_home(user_id=user.id)
+    resolver = await build_relation_resolver(
+        db, user_id=user.id, held_pairs=_held_pairs_from_home(home)
+    )
+    return await build_crypto_dashboard(
+        db=db,
+        user_id=user.id,
+        resolver=resolver,
+        limit=limit,
+    )
 
 
 @router.get("/coverage")
@@ -444,7 +468,7 @@ async def get_screener_results_endpoint(
 @router.get("/screener/snapshots/coverage")
 async def screener_snapshots_coverage(
     db: Annotated[AsyncSession, Depends(get_db)],
-    market: Literal["kr", "us"] = Query("kr"),
+    market: Literal["kr", "us", "crypto"] = Query("kr"),
 ) -> dict:
     """Read-only coverage summary for invest_screener_snapshots (ROB-170)."""
     report = await build_coverage(db, market=market)

--- a/app/schemas/invest_crypto.py
+++ b/app/schemas/invest_crypto.py
@@ -1,0 +1,175 @@
+"""ROB-226 — read-only crypto dashboard DTOs for /invest/api/crypto/*.
+
+These models intentionally expose public market/read-model state only. Execution,
+watch/order-intent, and broker mutation controls stay out of this contract.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+CryptoCapabilityState = Literal[
+    "supported",
+    "unavailable",
+    "reference_only",
+    "external_gap",
+    "deferred",
+    "read_only_mvp",
+]
+CryptoRiskBadgeKind = Literal[
+    "thin_orderbook",
+    "held",
+    "pending_order",
+    "data_unavailable",
+    "high_volatility",
+]
+CryptoPendingOrderSide = Literal["buy", "sell"] | str
+
+
+class CryptoSourceState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    state: CryptoCapabilityState
+    label: str
+    fetchedAt: datetime | None = None
+
+
+class CryptoCapabilityFlag(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    state: CryptoCapabilityState
+    reason: str | None = None
+
+
+class CryptoDashboardCapabilities(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ticker: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(state="supported")
+    )
+    candles: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(state="supported")
+    )
+    orderbook: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(state="supported")
+    )
+    recentTrades: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(
+            state="external_gap", reason="upbit_public_dashboard_mvp"
+        )
+    )
+    projectInfo: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(
+            state="reference_only", reason="external_reference_only"
+        )
+    )
+    liveStreaming: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(state="deferred")
+    )
+    execution: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(state="read_only_mvp")
+    )
+
+
+class CryptoRiskBadge(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: CryptoRiskBadgeKind
+    label: str
+    severity: Literal["info", "warning", "danger"] = "info"
+
+
+class CryptoMarketCard(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    baseSymbol: str
+    displayName: str
+    priceKrw: float | None = None
+    changeRate24h: float | None = None
+    changeAmount24h: float | None = None
+    accTradePrice24h: float | None = None
+    volume24h: float | None = None
+    orderbookSpreadPct: float | None = None
+    isHeld: bool = False
+    isWatched: bool = False
+    badges: list[CryptoRiskBadge] = Field(default_factory=list)
+
+
+class CryptoHoldingSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    heldCount: int = Field(ge=0)
+    symbols: list[str] = Field(default_factory=list)
+    source: Literal["invest_home_read_model"] = "invest_home_read_model"
+
+
+class CryptoPendingOrderItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    orderId: str | None = None
+    symbol: str
+    baseSymbol: str | None = None
+    side: CryptoPendingOrderSide
+    orderType: str | None = None
+    price: float | None = None
+    quantity: float
+    filledQuantity: float = 0
+    status: str
+    orderedAt: datetime | None = None
+    updatedAt: datetime | None = None
+    source: Literal["pending_orders"] = "pending_orders"
+
+
+class CryptoPendingOrdersSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[CryptoPendingOrderItem] = Field(default_factory=list)
+    emptyState: Literal["no_pending_orders"] | None = None
+    source: Literal["pending_orders"] = "pending_orders"
+
+    @field_validator("emptyState")
+    @classmethod
+    def empty_state_matches_items(cls, value, info):
+        items = info.data.get("items") or []
+        if items and value is not None:
+            raise ValueError("emptyState must be null when pending orders are present")
+        if not items and value != "no_pending_orders":
+            raise ValueError(
+                "emptyState must be no_pending_orders when no pending orders exist"
+            )
+        return value
+
+
+class CryptoInsightsSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    badges: list[CryptoRiskBadge] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
+class CryptoDashboardMeta(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    warnings: list[str] = Field(default_factory=list)
+    sources: list[CryptoSourceState] = Field(default_factory=list)
+
+
+class CryptoDashboardResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    asOf: datetime
+    market: Literal["crypto"] = "crypto"
+    baseCurrency: Literal["KRW"] = "KRW"
+    cards: list[CryptoMarketCard]
+    holdings: CryptoHoldingSummary | None = None
+    pendingOrders: CryptoPendingOrdersSummary | None = None
+    insights: CryptoInsightsSummary
+    capabilities: CryptoDashboardCapabilities = Field(
+        default_factory=CryptoDashboardCapabilities
+    )
+    meta: CryptoDashboardMeta

--- a/app/services/invest_view_model/crypto_dashboard_service.py
+++ b/app/services/invest_view_model/crypto_dashboard_service.py
@@ -1,0 +1,331 @@
+"""Read-only crypto dashboard view model for ROB-226."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.pending_order import PendingOrder
+from app.models.upbit_symbol_universe import UpbitSymbolUniverse
+from app.schemas.invest_crypto import (
+    CryptoDashboardMeta,
+    CryptoDashboardResponse,
+    CryptoHoldingSummary,
+    CryptoInsightsSummary,
+    CryptoMarketCard,
+    CryptoPendingOrderItem,
+    CryptoPendingOrdersSummary,
+    CryptoRiskBadge,
+    CryptoSourceState,
+)
+from app.services.invest_view_model.relation_resolver import RelationResolver
+
+TickerProvider = Callable[
+    [list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]
+]
+OrderbookSpreadProvider = Callable[
+    [list[str]], Awaitable[dict[str, float | None]] | dict[str, float | None]
+]
+
+
+async def _maybe_await(value):
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _base_symbol(symbol: str) -> str:
+    normalized = str(symbol or "").upper()
+    if normalized.startswith("KRW-"):
+        return normalized.split("-", 1)[1]
+    if normalized.endswith("-KRW"):
+        return normalized.rsplit("-", 1)[0]
+    return normalized
+
+
+def _ticker_map(rows: Sequence[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    mapped: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        market = str(row.get("market") or "").upper()
+        if market:
+            mapped[market] = row
+    return mapped
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _pending_symbol_variants(symbols: Sequence[str]) -> set[str]:
+    variants: set[str] = set()
+    for symbol in symbols:
+        upper = str(symbol).upper()
+        base = _base_symbol(upper)
+        variants.update({upper, base, f"KRW-{base}", f"{base}-KRW"})
+    return variants
+
+
+async def _default_ticker_provider(markets: list[str]) -> list[dict[str, Any]]:
+    from app.services.brokers.upbit.client import fetch_multiple_tickers
+
+    return await fetch_multiple_tickers(markets)
+
+
+async def _default_orderbook_spread_provider(
+    markets: list[str],
+) -> dict[str, float | None]:
+    from app.services.upbit_orderbook import fetch_multiple_orderbooks
+
+    spreads: dict[str, float | None] = {}
+    orderbooks = await fetch_multiple_orderbooks(markets)
+    for market, book in orderbooks.items():
+        units = list(book.get("orderbook_units") or [])
+        if not units:
+            spreads[str(market).upper()] = None
+            continue
+        best = units[0]
+        ask = _float_or_none(best.get("ask_price"))
+        bid = _float_or_none(best.get("bid_price"))
+        if ask is None or bid is None or bid <= 0:
+            spreads[str(market).upper()] = None
+            continue
+        spreads[str(market).upper()] = ((ask - bid) / bid) * 100
+    return spreads
+
+
+async def _load_active_krw_markets(
+    db: AsyncSession, *, limit: int
+) -> list[UpbitSymbolUniverse]:
+    stmt = (
+        select(UpbitSymbolUniverse)
+        .where(
+            UpbitSymbolUniverse.quote_currency == "KRW",
+            UpbitSymbolUniverse.is_active.is_(True),
+        )
+        .order_by(UpbitSymbolUniverse.market.asc())
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def _load_pending_orders(
+    db: AsyncSession,
+    *,
+    user_id: int,
+    symbols: Sequence[str],
+    limit: int = 20,
+) -> list[PendingOrder]:
+    variants = _pending_symbol_variants(symbols)
+    if not variants:
+        return []
+    stmt = (
+        select(PendingOrder)
+        .where(
+            PendingOrder.user_id == user_id,
+            PendingOrder.market == "crypto",
+            PendingOrder.venue == "upbit",
+            PendingOrder.symbol.in_(sorted(variants)),
+            or_(PendingOrder.status == "open", PendingOrder.status == "partial_fill"),
+        )
+        .order_by(PendingOrder.ordered_at.desc().nullslast())
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+def _build_pending_summary(rows: Sequence[PendingOrder]) -> CryptoPendingOrdersSummary:
+    items = [
+        CryptoPendingOrderItem(
+            orderId=row.broker_order_id,
+            symbol=str(row.symbol).upper(),
+            baseSymbol=_base_symbol(str(row.symbol)),
+            side=row.side,
+            orderType=row.order_type,
+            price=_float_or_none(row.price),
+            quantity=float(row.quantity or 0),
+            filledQuantity=float(row.filled_quantity or 0),
+            status=row.status,
+            orderedAt=row.ordered_at,
+            updatedAt=row.updated_at,
+        )
+        for row in rows
+    ]
+    return CryptoPendingOrdersSummary(
+        items=items,
+        emptyState=None if items else "no_pending_orders",
+    )
+
+
+async def build_crypto_dashboard(
+    *,
+    db: AsyncSession,
+    user_id: int,
+    resolver: RelationResolver | None = None,
+    ticker_provider: TickerProvider | None = None,
+    orderbook_spread_provider: OrderbookSpreadProvider | None = None,
+    limit: int = 20,
+    orderbook_limit: int = 5,
+) -> CryptoDashboardResponse:
+    """Build a read-only crypto dashboard without broker mutations or syncs."""
+    now = datetime.now(UTC)
+    warnings: list[str] = []
+    sources: list[CryptoSourceState] = []
+    limit = max(1, min(limit, 50))
+    orderbook_limit = max(0, min(orderbook_limit, limit))
+
+    universe = await _load_active_krw_markets(db, limit=limit)
+    markets = [row.market.upper() for row in universe]
+
+    tickers: dict[str, dict[str, Any]] = {}
+    if markets:
+        provider = ticker_provider or _default_ticker_provider
+        try:
+            tickers = _ticker_map(await _maybe_await(provider(markets)))
+            sources.append(
+                CryptoSourceState(
+                    source="upbit_ticker",
+                    state="supported",
+                    label="Upbit ticker",
+                    fetchedAt=now,
+                )
+            )
+        except Exception:
+            warnings.append("crypto_ticker_unavailable")
+            sources.append(
+                CryptoSourceState(
+                    source="upbit_ticker", state="unavailable", label="Upbit ticker"
+                )
+            )
+
+    spreads: dict[str, float | None] = {}
+    if markets and orderbook_limit > 0:
+        spread_provider = (
+            orderbook_spread_provider or _default_orderbook_spread_provider
+        )
+        try:
+            raw_spreads = await _maybe_await(spread_provider(markets[:orderbook_limit]))
+            spreads = {str(k).upper(): v for k, v in dict(raw_spreads).items()}
+            sources.append(
+                CryptoSourceState(
+                    source="upbit_orderbook",
+                    state="supported",
+                    label="Upbit orderbook",
+                    fetchedAt=now,
+                )
+            )
+        except Exception:
+            warnings.append("crypto_orderbook_unavailable")
+            sources.append(
+                CryptoSourceState(
+                    source="upbit_orderbook",
+                    state="unavailable",
+                    label="Upbit orderbook",
+                )
+            )
+
+    pending_rows = await _load_pending_orders(db, user_id=user_id, symbols=markets)
+    pending_summary = _build_pending_summary(pending_rows)
+    pending_by_base = {
+        item.baseSymbol for item in pending_summary.items if item.baseSymbol
+    }
+
+    cards: list[CryptoMarketCard] = []
+    held_symbols: list[str] = []
+    for row in universe:
+        symbol = row.market.upper()
+        base = row.base_currency.upper()
+        ticker = tickers.get(symbol, {})
+        direct_keys = {("crypto", symbol), ("crypto", base), ("crypto", f"{base}-KRW")}
+        is_held = bool(
+            resolver
+            and (
+                resolver.is_held("crypto", symbol)
+                or resolver.is_held("crypto", base)
+                or resolver.is_held("crypto", f"{base}-KRW")
+                or bool(direct_keys & resolver.held)
+            )
+        )
+        is_watched = bool(
+            resolver
+            and (
+                resolver.is_watched("crypto", symbol)
+                or resolver.is_watched("crypto", base)
+                or resolver.is_watched("crypto", f"{base}-KRW")
+                or bool(direct_keys & resolver.watch)
+            )
+        )
+        if is_held:
+            held_symbols.append(symbol)
+        badges: list[CryptoRiskBadge] = []
+        if is_held:
+            badges.append(CryptoRiskBadge(kind="held", label="보유", severity="info"))
+        if base in pending_by_base:
+            badges.append(
+                CryptoRiskBadge(
+                    kind="pending_order", label="미체결", severity="warning"
+                )
+            )
+        spread = spreads.get(symbol)
+        if spread is not None and spread > 0.5:
+            badges.append(
+                CryptoRiskBadge(
+                    kind="thin_orderbook",
+                    label="호가 스프레드 주의",
+                    severity="warning",
+                )
+            )
+        if symbol not in tickers:
+            badges.append(
+                CryptoRiskBadge(
+                    kind="data_unavailable", label="시세 없음", severity="warning"
+                )
+            )
+        cards.append(
+            CryptoMarketCard(
+                symbol=symbol,
+                baseSymbol=base,
+                displayName=row.korean_name or row.english_name or base,
+                priceKrw=_float_or_none(ticker.get("trade_price")),
+                changeRate24h=_float_or_none(ticker.get("signed_change_rate")),
+                changeAmount24h=_float_or_none(ticker.get("signed_change_price")),
+                accTradePrice24h=_float_or_none(ticker.get("acc_trade_price_24h")),
+                volume24h=_float_or_none(ticker.get("acc_trade_volume_24h")),
+                orderbookSpreadPct=spread,
+                isHeld=is_held,
+                isWatched=is_watched,
+                badges=badges,
+            )
+        )
+
+    insights = CryptoInsightsSummary(
+        badges=[
+            badge
+            for card in cards
+            for badge in card.badges
+            if badge.kind in {"thin_orderbook", "data_unavailable"}
+        ][:5],
+        notes=["읽기 전용 대시보드입니다. 주문/감시/동기화 작업은 실행하지 않습니다."],
+    )
+
+    return CryptoDashboardResponse(
+        asOf=now,
+        cards=cards,
+        holdings=CryptoHoldingSummary(
+            heldCount=len(held_symbols), symbols=held_symbols
+        ),
+        pendingOrders=pending_summary,
+        insights=insights,
+        meta=CryptoDashboardMeta(warnings=warnings, sources=sources),
+    )

--- a/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, expect, test, vi } from "vitest";
+
+vi.mock("../desktop/RightRemotePanel", () => ({
+  RightRemotePanel: () => <aside data-testid="right-remote-panel" />,
+}));
+
+import { DesktopCryptoPage } from "../pages/desktop/DesktopCryptoPage";
+import * as cryptoApi from "../api/investCrypto";
+import type { CryptoDashboardResponse } from "../types/investCrypto";
+
+const dashboard: CryptoDashboardResponse = {
+  asOf: "2026-05-13T12:00:00Z",
+  market: "crypto",
+  baseCurrency: "KRW",
+  cards: [
+    {
+      symbol: "KRW-BTC",
+      baseSymbol: "BTC",
+      displayName: "비트코인",
+      priceKrw: 101000000,
+      changeRate24h: 0.0123,
+      changeAmount24h: 1230000,
+      accTradePrice24h: 12345678900,
+      volume24h: 234.5,
+      orderbookSpreadPct: 0.62,
+      isHeld: true,
+      isWatched: true,
+      badges: [
+        { kind: "held", label: "보유", severity: "info" },
+        { kind: "pending_order", label: "미체결", severity: "warning" },
+      ],
+    },
+  ],
+  holdings: { heldCount: 1, symbols: ["KRW-BTC"], source: "invest_home_read_model" },
+  pendingOrders: {
+    items: [
+      {
+        orderId: "upbit-open-1",
+        symbol: "KRW-BTC",
+        baseSymbol: "BTC",
+        side: "buy",
+        orderType: "limit",
+        price: 100000000,
+        quantity: 0.01,
+        filledQuantity: 0,
+        status: "open",
+        orderedAt: "2026-05-13T12:00:00Z",
+        updatedAt: "2026-05-13T12:01:00Z",
+        source: "pending_orders",
+      },
+    ],
+    emptyState: null,
+    source: "pending_orders",
+  },
+  insights: { badges: [], notes: ["읽기 전용"] },
+  capabilities: {
+    ticker: { state: "supported", reason: null },
+    candles: { state: "supported", reason: null },
+    orderbook: { state: "supported", reason: null },
+    recentTrades: { state: "external_gap", reason: "upbit_public_dashboard_mvp" },
+    projectInfo: { state: "reference_only", reason: "external_reference_only" },
+    liveStreaming: { state: "deferred", reason: null },
+    execution: { state: "read_only_mvp", reason: null },
+  },
+  meta: { warnings: [], sources: [{ source: "upbit_ticker", state: "supported", label: "Upbit ticker", fetchedAt: "2026-05-13T12:00:00Z" }] },
+};
+
+beforeEach(() => {
+  vi.spyOn(cryptoApi, "fetchCryptoDashboard").mockResolvedValue(dashboard);
+});
+
+test("renders crypto dashboard cards and read-only capability states", async () => {
+  render(
+    <MemoryRouter basename="/invest" initialEntries={["/invest/crypto"]}>
+      <DesktopCryptoPage />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByTestId("crypto-dashboard")).toBeInTheDocument();
+  expect(screen.getByRole("heading", { name: "크립토 대시보드" })).toBeInTheDocument();
+  expect(screen.getByText("비트코인")).toBeInTheDocument();
+  expect(screen.getByText("101,000,000원")).toBeInTheDocument();
+  expect(screen.getByText("보유")).toBeInTheDocument();
+  expect(screen.getByText("미체결")).toBeInTheDocument();
+  expect(screen.getByText(/주문·감시·동기화 작업은 실행하지 않습니다/)).toBeInTheDocument();
+  expect(screen.getByText(/체결\/주문 실행: read_only_mvp/)).toBeInTheDocument();
+});

--- a/frontend/invest/src/api/investCrypto.ts
+++ b/frontend/invest/src/api/investCrypto.ts
@@ -1,0 +1,14 @@
+import type { CryptoDashboardResponse } from "../types/investCrypto";
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { credentials: "include" });
+  if (!res.ok) throw new Error(`${url} ${res.status}`);
+  return res.json();
+}
+
+export async function fetchCryptoDashboard(params: { limit?: number } = {}): Promise<CryptoDashboardResponse> {
+  const q = new URLSearchParams();
+  if (params.limit !== undefined) q.set("limit", String(params.limit));
+  const qs = q.toString();
+  return getJson<CryptoDashboardResponse>(`/invest/api/crypto/dashboard${qs ? `?${qs}` : ""}`);
+}

--- a/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { DesktopShell } from "../../desktop/DesktopShell";
+import { RightRemotePanel } from "../../desktop/RightRemotePanel";
+import { fetchCryptoDashboard } from "../../api/investCrypto";
+import type { CryptoDashboardResponse, CryptoMarketCard } from "../../types/investCrypto";
+import "../../desktop/screener/screener.css";
+
+function formatKrw(value: number | null): string {
+  if (value === null || Number.isNaN(value)) return "-";
+  return `${Math.round(value).toLocaleString("ko-KR")}원`;
+}
+
+function formatPct(value: number | null): string {
+  if (value === null || Number.isNaN(value)) return "-";
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+function cardMetric(card: CryptoMarketCard): string {
+  if (card.accTradePrice24h === null) return "거래대금 -";
+  if (card.accTradePrice24h >= 1_0000_0000) {
+    return `거래대금 ${(card.accTradePrice24h / 1_0000_0000).toFixed(1)}억`;
+  }
+  return `거래대금 ${Math.round(card.accTradePrice24h).toLocaleString("ko-KR")}`;
+}
+
+function CryptoCard({ card }: { card: CryptoMarketCard }) {
+  return (
+    <Link
+      to={`/crypto/${encodeURIComponent(card.symbol)}`}
+      style={{
+        display: "block",
+        padding: 16,
+        border: "1px solid var(--border)",
+        borderRadius: 14,
+        background: "var(--surface)",
+        color: "inherit",
+        textDecoration: "none",
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12 }}>
+        <div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{card.symbol}</div>
+          <h3 style={{ margin: "4px 0 0" }}>{card.displayName}</h3>
+        </div>
+        <div style={{ textAlign: "right" }}>
+          <strong>{formatKrw(card.priceKrw)}</strong>
+          <div style={{ color: (card.changeRate24h ?? 0) >= 0 ? "var(--danger)" : "var(--blue)", fontSize: 13 }}>
+            {formatPct(card.changeRate24h)}
+          </div>
+        </div>
+      </div>
+      <div style={{ marginTop: 12, color: "var(--fg-3)", fontSize: 13 }}>
+        {cardMetric(card)} · 호가 스프레드 {card.orderbookSpreadPct === null ? "-" : `${card.orderbookSpreadPct.toFixed(3)}%`}
+      </div>
+      {card.badges.length > 0 && (
+        <div style={{ marginTop: 10, display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {card.badges.map((badge, idx) => (
+            <span key={`${badge.kind}-${idx}`} className="screener-chip">
+              {badge.label}
+            </span>
+          ))}
+        </div>
+      )}
+    </Link>
+  );
+}
+
+function cryptoErrorMessage(error: unknown): string {
+  const text = error instanceof Error ? error.message : String(error ?? "");
+  if (/Failed to fetch|NetworkError|Load failed|crypto\/dashboard \d{3}/i.test(text)) {
+    return "크립토 대시보드 데이터를 일시적으로 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.";
+  }
+  return text || "크립토 대시보드 데이터를 일시적으로 불러오지 못했습니다.";
+}
+
+export function DesktopCryptoPage() {
+  const [data, setData] = useState<CryptoDashboardResponse | undefined>();
+  const [err, setErr] = useState<string | undefined>();
+
+  useEffect(() => {
+    let cancel = false;
+    setErr(undefined);
+    fetchCryptoDashboard({ limit: 20 })
+      .then((response) => {
+        if (cancel) return;
+        setData(response);
+      })
+      .catch((error) => !cancel && setErr(cryptoErrorMessage(error)));
+    return () => { cancel = true; };
+  }, []);
+
+  return (
+    <DesktopShell
+      left={
+        <aside style={{ padding: 16 }}>
+          <h2 style={{ marginTop: 0 }}>크립토</h2>
+          <p style={{ color: "var(--fg-3)", lineHeight: 1.5 }}>
+            Upbit KRW 마켓 읽기 전용 화면입니다. 주문·감시·동기화 작업은 실행하지 않습니다.
+          </p>
+          {data?.pendingOrders && (
+            <p style={{ color: "var(--fg-3)", fontSize: 13 }}>
+              미체결 {data.pendingOrders.items.length}건 · 보유 {data.holdings?.heldCount ?? 0}종목
+            </p>
+          )}
+        </aside>
+      }
+      center={
+        <main data-testid="crypto-dashboard" style={{ padding: 16 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 16 }}>
+            <div>
+              <h1 style={{ margin: 0 }}>크립토 대시보드</h1>
+              <p style={{ marginTop: 6, color: "var(--fg-3)" }}>KRW 마켓 시세, 호가 스프레드, 보유/미체결 상태</p>
+            </div>
+            <Link to="/screener" className="screener-chip">스크리너로 이동</Link>
+          </div>
+          {err && <div style={{ color: "var(--danger)", marginTop: 16 }}>오류: {err}</div>}
+          {!data && !err && <div style={{ padding: 16, color: "var(--fg-3)" }}>불러오는 중...</div>}
+          {data && (
+            <>
+              {data.meta.warnings.length > 0 && (
+                <ul className="screener-warnings" aria-label="crypto warnings">
+                  {data.meta.warnings.map((warning) => <li key={warning}>{warning}</li>)}
+                </ul>
+              )}
+              <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 12, marginTop: 16 }}>
+                {data.cards.map((card) => <CryptoCard key={card.symbol} card={card} />)}
+              </section>
+              <section style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14 }}>
+                <h2 style={{ marginTop: 0 }}>기능 상태</h2>
+                <p style={{ color: "var(--fg-3)" }}>체결/주문 실행: {data.capabilities.execution.state} · 실시간 스트리밍: {data.capabilities.liveStreaming.state}</p>
+                <p style={{ color: "var(--fg-3)" }}>최근 체결/프로젝트 정보는 참고용 또는 외부 데이터 공백으로 표시됩니다.</p>
+              </section>
+            </>
+          )}
+        </main>
+      }
+      right={<RightRemotePanel />}
+    />
+  );
+}

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -32,6 +32,7 @@ import { CoverageRoute } from "./pages/desktop/DesktopCoveragePage";
 import { DesktopScreenerPage } from "./pages/desktop/DesktopScreenerPage";
 import { DesktopMarketPage } from "./pages/desktop/DesktopMarketPage";
 import { FxMacroRoute } from "./pages/desktop/FxMacroPage";
+import { DesktopCryptoPage } from "./pages/desktop/DesktopCryptoPage";
 import { StockDetailPage } from "./pages/stock-detail/StockDetailPage";
 
 // Static legacy /app/* redirect that preserves any ?search and #hash
@@ -49,6 +50,12 @@ function DiscoverIssueRedirect() {
   const { issueId } = useParams();
   const { search, hash } = useLocation();
   return <Navigate to={`/discover/issues/${issueId ?? ""}${search}${hash}`} replace />;
+}
+
+function CryptoPairRedirect() {
+  const { pair } = useParams();
+  const { search, hash } = useLocation();
+  return <Navigate to={`/stocks/crypto/${encodeURIComponent(pair ?? "")}${search}${hash}`} replace />;
 }
 
 export const router = createBrowserRouter(
@@ -70,6 +77,8 @@ export const router = createBrowserRouter(
     { path: "/coverage", element: <CoverageRoute /> },
     { path: "/market", element: <DesktopMarketPage /> },
     { path: "/market/fx", element: <FxMacroRoute /> },
+    { path: "/crypto", element: <DesktopCryptoPage /> },
+    { path: "/crypto/:pair", element: <CryptoPairRedirect /> },
     { path: "/screener", element: <DesktopScreenerPage /> },
     { path: "/stocks/:market/:symbol", element: <StockDetailPage /> },
 

--- a/frontend/invest/src/types/investCrypto.ts
+++ b/frontend/invest/src/types/investCrypto.ts
@@ -1,0 +1,101 @@
+export type CryptoCapabilityState =
+  | "supported"
+  | "unavailable"
+  | "reference_only"
+  | "external_gap"
+  | "deferred"
+  | "read_only_mvp";
+
+export type CryptoRiskBadgeKind =
+  | "thin_orderbook"
+  | "held"
+  | "pending_order"
+  | "data_unavailable"
+  | "high_volatility";
+
+export interface CryptoSourceState {
+  source: string;
+  state: CryptoCapabilityState;
+  label: string;
+  fetchedAt: string | null;
+}
+
+export interface CryptoCapabilityFlag {
+  state: CryptoCapabilityState;
+  reason: string | null;
+}
+
+export interface CryptoDashboardCapabilities {
+  ticker: CryptoCapabilityFlag;
+  candles: CryptoCapabilityFlag;
+  orderbook: CryptoCapabilityFlag;
+  recentTrades: CryptoCapabilityFlag;
+  projectInfo: CryptoCapabilityFlag;
+  liveStreaming: CryptoCapabilityFlag;
+  execution: CryptoCapabilityFlag;
+}
+
+export interface CryptoRiskBadge {
+  kind: CryptoRiskBadgeKind;
+  label: string;
+  severity: "info" | "warning" | "danger";
+}
+
+export interface CryptoMarketCard {
+  symbol: string;
+  baseSymbol: string;
+  displayName: string;
+  priceKrw: number | null;
+  changeRate24h: number | null;
+  changeAmount24h: number | null;
+  accTradePrice24h: number | null;
+  volume24h: number | null;
+  orderbookSpreadPct: number | null;
+  isHeld: boolean;
+  isWatched: boolean;
+  badges: CryptoRiskBadge[];
+}
+
+export interface CryptoHoldingSummary {
+  heldCount: number;
+  symbols: string[];
+  source: "invest_home_read_model";
+}
+
+export interface CryptoPendingOrderItem {
+  orderId: string | null;
+  symbol: string;
+  baseSymbol: string | null;
+  side: string;
+  orderType: string | null;
+  price: number | null;
+  quantity: number;
+  filledQuantity: number;
+  status: string;
+  orderedAt: string | null;
+  updatedAt: string | null;
+  source: "pending_orders";
+}
+
+export interface CryptoPendingOrdersSummary {
+  items: CryptoPendingOrderItem[];
+  emptyState: "no_pending_orders" | null;
+  source: "pending_orders";
+}
+
+export interface CryptoInsightsSummary {
+  badges: CryptoRiskBadge[];
+  notes: string[];
+}
+
+export interface CryptoDashboardResponse {
+  asOf: string;
+  market: "crypto";
+  baseCurrency: "KRW";
+  cards: CryptoMarketCard[];
+  holdings: CryptoHoldingSummary | null;
+  pendingOrders: CryptoPendingOrdersSummary | null;
+  insights: CryptoInsightsSummary;
+  capabilities: CryptoDashboardCapabilities;
+  meta: { warnings: string[]; sources: CryptoSourceState[] };
+}

--- a/tests/test_invest_api_crypto_router.py
+++ b/tests/test_invest_api_crypto_router.py
@@ -1,0 +1,85 @@
+"""ROB-226 router tests for read-only /invest/api/crypto endpoints."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import app.routers.invest_api as invest_api
+from app.core.db import get_db
+from app.routers.dependencies import get_authenticated_user
+from app.routers.invest_api import get_invest_home_service
+from app.routers.invest_api import router as invest_api_router
+from app.schemas.invest_crypto import (
+    CryptoDashboardMeta,
+    CryptoDashboardResponse,
+    CryptoInsightsSummary,
+)
+from app.schemas.invest_home import InvestHomeResponse, InvestHomeResponseMeta
+from app.services.invest_home_service import build_grouped_holdings, build_home_summary
+
+
+class _StubHomeService:
+    async def get_home(self, *, user_id: int) -> InvestHomeResponse:
+        return InvestHomeResponse(
+            homeSummary=build_home_summary([]),
+            accounts=[],
+            holdings=[],
+            groupedHoldings=build_grouped_holdings([]),
+            meta=InvestHomeResponseMeta(warnings=[]),
+        )
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(invest_api_router)
+    app.dependency_overrides[get_authenticated_user] = lambda: type(
+        "U", (), {"id": 7}
+    )()
+    app.dependency_overrides[get_invest_home_service] = lambda: _StubHomeService()
+
+    async def _db_override():
+        yield object()
+
+    app.dependency_overrides[get_db] = _db_override
+    return app
+
+
+@pytest.mark.unit
+def test_crypto_dashboard_endpoint_uses_read_only_view_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, Any] = {}
+
+    async def fake_relation_resolver(
+        db: Any, *, user_id: int, held_pairs: set[tuple[str, str]]
+    ):
+        calls["relation"] = {"db": db, "user_id": user_id, "held_pairs": held_pairs}
+        return object()
+
+    async def fake_dashboard(**kwargs: Any) -> CryptoDashboardResponse:
+        calls["dashboard"] = kwargs
+        return CryptoDashboardResponse(
+            asOf=datetime(2026, 5, 13, 12, tzinfo=UTC),
+            cards=[],
+            holdings=None,
+            pendingOrders=None,
+            insights=CryptoInsightsSummary(notes=["read-only"]),
+            meta=CryptoDashboardMeta(warnings=[], sources=[]),
+        )
+
+    monkeypatch.setattr(invest_api, "build_relation_resolver", fake_relation_resolver)
+    monkeypatch.setattr(invest_api, "build_crypto_dashboard", fake_dashboard)
+
+    response = TestClient(_build_app()).get("/invest/api/crypto/dashboard?limit=3")
+
+    assert response.status_code == 200
+    assert response.json()["market"] == "crypto"
+    assert calls["relation"]["user_id"] == 7
+    assert calls["dashboard"]["user_id"] == 7
+    assert calls["dashboard"]["limit"] == 3
+    assert calls["dashboard"]["resolver"] is not None

--- a/tests/test_invest_api_router_safety.py
+++ b/tests/test_invest_api_router_safety.py
@@ -70,3 +70,12 @@ def test_invest_home_service_no_mutation_imports() -> None:
     v = _violations(loaded, FORBIDDEN_MUTATION_MODULES)
     if v:
         pytest.fail(f"Forbidden imports in invest_home_service: {v}")
+
+
+@pytest.mark.unit
+def test_crypto_dashboard_service_no_mutation_imports() -> None:
+    root = Path(__file__).resolve().parent.parent
+    loaded = _loaded("app.services.invest_view_model.crypto_dashboard_service", root)
+    v = _violations(loaded, FORBIDDEN_MUTATION_MODULES)
+    if v:
+        pytest.fail(f"Forbidden imports in crypto_dashboard_service: {v}")

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.models.pending_order import PendingOrder
+from app.services.invest_view_model.crypto_dashboard_service import (
+    build_crypto_dashboard,
+)
+from app.services.invest_view_model.relation_resolver import RelationResolver
+
+
+class _ScalarRows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return _ScalarRows(self._rows)
+
+
+class FakeSession:
+    def __init__(self, universe_rows, pending_rows=None):
+        self.universe_rows = universe_rows
+        self.pending_rows = pending_rows or []
+        self.statements = []
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        if len(self.statements) == 1:
+            return _Result(self.universe_rows)
+        return _Result(self.pending_rows)
+
+
+def _market(market="KRW-BTC", base="BTC", korean_name="비트코인"):
+    return SimpleNamespace(
+        market=market,
+        base_currency=base,
+        quote_currency="KRW",
+        korean_name=korean_name,
+        english_name="Bitcoin",
+        is_active=True,
+    )
+
+
+def _pending(symbol="KRW-BTC"):
+    row = PendingOrder()
+    row.user_id = 7
+    row.symbol = symbol
+    row.market = "crypto"
+    row.venue = "upbit"
+    row.broker_order_id = "upbit-open-1"
+    row.side = "buy"
+    row.order_type = "limit"
+    row.price = 100000000
+    row.quantity = 0.01
+    row.filled_quantity = 0
+    row.status = "open"
+    row.ordered_at = datetime(2026, 5, 13, 12, tzinfo=UTC)
+    row.updated_at = datetime(2026, 5, 13, 12, 1, tzinfo=UTC)
+    return row
+
+
+@pytest.mark.asyncio
+async def test_crypto_dashboard_maps_ticker_spread_relation_and_pending_orders():
+    async def ticker_provider(markets):
+        assert markets == ["KRW-BTC"]
+        return [
+            {
+                "market": "KRW-BTC",
+                "trade_price": 101000000,
+                "signed_change_rate": 0.0123,
+                "signed_change_price": 1230000,
+                "acc_trade_price_24h": 12345678900,
+                "acc_trade_volume_24h": 234.5,
+            }
+        ]
+
+    async def spread_provider(markets):
+        assert markets == ["KRW-BTC"]
+        return {"KRW-BTC": 0.62}
+
+    resolver = RelationResolver(
+        held={("crypto", "KRW-BTC")}, watch={("crypto", "KRW-BTC")}
+    )
+    response = await build_crypto_dashboard(
+        db=FakeSession([_market()], [_pending("BTC")]),
+        user_id=7,
+        resolver=resolver,
+        ticker_provider=ticker_provider,
+        orderbook_spread_provider=spread_provider,
+    )
+
+    assert response.market == "crypto"
+    assert response.cards[0].symbol == "KRW-BTC"
+    assert response.cards[0].priceKrw == 101000000
+    assert response.cards[0].orderbookSpreadPct == pytest.approx(0.62)
+    assert response.cards[0].isHeld is True
+    assert response.cards[0].isWatched is True
+    assert {badge.kind for badge in response.cards[0].badges} >= {
+        "held",
+        "pending_order",
+        "thin_orderbook",
+    }
+    assert response.pendingOrders is not None
+    assert response.pendingOrders.items[0].orderId == "upbit-open-1"
+    assert response.pendingOrders.emptyState is None
+    assert response.capabilities.execution.state == "read_only_mvp"
+
+
+@pytest.mark.asyncio
+async def test_crypto_dashboard_is_renderable_when_public_sources_fail():
+    async def failing_ticker(_markets):
+        raise RuntimeError("upstream down")
+
+    async def failing_spread(_markets):
+        raise RuntimeError("upstream down")
+
+    response = await build_crypto_dashboard(
+        db=FakeSession([_market()], []),
+        user_id=7,
+        ticker_provider=failing_ticker,
+        orderbook_spread_provider=failing_spread,
+    )
+
+    assert response.cards[0].priceKrw is None
+    assert response.pendingOrders is not None
+    assert response.pendingOrders.emptyState == "no_pending_orders"
+    assert "crypto_ticker_unavailable" in response.meta.warnings
+    assert "crypto_orderbook_unavailable" in response.meta.warnings
+    assert {source.state for source in response.meta.sources} == {"unavailable"}


### PR DESCRIPTION
## Summary
- Add read-only `/invest/api/crypto/dashboard` view model with ticker/orderbook capability states and pending-order/holding context from SELECT-only data paths.
- Add `/invest/crypto` desktop page and `/invest/crypto/:pair` route handoff to existing read-only crypto detail surface.
- Extend screener market handling and regression coverage for the crypto entry points.

## Safety
- Read-only crypto data/UI surface only.
- No broker/order/watch/order-intent mutations.
- No Upbit/KIS/Alpaca submit/cancel/modify calls.
- No production DB writes/backfills/deletes or scheduler activation.

## Verification
- `uv run pytest tests/test_invest_crypto_dashboard_service.py tests/test_invest_api_crypto_router.py tests/test_invest_api_router_safety.py -q` — 6 passed, 2 existing Pydantic deprecation warnings.
- `python -m ruff check app/routers/invest_api.py app/schemas/invest_crypto.py app/services/invest_view_model/crypto_dashboard_service.py tests/test_invest_crypto_dashboard_service.py tests/test_invest_api_crypto_router.py tests/test_invest_api_router_safety.py` — passed.
- `git diff --check` — passed.
- `npm test -- --run src/__tests__/DesktopCryptoPage.test.tsx src/__tests__/DesktopScreenerPage.test.tsx src/__tests__/routes.test.tsx` — 3 files passed, 9 tests passed.
- `npm run typecheck` — passed.
- `npm run build` — passed.

## Review
- Kanban parent review passed at pre-rebase commit 5f333b64 with no blocking findings.
- Rebased onto origin/main de0cfa94 and resolved the screener crypto-label conflict by preserving the current market-change reset behavior and Korean `가상자산` label.

Linear: ROB-226
