### PR TITLE
feat(invest): add crypto screener market bridge

### DIFF
--- a/app/schemas/invest_screener.py
+++ b/app/schemas/invest_screener.py
@@ -13,6 +13,24 @@ from pydantic import BaseModel, ConfigDict, Field
 
 ScreenerMarket = Literal["kr", "us", "crypto"]
 ChangeDirection = Literal["up", "down", "flat"]
+ScreenerDataSourceKind = Literal[
+    "upbit_official",
+    "tvscreener_upbit",
+    "mcp_screen_stocks",
+    "naver_reference",
+    "coingecko_reference",
+    "external_reference",
+    "snapshot_cache",
+]
+ScreenerSourceState = Literal[
+    "supported",
+    "cached",
+    "reference_only",
+    "partial",
+    "unavailable",
+    "fallback",
+]
+ScreenerRiskSeverity = Literal["info", "warning", "danger"]
 
 
 class ScreenerFilterChip(BaseModel):
@@ -30,6 +48,30 @@ class ScreenerPreset(BaseModel):
     filterChips: list[ScreenerFilterChip] = Field(default_factory=list)
     metricLabel: str
     market: ScreenerMarket = "kr"
+
+
+class ScreenerSourceContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    source: ScreenerDataSourceKind
+    label: str
+    state: ScreenerSourceState
+    fetchedAt: str | None = None
+    detail: str | None = None
+
+
+class ScreenerRiskContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    kind: str
+    label: str
+    severity: ScreenerRiskSeverity = "info"
+    source: ScreenerDataSourceKind | None = None
+
+
+class ScreenerCandidateContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    scoreLabel: str | None = None
+    reasons: list[str] = Field(default_factory=list)
+    source: ScreenerDataSourceKind | None = None
 
 
 class ScreenerResultRow(BaseModel):
@@ -50,6 +92,9 @@ class ScreenerResultRow(BaseModel):
     analystLabel: str
     metricValueLabel: str
     warnings: list[str] = Field(default_factory=list)
+    sourceContext: list[ScreenerSourceContext] = Field(default_factory=list)
+    riskContext: list[ScreenerRiskContext] = Field(default_factory=list)
+    candidateContext: ScreenerCandidateContext | None = None
 
 
 class ScreenerPresetsResponse(BaseModel):
@@ -78,3 +123,4 @@ class ScreenerResultsResponse(BaseModel):
     results: list[ScreenerResultRow]
     warnings: list[str] = Field(default_factory=list)
     freshness: ScreenerFreshness
+    sources: list[ScreenerSourceContext] = Field(default_factory=list)

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -24,10 +24,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.schemas.invest_screener import (
     ChangeDirection,
+    ScreenerCandidateContext,
     ScreenerFreshness,
     ScreenerPresetsResponse,
     ScreenerResultRow,
     ScreenerResultsResponse,
+    ScreenerRiskContext,
+    ScreenerSourceContext,
 )
 from app.services.invest_view_model.screener_presets import (
     CRYPTO_DEFAULT_PRESET_ID,
@@ -104,22 +107,26 @@ def _safe_warning(message: Any) -> str:
     text = _clean_text(message)
     if not text:
         return "스크리너 데이터 소스가 일시적으로 응답하지 않습니다."
+    normalized_text = text.lower()
     noisy_markers = (
-        "HTTPSConnectionPool(",
-        "ConnectionError",
-        "ConnectError",
-        "NameResolutionError",
+        "httpsconnectionpool(",
+        "connectionerror",
+        "connecterror",
+        "nameresolutionerror",
         "nodename nor servname",
-        "Could not resolve host",
+        "could not resolve host",
         "getaddrinfo()",
-        "Max retries exceeded",
+        "max retries exceeded",
         "api.finnhub.io",
+        "api.upbit.com",
+        "upbit",
+        "coingecko",
         "scanner.tradingview.com",
         "query1.finance.yahoo.com",
         "query2.finance.yahoo.com",
         "token=",
     )
-    if any(marker in text for marker in noisy_markers):
+    if any(marker in normalized_text for marker in noisy_markers):
         return "외부 시세/스크리너 데이터 소스 연결이 일시적으로 불안정해 일부 결과를 갱신하지 못했습니다."
     if len(text) > _MAX_WARNING_CHARS:
         return text[: _MAX_WARNING_CHARS - 1].rstrip() + "…"
@@ -402,6 +409,10 @@ async def _load_crypto_rows_from_snapshots(
                 else None,
                 "rsi": float(snap.rsi) if snap.rsi is not None else None,
                 "adx": float(snap.adx) if snap.adx is not None else None,
+                "source": "tvscreener_upbit",
+                "computed_at": snap.computed_at.isoformat()
+                if getattr(snap, "computed_at", None) is not None
+                else None,
                 "_screener_snapshot_state": state,
             }
         )
@@ -520,6 +531,28 @@ def _normalize_symbol(row: dict[str, Any], market: str) -> tuple[str, list[str]]
         return symbol, []
 
     return symbol.upper(), []
+
+
+def _normalize_crypto_symbol(row: dict[str, Any]) -> tuple[str, list[str]]:
+    raw_values = [
+        _clean_text(row.get(key))
+        for key in ("symbol", "original_market", "code", "ticker", "market_code")
+    ]
+    for raw in raw_values:
+        if not raw:
+            continue
+        symbol = raw.upper().replace("/", "-").replace("_", "-")
+        if symbol.startswith("KRW-") and len(symbol) > 4:
+            return symbol, []
+        if symbol.endswith("-KRW") and len(symbol) > 4:
+            return f"KRW-{symbol[:-4]}", []
+        if symbol.startswith("UPBIT:"):
+            pair = symbol.split(":", 1)[1]
+            if pair.endswith("KRW") and len(pair) > 3:
+                return f"KRW-{pair[:-3]}", []
+        if symbol.endswith("KRW") and "-" not in symbol and ":" not in symbol:
+            return f"KRW-{symbol[:-3]}", []
+    return "", ["비KRW 가상자산 행은 제외했습니다."]
 
 
 def _coerce_float(value: Any) -> float | None:
@@ -676,6 +709,180 @@ def _metric_value_label(preset_id: str, row: dict[str, Any]) -> tuple[str, list[
     if field in ("volume", "trade_amount_24h"):
         return f"{int(float(value)):,}", []
     return str(value), []
+
+
+def _source_label(source: str) -> str:
+    return {
+        "snapshot_cache": "스냅샷 캐시",
+        "tvscreener_upbit": "TV Screener Upbit",
+        "mcp_screen_stocks": "MCP screen_stocks",
+        "upbit_official": "Upbit 공식 데이터",
+        "coingecko_reference": "CoinGecko 참고 데이터",
+        "naver_reference": "Naver 참고 데이터",
+        "external_reference": "외부 참고 데이터",
+    }.get(source, source)
+
+
+def _source_context(
+    source: str,
+    *,
+    state: str = "supported",
+    fetched_at: str | None = None,
+    detail: str | None = None,
+) -> ScreenerSourceContext:
+    return ScreenerSourceContext(
+        source=source,  # type: ignore[arg-type]
+        label=_source_label(source),
+        state=state,  # type: ignore[arg-type]
+        fetchedAt=fetched_at,
+        detail=detail,
+    )
+
+
+def _dedupe_sources(
+    sources: Sequence[ScreenerSourceContext],
+) -> list[ScreenerSourceContext]:
+    deduped: list[ScreenerSourceContext] = []
+    seen: set[tuple[str, str]] = set()
+    for source in sources:
+        key = (source.source, source.state)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(source)
+    return deduped
+
+
+def _crypto_row_source_context(
+    row: dict[str, Any], *, snapshot_was_checked: bool, raw: dict[str, Any]
+) -> list[ScreenerSourceContext]:
+    sources: list[ScreenerSourceContext] = []
+    fetched_at = _clean_text(row.get("computed_at") or row.get("fetched_at")) or None
+    if snapshot_was_checked:
+        sources.append(
+            _source_context("snapshot_cache", state="cached", fetched_at=fetched_at)
+        )
+    else:
+        sources.append(_source_context("mcp_screen_stocks", state="fallback"))
+
+    row_source = _clean_text(row.get("source")).lower()
+    meta = raw.get("meta") if isinstance(raw.get("meta"), dict) else {}
+    meta_source = _clean_text(
+        meta.get("source") if isinstance(meta, dict) else ""
+    ).lower()
+    if row_source in {"tvscreener", "tvscreener_upbit"} or meta_source in {
+        "tvscreener",
+        "tvscreener_upbit",
+    }:
+        sources.append(_source_context("tvscreener_upbit"))
+    if row.get("market_warning") is not None or row.get("warning") is not None:
+        sources.append(_source_context("upbit_official"))
+    if row.get("market_cap") is not None or row.get("market_cap_rank") is not None:
+        sources.append(_source_context("coingecko_reference", state="reference_only"))
+    return _dedupe_sources(sources)
+
+
+def _screen_response_sources(
+    *, requested_market: str, snapshot_was_checked: bool, raw: dict[str, Any]
+) -> list[ScreenerSourceContext]:
+    if requested_market != "crypto":
+        return []
+    sample_row: dict[str, Any] = {}
+    rows = raw.get("results") or raw.get("stocks") or []
+    if rows:
+        sample_row = rows[0]
+    sources = _crypto_row_source_context(
+        sample_row, snapshot_was_checked=snapshot_was_checked, raw=raw
+    )
+    meta = raw.get("meta") if isinstance(raw.get("meta"), dict) else {}
+    if isinstance(meta, dict) and meta.get("coingecko_cached"):
+        sources.append(_source_context("coingecko_reference", state="reference_only"))
+    return _dedupe_sources(sources)
+
+
+def _crypto_risk_context(row: dict[str, Any]) -> list[ScreenerRiskContext]:
+    risks: list[ScreenerRiskContext] = []
+    if row.get("market_warning") or row.get("warning"):
+        risks.append(
+            ScreenerRiskContext(
+                kind="market_warning",
+                label="Upbit 유의 종목",
+                severity="warning",
+                source="upbit_official",
+            )
+        )
+    if (
+        _coerce_float(row.get("close") or row.get("price") or row.get("current_price"))
+        is None
+    ):
+        risks.append(
+            ScreenerRiskContext(
+                kind="data_unavailable",
+                label="가격 데이터 준비중",
+                severity="warning",
+            )
+        )
+    rsi = _coerce_float(row.get("rsi"))
+    if rsi is not None and rsi <= 35:
+        risks.append(
+            ScreenerRiskContext(
+                kind="low_rsi",
+                label=f"RSI {rsi:.1f} 저점권",
+                severity="info",
+                source="tvscreener_upbit",
+            )
+        )
+    adx = _coerce_float(row.get("adx"))
+    if adx is not None and adx >= 25:
+        risks.append(
+            ScreenerRiskContext(
+                kind="trend_strength",
+                label=f"ADX {adx:.1f} 추세 강도",
+                severity="info",
+                source="tvscreener_upbit",
+            )
+        )
+    return risks
+
+
+def _crypto_candidate_source(row: dict[str, Any]) -> str:
+    row_source = _clean_text(row.get("source")).lower()
+    if row_source in {"tvscreener", "tvscreener_upbit"}:
+        return "tvscreener_upbit"
+    if row_source in {"upbit", "upbit_official"}:
+        return "upbit_official"
+    if row_source:
+        return "external_reference"
+    return "mcp_screen_stocks"
+
+
+def _crypto_candidate_context(
+    row: dict[str, Any], preset_id: str
+) -> ScreenerCandidateContext | None:
+    reasons: list[str] = []
+    score_label: str | None = None
+    if preset_id == "crypto_high_volume":
+        trade_amount = _coerce_float(_metric_raw_value("trade_amount_24h", row))
+        if trade_amount is not None:
+            score_label = f"거래대금 {int(trade_amount):,}"
+            reasons.append("24시간 KRW 거래대금 상위")
+    elif preset_id == "crypto_oversold":
+        rsi = _coerce_float(row.get("rsi"))
+        if rsi is not None:
+            score_label = f"RSI {rsi:.1f}"
+            reasons.append("RSI 저점권 후보")
+    elif preset_id == "crypto_momentum":
+        change_rate = _coerce_float(row.get("change_rate"))
+        if change_rate is not None:
+            score_label = f"{change_rate:+.2f}%"
+            reasons.append("단기 상승 모멘텀 후보")
+    if not reasons:
+        return None
+    return ScreenerCandidateContext(
+        scoreLabel=score_label,
+        reasons=reasons,
+        source=_crypto_candidate_source(row),  # type: ignore[arg-type]
+    )
 
 
 def _format_relative_korean(delta_seconds: int) -> str:
@@ -886,10 +1093,22 @@ async def build_screener_results(
             )
             _kr_names = {row_t.symbol: row_t.name for row_t in _kr_result.all()}
 
+    response_sources = _screen_response_sources(
+        requested_market=requested_market,
+        snapshot_was_checked=_snapshot_was_checked,
+        raw=raw,
+    )
     results: list[ScreenerResultRow] = []
-    for idx, row in enumerate(rows, start=1):
+    excluded_crypto_rows = 0
+    for row in rows:
         market = _normalize_market(row.get("market") or requested_market)
-        symbol, symbol_warnings = _normalize_symbol(row, market)
+        if market == "crypto":
+            symbol, symbol_warnings = _normalize_crypto_symbol(row)
+            if not symbol:
+                excluded_crypto_rows += 1
+                continue
+        else:
+            symbol, symbol_warnings = _normalize_symbol(row, market)
         market_cap_label, market_cap_warnings = _format_market_cap(row, market)
         change_pct_label, direction = _format_change_pct(row.get("change_rate"))
         _enrich_consecutive_up_days(preset_id, row)
@@ -897,9 +1116,17 @@ async def build_screener_results(
         relation = resolver.relation(market, symbol)
         is_watched = relation in ("watchlist", "both")
         row_warnings = symbol_warnings + market_cap_warnings + metric_warnings
+        source_context = (
+            _crypto_row_source_context(
+                row, snapshot_was_checked=_snapshot_was_checked, raw=raw
+            )
+            if market == "crypto"
+            else []
+        )
+        response_sources = _dedupe_sources([*response_sources, *source_context])
         results.append(
             ScreenerResultRow(
-                rank=idx,
+                rank=len(results) + 1,
                 symbol=symbol,
                 market=market,  # type: ignore[arg-type]
                 name=_kr_names.get(symbol) or _clean_text(row.get("name")) or symbol,
@@ -933,8 +1160,19 @@ async def build_screener_results(
                 analystLabel=str(row.get("analyst_label") or "-"),
                 metricValueLabel=metric_label,
                 warnings=row_warnings,
+                sourceContext=source_context,
+                riskContext=_crypto_risk_context(row) if market == "crypto" else [],
+                candidateContext=_crypto_candidate_context(row, preset_id)
+                if market == "crypto"
+                else None,
             )
         )
+
+    if (
+        excluded_crypto_rows
+        and "비KRW 가상자산 행은 제외했습니다." not in upstream_warnings
+    ):
+        upstream_warnings.append("비KRW 가상자산 행은 제외했습니다.")
 
     return ScreenerResultsResponse(
         presetId=preset.id,
@@ -945,4 +1183,5 @@ async def build_screener_results(
         results=results,
         warnings=upstream_warnings,
         freshness=freshness,
+        sources=response_sources,
     )

--- a/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
@@ -90,7 +90,22 @@ const CRYPTO_RESULTS = {
     marketCapLabel: "$2.10T",
     category: "Crypto",
     metricValueLabel: "120,000,000,000",
+    sourceContext: [
+      { source: "snapshot_cache" as const, label: "스냅샷 캐시", state: "cached" as const, fetchedAt: null, detail: null },
+      { source: "tvscreener_upbit" as const, label: "TV Screener Upbit", state: "supported" as const, fetchedAt: null, detail: null },
+    ],
+    riskContext: [
+      { kind: "low_rsi", label: "RSI 31.5 저점권", severity: "info" as const, source: "tvscreener_upbit" as const },
+    ],
+    candidateContext: {
+      scoreLabel: "거래대금 120,000,000,000",
+      reasons: ["24시간 KRW 거래대금 상위"],
+      source: "tvscreener_upbit" as const,
+    },
   }],
+  sources: [
+    { source: "snapshot_cache" as const, label: "스냅샷 캐시", state: "cached" as const, fetchedAt: null, detail: null },
+  ],
 };
 
 function wrap(ui: React.ReactElement) {
@@ -196,6 +211,10 @@ test("switches to the crypto market", async () => {
   await userEvent.click(screen.getByRole("button", { name: "가상자산" }));
 
   await waitFor(() => expect(screen.getByText("Bitcoin")).toBeInTheDocument());
+  expect(screen.getByText("스냅샷 캐시")).toBeInTheDocument();
+  expect(screen.getByText("TV Screener Upbit")).toBeInTheDocument();
+  expect(screen.getByText("RSI 31.5 저점권")).toBeInTheDocument();
+  expect(screen.getByText("24시간 KRW 거래대금 상위")).toBeInTheDocument();
   expect(screenerApi.fetchScreenerPresets).toHaveBeenCalledWith("crypto");
   expect(screenerApi.fetchScreenerResults).toHaveBeenCalledWith("crypto_high_volume", "crypto");
 });

--- a/frontend/invest/src/desktop/screener/ScreenerResultsTable.tsx
+++ b/frontend/invest/src/desktop/screener/ScreenerResultsTable.tsx
@@ -48,6 +48,39 @@ export function ScreenerResultsTable({ rows, metricLabel }: Props) {
             <td className="screener-name-cell">
               <span className="screener-symbol-badge">{r.symbol}</span>
               <span className="screener-symbol-name">{r.name}</span>
+              {r.market === "crypto" && (
+                <div className="screener-context-stack">
+                  {(r.sourceContext ?? []).length > 0 && (
+                    <div className="screener-context-row" aria-label="데이터 출처">
+                      {(r.sourceContext ?? []).map((source) => (
+                        <span
+                          key={`${r.symbol}-${source.source}-${source.state}`}
+                          className={`screener-context-chip screener-context-chip--${source.state}`}
+                        >
+                          {source.label}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {(r.riskContext ?? []).length > 0 && (
+                    <div className="screener-context-row" aria-label="리스크 맥락">
+                      {(r.riskContext ?? []).map((risk) => (
+                        <span
+                          key={`${r.symbol}-${risk.kind}`}
+                          className={`screener-risk-chip screener-risk-chip--${risk.severity}`}
+                        >
+                          {risk.label}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {r.candidateContext && r.candidateContext.reasons.length > 0 && (
+                    <div className="screener-candidate-context">
+                      {r.candidateContext.reasons.join(" · ")}
+                    </div>
+                  )}
+                </div>
+              )}
             </td>
             <td>{r.priceLabel}</td>
             <td className={directionClass[r.changeDirection]}>

--- a/frontend/invest/src/desktop/screener/screener.css
+++ b/frontend/invest/src/desktop/screener/screener.css
@@ -27,6 +27,17 @@
 .screener-name-cell { display: flex; flex-direction: column; gap: 2px; }
 .screener-symbol-badge { font-size: 11px; color: var(--fg-3); font-family: var(--font-mono); }
 .screener-symbol-name { font-weight: 700; color: var(--fg); }
+.screener-context-stack { display: flex; flex-direction: column; gap: 4px; margin-top: 5px; }
+.screener-context-row { display: flex; flex-wrap: wrap; gap: 4px; }
+.screener-context-chip,
+.screener-risk-chip { display: inline-flex; align-items: center; border-radius: 999px; padding: 2px 7px; font-size: 10px; font-weight: 700; border: 1px solid var(--border); background: var(--surface-2); color: var(--fg-2); }
+.screener-context-chip--cached,
+.screener-context-chip--fallback,
+.screener-context-chip--partial { background: var(--accent-soft); color: var(--accent-press); }
+.screener-context-chip--reference_only { background: var(--surface-2); color: var(--fg-3); }
+.screener-risk-chip--warning,
+.screener-risk-chip--danger { background: var(--warn-soft); color: var(--warn); }
+.screener-candidate-context { color: var(--fg-3); font-size: 11px; line-height: 1.4; }
 .screener-change-up { color: var(--gain); }
 .screener-change-down { color: var(--loss); }
 .screener-change-flat { color: var(--flat); }

--- a/frontend/invest/src/types/screener.ts
+++ b/frontend/invest/src/types/screener.ts
@@ -21,6 +21,46 @@ export interface ScreenerPresetsResponse {
   selectedPresetId: string | null;
 }
 
+export type ScreenerDataSourceKind =
+  | "upbit_official"
+  | "tvscreener_upbit"
+  | "mcp_screen_stocks"
+  | "naver_reference"
+  | "coingecko_reference"
+  | "external_reference"
+  | "snapshot_cache";
+
+export type ScreenerSourceState =
+  | "supported"
+  | "cached"
+  | "reference_only"
+  | "partial"
+  | "unavailable"
+  | "fallback";
+
+export type ScreenerRiskSeverity = "info" | "warning" | "danger";
+
+export interface ScreenerSourceContext {
+  source: ScreenerDataSourceKind;
+  label: string;
+  state: ScreenerSourceState;
+  fetchedAt: string | null;
+  detail: string | null;
+}
+
+export interface ScreenerRiskContext {
+  kind: string;
+  label: string;
+  severity: ScreenerRiskSeverity;
+  source: ScreenerDataSourceKind | null;
+}
+
+export interface ScreenerCandidateContext {
+  scoreLabel: string | null;
+  reasons: string[];
+  source: ScreenerDataSourceKind | null;
+}
+
 export interface ScreenerResultRow {
   rank: number;
   symbol: string;
@@ -38,6 +78,9 @@ export interface ScreenerResultRow {
   analystLabel: string;
   metricValueLabel: string;
   warnings: string[];
+  sourceContext?: ScreenerSourceContext[];
+  riskContext?: ScreenerRiskContext[];
+  candidateContext?: ScreenerCandidateContext | null;
 }
 
 export type ScreenerFreshnessSource = "live" | "cached" | "previous_session";
@@ -61,4 +104,5 @@ export interface ScreenerResultsResponse {
   results: ScreenerResultRow[];
   warnings: string[];
   freshness: ScreenerFreshness;
+  sources?: ScreenerSourceContext[];
 }

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -367,6 +367,131 @@ async def test_build_screener_results_uses_fresh_crypto_snapshots_first() -> Non
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_crypto_snapshot_rows_include_source_risk_and_candidate_context() -> None:
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[date(2026, 5, 13)]),
+            _FakeExecuteResult(
+                scalar_rows=[
+                    _FakeCryptoSnapshot(
+                        rsi=Decimal("31.5"),
+                        trade_amount_24h=Decimal("234000000000"),
+                    )
+                ]
+            ),
+            _FakeExecuteResult(scalar_rows=[date(2026, 5, 13)]),
+            _FakeExecuteResult(rows=[_coverage_row(latest_count=30)]),
+        ]
+    )
+
+    resp = await build_screener_results(
+        preset_id="crypto_high_volume",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched=set()),
+        market="crypto",
+        session=session,
+        now=lambda: datetime(2026, 5, 13, 3, 0, tzinfo=UTC),
+    )
+
+    assert {source.source for source in resp.sources} >= {
+        "snapshot_cache",
+        "tvscreener_upbit",
+    }
+    row = resp.results[0]
+    assert {source.source for source in row.sourceContext} >= {
+        "snapshot_cache",
+        "tvscreener_upbit",
+    }
+    assert any(risk.kind == "low_rsi" for risk in row.riskContext)
+    assert row.candidateContext is not None
+    assert row.candidateContext.reasons
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_crypto_fallback_filters_to_upbit_krw_and_labels_mcp_sources() -> None:
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "KRW-BTC",
+                    "market": "crypto",
+                    "name": "Bitcoin",
+                    "current_price": 150_000_000,
+                    "change_rate": 2.5,
+                    "trade_amount_24h": 120_000_000_000,
+                    "source": "tvscreener",
+                },
+                {
+                    "symbol": "BTC/USDT",
+                    "market": "crypto",
+                    "name": "Bitcoin/Tether",
+                    "current_price": 100_000,
+                    "change_rate": 1.0,
+                    "trade_amount_24h": 1,
+                },
+                {
+                    "symbol": "XRP/KRW",
+                    "market": "crypto",
+                    "name": "XRP",
+                    "current_price": 3_200,
+                    "change_rate": 3.0,
+                    "trade_amount_24h": 40_000_000_000,
+                    "source": "upbit_official",
+                },
+                {
+                    "symbol": "UPBIT:ETHKRW",
+                    "market": "crypto",
+                    "name": "Ethereum",
+                    "current_price": 4_800_000,
+                    "change_rate": 0.5,
+                    "trade_amount_24h": 50_000_000_000,
+                    "market_cap_rank": 2,
+                },
+            ],
+            "warnings": [
+                "HTTPSConnectionPool(host='API.UPBIT.COM'): TOKEN=synthetic-credential",
+            ],
+            "meta": {"source": "tvscreener", "coingecko_cached": True},
+        }
+    )
+
+    resp = await build_screener_results(
+        preset_id="crypto_high_volume",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched=set()),
+        market="crypto",
+    )
+
+    assert [row.symbol for row in resp.results] == ["KRW-BTC", "KRW-XRP", "KRW-ETH"]
+    assert all(row.market == "crypto" for row in resp.results)
+    assert any("비KRW" in warning for warning in resp.warnings)
+    warning_text = " ".join(resp.warnings)
+    assert "api.upbit.com" not in warning_text.lower()
+    assert "token=" not in warning_text.lower()
+    assert {source.source for source in resp.sources} >= {
+        "mcp_screen_stocks",
+        "tvscreener_upbit",
+        "coingecko_reference",
+    }
+    assert {source.source for source in resp.results[0].sourceContext} >= {
+        "mcp_screen_stocks",
+        "tvscreener_upbit",
+    }
+    assert any(
+        source.source == "coingecko_reference" and source.state == "reference_only"
+        for source in resp.results[2].sourceContext
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_build_screener_results_does_not_fallback_when_fresh_crypto_snapshot_has_no_qualifiers() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- Adds `/invest/api/screener?market=crypto` view-model support with crypto-aware preset/result contexts, source labels, and source/risk/candidate metadata.
- Normalizes crypto rows for Upbit KRW screener surfaces while preserving graceful snapshot/external fallback behavior.
- Extends the `/invest/screener` frontend crypto tab/table/types to render crypto-specific context without exposing internal fallback diagnostics.

## Review / verification
- Parent review task t_2f4fe929 approved the latest ROB-233 implementation diff with no blocking findings.
- `git diff --check $(git merge-base HEAD origin/main)..HEAD` passed.
- `uv run ruff check app/schemas/invest_screener.py app/services/invest_view_model/screener_service.py tests/test_invest_view_model_screener_service.py` passed.
- `uv run pytest tests/test_invest_view_model_screener_service.py -q` passed: 42 passed, 2 existing Pydantic deprecation warnings.
- Parent review also recorded broader targeted verification: API/schema tests, MCP crypto screening tests, frontend unit tests, and frontend typecheck passed.

## Smoke plan after merge/deploy approval
Read-only only; do not submit/cancel/modify broker, paper, Alpaca, KIS, Upbit, watch, or order-intent actions.

1. Verify production/deployed SHA points at the expected merge commit.
2. Use an authenticated web session without printing cookies/tokens.
3. API smoke: `GET /invest/api/screener?market=crypto`
   - Expect HTTP 200.
   - Confirm `market=crypto` result context, non-empty rows if data is available, Upbit/KRW-only crypto symbols for Upbit KRW surfaces, source labels, candidate/risk context, and user-safe warnings.
   - Confirm snapshot/external fallback states are explicit and do not expose internal ticker fallback warnings.
4. UI smoke: open `/invest/screener`, select the crypto tab.
   - Confirm crypto tab renders, rows/table remain stable, source/risk/candidate chips render, and no console/runtime errors.
5. Re-check safety boundaries: no order/broker/watch/order-intent calls, no production DB write/delete/backfill/migration, no scheduler/Prefect/TaskIQ activation, and no credential output.

## Safety boundary
- Read-only `/invest` crypto data and UI only.
- No Upbit, KIS, Alpaca, generic broker, paper, or live order submit/cancel/modify.
- No watch or order-intent mutation.
- No production DB write/delete/backfill/migration application.
- No scheduler, Prefect, or TaskIQ activation.

Closes ROB-233


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced screener results with additional context information, including source labels, risk indicators, and candidate reasoning displayed alongside each result.
  * Improved crypto screener output with visual context chips showing data sources, risk levels, and explanatory notes for better investment decision-making.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/837)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->