### PR TITLE
fix(config): parse public API paths without JSON decoding

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -406,7 +406,7 @@ class Settings(BaseSettings):
 
     # N8N API Key Authentication
     N8N_API_KEY: str = ""
-    PUBLIC_API_PATHS: list[str] = []
+    PUBLIC_API_PATHS: Annotated[list[str], NoDecode] = []
 
     # news-ingestor machine-to-machine bulk ingest authentication
     NEWS_INGESTOR_INGEST_TOKEN: str = ""
@@ -503,7 +503,19 @@ class Settings(BaseSettings):
     def validate_public_api_paths(cls, v: list[str] | str) -> list[str]:
         """Ensure PUBLIC_API_PATHS is parsed consistently from env strings."""
         if isinstance(v, str):
-            return [path.strip() for path in v.split(",") if path.strip()]
+            value = v.strip()
+            if not value:
+                return []
+            if value.startswith("["):
+                parsed = json.loads(value)
+                if not isinstance(parsed, list) or not all(
+                    isinstance(path, str) for path in parsed
+                ):
+                    raise ValueError(
+                        "PUBLIC_API_PATHS JSON value must be a string list"
+                    )
+                return [path.strip() for path in parsed if path.strip()]
+            return [path.strip() for path in value.split(",") if path.strip()]
         return v or []
 
     @field_validator("SENTRY_TRACES_SAMPLE_RATE", "SENTRY_PROFILES_SAMPLE_RATE")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -169,6 +169,27 @@ class TestConfigLoading:
             "TTTC8001R|/uapi/domestic-stock/v1/trading/inquire-daily-ccld"
         ] == {"rate": 10, "period": 1.0}
 
+    def test_public_api_paths_supports_csv_env_string(self, monkeypatch):
+        monkeypatch.setenv("PUBLIC_API_PATHS", "/healthz,/api/n8n/scan")
+
+        cfg = _new_settings()
+
+        assert cfg.PUBLIC_API_PATHS == ["/healthz", "/api/n8n/scan"]
+
+    def test_public_api_paths_supports_json_env_string(self, monkeypatch):
+        monkeypatch.setenv("PUBLIC_API_PATHS", '["/healthz", "/api/n8n/scan"]')
+
+        cfg = _new_settings()
+
+        assert cfg.PUBLIC_API_PATHS == ["/healthz", "/api/n8n/scan"]
+
+    def test_public_api_paths_supports_empty_json_env_string(self, monkeypatch):
+        monkeypatch.setenv("PUBLIC_API_PATHS", "[]")
+
+        cfg = _new_settings()
+
+        assert cfg.PUBLIC_API_PATHS == []
+
     def test_invalid_api_rate_limit_json_raises_validation_error(self, monkeypatch):
         monkeypatch.setenv("KIS_API_RATE_LIMITS", "{not-json}")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -183,12 +183,33 @@ class TestConfigLoading:
 
         assert cfg.PUBLIC_API_PATHS == ["/healthz", "/api/n8n/scan"]
 
+    def test_public_api_paths_supports_empty_string_env(self, monkeypatch):
+        monkeypatch.setenv("PUBLIC_API_PATHS", "")
+
+        cfg = _new_settings()
+
+        assert cfg.PUBLIC_API_PATHS == []
+
     def test_public_api_paths_supports_empty_json_env_string(self, monkeypatch):
         monkeypatch.setenv("PUBLIC_API_PATHS", "[]")
 
         cfg = _new_settings()
 
         assert cfg.PUBLIC_API_PATHS == []
+
+    def test_public_api_paths_rejects_non_string_json_list(self, monkeypatch):
+        monkeypatch.setenv("PUBLIC_API_PATHS", '["/healthz", 1]')
+
+        with pytest.raises(ValidationError, match="PUBLIC_API_PATHS JSON value"):
+            _new_settings()
+
+    def test_constructor_public_api_paths_list_is_preserved(self):
+        cfg = _build_settings(
+            **_required_settings_kwargs(),
+            PUBLIC_API_PATHS=["/healthz"],
+        )
+
+        assert cfg.PUBLIC_API_PATHS == ["/healthz"]
 
     def test_invalid_api_rate_limit_json_raises_validation_error(self, monkeypatch):
         monkeypatch.setenv("KIS_API_RATE_LIMITS", "{not-json}")


### PR DESCRIPTION
## Summary\n- mark PUBLIC_API_PATHS as NoDecode so pydantic-settings does not pre-parse CSV/env strings as JSON\n- keep validator support for CSV, JSON arrays, and empty JSON []\n- fixes native deploy/alembic startup with the current production env value\n\n## Tests\n- uv run --group test pytest tests/test_config.py -q\n- ENV_FILE=/Users/mgh3326/services/auto_trader/shared/.env.prod.native uv run python - <<'PY' ... import settings.PUBLIC_API_PATHS\n- uv run ruff check app/core/config.py tests/test_config.py\n- uv run ruff format --check app/core/config.py tests/test_config.py\n