### PR TITLE
fix(alpaca-paper): allow legacy preflight warnings in test mode

### DIFF
--- a/app/mcp_server/README.md
+++ b/app/mcp_server/README.md
@@ -142,7 +142,14 @@ callers may pass `lifecycle_correlation_id`, `client_order_id`, `candidate_uuid`
 `briefing_artifact_run_uuid`, or an `approval_packet` containing those keys; the
 tool then reads only matching ledger rows and returns `scoped_by` so decision
 sessions do not get blocked by unrelated recent ETH/SOL/BTC rows. Calls without
-scope keep the broad recent-ledger safety behavior for global runners. ROB-93
+scope keep the broad recent-ledger safety behavior for global runners. Passing
+`legacy_cycle_blockers_as_warnings=True` is an explicit Alpaca Paper execution
+flow test-mode: residual positions and stale preview/approval packets are
+returned as warnings instead of blockers so operators can test buy/sell/order
+adjust/close flows on a used paper account. It does not weaken open-order
+conflicts, duplicate `client_order_id`, ledger/order/fill anomalies, missing
+linked sells, unclosed sell snapshots, or symbol mismatches; those remain
+blocking. ROB-93
 checks include unexpected open orders, residual positions, duplicate
 `client_order_id`, filled buys without linked sells, filled sells without a zero
 final position snapshot, ledger/order/fill mismatches, stale previews/approval

--- a/app/mcp_server/tooling/alpaca_paper_ledger_read.py
+++ b/app/mcp_server/tooling/alpaca_paper_ledger_read.py
@@ -127,6 +127,7 @@ async def alpaca_paper_execution_preflight_check(
     expected_signal_symbol: str | None = None,
     expected_execution_symbol: str | None = None,
     stale_after_minutes: int = 30,
+    legacy_cycle_blockers_as_warnings: bool = False,
     lifecycle_correlation_id: str | None = None,
     client_order_id: str | None = None,
     candidate_uuid: str | None = None,
@@ -146,6 +147,10 @@ async def alpaca_paper_execution_preflight_check(
     behavior used by broad cycle runners. ``session_uuid`` is surfaced as a
     response scope marker for decision-session callers; ledger scoping still
     uses correlation/provenance keys because the Alpaca ledger has no session FK.
+    ``legacy_cycle_blockers_as_warnings`` is an explicit Alpaca Paper test-mode
+    switch: residual-position and stale-preview cleanup findings are returned as
+    warnings, while open-order conflicts, duplicate IDs, ledger/fill anomalies,
+    symbol mismatches, and other execution-safety findings remain blockers.
     """
     if limit < 1:
         raise ValueError("limit must be >= 1")
@@ -203,6 +208,7 @@ async def alpaca_paper_execution_preflight_check(
         expected_signal_symbol=expected_signal_symbol,
         expected_execution_symbol=expected_execution_symbol,
         stale_after_minutes=stale_after_minutes,
+        legacy_cycle_blockers_as_warnings=legacy_cycle_blockers_as_warnings,
     )
     data = report.to_dict()
     data.update(
@@ -212,6 +218,7 @@ async def alpaca_paper_execution_preflight_check(
             "source": "alpaca_paper_execution_preflight",
             "read_only": True,
             "limit": limit,
+            "legacy_cycle_blockers_as_warnings": legacy_cycle_blockers_as_warnings,
             "scoped_by": scoped_by,
             "session_uuid": scope["session_uuid"],
         }

--- a/app/services/alpaca_paper_anomaly_checks.py
+++ b/app/services/alpaca_paper_anomaly_checks.py
@@ -294,6 +294,7 @@ def build_paper_execution_preflight_report(
     expected_execution_symbol: str | None = None,
     now: datetime | None = None,
     stale_after_minutes: int = 30,
+    legacy_cycle_blockers_as_warnings: bool = False,
 ) -> PaperExecutionPreflightReport:
     """Build a read-only Alpaca Paper execution preflight anomaly report.
 
@@ -310,6 +311,13 @@ def build_paper_execution_preflight_report(
         expected_execution_symbol: Optional symbol expected at Alpaca Paper.
         now: Clock injection for deterministic tests.
         stale_after_minutes: Preview/approval max age before blocking.
+        legacy_cycle_blockers_as_warnings: When True, downgrade the legacy
+            single-cycle cleanup gates (residual positions and stale preview
+            rows) to warnings. This is intended for Alpaca Paper execution-flow
+            testing where operators deliberately exercise buy/sell/adjust/close
+            paths against an already-used paper account. Open orders,
+            duplicate client IDs, ledger/order/fill mismatches, unclosed sells,
+            missing linked sells, and symbol mismatches still block.
     """
     checked_at = _as_aware_utc(now) or datetime.now(UTC)
     unscoped_ledger = list(ledger_rows)
@@ -359,7 +367,9 @@ def build_paper_execution_preflight_report(
     if residual_positions:
         add(
             "residual_position_exists",
-            PaperExecutionAnomalySeverity.block,
+            PaperExecutionAnomalySeverity.warning
+            if legacy_cycle_blockers_as_warnings
+            else PaperExecutionAnomalySeverity.block,
             "Residual Alpaca Paper position exists before starting a new cycle",
             {
                 "count": len(residual_positions),
@@ -496,7 +506,9 @@ def build_paper_execution_preflight_report(
     if stale_rows:
         add(
             "stale_preview_or_approval_packet",
-            PaperExecutionAnomalySeverity.block,
+            PaperExecutionAnomalySeverity.warning
+            if legacy_cycle_blockers_as_warnings
+            else PaperExecutionAnomalySeverity.block,
             "Preview or approval packet is older than the allowed threshold",
             {
                 "stale_after_minutes": stale_after_minutes,

--- a/tests/services/test_alpaca_paper_anomaly_checks.py
+++ b/tests/services/test_alpaca_paper_anomaly_checks.py
@@ -93,6 +93,23 @@ def test_residual_position_blocks_new_cycle():
 
 
 @pytest.mark.unit
+def test_residual_position_can_warn_in_paper_execution_test_mode():
+    report = build_paper_execution_preflight_report(
+        positions=[{"symbol": "BTCUSD", "qty": "0.001", "asset_class": "crypto"}],
+        legacy_cycle_blockers_as_warnings=True,
+    )
+
+    assert report.status == "pass"
+    assert report.should_block is False
+    anomaly = next(
+        a for a in report.anomalies if a.check_id == "residual_position_exists"
+    )
+    assert anomaly.severity == PaperExecutionAnomalySeverity.warning
+    assert report.counts["warning"] == 1
+    assert report.counts["block"] == 0
+
+
+@pytest.mark.unit
 def test_duplicate_client_order_id_blocks_against_packet_and_ledger():
     report = build_paper_execution_preflight_report(
         ledger_rows=[
@@ -245,6 +262,61 @@ def test_stale_preview_blocks():
     }
     assert anomaly.details["rows"][0]["recommended_lifecycle_state"] == (
         STALE_PREVIEW_CLEANUP_REQUIRED_STATE
+    )
+
+
+@pytest.mark.unit
+def test_stale_preview_can_warn_in_paper_execution_test_mode():
+    now = datetime(2026, 5, 3, 12, 0, tzinfo=UTC)
+    report = build_paper_execution_preflight_report(
+        ledger_rows=[
+            _row(
+                client_order_id="stale-preview",
+                side="buy",
+                lifecycle_state="previewed",
+                order_status=None,
+                filled_qty=None,
+                created_at=now - timedelta(minutes=45),
+            )
+        ],
+        now=now,
+        stale_after_minutes=30,
+        legacy_cycle_blockers_as_warnings=True,
+    )
+
+    assert report.status == "pass"
+    assert report.should_block is False
+    anomaly = next(
+        a for a in report.anomalies if a.check_id == "stale_preview_or_approval_packet"
+    )
+    assert anomaly.severity == PaperExecutionAnomalySeverity.warning
+    assert anomaly.details["recommended_action"] == STALE_PREVIEW_CLEANUP_ACTION
+    assert report.counts["warning"] == 1
+    assert report.counts["block"] == 0
+
+
+@pytest.mark.unit
+def test_test_mode_still_blocks_open_order_conflicts():
+    report = build_paper_execution_preflight_report(
+        open_orders=[
+            {
+                "id": "order-1",
+                "client_order_id": "rob93-open-001",
+                "symbol": "BTCUSD",
+                "status": "accepted",
+                "side": "buy",
+            }
+        ],
+        positions=[{"symbol": "BTCUSD", "qty": "0.001", "asset_class": "crypto"}],
+        legacy_cycle_blockers_as_warnings=True,
+    )
+
+    assert report.status == "blocked"
+    assert report.should_block is True
+    severities = {a.check_id: a.severity for a in report.anomalies}
+    assert severities["unexpected_open_orders"] == PaperExecutionAnomalySeverity.block
+    assert (
+        severities["residual_position_exists"] == PaperExecutionAnomalySeverity.warning
     )
 
 


### PR DESCRIPTION
## Summary
- Add an explicit `legacy_cycle_blockers_as_warnings` switch to Alpaca Paper execution preflight.
- Downgrade only residual-position and stale-preview/approval findings to warnings when the switch is enabled.
- Keep open-order conflicts, duplicate client IDs, ledger/fill anomalies, missing linked sells, unclosed sells, and symbol mismatches as blockers.
- Document the MCP parameter and add unit coverage for default blocker behavior plus paper execution-flow test mode.

## Test Plan
- `uv run ruff format --check app/services/alpaca_paper_anomaly_checks.py app/mcp_server/tooling/alpaca_paper_ledger_read.py tests/services/test_alpaca_paper_anomaly_checks.py`
- `uv run ruff check app/services/alpaca_paper_anomaly_checks.py app/mcp_server/tooling/alpaca_paper_ledger_read.py tests/services/test_alpaca_paper_anomaly_checks.py`
- `uv run pytest tests/services/test_alpaca_paper_anomaly_checks.py -q`

## Safety Notes
- Alpaca Paper only; no live/KIS/Upbit routing changes.
- Default behavior remains fail-closed.
- The relaxed behavior is opt-in via `legacy_cycle_blockers_as_warnings=True` and preserves hard blockers for execution-safety findings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added test-mode option for execution preflight checks that downgrades residual positions and stale approval packet conditions from blockers to warnings, while maintaining other safety checks as blocking.

* **Documentation**
  * Updated documentation to clarify test-mode behavior and affected check conditions.

* **Tests**
  * Added test coverage for test-mode behavior and safety check interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/835)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->