### PR TITLE
feat(invest): add sell history tab with symbol names

### DIFF
--- a/frontend/invest/src/__tests__/SellHistoryPanel.test.tsx
+++ b/frontend/invest/src/__tests__/SellHistoryPanel.test.tsx
@@ -51,9 +51,11 @@ afterEach(() => {
 test("SellHistoryPanel renders sell ledger rows and uses include credentials", async () => {
   render(<SellHistoryPanel />);
 
-  expect(await screen.findByText("000660")).toBeInTheDocument();
+  expect(await screen.findByText("SK하이닉스")).toBeInTheDocument();
+  expect(screen.getByText(/000660/)).toBeInTheDocument();
   expect(screen.getByText("매도 이력")).toBeInTheDocument();
   expect(screen.getAllByText("₩1,959,000").length).toBeGreaterThan(0);
+  expect(screen.getByText("총 판매금액 · KRW")).toBeInTheDocument();
   expect(screen.getByText("보정")).toBeInTheDocument();
   expect(screen.getByText("출처 보정 1")).toBeInTheDocument();
 
@@ -66,7 +68,7 @@ test("SellHistoryPanel renders sell ledger rows and uses include credentials", a
 
 test("SellHistoryPanel refetches with market filter", async () => {
   render(<SellHistoryPanel />);
-  await screen.findByText("000660");
+  await screen.findByText("SK하이닉스");
 
   await userEvent.click(screen.getByRole("button", { name: "국내" }));
 

--- a/frontend/invest/src/components/my/SellHistoryPanel.tsx
+++ b/frontend/invest/src/components/my/SellHistoryPanel.tsx
@@ -9,6 +9,22 @@ const MARKET_OPTIONS: { key: FillMarket | "all"; label: string }[] = [
   { key: "crypto", label: "코인" },
 ];
 
+const FALLBACK_SYMBOL_NAMES: Record<string, string> = {
+  "000660": "SK하이닉스",
+  "005930": "삼성전자",
+  "000270": "기아",
+  "000660.KS": "SK하이닉스",
+  "004020": "현대제철",
+  "034220": "LG디스플레이",
+  "064350": "현대로템",
+  "096770": "SK이노베이션",
+  QQQ: "Invesco QQQ Trust",
+  QQQM: "Invesco NASDAQ 100 ETF",
+  TSLA: "Tesla",
+  CONL: "GraniteShares 2x Long COIN ETF",
+  CTSH: "Cognizant Technology Solutions",
+};
+
 function toNumber(value: string | number | null | undefined): number | null {
   if (value == null || value === "") return null;
   const parsed = typeof value === "number" ? value : Number(value);
@@ -66,6 +82,22 @@ function sourceBreakdownLabel(data: FillListResponse): string | null {
   return parts.map(([label, count]) => `${label} ${count}`).join(" · ");
 }
 
+function symbolDisplayName(row: FillRow): string | null {
+  const name = row.symbol_name ?? row.symbolName ?? FALLBACK_SYMBOL_NAMES[row.symbol] ?? FALLBACK_SYMBOL_NAMES[row.raw_symbol];
+  if (!name || name === row.symbol) return null;
+  return name;
+}
+
+function totalByCurrency(rows: FillRow[]): { currency: string; total: number }[] {
+  const totals = new Map<string, number>();
+  for (const row of rows) {
+    const notional = toNumber(row.filled_notional);
+    if (notional == null) continue;
+    totals.set(row.currency, (totals.get(row.currency) ?? 0) + notional);
+  }
+  return Array.from(totals.entries()).map(([currency, total]) => ({ currency, total }));
+}
+
 export function SellHistoryPanel({ compact = false }: { compact?: boolean }) {
   const [market, setMarket] = useState<FillMarket | "all">("all");
   const [state, setState] = useState<
@@ -93,6 +125,7 @@ export function SellHistoryPanel({ compact = false }: { compact?: boolean }) {
   const count = state.status === "ready" ? state.data.count : 0;
   const dataState = state.status === "ready" ? state.data.data_state : null;
   const breakdownLabel = state.status === "ready" ? sourceBreakdownLabel(state.data) : null;
+  const saleTotals = useMemo(() => totalByCurrency(rows), [rows]);
 
   return (
     <section
@@ -168,6 +201,38 @@ export function SellHistoryPanel({ compact = false }: { compact?: boolean }) {
         </div>
       </div>
 
+      {saleTotals.length > 0 && (
+        <div
+          style={{
+            display: "flex",
+            gap: 8,
+            flexWrap: "wrap",
+            padding: compact ? "0 14px 12px" : "0 18px 14px",
+          }}
+          aria-label="매도 금액 요약"
+        >
+          {saleTotals.map(({ currency, total }) => (
+            <div
+              key={currency}
+              style={{
+                borderRadius: 12,
+                background: "var(--surface-2)",
+                padding: "8px 10px",
+                minWidth: compact ? 0 : 150,
+              }}
+            >
+              <div style={{ fontSize: 10, color: "var(--fg-3)", fontWeight: 700 }}>총 판매금액 · {currency}</div>
+              <div style={{ marginTop: 2, fontSize: compact ? 13 : 15, fontWeight: 900, fontFeatureSettings: '"tnum"' }}>
+                {formatMoney(total, currency)}
+              </div>
+            </div>
+          ))}
+          <div style={{ alignSelf: "center", fontSize: 11, color: "var(--fg-3)" }}>
+            실현손익/수익률은 매수 원가 매칭이 추가되면 토스 수익분석처럼 표시됩니다.
+          </div>
+        </div>
+      )}
+
       {state.status === "loading" && (
         <div style={{ padding: 24, color: "var(--fg-3)", fontSize: 13, textAlign: "center" }}>매도 이력을 불러오는 중…</div>
       )}
@@ -198,14 +263,20 @@ export function SellHistoryPanel({ compact = false }: { compact?: boolean }) {
               </tr>
             </thead>
             <tbody>
-              {rows.map((row) => (
+              {rows.map((row) => {
+                const displayName = symbolDisplayName(row);
+                return (
                 <tr key={`${row.broker}-${row.account_mode}-${row.venue}-${row.broker_order_id}-${row.fill_seq}`}>
                   <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 12, color: "var(--fg-2)", whiteSpace: "nowrap" }}>
                     {formatDateTime(row.filled_at)}
                   </td>
                   <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)" }}>
-                    <div style={{ fontSize: 13, fontWeight: 800 }}>{row.symbol}</div>
-                    <div style={{ marginTop: 2, fontSize: 11, color: "var(--fg-3)" }}>{compact ? formatQty(row) : `${row.broker.toUpperCase()} · ${row.venue}`}</div>
+                    <div style={{ fontSize: 13, fontWeight: 800 }}>{displayName ?? row.symbol}</div>
+                    <div style={{ marginTop: 2, fontSize: 11, color: "var(--fg-3)" }}>
+                      {compact
+                        ? `${row.symbol} · ${formatQty(row)}`
+                        : `${row.symbol} · ${row.broker.toUpperCase()} · ${row.venue}`}
+                    </div>
                   </td>
                   {!compact && <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13 }}>{formatQty(row)}</td>}
                   <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, textAlign: "right", fontFeatureSettings: '"tnum"' }}>
@@ -216,7 +287,8 @@ export function SellHistoryPanel({ compact = false }: { compact?: boolean }) {
                   </td>
                   {!compact && <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 12, color: "var(--fg-3)" }}>{sourceLabel(row)}</td>}
                 </tr>
-              ))}
+                );
+              })}
             </tbody>
           </table>
           <div style={{ padding: "8px 14px", fontSize: 11, color: "var(--fg-3)" }}>

--- a/frontend/invest/src/pages/desktop/DesktopPortfolioPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopPortfolioPage.tsx
@@ -17,6 +17,13 @@ import { MobilePortfolioPage } from "../mobile/MobilePortfolioPage";
 import type { AssetCategoryKey } from "../../components/AssetCategoryFilter";
 import type { AccountSource, HomeSummary } from "../../types/invest";
 
+type PortfolioTab = "holdings" | "sellHistory";
+
+const PORTFOLIO_TABS: { key: PortfolioTab; label: string }[] = [
+  { key: "holdings", label: "보유 현황" },
+  { key: "sellHistory", label: "매도 이력" },
+];
+
 export function InvestPortfolioRoute() {
   const viewport = useViewport();
   return viewport === "mobile" ? <MobilePortfolioPage /> : <DesktopPortfolioPage />;
@@ -26,6 +33,7 @@ export function DesktopPortfolioPage() {
   const home = useInvestHome();
   const [account, setAccount] = useState<AccountFilterKey>("all");
   const [category, setCategory] = useState<AssetCategoryKey>("all");
+  const [activeTab, setActiveTab] = useState<PortfolioTab>("holdings");
 
   const data = home.state.status === "ready" ? home.state.data : null;
 
@@ -101,28 +109,36 @@ export function DesktopPortfolioPage() {
               <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
                 <div style={{ fontSize: 12, color: "var(--fg-3)", fontWeight: 700 }}>내 투자</div>
                 <h1 style={{ margin: 0, fontSize: 26, lineHeight: 1.2, letterSpacing: "-0.03em" }}>
-                  통합 보유 현황
+                  {activeTab === "holdings" ? "통합 보유 현황" : "매도 이력"}
                 </h1>
                 <p style={{ margin: 0, color: "var(--fg-3)", fontSize: 13 }}>
-                  KIS, Toss/manual, 모의/수동 계좌를 한 화면에서 비교하고 종목별 출처를 확인합니다.
+                  {activeTab === "holdings"
+                    ? "KIS, Toss/manual, 모의/수동 계좌를 한 화면에서 비교하고 종목별 출처를 확인합니다."
+                    : "KIS/Upbit 체결 보정 ledger 기준 최근 매도 체결을 별도 화면에서 확인합니다."}
                 </p>
               </div>
-              <DesktopHero
-                summary={summary}
-                accountCount={account === "all" ? data.accounts.length : 1}
-                holdings={scopedGrouped}
-              />
-              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: 4 }}>
-                <h2 style={{ margin: 0, fontSize: 18, fontWeight: 700, letterSpacing: "-0.01em" }}>
-                  통합 보유 종목 {filteredScoped.length > 0 && `(${filteredScoped.length})`}
-                </h2>
-                <FilterChips value={category} onChange={setCategory} />
-              </div>
-              <UnifiedHoldingsTable
-                holdings={filteredScoped}
-                accounts={data.accounts}
-              />
-              <SellHistoryPanel />
+              <PortfolioTabBar activeTab={activeTab} onChange={setActiveTab} />
+              {activeTab === "holdings" ? (
+                <>
+                  <DesktopHero
+                    summary={summary}
+                    accountCount={account === "all" ? data.accounts.length : 1}
+                    holdings={scopedGrouped}
+                  />
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginTop: 4 }}>
+                    <h2 style={{ margin: 0, fontSize: 18, fontWeight: 700, letterSpacing: "-0.01em" }}>
+                      통합 보유 종목 {filteredScoped.length > 0 && `(${filteredScoped.length})`}
+                    </h2>
+                    <FilterChips value={category} onChange={setCategory} />
+                  </div>
+                  <UnifiedHoldingsTable
+                    holdings={filteredScoped}
+                    accounts={data.accounts}
+                  />
+                </>
+              ) : (
+                <SellHistoryPanel />
+              )}
               {data.meta?.warnings && data.meta.warnings.length > 0 && (
                 <div
                   role="alert"
@@ -143,5 +159,49 @@ export function DesktopPortfolioPage() {
       }
       right={<RightRemotePanel />}
     />
+  );
+}
+
+function PortfolioTabBar({ activeTab, onChange }: { activeTab: PortfolioTab; onChange: (tab: PortfolioTab) => void }) {
+  return (
+    <div
+      role="tablist"
+      aria-label="내 투자 보기 전환"
+      style={{
+        display: "inline-flex",
+        alignSelf: "flex-start",
+        gap: 6,
+        padding: 4,
+        borderRadius: 999,
+        background: "var(--surface-2)",
+        border: "1px solid var(--border)",
+      }}
+    >
+      {PORTFOLIO_TABS.map((tab) => {
+        const active = activeTab === tab.key;
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(tab.key)}
+            style={{
+              border: "none",
+              borderRadius: 999,
+              padding: "8px 14px",
+              fontSize: 13,
+              fontWeight: 800,
+              cursor: "pointer",
+              fontFamily: "inherit",
+              background: active ? "var(--fg)" : "transparent",
+              color: active ? "var(--bg)" : "var(--fg-2)",
+            }}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
   );
 }

--- a/frontend/invest/src/pages/mobile/MobilePortfolioPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobilePortfolioPage.tsx
@@ -12,6 +12,13 @@ import { SellHistoryPanel } from "../../components/my/SellHistoryPanel";
 import type { AccountSource, GroupedHolding, HomeSummary, PriceState } from "../../types/invest";
 import type { AssetCategoryKey } from "../../components/AssetCategoryFilter";
 
+type PortfolioTab = "holdings" | "sellHistory";
+
+const PORTFOLIO_TABS: { key: PortfolioTab; label: string }[] = [
+  { key: "holdings", label: "보유 현황" },
+  { key: "sellHistory", label: "매도 이력" },
+];
+
 function fmtKrw(v: number | null | undefined): string {
   if (v == null) return "—";
   return `₩${Math.round(v).toLocaleString("ko-KR")}`;
@@ -50,6 +57,7 @@ export function MobilePortfolioPage() {
   const home = useInvestHome();
   const [account, setAccount] = useState<"all" | AccountSource>("all");
   const [category, setCategory] = useState<AssetCategoryKey>("all");
+  const [activeTab, setActiveTab] = useState<PortfolioTab>("holdings");
 
   const data = home.state.status === "ready" ? home.state.data : null;
 
@@ -141,7 +149,13 @@ export function MobilePortfolioPage() {
             )}
           </section>
 
-          {/* Account selector */}
+          <section style={{ padding: "0 16px" }}>
+            <PortfolioTabBar activeTab={activeTab} onChange={setActiveTab} />
+          </section>
+
+          {activeTab === "holdings" ? (
+            <>
+              {/* Account selector */}
           {data.accounts.length > 0 && (
             <section style={{ padding: "0 16px" }} data-testid="mobile-portfolio-account-row">
               <div style={{ display: "flex", gap: 6, overflowX: "auto", paddingBottom: 4 }}>
@@ -296,11 +310,13 @@ export function MobilePortfolioPage() {
                 })}
               </div>
             )}
-          </section>
-
-          <section style={{ padding: "0 16px" }}>
-            <SellHistoryPanel compact />
-          </section>
+              </section>
+            </>
+          ) : (
+            <section style={{ padding: "0 16px" }}>
+              <SellHistoryPanel compact />
+            </section>
+          )}
 
           {data.meta?.warnings && data.meta.warnings.length > 0 && (
             <div
@@ -320,6 +336,50 @@ export function MobilePortfolioPage() {
         </div>
       )}
     </MobileShell>
+  );
+}
+
+function PortfolioTabBar({ activeTab, onChange }: { activeTab: PortfolioTab; onChange: (tab: PortfolioTab) => void }) {
+  return (
+    <div
+      role="tablist"
+      aria-label="내 투자 보기 전환"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr 1fr",
+        gap: 4,
+        padding: 4,
+        borderRadius: 999,
+        background: "var(--surface-2)",
+        border: "1px solid var(--border)",
+      }}
+    >
+      {PORTFOLIO_TABS.map((tab) => {
+        const active = activeTab === tab.key;
+        return (
+          <button
+            key={tab.key}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(tab.key)}
+            style={{
+              border: "none",
+              borderRadius: 999,
+              padding: "8px 10px",
+              background: active ? "var(--fg)" : "transparent",
+              color: active ? "var(--bg)" : "var(--fg-2)",
+              fontSize: 12,
+              fontWeight: 700,
+              cursor: "pointer",
+              fontFamily: "inherit",
+            }}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
   );
 }
 

--- a/frontend/invest/src/types/fills.ts
+++ b/frontend/invest/src/types/fills.ts
@@ -9,6 +9,10 @@ export interface FillRow {
   venue: string;
   instrument_type: string;
   symbol: string;
+  /** Optional display name supplied by backend or future broker/Toss enrichment. */
+  symbol_name?: string | null;
+  /** Camel-case alias tolerated for client-side/backward-compatible enrichers. */
+  symbolName?: string | null;
   raw_symbol: string;
   side: FillSide;
   broker_order_id: string;


### PR DESCRIPTION
## Summary
- Split `/invest/my` into `보유 현황` and `매도 이력` tabs on desktop/mobile.
- Update the sell-history table to show recognizable stock/ETF names first, with ticker/broker/venue as metadata.
- Add Toss-inspired total sale amount summary chips by currency above the sell-history table.

## Notes
- Realized profit and return-rate columns like Toss need buy-cost matching/FIFO or broker-provided realized PnL data. This PR labels the current summary as total sale amount only.
- Chrome remote debugging on `127.0.0.1:9222` was not reachable from this session, so Toss network API extraction is not included here.

## Test Plan
- `npm run typecheck` in `frontend/invest`
- `npx vitest run src/__tests__/SellHistoryPanel.test.tsx` in `frontend/invest`
- `npm run build` in `frontend/invest`
