### PR TITLE
feat(invest): add KR investor-flow insights

### DIFF
--- a/app/schemas/invest_screener.py
+++ b/app/schemas/invest_screener.py
@@ -13,6 +13,24 @@ from pydantic import BaseModel, ConfigDict, Field
 
 ScreenerMarket = Literal["kr", "us", "crypto"]
 ChangeDirection = Literal["up", "down", "flat"]
+InvestorFlowChipTone = Literal[
+    "double_buy",
+    "double_sell",
+    "foreign_buy",
+    "foreign_sell",
+    "institution_buy",
+    "institution_sell",
+    "neutral",
+]
+InvestorFlowChipState = Literal["fresh", "stale", "missing"]
+
+
+class ScreenerInvestorFlowChip(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    label: str
+    tone: InvestorFlowChipTone
+    dataState: InvestorFlowChipState
+    snapshotDate: str | None = None
 
 
 class ScreenerFilterChip(BaseModel):
@@ -49,6 +67,7 @@ class ScreenerResultRow(BaseModel):
     volumeLabel: str
     analystLabel: str
     metricValueLabel: str
+    investorFlowChip: ScreenerInvestorFlowChip | None = None
     warnings: list[str] = Field(default_factory=list)
 
 

--- a/app/schemas/invest_stock_detail.py
+++ b/app/schemas/invest_stock_detail.py
@@ -233,6 +233,19 @@ class StockDetailDiscussionSignal(BaseModel):
 InvestorFlowDetailState = Literal["fresh", "stale", "missing"]
 
 
+class StockDetailInvestorFlowDailyRow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    snapshotDate: str
+    collectedAt: datetime | None = None
+    source: str | None = None
+    foreignNet: int | None = None
+    institutionNet: int | None = None
+    individualNet: int | None = None
+    doubleBuy: bool = False
+    doubleSell: bool = False
+
+
 class StockDetailInvestorFlow(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -258,7 +271,10 @@ class StockDetailInvestorFlow(BaseModel):
     institutionConsecutiveSellDays: int | None = None
     individualConsecutiveBuyDays: int | None = None
     individualConsecutiveSellDays: int | None = None
-    cautionLabel: str = "투자자별 수급은 과거 신호이며 매매 판단을 대신하지 않습니다."
+    dailyRows: list[StockDetailInvestorFlowDailyRow] = Field(default_factory=list)
+    cautionLabel: str = (
+        "투자자별 수급은 지연된 과거 참고 데이터이며 매매 판단을 대신하지 않습니다."
+    )
 
     @model_validator(mode="after")
     def enforce_kr_only(self) -> StockDetailInvestorFlow:

--- a/app/schemas/invest_stock_detail.py
+++ b/app/schemas/invest_stock_detail.py
@@ -267,9 +267,7 @@ class StockDetailInvestorFlow(BaseModel):
         if self.dataState == "missing" and (
             self.foreignNet is not None or self.institutionNet is not None
         ):
-            raise ValueError(
-                "missing investor_flow must not expose any flow values"
-            )
+            raise ValueError("missing investor_flow must not expose any flow values")
         return self
 
 

--- a/app/schemas/invest_stock_detail.py
+++ b/app/schemas/invest_stock_detail.py
@@ -318,7 +318,9 @@ class StockDetailInvestorFlow(BaseModel):
         if self.market != "kr":
             raise ValueError("investor_flow is KR-only in /invest stock detail")
         if self.dataState == "missing" and (
-            self.foreignNet is not None or self.institutionNet is not None
+            self.foreignNet is not None
+            or self.institutionNet is not None
+            or self.individualNet is not None
         ):
             raise ValueError("missing investor_flow must not expose any flow values")
         return self

--- a/app/schemas/invest_stock_detail.py
+++ b/app/schemas/invest_stock_detail.py
@@ -230,6 +230,49 @@ class StockDetailDiscussionSignal(BaseModel):
         return self
 
 
+InvestorFlowDetailState = Literal["fresh", "stale", "missing"]
+
+
+class StockDetailInvestorFlow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: Literal["investor_flow_snapshots"] = "investor_flow_snapshots"
+    market: Literal["kr"] = "kr"
+    symbol: str
+    dataState: InvestorFlowDetailState
+    snapshotDate: str | None = None
+    collectedAt: datetime | None = None
+    snapshotSource: str | None = None
+    foreignNet: int | None = None
+    institutionNet: int | None = None
+    individualNet: int | None = None
+    foreignNetBuyRank: int | None = None
+    foreignNetSellRank: int | None = None
+    institutionNetBuyRank: int | None = None
+    institutionNetSellRank: int | None = None
+    doubleBuy: bool = False
+    doubleSell: bool = False
+    foreignConsecutiveBuyDays: int | None = None
+    foreignConsecutiveSellDays: int | None = None
+    institutionConsecutiveBuyDays: int | None = None
+    institutionConsecutiveSellDays: int | None = None
+    individualConsecutiveBuyDays: int | None = None
+    individualConsecutiveSellDays: int | None = None
+    cautionLabel: str = "투자자별 수급은 과거 신호이며 매매 판단을 대신하지 않습니다."
+
+    @model_validator(mode="after")
+    def enforce_kr_only(self) -> StockDetailInvestorFlow:
+        if self.market != "kr":
+            raise ValueError("investor_flow is KR-only in /invest stock detail")
+        if self.dataState == "missing" and (
+            self.foreignNet is not None or self.institutionNet is not None
+        ):
+            raise ValueError(
+                "missing investor_flow must not expose any flow values"
+            )
+        return self
+
+
 class StockDetailHolding(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -337,6 +380,7 @@ class StockDetailResponse(BaseModel):
     valuation: StockDetailValuation | None = None
     naverEnrichment: StockDetailNaverEnrichment | None = None
     discussionSignal: StockDetailDiscussionSignal | None = None
+    investorFlow: StockDetailInvestorFlow | None = None
     holding: StockDetailHolding | None = None
     fxSensitivity: StockDetailFxSensitivity | None = None
     latestAnalysis: StockDetailLatestAnalysis | None = None

--- a/app/schemas/invest_stock_detail.py
+++ b/app/schemas/invest_stock_detail.py
@@ -239,11 +239,45 @@ class StockDetailInvestorFlowDailyRow(BaseModel):
     snapshotDate: str
     collectedAt: datetime | None = None
     source: str | None = None
+    close: float | None = None
+    changeRate: float | None = None
+    volume: int | None = None
     foreignNet: int | None = None
+    foreignHoldingShares: int | None = None
+    foreignHoldingRate: float | None = None
     institutionNet: int | None = None
     individualNet: int | None = None
     doubleBuy: bool = False
     doubleSell: bool = False
+
+
+class StockDetailInvestorFlowPeriodSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    windowDays: int
+    rowCount: int
+    foreignNetTotal: int | None = None
+    institutionNetTotal: int | None = None
+    individualNetTotal: int | None = None
+    foreignBuyDays: int = 0
+    foreignSellDays: int = 0
+    foreignFlatDays: int = 0
+    foreignNetToVolumeRatio: float | None = None
+    foreignHoldingSharesChange: int | None = None
+    foreignHoldingRateChange: float | None = None
+    unavailableLabels: list[str] = Field(default_factory=list)
+
+
+class StockDetailInvestorFlowBuyerDecomposition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    snapshotDate: str
+    label: str
+    leadingBuyer: Literal["foreign", "institution", "individual", "mixed", "unknown"]
+    foreignNet: int | None = None
+    institutionNet: int | None = None
+    individualNet: int | None = None
+    note: str
 
 
 class StockDetailInvestorFlow(BaseModel):
@@ -272,6 +306,9 @@ class StockDetailInvestorFlow(BaseModel):
     individualConsecutiveBuyDays: int | None = None
     individualConsecutiveSellDays: int | None = None
     dailyRows: list[StockDetailInvestorFlowDailyRow] = Field(default_factory=list)
+    periodSummary: StockDetailInvestorFlowPeriodSummary | None = None
+    buyerDecomposition: StockDetailInvestorFlowBuyerDecomposition | None = None
+    unavailableLabels: list[str] = Field(default_factory=list)
     cautionLabel: str = (
         "투자자별 수급은 지연된 과거 참고 데이터이며 매매 판단을 대신하지 않습니다."
     )

--- a/app/services/invest_coverage_service.py
+++ b/app/services/invest_coverage_service.py
@@ -76,10 +76,12 @@ async def build_invest_coverage(
     surfaces: list[InvestCoverageSurface] = []
     surfaces.extend(await _symbol_universe_surfaces(db, market_norm))
     surfaces.extend(await _screener_surfaces(db, market_norm, trading_day))
-    surfaces.extend(await _news_surfaces(db, market_norm, now))
+    surfaces.extend(await _news_surfaces(db, market_norm, now, symbols=symbol_list))
     surfaces.extend(await _calendar_surfaces(db, market_norm, trading_day, now))
     surfaces.extend(await _research_report_surfaces(db, market_norm, now))
-    surfaces.extend(await _investor_flow_surfaces(db, market_norm, trading_day))
+    surfaces.extend(
+        await _investor_flow_surfaces(db, market_norm, trading_day, symbols=symbol_list)
+    )
     surfaces.extend(await _holdings_surfaces(db, market_norm, now))
     surfaces.extend(await _pending_order_surfaces(db, market_norm, now))
     surfaces.extend(await _orderbook_nxt_surfaces(db, market_norm))
@@ -516,12 +518,19 @@ async def _screener_surfaces(
 
 
 async def _news_surfaces(
-    db: AsyncSession, market: str, now: dt.datetime
+    db: AsyncSession,
+    market: str,
+    now: dt.datetime,
+    *,
+    symbols: list[str] | None = None,
 ) -> list[InvestCoverageSurface]:
     markets = ["kr", "us", "crypto"] if market == "all" else [market]
     rows: list[InvestCoverageSurface] = []
     # news_articles.article_published_at is a timestamp without timezone.
     stale_cutoff = now.replace(tzinfo=None) - dt.timedelta(hours=24)
+    scoped_symbols = sorted(
+        {symbol.strip().upper() for symbol in (symbols or []) if symbol.strip()}
+    )
     for m in markets:
         run = (
             await db.execute(
@@ -534,19 +543,24 @@ async def _news_surfaces(
                 .limit(1)
             )
         ).scalar_one_or_none()
-        article_row = (
-            await db.execute(
-                sa.select(
-                    sa.func.count()
-                    .filter(NewsArticle.article_published_at >= stale_cutoff)
-                    .label("fresh"),
-                    sa.func.count()
-                    .filter(NewsArticle.article_published_at < stale_cutoff)
-                    .label("stale"),
-                    sa.func.max(NewsArticle.article_published_at).label("latest_at"),
-                ).where(NewsArticle.market == m)
+        article_query = sa.select(
+            sa.func.count(sa.distinct(NewsArticle.id))
+            .filter(NewsArticle.article_published_at >= stale_cutoff)
+            .label("fresh"),
+            sa.func.count(sa.distinct(NewsArticle.id))
+            .filter(NewsArticle.article_published_at < stale_cutoff)
+            .label("stale"),
+            sa.func.max(NewsArticle.article_published_at).label("latest_at"),
+        ).where(NewsArticle.market == m)
+        if scoped_symbols:
+            article_query = article_query.join(
+                NewsArticleRelatedSymbol,
+                NewsArticleRelatedSymbol.article_id == NewsArticle.id,
+            ).where(
+                NewsArticleRelatedSymbol.market == m,
+                NewsArticleRelatedSymbol.symbol.in_(scoped_symbols),
             )
-        ).one()
+        article_row = (await db.execute(article_query)).one()
         fresh = int(article_row.fresh or 0)
         stale = int(article_row.stale or 0)
         state = _state_from_counts(fresh=fresh, stale=stale)
@@ -718,7 +732,11 @@ async def _research_report_surfaces(
 
 
 async def _investor_flow_surfaces(
-    db: AsyncSession, market: str, trading_day: dt.date
+    db: AsyncSession,
+    market: str,
+    trading_day: dt.date,
+    *,
+    symbols: list[str] | None = None,
 ) -> list[InvestCoverageSurface]:
     if market in {"us", "crypto"}:
         return [
@@ -733,8 +751,16 @@ async def _investor_flow_surfaces(
         ]
     markets = ["kr"] if market in {"kr", "all"} else []
     rows: list[InvestCoverageSurface] = []
-    expected = await _universe_count(db, "kr")
+    scoped_symbols = sorted(
+        {symbol.strip().upper() for symbol in (symbols or []) if symbol.strip()}
+    )
+    expected = (
+        len(scoped_symbols) if scoped_symbols else await _universe_count(db, "kr")
+    )
     for m in markets:
+        predicates = [InvestorFlowSnapshot.market == m]
+        if scoped_symbols:
+            predicates.append(InvestorFlowSnapshot.symbol.in_(scoped_symbols))
         row = (
             await db.execute(
                 sa.select(
@@ -748,7 +774,7 @@ async def _investor_flow_surfaces(
                     sa.func.max(InvestorFlowSnapshot.snapshot_date).label(
                         "latest_date"
                     ),
-                ).where(InvestorFlowSnapshot.market == m)
+                ).where(*predicates)
             )
         ).one()
         fresh = int(row.fresh or 0)

--- a/app/services/invest_view_model/investor_flow_service.py
+++ b/app/services/invest_view_model/investor_flow_service.py
@@ -97,9 +97,7 @@ async def latest_items_for_symbols(
         market="kr", symbols=normalized_symbols, as_of=today
     )
     return {
-        row.symbol: _item_from_snapshot(
-            row, as_of=today, max_stale_days=max_stale_days
-        )
+        row.symbol: _item_from_snapshot(row, as_of=today, max_stale_days=max_stale_days)
         for row in rows
     }
 

--- a/app/services/invest_view_model/investor_flow_service.py
+++ b/app/services/invest_view_model/investor_flow_service.py
@@ -71,6 +71,39 @@ def _aggregate_state(items: list[InvestorFlowItem]) -> str:
     return "partial"
 
 
+async def latest_items_for_symbols(
+    *,
+    db: AsyncSession,
+    symbols: list[str],
+    market: str = "kr",
+    as_of: dt.date | None = None,
+    max_stale_days: int = 1,
+) -> dict[str, InvestorFlowItem]:
+    """Return {symbol -> fresh/stale InvestorFlowItem} for snapshots that exist.
+
+    Symbols with no snapshot are absent from the dict. Read-only; no live fetch.
+    """
+    normalized_market = market.strip().lower()
+    if normalized_market != "kr":
+        raise ValueError("investor_flow only supports market=kr")
+    today = as_of or dt.date.today()
+    normalized_symbols = [
+        _normalize_symbol(symbol) for symbol in symbols if symbol.strip()
+    ]
+    if not normalized_symbols:
+        return {}
+    repo = InvestorFlowSnapshotsRepository(db)
+    rows = await repo.latest_by_symbols(
+        market="kr", symbols=normalized_symbols, as_of=today
+    )
+    return {
+        row.symbol: _item_from_snapshot(
+            row, as_of=today, max_stale_days=max_stale_days
+        )
+        for row in rows
+    }
+
+
 async def build_investor_flow_cards(
     *,
     db: AsyncSession,

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -12,6 +12,7 @@ from app.schemas.invest_screener import ScreenerFilterChip, ScreenerPreset
 DEFAULT_PRESET_ID = "consecutive_gainers"
 CONSECUTIVE_GAINERS_LIMIT = 80
 CRYPTO_DEFAULT_PRESET_ID = "crypto_high_volume"
+_KR_ONLY_PRESET_IDS = {"investor_flow_momentum"}
 
 
 SCREENER_PRESETS: list[ScreenerPreset] = [
@@ -255,7 +256,10 @@ def preset_definitions(market: str = "kr") -> list[ScreenerPreset]:
     normalized_market = _normalize_requested_market(market)
     if normalized_market == "crypto":
         return [_with_market(p, "crypto") for p in CRYPTO_SCREENER_PRESETS]
-    return [_with_market(p, normalized_market) for p in SCREENER_PRESETS]
+    presets = SCREENER_PRESETS
+    if normalized_market != "kr":
+        presets = [p for p in SCREENER_PRESETS if p.id not in _KR_ONLY_PRESET_IDS]
+    return [_with_market(p, normalized_market) for p in presets]
 
 
 def get_preset(preset_id: str, market: str = "kr") -> ScreenerPreset | None:

--- a/app/services/invest_view_model/screener_presets.py
+++ b/app/services/invest_view_model/screener_presets.py
@@ -78,6 +78,19 @@ SCREENER_PRESETS: list[ScreenerPreset] = [
         market="kr",
     ),
     ScreenerPreset(
+        id="investor_flow_momentum",
+        name="수급 모멘텀",
+        description="외국인 연속 순매수·쌍끌이 매수 스냅샷 기반 후보",
+        badges=["MVP"],
+        filterChips=[
+            ScreenerFilterChip(label="국내", detail=None),
+            ScreenerFilterChip(label="투자자별 수급", detail="외국인 3일+ 또는 쌍끌이"),
+            ScreenerFilterChip(label="데이터", detail="지연 스냅샷 기반"),
+        ],
+        metricLabel="외국인 순매수",
+        market="kr",
+    ),
+    ScreenerPreset(
         id="growth_expectation",
         name="성장 기대주",
         description="시가총액이 충분하고 등락률 상위인 성장 기대 종목",
@@ -181,6 +194,15 @@ _SCREENING_FILTERS: dict[str, dict[str, object]] = {
         "sort_by": "change_rate",
         "sort_order": "desc",
         "min_market_cap": 1_000_000_000_000.0,
+        "limit": 20,
+    },
+    "investor_flow_momentum": {
+        "market": "kr",
+        "asset_type": "stock",
+        "sort_by": "investor_flow",
+        "sort_order": "desc",
+        "min_foreign_consecutive_buy_days": 3,
+        "include_double_buy": True,
         "limit": 20,
     },
     "crypto_high_volume": {

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -25,9 +25,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.schemas.invest_screener import (
     ChangeDirection,
     ScreenerFreshness,
+    ScreenerInvestorFlowChip,
     ScreenerPresetsResponse,
     ScreenerResultRow,
     ScreenerResultsResponse,
+)
+from app.schemas.investor_flow import InvestorFlowItem
+from app.services.invest_view_model.investor_flow_service import (
+    latest_items_for_symbols as _latest_investor_flow_items,
 )
 from app.services.invest_view_model.screener_presets import (
     CRYPTO_DEFAULT_PRESET_ID,
@@ -89,7 +94,96 @@ _KR_TOSS_EXCLUDED_NAME_TOKENS = (
     "TDF",
 )
 _KR_PREFERRED_SUFFIXES = ("우", "우B", "우C")
+_INVESTOR_FLOW_MIN_STREAK = 3
+_INVESTOR_FLOW_STALE_SUFFIX = " · 1일 지연"
 logger = logging.getLogger(__name__)
+
+
+def _investor_flow_chip_for_item(
+    item: InvestorFlowItem,
+) -> ScreenerInvestorFlowChip | None:
+    if item.dataState == "missing":
+        return None
+
+    def _annotate(label: str) -> str:
+        return label + _INVESTOR_FLOW_STALE_SUFFIX if item.dataState == "stale" else label
+
+    snapshot = item.snapshotDate.isoformat() if item.snapshotDate else None
+
+    if item.doubleBuy:
+        streak = max(
+            item.foreignConsecutiveBuyDays or 0,
+            item.institutionConsecutiveBuyDays or 0,
+        )
+        label = "쌍끌이 매수" + (f" {streak}일" if streak >= 2 else "")
+        return ScreenerInvestorFlowChip(
+            label=_annotate(label),
+            tone="double_buy",
+            dataState=item.dataState,
+            snapshotDate=snapshot,
+        )
+    if item.doubleSell:
+        streak = max(
+            item.foreignConsecutiveSellDays or 0,
+            item.institutionConsecutiveSellDays or 0,
+        )
+        label = "쌍끌이 매도" + (f" {streak}일" if streak >= 2 else "")
+        return ScreenerInvestorFlowChip(
+            label=_annotate(label),
+            tone="double_sell",
+            dataState=item.dataState,
+            snapshotDate=snapshot,
+        )
+    if (item.foreignConsecutiveBuyDays or 0) >= _INVESTOR_FLOW_MIN_STREAK:
+        return ScreenerInvestorFlowChip(
+            label=_annotate(f"외국인 {item.foreignConsecutiveBuyDays}일 순매수"),
+            tone="foreign_buy",
+            dataState=item.dataState,
+            snapshotDate=snapshot,
+        )
+    if (item.foreignConsecutiveSellDays or 0) >= _INVESTOR_FLOW_MIN_STREAK:
+        return ScreenerInvestorFlowChip(
+            label=_annotate(f"외국인 {item.foreignConsecutiveSellDays}일 순매도"),
+            tone="foreign_sell",
+            dataState=item.dataState,
+            snapshotDate=snapshot,
+        )
+    if (item.institutionConsecutiveBuyDays or 0) >= _INVESTOR_FLOW_MIN_STREAK:
+        return ScreenerInvestorFlowChip(
+            label=_annotate(f"기관 {item.institutionConsecutiveBuyDays}일 순매수"),
+            tone="institution_buy",
+            dataState=item.dataState,
+            snapshotDate=snapshot,
+        )
+    if (item.institutionConsecutiveSellDays or 0) >= _INVESTOR_FLOW_MIN_STREAK:
+        return ScreenerInvestorFlowChip(
+            label=_annotate(f"기관 {item.institutionConsecutiveSellDays}일 순매도"),
+            tone="institution_sell",
+            dataState=item.dataState,
+            snapshotDate=snapshot,
+        )
+    return None
+
+
+async def _hydrate_investor_flow_chips(
+    *, db: Any, market: str, rows: list[dict[str, Any]]
+) -> dict[str, ScreenerInvestorFlowChip]:
+    if market != "kr" or not rows or db is None:
+        return {}
+    symbols = sorted({str(r.get("symbol")) for r in rows if r.get("symbol")})
+    if not symbols:
+        return {}
+    try:
+        items = await _latest_investor_flow_items(db=db, symbols=symbols, market="kr")
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("screener investor-flow hydrate failed: %s", exc, exc_info=True)
+        return {}
+    chips: dict[str, ScreenerInvestorFlowChip] = {}
+    for symbol, item in items.items():
+        chip = _investor_flow_chip_for_item(item)
+        if chip is not None:
+            chips[symbol] = chip
+    return chips
 
 
 class _ScreeningServiceProto(Protocol):
@@ -886,6 +980,10 @@ async def build_screener_results(
             )
             _kr_names = {row_t.symbol: row_t.name for row_t in _kr_result.all()}
 
+    investor_flow_chips = await _hydrate_investor_flow_chips(
+        db=session, market=requested_market, rows=rows
+    )
+
     results: list[ScreenerResultRow] = []
     for idx, row in enumerate(rows, start=1):
         market = _normalize_market(row.get("market") or requested_market)
@@ -932,6 +1030,7 @@ async def build_screener_results(
                 volumeLabel=_format_volume_label(row, market),
                 analystLabel=str(row.get("analyst_label") or "-"),
                 metricValueLabel=metric_label,
+                investorFlowChip=investor_flow_chips.get(symbol),
                 warnings=row_warnings,
             )
         )

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -414,6 +414,110 @@ async def _load_consecutive_gainers_from_snapshots(
     return rows
 
 
+async def _load_investor_flow_discovery_from_snapshots(
+    session: AsyncSession | None, *, market: str, limit: int = 20
+) -> list[dict[str, Any]] | None:
+    """Return MVP 수급 discovery rows from persisted investor_flow_snapshots.
+
+    This preset is intentionally snapshot-only/read-only: if durable snapshots are
+    unavailable, callers may fall back to the generic screener service, but no
+    request-time Naver scraping is introduced here.
+    """
+    if session is None or market != "kr":
+        return None
+
+    from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+
+    latest_date_stmt = sa.select(sa.func.max(InvestorFlowSnapshot.snapshot_date)).where(
+        InvestorFlowSnapshot.market == "kr"
+    )
+    try:
+        latest_date_result = await session.execute(latest_date_stmt)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "failed to read investor_flow_snapshots max date: %s", exc, exc_info=True
+        )
+        return None
+    latest_snapshot_date = latest_date_result.scalar_one_or_none()
+    if latest_snapshot_date is None:
+        return None
+
+    candidate_limit = max(limit * 5, limit + 60)
+    stmt = (
+        sa.select(InvestorFlowSnapshot)
+        .where(
+            InvestorFlowSnapshot.market == "kr",
+            InvestorFlowSnapshot.snapshot_date == latest_snapshot_date,
+            sa.or_(
+                InvestorFlowSnapshot.double_buy.is_(True),
+                InvestorFlowSnapshot.foreign_consecutive_buy_days
+                >= _INVESTOR_FLOW_MIN_STREAK,
+                InvestorFlowSnapshot.foreign_net_buy_rank.is_not(None),
+            ),
+        )
+        .order_by(
+            InvestorFlowSnapshot.double_buy.desc(),
+            InvestorFlowSnapshot.foreign_consecutive_buy_days.desc().nullslast(),
+            InvestorFlowSnapshot.foreign_net_buy_rank.asc().nullslast(),
+            InvestorFlowSnapshot.foreign_net.desc().nullslast(),
+            InvestorFlowSnapshot.symbol.asc(),
+        )
+        .limit(candidate_limit)
+    )
+    try:
+        result = await session.execute(stmt)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("failed to read investor_flow_snapshots: %s", exc, exc_info=True)
+        return None
+    candidate_snaps = result.scalars().all()
+
+    symbol_names: dict[str, str] = {}
+    if candidate_snaps:
+        from app.models.kr_symbol_universe import KRSymbolUniverse
+
+        candidate_symbols = [snap.symbol for snap in candidate_snaps]
+        try:
+            name_result = await session.execute(
+                sa.select(KRSymbolUniverse.symbol, KRSymbolUniverse.name).where(
+                    KRSymbolUniverse.symbol.in_(candidate_symbols),
+                    KRSymbolUniverse.is_active.is_(True),
+                )
+            )
+            symbol_names = {row.symbol: row.name for row in name_result.all()}
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "failed to read kr_symbol_universe for investor-flow screener: %s",
+                exc,
+                exc_info=True,
+            )
+
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for snap in candidate_snaps:
+        if snap.symbol in seen:
+            continue
+        if not _is_kr_toss_common_stock(snap.symbol, symbol_names.get(snap.symbol)):
+            continue
+        seen.add(snap.symbol)
+        rows.append(
+            {
+                "symbol": snap.symbol,
+                "market": "kr",
+                "name": symbol_names.get(snap.symbol),
+                "foreign_net": snap.foreign_net,
+                "institution_net": snap.institution_net,
+                "individual_net": snap.individual_net,
+                "foreign_consecutive_buy_days": snap.foreign_consecutive_buy_days,
+                "institution_consecutive_buy_days": snap.institution_consecutive_buy_days,
+                "double_buy": snap.double_buy,
+                "_screener_snapshot_state": "fresh",
+            }
+        )
+        if len(rows) >= limit:
+            break
+    return rows
+
+
 async def _load_crypto_rows_from_snapshots(
     session: AsyncSession | None,
     *,
@@ -521,6 +625,7 @@ _METRIC_FIELD: dict[str, str] = {
     "oversold_recovery": "rsi",
     "high_volume_momentum": "volume",
     "growth_expectation": "change_rate",
+    "investor_flow_momentum": "foreign_net",
     "crypto_high_volume": "trade_amount_24h",
     "crypto_oversold": "rsi",
     "crypto_momentum": "change_rate",
@@ -771,6 +876,9 @@ def _metric_value_label(preset_id: str, row: dict[str, Any]) -> tuple[str, list[
         return f"{float(value):.2f}%", []
     if field in ("volume", "trade_amount_24h"):
         return f"{int(float(value)):,}", []
+    if field == "foreign_net":
+        sign = "+" if int(value) > 0 else "−" if int(value) < 0 else ""
+        return f"{sign}{abs(int(value)):,}주", []
     return str(value), []
 
 
@@ -877,6 +985,15 @@ async def build_screener_results(
                 market=requested_market,
                 limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
             )
+        elif preset_id == "investor_flow_momentum":
+            _snapshot_check_result = await _load_investor_flow_discovery_from_snapshots(
+                session,
+                market=requested_market,
+                limit=int(filters.get("limit") or _SNAPSHOT_FIRST_LIMIT),
+            )
+            _snapshot_empty_warning = (
+                "최신 수급 스냅샷에서 조건에 맞는 결과가 없습니다."
+            )
         elif requested_market == "crypto":
             _crypto_snapshot_result = await _load_crypto_rows_from_snapshots(
                 session,
@@ -891,6 +1008,16 @@ async def build_screener_results(
                 _snapshot_empty_warning = (
                     "최신 암호화폐 스크리너 스냅샷에서 조건에 맞는 결과가 없습니다."
                 )
+
+    if preset_id == "investor_flow_momentum" and _snapshot_check_result is None:
+        # This preset is deliberately persisted-snapshot-only. Do not fall
+        # through to the generic screener provider, which neither supports the
+        # investor-flow filters nor guarantees no request-time external lookup.
+        _snapshot_check_result = []
+        _snapshot_state_override = "missing"
+        _snapshot_empty_warning = (
+            "수급 스냅샷이 아직 적재되지 않아 수급 모멘텀 후보를 표시할 수 없습니다."
+        )
 
     _snapshot_was_checked = _snapshot_check_result is not None
     if _snapshot_was_checked:

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -167,20 +167,58 @@ def _investor_flow_chip_for_item(
     return None
 
 
+def _investor_flow_item_from_screener_row(
+    row: dict[str, Any],
+) -> InvestorFlowItem | None:
+    symbol = str(row.get("symbol") or "").strip().upper()
+    if not symbol:
+        return None
+
+    snapshot_state = str(row.get("_screener_snapshot_state") or "").strip()
+    data_state = snapshot_state if snapshot_state in {"fresh", "stale"} else "fresh"
+    return InvestorFlowItem(
+        symbol=symbol,
+        market="kr",
+        dataState=data_state,
+        snapshotDate=row.get("snapshot_date"),
+        foreignNet=row.get("foreign_net"),
+        institutionNet=row.get("institution_net"),
+        individualNet=row.get("individual_net"),
+        doubleBuy=bool(row.get("double_buy")),
+        doubleSell=bool(row.get("double_sell")),
+        foreignConsecutiveBuyDays=row.get("foreign_consecutive_buy_days"),
+        foreignConsecutiveSellDays=row.get("foreign_consecutive_sell_days"),
+        institutionConsecutiveBuyDays=row.get("institution_consecutive_buy_days"),
+        institutionConsecutiveSellDays=row.get("institution_consecutive_sell_days"),
+        individualConsecutiveBuyDays=row.get("individual_consecutive_buy_days"),
+        individualConsecutiveSellDays=row.get("individual_consecutive_sell_days"),
+    )
+
+
 async def _hydrate_investor_flow_chips(
     *, db: Any, market: str, rows: list[dict[str, Any]]
 ) -> dict[str, ScreenerInvestorFlowChip]:
     if market != "kr" or not rows or db is None:
         return {}
-    symbols = sorted({str(r.get("symbol")) for r in rows if r.get("symbol")})
+    chips: dict[str, ScreenerInvestorFlowChip] = {}
+    for row in rows:
+        item = _investor_flow_item_from_screener_row(row)
+        if item is None:
+            continue
+        chip = _investor_flow_chip_for_item(item)
+        if chip is not None:
+            chips[item.symbol] = chip
+
+    symbols = sorted(
+        {str(r.get("symbol")) for r in rows if r.get("symbol")} - set(chips.keys())
+    )
     if not symbols:
-        return {}
+        return chips
     try:
         items = await _latest_investor_flow_items(db=db, symbols=symbols, market="kr")
     except Exception as exc:  # noqa: BLE001
         logger.warning("screener investor-flow hydrate failed: %s", exc, exc_info=True)
-        return {}
-    chips: dict[str, ScreenerInvestorFlowChip] = {}
+        return chips
     for symbol, item in items.items():
         chip = _investor_flow_chip_for_item(item)
         if chip is not None:

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -106,7 +106,9 @@ def _investor_flow_chip_for_item(
         return None
 
     def _annotate(label: str) -> str:
-        return label + _INVESTOR_FLOW_STALE_SUFFIX if item.dataState == "stale" else label
+        return (
+            label + _INVESTOR_FLOW_STALE_SUFFIX if item.dataState == "stale" else label
+        )
 
     snapshot = item.snapshotDate.isoformat() if item.snapshotDate else None
 

--- a/app/services/invest_view_model/stock_detail_service.py
+++ b/app/services/invest_view_model/stock_detail_service.py
@@ -16,6 +16,7 @@ from app.schemas.invest_stock_detail import (
     StockDetailFxSensitivity,
     StockDetailHolding,
     StockDetailInvestorFlow,
+    StockDetailInvestorFlowDailyRow,
     StockDetailLatestAnalysis,
     StockDetailNaverEnrichment,
     StockDetailOrderbook,
@@ -38,6 +39,9 @@ from app.services.invest_view_model.stock_detail_symbol_resolver import (
     ResolvedSymbol,
     resolve_symbol,
 )
+from app.services.investor_flow_snapshots.repository import (
+    InvestorFlowSnapshotsRepository,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +53,27 @@ async def _none_provider(*args: Any, **kwargs: Any) -> None:
     return None
 
 
+def _daily_row_from_snapshot(row: Any) -> StockDetailInvestorFlowDailyRow:
+    return StockDetailInvestorFlowDailyRow(
+        snapshotDate=row.snapshot_date.isoformat(),
+        collectedAt=row.collected_at,
+        source=row.source,
+        foreignNet=row.foreign_net,
+        institutionNet=row.institution_net,
+        individualNet=row.individual_net,
+        doubleBuy=row.double_buy,
+        doubleSell=row.double_sell,
+    )
+
+
+async def _recent_investor_flow_rows(
+    *, db: Any, symbol: str, limit: int = 10
+) -> list[StockDetailInvestorFlowDailyRow]:
+    repo = InvestorFlowSnapshotsRepository(db)
+    rows = await repo.recent_by_symbol(market="kr", symbol=symbol, limit=limit)
+    return [_daily_row_from_snapshot(row) for row in rows]
+
+
 async def _default_investor_flow_provider(
     market: NewsMarket, symbol: str, db: Any
 ) -> StockDetailInvestorFlow | None:
@@ -56,8 +81,11 @@ async def _default_investor_flow_provider(
         return None
     items = await _latest_investor_flow_items(db=db, symbols=[symbol], market="kr")
     item = items.get(symbol)
+    daily_rows = await _recent_investor_flow_rows(db=db, symbol=symbol)
     if item is None:
-        return StockDetailInvestorFlow(symbol=symbol, dataState="missing")
+        return StockDetailInvestorFlow(
+            symbol=symbol, dataState="missing", dailyRows=daily_rows
+        )
     return StockDetailInvestorFlow(
         symbol=item.symbol,
         dataState=item.dataState,
@@ -79,6 +107,7 @@ async def _default_investor_flow_provider(
         institutionConsecutiveSellDays=item.institutionConsecutiveSellDays,
         individualConsecutiveBuyDays=item.individualConsecutiveBuyDays,
         individualConsecutiveSellDays=item.individualConsecutiveSellDays,
+        dailyRows=daily_rows,
     )
 
 

--- a/app/services/invest_view_model/stock_detail_service.py
+++ b/app/services/invest_view_model/stock_detail_service.py
@@ -16,7 +16,9 @@ from app.schemas.invest_stock_detail import (
     StockDetailFxSensitivity,
     StockDetailHolding,
     StockDetailInvestorFlow,
+    StockDetailInvestorFlowBuyerDecomposition,
     StockDetailInvestorFlowDailyRow,
+    StockDetailInvestorFlowPeriodSummary,
     StockDetailLatestAnalysis,
     StockDetailNaverEnrichment,
     StockDetailOrderbook,
@@ -67,11 +69,98 @@ def _daily_row_from_snapshot(row: Any) -> StockDetailInvestorFlowDailyRow:
 
 
 async def _recent_investor_flow_rows(
-    *, db: Any, symbol: str, limit: int = 10
+    *, db: Any, symbol: str, limit: int = 20
 ) -> list[StockDetailInvestorFlowDailyRow]:
     repo = InvestorFlowSnapshotsRepository(db)
     rows = await repo.recent_by_symbol(market="kr", symbol=symbol, limit=limit)
     return [_daily_row_from_snapshot(row) for row in rows]
+
+
+def _sum_known(values: list[int | None]) -> int | None:
+    known = [value for value in values if value is not None]
+    if not known:
+        return None
+    return sum(known)
+
+
+def _build_period_summary(
+    daily_rows: list[StockDetailInvestorFlowDailyRow],
+) -> StockDetailInvestorFlowPeriodSummary | None:
+    if not daily_rows:
+        return None
+    foreign_values = [row.foreignNet for row in daily_rows]
+    volume_values = [row.volume for row in daily_rows if row.volume is not None]
+    foreign_total = _sum_known(foreign_values)
+    volume_total = sum(volume_values) if volume_values else None
+    unavailable = [
+        "종가/등락률/거래량은 investor_flow_snapshots 저장소에 아직 없어 일별 표에서 준비중으로 표시됩니다.",
+        "외국인 보유주수/보유율은 investor_flow_snapshots 저장소에 아직 없어 변화율을 계산하지 않습니다.",
+    ]
+    return StockDetailInvestorFlowPeriodSummary(
+        windowDays=len(daily_rows),
+        rowCount=len(daily_rows),
+        foreignNetTotal=foreign_total,
+        institutionNetTotal=_sum_known([row.institutionNet for row in daily_rows]),
+        individualNetTotal=_sum_known([row.individualNet for row in daily_rows]),
+        foreignBuyDays=sum(
+            1 for value in foreign_values if value is not None and value > 0
+        ),
+        foreignSellDays=sum(
+            1 for value in foreign_values if value is not None and value < 0
+        ),
+        foreignFlatDays=sum(1 for value in foreign_values if value == 0),
+        foreignNetToVolumeRatio=(foreign_total / volume_total)
+        if foreign_total is not None and volume_total
+        else None,
+        foreignHoldingSharesChange=None,
+        foreignHoldingRateChange=None,
+        unavailableLabels=unavailable,
+    )
+
+
+def _build_buyer_decomposition(
+    daily_rows: list[StockDetailInvestorFlowDailyRow],
+) -> StockDetailInvestorFlowBuyerDecomposition | None:
+    if not daily_rows:
+        return None
+    # Without price/change-rate storage, use the latest available row as the
+    # decomposition proxy and label the price leg explicitly unavailable.
+    row = daily_rows[0]
+    buyers = {
+        "foreign": row.foreignNet,
+        "institution": row.institutionNet,
+        "individual": row.individualNet,
+    }
+    positive = {k: v for k, v in buyers.items() if v is not None and v > 0}
+    if not positive:
+        leading = "unknown"
+    else:
+        max_value = max(positive.values())
+        leaders = [k for k, v in positive.items() if v == max_value]
+        leading = leaders[0] if len(leaders) == 1 else "mixed"
+    label_by_leader = {
+        "foreign": "외국인 주도",
+        "institution": "기관 주도",
+        "individual": "개인 주도",
+        "mixed": "복합 주도",
+        "unknown": "주도 매수자 불명",
+    }
+    return StockDetailInvestorFlowBuyerDecomposition(
+        snapshotDate=row.snapshotDate,
+        label=label_by_leader[leading],
+        leadingBuyer=leading,
+        foreignNet=row.foreignNet,
+        institutionNet=row.institutionNet,
+        individualNet=row.individualNet,
+        note="급등일 여부는 종가/등락률 저장 전까지 판별하지 않고, 최신 수급 행의 매수 주체 분해만 표시합니다.",
+    )
+
+
+_INVESTOR_FLOW_UNAVAILABLE_LABELS = [
+    "일별 종가/등락률/거래량: 저장소 미적재",
+    "외국인 보유주수/보유율: 저장소 미적재",
+    "외국인 순매수/거래량 강도: 거래량 저장 전까지 계산 불가",
+]
 
 
 async def _default_investor_flow_provider(
@@ -82,9 +171,16 @@ async def _default_investor_flow_provider(
     items = await _latest_investor_flow_items(db=db, symbols=[symbol], market="kr")
     item = items.get(symbol)
     daily_rows = await _recent_investor_flow_rows(db=db, symbol=symbol)
+    period_summary = _build_period_summary(daily_rows)
+    buyer_decomposition = _build_buyer_decomposition(daily_rows)
     if item is None:
         return StockDetailInvestorFlow(
-            symbol=symbol, dataState="missing", dailyRows=daily_rows
+            symbol=symbol,
+            dataState="missing",
+            dailyRows=daily_rows,
+            periodSummary=period_summary,
+            buyerDecomposition=buyer_decomposition,
+            unavailableLabels=_INVESTOR_FLOW_UNAVAILABLE_LABELS,
         )
     return StockDetailInvestorFlow(
         symbol=item.symbol,
@@ -108,6 +204,9 @@ async def _default_investor_flow_provider(
         individualConsecutiveBuyDays=item.individualConsecutiveBuyDays,
         individualConsecutiveSellDays=item.individualConsecutiveSellDays,
         dailyRows=daily_rows,
+        periodSummary=period_summary,
+        buyerDecomposition=buyer_decomposition,
+        unavailableLabels=_INVESTOR_FLOW_UNAVAILABLE_LABELS,
     )
 
 

--- a/app/services/invest_view_model/stock_detail_service.py
+++ b/app/services/invest_view_model/stock_detail_service.py
@@ -15,6 +15,7 @@ from app.schemas.invest_stock_detail import (
     StockDetailFxScenario,
     StockDetailFxSensitivity,
     StockDetailHolding,
+    StockDetailInvestorFlow,
     StockDetailLatestAnalysis,
     StockDetailNaverEnrichment,
     StockDetailOrderbook,
@@ -22,6 +23,9 @@ from app.schemas.invest_stock_detail import (
     StockDetailResponse,
     default_capabilities_for_market,
     orderbook_support_for_market,
+)
+from app.services.invest_view_model.investor_flow_service import (
+    latest_items_for_symbols as _latest_investor_flow_items,
 )
 from app.services.exchange_rate_service import get_usd_krw_quote
 from app.services.invest_view_model.naver_discussion_signal_poc import (
@@ -43,6 +47,39 @@ Provider = Callable[..., Awaitable[Any]]
 
 async def _none_provider(*args: Any, **kwargs: Any) -> None:
     return None
+
+
+async def _default_investor_flow_provider(
+    market: NewsMarket, symbol: str, db: Any
+) -> StockDetailInvestorFlow | None:
+    if market != "kr":
+        return None
+    items = await _latest_investor_flow_items(db=db, symbols=[symbol], market="kr")
+    item = items.get(symbol)
+    if item is None:
+        return StockDetailInvestorFlow(symbol=symbol, dataState="missing")
+    return StockDetailInvestorFlow(
+        symbol=item.symbol,
+        dataState=item.dataState,
+        snapshotDate=item.snapshotDate.isoformat() if item.snapshotDate else None,
+        collectedAt=item.collectedAt,
+        snapshotSource=item.source,
+        foreignNet=item.foreignNet,
+        institutionNet=item.institutionNet,
+        individualNet=item.individualNet,
+        foreignNetBuyRank=item.foreignNetBuyRank,
+        foreignNetSellRank=item.foreignNetSellRank,
+        institutionNetBuyRank=item.institutionNetBuyRank,
+        institutionNetSellRank=item.institutionNetSellRank,
+        doubleBuy=item.doubleBuy,
+        doubleSell=item.doubleSell,
+        foreignConsecutiveBuyDays=item.foreignConsecutiveBuyDays,
+        foreignConsecutiveSellDays=item.foreignConsecutiveSellDays,
+        institutionConsecutiveBuyDays=item.institutionConsecutiveBuyDays,
+        institutionConsecutiveSellDays=item.institutionConsecutiveSellDays,
+        individualConsecutiveBuyDays=item.individualConsecutiveBuyDays,
+        individualConsecutiveSellDays=item.individualConsecutiveSellDays,
+    )
 
 
 async def _run_optional_block(
@@ -70,6 +107,7 @@ class StockDetailProviders:
     fx_rate: Provider = get_usd_krw_quote
     naver_enrichment: Provider = build_naver_stock_detail_poc
     discussion_signal: Provider = build_naver_discussion_signal_poc
+    investor_flow: Provider = _default_investor_flow_provider
 
 
 DEFAULT_STOCK_DETAIL_PROVIDERS = StockDetailProviders()
@@ -129,8 +167,14 @@ async def build_stock_detail(
         orderbook_task = _run_optional_block(
             "orderbook", providers.orderbook(market, resolved.symbol_db, db), warnings
         )
+        investor_flow_task = _run_optional_block(
+            "investor_flow",
+            providers.investor_flow(market, resolved.symbol_db, db),
+            warnings,
+        )
     else:
         orderbook_task = _none_provider()
+        investor_flow_task = _none_provider()
 
     (
         quote,
@@ -141,6 +185,7 @@ async def build_stock_detail(
         naver_enrichment,
         discussion_signal,
         orderbook,
+        investor_flow,
     ) = await asyncio.gather(
         quote_task,
         screener_task,
@@ -150,6 +195,7 @@ async def build_stock_detail(
         naver_enrichment_task,
         discussion_signal_task,
         orderbook_task,
+        investor_flow_task,
     )
 
     capabilities = default_capabilities_for_market(market)
@@ -186,6 +232,10 @@ async def build_stock_detail(
         )
     if orderbook is not None and not isinstance(orderbook, StockDetailOrderbook):
         orderbook = StockDetailOrderbook.model_validate(orderbook)
+    if investor_flow is not None and not isinstance(
+        investor_flow, StockDetailInvestorFlow
+    ):
+        investor_flow = StockDetailInvestorFlow.model_validate(investor_flow)
 
     fx_rate = None
     if _should_fetch_fx_rate(
@@ -215,6 +265,7 @@ async def build_stock_detail(
         valuation=valuation,
         naverEnrichment=naver_enrichment,
         discussionSignal=discussion_signal,
+        investorFlow=investor_flow,
         holding=holding,
         fxSensitivity=fx_sensitivity,
         latestAnalysis=latest_analysis,

--- a/app/services/invest_view_model/stock_detail_service.py
+++ b/app/services/invest_view_model/stock_detail_service.py
@@ -24,10 +24,10 @@ from app.schemas.invest_stock_detail import (
     default_capabilities_for_market,
     orderbook_support_for_market,
 )
+from app.services.exchange_rate_service import get_usd_krw_quote
 from app.services.invest_view_model.investor_flow_service import (
     latest_items_for_symbols as _latest_investor_flow_items,
 )
-from app.services.exchange_rate_service import get_usd_krw_quote
 from app.services.invest_view_model.naver_discussion_signal_poc import (
     build_naver_discussion_signal_poc,
 )

--- a/app/services/investor_flow_snapshots/repository.py
+++ b/app/services/investor_flow_snapshots/repository.py
@@ -85,6 +85,36 @@ class InvestorFlowSnapshotsRepository:
         )
         await self._session.execute(stmt)
 
+    async def recent_by_symbol(
+        self,
+        *,
+        market: str,
+        symbol: str,
+        as_of: dt.date | None = None,
+        limit: int = 10,
+    ) -> list[InvestorFlowSnapshot]:
+        normalized_symbol = _normalize_symbol(symbol)
+        if not normalized_symbol:
+            return []
+        stmt = select(InvestorFlowSnapshot).where(
+            InvestorFlowSnapshot.market == market.strip().lower(),
+            InvestorFlowSnapshot.symbol == normalized_symbol,
+        )
+        if as_of is not None:
+            stmt = stmt.where(InvestorFlowSnapshot.snapshot_date <= as_of)
+        result = await self._session.execute(
+            stmt.order_by(
+                InvestorFlowSnapshot.snapshot_date.desc(),
+                InvestorFlowSnapshot.source.asc(),
+            ).limit(limit)
+        )
+        rows = list(result.scalars().all())
+        by_date: dict[dt.date, InvestorFlowSnapshot] = {}
+        for row in rows:
+            # Keep deterministic source precedence if multiple source snapshots exist.
+            by_date.setdefault(row.snapshot_date, row)
+        return list(by_date.values())
+
     async def latest_by_symbols(
         self,
         *,

--- a/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
@@ -35,7 +35,7 @@ const ROW = {
   priceLabel: "80,000원", changePctLabel: "+1.23%", changeAmountLabel: "+970원",
   changeDirection: "up" as const, category: "반도체",
   marketCapLabel: "478조원", volumeLabel: "12,345,678",
-  analystLabel: "구매", metricValueLabel: "+8.00%", warnings: [],
+  analystLabel: "구매", metricValueLabel: "+8.00%", investorFlowChip: null, warnings: [],
 };
 
 const RESULTS_GAINERS = {

--- a/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
@@ -25,6 +25,13 @@ const PRESETS = {
       filterChips: [{ label: "PER", detail: "15 이하" }],
       metricLabel: "PER", market: "kr" as const,
     },
+    {
+      id: "investor_flow_momentum", name: "수급 모멘텀",
+      description: "외국인 연속 순매수·쌍끌이 매수 스냅샷 기반 후보",
+      badges: ["MVP"],
+      filterChips: [{ label: "투자자별 수급", detail: "외국인 3일+ 또는 쌍끌이" }],
+      metricLabel: "외국인 순매수", market: "kr" as const,
+    },
   ],
   selectedPresetId: "consecutive_gainers",
 };
@@ -60,6 +67,26 @@ const RESULTS_VALUE = {
   metricLabel: "PER",
   filterChips: [{ label: "PER", detail: "15 이하" }],
   results: [{ ...ROW, metricValueLabel: "14.0" }],
+};
+
+const RESULTS_INVESTOR_FLOW = {
+  ...RESULTS_GAINERS,
+  presetId: "investor_flow_momentum", title: "수급 모멘텀",
+  description: "외국인 연속 순매수·쌍끌이 매수 스냅샷 기반 후보",
+  metricLabel: "외국인 순매수",
+  filterChips: [{ label: "투자자별 수급", detail: "외국인 3일+ 또는 쌍끌이" }],
+  results: [{
+    ...ROW,
+    symbol: "403550",
+    name: "에스케이엔펄스",
+    metricValueLabel: "+20,859주",
+    investorFlowChip: {
+      label: "외국인 4일 순매수",
+      tone: "foreign_buy" as const,
+      dataState: "fresh" as const,
+      snapshotDate: "2026-05-13",
+    },
+  }],
 };
 
 const CRYPTO_PRESETS = {
@@ -134,7 +161,9 @@ beforeEach(() => {
         }],
       };
     }
-    return id === "cheap_value" ? RESULTS_VALUE : RESULTS_GAINERS;
+    if (id === "cheap_value") return RESULTS_VALUE;
+    if (id === "investor_flow_momentum") return RESULTS_INVESTOR_FLOW;
+    return RESULTS_GAINERS;
   });
 });
 
@@ -161,6 +190,19 @@ test("shows an empty-state message when results are empty", async () => {
   await waitFor(() =>
     expect(screen.getByText(/표시할 종목이 없습니다/)).toBeInTheDocument(),
   );
+});
+
+
+test("renders the investor-flow MVP preset and result chip", async () => {
+  render(wrap(<DesktopScreenerPage />));
+  await waitFor(() => expect(screen.getByText("삼성전자")).toBeInTheDocument());
+
+  await userEvent.click(screen.getByTestId("screener-preset-investor_flow_momentum"));
+
+  await waitFor(() => expect(screen.getByText("에스케이엔펄스")).toBeInTheDocument());
+  expect(screen.getByText("외국인 연속 순매수·쌍끌이 매수 스냅샷 기반 후보")).toBeInTheDocument();
+  expect(screen.getByText("외국인 4일 순매수")).toBeInTheDocument();
+  expect(screenerApi.fetchScreenerResults).toHaveBeenCalledWith("investor_flow_momentum", "kr");
 });
 
 

--- a/frontend/invest/src/__tests__/StockDetailPage.test.tsx
+++ b/frontend/invest/src/__tests__/StockDetailPage.test.tsx
@@ -386,6 +386,76 @@ test("omits the Naver PoC card when the backend has no safe enrichment map", asy
   expect(screen.queryByTestId("stock-detail-naver-poc")).not.toBeInTheDocument();
 });
 
+test("renders KR investor-flow summary and daily rows as read-only reference data", async () => {
+  vi.mocked(stockApi.fetchStockDetail).mockResolvedValue({
+    ...aboveFold,
+    market: "kr",
+    symbol: "403550",
+    displayName: "쏘카",
+    exchange: "KOSPI",
+    currency: "KRW",
+    investorFlow: {
+      source: "investor_flow_snapshots",
+      market: "kr",
+      symbol: "403550",
+      dataState: "fresh",
+      snapshotDate: "2026-05-13",
+      collectedAt: "2026-05-13T15:40:00Z",
+      snapshotSource: "naver_finance",
+      foreignNet: 20859,
+      institutionNet: -12931,
+      individualNet: 125586,
+      foreignNetBuyRank: null,
+      foreignNetSellRank: null,
+      institutionNetBuyRank: null,
+      institutionNetSellRank: null,
+      doubleBuy: false,
+      doubleSell: false,
+      foreignConsecutiveBuyDays: 4,
+      foreignConsecutiveSellDays: null,
+      institutionConsecutiveBuyDays: null,
+      institutionConsecutiveSellDays: 1,
+      individualConsecutiveBuyDays: 2,
+      individualConsecutiveSellDays: null,
+      dailyRows: [
+        {
+          snapshotDate: "2026-05-13",
+          collectedAt: "2026-05-13T15:40:00Z",
+          source: "naver_finance",
+          foreignNet: 20859,
+          institutionNet: -12931,
+          individualNet: 125586,
+          doubleBuy: false,
+          doubleSell: false,
+        },
+        {
+          snapshotDate: "2026-05-12",
+          collectedAt: "2026-05-12T15:40:00Z",
+          source: "naver_finance",
+          foreignNet: 440,
+          institutionNet: 1024,
+          individualNet: -1464,
+          doubleBuy: true,
+          doubleSell: false,
+        },
+      ],
+      cautionLabel: "투자자별 수급은 지연된 과거 참고 데이터이며 매매 판단을 대신하지 않습니다.",
+    },
+  });
+
+  renderPage();
+
+  const card = await screen.findByTestId("stock-detail-investor-flow");
+  expect(card).toHaveTextContent("투자자별 매매동향 · 수급 흐름");
+  expect(card).toHaveTextContent("naver_finance · 기준일 2026-05-13");
+  expect(card).toHaveTextContent("+20,859주");
+  expect(card).toHaveTextContent("−12,931주");
+  expect(card).toHaveTextContent("2026-05-12");
+  expect(card).toHaveTextContent("쌍끌이");
+  expect(card).toHaveTextContent("매매 판단을 대신하지 않습니다");
+});
+
+
 test("renders conservative fallback text when FX sensitivity is not applicable", async () => {
   vi.mocked(stockApi.fetchStockDetail).mockResolvedValue({
     ...aboveFold,

--- a/frontend/invest/src/__tests__/StockDetailPage.test.tsx
+++ b/frontend/invest/src/__tests__/StockDetailPage.test.tsx
@@ -422,7 +422,12 @@ test("renders KR investor-flow summary and daily rows as read-only reference dat
           snapshotDate: "2026-05-13",
           collectedAt: "2026-05-13T15:40:00Z",
           source: "naver_finance",
+          close: null,
+          changeRate: null,
+          volume: null,
           foreignNet: 20859,
+          foreignHoldingShares: null,
+          foreignHoldingRate: null,
           institutionNet: -12931,
           individualNet: 125586,
           doubleBuy: false,
@@ -432,13 +437,42 @@ test("renders KR investor-flow summary and daily rows as read-only reference dat
           snapshotDate: "2026-05-12",
           collectedAt: "2026-05-12T15:40:00Z",
           source: "naver_finance",
+          close: null,
+          changeRate: null,
+          volume: null,
           foreignNet: 440,
+          foreignHoldingShares: null,
+          foreignHoldingRate: null,
           institutionNet: 1024,
           individualNet: -1464,
           doubleBuy: true,
           doubleSell: false,
         },
       ],
+      periodSummary: {
+        windowDays: 2,
+        rowCount: 2,
+        foreignNetTotal: 21299,
+        institutionNetTotal: -11907,
+        individualNetTotal: 124122,
+        foreignBuyDays: 2,
+        foreignSellDays: 0,
+        foreignFlatDays: 0,
+        foreignNetToVolumeRatio: null,
+        foreignHoldingSharesChange: null,
+        foreignHoldingRateChange: null,
+        unavailableLabels: ["거래량 저장 전까지 계산 불가"],
+      },
+      buyerDecomposition: {
+        snapshotDate: "2026-05-13",
+        label: "개인 주도",
+        leadingBuyer: "individual",
+        foreignNet: 20859,
+        institutionNet: -12931,
+        individualNet: 125586,
+        note: "최신 수급 행 기준입니다.",
+      },
+      unavailableLabels: ["외국인 순매수/거래량 강도: 거래량 저장 전까지 계산 불가"],
       cautionLabel: "투자자별 수급은 지연된 과거 참고 데이터이며 매매 판단을 대신하지 않습니다.",
     },
   });
@@ -450,6 +484,9 @@ test("renders KR investor-flow summary and daily rows as read-only reference dat
   expect(card).toHaveTextContent("naver_finance · 기준일 2026-05-13");
   expect(card).toHaveTextContent("+20,859주");
   expect(card).toHaveTextContent("−12,931주");
+  expect(card).toHaveTextContent("최근 2거래일 수급 요약");
+  expect(card).toHaveTextContent("주도 매수자 분해");
+  expect(card).toHaveTextContent("개인 주도");
   expect(card).toHaveTextContent("2026-05-12");
   expect(card).toHaveTextContent("쌍끌이");
   expect(card).toHaveTextContent("매매 판단을 대신하지 않습니다");

--- a/frontend/invest/src/__tests__/StockDetailPage.test.tsx
+++ b/frontend/invest/src/__tests__/StockDetailPage.test.tsx
@@ -49,6 +49,7 @@ const aboveFold: StockDetailResponse = {
     asOf: "2026-05-09T00:00:00Z",
     freshness: "ok",
   },
+  investorFlow: null,
   naverEnrichment: {
     source: "naver_stock_detail_poc",
     market: "us",

--- a/frontend/invest/src/desktop/screener/InvestorFlowChip.tsx
+++ b/frontend/invest/src/desktop/screener/InvestorFlowChip.tsx
@@ -10,7 +10,7 @@ const TONE_CLASS: Record<ScreenerInvestorFlowChip["tone"], string> = {
   neutral: "investor-flow-chip--neutral",
 };
 
-export function InvestorFlowChip({ chip }: { chip: ScreenerInvestorFlowChip }) {
+export function InvestorFlowChip({ chip }: Readonly<{ chip: ScreenerInvestorFlowChip }>) {
   const title = chip.snapshotDate ? `${chip.label} (${chip.snapshotDate})` : chip.label;
   return (
     <span

--- a/frontend/invest/src/desktop/screener/InvestorFlowChip.tsx
+++ b/frontend/invest/src/desktop/screener/InvestorFlowChip.tsx
@@ -1,0 +1,24 @@
+import type { ScreenerInvestorFlowChip } from "../../types/screener";
+
+const TONE_CLASS: Record<ScreenerInvestorFlowChip["tone"], string> = {
+  double_buy: "investor-flow-chip--double-buy",
+  double_sell: "investor-flow-chip--double-sell",
+  foreign_buy: "investor-flow-chip--foreign-buy",
+  foreign_sell: "investor-flow-chip--foreign-sell",
+  institution_buy: "investor-flow-chip--institution-buy",
+  institution_sell: "investor-flow-chip--institution-sell",
+  neutral: "investor-flow-chip--neutral",
+};
+
+export function InvestorFlowChip({ chip }: { chip: ScreenerInvestorFlowChip }) {
+  const title = chip.snapshotDate ? `${chip.label} (${chip.snapshotDate})` : chip.label;
+  return (
+    <span
+      className={`investor-flow-chip ${TONE_CLASS[chip.tone]} investor-flow-chip--${chip.dataState}`}
+      title={title}
+      data-testid="investor-flow-chip"
+    >
+      {chip.label}
+    </span>
+  );
+}

--- a/frontend/invest/src/desktop/screener/ScreenerResultsTable.tsx
+++ b/frontend/invest/src/desktop/screener/ScreenerResultsTable.tsx
@@ -1,4 +1,5 @@
 import "./screener.css";
+import { InvestorFlowChip } from "./InvestorFlowChip";
 import type { ScreenerResultRow } from "../../types/screener";
 
 interface Props {
@@ -58,7 +59,10 @@ export function ScreenerResultsTable({ rows, metricLabel }: Props) {
             <td>{r.marketCapLabel}</td>
             <td>{r.volumeLabel}</td>
             <td>{r.analystLabel}</td>
-            <td>{r.metricValueLabel}</td>
+            <td>
+              {r.metricValueLabel}
+              {r.investorFlowChip ? <InvestorFlowChip chip={r.investorFlowChip} /> : null}
+            </td>
           </tr>
         ))}
       </tbody>

--- a/frontend/invest/src/desktop/stock-detail/InvestorFlowCard.tsx
+++ b/frontend/invest/src/desktop/stock-detail/InvestorFlowCard.tsx
@@ -23,6 +23,22 @@ function fmtSignedShares(v: number | null | undefined): string {
   return `${sign}${Math.abs(v).toLocaleString("ko-KR")}주`;
 }
 
+function fmtNumber(v: number | null | undefined, suffix = ""): string {
+  if (v == null) return "−";
+  return `${v.toLocaleString("ko-KR")}${suffix}`;
+}
+
+function fmtRatio(v: number | null | undefined): string {
+  if (v == null) return "계산 불가";
+  return `${(v * 100).toLocaleString("ko-KR", { maximumFractionDigits: 2 })}%`;
+}
+
+function fmtPercent(v: number | null | undefined): string {
+  if (v == null) return "−";
+  const sign = v > 0 ? "+" : "";
+  return `${sign}${v.toLocaleString("ko-KR", { maximumFractionDigits: 2 })}%`;
+}
+
 function streakLabel(buy: number | null | undefined, sell: number | null | undefined): string {
   if ((buy ?? 0) >= 1) return `+${buy}일 순매수`;
   if ((sell ?? 0) >= 1) return `−${sell}일 순매도`;
@@ -55,6 +71,48 @@ function RowTonePill({ row }: { row: StockDetailInvestorFlowDailyRow }) {
   return <Pill tone="paper">관찰</Pill>;
 }
 
+function InvestorFlowSummary({ data }: { data: StockDetailInvestorFlow }) {
+  const summary = data.periodSummary;
+  const decomposition = data.buyerDecomposition;
+  if (!summary && !decomposition) return null;
+  return (
+    <div
+      style={{
+        marginTop: 12,
+        display: "grid",
+        gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+        gap: 12,
+      }}
+    >
+      {summary ? (
+        <div style={{ border: "1px solid var(--line)", borderRadius: 14, padding: 12 }}>
+          <div style={{ fontWeight: 800, fontSize: 13 }}>최근 {summary.windowDays}거래일 수급 요약</div>
+          <div style={{ marginTop: 8, display: "grid", gap: 4, color: "var(--fg-2)", fontSize: 12 }}>
+            <span>외국인 누적 {fmtSignedShares(summary.foreignNetTotal)}</span>
+            <span>기관 누적 {fmtSignedShares(summary.institutionNetTotal)}</span>
+            <span>개인 누적 {fmtSignedShares(summary.individualNetTotal)}</span>
+            <span>외국인 순매수/순매도/보합 {summary.foreignBuyDays}/{summary.foreignSellDays}/{summary.foreignFlatDays}일</span>
+            <span>외국인 순매수÷거래량 {fmtRatio(summary.foreignNetToVolumeRatio)}</span>
+          </div>
+        </div>
+      ) : null}
+      {decomposition ? (
+        <div style={{ border: "1px solid var(--line)", borderRadius: 14, padding: 12 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "center" }}>
+            <div style={{ fontWeight: 800, fontSize: 13 }}>주도 매수자 분해</div>
+            <Pill tone={decomposition.leadingBuyer === "unknown" ? "paper" : "gain"}>{decomposition.label}</Pill>
+          </div>
+          <div style={{ marginTop: 8, display: "grid", gap: 4, color: "var(--fg-2)", fontSize: 12 }}>
+            <span>기준 {decomposition.snapshotDate}</span>
+            <span>외국인 {fmtSignedShares(decomposition.foreignNet)} · 기관 {fmtSignedShares(decomposition.institutionNet)} · 개인 {fmtSignedShares(decomposition.individualNet)}</span>
+            <span style={{ color: "var(--fg-3)" }}>{decomposition.note}</span>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function DailyRowsTable({ rows }: { rows: StockDetailInvestorFlowDailyRow[] }) {
   if (rows.length === 0) {
     return (
@@ -69,7 +127,11 @@ function DailyRowsTable({ rows }: { rows: StockDetailInvestorFlowDailyRow[] }) {
         <thead>
           <tr style={{ color: "var(--fg-3)", textAlign: "right" }}>
             <th style={{ padding: "6px 4px", textAlign: "left", borderBottom: "1px solid var(--line)" }}>일자</th>
+            <th style={{ padding: "6px 4px", borderBottom: "1px solid var(--line)" }}>종가</th>
+            <th style={{ padding: "6px 4px", borderBottom: "1px solid var(--line)" }}>등락률</th>
+            <th style={{ padding: "6px 4px", borderBottom: "1px solid var(--line)" }}>거래량</th>
             <th style={{ padding: "6px 4px", borderBottom: "1px solid var(--line)" }}>외국인</th>
+            <th style={{ padding: "6px 4px", borderBottom: "1px solid var(--line)" }}>외국인 보유</th>
             <th style={{ padding: "6px 4px", borderBottom: "1px solid var(--line)" }}>기관</th>
             <th style={{ padding: "6px 4px", borderBottom: "1px solid var(--line)" }}>개인</th>
             <th style={{ padding: "6px 4px", textAlign: "center", borderBottom: "1px solid var(--line)" }}>메모</th>
@@ -79,7 +141,11 @@ function DailyRowsTable({ rows }: { rows: StockDetailInvestorFlowDailyRow[] }) {
           {rows.slice(0, 10).map((row) => (
             <tr key={`${row.snapshotDate}-${row.source ?? "snapshot"}`}>
               <td style={{ padding: "7px 4px", borderBottom: "1px solid var(--line)", color: "var(--fg-2)" }}>{row.snapshotDate}</td>
+              <td style={{ padding: "7px 4px", textAlign: "right", borderBottom: "1px solid var(--line)", color: "var(--fg-2)" }}>{fmtNumber(row.close)}</td>
+              <td style={{ padding: "7px 4px", textAlign: "right", borderBottom: "1px solid var(--line)", color: (row.changeRate ?? 0) >= 0 ? "var(--gain)" : "var(--loss)" }}>{fmtPercent(row.changeRate)}</td>
+              <td style={{ padding: "7px 4px", textAlign: "right", borderBottom: "1px solid var(--line)", color: "var(--fg-2)" }}>{fmtNumber(row.volume)}</td>
               <td style={{ padding: "7px 4px", textAlign: "right", borderBottom: "1px solid var(--line)", color: (row.foreignNet ?? 0) >= 0 ? "var(--gain)" : "var(--loss)" }}>{fmtSignedShares(row.foreignNet)}</td>
+              <td style={{ padding: "7px 4px", textAlign: "right", borderBottom: "1px solid var(--line)", color: "var(--fg-2)" }}>{fmtNumber(row.foreignHoldingShares, "주")} / {fmtPercent(row.foreignHoldingRate)}</td>
               <td style={{ padding: "7px 4px", textAlign: "right", borderBottom: "1px solid var(--line)", color: (row.institutionNet ?? 0) >= 0 ? "var(--gain)" : "var(--loss)" }}>{fmtSignedShares(row.institutionNet)}</td>
               <td style={{ padding: "7px 4px", textAlign: "right", borderBottom: "1px solid var(--line)", color: (row.individualNet ?? 0) >= 0 ? "var(--gain)" : "var(--loss)" }}>{fmtSignedShares(row.individualNet)}</td>
               <td style={{ padding: "7px 4px", textAlign: "center", borderBottom: "1px solid var(--line)" }}><RowTonePill row={row} /></td>
@@ -138,6 +204,7 @@ export function InvestorFlowCard({ data }: { data: StockDetailInvestorFlow }) {
               sub={streakLabel(data.individualConsecutiveBuyDays, data.individualConsecutiveSellDays)}
             />
           </div>
+          <InvestorFlowSummary data={data} />
           {(data.doubleBuy || data.doubleSell) && (
             <div style={{ marginTop: 10 }}>
               <Pill tone={data.doubleBuy ? "gain" : "loss"}>
@@ -148,6 +215,11 @@ export function InvestorFlowCard({ data }: { data: StockDetailInvestorFlow }) {
           <DailyRowsTable rows={dailyRows} />
         </>
       )}
+      {(data.unavailableLabels ?? []).length > 0 ? (
+        <p style={{ marginTop: 12, color: "var(--fg-3)", fontSize: 11 }}>
+          준비중 지표: {(data.unavailableLabels ?? []).join(" · ")}
+        </p>
+      ) : null}
       <p style={{ marginTop: 12, color: "var(--fg-3)", fontSize: 11 }}>
         {data.cautionLabel}
       </p>

--- a/frontend/invest/src/desktop/stock-detail/InvestorFlowCard.tsx
+++ b/frontend/invest/src/desktop/stock-detail/InvestorFlowCard.tsx
@@ -1,0 +1,89 @@
+import { Card, Pill } from "../../ds";
+import type { InvestorFlowDetailState, StockDetailInvestorFlow } from "../../types/stockDetail";
+
+const STATE_TONE: Record<InvestorFlowDetailState, "gain" | "warn" | "paper"> = {
+  fresh: "gain",
+  stale: "warn",
+  missing: "paper",
+};
+
+const STATE_LABEL: Record<InvestorFlowDetailState, string> = {
+  fresh: "최신",
+  stale: "지연",
+  missing: "데이터 준비중",
+};
+
+function fmtKrwSigned(v: number | null | undefined): string {
+  if (v == null) return "−";
+  const sign = v > 0 ? "+" : v < 0 ? "−" : "";
+  return `${sign}₩${Math.abs(v).toLocaleString("ko-KR")}`;
+}
+
+function streakLabel(buy: number | null | undefined, sell: number | null | undefined): string {
+  if ((buy ?? 0) >= 1) return `+${buy}일 순매수`;
+  if ((sell ?? 0) >= 1) return `−${sell}일 순매도`;
+  return "−";
+}
+
+function FlowMetric({ label, value, sub }: { label: string; value: string; sub: string }) {
+  return (
+    <div>
+      <div style={{ color: "var(--fg-3)", fontSize: 11 }}>{label}</div>
+      <div style={{ fontWeight: 700, fontSize: 16 }}>{value}</div>
+      <div style={{ color: "var(--fg-3)", fontSize: 11 }}>{sub}</div>
+    </div>
+  );
+}
+
+export function InvestorFlowCard({ data }: { data: StockDetailInvestorFlow }) {
+  return (
+    <Card data-testid="stock-detail-investor-flow">
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <strong>투자자별 수급 ({data.snapshotDate ?? "−"})</strong>
+        <Pill tone={STATE_TONE[data.dataState]}>{STATE_LABEL[data.dataState]}</Pill>
+      </div>
+      {data.dataState === "missing" ? (
+        <p style={{ marginTop: 8, color: "var(--fg-3)", fontSize: 12 }}>
+          최근 KR 투자자별 수급 스냅샷이 없어 표시할 수 없습니다.
+        </p>
+      ) : (
+        <>
+          <div
+            style={{
+              marginTop: 12,
+              display: "grid",
+              gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+              gap: 12,
+            }}
+          >
+            <FlowMetric
+              label="외국인 순매수"
+              value={fmtKrwSigned(data.foreignNet)}
+              sub={streakLabel(data.foreignConsecutiveBuyDays, data.foreignConsecutiveSellDays)}
+            />
+            <FlowMetric
+              label="기관 순매수"
+              value={fmtKrwSigned(data.institutionNet)}
+              sub={streakLabel(data.institutionConsecutiveBuyDays, data.institutionConsecutiveSellDays)}
+            />
+            <FlowMetric
+              label="개인 순매수"
+              value={fmtKrwSigned(data.individualNet)}
+              sub={streakLabel(data.individualConsecutiveBuyDays, data.individualConsecutiveSellDays)}
+            />
+          </div>
+          {(data.doubleBuy || data.doubleSell) && (
+            <div style={{ marginTop: 10 }}>
+              <Pill tone={data.doubleBuy ? "gain" : "loss"}>
+                {data.doubleBuy ? "쌍끌이 매수" : "쌍끌이 매도"}
+              </Pill>
+            </div>
+          )}
+        </>
+      )}
+      <p style={{ marginTop: 12, color: "var(--fg-3)", fontSize: 11 }}>
+        {data.cautionLabel}
+      </p>
+    </Card>
+  );
+}

--- a/frontend/invest/src/desktop/stock-detail/InvestorFlowCard.tsx
+++ b/frontend/invest/src/desktop/stock-detail/InvestorFlowCard.tsx
@@ -1,5 +1,9 @@
 import { Card, Pill } from "../../ds";
-import type { InvestorFlowDetailState, StockDetailInvestorFlow } from "../../types/stockDetail";
+import type {
+  InvestorFlowDetailState,
+  StockDetailInvestorFlow,
+  StockDetailInvestorFlowDailyRow,
+} from "../../types/stockDetail";
 
 const STATE_TONE: Record<InvestorFlowDetailState, "gain" | "warn" | "paper"> = {
   fresh: "gain",
@@ -13,37 +17,99 @@ const STATE_LABEL: Record<InvestorFlowDetailState, string> = {
   missing: "데이터 준비중",
 };
 
-function fmtKrwSigned(v: number | null | undefined): string {
+function fmtSignedShares(v: number | null | undefined): string {
   if (v == null) return "−";
   const sign = v > 0 ? "+" : v < 0 ? "−" : "";
-  return `${sign}₩${Math.abs(v).toLocaleString("ko-KR")}`;
+  return `${sign}${Math.abs(v).toLocaleString("ko-KR")}주`;
 }
 
 function streakLabel(buy: number | null | undefined, sell: number | null | undefined): string {
   if ((buy ?? 0) >= 1) return `+${buy}일 순매수`;
   if ((sell ?? 0) >= 1) return `−${sell}일 순매도`;
-  return "−";
+  return "연속성 없음";
+}
+
+function sourceLabel(data: StockDetailInvestorFlow): string {
+  const rows = data.dailyRows ?? [];
+  const source = data.snapshotSource ?? rows[0]?.source ?? "investor_flow_snapshots";
+  const collected = data.collectedAt
+    ? ` · 수집 ${new Date(data.collectedAt).toLocaleString("ko-KR")}`
+    : "";
+  const basis = data.snapshotDate ? `기준일 ${data.snapshotDate}` : "기준일 없음";
+  return `${source} · ${basis}${collected} · delayed/read-only`;
 }
 
 function FlowMetric({ label, value, sub }: { label: string; value: string; sub: string }) {
   return (
-    <div>
+    <div style={{ border: "1px solid var(--line)", borderRadius: 14, padding: 12 }}>
       <div style={{ color: "var(--fg-3)", fontSize: 11 }}>{label}</div>
-      <div style={{ fontWeight: 700, fontSize: 16 }}>{value}</div>
-      <div style={{ color: "var(--fg-3)", fontSize: 11 }}>{sub}</div>
+      <div style={{ marginTop: 4, fontWeight: 800, fontSize: 16 }}>{value}</div>
+      <div style={{ marginTop: 3, color: "var(--fg-3)", fontSize: 11 }}>{sub}</div>
+    </div>
+  );
+}
+
+function RowTonePill({ row }: { row: StockDetailInvestorFlowDailyRow }) {
+  if (row.doubleBuy) return <Pill tone="gain">쌍끌이</Pill>;
+  if (row.doubleSell) return <Pill tone="loss">동반 매도</Pill>;
+  return <Pill tone="paper">관찰</Pill>;
+}
+
+function DailyRowsTable({ rows }: { rows: StockDetailInvestorFlowDailyRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <p style={{ margin: "12px 0 0", color: "var(--fg-3)", fontSize: 12 }}>
+        일별 투자자별 수급 행이 아직 적재되지 않았습니다.
+      </p>
+    );
+  }
+  return (
+    <div style={{ marginTop: 12, overflowX: "auto" }}>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+        <thead>
+          <tr style={{ color: "var(--fg-3)", textAlign: "right" }}>
+            <th style={{ padding: "6px 4px", textAlign: "left", borderBottom: "1px solid var(--line)" }}>일자</th>
+            <th style={{ padding: "6px 4px", borderBottom: "1px solid var(--line)" }}>외국인</th>
+            <th style={{ padding: "6px 4px", borderBottom: "1px solid var(--line)" }}>기관</th>
+            <th style={{ padding: "6px 4px", borderBottom: "1px solid var(--line)" }}>개인</th>
+            <th style={{ padding: "6px 4px", textAlign: "center", borderBottom: "1px solid var(--line)" }}>메모</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.slice(0, 10).map((row) => (
+            <tr key={`${row.snapshotDate}-${row.source ?? "snapshot"}`}>
+              <td style={{ padding: "7px 4px", borderBottom: "1px solid var(--line)", color: "var(--fg-2)" }}>{row.snapshotDate}</td>
+              <td style={{ padding: "7px 4px", textAlign: "right", borderBottom: "1px solid var(--line)", color: (row.foreignNet ?? 0) >= 0 ? "var(--gain)" : "var(--loss)" }}>{fmtSignedShares(row.foreignNet)}</td>
+              <td style={{ padding: "7px 4px", textAlign: "right", borderBottom: "1px solid var(--line)", color: (row.institutionNet ?? 0) >= 0 ? "var(--gain)" : "var(--loss)" }}>{fmtSignedShares(row.institutionNet)}</td>
+              <td style={{ padding: "7px 4px", textAlign: "right", borderBottom: "1px solid var(--line)", color: (row.individualNet ?? 0) >= 0 ? "var(--gain)" : "var(--loss)" }}>{fmtSignedShares(row.individualNet)}</td>
+              <td style={{ padding: "7px 4px", textAlign: "center", borderBottom: "1px solid var(--line)" }}><RowTonePill row={row} /></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }
 
 export function InvestorFlowCard({ data }: { data: StockDetailInvestorFlow }) {
+  const dailyRows = data.dailyRows ?? [];
+  const isMissing = data.dataState === "missing";
   return (
     <Card data-testid="stock-detail-investor-flow">
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-        <strong>투자자별 수급 ({data.snapshotDate ?? "−"})</strong>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12 }}>
+        <div>
+          <strong>투자자별 매매동향 · 수급 흐름</strong>
+          <p style={{ margin: "4px 0 0", color: "var(--fg-3)", fontSize: 12 }}>{sourceLabel(data)}</p>
+        </div>
         <Pill tone={STATE_TONE[data.dataState]}>{STATE_LABEL[data.dataState]}</Pill>
       </div>
-      {data.dataState === "missing" ? (
-        <p style={{ marginTop: 8, color: "var(--fg-3)", fontSize: 12 }}>
+      {data.dataState === "stale" ? (
+        <p style={{ margin: "10px 0 0", color: "var(--warn)", fontSize: 12 }}>
+          최신 거래일보다 오래된 스냅샷입니다. 방향성 참고용으로만 확인하세요.
+        </p>
+      ) : null}
+      {isMissing ? (
+        <p style={{ marginTop: 12, color: "var(--fg-3)", fontSize: 12 }}>
           최근 KR 투자자별 수급 스냅샷이 없어 표시할 수 없습니다.
         </p>
       ) : (
@@ -58,27 +124,28 @@ export function InvestorFlowCard({ data }: { data: StockDetailInvestorFlow }) {
           >
             <FlowMetric
               label="외국인 순매수"
-              value={fmtKrwSigned(data.foreignNet)}
+              value={fmtSignedShares(data.foreignNet)}
               sub={streakLabel(data.foreignConsecutiveBuyDays, data.foreignConsecutiveSellDays)}
             />
             <FlowMetric
               label="기관 순매수"
-              value={fmtKrwSigned(data.institutionNet)}
+              value={fmtSignedShares(data.institutionNet)}
               sub={streakLabel(data.institutionConsecutiveBuyDays, data.institutionConsecutiveSellDays)}
             />
             <FlowMetric
               label="개인 순매수"
-              value={fmtKrwSigned(data.individualNet)}
+              value={fmtSignedShares(data.individualNet)}
               sub={streakLabel(data.individualConsecutiveBuyDays, data.individualConsecutiveSellDays)}
             />
           </div>
           {(data.doubleBuy || data.doubleSell) && (
             <div style={{ marginTop: 10 }}>
               <Pill tone={data.doubleBuy ? "gain" : "loss"}>
-                {data.doubleBuy ? "쌍끌이 매수" : "쌍끌이 매도"}
+                {data.doubleBuy ? "외국인·기관 동반 순매수" : "외국인·기관 동반 순매도"}
               </Pill>
             </div>
           )}
+          <DailyRowsTable rows={dailyRows} />
         </>
       )}
       <p style={{ marginTop: 12, color: "var(--fg-3)", fontSize: 11 }}>

--- a/frontend/invest/src/desktop/stock-detail/InvestorFlowCard.tsx
+++ b/frontend/invest/src/desktop/stock-detail/InvestorFlowCard.tsx
@@ -19,7 +19,9 @@ const STATE_LABEL: Record<InvestorFlowDetailState, string> = {
 
 function fmtSignedShares(v: number | null | undefined): string {
   if (v == null) return "−";
-  const sign = v > 0 ? "+" : v < 0 ? "−" : "";
+  let sign = "";
+  if (v > 0) sign = "+";
+  else if (v < 0) sign = "−";
   return `${sign}${Math.abs(v).toLocaleString("ko-KR")}주`;
 }
 
@@ -55,7 +57,7 @@ function sourceLabel(data: StockDetailInvestorFlow): string {
   return `${source} · ${basis}${collected} · delayed/read-only`;
 }
 
-function FlowMetric({ label, value, sub }: { label: string; value: string; sub: string }) {
+function FlowMetric({ label, value, sub }: Readonly<{ label: string; value: string; sub: string }>) {
   return (
     <div style={{ border: "1px solid var(--line)", borderRadius: 14, padding: 12 }}>
       <div style={{ color: "var(--fg-3)", fontSize: 11 }}>{label}</div>
@@ -65,13 +67,13 @@ function FlowMetric({ label, value, sub }: { label: string; value: string; sub: 
   );
 }
 
-function RowTonePill({ row }: { row: StockDetailInvestorFlowDailyRow }) {
+function RowTonePill({ row }: Readonly<{ row: StockDetailInvestorFlowDailyRow }>) {
   if (row.doubleBuy) return <Pill tone="gain">쌍끌이</Pill>;
   if (row.doubleSell) return <Pill tone="loss">동반 매도</Pill>;
   return <Pill tone="paper">관찰</Pill>;
 }
 
-function InvestorFlowSummary({ data }: { data: StockDetailInvestorFlow }) {
+function InvestorFlowSummary({ data }: Readonly<{ data: StockDetailInvestorFlow }>) {
   const summary = data.periodSummary;
   const decomposition = data.buyerDecomposition;
   if (!summary && !decomposition) return null;
@@ -113,7 +115,7 @@ function InvestorFlowSummary({ data }: { data: StockDetailInvestorFlow }) {
   );
 }
 
-function DailyRowsTable({ rows }: { rows: StockDetailInvestorFlowDailyRow[] }) {
+function DailyRowsTable({ rows }: Readonly<{ rows: StockDetailInvestorFlowDailyRow[] }>) {
   if (rows.length === 0) {
     return (
       <p style={{ margin: "12px 0 0", color: "var(--fg-3)", fontSize: 12 }}>
@@ -157,7 +159,7 @@ function DailyRowsTable({ rows }: { rows: StockDetailInvestorFlowDailyRow[] }) {
   );
 }
 
-export function InvestorFlowCard({ data }: { data: StockDetailInvestorFlow }) {
+export function InvestorFlowCard({ data }: Readonly<{ data: StockDetailInvestorFlow }>) {
   const dailyRows = data.dailyRows ?? [];
   const isMissing = data.dataState === "missing";
   return (

--- a/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
+++ b/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
@@ -9,6 +9,7 @@ import {
   fetchStockDetailOrders,
   fetchStockDetailResearchConsensus,
 } from "../../api/stockDetail";
+import { InvestorFlowCard } from "../../desktop/stock-detail/InvestorFlowCard";
 import type {
   StockDetailCandlesResponse,
   StockDetailFxSensitivity,
@@ -412,6 +413,9 @@ export function StockDetailPage() {
                 <OrdersCard orders={orders} />
               </div>
               <NewsCard news={news} />
+              {data.market === "kr" && data.investorFlow ? (
+                <InvestorFlowCard data={data.investorFlow} />
+              ) : null}
               {data.meta.warnings.length > 0 ? (
                 <Card soft>
                   {data.meta.warnings.map((w) => <div key={w}>{w}</div>)}

--- a/frontend/invest/src/types/screener.ts
+++ b/frontend/invest/src/types/screener.ts
@@ -1,5 +1,21 @@
 export type ScreenerMarket = "kr" | "us" | "crypto";
 export type ScreenerChangeDirection = "up" | "down" | "flat";
+export type InvestorFlowChipTone =
+  | "double_buy"
+  | "double_sell"
+  | "foreign_buy"
+  | "foreign_sell"
+  | "institution_buy"
+  | "institution_sell"
+  | "neutral";
+export type InvestorFlowChipState = "fresh" | "stale" | "missing";
+
+export interface ScreenerInvestorFlowChip {
+  label: string;
+  tone: InvestorFlowChipTone;
+  dataState: InvestorFlowChipState;
+  snapshotDate: string | null;
+}
 
 export interface ScreenerFilterChip {
   label: string;
@@ -37,6 +53,7 @@ export interface ScreenerResultRow {
   volumeLabel: string;
   analystLabel: string;
   metricValueLabel: string;
+  investorFlowChip: ScreenerInvestorFlowChip | null;
   warnings: string[];
 }
 

--- a/frontend/invest/src/types/stockDetail.ts
+++ b/frontend/invest/src/types/stockDetail.ts
@@ -28,6 +28,33 @@ export type FxSensitivityStatus =
   | "missing_native_value"
   | "missing_fx_rate";
 export type FxSensitivityBasis = "portfolio_value" | "fallback_quote" | "not_applicable";
+export type InvestorFlowDetailState = "fresh" | "stale" | "missing";
+
+export interface StockDetailInvestorFlow {
+  source: "investor_flow_snapshots";
+  market: "kr";
+  symbol: string;
+  dataState: InvestorFlowDetailState;
+  snapshotDate: string | null;
+  collectedAt: string | null;
+  snapshotSource: string | null;
+  foreignNet: number | null;
+  institutionNet: number | null;
+  individualNet: number | null;
+  foreignNetBuyRank: number | null;
+  foreignNetSellRank: number | null;
+  institutionNetBuyRank: number | null;
+  institutionNetSellRank: number | null;
+  doubleBuy: boolean;
+  doubleSell: boolean;
+  foreignConsecutiveBuyDays: number | null;
+  foreignConsecutiveSellDays: number | null;
+  institutionConsecutiveBuyDays: number | null;
+  institutionConsecutiveSellDays: number | null;
+  individualConsecutiveBuyDays: number | null;
+  individualConsecutiveSellDays: number | null;
+  cautionLabel: string;
+}
 
 export interface CapabilityFlag {
   supported: boolean;
@@ -174,6 +201,7 @@ export interface StockDetailResponse {
   screenerSnapshot: StockDetailScreenerSnapshot | null;
   valuation: StockDetailValuation | null;
   naverEnrichment: StockDetailNaverEnrichment | null;
+  investorFlow: StockDetailInvestorFlow | null;
   holding: StockDetailHolding | null;
   fxSensitivity: StockDetailFxSensitivity | null;
   latestAnalysis: StockDetailLatestAnalysis | null;

--- a/frontend/invest/src/types/stockDetail.ts
+++ b/frontend/invest/src/types/stockDetail.ts
@@ -34,11 +34,41 @@ export interface StockDetailInvestorFlowDailyRow {
   snapshotDate: string;
   collectedAt: string | null;
   source: string | null;
+  close: number | null;
+  changeRate: number | null;
+  volume: number | null;
   foreignNet: number | null;
+  foreignHoldingShares: number | null;
+  foreignHoldingRate: number | null;
   institutionNet: number | null;
   individualNet: number | null;
   doubleBuy: boolean;
   doubleSell: boolean;
+}
+
+export interface StockDetailInvestorFlowPeriodSummary {
+  windowDays: number;
+  rowCount: number;
+  foreignNetTotal: number | null;
+  institutionNetTotal: number | null;
+  individualNetTotal: number | null;
+  foreignBuyDays: number;
+  foreignSellDays: number;
+  foreignFlatDays: number;
+  foreignNetToVolumeRatio: number | null;
+  foreignHoldingSharesChange: number | null;
+  foreignHoldingRateChange: number | null;
+  unavailableLabels: string[];
+}
+
+export interface StockDetailInvestorFlowBuyerDecomposition {
+  snapshotDate: string;
+  label: string;
+  leadingBuyer: "foreign" | "institution" | "individual" | "mixed" | "unknown";
+  foreignNet: number | null;
+  institutionNet: number | null;
+  individualNet: number | null;
+  note: string;
 }
 
 export interface StockDetailInvestorFlow {
@@ -65,6 +95,9 @@ export interface StockDetailInvestorFlow {
   individualConsecutiveBuyDays: number | null;
   individualConsecutiveSellDays: number | null;
   dailyRows: StockDetailInvestorFlowDailyRow[];
+  periodSummary: StockDetailInvestorFlowPeriodSummary | null;
+  buyerDecomposition: StockDetailInvestorFlowBuyerDecomposition | null;
+  unavailableLabels: string[];
   cautionLabel: string;
 }
 

--- a/frontend/invest/src/types/stockDetail.ts
+++ b/frontend/invest/src/types/stockDetail.ts
@@ -30,6 +30,17 @@ export type FxSensitivityStatus =
 export type FxSensitivityBasis = "portfolio_value" | "fallback_quote" | "not_applicable";
 export type InvestorFlowDetailState = "fresh" | "stale" | "missing";
 
+export interface StockDetailInvestorFlowDailyRow {
+  snapshotDate: string;
+  collectedAt: string | null;
+  source: string | null;
+  foreignNet: number | null;
+  institutionNet: number | null;
+  individualNet: number | null;
+  doubleBuy: boolean;
+  doubleSell: boolean;
+}
+
 export interface StockDetailInvestorFlow {
   source: "investor_flow_snapshots";
   market: "kr";
@@ -53,6 +64,7 @@ export interface StockDetailInvestorFlow {
   institutionConsecutiveSellDays: number | null;
   individualConsecutiveBuyDays: number | null;
   individualConsecutiveSellDays: number | null;
+  dailyRows: StockDetailInvestorFlowDailyRow[];
   cautionLabel: string;
 }
 

--- a/tests/fixtures/investor_flow/403550_naver_sample.json
+++ b/tests/fixtures/investor_flow/403550_naver_sample.json
@@ -1,0 +1,18 @@
+{
+  "symbol": "403550",
+  "name": "에스케이엔펄스",
+  "source": "naver_finance",
+  "captured_at": "2026-05-13T00:00:00+00:00",
+  "rows": [
+    {"date": "2026-05-12", "foreign_net":  450123, "institutional_net":  120044},
+    {"date": "2026-05-09", "foreign_net":  221890, "institutional_net":   55012},
+    {"date": "2026-05-08", "foreign_net":   80120, "institutional_net":   31200},
+    {"date": "2026-05-07", "foreign_net":   12345, "institutional_net":  -10220},
+    {"date": "2026-05-02", "foreign_net":  -45100, "institutional_net":   62000},
+    {"date": "2026-05-01", "foreign_net":  -88010, "institutional_net":   71005},
+    {"date": "2026-04-30", "foreign_net":  -90212, "institutional_net":  102330},
+    {"date": "2026-04-29", "foreign_net":   23000, "institutional_net":  -28000},
+    {"date": "2026-04-28", "foreign_net":   45000, "institutional_net":  -33000},
+    {"date": "2026-04-25", "foreign_net":   10000, "institutional_net":   -5000}
+  ]
+}

--- a/tests/test_investor_flow_service_latest_items.py
+++ b/tests/test_investor_flow_service_latest_items.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import datetime as dt
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.investor_flow_snapshot import InvestorFlowSnapshot
 from app.services.invest_view_model.investor_flow_service import (
@@ -37,6 +38,7 @@ def _row(symbol: str, snapshot_date: dt.date) -> InvestorFlowSnapshot:
     )
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_latest_items_for_symbols_returns_dict_keyed_by_symbol(monkeypatch):
     today = dt.date(2026, 5, 13)
@@ -50,8 +52,8 @@ async def test_latest_items_for_symbols_returns_dict_keyed_by_symbol(monkeypatch
     )
 
     result = await latest_items_for_symbols(
-        db=SimpleNamespace(),
-        symbols=["403550", " 003550 "],
+        db=MagicMock(spec=AsyncSession),
+        symbols=["403550", " 403550 "],
         as_of=today,
         max_stale_days=1,
     )
@@ -62,6 +64,7 @@ async def test_latest_items_for_symbols_returns_dict_keyed_by_symbol(monkeypatch
     fake_repo.latest_by_symbols.assert_awaited_once()
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_latest_items_for_symbols_marks_stale_when_age_exceeds_threshold(
     monkeypatch,
@@ -76,7 +79,7 @@ async def test_latest_items_for_symbols_marks_stale_when_age_exceeds_threshold(
     )
 
     result = await latest_items_for_symbols(
-        db=SimpleNamespace(),
+        db=MagicMock(spec=AsyncSession),
         symbols=["403550"],
         as_of=today,
         max_stale_days=1,
@@ -85,6 +88,7 @@ async def test_latest_items_for_symbols_marks_stale_when_age_exceeds_threshold(
     assert result["403550"].dataState == "stale"
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_latest_items_for_symbols_empty_input_returns_empty(monkeypatch):
     result = await latest_items_for_symbols(
@@ -95,6 +99,7 @@ async def test_latest_items_for_symbols_empty_input_returns_empty(monkeypatch):
     assert result == {}
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_latest_items_for_symbols_non_kr_raises(monkeypatch):
     with pytest.raises(ValueError, match="kr"):

--- a/tests/test_investor_flow_service_latest_items.py
+++ b/tests/test_investor_flow_service_latest_items.py
@@ -41,9 +41,7 @@ def _row(symbol: str, snapshot_date: dt.date) -> InvestorFlowSnapshot:
 async def test_latest_items_for_symbols_returns_dict_keyed_by_symbol(monkeypatch):
     today = dt.date(2026, 5, 13)
     fake_repo = SimpleNamespace(
-        latest_by_symbols=AsyncMock(
-            return_value=[_row("403550", dt.date(2026, 5, 12))]
-        )
+        latest_by_symbols=AsyncMock(return_value=[_row("403550", dt.date(2026, 5, 12))])
     )
 
     monkeypatch.setattr(
@@ -70,9 +68,7 @@ async def test_latest_items_for_symbols_marks_stale_when_age_exceeds_threshold(
 ):
     today = dt.date(2026, 5, 13)
     fake_repo = SimpleNamespace(
-        latest_by_symbols=AsyncMock(
-            return_value=[_row("403550", dt.date(2026, 5, 10))]
-        )
+        latest_by_symbols=AsyncMock(return_value=[_row("403550", dt.date(2026, 5, 10))])
     )
     monkeypatch.setattr(
         "app.services.invest_view_model.investor_flow_service.InvestorFlowSnapshotsRepository",

--- a/tests/test_investor_flow_service_latest_items.py
+++ b/tests/test_investor_flow_service_latest_items.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.models.investor_flow_snapshot import InvestorFlowSnapshot
+from app.services.invest_view_model.investor_flow_service import (
+    latest_items_for_symbols,
+)
+
+
+def _row(symbol: str, snapshot_date: dt.date) -> InvestorFlowSnapshot:
+    return InvestorFlowSnapshot(
+        market="kr",
+        symbol=symbol,
+        snapshot_date=snapshot_date,
+        foreign_net=100,
+        institution_net=-50,
+        individual_net=-50,
+        foreign_net_buy_rank=3,
+        foreign_net_sell_rank=None,
+        institution_net_buy_rank=None,
+        institution_net_sell_rank=12,
+        double_buy=False,
+        double_sell=False,
+        foreign_consecutive_buy_days=2,
+        foreign_consecutive_sell_days=None,
+        institution_consecutive_buy_days=None,
+        institution_consecutive_sell_days=4,
+        individual_consecutive_buy_days=None,
+        individual_consecutive_sell_days=None,
+        source="naver_finance",
+        collected_at=dt.datetime(2026, 5, 12, tzinfo=dt.UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_latest_items_for_symbols_returns_dict_keyed_by_symbol(monkeypatch):
+    today = dt.date(2026, 5, 13)
+    fake_repo = SimpleNamespace(
+        latest_by_symbols=AsyncMock(
+            return_value=[_row("403550", dt.date(2026, 5, 12))]
+        )
+    )
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.investor_flow_service.InvestorFlowSnapshotsRepository",
+        lambda db: fake_repo,
+    )
+
+    result = await latest_items_for_symbols(
+        db=SimpleNamespace(),
+        symbols=["403550", " 003550 "],
+        as_of=today,
+        max_stale_days=1,
+    )
+
+    assert set(result.keys()) == {"403550"}
+    assert result["403550"].dataState == "fresh"
+    assert result["403550"].foreignNet == 100
+    fake_repo.latest_by_symbols.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_latest_items_for_symbols_marks_stale_when_age_exceeds_threshold(
+    monkeypatch,
+):
+    today = dt.date(2026, 5, 13)
+    fake_repo = SimpleNamespace(
+        latest_by_symbols=AsyncMock(
+            return_value=[_row("403550", dt.date(2026, 5, 10))]
+        )
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.investor_flow_service.InvestorFlowSnapshotsRepository",
+        lambda db: fake_repo,
+    )
+
+    result = await latest_items_for_symbols(
+        db=SimpleNamespace(),
+        symbols=["403550"],
+        as_of=today,
+        max_stale_days=1,
+    )
+
+    assert result["403550"].dataState == "stale"
+
+
+@pytest.mark.asyncio
+async def test_latest_items_for_symbols_empty_input_returns_empty(monkeypatch):
+    result = await latest_items_for_symbols(
+        db=SimpleNamespace(),
+        symbols=[],
+        as_of=dt.date(2026, 5, 13),
+    )
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_latest_items_for_symbols_non_kr_raises(monkeypatch):
+    with pytest.raises(ValueError, match="kr"):
+        await latest_items_for_symbols(
+            db=SimpleNamespace(),
+            symbols=["AAPL"],
+            market="us",
+        )

--- a/tests/test_investor_flow_snapshot_builder.py
+++ b/tests/test_investor_flow_snapshot_builder.py
@@ -28,6 +28,7 @@ async def _fake_fetcher(symbol: str, days: int):
     return {"symbol": symbol, "data": fixtures[symbol]}
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_build_investor_flow_snapshots_derives_streaks_ranks_and_individual():
     collected_at = dt.datetime(2026, 5, 12, 7, 0, tzinfo=dt.UTC)
@@ -62,6 +63,7 @@ async def test_build_investor_flow_snapshots_derives_streaks_ranks_and_individua
     assert sell_leader.institution_net_sell_rank == 1
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_build_investor_flow_snapshots_warns_and_skips_empty_or_invalid_rows():
     async def fake_fetcher(symbol: str, days: int):
@@ -80,6 +82,7 @@ async def test_build_investor_flow_snapshots_warns_and_skips_empty_or_invalid_ro
     assert "900304: no valid investor-flow rows built" in result.warnings
 
 
+@pytest.mark.unit
 def test_403550_naver_fixture_loads_and_has_expected_shape():
     fixture = json.loads((_FIXTURE_DIR / "403550_naver_sample.json").read_text())
     assert fixture["symbol"] == "403550"

--- a/tests/test_investor_flow_snapshot_builder.py
+++ b/tests/test_investor_flow_snapshot_builder.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
+from pathlib import Path
 
 import pytest
 
 from app.services.investor_flow_snapshots.builder import build_investor_flow_snapshots
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "investor_flow"
 
 
 async def _fake_fetcher(symbol: str, days: int):
@@ -74,3 +78,14 @@ async def test_build_investor_flow_snapshots_warns_and_skips_empty_or_invalid_ro
     assert "900303: no investor-flow rows returned" in result.warnings
     assert "900304: row 0 has invalid date" in result.warnings
     assert "900304: no valid investor-flow rows built" in result.warnings
+
+
+def test_403550_naver_fixture_loads_and_has_expected_shape():
+    fixture = json.loads((_FIXTURE_DIR / "403550_naver_sample.json").read_text())
+    assert fixture["symbol"] == "403550"
+    assert fixture["source"] == "naver_finance"
+    payloads = fixture["rows"]
+    assert len(payloads) == 10
+    assert payloads[0]["date"] == "2026-05-12"
+    assert isinstance(payloads[0]["foreign_net"], int)
+    assert isinstance(payloads[0]["institutional_net"], int)

--- a/tests/test_investor_flow_snapshots_repository.py
+++ b/tests/test_investor_flow_snapshots_repository.py
@@ -10,6 +10,7 @@ from app.services.investor_flow_snapshots.repository import (
 )
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_upsert_and_latest_by_symbols_returns_fresh_snapshot(db_session):
     repo = InvestorFlowSnapshotsRepository(db_session)
@@ -51,6 +52,7 @@ async def test_upsert_and_latest_by_symbols_returns_fresh_snapshot(db_session):
     assert row.source == "naver_finance"
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_latest_by_symbols_picks_newest_snapshot_per_symbol(db_session):
     repo = InvestorFlowSnapshotsRepository(db_session)
@@ -88,6 +90,7 @@ async def test_latest_by_symbols_picks_newest_snapshot_per_symbol(db_session):
     assert rows[0].double_buy is True
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_recent_by_symbol_returns_descending_daily_history(db_session):
     repo = InvestorFlowSnapshotsRepository(db_session)

--- a/tests/test_investor_flow_snapshots_repository.py
+++ b/tests/test_investor_flow_snapshots_repository.py
@@ -86,3 +86,32 @@ async def test_latest_by_symbols_picks_newest_snapshot_per_symbol(db_session):
     assert len(rows) == 1
     assert rows[0].snapshot_date == dt.date(2026, 5, 11)
     assert rows[0].double_buy is True
+
+
+@pytest.mark.asyncio
+async def test_recent_by_symbol_returns_descending_daily_history(db_session):
+    repo = InvestorFlowSnapshotsRepository(db_session)
+    symbol = "900193"
+    for day, foreign_net in [(9, 90), (10, -10), (11, 110)]:
+        await repo.upsert(
+            InvestorFlowSnapshotUpsert(
+                market="kr",
+                symbol=symbol,
+                snapshot_date=dt.date(2026, 5, day),
+                foreign_net=foreign_net,
+                institution_net=day,
+                individual_net=-foreign_net,
+                source="naver_finance",
+            )
+        )
+    await db_session.commit()
+
+    rows = await repo.recent_by_symbol(
+        market="kr", symbol=symbol, as_of=dt.date(2026, 5, 11), limit=2
+    )
+
+    assert [row.snapshot_date for row in rows] == [
+        dt.date(2026, 5, 11),
+        dt.date(2026, 5, 10),
+    ]
+    assert rows[0].foreign_net == 110

--- a/tests/test_screener_service_investor_flow_chip.py
+++ b/tests/test_screener_service_investor_flow_chip.py
@@ -14,20 +14,20 @@ from app.services.invest_view_model.screener_service import (
 
 
 def _item(**overrides) -> InvestorFlowItem:
-    defaults = dict(
-        symbol="403550",
-        market="kr",
-        dataState="fresh",
-        snapshotDate=dt.date(2026, 5, 12),
-        doubleBuy=False,
-        doubleSell=False,
-        foreignConsecutiveBuyDays=None,
-        foreignConsecutiveSellDays=None,
-        institutionConsecutiveBuyDays=None,
-        institutionConsecutiveSellDays=None,
-        individualConsecutiveBuyDays=None,
-        individualConsecutiveSellDays=None,
-    )
+    defaults = {
+        "symbol": "403550",
+        "market": "kr",
+        "dataState": "fresh",
+        "snapshotDate": dt.date(2026, 5, 12),
+        "doubleBuy": False,
+        "doubleSell": False,
+        "foreignConsecutiveBuyDays": None,
+        "foreignConsecutiveSellDays": None,
+        "institutionConsecutiveBuyDays": None,
+        "institutionConsecutiveSellDays": None,
+        "individualConsecutiveBuyDays": None,
+        "individualConsecutiveSellDays": None,
+    }
     defaults.update(overrides)
     return InvestorFlowItem(**defaults)
 
@@ -73,7 +73,11 @@ def test_stale_state_annotates_label():
 
 def test_double_sell_chip():
     chip = _investor_flow_chip_for_item(
-        _item(doubleSell=True, foreignConsecutiveSellDays=3, institutionConsecutiveSellDays=2)
+        _item(
+            doubleSell=True,
+            foreignConsecutiveSellDays=3,
+            institutionConsecutiveSellDays=2,
+        )
     )
     assert chip is not None
     assert chip.tone == "double_sell"

--- a/tests/test_screener_service_investor_flow_chip.py
+++ b/tests/test_screener_service_investor_flow_chip.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.schemas.investor_flow import InvestorFlowItem
+from app.services.invest_view_model.screener_service import (
+    _hydrate_investor_flow_chips,
+    _investor_flow_chip_for_item,
+)
+
+
+def _item(**overrides) -> InvestorFlowItem:
+    defaults = dict(
+        symbol="403550",
+        market="kr",
+        dataState="fresh",
+        snapshotDate=dt.date(2026, 5, 12),
+        doubleBuy=False,
+        doubleSell=False,
+        foreignConsecutiveBuyDays=None,
+        foreignConsecutiveSellDays=None,
+        institutionConsecutiveBuyDays=None,
+        institutionConsecutiveSellDays=None,
+        individualConsecutiveBuyDays=None,
+        individualConsecutiveSellDays=None,
+    )
+    defaults.update(overrides)
+    return InvestorFlowItem(**defaults)
+
+
+def test_double_buy_takes_precedence():
+    chip = _investor_flow_chip_for_item(
+        _item(
+            doubleBuy=True,
+            foreignConsecutiveBuyDays=4,
+            institutionConsecutiveBuyDays=2,
+        )
+    )
+    assert chip is not None
+    assert chip.tone == "double_buy"
+    assert "쌍끌이 매수" in chip.label
+
+
+def test_foreign_consecutive_buy_only():
+    chip = _investor_flow_chip_for_item(_item(foreignConsecutiveBuyDays=5))
+    assert chip is not None
+    assert chip.tone == "foreign_buy"
+    assert chip.label == "외국인 5일 순매수"
+
+
+def test_no_chip_when_signals_below_threshold():
+    chip = _investor_flow_chip_for_item(_item(foreignConsecutiveBuyDays=2))
+    assert chip is None
+
+
+def test_missing_state_yields_no_chip():
+    chip = _investor_flow_chip_for_item(_item(dataState="missing"))
+    assert chip is None
+
+
+def test_stale_state_annotates_label():
+    chip = _investor_flow_chip_for_item(
+        _item(dataState="stale", foreignConsecutiveBuyDays=4)
+    )
+    assert chip is not None
+    assert chip.dataState == "stale"
+    assert "1일 지연" in chip.label
+
+
+def test_double_sell_chip():
+    chip = _investor_flow_chip_for_item(
+        _item(doubleSell=True, foreignConsecutiveSellDays=3, institutionConsecutiveSellDays=2)
+    )
+    assert chip is not None
+    assert chip.tone == "double_sell"
+    assert "쌍끌이 매도" in chip.label
+
+
+def test_institution_consecutive_buy():
+    chip = _investor_flow_chip_for_item(_item(institutionConsecutiveBuyDays=4))
+    assert chip is not None
+    assert chip.tone == "institution_buy"
+    assert "기관 4일 순매수" in chip.label
+
+
+def test_institution_consecutive_sell():
+    chip = _investor_flow_chip_for_item(_item(institutionConsecutiveSellDays=3))
+    assert chip is not None
+    assert chip.tone == "institution_sell"
+    assert "기관 3일 순매도" in chip.label
+
+
+@pytest.mark.asyncio
+async def test_hydrate_skips_non_kr_market():
+    rows = [{"market": "us", "symbol": "AAPL"}]
+    chips = await _hydrate_investor_flow_chips(
+        db=SimpleNamespace(), market="us", rows=rows
+    )
+    assert chips == {}
+
+
+@pytest.mark.asyncio
+async def test_hydrate_swallows_provider_failures(monkeypatch):
+    async def boom(**kwargs):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service._latest_investor_flow_items",
+        boom,
+    )
+
+    chips = await _hydrate_investor_flow_chips(
+        db=SimpleNamespace(),
+        market="kr",
+        rows=[{"market": "kr", "symbol": "403550"}],
+    )
+    assert chips == {}
+
+
+@pytest.mark.asyncio
+async def test_hydrate_returns_chip_for_matching_snapshot(monkeypatch):
+    fake_item = _item(foreignConsecutiveBuyDays=4)
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service._latest_investor_flow_items",
+        AsyncMock(return_value={"403550": fake_item}),
+    )
+
+    chips = await _hydrate_investor_flow_chips(
+        db=SimpleNamespace(),
+        market="kr",
+        rows=[{"market": "kr", "symbol": "403550"}],
+    )
+    assert "403550" in chips
+    assert chips["403550"].tone == "foreign_buy"

--- a/tests/test_screener_service_investor_flow_chip.py
+++ b/tests/test_screener_service_investor_flow_chip.py
@@ -10,6 +10,11 @@ from app.schemas.investor_flow import InvestorFlowItem
 from app.services.invest_view_model.screener_service import (
     _hydrate_investor_flow_chips,
     _investor_flow_chip_for_item,
+    build_screener_results,
+)
+from app.services.investor_flow_snapshots.repository import (
+    InvestorFlowSnapshotsRepository,
+    InvestorFlowSnapshotUpsert,
 )
 
 
@@ -140,3 +145,82 @@ async def test_hydrate_returns_chip_for_matching_snapshot(monkeypatch):
     )
     assert "403550" in chips
     assert chips["403550"].tone == "foreign_buy"
+
+
+class _StubResolver:
+    def relation(self, market: str, symbol: str) -> str:
+        return "neither"
+
+
+class _StubScreeningService:
+    async def list_screening(self, **kwargs):
+        return {
+            "results": [],
+            "warnings": ["fallback should not be used when snapshot path succeeds"],
+            "timestamp": "2026-05-13T06:30:00+00:00",
+            "cache_hit": False,
+        }
+
+
+@pytest.mark.asyncio
+async def test_investor_flow_momentum_preset_uses_snapshot_discovery(
+    db_session, monkeypatch
+):
+    repo = InvestorFlowSnapshotsRepository(db_session)
+    latest_partition = dt.date(2099, 5, 13)
+    await repo.upsert(
+        InvestorFlowSnapshotUpsert(
+            market="kr",
+            symbol="403550",
+            snapshot_date=latest_partition,
+            foreign_net=20859,
+            institution_net=-12931,
+            individual_net=125586,
+            foreign_net_buy_rank=3,
+            foreign_consecutive_buy_days=4,
+            source="naver_finance",
+        )
+    )
+    await repo.upsert(
+        InvestorFlowSnapshotUpsert(
+            market="kr",
+            symbol="005930",
+            snapshot_date=latest_partition,
+            foreign_net=1000,
+            institution_net=2000,
+            individual_net=-3000,
+            institution_consecutive_buy_days=2,
+            source="naver_finance",
+        )
+    )
+    await db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.screener_service._should_use_snapshot_first",
+        lambda service: True,
+    )
+
+    result = await build_screener_results(
+        preset_id="investor_flow_momentum",
+        screening_service=_StubScreeningService(),
+        resolver=_StubResolver(),
+        market="kr",
+        session=db_session,
+    )
+
+    assert result.presetId == "investor_flow_momentum"
+    assert result.title == "수급 모멘텀"
+    assert result.metricLabel == "외국인 순매수"
+    assert result.freshness.dataState == "fresh"
+    assert [row.symbol for row in result.results] == ["005930", "403550"]
+    double_buy_row = result.results[0]
+    assert double_buy_row.metricValueLabel == "+1,000주"
+    assert double_buy_row.investorFlowChip is not None
+    assert double_buy_row.investorFlowChip.tone == "double_buy"
+    assert "쌍끌이 매수" in double_buy_row.investorFlowChip.label
+    foreign_streak_row = result.results[1]
+    assert foreign_streak_row.metricValueLabel == "+20,859주"
+    assert foreign_streak_row.investorFlowChip is not None
+    assert foreign_streak_row.investorFlowChip.tone == "foreign_buy"
+    assert foreign_streak_row.investorFlowChip.label == "외국인 4일 순매수"
+    assert result.warnings == []

--- a/tests/test_screener_service_investor_flow_chip.py
+++ b/tests/test_screener_service_investor_flow_chip.py
@@ -37,6 +37,7 @@ def _item(**overrides) -> InvestorFlowItem:
     return InvestorFlowItem(**defaults)
 
 
+@pytest.mark.unit
 def test_double_buy_takes_precedence():
     chip = _investor_flow_chip_for_item(
         _item(
@@ -50,6 +51,7 @@ def test_double_buy_takes_precedence():
     assert "쌍끌이 매수" in chip.label
 
 
+@pytest.mark.unit
 def test_foreign_consecutive_buy_only():
     chip = _investor_flow_chip_for_item(_item(foreignConsecutiveBuyDays=5))
     assert chip is not None
@@ -57,16 +59,19 @@ def test_foreign_consecutive_buy_only():
     assert chip.label == "외국인 5일 순매수"
 
 
+@pytest.mark.unit
 def test_no_chip_when_signals_below_threshold():
     chip = _investor_flow_chip_for_item(_item(foreignConsecutiveBuyDays=2))
     assert chip is None
 
 
+@pytest.mark.unit
 def test_missing_state_yields_no_chip():
     chip = _investor_flow_chip_for_item(_item(dataState="missing"))
     assert chip is None
 
 
+@pytest.mark.unit
 def test_stale_state_annotates_label():
     chip = _investor_flow_chip_for_item(
         _item(dataState="stale", foreignConsecutiveBuyDays=4)
@@ -76,6 +81,7 @@ def test_stale_state_annotates_label():
     assert "1일 지연" in chip.label
 
 
+@pytest.mark.unit
 def test_double_sell_chip():
     chip = _investor_flow_chip_for_item(
         _item(
@@ -89,6 +95,7 @@ def test_double_sell_chip():
     assert "쌍끌이 매도" in chip.label
 
 
+@pytest.mark.unit
 def test_institution_consecutive_buy():
     chip = _investor_flow_chip_for_item(_item(institutionConsecutiveBuyDays=4))
     assert chip is not None
@@ -96,6 +103,7 @@ def test_institution_consecutive_buy():
     assert "기관 4일 순매수" in chip.label
 
 
+@pytest.mark.unit
 def test_institution_consecutive_sell():
     chip = _investor_flow_chip_for_item(_item(institutionConsecutiveSellDays=3))
     assert chip is not None
@@ -130,6 +138,7 @@ async def test_hydrate_swallows_provider_failures(monkeypatch):
     assert chips == {}
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_hydrate_returns_chip_for_matching_snapshot(monkeypatch):
     fake_item = _item(foreignConsecutiveBuyDays=4)
@@ -162,6 +171,7 @@ class _StubScreeningService:
         }
 
 
+@pytest.mark.integration
 @pytest.mark.asyncio
 async def test_investor_flow_momentum_preset_uses_snapshot_discovery(
     db_session, monkeypatch

--- a/tests/test_stock_detail_investor_flow_provider.py
+++ b/tests/test_stock_detail_investor_flow_provider.py
@@ -56,7 +56,10 @@ async def test_kr_detail_includes_investor_flow_when_provider_returns_payload():
         investor_flow=fake_investor_flow,
     )
     response = await build_stock_detail(
-        user_id=1, market="kr", symbol="403550", db=SimpleNamespace(),
+        user_id=1,
+        market="kr",
+        symbol="403550",
+        db=SimpleNamespace(),
         providers=providers,
     )
     assert response.investorFlow is not None
@@ -78,7 +81,10 @@ async def test_us_detail_does_not_call_investor_flow_provider():
         investor_flow=fake_investor_flow,
     )
     response = await build_stock_detail(
-        user_id=1, market="us", symbol="AAPL", db=SimpleNamespace(),
+        user_id=1,
+        market="us",
+        symbol="AAPL",
+        db=SimpleNamespace(),
         providers=providers,
     )
     assert response.investorFlow is None
@@ -95,7 +101,10 @@ async def test_investor_flow_provider_failure_warns_but_keeps_response():
         investor_flow=boom,
     )
     response = await build_stock_detail(
-        user_id=1, market="kr", symbol="403550", db=SimpleNamespace(),
+        user_id=1,
+        market="kr",
+        symbol="403550",
+        db=SimpleNamespace(),
         providers=providers,
     )
     assert response.investorFlow is None
@@ -111,7 +120,10 @@ async def test_kr_detail_investor_flow_defaults_to_none_without_snapshots(monkey
         AsyncMock(return_value={}),
     )
     response = await build_stock_detail(
-        user_id=1, market="kr", symbol="403550", db=SimpleNamespace(),
+        user_id=1,
+        market="kr",
+        symbol="403550",
+        db=SimpleNamespace(),
         providers=StockDetailProviders(resolver=_resolve_kr),
     )
     assert response.investorFlow is not None

--- a/tests/test_stock_detail_investor_flow_provider.py
+++ b/tests/test_stock_detail_investor_flow_provider.py
@@ -39,6 +39,7 @@ async def _resolve_us(market, raw_symbol, db):
     )
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_kr_detail_includes_investor_flow_when_provider_returns_payload():
     async def fake_investor_flow(market, symbol, db):
@@ -71,6 +72,7 @@ async def test_kr_detail_includes_investor_flow_when_provider_returns_payload():
     assert response.investorFlow.doubleBuy is True
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_us_detail_does_not_call_investor_flow_provider():
     calls = []
@@ -94,6 +96,7 @@ async def test_us_detail_does_not_call_investor_flow_provider():
     assert calls == []
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_investor_flow_provider_failure_warns_but_keeps_response():
     async def boom(market, symbol, db):
@@ -114,6 +117,7 @@ async def test_investor_flow_provider_failure_warns_but_keeps_response():
     assert "investor_flow_unavailable" in response.meta.warnings
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_kr_detail_investor_flow_defaults_to_none_without_snapshots(monkeypatch):
     from unittest.mock import AsyncMock
@@ -142,6 +146,7 @@ async def test_kr_detail_investor_flow_defaults_to_none_without_snapshots(monkey
     assert "거래량" in " ".join(response.investorFlow.unavailableLabels)
 
 
+@pytest.mark.unit
 @pytest.mark.asyncio
 async def test_kr_detail_default_investor_flow_includes_daily_rows(monkeypatch):
     from datetime import date

--- a/tests/test_stock_detail_investor_flow_provider.py
+++ b/tests/test_stock_detail_investor_flow_provider.py
@@ -137,6 +137,9 @@ async def test_kr_detail_investor_flow_defaults_to_none_without_snapshots(monkey
     assert response.investorFlow.dataState == "missing"
     assert response.investorFlow.foreignNet is None
     assert response.investorFlow.dailyRows == []
+    assert response.investorFlow.periodSummary is None
+    assert response.investorFlow.buyerDecomposition is None
+    assert "거래량" in " ".join(response.investorFlow.unavailableLabels)
 
 
 @pytest.mark.asyncio
@@ -196,4 +199,16 @@ async def test_kr_detail_default_investor_flow_includes_daily_rows(monkeypatch):
     assert response.investorFlow is not None
     assert response.investorFlow.dailyRows[0].snapshotDate == "2026-05-13"
     assert response.investorFlow.dailyRows[0].foreignNet == 20859
+    assert response.investorFlow.dailyRows[0].close is None
+    assert response.investorFlow.periodSummary is not None
+    assert response.investorFlow.periodSummary.windowDays == 2
+    assert response.investorFlow.periodSummary.foreignNetTotal == 21299
+    assert response.investorFlow.periodSummary.institutionNetTotal == -13955
+    assert response.investorFlow.periodSummary.individualNetTotal == 126176
+    assert response.investorFlow.periodSummary.foreignBuyDays == 2
+    assert response.investorFlow.periodSummary.foreignNetToVolumeRatio is None
+    assert response.investorFlow.buyerDecomposition is not None
+    assert response.investorFlow.buyerDecomposition.leadingBuyer == "individual"
+    assert response.investorFlow.buyerDecomposition.label == "개인 주도"
+    assert "거래량" in " ".join(response.investorFlow.unavailableLabels)
     assert "지연된 과거 참고 데이터" in response.investorFlow.cautionLabel

--- a/tests/test_stock_detail_investor_flow_provider.py
+++ b/tests/test_stock_detail_investor_flow_provider.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.schemas.invest_stock_detail import StockDetailInvestorFlow
+from app.services.invest_view_model.stock_detail_service import (
+    StockDetailProviders,
+    build_stock_detail,
+)
+from app.services.invest_view_model.stock_detail_symbol_resolver import ResolvedSymbol
+
+
+async def _resolve_kr(market, raw_symbol, db):
+    return ResolvedSymbol(
+        symbol_db=raw_symbol,
+        display_name="에스케이엔펄스",
+        exchange="KOSPI",
+        instrument_type="equity_kr",
+        asset_type="equity",
+        asset_category="kr_stock",
+        currency="KRW",
+    )
+
+
+async def _resolve_us(market, raw_symbol, db):
+    return ResolvedSymbol(
+        symbol_db=raw_symbol,
+        display_name="Apple Inc",
+        exchange="NASDAQ",
+        instrument_type="equity_us",
+        asset_type="equity",
+        asset_category="us_stock",
+        currency="USD",
+    )
+
+
+@pytest.mark.asyncio
+async def test_kr_detail_includes_investor_flow_when_provider_returns_payload():
+    async def fake_investor_flow(market, symbol, db):
+        return StockDetailInvestorFlow(
+            symbol=symbol,
+            dataState="fresh",
+            snapshotDate="2026-05-12",
+            snapshotSource="naver_finance",
+            foreignNet=450123,
+            institutionNet=120044,
+            individualNet=-570167,
+            foreignConsecutiveBuyDays=3,
+            doubleBuy=True,
+        )
+
+    providers = StockDetailProviders(
+        resolver=_resolve_kr,
+        investor_flow=fake_investor_flow,
+    )
+    response = await build_stock_detail(
+        user_id=1, market="kr", symbol="403550", db=SimpleNamespace(),
+        providers=providers,
+    )
+    assert response.investorFlow is not None
+    assert response.investorFlow.dataState == "fresh"
+    assert response.investorFlow.foreignNet == 450123
+    assert response.investorFlow.doubleBuy is True
+
+
+@pytest.mark.asyncio
+async def test_us_detail_does_not_call_investor_flow_provider():
+    calls = []
+
+    async def fake_investor_flow(market, symbol, db):
+        calls.append((market, symbol))
+        return None
+
+    providers = StockDetailProviders(
+        resolver=_resolve_us,
+        investor_flow=fake_investor_flow,
+    )
+    response = await build_stock_detail(
+        user_id=1, market="us", symbol="AAPL", db=SimpleNamespace(),
+        providers=providers,
+    )
+    assert response.investorFlow is None
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_investor_flow_provider_failure_warns_but_keeps_response():
+    async def boom(market, symbol, db):
+        raise RuntimeError("db unavailable")
+
+    providers = StockDetailProviders(
+        resolver=_resolve_kr,
+        investor_flow=boom,
+    )
+    response = await build_stock_detail(
+        user_id=1, market="kr", symbol="403550", db=SimpleNamespace(),
+        providers=providers,
+    )
+    assert response.investorFlow is None
+    assert "investor_flow_unavailable" in response.meta.warnings
+
+
+@pytest.mark.asyncio
+async def test_kr_detail_investor_flow_defaults_to_none_without_snapshots(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.stock_detail_service._latest_investor_flow_items",
+        AsyncMock(return_value={}),
+    )
+    response = await build_stock_detail(
+        user_id=1, market="kr", symbol="403550", db=SimpleNamespace(),
+        providers=StockDetailProviders(resolver=_resolve_kr),
+    )
+    assert response.investorFlow is not None
+    assert response.investorFlow.dataState == "missing"
+    assert response.investorFlow.foreignNet is None

--- a/tests/test_stock_detail_investor_flow_provider.py
+++ b/tests/test_stock_detail_investor_flow_provider.py
@@ -4,7 +4,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from app.schemas.invest_stock_detail import StockDetailInvestorFlow
+from app.schemas.invest_stock_detail import (
+    StockDetailInvestorFlow,
+    StockDetailInvestorFlowDailyRow,
+)
 from app.services.invest_view_model.stock_detail_service import (
     StockDetailProviders,
     build_stock_detail,
@@ -119,6 +122,10 @@ async def test_kr_detail_investor_flow_defaults_to_none_without_snapshots(monkey
         "app.services.invest_view_model.stock_detail_service._latest_investor_flow_items",
         AsyncMock(return_value={}),
     )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.stock_detail_service._recent_investor_flow_rows",
+        AsyncMock(return_value=[]),
+    )
     response = await build_stock_detail(
         user_id=1,
         market="kr",
@@ -129,3 +136,64 @@ async def test_kr_detail_investor_flow_defaults_to_none_without_snapshots(monkey
     assert response.investorFlow is not None
     assert response.investorFlow.dataState == "missing"
     assert response.investorFlow.foreignNet is None
+    assert response.investorFlow.dailyRows == []
+
+
+@pytest.mark.asyncio
+async def test_kr_detail_default_investor_flow_includes_daily_rows(monkeypatch):
+    from datetime import date
+    from unittest.mock import AsyncMock
+
+    from app.schemas.investor_flow import InvestorFlowItem
+
+    monkeypatch.setattr(
+        "app.services.invest_view_model.stock_detail_service._latest_investor_flow_items",
+        AsyncMock(
+            return_value={
+                "403550": InvestorFlowItem(
+                    symbol="403550",
+                    dataState="fresh",
+                    snapshotDate=date(2026, 5, 13),
+                    source="naver_finance",
+                    foreignNet=20859,
+                    institutionNet=-12931,
+                    individualNet=125586,
+                    foreignConsecutiveBuyDays=4,
+                )
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "app.services.invest_view_model.stock_detail_service._recent_investor_flow_rows",
+        AsyncMock(
+            return_value=[
+                StockDetailInvestorFlowDailyRow(
+                    snapshotDate="2026-05-13",
+                    source="naver_finance",
+                    foreignNet=20859,
+                    institutionNet=-12931,
+                    individualNet=125586,
+                ),
+                StockDetailInvestorFlowDailyRow(
+                    snapshotDate="2026-05-12",
+                    source="naver_finance",
+                    foreignNet=440,
+                    institutionNet=-1024,
+                    individualNet=590,
+                ),
+            ]
+        ),
+    )
+
+    response = await build_stock_detail(
+        user_id=1,
+        market="kr",
+        symbol="403550",
+        db=SimpleNamespace(),
+        providers=StockDetailProviders(resolver=_resolve_kr),
+    )
+
+    assert response.investorFlow is not None
+    assert response.investorFlow.dailyRows[0].snapshotDate == "2026-05-13"
+    assert response.investorFlow.dailyRows[0].foreignNet == 20859
+    assert "지연된 과거 참고 데이터" in response.investorFlow.cautionLabel


### PR DESCRIPTION
## Summary
- Add KR stock-detail investor-flow insight cards backed by existing investor_flow_snapshots read paths.
- Add /invest screener investor-flow MVP preset and result chip using snapshot-only discovery with explicit unavailable/missing states.
- Add backend/frontend regression coverage for read-only investor-flow detail and screener UX.

## Safety
- Read-only /invest data UX/API work only.
- Reuses existing ROB-191/ROB-205 investor_flow_snapshots model/repository; no schema, migration, broker/order/watch/order-intent, scheduler, or live provider request path added.
- Screener preset returns empty/missing state when snapshots are absent; it does not fall through to live Naver full-universe scraping.

## Verification
- `uv run pytest tests/test_investor_flow_snapshots_repository.py tests/test_investor_flow_service_latest_items.py tests/test_stock_detail_investor_flow_provider.py tests/test_screener_service_investor_flow_chip.py tests/test_investor_flow_snapshot_builder.py tests/test_invest_view_model_safety.py -q` -> 29 passed
- `pnpm --dir frontend/invest exec vitest run src/__tests__/StockDetailPage.test.tsx src/__tests__/DesktopScreenerPage.test.tsx` -> 18 passed
- `pnpm --dir frontend/invest typecheck` -> pass
- `uv run ruff check <changed backend files>` -> pass
- `uv run ruff format --check <changed backend files>` -> pass

Linear: ROB-254


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Investor Flow Momentum" screener preset to identify stocks with strong foreign and institutional buying momentum.
  * Introduced investor flow indicator chips in screener results displaying buy/sell momentum signals.
  * Added investor flow data card in stock detail page showing net buy/sell amounts by investor type, including daily trading history and buyer breakdowns.

* **Tests**
  * Added comprehensive test coverage for investor flow features across screener and stock detail views.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/829)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->