### PR TITLE
feat(invest): score Naver momentum candidates

### DIFF
--- a/app/mcp_server/tooling/analysis_registration.py
+++ b/app/mcp_server/tooling/analysis_registration.py
@@ -16,6 +16,7 @@ from app.mcp_server.tooling.analysis_tool_handlers import (
     recommend_stocks_impl,
     screen_stocks_impl,
 )
+from app.mcp_server.tooling.momentum_candidates import get_momentum_candidates_impl
 from app.mcp_server.tooling.research_pipeline_read import (
     research_session_get_impl,
     research_session_list_recent_impl,
@@ -37,6 +38,7 @@ ANALYSIS_TOOL_NAMES: set[str] = {
     "get_correlation",
     "get_dividends",
     "get_fear_greed_index",
+    "get_momentum_candidates",
     "research_session_get",
     "research_session_list_recent",
     "stage_analysis_get",
@@ -46,6 +48,26 @@ ANALYSIS_TOOL_NAMES: set[str] = {
 
 def register_analysis_tools(mcp: FastMCP) -> None:
     """Register MCP tools for analysis, screening, and ranking utilities."""
+
+    @mcp.tool(
+        name="get_momentum_candidates",
+        description=(
+            "Read-only early-catch candidates for 급등 Korean stocks from persisted "
+            "Naver Stock momentum snapshots. Scores cross-surface signals such as "
+            "searchTop, quantTop, up, priceTop, KRX/NXT confirmation, rank deltas, "
+            "and theme leadership. Does not fetch Naver or mutate broker/order state."
+        ),
+    )
+    async def get_momentum_candidates(
+        market: str = "kr",
+        date: str | None = None,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        return await get_momentum_candidates_impl(
+            market=market,
+            date=date,
+            limit=limit,
+        )
 
     @mcp.tool(
         name="get_top_stocks",

--- a/app/mcp_server/tooling/momentum_candidates.py
+++ b/app/mcp_server/tooling/momentum_candidates.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from app.core.db import AsyncSessionLocal
+from app.services.invest_momentum_events.repository import (
+    InvestMomentumEventSnapshotsRepository,
+)
+
+
+def _candidate_to_dict(candidate) -> dict[str, Any]:
+    return {
+        "symbol": candidate.symbol,
+        "name": candidate.name,
+        "score": candidate.score,
+        "latest_snapshot_at": candidate.latest_snapshot_at.isoformat(),
+        "trading_date": candidate.trading_date.isoformat(),
+        "price": float(candidate.price) if candidate.price is not None else None,
+        "change_rate": float(candidate.change_rate)
+        if candidate.change_rate is not None
+        else None,
+        "surface_count": candidate.surface_count,
+        "venue_count": candidate.venue_count,
+        "rank_delta": candidate.rank_delta,
+        "signals": [
+            {
+                **signal,
+                "changeRate": float(signal["changeRate"])
+                if signal.get("changeRate") is not None
+                else None,
+                "tradeValue": float(signal["tradeValue"])
+                if signal.get("tradeValue") is not None
+                else None,
+            }
+            for signal in candidate.signals
+        ],
+        "theme_names": candidate.theme_names,
+        "reason_codes": candidate.reason_codes,
+    }
+
+
+async def get_momentum_candidates_impl(
+    market: str = "kr",
+    date: str | None = None,
+    limit: int = 20,
+) -> dict[str, Any]:
+    """Return read-only 급등 조기 포착 candidates from persisted Naver snapshots."""
+    limit = max(1, min(int(limit or 20), 50))
+    if market != "kr":
+        return {
+            "market": market,
+            "data_state": "unsupported",
+            "empty_reason": "naver_stock_supports_kr_only",
+            "items": [],
+        }
+
+    snapshot_date = dt.date.fromisoformat(date) if date else None
+    async with AsyncSessionLocal() as session:
+        rows = await InvestMomentumEventSnapshotsRepository(
+            session
+        ).list_candidate_signals(
+            trading_date=snapshot_date,
+            limit=limit,
+        )
+    return {
+        "market": "kr",
+        "data_state": "fresh" if rows else "missing",
+        "empty_reason": None if rows else "no_naver_momentum_snapshots",
+        "items": [_candidate_to_dict(row) for row in rows],
+        "scoring_notes": [
+            "searchTop/quantTop/up/priceTop 동시 출현을 우대",
+            "KRX+NXT 동시 출현과 테마 리더 편입을 보너스로 반영",
+            "동일 surface의 직전 스냅샷 대비 순위 개선(rank_delta)을 반영",
+            "read-only: 네이버/브로커 요청 없이 저장된 스냅샷만 조회",
+        ],
+    }

--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -32,6 +32,8 @@ from app.schemas.invest_fx_dashboard import FxDashboardResponse
 from app.schemas.invest_home import InvestHomeResponse
 from app.schemas.invest_market_dashboard import MarketDashboardResponse
 from app.schemas.invest_momentum_events import (
+    MomentumCandidateItem,
+    MomentumCandidatesResponse,
     MomentumCoverageResponse,
     MomentumEventItem,
     MomentumEventsResponse,
@@ -516,6 +518,33 @@ async def get_momentum_events(
         data_state="fresh" if rows else "missing",
         empty_reason=None if rows else "no_naver_momentum_snapshots",
         items=[MomentumEventItem.model_validate(row) for row in rows],
+    )
+
+
+@router.get("/momentum/candidates", response_model=MomentumCandidatesResponse)
+async def get_momentum_candidates(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    market: Literal["kr", "us", "crypto"] = Query("kr"),
+    snapshot_date: Annotated[date | None, Query(alias="date")] = None,
+    limit: int = Query(20, ge=1, le=50),
+) -> MomentumCandidatesResponse:
+    """Read-only early-catch candidates scored from persisted Naver momentum snapshots."""
+    if market != "kr":
+        return MomentumCandidatesResponse(
+            market=market,
+            data_state="unsupported",
+            empty_reason="naver_stock_supports_kr_only",
+            items=[],
+        )
+    rows = await InvestMomentumEventSnapshotsRepository(db).list_candidate_signals(
+        trading_date=snapshot_date,
+        limit=limit,
+    )
+    return MomentumCandidatesResponse(
+        market="kr",
+        data_state="fresh" if rows else "missing",
+        empty_reason=None if rows else "no_naver_momentum_snapshots",
+        items=[MomentumCandidateItem.model_validate(row) for row in rows],
     )
 
 

--- a/app/schemas/invest_momentum_events.py
+++ b/app/schemas/invest_momentum_events.py
@@ -72,6 +72,33 @@ class ThemeEventsResponse(BaseModel):
     items: list[ThemeEventItem]
 
 
+class MomentumCandidateItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    symbol: str
+    name: str | None = None
+    score: float
+    latest_snapshot_at: dt.datetime = Field(alias="latestSnapshotAt")
+    trading_date: dt.date = Field(alias="tradingDate")
+    price: Decimal | None = None
+    change_rate: Decimal | None = Field(default=None, alias="changeRate")
+    surface_count: int = Field(alias="surfaceCount")
+    venue_count: int = Field(alias="venueCount")
+    rank_delta: int | None = Field(default=None, alias="rankDelta")
+    signals: list[dict[str, Any]]
+    theme_names: list[str] = Field(default_factory=list, alias="themeNames")
+    reason_codes: list[str] = Field(default_factory=list, alias="reasonCodes")
+
+
+class MomentumCandidatesResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    market: str
+    data_state: str = Field(alias="dataState")
+    empty_reason: str | None = Field(default=None, alias="emptyReason")
+    items: list[MomentumCandidateItem]
+
+
 class MomentumCoverageResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 

--- a/app/services/invest_momentum_events/repository.py
+++ b/app/services/invest_momentum_events/repository.py
@@ -20,6 +20,23 @@ from app.services.invest_momentum_events.models import (
 
 
 @dataclass(frozen=True)
+class MomentumCandidateSignal:
+    symbol: str
+    name: str | None
+    score: float
+    latest_snapshot_at: dt.datetime
+    trading_date: dt.date
+    price: object | None
+    change_rate: object | None
+    surface_count: int
+    venue_count: int
+    rank_delta: int | None
+    signals: list[dict]
+    theme_names: list[str]
+    reason_codes: list[str]
+
+
+@dataclass(frozen=True)
 class SnapshotCoverage:
     market: str
     as_of: dt.date
@@ -136,6 +153,195 @@ class InvestMomentumEventSnapshotsRepository:
         )
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
+
+    async def list_candidate_signals(
+        self,
+        *,
+        trading_date: dt.date | None = None,
+        limit: int = 20,
+    ) -> list[MomentumCandidateSignal]:
+        """Score latest persisted Naver momentum snapshots into early-catch candidates.
+
+        Read-only. The scoring intentionally favors cross-surface confirmation:
+        searchTop + quantTop + up + KRX/NXT repetition is stronger than a single
+        price-rank appearance. Rank deltas are computed against the prior same-day
+        snapshot for the same symbol/surface/venue/order combination when present.
+        """
+        conditions = [InvestMomentumEventSnapshot.market == "kr"]
+        if trading_date is not None:
+            conditions.append(InvestMomentumEventSnapshot.trading_date == trading_date)
+
+        latest_result = await self._session.execute(
+            select(func.max(InvestMomentumEventSnapshot.snapshot_at)).where(*conditions)
+        )
+        latest_snapshot_at = latest_result.scalar_one_or_none()
+        if latest_snapshot_at is None:
+            return []
+
+        if trading_date is None:
+            date_result = await self._session.execute(
+                select(InvestMomentumEventSnapshot.trading_date)
+                .where(
+                    InvestMomentumEventSnapshot.snapshot_at == latest_snapshot_at,
+                    InvestMomentumEventSnapshot.market == "kr",
+                )
+                .limit(1)
+            )
+            trading_date = date_result.scalar_one()
+
+        rows_result = await self._session.execute(
+            select(InvestMomentumEventSnapshot)
+            .where(
+                InvestMomentumEventSnapshot.market == "kr",
+                InvestMomentumEventSnapshot.trading_date == trading_date,
+            )
+            .order_by(
+                InvestMomentumEventSnapshot.snapshot_at.asc(),
+                InvestMomentumEventSnapshot.rank.asc(),
+            )
+        )
+        rows = list(rows_result.scalars().all())
+        latest_rows = [row for row in rows if row.snapshot_at == latest_snapshot_at]
+        if not latest_rows:
+            return []
+
+        previous_ranks: dict[tuple[str, str | None, str | None, str], int] = {}
+        for row in rows:
+            if row.snapshot_at >= latest_snapshot_at:
+                continue
+            key = (row.symbol, row.trade_type, row.market_type, row.order_type)
+            previous_ranks[key] = row.rank
+
+        latest_theme_result = await self._session.execute(
+            select(func.max(InvestThemeEventSnapshot.snapshot_at)).where(
+                InvestThemeEventSnapshot.market == "kr",
+                InvestThemeEventSnapshot.trading_date == trading_date,
+            )
+        )
+        latest_theme_snapshot_at = latest_theme_result.scalar_one_or_none()
+        themes_by_symbol: dict[str, list[str]] = {}
+        if latest_theme_snapshot_at is not None:
+            theme_rows_result = await self._session.execute(
+                select(InvestThemeEventSnapshot, InvestThemeEventSnapshotStock)
+                .join(
+                    InvestThemeEventSnapshotStock,
+                    InvestThemeEventSnapshotStock.theme_snapshot_id
+                    == InvestThemeEventSnapshot.id,
+                )
+                .where(
+                    InvestThemeEventSnapshot.market == "kr",
+                    InvestThemeEventSnapshot.trading_date == trading_date,
+                    InvestThemeEventSnapshot.snapshot_at == latest_theme_snapshot_at,
+                )
+            )
+            for theme, stock in theme_rows_result.all():
+                bucket = themes_by_symbol.setdefault(stock.symbol, [])
+                if theme.name not in bucket:
+                    bucket.append(theme.name)
+
+        order_weights = {
+            "searchTop": 34.0,
+            "quantTop": 29.0,
+            "up": 27.0,
+            "priceTop": 18.0,
+        }
+        grouped: dict[str, dict] = {}
+        for row in latest_rows:
+            bucket = grouped.setdefault(
+                row.symbol,
+                {
+                    "symbol": row.symbol,
+                    "name": row.name,
+                    "price": row.price,
+                    "change_rate": row.change_rate,
+                    "score": 0.0,
+                    "surfaces": set(),
+                    "venues": set(),
+                    "signals": [],
+                    "rank_deltas": [],
+                    "reason_codes": set(),
+                },
+            )
+            if not bucket.get("name") and row.name:
+                bucket["name"] = row.name
+            if row.price is not None:
+                bucket["price"] = row.price
+            if row.change_rate is not None:
+                bucket["change_rate"] = row.change_rate
+
+            rank_score = max(0.0, 21.0 - float(row.rank))
+            order_score = order_weights.get(row.order_type, 12.0)
+            score_add = order_score + rank_score
+            if row.change_rate is not None:
+                score_add += min(max(float(row.change_rate), 0.0), 20.0)
+
+            key = (row.symbol, row.trade_type, row.market_type, row.order_type)
+            prev_rank = previous_ranks.get(key)
+            rank_delta = prev_rank - row.rank if prev_rank is not None else None
+            if rank_delta is not None and rank_delta > 0:
+                score_add += min(float(rank_delta) * 1.5, 30.0)
+                bucket["rank_deltas"].append(rank_delta)
+                bucket["reason_codes"].add("rank_improving")
+
+            bucket["score"] += score_add
+            bucket["surfaces"].add(row.order_type)
+            if row.trade_type:
+                bucket["venues"].add(row.trade_type)
+            bucket["signals"].append(
+                {
+                    "orderType": row.order_type,
+                    "tradeType": row.trade_type,
+                    "rank": row.rank,
+                    "rankDelta": rank_delta,
+                    "changeRate": row.change_rate,
+                    "volume": row.volume,
+                    "tradeValue": row.trade_value,
+                }
+            )
+            bucket["reason_codes"].add(f"surface_{row.order_type}")
+
+        candidates: list[MomentumCandidateSignal] = []
+        for symbol, bucket in grouped.items():
+            surface_count = len(bucket["surfaces"])
+            venue_count = len(bucket["venues"])
+            if surface_count >= 2:
+                bucket["score"] += 20.0 * (surface_count - 1)
+                bucket["reason_codes"].add("multi_surface")
+            if venue_count >= 2:
+                bucket["score"] += 12.0
+                bucket["reason_codes"].add("krx_nxt_confirmed")
+            theme_names = themes_by_symbol.get(symbol, [])
+            if theme_names:
+                bucket["score"] += 10.0
+                bucket["reason_codes"].add("theme_leader")
+            rank_delta = max(bucket["rank_deltas"]) if bucket["rank_deltas"] else None
+            candidates.append(
+                MomentumCandidateSignal(
+                    symbol=symbol,
+                    name=bucket["name"],
+                    score=round(float(bucket["score"]), 2),
+                    latest_snapshot_at=latest_snapshot_at,
+                    trading_date=trading_date,
+                    price=bucket["price"],
+                    change_rate=bucket["change_rate"],
+                    surface_count=surface_count,
+                    venue_count=venue_count,
+                    rank_delta=rank_delta,
+                    signals=sorted(
+                        bucket["signals"],
+                        key=lambda item: (
+                            item["rank"],
+                            item["orderType"],
+                            item.get("tradeType") or "",
+                        ),
+                    ),
+                    theme_names=theme_names[:5],
+                    reason_codes=sorted(bucket["reason_codes"]),
+                )
+            )
+
+        candidates.sort(key=lambda item: (-item.score, item.symbol))
+        return candidates[:limit]
 
     async def list_theme_events(
         self,

--- a/tests/test_invest_momentum_events.py
+++ b/tests/test_invest_momentum_events.py
@@ -275,6 +275,120 @@ async def test_coverage_reports_unsupported_missing_and_fresh(db_session):
     assert fresh.momentumEvents >= 1
 
 
+@pytest.mark.asyncio
+async def test_repository_scores_momentum_candidates_with_cross_surface_rank_delta_and_theme(
+    db_session,
+):
+    candidate_date = dt.date(2026, 5, 18)
+    previous_snapshot_at = dt.datetime(2026, 5, 18, 9, 10, tzinfo=dt.UTC)
+    latest_snapshot_at = dt.datetime(2026, 5, 18, 9, 20, tzinfo=dt.UTC)
+
+    stale_theme_ids = select(InvestThemeEventSnapshot.id).where(
+        InvestThemeEventSnapshot.trading_date == candidate_date
+    )
+    await db_session.execute(
+        delete(InvestThemeEventSnapshotStock).where(
+            InvestThemeEventSnapshotStock.theme_snapshot_id.in_(stale_theme_ids)
+        )
+    )
+    await db_session.execute(
+        delete(InvestThemeEventSnapshot).where(
+            InvestThemeEventSnapshot.trading_date == candidate_date
+        )
+    )
+    await db_session.execute(
+        delete(InvestMomentumEventSnapshot).where(
+            InvestMomentumEventSnapshot.trading_date == candidate_date
+        )
+    )
+
+    repo = InvestMomentumEventSnapshotsRepository(db_session)
+    base = MomentumEventUpsert(
+        snapshot_at=previous_snapshot_at,
+        trading_date=candidate_date,
+        surface="domestic_market_stock_default",
+        trade_type="KRX",
+        market_type="ALL",
+        order_type="searchTop",
+        rank=18,
+        symbol="123456",
+        name="급등후보",
+        price=Decimal("12000"),
+        change_rate=Decimal("4.5"),
+    )
+    await repo.upsert_momentum(base)
+    await repo.upsert_momentum(
+        base.model_copy(update={"snapshot_at": latest_snapshot_at, "rank": 3})
+    )
+    await repo.upsert_momentum(
+        base.model_copy(
+            update={
+                "snapshot_at": latest_snapshot_at,
+                "trade_type": "NXT",
+                "order_type": "quantTop",
+                "rank": 2,
+                "volume": 1_500_000,
+            }
+        )
+    )
+    await repo.upsert_momentum(
+        base.model_copy(
+            update={
+                "snapshot_at": latest_snapshot_at,
+                "symbol": "654321",
+                "name": "단일신호",
+                "order_type": "priceTop",
+                "rank": 1,
+            }
+        )
+    )
+    await repo.upsert_theme(
+        ThemeEventUpsert(
+            snapshot_at=latest_snapshot_at,
+            trading_date=candidate_date,
+            surface="market_theme_list",
+            event_kind="theme",
+            source_event_key="theme:999:changeRate:ALL",
+            naver_theme_no="999",
+            name="AI반도체",
+            sort_type="changeRate",
+            rank=1,
+            market_type="ALL",
+            stocks=[
+                {
+                    "symbol": "123456",
+                    "name": "급등후보",
+                    "rank": 1,
+                    "order_type": "changeRate",
+                }
+            ],
+        )
+    )
+    await db_session.commit()
+
+    candidates = await repo.list_candidate_signals(
+        trading_date=candidate_date,
+        limit=10,
+    )
+
+    assert [candidate.symbol for candidate in candidates][:2] == ["123456", "654321"]
+    top = candidates[0]
+    assert top.surface_count == 2
+    assert top.venue_count == 2
+    assert top.rank_delta == 15
+    assert top.theme_names == ["AI반도체"]
+    assert "multi_surface" in top.reason_codes
+    assert "krx_nxt_confirmed" in top.reason_codes
+    assert "rank_improving" in top.reason_codes
+    assert "theme_leader" in top.reason_codes
+
+
+def test_mcp_momentum_candidate_tool_is_registered():
+    from app.mcp_server.tooling.analysis_registration import ANALYSIS_TOOL_NAMES
+
+    assert "get_momentum_candidates" in ANALYSIS_TOOL_NAMES
+
+
 def test_no_scheduler_or_broker_order_watch_mutation_imports_in_new_modules():
     root = Path(__file__).resolve().parents[1]
     files = [


### PR DESCRIPTION
## Summary\n- add read-only Naver momentum candidate scoring from persisted snapshots\n- expose /invest/api/momentum/candidates and MCP get_momentum_candidates\n- score cross-surface confirmation, KRX/NXT confirmation, rank deltas, and theme leadership\n\n## Safety\n- read-only: no broker/order/watch mutation\n- no request-path Naver fetch; uses persisted snapshots only\n- no scheduler activation or production DB writes\n\n## Tests\n- uv run --group test pytest tests/test_invest_momentum_events.py -q\n- uv run ruff check app/services/invest_momentum_events/repository.py app/schemas/invest_momentum_events.py app/routers/invest_api.py app/mcp_server/tooling/analysis_registration.py app/mcp_server/tooling/momentum_candidates.py tests/test_invest_momentum_events.py\n- uv run ruff format --check app/services/invest_momentum_events/repository.py app/schemas/invest_momentum_events.py app/routers/invest_api.py app/mcp_server/tooling/analysis_registration.py app/mcp_server/tooling/momentum_candidates.py tests/test_invest_momentum_events.py\n\n## Production read-only smoke\n- ENV_FILE=/Users/mgh3326/services/auto_trader/shared/.env.prod.native PUBLIC_API_PATHS='[]' uv run python - <<'PY' ... get_momentum_candidates_impl(market='kr', limit=5)\n- result: data_state=fresh, top candidates 현대차/현대모비스/삼성전자/SK하이닉스/LG전자\n