### PR TITLE
feat(upbit-read-model): add official crypto read model

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -217,6 +217,7 @@ class Settings(BaseSettings):
     )
 
     upbit_ohlcv_cache_enabled: bool = True
+    upbit_public_read_model_cache_enabled: bool = True
     upbit_ohlcv_cache_max_days: int = 400
     upbit_ohlcv_cache_lock_ttl_seconds: int = 10
     yahoo_ohlcv_cache_enabled: bool = True

--- a/app/services/brokers/upbit/public_trades.py
+++ b/app/services/brokers/upbit/public_trades.py
@@ -1,0 +1,42 @@
+"""Upbit public recent-trades fetcher (read-only)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.brokers.upbit.client import UPBIT_REST, _request_json
+from app.services.upbit_symbol_universe_service import get_upbit_market_by_coin
+
+UPBIT_TRADES_URL = f"{UPBIT_REST}/trades/ticks"
+_MAX_COUNT = 500
+
+
+async def _normalize_market(market: str) -> str:
+    code = str(market or "").strip().upper()
+    if not code:
+        raise ValueError("market is required")
+    if code.startswith("KRW-"):
+        return code
+    resolved = await get_upbit_market_by_coin(code)
+    if not resolved:
+        raise ValueError(f"unknown Upbit market: {market!r}")
+    return resolved
+
+
+async def fetch_recent_trades(
+    market: str = "KRW-BTC", count: int = 50
+) -> list[dict[str, Any]]:
+    """Return recent public trades for a KRW Upbit market.
+
+    This is read-only and only calls Upbit's public /v1/trades/ticks endpoint.
+    Transport/status errors are deliberately propagated so callers can classify
+    them into freshness/error envelopes.
+    """
+    normalized = await _normalize_market(market)
+    bounded = max(1, min(int(count), _MAX_COUNT))
+    rows = await _request_json(
+        UPBIT_TRADES_URL, params={"market": normalized, "count": bounded}
+    )
+    if not isinstance(rows, list):
+        raise ValueError("unexpected Upbit trades response shape")
+    return list(rows)

--- a/app/services/invest_view_model/crypto_dashboard_service.py
+++ b/app/services/invest_view_model/crypto_dashboard_service.py
@@ -25,12 +25,8 @@ from app.schemas.invest_crypto import (
 )
 from app.services.invest_view_model.relation_resolver import RelationResolver
 
-TickerProvider = Callable[
-    [list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]
-]
-OrderbookSpreadProvider = Callable[
-    [list[str]], Awaitable[dict[str, float | None]] | dict[str, float | None]
-]
+TickerProvider = Callable[[list[str]], Awaitable[Any] | Any]
+OrderbookSpreadProvider = Callable[[list[str]], Awaitable[Any] | Any]
 
 
 async def _maybe_await(value):
@@ -75,32 +71,54 @@ def _pending_symbol_variants(symbols: Sequence[str]) -> set[str]:
     return variants
 
 
-async def _default_ticker_provider(markets: list[str]) -> list[dict[str, Any]]:
-    from app.services.brokers.upbit.client import fetch_multiple_tickers
+async def _default_ticker_provider(markets: list[str]):
+    from app.services.upbit_public_read_model import get_default_read_model
 
-    return await fetch_multiple_tickers(markets)
+    read_model = await get_default_read_model()
+    return await read_model.get_tickers(markets)
 
 
-async def _default_orderbook_spread_provider(
-    markets: list[str],
-) -> dict[str, float | None]:
-    from app.services.upbit_orderbook import fetch_multiple_orderbooks
+async def _default_orderbook_spread_provider(markets: list[str]):
+    from app.services.upbit_public_read_model import get_default_read_model
 
-    spreads: dict[str, float | None] = {}
-    orderbooks = await fetch_multiple_orderbooks(markets)
-    for market, book in orderbooks.items():
-        units = list(book.get("orderbook_units") or [])
-        if not units:
-            spreads[str(market).upper()] = None
-            continue
-        best = units[0]
-        ask = _float_or_none(best.get("ask_price"))
-        bid = _float_or_none(best.get("bid_price"))
-        if ask is None or bid is None or bid <= 0:
-            spreads[str(market).upper()] = None
-            continue
-        spreads[str(market).upper()] = ((ask - bid) / bid) * 100
-    return spreads
+    read_model = await get_default_read_model()
+    return await read_model.get_orderbooks(markets)
+
+
+def _normalize_ticker_provider_result(
+    result: Any,
+) -> tuple[dict[str, dict[str, Any]], Any | None]:
+    if hasattr(result, "tickers") and hasattr(result, "meta"):
+        return dict(result.tickers), result.meta
+    return _ticker_map(result or []), None
+
+
+def _normalize_orderbook_provider_result(
+    result: Any,
+) -> tuple[dict[str, float | None], Any | None]:
+    if hasattr(result, "spreadsPct") and hasattr(result, "meta"):
+        return {
+            str(k).upper(): v for k, v in dict(result.spreadsPct).items()
+        }, result.meta
+    return {str(k).upper(): v for k, v in dict(result or {}).items()}, None
+
+
+def _crypto_source_from_upbit_meta(
+    meta: Any, *, fallback_source: str, fallback_label: str, fetched_at: datetime
+) -> CryptoSourceState:
+    if meta is not None:
+        try:
+            from app.services.upbit_public_read_model import to_crypto_source_state
+
+            return to_crypto_source_state(meta)
+        except Exception:  # noqa: BLE001 - fallback keeps dashboard renderable
+            pass
+    return CryptoSourceState(
+        source=fallback_source,
+        state="supported",
+        label=fallback_label,
+        fetchedAt=fetched_at,
+    )
 
 
 async def _load_active_krw_markets(
@@ -192,13 +210,14 @@ async def build_crypto_dashboard(
     if markets:
         provider = ticker_provider or _default_ticker_provider
         try:
-            tickers = _ticker_map(await _maybe_await(provider(markets)))
+            result = await _maybe_await(provider(markets))
+            tickers, ticker_meta = _normalize_ticker_provider_result(result)
             sources.append(
-                CryptoSourceState(
-                    source="upbit_ticker",
-                    state="supported",
-                    label="Upbit ticker",
-                    fetchedAt=now,
+                _crypto_source_from_upbit_meta(
+                    ticker_meta,
+                    fallback_source="upbit_ticker",
+                    fallback_label="Upbit ticker",
+                    fetched_at=now,
                 )
             )
         except Exception:
@@ -215,14 +234,14 @@ async def build_crypto_dashboard(
             orderbook_spread_provider or _default_orderbook_spread_provider
         )
         try:
-            raw_spreads = await _maybe_await(spread_provider(markets[:orderbook_limit]))
-            spreads = {str(k).upper(): v for k, v in dict(raw_spreads).items()}
+            raw_result = await _maybe_await(spread_provider(markets[:orderbook_limit]))
+            spreads, orderbook_meta = _normalize_orderbook_provider_result(raw_result)
             sources.append(
-                CryptoSourceState(
-                    source="upbit_orderbook",
-                    state="supported",
-                    label="Upbit orderbook",
-                    fetchedAt=now,
+                _crypto_source_from_upbit_meta(
+                    orderbook_meta,
+                    fallback_source="upbit_orderbook",
+                    fallback_label="Upbit orderbook",
+                    fetched_at=now,
                 )
             )
         except Exception:

--- a/app/services/upbit_public_read_model/__init__.py
+++ b/app/services/upbit_public_read_model/__init__.py
@@ -1,0 +1,35 @@
+"""Public exports for the Upbit official public read-model cache."""
+
+from app.services.upbit_public_read_model.read_model import (
+    UpbitPublicReadModel,
+    get_default_read_model,
+)
+from app.services.upbit_public_read_model.types import (
+    UpbitBlockMeta,
+    UpbitBlockState,
+    UpbitCandlesBlock,
+    UpbitMarketWarningEntry,
+    UpbitMarketWarningsBlock,
+    UpbitOrderbookBlock,
+    UpbitPublicSnapshot,
+    UpbitSource,
+    UpbitTickerBlock,
+    UpbitTradesBlock,
+    to_crypto_source_state,
+)
+
+__all__ = [
+    "UpbitPublicReadModel",
+    "get_default_read_model",
+    "UpbitBlockMeta",
+    "UpbitBlockState",
+    "UpbitCandlesBlock",
+    "UpbitMarketWarningEntry",
+    "UpbitMarketWarningsBlock",
+    "UpbitOrderbookBlock",
+    "UpbitPublicSnapshot",
+    "UpbitSource",
+    "UpbitTickerBlock",
+    "UpbitTradesBlock",
+    "to_crypto_source_state",
+]

--- a/app/services/upbit_public_read_model/__init__.py
+++ b/app/services/upbit_public_read_model/__init__.py
@@ -2,6 +2,7 @@
 
 from app.services.upbit_public_read_model.read_model import (
     UpbitPublicReadModel,
+    close_default_read_model,
     get_default_read_model,
 )
 from app.services.upbit_public_read_model.types import (
@@ -20,6 +21,7 @@ from app.services.upbit_public_read_model.types import (
 
 __all__ = [
     "UpbitPublicReadModel",
+    "close_default_read_model",
     "get_default_read_model",
     "UpbitBlockMeta",
     "UpbitBlockState",

--- a/app/services/upbit_public_read_model/cache_common.py
+++ b/app/services/upbit_public_read_model/cache_common.py
@@ -1,0 +1,67 @@
+"""Internal cache helpers for Upbit public read-model modules."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def cache_enabled() -> bool:
+    return bool(getattr(settings, "upbit_public_read_model_cache_enabled", True))
+
+
+def classify_error(exc: BaseException) -> str:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return "rate_limited" if exc.response.status_code == 429 else "http_error"
+    if isinstance(exc, (httpx.TimeoutException, TimeoutError)):
+        return "timeout"
+    return "unknown"
+
+
+async def read_json(redis_client: Any, key: str) -> dict[str, Any] | None:
+    if not cache_enabled():
+        return None
+    try:
+        raw = await redis_client.get(key)
+    except Exception as exc:  # noqa: BLE001 — cache outage should degrade to miss
+        logger.warning("upbit_public_read_model cache read failed key=%s: %s", key, exc)
+        return None
+    if not raw:
+        return None
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8")
+    try:
+        obj = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    for field in ("fetchedAt", "cachedAt"):
+        if obj.get(field):
+            obj[field] = datetime.fromisoformat(obj[field])
+    return obj
+
+
+async def write_json(
+    redis_client: Any, key: str, payload: dict[str, Any], *, ex: int
+) -> None:
+    if not cache_enabled():
+        return
+
+    def default(value: Any) -> str:
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return str(value)
+
+    try:
+        await redis_client.set(key, json.dumps(payload, default=default), ex=ex)
+    except Exception as exc:  # noqa: BLE001 — fresh upstream data is still usable
+        logger.warning(
+            "upbit_public_read_model cache write failed key=%s: %s", key, exc
+        )

--- a/app/services/upbit_public_read_model/candles_cache.py
+++ b/app/services/upbit_public_read_model/candles_cache.py
@@ -1,0 +1,82 @@
+"""Thin Upbit public candles wrapper over the existing closed-candle cache."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal
+
+import pandas as pd
+
+from app.services.upbit_public_read_model.cache_common import classify_error
+from app.services.upbit_public_read_model.types import (
+    UpbitBlockMeta,
+    UpbitCandlesBlock,
+    _now_utc,
+)
+
+Period = Literal["day", "week", "month"]
+
+
+class CandlesCache:
+    def __init__(
+        self,
+        *,
+        closed_candles_getter: Callable[..., Awaitable[pd.DataFrame | None]]
+        | None = None,
+    ) -> None:
+        self._closed_candles_getter = closed_candles_getter
+
+    async def get(
+        self, market: str, *, period: Period, count: int = 30
+    ) -> UpbitCandlesBlock:
+        if period not in {"day", "week", "month"}:
+            raise ValueError("period must be one of: day, week, month")
+        normalized_market = str(market or "").strip().upper()
+        now = _now_utc()
+        try:
+            getter = self._closed_candles_getter
+            if getter is None:
+                from app.services.upbit_ohlcv_cache import get_closed_candles
+
+                getter = get_closed_candles
+            frame = await getter(normalized_market, count=count, period=period)
+            rows = _frame_to_rows(frame)
+            state = "fresh" if rows else "missing"
+            return UpbitCandlesBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_candles",
+                    state=state,
+                    label="Upbit candles",
+                    fetchedAt=now,
+                ),
+                market=normalized_market,
+                period=period,
+                rows=rows,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return UpbitCandlesBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_candles",
+                    state="unavailable",
+                    label="Upbit candles",
+                    errorReason=classify_error(exc),
+                ),
+                market=normalized_market,
+                period=period,
+                rows=[],
+            )
+
+
+def _frame_to_rows(frame: pd.DataFrame | None) -> list[dict[str, Any]]:
+    if frame is None or frame.empty:
+        return []
+    rows: list[dict[str, Any]] = []
+    for _, row in frame.reset_index().iterrows():
+        item: dict[str, Any] = {}
+        for key, value in row.items():
+            if hasattr(value, "isoformat"):
+                item[str(key)] = value.isoformat()
+            else:
+                item[str(key)] = value.item() if hasattr(value, "item") else value
+        rows.append(item)
+    return rows

--- a/app/services/upbit_public_read_model/market_warnings.py
+++ b/app/services/upbit_public_read_model/market_warnings.py
@@ -1,0 +1,145 @@
+"""Read-only Upbit market-warning read model."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from typing import Any, Protocol
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import AsyncSessionLocal
+from app.models.upbit_symbol_universe import UpbitSymbolUniverse
+from app.services.upbit_public_read_model.cache_common import (
+    classify_error,
+    read_json,
+    write_json,
+)
+from app.services.upbit_public_read_model.types import (
+    WARNINGS_STALE_TOLERANCE_SECONDS,
+    WARNINGS_TTL_SECONDS,
+    UpbitBlockMeta,
+    UpbitMarketWarningEntry,
+    UpbitMarketWarningsBlock,
+    _now_utc,
+)
+
+_UPBIT_MARKET_ALL_URL = "https://api.upbit.com/v1/market/all"
+_WARNINGS_KEY = "upbit:public:read:warnings:v1"
+
+
+class MarketWarningsProvider(Protocol):
+    def __call__(
+        self, markets: list[str] | None = None
+    ) -> Awaitable[UpbitMarketWarningsBlock]: ...
+
+
+async def fetch_market_event_details() -> list[dict[str, Any]]:
+    timeout = httpx.Timeout(10.0)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.get(_UPBIT_MARKET_ALL_URL, params={"isDetails": "true"})
+        response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, list):
+        raise ValueError("unexpected Upbit market/all response shape")
+    return payload
+
+
+class MarketWarningsService:
+    def __init__(
+        self,
+        *,
+        redis=None,
+        db_session_factory=AsyncSessionLocal,
+        detail_fetcher=fetch_market_event_details,
+    ) -> None:
+        self._redis = redis
+        self._db_session_factory = db_session_factory
+        self._detail_fetcher = detail_fetcher
+
+    async def get(
+        self,
+        markets: list[str] | None = None,
+        *,
+        include_event_detail: bool = False,
+        db: AsyncSession | None = None,
+    ) -> UpbitMarketWarningsBlock:
+        requested = {m.upper() for m in markets} if markets else None
+
+        async def load(session: AsyncSession) -> list[UpbitSymbolUniverse]:
+            stmt = select(UpbitSymbolUniverse).where(
+                UpbitSymbolUniverse.quote_currency == "KRW",
+                UpbitSymbolUniverse.is_active.is_(True),
+            )
+            if requested:
+                stmt = stmt.where(UpbitSymbolUniverse.market.in_(sorted(requested)))
+            result = await session.execute(
+                stmt.order_by(UpbitSymbolUniverse.market.asc())
+            )
+            return list(result.scalars().all())
+
+        if db is None:
+            async with self._db_session_factory() as session:
+                rows = await load(session)
+        else:
+            rows = await load(db)
+        latest = max((getattr(row, "updated_at", None) for row in rows), default=None)
+        entries = {
+            row.market.upper(): UpbitMarketWarningEntry(
+                market=row.market.upper(), warning=(row.market_warning or "NONE")
+            )
+            for row in rows
+        }
+        state = "fresh" if entries else "missing"
+        label = "Upbit market warnings (universe)"
+        error_reason = None
+        if include_event_detail and entries:
+            try:
+                details = await self._get_detail_rows()
+                by_market = {
+                    str(item.get("market") or "").upper(): item for item in details
+                }
+                for market, entry in list(entries.items()):
+                    event = by_market.get(market, {}).get("market_event")
+                    entries[market] = entry.model_copy(update={"event": event})
+            except Exception as exc:  # noqa: BLE001
+                state = "stale" if entries else "unavailable"
+                error_reason = classify_error(exc)
+        return UpbitMarketWarningsBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_market_warnings",
+                state=state,
+                label=label,
+                fetchedAt=latest or _now_utc(),
+                ttlSeconds=WARNINGS_TTL_SECONDS,
+                errorReason=error_reason,
+            ),
+            entries=entries,
+        )
+
+    async def _get_detail_rows(self) -> list[dict[str, Any]]:
+        if self._redis is not None:
+            cached = await read_json(self._redis, _WARNINGS_KEY)
+            now = _now_utc()
+            if (
+                cached
+                and (now - cached["cachedAt"]).total_seconds() <= WARNINGS_TTL_SECONDS
+            ):
+                return list(cached["rows"])
+        rows = await self._detail_fetcher()
+        if self._redis is not None:
+            now = _now_utc()
+            await write_json(
+                self._redis,
+                _WARNINGS_KEY,
+                {"rows": rows, "fetchedAt": now, "cachedAt": now},
+                ex=WARNINGS_STALE_TOLERANCE_SECONDS,
+            )
+        return rows
+
+
+async def db_universe_warnings_provider(
+    markets: list[str] | None = None,
+) -> UpbitMarketWarningsBlock:
+    return await MarketWarningsService().get(markets)

--- a/app/services/upbit_public_read_model/orderbook_cache.py
+++ b/app/services/upbit_public_read_model/orderbook_cache.py
@@ -1,0 +1,150 @@
+"""Redis-cached Upbit orderbook fetcher with derived spread metadata."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import Any
+
+from app.services.upbit_public_read_model.cache_common import (
+    classify_error,
+    read_json,
+    write_json,
+)
+from app.services.upbit_public_read_model.types import (
+    ORDERBOOK_STALE_TOLERANCE_SECONDS,
+    ORDERBOOK_TTL_SECONDS,
+    UpbitBlockMeta,
+    UpbitOrderbookBlock,
+    _now_utc,
+)
+
+logger = logging.getLogger(__name__)
+OrderbookFetcher = Callable[[list[str]], Awaitable[dict[str, dict[str, Any]]]]
+_NS = "upbit:public:read:orderbook:v1"
+
+
+def _key(market: str) -> str:
+    return f"{_NS}:{market.upper()}"
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        return None if value is None else float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _spread_pct(book: dict[str, Any]) -> float | None:
+    units = list(book.get("orderbook_units") or [])
+    if not units:
+        return None
+    ask = _float_or_none(units[0].get("ask_price"))
+    bid = _float_or_none(units[0].get("bid_price"))
+    if ask is None or bid is None or bid <= 0:
+        return None
+    return ((ask - bid) / bid) * 100
+
+
+class OrderbookCache:
+    def __init__(self, *, redis, fetcher: OrderbookFetcher) -> None:
+        self._redis = redis
+        self._fetcher = fetcher
+
+    async def get(self, markets: list[str]) -> UpbitOrderbookBlock:
+        markets = [str(m).upper() for m in markets if str(m or "").strip()]
+        if not markets:
+            return UpbitOrderbookBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_orderbook", state="missing", label="Upbit orderbook"
+                )
+            )
+        now = _now_utc()
+        cached_by_market = {m: await read_json(self._redis, _key(m)) for m in markets}
+        fresh = {
+            m: c["orderbook"]
+            for m, c in cached_by_market.items()
+            if c and (now - c["cachedAt"]).total_seconds() <= ORDERBOOK_TTL_SECONDS
+        }
+        missing = [m for m in markets if m not in fresh]
+        books = dict(fresh)
+        reason = None
+        state = "fresh"
+        if missing:
+            try:
+                fetched = await self._fetcher(missing)
+                fetched = {str(k).upper(): v for k, v in fetched.items()}
+                for market, book in fetched.items():
+                    await write_json(
+                        self._redis,
+                        _key(market),
+                        {"orderbook": book, "fetchedAt": now, "cachedAt": now},
+                        ex=ORDERBOOK_STALE_TOLERANCE_SECONDS,
+                    )
+                books.update(fetched)
+                unfetched = [m for m in missing if m not in fetched]
+                if unfetched:
+                    reason = "partial_missing"
+                    stale = self._stale_books(cached_by_market, now, markets=unfetched)
+                    books.update(stale)
+                    state = "stale" if books else "unavailable"
+            except Exception as exc:  # noqa: BLE001
+                reason = classify_error(exc)
+                logger.warning("upbit_orderbook_cache fetch failed reason=%s", reason)
+                stale = self._stale_books(cached_by_market, now, markets=missing)
+                books.update(stale)
+                state = "stale" if books else "unavailable"
+        fetched_at = now
+        cached_at = now if books and state == "fresh" else None
+        if state == "stale":
+            cached_vals = [c for c in cached_by_market.values() if c]
+            fetched_at = max((c["fetchedAt"] for c in cached_vals), default=now)
+            cached_at = max((c["cachedAt"] for c in cached_vals), default=None)
+        return self._block(
+            books,
+            state=state,
+            fetched_at=fetched_at if books else None,
+            cached_at=cached_at,
+            error_reason=reason,
+        )
+
+    @staticmethod
+    def _stale_books(
+        cached_by_market: dict[str, dict[str, Any] | None],
+        now: datetime,
+        *,
+        markets: list[str],
+    ) -> dict[str, dict[str, Any]]:
+        requested = set(markets)
+        return {
+            market: cached["orderbook"]
+            for market, cached in cached_by_market.items()
+            if market in requested
+            and cached
+            and (now - cached["cachedAt"]).total_seconds()
+            <= ORDERBOOK_STALE_TOLERANCE_SECONDS
+        }
+
+    def _block(
+        self,
+        books: dict[str, dict[str, Any]],
+        *,
+        state: str,
+        fetched_at: datetime | None,
+        cached_at: datetime | None,
+        error_reason: str | None = None,
+    ) -> UpbitOrderbookBlock:
+        return UpbitOrderbookBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_orderbook",
+                state=state,
+                label="Upbit orderbook",
+                fetchedAt=fetched_at,
+                cachedAt=cached_at,
+                ttlSeconds=ORDERBOOK_TTL_SECONDS,
+                errorReason=error_reason,
+            ),
+            orderbooks=books,
+            spreadsPct={m: _spread_pct(b) for m, b in books.items()},
+        )

--- a/app/services/upbit_public_read_model/read_model.py
+++ b/app/services/upbit_public_read_model/read_model.py
@@ -17,6 +17,9 @@ from app.services.upbit_public_read_model.trades_cache import TradesCache
 from app.services.upbit_public_read_model.types import UpbitPublicSnapshot, _now_utc
 
 _TRADES_CONCURRENCY = 4
+_DEFAULT_READ_MODEL: UpbitPublicReadModel | None = None
+_DEFAULT_REDIS_CLIENT: Any | None = None
+_DEFAULT_READ_MODEL_LOCK = asyncio.Lock()
 
 
 class UpbitPublicReadModel:
@@ -83,14 +86,11 @@ class UpbitPublicReadModel:
         )
 
 
-async def get_default_read_model(redis_client=None) -> UpbitPublicReadModel:
+def _build_read_model(redis_client) -> UpbitPublicReadModel:
     from app.services.brokers.upbit.client import fetch_multiple_tickers
     from app.services.brokers.upbit.public_trades import fetch_recent_trades
-    from app.services.ohlcv_cache_common import create_redis_client
     from app.services.upbit_orderbook import fetch_multiple_orderbooks
 
-    if redis_client is None:
-        redis_client = await create_redis_client()
     return UpbitPublicReadModel(
         redis=redis_client,
         ticker_fetcher=fetch_multiple_tickers,
@@ -98,3 +98,35 @@ async def get_default_read_model(redis_client=None) -> UpbitPublicReadModel:
         trades_fetcher=fetch_recent_trades,
         warnings_provider=db_universe_warnings_provider,
     )
+
+
+async def get_default_read_model(redis_client=None) -> UpbitPublicReadModel:
+    """Return the shared default Upbit read model unless a custom client is injected."""
+    if redis_client is not None:
+        return _build_read_model(redis_client)
+
+    global _DEFAULT_READ_MODEL, _DEFAULT_REDIS_CLIENT
+    if _DEFAULT_READ_MODEL is None:
+        async with _DEFAULT_READ_MODEL_LOCK:
+            if _DEFAULT_READ_MODEL is None:
+                from app.services.ohlcv_cache_common import create_redis_client
+
+                _DEFAULT_REDIS_CLIENT = await create_redis_client()
+                _DEFAULT_READ_MODEL = _build_read_model(_DEFAULT_REDIS_CLIENT)
+    return _DEFAULT_READ_MODEL
+
+
+async def close_default_read_model() -> None:
+    """Close and reset the shared default Redis client/read model."""
+    global _DEFAULT_READ_MODEL, _DEFAULT_REDIS_CLIENT
+    redis_client = _DEFAULT_REDIS_CLIENT
+    _DEFAULT_READ_MODEL = None
+    _DEFAULT_REDIS_CLIENT = None
+    if redis_client is None:
+        return
+    close = getattr(redis_client, "aclose", None) or getattr(redis_client, "close", None)
+    if close is None:
+        return
+    result = close()
+    if asyncio.iscoroutine(result):
+        await result

--- a/app/services/upbit_public_read_model/read_model.py
+++ b/app/services/upbit_public_read_model/read_model.py
@@ -1,0 +1,100 @@
+"""Composition root for the Upbit public read-model cache."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any
+
+from app.services.upbit_public_read_model.candles_cache import CandlesCache
+from app.services.upbit_public_read_model.market_warnings import (
+    MarketWarningsProvider,
+    db_universe_warnings_provider,
+)
+from app.services.upbit_public_read_model.orderbook_cache import OrderbookCache
+from app.services.upbit_public_read_model.ticker_cache import TickerCache
+from app.services.upbit_public_read_model.trades_cache import TradesCache
+from app.services.upbit_public_read_model.types import UpbitPublicSnapshot, _now_utc
+
+_TRADES_CONCURRENCY = 4
+
+
+class UpbitPublicReadModel:
+    def __init__(
+        self,
+        *,
+        redis,
+        ticker_fetcher: Callable[[list[str]], Awaitable[list[dict[str, Any]]]],
+        orderbook_fetcher: Callable[[list[str]], Awaitable[dict[str, dict[str, Any]]]],
+        trades_fetcher: Callable[[str, int], Awaitable[list[dict[str, Any]]]],
+        warnings_provider: MarketWarningsProvider = db_universe_warnings_provider,
+    ) -> None:
+        self._ticker = TickerCache(redis=redis, fetcher=ticker_fetcher)
+        self._orderbook = OrderbookCache(redis=redis, fetcher=orderbook_fetcher)
+        self._trades = TradesCache(redis=redis, fetcher=trades_fetcher)
+        self._candles = CandlesCache()
+        self._warnings_provider = warnings_provider
+
+    async def get_tickers(self, markets: Iterable[str]):
+        return await self._ticker.get(list(markets))
+
+    async def get_orderbooks(self, markets: Iterable[str]):
+        return await self._orderbook.get(list(markets))
+
+    async def get_recent_trades(self, market: str, count: int = 50):
+        return await self._trades.get(market, count)
+
+    async def get_candles(self, market: str, *, period, count: int):
+        return await self._candles.get(market, period=period, count=count)
+
+    async def get_market_warnings(self, markets: Iterable[str] | None = None):
+        return await self._warnings_provider(list(markets) if markets else None)
+
+    async def snapshot(
+        self, markets: list[str], *, include_trades_for: list[str] | None = None
+    ) -> UpbitPublicSnapshot:
+        now = _now_utc()
+        ticker, orderbook, warnings = await asyncio.gather(
+            self._ticker.get(markets),
+            self._orderbook.get(markets),
+            self._warnings_provider(markets),
+        )
+        trades_block = None
+        if include_trades_for:
+            sem = asyncio.Semaphore(_TRADES_CONCURRENCY)
+
+            async def one(market: str):
+                async with sem:
+                    return await self._trades.get(market, 50)
+
+            trades_block = TradesCache.merge(
+                await asyncio.gather(*(one(m) for m in include_trades_for))
+            )
+        sources = [ticker.meta, orderbook.meta, warnings.meta]
+        if trades_block is not None:
+            sources.append(trades_block.meta)
+        return UpbitPublicSnapshot(
+            asOf=now,
+            ticker=ticker,
+            orderbook=orderbook,
+            trades=trades_block,
+            marketWarnings=warnings,
+            sources=sources,
+        )
+
+
+async def get_default_read_model(redis_client=None) -> UpbitPublicReadModel:
+    from app.services.brokers.upbit.client import fetch_multiple_tickers
+    from app.services.brokers.upbit.public_trades import fetch_recent_trades
+    from app.services.ohlcv_cache_common import create_redis_client
+    from app.services.upbit_orderbook import fetch_multiple_orderbooks
+
+    if redis_client is None:
+        redis_client = await create_redis_client()
+    return UpbitPublicReadModel(
+        redis=redis_client,
+        ticker_fetcher=fetch_multiple_tickers,
+        orderbook_fetcher=fetch_multiple_orderbooks,
+        trades_fetcher=fetch_recent_trades,
+        warnings_provider=db_universe_warnings_provider,
+    )

--- a/app/services/upbit_public_read_model/read_model.py
+++ b/app/services/upbit_public_read_model/read_model.py
@@ -124,7 +124,9 @@ async def close_default_read_model() -> None:
     _DEFAULT_REDIS_CLIENT = None
     if redis_client is None:
         return
-    close = getattr(redis_client, "aclose", None) or getattr(redis_client, "close", None)
+    close = getattr(redis_client, "aclose", None) or getattr(
+        redis_client, "close", None
+    )
     if close is None:
         return
     result = close()

--- a/app/services/upbit_public_read_model/ticker_cache.py
+++ b/app/services/upbit_public_read_model/ticker_cache.py
@@ -1,0 +1,118 @@
+"""Redis-cached Upbit ticker fetcher with freshness/error envelope."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import Any
+
+from app.services.upbit_public_read_model.cache_common import (
+    classify_error,
+    read_json,
+    write_json,
+)
+from app.services.upbit_public_read_model.types import (
+    TICKER_STALE_TOLERANCE_SECONDS,
+    TICKER_TTL_SECONDS,
+    UpbitBlockMeta,
+    UpbitTickerBlock,
+    _now_utc,
+)
+
+logger = logging.getLogger(__name__)
+TickerFetcher = Callable[[list[str]], Awaitable[list[dict[str, Any]]]]
+_NS = "upbit:public:read:ticker:v1"
+
+
+def _key(markets: list[str]) -> str:
+    digest = hashlib.sha1(
+        ",".join(sorted({m.upper() for m in markets})).encode("utf-8")
+    ).hexdigest()
+    return f"{_NS}:{digest}"
+
+
+class TickerCache:
+    def __init__(self, *, redis, fetcher: TickerFetcher) -> None:
+        self._redis = redis
+        self._fetcher = fetcher
+
+    async def get(self, markets: list[str]) -> UpbitTickerBlock:
+        markets = [str(m).upper() for m in markets if str(m or "").strip()]
+        if not markets:
+            return UpbitTickerBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_ticker", state="missing", label="Upbit ticker"
+                )
+            )
+        key = _key(markets)
+        cached = await read_json(self._redis, key)
+        now = _now_utc()
+        if (
+            cached is not None
+            and (now - cached["cachedAt"]).total_seconds() <= TICKER_TTL_SECONDS
+        ):
+            return self._block(
+                cached["tickers"],
+                state="fresh",
+                fetched_at=cached["fetchedAt"],
+                cached_at=cached["cachedAt"],
+            )
+        try:
+            rows = await self._fetcher(markets)
+            tickers = {
+                str(r.get("market") or "").upper(): r for r in rows if r.get("market")
+            }
+            await write_json(
+                self._redis,
+                key,
+                {"tickers": tickers, "fetchedAt": now, "cachedAt": now},
+                ex=TICKER_STALE_TOLERANCE_SECONDS,
+            )
+            return self._block(tickers, state="fresh", fetched_at=now, cached_at=now)
+        except Exception as exc:  # noqa: BLE001
+            reason = classify_error(exc)
+            logger.warning("upbit_ticker_cache fetch failed reason=%s", reason)
+            if (
+                cached is not None
+                and (now - cached["cachedAt"]).total_seconds()
+                <= TICKER_STALE_TOLERANCE_SECONDS
+            ):
+                return self._block(
+                    cached["tickers"],
+                    state="stale",
+                    fetched_at=cached["fetchedAt"],
+                    cached_at=cached["cachedAt"],
+                    error_reason=reason,
+                )
+            return UpbitTickerBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_ticker",
+                    state="unavailable",
+                    label="Upbit ticker",
+                    errorReason=reason,
+                )
+            )
+
+    def _block(
+        self,
+        tickers: dict[str, dict[str, Any]],
+        *,
+        state: str,
+        fetched_at: datetime,
+        cached_at: datetime | None,
+        error_reason: str | None = None,
+    ) -> UpbitTickerBlock:
+        return UpbitTickerBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_ticker",
+                state=state,
+                label="Upbit ticker",
+                fetchedAt=fetched_at,
+                cachedAt=cached_at,
+                ttlSeconds=TICKER_TTL_SECONDS,
+                errorReason=error_reason,
+            ),
+            tickers=tickers,
+        )

--- a/app/services/upbit_public_read_model/trades_cache.py
+++ b/app/services/upbit_public_read_model/trades_cache.py
@@ -1,0 +1,141 @@
+"""Redis-cached Upbit recent trades fetcher."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import Any
+
+from app.services.upbit_public_read_model.cache_common import (
+    classify_error,
+    read_json,
+    write_json,
+)
+from app.services.upbit_public_read_model.types import (
+    TRADES_STALE_TOLERANCE_SECONDS,
+    TRADES_TTL_SECONDS,
+    UpbitBlockMeta,
+    UpbitTradesBlock,
+    _now_utc,
+)
+
+logger = logging.getLogger(__name__)
+TradesFetcher = Callable[[str, int], Awaitable[list[dict[str, Any]]]]
+_NS = "upbit:public:read:trades:v1"
+_MAX_COUNT = 500
+_STATE_RANK = {"fresh": 0, "missing": 1, "stale": 2, "unavailable": 3}
+
+
+def _key(market: str, count: int) -> str:
+    return f"{_NS}:{market.upper()}:{count}"
+
+
+class TradesCache:
+    def __init__(self, *, redis, fetcher: TradesFetcher) -> None:
+        self._redis = redis
+        self._fetcher = fetcher
+
+    async def get(self, market: str, count: int = 50) -> UpbitTradesBlock:
+        market = str(market or "").strip().upper()
+        count = max(1, min(int(count), _MAX_COUNT))
+        if not market:
+            return UpbitTradesBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_trades", state="missing", label="Upbit trades"
+                )
+            )
+        key = _key(market, count)
+        cached = await read_json(self._redis, key)
+        now = _now_utc()
+        if (
+            cached is not None
+            and (now - cached["cachedAt"]).total_seconds() <= TRADES_TTL_SECONDS
+        ):
+            return self._block(
+                {market: cached["rows"]},
+                state="fresh",
+                fetched_at=cached["fetchedAt"],
+                cached_at=cached["cachedAt"],
+            )
+        try:
+            rows = await self._fetcher(market, count)
+            await write_json(
+                self._redis,
+                key,
+                {"rows": rows, "fetchedAt": now, "cachedAt": now},
+                ex=TRADES_STALE_TOLERANCE_SECONDS,
+            )
+            return self._block(
+                {market: list(rows)}, state="fresh", fetched_at=now, cached_at=now
+            )
+        except Exception as exc:  # noqa: BLE001
+            reason = classify_error(exc)
+            logger.warning("upbit_trades_cache fetch failed reason=%s", reason)
+            if (
+                cached is not None
+                and (now - cached["cachedAt"]).total_seconds()
+                <= TRADES_STALE_TOLERANCE_SECONDS
+            ):
+                return self._block(
+                    {market: cached["rows"]},
+                    state="stale",
+                    fetched_at=cached["fetchedAt"],
+                    cached_at=cached["cachedAt"],
+                    error_reason=reason,
+                )
+            return UpbitTradesBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_trades",
+                    state="unavailable",
+                    label="Upbit trades",
+                    errorReason=reason,
+                )
+            )
+
+    @classmethod
+    def merge(cls, blocks: list[UpbitTradesBlock]) -> UpbitTradesBlock:
+        if not blocks:
+            return UpbitTradesBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_trades", state="missing", label="Upbit trades"
+                )
+            )
+        worst = max(blocks, key=lambda b: _STATE_RANK[b.meta.state])
+        merged: dict[str, list[dict[str, Any]]] = {}
+        for block in blocks:
+            merged.update(block.trades)
+        return UpbitTradesBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_trades",
+                state=worst.meta.state,
+                label="Upbit trades",
+                fetchedAt=worst.meta.fetchedAt,
+                cachedAt=worst.meta.cachedAt,
+                ttlSeconds=TRADES_TTL_SECONDS,
+                errorReason=worst.meta.errorReason,
+            ),
+            trades=merged,
+        )
+
+    def _block(
+        self,
+        trades: dict[str, list[dict[str, Any]]],
+        *,
+        state: str,
+        fetched_at: datetime,
+        cached_at: datetime | None,
+        error_reason: str | None = None,
+    ) -> UpbitTradesBlock:
+        return UpbitTradesBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_trades",
+                state=state,
+                label="Upbit trades",
+                fetchedAt=fetched_at,
+                cachedAt=cached_at,
+                ttlSeconds=TRADES_TTL_SECONDS,
+                errorReason=error_reason,
+            ),
+            trades=trades,
+        )

--- a/app/services/upbit_public_read_model/types.py
+++ b/app/services/upbit_public_read_model/types.py
@@ -1,0 +1,108 @@
+"""DTOs and shared helpers for the Upbit public read-model cache."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+UpbitBlockState = Literal["fresh", "stale", "unavailable", "missing"]
+UpbitSource = Literal[
+    "upbit_ticker",
+    "upbit_orderbook",
+    "upbit_trades",
+    "upbit_candles",
+    "upbit_market_warnings",
+    "upbit_balances",
+    "local_pending_orders",
+]
+
+TICKER_TTL_SECONDS = 5
+TICKER_STALE_TOLERANCE_SECONDS = 60
+ORDERBOOK_TTL_SECONDS = 3
+ORDERBOOK_STALE_TOLERANCE_SECONDS = 30
+TRADES_TTL_SECONDS = 5
+TRADES_STALE_TOLERANCE_SECONDS = 30
+WARNINGS_TTL_SECONDS = 300
+WARNINGS_STALE_TOLERANCE_SECONDS = 1800
+
+
+def _now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+class UpbitBlockMeta(BaseModel):
+    """Per-block freshness/error envelope. Mirrors CryptoSourceState shape."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    source: UpbitSource
+    state: UpbitBlockState
+    label: str
+    fetchedAt: datetime | None = None
+    cachedAt: datetime | None = None
+    ttlSeconds: int | None = None
+    errorReason: str | None = None
+
+
+class UpbitTickerBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    meta: UpbitBlockMeta
+    tickers: dict[str, dict[str, Any]] = Field(default_factory=dict)
+
+
+class UpbitOrderbookBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    meta: UpbitBlockMeta
+    orderbooks: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    spreadsPct: dict[str, float | None] = Field(default_factory=dict)
+
+
+class UpbitTradesBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    meta: UpbitBlockMeta
+    trades: dict[str, list[dict[str, Any]]] = Field(default_factory=dict)
+
+
+class UpbitCandlesBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    meta: UpbitBlockMeta
+    market: str
+    period: Literal["day", "week", "month"]
+    rows: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class UpbitMarketWarningEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    market: str
+    warning: Literal["NONE", "CAUTION"] = "NONE"
+    event: dict[str, Any] | None = None
+
+
+class UpbitMarketWarningsBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    meta: UpbitBlockMeta
+    entries: dict[str, UpbitMarketWarningEntry] = Field(default_factory=dict)
+
+
+class UpbitPublicSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    asOf: datetime
+    ticker: UpbitTickerBlock
+    orderbook: UpbitOrderbookBlock
+    trades: UpbitTradesBlock | None = None
+    marketWarnings: UpbitMarketWarningsBlock
+    sources: list[UpbitBlockMeta] = Field(default_factory=list)
+
+
+def to_crypto_source_state(meta: UpbitBlockMeta):
+    """Map read-model block metadata into invest crypto source metadata."""
+    from app.schemas.invest_crypto import CryptoSourceState
+
+    return CryptoSourceState(
+        source=meta.source,
+        state="supported" if meta.state in {"fresh", "stale"} else "unavailable",
+        label=meta.label,
+        fetchedAt=meta.fetchedAt,
+    )

--- a/docs/runbooks/upbit-public-read-model.md
+++ b/docs/runbooks/upbit-public-read-model.md
@@ -1,0 +1,48 @@
+# Upbit public read-model cache (ROB-232)
+
+## What this is
+
+A read-only Redis-cached service layer wrapping Upbit official public data for KRW pairs: ticker, orderbook, recent trades, closed candles, and market warnings. It is consumed by `/trading/api/invest/crypto/dashboard` through the crypto dashboard service and can be reused by later coin-detail work.
+
+## Cache keys and TTLs
+
+| Block | Redis key | TTL | Stale window |
+| --- | --- | ---: | ---: |
+| ticker | `upbit:public:read:ticker:v1:<sha1>` | 5 s | 60 s |
+| orderbook | `upbit:public:read:orderbook:v1:<market>` | 3 s | 30 s |
+| trades | `upbit:public:read:trades:v1:<market>:<count>` | 5 s | 30 s |
+| candles | reuses existing `upbit_ohlcv_cache` keys | day/week/month bucketed | n/a |
+| market warnings detail | `upbit:public:read:warnings:v1` | 300 s | 1800 s |
+
+Set `UPBIT_PUBLIC_READ_MODEL_CACHE_ENABLED=false` only for local/debug bypass. Bypassing Redis makes every request call Upbit public endpoints directly and can increase rate-limit risk.
+
+## State model
+
+Each block returns metadata with `{source, fetchedAt, state, errorReason}`-style fields.
+
+- `fresh`: upstream call succeeded or cached payload is still inside its TTL.
+- `stale`: upstream refresh failed, but a stale cached payload is still inside the stale window.
+- `unavailable`: upstream failed and no cached payload is available.
+- `missing`: no upstream call was attempted, such as an empty market list.
+
+When adapted into dashboard `meta.sources`, `fresh` and `stale` are reported as `supported`; `unavailable` and `missing` are reported as `unavailable`.
+
+## Operations
+
+Inspect dashboard source freshness locally:
+
+```bash
+curl -sS 'http://localhost:8000/trading/api/invest/crypto/dashboard?limit=5' | jq '.meta.sources'
+```
+
+Flush all Upbit public read-model cache keys during an Upbit incident:
+
+```bash
+redis-cli --scan --pattern 'upbit:public:read:*' | xargs -r redis-cli del
+```
+
+For Docker-based local Redis, run the same scan/delete through the Redis container shell. Do not run this against production without separate operator approval.
+
+## Safety boundary
+
+This package is read-only. It must not submit, cancel, replace, or modify broker orders, must not import `app.services.brokers.upbit.orders`, and must not add migrations, backfills, schedulers, or production write paths. The safety-import test covers the mutation-import boundary.

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -167,3 +167,82 @@ async def test_dashboard_records_stale_source_state_from_read_model():
     sources = {source.source: source for source in response.meta.sources}
     assert sources["upbit_ticker"].state == "supported"
     assert response.cards[0].priceKrw == 100.0
+
+
+@pytest.mark.asyncio
+async def test_default_dashboard_reuses_single_upbit_read_model_redis_client(monkeypatch):
+    import fakeredis.aioredis
+
+    from app.services.upbit_public_read_model import close_default_read_model
+
+    await close_default_read_model()
+    redis_clients = []
+
+    async def create_redis_client():
+        client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+        redis_clients.append(client)
+        return client
+
+    async def fetch_tickers(markets):
+        return [
+            {
+                "market": market,
+                "trade_price": 101000000,
+                "signed_change_rate": 0.0123,
+                "signed_change_price": 1230000,
+                "acc_trade_price_24h": 12345678900,
+                "acc_trade_volume_24h": 234.5,
+            }
+            for market in markets
+        ]
+
+    async def fetch_orderbooks(markets):
+        return {
+            market: {
+                "market": market,
+                "orderbook_units": [
+                    {
+                        "ask_price": 101000000,
+                        "bid_price": 100900000,
+                        "ask_size": 1,
+                        "bid_size": 1,
+                    }
+                ],
+            }
+            for market in markets
+        }
+
+    async def fetch_trades(_market, _count):
+        return []
+
+    monkeypatch.setattr(
+        "app.services.ohlcv_cache_common.create_redis_client", create_redis_client
+    )
+    monkeypatch.setattr(
+        "app.services.brokers.upbit.client.fetch_multiple_tickers", fetch_tickers
+    )
+    monkeypatch.setattr(
+        "app.services.upbit_orderbook.fetch_multiple_orderbooks", fetch_orderbooks
+    )
+    monkeypatch.setattr(
+        "app.services.brokers.upbit.public_trades.fetch_recent_trades", fetch_trades
+    )
+
+    try:
+        first = await build_crypto_dashboard(
+            db=FakeSession([_market()], []), user_id=7
+        )
+        second = await build_crypto_dashboard(
+            db=FakeSession([_market()], []), user_id=7
+        )
+
+        assert len(redis_clients) == 1
+        assert first.cards[0].priceKrw == 101000000
+        assert second.cards[0].priceKrw == 101000000
+        assert {source.source for source in first.meta.sources} >= {
+            "upbit_ticker",
+            "upbit_orderbook",
+        }
+        assert first.meta.warnings == []
+    finally:
+        await close_default_read_model()

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -170,7 +170,9 @@ async def test_dashboard_records_stale_source_state_from_read_model():
 
 
 @pytest.mark.asyncio
-async def test_default_dashboard_reuses_single_upbit_read_model_redis_client(monkeypatch):
+async def test_default_dashboard_reuses_single_upbit_read_model_redis_client(
+    monkeypatch,
+):
     import fakeredis.aioredis
 
     from app.services.upbit_public_read_model import close_default_read_model
@@ -229,9 +231,7 @@ async def test_default_dashboard_reuses_single_upbit_read_model_redis_client(mon
     )
 
     try:
-        first = await build_crypto_dashboard(
-            db=FakeSession([_market()], []), user_id=7
-        )
+        first = await build_crypto_dashboard(db=FakeSession([_market()], []), user_id=7)
         second = await build_crypto_dashboard(
             db=FakeSession([_market()], []), user_id=7
         )

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -138,3 +138,32 @@ async def test_crypto_dashboard_is_renderable_when_public_sources_fail():
     assert "crypto_ticker_unavailable" in response.meta.warnings
     assert "crypto_orderbook_unavailable" in response.meta.warnings
     assert {source.state for source in response.meta.sources} == {"unavailable"}
+
+
+@pytest.mark.asyncio
+async def test_dashboard_records_stale_source_state_from_read_model():
+    from app.services.upbit_public_read_model.types import (
+        UpbitBlockMeta,
+        UpbitTickerBlock,
+    )
+
+    async def stale_ticker_provider(markets):
+        return UpbitTickerBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_ticker",
+                state="stale",
+                label="Upbit ticker",
+                errorReason="rate_limited",
+            ),
+            tickers={m: {"market": m, "trade_price": 100.0} for m in markets},
+        )
+
+    response = await build_crypto_dashboard(
+        db=FakeSession([_market()], []),
+        user_id=7,
+        ticker_provider=stale_ticker_provider,
+        orderbook_spread_provider=lambda _: {},
+    )
+    sources = {source.source: source for source in response.meta.sources}
+    assert sources["upbit_ticker"].state == "supported"
+    assert response.cards[0].priceKrw == 100.0

--- a/tests/test_upbit_public_trades.py
+++ b/tests/test_upbit_public_trades.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.services.brokers.upbit import public_trades
+
+
+@pytest.mark.asyncio
+async def test_fetch_recent_trades_returns_rows(monkeypatch):
+    sample = [{"market": "KRW-BTC", "trade_price": 1.0}]
+
+    async def fake_request_json(url, params=None):
+        assert "trades/ticks" in url
+        assert params == {"market": "KRW-BTC", "count": 50}
+        return sample
+
+    monkeypatch.setattr(public_trades, "_request_json", fake_request_json)
+    assert await public_trades.fetch_recent_trades("KRW-BTC", count=50) == sample
+
+
+@pytest.mark.asyncio
+async def test_fetch_recent_trades_normalizes_market_and_bounds_count(monkeypatch):
+    captured = {}
+
+    async def fake_request_json(url, params=None):
+        captured["params"] = params
+        return []
+
+    async def fake_market_by_coin(symbol):
+        assert symbol == "BTC"
+        return "KRW-BTC"
+
+    monkeypatch.setattr(public_trades, "_request_json", fake_request_json)
+    monkeypatch.setattr(public_trades, "get_upbit_market_by_coin", fake_market_by_coin)
+    await public_trades.fetch_recent_trades("btc", count=10_000)
+    assert captured["params"] == {"market": "KRW-BTC", "count": 500}
+
+
+@pytest.mark.asyncio
+async def test_fetch_recent_trades_propagates_http_error(monkeypatch):
+    async def fake_request_json(url, params=None):
+        raise httpx.HTTPStatusError(
+            "boom", request=httpx.Request("GET", url), response=httpx.Response(429)
+        )
+
+    monkeypatch.setattr(public_trades, "_request_json", fake_request_json)
+    with pytest.raises(httpx.HTTPStatusError):
+        await public_trades.fetch_recent_trades("KRW-BTC")

--- a/tests/upbit_public_read_model/conftest.py
+++ b/tests/upbit_public_read_model/conftest.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import fakeredis.aioredis
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def fake_redis():
+    client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    try:
+        yield client
+    finally:
+        await client.flushall()
+        await client.aclose()

--- a/tests/upbit_public_read_model/test_candles_cache.py
+++ b/tests/upbit_public_read_model/test_candles_cache.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import pytest
+
+from app.services.upbit_public_read_model.candles_cache import CandlesCache
+
+
+@pytest.mark.asyncio
+async def test_candles_cache_rejects_intraday_period():
+    cache = CandlesCache(closed_candles_getter=lambda *a, **k: None)
+    with pytest.raises(ValueError):
+        await cache.get("KRW-BTC", period="1m", count=5)
+
+
+@pytest.mark.asyncio
+async def test_candles_cache_converts_dataframe_rows():
+    async def getter(market, count, period):
+        return pd.DataFrame(
+            [{"open": 1, "high": 2, "low": 0.5, "close": 1.5, "volume": 3, "value": 4}],
+            index=[pd.Timestamp("2026-05-14")],
+        )
+
+    block = await CandlesCache(closed_candles_getter=getter).get(
+        "KRW-BTC", period="day", count=1
+    )
+    assert block.meta.state == "fresh"
+    assert block.rows[0]["open"] == 1
+
+
+@pytest.mark.asyncio
+async def test_candles_cache_unavailable_on_exception():
+    async def getter(*args, **kwargs):
+        raise RuntimeError("down")
+
+    block = await CandlesCache(closed_candles_getter=getter).get(
+        "KRW-BTC", period="day", count=1
+    )
+    assert block.meta.state == "unavailable"

--- a/tests/upbit_public_read_model/test_market_warnings.py
+++ b/tests/upbit_public_read_model/test_market_warnings.py
@@ -1,0 +1,70 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.upbit_public_read_model.market_warnings import MarketWarningsService
+
+
+class _ScalarRows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return _ScalarRows(self._rows)
+
+
+class FakeSession:
+    def __init__(self, rows):
+        self.rows = rows
+
+    async def execute(self, statement):
+        return _Result(self.rows)
+
+
+def _row(market="KRW-BTC", warning="NONE"):
+    return SimpleNamespace(
+        market=market,
+        quote_currency="KRW",
+        is_active=True,
+        market_warning=warning,
+        updated_at=datetime(2026, 5, 14, tzinfo=UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_market_warnings_universe_tier_does_not_call_http(fake_redis):
+    async def detail_fetcher():
+        raise AssertionError("must not call HTTP")
+
+    block = await MarketWarningsService(
+        redis=fake_redis, detail_fetcher=detail_fetcher
+    ).get(["KRW-BTC"], db=FakeSession([_row()]))
+    assert block.meta.state == "fresh"
+    assert block.entries["KRW-BTC"].warning == "NONE"
+
+
+@pytest.mark.asyncio
+async def test_market_warning_detail_tier_uses_cache(fake_redis, monkeypatch):
+    calls = 0
+
+    async def detail_fetcher():
+        nonlocal calls
+        calls += 1
+        return [{"market": "KRW-BTC", "market_event": {"warning": True}}]
+
+    svc = MarketWarningsService(redis=fake_redis, detail_fetcher=detail_fetcher)
+    session = FakeSession([_row()])
+    first = await svc.get(["KRW-BTC"], include_event_detail=True, db=session)
+    second = await svc.get(["KRW-BTC"], include_event_detail=True, db=session)
+    assert first.entries["KRW-BTC"].event == {"warning": True}
+    assert second.entries["KRW-BTC"].event == {"warning": True}
+    assert calls == 1

--- a/tests/upbit_public_read_model/test_orderbook_cache.py
+++ b/tests/upbit_public_read_model/test_orderbook_cache.py
@@ -1,0 +1,113 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.services.upbit_public_read_model.orderbook_cache import OrderbookCache
+from app.services.upbit_public_read_model.types import ORDERBOOK_TTL_SECONDS
+
+
+class BrokenRedis:
+    async def get(self, key):
+        raise RuntimeError("redis get unavailable")
+
+    async def set(self, key, value, ex=None):
+        raise RuntimeError("redis set unavailable")
+
+
+def _book(market="KRW-BTC"):
+    return {
+        "market": market,
+        "orderbook_units": [
+            {"ask_price": 100.0, "bid_price": 99.0, "ask_size": 1, "bid_size": 1}
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_orderbook_cache_computes_spread_and_hits_cache(fake_redis):
+    calls = 0
+
+    async def fetcher(markets):
+        nonlocal calls
+        calls += 1
+        return {m: _book(m) for m in markets}
+
+    cache = OrderbookCache(redis=fake_redis, fetcher=fetcher)
+    first = await cache.get(["KRW-BTC"])
+    second = await cache.get(["KRW-BTC"])
+    assert first.spreadsPct["KRW-BTC"] == pytest.approx((100 - 99) / 99 * 100)
+    assert second.meta.state == "fresh"
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_orderbook_cache_stale_and_unavailable(fake_redis, monkeypatch):
+    async def fetcher_ok(markets):
+        return {m: _book(m) for m in markets}
+
+    cache = OrderbookCache(redis=fake_redis, fetcher=fetcher_ok)
+    await cache.get(["KRW-BTC"])
+    monkeypatch.setattr(
+        "app.services.upbit_public_read_model.orderbook_cache._now_utc",
+        lambda: datetime.now(UTC) + timedelta(seconds=ORDERBOOK_TTL_SECONDS + 1),
+    )
+
+    async def fail(markets):
+        raise RuntimeError("boom")
+
+    cache._fetcher = fail
+    assert (await cache.get(["KRW-BTC"])).meta.state == "stale"
+    empty = OrderbookCache(redis=fake_redis, fetcher=fail)
+    await fake_redis.flushall()
+    assert (await empty.get(["KRW-ETH"])).meta.state == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_orderbook_cache_partial_fetch_uses_stale_cache(fake_redis, monkeypatch):
+    async def fetcher_ok(markets):
+        return {m: _book(m) for m in markets}
+
+    cache = OrderbookCache(redis=fake_redis, fetcher=fetcher_ok)
+    await cache.get(["KRW-BTC"])
+    monkeypatch.setattr(
+        "app.services.upbit_public_read_model.orderbook_cache._now_utc",
+        lambda: datetime.now(UTC) + timedelta(seconds=ORDERBOOK_TTL_SECONDS + 1),
+    )
+
+    async def partial(markets):
+        assert markets == ["KRW-BTC", "KRW-ETH"]
+        return {"KRW-ETH": _book("KRW-ETH")}
+
+    cache._fetcher = partial
+    block = await cache.get(["KRW-BTC", "KRW-ETH"])
+    assert block.meta.state == "stale"
+    assert block.meta.errorReason == "partial_missing"
+    assert set(block.orderbooks) == {"KRW-BTC", "KRW-ETH"}
+
+
+@pytest.mark.asyncio
+async def test_orderbook_cache_empty_fetch_without_cache_is_unavailable(fake_redis):
+    async def empty(markets):
+        return {}
+
+    cache = OrderbookCache(redis=fake_redis, fetcher=empty)
+    block = await cache.get(["KRW-BTC"])
+    assert block.meta.state == "unavailable"
+    assert block.meta.errorReason == "partial_missing"
+    assert block.orderbooks == {}
+
+
+@pytest.mark.asyncio
+async def test_orderbook_cache_returns_fresh_when_redis_is_unavailable():
+    calls = 0
+
+    async def fetcher(markets):
+        nonlocal calls
+        calls += 1
+        return {m: _book(m) for m in markets}
+
+    cache = OrderbookCache(redis=BrokenRedis(), fetcher=fetcher)
+    block = await cache.get(["KRW-BTC"])
+    assert block.meta.state == "fresh"
+    assert block.spreadsPct["KRW-BTC"] == pytest.approx((100 - 99) / 99 * 100)
+    assert calls == 1

--- a/tests/upbit_public_read_model/test_read_model_facade.py
+++ b/tests/upbit_public_read_model/test_read_model_facade.py
@@ -1,0 +1,60 @@
+import pytest
+
+from app.services.upbit_public_read_model import (
+    UpbitPublicReadModel,
+    UpbitPublicSnapshot,
+)
+from app.services.upbit_public_read_model.types import (
+    UpbitBlockMeta,
+    UpbitMarketWarningEntry,
+    UpbitMarketWarningsBlock,
+)
+
+
+async def _inline_warnings_provider(markets):
+    return UpbitMarketWarningsBlock(
+        meta=UpbitBlockMeta(source="upbit_market_warnings", state="fresh", label="w"),
+        entries={
+            m: UpbitMarketWarningEntry(market=m, warning="NONE")
+            for m in (markets or [])
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_snapshot_composes_all_blocks(fake_redis):
+    async def ticker_fetcher(markets):
+        return [{"market": m, "trade_price": 1.0} for m in markets]
+
+    async def orderbook_fetcher(markets):
+        return {
+            m: {
+                "market": m,
+                "orderbook_units": [
+                    {"ask_price": 10.0, "bid_price": 9.0, "ask_size": 1, "bid_size": 1}
+                ],
+            }
+            for m in markets
+        }
+
+    async def trades_fetcher(market, count):
+        return [{"market": market, "trade_price": 1.0}]
+
+    rm = UpbitPublicReadModel(
+        redis=fake_redis,
+        ticker_fetcher=ticker_fetcher,
+        orderbook_fetcher=orderbook_fetcher,
+        trades_fetcher=trades_fetcher,
+        warnings_provider=_inline_warnings_provider,
+    )
+    snap = await rm.snapshot(["KRW-BTC"], include_trades_for=["KRW-BTC"])
+    assert isinstance(snap, UpbitPublicSnapshot)
+    assert snap.ticker.meta.state == "fresh"
+    assert snap.orderbook.spreadsPct["KRW-BTC"] > 0
+    assert snap.trades is not None and snap.trades.trades["KRW-BTC"]
+    assert {m.source for m in snap.sources} >= {
+        "upbit_ticker",
+        "upbit_orderbook",
+        "upbit_trades",
+        "upbit_market_warnings",
+    }

--- a/tests/upbit_public_read_model/test_safety_imports.py
+++ b/tests/upbit_public_read_model/test_safety_imports.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+_FORBIDDEN = {"app.services.brokers.upbit.orders", "app.services.upbit_websocket"}
+
+
+def test_read_model_does_not_import_broker_mutations():
+    for forbidden in _FORBIDDEN:
+        sys.modules.pop(forbidden, None)
+    importlib.import_module("app.services.upbit_public_read_model")
+    importlib.import_module("app.services.upbit_public_read_model.read_model")
+    for forbidden in _FORBIDDEN:
+        assert forbidden not in sys.modules

--- a/tests/upbit_public_read_model/test_ticker_cache.py
+++ b/tests/upbit_public_read_model/test_ticker_cache.py
@@ -1,0 +1,80 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.services.upbit_public_read_model.ticker_cache import TickerCache
+from app.services.upbit_public_read_model.types import TICKER_TTL_SECONDS
+
+
+class BrokenRedis:
+    async def get(self, key):
+        raise RuntimeError("redis get unavailable")
+
+    async def set(self, key, value, ex=None):
+        raise RuntimeError("redis set unavailable")
+
+
+@pytest.mark.asyncio
+async def test_ticker_cache_fresh_and_hits_redis(fake_redis):
+    calls = 0
+
+    async def fetcher(markets):
+        nonlocal calls
+        calls += 1
+        return [{"market": m, "trade_price": 1.0} for m in markets]
+
+    cache = TickerCache(redis=fake_redis, fetcher=fetcher)
+    first = await cache.get(["KRW-BTC"])
+    second = await cache.get(["KRW-BTC"])
+    assert first.meta.state == second.meta.state == "fresh"
+    assert calls == 1
+    assert second.meta.cachedAt is not None
+
+
+@pytest.mark.asyncio
+async def test_ticker_cache_returns_stale_on_fetch_failure(fake_redis, monkeypatch):
+    async def fetcher_ok(markets):
+        return [{"market": m, "trade_price": 1.0} for m in markets]
+
+    cache = TickerCache(redis=fake_redis, fetcher=fetcher_ok)
+    await cache.get(["KRW-BTC"])
+    monkeypatch.setattr(
+        "app.services.upbit_public_read_model.ticker_cache._now_utc",
+        lambda: datetime.now(UTC) + timedelta(seconds=TICKER_TTL_SECONDS + 1),
+    )
+
+    async def fetcher_fail(markets):
+        raise RuntimeError("boom")
+
+    cache._fetcher = fetcher_fail
+    block = await cache.get(["KRW-BTC"])
+    assert block.meta.state == "stale"
+    assert block.tickers["KRW-BTC"]["trade_price"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_ticker_cache_unavailable_and_missing(fake_redis):
+    async def fetcher_fail(markets):
+        raise RuntimeError("network")
+
+    cache = TickerCache(redis=fake_redis, fetcher=fetcher_fail)
+    assert (await cache.get([])).meta.state == "missing"
+    block = await cache.get(["KRW-BTC"])
+    assert block.meta.state == "unavailable"
+    assert block.meta.errorReason == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_ticker_cache_returns_fresh_when_redis_is_unavailable():
+    calls = 0
+
+    async def fetcher(markets):
+        nonlocal calls
+        calls += 1
+        return [{"market": m, "trade_price": 1.0} for m in markets]
+
+    cache = TickerCache(redis=BrokenRedis(), fetcher=fetcher)
+    block = await cache.get(["KRW-BTC"])
+    assert block.meta.state == "fresh"
+    assert block.tickers["KRW-BTC"]["trade_price"] == 1.0
+    assert calls == 1

--- a/tests/upbit_public_read_model/test_trades_cache.py
+++ b/tests/upbit_public_read_model/test_trades_cache.py
@@ -1,0 +1,77 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.services.upbit_public_read_model.trades_cache import TradesCache
+from app.services.upbit_public_read_model.types import (
+    TRADES_TTL_SECONDS,
+    UpbitBlockMeta,
+    UpbitTradesBlock,
+)
+
+
+class BrokenRedis:
+    async def get(self, key):
+        raise RuntimeError("redis get unavailable")
+
+    async def set(self, key, value, ex=None):
+        raise RuntimeError("redis set unavailable")
+
+
+@pytest.mark.asyncio
+async def test_trades_cache_fresh_empty_and_bounds_count(fake_redis):
+    captured = {}
+
+    async def fetcher(market, count):
+        captured["args"] = (market, count)
+        return []
+
+    cache = TradesCache(redis=fake_redis, fetcher=fetcher)
+    block = await cache.get("KRW-BTC", 9999)
+    assert captured["args"] == ("KRW-BTC", 500)
+    assert block.meta.state == "fresh"
+    assert block.trades == {"KRW-BTC": []}
+
+
+@pytest.mark.asyncio
+async def test_trades_cache_stale_and_merge(fake_redis, monkeypatch):
+    async def ok(market, count):
+        return [{"market": market, "trade_price": 1.0}]
+
+    cache = TradesCache(redis=fake_redis, fetcher=ok)
+    await cache.get("KRW-BTC", 50)
+    monkeypatch.setattr(
+        "app.services.upbit_public_read_model.trades_cache._now_utc",
+        lambda: datetime.now(UTC) + timedelta(seconds=TRADES_TTL_SECONDS + 1),
+    )
+
+    async def fail(market, count):
+        raise RuntimeError("boom")
+
+    cache._fetcher = fail
+    stale = await cache.get("KRW-BTC", 50)
+    unavailable = UpbitTradesBlock(
+        meta=UpbitBlockMeta(
+            source="upbit_trades", state="unavailable", label="Upbit trades"
+        )
+    )
+    merged = TradesCache.merge([stale, unavailable])
+    assert stale.meta.state == "stale"
+    assert merged.meta.state == "unavailable"
+    assert "KRW-BTC" in merged.trades
+
+
+@pytest.mark.asyncio
+async def test_trades_cache_returns_fresh_when_redis_is_unavailable():
+    calls = 0
+
+    async def fetcher(market, count):
+        nonlocal calls
+        calls += 1
+        return [{"market": market, "trade_price": 1.0}]
+
+    cache = TradesCache(redis=BrokenRedis(), fetcher=fetcher)
+    block = await cache.get("KRW-BTC", 50)
+    assert block.meta.state == "fresh"
+    assert block.trades["KRW-BTC"][0]["trade_price"] == 1.0
+    assert calls == 1

--- a/tests/upbit_public_read_model/test_types.py
+++ b/tests/upbit_public_read_model/test_types.py
@@ -1,0 +1,69 @@
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.invest_crypto import CryptoSourceState
+from app.services.upbit_public_read_model.types import (
+    UpbitBlockMeta,
+    UpbitMarketWarningsBlock,
+    UpbitOrderbookBlock,
+    UpbitPublicSnapshot,
+    UpbitTickerBlock,
+    to_crypto_source_state,
+)
+
+
+def test_upbit_block_meta_is_frozen_and_extra_forbid():
+    meta = UpbitBlockMeta(source="upbit_ticker", state="fresh", label="Upbit ticker")
+    with pytest.raises(ValidationError):
+        UpbitBlockMeta(source="upbit_ticker", state="fresh", label="x", bogus=1)
+    with pytest.raises(ValidationError):
+        meta.source = "upbit_orderbook"
+
+
+def test_to_crypto_source_state_maps_states():
+    now = datetime.now(UTC)
+    fresh = to_crypto_source_state(
+        UpbitBlockMeta(
+            source="upbit_ticker", state="fresh", label="Upbit ticker", fetchedAt=now
+        )
+    )
+    assert isinstance(fresh, CryptoSourceState)
+    assert fresh.state == "supported"
+    stale = to_crypto_source_state(
+        UpbitBlockMeta(source="upbit_ticker", state="stale", label="Upbit ticker")
+    )
+    assert stale.state == "supported"
+    fail = to_crypto_source_state(
+        UpbitBlockMeta(
+            source="upbit_orderbook",
+            state="unavailable",
+            label="Upbit orderbook",
+            errorReason="http_error",
+        )
+    )
+    assert fail.state == "unavailable"
+
+
+def test_snapshot_round_trips():
+    now = datetime.now(UTC)
+    meta = UpbitBlockMeta(
+        source="upbit_ticker", state="fresh", label="t", fetchedAt=now
+    )
+    snap = UpbitPublicSnapshot(
+        asOf=now,
+        ticker=UpbitTickerBlock(meta=meta, tickers={"KRW-BTC": {"trade_price": 1}}),
+        orderbook=UpbitOrderbookBlock(
+            meta=UpbitBlockMeta(source="upbit_orderbook", state="fresh", label="o"),
+            orderbooks={},
+            spreadsPct={"KRW-BTC": 0.0},
+        ),
+        marketWarnings=UpbitMarketWarningsBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_market_warnings", state="fresh", label="w"
+            )
+        ),
+        sources=[meta],
+    )
+    assert "KRW-BTC" in snap.model_dump_json()


### PR DESCRIPTION
## Summary
- Add an Upbit official/public read-model cache facade for ticker, orderbook, candles, trades, and market warnings.
- Wire `/invest` crypto dashboard service reads through the new public read-model with Redis-backed lifecycle reuse.
- Add docs and targeted tests for read-only crypto dashboard/data paths.

## Verification
- `PUBLIC_API_PATHS='["/api/v1/openclaw/callback"]' uv run --group test pytest tests/upbit_public_read_model/ tests/test_upbit_public_trades.py tests/test_invest_crypto_dashboard_service.py tests/test_invest_api_crypto_router.py -q` -> 30 passed, 2 pre-existing Pydantic warnings.
- `PUBLIC_API_PATHS='["/api/v1/openclaw/callback"]' uv run --group test pytest tests/test_invest_api_router_safety.py tests/test_invest_view_model_safety.py tests/upbit_public_read_model/test_safety_imports.py -q` -> 6 passed, 2 pre-existing Pydantic warnings.
- `uv run --group dev ruff check app/services/upbit_public_read_model app/services/brokers/upbit/public_trades.py app/services/invest_view_model/crypto_dashboard_service.py tests/upbit_public_read_model tests/test_upbit_public_trades.py tests/test_invest_crypto_dashboard_service.py` -> All checks passed.
- `uv run --group dev ruff format --check app/services/upbit_public_read_model app/services/brokers/upbit/public_trades.py app/services/invest_view_model/crypto_dashboard_service.py tests/upbit_public_read_model tests/test_upbit_public_trades.py tests/test_invest_crypto_dashboard_service.py && git diff --check origin/main...HEAD` -> 23 files already formatted; diff whitespace check clean.

## Safety / non-actions
- Read-only `/invest` crypto data and UI only.
- No Upbit/KIS/Alpaca/generic broker/paper/live order submit, cancel, modify, or replace.
- No watch/order-intent mutation.
- No production DB write/delete/backfill/migration application.
- No scheduler, Prefect, or TaskIQ activation.

## Notes
- Parent review PASS: Kanban t_11888a2c reviewed commit `336842d5` with no blocking findings.
- Branch currently preserves reviewed commit history and is based before several newer `main` commits; local merge-tree scan against current `origin/main` found no textual conflicts.
- Linear: ROB-232.
