### PR TITLE
feat(mcp): enable confirmed Kiwoom mock orders

### DIFF
--- a/app/mcp_server/tooling/orders_kiwoom_variants.py
+++ b/app/mcp_server/tooling/orders_kiwoom_variants.py
@@ -16,10 +16,12 @@ Mirrors the structure of ``orders_kis_variants.py``.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from app.core.config import validate_kiwoom_mock_config
 from app.services.brokers.kiwoom import constants
+from app.services.brokers.kiwoom.client import KiwoomMockClient
+from app.services.brokers.kiwoom.domestic_orders import KiwoomDomesticOrderClient
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -142,19 +144,75 @@ def _confirmed_not_implemented(tool_name: str) -> dict[str, Any]:
 
 
 async def _kiwoom_mock_place_order_impl(**kwargs: Any) -> dict[str, Any]:
-    # Real implementation would build KiwoomMockClient.from_app_settings()
-    # and call KiwoomDomesticOrderClient.place_buy_order/place_sell_order.
-    # In this PR we only support dry_run; live submission is intentionally
-    # blocked at the tool boundary (see register()).
-    return {
-        "success": True,
-        "dry_run": kwargs.get("dry_run", True),
-        "side": kwargs.get("side"),
-        "symbol": kwargs.get("symbol"),
-        "quantity": kwargs.get("quantity"),
-        "price": kwargs.get("price"),
+    symbol = str(kwargs.get("symbol") or "").strip()
+    side = kwargs.get("side")
+    quantity_value = kwargs.get("quantity")
+    price_value = kwargs.get("price")
+    if quantity_value is None or price_value is None:
+        raise ValueError("kiwoom_mock_place_order requires quantity and price")
+    quantity = int(quantity_value)
+    price = int(price_value)
+    dry_run = bool(kwargs.get("dry_run", True))
+    exchange = kwargs.get("exchange") or constants.MOCK_EXCHANGE_KRX
+
+    base_response = {
+        "source": "kiwoom",
         "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+        "dry_run": dry_run,
+        "side": side,
+        "symbol": symbol,
+        "quantity": quantity,
+        "price": price,
+        "exchange": str(exchange).strip().upper(),
     }
+    if dry_run:
+        return {"success": True, **base_response}
+    if side not in {"buy", "sell"}:
+        return {
+            "success": False,
+            **base_response,
+            "error": f"kiwoom_mock_place_order supports side='buy' or 'sell'; got {side!r}.",
+        }
+
+    try:
+        client = KiwoomMockClient.from_app_settings()
+        order_client = KiwoomDomesticOrderClient(cast(Any, client))
+        if side == "buy":
+            broker_response = await order_client.place_buy_order(
+                symbol=symbol,
+                quantity=quantity,
+                price=price,
+                exchange=exchange,
+            )
+        else:
+            broker_response = await order_client.place_sell_order(
+                symbol=symbol,
+                quantity=quantity,
+                price=price,
+                exchange=exchange,
+            )
+    except Exception as exc:  # noqa: BLE001 - MCP tools should fail closed with JSON
+        return {
+            "success": False,
+            **base_response,
+            "error": f"kiwoom_mock_place_order failed: {type(exc).__name__}: {exc}",
+        }
+
+    return_code = broker_response.get("return_code", constants.SUCCESS_RETURN_CODE)
+    try:
+        success = int(return_code) == constants.SUCCESS_RETURN_CODE
+    except (TypeError, ValueError):
+        success = return_code in (None, "", "0")
+
+    response = {
+        "success": success,
+        **base_response,
+        "broker_response": broker_response,
+    }
+    for key in ("return_code", "return_msg", "continuation", "ord_no", "order_no"):
+        if key in broker_response:
+            response[key] = broker_response[key]
+    return response
 
 
 async def _kiwoom_mock_preview_impl(**kwargs: Any) -> dict[str, Any]:
@@ -265,20 +323,19 @@ def register(mcp: FastMCP) -> None:
         ):
             if guard:
                 return guard
-        if not dry_run:
-            if not confirm:
-                return {
-                    "success": False,
-                    "error": "kiwoom_mock_place_order requires confirm=True when dry_run=False.",
-                    "source": "kiwoom",
-                    "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
-                }
-            return _confirmed_not_implemented("kiwoom_mock_place_order")
+        if not dry_run and not confirm:
+            return {
+                "success": False,
+                "error": "kiwoom_mock_place_order requires confirm=True when dry_run=False.",
+                "source": "kiwoom",
+                "account_mode": ACCOUNT_MODE_KIWOOM_MOCK,
+            }
         return await _kiwoom_mock_place_order_impl(
             symbol=symbol,
             side=side,
             quantity=quantity,
             price=price,
+            exchange=exchange,
             dry_run=dry_run,
         )
 

--- a/tests/test_mcp_kiwoom_order_variants.py
+++ b/tests/test_mcp_kiwoom_order_variants.py
@@ -157,39 +157,160 @@ async def test_cancel_rejects_unsafe_order_ids(monkeypatch, bad_id):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_place_order_confirmed_returns_explicit_not_implemented_failure(
-    monkeypatch,
+def _patch_fake_kiwoom_order_client(
+    monkeypatch, mod, responses: dict[str, dict[str, Any]]
 ):
-    """dry_run=False + confirm=True must NOT return stub success — that would
-    trick operators into thinking a real mock order was submitted."""
+    calls: list[dict[str, Any]] = []
+
+    class FakeKiwoomMockClient:
+        @classmethod
+        def from_app_settings(cls):
+            calls.append({"client": "from_app_settings"})
+            return cls()
+
+    class FakeOrderClient:
+        def __init__(self, client):
+            calls.append({"order_client": client.__class__.__name__})
+
+        async def place_buy_order(self, **kwargs):
+            calls.append({"method": "buy", **kwargs})
+            return responses["buy"]
+
+        async def place_sell_order(self, **kwargs):
+            calls.append({"method": "sell", **kwargs})
+            return responses["sell"]
+
+    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
+    monkeypatch.setattr(mod, "KiwoomMockClient", FakeKiwoomMockClient, raising=False)
+    monkeypatch.setattr(
+        mod, "KiwoomDomesticOrderClient", FakeOrderClient, raising=False
+    )
+    return calls
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("side", "quantity", "price", "broker_response", "extra_assertions"),
+    [
+        (
+            "buy",
+            1,
+            70000,
+            {"return_code": 0, "return_msg": "정상", "ord_no": "0000111222"},
+            {"return_code": 0, "ord_no": "0000111222"},
+        ),
+        (
+            "sell",
+            2,
+            71000,
+            {
+                "return_code": "0",
+                "return_msg": "정상",
+                "ord_no": "0000222333",
+                "continuation": {"cont_yn": "N", "next_key": ""},
+            },
+            {
+                "return_code": "0",
+                "ord_no": "0000222333",
+                "continuation": {"cont_yn": "N", "next_key": ""},
+            },
+        ),
+    ],
+)
+async def test_place_order_confirmed_calls_kiwoom_mock_order_client(
+    monkeypatch,
+    side,
+    quantity,
+    price,
+    broker_response,
+    extra_assertions,
+):
+    """dry_run=False + confirm=True should call the Kiwoom mock client once.
+
+    This must not return a local stub success: the response should come from
+    KiwoomDomesticOrderClient using KiwoomMockClient.from_app_settings().
+    """
 
     from app.mcp_server.tooling import orders_kiwoom_variants as mod
 
-    impl_calls = {"count": 0}
-
-    async def fake_impl(**kwargs):
-        impl_calls["count"] += 1
-        return {"success": True}
-
-    monkeypatch.setattr(mod, "_mock_config_error", lambda: None)
-    monkeypatch.setattr(mod, "_kiwoom_mock_place_order_impl", fake_impl)
+    fallback_response = {"return_code": 0, "return_msg": "정상", "ord_no": "unused"}
+    calls = _patch_fake_kiwoom_order_client(
+        monkeypatch,
+        mod,
+        responses={
+            "buy": fallback_response,
+            "sell": fallback_response,
+            side: broker_response,
+        },
+    )
     mcp = DummyMCP()
     _register(mcp)
 
     response = await mcp.tools["kiwoom_mock_place_order"](
         symbol="005930",
-        side="buy",
-        quantity=1,
-        price=70000,
+        side=side,
+        quantity=quantity,
+        price=price,
         dry_run=False,
         confirm=True,
     )
 
-    assert response["success"] is False
-    assert "not implemented" in response["error"].lower()
+    assert response["success"] is True
+    assert response["source"] == "kiwoom"
     assert response["account_mode"] == "kiwoom_mock"
-    assert impl_calls["count"] == 0
+    assert response["dry_run"] is False
+    assert response["broker_response"] == broker_response
+    assert response["return_msg"] == "정상"
+    for key, value in extra_assertions.items():
+        assert response[key] == value
+    assert calls == [
+        {"client": "from_app_settings"},
+        {"order_client": "FakeKiwoomMockClient"},
+        {
+            "method": side,
+            "symbol": "005930",
+            "quantity": quantity,
+            "price": price,
+            "exchange": "KRX",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_place_order_confirmed_rejects_unexpected_side_without_broker_call(
+    monkeypatch,
+):
+    from app.mcp_server.tooling import orders_kiwoom_variants as mod
+
+    calls = {"client": 0, "order_client": 0}
+
+    class FakeKiwoomMockClient:
+        @classmethod
+        def from_app_settings(cls):
+            calls["client"] += 1
+            return cls()
+
+    class FakeOrderClient:
+        def __init__(self, client):  # noqa: ARG002
+            calls["order_client"] += 1
+
+    monkeypatch.setattr(mod, "KiwoomMockClient", FakeKiwoomMockClient, raising=False)
+    monkeypatch.setattr(
+        mod, "KiwoomDomesticOrderClient", FakeOrderClient, raising=False
+    )
+
+    response = await mod._kiwoom_mock_place_order_impl(
+        symbol="005930",
+        side="hold",
+        quantity=1,
+        price=70000,
+        exchange="KRX",
+        dry_run=False,
+    )
+
+    assert response["success"] is False
+    assert "buy" in response["error"]
+    assert calls == {"client": 0, "order_client": 0}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Enables confirmed Kiwoom mock buy/sell order submission through the Kiwoom mock-specific MCP path only.
- Preserves dry-run defaults and requires `dry_run=False` plus `confirm=True` before a confirmed mock order request can submit.
- Keeps KRX-only execution constraints and covers broker client responses with unit tests using fake clients / mock transports.

## Verification
- `uv run pytest tests/test_kiwoom_mock_config.py tests/test_kiwoom_client_endpoint_guard.py tests/test_kiwoom_domestic_orders.py tests/test_mcp_kiwoom_order_variants.py -q` -> 83 passed, 2 warnings
- `uv run ruff format --check app/mcp_server/tooling/orders_kiwoom_variants.py tests/test_mcp_kiwoom_order_variants.py` -> 2 files already formatted
- `uv run ruff check app/mcp_server/tooling/orders_kiwoom_variants.py tests/test_mcp_kiwoom_order_variants.py` -> All checks passed
- `git diff --check` -> passed
- MCP preview smoke: `kiwoom_mock_preview_order(005930 buy 1 @ 50000, KRX)` -> success, preview=true
- MCP dry-run smoke: `kiwoom_mock_place_order(005930 buy 1 @ 50000, KRX, dry_run=true, confirm=false)` -> success, dry_run=true

## Safety / non-actions
- Kiwoom mock only; no live Kiwoom, KIS, Upbit, Alpaca, or generic order route used.
- No confirmed Kiwoom mock order was submitted.
- No production deploy, scheduler change, broker mutation, or database mutation was performed.
- No secrets, app keys, tokens, account numbers, or authorization values are included.

## Operational follow-up before actual mock execution
Actual confirmed Kiwoom mock order smoke should only happen after explicit user approval and deploy, with exact symbol/side/quantity/price, read-only preflight, cancel/reconcile plan, and secret-redacted evidence capture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kiwoom order placement now processes confirmed orders in non-dry-run mode, executing them through the mock broker instead of returning an error.

* **Tests**
  * Added tests to verify order placement execution and validate order side parameter handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/830)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->