### PR TITLE
fix(invest): clarify action center candidate fallbacks

### DIFF
--- a/frontend/invest/src/__tests__/DesktopActionCenterPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopActionCenterPage.test.tsx
@@ -100,6 +100,62 @@ const readyState = {
           validUntil: null,
         },
         {
+          candidateUuid: "cand-3",
+          reportUuid: "report-2",
+          symbol: "KRW-SOL",
+          market: "crypto",
+          side: "sell",
+          actionType: "watch_partial_trim",
+          quantity: null,
+          quantityPct: "20.000000",
+          limitPrice: "133000",
+          notional: null,
+          currency: "KRW",
+          priority: 4,
+          confidence: 0.58,
+          thesis: "비중 기준 일부 축소 후보입니다.",
+          riskNotes: ["매도 가능 수량 확인 필요"],
+          verification: {
+            accountFeasibility: "확인 불가: 스테이킹 잠금/매도 가능 수량 확인 필요",
+            liquidity: "스프레드 확인",
+            eventNewsRisk: "비중 집중 위험",
+          },
+          blockingReasons: [],
+          approvalStatus: "awaiting_approval",
+          approvalType: "manual",
+          executionState: "not_submitted",
+          createdAt: "2026-05-16T00:03:00Z",
+          validUntil: null,
+        },
+        {
+          candidateUuid: "cand-4",
+          reportUuid: "report-2",
+          symbol: "KRW-POLYX",
+          market: "crypto",
+          side: "buy",
+          actionType: "exclude_new_buy",
+          quantity: null,
+          quantityPct: null,
+          limitPrice: null,
+          notional: null,
+          currency: "KRW",
+          priority: 5,
+          confidence: 0.7,
+          thesis: "추격 매수 제외 후보입니다.",
+          riskNotes: ["과열 위험"],
+          verification: {
+            accountFeasibility: "거절 후보라 계좌 검증 대상 아님",
+            liquidity: "중립",
+            eventNewsRisk: "반전 위험",
+          },
+          blockingReasons: ["추격 매수 회피"],
+          approvalStatus: "rejected",
+          approvalType: "manual",
+          executionState: "not_submitted",
+          createdAt: "2026-05-16T00:04:00Z",
+          validUntil: null,
+        },
+        {
           candidateUuid: "cand-1",
           reportUuid: "report-1",
           symbol: "005930",
@@ -155,13 +211,30 @@ test("renders analyst reports, candidate queue, and unavailable markers", () => 
   expect(screen.getByText(/정규장 확인 필요/)).toBeInTheDocument();
 });
 
+test("uses actionable fallbacks instead of 확인 불가 for non-order or percentage-based candidates", () => {
+  render(wrap(<DesktopActionCenterPage />));
+
+  expect(screen.getByText("KRW-SOL")).toBeInTheDocument();
+  expect(screen.getByText("비중 기준 산정")).toBeInTheDocument();
+  expect(screen.getByText("20.000000%")).toBeInTheDocument();
+  expect(screen.getByText("수량 확인 후 산정")).toBeInTheDocument();
+  expect(screen.getByText("추가 확인 필요: 스테이킹 잠금/매도 가능 수량 확인 필요")).toBeInTheDocument();
+
+  expect(screen.getByText("KRW-POLYX")).toBeInTheDocument();
+  expect(screen.getAllByText("해당 없음").length).toBeGreaterThanOrEqual(4);
+});
+
 test("keeps approval controls read-only and separates approval from execution state", () => {
   render(wrap(<DesktopActionCenterPage />));
 
-  expect(screen.getByText("승인 상태: awaiting_approval")).toBeInTheDocument();
-  expect(screen.getByText("실행 상태: not_submitted")).toBeInTheDocument();
-  expect(screen.getByRole("button", { name: "승인 기록은 수동 처리" })).toBeDisabled();
-  expect(screen.getByRole("button", { name: "거절 기록은 수동 처리" })).toBeDisabled();
+  expect(screen.getAllByText("승인 상태: awaiting_approval").length).toBeGreaterThanOrEqual(1);
+  expect(screen.getAllByText("실행 상태: not_submitted").length).toBeGreaterThanOrEqual(1);
+  for (const button of screen.getAllByRole("button", { name: "승인 기록은 수동 처리" })) {
+    expect(button).toBeDisabled();
+  }
+  for (const button of screen.getAllByRole("button", { name: "거절 기록은 수동 처리" })) {
+    expect(button).toBeDisabled();
+  }
   expect(screen.getByText(/의사결정\/승인 대기 자료이며 주문 실행이 아닙니다/)).toBeInTheDocument();
 });
 

--- a/frontend/invest/src/components/action-center/CandidateCard.tsx
+++ b/frontend/invest/src/components/action-center/CandidateCard.tsx
@@ -3,17 +3,57 @@ import type { AnalysisCandidate } from "../../types/actionCenter";
 import { StatusBadge } from "./StatusBadge";
 
 const UNAVAILABLE = "확인 불가";
+const NOT_APPLICABLE = "해당 없음";
 
-function displayValue(value: unknown, suffix = ""): string {
-  if (value == null || value === "") return UNAVAILABLE;
+function hasValue(value: unknown): boolean {
+  return value != null && value !== "";
+}
+
+function isRejectedOrExcluded(candidate: AnalysisCandidate): boolean {
+  return candidate.approvalStatus === "rejected" || candidate.actionType.startsWith("exclude_");
+}
+
+function formatValue(value: unknown, suffix = ""): string {
   if (typeof value === "number") return `${value.toLocaleString("ko-KR")}${suffix}`;
   return `${String(value)}${suffix}`;
+}
+
+function displayValue(value: unknown, suffix = "", fallback = UNAVAILABLE): string {
+  if (!hasValue(value)) return fallback;
+  return formatValue(value, suffix);
+}
+
+function quantityValue(candidate: AnalysisCandidate): string {
+  if (hasValue(candidate.quantity)) return formatValue(candidate.quantity);
+  if (isRejectedOrExcluded(candidate)) return NOT_APPLICABLE;
+  if (hasValue(candidate.quantityPct)) return "비중 기준 산정";
+  return "승인 시 산정";
+}
+
+function quantityPctValue(candidate: AnalysisCandidate): string {
+  if (hasValue(candidate.quantityPct)) return formatValue(candidate.quantityPct, "%");
+  if (hasValue(candidate.quantity)) return "수량 기준";
+  if (isRejectedOrExcluded(candidate)) return NOT_APPLICABLE;
+  return "승인 시 산정";
+}
+
+function limitPriceValue(candidate: AnalysisCandidate): string {
+  if (hasValue(candidate.limitPrice)) return formatValue(candidate.limitPrice);
+  if (isRejectedOrExcluded(candidate)) return NOT_APPLICABLE;
+  return "승인 시 재확인";
+}
+
+function notionalValue(candidate: AnalysisCandidate): string {
+  if (hasValue(candidate.notional)) return formatValue(candidate.notional, candidate.currency ? ` ${candidate.currency}` : "");
+  if (isRejectedOrExcluded(candidate)) return NOT_APPLICABLE;
+  if (hasValue(candidate.quantityPct) || hasValue(candidate.quantity)) return "수량 확인 후 산정";
+  return "승인 시 산정";
 }
 
 function verificationValue(candidate: AnalysisCandidate, key: string): string {
   const raw = candidate.verification?.[key];
   if (raw == null || raw === "") return UNAVAILABLE;
-  return String(raw);
+  return String(raw).replace(/^확인 불가[:：]\s*/, "추가 확인 필요: ");
 }
 
 export function CandidateCard({ candidate }: { candidate: AnalysisCandidate }) {
@@ -35,10 +75,10 @@ export function CandidateCard({ candidate }: { candidate: AnalysisCandidate }) {
 
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(135px, 1fr))", gap: 8 }}>
           <Metric label="side" value={candidate.side} />
-          <Metric label="수량" value={displayValue(candidate.quantity)} />
-          <Metric label="비중" value={displayValue(candidate.quantityPct, "%")} />
-          <Metric label="지정가" value={displayValue(candidate.limitPrice)} />
-          <Metric label="금액" value={displayValue(candidate.notional, candidate.currency ? ` ${candidate.currency}` : "")} />
+          <Metric label="수량" value={quantityValue(candidate)} />
+          <Metric label="비중" value={quantityPctValue(candidate)} />
+          <Metric label="지정가" value={limitPriceValue(candidate)} />
+          <Metric label="금액" value={notionalValue(candidate)} />
           <Metric label="confidence" value={displayValue(candidate.confidence)} />
         </div>
 


### PR DESCRIPTION
## Summary
- Replace misleading `확인 불가` placeholders on action-center candidate cards with context-aware fallback copy.
- Show rejected/excluded candidates as `해당 없음` for order-only fields.
- Show percentage-based trim candidates as `비중 기준 산정` / `수량 확인 후 산정` instead of implying broken data.
- Normalize `확인 불가:` verification prefixes to `추가 확인 필요:`.
- Add regression coverage for rejected and percentage-based crypto candidates.

## Test Plan
- `npm test -- --run src/__tests__/DesktopActionCenterPage.test.tsx`
- `npm run typecheck`
- `npm run build`

## Safety
- Display-only frontend change.
- No broker, order, approval, or database mutation logic changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved candidate card display by showing contextual information for quantity, price limits, and amounts with localized labels.
  * Enhanced verification status messaging to display actionable guidance instead of generic unavailable indicators.

* **Tests**
  * Expanded test coverage for candidate card rendering across various states and data scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/848?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->