### PR TITLE
feat(invest): add analyst report action center

### DIFF
--- a/alembic/versions/20260515_rob257_add_analysis_report_action_center.py
+++ b/alembic/versions/20260515_rob257_add_analysis_report_action_center.py
@@ -1,0 +1,166 @@
+"""add analysis report action center tables
+
+Revision ID: 20260515_rob257
+Revises: 20260513_rob225
+Create Date: 2026-05-15
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "20260515_rob257"
+down_revision: str | None = "20260513_rob225"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "analysis_reports",
+        sa.Column("id", sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column("report_uuid", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("idempotency_key", sa.Text(), nullable=False),
+        sa.Column("report_type", sa.Text(), nullable=False),
+        sa.Column("market", sa.Text(), nullable=False),
+        sa.Column("account_scope", sa.Text(), nullable=True),
+        sa.Column("created_by_profile", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("risk_summary", sa.Text(), nullable=True),
+        sa.Column("data_freshness", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("coverage", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("source_policy", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("safety_notes", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("metadata", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("published_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("valid_until", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.CheckConstraint(
+            "status IN ('draft','published','superseded','expired')",
+            name="analysis_reports_status_allowed",
+        ),
+        sa.UniqueConstraint("report_uuid", name="uq_analysis_reports_report_uuid"),
+        sa.UniqueConstraint("idempotency_key", name="uq_analysis_reports_idempotency_key"),
+        schema="review",
+    )
+    op.create_index(
+        "ix_analysis_reports_market_created",
+        "analysis_reports",
+        ["market", "created_at"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_analysis_reports_status_created",
+        "analysis_reports",
+        ["status", "created_at"],
+        schema="review",
+    )
+
+    op.create_table(
+        "analysis_stage_results",
+        sa.Column("id", sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column("report_id", sa.BigInteger(), nullable=False),
+        sa.Column("stage_key", sa.Text(), nullable=False),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("provenance", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("freshness_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("raw_payload", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("normalized_payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("unavailable_reason", sa.Text(), nullable=True),
+        sa.Column("warnings", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.CheckConstraint(
+            "status IN ('ok','stale','unavailable','error')",
+            name="analysis_stage_status_allowed",
+        ),
+        sa.ForeignKeyConstraint(["report_id"], ["review.analysis_reports.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("report_id", "stage_key", "source", name="uq_analysis_stage_report_stage_source"),
+        schema="review",
+    )
+    op.create_index(
+        "ix_analysis_stage_results_report",
+        "analysis_stage_results",
+        ["report_id"],
+        schema="review",
+    )
+
+    op.create_table(
+        "analysis_order_candidates",
+        sa.Column("id", sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column("report_id", sa.BigInteger(), nullable=False),
+        sa.Column("candidate_uuid", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("idempotency_key", sa.Text(), nullable=False),
+        sa.Column("symbol", sa.Text(), nullable=False),
+        sa.Column("market", sa.Text(), nullable=False),
+        sa.Column("side", sa.Text(), nullable=False),
+        sa.Column("action_type", sa.Text(), nullable=False),
+        sa.Column("quantity", sa.Numeric(20, 8), nullable=True),
+        sa.Column("quantity_pct", sa.Numeric(10, 6), nullable=True),
+        sa.Column("limit_price", sa.Numeric(20, 4), nullable=True),
+        sa.Column("notional", sa.Numeric(20, 4), nullable=True),
+        sa.Column("currency", sa.Text(), nullable=True),
+        sa.Column("priority", sa.Integer(), nullable=False),
+        sa.Column("confidence", sa.Numeric(8, 4), nullable=True),
+        sa.Column("thesis", sa.Text(), nullable=False),
+        sa.Column("risk_notes", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("verification", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("blocking_reasons", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("approval_status", sa.Text(), nullable=False),
+        sa.Column("approval_type", sa.Text(), nullable=False),
+        sa.Column("approved_by", sa.Text(), nullable=True),
+        sa.Column("approved_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("rejected_by", sa.Text(), nullable=True),
+        sa.Column("rejected_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("policy_id", sa.Text(), nullable=True),
+        sa.Column("policy_snapshot", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("execution_state", sa.Text(), nullable=False),
+        sa.Column("linked_trade_journal_id", sa.BigInteger(), nullable=True),
+        sa.Column("linked_order_ledger_ref", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("valid_until", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.CheckConstraint("side IN ('buy','sell')", name="analysis_candidates_side_allowed"),
+        sa.CheckConstraint(
+            "approval_status IN ('awaiting_approval','approved','rejected','expired')",
+            name="analysis_candidates_approval_status_allowed",
+        ),
+        sa.CheckConstraint(
+            "execution_state IN ('not_submitted','blocked','submitted_elsewhere')",
+            name="analysis_candidates_execution_state_allowed",
+        ),
+        sa.ForeignKeyConstraint(["report_id"], ["review.analysis_reports.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint("candidate_uuid", name="uq_analysis_candidates_candidate_uuid"),
+        sa.UniqueConstraint("idempotency_key", name="uq_analysis_candidates_idempotency_key"),
+        schema="review",
+    )
+    op.create_index(
+        "ix_analysis_candidates_symbol_market",
+        "analysis_order_candidates",
+        ["symbol", "market"],
+        schema="review",
+    )
+    op.create_index(
+        "ix_analysis_candidates_approval",
+        "analysis_order_candidates",
+        ["approval_status", "created_at"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_analysis_candidates_approval", table_name="analysis_order_candidates", schema="review")
+    op.drop_index("ix_analysis_candidates_symbol_market", table_name="analysis_order_candidates", schema="review")
+    op.drop_table("analysis_order_candidates", schema="review")
+    op.drop_index("ix_analysis_stage_results_report", table_name="analysis_stage_results", schema="review")
+    op.drop_table("analysis_stage_results", schema="review")
+    op.drop_index("ix_analysis_reports_status_created", table_name="analysis_reports", schema="review")
+    op.drop_index("ix_analysis_reports_market_created", table_name="analysis_reports", schema="review")
+    op.drop_table("analysis_reports", schema="review")

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ from app.monitoring.trade_notifier import get_trade_notifier
 from app.routers import (
     ai_markdown,
     alpaca_paper_ledger,
+    analysis_reports,
     candidate_discovery,
     deprecated_pages,
     health,
@@ -177,6 +178,7 @@ def create_app() -> FastAPI:
     app.include_router(user_defaults.router)
     app.include_router(order_estimation.router)
     app.include_router(order_previews.router)
+    app.include_router(analysis_reports.router)
     app.include_router(symbol_settings.router)
     app.include_router(portfolio.router)
     app.include_router(ai_markdown.router)

--- a/app/mcp_server/tooling/analysis_reports_handlers.py
+++ b/app/mcp_server/tooling/analysis_reports_handlers.py
@@ -1,0 +1,117 @@
+"""MCP handlers for ROB-257 analysis report artifacts."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from app.core.db import AsyncSessionLocal
+from app.schemas.analysis_reports import AnalysisReportCreateRequest
+from app.services.analysis_report_service import AnalysisReportService
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+ANALYSIS_REPORT_TOOL_NAMES: set[str] = {
+    "analysis_report_create",
+    "analysis_report_list",
+    "analysis_report_get",
+    "analysis_candidate_list",
+    "analysis_candidate_get",
+}
+
+
+async def analysis_report_create_impl(**payload: Any) -> dict:
+    request = AnalysisReportCreateRequest.model_validate(payload)
+    async with AsyncSessionLocal() as db:
+        service = AnalysisReportService(db)
+        report = await service.create_report(request, created_by_profile="mcp")
+        return {
+            "success": True,
+            "idempotent": bool(report.get("idempotent", False)),
+            "report": report,
+        }
+
+
+async def analysis_report_list_impl(
+    market: str | None = None,
+    status: str | None = None,
+    limit: int = 20,
+) -> dict:
+    capped = max(1, min(int(limit), 100))
+    async with AsyncSessionLocal() as db:
+        service = AnalysisReportService(db)
+        result = await service.list_reports(market=market, status=status, limit=capped)
+        return {"success": True, **result}
+
+
+async def analysis_report_get_impl(report_uuid: str) -> dict:
+    async with AsyncSessionLocal() as db:
+        service = AnalysisReportService(db)
+        report = await service.get_report(report_uuid)
+        if report is None:
+            return {"success": False, "error": "not_found"}
+        return {"success": True, "report": report}
+
+
+async def analysis_candidate_list_impl(
+    market: str | None = None,
+    symbol: str | None = None,
+    approval_status: str | None = None,
+    limit: int = 50,
+) -> dict:
+    capped = max(1, min(int(limit), 100))
+    async with AsyncSessionLocal() as db:
+        service = AnalysisReportService(db)
+        result = await service.list_candidates(
+            market=market,
+            symbol=symbol,
+            approval_status=approval_status,
+            limit=capped,
+        )
+        return {"success": True, **result}
+
+
+async def analysis_candidate_get_impl(candidate_uuid: str) -> dict:
+    async with AsyncSessionLocal() as db:
+        service = AnalysisReportService(db)
+        candidate = await service.get_candidate(candidate_uuid)
+        if candidate is None:
+            return {"success": False, "error": "not_found"}
+        return {"success": True, "candidate": candidate}
+
+
+def register_analysis_report_tools(mcp: FastMCP) -> None:
+    mcp.tool(
+        name="analysis_report_create",
+        description=(
+            "Persist one ROB-257 analysis report decision artifact and candidates. "
+            "No broker/order submission is performed."
+        ),
+    )(analysis_report_create_impl)
+    mcp.tool(
+        name="analysis_report_list",
+        description="List analysis report artifacts (read-only, limit clamped to 1..100).",
+    )(analysis_report_list_impl)
+    mcp.tool(
+        name="analysis_report_get",
+        description="Fetch one analysis report artifact by report_uuid (read-only).",
+    )(analysis_report_get_impl)
+    mcp.tool(
+        name="analysis_candidate_list",
+        description="List analysis action-center candidates (read-only, limit clamped to 1..100).",
+    )(analysis_candidate_list_impl)
+    mcp.tool(
+        name="analysis_candidate_get",
+        description="Fetch one analysis action-center candidate by candidate_uuid (read-only).",
+    )(analysis_candidate_get_impl)
+
+
+__all__ = [
+    "ANALYSIS_REPORT_TOOL_NAMES",
+    "analysis_candidate_get_impl",
+    "analysis_candidate_list_impl",
+    "analysis_report_create_impl",
+    "analysis_report_get_impl",
+    "analysis_report_list_impl",
+    "register_analysis_report_tools",
+]

--- a/app/mcp_server/tooling/analysis_reports_handlers.py
+++ b/app/mcp_server/tooling/analysis_reports_handlers.py
@@ -20,7 +20,42 @@ ANALYSIS_REPORT_TOOL_NAMES: set[str] = {
 }
 
 
-async def analysis_report_create_impl(**payload: Any) -> dict:
+async def analysis_report_create_impl(
+    idempotency_key: str,
+    report_type: str,
+    market: str,
+    summary: str,
+    account_scope: str | None = None,
+    status: str = "draft",
+    risk_summary: str | None = None,
+    data_freshness: dict[str, Any] | None = None,
+    coverage: dict[str, Any] | None = None,
+    source_policy: list[str] | None = None,
+    safety_notes: list[str] | None = None,
+    metadata: dict[str, Any] | None = None,
+    stage_results: list[dict[str, Any]] | None = None,
+    candidates: list[dict[str, Any]] | None = None,
+    published_at: str | None = None,
+    valid_until: str | None = None,
+) -> dict:
+    payload = {
+        "idempotency_key": idempotency_key,
+        "report_type": report_type,
+        "market": market,
+        "account_scope": account_scope,
+        "status": status,
+        "summary": summary,
+        "risk_summary": risk_summary,
+        "data_freshness": {} if data_freshness is None else data_freshness,
+        "coverage": {} if coverage is None else coverage,
+        "source_policy": [] if source_policy is None else source_policy,
+        "safety_notes": [] if safety_notes is None else safety_notes,
+        "metadata": {} if metadata is None else metadata,
+        "stage_results": [] if stage_results is None else stage_results,
+        "candidates": [] if candidates is None else candidates,
+        "published_at": published_at,
+        "valid_until": valid_until,
+    }
     request = AnalysisReportCreateRequest.model_validate(payload)
     async with AsyncSessionLocal() as db:
         service = AnalysisReportService(db)

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -33,6 +33,9 @@ from app.mcp_server.tooling.alpaca_paper_preview import (
     register_alpaca_paper_preview_tools,
 )
 from app.mcp_server.tooling.analysis_registration import register_analysis_tools
+from app.mcp_server.tooling.analysis_reports_handlers import (
+    register_analysis_report_tools,
+)
 from app.mcp_server.tooling.execution_comment_registration import (
     register_execution_comment_tools,
 )
@@ -98,6 +101,7 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
     register_market_data_tools(mcp)
     register_fundamentals_tools(mcp)
     register_analysis_tools(mcp)
+    register_analysis_report_tools(mcp)
     register_watch_alert_tools(mcp)
     register_trade_profile_tools(mcp)
     register_market_report_tools(mcp)

--- a/app/models/review.py
+++ b/app/models/review.py
@@ -531,3 +531,170 @@ class WatchOrderIntentLedger(Base):
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
     )
+
+
+# ---------------------------------------------------------------------------
+# review.analysis_reports — analyst/research decision artifacts (ROB-257)
+# ---------------------------------------------------------------------------
+class AnalysisReport(Base):
+    """Persisted analyst report artifact isolated from broker execution paths."""
+
+    __tablename__ = "analysis_reports"
+    __table_args__ = (
+        UniqueConstraint("report_uuid", name="uq_analysis_reports_report_uuid"),
+        UniqueConstraint("idempotency_key", name="uq_analysis_reports_idempotency_key"),
+        CheckConstraint(
+            "status IN ('draft','published','superseded','expired')",
+            name="analysis_reports_status_allowed",
+        ),
+        Index("ix_analysis_reports_market_created", "market", "created_at"),
+        Index("ix_analysis_reports_status_created", "status", "created_at"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    report_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False, default=uuid.uuid4
+    )
+    idempotency_key: Mapped[str] = mapped_column(Text, nullable=False)
+    report_type: Mapped[str] = mapped_column(Text, nullable=False)
+    market: Mapped[str] = mapped_column(Text, nullable=False)
+    account_scope: Mapped[str | None] = mapped_column(Text)
+    created_by_profile: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="draft")
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    risk_summary: Mapped[str | None] = mapped_column(Text)
+    data_freshness: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    coverage: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    source_policy: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    safety_notes: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    report_metadata: Mapped[dict] = mapped_column(
+        "metadata", JSONB, nullable=False, default=dict
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+    published_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    valid_until: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+
+
+class AnalysisStageResult(Base):
+    """Normalized source/stage result attached to an analysis report."""
+
+    __tablename__ = "analysis_stage_results"
+    __table_args__ = (
+        UniqueConstraint(
+            "report_id",
+            "stage_key",
+            "source",
+            name="uq_analysis_stage_report_stage_source",
+        ),
+        CheckConstraint(
+            "status IN ('ok','stale','unavailable','error')",
+            name="analysis_stage_status_allowed",
+        ),
+        Index("ix_analysis_stage_results_report", "report_id"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    report_id: Mapped[int] = mapped_column(
+        ForeignKey("review.analysis_reports.id", ondelete="CASCADE"), nullable=False
+    )
+    stage_key: Mapped[str] = mapped_column(Text, nullable=False)
+    source: Mapped[str] = mapped_column(Text, nullable=False)
+    provenance: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    freshness_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    raw_payload: Mapped[dict | None] = mapped_column(JSONB)
+    normalized_payload: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict
+    )
+    unavailable_reason: Mapped[str | None] = mapped_column(Text)
+    warnings: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class AnalysisOrderCandidate(Base):
+    """Manual-approval action candidate derived from an analysis report."""
+
+    __tablename__ = "analysis_order_candidates"
+    __table_args__ = (
+        UniqueConstraint(
+            "candidate_uuid", name="uq_analysis_candidates_candidate_uuid"
+        ),
+        UniqueConstraint(
+            "idempotency_key", name="uq_analysis_candidates_idempotency_key"
+        ),
+        CheckConstraint(
+            "side IN ('buy','sell')", name="analysis_candidates_side_allowed"
+        ),
+        CheckConstraint(
+            "approval_status IN ('awaiting_approval','approved','rejected','expired')",
+            name="analysis_candidates_approval_status_allowed",
+        ),
+        CheckConstraint(
+            "execution_state IN ('not_submitted','blocked','submitted_elsewhere')",
+            name="analysis_candidates_execution_state_allowed",
+        ),
+        Index("ix_analysis_candidates_symbol_market", "symbol", "market"),
+        Index("ix_analysis_candidates_approval", "approval_status", "created_at"),
+        {"schema": "review"},
+    )
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    report_id: Mapped[int] = mapped_column(
+        ForeignKey("review.analysis_reports.id", ondelete="CASCADE"), nullable=False
+    )
+    candidate_uuid: Mapped[uuid.UUID] = mapped_column(
+        PG_UUID(as_uuid=True), nullable=False, default=uuid.uuid4
+    )
+    idempotency_key: Mapped[str] = mapped_column(Text, nullable=False)
+    symbol: Mapped[str] = mapped_column(Text, nullable=False)
+    market: Mapped[str] = mapped_column(Text, nullable=False)
+    side: Mapped[str] = mapped_column(Text, nullable=False)
+    action_type: Mapped[str] = mapped_column(Text, nullable=False)
+    quantity: Mapped[float | None] = mapped_column(Numeric(20, 8))
+    quantity_pct: Mapped[float | None] = mapped_column(Numeric(10, 6))
+    limit_price: Mapped[float | None] = mapped_column(Numeric(20, 4))
+    notional: Mapped[float | None] = mapped_column(Numeric(20, 4))
+    currency: Mapped[str | None] = mapped_column(Text)
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    confidence: Mapped[float | None] = mapped_column(Numeric(8, 4))
+    thesis: Mapped[str] = mapped_column(Text, nullable=False)
+    risk_notes: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    verification: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    blocking_reasons: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    approval_status: Mapped[str] = mapped_column(
+        Text, nullable=False, default="awaiting_approval"
+    )
+    approval_type: Mapped[str] = mapped_column(Text, nullable=False, default="manual")
+    approved_by: Mapped[str | None] = mapped_column(Text)
+    approved_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    rejected_by: Mapped[str | None] = mapped_column(Text)
+    rejected_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    policy_id: Mapped[str | None] = mapped_column(Text)
+    policy_snapshot: Mapped[dict | None] = mapped_column(JSONB)
+    execution_state: Mapped[str] = mapped_column(
+        Text, nullable=False, default="not_submitted"
+    )
+    linked_trade_journal_id: Mapped[int | None] = mapped_column(BigInteger)
+    linked_order_ledger_ref: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+    valid_until: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))

--- a/app/routers/analysis_reports.py
+++ b/app/routers/analysis_reports.py
@@ -1,0 +1,108 @@
+"""ROB-257 analyst report/action-center API routes."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.models.trading import User
+from app.routers.dependencies import get_authenticated_user
+from app.schemas.analysis_reports import (
+    AnalysisCandidateListResponse,
+    AnalysisOrderCandidateResponse,
+    AnalysisReportCreateRequest,
+    AnalysisReportListResponse,
+    AnalysisReportResponse,
+)
+from app.services.analysis_report_service import AnalysisReportService
+
+router = APIRouter(tags=["analysis-reports"])
+
+
+def get_analysis_report_service(
+    db: AsyncSession = Depends(get_db),
+) -> AnalysisReportService:
+    return AnalysisReportService(db)
+
+
+@router.post(
+    "/trading/api/analysis-reports",
+    response_model=AnalysisReportResponse,
+    summary="Create a decision-only analysis report artifact",
+)
+async def create_analysis_report(
+    request: AnalysisReportCreateRequest,
+    user: Annotated[User, Depends(get_authenticated_user)],
+    service: Annotated[AnalysisReportService, Depends(get_analysis_report_service)],
+) -> dict:
+    created_by = (
+        getattr(user, "username", None) or getattr(user, "email", None) or "analyst"
+    )
+    return await service.create_report(request, created_by_profile=created_by)
+
+
+@router.get(
+    "/trading/api/analysis-reports",
+    response_model=AnalysisReportListResponse,
+    summary="List analysis report artifacts",
+)
+async def list_analysis_reports(
+    service: Annotated[AnalysisReportService, Depends(get_analysis_report_service)],
+    market: str | None = None,
+    status_filter: Annotated[str | None, Query(alias="status")] = None,
+    limit: int = Query(default=20, ge=1, le=100),
+) -> dict:
+    return await service.list_reports(market=market, status=status_filter, limit=limit)
+
+
+@router.get(
+    "/trading/api/analysis-reports/{report_uuid}",
+    response_model=AnalysisReportResponse,
+    summary="Get one analysis report artifact",
+)
+async def get_analysis_report(
+    report_uuid: str,
+    service: Annotated[AnalysisReportService, Depends(get_analysis_report_service)],
+) -> dict:
+    report = await service.get_report(report_uuid)
+    if report is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not_found")
+    return report
+
+
+@router.get(
+    "/invest/api/action-center/candidates",
+    response_model=AnalysisCandidateListResponse,
+    summary="List decision-only action center candidates",
+)
+async def list_action_center_candidates(
+    service: Annotated[AnalysisReportService, Depends(get_analysis_report_service)],
+    market: str | None = None,
+    symbol: str | None = None,
+    approval_status: str | None = None,
+    limit: int = Query(default=50, ge=1, le=100),
+) -> dict:
+    return await service.list_candidates(
+        market=market,
+        symbol=symbol,
+        approval_status=approval_status,
+        limit=limit,
+    )
+
+
+@router.get(
+    "/invest/api/action-center/candidates/{candidate_uuid}",
+    response_model=AnalysisOrderCandidateResponse,
+    summary="Get one decision-only action center candidate",
+)
+async def get_action_center_candidate(
+    candidate_uuid: str,
+    service: Annotated[AnalysisReportService, Depends(get_analysis_report_service)],
+) -> dict:
+    candidate = await service.get_candidate(candidate_uuid)
+    if candidate is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not_found")
+    return candidate

--- a/app/routers/analysis_reports.py
+++ b/app/routers/analysis_reports.py
@@ -45,6 +45,11 @@ async def create_analysis_report(
 
 
 @router.get(
+    "/invest/api/action-center/reports",
+    response_model=AnalysisReportListResponse,
+    summary="List action center analysis report artifacts",
+)
+@router.get(
     "/trading/api/analysis-reports",
     response_model=AnalysisReportListResponse,
     summary="List analysis report artifacts",
@@ -58,6 +63,11 @@ async def list_analysis_reports(
     return await service.list_reports(market=market, status=status_filter, limit=limit)
 
 
+@router.get(
+    "/invest/api/action-center/reports/{report_uuid}",
+    response_model=AnalysisReportResponse,
+    summary="Get one action center analysis report artifact",
+)
 @router.get(
     "/trading/api/analysis-reports/{report_uuid}",
     response_model=AnalysisReportResponse,

--- a/app/schemas/analysis_reports.py
+++ b/app/schemas/analysis_reports.py
@@ -1,0 +1,169 @@
+"""Schemas for ROB-257 analyst report action-center artifacts."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+ReportStatus = Literal["draft", "published", "superseded", "expired"]
+StageStatus = Literal["ok", "stale", "unavailable", "error"]
+CandidateSide = Literal["buy", "sell"]
+ApprovalStatus = Literal["awaiting_approval", "approved", "rejected", "expired"]
+ExecutionState = Literal["not_submitted", "blocked", "submitted_elsewhere"]
+
+
+class AnalysisStageResultCreate(BaseModel):
+    stage_key: str
+    source: str
+    provenance: dict[str, Any] = Field(default_factory=dict)
+    status: StageStatus
+    freshness_at: datetime | None = None
+    raw_payload: dict[str, Any] | None = None
+    normalized_payload: dict[str, Any] = Field(default_factory=dict)
+    unavailable_reason: str | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+
+class AnalysisOrderCandidateCreate(BaseModel):
+    idempotency_key: str
+    symbol: str
+    market: str
+    side: CandidateSide
+    action_type: str
+    quantity: Decimal | None = None
+    quantity_pct: Decimal | None = None
+    limit_price: Decimal | None = None
+    notional: Decimal | None = None
+    currency: str | None = None
+    priority: int = 0
+    confidence: Decimal | None = None
+    thesis: str
+    risk_notes: list[str] = Field(default_factory=list)
+    verification: dict[str, Any] = Field(default_factory=dict)
+    blocking_reasons: list[str] = Field(default_factory=list)
+    approval_status: ApprovalStatus = "awaiting_approval"
+    approval_type: str = "manual"
+    policy_id: str | None = None
+    policy_snapshot: dict[str, Any] | None = None
+    execution_state: ExecutionState = "not_submitted"
+    valid_until: datetime | None = None
+
+    @field_validator("execution_state")
+    @classmethod
+    def _no_submitted_execution_state(cls, value: ExecutionState) -> ExecutionState:
+        if value != "not_submitted":
+            raise ValueError(
+                "analysis candidates are decision artifacts and must not be submitted"
+            )
+        return value
+
+
+class AnalysisReportCreateRequest(BaseModel):
+    idempotency_key: str
+    report_type: str
+    market: str
+    account_scope: str | None = None
+    status: ReportStatus = "draft"
+    summary: str
+    risk_summary: str | None = None
+    data_freshness: dict[str, Any] = Field(default_factory=dict)
+    coverage: dict[str, Any] = Field(default_factory=dict)
+    source_policy: list[str] = Field(default_factory=list)
+    safety_notes: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    stage_results: list[AnalysisStageResultCreate] = Field(default_factory=list)
+    candidates: list[AnalysisOrderCandidateCreate] = Field(default_factory=list)
+    published_at: datetime | None = None
+    valid_until: datetime | None = None
+
+
+class AnalysisStageResultResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    stage_key: str
+    source: str
+    provenance: dict[str, Any]
+    status: StageStatus
+    freshness_at: datetime | None
+    raw_payload: dict[str, Any] | None
+    normalized_payload: dict[str, Any]
+    unavailable_reason: str | None
+    warnings: list[str]
+    created_at: datetime
+
+
+class AnalysisOrderCandidateResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    candidate_uuid: str
+    report_uuid: str | None = None
+    idempotency_key: str
+    symbol: str
+    market: str
+    side: CandidateSide
+    action_type: str
+    quantity: Decimal | None
+    quantity_pct: Decimal | None
+    limit_price: Decimal | None
+    notional: Decimal | None
+    currency: str | None
+    priority: int
+    confidence: Decimal | None
+    thesis: str
+    risk_notes: list[str]
+    verification: dict[str, Any]
+    blocking_reasons: list[str]
+    approval_status: ApprovalStatus
+    approval_type: str
+    approved_by: str | None = None
+    approved_at: datetime | None = None
+    rejected_by: str | None = None
+    rejected_at: datetime | None = None
+    policy_id: str | None = None
+    policy_snapshot: dict[str, Any] | None = None
+    execution_state: ExecutionState
+    linked_trade_journal_id: int | None = None
+    linked_order_ledger_ref: str | None = None
+    created_at: datetime
+    valid_until: datetime | None = None
+
+
+class AnalysisReportResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    report_uuid: str
+    idempotency_key: str
+    report_type: str
+    market: str
+    account_scope: str | None
+    created_by_profile: str
+    status: ReportStatus
+    summary: str
+    risk_summary: str | None
+    data_freshness: dict[str, Any]
+    coverage: dict[str, Any]
+    source_policy: list[str]
+    safety_notes: list[str]
+    metadata: dict[str, Any]
+    created_at: datetime
+    published_at: datetime | None = None
+    valid_until: datetime | None = None
+    stages: list[AnalysisStageResultResponse] = Field(default_factory=list)
+    candidates: list[AnalysisOrderCandidateResponse] = Field(default_factory=list)
+    idempotent: bool = False
+
+
+class AnalysisReportListResponse(BaseModel):
+    count: int
+    items: list[AnalysisReportResponse]
+
+
+class AnalysisCandidateListResponse(BaseModel):
+    count: int
+    items: list[AnalysisOrderCandidateResponse]

--- a/app/services/analysis_report_service.py
+++ b/app/services/analysis_report_service.py
@@ -1,0 +1,318 @@
+"""Service layer for ROB-257 analyst report decision artifacts.
+
+This service persists analyst/research report outputs and manual-approval
+candidates only. It does not call broker, order, watch, or notification clients.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.review import (
+    AnalysisOrderCandidate,
+    AnalysisReport,
+    AnalysisStageResult,
+)
+from app.schemas.analysis_reports import AnalysisReportCreateRequest
+
+
+class AnalysisReportService:
+    """Only write/read path for ROB-257 analysis report artifacts."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def create_report(
+        self, request: AnalysisReportCreateRequest, *, created_by_profile: str
+    ) -> dict[str, Any]:
+        existing = await self._get_report_by_idempotency(request.idempotency_key)
+        if existing is not None:
+            serialized = await self._serialize_report(existing)
+            serialized["idempotent"] = True
+            return serialized
+
+        report = AnalysisReport(
+            idempotency_key=request.idempotency_key,
+            report_type=request.report_type,
+            market=request.market,
+            account_scope=request.account_scope,
+            created_by_profile=created_by_profile,
+            status=request.status,
+            summary=request.summary,
+            risk_summary=request.risk_summary,
+            data_freshness=request.data_freshness,
+            coverage=request.coverage,
+            source_policy=request.source_policy,
+            safety_notes=request.safety_notes,
+            report_metadata=request.metadata,
+            published_at=request.published_at,
+            valid_until=request.valid_until,
+        )
+        self.db.add(report)
+        await self.db.flush()
+
+        for stage in request.stage_results:
+            self.db.add(
+                AnalysisStageResult(
+                    report_id=report.id,
+                    stage_key=stage.stage_key,
+                    source=stage.source,
+                    provenance=stage.provenance,
+                    status=stage.status,
+                    freshness_at=stage.freshness_at,
+                    raw_payload=stage.raw_payload,
+                    normalized_payload=stage.normalized_payload,
+                    unavailable_reason=stage.unavailable_reason,
+                    warnings=stage.warnings,
+                )
+            )
+
+        for candidate in request.candidates:
+            self.db.add(
+                AnalysisOrderCandidate(
+                    report_id=report.id,
+                    idempotency_key=candidate.idempotency_key,
+                    symbol=candidate.symbol,
+                    market=candidate.market,
+                    side=candidate.side,
+                    action_type=candidate.action_type,
+                    quantity=candidate.quantity,
+                    quantity_pct=candidate.quantity_pct,
+                    limit_price=candidate.limit_price,
+                    notional=candidate.notional,
+                    currency=candidate.currency,
+                    priority=candidate.priority,
+                    confidence=candidate.confidence,
+                    thesis=candidate.thesis,
+                    risk_notes=candidate.risk_notes,
+                    verification=candidate.verification,
+                    blocking_reasons=candidate.blocking_reasons,
+                    approval_status=candidate.approval_status,
+                    approval_type=candidate.approval_type,
+                    policy_id=candidate.policy_id,
+                    policy_snapshot=candidate.policy_snapshot,
+                    execution_state=candidate.execution_state,
+                    valid_until=candidate.valid_until,
+                )
+            )
+
+        await self.db.commit()
+        await self.db.refresh(report)
+        serialized = await self._serialize_report(report)
+        serialized["idempotent"] = False
+        return serialized
+
+    async def list_reports(
+        self,
+        *,
+        market: str | None = None,
+        status: str | None = None,
+        limit: int = 20,
+    ) -> dict[str, Any]:
+        limit = max(1, min(limit, 100))
+        stmt = (
+            select(AnalysisReport)
+            .order_by(AnalysisReport.created_at.desc())
+            .limit(limit)
+        )
+        if market:
+            stmt = stmt.where(AnalysisReport.market == market)
+        if status:
+            stmt = stmt.where(AnalysisReport.status == status)
+        rows = (await self.db.execute(stmt)).scalars().all()
+        items = [
+            await self._serialize_report(row, include_children=False) for row in rows
+        ]
+        return {"count": len(items), "items": items}
+
+    async def get_report(self, report_uuid: str) -> dict[str, Any] | None:
+        stmt = select(AnalysisReport).where(
+            AnalysisReport.report_uuid == _coerce_uuid(report_uuid)
+        )
+        row = (await self.db.execute(stmt)).scalar_one_or_none()
+        if row is None:
+            return None
+        return await self._serialize_report(row)
+
+    async def list_candidates(
+        self,
+        *,
+        market: str | None = None,
+        symbol: str | None = None,
+        approval_status: str | None = None,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        limit = max(1, min(limit, 100))
+        stmt = (
+            select(AnalysisOrderCandidate)
+            .order_by(
+                AnalysisOrderCandidate.priority.desc(),
+                AnalysisOrderCandidate.created_at.desc(),
+            )
+            .limit(limit)
+        )
+        if market:
+            stmt = stmt.where(AnalysisOrderCandidate.market == market)
+        if symbol:
+            stmt = stmt.where(AnalysisOrderCandidate.symbol == symbol)
+        if approval_status:
+            stmt = stmt.where(AnalysisOrderCandidate.approval_status == approval_status)
+        rows = (await self.db.execute(stmt)).scalars().all()
+        items = [await self._serialize_candidate(row) for row in rows]
+        return {"count": len(items), "items": items}
+
+    async def get_candidate(self, candidate_uuid: str) -> dict[str, Any] | None:
+        stmt = select(AnalysisOrderCandidate).where(
+            AnalysisOrderCandidate.candidate_uuid == _coerce_uuid(candidate_uuid)
+        )
+        row = (await self.db.execute(stmt)).scalar_one_or_none()
+        if row is None:
+            return None
+        return await self._serialize_candidate(row)
+
+    async def _get_report_by_idempotency(self, key: str) -> AnalysisReport | None:
+        stmt = select(AnalysisReport).where(AnalysisReport.idempotency_key == key)
+        return (await self.db.execute(stmt)).scalar_one_or_none()
+
+    async def _serialize_report(
+        self, report: AnalysisReport, *, include_children: bool = True
+    ) -> dict[str, Any]:
+        stages: list[dict[str, Any]] = []
+        candidates: list[dict[str, Any]] = []
+        if include_children:
+            stage_rows = (
+                (
+                    await self.db.execute(
+                        select(AnalysisStageResult)
+                        .where(AnalysisStageResult.report_id == report.id)
+                        .order_by(AnalysisStageResult.id.asc())
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            stages = [_serialize_stage(row) for row in stage_rows]
+            candidate_rows = (
+                (
+                    await self.db.execute(
+                        select(AnalysisOrderCandidate)
+                        .where(AnalysisOrderCandidate.report_id == report.id)
+                        .order_by(
+                            AnalysisOrderCandidate.priority.desc(),
+                            AnalysisOrderCandidate.id.asc(),
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            candidates = [
+                await self._serialize_candidate(row, report=report)
+                for row in candidate_rows
+            ]
+        return {
+            "id": report.id,
+            "report_uuid": str(report.report_uuid),
+            "idempotency_key": report.idempotency_key,
+            "report_type": report.report_type,
+            "market": report.market,
+            "account_scope": report.account_scope,
+            "created_by_profile": report.created_by_profile,
+            "status": report.status,
+            "summary": report.summary,
+            "risk_summary": report.risk_summary,
+            "data_freshness": report.data_freshness,
+            "coverage": report.coverage,
+            "source_policy": report.source_policy,
+            "safety_notes": report.safety_notes,
+            "metadata": report.report_metadata,
+            "created_at": report.created_at,
+            "published_at": report.published_at,
+            "valid_until": report.valid_until,
+            "stages": stages,
+            "candidates": candidates,
+        }
+
+    async def _serialize_candidate(
+        self, candidate: AnalysisOrderCandidate, *, report: AnalysisReport | None = None
+    ) -> dict[str, Any]:
+        report_uuid = None
+        if report is not None:
+            report_uuid = str(report.report_uuid)
+        elif candidate.report_id is not None:
+            stmt = select(AnalysisReport.report_uuid).where(
+                AnalysisReport.id == candidate.report_id
+            )
+            report_uuid_value = (await self.db.execute(stmt)).scalar_one_or_none()
+            report_uuid = (
+                str(report_uuid_value) if report_uuid_value is not None else None
+            )
+        return _serialize_candidate(candidate, report_uuid=report_uuid)
+
+
+def _serialize_stage(stage: AnalysisStageResult) -> dict[str, Any]:
+    return {
+        "id": stage.id,
+        "stage_key": stage.stage_key,
+        "source": stage.source,
+        "provenance": stage.provenance,
+        "status": stage.status,
+        "freshness_at": stage.freshness_at,
+        "raw_payload": stage.raw_payload,
+        "normalized_payload": stage.normalized_payload,
+        "unavailable_reason": stage.unavailable_reason,
+        "warnings": stage.warnings,
+        "created_at": stage.created_at,
+    }
+
+
+def _serialize_candidate(
+    candidate: AnalysisOrderCandidate, *, report_uuid: str | None
+) -> dict[str, Any]:
+    return {
+        "id": candidate.id,
+        "candidate_uuid": str(candidate.candidate_uuid),
+        "report_uuid": report_uuid,
+        "idempotency_key": candidate.idempotency_key,
+        "symbol": candidate.symbol,
+        "market": candidate.market,
+        "side": candidate.side,
+        "action_type": candidate.action_type,
+        "quantity": _decimal_or_none(candidate.quantity),
+        "quantity_pct": _decimal_or_none(candidate.quantity_pct),
+        "limit_price": _decimal_or_none(candidate.limit_price),
+        "notional": _decimal_or_none(candidate.notional),
+        "currency": candidate.currency,
+        "priority": candidate.priority,
+        "confidence": _decimal_or_none(candidate.confidence),
+        "thesis": candidate.thesis,
+        "risk_notes": candidate.risk_notes,
+        "verification": candidate.verification,
+        "blocking_reasons": candidate.blocking_reasons,
+        "approval_status": candidate.approval_status,
+        "approval_type": candidate.approval_type,
+        "approved_by": candidate.approved_by,
+        "approved_at": candidate.approved_at,
+        "rejected_by": candidate.rejected_by,
+        "rejected_at": candidate.rejected_at,
+        "policy_id": candidate.policy_id,
+        "policy_snapshot": candidate.policy_snapshot,
+        "execution_state": candidate.execution_state,
+        "linked_trade_journal_id": candidate.linked_trade_journal_id,
+        "linked_order_ledger_ref": candidate.linked_order_ledger_ref,
+        "created_at": candidate.created_at,
+        "valid_until": candidate.valid_until,
+    }
+
+
+def _decimal_or_none(value: Any) -> Decimal | None:
+    return None if value is None else Decimal(str(value))
+
+
+def _coerce_uuid(value: str) -> UUID:
+    return UUID(str(value))

--- a/frontend/invest/src/__tests__/DesktopActionCenterPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopActionCenterPage.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, expect, test, vi } from "vitest";
+
+import { DesktopActionCenterPage } from "../pages/desktop/DesktopActionCenterPage";
+import { useActionCenter } from "../hooks/useActionCenter";
+
+vi.mock("../hooks/useActionCenter", () => ({ useActionCenter: vi.fn() }));
+vi.mock("../desktop/RightRemotePanel", () => ({ RightRemotePanel: () => <div data-testid="right-remote-panel" /> }));
+
+const readyState = {
+  state: {
+    status: "ready" as const,
+    reports: {
+      reports: [
+        {
+          reportUuid: "report-1",
+          reportType: "daily",
+          market: "kr",
+          accountScope: "kis-live",
+          createdByProfile: "analyst",
+          status: "published",
+          summary: "삼성전자 후보와 현금 여력 점검",
+          riskSummary: "이벤트 리스크가 남아 있습니다.",
+          dataFreshness: {
+            accountFeasibility: "확인 불가",
+            marketLiquidity: "2026-05-15T09:10:00+09:00",
+          },
+          coverage: {
+            accountFeasibility: "확인 불가",
+            eventRisk: "degraded",
+          },
+          sourcePolicy: ["KIS live is account/order authority"],
+          safetyNotes: ["이 화면은 주문 실행이 아닙니다."],
+          createdAt: "2026-05-15T00:00:00Z",
+          publishedAt: "2026-05-15T00:01:00Z",
+          validUntil: null,
+          stageResults: [
+            {
+              stageKey: "account_feasibility",
+              source: "kis_live",
+              status: "unavailable",
+              freshnessAt: null,
+              unavailableReason: "확인 불가",
+              warnings: ["계좌 여력 확인 필요"],
+            },
+          ],
+          candidates: [],
+        },
+      ],
+      unavailableLabel: "확인 불가",
+    },
+    candidates: {
+      candidates: [
+        {
+          candidateUuid: "cand-1",
+          reportUuid: "report-1",
+          symbol: "005930",
+          market: "kr",
+          side: "buy",
+          actionType: "buy_candidate",
+          quantity: null,
+          quantityPct: 12.5,
+          limitPrice: null,
+          notional: null,
+          currency: "KRW",
+          priority: 8,
+          confidence: 0.72,
+          thesis: "메모리 업황 개선과 수급 회복 기대",
+          riskNotes: ["정규장 유동성 확인 필요", "뉴스 리스크 확인 필요"],
+          verification: {
+            accountFeasibility: "확인 불가",
+            liquidity: "확인 불가",
+            eventNewsRisk: "확인 불가",
+          },
+          blockingReasons: ["계좌 여력 확인 필요"],
+          approvalStatus: "awaiting_approval",
+          approvalType: "manual",
+          executionState: "not_submitted",
+          createdAt: "2026-05-15T00:02:00Z",
+          validUntil: null,
+        },
+      ],
+      unavailableLabel: "확인 불가",
+    },
+  },
+  reload: vi.fn(),
+};
+
+function wrap(ui: React.ReactElement) {
+  return <MemoryRouter basename="/invest" initialEntries={["/invest/action-center"]}>{ui}</MemoryRouter>;
+}
+
+beforeEach(() => {
+  vi.mocked(useActionCenter).mockReturnValue(readyState);
+});
+
+test("renders analyst reports, candidate queue, and unavailable markers", () => {
+  render(wrap(<DesktopActionCenterPage />));
+
+  expect(screen.getByRole("heading", { name: "액션 센터" })).toBeInTheDocument();
+  expect(screen.getByText("삼성전자 후보와 현금 여력 점검")).toBeInTheDocument();
+  expect(screen.getByText("005930")).toBeInTheDocument();
+  expect(screen.getAllByText("확인 불가").length).toBeGreaterThanOrEqual(3);
+  expect(screen.getAllByText(/계좌 여력 확인 필요/).length).toBeGreaterThanOrEqual(1);
+  expect(screen.getByText(/정규장 확인 필요/)).toBeInTheDocument();
+});
+
+test("keeps approval controls read-only and separates approval from execution state", () => {
+  render(wrap(<DesktopActionCenterPage />));
+
+  expect(screen.getByText("승인 상태: awaiting_approval")).toBeInTheDocument();
+  expect(screen.getByText("실행 상태: not_submitted")).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "승인 기록은 수동 처리" })).toBeDisabled();
+  expect(screen.getByRole("button", { name: "거절 기록은 수동 처리" })).toBeDisabled();
+  expect(screen.getByText(/의사결정\/승인 대기 자료이며 주문 실행이 아닙니다/)).toBeInTheDocument();
+});
+
+test("renders loading and error states without hiding non-execution copy", () => {
+  vi.mocked(useActionCenter).mockReturnValueOnce({ state: { status: "loading" }, reload: vi.fn() });
+  const { rerender } = render(wrap(<DesktopActionCenterPage />));
+  expect(screen.getByText(/액션 센터 데이터를 불러오는 중/)).toBeInTheDocument();
+  expect(screen.getAllByText(/주문 실행이 아닙니다/).length).toBeGreaterThanOrEqual(1);
+
+  vi.mocked(useActionCenter).mockReturnValueOnce({ state: { status: "error", message: "boom" }, reload: vi.fn() });
+  rerender(wrap(<DesktopActionCenterPage />));
+  expect(screen.getByText(/액션 센터 데이터를 일시적으로 불러오지 못했습니다/)).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "재시도" })).toBeInTheDocument();
+});

--- a/frontend/invest/src/__tests__/actionCenter.api.test.ts
+++ b/frontend/invest/src/__tests__/actionCenter.api.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, expect, test, vi } from "vitest";
+
+import { fetchActionCenterCandidates, fetchActionCenterReport, fetchActionCenterReports } from "../api/actionCenter";
+
+const REPORTS_PAYLOAD = {
+  reports: [
+    {
+      reportUuid: "report-1",
+      reportType: "daily",
+      market: "kr",
+      accountScope: "kis-live",
+      createdByProfile: "analyst",
+      status: "published",
+      summary: "오늘의 후보 요약",
+      riskSummary: "정규장 확인 필요",
+      dataFreshness: { accountFeasibility: "확인 불가" },
+      coverage: { liquidity: "degraded" },
+      safetyNotes: ["주문 실행이 아닙니다."],
+      createdAt: "2026-05-15T00:00:00Z",
+      publishedAt: "2026-05-15T00:01:00Z",
+      validUntil: null,
+      stageResults: [],
+      candidates: [],
+    },
+  ],
+  unavailableLabel: "확인 불가",
+};
+
+const CANDIDATES_PAYLOAD = {
+  candidates: [
+    {
+      candidateUuid: "cand-1",
+      reportUuid: "report-1",
+      symbol: "005930",
+      market: "kr",
+      side: "buy",
+      actionType: "buy_candidate",
+      priority: 10,
+      confidence: 0.72,
+      thesis: "실적 모멘텀",
+      riskNotes: ["뉴스 리스크 확인 필요"],
+      verification: { accountFeasibility: "확인 불가" },
+      blockingReasons: [],
+      approvalStatus: "awaiting_approval",
+      approvalType: "manual",
+      executionState: "not_submitted",
+      createdAt: "2026-05-15T00:02:00Z",
+      validUntil: null,
+    },
+  ],
+  unavailableLabel: "확인 불가",
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("fetchActionCenterReports reads the non-executing invest action center report endpoint", async () => {
+  const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify(REPORTS_PAYLOAD), { status: 200, headers: { "content-type": "application/json" } }),
+  );
+
+  await expect(fetchActionCenterReports()).resolves.toEqual(REPORTS_PAYLOAD);
+  expect(fetchMock).toHaveBeenCalledWith("/invest/api/action-center/reports", {
+    credentials: "include",
+    signal: undefined,
+  });
+});
+
+test("fetchActionCenterReport reads one report by uuid without mutating approval or orders", async () => {
+  const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify(REPORTS_PAYLOAD.reports[0]), { status: 200, headers: { "content-type": "application/json" } }),
+  );
+
+  await expect(fetchActionCenterReport("report-1")).resolves.toEqual(REPORTS_PAYLOAD.reports[0]);
+  expect(fetchMock).toHaveBeenCalledWith("/invest/api/action-center/reports/report-1", {
+    credentials: "include",
+    signal: undefined,
+  });
+});
+
+test("fetchActionCenterCandidates reads the non-executing candidate queue endpoint", async () => {
+  const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    new Response(JSON.stringify(CANDIDATES_PAYLOAD), { status: 200, headers: { "content-type": "application/json" } }),
+  );
+
+  await expect(fetchActionCenterCandidates()).resolves.toEqual(CANDIDATES_PAYLOAD);
+  expect(fetchMock).toHaveBeenCalledWith("/invest/api/action-center/candidates", {
+    credentials: "include",
+    signal: undefined,
+  });
+});
+
+test("action center fetch errors include only the endpoint and status", async () => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("broker token should not echo", { status: 503 }));
+
+  await expect(fetchActionCenterCandidates()).rejects.toThrow("/invest/api/action-center/candidates 503");
+});

--- a/frontend/invest/src/api/actionCenter.ts
+++ b/frontend/invest/src/api/actionCenter.ts
@@ -1,0 +1,24 @@
+import type { AnalysisCandidateQueueResponse, AnalysisReport, AnalysisReportListResponse } from "../types/actionCenter";
+
+const REPORTS_ENDPOINT = "/invest/api/action-center/reports";
+const CANDIDATES_ENDPOINT = "/invest/api/action-center/candidates";
+
+async function readJson<T>(endpoint: string, signal?: AbortSignal): Promise<T> {
+  const res = await fetch(endpoint, { credentials: "include", signal });
+  if (!res.ok) {
+    throw new Error(`${endpoint} ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function fetchActionCenterReports(signal?: AbortSignal): Promise<AnalysisReportListResponse> {
+  return readJson<AnalysisReportListResponse>(REPORTS_ENDPOINT, signal);
+}
+
+export async function fetchActionCenterReport(reportUuid: string, signal?: AbortSignal): Promise<AnalysisReport> {
+  return readJson<AnalysisReport>(`${REPORTS_ENDPOINT}/${encodeURIComponent(reportUuid)}`, signal);
+}
+
+export async function fetchActionCenterCandidates(signal?: AbortSignal): Promise<AnalysisCandidateQueueResponse> {
+  return readJson<AnalysisCandidateQueueResponse>(CANDIDATES_ENDPOINT, signal);
+}

--- a/frontend/invest/src/components/action-center/ActionCenterContent.tsx
+++ b/frontend/invest/src/components/action-center/ActionCenterContent.tsx
@@ -1,0 +1,105 @@
+import { Link } from "react-router-dom";
+import { AnalystReportCard } from "./AnalystReportCard";
+import { CandidateCard } from "./CandidateCard";
+import { Card } from "../../ds";
+import { useActionCenter } from "../../hooks/useActionCenter";
+
+function SafetyHero() {
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 9 }}>
+        <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 900 }}>ROB-257 analyst report action center</div>
+        <h1 style={{ margin: 0, fontSize: 28, letterSpacing: "-0.05em" }}>액션 센터</h1>
+        <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 14, lineHeight: 1.65 }}>
+          이 화면은 의사결정/승인 대기 자료이며 주문 실행이 아닙니다. 승인·거절은 현재 read-only 수동 검토 상태로 표시하고,
+          KIS live를 계좌·주문 권한의 기준으로 둡니다.
+        </p>
+        <div style={{ color: "var(--warn)", fontSize: 13, fontWeight: 800 }}>
+          정규장 확인 필요 · NXT/프리마켓/시간외 시장가 또는 시장가 유사 실행은 금지
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function StatusCard({ children }: { children: React.ReactNode }) {
+  return <Card><div role="status" style={{ color: "var(--fg-3)", fontSize: 13 }}>{children}</div></Card>;
+}
+
+export function ActionCenterContent({ compact = false }: { compact?: boolean }) {
+  const actionCenter = useActionCenter();
+
+  return (
+    <div style={{ padding: compact ? "14px 16px 22px" : 24, display: "grid", gap: 16 }}>
+      <SafetyHero />
+
+      {actionCenter.state.status === "loading" && <StatusCard>액션 센터 데이터를 불러오는 중… 주문 실행이 아닙니다.</StatusCard>}
+      {actionCenter.state.status === "error" && (
+        <Card>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center" }}>
+            <div style={{ color: "var(--danger)", fontSize: 13 }}>액션 센터 데이터를 일시적으로 불러오지 못했습니다.</div>
+            <button
+              type="button"
+              onClick={actionCenter.reload}
+              style={{
+                padding: "6px 12px",
+                borderRadius: 10,
+                border: "1px solid var(--border)",
+                background: "var(--surface-2)",
+                color: "var(--fg-1)",
+                fontFamily: "inherit",
+                fontWeight: 800,
+                cursor: "pointer",
+              }}
+            >
+              재시도
+            </button>
+          </div>
+        </Card>
+      )}
+
+      {actionCenter.state.status === "ready" && (
+        <>
+          <section style={{ display: "grid", gap: 10 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 10 }}>
+              <h2 style={{ margin: 0, fontSize: 18 }}>최신 애널리스트 리포트</h2>
+              <span style={{ color: "var(--fg-3)", fontSize: 12 }}>{actionCenter.state.reports.reports.length}개</span>
+            </div>
+            {actionCenter.state.reports.reports.length === 0 ? (
+              <StatusCard>표시할 리포트가 없습니다. 확인 불가</StatusCard>
+            ) : (
+              actionCenter.state.reports.reports.map((report) => <AnalystReportCard key={report.reportUuid} report={report} />)
+            )}
+          </section>
+
+          <section style={{ display: "grid", gap: 10 }}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 10 }}>
+              <h2 style={{ margin: 0, fontSize: 18 }}>승인 대기 후보</h2>
+              <span style={{ color: "var(--fg-3)", fontSize: 12 }}>{actionCenter.state.candidates.candidates.length}개</span>
+            </div>
+            {actionCenter.state.candidates.candidates.length === 0 ? (
+              <StatusCard>표시할 후보가 없습니다. 확인 불가</StatusCard>
+            ) : (
+              actionCenter.state.candidates.candidates.map((candidate) => (
+                <CandidateCard key={candidate.candidateUuid} candidate={candidate} />
+              ))
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  );
+}
+
+export function ActionCenterRelatedLinks() {
+  return (
+    <Card>
+      <div style={{ fontWeight: 900, marginBottom: 8 }}>관련 화면</div>
+      <div style={{ display: "grid", gap: 8, fontSize: 13 }}>
+        <Link to="/" style={{ color: "var(--fg-1)", textDecoration: "none" }}>홈</Link>
+        <Link to="/insights" style={{ color: "var(--fg-1)", textDecoration: "none" }}>인사이트</Link>
+        <Link to="/my?tab=signals" style={{ color: "var(--fg-1)", textDecoration: "none" }}>시그널</Link>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/invest/src/components/action-center/AnalystReportCard.tsx
+++ b/frontend/invest/src/components/action-center/AnalystReportCard.tsx
@@ -1,0 +1,37 @@
+import { Card } from "../../ds";
+import type { AnalysisReport } from "../../types/actionCenter";
+import { DataVerificationPanel } from "./DataVerificationPanel";
+import { StatusBadge } from "./StatusBadge";
+
+function dateText(value?: string | null): string {
+  if (!value) return "확인 불가";
+  return new Date(value).toLocaleString("ko-KR", { dateStyle: "short", timeStyle: "short" });
+}
+
+export function AnalystReportCard({ report }: { report: AnalysisReport }) {
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 14 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+          <div style={{ display: "grid", gap: 5 }}>
+            <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 800 }}>
+              {report.reportType} · {report.market} · {report.accountScope ?? "전체 계좌"}
+            </div>
+            <h2 style={{ margin: 0, fontSize: 20, letterSpacing: "-0.03em" }}>{report.summary}</h2>
+            <div style={{ color: "var(--fg-3)", fontSize: 12 }}>
+              {report.createdByProfile} · 생성 {dateText(report.createdAt)} · 유효 {dateText(report.validUntil)}
+            </div>
+          </div>
+          <StatusBadge status={report.status} />
+        </div>
+        {report.riskSummary && <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.6 }}>{report.riskSummary}</p>}
+        <DataVerificationPanel report={report} />
+        {report.safetyNotes && report.safetyNotes.length > 0 && (
+          <div style={{ color: "var(--warn)", fontSize: 12, lineHeight: 1.6 }}>
+            {report.safetyNotes.map((note) => <div key={note}>• {note}</div>)}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/invest/src/components/action-center/CandidateCard.tsx
+++ b/frontend/invest/src/components/action-center/CandidateCard.tsx
@@ -1,0 +1,85 @@
+import { Button, Card } from "../../ds";
+import type { AnalysisCandidate } from "../../types/actionCenter";
+import { StatusBadge } from "./StatusBadge";
+
+const UNAVAILABLE = "확인 불가";
+
+function displayValue(value: unknown, suffix = ""): string {
+  if (value == null || value === "") return UNAVAILABLE;
+  return `${String(value)}${suffix}`;
+}
+
+function verificationValue(candidate: AnalysisCandidate, key: string): string {
+  const raw = candidate.verification?.[key];
+  if (raw == null || raw === "") return UNAVAILABLE;
+  return String(raw);
+}
+
+export function CandidateCard({ candidate }: { candidate: AnalysisCandidate }) {
+  return (
+    <Card>
+      <div style={{ display: "grid", gap: 14 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+          <div>
+            <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 800 }}>
+              {candidate.market} · {candidate.actionType} · priority {candidate.priority}
+            </div>
+            <h3 style={{ margin: "4px 0 0", fontSize: 22, letterSpacing: "-0.03em" }}>{candidate.symbol}</h3>
+          </div>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", justifyContent: "flex-end" }}>
+            <StatusBadge label="승인" status={candidate.approvalStatus} />
+            <StatusBadge label="실행" status={candidate.executionState} />
+          </div>
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))", gap: 8 }}>
+          <Metric label="side" value={candidate.side} />
+          <Metric label="수량" value={displayValue(candidate.quantity)} />
+          <Metric label="비중" value={displayValue(candidate.quantityPct, "%")} />
+          <Metric label="지정가" value={displayValue(candidate.limitPrice)} />
+          <Metric label="금액" value={displayValue(candidate.notional, candidate.currency ? ` ${candidate.currency}` : "")} />
+          <Metric label="confidence" value={displayValue(candidate.confidence)} />
+        </div>
+
+        <div>
+          <div style={{ fontWeight: 900, marginBottom: 6 }}>Thesis</div>
+          <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.6 }}>{candidate.thesis}</p>
+        </div>
+
+        <div style={{ display: "grid", gap: 8 }}>
+          <div style={{ fontWeight: 900 }}>검증/리스크</div>
+          <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 8 }}>
+            <Metric label="계좌 feasibility" value={verificationValue(candidate, "accountFeasibility")} warn />
+            <Metric label="시장/유동성" value={verificationValue(candidate, "liquidity")} warn />
+            <Metric label="이벤트/뉴스 리스크" value={verificationValue(candidate, "eventNewsRisk")} warn />
+          </div>
+          {candidate.riskNotes.length > 0 && (
+            <div style={{ color: "var(--warn)", fontSize: 12, lineHeight: 1.6 }}>{candidate.riskNotes.join(" · ")}</div>
+          )}
+          {candidate.blockingReasons.length > 0 && (
+            <div style={{ color: "var(--danger)", fontSize: 12, lineHeight: 1.6 }}>{candidate.blockingReasons.join(" · ")}</div>
+          )}
+        </div>
+
+        <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+          <Button type="button" variant="secondary" disabled>승인 기록은 수동 처리</Button>
+          <Button type="button" variant="ghost" disabled>거절 기록은 수동 처리</Button>
+          <div style={{ color: "var(--fg-3)", fontSize: 12, display: "flex", gap: 10, flexWrap: "wrap" }}>
+            <span>승인 상태: {candidate.approvalStatus}</span>
+            <span>실행 상태: {candidate.executionState}</span>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function Metric({ label, value, warn = false }: { label: string; value: string; warn?: boolean }) {
+  const unavailable = value === UNAVAILABLE;
+  return (
+    <div style={{ padding: 10, borderRadius: 12, background: "var(--surface-2)", display: "grid", gap: 3 }}>
+      <div style={{ color: "var(--fg-3)", fontSize: 11 }}>{label}</div>
+      <div style={{ color: warn || unavailable ? "var(--warn)" : "var(--fg-1)", fontWeight: 900, fontSize: 12 }}>{value}</div>
+    </div>
+  );
+}

--- a/frontend/invest/src/components/action-center/DataVerificationPanel.tsx
+++ b/frontend/invest/src/components/action-center/DataVerificationPanel.tsx
@@ -1,0 +1,77 @@
+import { Card } from "../../ds";
+import type { AnalysisReport, AnalysisStageResult } from "../../types/actionCenter";
+import { StatusBadge } from "./StatusBadge";
+
+const UNAVAILABLE = "확인 불가";
+
+function valueText(value: unknown): string {
+  if (value == null || value === "") return UNAVAILABLE;
+  if (Array.isArray(value)) return value.length === 0 ? UNAVAILABLE : value.join(", ");
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function KeyValueGrid({ values }: { values: Record<string, unknown> }) {
+  const entries = Object.entries(values);
+  if (entries.length === 0) {
+    return <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{UNAVAILABLE}</div>;
+  }
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 8 }}>
+      {entries.map(([key, value]) => (
+        <div key={key} style={{ padding: 10, borderRadius: 12, background: "var(--surface-2)", display: "grid", gap: 3 }}>
+          <div style={{ color: "var(--fg-3)", fontSize: 11 }}>{key}</div>
+          <div style={{ color: valueText(value) === UNAVAILABLE ? "var(--warn)" : "var(--fg-1)", fontWeight: 800, fontSize: 12 }}>
+            {valueText(value)}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function StageRow({ stage }: { stage: AnalysisStageResult }) {
+  return (
+    <div style={{ padding: "9px 0", borderTop: "1px solid var(--divider)", display: "grid", gap: 4 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "center" }}>
+        <strong style={{ fontSize: 13 }}>{stage.stageKey}</strong>
+        <StatusBadge status={stage.status} />
+      </div>
+      <div style={{ color: "var(--fg-3)", fontSize: 12 }}>
+        {stage.source} · {stage.freshnessAt ?? stage.unavailableReason ?? UNAVAILABLE}
+      </div>
+      {stage.warnings && stage.warnings.length > 0 && (
+        <div style={{ color: "var(--warn)", fontSize: 12 }}>{stage.warnings.join(" · ")}</div>
+      )}
+    </div>
+  );
+}
+
+export function DataVerificationPanel({ report }: { report: AnalysisReport }) {
+  return (
+    <Card soft>
+      <div style={{ display: "grid", gap: 12 }}>
+        <div>
+          <div style={{ fontWeight: 900, marginBottom: 4 }}>데이터 검증</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12, lineHeight: 1.5 }}>
+            KIS live가 계좌·주문 권한의 기준입니다. Toss/Naver는 교차 검증 참고이며, 확인되지 않은 핵심 값은 {UNAVAILABLE}로 표시합니다.
+          </div>
+        </div>
+        <div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 800, marginBottom: 6 }}>Freshness</div>
+          <KeyValueGrid values={report.dataFreshness ?? {}} />
+        </div>
+        <div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 800, marginBottom: 6 }}>Coverage</div>
+          <KeyValueGrid values={report.coverage ?? {}} />
+        </div>
+        {report.stageResults && report.stageResults.length > 0 && (
+          <div>
+            <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 800, marginBottom: 2 }}>Stage checks</div>
+            {report.stageResults.map((stage) => <StageRow key={`${stage.stageKey}:${stage.source}`} stage={stage} />)}
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/frontend/invest/src/components/action-center/StatusBadge.tsx
+++ b/frontend/invest/src/components/action-center/StatusBadge.tsx
@@ -1,0 +1,19 @@
+import { Pill } from "../../ds";
+
+type Tone = "paper" | "accent" | "gain" | "loss" | "warn";
+
+function toneForStatus(status: string): Tone {
+  if (["published", "ok", "approved", "filled"].includes(status)) return "gain";
+  if (["rejected", "failed", "blocked"].includes(status)) return "loss";
+  if (["awaiting_approval", "degraded", "stale", "unavailable", "not_submitted"].includes(status)) return "warn";
+  return "paper";
+}
+
+export function StatusBadge({ label, status }: { label?: string; status: string }) {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
+      {label && <span style={{ color: "var(--fg-3)", fontSize: 12 }}>{label}</span>}
+      <Pill tone={toneForStatus(status)} size="sm">{status}</Pill>
+    </span>
+  );
+}

--- a/frontend/invest/src/hooks/useActionCenter.ts
+++ b/frontend/invest/src/hooks/useActionCenter.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import { fetchActionCenterCandidates, fetchActionCenterReports } from "../api/actionCenter";
+import type { AnalysisCandidateQueueResponse, AnalysisReportListResponse } from "../types/actionCenter";
+
+type State =
+  | { status: "loading" }
+  | { status: "ready"; reports: AnalysisReportListResponse; candidates: AnalysisCandidateQueueResponse }
+  | { status: "error"; message: string };
+
+export function useActionCenter() {
+  const [state, setState] = useState<State>({ status: "loading" });
+  const [nonce, setNonce] = useState(0);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setState({ status: "loading" });
+    Promise.all([fetchActionCenterReports(controller.signal), fetchActionCenterCandidates(controller.signal)])
+      .then(([reports, candidates]) => setState({ status: "ready", reports, candidates }))
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        setState({ status: "error", message: String(err?.message ?? err) });
+      });
+    return () => controller.abort();
+  }, [nonce]);
+
+  return { state, reload: () => setNonce((n) => n + 1) };
+}

--- a/frontend/invest/src/pages/desktop/DesktopActionCenterPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopActionCenterPage.tsx
@@ -1,0 +1,19 @@
+import { ActionCenterContent, ActionCenterRelatedLinks } from "../../components/action-center/ActionCenterContent";
+import { DesktopShell } from "../../desktop/DesktopShell";
+import { RightRemotePanel } from "../../desktop/RightRemotePanel";
+import { useViewport } from "../../hooks/useViewport";
+import { MobileActionCenterPage } from "../mobile/MobileActionCenterPage";
+
+export function DesktopActionCenterPage() {
+  return (
+    <DesktopShell
+      center={<ActionCenterContent />}
+      right={<div style={{ display: "grid", gap: 12 }}><ActionCenterRelatedLinks /><RightRemotePanel /></div>}
+    />
+  );
+}
+
+export function ActionCenterRoute() {
+  const viewport = useViewport();
+  return viewport === "mobile" ? <MobileActionCenterPage /> : <DesktopActionCenterPage />;
+}

--- a/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
@@ -92,6 +92,12 @@ const NAV_CARDS: NavCard[] = [
     desc: "조건별 종목 필터링",
     icon: <Icon name="search" size={20} />,
   },
+  {
+    to: "/action-center",
+    label: "액션 센터",
+    desc: "애널리스트 리포트와 승인 대기 후보",
+    icon: <Icon name="flash" size={20} />,
+  },
 ];
 
 export function DesktopHomePage() {

--- a/frontend/invest/src/pages/mobile/MobileActionCenterPage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileActionCenterPage.tsx
@@ -1,0 +1,10 @@
+import { ActionCenterContent } from "../../components/action-center/ActionCenterContent";
+import { MobileShell } from "../../mobile/MobileShell";
+
+export function MobileActionCenterPage() {
+  return (
+    <MobileShell title="액션 센터">
+      <ActionCenterContent compact />
+    </MobileShell>
+  );
+}

--- a/frontend/invest/src/pages/mobile/MobileHomePage.tsx
+++ b/frontend/invest/src/pages/mobile/MobileHomePage.tsx
@@ -55,6 +55,12 @@ const NAV_CARDS: MobileNavCard[] = [
     desc: "실적·배당 일정",
     icon: <Icon name="calendar" size={18} />,
   },
+  {
+    to: "/action-center",
+    label: "액션 센터",
+    desc: "승인 대기 후보",
+    icon: <Icon name="flash" size={18} />,
+  },
 ];
 
 export function MobileHomePage() {

--- a/frontend/invest/src/routes.tsx
+++ b/frontend/invest/src/routes.tsx
@@ -19,6 +19,7 @@
 // /invest/coverage          — Data coverage dashboard.
 // /invest/insights          — Read-only market insight cards.
 // /invest/screener          — Stock screener (골라보기).
+// /invest/action-center     — Analyst report / approval candidate action center.
 // /invest/stocks/:m/:sym    — Stock detail page.
 // ─────────────────────────────────────────────────────────────────────────────
 import { createBrowserRouter, Navigate, useLocation, useParams } from "react-router-dom";
@@ -34,6 +35,7 @@ import { DesktopMarketPage } from "./pages/desktop/DesktopMarketPage";
 import { DesktopInsightsPage } from "./pages/desktop/DesktopInsightsPage";
 import { FxMacroRoute } from "./pages/desktop/FxMacroPage";
 import { DesktopCryptoPage } from "./pages/desktop/DesktopCryptoPage";
+import { ActionCenterRoute } from "./pages/desktop/DesktopActionCenterPage";
 import { StockDetailPage } from "./pages/stock-detail/StockDetailPage";
 
 // Static legacy /app/* redirect that preserves any ?search and #hash
@@ -81,6 +83,7 @@ export const router = createBrowserRouter(
     { path: "/crypto", element: <DesktopCryptoPage /> },
     { path: "/crypto/:pair", element: <CryptoPairRedirect /> },
     { path: "/screener", element: <DesktopScreenerPage /> },
+    { path: "/action-center", element: <ActionCenterRoute /> },
     { path: "/stocks/:market/:symbol", element: <StockDetailPage /> },
 
     // Stage 6: legacy /invest/app/* URLs redirect to their canonical

--- a/frontend/invest/src/types/actionCenter.ts
+++ b/frontend/invest/src/types/actionCenter.ts
@@ -1,0 +1,65 @@
+export type ActionCenterStatus = "loading" | "ready" | "error";
+
+export interface AnalysisStageResult {
+  stageKey: string;
+  source: string;
+  status: string;
+  freshnessAt?: string | null;
+  unavailableReason?: string | null;
+  warnings?: string[];
+}
+
+export interface AnalysisCandidate {
+  candidateUuid: string;
+  reportUuid?: string | null;
+  symbol: string;
+  market: string;
+  side: "buy" | "sell" | string;
+  actionType: string;
+  quantity?: number | string | null;
+  quantityPct?: number | string | null;
+  limitPrice?: number | string | null;
+  notional?: number | string | null;
+  currency?: string | null;
+  priority: number;
+  confidence?: number | string | null;
+  thesis: string;
+  riskNotes: string[];
+  verification: Record<string, unknown>;
+  blockingReasons: string[];
+  approvalStatus: string;
+  approvalType: string;
+  executionState: string;
+  createdAt: string;
+  validUntil?: string | null;
+}
+
+export interface AnalysisReport {
+  reportUuid: string;
+  reportType: string;
+  market: string;
+  accountScope?: string | null;
+  createdByProfile: string;
+  status: string;
+  summary: string;
+  riskSummary?: string | null;
+  dataFreshness: Record<string, unknown>;
+  coverage: Record<string, unknown>;
+  sourcePolicy?: string[];
+  safetyNotes?: string[];
+  createdAt: string;
+  publishedAt?: string | null;
+  validUntil?: string | null;
+  stageResults?: AnalysisStageResult[];
+  candidates?: AnalysisCandidate[];
+}
+
+export interface AnalysisReportListResponse {
+  reports: AnalysisReport[];
+  unavailableLabel?: string;
+}
+
+export interface AnalysisCandidateQueueResponse {
+  candidates: AnalysisCandidate[];
+  unavailableLabel?: string;
+}

--- a/tests/test_analysis_report_workflow.py
+++ b/tests/test_analysis_report_workflow.py
@@ -183,6 +183,7 @@ def test_router_create_and_read_contract_uses_service_without_broker_submission(
             return created
 
         async def list_reports(self, **kwargs):
+            assert kwargs == {"market": "kr", "status": "draft", "limit": 10}
             return {"count": 1, "items": [created]}
 
         async def get_report(self, report_uuid: str):
@@ -209,6 +210,26 @@ def test_router_create_and_read_contract_uses_service_without_broker_submission(
         body = response.json()
         assert body["candidates"][0]["execution_state"] == "not_submitted"
         assert body["data_freshness"]["cash_balance"] == "확인 불가"
+
+        report_list_response = client.get(
+            "/invest/api/action-center/reports?market=kr&status=draft&limit=10"
+        )
+        assert report_list_response.status_code == 200
+        assert (
+            report_list_response.json()["items"][0]["report_uuid"]
+            == created["report_uuid"]
+        )
+
+        report_detail_response = client.get(
+            f"/invest/api/action-center/reports/{created['report_uuid']}"
+        )
+        assert report_detail_response.status_code == 200
+        assert report_detail_response.json()["report_uuid"] == created["report_uuid"]
+
+        missing_report_response = client.get(
+            "/invest/api/action-center/reports/00000000-0000-4000-8000-00000000ffff"
+        )
+        assert missing_report_response.status_code == 404
 
         read_response = client.get("/invest/api/action-center/candidates")
         assert read_response.status_code == 200

--- a/tests/test_analysis_report_workflow.py
+++ b/tests/test_analysis_report_workflow.py
@@ -259,3 +259,26 @@ async def test_mcp_analysis_report_create_returns_decision_artifact(
     assert result["success"] is True
     assert result["report"]["candidates"][0]["execution_state"] == "not_submitted"
     assert result["idempotent"] is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "bad_value"),
+    [
+        ("data_freshness", []),
+        ("metadata", []),
+        ("source_policy", ""),
+        ("candidates", ""),
+    ],
+)
+async def test_mcp_analysis_report_create_preserves_falsy_bad_types(
+    field: str,
+    bad_value: object,
+) -> None:
+    import app.mcp_server.tooling.analysis_reports_handlers as mod
+
+    bad_payload = _sample_create_payload()
+    bad_payload[field] = bad_value
+
+    with pytest.raises(ValueError):
+        await mod.analysis_report_create_impl(**bad_payload)

--- a/tests/test_analysis_report_workflow.py
+++ b/tests/test_analysis_report_workflow.py
@@ -1,0 +1,240 @@
+"""ROB-257 analysis report persistence/API/MCP contracts."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _sample_create_payload() -> dict:
+    return {
+        "idempotency_key": "rob257-sample-1",
+        "report_type": "preopen_action_plan",
+        "market": "kr",
+        "account_scope": "kis_live",
+        "status": "draft",
+        "summary": "삼성전자 후보 검토",
+        "risk_summary": "확인 불가 항목은 주문으로 연결하지 않는다.",
+        "data_freshness": {"cash_balance": "확인 불가"},
+        "coverage": {"symbols": 1},
+        "source_policy": [
+            "KIS live is authoritative; Toss/Naver are cross-validation only."
+        ],
+        "safety_notes": ["decision artifact only; no broker order side effects"],
+        "metadata": {"session": "sample"},
+        "stage_results": [
+            {
+                "stage_key": "account_authority",
+                "source": "kis_live",
+                "status": "unavailable",
+                "unavailable_reason": "확인 불가",
+                "normalized_payload": {"cash": "확인 불가"},
+                "warnings": ["do not infer cash"],
+            }
+        ],
+        "candidates": [
+            {
+                "idempotency_key": "rob257-sample-1-005930-buy",
+                "symbol": "005930",
+                "market": "kr",
+                "side": "buy",
+                "action_type": "buy_candidate",
+                "limit_price": "70000",
+                "notional": "350000",
+                "currency": "KRW",
+                "priority": 10,
+                "confidence": "0.7300",
+                "thesis": "정규장 확인 후 수동 승인 후보",
+                "risk_notes": ["정규장 확인 필요"],
+                "verification": {"cash_balance": "확인 불가"},
+                "blocking_reasons": ["cash_balance 확인 불가"],
+                "approval_status": "awaiting_approval",
+            }
+        ],
+    }
+
+
+def _sample_report_response() -> dict:
+    now = datetime(2026, 5, 15, 3, 0, tzinfo=UTC)
+    return {
+        "id": 1,
+        "report_uuid": "00000000-0000-4000-8000-000000000001",
+        "idempotency_key": "rob257-sample-1",
+        "report_type": "preopen_action_plan",
+        "market": "kr",
+        "account_scope": "kis_live",
+        "created_by_profile": "analyst",
+        "status": "draft",
+        "summary": "삼성전자 후보 검토",
+        "risk_summary": "확인 불가 항목은 주문으로 연결하지 않는다.",
+        "data_freshness": {"cash_balance": "확인 불가"},
+        "coverage": {"symbols": 1},
+        "source_policy": [
+            "KIS live is authoritative; Toss/Naver are cross-validation only."
+        ],
+        "safety_notes": ["decision artifact only; no broker order side effects"],
+        "metadata": {"session": "sample"},
+        "created_at": now.isoformat(),
+        "published_at": None,
+        "valid_until": None,
+        "stages": [
+            {
+                "id": 11,
+                "stage_key": "account_authority",
+                "source": "kis_live",
+                "provenance": {},
+                "status": "unavailable",
+                "freshness_at": None,
+                "raw_payload": None,
+                "normalized_payload": {"cash": "확인 불가"},
+                "unavailable_reason": "확인 불가",
+                "warnings": ["do not infer cash"],
+                "created_at": now.isoformat(),
+            }
+        ],
+        "candidates": [
+            {
+                "id": 21,
+                "candidate_uuid": "00000000-0000-4000-8000-000000000021",
+                "report_uuid": "00000000-0000-4000-8000-000000000001",
+                "idempotency_key": "rob257-sample-1-005930-buy",
+                "symbol": "005930",
+                "market": "kr",
+                "side": "buy",
+                "action_type": "buy_candidate",
+                "quantity": None,
+                "quantity_pct": None,
+                "limit_price": "70000.0000",
+                "notional": "350000.0000",
+                "currency": "KRW",
+                "priority": 10,
+                "confidence": "0.7300",
+                "thesis": "정규장 확인 후 수동 승인 후보",
+                "risk_notes": ["정규장 확인 필요"],
+                "verification": {"cash_balance": "확인 불가"},
+                "blocking_reasons": ["cash_balance 확인 불가"],
+                "approval_status": "awaiting_approval",
+                "approval_type": "manual",
+                "approved_by": None,
+                "approved_at": None,
+                "rejected_by": None,
+                "rejected_at": None,
+                "policy_id": None,
+                "policy_snapshot": None,
+                "execution_state": "not_submitted",
+                "linked_trade_journal_id": None,
+                "linked_order_ledger_ref": None,
+                "created_at": now.isoformat(),
+                "valid_until": None,
+            }
+        ],
+        "idempotent": False,
+    }
+
+
+def test_analysis_models_define_decision_artifact_tables() -> None:
+    from app.models.review import AnalysisOrderCandidate, AnalysisReport
+
+    assert AnalysisReport.__table__.schema == "review"
+    assert AnalysisReport.__tablename__ == "analysis_reports"
+    assert "idempotency_key" in AnalysisReport.__table__.columns
+    assert "execution_state" in AnalysisOrderCandidate.__table__.columns
+    assert (
+        AnalysisOrderCandidate.__table__.columns["execution_state"].default.arg
+        == "not_submitted"
+    )
+
+
+def test_schema_preserves_unavailable_marker_and_rejects_bad_candidate_status() -> None:
+    from pydantic import ValidationError
+
+    from app.schemas.analysis_reports import AnalysisReportCreateRequest
+
+    request = AnalysisReportCreateRequest.model_validate(_sample_create_payload())
+    assert request.data_freshness["cash_balance"] == "확인 불가"
+    assert request.candidates[0].execution_state == "not_submitted"
+
+    bad = _sample_create_payload()
+    bad["candidates"][0]["approval_status"] = "submitted_to_broker"
+    with pytest.raises(ValidationError):
+        AnalysisReportCreateRequest.model_validate(bad)
+
+
+def test_router_create_and_read_contract_uses_service_without_broker_submission() -> (
+    None
+):
+    from app.routers import analysis_reports as router_mod
+    from app.routers.dependencies import get_authenticated_user
+
+    app = FastAPI()
+    app.include_router(router_mod.router)
+
+    created = _sample_report_response()
+
+    class StubService:
+        async def create_report(self, request, *, created_by_profile: str):
+            assert created_by_profile == "analyst"
+            assert request.candidates[0].execution_state == "not_submitted"
+            return created
+
+        async def list_reports(self, **kwargs):
+            return {"count": 1, "items": [created]}
+
+        async def get_report(self, report_uuid: str):
+            return created if report_uuid == created["report_uuid"] else None
+
+        async def list_candidates(self, **kwargs):
+            return {"count": 1, "items": created["candidates"]}
+
+        async def get_candidate(self, candidate_uuid: str):
+            return created["candidates"][0]
+
+    app.dependency_overrides[router_mod.get_analysis_report_service] = lambda: (
+        StubService()
+    )
+    app.dependency_overrides[get_authenticated_user] = lambda: SimpleNamespace(
+        id=1, username="analyst"
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/trading/api/analysis-reports", json=_sample_create_payload()
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["candidates"][0]["execution_state"] == "not_submitted"
+        assert body["data_freshness"]["cash_balance"] == "확인 불가"
+
+        read_response = client.get("/invest/api/action-center/candidates")
+        assert read_response.status_code == 200
+        assert (
+            read_response.json()["items"][0]["approval_status"] == "awaiting_approval"
+        )
+
+
+@pytest.mark.asyncio
+async def test_mcp_analysis_report_create_returns_decision_artifact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.mcp_server.tooling.analysis_reports_handlers as mod
+
+    class StubService:
+        async def create_report(self, request, *, created_by_profile: str):
+            return _sample_report_response()
+
+    fake_session = AsyncMock()
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=fake_session)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    monkeypatch.setattr(mod, "AsyncSessionLocal", lambda: cm)
+    monkeypatch.setattr(mod, "AnalysisReportService", lambda db: StubService())
+
+    result = await mod.analysis_report_create_impl(**_sample_create_payload())
+    assert result["success"] is True
+    assert result["report"]["candidates"][0]["execution_state"] == "not_submitted"
+    assert result["idempotent"] is False


### PR DESCRIPTION
## Summary
- Add durable analyst report / order candidate persistence for /invest Action Center
- Add read-only report and candidate APIs plus MCP persistence entrypoint
- Add /invest Action Center UI for analyst reports and approval packets
- Add /invest report route aliases for frontend contract

## Safety
- Decision artifacts only; no broker/order/watch/order-intent mutations
- KIS live remains account/order authority; Toss/Naver are cross-check only
- Unverified critical data is surfaced as 확인 불가

## Verification
- uv run pytest tests/test_analysis_report_workflow.py -q
- uv run ruff format --check app/routers/analysis_reports.py tests/test_analysis_report_workflow.py
- uv run ruff check app/routers/analysis_reports.py tests/test_analysis_report_workflow.py
- cd frontend/invest && npm test -- --run src/__tests__/actionCenter.api.test.ts src/__tests__/DesktopActionCenterPage.test.tsx
- cd frontend/invest && npm run typecheck
- cd frontend/invest && npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * **Action Center**: New feature enabling users to review analyst reports and manage pending approval candidates in a centralized dashboard.
  * **Analysis Reports**: View, list, and create analyst reports with metadata, summaries, and verification details.
  * **Approval Candidates**: Browse and review pending order candidates awaiting approval with comprehensive status tracking.
  * **Enhanced MCP Integration**: Added analyst report tools to server for improved tooling workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/839)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->