### PR TITLE
feat(invest): integrate ROB-247 raoni-style sprint

### DIFF
--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -34,6 +34,7 @@ from app.schemas.invest_feed_research import (
 from app.schemas.invest_fx_dashboard import FxDashboardResponse
 from app.schemas.invest_home import InvestHomeResponse
 from app.schemas.invest_market_dashboard import MarketDashboardResponse
+from app.schemas.invest_market_parity import InvestMarketParityResponse
 from app.schemas.invest_momentum_events import (
     MomentumCandidateItem,
     MomentumCandidatesResponse,
@@ -81,6 +82,7 @@ from app.services.invest_view_model.investor_flow_service import (
 from app.services.invest_view_model.market_dashboard_service import (
     build_market_dashboard,
 )
+from app.services.invest_view_model.market_parity_service import build_market_parity
 from app.services.invest_view_model.relation_resolver import build_relation_resolver
 from app.services.invest_view_model.screener_service import (
     build_screener_presets,
@@ -155,6 +157,26 @@ async def get_market_dashboard(
     """Read-only Naver-style market/index dashboard source (ROB-198)."""
     _ = user
     return await build_market_dashboard()
+
+
+@router.get("/market-parity")
+@router.get("/market/parity")
+async def get_market_parity(
+    user: Annotated[Any, Depends(get_authenticated_user)],
+    market: Literal["kr"] = Query("kr"),
+    include_disabled: Annotated[bool, Query(alias="includeDisabled")] = True,
+    limit: int = Query(20, ge=1, le=20),
+) -> InvestMarketParityResponse:
+    """Read-only market parity cards; no broker/order/watch mutations."""
+    _ = user
+    try:
+        return await build_market_parity(
+            market=market,
+            include_disabled=include_disabled,
+            limit=limit,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.get("/market/fx/dashboard")

--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -6,7 +6,7 @@ import 하지 않는다. order / watch / scheduler / mutation 경로 import 금�
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import UTC, date, datetime, time
 from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -19,6 +19,9 @@ from app.schemas.invest_calendar import (
     CalendarResponse,
     CalendarTab,
     WeeklySummaryResponse,
+)
+from app.schemas.invest_common_preferred_disparity import (
+    CommonPreferredDisparityResponse,
 )
 from app.schemas.invest_coverage import CoverageMarket, InvestCoverageResponse
 from app.schemas.invest_crypto import CryptoDashboardResponse
@@ -63,6 +66,9 @@ from app.services.invest_momentum_events.repository import (
 from app.services.invest_screener_snapshots.coverage_service import build_coverage
 from app.services.invest_view_model.account_panel_service import build_account_panel
 from app.services.invest_view_model.calendar_service import build_calendar
+from app.services.invest_view_model.common_preferred_disparity_service import (
+    build_common_preferred_disparity,
+)
 from app.services.invest_view_model.crypto_dashboard_service import (
     build_crypto_dashboard,
 )
@@ -234,6 +240,31 @@ async def get_investor_flow(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/disparity/common-preferred")
+async def get_common_preferred_disparity(
+    user: Annotated[Any, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    symbols: str = Query("", description="Optional comma-separated KR common/preferred symbols"),
+    market: Literal["kr"] = Query("kr"),
+    as_of: Annotated[date | None, Query(alias="asOf")] = None,
+    max_stale_days: Annotated[int, Query(alias="maxStaleDays", ge=0, le=30)] = 1,
+    limit: int = Query(10, ge=1, le=50),
+) -> CommonPreferredDisparityResponse:
+    """Read-only common/preferred-share disparity cards (ROB-250)."""
+    _ = user
+    if market != "kr":
+        raise HTTPException(status_code=400, detail="unsupported_market")
+    symbol_list = [part.strip() for part in symbols.split(",") if part.strip()]
+    as_of_dt = datetime.combine(as_of, time.max, tzinfo=UTC) if as_of else None
+    return await build_common_preferred_disparity(
+        db=db,
+        symbols=symbol_list,
+        as_of=as_of_dt,
+        limit=limit,
+        max_stale_days=max_stale_days,
+    )
 
 
 StockDetailMarketParam = Literal["kr", "us", "crypto"]

--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -50,6 +50,9 @@ from app.schemas.invest_stock_detail import (
     StockDetailOrdersResponse,
     StockDetailResponse,
 )
+from app.schemas.invest_stock_detail_research_consensus import (
+    StockDetailResearchConsensusResponse,
+)
 from app.schemas.investor_flow import InvestorFlowResponse
 from app.services.invest_coverage_service import build_invest_coverage
 from app.services.invest_home_service import InvestHomeService
@@ -84,6 +87,9 @@ from app.services.invest_view_model.stock_detail_candles_service import (
 )
 from app.services.invest_view_model.stock_detail_orders_service import (
     build_stock_detail_orders,
+)
+from app.services.invest_view_model.stock_detail_research_consensus_service import (
+    build_stock_detail_research_consensus,
 )
 from app.services.invest_view_model.stock_detail_service import build_stock_detail
 from app.services.invest_view_model.stock_detail_symbol_resolver import (
@@ -243,6 +249,29 @@ async def get_stock_detail(
     try:
         return await build_stock_detail(
             user_id=user.id,
+            market=market,
+            symbol=symbol,
+            db=db,
+        )
+    except SymbolNotFound as exc:
+        raise HTTPException(status_code=404, detail="symbol_not_found") from exc
+
+
+@router.get("/stock-detail/{market}/{symbol}/research-consensus")
+async def get_stock_detail_research_consensus(
+    market: StockDetailMarketParam,
+    symbol: str,
+    user: Annotated[Any, Depends(get_authenticated_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> StockDetailResearchConsensusResponse:
+    _ = user
+    if market == "crypto":
+        raise HTTPException(
+            status_code=400,
+            detail="research_consensus_supports_kr_us_only",
+        )
+    try:
+        return await build_stock_detail_research_consensus(
             market=market,
             symbol=symbol,
             db=db,

--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -268,7 +268,9 @@ async def get_investor_flow(
 async def get_common_preferred_disparity(
     user: Annotated[Any, Depends(get_authenticated_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
-    symbols: str = Query("", description="Optional comma-separated KR common/preferred symbols"),
+    symbols: str = Query(
+        "", description="Optional comma-separated KR common/preferred symbols"
+    ),
     market: Literal["kr"] = Query("kr"),
     as_of: Annotated[date | None, Query(alias="asOf")] = None,
     max_stale_days: Annotated[int, Query(alias="maxStaleDays", ge=0, le=30)] = 1,

--- a/app/schemas/invest_common_preferred_disparity.py
+++ b/app/schemas/invest_common_preferred_disparity.py
@@ -1,0 +1,82 @@
+"""Read-only /invest common/preferred-share disparity schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+DisparityState = Literal["fresh", "partial", "stale", "missing"]
+DisparityTone = Literal["discount", "premium", "parity", "unknown"]
+
+
+class DisparitySource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    sourceOfTruth: str
+    asOf: datetime | None = None
+    stale: bool = False
+    freshnessSec: int | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+
+class DisparityPeriodWindow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    period: Literal["1d", "5d", "20d", "60d"]
+    sampleCount: int
+    meanDisparityPct: float | None = None
+    minDisparityPct: float | None = None
+    maxDisparityPct: float | None = None
+    zScore: float | None = None
+    dataState: DisparityState
+    emptyReason: str | None = None
+
+
+class CommonPreferredDisparityCard(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    commonSymbol: str
+    commonName: str
+    preferredSymbol: str
+    preferredName: str
+    exchange: str | None = None
+    commonPrice: float | None = None
+    preferredPrice: float | None = None
+    disparityPct: float | None = None
+    preferredDiscountPct: float | None = None
+    preferredPremiumPct: float | None = None
+    zScore: float | None = None
+    primaryWindow: Literal["1d", "5d", "20d", "60d"] = "20d"
+    windows: list[DisparityPeriodWindow] = Field(default_factory=list)
+    tone: DisparityTone = "unknown"
+    dataState: DisparityState
+    emptyReason: str | None = None
+    formula: str = "((commonPrice - preferredPrice) / commonPrice) * 100"
+    source: DisparitySource
+    warnings: list[str] = Field(default_factory=list)
+    caution: str = (
+        "보통주/우선주 괴리율은 참고용 정보이며 매수·매도 신호가 아닙니다. "
+        "배당, 유동성, 의결권, 세금, 이벤트 리스크를 별도로 확인하세요."
+    )
+
+
+class CommonPreferredDisparityResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    market: Literal["kr"] = "kr"
+    state: DisparityState
+    asOf: datetime
+    cards: list[CommonPreferredDisparityCard] = Field(default_factory=list)
+    emptyReason: str | None = None
+    warnings: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(
+        default_factory=lambda: [
+            "Read-only disparity dashboard; no broker/order/watch mutations.",
+            "raoni.xyz is benchmark-only and is not queried in production.",
+            "Common/preferred pair mapping is heuristic until a curated mapping table is approved.",
+        ]
+    )

--- a/app/schemas/invest_market_parity.py
+++ b/app/schemas/invest_market_parity.py
@@ -1,0 +1,65 @@
+"""ROB-251 — read-only /invest market parity schemas."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+InvestParityState = Literal["fresh", "partial", "stale", "missing", "disabled"]
+InvestParityTone = Literal["premium", "discount", "flat", "unknown"]
+InvestParityCardType = Literal[
+    "index_implied_parity",
+    "stablecoin_fx_premium",
+    "crypto_kimchi_premium",
+    "synthetic_kr_stock_parity",
+]
+
+
+class InvestParitySource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    sourceOfTruth: str
+    asOf: datetime | None = None
+    stale: bool = False
+    freshnessSec: int | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+
+class InvestMarketParityCard(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    type: InvestParityCardType
+    title: str
+    baseSymbol: str | None = None
+    baseName: str | None = None
+    proxySymbol: str | None = None
+    syntheticSymbol: str | None = None
+    basePrice: float | None = None
+    proxyPrice: float | None = None
+    syntheticPrice: float | None = None
+    fxRate: float | None = None
+    usdtKrw: float | None = None
+    usdKrw: float | None = None
+    impliedValue: float | None = None
+    premiumPct: float | None = None
+    tone: InvestParityTone = "unknown"
+    formula: str | None = None
+    dataState: InvestParityState
+    emptyReason: str | None = None
+    source: InvestParitySource
+
+
+class InvestMarketParityResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    market: Literal["kr"] = "kr"
+    state: InvestParityState
+    asOf: datetime
+    cards: list[InvestMarketParityCard]
+    emptyReason: str | None = None
+    warnings: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)

--- a/app/schemas/invest_stock_detail_research_consensus.py
+++ b/app/schemas/invest_stock_detail_research_consensus.py
@@ -13,8 +13,12 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from app.schemas.research_reports import ResearchReportCitation
 
-StockDetailResearchConsensusState = Literal["ready", "partial", "missing", "unsupported", "error"]
-StockDetailResearchConsensusDataState = Literal["fresh", "stale", "missing", "unsupported", "error"]
+StockDetailResearchConsensusState = Literal[
+    "ready", "partial", "missing", "unsupported", "error"
+]
+StockDetailResearchConsensusDataState = Literal[
+    "fresh", "stale", "missing", "unsupported", "error"
+]
 StockDetailResearchConsensusEmptyReason = Literal[
     "no_analyst_consensus_or_research_reports",
     "market_unsupported",

--- a/app/schemas/invest_stock_detail_research_consensus.py
+++ b/app/schemas/invest_stock_detail_research_consensus.py
@@ -1,0 +1,74 @@
+"""ROB-249 — stock detail research consensus transport schema.
+
+This schema is citation-only. It intentionally references
+``ResearchReportCitation`` and never exposes report body/PDF/raw payload text.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.research_reports import ResearchReportCitation
+
+StockDetailResearchConsensusState = Literal["ready", "partial", "missing", "unsupported", "error"]
+StockDetailResearchConsensusDataState = Literal["fresh", "stale", "missing", "unsupported", "error"]
+StockDetailResearchConsensusEmptyReason = Literal[
+    "no_analyst_consensus_or_research_reports",
+    "market_unsupported",
+    "provider_error",
+]
+StockDetailResearchConsensusSourceOfTruth = Literal[
+    "analyst_opinions_and_research_reports",
+    "analyst_opinions",
+    "research_reports",
+    "none",
+]
+
+
+class StockDetailAnalystConsensus(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: str | None = None
+    buyCount: int = 0
+    holdCount: int = 0
+    sellCount: int = 0
+    strongBuyCount: int = 0
+    totalCount: int = 0
+    avgTargetPrice: float | None = None
+    medianTargetPrice: float | None = None
+    minTargetPrice: float | None = None
+    maxTargetPrice: float | None = None
+    upsidePct: float | None = None
+    currentPrice: float | None = None
+
+
+class StockDetailResearchFreshness(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    isReady: bool
+    isStale: bool
+    latestRunUuid: str | None = None
+    latestFinishedAt: datetime | None = None
+    latestReportCount: int = 0
+    maxAgeHours: int
+
+
+class StockDetailResearchConsensusResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    market: Literal["kr", "us"]
+    displayName: str
+    state: StockDetailResearchConsensusState
+    dataState: StockDetailResearchConsensusDataState
+    emptyReason: StockDetailResearchConsensusEmptyReason | None = None
+    warnings: list[str] = Field(default_factory=list)
+    sourceOfTruth: StockDetailResearchConsensusSourceOfTruth = "none"
+    asOf: datetime
+    stale: bool = False
+    consensus: StockDetailAnalystConsensus | None = None
+    citations: list[ResearchReportCitation] = Field(default_factory=list)
+    freshness: StockDetailResearchFreshness

--- a/app/services/invest_view_model/common_preferred_disparity_service.py
+++ b/app/services/invest_view_model/common_preferred_disparity_service.py
@@ -56,7 +56,9 @@ def _round(value: float | None, digits: int = 2) -> float | None:
     return round(value, digits)
 
 
-def _disparity_pct(common_price: float | None, preferred_price: float | None) -> float | None:
+def _disparity_pct(
+    common_price: float | None, preferred_price: float | None
+) -> float | None:
     if common_price is None or preferred_price is None or common_price <= 0:
         return None
     return ((common_price - preferred_price) / common_price) * 100.0
@@ -157,7 +159,10 @@ def _build_windows(
         if not values:
             windows.append(
                 DisparityPeriodWindow(
-                    period=period, sampleCount=0, dataState="missing", emptyReason="quote_window_missing"
+                    period=period,
+                    sampleCount=0,
+                    dataState="missing",
+                    emptyReason="quote_window_missing",
                 )
             )
             continue
@@ -184,11 +189,16 @@ def _build_windows(
 
 async def _load_active_universe(db: AsyncSession) -> list[KRSymbolRow]:
     result = await db.execute(
-        sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name, KRSymbolUniverse.exchange)
+        sa.select(
+            KRSymbolUniverse.symbol, KRSymbolUniverse.name, KRSymbolUniverse.exchange
+        )
         .where(KRSymbolUniverse.is_active.is_(True))
         .order_by(KRSymbolUniverse.symbol.asc())
     )
-    return [KRSymbolRow(symbol=row.symbol, name=row.name, exchange=row.exchange) for row in result.all()]
+    return [
+        KRSymbolRow(symbol=row.symbol, name=row.name, exchange=row.exchange)
+        for row in result.all()
+    ]
 
 
 async def _load_quote_rows(
@@ -234,7 +244,9 @@ async def build_common_preferred_disparity(
     effective_as_of = _as_aware(as_of) or now
     wanted = {s.strip() for s in symbols or [] if s.strip()}
     universe_rows = await _load_active_universe(db)
-    pairs = discover_common_preferred_pairs(universe_rows, symbols=wanted or None)[:limit]
+    pairs = discover_common_preferred_pairs(universe_rows, symbols=wanted or None)[
+        :limit
+    ]
     if not pairs:
         return CommonPreferredDisparityResponse(
             state="missing",
@@ -244,7 +256,9 @@ async def build_common_preferred_disparity(
             warnings=["preferred_pair_mapping_heuristic_no_match"],
         )
 
-    quote_symbols = {pair.common_symbol for pair in pairs} | {pair.preferred_symbol for pair in pairs}
+    quote_symbols = {pair.common_symbol for pair in pairs} | {
+        pair.preferred_symbol for pair in pairs
+    }
     quotes = await _load_quote_rows(db, symbols=quote_symbols, as_of=effective_as_of)
     cards: list[CommonPreferredDisparityCard] = []
     global_warnings = ["preferred_pair_mapping_heuristic"]
@@ -253,7 +267,9 @@ async def build_common_preferred_disparity(
     for pair in pairs:
         common_rows = quotes.get(pair.common_symbol, [])
         preferred_rows = quotes.get(pair.preferred_symbol, [])
-        source, common_quote, preferred_quote = _choose_same_source_quote(common_rows, preferred_rows)
+        source, common_quote, preferred_quote = _choose_same_source_quote(
+            common_rows, preferred_rows
+        )
         warnings = [f"pair_mapping:{pair.mapping_source}"]
         empty_reason = None
         data_state = "fresh"
@@ -269,7 +285,9 @@ async def build_common_preferred_disparity(
             common_ts = _as_aware(common_quote.snapshot_at) or effective_as_of
             preferred_ts = _as_aware(preferred_quote.snapshot_at) or effective_as_of
             source_as_of = min(common_ts, preferred_ts)
-            freshness_sec = max(0, int((effective_as_of - source_as_of).total_seconds()))
+            freshness_sec = max(
+                0, int((effective_as_of - source_as_of).total_seconds())
+            )
             common_price = _to_float(common_quote.price)
             preferred_price = _to_float(preferred_quote.price)
             disparity = _disparity_pct(common_price, preferred_price)
@@ -290,7 +308,9 @@ async def build_common_preferred_disparity(
             source=source,
             as_of=effective_as_of,
         )
-        if data_state == "fresh" and any(window.dataState != "fresh" for window in windows):
+        if data_state == "fresh" and any(
+            window.dataState != "fresh" for window in windows
+        ):
             data_state = "partial"
             warnings.append("quote_window_partial")
 

--- a/app/services/invest_view_model/common_preferred_disparity_service.py
+++ b/app/services/invest_view_model/common_preferred_disparity_service.py
@@ -1,0 +1,348 @@
+"""Read-only common/preferred-share disparity view model service."""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
+from statistics import mean, pstdev
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.market_quote_snapshot import MarketQuoteSnapshot
+from app.schemas.invest_common_preferred_disparity import (
+    CommonPreferredDisparityCard,
+    CommonPreferredDisparityResponse,
+    DisparityPeriodWindow,
+    DisparitySource,
+)
+from app.services.invest_view_model.kr_preferred_pairs import (
+    KRSymbolRow,
+    discover_common_preferred_pairs,
+)
+
+_PERIOD_DAYS: dict[str, int] = {"1d": 1, "5d": 5, "20d": 20, "60d": 60}
+_PRIMARY_WINDOW = "20d"
+_DISPARITY_FORMULA = "((commonPrice - preferredPrice) / commonPrice) * 100"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _as_aware(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _to_float(value: Decimal | int | float | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(Decimal(str(value)))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _round(value: float | None, digits: int = 2) -> float | None:
+    if value is None or not math.isfinite(value):
+        return None
+    return round(value, digits)
+
+
+def _disparity_pct(common_price: float | None, preferred_price: float | None) -> float | None:
+    if common_price is None or preferred_price is None or common_price <= 0:
+        return None
+    return ((common_price - preferred_price) / common_price) * 100.0
+
+
+def _state_from_cards(cards: list[CommonPreferredDisparityCard]) -> str:
+    if not cards:
+        return "missing"
+    states = {card.dataState for card in cards}
+    if states == {"fresh"}:
+        return "fresh"
+    if states <= {"missing"}:
+        return "missing"
+    if states <= {"stale", "missing"} and "stale" in states:
+        return "stale"
+    return "partial"
+
+
+def _latest_by_source(
+    rows: list[MarketQuoteSnapshot],
+) -> dict[str, MarketQuoteSnapshot]:
+    latest: dict[str, MarketQuoteSnapshot] = {}
+    for row in rows:
+        existing = latest.get(row.source)
+        if existing is None or row.snapshot_at > existing.snapshot_at:
+            latest[row.source] = row
+    return latest
+
+
+def _choose_same_source_quote(
+    common_rows: list[MarketQuoteSnapshot],
+    preferred_rows: list[MarketQuoteSnapshot],
+) -> tuple[str | None, MarketQuoteSnapshot | None, MarketQuoteSnapshot | None]:
+    common_latest = _latest_by_source(common_rows)
+    preferred_latest = _latest_by_source(preferred_rows)
+    shared = set(common_latest) & set(preferred_latest)
+    if not shared:
+        return None, None, None
+    best_source = max(
+        shared,
+        key=lambda source: min(
+            common_latest[source].snapshot_at,
+            preferred_latest[source].snapshot_at,
+        ),
+    )
+    return best_source, common_latest[best_source], preferred_latest[best_source]
+
+
+def _window_values(
+    *,
+    common_rows: list[MarketQuoteSnapshot],
+    preferred_rows: list[MarketQuoteSnapshot],
+    source: str,
+    as_of: datetime,
+    days: int,
+) -> list[float]:
+    since = as_of - timedelta(days=days)
+    common_by_at = {
+        _as_aware(row.snapshot_at): _to_float(row.price)
+        for row in common_rows
+        if row.source == source and (_as_aware(row.snapshot_at) or as_of) >= since
+    }
+    preferred_by_at = {
+        _as_aware(row.snapshot_at): _to_float(row.price)
+        for row in preferred_rows
+        if row.source == source and (_as_aware(row.snapshot_at) or as_of) >= since
+    }
+    values: list[float] = []
+    for snapshot_at in sorted(set(common_by_at) & set(preferred_by_at)):
+        value = _disparity_pct(common_by_at[snapshot_at], preferred_by_at[snapshot_at])
+        if value is not None:
+            values.append(value)
+    return values
+
+
+def _build_windows(
+    *,
+    current_disparity: float | None,
+    common_rows: list[MarketQuoteSnapshot],
+    preferred_rows: list[MarketQuoteSnapshot],
+    source: str | None,
+    as_of: datetime,
+) -> tuple[list[DisparityPeriodWindow], float | None]:
+    windows: list[DisparityPeriodWindow] = []
+    primary_z: float | None = None
+    for period, days in _PERIOD_DAYS.items():
+        values = (
+            _window_values(
+                common_rows=common_rows,
+                preferred_rows=preferred_rows,
+                source=source,
+                as_of=as_of,
+                days=days,
+            )
+            if source
+            else []
+        )
+        if not values:
+            windows.append(
+                DisparityPeriodWindow(
+                    period=period, sampleCount=0, dataState="missing", emptyReason="quote_window_missing"
+                )
+            )
+            continue
+        avg = mean(values)
+        sigma = pstdev(values) if len(values) > 1 else 0.0
+        z_score = None
+        if current_disparity is not None and sigma > 0:
+            z_score = (current_disparity - avg) / sigma
+        if period == _PRIMARY_WINDOW:
+            primary_z = z_score
+        windows.append(
+            DisparityPeriodWindow(
+                period=period,
+                sampleCount=len(values),
+                meanDisparityPct=_round(avg),
+                minDisparityPct=_round(min(values)),
+                maxDisparityPct=_round(max(values)),
+                zScore=_round(z_score),
+                dataState="fresh",
+            )
+        )
+    return windows, _round(primary_z)
+
+
+async def _load_active_universe(db: AsyncSession) -> list[KRSymbolRow]:
+    result = await db.execute(
+        sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name, KRSymbolUniverse.exchange)
+        .where(KRSymbolUniverse.is_active.is_(True))
+        .order_by(KRSymbolUniverse.symbol.asc())
+    )
+    return [KRSymbolRow(symbol=row.symbol, name=row.name, exchange=row.exchange) for row in result.all()]
+
+
+async def _load_quote_rows(
+    db: AsyncSession,
+    *,
+    symbols: set[str],
+    as_of: datetime,
+) -> dict[str, list[MarketQuoteSnapshot]]:
+    if not symbols:
+        return {}
+    since = as_of - timedelta(days=max(_PERIOD_DAYS.values()) + 1)
+    result = await db.execute(
+        sa.select(MarketQuoteSnapshot)
+        .where(
+            MarketQuoteSnapshot.market == "kr",
+            MarketQuoteSnapshot.symbol.in_(sorted(symbols)),
+            MarketQuoteSnapshot.snapshot_at <= as_of,
+            MarketQuoteSnapshot.snapshot_at >= since,
+        )
+        .order_by(
+            MarketQuoteSnapshot.symbol.asc(),
+            MarketQuoteSnapshot.source.asc(),
+            MarketQuoteSnapshot.snapshot_at.desc(),
+        )
+    )
+    grouped: dict[str, list[MarketQuoteSnapshot]] = defaultdict(list)
+    for row in result.scalars().all():
+        grouped[row.symbol].append(row)
+    return grouped
+
+
+async def build_common_preferred_disparity(
+    *,
+    db: AsyncSession,
+    symbols: list[str] | None = None,
+    as_of: datetime | None = None,
+    limit: int = 10,
+    max_stale_days: int = 1,
+) -> CommonPreferredDisparityResponse:
+    """Build common/preferred disparity cards from persisted read-only snapshots."""
+
+    now = _utc_now()
+    effective_as_of = _as_aware(as_of) or now
+    wanted = {s.strip() for s in symbols or [] if s.strip()}
+    universe_rows = await _load_active_universe(db)
+    pairs = discover_common_preferred_pairs(universe_rows, symbols=wanted or None)[:limit]
+    if not pairs:
+        return CommonPreferredDisparityResponse(
+            state="missing",
+            asOf=effective_as_of,
+            cards=[],
+            emptyReason="common_preferred_pair_missing",
+            warnings=["preferred_pair_mapping_heuristic_no_match"],
+        )
+
+    quote_symbols = {pair.common_symbol for pair in pairs} | {pair.preferred_symbol for pair in pairs}
+    quotes = await _load_quote_rows(db, symbols=quote_symbols, as_of=effective_as_of)
+    cards: list[CommonPreferredDisparityCard] = []
+    global_warnings = ["preferred_pair_mapping_heuristic"]
+    stale_after = timedelta(days=max_stale_days)
+
+    for pair in pairs:
+        common_rows = quotes.get(pair.common_symbol, [])
+        preferred_rows = quotes.get(pair.preferred_symbol, [])
+        source, common_quote, preferred_quote = _choose_same_source_quote(common_rows, preferred_rows)
+        warnings = [f"pair_mapping:{pair.mapping_source}"]
+        empty_reason = None
+        data_state = "fresh"
+        freshness_sec = None
+        source_as_of = None
+        common_price = preferred_price = disparity = premium = None
+
+        if source is None or common_quote is None or preferred_quote is None:
+            data_state = "missing"
+            empty_reason = "same_source_quote_pair_missing"
+            warnings.append("same_source_quote_pair_missing")
+        else:
+            common_ts = _as_aware(common_quote.snapshot_at) or effective_as_of
+            preferred_ts = _as_aware(preferred_quote.snapshot_at) or effective_as_of
+            source_as_of = min(common_ts, preferred_ts)
+            freshness_sec = max(0, int((effective_as_of - source_as_of).total_seconds()))
+            common_price = _to_float(common_quote.price)
+            preferred_price = _to_float(preferred_quote.price)
+            disparity = _disparity_pct(common_price, preferred_price)
+            premium = _disparity_pct(preferred_price, common_price)
+            if disparity is None:
+                data_state = "missing"
+                empty_reason = "quote_price_invalid"
+                warnings.append("quote_price_invalid")
+            elif effective_as_of - source_as_of > stale_after:
+                data_state = "stale"
+                empty_reason = "quote_snapshot_stale"
+                warnings.append("quote_snapshot_stale")
+
+        windows, z_score = _build_windows(
+            current_disparity=disparity,
+            common_rows=common_rows,
+            preferred_rows=preferred_rows,
+            source=source,
+            as_of=effective_as_of,
+        )
+        if data_state == "fresh" and any(window.dataState != "fresh" for window in windows):
+            data_state = "partial"
+            warnings.append("quote_window_partial")
+
+        tone = "unknown"
+        if disparity is not None:
+            if disparity > 0.25:
+                tone = "discount"
+            elif disparity < -0.25:
+                tone = "premium"
+            else:
+                tone = "parity"
+
+        cards.append(
+            CommonPreferredDisparityCard(
+                id=f"{pair.common_symbol}-{pair.preferred_symbol}",
+                commonSymbol=pair.common_symbol,
+                commonName=pair.common_name,
+                preferredSymbol=pair.preferred_symbol,
+                preferredName=pair.preferred_name,
+                exchange=pair.exchange,
+                commonPrice=_round(common_price, 2),
+                preferredPrice=_round(preferred_price, 2),
+                disparityPct=_round(disparity),
+                preferredDiscountPct=_round(disparity),
+                preferredPremiumPct=_round(premium),
+                zScore=z_score,
+                primaryWindow=_PRIMARY_WINDOW,
+                windows=windows,
+                tone=tone,  # type: ignore[arg-type]
+                dataState=data_state,  # type: ignore[arg-type]
+                emptyReason=empty_reason,
+                formula=_DISPARITY_FORMULA,
+                source=DisparitySource(
+                    source=source or "market_quote_snapshots",
+                    sourceOfTruth="market_quote_snapshots",
+                    asOf=source_as_of,
+                    stale=data_state == "stale",
+                    freshnessSec=freshness_sec,
+                    warnings=warnings,
+                ),
+                warnings=warnings,
+            )
+        )
+
+    state = _state_from_cards(cards)
+    empty_reason = None if cards else "common_preferred_pair_missing"
+    if cards and state in {"missing", "stale"}:
+        empty_reason = "quote_snapshot_unavailable"
+    return CommonPreferredDisparityResponse(
+        state=state,  # type: ignore[arg-type]
+        asOf=effective_as_of,
+        cards=cards,
+        emptyReason=empty_reason,
+        warnings=global_warnings,
+    )

--- a/app/services/invest_view_model/kr_preferred_pairs.py
+++ b/app/services/invest_view_model/kr_preferred_pairs.py
@@ -74,7 +74,12 @@ def discover_common_preferred_pairs(
         )
 
     if include_seed:
-        for common_symbol, common_name, preferred_symbol, preferred_name in SEED_COMMON_PREFERRED_PAIRS:
+        for (
+            common_symbol,
+            common_name,
+            preferred_symbol,
+            preferred_name,
+        ) in SEED_COMMON_PREFERRED_PAIRS:
             if not _include(common_symbol, preferred_symbol):
                 continue
             common = by_symbol.get(common_symbol)
@@ -85,11 +90,15 @@ def discover_common_preferred_pairs(
                     common_symbol=common_symbol,
                     common_name=common.name if common is not None else common_name,
                     preferred_symbol=preferred_symbol,
-                    preferred_name=preferred.name if preferred is not None else preferred_name,
+                    preferred_name=preferred.name
+                    if preferred is not None
+                    else preferred_name,
                     exchange=(preferred.exchange if preferred is not None else None)
                     or (common.exchange if common is not None else None),
                     mapping_source="seed_samsung_pair",
                 ),
             )
 
-    return sorted(pairs.values(), key=lambda pair: (pair.common_symbol, pair.preferred_symbol))
+    return sorted(
+        pairs.values(), key=lambda pair: (pair.common_symbol, pair.preferred_symbol)
+    )

--- a/app/services/invest_view_model/kr_preferred_pairs.py
+++ b/app/services/invest_view_model/kr_preferred_pairs.py
@@ -1,0 +1,95 @@
+"""Pure KR common/preferred-share pair helpers for read-only /invest cards."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+PREFERRED_SUFFIXES: tuple[str, ...] = ("우B", "우C", "우", "1우", "2우B", "3우B")
+SEED_COMMON_PREFERRED_PAIRS: tuple[tuple[str, str, str, str], ...] = (
+    ("005930", "삼성전자", "005935", "삼성전자우"),
+)
+
+
+@dataclass(frozen=True)
+class KRSymbolRow:
+    symbol: str
+    name: str
+    exchange: str | None = None
+
+
+@dataclass(frozen=True)
+class CommonPreferredPair:
+    common_symbol: str
+    common_name: str
+    preferred_symbol: str
+    preferred_name: str
+    exchange: str | None = None
+    mapping_source: str = "heuristic"
+
+
+def preferred_base_name(name: str) -> str | None:
+    normalized = (name or "").strip()
+    for suffix in sorted(PREFERRED_SUFFIXES, key=len, reverse=True):
+        if normalized.endswith(suffix) and len(normalized) > len(suffix):
+            return normalized[: -len(suffix)]
+    return None
+
+
+def is_preferred_name(name: str) -> bool:
+    return preferred_base_name(name) is not None
+
+
+def discover_common_preferred_pairs(
+    rows: list[KRSymbolRow],
+    *,
+    symbols: set[str] | None = None,
+    include_seed: bool = True,
+) -> list[CommonPreferredPair]:
+    """Discover common/preferred pairs without DB writes or provider calls."""
+
+    by_name = {row.name.strip(): row for row in rows if row.name.strip()}
+    by_symbol = {row.symbol.strip(): row for row in rows if row.symbol.strip()}
+    wanted = {s.strip() for s in symbols or set() if s.strip()}
+    pairs: dict[tuple[str, str], CommonPreferredPair] = {}
+
+    def _include(common_symbol: str, preferred_symbol: str) -> bool:
+        return not wanted or common_symbol in wanted or preferred_symbol in wanted
+
+    for row in rows:
+        base = preferred_base_name(row.name)
+        if not base:
+            continue
+        common = by_name.get(base)
+        if common is None or common.symbol == row.symbol:
+            continue
+        if not _include(common.symbol, row.symbol):
+            continue
+        pairs[(common.symbol, row.symbol)] = CommonPreferredPair(
+            common_symbol=common.symbol,
+            common_name=common.name,
+            preferred_symbol=row.symbol,
+            preferred_name=row.name,
+            exchange=row.exchange or common.exchange,
+            mapping_source="heuristic_name_suffix",
+        )
+
+    if include_seed:
+        for common_symbol, common_name, preferred_symbol, preferred_name in SEED_COMMON_PREFERRED_PAIRS:
+            if not _include(common_symbol, preferred_symbol):
+                continue
+            common = by_symbol.get(common_symbol)
+            preferred = by_symbol.get(preferred_symbol)
+            pairs.setdefault(
+                (common_symbol, preferred_symbol),
+                CommonPreferredPair(
+                    common_symbol=common_symbol,
+                    common_name=common.name if common is not None else common_name,
+                    preferred_symbol=preferred_symbol,
+                    preferred_name=preferred.name if preferred is not None else preferred_name,
+                    exchange=(preferred.exchange if preferred is not None else None)
+                    or (common.exchange if common is not None else None),
+                    mapping_source="seed_samsung_pair",
+                ),
+            )
+
+    return sorted(pairs.values(), key=lambda pair: (pair.common_symbol, pair.preferred_symbol))

--- a/app/services/invest_view_model/market_parity_service.py
+++ b/app/services/invest_view_model/market_parity_service.py
@@ -236,12 +236,16 @@ async def _build_index_card(
     provider: MarketParityProvider, config: IndexParityConfig
 ) -> tuple[InvestMarketParityCard, list[str]]:
     base, base_warning = await _capture(
-        f"index:{config.base_symbol}", lambda: provider.get_index_quote(config.base_symbol)
+        f"index:{config.base_symbol}",
+        lambda: provider.get_index_quote(config.base_symbol),
     )
     proxy, proxy_warning = await _capture(
-        f"proxy:{config.proxy_symbol}", lambda: provider.get_proxy_quote(config.proxy_symbol)
+        f"proxy:{config.proxy_symbol}",
+        lambda: provider.get_proxy_quote(config.proxy_symbol),
     )
-    fx, fx_warning = await _capture("fx:USD/KRW", lambda: provider.get_fx_rate("USD/KRW"))
+    fx, fx_warning = await _capture(
+        "fx:USD/KRW", lambda: provider.get_fx_rate("USD/KRW")
+    )
     warnings = [w for w in [base_warning, proxy_warning, fx_warning] if w]
     missing: list[str] = []
     if base is None:
@@ -269,7 +273,9 @@ async def _build_index_card(
             premiumPct=premium,
             tone=_tone(premium),
             formula=_INDEX_PARITY_FORMULA,
-            dataState="stale" if any(leg.stale for leg in [base, proxy, fx]) else "fresh",
+            dataState="stale"
+            if any(leg.stale for leg in [base, proxy, fx])
+            else "fresh",
             source=_source(
                 source="market_index+proxy+fx",
                 source_of_truth="market_index/provider_fixture/fx",
@@ -284,7 +290,9 @@ async def _build_index_card(
 async def _build_stablecoin_card(
     provider: MarketParityProvider,
 ) -> tuple[InvestMarketParityCard, list[str]]:
-    usd, usd_warning = await _capture("fx:USD/KRW", lambda: provider.get_fx_rate("USD/KRW"))
+    usd, usd_warning = await _capture(
+        "fx:USD/KRW", lambda: provider.get_fx_rate("USD/KRW")
+    )
     usdt, usdt_warning = await _capture(
         "stablecoin:USDT/KRW", lambda: provider.get_stablecoin_rate("USDT/KRW")
     )
@@ -337,7 +345,9 @@ async def _build_stablecoin_card(
     )
 
 
-def _extract_kimchi(payload: Any) -> tuple[float | None, str, datetime | None, list[str]]:
+def _extract_kimchi(
+    payload: Any,
+) -> tuple[float | None, str, datetime | None, list[str]]:
     row: dict[str, Any] | None = None
     if isinstance(payload, list) and payload:
         first = payload[0]
@@ -362,7 +372,9 @@ async def _build_kimchi_card(
     )
     premium, symbol, as_of, payload_warnings = _extract_kimchi(payload)
     warnings = [w for w in [warning, *payload_warnings] if w]
-    state: InvestParityState = "fresh" if premium is not None and not warnings else "missing"
+    state: InvestParityState = (
+        "fresh" if premium is not None and not warnings else "missing"
+    )
     return (
         InvestMarketParityCard(
             id="btc-kimchi-premium",
@@ -396,7 +408,9 @@ async def _build_synthetic_card(
         f"synthetic:{config.synthetic_symbol}",
         lambda: provider.get_synthetic_quote(config.synthetic_symbol),
     )
-    fx, fx_warning = await _capture("fx:USD/KRW", lambda: provider.get_fx_rate("USD/KRW"))
+    fx, fx_warning = await _capture(
+        "fx:USD/KRW", lambda: provider.get_fx_rate("USD/KRW")
+    )
     warnings = [w for w in [base_warning, synthetic_warning, fx_warning] if w]
     if synthetic is None:
         return (
@@ -465,7 +479,9 @@ async def _build_synthetic_card(
             premiumPct=premium,
             tone=_tone(premium),
             formula=_SYNTHETIC_FORMULA,
-            dataState="stale" if any(leg.stale for leg in [base, synthetic, fx]) else "fresh",
+            dataState="stale"
+            if any(leg.stale for leg in [base, synthetic, fx])
+            else "fresh",
             source=_source(
                 source="kr_quote+synthetic+fx",
                 source_of_truth="provider_fixture/hyperliquid_approval_required",
@@ -477,13 +493,19 @@ async def _build_synthetic_card(
     )
 
 
-def _response_state(cards: list[InvestMarketParityCard], warnings: list[str]) -> InvestParityState:
+def _response_state(
+    cards: list[InvestMarketParityCard], warnings: list[str]
+) -> InvestParityState:
     if not cards:
         return "missing"
     usable = [card for card in cards if card.dataState in {"fresh", "stale", "partial"}]
     if not usable:
         return "missing"
-    if warnings or len(usable) < len(cards) or any(card.dataState != "fresh" for card in usable):
+    if (
+        warnings
+        or len(usable) < len(cards)
+        or any(card.dataState != "fresh" for card in usable)
+    ):
         return "partial"
     return "fresh"
 

--- a/app/services/invest_view_model/market_parity_service.py
+++ b/app/services/invest_view_model/market_parity_service.py
@@ -1,0 +1,563 @@
+"""ROB-251 — read-only market parity view model for /invest.
+
+The default implementation intentionally avoids unapproved production sources:
+- no raoni.xyz calls
+- no Hyperliquid calls until an explicit collector/source approval exists
+- no DB writes, scheduler activation, broker/order/watch imports
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from typing import Any, Protocol
+
+from app.mcp_server.tooling.fundamentals._crypto import handle_get_kimchi_premium
+from app.mcp_server.tooling.fundamentals._market_index import handle_get_market_index
+from app.schemas.invest_market_parity import (
+    InvestMarketParityCard,
+    InvestMarketParityResponse,
+    InvestParitySource,
+    InvestParityState,
+    InvestParityTone,
+)
+
+_INDEX_PARITY_FORMULA = "((proxyPrice * fxRate * divisor) / basePrice - 1) * 100"
+_STABLECOIN_FX_FORMULA = "(usdtKrw / usdKrw - 1) * 100"
+_SYNTHETIC_FORMULA = "((syntheticPrice * fxRate) / basePrice - 1) * 100"
+
+
+@dataclass(frozen=True)
+class ParityQuote:
+    symbol: str
+    price: Decimal
+    source: str
+    as_of: datetime | None = None
+    stale: bool = False
+    warnings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class IndexParityConfig:
+    id: str
+    title: str
+    base_symbol: str
+    proxy_symbol: str
+    divisor: Decimal = Decimal("1")
+
+
+@dataclass(frozen=True)
+class SyntheticParityConfig:
+    base_symbol: str
+    base_name: str
+    synthetic_symbol: str
+    title: str
+
+
+class MarketParityProvider(Protocol):
+    async def get_index_quote(self, symbol: str) -> ParityQuote | None: ...
+    async def get_proxy_quote(self, symbol: str) -> ParityQuote | None: ...
+    async def get_fx_rate(self, pair: str) -> ParityQuote | None: ...
+    async def get_stablecoin_rate(self, pair: str) -> ParityQuote | None: ...
+    async def get_crypto_kimchi_premium(self, symbol: str) -> dict[str, Any] | None: ...
+    async def get_synthetic_quote(self, symbol: str) -> ParityQuote | None: ...
+    async def get_kr_stock_quote(self, symbol: str) -> ParityQuote | None: ...
+
+
+class DefaultMarketParityProvider:
+    """Read-only provider backed only by currently owned/approved adapters.
+
+    ETF proxy, FX, stablecoin, and Hyperliquid synthetic sources are returned as
+    missing/disabled by default until the user approves source selection and
+    collector activation. Tests can inject a provider with those legs to verify
+    calculations without production dependencies.
+    """
+
+    async def get_index_quote(self, symbol: str) -> ParityQuote | None:
+        payload = await handle_get_market_index(symbol=symbol, period="day", count=1)
+        row = _first_index_row(payload, symbol)
+        if row is None:
+            return None
+        price = _decimal_or_none(row.get("current") or row.get("price"))
+        if price is None:
+            return None
+        return ParityQuote(
+            symbol=symbol,
+            price=price,
+            source=str(row.get("source") or "market_index"),
+            as_of=_parse_datetime(row.get("as_of") or row.get("timestamp")),
+            stale=bool(row.get("stale", False)),
+            warnings=tuple([str(row["error"])] if row.get("error") else []),
+        )
+
+    async def get_proxy_quote(self, symbol: str) -> ParityQuote | None:
+        _ = symbol
+        return None
+
+    async def get_fx_rate(self, pair: str) -> ParityQuote | None:
+        _ = pair
+        return None
+
+    async def get_stablecoin_rate(self, pair: str) -> ParityQuote | None:
+        _ = pair
+        return None
+
+    async def get_crypto_kimchi_premium(self, symbol: str) -> dict[str, Any] | None:
+        return await handle_get_kimchi_premium(symbol)
+
+    async def get_synthetic_quote(self, symbol: str) -> ParityQuote | None:
+        _ = symbol
+        return None
+
+    async def get_kr_stock_quote(self, symbol: str) -> ParityQuote | None:
+        _ = symbol
+        return None
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _decimal_or_none(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _first_index_row(payload: Any, symbol: str) -> dict[str, Any] | None:
+    rows: list[Any]
+    if isinstance(payload, dict):
+        if isinstance(payload.get("indices"), list):
+            rows = payload["indices"]
+        else:
+            rows = [payload]
+    elif isinstance(payload, list):
+        rows = payload
+    else:
+        rows = []
+    wanted = symbol.upper()
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        row_symbol = str(row.get("symbol") or row.get("code") or "").upper()
+        if row_symbol == wanted or len(rows) == 1:
+            return row
+    return None
+
+
+def _pct(numerator: Decimal, denominator: Decimal) -> Decimal | None:
+    if denominator == 0:
+        return None
+    return ((numerator / denominator) - Decimal("1")) * Decimal("100")
+
+
+def _round_decimal(value: Decimal | None, places: str = "0.01") -> float | None:
+    if value is None:
+        return None
+    return float(value.quantize(Decimal(places), rounding=ROUND_HALF_UP))
+
+
+def _tone(premium_pct: float | None) -> InvestParityTone:
+    if premium_pct is None:
+        return "unknown"
+    if premium_pct > 0:
+        return "premium"
+    if premium_pct < 0:
+        return "discount"
+    return "flat"
+
+
+def _source(
+    *,
+    source: str,
+    source_of_truth: str,
+    legs: list[ParityQuote | None] | None = None,
+    warnings: list[str] | None = None,
+) -> InvestParitySource:
+    real_legs = [leg for leg in (legs or []) if leg is not None]
+    as_of_values = [leg.as_of for leg in real_legs if leg.as_of is not None]
+    return InvestParitySource(
+        source=source,
+        sourceOfTruth=source_of_truth,
+        asOf=max(as_of_values) if as_of_values else None,
+        stale=any(leg.stale for leg in real_legs),
+        warnings=[*(warnings or []), *(w for leg in real_legs for w in leg.warnings)],
+    )
+
+
+async def _capture(label: str, call: Any) -> tuple[Any | None, str | None]:
+    try:
+        return await asyncio.wait_for(call(), timeout=6), None
+    except Exception as exc:  # provider failures degrade the /invest shell
+        return None, f"{label}: {exc}"
+
+
+def _missing_index_card(
+    config: IndexParityConfig, missing_reasons: list[str], warnings: list[str]
+) -> InvestMarketParityCard:
+    reason = missing_reasons[0] if missing_reasons else "index_parity_source_missing"
+    return InvestMarketParityCard(
+        id=config.id,
+        type="index_implied_parity",
+        title=config.title,
+        baseSymbol=config.base_symbol,
+        proxySymbol=config.proxy_symbol,
+        formula=_INDEX_PARITY_FORMULA,
+        dataState="missing",
+        emptyReason=reason,
+        source=_source(
+            source="not_configured",
+            source_of_truth="market_index/proxy_quote/fx",
+            warnings=[*missing_reasons, *warnings],
+        ),
+    )
+
+
+async def _build_index_card(
+    provider: MarketParityProvider, config: IndexParityConfig
+) -> tuple[InvestMarketParityCard, list[str]]:
+    base, base_warning = await _capture(
+        f"index:{config.base_symbol}", lambda: provider.get_index_quote(config.base_symbol)
+    )
+    proxy, proxy_warning = await _capture(
+        f"proxy:{config.proxy_symbol}", lambda: provider.get_proxy_quote(config.proxy_symbol)
+    )
+    fx, fx_warning = await _capture("fx:USD/KRW", lambda: provider.get_fx_rate("USD/KRW"))
+    warnings = [w for w in [base_warning, proxy_warning, fx_warning] if w]
+    missing: list[str] = []
+    if base is None:
+        missing.append("market_index_unavailable")
+    if proxy is None:
+        missing.append("proxy_quote_missing")
+    if fx is None:
+        missing.append("fx_source_not_configured")
+    if missing:
+        return _missing_index_card(config, missing, warnings), warnings
+
+    implied = proxy.price * fx.price * config.divisor
+    premium = _round_decimal(_pct(implied, base.price))
+    return (
+        InvestMarketParityCard(
+            id=config.id,
+            type="index_implied_parity",
+            title=config.title,
+            baseSymbol=config.base_symbol,
+            proxySymbol=config.proxy_symbol,
+            basePrice=_round_decimal(base.price, "0.0001"),
+            proxyPrice=_round_decimal(proxy.price, "0.0001"),
+            fxRate=_round_decimal(fx.price, "0.0001"),
+            impliedValue=_round_decimal(implied, "0.0001"),
+            premiumPct=premium,
+            tone=_tone(premium),
+            formula=_INDEX_PARITY_FORMULA,
+            dataState="stale" if any(leg.stale for leg in [base, proxy, fx]) else "fresh",
+            source=_source(
+                source="market_index+proxy+fx",
+                source_of_truth="market_index/provider_fixture/fx",
+                legs=[base, proxy, fx],
+                warnings=warnings,
+            ),
+        ),
+        warnings,
+    )
+
+
+async def _build_stablecoin_card(
+    provider: MarketParityProvider,
+) -> tuple[InvestMarketParityCard, list[str]]:
+    usd, usd_warning = await _capture("fx:USD/KRW", lambda: provider.get_fx_rate("USD/KRW"))
+    usdt, usdt_warning = await _capture(
+        "stablecoin:USDT/KRW", lambda: provider.get_stablecoin_rate("USDT/KRW")
+    )
+    warnings = [w for w in [usd_warning, usdt_warning] if w]
+    missing: list[str] = []
+    if usd is None:
+        missing.append("fx_source_not_configured")
+    if usdt is None:
+        missing.append("stablecoin_fx_source_not_configured")
+    if missing:
+        return (
+            InvestMarketParityCard(
+                id="usdt-krw-usd-krw-premium",
+                type="stablecoin_fx_premium",
+                title="USDT/KRW vs USD/KRW premium",
+                usdKrw=_round_decimal(usd.price, "0.0001") if usd else None,
+                usdtKrw=_round_decimal(usdt.price, "0.0001") if usdt else None,
+                formula=_STABLECOIN_FX_FORMULA,
+                dataState="missing",
+                emptyReason=missing[0],
+                source=_source(
+                    source="not_configured",
+                    source_of_truth="approval_gate",
+                    legs=[usd, usdt],
+                    warnings=[*missing, *warnings],
+                ),
+            ),
+            warnings,
+        )
+    premium = _round_decimal(_pct(usdt.price, usd.price))
+    return (
+        InvestMarketParityCard(
+            id="usdt-krw-usd-krw-premium",
+            type="stablecoin_fx_premium",
+            title="USDT/KRW vs USD/KRW premium",
+            usdKrw=_round_decimal(usd.price, "0.0001"),
+            usdtKrw=_round_decimal(usdt.price, "0.0001"),
+            premiumPct=premium,
+            tone=_tone(premium),
+            formula=_STABLECOIN_FX_FORMULA,
+            dataState="stale" if usd.stale or usdt.stale else "fresh",
+            source=_source(
+                source="fx+stablecoin",
+                source_of_truth="provider_fixture/fx",
+                legs=[usd, usdt],
+                warnings=warnings,
+            ),
+        ),
+        warnings,
+    )
+
+
+def _extract_kimchi(payload: Any) -> tuple[float | None, str, datetime | None, list[str]]:
+    row: dict[str, Any] | None = None
+    if isinstance(payload, list) and payload:
+        first = payload[0]
+        row = first if isinstance(first, dict) else None
+    elif isinstance(payload, dict):
+        row = payload
+    if row is None:
+        return None, "BTC", None, ["crypto_kimchi_payload_unavailable"]
+    premium = _decimal_or_none(
+        row.get("premium_pct") or row.get("kimchi_premium") or row.get("premium")
+    )
+    symbol = str(row.get("symbol") or row.get("market") or "BTC")
+    warnings = [str(row["error"])] if row.get("error") else []
+    return _round_decimal(premium), symbol, _parse_datetime(row.get("as_of")), warnings
+
+
+async def _build_kimchi_card(
+    provider: MarketParityProvider,
+) -> tuple[InvestMarketParityCard, list[str]]:
+    payload, warning = await _capture(
+        "crypto_kimchi:BTC", lambda: provider.get_crypto_kimchi_premium("BTC")
+    )
+    premium, symbol, as_of, payload_warnings = _extract_kimchi(payload)
+    warnings = [w for w in [warning, *payload_warnings] if w]
+    state: InvestParityState = "fresh" if premium is not None and not warnings else "missing"
+    return (
+        InvestMarketParityCard(
+            id="btc-kimchi-premium",
+            type="crypto_kimchi_premium",
+            title="BTC kimchi premium",
+            baseSymbol=symbol,
+            premiumPct=premium,
+            tone=_tone(premium),
+            dataState=state,
+            emptyReason=None if premium is not None else "crypto_kimchi_unavailable",
+            source=InvestParitySource(
+                source="upbit+binance" if premium is not None else "not_available",
+                sourceOfTruth="get_kimchi_premium(BTC)",
+                asOf=as_of,
+                stale=False,
+                warnings=warnings,
+            ),
+        ),
+        warnings,
+    )
+
+
+async def _build_synthetic_card(
+    provider: MarketParityProvider, config: SyntheticParityConfig
+) -> tuple[InvestMarketParityCard, list[str]]:
+    base, base_warning = await _capture(
+        f"kr_stock:{config.base_symbol}",
+        lambda: provider.get_kr_stock_quote(config.base_symbol),
+    )
+    synthetic, synthetic_warning = await _capture(
+        f"synthetic:{config.synthetic_symbol}",
+        lambda: provider.get_synthetic_quote(config.synthetic_symbol),
+    )
+    fx, fx_warning = await _capture("fx:USD/KRW", lambda: provider.get_fx_rate("USD/KRW"))
+    warnings = [w for w in [base_warning, synthetic_warning, fx_warning] if w]
+    if synthetic is None:
+        return (
+            InvestMarketParityCard(
+                id=f"{config.base_symbol}-{config.synthetic_symbol.lower().replace(':', '-')}",
+                type="synthetic_kr_stock_parity",
+                title=config.title,
+                baseSymbol=config.base_symbol,
+                baseName=config.base_name,
+                syntheticSymbol=config.synthetic_symbol,
+                basePrice=_round_decimal(base.price, "0.0001") if base else None,
+                fxRate=_round_decimal(fx.price, "0.0001") if fx else None,
+                formula=_SYNTHETIC_FORMULA,
+                dataState="disabled",
+                emptyReason="hyperliquid_source_not_approved",
+                source=_source(
+                    source="not_configured",
+                    source_of_truth="approval_gate",
+                    legs=[base, fx],
+                    warnings=["hyperliquid_source_not_approved", *warnings],
+                ),
+            ),
+            warnings,
+        )
+    missing = []
+    if base is None:
+        missing.append("kr_stock_quote_missing")
+    if fx is None:
+        missing.append("fx_source_not_configured")
+    if missing:
+        return (
+            InvestMarketParityCard(
+                id=f"{config.base_symbol}-{config.synthetic_symbol.lower().replace(':', '-')}",
+                type="synthetic_kr_stock_parity",
+                title=config.title,
+                baseSymbol=config.base_symbol,
+                baseName=config.base_name,
+                syntheticSymbol=config.synthetic_symbol,
+                syntheticPrice=_round_decimal(synthetic.price, "0.0001"),
+                formula=_SYNTHETIC_FORMULA,
+                dataState="missing",
+                emptyReason=missing[0],
+                source=_source(
+                    source="hyperliquid_fixture",
+                    source_of_truth="provider_fixture/approval_gate",
+                    legs=[base, synthetic, fx],
+                    warnings=[*missing, *warnings],
+                ),
+            ),
+            warnings,
+        )
+    implied = synthetic.price * fx.price
+    premium = _round_decimal(_pct(implied, base.price))
+    return (
+        InvestMarketParityCard(
+            id=f"{config.base_symbol}-{config.synthetic_symbol.lower().replace(':', '-')}",
+            type="synthetic_kr_stock_parity",
+            title=config.title,
+            baseSymbol=config.base_symbol,
+            baseName=config.base_name,
+            syntheticSymbol=config.synthetic_symbol,
+            basePrice=_round_decimal(base.price, "0.0001"),
+            syntheticPrice=_round_decimal(synthetic.price, "0.0001"),
+            fxRate=_round_decimal(fx.price, "0.0001"),
+            impliedValue=_round_decimal(implied, "0.0001"),
+            premiumPct=premium,
+            tone=_tone(premium),
+            formula=_SYNTHETIC_FORMULA,
+            dataState="stale" if any(leg.stale for leg in [base, synthetic, fx]) else "fresh",
+            source=_source(
+                source="kr_quote+synthetic+fx",
+                source_of_truth="provider_fixture/hyperliquid_approval_required",
+                legs=[base, synthetic, fx],
+                warnings=warnings,
+            ),
+        ),
+        warnings,
+    )
+
+
+def _response_state(cards: list[InvestMarketParityCard], warnings: list[str]) -> InvestParityState:
+    if not cards:
+        return "missing"
+    usable = [card for card in cards if card.dataState in {"fresh", "stale", "partial"}]
+    if not usable:
+        return "missing"
+    if warnings or len(usable) < len(cards) or any(card.dataState != "fresh" for card in usable):
+        return "partial"
+    return "fresh"
+
+
+async def build_market_parity(
+    provider: MarketParityProvider | None = None,
+    *,
+    market: str = "kr",
+    include_disabled: bool = True,
+    limit: int = 20,
+) -> InvestMarketParityResponse:
+    if market != "kr":
+        raise ValueError("market_parity_only_supports_kr")
+    provider = provider or DefaultMarketParityProvider()
+    as_of = _now()
+    warnings: list[str] = []
+    cards: list[InvestMarketParityCard] = []
+
+    index_card, index_warnings = await _build_index_card(
+        provider,
+        IndexParityConfig(
+            id="ewy-kospi-implied-parity",
+            title="EWY implied KOSPI parity",
+            base_symbol="KOSPI",
+            proxy_symbol="EWY",
+        ),
+    )
+    cards.append(index_card)
+    warnings.extend(index_warnings)
+
+    stablecoin_card, stablecoin_warnings = await _build_stablecoin_card(provider)
+    cards.append(stablecoin_card)
+    warnings.extend(stablecoin_warnings)
+
+    kimchi_card, kimchi_warnings = await _build_kimchi_card(provider)
+    cards.append(kimchi_card)
+    warnings.extend(kimchi_warnings)
+
+    synthetic_configs = [
+        SyntheticParityConfig(
+            base_symbol="005930",
+            base_name="삼성전자",
+            synthetic_symbol="xyz:SMSN",
+            title="Samsung Electronics synthetic parity",
+        ),
+        SyntheticParityConfig(
+            base_symbol="000660",
+            base_name="SK하이닉스",
+            synthetic_symbol="xyz:SKHX",
+            title="SK hynix synthetic parity",
+        ),
+    ][: max(limit, 0)]
+    for config in synthetic_configs:
+        card, card_warnings = await _build_synthetic_card(provider, config)
+        cards.append(card)
+        warnings.extend(card_warnings)
+
+    if not include_disabled:
+        cards = [card for card in cards if card.dataState != "disabled"]
+
+    # Card-level source warnings carry expected approval-gate diagnostics. Top-level
+    # warnings are reserved for provider failures/unexpected partial failures.
+    unique_warnings = list(dict.fromkeys(warnings))
+    state = _response_state(cards, unique_warnings)
+    return InvestMarketParityResponse(
+        market="kr",
+        state=state,
+        asOf=as_of,
+        cards=cards,
+        emptyReason="no_market_parity_cards" if not cards else None,
+        warnings=unique_warnings,
+        notes=[
+            "Read-only market parity dashboard; no broker/order/watch mutations.",
+            "raoni.xyz is benchmark-only and is not queried in production.",
+            "Hyperliquid, ETF proxy, FX, and stablecoin collectors remain approval-gated unless explicitly supplied by an owned provider/fixture.",
+        ],
+    )

--- a/app/services/invest_view_model/stock_detail_research_consensus_service.py
+++ b/app/services/invest_view_model/stock_detail_research_consensus_service.py
@@ -1,0 +1,313 @@
+"""ROB-249 — read-only stock-detail analyst consensus + research citations."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.mcp_server.tooling.fundamentals._valuation import (
+    handle_get_investment_opinions,
+)
+from app.schemas.invest_stock_detail_research_consensus import (
+    StockDetailAnalystConsensus,
+    StockDetailResearchConsensusDataState,
+    StockDetailResearchConsensusResponse,
+    StockDetailResearchConsensusSourceOfTruth,
+    StockDetailResearchConsensusState,
+    StockDetailResearchFreshness,
+)
+from app.schemas.research_reports import (
+    ResearchReportCitation,
+    ResearchReportsReadinessResponse,
+)
+from app.services.analyst_normalizer import build_consensus
+from app.services.invest_view_model.stock_detail_symbol_resolver import (
+    ResolvedSymbol,
+    resolve_symbol,
+)
+from app.services.research_reports.freshness import compute_research_reports_readiness
+from app.services.research_reports.query_service import ResearchReportsQueryService
+
+logger = logging.getLogger(__name__)
+
+ResearchConsensusMarket = Literal["kr", "us"]
+Resolver = Callable[[ResearchConsensusMarket, str, AsyncSession], Awaitable[ResolvedSymbol]]
+OpinionsProvider = Callable[[str, ResearchConsensusMarket, int], Awaitable[dict[str, Any]]]
+CitationsProvider = Callable[[AsyncSession, str, int], Awaitable[list[ResearchReportCitation]]]
+ReadinessProvider = Callable[[AsyncSession, str | None, int], Awaitable[ResearchReportsReadinessResponse]]
+
+DEFAULT_OPINION_LIMIT = 10
+DEFAULT_CITATION_LIMIT = 5
+DEFAULT_MAX_AGE_HOURS = 24
+
+
+async def _default_opinions_provider(
+    symbol: str, market: ResearchConsensusMarket, limit: int
+) -> dict[str, Any]:
+    return await handle_get_investment_opinions(symbol=symbol, market=market, limit=limit)
+
+
+async def _default_citations_provider(
+    db: AsyncSession, symbol: str, limit: int
+) -> list[ResearchReportCitation]:
+    result = await ResearchReportsQueryService(db).find_relevant(symbol=symbol, limit=limit)
+    return result.citations
+
+
+async def _default_readiness_provider(
+    db: AsyncSession, source: str | None, max_age_hours: int
+) -> ResearchReportsReadinessResponse:
+    return await compute_research_reports_readiness(
+        db, source=source, max_age_hours=max_age_hours
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class StockDetailResearchConsensusProviders:
+    resolver: Resolver = resolve_symbol
+    opinions: OpinionsProvider = _default_opinions_provider
+    citations: CitationsProvider = _default_citations_provider
+    readiness: ReadinessProvider = _default_readiness_provider
+
+
+DEFAULT_RESEARCH_CONSENSUS_PROVIDERS = StockDetailResearchConsensusProviders()
+
+
+async def build_stock_detail_research_consensus(
+    *,
+    market: ResearchConsensusMarket,
+    symbol: str,
+    db: AsyncSession,
+    providers: StockDetailResearchConsensusProviders = DEFAULT_RESEARCH_CONSENSUS_PROVIDERS,
+    opinion_limit: int = DEFAULT_OPINION_LIMIT,
+    citation_limit: int = DEFAULT_CITATION_LIMIT,
+    max_age_hours: int = DEFAULT_MAX_AGE_HOURS,
+) -> StockDetailResearchConsensusResponse:
+    """Build a read-only research consensus panel for KR/US stock detail.
+
+    Provider failures are isolated into warning codes. The response may still be
+    useful when only compact research citations are available. It never includes
+    report bodies, raw payloads, or PDF bytes.
+    """
+
+    resolved = await providers.resolver(market, symbol, db)
+    warnings: list[str] = []
+    as_of = datetime.now(UTC)
+
+    opinions_task = _safe_opinions(
+        providers.opinions(resolved.symbol_db, market, opinion_limit), warnings
+    )
+    citations_task = _safe_citations(
+        providers.citations(db, resolved.symbol_db, citation_limit), warnings
+    )
+    readiness_task = _safe_readiness(
+        providers.readiness(db, None, max_age_hours), warnings, max_age_hours
+    )
+
+    opinions_payload, citations, readiness = await asyncio.gather(
+        opinions_task, citations_task, readiness_task
+    )
+
+    consensus = _build_consensus_model(opinions_payload, warnings)
+    freshness = StockDetailResearchFreshness(
+        isReady=readiness.is_ready,
+        isStale=readiness.is_stale,
+        latestRunUuid=readiness.latest_run_uuid,
+        latestFinishedAt=readiness.latest_finished_at,
+        latestReportCount=readiness.latest_report_count,
+        maxAgeHours=readiness.max_age_hours,
+    )
+    warnings.extend(w for w in readiness.warnings if w not in warnings)
+
+    has_consensus = consensus is not None and consensus.totalCount > 0
+    has_citations = bool(citations)
+    source_of_truth = _source_of_truth(has_consensus, has_citations)
+    state = _state(has_consensus, has_citations)
+    provider_error = _has_provider_error(warnings)
+    data_state = _data_state(state, readiness.is_stale, warnings, provider_error)
+    empty_reason = None
+    if state == "missing":
+        empty_reason = (
+            "provider_error" if provider_error else "no_analyst_consensus_or_research_reports"
+        )
+
+    return StockDetailResearchConsensusResponse(
+        symbol=resolved.symbol_db,
+        market=market,
+        displayName=resolved.display_name,
+        state=state,
+        dataState=data_state,
+        emptyReason=empty_reason,
+        warnings=warnings,
+        sourceOfTruth=source_of_truth,
+        asOf=as_of,
+        stale=readiness.is_stale,
+        consensus=consensus if has_consensus else None,
+        citations=citations,
+        freshness=freshness,
+    )
+
+
+async def _safe_opinions(
+    coro: Awaitable[dict[str, Any]], warnings: list[str]
+) -> dict[str, Any] | None:
+    try:
+        return await asyncio.wait_for(coro, timeout=4)
+    except TimeoutError:
+        warnings.append("analyst_opinions_timeout")
+    except Exception as exc:  # pragma: no cover - exercised via stubs/logging only
+        logger.warning("stock-detail analyst opinions unavailable: %s", exc)
+        warnings.append("analyst_opinions_unavailable")
+    return None
+
+
+async def _safe_citations(
+    coro: Awaitable[list[ResearchReportCitation]], warnings: list[str]
+) -> list[ResearchReportCitation]:
+    try:
+        return await asyncio.wait_for(coro, timeout=4)
+    except TimeoutError:
+        warnings.append("research_reports_timeout")
+    except Exception as exc:  # pragma: no cover - exercised via stubs/logging only
+        logger.warning("stock-detail research citations unavailable: %s", exc)
+        warnings.append("research_reports_unavailable")
+    return []
+
+
+async def _safe_readiness(
+    coro: Awaitable[ResearchReportsReadinessResponse],
+    warnings: list[str],
+    max_age_hours: int,
+) -> ResearchReportsReadinessResponse:
+    try:
+        return await asyncio.wait_for(coro, timeout=4)
+    except TimeoutError:
+        warnings.append("research_reports_readiness_timeout")
+    except Exception as exc:  # pragma: no cover - exercised via stubs/logging only
+        logger.warning("stock-detail research readiness unavailable: %s", exc)
+        warnings.append("research_reports_readiness_unavailable")
+    return ResearchReportsReadinessResponse(
+        source=None,
+        is_ready=False,
+        is_stale=False,
+        latest_inserted_count=0,
+        latest_skipped_count=0,
+        latest_report_count=0,
+        warnings=["research_reports_readiness_unavailable"],
+        max_age_hours=max_age_hours,
+    )
+
+
+def _build_consensus_model(
+    payload: dict[str, Any] | None, warnings: list[str]
+) -> StockDetailAnalystConsensus | None:
+    if not payload:
+        return None
+    if payload.get("error"):
+        if "analyst_opinions_unavailable" not in warnings:
+            warnings.append("analyst_opinions_unavailable")
+        return None
+
+    raw_opinions = payload.get("opinions") or payload.get("items") or []
+    if not isinstance(raw_opinions, list) or not raw_opinions:
+        return None
+
+    current_price = _to_float(
+        payload.get("current_price")
+        or payload.get("currentPrice")
+        or payload.get("price")
+        or payload.get("current")
+    )
+    normalized_opinions = [_normalize_opinion(row) for row in raw_opinions]
+    consensus = build_consensus(normalized_opinions, current_price=current_price)
+    return StockDetailAnalystConsensus(
+        source=payload.get("source") or payload.get("provider"),
+        buyCount=consensus["buy_count"],
+        holdCount=consensus["hold_count"],
+        sellCount=consensus["sell_count"],
+        strongBuyCount=consensus["strong_buy_count"],
+        totalCount=consensus["total_count"],
+        avgTargetPrice=consensus["avg_target_price"],
+        medianTargetPrice=consensus["median_target_price"],
+        minTargetPrice=consensus["min_target_price"],
+        maxTargetPrice=consensus["max_target_price"],
+        upsidePct=consensus["upside_pct"],
+        currentPrice=consensus["current_price"],
+    )
+
+
+def _normalize_opinion(row: Any) -> dict[str, Any]:
+    if not isinstance(row, dict):
+        return {"rating": None, "target_price": None}
+    return {
+        "rating": row.get("rating")
+        or row.get("opinion")
+        or row.get("investment_opinion")
+        or row.get("recommendation"),
+        "target_price": _to_float(
+            row.get("target_price")
+            or row.get("targetPrice")
+            or row.get("target")
+            or row.get("tp")
+        ),
+    }
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(str(value).replace(",", ""))
+    except (TypeError, ValueError):
+        return None
+
+
+def _source_of_truth(
+    has_consensus: bool, has_citations: bool
+) -> StockDetailResearchConsensusSourceOfTruth:
+    if has_consensus and has_citations:
+        return "analyst_opinions_and_research_reports"
+    if has_consensus:
+        return "analyst_opinions"
+    if has_citations:
+        return "research_reports"
+    return "none"
+
+
+def _state(has_consensus: bool, has_citations: bool) -> StockDetailResearchConsensusState:
+    if has_consensus and has_citations:
+        return "ready"
+    if has_consensus or has_citations:
+        return "partial"
+    return "missing"
+
+
+def _data_state(
+    state: StockDetailResearchConsensusState,
+    is_stale: bool,
+    warnings: list[str],
+    provider_error: bool = False,
+) -> StockDetailResearchConsensusDataState:
+    if any(w.endswith("_timeout") for w in warnings):
+        return "error" if state == "missing" else "stale"
+    if provider_error and state == "missing":
+        return "error"
+    if state == "missing":
+        return "missing"
+    if is_stale:
+        return "stale"
+    return "fresh"
+
+
+def _has_provider_error(warnings: list[str]) -> bool:
+    return any(
+        w.endswith("_unavailable") or w.endswith("_timeout")
+        for w in warnings
+        if w != "research_reports_stale"
+    )

--- a/app/services/invest_view_model/stock_detail_research_consensus_service.py
+++ b/app/services/invest_view_model/stock_detail_research_consensus_service.py
@@ -37,10 +37,18 @@ from app.services.research_reports.query_service import ResearchReportsQueryServ
 logger = logging.getLogger(__name__)
 
 ResearchConsensusMarket = Literal["kr", "us"]
-Resolver = Callable[[ResearchConsensusMarket, str, AsyncSession], Awaitable[ResolvedSymbol]]
-OpinionsProvider = Callable[[str, ResearchConsensusMarket, int], Awaitable[dict[str, Any]]]
-CitationsProvider = Callable[[AsyncSession, str, int], Awaitable[list[ResearchReportCitation]]]
-ReadinessProvider = Callable[[AsyncSession, str | None, int], Awaitable[ResearchReportsReadinessResponse]]
+Resolver = Callable[
+    [ResearchConsensusMarket, str, AsyncSession], Awaitable[ResolvedSymbol]
+]
+OpinionsProvider = Callable[
+    [str, ResearchConsensusMarket, int], Awaitable[dict[str, Any]]
+]
+CitationsProvider = Callable[
+    [AsyncSession, str, int], Awaitable[list[ResearchReportCitation]]
+]
+ReadinessProvider = Callable[
+    [AsyncSession, str | None, int], Awaitable[ResearchReportsReadinessResponse]
+]
 
 DEFAULT_OPINION_LIMIT = 10
 DEFAULT_CITATION_LIMIT = 5
@@ -50,13 +58,17 @@ DEFAULT_MAX_AGE_HOURS = 24
 async def _default_opinions_provider(
     symbol: str, market: ResearchConsensusMarket, limit: int
 ) -> dict[str, Any]:
-    return await handle_get_investment_opinions(symbol=symbol, market=market, limit=limit)
+    return await handle_get_investment_opinions(
+        symbol=symbol, market=market, limit=limit
+    )
 
 
 async def _default_citations_provider(
     db: AsyncSession, symbol: str, limit: int
 ) -> list[ResearchReportCitation]:
-    result = await ResearchReportsQueryService(db).find_relevant(symbol=symbol, limit=limit)
+    result = await ResearchReportsQueryService(db).find_relevant(
+        symbol=symbol, limit=limit
+    )
     return result.citations
 
 
@@ -134,7 +146,9 @@ async def build_stock_detail_research_consensus(
     empty_reason = None
     if state == "missing":
         empty_reason = (
-            "provider_error" if provider_error else "no_analyst_consensus_or_research_reports"
+            "provider_error"
+            if provider_error
+            else "no_analyst_consensus_or_research_reports"
         )
 
     return StockDetailResearchConsensusResponse(
@@ -280,7 +294,9 @@ def _source_of_truth(
     return "none"
 
 
-def _state(has_consensus: bool, has_citations: bool) -> StockDetailResearchConsensusState:
+def _state(
+    has_consensus: bool, has_citations: bool
+) -> StockDetailResearchConsensusState:
     if has_consensus and has_citations:
         return "ready"
     if has_consensus or has_citations:

--- a/docs/plans/ROB-253-invest-insights-decision.md
+++ b/docs/plans/ROB-253-invest-insights-decision.md
@@ -1,0 +1,17 @@
+# ROB-253 /invest market insights decision
+
+Decision: scaffold `/invest/insights` as a read-only aggregation page.
+
+Rationale:
+- ROB-249 research consensus is symbol-scoped, so it stays embedded in `/invest/stocks/:market/:symbol` where the user has a concrete stock context.
+- ROB-250 common/preferred disparity and ROB-252 market parity cards are cross-market observation widgets with stronger "not a signal" caveats. Keeping them all on `/invest` or `/invest/market` would make those entry pages too dense.
+- A dedicated `/invest/insights` surface lets home keep compact summaries while market insight widgets get their own loading, empty, error, and read-only guardrail copy.
+
+Safety boundaries preserved:
+- Uses existing read-only `/invest/api` frontend hooks only.
+- No broker/order/watch mutation path is called or imported.
+- No production DB write, backfill, or scheduler activation is added.
+- No production dependency on raoni.xyz APIs is introduced.
+
+Deferred/follow-up trigger:
+- If additional cross-market insight widgets are added, place them on `/invest/insights` first and only promote compact summaries back to home after UX review.

--- a/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, expect, test, vi } from "vitest";
+
+import { DesktopInsightsPage } from "../pages/desktop/DesktopInsightsPage";
+import { useCommonPreferredDisparity } from "../hooks/useCommonPreferredDisparity";
+import { useMarketParity } from "../hooks/useMarketParity";
+
+vi.mock("../hooks/useMarketParity", () => ({ useMarketParity: vi.fn() }));
+vi.mock("../hooks/useCommonPreferredDisparity", () => ({ useCommonPreferredDisparity: vi.fn() }));
+
+const marketParityReady = {
+  state: {
+    status: "ready" as const,
+    data: {
+      asOf: "2026-05-14T00:00:00Z",
+      market: "kr" as const,
+      state: "fresh" as const,
+      emptyReason: null,
+      warnings: [],
+      notes: ["read-only"],
+      cards: [
+        {
+          id: "kospi-etf",
+          title: "KOSPI ETF parity",
+          type: "index_implied_parity" as const,
+          baseSymbol: "KOSPI",
+          baseName: "KOSPI",
+          proxySymbol: "069500",
+          syntheticSymbol: null,
+          formula: "ETF/NAV",
+          premiumPct: 1.23,
+          tone: "premium" as const,
+          dataState: "fresh" as const,
+          emptyReason: null,
+          source: {
+            source: "read-only fixture",
+            sourceOfTruth: "market parity service",
+            asOf: "2026-05-14T00:00:00Z",
+            freshnessSec: 60,
+            stale: false,
+            warnings: [],
+          },
+        },
+      ],
+    },
+  },
+  reload: vi.fn(),
+};
+
+const disparityReady = {
+  status: "ready" as const,
+  data: {
+    asOf: "2026-05-14T00:00:00Z",
+    market: "kr" as const,
+    state: "fresh" as const,
+    emptyReason: null,
+    warnings: [],
+    notes: ["read-only"],
+    cards: [
+      {
+        id: "005930-005935",
+        commonSymbol: "005930",
+        commonName: "삼성전자",
+        preferredSymbol: "005935",
+        preferredName: "삼성전자우",
+        commonPrice: 80000,
+        preferredPrice: 65000,
+        disparityPct: -18.75,
+        zScore: -1.2,
+        tone: "discount" as const,
+        dataState: "fresh" as const,
+        emptyReason: null,
+        primaryWindow: "60d" as const,
+        windows: [{ period: "60d" as const, sampleCount: 60, meanDisparityPct: -15, zScore: -1.2, dataState: "fresh" as const }],
+        formula: "preferred/common - 1",
+        source: {
+          source: "read-only fixture",
+          sourceOfTruth: "common preferred disparity service",
+          asOf: "2026-05-14T00:00:00Z",
+          stale: false,
+          freshnessSec: 60,
+          warnings: [],
+        },
+        caution: "매수·매도 추천이 아닙니다.",
+        warnings: [],
+      },
+    ],
+  },
+};
+
+function wrap(ui: React.ReactElement) {
+  return <MemoryRouter basename="/invest" initialEntries={["/invest/insights"]}>{ui}</MemoryRouter>;
+}
+
+beforeEach(() => {
+  vi.mocked(useMarketParity).mockReturnValue(marketParityReady);
+  vi.mocked(useCommonPreferredDisparity).mockReturnValue(disparityReady);
+});
+
+test("renders the dedicated read-only insights scaffold", () => {
+  render(wrap(<DesktopInsightsPage />));
+
+  expect(screen.getByRole("heading", { name: "인사이트" })).toBeInTheDocument();
+  expect(screen.getByText(/ROB-253 decision/)).toBeInTheDocument();
+  expect(screen.getByText(/주문·매매·watch mutation API를 호출하지 않습니다/)).toBeInTheDocument();
+  expect(screen.getByText("KOSPI ETF parity")).toBeInTheDocument();
+  expect(screen.getByText("삼성전자 / 삼성전자우")).toBeInTheDocument();
+  expect(screen.getByRole("link", { name: "시장 대시보드" })).toHaveAttribute("href", "/invest/market");
+});
+
+test("renders loading and error states for independent insight widgets", () => {
+  vi.mocked(useMarketParity).mockReturnValue({ state: { status: "error", message: "boom" }, reload: vi.fn() });
+  vi.mocked(useCommonPreferredDisparity).mockReturnValue({ status: "loading" });
+
+  render(wrap(<DesktopInsightsPage />));
+
+  expect(screen.getByText(/괴리 참고 카드를 일시적으로 불러오지 못했습니다/)).toBeInTheDocument();
+  expect(screen.getByText(/보통주\/우선주 괴리 데이터를 불러오는 중/)).toBeInTheDocument();
+});
+
+test("renders an empty market parity state without hiding the page", () => {
+  vi.mocked(useMarketParity).mockReturnValue({
+    state: {
+      status: "ready",
+      data: { ...marketParityReady.state.data, state: "missing", emptyReason: "승인된 패리티 카드가 없습니다.", cards: [] },
+    },
+    reload: vi.fn(),
+  });
+
+  render(wrap(<DesktopInsightsPage />));
+
+  expect(screen.getByText("승인된 패리티 카드가 없습니다.")).toBeInTheDocument();
+  expect(screen.getByText("삼성전자 / 삼성전자우")).toBeInTheDocument();
+});

--- a/frontend/invest/src/__tests__/DesktopMarketPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopMarketPage.test.tsx
@@ -3,7 +3,59 @@ import { MemoryRouter } from "react-router-dom";
 import { beforeEach, expect, test, vi } from "vitest";
 
 import { DesktopMarketPage } from "../pages/desktop/DesktopMarketPage";
+import * as disparityApi from "../api/commonPreferredDisparity";
 import * as marketApi from "../api/marketDashboard";
+import type { CommonPreferredDisparityResponse } from "../types/commonPreferredDisparity";
+
+const DISPARITY_PAYLOAD: CommonPreferredDisparityResponse = {
+  market: "kr",
+  state: "fresh",
+  asOf: "2026-05-14T06:00:00Z",
+  cards: [
+    {
+      id: "005930-005935",
+      commonSymbol: "005930",
+      commonName: "삼성전자",
+      preferredSymbol: "005935",
+      preferredName: "삼성전자우",
+      commonPrice: 100000,
+      preferredPrice: 78000,
+      disparityPct: 22,
+      preferredDiscountPct: 22,
+      preferredPremiumPct: -22,
+      zScore: 1.25,
+      tone: "discount" as const,
+      dataState: "fresh" as const,
+      primaryWindow: "20d",
+      windows: [
+        {
+          period: "20d" as const,
+          sampleCount: 3,
+          meanDisparityPct: 20,
+          minDisparityPct: 18,
+          maxDisparityPct: 22,
+          zScore: 1.25,
+          dataState: "fresh" as const,
+          emptyReason: null,
+        },
+      ],
+      source: {
+        source: "kis",
+        sourceOfTruth: "market_quote_snapshots",
+        asOf: "2026-05-14T06:00:00Z",
+        stale: false,
+        freshnessSec: 0,
+        warnings: [],
+      },
+      emptyReason: null,
+      formula: "((commonPrice - preferredPrice) / commonPrice) * 100",
+      warnings: [],
+      caution: "괴리율은 가격 차이 참고 지표이며 매수·매도 신호가 아닙니다.",
+    },
+  ],
+  warnings: [],
+  notes: ["MarketQuoteSnapshot 기반 read-only 표시입니다."],
+};
 
 const MARKET_PAYLOAD = {
   asOf: "2026-05-11T05:00:00Z",
@@ -73,7 +125,9 @@ function wrap(ui: React.ReactElement) {
 }
 
 beforeEach(() => {
+  vi.restoreAllMocks();
   vi.spyOn(marketApi, "fetchMarketDashboard").mockResolvedValue(MARKET_PAYLOAD);
+  vi.spyOn(disparityApi, "fetchCommonPreferredDisparity").mockResolvedValue(DISPARITY_PAYLOAD);
 });
 
 test("renders market dashboard sections and read-only copy", async () => {
@@ -83,6 +137,10 @@ test("renders market dashboard sections and read-only copy", async () => {
   expect(screen.getByRole("heading", { name: "시장" })).toBeInTheDocument();
   expect(screen.getByText("2,875.25")).toBeInTheDocument();
   expect(screen.getByText("가상자산 시장")).toBeInTheDocument();
+  expect(screen.getByText("보통주/우선주 괴리")).toBeInTheDocument();
+  expect(screen.getByText("삼성전자 / 삼성전자우")).toBeInTheDocument();
+  expect(screen.getByText(/005930 · 005935 · kis/)).toBeInTheDocument();
+  expect(screen.getByText(/매수·매도 신호가 아닙니다/)).toBeInTheDocument();
   expect(screen.getByRole("link", { name: "FX·매크로 상세" })).toHaveAttribute("href", "/invest/market/fx");
   expect(screen.getAllByText(/kimchi_premium: timeout/).length).toBeGreaterThan(0);
   expect(screen.getByText(/주문·매매 API를 호출하지 않습니다/)).toBeInTheDocument();

--- a/frontend/invest/src/__tests__/InvestHomeRoute.test.tsx
+++ b/frontend/invest/src/__tests__/InvestHomeRoute.test.tsx
@@ -8,6 +8,12 @@ import { InvestHomeRoute } from "../pages/desktop/DesktopHomePage";
 vi.mock("../hooks/useInvestHome", () => ({
   useInvestHome: () => ({ state: { status: "loading" }, reload: () => {} }),
 }));
+vi.mock("../hooks/useMarketDashboard", () => ({
+  useMarketDashboard: () => ({ state: { status: "loading" }, reload: () => {} }),
+}));
+vi.mock("../hooks/useMarketParity", () => ({
+  useMarketParity: () => ({ state: { status: "loading" }, reload: () => {} }),
+}));
 vi.mock("../desktop/useAccountPanel", () => ({
   useAccountPanel: () => ({ data: undefined, error: undefined, loading: true, reload: () => {} }),
 }));

--- a/frontend/invest/src/__tests__/MarketParityStrip.test.tsx
+++ b/frontend/invest/src/__tests__/MarketParityStrip.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { expect, test, vi } from "vitest";
+
+import { MarketParityStrip } from "../components/home/MarketParityStrip";
+import type { MarketParityResponse } from "../types/marketParity";
+
+const PAYLOAD: MarketParityResponse = {
+  market: "kr",
+  state: "partial",
+  asOf: "2026-05-14T00:00:00Z",
+  warnings: ["stablecoin_fx_source_not_approved"],
+  notes: ["read-only"],
+  cards: [
+    {
+      id: "ewy-kospi-implied-parity",
+      type: "index_implied_parity",
+      title: "EWY implied KOSPI parity",
+      baseSymbol: "KOSPI",
+      proxySymbol: "EWY",
+      basePrice: 2900,
+      proxyPrice: 72,
+      fxRate: 1360,
+      impliedValue: 2950,
+      premiumPct: 1.72,
+      tone: "premium",
+      formula: "((proxyPrice * fxRate * divisor) / basePrice - 1) * 100",
+      dataState: "fresh",
+      source: {
+        source: "fixture/naver+yahoo",
+        sourceOfTruth: "approved_fixture_provider",
+        asOf: "2026-05-14T00:00:00Z",
+        stale: false,
+        freshnessSec: 60,
+        warnings: [],
+      },
+    },
+    {
+      id: "hyperliquid-smsn",
+      type: "synthetic_kr_stock_parity",
+      title: "삼성전자 synthetic parity",
+      baseSymbol: "005930",
+      syntheticSymbol: "xyz:SMSN",
+      premiumPct: null,
+      tone: "unknown",
+      dataState: "disabled",
+      emptyReason: "hyperliquid_source_not_approved",
+      source: {
+        source: "hyperliquid",
+        sourceOfTruth: "approval_gate",
+        asOf: null,
+        stale: true,
+        freshnessSec: null,
+        warnings: ["hyperliquid_source_not_approved"],
+      },
+    },
+  ],
+};
+
+test("renders market parity cards as reference observations, not recommendations", () => {
+  render(<MarketParityStrip state={{ status: "ready", data: PAYLOAD }} />);
+
+  expect(screen.getByText("괴리 참고")).toBeInTheDocument();
+  expect(screen.getByText(/매수·매도 추천이 아닙니다/)).toBeInTheDocument();
+  expect(screen.getByText("EWY implied KOSPI parity")).toBeInTheDocument();
+  expect(screen.getByText("+1.72%")).toBeInTheDocument();
+  expect(screen.getByText("fixture/naver+yahoo")).toBeInTheDocument();
+  expect(screen.getByText(/일부 다리가 비어 있어/)).toBeInTheDocument();
+  expect(screen.getByText(/hyperliquid_source_not_approved/)).toBeInTheDocument();
+});
+
+test("renders loading, empty, and error states", () => {
+  const reload = vi.fn();
+  const { rerender } = render(<MarketParityStrip state={{ status: "loading" }} reload={reload} />);
+  expect(screen.getByTestId("market-parity-loading")).toBeInTheDocument();
+
+  rerender(<MarketParityStrip state={{ status: "ready", data: { ...PAYLOAD, state: "missing", cards: [], emptyReason: "no approved parity legs" } }} />);
+  expect(screen.getByText("no approved parity legs")).toBeInTheDocument();
+
+  rerender(<MarketParityStrip state={{ status: "error", message: "/invest/api/market-parity 500" }} reload={reload} />);
+  expect(screen.getByText(/일시적으로 불러오지 못했습니다/)).toBeInTheDocument();
+  fireEvent.click(screen.getByRole("button", { name: "재시도" }));
+  expect(reload).toHaveBeenCalledTimes(1);
+});

--- a/frontend/invest/src/__tests__/StockDetailPage.test.tsx
+++ b/frontend/invest/src/__tests__/StockDetailPage.test.tsx
@@ -1,12 +1,13 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
-import { beforeEach, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { StockDetailPage } from "../pages/stock-detail/StockDetailPage";
 import * as stockApi from "../api/stockDetail";
 import type {
   StockDetailCandlesResponse,
   StockDetailNewsResponse,
   StockDetailOrdersResponse,
+  StockDetailResearchConsensusResponse,
   StockDetailResponse,
 } from "../types/stockDetail";
 
@@ -181,9 +182,59 @@ const news: StockDetailNewsResponse = {
   meta: { warnings: [] },
 };
 
-function renderPage() {
+const researchConsensus: StockDetailResearchConsensusResponse = {
+  symbol: "QQQM",
+  market: "us",
+  displayName: "Invesco NASDAQ 100 ETF",
+  state: "ready",
+  dataState: "fresh",
+  emptyReason: null,
+  warnings: [],
+  sourceOfTruth: "analyst_opinions_and_research_reports",
+  asOf: "2026-05-10T09:31:00Z",
+  stale: false,
+  consensus: {
+    source: "yfinance",
+    buyCount: 7,
+    holdCount: 2,
+    sellCount: 0,
+    strongBuyCount: 3,
+    totalCount: 9,
+    avgTargetPrice: 235,
+    medianTargetPrice: 236,
+    minTargetPrice: 220,
+    maxTargetPrice: 250,
+    upsidePct: 11.2,
+    currentPrice: 211.34,
+  },
+  citations: [
+    {
+      source: "issuer_ir",
+      title: "QQQM holdings note",
+      analyst: "ETF Desk",
+      published_at: "2026-05-10T08:30:00Z",
+      category: "ETF",
+      detail_url: "https://example.com/research/qqqm",
+      pdf_url: null,
+      excerpt: "Nasdaq 100 구성 종목 변화와 기술주 집중도를 요약합니다.",
+      symbol_candidates: [{ symbol: "QQQM", market: "us", source: "ticker" }],
+      attribution_publisher: "Issuer",
+      attribution_copyright_notice: "metadata only",
+    },
+  ],
+  freshness: {
+    isReady: true,
+    isStale: false,
+    latestRunUuid: "run-1",
+    latestFinishedAt: "2026-05-10T09:00:00Z",
+    latestReportCount: 1,
+    maxAgeHours: 24,
+  },
+};
+
+function renderPage(path = "/invest/stocks/us/QQQM") {
   return render(
-    <MemoryRouter basename="/invest" initialEntries={["/invest/stocks/us/QQQM"]}>
+    <MemoryRouter basename="/invest" initialEntries={[path]}>
       <Routes>
         <Route path="/stocks/:market/:symbol" element={<StockDetailPage />} />
       </Routes>
@@ -196,6 +247,11 @@ beforeEach(() => {
   vi.spyOn(stockApi, "fetchStockDetailCandles").mockResolvedValue(candles);
   vi.spyOn(stockApi, "fetchStockDetailOrders").mockResolvedValue(orders);
   vi.spyOn(stockApi, "fetchStockDetailNews").mockResolvedValue(news);
+  vi.spyOn(stockApi, "fetchStockDetailResearchConsensus").mockResolvedValue(researchConsensus);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 test("renders the QQQM stock detail shell from the read-only backend contract", async () => {
@@ -218,6 +274,87 @@ test("renders the QQQM stock detail shell from the read-only backend contract", 
   await waitFor(() => expect(stockApi.fetchStockDetailCandles).toHaveBeenCalledWith({ market: "us", symbol: "QQQM", period: "1d" }));
   expect(await screen.findByTestId("stock-detail-chart")).toHaveTextContent("3개 캔들");
   expect(await screen.findByTestId("stock-detail-news")).toHaveTextContent("QQQM tracks Nasdaq rally");
+});
+
+test("renders research consensus ready state with analyst metrics and compact citations", async () => {
+  renderPage();
+
+  const card = await screen.findByTestId("stock-detail-research-consensus");
+  expect(card).toHaveTextContent("리서치 · 컨센서스");
+  expect(card).toHaveTextContent("최신");
+  expect(card).toHaveTextContent("Buy");
+  expect(card).toHaveTextContent("7/9");
+  expect(card).toHaveTextContent("QQQM holdings note");
+  expect(card).toHaveTextContent("ETF Desk");
+  expect(card).not.toHaveTextContent("raw_payload");
+  await waitFor(() => expect(stockApi.fetchStockDetailResearchConsensus).toHaveBeenCalledWith({ market: "us", symbol: "QQQM" }));
+});
+
+test("renders research consensus empty state when no opinions or citations are available", async () => {
+  vi.mocked(stockApi.fetchStockDetailResearchConsensus).mockResolvedValue({
+    ...researchConsensus,
+    state: "missing",
+    dataState: "missing",
+    emptyReason: "no_analyst_consensus_or_research_reports",
+    sourceOfTruth: "none",
+    consensus: null,
+    citations: [],
+  });
+
+  renderPage();
+
+  const card = await screen.findByTestId("stock-detail-research-consensus");
+  expect(card).toHaveTextContent("데이터 없음");
+  expect(card).toHaveTextContent("애널리스트 컨센서스와 리서치 인용이 없습니다.");
+});
+
+test("renders research consensus stale and warning state", async () => {
+  vi.mocked(stockApi.fetchStockDetailResearchConsensus).mockResolvedValue({
+    ...researchConsensus,
+    state: "partial",
+    dataState: "stale",
+    stale: true,
+    warnings: ["research_reports_stale"],
+    sourceOfTruth: "research_reports",
+    consensus: null,
+    freshness: { ...researchConsensus.freshness, isReady: false, isStale: true },
+  });
+
+  renderPage();
+
+  const card = await screen.findByTestId("stock-detail-research-consensus");
+  expect(card).toHaveTextContent("오래된 데이터");
+  expect(card).toHaveTextContent("컨센서스 없이 리서치 인용만 표시합니다.");
+  expect(card).toHaveTextContent("경고: research_reports_stale");
+});
+
+test("renders research consensus fetch error state without blocking the page", async () => {
+  vi.mocked(stockApi.fetchStockDetailResearchConsensus).mockRejectedValue(new Error("offline"));
+
+  renderPage();
+
+  expect(await screen.findByTestId("stock-detail-shell")).toBeInTheDocument();
+  expect(await screen.findByTestId("stock-detail-research-consensus")).toHaveTextContent("리서치 데이터를 사용할 수 없습니다.");
+});
+
+test("does not fetch or render research consensus for crypto symbols", async () => {
+  vi.mocked(stockApi.fetchStockDetail).mockResolvedValue({
+    ...aboveFold,
+    symbol: "KRW-BTC",
+    market: "crypto",
+    displayName: "Bitcoin",
+    exchange: "UPBIT",
+    currency: "KRW",
+    assetCategory: "crypto",
+    naverEnrichment: null,
+    fxSensitivity: null,
+  });
+
+  renderPage("/invest/stocks/crypto/KRW-BTC");
+
+  expect(await screen.findByTestId("stock-detail-shell")).toBeInTheDocument();
+  expect(stockApi.fetchStockDetailResearchConsensus).not.toHaveBeenCalled();
+  expect(screen.queryByTestId("stock-detail-research-consensus")).not.toBeInTheDocument();
 });
 
 test("keeps buy/sell controls disabled and shows explicit orderbook plus empty order history states", async () => {

--- a/frontend/invest/src/__tests__/marketParity.api.test.ts
+++ b/frontend/invest/src/__tests__/marketParity.api.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, expect, test, vi } from "vitest";
+
+import { fetchMarketParity } from "../api/marketParity";
+
+const PAYLOAD = {
+  market: "kr",
+  state: "partial",
+  asOf: "2026-05-14T00:00:00Z",
+  cards: [],
+  warnings: [],
+  notes: [],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("fetchMarketParity reads the read-only dashed market parity endpoint", async () => {
+  const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify(PAYLOAD), { status: 200, headers: { "content-type": "application/json" } }),
+  );
+
+  await expect(fetchMarketParity()).resolves.toEqual(PAYLOAD);
+  expect(fetchMock).toHaveBeenCalledWith("/invest/api/market-parity?market=kr&includeDisabled=true&limit=8", {
+    credentials: "include",
+    signal: undefined,
+  });
+});
+
+test("fetchMarketParity raises a scrubbed endpoint/status error", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("nope", { status: 503 }));
+
+  await expect(fetchMarketParity()).rejects.toThrow("/invest/api/market-parity 503");
+});

--- a/frontend/invest/src/api/commonPreferredDisparity.ts
+++ b/frontend/invest/src/api/commonPreferredDisparity.ts
@@ -1,0 +1,24 @@
+import type { CommonPreferredDisparityResponse } from "../types/commonPreferredDisparity";
+
+export type CommonPreferredDisparityParams = {
+  symbols?: string;
+  limit?: number;
+  maxStaleDays?: number;
+  signal?: AbortSignal;
+};
+
+export async function fetchCommonPreferredDisparity(
+  params: CommonPreferredDisparityParams = {},
+): Promise<CommonPreferredDisparityResponse> {
+  const q = new URLSearchParams();
+  if (params.symbols?.trim()) q.set("symbols", params.symbols.trim());
+  if (params.limit !== undefined) q.set("limit", String(params.limit));
+  if (params.maxStaleDays !== undefined) q.set("maxStaleDays", String(params.maxStaleDays));
+  const suffix = q.toString() ? `?${q.toString()}` : "";
+  const res = await fetch(`/invest/api/disparity/common-preferred${suffix}`, {
+    credentials: "include",
+    signal: params.signal,
+  });
+  if (!res.ok) throw new Error(`/invest/api/disparity/common-preferred ${res.status}`);
+  return res.json();
+}

--- a/frontend/invest/src/api/marketParity.ts
+++ b/frontend/invest/src/api/marketParity.ts
@@ -1,0 +1,12 @@
+import type { MarketParityResponse } from "../types/marketParity";
+
+export async function fetchMarketParity(signal?: AbortSignal): Promise<MarketParityResponse> {
+  const res = await fetch("/invest/api/market-parity?market=kr&includeDisabled=true&limit=8", {
+    credentials: "include",
+    signal,
+  });
+  if (!res.ok) {
+    throw new Error(`/invest/api/market-parity ${res.status}`);
+  }
+  return res.json();
+}

--- a/frontend/invest/src/api/stockDetail.ts
+++ b/frontend/invest/src/api/stockDetail.ts
@@ -3,6 +3,7 @@ import type {
   StockDetailMarket,
   StockDetailNewsResponse,
   StockDetailOrdersResponse,
+  StockDetailResearchConsensusResponse,
   StockDetailResponse,
 } from "../types/stockDetail";
 
@@ -21,6 +22,13 @@ export async function fetchStockDetail(params: {
   symbol: string;
 }): Promise<StockDetailResponse> {
   return getJson<StockDetailResponse>(stockDetailPath(params.market, params.symbol));
+}
+
+export async function fetchStockDetailResearchConsensus(params: {
+  market: StockDetailMarket;
+  symbol: string;
+}): Promise<StockDetailResearchConsensusResponse> {
+  return getJson<StockDetailResearchConsensusResponse>(`${stockDetailPath(params.market, params.symbol)}/research-consensus`);
 }
 
 export async function fetchStockDetailCandles(params: {

--- a/frontend/invest/src/components/CommonPreferredDisparityCard.tsx
+++ b/frontend/invest/src/components/CommonPreferredDisparityCard.tsx
@@ -1,0 +1,94 @@
+import { Card } from "../ds";
+import type { CommonPreferredDisparityCard, CommonPreferredDisparityResponse, DisparityState } from "../types/commonPreferredDisparity";
+
+const STATE_LABEL: Record<DisparityState, string> = {
+  fresh: "정상",
+  partial: "부분",
+  stale: "오래됨",
+  missing: "없음",
+};
+
+const STATE_COLOR: Record<DisparityState, string> = {
+  fresh: "#16a34a",
+  partial: "#ca8a04",
+  stale: "#ca8a04",
+  missing: "#dc2626",
+};
+
+function fmtPct(value?: number | null) {
+  return value == null ? "—" : `${value >= 0 ? "+" : ""}${value.toFixed(2)}%`;
+}
+
+function fmtPrice(value?: number | null) {
+  return value == null ? "—" : `${Math.round(value).toLocaleString()}원`;
+}
+
+function StatePill({ state }: { state: DisparityState }) {
+  return (
+    <span style={{ borderRadius: 999, padding: "3px 8px", fontSize: 12, fontWeight: 800, color: "white", background: STATE_COLOR[state] }}>
+      {STATE_LABEL[state]}
+    </span>
+  );
+}
+
+function DisparityMiniCard({ card }: { card: CommonPreferredDisparityCard }) {
+  const window = card.windows.find((w) => w.period === card.primaryWindow) ?? card.windows[0];
+  return (
+    <div style={{ border: "1px solid var(--divider)", borderRadius: 16, padding: 14, display: "grid", gap: 8 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "start" }}>
+        <div>
+          <div style={{ fontWeight: 900 }}>{card.commonName} / {card.preferredName}</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{card.commonSymbol} · {card.preferredSymbol} · {card.source.source}</div>
+        </div>
+        <StatePill state={card.dataState} />
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 8, fontFeatureSettings: '"tnum"' }}>
+        <div>
+          <div style={{ color: "var(--fg-3)", fontSize: 11 }}>괴리율</div>
+          <div style={{ fontSize: 22, fontWeight: 900, color: card.tone === "discount" ? "var(--gain)" : card.tone === "premium" ? "var(--loss)" : "var(--fg-1)" }}>{fmtPct(card.disparityPct)}</div>
+        </div>
+        <div>
+          <div style={{ color: "var(--fg-3)", fontSize: 11 }}>보통/우선</div>
+          <div style={{ fontSize: 13, fontWeight: 800 }}>{fmtPrice(card.commonPrice)}</div>
+          <div style={{ fontSize: 13, fontWeight: 800 }}>{fmtPrice(card.preferredPrice)}</div>
+        </div>
+        <div>
+          <div style={{ color: "var(--fg-3)", fontSize: 11 }}>{card.primaryWindow} z-score</div>
+          <div style={{ fontSize: 18, fontWeight: 900 }}>{card.zScore == null ? "—" : card.zScore.toFixed(2)}</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 11 }}>n={window?.sampleCount ?? 0}</div>
+        </div>
+      </div>
+      {card.source.asOf && <div style={{ color: "var(--fg-3)", fontSize: 11 }}>asOf {card.source.asOf}</div>}
+      {(card.warnings.length > 0 || card.emptyReason) && <div style={{ color: "var(--warn)", fontSize: 12 }}>⚠ {[card.emptyReason, ...card.warnings].filter(Boolean).join(" · ")}</div>}
+      <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{card.caution}</div>
+    </div>
+  );
+}
+
+export function CommonPreferredDisparityCardView({ data }: { data: CommonPreferredDisparityResponse }) {
+  return (
+    <Card>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "start", marginBottom: 14 }}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: 20, letterSpacing: "-0.03em" }}>보통주/우선주 괴리</h2>
+          <p style={{ margin: "5px 0 0", color: "var(--fg-2)", fontSize: 13 }}>005930/005935부터 표시하는 read-only 참고 카드입니다.</p>
+          <div style={{ marginTop: 6, color: "var(--fg-3)", fontSize: 12 }}>asOf {data.asOf}</div>
+        </div>
+        <StatePill state={data.state} />
+      </div>
+      {data.cards.length === 0 ? (
+        <div style={{ color: "var(--fg-3)", fontSize: 13 }}>{data.emptyReason ?? "표시할 괴리 데이터가 없습니다."}</div>
+      ) : (
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 12 }}>
+          {data.cards.map((card) => <DisparityMiniCard key={card.id} card={card} />)}
+        </div>
+      )}
+      {(data.warnings.length > 0 || data.notes.length > 0) && (
+        <div style={{ marginTop: 12, display: "grid", gap: 4, color: "var(--fg-3)", fontSize: 12 }}>
+          {data.warnings.map((warning) => <div key={warning} style={{ color: "var(--warn)" }}>⚠ {warning}</div>)}
+          {data.notes.map((note) => <div key={note}>• {note}</div>)}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/invest/src/components/home/MarketParityStrip.tsx
+++ b/frontend/invest/src/components/home/MarketParityStrip.tsx
@@ -1,0 +1,185 @@
+import { formatRelativeTime } from "../../format/relativeTime";
+import type { MarketParityHookState } from "../../hooks/useMarketParity";
+import type { MarketParityCard, MarketParityResponse, MarketParityTone } from "../../types/marketParity";
+
+const TONE_COLOR: Record<MarketParityTone, string> = {
+  premium: "var(--loss)",
+  discount: "var(--gain)",
+  flat: "var(--flat)",
+  unknown: "var(--fg-3)",
+};
+
+const TONE_LABEL: Record<MarketParityTone, string> = {
+  premium: "프리미엄",
+  discount: "디스카운트",
+  flat: "중립",
+  unknown: "미확인",
+};
+
+function formatPremium(value: number | null | undefined): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return "괴리율 없음";
+  const sign = value > 0 ? "+" : "";
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+function sourceFreshness(card: MarketParityCard): string {
+  if (card.source.asOf) {
+    const relative = formatRelativeTime(card.source.asOf);
+    if (relative) return card.source.stale ? `${relative} · 지연` : relative;
+  }
+  if (card.source.freshnessSec != null) {
+    const minutes = Math.floor(card.source.freshnessSec / 60);
+    return minutes < 1 ? "방금" : `${minutes}분 전`;
+  }
+  return card.source.stale ? "지연 가능" : "시각 미확인";
+}
+
+function stateCopy(data: MarketParityResponse): string {
+  if (data.state === "fresh") return "실시간 판단 대신 참고용으로만 보세요.";
+  if (data.state === "partial") return "일부 다리가 비어 있어 괴리 관찰만 가능합니다.";
+  if (data.state === "stale") return "오래된 값이 포함되어 방향성 참고만 가능합니다.";
+  if (data.state === "disabled") return "승인되지 않은 데이터 다리는 비활성화되어 있습니다.";
+  return data.emptyReason ?? "표시할 괴리 관찰값이 없습니다.";
+}
+
+function sourceBadge(card: MarketParityCard) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        border: "1px solid var(--border)",
+        borderRadius: 999,
+        padding: "2px 7px",
+        color: "var(--fg-3)",
+        fontSize: 10,
+        fontWeight: 700,
+        maxWidth: "100%",
+      }}
+      title={card.source.sourceOfTruth}
+    >
+      {card.source.source}
+      {card.source.stale ? " · stale" : ""}
+    </span>
+  );
+}
+
+function cardSubline(card: MarketParityCard): string {
+  const parts = [card.baseSymbol ?? card.baseName, card.proxySymbol ?? card.syntheticSymbol].filter(Boolean);
+  if (parts.length > 0) return parts.join(" ↔ ");
+  if (card.emptyReason) return card.emptyReason;
+  return card.formula ?? "관찰식 준비 중";
+}
+
+function ParityCard({ card }: { card: MarketParityCard }) {
+  const color = TONE_COLOR[card.tone];
+  const muted = card.dataState === "missing" || card.dataState === "disabled";
+  return (
+    <div
+      data-testid="market-parity-card"
+      style={{
+        minHeight: 112,
+        padding: 12,
+        background: "var(--surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 14,
+        boxShadow: "var(--shadow-1)",
+        opacity: muted ? 0.74 : 1,
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "flex-start" }}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontSize: 12, fontWeight: 800, color: "var(--fg-2)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {card.title}
+          </div>
+          <div style={{ fontSize: 11, color: "var(--fg-3)", marginTop: 3, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+            {cardSubline(card)}
+          </div>
+        </div>
+        {sourceBadge(card)}
+      </div>
+
+      <div style={{ display: "flex", alignItems: "baseline", gap: 7, marginTop: 10 }}>
+        <span style={{ color, fontSize: 18, fontWeight: 900, fontFeatureSettings: '"tnum"' }}>
+          {formatPremium(card.premiumPct)}
+        </span>
+        <span style={{ color, fontSize: 11, fontWeight: 800 }}>{TONE_LABEL[card.tone]}</span>
+      </div>
+
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 8, marginTop: 9, fontSize: 11, color: "var(--fg-3)" }}>
+        <span>{sourceFreshness(card)}</span>
+        <span>{card.dataState}</span>
+      </div>
+      {card.source.warnings.length > 0 && (
+        <div style={{ marginTop: 6, color: "var(--warn)", fontSize: 10, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          {card.source.warnings[0]}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LoadingCards() {
+  return (
+    <div data-testid="market-parity-loading" style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 10 }}>
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} style={{ minHeight: 112, padding: 12, background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 14, boxShadow: "var(--shadow-1)" }}>
+          <div style={{ width: "60%", height: 12, borderRadius: 999, background: "var(--surface-2)" }} />
+          <div style={{ width: "34%", height: 22, borderRadius: 999, background: "var(--surface-2)", marginTop: 16 }} />
+          <div style={{ width: "70%", height: 10, borderRadius: 999, background: "var(--surface-2)", marginTop: 18 }} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function MarketParityStrip({ state, reload }: { state: MarketParityHookState; reload?: () => void }) {
+  return (
+    <section data-testid="market-parity-strip" aria-label="시장 괴리 참고 카드">
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "end", gap: 12, marginBottom: 10 }}>
+        <div>
+          <h2 style={{ margin: 0, fontSize: 15, fontWeight: 800, color: "var(--fg-2)", letterSpacing: "-0.01em" }}>
+            괴리 참고
+          </h2>
+          <div style={{ marginTop: 3, color: "var(--fg-3)", fontSize: 12 }}>
+            ETF·환율·김치프리미엄 괴리 관찰용입니다. 매수·매도 추천이 아닙니다.
+          </div>
+        </div>
+        {state.status === "ready" && (
+          <div style={{ color: "var(--fg-3)", fontSize: 11 }}>기준 {formatRelativeTime(state.data.asOf) ?? "시각 미확인"}</div>
+        )}
+      </div>
+
+      {state.status === "loading" && <LoadingCards />}
+
+      {state.status === "error" && (
+        <div role="status" style={{ padding: 14, background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 14, color: "var(--fg-3)", fontSize: 12 }}>
+          괴리 참고 카드를 일시적으로 불러오지 못했습니다.
+          {reload && (
+            <button type="button" onClick={reload} style={{ marginLeft: 8, padding: "3px 9px", borderRadius: 8, border: "1px solid var(--border)", background: "var(--surface-2)", color: "var(--fg-1)", cursor: "pointer" }}>
+              재시도
+            </button>
+          )}
+        </div>
+      )}
+
+      {state.status === "ready" && state.data.cards.length === 0 && (
+        <div role="status" style={{ padding: 14, background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 14, color: "var(--fg-3)", fontSize: 12 }}>
+          {stateCopy(state.data)}
+        </div>
+      )}
+
+      {state.status === "ready" && state.data.cards.length > 0 && (
+        <>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 10 }}>
+            {state.data.cards.slice(0, 4).map((card) => <ParityCard key={card.id} card={card} />)}
+          </div>
+          <div style={{ marginTop: 8, color: state.data.state === "partial" ? "var(--warn)" : "var(--fg-3)", fontSize: 11 }}>
+            {stateCopy(state.data)}
+            {state.data.warnings.length > 0 ? ` · ${state.data.warnings[0]}` : ""}
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/invest/src/hooks/useCommonPreferredDisparity.ts
+++ b/frontend/invest/src/hooks/useCommonPreferredDisparity.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+import { fetchCommonPreferredDisparity } from "../api/commonPreferredDisparity";
+import type { CommonPreferredDisparityResponse } from "../types/commonPreferredDisparity";
+
+type State =
+  | { status: "loading" }
+  | { status: "ready"; data: CommonPreferredDisparityResponse }
+  | { status: "error"; message: string };
+
+export function useCommonPreferredDisparity() {
+  const [state, setState] = useState<State>({ status: "loading" });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState({ status: "loading" });
+    fetchCommonPreferredDisparity({ symbols: "005930,005935", limit: 6, signal: controller.signal })
+      .then((data) => setState({ status: "ready", data }))
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        setState({ status: "error", message: String(err?.message ?? err) });
+      });
+    return () => controller.abort();
+  }, []);
+
+  return state;
+}

--- a/frontend/invest/src/hooks/useMarketParity.ts
+++ b/frontend/invest/src/hooks/useMarketParity.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import { fetchMarketParity } from "../api/marketParity";
+import type { MarketParityResponse } from "../types/marketParity";
+
+export type MarketParityHookState =
+  | { status: "loading" }
+  | { status: "ready"; data: MarketParityResponse }
+  | { status: "error"; message: string };
+
+export function useMarketParity() {
+  const [state, setState] = useState<MarketParityHookState>({ status: "loading" });
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState({ status: "loading" });
+    fetchMarketParity(controller.signal)
+      .then((data) => setState({ status: "ready", data }))
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        setState({ status: "error", message: String(err?.message ?? err) });
+      });
+    return () => controller.abort();
+  }, [nonce]);
+
+  return { state, reload: () => setNonce((n) => n + 1) };
+}

--- a/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
@@ -18,10 +18,12 @@ import type { AccountFilterKey } from "../../desktop/LeftContextRail";
 import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useInvestHome } from "../../hooks/useInvestHome";
 import { useMarketDashboard } from "../../hooks/useMarketDashboard";
+import { useMarketParity } from "../../hooks/useMarketParity";
 import { useViewport } from "../../hooks/useViewport";
 import { scopeGroupedToSource } from "../../desktop/scopeHoldings";
 import { DesktopHero } from "../../components/home/DesktopHero";
 import { MarketStrip, marketDashboardToStripItems } from "../../components/home/MarketStrip";
+import { MarketParityStrip } from "../../components/home/MarketParityStrip";
 import { MobileHomePage } from "../mobile/MobileHomePage";
 import { Icon } from "../../ds";
 import type { AssetCategoryKey } from "../../components/AssetCategoryFilter";
@@ -89,6 +91,7 @@ const NAV_CARDS: NavCard[] = [
 export function DesktopHomePage() {
   const home = useInvestHome();
   const market = useMarketDashboard();
+  const marketParity = useMarketParity();
   const [account, setAccount] = useState<AccountFilterKey>("all");
   const [category] = useState<AssetCategoryKey>("all");
 
@@ -168,6 +171,9 @@ export function DesktopHomePage() {
 
               {/* Market index strip — live data from market dashboard */}
               <MarketStrip items={marketStripItems} />
+
+              {/* Market parity strip — read-only reference/괴리 observation, not recommendations */}
+              <MarketParityStrip state={marketParity.state} reload={marketParity.reload} />
 
               {/* Navigation cards — market-entry shortcuts to all /invest surfaces */}
               <div>

--- a/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
@@ -57,6 +57,12 @@ const NAV_CARDS: NavCard[] = [
     icon: <Icon name="bell" size={20} />,
   },
   {
+    to: "/insights",
+    label: "인사이트",
+    desc: "괴리·패리티 read-only 관찰",
+    icon: <Icon name="chart" size={20} />,
+  },
+  {
     to: "/discover",
     label: "발견",
     desc: "투자 아이디어 및 이슈 탐색",

--- a/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
@@ -1,0 +1,92 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { CommonPreferredDisparityCardView } from "../../components/CommonPreferredDisparityCard";
+import { MarketParityStrip } from "../../components/home/MarketParityStrip";
+import { DesktopShell } from "../../desktop/DesktopShell";
+import { Card } from "../../ds";
+import { useCommonPreferredDisparity } from "../../hooks/useCommonPreferredDisparity";
+import { useMarketParity } from "../../hooks/useMarketParity";
+
+function SectionStatus({ children }: { children: ReactNode }) {
+  return (
+    <div
+      role="status"
+      style={{
+        padding: 14,
+        background: "var(--surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 14,
+        color: "var(--fg-3)",
+        fontSize: 13,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function DecisionCard() {
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 8 }}>
+        <div style={{ fontSize: 12, color: "var(--fg-3)", fontWeight: 800 }}>ROB-253 decision</div>
+        <h1 style={{ margin: 0, fontSize: 28, letterSpacing: "-0.05em" }}>인사이트</h1>
+        <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 14, lineHeight: 1.6 }}>
+          홈에는 compact 요약만 남기고, 괴리·패리티처럼 해석 주의가 필요한 read-only 관찰 카드는
+          /invest/insights에서 모아 봅니다. 종목별 리서치 컨센서스는 symbol context가 필요하므로
+          개별 종목 상세 화면에 유지합니다.
+        </p>
+      </div>
+    </Card>
+  );
+}
+
+function ReadOnlyGuardrailCard() {
+  return (
+    <Card>
+      <div style={{ fontWeight: 900, marginBottom: 8 }}>읽기 전용 가드레일</div>
+      <ul style={{ margin: 0, paddingLeft: 18, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.7 }}>
+        <li>주문·매매·watch mutation API를 호출하지 않습니다.</li>
+        <li>기존 read-only /invest/api 응답만 표시합니다.</li>
+        <li>데이터 수집 활성화·백필·production DB write는 별도 승인 후 진행합니다.</li>
+        <li>raoni.xyz API에 production 의존성을 추가하지 않습니다.</li>
+      </ul>
+    </Card>
+  );
+}
+
+export function DesktopInsightsPage() {
+  const marketParity = useMarketParity();
+  const disparity = useCommonPreferredDisparity();
+
+  return (
+    <DesktopShell
+      center={
+        <div style={{ padding: 24, display: "grid", gap: 16 }}>
+          <DecisionCard />
+
+          <Card>
+            <MarketParityStrip state={marketParity.state} reload={marketParity.reload} />
+          </Card>
+
+          {disparity.status === "loading" && <SectionStatus>보통주/우선주 괴리 데이터를 불러오는 중…</SectionStatus>}
+          {disparity.status === "error" && <SectionStatus>보통주/우선주 괴리 데이터를 일시적으로 불러오지 못했습니다.</SectionStatus>}
+          {disparity.status === "ready" && <CommonPreferredDisparityCardView data={disparity.data} />}
+        </div>
+      }
+      right={
+        <div style={{ display: "grid", gap: 12 }}>
+          <ReadOnlyGuardrailCard />
+          <Card>
+            <div style={{ fontWeight: 900, marginBottom: 8 }}>관련 화면</div>
+            <div style={{ display: "grid", gap: 8, fontSize: 13 }}>
+              <Link to="/" style={{ color: "var(--fg-1)", textDecoration: "none" }}>홈 compact 요약</Link>
+              <Link to="/market" style={{ color: "var(--fg-1)", textDecoration: "none" }}>시장 대시보드</Link>
+              <Link to="/stocks/kr/005930" style={{ color: "var(--fg-1)", textDecoration: "none" }}>종목 상세 리서치 예시</Link>
+            </div>
+          </Card>
+        </div>
+      }
+    />
+  );
+}

--- a/frontend/invest/src/pages/desktop/DesktopMarketPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopMarketPage.tsx
@@ -138,6 +138,12 @@ export function DesktopMarketPage() {
             </div>
             <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
               <Link
+                to="/insights"
+                style={{ padding: "8px 12px", borderRadius: 10, border: "1px solid var(--border)", background: "var(--surface)", color: "var(--fg-1)", fontWeight: 800, textDecoration: "none" }}
+              >
+                인사이트
+              </Link>
+              <Link
                 to="/market/fx"
                 style={{ padding: "8px 12px", borderRadius: 10, border: "1px solid var(--border)", background: "var(--surface)", color: "var(--fg-1)", fontWeight: 800, textDecoration: "none" }}
               >

--- a/frontend/invest/src/pages/desktop/DesktopMarketPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopMarketPage.tsx
@@ -1,6 +1,8 @@
 import { Link } from "react-router-dom";
+import { CommonPreferredDisparityCardView } from "../../components/CommonPreferredDisparityCard";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { Card } from "../../ds";
+import { useCommonPreferredDisparity } from "../../hooks/useCommonPreferredDisparity";
 import { useMarketDashboard } from "../../hooks/useMarketDashboard";
 import type { MarketDashboardMetric, MarketDashboardSection, MarketDashboardState, MarketDashboardTone } from "../../types/marketDashboard";
 
@@ -120,6 +122,7 @@ function SectionCard({ section }: { section: MarketDashboardSection }) {
 
 export function DesktopMarketPage() {
   const { state, reload } = useMarketDashboard();
+  const disparityState = useCommonPreferredDisparity();
   const data = state.status === "ready" ? state.data : null;
 
   return (
@@ -167,6 +170,9 @@ export function DesktopMarketPage() {
                   <div style={{ marginTop: 10, color: "var(--warn)", fontSize: 12 }}>{data.warnings.map((w) => `⚠ ${w}`).join(" · ")}</div>
                 )}
               </Card>
+              {disparityState.status === "loading" && <Card>보통주/우선주 괴리 데이터를 불러오는 중…</Card>}
+              {disparityState.status === "error" && <Card><span style={{ color: "var(--danger)" }}>보통주/우선주 괴리 데이터를 일시적으로 불러오지 못했습니다.</span></Card>}
+              {disparityState.status === "ready" && <CommonPreferredDisparityCardView data={disparityState.data} />}
               {data.sections.map((section) => <SectionCard key={section.id} section={section} />)}
             </>
           )}

--- a/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
+++ b/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
@@ -7,6 +7,7 @@ import {
   fetchStockDetailCandles,
   fetchStockDetailNews,
   fetchStockDetailOrders,
+  fetchStockDetailResearchConsensus,
 } from "../../api/stockDetail";
 import type {
   StockDetailCandlesResponse,
@@ -14,6 +15,7 @@ import type {
   StockDetailMarket,
   StockDetailNewsResponse,
   StockDetailOrdersResponse,
+  StockDetailResearchConsensusResponse,
   StockDetailResponse,
 } from "../../types/stockDetail";
 
@@ -220,6 +222,48 @@ function ProfileCard({ data }: { data: StockDetailResponse }) {
   );
 }
 
+function ResearchConsensusCard({ data, error }: { data: StockDetailResearchConsensusResponse | undefined; error: string | undefined }) {
+  const consensus = data?.consensus;
+  const stateLabel = data?.dataState === "stale" ? "오래된 데이터" : data?.state === "partial" ? "일부 데이터" : data?.state === "missing" ? "데이터 없음" : "최신";
+  return (
+    <Card data-testid="stock-detail-research-consensus">
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+        <div>
+          <h2 style={{ margin: "0 0 8px", fontSize: 16 }}>리서치 · 컨센서스</h2>
+          {!data && !error ? <p style={{ margin: 0, color: "var(--fg-3)" }}>리서치 데이터를 불러오는 중입니다…</p> : null}
+          {error ? <p style={{ margin: 0, color: "var(--danger)" }}>리서치 데이터를 사용할 수 없습니다.</p> : null}
+        </div>
+        {data ? <Pill tone={data.dataState === "fresh" ? "accent" : data.dataState === "stale" ? "paper" : "loss"}>{stateLabel}</Pill> : null}
+      </div>
+      {data && consensus ? (
+        <div style={{ marginTop: 12, display: "grid", gridTemplateColumns: "repeat(4, minmax(0, 1fr))", gap: 10 }}>
+          <Metric label="Buy" value={`${consensus.buyCount}/${consensus.totalCount}`} />
+          <Metric label="Hold" value={`${consensus.holdCount}`} />
+          <Metric label="목표가 평균" value={consensus.avgTargetPrice == null ? "−" : Math.round(consensus.avgTargetPrice).toLocaleString("ko-KR")} />
+          <Metric label="상승여력" value={fmtPct(consensus.upsidePct)} />
+        </div>
+      ) : null}
+      {data && !consensus && !error ? (
+        <p style={{ margin: "10px 0 0", color: "var(--fg-3)" }}>{data.emptyReason ? "애널리스트 컨센서스와 리서치 인용이 없습니다." : "컨센서스 없이 리서치 인용만 표시합니다."}</p>
+      ) : null}
+      {data && data.citations.length > 0 ? (
+        <ul style={{ listStyle: "none", margin: "12px 0 0", padding: 0, display: "flex", flexDirection: "column", gap: 8 }}>
+          {data.citations.slice(0, 3).map((citation, index) => (
+            <li key={`${citation.source}-${citation.title ?? index}`}>
+              <div style={{ fontWeight: 700 }}>{citation.title ?? "제목 없음"}</div>
+              <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{citation.source}{citation.analyst ? ` · ${citation.analyst}` : ""}</div>
+              {citation.excerpt ? <p style={{ margin: "4px 0 0", color: "var(--fg-2)", fontSize: 12 }}>{citation.excerpt}</p> : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {data && data.warnings.length > 0 ? (
+        <p style={{ margin: "10px 0 0", color: "var(--fg-3)", fontSize: 12 }}>경고: {data.warnings.join(", ")}</p>
+      ) : null}
+    </Card>
+  );
+}
+
 function AnalysisCard({ data }: { data: StockDetailResponse }) {
   const analysis = data.latestAnalysis;
   return (
@@ -303,6 +347,8 @@ export function StockDetailPage() {
   const [candles, setCandles] = useState<StockDetailCandlesResponse | undefined>();
   const [orders, setOrders] = useState<StockDetailOrdersResponse | undefined>();
   const [news, setNews] = useState<StockDetailNewsResponse | undefined>();
+  const [researchConsensus, setResearchConsensus] = useState<StockDetailResearchConsensusResponse | undefined>();
+  const [researchErr, setResearchErr] = useState<string | undefined>();
   const [err, setErr] = useState<string | undefined>();
 
   useEffect(() => {
@@ -311,11 +357,18 @@ export function StockDetailPage() {
     setCandles(undefined);
     setOrders(undefined);
     setNews(undefined);
+    setResearchConsensus(undefined);
+    setResearchErr(undefined);
     setErr(undefined);
 
     fetchStockDetail({ market, symbol })
       .then((r) => !cancel && setData(r))
       .catch((e) => !cancel && setErr(String(e?.message ?? e)));
+    if (market !== "crypto") {
+      fetchStockDetailResearchConsensus({ market, symbol })
+        .then((r) => !cancel && setResearchConsensus(r))
+        .catch((e) => !cancel && setResearchErr(String(e?.message ?? e)));
+    }
     fetchStockDetailCandles({ market, symbol, period: "1d" })
       .then((r) => !cancel && setCandles(r))
       .catch(() => undefined);
@@ -334,11 +387,12 @@ export function StockDetailPage() {
   const right = useMemo(() => (
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
       {data ? <ProfileCard data={data} /> : null}
+      {data && market !== "crypto" ? <ResearchConsensusCard data={researchConsensus} error={researchErr} /> : null}
       {data ? <AnalysisCard data={data} /> : null}
       {data ? <NaverPocCard data={data} /> : null}
       <MemoCard />
     </div>
-  ), [data]);
+  ), [data, market, researchConsensus, researchErr]);
 
   return (
     <DesktopShell

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -17,6 +17,7 @@
 // /invest/signals           — AI analysis signals.
 // /invest/calendar          — Earnings/events calendar.
 // /invest/coverage          — Data coverage dashboard.
+// /invest/insights          — Read-only market insight cards.
 // /invest/screener          — Stock screener (골라보기).
 // /invest/stocks/:m/:sym    — Stock detail page.
 // ─────────────────────────────────────────────────────────────────────────────
@@ -31,6 +32,7 @@ import { CalendarRoute } from "./pages/desktop/DesktopCalendarPage";
 import { CoverageRoute } from "./pages/desktop/DesktopCoveragePage";
 import { DesktopScreenerPage } from "./pages/desktop/DesktopScreenerPage";
 import { DesktopMarketPage } from "./pages/desktop/DesktopMarketPage";
+import { DesktopInsightsPage } from "./pages/desktop/DesktopInsightsPage";
 import { FxMacroRoute } from "./pages/desktop/FxMacroPage";
 import { DesktopCryptoPage } from "./pages/desktop/DesktopCryptoPage";
 import { StockDetailPage } from "./pages/stock-detail/StockDetailPage";
@@ -76,6 +78,7 @@ export const router = createBrowserRouter(
     { path: "/calendar", element: <CalendarRoute /> },
     { path: "/coverage", element: <CoverageRoute /> },
     { path: "/market", element: <DesktopMarketPage /> },
+    { path: "/insights", element: <DesktopInsightsPage /> },
     { path: "/market/fx", element: <FxMacroRoute /> },
     { path: "/crypto", element: <DesktopCryptoPage /> },
     { path: "/crypto/:pair", element: <CryptoPairRedirect /> },

--- a/frontend/invest/src/types/commonPreferredDisparity.ts
+++ b/frontend/invest/src/types/commonPreferredDisparity.ts
@@ -1,0 +1,56 @@
+export type DisparityState = "fresh" | "partial" | "stale" | "missing";
+export type DisparityTone = "discount" | "premium" | "parity" | "unknown";
+
+export type DisparitySource = {
+  source: string;
+  sourceOfTruth: string;
+  asOf?: string | null;
+  stale: boolean;
+  freshnessSec?: number | null;
+  warnings: string[];
+};
+
+export type DisparityPeriodWindow = {
+  period: "1d" | "5d" | "20d" | "60d";
+  sampleCount: number;
+  meanDisparityPct?: number | null;
+  minDisparityPct?: number | null;
+  maxDisparityPct?: number | null;
+  zScore?: number | null;
+  dataState: DisparityState;
+  emptyReason?: string | null;
+};
+
+export type CommonPreferredDisparityCard = {
+  id: string;
+  commonSymbol: string;
+  commonName: string;
+  preferredSymbol: string;
+  preferredName: string;
+  exchange?: string | null;
+  commonPrice?: number | null;
+  preferredPrice?: number | null;
+  disparityPct?: number | null;
+  preferredDiscountPct?: number | null;
+  preferredPremiumPct?: number | null;
+  zScore?: number | null;
+  primaryWindow: "1d" | "5d" | "20d" | "60d";
+  windows: DisparityPeriodWindow[];
+  tone: DisparityTone;
+  dataState: DisparityState;
+  emptyReason?: string | null;
+  formula: string;
+  source: DisparitySource;
+  warnings: string[];
+  caution: string;
+};
+
+export type CommonPreferredDisparityResponse = {
+  market: "kr";
+  state: DisparityState;
+  asOf: string;
+  cards: CommonPreferredDisparityCard[];
+  emptyReason?: string | null;
+  warnings: string[];
+  notes: string[];
+};

--- a/frontend/invest/src/types/marketParity.ts
+++ b/frontend/invest/src/types/marketParity.ts
@@ -1,0 +1,49 @@
+export type MarketParityState = "fresh" | "partial" | "stale" | "missing" | "disabled";
+export type MarketParityTone = "premium" | "discount" | "flat" | "unknown";
+export type MarketParityCardType =
+  | "index_implied_parity"
+  | "stablecoin_fx_premium"
+  | "crypto_kimchi_premium"
+  | "synthetic_kr_stock_parity";
+
+export interface MarketParitySource {
+  source: string;
+  sourceOfTruth: string;
+  asOf?: string | null;
+  stale: boolean;
+  freshnessSec?: number | null;
+  warnings: string[];
+}
+
+export interface MarketParityCard {
+  id: string;
+  type: MarketParityCardType;
+  title: string;
+  baseSymbol?: string | null;
+  baseName?: string | null;
+  proxySymbol?: string | null;
+  syntheticSymbol?: string | null;
+  basePrice?: number | null;
+  proxyPrice?: number | null;
+  syntheticPrice?: number | null;
+  fxRate?: number | null;
+  usdtKrw?: number | null;
+  usdKrw?: number | null;
+  impliedValue?: number | null;
+  premiumPct?: number | null;
+  tone: MarketParityTone;
+  formula?: string | null;
+  dataState: MarketParityState;
+  emptyReason?: string | null;
+  source: MarketParitySource;
+}
+
+export interface MarketParityResponse {
+  market: "kr";
+  state: MarketParityState;
+  asOf: string;
+  cards: MarketParityCard[];
+  emptyReason?: string | null;
+  warnings: string[];
+  notes: string[];
+}

--- a/frontend/invest/src/types/stockDetail.ts
+++ b/frontend/invest/src/types/stockDetail.ts
@@ -192,6 +192,61 @@ export interface StockDetailCandle {
   volume: number | null;
 }
 
+export interface StockDetailResearchCitation {
+  source: string;
+  title: string | null;
+  analyst: string | null;
+  published_at_text?: string | null;
+  published_at?: string | null;
+  category: string | null;
+  detail_url: string | null;
+  pdf_url: string | null;
+  excerpt: string | null;
+  symbol_candidates: Array<{ symbol: string; market?: string | null; source?: string | null }>;
+  attribution_publisher: string | null;
+  attribution_copyright_notice: string | null;
+}
+
+export interface StockDetailAnalystConsensus {
+  source: string | null;
+  buyCount: number;
+  holdCount: number;
+  sellCount: number;
+  strongBuyCount: number;
+  totalCount: number;
+  avgTargetPrice: number | null;
+  medianTargetPrice: number | null;
+  minTargetPrice: number | null;
+  maxTargetPrice: number | null;
+  upsidePct: number | null;
+  currentPrice: number | null;
+}
+
+export interface StockDetailResearchFreshness {
+  isReady: boolean;
+  isStale: boolean;
+  latestRunUuid: string | null;
+  latestFinishedAt: string | null;
+  latestReportCount: number;
+  maxAgeHours: number;
+}
+
+export interface StockDetailResearchConsensusResponse {
+  symbol: string;
+  market: "kr" | "us";
+  displayName: string;
+  state: "ready" | "partial" | "missing" | "unsupported" | "error";
+  dataState: "fresh" | "stale" | "missing" | "unsupported" | "error";
+  emptyReason: "no_analyst_consensus_or_research_reports" | "market_unsupported" | "provider_error" | null;
+  warnings: string[];
+  sourceOfTruth: "analyst_opinions_and_research_reports" | "analyst_opinions" | "research_reports" | "none";
+  asOf: string;
+  stale: boolean;
+  consensus: StockDetailAnalystConsensus | null;
+  citations: StockDetailResearchCitation[];
+  freshness: StockDetailResearchFreshness;
+}
+
 export interface StockDetailCandlesResponse {
   symbol: string;
   market: StockDetailMarket;

--- a/tests/test_invest_api_router_safety.py
+++ b/tests/test_invest_api_router_safety.py
@@ -79,3 +79,14 @@ def test_crypto_dashboard_service_no_mutation_imports() -> None:
     v = _violations(loaded, FORBIDDEN_MUTATION_MODULES)
     if v:
         pytest.fail(f"Forbidden imports in crypto_dashboard_service: {v}")
+
+
+@pytest.mark.unit
+def test_stock_detail_research_consensus_service_no_mutation_imports() -> None:
+    root = Path(__file__).resolve().parent.parent
+    loaded = _loaded(
+        "app.services.invest_view_model.stock_detail_research_consensus_service", root
+    )
+    v = _violations(loaded, FORBIDDEN_MUTATION_MODULES)
+    if v:
+        pytest.fail(f"Forbidden imports in stock_detail_research_consensus_service: {v}")

--- a/tests/test_invest_api_router_safety.py
+++ b/tests/test_invest_api_router_safety.py
@@ -82,11 +82,9 @@ def test_crypto_dashboard_service_no_mutation_imports() -> None:
 
 
 @pytest.mark.unit
-def test_stock_detail_research_consensus_service_no_mutation_imports() -> None:
+def test_market_parity_service_no_mutation_imports() -> None:
     root = Path(__file__).resolve().parent.parent
-    loaded = _loaded(
-        "app.services.invest_view_model.stock_detail_research_consensus_service", root
-    )
+    loaded = _loaded("app.services.invest_view_model.market_parity_service", root)
     v = _violations(loaded, FORBIDDEN_MUTATION_MODULES)
     if v:
-        pytest.fail(f"Forbidden imports in stock_detail_research_consensus_service: {v}")
+        pytest.fail(f"Forbidden imports in market_parity_service: {v}")

--- a/tests/test_invest_common_preferred_disparity.py
+++ b/tests/test_invest_common_preferred_disparity.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+import sqlalchemy as sa
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.db import get_db
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.market_quote_snapshot import MarketQuoteSnapshot
+from app.routers import invest_api
+from app.routers.dependencies import get_authenticated_user
+from app.routers.invest_api import router as invest_api_router
+from app.schemas.invest_common_preferred_disparity import (
+    CommonPreferredDisparityCard,
+    CommonPreferredDisparityResponse,
+    DisparitySource,
+)
+from app.services.invest_view_model.common_preferred_disparity_service import (
+    build_common_preferred_disparity,
+)
+from app.services.invest_view_model.kr_preferred_pairs import (
+    KRSymbolRow,
+    discover_common_preferred_pairs,
+)
+
+
+def test_seed_pair_discovers_samsung_common_preferred() -> None:
+    pairs = discover_common_preferred_pairs(
+        [
+            KRSymbolRow(symbol="005930", name="삼성전자", exchange="KOSPI"),
+            KRSymbolRow(symbol="005935", name="삼성전자우", exchange="KOSPI"),
+        ],
+        symbols={"005930"},
+    )
+
+    assert [(p.common_symbol, p.preferred_symbol) for p in pairs] == [("005930", "005935")]
+    assert pairs[0].mapping_source == "heuristic_name_suffix"
+
+
+@pytest.mark.asyncio
+async def test_build_common_preferred_disparity_calculates_discount_and_zscore(db_session) -> None:
+    now = dt.datetime(2026, 5, 14, 6, 0, tzinfo=dt.UTC)
+    common_symbol = "901001"
+    preferred_symbol = "901002"
+    await db_session.execute(
+        sa.delete(MarketQuoteSnapshot).where(
+            MarketQuoteSnapshot.symbol.in_([common_symbol, preferred_symbol])
+        )
+    )
+    await db_session.execute(
+        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.in_([common_symbol, preferred_symbol]))
+    )
+    await db_session.commit()
+    db_session.add_all(
+        [
+            KRSymbolUniverse(symbol=common_symbol, name="테스트홀딩", exchange="KOSPI", is_active=True),
+            KRSymbolUniverse(symbol=preferred_symbol, name="테스트홀딩우", exchange="KOSPI", is_active=True),
+        ]
+    )
+    prices = [
+        (now - dt.timedelta(days=2), Decimal("100000"), Decimal("82000")),
+        (now - dt.timedelta(days=1), Decimal("100000"), Decimal("80000")),
+        (now, Decimal("100000"), Decimal("78000")),
+    ]
+    rows = []
+    row_id = 2500000
+    for snapshot_at, common_price, preferred_price in prices:
+        rows.extend(
+            [
+                MarketQuoteSnapshot(
+                    id=row_id,
+                    market="kr",
+                    symbol=common_symbol,
+                    source="kis",
+                    snapshot_at=snapshot_at,
+                    price=common_price,
+                ),
+                MarketQuoteSnapshot(
+                    id=row_id + 1,
+                    market="kr",
+                    symbol=preferred_symbol,
+                    source="kis",
+                    snapshot_at=snapshot_at,
+                    price=preferred_price,
+                ),
+            ]
+        )
+        row_id += 2
+    db_session.add_all(rows)
+    await db_session.commit()
+
+    response = await build_common_preferred_disparity(
+        db=db_session,
+        symbols=[common_symbol],
+        as_of=now,
+        limit=5,
+        max_stale_days=1,
+    )
+
+    assert response.state == "fresh"
+    card = response.cards[0]
+    assert card.commonSymbol == common_symbol
+    assert card.preferredSymbol == preferred_symbol
+    assert card.commonPrice == 100000
+    assert card.preferredPrice == 78000
+    assert card.disparityPct == 22.0
+    assert card.preferredDiscountPct == 22.0
+    assert card.preferredPremiumPct == -28.21
+    assert card.tone == "discount"
+    assert card.zScore is not None
+    assert card.windows[-1].sampleCount == 3
+    assert "매수·매도 신호가 아닙니다" in card.caution
+
+
+@pytest.mark.asyncio
+async def test_common_preferred_disparity_requires_same_source_quotes(db_session) -> None:
+    now = dt.datetime(2026, 5, 14, 6, 0, tzinfo=dt.UTC)
+    common_symbol = "901011"
+    preferred_symbol = "901012"
+    await db_session.execute(
+        sa.delete(MarketQuoteSnapshot).where(
+            MarketQuoteSnapshot.symbol.in_([common_symbol, preferred_symbol])
+        )
+    )
+    await db_session.execute(
+        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.in_([common_symbol, preferred_symbol]))
+    )
+    await db_session.commit()
+    db_session.add_all(
+        [
+            KRSymbolUniverse(symbol=common_symbol, name="소스테스트", exchange="KOSPI", is_active=True),
+            KRSymbolUniverse(symbol=preferred_symbol, name="소스테스트우", exchange="KOSPI", is_active=True),
+            MarketQuoteSnapshot(id=2500100, market="kr", symbol=common_symbol, source="kis", snapshot_at=now, price=Decimal("100000")),
+            MarketQuoteSnapshot(id=2500101, market="kr", symbol=preferred_symbol, source="naver_finance", snapshot_at=now, price=Decimal("80000")),
+        ]
+    )
+    await db_session.commit()
+
+    response = await build_common_preferred_disparity(
+        db=db_session, symbols=[common_symbol], as_of=now, limit=5
+    )
+
+    assert response.state == "missing"
+    assert response.cards[0].dataState == "missing"
+    assert response.cards[0].emptyReason == "same_source_quote_pair_missing"
+
+
+def test_common_preferred_schema_uses_camel_case() -> None:
+    response = CommonPreferredDisparityResponse(
+        state="missing",
+        asOf=dt.datetime(2026, 5, 14, tzinfo=dt.UTC),
+        cards=[
+            CommonPreferredDisparityCard(
+                id="005930-005935",
+                commonSymbol="005930",
+                commonName="삼성전자",
+                preferredSymbol="005935",
+                preferredName="삼성전자우",
+                dataState="missing",
+                emptyReason="same_source_quote_pair_missing",
+                source=DisparitySource(source="market_quote_snapshots", sourceOfTruth="market_quote_snapshots"),
+            )
+        ],
+    )
+
+    payload = response.model_dump(mode="json")
+    assert payload["cards"][0]["commonSymbol"] == "005930"
+    assert payload["cards"][0]["preferredDiscountPct"] is None
+    assert "common_symbol" not in payload["cards"][0]
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    app = FastAPI()
+    app.include_router(invest_api_router)
+    app.dependency_overrides[get_authenticated_user] = lambda: type("U", (), {"id": 1})()
+
+    async def _fake_db():
+        yield object()
+
+    app.dependency_overrides[get_db] = _fake_db
+
+    async def _stub_disparity(**kwargs):
+        return CommonPreferredDisparityResponse(
+            state="fresh",
+            asOf=dt.datetime(2026, 5, 14, tzinfo=dt.UTC),
+            cards=[
+                CommonPreferredDisparityCard(
+                    id="005930-005935",
+                    commonSymbol="005930",
+                    commonName="삼성전자",
+                    preferredSymbol="005935",
+                    preferredName="삼성전자우",
+                    commonPrice=100000,
+                    preferredPrice=78000,
+                    disparityPct=22.0,
+                    preferredDiscountPct=22.0,
+                    preferredPremiumPct=-22.0,
+                    zScore=1.25,
+                    dataState="fresh",
+                    tone="discount",
+                    source=DisparitySource(source="kis", sourceOfTruth="market_quote_snapshots"),
+                )
+            ],
+        )
+
+    monkeypatch.setattr(invest_api, "build_common_preferred_disparity", _stub_disparity)
+    return TestClient(app)
+
+
+def test_common_preferred_disparity_router_returns_camel_case(client: TestClient) -> None:
+    response = client.get("/invest/api/disparity/common-preferred?symbols=005930,005935&limit=1")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["state"] == "fresh"
+    assert body["cards"][0]["commonSymbol"] == "005930"
+    assert body["cards"][0]["preferredSymbol"] == "005935"
+    assert "common_symbol" not in body["cards"][0]
+    assert "매수·매도 신호" in body["cards"][0]["caution"]
+
+
+def test_common_preferred_disparity_router_enforces_limit_bounds(client: TestClient) -> None:
+    response = client.get("/invest/api/disparity/common-preferred?limit=0")
+
+    assert response.status_code == 422

--- a/tests/test_invest_common_preferred_disparity.py
+++ b/tests/test_invest_common_preferred_disparity.py
@@ -37,12 +37,16 @@ def test_seed_pair_discovers_samsung_common_preferred() -> None:
         symbols={"005930"},
     )
 
-    assert [(p.common_symbol, p.preferred_symbol) for p in pairs] == [("005930", "005935")]
+    assert [(p.common_symbol, p.preferred_symbol) for p in pairs] == [
+        ("005930", "005935")
+    ]
     assert pairs[0].mapping_source == "heuristic_name_suffix"
 
 
 @pytest.mark.asyncio
-async def test_build_common_preferred_disparity_calculates_discount_and_zscore(db_session) -> None:
+async def test_build_common_preferred_disparity_calculates_discount_and_zscore(
+    db_session,
+) -> None:
     now = dt.datetime(2026, 5, 14, 6, 0, tzinfo=dt.UTC)
     common_symbol = "901001"
     preferred_symbol = "901002"
@@ -52,13 +56,25 @@ async def test_build_common_preferred_disparity_calculates_discount_and_zscore(d
         )
     )
     await db_session.execute(
-        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.in_([common_symbol, preferred_symbol]))
+        sa.delete(KRSymbolUniverse).where(
+            KRSymbolUniverse.symbol.in_([common_symbol, preferred_symbol])
+        )
     )
     await db_session.commit()
     db_session.add_all(
         [
-            KRSymbolUniverse(symbol=common_symbol, name="테스트홀딩", exchange="KOSPI", is_active=True),
-            KRSymbolUniverse(symbol=preferred_symbol, name="테스트홀딩우", exchange="KOSPI", is_active=True),
+            KRSymbolUniverse(
+                symbol=common_symbol,
+                name="테스트홀딩",
+                exchange="KOSPI",
+                is_active=True,
+            ),
+            KRSymbolUniverse(
+                symbol=preferred_symbol,
+                name="테스트홀딩우",
+                exchange="KOSPI",
+                is_active=True,
+            ),
         ]
     )
     prices = [
@@ -117,7 +133,9 @@ async def test_build_common_preferred_disparity_calculates_discount_and_zscore(d
 
 
 @pytest.mark.asyncio
-async def test_common_preferred_disparity_requires_same_source_quotes(db_session) -> None:
+async def test_common_preferred_disparity_requires_same_source_quotes(
+    db_session,
+) -> None:
     now = dt.datetime(2026, 5, 14, 6, 0, tzinfo=dt.UTC)
     common_symbol = "901011"
     preferred_symbol = "901012"
@@ -127,15 +145,41 @@ async def test_common_preferred_disparity_requires_same_source_quotes(db_session
         )
     )
     await db_session.execute(
-        sa.delete(KRSymbolUniverse).where(KRSymbolUniverse.symbol.in_([common_symbol, preferred_symbol]))
+        sa.delete(KRSymbolUniverse).where(
+            KRSymbolUniverse.symbol.in_([common_symbol, preferred_symbol])
+        )
     )
     await db_session.commit()
     db_session.add_all(
         [
-            KRSymbolUniverse(symbol=common_symbol, name="소스테스트", exchange="KOSPI", is_active=True),
-            KRSymbolUniverse(symbol=preferred_symbol, name="소스테스트우", exchange="KOSPI", is_active=True),
-            MarketQuoteSnapshot(id=2500100, market="kr", symbol=common_symbol, source="kis", snapshot_at=now, price=Decimal("100000")),
-            MarketQuoteSnapshot(id=2500101, market="kr", symbol=preferred_symbol, source="naver_finance", snapshot_at=now, price=Decimal("80000")),
+            KRSymbolUniverse(
+                symbol=common_symbol,
+                name="소스테스트",
+                exchange="KOSPI",
+                is_active=True,
+            ),
+            KRSymbolUniverse(
+                symbol=preferred_symbol,
+                name="소스테스트우",
+                exchange="KOSPI",
+                is_active=True,
+            ),
+            MarketQuoteSnapshot(
+                id=2500100,
+                market="kr",
+                symbol=common_symbol,
+                source="kis",
+                snapshot_at=now,
+                price=Decimal("100000"),
+            ),
+            MarketQuoteSnapshot(
+                id=2500101,
+                market="kr",
+                symbol=preferred_symbol,
+                source="naver_finance",
+                snapshot_at=now,
+                price=Decimal("80000"),
+            ),
         ]
     )
     await db_session.commit()
@@ -162,7 +206,10 @@ def test_common_preferred_schema_uses_camel_case() -> None:
                 preferredName="삼성전자우",
                 dataState="missing",
                 emptyReason="same_source_quote_pair_missing",
-                source=DisparitySource(source="market_quote_snapshots", sourceOfTruth="market_quote_snapshots"),
+                source=DisparitySource(
+                    source="market_quote_snapshots",
+                    sourceOfTruth="market_quote_snapshots",
+                ),
             )
         ],
     )
@@ -177,7 +224,9 @@ def test_common_preferred_schema_uses_camel_case() -> None:
 def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     app = FastAPI()
     app.include_router(invest_api_router)
-    app.dependency_overrides[get_authenticated_user] = lambda: type("U", (), {"id": 1})()
+    app.dependency_overrides[get_authenticated_user] = lambda: type(
+        "U", (), {"id": 1}
+    )()
 
     async def _fake_db():
         yield object()
@@ -203,7 +252,9 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
                     zScore=1.25,
                     dataState="fresh",
                     tone="discount",
-                    source=DisparitySource(source="kis", sourceOfTruth="market_quote_snapshots"),
+                    source=DisparitySource(
+                        source="kis", sourceOfTruth="market_quote_snapshots"
+                    ),
                 )
             ],
         )
@@ -212,8 +263,12 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     return TestClient(app)
 
 
-def test_common_preferred_disparity_router_returns_camel_case(client: TestClient) -> None:
-    response = client.get("/invest/api/disparity/common-preferred?symbols=005930,005935&limit=1")
+def test_common_preferred_disparity_router_returns_camel_case(
+    client: TestClient,
+) -> None:
+    response = client.get(
+        "/invest/api/disparity/common-preferred?symbols=005930,005935&limit=1"
+    )
 
     assert response.status_code == 200
     body = response.json()
@@ -224,7 +279,9 @@ def test_common_preferred_disparity_router_returns_camel_case(client: TestClient
     assert "매수·매도 신호" in body["cards"][0]["caution"]
 
 
-def test_common_preferred_disparity_router_enforces_limit_bounds(client: TestClient) -> None:
+def test_common_preferred_disparity_router_enforces_limit_bounds(
+    client: TestClient,
+) -> None:
     response = client.get("/invest/api/disparity/common-preferred?limit=0")
 
     assert response.status_code == 422

--- a/tests/test_invest_market_parity_router.py
+++ b/tests/test_invest_market_parity_router.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import invest_api
+from app.routers.dependencies import get_authenticated_user
+from app.routers.invest_api import router as invest_api_router
+from app.schemas.invest_market_parity import (
+    InvestMarketParityCard,
+    InvestMarketParityResponse,
+    InvestParitySource,
+)
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    app = FastAPI()
+    app.include_router(invest_api_router)
+    app.dependency_overrides[get_authenticated_user] = lambda: type(
+        "U", (), {"id": 1}
+    )()
+
+    async def _stub_market_parity(**kwargs):
+        assert kwargs["market"] == "kr"
+        assert kwargs["include_disabled"] is False
+        assert kwargs["limit"] == 2
+        as_of = datetime(2026, 5, 14, 0, 0, tzinfo=UTC)
+        return InvestMarketParityResponse(
+            market="kr",
+            state="fresh",
+            asOf=as_of,
+            cards=[
+                InvestMarketParityCard(
+                    id="ewy-kospi-implied-parity",
+                    type="index_implied_parity",
+                    title="EWY implied KOSPI parity",
+                    baseSymbol="KOSPI",
+                    proxySymbol="EWY",
+                    basePrice=100,
+                    proxyPrice=10,
+                    fxRate=11,
+                    impliedValue=110,
+                    premiumPct=10,
+                    tone="premium",
+                    formula="((proxyPrice * fxRate * divisor) / basePrice - 1) * 100",
+                    dataState="fresh",
+                    source=InvestParitySource(
+                        source="fixture",
+                        sourceOfTruth="test_fixture",
+                        asOf=as_of,
+                    ),
+                )
+            ],
+            warnings=[],
+            notes=["Read-only market parity dashboard; no broker/order/watch mutations."],
+        )
+
+    monkeypatch.setattr(invest_api, "build_market_parity", _stub_market_parity)
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_get_market_parity_returns_camel_case_payload(client: TestClient) -> None:
+    response = client.get("/invest/api/market/parity?includeDisabled=false&limit=2")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["market"] == "kr"
+    assert body["state"] == "fresh"
+    assert body["cards"][0]["dataState"] == "fresh"
+    assert body["cards"][0]["source"]["sourceOfTruth"] == "test_fixture"
+    assert body["cards"][0]["premiumPct"] == 10
+    assert "source_of_truth" not in body["cards"][0]["source"]
+    assert all("order_id" not in card for card in body["cards"])
+
+
+@pytest.mark.unit
+def test_get_market_parity_dash_alias_returns_payload(client: TestClient) -> None:
+    response = client.get("/invest/api/market-parity?includeDisabled=false&limit=2")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["cards"][0]["title"] == "EWY implied KOSPI parity"
+
+
+@pytest.mark.unit
+def test_get_market_parity_requires_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    app = FastAPI()
+    app.include_router(invest_api_router)
+
+    async def _stub_market_parity(**kwargs):
+        raise AssertionError("must not call service without auth")
+
+    monkeypatch.setattr(invest_api, "build_market_parity", _stub_market_parity)
+    response = TestClient(app).get("/invest/api/market/parity")
+
+    assert response.status_code in {401, 403}
+
+
+@pytest.mark.unit
+def test_get_market_parity_enforces_limit_bounds(client: TestClient) -> None:
+    response = client.get("/invest/api/market/parity?limit=99")
+
+    assert response.status_code == 422

--- a/tests/test_invest_market_parity_router.py
+++ b/tests/test_invest_market_parity_router.py
@@ -56,7 +56,9 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
                 )
             ],
             warnings=[],
-            notes=["Read-only market parity dashboard; no broker/order/watch mutations."],
+            notes=[
+                "Read-only market parity dashboard; no broker/order/watch mutations."
+            ],
         )
 
     monkeypatch.setattr(invest_api, "build_market_parity", _stub_market_parity)

--- a/tests/test_invest_market_parity_service.py
+++ b/tests/test_invest_market_parity_service.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from app.services.invest_view_model.market_parity_service import (
+    ParityQuote,
+    build_market_parity,
+)
+
+_AS_OF = datetime(2026, 5, 14, 0, 0, tzinfo=UTC)
+
+
+class _StubParityProvider:
+    def __init__(self, *, fail_proxy: bool = False, include_synthetic: bool = True) -> None:
+        self.fail_proxy = fail_proxy
+        self.include_synthetic = include_synthetic
+
+    async def get_index_quote(self, symbol: str) -> ParityQuote | None:
+        assert symbol == "KOSPI"
+        return ParityQuote(symbol=symbol, price=Decimal("100"), source="fixture", as_of=_AS_OF)
+
+    async def get_proxy_quote(self, symbol: str) -> ParityQuote | None:
+        if self.fail_proxy:
+            raise RuntimeError("proxy fixture unavailable")
+        assert symbol == "EWY"
+        return ParityQuote(symbol=symbol, price=Decimal("10"), source="fixture", as_of=_AS_OF)
+
+    async def get_fx_rate(self, pair: str) -> ParityQuote | None:
+        assert pair == "USD/KRW"
+        return ParityQuote(symbol=pair, price=Decimal("11"), source="fixture", as_of=_AS_OF)
+
+    async def get_stablecoin_rate(self, pair: str) -> ParityQuote | None:
+        assert pair == "USDT/KRW"
+        return ParityQuote(symbol=pair, price=Decimal("11.55"), source="fixture", as_of=_AS_OF)
+
+    async def get_crypto_kimchi_premium(self, symbol: str) -> dict[str, Any] | None:
+        assert symbol == "BTC"
+        return {"symbol": "BTC", "premium_pct": 2.41, "as_of": _AS_OF.isoformat()}
+
+    async def get_synthetic_quote(self, symbol: str) -> ParityQuote | None:
+        if not self.include_synthetic:
+            return None
+        prices = {"xyz:SMSN": Decimal("8"), "xyz:SKHX": Decimal("5")}
+        return ParityQuote(symbol=symbol, price=prices[symbol], source="fixture", as_of=_AS_OF)
+
+    async def get_kr_stock_quote(self, symbol: str) -> ParityQuote | None:
+        prices = {"005930": Decimal("88"), "000660": Decimal("60")}
+        return ParityQuote(symbol=symbol, price=prices[symbol], source="fixture", as_of=_AS_OF)
+
+
+class _ApprovalGatedProvider(_StubParityProvider):
+    def __init__(self) -> None:
+        super().__init__(include_synthetic=False)
+
+    async def get_proxy_quote(self, symbol: str) -> ParityQuote | None:
+        _ = symbol
+        return None
+
+    async def get_fx_rate(self, pair: str) -> ParityQuote | None:
+        _ = pair
+        return None
+
+    async def get_stablecoin_rate(self, pair: str) -> ParityQuote | None:
+        _ = pair
+        return None
+
+    async def get_kr_stock_quote(self, symbol: str) -> ParityQuote | None:
+        _ = symbol
+        return None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_market_parity_calculates_stubbed_cards() -> None:
+    response = await build_market_parity(_StubParityProvider())
+
+    assert response.state == "fresh"
+    cards = {card.id: card for card in response.cards}
+
+    index = cards["ewy-kospi-implied-parity"]
+    assert index.dataState == "fresh"
+    assert index.basePrice == 100
+    assert index.proxyPrice == 10
+    assert index.fxRate == 11
+    assert index.impliedValue == 110
+    assert index.premiumPct == 10
+    assert index.tone == "premium"
+
+    stablecoin = cards["usdt-krw-usd-krw-premium"]
+    assert stablecoin.dataState == "fresh"
+    assert stablecoin.usdKrw == 11
+    assert stablecoin.usdtKrw == 11.55
+    assert stablecoin.premiumPct == 5
+
+    sms = cards["005930-xyz-smsn"]
+    assert sms.syntheticSymbol == "xyz:SMSN"
+    assert sms.basePrice == 88
+    assert sms.syntheticPrice == 8
+    assert sms.impliedValue == 88
+    assert sms.premiumPct == 0
+    assert sms.tone == "flat"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_market_parity_defaults_to_approval_gated_missing_cards() -> None:
+    response = await build_market_parity(_ApprovalGatedProvider())
+
+    assert response.state == "partial"
+    cards = {card.id: card for card in response.cards}
+    assert cards["ewy-kospi-implied-parity"].dataState == "missing"
+    assert cards["ewy-kospi-implied-parity"].emptyReason == "proxy_quote_missing"
+    assert cards["usdt-krw-usd-krw-premium"].dataState == "missing"
+    assert cards["usdt-krw-usd-krw-premium"].emptyReason == "fx_source_not_configured"
+    assert cards["005930-xyz-smsn"].dataState == "disabled"
+    assert cards["005930-xyz-smsn"].emptyReason == "hyperliquid_source_not_approved"
+    assert "hyperliquid_source_not_approved" in cards["005930-xyz-smsn"].source.warnings
+    assert any("raoni.xyz" in note for note in response.notes)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_market_parity_redacts_provider_exception_to_warning() -> None:
+    response = await build_market_parity(_StubParityProvider(fail_proxy=True))
+
+    assert response.state == "partial"
+    index = next(card for card in response.cards if card.id == "ewy-kospi-implied-parity")
+    assert index.dataState == "missing"
+    assert index.emptyReason == "proxy_quote_missing"
+    assert any("proxy:EWY" in warning for warning in response.warnings)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_build_market_parity_can_hide_disabled_cards() -> None:
+    response = await build_market_parity(
+        _ApprovalGatedProvider(), include_disabled=False, limit=20
+    )
+
+    assert all(card.dataState != "disabled" for card in response.cards)
+    assert {card.type for card in response.cards} == {
+        "index_implied_parity",
+        "stablecoin_fx_premium",
+        "crypto_kimchi_premium",
+    }

--- a/tests/test_invest_market_parity_service.py
+++ b/tests/test_invest_market_parity_service.py
@@ -15,27 +15,37 @@ _AS_OF = datetime(2026, 5, 14, 0, 0, tzinfo=UTC)
 
 
 class _StubParityProvider:
-    def __init__(self, *, fail_proxy: bool = False, include_synthetic: bool = True) -> None:
+    def __init__(
+        self, *, fail_proxy: bool = False, include_synthetic: bool = True
+    ) -> None:
         self.fail_proxy = fail_proxy
         self.include_synthetic = include_synthetic
 
     async def get_index_quote(self, symbol: str) -> ParityQuote | None:
         assert symbol == "KOSPI"
-        return ParityQuote(symbol=symbol, price=Decimal("100"), source="fixture", as_of=_AS_OF)
+        return ParityQuote(
+            symbol=symbol, price=Decimal("100"), source="fixture", as_of=_AS_OF
+        )
 
     async def get_proxy_quote(self, symbol: str) -> ParityQuote | None:
         if self.fail_proxy:
             raise RuntimeError("proxy fixture unavailable")
         assert symbol == "EWY"
-        return ParityQuote(symbol=symbol, price=Decimal("10"), source="fixture", as_of=_AS_OF)
+        return ParityQuote(
+            symbol=symbol, price=Decimal("10"), source="fixture", as_of=_AS_OF
+        )
 
     async def get_fx_rate(self, pair: str) -> ParityQuote | None:
         assert pair == "USD/KRW"
-        return ParityQuote(symbol=pair, price=Decimal("11"), source="fixture", as_of=_AS_OF)
+        return ParityQuote(
+            symbol=pair, price=Decimal("11"), source="fixture", as_of=_AS_OF
+        )
 
     async def get_stablecoin_rate(self, pair: str) -> ParityQuote | None:
         assert pair == "USDT/KRW"
-        return ParityQuote(symbol=pair, price=Decimal("11.55"), source="fixture", as_of=_AS_OF)
+        return ParityQuote(
+            symbol=pair, price=Decimal("11.55"), source="fixture", as_of=_AS_OF
+        )
 
     async def get_crypto_kimchi_premium(self, symbol: str) -> dict[str, Any] | None:
         assert symbol == "BTC"
@@ -45,11 +55,15 @@ class _StubParityProvider:
         if not self.include_synthetic:
             return None
         prices = {"xyz:SMSN": Decimal("8"), "xyz:SKHX": Decimal("5")}
-        return ParityQuote(symbol=symbol, price=prices[symbol], source="fixture", as_of=_AS_OF)
+        return ParityQuote(
+            symbol=symbol, price=prices[symbol], source="fixture", as_of=_AS_OF
+        )
 
     async def get_kr_stock_quote(self, symbol: str) -> ParityQuote | None:
         prices = {"005930": Decimal("88"), "000660": Decimal("60")}
-        return ParityQuote(symbol=symbol, price=prices[symbol], source="fixture", as_of=_AS_OF)
+        return ParityQuote(
+            symbol=symbol, price=prices[symbol], source="fixture", as_of=_AS_OF
+        )
 
 
 class _ApprovalGatedProvider(_StubParityProvider):
@@ -128,7 +142,9 @@ async def test_build_market_parity_redacts_provider_exception_to_warning() -> No
     response = await build_market_parity(_StubParityProvider(fail_proxy=True))
 
     assert response.state == "partial"
-    index = next(card for card in response.cards if card.id == "ewy-kospi-implied-parity")
+    index = next(
+        card for card in response.cards if card.id == "ewy-kospi-implied-parity"
+    )
     assert index.dataState == "missing"
     assert index.emptyReason == "proxy_quote_missing"
     assert any("proxy:EWY" in warning for warning in response.warnings)

--- a/tests/test_stock_detail_research_consensus_service.py
+++ b/tests/test_stock_detail_research_consensus_service.py
@@ -59,8 +59,18 @@ async def test_build_stock_detail_research_consensus_combines_opinions_and_citat
             "source": "naver",
             "current_price": 70000,
             "opinions": [
-                {"firm": "A증권", "rating": "매수", "target_price": 84000, "date": "2026-05-13"},
-                {"firm": "B증권", "rating": "중립", "target_price": 72000, "date": "2026-05-12"},
+                {
+                    "firm": "A증권",
+                    "rating": "매수",
+                    "target_price": 84000,
+                    "date": "2026-05-13",
+                },
+                {
+                    "firm": "B증권",
+                    "rating": "중립",
+                    "target_price": 72000,
+                    "date": "2026-05-12",
+                },
             ],
         }
 
@@ -73,7 +83,9 @@ async def test_build_stock_detail_research_consensus_combines_opinions_and_citat
                 published_at=now,
                 excerpt="메모리 회복과 AI 수요를 점검합니다.",
                 detail_url="https://example.com/reports/1",
-                symbol_candidates=[{"symbol": "005930", "market": "kr", "source": "ticker"}],
+                symbol_candidates=[
+                    {"symbol": "005930", "market": "kr", "source": "ticker"}
+                ],
                 attribution_publisher="Naver",
                 attribution_copyright_notice="copyright",
             )
@@ -120,7 +132,14 @@ async def test_build_stock_detail_research_consensus_combines_opinions_and_citat
     assert response.citations[0].title == "삼성전자 실적 프리뷰"
 
     dumped = response.model_dump(by_alias=True)
-    forbidden = {"pdf_body", "pdf_text", "extracted_text", "full_text", "raw_payload", "raw_payload_json"}
+    forbidden = {
+        "pdf_body",
+        "pdf_text",
+        "extracted_text",
+        "full_text",
+        "raw_payload",
+        "raw_payload_json",
+    }
     assert forbidden.isdisjoint(str(dumped).lower())
 
 
@@ -289,7 +308,9 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
 
 
 @pytest.mark.unit
-def test_research_consensus_route_returns_read_only_contract(client: TestClient) -> None:
+def test_research_consensus_route_returns_read_only_contract(
+    client: TestClient,
+) -> None:
     response = client.get("/invest/api/stock-detail/us/QQQM/research-consensus")
 
     assert response.status_code == 200
@@ -323,7 +344,9 @@ def test_research_consensus_route_maps_symbol_not_found(
     async def _raise_not_found(**kwargs):
         raise SymbolNotFound("missing")
 
-    monkeypatch.setattr(invest_api, "build_stock_detail_research_consensus", _raise_not_found)
+    monkeypatch.setattr(
+        invest_api, "build_stock_detail_research_consensus", _raise_not_found
+    )
 
     response = client.get("/invest/api/stock-detail/us/MISSING/research-consensus")
 

--- a/tests/test_stock_detail_research_consensus_service.py
+++ b/tests/test_stock_detail_research_consensus_service.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.core.db import get_db
+from app.routers import invest_api
+from app.routers.dependencies import get_authenticated_user
+from app.routers.invest_api import router as invest_api_router
+from app.schemas.invest_stock_detail_research_consensus import (
+    StockDetailResearchConsensusResponse,
+    StockDetailResearchFreshness,
+)
+from app.schemas.research_reports import (
+    ResearchReportCitation,
+    ResearchReportsReadinessResponse,
+)
+from app.services.invest_view_model.stock_detail_research_consensus_service import (
+    StockDetailResearchConsensusProviders,
+    build_stock_detail_research_consensus,
+)
+from app.services.invest_view_model.stock_detail_symbol_resolver import ResolvedSymbol
+
+
+async def _resolve_kr(market, raw_symbol, db):
+    return ResolvedSymbol(
+        symbol_db="005930",
+        display_name="삼성전자",
+        exchange="KOSPI",
+        instrument_type="equity_kr",
+        asset_type="equity",
+        asset_category="kr_stock",
+        currency="KRW",
+    )
+
+
+async def _resolve_us(market, raw_symbol, db):
+    return ResolvedSymbol(
+        symbol_db="QQQM",
+        display_name="Invesco NASDAQ 100 ETF",
+        exchange="NASDAQ",
+        instrument_type="etf_us",
+        asset_type="etf",
+        asset_category="us_etf",
+        currency="USD",
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_stock_detail_research_consensus_combines_opinions_and_citations_without_body_fields():
+    now = datetime.now(UTC)
+
+    async def opinions_provider(symbol, market, limit):
+        return {
+            "source": "naver",
+            "current_price": 70000,
+            "opinions": [
+                {"firm": "A증권", "rating": "매수", "target_price": 84000, "date": "2026-05-13"},
+                {"firm": "B증권", "rating": "중립", "target_price": 72000, "date": "2026-05-12"},
+            ],
+        }
+
+    async def citations_provider(db, symbol, limit):
+        return [
+            ResearchReportCitation(
+                source="naver_research",
+                title="삼성전자 실적 프리뷰",
+                analyst="홍길동",
+                published_at=now,
+                excerpt="메모리 회복과 AI 수요를 점검합니다.",
+                detail_url="https://example.com/reports/1",
+                symbol_candidates=[{"symbol": "005930", "market": "kr", "source": "ticker"}],
+                attribution_publisher="Naver",
+                attribution_copyright_notice="copyright",
+            )
+        ]
+
+    async def readiness_provider(db, source, max_age_hours):
+        return ResearchReportsReadinessResponse(
+            source=source,
+            is_ready=True,
+            is_stale=False,
+            latest_run_uuid="run-1",
+            latest_finished_at=now,
+            latest_inserted_count=1,
+            latest_skipped_count=0,
+            latest_report_count=1,
+            warnings=[],
+            max_age_hours=max_age_hours,
+        )
+
+    response = await build_stock_detail_research_consensus(
+        market="kr",
+        symbol="005930",
+        db=SimpleNamespace(),
+        providers=StockDetailResearchConsensusProviders(
+            resolver=_resolve_kr,
+            opinions=opinions_provider,
+            citations=citations_provider,
+            readiness=readiness_provider,
+        ),
+    )
+
+    assert response.market == "kr"
+    assert response.symbol == "005930"
+    assert response.state == "ready"
+    assert response.dataState == "fresh"
+    assert response.emptyReason is None
+    assert response.sourceOfTruth == "analyst_opinions_and_research_reports"
+    assert response.consensus is not None
+    assert response.consensus.buyCount == 1
+    assert response.consensus.holdCount == 1
+    assert response.consensus.totalCount == 2
+    assert response.consensus.avgTargetPrice == 78000
+    assert response.consensus.upsidePct == pytest.approx(11.43)
+    assert response.citations[0].title == "삼성전자 실적 프리뷰"
+
+    dumped = response.model_dump(by_alias=True)
+    forbidden = {"pdf_body", "pdf_text", "extracted_text", "full_text", "raw_payload", "raw_payload_json"}
+    assert forbidden.isdisjoint(str(dumped).lower())
+
+
+@pytest.mark.asyncio
+async def test_build_stock_detail_research_consensus_keeps_citations_when_opinions_missing():
+    now = datetime.now(UTC)
+
+    async def opinions_provider(symbol, market, limit):
+        return {"error": True, "message": "provider unavailable"}
+
+    async def citations_provider(db, symbol, limit):
+        return [
+            ResearchReportCitation(
+                source="issuer_ir",
+                title="QQQM holdings note",
+                published_at=now,
+                excerpt="ETF 구성 종목 변경만 요약합니다.",
+            )
+        ]
+
+    async def readiness_provider(db, source, max_age_hours):
+        return ResearchReportsReadinessResponse(
+            source=source,
+            is_ready=False,
+            is_stale=True,
+            latest_run_uuid="run-stale",
+            latest_finished_at=now - timedelta(days=3),
+            latest_inserted_count=1,
+            latest_skipped_count=0,
+            latest_report_count=1,
+            warnings=["research_reports_stale"],
+            max_age_hours=max_age_hours,
+        )
+
+    response = await build_stock_detail_research_consensus(
+        market="us",
+        symbol="QQQM",
+        db=SimpleNamespace(),
+        providers=StockDetailResearchConsensusProviders(
+            resolver=_resolve_us,
+            opinions=opinions_provider,
+            citations=citations_provider,
+            readiness=readiness_provider,
+        ),
+    )
+
+    assert response.state == "partial"
+    assert response.dataState == "stale"
+    assert response.emptyReason is None
+    assert response.consensus is None
+    assert response.citations[0].source == "issuer_ir"
+    assert "analyst_opinions_unavailable" in response.warnings
+    assert "research_reports_stale" in response.warnings
+
+
+@pytest.mark.asyncio
+async def test_build_stock_detail_research_consensus_reports_missing_when_no_sources():
+    async def opinions_provider(symbol, market, limit):
+        return {"opinions": [], "source": "yfinance"}
+
+    async def citations_provider(db, symbol, limit):
+        return []
+
+    async def readiness_provider(db, source, max_age_hours):
+        return ResearchReportsReadinessResponse(
+            source=source,
+            is_ready=False,
+            is_stale=False,
+            latest_inserted_count=0,
+            latest_skipped_count=0,
+            latest_report_count=0,
+            warnings=[],
+            max_age_hours=max_age_hours,
+        )
+
+    response = await build_stock_detail_research_consensus(
+        market="us",
+        symbol="QQQM",
+        db=SimpleNamespace(),
+        providers=StockDetailResearchConsensusProviders(
+            resolver=_resolve_us,
+            opinions=opinions_provider,
+            citations=citations_provider,
+            readiness=readiness_provider,
+        ),
+    )
+
+    assert response.state == "missing"
+    assert response.dataState == "missing"
+    assert response.emptyReason == "no_analyst_consensus_or_research_reports"
+    assert response.consensus is None
+    assert response.citations == []
+
+
+@pytest.mark.asyncio
+async def test_build_stock_detail_research_consensus_reports_error_state_when_providers_fail():
+    async def failing_opinions_provider(symbol, market, limit):
+        raise RuntimeError("opinions offline")
+
+    async def failing_citations_provider(db, symbol, limit):
+        raise RuntimeError("research db offline")
+
+    async def failing_readiness_provider(db, source, max_age_hours):
+        raise RuntimeError("freshness offline")
+
+    response = await build_stock_detail_research_consensus(
+        market="us",
+        symbol="QQQM",
+        db=SimpleNamespace(),
+        providers=StockDetailResearchConsensusProviders(
+            resolver=_resolve_us,
+            opinions=failing_opinions_provider,
+            citations=failing_citations_provider,
+            readiness=failing_readiness_provider,
+        ),
+    )
+
+    assert response.state == "missing"
+    assert response.dataState == "error"
+    assert response.emptyReason == "provider_error"
+    assert response.sourceOfTruth == "none"
+    assert response.consensus is None
+    assert response.citations == []
+    assert "analyst_opinions_unavailable" in response.warnings
+    assert "research_reports_unavailable" in response.warnings
+    assert "research_reports_readiness_unavailable" in response.warnings
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    app = FastAPI()
+    app.include_router(invest_api_router)
+    app.dependency_overrides[get_authenticated_user] = lambda: type(
+        "U", (), {"id": 1}
+    )()
+    app.dependency_overrides[get_db] = lambda: SimpleNamespace()
+
+    async def _stub_research_consensus(**kwargs):
+        assert kwargs["market"] == "us"
+        assert kwargs["symbol"] == "QQQM"
+        return StockDetailResearchConsensusResponse(
+            symbol="QQQM",
+            market="us",
+            displayName="Invesco NASDAQ 100 ETF",
+            state="ready",
+            dataState="fresh",
+            warnings=[],
+            sourceOfTruth="analyst_opinions_and_research_reports",
+            asOf=datetime(2026, 5, 10, 9, 31, tzinfo=UTC),
+            consensus=None,
+            citations=[ResearchReportCitation(source="issuer_ir", title="QQQM note")],
+            freshness=StockDetailResearchFreshness(
+                isReady=True,
+                isStale=False,
+                latestRunUuid="run-1",
+                latestFinishedAt=datetime(2026, 5, 10, 9, 0, tzinfo=UTC),
+                latestReportCount=1,
+                maxAgeHours=24,
+            ),
+        )
+
+    monkeypatch.setattr(
+        invest_api, "build_stock_detail_research_consensus", _stub_research_consensus
+    )
+    return TestClient(app)
+
+
+@pytest.mark.unit
+def test_research_consensus_route_returns_read_only_contract(client: TestClient) -> None:
+    response = client.get("/invest/api/stock-detail/us/QQQM/research-consensus")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["symbol"] == "QQQM"
+    assert body["market"] == "us"
+    assert body["state"] == "ready"
+    assert body["dataState"] == "fresh"
+    assert body["sourceOfTruth"] == "analyst_opinions_and_research_reports"
+    assert body["citations"][0]["title"] == "QQQM note"
+    forbidden = {"pdf_body", "pdf_text", "extracted_text", "full_text", "raw_payload"}
+    assert forbidden.isdisjoint(str(body).lower())
+
+
+@pytest.mark.unit
+def test_research_consensus_route_rejects_crypto(client: TestClient) -> None:
+    response = client.get("/invest/api/stock-detail/crypto/KRW-BTC/research-consensus")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "research_consensus_supports_kr_us_only"
+
+
+@pytest.mark.unit
+def test_research_consensus_route_maps_symbol_not_found(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from app.services.invest_view_model.stock_detail_symbol_resolver import (
+        SymbolNotFound,
+    )
+
+    async def _raise_not_found(**kwargs):
+        raise SymbolNotFound("missing")
+
+    monkeypatch.setattr(invest_api, "build_stock_detail_research_consensus", _raise_not_found)
+
+    response = client.get("/invest/api/stock-detail/us/MISSING/research-consensus")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "symbol_not_found"


### PR DESCRIPTION
## Summary
- Integrates accepted ROB-249..ROB-253 /invest read-only sprint work onto the ROB-247 raoni-style sprint integration branch.
- Keeps production behavior independent from raoni.xyz APIs.
- Preserves safety boundary: no broker/order/watch/order-intent mutations, no production DB write/backfill, no scheduler activation.

## Local verification from Kanban integration worker
- `uv run pytest tests/test_invest_market_parity_router.py tests/test_invest_market_parity_service.py tests/test_invest_common_preferred_disparity.py tests/test_stock_detail_research_consensus_service.py tests/test_invest_api_router_safety.py -q` — 25 passed
- `uv run pytest tests/test_invest_market_dashboard.py tests/test_invest_fx_dashboard.py tests/test_invest_home_service.py -q` — 29 passed
- `npm test -- --run src/__tests__/DesktopInsightsPage.test.tsx DesktopMarketPage.test.tsx InvestHomeRoute.test.tsx MarketParityStrip.test.tsx marketParity.api.test.ts StockDetailPage.test.tsx` — 22 passed after `npm ci`
- `npm run typecheck` — passed
- `uv run ruff check ...` on changed backend/test files — passed
- `git diff --check origin/main...HEAD` — clean
- Safety scan: no broker/order/watch mutation, no production raoni.xyz dependency, no scheduler/backfill activation found.

## Safety / operations
- Read-only `/invest` feature integration only.
- No trading recommendation, broker/order/watch/order-intent side effects.
- No production DB write/backfill/scheduler activation in this PR.
- Deploy/smoke will be handled after PR CI/merge per ROB-247 Kanban flow.

Closes ROB-247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/invest/insights` page displaying market parity observations and common/preferred share disparity metrics as read-only references.
  * Introduced research consensus card on stock detail pages showing analyst opinions and research citations.
  * Added three new API endpoints providing market parity, common/preferred disparity, and stock detail research consensus data.

* **Documentation**
  * Added architecture decision document for insights page design.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/828)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->