### PR TITLE
feat(invest): add KR action readiness dashboard

### DIFF
--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.db import get_db
 from app.routers.dependencies import get_authenticated_user
 from app.schemas.invest_account_panel import AccountPanelResponse
+from app.schemas.invest_action_readiness import KrActionReadinessResponse
 from app.schemas.invest_calendar import (
     CalendarResponse,
     CalendarTab,
@@ -66,6 +67,9 @@ from app.services.invest_momentum_events.repository import (
 )
 from app.services.invest_screener_snapshots.coverage_service import build_coverage
 from app.services.invest_view_model.account_panel_service import build_account_panel
+from app.services.invest_view_model.action_readiness_service import (
+    build_kr_action_readiness,
+)
 from app.services.invest_view_model.calendar_service import build_calendar
 from app.services.invest_view_model.common_preferred_disparity_service import (
     build_common_preferred_disparity,
@@ -233,6 +237,22 @@ async def get_invest_coverage(
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get("/kr/action-readiness")
+async def get_kr_action_readiness(
+    user: Annotated[Any, Depends(get_authenticated_user)],
+    service: Annotated[InvestHomeService, Depends(get_invest_home_service)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    symbol: str = Query("", description="Optional six-digit KR equity symbol"),
+) -> KrActionReadinessResponse:
+    """Read-only KR action-report readiness/source dashboard (ROB-256)."""
+    return await build_kr_action_readiness(
+        db=db,
+        user_id=user.id,
+        home_service=service,
+        symbol=symbol or None,
+    )
 
 
 @router.get("/account-panel")

--- a/app/schemas/invest_action_readiness.py
+++ b/app/schemas/invest_action_readiness.py
@@ -1,0 +1,82 @@
+"""ROB-256 — read-only KR action-report data readiness contract."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.invest_coverage import (
+    CoverageActionability,
+    CoverageState,
+    InvestCoverageCounts,
+)
+
+ActionReadinessState = Literal[
+    "ready",
+    "degraded",
+    "blocked",
+    "missing",
+    "unsupported",
+    "unknown",
+]
+ActionReadinessAuthority = Literal[
+    "kis_live_broker",
+    "auto_trader_read_model",
+    "manual_or_paper_reference",
+    "external_reference",
+    "unsupported",
+]
+ActionReportImpact = Literal[
+    "none",
+    "degrades_report",
+    "blocks_buy_report",
+    "blocks_sell_report",
+    "blocks_all_action_reports",
+]
+
+
+class ActionReadinessLink(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    label: str
+    href: str
+
+
+class ActionReadinessFamily(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    labelKo: str
+    category: str
+    state: ActionReadinessState
+    impact: ActionReportImpact
+    authority: ActionReadinessAuthority
+    sourceOfTruth: str
+    references: list[str] = Field(default_factory=list)
+    latestAt: datetime | None = None
+    latestDate: date | None = None
+    counts: InvestCoverageCounts | None = None
+    coverageState: CoverageState | None = None
+    actionability: CoverageActionability
+    blockers: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+    links: list[ActionReadinessLink] = Field(default_factory=list)
+
+
+class KrActionReadinessResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    market: Literal["kr"] = "kr"
+    asOf: datetime
+    symbol: str | None = None
+    overallState: ActionReadinessState
+    canGenerateBuyReport: bool
+    canGenerateSellReport: bool
+    families: list[ActionReadinessFamily]
+    blockers: list[str] = Field(default_factory=list)
+    degradedSignals: list[str] = Field(default_factory=list)
+    sourcePolicy: list[str]
+    notes: list[str] = Field(default_factory=list)

--- a/app/services/invest_view_model/action_readiness_service.py
+++ b/app/services/invest_view_model/action_readiness_service.py
@@ -145,7 +145,9 @@ _AGGREGATE_VALUATION_SPEC = _SurfaceFamilySpec(
 )
 
 _COMMON_POST_VALUATION_SPECS = (
-    _SurfaceFamilySpec("research_reports", "리서치 리포트", _CONTEXT, "research_reports"),
+    _SurfaceFamilySpec(
+        "research_reports", "리서치 리포트", _CONTEXT, "research_reports"
+    ),
     _SurfaceFamilySpec(
         "research_consensus",
         "리서치 컨센서스",

--- a/app/services/invest_view_model/action_readiness_service.py
+++ b/app/services/invest_view_model/action_readiness_service.py
@@ -1,0 +1,670 @@
+"""ROB-256 — read-only KR action-report readiness view model.
+
+This module intentionally maps existing /invest read models and the existing
+InvestHomeService account-panel path into readiness metadata. It does not call
+order submission/cancel/modify services, run backfills, activate schedulers, or
+scrape external sites from the request path.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.kr_symbol_universe import KRSymbolUniverse
+from app.models.market_quote_snapshot import MarketQuoteSnapshot
+from app.models.market_valuation_snapshot import MarketValuationSnapshot
+from app.models.trade_journal import TradeJournal
+from app.schemas.invest_action_readiness import (
+    ActionReadinessAuthority,
+    ActionReadinessFamily,
+    ActionReadinessLink,
+    ActionReadinessState,
+    ActionReportImpact,
+    KrActionReadinessResponse,
+)
+from app.schemas.invest_coverage import (
+    CoverageActionability,
+    CoverageState,
+    InvestCoverageResponse,
+    InvestCoverageSurface,
+)
+from app.schemas.invest_home import InvestHomeResponse
+from app.services.invest_coverage_service import build_invest_coverage
+from app.services.invest_home_service import InvestHomeService
+
+_SOURCE_POLICY = [
+    "KIS live broker values are authoritative for tradeable KR holdings, cash, open orders, and sellable quantity.",
+    "/invest DB/read-model state is the product authority for market, screener, Naver/Toss-derived reference, news, calendar, valuation, flow, and historical ledger readiness.",
+    "Toss/Naver/external sources are displayed only as reference, candidate, or supporting signals and are never source-of-truth for action readiness.",
+    "Unavailable data is surfaced as stale/missing/partial/failed/unsupported/확인 불가 rather than estimated.",
+]
+
+
+def _safe_actionability(reason: str, *, priority: str = "high") -> CoverageActionability:
+    if priority == "none":
+        return CoverageActionability(
+            priority="none",
+            action="none",
+            queue=None,
+            approvalGates=[],
+            reason=reason,
+            safeByDefault=True,
+        )
+    return CoverageActionability(
+        priority=priority,  # type: ignore[arg-type]
+        action="investigate" if priority != "blocked" else "provider_contract_needed",
+        queue="invest-action-readiness-review",
+        approvalGates=["code_review"],
+        reason=reason,
+        safeByDefault=True,
+    )
+
+
+def _coverage_state_to_readiness(
+    state: CoverageState,
+    *, critical: bool = False,
+) -> ActionReadinessState:
+    if state == "fresh":
+        return "ready"
+    if state in {"partial", "stale"}:
+        return "degraded"
+    if state == "unsupported":
+        return "unsupported"
+    if state == "provider_unwired":
+        return "blocked" if critical else "unknown"
+    if state == "error":
+        return "blocked"
+    if state == "missing":
+        return "blocked" if critical else "missing"
+    return "unknown"
+
+
+def _surface_index(
+    coverage: InvestCoverageResponse,
+) -> dict[tuple[str, str | None], InvestCoverageSurface]:
+    return {(surface.surface, surface.market): surface for surface in coverage.surfaces}
+
+
+def _surface_family(
+    *,
+    key: str,
+    label_ko: str,
+    category: str,
+    surface: InvestCoverageSurface | None,
+    authority: ActionReadinessAuthority = "auto_trader_read_model",
+    impact: ActionReportImpact = "degrades_report",
+    critical: bool = False,
+    source_override: str | None = None,
+    extra_notes: Sequence[str] = (),
+    extra_references: Sequence[str] = (),
+    links: Sequence[ActionReadinessLink] = (),
+) -> ActionReadinessFamily:
+    if surface is None:
+        state: ActionReadinessState = "unknown" if not critical else "blocked"
+        blockers = [f"{key}: 확인 불가 — durable /invest read-model surface is not wired."]
+        return ActionReadinessFamily(
+            key=key,
+            labelKo=label_ko,
+            category=category,
+            state=state,
+            impact="blocks_all_action_reports" if critical else impact,
+            authority=authority,
+            sourceOfTruth=source_override or "auto_trader_read_model/unwired",
+            references=list(extra_references),
+            actionability=_safe_actionability(blockers[0], priority="blocked"),
+            blockers=blockers if critical else [],
+            warnings=[] if critical else blockers,
+            notes=list(extra_notes),
+            links=list(links),
+        )
+
+    readiness = _coverage_state_to_readiness(surface.state, critical=critical)
+    blockers: list[str] = []
+    warnings = list(surface.warnings)
+    if readiness == "blocked":
+        blockers.extend(surface.warnings or [f"{key}: 확인 불가"])
+    elif readiness in {"degraded", "missing", "unknown"} and not warnings:
+        warnings.append(f"{key}: {surface.state} 상태입니다.")
+    return ActionReadinessFamily(
+        key=key,
+        labelKo=label_ko,
+        category=category,
+        state=readiness,
+        impact=("blocks_all_action_reports" if critical and readiness == "blocked" else impact),
+        authority=authority,
+        sourceOfTruth=source_override or surface.sourceOfTruth,
+        references=surface.references,
+        latestAt=surface.latestAt,
+        latestDate=surface.latestDate,
+        counts=surface.counts,
+        coverageState=surface.state,
+        actionability=surface.actionability,
+        blockers=blockers,
+        warnings=warnings,
+        notes=list(surface.notes) + list(extra_notes),
+        links=list(links),
+    )
+
+
+def _symbol_state_from_latest_date(
+    latest_date: dt.date | None,
+    trading_day: dt.date,
+    *,
+    critical: bool = False,
+) -> ActionReadinessState:
+    if latest_date is None:
+        return "blocked" if critical else "missing"
+    return "ready" if latest_date >= trading_day else "degraded"
+
+
+def _symbol_blocker_or_warning(
+    *,
+    key: str,
+    symbol: str,
+    state: ActionReadinessState,
+    source: str,
+) -> tuple[list[str], list[str]]:
+    message = f"{key}: {symbol} {source} 확인 불가"
+    if state == "blocked":
+        return [message], []
+    if state in {"degraded", "missing", "unknown"}:
+        return [], [f"{key}: {symbol} symbol-scoped read-model is {state}/확인 불가"]
+    return [], []
+
+
+async def _symbol_quote_family(
+    db: AsyncSession,
+    *,
+    symbol: str,
+    trading_day: dt.date,
+) -> ActionReadinessFamily:
+    latest_at = (
+        await db.execute(
+            sa.select(sa.func.max(MarketQuoteSnapshot.snapshot_at)).where(
+                MarketQuoteSnapshot.market == "kr",
+                MarketQuoteSnapshot.symbol == symbol,
+            )
+        )
+    ).scalar_one_or_none()
+    latest_date = latest_at.date() if latest_at else None
+    state = _symbol_state_from_latest_date(latest_date, trading_day, critical=True)
+    blockers, warnings = _symbol_blocker_or_warning(
+        key="quotes", symbol=symbol, state=state, source="market_quote_snapshots"
+    )
+    return ActionReadinessFamily(
+        key="quotes",
+        labelKo="시세 / 현재가",
+        category="Market/read-model data",
+        state=state,
+        impact="blocks_all_action_reports" if state == "blocked" else "degrades_report",
+        authority="auto_trader_read_model",
+        sourceOfTruth="market_quote_snapshots",
+        references=["toss", "naver_reference"],
+        latestAt=latest_at,
+        latestDate=latest_date,
+        coverageState=None,
+        actionability=_safe_actionability(
+            blockers[0] if blockers else warnings[0] if warnings else f"{symbol} quote read-model is visible.",
+            priority="blocked" if blockers else "high" if warnings else "none",
+        ),
+        blockers=blockers,
+        warnings=warnings,
+        notes=["Symbol-scoped quote readiness is checked from the durable read-model only; no request-path provider fetch is made."],
+        links=[ActionReadinessLink(label="Stock detail", href=f"/invest/stocks/kr/{symbol}")],
+    )
+
+
+async def _symbol_ohlcv_family(
+    db: AsyncSession,
+    *,
+    symbol: str,
+    trading_day: dt.date,
+) -> ActionReadinessFamily:
+    try:
+        row = (
+            await db.execute(
+                sa.text(
+                    """
+                    SELECT MAX(time) AS latest_time,
+                           MAX(time::date) AS latest_date
+                    FROM public.kr_candles_1m
+                    WHERE symbol = :symbol
+                    """
+                ),
+                {"symbol": symbol},
+            )
+        ).one()
+        latest_at = row[0]
+        latest_date = row[1]
+    except Exception:  # noqa: BLE001 - readiness must fail closed/read-only
+        await db.rollback()
+        latest_at = None
+        latest_date = None
+    state = _symbol_state_from_latest_date(latest_date, trading_day)
+    blockers, warnings = _symbol_blocker_or_warning(
+        key="ohlcv", symbol=symbol, state=state, source="kr_candles_1m"
+    )
+    return ActionReadinessFamily(
+        key="ohlcv",
+        labelKo="OHLCV 캔들",
+        category="Market/read-model data",
+        state=state,
+        impact="degrades_report",
+        authority="auto_trader_read_model",
+        sourceOfTruth="kr_candles_1m",
+        references=[],
+        latestAt=latest_at,
+        latestDate=latest_date,
+        coverageState=None,
+        actionability=_safe_actionability(
+            warnings[0] if warnings else f"{symbol} OHLCV read-model is visible.",
+            priority="high" if warnings else "none",
+        ),
+        blockers=blockers,
+        warnings=warnings,
+        notes=["Symbol-scoped OHLCV readiness is checked from kr_candles_1m only; no request-path provider fetch is made."],
+    )
+
+
+async def _symbol_valuation_family(
+    db: AsyncSession,
+    *,
+    symbol: str,
+    trading_day: dt.date,
+) -> ActionReadinessFamily:
+    latest_date = (
+        await db.execute(
+            sa.select(sa.func.max(MarketValuationSnapshot.snapshot_date)).where(
+                MarketValuationSnapshot.market == "kr",
+                MarketValuationSnapshot.symbol == symbol,
+            )
+        )
+    ).scalar_one_or_none()
+    state = _symbol_state_from_latest_date(latest_date, trading_day)
+    blockers, warnings = _symbol_blocker_or_warning(
+        key="valuation_fundamentals",
+        symbol=symbol,
+        state=state,
+        source="market_valuation_snapshots",
+    )
+    return ActionReadinessFamily(
+        key="valuation_fundamentals",
+        labelKo="밸류에이션 / 펀더멘털",
+        category="News/calendar/research context",
+        state=state,
+        impact="degrades_report",
+        authority="auto_trader_read_model",
+        sourceOfTruth="market_valuation_snapshots",
+        references=["naver_reference"],
+        latestDate=latest_date,
+        coverageState=None,
+        actionability=_safe_actionability(
+            warnings[0] if warnings else f"{symbol} valuation read-model is visible.",
+            priority="high" if warnings else "none",
+        ),
+        blockers=blockers,
+        warnings=warnings,
+        notes=["Symbol-scoped valuation readiness is checked from the durable read-model only; no request-path provider fetch is made."],
+    )
+
+
+def _apply_symbol_surface_diagnostics(
+    families: list[ActionReadinessFamily],
+    coverage: InvestCoverageResponse,
+    *,
+    symbol: str,
+) -> None:
+    symbol_row = next((row for row in coverage.symbols if row.symbol == symbol), None)
+    if symbol_row is None:
+        return
+    by_key = {family.key: family for family in families}
+    for key in ("screener_snapshots", "news_feed", "investor_flow"):
+        state = symbol_row.surfaces.get(key)
+        family = by_key.get(key)
+        if state is None or family is None:
+            continue
+        readiness = _coverage_state_to_readiness(state)
+        if readiness == "ready":
+            family.notes.append(f"{symbol} symbol-scoped {key} diagnostic is ready.")
+            continue
+        family.state = readiness
+        family.coverageState = state
+        family.latestDate = symbol_row.latestDates.get(key)
+        warning = f"{key}: {symbol} symbol-scoped diagnostic is {state}/확인 불가"
+        if readiness == "blocked":
+            family.blockers.append(warning)
+        else:
+            family.warnings.append(warning)
+        family.notes.append("Aggregate market coverage was overridden by symbol-scoped coverage diagnostics for action-readiness.")
+
+
+def _broker_family(
+    *,
+    key: str,
+    label_ko: str,
+    impact: ActionReportImpact,
+    home: InvestHomeResponse | None,
+    symbol: str | None,
+) -> ActionReadinessFamily:
+    live_accounts = [account for account in (home.accounts if home else []) if account.source == "kis" and account.accountKind == "live"]
+    live_kr_holdings = [
+        holding
+        for holding in (home.holdings if home else [])
+        if holding.source == "kis" and holding.accountKind == "live" and holding.market == "KR"
+    ]
+    if symbol:
+        live_kr_holdings = [holding for holding in live_kr_holdings if holding.symbol == symbol]
+
+    warnings = [w.message for w in (home.meta.warnings if home else []) if w.source == "kis"]
+    has_kis_warning = bool(warnings)
+    state: ActionReadinessState = "ready"
+    blockers: list[str] = []
+    notes: list[str] = []
+    latest_note = "Existing InvestHomeService/account-panel read path only; no new broker mutation path."
+
+    if home is None or has_kis_warning:
+        state = "blocked"
+        blockers.append(f"{label_ko}: KIS live 확인 불가")
+    elif key == "kis_live_cash_orderable":
+        has_orderable = any(
+            (account.buyingPower.krw is not None or account.cashBalances.krw is not None)
+            for account in live_accounts
+        )
+        if not has_orderable:
+            state = "blocked"
+            blockers.append("KIS live 주문가능 현금 확인 불가")
+    elif key in {"kis_live_holdings", "kis_live_sellable_quantity"}:
+        if symbol:
+            if not live_kr_holdings:
+                state = "blocked" if key == "kis_live_sellable_quantity" else "missing"
+                blockers.append(f"{symbol} KIS live 보유/매도가능 수량 확인 불가")
+            elif key == "kis_live_sellable_quantity" and all(
+                holding.sellableQuantity is None for holding in live_kr_holdings
+            ):
+                state = "blocked"
+                blockers.append(f"{symbol} KIS live 매도가능 수량 확인 불가")
+        elif key == "kis_live_sellable_quantity":
+            state = "blocked"
+            blockers.append("심볼 미지정으로 KIS live 매도가능 수량 확인 불가")
+            notes.append("심볼을 지정하면 매도가능 수량 readiness를 평가합니다.")
+    elif key == "kis_live_open_orders":
+        # Current open-order authority is represented by the pending_orders
+        # read-model/reconciliation family below. The live broker remains the
+        # authority, so absence of a live open-order snapshot is fail-closed.
+        state = "blocked"
+        blockers.append("KIS live 미체결 주문 확인 불가")
+        notes.append("pending_orders read-model과 reconcile 상태는 별도 가족에서 함께 표시합니다.")
+
+    if state == "ready" and not live_accounts:
+        state = "blocked"
+        blockers.append("KIS live 계좌 확인 불가")
+
+    return ActionReadinessFamily(
+        key=key,
+        labelKo=label_ko,
+        category="Broker authority",
+        state=state,
+        impact=impact if state in {"blocked", "unknown", "missing"} else "none",
+        authority="kis_live_broker",
+        sourceOfTruth="KIS live via existing InvestHomeService/account-panel",
+        references=["manual_or_paper_reference"],
+        actionability=_safe_actionability(blockers[0] if blockers else latest_note, priority="blocked" if blockers else "none"),
+        blockers=blockers,
+        warnings=warnings,
+        notes=[latest_note, *notes],
+        links=[ActionReadinessLink(label="Account panel", href="/invest/api/account-panel")],
+    )
+
+
+async def _trade_journal_family(db: AsyncSession, symbol: str | None) -> ActionReadinessFamily:
+    stmt = sa.select(sa.func.count(), sa.func.max(TradeJournal.updated_at)).where(
+        TradeJournal.status == "active",
+        TradeJournal.account_type == "live",
+    )
+    if symbol:
+        stmt = stmt.where(TradeJournal.symbol == symbol)
+    count, latest_at = (await db.execute(stmt)).one()
+    active_count = int(count or 0)
+    state: ActionReadinessState = "ready" if active_count else "missing"
+    warnings = [] if active_count else ["활성 live trade journal 확인 불가 — sell report는 thesis/target/stop 확인이 필요합니다."]
+    return ActionReadinessFamily(
+        key="trade_journals",
+        labelKo="투자 저널 / thesis",
+        category="Broker authority",
+        state=state,
+        impact="degrades_report",
+        authority="auto_trader_read_model",
+        sourceOfTruth="review.trade_journals",
+        references=[],
+        latestAt=latest_at,
+        counts=None,
+        coverageState=None,
+        actionability=_safe_actionability(warnings[0] if warnings else "Active live trade journals are visible.", priority="high" if warnings else "none"),
+        blockers=[],
+        warnings=warnings,
+        notes=["Sell action reports must check active journals before any sell recommendation."],
+    )
+
+
+async def build_kr_action_readiness(
+    *,
+    db: AsyncSession,
+    user_id: int,
+    home_service: InvestHomeService,
+    symbol: str | None = None,
+) -> KrActionReadinessResponse:
+    normalized_symbol = symbol.strip().upper() if symbol and symbol.strip() else None
+    if normalized_symbol is not None and not (normalized_symbol.isdigit() and len(normalized_symbol) == 6):
+        now = dt.datetime.now(dt.UTC)
+        blocker = "symbol_not_kr_equity: KR 심볼은 6자리 종목코드여야 합니다. 확인 불가"
+        return KrActionReadinessResponse(
+            asOf=now,
+            symbol=normalized_symbol,
+            overallState="blocked",
+            canGenerateBuyReport=False,
+            canGenerateSellReport=False,
+            families=[],
+            blockers=[blocker],
+            sourcePolicy=_SOURCE_POLICY,
+            notes=["No provider or broker request was made for unsupported symbol input."],
+        )
+
+    symbol_exists = True
+    if normalized_symbol is not None:
+        symbol_exists = bool(
+            (
+                await db.execute(
+                    sa.select(KRSymbolUniverse.symbol).where(
+                        KRSymbolUniverse.symbol == normalized_symbol,
+                        KRSymbolUniverse.is_active.is_(True),
+                    )
+                )
+            ).scalar_one_or_none()
+        )
+
+    if normalized_symbol is not None and not symbol_exists:
+        now = dt.datetime.now(dt.UTC)
+        blocker = f"symbol_not_in_kr_universe: {normalized_symbol} 확인 불가"
+        return KrActionReadinessResponse(
+            asOf=now,
+            symbol=normalized_symbol,
+            overallState="blocked",
+            canGenerateBuyReport=False,
+            canGenerateSellReport=False,
+            families=[
+                ActionReadinessFamily(
+                    key="symbol_resolution",
+                    labelKo="KR 심볼 확인",
+                    category="Market/read-model data",
+                    state="blocked",
+                    impact="blocks_all_action_reports",
+                    authority="auto_trader_read_model",
+                    sourceOfTruth="kr_symbol_universe",
+                    references=[],
+                    actionability=_safe_actionability(
+                        "KR symbol universe에서 심볼 확인 불가", priority="blocked"
+                    ),
+                    blockers=[f"{normalized_symbol} not found in active kr_symbol_universe"],
+                    warnings=[],
+                    notes=[
+                        "No coverage, account-panel, broker, or provider request was made for unresolved symbol input.",
+                        "Do not infer or fabricate KR symbol identity.",
+                    ],
+                )
+            ],
+            blockers=[blocker],
+            sourcePolicy=_SOURCE_POLICY,
+            notes=["No provider or broker request was made for unresolved symbol input."],
+        )
+
+    coverage = await build_invest_coverage(
+        db, market="kr", symbols=[normalized_symbol] if normalized_symbol else []
+    )
+    surfaces = _surface_index(coverage)
+    home: InvestHomeResponse | None = None
+    home_unavailable = False
+    try:
+        home = await home_service.get_home(user_id=user_id)
+    except Exception:  # read-only partial failure: surface 확인 불가
+        home_unavailable = True
+
+    families: list[ActionReadinessFamily] = [
+        _broker_family(
+            key="kis_live_holdings",
+            label_ko="KIS live 보유",
+            impact="blocks_sell_report",
+            home=home,
+            symbol=normalized_symbol,
+        ),
+        _broker_family(
+            key="kis_live_cash_orderable",
+            label_ko="KIS live 주문가능 현금",
+            impact="blocks_buy_report",
+            home=home,
+            symbol=normalized_symbol,
+        ),
+        _broker_family(
+            key="kis_live_open_orders",
+            label_ko="KIS live 미체결 주문",
+            impact="blocks_all_action_reports",
+            home=home,
+            symbol=normalized_symbol,
+        ),
+        _broker_family(
+            key="kis_live_sellable_quantity",
+            label_ko="KIS live 매도가능 수량",
+            impact="blocks_sell_report",
+            home=home,
+            symbol=normalized_symbol,
+        ),
+        await _trade_journal_family(db, normalized_symbol),
+    ]
+
+    if home_unavailable:
+        for family in families[:4]:
+            family.state = "blocked"
+            family.blockers.append("KIS/account panel 확인 불가")
+
+    def s(name: str) -> InvestCoverageSurface | None:
+        return surfaces.get((name, "kr")) or surfaces.get((name, None))
+
+    if normalized_symbol:
+        symbol_market_families = [
+            await _symbol_quote_family(db, symbol=normalized_symbol, trading_day=coverage.tradingDate),
+            await _symbol_ohlcv_family(db, symbol=normalized_symbol, trading_day=coverage.tradingDate),
+            _surface_family(key="technical_indicators", label_ko="기술지표", category="Market/read-model data", surface=None, impact="degrades_report", extra_notes=["No separate durable indicator readiness surface is wired; do not calculate indicators in this request path."]),
+            _surface_family(key="support_resistance", label_ko="지지/저항", category="Market/read-model data", surface=None, impact="degrades_report", extra_notes=["No durable support/resistance readiness surface is wired; values must not be fabricated."]),
+            _surface_family(key="orderbook_session", label_ko="호가 / 세션", category="Market/read-model data", surface=s("orderbook_nxt_capability"), impact="degrades_report", extra_notes=["This reports local NXT/session capability, not a request-path orderbook fetch."]),
+            _surface_family(key="nxt_eligibility", label_ko="NXT 대상 여부", category="Market/read-model data", surface=s("orderbook_nxt_capability")),
+            _surface_family(key="screener_snapshots", label_ko="스크리너 스냅샷", category="Market/read-model data", surface=s("screener_snapshots")),
+            _surface_family(key="naver_momentum_events", label_ko="Naver 모멘텀 이벤트", category="Market/read-model data", surface=None, impact="degrades_report", extra_references=["naver_reference"], extra_notes=["Naver momentum events are reference/candidate only and not source-of-truth."]),
+            _surface_family(key="naver_momentum_candidates", label_ko="Naver 모멘텀 후보", category="Market/read-model data", surface=None, impact="degrades_report", extra_references=["naver_reference"], extra_notes=["Momentum candidates are aggregate reference data only, not trading instructions."]),
+            _surface_family(key="naver_theme_events", label_ko="Naver 테마 이벤트", category="Market/read-model data", surface=None, impact="degrades_report", extra_references=["naver_reference"], extra_notes=["Theme events are aggregate reference data only."]),
+            _surface_family(key="investor_flow", label_ko="투자자 수급", category="Market/read-model data", surface=s("investor_flow")),
+            _surface_family(key="news_feed", label_ko="뉴스 피드", category="News/calendar/research context", surface=s("news_feed")),
+            _surface_family(key="issue_clusters", label_ko="시장 이슈 클러스터", category="News/calendar/research context", surface=None, impact="degrades_report"),
+            _surface_family(key="disclosures", label_ko="공시", category="News/calendar/research context", surface=None, impact="degrades_report"),
+            _surface_family(key="calendar_events", label_ko="캘린더 이벤트", category="News/calendar/research context", surface=s("calendar_events")),
+            await _symbol_valuation_family(db, symbol=normalized_symbol, trading_day=coverage.tradingDate),
+            _surface_family(key="research_reports", label_ko="리서치 리포트", category="News/calendar/research context", surface=s("research_reports")),
+            _surface_family(key="research_consensus", label_ko="리서치 컨센서스", category="News/calendar/research context", surface=None, impact="degrades_report", extra_notes=["No distinct durable research-consensus readiness surface is wired; research report freshness is not treated as consensus availability."]),
+            _surface_family(key="execution_ledger", label_ko="체결 / 실행 이력", category="Execution/history", surface=None, impact="degrades_report", extra_notes=["No distinct execution/fill ledger readiness surface is wired; pending orders are not treated as historical fills."]),
+            _surface_family(key="sell_history", label_ko="매도 이력", category="Execution/history", surface=None, impact="degrades_report", extra_notes=["No distinct sell-history readiness surface is wired; do not infer sell history from pending orders."]),
+            _surface_family(key="pending_order_reconciliation", label_ko="미체결 주문 reconcile", category="Execution/history", surface=None, critical=True, impact="blocks_all_action_reports", extra_notes=["Pending-order table freshness alone does not prove live open-order reconciliation; fail closed until a reconciliation read-model is wired."]),
+        ]
+        families.extend(symbol_market_families)
+        _apply_symbol_surface_diagnostics(families, coverage, symbol=normalized_symbol)
+    else:
+        families.extend(
+            [
+                _surface_family(key="quotes", label_ko="시세 / 현재가", category="Market/read-model data", surface=s("quotes"), critical=False, impact="degrades_report", links=[ActionReadinessLink(label="Coverage", href="/invest/coverage")]),
+                _surface_family(key="ohlcv", label_ko="OHLCV 캔들", category="Market/read-model data", surface=s("ohlcv")),
+                _surface_family(key="technical_indicators", label_ko="기술지표", category="Market/read-model data", surface=None, impact="degrades_report", extra_notes=["No separate durable indicator readiness surface is wired; do not calculate indicators in this request path."]),
+                _surface_family(key="support_resistance", label_ko="지지/저항", category="Market/read-model data", surface=None, impact="degrades_report", extra_notes=["No durable support/resistance readiness surface is wired; values must not be fabricated."]),
+                _surface_family(key="orderbook_session", label_ko="호가 / 세션", category="Market/read-model data", surface=s("orderbook_nxt_capability"), impact="degrades_report", extra_notes=["This reports local NXT/session capability, not a request-path orderbook fetch."]),
+                _surface_family(key="nxt_eligibility", label_ko="NXT 대상 여부", category="Market/read-model data", surface=s("orderbook_nxt_capability")),
+                _surface_family(key="screener_snapshots", label_ko="스크리너 스냅샷", category="Market/read-model data", surface=s("screener_snapshots")),
+                _surface_family(key="naver_momentum_events", label_ko="Naver 모멘텀 이벤트", category="Market/read-model data", surface=None, impact="degrades_report", extra_references=["naver_reference"], extra_notes=["Naver momentum events are reference/candidate only and not source-of-truth."]),
+                _surface_family(key="naver_momentum_candidates", label_ko="Naver 모멘텀 후보", category="Market/read-model data", surface=None, impact="degrades_report", extra_references=["naver_reference"], extra_notes=["Momentum candidates are aggregate reference data only, not trading instructions."]),
+                _surface_family(key="naver_theme_events", label_ko="Naver 테마 이벤트", category="Market/read-model data", surface=None, impact="degrades_report", extra_references=["naver_reference"], extra_notes=["Theme events are aggregate reference data only."]),
+                _surface_family(key="investor_flow", label_ko="투자자 수급", category="Market/read-model data", surface=s("investor_flow")),
+                _surface_family(key="news_feed", label_ko="뉴스 피드", category="News/calendar/research context", surface=s("news_feed")),
+                _surface_family(key="issue_clusters", label_ko="시장 이슈 클러스터", category="News/calendar/research context", surface=None, impact="degrades_report"),
+                _surface_family(key="disclosures", label_ko="공시", category="News/calendar/research context", surface=None, impact="degrades_report"),
+                _surface_family(key="calendar_events", label_ko="캘린더 이벤트", category="News/calendar/research context", surface=s("calendar_events")),
+                _surface_family(key="valuation_fundamentals", label_ko="밸류에이션 / 펀더멘털", category="News/calendar/research context", surface=s("valuation_fundamentals")),
+                _surface_family(key="research_reports", label_ko="리서치 리포트", category="News/calendar/research context", surface=s("research_reports")),
+                _surface_family(key="research_consensus", label_ko="리서치 컨센서스", category="News/calendar/research context", surface=None, impact="degrades_report", extra_notes=["No distinct durable research-consensus readiness surface is wired; research report freshness is not treated as consensus availability."]),
+                _surface_family(key="execution_ledger", label_ko="체결 / 실행 이력", category="Execution/history", surface=None, impact="degrades_report", extra_notes=["No distinct execution/fill ledger readiness surface is wired; pending orders are not treated as historical fills."]),
+                _surface_family(key="sell_history", label_ko="매도 이력", category="Execution/history", surface=None, impact="degrades_report", extra_notes=["No distinct sell-history readiness surface is wired; do not infer sell history from pending orders."]),
+                _surface_family(key="pending_order_reconciliation", label_ko="미체결 주문 reconcile", category="Execution/history", surface=None, critical=True, impact="blocks_all_action_reports", extra_notes=["Pending-order table freshness alone does not prove live open-order reconciliation; fail closed until a reconciliation read-model is wired."]),
+            ]
+        )
+
+    blockers: list[str] = []
+    degraded: list[str] = []
+    for family in families:
+        if family.blockers:
+            blockers.extend(f"{family.key}: {blocker}" for blocker in family.blockers)
+        elif family.state in {"degraded", "missing", "unknown"}:
+            degraded.append(f"{family.key}: {family.warnings[0] if family.warnings else family.state}")
+
+    buy_blocked = any(
+        family.state == "blocked"
+        and family.impact in {"blocks_buy_report", "blocks_all_action_reports"}
+        for family in families
+    ) or bool(normalized_symbol and not symbol_exists)
+    sell_blocked = any(
+        family.state == "blocked"
+        and family.impact in {"blocks_sell_report", "blocks_all_action_reports"}
+        for family in families
+    ) or bool(normalized_symbol and not symbol_exists)
+    overall: ActionReadinessState
+    if buy_blocked and sell_blocked:
+        overall = "blocked"
+    elif buy_blocked or sell_blocked:
+        overall = "degraded"
+    elif degraded:
+        overall = "degraded"
+    else:
+        overall = "ready"
+
+    return KrActionReadinessResponse(
+        asOf=coverage.asOf,
+        symbol=normalized_symbol,
+        overallState=overall,
+        canGenerateBuyReport=not buy_blocked,
+        canGenerateSellReport=not sell_blocked,
+        families=families,
+        blockers=blockers,
+        degradedSignals=degraded,
+        sourcePolicy=_SOURCE_POLICY,
+        notes=[
+            "Read-only readiness only: no order, watch/order-intent, scheduler, backfill, or broker mutation is performed.",
+            "Actionability metadata is advisory and approval-gated; it is not an execution control.",
+        ],
+    )

--- a/app/services/invest_view_model/action_readiness_service.py
+++ b/app/services/invest_view_model/action_readiness_service.py
@@ -9,7 +9,8 @@ scrape external sites from the request path.
 from __future__ import annotations
 
 import datetime as dt
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -42,6 +43,144 @@ _SOURCE_POLICY = [
     "Toss/Naver/external sources are displayed only as reference, candidate, or supporting signals and are never source-of-truth for action readiness.",
     "Unavailable data is surfaced as stale/missing/partial/failed/unsupported/확인 불가 rather than estimated.",
 ]
+
+
+@dataclass(frozen=True)
+class _SurfaceFamilySpec:
+    key: str
+    label_ko: str
+    category: str
+    surface_name: str | None = None
+    impact: ActionReportImpact = "degrades_report"
+    critical: bool = False
+    extra_references: tuple[str, ...] = ()
+    extra_notes: tuple[str, ...] = ()
+    links: tuple[ActionReadinessLink, ...] = ()
+
+
+_READ_MODEL = "Market/read-model data"
+_CONTEXT = "News/calendar/research context"
+_EXECUTION = "Execution/history"
+
+_AGGREGATE_LEADING_SPECS = (
+    _SurfaceFamilySpec(
+        "quotes",
+        "시세 / 현재가",
+        _READ_MODEL,
+        "quotes",
+        links=(ActionReadinessLink(label="Coverage", href="/invest/coverage"),),
+    ),
+    _SurfaceFamilySpec("ohlcv", "OHLCV 캔들", _READ_MODEL, "ohlcv"),
+)
+
+_COMMON_PRE_VALUATION_SPECS = (
+    _SurfaceFamilySpec(
+        "technical_indicators",
+        "기술지표",
+        _READ_MODEL,
+        extra_notes=(
+            "No separate durable indicator readiness surface is wired; do not calculate indicators in this request path.",
+        ),
+    ),
+    _SurfaceFamilySpec(
+        "support_resistance",
+        "지지/저항",
+        _READ_MODEL,
+        extra_notes=(
+            "No durable support/resistance readiness surface is wired; values must not be fabricated.",
+        ),
+    ),
+    _SurfaceFamilySpec(
+        "orderbook_session",
+        "호가 / 세션",
+        _READ_MODEL,
+        "orderbook_nxt_capability",
+        extra_notes=(
+            "This reports local NXT/session capability, not a request-path orderbook fetch.",
+        ),
+    ),
+    _SurfaceFamilySpec(
+        "nxt_eligibility", "NXT 대상 여부", _READ_MODEL, "orderbook_nxt_capability"
+    ),
+    _SurfaceFamilySpec(
+        "screener_snapshots", "스크리너 스냅샷", _READ_MODEL, "screener_snapshots"
+    ),
+    _SurfaceFamilySpec(
+        "naver_momentum_events",
+        "Naver 모멘텀 이벤트",
+        _READ_MODEL,
+        extra_references=("naver_reference",),
+        extra_notes=(
+            "Naver momentum events are reference/candidate only and not source-of-truth.",
+        ),
+    ),
+    _SurfaceFamilySpec(
+        "naver_momentum_candidates",
+        "Naver 모멘텀 후보",
+        _READ_MODEL,
+        extra_references=("naver_reference",),
+        extra_notes=(
+            "Momentum candidates are aggregate reference data only, not trading instructions.",
+        ),
+    ),
+    _SurfaceFamilySpec(
+        "naver_theme_events",
+        "Naver 테마 이벤트",
+        _READ_MODEL,
+        extra_references=("naver_reference",),
+        extra_notes=("Theme events are aggregate reference data only.",),
+    ),
+    _SurfaceFamilySpec("investor_flow", "투자자 수급", _READ_MODEL, "investor_flow"),
+    _SurfaceFamilySpec("news_feed", "뉴스 피드", _CONTEXT, "news_feed"),
+    _SurfaceFamilySpec("issue_clusters", "시장 이슈 클러스터", _CONTEXT),
+    _SurfaceFamilySpec("disclosures", "공시", _CONTEXT),
+    _SurfaceFamilySpec("calendar_events", "캘린더 이벤트", _CONTEXT, "calendar_events"),
+)
+
+_AGGREGATE_VALUATION_SPEC = _SurfaceFamilySpec(
+    "valuation_fundamentals",
+    "밸류에이션 / 펀더멘털",
+    _CONTEXT,
+    "valuation_fundamentals",
+)
+
+_COMMON_POST_VALUATION_SPECS = (
+    _SurfaceFamilySpec("research_reports", "리서치 리포트", _CONTEXT, "research_reports"),
+    _SurfaceFamilySpec(
+        "research_consensus",
+        "리서치 컨센서스",
+        _CONTEXT,
+        extra_notes=(
+            "No distinct durable research-consensus readiness surface is wired; research report freshness is not treated as consensus availability.",
+        ),
+    ),
+    _SurfaceFamilySpec(
+        "execution_ledger",
+        "체결 / 실행 이력",
+        _EXECUTION,
+        extra_notes=(
+            "No distinct execution/fill ledger readiness surface is wired; pending orders are not treated as historical fills.",
+        ),
+    ),
+    _SurfaceFamilySpec(
+        "sell_history",
+        "매도 이력",
+        _EXECUTION,
+        extra_notes=(
+            "No distinct sell-history readiness surface is wired; do not infer sell history from pending orders.",
+        ),
+    ),
+    _SurfaceFamilySpec(
+        "pending_order_reconciliation",
+        "미체결 주문 reconcile",
+        _EXECUTION,
+        critical=True,
+        impact="blocks_all_action_reports",
+        extra_notes=(
+            "Pending-order table freshness alone does not prove live open-order reconciliation; fail closed until a reconciliation read-model is wired.",
+        ),
+    ),
+)
 
 
 def _safe_actionability(
@@ -157,6 +296,30 @@ def _surface_family(
         notes=list(surface.notes) + list(extra_notes),
         links=list(links),
     )
+
+
+def _surface_family_from_spec(
+    spec: _SurfaceFamilySpec,
+    surface_lookup: Callable[[str], InvestCoverageSurface | None],
+) -> ActionReadinessFamily:
+    return _surface_family(
+        key=spec.key,
+        label_ko=spec.label_ko,
+        category=spec.category,
+        surface=surface_lookup(spec.surface_name) if spec.surface_name else None,
+        impact=spec.impact,
+        critical=spec.critical,
+        extra_references=spec.extra_references,
+        extra_notes=spec.extra_notes,
+        links=spec.links,
+    )
+
+
+def _surface_families_from_specs(
+    specs: Sequence[_SurfaceFamilySpec],
+    surface_lookup: Callable[[str], InvestCoverageSurface | None],
+) -> list[ActionReadinessFamily]:
+    return [_surface_family_from_spec(spec, surface_lookup) for spec in specs]
 
 
 def _symbol_state_from_latest_date(
@@ -646,343 +809,25 @@ async def build_kr_action_readiness(
             await _symbol_ohlcv_family(
                 db, symbol=normalized_symbol, trading_day=coverage.tradingDate
             ),
-            _surface_family(
-                key="technical_indicators",
-                label_ko="기술지표",
-                category="Market/read-model data",
-                surface=None,
-                impact="degrades_report",
-                extra_notes=[
-                    "No separate durable indicator readiness surface is wired; do not calculate indicators in this request path."
-                ],
-            ),
-            _surface_family(
-                key="support_resistance",
-                label_ko="지지/저항",
-                category="Market/read-model data",
-                surface=None,
-                impact="degrades_report",
-                extra_notes=[
-                    "No durable support/resistance readiness surface is wired; values must not be fabricated."
-                ],
-            ),
-            _surface_family(
-                key="orderbook_session",
-                label_ko="호가 / 세션",
-                category="Market/read-model data",
-                surface=s("orderbook_nxt_capability"),
-                impact="degrades_report",
-                extra_notes=[
-                    "This reports local NXT/session capability, not a request-path orderbook fetch."
-                ],
-            ),
-            _surface_family(
-                key="nxt_eligibility",
-                label_ko="NXT 대상 여부",
-                category="Market/read-model data",
-                surface=s("orderbook_nxt_capability"),
-            ),
-            _surface_family(
-                key="screener_snapshots",
-                label_ko="스크리너 스냅샷",
-                category="Market/read-model data",
-                surface=s("screener_snapshots"),
-            ),
-            _surface_family(
-                key="naver_momentum_events",
-                label_ko="Naver 모멘텀 이벤트",
-                category="Market/read-model data",
-                surface=None,
-                impact="degrades_report",
-                extra_references=["naver_reference"],
-                extra_notes=[
-                    "Naver momentum events are reference/candidate only and not source-of-truth."
-                ],
-            ),
-            _surface_family(
-                key="naver_momentum_candidates",
-                label_ko="Naver 모멘텀 후보",
-                category="Market/read-model data",
-                surface=None,
-                impact="degrades_report",
-                extra_references=["naver_reference"],
-                extra_notes=[
-                    "Momentum candidates are aggregate reference data only, not trading instructions."
-                ],
-            ),
-            _surface_family(
-                key="naver_theme_events",
-                label_ko="Naver 테마 이벤트",
-                category="Market/read-model data",
-                surface=None,
-                impact="degrades_report",
-                extra_references=["naver_reference"],
-                extra_notes=["Theme events are aggregate reference data only."],
-            ),
-            _surface_family(
-                key="investor_flow",
-                label_ko="투자자 수급",
-                category="Market/read-model data",
-                surface=s("investor_flow"),
-            ),
-            _surface_family(
-                key="news_feed",
-                label_ko="뉴스 피드",
-                category="News/calendar/research context",
-                surface=s("news_feed"),
-            ),
-            _surface_family(
-                key="issue_clusters",
-                label_ko="시장 이슈 클러스터",
-                category="News/calendar/research context",
-                surface=None,
-                impact="degrades_report",
-            ),
-            _surface_family(
-                key="disclosures",
-                label_ko="공시",
-                category="News/calendar/research context",
-                surface=None,
-                impact="degrades_report",
-            ),
-            _surface_family(
-                key="calendar_events",
-                label_ko="캘린더 이벤트",
-                category="News/calendar/research context",
-                surface=s("calendar_events"),
-            ),
+            *_surface_families_from_specs(_COMMON_PRE_VALUATION_SPECS, s),
             await _symbol_valuation_family(
                 db, symbol=normalized_symbol, trading_day=coverage.tradingDate
             ),
-            _surface_family(
-                key="research_reports",
-                label_ko="리서치 리포트",
-                category="News/calendar/research context",
-                surface=s("research_reports"),
-            ),
-            _surface_family(
-                key="research_consensus",
-                label_ko="리서치 컨센서스",
-                category="News/calendar/research context",
-                surface=None,
-                impact="degrades_report",
-                extra_notes=[
-                    "No distinct durable research-consensus readiness surface is wired; research report freshness is not treated as consensus availability."
-                ],
-            ),
-            _surface_family(
-                key="execution_ledger",
-                label_ko="체결 / 실행 이력",
-                category="Execution/history",
-                surface=None,
-                impact="degrades_report",
-                extra_notes=[
-                    "No distinct execution/fill ledger readiness surface is wired; pending orders are not treated as historical fills."
-                ],
-            ),
-            _surface_family(
-                key="sell_history",
-                label_ko="매도 이력",
-                category="Execution/history",
-                surface=None,
-                impact="degrades_report",
-                extra_notes=[
-                    "No distinct sell-history readiness surface is wired; do not infer sell history from pending orders."
-                ],
-            ),
-            _surface_family(
-                key="pending_order_reconciliation",
-                label_ko="미체결 주문 reconcile",
-                category="Execution/history",
-                surface=None,
-                critical=True,
-                impact="blocks_all_action_reports",
-                extra_notes=[
-                    "Pending-order table freshness alone does not prove live open-order reconciliation; fail closed until a reconciliation read-model is wired."
-                ],
-            ),
+            *_surface_families_from_specs(_COMMON_POST_VALUATION_SPECS, s),
         ]
         families.extend(symbol_market_families)
         _apply_symbol_surface_diagnostics(families, coverage, symbol=normalized_symbol)
     else:
         families.extend(
-            [
-                _surface_family(
-                    key="quotes",
-                    label_ko="시세 / 현재가",
-                    category="Market/read-model data",
-                    surface=s("quotes"),
-                    critical=False,
-                    impact="degrades_report",
-                    links=[
-                        ActionReadinessLink(label="Coverage", href="/invest/coverage")
-                    ],
+            _surface_families_from_specs(
+                (
+                    *_AGGREGATE_LEADING_SPECS,
+                    *_COMMON_PRE_VALUATION_SPECS,
+                    _AGGREGATE_VALUATION_SPEC,
+                    *_COMMON_POST_VALUATION_SPECS,
                 ),
-                _surface_family(
-                    key="ohlcv",
-                    label_ko="OHLCV 캔들",
-                    category="Market/read-model data",
-                    surface=s("ohlcv"),
-                ),
-                _surface_family(
-                    key="technical_indicators",
-                    label_ko="기술지표",
-                    category="Market/read-model data",
-                    surface=None,
-                    impact="degrades_report",
-                    extra_notes=[
-                        "No separate durable indicator readiness surface is wired; do not calculate indicators in this request path."
-                    ],
-                ),
-                _surface_family(
-                    key="support_resistance",
-                    label_ko="지지/저항",
-                    category="Market/read-model data",
-                    surface=None,
-                    impact="degrades_report",
-                    extra_notes=[
-                        "No durable support/resistance readiness surface is wired; values must not be fabricated."
-                    ],
-                ),
-                _surface_family(
-                    key="orderbook_session",
-                    label_ko="호가 / 세션",
-                    category="Market/read-model data",
-                    surface=s("orderbook_nxt_capability"),
-                    impact="degrades_report",
-                    extra_notes=[
-                        "This reports local NXT/session capability, not a request-path orderbook fetch."
-                    ],
-                ),
-                _surface_family(
-                    key="nxt_eligibility",
-                    label_ko="NXT 대상 여부",
-                    category="Market/read-model data",
-                    surface=s("orderbook_nxt_capability"),
-                ),
-                _surface_family(
-                    key="screener_snapshots",
-                    label_ko="스크리너 스냅샷",
-                    category="Market/read-model data",
-                    surface=s("screener_snapshots"),
-                ),
-                _surface_family(
-                    key="naver_momentum_events",
-                    label_ko="Naver 모멘텀 이벤트",
-                    category="Market/read-model data",
-                    surface=None,
-                    impact="degrades_report",
-                    extra_references=["naver_reference"],
-                    extra_notes=[
-                        "Naver momentum events are reference/candidate only and not source-of-truth."
-                    ],
-                ),
-                _surface_family(
-                    key="naver_momentum_candidates",
-                    label_ko="Naver 모멘텀 후보",
-                    category="Market/read-model data",
-                    surface=None,
-                    impact="degrades_report",
-                    extra_references=["naver_reference"],
-                    extra_notes=[
-                        "Momentum candidates are aggregate reference data only, not trading instructions."
-                    ],
-                ),
-                _surface_family(
-                    key="naver_theme_events",
-                    label_ko="Naver 테마 이벤트",
-                    category="Market/read-model data",
-                    surface=None,
-                    impact="degrades_report",
-                    extra_references=["naver_reference"],
-                    extra_notes=["Theme events are aggregate reference data only."],
-                ),
-                _surface_family(
-                    key="investor_flow",
-                    label_ko="투자자 수급",
-                    category="Market/read-model data",
-                    surface=s("investor_flow"),
-                ),
-                _surface_family(
-                    key="news_feed",
-                    label_ko="뉴스 피드",
-                    category="News/calendar/research context",
-                    surface=s("news_feed"),
-                ),
-                _surface_family(
-                    key="issue_clusters",
-                    label_ko="시장 이슈 클러스터",
-                    category="News/calendar/research context",
-                    surface=None,
-                    impact="degrades_report",
-                ),
-                _surface_family(
-                    key="disclosures",
-                    label_ko="공시",
-                    category="News/calendar/research context",
-                    surface=None,
-                    impact="degrades_report",
-                ),
-                _surface_family(
-                    key="calendar_events",
-                    label_ko="캘린더 이벤트",
-                    category="News/calendar/research context",
-                    surface=s("calendar_events"),
-                ),
-                _surface_family(
-                    key="valuation_fundamentals",
-                    label_ko="밸류에이션 / 펀더멘털",
-                    category="News/calendar/research context",
-                    surface=s("valuation_fundamentals"),
-                ),
-                _surface_family(
-                    key="research_reports",
-                    label_ko="리서치 리포트",
-                    category="News/calendar/research context",
-                    surface=s("research_reports"),
-                ),
-                _surface_family(
-                    key="research_consensus",
-                    label_ko="리서치 컨센서스",
-                    category="News/calendar/research context",
-                    surface=None,
-                    impact="degrades_report",
-                    extra_notes=[
-                        "No distinct durable research-consensus readiness surface is wired; research report freshness is not treated as consensus availability."
-                    ],
-                ),
-                _surface_family(
-                    key="execution_ledger",
-                    label_ko="체결 / 실행 이력",
-                    category="Execution/history",
-                    surface=None,
-                    impact="degrades_report",
-                    extra_notes=[
-                        "No distinct execution/fill ledger readiness surface is wired; pending orders are not treated as historical fills."
-                    ],
-                ),
-                _surface_family(
-                    key="sell_history",
-                    label_ko="매도 이력",
-                    category="Execution/history",
-                    surface=None,
-                    impact="degrades_report",
-                    extra_notes=[
-                        "No distinct sell-history readiness surface is wired; do not infer sell history from pending orders."
-                    ],
-                ),
-                _surface_family(
-                    key="pending_order_reconciliation",
-                    label_ko="미체결 주문 reconcile",
-                    category="Execution/history",
-                    surface=None,
-                    critical=True,
-                    impact="blocks_all_action_reports",
-                    extra_notes=[
-                        "Pending-order table freshness alone does not prove live open-order reconciliation; fail closed until a reconciliation read-model is wired."
-                    ],
-                ),
-            ]
+                s,
+            )
         )
 
     blockers: list[str] = []

--- a/app/services/invest_view_model/action_readiness_service.py
+++ b/app/services/invest_view_model/action_readiness_service.py
@@ -44,7 +44,9 @@ _SOURCE_POLICY = [
 ]
 
 
-def _safe_actionability(reason: str, *, priority: str = "high") -> CoverageActionability:
+def _safe_actionability(
+    reason: str, *, priority: str = "high"
+) -> CoverageActionability:
     if priority == "none":
         return CoverageActionability(
             priority="none",
@@ -66,7 +68,8 @@ def _safe_actionability(reason: str, *, priority: str = "high") -> CoverageActio
 
 def _coverage_state_to_readiness(
     state: CoverageState,
-    *, critical: bool = False,
+    *,
+    critical: bool = False,
 ) -> ActionReadinessState:
     if state == "fresh":
         return "ready"
@@ -105,7 +108,9 @@ def _surface_family(
 ) -> ActionReadinessFamily:
     if surface is None:
         state: ActionReadinessState = "unknown" if not critical else "blocked"
-        blockers = [f"{key}: 확인 불가 — durable /invest read-model surface is not wired."]
+        blockers = [
+            f"{key}: 확인 불가 — durable /invest read-model surface is not wired."
+        ]
         return ActionReadinessFamily(
             key=key,
             labelKo=label_ko,
@@ -134,7 +139,11 @@ def _surface_family(
         labelKo=label_ko,
         category=category,
         state=readiness,
-        impact=("blocks_all_action_reports" if critical and readiness == "blocked" else impact),
+        impact=(
+            "blocks_all_action_reports"
+            if critical and readiness == "blocked"
+            else impact
+        ),
         authority=authority,
         sourceOfTruth=source_override or surface.sourceOfTruth,
         references=surface.references,
@@ -208,13 +217,23 @@ async def _symbol_quote_family(
         latestDate=latest_date,
         coverageState=None,
         actionability=_safe_actionability(
-            blockers[0] if blockers else warnings[0] if warnings else f"{symbol} quote read-model is visible.",
+            blockers[0]
+            if blockers
+            else warnings[0]
+            if warnings
+            else f"{symbol} quote read-model is visible.",
             priority="blocked" if blockers else "high" if warnings else "none",
         ),
         blockers=blockers,
         warnings=warnings,
-        notes=["Symbol-scoped quote readiness is checked from the durable read-model only; no request-path provider fetch is made."],
-        links=[ActionReadinessLink(label="Stock detail", href=f"/invest/stocks/kr/{symbol}")],
+        notes=[
+            "Symbol-scoped quote readiness is checked from the durable read-model only; no request-path provider fetch is made."
+        ],
+        links=[
+            ActionReadinessLink(
+                label="Stock detail", href=f"/invest/stocks/kr/{symbol}"
+            )
+        ],
     )
 
 
@@ -266,7 +285,9 @@ async def _symbol_ohlcv_family(
         ),
         blockers=blockers,
         warnings=warnings,
-        notes=["Symbol-scoped OHLCV readiness is checked from kr_candles_1m only; no request-path provider fetch is made."],
+        notes=[
+            "Symbol-scoped OHLCV readiness is checked from kr_candles_1m only; no request-path provider fetch is made."
+        ],
     )
 
 
@@ -308,7 +329,9 @@ async def _symbol_valuation_family(
         ),
         blockers=blockers,
         warnings=warnings,
-        notes=["Symbol-scoped valuation readiness is checked from the durable read-model only; no request-path provider fetch is made."],
+        notes=[
+            "Symbol-scoped valuation readiness is checked from the durable read-model only; no request-path provider fetch is made."
+        ],
     )
 
 
@@ -339,7 +362,9 @@ def _apply_symbol_surface_diagnostics(
             family.blockers.append(warning)
         else:
             family.warnings.append(warning)
-        family.notes.append("Aggregate market coverage was overridden by symbol-scoped coverage diagnostics for action-readiness.")
+        family.notes.append(
+            "Aggregate market coverage was overridden by symbol-scoped coverage diagnostics for action-readiness."
+        )
 
 
 def _broker_family(
@@ -350,16 +375,26 @@ def _broker_family(
     home: InvestHomeResponse | None,
     symbol: str | None,
 ) -> ActionReadinessFamily:
-    live_accounts = [account for account in (home.accounts if home else []) if account.source == "kis" and account.accountKind == "live"]
+    live_accounts = [
+        account
+        for account in (home.accounts if home else [])
+        if account.source == "kis" and account.accountKind == "live"
+    ]
     live_kr_holdings = [
         holding
         for holding in (home.holdings if home else [])
-        if holding.source == "kis" and holding.accountKind == "live" and holding.market == "KR"
+        if holding.source == "kis"
+        and holding.accountKind == "live"
+        and holding.market == "KR"
     ]
     if symbol:
-        live_kr_holdings = [holding for holding in live_kr_holdings if holding.symbol == symbol]
+        live_kr_holdings = [
+            holding for holding in live_kr_holdings if holding.symbol == symbol
+        ]
 
-    warnings = [w.message for w in (home.meta.warnings if home else []) if w.source == "kis"]
+    warnings = [
+        w.message for w in (home.meta.warnings if home else []) if w.source == "kis"
+    ]
     has_kis_warning = bool(warnings)
     state: ActionReadinessState = "ready"
     blockers: list[str] = []
@@ -371,7 +406,10 @@ def _broker_family(
         blockers.append(f"{label_ko}: KIS live 확인 불가")
     elif key == "kis_live_cash_orderable":
         has_orderable = any(
-            (account.buyingPower.krw is not None or account.cashBalances.krw is not None)
+            (
+                account.buyingPower.krw is not None
+                or account.cashBalances.krw is not None
+            )
             for account in live_accounts
         )
         if not has_orderable:
@@ -397,7 +435,9 @@ def _broker_family(
         # authority, so absence of a live open-order snapshot is fail-closed.
         state = "blocked"
         blockers.append("KIS live 미체결 주문 확인 불가")
-        notes.append("pending_orders read-model과 reconcile 상태는 별도 가족에서 함께 표시합니다.")
+        notes.append(
+            "pending_orders read-model과 reconcile 상태는 별도 가족에서 함께 표시합니다."
+        )
 
     if state == "ready" and not live_accounts:
         state = "blocked"
@@ -412,15 +452,22 @@ def _broker_family(
         authority="kis_live_broker",
         sourceOfTruth="KIS live via existing InvestHomeService/account-panel",
         references=["manual_or_paper_reference"],
-        actionability=_safe_actionability(blockers[0] if blockers else latest_note, priority="blocked" if blockers else "none"),
+        actionability=_safe_actionability(
+            blockers[0] if blockers else latest_note,
+            priority="blocked" if blockers else "none",
+        ),
         blockers=blockers,
         warnings=warnings,
         notes=[latest_note, *notes],
-        links=[ActionReadinessLink(label="Account panel", href="/invest/api/account-panel")],
+        links=[
+            ActionReadinessLink(label="Account panel", href="/invest/api/account-panel")
+        ],
     )
 
 
-async def _trade_journal_family(db: AsyncSession, symbol: str | None) -> ActionReadinessFamily:
+async def _trade_journal_family(
+    db: AsyncSession, symbol: str | None
+) -> ActionReadinessFamily:
     stmt = sa.select(sa.func.count(), sa.func.max(TradeJournal.updated_at)).where(
         TradeJournal.status == "active",
         TradeJournal.account_type == "live",
@@ -430,7 +477,13 @@ async def _trade_journal_family(db: AsyncSession, symbol: str | None) -> ActionR
     count, latest_at = (await db.execute(stmt)).one()
     active_count = int(count or 0)
     state: ActionReadinessState = "ready" if active_count else "missing"
-    warnings = [] if active_count else ["활성 live trade journal 확인 불가 — sell report는 thesis/target/stop 확인이 필요합니다."]
+    warnings = (
+        []
+        if active_count
+        else [
+            "활성 live trade journal 확인 불가 — sell report는 thesis/target/stop 확인이 필요합니다."
+        ]
+    )
     return ActionReadinessFamily(
         key="trade_journals",
         labelKo="투자 저널 / thesis",
@@ -443,10 +496,15 @@ async def _trade_journal_family(db: AsyncSession, symbol: str | None) -> ActionR
         latestAt=latest_at,
         counts=None,
         coverageState=None,
-        actionability=_safe_actionability(warnings[0] if warnings else "Active live trade journals are visible.", priority="high" if warnings else "none"),
+        actionability=_safe_actionability(
+            warnings[0] if warnings else "Active live trade journals are visible.",
+            priority="high" if warnings else "none",
+        ),
         blockers=[],
         warnings=warnings,
-        notes=["Sell action reports must check active journals before any sell recommendation."],
+        notes=[
+            "Sell action reports must check active journals before any sell recommendation."
+        ],
     )
 
 
@@ -458,7 +516,9 @@ async def build_kr_action_readiness(
     symbol: str | None = None,
 ) -> KrActionReadinessResponse:
     normalized_symbol = symbol.strip().upper() if symbol and symbol.strip() else None
-    if normalized_symbol is not None and not (normalized_symbol.isdigit() and len(normalized_symbol) == 6):
+    if normalized_symbol is not None and not (
+        normalized_symbol.isdigit() and len(normalized_symbol) == 6
+    ):
         now = dt.datetime.now(dt.UTC)
         blocker = "symbol_not_kr_equity: KR 심볼은 6자리 종목코드여야 합니다. 확인 불가"
         return KrActionReadinessResponse(
@@ -470,7 +530,9 @@ async def build_kr_action_readiness(
             families=[],
             blockers=[blocker],
             sourcePolicy=_SOURCE_POLICY,
-            notes=["No provider or broker request was made for unsupported symbol input."],
+            notes=[
+                "No provider or broker request was made for unsupported symbol input."
+            ],
         )
 
     symbol_exists = True
@@ -508,7 +570,9 @@ async def build_kr_action_readiness(
                     actionability=_safe_actionability(
                         "KR symbol universe에서 심볼 확인 불가", priority="blocked"
                     ),
-                    blockers=[f"{normalized_symbol} not found in active kr_symbol_universe"],
+                    blockers=[
+                        f"{normalized_symbol} not found in active kr_symbol_universe"
+                    ],
                     warnings=[],
                     notes=[
                         "No coverage, account-panel, broker, or provider request was made for unresolved symbol input.",
@@ -518,7 +582,9 @@ async def build_kr_action_readiness(
             ],
             blockers=[blocker],
             sourcePolicy=_SOURCE_POLICY,
-            notes=["No provider or broker request was made for unresolved symbol input."],
+            notes=[
+                "No provider or broker request was made for unresolved symbol input."
+            ],
         )
 
     coverage = await build_invest_coverage(
@@ -574,54 +640,348 @@ async def build_kr_action_readiness(
 
     if normalized_symbol:
         symbol_market_families = [
-            await _symbol_quote_family(db, symbol=normalized_symbol, trading_day=coverage.tradingDate),
-            await _symbol_ohlcv_family(db, symbol=normalized_symbol, trading_day=coverage.tradingDate),
-            _surface_family(key="technical_indicators", label_ko="기술지표", category="Market/read-model data", surface=None, impact="degrades_report", extra_notes=["No separate durable indicator readiness surface is wired; do not calculate indicators in this request path."]),
-            _surface_family(key="support_resistance", label_ko="지지/저항", category="Market/read-model data", surface=None, impact="degrades_report", extra_notes=["No durable support/resistance readiness surface is wired; values must not be fabricated."]),
-            _surface_family(key="orderbook_session", label_ko="호가 / 세션", category="Market/read-model data", surface=s("orderbook_nxt_capability"), impact="degrades_report", extra_notes=["This reports local NXT/session capability, not a request-path orderbook fetch."]),
-            _surface_family(key="nxt_eligibility", label_ko="NXT 대상 여부", category="Market/read-model data", surface=s("orderbook_nxt_capability")),
-            _surface_family(key="screener_snapshots", label_ko="스크리너 스냅샷", category="Market/read-model data", surface=s("screener_snapshots")),
-            _surface_family(key="naver_momentum_events", label_ko="Naver 모멘텀 이벤트", category="Market/read-model data", surface=None, impact="degrades_report", extra_references=["naver_reference"], extra_notes=["Naver momentum events are reference/candidate only and not source-of-truth."]),
-            _surface_family(key="naver_momentum_candidates", label_ko="Naver 모멘텀 후보", category="Market/read-model data", surface=None, impact="degrades_report", extra_references=["naver_reference"], extra_notes=["Momentum candidates are aggregate reference data only, not trading instructions."]),
-            _surface_family(key="naver_theme_events", label_ko="Naver 테마 이벤트", category="Market/read-model data", surface=None, impact="degrades_report", extra_references=["naver_reference"], extra_notes=["Theme events are aggregate reference data only."]),
-            _surface_family(key="investor_flow", label_ko="투자자 수급", category="Market/read-model data", surface=s("investor_flow")),
-            _surface_family(key="news_feed", label_ko="뉴스 피드", category="News/calendar/research context", surface=s("news_feed")),
-            _surface_family(key="issue_clusters", label_ko="시장 이슈 클러스터", category="News/calendar/research context", surface=None, impact="degrades_report"),
-            _surface_family(key="disclosures", label_ko="공시", category="News/calendar/research context", surface=None, impact="degrades_report"),
-            _surface_family(key="calendar_events", label_ko="캘린더 이벤트", category="News/calendar/research context", surface=s("calendar_events")),
-            await _symbol_valuation_family(db, symbol=normalized_symbol, trading_day=coverage.tradingDate),
-            _surface_family(key="research_reports", label_ko="리서치 리포트", category="News/calendar/research context", surface=s("research_reports")),
-            _surface_family(key="research_consensus", label_ko="리서치 컨센서스", category="News/calendar/research context", surface=None, impact="degrades_report", extra_notes=["No distinct durable research-consensus readiness surface is wired; research report freshness is not treated as consensus availability."]),
-            _surface_family(key="execution_ledger", label_ko="체결 / 실행 이력", category="Execution/history", surface=None, impact="degrades_report", extra_notes=["No distinct execution/fill ledger readiness surface is wired; pending orders are not treated as historical fills."]),
-            _surface_family(key="sell_history", label_ko="매도 이력", category="Execution/history", surface=None, impact="degrades_report", extra_notes=["No distinct sell-history readiness surface is wired; do not infer sell history from pending orders."]),
-            _surface_family(key="pending_order_reconciliation", label_ko="미체결 주문 reconcile", category="Execution/history", surface=None, critical=True, impact="blocks_all_action_reports", extra_notes=["Pending-order table freshness alone does not prove live open-order reconciliation; fail closed until a reconciliation read-model is wired."]),
+            await _symbol_quote_family(
+                db, symbol=normalized_symbol, trading_day=coverage.tradingDate
+            ),
+            await _symbol_ohlcv_family(
+                db, symbol=normalized_symbol, trading_day=coverage.tradingDate
+            ),
+            _surface_family(
+                key="technical_indicators",
+                label_ko="기술지표",
+                category="Market/read-model data",
+                surface=None,
+                impact="degrades_report",
+                extra_notes=[
+                    "No separate durable indicator readiness surface is wired; do not calculate indicators in this request path."
+                ],
+            ),
+            _surface_family(
+                key="support_resistance",
+                label_ko="지지/저항",
+                category="Market/read-model data",
+                surface=None,
+                impact="degrades_report",
+                extra_notes=[
+                    "No durable support/resistance readiness surface is wired; values must not be fabricated."
+                ],
+            ),
+            _surface_family(
+                key="orderbook_session",
+                label_ko="호가 / 세션",
+                category="Market/read-model data",
+                surface=s("orderbook_nxt_capability"),
+                impact="degrades_report",
+                extra_notes=[
+                    "This reports local NXT/session capability, not a request-path orderbook fetch."
+                ],
+            ),
+            _surface_family(
+                key="nxt_eligibility",
+                label_ko="NXT 대상 여부",
+                category="Market/read-model data",
+                surface=s("orderbook_nxt_capability"),
+            ),
+            _surface_family(
+                key="screener_snapshots",
+                label_ko="스크리너 스냅샷",
+                category="Market/read-model data",
+                surface=s("screener_snapshots"),
+            ),
+            _surface_family(
+                key="naver_momentum_events",
+                label_ko="Naver 모멘텀 이벤트",
+                category="Market/read-model data",
+                surface=None,
+                impact="degrades_report",
+                extra_references=["naver_reference"],
+                extra_notes=[
+                    "Naver momentum events are reference/candidate only and not source-of-truth."
+                ],
+            ),
+            _surface_family(
+                key="naver_momentum_candidates",
+                label_ko="Naver 모멘텀 후보",
+                category="Market/read-model data",
+                surface=None,
+                impact="degrades_report",
+                extra_references=["naver_reference"],
+                extra_notes=[
+                    "Momentum candidates are aggregate reference data only, not trading instructions."
+                ],
+            ),
+            _surface_family(
+                key="naver_theme_events",
+                label_ko="Naver 테마 이벤트",
+                category="Market/read-model data",
+                surface=None,
+                impact="degrades_report",
+                extra_references=["naver_reference"],
+                extra_notes=["Theme events are aggregate reference data only."],
+            ),
+            _surface_family(
+                key="investor_flow",
+                label_ko="투자자 수급",
+                category="Market/read-model data",
+                surface=s("investor_flow"),
+            ),
+            _surface_family(
+                key="news_feed",
+                label_ko="뉴스 피드",
+                category="News/calendar/research context",
+                surface=s("news_feed"),
+            ),
+            _surface_family(
+                key="issue_clusters",
+                label_ko="시장 이슈 클러스터",
+                category="News/calendar/research context",
+                surface=None,
+                impact="degrades_report",
+            ),
+            _surface_family(
+                key="disclosures",
+                label_ko="공시",
+                category="News/calendar/research context",
+                surface=None,
+                impact="degrades_report",
+            ),
+            _surface_family(
+                key="calendar_events",
+                label_ko="캘린더 이벤트",
+                category="News/calendar/research context",
+                surface=s("calendar_events"),
+            ),
+            await _symbol_valuation_family(
+                db, symbol=normalized_symbol, trading_day=coverage.tradingDate
+            ),
+            _surface_family(
+                key="research_reports",
+                label_ko="리서치 리포트",
+                category="News/calendar/research context",
+                surface=s("research_reports"),
+            ),
+            _surface_family(
+                key="research_consensus",
+                label_ko="리서치 컨센서스",
+                category="News/calendar/research context",
+                surface=None,
+                impact="degrades_report",
+                extra_notes=[
+                    "No distinct durable research-consensus readiness surface is wired; research report freshness is not treated as consensus availability."
+                ],
+            ),
+            _surface_family(
+                key="execution_ledger",
+                label_ko="체결 / 실행 이력",
+                category="Execution/history",
+                surface=None,
+                impact="degrades_report",
+                extra_notes=[
+                    "No distinct execution/fill ledger readiness surface is wired; pending orders are not treated as historical fills."
+                ],
+            ),
+            _surface_family(
+                key="sell_history",
+                label_ko="매도 이력",
+                category="Execution/history",
+                surface=None,
+                impact="degrades_report",
+                extra_notes=[
+                    "No distinct sell-history readiness surface is wired; do not infer sell history from pending orders."
+                ],
+            ),
+            _surface_family(
+                key="pending_order_reconciliation",
+                label_ko="미체결 주문 reconcile",
+                category="Execution/history",
+                surface=None,
+                critical=True,
+                impact="blocks_all_action_reports",
+                extra_notes=[
+                    "Pending-order table freshness alone does not prove live open-order reconciliation; fail closed until a reconciliation read-model is wired."
+                ],
+            ),
         ]
         families.extend(symbol_market_families)
         _apply_symbol_surface_diagnostics(families, coverage, symbol=normalized_symbol)
     else:
         families.extend(
             [
-                _surface_family(key="quotes", label_ko="시세 / 현재가", category="Market/read-model data", surface=s("quotes"), critical=False, impact="degrades_report", links=[ActionReadinessLink(label="Coverage", href="/invest/coverage")]),
-                _surface_family(key="ohlcv", label_ko="OHLCV 캔들", category="Market/read-model data", surface=s("ohlcv")),
-                _surface_family(key="technical_indicators", label_ko="기술지표", category="Market/read-model data", surface=None, impact="degrades_report", extra_notes=["No separate durable indicator readiness surface is wired; do not calculate indicators in this request path."]),
-                _surface_family(key="support_resistance", label_ko="지지/저항", category="Market/read-model data", surface=None, impact="degrades_report", extra_notes=["No durable support/resistance readiness surface is wired; values must not be fabricated."]),
-                _surface_family(key="orderbook_session", label_ko="호가 / 세션", category="Market/read-model data", surface=s("orderbook_nxt_capability"), impact="degrades_report", extra_notes=["This reports local NXT/session capability, not a request-path orderbook fetch."]),
-                _surface_family(key="nxt_eligibility", label_ko="NXT 대상 여부", category="Market/read-model data", surface=s("orderbook_nxt_capability")),
-                _surface_family(key="screener_snapshots", label_ko="스크리너 스냅샷", category="Market/read-model data", surface=s("screener_snapshots")),
-                _surface_family(key="naver_momentum_events", label_ko="Naver 모멘텀 이벤트", category="Market/read-model data", surface=None, impact="degrades_report", extra_references=["naver_reference"], extra_notes=["Naver momentum events are reference/candidate only and not source-of-truth."]),
-                _surface_family(key="naver_momentum_candidates", label_ko="Naver 모멘텀 후보", category="Market/read-model data", surface=None, impact="degrades_report", extra_references=["naver_reference"], extra_notes=["Momentum candidates are aggregate reference data only, not trading instructions."]),
-                _surface_family(key="naver_theme_events", label_ko="Naver 테마 이벤트", category="Market/read-model data", surface=None, impact="degrades_report", extra_references=["naver_reference"], extra_notes=["Theme events are aggregate reference data only."]),
-                _surface_family(key="investor_flow", label_ko="투자자 수급", category="Market/read-model data", surface=s("investor_flow")),
-                _surface_family(key="news_feed", label_ko="뉴스 피드", category="News/calendar/research context", surface=s("news_feed")),
-                _surface_family(key="issue_clusters", label_ko="시장 이슈 클러스터", category="News/calendar/research context", surface=None, impact="degrades_report"),
-                _surface_family(key="disclosures", label_ko="공시", category="News/calendar/research context", surface=None, impact="degrades_report"),
-                _surface_family(key="calendar_events", label_ko="캘린더 이벤트", category="News/calendar/research context", surface=s("calendar_events")),
-                _surface_family(key="valuation_fundamentals", label_ko="밸류에이션 / 펀더멘털", category="News/calendar/research context", surface=s("valuation_fundamentals")),
-                _surface_family(key="research_reports", label_ko="리서치 리포트", category="News/calendar/research context", surface=s("research_reports")),
-                _surface_family(key="research_consensus", label_ko="리서치 컨센서스", category="News/calendar/research context", surface=None, impact="degrades_report", extra_notes=["No distinct durable research-consensus readiness surface is wired; research report freshness is not treated as consensus availability."]),
-                _surface_family(key="execution_ledger", label_ko="체결 / 실행 이력", category="Execution/history", surface=None, impact="degrades_report", extra_notes=["No distinct execution/fill ledger readiness surface is wired; pending orders are not treated as historical fills."]),
-                _surface_family(key="sell_history", label_ko="매도 이력", category="Execution/history", surface=None, impact="degrades_report", extra_notes=["No distinct sell-history readiness surface is wired; do not infer sell history from pending orders."]),
-                _surface_family(key="pending_order_reconciliation", label_ko="미체결 주문 reconcile", category="Execution/history", surface=None, critical=True, impact="blocks_all_action_reports", extra_notes=["Pending-order table freshness alone does not prove live open-order reconciliation; fail closed until a reconciliation read-model is wired."]),
+                _surface_family(
+                    key="quotes",
+                    label_ko="시세 / 현재가",
+                    category="Market/read-model data",
+                    surface=s("quotes"),
+                    critical=False,
+                    impact="degrades_report",
+                    links=[
+                        ActionReadinessLink(label="Coverage", href="/invest/coverage")
+                    ],
+                ),
+                _surface_family(
+                    key="ohlcv",
+                    label_ko="OHLCV 캔들",
+                    category="Market/read-model data",
+                    surface=s("ohlcv"),
+                ),
+                _surface_family(
+                    key="technical_indicators",
+                    label_ko="기술지표",
+                    category="Market/read-model data",
+                    surface=None,
+                    impact="degrades_report",
+                    extra_notes=[
+                        "No separate durable indicator readiness surface is wired; do not calculate indicators in this request path."
+                    ],
+                ),
+                _surface_family(
+                    key="support_resistance",
+                    label_ko="지지/저항",
+                    category="Market/read-model data",
+                    surface=None,
+                    impact="degrades_report",
+                    extra_notes=[
+                        "No durable support/resistance readiness surface is wired; values must not be fabricated."
+                    ],
+                ),
+                _surface_family(
+                    key="orderbook_session",
+                    label_ko="호가 / 세션",
+                    category="Market/read-model data",
+                    surface=s("orderbook_nxt_capability"),
+                    impact="degrades_report",
+                    extra_notes=[
+                        "This reports local NXT/session capability, not a request-path orderbook fetch."
+                    ],
+                ),
+                _surface_family(
+                    key="nxt_eligibility",
+                    label_ko="NXT 대상 여부",
+                    category="Market/read-model data",
+                    surface=s("orderbook_nxt_capability"),
+                ),
+                _surface_family(
+                    key="screener_snapshots",
+                    label_ko="스크리너 스냅샷",
+                    category="Market/read-model data",
+                    surface=s("screener_snapshots"),
+                ),
+                _surface_family(
+                    key="naver_momentum_events",
+                    label_ko="Naver 모멘텀 이벤트",
+                    category="Market/read-model data",
+                    surface=None,
+                    impact="degrades_report",
+                    extra_references=["naver_reference"],
+                    extra_notes=[
+                        "Naver momentum events are reference/candidate only and not source-of-truth."
+                    ],
+                ),
+                _surface_family(
+                    key="naver_momentum_candidates",
+                    label_ko="Naver 모멘텀 후보",
+                    category="Market/read-model data",
+                    surface=None,
+                    impact="degrades_report",
+                    extra_references=["naver_reference"],
+                    extra_notes=[
+                        "Momentum candidates are aggregate reference data only, not trading instructions."
+                    ],
+                ),
+                _surface_family(
+                    key="naver_theme_events",
+                    label_ko="Naver 테마 이벤트",
+                    category="Market/read-model data",
+                    surface=None,
+                    impact="degrades_report",
+                    extra_references=["naver_reference"],
+                    extra_notes=["Theme events are aggregate reference data only."],
+                ),
+                _surface_family(
+                    key="investor_flow",
+                    label_ko="투자자 수급",
+                    category="Market/read-model data",
+                    surface=s("investor_flow"),
+                ),
+                _surface_family(
+                    key="news_feed",
+                    label_ko="뉴스 피드",
+                    category="News/calendar/research context",
+                    surface=s("news_feed"),
+                ),
+                _surface_family(
+                    key="issue_clusters",
+                    label_ko="시장 이슈 클러스터",
+                    category="News/calendar/research context",
+                    surface=None,
+                    impact="degrades_report",
+                ),
+                _surface_family(
+                    key="disclosures",
+                    label_ko="공시",
+                    category="News/calendar/research context",
+                    surface=None,
+                    impact="degrades_report",
+                ),
+                _surface_family(
+                    key="calendar_events",
+                    label_ko="캘린더 이벤트",
+                    category="News/calendar/research context",
+                    surface=s("calendar_events"),
+                ),
+                _surface_family(
+                    key="valuation_fundamentals",
+                    label_ko="밸류에이션 / 펀더멘털",
+                    category="News/calendar/research context",
+                    surface=s("valuation_fundamentals"),
+                ),
+                _surface_family(
+                    key="research_reports",
+                    label_ko="리서치 리포트",
+                    category="News/calendar/research context",
+                    surface=s("research_reports"),
+                ),
+                _surface_family(
+                    key="research_consensus",
+                    label_ko="리서치 컨센서스",
+                    category="News/calendar/research context",
+                    surface=None,
+                    impact="degrades_report",
+                    extra_notes=[
+                        "No distinct durable research-consensus readiness surface is wired; research report freshness is not treated as consensus availability."
+                    ],
+                ),
+                _surface_family(
+                    key="execution_ledger",
+                    label_ko="체결 / 실행 이력",
+                    category="Execution/history",
+                    surface=None,
+                    impact="degrades_report",
+                    extra_notes=[
+                        "No distinct execution/fill ledger readiness surface is wired; pending orders are not treated as historical fills."
+                    ],
+                ),
+                _surface_family(
+                    key="sell_history",
+                    label_ko="매도 이력",
+                    category="Execution/history",
+                    surface=None,
+                    impact="degrades_report",
+                    extra_notes=[
+                        "No distinct sell-history readiness surface is wired; do not infer sell history from pending orders."
+                    ],
+                ),
+                _surface_family(
+                    key="pending_order_reconciliation",
+                    label_ko="미체결 주문 reconcile",
+                    category="Execution/history",
+                    surface=None,
+                    critical=True,
+                    impact="blocks_all_action_reports",
+                    extra_notes=[
+                        "Pending-order table freshness alone does not prove live open-order reconciliation; fail closed until a reconciliation read-model is wired."
+                    ],
+                ),
             ]
         )
 
@@ -631,7 +991,9 @@ async def build_kr_action_readiness(
         if family.blockers:
             blockers.extend(f"{family.key}: {blocker}" for blocker in family.blockers)
         elif family.state in {"degraded", "missing", "unknown"}:
-            degraded.append(f"{family.key}: {family.warnings[0] if family.warnings else family.state}")
+            degraded.append(
+                f"{family.key}: {family.warnings[0] if family.warnings else family.state}"
+            )
 
     buy_blocked = any(
         family.state == "blocked"

--- a/docs/invest-coverage-dashboard.md
+++ b/docs/invest-coverage-dashboard.md
@@ -103,6 +103,47 @@ Expected semantics:
 - Nav label: `커버리지`
 - The UI groups counts by state, lists surface-level gaps, shows Naver/Toss candidate readiness chips, renders actionability priority/action/queue/approval gates, and optionally shows symbol-level coverage for screener/news/investor-flow.
 
+## KR action-report readiness
+
+ROB-256 adds a dedicated read-only readiness API for domestic-stock action-report prerequisites:
+
+Endpoint: `GET /invest/api/kr/action-readiness`
+
+Query parameters:
+- `symbol`: optional six-digit KR equity code. Invalid/non-KR symbols return `overallState="blocked"` without provider or broker calls.
+
+Contract:
+- The endpoint maps existing `/invest/api/coverage` read-model surfaces plus the existing `InvestHomeService` account-panel read path into action-report readiness metadata.
+- KIS live is authoritative for tradeable KR holdings, cash/orderable state, open-order visibility, and sellable quantity.
+- `/invest` DB/read models are product authority for quotes/OHLCV/technical-readiness, screeners, Naver momentum/theme reference data, investor flow, news/issues/disclosures, calendar, valuation/research, and historical execution/fill readiness.
+- Manual/paper holdings and Toss/Naver/external sources are reference/candidate/supporting only; they must not be rendered as action-readiness `sourceOfTruth`.
+- Missing, stale, partial, failed, unsupported, or unwired data is shown as `missing`, `degraded`, `blocked`, `unsupported`, or `unknown`/`확인 불가`; the service must not estimate missing values.
+- The endpoint does not submit/cancel/modify orders, mutate watch/order-intent ledgers, run production DB writes/backfills, activate schedulers, or scrape Toss/Naver/provider pages from request paths.
+
+Response highlights:
+- `overallState`: `ready`, `degraded`, `blocked`, `missing`, `unsupported`, or `unknown`.
+- `canGenerateBuyReport` / `canGenerateSellReport`: conservative readiness booleans, not trade recommendations.
+- `families`: grouped readiness cards with `authority`, `sourceOfTruth`, `references`, coverage state, blockers, warnings, notes, and advisory `actionability`.
+- `sourcePolicy`: human-readable source-authority rules echoed to the frontend.
+
+Readiness family mapping:
+
+| Family | Authority | Blocks/degrades |
+| --- | --- | --- |
+| `kis_live_holdings`, `kis_live_cash_orderable`, `kis_live_open_orders`, `kis_live_sellable_quantity` | KIS live via existing account-panel read path | Cash blocks buy readiness; holdings/sellable blocks sell readiness; unavailable live broker/account state is `확인 불가`. |
+| `trade_journals` | `auto_trader` live trade journals | Missing active thesis/target/stop context degrades reports and is mandatory context before sell recommendations. |
+| `quotes`, `ohlcv`, `technical_indicators`, `support_resistance` | `/invest` read models | Missing quote for a requested symbol blocks action reports; unwired indicator/support-resistance surfaces degrade rather than fabricate values. |
+| `orderbook_session`, `nxt_eligibility`, `pending_order_reconciliation` | `/invest` read models plus KIS live authority where already represented elsewhere | Missing reconciliation/open-order visibility blocks or degrades; no request-path orderbook fetch is introduced. |
+| `screener_snapshots`, `naver_momentum_events`, `naver_momentum_candidates`, `naver_theme_events`, `investor_flow` | `/invest` read models; Naver is reference/candidate only | Stale/missing data degrades reports. |
+| `news_feed`, `issue_clusters`, `disclosures`, `calendar_events` | `/invest` read models | Missing/stale context degrades reports and renders `확인 불가`. |
+| `valuation_fundamentals`, `research_reports`, `research_consensus` | `/invest` read models | Missing/stale valuation or consensus degrades; full report bodies remain excluded when existing policy excludes them. |
+| `execution_ledger`, `sell_history` | `/invest` historical ledger/read models; KIS live remains current open-order/sellable authority | Stale/missing historical fill/sell history degrades sell reports. |
+
+Frontend placement:
+- `/invest/coverage` now renders a top `KR 액션 리포트 준비도` card for KR mode before the raw coverage table.
+- It shows overall state, buy/sell report readiness, blockers, degraded signals, source policy, and grouped family cards.
+- It intentionally renders advisory actionability text only; no order/backfill/scheduler/run controls are present.
+
 ## Approval gates
 
 Any production remediation discovered from coverage output requires a separate approval packet and task. This issue does not approve:

--- a/frontend/invest/src/__tests__/ActionReadiness.test.tsx
+++ b/frontend/invest/src/__tests__/ActionReadiness.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { fetchKrActionReadiness } from "../api/actionReadiness";
+import { CoverageRoute } from "../pages/desktop/DesktopCoveragePage";
+
+const actionability = {
+  priority: "none",
+  action: "none",
+  queue: null,
+  approvalGates: [],
+  reason: null,
+  safeByDefault: true,
+};
+
+const counts = {
+  expected: null,
+  fresh: 1,
+  stale: 0,
+  missing: 0,
+  partial: 0,
+  total: 1,
+};
+
+function coverageResponse() {
+  return {
+    market: "kr",
+    asOf: "2026-05-14T09:00:00Z",
+    tradingDate: "2026-05-14",
+    states: ["fresh", "missing", "provider_unwired"],
+    surfaces: [
+      {
+        surface: "quotes",
+        label: "quotes",
+        state: "fresh",
+        market: "kr",
+        sourceOfTruth: "market_quote_snapshots",
+        references: ["toss"],
+        latestAt: "2026-05-14T09:00:00Z",
+        latestDate: null,
+        counts,
+        staleAfterHours: null,
+        warnings: [],
+        notes: [],
+        sourceCandidates: [],
+        actionability,
+      },
+    ],
+    symbols: [],
+    gaps: [],
+    notes: [],
+  };
+}
+
+function readinessResponse() {
+  return {
+    market: "kr",
+    asOf: "2026-05-14T09:00:00Z",
+    symbol: "005930",
+    overallState: "blocked",
+    canGenerateBuyReport: false,
+    canGenerateSellReport: false,
+    blockers: ["kis_live_cash_orderable: KIS live 주문가능 현금 확인 불가"],
+    degradedSignals: ["investor_flow: stale 상태입니다."],
+    sourcePolicy: [
+      "KIS live broker values are authoritative for tradeable KR holdings, cash, open orders, and sellable quantity.",
+      "/invest DB/read-model state is the product authority for market, screener, Naver/Toss-derived reference, news, calendar, valuation, flow, and historical ledger readiness.",
+      "Toss/Naver/external sources are displayed only as reference, candidate, or supporting signals and are never source-of-truth for action readiness.",
+    ],
+    notes: ["Read-only readiness only: no order, watch/order-intent, scheduler, backfill, or broker mutation is performed."],
+    families: [
+      {
+        key: "kis_live_cash_orderable",
+        labelKo: "KIS live 주문가능 현금",
+        category: "Broker authority",
+        state: "blocked",
+        impact: "blocks_buy_report",
+        authority: "kis_live_broker",
+        sourceOfTruth: "KIS live via existing InvestHomeService/account-panel",
+        references: ["manual_or_paper_reference"],
+        latestAt: null,
+        latestDate: null,
+        counts: null,
+        coverageState: null,
+        actionability: { ...actionability, priority: "blocked", action: "provider_contract_needed", queue: "invest-action-readiness-review", approvalGates: ["code_review"], reason: "KIS live 주문가능 현금 확인 불가" },
+        blockers: ["KIS live 주문가능 현금 확인 불가"],
+        warnings: [],
+        notes: ["Existing InvestHomeService/account-panel read path only; no new broker mutation path."],
+        links: [],
+      },
+      {
+        key: "investor_flow",
+        labelKo: "투자자 수급",
+        category: "Market/read-model data",
+        state: "degraded",
+        impact: "degrades_report",
+        authority: "auto_trader_read_model",
+        sourceOfTruth: "investor_flow_snapshots",
+        references: ["naver"],
+        latestAt: null,
+        latestDate: "2026-05-13",
+        counts,
+        coverageState: "stale",
+        actionability: { ...actionability, priority: "high", action: "investigate", queue: "invest-action-readiness-review", approvalGates: ["code_review"], reason: "stale" },
+        blockers: [],
+        warnings: ["investor_flow: stale 상태입니다."],
+        notes: [],
+        links: [],
+      },
+    ],
+  };
+}
+
+const fetchMock = vi.fn();
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockImplementation((input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.startsWith("/invest/api/coverage")) {
+      return Promise.resolve({ ok: true, json: async () => coverageResponse() });
+    }
+    if (url.startsWith("/invest/api/kr/action-readiness")) {
+      return Promise.resolve({ ok: true, json: async () => readinessResponse() });
+    }
+    return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test("action readiness API client builds symbol query and includes credentials", async () => {
+  await fetchKrActionReadiness({ symbol: " 005930 " });
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    "/invest/api/kr/action-readiness?symbol=005930",
+    expect.objectContaining({ credentials: "include" }),
+  );
+});
+
+test("coverage page renders KR action readiness blockers and source boundaries without execution buttons", async () => {
+  render(
+    <MemoryRouter basename="/invest" initialEntries={["/invest/coverage"]}>
+      <CoverageRoute />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText("KR 액션 리포트 준비도")).toBeInTheDocument();
+  expect(screen.getByText("매수 리포트 차단")).toBeInTheDocument();
+  expect(screen.getByText("매도 리포트 차단")).toBeInTheDocument();
+  expect(screen.getAllByText(/KIS live 주문가능 현금 확인 불가/).length).toBeGreaterThan(0);
+  expect(screen.getByText(/authority KIS live/)).toBeInTheDocument();
+  expect(screen.getByText(/sourceOfTruth: investor_flow_snapshots/)).toBeInTheDocument();
+  expect(screen.getByText(/Toss\/Naver\/external sources/)).toBeInTheDocument();
+
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/invest/api/kr/action-readiness?symbol=005930",
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+
+  expect(screen.queryByRole("button", { name: /주문|백필|스케줄|실행|refresh/i })).not.toBeInTheDocument();
+});

--- a/frontend/invest/src/api/actionReadiness.ts
+++ b/frontend/invest/src/api/actionReadiness.ts
@@ -1,0 +1,18 @@
+import type { KrActionReadinessResponse } from "../types/actionReadiness";
+
+export async function fetchKrActionReadiness(params: {
+  symbol?: string;
+  signal?: AbortSignal;
+} = {}): Promise<KrActionReadinessResponse> {
+  const q = new URLSearchParams();
+  if (params.symbol?.trim()) q.set("symbol", params.symbol.trim());
+  const suffix = q.toString() ? `?${q.toString()}` : "";
+  const res = await fetch(`/invest/api/kr/action-readiness${suffix}`, {
+    credentials: "include",
+    signal: params.signal,
+  });
+  if (!res.ok) {
+    throw new Error(`/invest/api/kr/action-readiness ${res.status}`);
+  }
+  return res.json();
+}

--- a/frontend/invest/src/pages/desktop/DesktopCoveragePage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCoveragePage.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useMemo, useState } from "react";
+import { fetchKrActionReadiness } from "../../api/actionReadiness";
 import { fetchInvestCoverage } from "../../api/coverage";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { Card } from "../../ds";
+import type {
+  ActionReadinessState,
+  KrActionReadinessResponse,
+} from "../../types/actionReadiness";
 import type {
   CoverageActionability,
   CoverageCandidateReadiness,
@@ -64,6 +69,40 @@ const ACTION_PRIORITY_COLOR: Record<CoverageActionability["priority"], string> =
   blocked: "#7c3aed",
 };
 
+const ACTION_READINESS_LABEL: Record<ActionReadinessState, string> = {
+  ready: "준비됨",
+  degraded: "저하",
+  blocked: "차단",
+  missing: "없음",
+  unsupported: "미지원",
+  unknown: "확인 불가",
+};
+
+const ACTION_READINESS_COLOR: Record<ActionReadinessState, string> = {
+  ready: "#16a34a",
+  degraded: "#ca8a04",
+  blocked: "#dc2626",
+  missing: "#d97706",
+  unsupported: "#64748b",
+  unknown: "#7c3aed",
+};
+
+const IMPACT_LABEL: Record<string, string> = {
+  none: "영향 없음",
+  degrades_report: "리포트 품질 저하",
+  blocks_buy_report: "매수 리포트 차단",
+  blocks_sell_report: "매도 리포트 차단",
+  blocks_all_action_reports: "전체 차단",
+};
+
+const AUTHORITY_LABEL: Record<string, string> = {
+  kis_live_broker: "KIS live",
+  auto_trader_read_model: "read-model",
+  manual_or_paper_reference: "참조 계좌",
+  external_reference: "외부 참조",
+  unsupported: "미지원",
+};
+
 const ACTION_LABEL: Record<CoverageActionability["action"], string> = {
   none: "조치 없음",
   monitor: "모니터링",
@@ -119,6 +158,121 @@ function StatePill({ state }: { state: CoverageState }) {
     >
       {STATE_LABEL[state]}
     </span>
+  );
+}
+
+function ActionReadinessPill({ state }: { state: ActionReadinessState }) {
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        borderRadius: 999,
+        padding: "3px 8px",
+        fontSize: 12,
+        fontWeight: 800,
+        color: "white",
+        background: ACTION_READINESS_COLOR[state],
+        whiteSpace: "nowrap",
+      }}
+    >
+      {ACTION_READINESS_LABEL[state]}
+    </span>
+  );
+}
+
+function firstKrSymbol(symbols: string): string | undefined {
+  return symbols
+    .split(",")
+    .map((part) => part.trim())
+    .find((part) => /^\d{6}$/.test(part));
+}
+
+function ReadinessFamilyCard({ family }: { family: KrActionReadinessResponse["families"][number] }) {
+  const latest = family.latestDate ?? family.latestAt ?? "-";
+  const message = family.blockers[0] ?? family.warnings[0] ?? family.notes[0] ?? "확인된 blocker 없음";
+  return (
+    <div style={{ border: "1px solid var(--divider)", borderRadius: 12, padding: 12, display: "grid", gap: 8 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "center" }}>
+        <div>
+          <div style={{ fontWeight: 900 }}>{family.labelKo}</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{family.key} · {IMPACT_LABEL[family.impact] ?? family.impact}</div>
+        </div>
+        <ActionReadinessPill state={family.state} />
+      </div>
+      <div style={{ color: "var(--fg-2)", fontSize: 12 }}>
+        authority {AUTHORITY_LABEL[family.authority] ?? family.authority} · latest {latest}
+      </div>
+      <div style={{ fontFamily: "var(--font-mono)", fontSize: 12, color: "var(--fg-2)", overflowWrap: "anywhere" }}>
+        sourceOfTruth: {family.sourceOfTruth}
+      </div>
+      <div style={{ color: family.blockers.length > 0 ? "#dc2626" : "var(--fg-3)", fontSize: 12 }}>
+        {message}
+      </div>
+      {family.references.length > 0 && (
+        <div style={{ color: "var(--fg-3)", fontSize: 12 }}>references: {family.references.join(", ")}</div>
+      )}
+      <ActionabilityBadge actionability={family.actionability} />
+    </div>
+  );
+}
+
+function ActionReadinessCard({ data }: { data: KrActionReadinessResponse }) {
+  const groups = Array.from(new Set(data.families.map((family) => family.category)));
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 14 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start", flexWrap: "wrap" }}>
+          <div>
+            <h2 style={{ margin: 0, fontSize: 20 }}>KR 액션 리포트 준비도</h2>
+            <p style={{ margin: "6px 0 0", color: "var(--fg-2)", fontSize: 13 }}>
+              read-only source dashboard입니다. 매매 추천·주문·백필·스케줄 실행 버튼을 제공하지 않습니다.
+            </p>
+          </div>
+          <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+            <ActionReadinessPill state={data.overallState} />
+            <span style={{ color: data.canGenerateBuyReport ? "#16a34a" : "#dc2626", fontWeight: 800 }}>
+              매수 리포트 {data.canGenerateBuyReport ? "가능" : "차단"}
+            </span>
+            <span style={{ color: data.canGenerateSellReport ? "#16a34a" : "#dc2626", fontWeight: 800 }}>
+              매도 리포트 {data.canGenerateSellReport ? "가능" : "차단"}
+            </span>
+          </div>
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 10 }}>
+          <div>
+            <div style={{ fontWeight: 800, marginBottom: 6 }}>Blockers</div>
+            {(data.blockers.length ? data.blockers : ["현재 전체 blocker 없음"]).slice(0, 6).map((item) => (
+              <div key={item} style={{ color: data.blockers.length ? "#dc2626" : "var(--fg-3)", fontSize: 12, marginBottom: 4 }}>{item}</div>
+            ))}
+          </div>
+          <div>
+            <div style={{ fontWeight: 800, marginBottom: 6 }}>Degraded signals</div>
+            {(data.degradedSignals.length ? data.degradedSignals : ["저하 신호 없음"]).slice(0, 6).map((item) => (
+              <div key={item} style={{ color: "var(--fg-3)", fontSize: 12, marginBottom: 4 }}>{item}</div>
+            ))}
+          </div>
+          <div>
+            <div style={{ fontWeight: 800, marginBottom: 6 }}>Source policy</div>
+            {data.sourcePolicy.slice(0, 4).map((item) => (
+              <div key={item} style={{ color: "var(--fg-3)", fontSize: 12, marginBottom: 4 }}>{item}</div>
+            ))}
+          </div>
+        </div>
+
+        {groups.map((group) => (
+          <div key={group} style={{ display: "grid", gap: 10 }}>
+            <h3 style={{ margin: 0, fontSize: 15 }}>{group}</h3>
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 10 }}>
+              {data.families.filter((family) => family.category === group).map((family) => (
+                <ReadinessFamilyCard key={family.key} family={family} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
   );
 }
 
@@ -188,6 +342,10 @@ export function CoverageRoute() {
   const [data, setData] = useState<InvestCoverageResponse | undefined>();
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
+  const [readiness, setReadiness] = useState<KrActionReadinessResponse | undefined>();
+  const [readinessLoading, setReadinessLoading] = useState(true);
+  const [readinessErr, setReadinessErr] = useState<string | null>(null);
+  const readinessSymbol = market === "kr" ? firstKrSymbol(symbols) : undefined;
 
   useEffect(() => {
     const controller = new AbortController();
@@ -205,6 +363,29 @@ export function CoverageRoute() {
       });
     return () => controller.abort();
   }, [market, symbols]);
+
+  useEffect(() => {
+    if (market !== "kr") {
+      setReadiness(undefined);
+      setReadinessLoading(false);
+      setReadinessErr(null);
+      return;
+    }
+    const controller = new AbortController();
+    setReadinessLoading(true);
+    setReadinessErr(null);
+    fetchKrActionReadiness({ symbol: readinessSymbol, signal: controller.signal })
+      .then((response) => {
+        setReadiness(response);
+        setReadinessLoading(false);
+      })
+      .catch((e) => {
+        if (controller.signal.aborted) return;
+        setReadinessErr(String(e?.message ?? e));
+        setReadinessLoading(false);
+      });
+    return () => controller.abort();
+  }, [market, readinessSymbol]);
 
   const summary = useMemo(() => {
     const surfaces = data?.surfaces ?? [];
@@ -246,6 +427,9 @@ export function CoverageRoute() {
 
         {loading && <Card>커버리지 로딩 중…</Card>}
         {err && <Card><span style={{ color: STATE_COLOR.error }}>커버리지 API 오류: {err}</span></Card>}
+        {market === "kr" && readinessLoading && <Card>KR 액션 리포트 준비도 로딩 중…</Card>}
+        {market === "kr" && readinessErr && <Card><span style={{ color: STATE_COLOR.error }}>액션 준비도 API 오류: {readinessErr}</span></Card>}
+        {market === "kr" && readiness && !readinessLoading && <ActionReadinessCard data={readiness} />}
 
         {data && !loading && (
           <>

--- a/frontend/invest/src/types/actionReadiness.ts
+++ b/frontend/invest/src/types/actionReadiness.ts
@@ -1,0 +1,62 @@
+import type { CoverageActionability, CoverageState, InvestCoverageCounts } from "./coverage";
+
+export type ActionReadinessState =
+  | "ready"
+  | "degraded"
+  | "blocked"
+  | "missing"
+  | "unsupported"
+  | "unknown";
+
+export type ActionReadinessAuthority =
+  | "kis_live_broker"
+  | "auto_trader_read_model"
+  | "manual_or_paper_reference"
+  | "external_reference"
+  | "unsupported";
+
+export type ActionReportImpact =
+  | "none"
+  | "degrades_report"
+  | "blocks_buy_report"
+  | "blocks_sell_report"
+  | "blocks_all_action_reports";
+
+export interface ActionReadinessLink {
+  label: string;
+  href: string;
+}
+
+export interface ActionReadinessFamily {
+  key: string;
+  labelKo: string;
+  category: string;
+  state: ActionReadinessState;
+  impact: ActionReportImpact;
+  authority: ActionReadinessAuthority;
+  sourceOfTruth: string;
+  references: string[];
+  latestAt: string | null;
+  latestDate: string | null;
+  counts: InvestCoverageCounts | null;
+  coverageState: CoverageState | null;
+  actionability: CoverageActionability;
+  blockers: string[];
+  warnings: string[];
+  notes: string[];
+  links: ActionReadinessLink[];
+}
+
+export interface KrActionReadinessResponse {
+  market: "kr";
+  asOf: string;
+  symbol: string | null;
+  overallState: ActionReadinessState;
+  canGenerateBuyReport: boolean;
+  canGenerateSellReport: boolean;
+  families: ActionReadinessFamily[];
+  blockers: string[];
+  degradedSignals: string[];
+  sourcePolicy: string[];
+  notes: string[];
+}

--- a/tests/test_invest_action_readiness.py
+++ b/tests/test_invest_action_readiness.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Iterable
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.invest_action_readiness import KrActionReadinessResponse
+from app.schemas.invest_coverage import InvestCoverageResponse, InvestCoverageSurface
+from app.schemas.invest_home import (
+    Account,
+    Holding,
+    HomeSummary,
+    InvestHomeResponse,
+)
+from app.services.invest_view_model import action_readiness_service as service_module
+
+
+class _ScalarResult:
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+    def scalar_one_or_none(self) -> Any:
+        return self.value
+
+
+class _OneResult:
+    def __init__(self, value: tuple[Any, ...]) -> None:
+        self.value = value
+
+    def one(self) -> tuple[Any, ...]:
+        return self.value
+
+
+class _FakeDb:
+    def __init__(self, results: Iterable[Any]) -> None:
+        self.results = list(results)
+        self.execute_count = 0
+
+    async def execute(self, _stmt: Any, _params: Any = None) -> Any:
+        self.execute_count += 1
+        if not self.results:
+            raise AssertionError("unexpected execute call")
+        return self.results.pop(0)
+
+
+class _FakeHomeService:
+    def __init__(self, home: InvestHomeResponse) -> None:
+        self.home = home
+        self.user_ids: list[int] = []
+
+    async def get_home(self, *, user_id: int) -> InvestHomeResponse:
+        self.user_ids.append(user_id)
+        return self.home
+
+
+def _surface(name: str, state: str = "fresh") -> InvestCoverageSurface:
+    return InvestCoverageSurface(
+        surface=name,
+        label=name,
+        state=state,  # type: ignore[arg-type]
+        market="kr",
+        sourceOfTruth=f"{name}_read_model",
+        references=["toss"],
+    )
+
+
+def _coverage() -> InvestCoverageResponse:
+    now = dt.datetime(2026, 5, 14, 9, 0, tzinfo=dt.UTC)
+    return InvestCoverageResponse(
+        market="kr",
+        asOf=now,
+        tradingDate=now.date(),
+        states=["fresh", "missing", "provider_unwired"],
+        surfaces=[
+            _surface("quotes"),
+            _surface("ohlcv"),
+            _surface("orderbook_nxt_capability"),
+            _surface("screener_snapshots"),
+            _surface("investor_flow"),
+            _surface("news_feed"),
+            _surface("calendar_events"),
+            _surface("valuation_fundamentals"),
+            _surface("research_reports"),
+            _surface("pending_orders"),
+        ],
+        symbols=[],
+        gaps=[],
+        notes=[],
+    )
+
+
+def _home(*, symbol: str = "005930", sellable_quantity: float | None = 1.0) -> InvestHomeResponse:
+    return InvestHomeResponse(
+        homeSummary=HomeSummary(
+            includedSources=["kis"],
+            excludedSources=[],
+            totalValueKrw=100_000.0,
+        ),
+        accounts=[
+            Account(
+                accountId="kis-live",
+                displayName="KIS live",
+                source="kis",
+                accountKind="live",
+                includedInHome=True,
+                valueKrw=100_000.0,
+                buyingPower={"krw": 50_000.0},
+                cashBalances={"krw": 50_000.0},
+            )
+        ],
+        holdings=[
+            Holding(
+                holdingId="kis-live-005930",
+                accountId="kis-live",
+                source="kis",
+                accountKind="live",
+                symbol=symbol,
+                market="KR",
+                assetType="equity",
+                assetCategory="kr_stock",
+                displayName="삼성전자",
+                quantity=2.0,
+                currency="KRW",
+                sellableQuantity=sellable_quantity,
+            )
+        ],
+        groupedHoldings=[],
+    )
+
+
+def test_kr_action_readiness_schema_forbids_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        KrActionReadinessResponse(
+            asOf=dt.datetime.now(dt.UTC),
+            overallState="ready",
+            canGenerateBuyReport=True,
+            canGenerateSellReport=True,
+            families=[],
+            sourcePolicy=[],
+            unexpected="nope",
+        )
+
+
+@pytest.mark.asyncio
+async def test_build_kr_action_readiness_uses_empty_symbol_list_and_kis_authority(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def fake_coverage(db: Any, **kwargs: Any) -> InvestCoverageResponse:
+        calls.append(kwargs)
+        return _coverage()
+
+    monkeypatch.setattr(service_module, "build_invest_coverage", fake_coverage)
+
+    response = await service_module.build_kr_action_readiness(
+        db=_FakeDb([_OneResult((1, dt.datetime(2026, 5, 14, tzinfo=dt.UTC)))]),
+        user_id=7,
+        home_service=_FakeHomeService(_home()),
+        symbol=None,
+    )
+
+    assert calls == [{"market": "kr", "symbols": []}]
+    family_by_key = {family.key: family for family in response.families}
+    assert family_by_key["kis_live_cash_orderable"].authority == "kis_live_broker"
+    assert family_by_key["kis_live_holdings"].state == "ready"
+    assert family_by_key["kis_live_open_orders"].state == "blocked"
+    assert family_by_key["pending_order_reconciliation"].state == "blocked"
+    assert family_by_key["execution_ledger"].state == "unknown"
+    assert family_by_key["sell_history"].state == "unknown"
+    assert family_by_key["research_consensus"].state == "unknown"
+    assert family_by_key["naver_momentum_events"].authority == "auto_trader_read_model"
+    assert family_by_key["naver_momentum_events"].sourceOfTruth == "auto_trader_read_model/unwired"
+    assert "naver_reference" in family_by_key["naver_momentum_events"].references
+    assert response.canGenerateBuyReport is False
+    assert any("KIS live 미체결 주문" in blocker for blocker in response.blockers)
+    assert response.notes[0].startswith("Read-only readiness only")
+
+
+@pytest.mark.asyncio
+async def test_symbol_scoped_sell_readiness_blocks_when_live_holding_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[dict[str, Any]] = []
+
+    async def fake_coverage(db: Any, **kwargs: Any) -> InvestCoverageResponse:
+        calls.append(kwargs)
+        return _coverage()
+
+    monkeypatch.setattr(service_module, "build_invest_coverage", fake_coverage)
+
+    response = await service_module.build_kr_action_readiness(
+        db=_FakeDb(
+            [
+                _ScalarResult("000660"),
+                _OneResult((0, None)),
+                _ScalarResult(dt.datetime(2026, 5, 14, 9, 0, tzinfo=dt.UTC)),
+                _OneResult((dt.datetime(2026, 5, 14, 9, 0, tzinfo=dt.UTC), dt.date(2026, 5, 14))),
+                _ScalarResult(dt.date(2026, 5, 14)),
+            ]
+        ),
+        user_id=7,
+        home_service=_FakeHomeService(_home(symbol="005930")),
+        symbol="000660",
+    )
+
+    assert calls == [{"market": "kr", "symbols": ["000660"]}]
+    family_by_key = {family.key: family for family in response.families}
+    assert family_by_key["kis_live_sellable_quantity"].state == "blocked"
+    assert response.canGenerateSellReport is False
+    assert any("000660" in blocker for blocker in response.blockers)
+
+
+@pytest.mark.asyncio
+async def test_invalid_kr_symbol_returns_blocked_without_provider_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_coverage(db: Any, **kwargs: Any) -> InvestCoverageResponse:
+        raise AssertionError("coverage should not run for invalid symbols")
+
+    monkeypatch.setattr(service_module, "build_invest_coverage", fail_coverage)
+
+    response = await service_module.build_kr_action_readiness(
+        db=_FakeDb([]),
+        user_id=7,
+        home_service=_FakeHomeService(_home()),
+        symbol="AAPL",
+    )
+
+    assert response.overallState == "blocked"
+    assert response.canGenerateBuyReport is False
+    assert response.canGenerateSellReport is False
+    assert response.families == []
+    assert response.blockers == [
+        "symbol_not_kr_equity: KR 심볼은 6자리 종목코드여야 합니다. 확인 불가"
+    ]

--- a/tests/test_invest_action_readiness.py
+++ b/tests/test_invest_action_readiness.py
@@ -92,7 +92,9 @@ def _coverage() -> InvestCoverageResponse:
     )
 
 
-def _home(*, symbol: str = "005930", sellable_quantity: float | None = 1.0) -> InvestHomeResponse:
+def _home(
+    *, symbol: str = "005930", sellable_quantity: float | None = 1.0
+) -> InvestHomeResponse:
     return InvestHomeResponse(
         homeSummary=HomeSummary(
             includedSources=["kis"],
@@ -173,7 +175,10 @@ async def test_build_kr_action_readiness_uses_empty_symbol_list_and_kis_authorit
     assert family_by_key["sell_history"].state == "unknown"
     assert family_by_key["research_consensus"].state == "unknown"
     assert family_by_key["naver_momentum_events"].authority == "auto_trader_read_model"
-    assert family_by_key["naver_momentum_events"].sourceOfTruth == "auto_trader_read_model/unwired"
+    assert (
+        family_by_key["naver_momentum_events"].sourceOfTruth
+        == "auto_trader_read_model/unwired"
+    )
     assert "naver_reference" in family_by_key["naver_momentum_events"].references
     assert response.canGenerateBuyReport is False
     assert any("KIS live 미체결 주문" in blocker for blocker in response.blockers)
@@ -198,7 +203,12 @@ async def test_symbol_scoped_sell_readiness_blocks_when_live_holding_missing(
                 _ScalarResult("000660"),
                 _OneResult((0, None)),
                 _ScalarResult(dt.datetime(2026, 5, 14, 9, 0, tzinfo=dt.UTC)),
-                _OneResult((dt.datetime(2026, 5, 14, 9, 0, tzinfo=dt.UTC), dt.date(2026, 5, 14))),
+                _OneResult(
+                    (
+                        dt.datetime(2026, 5, 14, 9, 0, tzinfo=dt.UTC),
+                        dt.date(2026, 5, 14),
+                    )
+                ),
                 _ScalarResult(dt.date(2026, 5, 14)),
             ]
         ),


### PR DESCRIPTION
## Summary
- Add read-only `/invest/api/action-readiness` KR action-readiness model for source authority, freshness, blocker visibility, and required evidence.
- Add `/invest/coverage` action-readiness dashboard surface with explicit source boundaries and no execution controls.
- Document `/invest` coverage/readiness authority across KIS live, DB/read-model, Toss/Naver reference-only, and unsupported/missing/stale states.

Closes ROB-256

## Verification
- `PUBLIC_API_PATHS='["/api/v1/openclaw/callback"]' uv run --group test pytest tests/test_invest_action_readiness.py tests/test_invest_coverage.py tests/test_invest_api_router_safety.py -q` -> 19 passed, 2 pre-existing Pydantic warnings
- `uv run ruff check app/routers/invest_api.py app/schemas/invest_action_readiness.py app/services/invest_view_model/action_readiness_service.py tests/test_invest_action_readiness.py` -> passed
- `git diff --check HEAD^..HEAD` -> passed
- `cd frontend/invest && npm test -- --run src/__tests__/ActionReadiness.test.tsx src/__tests__/routes.test.tsx` -> 5 passed
- `cd frontend/invest && npm run typecheck` -> passed

## Safety / non-actions
- No broker order submit/cancel/modify calls.
- No watch/order-intent ledger mutations.
- No production DB writes, backfills, scheduler activation, or broker-side mutations.
- No frontend request-path Toss/Naver scraping.
- Unavailable sources are surfaced as missing/stale/partial/unsupported/확인 불가 instead of estimated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a KR action-readiness read-only API endpoint to check system readiness for generating action reports, including per-subsystem status details
  * Integrated readiness status display on the investment coverage page with overall state, per-family details, and advisory information

* **Documentation**
  * Updated investment coverage dashboard documentation with action-readiness API specifications, contract details, and frontend implementation guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/834)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->