### PR TITLE
feat(invest): add theme toggle to desktop header

### DIFF
--- a/frontend/invest/src/desktop/DesktopHeader.tsx
+++ b/frontend/invest/src/desktop/DesktopHeader.tsx
@@ -1,5 +1,6 @@
 import { NavLink } from "react-router-dom";
 import { Icon } from "../ds";
+import { ThemeToggle } from "../theme/ThemeToggle";
 
 const LINKS: { to: string; label: string; end?: boolean }[] = [
   { to: "/", label: "홈", end: true },
@@ -120,6 +121,8 @@ export function DesktopHeader() {
           ⌘K
         </span>
       </div>
+
+      <ThemeToggle variant="compact" />
 
       <button
         type="button"

--- a/frontend/invest/src/ds/atoms.tsx
+++ b/frontend/invest/src/ds/atoms.tsx
@@ -264,7 +264,10 @@ export type IconName =
   | "plus"
   | "refresh"
   | "flash"
-  | "person";
+  | "person"
+  | "sun"
+  | "moon"
+  | "monitor";
 
 const ICON_PATHS: Record<IconName, ReactNode> = {
   home: <path d="M3 9.5L12 3l9 6.5V20a1 1 0 0 1-1 1h-5v-7H9v7H4a1 1 0 0 1-1-1V9.5z" />,
@@ -313,6 +316,19 @@ const ICON_PATHS: Record<IconName, ReactNode> = {
     <>
       <circle cx="12" cy="8" r="4" />
       <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7" />
+    </>
+  ),
+  sun: (
+    <>
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+    </>
+  ),
+  moon: <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />,
+  monitor: (
+    <>
+      <rect x="2" y="4" width="20" height="14" rx="2" />
+      <path d="M8 21h8M12 18v3" />
     </>
   ),
 };

--- a/frontend/invest/src/theme/ThemeToggle.tsx
+++ b/frontend/invest/src/theme/ThemeToggle.tsx
@@ -1,0 +1,75 @@
+import type { CSSProperties } from "react";
+import { Icon, type IconName } from "../ds";
+import { useTheme, type Theme } from "./useTheme";
+
+const OPTIONS: { value: Theme; label: string; icon: IconName }[] = [
+  { value: "light", label: "라이트", icon: "sun" },
+  { value: "system", label: "시스템", icon: "monitor" },
+  { value: "dark", label: "다크", icon: "moon" },
+];
+
+const TRACK_STYLE: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  padding: 2,
+  borderRadius: 999,
+  background: "var(--surface-2)",
+  border: "1px solid var(--border)",
+  gap: 2,
+};
+
+const SEGMENT_BASE: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: 6,
+  height: 28,
+  padding: "0 10px",
+  borderRadius: 999,
+  border: "none",
+  background: "transparent",
+  color: "var(--fg-3)",
+  fontSize: 12,
+  fontWeight: 600,
+  cursor: "pointer",
+  transition: "background 160ms cubic-bezier(0.2,0,0,1), color 160ms cubic-bezier(0.2,0,0,1)",
+};
+
+const SEGMENT_ACTIVE: CSSProperties = {
+  background: "var(--surface)",
+  color: "var(--fg)",
+  boxShadow: "var(--shadow-1)",
+};
+
+export type ThemeToggleVariant = "labeled" | "compact";
+
+export function ThemeToggle({ variant = "labeled" }: { variant?: ThemeToggleVariant } = {}) {
+  const [theme, setTheme] = useTheme();
+  const compact = variant === "compact";
+  return (
+    <div role="radiogroup" aria-label="테마 선택" style={TRACK_STYLE}>
+      {OPTIONS.map((opt) => {
+        const active = theme === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={opt.label}
+            title={opt.label}
+            onClick={() => setTheme(opt.value)}
+            style={{
+              ...SEGMENT_BASE,
+              ...(active ? SEGMENT_ACTIVE : null),
+              padding: compact ? "0 8px" : SEGMENT_BASE.padding,
+            }}
+          >
+            <Icon name={opt.icon} size={14} />
+            {!compact ? <span>{opt.label}</span> : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `ThemeToggle` component (`src/theme/ThemeToggle.tsx`) — segmented 라이트 · 시스템 · 다크 control wired to the existing `useTheme()` hook.
- Mount the toggle in `DesktopHeader` between the search input and notification bell (compact variant, icons only).
- Add `sun`, `moon`, `monitor` icons to the `Icon` DS in `ds/atoms.tsx`.

## Why
`tokens.css`, `useTheme.ts`, and the `prefers-color-scheme` fallback have shipped, but there was no in-product affordance to switch themes — the dark theme handoff brief from the design system (`auto-trader-invest-design-system/project/handoff/IMPLEMENTATION_BRIEF.md`) explicitly calls for a header-mounted segmented control. This adds that affordance using tokens only (no hardcoded colors).

## Scope
- Tokens / state model / storage key are unchanged — the toggle reuses the existing `invest-theme` localStorage key and the `light | dark | system` union from `useTheme`.
- Component logic untouched outside the header; no prop shape changes.
- The 42 remaining hex literals in `Coverage` / `FX` / `Market` / `Disparity` cards are out of scope — they're page-level data-state palettes that need a separate token-mapping decision.

## Test plan
- [x] `pnpm typecheck` passes
- [x] `tokens.contract.test.ts` still passes (7/7)
- [ ] Manual: open `/invest`, click each segment, confirm `<html data-theme>` flips and `localStorage["invest-theme"]` updates
- [ ] Manual: hard-reload after picking `dark` — verify no light-flash on first paint (applyInitialTheme runs in main.tsx before render)
- [ ] Manual: with `system`, toggle OS light/dark and confirm UI follows
- [ ] Manual: P/L colors — gain row ▲ red, loss row ▼ blue in both themes (Korean rule preserved)

## Notes
Other suite failures observed locally (`localStorage.clear is not a function`, a couple of `@testing-library` query failures) reproduce on clean `main` after a fresh `pnpm install` — caused by a freshly resolved `jsdom@29.1.1`. Unrelated to this change; worth a follow-up to pin / shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a theme toggle to the header, enabling users to switch between light, system, and dark theme modes
  * Introduced new sun, moon, and monitor icons to support theme selection UI with compact and labeled display variants

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/847?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->