### PR TITLE
ROB-238: add paper/mock account rows to /invest

### DIFF
--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -99,7 +99,9 @@ def get_invest_home_service(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> InvestHomeService:
     from app.services.invest_home_readers import (
+        AlpacaPaperHomeReader,
         KISHomeReader,
+        KISMockHomeReader,
         ManualHomeReader,
         SafeKISClient,
         UpbitHomeReader,
@@ -113,6 +115,7 @@ def get_invest_home_service(
         kis_reader=KISHomeReader(db),
         upbit_reader=UpbitHomeReader(db),
         manual_reader=ManualHomeReader(db, quote_service=quote_service),
+        paper_readers=[KISMockHomeReader(), AlpacaPaperHomeReader()],
     )
 
 

--- a/app/services/invest_home_readers.py
+++ b/app/services/invest_home_readers.py
@@ -645,7 +645,10 @@ class _KISMockSettingsProxy:
 
     @property
     def kis_base_url(self) -> str:
-        return self._real.kis_mock_base_url or "https://openapivts.koreainvestment.com:29443"
+        return (
+            self._real.kis_mock_base_url
+            or "https://openapivts.koreainvestment.com:29443"
+        )
 
     @property
     def kis_access_token(self) -> str | None:
@@ -767,11 +770,17 @@ class KISMockHomeReader:
                     )
                 )
 
-            investment_value_krw = sum(h.valueKrw for h in holdings if h.valueKrw is not None)
-            cost_basis_krw = sum(
-                h.costBasis for h in holdings if h.costBasis is not None and h.currency == "KRW"
+            investment_value_krw = sum(
+                h.valueKrw for h in holdings if h.valueKrw is not None
             )
-            pnl_krw_total = investment_value_krw - cost_basis_krw if cost_basis_krw > 0 else None
+            cost_basis_krw = sum(
+                h.costBasis
+                for h in holdings
+                if h.costBasis is not None and h.currency == "KRW"
+            )
+            pnl_krw_total = (
+                investment_value_krw - cost_basis_krw if cost_basis_krw > 0 else None
+            )
             pnl_rate_total = (
                 pnl_krw_total / cost_basis_krw
                 if pnl_krw_total is not None and cost_basis_krw > 0
@@ -782,7 +791,9 @@ class KISMockHomeReader:
             buying_power_krw: float | None = None
             cash_warning: InvestHomeWarning | None = None
             try:
-                cash_data = await client.account.inquire_domestic_cash_balance(is_mock=True)
+                cash_data = await client.account.inquire_domestic_cash_balance(
+                    is_mock=True
+                )
                 raw_balance = cash_data.get("dnca_tot_amt")
                 raw_orderable = cash_data.get("stck_cash_ord_psbl_amt")
                 if raw_balance is not None:
@@ -815,7 +826,9 @@ class KISMockHomeReader:
                 cashBalances=CashAmounts(krw=cash_krw),
                 buyingPower=CashAmounts(krw=buying_power_krw),
             )
-            return _SourceFetchResult(accounts=[account], holdings=holdings, warning=cash_warning)
+            return _SourceFetchResult(
+                accounts=[account], holdings=holdings, warning=cash_warning
+            )
 
         except Exception as exc:
             logger.warning("KIS mock fetch failed: %s", exc, exc_info=True)

--- a/app/services/invest_home_readers.py
+++ b/app/services/invest_home_readers.py
@@ -778,14 +778,15 @@ class KISMockHomeReader:
                 for h in holdings
                 if h.costBasis is not None and h.currency == "KRW"
             )
-            pnl_krw_total = (
-                investment_value_krw - cost_basis_krw if cost_basis_krw > 0 else None
-            )
-            pnl_rate_total = (
-                pnl_krw_total / cost_basis_krw
-                if pnl_krw_total is not None and cost_basis_krw > 0
-                else None
-            )
+            if cost_basis_krw > 0:
+                pnl_krw_total = investment_value_krw - cost_basis_krw
+                pnl_rate_total = pnl_krw_total / cost_basis_krw
+            elif holdings and investment_value_krw > 0:
+                pnl_krw_total = investment_value_krw
+                pnl_rate_total = None
+            else:
+                pnl_krw_total = None
+                pnl_rate_total = None
 
             cash_krw: float | None = None
             buying_power_krw: float | None = None
@@ -977,6 +978,30 @@ class AlpacaPaperHomeReader:
             investment_value_krw = sum(
                 h.valueKrw for h in holdings if h.valueKrw is not None
             )
+            valued_holdings = [h for h in holdings if h.valueKrw is not None]
+            cost_basis_krw_values = [
+                h.costBasis * (h.valueKrw / h.valueNative)
+                for h in valued_holdings
+                if h.costBasis is not None
+                and h.valueNative is not None
+                and h.valueNative > 0
+            ]
+            account_cost_basis_krw = (
+                sum(cost_basis_krw_values)
+                if cost_basis_krw_values
+                and len(cost_basis_krw_values) == len(valued_holdings)
+                else None
+            )
+            account_pnl_krw = (
+                investment_value_krw - account_cost_basis_krw
+                if account_cost_basis_krw is not None
+                else None
+            )
+            account_pnl_rate = (
+                account_pnl_krw / account_cost_basis_krw
+                if account_pnl_krw is not None and account_cost_basis_krw > 0
+                else None
+            )
             # Cash and buying power in USD — keep native, convert to KRW for account
             cash_usd = float(account_snap.cash)
             buying_power_usd = float(account_snap.buying_power)
@@ -988,9 +1013,9 @@ class AlpacaPaperHomeReader:
                 accountKind="paper",
                 includedInHome=False,
                 valueKrw=investment_value_krw,
-                costBasisKrw=None,
-                pnlKrw=None,
-                pnlRate=None,
+                costBasisKrw=account_cost_basis_krw,
+                pnlKrw=account_pnl_krw,
+                pnlRate=account_pnl_rate,
                 cashBalances=CashAmounts(usd=cash_usd),
                 buyingPower=CashAmounts(usd=buying_power_usd),
             )

--- a/app/services/invest_home_readers.py
+++ b/app/services/invest_home_readers.py
@@ -778,6 +778,30 @@ class KISMockHomeReader:
                 else None
             )
 
+            cash_krw: float | None = None
+            buying_power_krw: float | None = None
+            cash_warning: InvestHomeWarning | None = None
+            try:
+                cash_data = await client.account.inquire_domestic_cash_balance(is_mock=True)
+                raw_balance = cash_data.get("dnca_tot_amt")
+                raw_orderable = cash_data.get("stck_cash_ord_psbl_amt")
+                if raw_balance is not None:
+                    try:
+                        cash_krw = float(raw_balance)
+                    except (TypeError, ValueError):
+                        cash_krw = None
+                if raw_orderable is not None:
+                    try:
+                        buying_power_krw = float(raw_orderable)
+                    except (TypeError, ValueError):
+                        buying_power_krw = None
+            except Exception as exc:
+                logger.warning("KIS mock cash balance fetch failed: %s", exc)
+                cash_warning = InvestHomeWarning(
+                    source="kis_mock",
+                    message="KIS 모의투자 예수금/주문가능 조회 실패",
+                )
+
             account = Account(
                 accountId="kis_mock_account",
                 displayName="KIS 모의투자",
@@ -788,10 +812,10 @@ class KISMockHomeReader:
                 costBasisKrw=cost_basis_krw if cost_basis_krw > 0 else None,
                 pnlKrw=pnl_krw_total,
                 pnlRate=pnl_rate_total,
-                cashBalances=CashAmounts(),
-                buyingPower=CashAmounts(),
+                cashBalances=CashAmounts(krw=cash_krw),
+                buyingPower=CashAmounts(krw=buying_power_krw),
             )
-            return _SourceFetchResult(accounts=[account], holdings=holdings)
+            return _SourceFetchResult(accounts=[account], holdings=holdings, warning=cash_warning)
 
         except Exception as exc:
             logger.warning("KIS mock fetch failed: %s", exc, exc_info=True)

--- a/app/services/invest_home_readers.py
+++ b/app/services/invest_home_readers.py
@@ -8,7 +8,7 @@ DB write / backfill 금지 — read-only 조회만 사용.
 from __future__ import annotations
 
 import logging
-from typing import Protocol
+from typing import Any, Protocol
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -614,4 +614,360 @@ class ManualHomeReader:
                 accounts=[],
                 holdings=[],
                 warning=InvestHomeWarning(source="toss_manual", message=str(exc)),
+            )
+
+
+# ---------------------------------------------------------------------------
+# ROB-238: KIS mock (paper) reader
+# ---------------------------------------------------------------------------
+
+
+class _KISMockSettingsProxy:
+    """Proxy that maps mock-specific KIS settings to the standard KIS field names.
+
+    Prevents live KIS credentials from leaking into the mock client path.
+    """
+
+    def __init__(self, real_settings: Any) -> None:
+        self._real = real_settings
+
+    @property
+    def kis_app_key(self) -> str | None:
+        return self._real.kis_mock_app_key
+
+    @property
+    def kis_app_secret(self) -> str | None:
+        return self._real.kis_mock_app_secret
+
+    @property
+    def kis_account_no(self) -> str | None:
+        return self._real.kis_mock_account_no
+
+    @property
+    def kis_base_url(self) -> str:
+        return self._real.kis_mock_base_url or "https://openapivts.koreainvestment.com:29443"
+
+    @property
+    def kis_access_token(self) -> str | None:
+        return self._real.kis_mock_access_token
+
+    @kis_access_token.setter
+    def kis_access_token(self, value: str | None) -> None:
+        self._real.kis_mock_access_token = value
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+
+class SafeKISMockClient(BaseKISClient):
+    """Mutation-safe KIS mock client using mock-specific credentials and endpoint.
+
+    Uses a separate Redis token namespace (kis_mock) to avoid sharing tokens
+    with the live KIS client.
+    """
+
+    def __init__(self) -> None:
+        from app.core.config import settings as _settings
+        from app.services.redis_token_manager import RedisTokenManager
+
+        self._mock_settings = _KISMockSettingsProxy(_settings)
+        # Call super().__init__() — since _settings property is overridden,
+        # _hdr_base will use mock app key/secret automatically.
+        super().__init__()
+        # Override token manager to use separate Redis namespace for mock tokens.
+        self._token_manager = RedisTokenManager(namespace="kis_mock")
+        self.account = AccountClient(self)
+
+    @property
+    def _settings(self) -> Any:  # type: ignore[override]
+        return self._mock_settings
+
+    def _kis_url(self, path: str) -> str:
+        base_url = (self._mock_settings.kis_base_url or "").rstrip("/")
+        if not base_url:
+            base_url = "https://openapivts.koreainvestment.com:29443"
+        return f"{base_url}{path}"
+
+
+def _kis_mock_configured() -> bool:
+    """Return True only when all required KIS mock credentials are present."""
+    from app.core.config import settings as _settings
+
+    return bool(
+        getattr(_settings, "kis_mock_enabled", False)
+        and getattr(_settings, "kis_mock_app_key", None)
+        and getattr(_settings, "kis_mock_app_secret", None)
+        and getattr(_settings, "kis_mock_account_no", None)
+    )
+
+
+class KISMockHomeReader:
+    """KIS 모의투자 계좌 read-only reader (ROB-238).
+
+    Returns paper-tagged Account/Holding rows excluded from home totals.
+    Returns empty result with sanitized warning when mock credentials are absent.
+    """
+
+    source: str = "kis_mock"
+
+    def __init__(self) -> None:
+        pass
+
+    async def fetch(self, *, user_id: int) -> _SourceFetchResult:
+        if not _kis_mock_configured():
+            logger.info("KIS mock reader: not configured, skipping")
+            return _SourceFetchResult(
+                accounts=[],
+                holdings=[],
+                warning=InvestHomeWarning(
+                    source="kis_mock",
+                    message="KIS 모의투자 미설정 (KIS_MOCK_ENABLED 또는 자격증명 없음)",
+                ),
+            )
+
+        try:
+            client = SafeKISMockClient()
+            stocks_kr = await client.account.fetch_my_stocks(
+                is_mock=True, is_overseas=False
+            )
+
+            holdings: list[Holding] = []
+            for s in stocks_kr:
+                qty = float(s.get("hldg_qty", 0))
+                avg_price = float(s.get("pchs_avg_pric", 0))
+                value_krw = float(s.get("evlu_amt", 0))
+                cost_basis = float(s.get("pchs_amt", 0)) or (qty * avg_price)
+                pnl_krw = float(s.get("evlu_pfls_amt", 0))
+                pnl_rate_raw = s.get("evlu_pfls_rt")
+                pnl_rate = (
+                    float(pnl_rate_raw) / 100.0
+                    if pnl_rate_raw not in (None, "", "0", 0)
+                    else None
+                )
+                holdings.append(
+                    Holding(
+                        holdingId=f"kis_mock:kr:{s.get('pdno')}",
+                        accountId="kis_mock_account",
+                        source="kis_mock",
+                        accountKind="paper",
+                        symbol=str(s.get("pdno")),
+                        market="KR",
+                        assetType="equity",
+                        assetCategory="kr_stock",
+                        displayName=str(s.get("prdt_name")),
+                        quantity=qty,
+                        averageCost=avg_price if avg_price > 0 else None,
+                        costBasis=cost_basis if cost_basis > 0 else None,
+                        currency="KRW",
+                        valueNative=value_krw,
+                        valueKrw=value_krw,
+                        pnlKrw=pnl_krw,
+                        pnlRate=pnl_rate,
+                        priceState="live" if value_krw > 0 else "missing",
+                    )
+                )
+
+            investment_value_krw = sum(h.valueKrw for h in holdings if h.valueKrw is not None)
+            cost_basis_krw = sum(
+                h.costBasis for h in holdings if h.costBasis is not None and h.currency == "KRW"
+            )
+            pnl_krw_total = investment_value_krw - cost_basis_krw if cost_basis_krw > 0 else None
+            pnl_rate_total = (
+                pnl_krw_total / cost_basis_krw
+                if pnl_krw_total is not None and cost_basis_krw > 0
+                else None
+            )
+
+            account = Account(
+                accountId="kis_mock_account",
+                displayName="KIS 모의투자",
+                source="kis_mock",
+                accountKind="paper",
+                includedInHome=False,
+                valueKrw=investment_value_krw,
+                costBasisKrw=cost_basis_krw if cost_basis_krw > 0 else None,
+                pnlKrw=pnl_krw_total,
+                pnlRate=pnl_rate_total,
+                cashBalances=CashAmounts(),
+                buyingPower=CashAmounts(),
+            )
+            return _SourceFetchResult(accounts=[account], holdings=holdings)
+
+        except Exception as exc:
+            logger.warning("KIS mock fetch failed: %s", exc, exc_info=True)
+            return _SourceFetchResult(
+                accounts=[],
+                holdings=[],
+                warning=InvestHomeWarning(
+                    source="kis_mock",
+                    message="KIS 모의투자 조회 실패",
+                ),
+            )
+
+
+# ---------------------------------------------------------------------------
+# ROB-238: Alpaca Paper reader
+# ---------------------------------------------------------------------------
+
+
+class AlpacaPaperHomeReader:
+    """Alpaca Paper 계좌 read-only reader (ROB-238).
+
+    Exposes only get_account / list_positions from AlpacaPaperBrokerService.
+    Mutation methods (submit_order, cancel_order) are never imported or called.
+    Returns paper-tagged rows excluded from home totals.
+    """
+
+    source: str = "alpaca_paper"
+
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    def _make_service() -> Any:
+        from app.services.brokers.alpaca.service import AlpacaPaperBrokerService
+
+        return AlpacaPaperBrokerService()
+
+    async def fetch(self, *, user_id: int) -> _SourceFetchResult:
+        from app.services.brokers.alpaca.exceptions import (
+            AlpacaPaperConfigurationError,
+            AlpacaPaperEndpointError,
+        )
+
+        try:
+            svc = self._make_service()
+        except AlpacaPaperConfigurationError:
+            logger.info("Alpaca Paper reader: not configured, skipping")
+            return _SourceFetchResult(
+                accounts=[],
+                holdings=[],
+                warning=InvestHomeWarning(
+                    source="alpaca_paper",
+                    message="Alpaca Paper 미설정 (자격증명 없음)",
+                ),
+            )
+        except AlpacaPaperEndpointError as exc:
+            logger.warning("Alpaca Paper endpoint error: %s", exc)
+            return _SourceFetchResult(
+                accounts=[],
+                holdings=[],
+                warning=InvestHomeWarning(
+                    source="alpaca_paper",
+                    message="Alpaca Paper 엔드포인트 오류",
+                ),
+            )
+        except Exception as exc:
+            logger.warning("Alpaca Paper service init failed: %s", exc, exc_info=True)
+            return _SourceFetchResult(
+                accounts=[],
+                holdings=[],
+                warning=InvestHomeWarning(
+                    source="alpaca_paper",
+                    message="Alpaca Paper 초기화 실패",
+                ),
+            )
+
+        try:
+            account_snap = await svc.get_account()
+            positions = await svc.list_positions()
+
+            usd_krw_rate: float | None = None
+            fx_warning: InvestHomeWarning | None = None
+            try:
+                usd_krw_rate = await get_usd_krw_rate()
+            except Exception as exc:
+                logger.warning("USD/KRW FX fetch failed for Alpaca: %s", exc)
+                fx_warning = InvestHomeWarning(
+                    source="alpaca_paper",
+                    message="USD 환율 조회 실패 — KRW 환산 불가",
+                )
+
+            holdings: list[Holding] = []
+            for pos in positions:
+                qty = float(pos.qty)
+                avg_price = float(pos.avg_entry_price)
+                cost_basis_usd = qty * avg_price
+                value_native: float | None = (
+                    float(pos.market_value) if pos.market_value is not None else None
+                )
+                pnl_native: float | None = (
+                    float(pos.unrealized_pl) if pos.unrealized_pl is not None else None
+                )
+                current_price: float | None = (
+                    float(pos.current_price) if pos.current_price is not None else None
+                )
+
+                value_krw: float | None = (
+                    value_native * usd_krw_rate
+                    if value_native is not None and usd_krw_rate is not None
+                    else None
+                )
+                pnl_krw: float | None = (
+                    pnl_native * usd_krw_rate
+                    if pnl_native is not None and usd_krw_rate is not None
+                    else None
+                )
+                pnl_rate: float | None = (
+                    pnl_native / cost_basis_usd
+                    if pnl_native is not None and cost_basis_usd > 0
+                    else None
+                )
+
+                holdings.append(
+                    Holding(
+                        holdingId=f"alpaca_paper:{pos.symbol}",
+                        accountId="alpaca_paper_account",
+                        source="alpaca_paper",
+                        accountKind="paper",
+                        symbol=pos.symbol,
+                        market="US",
+                        assetType="equity",
+                        assetCategory="us_stock",
+                        displayName=pos.symbol,
+                        quantity=qty,
+                        averageCost=avg_price if avg_price > 0 else None,
+                        costBasis=cost_basis_usd if cost_basis_usd > 0 else None,
+                        currency="USD",
+                        valueNative=value_native,
+                        valueKrw=value_krw,
+                        pnlKrw=pnl_krw,
+                        pnlRate=pnl_rate,
+                        priceState="live" if current_price is not None else "missing",
+                    )
+                )
+
+            investment_value_krw = sum(
+                h.valueKrw for h in holdings if h.valueKrw is not None
+            )
+            # Cash and buying power in USD — keep native, convert to KRW for account
+            cash_usd = float(account_snap.cash)
+            buying_power_usd = float(account_snap.buying_power)
+
+            account = Account(
+                accountId="alpaca_paper_account",
+                displayName="Alpaca Paper",
+                source="alpaca_paper",
+                accountKind="paper",
+                includedInHome=False,
+                valueKrw=investment_value_krw,
+                costBasisKrw=None,
+                pnlKrw=None,
+                pnlRate=None,
+                cashBalances=CashAmounts(usd=cash_usd),
+                buyingPower=CashAmounts(usd=buying_power_usd),
+            )
+            return _SourceFetchResult(
+                accounts=[account], holdings=holdings, warning=fx_warning
+            )
+
+        except Exception as exc:
+            logger.warning("Alpaca Paper fetch failed: %s", exc, exc_info=True)
+            return _SourceFetchResult(
+                accounts=[],
+                holdings=[],
+                warning=InvestHomeWarning(
+                    source="alpaca_paper",
+                    message="Alpaca Paper 조회 실패",
+                ),
             )

--- a/app/services/invest_home_service.py
+++ b/app/services/invest_home_service.py
@@ -382,14 +382,8 @@ class InvestHomeService:
                     exc,
                     exc_info=True,
                 )
-                # Only emit warning when source is a known valid literal
-                _valid_sources = {
-                    "kis_mock",
-                    "kiwoom_mock",
-                    "alpaca_paper",
-                    "db_simulated",
-                }
-                if reader_source in _valid_sources:
+                # Only emit warning when source is a known valid paper literal.
+                if reader_source in _PAPER:
                     warnings.append(
                         InvestHomeWarning(
                             source=reader_source, message=type(exc).__name__

--- a/app/services/invest_home_service.py
+++ b/app/services/invest_home_service.py
@@ -377,15 +377,23 @@ class InvestHomeService:
             except Exception as exc:
                 src_name = type(reader).__name__
                 logger.warning(
-                    "[invest_home] paper reader %s failed: %s", src_name, exc, exc_info=True
+                    "[invest_home] paper reader %s failed: %s",
+                    src_name,
+                    exc,
+                    exc_info=True,
                 )
                 # Only emit warning when source is a known valid literal
                 _valid_sources = {
-                    "kis_mock", "kiwoom_mock", "alpaca_paper", "db_simulated"
+                    "kis_mock",
+                    "kiwoom_mock",
+                    "alpaca_paper",
+                    "db_simulated",
                 }
                 if reader_source in _valid_sources:
                     warnings.append(
-                        InvestHomeWarning(source=reader_source, message=type(exc).__name__)  # type: ignore[arg-type]
+                        InvestHomeWarning(
+                            source=reader_source, message=type(exc).__name__
+                        )  # type: ignore[arg-type]
                     )
 
         return InvestHomeResponse(

--- a/app/services/invest_home_service.py
+++ b/app/services/invest_home_service.py
@@ -8,7 +8,7 @@ mutation 경로(submit/cancel/modify/place_order/watch/order-intent/scheduler/wo
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 
 from app.schemas.invest_home import (
@@ -305,10 +305,18 @@ class _SourceFetchResult:
 class InvestHomeService:
     """Read-only 합성 서비스. mutation 경로 호출 금지."""
 
-    def __init__(self, *, kis_reader, upbit_reader, manual_reader) -> None:
+    def __init__(
+        self,
+        *,
+        kis_reader,
+        upbit_reader,
+        manual_reader,
+        paper_readers: Sequence[object] | None = None,
+    ) -> None:
         self._kis = kis_reader
         self._upbit = upbit_reader
         self._manual = manual_reader
+        self._paper_readers: Sequence[object] = paper_readers or []
 
     async def get_home(self, *, user_id: int) -> InvestHomeResponse:
         warnings: list[InvestHomeWarning] = []
@@ -354,6 +362,32 @@ class InvestHomeService:
                         source=src, message=str(exc) or type(exc).__name__
                     )
                 )
+
+        # Paper readers — each is a read-only adapter (e.g. KISMockHomeReader,
+        # AlpacaPaperHomeReader). Partial failure must not affect live accounts.
+        for reader in self._paper_readers:
+            # Readers expose an optional `source` attribute for warning attribution.
+            reader_source: str = getattr(reader, "source", None) or "kis_mock"
+            try:
+                result = await reader.fetch(user_id=user_id)  # type: ignore[union-attr]
+                accounts.extend(result.accounts)
+                holdings.extend(result.holdings)
+                if result.warning is not None:
+                    warnings.append(result.warning)
+            except Exception as exc:
+                src_name = type(reader).__name__
+                logger.warning(
+                    "[invest_home] paper reader %s failed: %s", src_name, exc, exc_info=True
+                )
+                # Only emit warning when source is a known valid literal
+                _valid_sources = {
+                    "kis_mock", "kiwoom_mock", "alpaca_paper", "db_simulated"
+                }
+                if reader_source in _valid_sources:
+                    warnings.append(
+                        InvestHomeWarning(source=reader_source, message=type(exc).__name__)  # type: ignore[arg-type]
+                    )
+
         return InvestHomeResponse(
             homeSummary=build_home_summary(accounts),
             accounts=accounts,

--- a/app/services/invest_view_model/account_visual.py
+++ b/app/services/invest_view_model/account_visual.py
@@ -27,7 +27,7 @@ _VISUAL_MAP: dict[str, tuple[Tone, BadgeText, str]] = {
     "toss_manual": ("dashed", "Manual", "토스 수동"),
     "pension_manual": ("dashed", "Manual", "연금 수동"),
     "isa_manual": ("dashed", "Manual", "ISA 수동"),
-    "db_simulated": ("dashed", "Manual", "시뮬레이션"),
+    "db_simulated": ("dashed", "Paper", "시뮬레이션"),
 }
 
 

--- a/frontend/invest/src/__tests__/RightAccountPanel.test.tsx
+++ b/frontend/invest/src/__tests__/RightAccountPanel.test.tsx
@@ -35,6 +35,37 @@ test("renders accounts with source-based badge", () => {
   expect(card.textContent).toContain("Live");
 });
 
+test("keeps KIS mock visibly distinct from live account", () => {
+  const data: AccountPanelResponse = {
+    ...baseResp,
+    accounts: [
+      ...baseResp.accounts,
+      {
+        accountId: "km1",
+        displayName: "KIS official mock",
+        source: "kis_mock",
+        accountKind: "paper",
+        includedInHome: false,
+        valueKrw: 0,
+        cashBalances: { krw: 1_000_000, usd: 10 },
+        buyingPower: { krw: 1_000_000, usd: 10 },
+      },
+    ],
+    sourceVisuals: [
+      ...baseResp.sourceVisuals,
+      { source: "kis_mock", tone: "dashed", badge: "Mock", displayName: "KIS mock" },
+    ],
+  };
+
+  render(<RightAccountPanel data={data} />);
+
+  const cards = screen.getAllByTestId("right-panel-account");
+  expect(cards.map((card) => card.dataset.source)).toEqual(["kis", "kis_mock"]);
+  expect(screen.getByText("KIS official mock · KIS 모의")).toBeInTheDocument();
+  expect(screen.getByText("Mock")).toBeInTheDocument();
+  expect(screen.getByText("$10.00")).toBeInTheDocument();
+});
+
 test("watchlist empty state", () => {
   render(<RightAccountPanel data={baseResp} />);
   expect(screen.getByTestId("watchlist-empty")).toBeInTheDocument();

--- a/frontend/invest/src/__tests__/RightRemotePanel.test.tsx
+++ b/frontend/invest/src/__tests__/RightRemotePanel.test.tsx
@@ -38,6 +38,26 @@ const PANEL_RESP: AccountPanelResponse = {
       cashBalances: { krw: 50_000 },
       buyingPower: { krw: 50_000 },
     },
+    {
+      accountId: "km1",
+      displayName: "KIS official mock",
+      source: "kis_mock",
+      accountKind: "paper",
+      includedInHome: false,
+      valueKrw: 0,
+      cashBalances: { krw: 1_000_000, usd: 10 },
+      buyingPower: { krw: 1_000_000, usd: 10 },
+    },
+    {
+      accountId: "ap1",
+      displayName: "Alpaca sandbox",
+      source: "alpaca_paper",
+      accountKind: "paper",
+      includedInHome: false,
+      valueKrw: 0,
+      cashBalances: { usd: 250.25 },
+      buyingPower: { usd: 250.25 },
+    },
   ],
   groupedHoldings: [
     {
@@ -111,6 +131,8 @@ const PANEL_RESP: AccountPanelResponse = {
     { source: "kis", tone: "navy", badge: "Live", displayName: "KIS" },
     { source: "upbit", tone: "green", badge: "Crypto", displayName: "Upbit" },
     { source: "toss_manual", tone: "gray", badge: "Manual", displayName: "Toss/manual" },
+    { source: "kis_mock", tone: "dashed", badge: "Mock", displayName: "KIS mock" },
+    { source: "alpaca_paper", tone: "dashed", badge: "Paper", displayName: "Alpaca" },
   ],
   meta: { warnings: [], watchlistAvailable: true },
 };
@@ -155,9 +177,11 @@ test("portfolio tab shows account cash card, filters, and all-account holdings a
   expect(within(cashCard).getByText("₩150,000")).toBeInTheDocument();
   expect(within(cashCard).getByText("$25.5")).toBeInTheDocument();
   expect(screen.getByRole("button", { name: "전체" })).toHaveAttribute("aria-pressed", "true");
-  expect(screen.getByRole("button", { name: "KIS" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "KIS 실계좌" })).toBeInTheDocument();
   expect(screen.getByRole("button", { name: "Upbit" })).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "Toss/manual" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Toss 수동" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "KIS 모의" })).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Alpaca Paper" })).toBeInTheDocument();
   expect(screen.getByText("전체 보유종목")).toBeInTheDocument();
   expect(screen.getByText("비트코인")).toBeInTheDocument();
   expect(screen.getByText("Tesla")).toBeInTheDocument();
@@ -171,10 +195,10 @@ test("KIS filter recomputes totals and rows without refetching account panel", a
   await waitFor(() => expect(screen.getByTestId("portfolio-panel")).toBeInTheDocument());
   expect(fetchSpy).toHaveBeenCalledTimes(1);
 
-  await user.click(screen.getByRole("button", { name: "KIS" }));
+  await user.click(screen.getByRole("button", { name: "KIS 실계좌" }));
 
-  expect(screen.getByRole("button", { name: "KIS" })).toHaveAttribute("aria-pressed", "true");
-  expect(screen.getByText("KIS 보유종목")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "KIS 실계좌" })).toHaveAttribute("aria-pressed", "true");
+  expect(screen.getByText("KIS 실계좌 보유종목")).toBeInTheDocument();
   expect(screen.getByText("Tesla")).toBeInTheDocument();
   expect(screen.queryByText("비트코인")).not.toBeInTheDocument();
   expect(screen.getAllByText("₩1,244,000")).toHaveLength(2);
@@ -200,13 +224,28 @@ test("Upbit and Toss/manual filters scope holdings and cash independently", asyn
   let cashCard = screen.getByTestId("account-cash-card");
   expect(within(cashCard).getByText("₩50,000")).toBeInTheDocument();
 
-  await user.click(screen.getByRole("button", { name: "Toss/manual" }));
-  expect(screen.getByText("Toss/manual 보유종목")).toBeInTheDocument();
+  await user.click(screen.getByRole("button", { name: "Toss 수동" }));
+  expect(screen.getByText("Toss 수동 보유종목")).toBeInTheDocument();
   expect(screen.getByText("Tesla")).toBeInTheDocument();
   expect(screen.queryByText("비트코인")).not.toBeInTheDocument();
   expect(screen.getAllByText("₩356,000")).toHaveLength(2);
   cashCard = screen.getByTestId("account-cash-card");
   expect(within(cashCard).getByText("현금 정보 없음")).toBeInTheDocument();
+});
+
+test("paper account filters show distinct labels and cash-only empty state", async () => {
+  const user = userEvent.setup();
+  renderPanel();
+  await waitFor(() => expect(screen.getByTestId("portfolio-panel")).toBeInTheDocument());
+
+  await user.click(screen.getByRole("button", { name: "Alpaca Paper" }));
+
+  expect(screen.getByRole("button", { name: "Alpaca Paper" })).toHaveAttribute("aria-pressed", "true");
+  expect(screen.getByText("Alpaca Paper 보유종목")).toBeInTheDocument();
+  expect(screen.getByText("Alpaca Paper 계좌는 표시할 모의/Paper 보유종목이 없습니다.")).toBeInTheDocument();
+  const cashCard = screen.getByTestId("account-cash-card");
+  expect(within(cashCard).getByText("$250.25")).toBeInTheDocument();
+  expect(screen.queryByText("KIS 실계좌 보유종목")).not.toBeInTheDocument();
 });
 
 test("watchlist tab shows watch symbols", async () => {

--- a/frontend/invest/src/__tests__/RightRemotePanel.test.tsx
+++ b/frontend/invest/src/__tests__/RightRemotePanel.test.tsx
@@ -248,6 +248,22 @@ test("paper account filters show distinct labels and cash-only empty state", asy
   expect(screen.queryByText("KIS 실계좌 보유종목")).not.toBeInTheDocument();
 });
 
+test("KIS mock filter shows distinct labels and cash-only empty state", async () => {
+  const user = userEvent.setup();
+  renderPanel();
+  await waitFor(() => expect(screen.getByTestId("portfolio-panel")).toBeInTheDocument());
+
+  await user.click(screen.getByRole("button", { name: "KIS 모의" }));
+
+  expect(screen.getByRole("button", { name: "KIS 모의" })).toHaveAttribute("aria-pressed", "true");
+  expect(screen.getByText("KIS 모의 보유종목")).toBeInTheDocument();
+  expect(screen.getByText("KIS 모의 계좌는 표시할 모의/Paper 보유종목이 없습니다.")).toBeInTheDocument();
+  const cashCard = screen.getByTestId("account-cash-card");
+  expect(within(cashCard).getByText("₩1,000,000")).toBeInTheDocument();
+  expect(within(cashCard).getByText("$10")).toBeInTheDocument();
+  expect(screen.queryByText("KIS 실계좌 보유종목")).not.toBeInTheDocument();
+});
+
 test("watchlist tab shows watch symbols", async () => {
   renderPanel();
   await waitFor(() => expect(screen.getByTestId("portfolio-panel")).toBeInTheDocument());

--- a/frontend/invest/src/__tests__/scopeHoldings.test.ts
+++ b/frontend/invest/src/__tests__/scopeHoldings.test.ts
@@ -69,6 +69,22 @@ const baseGroup: GroupedHolding = {
   ],
 };
 
+const kisMockGroup: GroupedHolding = {
+  ...baseGroup,
+  groupId: "US:equity:USD:MSFT:kis_mock",
+  symbol: "MSFT",
+  displayName: "Microsoft",
+  totalQuantity: 1,
+  averageCost: 300,
+  costBasis: 300,
+  valueNative: 320,
+  valueKrw: 430_000,
+  pnlKrw: 30_000,
+  pnlRate: 0.075,
+  includedSources: ["kis_mock"],
+  sourceBreakdown: [],
+};
+
 const upbitGroup: GroupedHolding = {
   groupId: "CRYPTO:crypto:KRW:BTC",
   symbol: "KRW-BTC",
@@ -125,13 +141,41 @@ const panelResponse: AccountPanelResponse = {
       cashBalances: { krw: 50_000 },
       buyingPower: { krw: 50_000 },
     },
+    {
+      accountId: "kis-mock-1",
+      displayName: "KIS official mock",
+      source: "kis_mock",
+      accountKind: "paper",
+      includedInHome: false,
+      valueKrw: 430_000,
+      costBasisKrw: 400_000,
+      pnlKrw: 30_000,
+      pnlRate: 0.075,
+      cashBalances: { krw: 1_000_000, usd: 10 },
+      buyingPower: { krw: 1_000_000, usd: 10 },
+    },
+    {
+      accountId: "alpaca-paper-1",
+      displayName: "Alpaca sandbox",
+      source: "alpaca_paper",
+      accountKind: "paper",
+      includedInHome: false,
+      valueKrw: 0,
+      costBasisKrw: null,
+      pnlKrw: null,
+      pnlRate: null,
+      cashBalances: { krw: null, usd: 250.25 },
+      buyingPower: { krw: null, usd: 250.25 },
+    },
   ],
-  groupedHoldings: [baseGroup, upbitGroup],
+  groupedHoldings: [baseGroup, upbitGroup, kisMockGroup],
   watchSymbols: [],
   sourceVisuals: [
     { source: "kis", tone: "navy", badge: "Live", displayName: "KIS" },
     { source: "upbit", tone: "green", badge: "Crypto", displayName: "Upbit" },
     { source: "toss_manual", tone: "gray", badge: "Manual", displayName: "Toss/manual" },
+    { source: "kis_mock", tone: "dashed", badge: "Mock", displayName: "KIS mock" },
+    { source: "alpaca_paper", tone: "dashed", badge: "Paper", displayName: "Alpaca" },
   ],
   meta: { warnings: [], watchlistAvailable: true },
 };
@@ -208,8 +252,8 @@ describe("buildScopedPortfolioPanel", () => {
 
   it("builds filter options from accounts and holding-only manual sources", () => {
     const options = buildAccountFilterOptions(panelResponse);
-    expect(options.map((option) => option.key)).toEqual(["all", "kis", "upbit", "toss_manual"]);
-    expect(options.map((option) => option.label)).toEqual(["전체", "KIS", "Upbit", "Toss/manual"]);
+    expect(options.map((option) => option.key)).toEqual(["all", "kis", "upbit", "kis_mock", "alpaca_paper", "toss_manual"]);
+    expect(options.map((option) => option.label)).toEqual(["전체", "KIS 실계좌", "Upbit", "KIS 모의", "Alpaca Paper", "Toss 수동"]);
     expect(options.find((option) => option.key === "toss_manual")?.cashBalances).toEqual({ krw: null, usd: null });
   });
 
@@ -234,8 +278,31 @@ describe("buildScopedPortfolioPanel", () => {
     expect(scoped.cashBalances).toEqual({ krw: 50_000, usd: null });
   });
 
-  it("falls back to all for missing selected keys", () => {
+  it("handles cash-only paper accounts without holdings", () => {
     const scoped = buildScopedPortfolioPanel(panelResponse, "alpaca_paper");
+    expect(scoped.selected.key).toBe("alpaca_paper");
+    expect(scoped.selected.label).toBe("Alpaca Paper");
+    expect(scoped.groupedHoldings).toEqual([]);
+    expect(scoped.totalValueKrw).toBe(0);
+    expect(scoped.cashBalances).toEqual({ krw: null, usd: 250.25 });
+  });
+
+  it("keeps live KIS distinct from KIS mock", () => {
+    const live = buildScopedPortfolioPanel(panelResponse, "kis");
+    const mock = buildScopedPortfolioPanel(panelResponse, "kis_mock");
+    expect(live.selected.label).toBe("KIS 실계좌");
+    expect(mock.selected.label).toBe("KIS 모의");
+    expect(mock.groupedHoldings.map((group) => group.symbol)).toEqual(["MSFT"]);
+    expect(mock.cashBalances).toEqual({ krw: 1_000_000, usd: 10 });
+  });
+
+  it("falls back to all for missing selected keys", () => {
+    const response = {
+      ...panelResponse,
+      accounts: panelResponse.accounts.filter((account) => account.source !== "db_simulated"),
+      groupedHoldings: panelResponse.groupedHoldings.filter((group) => !group.includedSources.includes("db_simulated")),
+    };
+    const scoped = buildScopedPortfolioPanel(response, "db_simulated");
     expect(scoped.selected.key).toBe("all");
     expect(scoped.totalValueKrw).toBe(panelResponse.homeSummary.totalValueKrw);
   });

--- a/frontend/invest/src/components/AccountCardList.tsx
+++ b/frontend/invest/src/components/AccountCardList.tsx
@@ -1,6 +1,7 @@
 import type { Account, InvestHomeWarning } from "../types/invest";
 import { formatKrw, formatUsd } from "../format/currency";
 import { formatPercent } from "../format/percent";
+import { accountSourceMeta, displayNameWithSource } from "../desktop/AccountSourceMeta";
 
 function gainClass(rate: number | null | undefined): string {
   if (rate === null || rate === undefined) return "fallback";
@@ -8,7 +9,9 @@ function gainClass(rate: number | null | undefined): string {
 }
 
 function AccountCard({ a, warnings = [] }: { a: Account; warnings?: InvestHomeWarning[] }) {
+  const meta = accountSourceMeta(a.source);
   const isManual = a.accountKind === "manual";
+  const showUsd = a.cashBalances.usd != null || a.buyingPower.usd != null || a.source === "kis" || a.source === "kis_mock" || a.source === "alpaca_paper";
   const kisUsdWarning =
     a.source === "kis" && warnings.some((w) => w.source === "kis" && w.message.includes("USD"));
 
@@ -23,21 +26,20 @@ function AccountCard({ a, warnings = [] }: { a: Account; warnings?: InvestHomeWa
         flex: "0 0 auto",
       }}
     >
-      <div style={{ fontWeight: 600, fontSize: 12, display: "flex", justifyContent: "space-between" }}>
-        <span>{a.displayName}</span>
-        {isManual && (
-          <span
-            style={{
-              padding: "1px 6px",
-              borderRadius: 5,
-              background: "var(--surface-2)",
-              color: "var(--fg-2)",
-              fontSize: 9,
-            }}
-          >
-            수동
-          </span>
-        )}
+      <div style={{ fontWeight: 600, fontSize: 12, display: "flex", justifyContent: "space-between", gap: 8 }}>
+        <span style={{ minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{displayNameWithSource(a)}</span>
+        <span
+          style={{
+            padding: "1px 6px",
+            borderRadius: 5,
+            background: `var(--pill-${meta.tone}-bg)`,
+            color: `var(--pill-${meta.tone}-fg)`,
+            fontSize: 9,
+            flexShrink: 0,
+          }}
+        >
+          {isManual ? "수동" : meta.badge}
+        </span>
       </div>
       <div style={{ fontWeight: 700, fontSize: 18, marginTop: 4 }}>{formatKrw(a.valueKrw)}</div>
       <div className={gainClass(a.pnlRate)} style={{ fontSize: 11 }}>
@@ -58,34 +60,24 @@ function AccountCard({ a, warnings = [] }: { a: Account; warnings?: InvestHomeWa
           gap: "4px 10px",
         }}
       >
-        {a.source === "kis" && (
-          <>
-            <Cell k="원화 · 현금" v={formatKrw(a.cashBalances.krw ?? null)} />
+        <>
+          <Cell k="KRW · 현금" v={formatKrw(a.cashBalances.krw ?? null)} />
+          {showUsd && (
             <Cell
-              k="달러 · 현금"
+              k="USD · 현금"
               v={kisUsdWarning ? "확인 필요" : formatUsd(a.cashBalances.usd ?? null)}
               warn={kisUsdWarning}
             />
-            <Cell k="원화 · 매수 가능" v={formatKrw(a.buyingPower.krw ?? null)} />
+          )}
+          <Cell k="KRW · 매수 가능" v={formatKrw(a.buyingPower.krw ?? null)} />
+          {showUsd && (
             <Cell
-              k="달러 · 매수 가능"
+              k="USD · 매수 가능"
               v={kisUsdWarning ? "확인 필요" : formatUsd(a.buyingPower.usd ?? null)}
               warn={kisUsdWarning}
             />
-          </>
-        )}
-        {a.source === "upbit" && (
-          <>
-            <Cell k="원화 · 현금" v={formatKrw(a.cashBalances.krw ?? null)} />
-            <Cell k="원화 · 매수 가능" v={formatKrw(a.buyingPower.krw ?? null)} />
-          </>
-        )}
-        {isManual && (
-          <>
-            <Cell k="원화 · 현금" v={a.cashBalances.krw != null ? formatKrw(a.cashBalances.krw) : "-"} />
-            <Cell k="원화 · 매수 가능" v={a.buyingPower.krw != null ? formatKrw(a.buyingPower.krw) : "-"} />
-          </>
-        )}
+          )}
+        </>
       </div>
     </div>
   );

--- a/frontend/invest/src/components/AccountSelector.tsx
+++ b/frontend/invest/src/components/AccountSelector.tsx
@@ -1,13 +1,25 @@
 import type { AccountSource } from "../types/invest";
+import { accountSourceMeta } from "../desktop/AccountSourceMeta";
 
 export type AccountKey = AccountSource | "all";
 
-const LABELS: Partial<Record<AccountKey, string>> = {
-  all: "전체",
-  kis: "KIS 실계좌",
-  upbit: "Upbit",
-  toss_manual: "Toss 수동",
-};
+function labelFor(key: AccountKey): string {
+  if (key === "all") return "전체";
+  return accountSourceMeta(key).label;
+}
+
+const OPTIONS: AccountKey[] = [
+  "all",
+  "kis",
+  "upbit",
+  "toss_manual",
+  "pension_manual",
+  "isa_manual",
+  "kis_mock",
+  "kiwoom_mock",
+  "alpaca_paper",
+  "db_simulated",
+];
 
 export function AccountSelector({
   active,
@@ -16,7 +28,7 @@ export function AccountSelector({
   active: AccountKey;
   onChange: (s: AccountKey) => void;
 }) {
-  const options: AccountKey[] = ["all", "kis", "upbit", "toss_manual"];
+  const options = OPTIONS;
 
   return (
     <div
@@ -53,7 +65,7 @@ export function AccountSelector({
               transition: "all 0.2s",
             }}
           >
-            {LABELS[s] || s}
+            {labelFor(s)}
           </button>
         );
       })}

--- a/frontend/invest/src/components/home/HoldingsTable.tsx
+++ b/frontend/invest/src/components/home/HoldingsTable.tsx
@@ -1,6 +1,6 @@
 import type { GroupedHolding } from "../../types/invest";
 import { Pill } from "../../ds";
-import { pillToneForSource } from "../../desktop/AccountSourceTone";
+import { accountSourceMeta, quoteFreshnessLabel } from "../../desktop/AccountSourceMeta";
 import type { AssetCategoryKey } from "../AssetCategoryFilter";
 
 const COLS = "minmax(0,1.8fr) 100px 120px 140px 100px";
@@ -68,7 +68,10 @@ export function HoldingsTable({
           const dir = (h.pnlRate ?? 0) >= 0 ? "up" : "down";
           const color = dir === "up" ? "var(--gain)" : "var(--loss)";
           const arrow = dir === "up" ? "▲" : "▼";
-          const tone = h.includedSources[0] ? pillToneForSource(h.includedSources[0]) : "paper";
+          const sourceMeta = h.includedSources[0] ? accountSourceMeta(h.includedSources[0]) : null;
+          const tone = sourceMeta?.tone ?? "paper";
+          const sourceLabel = sourceMeta?.shortLabel ?? "계좌";
+          const freshness = quoteFreshnessLabel(h.priceState);
           const value = h.valueNative ?? h.valueKrw;
           return (
             <div
@@ -120,8 +123,9 @@ export function HoldingsTable({
                     <span style={{ fontSize: 11, color: "var(--fg-3)", fontFamily: "var(--font-mono)" }}>{h.symbol}</span>
                     <span aria-hidden style={{ width: 2, height: 2, background: "var(--fg-4)", borderRadius: 999 }} />
                     <Pill tone={tone} size="sm">
-                      {tone.toUpperCase()}
+                      {sourceLabel}
                     </Pill>
+                    <span style={{ fontSize: 11, color: "var(--fg-3)" }}>{freshness}</span>
                   </div>
                 </div>
               </div>

--- a/frontend/invest/src/desktop/AccountSourceMeta.ts
+++ b/frontend/invest/src/desktop/AccountSourceMeta.ts
@@ -1,0 +1,101 @@
+import type { Account, AccountSource, PriceState } from "../types/invest";
+import type { PillTone } from "../ds";
+import { pillToneForSource } from "./AccountSourceTone";
+
+export interface AccountSourceMeta {
+  label: string;
+  shortLabel: string;
+  badge: string;
+  kindLabel: string;
+  tone: PillTone;
+}
+
+const SOURCE_META: Record<AccountSource, AccountSourceMeta> = {
+  kis: {
+    label: "KIS 실계좌",
+    shortLabel: "KIS",
+    badge: "Live",
+    kindLabel: "실계좌",
+    tone: "kis",
+  },
+  upbit: {
+    label: "Upbit",
+    shortLabel: "Upbit",
+    badge: "Crypto",
+    kindLabel: "코인",
+    tone: "upbit",
+  },
+  toss_manual: {
+    label: "Toss 수동",
+    shortLabel: "Toss",
+    badge: "Manual",
+    kindLabel: "수동",
+    tone: "toss",
+  },
+  pension_manual: {
+    label: "연금 수동",
+    shortLabel: "연금",
+    badge: "Manual",
+    kindLabel: "수동",
+    tone: "pension",
+  },
+  isa_manual: {
+    label: "ISA 수동",
+    shortLabel: "ISA",
+    badge: "Manual",
+    kindLabel: "수동",
+    tone: "isa",
+  },
+  kis_mock: {
+    label: "KIS 모의",
+    shortLabel: "KIS 모의",
+    badge: "Mock",
+    kindLabel: "모의",
+    tone: "paper",
+  },
+  kiwoom_mock: {
+    label: "Kiwoom 모의",
+    shortLabel: "Kiwoom 모의",
+    badge: "Mock",
+    kindLabel: "모의",
+    tone: "paper",
+  },
+  alpaca_paper: {
+    label: "Alpaca Paper",
+    shortLabel: "Alpaca Paper",
+    badge: "Paper",
+    kindLabel: "Paper",
+    tone: "paper",
+  },
+  db_simulated: {
+    label: "DB Paper",
+    shortLabel: "DB Paper",
+    badge: "Paper",
+    kindLabel: "Paper",
+    tone: "paper",
+  },
+};
+
+export function accountSourceMeta(source: AccountSource): AccountSourceMeta {
+  return SOURCE_META[source] ?? {
+    label: source,
+    shortLabel: source,
+    badge: "Account",
+    kindLabel: "계좌",
+    tone: pillToneForSource(source),
+  };
+}
+
+export function displayNameWithSource(account: Pick<Account, "displayName" | "source">): string {
+  const meta = accountSourceMeta(account.source);
+  const name = account.displayName.trim();
+  if (!name) return meta.label;
+  if (name.includes(meta.label) || name.includes(meta.shortLabel) || name.includes(meta.kindLabel)) return name;
+  return `${name} · ${meta.label}`;
+}
+
+export function quoteFreshnessLabel(state: PriceState): string {
+  if (state === "live") return "브로커/실시간";
+  if (state === "stale") return "시세 지연";
+  return "시세 없음";
+}

--- a/frontend/invest/src/desktop/AccountSourceTone.ts
+++ b/frontend/invest/src/desktop/AccountSourceTone.ts
@@ -31,7 +31,7 @@ export function visualBySource(
 
 const SOURCE_TO_PILL: Record<AccountSource, PillTone> = {
   kis: "kis",
-  kis_mock: "kis",
+  kis_mock: "paper",
   upbit: "upbit",
   toss_manual: "toss",
   isa_manual: "isa",

--- a/frontend/invest/src/desktop/LeftContextRail.tsx
+++ b/frontend/invest/src/desktop/LeftContextRail.tsx
@@ -1,16 +1,17 @@
 import type { Account } from "../types/invest";
-import { pillToneForSource } from "./AccountSourceTone";
+import { accountSourceMeta, displayNameWithSource } from "./AccountSourceMeta";
 import type { AssetCategoryKey } from "../components/AssetCategoryFilter";
 
 interface ItemProps {
   label: string;
   toneDot?: string;
+  badge?: string;
   value?: string;
   active?: boolean;
   onClick?: () => void;
 }
 
-function Item({ label, toneDot, value, active, onClick }: ItemProps) {
+function Item({ label, toneDot, badge, value, active, onClick }: ItemProps) {
   return (
     <button
       onClick={onClick}
@@ -41,6 +42,9 @@ function Item({ label, toneDot, value, active, onClick }: ItemProps) {
         <span aria-hidden style={{ width: 6, height: 6, borderRadius: 2, background: "var(--fg-2)", flexShrink: 0 }} />
       )}
       <span style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}>{label}</span>
+      {badge != null && (
+        <span style={{ fontSize: 10, color: "var(--fg-3)", fontWeight: 700, flexShrink: 0 }}>{badge}</span>
+      )}
       {value != null && (
         <span style={{ fontSize: 11, color: "var(--fg-3)", fontFeatureSettings: '"tnum"', fontWeight: 500 }}>{value}</span>
       )}
@@ -104,12 +108,13 @@ export function LeftContextRail({
             onClick={() => onAccount("all")}
           />
           {accounts.map((a) => {
-            const tone = pillToneForSource(a.source);
+            const meta = accountSourceMeta(a.source);
             return (
               <Item
                 key={a.accountId}
-                label={a.displayName}
-                toneDot={`var(--pill-${tone}-fg)`}
+                label={displayNameWithSource(a)}
+                badge={meta.badge}
+                toneDot={`var(--pill-${meta.tone}-fg)`}
                 value={fmtMillion(a.valueKrw)}
                 active={account === a.source}
                 onClick={() => onAccount(a.source)}

--- a/frontend/invest/src/desktop/RightAccountPanel.tsx
+++ b/frontend/invest/src/desktop/RightAccountPanel.tsx
@@ -1,5 +1,6 @@
 import type { AccountPanelResponse, WatchSymbol } from "../types/invest";
 import { Button, Card, Icon, PL, Pill } from "../ds";
+import { displayNameWithSource } from "./AccountSourceMeta";
 import { pillToneForSource, visualBySource } from "./AccountSourceTone";
 
 function fmtKrw(v?: number | null): string {
@@ -126,7 +127,7 @@ export function RightAccountPanel({
                       color: "var(--fg-1)",
                     }}
                   >
-                    {a.displayName}
+                    {displayNameWithSource(a)}
                   </span>
                   <Pill tone={tone} size="sm">
                     {visual?.badge ?? tone.toUpperCase()}

--- a/frontend/invest/src/desktop/RightRemotePanel.tsx
+++ b/frontend/invest/src/desktop/RightRemotePanel.tsx
@@ -8,6 +8,7 @@ import type { PillTone } from "../ds";
 import { fetchSignals } from "../api/signals";
 import type { SignalCard } from "../types/signals";
 import { buildScopedPortfolioPanel, type AccountFilterKey } from "./scopeHoldings";
+import { accountSourceMeta } from "./AccountSourceMeta";
 import type { GroupedHolding, WatchSymbol } from "../types/invest";
 import { formatRelativeTime } from "../format/relativeTime";
 
@@ -215,6 +216,12 @@ function PortfolioPanel({ onNavigate }: Readonly<{ onNavigate: NavigateToSymbol 
   };
 
   const sectionLabel = `${scoped.selected.label} 보유종목`;
+  const selectedSourceMeta = scoped.selected.source ? accountSourceMeta(scoped.selected.source) : null;
+  const emptyText = selectedKey === "all"
+    ? "보유 종목이 없습니다."
+    : selectedSourceMeta?.tone === "paper"
+      ? `${scoped.selected.label} 계좌는 표시할 모의/Paper 보유종목이 없습니다.`
+      : "선택한 계좌에 표시할 보유종목이 없습니다.";
   const hasCash = scoped.cashBalances.krw != null || scoped.cashBalances.usd != null;
 
   return (
@@ -309,7 +316,7 @@ function PortfolioPanel({ onNavigate }: Readonly<{ onNavigate: NavigateToSymbol 
         </div>
         {sorted.length === 0 ? (
           <div data-testid="holdings-empty" style={{ fontSize: 12, color: "var(--fg-3)", padding: "8px 0" }}>
-            {selectedKey === "all" ? "보유 종목이 없습니다." : "선택한 계좌에 표시할 보유종목이 없습니다."}
+            {emptyText}
           </div>
         ) : (
           <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column" }}>

--- a/frontend/invest/src/desktop/scopeHoldings.ts
+++ b/frontend/invest/src/desktop/scopeHoldings.ts
@@ -109,7 +109,7 @@ function sourceLabel(response: AccountPanelResponse, source: AccountSource): str
   const meta = accountSourceMeta(source);
   const account = response.accounts.find((a) => a.source === source);
   if (account?.displayName && (source === "alpaca_paper" || source === "db_simulated" || source === "kiwoom_mock")) {
-    if (account.displayName.includes(meta.label) || account.displayName.includes(meta.shortLabel)) return account.displayName;
+    if (account.displayName === meta.label || account.displayName === meta.shortLabel) return account.displayName;
   }
   return meta.label;
 }

--- a/frontend/invest/src/desktop/scopeHoldings.ts
+++ b/frontend/invest/src/desktop/scopeHoldings.ts
@@ -1,4 +1,5 @@
 import type { AccountPanelResponse, AccountSource, CashAmounts, GroupedHolding } from "../types/invest";
+import { accountSourceMeta } from "./AccountSourceMeta";
 
 export type AccountFilterKey = "all" | AccountSource;
 
@@ -24,18 +25,6 @@ export interface ScopedPortfolioPanel {
   pnlRate: number | null;
   cashBalances: CashAmounts;
 }
-
-const SOURCE_LABELS: Partial<Record<AccountSource, string>> = {
-  kis: "KIS",
-  upbit: "Upbit",
-  toss_manual: "Toss/manual",
-  pension_manual: "연금/manual",
-  isa_manual: "ISA/manual",
-  kis_mock: "KIS Mock",
-  kiwoom_mock: "Kiwoom Mock",
-  alpaca_paper: "Alpaca Paper",
-  db_simulated: "DB simulated",
-};
 
 // When the user filters the home view to a single source/account, the grouped
 // rows must be reduced to that source's slice so the table totals match the
@@ -117,12 +106,12 @@ export function scopeGroupedToSource(
 }
 
 function sourceLabel(response: AccountPanelResponse, source: AccountSource): string {
-  if (SOURCE_LABELS[source]) return SOURCE_LABELS[source]!;
-  const visual = response.sourceVisuals.find((v) => v.source === source);
-  if (visual?.displayName) return visual.displayName;
+  const meta = accountSourceMeta(source);
   const account = response.accounts.find((a) => a.source === source);
-  if (account?.displayName) return account.displayName;
-  return source;
+  if (account?.displayName && (source === "alpaca_paper" || source === "db_simulated" || source === "kiwoom_mock")) {
+    if (account.displayName.includes(meta.label) || account.displayName.includes(meta.shortLabel)) return account.displayName;
+  }
+  return meta.label;
 }
 
 function sumCash(accounts: AccountPanelResponse["accounts"]): CashAmounts {
@@ -180,7 +169,7 @@ function optionFor(response: AccountPanelResponse, key: AccountFilterKey): Accou
     return {
       key: "all",
       label: "전체",
-      cashBalances: sumCash(response.accounts),
+      cashBalances: sumCash(response.accounts.filter((account) => account.includedInHome)),
       totalValueKrw: response.homeSummary.totalValueKrw,
       costBasisKrw: response.homeSummary.costBasisKrw ?? null,
       pnlKrw: response.homeSummary.pnlKrw ?? null,

--- a/frontend/invest/src/pages/mobile/MobileHomePage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileHomePage.tsx
@@ -186,7 +186,7 @@ export function MobileHomePage() {
           {data.accounts.length > 0 && (
             <section style={{ padding: "0 16px" }} data-testid="mobile-account-row">
               <div style={{ display: "flex", gap: 6, overflowX: "auto", paddingBottom: 4 }}>
-                <PillButton on={account === "all"} onClick={() => setAccount("all")}>
+                <PillButton on={account === "all"} onClick={() => setAccount("all")} tone="accent">
                   전체
                 </PillButton>
                 {data.accounts.map((a) => {
@@ -311,7 +311,7 @@ export function MobileHomePage() {
   );
 }
 
-function PillButton({ on, onClick, children, tone = "paper" }: { on: boolean; onClick: () => void; children: React.ReactNode; tone?: PillTone }) {
+function PillButton({ on, onClick, children, tone = "paper" }: Readonly<{ on: boolean; onClick: () => void; children: React.ReactNode; tone?: PillTone }>) {
   return (
     <button
       type="button"

--- a/frontend/invest/src/pages/mobile/MobileHomePage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileHomePage.tsx
@@ -6,7 +6,9 @@ import { MobileShell } from "../../mobile/MobileShell";
 import { useInvestHome } from "../../hooks/useInvestHome";
 import { useAccountPanel } from "../../desktop/useAccountPanel";
 import { scopeGroupedToSource } from "../../desktop/scopeHoldings";
+import { accountSourceMeta, displayNameWithSource } from "../../desktop/AccountSourceMeta";
 import { PL } from "../../ds";
+import type { PillTone } from "../../ds";
 import { Icon } from "../../ds";
 import type { AccountSource, HomeSummary } from "../../types/invest";
 
@@ -187,15 +189,20 @@ export function MobileHomePage() {
                 <PillButton on={account === "all"} onClick={() => setAccount("all")}>
                   전체
                 </PillButton>
-                {data.accounts.map((a) => (
-                  <PillButton
-                    key={a.accountId}
-                    on={account === a.source}
-                    onClick={() => setAccount(a.source)}
-                  >
-                    {a.displayName}
-                  </PillButton>
-                ))}
+                {data.accounts.map((a) => {
+                  const meta = accountSourceMeta(a.source);
+                  return (
+                    <PillButton
+                      key={a.accountId}
+                      on={account === a.source}
+                      onClick={() => setAccount(a.source)}
+                      tone={meta.tone}
+                    >
+                      <span>{displayNameWithSource(a)}</span>
+                      <span style={{ opacity: 0.72, marginLeft: 4 }}>{meta.badge}</span>
+                    </PillButton>
+                  );
+                })}
               </div>
             </section>
           )}
@@ -304,7 +311,7 @@ export function MobileHomePage() {
   );
 }
 
-function PillButton({ on, onClick, children }: { on: boolean; onClick: () => void; children: React.ReactNode }) {
+function PillButton({ on, onClick, children, tone = "paper" }: { on: boolean; onClick: () => void; children: React.ReactNode; tone?: PillTone }) {
   return (
     <button
       type="button"
@@ -314,8 +321,8 @@ function PillButton({ on, onClick, children }: { on: boolean; onClick: () => voi
         padding: "6px 12px",
         borderRadius: 999,
         border: "none",
-        background: on ? "var(--fg)" : "var(--surface-2)",
-        color: on ? "var(--bg)" : "var(--fg-2)",
+        background: on ? `var(--pill-${tone}-fg)` : `var(--pill-${tone}-bg)`,
+        color: on ? "var(--bg)" : `var(--pill-${tone}-fg)`,
         fontSize: 12,
         fontWeight: 600,
         whiteSpace: "nowrap",

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -472,3 +472,247 @@ async def test_manual_reader_does_not_fabricate_value_from_cost_basis(
     assert result.holdings[0].assetCategory == "kr_stock"
     assert result.holdings[0].priceState == "missing"
     assert result.warning is not None
+
+
+# ---------------------------------------------------------------------------
+# ROB-238: KISMockHomeReader tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeKISMockAccount:
+    async def fetch_my_stocks(
+        self, *, is_mock: bool, is_overseas: bool
+    ) -> list[dict[str, Any]]:
+        assert is_mock is True
+        assert is_overseas is False
+        return [
+            {
+                "pdno": "005935",
+                "prdt_name": "삼성전자우",
+                "hldg_qty": "5",
+                "pchs_avg_pric": "60000",
+                "pchs_amt": "300000",
+                "evlu_amt": "310000",
+                "evlu_pfls_amt": "10000",
+                "evlu_pfls_rt": "3.3333",
+            }
+        ]
+
+
+class _FakeKISMockClient:
+    def __init__(self) -> None:
+        self.account = _FakeKISMockAccount()
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kis_mock_reader_passes_is_mock_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(readers, "SafeKISMockClient", _FakeKISMockClient)
+    monkeypatch.setattr(readers, "_kis_mock_configured", lambda: True)
+
+    result = await readers.KISMockHomeReader().fetch(user_id=1)
+
+    account = result.accounts[0]
+    assert account.source == "kis_mock"
+    assert account.accountKind == "paper"
+    assert account.includedInHome is False
+    assert account.accountId == "kis_mock_account"
+    assert account.valueKrw == 310_000
+
+    h = result.holdings[0]
+    assert h.source == "kis_mock"
+    assert h.accountKind == "paper"
+    assert h.symbol == "005935"
+    assert h.assetCategory == "kr_stock"
+    assert h.currency == "KRW"
+    assert h.valueKrw == 310_000
+    assert h.costBasis == 300_000
+    assert h.pnlKrw == 10_000
+    assert h.pnlRate == pytest.approx(3.3333 / 100.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kis_mock_reader_returns_warning_when_not_configured() -> None:
+    result = await readers.KISMockHomeReader().fetch(user_id=1)
+
+    assert result.accounts == []
+    assert result.holdings == []
+    assert result.warning is not None
+    assert result.warning.source == "kis_mock"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kis_mock_reader_partial_failure_returns_warning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _BrokenKISMockClient:
+        def __init__(self) -> None:
+            self.account = None
+
+        async def fetch_my_stocks(self, **kwargs: Any) -> list[dict[str, Any]]:
+            raise RuntimeError("mock API down")
+
+    class _BrokenAccount:
+        async def fetch_my_stocks(self, **kwargs: Any) -> list[dict[str, Any]]:
+            raise RuntimeError("mock API down")
+
+    class _BrokenClient:
+        def __init__(self) -> None:
+            self.account = _BrokenAccount()
+
+    monkeypatch.setattr(readers, "SafeKISMockClient", _BrokenClient)
+    monkeypatch.setattr(readers, "_kis_mock_configured", lambda: True)
+
+    result = await readers.KISMockHomeReader().fetch(user_id=1)
+
+    assert result.accounts == []
+    assert result.holdings == []
+    assert result.warning is not None
+    assert result.warning.source == "kis_mock"
+
+
+# ---------------------------------------------------------------------------
+# ROB-238: AlpacaPaperHomeReader tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_alpaca_paper_reader_maps_positions_and_converts_usd(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from decimal import Decimal
+
+    from app.services.brokers.alpaca.schemas import AccountSnapshot, Position
+
+    fake_account = AccountSnapshot(
+        id="alpaca-test",
+        buying_power=Decimal("1000"),
+        cash=Decimal("500"),
+        portfolio_value=Decimal("5500"),
+        status="ACTIVE",
+    )
+    fake_positions = [
+        Position(
+            asset_id="aapl-id",
+            symbol="AAPL",
+            qty=Decimal("2"),
+            avg_entry_price=Decimal("100"),
+            current_price=Decimal("110"),
+            market_value=Decimal("220"),
+            unrealized_pl=Decimal("20"),
+            side="long",
+        )
+    ]
+
+    class _FakeAlpacaSvc:
+        async def get_account(self) -> AccountSnapshot:
+            return fake_account
+
+        async def list_positions(self) -> list[Position]:
+            return fake_positions
+
+    monkeypatch.setattr(
+        readers.AlpacaPaperHomeReader, "_make_service", staticmethod(lambda: _FakeAlpacaSvc())
+    )
+
+    async def _fx() -> float:
+        return 1_300.0
+
+    monkeypatch.setattr(readers, "get_usd_krw_rate", _fx)
+
+    result = await readers.AlpacaPaperHomeReader().fetch(user_id=1)
+
+    account = result.accounts[0]
+    assert account.source == "alpaca_paper"
+    assert account.accountKind == "paper"
+    assert account.includedInHome is False
+    assert account.accountId == "alpaca_paper_account"
+    assert account.cashBalances.usd == pytest.approx(500.0)
+    assert account.buyingPower.usd == pytest.approx(1000.0)
+    assert account.valueKrw == pytest.approx(220 * 1_300.0)
+
+    h = result.holdings[0]
+    assert h.source == "alpaca_paper"
+    assert h.accountKind == "paper"
+    assert h.symbol == "AAPL"
+    assert h.market == "US"
+    assert h.currency == "USD"
+    assert h.assetCategory == "us_stock"
+    assert h.valueNative == pytest.approx(220.0)
+    assert h.valueKrw == pytest.approx(220 * 1_300.0)
+    assert h.pnlKrw == pytest.approx(20 * 1_300.0)
+    assert h.pnlRate == pytest.approx(20 / 200)
+    assert h.priceState == "live"
+    assert result.warning is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_alpaca_paper_reader_not_configured_returns_warning() -> None:
+    from app.services.brokers.alpaca.exceptions import AlpacaPaperConfigurationError
+
+    class _Reader(readers.AlpacaPaperHomeReader):
+        @staticmethod
+        def _make_service() -> Any:
+            raise AlpacaPaperConfigurationError("no creds")
+
+    result = await _Reader().fetch(user_id=1)
+
+    assert result.accounts == []
+    assert result.holdings == []
+    assert result.warning is not None
+    assert result.warning.source == "alpaca_paper"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_alpaca_paper_reader_mutation_methods_not_called(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that submit_order and cancel_order are never called during fetch."""
+    from decimal import Decimal
+
+    from app.services.brokers.alpaca.schemas import AccountSnapshot
+
+    mutation_called: list[str] = []
+
+    class _SafeFakeAlpacaSvc:
+        async def get_account(self) -> AccountSnapshot:
+            return AccountSnapshot(
+                id="safe-test",
+                buying_power=Decimal("0"),
+                cash=Decimal("0"),
+                portfolio_value=Decimal("0"),
+                status="ACTIVE",
+            )
+
+        async def list_positions(self) -> list[Any]:
+            return []
+
+        async def submit_order(self, *args: Any, **kwargs: Any) -> Any:
+            mutation_called.append("submit_order")
+            raise AssertionError("submit_order must not be called from Invest Home")
+
+        async def cancel_order(self, *args: Any, **kwargs: Any) -> Any:
+            mutation_called.append("cancel_order")
+            raise AssertionError("cancel_order must not be called from Invest Home")
+
+    monkeypatch.setattr(
+        readers.AlpacaPaperHomeReader,
+        "_make_service",
+        staticmethod(lambda: _SafeFakeAlpacaSvc()),
+    )
+
+    async def _fx() -> float:
+        return 1_300.0
+
+    monkeypatch.setattr(readers, "get_usd_krw_rate", _fx)
+
+    await readers.AlpacaPaperHomeReader().fetch(user_id=1)
+
+    assert mutation_called == [], "Mutation methods were called during Invest Home fetch"

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -498,6 +498,14 @@ class _FakeKISMockAccount:
             }
         ]
 
+    async def inquire_domestic_cash_balance(self, is_mock: bool = False) -> dict[str, Any]:
+        assert is_mock is True
+        return {
+            "dnca_tot_amt": 200_000.0,
+            "stck_cash_ord_psbl_amt": 180_000.0,
+            "raw": {},
+        }
+
 
 class _FakeKISMockClient:
     def __init__(self) -> None:
@@ -520,6 +528,10 @@ async def test_kis_mock_reader_passes_is_mock_true(
     assert account.includedInHome is False
     assert account.accountId == "kis_mock_account"
     assert account.valueKrw == 310_000
+    assert account.cashBalances.krw == pytest.approx(200_000.0)
+    assert account.buyingPower.krw == pytest.approx(180_000.0)
+    # Cash must NOT be included in investment value
+    assert account.valueKrw != account.cashBalances.krw
 
     h = result.holdings[0]
     assert h.source == "kis_mock"
@@ -571,6 +583,85 @@ async def test_kis_mock_reader_partial_failure_returns_warning(
 
     assert result.accounts == []
     assert result.holdings == []
+    assert result.warning is not None
+    assert result.warning.source == "kis_mock"
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kis_mock_reader_cash_balance_called_with_is_mock_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """inquire_domestic_cash_balance must be called with is_mock=True."""
+    cash_balance_calls: list[bool] = []
+
+    class _TrackingAccount:
+        async def fetch_my_stocks(
+            self, *, is_mock: bool, is_overseas: bool
+        ) -> list[dict[str, Any]]:
+            return []
+
+        async def inquire_domestic_cash_balance(self, is_mock: bool = False) -> dict[str, Any]:
+            cash_balance_calls.append(is_mock)
+            return {"dnca_tot_amt": 50_000.0, "stck_cash_ord_psbl_amt": 40_000.0, "raw": {}}
+
+    class _TrackingClient:
+        def __init__(self) -> None:
+            self.account = _TrackingAccount()
+
+    monkeypatch.setattr(readers, "SafeKISMockClient", _TrackingClient)
+    monkeypatch.setattr(readers, "_kis_mock_configured", lambda: True)
+
+    result = await readers.KISMockHomeReader().fetch(user_id=1)
+
+    assert cash_balance_calls == [True], "inquire_domestic_cash_balance was not called with is_mock=True"
+    account = result.accounts[0]
+    assert account.cashBalances.krw == pytest.approx(50_000.0)
+    assert account.buyingPower.krw == pytest.approx(40_000.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_kis_mock_reader_cash_failure_is_non_fatal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cash balance fetch failure must not block holdings/account — produces a warning."""
+
+    class _CashFailAccount:
+        async def fetch_my_stocks(
+            self, *, is_mock: bool, is_overseas: bool
+        ) -> list[dict[str, Any]]:
+            return [
+                {
+                    "pdno": "005930",
+                    "prdt_name": "삼성전자",
+                    "hldg_qty": "1",
+                    "pchs_avg_pric": "70000",
+                    "pchs_amt": "70000",
+                    "evlu_amt": "72000",
+                    "evlu_pfls_amt": "2000",
+                    "evlu_pfls_rt": "2.857",
+                }
+            ]
+
+        async def inquire_domestic_cash_balance(self, is_mock: bool = False) -> dict[str, Any]:
+            raise RuntimeError("cash API unavailable")
+
+    class _CashFailClient:
+        def __init__(self) -> None:
+            self.account = _CashFailAccount()
+
+    monkeypatch.setattr(readers, "SafeKISMockClient", _CashFailClient)
+    monkeypatch.setattr(readers, "_kis_mock_configured", lambda: True)
+
+    result = await readers.KISMockHomeReader().fetch(user_id=1)
+
+    assert len(result.accounts) == 1
+    assert len(result.holdings) == 1
+    account = result.accounts[0]
+    assert account.cashBalances.krw is None
+    assert account.buyingPower.krw is None
+    # Warning emitted but result is not empty
     assert result.warning is not None
     assert result.warning.source == "kis_mock"
 

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -549,6 +549,54 @@ async def test_kis_mock_reader_passes_is_mock_true(
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_kis_mock_reader_reports_zero_cost_basis_gain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Zero recorded cost basis should not hide an otherwise valued mock position."""
+
+    class _ZeroCostAccount:
+        async def fetch_my_stocks(
+            self, *, is_mock: bool, is_overseas: bool
+        ) -> list[dict[str, Any]]:
+            assert is_mock is True
+            assert is_overseas is False
+            return [
+                {
+                    "pdno": "000000",
+                    "prdt_name": "무상입고",
+                    "hldg_qty": "1",
+                    "pchs_avg_pric": "0",
+                    "pchs_amt": "0",
+                    "evlu_amt": "12345",
+                    "evlu_pfls_amt": "12345",
+                    "evlu_pfls_rt": "0",
+                }
+            ]
+
+        async def inquire_domestic_cash_balance(
+            self, is_mock: bool = False
+        ) -> dict[str, Any]:
+            assert is_mock is True
+            return {"dnca_tot_amt": 0, "stck_cash_ord_psbl_amt": 0, "raw": {}}
+
+    class _ZeroCostClient:
+        def __init__(self) -> None:
+            self.account = _ZeroCostAccount()
+
+    monkeypatch.setattr(readers, "SafeKISMockClient", _ZeroCostClient)
+    monkeypatch.setattr(readers, "_kis_mock_configured", lambda: True)
+
+    result = await readers.KISMockHomeReader().fetch(user_id=1)
+
+    account = result.accounts[0]
+    assert account.valueKrw == pytest.approx(12_345.0)
+    assert account.costBasisKrw is None
+    assert account.pnlKrw == pytest.approx(12_345.0)
+    assert account.pnlRate is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_kis_mock_reader_returns_warning_when_not_configured() -> None:
     result = await readers.KISMockHomeReader().fetch(user_id=1)
 
@@ -740,6 +788,9 @@ async def test_alpaca_paper_reader_maps_positions_and_converts_usd(
     assert account.cashBalances.usd == pytest.approx(500.0)
     assert account.buyingPower.usd == pytest.approx(1000.0)
     assert account.valueKrw == pytest.approx(220 * 1_300.0)
+    assert account.costBasisKrw == pytest.approx(200 * 1_300.0)
+    assert account.pnlKrw == pytest.approx(20 * 1_300.0)
+    assert account.pnlRate == pytest.approx(20 / 200)
 
     h = result.holdings[0]
     assert h.source == "alpaca_paper"

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -597,6 +597,50 @@ async def test_kis_mock_reader_reports_zero_cost_basis_gain(
 
 @pytest.mark.asyncio
 @pytest.mark.unit
+async def test_kis_mock_reader_ignores_unparseable_cash_amounts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bad mock cash strings should not poison holdings or account valuation."""
+
+    class _BadCashAccount:
+        async def fetch_my_stocks(
+            self, *, is_mock: bool, is_overseas: bool
+        ) -> list[dict[str, Any]]:
+            assert is_mock is True
+            assert is_overseas is False
+            return []
+
+        async def inquire_domestic_cash_balance(
+            self, is_mock: bool = False
+        ) -> dict[str, Any]:
+            assert is_mock is True
+            return {
+                "dnca_tot_amt": "not-a-number",
+                "stck_cash_ord_psbl_amt": "also-bad",
+                "raw": {},
+            }
+
+    class _BadCashClient:
+        def __init__(self) -> None:
+            self.account = _BadCashAccount()
+
+    monkeypatch.setattr(readers, "SafeKISMockClient", _BadCashClient)
+    monkeypatch.setattr(readers, "_kis_mock_configured", lambda: True)
+
+    result = await readers.KISMockHomeReader().fetch(user_id=1)
+
+    account = result.accounts[0]
+    assert account.valueKrw == 0
+    assert account.costBasisKrw is None
+    assert account.pnlKrw is None
+    assert account.pnlRate is None
+    assert account.cashBalances.krw is None
+    assert account.buyingPower.krw is None
+    assert result.warning is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
 async def test_kis_mock_reader_returns_warning_when_not_configured() -> None:
     result = await readers.KISMockHomeReader().fetch(user_id=1)
 
@@ -805,6 +849,79 @@ async def test_alpaca_paper_reader_maps_positions_and_converts_usd(
     assert h.pnlRate == pytest.approx(20 / 200)
     assert h.priceState == "live"
     assert result.warning is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_alpaca_paper_reader_keeps_account_pnl_unknown_when_basis_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from decimal import Decimal
+
+    from app.services.brokers.alpaca.schemas import AccountSnapshot, Position
+
+    class _MissingBasisSvc:
+        async def get_account(self) -> AccountSnapshot:
+            return AccountSnapshot(
+                id="alpaca-missing-basis",
+                buying_power=Decimal("100"),
+                cash=Decimal("50"),
+                portfolio_value=Decimal("100"),
+                status="ACTIVE",
+            )
+
+        async def list_positions(self) -> list[Position]:
+            return [
+                Position(
+                    asset_id="free-share",
+                    symbol="FREE",
+                    qty=Decimal("1"),
+                    avg_entry_price=Decimal("0"),
+                    current_price=Decimal("50"),
+                    market_value=Decimal("50"),
+                    unrealized_pl=Decimal("50"),
+                    side="long",
+                ),
+                Position(
+                    asset_id="missing-price",
+                    symbol="MISS",
+                    qty=Decimal("1"),
+                    avg_entry_price=Decimal("10"),
+                    current_price=None,
+                    market_value=None,
+                    unrealized_pl=None,
+                    side="long",
+                ),
+            ]
+
+    monkeypatch.setattr(
+        readers.AlpacaPaperHomeReader,
+        "_make_service",
+        staticmethod(lambda: _MissingBasisSvc()),
+    )
+
+    async def _fx() -> float:
+        return 1_300.0
+
+    monkeypatch.setattr(readers, "get_usd_krw_rate", _fx)
+
+    result = await readers.AlpacaPaperHomeReader().fetch(user_id=1)
+
+    account = result.accounts[0]
+    assert account.valueKrw == pytest.approx(50 * 1_300.0)
+    assert account.costBasisKrw is None
+    assert account.pnlKrw is None
+    assert account.pnlRate is None
+
+    free = next(h for h in result.holdings if h.symbol == "FREE")
+    assert free.valueKrw == pytest.approx(50 * 1_300.0)
+    assert free.costBasis is None
+    assert free.priceState == "live"
+
+    missing = next(h for h in result.holdings if h.symbol == "MISS")
+    assert missing.valueKrw is None
+    assert missing.pnlKrw is None
+    assert missing.priceState == "missing"
 
 
 @pytest.mark.asyncio

--- a/tests/test_invest_home_readers.py
+++ b/tests/test_invest_home_readers.py
@@ -498,7 +498,9 @@ class _FakeKISMockAccount:
             }
         ]
 
-    async def inquire_domestic_cash_balance(self, is_mock: bool = False) -> dict[str, Any]:
+    async def inquire_domestic_cash_balance(
+        self, is_mock: bool = False
+    ) -> dict[str, Any]:
         assert is_mock is True
         return {
             "dnca_tot_amt": 200_000.0,
@@ -601,9 +603,15 @@ async def test_kis_mock_reader_cash_balance_called_with_is_mock_true(
         ) -> list[dict[str, Any]]:
             return []
 
-        async def inquire_domestic_cash_balance(self, is_mock: bool = False) -> dict[str, Any]:
+        async def inquire_domestic_cash_balance(
+            self, is_mock: bool = False
+        ) -> dict[str, Any]:
             cash_balance_calls.append(is_mock)
-            return {"dnca_tot_amt": 50_000.0, "stck_cash_ord_psbl_amt": 40_000.0, "raw": {}}
+            return {
+                "dnca_tot_amt": 50_000.0,
+                "stck_cash_ord_psbl_amt": 40_000.0,
+                "raw": {},
+            }
 
     class _TrackingClient:
         def __init__(self) -> None:
@@ -614,7 +622,9 @@ async def test_kis_mock_reader_cash_balance_called_with_is_mock_true(
 
     result = await readers.KISMockHomeReader().fetch(user_id=1)
 
-    assert cash_balance_calls == [True], "inquire_domestic_cash_balance was not called with is_mock=True"
+    assert cash_balance_calls == [True], (
+        "inquire_domestic_cash_balance was not called with is_mock=True"
+    )
     account = result.accounts[0]
     assert account.cashBalances.krw == pytest.approx(50_000.0)
     assert account.buyingPower.krw == pytest.approx(40_000.0)
@@ -644,7 +654,9 @@ async def test_kis_mock_reader_cash_failure_is_non_fatal(
                 }
             ]
 
-        async def inquire_domestic_cash_balance(self, is_mock: bool = False) -> dict[str, Any]:
+        async def inquire_domestic_cash_balance(
+            self, is_mock: bool = False
+        ) -> dict[str, Any]:
             raise RuntimeError("cash API unavailable")
 
     class _CashFailClient:
@@ -708,7 +720,9 @@ async def test_alpaca_paper_reader_maps_positions_and_converts_usd(
             return fake_positions
 
     monkeypatch.setattr(
-        readers.AlpacaPaperHomeReader, "_make_service", staticmethod(lambda: _FakeAlpacaSvc())
+        readers.AlpacaPaperHomeReader,
+        "_make_service",
+        staticmethod(lambda: _FakeAlpacaSvc()),
     )
 
     async def _fx() -> float:
@@ -806,4 +820,6 @@ async def test_alpaca_paper_reader_mutation_methods_not_called(
 
     await readers.AlpacaPaperHomeReader().fetch(user_id=1)
 
-    assert mutation_called == [], "Mutation methods were called during Invest Home fetch"
+    assert mutation_called == [], (
+        "Mutation methods were called during Invest Home fetch"
+    )

--- a/tests/test_invest_home_service.py
+++ b/tests/test_invest_home_service.py
@@ -460,7 +460,9 @@ def test_home_summary_does_not_include_cash_balances_or_buying_power() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_paper_readers_appear_in_accounts_but_excluded_from_home_summary() -> None:
+async def test_paper_readers_appear_in_accounts_but_excluded_from_home_summary() -> (
+    None
+):
     from app.schemas.invest_home import Account, CashAmounts
     from app.services.invest_home_service import InvestHomeService, _SourceFetchResult
 

--- a/tests/test_invest_home_service.py
+++ b/tests/test_invest_home_service.py
@@ -451,3 +451,154 @@ def test_home_summary_does_not_include_cash_balances_or_buying_power() -> None:
     summary = build_home_summary(accounts)
     assert summary.totalValueKrw == 720_000
     assert summary.totalValueKrw != 720_000 + 100_000 + 50_000
+
+
+# ---------------------------------------------------------------------------
+# ROB-238: paper readers integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_paper_readers_appear_in_accounts_but_excluded_from_home_summary() -> None:
+    from app.schemas.invest_home import Account, CashAmounts
+    from app.services.invest_home_service import InvestHomeService, _SourceFetchResult
+
+    kis_reader = AsyncMock()
+    kis_reader.fetch.return_value = _SourceFetchResult(
+        accounts=[
+            Account(
+                accountId="kis_account",
+                displayName="KIS 실계좌",
+                source="kis",
+                accountKind="live",
+                includedInHome=True,
+                valueKrw=10_000_000,
+                cashBalances=CashAmounts(),
+                buyingPower=CashAmounts(),
+            )
+        ],
+        holdings=[],
+    )
+    upbit_reader = AsyncMock()
+    upbit_reader.fetch.return_value = _SourceFetchResult(accounts=[], holdings=[])
+    manual_reader = AsyncMock()
+    manual_reader.fetch.return_value = _SourceFetchResult(accounts=[], holdings=[])
+
+    mock_paper_reader = AsyncMock()
+    mock_paper_reader.fetch.return_value = _SourceFetchResult(
+        accounts=[
+            Account(
+                accountId="kis_mock_account",
+                displayName="KIS 모의투자",
+                source="kis_mock",
+                accountKind="paper",
+                includedInHome=False,
+                valueKrw=999_000,
+                cashBalances=CashAmounts(),
+                buyingPower=CashAmounts(),
+            )
+        ],
+        holdings=[
+            _h(
+                holdingId="km:005930",
+                accountId="kis_mock_account",
+                source="kis_mock",
+                accountKind="paper",
+                symbol="005930",
+                valueKrw=999_000,
+            )
+        ],
+    )
+
+    service = InvestHomeService(
+        kis_reader=kis_reader,
+        upbit_reader=upbit_reader,
+        manual_reader=manual_reader,
+        paper_readers=[mock_paper_reader],
+    )
+    response = await service.get_home(user_id=1)
+
+    # Both accounts are present
+    sources = {a.source for a in response.accounts}
+    assert "kis" in sources
+    assert "kis_mock" in sources
+
+    # Paper is excluded from home summary
+    assert response.homeSummary.totalValueKrw == 10_000_000
+    assert "kis_mock" not in response.homeSummary.includedSources
+    assert "kis_mock" in response.homeSummary.excludedSources
+
+    # Holdings include paper holdings
+    assert any(h.source == "kis_mock" for h in response.holdings)
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_paper_reader_partial_failure_does_not_break_live_accounts() -> None:
+    from app.schemas.invest_home import Account, CashAmounts
+    from app.services.invest_home_service import InvestHomeService, _SourceFetchResult
+
+    kis_reader = AsyncMock()
+    kis_reader.fetch.return_value = _SourceFetchResult(
+        accounts=[
+            Account(
+                accountId="kis_account",
+                displayName="KIS 실계좌",
+                source="kis",
+                accountKind="live",
+                includedInHome=True,
+                valueKrw=5_000_000,
+                cashBalances=CashAmounts(),
+                buyingPower=CashAmounts(),
+            )
+        ],
+        holdings=[],
+    )
+    upbit_reader = AsyncMock()
+    upbit_reader.fetch.return_value = _SourceFetchResult(accounts=[], holdings=[])
+    manual_reader = AsyncMock()
+    manual_reader.fetch.return_value = _SourceFetchResult(accounts=[], holdings=[])
+
+    broken_reader = AsyncMock()
+    broken_reader.source = "kis_mock"
+    broken_reader.fetch.side_effect = RuntimeError("paper API unreachable")
+
+    service = InvestHomeService(
+        kis_reader=kis_reader,
+        upbit_reader=upbit_reader,
+        manual_reader=manual_reader,
+        paper_readers=[broken_reader],
+    )
+    response = await service.get_home(user_id=1)
+
+    # Live KIS account still present
+    assert any(a.source == "kis" for a in response.accounts)
+    assert response.homeSummary.totalValueKrw == 5_000_000
+
+    # Warning was recorded for broken paper reader
+    assert len(response.meta.warnings) >= 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_service_without_paper_readers_unchanged() -> None:
+    """No paper_readers param is backward-compatible."""
+    from app.services.invest_home_service import InvestHomeService, _SourceFetchResult
+
+    kis_reader = AsyncMock()
+    kis_reader.fetch.return_value = _SourceFetchResult(accounts=[], holdings=[])
+    upbit_reader = AsyncMock()
+    upbit_reader.fetch.return_value = _SourceFetchResult(accounts=[], holdings=[])
+    manual_reader = AsyncMock()
+    manual_reader.fetch.return_value = _SourceFetchResult(accounts=[], holdings=[])
+
+    # No paper_readers arg — backward-compatible construction
+    service = InvestHomeService(
+        kis_reader=kis_reader,
+        upbit_reader=upbit_reader,
+        manual_reader=manual_reader,
+    )
+    response = await service.get_home(user_id=1)
+    assert response.accounts == []
+    assert response.homeSummary.totalValueKrw == 0


### PR DESCRIPTION
Linear: ROB-238

## Summary
- Adds distinct `/invest` account rows for KIS official mock and Alpaca Paper alongside KIS live/Upbit/manual sources.
- Normalizes mock/paper cash, buying power, positions, valuation, PnL/avg-cost, currency metadata, quote source/freshness, and UI account-source labels.
- Keeps Home totals locked to live/manual sources while exposing paper/mock accounts as visibly separate, opt-in rows/panels.

## Safety boundaries
- Read-only `/invest` account/holdings surface only; no production broker mutation path added.
- KIS mock uses explicit mock configuration/client adapter paths; KIS live and KIS mock labels remain visually distinct.
- Alpaca Paper is represented as paper-only account data, not live brokerage execution.
- No DB migration, backfill, scheduler activation, live KIS order, Upbit order, cancel/modify, or bulk mutation added.
- Diff keyword scan only found config property names/comments and negative mutation tests; no secret values were committed.

## Tests
- `git diff --check origin/main...HEAD`
- `uv run --group test pytest tests/test_invest_home_service.py tests/test_invest_home_readers.py -q` — 33 passed, 2 unrelated Pydantic deprecation warnings.
- `cd frontend/invest && npm test -- --run src/__tests__/scopeHoldings.test.ts src/__tests__/RightRemotePanel.test.tsx src/__tests__/RightAccountPanel.test.tsx` — 3 files passed, 25 tests passed.
- `cd frontend/invest && npm run build`

## Review gate
- K3 reviewer PASS recorded in Kanban: no blocking correctness or live-order safety issues after KIS mock cash remediation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for KIS mock and Alpaca paper trading accounts with dedicated visual indicators and source-specific labeling
  * Paper accounts are now displayed separately and excluded from portfolio totals

* **User Interface**
  * Updated account cards, filters, and selectors to clearly distinguish paper accounts from live accounts
  * Enhanced account display with source-specific badges and metadata for improved clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/826)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->