### PR TITLE
feat(invest): add crypto coin detail pre-order checklist

### DIFF
--- a/app/schemas/invest_stock_detail.py
+++ b/app/schemas/invest_stock_detail.py
@@ -5,6 +5,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from app.schemas.invest_crypto import CryptoPendingOrdersSummary, CryptoSourceState
 from app.schemas.invest_feed_news import FeedNewsResponse, NewsMarket
 from app.schemas.invest_home import (
     AccountSourceLiteral,
@@ -19,6 +20,7 @@ OrderbookUnsupportedReason = Literal[
     "us_unsupported",
     "crypto_deferred",
     "kr_unavailable",
+    "provider_unavailable",
 ]
 CapabilityUnsupportedReason = Literal[
     "read_only_mvp",
@@ -410,6 +412,75 @@ class StockDetailOrderbookSupport(CapabilityFlag):
     reason: OrderbookUnsupportedReason | None = None
 
 
+CryptoRecentTradesState = Literal["supported", "empty", "unavailable"]
+CryptoPreOrderCheckState = Literal["ok", "warning", "danger", "unavailable", "info"]
+
+
+class CryptoDetailProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    baseSymbol: str
+    displayNameKo: str | None = None
+    displayNameEn: str | None = None
+    quoteCurrency: Literal["KRW"] = "KRW"
+    source: str = "upbit_symbol_universe"
+    state: Literal["supported", "unavailable"] = "supported"
+    asOf: datetime | None = None
+
+
+class CryptoRecentTradeItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tradeTime: datetime | None = None
+    priceKrw: float
+    volume: float
+    side: str | None = None
+    sequentialId: str | int | None = None
+    source: Literal["upbit_recent_trades"] = "upbit_recent_trades"
+
+
+class CryptoRecentTrades(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[CryptoRecentTradeItem] = Field(default_factory=list)
+    emptyState: Literal["no_recent_trades"] | None = None
+    source: Literal["upbit_recent_trades"] = "upbit_recent_trades"
+    state: CryptoRecentTradesState
+    asOf: datetime | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+
+class CryptoPreOrderCheckItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    label: str
+    state: CryptoPreOrderCheckState
+    detail: str
+    source: str
+    computedAt: datetime
+
+
+class CryptoPreOrderChecklist(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["informational_only"] = "informational_only"
+    items: list[CryptoPreOrderCheckItem] = Field(default_factory=list)
+    disclaimer: str = "참고용 체크리스트입니다. 주문을 생성하거나 승인하지 않습니다."
+    sources: list[str] = Field(default_factory=list)
+
+
+class CryptoDetail(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    profile: CryptoDetailProfile
+    recentTrades: CryptoRecentTrades
+    pendingOrders: CryptoPendingOrdersSummary
+    preOrderChecklist: CryptoPreOrderChecklist
+    sources: list[CryptoSourceState] = Field(default_factory=list)
+
+
 class StockDetailMeta(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -440,6 +511,7 @@ class StockDetailResponse(BaseModel):
     orderbookSupport: StockDetailOrderbookSupport
     orderbook: StockDetailOrderbook | None = None
     capabilities: StockDetailCapabilities
+    cryptoDetail: CryptoDetail | None = None
     meta: StockDetailMeta
 
     @model_validator(mode="after")
@@ -522,7 +594,7 @@ def default_capabilities_for_market(
         )
     return StockDetailCapabilities(
         candles=CandleCapability(supported=True, intradaySupported=False),
-        orderbook=CapabilityFlag(supported=False, reason="crypto_deferred"),
+        orderbook=CapabilityFlag(supported=True, reason=None),
     )
 
 
@@ -533,4 +605,4 @@ def orderbook_support_for_market(
         return StockDetailOrderbookSupport(supported=True, reason=None)
     if market == "us":
         return StockDetailOrderbookSupport(supported=False, reason="us_unsupported")
-    return StockDetailOrderbookSupport(supported=False, reason="crypto_deferred")
+    return StockDetailOrderbookSupport(supported=True, reason=None)

--- a/app/services/invest_view_model/crypto_preorder_check.py
+++ b/app/services/invest_view_model/crypto_preorder_check.py
@@ -1,0 +1,175 @@
+"""Pure read-only crypto detail pre-order checklist helpers.
+
+The checklist is intentionally informational. It must not persist results or
+produce executable order payloads.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.schemas.invest_crypto import CryptoPendingOrdersSummary
+from app.schemas.invest_stock_detail import (
+    CryptoPreOrderCheckItem,
+    CryptoPreOrderChecklist,
+    CryptoRecentTrades,
+    StockDetailHolding,
+    StockDetailOrderbook,
+    StockDetailQuote,
+)
+
+
+def _spread_pct(orderbook: StockDetailOrderbook | None) -> float | None:
+    if not orderbook or not orderbook.asks or not orderbook.bids:
+        return None
+    ask = orderbook.asks[0].price
+    bid = orderbook.bids[0].price
+    if bid <= 0:
+        return None
+    return ((ask - bid) / bid) * 100
+
+
+def build_crypto_preorder_checklist(
+    *,
+    quote: StockDetailQuote | None,
+    orderbook: StockDetailOrderbook | None,
+    recent_trades: CryptoRecentTrades,
+    holding: StockDetailHolding | None,
+    pending_orders: CryptoPendingOrdersSummary,
+    warnings: list[str] | None = None,
+    computed_at: datetime | None = None,
+) -> CryptoPreOrderChecklist:
+    """Build a non-executable risk summary from already-read data."""
+
+    now = computed_at or datetime.now(UTC)
+    warning_set = set(warnings or [])
+    items: list[CryptoPreOrderCheckItem] = []
+
+    data_unavailable = any(
+        token in warning_set
+        for token in {
+            "crypto_ticker_unavailable",
+            "crypto_orderbook_unavailable",
+            "crypto_recent_trades_unavailable",
+        }
+    )
+    if quote is None or orderbook is None or recent_trades.state == "unavailable":
+        data_unavailable = True
+    items.append(
+        CryptoPreOrderCheckItem(
+            key="data_freshness",
+            label="데이터 신선도",
+            state="warning" if data_unavailable else "ok",
+            detail=(
+                "일부 Upbit 공개 데이터가 없어 참고 신뢰도를 낮춥니다."
+                if data_unavailable
+                else "시세·호가·체결 공개 데이터를 확인했습니다."
+            ),
+            source="upbit_public_reads",
+            computedAt=now,
+        )
+    )
+
+    spread = _spread_pct(orderbook)
+    spread_state = "unavailable"
+    spread_detail = "호가 스프레드를 계산할 수 없습니다."
+    if spread is not None:
+        if spread > 1.0:
+            spread_state = "danger"
+            spread_detail = f"최우선 호가 스프레드가 {spread:.2f}%로 넓습니다."
+        elif spread > 0.5:
+            spread_state = "warning"
+            spread_detail = f"최우선 호가 스프레드가 {spread:.2f}%입니다."
+        else:
+            spread_state = "ok"
+            spread_detail = f"최우선 호가 스프레드가 {spread:.2f}%입니다."
+    items.append(
+        CryptoPreOrderCheckItem(
+            key="orderbook_spread",
+            label="호가 스프레드",
+            state=spread_state,  # type: ignore[arg-type]
+            detail=spread_detail,
+            source="upbit_orderbook",
+            computedAt=now,
+        )
+    )
+
+    move = quote.changeRate if quote else None
+    if move is None:
+        state = "unavailable"
+        detail = "24시간 변동률을 확인할 수 없습니다."
+    elif abs(move) >= 10:
+        state = "warning"
+        detail = f"24시간 변동률이 {move:.2f}%로 큽니다."
+    else:
+        state = "ok"
+        detail = f"24시간 변동률 {move:.2f}%입니다."
+    items.append(
+        CryptoPreOrderCheckItem(
+            key="volatility_24h",
+            label="24시간 변동성",
+            state=state,  # type: ignore[arg-type]
+            detail=detail,
+            source="upbit_ticker",
+            computedAt=now,
+        )
+    )
+
+    has_pending = bool(pending_orders.items)
+    items.append(
+        CryptoPreOrderCheckItem(
+            key="pending_duplicate",
+            label="미체결 중복 확인",
+            state="warning" if has_pending else "ok",
+            detail=(
+                f"같은 코인에 미체결 주문 {len(pending_orders.items)}건이 있습니다."
+                if has_pending
+                else "같은 코인의 미체결 주문이 없습니다."
+            ),
+            source="pending_orders",
+            computedAt=now,
+        )
+    )
+
+    items.append(
+        CryptoPreOrderCheckItem(
+            key="position_exposure",
+            label="보유 노출",
+            state="info" if holding else "ok",
+            detail=(
+                f"현재 보유 수량 {holding.totalQuantity:g}을(를) 표시합니다."
+                if holding
+                else "현재 보유 수량이 없습니다."
+            ),
+            source="invest_home_read_model",
+            computedAt=now,
+        )
+    )
+
+    items.append(
+        CryptoPreOrderCheckItem(
+            key="read_only_guardrail",
+            label="읽기 전용 가드레일",
+            state="info",
+            detail="이 체크리스트는 참고용이며 주문 생성·수정·취소를 실행하지 않습니다.",
+            source="read_only_mvp",
+            computedAt=now,
+        )
+    )
+
+    return CryptoPreOrderChecklist(
+        items=items,
+        sources=sorted(
+            {
+                "upbit_ticker",
+                "upbit_orderbook",
+                "upbit_recent_trades",
+                "pending_orders",
+                "invest_home_read_model",
+                "read_only_mvp",
+            }
+        ),
+    )
+
+
+__all__ = ["build_crypto_preorder_checklist"]

--- a/app/services/invest_view_model/stock_detail_orders_service.py
+++ b/app/services/invest_view_model/stock_detail_orders_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -11,6 +13,9 @@ from app.services.invest_view_model.stock_detail_symbol_resolver import (
 )
 
 FilledOrdersFetcher = Callable[[int, list[NewsMarket]], Awaitable[list[dict[str, Any]]]]
+
+logger = logging.getLogger(__name__)
+_FILLED_ORDERS_TIMEOUT_SECONDS = 3
 
 
 def _canonical_order_symbol(market: NewsMarket, symbol: str) -> str:
@@ -55,12 +60,35 @@ async def build_stock_detail_orders(
     days: int = 90,
     limit: int = 30,
     cursor: str | None = None,
+    timeout_seconds: float = _FILLED_ORDERS_TIMEOUT_SECONDS,
 ) -> StockDetailOrdersResponse:
     days_clamped = max(1, min(days, 365))
     limit_clamped = max(1, min(limit, 100))
     offset = max(0, int(cursor or 0))
     canonical = _canonical_order_symbol(market, symbol)
-    rows = await fetcher(days_clamped, [market])
+    warnings: list[str] = []
+    try:
+        rows = await asyncio.wait_for(
+            fetcher(days_clamped, [market]), timeout=timeout_seconds
+        )
+    except TimeoutError:
+        logger.warning(
+            "stock-detail filled-orders fetch timed out: market=%s symbol=%s days=%s",
+            market,
+            symbol,
+            days_clamped,
+        )
+        rows = []
+        warnings.append("filled_orders_timeout")
+    except Exception as exc:
+        logger.warning(
+            "stock-detail filled-orders fetch unavailable: market=%s symbol=%s error=%s",
+            market,
+            symbol,
+            exc,
+        )
+        rows = []
+        warnings.append("filled_orders_unavailable")
     filtered = [row for row in rows if _row_symbol(row, market) == canonical]
     page = filtered[offset : offset + limit_clamped]
     next_offset = offset + limit_clamped
@@ -92,7 +120,7 @@ async def build_stock_detail_orders(
         nextCursor=next_cursor,
         meta={
             "emptyState": "no_filled_orders" if not filtered else None,
-            "warnings": [],
+            "warnings": warnings,
         },
     )
 

--- a/app/services/invest_view_model/stock_detail_service.py
+++ b/app/services/invest_view_model/stock_detail_service.py
@@ -7,10 +7,21 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.pending_order import PendingOrder
+from app.schemas.invest_crypto import (
+    CryptoPendingOrderItem,
+    CryptoPendingOrdersSummary,
+    CryptoSourceState,
+)
 from app.schemas.invest_feed_news import NewsMarket
 from app.schemas.invest_stock_detail import (
+    CryptoDetail,
+    CryptoDetailProfile,
+    CryptoRecentTradeItem,
+    CryptoRecentTrades,
     StockDetailDiscussionSignal,
     StockDetailFxScenario,
     StockDetailFxSensitivity,
@@ -20,6 +31,7 @@ from app.schemas.invest_stock_detail import (
     StockDetailInvestorFlowDailyRow,
     StockDetailInvestorFlowPeriodSummary,
     StockDetailLatestAnalysis,
+    StockDetailMeta,
     StockDetailNaverEnrichment,
     StockDetailOrderbook,
     StockDetailQuote,
@@ -28,6 +40,9 @@ from app.schemas.invest_stock_detail import (
     orderbook_support_for_market,
 )
 from app.services.exchange_rate_service import get_usd_krw_quote
+from app.services.invest_view_model.crypto_preorder_check import (
+    build_crypto_preorder_checklist,
+)
 from app.services.invest_view_model.investor_flow_service import (
     latest_items_for_symbols as _latest_investor_flow_items,
 )
@@ -53,6 +68,186 @@ Provider = Callable[..., Awaitable[Any]]
 
 async def _none_provider(*args: Any, **kwargs: Any) -> None:
     return None
+
+
+def _base_crypto_symbol(symbol: str) -> str:
+    normalized = str(symbol or "").upper()
+    if normalized.startswith("KRW-"):
+        return normalized.split("-", 1)[1]
+    if normalized.endswith("-KRW"):
+        return normalized.rsplit("-", 1)[0]
+    return normalized
+
+
+def _pending_symbol_variants(symbol: str) -> set[str]:
+    upper = str(symbol or "").upper()
+    base = _base_crypto_symbol(upper)
+    return {upper, base, f"KRW-{base}", f"{base}-KRW"}
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_upbit_datetime(value: Any) -> datetime | None:
+    if not value:
+        return None
+    text = str(value)
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+async def _default_quote_provider(
+    market: NewsMarket, symbol: str, db: Any
+) -> StockDetailQuote | None:
+    _ = db
+    if market != "crypto":
+        return None
+    from app.services.brokers.upbit.client import fetch_multiple_tickers
+
+    rows = await fetch_multiple_tickers([symbol])
+    if not rows:
+        return None
+    row = rows[0]
+    price = _float_or_none(row.get("trade_price"))
+    change_amount = _float_or_none(row.get("signed_change_price"))
+    change_rate = _float_or_none(row.get("signed_change_rate"))
+    if change_rate is not None:
+        change_rate *= 100
+    previous_close = (
+        price - change_amount
+        if price is not None and change_amount is not None
+        else None
+    )
+    return StockDetailQuote(
+        price=price,
+        previousClose=previous_close,
+        changeAmount=change_amount,
+        changeRate=change_rate,
+        asOf=datetime.now(UTC),
+        priceState="live" if price is not None else "missing",
+    )
+
+
+async def _default_orderbook_provider(
+    market: NewsMarket, symbol: str, db: Any
+) -> StockDetailOrderbook | None:
+    _ = db
+    if market != "crypto":
+        return None
+    from app.services.upbit_orderbook import fetch_orderbook
+
+    book = await fetch_orderbook(symbol)
+    units = list(book.get("orderbook_units") or [])
+    if not units:
+        return None
+    asks = []
+    bids = []
+    for unit in units[:10]:
+        ask_price = _float_or_none(unit.get("ask_price"))
+        ask_size = _float_or_none(unit.get("ask_size"))
+        bid_price = _float_or_none(unit.get("bid_price"))
+        bid_size = _float_or_none(unit.get("bid_size"))
+        if ask_price is not None and ask_size is not None:
+            asks.append({"price": ask_price, "quantity": ask_size})
+        if bid_price is not None and bid_size is not None:
+            bids.append({"price": bid_price, "quantity": bid_size})
+    if not asks and not bids:
+        return None
+    return StockDetailOrderbook(asOf=datetime.now(UTC), asks=asks, bids=bids)
+
+
+async def _default_recent_trades_provider(
+    market: NewsMarket, symbol: str, db: Any
+) -> CryptoRecentTrades | None:
+    _ = db
+    if market != "crypto":
+        return None
+    import httpx
+
+    url = "https://api.upbit.com/v1/trades/ticks"
+    async with httpx.AsyncClient(timeout=5) as client:
+        response = await client.get(url, params={"market": symbol, "count": 15})
+        response.raise_for_status()
+        rows = response.json()
+    items = []
+    for row in rows or []:
+        price = _float_or_none(row.get("trade_price"))
+        volume = _float_or_none(row.get("trade_volume"))
+        if price is None or volume is None:
+            continue
+        items.append(
+            CryptoRecentTradeItem(
+                tradeTime=_parse_upbit_datetime(
+                    row.get("trade_timestamp") or row.get("trade_date_utc")
+                ),
+                priceKrw=price,
+                volume=volume,
+                side=row.get("ask_bid"),
+                sequentialId=row.get("sequential_id"),
+            )
+        )
+    return CryptoRecentTrades(
+        items=items,
+        emptyState=None if items else "no_recent_trades",
+        state="supported" if items else "empty",
+        asOf=datetime.now(UTC),
+    )
+
+
+async def _default_pending_orders_provider(
+    user_id: int | str, market: NewsMarket, symbol: str, db: Any
+) -> CryptoPendingOrdersSummary | None:
+    if market != "crypto":
+        return None
+    if not hasattr(db, "execute"):
+        return CryptoPendingOrdersSummary(items=[], emptyState="no_pending_orders")
+    variants = _pending_symbol_variants(symbol)
+    stmt = (
+        select(PendingOrder)
+        .where(
+            PendingOrder.user_id == int(user_id),
+            PendingOrder.market == "crypto",
+            PendingOrder.venue == "upbit",
+            PendingOrder.symbol.in_(sorted(variants)),
+            or_(PendingOrder.status == "open", PendingOrder.status == "partial_fill"),
+        )
+        .order_by(PendingOrder.ordered_at.desc().nullslast())
+        .limit(20)
+    )
+    result = await db.execute(stmt)
+    rows = list(result.scalars().all())
+    items = [
+        CryptoPendingOrderItem(
+            orderId=row.broker_order_id,
+            symbol=str(row.symbol).upper(),
+            baseSymbol=_base_crypto_symbol(str(row.symbol)),
+            side=row.side,
+            orderType=row.order_type,
+            price=_float_or_none(row.price),
+            quantity=float(row.quantity or 0),
+            filledQuantity=float(row.filled_quantity or 0),
+            status=row.status,
+            orderedAt=row.ordered_at,
+            updatedAt=row.updated_at,
+        )
+        for row in rows
+    ]
+    return CryptoPendingOrdersSummary(
+        items=items, emptyState=None if items else "no_pending_orders"
+    )
 
 
 def _daily_row_from_snapshot(row: Any) -> StockDetailInvestorFlowDailyRow:
@@ -226,16 +421,18 @@ async def _run_optional_block(
 @dataclass(frozen=True, slots=True)
 class StockDetailProviders:
     resolver: Resolver = resolve_symbol
-    quote: Provider = _none_provider
+    quote: Provider = _default_quote_provider
     screener: Provider = _none_provider
     valuation: Provider = _none_provider
     holding: Provider = _none_provider
     latest_analysis: Provider = _none_provider
-    orderbook: Provider = _none_provider
+    orderbook: Provider = _default_orderbook_provider
     fx_rate: Provider = get_usd_krw_quote
     naver_enrichment: Provider = build_naver_stock_detail_poc
     discussion_signal: Provider = build_naver_discussion_signal_poc
     investor_flow: Provider = _default_investor_flow_provider
+    recent_trades: Provider = _default_recent_trades_provider
+    pending_orders: Provider = _default_pending_orders_provider
 
 
 DEFAULT_STOCK_DETAIL_PROVIDERS = StockDetailProviders()
@@ -291,18 +488,34 @@ async def build_stock_detail(
         providers.discussion_signal(market, resolved.symbol_db, db),
         warnings,
     )
-    if market == "kr":
+    if market in {"kr", "crypto"}:
         orderbook_task = _run_optional_block(
             "orderbook", providers.orderbook(market, resolved.symbol_db, db), warnings
         )
+    else:
+        orderbook_task = _none_provider()
+    if market == "kr":
         investor_flow_task = _run_optional_block(
             "investor_flow",
             providers.investor_flow(market, resolved.symbol_db, db),
             warnings,
         )
     else:
-        orderbook_task = _none_provider()
         investor_flow_task = _none_provider()
+    if market == "crypto":
+        recent_trades_task = _run_optional_block(
+            "crypto_recent_trades",
+            providers.recent_trades(market, resolved.symbol_db, db),
+            warnings,
+        )
+        pending_orders_task = _run_optional_block(
+            "crypto_pending_orders",
+            providers.pending_orders(user_id, market, resolved.symbol_db, db),
+            warnings,
+        )
+    else:
+        recent_trades_task = _none_provider()
+        pending_orders_task = _none_provider()
 
     (
         quote,
@@ -314,6 +527,8 @@ async def build_stock_detail(
         discussion_signal,
         orderbook,
         investor_flow,
+        recent_trades,
+        pending_orders,
     ) = await asyncio.gather(
         quote_task,
         screener_task,
@@ -324,6 +539,8 @@ async def build_stock_detail(
         discussion_signal_task,
         orderbook_task,
         investor_flow_task,
+        recent_trades_task,
+        pending_orders_task,
     )
 
     capabilities = default_capabilities_for_market(market)
@@ -364,6 +581,24 @@ async def build_stock_detail(
         investor_flow, StockDetailInvestorFlow
     ):
         investor_flow = StockDetailInvestorFlow.model_validate(investor_flow)
+    if recent_trades is not None and not isinstance(recent_trades, CryptoRecentTrades):
+        recent_trades = CryptoRecentTrades.model_validate(recent_trades)
+    if pending_orders is not None and not isinstance(
+        pending_orders, CryptoPendingOrdersSummary
+    ):
+        pending_orders = CryptoPendingOrdersSummary.model_validate(pending_orders)
+
+    if market == "crypto" and orderbook is None:
+        orderbook_support = orderbook_support.model_copy(
+            update={"supported": False, "reason": "provider_unavailable"}
+        )
+        capabilities = capabilities.model_copy(
+            update={
+                "orderbook": capabilities.orderbook.model_copy(
+                    update={"supported": False, "reason": "provider_unavailable"}
+                )
+            }
+        )
 
     fx_rate = None
     if _should_fetch_fx_rate(
@@ -378,6 +613,69 @@ async def build_stock_detail(
         holding=holding,
         fx_rate=fx_rate,
     )
+
+    crypto_detail = None
+    if market == "crypto":
+        if recent_trades is None:
+            recent_trades = CryptoRecentTrades(
+                items=[],
+                emptyState="no_recent_trades",
+                state="unavailable",
+                warnings=["crypto_recent_trades_unavailable"],
+            )
+        if pending_orders is None:
+            pending_orders = CryptoPendingOrdersSummary(
+                items=[], emptyState="no_pending_orders"
+            )
+        base_symbol = _base_crypto_symbol(resolved.symbol_db)
+        crypto_sources = [
+            CryptoSourceState(
+                source="upbit_ticker",
+                state="supported" if quote else "unavailable",
+                label="Upbit ticker" if quote else "Upbit ticker unavailable",
+                fetchedAt=datetime.now(UTC),
+            ),
+            CryptoSourceState(
+                source="upbit_orderbook",
+                state="supported" if orderbook else "unavailable",
+                label="Upbit orderbook" if orderbook else "Upbit orderbook unavailable",
+                fetchedAt=datetime.now(UTC),
+            ),
+            CryptoSourceState(
+                source="upbit_recent_trades",
+                state="supported"
+                if recent_trades.state != "unavailable"
+                else "unavailable",
+                label="Upbit recent trades",
+                fetchedAt=recent_trades.asOf,
+            ),
+            CryptoSourceState(
+                source="pending_orders",
+                state="supported",
+                label="Read-only pending orders",
+                fetchedAt=datetime.now(UTC),
+            ),
+        ]
+        crypto_detail = CryptoDetail(
+            profile=CryptoDetailProfile(
+                symbol=resolved.symbol_db,
+                baseSymbol=base_symbol,
+                displayNameKo=resolved.display_name,
+                displayNameEn=base_symbol,
+                asOf=datetime.now(UTC),
+            ),
+            recentTrades=recent_trades,
+            pendingOrders=pending_orders,
+            preOrderChecklist=build_crypto_preorder_checklist(
+                quote=quote,
+                orderbook=orderbook,
+                recent_trades=recent_trades,
+                holding=holding,
+                pending_orders=pending_orders,
+                warnings=warnings,
+            ),
+            sources=crypto_sources,
+        )
 
     return StockDetailResponse(
         symbol=resolved.symbol_db,
@@ -400,7 +698,8 @@ async def build_stock_detail(
         orderbookSupport=orderbook_support,
         orderbook=orderbook,
         capabilities=capabilities,
-        meta={"computedAt": datetime.now(UTC), "warnings": warnings},
+        cryptoDetail=crypto_detail,
+        meta=StockDetailMeta(computedAt=datetime.now(UTC), warnings=warnings),
     )
 
 

--- a/frontend/invest/src/__tests__/StockDetailPage.test.tsx
+++ b/frontend/invest/src/__tests__/StockDetailPage.test.tsx
@@ -127,6 +127,7 @@ const aboveFold: StockDetailResponse = {
   },
   orderbookSupport: { supported: false, reason: "us_unsupported" },
   orderbook: null,
+  cryptoDetail: null,
   capabilities: {
     candles: { supported: true, intradaySupported: true },
     orderbook: { supported: false, reason: "us_unsupported" },

--- a/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
+++ b/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
@@ -56,6 +56,7 @@ function currencyValue(currency: string, value: number | null | undefined) {
 function orderbookMessage(data: StockDetailResponse): string {
   if (data.orderbookSupport.supported && data.orderbook) return "호가를 표시합니다";
   if (data.orderbookSupport.reason === "us_unsupported") return "US 호가는 아직 지원하지 않습니다";
+  if (data.orderbookSupport.reason === "provider_unavailable") return "호가 제공자 데이터를 사용할 수 없습니다";
   if (data.orderbookSupport.reason === "crypto_deferred") return "크립토 호가는 다음 단계에서 연결합니다";
   return "호가 데이터를 사용할 수 없습니다";
 }
@@ -203,6 +204,40 @@ function OrdersCard({ orders }: { orders: StockDetailOrdersResponse | undefined 
       {!orders ? <p style={{ margin: 0, color: "var(--fg-3)" }}>불러오는 중입니다…</p> : null}
       {orders && empty ? <p style={{ margin: 0, color: "var(--fg-3)" }}>체결 내역이 없습니다.</p> : null}
       {orders && !empty ? <ul>{orders.items.map((o) => <li key={o.orderId ?? `${o.side}-${o.filledAt}`}>{o.side} {o.quantity}</li>)}</ul> : null}
+    </Card>
+  );
+}
+
+function CryptoDetailCard({ data }: { data: StockDetailResponse }) {
+  const crypto = data.cryptoDetail;
+  if (!crypto) return null;
+  const pendingCount = crypto.pendingOrders.items.length;
+  const recent = crypto.recentTrades.items.slice(0, 3);
+  return (
+    <Card data-testid="stock-detail-crypto-detail" soft>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+        <div>
+          <h2 style={{ margin: "0 0 6px", fontSize: 16 }}>크립토 사전 체크</h2>
+          <p style={{ margin: 0, color: "var(--fg-3)", fontSize: 12 }}>
+            {crypto.profile.baseSymbol} · 미체결 {pendingCount}건 · {crypto.preOrderChecklist.mode}
+          </p>
+        </div>
+        <Pill tone="upbit">read-only</Pill>
+      </div>
+      <ul style={{ margin: "12px 0 0", paddingLeft: 18, color: "var(--fg-2)", fontSize: 13 }}>
+        {crypto.preOrderChecklist.items.slice(0, 6).map((item) => (
+          <li key={item.key}><strong>{item.label}</strong> · {item.detail}</li>
+        ))}
+      </ul>
+      <p style={{ margin: "10px 0 0", color: "var(--fg-3)", fontSize: 12 }}>{crypto.preOrderChecklist.disclaimer}</p>
+      {recent.length > 0 ? (
+        <div style={{ marginTop: 12 }}>
+          <div style={{ color: "var(--fg-3)", fontSize: 12, marginBottom: 6 }}>최근 체결</div>
+          <ul style={{ margin: 0, paddingLeft: 18, color: "var(--fg-2)", fontSize: 13 }}>
+            {recent.map((trade) => <li key={`${trade.sequentialId ?? trade.tradeTime}-${trade.priceKrw}`}>₩{Math.round(trade.priceKrw).toLocaleString("ko-KR")} · {trade.volume.toLocaleString("ko-KR", { maximumFractionDigits: 6 })}</li>)}
+          </ul>
+        </div>
+      ) : null}
     </Card>
   );
 }
@@ -389,6 +424,7 @@ export function StockDetailPage() {
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
       {data ? <ProfileCard data={data} /> : null}
       {data && market !== "crypto" ? <ResearchConsensusCard data={researchConsensus} error={researchErr} /> : null}
+      {data && market === "crypto" ? <CryptoDetailCard data={data} /> : null}
       {data ? <AnalysisCard data={data} /> : null}
       {data ? <NaverPocCard data={data} /> : null}
       <MemoCard />

--- a/frontend/invest/src/types/stockDetail.ts
+++ b/frontend/invest/src/types/stockDetail.ts
@@ -2,7 +2,7 @@ import type { AccountSource, AssetCategory, AssetType, Currency, PriceState } fr
 import type { FeedNewsResponse } from "./feedNews";
 
 export type StockDetailMarket = "kr" | "us" | "crypto";
-export type OrderbookUnsupportedReason = "us_unsupported" | "crypto_deferred" | "kr_unavailable";
+export type OrderbookUnsupportedReason = "us_unsupported" | "crypto_deferred" | "kr_unavailable" | "provider_unavailable";
 export type CapabilityUnsupportedReason =
   | "read_only_mvp"
   | "out_of_mvp_scope"
@@ -233,6 +233,70 @@ export interface StockDetailOrderbookSupport extends CapabilityFlag {
   reason: OrderbookUnsupportedReason | null;
 }
 
+export interface CryptoRecentTradeItem {
+  tradeTime: string | null;
+  priceKrw: number;
+  volume: number;
+  side: string | null;
+  sequentialId: string | number | null;
+  source: "upbit_recent_trades";
+}
+
+export interface CryptoRecentTrades {
+  items: CryptoRecentTradeItem[];
+  emptyState: "no_recent_trades" | null;
+  source: "upbit_recent_trades";
+  state: "supported" | "empty" | "unavailable";
+  asOf: string | null;
+  warnings: string[];
+}
+
+export interface CryptoPreOrderCheckItem {
+  key: string;
+  label: string;
+  state: "ok" | "warning" | "danger" | "unavailable" | "info";
+  detail: string;
+  source: string;
+  computedAt: string;
+}
+
+export interface CryptoDetail {
+  profile: {
+    symbol: string;
+    baseSymbol: string;
+    displayNameKo: string | null;
+    displayNameEn: string | null;
+    quoteCurrency: "KRW";
+    source: string;
+    state: "supported" | "unavailable";
+    asOf: string | null;
+  };
+  recentTrades: CryptoRecentTrades;
+  pendingOrders: {
+    items: Array<{
+      orderId: string | null;
+      symbol: string;
+      baseSymbol: string;
+      side: string;
+      orderType: string | null;
+      price: number | null;
+      quantity: number;
+      filledQuantity: number;
+      status: string;
+      orderedAt: string | null;
+      updatedAt: string | null;
+    }>;
+    emptyState: "no_pending_orders" | null;
+  };
+  preOrderChecklist: {
+    mode: "informational_only";
+    items: CryptoPreOrderCheckItem[];
+    disclaimer: string;
+    sources: string[];
+  };
+  sources: Array<{ source: string; state: string; label: string; fetchedAt: string | null }>;
+}
+
 export interface StockDetailResponse {
   symbol: string;
   market: StockDetailMarket;
@@ -253,6 +317,7 @@ export interface StockDetailResponse {
   orderbookSupport: StockDetailOrderbookSupport;
   orderbook: StockDetailOrderbook | null;
   capabilities: StockDetailCapabilities;
+  cryptoDetail: CryptoDetail | null;
   meta: { computedAt: string; warnings: string[] };
 }
 

--- a/tests/test_stock_detail_orders.py
+++ b/tests/test_stock_detail_orders.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 
 import pytest
@@ -86,3 +87,48 @@ async def test_stock_detail_orders_clamps_days_at_365():
     )
 
     assert seen["days"] == 365
+
+
+@pytest.mark.asyncio
+async def test_stock_detail_orders_timeout_degrades_to_empty_with_warning():
+    async def fetcher(days, markets):
+        await asyncio.sleep(0.05)
+        return [
+            {
+                "symbol": "BTC",
+                "side": "buy",
+                "quantity": 1,
+                "price": 100,
+                "filled_at": datetime.now(UTC),
+                "order_id": "late",
+            }
+        ]
+
+    response = await build_stock_detail_orders(
+        market="crypto",
+        symbol="KRW-BTC",
+        fetcher=fetcher,
+        timeout_seconds=0.001,
+    )
+
+    assert response.symbol == "BTC"
+    assert response.items == []
+    assert response.meta.emptyState == "no_filled_orders"
+    assert response.meta.warnings == ["filled_orders_timeout"]
+
+
+@pytest.mark.asyncio
+async def test_stock_detail_orders_fetch_error_degrades_to_empty_with_warning():
+    async def fetcher(days, markets):
+        raise RuntimeError("broker history unavailable")
+
+    response = await build_stock_detail_orders(
+        market="crypto",
+        symbol="BTC-KRW",
+        fetcher=fetcher,
+    )
+
+    assert response.symbol == "BTC"
+    assert response.items == []
+    assert response.meta.emptyState == "no_filled_orders"
+    assert response.meta.warnings == ["filled_orders_unavailable"]

--- a/tests/test_stock_detail_service.py
+++ b/tests/test_stock_detail_service.py
@@ -6,7 +6,13 @@ from types import SimpleNamespace
 
 import pytest
 
-from app.schemas.invest_stock_detail import StockDetailHolding, StockDetailOrderbook
+from app.schemas.invest_crypto import CryptoPendingOrdersSummary
+from app.schemas.invest_stock_detail import (
+    CryptoRecentTrades,
+    StockDetailHolding,
+    StockDetailOrderbook,
+    StockDetailQuote,
+)
 from app.services.invest_view_model.stock_detail_service import (
     StockDetailProviders,
     build_stock_detail,
@@ -140,12 +146,26 @@ async def test_build_stock_detail_maps_holding_and_kr_orderbook_when_available()
 
 @pytest.mark.asyncio
 async def test_build_stock_detail_omits_naver_poc_for_crypto():
+    async def no_quote_provider(market, symbol, db):
+        return None
+
+    async def no_orderbook_provider(market, symbol, db):
+        return None
+
+    async def no_recent_trades_provider(market, symbol, db):
+        return None
+
     response = await build_stock_detail(
         user_id=1,
         market="crypto",
         symbol="KRW-BTC",
         db=SimpleNamespace(),
-        providers=StockDetailProviders(resolver=_resolve_crypto),
+        providers=StockDetailProviders(
+            resolver=_resolve_crypto,
+            quote=no_quote_provider,
+            orderbook=no_orderbook_provider,
+            recent_trades=no_recent_trades_provider,
+        ),
     )
 
     assert response.market == "crypto"
@@ -153,6 +173,7 @@ async def test_build_stock_detail_omits_naver_poc_for_crypto():
     assert response.fxSensitivity.status == "not_applicable"
     assert response.naverEnrichment is None
     assert response.orderbookSupport.supported is False
+    assert response.orderbookSupport.reason == "provider_unavailable"
 
 
 @pytest.mark.asyncio
@@ -242,3 +263,108 @@ async def test_build_stock_detail_degrades_when_us_fx_provider_fails():
     assert response.fxSensitivity.status == "missing_fx_rate"
     assert response.fxSensitivity.scenarios == []
     assert "fx_sensitivity_unavailable" in response.meta.warnings
+
+
+def test_build_stock_detail_crypto_includes_read_only_detail_and_preorder_check():
+    async def quote_provider(market, symbol, db):
+        assert market == "crypto"
+        assert symbol == "KRW-BTC"
+        return StockDetailQuote(
+            price=100_000_000,
+            previousClose=99_000_000,
+            changeAmount=1_000_000,
+            changeRate=1.01,
+            asOf=datetime.now(UTC),
+            priceState="live",
+        )
+
+    async def orderbook_provider(market, symbol, db):
+        return StockDetailOrderbook(
+            asks=[{"price": 100_100_000, "quantity": 0.5}],
+            bids=[{"price": 100_000_000, "quantity": 0.4}],
+        )
+
+    async def recent_trades_provider(market, symbol, db):
+        return CryptoRecentTrades(
+            state="supported",
+            items=[
+                {
+                    "priceKrw": 100_000_000,
+                    "volume": 0.01,
+                    "tradeTime": datetime.now(UTC),
+                }
+            ],
+        )
+
+    async def pending_orders_provider(user_id, market, symbol, db):
+        return CryptoPendingOrdersSummary(items=[], emptyState="no_pending_orders")
+
+    providers = StockDetailProviders(
+        resolver=_resolve_crypto,
+        quote=quote_provider,
+        orderbook=orderbook_provider,
+        recent_trades=recent_trades_provider,
+        pending_orders=pending_orders_provider,
+    )
+
+    response = asyncio.run(
+        build_stock_detail(
+            user_id=7,
+            market="crypto",
+            symbol="btc",
+            db=SimpleNamespace(),
+            providers=providers,
+        )
+    )
+
+    assert response.symbol == "KRW-BTC"
+    assert response.orderbookSupport.supported is True
+    assert response.orderbookSupport.reason is None
+    assert response.capabilities.orderbook.supported is True
+    assert response.capabilities.execution.supported is False
+    assert response.capabilities.execution.reason == "read_only_mvp"
+    assert response.cryptoDetail is not None
+    assert response.cryptoDetail.profile.baseSymbol == "BTC"
+    assert response.cryptoDetail.pendingOrders.emptyState == "no_pending_orders"
+    assert response.cryptoDetail.preOrderChecklist.mode == "informational_only"
+    assert any(
+        item.key == "read_only_guardrail"
+        for item in response.cryptoDetail.preOrderChecklist.items
+    )
+
+
+def test_build_stock_detail_crypto_orderbook_provider_unavailable_is_explicit():
+    async def failing_orderbook_provider(market, symbol, db):
+        raise RuntimeError("provider down")
+
+    async def no_quote_provider(market, symbol, db):
+        return None
+
+    async def no_recent_trades_provider(market, symbol, db):
+        return None
+
+    providers = StockDetailProviders(
+        resolver=_resolve_crypto,
+        quote=no_quote_provider,
+        orderbook=failing_orderbook_provider,
+        recent_trades=no_recent_trades_provider,
+    )
+
+    response = asyncio.run(
+        build_stock_detail(
+            user_id=7,
+            market="crypto",
+            symbol="KRW-BTC",
+            db=SimpleNamespace(),
+            providers=providers,
+        )
+    )
+
+    assert response.orderbook is None
+    assert response.orderbookSupport.supported is False
+    assert response.orderbookSupport.reason == "provider_unavailable"
+    assert response.capabilities.orderbook.supported is False
+    assert response.capabilities.orderbook.reason == "provider_unavailable"
+    assert "orderbook_unavailable" in response.meta.warnings
+    assert response.cryptoDetail is not None
+    assert response.cryptoDetail.recentTrades.state == "unavailable"


### PR DESCRIPTION
## Summary
- Adds read-only crypto detail payloads for `/invest/stocks/crypto/KRW-BTC`: Upbit-backed profile, orderbook, recent trades, pending-order summary, source state, and informational pre-order checklist.
- Keeps execution disabled with `read_only_mvp` guardrails; the checklist is explicitly `mode=informational_only` and does not create executable order payloads.
- Bounds stock/crypto detail order-history reads with timeout/error warnings so provider slowness does not block the detail page.

## Verification
- `uv run pytest tests/test_stock_detail_orders.py tests/test_stock_detail_service.py tests/test_invest_stock_detail_schemas.py tests/test_invest_api_crypto_router.py tests/test_invest_api_router_safety.py -q` -> 31 passed, 2 existing Pydantic warnings.
- `pnpm -C frontend/invest exec vitest run src/__tests__/StockDetailPage.test.tsx src/__tests__/stockDetailApi.test.ts` -> 13 passed.
- `uv run ruff check app/schemas/invest_stock_detail.py app/services/invest_view_model/crypto_preorder_check.py app/services/invest_view_model/stock_detail_orders_service.py app/services/invest_view_model/stock_detail_service.py tests/test_stock_detail_orders.py tests/test_stock_detail_service.py` -> pass.
- `pnpm -C frontend/invest run typecheck` -> pass.
- `pnpm -C frontend/invest run build` -> pass, with existing Vite chunk-size warning.
- `git diff --check ssh-origin/main...HEAD` -> pass.
- Added-line static scan for hardcoded secret assignments, shell injection, eval/exec, pickle loads, and SQL string formatting -> no matches.

## Representative smoke criteria for ROB-237/final integration
Use authenticated read-only `/invest` access; do not perform any broker/order/watch/order-intent action.
1. Open `/invest/crypto/KRW-BTC` and confirm it redirects to canonical `/invest/stocks/crypto/KRW-BTC` while preserving query/hash when present.
2. Confirm the detail page renders with crypto profile/source state, orderbook card, recent trades/체결, pending orders, and pre-order checklist.
3. Confirm buy/sell controls remain disabled/guarded and execution capability remains `supported=false`, `reason=read_only_mvp`.
4. Confirm pre-order checklist text includes the informational-only/non-order disclaimer and never exposes a submit/cancel/modify CTA or payload.
5. Confirm provider-unavailable/stale paths render explicit warnings (`provider_unavailable`, `crypto_*_unavailable`) without blocking the page.

## Safety / non-actions
- No Upbit, KIS, Alpaca, generic broker, paper, or live order submit/cancel/modify/replace.
- No watch or order-intent mutation.
- No production DB write/delete/backfill/migration application.
- No scheduler, Prefect, or TaskIQ activation.
- No merge or deploy.

Closes ROB-236
