### PR TITLE
fix: keep crypto screener fallback on Upbit KRW pairs

### DIFF
--- a/app/mcp_server/tooling/screening/crypto.py
+++ b/app/mcp_server/tooling/screening/crypto.py
@@ -47,6 +47,18 @@ logger = logging.getLogger(__name__)
 
 _CRYPTO_MARKET_CAP_CACHE = MarketCapCache(ttl=600)
 
+
+def _is_upbit_krw_market_code(symbol: Any) -> bool:
+    """Return True for Upbit KRW quote-market symbols only.
+
+    TradingView's UPBIT crypto screener includes KRW, BTC, and USDT quote
+    markets.  `/invest` crypto surfaces model Upbit's Korean/KRW market, so
+    fallback/live screener rows must not leak BTC-* or USDT-* pairs into the
+    read model.
+    """
+    return str(symbol or "").strip().upper().startswith("KRW-")
+
+
 # Crypto trade cooldown service singleton
 _cooldown_service: CryptoTradeCooldownService | None = None
 
@@ -218,6 +230,18 @@ async def _normalize_crypto_results(
             }
         )
 
+    pre_krw_filter_total = len(raw_results)
+    raw_results = [
+        item for item in raw_results if _is_upbit_krw_market_code(item.get("symbol"))
+    ]
+    filtered_by_quote_market = pre_krw_filter_total - len(raw_results)
+    if filtered_by_quote_market:
+        logger.info(
+            "filtered %s non-KRW Upbit crypto screener rows from %s live rows",
+            filtered_by_quote_market,
+            pre_krw_filter_total,
+        )
+
     # Fetch Upbit display names and warning markets
     market_codes = [
         str(item.get("symbol") or "").strip().upper() for item in raw_results
@@ -275,18 +299,28 @@ async def _normalize_crypto_results(
     )
     btc_change_24h: float | None = None
     if btc_item is None:
-        warnings.append(
-            "KRW-BTC ticker not found; crash filter uses btc_change_24h=0.0 fallback."
-        )
+        if not pure_market_snapshot:
+            logger.warning(
+                "KRW-BTC ticker not found in Upbit KRW crypto screener rows; "
+                "crash filter uses btc_change_24h=0.0 fallback"
+            )
+            warnings.append(
+                "BTC 기준 데이터가 없어 급락 방어 필터를 기본값으로 적용했습니다."
+            )
     else:
         btc_change_24h = _to_optional_float(
             btc_item.get("signed_change_rate") or btc_item.get("change_rate")
         )
         if btc_change_24h is None:
             btc_change_24h = 0.0
-            warnings.append(
-                "KRW-BTC change rate is missing; crash filter uses btc_change_24h=0.0 fallback."
-            )
+            if not pure_market_snapshot:
+                logger.warning(
+                    "KRW-BTC change rate is missing; crash filter uses "
+                    "btc_change_24h=0.0 fallback"
+                )
+                warnings.append(
+                    "BTC 기준 등락률이 없어 급락 방어 필터를 기본값으로 적용했습니다."
+                )
 
     # Apply warning + crash filters for interactive screening; snapshot builds keep
     # every provider row and only carry warning metadata forward.

--- a/app/mcp_server/tooling/screening/crypto.py
+++ b/app/mcp_server/tooling/screening/crypto.py
@@ -59,6 +59,23 @@ def _is_upbit_krw_market_code(symbol: Any) -> bool:
     return str(symbol or "").strip().upper().startswith("KRW-")
 
 
+def _resolve_upbit_market_code_from_row(row: Any) -> str | None:
+    """Resolve an Upbit market code from tvscreener or Upbit-shaped rows."""
+    raw_symbol = _clean_text(row.get("symbol")).upper()
+    raw_market = _clean_text(row.get("market")).upper()
+
+    for candidate in (raw_symbol, raw_market):
+        if "-" in candidate:
+            return candidate
+
+    if not raw_symbol:
+        return None
+    try:
+        return tradingview_to_upbit(raw_symbol)
+    except SymbolMappingError:
+        return None
+
+
 # Crypto trade cooldown service singleton
 _cooldown_service: CryptoTradeCooldownService | None = None
 
@@ -203,12 +220,8 @@ async def _normalize_crypto_results(
     # Map raw rows
     raw_results: list[dict[str, Any]] = []
     for _, row in df.iterrows():
-        tradingview_symbol = _clean_text(row.get("symbol")).upper()
-        if not tradingview_symbol:
-            continue
-        try:
-            upbit_symbol = tradingview_to_upbit(tradingview_symbol)
-        except SymbolMappingError:
+        upbit_symbol = _resolve_upbit_market_code_from_row(row)
+        if not upbit_symbol:
             continue
 
         raw_results.append(

--- a/tests/test_crypto_composite_score.py
+++ b/tests/test_crypto_composite_score.py
@@ -455,6 +455,26 @@ class TestScreenStocksCryptoScore:
             upbit_service, "fetch_top_traded_coins", mock_fetch_top_traded_coins
         )
         monkeypatch.setattr(
+            screening_crypto,
+            "_execute_crypto_query",
+            AsyncMock(
+                return_value=pd.DataFrame(
+                    {
+                        "symbol": ["UPBIT:BTCKRW", "UPBIT:ETHKRW"],
+                        "name": ["BTCKRW", "ETHKRW"],
+                        "description": ["비트코인", "이더리움"],
+                        "price": [100_000_000.0, 5_000_000.0],
+                        "change_percent": [1.0, 2.0],
+                        "value_traded": [1_000_000_000_000.0, 800_000_000_000.0],
+                        "market_cap": [None, None],
+                        "relative_strength_index_14": [55.0, 45.0],
+                        "average_directional_index_14": [20.0, 25.0],
+                        "volume_24h_in_usd": [None, None],
+                    }
+                )
+            ),
+        )
+        monkeypatch.setattr(
             "app.mcp_server.tooling.market_data_indicators._fetch_ohlcv_for_indicators",
             mock_fetch_ohlcv,
         )

--- a/tests/test_screening_crypto.py
+++ b/tests/test_screening_crypto.py
@@ -59,6 +59,17 @@ class TestCryptoScreeningPhases:
         assert not _is_upbit_krw_market_code("USDT-OP")
         assert not _is_upbit_krw_market_code("BTC-PRL")
 
+    def test_resolve_upbit_market_code_accepts_tvscreener_and_upbit_rows(self):
+        from app.mcp_server.tooling.screening.crypto import (
+            _resolve_upbit_market_code_from_row,
+        )
+
+        assert (
+            _resolve_upbit_market_code_from_row({"symbol": "UPBIT:BTCKRW"}) == "KRW-BTC"
+        )
+        assert _resolve_upbit_market_code_from_row({"market": "KRW-ETH"}) == "KRW-ETH"
+        assert _resolve_upbit_market_code_from_row({"symbol": "USDT-OP"}) == "USDT-OP"
+
     @pytest.mark.asyncio
     async def test_normalize_crypto_results_filters_non_krw_upbit_pairs(
         self, monkeypatch

--- a/tests/test_screening_crypto.py
+++ b/tests/test_screening_crypto.py
@@ -1,6 +1,21 @@
 # tests/test_screening_crypto.py
 """Verify crypto screening functions are importable from the new location."""
 
+import pytest
+
+
+class _FakeFrame:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def iterrows(self):
+        yield from enumerate(self._rows)
+
+
+class _CooldownStub:
+    async def filter_symbols_in_cooldown(self, symbols):
+        return set()
+
 
 class TestCryptoScreeningImports:
     def test_screen_crypto_via_tvscreener_importable(self):
@@ -36,3 +51,91 @@ class TestCryptoScreeningPhases:
         from app.mcp_server.tooling.screening.crypto import _normalize_crypto_results
 
         assert callable(_normalize_crypto_results)
+
+    def test_is_upbit_krw_market_code_excludes_non_krw_quotes(self):
+        from app.mcp_server.tooling.screening.crypto import _is_upbit_krw_market_code
+
+        assert _is_upbit_krw_market_code("KRW-BTC")
+        assert not _is_upbit_krw_market_code("USDT-OP")
+        assert not _is_upbit_krw_market_code("BTC-PRL")
+
+    @pytest.mark.asyncio
+    async def test_normalize_crypto_results_filters_non_krw_upbit_pairs(
+        self, monkeypatch
+    ):
+        from app.mcp_server.tooling.screening import crypto
+
+        async def fake_names(markets, db):
+            return {
+                "KRW-IMX": {
+                    "korean_name": "이뮤터블엑스",
+                    "english_name": "Immutable X",
+                }
+            }
+
+        async def fake_warning_markets(quote_currency, db):
+            return set()
+
+        async def fake_tickers(markets):
+            return [{"market": "KRW-IMX", "acc_trade_volume_24h": 1234}]
+
+        async def fake_coingecko():
+            return {
+                "data": {},
+                "cached": False,
+                "age_seconds": None,
+                "stale": False,
+                "error": None,
+            }
+
+        monkeypatch.setattr(crypto, "get_upbit_market_display_names", fake_names)
+        monkeypatch.setattr(crypto, "get_upbit_warning_markets", fake_warning_markets)
+        monkeypatch.setattr(
+            crypto.upbit_service, "fetch_multiple_tickers", fake_tickers
+        )
+        monkeypatch.setattr(crypto, "_run_crypto_coingecko_fetch", fake_coingecko)
+        monkeypatch.setattr(
+            crypto, "_get_crypto_trade_cooldown_service", lambda: _CooldownStub()
+        )
+
+        payload = await crypto._normalize_crypto_results(
+            _FakeFrame(
+                [
+                    {
+                        "symbol": "UPBIT:OPUSDT",
+                        "name": "Optimism",
+                        "price": 0.16,
+                        "change_percent": 2.0,
+                        "value_traded": 9000,
+                    },
+                    {
+                        "symbol": "UPBIT:PRLBTC",
+                        "name": "PRL",
+                        "price": 0.0,
+                        "change_percent": -0.2,
+                        "value_traded": 8000,
+                    },
+                    {
+                        "symbol": "UPBIT:IMXKRW",
+                        "name": "Immutable X",
+                        "price": 277,
+                        "change_percent": 0.36,
+                        "value_traded": 7000,
+                    },
+                ]
+            ),
+            market="crypto",
+            max_rsi=None,
+            min_market_cap=None,
+            filters_applied={"sort_by": "trade_amount", "sort_order": "desc"},
+            limit=20,
+        )
+
+        assert [row["symbol"] for row in payload["results"]] == ["KRW-IMX"]
+        assert all(row["symbol"].startswith("KRW-") for row in payload["results"])
+        warnings = payload.get("warnings", [])
+        assert not any("KRW-BTC ticker not found" in warning for warning in warnings)
+        assert (
+            "BTC 기준 데이터가 없어 급락 방어 필터를 기본값으로 적용했습니다."
+            in warnings
+        )


### PR DESCRIPTION
## Summary
- Keep `/invest/screener` crypto fallback rows scoped to Upbit KRW quote-market pairs.
- Prevent BTC/USDT quote-market pairs from leaking into the 가상자산 table when DB snapshots are missing/stale.
- Replace the raw English `KRW-BTC ticker not found...` diagnostic with a Korean user-safe warning while keeping details in logs.

## Test Plan
- `uv run --group test pytest tests/test_screening_crypto.py -q`
- `uv run --group dev --group test ruff check app/mcp_server/tooling/screening/crypto.py tests/test_screening_crypto.py`
- `uv run --group dev --group test ruff format --check app/mcp_server/tooling/screening/crypto.py tests/test_screening_crypto.py`

Fixes ROB-230


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cryptocurrency market data filtering with enhanced validation
  * Refined warning messaging behavior for crypto market data processing

* **Tests**
  * Expanded test coverage for cryptocurrency screening functionality with additional validation scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/821)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->