### PR TITLE
feat(invest): make right rail collapsible and relocate page advisories

### DIFF
--- a/frontend/invest/src/__tests__/ActionReadiness.test.tsx
+++ b/frontend/invest/src/__tests__/ActionReadiness.test.tsx
@@ -3,6 +3,8 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { fetchKrActionReadiness } from "../api/actionReadiness";
 import { CoverageRoute } from "../pages/desktop/DesktopCoveragePage";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
+import { mockRightRail } from "../test/mockRightRail";
 
 const actionability = {
   priority: "none",
@@ -113,6 +115,8 @@ function readinessResponse() {
 
 const fetchMock = vi.fn();
 beforeEach(() => {
+  localStorage.clear();
+  mockRightRail();
   fetchMock.mockReset();
   fetchMock.mockImplementation((input: RequestInfo | URL) => {
     const url = String(input);
@@ -142,9 +146,11 @@ test("action readiness API client builds symbol query and includes credentials",
 
 test("coverage page renders KR action readiness blockers and source boundaries without execution buttons", async () => {
   render(
-    <MemoryRouter basename="/invest" initialEntries={["/invest/coverage"]}>
-      <CoverageRoute />
-    </MemoryRouter>,
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/coverage"]}>
+        <CoverageRoute />
+      </MemoryRouter>
+    </AccountPanelProvider>,
   );
 
   expect(await screen.findByText("KR 액션 리포트 준비도")).toBeInTheDocument();

--- a/frontend/invest/src/__tests__/DesktopCoveragePage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopCoveragePage.test.tsx
@@ -4,6 +4,8 @@ import { beforeEach, expect, test, vi } from "vitest";
 
 import * as coverageApi from "../api/coverage";
 import { CoverageRoute } from "../pages/desktop/DesktopCoveragePage";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
+import { mockRightRail } from "../test/mockRightRail";
 import type { InvestCoverageResponse } from "../types/coverage";
 
 const BASE_ACTIONABILITY = {
@@ -108,10 +110,16 @@ const COVERAGE_PAYLOAD: InvestCoverageResponse = {
 };
 
 function wrap(ui: React.ReactElement) {
-  return <MemoryRouter basename="/invest" initialEntries={["/invest/coverage"]}>{ui}</MemoryRouter>;
+  return (
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/coverage"]}>{ui}</MemoryRouter>
+    </AccountPanelProvider>
+  );
 }
 
 beforeEach(() => {
+  localStorage.clear();
+  mockRightRail();
   vi.spyOn(coverageApi, "fetchInvestCoverage").mockResolvedValue(COVERAGE_PAYLOAD);
 });
 

--- a/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopInsightsPage.test.tsx
@@ -5,6 +5,8 @@ import { beforeEach, expect, test, vi } from "vitest";
 import { DesktopInsightsPage } from "../pages/desktop/DesktopInsightsPage";
 import { useCommonPreferredDisparity } from "../hooks/useCommonPreferredDisparity";
 import { useMarketParity } from "../hooks/useMarketParity";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
+import { mockRightRail } from "../test/mockRightRail";
 
 vi.mock("../hooks/useMarketParity", () => ({ useMarketParity: vi.fn() }));
 vi.mock("../hooks/useCommonPreferredDisparity", () => ({ useCommonPreferredDisparity: vi.fn() }));
@@ -90,10 +92,16 @@ const disparityReady = {
 };
 
 function wrap(ui: React.ReactElement) {
-  return <MemoryRouter basename="/invest" initialEntries={["/invest/insights"]}>{ui}</MemoryRouter>;
+  return (
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/insights"]}>{ui}</MemoryRouter>
+    </AccountPanelProvider>
+  );
 }
 
 beforeEach(() => {
+  localStorage.clear();
+  mockRightRail();
   vi.mocked(useMarketParity).mockReturnValue(marketParityReady);
   vi.mocked(useCommonPreferredDisparity).mockReturnValue(disparityReady);
 });

--- a/frontend/invest/src/__tests__/DesktopMarketPage.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopMarketPage.test.tsx
@@ -5,6 +5,8 @@ import { beforeEach, expect, test, vi } from "vitest";
 import { DesktopMarketPage } from "../pages/desktop/DesktopMarketPage";
 import * as disparityApi from "../api/commonPreferredDisparity";
 import * as marketApi from "../api/marketDashboard";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
+import { mockRightRail } from "../test/mockRightRail";
 import type { CommonPreferredDisparityResponse } from "../types/commonPreferredDisparity";
 
 const DISPARITY_PAYLOAD: CommonPreferredDisparityResponse = {
@@ -121,11 +123,17 @@ const MARKET_PAYLOAD = {
 };
 
 function wrap(ui: React.ReactElement) {
-  return <MemoryRouter basename="/invest" initialEntries={["/invest/market"]}>{ui}</MemoryRouter>;
+  return (
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/market"]}>{ui}</MemoryRouter>
+    </AccountPanelProvider>
+  );
 }
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  localStorage.clear();
+  mockRightRail();
   vi.spyOn(marketApi, "fetchMarketDashboard").mockResolvedValue(MARKET_PAYLOAD);
   vi.spyOn(disparityApi, "fetchCommonPreferredDisparity").mockResolvedValue(DISPARITY_PAYLOAD);
 });

--- a/frontend/invest/src/__tests__/DesktopShell.test.tsx
+++ b/frontend/invest/src/__tests__/DesktopShell.test.tsx
@@ -1,20 +1,81 @@
 import { render, screen } from "@testing-library/react";
-import { expect, test } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, expect, test, vi } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { DesktopShell } from "../desktop/DesktopShell";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
+import * as panelApi from "../api/accountPanel";
+import * as signalsApi from "../api/signals";
+import type { AccountPanelResponse } from "../types/invest";
 
-test("renders left/center/right slots", () => {
-  render(
-    <MemoryRouter basename="/invest" initialEntries={["/invest/"]}>
-      <DesktopShell
-        left={<div>L</div>}
-        center={<div>C</div>}
-        right={<div>R</div>}
-      />
-    </MemoryRouter>,
+const EMPTY_PANEL: AccountPanelResponse = {
+  homeSummary: {
+    includedSources: [],
+    excludedSources: [],
+    totalValueKrw: 0,
+    costBasisKrw: null,
+    pnlKrw: null,
+    pnlRate: null,
+  },
+  accounts: [],
+  groupedHoldings: [],
+  watchSymbols: [],
+  sourceVisuals: [],
+  meta: { warnings: [], watchlistAvailable: true },
+};
+
+function renderShell() {
+  return render(
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/"]}>
+        <DesktopShell left={<div>L</div>} center={<div>C</div>} />
+      </MemoryRouter>
+    </AccountPanelProvider>,
   );
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(panelApi, "fetchAccountPanel").mockResolvedValue(EMPTY_PANEL);
+  vi.spyOn(signalsApi, "fetchSignals").mockResolvedValue({
+    tab: "kr",
+    asOf: new Date().toISOString(),
+    items: [],
+    meta: { warnings: [] },
+  });
+  localStorage.clear();
+});
+
+test("renders left and center slots plus the always-mounted right rail panel", () => {
+  renderShell();
   expect(screen.getByTestId("desktop-shell")).toBeInTheDocument();
   expect(screen.getByText("L")).toBeInTheDocument();
   expect(screen.getByText("C")).toBeInTheDocument();
-  expect(screen.getByText("R")).toBeInTheDocument();
+  expect(screen.getByTestId("right-remote-panel")).toBeInTheDocument();
+  expect(screen.getByTestId("desktop-shell")).toHaveAttribute("data-rail-collapsed", "false");
+});
+
+test("⌘. shortcut toggles the right rail collapsed state and persists it", async () => {
+  const user = userEvent.setup();
+  renderShell();
+  expect(screen.getByTestId("desktop-shell")).toHaveAttribute("data-rail-collapsed", "false");
+
+  await user.keyboard("{Meta>}.{/Meta}");
+
+  expect(screen.getByTestId("desktop-shell")).toHaveAttribute("data-rail-collapsed", "true");
+  expect(localStorage.getItem("invest:right-rail-collapsed")).toBe("1");
+  expect(screen.getByTestId("right-remote-panel-collapsed")).toBeInTheDocument();
+
+  await user.keyboard("{Meta>}.{/Meta}");
+  expect(screen.getByTestId("desktop-shell")).toHaveAttribute("data-rail-collapsed", "false");
+  expect(localStorage.getItem("invest:right-rail-collapsed")).toBe("0");
+});
+
+test("collapse button inside the pane collapses the rail", async () => {
+  const user = userEvent.setup();
+  renderShell();
+  expect(screen.getByTestId("desktop-shell")).toHaveAttribute("data-rail-collapsed", "false");
+
+  await user.click(screen.getByTestId("right-remote-panel-collapse"));
+  expect(screen.getByTestId("desktop-shell")).toHaveAttribute("data-rail-collapsed", "true");
 });

--- a/frontend/invest/src/__tests__/FxMacroPage.test.tsx
+++ b/frontend/invest/src/__tests__/FxMacroPage.test.tsx
@@ -4,6 +4,8 @@ import { beforeEach, expect, test, vi } from "vitest";
 
 import { FxMacroRoute } from "../pages/desktop/FxMacroPage";
 import * as fxApi from "../api/fxDashboard";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
+import { mockRightRail } from "../test/mockRightRail";
 import type { FxDashboardResponse } from "../types/fxDashboard";
 
 const FX_PAYLOAD: FxDashboardResponse = {
@@ -57,11 +59,17 @@ const FX_PAYLOAD: FxDashboardResponse = {
 };
 
 function wrap(ui: React.ReactElement) {
-  return <MemoryRouter basename="/invest" initialEntries={["/invest/market/fx"]}>{ui}</MemoryRouter>;
+  return (
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={["/invest/market/fx"]}>{ui}</MemoryRouter>
+    </AccountPanelProvider>
+  );
 }
 
 beforeEach(() => {
+  localStorage.clear();
   Object.defineProperty(window, "innerWidth", { writable: true, configurable: true, value: 1280 });
+  mockRightRail();
   vi.spyOn(fxApi, "fetchFxDashboard").mockResolvedValue(FX_PAYLOAD);
 });
 

--- a/frontend/invest/src/__tests__/PageSafetyNote.test.tsx
+++ b/frontend/invest/src/__tests__/PageSafetyNote.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, expect, test } from "vitest";
+import { PageSafetyNote } from "../components/PageSafetyNote";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+test("renders heading, tag and bulleted items", () => {
+  render(
+    <PageSafetyNote
+      routeId="t1"
+      heading="읽기 전용 원칙"
+      tag="시장 페이지"
+      items={["주문·매매 API를 호출하지 않습니다.", "응답을 표시만 합니다."]}
+    />,
+  );
+  const note = screen.getByTestId("page-safety-note");
+  expect(note).toHaveAttribute("data-route-id", "t1");
+  expect(screen.getByText("읽기 전용 원칙")).toBeInTheDocument();
+  expect(screen.getByText("시장 페이지")).toBeInTheDocument();
+  expect(screen.getByText("주문·매매 API를 호출하지 않습니다.")).toBeInTheDocument();
+});
+
+test("dismiss button persists per-route and hides the note", async () => {
+  const user = userEvent.setup();
+  const { unmount } = render(
+    <PageSafetyNote routeId="market" heading="hello" items={["x"]} />,
+  );
+  expect(screen.getByTestId("page-safety-note")).toBeInTheDocument();
+
+  await user.click(screen.getByTestId("page-safety-note-dismiss"));
+  expect(screen.queryByTestId("page-safety-note")).not.toBeInTheDocument();
+  expect(localStorage.getItem("invest:safety-note-dismissed:market")).toBe("1");
+
+  unmount();
+  render(<PageSafetyNote routeId="market" heading="hello" items={["x"]} />);
+  expect(screen.queryByTestId("page-safety-note")).not.toBeInTheDocument();
+});
+
+test("dismiss state is scoped to its routeId", async () => {
+  const user = userEvent.setup();
+  localStorage.setItem("invest:safety-note-dismissed:market", "1");
+  render(
+    <>
+      <PageSafetyNote routeId="market" heading="A" items={["a"]} />
+      <PageSafetyNote routeId="coverage" heading="B" items={["b"]} />
+    </>,
+  );
+  const visible = screen.getByTestId("page-safety-note");
+  expect(visible).toHaveAttribute("data-route-id", "coverage");
+
+  await user.click(screen.getByTestId("page-safety-note-dismiss"));
+  expect(screen.queryByTestId("page-safety-note")).not.toBeInTheDocument();
+});
+
+test("non-dismissible note hides the close button", () => {
+  render(<PageSafetyNote routeId="x" heading="hi" items={["a"]} dismissible={false} />);
+  expect(screen.queryByTestId("page-safety-note-dismiss")).not.toBeInTheDocument();
+});

--- a/frontend/invest/src/__tests__/StockDetailPage.test.tsx
+++ b/frontend/invest/src/__tests__/StockDetailPage.test.tsx
@@ -3,6 +3,8 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { StockDetailPage } from "../pages/stock-detail/StockDetailPage";
 import * as stockApi from "../api/stockDetail";
+import { AccountPanelProvider } from "../desktop/AccountPanelProvider";
+import { mockRightRail } from "../test/mockRightRail";
 import type {
   StockDetailCandlesResponse,
   StockDetailNewsResponse,
@@ -236,15 +238,19 @@ const researchConsensus: StockDetailResearchConsensusResponse = {
 
 function renderPage(path = "/invest/stocks/us/QQQM") {
   return render(
-    <MemoryRouter basename="/invest" initialEntries={[path]}>
-      <Routes>
-        <Route path="/stocks/:market/:symbol" element={<StockDetailPage />} />
-      </Routes>
-    </MemoryRouter>,
+    <AccountPanelProvider>
+      <MemoryRouter basename="/invest" initialEntries={[path]}>
+        <Routes>
+          <Route path="/stocks/:market/:symbol" element={<StockDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </AccountPanelProvider>,
   );
 }
 
 beforeEach(() => {
+  localStorage.clear();
+  mockRightRail();
   vi.spyOn(stockApi, "fetchStockDetail").mockResolvedValue(aboveFold);
   vi.spyOn(stockApi, "fetchStockDetailCandles").mockResolvedValue(candles);
   vi.spyOn(stockApi, "fetchStockDetailOrders").mockResolvedValue(orders);

--- a/frontend/invest/src/components/PageSafetyNote.tsx
+++ b/frontend/invest/src/components/PageSafetyNote.tsx
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useState, type ReactNode } from "react";
+import { Icon } from "../ds";
+
+const DISMISS_KEY_PREFIX = "invest:safety-note-dismissed:";
+
+function readDismissed(routeId: string): boolean {
+  try {
+    return window.localStorage.getItem(`${DISMISS_KEY_PREFIX}${routeId}`) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeDismissed(routeId: string): void {
+  try {
+    window.localStorage.setItem(`${DISMISS_KEY_PREFIX}${routeId}`, "1");
+  } catch {
+    /* ignore */
+  }
+}
+
+export function PageSafetyNote({
+  routeId,
+  heading,
+  tag,
+  items,
+  children,
+  dismissible = true,
+}: Readonly<{
+  routeId: string;
+  heading: string;
+  tag?: string;
+  items?: ReactNode[];
+  children?: ReactNode;
+  dismissible?: boolean;
+}>) {
+  const [dismissed, setDismissed] = useState<boolean>(() =>
+    dismissible ? readDismissed(routeId) : false,
+  );
+
+  useEffect(() => {
+    if (!dismissible) {
+      setDismissed(false);
+      return;
+    }
+    setDismissed(readDismissed(routeId));
+  }, [routeId, dismissible]);
+
+  const handleDismiss = useCallback(() => {
+    writeDismissed(routeId);
+    setDismissed(true);
+  }, [routeId]);
+
+  if (dismissed) return null;
+
+  return (
+    <div
+      data-testid="page-safety-note"
+      data-route-id={routeId}
+      role="note"
+      style={{
+        display: "grid",
+        gridTemplateColumns: dismissible ? "18px 1fr auto" : "18px 1fr",
+        gap: 12,
+        alignItems: "start",
+        background: "var(--accent-soft)",
+        border: "1px solid color-mix(in srgb, var(--accent) 15%, transparent)",
+        borderRadius: 12,
+        padding: "12px 14px",
+        fontSize: 12,
+        color: "var(--fg-1)",
+      }}
+    >
+      <span style={{ color: "var(--accent)", marginTop: 1 }}>
+        <Icon name="info" size={16} />
+      </span>
+      <div style={{ minWidth: 0 }}>
+        <div
+          style={{
+            fontWeight: 700,
+            color: "var(--fg)",
+            display: "flex",
+            gap: 8,
+            alignItems: "center",
+            flexWrap: "wrap",
+          }}
+        >
+          {heading}
+          {tag ? (
+            <span
+              style={{
+                fontSize: 10,
+                padding: "1px 6px",
+                borderRadius: 999,
+                background: "var(--surface)",
+                color: "var(--accent)",
+                fontWeight: 700,
+                border: "1px solid color-mix(in srgb, var(--accent) 20%, transparent)",
+              }}
+            >
+              {tag}
+            </span>
+          ) : null}
+        </div>
+        {items && items.length > 0 ? (
+          <ul
+            style={{
+              margin: "6px 0 0",
+              padding: 0,
+              listStyle: "none",
+              display: "grid",
+              gap: 4,
+            }}
+          >
+            {items.map((item, idx) => (
+              <li
+                key={idx}
+                style={{
+                  color: "var(--fg-2)",
+                  lineHeight: 1.55,
+                }}
+              >
+                <span style={{ color: "var(--fg-4)", marginRight: 6 }}>·</span>
+                {item}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        {children ? <div style={{ marginTop: 6, color: "var(--fg-2)", lineHeight: 1.55 }}>{children}</div> : null}
+      </div>
+      {dismissible ? (
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="안내 닫기"
+          data-testid="page-safety-note-dismiss"
+          style={{
+            background: "transparent",
+            border: "none",
+            cursor: "pointer",
+            padding: 2,
+            color: "var(--fg-3)",
+            fontFamily: "inherit",
+            fontSize: 13,
+            lineHeight: 1,
+          }}
+        >
+          ✕
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/invest/src/desktop/DesktopShell.tsx
+++ b/frontend/invest/src/desktop/DesktopShell.tsx
@@ -1,45 +1,59 @@
 import type { ReactNode } from "react";
 import { DesktopHeader } from "./DesktopHeader";
+import { RightRemotePanel } from "./RightRemotePanel";
+import { useRightRailCollapsed } from "./useRightRailCollapsed";
+
+const RAIL_WIDTH_EXPANDED = "320px";
+const RAIL_WIDTH_COLLAPSED = "56px";
 
 export function DesktopShell({
   left,
   center,
-  right,
   leftColumnWidth = 220,
 }: {
   left?: ReactNode;
   center: ReactNode;
-  right: ReactNode;
   leftColumnWidth?: number | string;
 }) {
   const resolvedLeftColumnWidth =
     typeof leftColumnWidth === "number" ? `${leftColumnWidth}px` : leftColumnWidth;
+  const { collapsed, setCollapsed } = useRightRailCollapsed();
+  const railWidth = collapsed ? RAIL_WIDTH_COLLAPSED : RAIL_WIDTH_EXPANDED;
 
   return (
-    <div data-testid="desktop-shell" style={{ minHeight: "100vh", background: "var(--bg-alt)", color: "var(--fg)" }}>
+    <div
+      data-testid="desktop-shell"
+      data-rail-collapsed={collapsed ? "true" : "false"}
+      style={{ minHeight: "100vh", background: "var(--bg-alt)", color: "var(--fg)" }}
+    >
       <DesktopHeader />
       <div
         style={{
           display: "grid",
-          gridTemplateColumns: left ? `${resolvedLeftColumnWidth} minmax(0,1fr) 320px` : "minmax(0,1fr) 320px",
+          gridTemplateColumns: left
+            ? `${resolvedLeftColumnWidth} minmax(0,1fr) ${railWidth}`
+            : `minmax(0,1fr) ${railWidth}`,
           gap: 24,
           padding: "24px 28px 64px",
           maxWidth: 1440,
           margin: "0 auto",
+          transition: "grid-template-columns var(--dur-slow, 240ms) var(--ease-emph, cubic-bezier(0.2, 0.8, 0.2, 1.0))",
         }}
       >
         {left ? <aside style={{ minWidth: 0 }}>{left}</aside> : null}
         <main style={{ minWidth: 0, display: "flex", flexDirection: "column", gap: 16 }}>{center}</main>
         <aside
+          data-testid="desktop-shell-rail"
           style={{
             position: "sticky",
             top: 80,
             alignSelf: "start",
             maxHeight: "calc(100vh - 96px)",
             overflowY: "auto",
+            minWidth: 0,
           }}
         >
-          {right}
+          <RightRemotePanel collapsed={collapsed} onCollapseChange={setCollapsed} />
         </aside>
       </div>
     </div>

--- a/frontend/invest/src/desktop/RightRemotePanel.tsx
+++ b/frontend/invest/src/desktop/RightRemotePanel.tsx
@@ -25,6 +25,35 @@ const TABS: { key: RightPanelTab; label: string }[] = [
   { key: "realtime", label: "실시간" },
 ];
 
+const RIGHT_RAIL_TAB_STORAGE_KEY = "invest:right-rail-tab";
+
+const RAIL_ICON_TABS: { key: RightPanelTab; label: string; icon: "chart" | "heart" | "clock" | "flash" }[] = [
+  { key: "portfolio", label: "내 투자", icon: "chart" },
+  { key: "watchlist", label: "관심", icon: "heart" },
+  { key: "recent", label: "최근 본", icon: "clock" },
+  { key: "realtime", label: "실시간", icon: "flash" },
+];
+
+function readStoredTab(): RightPanelTab {
+  try {
+    const value = window.localStorage.getItem(RIGHT_RAIL_TAB_STORAGE_KEY);
+    if (value === "portfolio" || value === "watchlist" || value === "recent" || value === "realtime") {
+      return value;
+    }
+  } catch {
+    /* ignore */
+  }
+  return "portfolio";
+}
+
+function writeStoredTab(tab: RightPanelTab): void {
+  try {
+    window.localStorage.setItem(RIGHT_RAIL_TAB_STORAGE_KEY, tab);
+  } catch {
+    /* ignore */
+  }
+}
+
 const MARKET_LABEL: Record<MarketKey, string> = {
   kr: "KR",
   us: "US",
@@ -639,10 +668,153 @@ function RealtimePanel({
   );
 }
 
-export function RightRemotePanel() {
-  const [activeTab, setActiveTab] = useState<RightPanelTab>("portfolio");
+function RailIconButton({
+  label,
+  icon,
+  active,
+  onClick,
+  ariaLabel,
+}: Readonly<{
+  label?: string;
+  icon: "chart" | "heart" | "clock" | "flash" | "expandLeft" | "settings";
+  active?: boolean;
+  onClick: () => void;
+  ariaLabel?: string;
+}>) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-current={active ? "true" : undefined}
+      aria-label={ariaLabel ?? label}
+      style={{
+        width: 44,
+        height: label ? 52 : 36,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 4,
+        borderRadius: 10,
+        color: active ? "var(--fg)" : "var(--fg-3)",
+        background: "transparent",
+        border: "none",
+        fontFamily: "inherit",
+        fontSize: 10,
+        cursor: "pointer",
+      }}
+    >
+      <span style={{ color: active ? "var(--accent)" : "currentColor" }}>
+        <Icon name={icon} size={20} />
+      </span>
+      {label ? <span>{label}</span> : null}
+    </button>
+  );
+}
+
+function CollapsedRail({
+  activeTab,
+  onPickTab,
+  onExpand,
+}: Readonly<{
+  activeTab: RightPanelTab;
+  onPickTab: (tab: RightPanelTab) => void;
+  onExpand: () => void;
+}>) {
+  return (
+    <div
+      data-testid="right-remote-panel-collapsed"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 4,
+        padding: "8px 6px",
+        alignItems: "center",
+      }}
+    >
+      <RailIconButton
+        icon="expandLeft"
+        ariaLabel="패널 펼치기"
+        onClick={onExpand}
+      />
+      {RAIL_ICON_TABS.map((tab) => (
+        <RailIconButton
+          key={tab.key}
+          label={tab.label}
+          icon={tab.icon}
+          active={tab.key === activeTab}
+          onClick={() => onPickTab(tab.key)}
+        />
+      ))}
+      <div style={{ height: 1, alignSelf: "stretch", background: "var(--divider)", margin: "8px 6px" }} />
+      <RailIconButton icon="settings" ariaLabel="설정" onClick={() => { /* settings entry — placeholder */ }} />
+    </div>
+  );
+}
+
+function PaneHeader({ onCollapse }: Readonly<{ onCollapse?: () => void }>) {
+  if (!onCollapse) return null;
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "flex-end",
+        paddingBottom: 8,
+        marginBottom: 4,
+        borderBottom: "1px solid var(--divider)",
+      }}
+    >
+      <button
+        type="button"
+        onClick={onCollapse}
+        aria-label="패널 접기"
+        data-testid="right-remote-panel-collapse"
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "4px 10px",
+          borderRadius: 999,
+          background: "var(--surface-2)",
+          color: "var(--fg-2)",
+          border: "none",
+          fontFamily: "inherit",
+          fontSize: 11,
+          fontWeight: 600,
+          cursor: "pointer",
+        }}
+      >
+        접기
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: 10,
+            color: "var(--fg-3)",
+          }}
+        >
+          ⌘.
+        </span>
+      </button>
+    </div>
+  );
+}
+
+export function RightRemotePanel({
+  collapsed = false,
+  onCollapseChange,
+}: Readonly<{
+  collapsed?: boolean;
+  onCollapseChange?: (value: boolean) => void;
+}> = {}) {
+  const [activeTab, setActiveTabState] = useState<RightPanelTab>(() => readStoredTab());
   const [recentRefreshKey, setRecentRefreshKey] = useState(0);
   const navigate = useNavigate();
+
+  const setActiveTab = useCallback((tab: RightPanelTab) => {
+    setActiveTabState(tab);
+    writeStoredTab(tab);
+  }, []);
 
   const handleNavigate = useCallback(
     (path: string, sym: RecentInvestSymbol) => {
@@ -653,8 +825,24 @@ export function RightRemotePanel() {
     [navigate],
   );
 
+  if (collapsed) {
+    return (
+      <div data-testid="right-remote-panel" data-collapsed="true">
+        <CollapsedRail
+          activeTab={activeTab}
+          onPickTab={(tab) => {
+            setActiveTab(tab);
+            onCollapseChange?.(false);
+          }}
+          onExpand={() => onCollapseChange?.(false)}
+        />
+      </div>
+    );
+  }
+
   return (
-    <div data-testid="right-remote-panel">
+    <div data-testid="right-remote-panel" data-collapsed="false">
+      <PaneHeader onCollapse={onCollapseChange ? () => onCollapseChange(true) : undefined} />
       <TabBar active={activeTab} onChange={setActiveTab} />
       {activeTab === "portfolio" && <PortfolioPanel onNavigate={handleNavigate} />}
       {activeTab === "watchlist" && <WatchlistPanel onNavigate={handleNavigate} />}

--- a/frontend/invest/src/desktop/useRightRailCollapsed.ts
+++ b/frontend/invest/src/desktop/useRightRailCollapsed.ts
@@ -1,0 +1,53 @@
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "invest:right-rail-collapsed";
+
+function readStored(): boolean {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeStored(value: boolean): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value ? "1" : "0");
+  } catch {
+    /* ignore */
+  }
+}
+
+export function useRightRailCollapsed(): {
+  collapsed: boolean;
+  setCollapsed: (value: boolean) => void;
+  toggle: () => void;
+} {
+  const [collapsed, setCollapsedState] = useState<boolean>(() => readStored());
+
+  const setCollapsed = useCallback((value: boolean) => {
+    setCollapsedState(value);
+    writeStored(value);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setCollapsedState((prev) => {
+      const next = !prev;
+      writeStored(next);
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (!(event.metaKey || event.ctrlKey)) return;
+      if (event.key !== ".") return;
+      event.preventDefault();
+      toggle();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [toggle]);
+
+  return { collapsed, setCollapsed, toggle };
+}

--- a/frontend/invest/src/ds/atoms.tsx
+++ b/frontend/invest/src/ds/atoms.tsx
@@ -267,7 +267,10 @@ export type IconName =
   | "person"
   | "sun"
   | "moon"
-  | "monitor";
+  | "monitor"
+  | "heart"
+  | "clock"
+  | "expandLeft";
 
 const ICON_PATHS: Record<IconName, ReactNode> = {
   home: <path d="M3 9.5L12 3l9 6.5V20a1 1 0 0 1-1 1h-5v-7H9v7H4a1 1 0 0 1-1-1V9.5z" />,
@@ -331,6 +334,16 @@ const ICON_PATHS: Record<IconName, ReactNode> = {
       <path d="M8 21h8M12 18v3" />
     </>
   ),
+  heart: (
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+  ),
+  clock: (
+    <>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7v5l3 2" />
+    </>
+  ),
+  expandLeft: <path d="M13 6l-6 6 6 6M19 6l-6 6 6 6" />,
 };
 
 export function Icon({ name, size = 20 }: { name: IconName; size?: number }) {

--- a/frontend/invest/src/pages/desktop/DesktopActionCenterPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopActionCenterPage.tsx
@@ -1,14 +1,17 @@
 import { ActionCenterContent, ActionCenterRelatedLinks } from "../../components/action-center/ActionCenterContent";
 import { DesktopShell } from "../../desktop/DesktopShell";
-import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useViewport } from "../../hooks/useViewport";
 import { MobileActionCenterPage } from "../mobile/MobileActionCenterPage";
 
 export function DesktopActionCenterPage() {
   return (
     <DesktopShell
-      center={<ActionCenterContent />}
-      right={<div style={{ display: "grid", gap: 12 }}><ActionCenterRelatedLinks /><RightRemotePanel /></div>}
+      center={
+        <div style={{ display: "grid", gap: 12 }}>
+          <ActionCenterContent />
+          <ActionCenterRelatedLinks />
+        </div>
+      }
     />
   );
 }

--- a/frontend/invest/src/pages/desktop/DesktopCalendarPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCalendarPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
 import { DesktopShell } from "../../desktop/DesktopShell";
-import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useViewport } from "../../hooks/useViewport";
 import { fetchCalendar, fetchWeeklySummary } from "../../api/calendar";
 import type { CalendarDaySummary, CalendarResponse, WeeklySummaryResponse } from "../../types/calendar";
@@ -254,7 +253,6 @@ export function DesktopCalendarPage() {
             </Card>
           </>
         }
-        right={<RightRemotePanel />}
       />
       {showSummary && (
         <EventDetailModal

--- a/frontend/invest/src/pages/desktop/DesktopCoveragePage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCoveragePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { fetchKrActionReadiness } from "../../api/actionReadiness";
 import { fetchInvestCoverage } from "../../api/coverage";
+import { PageSafetyNote } from "../../components/PageSafetyNote";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { Card } from "../../ds";
 import type {
@@ -399,6 +400,17 @@ export function CoverageRoute() {
     <DesktopShell
       center={
         <div style={{ padding: 24, display: "grid", gap: 16 }}>
+        <PageSafetyNote
+          routeId="coverage"
+          heading="ROB-201 원칙"
+          tag="커버리지"
+          items={[
+            "source-of-truth는 로컬 DB/read-model만",
+            "Toss/Naver는 기준·후보 신호로만 표기",
+            "매매 추천·주문·백필·요청 중 스크래핑 없음",
+            "Actionability는 승인 게이트를 표시하는 advisory metadata이며 실행 버튼이 아님",
+          ]}
+        />
         <div>
           <h1 style={{ margin: 0, fontSize: 26, letterSpacing: "-0.04em" }}>데이터 커버리지</h1>
           <p style={{ margin: "6px 0 0", color: "var(--fg-2)", fontSize: 14 }}>
@@ -482,17 +494,6 @@ export function CoverageRoute() {
           </>
         )}
         </div>
-      }
-      right={
-        <Card>
-          <div style={{ fontWeight: 800, marginBottom: 8 }}>ROB-201 원칙</div>
-          <ul style={{ margin: 0, paddingLeft: 18, color: "var(--fg-2)", fontSize: 13 }}>
-            <li>source-of-truth는 로컬 DB/read-model만</li>
-            <li>Toss/Naver는 기준·후보 신호로만 표기</li>
-            <li>매매 추천·주문·백필·요청 중 스크래핑 없음</li>
-            <li>Actionability는 승인 게이트를 표시하는 advisory metadata이며 실행 버튼이 아님</li>
-          </ul>
-        </Card>
       }
     />
   );

--- a/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopCryptoPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { DesktopShell } from "../../desktop/DesktopShell";
-import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { fetchCryptoDashboard, fetchCryptoNaverReference } from "../../api/investCrypto";
 import type {
   CryptoCandidateInsight,
@@ -351,7 +350,6 @@ export function DesktopCryptoPage() {
           )}
         </main>
       }
-      right={<RightRemotePanel />}
     />
   );
 }

--- a/frontend/invest/src/pages/desktop/DesktopDiscoverPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopDiscoverPage.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { DesktopShell } from "../../desktop/DesktopShell";
-import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useViewport } from "../../hooks/useViewport";
 import { useNewsIssues } from "../../hooks/useNewsIssues";
 import { sortMarketIssues } from "../../components/discover/severity";
@@ -87,7 +86,6 @@ export function DesktopDiscoverPage() {
           </div>
         </>
       }
-      right={<RightRemotePanel />}
     />
   );
 }

--- a/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopFeedNewsPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { DesktopShell } from "../../desktop/DesktopShell";
-import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useViewport } from "../../hooks/useViewport";
 import { fetchFeedNews } from "../../api/feedNews";
 import { fetchFeedResearch } from "../../api/feedResearch";
@@ -129,7 +128,6 @@ export function DesktopFeedNewsPage() {
           </div>
         </>
       }
-      right={<RightRemotePanel />}
     />
   );
 }

--- a/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopHomePage.tsx
@@ -15,7 +15,6 @@ import { Link } from "react-router-dom";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { LeftContextRail } from "../../desktop/LeftContextRail";
 import type { AccountFilterKey } from "../../desktop/LeftContextRail";
-import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useInvestHome } from "../../hooks/useInvestHome";
 import { useMarketDashboard } from "../../hooks/useMarketDashboard";
 import { useMarketParity } from "../../hooks/useMarketParity";
@@ -280,7 +279,6 @@ export function DesktopHomePage() {
           )}
         </>
       }
-      right={<RightRemotePanel />}
     />
   );
 }

--- a/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopInsightsPage.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { CommonPreferredDisparityCardView } from "../../components/CommonPreferredDisparityCard";
 import { MarketParityStrip } from "../../components/home/MarketParityStrip";
+import { PageSafetyNote } from "../../components/PageSafetyNote";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { Card } from "../../ds";
 import { useCommonPreferredDisparity } from "../../hooks/useCommonPreferredDisparity";
@@ -41,16 +42,31 @@ function DecisionCard() {
   );
 }
 
-function ReadOnlyGuardrailCard() {
+function ReadOnlyGuardrailNote() {
+  return (
+    <PageSafetyNote
+      routeId="insights"
+      heading="읽기 전용 가드레일"
+      tag="인사이트"
+      items={[
+        "주문·매매·watch mutation API를 호출하지 않습니다.",
+        "기존 read-only /invest/api 응답만 표시합니다.",
+        "데이터 수집 활성화·백필·production DB write는 별도 승인 후 진행합니다.",
+        "raoni.xyz API에 production 의존성을 추가하지 않습니다.",
+      ]}
+    />
+  );
+}
+
+function RelatedScreensCard() {
   return (
     <Card>
-      <div style={{ fontWeight: 900, marginBottom: 8 }}>읽기 전용 가드레일</div>
-      <ul style={{ margin: 0, paddingLeft: 18, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.7 }}>
-        <li>주문·매매·watch mutation API를 호출하지 않습니다.</li>
-        <li>기존 read-only /invest/api 응답만 표시합니다.</li>
-        <li>데이터 수집 활성화·백필·production DB write는 별도 승인 후 진행합니다.</li>
-        <li>raoni.xyz API에 production 의존성을 추가하지 않습니다.</li>
-      </ul>
+      <div style={{ fontWeight: 900, marginBottom: 8 }}>관련 화면</div>
+      <div style={{ display: "grid", gap: 8, fontSize: 13 }}>
+        <Link to="/" style={{ color: "var(--fg-1)", textDecoration: "none" }}>홈 compact 요약</Link>
+        <Link to="/market" style={{ color: "var(--fg-1)", textDecoration: "none" }}>시장 대시보드</Link>
+        <Link to="/stocks/kr/005930" style={{ color: "var(--fg-1)", textDecoration: "none" }}>종목 상세 리서치 예시</Link>
+      </div>
     </Card>
   );
 }
@@ -63,6 +79,7 @@ export function DesktopInsightsPage() {
     <DesktopShell
       center={
         <div style={{ padding: 24, display: "grid", gap: 16 }}>
+          <ReadOnlyGuardrailNote />
           <DecisionCard />
 
           <Card>
@@ -72,19 +89,8 @@ export function DesktopInsightsPage() {
           {disparity.status === "loading" && <SectionStatus>보통주/우선주 괴리 데이터를 불러오는 중…</SectionStatus>}
           {disparity.status === "error" && <SectionStatus>보통주/우선주 괴리 데이터를 일시적으로 불러오지 못했습니다.</SectionStatus>}
           {disparity.status === "ready" && <CommonPreferredDisparityCardView data={disparity.data} />}
-        </div>
-      }
-      right={
-        <div style={{ display: "grid", gap: 12 }}>
-          <ReadOnlyGuardrailCard />
-          <Card>
-            <div style={{ fontWeight: 900, marginBottom: 8 }}>관련 화면</div>
-            <div style={{ display: "grid", gap: 8, fontSize: 13 }}>
-              <Link to="/" style={{ color: "var(--fg-1)", textDecoration: "none" }}>홈 compact 요약</Link>
-              <Link to="/market" style={{ color: "var(--fg-1)", textDecoration: "none" }}>시장 대시보드</Link>
-              <Link to="/stocks/kr/005930" style={{ color: "var(--fg-1)", textDecoration: "none" }}>종목 상세 리서치 예시</Link>
-            </div>
-          </Card>
+
+          <RelatedScreensCard />
         </div>
       }
     />

--- a/frontend/invest/src/pages/desktop/DesktopMarketPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopMarketPage.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { CommonPreferredDisparityCardView } from "../../components/CommonPreferredDisparityCard";
+import { PageSafetyNote } from "../../components/PageSafetyNote";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { Card } from "../../ds";
 import { useCommonPreferredDisparity } from "../../hooks/useCommonPreferredDisparity";
@@ -129,6 +130,18 @@ export function DesktopMarketPage() {
     <DesktopShell
       center={
         <div style={{ padding: 24, display: "grid", gap: 16 }}>
+          <PageSafetyNote
+            routeId="market"
+            heading="읽기 전용 원칙"
+            tag="시장 페이지"
+            items={[
+              "주문·매매 API를 호출하지 않습니다.",
+              "시장/지수 provider 응답을 표시만 합니다.",
+              <>
+                <Link to="/coverage" style={{ color: "inherit" }}>커버리지</Link>에서 freshness를 별도 확인합니다.
+              </>,
+            ]}
+          />
           <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "start", flexWrap: "wrap" }}>
             <div>
               <h1 style={{ margin: 0, fontSize: 28, letterSpacing: "-0.05em" }}>시장</h1>
@@ -183,16 +196,6 @@ export function DesktopMarketPage() {
             </>
           )}
         </div>
-      }
-      right={
-        <Card>
-          <div style={{ fontWeight: 900, marginBottom: 8 }}>읽기 전용 원칙</div>
-          <ul style={{ margin: 0, paddingLeft: 18, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.7 }}>
-            <li>주문·매매 API를 호출하지 않습니다.</li>
-            <li>시장/지수 provider 응답을 표시만 합니다.</li>
-            <li><Link to="/coverage" style={{ color: "inherit" }}>커버리지</Link>에서 freshness를 별도 확인합니다.</li>
-          </ul>
-        </Card>
       }
     />
   );

--- a/frontend/invest/src/pages/desktop/DesktopPortfolioPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopPortfolioPage.tsx
@@ -5,7 +5,6 @@ import { useMemo, useState } from "react";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { LeftContextRail } from "../../desktop/LeftContextRail";
 import type { AccountFilterKey } from "../../desktop/LeftContextRail";
-import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { useInvestHome } from "../../hooks/useInvestHome";
 import { useViewport } from "../../hooks/useViewport";
 import { scopeGroupedToSource } from "../../desktop/scopeHoldings";
@@ -156,7 +155,6 @@ export function DesktopPortfolioPage() {
           )}
         </>
       }
-      right={<RightRemotePanel />}
     />
   );
 }

--- a/frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopScreenerPage.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from "react";
 import { DesktopShell } from "../../desktop/DesktopShell";
-import { RightRemotePanel } from "../../desktop/RightRemotePanel";
 import { ScreenerPresetSidebar } from "../../desktop/screener/ScreenerPresetSidebar";
 import { ScreenerFilterBar } from "../../desktop/screener/ScreenerFilterBar";
 import { ScreenerResultsTable } from "../../desktop/screener/ScreenerResultsTable";
@@ -139,7 +138,6 @@ export function DesktopScreenerPage() {
           />
         </div>
       }
-      right={<RightRemotePanel />}
     />
   );
 }

--- a/frontend/invest/src/pages/desktop/FxMacroPage.tsx
+++ b/frontend/invest/src/pages/desktop/FxMacroPage.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { DesktopShell } from "../../desktop/DesktopShell";
+import { PageSafetyNote } from "../../components/PageSafetyNote";
 import { Card } from "../../ds";
 import { FxCollectionCard, FxDefenseSignalCard, FxDeferredSectionsCard, FxQuoteCard, FxSourceFreshnessList, FxStatePill, FxThresholdCard } from "../../components/fx/FxDashboardCards";
 import { useFxDashboard } from "../../hooks/useFxDashboard";
@@ -46,16 +47,20 @@ function StatusCard({ data }: { data: FxDashboardResponse }) {
   );
 }
 
-function SafetyCard() {
+function SafetyNote() {
   return (
-    <Card>
-      <div style={{ fontWeight: 900, marginBottom: 8 }}>읽기 전용 원칙</div>
-      <ul style={{ margin: 0, paddingLeft: 18, color: "var(--fg-2)", fontSize: 13, lineHeight: 1.7 }}>
-        <li>주문·매매 API, watch/order intent, scheduler activation을 호출하지 않습니다.</li>
-        <li>당국 개입은 확정 표현하지 않고 사후 검증 필요 여부만 표시합니다.</li>
-        <li><Link to="/market" style={{ color: "inherit" }}>시장 대시보드</Link>와 동일한 읽기 전용 분석 영역입니다.</li>
-      </ul>
-    </Card>
+    <PageSafetyNote
+      routeId="market-fx"
+      heading="읽기 전용 원칙"
+      tag="FX·매크로"
+      items={[
+        "주문·매매 API, watch/order intent, scheduler activation을 호출하지 않습니다.",
+        "당국 개입은 확정 표현하지 않고 사후 검증 필요 여부만 표시합니다.",
+        <>
+          <Link to="/market" style={{ color: "inherit" }}>시장 대시보드</Link>와 동일한 읽기 전용 분석 영역입니다.
+        </>,
+      ]}
+    />
   );
 }
 
@@ -89,13 +94,14 @@ function FxMain({ mobile = false }: { mobile?: boolean }) {
 
   return (
     <div style={{ padding: mobile ? 16 : 24, display: "grid", gap: 16, maxWidth: mobile ? 860 : undefined, margin: mobile ? "0 auto" : undefined }}>
+      {!mobile && <SafetyNote />}
       <Header data={data} onReload={reload} />
       {state.status === "loading" && <Card>FX·매크로 데이터를 불러오는 중…</Card>}
       {state.status === "error" && (
         <Card><span style={{ color: "var(--danger)" }}>FX·매크로 데이터를 일시적으로 불러오지 못했습니다.</span></Card>
       )}
       {data && <FxContent data={data} />}
-      {mobile && <SafetyCard />}
+      {mobile && <SafetyNote />}
     </div>
   );
 }
@@ -113,7 +119,6 @@ export function FxMacroRoute() {
   return (
     <DesktopShell
       center={<FxMain />}
-      right={<SafetyCard />}
     />
   );
 }

--- a/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
+++ b/frontend/invest/src/pages/stock-detail/StockDetailPage.tsx
@@ -420,16 +420,28 @@ export function StockDetailPage() {
     };
   }, [market, symbol]);
 
-  const right = useMemo(() => (
-    <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-      {data ? <ProfileCard data={data} /> : null}
-      {data && market !== "crypto" ? <ResearchConsensusCard data={researchConsensus} error={researchErr} /> : null}
-      {data && market === "crypto" ? <CryptoDetailCard data={data} /> : null}
-      {data ? <AnalysisCard data={data} /> : null}
-      {data ? <NaverPocCard data={data} /> : null}
-      <MemoCard />
-    </div>
-  ), [data, market, researchConsensus, researchErr]);
+  const sideDetails = useMemo(() => {
+    if (!data) {
+      return <MemoCard />;
+    }
+    return (
+      <div
+        data-testid="stock-detail-side"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+          gap: 14,
+        }}
+      >
+        <ProfileCard data={data} />
+        {market !== "crypto" ? <ResearchConsensusCard data={researchConsensus} error={researchErr} /> : null}
+        {market === "crypto" ? <CryptoDetailCard data={data} /> : null}
+        <AnalysisCard data={data} />
+        <NaverPocCard data={data} />
+        <MemoCard />
+      </div>
+    );
+  }, [data, market, researchConsensus, researchErr]);
 
   return (
     <DesktopShell
@@ -458,11 +470,11 @@ export function StockDetailPage() {
                 </Card>
               ) : null}
               <Hairline />
+              {sideDetails}
             </>
           ) : null}
         </div>
       }
-      right={right}
     />
   );
 }

--- a/frontend/invest/src/test/mockRightRail.ts
+++ b/frontend/invest/src/test/mockRightRail.ts
@@ -1,0 +1,30 @@
+import { vi } from "vitest";
+import * as panelApi from "../api/accountPanel";
+import * as signalsApi from "../api/signals";
+import type { AccountPanelResponse } from "../types/invest";
+
+const EMPTY_PANEL: AccountPanelResponse = {
+  homeSummary: {
+    includedSources: [],
+    excludedSources: [],
+    totalValueKrw: 0,
+    costBasisKrw: null,
+    pnlKrw: null,
+    pnlRate: null,
+  },
+  accounts: [],
+  groupedHoldings: [],
+  watchSymbols: [],
+  sourceVisuals: [],
+  meta: { warnings: [], watchlistAvailable: true },
+};
+
+export function mockRightRail(panel: AccountPanelResponse = EMPTY_PANEL): void {
+  vi.spyOn(panelApi, "fetchAccountPanel").mockResolvedValue(panel);
+  vi.spyOn(signalsApi, "fetchSignals").mockResolvedValue({
+    tab: "kr",
+    asOf: new Date().toISOString(),
+    items: [],
+    meta: { warnings: [] },
+  });
+}


### PR DESCRIPTION
## Summary

Implements the **right-rail contract** from the `auto-trader-invest-design-system` handoff bundle. The desktop shell now always mounts a single `<RightRemotePanel />` — no page passes a `right` prop anymore — and the rail collapses between 320px and 56px via `⌘.` / `Ctrl+.` with state persisted in `localStorage`. Page-specific advisories that previously lived in the right rail relocate to a new dismissible `<PageSafetyNote>` slot at the top of the center column.

The dark-theme thread from the same design package was already shipped in #847, so this PR focuses only on the right-rail + relocation work that was outstanding.

### What changed

**New**
- `components/PageSafetyNote.tsx` — accent-soft advisory card with per-route dismiss persistence (`invest:safety-note-dismissed:<routeId>`)
- `desktop/useRightRailCollapsed.ts` — `invest:right-rail-collapsed` persistence + `⌘.` / `Ctrl+.` shortcut
- `test/mockRightRail.ts` — shared test helper that stubs `fetchAccountPanel` + `fetchSignals`

**Modified**
- `DesktopShell` — drops `right` prop, mounts `<RightRemotePanel />` itself, transitions grid template between 320px ↔ 56px on `--dur-slow` / `--ease-emph`, exposes `data-rail-collapsed`
- `RightRemotePanel` — adds pane header with `접기 ⌘.` button, collapsed icon-rail mode (expand chevron + 4 tab icons + settings), active tab persisted to `invest:right-rail-tab`
- `ds/atoms.tsx` — adds `heart`, `clock`, `expandLeft` icons for the collapsed rail
- 12 desktop pages — drop `right={...}` and relocate page-specific content:
  - `/market` "읽기 전용 원칙" → `PageSafetyNote`
  - `/market/fx` `SafetyCard` → `PageSafetyNote`
  - `/insights` `ReadOnlyGuardrailCard` → `PageSafetyNote`, "관련 화면" card moves inline
  - `/coverage` "ROB-201 원칙" → `PageSafetyNote`
  - `/action-center` `ActionCenterRelatedLinks` moves inline beneath the center content
  - `/stocks/:market/:symbol` page-specific siblings (Profile / Research / Analysis / Memo) move into a responsive grid at the bottom of center
  - Remaining 6 pages (`Home`, `Portfolio`, `Discover`, `Screener`, `FeedNews`, `Crypto`, `Calendar`) simply stop passing `right={<RightRemotePanel />}`

### Decisions taken
Defaults from the design chat were applied without further prompts:
- Collapsed width **56px**, expanded **320px**
- Shortcut **`⌘.`** / **`Ctrl+.`**
- Persistence keys **`invest:right-rail-collapsed`** + **`invest:right-rail-tab`**
- Per-page advisory dismiss keys **`invest:safety-note-dismissed:<routeId>`**, all advisories dismissible

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 323 / 329 passing; the remaining 6 failures (`AccountCardList`, `DaySection`, `DesktopCalendarPage` ×2, `MonthlyEventsTimeline`) all reproduce on `main` and are unrelated to this change
- [x] New tests cover `DesktopShell` collapsed state + `⌘.` shortcut + collapse button, and `PageSafetyNote` dismiss persistence / per-route scope
- [ ] Manual smoke: open `/market`, `/market/fx`, `/coverage`, `/insights`, `/action-center`, `/stocks/us/QQQM` and verify the page advisory lands at the top of center and the rail stays as `<RightRemotePanel />`
- [ ] Manual smoke: toggle `⌘.` (Mac) / `Ctrl+.` (Win) on any desktop page, verify rail collapses to 56px icon strip and the choice persists on reload; dismiss a `PageSafetyNote` and confirm it stays dismissed per route after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible/expandable right panel with keyboard shortcut (Ctrl/Meta + .) for quick toggling.
  * Introduced dismissible safety notes on multiple pages that persist per page using local storage.
  * Right panel now remembers the last selected tab across sessions.
  * Added new icon options: heart, clock, and expandLeft.

* **Improvements**
  * Reorganized page layouts for better content presentation in center area.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->