### PR TITLE
feat(invest): add crypto screener snapshots

### DIFF
--- a/alembic/versions/2026_05_13_rob225_crypto_screener_snapshots.py
+++ b/alembic/versions/2026_05_13_rob225_crypto_screener_snapshots.py
@@ -1,0 +1,121 @@
+"""Add crypto screener snapshot table for ROB-225.
+
+Revision ID: 20260513_rob225
+Revises: 20260513_rob227
+Create Date: 2026-05-13
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "20260513_rob225"
+down_revision = "20260513_rob227"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "invest_crypto_screener_snapshots",
+        sa.Column("id", sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column("symbol", sa.String(length=20), nullable=False),
+        sa.Column("snapshot_date", sa.Date(), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=True),
+        sa.Column("latest_close", sa.Numeric(24, 8), nullable=False),
+        sa.Column("change_amount", sa.Numeric(24, 8), nullable=True),
+        sa.Column("change_rate", sa.Numeric(10, 4), nullable=True),
+        sa.Column("trade_amount_24h", sa.Numeric(28, 4), nullable=True),
+        sa.Column("volume_24h", sa.Numeric(28, 8), nullable=True),
+        sa.Column("volume_24h_usd", sa.Numeric(28, 4), nullable=True),
+        sa.Column("market_cap", sa.Numeric(28, 4), nullable=True),
+        sa.Column("rsi", sa.Numeric(10, 4), nullable=True),
+        sa.Column("adx", sa.Numeric(10, 4), nullable=True),
+        sa.Column(
+            "market_warning",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.Column(
+            "raw_payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'{}'::jsonb"),
+            nullable=False,
+        ),
+        sa.Column("source", sa.String(length=32), nullable=False),
+        sa.Column(
+            "computed_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "symbol",
+            "snapshot_date",
+            name="uq_invest_crypto_screener_snapshots_symbol_date",
+        ),
+        sa.CheckConstraint(
+            "symbol LIKE 'KRW-%'",
+            name="ck_invest_crypto_screener_snapshots_symbol",
+        ),
+        sa.CheckConstraint(
+            "source IN ('tvscreener_upbit')",
+            name="ck_invest_crypto_screener_snapshots_source",
+        ),
+    )
+    op.create_index(
+        "ix_invest_crypto_screener_snapshots_date",
+        "invest_crypto_screener_snapshots",
+        ["snapshot_date"],
+    )
+    op.create_index(
+        "ix_invest_crypto_screener_snapshots_date_trade_amount",
+        "invest_crypto_screener_snapshots",
+        ["snapshot_date", "trade_amount_24h"],
+    )
+    op.create_index(
+        "ix_invest_crypto_screener_snapshots_date_rsi",
+        "invest_crypto_screener_snapshots",
+        ["snapshot_date", "rsi"],
+    )
+    op.create_index(
+        "ix_invest_crypto_screener_snapshots_date_change_rate",
+        "invest_crypto_screener_snapshots",
+        ["snapshot_date", "change_rate"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_invest_crypto_screener_snapshots_date_change_rate",
+        table_name="invest_crypto_screener_snapshots",
+    )
+    op.drop_index(
+        "ix_invest_crypto_screener_snapshots_date_rsi",
+        table_name="invest_crypto_screener_snapshots",
+    )
+    op.drop_index(
+        "ix_invest_crypto_screener_snapshots_date_trade_amount",
+        table_name="invest_crypto_screener_snapshots",
+    )
+    op.drop_index(
+        "ix_invest_crypto_screener_snapshots_date",
+        table_name="invest_crypto_screener_snapshots",
+    )
+    op.drop_table("invest_crypto_screener_snapshots")

--- a/app/jobs/invest_crypto_screener_snapshots.py
+++ b/app/jobs/invest_crypto_screener_snapshots.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from app.core.db import AsyncSessionLocal
+from app.services.invest_crypto_screener_snapshots.builder import build_crypto_snapshots
+from app.services.invest_crypto_screener_snapshots.provider import (
+    TvScreenerUpbitCryptoSnapshotProvider,
+)
+from app.services.invest_crypto_screener_snapshots.repository import (
+    InvestCryptoScreenerSnapshotsRepository,
+)
+
+
+@dataclass(frozen=True)
+class CryptoSnapshotBuildRequest:
+    limit: int | None = 50
+    all_markets: bool = False
+    commit: bool = False
+
+
+async def run_crypto_snapshot_build(
+    request: CryptoSnapshotBuildRequest,
+) -> dict[str, Any]:
+    limit = None if request.all_markets else request.limit
+    async with AsyncSessionLocal() as session:
+        result = await build_crypto_snapshots(
+            provider=TvScreenerUpbitCryptoSnapshotProvider(),
+            repository=InvestCryptoScreenerSnapshotsRepository(session),
+            commit=request.commit,
+            limit=limit,
+        )
+        if request.commit:
+            await session.commit()
+        else:
+            await session.rollback()
+        return result

--- a/app/mcp_server/tooling/screening/crypto.py
+++ b/app/mcp_server/tooling/screening/crypto.py
@@ -174,11 +174,13 @@ async def _normalize_crypto_results(
     min_market_cap: float | None,
     filters_applied: dict[str, Any],
     limit: int,
+    pure_market_snapshot: bool = False,
 ) -> dict[str, Any]:
-    """Map tvscreener crypto DataFrame to filtered candidate list and finalize.
+    """Map tvscreener crypto DataFrame to candidate rows and finalize.
 
-    Applies Upbit symbol mapping, warning-market filter, crash filter,
-    cooldown filter, RSI filter, and delegates to finalize_crypto_screen.
+    The normal MCP screening path applies warning-market, crash, and
+    stop-loss-cooldown filters.  Snapshot builds pass ``pure_market_snapshot``
+    so persisted rows remain provider/account-state agnostic market data.
     """
     warnings: list[str] = []
     if min_market_cap is not None:
@@ -286,20 +288,24 @@ async def _normalize_crypto_results(
                 "KRW-BTC change rate is missing; crash filter uses btc_change_24h=0.0 fallback."
             )
 
-    # Apply warning + crash filters, build candidates
+    # Apply warning + crash filters for interactive screening; snapshot builds keep
+    # every provider row and only carry warning metadata forward.
     filtered_by_warning = 0
     filtered_by_crash = 0
     candidates: list[dict[str, Any]] = []
     for raw_item in raw_results:
         market_code = str(raw_item.get("symbol") or "").strip().upper()
-        if market_code in warning_markets:
+        is_warning_market = market_code in warning_markets
+        if is_warning_market and not pure_market_snapshot:
             filtered_by_warning += 1
             continue
 
         coin_change_24h = raw_item.get("signed_change_rate")
         if coin_change_24h is None:
             coin_change_24h = raw_item.get("change_rate")
-        if not is_safe_drop(coin_change_24h, btc_change_24h):
+        if not pure_market_snapshot and not is_safe_drop(
+            coin_change_24h, btc_change_24h
+        ):
             filtered_by_crash += 1
             continue
 
@@ -322,7 +328,7 @@ async def _normalize_crypto_results(
             "volume_24h": ticker_volume_map.get(market_code, 0.0),
             "market_cap": _to_optional_float(raw_item.get("tv_market_cap")),
             "market_cap_rank": None,
-            "market_warning": None,
+            "market_warning": is_warning_market if pure_market_snapshot else None,
             "rsi": _to_optional_float(raw_item.get("rsi")),
             "volume_ratio": None,
             "candle_type": "flat",
@@ -340,27 +346,34 @@ async def _normalize_crypto_results(
             if item.get("rsi") is not None and float(item["rsi"]) <= max_rsi
         ]
 
-    # Cooldown filter + coingecko fetch
-    coingecko_fetch_task = asyncio.create_task(_run_crypto_coingecko_fetch())
+    # Cooldown filter + coingecko fetch.  Snapshot builds must not consult
+    # account/trade-state cooldowns and should not blend in non-Upbit/TV market
+    # data before persistence.
+    coingecko_fetch_task = (
+        None
+        if pure_market_snapshot
+        else asyncio.create_task(_run_crypto_coingecko_fetch())
+    )
     try:
         filtered_by_cooldown = 0
-        try:
-            cooldown_service = _get_crypto_trade_cooldown_service()
-            blocked_symbols = await cooldown_service.filter_symbols_in_cooldown(
-                str(item.get("symbol") or "") for item in candidates
-            )
-            if blocked_symbols:
-                candidates = [
-                    item
-                    for item in candidates
-                    if str(item.get("symbol") or "").strip().upper()
-                    not in blocked_symbols
-                ]
-                filtered_by_cooldown = len(blocked_symbols)
-        except Exception as exc:
-            warnings.append(
-                f"Stop-loss cooldown filter failed; showing all candidates ({type(exc).__name__}: {exc})"
-            )
+        if not pure_market_snapshot:
+            try:
+                cooldown_service = _get_crypto_trade_cooldown_service()
+                blocked_symbols = await cooldown_service.filter_symbols_in_cooldown(
+                    str(item.get("symbol") or "") for item in candidates
+                )
+                if blocked_symbols:
+                    candidates = [
+                        item
+                        for item in candidates
+                        if str(item.get("symbol") or "").strip().upper()
+                        not in blocked_symbols
+                    ]
+                    filtered_by_cooldown = len(blocked_symbols)
+            except Exception as exc:
+                warnings.append(
+                    f"Stop-loss cooldown filter failed; showing all candidates ({type(exc).__name__}: {exc})"
+                )
 
         if max_rsi is not None:
             candidates = [
@@ -370,9 +383,19 @@ async def _normalize_crypto_results(
             ]
 
         metric_diagnostics = _empty_rsi_enrichment_diagnostics()
-        coingecko_payload = await coingecko_fetch_task
+        coingecko_payload = (
+            {
+                "data": {},
+                "cached": False,
+                "age_seconds": None,
+                "stale": False,
+                "error": None,
+            }
+            if coingecko_fetch_task is None
+            else await coingecko_fetch_task
+        )
     finally:
-        if not coingecko_fetch_task.done():
+        if coingecko_fetch_task is not None and not coingecko_fetch_task.done():
             coingecko_fetch_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await coingecko_fetch_task
@@ -406,6 +429,7 @@ async def _screen_crypto_via_tvscreener(
     sort_by: str,
     sort_order: str,
     limit: int,
+    pure_market_snapshot: bool = False,
 ) -> dict[str, Any]:
     (
         min_dividend_yield_input,
@@ -453,6 +477,7 @@ async def _screen_crypto_via_tvscreener(
         min_market_cap=min_market_cap,
         filters_applied=filters_applied,
         limit=limit,
+        pure_market_snapshot=pure_market_snapshot,
     )
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -3,6 +3,7 @@ from .analysis import StockAnalysisResult, StockInfo
 from .base import Base
 from .crypto_insight_snapshot import CryptoInsightSnapshot
 from .execution_ledger import ExecutionLedger, ExecutionLedgerReconcileRun
+from .invest_crypto_screener_snapshot import InvestCryptoScreenerSnapshot
 from .invest_momentum_event_snapshot import (
     InvestMomentumEventSnapshot,
     InvestThemeEventSnapshot,
@@ -112,6 +113,7 @@ __all__ = [
     "StockInfo",
     "StockAnalysisResult",
     "InvestorFlowSnapshot",
+    "InvestCryptoScreenerSnapshot",
     "InvestMomentumEventSnapshot",
     "InvestThemeEventSnapshot",
     "InvestThemeEventSnapshotStock",

--- a/app/models/invest_crypto_screener_snapshot.py
+++ b/app/models/invest_crypto_screener_snapshot.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import (
+    TIMESTAMP,
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    Date,
+    Index,
+    Numeric,
+    String,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class InvestCryptoScreenerSnapshot(Base):
+    __tablename__ = "invest_crypto_screener_snapshots"
+    __table_args__ = (
+        UniqueConstraint(
+            "symbol",
+            "snapshot_date",
+            name="uq_invest_crypto_screener_snapshots_symbol_date",
+        ),
+        CheckConstraint(
+            "symbol LIKE 'KRW-%'",
+            name="symbol",
+        ),
+        CheckConstraint(
+            "source IN ('tvscreener_upbit')",
+            name="source",
+        ),
+        Index("ix_invest_crypto_screener_snapshots_date", "snapshot_date"),
+        Index(
+            "ix_invest_crypto_screener_snapshots_date_trade_amount",
+            "snapshot_date",
+            "trade_amount_24h",
+        ),
+        Index(
+            "ix_invest_crypto_screener_snapshots_date_rsi",
+            "snapshot_date",
+            "rsi",
+        ),
+        Index(
+            "ix_invest_crypto_screener_snapshots_date_change_rate",
+            "snapshot_date",
+            "change_rate",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    symbol: Mapped[str] = mapped_column(String(20), nullable=False)
+    snapshot_date: Mapped[date] = mapped_column(Date, nullable=False)
+    name: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    latest_close: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    change_amount: Mapped[Decimal | None] = mapped_column(Numeric(24, 8), nullable=True)
+    change_rate: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
+    trade_amount_24h: Mapped[Decimal | None] = mapped_column(
+        Numeric(28, 4), nullable=True
+    )
+    volume_24h: Mapped[Decimal | None] = mapped_column(Numeric(28, 8), nullable=True)
+    volume_24h_usd: Mapped[Decimal | None] = mapped_column(
+        Numeric(28, 4), nullable=True
+    )
+    market_cap: Mapped[Decimal | None] = mapped_column(Numeric(28, 4), nullable=True)
+    rsi: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
+    adx: Mapped[Decimal | None] = mapped_column(Numeric(10, 4), nullable=True)
+    market_warning: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false"), default=False
+    )
+    raw_payload: Mapped[dict[str, Any]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb"), default=dict
+    )
+    source: Mapped[str] = mapped_column(String(32), nullable=False)
+    computed_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/app/services/invest_crypto_screener_snapshots/__init__.py
+++ b/app/services/invest_crypto_screener_snapshots/__init__.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from .builder import (
+    CryptoProviderRow,
+    build_crypto_snapshot_payloads,
+    build_crypto_snapshots,
+)
+from .freshness import (
+    CRYPTO_STALE_AFTER,
+    DataState,
+    classify_crypto_partition,
+    today_crypto_snapshot_date,
+)
+from .repository import (
+    CryptoCoverageCounts,
+    CryptoSnapshotUpsert,
+    InvestCryptoScreenerSnapshotsRepository,
+)
+
+__all__ = [
+    "CRYPTO_STALE_AFTER",
+    "CryptoCoverageCounts",
+    "CryptoProviderRow",
+    "CryptoSnapshotUpsert",
+    "DataState",
+    "InvestCryptoScreenerSnapshotsRepository",
+    "build_crypto_snapshot_payloads",
+    "build_crypto_snapshots",
+    "classify_crypto_partition",
+    "today_crypto_snapshot_date",
+]

--- a/app/services/invest_crypto_screener_snapshots/builder.py
+++ b/app/services/invest_crypto_screener_snapshots/builder.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+from decimal import Decimal, InvalidOperation
+from typing import Any, Protocol
+
+from app.services.invest_crypto_screener_snapshots.freshness import (
+    today_crypto_snapshot_date,
+)
+from app.services.invest_crypto_screener_snapshots.repository import (
+    CryptoSnapshotUpsert,
+    InvestCryptoScreenerSnapshotsRepository,
+)
+
+
+@dataclass(frozen=True)
+class CryptoProviderRow:
+    symbol: str
+    latest_close: Decimal
+    name: str | None = None
+    change_amount: Decimal | None = None
+    change_rate: Decimal | None = None
+    trade_amount_24h: Decimal | None = None
+    volume_24h: Decimal | None = None
+    volume_24h_usd: Decimal | None = None
+    market_cap: Decimal | None = None
+    rsi: Decimal | None = None
+    adx: Decimal | None = None
+    market_warning: bool = False
+    raw_payload: dict[str, Any] = field(default_factory=dict)
+
+
+class CryptoSnapshotProvider(Protocol):
+    async def fetch_rows(
+        self, *, limit: int | None = None
+    ) -> list[CryptoProviderRow]: ...
+
+
+def _decimal_or_none(value: Any) -> Decimal | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def build_crypto_snapshot_payloads(
+    rows: list[CryptoProviderRow], *, snapshot_date: dt.date
+) -> list[CryptoSnapshotUpsert]:
+    payloads: list[CryptoSnapshotUpsert] = []
+    for row in rows:
+        symbol = str(row.symbol or "").strip().upper()
+        if not symbol.startswith("KRW-"):
+            continue
+        payloads.append(
+            CryptoSnapshotUpsert(
+                symbol=symbol,
+                snapshot_date=snapshot_date,
+                name=row.name,
+                latest_close=row.latest_close,
+                change_amount=row.change_amount,
+                change_rate=row.change_rate,
+                trade_amount_24h=row.trade_amount_24h,
+                volume_24h=row.volume_24h,
+                volume_24h_usd=row.volume_24h_usd,
+                market_cap=row.market_cap,
+                rsi=row.rsi,
+                adx=row.adx,
+                market_warning=row.market_warning,
+                raw_payload=row.raw_payload,
+                source="tvscreener_upbit",
+            )
+        )
+    return payloads
+
+
+async def build_crypto_snapshots(
+    *,
+    provider: CryptoSnapshotProvider,
+    repository: InvestCryptoScreenerSnapshotsRepository,
+    snapshot_date: dt.date | None = None,
+    commit: bool = False,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    date_value = snapshot_date or today_crypto_snapshot_date()
+    provider_rows = await provider.fetch_rows(limit=limit)
+    payloads = build_crypto_snapshot_payloads(provider_rows, snapshot_date=date_value)
+    upserted = 0
+    if commit:
+        for payload in payloads:
+            await repository.upsert(payload)
+            upserted += 1
+    return {
+        "snapshot_date": date_value.isoformat(),
+        "fetched": len(provider_rows),
+        "would_upsert": len(payloads),
+        "upserted": upserted,
+        "committed": commit,
+        "samples": [payload.model_dump(mode="json") for payload in payloads[:5]],
+    }
+
+
+def provider_row_from_mapping(row: dict[str, Any]) -> CryptoProviderRow | None:
+    symbol = str(row.get("symbol") or row.get("market") or "").strip().upper()
+    latest_close = _decimal_or_none(
+        row.get("close") or row.get("current_price") or row.get("price")
+    )
+    if not symbol.startswith("KRW-") or latest_close is None:
+        return None
+    return CryptoProviderRow(
+        symbol=symbol,
+        name=str(row.get("name") or "").strip() or None,
+        latest_close=latest_close,
+        change_amount=_decimal_or_none(row.get("change_amount")),
+        change_rate=_decimal_or_none(row.get("change_rate")),
+        trade_amount_24h=_decimal_or_none(
+            row.get("trade_amount_24h") or row.get("value_traded")
+        ),
+        volume_24h=_decimal_or_none(row.get("volume_24h")),
+        volume_24h_usd=_decimal_or_none(row.get("volume_24h_usd")),
+        market_cap=_decimal_or_none(row.get("market_cap")),
+        rsi=_decimal_or_none(row.get("rsi")),
+        adx=_decimal_or_none(row.get("adx")),
+        market_warning=bool(row.get("market_warning") or False),
+        raw_payload={
+            k: v
+            for k, v in row.items()
+            if k
+            in {
+                "symbol",
+                "name",
+                "market",
+                "source",
+                "market_cap_rank",
+                "rsi_bucket",
+            }
+        },
+    )

--- a/app/services/invest_crypto_screener_snapshots/coverage_service.py
+++ b/app/services/invest_crypto_screener_snapshots/coverage_service.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.invest_crypto_screener_snapshots.freshness import (
+    DataState,
+    classify_crypto_partition,
+    today_crypto_snapshot_date,
+)
+from app.services.invest_crypto_screener_snapshots.repository import (
+    InvestCryptoScreenerSnapshotsRepository,
+)
+
+
+@dataclass(frozen=True)
+class CryptoCoverageReport:
+    market: str
+    asOf: dt.datetime
+    latestPartitionDate: dt.date | None
+    snapshotsInLatestPartition: int
+    snapshotsStale: int
+    lastComputedAt: dt.datetime | None
+    dataState: DataState
+
+
+async def build_crypto_coverage(session: AsyncSession) -> CryptoCoverageReport:
+    now = dt.datetime.now(dt.UTC)
+    today = today_crypto_snapshot_date(now)
+    counts = await InvestCryptoScreenerSnapshotsRepository(session).coverage(
+        today=today
+    )
+    state = classify_crypto_partition(
+        latest_partition_date=counts.latest_partition_date,
+        row_count=counts.latest_partition_count,
+        last_computed_at=counts.last_computed_at,
+        today=today,
+        now=now,
+    )
+    return CryptoCoverageReport(
+        market="crypto",
+        asOf=now,
+        latestPartitionDate=counts.latest_partition_date,
+        snapshotsInLatestPartition=counts.latest_partition_count,
+        snapshotsStale=counts.stale_count,
+        lastComputedAt=counts.last_computed_at,
+        dataState=state,
+    )

--- a/app/services/invest_crypto_screener_snapshots/freshness.py
+++ b/app/services/invest_crypto_screener_snapshots/freshness.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import Literal
+
+DataState = Literal["fresh", "partial", "stale", "missing", "fallback"]
+CRYPTO_STALE_AFTER = dt.timedelta(hours=3)
+_CRYPTO_MIN_FRESH_ROWS = 20
+_KST = dt.timezone(dt.timedelta(hours=9))
+
+
+def today_crypto_snapshot_date(now: dt.datetime | None = None) -> dt.date:
+    """Return the current KST calendar date for 24/7 crypto snapshots."""
+    current = now or dt.datetime.now(dt.UTC)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=dt.UTC)
+    return current.astimezone(_KST).date()
+
+
+def classify_crypto_partition(
+    *,
+    latest_partition_date: dt.date | None,
+    row_count: int,
+    last_computed_at: dt.datetime | None,
+    today: dt.date | None = None,
+    now: dt.datetime | None = None,
+    min_fresh_rows: int = _CRYPTO_MIN_FRESH_ROWS,
+    stale_after: dt.timedelta = CRYPTO_STALE_AFTER,
+) -> DataState:
+    current = now or dt.datetime.now(dt.UTC)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=dt.UTC)
+    today_value = today or today_crypto_snapshot_date(current)
+    if latest_partition_date is None or row_count <= 0 or last_computed_at is None:
+        return "missing"
+    if latest_partition_date < today_value:
+        return "stale"
+    computed_at = last_computed_at
+    if computed_at.tzinfo is None:
+        computed_at = computed_at.replace(tzinfo=dt.UTC)
+    if current - computed_at.astimezone(dt.UTC) >= stale_after:
+        return "stale"
+    if row_count < min_fresh_rows:
+        return "partial"
+    return "fresh"

--- a/app/services/invest_crypto_screener_snapshots/provider.py
+++ b/app/services/invest_crypto_screener_snapshots/provider.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Any
+
+from app.mcp_server.tooling.screening.crypto import _screen_crypto_via_tvscreener
+from app.services.invest_crypto_screener_snapshots.builder import (
+    CryptoProviderRow,
+    provider_row_from_mapping,
+)
+
+
+class TvScreenerUpbitCryptoSnapshotProvider:
+    """Pure market-data provider for crypto screener snapshots.
+
+    This intentionally does not persist rows or mutate broker/order state.  The
+    current implementation delegates to the existing tvscreener crypto contract
+    and converts display rows into snapshot DTOs; account-state filters remain
+    outside the persisted snapshot table.
+    """
+
+    async def fetch_rows(self, *, limit: int | None = None) -> list[CryptoProviderRow]:
+        query_limit = limit or 200
+        payload: dict[str, Any] = await _screen_crypto_via_tvscreener(
+            market="crypto",
+            asset_type=None,
+            category=None,
+            min_market_cap=None,
+            max_per=None,
+            min_dividend_yield=None,
+            max_rsi=None,
+            sort_by="trade_amount",
+            sort_order="desc",
+            limit=query_limit,
+            pure_market_snapshot=True,
+        )
+        rows: list[CryptoProviderRow] = []
+        for raw in payload.get("results") or payload.get("stocks") or []:
+            if not isinstance(raw, dict):
+                continue
+            row = provider_row_from_mapping(raw)
+            if row is not None:
+                rows.append(row)
+        return rows[:query_limit]

--- a/app/services/invest_crypto_screener_snapshots/repository.py
+++ b/app/services/invest_crypto_screener_snapshots/repository.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+import sqlalchemy as sa
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invest_crypto_screener_snapshot import InvestCryptoScreenerSnapshot
+
+
+class CryptoSnapshotUpsert(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    snapshot_date: dt.date
+    name: str | None = None
+    latest_close: Decimal
+    change_amount: Decimal | None = None
+    change_rate: Decimal | None = None
+    trade_amount_24h: Decimal | None = None
+    volume_24h: Decimal | None = None
+    volume_24h_usd: Decimal | None = None
+    market_cap: Decimal | None = None
+    rsi: Decimal | None = None
+    adx: Decimal | None = None
+    market_warning: bool = False
+    raw_payload: dict[str, Any] = Field(default_factory=dict)
+    source: str = "tvscreener_upbit"
+
+
+@dataclass(frozen=True)
+class CryptoCoverageCounts:
+    latest_partition_date: dt.date | None
+    latest_partition_count: int
+    stale_count: int
+    last_computed_at: dt.datetime | None
+
+
+class InvestCryptoScreenerSnapshotsRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def upsert(self, payload: CryptoSnapshotUpsert) -> None:
+        values = payload.model_dump()
+        stmt = insert(InvestCryptoScreenerSnapshot).values(**values)
+        stmt = stmt.on_conflict_do_update(
+            constraint="uq_invest_crypto_screener_snapshots_symbol_date",
+            set_={
+                **{
+                    k: stmt.excluded[k]
+                    for k in values
+                    if k not in {"symbol", "snapshot_date"}
+                },
+                "updated_at": func.now(),
+                "computed_at": func.now(),
+            },
+        )
+        await self._session.execute(stmt)
+
+    async def latest_partition(self) -> dt.date | None:
+        result = await self._session.execute(
+            select(func.max(InvestCryptoScreenerSnapshot.snapshot_date))
+        )
+        return result.scalar_one_or_none()
+
+    async def list_latest(
+        self,
+        *,
+        preset_id: str,
+        limit: int = 20,
+        snapshot_date: dt.date | None = None,
+    ) -> list[InvestCryptoScreenerSnapshot]:
+        latest_date = snapshot_date or await self.latest_partition()
+        if latest_date is None:
+            return []
+
+        stmt = select(InvestCryptoScreenerSnapshot).where(
+            InvestCryptoScreenerSnapshot.snapshot_date == latest_date,
+            InvestCryptoScreenerSnapshot.market_warning.is_(False),
+        )
+        if preset_id == "crypto_oversold":
+            stmt = stmt.where(
+                InvestCryptoScreenerSnapshot.rsi.is_not(None),
+                InvestCryptoScreenerSnapshot.rsi <= 35,
+            ).order_by(
+                InvestCryptoScreenerSnapshot.rsi.asc().nullslast(),
+                InvestCryptoScreenerSnapshot.trade_amount_24h.desc().nullslast(),
+                InvestCryptoScreenerSnapshot.symbol.asc(),
+            )
+        elif preset_id == "crypto_momentum":
+            stmt = stmt.order_by(
+                InvestCryptoScreenerSnapshot.change_rate.desc().nullslast(),
+                InvestCryptoScreenerSnapshot.trade_amount_24h.desc().nullslast(),
+                InvestCryptoScreenerSnapshot.symbol.asc(),
+            )
+        else:
+            stmt = stmt.order_by(
+                InvestCryptoScreenerSnapshot.trade_amount_24h.desc().nullslast(),
+                InvestCryptoScreenerSnapshot.symbol.asc(),
+            )
+        result = await self._session.execute(stmt.limit(limit))
+        return list(result.scalars().all())
+
+    async def coverage(self, *, today: dt.date) -> CryptoCoverageCounts:
+        latest = await self.latest_partition()
+        if latest is None:
+            return CryptoCoverageCounts(
+                latest_partition_date=None,
+                latest_partition_count=0,
+                stale_count=0,
+                last_computed_at=None,
+            )
+        result = await self._session.execute(
+            sa.select(
+                sa.func.count()
+                .filter(InvestCryptoScreenerSnapshot.snapshot_date == latest)
+                .label("latest_count"),
+                sa.func.count()
+                .filter(InvestCryptoScreenerSnapshot.snapshot_date < today)
+                .label("stale"),
+                sa.func.max(InvestCryptoScreenerSnapshot.computed_at).label("last"),
+            )
+        )
+        row = result.one()
+        return CryptoCoverageCounts(
+            latest_partition_date=latest,
+            latest_partition_count=int(row.latest_count or 0),
+            stale_count=int(row.stale or 0),
+            last_computed_at=row.last,
+        )

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -185,7 +185,7 @@ _SCREENING_FILTERS: dict[str, dict[str, object]] = {
     },
     "crypto_high_volume": {
         "market": "crypto",
-        "sort_by": "volume",
+        "sort_by": "trade_amount",
         "sort_order": "desc",
         "limit": 20,
     },

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -318,6 +318,96 @@ async def _load_consecutive_gainers_from_snapshots(
     return rows
 
 
+async def _load_crypto_rows_from_snapshots(
+    session: AsyncSession | None,
+    *,
+    preset_id: str,
+    limit: int = 20,
+    now: Callable[[], datetime] = lambda: datetime.now(UTC),
+) -> tuple[list[dict[str, Any]], str] | None:
+    """Return crypto rows from the latest crypto snapshot partition.
+
+    None means there is no usable snapshot partition and live provider fallback is
+    allowed.  An empty list with a state means a latest fresh/partial partition
+    exists but has no qualifiers for the preset; callers must not query older
+    partitions or silently fall back.
+    """
+    if session is None:
+        return None
+
+    from app.services.invest_crypto_screener_snapshots.freshness import (
+        classify_crypto_partition,
+        today_crypto_snapshot_date,
+    )
+    from app.services.invest_crypto_screener_snapshots.repository import (
+        InvestCryptoScreenerSnapshotsRepository,
+    )
+
+    repo = InvestCryptoScreenerSnapshotsRepository(session)
+    try:
+        latest_date = await repo.latest_partition()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("failed to read crypto screener snapshot partition: %s", exc)
+        return None
+    if latest_date is None:
+        return None
+
+    try:
+        rows = await repo.list_latest(
+            preset_id=preset_id,
+            limit=limit,
+            snapshot_date=latest_date,
+        )
+        coverage = await repo.coverage(today=today_crypto_snapshot_date(now()))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("failed to read crypto screener snapshots: %s", exc)
+        return None
+
+    state = classify_crypto_partition(
+        latest_partition_date=coverage.latest_partition_date,
+        row_count=coverage.latest_partition_count,
+        last_computed_at=coverage.last_computed_at,
+        now=now(),
+    )
+    if state in {"missing", "stale"}:
+        return None
+
+    mapped: list[dict[str, Any]] = []
+    for snap in rows:
+        mapped.append(
+            {
+                "symbol": snap.symbol,
+                "market": "crypto",
+                "name": snap.name,
+                "close": float(snap.latest_close)
+                if snap.latest_close is not None
+                else None,
+                "change_rate": float(snap.change_rate)
+                if snap.change_rate is not None
+                else None,
+                "change_amount": float(snap.change_amount)
+                if snap.change_amount is not None
+                else None,
+                "trade_amount_24h": float(snap.trade_amount_24h)
+                if snap.trade_amount_24h is not None
+                else None,
+                "volume_24h": float(snap.volume_24h)
+                if snap.volume_24h is not None
+                else None,
+                "volume_24h_usd": float(snap.volume_24h_usd)
+                if snap.volume_24h_usd is not None
+                else None,
+                "market_cap": float(snap.market_cap)
+                if snap.market_cap is not None
+                else None,
+                "rsi": float(snap.rsi) if snap.rsi is not None else None,
+                "adx": float(snap.adx) if snap.adx is not None else None,
+                "_screener_snapshot_state": state,
+            }
+        )
+    return mapped, state
+
+
 def build_screener_presets(market: str = "kr") -> ScreenerPresetsResponse:
     requested_market = _normalize_market(market)
     return ScreenerPresetsResponse(
@@ -680,16 +770,31 @@ async def build_screener_results(
 
     filters = screening_filters_for(preset_id, requested_market)
     _snapshot_check_result: list[dict[str, Any]] | None = None
-    if (
-        preset_id == "consecutive_gainers"
-        and session is not None
-        and _should_use_snapshot_first(screening_service)
-    ):
-        _snapshot_check_result = await _load_consecutive_gainers_from_snapshots(
-            session,
-            market=requested_market,
-            limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
-        )
+    _snapshot_state_override: str | None = None
+    _snapshot_empty_warning = (
+        "스크리너 스냅샷 업데이트가 필요해 최신 연속 상승세 결과를 표시하지 못했습니다."
+    )
+    if session is not None and _should_use_snapshot_first(screening_service):
+        if preset_id == "consecutive_gainers":
+            _snapshot_check_result = await _load_consecutive_gainers_from_snapshots(
+                session,
+                market=requested_market,
+                limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
+            )
+        elif requested_market == "crypto":
+            _crypto_snapshot_result = await _load_crypto_rows_from_snapshots(
+                session,
+                preset_id=preset_id,
+                limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
+                now=now,
+            )
+            if _crypto_snapshot_result is not None:
+                _snapshot_check_result, _snapshot_state_override = (
+                    _crypto_snapshot_result
+                )
+                _snapshot_empty_warning = (
+                    "최신 암호화폐 스크리너 스냅샷에서 조건에 맞는 결과가 없습니다."
+                )
 
     _snapshot_was_checked = _snapshot_check_result is not None
     if _snapshot_was_checked:
@@ -699,9 +804,7 @@ async def build_screener_results(
         snapshot_rows = _snapshot_check_result  # type: ignore[assignment]
         _snapshot_empty_warnings: list[str] = []
         if not snapshot_rows:
-            _snapshot_empty_warnings = [
-                "스크리너 스냅샷 업데이트가 필요해 최신 연속 상승세 결과를 표시하지 못했습니다."
-            ]
+            _snapshot_empty_warnings = [_snapshot_empty_warning]
         raw = {
             "results": snapshot_rows,
             "warnings": _snapshot_empty_warnings,
@@ -742,8 +845,10 @@ async def build_screener_results(
 
     if _snapshot_was_checked and not rows:
         # Latest snapshot partition was found but had no qualifying rows —
-        # the data is stale, not missing (snapshots exist, just not qualifying).
-        _aggregated_data_state: str = "stale"
+        # the data exists, but this preset has no current qualifiers.  Stock
+        # snapshot semantics keep the historical stale warning; crypto snapshots
+        # can still be fresh/partial 24/7 even when a preset returns zero rows.
+        _aggregated_data_state = _snapshot_state_override or "stale"
     else:
         _row_states: list[str] = [
             str(r.get("_screener_snapshot_state") or "missing") for r in rows

--- a/scripts/build_invest_crypto_screener_snapshots.py
+++ b/scripts/build_invest_crypto_screener_snapshots.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Build invest_crypto_screener_snapshots rows from the Upbit crypto screener.
+
+Defaults to dry-run/no DB writes.  Pass --commit only after operator approval and
+reviewing dry-run evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+
+from app.core.cli import setup_logging_and_sentry
+from app.jobs.invest_crypto_screener_snapshots import (
+    CryptoSnapshotBuildRequest,
+    run_crypto_snapshot_build,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read-only crypto screener snapshot builder (ROB-225)."
+    )
+    parser.add_argument("--limit", type=int, default=50)
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Fetch the full provider result set instead of --limit rows.",
+    )
+    parser.add_argument(
+        "--commit",
+        action="store_true",
+        help="Actually write to the database. Default is dry-run/no writes.",
+    )
+    args = parser.parse_args(argv)
+    if args.all and args.limit != 50:
+        parser.error("--all is mutually exclusive with --limit")
+    return args
+
+
+async def run(args: argparse.Namespace) -> int:
+    result = await run_crypto_snapshot_build(
+        CryptoSnapshotBuildRequest(
+            limit=args.limit,
+            all_markets=args.all,
+            commit=args.commit,
+        )
+    )
+    print(json.dumps(result, ensure_ascii=False, indent=2, default=str))
+    if not args.commit:
+        print("\n--dry-run: no rows written. Pass --commit only with operator approval.")
+    return 0
+
+
+async def main() -> int:
+    setup_logging_and_sentry(service_name="build-invest-crypto-screener-snapshots")
+    return await run(parse_args())
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/test_invest_crypto_screener_snapshots_builder.py
+++ b/tests/test_invest_crypto_screener_snapshots_builder.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pandas as pd
+import pytest
+
+from app.services.invest_crypto_screener_snapshots.builder import (
+    CryptoProviderRow,
+    build_crypto_snapshot_payloads,
+    build_crypto_snapshots,
+)
+from app.services.invest_crypto_screener_snapshots.provider import (
+    TvScreenerUpbitCryptoSnapshotProvider,
+)
+from app.services.invest_crypto_screener_snapshots.repository import (
+    CryptoSnapshotUpsert,
+)
+
+
+class _Condition:
+    def __init__(self, label: str) -> None:
+        self.label = label
+
+    def __eq__(self, other: object) -> bool:  # type: ignore[override]
+        return isinstance(other, _Condition) and self.label == other.label
+
+
+class _Field:
+    def __init__(self, label: str) -> None:
+        self.label = label
+
+    def __eq__(self, other: object) -> _Condition:  # type: ignore[override]
+        return _Condition(f"{self.label}=={other}")
+
+
+class _Provider:
+    async def fetch_rows(self, *, limit: int | None = None) -> list[CryptoProviderRow]:
+        return [
+            CryptoProviderRow(
+                symbol="KRW-BTC",
+                name="비트코인",
+                latest_close=Decimal("150000000"),
+                change_rate=Decimal("2.5"),
+                trade_amount_24h=Decimal("120000000000"),
+                volume_24h=Decimal("123.456"),
+                volume_24h_usd=Decimal("90000000"),
+                market_cap=Decimal("2100000000000"),
+                rsi=Decimal("31.5"),
+                adx=Decimal("24.1"),
+                market_warning=False,
+                raw_payload={"provider": "fixture"},
+            )
+        ][:limit]
+
+
+class _Repo:
+    def __init__(self) -> None:
+        self.payloads: list[CryptoSnapshotUpsert] = []
+
+    async def upsert(self, payload: CryptoSnapshotUpsert) -> None:
+        self.payloads.append(payload)
+
+
+def test_build_crypto_snapshot_payloads_maps_provider_rows() -> None:
+    payloads = build_crypto_snapshot_payloads(
+        [
+            CryptoProviderRow(
+                symbol="KRW-BTC",
+                name="Bitcoin",
+                latest_close=Decimal("150000000"),
+                change_rate=Decimal("2.5"),
+                trade_amount_24h=Decimal("120000000000"),
+                volume_24h=Decimal("123.456"),
+                market_cap=Decimal("2100000000000"),
+                rsi=Decimal("31.5"),
+                adx=Decimal("24.1"),
+                market_warning=True,
+                raw_payload={"safe": True},
+            )
+        ],
+        snapshot_date=dt.date(2026, 5, 13),
+    )
+
+    payload = payloads[0]
+    assert payload.symbol == "KRW-BTC"
+    assert payload.snapshot_date == dt.date(2026, 5, 13)
+    assert payload.source == "tvscreener_upbit"
+    assert payload.trade_amount_24h == Decimal("120000000000")
+    assert payload.volume_24h == Decimal("123.456")
+    assert payload.rsi == Decimal("31.5")
+    assert payload.adx == Decimal("24.1")
+    assert payload.market_warning is True
+    assert payload.raw_payload == {"safe": True}
+
+
+@pytest.mark.asyncio
+async def test_build_crypto_snapshots_dry_run_does_not_upsert() -> None:
+    repo = _Repo()
+
+    result = await build_crypto_snapshots(
+        provider=_Provider(),
+        repository=repo,
+        snapshot_date=dt.date(2026, 5, 13),
+        commit=False,
+        limit=1,
+    )
+
+    assert result["snapshot_date"] == "2026-05-13"
+    assert result["fetched"] == 1
+    assert result["would_upsert"] == 1
+    assert result["upserted"] == 0
+    assert repo.payloads == []
+
+
+@pytest.mark.asyncio
+async def test_build_crypto_snapshots_commit_upserts_payloads() -> None:
+    repo = _Repo()
+
+    result = await build_crypto_snapshots(
+        provider=_Provider(),
+        repository=repo,
+        snapshot_date=dt.date(2026, 5, 13),
+        commit=True,
+        limit=1,
+    )
+
+    assert result["upserted"] == 1
+    assert repo.payloads[0].symbol == "KRW-BTC"
+
+
+@pytest.mark.asyncio
+async def test_tvscreener_upbit_snapshot_provider_keeps_cooldown_symbols() -> None:
+    service = AsyncMock()
+    service.query_crypto_screener.return_value = pd.DataFrame(
+        {
+            "symbol": ["UPBIT:BTCKRW", "UPBIT:ETHKRW", "UPBIT:XRPKRW"],
+            "name": ["BTCKRW", "ETHKRW", "XRPKRW"],
+            "description": ["Bitcoin", "Ethereum", "XRP"],
+            "price": [150_000_000.0, 5_000_000.0, 3_000.0],
+            "change_percent": [1.5, -0.2, -25.0],
+            "relative_strength_index_14": [45.5, 32.1, 28.5],
+            "average_directional_index_14": [25.3, 18.7, 30.0],
+            "value_traded": [
+                900_000_000_000.0,
+                1_200_000_000_000.0,
+                700_000_000_000.0,
+            ],
+            "market_cap": [
+                2_500_000_000_000_000.0,
+                1_200_000_000_000_000.0,
+                500_000_000_000_000.0,
+            ],
+            "volume_24h_in_usd": [156_000_000.0, 95_000_000.0, 44_000_000.0],
+            "exchange": ["UPBIT", "UPBIT", "UPBIT"],
+        }
+    )
+    fake_tvscreener = type(
+        "FakeTvScreener",
+        (),
+        {
+            "CryptoField": type(
+                "CryptoField",
+                (),
+                {
+                    "NAME": _Field("name"),
+                    "DESCRIPTION": _Field("description"),
+                    "PRICE": _Field("price"),
+                    "CHANGE_PERCENT": _Field("change_percent"),
+                    "VALUE_TRADED": _Field("value_traded"),
+                    "MARKET_CAP": _Field("market_cap"),
+                    "RELATIVE_STRENGTH_INDEX_14": _Field("rsi14"),
+                    "AVERAGE_DIRECTIONAL_INDEX_14": _Field("adx14"),
+                    "VOLUME_24H_IN_USD": _Field("volume_usd"),
+                    "EXCHANGE": _Field("exchange"),
+                },
+            )
+        },
+    )
+    fetch_multiple_tickers = AsyncMock(
+        return_value=[
+            {"market": "KRW-BTC", "acc_trade_volume_24h": 15_600.0},
+            {"market": "KRW-ETH", "acc_trade_volume_24h": 9_500.0},
+            {"market": "KRW-XRP", "acc_trade_volume_24h": 4_400.0},
+        ]
+    )
+    cooldown_filter = AsyncMock(return_value={"KRW-ETH"})
+
+    with (
+        patch(
+            "app.mcp_server.tooling.screening.crypto._import_tvscreener",
+            return_value=fake_tvscreener,
+        ),
+        patch(
+            "app.mcp_server.tooling.screening.crypto.TvScreenerService",
+            return_value=service,
+        ),
+        patch(
+            "app.mcp_server.tooling.screening.crypto.upbit_service.fetch_multiple_tickers",
+            new=fetch_multiple_tickers,
+        ),
+        patch(
+            "app.mcp_server.tooling.screening.crypto.get_upbit_market_display_names",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "app.mcp_server.tooling.screening.crypto.get_upbit_warning_markets",
+            new=AsyncMock(return_value={"KRW-ETH"}),
+        ),
+        patch(
+            "app.mcp_server.tooling.screening.crypto._run_crypto_coingecko_fetch",
+            new=AsyncMock(
+                return_value={
+                    "data": {},
+                    "cached": True,
+                    "age_seconds": 0.0,
+                    "stale": False,
+                    "error": None,
+                }
+            ),
+        ),
+        patch(
+            "app.mcp_server.tooling.screening.crypto._get_crypto_trade_cooldown_service",
+            return_value=type(
+                "Cooldown", (), {"filter_symbols_in_cooldown": cooldown_filter}
+            )(),
+        ),
+    ):
+        rows = await TvScreenerUpbitCryptoSnapshotProvider().fetch_rows(limit=10)
+
+    assert cooldown_filter.await_count == 0
+    assert {row.symbol for row in rows} == {"KRW-BTC", "KRW-ETH", "KRW-XRP"}

--- a/tests/test_invest_crypto_screener_snapshots_freshness.py
+++ b/tests/test_invest_crypto_screener_snapshots_freshness.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+import pytest
+
+from app.jobs import invest_crypto_screener_snapshots as snapshot_job
+from app.services.invest_crypto_screener_snapshots import coverage_service
+from app.services.invest_crypto_screener_snapshots.freshness import (
+    classify_crypto_partition,
+    today_crypto_snapshot_date,
+)
+from app.services.invest_crypto_screener_snapshots.repository import (
+    CryptoCoverageCounts,
+)
+
+
+def test_today_crypto_snapshot_date_does_not_weekend_roll_back() -> None:
+    saturday_kst = dt.datetime(2026, 5, 16, 12, 0, tzinfo=dt.UTC)
+
+    assert today_crypto_snapshot_date(saturday_kst) == dt.date(2026, 5, 16)
+
+
+def test_classify_crypto_partition_states() -> None:
+    now = dt.datetime(2026, 5, 13, 5, 0, tzinfo=dt.UTC)
+    today = dt.date(2026, 5, 13)
+
+    assert (
+        classify_crypto_partition(
+            latest_partition_date=None,
+            row_count=0,
+            last_computed_at=None,
+            today=today,
+            now=now,
+        )
+        == "missing"
+    )
+    assert (
+        classify_crypto_partition(
+            latest_partition_date=today,
+            row_count=50,
+            last_computed_at=now - dt.timedelta(hours=1),
+            today=today,
+            now=now,
+        )
+        == "fresh"
+    )
+    assert (
+        classify_crypto_partition(
+            latest_partition_date=today,
+            row_count=5,
+            last_computed_at=now - dt.timedelta(hours=1),
+            today=today,
+            now=now,
+        )
+        == "partial"
+    )
+    assert (
+        classify_crypto_partition(
+            latest_partition_date=today - dt.timedelta(days=1),
+            row_count=50,
+            last_computed_at=now - dt.timedelta(hours=1),
+            today=today,
+            now=now,
+        )
+        == "stale"
+    )
+    assert (
+        classify_crypto_partition(
+            latest_partition_date=today,
+            row_count=50,
+            last_computed_at=now - dt.timedelta(hours=4),
+            today=today,
+            now=now,
+        )
+        == "stale"
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_crypto_coverage_reports_repository_counts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeRepository:
+        def __init__(self, session: object) -> None:
+            assert session == "session"
+
+        async def coverage(self, *, today: dt.date) -> Any:
+            return CryptoCoverageCounts(
+                latest_partition_date=today,
+                latest_partition_count=12,
+                stale_count=4,
+                last_computed_at=dt.datetime.now(dt.UTC) - dt.timedelta(minutes=30),
+            )
+
+    monkeypatch.setattr(
+        coverage_service,
+        "InvestCryptoScreenerSnapshotsRepository",
+        FakeRepository,
+    )
+
+    report = await coverage_service.build_crypto_coverage("session")  # type: ignore[arg-type]
+
+    assert report.market == "crypto"
+    assert report.latestPartitionDate == today_crypto_snapshot_date(report.asOf)
+    assert report.snapshotsInLatestPartition == 12
+    assert report.snapshotsStale == 4
+    assert report.dataState == "partial"
+
+
+@pytest.mark.asyncio
+async def test_run_crypto_snapshot_build_rolls_back_dry_run(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[str, object]] = []
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            events.append(("enter", self))
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            events.append(("exit", self))
+
+        async def commit(self) -> None:
+            events.append(("commit", self))
+
+        async def rollback(self) -> None:
+            events.append(("rollback", self))
+
+    fake_session = FakeSession()
+
+    def fake_session_factory() -> FakeSession:
+        return fake_session
+
+    async def fake_build_crypto_snapshots(**kwargs: object) -> dict[str, object]:
+        events.append(("limit", kwargs["limit"]))
+        events.append(("commit_flag", kwargs["commit"]))
+        return {"inserted": 3}
+
+    monkeypatch.setattr(snapshot_job, "AsyncSessionLocal", fake_session_factory)
+    monkeypatch.setattr(
+        snapshot_job, "build_crypto_snapshots", fake_build_crypto_snapshots
+    )
+
+    result = await snapshot_job.run_crypto_snapshot_build(
+        snapshot_job.CryptoSnapshotBuildRequest(limit=7, commit=False)
+    )
+
+    assert result == {"inserted": 3}
+    assert ("limit", 7) in events
+    assert ("commit_flag", False) in events
+    assert ("rollback", fake_session) in events
+    assert ("commit", fake_session) not in events
+
+
+@pytest.mark.asyncio
+async def test_run_crypto_snapshot_build_commits_all_markets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[tuple[str, object]] = []
+
+    class FakeSession:
+        async def __aenter__(self) -> FakeSession:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+        async def commit(self) -> None:
+            events.append(("commit", self))
+
+        async def rollback(self) -> None:
+            events.append(("rollback", self))
+
+    fake_session = FakeSession()
+
+    async def fake_build_crypto_snapshots(**kwargs: object) -> dict[str, object]:
+        events.append(("limit", kwargs["limit"]))
+        events.append(("commit_flag", kwargs["commit"]))
+        return {"inserted": 50}
+
+    monkeypatch.setattr(snapshot_job, "AsyncSessionLocal", lambda: fake_session)
+    monkeypatch.setattr(
+        snapshot_job, "build_crypto_snapshots", fake_build_crypto_snapshots
+    )
+
+    result = await snapshot_job.run_crypto_snapshot_build(
+        snapshot_job.CryptoSnapshotBuildRequest(all_markets=True, commit=True)
+    )
+
+    assert result == {"inserted": 50}
+    assert ("limit", None) in events
+    assert ("commit_flag", True) in events
+    assert ("commit", fake_session) in events
+    assert ("rollback", fake_session) not in events

--- a/tests/test_invest_crypto_screener_snapshots_model.py
+++ b/tests/test_invest_crypto_screener_snapshots_model.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from app.models.invest_crypto_screener_snapshot import InvestCryptoScreenerSnapshot
+
+
+def _constraint_sql(name: str) -> str:
+    table = InvestCryptoScreenerSnapshot.__table__
+    constraint = next(c for c in table.constraints if c.name == name)
+    assert isinstance(constraint, sa.CheckConstraint)
+    return str(constraint.sqltext)
+
+
+def test_crypto_snapshot_table_constraints_are_crypto_specific() -> None:
+    table = InvestCryptoScreenerSnapshot.__table__
+
+    assert table.name == "invest_crypto_screener_snapshots"
+    assert "uq_invest_crypto_screener_snapshots_symbol_date" in {
+        c.name for c in table.constraints
+    }
+    assert "KRW-%" in _constraint_sql("ck_invest_crypto_screener_snapshots_symbol")
+    assert "tvscreener_upbit" in _constraint_sql(
+        "ck_invest_crypto_screener_snapshots_source"
+    )
+
+
+def test_crypto_snapshot_has_preset_metric_columns() -> None:
+    columns = InvestCryptoScreenerSnapshot.__table__.columns
+
+    for name in (
+        "trade_amount_24h",
+        "volume_24h",
+        "volume_24h_usd",
+        "market_cap",
+        "rsi",
+        "adx",
+        "market_warning",
+        "raw_payload",
+    ):
+        assert name in columns

--- a/tests/test_invest_screener_presets.py
+++ b/tests/test_invest_screener_presets.py
@@ -107,7 +107,7 @@ def test_crypto_screening_filters_are_read_only_market_filters() -> None:
 
     assert high_volume == {
         "market": "crypto",
-        "sort_by": "volume",
+        "sort_by": "trade_amount",
         "sort_order": "desc",
         "limit": 20,
     }

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -78,6 +78,11 @@ class _FakeExecuteResult:
     def scalar_one_or_none(self) -> Any | None:
         return self._scalar_rows[0] if self._scalar_rows else None
 
+    def one(self) -> Any:
+        if self._rows:
+            return self._rows[0]
+        return type("EmptyRow", (), {})()
+
 
 class _FakeSession:
     def __init__(self, results: list[_FakeExecuteResult]) -> None:
@@ -109,6 +114,38 @@ class _FakeSnapshot:
         self.computed_at = kwargs.get(
             "computed_at", datetime(2026, 5, 11, 0, 30, tzinfo=UTC)
         )
+
+
+class _FakeCryptoSnapshot:
+    def __init__(self, **kwargs: Any) -> None:
+        self.symbol = kwargs.get("symbol", "KRW-BTC")
+        self.snapshot_date = kwargs.get("snapshot_date", date(2026, 5, 13))
+        self.name = kwargs.get("name", "Bitcoin")
+        self.latest_close = kwargs.get("latest_close", Decimal("145000000"))
+        self.change_amount = kwargs.get("change_amount", Decimal("1000000"))
+        self.change_rate = kwargs.get("change_rate", Decimal("1.25"))
+        self.trade_amount_24h = kwargs.get("trade_amount_24h", Decimal("123456789000"))
+        self.volume_24h = kwargs.get("volume_24h", Decimal("9876.5"))
+        self.volume_24h_usd = kwargs.get("volume_24h_usd", Decimal("90000000"))
+        self.market_cap = kwargs.get("market_cap", Decimal("1800000000000"))
+        self.rsi = kwargs.get("rsi", Decimal("58.0"))
+        self.adx = kwargs.get("adx", Decimal("24.0"))
+        self.computed_at = kwargs.get(
+            "computed_at", datetime(2026, 5, 13, 2, 30, tzinfo=UTC)
+        )
+
+
+def _coverage_row(
+    *,
+    latest_count: int,
+    stale: int = 0,
+    last: datetime | None = datetime(2026, 5, 13, 2, 30, tzinfo=UTC),
+) -> Any:
+    return type(
+        "CoverageRow",
+        (),
+        {"latest_count": latest_count, "stale": stale, "last": last},
+    )()
 
 
 def _name_row(symbol: str, name: str) -> Any:
@@ -273,7 +310,7 @@ async def test_build_screener_results_forwards_crypto_market_and_formats_crypto_
     fake_screening.list_screening.assert_awaited_once()
     assert fake_screening.list_screening.await_args.kwargs == {
         "market": "crypto",
-        "sort_by": "volume",
+        "sort_by": "trade_amount",
         "sort_order": "desc",
         "limit": 20,
     }
@@ -289,6 +326,127 @@ async def test_build_screener_results_forwards_crypto_market_and_formats_crypto_
     assert row.metricValueLabel == "120,000,000,000"
     assert row.isWatched is True
     assert resolver.calls == [("crypto", "KRW-BTC")]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_uses_fresh_crypto_snapshots_first() -> None:
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[date(2026, 5, 13)]),
+            _FakeExecuteResult(scalar_rows=[_FakeCryptoSnapshot()]),
+            _FakeExecuteResult(scalar_rows=[date(2026, 5, 13)]),
+            _FakeExecuteResult(rows=[_coverage_row(latest_count=30)]),
+        ]
+    )
+
+    resp = await build_screener_results(
+        preset_id="crypto_high_volume",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched={("crypto", "KRW-BTC")}),
+        market="crypto",
+        session=session,
+        now=lambda: datetime(2026, 5, 13, 3, 0, tzinfo=UTC),
+    )
+
+    fake_screening.list_screening.assert_not_called()
+    assert session.calls == 4
+    assert resp.freshness.cacheHit is True
+    assert resp.freshness.dataState == "fresh"
+    row = resp.results[0]
+    assert row.symbol == "KRW-BTC"
+    assert row.priceLabel == "145,000,000원"
+    assert row.metricValueLabel == "123,456,789,000"
+    assert row.isWatched is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_does_not_fallback_when_fresh_crypto_snapshot_has_no_qualifiers() -> (
+    None
+):
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[date(2026, 5, 13)]),
+            _FakeExecuteResult(scalar_rows=[]),
+            _FakeExecuteResult(scalar_rows=[date(2026, 5, 13)]),
+            _FakeExecuteResult(rows=[_coverage_row(latest_count=30)]),
+        ]
+    )
+
+    resp = await build_screener_results(
+        preset_id="crypto_oversold",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched=set()),
+        market="crypto",
+        session=session,
+        now=lambda: datetime(2026, 5, 13, 3, 0, tzinfo=UTC),
+    )
+
+    fake_screening.list_screening.assert_not_called()
+    assert resp.results == []
+    assert any("암호화폐 스크리너 스냅샷" in w for w in resp.warnings)
+    assert resp.freshness.dataState == "fresh"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_screener_results_falls_back_when_crypto_snapshot_is_stale() -> (
+    None
+):
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "KRW-ETH",
+                    "name": "Ethereum",
+                    "market": "crypto",
+                    "current_price": 4_800_000,
+                    "change_rate": 0.5,
+                    "trade_amount_24h": 50_000_000_000,
+                }
+            ],
+            "warnings": [],
+            "timestamp": datetime(2026, 5, 13, 3, 0, tzinfo=UTC).isoformat(),
+            "cache_hit": False,
+        }
+    )
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[date(2026, 5, 12)]),
+            _FakeExecuteResult(scalar_rows=[]),
+            _FakeExecuteResult(scalar_rows=[date(2026, 5, 12)]),
+            _FakeExecuteResult(rows=[_coverage_row(latest_count=30)]),
+        ]
+    )
+
+    resp = await build_screener_results(
+        preset_id="crypto_high_volume",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched=set()),
+        market="crypto",
+        session=session,
+        now=lambda: datetime(2026, 5, 13, 3, 0, tzinfo=UTC),
+    )
+
+    fake_screening.list_screening.assert_awaited_once()
+    assert resp.results[0].symbol == "KRW-ETH"
+    assert resp.freshness.cacheHit is False
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- add ROB-225 crypto screener snapshot ORM/migration/repository/freshness services and dry-run-first builder path
- add snapshot-first crypto read path in `/invest` screener view model with stale/missing fallback and fresh/partial data-state handling
- distinguish tvscreener `CryptoScreener` snapshot source from live `CoinScreener`, and switch the crypto high-volume preset to `trade_amount`

## Safety
- read-only `/invest` crypto data/UI path only
- no broker/order/watch/order-intent mutations
- snapshot builder defaults to dry-run; no scheduler activation in this PR
- rebased migration onto `20260513_rob227` to keep Alembic single-head after ROB-227 landed

## Test plan
- `uv run pytest tests/test_invest_screener_presets.py tests/test_invest_view_model_screener_service.py tests/test_tvscreener_crypto.py tests/test_invest_crypto_screener_snapshots_builder.py tests/test_invest_crypto_screener_snapshots_freshness.py tests/test_invest_crypto_screener_snapshots_model.py` — 68 passed, 2 existing Pydantic v2 warnings
- `uv run ruff check app/mcp_server/tooling/screening/crypto.py app/models/__init__.py app/models/invest_crypto_screener_snapshot.py app/services/invest_crypto_screener_snapshots app/services/invest_view_model/screener_presets.py app/services/invest_view_model/screener_service.py app/jobs/invest_crypto_screener_snapshots.py scripts/build_invest_crypto_screener_snapshots.py tests/test_invest_crypto_screener_snapshots_builder.py tests/test_invest_crypto_screener_snapshots_freshness.py tests/test_invest_crypto_screener_snapshots_model.py tests/test_invest_screener_presets.py tests/test_invest_view_model_screener_service.py` — passed
- `uv run alembic heads` — `20260513_rob225 (head)`
- `git diff --check` — clean

Closes ROB-225
