### PR TITLE
ci: decommission Raspberry Pi Docker deploy path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
-name: Deploy to GHCR
+name: Build GHCR images (legacy Docker deploy disabled)
 
 on:
   workflow_dispatch:
   release:
-    types: [ published ]
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
@@ -16,7 +16,7 @@ jobs:
       contents: read
       packages: write
     strategy:
-      fail-fast: false  # 하나 실패해도 다른 것은 계속 진행
+      fail-fast: false
       matrix:
         include:
           - image: api
@@ -64,7 +64,7 @@ jobs:
 
       - name: Build and push ${{ matrix.image }} Docker image
         id: build
-        timeout-minutes: 30  # 30분 타임아웃 설정
+        timeout-minutes: 30
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -78,89 +78,35 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}
           platforms: linux/amd64,linux/arm64
-          provenance: false  # Provenance 비활성화로 빌드 속도 향상
+          provenance: false
 
-# Attestation 단계 제거 - OIDC 권한 이슈로 인해 주석 처리
-      # - name: Generate artifact attestation for ${{ matrix.image }}
-      #   if: success()
-      #   uses: actions/attest-build-provenance@v1
-      #   with:
-      #     subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}${{ matrix.suffix }}
-      #     subject-digest: ${{ steps.build.outputs.digest }}
-      #     push-to-registry: true
-      #   continue-on-error: true
+      - name: Legacy deploy disabled notice
+        run: |
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ## Legacy Docker deploy disabled
+
+          This workflow only builds/pushes GHCR images. ROB-263 retired the
+          Raspberry Pi Docker production deploy path that used the old Pi SSH
+          deployment secret and `scripts/deploy.sh`.
+
+          Production deployment is handled by:
+          - `.github/workflows/deploy-macos-native.yml`
+          - `scripts/deploy-native.sh`
+          EOF
 
       - name: Build Summary
         if: always()
         run: |
-          echo "## Build Summary for ${{ matrix.image }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Image**: ${{ matrix.image }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Dockerfile**: ${{ matrix.dockerfile }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Status**: ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.build.outcome }}" == "success" ]; then
-            echo "- **Image pushed**: ✅" >> $GITHUB_STEP_SUMMARY
-            echo "- **Tags**: ${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo "## Build Summary for ${{ matrix.image }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Image**: ${{ matrix.image }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Dockerfile**: ${{ matrix.dockerfile }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Status**: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.build.outcome }}" = "success" ]; then
+            echo "- **Image pushed**: ✅" >> "$GITHUB_STEP_SUMMARY"
+            echo "- **Tags**: ${{ steps.meta.outputs.tags }}" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- **Image pushed**: ❌" >> $GITHUB_STEP_SUMMARY
+            echo "- **Image pushed**: ❌" >> "$GITHUB_STEP_SUMMARY"
           fi
-
-  deploy:
-    needs: build-and-push
-    if: needs.build-and-push.result == 'success'
-    runs-on: ubuntu-latest
-    concurrency:
-      group: production-deploy
-      cancel-in-progress: false
-    steps:
-      - name: Setup Tailscale
-        uses: tailscale/github-action@v3
-        with:
-          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-
-      - name: Deploy via SSH
-        timeout-minutes: 20
-        shell: bash
-        run: |
-          set -eo pipefail
-          ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
-            ${{ secrets.DEPLOY_SSH_HOST }} \
-            "cd /home/mgh3326/auto_trader && ./scripts/deploy.sh" 2>&1 | tee /tmp/deploy-output.txt
-
-      - name: Discord notification (success)
-        if: success()
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
-        run: |
-          curl -s -H "Content-Type: application/json" \
-            -d "{
-              \"embeds\": [{
-                \"title\": \"✅ Auto Trader 배포 완료\",
-                \"description\": \"**Branch:** \`${{ github.ref_name }}\`\n**Commit:** [\`${GITHUB_SHA::7}\`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})\n**Author:** ${{ github.actor }}\n**Run:** [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\",
-                \"color\": 5763719,
-                \"footer\": {\"text\": \"auto_trader production\"},
-                \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
-              }]
-            }" \
-            "$DISCORD_WEBHOOK"
-
-      - name: Discord notification (failure)
-        if: failure()
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK_URL }}
-        run: |
-          DEPLOY_LOG=$(tail -15 /tmp/deploy-output.txt 2>/dev/null | head -c 1000 || echo "No log available")
-
-          curl -s -H "Content-Type: application/json" \
-            -d "{
-              \"embeds\": [{
-                \"title\": \"❌ Auto Trader 배포 실패\",
-                \"description\": \"**Branch:** \`${{ github.ref_name }}\`\n**Commit:** [\`${GITHUB_SHA::7}\`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})\n**Author:** ${{ github.actor }}\n**Run:** [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\n\n**Log:**\n\`\`\`\n${DEPLOY_LOG}\n\`\`\`\",
-                \"color\": 15548997,
-                \"footer\": {\"text\": \"auto_trader production\"},
-                \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
-              }]
-            }" \
-            "$DISCORD_WEBHOOK"
 
   notify:
     if: failure()
@@ -174,7 +120,7 @@ jobs:
           curl -s -H "Content-Type: application/json" \
             -d "{
               \"embeds\": [{
-                \"title\": \"❌ Deploy 실패\",
+                \"title\": \"❌ GHCR 이미지 빌드 실패\",
                 \"description\": \"**Branch:** \`${{ github.ref_name }}\`\n**Commit:** \`${GITHUB_SHA::7}\`\n**Author:** ${{ github.actor }}\n**Image:** GHCR push failed\",
                 \"url\": \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\",
                 \"color\": 16711680,

--- a/RASPBERRY_PI_DEPLOYMENT.md
+++ b/RASPBERRY_PI_DEPLOYMENT.md
@@ -1,113 +1,45 @@
-# Raspberry Pi 배포 가이드
+# Raspberry Pi Docker 배포 가이드 (Retired)
 
-라즈베리파이(권장: Pi 5, 8GB)에서 Auto Trader를 `docker-compose.prod.yml`로 배포하는 절차입니다.
+> **상태:** 폐기됨 / 사용 금지  
+> **이유:** ROB-263에서 Raspberry Pi Docker production deploy 경로를 제거했습니다.  
+> **현재 production 경로:** MacBook native launchd 배포만 사용합니다.
 
-## 빠른 시작
+## 현재 운영 원칙
 
-```bash
-git clone <repo> ~/auto_trader
-cd ~/auto_trader
-cp env.prod.example .env.prod
-nano .env.prod
+- Auto Trader production은 MacBook native 서비스(`launchd`)가 단일 owner입니다.
+- 특히 KIS websocket은 **MacBook native single-owner**로만 운영해야 합니다.
+- Raspberry Pi에서 `docker-compose.prod.yml` 또는 `docker-compose.n8n.yml`로 production stack을 다시 올리면 KIS websocket appkey/session 점유 충돌(`OPSP8996 ALREADY IN USE appkey`)을 재발시킬 수 있습니다.
 
-# 마이그레이션
-docker compose --env-file .env.prod -f docker-compose.prod.yml --profile migration up migration
-
-# 서비스 실행
-docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
-
-# HTTPS reverse proxy가 필요하면
-docker compose -f docker-compose.monitoring-rpi.yml up -d caddy
-```
-
-## 1. 시스템 준비
+## 사용해야 하는 배포 경로
 
 ```bash
-sudo apt update && sudo apt upgrade -y
-curl -fsSL https://get.docker.com -o get-docker.sh
-sudo sh get-docker.sh
-sudo usermod -aG docker $USER
-newgrp docker
-sudo apt install -y docker-compose-plugin
+# GitHub Actions
+.github/workflows/deploy-macos-native.yml
+
+# 원격 MacBook native 배포 스크립트
+scripts/deploy-native.sh
 ```
 
-## 2. .env.prod 필수 값
+수동 배포가 필요하면 `Deploy MacBook Native Production` workflow를 사용하거나, 운영 runbook에 따라 `scripts/deploy-native.sh`를 통해 MacBook native 서비스를 갱신하세요.
 
-- `DATABASE_URL` (네이티브 PostgreSQL)
-- `REDIS_URL` (네이티브 Redis)
-- `API_PORT`
-- `GITHUB_REPOSITORY`
-- API 키들
-- `DOCS_ENABLED=false`
+## 과거 Raspberry Pi stack 정리 명령
 
-Sentry:
+아래 명령은 **새 배포용이 아니라 기존 Raspberry Pi host 정리용**입니다.
 
 ```bash
-SENTRY_DSN=https://<key>@o0.ingest.sentry.io/0
-SENTRY_ENVIRONMENT=production
-SENTRY_TRACES_SAMPLE_RATE=1.0
-SENTRY_PROFILES_SAMPLE_RATE=1.0
-SENTRY_SEND_DEFAULT_PII=true
-SENTRY_ENABLE_LOG_EVENTS=true
+cd /home/mgh3326/auto_trader
+
+docker compose --env-file .env.prod -f docker-compose.prod.yml down --remove-orphans
+docker compose --env-file .env.prod -f docker-compose.n8n.yml down --remove-orphans
 ```
 
-릴리즈는 이미지 빌드 SHA 또는 현재 git HEAD에서 자동 해상도됩니다.
-
-선택 (Caddy):
+정리 후에는 다음을 확인하세요.
 
 ```bash
-ACME_EMAIL=your_email@example.com
-DOMAIN_NAME=your_domain.com
+docker ps -a | grep '^auto_trader_' || true
+ps aux | grep -E 'websocket_monitor|kis_websocket|upbit_websocket' | grep -v grep || true
 ```
 
-## 3. 실행 및 확인
+## 참고
 
-```bash
-docker compose --env-file .env.prod -f docker-compose.prod.yml pull
-docker compose --env-file .env.prod -f docker-compose.prod.yml up -d
-
-docker compose --env-file .env.prod -f docker-compose.prod.yml ps
-curl http://localhost:8000/healthz
-curl http://127.0.0.1:5678/healthz   # n8n
-```
-
-로그 확인:
-
-```bash
-docker compose --env-file .env.prod -f docker-compose.prod.yml logs -f api
-docker compose --env-file .env.prod -f docker-compose.prod.yml logs -f worker
-docker compose --env-file .env.prod -f docker-compose.prod.yml logs -f mcp
-docker compose --env-file .env.prod -f docker-compose.prod.yml logs -f upbit_websocket
-docker compose --env-file .env.prod -f docker-compose.prod.yml logs -f kis_websocket
-docker compose -f docker-compose.n8n.yml logs -f  # n8n
-
-# Caddy 로그
-docker compose -f docker-compose.monitoring-rpi.yml logs -f caddy
-```
-
-## 4. Sentry 확인
-
-- 단일 프로젝트에서 `service` 태그 조회
-- api/worker/mcp/ws 5개 서비스 이벤트 분리 확인
-- Errors + Transactions + Profiles 유입 확인
-
-## 5. 운영 명령어
-
-```bash
-# 재시작
-docker compose --env-file .env.prod -f docker-compose.prod.yml restart
-
-# 중지
-docker compose --env-file .env.prod -f docker-compose.prod.yml stop
-
-# 중지 및 제거
-docker compose --env-file .env.prod -f docker-compose.prod.yml down
-```
-
-## 6. 성능 점검
-
-```bash
-docker stats
-free -h
-df -h
-```
+이 문서는 과거 운영 흔적을 남기기 위한 retired 문서입니다. 신규 Raspberry Pi Docker production 설정 절차를 추가하지 마세요.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -6,10 +6,11 @@
 ## WHERE TO LOOK
 | Task | Location | Notes |
 |------|----------|-------|
-| Production deployment orchestration | `scripts/deploy.sh` | Migration mode selection, deploy flow, optional health/backup |
+| Production deployment orchestration | `scripts/deploy-native.sh`, `ops/native/` | MacBook native launchd production path |
+| Retired Docker deployment guard | `scripts/deploy.sh`, `scripts/healthcheck.sh` | Fail closed after ROB-263; cleanup guidance only |
 | Migration risk precheck | `scripts/migration-check.sh` | DB connectivity and high-risk migration pattern checks |
 | Migration execution | `scripts/migrate.sh` | Host-side Alembic execution with pre/post verification |
-| Runtime health checks | `scripts/healthcheck.sh` | Container/service/resource/log checks |
+| Native runtime checks | `ops/native/`, launchd services | Production MacBook native service inspection |
 | HTTPS/Caddy checks | `scripts/test-caddy-https.sh` | TLS redirect/header/certificate checks |
 | Test env bootstrap | `scripts/setup-test-env.sh` | `.env.test` generation for CI/local tests |
 | MCP startup wrapper | `scripts/mcp_server.sh` | MCP process boot wrapper with `.env.mcp` |

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,220 +1,30 @@
 #!/bin/bash
+# Deprecated legacy Docker deployment entrypoint.
+#
+# ROB-263 retired the Raspberry Pi / Docker Compose production deploy path.
+# Production deploys now use the MacBook native launchd workflow:
+#   .github/workflows/deploy-macos-native.yml
+#   scripts/deploy-native.sh
+#
+# This script intentionally fails closed so old GitHub Actions, cron jobs,
+# or manual muscle-memory commands cannot resurrect the Raspberry Pi Docker
+# stack and accidentally create a second KIS websocket owner.
 
-# Auto Trader Production Deployment Script
-# 개선: down 없이 up -d로 순단 최소화, health check 기본 활성화,
-#       마이그레이션은 컨테이너 내에서 실행 (DATABASE_URL 호스트 불필요)
+set -euo pipefail
 
-set -e
+cat >&2 <<'EOF'
+❌ scripts/deploy.sh is retired.
 
-# 색상 정의
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+The legacy Raspberry Pi Docker production deploy path was decommissioned in ROB-263.
+Do not use docker-compose.prod.yml to run production API/worker/MCP/websocket services.
 
-# 설정
-COMPOSE_FILE="docker-compose.prod.yml"
-ENV_FILE=".env.prod"
-HEALTH_URL="http://localhost:8000/healthz"
-MCP_URL="http://localhost:${MCP_PORT:-8765}/mcp"
-HEALTH_RETRIES=15
-HEALTH_INTERVAL=3
+Use the MacBook native deployment path instead:
+  - GitHub Actions: .github/workflows/deploy-macos-native.yml
+  - Script: scripts/deploy-native.sh
 
-# 도움말
-show_help() {
-    echo "Auto Trader Deployment Script"
-    echo ""
-    echo "Usage: $0 [OPTIONS]"
-    echo ""
-    echo "Options:"
-    echo "  --auto-migrate     Run migrations automatically in Docker container"
-    echo "  --skip-migrate     Skip migrations entirely"
-    echo "  --backup           Create database backup before deployment"
-    echo "  --rollback         Rollback to previous version"
-    echo "  --no-health-check  Skip health check after deployment"
-    echo "  --help             Show this help message"
-    echo ""
-    echo "Default behavior (no options):"
-    echo "  - Pull latest images"
-    echo "  - Skip migrations (use --auto-migrate to run)"
-    echo "  - Deploy with zero-downtime (no docker compose down)"
-    echo "  - Run health check"
-    echo ""
-    echo "Examples:"
-    echo "  $0                              # Quick deploy (no migration)"
-    echo "  $0 --auto-migrate --backup      # Safe deployment with migration + backup"
-    echo "  $0 --auto-migrate               # Deploy with auto migration"
-    echo "  $0 --skip-migrate               # Explicit skip migrations"
-}
+If you are cleaning up an old Raspberry Pi host, stop the legacy stack manually:
+  docker compose --env-file .env.prod -f docker-compose.prod.yml down --remove-orphans
+  docker compose --env-file .env.prod -f docker-compose.n8n.yml down --remove-orphans
+EOF
 
-# 변수 초기화
-AUTO_MIGRATE=false
-SKIP_MIGRATE=true  # 기본값: 마이그레이션 스킵 (안전)
-CREATE_BACKUP=false
-ROLLBACK=false
-HEALTH_CHECK=true  # 기본값: 항상 헬스체크
-
-# 인수 파싱
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        --auto-migrate)
-            AUTO_MIGRATE=true
-            SKIP_MIGRATE=false
-            shift
-            ;;
-        --skip-migrate)
-            SKIP_MIGRATE=true
-            shift
-            ;;
-        --backup)
-            CREATE_BACKUP=true
-            shift
-            ;;
-        --rollback)
-            ROLLBACK=true
-            shift
-            ;;
-        --no-health-check)
-            HEALTH_CHECK=false
-            shift
-            ;;
-        --help)
-            show_help
-            exit 0
-            ;;
-        *)
-            echo "Unknown option: $1"
-            show_help
-            exit 1
-            ;;
-    esac
-done
-
-# 배포 시작 시간
-DEPLOY_START=$(date +%s)
-
-echo -e "${BLUE}🚀 Auto Trader Production Deployment${NC}"
-echo "====================================="
-echo ""
-
-# 환경 확인
-echo -e "${YELLOW}🔍 Environment Check${NC}"
-if [ ! -f "$ENV_FILE" ]; then
-    echo -e "${RED}❌ $ENV_FILE not found! Copy from env.prod.example and configure.${NC}"
-    exit 1
-fi
-
-if [ ! -f "$COMPOSE_FILE" ]; then
-    echo -e "${RED}❌ $COMPOSE_FILE not found!${NC}"
-    exit 1
-fi
-
-source "$ENV_FILE"
-if [ -z "$GITHUB_REPOSITORY" ]; then
-    echo -e "${RED}❌ GITHUB_REPOSITORY not set in $ENV_FILE${NC}"
-    exit 1
-fi
-
-echo -e "${GREEN}✅ Environment check passed${NC}"
-
-# 롤백 처리 (다른 단계 건너뜀)
-if [ "$ROLLBACK" = true ]; then
-    echo -e "${YELLOW}🔄 Rolling back services...${NC}"
-    docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" down
-
-    echo "Rollback requires manual image tag specification."
-    echo "Example: docker tag ghcr.io/$GITHUB_REPOSITORY:previous ghcr.io/$GITHUB_REPOSITORY:latest"
-    exit 0
-fi
-
-# 백업 생성
-if [ "$CREATE_BACKUP" = true ]; then
-    echo -e "${YELLOW}💾 Creating database backup...${NC}"
-    backup_file="/var/backups/postgresql/auto_trader_$(date +%Y%m%d_%H%M%S).sql"
-    sudo mkdir -p /var/backups/postgresql
-
-    if command -v pg_dump >/dev/null 2>&1; then
-        sudo -u postgres pg_dump auto_trader_prod > "$backup_file"
-        echo -e "${GREEN}✅ Backup created: $backup_file${NC}"
-    else
-        echo -e "${YELLOW}⚠️  pg_dump not found, skipping backup${NC}"
-    fi
-fi
-
-# 1. 최신 이미지 Pull (기존 서비스 유지 — 순단 없음)
-echo -e "${YELLOW}📦 Pulling latest Docker images...${NC}"
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" pull
-echo -e "${GREEN}✅ Images pulled${NC}"
-
-# 2. 마이그레이션 (컨테이너 안에서 실행)
-if [ "$SKIP_MIGRATE" = true ]; then
-    echo -e "${YELLOW}⏭️  Skipping migrations${NC}"
-elif [ "$AUTO_MIGRATE" = true ]; then
-    echo -e "${YELLOW}🔄 Running migrations (in Docker container)...${NC}"
-    docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" --profile migration run --rm migration
-    echo -e "${GREEN}✅ Migrations completed${NC}"
-fi
-
-# 3. 서비스 배포 (핵심: down 없이 up -d로 변경분만 재생성)
-echo -e "${YELLOW}🚀 Deploying services...${NC}"
-docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d --remove-orphans
-echo -e "${GREEN}✅ Services updated${NC}"
-
-# 4. 헬스체크
-if [ "$HEALTH_CHECK" = true ]; then
-    echo -e "${YELLOW}🏥 Running health check...${NC}"
-    for i in $(seq 1 $HEALTH_RETRIES); do
-        if curl -sf "$HEALTH_URL" > /dev/null 2>&1; then
-            echo -e "${GREEN}✅ API health check passed!${NC}"
-
-            # MCP 서버 헬스체크
-            MCP_OK=false
-            for j in $(seq 1 5); do
-                if curl -sf "$MCP_URL" > /dev/null 2>&1 || curl -s "$MCP_URL" 2>/dev/null | grep -q 'error\|method\|session'; then
-                    MCP_OK=true
-                    break
-                fi
-                echo -e "  ⏳ Waiting for MCP server... ($j/5)"
-                sleep 2
-            done
-
-            if [ "$MCP_OK" = true ]; then
-                echo -e "${GREEN}✅ MCP server health check passed!${NC}"
-            else
-                echo -e "${YELLOW}⚠️  MCP server not responding on $MCP_URL (non-fatal)${NC}"
-            fi
-
-            DEPLOY_END=$(date +%s)
-            DEPLOY_DURATION=$((DEPLOY_END - DEPLOY_START))
-            echo ""
-            echo -e "${GREEN}🎉 Deployment completed in ${DEPLOY_DURATION}s${NC}"
-            echo ""
-            echo "📋 Useful commands:"
-            echo "  docker compose --env-file $ENV_FILE -f $COMPOSE_FILE logs -f    # View logs"
-            echo "  docker compose --env-file $ENV_FILE -f $COMPOSE_FILE ps         # Check status"
-            echo ""
-
-            # 오래된 이미지 정리
-            docker image prune -f > /dev/null 2>&1 || true
-
-            exit 0
-        fi
-        echo -e "  ⏳ Waiting for service... ($i/$HEALTH_RETRIES)"
-        sleep $HEALTH_INTERVAL
-    done
-
-    echo -e "${RED}🔴 Health check failed after $((HEALTH_RETRIES * HEALTH_INTERVAL))s!${NC}"
-    echo ""
-    echo "📋 Debug commands:"
-    echo "  curl -f $HEALTH_URL"
-    echo "  docker compose --env-file $ENV_FILE -f $COMPOSE_FILE logs --tail=50 api"
-    echo "  docker compose --env-file $ENV_FILE -f $COMPOSE_FILE logs --tail=50"
-    echo "  docker compose --env-file $ENV_FILE -f $COMPOSE_FILE ps"
-    exit 1
-else
-    DEPLOY_END=$(date +%s)
-    DEPLOY_DURATION=$((DEPLOY_END - DEPLOY_START))
-    echo ""
-    echo -e "${GREEN}🎉 Deployment completed in ${DEPLOY_DURATION}s (health check skipped)${NC}"
-fi
+exit 1

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -1,136 +1,23 @@
 #!/bin/bash
+# Deprecated legacy Docker production health check.
+#
+# ROB-263 retired the Raspberry Pi / Docker Compose production runtime. This
+# script intentionally fails closed instead of checking legacy Docker container
+# names that should no longer exist in production.
 
-# Auto Trader Production Health Check Script
+set -euo pipefail
 
-echo "🏥 Auto Trader Health Check"
-echo "=========================="
+cat >&2 <<'EOF'
+❌ scripts/healthcheck.sh is retired for production.
 
-# 색상 정의
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m' # No Color
+The Raspberry Pi Docker production stack was decommissioned in ROB-263.
+Do not use legacy Docker container health checks for production API/worker/MCP/websocket services.
 
-# 체크 함수
-check_service() {
-    local service=$1
-    local command=$2
-    local description=$3
-    
-    echo -n "🔍 $description... "
-    
-    if eval $command >/dev/null 2>&1; then
-        echo -e "${GREEN}✅ OK${NC}"
-        return 0
-    else
-        echo -e "${RED}❌ FAILED${NC}"
-        return 1
-    fi
-}
+Use the MacBook native launchd/service runbook instead, or inspect the native host directly.
+Helpful entrypoints:
+  - .github/workflows/deploy-macos-native.yml
+  - scripts/deploy-native.sh
+  - ops/native/
+EOF
 
-# 시스템 리소스 체크
-echo -e "${BLUE}📊 System Resources${NC}"
-echo "Memory Usage: $(free -h | awk '/^Mem:/ {print $3 "/" $2}')"
-echo "Disk Usage: $(df -h / | awk 'NR==2 {print $3 "/" $2 " (" $5 ")"}')"
-echo "Load Average: $(uptime | awk '{print $NF}')"
-echo ""
-
-# PostgreSQL 체크
-echo -e "${BLUE}🐘 PostgreSQL${NC}"
-check_service "postgresql" "sudo systemctl is-active postgresql" "PostgreSQL Service"
-check_service "postgresql" "sudo -u postgres psql -c 'SELECT 1;'" "PostgreSQL Connection"
-
-# Redis 체크
-echo -e "${BLUE}🔴 Redis${NC}"
-check_service "redis" "sudo systemctl is-active redis" "Redis Service"
-check_service "redis" "redis-cli ping" "Redis Connection"
-
-# Docker 컨테이너 체크
-echo -e "${BLUE}🐳 Docker Containers${NC}"
-check_service "api" "docker ps --filter 'name=auto_trader_api_prod' --filter 'status=running' | grep -q auto_trader_api_prod" "API Container"
-check_service "upbit_websocket" "docker ps --filter 'name=auto_trader_upbit_ws_prod' --filter 'status=running' | grep -q auto_trader_upbit_ws_prod" "Upbit WebSocket Container"
-check_service "kis_websocket" "docker ps --filter 'name=auto_trader_kis_ws_prod' --filter 'status=running' | grep -q auto_trader_kis_ws_prod" "KIS WebSocket Container"
-check_service "n8n" "docker ps --filter 'name=auto_trader_n8n_prod' --filter 'status=running' | grep -q auto_trader_n8n_prod" "n8n Container"
-
-# API 엔드포인트 체크
-echo -e "${BLUE}🌐 API Endpoints${NC}"
-check_service "api-health" "curl -f -s http://localhost:8000/healthz >/dev/null" "API Health Endpoint"
-check_service "n8n-health" "wget -q --spider http://127.0.0.1:5678/healthz 2>/dev/null || curl -f -s http://127.0.0.1:5678/healthz >/dev/null" "n8n Health Endpoint"
-
-# 로그 체크 (최근 에러)
-echo -e "${BLUE}📋 Recent Logs${NC}"
-echo "🔍 Checking for recent errors..."
-
-# API 컨테이너 로그에서 에러 검색
-api_errors=$(docker logs auto_trader_api_prod --since=10m 2>&1 | grep -i "error\|exception\|fail" | wc -l)
-if [ $api_errors -gt 0 ]; then
-    echo -e "${YELLOW}⚠️  Found $api_errors error(s) in API logs (last 10 minutes)${NC}"
-else
-    echo -e "${GREEN}✅ No recent errors in API logs${NC}"
-fi
-
-# Upbit WebSocket 컨테이너 로그에서 에러 검색
-upbit_ws_errors=$(docker logs auto_trader_upbit_ws_prod --since=10m 2>&1 | grep -i "error\|exception\|fail" | wc -l)
-if [ $upbit_ws_errors -gt 0 ]; then
-    echo -e "${YELLOW}⚠️  Found $upbit_ws_errors error(s) in Upbit WebSocket logs (last 10 minutes)${NC}"
-else
-    echo -e "${GREEN}✅ No recent errors in Upbit WebSocket logs${NC}"
-fi
-
-# KIS WebSocket 컨테이너 로그에서 에러 검색
-kis_ws_errors=$(docker logs auto_trader_kis_ws_prod --since=10m 2>&1 | grep -i "error\|exception\|fail" | wc -l)
-if [ $kis_ws_errors -gt 0 ]; then
-    echo -e "${YELLOW}⚠️  Found $kis_ws_errors error(s) in KIS WebSocket logs (last 10 minutes)${NC}"
-else
-    echo -e "${GREEN}✅ No recent errors in KIS WebSocket logs${NC}"
-fi
-
-echo -e "${BLUE}🔌 WebSocket Services Status${NC}"
-upbit_health_line=$(docker logs auto_trader_upbit_ws_prod --since=10m 2>&1 | tail -n 1)
-kis_health_line=$(docker logs auto_trader_kis_ws_prod --since=10m 2>&1 | tail -n 1)
-
-if [ -n "$upbit_health_line" ]; then
-    echo -e "${GREEN}✅ Upbit status log found${NC}: $upbit_health_line"
-else
-    echo -e "${YELLOW}⚠️  No recent Upbit status log in upbit_websocket container${NC}"
-fi
-
-if [ -n "$kis_health_line" ]; then
-    echo -e "${GREEN}✅ KIS status log found${NC}: $kis_health_line"
-else
-    echo -e "${YELLOW}⚠️  No recent KIS status log in kis_websocket container${NC}"
-fi
-
-# 디스크 용량 체크
-echo -e "${BLUE}💾 Storage Check${NC}"
-disk_usage=$(df / | awk 'NR==2 {print $5}' | sed 's/%//')
-if [ $disk_usage -gt 90 ]; then
-    echo -e "${RED}❌ Disk usage is ${disk_usage}% (Critical)${NC}"
-elif [ $disk_usage -gt 80 ]; then
-    echo -e "${YELLOW}⚠️  Disk usage is ${disk_usage}% (Warning)${NC}"
-else
-    echo -e "${GREEN}✅ Disk usage is ${disk_usage}% (OK)${NC}"
-fi
-
-# 메모리 사용량 체크
-echo -e "${BLUE}🧠 Memory Check${NC}"
-memory_usage=$(free | awk 'NR==2{printf "%.0f", $3*100/$2}')
-if [ $memory_usage -gt 90 ]; then
-    echo -e "${RED}❌ Memory usage is ${memory_usage}% (Critical)${NC}"
-elif [ $memory_usage -gt 80 ]; then
-    echo -e "${YELLOW}⚠️  Memory usage is ${memory_usage}% (Warning)${NC}"
-else
-    echo -e "${GREEN}✅ Memory usage is ${memory_usage}% (OK)${NC}"
-fi
-
-echo ""
-echo -e "${BLUE}📈 Quick Stats${NC}"
-echo "🕐 Current Time: $(date)"
-echo "⏰ Uptime: $(uptime -p)"
-echo "🔄 Docker Images:"
-docker images --filter "reference=ghcr.io/*/*auto*" --format "table {{.Repository}}\t{{.Tag}}\t{{.Size}}\t{{.CreatedSince}}"
-
-echo ""
-echo -e "${GREEN}🎉 Health check completed!${NC}"
-echo "For detailed logs: docker compose -f docker-compose.prod.yml logs"
+exit 1

--- a/tests/test_n8n_prod_configuration.py
+++ b/tests/test_n8n_prod_configuration.py
@@ -3,6 +3,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 N8N_COMPOSE_PATH = REPO_ROOT / "docker-compose.n8n.yml"
 PROD_COMPOSE_PATH = REPO_ROOT / "docker-compose.prod.yml"
+DEPLOY_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "deploy.yml"
 DEPLOY_SCRIPT_PATH = REPO_ROOT / "scripts" / "deploy.sh"
 README_PATH = REPO_ROOT / "n8n" / "README.md"
 
@@ -29,13 +30,28 @@ def test_n8n_compose_uses_fixed_internal_port_for_healthcheck() -> None:
     assert "N8N_PORT" not in content
 
 
-def test_deploy_script_checks_api_only() -> None:
-    """deploy script는 API 헬스체크만 수행하며 n8n은 체크하지 않는다."""
+def test_deploy_script_is_retired_fail_closed() -> None:
+    """legacy Raspberry Pi Docker deploy script는 실수로 실행되어도 실패해야 한다."""
     content = DEPLOY_SCRIPT_PATH.read_text(encoding="utf-8")
 
-    assert "N8N_HEALTH_URL=" not in content
-    assert 'curl -sf "$HEALTH_URL" > /dev/null 2>&1' in content
-    assert 'curl -sf "$N8N_HEALTH_URL" > /dev/null 2>&1' not in content
+    assert "scripts/deploy.sh is retired" in content
+    assert "Raspberry Pi Docker production deploy path was decommissioned" in content
+    assert "scripts/deploy-native.sh" in content
+    assert "exit 1" in content
+    assert 'curl -sf "$HEALTH_URL" > /dev/null 2>&1' not in content
+    assert (
+        'docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" up -d' not in content
+    )
+
+
+def test_legacy_deploy_workflow_no_longer_ssh_deploys_to_pi() -> None:
+    """GHCR workflow는 이미지 빌드만 수행하고 Pi SSH deploy를 수행하지 않는다."""
+    content = DEPLOY_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "Build GHCR images" in content
+    assert "DEPLOY_SSH_HOST" not in content
+    assert "cd /home/mgh3326/auto_trader && ./scripts/deploy.sh" not in content
+    assert "scripts/deploy-native.sh" in content
 
 
 def test_n8n_readme_documents_fixed_internal_port() -> None:
@@ -52,9 +68,10 @@ def test_n8n_readme_references_separate_compose() -> None:
     assert "docker-compose.n8n.yml" in content
 
 
-def test_deploy_script_has_only_prod_debug_commands() -> None:
-    """deploy.sh는 prod stack 디버그 명령어만 포함한다."""
+def test_deploy_script_has_only_retirement_guidance() -> None:
+    """deploy.sh는 legacy prod stack을 시작하지 않고 native 배포 안내만 포함한다."""
     content = DEPLOY_SCRIPT_PATH.read_text(encoding="utf-8")
 
-    assert "docker-compose.n8n.yml" not in content
-    assert "logs --tail=50 api" in content
+    assert "docker-compose.n8n.yml" in content  # cleanup guidance only
+    assert "logs --tail=50 api" not in content
+    assert "deploy-native.sh" in content


### PR DESCRIPTION
## Summary
- Remove the old `deploy` job from `.github/workflows/deploy.yml` so it only builds/pushes GHCR images and no longer SSHes to the Raspberry Pi host.
- Replace `scripts/deploy.sh` and `scripts/healthcheck.sh` with fail-closed retirement guards that point operators to the MacBook native deployment path.
- Convert `RASPBERRY_PI_DEPLOYMENT.md` into a retired/cleanup-only note and update tests to guard against reintroducing the old Pi deploy path.

## Safety / Operations
- Production deployment remains `.github/workflows/deploy-macos-native.yml` + `scripts/deploy-native.sh`.
- This prevents accidental resurrection of the Raspberry Pi Docker stack and a second KIS websocket owner.
- No broker/order execution logic changed.

## Test Plan
- [x] `bash -n scripts/deploy.sh`
- [x] `bash -n scripts/healthcheck.sh`
- [x] YAML parse for `.github/workflows/deploy.yml` and `.github/workflows/deploy-macos-native.yml`
- [x] `uv run pytest tests/test_n8n_prod_configuration.py -q`
- [x] `uv run ruff check tests/test_n8n_prod_configuration.py`
- [x] `uv run ruff format --check tests/test_n8n_prod_configuration.py`
- [x] Guard script confirms no actionable old Pi deploy references remain in guarded files

Closes ROB-263


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated deployment guides to indicate legacy Raspberry Pi Docker deployment is discontinued
  * Deployment workflows now focus exclusively on container image building

* **Chores**
  * Removed SSH-based production deployment automation
  * Retired legacy deployment and health check scripts with deprecation notices

* **Tests**
  * Added verification that legacy deployment paths are properly deprecated

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->