### PR TITLE
feat: show sale profit in invest sell history

### DIFF
--- a/app/schemas/execution_ledger.py
+++ b/app/schemas/execution_ledger.py
@@ -86,6 +86,9 @@ class ExecutionLedgerRead(BaseModel):
     source_run_id: uuid.UUID | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
+    cost_basis_notional: Decimal | None = None
+    realized_profit: Decimal | None = None
+    realized_profit_rate: Decimal | None = None
 
 
 class SourceBreakdown(BaseModel):

--- a/app/services/execution_ledger/query_service.py
+++ b/app/services/execution_ledger/query_service.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections import deque
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -42,6 +44,105 @@ def _data_state_from_lag(lag_minutes: float | None) -> DataState:
     if lag_minutes <= _STALE_HOURS * 60:
         return "stale"
     return "missing"
+
+
+def _ledger_match_key(item: ExecutionLedgerRead) -> tuple[str, str, str, str, str, str]:
+    return (
+        item.broker,
+        item.account_mode,
+        item.venue,
+        item.instrument_type,
+        item.symbol,
+        item.currency,
+    )
+
+
+def _ledger_item_key(item: ExecutionLedgerRead) -> tuple[str, str, str, str, int]:
+    return (
+        item.broker,
+        item.account_mode,
+        item.venue,
+        item.broker_order_id,
+        item.fill_seq,
+    )
+
+
+def _annotate_realized_profit(
+    sell_items: list[ExecutionLedgerRead],
+    history_items: list[ExecutionLedgerRead],
+) -> list[ExecutionLedgerRead]:
+    """Attach FIFO realized P/L to sells using earlier buy fills in the same account.
+
+    The execution ledger is append-only fill data, so this is intentionally a
+    read-model calculation. Unmatched sells remain visible with P/L fields null
+    instead of guessing a cost basis.
+    """
+    if not sell_items:
+        return sell_items
+
+    sell_keys = {_ledger_item_key(item) for item in sell_items}
+    annotations: dict[
+        tuple[str, str, str, str, int], tuple[Decimal, Decimal, Decimal]
+    ] = {}
+    lots: dict[tuple[str, str, str, str, str, str], deque[tuple[Decimal, Decimal]]] = {}
+
+    for item in sorted(history_items, key=lambda row: row.filled_at):
+        qty = Decimal(item.filled_qty)
+        if qty <= 0:
+            continue
+        key = _ledger_match_key(item)
+        if item.side == "buy":
+            unit_cost = Decimal(item.filled_notional) / qty
+            lots.setdefault(key, deque()).append((qty, unit_cost))
+            continue
+        if item.side != "sell":
+            continue
+
+        remaining = qty
+        cost_basis = Decimal("0")
+        queue = lots.setdefault(key, deque())
+        while remaining > 0 and queue:
+            lot_qty, lot_unit_cost = queue[0]
+            matched_qty = min(remaining, lot_qty)
+            cost_basis += matched_qty * lot_unit_cost
+            remaining -= matched_qty
+            lot_qty -= matched_qty
+            if lot_qty <= 0:
+                queue.popleft()
+            else:
+                queue[0] = (lot_qty, lot_unit_cost)
+
+        if remaining > 0:
+            # Not enough historical buys in this ledger scope. Keep the row but
+            # do not present a potentially misleading Toss-style return.
+            continue
+
+        item_key = _ledger_item_key(item)
+        if item_key in sell_keys:
+            proceeds = Decimal(item.filled_notional)
+            profit = proceeds - cost_basis
+            rate = (
+                (profit / cost_basis * Decimal("100")) if cost_basis else Decimal("0")
+            )
+            annotations[item_key] = (cost_basis, profit, rate)
+
+    annotated: list[ExecutionLedgerRead] = []
+    for item in sell_items:
+        values = annotations.get(_ledger_item_key(item))
+        if values is None:
+            annotated.append(item)
+        else:
+            cost_basis, profit, rate = values
+            annotated.append(
+                item.model_copy(
+                    update={
+                        "cost_basis_notional": cost_basis,
+                        "realized_profit": profit,
+                        "realized_profit_rate": rate,
+                    }
+                )
+            )
+    return annotated
 
 
 def _state_from_items_and_freshness(
@@ -151,6 +252,30 @@ class ExecutionLedgerQueryService:
         stmt = ExecutionLedgerRepository.apply_market_filter(stmt, market)
         rows = (await self.db.execute(stmt)).scalars().all()
         items = [ExecutionLedgerRead.model_validate(row) for row in rows]
+        if items:
+            max_sell_at = max(item.filled_at for item in items)
+            symbols = {item.symbol for item in items}
+            brokers = {item.broker for item in items}
+            account_modes = {item.account_mode for item in items}
+            venues = {item.venue for item in items}
+            instrument_types = {item.instrument_type for item in items}
+            currencies = {item.currency for item in items}
+            history_stmt = (
+                select(ExecutionLedger)
+                .where(ExecutionLedger.filled_at <= max_sell_at)
+                .where(ExecutionLedger.symbol.in_(symbols))
+                .where(ExecutionLedger.broker.in_(brokers))
+                .where(ExecutionLedger.account_mode.in_(account_modes))
+                .where(ExecutionLedger.venue.in_(venues))
+                .where(ExecutionLedger.instrument_type.in_(instrument_types))
+                .where(ExecutionLedger.currency.in_(currencies))
+                .order_by(ExecutionLedger.filled_at.asc(), ExecutionLedger.id.asc())
+            )
+            history_rows = (await self.db.execute(history_stmt)).scalars().all()
+            history_items = [
+                ExecutionLedgerRead.model_validate(row) for row in history_rows
+            ]
+            items = _annotate_realized_profit(items, history_items)
 
         freshness = await self.freshness()
         data_state, empty_reason = _state_from_items_and_freshness(

--- a/frontend/invest/src/__tests__/SellHistoryPanel.test.tsx
+++ b/frontend/invest/src/__tests__/SellHistoryPanel.test.tsx
@@ -34,6 +34,9 @@ const baseResponse = {
       source_run_id: "run-1",
       created_at: "2026-05-13T07:20:32Z",
       updated_at: null,
+      cost_basis_notional: "1500000.0000",
+      realized_profit: "459000.0000",
+      realized_profit_rate: "30.6000",
     },
   ],
 };
@@ -56,6 +59,9 @@ test("SellHistoryPanel renders sell ledger rows and uses include credentials", a
   expect(screen.getByText("매도 이력")).toBeInTheDocument();
   expect(screen.getAllByText("₩1,959,000").length).toBeGreaterThan(0);
   expect(screen.getByText("총 판매금액 · KRW")).toBeInTheDocument();
+  expect(screen.getByText("판매수익 · KRW")).toBeInTheDocument();
+  expect(screen.getAllByText("+₩459,000").length).toBeGreaterThan(0);
+  expect(screen.getAllByText("수익률 +30.6%").length).toBeGreaterThan(0);
   expect(screen.getByText("보정")).toBeInTheDocument();
   expect(screen.getByText("출처 보정 1")).toBeInTheDocument();
 

--- a/frontend/invest/src/components/my/SellHistoryPanel.tsx
+++ b/frontend/invest/src/components/my/SellHistoryPanel.tsx
@@ -43,6 +43,26 @@ function formatMoney(value: string | number | null | undefined, currency: string
   return `${n.toLocaleString("ko-KR")} ${currency}`;
 }
 
+function formatSignedMoney(value: string | number | null | undefined, currency: string): string {
+  const n = toNumber(value);
+  if (n == null) return "—";
+  const sign = n > 0 ? "+" : n < 0 ? "-" : "";
+  return `${sign}${formatMoney(Math.abs(n), currency)}`;
+}
+
+function formatRate(value: string | number | null | undefined): string {
+  const n = toNumber(value);
+  if (n == null) return "—";
+  const sign = n > 0 ? "+" : "";
+  return `${sign}${n.toLocaleString("ko-KR", { minimumFractionDigits: 1, maximumFractionDigits: 1 })}%`;
+}
+
+function signedColor(value: string | number | null | undefined): string {
+  const n = toNumber(value);
+  if (n == null || n === 0) return "var(--fg-2)";
+  return n > 0 ? "var(--gain)" : "var(--danger)";
+}
+
 function formatQty(row: FillRow): string {
   const qty = toNumber(row.filled_qty);
   if (qty == null) return "—";
@@ -98,6 +118,25 @@ function totalByCurrency(rows: FillRow[]): { currency: string; total: number }[]
   return Array.from(totals.entries()).map(([currency, total]) => ({ currency, total }));
 }
 
+function profitByCurrency(rows: FillRow[]): { currency: string; profit: number; costBasis: number; rate: number | null }[] {
+  const totals = new Map<string, { profit: number; costBasis: number }>();
+  for (const row of rows) {
+    const profit = toNumber(row.realized_profit);
+    const costBasis = toNumber(row.cost_basis_notional);
+    if (profit == null || costBasis == null) continue;
+    const current = totals.get(row.currency) ?? { profit: 0, costBasis: 0 };
+    current.profit += profit;
+    current.costBasis += costBasis;
+    totals.set(row.currency, current);
+  }
+  return Array.from(totals.entries()).map(([currency, value]) => ({
+    currency,
+    profit: value.profit,
+    costBasis: value.costBasis,
+    rate: value.costBasis > 0 ? (value.profit / value.costBasis) * 100 : null,
+  }));
+}
+
 export function SellHistoryPanel({ compact = false }: { compact?: boolean }) {
   const [market, setMarket] = useState<FillMarket | "all">("all");
   const [state, setState] = useState<
@@ -126,6 +165,7 @@ export function SellHistoryPanel({ compact = false }: { compact?: boolean }) {
   const dataState = state.status === "ready" ? state.data.data_state : null;
   const breakdownLabel = state.status === "ready" ? sourceBreakdownLabel(state.data) : null;
   const saleTotals = useMemo(() => totalByCurrency(rows), [rows]);
+  const profitTotals = useMemo(() => profitByCurrency(rows), [rows]);
 
   return (
     <section
@@ -227,9 +267,28 @@ export function SellHistoryPanel({ compact = false }: { compact?: boolean }) {
               </div>
             </div>
           ))}
-          <div style={{ alignSelf: "center", fontSize: 11, color: "var(--fg-3)" }}>
-            실현손익/수익률은 매수 원가 매칭이 추가되면 토스 수익분석처럼 표시됩니다.
-          </div>
+          {profitTotals.map(({ currency, profit, rate }) => (
+            <div
+              key={`profit-${currency}`}
+              style={{
+                borderRadius: 12,
+                background: "var(--surface-2)",
+                padding: "8px 10px",
+                minWidth: compact ? 0 : 150,
+              }}
+            >
+              <div style={{ fontSize: 10, color: "var(--fg-3)", fontWeight: 700 }}>판매수익 · {currency}</div>
+              <div style={{ marginTop: 2, fontSize: compact ? 13 : 15, fontWeight: 900, fontFeatureSettings: '"tnum"', color: signedColor(profit) }}>
+                {formatSignedMoney(profit, currency)}
+              </div>
+              <div style={{ marginTop: 2, fontSize: 11, color: signedColor(rate) }}>수익률 {formatRate(rate)}</div>
+            </div>
+          ))}
+          {profitTotals.length === 0 && saleTotals.length > 0 && (
+            <div style={{ alignSelf: "center", fontSize: 11, color: "var(--fg-3)" }}>
+              매수 원가가 매칭된 체결부터 토스 수익분석처럼 판매수익/수익률이 표시됩니다.
+            </div>
+          )}
         </div>
       )}
 
@@ -251,14 +310,16 @@ export function SellHistoryPanel({ compact = false }: { compact?: boolean }) {
 
       {state.status === "ready" && rows.length > 0 && (
         <div style={{ overflowX: "auto" }}>
-          <table style={{ width: "100%", borderCollapse: "collapse", minWidth: compact ? 0 : 720 }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", minWidth: compact ? 0 : 900 }}>
             <thead>
               <tr style={{ color: "var(--fg-3)", fontSize: 11, textAlign: "left" }}>
                 <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)" }}>일시</th>
                 <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)" }}>종목</th>
                 {!compact && <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)" }}>수량</th>}
                 <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)", textAlign: "right" }}>단가</th>
-                <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)", textAlign: "right" }}>금액</th>
+                <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)", textAlign: "right" }}>총 판매금액</th>
+                {!compact && <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)", textAlign: "right" }}>판매수익</th>}
+                {!compact && <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)", textAlign: "right" }}>수익률</th>}
                 {!compact && <th style={{ padding: "8px 14px", borderTop: "1px solid var(--divider)", borderBottom: "1px solid var(--divider)" }}>출처</th>}
               </tr>
             </thead>
@@ -285,6 +346,16 @@ export function SellHistoryPanel({ compact = false }: { compact?: boolean }) {
                   <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, fontWeight: 800, textAlign: "right", fontFeatureSettings: '"tnum"' }}>
                     {formatMoney(row.filled_notional, row.currency)}
                   </td>
+                  {!compact && (
+                    <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, fontWeight: 800, textAlign: "right", fontFeatureSettings: '"tnum"', color: signedColor(row.realized_profit) }}>
+                      {formatSignedMoney(row.realized_profit, row.currency)}
+                    </td>
+                  )}
+                  {!compact && (
+                    <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 13, fontWeight: 800, textAlign: "right", fontFeatureSettings: '"tnum"', color: signedColor(row.realized_profit_rate) }}>
+                      {formatRate(row.realized_profit_rate)}
+                    </td>
+                  )}
                   {!compact && <td style={{ padding: "10px 14px", borderBottom: "1px solid var(--divider)", fontSize: 12, color: "var(--fg-3)" }}>{sourceLabel(row)}</td>}
                 </tr>
                 );

--- a/frontend/invest/src/types/fills.ts
+++ b/frontend/invest/src/types/fills.ts
@@ -29,6 +29,9 @@ export interface FillRow {
   source_run_id: string | null;
   created_at: string | null;
   updated_at: string | null;
+  cost_basis_notional?: string | null;
+  realized_profit?: string | null;
+  realized_profit_rate?: string | null;
 }
 
 export interface FillSourceBreakdown {

--- a/tests/routers/test_invest_fills_router.py
+++ b/tests/routers/test_invest_fills_router.py
@@ -68,11 +68,12 @@ def _reconcile_run_row(broker: str = "kis"):
     )
 
 
-def _make_db(data_rows, reconcile_rows):
-    """Return an AsyncSession-like mock serving two distinct execute() calls.
+def _make_db(data_rows, reconcile_rows, history_rows=None):
+    """Return an AsyncSession-like mock serving ledger/history/freshness queries.
 
     First call → data rows (main ledger query).
-    Second call → reconcile_rows (latest_run_per_broker subquery).
+    Optional second call → history_rows (sell-history cost-basis query).
+    Remaining calls → reconcile_rows (latest_run_per_broker subquery).
     """
 
     def _scalars_for(rows):
@@ -96,6 +97,8 @@ def _make_db(data_rows, reconcile_rows):
         call_count += 1
         if call_count == 1:
             return _scalars_for(data_rows)
+        if history_rows is not None and call_count == 2:
+            return _scalars_for(history_rows)
         return _scalars_for(reconcile_rows)
 
     db = AsyncMock()
@@ -243,9 +246,25 @@ def test_fills_by_symbol_with_fresh_run_shows_stale_not_missing():
 
 @pytest.mark.unit
 def test_sell_history_returns_200_with_sell_rows():
-    row = _ledger_row(side="sell", broker_order_id="sell-001")
+    buy = _ledger_row(
+        id=10,
+        side="buy",
+        broker_order_id="buy-001",
+        filled_qty=Decimal("10"),
+        filled_price=Decimal("60000"),
+        filled_notional=Decimal("600000"),
+        filled_at=datetime(2026, 5, 9, 9, 0, tzinfo=UTC),
+    )
+    row = _ledger_row(
+        side="sell",
+        broker_order_id="sell-001",
+        filled_qty=Decimal("10"),
+        filled_price=Decimal("70000"),
+        filled_notional=Decimal("700000"),
+        filled_at=datetime(2026, 5, 10, 9, 0, tzinfo=UTC),
+    )
     run = _reconcile_run_row("kis")
-    db = _make_db([row], [run])
+    db = _make_db([row], [run], history_rows=[buy, row])
     client = TestClient(_make_app(db))
 
     resp = client.get("/trading/api/invest/fills/sell-history")
@@ -253,6 +272,8 @@ def test_sell_history_returns_200_with_sell_rows():
     data = resp.json()
     assert data["count"] == 1
     assert data["items"][0]["side"] == "sell"
+    assert data["items"][0]["realized_profit"] == "100000"
+    assert data["items"][0]["realized_profit_rate"].startswith("16.666")
     assert "source_breakdown" in data
     assert "data_state" in data
 
@@ -272,9 +293,35 @@ def test_sell_history_empty_with_no_runs():
 
 @pytest.mark.unit
 def test_sell_history_market_filter_param_accepted():
-    row = _ledger_row(side="sell", instrument_type="crypto", broker="upbit")
+    buy = _ledger_row(
+        id=10,
+        side="buy",
+        broker="upbit",
+        instrument_type="crypto",
+        venue="upbit",
+        symbol="KRW-BTC",
+        raw_symbol="KRW-BTC",
+        broker_order_id="buy-crypto-001",
+        filled_qty=Decimal("0.01000000"),
+        filled_price=Decimal("100000000"),
+        filled_notional=Decimal("1000000"),
+        filled_at=datetime(2026, 5, 9, 9, 0, tzinfo=UTC),
+    )
+    row = _ledger_row(
+        side="sell",
+        instrument_type="crypto",
+        broker="upbit",
+        venue="upbit",
+        symbol="KRW-BTC",
+        raw_symbol="KRW-BTC",
+        broker_order_id="sell-crypto-001",
+        filled_qty=Decimal("0.01000000"),
+        filled_price=Decimal("110000000"),
+        filled_notional=Decimal("1100000"),
+        filled_at=datetime(2026, 5, 10, 9, 0, tzinfo=UTC),
+    )
     run = _reconcile_run_row("upbit")
-    db = _make_db([row], [run])
+    db = _make_db([row], [run], history_rows=[buy, row])
     client = TestClient(_make_app(db))
 
     resp = client.get("/trading/api/invest/fills/sell-history?market=crypto&days=7")


### PR DESCRIPTION
## Summary
- Add FIFO cost-basis matching for sell-history rows so `/invest/my` can expose realized sale profit and return rate.
- Preserve unmatched sells while leaving profit fields null instead of guessing missing cost basis.
- Update the invest sell-history UI to show Toss-like total sale amount, sale profit, return rate, and coin-friendly quantity formatting.

## Toss reference
- Remote debugging endpoint was reachable, but the live Toss tab redirected to `signin`; attached Toss screenshot was used as the visual source of truth.
- Reference fields: period/month filter, profit/dividend/interest tabs, asset-class filters, total realized/sale profit, per-row sale profit, return rate, total sale amount, total purchase amount, sale quantity.

## Test Plan
- `PUBLIC_API_PATHS='["/api/v1/openclaw/callback"]' python -m pytest tests/routers/test_invest_fills_router.py -q`
- `npm test -- src/__tests__/SellHistoryPanel.test.tsx`
- `npm run typecheck`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sell history now displays realized profit amounts and profit rate percentages for each transaction.
  * Added profit totals aggregated by currency with color-coded formatting to quickly identify gains and losses.
  * Enhanced transaction details to show cost basis information for comprehensive profit tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/832)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->