### PR TITLE
feat(invest): add crypto dashboard risk cards

### DIFF
--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -25,7 +25,10 @@ from app.schemas.invest_common_preferred_disparity import (
     CommonPreferredDisparityResponse,
 )
 from app.schemas.invest_coverage import CoverageMarket, InvestCoverageResponse
-from app.schemas.invest_crypto import CryptoDashboardResponse
+from app.schemas.invest_crypto import (
+    CryptoDashboardResponse,
+    NaverCryptoReferenceResponse,
+)
 from app.schemas.invest_feed_news import FeedNewsResponse, FeedTab, FeedTopic
 from app.schemas.invest_feed_research import (
     FeedResearchFilters,
@@ -60,6 +63,7 @@ from app.schemas.invest_stock_detail_research_consensus import (
 )
 from app.schemas.investor_flow import InvestorFlowResponse
 from app.services.invest_coverage_service import build_invest_coverage
+from app.services.invest_crypto_naver_adapter import build_naver_crypto_reference
 from app.services.invest_home_service import InvestHomeService
 from app.services.invest_momentum_events.coverage_service import build_momentum_coverage
 from app.services.invest_momentum_events.repository import (
@@ -212,6 +216,32 @@ async def get_crypto_dashboard(
         user_id=user.id,
         resolver=resolver,
         limit=limit,
+    )
+
+
+@router.get("/crypto/naver-reference")
+async def get_crypto_naver_reference(
+    user: Annotated[Any, Depends(get_authenticated_user)],
+    service: Annotated[InvestHomeService, Depends(get_invest_home_service)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    symbol: str | None = Query(None, description="Optional KRW pair or base symbol"),
+    limit: int = Query(20, ge=1, le=50),
+) -> NaverCryptoReferenceResponse:
+    """Read-only Naver-style crypto reference adapter.
+
+    This endpoint aggregates source-labeled public/read-model data and fixture
+    metadata only. It never syncs, submits orders, mutates watch/order-intent
+    state, or writes production data.
+    """
+    home = await service.get_home(user_id=user.id)
+    resolver = await build_relation_resolver(
+        db, user_id=user.id, held_pairs=_held_pairs_from_home(home)
+    )
+    return await build_naver_crypto_reference(
+        db=db,
+        symbol=symbol,
+        limit=limit,
+        resolver=resolver,
     )
 
 

--- a/app/schemas/invest_crypto.py
+++ b/app/schemas/invest_crypto.py
@@ -11,6 +11,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from app.schemas.invest_feed_news import FeedNewsResponse
+
 CryptoCapabilityState = Literal[
     "supported",
     "unavailable",
@@ -39,6 +41,16 @@ CryptoCandidateReasonKind = Literal[
     "pending_order",
     "data_quality",
 ]
+CryptoReferenceSourceState = Literal[
+    "available",
+    "cached",
+    "fixture",
+    "reference_only",
+    "stale",
+    "unavailable",
+    "error",
+]
+CryptoReferenceFreshness = Literal["fresh", "partial", "stale", "missing", "fixture"]
 CryptoPendingOrderSide = Literal["buy", "sell"] | str
 
 
@@ -212,3 +224,101 @@ class CryptoDashboardResponse(BaseModel):
         default_factory=CryptoDashboardCapabilities
     )
     meta: CryptoDashboardMeta
+
+
+class CryptoReferenceSourceMeta(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    label: str
+    state: CryptoReferenceSourceState
+    fetchedAt: datetime | None = None
+    cacheAgeSeconds: float | None = None
+    freshness: CryptoReferenceFreshness
+    errorCode: str | None = None
+    referenceOnly: bool = False
+
+
+class NaverCryptoRankItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rank: int = Field(ge=1)
+    symbol: str
+    displayName: str
+    priceKrw: float | None = None
+    changeRate24h: float | None = None
+    tradeAmount24h: float | None = None
+    rsi: float | None = None
+    marketWarning: bool | None = None
+    source: str
+
+
+class NaverCryptoProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    baseSymbol: str
+    displayName: str
+    koreanName: str | None = None
+    englishName: str | None = None
+    naverUrl: str | None = None
+    officialMarket: str | None = None
+    referenceNotes: list[str] = Field(default_factory=list)
+
+
+class NaverCryptoKimchiPremium(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    baseSymbol: str
+    premiumPct: float | None = None
+    domesticPriceKrw: float | None = None
+    overseasPriceKrw: float | None = None
+    state: CryptoReferenceSourceState
+    source: str
+    caution: str
+
+
+class NaverCryptoReferenceCapabilities(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rank: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(state="supported")
+    )
+    price: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(state="supported")
+    )
+    profile: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(
+            state="reference_only", reason="naver_fixture_reference_only"
+        )
+    )
+    news: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(state="supported")
+    )
+    kimchiPremium: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(
+            state="reference_only", reason="macro_reference_only"
+        )
+    )
+    execution: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(
+            state="read_only_mvp", reason="no_order_execution_controls"
+        )
+    )
+
+
+class NaverCryptoReferenceResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    market: Literal["crypto"] = "crypto"
+    asOf: datetime
+    symbol: str | None = None
+    rank: list[NaverCryptoRankItem] = Field(default_factory=list)
+    profile: NaverCryptoProfile | None = None
+    news: FeedNewsResponse | None = None
+    kimchiPremium: NaverCryptoKimchiPremium | None = None
+    sources: list[CryptoReferenceSourceMeta] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    capabilities: NaverCryptoReferenceCapabilities = Field(
+        default_factory=NaverCryptoReferenceCapabilities
+    )

--- a/app/schemas/invest_crypto.py
+++ b/app/schemas/invest_crypto.py
@@ -25,6 +25,19 @@ CryptoRiskBadgeKind = Literal[
     "pending_order",
     "data_unavailable",
     "high_volatility",
+    "low_liquidity",
+    "candidate_watch",
+    "momentum_candidate",
+]
+CryptoRiskLevel = Literal["low", "medium", "high", "unknown"]
+CryptoCandidateReasonKind = Literal[
+    "momentum",
+    "liquidity",
+    "spread",
+    "watched",
+    "held",
+    "pending_order",
+    "data_quality",
 ]
 CryptoPendingOrderSide = Literal["buy", "sell"] | str
 
@@ -83,6 +96,30 @@ class CryptoRiskBadge(BaseModel):
     severity: Literal["info", "warning", "danger"] = "info"
 
 
+class CryptoRiskSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    level: CryptoRiskLevel
+    score: int = Field(ge=0, le=100)
+    reasons: list[str] = Field(default_factory=list)
+
+
+class CryptoCandidateInsight(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    baseSymbol: str
+    displayName: str
+    rank: int = Field(ge=1)
+    score: int = Field(ge=0, le=100)
+    reasons: list[CryptoCandidateReasonKind] = Field(default_factory=list)
+    summary: str
+    isHeld: bool = False
+    isWatched: bool = False
+    hasPendingOrder: bool = False
+    riskLevel: CryptoRiskLevel
+
+
 class CryptoMarketCard(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -98,6 +135,7 @@ class CryptoMarketCard(BaseModel):
     isHeld: bool = False
     isWatched: bool = False
     badges: list[CryptoRiskBadge] = Field(default_factory=list)
+    risk: CryptoRiskSummary | None = None
 
 
 class CryptoHoldingSummary(BaseModel):
@@ -150,6 +188,7 @@ class CryptoInsightsSummary(BaseModel):
 
     badges: list[CryptoRiskBadge] = Field(default_factory=list)
     notes: list[str] = Field(default_factory=list)
+    candidates: list[CryptoCandidateInsight] = Field(default_factory=list)
 
 
 class CryptoDashboardMeta(BaseModel):

--- a/app/schemas/invest_crypto.py
+++ b/app/schemas/invest_crypto.py
@@ -47,6 +47,7 @@ CryptoReferenceSourceState = Literal[
     "fixture",
     "reference_only",
     "stale",
+    "live",
     "unavailable",
     "error",
 ]

--- a/app/schemas/invest_crypto.py
+++ b/app/schemas/invest_crypto.py
@@ -50,7 +50,9 @@ CryptoReferenceSourceState = Literal[
     "unavailable",
     "error",
 ]
-CryptoReferenceFreshness = Literal["fresh", "partial", "stale", "missing", "fixture"]
+CryptoReferenceFreshness = Literal[
+    "fresh", "partial", "stale", "missing", "fixture", "live"
+]
 CryptoPendingOrderSide = Literal["buy", "sell"] | str
 
 

--- a/app/services/invest_crypto_naver_adapter/__init__.py
+++ b/app/services/invest_crypto_naver_adapter/__init__.py
@@ -1,0 +1,13 @@
+"""Read-only Naver-style crypto reference adapter package."""
+
+from app.services.invest_crypto_naver_adapter.adapter import (
+    NaverCryptoReferenceProviders,
+    build_naver_crypto_reference,
+    normalize_krw_symbol,
+)
+
+__all__ = [
+    "NaverCryptoReferenceProviders",
+    "build_naver_crypto_reference",
+    "normalize_krw_symbol",
+]

--- a/app/services/invest_crypto_naver_adapter/adapter.py
+++ b/app/services/invest_crypto_naver_adapter/adapter.py
@@ -1,0 +1,451 @@
+"""Read-only Naver-style crypto reference adapter for /invest.
+
+The adapter aggregates existing read-only sources and fixture-backed Naver
+reference metadata. It must never submit/cancel/modify orders, mutate watch or
+order-intent state, build/commit screener snapshots, or write production data.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.upbit_symbol_universe import UpbitSymbolUniverse
+from app.schemas.invest_crypto import (
+    CryptoCapabilityFlag,
+    CryptoReferenceSourceMeta,
+    NaverCryptoKimchiPremium,
+    NaverCryptoProfile,
+    NaverCryptoRankItem,
+    NaverCryptoReferenceCapabilities,
+    NaverCryptoReferenceResponse,
+)
+from app.schemas.invest_feed_news import FeedNewsResponse
+from app.services.invest_crypto_naver_adapter.fixtures import NAVER_CRYPTO_REFERENCES
+from app.services.invest_crypto_screener_snapshots.repository import (
+    InvestCryptoScreenerSnapshotsRepository,
+)
+from app.services.invest_view_model.relation_resolver import RelationResolver
+
+RankProvider = Callable[[AsyncSession, int], Awaitable[Sequence[Any]] | Sequence[Any]]
+TickerProvider = Callable[[list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]]
+NewsProvider = Callable[
+    [AsyncSession, RelationResolver, str | None, int],
+    Awaitable[FeedNewsResponse | None] | FeedNewsResponse | None,
+]
+KimchiProvider = Callable[[str], Awaitable[dict[str, Any] | list[dict[str, Any]] | None] | dict[str, Any] | list[dict[str, Any]] | None]
+
+
+@dataclass(frozen=True)
+class NaverCryptoReferenceProviders:
+    rank_provider: RankProvider | None = None
+    ticker_provider: TickerProvider | None = None
+    news_provider: NewsProvider | None = None
+    kimchi_provider: KimchiProvider | None = None
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def normalize_krw_symbol(symbol: str | None) -> str | None:
+    if not symbol:
+        return None
+    normalized = str(symbol).strip().upper().replace("/", "-")
+    if not normalized:
+        return None
+    if normalized.startswith("KRW-"):
+        return normalized
+    if normalized.endswith("-KRW"):
+        return f"KRW-{normalized.rsplit('-', 1)[0]}"
+    return f"KRW-{normalized}"
+
+
+def _base_symbol(symbol: str | None) -> str:
+    normalized = normalize_krw_symbol(symbol) or ""
+    return normalized.split("-", 1)[1] if "-" in normalized else normalized
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError, ArithmeticError):
+        return None
+
+
+def _ticker_map(rows: Sequence[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    mapped: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        market = str(row.get("market") or "").upper()
+        if market:
+            mapped[market] = row
+    return mapped
+
+
+async def _default_rank_provider(db: AsyncSession, limit: int) -> Sequence[Any]:
+    repo = InvestCryptoScreenerSnapshotsRepository(db)
+    return await repo.list_latest(preset_id="crypto_momentum", limit=limit)
+
+
+async def _default_ticker_provider(markets: list[str]) -> list[dict[str, Any]]:
+    from app.services.brokers.upbit.client import fetch_multiple_tickers
+
+    return await fetch_multiple_tickers(markets)
+
+
+async def _default_news_provider(
+    db: AsyncSession,
+    resolver: RelationResolver,
+    symbol: str | None,
+    limit: int,
+) -> FeedNewsResponse | None:
+    from app.services.invest_view_model.feed_news_service import build_feed_news
+
+    symbol_filter = (symbol, "crypto") if symbol else None
+    return await build_feed_news(
+        db=db,
+        resolver=resolver,
+        tab="crypto",
+        limit=max(1, min(limit, 20)),
+        cursor=None,
+        include_quotes=False,
+        symbol_filter=symbol_filter,
+    )
+
+
+async def _default_kimchi_provider(base_symbol: str) -> dict[str, Any] | list[dict[str, Any]] | None:
+    from app.mcp_server.tooling.fundamentals._crypto import handle_get_kimchi_premium
+
+    return await handle_get_kimchi_premium(base_symbol or "BTC")
+
+
+async def _load_universe_fallback(db: AsyncSession, *, limit: int) -> list[UpbitSymbolUniverse]:
+    stmt = (
+        select(UpbitSymbolUniverse)
+        .where(
+            UpbitSymbolUniverse.quote_currency == "KRW",
+            UpbitSymbolUniverse.is_active.is_(True),
+        )
+        .order_by(UpbitSymbolUniverse.market.asc())
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+def _decimal_float(value: Decimal | float | int | str | None) -> float | None:
+    return _float_or_none(value)
+
+
+def _market_from_row(row: Any) -> str | None:
+    return normalize_krw_symbol(getattr(row, "symbol", None) or getattr(row, "market", None))
+
+
+def _name_from_row(row: Any, symbol: str) -> str:
+    fixture = NAVER_CRYPTO_REFERENCES.get(symbol, {})
+    return str(
+        getattr(row, "name", None)
+        or getattr(row, "korean_name", None)
+        or getattr(row, "english_name", None)
+        or fixture.get("displayName")
+        or _base_symbol(symbol)
+    )
+
+
+def _rank_item_from_snapshot(
+    *, rank: int,
+    row: Any,
+    ticker: dict[str, Any] | None,
+) -> NaverCryptoRankItem | None:
+    symbol = _market_from_row(row)
+    if not symbol:
+        return None
+    return NaverCryptoRankItem(
+        rank=rank,
+        symbol=symbol,
+        displayName=_name_from_row(row, symbol),
+        priceKrw=_decimal_float(getattr(row, "latest_close", None))
+        or _float_or_none((ticker or {}).get("trade_price")),
+        changeRate24h=_decimal_float(getattr(row, "change_rate", None))
+        or _float_or_none((ticker or {}).get("signed_change_rate")),
+        tradeAmount24h=_decimal_float(getattr(row, "trade_amount_24h", None))
+        or _float_or_none((ticker or {}).get("acc_trade_price_24h")),
+        rsi=_decimal_float(getattr(row, "rsi", None)),
+        marketWarning=bool(getattr(row, "market_warning", False)),
+        source=str(getattr(row, "source", None) or "tvscreener_upbit"),
+    )
+
+
+def _rank_item_from_universe(
+    *, rank: int,
+    row: UpbitSymbolUniverse,
+    ticker: dict[str, Any] | None,
+) -> NaverCryptoRankItem:
+    symbol = normalize_krw_symbol(row.market) or row.market.upper()
+    return NaverCryptoRankItem(
+        rank=rank,
+        symbol=symbol,
+        displayName=row.korean_name or row.english_name or _base_symbol(symbol),
+        priceKrw=_float_or_none((ticker or {}).get("trade_price")),
+        changeRate24h=_float_or_none((ticker or {}).get("signed_change_rate")),
+        tradeAmount24h=_float_or_none((ticker or {}).get("acc_trade_price_24h")),
+        rsi=None,
+        marketWarning=None,
+        source="upbit_official",
+    )
+
+
+def _build_profile(symbol: str | None, rank: Sequence[NaverCryptoRankItem]) -> NaverCryptoProfile | None:
+    target = normalize_krw_symbol(symbol) if symbol else (rank[0].symbol if rank else None)
+    if target is None:
+        return None
+    fixture = NAVER_CRYPTO_REFERENCES.get(target, {})
+    rank_match = next((item for item in rank if item.symbol == target), None)
+    base = str(fixture.get("baseSymbol") or _base_symbol(target))
+    display_name = str(fixture.get("displayName") or (rank_match.displayName if rank_match else base))
+    notes = list(fixture.get("referenceNotes") or [])
+    if not notes:
+        notes = [
+            "Naver crypto metadata is fixture/reference-only in ROB-234.",
+            "Live prices use Upbit official/public read-model sources where available.",
+        ]
+    return NaverCryptoProfile(
+        symbol=target,
+        baseSymbol=base,
+        displayName=display_name,
+        koreanName=str(fixture.get("koreanName")) if fixture.get("koreanName") else None,
+        englishName=str(fixture.get("englishName")) if fixture.get("englishName") else None,
+        naverUrl=str(fixture.get("naverUrl")) if fixture.get("naverUrl") else None,
+        officialMarket="UPBIT/KRW",
+        referenceNotes=notes,
+    )
+
+
+def _first_kimchi_row(payload: dict[str, Any] | list[dict[str, Any]] | None) -> dict[str, Any] | None:
+    if isinstance(payload, list):
+        return payload[0] if payload else None
+    if isinstance(payload, dict):
+        return payload
+    return None
+
+
+def _build_kimchi(base_symbol: str, payload: dict[str, Any] | list[dict[str, Any]] | None) -> NaverCryptoKimchiPremium:
+    row = _first_kimchi_row(payload)
+    if not row:
+        return NaverCryptoKimchiPremium(
+            baseSymbol=base_symbol,
+            premiumPct=None,
+            domesticPriceKrw=None,
+            overseasPriceKrw=None,
+            state="unavailable",
+            source="mcp_kimchi_premium",
+            caution="김치 프리미엄은 참고용 매크로 지표이며 주문 실행 신호가 아닙니다.",
+        )
+    return NaverCryptoKimchiPremium(
+        baseSymbol=str(row.get("base_symbol") or row.get("symbol") or base_symbol).replace("KRW-", ""),
+        premiumPct=_float_or_none(row.get("premium_pct") or row.get("kimchi_premium") or row.get("premium")),
+        domesticPriceKrw=_float_or_none(row.get("domestic_price_krw") or row.get("upbit_price_krw") or row.get("upbit_price")),
+        overseasPriceKrw=_float_or_none(row.get("overseas_price_krw") or row.get("binance_price_krw") or row.get("global_price_krw")),
+        state="available",
+        source="mcp_kimchi_premium",
+        caution="김치 프리미엄은 참고용 매크로 지표이며 주문 실행 신호가 아닙니다.",
+    )
+
+
+async def build_naver_crypto_reference(
+    *,
+    db: AsyncSession,
+    symbol: str | None = None,
+    limit: int = 20,
+    resolver: RelationResolver | None = None,
+    providers: NaverCryptoReferenceProviders | None = None,
+) -> NaverCryptoReferenceResponse:
+    """Build a partial, source-labeled crypto reference response."""
+
+    now = datetime.now(UTC)
+    limit = max(1, min(int(limit or 20), 50))
+    normalized_symbol = normalize_krw_symbol(symbol)
+    base_symbol = _base_symbol(normalized_symbol) or "BTC"
+    providers = providers or NaverCryptoReferenceProviders()
+    resolver = resolver or RelationResolver()
+    sources: list[CryptoReferenceSourceMeta] = []
+    warnings: list[str] = [
+        "naver_crypto_reference_only",
+        "read_only_no_order_watch_or_broker_mutation",
+    ]
+
+    rank_rows: Sequence[Any] = []
+    rank_provider = providers.rank_provider or _default_rank_provider
+    try:
+        rank_rows = await _maybe_await(rank_provider(db, limit))
+        sources.append(
+            CryptoReferenceSourceMeta(
+                source="tvscreener_upbit",
+                label="Persisted crypto screener snapshots",
+                state="available" if rank_rows else "unavailable",
+                fetchedAt=now if rank_rows else None,
+                freshness="fresh" if rank_rows else "missing",
+            )
+        )
+    except Exception:
+        warnings.append("crypto_rank_snapshot_unavailable")
+        sources.append(
+            CryptoReferenceSourceMeta(
+                source="tvscreener_upbit",
+                label="Persisted crypto screener snapshots",
+                state="error",
+                freshness="missing",
+                errorCode="crypto_rank_snapshot_unavailable",
+            )
+        )
+
+    markets = [_market_from_row(row) for row in rank_rows]
+    markets = [market for market in markets if market]
+    if normalized_symbol and normalized_symbol not in markets:
+        markets.insert(0, normalized_symbol)
+    markets = list(dict.fromkeys(markets))[:limit]
+
+    ticker_rows: list[dict[str, Any]] = []
+    if markets:
+        ticker_provider = providers.ticker_provider or _default_ticker_provider
+        try:
+            ticker_rows = list(await _maybe_await(ticker_provider(markets)))
+            sources.append(
+                CryptoReferenceSourceMeta(
+                    source="upbit_official",
+                    label="Upbit official/public ticker",
+                    state="available" if ticker_rows else "unavailable",
+                    fetchedAt=now if ticker_rows else None,
+                    freshness="fresh" if ticker_rows else "missing",
+                )
+            )
+        except Exception:
+            warnings.append("crypto_ticker_unavailable")
+            sources.append(
+                CryptoReferenceSourceMeta(
+                    source="upbit_official",
+                    label="Upbit official/public ticker",
+                    state="error",
+                    freshness="partial",
+                    errorCode="crypto_ticker_unavailable",
+                )
+            )
+    ticker_by_market = _ticker_map(ticker_rows)
+
+    rank_items: list[NaverCryptoRankItem] = []
+    for index, row in enumerate(rank_rows, start=1):
+        market = _market_from_row(row)
+        item = _rank_item_from_snapshot(rank=index, row=row, ticker=ticker_by_market.get(market or ""))
+        if item:
+            rank_items.append(item)
+
+    if not rank_items:
+        try:
+            universe_rows = await _load_universe_fallback(db, limit=limit)
+            rank_items = [
+                _rank_item_from_universe(
+                    rank=index,
+                    row=row,
+                    ticker=ticker_by_market.get(normalize_krw_symbol(row.market) or row.market.upper()),
+                )
+                for index, row in enumerate(universe_rows, start=1)
+            ]
+            if universe_rows:
+                warnings.append("crypto_rank_snapshot_empty_used_universe_fallback")
+        except Exception:
+            warnings.append("crypto_universe_fallback_unavailable")
+
+    profile = _build_profile(normalized_symbol, rank_items)
+    sources.append(
+        CryptoReferenceSourceMeta(
+            source="naver_reference",
+            label="Naver crypto reference fixture",
+            state="reference_only" if profile else "unavailable",
+            freshness="fixture" if profile else "missing",
+            referenceOnly=True,
+        )
+    )
+
+    news: FeedNewsResponse | None = None
+    news_provider = providers.news_provider or _default_news_provider
+    try:
+        news = await _maybe_await(news_provider(db, resolver, normalized_symbol, min(limit, 20)))
+        sources.append(
+            CryptoReferenceSourceMeta(
+                source="feed_news",
+                label="Persisted crypto news feed",
+                state="available" if news and news.items else "unavailable",
+                fetchedAt=now if news else None,
+                freshness="fresh" if news and news.items else "missing",
+            )
+        )
+        if news and news.meta.warnings:
+            warnings.extend(f"news:{warning}" for warning in news.meta.warnings)
+    except Exception:
+        warnings.append("crypto_news_unavailable")
+        sources.append(
+            CryptoReferenceSourceMeta(
+                source="feed_news",
+                label="Persisted crypto news feed",
+                state="error",
+                freshness="partial",
+                errorCode="crypto_news_unavailable",
+            )
+        )
+
+    kimchi_payload: dict[str, Any] | list[dict[str, Any]] | None = None
+    kimchi_provider = providers.kimchi_provider or _default_kimchi_provider
+    try:
+        kimchi_payload = await _maybe_await(kimchi_provider(base_symbol))
+        sources.append(
+            CryptoReferenceSourceMeta(
+                source="mcp_kimchi_premium",
+                label="Kimchi premium reference",
+                state="available" if _first_kimchi_row(kimchi_payload) else "unavailable",
+                fetchedAt=now if _first_kimchi_row(kimchi_payload) else None,
+                freshness="fresh" if _first_kimchi_row(kimchi_payload) else "missing",
+                referenceOnly=True,
+            )
+        )
+    except Exception:
+        warnings.append("crypto_kimchi_premium_unavailable")
+        sources.append(
+            CryptoReferenceSourceMeta(
+                source="mcp_kimchi_premium",
+                label="Kimchi premium reference",
+                state="error",
+                freshness="partial",
+                errorCode="crypto_kimchi_premium_unavailable",
+                referenceOnly=True,
+            )
+        )
+
+    return NaverCryptoReferenceResponse(
+        asOf=now,
+        symbol=normalized_symbol,
+        rank=rank_items[:limit],
+        profile=profile,
+        news=news,
+        kimchiPremium=_build_kimchi(base_symbol, kimchi_payload),
+        sources=sources,
+        warnings=list(dict.fromkeys(warnings)),
+        capabilities=NaverCryptoReferenceCapabilities(
+            rank=CryptoCapabilityFlag(state="supported" if rank_items else "unavailable"),
+            price=CryptoCapabilityFlag(state="supported" if ticker_rows or rank_items else "unavailable"),
+            profile=CryptoCapabilityFlag(state="reference_only", reason="naver_fixture_reference_only"),
+            news=CryptoCapabilityFlag(state="supported" if news else "unavailable"),
+            kimchiPremium=CryptoCapabilityFlag(state="reference_only", reason="macro_reference_only"),
+            execution=CryptoCapabilityFlag(state="read_only_mvp", reason="no_order_execution_controls"),
+        ),
+    )

--- a/app/services/invest_crypto_naver_adapter/adapter.py
+++ b/app/services/invest_crypto_naver_adapter/adapter.py
@@ -35,20 +35,12 @@ from app.services.invest_crypto_screener_snapshots.repository import (
 from app.services.invest_view_model.relation_resolver import RelationResolver
 
 RankProvider = Callable[[AsyncSession, int], Awaitable[Sequence[Any]] | Sequence[Any]]
-TickerProvider = Callable[
-    [list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]
-]
+TickerProvider = Callable[[list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]]
 NewsProvider = Callable[
     [AsyncSession, RelationResolver, str | None, int],
     Awaitable[FeedNewsResponse | None] | FeedNewsResponse | None,
 ]
-KimchiProvider = Callable[
-    [str],
-    Awaitable[dict[str, Any] | list[dict[str, Any]] | None]
-    | dict[str, Any]
-    | list[dict[str, Any]]
-    | None,
-]
+KimchiProvider = Callable[[str], Awaitable[dict[str, Any] | list[dict[str, Any]] | None] | dict[str, Any] | list[dict[str, Any]] | None]
 
 
 @dataclass(frozen=True)
@@ -141,9 +133,7 @@ def _row_value(row: Any, key: str) -> Any:
     return getattr(row, key, None)
 
 
-def _source_timestamp_from_rows(
-    rows: Sequence[Any], keys: Sequence[str]
-) -> datetime | None:
+def _source_timestamp_from_rows(rows: Sequence[Any], keys: Sequence[str]) -> datetime | None:
     timestamps: list[datetime] = []
     for row in rows:
         for key in keys:
@@ -184,9 +174,7 @@ def _cached_source_meta(
         state="stale" if is_stale else "cached",
         fetchedAt=fetched_at,
         cacheAgeSeconds=age_seconds,
-        freshness="stale"
-        if is_stale
-        else ("fresh" if fetched_at is not None else "partial"),
+        freshness="stale" if is_stale else ("fresh" if fetched_at is not None else "partial"),
     )
 
 
@@ -266,9 +254,7 @@ async def _default_news_provider(
     )
 
 
-async def _default_kimchi_provider(
-    base_symbol: str,
-) -> dict[str, Any] | list[dict[str, Any]] | None:
+async def _default_kimchi_provider(base_symbol: str) -> dict[str, Any] | list[dict[str, Any]] | None:
     """Default kimchi provider intentionally avoids uncached live HTTP.
 
     A caller may inject a live or cached provider; without one the endpoint still
@@ -278,9 +264,7 @@ async def _default_kimchi_provider(
     return None
 
 
-async def _load_universe_fallback(
-    db: AsyncSession, *, limit: int
-) -> list[UpbitSymbolUniverse]:
+async def _load_universe_fallback(db: AsyncSession, *, limit: int) -> list[UpbitSymbolUniverse]:
     stmt = (
         select(UpbitSymbolUniverse)
         .where(
@@ -299,9 +283,7 @@ def _decimal_float(value: Decimal | float | int | str | None) -> float | None:
 
 
 def _market_from_row(row: Any) -> str | None:
-    return normalize_krw_symbol(
-        getattr(row, "symbol", None) or getattr(row, "market", None)
-    )
+    return normalize_krw_symbol(getattr(row, "symbol", None) or getattr(row, "market", None))
 
 
 def _name_from_row(row: Any, symbol: str) -> str:
@@ -316,8 +298,7 @@ def _name_from_row(row: Any, symbol: str) -> str:
 
 
 def _rank_item_from_snapshot(
-    *,
-    rank: int,
+    *, rank: int,
     row: Any,
     ticker: dict[str, Any] | None,
 ) -> NaverCryptoRankItem | None:
@@ -341,8 +322,7 @@ def _rank_item_from_snapshot(
 
 
 def _rank_item_from_universe(
-    *,
-    rank: int,
+    *, rank: int,
     row: UpbitSymbolUniverse,
     ticker: dict[str, Any] | None,
 ) -> NaverCryptoRankItem:
@@ -360,20 +340,14 @@ def _rank_item_from_universe(
     )
 
 
-def _build_profile(
-    symbol: str | None, rank: Sequence[NaverCryptoRankItem]
-) -> NaverCryptoProfile | None:
-    target = (
-        normalize_krw_symbol(symbol) if symbol else (rank[0].symbol if rank else None)
-    )
+def _build_profile(symbol: str | None, rank: Sequence[NaverCryptoRankItem]) -> NaverCryptoProfile | None:
+    target = normalize_krw_symbol(symbol) if symbol else (rank[0].symbol if rank else None)
     if target is None:
         return None
     fixture = NAVER_CRYPTO_REFERENCES.get(target, {})
     rank_match = next((item for item in rank if item.symbol == target), None)
     base = str(fixture.get("baseSymbol") or _base_symbol(target))
-    display_name = str(
-        fixture.get("displayName") or (rank_match.displayName if rank_match else base)
-    )
+    display_name = str(fixture.get("displayName") or (rank_match.displayName if rank_match else base))
     notes = list(fixture.get("referenceNotes") or [])
     if not notes:
         notes = [
@@ -384,21 +358,15 @@ def _build_profile(
         symbol=target,
         baseSymbol=base,
         displayName=display_name,
-        koreanName=str(fixture.get("koreanName"))
-        if fixture.get("koreanName")
-        else None,
-        englishName=str(fixture.get("englishName"))
-        if fixture.get("englishName")
-        else None,
+        koreanName=str(fixture.get("koreanName")) if fixture.get("koreanName") else None,
+        englishName=str(fixture.get("englishName")) if fixture.get("englishName") else None,
         naverUrl=str(fixture.get("naverUrl")) if fixture.get("naverUrl") else None,
         officialMarket="UPBIT/KRW",
         referenceNotes=notes,
     )
 
 
-def _first_kimchi_row(
-    payload: dict[str, Any] | list[dict[str, Any]] | None,
-) -> dict[str, Any] | None:
+def _first_kimchi_row(payload: dict[str, Any] | list[dict[str, Any]] | None) -> dict[str, Any] | None:
     if isinstance(payload, list):
         return payload[0] if payload else None
     if isinstance(payload, dict):
@@ -406,9 +374,7 @@ def _first_kimchi_row(
     return None
 
 
-def _build_kimchi(
-    base_symbol: str, payload: dict[str, Any] | list[dict[str, Any]] | None
-) -> NaverCryptoKimchiPremium:
+def _build_kimchi(base_symbol: str, payload: dict[str, Any] | list[dict[str, Any]] | None) -> NaverCryptoKimchiPremium:
     row = _first_kimchi_row(payload)
     if not row:
         return NaverCryptoKimchiPremium(
@@ -421,22 +387,10 @@ def _build_kimchi(
             caution="김치 프리미엄은 참고용 매크로 지표이며 주문 실행 신호가 아닙니다.",
         )
     return NaverCryptoKimchiPremium(
-        baseSymbol=str(
-            row.get("base_symbol") or row.get("symbol") or base_symbol
-        ).replace("KRW-", ""),
-        premiumPct=_float_or_none(
-            row.get("premium_pct") or row.get("kimchi_premium") or row.get("premium")
-        ),
-        domesticPriceKrw=_float_or_none(
-            row.get("domestic_price_krw")
-            or row.get("upbit_price_krw")
-            or row.get("upbit_price")
-        ),
-        overseasPriceKrw=_float_or_none(
-            row.get("overseas_price_krw")
-            or row.get("binance_price_krw")
-            or row.get("global_price_krw")
-        ),
+        baseSymbol=str(row.get("base_symbol") or row.get("symbol") or base_symbol).replace("KRW-", ""),
+        premiumPct=_float_or_none(row.get("premium_pct") or row.get("kimchi_premium") or row.get("premium")),
+        domesticPriceKrw=_float_or_none(row.get("domestic_price_krw") or row.get("upbit_price_krw") or row.get("upbit_price")),
+        overseasPriceKrw=_float_or_none(row.get("overseas_price_krw") or row.get("binance_price_krw") or row.get("global_price_krw")),
         state="available",
         source="mcp_kimchi_premium",
         caution="김치 프리미엄은 참고용 매크로 지표이며 주문 실행 신호가 아닙니다.",
@@ -506,14 +460,7 @@ async def build_naver_crypto_reference(
             ticker_rows = list(await _maybe_await(ticker_provider(markets)))
             ticker_fetched_at = _source_timestamp_from_rows(
                 ticker_rows,
-                (
-                    "fetched_at",
-                    "fetchedAt",
-                    "cached_at",
-                    "updated_at",
-                    "timestamp",
-                    "trade_timestamp",
-                ),
+                ("fetched_at", "fetchedAt", "cached_at", "updated_at", "timestamp", "trade_timestamp"),
             )
             sources.append(
                 _provider_source_meta(
@@ -541,9 +488,7 @@ async def build_naver_crypto_reference(
     rank_items: list[NaverCryptoRankItem] = []
     for index, row in enumerate(rank_rows, start=1):
         market = _market_from_row(row)
-        item = _rank_item_from_snapshot(
-            rank=index, row=row, ticker=ticker_by_market.get(market or "")
-        )
+        item = _rank_item_from_snapshot(rank=index, row=row, ticker=ticker_by_market.get(market or ""))
         if item:
             rank_items.append(item)
 
@@ -554,9 +499,7 @@ async def build_naver_crypto_reference(
                 _rank_item_from_universe(
                     rank=index,
                     row=row,
-                    ticker=ticker_by_market.get(
-                        normalize_krw_symbol(row.market) or row.market.upper()
-                    ),
+                    ticker=ticker_by_market.get(normalize_krw_symbol(row.market) or row.market.upper()),
                 )
                 for index, row in enumerate(universe_rows, start=1)
             ]
@@ -579,9 +522,7 @@ async def build_naver_crypto_reference(
     news: FeedNewsResponse | None = None
     news_provider = providers.news_provider or _default_news_provider
     try:
-        news = await _maybe_await(
-            news_provider(db, resolver, normalized_symbol, min(limit, 20))
-        )
+        news = await _maybe_await(news_provider(db, resolver, normalized_symbol, min(limit, 20)))
         sources.append(
             _cached_source_meta(
                 source="feed_news",
@@ -647,21 +588,11 @@ async def build_naver_crypto_reference(
         sources=sources,
         warnings=list(dict.fromkeys(warnings)),
         capabilities=NaverCryptoReferenceCapabilities(
-            rank=CryptoCapabilityFlag(
-                state="supported" if rank_items else "unavailable"
-            ),
-            price=CryptoCapabilityFlag(
-                state="supported" if ticker_rows or rank_items else "unavailable"
-            ),
-            profile=CryptoCapabilityFlag(
-                state="reference_only", reason="naver_fixture_reference_only"
-            ),
+            rank=CryptoCapabilityFlag(state="supported" if rank_items else "unavailable"),
+            price=CryptoCapabilityFlag(state="supported" if ticker_rows or rank_items else "unavailable"),
+            profile=CryptoCapabilityFlag(state="reference_only", reason="naver_fixture_reference_only"),
             news=CryptoCapabilityFlag(state="supported" if news else "unavailable"),
-            kimchiPremium=CryptoCapabilityFlag(
-                state="reference_only", reason="macro_reference_only"
-            ),
-            execution=CryptoCapabilityFlag(
-                state="read_only_mvp", reason="no_order_execution_controls"
-            ),
+            kimchiPremium=CryptoCapabilityFlag(state="reference_only", reason="macro_reference_only"),
+            execution=CryptoCapabilityFlag(state="read_only_mvp", reason="no_order_execution_controls"),
         ),
     )

--- a/app/services/invest_crypto_naver_adapter/adapter.py
+++ b/app/services/invest_crypto_naver_adapter/adapter.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import inspect
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import Any
 
@@ -35,12 +35,20 @@ from app.services.invest_crypto_screener_snapshots.repository import (
 from app.services.invest_view_model.relation_resolver import RelationResolver
 
 RankProvider = Callable[[AsyncSession, int], Awaitable[Sequence[Any]] | Sequence[Any]]
-TickerProvider = Callable[[list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]]
+TickerProvider = Callable[
+    [list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]
+]
 NewsProvider = Callable[
     [AsyncSession, RelationResolver, str | None, int],
     Awaitable[FeedNewsResponse | None] | FeedNewsResponse | None,
 ]
-KimchiProvider = Callable[[str], Awaitable[dict[str, Any] | list[dict[str, Any]] | None] | dict[str, Any] | list[dict[str, Any]] | None]
+KimchiProvider = Callable[
+    [str],
+    Awaitable[dict[str, Any] | list[dict[str, Any]] | None]
+    | dict[str, Any]
+    | list[dict[str, Any]]
+    | None,
+]
 
 
 @dataclass(frozen=True)
@@ -93,15 +101,149 @@ def _ticker_map(rows: Sequence[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     return mapped
 
 
+_SOURCE_STALE_AFTER_SECONDS = 24 * 60 * 60
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _parse_source_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _as_utc(value)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=UTC)
+    if isinstance(value, (int, float)):
+        # Upbit ticker timestamps are millisecond epochs. Accept seconds too.
+        seconds = float(value) / 1000 if float(value) > 10_000_000_000 else float(value)
+        try:
+            return datetime.fromtimestamp(seconds, tz=UTC)
+        except (OverflowError, OSError, ValueError):
+            return None
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        try:
+            return _as_utc(datetime.fromisoformat(raw.replace("Z", "+00:00")))
+        except ValueError:
+            return None
+    return None
+
+
+def _row_value(row: Any, key: str) -> Any:
+    if isinstance(row, dict):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _source_timestamp_from_rows(
+    rows: Sequence[Any], keys: Sequence[str]
+) -> datetime | None:
+    timestamps: list[datetime] = []
+    for row in rows:
+        for key in keys:
+            parsed = _parse_source_datetime(_row_value(row, key))
+            if parsed is not None:
+                timestamps.append(parsed)
+                break
+    return max(timestamps) if timestamps else None
+
+
+def _cache_age_seconds(*, now: datetime, fetched_at: datetime | None) -> float | None:
+    if fetched_at is None:
+        return None
+    return max(0.0, (now - fetched_at).total_seconds())
+
+
+def _cached_source_meta(
+    *,
+    source: str,
+    label: str,
+    has_data: bool,
+    fetched_at: datetime | None,
+    now: datetime,
+    stale_after_seconds: int = _SOURCE_STALE_AFTER_SECONDS,
+) -> CryptoReferenceSourceMeta:
+    if not has_data:
+        return CryptoReferenceSourceMeta(
+            source=source,
+            label=label,
+            state="unavailable",
+            freshness="missing",
+        )
+    age_seconds = _cache_age_seconds(now=now, fetched_at=fetched_at)
+    is_stale = age_seconds is not None and age_seconds > stale_after_seconds
+    return CryptoReferenceSourceMeta(
+        source=source,
+        label=label,
+        state="stale" if is_stale else "cached",
+        fetchedAt=fetched_at,
+        cacheAgeSeconds=age_seconds,
+        freshness="stale"
+        if is_stale
+        else ("fresh" if fetched_at is not None else "partial"),
+    )
+
+
+def _provider_source_meta(
+    *,
+    source: str,
+    label: str,
+    has_data: bool,
+    fetched_at: datetime | None,
+    now: datetime,
+    reference_only: bool = False,
+    stale_after_seconds: int = _SOURCE_STALE_AFTER_SECONDS,
+) -> CryptoReferenceSourceMeta:
+    if not has_data:
+        return CryptoReferenceSourceMeta(
+            source=source,
+            label=label,
+            state="unavailable",
+            freshness="missing",
+            referenceOnly=reference_only,
+        )
+    if fetched_at is None:
+        return CryptoReferenceSourceMeta(
+            source=source,
+            label=label,
+            state="live",
+            fetchedAt=now,
+            freshness="live",
+            referenceOnly=reference_only,
+        )
+    meta = _cached_source_meta(
+        source=source,
+        label=label,
+        has_data=True,
+        fetched_at=fetched_at,
+        now=now,
+        stale_after_seconds=stale_after_seconds,
+    )
+    if reference_only:
+        return meta.model_copy(update={"referenceOnly": True})
+    return meta
+
+
 async def _default_rank_provider(db: AsyncSession, limit: int) -> Sequence[Any]:
     repo = InvestCryptoScreenerSnapshotsRepository(db)
     return await repo.list_latest(preset_id="crypto_momentum", limit=limit)
 
 
 async def _default_ticker_provider(markets: list[str]) -> list[dict[str, Any]]:
-    from app.services.brokers.upbit.client import fetch_multiple_tickers
+    """Default ticker provider intentionally avoids live request-path HTTP.
 
-    return await fetch_multiple_tickers(markets)
+    The Naver reference endpoint is a read-model/fixture view. Live Upbit ticker
+    fetches are volatile external HTTP and must be injected explicitly by callers
+    that can label them as live data.
+    """
+
+    return []
 
 
 async def _default_news_provider(
@@ -124,13 +266,21 @@ async def _default_news_provider(
     )
 
 
-async def _default_kimchi_provider(base_symbol: str) -> dict[str, Any] | list[dict[str, Any]] | None:
-    from app.mcp_server.tooling.fundamentals._crypto import handle_get_kimchi_premium
+async def _default_kimchi_provider(
+    base_symbol: str,
+) -> dict[str, Any] | list[dict[str, Any]] | None:
+    """Default kimchi provider intentionally avoids uncached live HTTP.
 
-    return await handle_get_kimchi_premium(base_symbol or "BTC")
+    A caller may inject a live or cached provider; without one the endpoint still
+    returns fixture/read-model data and marks kimchi premium unavailable.
+    """
+
+    return None
 
 
-async def _load_universe_fallback(db: AsyncSession, *, limit: int) -> list[UpbitSymbolUniverse]:
+async def _load_universe_fallback(
+    db: AsyncSession, *, limit: int
+) -> list[UpbitSymbolUniverse]:
     stmt = (
         select(UpbitSymbolUniverse)
         .where(
@@ -149,7 +299,9 @@ def _decimal_float(value: Decimal | float | int | str | None) -> float | None:
 
 
 def _market_from_row(row: Any) -> str | None:
-    return normalize_krw_symbol(getattr(row, "symbol", None) or getattr(row, "market", None))
+    return normalize_krw_symbol(
+        getattr(row, "symbol", None) or getattr(row, "market", None)
+    )
 
 
 def _name_from_row(row: Any, symbol: str) -> str:
@@ -164,7 +316,8 @@ def _name_from_row(row: Any, symbol: str) -> str:
 
 
 def _rank_item_from_snapshot(
-    *, rank: int,
+    *,
+    rank: int,
     row: Any,
     ticker: dict[str, Any] | None,
 ) -> NaverCryptoRankItem | None:
@@ -188,7 +341,8 @@ def _rank_item_from_snapshot(
 
 
 def _rank_item_from_universe(
-    *, rank: int,
+    *,
+    rank: int,
     row: UpbitSymbolUniverse,
     ticker: dict[str, Any] | None,
 ) -> NaverCryptoRankItem:
@@ -206,14 +360,20 @@ def _rank_item_from_universe(
     )
 
 
-def _build_profile(symbol: str | None, rank: Sequence[NaverCryptoRankItem]) -> NaverCryptoProfile | None:
-    target = normalize_krw_symbol(symbol) if symbol else (rank[0].symbol if rank else None)
+def _build_profile(
+    symbol: str | None, rank: Sequence[NaverCryptoRankItem]
+) -> NaverCryptoProfile | None:
+    target = (
+        normalize_krw_symbol(symbol) if symbol else (rank[0].symbol if rank else None)
+    )
     if target is None:
         return None
     fixture = NAVER_CRYPTO_REFERENCES.get(target, {})
     rank_match = next((item for item in rank if item.symbol == target), None)
     base = str(fixture.get("baseSymbol") or _base_symbol(target))
-    display_name = str(fixture.get("displayName") or (rank_match.displayName if rank_match else base))
+    display_name = str(
+        fixture.get("displayName") or (rank_match.displayName if rank_match else base)
+    )
     notes = list(fixture.get("referenceNotes") or [])
     if not notes:
         notes = [
@@ -224,15 +384,21 @@ def _build_profile(symbol: str | None, rank: Sequence[NaverCryptoRankItem]) -> N
         symbol=target,
         baseSymbol=base,
         displayName=display_name,
-        koreanName=str(fixture.get("koreanName")) if fixture.get("koreanName") else None,
-        englishName=str(fixture.get("englishName")) if fixture.get("englishName") else None,
+        koreanName=str(fixture.get("koreanName"))
+        if fixture.get("koreanName")
+        else None,
+        englishName=str(fixture.get("englishName"))
+        if fixture.get("englishName")
+        else None,
         naverUrl=str(fixture.get("naverUrl")) if fixture.get("naverUrl") else None,
         officialMarket="UPBIT/KRW",
         referenceNotes=notes,
     )
 
 
-def _first_kimchi_row(payload: dict[str, Any] | list[dict[str, Any]] | None) -> dict[str, Any] | None:
+def _first_kimchi_row(
+    payload: dict[str, Any] | list[dict[str, Any]] | None,
+) -> dict[str, Any] | None:
     if isinstance(payload, list):
         return payload[0] if payload else None
     if isinstance(payload, dict):
@@ -240,7 +406,9 @@ def _first_kimchi_row(payload: dict[str, Any] | list[dict[str, Any]] | None) -> 
     return None
 
 
-def _build_kimchi(base_symbol: str, payload: dict[str, Any] | list[dict[str, Any]] | None) -> NaverCryptoKimchiPremium:
+def _build_kimchi(
+    base_symbol: str, payload: dict[str, Any] | list[dict[str, Any]] | None
+) -> NaverCryptoKimchiPremium:
     row = _first_kimchi_row(payload)
     if not row:
         return NaverCryptoKimchiPremium(
@@ -253,10 +421,22 @@ def _build_kimchi(base_symbol: str, payload: dict[str, Any] | list[dict[str, Any
             caution="김치 프리미엄은 참고용 매크로 지표이며 주문 실행 신호가 아닙니다.",
         )
     return NaverCryptoKimchiPremium(
-        baseSymbol=str(row.get("base_symbol") or row.get("symbol") or base_symbol).replace("KRW-", ""),
-        premiumPct=_float_or_none(row.get("premium_pct") or row.get("kimchi_premium") or row.get("premium")),
-        domesticPriceKrw=_float_or_none(row.get("domestic_price_krw") or row.get("upbit_price_krw") or row.get("upbit_price")),
-        overseasPriceKrw=_float_or_none(row.get("overseas_price_krw") or row.get("binance_price_krw") or row.get("global_price_krw")),
+        baseSymbol=str(
+            row.get("base_symbol") or row.get("symbol") or base_symbol
+        ).replace("KRW-", ""),
+        premiumPct=_float_or_none(
+            row.get("premium_pct") or row.get("kimchi_premium") or row.get("premium")
+        ),
+        domesticPriceKrw=_float_or_none(
+            row.get("domestic_price_krw")
+            or row.get("upbit_price_krw")
+            or row.get("upbit_price")
+        ),
+        overseasPriceKrw=_float_or_none(
+            row.get("overseas_price_krw")
+            or row.get("binance_price_krw")
+            or row.get("global_price_krw")
+        ),
         state="available",
         source="mcp_kimchi_premium",
         caution="김치 프리미엄은 참고용 매크로 지표이며 주문 실행 신호가 아닙니다.",
@@ -289,13 +469,16 @@ async def build_naver_crypto_reference(
     rank_provider = providers.rank_provider or _default_rank_provider
     try:
         rank_rows = await _maybe_await(rank_provider(db, limit))
+        rank_fetched_at = _source_timestamp_from_rows(
+            rank_rows, ("computed_at", "updated_at", "created_at", "snapshot_date")
+        )
         sources.append(
-            CryptoReferenceSourceMeta(
+            _cached_source_meta(
                 source="tvscreener_upbit",
                 label="Persisted crypto screener snapshots",
-                state="available" if rank_rows else "unavailable",
-                fetchedAt=now if rank_rows else None,
-                freshness="fresh" if rank_rows else "missing",
+                has_data=bool(rank_rows),
+                fetched_at=rank_fetched_at,
+                now=now,
             )
         )
     except Exception:
@@ -321,13 +504,25 @@ async def build_naver_crypto_reference(
         ticker_provider = providers.ticker_provider or _default_ticker_provider
         try:
             ticker_rows = list(await _maybe_await(ticker_provider(markets)))
+            ticker_fetched_at = _source_timestamp_from_rows(
+                ticker_rows,
+                (
+                    "fetched_at",
+                    "fetchedAt",
+                    "cached_at",
+                    "updated_at",
+                    "timestamp",
+                    "trade_timestamp",
+                ),
+            )
             sources.append(
-                CryptoReferenceSourceMeta(
+                _provider_source_meta(
                     source="upbit_official",
                     label="Upbit official/public ticker",
-                    state="available" if ticker_rows else "unavailable",
-                    fetchedAt=now if ticker_rows else None,
-                    freshness="fresh" if ticker_rows else "missing",
+                    has_data=bool(ticker_rows),
+                    fetched_at=ticker_fetched_at,
+                    now=now,
+                    stale_after_seconds=60,
                 )
             )
         except Exception:
@@ -346,7 +541,9 @@ async def build_naver_crypto_reference(
     rank_items: list[NaverCryptoRankItem] = []
     for index, row in enumerate(rank_rows, start=1):
         market = _market_from_row(row)
-        item = _rank_item_from_snapshot(rank=index, row=row, ticker=ticker_by_market.get(market or ""))
+        item = _rank_item_from_snapshot(
+            rank=index, row=row, ticker=ticker_by_market.get(market or "")
+        )
         if item:
             rank_items.append(item)
 
@@ -357,7 +554,9 @@ async def build_naver_crypto_reference(
                 _rank_item_from_universe(
                     rank=index,
                     row=row,
-                    ticker=ticker_by_market.get(normalize_krw_symbol(row.market) or row.market.upper()),
+                    ticker=ticker_by_market.get(
+                        normalize_krw_symbol(row.market) or row.market.upper()
+                    ),
                 )
                 for index, row in enumerate(universe_rows, start=1)
             ]
@@ -371,7 +570,7 @@ async def build_naver_crypto_reference(
         CryptoReferenceSourceMeta(
             source="naver_reference",
             label="Naver crypto reference fixture",
-            state="reference_only" if profile else "unavailable",
+            state="fixture" if profile else "unavailable",
             freshness="fixture" if profile else "missing",
             referenceOnly=True,
         )
@@ -380,14 +579,16 @@ async def build_naver_crypto_reference(
     news: FeedNewsResponse | None = None
     news_provider = providers.news_provider or _default_news_provider
     try:
-        news = await _maybe_await(news_provider(db, resolver, normalized_symbol, min(limit, 20)))
+        news = await _maybe_await(
+            news_provider(db, resolver, normalized_symbol, min(limit, 20))
+        )
         sources.append(
-            CryptoReferenceSourceMeta(
+            _cached_source_meta(
                 source="feed_news",
                 label="Persisted crypto news feed",
-                state="available" if news and news.items else "unavailable",
-                fetchedAt=now if news else None,
-                freshness="fresh" if news and news.items else "missing",
+                has_data=bool(news and news.items),
+                fetched_at=_parse_source_datetime(getattr(news, "asOf", None)),
+                now=now,
             )
         )
         if news and news.meta.warnings:
@@ -408,14 +609,19 @@ async def build_naver_crypto_reference(
     kimchi_provider = providers.kimchi_provider or _default_kimchi_provider
     try:
         kimchi_payload = await _maybe_await(kimchi_provider(base_symbol))
+        kimchi_row = _first_kimchi_row(kimchi_payload)
         sources.append(
-            CryptoReferenceSourceMeta(
+            _provider_source_meta(
                 source="mcp_kimchi_premium",
                 label="Kimchi premium reference",
-                state="available" if _first_kimchi_row(kimchi_payload) else "unavailable",
-                fetchedAt=now if _first_kimchi_row(kimchi_payload) else None,
-                freshness="fresh" if _first_kimchi_row(kimchi_payload) else "missing",
-                referenceOnly=True,
+                has_data=bool(kimchi_row),
+                fetched_at=_source_timestamp_from_rows(
+                    [kimchi_row] if kimchi_row else [],
+                    ("fetched_at", "fetchedAt", "cached_at", "updated_at", "timestamp"),
+                ),
+                now=now,
+                reference_only=True,
+                stale_after_seconds=10 * 60,
             )
         )
     except Exception:
@@ -441,11 +647,21 @@ async def build_naver_crypto_reference(
         sources=sources,
         warnings=list(dict.fromkeys(warnings)),
         capabilities=NaverCryptoReferenceCapabilities(
-            rank=CryptoCapabilityFlag(state="supported" if rank_items else "unavailable"),
-            price=CryptoCapabilityFlag(state="supported" if ticker_rows or rank_items else "unavailable"),
-            profile=CryptoCapabilityFlag(state="reference_only", reason="naver_fixture_reference_only"),
+            rank=CryptoCapabilityFlag(
+                state="supported" if rank_items else "unavailable"
+            ),
+            price=CryptoCapabilityFlag(
+                state="supported" if ticker_rows or rank_items else "unavailable"
+            ),
+            profile=CryptoCapabilityFlag(
+                state="reference_only", reason="naver_fixture_reference_only"
+            ),
             news=CryptoCapabilityFlag(state="supported" if news else "unavailable"),
-            kimchiPremium=CryptoCapabilityFlag(state="reference_only", reason="macro_reference_only"),
-            execution=CryptoCapabilityFlag(state="read_only_mvp", reason="no_order_execution_controls"),
+            kimchiPremium=CryptoCapabilityFlag(
+                state="reference_only", reason="macro_reference_only"
+            ),
+            execution=CryptoCapabilityFlag(
+                state="read_only_mvp", reason="no_order_execution_controls"
+            ),
         ),
     )

--- a/app/services/invest_crypto_naver_adapter/fixtures.py
+++ b/app/services/invest_crypto_naver_adapter/fixtures.py
@@ -1,0 +1,55 @@
+"""Fixture/reference metadata for the read-only Naver crypto adapter.
+
+Naver crypto coverage is intentionally treated as reference-only until a stable,
+allowed upstream endpoint is separately verified. Keep this file deterministic and
+side-effect free.
+"""
+
+from __future__ import annotations
+
+NAVER_CRYPTO_REFERENCES: dict[str, dict[str, str | list[str]]] = {
+    "KRW-BTC": {
+        "baseSymbol": "BTC",
+        "koreanName": "비트코인",
+        "englishName": "Bitcoin",
+        "displayName": "비트코인",
+        "naverUrl": "https://m.stock.naver.com/crypto/UPBIT/KRW-BTC",
+        "referenceNotes": [
+            "Naver crypto metadata is fixture/reference-only in ROB-234.",
+            "Use Upbit official/public read-model prices as the executable source of truth.",
+        ],
+    },
+    "KRW-ETH": {
+        "baseSymbol": "ETH",
+        "koreanName": "이더리움",
+        "englishName": "Ethereum",
+        "displayName": "이더리움",
+        "naverUrl": "https://m.stock.naver.com/crypto/UPBIT/KRW-ETH",
+        "referenceNotes": [
+            "Naver crypto metadata is fixture/reference-only in ROB-234.",
+            "Use Upbit official/public read-model prices as the executable source of truth.",
+        ],
+    },
+    "KRW-XRP": {
+        "baseSymbol": "XRP",
+        "koreanName": "엑스알피",
+        "englishName": "XRP",
+        "displayName": "엑스알피",
+        "naverUrl": "https://m.stock.naver.com/crypto/UPBIT/KRW-XRP",
+        "referenceNotes": [
+            "Naver crypto metadata is fixture/reference-only in ROB-234.",
+            "Use Upbit official/public read-model prices as the executable source of truth.",
+        ],
+    },
+    "KRW-SOL": {
+        "baseSymbol": "SOL",
+        "koreanName": "솔라나",
+        "englishName": "Solana",
+        "displayName": "솔라나",
+        "naverUrl": "https://m.stock.naver.com/crypto/UPBIT/KRW-SOL",
+        "referenceNotes": [
+            "Naver crypto metadata is fixture/reference-only in ROB-234.",
+            "Use Upbit official/public read-model prices as the executable source of truth.",
+        ],
+    },
+}

--- a/app/services/invest_view_model/crypto_dashboard_service.py
+++ b/app/services/invest_view_model/crypto_dashboard_service.py
@@ -116,7 +116,7 @@ async def _default_orderbook_spread_provider(
 
 
 async def _load_active_krw_markets(
-    db: AsyncSession, *, limit: int
+    db: AsyncSession, *, limit: int | None = None
 ) -> list[UpbitSymbolUniverse]:
     stmt = (
         select(UpbitSymbolUniverse)
@@ -125,8 +125,9 @@ async def _load_active_krw_markets(
             UpbitSymbolUniverse.is_active.is_(True),
         )
         .order_by(UpbitSymbolUniverse.market.asc())
-        .limit(limit)
     )
+    if limit is not None:
+        stmt = stmt.limit(limit)
     result = await db.execute(stmt)
     return list(result.scalars().all())
 
@@ -339,14 +340,16 @@ async def build_crypto_dashboard(
     limit = max(1, min(limit, 50))
     orderbook_limit = max(0, min(orderbook_limit, limit))
 
-    universe = await _load_active_krw_markets(db, limit=limit)
-    markets = [row.market.upper() for row in universe]
+    # Load the active KRW universe before ticker ranking. The page is a
+    # top-movers/volume view, not an alphabetical slice of active markets.
+    universe = await _load_active_krw_markets(db)
+    all_markets = [row.market.upper() for row in universe]
 
     tickers: dict[str, dict[str, Any]] = {}
-    if markets:
+    if all_markets:
         provider = ticker_provider or _default_ticker_provider
         try:
-            tickers = _ticker_map(await _maybe_await(provider(markets)))
+            tickers = _ticker_map(await _maybe_await(provider(all_markets)))
             sources.append(
                 CryptoSourceState(
                     source="upbit_ticker",
@@ -362,6 +365,15 @@ async def build_crypto_dashboard(
                     source="upbit_ticker", state="unavailable", label="Upbit ticker"
                 )
             )
+
+    def _market_rank(row: UpbitSymbolUniverse) -> tuple[float, float, str]:
+        ticker = tickers.get(row.market.upper(), {})
+        change = abs(_float_or_none(ticker.get("signed_change_rate")) or 0)
+        trade_amount = _float_or_none(ticker.get("acc_trade_price_24h")) or 0
+        return (-change, -trade_amount, row.market.upper())
+
+    ranked_universe = sorted(universe, key=_market_rank)[:limit]
+    markets = [row.market.upper() for row in ranked_universe]
 
     spreads: dict[str, float | None] = {}
     if markets and orderbook_limit > 0:
@@ -391,13 +403,21 @@ async def build_crypto_dashboard(
 
     pending_rows = await _load_pending_orders(db, user_id=user_id, symbols=markets)
     pending_summary = _build_pending_summary(pending_rows)
+    sources.append(
+        CryptoSourceState(
+            source="pending_orders",
+            state="supported",
+            label="Pending orders read model",
+            fetchedAt=now,
+        )
+    )
     pending_by_base = {
         item.baseSymbol for item in pending_summary.items if item.baseSymbol
     }
 
     cards: list[CryptoMarketCard] = []
     held_symbols: list[str] = []
-    for row in universe:
+    for row in ranked_universe:
         symbol = row.market.upper()
         base = row.base_currency.upper()
         ticker = tickers.get(symbol, {})
@@ -496,6 +516,22 @@ async def build_crypto_dashboard(
         )
 
     candidates = _build_candidate_insights(cards, pending_by_base)
+    sources.extend(
+        [
+            CryptoSourceState(
+                source="mcp_risk_reference",
+                state="reference_only",
+                label="MCP risk reference",
+                fetchedAt=now,
+            ),
+            CryptoSourceState(
+                source="mcp_candidate_reference",
+                state="reference_only",
+                label="MCP candidate reference",
+                fetchedAt=now,
+            ),
+        ]
+    )
     candidate_symbols = {candidate.symbol for candidate in candidates}
     for card in cards:
         if card.symbol not in candidate_symbols:

--- a/app/services/invest_view_model/crypto_dashboard_service.py
+++ b/app/services/invest_view_model/crypto_dashboard_service.py
@@ -13,6 +13,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.pending_order import PendingOrder
 from app.models.upbit_symbol_universe import UpbitSymbolUniverse
 from app.schemas.invest_crypto import (
+    CryptoCandidateInsight,
+    CryptoCandidateReasonKind,
     CryptoDashboardMeta,
     CryptoDashboardResponse,
     CryptoHoldingSummary,
@@ -21,6 +23,8 @@ from app.schemas.invest_crypto import (
     CryptoPendingOrderItem,
     CryptoPendingOrdersSummary,
     CryptoRiskBadge,
+    CryptoRiskLevel,
+    CryptoRiskSummary,
     CryptoSourceState,
 )
 from app.services.invest_view_model.relation_resolver import RelationResolver
@@ -31,6 +35,14 @@ TickerProvider = Callable[
 OrderbookSpreadProvider = Callable[
     [list[str]], Awaitable[dict[str, float | None]] | dict[str, float | None]
 ]
+
+# Deterministic dashboard heuristics only; these thresholds never trigger orders,
+# watch writes, candidate persistence, or provider-side mutations.
+HIGH_VOLATILITY_ABS_CHANGE = 0.07
+ELEVATED_MOMENTUM_ABS_CHANGE = 0.04
+THIN_ORDERBOOK_SPREAD_PCT = 0.5
+LOW_LIQUIDITY_TRADE_PRICE_KRW = 500_000_000
+CANDIDATE_MAX_ITEMS = 5
 
 
 async def _maybe_await(value):
@@ -168,6 +180,148 @@ def _build_pending_summary(rows: Sequence[PendingOrder]) -> CryptoPendingOrdersS
     )
 
 
+def _risk_level(score: int, *, ticker_available: bool) -> CryptoRiskLevel:
+    if not ticker_available:
+        return "unknown"
+    if score >= 60:
+        return "high"
+    if score >= 30:
+        return "medium"
+    return "low"
+
+
+def _risk_score(
+    *,
+    change_rate: float | None,
+    acc_trade_price_24h: float | None,
+    spread: float | None,
+    ticker_available: bool,
+    has_pending_order: bool,
+) -> tuple[int, list[str]]:
+    score = 0
+    reasons: list[str] = []
+    if not ticker_available:
+        score += 40
+        reasons.append("시세 데이터 없음")
+    if spread is not None and spread > THIN_ORDERBOOK_SPREAD_PCT:
+        score += 25
+        reasons.append("호가 스프레드 확대")
+    if change_rate is not None and abs(change_rate) >= HIGH_VOLATILITY_ABS_CHANGE:
+        score += 25
+        reasons.append("24시간 변동성 확대")
+    if (
+        ticker_available
+        and acc_trade_price_24h is not None
+        and acc_trade_price_24h < LOW_LIQUIDITY_TRADE_PRICE_KRW
+    ):
+        score += 15
+        reasons.append("24시간 거래대금 낮음")
+    if has_pending_order:
+        score += 10
+        reasons.append("미체결 상태 존재")
+    return min(score, 100), reasons
+
+
+def _candidate_score(
+    card: CryptoMarketCard, *, has_pending_order: bool
+) -> tuple[int, list[CryptoCandidateReasonKind], str]:
+    score = 0
+    reasons: list[CryptoCandidateReasonKind] = []
+    if card.isWatched:
+        score += 35
+        reasons.append("watched")
+    if card.changeRate24h is not None and abs(card.changeRate24h) >= ELEVATED_MOMENTUM_ABS_CHANGE:
+        score += 25
+        reasons.append("momentum")
+    if (
+        card.accTradePrice24h is not None
+        and card.accTradePrice24h >= LOW_LIQUIDITY_TRADE_PRICE_KRW
+    ):
+        score += 20
+        reasons.append("liquidity")
+    if card.orderbookSpreadPct is not None and card.orderbookSpreadPct <= THIN_ORDERBOOK_SPREAD_PCT:
+        score += 10
+        reasons.append("spread")
+    if card.isHeld:
+        reasons.append("held")
+    if has_pending_order:
+        score -= 30
+        reasons.append("pending_order")
+    if card.risk and card.risk.level == "high":
+        score -= 20
+    if card.risk and card.risk.level in {"low", "medium"}:
+        reasons.append("data_quality")
+    score = max(0, min(score, 100))
+    summary_parts: list[str] = []
+    if "watched" in reasons:
+        summary_parts.append("기존 검토 목록과 일치")
+    if "momentum" in reasons:
+        summary_parts.append("24시간 변화가 큼")
+    if "liquidity" in reasons:
+        summary_parts.append("거래대금 양호")
+    if "spread" in reasons:
+        summary_parts.append("호가 간격 안정")
+    if "pending_order" in reasons:
+        summary_parts.append("미체결 상태로 감점")
+    summary = " · ".join(summary_parts) or "참고용 검토 후보"
+    return score, reasons, summary
+
+
+def _build_candidate_insights(
+    cards: Sequence[CryptoMarketCard],
+    pending_by_base: set[str],
+    *,
+    limit: int = CANDIDATE_MAX_ITEMS,
+) -> list[CryptoCandidateInsight]:
+    ranked: list[tuple[int, float, str, CryptoMarketCard, list[CryptoCandidateReasonKind], str]] = []
+    for card in cards:
+        risk = card.risk
+        if risk is None or risk.level == "unknown":
+            continue
+        if any(badge.kind == "data_unavailable" for badge in card.badges):
+            continue
+        has_pending_order = card.baseSymbol in pending_by_base
+        score, reasons, summary = _candidate_score(
+            card, has_pending_order=has_pending_order
+        )
+        if score <= 0:
+            continue
+        ranked.append(
+            (
+                score,
+                card.accTradePrice24h or 0,
+                card.symbol,
+                card,
+                reasons,
+                summary,
+            )
+        )
+    ranked.sort(key=lambda item: (-item[0], -item[1], item[2]))
+    candidates: list[CryptoCandidateInsight] = []
+    for rank, (score, _trade_amount, _symbol, card, reasons, summary) in enumerate(
+        ranked[: max(0, limit)], start=1
+    ):
+        risk = card.risk
+        if risk is None:
+            continue
+        candidates.append(
+            CryptoCandidateInsight(
+                symbol=card.symbol,
+                baseSymbol=card.baseSymbol,
+                displayName=card.displayName,
+                rank=rank,
+                score=score,
+                reasons=reasons,
+                summary=summary,
+                isHeld=card.isHeld,
+                isWatched=card.isWatched,
+                hasPendingOrder=card.baseSymbol in pending_by_base,
+                riskLevel=risk.level,
+            )
+        )
+    return candidates
+
+
 async def build_crypto_dashboard(
     *,
     db: AsyncSession,
@@ -269,16 +423,20 @@ async def build_crypto_dashboard(
         if is_held:
             held_symbols.append(symbol)
         badges: list[CryptoRiskBadge] = []
+        has_pending_order = base in pending_by_base
+        change_rate = _float_or_none(ticker.get("signed_change_rate"))
+        acc_trade_price = _float_or_none(ticker.get("acc_trade_price_24h"))
+        ticker_available = symbol in tickers
         if is_held:
             badges.append(CryptoRiskBadge(kind="held", label="보유", severity="info"))
-        if base in pending_by_base:
+        if has_pending_order:
             badges.append(
                 CryptoRiskBadge(
                     kind="pending_order", label="미체결", severity="warning"
                 )
             )
         spread = spreads.get(symbol)
-        if spread is not None and spread > 0.5:
+        if spread is not None and spread > THIN_ORDERBOOK_SPREAD_PCT:
             badges.append(
                 CryptoRiskBadge(
                     kind="thin_orderbook",
@@ -286,37 +444,84 @@ async def build_crypto_dashboard(
                     severity="warning",
                 )
             )
-        if symbol not in tickers:
+        if change_rate is not None and abs(change_rate) >= HIGH_VOLATILITY_ABS_CHANGE:
+            badges.append(
+                CryptoRiskBadge(
+                    kind="high_volatility", label="변동성 주의", severity="warning"
+                )
+            )
+        if (
+            ticker_available
+            and acc_trade_price is not None
+            and acc_trade_price < LOW_LIQUIDITY_TRADE_PRICE_KRW
+        ):
+            badges.append(
+                CryptoRiskBadge(
+                    kind="low_liquidity", label="거래대금 낮음", severity="warning"
+                )
+            )
+        if not ticker_available:
             badges.append(
                 CryptoRiskBadge(
                     kind="data_unavailable", label="시세 없음", severity="warning"
                 )
             )
+        risk_score, risk_reasons = _risk_score(
+            change_rate=change_rate,
+            acc_trade_price_24h=acc_trade_price,
+            spread=spread,
+            ticker_available=ticker_available,
+            has_pending_order=has_pending_order,
+        )
         cards.append(
             CryptoMarketCard(
                 symbol=symbol,
                 baseSymbol=base,
                 displayName=row.korean_name or row.english_name or base,
                 priceKrw=_float_or_none(ticker.get("trade_price")),
-                changeRate24h=_float_or_none(ticker.get("signed_change_rate")),
+                changeRate24h=change_rate,
                 changeAmount24h=_float_or_none(ticker.get("signed_change_price")),
-                accTradePrice24h=_float_or_none(ticker.get("acc_trade_price_24h")),
+                accTradePrice24h=acc_trade_price,
                 volume24h=_float_or_none(ticker.get("acc_trade_volume_24h")),
                 orderbookSpreadPct=spread,
                 isHeld=is_held,
                 isWatched=is_watched,
                 badges=badges,
+                risk=CryptoRiskSummary(
+                    level=_risk_level(risk_score, ticker_available=ticker_available),
+                    score=risk_score,
+                    reasons=risk_reasons,
+                ),
             )
         )
+
+    candidates = _build_candidate_insights(cards, pending_by_base)
+    candidate_symbols = {candidate.symbol for candidate in candidates}
+    for card in cards:
+        if card.symbol not in candidate_symbols:
+            continue
+        if card.isWatched:
+            card.badges.append(
+                CryptoRiskBadge(
+                    kind="candidate_watch", label="관심 후보", severity="info"
+                )
+            )
+        elif card.changeRate24h is not None and abs(card.changeRate24h) >= ELEVATED_MOMENTUM_ABS_CHANGE:
+            card.badges.append(
+                CryptoRiskBadge(
+                    kind="momentum_candidate", label="모멘텀 후보", severity="info"
+                )
+            )
 
     insights = CryptoInsightsSummary(
         badges=[
             badge
             for card in cards
             for badge in card.badges
-            if badge.kind in {"thin_orderbook", "data_unavailable"}
+            if badge.kind in {"thin_orderbook", "data_unavailable", "high_volatility", "low_liquidity"}
         ][:5],
-        notes=["읽기 전용 대시보드입니다. 주문/감시/동기화 작업은 실행하지 않습니다."],
+        notes=["읽기 전용 대시보드입니다. 후보 인사이트는 참고용이며 상태 변경을 실행하지 않습니다."],
+        candidates=candidates,
     )
 
     return CryptoDashboardResponse(

--- a/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
@@ -105,7 +105,15 @@ const dashboard: CryptoDashboardResponse = {
     liveStreaming: { state: "deferred", reason: null },
     execution: { state: "read_only_mvp", reason: null },
   },
-  meta: { warnings: [], sources: [{ source: "upbit_ticker", state: "supported", label: "Upbit ticker", fetchedAt: "2026-05-13T12:00:00Z" }] },
+  meta: {
+    warnings: [],
+    sources: [
+      { source: "upbit_ticker", state: "supported", label: "Upbit ticker", fetchedAt: "2026-05-13T12:00:00Z" },
+      { source: "pending_orders", state: "supported", label: "Pending orders read model", fetchedAt: "2026-05-13T12:00:00Z" },
+      { source: "mcp_risk_reference", state: "reference_only", label: "MCP risk reference", fetchedAt: "2026-05-13T12:00:00Z" },
+      { source: "mcp_candidate_reference", state: "reference_only", label: "MCP candidate reference", fetchedAt: "2026-05-13T12:00:00Z" },
+    ],
+  },
 };
 
 const reference: NaverCryptoReferenceResponse = {
@@ -188,10 +196,12 @@ test("renders crypto dashboard cards and read-only capability states", async () 
   expect(screen.getByText("미체결")).toBeInTheDocument();
   expect(screen.getByText(/주문·감시·동기화 작업은 실행하지 않습니다/)).toBeInTheDocument();
   expect(screen.getByText(/체결\/주문 실행: read_only_mvp/)).toBeInTheDocument();
+  expect(screen.getAllByText(/Upbit ticker supported.*fetched 2026-05-13/).length).toBeGreaterThan(0);
+  expect(screen.getAllByText(/Upbit ticker: supported .*fetched 2026-05-13/).length).toBeGreaterThan(0);
   expect(await screen.findByRole("heading", { name: "Naver 참고 지표" })).toBeInTheDocument();
   expect(screen.getByText("2.50%")).toBeInTheDocument();
   expect(screen.getByText("BTC reference news")).toBeInTheDocument();
-  expect(screen.getByText(/Naver crypto reference fixture: reference_only/)).toBeInTheDocument();
+  expect(screen.getByText(/Naver crypto reference fixture: reference_only .* fixture .* freshness unavailable/)).toBeInTheDocument();
   expect(cryptoApi.fetchCryptoNaverReference).toHaveBeenCalledWith({ symbol: "KRW-BTC", limit: 20 });
 });
 
@@ -205,6 +215,7 @@ test("renders risk summary, card risk labels, and candidate insight rows", async
   const summary = await screen.findByLabelText("리스크 요약");
   expect(within(summary).getByText("중간 1")).toBeInTheDocument();
   expect(within(summary).getByText("낮음 1")).toBeInTheDocument();
+  expect(within(summary).getByText(/MCP risk reference: reference_only/)).toBeInTheDocument();
   expect(screen.getByText(/리스크 중간 · 35/)).toBeInTheDocument();
   expect(screen.getByText("변동성 주의")).toBeInTheDocument();
   expect(screen.getByText("거래대금 낮음")).toBeInTheDocument();
@@ -213,6 +224,7 @@ test("renders risk summary, card risk labels, and candidate insight rows", async
   const candidates = screen.getByLabelText("후보 인사이트");
   expect(within(candidates).getByText("1. 비트코인")).toBeInTheDocument();
   expect(within(candidates).getByText(/후보 인사이트는 참고용/)).toBeInTheDocument();
+  expect(within(candidates).getByText(/MCP candidate reference: reference_only/)).toBeInTheDocument();
   expect(within(candidates).getByText("검토 목록")).toBeInTheDocument();
   expect(within(candidates).getByText("유동성")).toBeInTheDocument();
   expect(within(candidates).queryByRole("button", { name: /주문|매수|매도|실행|등록/ })).not.toBeInTheDocument();
@@ -231,4 +243,18 @@ test("renders empty candidate insight state", async () => {
   );
 
   expect(await screen.findByText("조건에 맞는 후보 인사이트가 없습니다.")).toBeInTheDocument();
+});
+
+test("renders Naver/MCP fallback labels when reference request fails", async () => {
+  vi.spyOn(cryptoApi, "fetchCryptoNaverReference").mockRejectedValue(new Error("reference down"));
+
+  render(
+    <MemoryRouter basename="/invest" initialEntries={["/invest/crypto"]}>
+      <DesktopCryptoPage />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText(/Naver\/MCP 참고 지표를 불러오지 못했습니다/)).toBeInTheDocument();
+  expect(screen.getByText("Naver crypto reference: unavailable · freshness unavailable")).toBeInTheDocument();
+  expect(screen.getByText("MCP kimchi premium: unavailable · freshness unavailable")).toBeInTheDocument();
 });

--- a/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
@@ -8,7 +8,7 @@ vi.mock("../desktop/RightRemotePanel", () => ({
 
 import { DesktopCryptoPage } from "../pages/desktop/DesktopCryptoPage";
 import * as cryptoApi from "../api/investCrypto";
-import type { CryptoDashboardResponse } from "../types/investCrypto";
+import type { CryptoDashboardResponse, NaverCryptoReferenceResponse } from "../types/investCrypto";
 
 const dashboard: CryptoDashboardResponse = {
   asOf: "2026-05-13T12:00:00Z",
@@ -108,8 +108,69 @@ const dashboard: CryptoDashboardResponse = {
   meta: { warnings: [], sources: [{ source: "upbit_ticker", state: "supported", label: "Upbit ticker", fetchedAt: "2026-05-13T12:00:00Z" }] },
 };
 
+const reference: NaverCryptoReferenceResponse = {
+  market: "crypto",
+  asOf: "2026-05-13T12:01:00Z",
+  symbol: "KRW-BTC",
+  rank: [
+    {
+      rank: 1,
+      symbol: "KRW-BTC",
+      displayName: "비트코인",
+      priceKrw: 101000000,
+      changeRate24h: 0.0123,
+      tradeAmount24h: 12345678900,
+      rsi: 55.5,
+      marketWarning: false,
+      source: "tvscreener_upbit",
+    },
+  ],
+  profile: {
+    symbol: "KRW-BTC",
+    baseSymbol: "BTC",
+    displayName: "비트코인",
+    koreanName: "비트코인",
+    englishName: "Bitcoin",
+    naverUrl: "https://m.stock.naver.com/crypto/UPBIT/KRW-BTC",
+    officialMarket: "UPBIT/KRW",
+    referenceNotes: ["reference-only"],
+  },
+  news: { items: [{ id: 1, title: "BTC reference news", publisher: "fixture", url: "https://example.test/btc" }] },
+  kimchiPremium: {
+    baseSymbol: "BTC",
+    premiumPct: 2.5,
+    domesticPriceKrw: 101000000,
+    overseasPriceKrw: 98500000,
+    state: "available",
+    source: "mcp_kimchi_premium",
+    caution: "참고용 매크로 지표",
+  },
+  sources: [
+    {
+      source: "naver_reference",
+      label: "Naver crypto reference fixture",
+      state: "reference_only",
+      fetchedAt: null,
+      cacheAgeSeconds: null,
+      freshness: "fixture",
+      errorCode: null,
+      referenceOnly: true,
+    },
+  ],
+  warnings: ["naver_crypto_reference_only"],
+  capabilities: {
+    rank: { state: "supported", reason: null },
+    price: { state: "supported", reason: null },
+    profile: { state: "reference_only", reason: "naver_fixture_reference_only" },
+    news: { state: "supported", reason: null },
+    kimchiPremium: { state: "reference_only", reason: "macro_reference_only" },
+    execution: { state: "read_only_mvp", reason: "no_order_execution_controls" },
+  },
+};
+
 beforeEach(() => {
   vi.spyOn(cryptoApi, "fetchCryptoDashboard").mockResolvedValue(dashboard);
+  vi.spyOn(cryptoApi, "fetchCryptoNaverReference").mockResolvedValue(reference);
 });
 
 test("renders crypto dashboard cards and read-only capability states", async () => {
@@ -121,12 +182,17 @@ test("renders crypto dashboard cards and read-only capability states", async () 
 
   expect(await screen.findByTestId("crypto-dashboard")).toBeInTheDocument();
   expect(screen.getByRole("heading", { name: "크립토 대시보드" })).toBeInTheDocument();
-  expect(screen.getByText("비트코인")).toBeInTheDocument();
+  expect(screen.getAllByText("비트코인").length).toBeGreaterThan(0);
   expect(screen.getByText("101,000,000원")).toBeInTheDocument();
   expect(screen.getByText("보유")).toBeInTheDocument();
   expect(screen.getByText("미체결")).toBeInTheDocument();
   expect(screen.getByText(/주문·감시·동기화 작업은 실행하지 않습니다/)).toBeInTheDocument();
   expect(screen.getByText(/체결\/주문 실행: read_only_mvp/)).toBeInTheDocument();
+  expect(await screen.findByRole("heading", { name: "Naver 참고 지표" })).toBeInTheDocument();
+  expect(screen.getByText("2.50%")).toBeInTheDocument();
+  expect(screen.getByText("BTC reference news")).toBeInTheDocument();
+  expect(screen.getByText(/Naver crypto reference fixture: reference_only/)).toBeInTheDocument();
+  expect(cryptoApi.fetchCryptoNaverReference).toHaveBeenCalledWith({ symbol: "KRW-BTC", limit: 20 });
 });
 
 test("renders risk summary, card risk labels, and candidate insight rows", async () => {

--- a/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, expect, test, vi } from "vitest";
 
@@ -30,7 +30,30 @@ const dashboard: CryptoDashboardResponse = {
       badges: [
         { kind: "held", label: "보유", severity: "info" },
         { kind: "pending_order", label: "미체결", severity: "warning" },
+        { kind: "high_volatility", label: "변동성 주의", severity: "warning" },
+        { kind: "low_liquidity", label: "거래대금 낮음", severity: "warning" },
+        { kind: "candidate_watch", label: "관심 후보", severity: "info" },
       ],
+      risk: {
+        level: "medium",
+        score: 35,
+        reasons: ["호가 스프레드 확대", "미체결 상태 존재"],
+      },
+    },
+    {
+      symbol: "KRW-ETH",
+      baseSymbol: "ETH",
+      displayName: "이더리움",
+      priceKrw: 5200000,
+      changeRate24h: -0.01,
+      changeAmount24h: -52000,
+      accTradePrice24h: 800000000,
+      volume24h: 1000,
+      orderbookSpreadPct: 0.2,
+      isHeld: false,
+      isWatched: false,
+      badges: [],
+      risk: { level: "low", score: 0, reasons: [] },
     },
   ],
   holdings: { heldCount: 1, symbols: ["KRW-BTC"], source: "invest_home_read_model" },
@@ -54,7 +77,25 @@ const dashboard: CryptoDashboardResponse = {
     emptyState: null,
     source: "pending_orders",
   },
-  insights: { badges: [], notes: ["읽기 전용"] },
+  insights: {
+    badges: [],
+    notes: ["읽기 전용"],
+    candidates: [
+      {
+        symbol: "KRW-BTC",
+        baseSymbol: "BTC",
+        displayName: "비트코인",
+        rank: 1,
+        score: 55,
+        reasons: ["watched", "liquidity", "spread"],
+        summary: "기존 검토 목록과 일치 · 거래대금 양호",
+        isHeld: true,
+        isWatched: true,
+        hasPendingOrder: true,
+        riskLevel: "medium",
+      },
+    ],
+  },
   capabilities: {
     ticker: { state: "supported", reason: null },
     candles: { state: "supported", reason: null },
@@ -86,4 +127,42 @@ test("renders crypto dashboard cards and read-only capability states", async () 
   expect(screen.getByText("미체결")).toBeInTheDocument();
   expect(screen.getByText(/주문·감시·동기화 작업은 실행하지 않습니다/)).toBeInTheDocument();
   expect(screen.getByText(/체결\/주문 실행: read_only_mvp/)).toBeInTheDocument();
+});
+
+test("renders risk summary, card risk labels, and candidate insight rows", async () => {
+  render(
+    <MemoryRouter basename="/invest" initialEntries={["/invest/crypto"]}>
+      <DesktopCryptoPage />
+    </MemoryRouter>,
+  );
+
+  const summary = await screen.findByLabelText("리스크 요약");
+  expect(within(summary).getByText("중간 1")).toBeInTheDocument();
+  expect(within(summary).getByText("낮음 1")).toBeInTheDocument();
+  expect(screen.getByText(/리스크 중간 · 35/)).toBeInTheDocument();
+  expect(screen.getByText("변동성 주의")).toBeInTheDocument();
+  expect(screen.getByText("거래대금 낮음")).toBeInTheDocument();
+  expect(screen.getByText("관심 후보")).toBeInTheDocument();
+
+  const candidates = screen.getByLabelText("후보 인사이트");
+  expect(within(candidates).getByText("1. 비트코인")).toBeInTheDocument();
+  expect(within(candidates).getByText(/후보 인사이트는 참고용/)).toBeInTheDocument();
+  expect(within(candidates).getByText("검토 목록")).toBeInTheDocument();
+  expect(within(candidates).getByText("유동성")).toBeInTheDocument();
+  expect(within(candidates).queryByRole("button", { name: /주문|매수|매도|실행|등록/ })).not.toBeInTheDocument();
+});
+
+test("renders empty candidate insight state", async () => {
+  vi.spyOn(cryptoApi, "fetchCryptoDashboard").mockResolvedValue({
+    ...dashboard,
+    insights: { ...dashboard.insights, candidates: [] },
+  });
+
+  render(
+    <MemoryRouter basename="/invest" initialEntries={["/invest/crypto"]}>
+      <DesktopCryptoPage />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText("조건에 맞는 후보 인사이트가 없습니다.")).toBeInTheDocument();
 });

--- a/frontend/invest/src/api/investCrypto.ts
+++ b/frontend/invest/src/api/investCrypto.ts
@@ -1,4 +1,4 @@
-import type { CryptoDashboardResponse } from "../types/investCrypto";
+import type { CryptoDashboardResponse, NaverCryptoReferenceResponse } from "../types/investCrypto";
 
 async function getJson<T>(url: string): Promise<T> {
   const res = await fetch(url, { credentials: "include" });
@@ -11,4 +11,14 @@ export async function fetchCryptoDashboard(params: { limit?: number } = {}): Pro
   if (params.limit !== undefined) q.set("limit", String(params.limit));
   const qs = q.toString();
   return getJson<CryptoDashboardResponse>(`/invest/api/crypto/dashboard${qs ? `?${qs}` : ""}`);
+}
+
+export async function fetchCryptoNaverReference(
+  params: { symbol?: string; limit?: number } = {},
+): Promise<NaverCryptoReferenceResponse> {
+  const q = new URLSearchParams();
+  if (params.symbol) q.set("symbol", params.symbol);
+  if (params.limit !== undefined) q.set("limit", String(params.limit));
+  const qs = q.toString();
+  return getJson<NaverCryptoReferenceResponse>(`/invest/api/crypto/naver-reference${qs ? `?${qs}` : ""}`);
 }

--- a/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
@@ -3,7 +3,12 @@ import { Link } from "react-router-dom";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { fetchCryptoDashboard } from "../../api/investCrypto";
-import type { CryptoDashboardResponse, CryptoMarketCard } from "../../types/investCrypto";
+import type {
+  CryptoCandidateInsight,
+  CryptoDashboardResponse,
+  CryptoMarketCard,
+  CryptoRiskLevel,
+} from "../../types/investCrypto";
 import "../../desktop/screener/screener.css";
 
 function formatKrw(value: number | null): string {
@@ -22,6 +27,34 @@ function cardMetric(card: CryptoMarketCard): string {
     return `거래대금 ${(card.accTradePrice24h / 1_0000_0000).toFixed(1)}억`;
   }
   return `거래대금 ${Math.round(card.accTradePrice24h).toLocaleString("ko-KR")}`;
+}
+
+const riskLabels: Record<CryptoRiskLevel, string> = {
+  high: "높음",
+  medium: "중간",
+  low: "낮음",
+  unknown: "미확인",
+};
+
+const reasonLabels: Record<string, string> = {
+  momentum: "변화",
+  liquidity: "유동성",
+  spread: "호가 안정",
+  watched: "검토 목록",
+  held: "보유",
+  pending_order: "미체결",
+  data_quality: "데이터 확인",
+};
+
+function riskCounts(cards: CryptoMarketCard[]): Record<CryptoRiskLevel, number> {
+  return cards.reduce<Record<CryptoRiskLevel, number>>(
+    (counts, card) => {
+      const level = card.risk?.level ?? "unknown";
+      counts[level] += 1;
+      return counts;
+    },
+    { high: 0, medium: 0, low: 0, unknown: 0 },
+  );
 }
 
 function CryptoCard({ card }: { card: CryptoMarketCard }) {
@@ -53,6 +86,14 @@ function CryptoCard({ card }: { card: CryptoMarketCard }) {
       <div style={{ marginTop: 12, color: "var(--fg-3)", fontSize: 13 }}>
         {cardMetric(card)} · 호가 스프레드 {card.orderbookSpreadPct === null ? "-" : `${card.orderbookSpreadPct.toFixed(3)}%`}
       </div>
+      {card.risk && (
+        <div style={{ marginTop: 8, color: "var(--fg-2)", fontSize: 13 }}>
+          리스크 {riskLabels[card.risk.level]} · {card.risk.score}
+          {card.risk.reasons.length > 0 && (
+            <span style={{ color: "var(--fg-3)" }}> · {card.risk.reasons.slice(0, 2).join(" · ")}</span>
+          )}
+        </div>
+      )}
       {card.badges.length > 0 && (
         <div style={{ marginTop: 10, display: "flex", flexWrap: "wrap", gap: 6 }}>
           {card.badges.map((badge, idx) => (
@@ -63,6 +104,62 @@ function CryptoCard({ card }: { card: CryptoMarketCard }) {
         </div>
       )}
     </Link>
+  );
+}
+
+function RiskSummary({ cards }: { cards: CryptoMarketCard[] }) {
+  const counts = riskCounts(cards);
+  return (
+    <section aria-label="리스크 요약" style={{ marginTop: 16, padding: 16, border: "1px solid var(--border)", borderRadius: 14 }}>
+      <h2 style={{ marginTop: 0 }}>리스크 요약</h2>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        {(["high", "medium", "low", "unknown"] as CryptoRiskLevel[]).map((level) => (
+          <span key={level} className="screener-chip">
+            {riskLabels[level]} {counts[level]}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function CandidateInsightCard({ candidate }: { candidate: CryptoCandidateInsight }) {
+  return (
+    <article style={{ padding: 12, border: "1px solid var(--border)", borderRadius: 12 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12 }}>
+        <strong>{candidate.rank}. {candidate.displayName}</strong>
+        <span>점수 {candidate.score}</span>
+      </div>
+      <div style={{ marginTop: 4, color: "var(--fg-3)", fontSize: 13 }}>
+        {candidate.symbol} · 리스크 {riskLabels[candidate.riskLevel]}
+      </div>
+      <p style={{ margin: "8px 0", color: "var(--fg-2)" }}>{candidate.summary}</p>
+      {candidate.reasons.length > 0 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {candidate.reasons.map((reason) => (
+            <span key={reason} className="screener-chip">{reasonLabels[reason] ?? reason}</span>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function CandidateInsights({ candidates }: { candidates: CryptoCandidateInsight[] }) {
+  return (
+    <section aria-label="후보 인사이트" style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14 }}>
+      <h2 style={{ marginTop: 0 }}>후보 인사이트</h2>
+      <p style={{ color: "var(--fg-3)" }}>후보 인사이트는 참고용이며 주문/감시 등록을 실행하지 않습니다.</p>
+      {candidates.length === 0 ? (
+        <p style={{ color: "var(--fg-3)" }}>조건에 맞는 후보 인사이트가 없습니다.</p>
+      ) : (
+        <div style={{ display: "grid", gap: 10 }}>
+          {candidates.map((candidate) => (
+            <CandidateInsightCard key={candidate.symbol} candidate={candidate} />
+          ))}
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -123,6 +220,8 @@ export function DesktopCryptoPage() {
                   {data.meta.warnings.map((warning) => <li key={warning}>{warning}</li>)}
                 </ul>
               )}
+              <RiskSummary cards={data.cards} />
+              <CandidateInsights candidates={data.insights.candidates ?? []} />
               <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 12, marginTop: 16 }}>
                 {data.cards.map((card) => <CryptoCard key={card.symbol} card={card} />)}
               </section>

--- a/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { RightRemotePanel } from "../../desktop/RightRemotePanel";
-import { fetchCryptoDashboard } from "../../api/investCrypto";
+import { fetchCryptoDashboard, fetchCryptoNaverReference } from "../../api/investCrypto";
 import type {
   CryptoCandidateInsight,
   CryptoDashboardResponse,
   CryptoMarketCard,
   CryptoRiskLevel,
+  NaverCryptoReferenceResponse,
 } from "../../types/investCrypto";
 import "../../desktop/screener/screener.css";
 
@@ -171,19 +172,82 @@ function cryptoErrorMessage(error: unknown): string {
   return text || "크립토 대시보드 데이터를 일시적으로 불러오지 못했습니다.";
 }
 
+function ReferencePanel({ reference }: { reference: NaverCryptoReferenceResponse }) {
+  const kimchi = reference.kimchiPremium;
+  return (
+    <section style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14, background: "var(--surface)" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "baseline" }}>
+        <div>
+          <h2 style={{ margin: 0 }}>Naver 참고 지표</h2>
+          <p style={{ marginTop: 6, color: "var(--fg-3)" }}>출처 라벨이 있는 읽기 전용 참고 데이터입니다. 주문 실행 없음.</p>
+        </div>
+        <span className="screener-chip">{reference.capabilities.execution.state}</span>
+      </div>
+      {reference.warnings.length > 0 && (
+        <div style={{ marginTop: 10, color: "var(--fg-3)", fontSize: 13 }}>
+          {reference.warnings.slice(0, 3).join(" · ")}
+        </div>
+      )}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12, marginTop: 14 }}>
+        <div>
+          <strong>김치 프리미엄</strong>
+          <div style={{ marginTop: 4 }}>{kimchi?.premiumPct === null || kimchi?.premiumPct === undefined ? "-" : `${kimchi.premiumPct.toFixed(2)}%`}</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{kimchi?.caution ?? "참고용 매크로 지표"}</div>
+        </div>
+        <div>
+          <strong>프로필</strong>
+          <div style={{ marginTop: 4 }}>{reference.profile?.displayName ?? reference.symbol ?? "-"}</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{reference.profile?.officialMarket ?? "UPBIT/KRW"} · reference-only</div>
+        </div>
+        <div>
+          <strong>뉴스</strong>
+          <div style={{ marginTop: 4 }}>{reference.news?.items.length ?? 0}건</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{reference.news?.items[0]?.title ?? "최근 크립토 뉴스 없음"}</div>
+        </div>
+      </div>
+      {reference.rank.length > 0 && (
+        <div style={{ marginTop: 14, display: "grid", gap: 8 }}>
+          {reference.rank.slice(0, 5).map((item) => (
+            <div key={item.symbol} style={{ display: "flex", justifyContent: "space-between", gap: 12, color: "var(--fg-2)", fontSize: 13 }}>
+              <span>#{item.rank} {item.displayName} <span style={{ color: "var(--fg-3)" }}>{item.source}</span></span>
+              <span>{formatKrw(item.priceKrw)} · {formatPct(item.changeRate24h)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      <div style={{ marginTop: 12, display: "flex", flexWrap: "wrap", gap: 6 }}>
+        {reference.sources.map((source) => (
+          <span key={`${source.source}-${source.state}`} className="screener-chip">
+            {source.label}: {source.state}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function DesktopCryptoPage() {
   const [data, setData] = useState<CryptoDashboardResponse | undefined>();
+  const [reference, setReference] = useState<NaverCryptoReferenceResponse | undefined>();
   const [err, setErr] = useState<string | undefined>();
 
   useEffect(() => {
     let cancel = false;
     setErr(undefined);
-    fetchCryptoDashboard({ limit: 20 })
-      .then((response) => {
-        if (cancel) return;
-        setData(response);
-      })
-      .catch((error) => !cancel && setErr(cryptoErrorMessage(error)));
+    Promise.allSettled([
+      fetchCryptoDashboard({ limit: 20 }),
+      fetchCryptoNaverReference({ symbol: "KRW-BTC", limit: 20 }),
+    ]).then(([dashboardResult, referenceResult]) => {
+      if (cancel) return;
+      if (dashboardResult.status === "fulfilled") {
+        setData(dashboardResult.value);
+      } else {
+        setErr(cryptoErrorMessage(dashboardResult.reason));
+      }
+      if (referenceResult.status === "fulfilled") {
+        setReference(referenceResult.value);
+      }
+    });
     return () => { cancel = true; };
   }, []);
 
@@ -225,6 +289,7 @@ export function DesktopCryptoPage() {
               <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 12, marginTop: 16 }}>
                 {data.cards.map((card) => <CryptoCard key={card.symbol} card={card} />)}
               </section>
+              {reference && <ReferencePanel reference={reference} />}
               <section style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14 }}>
                 <h2 style={{ marginTop: 0 }}>기능 상태</h2>
                 <p style={{ color: "var(--fg-3)" }}>체결/주문 실행: {data.capabilities.execution.state} · 실시간 스트리밍: {data.capabilities.liveStreaming.state}</p>

--- a/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
@@ -8,6 +8,7 @@ import type {
   CryptoDashboardResponse,
   CryptoMarketCard,
   CryptoRiskLevel,
+  CryptoSourceState,
   NaverCryptoReferenceResponse,
 } from "../../types/investCrypto";
 import "../../desktop/screener/screener.css";
@@ -20,6 +21,33 @@ function formatKrw(value: number | null): string {
 function formatPct(value: number | null): string {
   if (value === null || Number.isNaN(value)) return "-";
   return `${(value * 100).toFixed(2)}%`;
+}
+
+function sourceFreshness(fetchedAt: string | null | undefined): string {
+  if (!fetchedAt) return "freshness unavailable";
+  return `fetched ${fetchedAt}`;
+}
+
+function sourceSummary(sources: CryptoSourceState[], sourceIds: string[]): string {
+  const selected = sources.filter((source) => sourceIds.includes(source.source));
+  if (selected.length === 0) return "출처: 확인 불가";
+  return `출처: ${selected.map((source) => `${source.label} ${source.state} (${sourceFreshness(source.fetchedAt)})`).join(" · ")}`;
+}
+
+function SourceLabels({ sources, sourceIds }: { sources: CryptoSourceState[]; sourceIds: string[] }) {
+  const selected = sources.filter((source) => sourceIds.includes(source.source));
+  if (selected.length === 0) {
+    return <span className="screener-chip">출처 확인 불가</span>;
+  }
+  return (
+    <>
+      {selected.map((source) => (
+        <span key={`${source.source}-${source.state}`} className="screener-chip">
+          {source.label}: {source.state} · {sourceFreshness(source.fetchedAt)}
+        </span>
+      ))}
+    </>
+  );
 }
 
 function cardMetric(card: CryptoMarketCard): string {
@@ -58,7 +86,7 @@ function riskCounts(cards: CryptoMarketCard[]): Record<CryptoRiskLevel, number> 
   );
 }
 
-function CryptoCard({ card }: { card: CryptoMarketCard }) {
+function CryptoCard({ card, sources }: { card: CryptoMarketCard; sources: CryptoSourceState[] }) {
   return (
     <Link
       to={`/crypto/${encodeURIComponent(card.symbol)}`}
@@ -87,6 +115,9 @@ function CryptoCard({ card }: { card: CryptoMarketCard }) {
       <div style={{ marginTop: 12, color: "var(--fg-3)", fontSize: 13 }}>
         {cardMetric(card)} · 호가 스프레드 {card.orderbookSpreadPct === null ? "-" : `${card.orderbookSpreadPct.toFixed(3)}%`}
       </div>
+      <div style={{ marginTop: 8, color: "var(--fg-3)", fontSize: 12 }}>
+        {sourceSummary(sources, ["upbit_ticker", "upbit_orderbook"])}
+      </div>
       {card.risk && (
         <div style={{ marginTop: 8, color: "var(--fg-2)", fontSize: 13 }}>
           리스크 {riskLabels[card.risk.level]} · {card.risk.score}
@@ -108,7 +139,7 @@ function CryptoCard({ card }: { card: CryptoMarketCard }) {
   );
 }
 
-function RiskSummary({ cards }: { cards: CryptoMarketCard[] }) {
+function RiskSummary({ cards, sources }: { cards: CryptoMarketCard[]; sources: CryptoSourceState[] }) {
   const counts = riskCounts(cards);
   return (
     <section aria-label="리스크 요약" style={{ marginTop: 16, padding: 16, border: "1px solid var(--border)", borderRadius: 14 }}>
@@ -119,6 +150,9 @@ function RiskSummary({ cards }: { cards: CryptoMarketCard[] }) {
             {riskLabels[level]} {counts[level]}
           </span>
         ))}
+      </div>
+      <div style={{ marginTop: 10, display: "flex", flexWrap: "wrap", gap: 6 }}>
+        <SourceLabels sources={sources} sourceIds={["upbit_ticker", "upbit_orderbook", "pending_orders", "mcp_risk_reference"]} />
       </div>
     </section>
   );
@@ -146,11 +180,14 @@ function CandidateInsightCard({ candidate }: { candidate: CryptoCandidateInsight
   );
 }
 
-function CandidateInsights({ candidates }: { candidates: CryptoCandidateInsight[] }) {
+function CandidateInsights({ candidates, sources }: { candidates: CryptoCandidateInsight[]; sources: CryptoSourceState[] }) {
   return (
     <section aria-label="후보 인사이트" style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14 }}>
       <h2 style={{ marginTop: 0 }}>후보 인사이트</h2>
       <p style={{ color: "var(--fg-3)" }}>후보 인사이트는 참고용이며 주문/감시 등록을 실행하지 않습니다.</p>
+      <div style={{ marginBottom: 10, display: "flex", flexWrap: "wrap", gap: 6 }}>
+        <SourceLabels sources={sources} sourceIds={["upbit_ticker", "upbit_orderbook", "pending_orders", "mcp_candidate_reference"]} />
+      </div>
       {candidates.length === 0 ? (
         <p style={{ color: "var(--fg-3)" }}>조건에 맞는 후보 인사이트가 없습니다.</p>
       ) : (
@@ -218,9 +255,24 @@ function ReferencePanel({ reference }: { reference: NaverCryptoReferenceResponse
       <div style={{ marginTop: 12, display: "flex", flexWrap: "wrap", gap: 6 }}>
         {reference.sources.map((source) => (
           <span key={`${source.source}-${source.state}`} className="screener-chip">
-            {source.label}: {source.state}
+            {source.label}: {source.state} · {source.freshness} · {source.fetchedAt ?? "freshness unavailable"}
           </span>
         ))}
+      </div>
+    </section>
+  );
+}
+
+function ReferenceFallback() {
+  return (
+    <section style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14, background: "var(--surface)" }}>
+      <h2 style={{ margin: 0 }}>Naver 참고 지표</h2>
+      <p style={{ color: "var(--fg-3)" }}>
+        Naver/MCP 참고 지표를 불러오지 못했습니다. 대시보드 시세·리스크 카드는 계속 읽기 전용으로 표시됩니다.
+      </p>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+        <span className="screener-chip">Naver crypto reference: unavailable · freshness unavailable</span>
+        <span className="screener-chip">MCP kimchi premium: unavailable · freshness unavailable</span>
       </div>
     </section>
   );
@@ -284,12 +336,12 @@ export function DesktopCryptoPage() {
                   {data.meta.warnings.map((warning) => <li key={warning}>{warning}</li>)}
                 </ul>
               )}
-              <RiskSummary cards={data.cards} />
-              <CandidateInsights candidates={data.insights.candidates ?? []} />
+              <RiskSummary cards={data.cards} sources={data.meta.sources} />
+              <CandidateInsights candidates={data.insights.candidates ?? []} sources={data.meta.sources} />
               <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 12, marginTop: 16 }}>
-                {data.cards.map((card) => <CryptoCard key={card.symbol} card={card} />)}
+                {data.cards.map((card) => <CryptoCard key={card.symbol} card={card} sources={data.meta.sources} />)}
               </section>
-              {reference && <ReferencePanel reference={reference} />}
+              {reference ? <ReferencePanel reference={reference} /> : <ReferenceFallback />}
               <section style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14 }}>
                 <h2 style={{ marginTop: 0 }}>기능 상태</h2>
                 <p style={{ color: "var(--fg-3)" }}>체결/주문 실행: {data.capabilities.execution.state} · 실시간 스트리밍: {data.capabilities.liveStreaming.state}</p>

--- a/frontend/invest/src/types/investCrypto.ts
+++ b/frontend/invest/src/types/investCrypto.ts
@@ -11,7 +11,21 @@ export type CryptoRiskBadgeKind =
   | "held"
   | "pending_order"
   | "data_unavailable"
-  | "high_volatility";
+  | "high_volatility"
+  | "low_liquidity"
+  | "candidate_watch"
+  | "momentum_candidate";
+
+export type CryptoRiskLevel = "low" | "medium" | "high" | "unknown";
+
+export type CryptoCandidateReasonKind =
+  | "momentum"
+  | "liquidity"
+  | "spread"
+  | "watched"
+  | "held"
+  | "pending_order"
+  | "data_quality";
 
 export interface CryptoSourceState {
   source: string;
@@ -41,6 +55,26 @@ export interface CryptoRiskBadge {
   severity: "info" | "warning" | "danger";
 }
 
+export interface CryptoRiskSummary {
+  level: CryptoRiskLevel;
+  score: number;
+  reasons: string[];
+}
+
+export interface CryptoCandidateInsight {
+  symbol: string;
+  baseSymbol: string;
+  displayName: string;
+  rank: number;
+  score: number;
+  reasons: CryptoCandidateReasonKind[];
+  summary: string;
+  isHeld: boolean;
+  isWatched: boolean;
+  hasPendingOrder: boolean;
+  riskLevel: CryptoRiskLevel;
+}
+
 export interface CryptoMarketCard {
   symbol: string;
   baseSymbol: string;
@@ -54,6 +88,7 @@ export interface CryptoMarketCard {
   isHeld: boolean;
   isWatched: boolean;
   badges: CryptoRiskBadge[];
+  risk: CryptoRiskSummary | null;
 }
 
 export interface CryptoHoldingSummary {
@@ -86,6 +121,7 @@ export interface CryptoPendingOrdersSummary {
 export interface CryptoInsightsSummary {
   badges: CryptoRiskBadge[];
   notes: string[];
+  candidates: CryptoCandidateInsight[];
 }
 
 export interface CryptoDashboardResponse {

--- a/frontend/invest/src/types/investCrypto.ts
+++ b/frontend/invest/src/types/investCrypto.ts
@@ -6,6 +6,17 @@ export type CryptoCapabilityState =
   | "deferred"
   | "read_only_mvp";
 
+export type CryptoReferenceSourceState =
+  | "available"
+  | "cached"
+  | "fixture"
+  | "reference_only"
+  | "stale"
+  | "unavailable"
+  | "error";
+
+export type CryptoReferenceFreshness = "fresh" | "partial" | "stale" | "missing" | "fixture";
+
 export type CryptoRiskBadgeKind =
   | "thin_orderbook"
   | "held"
@@ -134,4 +145,70 @@ export interface CryptoDashboardResponse {
   insights: CryptoInsightsSummary;
   capabilities: CryptoDashboardCapabilities;
   meta: { warnings: string[]; sources: CryptoSourceState[] };
+}
+
+export interface CryptoReferenceSourceMeta {
+  source: string;
+  label: string;
+  state: CryptoReferenceSourceState;
+  fetchedAt: string | null;
+  cacheAgeSeconds: number | null;
+  freshness: CryptoReferenceFreshness;
+  errorCode: string | null;
+  referenceOnly: boolean;
+}
+
+export interface NaverCryptoRankItem {
+  rank: number;
+  symbol: string;
+  displayName: string;
+  priceKrw: number | null;
+  changeRate24h: number | null;
+  tradeAmount24h: number | null;
+  rsi: number | null;
+  marketWarning: boolean | null;
+  source: string;
+}
+
+export interface NaverCryptoProfile {
+  symbol: string;
+  baseSymbol: string;
+  displayName: string;
+  koreanName: string | null;
+  englishName: string | null;
+  naverUrl: string | null;
+  officialMarket: string | null;
+  referenceNotes: string[];
+}
+
+export interface NaverCryptoKimchiPremium {
+  baseSymbol: string;
+  premiumPct: number | null;
+  domesticPriceKrw: number | null;
+  overseasPriceKrw: number | null;
+  state: CryptoReferenceSourceState;
+  source: string;
+  caution: string;
+}
+
+export interface NaverCryptoReferenceCapabilities {
+  rank: CryptoCapabilityFlag;
+  price: CryptoCapabilityFlag;
+  profile: CryptoCapabilityFlag;
+  news: CryptoCapabilityFlag;
+  kimchiPremium: CryptoCapabilityFlag;
+  execution: CryptoCapabilityFlag;
+}
+
+export interface NaverCryptoReferenceResponse {
+  market: "crypto";
+  asOf: string;
+  symbol: string | null;
+  rank: NaverCryptoRankItem[];
+  profile: NaverCryptoProfile | null;
+  news: { items: Array<{ id: number; title: string; publisher: string | null; url: string }> } | null;
+  kimchiPremium: NaverCryptoKimchiPremium | null;
+  sources: CryptoReferenceSourceMeta[];
+  warnings: string[];
+  capabilities: NaverCryptoReferenceCapabilities;
 }

--- a/frontend/invest/src/types/investCrypto.ts
+++ b/frontend/invest/src/types/investCrypto.ts
@@ -12,10 +12,11 @@ export type CryptoReferenceSourceState =
   | "fixture"
   | "reference_only"
   | "stale"
+  | "live"
   | "unavailable"
   | "error";
 
-export type CryptoReferenceFreshness = "fresh" | "partial" | "stale" | "missing" | "fixture";
+export type CryptoReferenceFreshness = "fresh" | "partial" | "stale" | "missing" | "fixture" | "live";
 
 export type CryptoRiskBadgeKind =
   | "thin_orderbook"

--- a/tests/test_invest_api_crypto_router.py
+++ b/tests/test_invest_api_crypto_router.py
@@ -18,6 +18,7 @@ from app.schemas.invest_crypto import (
     CryptoDashboardMeta,
     CryptoDashboardResponse,
     CryptoInsightsSummary,
+    NaverCryptoReferenceResponse,
 )
 from app.schemas.invest_home import InvestHomeResponse, InvestHomeResponseMeta
 from app.services.invest_home_service import build_grouped_holdings, build_home_summary
@@ -83,3 +84,46 @@ def test_crypto_dashboard_endpoint_uses_read_only_view_model(
     assert calls["dashboard"]["user_id"] == 7
     assert calls["dashboard"]["limit"] == 3
     assert calls["dashboard"]["resolver"] is not None
+
+
+@pytest.mark.unit
+def test_crypto_naver_reference_endpoint_uses_read_only_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, Any] = {}
+
+    async def fake_relation_resolver(
+        db: Any, *, user_id: int, held_pairs: set[tuple[str, str]]
+    ):
+        calls["relation"] = {"db": db, "user_id": user_id, "held_pairs": held_pairs}
+        return object()
+
+    async def fake_reference(**kwargs: Any) -> NaverCryptoReferenceResponse:
+        calls["reference"] = kwargs
+        return NaverCryptoReferenceResponse(
+            asOf=datetime(2026, 5, 14, 12, tzinfo=UTC),
+            symbol="KRW-BTC",
+            rank=[],
+            profile=None,
+            news=None,
+            kimchiPremium=None,
+            sources=[],
+            warnings=["read_only_no_order_watch_or_broker_mutation"],
+        )
+
+    monkeypatch.setattr(invest_api, "build_relation_resolver", fake_relation_resolver)
+    monkeypatch.setattr(invest_api, "build_naver_crypto_reference", fake_reference)
+
+    response = TestClient(_build_app()).get(
+        "/invest/api/crypto/naver-reference?symbol=BTC&limit=4"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["market"] == "crypto"
+    assert payload["symbol"] == "KRW-BTC"
+    assert "read_only_no_order_watch_or_broker_mutation" in payload["warnings"]
+    assert calls["relation"]["user_id"] == 7
+    assert calls["reference"]["symbol"] == "BTC"
+    assert calls["reference"]["limit"] == 4
+    assert calls["reference"]["resolver"] is not None

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -78,7 +78,7 @@ async def test_crypto_dashboard_maps_ticker_spread_relation_and_pending_orders()
             {
                 "market": "KRW-BTC",
                 "trade_price": 101000000,
-                "signed_change_rate": 0.0123,
+                "signed_change_rate": 0.041,
                 "signed_change_price": 1230000,
                 "acc_trade_price_24h": 12345678900,
                 "acc_trade_volume_24h": 234.5,
@@ -86,7 +86,7 @@ async def test_crypto_dashboard_maps_ticker_spread_relation_and_pending_orders()
             {
                 "market": "KRW-ETH",
                 "trade_price": 5200000,
-                "signed_change_rate": 0.052,
+                "signed_change_rate": 0.032,
                 "signed_change_price": 260000,
                 "acc_trade_price_24h": 8500000000,
                 "acc_trade_volume_24h": 1000,
@@ -131,8 +131,18 @@ async def test_crypto_dashboard_maps_ticker_spread_relation_and_pending_orders()
     assert response.pendingOrders.items[0].orderId == "upbit-open-1"
     assert response.pendingOrders.emptyState is None
     assert response.capabilities.execution.state == "read_only_mvp"
-    assert [candidate.symbol for candidate in response.insights.candidates] == ["KRW-ETH"]
-    assert response.insights.candidates[0].reasons[:2] == ["watched", "momentum"]
+    assert [candidate.symbol for candidate in response.insights.candidates][:2] == [
+        "KRW-ETH",
+        "KRW-BTC",
+    ]
+    assert response.insights.candidates[0].reasons[:2] == ["watched", "liquidity"]
+    assert {source.source for source in response.meta.sources} >= {
+        "upbit_ticker",
+        "upbit_orderbook",
+        "pending_orders",
+        "mcp_risk_reference",
+        "mcp_candidate_reference",
+    }
 
 
 @pytest.mark.asyncio
@@ -227,6 +237,87 @@ async def test_crypto_dashboard_candidate_insights_are_read_only_and_ranked():
 
 
 @pytest.mark.asyncio
+async def test_crypto_dashboard_sorts_cards_by_move_then_volume_before_limit():
+    markets = [
+        _market("KRW-AAA", "AAA", "에이"),
+        _market("KRW-BBB", "BBB", "비"),
+        _market("KRW-CCC", "CCC", "씨"),
+    ]
+
+    async def ticker_provider(requested_markets):
+        assert requested_markets == ["KRW-AAA", "KRW-BBB", "KRW-CCC"]
+        return [
+            {
+                "market": "KRW-AAA",
+                "trade_price": 1000,
+                "signed_change_rate": 0.01,
+                "acc_trade_price_24h": 10_000_000_000,
+            },
+            {
+                "market": "KRW-BBB",
+                "trade_price": 1000,
+                "signed_change_rate": -0.07,
+                "acc_trade_price_24h": 100_000_000,
+            },
+            {
+                "market": "KRW-CCC",
+                "trade_price": 1000,
+                "signed_change_rate": 0.07,
+                "acc_trade_price_24h": 200_000_000,
+            },
+        ]
+
+    async def spread_provider(requested_markets):
+        assert requested_markets == ["KRW-CCC", "KRW-BBB"]
+        return dict.fromkeys(requested_markets, 0.2)
+
+    response = await build_crypto_dashboard(
+        db=FakeSession(markets, []),
+        user_id=7,
+        ticker_provider=ticker_provider,
+        orderbook_spread_provider=spread_provider,
+        limit=2,
+        orderbook_limit=2,
+    )
+
+    assert [card.symbol for card in response.cards] == ["KRW-CCC", "KRW-BBB"]
+    assert "KRW-AAA" not in [card.symbol for card in response.cards]
+
+
+@pytest.mark.asyncio
+async def test_crypto_dashboard_ranks_full_universe_before_limit():
+    markets = [_market(f"KRW-{index:03d}", f"C{index:03d}", f"코인{index:03d}") for index in range(60)]
+    top_market = markets[-1].market
+
+    async def ticker_provider(requested_markets):
+        assert requested_markets == [market.market for market in markets]
+        return [
+            {
+                "market": market.market,
+                "trade_price": 1000,
+                "signed_change_rate": 0.2 if market.market == top_market else 0.01,
+                "acc_trade_price_24h": 10_000_000_000,
+            }
+            for market in markets
+        ]
+
+    async def spread_provider(requested_markets):
+        assert requested_markets == [top_market]
+        return {top_market: 0.2}
+
+    response = await build_crypto_dashboard(
+        db=FakeSession(markets, []),
+        user_id=7,
+        ticker_provider=ticker_provider,
+        orderbook_spread_provider=spread_provider,
+        limit=1,
+        orderbook_limit=1,
+    )
+
+    assert [card.symbol for card in response.cards] == [top_market]
+
+
+@pytest.mark.asyncio
 async def test_crypto_dashboard_is_renderable_when_public_sources_fail():
     async def failing_ticker(_markets):
         raise RuntimeError("upstream down")
@@ -250,4 +341,13 @@ async def test_crypto_dashboard_is_renderable_when_public_sources_fail():
     assert response.pendingOrders.emptyState == "no_pending_orders"
     assert "crypto_ticker_unavailable" in response.meta.warnings
     assert "crypto_orderbook_unavailable" in response.meta.warnings
-    assert {source.state for source in response.meta.sources} == {"unavailable"}
+    assert {source.source for source in response.meta.sources} >= {
+        "upbit_ticker",
+        "pending_orders",
+        "mcp_risk_reference",
+        "mcp_candidate_reference",
+    }
+    states = {source.source: source.state for source in response.meta.sources}
+    assert states["upbit_ticker"] == "unavailable"
+    assert states["pending_orders"] == "supported"
+    assert states["mcp_risk_reference"] == "reference_only"

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -47,7 +47,7 @@ def _market(market="KRW-BTC", base="BTC", korean_name="비트코인"):
         base_currency=base,
         quote_currency="KRW",
         korean_name=korean_name,
-        english_name="Bitcoin",
+        english_name=base,
         is_active=True,
     )
 
@@ -73,7 +73,7 @@ def _pending(symbol="KRW-BTC"):
 @pytest.mark.asyncio
 async def test_crypto_dashboard_maps_ticker_spread_relation_and_pending_orders():
     async def ticker_provider(markets):
-        assert markets == ["KRW-BTC"]
+        assert markets == ["KRW-BTC", "KRW-ETH"]
         return [
             {
                 "market": "KRW-BTC",
@@ -82,39 +82,148 @@ async def test_crypto_dashboard_maps_ticker_spread_relation_and_pending_orders()
                 "signed_change_price": 1230000,
                 "acc_trade_price_24h": 12345678900,
                 "acc_trade_volume_24h": 234.5,
-            }
+            },
+            {
+                "market": "KRW-ETH",
+                "trade_price": 5200000,
+                "signed_change_rate": 0.052,
+                "signed_change_price": 260000,
+                "acc_trade_price_24h": 8500000000,
+                "acc_trade_volume_24h": 1000,
+            },
         ]
 
     async def spread_provider(markets):
-        assert markets == ["KRW-BTC"]
-        return {"KRW-BTC": 0.62}
+        assert markets == ["KRW-BTC", "KRW-ETH"]
+        return {"KRW-BTC": 0.62, "KRW-ETH": 0.2}
 
     resolver = RelationResolver(
-        held={("crypto", "KRW-BTC")}, watch={("crypto", "KRW-BTC")}
+        held={("crypto", "KRW-BTC")}, watch={("crypto", "KRW-ETH")}
     )
     response = await build_crypto_dashboard(
-        db=FakeSession([_market()], [_pending("BTC")]),
+        db=FakeSession(
+            [_market(), _market("KRW-ETH", "ETH", "이더리움")], [_pending("BTC")]
+        ),
         user_id=7,
         resolver=resolver,
         ticker_provider=ticker_provider,
         orderbook_spread_provider=spread_provider,
     )
 
+    btc = response.cards[0]
     assert response.market == "crypto"
-    assert response.cards[0].symbol == "KRW-BTC"
-    assert response.cards[0].priceKrw == 101000000
-    assert response.cards[0].orderbookSpreadPct == pytest.approx(0.62)
-    assert response.cards[0].isHeld is True
-    assert response.cards[0].isWatched is True
-    assert {badge.kind for badge in response.cards[0].badges} >= {
+    assert btc.symbol == "KRW-BTC"
+    assert btc.priceKrw == 101000000
+    assert btc.orderbookSpreadPct == pytest.approx(0.62)
+    assert btc.isHeld is True
+    assert btc.isWatched is False
+    assert {badge.kind for badge in btc.badges} >= {
         "held",
         "pending_order",
         "thin_orderbook",
     }
+    assert btc.risk is not None
+    assert btc.risk.score == 35
+    assert btc.risk.level == "medium"
+    assert "호가 스프레드 확대" in btc.risk.reasons
+    assert "미체결 상태 존재" in btc.risk.reasons
     assert response.pendingOrders is not None
     assert response.pendingOrders.items[0].orderId == "upbit-open-1"
     assert response.pendingOrders.emptyState is None
     assert response.capabilities.execution.state == "read_only_mvp"
+    assert [candidate.symbol for candidate in response.insights.candidates] == ["KRW-ETH"]
+    assert response.insights.candidates[0].reasons[:2] == ["watched", "momentum"]
+
+
+@pytest.mark.asyncio
+async def test_crypto_dashboard_marks_high_volatility_and_low_liquidity():
+    async def ticker_provider(_markets):
+        return [
+            {
+                "market": "KRW-XRP",
+                "trade_price": 1000,
+                "signed_change_rate": 0.081,
+                "signed_change_price": 81,
+                "acc_trade_price_24h": 100_000_000,
+                "acc_trade_volume_24h": 10_000,
+            }
+        ]
+
+    async def spread_provider(_markets):
+        return {"KRW-XRP": 0.1}
+
+    response = await build_crypto_dashboard(
+        db=FakeSession([_market("KRW-XRP", "XRP", "리플")], []),
+        user_id=7,
+        ticker_provider=ticker_provider,
+        orderbook_spread_provider=spread_provider,
+    )
+
+    card = response.cards[0]
+    assert {badge.kind for badge in card.badges} >= {
+        "high_volatility",
+        "low_liquidity",
+    }
+    assert card.risk is not None
+    assert card.risk.level == "medium"
+    assert "24시간 변동성 확대" in card.risk.reasons
+    candidate_summaries = " ".join(
+        candidate.summary for candidate in response.insights.candidates
+    )
+    assert "매수" not in candidate_summaries
+    assert "주문" not in candidate_summaries
+
+
+@pytest.mark.asyncio
+async def test_crypto_dashboard_candidate_insights_are_read_only_and_ranked():
+    markets = [
+        _market("KRW-AAA", "AAA", "에이"),
+        _market("KRW-BBB", "BBB", "비"),
+        _market("KRW-CCC", "CCC", "씨"),
+        _market("KRW-DDD", "DDD", "디"),
+        _market("KRW-EEE", "EEE", "이"),
+        _market("KRW-FFF", "FFF", "에프"),
+    ]
+
+    async def ticker_provider(_markets):
+        return [
+            {
+                "market": row.market,
+                "trade_price": 1000,
+                "signed_change_rate": 0.05 if row.market != "KRW-CCC" else 0.08,
+                "signed_change_price": 50,
+                "acc_trade_price_24h": 2_000_000_000 + index,
+                "acc_trade_volume_24h": 10_000,
+            }
+            for index, row in enumerate(markets)
+        ]
+
+    async def spread_provider(_markets):
+        return {row.market: (0.2 if row.market != "KRW-CCC" else 0.8) for row in markets}
+
+    resolver = RelationResolver(watch={("crypto", "KRW-AAA"), ("crypto", "KRW-BBB")})
+    response = await build_crypto_dashboard(
+        db=FakeSession(markets, [_pending("BBB")]),
+        user_id=7,
+        resolver=resolver,
+        ticker_provider=ticker_provider,
+        orderbook_spread_provider=spread_provider,
+        limit=6,
+        orderbook_limit=6,
+    )
+
+    candidates = response.insights.candidates
+    assert len(candidates) == 5
+    assert candidates[0].symbol == "KRW-AAA"
+    assert candidates[0].score > candidates[1].score
+    assert any(candidate.symbol == "KRW-BBB" for candidate in candidates)
+    bbb = next(candidate for candidate in candidates if candidate.symbol == "KRW-BBB")
+    assert bbb.hasPendingOrder is True
+    assert "pending_order" in bbb.reasons
+    serialized = [candidate.model_dump() for candidate in candidates]
+    forbidden_fields = {"action", "execute", "order", "watchIntent", "clientOrderId", "mutation"}
+    for item in serialized:
+        assert forbidden_fields.isdisjoint(item)
 
 
 @pytest.mark.asyncio
@@ -133,6 +242,10 @@ async def test_crypto_dashboard_is_renderable_when_public_sources_fail():
     )
 
     assert response.cards[0].priceKrw is None
+    assert response.cards[0].risk is not None
+    assert response.cards[0].risk.level == "unknown"
+    assert "data_unavailable" in {badge.kind for badge in response.cards[0].badges}
+    assert response.insights.candidates == []
     assert response.pendingOrders is not None
     assert response.pendingOrders.emptyState == "no_pending_orders"
     assert "crypto_ticker_unavailable" in response.meta.warnings

--- a/tests/test_invest_crypto_naver_adapter.py
+++ b/tests/test_invest_crypto_naver_adapter.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -28,6 +30,7 @@ class _SnapshotRow:
     rsi: Decimal | None = None
     market_warning: bool = False
     source: str = "tvscreener_upbit"
+    computed_at: datetime | None = None
 
 
 @pytest.mark.unit
@@ -44,14 +47,25 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
                 change_rate=Decimal("0.0123"),
                 trade_amount_24h=Decimal("1000000000"),
                 rsi=Decimal("55.5"),
+                computed_at=datetime(2026, 5, 14, 12, tzinfo=UTC),
             )
         ]
 
     async def ticker_provider(markets: list[str]):
         assert markets == ["KRW-BTC"]
-        return [{"market": "KRW-BTC", "trade_price": 91000000}]
+        return [
+            {
+                "market": "KRW-BTC",
+                "trade_price": 91000000,
+                "timestamp": int(
+                    datetime(2026, 5, 14, 12, tzinfo=UTC).timestamp() * 1000
+                ),
+            }
+        ]
 
-    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
+    async def news_provider(
+        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
+    ):
         assert symbol == "KRW-BTC"
         return FeedNewsResponse(
             tab="crypto",
@@ -74,6 +88,7 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
             "premium_pct": 2.5,
             "domestic_price_krw": 91000000,
             "overseas_price_krw": 88780000,
+            "fetched_at": datetime(2026, 5, 14, 12, tzinfo=UTC),
         }
 
     response = await build_naver_crypto_reference(
@@ -102,7 +117,126 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
     assert "naver_crypto_reference_only" in response.warnings
     source_by_name = {source.source: source for source in response.sources}
     assert source_by_name["naver_reference"].referenceOnly is True
+    assert source_by_name["naver_reference"].freshness == "fixture"
+    assert source_by_name["tvscreener_upbit"].state in {"cached", "stale"}
+    assert source_by_name["tvscreener_upbit"].fetchedAt == datetime(
+        2026, 5, 14, 12, tzinfo=UTC
+    )
+    assert source_by_name["tvscreener_upbit"].cacheAgeSeconds is not None
+    assert source_by_name["upbit_official"].fetchedAt == datetime(
+        2026, 5, 14, 12, tzinfo=UTC
+    )
+    assert source_by_name["upbit_official"].cacheAgeSeconds is not None
+    assert source_by_name["feed_news"].fetchedAt == datetime(
+        2026, 5, 14, 12, tzinfo=UTC
+    )
     assert source_by_name["mcp_kimchi_premium"].referenceOnly is True
+    assert source_by_name["mcp_kimchi_premium"].fetchedAt == datetime(
+        2026, 5, 14, 12, tzinfo=UTC
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_naver_crypto_reference_defaults_do_not_call_uncached_live_upbit_ticker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden_live_fetch(markets: list[str]):
+        raise AssertionError(f"unexpected live Upbit ticker fetch: {markets}")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "app.services.brokers.upbit.client",
+        SimpleNamespace(fetch_multiple_tickers=forbidden_live_fetch),
+    )
+
+    async def rank_provider(db: Any, limit: int):
+        return [
+            _SnapshotRow(
+                symbol="KRW-BTC",
+                name="비트코인",
+                latest_close=Decimal("90000000"),
+                change_rate=Decimal("0.0123"),
+                computed_at=datetime.now(UTC) - timedelta(minutes=5),
+            )
+        ]
+
+    async def news_provider(
+        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
+    ):
+        return FeedNewsResponse(
+            tab="crypto",
+            asOf=datetime.now(UTC) - timedelta(minutes=5),
+            items=[],
+        )
+
+    response = await build_naver_crypto_reference(
+        db="db",  # type: ignore[arg-type]
+        symbol="BTC",
+        providers=NaverCryptoReferenceProviders(
+            rank_provider=rank_provider,
+            news_provider=news_provider,
+        ),
+    )
+
+    assert response.rank[0].priceKrw == 90000000.0
+    source_by_name = {source.source: source for source in response.sources}
+    assert source_by_name["upbit_official"].state == "unavailable"
+    assert source_by_name["upbit_official"].freshness == "missing"
+    assert source_by_name["mcp_kimchi_premium"].state == "unavailable"
+    assert source_by_name["mcp_kimchi_premium"].referenceOnly is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_naver_crypto_reference_marks_stale_cached_read_model_sources() -> None:
+    stale_at = datetime.now(UTC) - timedelta(days=3)
+
+    async def rank_provider(db: Any, limit: int):
+        return [
+            _SnapshotRow(
+                symbol="KRW-BTC",
+                name="비트코인",
+                latest_close=Decimal("90000000"),
+                computed_at=stale_at,
+            )
+        ]
+
+    async def news_provider(
+        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
+    ):
+        return FeedNewsResponse(
+            tab="crypto",
+            asOf=stale_at,
+            items=[
+                FeedNewsItem(
+                    id=2,
+                    title="old cached crypto news",
+                    publisher="fixture",
+                    market="crypto",
+                    url="https://example.test/old",
+                )
+            ],
+        )
+
+    response = await build_naver_crypto_reference(
+        db="db",  # type: ignore[arg-type]
+        symbol="BTC",
+        providers=NaverCryptoReferenceProviders(
+            rank_provider=rank_provider,
+            news_provider=news_provider,
+        ),
+    )
+
+    source_by_name = {source.source: source for source in response.sources}
+    assert source_by_name["tvscreener_upbit"].state == "stale"
+    assert source_by_name["tvscreener_upbit"].freshness == "stale"
+    assert source_by_name["tvscreener_upbit"].fetchedAt == stale_at
+    assert source_by_name["tvscreener_upbit"].cacheAgeSeconds is not None
+    assert source_by_name["feed_news"].state == "stale"
+    assert source_by_name["feed_news"].fetchedAt == stale_at
+    assert source_by_name["naver_reference"].state == "fixture"
+    assert source_by_name["naver_reference"].cacheAgeSeconds is None
 
 
 @pytest.mark.unit
@@ -114,7 +248,9 @@ async def test_naver_crypto_reference_gracefully_records_provider_failures() -> 
     async def ticker_provider(markets: list[str]):
         raise RuntimeError("ticker down")
 
-    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
+    async def news_provider(
+        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
+    ):
         raise RuntimeError("news down")
 
     async def kimchi_provider(base_symbol: str):
@@ -139,7 +275,9 @@ async def test_naver_crypto_reference_gracefully_records_provider_failures() -> 
     assert "crypto_rank_snapshot_unavailable" in response.warnings
     assert "crypto_news_unavailable" in response.warnings
     assert "crypto_kimchi_premium_unavailable" in response.warnings
-    error_sources = {source.source for source in response.sources if source.state == "error"}
+    error_sources = {
+        source.source for source in response.sources if source.state == "error"
+    }
     assert {"tvscreener_upbit", "feed_news", "mcp_kimchi_premium"} <= error_sources
 
 

--- a/tests/test_invest_crypto_naver_adapter.py
+++ b/tests/test_invest_crypto_naver_adapter.py
@@ -1,0 +1,150 @@
+"""ROB-234 tests for the read-only Naver-style crypto adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from app.schemas.invest_feed_news import FeedNewsItem, FeedNewsResponse
+from app.services.invest_crypto_naver_adapter import (
+    NaverCryptoReferenceProviders,
+    build_naver_crypto_reference,
+    normalize_krw_symbol,
+)
+from app.services.invest_view_model.relation_resolver import RelationResolver
+
+
+@dataclass
+class _SnapshotRow:
+    symbol: str
+    name: str
+    latest_close: Decimal
+    change_rate: Decimal | None = None
+    trade_amount_24h: Decimal | None = None
+    rsi: Decimal | None = None
+    market_warning: bool = False
+    source: str = "tvscreener_upbit"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() -> None:
+    async def rank_provider(db: Any, limit: int):
+        assert db == "db"
+        assert limit == 5
+        return [
+            _SnapshotRow(
+                symbol="KRW-BTC",
+                name="비트코인",
+                latest_close=Decimal("90000000"),
+                change_rate=Decimal("0.0123"),
+                trade_amount_24h=Decimal("1000000000"),
+                rsi=Decimal("55.5"),
+            )
+        ]
+
+    async def ticker_provider(markets: list[str]):
+        assert markets == ["KRW-BTC"]
+        return [{"market": "KRW-BTC", "trade_price": 91000000}]
+
+    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
+        assert symbol == "KRW-BTC"
+        return FeedNewsResponse(
+            tab="crypto",
+            asOf=datetime(2026, 5, 14, 12, tzinfo=UTC),
+            items=[
+                FeedNewsItem(
+                    id=1,
+                    title="BTC reference news",
+                    publisher="fixture",
+                    market="crypto",
+                    url="https://example.test/btc",
+                )
+            ],
+        )
+
+    async def kimchi_provider(base_symbol: str):
+        assert base_symbol == "BTC"
+        return {
+            "symbol": "BTC",
+            "premium_pct": 2.5,
+            "domestic_price_krw": 91000000,
+            "overseas_price_krw": 88780000,
+        }
+
+    response = await build_naver_crypto_reference(
+        db="db",  # type: ignore[arg-type]
+        symbol="BTC",
+        limit=5,
+        providers=NaverCryptoReferenceProviders(
+            rank_provider=rank_provider,
+            ticker_provider=ticker_provider,
+            news_provider=news_provider,
+            kimchi_provider=kimchi_provider,
+        ),
+    )
+
+    assert response.symbol == "KRW-BTC"
+    assert response.rank[0].symbol == "KRW-BTC"
+    assert response.rank[0].priceKrw == 90000000.0
+    assert response.profile is not None
+    assert response.profile.naverUrl is not None
+    assert response.profile.referenceNotes
+    assert response.news is not None
+    assert response.news.items[0].title == "BTC reference news"
+    assert response.kimchiPremium is not None
+    assert response.kimchiPremium.premiumPct == 2.5
+    assert response.capabilities.execution.state == "read_only_mvp"
+    assert "naver_crypto_reference_only" in response.warnings
+    source_by_name = {source.source: source for source in response.sources}
+    assert source_by_name["naver_reference"].referenceOnly is True
+    assert source_by_name["mcp_kimchi_premium"].referenceOnly is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_naver_crypto_reference_gracefully_records_provider_failures() -> None:
+    async def rank_provider(db: Any, limit: int):
+        raise RuntimeError("rank down")
+
+    async def ticker_provider(markets: list[str]):
+        raise RuntimeError("ticker down")
+
+    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
+        raise RuntimeError("news down")
+
+    async def kimchi_provider(base_symbol: str):
+        raise RuntimeError("kimchi down")
+
+    response = await build_naver_crypto_reference(
+        db=object(),  # type: ignore[arg-type]
+        symbol="KRW-BTC",
+        providers=NaverCryptoReferenceProviders(
+            rank_provider=rank_provider,
+            ticker_provider=ticker_provider,
+            news_provider=news_provider,
+            kimchi_provider=kimchi_provider,
+        ),
+    )
+
+    assert response.market == "crypto"
+    assert response.profile is not None
+    assert response.profile.symbol == "KRW-BTC"
+    assert response.kimchiPremium is not None
+    assert response.kimchiPremium.state == "unavailable"
+    assert "crypto_rank_snapshot_unavailable" in response.warnings
+    assert "crypto_news_unavailable" in response.warnings
+    assert "crypto_kimchi_premium_unavailable" in response.warnings
+    error_sources = {source.source for source in response.sources if source.state == "error"}
+    assert {"tvscreener_upbit", "feed_news", "mcp_kimchi_premium"} <= error_sources
+
+
+@pytest.mark.unit
+def test_normalize_krw_symbol_accepts_base_and_pair_aliases() -> None:
+    assert normalize_krw_symbol("BTC") == "KRW-BTC"
+    assert normalize_krw_symbol("btc-krw") == "KRW-BTC"
+    assert normalize_krw_symbol("KRW/ETH") == "KRW-ETH"

--- a/tests/test_invest_crypto_naver_adapter.py
+++ b/tests/test_invest_crypto_naver_adapter.py
@@ -57,15 +57,11 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
             {
                 "market": "KRW-BTC",
                 "trade_price": 91000000,
-                "timestamp": int(
-                    datetime(2026, 5, 14, 12, tzinfo=UTC).timestamp() * 1000
-                ),
+                "timestamp": int(datetime(2026, 5, 14, 12, tzinfo=UTC).timestamp() * 1000),
             }
         ]
 
-    async def news_provider(
-        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
-    ):
+    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
         assert symbol == "KRW-BTC"
         return FeedNewsResponse(
             tab="crypto",
@@ -119,21 +115,13 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
     assert source_by_name["naver_reference"].referenceOnly is True
     assert source_by_name["naver_reference"].freshness == "fixture"
     assert source_by_name["tvscreener_upbit"].state in {"cached", "stale"}
-    assert source_by_name["tvscreener_upbit"].fetchedAt == datetime(
-        2026, 5, 14, 12, tzinfo=UTC
-    )
+    assert source_by_name["tvscreener_upbit"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
     assert source_by_name["tvscreener_upbit"].cacheAgeSeconds is not None
-    assert source_by_name["upbit_official"].fetchedAt == datetime(
-        2026, 5, 14, 12, tzinfo=UTC
-    )
+    assert source_by_name["upbit_official"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
     assert source_by_name["upbit_official"].cacheAgeSeconds is not None
-    assert source_by_name["feed_news"].fetchedAt == datetime(
-        2026, 5, 14, 12, tzinfo=UTC
-    )
+    assert source_by_name["feed_news"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
     assert source_by_name["mcp_kimchi_premium"].referenceOnly is True
-    assert source_by_name["mcp_kimchi_premium"].fetchedAt == datetime(
-        2026, 5, 14, 12, tzinfo=UTC
-    )
+    assert source_by_name["mcp_kimchi_premium"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
 
 
 @pytest.mark.unit
@@ -161,9 +149,7 @@ async def test_naver_crypto_reference_defaults_do_not_call_uncached_live_upbit_t
             )
         ]
 
-    async def news_provider(
-        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
-    ):
+    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
         return FeedNewsResponse(
             tab="crypto",
             asOf=datetime.now(UTC) - timedelta(minutes=5),
@@ -202,9 +188,7 @@ async def test_naver_crypto_reference_marks_stale_cached_read_model_sources() ->
             )
         ]
 
-    async def news_provider(
-        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
-    ):
+    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
         return FeedNewsResponse(
             tab="crypto",
             asOf=stale_at,
@@ -248,9 +232,7 @@ async def test_naver_crypto_reference_gracefully_records_provider_failures() -> 
     async def ticker_provider(markets: list[str]):
         raise RuntimeError("ticker down")
 
-    async def news_provider(
-        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
-    ):
+    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
         raise RuntimeError("news down")
 
     async def kimchi_provider(base_symbol: str):
@@ -275,9 +257,7 @@ async def test_naver_crypto_reference_gracefully_records_provider_failures() -> 
     assert "crypto_rank_snapshot_unavailable" in response.warnings
     assert "crypto_news_unavailable" in response.warnings
     assert "crypto_kimchi_premium_unavailable" in response.warnings
-    error_sources = {
-        source.source for source in response.sources if source.state == "error"
-    }
+    error_sources = {source.source for source in response.sources if source.state == "error"}
     assert {"tvscreener_upbit", "feed_news", "mcp_kimchi_premium"} <= error_sources
 
 


### PR DESCRIPTION
## Summary
- Upgrades `/invest/crypto` with read-only Upbit market overview, top KRW mover/volume sections, and owned/pending-order summary.
- Adds Naver crypto reference rank/profile/news/kimchi-premium adapter data and freshness/source metadata.
- Adds MCP/reference-labeled risk and candidate insight sections with graceful fallback states.
- Updates desktop `/invest/crypto` rendering, client types, API contract, and tests for Upbit + Naver + MCP-labeled content.

Closes ROB-235

## Verification
- `git diff --check ssh-origin/main...HEAD` — passed.
- `uv run pytest tests/test_invest_crypto_dashboard_service.py tests/test_invest_crypto_naver_adapter.py tests/test_invest_api_crypto_router.py -q` — 13 passed, 2 existing Pydantic deprecation warnings.
- `uv run ruff check app/schemas/invest_crypto.py app/services/invest_crypto_naver_adapter app/services/invest_view_model/crypto_dashboard_service.py tests/test_invest_crypto_dashboard_service.py tests/test_invest_crypto_naver_adapter.py tests/test_invest_api_crypto_router.py` — passed.
- `npm test -- --run src/__tests__/DesktopCryptoPage.test.tsx` from `frontend/invest` — 4 passed.
- `npm run typecheck -- --pretty false` from `frontend/invest` — passed.
- Reviewer pass is recorded in Linear comment `1b278e11-8b13-47f2-a1ed-f366961169f2`.

## Browser smoke criteria for `/invest/crypto`
Use an authenticated read-only web session; do not submit/cancel/modify any order and do not activate schedulers or migrations.

1. Open `/invest/crypto` on desktop width and confirm the page renders without console/runtime errors.
2. Confirm visible Upbit-labeled dashboard sections/cards, including market overview/freshness/warnings and KRW mover/volume content, or provider-unavailable fallback cards.
3. Confirm visible Naver-labeled reference content, including rank/profile/news/kimchi-premium areas, or source-specific fallback cards.
4. Confirm visible MCP/reference-labeled risk and candidate sections with source/freshness labels.
5. Confirm owned holdings and pending-order summary renders as read-only status content only.
6. Confirm no executable trading forms or buttons are present; specifically no Upbit/KIS/Alpaca/generic broker, paper, or live submit/cancel/modify path is available from the dashboard.
7. Repeat at mobile viewport width and confirm the same labels/fallback states remain readable without layout breakage.

## Safety / non-actions
- No Upbit, KIS, Alpaca, generic broker, paper-trading, or live order submit/cancel/modify actions performed.
- No watch or order-intent mutations performed.
- No production DB write/delete/backfill, migration application, scheduler, Prefect, or TaskIQ activation performed.
- No credentials, tokens, connection strings, or authorization output exposed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added risk scoring and levels to crypto market cards with detailed risk summaries
* Introduced candidate insights highlighting promising crypto opportunities with reason badges
* Added new crypto reference endpoint providing Naver-style data including rank items, crypto profiles, Kimchi premium info, and news feeds
* Enhanced dashboard with source metadata, freshness states, and capability indicators
* Expanded insights summary with candidate tracking and comprehensive warning codes

**Tests**
* Added comprehensive test coverage for new reference adapter and dashboard risk/candidate features

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/842)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->