### PR TITLE
fix(invest): group action center by report history

### DIFF
--- a/frontend/invest/src/__tests__/DesktopActionCenterPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopActionCenterPage.test.tsx
@@ -198,26 +198,28 @@ beforeEach(() => {
   vi.mocked(useActionCenter).mockReturnValue(readyState);
 });
 
-test("renders analyst reports, candidate queue, and unavailable markers", () => {
+test("renders report history with each report's own candidates", () => {
   render(wrap(<DesktopActionCenterPage />));
 
   expect(screen.getByRole("heading", { name: "액션 센터" })).toBeInTheDocument();
+  expect(screen.getByText("리포트별 검토 이력")).toBeInTheDocument();
   expect(screen.getByText("최신 코인 액션 리포트")).toBeInTheDocument();
-  expect(screen.queryByText("삼성전자 후보와 현금 여력 점검")).not.toBeInTheDocument();
+  expect(screen.getByText("삼성전자 후보와 현금 여력 점검")).toBeInTheDocument();
   expect(screen.getByText("KRW-ONDO")).toBeInTheDocument();
-  expect(screen.queryByText("005930")).not.toBeInTheDocument();
+  expect(screen.getByText("005930")).toBeInTheDocument();
   expect(screen.getByText("88.80994671")).toBeInTheDocument();
   expect(screen.getByText("541")).toBeInTheDocument();
-  expect(screen.getByText(/정규장 확인 필요/)).toBeInTheDocument();
+  expect(screen.getByText(/이전 리포트 대비/)).toBeInTheDocument();
+  expect(screen.getByText(/매수\/매도 실행 전 계좌/)).toBeInTheDocument();
 });
 
 test("uses actionable fallbacks instead of 확인 불가 for non-order or percentage-based candidates", () => {
   render(wrap(<DesktopActionCenterPage />));
 
   expect(screen.getByText("KRW-SOL")).toBeInTheDocument();
-  expect(screen.getByText("비중 기준 산정")).toBeInTheDocument();
+  expect(screen.getAllByText("비중 기준 산정").length).toBeGreaterThanOrEqual(1);
   expect(screen.getByText("20.000000%")).toBeInTheDocument();
-  expect(screen.getByText("수량 확인 후 산정")).toBeInTheDocument();
+  expect(screen.getAllByText("수량 확인 후 산정").length).toBeGreaterThanOrEqual(1);
   expect(screen.getByText("추가 확인 필요: 스테이킹 잠금/매도 가능 수량 확인 필요")).toBeInTheDocument();
 
   expect(screen.getByText("KRW-POLYX")).toBeInTheDocument();
@@ -227,15 +229,15 @@ test("uses actionable fallbacks instead of 확인 불가 for non-order or percen
 test("keeps approval controls read-only and separates approval from execution state", () => {
   render(wrap(<DesktopActionCenterPage />));
 
-  expect(screen.getAllByText("승인 상태: awaiting_approval").length).toBeGreaterThanOrEqual(1);
-  expect(screen.getAllByText("실행 상태: not_submitted").length).toBeGreaterThanOrEqual(1);
+  expect(screen.getAllByText("승인 상태: 승인 대기").length).toBeGreaterThanOrEqual(1);
+  expect(screen.getAllByText("실행 상태: 미제출").length).toBeGreaterThanOrEqual(1);
   for (const button of screen.getAllByRole("button", { name: "승인 기록은 수동 처리" })) {
     expect(button).toBeDisabled();
   }
   for (const button of screen.getAllByRole("button", { name: "거절 기록은 수동 처리" })) {
     expect(button).toBeDisabled();
   }
-  expect(screen.getByText(/의사결정\/승인 대기 자료이며 주문 실행이 아닙니다/)).toBeInTheDocument();
+  expect(screen.getByText(/리포트별 판단 근거와 승인 후보를 묶어 보는 읽기 전용 검토 화면/)).toBeInTheDocument();
 });
 
 test("renders loading and error states without hiding non-execution copy", () => {

--- a/frontend/invest/src/components/action-center/ActionCenterContent.tsx
+++ b/frontend/invest/src/components/action-center/ActionCenterContent.tsx
@@ -1,43 +1,114 @@
+import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { AnalystReportCard } from "./AnalystReportCard";
 import { CandidateCard } from "./CandidateCard";
 import { Card } from "../../ds";
 import { useActionCenter } from "../../hooks/useActionCenter";
+import type { AnalysisCandidate, AnalysisReport } from "../../types/actionCenter";
+
+const MARKET_LABELS: Record<string, string> = {
+  crypto: "코인",
+  kr: "국내주식",
+  us: "미국주식",
+};
 
 function SafetyHero() {
   return (
     <Card>
       <div style={{ display: "grid", gap: 9 }}>
-        <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 900 }}>ROB-257 analyst report action center</div>
+        <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 900 }}>ROB-257 애널리스트 리포트 액션 센터</div>
         <h1 style={{ margin: 0, fontSize: 28, letterSpacing: "-0.05em" }}>액션 센터</h1>
         <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 14, lineHeight: 1.65 }}>
-          이 화면은 의사결정/승인 대기 자료이며 주문 실행이 아닙니다. 승인·거절은 현재 read-only 수동 검토 상태로 표시하고,
-          KIS live를 계좌·주문 권한의 기준으로 둡니다.
+          이 화면은 리포트별 판단 근거와 승인 후보를 묶어 보는 읽기 전용 검토 화면입니다. 승인·거절 기록은 현재 수동 처리이며,
+          별도 승인 없이는 주문을 제출하지 않습니다.
         </p>
         <div style={{ color: "var(--warn)", fontSize: 13, fontWeight: 800 }}>
-          정규장 확인 필요 · NXT/프리마켓/시간외 시장가 또는 시장가 유사 실행은 금지
+          후보 카드는 리포트 단위로 묶입니다 · 매수/매도 실행 전 계좌·호가·매도 가능 수량 재확인 필수
         </div>
       </div>
     </Card>
   );
 }
 
-function StatusCard({ children }: { children: React.ReactNode }) {
+function StatusCard({ children }: { children: ReactNode }) {
   return <Card><div role="status" style={{ color: "var(--fg-3)", fontSize: 13 }}>{children}</div></Card>;
+}
+
+function reportTime(report: AnalysisReport): number {
+  return new Date(report.publishedAt ?? report.createdAt).getTime();
+}
+
+function reportTitle(report: AnalysisReport): string {
+  const date = new Date(report.publishedAt ?? report.createdAt);
+  const time = Number.isFinite(date.getTime())
+    ? date.toLocaleString("ko-KR", { month: "numeric", day: "numeric", hour: "2-digit", minute: "2-digit", hour12: false })
+    : "시각 확인 필요";
+  const market = MARKET_LABELS[report.market] ?? report.market;
+  return `${time} ${market} 리포트`;
+}
+
+function candidateKey(candidate: AnalysisCandidate): string {
+  return `${candidate.symbol}:${candidate.actionType}:${candidate.side}`;
+}
+
+function diffText(current: AnalysisCandidate[], previous?: AnalysisCandidate[]): string {
+  if (!previous) return "비교 기준이 되는 이전 리포트가 없습니다.";
+  const previousByKey = new Map(previous.map((candidate) => [candidateKey(candidate), candidate]));
+  const currentByKey = new Map(current.map((candidate) => [candidateKey(candidate), candidate]));
+  const added = current.filter((candidate) => !previousByKey.has(candidateKey(candidate))).map((candidate) => candidate.symbol);
+  const removed = previous.filter((candidate) => !currentByKey.has(candidateKey(candidate))).map((candidate) => candidate.symbol);
+  const changed = current.filter((candidate) => {
+    const before = previousByKey.get(candidateKey(candidate));
+    return before && (before.approvalStatus !== candidate.approvalStatus || before.executionState !== candidate.executionState || before.priority !== candidate.priority);
+  }).map((candidate) => candidate.symbol);
+
+  const parts = [
+    added.length ? `신규 ${Array.from(new Set(added)).join(", ")}` : null,
+    removed.length ? `사라짐 ${Array.from(new Set(removed)).join(", ")}` : null,
+    changed.length ? `상태/우선순위 변경 ${Array.from(new Set(changed)).join(", ")}` : null,
+  ].filter(Boolean);
+
+  return parts.length > 0 ? `이전 리포트 대비 ${parts.join(" · ")}` : "이전 리포트 대비 후보 구성 변화 없음";
+}
+
+function ReportBundle({ report, candidates, previousCandidates }: { report: AnalysisReport; candidates: AnalysisCandidate[]; previousCandidates?: AnalysisCandidate[] }) {
+  return (
+    <section style={{ display: "grid", gap: 10, padding: 12, border: "1px solid var(--border)", borderRadius: 18, background: "rgba(255,255,255,0.015)", minWidth: 0 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 10, alignItems: "baseline", flexWrap: "wrap" }}>
+        <div style={{ display: "grid", gap: 3, minWidth: 0 }}>
+          <h2 style={{ margin: 0, fontSize: 18, letterSpacing: "-0.03em" }}>{reportTitle(report)}</h2>
+          <div style={{ color: "var(--fg-3)", fontSize: 12, overflowWrap: "anywhere" }}>{diffText(candidates, previousCandidates)}</div>
+        </div>
+        <span style={{ color: "var(--fg-3)", fontSize: 12 }}>{candidates.length}개 후보</span>
+      </div>
+
+      <AnalystReportCard report={report} />
+
+      <div style={{ display: "grid", gap: 10 }}>
+        <div style={{ color: "var(--fg-2)", fontSize: 13, fontWeight: 900 }}>이 리포트의 승인/검토 후보</div>
+        {candidates.length === 0 ? (
+          <StatusCard>이 리포트에 연결된 후보가 없습니다.</StatusCard>
+        ) : (
+          candidates.map((candidate) => <CandidateCard key={candidate.candidateUuid} candidate={candidate} />)
+        )}
+      </div>
+    </section>
+  );
 }
 
 export function ActionCenterContent({ compact = false }: { compact?: boolean }) {
   const actionCenter = useActionCenter();
-  const reports = actionCenter.state.status === "ready" ? actionCenter.state.reports.reports : [];
-  const latestReport = reports[0];
-  const visibleReports = latestReport ? [latestReport] : [];
-  const latestReportUuid = latestReport?.reportUuid;
-  const candidates =
-    actionCenter.state.status === "ready"
-      ? latestReportUuid
-        ? actionCenter.state.candidates.candidates.filter((candidate) => candidate.reportUuid === latestReportUuid)
-        : actionCenter.state.candidates.candidates
-      : [];
+  const reports = actionCenter.state.status === "ready"
+    ? [...actionCenter.state.reports.reports].sort((a, b) => reportTime(b) - reportTime(a))
+    : [];
+  const allCandidates = actionCenter.state.status === "ready" ? actionCenter.state.candidates.candidates : [];
+  const candidatesByReport = new Map<string, AnalysisCandidate[]>();
+  for (const candidate of allCandidates) {
+    if (!candidate.reportUuid) continue;
+    const current = candidatesByReport.get(candidate.reportUuid) ?? [];
+    current.push(candidate);
+    candidatesByReport.set(candidate.reportUuid, current);
+  }
 
   return (
     <div style={{ padding: compact ? "14px 16px 22px" : 24, display: "grid", gap: 16 }}>
@@ -69,33 +140,30 @@ export function ActionCenterContent({ compact = false }: { compact?: boolean }) 
       )}
 
       {actionCenter.state.status === "ready" && (
-        <>
-          <section style={{ display: "grid", gap: 10 }}>
-            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 10 }}>
-              <h2 style={{ margin: 0, fontSize: 18 }}>최신 애널리스트 리포트</h2>
-              <span style={{ color: "var(--fg-3)", fontSize: 12 }}>{visibleReports.length}개</span>
+        <section style={{ display: "grid", gap: 12 }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 10 }}>
+            <div style={{ display: "grid", gap: 3 }}>
+              <h2 style={{ margin: 0, fontSize: 18 }}>리포트별 검토 이력</h2>
+              <div style={{ color: "var(--fg-3)", fontSize: 12 }}>각 리포트와 그 리포트에서 생성된 후보를 함께 보여줍니다.</div>
             </div>
-            {visibleReports.length === 0 ? (
-              <StatusCard>표시할 리포트가 없습니다. 확인 불가</StatusCard>
-            ) : (
-              visibleReports.map((report) => <AnalystReportCard key={report.reportUuid} report={report} />)
-            )}
-          </section>
-
-          <section style={{ display: "grid", gap: 10 }}>
-            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 10 }}>
-              <h2 style={{ margin: 0, fontSize: 18 }}>승인 대기 후보</h2>
-              <span style={{ color: "var(--fg-3)", fontSize: 12 }}>{candidates.length}개</span>
-            </div>
-            {candidates.length === 0 ? (
-              <StatusCard>표시할 후보가 없습니다. 확인 불가</StatusCard>
-            ) : (
-              candidates.map((candidate) => (
-                <CandidateCard key={candidate.candidateUuid} candidate={candidate} />
-              ))
-            )}
-          </section>
-        </>
+            <span style={{ color: "var(--fg-3)", fontSize: 12 }}>{reports.length}개 리포트</span>
+          </div>
+          {reports.length === 0 ? (
+            <StatusCard>표시할 리포트가 없습니다.</StatusCard>
+          ) : (
+            reports.map((report, index) => {
+              const previousReport = reports[index + 1];
+              return (
+                <ReportBundle
+                  key={report.reportUuid}
+                  report={report}
+                  candidates={candidatesByReport.get(report.reportUuid) ?? []}
+                  previousCandidates={previousReport ? candidatesByReport.get(previousReport.reportUuid) ?? [] : undefined}
+                />
+              );
+            })
+          )}
+        </section>
       )}
     </div>
   );

--- a/frontend/invest/src/components/action-center/AnalystReportCard.tsx
+++ b/frontend/invest/src/components/action-center/AnalystReportCard.tsx
@@ -3,9 +3,39 @@ import type { AnalysisReport } from "../../types/actionCenter";
 import { DataVerificationPanel } from "./DataVerificationPanel";
 import { StatusBadge } from "./StatusBadge";
 
-function dateText(value?: string | null): string {
-  if (!value) return "확인 불가";
+const MARKET_LABELS: Record<string, string> = {
+  crypto: "코인",
+  kr: "국내주식",
+  us: "미국주식",
+};
+
+const REPORT_TYPE_LABELS: Record<string, string> = {
+  action_report: "액션 리포트",
+  daily: "일일 리포트",
+};
+
+function dateText(value?: string | null, fallback = "시각 없음"): string {
+  if (!value) return fallback;
   return new Date(value).toLocaleString("ko-KR", { dateStyle: "short", timeStyle: "short" });
+}
+
+function normalizeText(value?: string | null): string {
+  if (!value) return "";
+  return value
+    .replace(/Crypto action report refresh: Upbit cash ([\d,]+) KRW, crypto evaluation ([\d,]+) KRW, P\/L (-?[\d.]+)%, pending orders (\d+)\. Primary candidates are ONDO and SAHARA stop-exit sells; BTC\/SOL are watch-only partial trim candidates; POLYX chase buy is rejected\. Candidate fields are stored in first-class quantity\/limit\/notional\/verification fields for action-center display\./gi, "코인 액션 리포트 갱신: Upbit 현금 $1원, 코인 평가액 $2원, 손익률 $3%, 대기 주문 $4건. 주요 후보는 ONDO·SAHARA 손절 매도, BTC·SOL은 관찰용 부분 축소, POLYX 추격 매수는 거절입니다.")
+    .replace(/Crypto market is open 24\/7\. US risk assets were weak in the Naver cross-check, and crypto regulatory\/security headlines remain elevated\. The report is a read-only decision artifact; no order was submitted\./gi, "코인 시장은 24시간 열려 있습니다. Naver 교차 확인 기준 미국 위험자산은 약했고, 코인 규제·보안 관련 뉴스 위험은 높은 편입니다. 이 리포트는 읽기 전용 판단 기록이며 주문은 제출하지 않았습니다.")
+    .replace(/Actual order execution not performed\./gi, "실제 주문 실행 없음")
+    .replace(/Before any sell, re-check Upbit sellable quantity, staking lock status, current orderbook, and active pending orders\./gi, "매도 전 Upbit 매도 가능 수량, 스테이킹 잠금 상태, 현재 호가, 대기 주문을 재확인")
+    .replace(/Use limit orders only\./gi, "지정가 주문만 사용")
+    .replace(/Rejected candidates must remain non-executable\./gi, "거절 후보는 실행 불가 상태 유지");
+}
+
+function reportTypeText(value: string): string {
+  return REPORT_TYPE_LABELS[value] ?? value;
+}
+
+function marketText(value: string): string {
+  return MARKET_LABELS[value] ?? value;
 }
 
 export function AnalystReportCard({ report }: { report: AnalysisReport }) {
@@ -15,7 +45,7 @@ export function AnalystReportCard({ report }: { report: AnalysisReport }) {
         <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
           <div style={{ display: "grid", gap: 5, minWidth: 0 }}>
             <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 800 }}>
-              {report.reportType} · {report.market} · {report.accountScope ?? "전체 계좌"}
+              {reportTypeText(report.reportType)} · {marketText(report.market)} · {report.accountScope ?? "전체 계좌"}
             </div>
             <h2
               style={{
@@ -26,23 +56,23 @@ export function AnalystReportCard({ report }: { report: AnalysisReport }) {
                 overflowWrap: "anywhere",
               }}
             >
-              {report.summary}
+              {normalizeText(report.summary)}
             </h2>
             <div style={{ color: "var(--fg-3)", fontSize: 12 }}>
-              {report.createdByProfile} · 생성 {dateText(report.createdAt)} · 유효 {dateText(report.validUntil)}
+              {report.createdByProfile} · 생성 {dateText(report.createdAt)} · 유효 {dateText(report.validUntil, "만료 시각 없음")}
             </div>
           </div>
           <StatusBadge status={report.status} />
         </div>
         {report.riskSummary && (
           <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.6, overflowWrap: "anywhere" }}>
-            {report.riskSummary}
+            {normalizeText(report.riskSummary)}
           </p>
         )}
         <DataVerificationPanel report={report} />
         {report.safetyNotes && report.safetyNotes.length > 0 && (
           <div style={{ color: "var(--warn)", fontSize: 12, lineHeight: 1.6 }}>
-            {report.safetyNotes.map((note) => <div key={note}>• {note}</div>)}
+            {report.safetyNotes.map((note) => <div key={note}>• {normalizeText(note)}</div>)}
           </div>
         )}
       </div>

--- a/frontend/invest/src/components/action-center/CandidateCard.tsx
+++ b/frontend/invest/src/components/action-center/CandidateCard.tsx
@@ -1,9 +1,28 @@
 import { Button, Card } from "../../ds";
 import type { AnalysisCandidate } from "../../types/actionCenter";
-import { StatusBadge } from "./StatusBadge";
+import { StatusBadge, statusText } from "./StatusBadge";
 
 const UNAVAILABLE = "확인 불가";
 const NOT_APPLICABLE = "해당 없음";
+
+const MARKET_LABELS: Record<string, string> = {
+  crypto: "코인",
+  kr: "국내주식",
+  us: "미국주식",
+};
+
+const ACTION_TYPE_LABELS: Record<string, string> = {
+  stop_exit_sell: "손절 매도 검토",
+  watch_partial_trim: "부분 축소 관찰",
+  exclude_new_buy: "신규 매수 제외",
+  buy_candidate: "매수 후보",
+  sell_candidate: "매도 후보",
+};
+
+const SIDE_LABELS: Record<string, string> = {
+  buy: "매수",
+  sell: "매도",
+};
 
 function hasValue(value: unknown): boolean {
   return value != null && value !== "";
@@ -21,6 +40,18 @@ function formatValue(value: unknown, suffix = ""): string {
 function displayValue(value: unknown, suffix = "", fallback = UNAVAILABLE): string {
   if (!hasValue(value)) return fallback;
   return formatValue(value, suffix);
+}
+
+function marketText(market: string): string {
+  return MARKET_LABELS[market] ?? market;
+}
+
+function actionTypeText(actionType: string): string {
+  return ACTION_TYPE_LABELS[actionType] ?? actionType;
+}
+
+function sideText(side: string): string {
+  return SIDE_LABELS[side] ?? side;
 }
 
 function quantityValue(candidate: AnalysisCandidate): string {
@@ -50,10 +81,33 @@ function notionalValue(candidate: AnalysisCandidate): string {
   return "승인 시 산정";
 }
 
+function normalizeUserText(value: unknown): string {
+  if (value == null || value === "") return UNAVAILABLE;
+  return String(value)
+    .replace(/^확인 불가[:：]?\s*/i, "추가 확인 필요: ")
+    .replace(/not applicable: rejected candidate/gi, "거절 후보라 계좌 검증 대상 아님")
+    .replace(/neutral orderbook; not enough to justify chase/gi, "호가 중립 · 추격 매수 근거 부족")
+    .replace(/momentum reversal risk elevated/gi, "모멘텀 반전 위험 증가")
+    .replace(/staking lock\/sellable quantity must be checked/gi, "스테이킹 잠금·매도 가능 수량 확인 필요")
+    .replace(/spread about 0\.075%; limit-only/gi, "스프레드 약 0.075% · 지정가만 사용")
+    .replace(/portfolio concentration risk/gi, "포트폴리오 집중 위험")
+    .replace(/Momentum is strong, but RSI 70\.37 and price is above upper Bollinger\. Exclude chase buy until pullback\./gi, "모멘텀은 강하지만 RSI 70.37 및 볼린저 상단 돌파로 과열 구간입니다. 눌림 전 추격 매수는 제외합니다.")
+    .replace(/Overbought extension risk/gi, "과열 연장 위험")
+    .replace(/Avoid chase buy/gi, "추격 매수 회피")
+    .replace(/RSI 70\.37 and price above upper Bollinger/gi, "RSI 70.37 및 볼린저 상단 돌파")
+    .replace(/Portfolio already crypto-heavy; no need to add beta/gi, "포트폴리오의 코인 비중이 이미 높아 추가 베타 노출 불필요")
+    .replace(/SOL concentration is high across spot\+staking\. Partial spot trim can reduce concentration only after sellable quantity and staking lock status are confirmed\./gi, "SOL 현물·스테이킹 합산 비중이 높습니다. 매도 가능 수량과 스테이킹 잠금 상태를 확인한 뒤에만 현물 일부 축소가 가능합니다.");
+}
+
 function verificationValue(candidate: AnalysisCandidate, key: string): string {
   const raw = candidate.verification?.[key];
-  if (raw == null || raw === "") return UNAVAILABLE;
-  return String(raw).replace(/^확인 불가[:：]\s*/, "추가 확인 필요: ");
+  const normalized = normalizeUserText(raw);
+  if (normalized === UNAVAILABLE && isRejectedOrExcluded(candidate)) return NOT_APPLICABLE;
+  return normalized;
+}
+
+function translatedList(values: string[]): string {
+  return values.map(normalizeUserText).join(" · ");
 }
 
 export function CandidateCard({ candidate }: { candidate: AnalysisCandidate }) {
@@ -63,7 +117,7 @@ export function CandidateCard({ candidate }: { candidate: AnalysisCandidate }) {
         <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "flex-start" }}>
           <div>
             <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 800 }}>
-              {candidate.market} · {candidate.actionType} · priority {candidate.priority}
+              {marketText(candidate.market)} · {actionTypeText(candidate.actionType)} · 우선순위 {candidate.priority}
             </div>
             <h3 style={{ margin: "4px 0 0", fontSize: 22, letterSpacing: "-0.03em" }}>{candidate.symbol}</h3>
           </div>
@@ -74,31 +128,31 @@ export function CandidateCard({ candidate }: { candidate: AnalysisCandidate }) {
         </div>
 
         <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(135px, 1fr))", gap: 8 }}>
-          <Metric label="side" value={candidate.side} />
+          <Metric label="방향" value={sideText(candidate.side)} />
           <Metric label="수량" value={quantityValue(candidate)} />
           <Metric label="비중" value={quantityPctValue(candidate)} />
           <Metric label="지정가" value={limitPriceValue(candidate)} />
           <Metric label="금액" value={notionalValue(candidate)} />
-          <Metric label="confidence" value={displayValue(candidate.confidence)} />
+          <Metric label="신뢰도" value={displayValue(candidate.confidence)} />
         </div>
 
         <div>
-          <div style={{ fontWeight: 900, marginBottom: 6 }}>Thesis</div>
-          <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.6, overflowWrap: "anywhere" }}>{candidate.thesis}</p>
+          <div style={{ fontWeight: 900, marginBottom: 6 }}>판단 근거</div>
+          <p style={{ margin: 0, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.6, overflowWrap: "anywhere" }}>{normalizeUserText(candidate.thesis)}</p>
         </div>
 
         <div style={{ display: "grid", gap: 8 }}>
           <div style={{ fontWeight: 900 }}>검증/리스크</div>
           <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(160px, 1fr))", gap: 8 }}>
-            <Metric label="계좌 feasibility" value={verificationValue(candidate, "accountFeasibility")} warn />
+            <Metric label="계좌 검증" value={verificationValue(candidate, "accountFeasibility")} warn />
             <Metric label="시장/유동성" value={verificationValue(candidate, "liquidity")} warn />
             <Metric label="이벤트/뉴스 리스크" value={verificationValue(candidate, "eventNewsRisk")} warn />
           </div>
           {candidate.riskNotes.length > 0 && (
-            <div style={{ color: "var(--warn)", fontSize: 12, lineHeight: 1.6, overflowWrap: "anywhere" }}>{candidate.riskNotes.join(" · ")}</div>
+            <div style={{ color: "var(--warn)", fontSize: 12, lineHeight: 1.6, overflowWrap: "anywhere" }}>{translatedList(candidate.riskNotes)}</div>
           )}
           {candidate.blockingReasons.length > 0 && (
-            <div style={{ color: "var(--danger)", fontSize: 12, lineHeight: 1.6, overflowWrap: "anywhere" }}>{candidate.blockingReasons.join(" · ")}</div>
+            <div style={{ color: "var(--danger)", fontSize: 12, lineHeight: 1.6, overflowWrap: "anywhere" }}>{translatedList(candidate.blockingReasons)}</div>
           )}
         </div>
 
@@ -106,8 +160,8 @@ export function CandidateCard({ candidate }: { candidate: AnalysisCandidate }) {
           <Button type="button" variant="secondary" disabled>승인 기록은 수동 처리</Button>
           <Button type="button" variant="ghost" disabled>거절 기록은 수동 처리</Button>
           <div style={{ color: "var(--fg-3)", fontSize: 12, display: "flex", gap: 10, flexWrap: "wrap" }}>
-            <span>승인 상태: {candidate.approvalStatus}</span>
-            <span>실행 상태: {candidate.executionState}</span>
+            <span>승인 상태: {statusText(candidate.approvalStatus)}</span>
+            <span>실행 상태: {statusText(candidate.executionState)}</span>
           </div>
         </div>
       </div>

--- a/frontend/invest/src/components/action-center/DataVerificationPanel.tsx
+++ b/frontend/invest/src/components/action-center/DataVerificationPanel.tsx
@@ -4,39 +4,97 @@ import { StatusBadge } from "./StatusBadge";
 
 const UNAVAILABLE = "확인 불가";
 
-function valueText(value: unknown): string {
+const KEY_LABELS: Record<string, string> = {
+  mcp: "MCP 수집",
+  toss: "Toss 교차 확인",
+  naver: "Naver 교차 확인",
+  as_of_kst: "기준 시각",
+  invest_page: "투자 화면",
+  accounts: "계좌/보유",
+  symbols_analyzed: "분석 종목",
+  external_cross_checks: "외부 교차 검증",
+  not_checked_or_unavailable: "추가 확인 필요",
+  accountFeasibility: "계좌 검증",
+  marketLiquidity: "시장/유동성",
+  eventRisk: "이벤트 리스크",
+};
+
+const STAGE_LABELS: Record<string, string> = {
+  account_feasibility: "계좌 검증",
+  market_liquidity: "시장/유동성",
+  event_risk: "이벤트 리스크",
+  candidate_generation: "후보 생성",
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  kis_live: "KIS 실계좌",
+  upbit: "Upbit",
+  mcp: "MCP",
+  naver: "Naver",
+  toss: "Toss",
+};
+
+function labelText(key: string): string {
+  return KEY_LABELS[key] ?? key;
+}
+
+function stageText(key: string): string {
+  return STAGE_LABELS[key] ?? key;
+}
+
+function sourceText(source: string): string {
+  return SOURCE_LABELS[source] ?? source;
+}
+
+function normalizeText(value: unknown): string {
   if (value == null || value === "") return UNAVAILABLE;
-  if (Array.isArray(value)) return value.length === 0 ? UNAVAILABLE : value.join(" · ");
+  if (Array.isArray(value)) return value.length === 0 ? UNAVAILABLE : value.map(normalizeText).join(" · ");
   if (typeof value === "object") return JSON.stringify(value);
-  return String(value);
+  return String(value)
+    .replace(/^확인 불가[:：]?\s*/i, "추가 확인 필요: ")
+    .replace(/tab detected but detailed values not extracted/gi, "탭은 확인했지만 상세 값은 추출하지 못함")
+    .replace(/stock\.naver\.com\/market\/crypto checked/gi, "Naver 코인 시장 페이지 확인")
+    .replace(/visible; layout issue identified in long text\/grid cards/gi, "접근 가능 · 긴 문구/그리드 카드 레이아웃 문제 확인")
+    .replace(/cash\/holdings\/pending\/journals collected around/gi, "현금·보유·대기 주문·저널 수집")
+    .replace(/Toss detailed page values/gi, "Toss 상세 페이지 값")
+    .replace(/Upbit staking lock\/sellable quantity details beyond holdings split/gi, "Upbit 스테이킹 잠금·매도 가능 수량 상세")
+    .replace(/Naver crypto market page/gi, "Naver 코인 시장 페이지")
+    .replace(/Chrome remote_debug tab inventory/gi, "Chrome 원격 디버그 탭 목록");
+}
+
+function valueText(value: unknown): string {
+  return normalizeText(value);
 }
 
 function KeyValueGrid({ values }: { values: Record<string, unknown> }) {
   const entries = Object.entries(values);
   if (entries.length === 0) {
-    return <div style={{ color: "var(--fg-3)", fontSize: 12 }}>{UNAVAILABLE}</div>;
+    return <div style={{ color: "var(--fg-3)", fontSize: 12 }}>표시할 항목이 없습니다.</div>;
   }
   return (
     <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))", gap: 8 }}>
-      {entries.map(([key, value]) => (
-        <div key={key} style={{ padding: 10, borderRadius: 12, background: "var(--surface-2)", display: "grid", gap: 3, minWidth: 0 }}>
-          <div style={{ color: "var(--fg-3)", fontSize: 11, overflowWrap: "anywhere" }}>{key}</div>
-          <div
-            style={{
-              color: valueText(value) === UNAVAILABLE ? "var(--warn)" : "var(--fg-1)",
-              fontWeight: 800,
-              fontSize: 12,
-              lineHeight: 1.45,
-              maxHeight: 96,
-              overflow: "auto",
-              overflowWrap: "anywhere",
-              whiteSpace: "pre-wrap",
-            }}
-          >
-            {valueText(value)}
+      {entries.map(([key, value]) => {
+        const text = valueText(value);
+        return (
+          <div key={key} style={{ padding: 10, borderRadius: 12, background: "var(--surface-2)", display: "grid", gap: 3, minWidth: 0 }}>
+            <div style={{ color: "var(--fg-3)", fontSize: 11, overflowWrap: "anywhere" }}>{labelText(key)}</div>
+            <div
+              style={{
+                color: text === UNAVAILABLE ? "var(--warn)" : "var(--fg-1)",
+                fontWeight: 800,
+                fontSize: 12,
+                lineHeight: 1.45,
+                maxHeight: 96,
+                overflow: "auto",
+                overflowWrap: "anywhere",
+                whiteSpace: "pre-wrap",
+              }}
+            >
+              {text}
+            </div>
           </div>
-        </div>
-      ))}
+        );
+      })}
     </div>
   );
 }
@@ -45,14 +103,14 @@ function StageRow({ stage }: { stage: AnalysisStageResult }) {
   return (
     <div style={{ padding: "9px 0", borderTop: "1px solid var(--divider)", display: "grid", gap: 4 }}>
       <div style={{ display: "flex", justifyContent: "space-between", gap: 8, alignItems: "center" }}>
-        <strong style={{ fontSize: 13 }}>{stage.stageKey}</strong>
+        <strong style={{ fontSize: 13 }}>{stageText(stage.stageKey)}</strong>
         <StatusBadge status={stage.status} />
       </div>
       <div style={{ color: "var(--fg-3)", fontSize: 12 }}>
-        {stage.source} · {stage.freshnessAt ?? stage.unavailableReason ?? UNAVAILABLE}
+        {sourceText(stage.source)} · {stage.freshnessAt ?? normalizeText(stage.unavailableReason) ?? UNAVAILABLE}
       </div>
       {stage.warnings && stage.warnings.length > 0 && (
-        <div style={{ color: "var(--warn)", fontSize: 12 }}>{stage.warnings.join(" · ")}</div>
+        <div style={{ color: "var(--warn)", fontSize: 12 }}>{stage.warnings.map(normalizeText).join(" · ")}</div>
       )}
     </div>
   );
@@ -69,16 +127,16 @@ export function DataVerificationPanel({ report }: { report: AnalysisReport }) {
           </div>
         </div>
         <div>
-          <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 800, marginBottom: 6 }}>Freshness</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 800, marginBottom: 6 }}>데이터 신선도</div>
           <KeyValueGrid values={report.dataFreshness ?? {}} />
         </div>
         <div>
-          <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 800, marginBottom: 6 }}>Coverage</div>
+          <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 800, marginBottom: 6 }}>검증 범위</div>
           <KeyValueGrid values={report.coverage ?? {}} />
         </div>
         {report.stageResults && report.stageResults.length > 0 && (
           <div>
-            <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 800, marginBottom: 2 }}>Stage checks</div>
+            <div style={{ color: "var(--fg-3)", fontSize: 12, fontWeight: 800, marginBottom: 2 }}>단계별 점검</div>
             {report.stageResults.map((stage) => <StageRow key={`${stage.stageKey}:${stage.source}`} stage={stage} />)}
           </div>
         )}

--- a/frontend/invest/src/components/action-center/StatusBadge.tsx
+++ b/frontend/invest/src/components/action-center/StatusBadge.tsx
@@ -2,6 +2,21 @@ import { Pill } from "../../ds";
 
 type Tone = "paper" | "accent" | "gain" | "loss" | "warn";
 
+const STATUS_LABELS: Record<string, string> = {
+  published: "발행됨",
+  ok: "정상",
+  approved: "승인됨",
+  filled: "체결됨",
+  rejected: "거절됨",
+  failed: "실패",
+  blocked: "차단됨",
+  awaiting_approval: "승인 대기",
+  degraded: "부분 확인",
+  stale: "오래됨",
+  unavailable: "확인 필요",
+  not_submitted: "미제출",
+};
+
 function toneForStatus(status: string): Tone {
   if (["published", "ok", "approved", "filled"].includes(status)) return "gain";
   if (["rejected", "failed", "blocked"].includes(status)) return "loss";
@@ -9,11 +24,15 @@ function toneForStatus(status: string): Tone {
   return "paper";
 }
 
+export function statusText(status: string): string {
+  return STATUS_LABELS[status] ?? status;
+}
+
 export function StatusBadge({ label, status }: { label?: string; status: string }) {
   return (
     <span style={{ display: "inline-flex", alignItems: "center", gap: 6 }}>
       {label && <span style={{ color: "var(--fg-3)", fontSize: 12 }}>{label}</span>}
-      <Pill tone={toneForStatus(status)} size="sm">{status}</Pill>
+      <Pill tone={toneForStatus(status)} size="sm">{statusText(status)}</Pill>
     </span>
   );
 }


### PR DESCRIPTION
## 요약
- 액션 센터를 `승인 대기 후보` + `최신 애널리스트 리포트` 병렬 섹션에서 `리포트별 검토 이력` 구조로 재배치했습니다.
- 각 리포트 카드 아래에 해당 리포트에서 생성된 후보만 묶어 표시하고, 바로 이전 리포트 대비 후보 변화 요약을 노출합니다.
- 스크린샷에서 보이던 `확인 불가` 남용, 영어 원시 상태값/문구, 후보 카드의 역할 혼재를 한국어/맥락 기반 표시로 정리했습니다.

## 변경 사항
- 리포트 제목 예: `5. 16. 09:55 코인 리포트` 형태로 시각·시장 단위 표시
- 이전 리포트 대비 신규/제외/상태·우선순위 변경 후보 요약
- `published`, `awaiting_approval`, `not_submitted` 등 원시 상태값을 `발행됨`, `승인 대기`, `미제출`로 표시
- 후보 카드의 `side`, action type, verification/risk 문구를 한국어 우선 표시
- 데이터 검증 패널의 `Freshness`, `Coverage`, key 이름과 일부 원시 영어 값을 한국어 표시로 정리

## 테스트
- `npm test -- --run src/__tests__/DesktopActionCenterPage.test.tsx`
- `npm run typecheck`
- `npm run build`

## 안전
- 읽기 전용 UI 표시 변경입니다.
- 주문 제출/취소/정정 로직은 변경하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced report-by-report review history view for better candidate tracking and organization
  * Added comprehensive Korean language localization throughout the action center

* **Improvements**
  * Enhanced text formatting and normalization across UI components
  * Improved candidate card metrics display and presentation
  * Reorganized data verification panel with clearer information sections

* **Tests**
  * Updated test suite to reflect new UI structure and localized labels

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/849?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->