### PR TITLE
fix(invest): normalize action center API responses

### DIFF
--- a/frontend/invest/src/__tests__/actionCenter.api.test.ts
+++ b/frontend/invest/src/__tests__/actionCenter.api.test.ts
@@ -15,6 +15,7 @@ const REPORTS_PAYLOAD = {
       riskSummary: "정규장 확인 필요",
       dataFreshness: { accountFeasibility: "확인 불가" },
       coverage: { liquidity: "degraded" },
+      sourcePolicy: [],
       safetyNotes: ["주문 실행이 아닙니다."],
       createdAt: "2026-05-15T00:00:00Z",
       publishedAt: "2026-05-15T00:01:00Z",
@@ -37,6 +38,11 @@ const CANDIDATES_PAYLOAD = {
       actionType: "buy_candidate",
       priority: 10,
       confidence: 0.72,
+      quantity: null,
+      quantityPct: null,
+      notional: null,
+      limitPrice: null,
+      currency: null,
       thesis: "실적 모멘텀",
       riskNotes: ["뉴스 리스크 확인 필요"],
       verification: { accountFeasibility: "확인 불가" },
@@ -88,6 +94,55 @@ test("fetchActionCenterCandidates reads the non-executing candidate queue endpoi
   expect(fetchMock).toHaveBeenCalledWith("/invest/api/action-center/candidates", {
     credentials: "include",
     signal: undefined,
+  });
+});
+
+test("action center API normalizes backend items and snake_case fields", async () => {
+  vi.spyOn(globalThis, "fetch")
+    .mockResolvedValueOnce(new Response(JSON.stringify({ count: 1, items: [{
+      report_uuid: "report-2",
+      report_type: "daily",
+      market: "kr",
+      account_scope: null,
+      created_by_profile: "analyst",
+      status: "published",
+      summary: "요약",
+      risk_summary: null,
+      data_freshness: {},
+      coverage: {},
+      source_policy: ["KIS live authority"],
+      safety_notes: ["주문 실행이 아닙니다."],
+      created_at: "2026-05-15T00:00:00Z",
+      published_at: null,
+      valid_until: null,
+      stages: [{ stage_key: "account", source: "kis", status: "unavailable", freshness_at: null, unavailable_reason: "확인 불가", warnings: [] }],
+      candidates: [],
+    }] }), { status: 200, headers: { "content-type": "application/json" } }))
+    .mockResolvedValueOnce(new Response(JSON.stringify({ count: 1, items: [{
+      candidate_uuid: "cand-2",
+      report_uuid: "report-2",
+      symbol: "005930",
+      market: "kr",
+      side: "buy",
+      action_type: "buy_candidate",
+      priority: 1,
+      thesis: "테스트",
+      risk_notes: ["확인 필요"],
+      verification: {},
+      blocking_reasons: [],
+      approval_status: "awaiting_approval",
+      approval_type: "manual",
+      execution_state: "not_submitted",
+      created_at: "2026-05-15T00:02:00Z",
+    }] }), { status: 200, headers: { "content-type": "application/json" } }));
+
+  await expect(fetchActionCenterReports()).resolves.toMatchObject({
+    reports: [{ reportUuid: "report-2", sourcePolicy: ["KIS live authority"], stageResults: [{ stageKey: "account", unavailableReason: "확인 불가" }] }],
+    unavailableLabel: "확인 불가",
+  });
+  await expect(fetchActionCenterCandidates()).resolves.toMatchObject({
+    candidates: [{ candidateUuid: "cand-2", actionType: "buy_candidate", riskNotes: ["확인 필요"], blockingReasons: [] }],
+    unavailableLabel: "확인 불가",
   });
 });
 

--- a/frontend/invest/src/api/actionCenter.ts
+++ b/frontend/invest/src/api/actionCenter.ts
@@ -1,7 +1,46 @@
-import type { AnalysisCandidateQueueResponse, AnalysisReport, AnalysisReportListResponse } from "../types/actionCenter";
+import type { AnalysisCandidate, AnalysisCandidateQueueResponse, AnalysisReport, AnalysisReportListResponse, AnalysisStageResult } from "../types/actionCenter";
 
 const REPORTS_ENDPOINT = "/invest/api/action-center/reports";
 const CANDIDATES_ENDPOINT = "/invest/api/action-center/candidates";
+const UNAVAILABLE_LABEL = "확인 불가";
+
+type ApiListResponse<T> = { count?: number; items?: T[] };
+
+type ApiStageResult = Partial<AnalysisStageResult> & {
+  stage_key?: string;
+  freshness_at?: string | null;
+  unavailable_reason?: string | null;
+};
+
+type ApiCandidate = Partial<AnalysisCandidate> & {
+  candidate_uuid?: string;
+  report_uuid?: string | null;
+  action_type?: string;
+  quantity_pct?: number | string | null;
+  limit_price?: number | string | null;
+  risk_notes?: string[];
+  blocking_reasons?: string[];
+  approval_status?: string;
+  approval_type?: string;
+  execution_state?: string;
+  created_at?: string;
+  valid_until?: string | null;
+};
+
+type ApiReport = Partial<AnalysisReport> & {
+  report_uuid?: string;
+  report_type?: string;
+  account_scope?: string | null;
+  created_by_profile?: string;
+  risk_summary?: string | null;
+  data_freshness?: Record<string, unknown>;
+  source_policy?: string[];
+  safety_notes?: string[];
+  created_at?: string;
+  published_at?: string | null;
+  valid_until?: string | null;
+  stages?: ApiStageResult[];
+};
 
 async function readJson<T>(endpoint: string, signal?: AbortSignal): Promise<T> {
   const res = await fetch(endpoint, { credentials: "include", signal });
@@ -11,14 +50,91 @@ async function readJson<T>(endpoint: string, signal?: AbortSignal): Promise<T> {
   return res.json();
 }
 
+function normalizeStage(stage: ApiStageResult): AnalysisStageResult {
+  return {
+    stageKey: stage.stageKey ?? stage.stage_key ?? UNAVAILABLE_LABEL,
+    source: stage.source ?? UNAVAILABLE_LABEL,
+    status: stage.status ?? "unavailable",
+    freshnessAt: stage.freshnessAt ?? stage.freshness_at ?? null,
+    unavailableReason: stage.unavailableReason ?? stage.unavailable_reason ?? null,
+    warnings: stage.warnings ?? [],
+  };
+}
+
+function normalizeCandidate(candidate: ApiCandidate): AnalysisCandidate {
+  return {
+    candidateUuid: candidate.candidateUuid ?? candidate.candidate_uuid ?? UNAVAILABLE_LABEL,
+    reportUuid: candidate.reportUuid ?? candidate.report_uuid ?? null,
+    symbol: candidate.symbol ?? UNAVAILABLE_LABEL,
+    market: candidate.market ?? UNAVAILABLE_LABEL,
+    side: candidate.side ?? "buy",
+    actionType: candidate.actionType ?? candidate.action_type ?? UNAVAILABLE_LABEL,
+    quantity: candidate.quantity ?? null,
+    quantityPct: candidate.quantityPct ?? candidate.quantity_pct ?? null,
+    limitPrice: candidate.limitPrice ?? candidate.limit_price ?? null,
+    notional: candidate.notional ?? null,
+    currency: candidate.currency ?? null,
+    priority: candidate.priority ?? 0,
+    confidence: candidate.confidence ?? null,
+    thesis: candidate.thesis ?? UNAVAILABLE_LABEL,
+    riskNotes: candidate.riskNotes ?? candidate.risk_notes ?? [],
+    verification: candidate.verification ?? {},
+    blockingReasons: candidate.blockingReasons ?? candidate.blocking_reasons ?? [],
+    approvalStatus: candidate.approvalStatus ?? candidate.approval_status ?? UNAVAILABLE_LABEL,
+    approvalType: candidate.approvalType ?? candidate.approval_type ?? UNAVAILABLE_LABEL,
+    executionState: candidate.executionState ?? candidate.execution_state ?? "not_submitted",
+    createdAt: candidate.createdAt ?? candidate.created_at ?? UNAVAILABLE_LABEL,
+    validUntil: candidate.validUntil ?? candidate.valid_until ?? null,
+  };
+}
+
+function normalizeReport(report: ApiReport): AnalysisReport {
+  return {
+    reportUuid: report.reportUuid ?? report.report_uuid ?? UNAVAILABLE_LABEL,
+    reportType: report.reportType ?? report.report_type ?? UNAVAILABLE_LABEL,
+    market: report.market ?? UNAVAILABLE_LABEL,
+    accountScope: report.accountScope ?? report.account_scope ?? null,
+    createdByProfile: report.createdByProfile ?? report.created_by_profile ?? UNAVAILABLE_LABEL,
+    status: report.status ?? "draft",
+    summary: report.summary ?? UNAVAILABLE_LABEL,
+    riskSummary: report.riskSummary ?? report.risk_summary ?? null,
+    dataFreshness: report.dataFreshness ?? report.data_freshness ?? {},
+    coverage: report.coverage ?? {},
+    sourcePolicy: report.sourcePolicy ?? report.source_policy ?? [],
+    safetyNotes: report.safetyNotes ?? report.safety_notes ?? [],
+    createdAt: report.createdAt ?? report.created_at ?? UNAVAILABLE_LABEL,
+    publishedAt: report.publishedAt ?? report.published_at ?? null,
+    validUntil: report.validUntil ?? report.valid_until ?? null,
+    stageResults: (report.stageResults ?? report.stages ?? []).map(normalizeStage),
+    candidates: (report.candidates ?? []).map(normalizeCandidate),
+  };
+}
+
 export async function fetchActionCenterReports(signal?: AbortSignal): Promise<AnalysisReportListResponse> {
-  return readJson<AnalysisReportListResponse>(REPORTS_ENDPOINT, signal);
+  const payload = await readJson<AnalysisReportListResponse | ApiListResponse<ApiReport>>(REPORTS_ENDPOINT, signal);
+  if ("reports" in payload && Array.isArray(payload.reports)) {
+    return { ...payload, reports: payload.reports.map(normalizeReport), unavailableLabel: payload.unavailableLabel ?? UNAVAILABLE_LABEL };
+  }
+  const listPayload = payload as ApiListResponse<ApiReport>;
+  return {
+    reports: (listPayload.items ?? []).map(normalizeReport),
+    unavailableLabel: UNAVAILABLE_LABEL,
+  };
 }
 
 export async function fetchActionCenterReport(reportUuid: string, signal?: AbortSignal): Promise<AnalysisReport> {
-  return readJson<AnalysisReport>(`${REPORTS_ENDPOINT}/${encodeURIComponent(reportUuid)}`, signal);
+  const payload = await readJson<ApiReport>(`${REPORTS_ENDPOINT}/${encodeURIComponent(reportUuid)}`, signal);
+  return normalizeReport(payload);
 }
 
 export async function fetchActionCenterCandidates(signal?: AbortSignal): Promise<AnalysisCandidateQueueResponse> {
-  return readJson<AnalysisCandidateQueueResponse>(CANDIDATES_ENDPOINT, signal);
+  const payload = await readJson<AnalysisCandidateQueueResponse | ApiListResponse<ApiCandidate>>(CANDIDATES_ENDPOINT, signal);
+  if ("candidates" in payload && Array.isArray(payload.candidates)) {
+    return { ...payload, candidates: payload.candidates.map(normalizeCandidate), unavailableLabel: payload.unavailableLabel ?? UNAVAILABLE_LABEL };
+  }
+  const listPayload = payload as ApiListResponse<ApiCandidate>;
+  return {
+    candidates: (listPayload.items ?? []).map(normalizeCandidate),
+    unavailableLabel: UNAVAILABLE_LABEL,
+  };
 }


### PR DESCRIPTION
## Summary
- Normalize action-center report and candidate API responses at the frontend adapter boundary.
- Support backend/Pydantic `{ count, items }` list responses and snake_case fields while preserving the existing camelCase frontend contract.
- Add regression coverage for report/candidate snake_case normalization and the `확인 불가` fallback.

## Verification
- Static added-line scan: 0 hits
- `npm test -- --run src/__tests__/actionCenter.api.test.ts` — 5 passed
- `npm run typecheck` — passed
- `npm run build` — passed; existing Vite chunk-size warning only
- `git diff --check` — passed
- Independent review subagent — passed, no blockers

## Safety / non-actions
- No broker, order, watch, order-intent, paper/live trading action.
- No production database writes/deletes/backfills or migrations executed.
- No scheduler/deploy/production service mutation.
- No credentials, tokens, connection strings, or authorization output exposed.

## Context
PR #839 already merged the ROB-257 action-center feature, but production/current frontend adapter still directly consumed JSON without normalizing backend snake_case/list responses. This hotfix keeps the scope limited to two frontend files and fixes the API boundary mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced action center API data processing for improved reliability and consistent formatting across reports and candidates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/841)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->