### PR TITLE
feat(invest): full-bleed desktop shell + relocate action-center safety note

### DIFF
--- a/frontend/invest/src/components/action-center/ActionCenterContent.tsx
+++ b/frontend/invest/src/components/action-center/ActionCenterContent.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import { Link } from "react-router-dom";
 import { AnalystReportCard } from "./AnalystReportCard";
 import { CandidateCard } from "./CandidateCard";
 import { Card } from "../../ds";
@@ -169,15 +168,3 @@ export function ActionCenterContent({ compact = false }: { compact?: boolean }) 
   );
 }
 
-export function ActionCenterRelatedLinks() {
-  return (
-    <Card>
-      <div style={{ fontWeight: 900, marginBottom: 8 }}>관련 화면</div>
-      <div style={{ display: "grid", gap: 8, fontSize: 13 }}>
-        <Link to="/" style={{ color: "var(--fg-1)", textDecoration: "none" }}>홈</Link>
-        <Link to="/insights" style={{ color: "var(--fg-1)", textDecoration: "none" }}>인사이트</Link>
-        <Link to="/my?tab=signals" style={{ color: "var(--fg-1)", textDecoration: "none" }}>시그널</Link>
-      </div>
-    </Card>
-  );
-}

--- a/frontend/invest/src/desktop/DesktopShell.tsx
+++ b/frontend/invest/src/desktop/DesktopShell.tsx
@@ -5,6 +5,7 @@ import { useRightRailCollapsed } from "./useRightRailCollapsed";
 
 const RAIL_WIDTH_EXPANDED = "320px";
 const RAIL_WIDTH_COLLAPSED = "56px";
+const HEADER_HEIGHT = 56;
 
 export function DesktopShell({
   left,
@@ -33,24 +34,39 @@ export function DesktopShell({
           gridTemplateColumns: left
             ? `${resolvedLeftColumnWidth} minmax(0,1fr) ${railWidth}`
             : `minmax(0,1fr) ${railWidth}`,
-          gap: 24,
-          padding: "24px 28px 64px",
-          maxWidth: 1440,
-          margin: "0 auto",
-          transition: "grid-template-columns var(--dur-slow, 240ms) var(--ease-emph, cubic-bezier(0.2, 0.8, 0.2, 1.0))",
+          gap: 0,
+          transition:
+            "grid-template-columns var(--dur-slow, 240ms) var(--ease-emph, cubic-bezier(0.2, 0.8, 0.2, 1.0))",
         }}
       >
-        {left ? <aside style={{ minWidth: 0 }}>{left}</aside> : null}
-        <main style={{ minWidth: 0, display: "flex", flexDirection: "column", gap: 16 }}>{center}</main>
+        {left ? (
+          <aside style={{ minWidth: 0, padding: "16px 12px 64px 20px" }}>{left}</aside>
+        ) : null}
+        <main
+          style={{
+            minWidth: 0,
+            display: "flex",
+            flexDirection: "column",
+            gap: 16,
+            padding: "24px 28px 64px",
+            maxWidth: 1100,
+            width: "100%",
+            margin: "0 auto",
+          }}
+        >
+          {center}
+        </main>
         <aside
           data-testid="desktop-shell-rail"
           style={{
             position: "sticky",
-            top: 80,
+            top: HEADER_HEIGHT,
             alignSelf: "start",
-            maxHeight: "calc(100vh - 96px)",
+            height: `calc(100vh - ${HEADER_HEIGHT}px)`,
             overflowY: "auto",
             minWidth: 0,
+            borderLeft: "1px solid var(--divider)",
+            background: "var(--bg)",
           }}
         >
           <RightRemotePanel collapsed={collapsed} onCollapseChange={setCollapsed} />

--- a/frontend/invest/src/pages/desktop/DesktopActionCenterPage.tsx
+++ b/frontend/invest/src/pages/desktop/DesktopActionCenterPage.tsx
@@ -1,4 +1,6 @@
-import { ActionCenterContent, ActionCenterRelatedLinks } from "../../components/action-center/ActionCenterContent";
+import { Link } from "react-router-dom";
+import { ActionCenterContent } from "../../components/action-center/ActionCenterContent";
+import { PageSafetyNote } from "../../components/PageSafetyNote";
 import { DesktopShell } from "../../desktop/DesktopShell";
 import { useViewport } from "../../hooks/useViewport";
 import { MobileActionCenterPage } from "../mobile/MobileActionCenterPage";
@@ -8,8 +10,17 @@ export function DesktopActionCenterPage() {
     <DesktopShell
       center={
         <div style={{ display: "grid", gap: 12 }}>
+          <PageSafetyNote
+            routeId="action-center"
+            heading="관련 화면"
+            tag="액션센터"
+            items={[
+              <Link key="home" to="/" style={{ color: "inherit" }}>홈</Link>,
+              <Link key="insights" to="/insights" style={{ color: "inherit" }}>인사이트</Link>,
+              <Link key="signals" to="/my?tab=signals" style={{ color: "inherit" }}>시그널</Link>,
+            ]}
+          />
           <ActionCenterContent />
-          <ActionCenterRelatedLinks />
         </div>
       }
     />

--- a/frontend/invest/src/test/setup.ts
+++ b/frontend/invest/src/test/setup.ts
@@ -2,4 +2,40 @@ import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { afterEach } from "vitest";
 
+// Node 25 ships a partial built-in globalThis.localStorage that lacks
+// Storage.prototype methods like clear()/getItem/setItem and shadows jsdom's
+// implementation. Install a minimal Storage-compatible polyfill so tests can
+// call the full API.
+function createMemoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.has(key) ? (map.get(key) as string) : null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, String(value));
+    },
+  };
+}
+
+for (const name of ["localStorage", "sessionStorage"] as const) {
+  const storage = createMemoryStorage();
+  Object.defineProperty(globalThis, name, { configurable: true, value: storage });
+  if (typeof window !== "undefined") {
+    Object.defineProperty(window, name, { configurable: true, value: storage });
+  }
+}
+
 afterEach(() => cleanup());

--- a/frontend/invest/vitest.config.ts
+++ b/frontend/invest/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: "jsdom",
+    environmentOptions: { jsdom: { url: "http://localhost/" } },
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
     css: true,


### PR DESCRIPTION
## Summary

`preview/right-rail-collapsible.html` from the auto-trader-invest design system, applied to `frontend/invest/`. The collapsible rail itself (⌘. shortcut, localStorage persistence, icon rail, pane fade) was already implemented; this PR delivers the **two undelivered halves of the design**:

1. **Full-bleed Toss shell.** `DesktopShell` drops the outer `maxWidth: 1440 / margin: 0 auto / gap: 24`; padding moves inside columns; center column gets `max-width: 1100px; margin: 0 auto`; the right rail becomes a *wall* against the viewport edge (`border-left: 1px solid var(--divider)`, `background: var(--bg)`, `sticky top: 56px`, `height: calc(100vh - 56px)`). No more black gutters on wide monitors, rail glued to the right edge.
2. **PageSafetyNote relocation on `/action-center`.** Per the README contract ("page-specific advisories and related-links cards move to a `<PageSafetyNote>` slot at the top of the center column"), `ActionCenterRelatedLinks` becomes a `PageSafetyNote` at the top of the center column and the unused export is removed. The right rail keeps mounting `RightRemotePanel` as before. The other four pages on the relocation list (`/market`, `/market/fx`, `/insights`, `/coverage`) were already on `PageSafetyNote`.
3. **Side fix — test infra.** Node 25 ships a partial built-in `globalThis.localStorage` (missing `clear/getItem/setItem`) that shadows jsdom's full implementation, breaking 18+ tests on `main`. Installed a minimal in-memory `Storage` polyfill in `src/test/setup.ts` and pinned a jsdom URL in `vitest.config.ts`.

Design source: `https://api.anthropic.com/v1/design/h/D71Yk1UA6IltMF9_8s-0Ng?open_file=preview%2Fright-rail-collapsible.html`.

## Files

- `frontend/invest/src/desktop/DesktopShell.tsx` — full-bleed grid, rail wall, sticky height
- `frontend/invest/src/pages/desktop/DesktopActionCenterPage.tsx` — adopt `PageSafetyNote`
- `frontend/invest/src/components/action-center/ActionCenterContent.tsx` — drop now-unused `ActionCenterRelatedLinks`
- `frontend/invest/src/test/setup.ts` — Node 25 localStorage polyfill
- `frontend/invest/vitest.config.ts` — `environmentOptions.jsdom.url`

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npx vitest run src/__tests__/DesktopShell.test.tsx src/__tests__/RightRemotePanel.test.tsx src/__tests__/PageSafetyNote.test.tsx` — 18/18 pass
- [x] `npx vitest run` — 292/296 pass. The 4 remaining failures (`DaySection`, `DesktopCalendarPage`, `MonthlyEventsTimeline`) reproduce on a clean stash of this branch — calendar date-fixture issues unrelated to the shell/rail/safety-note work. Net of the localStorage polyfill this branch turns ~16 pre-existing test-infra failures into passes.
- [ ] Visual smoke in `npm run dev` at wide viewport (rail flush right, no gutters) and at narrow viewport (rail still collapses via ⌘.)
- [ ] Toggle `data-theme="dark"` and confirm rail border-left + bg use tokens

## Safety

No broker/order/watch mutation; no schema or migration; design-system-only changes scoped to `frontend/invest/` plus the vitest setup files.

Co-Authored-By: Paperclip <noreply@paperclip.ing>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized navigation links in the Action Center for improved layout structure.
  * Adjusted desktop shell layout spacing and positioning for better visual consistency.

* **Chores**
  * Enhanced test setup with improved storage compatibility.
  * Updated test environment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->