### PR TITLE
fix(invest): tighten action center display

### DIFF
--- a/frontend/invest/src/__tests__/DesktopActionCenterPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopActionCenterPage.test.tsx
@@ -14,6 +14,25 @@ const readyState = {
     reports: {
       reports: [
         {
+          reportUuid: "report-2",
+          reportType: "daily",
+          market: "crypto",
+          accountScope: "upbit-live",
+          createdByProfile: "analyst",
+          status: "published",
+          summary: "최신 코인 액션 리포트",
+          riskSummary: "긴 리스크 문구도 카드 안에서 줄바꿈되어야 합니다.",
+          dataFreshness: {},
+          coverage: {},
+          sourcePolicy: [],
+          safetyNotes: [],
+          createdAt: "2026-05-16T00:00:00Z",
+          publishedAt: "2026-05-16T00:01:00Z",
+          validUntil: null,
+          stageResults: [],
+          candidates: [],
+        },
+        {
           reportUuid: "report-1",
           reportType: "daily",
           market: "kr",
@@ -52,6 +71,34 @@ const readyState = {
     },
     candidates: {
       candidates: [
+        {
+          candidateUuid: "cand-2",
+          reportUuid: "report-2",
+          symbol: "KRW-ONDO",
+          market: "crypto",
+          side: "sell",
+          actionType: "stop_exit_sell",
+          quantity: "88.80994671",
+          quantityPct: null,
+          limitPrice: "541",
+          notional: "48046",
+          currency: "KRW",
+          priority: 1,
+          confidence: 0.78,
+          thesis: "최신 리포트 후보만 표시되어야 합니다.",
+          riskNotes: ["지정가만 사용"],
+          verification: {
+            accountFeasibility: "manual check",
+            liquidity: "spread checked",
+            eventNewsRisk: "low",
+          },
+          blockingReasons: [],
+          approvalStatus: "awaiting_approval",
+          approvalType: "manual",
+          executionState: "not_submitted",
+          createdAt: "2026-05-16T00:02:00Z",
+          validUntil: null,
+        },
         {
           candidateUuid: "cand-1",
           reportUuid: "report-1",
@@ -99,10 +146,12 @@ test("renders analyst reports, candidate queue, and unavailable markers", () => 
   render(wrap(<DesktopActionCenterPage />));
 
   expect(screen.getByRole("heading", { name: "액션 센터" })).toBeInTheDocument();
-  expect(screen.getByText("삼성전자 후보와 현금 여력 점검")).toBeInTheDocument();
-  expect(screen.getByText("005930")).toBeInTheDocument();
-  expect(screen.getAllByText("확인 불가").length).toBeGreaterThanOrEqual(3);
-  expect(screen.getAllByText(/계좌 여력 확인 필요/).length).toBeGreaterThanOrEqual(1);
+  expect(screen.getByText("최신 코인 액션 리포트")).toBeInTheDocument();
+  expect(screen.queryByText("삼성전자 후보와 현금 여력 점검")).not.toBeInTheDocument();
+  expect(screen.getByText("KRW-ONDO")).toBeInTheDocument();
+  expect(screen.queryByText("005930")).not.toBeInTheDocument();
+  expect(screen.getByText("88.80994671")).toBeInTheDocument();
+  expect(screen.getByText("541")).toBeInTheDocument();
   expect(screen.getByText(/정규장 확인 필요/)).toBeInTheDocument();
 });
 

--- a/frontend/invest/src/components/action-center/ActionCenterContent.tsx
+++ b/frontend/invest/src/components/action-center/ActionCenterContent.tsx
@@ -28,6 +28,16 @@ function StatusCard({ children }: { children: React.ReactNode }) {
 
 export function ActionCenterContent({ compact = false }: { compact?: boolean }) {
   const actionCenter = useActionCenter();
+  const reports = actionCenter.state.status === "ready" ? actionCenter.state.reports.reports : [];
+  const latestReport = reports[0];
+  const visibleReports = latestReport ? [latestReport] : [];
+  const latestReportUuid = latestReport?.reportUuid;
+  const candidates =
+    actionCenter.state.status === "ready"
+      ? latestReportUuid
+        ? actionCenter.state.candidates.candidates.filter((candidate) => candidate.reportUuid === latestReportUuid)
+        : actionCenter.state.candidates.candidates
+      : [];
 
   return (
     <div style={{ padding: compact ? "14px 16px 22px" : 24, display: "grid", gap: 16 }}>
@@ -63,24 +73,24 @@ export function ActionCenterContent({ compact = false }: { compact?: boolean }) 
           <section style={{ display: "grid", gap: 10 }}>
             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 10 }}>
               <h2 style={{ margin: 0, fontSize: 18 }}>최신 애널리스트 리포트</h2>
-              <span style={{ color: "var(--fg-3)", fontSize: 12 }}>{actionCenter.state.reports.reports.length}개</span>
+              <span style={{ color: "var(--fg-3)", fontSize: 12 }}>{visibleReports.length}개</span>
             </div>
-            {actionCenter.state.reports.reports.length === 0 ? (
+            {visibleReports.length === 0 ? (
               <StatusCard>표시할 리포트가 없습니다. 확인 불가</StatusCard>
             ) : (
-              actionCenter.state.reports.reports.map((report) => <AnalystReportCard key={report.reportUuid} report={report} />)
+              visibleReports.map((report) => <AnalystReportCard key={report.reportUuid} report={report} />)
             )}
           </section>
 
           <section style={{ display: "grid", gap: 10 }}>
             <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 10 }}>
               <h2 style={{ margin: 0, fontSize: 18 }}>승인 대기 후보</h2>
-              <span style={{ color: "var(--fg-3)", fontSize: 12 }}>{actionCenter.state.candidates.candidates.length}개</span>
+              <span style={{ color: "var(--fg-3)", fontSize: 12 }}>{candidates.length}개</span>
             </div>
-            {actionCenter.state.candidates.candidates.length === 0 ? (
+            {candidates.length === 0 ? (
               <StatusCard>표시할 후보가 없습니다. 확인 불가</StatusCard>
             ) : (
-              actionCenter.state.candidates.candidates.map((candidate) => (
+              candidates.map((candidate) => (
                 <CandidateCard key={candidate.candidateUuid} candidate={candidate} />
               ))
             )}

--- a/frontend/invest/src/components/action-center/AnalystReportCard.tsx
+++ b/frontend/invest/src/components/action-center/AnalystReportCard.tsx
@@ -13,18 +13,32 @@ export function AnalystReportCard({ report }: { report: AnalysisReport }) {
     <Card>
       <div style={{ display: "grid", gap: 14 }}>
         <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
-          <div style={{ display: "grid", gap: 5 }}>
+          <div style={{ display: "grid", gap: 5, minWidth: 0 }}>
             <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 800 }}>
               {report.reportType} · {report.market} · {report.accountScope ?? "전체 계좌"}
             </div>
-            <h2 style={{ margin: 0, fontSize: 20, letterSpacing: "-0.03em" }}>{report.summary}</h2>
+            <h2
+              style={{
+                margin: 0,
+                fontSize: 18,
+                letterSpacing: "-0.03em",
+                lineHeight: 1.35,
+                overflowWrap: "anywhere",
+              }}
+            >
+              {report.summary}
+            </h2>
             <div style={{ color: "var(--fg-3)", fontSize: 12 }}>
               {report.createdByProfile} · 생성 {dateText(report.createdAt)} · 유효 {dateText(report.validUntil)}
             </div>
           </div>
           <StatusBadge status={report.status} />
         </div>
-        {report.riskSummary && <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.6 }}>{report.riskSummary}</p>}
+        {report.riskSummary && (
+          <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.6, overflowWrap: "anywhere" }}>
+            {report.riskSummary}
+          </p>
+        )}
         <DataVerificationPanel report={report} />
         {report.safetyNotes && report.safetyNotes.length > 0 && (
           <div style={{ color: "var(--warn)", fontSize: 12, lineHeight: 1.6 }}>

--- a/frontend/invest/src/components/action-center/CandidateCard.tsx
+++ b/frontend/invest/src/components/action-center/CandidateCard.tsx
@@ -6,6 +6,7 @@ const UNAVAILABLE = "확인 불가";
 
 function displayValue(value: unknown, suffix = ""): string {
   if (value == null || value === "") return UNAVAILABLE;
+  if (typeof value === "number") return `${value.toLocaleString("ko-KR")}${suffix}`;
   return `${String(value)}${suffix}`;
 }
 
@@ -32,7 +33,7 @@ export function CandidateCard({ candidate }: { candidate: AnalysisCandidate }) {
           </div>
         </div>
 
-        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))", gap: 8 }}>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(135px, 1fr))", gap: 8 }}>
           <Metric label="side" value={candidate.side} />
           <Metric label="수량" value={displayValue(candidate.quantity)} />
           <Metric label="비중" value={displayValue(candidate.quantityPct, "%")} />
@@ -43,7 +44,7 @@ export function CandidateCard({ candidate }: { candidate: AnalysisCandidate }) {
 
         <div>
           <div style={{ fontWeight: 900, marginBottom: 6 }}>Thesis</div>
-          <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.6 }}>{candidate.thesis}</p>
+          <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.6, overflowWrap: "anywhere" }}>{candidate.thesis}</p>
         </div>
 
         <div style={{ display: "grid", gap: 8 }}>
@@ -54,10 +55,10 @@ export function CandidateCard({ candidate }: { candidate: AnalysisCandidate }) {
             <Metric label="이벤트/뉴스 리스크" value={verificationValue(candidate, "eventNewsRisk")} warn />
           </div>
           {candidate.riskNotes.length > 0 && (
-            <div style={{ color: "var(--warn)", fontSize: 12, lineHeight: 1.6 }}>{candidate.riskNotes.join(" · ")}</div>
+            <div style={{ color: "var(--warn)", fontSize: 12, lineHeight: 1.6, overflowWrap: "anywhere" }}>{candidate.riskNotes.join(" · ")}</div>
           )}
           {candidate.blockingReasons.length > 0 && (
-            <div style={{ color: "var(--danger)", fontSize: 12, lineHeight: 1.6 }}>{candidate.blockingReasons.join(" · ")}</div>
+            <div style={{ color: "var(--danger)", fontSize: 12, lineHeight: 1.6, overflowWrap: "anywhere" }}>{candidate.blockingReasons.join(" · ")}</div>
           )}
         </div>
 
@@ -77,9 +78,9 @@ export function CandidateCard({ candidate }: { candidate: AnalysisCandidate }) {
 function Metric({ label, value, warn = false }: { label: string; value: string; warn?: boolean }) {
   const unavailable = value === UNAVAILABLE;
   return (
-    <div style={{ padding: 10, borderRadius: 12, background: "var(--surface-2)", display: "grid", gap: 3 }}>
-      <div style={{ color: "var(--fg-3)", fontSize: 11 }}>{label}</div>
-      <div style={{ color: warn || unavailable ? "var(--warn)" : "var(--fg-1)", fontWeight: 900, fontSize: 12 }}>{value}</div>
+    <div style={{ padding: 10, borderRadius: 12, background: "var(--surface-2)", display: "grid", gap: 3, minWidth: 0 }}>
+      <div style={{ color: "var(--fg-3)", fontSize: 11, overflowWrap: "anywhere" }}>{label}</div>
+      <div style={{ color: warn || unavailable ? "var(--warn)" : "var(--fg-1)", fontWeight: 900, fontSize: 12, overflowWrap: "anywhere" }}>{value}</div>
     </div>
   );
 }

--- a/frontend/invest/src/components/action-center/DataVerificationPanel.tsx
+++ b/frontend/invest/src/components/action-center/DataVerificationPanel.tsx
@@ -6,7 +6,7 @@ const UNAVAILABLE = "확인 불가";
 
 function valueText(value: unknown): string {
   if (value == null || value === "") return UNAVAILABLE;
-  if (Array.isArray(value)) return value.length === 0 ? UNAVAILABLE : value.join(", ");
+  if (Array.isArray(value)) return value.length === 0 ? UNAVAILABLE : value.join(" · ");
   if (typeof value === "object") return JSON.stringify(value);
   return String(value);
 }
@@ -17,11 +17,22 @@ function KeyValueGrid({ values }: { values: Record<string, unknown> }) {
     return <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{UNAVAILABLE}</div>;
   }
   return (
-    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))", gap: 8 }}>
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
       {entries.map(([key, value]) => (
-        <div key={key} style={{ padding: 10, borderRadius: 12, background: "var(--surface-2)", display: "grid", gap: 3 }}>
-          <div style={{ color: "var(--fg-3)", fontSize: 11 }}>{key}</div>
-          <div style={{ color: valueText(value) === UNAVAILABLE ? "var(--warn)" : "var(--fg-1)", fontWeight: 800, fontSize: 12 }}>
+        <div key={key} style={{ padding: 10, borderRadius: 12, background: "var(--surface-2)", display: "grid", gap: 3, minWidth: 0 }}>
+          <div style={{ color: "var(--fg-3)", fontSize: 11, overflowWrap: "anywhere" }}>{key}</div>
+          <div
+            style={{
+              color: valueText(value) === UNAVAILABLE ? "var(--warn)" : "var(--fg-1)",
+              fontWeight: 800,
+              fontSize: 12,
+              lineHeight: 1.45,
+              maxHeight: 96,
+              overflow: "auto",
+              overflowWrap: "anywhere",
+              whiteSpace: "pre-wrap",
+            }}
+          >
             {valueText(value)}
           </div>
         </div>
@@ -54,7 +65,7 @@ export function DataVerificationPanel({ report }: { report: AnalysisReport }) {
         <div>
           <div style={{ fontWeight: 900, marginBottom: 4 }}>데이터 검증</div>
           <div style={{ color: "var(--fg-3)", fontSize: 12, lineHeight: 1.5 }}>
-            KIS live가 계좌·주문 권한의 기준입니다. Toss/Naver는 교차 검증 참고이며, 확인되지 않은 핵심 값은 {UNAVAILABLE}로 표시합니다.
+            MCP 계좌·주문 데이터가 권위 기준입니다. Toss/Naver는 교차 검증 참고이며, 확인되지 않은 핵심 값은 {UNAVAILABLE}로 표시합니다.
           </div>
         </div>
         <div>


### PR DESCRIPTION
## Summary
- Show only the latest analyst report on the action center and filter candidates to that report
- Prevent long freshness/coverage/risk text from breaking card layout by increasing grid minimums, wrapping, and bounding overflow
- Store refreshed crypto candidates with first-class quantity/limit/notional/verification fields so the UI no longer shows avoidable `확인 불가`

## Verification
- `npm test -- --run src/__tests__/DesktopActionCenterPage.test.tsx`
- `npm run typecheck`
- `npm run build`

## Safety
- UI/read-only display change only
- No order submission/cancel/modify performed
