### PR TITLE
feat(invest): integrate crypto action dashboard work

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -217,6 +217,7 @@ class Settings(BaseSettings):
     )
 
     upbit_ohlcv_cache_enabled: bool = True
+    upbit_public_read_model_cache_enabled: bool = True
     upbit_ohlcv_cache_max_days: int = 400
     upbit_ohlcv_cache_lock_ttl_seconds: int = 10
     yahoo_ohlcv_cache_enabled: bool = True

--- a/app/routers/invest_api.py
+++ b/app/routers/invest_api.py
@@ -25,7 +25,10 @@ from app.schemas.invest_common_preferred_disparity import (
     CommonPreferredDisparityResponse,
 )
 from app.schemas.invest_coverage import CoverageMarket, InvestCoverageResponse
-from app.schemas.invest_crypto import CryptoDashboardResponse
+from app.schemas.invest_crypto import (
+    CryptoDashboardResponse,
+    NaverCryptoReferenceResponse,
+)
 from app.schemas.invest_feed_news import FeedNewsResponse, FeedTab, FeedTopic
 from app.schemas.invest_feed_research import (
     FeedResearchFilters,
@@ -60,6 +63,7 @@ from app.schemas.invest_stock_detail_research_consensus import (
 )
 from app.schemas.investor_flow import InvestorFlowResponse
 from app.services.invest_coverage_service import build_invest_coverage
+from app.services.invest_crypto_naver_adapter import build_naver_crypto_reference
 from app.services.invest_home_service import InvestHomeService
 from app.services.invest_momentum_events.coverage_service import build_momentum_coverage
 from app.services.invest_momentum_events.repository import (
@@ -212,6 +216,32 @@ async def get_crypto_dashboard(
         user_id=user.id,
         resolver=resolver,
         limit=limit,
+    )
+
+
+@router.get("/crypto/naver-reference")
+async def get_crypto_naver_reference(
+    user: Annotated[Any, Depends(get_authenticated_user)],
+    service: Annotated[InvestHomeService, Depends(get_invest_home_service)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+    symbol: str | None = Query(None, description="Optional KRW pair or base symbol"),
+    limit: int = Query(20, ge=1, le=50),
+) -> NaverCryptoReferenceResponse:
+    """Read-only Naver-style crypto reference adapter.
+
+    This endpoint aggregates source-labeled public/read-model data and fixture
+    metadata only. It never syncs, submits orders, mutates watch/order-intent
+    state, or writes production data.
+    """
+    home = await service.get_home(user_id=user.id)
+    resolver = await build_relation_resolver(
+        db, user_id=user.id, held_pairs=_held_pairs_from_home(home)
+    )
+    return await build_naver_crypto_reference(
+        db=db,
+        symbol=symbol,
+        limit=limit,
+        resolver=resolver,
     )
 
 

--- a/app/schemas/invest_crypto.py
+++ b/app/schemas/invest_crypto.py
@@ -11,6 +11,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from app.schemas.invest_feed_news import FeedNewsResponse
+
 CryptoCapabilityState = Literal[
     "supported",
     "unavailable",
@@ -39,6 +41,16 @@ CryptoCandidateReasonKind = Literal[
     "pending_order",
     "data_quality",
 ]
+CryptoReferenceSourceState = Literal[
+    "available",
+    "cached",
+    "fixture",
+    "reference_only",
+    "stale",
+    "unavailable",
+    "error",
+]
+CryptoReferenceFreshness = Literal["fresh", "partial", "stale", "missing", "fixture"]
 CryptoPendingOrderSide = Literal["buy", "sell"] | str
 
 
@@ -212,3 +224,101 @@ class CryptoDashboardResponse(BaseModel):
         default_factory=CryptoDashboardCapabilities
     )
     meta: CryptoDashboardMeta
+
+
+class CryptoReferenceSourceMeta(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    label: str
+    state: CryptoReferenceSourceState
+    fetchedAt: datetime | None = None
+    cacheAgeSeconds: float | None = None
+    freshness: CryptoReferenceFreshness
+    errorCode: str | None = None
+    referenceOnly: bool = False
+
+
+class NaverCryptoRankItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rank: int = Field(ge=1)
+    symbol: str
+    displayName: str
+    priceKrw: float | None = None
+    changeRate24h: float | None = None
+    tradeAmount24h: float | None = None
+    rsi: float | None = None
+    marketWarning: bool | None = None
+    source: str
+
+
+class NaverCryptoProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    baseSymbol: str
+    displayName: str
+    koreanName: str | None = None
+    englishName: str | None = None
+    naverUrl: str | None = None
+    officialMarket: str | None = None
+    referenceNotes: list[str] = Field(default_factory=list)
+
+
+class NaverCryptoKimchiPremium(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    baseSymbol: str
+    premiumPct: float | None = None
+    domesticPriceKrw: float | None = None
+    overseasPriceKrw: float | None = None
+    state: CryptoReferenceSourceState
+    source: str
+    caution: str
+
+
+class NaverCryptoReferenceCapabilities(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rank: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(state="supported")
+    )
+    price: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(state="supported")
+    )
+    profile: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(
+            state="reference_only", reason="naver_fixture_reference_only"
+        )
+    )
+    news: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(state="supported")
+    )
+    kimchiPremium: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(
+            state="reference_only", reason="macro_reference_only"
+        )
+    )
+    execution: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(
+            state="read_only_mvp", reason="no_order_execution_controls"
+        )
+    )
+
+
+class NaverCryptoReferenceResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    market: Literal["crypto"] = "crypto"
+    asOf: datetime
+    symbol: str | None = None
+    rank: list[NaverCryptoRankItem] = Field(default_factory=list)
+    profile: NaverCryptoProfile | None = None
+    news: FeedNewsResponse | None = None
+    kimchiPremium: NaverCryptoKimchiPremium | None = None
+    sources: list[CryptoReferenceSourceMeta] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    capabilities: NaverCryptoReferenceCapabilities = Field(
+        default_factory=NaverCryptoReferenceCapabilities
+    )

--- a/app/schemas/invest_crypto.py
+++ b/app/schemas/invest_crypto.py
@@ -25,6 +25,19 @@ CryptoRiskBadgeKind = Literal[
     "pending_order",
     "data_unavailable",
     "high_volatility",
+    "low_liquidity",
+    "candidate_watch",
+    "momentum_candidate",
+]
+CryptoRiskLevel = Literal["low", "medium", "high", "unknown"]
+CryptoCandidateReasonKind = Literal[
+    "momentum",
+    "liquidity",
+    "spread",
+    "watched",
+    "held",
+    "pending_order",
+    "data_quality",
 ]
 CryptoPendingOrderSide = Literal["buy", "sell"] | str
 
@@ -83,6 +96,30 @@ class CryptoRiskBadge(BaseModel):
     severity: Literal["info", "warning", "danger"] = "info"
 
 
+class CryptoRiskSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    level: CryptoRiskLevel
+    score: int = Field(ge=0, le=100)
+    reasons: list[str] = Field(default_factory=list)
+
+
+class CryptoCandidateInsight(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    baseSymbol: str
+    displayName: str
+    rank: int = Field(ge=1)
+    score: int = Field(ge=0, le=100)
+    reasons: list[CryptoCandidateReasonKind] = Field(default_factory=list)
+    summary: str
+    isHeld: bool = False
+    isWatched: bool = False
+    hasPendingOrder: bool = False
+    riskLevel: CryptoRiskLevel
+
+
 class CryptoMarketCard(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -98,6 +135,7 @@ class CryptoMarketCard(BaseModel):
     isHeld: bool = False
     isWatched: bool = False
     badges: list[CryptoRiskBadge] = Field(default_factory=list)
+    risk: CryptoRiskSummary | None = None
 
 
 class CryptoHoldingSummary(BaseModel):
@@ -150,6 +188,7 @@ class CryptoInsightsSummary(BaseModel):
 
     badges: list[CryptoRiskBadge] = Field(default_factory=list)
     notes: list[str] = Field(default_factory=list)
+    candidates: list[CryptoCandidateInsight] = Field(default_factory=list)
 
 
 class CryptoDashboardMeta(BaseModel):

--- a/app/schemas/invest_crypto.py
+++ b/app/schemas/invest_crypto.py
@@ -38,7 +38,9 @@ CryptoReferenceSourceState = Literal[
     "unavailable",
     "error",
 ]
-CryptoReferenceFreshness = Literal["fresh", "partial", "stale", "missing", "fixture", "live"]
+CryptoReferenceFreshness = Literal[
+    "fresh", "partial", "stale", "missing", "fixture", "live"
+]
 CryptoPendingOrderSide = Literal["buy", "sell"] | str
 
 

--- a/app/schemas/invest_crypto.py
+++ b/app/schemas/invest_crypto.py
@@ -47,6 +47,7 @@ CryptoReferenceSourceState = Literal[
     "fixture",
     "reference_only",
     "stale",
+    "live",
     "unavailable",
     "error",
 ]

--- a/app/schemas/invest_crypto.py
+++ b/app/schemas/invest_crypto.py
@@ -11,6 +11,8 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from app.schemas.invest_feed_news import FeedNewsResponse
+
 CryptoCapabilityState = Literal[
     "supported",
     "unavailable",
@@ -26,6 +28,16 @@ CryptoRiskBadgeKind = Literal[
     "data_unavailable",
     "high_volatility",
 ]
+CryptoReferenceSourceState = Literal[
+    "available",
+    "cached",
+    "fixture",
+    "reference_only",
+    "stale",
+    "unavailable",
+    "error",
+]
+CryptoReferenceFreshness = Literal["fresh", "partial", "stale", "missing", "fixture"]
 CryptoPendingOrderSide = Literal["buy", "sell"] | str
 
 
@@ -173,3 +185,101 @@ class CryptoDashboardResponse(BaseModel):
         default_factory=CryptoDashboardCapabilities
     )
     meta: CryptoDashboardMeta
+
+
+class CryptoReferenceSourceMeta(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: str
+    label: str
+    state: CryptoReferenceSourceState
+    fetchedAt: datetime | None = None
+    cacheAgeSeconds: float | None = None
+    freshness: CryptoReferenceFreshness
+    errorCode: str | None = None
+    referenceOnly: bool = False
+
+
+class NaverCryptoRankItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rank: int = Field(ge=1)
+    symbol: str
+    displayName: str
+    priceKrw: float | None = None
+    changeRate24h: float | None = None
+    tradeAmount24h: float | None = None
+    rsi: float | None = None
+    marketWarning: bool | None = None
+    source: str
+
+
+class NaverCryptoProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    baseSymbol: str
+    displayName: str
+    koreanName: str | None = None
+    englishName: str | None = None
+    naverUrl: str | None = None
+    officialMarket: str | None = None
+    referenceNotes: list[str] = Field(default_factory=list)
+
+
+class NaverCryptoKimchiPremium(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    baseSymbol: str
+    premiumPct: float | None = None
+    domesticPriceKrw: float | None = None
+    overseasPriceKrw: float | None = None
+    state: CryptoReferenceSourceState
+    source: str
+    caution: str
+
+
+class NaverCryptoReferenceCapabilities(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    rank: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(state="supported")
+    )
+    price: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(state="supported")
+    )
+    profile: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(
+            state="reference_only", reason="naver_fixture_reference_only"
+        )
+    )
+    news: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(state="supported")
+    )
+    kimchiPremium: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(
+            state="reference_only", reason="macro_reference_only"
+        )
+    )
+    execution: CryptoCapabilityFlag = Field(
+        default_factory=lambda: CryptoCapabilityFlag(
+            state="read_only_mvp", reason="no_order_execution_controls"
+        )
+    )
+
+
+class NaverCryptoReferenceResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    market: Literal["crypto"] = "crypto"
+    asOf: datetime
+    symbol: str | None = None
+    rank: list[NaverCryptoRankItem] = Field(default_factory=list)
+    profile: NaverCryptoProfile | None = None
+    news: FeedNewsResponse | None = None
+    kimchiPremium: NaverCryptoKimchiPremium | None = None
+    sources: list[CryptoReferenceSourceMeta] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    capabilities: NaverCryptoReferenceCapabilities = Field(
+        default_factory=NaverCryptoReferenceCapabilities
+    )

--- a/app/schemas/invest_crypto.py
+++ b/app/schemas/invest_crypto.py
@@ -50,7 +50,9 @@ CryptoReferenceSourceState = Literal[
     "unavailable",
     "error",
 ]
-CryptoReferenceFreshness = Literal["fresh", "partial", "stale", "missing", "fixture"]
+CryptoReferenceFreshness = Literal[
+    "fresh", "partial", "stale", "missing", "fixture", "live"
+]
 CryptoPendingOrderSide = Literal["buy", "sell"] | str
 
 

--- a/app/schemas/invest_crypto.py
+++ b/app/schemas/invest_crypto.py
@@ -34,10 +34,11 @@ CryptoReferenceSourceState = Literal[
     "fixture",
     "reference_only",
     "stale",
+    "live",
     "unavailable",
     "error",
 ]
-CryptoReferenceFreshness = Literal["fresh", "partial", "stale", "missing", "fixture"]
+CryptoReferenceFreshness = Literal["fresh", "partial", "stale", "missing", "fixture", "live"]
 CryptoPendingOrderSide = Literal["buy", "sell"] | str
 
 

--- a/app/schemas/invest_screener.py
+++ b/app/schemas/invest_screener.py
@@ -13,6 +13,24 @@ from pydantic import BaseModel, ConfigDict, Field
 
 ScreenerMarket = Literal["kr", "us", "crypto"]
 ChangeDirection = Literal["up", "down", "flat"]
+ScreenerDataSourceKind = Literal[
+    "upbit_official",
+    "tvscreener_upbit",
+    "mcp_screen_stocks",
+    "naver_reference",
+    "coingecko_reference",
+    "external_reference",
+    "snapshot_cache",
+]
+ScreenerSourceState = Literal[
+    "supported",
+    "cached",
+    "reference_only",
+    "partial",
+    "unavailable",
+    "fallback",
+]
+ScreenerRiskSeverity = Literal["info", "warning", "danger"]
 
 
 class ScreenerFilterChip(BaseModel):
@@ -30,6 +48,30 @@ class ScreenerPreset(BaseModel):
     filterChips: list[ScreenerFilterChip] = Field(default_factory=list)
     metricLabel: str
     market: ScreenerMarket = "kr"
+
+
+class ScreenerSourceContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    source: ScreenerDataSourceKind
+    label: str
+    state: ScreenerSourceState
+    fetchedAt: str | None = None
+    detail: str | None = None
+
+
+class ScreenerRiskContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    kind: str
+    label: str
+    severity: ScreenerRiskSeverity = "info"
+    source: ScreenerDataSourceKind | None = None
+
+
+class ScreenerCandidateContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    scoreLabel: str | None = None
+    reasons: list[str] = Field(default_factory=list)
+    source: ScreenerDataSourceKind | None = None
 
 
 class ScreenerResultRow(BaseModel):
@@ -50,6 +92,9 @@ class ScreenerResultRow(BaseModel):
     analystLabel: str
     metricValueLabel: str
     warnings: list[str] = Field(default_factory=list)
+    sourceContext: list[ScreenerSourceContext] = Field(default_factory=list)
+    riskContext: list[ScreenerRiskContext] = Field(default_factory=list)
+    candidateContext: ScreenerCandidateContext | None = None
 
 
 class ScreenerPresetsResponse(BaseModel):
@@ -78,3 +123,4 @@ class ScreenerResultsResponse(BaseModel):
     results: list[ScreenerResultRow]
     warnings: list[str] = Field(default_factory=list)
     freshness: ScreenerFreshness
+    sources: list[ScreenerSourceContext] = Field(default_factory=list)

--- a/app/schemas/invest_stock_detail.py
+++ b/app/schemas/invest_stock_detail.py
@@ -5,6 +5,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from app.schemas.invest_crypto import CryptoPendingOrdersSummary, CryptoSourceState
 from app.schemas.invest_feed_news import FeedNewsResponse, NewsMarket
 from app.schemas.invest_home import (
     AccountSourceLiteral,
@@ -19,6 +20,7 @@ OrderbookUnsupportedReason = Literal[
     "us_unsupported",
     "crypto_deferred",
     "kr_unavailable",
+    "provider_unavailable",
 ]
 CapabilityUnsupportedReason = Literal[
     "read_only_mvp",
@@ -410,6 +412,75 @@ class StockDetailOrderbookSupport(CapabilityFlag):
     reason: OrderbookUnsupportedReason | None = None
 
 
+CryptoRecentTradesState = Literal["supported", "empty", "unavailable"]
+CryptoPreOrderCheckState = Literal["ok", "warning", "danger", "unavailable", "info"]
+
+
+class CryptoDetailProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symbol: str
+    baseSymbol: str
+    displayNameKo: str | None = None
+    displayNameEn: str | None = None
+    quoteCurrency: Literal["KRW"] = "KRW"
+    source: str = "upbit_symbol_universe"
+    state: Literal["supported", "unavailable"] = "supported"
+    asOf: datetime | None = None
+
+
+class CryptoRecentTradeItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    tradeTime: datetime | None = None
+    priceKrw: float
+    volume: float
+    side: str | None = None
+    sequentialId: str | int | None = None
+    source: Literal["upbit_recent_trades"] = "upbit_recent_trades"
+
+
+class CryptoRecentTrades(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    items: list[CryptoRecentTradeItem] = Field(default_factory=list)
+    emptyState: Literal["no_recent_trades"] | None = None
+    source: Literal["upbit_recent_trades"] = "upbit_recent_trades"
+    state: CryptoRecentTradesState
+    asOf: datetime | None = None
+    warnings: list[str] = Field(default_factory=list)
+
+
+class CryptoPreOrderCheckItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str
+    label: str
+    state: CryptoPreOrderCheckState
+    detail: str
+    source: str
+    computedAt: datetime
+
+
+class CryptoPreOrderChecklist(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    mode: Literal["informational_only"] = "informational_only"
+    items: list[CryptoPreOrderCheckItem] = Field(default_factory=list)
+    disclaimer: str = "참고용 체크리스트입니다. 주문을 생성하거나 승인하지 않습니다."
+    sources: list[str] = Field(default_factory=list)
+
+
+class CryptoDetail(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    profile: CryptoDetailProfile
+    recentTrades: CryptoRecentTrades
+    pendingOrders: CryptoPendingOrdersSummary
+    preOrderChecklist: CryptoPreOrderChecklist
+    sources: list[CryptoSourceState] = Field(default_factory=list)
+
+
 class StockDetailMeta(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -440,6 +511,7 @@ class StockDetailResponse(BaseModel):
     orderbookSupport: StockDetailOrderbookSupport
     orderbook: StockDetailOrderbook | None = None
     capabilities: StockDetailCapabilities
+    cryptoDetail: CryptoDetail | None = None
     meta: StockDetailMeta
 
     @model_validator(mode="after")
@@ -522,7 +594,7 @@ def default_capabilities_for_market(
         )
     return StockDetailCapabilities(
         candles=CandleCapability(supported=True, intradaySupported=False),
-        orderbook=CapabilityFlag(supported=False, reason="crypto_deferred"),
+        orderbook=CapabilityFlag(supported=True, reason=None),
     )
 
 
@@ -533,4 +605,4 @@ def orderbook_support_for_market(
         return StockDetailOrderbookSupport(supported=True, reason=None)
     if market == "us":
         return StockDetailOrderbookSupport(supported=False, reason="us_unsupported")
-    return StockDetailOrderbookSupport(supported=False, reason="crypto_deferred")
+    return StockDetailOrderbookSupport(supported=True, reason=None)

--- a/app/services/brokers/upbit/public_trades.py
+++ b/app/services/brokers/upbit/public_trades.py
@@ -1,0 +1,42 @@
+"""Upbit public recent-trades fetcher (read-only)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.brokers.upbit.client import UPBIT_REST, _request_json
+from app.services.upbit_symbol_universe_service import get_upbit_market_by_coin
+
+UPBIT_TRADES_URL = f"{UPBIT_REST}/trades/ticks"
+_MAX_COUNT = 500
+
+
+async def _normalize_market(market: str) -> str:
+    code = str(market or "").strip().upper()
+    if not code:
+        raise ValueError("market is required")
+    if code.startswith("KRW-"):
+        return code
+    resolved = await get_upbit_market_by_coin(code)
+    if not resolved:
+        raise ValueError(f"unknown Upbit market: {market!r}")
+    return resolved
+
+
+async def fetch_recent_trades(
+    market: str = "KRW-BTC", count: int = 50
+) -> list[dict[str, Any]]:
+    """Return recent public trades for a KRW Upbit market.
+
+    This is read-only and only calls Upbit's public /v1/trades/ticks endpoint.
+    Transport/status errors are deliberately propagated so callers can classify
+    them into freshness/error envelopes.
+    """
+    normalized = await _normalize_market(market)
+    bounded = max(1, min(int(count), _MAX_COUNT))
+    rows = await _request_json(
+        UPBIT_TRADES_URL, params={"market": normalized, "count": bounded}
+    )
+    if not isinstance(rows, list):
+        raise ValueError("unexpected Upbit trades response shape")
+    return list(rows)

--- a/app/services/invest_crypto_naver_adapter/__init__.py
+++ b/app/services/invest_crypto_naver_adapter/__init__.py
@@ -1,0 +1,13 @@
+"""Read-only Naver-style crypto reference adapter package."""
+
+from app.services.invest_crypto_naver_adapter.adapter import (
+    NaverCryptoReferenceProviders,
+    build_naver_crypto_reference,
+    normalize_krw_symbol,
+)
+
+__all__ = [
+    "NaverCryptoReferenceProviders",
+    "build_naver_crypto_reference",
+    "normalize_krw_symbol",
+]

--- a/app/services/invest_crypto_naver_adapter/adapter.py
+++ b/app/services/invest_crypto_naver_adapter/adapter.py
@@ -35,12 +35,20 @@ from app.services.invest_crypto_screener_snapshots.repository import (
 from app.services.invest_view_model.relation_resolver import RelationResolver
 
 RankProvider = Callable[[AsyncSession, int], Awaitable[Sequence[Any]] | Sequence[Any]]
-TickerProvider = Callable[[list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]]
+TickerProvider = Callable[
+    [list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]
+]
 NewsProvider = Callable[
     [AsyncSession, RelationResolver, str | None, int],
     Awaitable[FeedNewsResponse | None] | FeedNewsResponse | None,
 ]
-KimchiProvider = Callable[[str], Awaitable[dict[str, Any] | list[dict[str, Any]] | None] | dict[str, Any] | list[dict[str, Any]] | None]
+KimchiProvider = Callable[
+    [str],
+    Awaitable[dict[str, Any] | list[dict[str, Any]] | None]
+    | dict[str, Any]
+    | list[dict[str, Any]]
+    | None,
+]
 
 
 @dataclass(frozen=True)
@@ -133,7 +141,9 @@ def _row_value(row: Any, key: str) -> Any:
     return getattr(row, key, None)
 
 
-def _source_timestamp_from_rows(rows: Sequence[Any], keys: Sequence[str]) -> datetime | None:
+def _source_timestamp_from_rows(
+    rows: Sequence[Any], keys: Sequence[str]
+) -> datetime | None:
     timestamps: list[datetime] = []
     for row in rows:
         for key in keys:
@@ -174,7 +184,9 @@ def _cached_source_meta(
         state="stale" if is_stale else "cached",
         fetchedAt=fetched_at,
         cacheAgeSeconds=age_seconds,
-        freshness="stale" if is_stale else ("fresh" if fetched_at is not None else "partial"),
+        freshness="stale"
+        if is_stale
+        else ("fresh" if fetched_at is not None else "partial"),
     )
 
 
@@ -254,7 +266,9 @@ async def _default_news_provider(
     )
 
 
-async def _default_kimchi_provider(base_symbol: str) -> dict[str, Any] | list[dict[str, Any]] | None:
+async def _default_kimchi_provider(
+    base_symbol: str,
+) -> dict[str, Any] | list[dict[str, Any]] | None:
     """Default kimchi provider intentionally avoids uncached live HTTP.
 
     A caller may inject a live or cached provider; without one the endpoint still
@@ -264,7 +278,9 @@ async def _default_kimchi_provider(base_symbol: str) -> dict[str, Any] | list[di
     return None
 
 
-async def _load_universe_fallback(db: AsyncSession, *, limit: int) -> list[UpbitSymbolUniverse]:
+async def _load_universe_fallback(
+    db: AsyncSession, *, limit: int
+) -> list[UpbitSymbolUniverse]:
     stmt = (
         select(UpbitSymbolUniverse)
         .where(
@@ -283,7 +299,9 @@ def _decimal_float(value: Decimal | float | int | str | None) -> float | None:
 
 
 def _market_from_row(row: Any) -> str | None:
-    return normalize_krw_symbol(getattr(row, "symbol", None) or getattr(row, "market", None))
+    return normalize_krw_symbol(
+        getattr(row, "symbol", None) or getattr(row, "market", None)
+    )
 
 
 def _name_from_row(row: Any, symbol: str) -> str:
@@ -298,7 +316,8 @@ def _name_from_row(row: Any, symbol: str) -> str:
 
 
 def _rank_item_from_snapshot(
-    *, rank: int,
+    *,
+    rank: int,
     row: Any,
     ticker: dict[str, Any] | None,
 ) -> NaverCryptoRankItem | None:
@@ -322,7 +341,8 @@ def _rank_item_from_snapshot(
 
 
 def _rank_item_from_universe(
-    *, rank: int,
+    *,
+    rank: int,
     row: UpbitSymbolUniverse,
     ticker: dict[str, Any] | None,
 ) -> NaverCryptoRankItem:
@@ -340,14 +360,20 @@ def _rank_item_from_universe(
     )
 
 
-def _build_profile(symbol: str | None, rank: Sequence[NaverCryptoRankItem]) -> NaverCryptoProfile | None:
-    target = normalize_krw_symbol(symbol) if symbol else (rank[0].symbol if rank else None)
+def _build_profile(
+    symbol: str | None, rank: Sequence[NaverCryptoRankItem]
+) -> NaverCryptoProfile | None:
+    target = (
+        normalize_krw_symbol(symbol) if symbol else (rank[0].symbol if rank else None)
+    )
     if target is None:
         return None
     fixture = NAVER_CRYPTO_REFERENCES.get(target, {})
     rank_match = next((item for item in rank if item.symbol == target), None)
     base = str(fixture.get("baseSymbol") or _base_symbol(target))
-    display_name = str(fixture.get("displayName") or (rank_match.displayName if rank_match else base))
+    display_name = str(
+        fixture.get("displayName") or (rank_match.displayName if rank_match else base)
+    )
     notes = list(fixture.get("referenceNotes") or [])
     if not notes:
         notes = [
@@ -358,15 +384,21 @@ def _build_profile(symbol: str | None, rank: Sequence[NaverCryptoRankItem]) -> N
         symbol=target,
         baseSymbol=base,
         displayName=display_name,
-        koreanName=str(fixture.get("koreanName")) if fixture.get("koreanName") else None,
-        englishName=str(fixture.get("englishName")) if fixture.get("englishName") else None,
+        koreanName=str(fixture.get("koreanName"))
+        if fixture.get("koreanName")
+        else None,
+        englishName=str(fixture.get("englishName"))
+        if fixture.get("englishName")
+        else None,
         naverUrl=str(fixture.get("naverUrl")) if fixture.get("naverUrl") else None,
         officialMarket="UPBIT/KRW",
         referenceNotes=notes,
     )
 
 
-def _first_kimchi_row(payload: dict[str, Any] | list[dict[str, Any]] | None) -> dict[str, Any] | None:
+def _first_kimchi_row(
+    payload: dict[str, Any] | list[dict[str, Any]] | None,
+) -> dict[str, Any] | None:
     if isinstance(payload, list):
         return payload[0] if payload else None
     if isinstance(payload, dict):
@@ -374,7 +406,9 @@ def _first_kimchi_row(payload: dict[str, Any] | list[dict[str, Any]] | None) -> 
     return None
 
 
-def _build_kimchi(base_symbol: str, payload: dict[str, Any] | list[dict[str, Any]] | None) -> NaverCryptoKimchiPremium:
+def _build_kimchi(
+    base_symbol: str, payload: dict[str, Any] | list[dict[str, Any]] | None
+) -> NaverCryptoKimchiPremium:
     row = _first_kimchi_row(payload)
     if not row:
         return NaverCryptoKimchiPremium(
@@ -387,10 +421,22 @@ def _build_kimchi(base_symbol: str, payload: dict[str, Any] | list[dict[str, Any
             caution="김치 프리미엄은 참고용 매크로 지표이며 주문 실행 신호가 아닙니다.",
         )
     return NaverCryptoKimchiPremium(
-        baseSymbol=str(row.get("base_symbol") or row.get("symbol") or base_symbol).replace("KRW-", ""),
-        premiumPct=_float_or_none(row.get("premium_pct") or row.get("kimchi_premium") or row.get("premium")),
-        domesticPriceKrw=_float_or_none(row.get("domestic_price_krw") or row.get("upbit_price_krw") or row.get("upbit_price")),
-        overseasPriceKrw=_float_or_none(row.get("overseas_price_krw") or row.get("binance_price_krw") or row.get("global_price_krw")),
+        baseSymbol=str(
+            row.get("base_symbol") or row.get("symbol") or base_symbol
+        ).replace("KRW-", ""),
+        premiumPct=_float_or_none(
+            row.get("premium_pct") or row.get("kimchi_premium") or row.get("premium")
+        ),
+        domesticPriceKrw=_float_or_none(
+            row.get("domestic_price_krw")
+            or row.get("upbit_price_krw")
+            or row.get("upbit_price")
+        ),
+        overseasPriceKrw=_float_or_none(
+            row.get("overseas_price_krw")
+            or row.get("binance_price_krw")
+            or row.get("global_price_krw")
+        ),
         state="available",
         source="mcp_kimchi_premium",
         caution="김치 프리미엄은 참고용 매크로 지표이며 주문 실행 신호가 아닙니다.",
@@ -460,7 +506,14 @@ async def build_naver_crypto_reference(
             ticker_rows = list(await _maybe_await(ticker_provider(markets)))
             ticker_fetched_at = _source_timestamp_from_rows(
                 ticker_rows,
-                ("fetched_at", "fetchedAt", "cached_at", "updated_at", "timestamp", "trade_timestamp"),
+                (
+                    "fetched_at",
+                    "fetchedAt",
+                    "cached_at",
+                    "updated_at",
+                    "timestamp",
+                    "trade_timestamp",
+                ),
             )
             sources.append(
                 _provider_source_meta(
@@ -488,7 +541,9 @@ async def build_naver_crypto_reference(
     rank_items: list[NaverCryptoRankItem] = []
     for index, row in enumerate(rank_rows, start=1):
         market = _market_from_row(row)
-        item = _rank_item_from_snapshot(rank=index, row=row, ticker=ticker_by_market.get(market or ""))
+        item = _rank_item_from_snapshot(
+            rank=index, row=row, ticker=ticker_by_market.get(market or "")
+        )
         if item:
             rank_items.append(item)
 
@@ -499,7 +554,9 @@ async def build_naver_crypto_reference(
                 _rank_item_from_universe(
                     rank=index,
                     row=row,
-                    ticker=ticker_by_market.get(normalize_krw_symbol(row.market) or row.market.upper()),
+                    ticker=ticker_by_market.get(
+                        normalize_krw_symbol(row.market) or row.market.upper()
+                    ),
                 )
                 for index, row in enumerate(universe_rows, start=1)
             ]
@@ -522,7 +579,9 @@ async def build_naver_crypto_reference(
     news: FeedNewsResponse | None = None
     news_provider = providers.news_provider or _default_news_provider
     try:
-        news = await _maybe_await(news_provider(db, resolver, normalized_symbol, min(limit, 20)))
+        news = await _maybe_await(
+            news_provider(db, resolver, normalized_symbol, min(limit, 20))
+        )
         sources.append(
             _cached_source_meta(
                 source="feed_news",
@@ -588,11 +647,21 @@ async def build_naver_crypto_reference(
         sources=sources,
         warnings=list(dict.fromkeys(warnings)),
         capabilities=NaverCryptoReferenceCapabilities(
-            rank=CryptoCapabilityFlag(state="supported" if rank_items else "unavailable"),
-            price=CryptoCapabilityFlag(state="supported" if ticker_rows or rank_items else "unavailable"),
-            profile=CryptoCapabilityFlag(state="reference_only", reason="naver_fixture_reference_only"),
+            rank=CryptoCapabilityFlag(
+                state="supported" if rank_items else "unavailable"
+            ),
+            price=CryptoCapabilityFlag(
+                state="supported" if ticker_rows or rank_items else "unavailable"
+            ),
+            profile=CryptoCapabilityFlag(
+                state="reference_only", reason="naver_fixture_reference_only"
+            ),
             news=CryptoCapabilityFlag(state="supported" if news else "unavailable"),
-            kimchiPremium=CryptoCapabilityFlag(state="reference_only", reason="macro_reference_only"),
-            execution=CryptoCapabilityFlag(state="read_only_mvp", reason="no_order_execution_controls"),
+            kimchiPremium=CryptoCapabilityFlag(
+                state="reference_only", reason="macro_reference_only"
+            ),
+            execution=CryptoCapabilityFlag(
+                state="read_only_mvp", reason="no_order_execution_controls"
+            ),
         ),
     )

--- a/app/services/invest_crypto_naver_adapter/adapter.py
+++ b/app/services/invest_crypto_naver_adapter/adapter.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import inspect
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import Any
 
@@ -93,15 +93,145 @@ def _ticker_map(rows: Sequence[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     return mapped
 
 
+_SOURCE_STALE_AFTER_SECONDS = 24 * 60 * 60
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _parse_source_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _as_utc(value)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=UTC)
+    if isinstance(value, (int, float)):
+        # Upbit ticker timestamps are millisecond epochs. Accept seconds too.
+        seconds = float(value) / 1000 if float(value) > 10_000_000_000 else float(value)
+        try:
+            return datetime.fromtimestamp(seconds, tz=UTC)
+        except (OverflowError, OSError, ValueError):
+            return None
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        try:
+            return _as_utc(datetime.fromisoformat(raw.replace("Z", "+00:00")))
+        except ValueError:
+            return None
+    return None
+
+
+def _row_value(row: Any, key: str) -> Any:
+    if isinstance(row, dict):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _source_timestamp_from_rows(rows: Sequence[Any], keys: Sequence[str]) -> datetime | None:
+    timestamps: list[datetime] = []
+    for row in rows:
+        for key in keys:
+            parsed = _parse_source_datetime(_row_value(row, key))
+            if parsed is not None:
+                timestamps.append(parsed)
+                break
+    return max(timestamps) if timestamps else None
+
+
+def _cache_age_seconds(*, now: datetime, fetched_at: datetime | None) -> float | None:
+    if fetched_at is None:
+        return None
+    return max(0.0, (now - fetched_at).total_seconds())
+
+
+def _cached_source_meta(
+    *,
+    source: str,
+    label: str,
+    has_data: bool,
+    fetched_at: datetime | None,
+    now: datetime,
+    stale_after_seconds: int = _SOURCE_STALE_AFTER_SECONDS,
+) -> CryptoReferenceSourceMeta:
+    if not has_data:
+        return CryptoReferenceSourceMeta(
+            source=source,
+            label=label,
+            state="unavailable",
+            freshness="missing",
+        )
+    age_seconds = _cache_age_seconds(now=now, fetched_at=fetched_at)
+    is_stale = age_seconds is not None and age_seconds > stale_after_seconds
+    return CryptoReferenceSourceMeta(
+        source=source,
+        label=label,
+        state="stale" if is_stale else "cached",
+        fetchedAt=fetched_at,
+        cacheAgeSeconds=age_seconds,
+        freshness="stale" if is_stale else ("fresh" if fetched_at is not None else "partial"),
+    )
+
+
+def _provider_source_meta(
+    *,
+    source: str,
+    label: str,
+    has_data: bool,
+    fetched_at: datetime | None,
+    now: datetime,
+    reference_only: bool = False,
+    stale_after_seconds: int = _SOURCE_STALE_AFTER_SECONDS,
+) -> CryptoReferenceSourceMeta:
+    if not has_data:
+        return CryptoReferenceSourceMeta(
+            source=source,
+            label=label,
+            state="unavailable",
+            freshness="missing",
+            referenceOnly=reference_only,
+        )
+    if fetched_at is None:
+        return CryptoReferenceSourceMeta(
+            source=source,
+            label=label,
+            state="live",
+            fetchedAt=now,
+            freshness="live",
+            referenceOnly=reference_only,
+        )
+    meta = _cached_source_meta(
+        source=source,
+        label=label,
+        has_data=True,
+        fetched_at=fetched_at,
+        now=now,
+        stale_after_seconds=stale_after_seconds,
+    )
+    if reference_only:
+        return meta.model_copy(update={"referenceOnly": True})
+    return meta
+
+
 async def _default_rank_provider(db: AsyncSession, limit: int) -> Sequence[Any]:
     repo = InvestCryptoScreenerSnapshotsRepository(db)
     return await repo.list_latest(preset_id="crypto_momentum", limit=limit)
 
 
 async def _default_ticker_provider(markets: list[str]) -> list[dict[str, Any]]:
-    from app.services.brokers.upbit.client import fetch_multiple_tickers
+    """Default ticker provider intentionally avoids live request-path HTTP.
 
-    return await fetch_multiple_tickers(markets)
+    The Naver reference endpoint is a read-model/fixture view. Live Upbit ticker
+    fetches are volatile external HTTP and must be injected explicitly by callers
+    that can label them as live data.
+    """
+
+    return []
 
 
 async def _default_news_provider(
@@ -125,9 +255,13 @@ async def _default_news_provider(
 
 
 async def _default_kimchi_provider(base_symbol: str) -> dict[str, Any] | list[dict[str, Any]] | None:
-    from app.mcp_server.tooling.fundamentals._crypto import handle_get_kimchi_premium
+    """Default kimchi provider intentionally avoids uncached live HTTP.
 
-    return await handle_get_kimchi_premium(base_symbol or "BTC")
+    A caller may inject a live or cached provider; without one the endpoint still
+    returns fixture/read-model data and marks kimchi premium unavailable.
+    """
+
+    return None
 
 
 async def _load_universe_fallback(db: AsyncSession, *, limit: int) -> list[UpbitSymbolUniverse]:
@@ -289,13 +423,16 @@ async def build_naver_crypto_reference(
     rank_provider = providers.rank_provider or _default_rank_provider
     try:
         rank_rows = await _maybe_await(rank_provider(db, limit))
+        rank_fetched_at = _source_timestamp_from_rows(
+            rank_rows, ("computed_at", "updated_at", "created_at", "snapshot_date")
+        )
         sources.append(
-            CryptoReferenceSourceMeta(
+            _cached_source_meta(
                 source="tvscreener_upbit",
                 label="Persisted crypto screener snapshots",
-                state="available" if rank_rows else "unavailable",
-                fetchedAt=now if rank_rows else None,
-                freshness="fresh" if rank_rows else "missing",
+                has_data=bool(rank_rows),
+                fetched_at=rank_fetched_at,
+                now=now,
             )
         )
     except Exception:
@@ -321,13 +458,18 @@ async def build_naver_crypto_reference(
         ticker_provider = providers.ticker_provider or _default_ticker_provider
         try:
             ticker_rows = list(await _maybe_await(ticker_provider(markets)))
+            ticker_fetched_at = _source_timestamp_from_rows(
+                ticker_rows,
+                ("fetched_at", "fetchedAt", "cached_at", "updated_at", "timestamp", "trade_timestamp"),
+            )
             sources.append(
-                CryptoReferenceSourceMeta(
+                _provider_source_meta(
                     source="upbit_official",
                     label="Upbit official/public ticker",
-                    state="available" if ticker_rows else "unavailable",
-                    fetchedAt=now if ticker_rows else None,
-                    freshness="fresh" if ticker_rows else "missing",
+                    has_data=bool(ticker_rows),
+                    fetched_at=ticker_fetched_at,
+                    now=now,
+                    stale_after_seconds=60,
                 )
             )
         except Exception:
@@ -371,7 +513,7 @@ async def build_naver_crypto_reference(
         CryptoReferenceSourceMeta(
             source="naver_reference",
             label="Naver crypto reference fixture",
-            state="reference_only" if profile else "unavailable",
+            state="fixture" if profile else "unavailable",
             freshness="fixture" if profile else "missing",
             referenceOnly=True,
         )
@@ -382,12 +524,12 @@ async def build_naver_crypto_reference(
     try:
         news = await _maybe_await(news_provider(db, resolver, normalized_symbol, min(limit, 20)))
         sources.append(
-            CryptoReferenceSourceMeta(
+            _cached_source_meta(
                 source="feed_news",
                 label="Persisted crypto news feed",
-                state="available" if news and news.items else "unavailable",
-                fetchedAt=now if news else None,
-                freshness="fresh" if news and news.items else "missing",
+                has_data=bool(news and news.items),
+                fetched_at=_parse_source_datetime(getattr(news, "asOf", None)),
+                now=now,
             )
         )
         if news and news.meta.warnings:
@@ -408,14 +550,19 @@ async def build_naver_crypto_reference(
     kimchi_provider = providers.kimchi_provider or _default_kimchi_provider
     try:
         kimchi_payload = await _maybe_await(kimchi_provider(base_symbol))
+        kimchi_row = _first_kimchi_row(kimchi_payload)
         sources.append(
-            CryptoReferenceSourceMeta(
+            _provider_source_meta(
                 source="mcp_kimchi_premium",
                 label="Kimchi premium reference",
-                state="available" if _first_kimchi_row(kimchi_payload) else "unavailable",
-                fetchedAt=now if _first_kimchi_row(kimchi_payload) else None,
-                freshness="fresh" if _first_kimchi_row(kimchi_payload) else "missing",
-                referenceOnly=True,
+                has_data=bool(kimchi_row),
+                fetched_at=_source_timestamp_from_rows(
+                    [kimchi_row] if kimchi_row else [],
+                    ("fetched_at", "fetchedAt", "cached_at", "updated_at", "timestamp"),
+                ),
+                now=now,
+                reference_only=True,
+                stale_after_seconds=10 * 60,
             )
         )
     except Exception:

--- a/app/services/invest_crypto_naver_adapter/adapter.py
+++ b/app/services/invest_crypto_naver_adapter/adapter.py
@@ -1,0 +1,451 @@
+"""Read-only Naver-style crypto reference adapter for /invest.
+
+The adapter aggregates existing read-only sources and fixture-backed Naver
+reference metadata. It must never submit/cancel/modify orders, mutate watch or
+order-intent state, build/commit screener snapshots, or write production data.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.upbit_symbol_universe import UpbitSymbolUniverse
+from app.schemas.invest_crypto import (
+    CryptoCapabilityFlag,
+    CryptoReferenceSourceMeta,
+    NaverCryptoKimchiPremium,
+    NaverCryptoProfile,
+    NaverCryptoRankItem,
+    NaverCryptoReferenceCapabilities,
+    NaverCryptoReferenceResponse,
+)
+from app.schemas.invest_feed_news import FeedNewsResponse
+from app.services.invest_crypto_naver_adapter.fixtures import NAVER_CRYPTO_REFERENCES
+from app.services.invest_crypto_screener_snapshots.repository import (
+    InvestCryptoScreenerSnapshotsRepository,
+)
+from app.services.invest_view_model.relation_resolver import RelationResolver
+
+RankProvider = Callable[[AsyncSession, int], Awaitable[Sequence[Any]] | Sequence[Any]]
+TickerProvider = Callable[[list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]]
+NewsProvider = Callable[
+    [AsyncSession, RelationResolver, str | None, int],
+    Awaitable[FeedNewsResponse | None] | FeedNewsResponse | None,
+]
+KimchiProvider = Callable[[str], Awaitable[dict[str, Any] | list[dict[str, Any]] | None] | dict[str, Any] | list[dict[str, Any]] | None]
+
+
+@dataclass(frozen=True)
+class NaverCryptoReferenceProviders:
+    rank_provider: RankProvider | None = None
+    ticker_provider: TickerProvider | None = None
+    news_provider: NewsProvider | None = None
+    kimchi_provider: KimchiProvider | None = None
+
+
+async def _maybe_await(value: Any) -> Any:
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def normalize_krw_symbol(symbol: str | None) -> str | None:
+    if not symbol:
+        return None
+    normalized = str(symbol).strip().upper().replace("/", "-")
+    if not normalized:
+        return None
+    if normalized.startswith("KRW-"):
+        return normalized
+    if normalized.endswith("-KRW"):
+        return f"KRW-{normalized.rsplit('-', 1)[0]}"
+    return f"KRW-{normalized}"
+
+
+def _base_symbol(symbol: str | None) -> str:
+    normalized = normalize_krw_symbol(symbol) or ""
+    return normalized.split("-", 1)[1] if "-" in normalized else normalized
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError, ArithmeticError):
+        return None
+
+
+def _ticker_map(rows: Sequence[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    mapped: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        market = str(row.get("market") or "").upper()
+        if market:
+            mapped[market] = row
+    return mapped
+
+
+async def _default_rank_provider(db: AsyncSession, limit: int) -> Sequence[Any]:
+    repo = InvestCryptoScreenerSnapshotsRepository(db)
+    return await repo.list_latest(preset_id="crypto_momentum", limit=limit)
+
+
+async def _default_ticker_provider(markets: list[str]) -> list[dict[str, Any]]:
+    from app.services.brokers.upbit.client import fetch_multiple_tickers
+
+    return await fetch_multiple_tickers(markets)
+
+
+async def _default_news_provider(
+    db: AsyncSession,
+    resolver: RelationResolver,
+    symbol: str | None,
+    limit: int,
+) -> FeedNewsResponse | None:
+    from app.services.invest_view_model.feed_news_service import build_feed_news
+
+    symbol_filter = (symbol, "crypto") if symbol else None
+    return await build_feed_news(
+        db=db,
+        resolver=resolver,
+        tab="crypto",
+        limit=max(1, min(limit, 20)),
+        cursor=None,
+        include_quotes=False,
+        symbol_filter=symbol_filter,
+    )
+
+
+async def _default_kimchi_provider(base_symbol: str) -> dict[str, Any] | list[dict[str, Any]] | None:
+    from app.mcp_server.tooling.fundamentals._crypto import handle_get_kimchi_premium
+
+    return await handle_get_kimchi_premium(base_symbol or "BTC")
+
+
+async def _load_universe_fallback(db: AsyncSession, *, limit: int) -> list[UpbitSymbolUniverse]:
+    stmt = (
+        select(UpbitSymbolUniverse)
+        .where(
+            UpbitSymbolUniverse.quote_currency == "KRW",
+            UpbitSymbolUniverse.is_active.is_(True),
+        )
+        .order_by(UpbitSymbolUniverse.market.asc())
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+def _decimal_float(value: Decimal | float | int | str | None) -> float | None:
+    return _float_or_none(value)
+
+
+def _market_from_row(row: Any) -> str | None:
+    return normalize_krw_symbol(getattr(row, "symbol", None) or getattr(row, "market", None))
+
+
+def _name_from_row(row: Any, symbol: str) -> str:
+    fixture = NAVER_CRYPTO_REFERENCES.get(symbol, {})
+    return str(
+        getattr(row, "name", None)
+        or getattr(row, "korean_name", None)
+        or getattr(row, "english_name", None)
+        or fixture.get("displayName")
+        or _base_symbol(symbol)
+    )
+
+
+def _rank_item_from_snapshot(
+    *, rank: int,
+    row: Any,
+    ticker: dict[str, Any] | None,
+) -> NaverCryptoRankItem | None:
+    symbol = _market_from_row(row)
+    if not symbol:
+        return None
+    return NaverCryptoRankItem(
+        rank=rank,
+        symbol=symbol,
+        displayName=_name_from_row(row, symbol),
+        priceKrw=_decimal_float(getattr(row, "latest_close", None))
+        or _float_or_none((ticker or {}).get("trade_price")),
+        changeRate24h=_decimal_float(getattr(row, "change_rate", None))
+        or _float_or_none((ticker or {}).get("signed_change_rate")),
+        tradeAmount24h=_decimal_float(getattr(row, "trade_amount_24h", None))
+        or _float_or_none((ticker or {}).get("acc_trade_price_24h")),
+        rsi=_decimal_float(getattr(row, "rsi", None)),
+        marketWarning=bool(getattr(row, "market_warning", False)),
+        source=str(getattr(row, "source", None) or "tvscreener_upbit"),
+    )
+
+
+def _rank_item_from_universe(
+    *, rank: int,
+    row: UpbitSymbolUniverse,
+    ticker: dict[str, Any] | None,
+) -> NaverCryptoRankItem:
+    symbol = normalize_krw_symbol(row.market) or row.market.upper()
+    return NaverCryptoRankItem(
+        rank=rank,
+        symbol=symbol,
+        displayName=row.korean_name or row.english_name or _base_symbol(symbol),
+        priceKrw=_float_or_none((ticker or {}).get("trade_price")),
+        changeRate24h=_float_or_none((ticker or {}).get("signed_change_rate")),
+        tradeAmount24h=_float_or_none((ticker or {}).get("acc_trade_price_24h")),
+        rsi=None,
+        marketWarning=None,
+        source="upbit_official",
+    )
+
+
+def _build_profile(symbol: str | None, rank: Sequence[NaverCryptoRankItem]) -> NaverCryptoProfile | None:
+    target = normalize_krw_symbol(symbol) if symbol else (rank[0].symbol if rank else None)
+    if target is None:
+        return None
+    fixture = NAVER_CRYPTO_REFERENCES.get(target, {})
+    rank_match = next((item for item in rank if item.symbol == target), None)
+    base = str(fixture.get("baseSymbol") or _base_symbol(target))
+    display_name = str(fixture.get("displayName") or (rank_match.displayName if rank_match else base))
+    notes = list(fixture.get("referenceNotes") or [])
+    if not notes:
+        notes = [
+            "Naver crypto metadata is fixture/reference-only in ROB-234.",
+            "Live prices use Upbit official/public read-model sources where available.",
+        ]
+    return NaverCryptoProfile(
+        symbol=target,
+        baseSymbol=base,
+        displayName=display_name,
+        koreanName=str(fixture.get("koreanName")) if fixture.get("koreanName") else None,
+        englishName=str(fixture.get("englishName")) if fixture.get("englishName") else None,
+        naverUrl=str(fixture.get("naverUrl")) if fixture.get("naverUrl") else None,
+        officialMarket="UPBIT/KRW",
+        referenceNotes=notes,
+    )
+
+
+def _first_kimchi_row(payload: dict[str, Any] | list[dict[str, Any]] | None) -> dict[str, Any] | None:
+    if isinstance(payload, list):
+        return payload[0] if payload else None
+    if isinstance(payload, dict):
+        return payload
+    return None
+
+
+def _build_kimchi(base_symbol: str, payload: dict[str, Any] | list[dict[str, Any]] | None) -> NaverCryptoKimchiPremium:
+    row = _first_kimchi_row(payload)
+    if not row:
+        return NaverCryptoKimchiPremium(
+            baseSymbol=base_symbol,
+            premiumPct=None,
+            domesticPriceKrw=None,
+            overseasPriceKrw=None,
+            state="unavailable",
+            source="mcp_kimchi_premium",
+            caution="김치 프리미엄은 참고용 매크로 지표이며 주문 실행 신호가 아닙니다.",
+        )
+    return NaverCryptoKimchiPremium(
+        baseSymbol=str(row.get("base_symbol") or row.get("symbol") or base_symbol).replace("KRW-", ""),
+        premiumPct=_float_or_none(row.get("premium_pct") or row.get("kimchi_premium") or row.get("premium")),
+        domesticPriceKrw=_float_or_none(row.get("domestic_price_krw") or row.get("upbit_price_krw") or row.get("upbit_price")),
+        overseasPriceKrw=_float_or_none(row.get("overseas_price_krw") or row.get("binance_price_krw") or row.get("global_price_krw")),
+        state="available",
+        source="mcp_kimchi_premium",
+        caution="김치 프리미엄은 참고용 매크로 지표이며 주문 실행 신호가 아닙니다.",
+    )
+
+
+async def build_naver_crypto_reference(
+    *,
+    db: AsyncSession,
+    symbol: str | None = None,
+    limit: int = 20,
+    resolver: RelationResolver | None = None,
+    providers: NaverCryptoReferenceProviders | None = None,
+) -> NaverCryptoReferenceResponse:
+    """Build a partial, source-labeled crypto reference response."""
+
+    now = datetime.now(UTC)
+    limit = max(1, min(int(limit or 20), 50))
+    normalized_symbol = normalize_krw_symbol(symbol)
+    base_symbol = _base_symbol(normalized_symbol) or "BTC"
+    providers = providers or NaverCryptoReferenceProviders()
+    resolver = resolver or RelationResolver()
+    sources: list[CryptoReferenceSourceMeta] = []
+    warnings: list[str] = [
+        "naver_crypto_reference_only",
+        "read_only_no_order_watch_or_broker_mutation",
+    ]
+
+    rank_rows: Sequence[Any] = []
+    rank_provider = providers.rank_provider or _default_rank_provider
+    try:
+        rank_rows = await _maybe_await(rank_provider(db, limit))
+        sources.append(
+            CryptoReferenceSourceMeta(
+                source="tvscreener_upbit",
+                label="Persisted crypto screener snapshots",
+                state="available" if rank_rows else "unavailable",
+                fetchedAt=now if rank_rows else None,
+                freshness="fresh" if rank_rows else "missing",
+            )
+        )
+    except Exception:
+        warnings.append("crypto_rank_snapshot_unavailable")
+        sources.append(
+            CryptoReferenceSourceMeta(
+                source="tvscreener_upbit",
+                label="Persisted crypto screener snapshots",
+                state="error",
+                freshness="missing",
+                errorCode="crypto_rank_snapshot_unavailable",
+            )
+        )
+
+    markets = [_market_from_row(row) for row in rank_rows]
+    markets = [market for market in markets if market]
+    if normalized_symbol and normalized_symbol not in markets:
+        markets.insert(0, normalized_symbol)
+    markets = list(dict.fromkeys(markets))[:limit]
+
+    ticker_rows: list[dict[str, Any]] = []
+    if markets:
+        ticker_provider = providers.ticker_provider or _default_ticker_provider
+        try:
+            ticker_rows = list(await _maybe_await(ticker_provider(markets)))
+            sources.append(
+                CryptoReferenceSourceMeta(
+                    source="upbit_official",
+                    label="Upbit official/public ticker",
+                    state="available" if ticker_rows else "unavailable",
+                    fetchedAt=now if ticker_rows else None,
+                    freshness="fresh" if ticker_rows else "missing",
+                )
+            )
+        except Exception:
+            warnings.append("crypto_ticker_unavailable")
+            sources.append(
+                CryptoReferenceSourceMeta(
+                    source="upbit_official",
+                    label="Upbit official/public ticker",
+                    state="error",
+                    freshness="partial",
+                    errorCode="crypto_ticker_unavailable",
+                )
+            )
+    ticker_by_market = _ticker_map(ticker_rows)
+
+    rank_items: list[NaverCryptoRankItem] = []
+    for index, row in enumerate(rank_rows, start=1):
+        market = _market_from_row(row)
+        item = _rank_item_from_snapshot(rank=index, row=row, ticker=ticker_by_market.get(market or ""))
+        if item:
+            rank_items.append(item)
+
+    if not rank_items:
+        try:
+            universe_rows = await _load_universe_fallback(db, limit=limit)
+            rank_items = [
+                _rank_item_from_universe(
+                    rank=index,
+                    row=row,
+                    ticker=ticker_by_market.get(normalize_krw_symbol(row.market) or row.market.upper()),
+                )
+                for index, row in enumerate(universe_rows, start=1)
+            ]
+            if universe_rows:
+                warnings.append("crypto_rank_snapshot_empty_used_universe_fallback")
+        except Exception:
+            warnings.append("crypto_universe_fallback_unavailable")
+
+    profile = _build_profile(normalized_symbol, rank_items)
+    sources.append(
+        CryptoReferenceSourceMeta(
+            source="naver_reference",
+            label="Naver crypto reference fixture",
+            state="reference_only" if profile else "unavailable",
+            freshness="fixture" if profile else "missing",
+            referenceOnly=True,
+        )
+    )
+
+    news: FeedNewsResponse | None = None
+    news_provider = providers.news_provider or _default_news_provider
+    try:
+        news = await _maybe_await(news_provider(db, resolver, normalized_symbol, min(limit, 20)))
+        sources.append(
+            CryptoReferenceSourceMeta(
+                source="feed_news",
+                label="Persisted crypto news feed",
+                state="available" if news and news.items else "unavailable",
+                fetchedAt=now if news else None,
+                freshness="fresh" if news and news.items else "missing",
+            )
+        )
+        if news and news.meta.warnings:
+            warnings.extend(f"news:{warning}" for warning in news.meta.warnings)
+    except Exception:
+        warnings.append("crypto_news_unavailable")
+        sources.append(
+            CryptoReferenceSourceMeta(
+                source="feed_news",
+                label="Persisted crypto news feed",
+                state="error",
+                freshness="partial",
+                errorCode="crypto_news_unavailable",
+            )
+        )
+
+    kimchi_payload: dict[str, Any] | list[dict[str, Any]] | None = None
+    kimchi_provider = providers.kimchi_provider or _default_kimchi_provider
+    try:
+        kimchi_payload = await _maybe_await(kimchi_provider(base_symbol))
+        sources.append(
+            CryptoReferenceSourceMeta(
+                source="mcp_kimchi_premium",
+                label="Kimchi premium reference",
+                state="available" if _first_kimchi_row(kimchi_payload) else "unavailable",
+                fetchedAt=now if _first_kimchi_row(kimchi_payload) else None,
+                freshness="fresh" if _first_kimchi_row(kimchi_payload) else "missing",
+                referenceOnly=True,
+            )
+        )
+    except Exception:
+        warnings.append("crypto_kimchi_premium_unavailable")
+        sources.append(
+            CryptoReferenceSourceMeta(
+                source="mcp_kimchi_premium",
+                label="Kimchi premium reference",
+                state="error",
+                freshness="partial",
+                errorCode="crypto_kimchi_premium_unavailable",
+                referenceOnly=True,
+            )
+        )
+
+    return NaverCryptoReferenceResponse(
+        asOf=now,
+        symbol=normalized_symbol,
+        rank=rank_items[:limit],
+        profile=profile,
+        news=news,
+        kimchiPremium=_build_kimchi(base_symbol, kimchi_payload),
+        sources=sources,
+        warnings=list(dict.fromkeys(warnings)),
+        capabilities=NaverCryptoReferenceCapabilities(
+            rank=CryptoCapabilityFlag(state="supported" if rank_items else "unavailable"),
+            price=CryptoCapabilityFlag(state="supported" if ticker_rows or rank_items else "unavailable"),
+            profile=CryptoCapabilityFlag(state="reference_only", reason="naver_fixture_reference_only"),
+            news=CryptoCapabilityFlag(state="supported" if news else "unavailable"),
+            kimchiPremium=CryptoCapabilityFlag(state="reference_only", reason="macro_reference_only"),
+            execution=CryptoCapabilityFlag(state="read_only_mvp", reason="no_order_execution_controls"),
+        ),
+    )

--- a/app/services/invest_crypto_naver_adapter/adapter.py
+++ b/app/services/invest_crypto_naver_adapter/adapter.py
@@ -35,20 +35,12 @@ from app.services.invest_crypto_screener_snapshots.repository import (
 from app.services.invest_view_model.relation_resolver import RelationResolver
 
 RankProvider = Callable[[AsyncSession, int], Awaitable[Sequence[Any]] | Sequence[Any]]
-TickerProvider = Callable[
-    [list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]
-]
+TickerProvider = Callable[[list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]]
 NewsProvider = Callable[
     [AsyncSession, RelationResolver, str | None, int],
     Awaitable[FeedNewsResponse | None] | FeedNewsResponse | None,
 ]
-KimchiProvider = Callable[
-    [str],
-    Awaitable[dict[str, Any] | list[dict[str, Any]] | None]
-    | dict[str, Any]
-    | list[dict[str, Any]]
-    | None,
-]
+KimchiProvider = Callable[[str], Awaitable[dict[str, Any] | list[dict[str, Any]] | None] | dict[str, Any] | list[dict[str, Any]] | None]
 
 
 @dataclass(frozen=True)
@@ -141,9 +133,7 @@ def _row_value(row: Any, key: str) -> Any:
     return getattr(row, key, None)
 
 
-def _source_timestamp_from_rows(
-    rows: Sequence[Any], keys: Sequence[str]
-) -> datetime | None:
+def _source_timestamp_from_rows(rows: Sequence[Any], keys: Sequence[str]) -> datetime | None:
     timestamps: list[datetime] = []
     for row in rows:
         for key in keys:
@@ -184,9 +174,7 @@ def _cached_source_meta(
         state="stale" if is_stale else "cached",
         fetchedAt=fetched_at,
         cacheAgeSeconds=age_seconds,
-        freshness="stale"
-        if is_stale
-        else ("fresh" if fetched_at is not None else "partial"),
+        freshness="stale" if is_stale else ("fresh" if fetched_at is not None else "partial"),
     )
 
 
@@ -266,9 +254,7 @@ async def _default_news_provider(
     )
 
 
-async def _default_kimchi_provider(
-    base_symbol: str,
-) -> dict[str, Any] | list[dict[str, Any]] | None:
+async def _default_kimchi_provider(base_symbol: str) -> dict[str, Any] | list[dict[str, Any]] | None:
     """Default kimchi provider intentionally avoids uncached live HTTP.
 
     A caller may inject a live or cached provider; without one the endpoint still
@@ -278,9 +264,7 @@ async def _default_kimchi_provider(
     return None
 
 
-async def _load_universe_fallback(
-    db: AsyncSession, *, limit: int
-) -> list[UpbitSymbolUniverse]:
+async def _load_universe_fallback(db: AsyncSession, *, limit: int) -> list[UpbitSymbolUniverse]:
     stmt = (
         select(UpbitSymbolUniverse)
         .where(
@@ -299,9 +283,7 @@ def _decimal_float(value: Decimal | float | int | str | None) -> float | None:
 
 
 def _market_from_row(row: Any) -> str | None:
-    return normalize_krw_symbol(
-        getattr(row, "symbol", None) or getattr(row, "market", None)
-    )
+    return normalize_krw_symbol(getattr(row, "symbol", None) or getattr(row, "market", None))
 
 
 def _name_from_row(row: Any, symbol: str) -> str:
@@ -316,8 +298,7 @@ def _name_from_row(row: Any, symbol: str) -> str:
 
 
 def _rank_item_from_snapshot(
-    *,
-    rank: int,
+    *, rank: int,
     row: Any,
     ticker: dict[str, Any] | None,
 ) -> NaverCryptoRankItem | None:
@@ -341,8 +322,7 @@ def _rank_item_from_snapshot(
 
 
 def _rank_item_from_universe(
-    *,
-    rank: int,
+    *, rank: int,
     row: UpbitSymbolUniverse,
     ticker: dict[str, Any] | None,
 ) -> NaverCryptoRankItem:
@@ -360,20 +340,14 @@ def _rank_item_from_universe(
     )
 
 
-def _build_profile(
-    symbol: str | None, rank: Sequence[NaverCryptoRankItem]
-) -> NaverCryptoProfile | None:
-    target = (
-        normalize_krw_symbol(symbol) if symbol else (rank[0].symbol if rank else None)
-    )
+def _build_profile(symbol: str | None, rank: Sequence[NaverCryptoRankItem]) -> NaverCryptoProfile | None:
+    target = normalize_krw_symbol(symbol) if symbol else (rank[0].symbol if rank else None)
     if target is None:
         return None
     fixture = NAVER_CRYPTO_REFERENCES.get(target, {})
     rank_match = next((item for item in rank if item.symbol == target), None)
     base = str(fixture.get("baseSymbol") or _base_symbol(target))
-    display_name = str(
-        fixture.get("displayName") or (rank_match.displayName if rank_match else base)
-    )
+    display_name = str(fixture.get("displayName") or (rank_match.displayName if rank_match else base))
     notes = list(fixture.get("referenceNotes") or [])
     if not notes:
         notes = [
@@ -384,21 +358,15 @@ def _build_profile(
         symbol=target,
         baseSymbol=base,
         displayName=display_name,
-        koreanName=str(fixture.get("koreanName"))
-        if fixture.get("koreanName")
-        else None,
-        englishName=str(fixture.get("englishName"))
-        if fixture.get("englishName")
-        else None,
+        koreanName=str(fixture.get("koreanName")) if fixture.get("koreanName") else None,
+        englishName=str(fixture.get("englishName")) if fixture.get("englishName") else None,
         naverUrl=str(fixture.get("naverUrl")) if fixture.get("naverUrl") else None,
         officialMarket="UPBIT/KRW",
         referenceNotes=notes,
     )
 
 
-def _first_kimchi_row(
-    payload: dict[str, Any] | list[dict[str, Any]] | None,
-) -> dict[str, Any] | None:
+def _first_kimchi_row(payload: dict[str, Any] | list[dict[str, Any]] | None) -> dict[str, Any] | None:
     if isinstance(payload, list):
         return payload[0] if payload else None
     if isinstance(payload, dict):
@@ -406,9 +374,7 @@ def _first_kimchi_row(
     return None
 
 
-def _build_kimchi(
-    base_symbol: str, payload: dict[str, Any] | list[dict[str, Any]] | None
-) -> NaverCryptoKimchiPremium:
+def _build_kimchi(base_symbol: str, payload: dict[str, Any] | list[dict[str, Any]] | None) -> NaverCryptoKimchiPremium:
     row = _first_kimchi_row(payload)
     if not row:
         return NaverCryptoKimchiPremium(
@@ -421,22 +387,10 @@ def _build_kimchi(
             caution="김치 프리미엄은 참고용 매크로 지표이며 주문 실행 신호가 아닙니다.",
         )
     return NaverCryptoKimchiPremium(
-        baseSymbol=str(
-            row.get("base_symbol") or row.get("symbol") or base_symbol
-        ).replace("KRW-", ""),
-        premiumPct=_float_or_none(
-            row.get("premium_pct") or row.get("kimchi_premium") or row.get("premium")
-        ),
-        domesticPriceKrw=_float_or_none(
-            row.get("domestic_price_krw")
-            or row.get("upbit_price_krw")
-            or row.get("upbit_price")
-        ),
-        overseasPriceKrw=_float_or_none(
-            row.get("overseas_price_krw")
-            or row.get("binance_price_krw")
-            or row.get("global_price_krw")
-        ),
+        baseSymbol=str(row.get("base_symbol") or row.get("symbol") or base_symbol).replace("KRW-", ""),
+        premiumPct=_float_or_none(row.get("premium_pct") or row.get("kimchi_premium") or row.get("premium")),
+        domesticPriceKrw=_float_or_none(row.get("domestic_price_krw") or row.get("upbit_price_krw") or row.get("upbit_price")),
+        overseasPriceKrw=_float_or_none(row.get("overseas_price_krw") or row.get("binance_price_krw") or row.get("global_price_krw")),
         state="available",
         source="mcp_kimchi_premium",
         caution="김치 프리미엄은 참고용 매크로 지표이며 주문 실행 신호가 아닙니다.",
@@ -506,14 +460,7 @@ async def build_naver_crypto_reference(
             ticker_rows = list(await _maybe_await(ticker_provider(markets)))
             ticker_fetched_at = _source_timestamp_from_rows(
                 ticker_rows,
-                (
-                    "fetched_at",
-                    "fetchedAt",
-                    "cached_at",
-                    "updated_at",
-                    "timestamp",
-                    "trade_timestamp",
-                ),
+                ("fetched_at", "fetchedAt", "cached_at", "updated_at", "timestamp", "trade_timestamp"),
             )
             sources.append(
                 _provider_source_meta(
@@ -541,9 +488,7 @@ async def build_naver_crypto_reference(
     rank_items: list[NaverCryptoRankItem] = []
     for index, row in enumerate(rank_rows, start=1):
         market = _market_from_row(row)
-        item = _rank_item_from_snapshot(
-            rank=index, row=row, ticker=ticker_by_market.get(market or "")
-        )
+        item = _rank_item_from_snapshot(rank=index, row=row, ticker=ticker_by_market.get(market or ""))
         if item:
             rank_items.append(item)
 
@@ -554,9 +499,7 @@ async def build_naver_crypto_reference(
                 _rank_item_from_universe(
                     rank=index,
                     row=row,
-                    ticker=ticker_by_market.get(
-                        normalize_krw_symbol(row.market) or row.market.upper()
-                    ),
+                    ticker=ticker_by_market.get(normalize_krw_symbol(row.market) or row.market.upper()),
                 )
                 for index, row in enumerate(universe_rows, start=1)
             ]
@@ -579,9 +522,7 @@ async def build_naver_crypto_reference(
     news: FeedNewsResponse | None = None
     news_provider = providers.news_provider or _default_news_provider
     try:
-        news = await _maybe_await(
-            news_provider(db, resolver, normalized_symbol, min(limit, 20))
-        )
+        news = await _maybe_await(news_provider(db, resolver, normalized_symbol, min(limit, 20)))
         sources.append(
             _cached_source_meta(
                 source="feed_news",
@@ -647,21 +588,11 @@ async def build_naver_crypto_reference(
         sources=sources,
         warnings=list(dict.fromkeys(warnings)),
         capabilities=NaverCryptoReferenceCapabilities(
-            rank=CryptoCapabilityFlag(
-                state="supported" if rank_items else "unavailable"
-            ),
-            price=CryptoCapabilityFlag(
-                state="supported" if ticker_rows or rank_items else "unavailable"
-            ),
-            profile=CryptoCapabilityFlag(
-                state="reference_only", reason="naver_fixture_reference_only"
-            ),
+            rank=CryptoCapabilityFlag(state="supported" if rank_items else "unavailable"),
+            price=CryptoCapabilityFlag(state="supported" if ticker_rows or rank_items else "unavailable"),
+            profile=CryptoCapabilityFlag(state="reference_only", reason="naver_fixture_reference_only"),
             news=CryptoCapabilityFlag(state="supported" if news else "unavailable"),
-            kimchiPremium=CryptoCapabilityFlag(
-                state="reference_only", reason="macro_reference_only"
-            ),
-            execution=CryptoCapabilityFlag(
-                state="read_only_mvp", reason="no_order_execution_controls"
-            ),
+            kimchiPremium=CryptoCapabilityFlag(state="reference_only", reason="macro_reference_only"),
+            execution=CryptoCapabilityFlag(state="read_only_mvp", reason="no_order_execution_controls"),
         ),
     )

--- a/app/services/invest_crypto_naver_adapter/adapter.py
+++ b/app/services/invest_crypto_naver_adapter/adapter.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import inspect
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from decimal import Decimal
 from typing import Any
 
@@ -35,12 +35,20 @@ from app.services.invest_crypto_screener_snapshots.repository import (
 from app.services.invest_view_model.relation_resolver import RelationResolver
 
 RankProvider = Callable[[AsyncSession, int], Awaitable[Sequence[Any]] | Sequence[Any]]
-TickerProvider = Callable[[list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]]
+TickerProvider = Callable[
+    [list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]
+]
 NewsProvider = Callable[
     [AsyncSession, RelationResolver, str | None, int],
     Awaitable[FeedNewsResponse | None] | FeedNewsResponse | None,
 ]
-KimchiProvider = Callable[[str], Awaitable[dict[str, Any] | list[dict[str, Any]] | None] | dict[str, Any] | list[dict[str, Any]] | None]
+KimchiProvider = Callable[
+    [str],
+    Awaitable[dict[str, Any] | list[dict[str, Any]] | None]
+    | dict[str, Any]
+    | list[dict[str, Any]]
+    | None,
+]
 
 
 @dataclass(frozen=True)
@@ -93,15 +101,149 @@ def _ticker_map(rows: Sequence[dict[str, Any]]) -> dict[str, dict[str, Any]]:
     return mapped
 
 
+_SOURCE_STALE_AFTER_SECONDS = 24 * 60 * 60
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _parse_source_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _as_utc(value)
+    if isinstance(value, date):
+        return datetime(value.year, value.month, value.day, tzinfo=UTC)
+    if isinstance(value, (int, float)):
+        # Upbit ticker timestamps are millisecond epochs. Accept seconds too.
+        seconds = float(value) / 1000 if float(value) > 10_000_000_000 else float(value)
+        try:
+            return datetime.fromtimestamp(seconds, tz=UTC)
+        except (OverflowError, OSError, ValueError):
+            return None
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            return None
+        try:
+            return _as_utc(datetime.fromisoformat(raw.replace("Z", "+00:00")))
+        except ValueError:
+            return None
+    return None
+
+
+def _row_value(row: Any, key: str) -> Any:
+    if isinstance(row, dict):
+        return row.get(key)
+    return getattr(row, key, None)
+
+
+def _source_timestamp_from_rows(
+    rows: Sequence[Any], keys: Sequence[str]
+) -> datetime | None:
+    timestamps: list[datetime] = []
+    for row in rows:
+        for key in keys:
+            parsed = _parse_source_datetime(_row_value(row, key))
+            if parsed is not None:
+                timestamps.append(parsed)
+                break
+    return max(timestamps) if timestamps else None
+
+
+def _cache_age_seconds(*, now: datetime, fetched_at: datetime | None) -> float | None:
+    if fetched_at is None:
+        return None
+    return max(0.0, (now - fetched_at).total_seconds())
+
+
+def _cached_source_meta(
+    *,
+    source: str,
+    label: str,
+    has_data: bool,
+    fetched_at: datetime | None,
+    now: datetime,
+    stale_after_seconds: int = _SOURCE_STALE_AFTER_SECONDS,
+) -> CryptoReferenceSourceMeta:
+    if not has_data:
+        return CryptoReferenceSourceMeta(
+            source=source,
+            label=label,
+            state="unavailable",
+            freshness="missing",
+        )
+    age_seconds = _cache_age_seconds(now=now, fetched_at=fetched_at)
+    is_stale = age_seconds is not None and age_seconds > stale_after_seconds
+    return CryptoReferenceSourceMeta(
+        source=source,
+        label=label,
+        state="stale" if is_stale else "cached",
+        fetchedAt=fetched_at,
+        cacheAgeSeconds=age_seconds,
+        freshness="stale"
+        if is_stale
+        else ("fresh" if fetched_at is not None else "partial"),
+    )
+
+
+def _provider_source_meta(
+    *,
+    source: str,
+    label: str,
+    has_data: bool,
+    fetched_at: datetime | None,
+    now: datetime,
+    reference_only: bool = False,
+    stale_after_seconds: int = _SOURCE_STALE_AFTER_SECONDS,
+) -> CryptoReferenceSourceMeta:
+    if not has_data:
+        return CryptoReferenceSourceMeta(
+            source=source,
+            label=label,
+            state="unavailable",
+            freshness="missing",
+            referenceOnly=reference_only,
+        )
+    if fetched_at is None:
+        return CryptoReferenceSourceMeta(
+            source=source,
+            label=label,
+            state="live",
+            fetchedAt=now,
+            freshness="live",
+            referenceOnly=reference_only,
+        )
+    meta = _cached_source_meta(
+        source=source,
+        label=label,
+        has_data=True,
+        fetched_at=fetched_at,
+        now=now,
+        stale_after_seconds=stale_after_seconds,
+    )
+    if reference_only:
+        return meta.model_copy(update={"referenceOnly": True})
+    return meta
+
+
 async def _default_rank_provider(db: AsyncSession, limit: int) -> Sequence[Any]:
     repo = InvestCryptoScreenerSnapshotsRepository(db)
     return await repo.list_latest(preset_id="crypto_momentum", limit=limit)
 
 
 async def _default_ticker_provider(markets: list[str]) -> list[dict[str, Any]]:
-    from app.services.brokers.upbit.client import fetch_multiple_tickers
+    """Default ticker provider intentionally avoids live request-path HTTP.
 
-    return await fetch_multiple_tickers(markets)
+    The Naver reference endpoint is a read-model/fixture view. Live Upbit ticker
+    fetches are volatile external HTTP and must be injected explicitly by callers
+    that can label them as live data.
+    """
+
+    return []
 
 
 async def _default_news_provider(
@@ -124,13 +266,21 @@ async def _default_news_provider(
     )
 
 
-async def _default_kimchi_provider(base_symbol: str) -> dict[str, Any] | list[dict[str, Any]] | None:
-    from app.mcp_server.tooling.fundamentals._crypto import handle_get_kimchi_premium
+async def _default_kimchi_provider(
+    base_symbol: str,
+) -> dict[str, Any] | list[dict[str, Any]] | None:
+    """Default kimchi provider intentionally avoids uncached live HTTP.
 
-    return await handle_get_kimchi_premium(base_symbol or "BTC")
+    A caller may inject a live or cached provider; without one the endpoint still
+    returns fixture/read-model data and marks kimchi premium unavailable.
+    """
+
+    return None
 
 
-async def _load_universe_fallback(db: AsyncSession, *, limit: int) -> list[UpbitSymbolUniverse]:
+async def _load_universe_fallback(
+    db: AsyncSession, *, limit: int
+) -> list[UpbitSymbolUniverse]:
     stmt = (
         select(UpbitSymbolUniverse)
         .where(
@@ -149,7 +299,9 @@ def _decimal_float(value: Decimal | float | int | str | None) -> float | None:
 
 
 def _market_from_row(row: Any) -> str | None:
-    return normalize_krw_symbol(getattr(row, "symbol", None) or getattr(row, "market", None))
+    return normalize_krw_symbol(
+        getattr(row, "symbol", None) or getattr(row, "market", None)
+    )
 
 
 def _name_from_row(row: Any, symbol: str) -> str:
@@ -164,7 +316,8 @@ def _name_from_row(row: Any, symbol: str) -> str:
 
 
 def _rank_item_from_snapshot(
-    *, rank: int,
+    *,
+    rank: int,
     row: Any,
     ticker: dict[str, Any] | None,
 ) -> NaverCryptoRankItem | None:
@@ -188,7 +341,8 @@ def _rank_item_from_snapshot(
 
 
 def _rank_item_from_universe(
-    *, rank: int,
+    *,
+    rank: int,
     row: UpbitSymbolUniverse,
     ticker: dict[str, Any] | None,
 ) -> NaverCryptoRankItem:
@@ -206,14 +360,20 @@ def _rank_item_from_universe(
     )
 
 
-def _build_profile(symbol: str | None, rank: Sequence[NaverCryptoRankItem]) -> NaverCryptoProfile | None:
-    target = normalize_krw_symbol(symbol) if symbol else (rank[0].symbol if rank else None)
+def _build_profile(
+    symbol: str | None, rank: Sequence[NaverCryptoRankItem]
+) -> NaverCryptoProfile | None:
+    target = (
+        normalize_krw_symbol(symbol) if symbol else (rank[0].symbol if rank else None)
+    )
     if target is None:
         return None
     fixture = NAVER_CRYPTO_REFERENCES.get(target, {})
     rank_match = next((item for item in rank if item.symbol == target), None)
     base = str(fixture.get("baseSymbol") or _base_symbol(target))
-    display_name = str(fixture.get("displayName") or (rank_match.displayName if rank_match else base))
+    display_name = str(
+        fixture.get("displayName") or (rank_match.displayName if rank_match else base)
+    )
     notes = list(fixture.get("referenceNotes") or [])
     if not notes:
         notes = [
@@ -224,15 +384,21 @@ def _build_profile(symbol: str | None, rank: Sequence[NaverCryptoRankItem]) -> N
         symbol=target,
         baseSymbol=base,
         displayName=display_name,
-        koreanName=str(fixture.get("koreanName")) if fixture.get("koreanName") else None,
-        englishName=str(fixture.get("englishName")) if fixture.get("englishName") else None,
+        koreanName=str(fixture.get("koreanName"))
+        if fixture.get("koreanName")
+        else None,
+        englishName=str(fixture.get("englishName"))
+        if fixture.get("englishName")
+        else None,
         naverUrl=str(fixture.get("naverUrl")) if fixture.get("naverUrl") else None,
         officialMarket="UPBIT/KRW",
         referenceNotes=notes,
     )
 
 
-def _first_kimchi_row(payload: dict[str, Any] | list[dict[str, Any]] | None) -> dict[str, Any] | None:
+def _first_kimchi_row(
+    payload: dict[str, Any] | list[dict[str, Any]] | None,
+) -> dict[str, Any] | None:
     if isinstance(payload, list):
         return payload[0] if payload else None
     if isinstance(payload, dict):
@@ -240,7 +406,9 @@ def _first_kimchi_row(payload: dict[str, Any] | list[dict[str, Any]] | None) -> 
     return None
 
 
-def _build_kimchi(base_symbol: str, payload: dict[str, Any] | list[dict[str, Any]] | None) -> NaverCryptoKimchiPremium:
+def _build_kimchi(
+    base_symbol: str, payload: dict[str, Any] | list[dict[str, Any]] | None
+) -> NaverCryptoKimchiPremium:
     row = _first_kimchi_row(payload)
     if not row:
         return NaverCryptoKimchiPremium(
@@ -253,10 +421,22 @@ def _build_kimchi(base_symbol: str, payload: dict[str, Any] | list[dict[str, Any
             caution="김치 프리미엄은 참고용 매크로 지표이며 주문 실행 신호가 아닙니다.",
         )
     return NaverCryptoKimchiPremium(
-        baseSymbol=str(row.get("base_symbol") or row.get("symbol") or base_symbol).replace("KRW-", ""),
-        premiumPct=_float_or_none(row.get("premium_pct") or row.get("kimchi_premium") or row.get("premium")),
-        domesticPriceKrw=_float_or_none(row.get("domestic_price_krw") or row.get("upbit_price_krw") or row.get("upbit_price")),
-        overseasPriceKrw=_float_or_none(row.get("overseas_price_krw") or row.get("binance_price_krw") or row.get("global_price_krw")),
+        baseSymbol=str(
+            row.get("base_symbol") or row.get("symbol") or base_symbol
+        ).replace("KRW-", ""),
+        premiumPct=_float_or_none(
+            row.get("premium_pct") or row.get("kimchi_premium") or row.get("premium")
+        ),
+        domesticPriceKrw=_float_or_none(
+            row.get("domestic_price_krw")
+            or row.get("upbit_price_krw")
+            or row.get("upbit_price")
+        ),
+        overseasPriceKrw=_float_or_none(
+            row.get("overseas_price_krw")
+            or row.get("binance_price_krw")
+            or row.get("global_price_krw")
+        ),
         state="available",
         source="mcp_kimchi_premium",
         caution="김치 프리미엄은 참고용 매크로 지표이며 주문 실행 신호가 아닙니다.",
@@ -289,13 +469,16 @@ async def build_naver_crypto_reference(
     rank_provider = providers.rank_provider or _default_rank_provider
     try:
         rank_rows = await _maybe_await(rank_provider(db, limit))
+        rank_fetched_at = _source_timestamp_from_rows(
+            rank_rows, ("computed_at", "updated_at", "created_at", "snapshot_date")
+        )
         sources.append(
-            CryptoReferenceSourceMeta(
+            _cached_source_meta(
                 source="tvscreener_upbit",
                 label="Persisted crypto screener snapshots",
-                state="available" if rank_rows else "unavailable",
-                fetchedAt=now if rank_rows else None,
-                freshness="fresh" if rank_rows else "missing",
+                has_data=bool(rank_rows),
+                fetched_at=rank_fetched_at,
+                now=now,
             )
         )
     except Exception:
@@ -321,13 +504,25 @@ async def build_naver_crypto_reference(
         ticker_provider = providers.ticker_provider or _default_ticker_provider
         try:
             ticker_rows = list(await _maybe_await(ticker_provider(markets)))
+            ticker_fetched_at = _source_timestamp_from_rows(
+                ticker_rows,
+                (
+                    "fetched_at",
+                    "fetchedAt",
+                    "cached_at",
+                    "updated_at",
+                    "timestamp",
+                    "trade_timestamp",
+                ),
+            )
             sources.append(
-                CryptoReferenceSourceMeta(
+                _provider_source_meta(
                     source="upbit_official",
                     label="Upbit official/public ticker",
-                    state="available" if ticker_rows else "unavailable",
-                    fetchedAt=now if ticker_rows else None,
-                    freshness="fresh" if ticker_rows else "missing",
+                    has_data=bool(ticker_rows),
+                    fetched_at=ticker_fetched_at,
+                    now=now,
+                    stale_after_seconds=60,
                 )
             )
         except Exception:
@@ -346,7 +541,9 @@ async def build_naver_crypto_reference(
     rank_items: list[NaverCryptoRankItem] = []
     for index, row in enumerate(rank_rows, start=1):
         market = _market_from_row(row)
-        item = _rank_item_from_snapshot(rank=index, row=row, ticker=ticker_by_market.get(market or ""))
+        item = _rank_item_from_snapshot(
+            rank=index, row=row, ticker=ticker_by_market.get(market or "")
+        )
         if item:
             rank_items.append(item)
 
@@ -357,7 +554,9 @@ async def build_naver_crypto_reference(
                 _rank_item_from_universe(
                     rank=index,
                     row=row,
-                    ticker=ticker_by_market.get(normalize_krw_symbol(row.market) or row.market.upper()),
+                    ticker=ticker_by_market.get(
+                        normalize_krw_symbol(row.market) or row.market.upper()
+                    ),
                 )
                 for index, row in enumerate(universe_rows, start=1)
             ]
@@ -371,7 +570,7 @@ async def build_naver_crypto_reference(
         CryptoReferenceSourceMeta(
             source="naver_reference",
             label="Naver crypto reference fixture",
-            state="reference_only" if profile else "unavailable",
+            state="fixture" if profile else "unavailable",
             freshness="fixture" if profile else "missing",
             referenceOnly=True,
         )
@@ -380,14 +579,16 @@ async def build_naver_crypto_reference(
     news: FeedNewsResponse | None = None
     news_provider = providers.news_provider or _default_news_provider
     try:
-        news = await _maybe_await(news_provider(db, resolver, normalized_symbol, min(limit, 20)))
+        news = await _maybe_await(
+            news_provider(db, resolver, normalized_symbol, min(limit, 20))
+        )
         sources.append(
-            CryptoReferenceSourceMeta(
+            _cached_source_meta(
                 source="feed_news",
                 label="Persisted crypto news feed",
-                state="available" if news and news.items else "unavailable",
-                fetchedAt=now if news else None,
-                freshness="fresh" if news and news.items else "missing",
+                has_data=bool(news and news.items),
+                fetched_at=_parse_source_datetime(getattr(news, "asOf", None)),
+                now=now,
             )
         )
         if news and news.meta.warnings:
@@ -408,14 +609,19 @@ async def build_naver_crypto_reference(
     kimchi_provider = providers.kimchi_provider or _default_kimchi_provider
     try:
         kimchi_payload = await _maybe_await(kimchi_provider(base_symbol))
+        kimchi_row = _first_kimchi_row(kimchi_payload)
         sources.append(
-            CryptoReferenceSourceMeta(
+            _provider_source_meta(
                 source="mcp_kimchi_premium",
                 label="Kimchi premium reference",
-                state="available" if _first_kimchi_row(kimchi_payload) else "unavailable",
-                fetchedAt=now if _first_kimchi_row(kimchi_payload) else None,
-                freshness="fresh" if _first_kimchi_row(kimchi_payload) else "missing",
-                referenceOnly=True,
+                has_data=bool(kimchi_row),
+                fetched_at=_source_timestamp_from_rows(
+                    [kimchi_row] if kimchi_row else [],
+                    ("fetched_at", "fetchedAt", "cached_at", "updated_at", "timestamp"),
+                ),
+                now=now,
+                reference_only=True,
+                stale_after_seconds=10 * 60,
             )
         )
     except Exception:
@@ -441,11 +647,21 @@ async def build_naver_crypto_reference(
         sources=sources,
         warnings=list(dict.fromkeys(warnings)),
         capabilities=NaverCryptoReferenceCapabilities(
-            rank=CryptoCapabilityFlag(state="supported" if rank_items else "unavailable"),
-            price=CryptoCapabilityFlag(state="supported" if ticker_rows or rank_items else "unavailable"),
-            profile=CryptoCapabilityFlag(state="reference_only", reason="naver_fixture_reference_only"),
+            rank=CryptoCapabilityFlag(
+                state="supported" if rank_items else "unavailable"
+            ),
+            price=CryptoCapabilityFlag(
+                state="supported" if ticker_rows or rank_items else "unavailable"
+            ),
+            profile=CryptoCapabilityFlag(
+                state="reference_only", reason="naver_fixture_reference_only"
+            ),
             news=CryptoCapabilityFlag(state="supported" if news else "unavailable"),
-            kimchiPremium=CryptoCapabilityFlag(state="reference_only", reason="macro_reference_only"),
-            execution=CryptoCapabilityFlag(state="read_only_mvp", reason="no_order_execution_controls"),
+            kimchiPremium=CryptoCapabilityFlag(
+                state="reference_only", reason="macro_reference_only"
+            ),
+            execution=CryptoCapabilityFlag(
+                state="read_only_mvp", reason="no_order_execution_controls"
+            ),
         ),
     )

--- a/app/services/invest_crypto_naver_adapter/fixtures.py
+++ b/app/services/invest_crypto_naver_adapter/fixtures.py
@@ -7,6 +7,11 @@ side-effect free.
 
 from __future__ import annotations
 
+REFERENCE_ONLY_NOTE = "Naver crypto metadata is fixture/reference-only in ROB-234."
+EXECUTABLE_SOURCE_NOTE = (
+    "Use Upbit official/public read-model prices as the executable source of truth."
+)
+
 NAVER_CRYPTO_REFERENCES: dict[str, dict[str, str | list[str]]] = {
     "KRW-BTC": {
         "baseSymbol": "BTC",
@@ -14,10 +19,7 @@ NAVER_CRYPTO_REFERENCES: dict[str, dict[str, str | list[str]]] = {
         "englishName": "Bitcoin",
         "displayName": "비트코인",
         "naverUrl": "https://m.stock.naver.com/crypto/UPBIT/KRW-BTC",
-        "referenceNotes": [
-            "Naver crypto metadata is fixture/reference-only in ROB-234.",
-            "Use Upbit official/public read-model prices as the executable source of truth.",
-        ],
+        "referenceNotes": [REFERENCE_ONLY_NOTE, EXECUTABLE_SOURCE_NOTE],
     },
     "KRW-ETH": {
         "baseSymbol": "ETH",
@@ -25,10 +27,7 @@ NAVER_CRYPTO_REFERENCES: dict[str, dict[str, str | list[str]]] = {
         "englishName": "Ethereum",
         "displayName": "이더리움",
         "naverUrl": "https://m.stock.naver.com/crypto/UPBIT/KRW-ETH",
-        "referenceNotes": [
-            "Naver crypto metadata is fixture/reference-only in ROB-234.",
-            "Use Upbit official/public read-model prices as the executable source of truth.",
-        ],
+        "referenceNotes": [REFERENCE_ONLY_NOTE, EXECUTABLE_SOURCE_NOTE],
     },
     "KRW-XRP": {
         "baseSymbol": "XRP",
@@ -36,10 +35,7 @@ NAVER_CRYPTO_REFERENCES: dict[str, dict[str, str | list[str]]] = {
         "englishName": "XRP",
         "displayName": "엑스알피",
         "naverUrl": "https://m.stock.naver.com/crypto/UPBIT/KRW-XRP",
-        "referenceNotes": [
-            "Naver crypto metadata is fixture/reference-only in ROB-234.",
-            "Use Upbit official/public read-model prices as the executable source of truth.",
-        ],
+        "referenceNotes": [REFERENCE_ONLY_NOTE, EXECUTABLE_SOURCE_NOTE],
     },
     "KRW-SOL": {
         "baseSymbol": "SOL",
@@ -47,9 +43,6 @@ NAVER_CRYPTO_REFERENCES: dict[str, dict[str, str | list[str]]] = {
         "englishName": "Solana",
         "displayName": "솔라나",
         "naverUrl": "https://m.stock.naver.com/crypto/UPBIT/KRW-SOL",
-        "referenceNotes": [
-            "Naver crypto metadata is fixture/reference-only in ROB-234.",
-            "Use Upbit official/public read-model prices as the executable source of truth.",
-        ],
+        "referenceNotes": [REFERENCE_ONLY_NOTE, EXECUTABLE_SOURCE_NOTE],
     },
 }

--- a/app/services/invest_crypto_naver_adapter/fixtures.py
+++ b/app/services/invest_crypto_naver_adapter/fixtures.py
@@ -1,0 +1,55 @@
+"""Fixture/reference metadata for the read-only Naver crypto adapter.
+
+Naver crypto coverage is intentionally treated as reference-only until a stable,
+allowed upstream endpoint is separately verified. Keep this file deterministic and
+side-effect free.
+"""
+
+from __future__ import annotations
+
+NAVER_CRYPTO_REFERENCES: dict[str, dict[str, str | list[str]]] = {
+    "KRW-BTC": {
+        "baseSymbol": "BTC",
+        "koreanName": "비트코인",
+        "englishName": "Bitcoin",
+        "displayName": "비트코인",
+        "naverUrl": "https://m.stock.naver.com/crypto/UPBIT/KRW-BTC",
+        "referenceNotes": [
+            "Naver crypto metadata is fixture/reference-only in ROB-234.",
+            "Use Upbit official/public read-model prices as the executable source of truth.",
+        ],
+    },
+    "KRW-ETH": {
+        "baseSymbol": "ETH",
+        "koreanName": "이더리움",
+        "englishName": "Ethereum",
+        "displayName": "이더리움",
+        "naverUrl": "https://m.stock.naver.com/crypto/UPBIT/KRW-ETH",
+        "referenceNotes": [
+            "Naver crypto metadata is fixture/reference-only in ROB-234.",
+            "Use Upbit official/public read-model prices as the executable source of truth.",
+        ],
+    },
+    "KRW-XRP": {
+        "baseSymbol": "XRP",
+        "koreanName": "엑스알피",
+        "englishName": "XRP",
+        "displayName": "엑스알피",
+        "naverUrl": "https://m.stock.naver.com/crypto/UPBIT/KRW-XRP",
+        "referenceNotes": [
+            "Naver crypto metadata is fixture/reference-only in ROB-234.",
+            "Use Upbit official/public read-model prices as the executable source of truth.",
+        ],
+    },
+    "KRW-SOL": {
+        "baseSymbol": "SOL",
+        "koreanName": "솔라나",
+        "englishName": "Solana",
+        "displayName": "솔라나",
+        "naverUrl": "https://m.stock.naver.com/crypto/UPBIT/KRW-SOL",
+        "referenceNotes": [
+            "Naver crypto metadata is fixture/reference-only in ROB-234.",
+            "Use Upbit official/public read-model prices as the executable source of truth.",
+        ],
+    },
+}

--- a/app/services/invest_view_model/crypto_dashboard_service.py
+++ b/app/services/invest_view_model/crypto_dashboard_service.py
@@ -249,7 +249,10 @@ def _candidate_score(
     if card.isWatched:
         score += 35
         reasons.append("watched")
-    if card.changeRate24h is not None and abs(card.changeRate24h) >= ELEVATED_MOMENTUM_ABS_CHANGE:
+    if (
+        card.changeRate24h is not None
+        and abs(card.changeRate24h) >= ELEVATED_MOMENTUM_ABS_CHANGE
+    ):
         score += 25
         reasons.append("momentum")
     if (
@@ -258,7 +261,10 @@ def _candidate_score(
     ):
         score += 20
         reasons.append("liquidity")
-    if card.orderbookSpreadPct is not None and card.orderbookSpreadPct <= THIN_ORDERBOOK_SPREAD_PCT:
+    if (
+        card.orderbookSpreadPct is not None
+        and card.orderbookSpreadPct <= THIN_ORDERBOOK_SPREAD_PCT
+    ):
         score += 10
         reasons.append("spread")
     if card.isHeld:
@@ -292,7 +298,9 @@ def _build_candidate_insights(
     *,
     limit: int = CANDIDATE_MAX_ITEMS,
 ) -> list[CryptoCandidateInsight]:
-    ranked: list[tuple[int, float, str, CryptoMarketCard, list[CryptoCandidateReasonKind], str]] = []
+    ranked: list[
+        tuple[int, float, str, CryptoMarketCard, list[CryptoCandidateReasonKind], str]
+    ] = []
     for card in cards:
         risk = card.risk
         if risk is None or risk.level == "unknown":
@@ -561,7 +569,10 @@ async def build_crypto_dashboard(
                     kind="candidate_watch", label="관심 후보", severity="info"
                 )
             )
-        elif card.changeRate24h is not None and abs(card.changeRate24h) >= ELEVATED_MOMENTUM_ABS_CHANGE:
+        elif (
+            card.changeRate24h is not None
+            and abs(card.changeRate24h) >= ELEVATED_MOMENTUM_ABS_CHANGE
+        ):
             card.badges.append(
                 CryptoRiskBadge(
                     kind="momentum_candidate", label="모멘텀 후보", severity="info"
@@ -573,9 +584,17 @@ async def build_crypto_dashboard(
             badge
             for card in cards
             for badge in card.badges
-            if badge.kind in {"thin_orderbook", "data_unavailable", "high_volatility", "low_liquidity"}
+            if badge.kind
+            in {
+                "thin_orderbook",
+                "data_unavailable",
+                "high_volatility",
+                "low_liquidity",
+            }
         ][:5],
-        notes=["읽기 전용 대시보드입니다. 후보 인사이트는 참고용이며 상태 변경을 실행하지 않습니다."],
+        notes=[
+            "읽기 전용 대시보드입니다. 후보 인사이트는 참고용이며 상태 변경을 실행하지 않습니다."
+        ],
         candidates=candidates,
     )
 

--- a/app/services/invest_view_model/crypto_dashboard_service.py
+++ b/app/services/invest_view_model/crypto_dashboard_service.py
@@ -116,7 +116,7 @@ async def _default_orderbook_spread_provider(
 
 
 async def _load_active_krw_markets(
-    db: AsyncSession, *, limit: int
+    db: AsyncSession, *, limit: int | None = None
 ) -> list[UpbitSymbolUniverse]:
     stmt = (
         select(UpbitSymbolUniverse)
@@ -125,8 +125,9 @@ async def _load_active_krw_markets(
             UpbitSymbolUniverse.is_active.is_(True),
         )
         .order_by(UpbitSymbolUniverse.market.asc())
-        .limit(limit)
     )
+    if limit is not None:
+        stmt = stmt.limit(limit)
     result = await db.execute(stmt)
     return list(result.scalars().all())
 
@@ -339,14 +340,16 @@ async def build_crypto_dashboard(
     limit = max(1, min(limit, 50))
     orderbook_limit = max(0, min(orderbook_limit, limit))
 
-    universe = await _load_active_krw_markets(db, limit=limit)
-    markets = [row.market.upper() for row in universe]
+    # Load the active KRW universe before ticker ranking. The page is a
+    # top-movers/volume view, not an alphabetical slice of active markets.
+    universe = await _load_active_krw_markets(db)
+    all_markets = [row.market.upper() for row in universe]
 
     tickers: dict[str, dict[str, Any]] = {}
-    if markets:
+    if all_markets:
         provider = ticker_provider or _default_ticker_provider
         try:
-            tickers = _ticker_map(await _maybe_await(provider(markets)))
+            tickers = _ticker_map(await _maybe_await(provider(all_markets)))
             sources.append(
                 CryptoSourceState(
                     source="upbit_ticker",
@@ -362,6 +365,15 @@ async def build_crypto_dashboard(
                     source="upbit_ticker", state="unavailable", label="Upbit ticker"
                 )
             )
+
+    def _market_rank(row: UpbitSymbolUniverse) -> tuple[float, float, str]:
+        ticker = tickers.get(row.market.upper(), {})
+        change = abs(_float_or_none(ticker.get("signed_change_rate")) or 0)
+        trade_amount = _float_or_none(ticker.get("acc_trade_price_24h")) or 0
+        return (-change, -trade_amount, row.market.upper())
+
+    ranked_universe = sorted(universe, key=_market_rank)[:limit]
+    markets = [row.market.upper() for row in ranked_universe]
 
     spreads: dict[str, float | None] = {}
     if markets and orderbook_limit > 0:
@@ -391,13 +403,21 @@ async def build_crypto_dashboard(
 
     pending_rows = await _load_pending_orders(db, user_id=user_id, symbols=markets)
     pending_summary = _build_pending_summary(pending_rows)
+    sources.append(
+        CryptoSourceState(
+            source="pending_orders",
+            state="supported",
+            label="Pending orders read model",
+            fetchedAt=now,
+        )
+    )
     pending_by_base = {
         item.baseSymbol for item in pending_summary.items if item.baseSymbol
     }
 
     cards: list[CryptoMarketCard] = []
     held_symbols: list[str] = []
-    for row in universe:
+    for row in ranked_universe:
         symbol = row.market.upper()
         base = row.base_currency.upper()
         ticker = tickers.get(symbol, {})
@@ -496,6 +516,22 @@ async def build_crypto_dashboard(
         )
 
     candidates = _build_candidate_insights(cards, pending_by_base)
+    sources.extend(
+        [
+            CryptoSourceState(
+                source="mcp_risk_reference",
+                state="reference_only",
+                label="MCP risk reference",
+                fetchedAt=now,
+            ),
+            CryptoSourceState(
+                source="mcp_candidate_reference",
+                state="reference_only",
+                label="MCP candidate reference",
+                fetchedAt=now,
+            ),
+        ]
+    )
     candidate_symbols = {candidate.symbol for candidate in candidates}
     for card in cards:
         if card.symbol not in candidate_symbols:

--- a/app/services/invest_view_model/crypto_dashboard_service.py
+++ b/app/services/invest_view_model/crypto_dashboard_service.py
@@ -13,6 +13,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.pending_order import PendingOrder
 from app.models.upbit_symbol_universe import UpbitSymbolUniverse
 from app.schemas.invest_crypto import (
+    CryptoCandidateInsight,
+    CryptoCandidateReasonKind,
     CryptoDashboardMeta,
     CryptoDashboardResponse,
     CryptoHoldingSummary,
@@ -21,6 +23,8 @@ from app.schemas.invest_crypto import (
     CryptoPendingOrderItem,
     CryptoPendingOrdersSummary,
     CryptoRiskBadge,
+    CryptoRiskLevel,
+    CryptoRiskSummary,
     CryptoSourceState,
 )
 from app.services.invest_view_model.relation_resolver import RelationResolver
@@ -31,6 +35,14 @@ TickerProvider = Callable[
 OrderbookSpreadProvider = Callable[
     [list[str]], Awaitable[dict[str, float | None]] | dict[str, float | None]
 ]
+
+# Deterministic dashboard heuristics only; these thresholds never trigger orders,
+# watch writes, candidate persistence, or provider-side mutations.
+HIGH_VOLATILITY_ABS_CHANGE = 0.07
+ELEVATED_MOMENTUM_ABS_CHANGE = 0.04
+THIN_ORDERBOOK_SPREAD_PCT = 0.5
+LOW_LIQUIDITY_TRADE_PRICE_KRW = 500_000_000
+CANDIDATE_MAX_ITEMS = 5
 
 
 async def _maybe_await(value):
@@ -168,6 +180,148 @@ def _build_pending_summary(rows: Sequence[PendingOrder]) -> CryptoPendingOrdersS
     )
 
 
+def _risk_level(score: int, *, ticker_available: bool) -> CryptoRiskLevel:
+    if not ticker_available:
+        return "unknown"
+    if score >= 60:
+        return "high"
+    if score >= 30:
+        return "medium"
+    return "low"
+
+
+def _risk_score(
+    *,
+    change_rate: float | None,
+    acc_trade_price_24h: float | None,
+    spread: float | None,
+    ticker_available: bool,
+    has_pending_order: bool,
+) -> tuple[int, list[str]]:
+    score = 0
+    reasons: list[str] = []
+    if not ticker_available:
+        score += 40
+        reasons.append("시세 데이터 없음")
+    if spread is not None and spread > THIN_ORDERBOOK_SPREAD_PCT:
+        score += 25
+        reasons.append("호가 스프레드 확대")
+    if change_rate is not None and abs(change_rate) >= HIGH_VOLATILITY_ABS_CHANGE:
+        score += 25
+        reasons.append("24시간 변동성 확대")
+    if (
+        ticker_available
+        and acc_trade_price_24h is not None
+        and acc_trade_price_24h < LOW_LIQUIDITY_TRADE_PRICE_KRW
+    ):
+        score += 15
+        reasons.append("24시간 거래대금 낮음")
+    if has_pending_order:
+        score += 10
+        reasons.append("미체결 상태 존재")
+    return min(score, 100), reasons
+
+
+def _candidate_score(
+    card: CryptoMarketCard, *, has_pending_order: bool
+) -> tuple[int, list[CryptoCandidateReasonKind], str]:
+    score = 0
+    reasons: list[CryptoCandidateReasonKind] = []
+    if card.isWatched:
+        score += 35
+        reasons.append("watched")
+    if card.changeRate24h is not None and abs(card.changeRate24h) >= ELEVATED_MOMENTUM_ABS_CHANGE:
+        score += 25
+        reasons.append("momentum")
+    if (
+        card.accTradePrice24h is not None
+        and card.accTradePrice24h >= LOW_LIQUIDITY_TRADE_PRICE_KRW
+    ):
+        score += 20
+        reasons.append("liquidity")
+    if card.orderbookSpreadPct is not None and card.orderbookSpreadPct <= THIN_ORDERBOOK_SPREAD_PCT:
+        score += 10
+        reasons.append("spread")
+    if card.isHeld:
+        reasons.append("held")
+    if has_pending_order:
+        score -= 30
+        reasons.append("pending_order")
+    if card.risk and card.risk.level == "high":
+        score -= 20
+    if card.risk and card.risk.level in {"low", "medium"}:
+        reasons.append("data_quality")
+    score = max(0, min(score, 100))
+    summary_parts: list[str] = []
+    if "watched" in reasons:
+        summary_parts.append("기존 검토 목록과 일치")
+    if "momentum" in reasons:
+        summary_parts.append("24시간 변화가 큼")
+    if "liquidity" in reasons:
+        summary_parts.append("거래대금 양호")
+    if "spread" in reasons:
+        summary_parts.append("호가 간격 안정")
+    if "pending_order" in reasons:
+        summary_parts.append("미체결 상태로 감점")
+    summary = " · ".join(summary_parts) or "참고용 검토 후보"
+    return score, reasons, summary
+
+
+def _build_candidate_insights(
+    cards: Sequence[CryptoMarketCard],
+    pending_by_base: set[str],
+    *,
+    limit: int = CANDIDATE_MAX_ITEMS,
+) -> list[CryptoCandidateInsight]:
+    ranked: list[tuple[int, float, str, CryptoMarketCard, list[CryptoCandidateReasonKind], str]] = []
+    for card in cards:
+        risk = card.risk
+        if risk is None or risk.level == "unknown":
+            continue
+        if any(badge.kind == "data_unavailable" for badge in card.badges):
+            continue
+        has_pending_order = card.baseSymbol in pending_by_base
+        score, reasons, summary = _candidate_score(
+            card, has_pending_order=has_pending_order
+        )
+        if score <= 0:
+            continue
+        ranked.append(
+            (
+                score,
+                card.accTradePrice24h or 0,
+                card.symbol,
+                card,
+                reasons,
+                summary,
+            )
+        )
+    ranked.sort(key=lambda item: (-item[0], -item[1], item[2]))
+    candidates: list[CryptoCandidateInsight] = []
+    for rank, (score, _trade_amount, _symbol, card, reasons, summary) in enumerate(
+        ranked[: max(0, limit)], start=1
+    ):
+        risk = card.risk
+        if risk is None:
+            continue
+        candidates.append(
+            CryptoCandidateInsight(
+                symbol=card.symbol,
+                baseSymbol=card.baseSymbol,
+                displayName=card.displayName,
+                rank=rank,
+                score=score,
+                reasons=reasons,
+                summary=summary,
+                isHeld=card.isHeld,
+                isWatched=card.isWatched,
+                hasPendingOrder=card.baseSymbol in pending_by_base,
+                riskLevel=risk.level,
+            )
+        )
+    return candidates
+
+
 async def build_crypto_dashboard(
     *,
     db: AsyncSession,
@@ -269,16 +423,20 @@ async def build_crypto_dashboard(
         if is_held:
             held_symbols.append(symbol)
         badges: list[CryptoRiskBadge] = []
+        has_pending_order = base in pending_by_base
+        change_rate = _float_or_none(ticker.get("signed_change_rate"))
+        acc_trade_price = _float_or_none(ticker.get("acc_trade_price_24h"))
+        ticker_available = symbol in tickers
         if is_held:
             badges.append(CryptoRiskBadge(kind="held", label="보유", severity="info"))
-        if base in pending_by_base:
+        if has_pending_order:
             badges.append(
                 CryptoRiskBadge(
                     kind="pending_order", label="미체결", severity="warning"
                 )
             )
         spread = spreads.get(symbol)
-        if spread is not None and spread > 0.5:
+        if spread is not None and spread > THIN_ORDERBOOK_SPREAD_PCT:
             badges.append(
                 CryptoRiskBadge(
                     kind="thin_orderbook",
@@ -286,37 +444,84 @@ async def build_crypto_dashboard(
                     severity="warning",
                 )
             )
-        if symbol not in tickers:
+        if change_rate is not None and abs(change_rate) >= HIGH_VOLATILITY_ABS_CHANGE:
+            badges.append(
+                CryptoRiskBadge(
+                    kind="high_volatility", label="변동성 주의", severity="warning"
+                )
+            )
+        if (
+            ticker_available
+            and acc_trade_price is not None
+            and acc_trade_price < LOW_LIQUIDITY_TRADE_PRICE_KRW
+        ):
+            badges.append(
+                CryptoRiskBadge(
+                    kind="low_liquidity", label="거래대금 낮음", severity="warning"
+                )
+            )
+        if not ticker_available:
             badges.append(
                 CryptoRiskBadge(
                     kind="data_unavailable", label="시세 없음", severity="warning"
                 )
             )
+        risk_score, risk_reasons = _risk_score(
+            change_rate=change_rate,
+            acc_trade_price_24h=acc_trade_price,
+            spread=spread,
+            ticker_available=ticker_available,
+            has_pending_order=has_pending_order,
+        )
         cards.append(
             CryptoMarketCard(
                 symbol=symbol,
                 baseSymbol=base,
                 displayName=row.korean_name or row.english_name or base,
                 priceKrw=_float_or_none(ticker.get("trade_price")),
-                changeRate24h=_float_or_none(ticker.get("signed_change_rate")),
+                changeRate24h=change_rate,
                 changeAmount24h=_float_or_none(ticker.get("signed_change_price")),
-                accTradePrice24h=_float_or_none(ticker.get("acc_trade_price_24h")),
+                accTradePrice24h=acc_trade_price,
                 volume24h=_float_or_none(ticker.get("acc_trade_volume_24h")),
                 orderbookSpreadPct=spread,
                 isHeld=is_held,
                 isWatched=is_watched,
                 badges=badges,
+                risk=CryptoRiskSummary(
+                    level=_risk_level(risk_score, ticker_available=ticker_available),
+                    score=risk_score,
+                    reasons=risk_reasons,
+                ),
             )
         )
+
+    candidates = _build_candidate_insights(cards, pending_by_base)
+    candidate_symbols = {candidate.symbol for candidate in candidates}
+    for card in cards:
+        if card.symbol not in candidate_symbols:
+            continue
+        if card.isWatched:
+            card.badges.append(
+                CryptoRiskBadge(
+                    kind="candidate_watch", label="관심 후보", severity="info"
+                )
+            )
+        elif card.changeRate24h is not None and abs(card.changeRate24h) >= ELEVATED_MOMENTUM_ABS_CHANGE:
+            card.badges.append(
+                CryptoRiskBadge(
+                    kind="momentum_candidate", label="모멘텀 후보", severity="info"
+                )
+            )
 
     insights = CryptoInsightsSummary(
         badges=[
             badge
             for card in cards
             for badge in card.badges
-            if badge.kind in {"thin_orderbook", "data_unavailable"}
+            if badge.kind in {"thin_orderbook", "data_unavailable", "high_volatility", "low_liquidity"}
         ][:5],
-        notes=["읽기 전용 대시보드입니다. 주문/감시/동기화 작업은 실행하지 않습니다."],
+        notes=["읽기 전용 대시보드입니다. 후보 인사이트는 참고용이며 상태 변경을 실행하지 않습니다."],
+        candidates=candidates,
     )
 
     return CryptoDashboardResponse(

--- a/app/services/invest_view_model/crypto_dashboard_service.py
+++ b/app/services/invest_view_model/crypto_dashboard_service.py
@@ -25,12 +25,8 @@ from app.schemas.invest_crypto import (
 )
 from app.services.invest_view_model.relation_resolver import RelationResolver
 
-TickerProvider = Callable[
-    [list[str]], Awaitable[list[dict[str, Any]]] | list[dict[str, Any]]
-]
-OrderbookSpreadProvider = Callable[
-    [list[str]], Awaitable[dict[str, float | None]] | dict[str, float | None]
-]
+TickerProvider = Callable[[list[str]], Awaitable[Any] | Any]
+OrderbookSpreadProvider = Callable[[list[str]], Awaitable[Any] | Any]
 
 
 async def _maybe_await(value):
@@ -75,32 +71,54 @@ def _pending_symbol_variants(symbols: Sequence[str]) -> set[str]:
     return variants
 
 
-async def _default_ticker_provider(markets: list[str]) -> list[dict[str, Any]]:
-    from app.services.brokers.upbit.client import fetch_multiple_tickers
+async def _default_ticker_provider(markets: list[str]):
+    from app.services.upbit_public_read_model import get_default_read_model
 
-    return await fetch_multiple_tickers(markets)
+    read_model = await get_default_read_model()
+    return await read_model.get_tickers(markets)
 
 
-async def _default_orderbook_spread_provider(
-    markets: list[str],
-) -> dict[str, float | None]:
-    from app.services.upbit_orderbook import fetch_multiple_orderbooks
+async def _default_orderbook_spread_provider(markets: list[str]):
+    from app.services.upbit_public_read_model import get_default_read_model
 
-    spreads: dict[str, float | None] = {}
-    orderbooks = await fetch_multiple_orderbooks(markets)
-    for market, book in orderbooks.items():
-        units = list(book.get("orderbook_units") or [])
-        if not units:
-            spreads[str(market).upper()] = None
-            continue
-        best = units[0]
-        ask = _float_or_none(best.get("ask_price"))
-        bid = _float_or_none(best.get("bid_price"))
-        if ask is None or bid is None or bid <= 0:
-            spreads[str(market).upper()] = None
-            continue
-        spreads[str(market).upper()] = ((ask - bid) / bid) * 100
-    return spreads
+    read_model = await get_default_read_model()
+    return await read_model.get_orderbooks(markets)
+
+
+def _normalize_ticker_provider_result(
+    result: Any,
+) -> tuple[dict[str, dict[str, Any]], Any | None]:
+    if hasattr(result, "tickers") and hasattr(result, "meta"):
+        return dict(result.tickers), result.meta
+    return _ticker_map(result or []), None
+
+
+def _normalize_orderbook_provider_result(
+    result: Any,
+) -> tuple[dict[str, float | None], Any | None]:
+    if hasattr(result, "spreadsPct") and hasattr(result, "meta"):
+        return {
+            str(k).upper(): v for k, v in dict(result.spreadsPct).items()
+        }, result.meta
+    return {str(k).upper(): v for k, v in dict(result or {}).items()}, None
+
+
+def _crypto_source_from_upbit_meta(
+    meta: Any, *, fallback_source: str, fallback_label: str, fetched_at: datetime
+) -> CryptoSourceState:
+    if meta is not None:
+        try:
+            from app.services.upbit_public_read_model import to_crypto_source_state
+
+            return to_crypto_source_state(meta)
+        except Exception:  # noqa: BLE001 - fallback keeps dashboard renderable
+            pass
+    return CryptoSourceState(
+        source=fallback_source,
+        state="supported",
+        label=fallback_label,
+        fetchedAt=fetched_at,
+    )
 
 
 async def _load_active_krw_markets(
@@ -192,13 +210,14 @@ async def build_crypto_dashboard(
     if markets:
         provider = ticker_provider or _default_ticker_provider
         try:
-            tickers = _ticker_map(await _maybe_await(provider(markets)))
+            result = await _maybe_await(provider(markets))
+            tickers, ticker_meta = _normalize_ticker_provider_result(result)
             sources.append(
-                CryptoSourceState(
-                    source="upbit_ticker",
-                    state="supported",
-                    label="Upbit ticker",
-                    fetchedAt=now,
+                _crypto_source_from_upbit_meta(
+                    ticker_meta,
+                    fallback_source="upbit_ticker",
+                    fallback_label="Upbit ticker",
+                    fetched_at=now,
                 )
             )
         except Exception:
@@ -215,14 +234,14 @@ async def build_crypto_dashboard(
             orderbook_spread_provider or _default_orderbook_spread_provider
         )
         try:
-            raw_spreads = await _maybe_await(spread_provider(markets[:orderbook_limit]))
-            spreads = {str(k).upper(): v for k, v in dict(raw_spreads).items()}
+            raw_result = await _maybe_await(spread_provider(markets[:orderbook_limit]))
+            spreads, orderbook_meta = _normalize_orderbook_provider_result(raw_result)
             sources.append(
-                CryptoSourceState(
-                    source="upbit_orderbook",
-                    state="supported",
-                    label="Upbit orderbook",
-                    fetchedAt=now,
+                _crypto_source_from_upbit_meta(
+                    orderbook_meta,
+                    fallback_source="upbit_orderbook",
+                    fallback_label="Upbit orderbook",
+                    fetched_at=now,
                 )
             )
         except Exception:

--- a/app/services/invest_view_model/crypto_preorder_check.py
+++ b/app/services/invest_view_model/crypto_preorder_check.py
@@ -1,0 +1,175 @@
+"""Pure read-only crypto detail pre-order checklist helpers.
+
+The checklist is intentionally informational. It must not persist results or
+produce executable order payloads.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.schemas.invest_crypto import CryptoPendingOrdersSummary
+from app.schemas.invest_stock_detail import (
+    CryptoPreOrderCheckItem,
+    CryptoPreOrderChecklist,
+    CryptoRecentTrades,
+    StockDetailHolding,
+    StockDetailOrderbook,
+    StockDetailQuote,
+)
+
+
+def _spread_pct(orderbook: StockDetailOrderbook | None) -> float | None:
+    if not orderbook or not orderbook.asks or not orderbook.bids:
+        return None
+    ask = orderbook.asks[0].price
+    bid = orderbook.bids[0].price
+    if bid <= 0:
+        return None
+    return ((ask - bid) / bid) * 100
+
+
+def build_crypto_preorder_checklist(
+    *,
+    quote: StockDetailQuote | None,
+    orderbook: StockDetailOrderbook | None,
+    recent_trades: CryptoRecentTrades,
+    holding: StockDetailHolding | None,
+    pending_orders: CryptoPendingOrdersSummary,
+    warnings: list[str] | None = None,
+    computed_at: datetime | None = None,
+) -> CryptoPreOrderChecklist:
+    """Build a non-executable risk summary from already-read data."""
+
+    now = computed_at or datetime.now(UTC)
+    warning_set = set(warnings or [])
+    items: list[CryptoPreOrderCheckItem] = []
+
+    data_unavailable = any(
+        token in warning_set
+        for token in {
+            "crypto_ticker_unavailable",
+            "crypto_orderbook_unavailable",
+            "crypto_recent_trades_unavailable",
+        }
+    )
+    if quote is None or orderbook is None or recent_trades.state == "unavailable":
+        data_unavailable = True
+    items.append(
+        CryptoPreOrderCheckItem(
+            key="data_freshness",
+            label="데이터 신선도",
+            state="warning" if data_unavailable else "ok",
+            detail=(
+                "일부 Upbit 공개 데이터가 없어 참고 신뢰도를 낮춥니다."
+                if data_unavailable
+                else "시세·호가·체결 공개 데이터를 확인했습니다."
+            ),
+            source="upbit_public_reads",
+            computedAt=now,
+        )
+    )
+
+    spread = _spread_pct(orderbook)
+    spread_state = "unavailable"
+    spread_detail = "호가 스프레드를 계산할 수 없습니다."
+    if spread is not None:
+        if spread > 1.0:
+            spread_state = "danger"
+            spread_detail = f"최우선 호가 스프레드가 {spread:.2f}%로 넓습니다."
+        elif spread > 0.5:
+            spread_state = "warning"
+            spread_detail = f"최우선 호가 스프레드가 {spread:.2f}%입니다."
+        else:
+            spread_state = "ok"
+            spread_detail = f"최우선 호가 스프레드가 {spread:.2f}%입니다."
+    items.append(
+        CryptoPreOrderCheckItem(
+            key="orderbook_spread",
+            label="호가 스프레드",
+            state=spread_state,  # type: ignore[arg-type]
+            detail=spread_detail,
+            source="upbit_orderbook",
+            computedAt=now,
+        )
+    )
+
+    move = quote.changeRate if quote else None
+    if move is None:
+        state = "unavailable"
+        detail = "24시간 변동률을 확인할 수 없습니다."
+    elif abs(move) >= 10:
+        state = "warning"
+        detail = f"24시간 변동률이 {move:.2f}%로 큽니다."
+    else:
+        state = "ok"
+        detail = f"24시간 변동률 {move:.2f}%입니다."
+    items.append(
+        CryptoPreOrderCheckItem(
+            key="volatility_24h",
+            label="24시간 변동성",
+            state=state,  # type: ignore[arg-type]
+            detail=detail,
+            source="upbit_ticker",
+            computedAt=now,
+        )
+    )
+
+    has_pending = bool(pending_orders.items)
+    items.append(
+        CryptoPreOrderCheckItem(
+            key="pending_duplicate",
+            label="미체결 중복 확인",
+            state="warning" if has_pending else "ok",
+            detail=(
+                f"같은 코인에 미체결 주문 {len(pending_orders.items)}건이 있습니다."
+                if has_pending
+                else "같은 코인의 미체결 주문이 없습니다."
+            ),
+            source="pending_orders",
+            computedAt=now,
+        )
+    )
+
+    items.append(
+        CryptoPreOrderCheckItem(
+            key="position_exposure",
+            label="보유 노출",
+            state="info" if holding else "ok",
+            detail=(
+                f"현재 보유 수량 {holding.totalQuantity:g}을(를) 표시합니다."
+                if holding
+                else "현재 보유 수량이 없습니다."
+            ),
+            source="invest_home_read_model",
+            computedAt=now,
+        )
+    )
+
+    items.append(
+        CryptoPreOrderCheckItem(
+            key="read_only_guardrail",
+            label="읽기 전용 가드레일",
+            state="info",
+            detail="이 체크리스트는 참고용이며 주문 생성·수정·취소를 실행하지 않습니다.",
+            source="read_only_mvp",
+            computedAt=now,
+        )
+    )
+
+    return CryptoPreOrderChecklist(
+        items=items,
+        sources=sorted(
+            {
+                "upbit_ticker",
+                "upbit_orderbook",
+                "upbit_recent_trades",
+                "pending_orders",
+                "invest_home_read_model",
+                "read_only_mvp",
+            }
+        ),
+    )
+
+
+__all__ = ["build_crypto_preorder_checklist"]

--- a/app/services/invest_view_model/crypto_preorder_check.py
+++ b/app/services/invest_view_model/crypto_preorder_check.py
@@ -29,6 +29,87 @@ def _spread_pct(orderbook: StockDetailOrderbook | None) -> float | None:
     return ((ask - bid) / bid) * 100
 
 
+def _data_freshness_item(
+    *,
+    quote: StockDetailQuote | None,
+    orderbook: StockDetailOrderbook | None,
+    recent_trades: CryptoRecentTrades,
+    warning_set: set[str],
+    computed_at: datetime,
+) -> CryptoPreOrderCheckItem:
+    data_unavailable = any(
+        token in warning_set
+        for token in {
+            "crypto_ticker_unavailable",
+            "crypto_orderbook_unavailable",
+            "crypto_recent_trades_unavailable",
+        }
+    )
+    if quote is None or orderbook is None or recent_trades.state == "unavailable":
+        data_unavailable = True
+    return CryptoPreOrderCheckItem(
+        key="data_freshness",
+        label="데이터 신선도",
+        state="warning" if data_unavailable else "ok",
+        detail=(
+            "일부 Upbit 공개 데이터가 없어 참고 신뢰도를 낮춥니다."
+            if data_unavailable
+            else "시세·호가·체결 공개 데이터를 확인했습니다."
+        ),
+        source="upbit_public_reads",
+        computedAt=computed_at,
+    )
+
+
+def _spread_item(
+    orderbook: StockDetailOrderbook | None, *, computed_at: datetime
+) -> CryptoPreOrderCheckItem:
+    spread = _spread_pct(orderbook)
+    spread_state = "unavailable"
+    spread_detail = "호가 스프레드를 계산할 수 없습니다."
+    if spread is not None:
+        if spread > 1.0:
+            spread_state = "danger"
+            spread_detail = f"최우선 호가 스프레드가 {spread:.2f}%로 넓습니다."
+        elif spread > 0.5:
+            spread_state = "warning"
+            spread_detail = f"최우선 호가 스프레드가 {spread:.2f}%입니다."
+        else:
+            spread_state = "ok"
+            spread_detail = f"최우선 호가 스프레드가 {spread:.2f}%입니다."
+    return CryptoPreOrderCheckItem(
+        key="orderbook_spread",
+        label="호가 스프레드",
+        state=spread_state,  # type: ignore[arg-type]
+        detail=spread_detail,
+        source="upbit_orderbook",
+        computedAt=computed_at,
+    )
+
+
+def _volatility_item(
+    quote: StockDetailQuote | None, *, computed_at: datetime
+) -> CryptoPreOrderCheckItem:
+    move = quote.changeRate if quote else None
+    if move is None:
+        state = "unavailable"
+        detail = "24시간 변동률을 확인할 수 없습니다."
+    elif abs(move) >= 10:
+        state = "warning"
+        detail = f"24시간 변동률이 {move:.2f}%로 큽니다."
+    else:
+        state = "ok"
+        detail = f"24시간 변동률 {move:.2f}%입니다."
+    return CryptoPreOrderCheckItem(
+        key="volatility_24h",
+        label="24시간 변동성",
+        state=state,  # type: ignore[arg-type]
+        detail=detail,
+        source="upbit_ticker",
+        computedAt=computed_at,
+    )
+
+
 def build_crypto_preorder_checklist(
     *,
     quote: StockDetailQuote | None,
@@ -43,77 +124,17 @@ def build_crypto_preorder_checklist(
 
     now = computed_at or datetime.now(UTC)
     warning_set = set(warnings or [])
-    items: list[CryptoPreOrderCheckItem] = []
-
-    data_unavailable = any(
-        token in warning_set
-        for token in {
-            "crypto_ticker_unavailable",
-            "crypto_orderbook_unavailable",
-            "crypto_recent_trades_unavailable",
-        }
-    )
-    if quote is None or orderbook is None or recent_trades.state == "unavailable":
-        data_unavailable = True
-    items.append(
-        CryptoPreOrderCheckItem(
-            key="data_freshness",
-            label="데이터 신선도",
-            state="warning" if data_unavailable else "ok",
-            detail=(
-                "일부 Upbit 공개 데이터가 없어 참고 신뢰도를 낮춥니다."
-                if data_unavailable
-                else "시세·호가·체결 공개 데이터를 확인했습니다."
-            ),
-            source="upbit_public_reads",
-            computedAt=now,
-        )
-    )
-
-    spread = _spread_pct(orderbook)
-    spread_state = "unavailable"
-    spread_detail = "호가 스프레드를 계산할 수 없습니다."
-    if spread is not None:
-        if spread > 1.0:
-            spread_state = "danger"
-            spread_detail = f"최우선 호가 스프레드가 {spread:.2f}%로 넓습니다."
-        elif spread > 0.5:
-            spread_state = "warning"
-            spread_detail = f"최우선 호가 스프레드가 {spread:.2f}%입니다."
-        else:
-            spread_state = "ok"
-            spread_detail = f"최우선 호가 스프레드가 {spread:.2f}%입니다."
-    items.append(
-        CryptoPreOrderCheckItem(
-            key="orderbook_spread",
-            label="호가 스프레드",
-            state=spread_state,  # type: ignore[arg-type]
-            detail=spread_detail,
-            source="upbit_orderbook",
-            computedAt=now,
-        )
-    )
-
-    move = quote.changeRate if quote else None
-    if move is None:
-        state = "unavailable"
-        detail = "24시간 변동률을 확인할 수 없습니다."
-    elif abs(move) >= 10:
-        state = "warning"
-        detail = f"24시간 변동률이 {move:.2f}%로 큽니다."
-    else:
-        state = "ok"
-        detail = f"24시간 변동률 {move:.2f}%입니다."
-    items.append(
-        CryptoPreOrderCheckItem(
-            key="volatility_24h",
-            label="24시간 변동성",
-            state=state,  # type: ignore[arg-type]
-            detail=detail,
-            source="upbit_ticker",
-            computedAt=now,
-        )
-    )
+    items: list[CryptoPreOrderCheckItem] = [
+        _data_freshness_item(
+            quote=quote,
+            orderbook=orderbook,
+            recent_trades=recent_trades,
+            warning_set=warning_set,
+            computed_at=now,
+        ),
+        _spread_item(orderbook, computed_at=now),
+        _volatility_item(quote, computed_at=now),
+    ]
 
     has_pending = bool(pending_orders.items)
     items.append(

--- a/app/services/invest_view_model/screener_service.py
+++ b/app/services/invest_view_model/screener_service.py
@@ -24,10 +24,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.schemas.invest_screener import (
     ChangeDirection,
+    ScreenerCandidateContext,
     ScreenerFreshness,
     ScreenerPresetsResponse,
     ScreenerResultRow,
     ScreenerResultsResponse,
+    ScreenerRiskContext,
+    ScreenerSourceContext,
 )
 from app.services.invest_view_model.screener_presets import (
     CRYPTO_DEFAULT_PRESET_ID,
@@ -104,22 +107,26 @@ def _safe_warning(message: Any) -> str:
     text = _clean_text(message)
     if not text:
         return "스크리너 데이터 소스가 일시적으로 응답하지 않습니다."
+    normalized_text = text.lower()
     noisy_markers = (
-        "HTTPSConnectionPool(",
-        "ConnectionError",
-        "ConnectError",
-        "NameResolutionError",
+        "httpsconnectionpool(",
+        "connectionerror",
+        "connecterror",
+        "nameresolutionerror",
         "nodename nor servname",
-        "Could not resolve host",
+        "could not resolve host",
         "getaddrinfo()",
-        "Max retries exceeded",
+        "max retries exceeded",
         "api.finnhub.io",
+        "api.upbit.com",
+        "upbit",
+        "coingecko",
         "scanner.tradingview.com",
         "query1.finance.yahoo.com",
         "query2.finance.yahoo.com",
         "token=",
     )
-    if any(marker in text for marker in noisy_markers):
+    if any(marker in normalized_text for marker in noisy_markers):
         return "외부 시세/스크리너 데이터 소스 연결이 일시적으로 불안정해 일부 결과를 갱신하지 못했습니다."
     if len(text) > _MAX_WARNING_CHARS:
         return text[: _MAX_WARNING_CHARS - 1].rstrip() + "…"
@@ -402,6 +409,10 @@ async def _load_crypto_rows_from_snapshots(
                 else None,
                 "rsi": float(snap.rsi) if snap.rsi is not None else None,
                 "adx": float(snap.adx) if snap.adx is not None else None,
+                "source": "tvscreener_upbit",
+                "computed_at": snap.computed_at.isoformat()
+                if getattr(snap, "computed_at", None) is not None
+                else None,
                 "_screener_snapshot_state": state,
             }
         )
@@ -520,6 +531,28 @@ def _normalize_symbol(row: dict[str, Any], market: str) -> tuple[str, list[str]]
         return symbol, []
 
     return symbol.upper(), []
+
+
+def _normalize_crypto_symbol(row: dict[str, Any]) -> tuple[str, list[str]]:
+    raw_values = [
+        _clean_text(row.get(key))
+        for key in ("symbol", "original_market", "code", "ticker", "market_code")
+    ]
+    for raw in raw_values:
+        if not raw:
+            continue
+        symbol = raw.upper().replace("/", "-").replace("_", "-")
+        if symbol.startswith("KRW-") and len(symbol) > 4:
+            return symbol, []
+        if symbol.endswith("-KRW") and len(symbol) > 4:
+            return f"KRW-{symbol[:-4]}", []
+        if symbol.startswith("UPBIT:"):
+            pair = symbol.split(":", 1)[1]
+            if pair.endswith("KRW") and len(pair) > 3:
+                return f"KRW-{pair[:-3]}", []
+        if symbol.endswith("KRW") and "-" not in symbol and ":" not in symbol:
+            return f"KRW-{symbol[:-3]}", []
+    return "", ["비KRW 가상자산 행은 제외했습니다."]
 
 
 def _coerce_float(value: Any) -> float | None:
@@ -676,6 +709,180 @@ def _metric_value_label(preset_id: str, row: dict[str, Any]) -> tuple[str, list[
     if field in ("volume", "trade_amount_24h"):
         return f"{int(float(value)):,}", []
     return str(value), []
+
+
+def _source_label(source: str) -> str:
+    return {
+        "snapshot_cache": "스냅샷 캐시",
+        "tvscreener_upbit": "TV Screener Upbit",
+        "mcp_screen_stocks": "MCP screen_stocks",
+        "upbit_official": "Upbit 공식 데이터",
+        "coingecko_reference": "CoinGecko 참고 데이터",
+        "naver_reference": "Naver 참고 데이터",
+        "external_reference": "외부 참고 데이터",
+    }.get(source, source)
+
+
+def _source_context(
+    source: str,
+    *,
+    state: str = "supported",
+    fetched_at: str | None = None,
+    detail: str | None = None,
+) -> ScreenerSourceContext:
+    return ScreenerSourceContext(
+        source=source,  # type: ignore[arg-type]
+        label=_source_label(source),
+        state=state,  # type: ignore[arg-type]
+        fetchedAt=fetched_at,
+        detail=detail,
+    )
+
+
+def _dedupe_sources(
+    sources: Sequence[ScreenerSourceContext],
+) -> list[ScreenerSourceContext]:
+    deduped: list[ScreenerSourceContext] = []
+    seen: set[tuple[str, str]] = set()
+    for source in sources:
+        key = (source.source, source.state)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(source)
+    return deduped
+
+
+def _crypto_row_source_context(
+    row: dict[str, Any], *, snapshot_was_checked: bool, raw: dict[str, Any]
+) -> list[ScreenerSourceContext]:
+    sources: list[ScreenerSourceContext] = []
+    fetched_at = _clean_text(row.get("computed_at") or row.get("fetched_at")) or None
+    if snapshot_was_checked:
+        sources.append(
+            _source_context("snapshot_cache", state="cached", fetched_at=fetched_at)
+        )
+    else:
+        sources.append(_source_context("mcp_screen_stocks", state="fallback"))
+
+    row_source = _clean_text(row.get("source")).lower()
+    meta = raw.get("meta") if isinstance(raw.get("meta"), dict) else {}
+    meta_source = _clean_text(
+        meta.get("source") if isinstance(meta, dict) else ""
+    ).lower()
+    if row_source in {"tvscreener", "tvscreener_upbit"} or meta_source in {
+        "tvscreener",
+        "tvscreener_upbit",
+    }:
+        sources.append(_source_context("tvscreener_upbit"))
+    if row.get("market_warning") is not None or row.get("warning") is not None:
+        sources.append(_source_context("upbit_official"))
+    if row.get("market_cap") is not None or row.get("market_cap_rank") is not None:
+        sources.append(_source_context("coingecko_reference", state="reference_only"))
+    return _dedupe_sources(sources)
+
+
+def _screen_response_sources(
+    *, requested_market: str, snapshot_was_checked: bool, raw: dict[str, Any]
+) -> list[ScreenerSourceContext]:
+    if requested_market != "crypto":
+        return []
+    sample_row: dict[str, Any] = {}
+    rows = raw.get("results") or raw.get("stocks") or []
+    if rows:
+        sample_row = rows[0]
+    sources = _crypto_row_source_context(
+        sample_row, snapshot_was_checked=snapshot_was_checked, raw=raw
+    )
+    meta = raw.get("meta") if isinstance(raw.get("meta"), dict) else {}
+    if isinstance(meta, dict) and meta.get("coingecko_cached"):
+        sources.append(_source_context("coingecko_reference", state="reference_only"))
+    return _dedupe_sources(sources)
+
+
+def _crypto_risk_context(row: dict[str, Any]) -> list[ScreenerRiskContext]:
+    risks: list[ScreenerRiskContext] = []
+    if row.get("market_warning") or row.get("warning"):
+        risks.append(
+            ScreenerRiskContext(
+                kind="market_warning",
+                label="Upbit 유의 종목",
+                severity="warning",
+                source="upbit_official",
+            )
+        )
+    if (
+        _coerce_float(row.get("close") or row.get("price") or row.get("current_price"))
+        is None
+    ):
+        risks.append(
+            ScreenerRiskContext(
+                kind="data_unavailable",
+                label="가격 데이터 준비중",
+                severity="warning",
+            )
+        )
+    rsi = _coerce_float(row.get("rsi"))
+    if rsi is not None and rsi <= 35:
+        risks.append(
+            ScreenerRiskContext(
+                kind="low_rsi",
+                label=f"RSI {rsi:.1f} 저점권",
+                severity="info",
+                source="tvscreener_upbit",
+            )
+        )
+    adx = _coerce_float(row.get("adx"))
+    if adx is not None and adx >= 25:
+        risks.append(
+            ScreenerRiskContext(
+                kind="trend_strength",
+                label=f"ADX {adx:.1f} 추세 강도",
+                severity="info",
+                source="tvscreener_upbit",
+            )
+        )
+    return risks
+
+
+def _crypto_candidate_source(row: dict[str, Any]) -> str:
+    row_source = _clean_text(row.get("source")).lower()
+    if row_source in {"tvscreener", "tvscreener_upbit"}:
+        return "tvscreener_upbit"
+    if row_source in {"upbit", "upbit_official"}:
+        return "upbit_official"
+    if row_source:
+        return "external_reference"
+    return "mcp_screen_stocks"
+
+
+def _crypto_candidate_context(
+    row: dict[str, Any], preset_id: str
+) -> ScreenerCandidateContext | None:
+    reasons: list[str] = []
+    score_label: str | None = None
+    if preset_id == "crypto_high_volume":
+        trade_amount = _coerce_float(_metric_raw_value("trade_amount_24h", row))
+        if trade_amount is not None:
+            score_label = f"거래대금 {int(trade_amount):,}"
+            reasons.append("24시간 KRW 거래대금 상위")
+    elif preset_id == "crypto_oversold":
+        rsi = _coerce_float(row.get("rsi"))
+        if rsi is not None:
+            score_label = f"RSI {rsi:.1f}"
+            reasons.append("RSI 저점권 후보")
+    elif preset_id == "crypto_momentum":
+        change_rate = _coerce_float(row.get("change_rate"))
+        if change_rate is not None:
+            score_label = f"{change_rate:+.2f}%"
+            reasons.append("단기 상승 모멘텀 후보")
+    if not reasons:
+        return None
+    return ScreenerCandidateContext(
+        scoreLabel=score_label,
+        reasons=reasons,
+        source=_crypto_candidate_source(row),  # type: ignore[arg-type]
+    )
 
 
 def _format_relative_korean(delta_seconds: int) -> str:
@@ -886,10 +1093,22 @@ async def build_screener_results(
             )
             _kr_names = {row_t.symbol: row_t.name for row_t in _kr_result.all()}
 
+    response_sources = _screen_response_sources(
+        requested_market=requested_market,
+        snapshot_was_checked=_snapshot_was_checked,
+        raw=raw,
+    )
     results: list[ScreenerResultRow] = []
-    for idx, row in enumerate(rows, start=1):
+    excluded_crypto_rows = 0
+    for row in rows:
         market = _normalize_market(row.get("market") or requested_market)
-        symbol, symbol_warnings = _normalize_symbol(row, market)
+        if market == "crypto":
+            symbol, symbol_warnings = _normalize_crypto_symbol(row)
+            if not symbol:
+                excluded_crypto_rows += 1
+                continue
+        else:
+            symbol, symbol_warnings = _normalize_symbol(row, market)
         market_cap_label, market_cap_warnings = _format_market_cap(row, market)
         change_pct_label, direction = _format_change_pct(row.get("change_rate"))
         _enrich_consecutive_up_days(preset_id, row)
@@ -897,9 +1116,17 @@ async def build_screener_results(
         relation = resolver.relation(market, symbol)
         is_watched = relation in ("watchlist", "both")
         row_warnings = symbol_warnings + market_cap_warnings + metric_warnings
+        source_context = (
+            _crypto_row_source_context(
+                row, snapshot_was_checked=_snapshot_was_checked, raw=raw
+            )
+            if market == "crypto"
+            else []
+        )
+        response_sources = _dedupe_sources([*response_sources, *source_context])
         results.append(
             ScreenerResultRow(
-                rank=idx,
+                rank=len(results) + 1,
                 symbol=symbol,
                 market=market,  # type: ignore[arg-type]
                 name=_kr_names.get(symbol) or _clean_text(row.get("name")) or symbol,
@@ -933,8 +1160,19 @@ async def build_screener_results(
                 analystLabel=str(row.get("analyst_label") or "-"),
                 metricValueLabel=metric_label,
                 warnings=row_warnings,
+                sourceContext=source_context,
+                riskContext=_crypto_risk_context(row) if market == "crypto" else [],
+                candidateContext=_crypto_candidate_context(row, preset_id)
+                if market == "crypto"
+                else None,
             )
         )
+
+    if (
+        excluded_crypto_rows
+        and "비KRW 가상자산 행은 제외했습니다." not in upstream_warnings
+    ):
+        upstream_warnings.append("비KRW 가상자산 행은 제외했습니다.")
 
     return ScreenerResultsResponse(
         presetId=preset.id,
@@ -945,4 +1183,5 @@ async def build_screener_results(
         results=results,
         warnings=upstream_warnings,
         freshness=freshness,
+        sources=response_sources,
     )

--- a/app/services/invest_view_model/stock_detail_orders_service.py
+++ b/app/services/invest_view_model/stock_detail_orders_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -11,6 +13,9 @@ from app.services.invest_view_model.stock_detail_symbol_resolver import (
 )
 
 FilledOrdersFetcher = Callable[[int, list[NewsMarket]], Awaitable[list[dict[str, Any]]]]
+
+logger = logging.getLogger(__name__)
+_FILLED_ORDERS_TIMEOUT_SECONDS = 3
 
 
 def _canonical_order_symbol(market: NewsMarket, symbol: str) -> str:
@@ -55,12 +60,35 @@ async def build_stock_detail_orders(
     days: int = 90,
     limit: int = 30,
     cursor: str | None = None,
+    timeout_seconds: float = _FILLED_ORDERS_TIMEOUT_SECONDS,
 ) -> StockDetailOrdersResponse:
     days_clamped = max(1, min(days, 365))
     limit_clamped = max(1, min(limit, 100))
     offset = max(0, int(cursor or 0))
     canonical = _canonical_order_symbol(market, symbol)
-    rows = await fetcher(days_clamped, [market])
+    warnings: list[str] = []
+    try:
+        rows = await asyncio.wait_for(
+            fetcher(days_clamped, [market]), timeout=timeout_seconds
+        )
+    except TimeoutError:
+        logger.warning(
+            "stock-detail filled-orders fetch timed out: market=%s symbol=%s days=%s",
+            market,
+            symbol,
+            days_clamped,
+        )
+        rows = []
+        warnings.append("filled_orders_timeout")
+    except Exception as exc:
+        logger.warning(
+            "stock-detail filled-orders fetch unavailable: market=%s symbol=%s error=%s",
+            market,
+            symbol,
+            exc,
+        )
+        rows = []
+        warnings.append("filled_orders_unavailable")
     filtered = [row for row in rows if _row_symbol(row, market) == canonical]
     page = filtered[offset : offset + limit_clamped]
     next_offset = offset + limit_clamped
@@ -92,7 +120,7 @@ async def build_stock_detail_orders(
         nextCursor=next_cursor,
         meta={
             "emptyState": "no_filled_orders" if not filtered else None,
-            "warnings": [],
+            "warnings": warnings,
         },
     )
 

--- a/app/services/invest_view_model/stock_detail_orders_service.py
+++ b/app/services/invest_view_model/stock_detail_orders_service.py
@@ -73,19 +73,17 @@ async def build_stock_detail_orders(
         )
     except TimeoutError:
         logger.warning(
-            "stock-detail filled-orders fetch timed out: market=%s symbol=%s days=%s",
+            "stock-detail filled-orders fetch timed out: market=%s days=%s",
             market,
-            symbol,
             days_clamped,
         )
         rows = []
         warnings.append("filled_orders_timeout")
     except Exception as exc:
         logger.warning(
-            "stock-detail filled-orders fetch unavailable: market=%s symbol=%s error=%s",
+            "stock-detail filled-orders fetch unavailable: market=%s error_type=%s",
             market,
-            symbol,
-            exc,
+            type(exc).__name__,
         )
         rows = []
         warnings.append("filled_orders_unavailable")

--- a/app/services/invest_view_model/stock_detail_service.py
+++ b/app/services/invest_view_model/stock_detail_service.py
@@ -7,10 +7,21 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.pending_order import PendingOrder
+from app.schemas.invest_crypto import (
+    CryptoPendingOrderItem,
+    CryptoPendingOrdersSummary,
+    CryptoSourceState,
+)
 from app.schemas.invest_feed_news import NewsMarket
 from app.schemas.invest_stock_detail import (
+    CryptoDetail,
+    CryptoDetailProfile,
+    CryptoRecentTradeItem,
+    CryptoRecentTrades,
     StockDetailDiscussionSignal,
     StockDetailFxScenario,
     StockDetailFxSensitivity,
@@ -20,6 +31,7 @@ from app.schemas.invest_stock_detail import (
     StockDetailInvestorFlowDailyRow,
     StockDetailInvestorFlowPeriodSummary,
     StockDetailLatestAnalysis,
+    StockDetailMeta,
     StockDetailNaverEnrichment,
     StockDetailOrderbook,
     StockDetailQuote,
@@ -28,6 +40,9 @@ from app.schemas.invest_stock_detail import (
     orderbook_support_for_market,
 )
 from app.services.exchange_rate_service import get_usd_krw_quote
+from app.services.invest_view_model.crypto_preorder_check import (
+    build_crypto_preorder_checklist,
+)
 from app.services.invest_view_model.investor_flow_service import (
     latest_items_for_symbols as _latest_investor_flow_items,
 )
@@ -53,6 +68,186 @@ Provider = Callable[..., Awaitable[Any]]
 
 async def _none_provider(*args: Any, **kwargs: Any) -> None:
     return None
+
+
+def _base_crypto_symbol(symbol: str) -> str:
+    normalized = str(symbol or "").upper()
+    if normalized.startswith("KRW-"):
+        return normalized.split("-", 1)[1]
+    if normalized.endswith("-KRW"):
+        return normalized.rsplit("-", 1)[0]
+    return normalized
+
+
+def _pending_symbol_variants(symbol: str) -> set[str]:
+    upper = str(symbol or "").upper()
+    base = _base_crypto_symbol(upper)
+    return {upper, base, f"KRW-{base}", f"{base}-KRW"}
+
+
+def _float_or_none(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_upbit_datetime(value: Any) -> datetime | None:
+    if not value:
+        return None
+    text = str(value)
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+async def _default_quote_provider(
+    market: NewsMarket, symbol: str, db: Any
+) -> StockDetailQuote | None:
+    _ = db
+    if market != "crypto":
+        return None
+    from app.services.brokers.upbit.client import fetch_multiple_tickers
+
+    rows = await fetch_multiple_tickers([symbol])
+    if not rows:
+        return None
+    row = rows[0]
+    price = _float_or_none(row.get("trade_price"))
+    change_amount = _float_or_none(row.get("signed_change_price"))
+    change_rate = _float_or_none(row.get("signed_change_rate"))
+    if change_rate is not None:
+        change_rate *= 100
+    previous_close = (
+        price - change_amount
+        if price is not None and change_amount is not None
+        else None
+    )
+    return StockDetailQuote(
+        price=price,
+        previousClose=previous_close,
+        changeAmount=change_amount,
+        changeRate=change_rate,
+        asOf=datetime.now(UTC),
+        priceState="live" if price is not None else "missing",
+    )
+
+
+async def _default_orderbook_provider(
+    market: NewsMarket, symbol: str, db: Any
+) -> StockDetailOrderbook | None:
+    _ = db
+    if market != "crypto":
+        return None
+    from app.services.upbit_orderbook import fetch_orderbook
+
+    book = await fetch_orderbook(symbol)
+    units = list(book.get("orderbook_units") or [])
+    if not units:
+        return None
+    asks = []
+    bids = []
+    for unit in units[:10]:
+        ask_price = _float_or_none(unit.get("ask_price"))
+        ask_size = _float_or_none(unit.get("ask_size"))
+        bid_price = _float_or_none(unit.get("bid_price"))
+        bid_size = _float_or_none(unit.get("bid_size"))
+        if ask_price is not None and ask_size is not None:
+            asks.append({"price": ask_price, "quantity": ask_size})
+        if bid_price is not None and bid_size is not None:
+            bids.append({"price": bid_price, "quantity": bid_size})
+    if not asks and not bids:
+        return None
+    return StockDetailOrderbook(asOf=datetime.now(UTC), asks=asks, bids=bids)
+
+
+async def _default_recent_trades_provider(
+    market: NewsMarket, symbol: str, db: Any
+) -> CryptoRecentTrades | None:
+    _ = db
+    if market != "crypto":
+        return None
+    import httpx
+
+    url = "https://api.upbit.com/v1/trades/ticks"
+    async with httpx.AsyncClient(timeout=5) as client:
+        response = await client.get(url, params={"market": symbol, "count": 15})
+        response.raise_for_status()
+        rows = response.json()
+    items = []
+    for row in rows or []:
+        price = _float_or_none(row.get("trade_price"))
+        volume = _float_or_none(row.get("trade_volume"))
+        if price is None or volume is None:
+            continue
+        items.append(
+            CryptoRecentTradeItem(
+                tradeTime=_parse_upbit_datetime(
+                    row.get("trade_timestamp") or row.get("trade_date_utc")
+                ),
+                priceKrw=price,
+                volume=volume,
+                side=row.get("ask_bid"),
+                sequentialId=row.get("sequential_id"),
+            )
+        )
+    return CryptoRecentTrades(
+        items=items,
+        emptyState=None if items else "no_recent_trades",
+        state="supported" if items else "empty",
+        asOf=datetime.now(UTC),
+    )
+
+
+async def _default_pending_orders_provider(
+    user_id: int | str, market: NewsMarket, symbol: str, db: Any
+) -> CryptoPendingOrdersSummary | None:
+    if market != "crypto":
+        return None
+    if not hasattr(db, "execute"):
+        return CryptoPendingOrdersSummary(items=[], emptyState="no_pending_orders")
+    variants = _pending_symbol_variants(symbol)
+    stmt = (
+        select(PendingOrder)
+        .where(
+            PendingOrder.user_id == int(user_id),
+            PendingOrder.market == "crypto",
+            PendingOrder.venue == "upbit",
+            PendingOrder.symbol.in_(sorted(variants)),
+            or_(PendingOrder.status == "open", PendingOrder.status == "partial_fill"),
+        )
+        .order_by(PendingOrder.ordered_at.desc().nullslast())
+        .limit(20)
+    )
+    result = await db.execute(stmt)
+    rows = list(result.scalars().all())
+    items = [
+        CryptoPendingOrderItem(
+            orderId=row.broker_order_id,
+            symbol=str(row.symbol).upper(),
+            baseSymbol=_base_crypto_symbol(str(row.symbol)),
+            side=row.side,
+            orderType=row.order_type,
+            price=_float_or_none(row.price),
+            quantity=float(row.quantity or 0),
+            filledQuantity=float(row.filled_quantity or 0),
+            status=row.status,
+            orderedAt=row.ordered_at,
+            updatedAt=row.updated_at,
+        )
+        for row in rows
+    ]
+    return CryptoPendingOrdersSummary(
+        items=items, emptyState=None if items else "no_pending_orders"
+    )
 
 
 def _daily_row_from_snapshot(row: Any) -> StockDetailInvestorFlowDailyRow:
@@ -226,16 +421,18 @@ async def _run_optional_block(
 @dataclass(frozen=True, slots=True)
 class StockDetailProviders:
     resolver: Resolver = resolve_symbol
-    quote: Provider = _none_provider
+    quote: Provider = _default_quote_provider
     screener: Provider = _none_provider
     valuation: Provider = _none_provider
     holding: Provider = _none_provider
     latest_analysis: Provider = _none_provider
-    orderbook: Provider = _none_provider
+    orderbook: Provider = _default_orderbook_provider
     fx_rate: Provider = get_usd_krw_quote
     naver_enrichment: Provider = build_naver_stock_detail_poc
     discussion_signal: Provider = build_naver_discussion_signal_poc
     investor_flow: Provider = _default_investor_flow_provider
+    recent_trades: Provider = _default_recent_trades_provider
+    pending_orders: Provider = _default_pending_orders_provider
 
 
 DEFAULT_STOCK_DETAIL_PROVIDERS = StockDetailProviders()
@@ -291,18 +488,34 @@ async def build_stock_detail(
         providers.discussion_signal(market, resolved.symbol_db, db),
         warnings,
     )
-    if market == "kr":
+    if market in {"kr", "crypto"}:
         orderbook_task = _run_optional_block(
             "orderbook", providers.orderbook(market, resolved.symbol_db, db), warnings
         )
+    else:
+        orderbook_task = _none_provider()
+    if market == "kr":
         investor_flow_task = _run_optional_block(
             "investor_flow",
             providers.investor_flow(market, resolved.symbol_db, db),
             warnings,
         )
     else:
-        orderbook_task = _none_provider()
         investor_flow_task = _none_provider()
+    if market == "crypto":
+        recent_trades_task = _run_optional_block(
+            "crypto_recent_trades",
+            providers.recent_trades(market, resolved.symbol_db, db),
+            warnings,
+        )
+        pending_orders_task = _run_optional_block(
+            "crypto_pending_orders",
+            providers.pending_orders(user_id, market, resolved.symbol_db, db),
+            warnings,
+        )
+    else:
+        recent_trades_task = _none_provider()
+        pending_orders_task = _none_provider()
 
     (
         quote,
@@ -314,6 +527,8 @@ async def build_stock_detail(
         discussion_signal,
         orderbook,
         investor_flow,
+        recent_trades,
+        pending_orders,
     ) = await asyncio.gather(
         quote_task,
         screener_task,
@@ -324,6 +539,8 @@ async def build_stock_detail(
         discussion_signal_task,
         orderbook_task,
         investor_flow_task,
+        recent_trades_task,
+        pending_orders_task,
     )
 
     capabilities = default_capabilities_for_market(market)
@@ -364,6 +581,24 @@ async def build_stock_detail(
         investor_flow, StockDetailInvestorFlow
     ):
         investor_flow = StockDetailInvestorFlow.model_validate(investor_flow)
+    if recent_trades is not None and not isinstance(recent_trades, CryptoRecentTrades):
+        recent_trades = CryptoRecentTrades.model_validate(recent_trades)
+    if pending_orders is not None and not isinstance(
+        pending_orders, CryptoPendingOrdersSummary
+    ):
+        pending_orders = CryptoPendingOrdersSummary.model_validate(pending_orders)
+
+    if market == "crypto" and orderbook is None:
+        orderbook_support = orderbook_support.model_copy(
+            update={"supported": False, "reason": "provider_unavailable"}
+        )
+        capabilities = capabilities.model_copy(
+            update={
+                "orderbook": capabilities.orderbook.model_copy(
+                    update={"supported": False, "reason": "provider_unavailable"}
+                )
+            }
+        )
 
     fx_rate = None
     if _should_fetch_fx_rate(
@@ -378,6 +613,69 @@ async def build_stock_detail(
         holding=holding,
         fx_rate=fx_rate,
     )
+
+    crypto_detail = None
+    if market == "crypto":
+        if recent_trades is None:
+            recent_trades = CryptoRecentTrades(
+                items=[],
+                emptyState="no_recent_trades",
+                state="unavailable",
+                warnings=["crypto_recent_trades_unavailable"],
+            )
+        if pending_orders is None:
+            pending_orders = CryptoPendingOrdersSummary(
+                items=[], emptyState="no_pending_orders"
+            )
+        base_symbol = _base_crypto_symbol(resolved.symbol_db)
+        crypto_sources = [
+            CryptoSourceState(
+                source="upbit_ticker",
+                state="supported" if quote else "unavailable",
+                label="Upbit ticker" if quote else "Upbit ticker unavailable",
+                fetchedAt=datetime.now(UTC),
+            ),
+            CryptoSourceState(
+                source="upbit_orderbook",
+                state="supported" if orderbook else "unavailable",
+                label="Upbit orderbook" if orderbook else "Upbit orderbook unavailable",
+                fetchedAt=datetime.now(UTC),
+            ),
+            CryptoSourceState(
+                source="upbit_recent_trades",
+                state="supported"
+                if recent_trades.state != "unavailable"
+                else "unavailable",
+                label="Upbit recent trades",
+                fetchedAt=recent_trades.asOf,
+            ),
+            CryptoSourceState(
+                source="pending_orders",
+                state="supported",
+                label="Read-only pending orders",
+                fetchedAt=datetime.now(UTC),
+            ),
+        ]
+        crypto_detail = CryptoDetail(
+            profile=CryptoDetailProfile(
+                symbol=resolved.symbol_db,
+                baseSymbol=base_symbol,
+                displayNameKo=resolved.display_name,
+                displayNameEn=base_symbol,
+                asOf=datetime.now(UTC),
+            ),
+            recentTrades=recent_trades,
+            pendingOrders=pending_orders,
+            preOrderChecklist=build_crypto_preorder_checklist(
+                quote=quote,
+                orderbook=orderbook,
+                recent_trades=recent_trades,
+                holding=holding,
+                pending_orders=pending_orders,
+                warnings=warnings,
+            ),
+            sources=crypto_sources,
+        )
 
     return StockDetailResponse(
         symbol=resolved.symbol_db,
@@ -400,7 +698,8 @@ async def build_stock_detail(
         orderbookSupport=orderbook_support,
         orderbook=orderbook,
         capabilities=capabilities,
-        meta={"computedAt": datetime.now(UTC), "warnings": warnings},
+        cryptoDetail=crypto_detail,
+        meta=StockDetailMeta(computedAt=datetime.now(UTC), warnings=warnings),
     )
 
 

--- a/app/services/upbit_public_read_model/__init__.py
+++ b/app/services/upbit_public_read_model/__init__.py
@@ -1,0 +1,35 @@
+"""Public exports for the Upbit official public read-model cache."""
+
+from app.services.upbit_public_read_model.read_model import (
+    UpbitPublicReadModel,
+    get_default_read_model,
+)
+from app.services.upbit_public_read_model.types import (
+    UpbitBlockMeta,
+    UpbitBlockState,
+    UpbitCandlesBlock,
+    UpbitMarketWarningEntry,
+    UpbitMarketWarningsBlock,
+    UpbitOrderbookBlock,
+    UpbitPublicSnapshot,
+    UpbitSource,
+    UpbitTickerBlock,
+    UpbitTradesBlock,
+    to_crypto_source_state,
+)
+
+__all__ = [
+    "UpbitPublicReadModel",
+    "get_default_read_model",
+    "UpbitBlockMeta",
+    "UpbitBlockState",
+    "UpbitCandlesBlock",
+    "UpbitMarketWarningEntry",
+    "UpbitMarketWarningsBlock",
+    "UpbitOrderbookBlock",
+    "UpbitPublicSnapshot",
+    "UpbitSource",
+    "UpbitTickerBlock",
+    "UpbitTradesBlock",
+    "to_crypto_source_state",
+]

--- a/app/services/upbit_public_read_model/__init__.py
+++ b/app/services/upbit_public_read_model/__init__.py
@@ -2,6 +2,7 @@
 
 from app.services.upbit_public_read_model.read_model import (
     UpbitPublicReadModel,
+    close_default_read_model,
     get_default_read_model,
 )
 from app.services.upbit_public_read_model.types import (
@@ -20,6 +21,7 @@ from app.services.upbit_public_read_model.types import (
 
 __all__ = [
     "UpbitPublicReadModel",
+    "close_default_read_model",
     "get_default_read_model",
     "UpbitBlockMeta",
     "UpbitBlockState",

--- a/app/services/upbit_public_read_model/cache_common.py
+++ b/app/services/upbit_public_read_model/cache_common.py
@@ -1,0 +1,67 @@
+"""Internal cache helpers for Upbit public read-model modules."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def cache_enabled() -> bool:
+    return bool(getattr(settings, "upbit_public_read_model_cache_enabled", True))
+
+
+def classify_error(exc: BaseException) -> str:
+    if isinstance(exc, httpx.HTTPStatusError):
+        return "rate_limited" if exc.response.status_code == 429 else "http_error"
+    if isinstance(exc, (httpx.TimeoutException, TimeoutError)):
+        return "timeout"
+    return "unknown"
+
+
+async def read_json(redis_client: Any, key: str) -> dict[str, Any] | None:
+    if not cache_enabled():
+        return None
+    try:
+        raw = await redis_client.get(key)
+    except Exception as exc:  # noqa: BLE001 — cache outage should degrade to miss
+        logger.warning("upbit_public_read_model cache read failed key=%s: %s", key, exc)
+        return None
+    if not raw:
+        return None
+    if isinstance(raw, bytes):
+        raw = raw.decode("utf-8")
+    try:
+        obj = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    for field in ("fetchedAt", "cachedAt"):
+        if obj.get(field):
+            obj[field] = datetime.fromisoformat(obj[field])
+    return obj
+
+
+async def write_json(
+    redis_client: Any, key: str, payload: dict[str, Any], *, ex: int
+) -> None:
+    if not cache_enabled():
+        return
+
+    def default(value: Any) -> str:
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return str(value)
+
+    try:
+        await redis_client.set(key, json.dumps(payload, default=default), ex=ex)
+    except Exception as exc:  # noqa: BLE001 — fresh upstream data is still usable
+        logger.warning(
+            "upbit_public_read_model cache write failed key=%s: %s", key, exc
+        )

--- a/app/services/upbit_public_read_model/candles_cache.py
+++ b/app/services/upbit_public_read_model/candles_cache.py
@@ -1,0 +1,82 @@
+"""Thin Upbit public candles wrapper over the existing closed-candle cache."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, Literal
+
+import pandas as pd
+
+from app.services.upbit_public_read_model.cache_common import classify_error
+from app.services.upbit_public_read_model.types import (
+    UpbitBlockMeta,
+    UpbitCandlesBlock,
+    _now_utc,
+)
+
+Period = Literal["day", "week", "month"]
+
+
+class CandlesCache:
+    def __init__(
+        self,
+        *,
+        closed_candles_getter: Callable[..., Awaitable[pd.DataFrame | None]]
+        | None = None,
+    ) -> None:
+        self._closed_candles_getter = closed_candles_getter
+
+    async def get(
+        self, market: str, *, period: Period, count: int = 30
+    ) -> UpbitCandlesBlock:
+        if period not in {"day", "week", "month"}:
+            raise ValueError("period must be one of: day, week, month")
+        normalized_market = str(market or "").strip().upper()
+        now = _now_utc()
+        try:
+            getter = self._closed_candles_getter
+            if getter is None:
+                from app.services.upbit_ohlcv_cache import get_closed_candles
+
+                getter = get_closed_candles
+            frame = await getter(normalized_market, count=count, period=period)
+            rows = _frame_to_rows(frame)
+            state = "fresh" if rows else "missing"
+            return UpbitCandlesBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_candles",
+                    state=state,
+                    label="Upbit candles",
+                    fetchedAt=now,
+                ),
+                market=normalized_market,
+                period=period,
+                rows=rows,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return UpbitCandlesBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_candles",
+                    state="unavailable",
+                    label="Upbit candles",
+                    errorReason=classify_error(exc),
+                ),
+                market=normalized_market,
+                period=period,
+                rows=[],
+            )
+
+
+def _frame_to_rows(frame: pd.DataFrame | None) -> list[dict[str, Any]]:
+    if frame is None or frame.empty:
+        return []
+    rows: list[dict[str, Any]] = []
+    for _, row in frame.reset_index().iterrows():
+        item: dict[str, Any] = {}
+        for key, value in row.items():
+            if hasattr(value, "isoformat"):
+                item[str(key)] = value.isoformat()
+            else:
+                item[str(key)] = value.item() if hasattr(value, "item") else value
+        rows.append(item)
+    return rows

--- a/app/services/upbit_public_read_model/market_warnings.py
+++ b/app/services/upbit_public_read_model/market_warnings.py
@@ -46,6 +46,29 @@ async def fetch_market_event_details() -> list[dict[str, Any]]:
     return payload
 
 
+def _entries_from_rows(
+    rows: list[UpbitSymbolUniverse],
+) -> dict[str, UpbitMarketWarningEntry]:
+    return {
+        row.market.upper(): UpbitMarketWarningEntry(
+            market=row.market.upper(), warning=(row.market_warning or "NONE")
+        )
+        for row in rows
+    }
+
+
+def _merge_event_details(
+    entries: dict[str, UpbitMarketWarningEntry], details: list[dict[str, Any]]
+) -> dict[str, UpbitMarketWarningEntry]:
+    by_market = {str(item.get("market") or "").upper(): item for item in details}
+    return {
+        market: entry.model_copy(
+            update={"event": by_market.get(market, {}).get("market_event")}
+        )
+        for market, entry in entries.items()
+    }
+
+
 class MarketWarningsService:
     def __init__(
         self,
@@ -66,7 +89,35 @@ class MarketWarningsService:
         db: AsyncSession | None = None,
     ) -> UpbitMarketWarningsBlock:
         requested = {m.upper() for m in markets} if markets else None
+        rows = await self._load_rows(requested=requested, db=db)
+        latest = max((getattr(row, "updated_at", None) for row in rows), default=None)
+        entries = _entries_from_rows(rows)
+        state = "fresh" if entries else "missing"
+        error_reason = None
 
+        if include_event_detail and entries:
+            try:
+                details = await self._get_detail_rows()
+                entries = _merge_event_details(entries, details)
+            except Exception as exc:  # noqa: BLE001
+                state = "stale" if entries else "unavailable"
+                error_reason = classify_error(exc)
+
+        return UpbitMarketWarningsBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_market_warnings",
+                state=state,
+                label="Upbit market warnings (universe)",
+                fetchedAt=latest or _now_utc(),
+                ttlSeconds=WARNINGS_TTL_SECONDS,
+                errorReason=error_reason,
+            ),
+            entries=entries,
+        )
+
+    async def _load_rows(
+        self, *, requested: set[str] | None, db: AsyncSession | None
+    ) -> list[UpbitSymbolUniverse]:
         async def load(session: AsyncSession) -> list[UpbitSymbolUniverse]:
             stmt = select(UpbitSymbolUniverse).where(
                 UpbitSymbolUniverse.quote_currency == "KRW",
@@ -79,44 +130,10 @@ class MarketWarningsService:
             )
             return list(result.scalars().all())
 
-        if db is None:
-            async with self._db_session_factory() as session:
-                rows = await load(session)
-        else:
-            rows = await load(db)
-        latest = max((getattr(row, "updated_at", None) for row in rows), default=None)
-        entries = {
-            row.market.upper(): UpbitMarketWarningEntry(
-                market=row.market.upper(), warning=(row.market_warning or "NONE")
-            )
-            for row in rows
-        }
-        state = "fresh" if entries else "missing"
-        label = "Upbit market warnings (universe)"
-        error_reason = None
-        if include_event_detail and entries:
-            try:
-                details = await self._get_detail_rows()
-                by_market = {
-                    str(item.get("market") or "").upper(): item for item in details
-                }
-                for market, entry in list(entries.items()):
-                    event = by_market.get(market, {}).get("market_event")
-                    entries[market] = entry.model_copy(update={"event": event})
-            except Exception as exc:  # noqa: BLE001
-                state = "stale" if entries else "unavailable"
-                error_reason = classify_error(exc)
-        return UpbitMarketWarningsBlock(
-            meta=UpbitBlockMeta(
-                source="upbit_market_warnings",
-                state=state,
-                label=label,
-                fetchedAt=latest or _now_utc(),
-                ttlSeconds=WARNINGS_TTL_SECONDS,
-                errorReason=error_reason,
-            ),
-            entries=entries,
-        )
+        if db is not None:
+            return await load(db)
+        async with self._db_session_factory() as session:
+            return await load(session)
 
     async def _get_detail_rows(self) -> list[dict[str, Any]]:
         if self._redis is not None:
@@ -139,7 +156,14 @@ class MarketWarningsService:
         return rows
 
 
-async def db_universe_warnings_provider(
-    markets: list[str] | None = None,
-) -> UpbitMarketWarningsBlock:
-    return await MarketWarningsService().get(markets)
+_default_service = MarketWarningsService()
+get_market_warnings = _default_service.get
+db_universe_warnings_provider = _default_service.get
+
+__all__ = [
+    "MarketWarningsProvider",
+    "MarketWarningsService",
+    "db_universe_warnings_provider",
+    "fetch_market_event_details",
+    "get_market_warnings",
+]

--- a/app/services/upbit_public_read_model/market_warnings.py
+++ b/app/services/upbit_public_read_model/market_warnings.py
@@ -1,0 +1,145 @@
+"""Read-only Upbit market-warning read model."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable
+from typing import Any, Protocol
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import AsyncSessionLocal
+from app.models.upbit_symbol_universe import UpbitSymbolUniverse
+from app.services.upbit_public_read_model.cache_common import (
+    classify_error,
+    read_json,
+    write_json,
+)
+from app.services.upbit_public_read_model.types import (
+    WARNINGS_STALE_TOLERANCE_SECONDS,
+    WARNINGS_TTL_SECONDS,
+    UpbitBlockMeta,
+    UpbitMarketWarningEntry,
+    UpbitMarketWarningsBlock,
+    _now_utc,
+)
+
+_UPBIT_MARKET_ALL_URL = "https://api.upbit.com/v1/market/all"
+_WARNINGS_KEY = "upbit:public:read:warnings:v1"
+
+
+class MarketWarningsProvider(Protocol):
+    def __call__(
+        self, markets: list[str] | None = None
+    ) -> Awaitable[UpbitMarketWarningsBlock]: ...
+
+
+async def fetch_market_event_details() -> list[dict[str, Any]]:
+    timeout = httpx.Timeout(10.0)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.get(_UPBIT_MARKET_ALL_URL, params={"isDetails": "true"})
+        response.raise_for_status()
+    payload = response.json()
+    if not isinstance(payload, list):
+        raise ValueError("unexpected Upbit market/all response shape")
+    return payload
+
+
+class MarketWarningsService:
+    def __init__(
+        self,
+        *,
+        redis=None,
+        db_session_factory=AsyncSessionLocal,
+        detail_fetcher=fetch_market_event_details,
+    ) -> None:
+        self._redis = redis
+        self._db_session_factory = db_session_factory
+        self._detail_fetcher = detail_fetcher
+
+    async def get(
+        self,
+        markets: list[str] | None = None,
+        *,
+        include_event_detail: bool = False,
+        db: AsyncSession | None = None,
+    ) -> UpbitMarketWarningsBlock:
+        requested = {m.upper() for m in markets} if markets else None
+
+        async def load(session: AsyncSession) -> list[UpbitSymbolUniverse]:
+            stmt = select(UpbitSymbolUniverse).where(
+                UpbitSymbolUniverse.quote_currency == "KRW",
+                UpbitSymbolUniverse.is_active.is_(True),
+            )
+            if requested:
+                stmt = stmt.where(UpbitSymbolUniverse.market.in_(sorted(requested)))
+            result = await session.execute(
+                stmt.order_by(UpbitSymbolUniverse.market.asc())
+            )
+            return list(result.scalars().all())
+
+        if db is None:
+            async with self._db_session_factory() as session:
+                rows = await load(session)
+        else:
+            rows = await load(db)
+        latest = max((getattr(row, "updated_at", None) for row in rows), default=None)
+        entries = {
+            row.market.upper(): UpbitMarketWarningEntry(
+                market=row.market.upper(), warning=(row.market_warning or "NONE")
+            )
+            for row in rows
+        }
+        state = "fresh" if entries else "missing"
+        label = "Upbit market warnings (universe)"
+        error_reason = None
+        if include_event_detail and entries:
+            try:
+                details = await self._get_detail_rows()
+                by_market = {
+                    str(item.get("market") or "").upper(): item for item in details
+                }
+                for market, entry in list(entries.items()):
+                    event = by_market.get(market, {}).get("market_event")
+                    entries[market] = entry.model_copy(update={"event": event})
+            except Exception as exc:  # noqa: BLE001
+                state = "stale" if entries else "unavailable"
+                error_reason = classify_error(exc)
+        return UpbitMarketWarningsBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_market_warnings",
+                state=state,
+                label=label,
+                fetchedAt=latest or _now_utc(),
+                ttlSeconds=WARNINGS_TTL_SECONDS,
+                errorReason=error_reason,
+            ),
+            entries=entries,
+        )
+
+    async def _get_detail_rows(self) -> list[dict[str, Any]]:
+        if self._redis is not None:
+            cached = await read_json(self._redis, _WARNINGS_KEY)
+            now = _now_utc()
+            if (
+                cached
+                and (now - cached["cachedAt"]).total_seconds() <= WARNINGS_TTL_SECONDS
+            ):
+                return list(cached["rows"])
+        rows = await self._detail_fetcher()
+        if self._redis is not None:
+            now = _now_utc()
+            await write_json(
+                self._redis,
+                _WARNINGS_KEY,
+                {"rows": rows, "fetchedAt": now, "cachedAt": now},
+                ex=WARNINGS_STALE_TOLERANCE_SECONDS,
+            )
+        return rows
+
+
+async def db_universe_warnings_provider(
+    markets: list[str] | None = None,
+) -> UpbitMarketWarningsBlock:
+    return await MarketWarningsService().get(markets)

--- a/app/services/upbit_public_read_model/orderbook_cache.py
+++ b/app/services/upbit_public_read_model/orderbook_cache.py
@@ -1,0 +1,150 @@
+"""Redis-cached Upbit orderbook fetcher with derived spread metadata."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import Any
+
+from app.services.upbit_public_read_model.cache_common import (
+    classify_error,
+    read_json,
+    write_json,
+)
+from app.services.upbit_public_read_model.types import (
+    ORDERBOOK_STALE_TOLERANCE_SECONDS,
+    ORDERBOOK_TTL_SECONDS,
+    UpbitBlockMeta,
+    UpbitOrderbookBlock,
+    _now_utc,
+)
+
+logger = logging.getLogger(__name__)
+OrderbookFetcher = Callable[[list[str]], Awaitable[dict[str, dict[str, Any]]]]
+_NS = "upbit:public:read:orderbook:v1"
+
+
+def _key(market: str) -> str:
+    return f"{_NS}:{market.upper()}"
+
+
+def _float_or_none(value: Any) -> float | None:
+    try:
+        return None if value is None else float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _spread_pct(book: dict[str, Any]) -> float | None:
+    units = list(book.get("orderbook_units") or [])
+    if not units:
+        return None
+    ask = _float_or_none(units[0].get("ask_price"))
+    bid = _float_or_none(units[0].get("bid_price"))
+    if ask is None or bid is None or bid <= 0:
+        return None
+    return ((ask - bid) / bid) * 100
+
+
+class OrderbookCache:
+    def __init__(self, *, redis, fetcher: OrderbookFetcher) -> None:
+        self._redis = redis
+        self._fetcher = fetcher
+
+    async def get(self, markets: list[str]) -> UpbitOrderbookBlock:
+        markets = [str(m).upper() for m in markets if str(m or "").strip()]
+        if not markets:
+            return UpbitOrderbookBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_orderbook", state="missing", label="Upbit orderbook"
+                )
+            )
+        now = _now_utc()
+        cached_by_market = {m: await read_json(self._redis, _key(m)) for m in markets}
+        fresh = {
+            m: c["orderbook"]
+            for m, c in cached_by_market.items()
+            if c and (now - c["cachedAt"]).total_seconds() <= ORDERBOOK_TTL_SECONDS
+        }
+        missing = [m for m in markets if m not in fresh]
+        books = dict(fresh)
+        reason = None
+        state = "fresh"
+        if missing:
+            try:
+                fetched = await self._fetcher(missing)
+                fetched = {str(k).upper(): v for k, v in fetched.items()}
+                for market, book in fetched.items():
+                    await write_json(
+                        self._redis,
+                        _key(market),
+                        {"orderbook": book, "fetchedAt": now, "cachedAt": now},
+                        ex=ORDERBOOK_STALE_TOLERANCE_SECONDS,
+                    )
+                books.update(fetched)
+                unfetched = [m for m in missing if m not in fetched]
+                if unfetched:
+                    reason = "partial_missing"
+                    stale = self._stale_books(cached_by_market, now, markets=unfetched)
+                    books.update(stale)
+                    state = "stale" if books else "unavailable"
+            except Exception as exc:  # noqa: BLE001
+                reason = classify_error(exc)
+                logger.warning("upbit_orderbook_cache fetch failed reason=%s", reason)
+                stale = self._stale_books(cached_by_market, now, markets=missing)
+                books.update(stale)
+                state = "stale" if books else "unavailable"
+        fetched_at = now
+        cached_at = now if books and state == "fresh" else None
+        if state == "stale":
+            cached_vals = [c for c in cached_by_market.values() if c]
+            fetched_at = max((c["fetchedAt"] for c in cached_vals), default=now)
+            cached_at = max((c["cachedAt"] for c in cached_vals), default=None)
+        return self._block(
+            books,
+            state=state,
+            fetched_at=fetched_at if books else None,
+            cached_at=cached_at,
+            error_reason=reason,
+        )
+
+    @staticmethod
+    def _stale_books(
+        cached_by_market: dict[str, dict[str, Any] | None],
+        now: datetime,
+        *,
+        markets: list[str],
+    ) -> dict[str, dict[str, Any]]:
+        requested = set(markets)
+        return {
+            market: cached["orderbook"]
+            for market, cached in cached_by_market.items()
+            if market in requested
+            and cached
+            and (now - cached["cachedAt"]).total_seconds()
+            <= ORDERBOOK_STALE_TOLERANCE_SECONDS
+        }
+
+    def _block(
+        self,
+        books: dict[str, dict[str, Any]],
+        *,
+        state: str,
+        fetched_at: datetime | None,
+        cached_at: datetime | None,
+        error_reason: str | None = None,
+    ) -> UpbitOrderbookBlock:
+        return UpbitOrderbookBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_orderbook",
+                state=state,
+                label="Upbit orderbook",
+                fetchedAt=fetched_at,
+                cachedAt=cached_at,
+                ttlSeconds=ORDERBOOK_TTL_SECONDS,
+                errorReason=error_reason,
+            ),
+            orderbooks=books,
+            spreadsPct={m: _spread_pct(b) for m, b in books.items()},
+        )

--- a/app/services/upbit_public_read_model/orderbook_cache.py
+++ b/app/services/upbit_public_read_model/orderbook_cache.py
@@ -40,8 +40,9 @@ def _spread_pct(book: dict[str, Any]) -> float | None:
     units = list(book.get("orderbook_units") or [])
     if not units:
         return None
-    ask = _float_or_none(units[0].get("ask_price"))
-    bid = _float_or_none(units[0].get("bid_price"))
+    first_unit = units[0]
+    ask = _float_or_none(first_unit.get("ask_price"))
+    bid = _float_or_none(first_unit.get("bid_price"))
     if ask is None or bid is None or bid <= 0:
         return None
     return ((ask - bid) / bid) * 100

--- a/app/services/upbit_public_read_model/orderbook_cache.py
+++ b/app/services/upbit_public_read_model/orderbook_cache.py
@@ -38,9 +38,9 @@ def _float_or_none(value: Any) -> float | None:
 
 def _spread_pct(book: dict[str, Any]) -> float | None:
     units = list(book.get("orderbook_units") or [])
-    if not units:
+    first_unit = next(iter(units), None)
+    if first_unit is None:
         return None
-    first_unit = units[0]
     ask = _float_or_none(first_unit.get("ask_price"))
     bid = _float_or_none(first_unit.get("bid_price"))
     if ask is None or bid is None or bid <= 0:

--- a/app/services/upbit_public_read_model/read_model.py
+++ b/app/services/upbit_public_read_model/read_model.py
@@ -17,6 +17,9 @@ from app.services.upbit_public_read_model.trades_cache import TradesCache
 from app.services.upbit_public_read_model.types import UpbitPublicSnapshot, _now_utc
 
 _TRADES_CONCURRENCY = 4
+_DEFAULT_READ_MODEL: UpbitPublicReadModel | None = None
+_DEFAULT_REDIS_CLIENT: Any | None = None
+_DEFAULT_READ_MODEL_LOCK = asyncio.Lock()
 
 
 class UpbitPublicReadModel:
@@ -83,14 +86,11 @@ class UpbitPublicReadModel:
         )
 
 
-async def get_default_read_model(redis_client=None) -> UpbitPublicReadModel:
+def _build_read_model(redis_client) -> UpbitPublicReadModel:
     from app.services.brokers.upbit.client import fetch_multiple_tickers
     from app.services.brokers.upbit.public_trades import fetch_recent_trades
-    from app.services.ohlcv_cache_common import create_redis_client
     from app.services.upbit_orderbook import fetch_multiple_orderbooks
 
-    if redis_client is None:
-        redis_client = await create_redis_client()
     return UpbitPublicReadModel(
         redis=redis_client,
         ticker_fetcher=fetch_multiple_tickers,
@@ -98,3 +98,35 @@ async def get_default_read_model(redis_client=None) -> UpbitPublicReadModel:
         trades_fetcher=fetch_recent_trades,
         warnings_provider=db_universe_warnings_provider,
     )
+
+
+async def get_default_read_model(redis_client=None) -> UpbitPublicReadModel:
+    """Return the shared default Upbit read model unless a custom client is injected."""
+    if redis_client is not None:
+        return _build_read_model(redis_client)
+
+    global _DEFAULT_READ_MODEL, _DEFAULT_REDIS_CLIENT
+    if _DEFAULT_READ_MODEL is None:
+        async with _DEFAULT_READ_MODEL_LOCK:
+            if _DEFAULT_READ_MODEL is None:
+                from app.services.ohlcv_cache_common import create_redis_client
+
+                _DEFAULT_REDIS_CLIENT = await create_redis_client()
+                _DEFAULT_READ_MODEL = _build_read_model(_DEFAULT_REDIS_CLIENT)
+    return _DEFAULT_READ_MODEL
+
+
+async def close_default_read_model() -> None:
+    """Close and reset the shared default Redis client/read model."""
+    global _DEFAULT_READ_MODEL, _DEFAULT_REDIS_CLIENT
+    redis_client = _DEFAULT_REDIS_CLIENT
+    _DEFAULT_READ_MODEL = None
+    _DEFAULT_REDIS_CLIENT = None
+    if redis_client is None:
+        return
+    close = getattr(redis_client, "aclose", None) or getattr(redis_client, "close", None)
+    if close is None:
+        return
+    result = close()
+    if asyncio.iscoroutine(result):
+        await result

--- a/app/services/upbit_public_read_model/read_model.py
+++ b/app/services/upbit_public_read_model/read_model.py
@@ -1,0 +1,100 @@
+"""Composition root for the Upbit public read-model cache."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any
+
+from app.services.upbit_public_read_model.candles_cache import CandlesCache
+from app.services.upbit_public_read_model.market_warnings import (
+    MarketWarningsProvider,
+    db_universe_warnings_provider,
+)
+from app.services.upbit_public_read_model.orderbook_cache import OrderbookCache
+from app.services.upbit_public_read_model.ticker_cache import TickerCache
+from app.services.upbit_public_read_model.trades_cache import TradesCache
+from app.services.upbit_public_read_model.types import UpbitPublicSnapshot, _now_utc
+
+_TRADES_CONCURRENCY = 4
+
+
+class UpbitPublicReadModel:
+    def __init__(
+        self,
+        *,
+        redis,
+        ticker_fetcher: Callable[[list[str]], Awaitable[list[dict[str, Any]]]],
+        orderbook_fetcher: Callable[[list[str]], Awaitable[dict[str, dict[str, Any]]]],
+        trades_fetcher: Callable[[str, int], Awaitable[list[dict[str, Any]]]],
+        warnings_provider: MarketWarningsProvider = db_universe_warnings_provider,
+    ) -> None:
+        self._ticker = TickerCache(redis=redis, fetcher=ticker_fetcher)
+        self._orderbook = OrderbookCache(redis=redis, fetcher=orderbook_fetcher)
+        self._trades = TradesCache(redis=redis, fetcher=trades_fetcher)
+        self._candles = CandlesCache()
+        self._warnings_provider = warnings_provider
+
+    async def get_tickers(self, markets: Iterable[str]):
+        return await self._ticker.get(list(markets))
+
+    async def get_orderbooks(self, markets: Iterable[str]):
+        return await self._orderbook.get(list(markets))
+
+    async def get_recent_trades(self, market: str, count: int = 50):
+        return await self._trades.get(market, count)
+
+    async def get_candles(self, market: str, *, period, count: int):
+        return await self._candles.get(market, period=period, count=count)
+
+    async def get_market_warnings(self, markets: Iterable[str] | None = None):
+        return await self._warnings_provider(list(markets) if markets else None)
+
+    async def snapshot(
+        self, markets: list[str], *, include_trades_for: list[str] | None = None
+    ) -> UpbitPublicSnapshot:
+        now = _now_utc()
+        ticker, orderbook, warnings = await asyncio.gather(
+            self._ticker.get(markets),
+            self._orderbook.get(markets),
+            self._warnings_provider(markets),
+        )
+        trades_block = None
+        if include_trades_for:
+            sem = asyncio.Semaphore(_TRADES_CONCURRENCY)
+
+            async def one(market: str):
+                async with sem:
+                    return await self._trades.get(market, 50)
+
+            trades_block = TradesCache.merge(
+                await asyncio.gather(*(one(m) for m in include_trades_for))
+            )
+        sources = [ticker.meta, orderbook.meta, warnings.meta]
+        if trades_block is not None:
+            sources.append(trades_block.meta)
+        return UpbitPublicSnapshot(
+            asOf=now,
+            ticker=ticker,
+            orderbook=orderbook,
+            trades=trades_block,
+            marketWarnings=warnings,
+            sources=sources,
+        )
+
+
+async def get_default_read_model(redis_client=None) -> UpbitPublicReadModel:
+    from app.services.brokers.upbit.client import fetch_multiple_tickers
+    from app.services.brokers.upbit.public_trades import fetch_recent_trades
+    from app.services.ohlcv_cache_common import create_redis_client
+    from app.services.upbit_orderbook import fetch_multiple_orderbooks
+
+    if redis_client is None:
+        redis_client = await create_redis_client()
+    return UpbitPublicReadModel(
+        redis=redis_client,
+        ticker_fetcher=fetch_multiple_tickers,
+        orderbook_fetcher=fetch_multiple_orderbooks,
+        trades_fetcher=fetch_recent_trades,
+        warnings_provider=db_universe_warnings_provider,
+    )

--- a/app/services/upbit_public_read_model/read_model.py
+++ b/app/services/upbit_public_read_model/read_model.py
@@ -124,7 +124,9 @@ async def close_default_read_model() -> None:
     _DEFAULT_REDIS_CLIENT = None
     if redis_client is None:
         return
-    close = getattr(redis_client, "aclose", None) or getattr(redis_client, "close", None)
+    close = getattr(redis_client, "aclose", None) or getattr(
+        redis_client, "close", None
+    )
     if close is None:
         return
     result = close()

--- a/app/services/upbit_public_read_model/ticker_cache.py
+++ b/app/services/upbit_public_read_model/ticker_cache.py
@@ -1,0 +1,118 @@
+"""Redis-cached Upbit ticker fetcher with freshness/error envelope."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import Any
+
+from app.services.upbit_public_read_model.cache_common import (
+    classify_error,
+    read_json,
+    write_json,
+)
+from app.services.upbit_public_read_model.types import (
+    TICKER_STALE_TOLERANCE_SECONDS,
+    TICKER_TTL_SECONDS,
+    UpbitBlockMeta,
+    UpbitTickerBlock,
+    _now_utc,
+)
+
+logger = logging.getLogger(__name__)
+TickerFetcher = Callable[[list[str]], Awaitable[list[dict[str, Any]]]]
+_NS = "upbit:public:read:ticker:v1"
+
+
+def _key(markets: list[str]) -> str:
+    digest = hashlib.sha1(
+        ",".join(sorted({m.upper() for m in markets})).encode("utf-8")
+    ).hexdigest()
+    return f"{_NS}:{digest}"
+
+
+class TickerCache:
+    def __init__(self, *, redis, fetcher: TickerFetcher) -> None:
+        self._redis = redis
+        self._fetcher = fetcher
+
+    async def get(self, markets: list[str]) -> UpbitTickerBlock:
+        markets = [str(m).upper() for m in markets if str(m or "").strip()]
+        if not markets:
+            return UpbitTickerBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_ticker", state="missing", label="Upbit ticker"
+                )
+            )
+        key = _key(markets)
+        cached = await read_json(self._redis, key)
+        now = _now_utc()
+        if (
+            cached is not None
+            and (now - cached["cachedAt"]).total_seconds() <= TICKER_TTL_SECONDS
+        ):
+            return self._block(
+                cached["tickers"],
+                state="fresh",
+                fetched_at=cached["fetchedAt"],
+                cached_at=cached["cachedAt"],
+            )
+        try:
+            rows = await self._fetcher(markets)
+            tickers = {
+                str(r.get("market") or "").upper(): r for r in rows if r.get("market")
+            }
+            await write_json(
+                self._redis,
+                key,
+                {"tickers": tickers, "fetchedAt": now, "cachedAt": now},
+                ex=TICKER_STALE_TOLERANCE_SECONDS,
+            )
+            return self._block(tickers, state="fresh", fetched_at=now, cached_at=now)
+        except Exception as exc:  # noqa: BLE001
+            reason = classify_error(exc)
+            logger.warning("upbit_ticker_cache fetch failed reason=%s", reason)
+            if (
+                cached is not None
+                and (now - cached["cachedAt"]).total_seconds()
+                <= TICKER_STALE_TOLERANCE_SECONDS
+            ):
+                return self._block(
+                    cached["tickers"],
+                    state="stale",
+                    fetched_at=cached["fetchedAt"],
+                    cached_at=cached["cachedAt"],
+                    error_reason=reason,
+                )
+            return UpbitTickerBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_ticker",
+                    state="unavailable",
+                    label="Upbit ticker",
+                    errorReason=reason,
+                )
+            )
+
+    def _block(
+        self,
+        tickers: dict[str, dict[str, Any]],
+        *,
+        state: str,
+        fetched_at: datetime,
+        cached_at: datetime | None,
+        error_reason: str | None = None,
+    ) -> UpbitTickerBlock:
+        return UpbitTickerBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_ticker",
+                state=state,
+                label="Upbit ticker",
+                fetchedAt=fetched_at,
+                cachedAt=cached_at,
+                ttlSeconds=TICKER_TTL_SECONDS,
+                errorReason=error_reason,
+            ),
+            tickers=tickers,
+        )

--- a/app/services/upbit_public_read_model/ticker_cache.py
+++ b/app/services/upbit_public_read_model/ticker_cache.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 from collections.abc import Awaitable, Callable
 from datetime import datetime
@@ -27,10 +26,8 @@ _NS = "upbit:public:read:ticker:v1"
 
 
 def _key(markets: list[str]) -> str:
-    digest = hashlib.sha1(
-        ",".join(sorted({m.upper() for m in markets})).encode("utf-8")
-    ).hexdigest()
-    return f"{_NS}:{digest}"
+    normalized = ",".join(sorted({m.upper() for m in markets}))
+    return f"{_NS}:{normalized}"
 
 
 class TickerCache:

--- a/app/services/upbit_public_read_model/trades_cache.py
+++ b/app/services/upbit_public_read_model/trades_cache.py
@@ -1,0 +1,141 @@
+"""Redis-cached Upbit recent trades fetcher."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from datetime import datetime
+from typing import Any
+
+from app.services.upbit_public_read_model.cache_common import (
+    classify_error,
+    read_json,
+    write_json,
+)
+from app.services.upbit_public_read_model.types import (
+    TRADES_STALE_TOLERANCE_SECONDS,
+    TRADES_TTL_SECONDS,
+    UpbitBlockMeta,
+    UpbitTradesBlock,
+    _now_utc,
+)
+
+logger = logging.getLogger(__name__)
+TradesFetcher = Callable[[str, int], Awaitable[list[dict[str, Any]]]]
+_NS = "upbit:public:read:trades:v1"
+_MAX_COUNT = 500
+_STATE_RANK = {"fresh": 0, "missing": 1, "stale": 2, "unavailable": 3}
+
+
+def _key(market: str, count: int) -> str:
+    return f"{_NS}:{market.upper()}:{count}"
+
+
+class TradesCache:
+    def __init__(self, *, redis, fetcher: TradesFetcher) -> None:
+        self._redis = redis
+        self._fetcher = fetcher
+
+    async def get(self, market: str, count: int = 50) -> UpbitTradesBlock:
+        market = str(market or "").strip().upper()
+        count = max(1, min(int(count), _MAX_COUNT))
+        if not market:
+            return UpbitTradesBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_trades", state="missing", label="Upbit trades"
+                )
+            )
+        key = _key(market, count)
+        cached = await read_json(self._redis, key)
+        now = _now_utc()
+        if (
+            cached is not None
+            and (now - cached["cachedAt"]).total_seconds() <= TRADES_TTL_SECONDS
+        ):
+            return self._block(
+                {market: cached["rows"]},
+                state="fresh",
+                fetched_at=cached["fetchedAt"],
+                cached_at=cached["cachedAt"],
+            )
+        try:
+            rows = await self._fetcher(market, count)
+            await write_json(
+                self._redis,
+                key,
+                {"rows": rows, "fetchedAt": now, "cachedAt": now},
+                ex=TRADES_STALE_TOLERANCE_SECONDS,
+            )
+            return self._block(
+                {market: list(rows)}, state="fresh", fetched_at=now, cached_at=now
+            )
+        except Exception as exc:  # noqa: BLE001
+            reason = classify_error(exc)
+            logger.warning("upbit_trades_cache fetch failed reason=%s", reason)
+            if (
+                cached is not None
+                and (now - cached["cachedAt"]).total_seconds()
+                <= TRADES_STALE_TOLERANCE_SECONDS
+            ):
+                return self._block(
+                    {market: cached["rows"]},
+                    state="stale",
+                    fetched_at=cached["fetchedAt"],
+                    cached_at=cached["cachedAt"],
+                    error_reason=reason,
+                )
+            return UpbitTradesBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_trades",
+                    state="unavailable",
+                    label="Upbit trades",
+                    errorReason=reason,
+                )
+            )
+
+    @classmethod
+    def merge(cls, blocks: list[UpbitTradesBlock]) -> UpbitTradesBlock:
+        if not blocks:
+            return UpbitTradesBlock(
+                meta=UpbitBlockMeta(
+                    source="upbit_trades", state="missing", label="Upbit trades"
+                )
+            )
+        worst = max(blocks, key=lambda b: _STATE_RANK[b.meta.state])
+        merged: dict[str, list[dict[str, Any]]] = {}
+        for block in blocks:
+            merged.update(block.trades)
+        return UpbitTradesBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_trades",
+                state=worst.meta.state,
+                label="Upbit trades",
+                fetchedAt=worst.meta.fetchedAt,
+                cachedAt=worst.meta.cachedAt,
+                ttlSeconds=TRADES_TTL_SECONDS,
+                errorReason=worst.meta.errorReason,
+            ),
+            trades=merged,
+        )
+
+    def _block(
+        self,
+        trades: dict[str, list[dict[str, Any]]],
+        *,
+        state: str,
+        fetched_at: datetime,
+        cached_at: datetime | None,
+        error_reason: str | None = None,
+    ) -> UpbitTradesBlock:
+        return UpbitTradesBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_trades",
+                state=state,
+                label="Upbit trades",
+                fetchedAt=fetched_at,
+                cachedAt=cached_at,
+                ttlSeconds=TRADES_TTL_SECONDS,
+                errorReason=error_reason,
+            ),
+            trades=trades,
+        )

--- a/app/services/upbit_public_read_model/types.py
+++ b/app/services/upbit_public_read_model/types.py
@@ -1,0 +1,108 @@
+"""DTOs and shared helpers for the Upbit public read-model cache."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+UpbitBlockState = Literal["fresh", "stale", "unavailable", "missing"]
+UpbitSource = Literal[
+    "upbit_ticker",
+    "upbit_orderbook",
+    "upbit_trades",
+    "upbit_candles",
+    "upbit_market_warnings",
+    "upbit_balances",
+    "local_pending_orders",
+]
+
+TICKER_TTL_SECONDS = 5
+TICKER_STALE_TOLERANCE_SECONDS = 60
+ORDERBOOK_TTL_SECONDS = 3
+ORDERBOOK_STALE_TOLERANCE_SECONDS = 30
+TRADES_TTL_SECONDS = 5
+TRADES_STALE_TOLERANCE_SECONDS = 30
+WARNINGS_TTL_SECONDS = 300
+WARNINGS_STALE_TOLERANCE_SECONDS = 1800
+
+
+def _now_utc() -> datetime:
+    return datetime.now(UTC)
+
+
+class UpbitBlockMeta(BaseModel):
+    """Per-block freshness/error envelope. Mirrors CryptoSourceState shape."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    source: UpbitSource
+    state: UpbitBlockState
+    label: str
+    fetchedAt: datetime | None = None
+    cachedAt: datetime | None = None
+    ttlSeconds: int | None = None
+    errorReason: str | None = None
+
+
+class UpbitTickerBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    meta: UpbitBlockMeta
+    tickers: dict[str, dict[str, Any]] = Field(default_factory=dict)
+
+
+class UpbitOrderbookBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    meta: UpbitBlockMeta
+    orderbooks: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    spreadsPct: dict[str, float | None] = Field(default_factory=dict)
+
+
+class UpbitTradesBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    meta: UpbitBlockMeta
+    trades: dict[str, list[dict[str, Any]]] = Field(default_factory=dict)
+
+
+class UpbitCandlesBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    meta: UpbitBlockMeta
+    market: str
+    period: Literal["day", "week", "month"]
+    rows: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class UpbitMarketWarningEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    market: str
+    warning: Literal["NONE", "CAUTION"] = "NONE"
+    event: dict[str, Any] | None = None
+
+
+class UpbitMarketWarningsBlock(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    meta: UpbitBlockMeta
+    entries: dict[str, UpbitMarketWarningEntry] = Field(default_factory=dict)
+
+
+class UpbitPublicSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    asOf: datetime
+    ticker: UpbitTickerBlock
+    orderbook: UpbitOrderbookBlock
+    trades: UpbitTradesBlock | None = None
+    marketWarnings: UpbitMarketWarningsBlock
+    sources: list[UpbitBlockMeta] = Field(default_factory=list)
+
+
+def to_crypto_source_state(meta: UpbitBlockMeta):
+    """Map read-model block metadata into invest crypto source metadata."""
+    from app.schemas.invest_crypto import CryptoSourceState
+
+    return CryptoSourceState(
+        source=meta.source,
+        state="supported" if meta.state in {"fresh", "stale"} else "unavailable",
+        label=meta.label,
+        fetchedAt=meta.fetchedAt,
+    )

--- a/docs/runbooks/upbit-public-read-model.md
+++ b/docs/runbooks/upbit-public-read-model.md
@@ -1,0 +1,48 @@
+# Upbit public read-model cache (ROB-232)
+
+## What this is
+
+A read-only Redis-cached service layer wrapping Upbit official public data for KRW pairs: ticker, orderbook, recent trades, closed candles, and market warnings. It is consumed by `/trading/api/invest/crypto/dashboard` through the crypto dashboard service and can be reused by later coin-detail work.
+
+## Cache keys and TTLs
+
+| Block | Redis key | TTL | Stale window |
+| --- | --- | ---: | ---: |
+| ticker | `upbit:public:read:ticker:v1:<sha1>` | 5 s | 60 s |
+| orderbook | `upbit:public:read:orderbook:v1:<market>` | 3 s | 30 s |
+| trades | `upbit:public:read:trades:v1:<market>:<count>` | 5 s | 30 s |
+| candles | reuses existing `upbit_ohlcv_cache` keys | day/week/month bucketed | n/a |
+| market warnings detail | `upbit:public:read:warnings:v1` | 300 s | 1800 s |
+
+Set `UPBIT_PUBLIC_READ_MODEL_CACHE_ENABLED=false` only for local/debug bypass. Bypassing Redis makes every request call Upbit public endpoints directly and can increase rate-limit risk.
+
+## State model
+
+Each block returns metadata with `{source, fetchedAt, state, errorReason}`-style fields.
+
+- `fresh`: upstream call succeeded or cached payload is still inside its TTL.
+- `stale`: upstream refresh failed, but a stale cached payload is still inside the stale window.
+- `unavailable`: upstream failed and no cached payload is available.
+- `missing`: no upstream call was attempted, such as an empty market list.
+
+When adapted into dashboard `meta.sources`, `fresh` and `stale` are reported as `supported`; `unavailable` and `missing` are reported as `unavailable`.
+
+## Operations
+
+Inspect dashboard source freshness locally:
+
+```bash
+curl -sS 'http://localhost:8000/trading/api/invest/crypto/dashboard?limit=5' | jq '.meta.sources'
+```
+
+Flush all Upbit public read-model cache keys during an Upbit incident:
+
+```bash
+redis-cli --scan --pattern 'upbit:public:read:*' | xargs -r redis-cli del
+```
+
+For Docker-based local Redis, run the same scan/delete through the Redis container shell. Do not run this against production without separate operator approval.
+
+## Safety boundary
+
+This package is read-only. It must not submit, cancel, replace, or modify broker orders, must not import `app.services.brokers.upbit.orders`, and must not add migrations, backfills, schedulers, or production write paths. The safety-import test covers the mutation-import boundary.

--- a/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
@@ -105,7 +105,15 @@ const dashboard: CryptoDashboardResponse = {
     liveStreaming: { state: "deferred", reason: null },
     execution: { state: "read_only_mvp", reason: null },
   },
-  meta: { warnings: [], sources: [{ source: "upbit_ticker", state: "supported", label: "Upbit ticker", fetchedAt: "2026-05-13T12:00:00Z" }] },
+  meta: {
+    warnings: [],
+    sources: [
+      { source: "upbit_ticker", state: "supported", label: "Upbit ticker", fetchedAt: "2026-05-13T12:00:00Z" },
+      { source: "pending_orders", state: "supported", label: "Pending orders read model", fetchedAt: "2026-05-13T12:00:00Z" },
+      { source: "mcp_risk_reference", state: "reference_only", label: "MCP risk reference", fetchedAt: "2026-05-13T12:00:00Z" },
+      { source: "mcp_candidate_reference", state: "reference_only", label: "MCP candidate reference", fetchedAt: "2026-05-13T12:00:00Z" },
+    ],
+  },
 };
 
 const reference: NaverCryptoReferenceResponse = {
@@ -188,10 +196,12 @@ test("renders crypto dashboard cards and read-only capability states", async () 
   expect(screen.getByText("미체결")).toBeInTheDocument();
   expect(screen.getByText(/주문·감시·동기화 작업은 실행하지 않습니다/)).toBeInTheDocument();
   expect(screen.getByText(/체결\/주문 실행: read_only_mvp/)).toBeInTheDocument();
+  expect(screen.getAllByText(/Upbit ticker supported.*fetched 2026-05-13/).length).toBeGreaterThan(0);
+  expect(screen.getAllByText(/Upbit ticker: supported .*fetched 2026-05-13/).length).toBeGreaterThan(0);
   expect(await screen.findByRole("heading", { name: "Naver 참고 지표" })).toBeInTheDocument();
   expect(screen.getByText("2.50%")).toBeInTheDocument();
   expect(screen.getByText("BTC reference news")).toBeInTheDocument();
-  expect(screen.getByText(/Naver crypto reference fixture: reference_only/)).toBeInTheDocument();
+  expect(screen.getByText(/Naver crypto reference fixture: reference_only .* fixture .* freshness unavailable/)).toBeInTheDocument();
   expect(cryptoApi.fetchCryptoNaverReference).toHaveBeenCalledWith({ symbol: "KRW-BTC", limit: 20 });
 });
 
@@ -205,6 +215,7 @@ test("renders risk summary, card risk labels, and candidate insight rows", async
   const summary = await screen.findByLabelText("리스크 요약");
   expect(within(summary).getByText("중간 1")).toBeInTheDocument();
   expect(within(summary).getByText("낮음 1")).toBeInTheDocument();
+  expect(within(summary).getByText(/MCP risk reference: reference_only/)).toBeInTheDocument();
   expect(screen.getByText(/리스크 중간 · 35/)).toBeInTheDocument();
   expect(screen.getByText("변동성 주의")).toBeInTheDocument();
   expect(screen.getByText("거래대금 낮음")).toBeInTheDocument();
@@ -213,6 +224,7 @@ test("renders risk summary, card risk labels, and candidate insight rows", async
   const candidates = screen.getByLabelText("후보 인사이트");
   expect(within(candidates).getByText("1. 비트코인")).toBeInTheDocument();
   expect(within(candidates).getByText(/후보 인사이트는 참고용/)).toBeInTheDocument();
+  expect(within(candidates).getByText(/MCP candidate reference: reference_only/)).toBeInTheDocument();
   expect(within(candidates).getByText("검토 목록")).toBeInTheDocument();
   expect(within(candidates).getByText("유동성")).toBeInTheDocument();
   expect(within(candidates).queryByRole("button", { name: /주문|매수|매도|실행|등록/ })).not.toBeInTheDocument();
@@ -231,4 +243,18 @@ test("renders empty candidate insight state", async () => {
   );
 
   expect(await screen.findByText("조건에 맞는 후보 인사이트가 없습니다.")).toBeInTheDocument();
+});
+
+test("renders Naver/MCP fallback labels when reference request fails", async () => {
+  vi.spyOn(cryptoApi, "fetchCryptoNaverReference").mockRejectedValue(new Error("reference down"));
+
+  render(
+    <MemoryRouter basename="/invest" initialEntries={["/invest/crypto"]}>
+      <DesktopCryptoPage />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText(/Naver\/MCP 참고 지표를 불러오지 못했습니다/)).toBeInTheDocument();
+  expect(screen.getByText("Naver crypto reference: unavailable · freshness unavailable")).toBeInTheDocument();
+  expect(screen.getByText("MCP kimchi premium: unavailable · freshness unavailable")).toBeInTheDocument();
 });

--- a/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
@@ -8,7 +8,7 @@ vi.mock("../desktop/RightRemotePanel", () => ({
 
 import { DesktopCryptoPage } from "../pages/desktop/DesktopCryptoPage";
 import * as cryptoApi from "../api/investCrypto";
-import type { CryptoDashboardResponse } from "../types/investCrypto";
+import type { CryptoDashboardResponse, NaverCryptoReferenceResponse } from "../types/investCrypto";
 
 const dashboard: CryptoDashboardResponse = {
   asOf: "2026-05-13T12:00:00Z",
@@ -108,8 +108,69 @@ const dashboard: CryptoDashboardResponse = {
   meta: { warnings: [], sources: [{ source: "upbit_ticker", state: "supported", label: "Upbit ticker", fetchedAt: "2026-05-13T12:00:00Z" }] },
 };
 
+const reference: NaverCryptoReferenceResponse = {
+  market: "crypto",
+  asOf: "2026-05-13T12:01:00Z",
+  symbol: "KRW-BTC",
+  rank: [
+    {
+      rank: 1,
+      symbol: "KRW-BTC",
+      displayName: "비트코인",
+      priceKrw: 101000000,
+      changeRate24h: 0.0123,
+      tradeAmount24h: 12345678900,
+      rsi: 55.5,
+      marketWarning: false,
+      source: "tvscreener_upbit",
+    },
+  ],
+  profile: {
+    symbol: "KRW-BTC",
+    baseSymbol: "BTC",
+    displayName: "비트코인",
+    koreanName: "비트코인",
+    englishName: "Bitcoin",
+    naverUrl: "https://m.stock.naver.com/crypto/UPBIT/KRW-BTC",
+    officialMarket: "UPBIT/KRW",
+    referenceNotes: ["reference-only"],
+  },
+  news: { items: [{ id: 1, title: "BTC reference news", publisher: "fixture", url: "https://example.test/btc" }] },
+  kimchiPremium: {
+    baseSymbol: "BTC",
+    premiumPct: 2.5,
+    domesticPriceKrw: 101000000,
+    overseasPriceKrw: 98500000,
+    state: "available",
+    source: "mcp_kimchi_premium",
+    caution: "참고용 매크로 지표",
+  },
+  sources: [
+    {
+      source: "naver_reference",
+      label: "Naver crypto reference fixture",
+      state: "reference_only",
+      fetchedAt: null,
+      cacheAgeSeconds: null,
+      freshness: "fixture",
+      errorCode: null,
+      referenceOnly: true,
+    },
+  ],
+  warnings: ["naver_crypto_reference_only"],
+  capabilities: {
+    rank: { state: "supported", reason: null },
+    price: { state: "supported", reason: null },
+    profile: { state: "reference_only", reason: "naver_fixture_reference_only" },
+    news: { state: "supported", reason: null },
+    kimchiPremium: { state: "reference_only", reason: "macro_reference_only" },
+    execution: { state: "read_only_mvp", reason: "no_order_execution_controls" },
+  },
+};
+
 beforeEach(() => {
   vi.spyOn(cryptoApi, "fetchCryptoDashboard").mockResolvedValue(dashboard);
+  vi.spyOn(cryptoApi, "fetchCryptoNaverReference").mockResolvedValue(reference);
 });
 
 test("renders crypto dashboard cards and read-only capability states", async () => {
@@ -121,12 +182,17 @@ test("renders crypto dashboard cards and read-only capability states", async () 
 
   expect(await screen.findByTestId("crypto-dashboard")).toBeInTheDocument();
   expect(screen.getByRole("heading", { name: "크립토 대시보드" })).toBeInTheDocument();
-  expect(screen.getByText("비트코인")).toBeInTheDocument();
+  expect(screen.getAllByText("비트코인").length).toBeGreaterThan(0);
   expect(screen.getByText("101,000,000원")).toBeInTheDocument();
   expect(screen.getByText("보유")).toBeInTheDocument();
   expect(screen.getByText("미체결")).toBeInTheDocument();
   expect(screen.getByText(/주문·감시·동기화 작업은 실행하지 않습니다/)).toBeInTheDocument();
   expect(screen.getByText(/체결\/주문 실행: read_only_mvp/)).toBeInTheDocument();
+  expect(await screen.findByRole("heading", { name: "Naver 참고 지표" })).toBeInTheDocument();
+  expect(screen.getByText("2.50%")).toBeInTheDocument();
+  expect(screen.getByText("BTC reference news")).toBeInTheDocument();
+  expect(screen.getByText(/Naver crypto reference fixture: reference_only/)).toBeInTheDocument();
+  expect(cryptoApi.fetchCryptoNaverReference).toHaveBeenCalledWith({ symbol: "KRW-BTC", limit: 20 });
 });
 
 test("renders risk summary, card risk labels, and candidate insight rows", async () => {

--- a/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
@@ -8,7 +8,7 @@ vi.mock("../desktop/RightRemotePanel", () => ({
 
 import { DesktopCryptoPage } from "../pages/desktop/DesktopCryptoPage";
 import * as cryptoApi from "../api/investCrypto";
-import type { CryptoDashboardResponse } from "../types/investCrypto";
+import type { CryptoDashboardResponse, NaverCryptoReferenceResponse } from "../types/investCrypto";
 
 const dashboard: CryptoDashboardResponse = {
   asOf: "2026-05-13T12:00:00Z",
@@ -67,8 +67,69 @@ const dashboard: CryptoDashboardResponse = {
   meta: { warnings: [], sources: [{ source: "upbit_ticker", state: "supported", label: "Upbit ticker", fetchedAt: "2026-05-13T12:00:00Z" }] },
 };
 
+const reference: NaverCryptoReferenceResponse = {
+  market: "crypto",
+  asOf: "2026-05-13T12:01:00Z",
+  symbol: "KRW-BTC",
+  rank: [
+    {
+      rank: 1,
+      symbol: "KRW-BTC",
+      displayName: "비트코인",
+      priceKrw: 101000000,
+      changeRate24h: 0.0123,
+      tradeAmount24h: 12345678900,
+      rsi: 55.5,
+      marketWarning: false,
+      source: "tvscreener_upbit",
+    },
+  ],
+  profile: {
+    symbol: "KRW-BTC",
+    baseSymbol: "BTC",
+    displayName: "비트코인",
+    koreanName: "비트코인",
+    englishName: "Bitcoin",
+    naverUrl: "https://m.stock.naver.com/crypto/UPBIT/KRW-BTC",
+    officialMarket: "UPBIT/KRW",
+    referenceNotes: ["reference-only"],
+  },
+  news: { items: [{ id: 1, title: "BTC reference news", publisher: "fixture", url: "https://example.test/btc" }] },
+  kimchiPremium: {
+    baseSymbol: "BTC",
+    premiumPct: 2.5,
+    domesticPriceKrw: 101000000,
+    overseasPriceKrw: 98500000,
+    state: "available",
+    source: "mcp_kimchi_premium",
+    caution: "참고용 매크로 지표",
+  },
+  sources: [
+    {
+      source: "naver_reference",
+      label: "Naver crypto reference fixture",
+      state: "reference_only",
+      fetchedAt: null,
+      cacheAgeSeconds: null,
+      freshness: "fixture",
+      errorCode: null,
+      referenceOnly: true,
+    },
+  ],
+  warnings: ["naver_crypto_reference_only"],
+  capabilities: {
+    rank: { state: "supported", reason: null },
+    price: { state: "supported", reason: null },
+    profile: { state: "reference_only", reason: "naver_fixture_reference_only" },
+    news: { state: "supported", reason: null },
+    kimchiPremium: { state: "reference_only", reason: "macro_reference_only" },
+    execution: { state: "read_only_mvp", reason: "no_order_execution_controls" },
+  },
+};
+
 beforeEach(() => {
   vi.spyOn(cryptoApi, "fetchCryptoDashboard").mockResolvedValue(dashboard);
+  vi.spyOn(cryptoApi, "fetchCryptoNaverReference").mockResolvedValue(reference);
 });
 
 test("renders crypto dashboard cards and read-only capability states", async () => {
@@ -80,10 +141,15 @@ test("renders crypto dashboard cards and read-only capability states", async () 
 
   expect(await screen.findByTestId("crypto-dashboard")).toBeInTheDocument();
   expect(screen.getByRole("heading", { name: "크립토 대시보드" })).toBeInTheDocument();
-  expect(screen.getByText("비트코인")).toBeInTheDocument();
+  expect(screen.getAllByText("비트코인").length).toBeGreaterThan(0);
   expect(screen.getByText("101,000,000원")).toBeInTheDocument();
   expect(screen.getByText("보유")).toBeInTheDocument();
   expect(screen.getByText("미체결")).toBeInTheDocument();
   expect(screen.getByText(/주문·감시·동기화 작업은 실행하지 않습니다/)).toBeInTheDocument();
   expect(screen.getByText(/체결\/주문 실행: read_only_mvp/)).toBeInTheDocument();
+  expect(await screen.findByRole("heading", { name: "Naver 참고 지표" })).toBeInTheDocument();
+  expect(screen.getByText("2.50%")).toBeInTheDocument();
+  expect(screen.getByText("BTC reference news")).toBeInTheDocument();
+  expect(screen.getByText(/Naver crypto reference fixture: reference_only/)).toBeInTheDocument();
+  expect(cryptoApi.fetchCryptoNaverReference).toHaveBeenCalledWith({ symbol: "KRW-BTC", limit: 20 });
 });

--- a/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopCryptoPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, expect, test, vi } from "vitest";
 
@@ -30,7 +30,30 @@ const dashboard: CryptoDashboardResponse = {
       badges: [
         { kind: "held", label: "보유", severity: "info" },
         { kind: "pending_order", label: "미체결", severity: "warning" },
+        { kind: "high_volatility", label: "변동성 주의", severity: "warning" },
+        { kind: "low_liquidity", label: "거래대금 낮음", severity: "warning" },
+        { kind: "candidate_watch", label: "관심 후보", severity: "info" },
       ],
+      risk: {
+        level: "medium",
+        score: 35,
+        reasons: ["호가 스프레드 확대", "미체결 상태 존재"],
+      },
+    },
+    {
+      symbol: "KRW-ETH",
+      baseSymbol: "ETH",
+      displayName: "이더리움",
+      priceKrw: 5200000,
+      changeRate24h: -0.01,
+      changeAmount24h: -52000,
+      accTradePrice24h: 800000000,
+      volume24h: 1000,
+      orderbookSpreadPct: 0.2,
+      isHeld: false,
+      isWatched: false,
+      badges: [],
+      risk: { level: "low", score: 0, reasons: [] },
     },
   ],
   holdings: { heldCount: 1, symbols: ["KRW-BTC"], source: "invest_home_read_model" },
@@ -54,7 +77,25 @@ const dashboard: CryptoDashboardResponse = {
     emptyState: null,
     source: "pending_orders",
   },
-  insights: { badges: [], notes: ["읽기 전용"] },
+  insights: {
+    badges: [],
+    notes: ["읽기 전용"],
+    candidates: [
+      {
+        symbol: "KRW-BTC",
+        baseSymbol: "BTC",
+        displayName: "비트코인",
+        rank: 1,
+        score: 55,
+        reasons: ["watched", "liquidity", "spread"],
+        summary: "기존 검토 목록과 일치 · 거래대금 양호",
+        isHeld: true,
+        isWatched: true,
+        hasPendingOrder: true,
+        riskLevel: "medium",
+      },
+    ],
+  },
   capabilities: {
     ticker: { state: "supported", reason: null },
     candles: { state: "supported", reason: null },
@@ -86,4 +127,42 @@ test("renders crypto dashboard cards and read-only capability states", async () 
   expect(screen.getByText("미체결")).toBeInTheDocument();
   expect(screen.getByText(/주문·감시·동기화 작업은 실행하지 않습니다/)).toBeInTheDocument();
   expect(screen.getByText(/체결\/주문 실행: read_only_mvp/)).toBeInTheDocument();
+});
+
+test("renders risk summary, card risk labels, and candidate insight rows", async () => {
+  render(
+    <MemoryRouter basename="/invest" initialEntries={["/invest/crypto"]}>
+      <DesktopCryptoPage />
+    </MemoryRouter>,
+  );
+
+  const summary = await screen.findByLabelText("리스크 요약");
+  expect(within(summary).getByText("중간 1")).toBeInTheDocument();
+  expect(within(summary).getByText("낮음 1")).toBeInTheDocument();
+  expect(screen.getByText(/리스크 중간 · 35/)).toBeInTheDocument();
+  expect(screen.getByText("변동성 주의")).toBeInTheDocument();
+  expect(screen.getByText("거래대금 낮음")).toBeInTheDocument();
+  expect(screen.getByText("관심 후보")).toBeInTheDocument();
+
+  const candidates = screen.getByLabelText("후보 인사이트");
+  expect(within(candidates).getByText("1. 비트코인")).toBeInTheDocument();
+  expect(within(candidates).getByText(/후보 인사이트는 참고용/)).toBeInTheDocument();
+  expect(within(candidates).getByText("검토 목록")).toBeInTheDocument();
+  expect(within(candidates).getByText("유동성")).toBeInTheDocument();
+  expect(within(candidates).queryByRole("button", { name: /주문|매수|매도|실행|등록/ })).not.toBeInTheDocument();
+});
+
+test("renders empty candidate insight state", async () => {
+  vi.spyOn(cryptoApi, "fetchCryptoDashboard").mockResolvedValue({
+    ...dashboard,
+    insights: { ...dashboard.insights, candidates: [] },
+  });
+
+  render(
+    <MemoryRouter basename="/invest" initialEntries={["/invest/crypto"]}>
+      <DesktopCryptoPage />
+    </MemoryRouter>,
+  );
+
+  expect(await screen.findByText("조건에 맞는 후보 인사이트가 없습니다.")).toBeInTheDocument();
 });

--- a/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopScreenerPage.test.tsx
@@ -90,7 +90,22 @@ const CRYPTO_RESULTS = {
     marketCapLabel: "$2.10T",
     category: "Crypto",
     metricValueLabel: "120,000,000,000",
+    sourceContext: [
+      { source: "snapshot_cache" as const, label: "스냅샷 캐시", state: "cached" as const, fetchedAt: null, detail: null },
+      { source: "tvscreener_upbit" as const, label: "TV Screener Upbit", state: "supported" as const, fetchedAt: null, detail: null },
+    ],
+    riskContext: [
+      { kind: "low_rsi", label: "RSI 31.5 저점권", severity: "info" as const, source: "tvscreener_upbit" as const },
+    ],
+    candidateContext: {
+      scoreLabel: "거래대금 120,000,000,000",
+      reasons: ["24시간 KRW 거래대금 상위"],
+      source: "tvscreener_upbit" as const,
+    },
   }],
+  sources: [
+    { source: "snapshot_cache" as const, label: "스냅샷 캐시", state: "cached" as const, fetchedAt: null, detail: null },
+  ],
 };
 
 function wrap(ui: React.ReactElement) {
@@ -196,6 +211,10 @@ test("switches to the crypto market", async () => {
   await userEvent.click(screen.getByRole("button", { name: "가상자산" }));
 
   await waitFor(() => expect(screen.getByText("Bitcoin")).toBeInTheDocument());
+  expect(screen.getByText("스냅샷 캐시")).toBeInTheDocument();
+  expect(screen.getByText("TV Screener Upbit")).toBeInTheDocument();
+  expect(screen.getByText("RSI 31.5 저점권")).toBeInTheDocument();
+  expect(screen.getByText("24시간 KRW 거래대금 상위")).toBeInTheDocument();
   expect(screenerApi.fetchScreenerPresets).toHaveBeenCalledWith("crypto");
   expect(screenerApi.fetchScreenerResults).toHaveBeenCalledWith("crypto_high_volume", "crypto");
 });

--- a/frontend/invest/src/__tests__/StockDetailPage.test.tsx
+++ b/frontend/invest/src/__tests__/StockDetailPage.test.tsx
@@ -127,6 +127,7 @@ const aboveFold: StockDetailResponse = {
   },
   orderbookSupport: { supported: false, reason: "us_unsupported" },
   orderbook: null,
+  cryptoDetail: null,
   capabilities: {
     candles: { supported: true, intradaySupported: true },
     orderbook: { supported: false, reason: "us_unsupported" },

--- a/frontend/invest/src/api/investCrypto.ts
+++ b/frontend/invest/src/api/investCrypto.ts
@@ -1,4 +1,4 @@
-import type { CryptoDashboardResponse } from "../types/investCrypto";
+import type { CryptoDashboardResponse, NaverCryptoReferenceResponse } from "../types/investCrypto";
 
 async function getJson<T>(url: string): Promise<T> {
   const res = await fetch(url, { credentials: "include" });
@@ -11,4 +11,14 @@ export async function fetchCryptoDashboard(params: { limit?: number } = {}): Pro
   if (params.limit !== undefined) q.set("limit", String(params.limit));
   const qs = q.toString();
   return getJson<CryptoDashboardResponse>(`/invest/api/crypto/dashboard${qs ? `?${qs}` : ""}`);
+}
+
+export async function fetchCryptoNaverReference(
+  params: { symbol?: string; limit?: number } = {},
+): Promise<NaverCryptoReferenceResponse> {
+  const q = new URLSearchParams();
+  if (params.symbol) q.set("symbol", params.symbol);
+  if (params.limit !== undefined) q.set("limit", String(params.limit));
+  const qs = q.toString();
+  return getJson<NaverCryptoReferenceResponse>(`/invest/api/crypto/naver-reference${qs ? `?${qs}` : ""}`);
 }

--- a/frontend/invest/src/desktop/screener/ScreenerResultsTable.tsx
+++ b/frontend/invest/src/desktop/screener/ScreenerResultsTable.tsx
@@ -48,6 +48,39 @@ export function ScreenerResultsTable({ rows, metricLabel }: Props) {
             <td className="screener-name-cell">
               <span className="screener-symbol-badge">{r.symbol}</span>
               <span className="screener-symbol-name">{r.name}</span>
+              {r.market === "crypto" && (
+                <div className="screener-context-stack">
+                  {(r.sourceContext ?? []).length > 0 && (
+                    <div className="screener-context-row" aria-label="데이터 출처">
+                      {(r.sourceContext ?? []).map((source) => (
+                        <span
+                          key={`${r.symbol}-${source.source}-${source.state}`}
+                          className={`screener-context-chip screener-context-chip--${source.state}`}
+                        >
+                          {source.label}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {(r.riskContext ?? []).length > 0 && (
+                    <div className="screener-context-row" aria-label="리스크 맥락">
+                      {(r.riskContext ?? []).map((risk) => (
+                        <span
+                          key={`${r.symbol}-${risk.kind}`}
+                          className={`screener-risk-chip screener-risk-chip--${risk.severity}`}
+                        >
+                          {risk.label}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {r.candidateContext && r.candidateContext.reasons.length > 0 && (
+                    <div className="screener-candidate-context">
+                      {r.candidateContext.reasons.join(" · ")}
+                    </div>
+                  )}
+                </div>
+              )}
             </td>
             <td>{r.priceLabel}</td>
             <td className={directionClass[r.changeDirection]}>

--- a/frontend/invest/src/desktop/screener/screener.css
+++ b/frontend/invest/src/desktop/screener/screener.css
@@ -27,6 +27,17 @@
 .screener-name-cell { display: flex; flex-direction: column; gap: 2px; }
 .screener-symbol-badge { font-size: 11px; color: var(--fg-3); font-family: var(--font-mono); }
 .screener-symbol-name { font-weight: 700; color: var(--fg); }
+.screener-context-stack { display: flex; flex-direction: column; gap: 4px; margin-top: 5px; }
+.screener-context-row { display: flex; flex-wrap: wrap; gap: 4px; }
+.screener-context-chip,
+.screener-risk-chip { display: inline-flex; align-items: center; border-radius: 999px; padding: 2px 7px; font-size: 10px; font-weight: 700; border: 1px solid var(--border); background: var(--surface-2); color: var(--fg-2); }
+.screener-context-chip--cached,
+.screener-context-chip--fallback,
+.screener-context-chip--partial { background: var(--accent-soft); color: var(--accent-press); }
+.screener-context-chip--reference_only { background: var(--surface-2); color: var(--fg-3); }
+.screener-risk-chip--warning,
+.screener-risk-chip--danger { background: var(--warn-soft); color: var(--warn); }
+.screener-candidate-context { color: var(--fg-3); font-size: 11px; line-height: 1.4; }
 .screener-change-up { color: var(--gain); }
 .screener-change-down { color: var(--loss); }
 .screener-change-flat { color: var(--flat); }

--- a/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { RightRemotePanel } from "../../desktop/RightRemotePanel";
-import { fetchCryptoDashboard } from "../../api/investCrypto";
-import type { CryptoDashboardResponse, CryptoMarketCard } from "../../types/investCrypto";
+import { fetchCryptoDashboard, fetchCryptoNaverReference } from "../../api/investCrypto";
+import type { CryptoDashboardResponse, CryptoMarketCard, NaverCryptoReferenceResponse } from "../../types/investCrypto";
 import "../../desktop/screener/screener.css";
 
 function formatKrw(value: number | null): string {
@@ -74,19 +74,82 @@ function cryptoErrorMessage(error: unknown): string {
   return text || "크립토 대시보드 데이터를 일시적으로 불러오지 못했습니다.";
 }
 
+function ReferencePanel({ reference }: { reference: NaverCryptoReferenceResponse }) {
+  const kimchi = reference.kimchiPremium;
+  return (
+    <section style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14, background: "var(--surface)" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "baseline" }}>
+        <div>
+          <h2 style={{ margin: 0 }}>Naver 참고 지표</h2>
+          <p style={{ marginTop: 6, color: "var(--fg-3)" }}>출처 라벨이 있는 읽기 전용 참고 데이터입니다. 주문 실행 없음.</p>
+        </div>
+        <span className="screener-chip">{reference.capabilities.execution.state}</span>
+      </div>
+      {reference.warnings.length > 0 && (
+        <div style={{ marginTop: 10, color: "var(--fg-3)", fontSize: 13 }}>
+          {reference.warnings.slice(0, 3).join(" · ")}
+        </div>
+      )}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12, marginTop: 14 }}>
+        <div>
+          <strong>김치 프리미엄</strong>
+          <div style={{ marginTop: 4 }}>{kimchi?.premiumPct === null || kimchi?.premiumPct === undefined ? "-" : `${kimchi.premiumPct.toFixed(2)}%`}</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{kimchi?.caution ?? "참고용 매크로 지표"}</div>
+        </div>
+        <div>
+          <strong>프로필</strong>
+          <div style={{ marginTop: 4 }}>{reference.profile?.displayName ?? reference.symbol ?? "-"}</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{reference.profile?.officialMarket ?? "UPBIT/KRW"} · reference-only</div>
+        </div>
+        <div>
+          <strong>뉴스</strong>
+          <div style={{ marginTop: 4 }}>{reference.news?.items.length ?? 0}건</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{reference.news?.items[0]?.title ?? "최근 크립토 뉴스 없음"}</div>
+        </div>
+      </div>
+      {reference.rank.length > 0 && (
+        <div style={{ marginTop: 14, display: "grid", gap: 8 }}>
+          {reference.rank.slice(0, 5).map((item) => (
+            <div key={item.symbol} style={{ display: "flex", justifyContent: "space-between", gap: 12, color: "var(--fg-2)", fontSize: 13 }}>
+              <span>#{item.rank} {item.displayName} <span style={{ color: "var(--fg-3)" }}>{item.source}</span></span>
+              <span>{formatKrw(item.priceKrw)} · {formatPct(item.changeRate24h)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      <div style={{ marginTop: 12, display: "flex", flexWrap: "wrap", gap: 6 }}>
+        {reference.sources.map((source) => (
+          <span key={`${source.source}-${source.state}`} className="screener-chip">
+            {source.label}: {source.state}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function DesktopCryptoPage() {
   const [data, setData] = useState<CryptoDashboardResponse | undefined>();
+  const [reference, setReference] = useState<NaverCryptoReferenceResponse | undefined>();
   const [err, setErr] = useState<string | undefined>();
 
   useEffect(() => {
     let cancel = false;
     setErr(undefined);
-    fetchCryptoDashboard({ limit: 20 })
-      .then((response) => {
-        if (cancel) return;
-        setData(response);
-      })
-      .catch((error) => !cancel && setErr(cryptoErrorMessage(error)));
+    Promise.allSettled([
+      fetchCryptoDashboard({ limit: 20 }),
+      fetchCryptoNaverReference({ symbol: "KRW-BTC", limit: 20 }),
+    ]).then(([dashboardResult, referenceResult]) => {
+      if (cancel) return;
+      if (dashboardResult.status === "fulfilled") {
+        setData(dashboardResult.value);
+      } else {
+        setErr(cryptoErrorMessage(dashboardResult.reason));
+      }
+      if (referenceResult.status === "fulfilled") {
+        setReference(referenceResult.value);
+      }
+    });
     return () => { cancel = true; };
   }, []);
 
@@ -126,6 +189,7 @@ export function DesktopCryptoPage() {
               <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 12, marginTop: 16 }}>
                 {data.cards.map((card) => <CryptoCard key={card.symbol} card={card} />)}
               </section>
+              {reference && <ReferencePanel reference={reference} />}
               <section style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14 }}>
                 <h2 style={{ marginTop: 0 }}>기능 상태</h2>
                 <p style={{ color: "var(--fg-3)" }}>체결/주문 실행: {data.capabilities.execution.state} · 실시간 스트리밍: {data.capabilities.liveStreaming.state}</p>

--- a/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
@@ -3,7 +3,12 @@ import { Link } from "react-router-dom";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { fetchCryptoDashboard } from "../../api/investCrypto";
-import type { CryptoDashboardResponse, CryptoMarketCard } from "../../types/investCrypto";
+import type {
+  CryptoCandidateInsight,
+  CryptoDashboardResponse,
+  CryptoMarketCard,
+  CryptoRiskLevel,
+} from "../../types/investCrypto";
 import "../../desktop/screener/screener.css";
 
 function formatKrw(value: number | null): string {
@@ -22,6 +27,34 @@ function cardMetric(card: CryptoMarketCard): string {
     return `거래대금 ${(card.accTradePrice24h / 1_0000_0000).toFixed(1)}억`;
   }
   return `거래대금 ${Math.round(card.accTradePrice24h).toLocaleString("ko-KR")}`;
+}
+
+const riskLabels: Record<CryptoRiskLevel, string> = {
+  high: "높음",
+  medium: "중간",
+  low: "낮음",
+  unknown: "미확인",
+};
+
+const reasonLabels: Record<string, string> = {
+  momentum: "변화",
+  liquidity: "유동성",
+  spread: "호가 안정",
+  watched: "검토 목록",
+  held: "보유",
+  pending_order: "미체결",
+  data_quality: "데이터 확인",
+};
+
+function riskCounts(cards: CryptoMarketCard[]): Record<CryptoRiskLevel, number> {
+  return cards.reduce<Record<CryptoRiskLevel, number>>(
+    (counts, card) => {
+      const level = card.risk?.level ?? "unknown";
+      counts[level] += 1;
+      return counts;
+    },
+    { high: 0, medium: 0, low: 0, unknown: 0 },
+  );
 }
 
 function CryptoCard({ card }: { card: CryptoMarketCard }) {
@@ -53,6 +86,14 @@ function CryptoCard({ card }: { card: CryptoMarketCard }) {
       <div style={{ marginTop: 12, color: "var(--fg-3)", fontSize: 13 }}>
         {cardMetric(card)} · 호가 스프레드 {card.orderbookSpreadPct === null ? "-" : `${card.orderbookSpreadPct.toFixed(3)}%`}
       </div>
+      {card.risk && (
+        <div style={{ marginTop: 8, color: "var(--fg-2)", fontSize: 13 }}>
+          리스크 {riskLabels[card.risk.level]} · {card.risk.score}
+          {card.risk.reasons.length > 0 && (
+            <span style={{ color: "var(--fg-3)" }}> · {card.risk.reasons.slice(0, 2).join(" · ")}</span>
+          )}
+        </div>
+      )}
       {card.badges.length > 0 && (
         <div style={{ marginTop: 10, display: "flex", flexWrap: "wrap", gap: 6 }}>
           {card.badges.map((badge, idx) => (
@@ -63,6 +104,62 @@ function CryptoCard({ card }: { card: CryptoMarketCard }) {
         </div>
       )}
     </Link>
+  );
+}
+
+function RiskSummary({ cards }: { cards: CryptoMarketCard[] }) {
+  const counts = riskCounts(cards);
+  return (
+    <section aria-label="리스크 요약" style={{ marginTop: 16, padding: 16, border: "1px solid var(--border)", borderRadius: 14 }}>
+      <h2 style={{ marginTop: 0 }}>리스크 요약</h2>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        {(["high", "medium", "low", "unknown"] as CryptoRiskLevel[]).map((level) => (
+          <span key={level} className="screener-chip">
+            {riskLabels[level]} {counts[level]}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function CandidateInsightCard({ candidate }: { candidate: CryptoCandidateInsight }) {
+  return (
+    <article style={{ padding: 12, border: "1px solid var(--border)", borderRadius: 12 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12 }}>
+        <strong>{candidate.rank}. {candidate.displayName}</strong>
+        <span>점수 {candidate.score}</span>
+      </div>
+      <div style={{ marginTop: 4, color: "var(--fg-3)", fontSize: 13 }}>
+        {candidate.symbol} · 리스크 {riskLabels[candidate.riskLevel]}
+      </div>
+      <p style={{ margin: "8px 0", color: "var(--fg-2)" }}>{candidate.summary}</p>
+      {candidate.reasons.length > 0 && (
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+          {candidate.reasons.map((reason) => (
+            <span key={reason} className="screener-chip">{reasonLabels[reason] ?? reason}</span>
+          ))}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function CandidateInsights({ candidates }: { candidates: CryptoCandidateInsight[] }) {
+  return (
+    <section aria-label="후보 인사이트" style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14 }}>
+      <h2 style={{ marginTop: 0 }}>후보 인사이트</h2>
+      <p style={{ color: "var(--fg-3)" }}>후보 인사이트는 참고용이며 주문/감시 등록을 실행하지 않습니다.</p>
+      {candidates.length === 0 ? (
+        <p style={{ color: "var(--fg-3)" }}>조건에 맞는 후보 인사이트가 없습니다.</p>
+      ) : (
+        <div style={{ display: "grid", gap: 10 }}>
+          {candidates.map((candidate) => (
+            <CandidateInsightCard key={candidate.symbol} candidate={candidate} />
+          ))}
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -123,6 +220,8 @@ export function DesktopCryptoPage() {
                   {data.meta.warnings.map((warning) => <li key={warning}>{warning}</li>)}
                 </ul>
               )}
+              <RiskSummary cards={data.cards} />
+              <CandidateInsights candidates={data.insights.candidates ?? []} />
               <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 12, marginTop: 16 }}>
                 {data.cards.map((card) => <CryptoCard key={card.symbol} card={card} />)}
               </section>

--- a/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
@@ -2,12 +2,13 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { RightRemotePanel } from "../../desktop/RightRemotePanel";
-import { fetchCryptoDashboard } from "../../api/investCrypto";
+import { fetchCryptoDashboard, fetchCryptoNaverReference } from "../../api/investCrypto";
 import type {
   CryptoCandidateInsight,
   CryptoDashboardResponse,
   CryptoMarketCard,
   CryptoRiskLevel,
+  NaverCryptoReferenceResponse,
 } from "../../types/investCrypto";
 import "../../desktop/screener/screener.css";
 
@@ -171,19 +172,82 @@ function cryptoErrorMessage(error: unknown): string {
   return text || "크립토 대시보드 데이터를 일시적으로 불러오지 못했습니다.";
 }
 
+function ReferencePanel({ reference }: { reference: NaverCryptoReferenceResponse }) {
+  const kimchi = reference.kimchiPremium;
+  return (
+    <section style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14, background: "var(--surface)" }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "baseline" }}>
+        <div>
+          <h2 style={{ margin: 0 }}>Naver 참고 지표</h2>
+          <p style={{ marginTop: 6, color: "var(--fg-3)" }}>출처 라벨이 있는 읽기 전용 참고 데이터입니다. 주문 실행 없음.</p>
+        </div>
+        <span className="screener-chip">{reference.capabilities.execution.state}</span>
+      </div>
+      {reference.warnings.length > 0 && (
+        <div style={{ marginTop: 10, color: "var(--fg-3)", fontSize: 13 }}>
+          {reference.warnings.slice(0, 3).join(" · ")}
+        </div>
+      )}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 12, marginTop: 14 }}>
+        <div>
+          <strong>김치 프리미엄</strong>
+          <div style={{ marginTop: 4 }}>{kimchi?.premiumPct === null || kimchi?.premiumPct === undefined ? "-" : `${kimchi.premiumPct.toFixed(2)}%`}</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{kimchi?.caution ?? "참고용 매크로 지표"}</div>
+        </div>
+        <div>
+          <strong>프로필</strong>
+          <div style={{ marginTop: 4 }}>{reference.profile?.displayName ?? reference.symbol ?? "-"}</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{reference.profile?.officialMarket ?? "UPBIT/KRW"} · reference-only</div>
+        </div>
+        <div>
+          <strong>뉴스</strong>
+          <div style={{ marginTop: 4 }}>{reference.news?.items.length ?? 0}건</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{reference.news?.items[0]?.title ?? "최근 크립토 뉴스 없음"}</div>
+        </div>
+      </div>
+      {reference.rank.length > 0 && (
+        <div style={{ marginTop: 14, display: "grid", gap: 8 }}>
+          {reference.rank.slice(0, 5).map((item) => (
+            <div key={item.symbol} style={{ display: "flex", justifyContent: "space-between", gap: 12, color: "var(--fg-2)", fontSize: 13 }}>
+              <span>#{item.rank} {item.displayName} <span style={{ color: "var(--fg-3)" }}>{item.source}</span></span>
+              <span>{formatKrw(item.priceKrw)} · {formatPct(item.changeRate24h)}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      <div style={{ marginTop: 12, display: "flex", flexWrap: "wrap", gap: 6 }}>
+        {reference.sources.map((source) => (
+          <span key={`${source.source}-${source.state}`} className="screener-chip">
+            {source.label}: {source.state}
+          </span>
+        ))}
+      </div>
+    </section>
+  );
+}
+
 export function DesktopCryptoPage() {
   const [data, setData] = useState<CryptoDashboardResponse | undefined>();
+  const [reference, setReference] = useState<NaverCryptoReferenceResponse | undefined>();
   const [err, setErr] = useState<string | undefined>();
 
   useEffect(() => {
     let cancel = false;
     setErr(undefined);
-    fetchCryptoDashboard({ limit: 20 })
-      .then((response) => {
-        if (cancel) return;
-        setData(response);
-      })
-      .catch((error) => !cancel && setErr(cryptoErrorMessage(error)));
+    Promise.allSettled([
+      fetchCryptoDashboard({ limit: 20 }),
+      fetchCryptoNaverReference({ symbol: "KRW-BTC", limit: 20 }),
+    ]).then(([dashboardResult, referenceResult]) => {
+      if (cancel) return;
+      if (dashboardResult.status === "fulfilled") {
+        setData(dashboardResult.value);
+      } else {
+        setErr(cryptoErrorMessage(dashboardResult.reason));
+      }
+      if (referenceResult.status === "fulfilled") {
+        setReference(referenceResult.value);
+      }
+    });
     return () => { cancel = true; };
   }, []);
 
@@ -225,6 +289,7 @@ export function DesktopCryptoPage() {
               <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 12, marginTop: 16 }}>
                 {data.cards.map((card) => <CryptoCard key={card.symbol} card={card} />)}
               </section>
+              {reference && <ReferencePanel reference={reference} />}
               <section style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14 }}>
                 <h2 style={{ marginTop: 0 }}>기능 상태</h2>
                 <p style={{ color: "var(--fg-3)" }}>체결/주문 실행: {data.capabilities.execution.state} · 실시간 스트리밍: {data.capabilities.liveStreaming.state}</p>

--- a/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
@@ -8,6 +8,7 @@ import type {
   CryptoDashboardResponse,
   CryptoMarketCard,
   CryptoRiskLevel,
+  CryptoSourceState,
   NaverCryptoReferenceResponse,
 } from "../../types/investCrypto";
 import "../../desktop/screener/screener.css";
@@ -20,6 +21,33 @@ function formatKrw(value: number | null): string {
 function formatPct(value: number | null): string {
   if (value === null || Number.isNaN(value)) return "-";
   return `${(value * 100).toFixed(2)}%`;
+}
+
+function sourceFreshness(fetchedAt: string | null | undefined): string {
+  if (!fetchedAt) return "freshness unavailable";
+  return `fetched ${fetchedAt}`;
+}
+
+function sourceSummary(sources: CryptoSourceState[], sourceIds: string[]): string {
+  const selected = sources.filter((source) => sourceIds.includes(source.source));
+  if (selected.length === 0) return "출처: 확인 불가";
+  return `출처: ${selected.map((source) => `${source.label} ${source.state} (${sourceFreshness(source.fetchedAt)})`).join(" · ")}`;
+}
+
+function SourceLabels({ sources, sourceIds }: { sources: CryptoSourceState[]; sourceIds: string[] }) {
+  const selected = sources.filter((source) => sourceIds.includes(source.source));
+  if (selected.length === 0) {
+    return <span className="screener-chip">출처 확인 불가</span>;
+  }
+  return (
+    <>
+      {selected.map((source) => (
+        <span key={`${source.source}-${source.state}`} className="screener-chip">
+          {source.label}: {source.state} · {sourceFreshness(source.fetchedAt)}
+        </span>
+      ))}
+    </>
+  );
 }
 
 function cardMetric(card: CryptoMarketCard): string {
@@ -58,7 +86,7 @@ function riskCounts(cards: CryptoMarketCard[]): Record<CryptoRiskLevel, number> 
   );
 }
 
-function CryptoCard({ card }: { card: CryptoMarketCard }) {
+function CryptoCard({ card, sources }: { card: CryptoMarketCard; sources: CryptoSourceState[] }) {
   return (
     <Link
       to={`/crypto/${encodeURIComponent(card.symbol)}`}
@@ -87,6 +115,9 @@ function CryptoCard({ card }: { card: CryptoMarketCard }) {
       <div style={{ marginTop: 12, color: "var(--fg-3)", fontSize: 13 }}>
         {cardMetric(card)} · 호가 스프레드 {card.orderbookSpreadPct === null ? "-" : `${card.orderbookSpreadPct.toFixed(3)}%`}
       </div>
+      <div style={{ marginTop: 8, color: "var(--fg-3)", fontSize: 12 }}>
+        {sourceSummary(sources, ["upbit_ticker", "upbit_orderbook"])}
+      </div>
       {card.risk && (
         <div style={{ marginTop: 8, color: "var(--fg-2)", fontSize: 13 }}>
           리스크 {riskLabels[card.risk.level]} · {card.risk.score}
@@ -108,7 +139,7 @@ function CryptoCard({ card }: { card: CryptoMarketCard }) {
   );
 }
 
-function RiskSummary({ cards }: { cards: CryptoMarketCard[] }) {
+function RiskSummary({ cards, sources }: { cards: CryptoMarketCard[]; sources: CryptoSourceState[] }) {
   const counts = riskCounts(cards);
   return (
     <section aria-label="리스크 요약" style={{ marginTop: 16, padding: 16, border: "1px solid var(--border)", borderRadius: 14 }}>
@@ -119,6 +150,9 @@ function RiskSummary({ cards }: { cards: CryptoMarketCard[] }) {
             {riskLabels[level]} {counts[level]}
           </span>
         ))}
+      </div>
+      <div style={{ marginTop: 10, display: "flex", flexWrap: "wrap", gap: 6 }}>
+        <SourceLabels sources={sources} sourceIds={["upbit_ticker", "upbit_orderbook", "pending_orders", "mcp_risk_reference"]} />
       </div>
     </section>
   );
@@ -146,11 +180,14 @@ function CandidateInsightCard({ candidate }: { candidate: CryptoCandidateInsight
   );
 }
 
-function CandidateInsights({ candidates }: { candidates: CryptoCandidateInsight[] }) {
+function CandidateInsights({ candidates, sources }: { candidates: CryptoCandidateInsight[]; sources: CryptoSourceState[] }) {
   return (
     <section aria-label="후보 인사이트" style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14 }}>
       <h2 style={{ marginTop: 0 }}>후보 인사이트</h2>
       <p style={{ color: "var(--fg-3)" }}>후보 인사이트는 참고용이며 주문/감시 등록을 실행하지 않습니다.</p>
+      <div style={{ marginBottom: 10, display: "flex", flexWrap: "wrap", gap: 6 }}>
+        <SourceLabels sources={sources} sourceIds={["upbit_ticker", "upbit_orderbook", "pending_orders", "mcp_candidate_reference"]} />
+      </div>
       {candidates.length === 0 ? (
         <p style={{ color: "var(--fg-3)" }}>조건에 맞는 후보 인사이트가 없습니다.</p>
       ) : (
@@ -218,9 +255,24 @@ function ReferencePanel({ reference }: { reference: NaverCryptoReferenceResponse
       <div style={{ marginTop: 12, display: "flex", flexWrap: "wrap", gap: 6 }}>
         {reference.sources.map((source) => (
           <span key={`${source.source}-${source.state}`} className="screener-chip">
-            {source.label}: {source.state}
+            {source.label}: {source.state} · {source.freshness} · {source.fetchedAt ?? "freshness unavailable"}
           </span>
         ))}
+      </div>
+    </section>
+  );
+}
+
+function ReferenceFallback() {
+  return (
+    <section style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14, background: "var(--surface)" }}>
+      <h2 style={{ margin: 0 }}>Naver 참고 지표</h2>
+      <p style={{ color: "var(--fg-3)" }}>
+        Naver/MCP 참고 지표를 불러오지 못했습니다. 대시보드 시세·리스크 카드는 계속 읽기 전용으로 표시됩니다.
+      </p>
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+        <span className="screener-chip">Naver crypto reference: unavailable · freshness unavailable</span>
+        <span className="screener-chip">MCP kimchi premium: unavailable · freshness unavailable</span>
       </div>
     </section>
   );
@@ -284,12 +336,12 @@ export function DesktopCryptoPage() {
                   {data.meta.warnings.map((warning) => <li key={warning}>{warning}</li>)}
                 </ul>
               )}
-              <RiskSummary cards={data.cards} />
-              <CandidateInsights candidates={data.insights.candidates ?? []} />
+              <RiskSummary cards={data.cards} sources={data.meta.sources} />
+              <CandidateInsights candidates={data.insights.candidates ?? []} sources={data.meta.sources} />
               <section style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(240px, 1fr))", gap: 12, marginTop: 16 }}>
-                {data.cards.map((card) => <CryptoCard key={card.symbol} card={card} />)}
+                {data.cards.map((card) => <CryptoCard key={card.symbol} card={card} sources={data.meta.sources} />)}
               </section>
-              {reference && <ReferencePanel reference={reference} />}
+              {reference ? <ReferencePanel reference={reference} /> : <ReferenceFallback />}
               <section style={{ marginTop: 18, padding: 16, border: "1px solid var(--border)", borderRadius: 14 }}>
                 <h2 style={{ marginTop: 0 }}>기능 상태</h2>
                 <p style={{ color: "var(--fg-3)" }}>체결/주문 실행: {data.capabilities.execution.state} · 실시간 스트리밍: {data.capabilities.liveStreaming.state}</p>

--- a/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
+++ b/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
@@ -56,6 +56,7 @@ function currencyValue(currency: string, value: number | null | undefined) {
 function orderbookMessage(data: StockDetailResponse): string {
   if (data.orderbookSupport.supported && data.orderbook) return "호가를 표시합니다";
   if (data.orderbookSupport.reason === "us_unsupported") return "US 호가는 아직 지원하지 않습니다";
+  if (data.orderbookSupport.reason === "provider_unavailable") return "호가 제공자 데이터를 사용할 수 없습니다";
   if (data.orderbookSupport.reason === "crypto_deferred") return "크립토 호가는 다음 단계에서 연결합니다";
   return "호가 데이터를 사용할 수 없습니다";
 }
@@ -203,6 +204,40 @@ function OrdersCard({ orders }: { orders: StockDetailOrdersResponse | undefined 
       {!orders ? <p style={{ margin: 0, color: "var(--fg-3)" }}>불러오는 중입니다…</p> : null}
       {orders && empty ? <p style={{ margin: 0, color: "var(--fg-3)" }}>체결 내역이 없습니다.</p> : null}
       {orders && !empty ? <ul>{orders.items.map((o) => <li key={o.orderId ?? `${o.side}-${o.filledAt}`}>{o.side} {o.quantity}</li>)}</ul> : null}
+    </Card>
+  );
+}
+
+function CryptoDetailCard({ data }: { data: StockDetailResponse }) {
+  const crypto = data.cryptoDetail;
+  if (!crypto) return null;
+  const pendingCount = crypto.pendingOrders.items.length;
+  const recent = crypto.recentTrades.items.slice(0, 3);
+  return (
+    <Card data-testid="stock-detail-crypto-detail" soft>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
+        <div>
+          <h2 style={{ margin: "0 0 6px", fontSize: 16 }}>크립토 사전 체크</h2>
+          <p style={{ margin: 0, color: "var(--fg-3)", fontSize: 12 }}>
+            {crypto.profile.baseSymbol} · 미체결 {pendingCount}건 · {crypto.preOrderChecklist.mode}
+          </p>
+        </div>
+        <Pill tone="upbit">read-only</Pill>
+      </div>
+      <ul style={{ margin: "12px 0 0", paddingLeft: 18, color: "var(--fg-2)", fontSize: 13 }}>
+        {crypto.preOrderChecklist.items.slice(0, 6).map((item) => (
+          <li key={item.key}><strong>{item.label}</strong> · {item.detail}</li>
+        ))}
+      </ul>
+      <p style={{ margin: "10px 0 0", color: "var(--fg-3)", fontSize: 12 }}>{crypto.preOrderChecklist.disclaimer}</p>
+      {recent.length > 0 ? (
+        <div style={{ marginTop: 12 }}>
+          <div style={{ color: "var(--fg-3)", fontSize: 12, marginBottom: 6 }}>최근 체결</div>
+          <ul style={{ margin: 0, paddingLeft: 18, color: "var(--fg-2)", fontSize: 13 }}>
+            {recent.map((trade) => <li key={`${trade.sequentialId ?? trade.tradeTime}-${trade.priceKrw}`}>₩{Math.round(trade.priceKrw).toLocaleString("ko-KR")} · {trade.volume.toLocaleString("ko-KR", { maximumFractionDigits: 6 })}</li>)}
+          </ul>
+        </div>
+      ) : null}
     </Card>
   );
 }
@@ -389,6 +424,7 @@ export function StockDetailPage() {
     <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
       {data ? <ProfileCard data={data} /> : null}
       {data && market !== "crypto" ? <ResearchConsensusCard data={researchConsensus} error={researchErr} /> : null}
+      {data && market === "crypto" ? <CryptoDetailCard data={data} /> : null}
       {data ? <AnalysisCard data={data} /> : null}
       {data ? <NaverPocCard data={data} /> : null}
       <MemoCard />

--- a/frontend/invest/src/types/investCrypto.ts
+++ b/frontend/invest/src/types/investCrypto.ts
@@ -11,7 +11,21 @@ export type CryptoRiskBadgeKind =
   | "held"
   | "pending_order"
   | "data_unavailable"
-  | "high_volatility";
+  | "high_volatility"
+  | "low_liquidity"
+  | "candidate_watch"
+  | "momentum_candidate";
+
+export type CryptoRiskLevel = "low" | "medium" | "high" | "unknown";
+
+export type CryptoCandidateReasonKind =
+  | "momentum"
+  | "liquidity"
+  | "spread"
+  | "watched"
+  | "held"
+  | "pending_order"
+  | "data_quality";
 
 export interface CryptoSourceState {
   source: string;
@@ -41,6 +55,26 @@ export interface CryptoRiskBadge {
   severity: "info" | "warning" | "danger";
 }
 
+export interface CryptoRiskSummary {
+  level: CryptoRiskLevel;
+  score: number;
+  reasons: string[];
+}
+
+export interface CryptoCandidateInsight {
+  symbol: string;
+  baseSymbol: string;
+  displayName: string;
+  rank: number;
+  score: number;
+  reasons: CryptoCandidateReasonKind[];
+  summary: string;
+  isHeld: boolean;
+  isWatched: boolean;
+  hasPendingOrder: boolean;
+  riskLevel: CryptoRiskLevel;
+}
+
 export interface CryptoMarketCard {
   symbol: string;
   baseSymbol: string;
@@ -54,6 +88,7 @@ export interface CryptoMarketCard {
   isHeld: boolean;
   isWatched: boolean;
   badges: CryptoRiskBadge[];
+  risk: CryptoRiskSummary | null;
 }
 
 export interface CryptoHoldingSummary {
@@ -86,6 +121,7 @@ export interface CryptoPendingOrdersSummary {
 export interface CryptoInsightsSummary {
   badges: CryptoRiskBadge[];
   notes: string[];
+  candidates: CryptoCandidateInsight[];
 }
 
 export interface CryptoDashboardResponse {

--- a/frontend/invest/src/types/investCrypto.ts
+++ b/frontend/invest/src/types/investCrypto.ts
@@ -6,6 +6,17 @@ export type CryptoCapabilityState =
   | "deferred"
   | "read_only_mvp";
 
+export type CryptoReferenceSourceState =
+  | "available"
+  | "cached"
+  | "fixture"
+  | "reference_only"
+  | "stale"
+  | "unavailable"
+  | "error";
+
+export type CryptoReferenceFreshness = "fresh" | "partial" | "stale" | "missing" | "fixture";
+
 export type CryptoRiskBadgeKind =
   | "thin_orderbook"
   | "held"
@@ -134,4 +145,70 @@ export interface CryptoDashboardResponse {
   insights: CryptoInsightsSummary;
   capabilities: CryptoDashboardCapabilities;
   meta: { warnings: string[]; sources: CryptoSourceState[] };
+}
+
+export interface CryptoReferenceSourceMeta {
+  source: string;
+  label: string;
+  state: CryptoReferenceSourceState;
+  fetchedAt: string | null;
+  cacheAgeSeconds: number | null;
+  freshness: CryptoReferenceFreshness;
+  errorCode: string | null;
+  referenceOnly: boolean;
+}
+
+export interface NaverCryptoRankItem {
+  rank: number;
+  symbol: string;
+  displayName: string;
+  priceKrw: number | null;
+  changeRate24h: number | null;
+  tradeAmount24h: number | null;
+  rsi: number | null;
+  marketWarning: boolean | null;
+  source: string;
+}
+
+export interface NaverCryptoProfile {
+  symbol: string;
+  baseSymbol: string;
+  displayName: string;
+  koreanName: string | null;
+  englishName: string | null;
+  naverUrl: string | null;
+  officialMarket: string | null;
+  referenceNotes: string[];
+}
+
+export interface NaverCryptoKimchiPremium {
+  baseSymbol: string;
+  premiumPct: number | null;
+  domesticPriceKrw: number | null;
+  overseasPriceKrw: number | null;
+  state: CryptoReferenceSourceState;
+  source: string;
+  caution: string;
+}
+
+export interface NaverCryptoReferenceCapabilities {
+  rank: CryptoCapabilityFlag;
+  price: CryptoCapabilityFlag;
+  profile: CryptoCapabilityFlag;
+  news: CryptoCapabilityFlag;
+  kimchiPremium: CryptoCapabilityFlag;
+  execution: CryptoCapabilityFlag;
+}
+
+export interface NaverCryptoReferenceResponse {
+  market: "crypto";
+  asOf: string;
+  symbol: string | null;
+  rank: NaverCryptoRankItem[];
+  profile: NaverCryptoProfile | null;
+  news: { items: Array<{ id: number; title: string; publisher: string | null; url: string }> } | null;
+  kimchiPremium: NaverCryptoKimchiPremium | null;
+  sources: CryptoReferenceSourceMeta[];
+  warnings: string[];
+  capabilities: NaverCryptoReferenceCapabilities;
 }

--- a/frontend/invest/src/types/investCrypto.ts
+++ b/frontend/invest/src/types/investCrypto.ts
@@ -6,6 +6,17 @@ export type CryptoCapabilityState =
   | "deferred"
   | "read_only_mvp";
 
+export type CryptoReferenceSourceState =
+  | "available"
+  | "cached"
+  | "fixture"
+  | "reference_only"
+  | "stale"
+  | "unavailable"
+  | "error";
+
+export type CryptoReferenceFreshness = "fresh" | "partial" | "stale" | "missing" | "fixture";
+
 export type CryptoRiskBadgeKind =
   | "thin_orderbook"
   | "held"
@@ -98,4 +109,70 @@ export interface CryptoDashboardResponse {
   insights: CryptoInsightsSummary;
   capabilities: CryptoDashboardCapabilities;
   meta: { warnings: string[]; sources: CryptoSourceState[] };
+}
+
+export interface CryptoReferenceSourceMeta {
+  source: string;
+  label: string;
+  state: CryptoReferenceSourceState;
+  fetchedAt: string | null;
+  cacheAgeSeconds: number | null;
+  freshness: CryptoReferenceFreshness;
+  errorCode: string | null;
+  referenceOnly: boolean;
+}
+
+export interface NaverCryptoRankItem {
+  rank: number;
+  symbol: string;
+  displayName: string;
+  priceKrw: number | null;
+  changeRate24h: number | null;
+  tradeAmount24h: number | null;
+  rsi: number | null;
+  marketWarning: boolean | null;
+  source: string;
+}
+
+export interface NaverCryptoProfile {
+  symbol: string;
+  baseSymbol: string;
+  displayName: string;
+  koreanName: string | null;
+  englishName: string | null;
+  naverUrl: string | null;
+  officialMarket: string | null;
+  referenceNotes: string[];
+}
+
+export interface NaverCryptoKimchiPremium {
+  baseSymbol: string;
+  premiumPct: number | null;
+  domesticPriceKrw: number | null;
+  overseasPriceKrw: number | null;
+  state: CryptoReferenceSourceState;
+  source: string;
+  caution: string;
+}
+
+export interface NaverCryptoReferenceCapabilities {
+  rank: CryptoCapabilityFlag;
+  price: CryptoCapabilityFlag;
+  profile: CryptoCapabilityFlag;
+  news: CryptoCapabilityFlag;
+  kimchiPremium: CryptoCapabilityFlag;
+  execution: CryptoCapabilityFlag;
+}
+
+export interface NaverCryptoReferenceResponse {
+  market: "crypto";
+  asOf: string;
+  symbol: string | null;
+  rank: NaverCryptoRankItem[];
+  profile: NaverCryptoProfile | null;
+  news: { items: Array<{ id: number; title: string; publisher: string | null; url: string }> } | null;
+  kimchiPremium: NaverCryptoKimchiPremium | null;
+  sources: CryptoReferenceSourceMeta[];
+  warnings: string[];
+  capabilities: NaverCryptoReferenceCapabilities;
 }

--- a/frontend/invest/src/types/investCrypto.ts
+++ b/frontend/invest/src/types/investCrypto.ts
@@ -12,10 +12,11 @@ export type CryptoReferenceSourceState =
   | "fixture"
   | "reference_only"
   | "stale"
+  | "live"
   | "unavailable"
   | "error";
 
-export type CryptoReferenceFreshness = "fresh" | "partial" | "stale" | "missing" | "fixture";
+export type CryptoReferenceFreshness = "fresh" | "partial" | "stale" | "missing" | "fixture" | "live";
 
 export type CryptoRiskBadgeKind =
   | "thin_orderbook"

--- a/frontend/invest/src/types/screener.ts
+++ b/frontend/invest/src/types/screener.ts
@@ -21,6 +21,46 @@ export interface ScreenerPresetsResponse {
   selectedPresetId: string | null;
 }
 
+export type ScreenerDataSourceKind =
+  | "upbit_official"
+  | "tvscreener_upbit"
+  | "mcp_screen_stocks"
+  | "naver_reference"
+  | "coingecko_reference"
+  | "external_reference"
+  | "snapshot_cache";
+
+export type ScreenerSourceState =
+  | "supported"
+  | "cached"
+  | "reference_only"
+  | "partial"
+  | "unavailable"
+  | "fallback";
+
+export type ScreenerRiskSeverity = "info" | "warning" | "danger";
+
+export interface ScreenerSourceContext {
+  source: ScreenerDataSourceKind;
+  label: string;
+  state: ScreenerSourceState;
+  fetchedAt: string | null;
+  detail: string | null;
+}
+
+export interface ScreenerRiskContext {
+  kind: string;
+  label: string;
+  severity: ScreenerRiskSeverity;
+  source: ScreenerDataSourceKind | null;
+}
+
+export interface ScreenerCandidateContext {
+  scoreLabel: string | null;
+  reasons: string[];
+  source: ScreenerDataSourceKind | null;
+}
+
 export interface ScreenerResultRow {
   rank: number;
   symbol: string;
@@ -38,6 +78,9 @@ export interface ScreenerResultRow {
   analystLabel: string;
   metricValueLabel: string;
   warnings: string[];
+  sourceContext?: ScreenerSourceContext[];
+  riskContext?: ScreenerRiskContext[];
+  candidateContext?: ScreenerCandidateContext | null;
 }
 
 export type ScreenerFreshnessSource = "live" | "cached" | "previous_session";
@@ -61,4 +104,5 @@ export interface ScreenerResultsResponse {
   results: ScreenerResultRow[];
   warnings: string[];
   freshness: ScreenerFreshness;
+  sources?: ScreenerSourceContext[];
 }

--- a/frontend/invest/src/types/stockDetail.ts
+++ b/frontend/invest/src/types/stockDetail.ts
@@ -2,7 +2,7 @@ import type { AccountSource, AssetCategory, AssetType, Currency, PriceState } fr
 import type { FeedNewsResponse } from "./feedNews";
 
 export type StockDetailMarket = "kr" | "us" | "crypto";
-export type OrderbookUnsupportedReason = "us_unsupported" | "crypto_deferred" | "kr_unavailable";
+export type OrderbookUnsupportedReason = "us_unsupported" | "crypto_deferred" | "kr_unavailable" | "provider_unavailable";
 export type CapabilityUnsupportedReason =
   | "read_only_mvp"
   | "out_of_mvp_scope"
@@ -233,6 +233,70 @@ export interface StockDetailOrderbookSupport extends CapabilityFlag {
   reason: OrderbookUnsupportedReason | null;
 }
 
+export interface CryptoRecentTradeItem {
+  tradeTime: string | null;
+  priceKrw: number;
+  volume: number;
+  side: string | null;
+  sequentialId: string | number | null;
+  source: "upbit_recent_trades";
+}
+
+export interface CryptoRecentTrades {
+  items: CryptoRecentTradeItem[];
+  emptyState: "no_recent_trades" | null;
+  source: "upbit_recent_trades";
+  state: "supported" | "empty" | "unavailable";
+  asOf: string | null;
+  warnings: string[];
+}
+
+export interface CryptoPreOrderCheckItem {
+  key: string;
+  label: string;
+  state: "ok" | "warning" | "danger" | "unavailable" | "info";
+  detail: string;
+  source: string;
+  computedAt: string;
+}
+
+export interface CryptoDetail {
+  profile: {
+    symbol: string;
+    baseSymbol: string;
+    displayNameKo: string | null;
+    displayNameEn: string | null;
+    quoteCurrency: "KRW";
+    source: string;
+    state: "supported" | "unavailable";
+    asOf: string | null;
+  };
+  recentTrades: CryptoRecentTrades;
+  pendingOrders: {
+    items: Array<{
+      orderId: string | null;
+      symbol: string;
+      baseSymbol: string;
+      side: string;
+      orderType: string | null;
+      price: number | null;
+      quantity: number;
+      filledQuantity: number;
+      status: string;
+      orderedAt: string | null;
+      updatedAt: string | null;
+    }>;
+    emptyState: "no_pending_orders" | null;
+  };
+  preOrderChecklist: {
+    mode: "informational_only";
+    items: CryptoPreOrderCheckItem[];
+    disclaimer: string;
+    sources: string[];
+  };
+  sources: Array<{ source: string; state: string; label: string; fetchedAt: string | null }>;
+}
+
 export interface StockDetailResponse {
   symbol: string;
   market: StockDetailMarket;
@@ -253,6 +317,7 @@ export interface StockDetailResponse {
   orderbookSupport: StockDetailOrderbookSupport;
   orderbook: StockDetailOrderbook | null;
   capabilities: StockDetailCapabilities;
+  cryptoDetail: CryptoDetail | null;
   meta: { computedAt: string; warnings: string[] };
 }
 

--- a/tests/test_invest_api_crypto_router.py
+++ b/tests/test_invest_api_crypto_router.py
@@ -18,6 +18,7 @@ from app.schemas.invest_crypto import (
     CryptoDashboardMeta,
     CryptoDashboardResponse,
     CryptoInsightsSummary,
+    NaverCryptoReferenceResponse,
 )
 from app.schemas.invest_home import InvestHomeResponse, InvestHomeResponseMeta
 from app.services.invest_home_service import build_grouped_holdings, build_home_summary
@@ -83,3 +84,46 @@ def test_crypto_dashboard_endpoint_uses_read_only_view_model(
     assert calls["dashboard"]["user_id"] == 7
     assert calls["dashboard"]["limit"] == 3
     assert calls["dashboard"]["resolver"] is not None
+
+
+@pytest.mark.unit
+def test_crypto_naver_reference_endpoint_uses_read_only_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: dict[str, Any] = {}
+
+    async def fake_relation_resolver(
+        db: Any, *, user_id: int, held_pairs: set[tuple[str, str]]
+    ):
+        calls["relation"] = {"db": db, "user_id": user_id, "held_pairs": held_pairs}
+        return object()
+
+    async def fake_reference(**kwargs: Any) -> NaverCryptoReferenceResponse:
+        calls["reference"] = kwargs
+        return NaverCryptoReferenceResponse(
+            asOf=datetime(2026, 5, 14, 12, tzinfo=UTC),
+            symbol="KRW-BTC",
+            rank=[],
+            profile=None,
+            news=None,
+            kimchiPremium=None,
+            sources=[],
+            warnings=["read_only_no_order_watch_or_broker_mutation"],
+        )
+
+    monkeypatch.setattr(invest_api, "build_relation_resolver", fake_relation_resolver)
+    monkeypatch.setattr(invest_api, "build_naver_crypto_reference", fake_reference)
+
+    response = TestClient(_build_app()).get(
+        "/invest/api/crypto/naver-reference?symbol=BTC&limit=4"
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["market"] == "crypto"
+    assert payload["symbol"] == "KRW-BTC"
+    assert "read_only_no_order_watch_or_broker_mutation" in payload["warnings"]
+    assert calls["relation"]["user_id"] == 7
+    assert calls["reference"]["symbol"] == "BTC"
+    assert calls["reference"]["limit"] == 4
+    assert calls["reference"]["resolver"] is not None

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -78,7 +78,7 @@ async def test_crypto_dashboard_maps_ticker_spread_relation_and_pending_orders()
             {
                 "market": "KRW-BTC",
                 "trade_price": 101000000,
-                "signed_change_rate": 0.0123,
+                "signed_change_rate": 0.041,
                 "signed_change_price": 1230000,
                 "acc_trade_price_24h": 12345678900,
                 "acc_trade_volume_24h": 234.5,
@@ -86,7 +86,7 @@ async def test_crypto_dashboard_maps_ticker_spread_relation_and_pending_orders()
             {
                 "market": "KRW-ETH",
                 "trade_price": 5200000,
-                "signed_change_rate": 0.052,
+                "signed_change_rate": 0.032,
                 "signed_change_price": 260000,
                 "acc_trade_price_24h": 8500000000,
                 "acc_trade_volume_24h": 1000,
@@ -131,8 +131,18 @@ async def test_crypto_dashboard_maps_ticker_spread_relation_and_pending_orders()
     assert response.pendingOrders.items[0].orderId == "upbit-open-1"
     assert response.pendingOrders.emptyState is None
     assert response.capabilities.execution.state == "read_only_mvp"
-    assert [candidate.symbol for candidate in response.insights.candidates] == ["KRW-ETH"]
-    assert response.insights.candidates[0].reasons[:2] == ["watched", "momentum"]
+    assert [candidate.symbol for candidate in response.insights.candidates][:2] == [
+        "KRW-ETH",
+        "KRW-BTC",
+    ]
+    assert response.insights.candidates[0].reasons[:2] == ["watched", "liquidity"]
+    assert {source.source for source in response.meta.sources} >= {
+        "upbit_ticker",
+        "upbit_orderbook",
+        "pending_orders",
+        "mcp_risk_reference",
+        "mcp_candidate_reference",
+    }
 
 
 @pytest.mark.asyncio
@@ -227,6 +237,87 @@ async def test_crypto_dashboard_candidate_insights_are_read_only_and_ranked():
 
 
 @pytest.mark.asyncio
+async def test_crypto_dashboard_sorts_cards_by_move_then_volume_before_limit():
+    markets = [
+        _market("KRW-AAA", "AAA", "에이"),
+        _market("KRW-BBB", "BBB", "비"),
+        _market("KRW-CCC", "CCC", "씨"),
+    ]
+
+    async def ticker_provider(requested_markets):
+        assert requested_markets == ["KRW-AAA", "KRW-BBB", "KRW-CCC"]
+        return [
+            {
+                "market": "KRW-AAA",
+                "trade_price": 1000,
+                "signed_change_rate": 0.01,
+                "acc_trade_price_24h": 10_000_000_000,
+            },
+            {
+                "market": "KRW-BBB",
+                "trade_price": 1000,
+                "signed_change_rate": -0.07,
+                "acc_trade_price_24h": 100_000_000,
+            },
+            {
+                "market": "KRW-CCC",
+                "trade_price": 1000,
+                "signed_change_rate": 0.07,
+                "acc_trade_price_24h": 200_000_000,
+            },
+        ]
+
+    async def spread_provider(requested_markets):
+        assert requested_markets == ["KRW-CCC", "KRW-BBB"]
+        return dict.fromkeys(requested_markets, 0.2)
+
+    response = await build_crypto_dashboard(
+        db=FakeSession(markets, []),
+        user_id=7,
+        ticker_provider=ticker_provider,
+        orderbook_spread_provider=spread_provider,
+        limit=2,
+        orderbook_limit=2,
+    )
+
+    assert [card.symbol for card in response.cards] == ["KRW-CCC", "KRW-BBB"]
+    assert "KRW-AAA" not in [card.symbol for card in response.cards]
+
+
+@pytest.mark.asyncio
+async def test_crypto_dashboard_ranks_full_universe_before_limit():
+    markets = [_market(f"KRW-{index:03d}", f"C{index:03d}", f"코인{index:03d}") for index in range(60)]
+    top_market = markets[-1].market
+
+    async def ticker_provider(requested_markets):
+        assert requested_markets == [market.market for market in markets]
+        return [
+            {
+                "market": market.market,
+                "trade_price": 1000,
+                "signed_change_rate": 0.2 if market.market == top_market else 0.01,
+                "acc_trade_price_24h": 10_000_000_000,
+            }
+            for market in markets
+        ]
+
+    async def spread_provider(requested_markets):
+        assert requested_markets == [top_market]
+        return {top_market: 0.2}
+
+    response = await build_crypto_dashboard(
+        db=FakeSession(markets, []),
+        user_id=7,
+        ticker_provider=ticker_provider,
+        orderbook_spread_provider=spread_provider,
+        limit=1,
+        orderbook_limit=1,
+    )
+
+    assert [card.symbol for card in response.cards] == [top_market]
+
+
+@pytest.mark.asyncio
 async def test_crypto_dashboard_is_renderable_when_public_sources_fail():
     async def failing_ticker(_markets):
         raise RuntimeError("upstream down")
@@ -250,4 +341,13 @@ async def test_crypto_dashboard_is_renderable_when_public_sources_fail():
     assert response.pendingOrders.emptyState == "no_pending_orders"
     assert "crypto_ticker_unavailable" in response.meta.warnings
     assert "crypto_orderbook_unavailable" in response.meta.warnings
-    assert {source.state for source in response.meta.sources} == {"unavailable"}
+    assert {source.source for source in response.meta.sources} >= {
+        "upbit_ticker",
+        "pending_orders",
+        "mcp_risk_reference",
+        "mcp_candidate_reference",
+    }
+    states = {source.source: source.state for source in response.meta.sources}
+    assert states["upbit_ticker"] == "unavailable"
+    assert states["pending_orders"] == "supported"
+    assert states["mcp_risk_reference"] == "reference_only"

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -167,3 +167,82 @@ async def test_dashboard_records_stale_source_state_from_read_model():
     sources = {source.source: source for source in response.meta.sources}
     assert sources["upbit_ticker"].state == "supported"
     assert response.cards[0].priceKrw == 100.0
+
+
+@pytest.mark.asyncio
+async def test_default_dashboard_reuses_single_upbit_read_model_redis_client(monkeypatch):
+    import fakeredis.aioredis
+
+    from app.services.upbit_public_read_model import close_default_read_model
+
+    await close_default_read_model()
+    redis_clients = []
+
+    async def create_redis_client():
+        client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+        redis_clients.append(client)
+        return client
+
+    async def fetch_tickers(markets):
+        return [
+            {
+                "market": market,
+                "trade_price": 101000000,
+                "signed_change_rate": 0.0123,
+                "signed_change_price": 1230000,
+                "acc_trade_price_24h": 12345678900,
+                "acc_trade_volume_24h": 234.5,
+            }
+            for market in markets
+        ]
+
+    async def fetch_orderbooks(markets):
+        return {
+            market: {
+                "market": market,
+                "orderbook_units": [
+                    {
+                        "ask_price": 101000000,
+                        "bid_price": 100900000,
+                        "ask_size": 1,
+                        "bid_size": 1,
+                    }
+                ],
+            }
+            for market in markets
+        }
+
+    async def fetch_trades(_market, _count):
+        return []
+
+    monkeypatch.setattr(
+        "app.services.ohlcv_cache_common.create_redis_client", create_redis_client
+    )
+    monkeypatch.setattr(
+        "app.services.brokers.upbit.client.fetch_multiple_tickers", fetch_tickers
+    )
+    monkeypatch.setattr(
+        "app.services.upbit_orderbook.fetch_multiple_orderbooks", fetch_orderbooks
+    )
+    monkeypatch.setattr(
+        "app.services.brokers.upbit.public_trades.fetch_recent_trades", fetch_trades
+    )
+
+    try:
+        first = await build_crypto_dashboard(
+            db=FakeSession([_market()], []), user_id=7
+        )
+        second = await build_crypto_dashboard(
+            db=FakeSession([_market()], []), user_id=7
+        )
+
+        assert len(redis_clients) == 1
+        assert first.cards[0].priceKrw == 101000000
+        assert second.cards[0].priceKrw == 101000000
+        assert {source.source for source in first.meta.sources} >= {
+            "upbit_ticker",
+            "upbit_orderbook",
+        }
+        assert first.meta.warnings == []
+    finally:
+        await close_default_read_model()

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.pending_order import PendingOrder
 from app.services.invest_view_model.crypto_dashboard_service import (
@@ -39,6 +41,10 @@ class FakeSession:
         if len(self.statements) == 1:
             return _Result(self.universe_rows)
         return _Result(self.pending_rows)
+
+
+def _session(universe_rows, pending_rows=None) -> AsyncSession:
+    return cast(AsyncSession, FakeSession(universe_rows, pending_rows))
 
 
 def _market(market="KRW-BTC", base="BTC", korean_name="비트코인"):
@@ -101,7 +107,7 @@ async def test_crypto_dashboard_maps_ticker_spread_relation_and_pending_orders()
         held={("crypto", "KRW-BTC")}, watch={("crypto", "KRW-ETH")}
     )
     response = await build_crypto_dashboard(
-        db=FakeSession(
+        db=_session(
             [_market(), _market("KRW-ETH", "ETH", "이더리움")], [_pending("BTC")]
         ),
         user_id=7,
@@ -163,7 +169,7 @@ async def test_crypto_dashboard_marks_high_volatility_and_low_liquidity():
         return {"KRW-XRP": 0.1}
 
     response = await build_crypto_dashboard(
-        db=FakeSession([_market("KRW-XRP", "XRP", "리플")], []),
+        db=_session([_market("KRW-XRP", "XRP", "리플")], []),
         user_id=7,
         ticker_provider=ticker_provider,
         orderbook_spread_provider=spread_provider,
@@ -215,7 +221,7 @@ async def test_crypto_dashboard_candidate_insights_are_read_only_and_ranked():
 
     resolver = RelationResolver(watch={("crypto", "KRW-AAA"), ("crypto", "KRW-BBB")})
     response = await build_crypto_dashboard(
-        db=FakeSession(markets, [_pending("BBB")]),
+        db=_session(markets, [_pending("BBB")]),
         user_id=7,
         resolver=resolver,
         ticker_provider=ticker_provider,
@@ -281,7 +287,7 @@ async def test_crypto_dashboard_sorts_cards_by_move_then_volume_before_limit():
         return dict.fromkeys(requested_markets, 0.2)
 
     response = await build_crypto_dashboard(
-        db=FakeSession(markets, []),
+        db=_session(markets, []),
         user_id=7,
         ticker_provider=ticker_provider,
         orderbook_spread_provider=spread_provider,
@@ -318,7 +324,7 @@ async def test_crypto_dashboard_ranks_full_universe_before_limit():
         return {top_market: 0.2}
 
     response = await build_crypto_dashboard(
-        db=FakeSession(markets, []),
+        db=_session(markets, []),
         user_id=7,
         ticker_provider=ticker_provider,
         orderbook_spread_provider=spread_provider,
@@ -338,7 +344,7 @@ async def test_crypto_dashboard_is_renderable_when_public_sources_fail():
         raise RuntimeError("upstream down")
 
     response = await build_crypto_dashboard(
-        db=FakeSession([_market()], []),
+        db=_session([_market()], []),
         user_id=7,
         ticker_provider=failing_ticker,
         orderbook_spread_provider=failing_spread,
@@ -384,7 +390,7 @@ async def test_dashboard_records_stale_source_state_from_read_model():
         )
 
     response = await build_crypto_dashboard(
-        db=FakeSession([_market()], []),
+        db=_session([_market()], []),
         user_id=7,
         ticker_provider=stale_ticker_provider,
         orderbook_spread_provider=lambda _: {},
@@ -468,10 +474,8 @@ async def test_default_dashboard_reuses_single_upbit_read_model_redis_client(
     )
 
     try:
-        first = await build_crypto_dashboard(db=FakeSession([_market()], []), user_id=7)
-        second = await build_crypto_dashboard(
-            db=FakeSession([_market()], []), user_id=7
-        )
+        first = await build_crypto_dashboard(db=_session([_market()], []), user_id=7)
+        second = await build_crypto_dashboard(db=_session([_market()], []), user_id=7)
 
         assert len(redis_clients) == 1
         assert first.cards[0].priceKrw == 101000000

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -397,7 +397,7 @@ async def test_dashboard_records_stale_source_state_from_read_model():
     )
     sources = {source.source: source for source in response.meta.sources}
     assert sources["upbit_ticker"].state == "supported"
-    assert response.cards[0].priceKrw == 100.0
+    assert response.cards[0].priceKrw == pytest.approx(100.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -47,7 +47,7 @@ def _market(market="KRW-BTC", base="BTC", korean_name="비트코인"):
         base_currency=base,
         quote_currency="KRW",
         korean_name=korean_name,
-        english_name="Bitcoin",
+        english_name=base,
         is_active=True,
     )
 
@@ -73,7 +73,7 @@ def _pending(symbol="KRW-BTC"):
 @pytest.mark.asyncio
 async def test_crypto_dashboard_maps_ticker_spread_relation_and_pending_orders():
     async def ticker_provider(markets):
-        assert markets == ["KRW-BTC"]
+        assert markets == ["KRW-BTC", "KRW-ETH"]
         return [
             {
                 "market": "KRW-BTC",
@@ -82,39 +82,148 @@ async def test_crypto_dashboard_maps_ticker_spread_relation_and_pending_orders()
                 "signed_change_price": 1230000,
                 "acc_trade_price_24h": 12345678900,
                 "acc_trade_volume_24h": 234.5,
-            }
+            },
+            {
+                "market": "KRW-ETH",
+                "trade_price": 5200000,
+                "signed_change_rate": 0.052,
+                "signed_change_price": 260000,
+                "acc_trade_price_24h": 8500000000,
+                "acc_trade_volume_24h": 1000,
+            },
         ]
 
     async def spread_provider(markets):
-        assert markets == ["KRW-BTC"]
-        return {"KRW-BTC": 0.62}
+        assert markets == ["KRW-BTC", "KRW-ETH"]
+        return {"KRW-BTC": 0.62, "KRW-ETH": 0.2}
 
     resolver = RelationResolver(
-        held={("crypto", "KRW-BTC")}, watch={("crypto", "KRW-BTC")}
+        held={("crypto", "KRW-BTC")}, watch={("crypto", "KRW-ETH")}
     )
     response = await build_crypto_dashboard(
-        db=FakeSession([_market()], [_pending("BTC")]),
+        db=FakeSession(
+            [_market(), _market("KRW-ETH", "ETH", "이더리움")], [_pending("BTC")]
+        ),
         user_id=7,
         resolver=resolver,
         ticker_provider=ticker_provider,
         orderbook_spread_provider=spread_provider,
     )
 
+    btc = response.cards[0]
     assert response.market == "crypto"
-    assert response.cards[0].symbol == "KRW-BTC"
-    assert response.cards[0].priceKrw == 101000000
-    assert response.cards[0].orderbookSpreadPct == pytest.approx(0.62)
-    assert response.cards[0].isHeld is True
-    assert response.cards[0].isWatched is True
-    assert {badge.kind for badge in response.cards[0].badges} >= {
+    assert btc.symbol == "KRW-BTC"
+    assert btc.priceKrw == 101000000
+    assert btc.orderbookSpreadPct == pytest.approx(0.62)
+    assert btc.isHeld is True
+    assert btc.isWatched is False
+    assert {badge.kind for badge in btc.badges} >= {
         "held",
         "pending_order",
         "thin_orderbook",
     }
+    assert btc.risk is not None
+    assert btc.risk.score == 35
+    assert btc.risk.level == "medium"
+    assert "호가 스프레드 확대" in btc.risk.reasons
+    assert "미체결 상태 존재" in btc.risk.reasons
     assert response.pendingOrders is not None
     assert response.pendingOrders.items[0].orderId == "upbit-open-1"
     assert response.pendingOrders.emptyState is None
     assert response.capabilities.execution.state == "read_only_mvp"
+    assert [candidate.symbol for candidate in response.insights.candidates] == ["KRW-ETH"]
+    assert response.insights.candidates[0].reasons[:2] == ["watched", "momentum"]
+
+
+@pytest.mark.asyncio
+async def test_crypto_dashboard_marks_high_volatility_and_low_liquidity():
+    async def ticker_provider(_markets):
+        return [
+            {
+                "market": "KRW-XRP",
+                "trade_price": 1000,
+                "signed_change_rate": 0.081,
+                "signed_change_price": 81,
+                "acc_trade_price_24h": 100_000_000,
+                "acc_trade_volume_24h": 10_000,
+            }
+        ]
+
+    async def spread_provider(_markets):
+        return {"KRW-XRP": 0.1}
+
+    response = await build_crypto_dashboard(
+        db=FakeSession([_market("KRW-XRP", "XRP", "리플")], []),
+        user_id=7,
+        ticker_provider=ticker_provider,
+        orderbook_spread_provider=spread_provider,
+    )
+
+    card = response.cards[0]
+    assert {badge.kind for badge in card.badges} >= {
+        "high_volatility",
+        "low_liquidity",
+    }
+    assert card.risk is not None
+    assert card.risk.level == "medium"
+    assert "24시간 변동성 확대" in card.risk.reasons
+    candidate_summaries = " ".join(
+        candidate.summary for candidate in response.insights.candidates
+    )
+    assert "매수" not in candidate_summaries
+    assert "주문" not in candidate_summaries
+
+
+@pytest.mark.asyncio
+async def test_crypto_dashboard_candidate_insights_are_read_only_and_ranked():
+    markets = [
+        _market("KRW-AAA", "AAA", "에이"),
+        _market("KRW-BBB", "BBB", "비"),
+        _market("KRW-CCC", "CCC", "씨"),
+        _market("KRW-DDD", "DDD", "디"),
+        _market("KRW-EEE", "EEE", "이"),
+        _market("KRW-FFF", "FFF", "에프"),
+    ]
+
+    async def ticker_provider(_markets):
+        return [
+            {
+                "market": row.market,
+                "trade_price": 1000,
+                "signed_change_rate": 0.05 if row.market != "KRW-CCC" else 0.08,
+                "signed_change_price": 50,
+                "acc_trade_price_24h": 2_000_000_000 + index,
+                "acc_trade_volume_24h": 10_000,
+            }
+            for index, row in enumerate(markets)
+        ]
+
+    async def spread_provider(_markets):
+        return {row.market: (0.2 if row.market != "KRW-CCC" else 0.8) for row in markets}
+
+    resolver = RelationResolver(watch={("crypto", "KRW-AAA"), ("crypto", "KRW-BBB")})
+    response = await build_crypto_dashboard(
+        db=FakeSession(markets, [_pending("BBB")]),
+        user_id=7,
+        resolver=resolver,
+        ticker_provider=ticker_provider,
+        orderbook_spread_provider=spread_provider,
+        limit=6,
+        orderbook_limit=6,
+    )
+
+    candidates = response.insights.candidates
+    assert len(candidates) == 5
+    assert candidates[0].symbol == "KRW-AAA"
+    assert candidates[0].score > candidates[1].score
+    assert any(candidate.symbol == "KRW-BBB" for candidate in candidates)
+    bbb = next(candidate for candidate in candidates if candidate.symbol == "KRW-BBB")
+    assert bbb.hasPendingOrder is True
+    assert "pending_order" in bbb.reasons
+    serialized = [candidate.model_dump() for candidate in candidates]
+    forbidden_fields = {"action", "execute", "order", "watchIntent", "clientOrderId", "mutation"}
+    for item in serialized:
+        assert forbidden_fields.isdisjoint(item)
 
 
 @pytest.mark.asyncio
@@ -133,6 +242,10 @@ async def test_crypto_dashboard_is_renderable_when_public_sources_fail():
     )
 
     assert response.cards[0].priceKrw is None
+    assert response.cards[0].risk is not None
+    assert response.cards[0].risk.level == "unknown"
+    assert "data_unavailable" in {badge.kind for badge in response.cards[0].badges}
+    assert response.insights.candidates == []
     assert response.pendingOrders is not None
     assert response.pendingOrders.emptyState == "no_pending_orders"
     assert "crypto_ticker_unavailable" in response.meta.warnings

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -209,7 +209,9 @@ async def test_crypto_dashboard_candidate_insights_are_read_only_and_ranked():
         ]
 
     async def spread_provider(_markets):
-        return {row.market: (0.2 if row.market != "KRW-CCC" else 0.8) for row in markets}
+        return {
+            row.market: (0.2 if row.market != "KRW-CCC" else 0.8) for row in markets
+        }
 
     resolver = RelationResolver(watch={("crypto", "KRW-AAA"), ("crypto", "KRW-BBB")})
     response = await build_crypto_dashboard(
@@ -231,7 +233,14 @@ async def test_crypto_dashboard_candidate_insights_are_read_only_and_ranked():
     assert bbb.hasPendingOrder is True
     assert "pending_order" in bbb.reasons
     serialized = [candidate.model_dump() for candidate in candidates]
-    forbidden_fields = {"action", "execute", "order", "watchIntent", "clientOrderId", "mutation"}
+    forbidden_fields = {
+        "action",
+        "execute",
+        "order",
+        "watchIntent",
+        "clientOrderId",
+        "mutation",
+    }
     for item in serialized:
         assert forbidden_fields.isdisjoint(item)
 
@@ -286,7 +295,10 @@ async def test_crypto_dashboard_sorts_cards_by_move_then_volume_before_limit():
 
 @pytest.mark.asyncio
 async def test_crypto_dashboard_ranks_full_universe_before_limit():
-    markets = [_market(f"KRW-{index:03d}", f"C{index:03d}", f"코인{index:03d}") for index in range(60)]
+    markets = [
+        _market(f"KRW-{index:03d}", f"C{index:03d}", f"코인{index:03d}")
+        for index in range(60)
+    ]
     top_market = markets[-1].market
 
     async def ticker_provider(requested_markets):

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -170,7 +170,9 @@ async def test_dashboard_records_stale_source_state_from_read_model():
 
 
 @pytest.mark.asyncio
-async def test_default_dashboard_reuses_single_upbit_read_model_redis_client(monkeypatch):
+async def test_default_dashboard_reuses_single_upbit_read_model_redis_client(
+    monkeypatch,
+):
     import fakeredis.aioredis
 
     from app.services.upbit_public_read_model import close_default_read_model
@@ -229,9 +231,7 @@ async def test_default_dashboard_reuses_single_upbit_read_model_redis_client(mon
     )
 
     try:
-        first = await build_crypto_dashboard(
-            db=FakeSession([_market()], []), user_id=7
-        )
+        first = await build_crypto_dashboard(db=FakeSession([_market()], []), user_id=7)
         second = await build_crypto_dashboard(
             db=FakeSession([_market()], []), user_id=7
         )

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -386,15 +386,27 @@ async def test_dashboard_records_stale_source_state_from_read_model():
 async def test_default_dashboard_reuses_single_upbit_read_model_redis_client(
     monkeypatch,
 ):
-    import fakeredis.aioredis
-
     from app.services.upbit_public_read_model import close_default_read_model
+
+    class FakeRedis:
+        def __init__(self):
+            self.values: dict[str, str] = {}
+            self.closed = False
+
+        async def get(self, key: str):
+            return self.values.get(key)
+
+        async def set(self, key: str, value: str, *, ex: int | None = None):
+            self.values[key] = value
+
+        async def aclose(self):
+            self.closed = True
 
     await close_default_read_model()
     redis_clients = []
 
     async def create_redis_client():
-        client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+        client = FakeRedis()
         redis_clients.append(client)
         return client
 

--- a/tests/test_invest_crypto_dashboard_service.py
+++ b/tests/test_invest_crypto_dashboard_service.py
@@ -138,3 +138,32 @@ async def test_crypto_dashboard_is_renderable_when_public_sources_fail():
     assert "crypto_ticker_unavailable" in response.meta.warnings
     assert "crypto_orderbook_unavailable" in response.meta.warnings
     assert {source.state for source in response.meta.sources} == {"unavailable"}
+
+
+@pytest.mark.asyncio
+async def test_dashboard_records_stale_source_state_from_read_model():
+    from app.services.upbit_public_read_model.types import (
+        UpbitBlockMeta,
+        UpbitTickerBlock,
+    )
+
+    async def stale_ticker_provider(markets):
+        return UpbitTickerBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_ticker",
+                state="stale",
+                label="Upbit ticker",
+                errorReason="rate_limited",
+            ),
+            tickers={m: {"market": m, "trade_price": 100.0} for m in markets},
+        )
+
+    response = await build_crypto_dashboard(
+        db=FakeSession([_market()], []),
+        user_id=7,
+        ticker_provider=stale_ticker_provider,
+        orderbook_spread_provider=lambda _: {},
+    )
+    sources = {source.source: source for source in response.meta.sources}
+    assert sources["upbit_ticker"].state == "supported"
+    assert response.cards[0].priceKrw == 100.0

--- a/tests/test_invest_crypto_naver_adapter.py
+++ b/tests/test_invest_crypto_naver_adapter.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -28,6 +30,7 @@ class _SnapshotRow:
     rsi: Decimal | None = None
     market_warning: bool = False
     source: str = "tvscreener_upbit"
+    computed_at: datetime | None = None
 
 
 @pytest.mark.unit
@@ -44,14 +47,25 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
                 change_rate=Decimal("0.0123"),
                 trade_amount_24h=Decimal("1000000000"),
                 rsi=Decimal("55.5"),
+                computed_at=datetime(2026, 5, 14, 12, tzinfo=UTC),
             )
         ]
 
     async def ticker_provider(markets: list[str]):
         assert markets == ["KRW-BTC"]
-        return [{"market": "KRW-BTC", "trade_price": 91000000}]
+        return [
+            {
+                "market": "KRW-BTC",
+                "trade_price": 91000000,
+                "timestamp": int(
+                    datetime(2026, 5, 14, 12, tzinfo=UTC).timestamp() * 1000
+                ),
+            }
+        ]
 
-    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
+    async def news_provider(
+        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
+    ):
         assert symbol == "KRW-BTC"
         return FeedNewsResponse(
             tab="crypto",
@@ -74,6 +88,7 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
             "premium_pct": 2.5,
             "domestic_price_krw": 91000000,
             "overseas_price_krw": 88780000,
+            "fetched_at": datetime(2026, 5, 14, 12, tzinfo=UTC),
         }
 
     response = await build_naver_crypto_reference(
@@ -102,7 +117,126 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
     assert "naver_crypto_reference_only" in response.warnings
     source_by_name = {source.source: source for source in response.sources}
     assert source_by_name["naver_reference"].referenceOnly is True
+    assert source_by_name["naver_reference"].freshness == "fixture"
+    assert source_by_name["tvscreener_upbit"].state in {"cached", "stale"}
+    assert source_by_name["tvscreener_upbit"].fetchedAt == datetime(
+        2026, 5, 14, 12, tzinfo=UTC
+    )
+    assert source_by_name["tvscreener_upbit"].cacheAgeSeconds is not None
+    assert source_by_name["upbit_official"].fetchedAt == datetime(
+        2026, 5, 14, 12, tzinfo=UTC
+    )
+    assert source_by_name["upbit_official"].cacheAgeSeconds is not None
+    assert source_by_name["feed_news"].fetchedAt == datetime(
+        2026, 5, 14, 12, tzinfo=UTC
+    )
     assert source_by_name["mcp_kimchi_premium"].referenceOnly is True
+    assert source_by_name["mcp_kimchi_premium"].fetchedAt == datetime(
+        2026, 5, 14, 12, tzinfo=UTC
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_naver_crypto_reference_defaults_do_not_call_uncached_live_upbit_ticker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden_live_fetch(markets: list[str]):
+        raise AssertionError(f"unexpected live Upbit ticker fetch: {markets}")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "app.services.brokers.upbit.client",
+        SimpleNamespace(fetch_multiple_tickers=forbidden_live_fetch),
+    )
+
+    async def rank_provider(db: Any, limit: int):
+        return [
+            _SnapshotRow(
+                symbol="KRW-BTC",
+                name="비트코인",
+                latest_close=Decimal("90000000"),
+                change_rate=Decimal("0.0123"),
+                computed_at=datetime.now(UTC) - timedelta(minutes=5),
+            )
+        ]
+
+    async def news_provider(
+        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
+    ):
+        return FeedNewsResponse(
+            tab="crypto",
+            asOf=datetime.now(UTC) - timedelta(minutes=5),
+            items=[],
+        )
+
+    response = await build_naver_crypto_reference(
+        db="db",  # type: ignore[arg-type]
+        symbol="BTC",
+        providers=NaverCryptoReferenceProviders(
+            rank_provider=rank_provider,
+            news_provider=news_provider,
+        ),
+    )
+
+    assert response.rank[0].priceKrw == 90000000.0
+    source_by_name = {source.source: source for source in response.sources}
+    assert source_by_name["upbit_official"].state == "unavailable"
+    assert source_by_name["upbit_official"].freshness == "missing"
+    assert source_by_name["mcp_kimchi_premium"].state == "unavailable"
+    assert source_by_name["mcp_kimchi_premium"].referenceOnly is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_naver_crypto_reference_marks_stale_cached_read_model_sources() -> None:
+    stale_at = datetime.now(UTC) - timedelta(days=3)
+
+    async def rank_provider(db: Any, limit: int):
+        return [
+            _SnapshotRow(
+                symbol="KRW-BTC",
+                name="비트코인",
+                latest_close=Decimal("90000000"),
+                computed_at=stale_at,
+            )
+        ]
+
+    async def news_provider(
+        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
+    ):
+        return FeedNewsResponse(
+            tab="crypto",
+            asOf=stale_at,
+            items=[
+                FeedNewsItem(
+                    id=2,
+                    title="old cached crypto news",
+                    publisher="fixture",
+                    market="crypto",
+                    url="https://example.test/old",
+                )
+            ],
+        )
+
+    response = await build_naver_crypto_reference(
+        db="db",  # type: ignore[arg-type]
+        symbol="BTC",
+        providers=NaverCryptoReferenceProviders(
+            rank_provider=rank_provider,
+            news_provider=news_provider,
+        ),
+    )
+
+    source_by_name = {source.source: source for source in response.sources}
+    assert source_by_name["tvscreener_upbit"].state == "stale"
+    assert source_by_name["tvscreener_upbit"].freshness == "stale"
+    assert source_by_name["tvscreener_upbit"].fetchedAt == stale_at
+    assert source_by_name["tvscreener_upbit"].cacheAgeSeconds is not None
+    assert source_by_name["feed_news"].state == "stale"
+    assert source_by_name["feed_news"].fetchedAt == stale_at
+    assert source_by_name["naver_reference"].state == "fixture"
+    assert source_by_name["naver_reference"].cacheAgeSeconds is None
 
 
 @pytest.mark.unit
@@ -114,7 +248,9 @@ async def test_naver_crypto_reference_gracefully_records_provider_failures() -> 
     async def ticker_provider(markets: list[str]):
         raise RuntimeError("ticker down")
 
-    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
+    async def news_provider(
+        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
+    ):
         raise RuntimeError("news down")
 
     async def kimchi_provider(base_symbol: str):
@@ -139,7 +275,9 @@ async def test_naver_crypto_reference_gracefully_records_provider_failures() -> 
     assert "crypto_rank_snapshot_unavailable" in response.warnings
     assert "crypto_news_unavailable" in response.warnings
     assert "crypto_kimchi_premium_unavailable" in response.warnings
-    error_sources = {source.source for source in response.sources if source.state == "error"}
+    error_sources = {
+        source.source for source in response.sources if source.state == "error"
+    }
     assert {"tvscreener_upbit", "feed_news", "mcp_kimchi_premium"} <= error_sources
 
 

--- a/tests/test_invest_crypto_naver_adapter.py
+++ b/tests/test_invest_crypto_naver_adapter.py
@@ -105,14 +105,14 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
 
     assert response.symbol == "KRW-BTC"
     assert response.rank[0].symbol == "KRW-BTC"
-    assert response.rank[0].priceKrw == 90000000.0
+    assert response.rank[0].priceKrw == pytest.approx(90000000.0)
     assert response.profile is not None
     assert response.profile.naverUrl is not None
     assert response.profile.referenceNotes
     assert response.news is not None
     assert response.news.items[0].title == "BTC reference news"
     assert response.kimchiPremium is not None
-    assert response.kimchiPremium.premiumPct == 2.5
+    assert response.kimchiPremium.premiumPct == pytest.approx(2.5)
     assert response.capabilities.execution.state == "read_only_mvp"
     assert "naver_crypto_reference_only" in response.warnings
     source_by_name = {source.source: source for source in response.sources}
@@ -179,7 +179,7 @@ async def test_naver_crypto_reference_defaults_do_not_call_uncached_live_upbit_t
         ),
     )
 
-    assert response.rank[0].priceKrw == 90000000.0
+    assert response.rank[0].priceKrw == pytest.approx(90000000.0)
     source_by_name = {source.source: source for source in response.sources}
     assert source_by_name["upbit_official"].state == "unavailable"
     assert source_by_name["upbit_official"].freshness == "missing"

--- a/tests/test_invest_crypto_naver_adapter.py
+++ b/tests/test_invest_crypto_naver_adapter.py
@@ -57,11 +57,15 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
             {
                 "market": "KRW-BTC",
                 "trade_price": 91000000,
-                "timestamp": int(datetime(2026, 5, 14, 12, tzinfo=UTC).timestamp() * 1000),
+                "timestamp": int(
+                    datetime(2026, 5, 14, 12, tzinfo=UTC).timestamp() * 1000
+                ),
             }
         ]
 
-    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
+    async def news_provider(
+        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
+    ):
         assert symbol == "KRW-BTC"
         return FeedNewsResponse(
             tab="crypto",
@@ -115,13 +119,21 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
     assert source_by_name["naver_reference"].referenceOnly is True
     assert source_by_name["naver_reference"].freshness == "fixture"
     assert source_by_name["tvscreener_upbit"].state in {"cached", "stale"}
-    assert source_by_name["tvscreener_upbit"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
+    assert source_by_name["tvscreener_upbit"].fetchedAt == datetime(
+        2026, 5, 14, 12, tzinfo=UTC
+    )
     assert source_by_name["tvscreener_upbit"].cacheAgeSeconds is not None
-    assert source_by_name["upbit_official"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
+    assert source_by_name["upbit_official"].fetchedAt == datetime(
+        2026, 5, 14, 12, tzinfo=UTC
+    )
     assert source_by_name["upbit_official"].cacheAgeSeconds is not None
-    assert source_by_name["feed_news"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
+    assert source_by_name["feed_news"].fetchedAt == datetime(
+        2026, 5, 14, 12, tzinfo=UTC
+    )
     assert source_by_name["mcp_kimchi_premium"].referenceOnly is True
-    assert source_by_name["mcp_kimchi_premium"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
+    assert source_by_name["mcp_kimchi_premium"].fetchedAt == datetime(
+        2026, 5, 14, 12, tzinfo=UTC
+    )
 
 
 @pytest.mark.unit
@@ -149,7 +161,9 @@ async def test_naver_crypto_reference_defaults_do_not_call_uncached_live_upbit_t
             )
         ]
 
-    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
+    async def news_provider(
+        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
+    ):
         return FeedNewsResponse(
             tab="crypto",
             asOf=datetime.now(UTC) - timedelta(minutes=5),
@@ -188,7 +202,9 @@ async def test_naver_crypto_reference_marks_stale_cached_read_model_sources() ->
             )
         ]
 
-    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
+    async def news_provider(
+        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
+    ):
         return FeedNewsResponse(
             tab="crypto",
             asOf=stale_at,
@@ -232,7 +248,9 @@ async def test_naver_crypto_reference_gracefully_records_provider_failures() -> 
     async def ticker_provider(markets: list[str]):
         raise RuntimeError("ticker down")
 
-    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
+    async def news_provider(
+        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
+    ):
         raise RuntimeError("news down")
 
     async def kimchi_provider(base_symbol: str):
@@ -257,7 +275,9 @@ async def test_naver_crypto_reference_gracefully_records_provider_failures() -> 
     assert "crypto_rank_snapshot_unavailable" in response.warnings
     assert "crypto_news_unavailable" in response.warnings
     assert "crypto_kimchi_premium_unavailable" in response.warnings
-    error_sources = {source.source for source in response.sources if source.state == "error"}
+    error_sources = {
+        source.source for source in response.sources if source.state == "error"
+    }
     assert {"tvscreener_upbit", "feed_news", "mcp_kimchi_premium"} <= error_sources
 
 

--- a/tests/test_invest_crypto_naver_adapter.py
+++ b/tests/test_invest_crypto_naver_adapter.py
@@ -1,0 +1,150 @@
+"""ROB-234 tests for the read-only Naver-style crypto adapter."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from app.schemas.invest_feed_news import FeedNewsItem, FeedNewsResponse
+from app.services.invest_crypto_naver_adapter import (
+    NaverCryptoReferenceProviders,
+    build_naver_crypto_reference,
+    normalize_krw_symbol,
+)
+from app.services.invest_view_model.relation_resolver import RelationResolver
+
+
+@dataclass
+class _SnapshotRow:
+    symbol: str
+    name: str
+    latest_close: Decimal
+    change_rate: Decimal | None = None
+    trade_amount_24h: Decimal | None = None
+    rsi: Decimal | None = None
+    market_warning: bool = False
+    source: str = "tvscreener_upbit"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() -> None:
+    async def rank_provider(db: Any, limit: int):
+        assert db == "db"
+        assert limit == 5
+        return [
+            _SnapshotRow(
+                symbol="KRW-BTC",
+                name="비트코인",
+                latest_close=Decimal("90000000"),
+                change_rate=Decimal("0.0123"),
+                trade_amount_24h=Decimal("1000000000"),
+                rsi=Decimal("55.5"),
+            )
+        ]
+
+    async def ticker_provider(markets: list[str]):
+        assert markets == ["KRW-BTC"]
+        return [{"market": "KRW-BTC", "trade_price": 91000000}]
+
+    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
+        assert symbol == "KRW-BTC"
+        return FeedNewsResponse(
+            tab="crypto",
+            asOf=datetime(2026, 5, 14, 12, tzinfo=UTC),
+            items=[
+                FeedNewsItem(
+                    id=1,
+                    title="BTC reference news",
+                    publisher="fixture",
+                    market="crypto",
+                    url="https://example.test/btc",
+                )
+            ],
+        )
+
+    async def kimchi_provider(base_symbol: str):
+        assert base_symbol == "BTC"
+        return {
+            "symbol": "BTC",
+            "premium_pct": 2.5,
+            "domestic_price_krw": 91000000,
+            "overseas_price_krw": 88780000,
+        }
+
+    response = await build_naver_crypto_reference(
+        db="db",  # type: ignore[arg-type]
+        symbol="BTC",
+        limit=5,
+        providers=NaverCryptoReferenceProviders(
+            rank_provider=rank_provider,
+            ticker_provider=ticker_provider,
+            news_provider=news_provider,
+            kimchi_provider=kimchi_provider,
+        ),
+    )
+
+    assert response.symbol == "KRW-BTC"
+    assert response.rank[0].symbol == "KRW-BTC"
+    assert response.rank[0].priceKrw == 90000000.0
+    assert response.profile is not None
+    assert response.profile.naverUrl is not None
+    assert response.profile.referenceNotes
+    assert response.news is not None
+    assert response.news.items[0].title == "BTC reference news"
+    assert response.kimchiPremium is not None
+    assert response.kimchiPremium.premiumPct == 2.5
+    assert response.capabilities.execution.state == "read_only_mvp"
+    assert "naver_crypto_reference_only" in response.warnings
+    source_by_name = {source.source: source for source in response.sources}
+    assert source_by_name["naver_reference"].referenceOnly is True
+    assert source_by_name["mcp_kimchi_premium"].referenceOnly is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_naver_crypto_reference_gracefully_records_provider_failures() -> None:
+    async def rank_provider(db: Any, limit: int):
+        raise RuntimeError("rank down")
+
+    async def ticker_provider(markets: list[str]):
+        raise RuntimeError("ticker down")
+
+    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
+        raise RuntimeError("news down")
+
+    async def kimchi_provider(base_symbol: str):
+        raise RuntimeError("kimchi down")
+
+    response = await build_naver_crypto_reference(
+        db=object(),  # type: ignore[arg-type]
+        symbol="KRW-BTC",
+        providers=NaverCryptoReferenceProviders(
+            rank_provider=rank_provider,
+            ticker_provider=ticker_provider,
+            news_provider=news_provider,
+            kimchi_provider=kimchi_provider,
+        ),
+    )
+
+    assert response.market == "crypto"
+    assert response.profile is not None
+    assert response.profile.symbol == "KRW-BTC"
+    assert response.kimchiPremium is not None
+    assert response.kimchiPremium.state == "unavailable"
+    assert "crypto_rank_snapshot_unavailable" in response.warnings
+    assert "crypto_news_unavailable" in response.warnings
+    assert "crypto_kimchi_premium_unavailable" in response.warnings
+    error_sources = {source.source for source in response.sources if source.state == "error"}
+    assert {"tvscreener_upbit", "feed_news", "mcp_kimchi_premium"} <= error_sources
+
+
+@pytest.mark.unit
+def test_normalize_krw_symbol_accepts_base_and_pair_aliases() -> None:
+    assert normalize_krw_symbol("BTC") == "KRW-BTC"
+    assert normalize_krw_symbol("btc-krw") == "KRW-BTC"
+    assert normalize_krw_symbol("KRW/ETH") == "KRW-ETH"

--- a/tests/test_invest_crypto_naver_adapter.py
+++ b/tests/test_invest_crypto_naver_adapter.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -28,6 +30,7 @@ class _SnapshotRow:
     rsi: Decimal | None = None
     market_warning: bool = False
     source: str = "tvscreener_upbit"
+    computed_at: datetime | None = None
 
 
 @pytest.mark.unit
@@ -44,12 +47,19 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
                 change_rate=Decimal("0.0123"),
                 trade_amount_24h=Decimal("1000000000"),
                 rsi=Decimal("55.5"),
+                computed_at=datetime(2026, 5, 14, 12, tzinfo=UTC),
             )
         ]
 
     async def ticker_provider(markets: list[str]):
         assert markets == ["KRW-BTC"]
-        return [{"market": "KRW-BTC", "trade_price": 91000000}]
+        return [
+            {
+                "market": "KRW-BTC",
+                "trade_price": 91000000,
+                "timestamp": int(datetime(2026, 5, 14, 12, tzinfo=UTC).timestamp() * 1000),
+            }
+        ]
 
     async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
         assert symbol == "KRW-BTC"
@@ -74,6 +84,7 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
             "premium_pct": 2.5,
             "domestic_price_krw": 91000000,
             "overseas_price_krw": 88780000,
+            "fetched_at": datetime(2026, 5, 14, 12, tzinfo=UTC),
         }
 
     response = await build_naver_crypto_reference(
@@ -102,7 +113,114 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
     assert "naver_crypto_reference_only" in response.warnings
     source_by_name = {source.source: source for source in response.sources}
     assert source_by_name["naver_reference"].referenceOnly is True
+    assert source_by_name["naver_reference"].freshness == "fixture"
+    assert source_by_name["tvscreener_upbit"].state in {"cached", "stale"}
+    assert source_by_name["tvscreener_upbit"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
+    assert source_by_name["tvscreener_upbit"].cacheAgeSeconds is not None
+    assert source_by_name["upbit_official"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
+    assert source_by_name["upbit_official"].cacheAgeSeconds is not None
+    assert source_by_name["feed_news"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
     assert source_by_name["mcp_kimchi_premium"].referenceOnly is True
+    assert source_by_name["mcp_kimchi_premium"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_naver_crypto_reference_defaults_do_not_call_uncached_live_upbit_ticker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden_live_fetch(markets: list[str]):
+        raise AssertionError(f"unexpected live Upbit ticker fetch: {markets}")
+
+    monkeypatch.setitem(
+        sys.modules,
+        "app.services.brokers.upbit.client",
+        SimpleNamespace(fetch_multiple_tickers=forbidden_live_fetch),
+    )
+
+    async def rank_provider(db: Any, limit: int):
+        return [
+            _SnapshotRow(
+                symbol="KRW-BTC",
+                name="비트코인",
+                latest_close=Decimal("90000000"),
+                change_rate=Decimal("0.0123"),
+                computed_at=datetime.now(UTC) - timedelta(minutes=5),
+            )
+        ]
+
+    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
+        return FeedNewsResponse(
+            tab="crypto",
+            asOf=datetime.now(UTC) - timedelta(minutes=5),
+            items=[],
+        )
+
+    response = await build_naver_crypto_reference(
+        db="db",  # type: ignore[arg-type]
+        symbol="BTC",
+        providers=NaverCryptoReferenceProviders(
+            rank_provider=rank_provider,
+            news_provider=news_provider,
+        ),
+    )
+
+    assert response.rank[0].priceKrw == 90000000.0
+    source_by_name = {source.source: source for source in response.sources}
+    assert source_by_name["upbit_official"].state == "unavailable"
+    assert source_by_name["upbit_official"].freshness == "missing"
+    assert source_by_name["mcp_kimchi_premium"].state == "unavailable"
+    assert source_by_name["mcp_kimchi_premium"].referenceOnly is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_naver_crypto_reference_marks_stale_cached_read_model_sources() -> None:
+    stale_at = datetime.now(UTC) - timedelta(days=3)
+
+    async def rank_provider(db: Any, limit: int):
+        return [
+            _SnapshotRow(
+                symbol="KRW-BTC",
+                name="비트코인",
+                latest_close=Decimal("90000000"),
+                computed_at=stale_at,
+            )
+        ]
+
+    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
+        return FeedNewsResponse(
+            tab="crypto",
+            asOf=stale_at,
+            items=[
+                FeedNewsItem(
+                    id=2,
+                    title="old cached crypto news",
+                    publisher="fixture",
+                    market="crypto",
+                    url="https://example.test/old",
+                )
+            ],
+        )
+
+    response = await build_naver_crypto_reference(
+        db="db",  # type: ignore[arg-type]
+        symbol="BTC",
+        providers=NaverCryptoReferenceProviders(
+            rank_provider=rank_provider,
+            news_provider=news_provider,
+        ),
+    )
+
+    source_by_name = {source.source: source for source in response.sources}
+    assert source_by_name["tvscreener_upbit"].state == "stale"
+    assert source_by_name["tvscreener_upbit"].freshness == "stale"
+    assert source_by_name["tvscreener_upbit"].fetchedAt == stale_at
+    assert source_by_name["tvscreener_upbit"].cacheAgeSeconds is not None
+    assert source_by_name["feed_news"].state == "stale"
+    assert source_by_name["feed_news"].fetchedAt == stale_at
+    assert source_by_name["naver_reference"].state == "fixture"
+    assert source_by_name["naver_reference"].cacheAgeSeconds is None
 
 
 @pytest.mark.unit

--- a/tests/test_invest_crypto_naver_adapter.py
+++ b/tests/test_invest_crypto_naver_adapter.py
@@ -57,15 +57,11 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
             {
                 "market": "KRW-BTC",
                 "trade_price": 91000000,
-                "timestamp": int(
-                    datetime(2026, 5, 14, 12, tzinfo=UTC).timestamp() * 1000
-                ),
+                "timestamp": int(datetime(2026, 5, 14, 12, tzinfo=UTC).timestamp() * 1000),
             }
         ]
 
-    async def news_provider(
-        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
-    ):
+    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
         assert symbol == "KRW-BTC"
         return FeedNewsResponse(
             tab="crypto",
@@ -119,21 +115,13 @@ async def test_naver_crypto_reference_aggregates_rank_profile_news_and_kimchi() 
     assert source_by_name["naver_reference"].referenceOnly is True
     assert source_by_name["naver_reference"].freshness == "fixture"
     assert source_by_name["tvscreener_upbit"].state in {"cached", "stale"}
-    assert source_by_name["tvscreener_upbit"].fetchedAt == datetime(
-        2026, 5, 14, 12, tzinfo=UTC
-    )
+    assert source_by_name["tvscreener_upbit"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
     assert source_by_name["tvscreener_upbit"].cacheAgeSeconds is not None
-    assert source_by_name["upbit_official"].fetchedAt == datetime(
-        2026, 5, 14, 12, tzinfo=UTC
-    )
+    assert source_by_name["upbit_official"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
     assert source_by_name["upbit_official"].cacheAgeSeconds is not None
-    assert source_by_name["feed_news"].fetchedAt == datetime(
-        2026, 5, 14, 12, tzinfo=UTC
-    )
+    assert source_by_name["feed_news"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
     assert source_by_name["mcp_kimchi_premium"].referenceOnly is True
-    assert source_by_name["mcp_kimchi_premium"].fetchedAt == datetime(
-        2026, 5, 14, 12, tzinfo=UTC
-    )
+    assert source_by_name["mcp_kimchi_premium"].fetchedAt == datetime(2026, 5, 14, 12, tzinfo=UTC)
 
 
 @pytest.mark.unit
@@ -161,9 +149,7 @@ async def test_naver_crypto_reference_defaults_do_not_call_uncached_live_upbit_t
             )
         ]
 
-    async def news_provider(
-        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
-    ):
+    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
         return FeedNewsResponse(
             tab="crypto",
             asOf=datetime.now(UTC) - timedelta(minutes=5),
@@ -202,9 +188,7 @@ async def test_naver_crypto_reference_marks_stale_cached_read_model_sources() ->
             )
         ]
 
-    async def news_provider(
-        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
-    ):
+    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
         return FeedNewsResponse(
             tab="crypto",
             asOf=stale_at,
@@ -248,9 +232,7 @@ async def test_naver_crypto_reference_gracefully_records_provider_failures() -> 
     async def ticker_provider(markets: list[str]):
         raise RuntimeError("ticker down")
 
-    async def news_provider(
-        db: Any, resolver: RelationResolver, symbol: str | None, limit: int
-    ):
+    async def news_provider(db: Any, resolver: RelationResolver, symbol: str | None, limit: int):
         raise RuntimeError("news down")
 
     async def kimchi_provider(base_symbol: str):
@@ -275,9 +257,7 @@ async def test_naver_crypto_reference_gracefully_records_provider_failures() -> 
     assert "crypto_rank_snapshot_unavailable" in response.warnings
     assert "crypto_news_unavailable" in response.warnings
     assert "crypto_kimchi_premium_unavailable" in response.warnings
-    error_sources = {
-        source.source for source in response.sources if source.state == "error"
-    }
+    error_sources = {source.source for source in response.sources if source.state == "error"}
     assert {"tvscreener_upbit", "feed_news", "mcp_kimchi_premium"} <= error_sources
 
 

--- a/tests/test_invest_view_model_screener_service.py
+++ b/tests/test_invest_view_model_screener_service.py
@@ -367,6 +367,131 @@ async def test_build_screener_results_uses_fresh_crypto_snapshots_first() -> Non
 
 @pytest.mark.unit
 @pytest.mark.asyncio
+async def test_crypto_snapshot_rows_include_source_risk_and_candidate_context() -> None:
+    fake_screening = type(
+        "ScreenerService",
+        (_FakeProductionScreening,),
+        {"__module__": "app.services.screener_service"},
+    )()
+    session = _FakeSession(
+        [
+            _FakeExecuteResult(scalar_rows=[date(2026, 5, 13)]),
+            _FakeExecuteResult(
+                scalar_rows=[
+                    _FakeCryptoSnapshot(
+                        rsi=Decimal("31.5"),
+                        trade_amount_24h=Decimal("234000000000"),
+                    )
+                ]
+            ),
+            _FakeExecuteResult(scalar_rows=[date(2026, 5, 13)]),
+            _FakeExecuteResult(rows=[_coverage_row(latest_count=30)]),
+        ]
+    )
+
+    resp = await build_screener_results(
+        preset_id="crypto_high_volume",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched=set()),
+        market="crypto",
+        session=session,
+        now=lambda: datetime(2026, 5, 13, 3, 0, tzinfo=UTC),
+    )
+
+    assert {source.source for source in resp.sources} >= {
+        "snapshot_cache",
+        "tvscreener_upbit",
+    }
+    row = resp.results[0]
+    assert {source.source for source in row.sourceContext} >= {
+        "snapshot_cache",
+        "tvscreener_upbit",
+    }
+    assert any(risk.kind == "low_rsi" for risk in row.riskContext)
+    assert row.candidateContext is not None
+    assert row.candidateContext.reasons
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_crypto_fallback_filters_to_upbit_krw_and_labels_mcp_sources() -> None:
+    fake_screening = MagicMock()
+    fake_screening.list_screening = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "symbol": "KRW-BTC",
+                    "market": "crypto",
+                    "name": "Bitcoin",
+                    "current_price": 150_000_000,
+                    "change_rate": 2.5,
+                    "trade_amount_24h": 120_000_000_000,
+                    "source": "tvscreener",
+                },
+                {
+                    "symbol": "BTC/USDT",
+                    "market": "crypto",
+                    "name": "Bitcoin/Tether",
+                    "current_price": 100_000,
+                    "change_rate": 1.0,
+                    "trade_amount_24h": 1,
+                },
+                {
+                    "symbol": "XRP/KRW",
+                    "market": "crypto",
+                    "name": "XRP",
+                    "current_price": 3_200,
+                    "change_rate": 3.0,
+                    "trade_amount_24h": 40_000_000_000,
+                    "source": "upbit_official",
+                },
+                {
+                    "symbol": "UPBIT:ETHKRW",
+                    "market": "crypto",
+                    "name": "Ethereum",
+                    "current_price": 4_800_000,
+                    "change_rate": 0.5,
+                    "trade_amount_24h": 50_000_000_000,
+                    "market_cap_rank": 2,
+                },
+            ],
+            "warnings": [
+                "HTTPSConnectionPool(host='API.UPBIT.COM'): TOKEN=synthetic-credential",
+            ],
+            "meta": {"source": "tvscreener", "coingecko_cached": True},
+        }
+    )
+
+    resp = await build_screener_results(
+        preset_id="crypto_high_volume",
+        screening_service=fake_screening,
+        resolver=_FakeResolver(watched=set()),
+        market="crypto",
+    )
+
+    assert [row.symbol for row in resp.results] == ["KRW-BTC", "KRW-XRP", "KRW-ETH"]
+    assert all(row.market == "crypto" for row in resp.results)
+    assert any("비KRW" in warning for warning in resp.warnings)
+    warning_text = " ".join(resp.warnings)
+    assert "api.upbit.com" not in warning_text.lower()
+    assert "token=" not in warning_text.lower()
+    assert {source.source for source in resp.sources} >= {
+        "mcp_screen_stocks",
+        "tvscreener_upbit",
+        "coingecko_reference",
+    }
+    assert {source.source for source in resp.results[0].sourceContext} >= {
+        "mcp_screen_stocks",
+        "tvscreener_upbit",
+    }
+    assert any(
+        source.source == "coingecko_reference" and source.state == "reference_only"
+        for source in resp.results[2].sourceContext
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
 async def test_build_screener_results_does_not_fallback_when_fresh_crypto_snapshot_has_no_qualifiers() -> (
     None
 ):

--- a/tests/test_stock_detail_capability_contract.py
+++ b/tests/test_stock_detail_capability_contract.py
@@ -10,7 +10,7 @@ from app.schemas.invest_stock_detail import default_capabilities_for_market
     [
         ("kr", True, None),
         ("us", False, "us_unsupported"),
-        ("crypto", False, "crypto_deferred"),
+        ("crypto", True, None),
     ],
 )
 def test_stock_detail_capabilities_keep_read_only_contract(

--- a/tests/test_stock_detail_orders.py
+++ b/tests/test_stock_detail_orders.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 
 import pytest
@@ -86,3 +87,48 @@ async def test_stock_detail_orders_clamps_days_at_365():
     )
 
     assert seen["days"] == 365
+
+
+@pytest.mark.asyncio
+async def test_stock_detail_orders_timeout_degrades_to_empty_with_warning():
+    async def fetcher(days, markets):
+        await asyncio.sleep(0.05)
+        return [
+            {
+                "symbol": "BTC",
+                "side": "buy",
+                "quantity": 1,
+                "price": 100,
+                "filled_at": datetime.now(UTC),
+                "order_id": "late",
+            }
+        ]
+
+    response = await build_stock_detail_orders(
+        market="crypto",
+        symbol="KRW-BTC",
+        fetcher=fetcher,
+        timeout_seconds=0.001,
+    )
+
+    assert response.symbol == "BTC"
+    assert response.items == []
+    assert response.meta.emptyState == "no_filled_orders"
+    assert response.meta.warnings == ["filled_orders_timeout"]
+
+
+@pytest.mark.asyncio
+async def test_stock_detail_orders_fetch_error_degrades_to_empty_with_warning():
+    async def fetcher(days, markets):
+        raise RuntimeError("broker history unavailable")
+
+    response = await build_stock_detail_orders(
+        market="crypto",
+        symbol="BTC-KRW",
+        fetcher=fetcher,
+    )
+
+    assert response.symbol == "BTC"
+    assert response.items == []
+    assert response.meta.emptyState == "no_filled_orders"
+    assert response.meta.warnings == ["filled_orders_unavailable"]

--- a/tests/test_stock_detail_service.py
+++ b/tests/test_stock_detail_service.py
@@ -6,7 +6,13 @@ from types import SimpleNamespace
 
 import pytest
 
-from app.schemas.invest_stock_detail import StockDetailHolding, StockDetailOrderbook
+from app.schemas.invest_crypto import CryptoPendingOrdersSummary
+from app.schemas.invest_stock_detail import (
+    CryptoRecentTrades,
+    StockDetailHolding,
+    StockDetailOrderbook,
+    StockDetailQuote,
+)
 from app.services.invest_view_model.stock_detail_service import (
     StockDetailProviders,
     build_stock_detail,
@@ -140,12 +146,26 @@ async def test_build_stock_detail_maps_holding_and_kr_orderbook_when_available()
 
 @pytest.mark.asyncio
 async def test_build_stock_detail_omits_naver_poc_for_crypto():
+    async def no_quote_provider(market, symbol, db):
+        return None
+
+    async def no_orderbook_provider(market, symbol, db):
+        return None
+
+    async def no_recent_trades_provider(market, symbol, db):
+        return None
+
     response = await build_stock_detail(
         user_id=1,
         market="crypto",
         symbol="KRW-BTC",
         db=SimpleNamespace(),
-        providers=StockDetailProviders(resolver=_resolve_crypto),
+        providers=StockDetailProviders(
+            resolver=_resolve_crypto,
+            quote=no_quote_provider,
+            orderbook=no_orderbook_provider,
+            recent_trades=no_recent_trades_provider,
+        ),
     )
 
     assert response.market == "crypto"
@@ -153,6 +173,7 @@ async def test_build_stock_detail_omits_naver_poc_for_crypto():
     assert response.fxSensitivity.status == "not_applicable"
     assert response.naverEnrichment is None
     assert response.orderbookSupport.supported is False
+    assert response.orderbookSupport.reason == "provider_unavailable"
 
 
 @pytest.mark.asyncio
@@ -242,3 +263,108 @@ async def test_build_stock_detail_degrades_when_us_fx_provider_fails():
     assert response.fxSensitivity.status == "missing_fx_rate"
     assert response.fxSensitivity.scenarios == []
     assert "fx_sensitivity_unavailable" in response.meta.warnings
+
+
+def test_build_stock_detail_crypto_includes_read_only_detail_and_preorder_check():
+    async def quote_provider(market, symbol, db):
+        assert market == "crypto"
+        assert symbol == "KRW-BTC"
+        return StockDetailQuote(
+            price=100_000_000,
+            previousClose=99_000_000,
+            changeAmount=1_000_000,
+            changeRate=1.01,
+            asOf=datetime.now(UTC),
+            priceState="live",
+        )
+
+    async def orderbook_provider(market, symbol, db):
+        return StockDetailOrderbook(
+            asks=[{"price": 100_100_000, "quantity": 0.5}],
+            bids=[{"price": 100_000_000, "quantity": 0.4}],
+        )
+
+    async def recent_trades_provider(market, symbol, db):
+        return CryptoRecentTrades(
+            state="supported",
+            items=[
+                {
+                    "priceKrw": 100_000_000,
+                    "volume": 0.01,
+                    "tradeTime": datetime.now(UTC),
+                }
+            ],
+        )
+
+    async def pending_orders_provider(user_id, market, symbol, db):
+        return CryptoPendingOrdersSummary(items=[], emptyState="no_pending_orders")
+
+    providers = StockDetailProviders(
+        resolver=_resolve_crypto,
+        quote=quote_provider,
+        orderbook=orderbook_provider,
+        recent_trades=recent_trades_provider,
+        pending_orders=pending_orders_provider,
+    )
+
+    response = asyncio.run(
+        build_stock_detail(
+            user_id=7,
+            market="crypto",
+            symbol="btc",
+            db=SimpleNamespace(),
+            providers=providers,
+        )
+    )
+
+    assert response.symbol == "KRW-BTC"
+    assert response.orderbookSupport.supported is True
+    assert response.orderbookSupport.reason is None
+    assert response.capabilities.orderbook.supported is True
+    assert response.capabilities.execution.supported is False
+    assert response.capabilities.execution.reason == "read_only_mvp"
+    assert response.cryptoDetail is not None
+    assert response.cryptoDetail.profile.baseSymbol == "BTC"
+    assert response.cryptoDetail.pendingOrders.emptyState == "no_pending_orders"
+    assert response.cryptoDetail.preOrderChecklist.mode == "informational_only"
+    assert any(
+        item.key == "read_only_guardrail"
+        for item in response.cryptoDetail.preOrderChecklist.items
+    )
+
+
+def test_build_stock_detail_crypto_orderbook_provider_unavailable_is_explicit():
+    async def failing_orderbook_provider(market, symbol, db):
+        raise RuntimeError("provider down")
+
+    async def no_quote_provider(market, symbol, db):
+        return None
+
+    async def no_recent_trades_provider(market, symbol, db):
+        return None
+
+    providers = StockDetailProviders(
+        resolver=_resolve_crypto,
+        quote=no_quote_provider,
+        orderbook=failing_orderbook_provider,
+        recent_trades=no_recent_trades_provider,
+    )
+
+    response = asyncio.run(
+        build_stock_detail(
+            user_id=7,
+            market="crypto",
+            symbol="KRW-BTC",
+            db=SimpleNamespace(),
+            providers=providers,
+        )
+    )
+
+    assert response.orderbook is None
+    assert response.orderbookSupport.supported is False
+    assert response.orderbookSupport.reason == "provider_unavailable"
+    assert response.capabilities.orderbook.supported is False
+    assert response.capabilities.orderbook.reason == "provider_unavailable"
+    assert "orderbook_unavailable" in response.meta.warnings
+    assert response.cryptoDetail is not None
+    assert response.cryptoDetail.recentTrades.state == "unavailable"

--- a/tests/test_upbit_public_trades.py
+++ b/tests/test_upbit_public_trades.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.services.brokers.upbit import public_trades
+
+
+@pytest.mark.asyncio
+async def test_fetch_recent_trades_returns_rows(monkeypatch):
+    sample = [{"market": "KRW-BTC", "trade_price": 1.0}]
+
+    async def fake_request_json(url, params=None):
+        assert "trades/ticks" in url
+        assert params == {"market": "KRW-BTC", "count": 50}
+        return sample
+
+    monkeypatch.setattr(public_trades, "_request_json", fake_request_json)
+    assert await public_trades.fetch_recent_trades("KRW-BTC", count=50) == sample
+
+
+@pytest.mark.asyncio
+async def test_fetch_recent_trades_normalizes_market_and_bounds_count(monkeypatch):
+    captured = {}
+
+    async def fake_request_json(url, params=None):
+        captured["params"] = params
+        return []
+
+    async def fake_market_by_coin(symbol):
+        assert symbol == "BTC"
+        return "KRW-BTC"
+
+    monkeypatch.setattr(public_trades, "_request_json", fake_request_json)
+    monkeypatch.setattr(public_trades, "get_upbit_market_by_coin", fake_market_by_coin)
+    await public_trades.fetch_recent_trades("btc", count=10_000)
+    assert captured["params"] == {"market": "KRW-BTC", "count": 500}
+
+
+@pytest.mark.asyncio
+async def test_fetch_recent_trades_propagates_http_error(monkeypatch):
+    async def fake_request_json(url, params=None):
+        raise httpx.HTTPStatusError(
+            "boom", request=httpx.Request("GET", url), response=httpx.Response(429)
+        )
+
+    monkeypatch.setattr(public_trades, "_request_json", fake_request_json)
+    with pytest.raises(httpx.HTTPStatusError):
+        await public_trades.fetch_recent_trades("KRW-BTC")

--- a/tests/upbit_public_read_model/conftest.py
+++ b/tests/upbit_public_read_model/conftest.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import fakeredis.aioredis
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def fake_redis():
+    client = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    try:
+        yield client
+    finally:
+        await client.flushall()
+        await client.aclose()

--- a/tests/upbit_public_read_model/test_candles_cache.py
+++ b/tests/upbit_public_read_model/test_candles_cache.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import pytest
+
+from app.services.upbit_public_read_model.candles_cache import CandlesCache
+
+
+@pytest.mark.asyncio
+async def test_candles_cache_rejects_intraday_period():
+    cache = CandlesCache(closed_candles_getter=lambda *a, **k: None)
+    with pytest.raises(ValueError):
+        await cache.get("KRW-BTC", period="1m", count=5)
+
+
+@pytest.mark.asyncio
+async def test_candles_cache_converts_dataframe_rows():
+    async def getter(market, count, period):
+        return pd.DataFrame(
+            [{"open": 1, "high": 2, "low": 0.5, "close": 1.5, "volume": 3, "value": 4}],
+            index=[pd.Timestamp("2026-05-14")],
+        )
+
+    block = await CandlesCache(closed_candles_getter=getter).get(
+        "KRW-BTC", period="day", count=1
+    )
+    assert block.meta.state == "fresh"
+    assert block.rows[0]["open"] == 1
+
+
+@pytest.mark.asyncio
+async def test_candles_cache_unavailable_on_exception():
+    async def getter(*args, **kwargs):
+        raise RuntimeError("down")
+
+    block = await CandlesCache(closed_candles_getter=getter).get(
+        "KRW-BTC", period="day", count=1
+    )
+    assert block.meta.state == "unavailable"

--- a/tests/upbit_public_read_model/test_market_warnings.py
+++ b/tests/upbit_public_read_model/test_market_warnings.py
@@ -1,0 +1,70 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.upbit_public_read_model.market_warnings import MarketWarningsService
+
+
+class _ScalarRows:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return _ScalarRows(self._rows)
+
+
+class FakeSession:
+    def __init__(self, rows):
+        self.rows = rows
+
+    async def execute(self, statement):
+        return _Result(self.rows)
+
+
+def _row(market="KRW-BTC", warning="NONE"):
+    return SimpleNamespace(
+        market=market,
+        quote_currency="KRW",
+        is_active=True,
+        market_warning=warning,
+        updated_at=datetime(2026, 5, 14, tzinfo=UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_market_warnings_universe_tier_does_not_call_http(fake_redis):
+    async def detail_fetcher():
+        raise AssertionError("must not call HTTP")
+
+    block = await MarketWarningsService(
+        redis=fake_redis, detail_fetcher=detail_fetcher
+    ).get(["KRW-BTC"], db=FakeSession([_row()]))
+    assert block.meta.state == "fresh"
+    assert block.entries["KRW-BTC"].warning == "NONE"
+
+
+@pytest.mark.asyncio
+async def test_market_warning_detail_tier_uses_cache(fake_redis, monkeypatch):
+    calls = 0
+
+    async def detail_fetcher():
+        nonlocal calls
+        calls += 1
+        return [{"market": "KRW-BTC", "market_event": {"warning": True}}]
+
+    svc = MarketWarningsService(redis=fake_redis, detail_fetcher=detail_fetcher)
+    session = FakeSession([_row()])
+    first = await svc.get(["KRW-BTC"], include_event_detail=True, db=session)
+    second = await svc.get(["KRW-BTC"], include_event_detail=True, db=session)
+    assert first.entries["KRW-BTC"].event == {"warning": True}
+    assert second.entries["KRW-BTC"].event == {"warning": True}
+    assert calls == 1

--- a/tests/upbit_public_read_model/test_orderbook_cache.py
+++ b/tests/upbit_public_read_model/test_orderbook_cache.py
@@ -1,0 +1,113 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.services.upbit_public_read_model.orderbook_cache import OrderbookCache
+from app.services.upbit_public_read_model.types import ORDERBOOK_TTL_SECONDS
+
+
+class BrokenRedis:
+    async def get(self, key):
+        raise RuntimeError("redis get unavailable")
+
+    async def set(self, key, value, ex=None):
+        raise RuntimeError("redis set unavailable")
+
+
+def _book(market="KRW-BTC"):
+    return {
+        "market": market,
+        "orderbook_units": [
+            {"ask_price": 100.0, "bid_price": 99.0, "ask_size": 1, "bid_size": 1}
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_orderbook_cache_computes_spread_and_hits_cache(fake_redis):
+    calls = 0
+
+    async def fetcher(markets):
+        nonlocal calls
+        calls += 1
+        return {m: _book(m) for m in markets}
+
+    cache = OrderbookCache(redis=fake_redis, fetcher=fetcher)
+    first = await cache.get(["KRW-BTC"])
+    second = await cache.get(["KRW-BTC"])
+    assert first.spreadsPct["KRW-BTC"] == pytest.approx((100 - 99) / 99 * 100)
+    assert second.meta.state == "fresh"
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_orderbook_cache_stale_and_unavailable(fake_redis, monkeypatch):
+    async def fetcher_ok(markets):
+        return {m: _book(m) for m in markets}
+
+    cache = OrderbookCache(redis=fake_redis, fetcher=fetcher_ok)
+    await cache.get(["KRW-BTC"])
+    monkeypatch.setattr(
+        "app.services.upbit_public_read_model.orderbook_cache._now_utc",
+        lambda: datetime.now(UTC) + timedelta(seconds=ORDERBOOK_TTL_SECONDS + 1),
+    )
+
+    async def fail(markets):
+        raise RuntimeError("boom")
+
+    cache._fetcher = fail
+    assert (await cache.get(["KRW-BTC"])).meta.state == "stale"
+    empty = OrderbookCache(redis=fake_redis, fetcher=fail)
+    await fake_redis.flushall()
+    assert (await empty.get(["KRW-ETH"])).meta.state == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_orderbook_cache_partial_fetch_uses_stale_cache(fake_redis, monkeypatch):
+    async def fetcher_ok(markets):
+        return {m: _book(m) for m in markets}
+
+    cache = OrderbookCache(redis=fake_redis, fetcher=fetcher_ok)
+    await cache.get(["KRW-BTC"])
+    monkeypatch.setattr(
+        "app.services.upbit_public_read_model.orderbook_cache._now_utc",
+        lambda: datetime.now(UTC) + timedelta(seconds=ORDERBOOK_TTL_SECONDS + 1),
+    )
+
+    async def partial(markets):
+        assert markets == ["KRW-BTC", "KRW-ETH"]
+        return {"KRW-ETH": _book("KRW-ETH")}
+
+    cache._fetcher = partial
+    block = await cache.get(["KRW-BTC", "KRW-ETH"])
+    assert block.meta.state == "stale"
+    assert block.meta.errorReason == "partial_missing"
+    assert set(block.orderbooks) == {"KRW-BTC", "KRW-ETH"}
+
+
+@pytest.mark.asyncio
+async def test_orderbook_cache_empty_fetch_without_cache_is_unavailable(fake_redis):
+    async def empty(markets):
+        return {}
+
+    cache = OrderbookCache(redis=fake_redis, fetcher=empty)
+    block = await cache.get(["KRW-BTC"])
+    assert block.meta.state == "unavailable"
+    assert block.meta.errorReason == "partial_missing"
+    assert block.orderbooks == {}
+
+
+@pytest.mark.asyncio
+async def test_orderbook_cache_returns_fresh_when_redis_is_unavailable():
+    calls = 0
+
+    async def fetcher(markets):
+        nonlocal calls
+        calls += 1
+        return {m: _book(m) for m in markets}
+
+    cache = OrderbookCache(redis=BrokenRedis(), fetcher=fetcher)
+    block = await cache.get(["KRW-BTC"])
+    assert block.meta.state == "fresh"
+    assert block.spreadsPct["KRW-BTC"] == pytest.approx((100 - 99) / 99 * 100)
+    assert calls == 1

--- a/tests/upbit_public_read_model/test_read_model_facade.py
+++ b/tests/upbit_public_read_model/test_read_model_facade.py
@@ -1,0 +1,60 @@
+import pytest
+
+from app.services.upbit_public_read_model import (
+    UpbitPublicReadModel,
+    UpbitPublicSnapshot,
+)
+from app.services.upbit_public_read_model.types import (
+    UpbitBlockMeta,
+    UpbitMarketWarningEntry,
+    UpbitMarketWarningsBlock,
+)
+
+
+async def _inline_warnings_provider(markets):
+    return UpbitMarketWarningsBlock(
+        meta=UpbitBlockMeta(source="upbit_market_warnings", state="fresh", label="w"),
+        entries={
+            m: UpbitMarketWarningEntry(market=m, warning="NONE")
+            for m in (markets or [])
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_snapshot_composes_all_blocks(fake_redis):
+    async def ticker_fetcher(markets):
+        return [{"market": m, "trade_price": 1.0} for m in markets]
+
+    async def orderbook_fetcher(markets):
+        return {
+            m: {
+                "market": m,
+                "orderbook_units": [
+                    {"ask_price": 10.0, "bid_price": 9.0, "ask_size": 1, "bid_size": 1}
+                ],
+            }
+            for m in markets
+        }
+
+    async def trades_fetcher(market, count):
+        return [{"market": market, "trade_price": 1.0}]
+
+    rm = UpbitPublicReadModel(
+        redis=fake_redis,
+        ticker_fetcher=ticker_fetcher,
+        orderbook_fetcher=orderbook_fetcher,
+        trades_fetcher=trades_fetcher,
+        warnings_provider=_inline_warnings_provider,
+    )
+    snap = await rm.snapshot(["KRW-BTC"], include_trades_for=["KRW-BTC"])
+    assert isinstance(snap, UpbitPublicSnapshot)
+    assert snap.ticker.meta.state == "fresh"
+    assert snap.orderbook.spreadsPct["KRW-BTC"] > 0
+    assert snap.trades is not None and snap.trades.trades["KRW-BTC"]
+    assert {m.source for m in snap.sources} >= {
+        "upbit_ticker",
+        "upbit_orderbook",
+        "upbit_trades",
+        "upbit_market_warnings",
+    }

--- a/tests/upbit_public_read_model/test_safety_imports.py
+++ b/tests/upbit_public_read_model/test_safety_imports.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import importlib
+import sys
+
+_FORBIDDEN = {"app.services.brokers.upbit.orders", "app.services.upbit_websocket"}
+
+
+def test_read_model_does_not_import_broker_mutations():
+    for forbidden in _FORBIDDEN:
+        sys.modules.pop(forbidden, None)
+    importlib.import_module("app.services.upbit_public_read_model")
+    importlib.import_module("app.services.upbit_public_read_model.read_model")
+    for forbidden in _FORBIDDEN:
+        assert forbidden not in sys.modules

--- a/tests/upbit_public_read_model/test_ticker_cache.py
+++ b/tests/upbit_public_read_model/test_ticker_cache.py
@@ -49,7 +49,7 @@ async def test_ticker_cache_returns_stale_on_fetch_failure(fake_redis, monkeypat
     cache._fetcher = fetcher_fail
     block = await cache.get(["KRW-BTC"])
     assert block.meta.state == "stale"
-    assert block.tickers["KRW-BTC"]["trade_price"] == 1.0
+    assert block.tickers["KRW-BTC"]["trade_price"] == pytest.approx(1.0)
 
 
 @pytest.mark.asyncio
@@ -76,5 +76,5 @@ async def test_ticker_cache_returns_fresh_when_redis_is_unavailable():
     cache = TickerCache(redis=BrokenRedis(), fetcher=fetcher)
     block = await cache.get(["KRW-BTC"])
     assert block.meta.state == "fresh"
-    assert block.tickers["KRW-BTC"]["trade_price"] == 1.0
+    assert block.tickers["KRW-BTC"]["trade_price"] == pytest.approx(1.0)
     assert calls == 1

--- a/tests/upbit_public_read_model/test_ticker_cache.py
+++ b/tests/upbit_public_read_model/test_ticker_cache.py
@@ -1,0 +1,80 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.services.upbit_public_read_model.ticker_cache import TickerCache
+from app.services.upbit_public_read_model.types import TICKER_TTL_SECONDS
+
+
+class BrokenRedis:
+    async def get(self, key):
+        raise RuntimeError("redis get unavailable")
+
+    async def set(self, key, value, ex=None):
+        raise RuntimeError("redis set unavailable")
+
+
+@pytest.mark.asyncio
+async def test_ticker_cache_fresh_and_hits_redis(fake_redis):
+    calls = 0
+
+    async def fetcher(markets):
+        nonlocal calls
+        calls += 1
+        return [{"market": m, "trade_price": 1.0} for m in markets]
+
+    cache = TickerCache(redis=fake_redis, fetcher=fetcher)
+    first = await cache.get(["KRW-BTC"])
+    second = await cache.get(["KRW-BTC"])
+    assert first.meta.state == second.meta.state == "fresh"
+    assert calls == 1
+    assert second.meta.cachedAt is not None
+
+
+@pytest.mark.asyncio
+async def test_ticker_cache_returns_stale_on_fetch_failure(fake_redis, monkeypatch):
+    async def fetcher_ok(markets):
+        return [{"market": m, "trade_price": 1.0} for m in markets]
+
+    cache = TickerCache(redis=fake_redis, fetcher=fetcher_ok)
+    await cache.get(["KRW-BTC"])
+    monkeypatch.setattr(
+        "app.services.upbit_public_read_model.ticker_cache._now_utc",
+        lambda: datetime.now(UTC) + timedelta(seconds=TICKER_TTL_SECONDS + 1),
+    )
+
+    async def fetcher_fail(markets):
+        raise RuntimeError("boom")
+
+    cache._fetcher = fetcher_fail
+    block = await cache.get(["KRW-BTC"])
+    assert block.meta.state == "stale"
+    assert block.tickers["KRW-BTC"]["trade_price"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_ticker_cache_unavailable_and_missing(fake_redis):
+    async def fetcher_fail(markets):
+        raise RuntimeError("network")
+
+    cache = TickerCache(redis=fake_redis, fetcher=fetcher_fail)
+    assert (await cache.get([])).meta.state == "missing"
+    block = await cache.get(["KRW-BTC"])
+    assert block.meta.state == "unavailable"
+    assert block.meta.errorReason == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_ticker_cache_returns_fresh_when_redis_is_unavailable():
+    calls = 0
+
+    async def fetcher(markets):
+        nonlocal calls
+        calls += 1
+        return [{"market": m, "trade_price": 1.0} for m in markets]
+
+    cache = TickerCache(redis=BrokenRedis(), fetcher=fetcher)
+    block = await cache.get(["KRW-BTC"])
+    assert block.meta.state == "fresh"
+    assert block.tickers["KRW-BTC"]["trade_price"] == 1.0
+    assert calls == 1

--- a/tests/upbit_public_read_model/test_trades_cache.py
+++ b/tests/upbit_public_read_model/test_trades_cache.py
@@ -73,5 +73,5 @@ async def test_trades_cache_returns_fresh_when_redis_is_unavailable():
     cache = TradesCache(redis=BrokenRedis(), fetcher=fetcher)
     block = await cache.get("KRW-BTC", 50)
     assert block.meta.state == "fresh"
-    assert block.trades["KRW-BTC"][0]["trade_price"] == 1.0
+    assert block.trades["KRW-BTC"][0]["trade_price"] == pytest.approx(1.0)
     assert calls == 1

--- a/tests/upbit_public_read_model/test_trades_cache.py
+++ b/tests/upbit_public_read_model/test_trades_cache.py
@@ -1,0 +1,77 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.services.upbit_public_read_model.trades_cache import TradesCache
+from app.services.upbit_public_read_model.types import (
+    TRADES_TTL_SECONDS,
+    UpbitBlockMeta,
+    UpbitTradesBlock,
+)
+
+
+class BrokenRedis:
+    async def get(self, key):
+        raise RuntimeError("redis get unavailable")
+
+    async def set(self, key, value, ex=None):
+        raise RuntimeError("redis set unavailable")
+
+
+@pytest.mark.asyncio
+async def test_trades_cache_fresh_empty_and_bounds_count(fake_redis):
+    captured = {}
+
+    async def fetcher(market, count):
+        captured["args"] = (market, count)
+        return []
+
+    cache = TradesCache(redis=fake_redis, fetcher=fetcher)
+    block = await cache.get("KRW-BTC", 9999)
+    assert captured["args"] == ("KRW-BTC", 500)
+    assert block.meta.state == "fresh"
+    assert block.trades == {"KRW-BTC": []}
+
+
+@pytest.mark.asyncio
+async def test_trades_cache_stale_and_merge(fake_redis, monkeypatch):
+    async def ok(market, count):
+        return [{"market": market, "trade_price": 1.0}]
+
+    cache = TradesCache(redis=fake_redis, fetcher=ok)
+    await cache.get("KRW-BTC", 50)
+    monkeypatch.setattr(
+        "app.services.upbit_public_read_model.trades_cache._now_utc",
+        lambda: datetime.now(UTC) + timedelta(seconds=TRADES_TTL_SECONDS + 1),
+    )
+
+    async def fail(market, count):
+        raise RuntimeError("boom")
+
+    cache._fetcher = fail
+    stale = await cache.get("KRW-BTC", 50)
+    unavailable = UpbitTradesBlock(
+        meta=UpbitBlockMeta(
+            source="upbit_trades", state="unavailable", label="Upbit trades"
+        )
+    )
+    merged = TradesCache.merge([stale, unavailable])
+    assert stale.meta.state == "stale"
+    assert merged.meta.state == "unavailable"
+    assert "KRW-BTC" in merged.trades
+
+
+@pytest.mark.asyncio
+async def test_trades_cache_returns_fresh_when_redis_is_unavailable():
+    calls = 0
+
+    async def fetcher(market, count):
+        nonlocal calls
+        calls += 1
+        return [{"market": market, "trade_price": 1.0}]
+
+    cache = TradesCache(redis=BrokenRedis(), fetcher=fetcher)
+    block = await cache.get("KRW-BTC", 50)
+    assert block.meta.state == "fresh"
+    assert block.trades["KRW-BTC"][0]["trade_price"] == 1.0
+    assert calls == 1

--- a/tests/upbit_public_read_model/test_types.py
+++ b/tests/upbit_public_read_model/test_types.py
@@ -1,0 +1,69 @@
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.invest_crypto import CryptoSourceState
+from app.services.upbit_public_read_model.types import (
+    UpbitBlockMeta,
+    UpbitMarketWarningsBlock,
+    UpbitOrderbookBlock,
+    UpbitPublicSnapshot,
+    UpbitTickerBlock,
+    to_crypto_source_state,
+)
+
+
+def test_upbit_block_meta_is_frozen_and_extra_forbid():
+    meta = UpbitBlockMeta(source="upbit_ticker", state="fresh", label="Upbit ticker")
+    with pytest.raises(ValidationError):
+        UpbitBlockMeta(source="upbit_ticker", state="fresh", label="x", bogus=1)
+    with pytest.raises(ValidationError):
+        meta.source = "upbit_orderbook"
+
+
+def test_to_crypto_source_state_maps_states():
+    now = datetime.now(UTC)
+    fresh = to_crypto_source_state(
+        UpbitBlockMeta(
+            source="upbit_ticker", state="fresh", label="Upbit ticker", fetchedAt=now
+        )
+    )
+    assert isinstance(fresh, CryptoSourceState)
+    assert fresh.state == "supported"
+    stale = to_crypto_source_state(
+        UpbitBlockMeta(source="upbit_ticker", state="stale", label="Upbit ticker")
+    )
+    assert stale.state == "supported"
+    fail = to_crypto_source_state(
+        UpbitBlockMeta(
+            source="upbit_orderbook",
+            state="unavailable",
+            label="Upbit orderbook",
+            errorReason="http_error",
+        )
+    )
+    assert fail.state == "unavailable"
+
+
+def test_snapshot_round_trips():
+    now = datetime.now(UTC)
+    meta = UpbitBlockMeta(
+        source="upbit_ticker", state="fresh", label="t", fetchedAt=now
+    )
+    snap = UpbitPublicSnapshot(
+        asOf=now,
+        ticker=UpbitTickerBlock(meta=meta, tickers={"KRW-BTC": {"trade_price": 1}}),
+        orderbook=UpbitOrderbookBlock(
+            meta=UpbitBlockMeta(source="upbit_orderbook", state="fresh", label="o"),
+            orderbooks={},
+            spreadsPct={"KRW-BTC": 0.0},
+        ),
+        marketWarnings=UpbitMarketWarningsBlock(
+            meta=UpbitBlockMeta(
+                source="upbit_market_warnings", state="fresh", label="w"
+            )
+        ),
+        sources=[meta],
+    )
+    assert "KRW-BTC" in snap.model_dump_json()


### PR DESCRIPTION
## Summary
- Integrates ROB-232/ROB-233 screener flows, ROB-234 Naver crypto reference adapter, ROB-235 crypto dashboard risk/source cards, and ROB-236 crypto detail pre-order checklist into one ROB-237 integration branch.
- Resolves merge conflicts across screener response sources, crypto dashboard source metadata, Naver reference tests, and frontend crypto dashboard UI.
- Preserves read-only dashboard/detail behavior: no order, watch, broker, scheduler, or DB mutation controls are introduced.

## Verification
- `git diff --check`
- `uv run ruff check app/schemas/invest_crypto.py app/schemas/invest_screener.py app/schemas/invest_stock_detail.py app/services/invest_crypto_naver_adapter app/services/invest_view_model/crypto_dashboard_service.py app/services/invest_view_model/screener_service.py app/services/invest_view_model/crypto_preorder_check.py app/services/invest_view_model/stock_detail_orders_service.py app/services/invest_view_model/stock_detail_service.py tests/test_invest_api_crypto_router.py tests/test_invest_crypto_dashboard_service.py tests/test_invest_crypto_naver_adapter.py tests/test_invest_view_model_screener_service.py tests/test_stock_detail_orders.py tests/test_stock_detail_service.py`
- `uv run pytest tests/test_invest_api_crypto_router.py tests/test_invest_crypto_dashboard_service.py tests/test_invest_crypto_naver_adapter.py tests/test_invest_view_model_screener_service.py tests/test_stock_detail_orders.py tests/test_stock_detail_service.py -q` (69 passed, 2 existing Pydantic warnings)
- `npm test -- --run src/__tests__/DesktopCryptoPage.test.tsx src/__tests__/DesktopScreenerPage.test.tsx src/__tests__/StockDetailPage.test.tsx` (22 passed)
- `npm run typecheck -- --pretty false`

## Safety / non-actions
- No KIS, Upbit, Alpaca, generic broker, paper, or live order submit/cancel/modify actions performed.
- No production DB write/delete/backfill/migration, scheduler activation, or deploy performed in this PR step.
- No secrets, tokens, connection strings, or authorization values printed.
