### PR TITLE
ROB-265 Plan 2: investment_* service layer (repo / ingestion / decisions / watch activation / query)

### DIFF
--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -1,0 +1,166 @@
+"""ROB-265 — Pydantic v2 request schemas for the investment_* service layer.
+
+These mirror the locked product decisions:
+
+* Advisory-only invariants: ``kis_live`` account + ``nxt`` session both
+  force ``execution_mode='advisory_only'``.
+* Watch items: ``watch_condition`` and ``valid_until`` are both required
+  when ``item_kind='watch'``.
+* Schema validators run BEFORE we hit the DB, so callers get a clean
+  Pydantic ValidationError instead of an IntegrityError.
+
+Defense in depth — the DB CHECK constraints from Plan 1 are the
+authoritative enforcement; these are early rejection for cleaner errors.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+# Enum-equivalent Literals — match the DB CHECK constraints from
+# alembic/versions/20260518_rob265_add_investment_reports.py exactly.
+MarketLiteral = Literal["kr", "us", "crypto"]
+MarketSessionLiteral = Literal["regular", "nxt", "pre", "post", "24x7"]
+AccountScopeLiteral = Literal["kis_live", "kis_mock", "alpaca_paper", "upbit_live"]
+ExecutionModeLiteral = Literal["advisory_only", "mock_preview"]
+ReportStatusLiteral = Literal["draft", "published", "decided", "expired", "superseded"]
+
+ItemKindLiteral = Literal["action", "watch", "risk"]
+ItemSideLiteral = Literal["buy", "sell"]
+ItemIntentLiteral = Literal[
+    "buy_review",
+    "sell_review",
+    "risk_review",
+    "trend_recovery_review",
+    "rebalance_review",
+]
+TargetKindLiteral = Literal["asset", "index", "fx"]
+ItemStatusLiteral = Literal[
+    "proposed", "approved", "denied", "deferred", "activated", "expired"
+]
+
+WatchMetricLiteral = Literal["price", "rsi", "trade_value"]
+WatchOperatorLiteral = Literal["above", "below"]
+WatchActionModeLiteral = Literal["notify_only", "preview_only", "approval_required"]
+
+DecisionVerbLiteral = Literal[
+    "approve", "deny", "defer", "skip", "partial_approve"
+]
+
+
+class WatchConditionPayload(BaseModel):
+    """Embedded condition for a watch item. Persisted as JSONB."""
+
+    metric: WatchMetricLiteral
+    operator: WatchOperatorLiteral
+    threshold: Decimal
+    threshold_key: str | None = None
+    target_kind: TargetKindLiteral = "asset"
+    action_mode: WatchActionModeLiteral = "notify_only"
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class IngestReportItem(BaseModel):
+    """One proposal item attached to an ingested report."""
+
+    item_kind: ItemKindLiteral
+    symbol: str | None = None
+    side: ItemSideLiteral | None = None
+    intent: ItemIntentLiteral
+    target_kind: TargetKindLiteral = "asset"
+    priority: int = 0
+    confidence: Decimal | None = None
+    rationale: str
+    evidence_snapshot: dict[str, Any] = Field(default_factory=dict)
+    watch_condition: WatchConditionPayload | None = None
+    trigger_checklist: list[Any] = Field(default_factory=list)
+    max_action: dict[str, Any] = Field(default_factory=dict)
+    valid_until: datetime | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_watch_invariants(self) -> IngestReportItem:
+        if self.item_kind == "watch":
+            if self.watch_condition is None:
+                raise ValueError(
+                    "watch items must carry watch_condition (item_kind='watch')"
+                )
+            if self.valid_until is None:
+                raise ValueError(
+                    "watch items must carry valid_until (item_kind='watch')"
+                )
+        return self
+
+
+class IngestReportRequest(BaseModel):
+    """Idempotent report-bundle ingestion request.
+
+    The repository / ingestion service composes deterministic idempotency
+    keys from ``report_type`` + ``market`` + ``market_session`` +
+    ``kst_date`` + ``generator_version``.
+    """
+
+    report_type: str
+    market: MarketLiteral
+    market_session: MarketSessionLiteral | None = None
+    account_scope: AccountScopeLiteral | None = None
+    execution_mode: ExecutionModeLiteral = "advisory_only"
+    created_by_profile: str
+    title: str
+    summary: str
+    risk_summary: str | None = None
+    thesis_text: str | None = None
+    no_action_note: str | None = None
+    market_snapshot: dict[str, Any] = Field(default_factory=dict)
+    portfolio_snapshot: dict[str, Any] = Field(default_factory=dict)
+    previous_report_uuid: UUID | None = None
+    status: Literal["draft", "published"] = "draft"
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    valid_until: datetime | None = None
+    published_at: datetime | None = None
+    items: list[IngestReportItem] = Field(default_factory=list)
+
+    # Deterministic idempotency components.
+    generator_version: str = "v1"
+    kst_date: str
+
+    @model_validator(mode="after")
+    def _validate_advisory_only(self) -> IngestReportRequest:
+        # Defense in depth — DB CHECK already enforces this.
+        if (
+            self.account_scope == "kis_live"
+            and self.execution_mode != "advisory_only"
+        ):
+            raise ValueError(
+                "account_scope='kis_live' requires execution_mode='advisory_only'"
+            )
+        if self.market_session == "nxt" and self.execution_mode != "advisory_only":
+            raise ValueError(
+                "market_session='nxt' requires execution_mode='advisory_only'"
+            )
+        return self
+
+
+class RecordDecisionRequest(BaseModel):
+    """Operator decision on a single item."""
+
+    item_uuid: UUID
+    decision: DecisionVerbLiteral
+    actor: str
+    decision_note: str | None = None
+    approved_payload_snapshot: dict[str, Any] | None = None
+    idempotency_key: str | None = None
+
+
+class ActivateWatchRequest(BaseModel):
+    """Activate an approved watch item into ``investment_watch_alerts``."""
+
+    item_uuid: UUID
+    actor: str
+    idempotency_key: str | None = None

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -65,6 +65,14 @@ class WatchConditionPayload(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
+    @model_validator(mode="after")
+    def _default_threshold_key(self) -> WatchConditionPayload:
+        # Canonical form: str(Decimal). Caller can override if they need
+        # a different dedup key (e.g. rounded value).
+        if self.threshold_key is None:
+            self.threshold_key = str(self.threshold)
+        return self
+
 
 class IngestReportItem(BaseModel):
     """One proposal item attached to an ingested report."""

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -73,8 +73,15 @@ class WatchConditionPayload(BaseModel):
 
 
 class IngestReportItem(BaseModel):
-    """One proposal item attached to an ingested report."""
+    """One proposal item attached to an ingested report.
 
+    ``client_item_key`` is a caller-supplied disambiguator used by the
+    item idempotency-key composer. It must be unique within a single
+    report bundle. Use it to disambiguate items that share natural
+    fields — multiple risk items, scoped buys on the same symbol, etc.
+    """
+
+    client_item_key: str = Field(min_length=1)
     item_kind: ItemKindLiteral
     symbol: str | None = None
     side: ItemSideLiteral | None = None
@@ -151,7 +158,14 @@ class IngestReportRequest(BaseModel):
 
 
 class RecordDecisionRequest(BaseModel):
-    """Operator decision on a single item."""
+    """Operator decision on a single item.
+
+    ``partial_approve`` requires a non-empty ``approved_payload_snapshot``
+    — the snapshot is the canonical record of what was scoped down (e.g.
+    ``{"max_notional_krw": 100_000}``). A partial approve without scope
+    is indistinguishable from a full approve and should not transition
+    the item.
+    """
 
     item_uuid: UUID
     decision: DecisionVerbLiteral
@@ -159,6 +173,14 @@ class RecordDecisionRequest(BaseModel):
     decision_note: str | None = None
     approved_payload_snapshot: dict[str, Any] | None = None
     idempotency_key: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_partial_approve_has_payload(self) -> RecordDecisionRequest:
+        if self.decision == "partial_approve" and not self.approved_payload_snapshot:
+            raise ValueError(
+                "partial_approve requires non-empty approved_payload_snapshot"
+            )
+        return self
 
 
 class ActivateWatchRequest(BaseModel):

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -48,9 +48,7 @@ WatchMetricLiteral = Literal["price", "rsi", "trade_value"]
 WatchOperatorLiteral = Literal["above", "below"]
 WatchActionModeLiteral = Literal["notify_only", "preview_only", "approval_required"]
 
-DecisionVerbLiteral = Literal[
-    "approve", "deny", "defer", "skip", "partial_approve"
-]
+DecisionVerbLiteral = Literal["approve", "deny", "defer", "skip", "partial_approve"]
 
 
 class WatchConditionPayload(BaseModel):
@@ -141,10 +139,7 @@ class IngestReportRequest(BaseModel):
     @model_validator(mode="after")
     def _validate_advisory_only(self) -> IngestReportRequest:
         # Defense in depth — DB CHECK already enforces this.
-        if (
-            self.account_scope == "kis_live"
-            and self.execution_mode != "advisory_only"
-        ):
+        if self.account_scope == "kis_live" and self.execution_mode != "advisory_only":
             raise ValueError(
                 "account_scope='kis_live' requires execution_mode='advisory_only'"
             )

--- a/app/services/investment_reports/decisions.py
+++ b/app/services/investment_reports/decisions.py
@@ -1,0 +1,89 @@
+"""ROB-265 — Operator decision recording service.
+
+Records one decision per (item, actor, verb) idempotently and transitions
+the owning item's status when appropriate. ``skip`` is intentionally an
+audit-only verb that does not move the item; everything else maps to a
+new ``item.status``.
+
+Multiple decisions per item are allowed by design — e.g. ``defer`` →
+later ``approve`` produces two rows and the latest-decision projection
+is the caller's responsibility (query service).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_reports import InvestmentReportItemDecision
+from app.schemas.investment_reports import (
+    DecisionVerbLiteral,
+    RecordDecisionRequest,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+# Decision verb → resulting item.status. ``skip`` is audit-only and
+# leaves the item unchanged.
+_ITEM_STATUS_BY_DECISION: dict[DecisionVerbLiteral, str | None] = {
+    "approve": "approved",
+    "deny": "denied",
+    "defer": "deferred",
+    "skip": None,
+    "partial_approve": "approved",
+}
+
+
+class InvestmentReportDecisionService:
+    """Idempotent decision recording + item status transition."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        repository: InvestmentReportsRepository | None = None,
+    ) -> None:
+        self._session = session
+        self._repo = repository or InvestmentReportsRepository(session)
+
+    async def record(
+        self, request: RecordDecisionRequest
+    ) -> InvestmentReportItemDecision:
+        item = await self._repo.get_item_by_uuid(request.item_uuid)
+        if item is None:
+            raise ValueError(f"item not found: {request.item_uuid}")
+
+        idempotency_key = (
+            request.idempotency_key or self._auto_idempotency_key(request)
+        )
+
+        existing = await self._repo.get_decision_by_idempotency_key(idempotency_key)
+        if existing is not None:
+            return existing
+
+        decision = await self._repo.insert_decision(
+            item_id=item.id,
+            idempotency_key=idempotency_key,
+            decision=request.decision,
+            actor=request.actor,
+            decision_note=request.decision_note,
+            approved_payload_snapshot=request.approved_payload_snapshot,
+        )
+
+        new_status = _ITEM_STATUS_BY_DECISION[request.decision]
+        if new_status is not None:
+            await self._repo.update_item_status(item.id, new_status)
+
+        await self._session.flush()
+        return decision
+
+    @staticmethod
+    def _auto_idempotency_key(request: RecordDecisionRequest) -> str:
+        # One default decision per (item, verb, actor). Caller can override
+        # to allow the same operator to revisit the same verb (e.g. an
+        # approval correction with a new dedup key).
+        return ":".join(
+            [
+                "decision",
+                str(request.item_uuid),
+                request.decision,
+                request.actor,
+            ]
+        )

--- a/app/services/investment_reports/decisions.py
+++ b/app/services/investment_reports/decisions.py
@@ -50,9 +50,7 @@ class InvestmentReportDecisionService:
         if item is None:
             raise ValueError(f"item not found: {request.item_uuid}")
 
-        idempotency_key = (
-            request.idempotency_key or self._auto_idempotency_key(request)
-        )
+        idempotency_key = request.idempotency_key or self._auto_idempotency_key(request)
 
         existing = await self._repo.get_decision_by_idempotency_key(idempotency_key)
         if existing is not None:

--- a/app/services/investment_reports/decisions.py
+++ b/app/services/investment_reports/decisions.py
@@ -54,6 +54,15 @@ class InvestmentReportDecisionService:
 
         existing = await self._repo.get_decision_by_idempotency_key(idempotency_key)
         if existing is not None:
+            if existing.item_id != item.id:
+                # Caller-supplied idempotency_key collided with a decision
+                # on a different item. Returning ``existing`` would silently
+                # bind a fresh request to the wrong item — reject loudly.
+                raise ValueError(
+                    f"idempotency_key {idempotency_key!r} already used for a "
+                    f"different item (existing item_id={existing.item_id}, "
+                    f"requested item_id={item.id})"
+                )
             return existing
 
         decision = await self._repo.insert_decision(

--- a/app/services/investment_reports/idempotency.py
+++ b/app/services/investment_reports/idempotency.py
@@ -2,9 +2,16 @@
 
 All composers return a colon-joined, lowercase-where-applicable string.
 ``_`` is the slot for ``None`` so a missing field never collides with a
-real value. The canonical watch-condition hash is sha256 of a JSON dump
-with sorted keys, so logically equivalent payloads produce the same hash
-regardless of dict insertion order.
+real value. The canonical watch-condition hash is sha256 over a
+sort_keys JSON dump.
+
+Plan-2 hardening:
+* ``report_key`` includes ``account_scope`` + ``execution_mode`` so a
+  ``kis_live`` vs ``kis_mock`` report on the same date/session/generator
+  does not collide.
+* ``item_key`` includes ``client_item_key`` — the caller-supplied stable
+  identifier — so duplicate natural-key items (multiple risks, or
+  two same-symbol/same-intent action items) get distinct keys.
 """
 
 from __future__ import annotations
@@ -35,6 +42,8 @@ def report_key(
     report_type: str,
     market: str,
     market_session: str | None,
+    account_scope: str | None,
+    execution_mode: str,
     kst_date: str,
     generator_version: str,
 ) -> str:
@@ -45,6 +54,8 @@ def report_key(
             _slot(report_type),
             _slot(market),
             _slot(market_session),
+            _slot(account_scope),
+            _slot(execution_mode),
             _slot(kst_date),
             _slot(generator_version),
         ]
@@ -54,13 +65,19 @@ def report_key(
 def item_key(
     *,
     report_uuid: str,
+    client_item_key: str,
     item_kind: str,
     symbol: str | None,
     side: str | None,
     intent: str,
     watch_condition: dict | None,
 ) -> str:
-    """Stable key per (report, kind, symbol, side, intent, condition)."""
+    """Stable key per (report, client_item_key, kind, symbol, side, intent, condition).
+
+    ``client_item_key`` is the disambiguator the caller supplies so two
+    items that happen to share the same natural fields (e.g. two risks,
+    or two scoped buys on the same symbol) still produce distinct keys.
+    """
     condition_hash = (
         canonical_watch_condition_hash(watch_condition)
         if watch_condition is not None
@@ -70,6 +87,7 @@ def item_key(
         [
             "item",
             _slot(report_uuid),
+            _slot(client_item_key),
             _slot(item_kind),
             _slot(symbol),
             _slot(side),

--- a/app/services/investment_reports/ingestion.py
+++ b/app/services/investment_reports/ingestion.py
@@ -38,6 +38,8 @@ class InvestmentReportIngestionService:
             report_type=request.report_type,
             market=request.market,
             market_session=request.market_session,
+            account_scope=request.account_scope,
+            execution_mode=request.execution_mode,
             kst_date=request.kst_date,
             generator_version=request.generator_version,
         )
@@ -84,6 +86,7 @@ class InvestmentReportIngestionService:
         )
         idempotency_key = item_key(
             report_uuid=str(report.report_uuid),
+            client_item_key=item_req.client_item_key,
             item_kind=item_req.item_kind,
             symbol=item_req.symbol,
             side=item_req.side,

--- a/app/services/investment_reports/ingestion.py
+++ b/app/services/investment_reports/ingestion.py
@@ -1,0 +1,110 @@
+"""ROB-265 — Idempotent investment-report ingestion service.
+
+Takes an :class:`IngestReportRequest`, returns the persisted
+:class:`InvestmentReport`. Idempotent on the report's composed
+idempotency key: a second call with the same
+``(report_type, market, market_session, kst_date, generator_version)``
+returns the existing report unchanged. Items are NOT re-applied or
+diff-merged on re-ingest — the report bundle is atomic by design.
+
+Service-level only. No broker mutation, no MCP wiring, no scanner side
+effects. Callers own the transaction boundary (this service flushes
+but never commits).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_reports import InvestmentReport
+from app.schemas.investment_reports import IngestReportItem, IngestReportRequest
+from app.services.investment_reports.idempotency import item_key, report_key
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+
+class InvestmentReportIngestionService:
+    """Atomic, idempotent report-bundle creation."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        repository: InvestmentReportsRepository | None = None,
+    ) -> None:
+        self._session = session
+        self._repo = repository or InvestmentReportsRepository(session)
+
+    async def ingest(self, request: IngestReportRequest) -> InvestmentReport:
+        idempotency_key = report_key(
+            report_type=request.report_type,
+            market=request.market,
+            market_session=request.market_session,
+            kst_date=request.kst_date,
+            generator_version=request.generator_version,
+        )
+
+        existing = await self._repo.get_report_by_idempotency_key(idempotency_key)
+        if existing is not None:
+            return existing
+
+        report = await self._repo.insert_report(
+            idempotency_key=idempotency_key,
+            report_type=request.report_type,
+            market=request.market,
+            market_session=request.market_session,
+            account_scope=request.account_scope,
+            execution_mode=request.execution_mode,
+            created_by_profile=request.created_by_profile,
+            title=request.title,
+            summary=request.summary,
+            risk_summary=request.risk_summary,
+            thesis_text=request.thesis_text,
+            no_action_note=request.no_action_note,
+            market_snapshot=request.market_snapshot,
+            portfolio_snapshot=request.portfolio_snapshot,
+            previous_report_uuid=request.previous_report_uuid,
+            status=request.status,
+            report_metadata=request.metadata,
+            valid_until=request.valid_until,
+            published_at=request.published_at,
+        )
+
+        for item_req in request.items:
+            await self._insert_item(report, item_req)
+
+        await self._session.flush()
+        return report
+
+    async def _insert_item(
+        self, report: InvestmentReport, item_req: IngestReportItem
+    ) -> None:
+        watch_condition_payload = (
+            item_req.watch_condition.model_dump(mode="json")
+            if item_req.watch_condition is not None
+            else None
+        )
+        idempotency_key = item_key(
+            report_uuid=str(report.report_uuid),
+            item_kind=item_req.item_kind,
+            symbol=item_req.symbol,
+            side=item_req.side,
+            intent=item_req.intent,
+            watch_condition=watch_condition_payload,
+        )
+        await self._repo.insert_item(
+            report_id=report.id,
+            idempotency_key=idempotency_key,
+            item_kind=item_req.item_kind,
+            symbol=item_req.symbol,
+            side=item_req.side,
+            intent=item_req.intent,
+            target_kind=item_req.target_kind,
+            priority=item_req.priority,
+            confidence=item_req.confidence,
+            rationale=item_req.rationale,
+            evidence_snapshot=item_req.evidence_snapshot,
+            watch_condition=watch_condition_payload,
+            trigger_checklist=item_req.trigger_checklist,
+            max_action=item_req.max_action,
+            valid_until=item_req.valid_until,
+            item_metadata=item_req.metadata,
+        )

--- a/app/services/investment_reports/query_service.py
+++ b/app/services/investment_reports/query_service.py
@@ -1,0 +1,179 @@
+"""ROB-265 — Read-only query service over the investment_* tables.
+
+Wraps the repository with the higher-level read shapes the next layers
+(MCP/API in Plan 3, frontend in Plan 5) need. ``get_bundle`` returns a
+single report with all its nested context. ``previous_report_context``
+implements locked refinement #7 — context retrieval is a *query* over
+prior reports, not a single-link traversal via ``previous_report_uuid``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_reports import (
+    InvestmentReport,
+    InvestmentReportItem,
+    InvestmentReportItemDecision,
+    InvestmentWatchAlert,
+    InvestmentWatchEvent,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+
+class InvestmentReportQueryService:
+    """Read-only queries — list / get / latest / previous-context."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        repository: InvestmentReportsRepository | None = None,
+    ) -> None:
+        self._session = session
+        self._repo = repository or InvestmentReportsRepository(session)
+
+    async def list_reports(
+        self,
+        *,
+        market: str | None = None,
+        market_session: str | None = None,
+        account_scope: str | None = None,
+        status: str | None = None,
+        report_type: str | None = None,
+        limit: int = 20,
+    ) -> list[InvestmentReport]:
+        return await self._repo.list_reports(
+            market=market,
+            market_session=market_session,
+            account_scope=account_scope,
+            status=status,
+            report_type=report_type,
+            limit=limit,
+        )
+
+    async def latest_report(
+        self,
+        *,
+        market: str | None = None,
+        market_session: str | None = None,
+        account_scope: str | None = None,
+        status: str | None = None,
+        report_type: str | None = None,
+    ) -> InvestmentReport | None:
+        return await self._repo.latest_report(
+            market=market,
+            market_session=market_session,
+            account_scope=account_scope,
+            status=status,
+            report_type=report_type,
+        )
+
+    async def get_bundle(self, report_uuid: UUID) -> dict[str, Any] | None:
+        """Return the report + nested items, decisions, alerts, recent events.
+
+        Returns ``None`` if the report doesn't exist.
+        """
+        report = await self._repo.get_report_by_uuid(report_uuid)
+        if report is None:
+            return None
+
+        items = await self._repo.list_items_for_report(report.id)
+        item_ids = [it.id for it in items]
+        decisions = await self._repo.list_decisions_for_items(item_ids)
+        alerts = await self._repo.list_alerts_for_source_reports([report.report_uuid])
+        events = await self._repo.list_events_for_source_reports(
+            [report.report_uuid]
+        )
+
+        decisions_by_item: dict[int, list[InvestmentReportItemDecision]] = {
+            it.id: [] for it in items
+        }
+        for d in decisions:
+            decisions_by_item.setdefault(d.item_id, []).append(d)
+
+        return {
+            "report": report,
+            "items": items,
+            "decisions_by_item": decisions_by_item,
+            "alerts": alerts,
+            "events": events,
+        }
+
+    async def previous_report_context(
+        self,
+        *,
+        market: str,
+        market_session: str | None = None,
+        account_scope: str | None = None,
+        report_type: str | None = None,
+        exclude_report_uuid: UUID | None = None,
+        n_prior: int = 3,
+        events_since: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Locked refinement #7 — previous context is a query, not a single FK.
+
+        Returns the most recent N prior reports matching the filters plus
+        the unresolved/deferred items, active watches, triggered watch
+        events, and recent decisions that span those reports.
+        """
+        prior_reports: list[InvestmentReport] = await self._repo.list_reports(
+            market=market,
+            market_session=market_session,
+            account_scope=account_scope,
+            report_type=report_type,
+            limit=n_prior + 1,  # +1 so we can drop the excluded one cleanly
+        )
+        if exclude_report_uuid is not None:
+            prior_reports = [
+                r for r in prior_reports if r.report_uuid != exclude_report_uuid
+            ]
+        prior_reports = prior_reports[:n_prior]
+
+        prior_report_uuids = [r.report_uuid for r in prior_reports]
+        prior_report_ids = [r.id for r in prior_reports]
+
+        # Items: deferred-status only, across the prior report set.
+        unresolved_deferred_items: list[InvestmentReportItem] = []
+        for r in prior_reports:
+            r_items = await self._repo.list_items_for_report(r.id)
+            unresolved_deferred_items.extend(
+                it for it in r_items if it.status == "deferred"
+            )
+
+        # Active watches sourced from those reports.
+        active_watches: list[InvestmentWatchAlert] = (
+            await self._repo.list_alerts_for_source_reports(
+                prior_report_uuids, status="active"
+            )
+        )
+
+        # Recent triggered events linked to those source reports.
+        triggered_events: list[InvestmentWatchEvent] = (
+            await self._repo.list_events_for_source_reports(
+                prior_report_uuids, since=events_since
+            )
+        )
+
+        # Recent decisions on items in those reports.
+        all_item_ids: list[int] = []
+        for r in prior_reports:
+            r_items = await self._repo.list_items_for_report(r.id)
+            all_item_ids.extend(it.id for it in r_items)
+        recent_decisions: list[InvestmentReportItemDecision] = (
+            await self._repo.list_decisions_for_items(all_item_ids)
+        )
+
+        # `prior_report_ids` is consumed indirectly above; keep it in the
+        # return shape for callers that want the integer IDs.
+        return {
+            "prior_reports": prior_reports,
+            "prior_report_ids": prior_report_ids,
+            "unresolved_deferred_items": unresolved_deferred_items,
+            "active_watches": active_watches,
+            "triggered_events": triggered_events,
+            "recent_decisions": recent_decisions,
+        }

--- a/app/services/investment_reports/query_service.py
+++ b/app/services/investment_reports/query_service.py
@@ -85,9 +85,7 @@ class InvestmentReportQueryService:
         item_ids = [it.id for it in items]
         decisions = await self._repo.list_decisions_for_items(item_ids)
         alerts = await self._repo.list_alerts_for_source_reports([report.report_uuid])
-        events = await self._repo.list_events_for_source_reports(
-            [report.report_uuid]
-        )
+        events = await self._repo.list_events_for_source_reports([report.report_uuid])
 
         decisions_by_item: dict[int, list[InvestmentReportItemDecision]] = {
             it.id: [] for it in items
@@ -145,17 +143,17 @@ class InvestmentReportQueryService:
             )
 
         # Active watches sourced from those reports.
-        active_watches: list[InvestmentWatchAlert] = (
-            await self._repo.list_alerts_for_source_reports(
-                prior_report_uuids, status="active"
-            )
+        active_watches: list[
+            InvestmentWatchAlert
+        ] = await self._repo.list_alerts_for_source_reports(
+            prior_report_uuids, status="active"
         )
 
         # Recent triggered events linked to those source reports.
-        triggered_events: list[InvestmentWatchEvent] = (
-            await self._repo.list_events_for_source_reports(
-                prior_report_uuids, since=events_since
-            )
+        triggered_events: list[
+            InvestmentWatchEvent
+        ] = await self._repo.list_events_for_source_reports(
+            prior_report_uuids, since=events_since
         )
 
         # Recent decisions on items in those reports.
@@ -163,9 +161,9 @@ class InvestmentReportQueryService:
         for r in prior_reports:
             r_items = await self._repo.list_items_for_report(r.id)
             all_item_ids.extend(it.id for it in r_items)
-        recent_decisions: list[InvestmentReportItemDecision] = (
-            await self._repo.list_decisions_for_items(all_item_ids)
-        )
+        recent_decisions: list[
+            InvestmentReportItemDecision
+        ] = await self._repo.list_decisions_for_items(all_item_ids)
 
         # `prior_report_ids` is consumed indirectly above; keep it in the
         # return shape for callers that want the integer IDs.

--- a/app/services/investment_reports/repository.py
+++ b/app/services/investment_reports/repository.py
@@ -1,0 +1,314 @@
+"""ROB-265 — Thin SQLAlchemy DAO over the five investment_* tables.
+
+The repository contains no business logic. Validation, idempotency
+composition, and status transitions live in the business services
+(``ingestion``, ``decisions``, ``watch_activation``, ``query_service``).
+
+Pattern matches ``app/services/watch_order_intent_service.py`` —
+class-based with an injected ``AsyncSession``. The repository flushes
+when it has to update an attached row but never commits; callers own
+the transaction boundary.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_reports import (
+    InvestmentReport,
+    InvestmentReportItem,
+    InvestmentReportItemDecision,
+    InvestmentWatchAlert,
+    InvestmentWatchEvent,
+)
+
+
+class InvestmentReportsRepository:
+    """DAO over investment_reports / items / decisions / alerts / events."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    # ------------------------------------------------------------------
+    # Reports
+    # ------------------------------------------------------------------
+    async def insert_report(self, **fields: Any) -> InvestmentReport:
+        row = InvestmentReport(**fields)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def get_report_by_id(self, report_id: int) -> InvestmentReport | None:
+        return await self._session.scalar(
+            sa.select(InvestmentReport).where(InvestmentReport.id == report_id)
+        )
+
+    async def get_report_by_uuid(
+        self, report_uuid: UUID
+    ) -> InvestmentReport | None:
+        return await self._session.scalar(
+            sa.select(InvestmentReport).where(
+                InvestmentReport.report_uuid == report_uuid
+            )
+        )
+
+    async def get_report_by_idempotency_key(
+        self, idempotency_key: str
+    ) -> InvestmentReport | None:
+        return await self._session.scalar(
+            sa.select(InvestmentReport).where(
+                InvestmentReport.idempotency_key == idempotency_key
+            )
+        )
+
+    async def list_reports(
+        self,
+        *,
+        market: str | None = None,
+        market_session: str | None = None,
+        account_scope: str | None = None,
+        status: str | None = None,
+        report_type: str | None = None,
+        limit: int = 20,
+    ) -> list[InvestmentReport]:
+        stmt = sa.select(InvestmentReport).order_by(
+            InvestmentReport.created_at.desc(), InvestmentReport.id.desc()
+        )
+        stmt = self._apply_report_filters(
+            stmt,
+            market=market,
+            market_session=market_session,
+            account_scope=account_scope,
+            status=status,
+            report_type=report_type,
+        )
+        stmt = stmt.limit(limit)
+        result = await self._session.scalars(stmt)
+        return list(result.all())
+
+    async def latest_report(
+        self,
+        *,
+        market: str | None = None,
+        market_session: str | None = None,
+        account_scope: str | None = None,
+        status: str | None = None,
+        report_type: str | None = None,
+    ) -> InvestmentReport | None:
+        stmt = sa.select(InvestmentReport).order_by(
+            InvestmentReport.created_at.desc(), InvestmentReport.id.desc()
+        )
+        stmt = self._apply_report_filters(
+            stmt,
+            market=market,
+            market_session=market_session,
+            account_scope=account_scope,
+            status=status,
+            report_type=report_type,
+        )
+        return await self._session.scalar(stmt.limit(1))
+
+    @staticmethod
+    def _apply_report_filters(
+        stmt: sa.Select,
+        *,
+        market: str | None,
+        market_session: str | None,
+        account_scope: str | None,
+        status: str | None,
+        report_type: str | None,
+    ) -> sa.Select:
+        if market is not None:
+            stmt = stmt.where(InvestmentReport.market == market)
+        if market_session is not None:
+            stmt = stmt.where(InvestmentReport.market_session == market_session)
+        if account_scope is not None:
+            stmt = stmt.where(InvestmentReport.account_scope == account_scope)
+        if status is not None:
+            stmt = stmt.where(InvestmentReport.status == status)
+        if report_type is not None:
+            stmt = stmt.where(InvestmentReport.report_type == report_type)
+        return stmt
+
+    # ------------------------------------------------------------------
+    # Items
+    # ------------------------------------------------------------------
+    async def insert_item(self, **fields: Any) -> InvestmentReportItem:
+        row = InvestmentReportItem(**fields)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def get_item_by_uuid(
+        self, item_uuid: UUID
+    ) -> InvestmentReportItem | None:
+        return await self._session.scalar(
+            sa.select(InvestmentReportItem).where(
+                InvestmentReportItem.item_uuid == item_uuid
+            )
+        )
+
+    async def list_items_for_report(
+        self, report_id: int
+    ) -> list[InvestmentReportItem]:
+        result = await self._session.scalars(
+            sa.select(InvestmentReportItem)
+            .where(InvestmentReportItem.report_id == report_id)
+            .order_by(InvestmentReportItem.created_at.asc())
+        )
+        return list(result.all())
+
+    async def update_item_status(self, item_id: int, status: str) -> None:
+        await self._session.execute(
+            sa.update(InvestmentReportItem)
+            .where(InvestmentReportItem.id == item_id)
+            .values(status=status)
+        )
+
+    # ------------------------------------------------------------------
+    # Decisions
+    # ------------------------------------------------------------------
+    async def insert_decision(self, **fields: Any) -> InvestmentReportItemDecision:
+        row = InvestmentReportItemDecision(**fields)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def get_decision_by_idempotency_key(
+        self, idempotency_key: str
+    ) -> InvestmentReportItemDecision | None:
+        return await self._session.scalar(
+            sa.select(InvestmentReportItemDecision).where(
+                InvestmentReportItemDecision.idempotency_key == idempotency_key
+            )
+        )
+
+    async def list_decisions_for_item(
+        self, item_id: int
+    ) -> list[InvestmentReportItemDecision]:
+        result = await self._session.scalars(
+            sa.select(InvestmentReportItemDecision)
+            .where(InvestmentReportItemDecision.item_id == item_id)
+            .order_by(InvestmentReportItemDecision.created_at.asc())
+        )
+        return list(result.all())
+
+    # ------------------------------------------------------------------
+    # Alerts
+    # ------------------------------------------------------------------
+    async def insert_alert(self, **fields: Any) -> InvestmentWatchAlert:
+        row = InvestmentWatchAlert(**fields)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def get_alert_by_idempotency_key(
+        self, idempotency_key: str
+    ) -> InvestmentWatchAlert | None:
+        return await self._session.scalar(
+            sa.select(InvestmentWatchAlert).where(
+                InvestmentWatchAlert.idempotency_key == idempotency_key
+            )
+        )
+
+    async def list_active_alerts(
+        self,
+        *,
+        market: str | None = None,
+        valid_at: datetime | None = None,
+    ) -> list[InvestmentWatchAlert]:
+        stmt = sa.select(InvestmentWatchAlert).where(
+            InvestmentWatchAlert.status == "active"
+        )
+        if market is not None:
+            stmt = stmt.where(InvestmentWatchAlert.market == market)
+        if valid_at is not None:
+            stmt = stmt.where(InvestmentWatchAlert.valid_until > valid_at)
+        stmt = stmt.order_by(InvestmentWatchAlert.activated_at.desc())
+        result = await self._session.scalars(stmt)
+        return list(result.all())
+
+    async def list_alerts_for_source_reports(
+        self, source_report_uuids: list[UUID], *, status: str | None = None
+    ) -> list[InvestmentWatchAlert]:
+        if not source_report_uuids:
+            return []
+        stmt = sa.select(InvestmentWatchAlert).where(
+            InvestmentWatchAlert.source_report_uuid.in_(source_report_uuids)
+        )
+        if status is not None:
+            stmt = stmt.where(InvestmentWatchAlert.status == status)
+        stmt = stmt.order_by(InvestmentWatchAlert.activated_at.desc())
+        result = await self._session.scalars(stmt)
+        return list(result.all())
+
+    async def update_alert_status(self, alert_id: int, status: str) -> None:
+        await self._session.execute(
+            sa.update(InvestmentWatchAlert)
+            .where(InvestmentWatchAlert.id == alert_id)
+            .values(status=status)
+        )
+
+    # ------------------------------------------------------------------
+    # Events
+    # ------------------------------------------------------------------
+    async def insert_event(self, **fields: Any) -> InvestmentWatchEvent:
+        row = InvestmentWatchEvent(**fields)
+        self._session.add(row)
+        await self._session.flush()
+        await self._session.refresh(row)
+        return row
+
+    async def list_events_for_alert(
+        self, alert_id: int, *, limit: int = 50
+    ) -> list[InvestmentWatchEvent]:
+        result = await self._session.scalars(
+            sa.select(InvestmentWatchEvent)
+            .where(InvestmentWatchEvent.alert_id == alert_id)
+            .order_by(InvestmentWatchEvent.created_at.desc())
+            .limit(limit)
+        )
+        return list(result.all())
+
+    async def list_events_for_source_reports(
+        self,
+        source_report_uuids: list[UUID],
+        *,
+        since: datetime | None = None,
+        limit: int = 50,
+    ) -> list[InvestmentWatchEvent]:
+        if not source_report_uuids:
+            return []
+        stmt = sa.select(InvestmentWatchEvent).where(
+            InvestmentWatchEvent.source_report_uuid.in_(source_report_uuids)
+        )
+        if since is not None:
+            stmt = stmt.where(InvestmentWatchEvent.created_at >= since)
+        stmt = stmt.order_by(InvestmentWatchEvent.created_at.desc()).limit(limit)
+        result = await self._session.scalars(stmt)
+        return list(result.all())
+
+    async def list_decisions_for_items(
+        self,
+        item_ids: list[int],
+        *,
+        limit: int = 100,
+    ) -> list[InvestmentReportItemDecision]:
+        if not item_ids:
+            return []
+        result = await self._session.scalars(
+            sa.select(InvestmentReportItemDecision)
+            .where(InvestmentReportItemDecision.item_id.in_(item_ids))
+            .order_by(InvestmentReportItemDecision.created_at.desc())
+            .limit(limit)
+        )
+        return list(result.all())

--- a/app/services/investment_reports/repository.py
+++ b/app/services/investment_reports/repository.py
@@ -49,9 +49,7 @@ class InvestmentReportsRepository:
             sa.select(InvestmentReport).where(InvestmentReport.id == report_id)
         )
 
-    async def get_report_by_uuid(
-        self, report_uuid: UUID
-    ) -> InvestmentReport | None:
+    async def get_report_by_uuid(self, report_uuid: UUID) -> InvestmentReport | None:
         return await self._session.scalar(
             sa.select(InvestmentReport).where(
                 InvestmentReport.report_uuid == report_uuid
@@ -146,18 +144,14 @@ class InvestmentReportsRepository:
         await self._session.refresh(row)
         return row
 
-    async def get_item_by_uuid(
-        self, item_uuid: UUID
-    ) -> InvestmentReportItem | None:
+    async def get_item_by_uuid(self, item_uuid: UUID) -> InvestmentReportItem | None:
         return await self._session.scalar(
             sa.select(InvestmentReportItem).where(
                 InvestmentReportItem.item_uuid == item_uuid
             )
         )
 
-    async def list_items_for_report(
-        self, report_id: int
-    ) -> list[InvestmentReportItem]:
+    async def list_items_for_report(self, report_id: int) -> list[InvestmentReportItem]:
         result = await self._session.scalars(
             sa.select(InvestmentReportItem)
             .where(InvestmentReportItem.report_id == report_id)

--- a/app/services/investment_reports/watch_activation.py
+++ b/app/services/investment_reports/watch_activation.py
@@ -31,9 +31,7 @@ class WatchActivationService:
         self._session = session
         self._repo = repository or InvestmentReportsRepository(session)
 
-    async def activate(
-        self, request: ActivateWatchRequest
-    ) -> InvestmentWatchAlert:
+    async def activate(self, request: ActivateWatchRequest) -> InvestmentWatchAlert:
         item = await self._repo.get_item_by_uuid(request.item_uuid)
         if item is None:
             raise ValueError(f"item not found: {request.item_uuid}")

--- a/app/services/investment_reports/watch_activation.py
+++ b/app/services/investment_reports/watch_activation.py
@@ -1,0 +1,105 @@
+"""ROB-265 — Watch activation service.
+
+Copies an approved watch :class:`InvestmentReportItem` into the
+immutable activation snapshot held in :class:`InvestmentWatchAlert`.
+Items are the source of truth; once activated, the alert's snapshot
+fields are not mutated again (the scanner re-wire in Plan 4 only
+flips ``status`` between active / triggered / expired / canceled).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.investment_reports import InvestmentWatchAlert
+from app.schemas.investment_reports import ActivateWatchRequest
+from app.services.investment_reports.idempotency import watch_activation_key
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+
+class WatchActivationService:
+    """Activate an approved watch item into ``investment_watch_alerts``."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        repository: InvestmentReportsRepository | None = None,
+    ) -> None:
+        self._session = session
+        self._repo = repository or InvestmentReportsRepository(session)
+
+    async def activate(
+        self, request: ActivateWatchRequest
+    ) -> InvestmentWatchAlert:
+        item = await self._repo.get_item_by_uuid(request.item_uuid)
+        if item is None:
+            raise ValueError(f"item not found: {request.item_uuid}")
+
+        idempotency_key = request.idempotency_key or watch_activation_key(
+            source_item_uuid=str(item.item_uuid)
+        )
+
+        # Idempotent re-activate: a subsequent call after the item has
+        # already transitioned to ``activated`` returns the existing alert
+        # without re-validating.
+        existing = await self._repo.get_alert_by_idempotency_key(idempotency_key)
+        if existing is not None:
+            return existing
+
+        if item.item_kind != "watch":
+            raise ValueError(
+                f"only watch items can be activated; item_kind={item.item_kind}"
+            )
+        if item.status != "approved":
+            raise ValueError(
+                f"only approved items can be activated; status={item.status}"
+            )
+        if item.watch_condition is None:
+            raise ValueError("watch_condition missing on item (corrupt state)")
+        if item.valid_until is None:
+            raise ValueError("valid_until missing on watch item (corrupt state)")
+        if item.symbol is None:
+            raise ValueError("symbol missing on watch item")
+
+        report = await self._repo.get_report_by_id(item.report_id)
+        if report is None:
+            raise ValueError(f"report not found for item: {item.report_id}")
+
+        condition: dict[str, Any] = item.watch_condition
+        threshold = _to_decimal(condition.get("threshold"))
+        threshold_key = condition.get("threshold_key") or str(threshold)
+
+        alert = await self._repo.insert_alert(
+            alert_uuid=None,  # default from PG
+            idempotency_key=idempotency_key,
+            source_report_uuid=report.report_uuid,
+            source_item_uuid=item.item_uuid,
+            market=report.market,
+            target_kind=item.target_kind,
+            symbol=item.symbol,
+            metric=condition["metric"],
+            operator=condition["operator"],
+            threshold=threshold,
+            threshold_key=threshold_key,
+            intent=item.intent,
+            action_mode=condition.get("action_mode", "notify_only"),
+            rationale=item.rationale,
+            trigger_checklist=list(item.trigger_checklist),
+            max_action=dict(item.max_action),
+            valid_until=item.valid_until,
+        )
+
+        await self._repo.update_item_status(item.id, "activated")
+        await self._session.flush()
+        return alert
+
+
+def _to_decimal(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    if value is None:
+        raise ValueError("threshold is required in watch_condition")
+    return Decimal(str(value))

--- a/app/services/investment_reports/watch_activation.py
+++ b/app/services/investment_reports/watch_activation.py
@@ -45,6 +45,16 @@ class WatchActivationService:
         # without re-validating.
         existing = await self._repo.get_alert_by_idempotency_key(idempotency_key)
         if existing is not None:
+            if existing.source_item_uuid != item.item_uuid:
+                # Caller-supplied idempotency_key collided with an alert
+                # already sourced from a different item — reject loudly
+                # rather than silently aliasing.
+                raise ValueError(
+                    f"idempotency_key {idempotency_key!r} already used for a "
+                    f"different watch item (existing source_item_uuid="
+                    f"{existing.source_item_uuid}, requested source_item_uuid="
+                    f"{item.item_uuid})"
+                )
             return existing
 
         if item.item_kind != "watch":

--- a/docs/plans/2026-05-18-ROB-265-plan-2-investment-reports-services.md
+++ b/docs/plans/2026-05-18-ROB-265-plan-2-investment-reports-services.md
@@ -1,0 +1,241 @@
+# ROB-265 Plan 2 — Service Layer (repository, ingestion, query, decisions, watch activation)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` or `superpowers:executing-plans` to implement this plan task-by-task.
+
+**Goal:** Add the service-layer operations that drive the `investment_*` schema added in Plan 1. Service-only: no MCP, no API routes, no scanner re-wire, no frontend, no broker mutation. Advisory-only invariants enforced app-side as defense-in-depth on top of the DB CHECKs.
+
+**Architecture:**
+- Pydantic v2 request schemas in `app/schemas/investment_reports.py` with `model_validator` enforcing the advisory-only invariants and the watch-item shape (`watch_condition` + `valid_until` required for `item_kind='watch'`).
+- DAO at `app/services/investment_reports/repository.py` — narrow CRUD over the 5 tables, no business logic.
+- Four business services on top of the repository, each in its own module: `ingestion`, `decisions`, `watch_activation`, `query_service`.
+- All services are class-based, take an `AsyncSession` (matching the project pattern from `WatchOrderIntentService`).
+- Idempotency keys composed via the Plan 1 helpers (`app/services/investment_reports/idempotency.py`).
+- Watch activation copies the watch's metric/operator/threshold/etc into the alert's immutable snapshot fields (per locked refinement #3: items are source of truth, alerts are immutable activation snapshot).
+- Tests against the real PostgreSQL `test_db` using the same `_ALL_TABLES` + truncate-between-tests pattern established in Plan 1.
+
+**Tech Stack:** SQLAlchemy 2.x async (`AsyncSession`, `select`, `update`), Pydantic v2 (`BaseModel`, `Field`, `model_validator`), pytest-asyncio.
+
+---
+
+## File Structure
+
+**Create:**
+- `app/schemas/investment_reports.py` — `WatchConditionPayload`, `IngestReportItem`, `IngestReportRequest`, `RecordDecisionRequest`, `ActivateWatchRequest`, `PreviousContextFilter` Pydantic models with cross-field validators.
+- `app/services/investment_reports/repository.py` — `InvestmentReportsRepository` class with CRUD methods over all 5 tables.
+- `app/services/investment_reports/ingestion.py` — `InvestmentReportIngestionService`: idempotent report-bundle creation with deterministic key composition.
+- `app/services/investment_reports/decisions.py` — `InvestmentReportDecisionService`: idempotent decision recording + item status transitions.
+- `app/services/investment_reports/watch_activation.py` — `WatchActivationService`: copy approved watch item to `investment_watch_alerts` as immutable activation snapshot, idempotent per source item.
+- `app/services/investment_reports/query_service.py` — `InvestmentReportQueryService`: list/get/latest + previous-report context.
+- `tests/test_investment_reports_repository.py` — repository CRUD tests.
+- `tests/test_investment_reports_ingestion.py` — ingestion idempotency, validator, advisory-only-at-schema tests.
+- `tests/test_investment_reports_decisions.py` — decision recording, idempotency, status transition tests.
+- `tests/test_investment_reports_watch_activation.py` — watch activation snapshot copy, idempotency, status-update, guard tests.
+- `tests/test_investment_reports_query_service.py` — listing/filtering/latest/context-retrieval tests.
+
+**Modify (light wiring only):**
+- `app/schemas/__init__.py` — if it exists and pre-exports schema modules; add the new module's exports. (Verify pattern before changing.)
+
+---
+
+## Locked design decisions (carried from the conversation)
+
+1. **Items are source of truth; alerts are immutable activation snapshot.** Activation copies these fields from item/report into alert: `market`, `target_kind`, `symbol`, `metric`, `operator`, `threshold`, `threshold_key`, `intent`, `action_mode`, `valid_until`, `rationale`, `trigger_checklist`, `max_action`. After copy, alert fields are not mutated except `status` and `updated_at`.
+
+2. **Idempotency-key composition:**
+   - Report: `report_key(report_type, market, market_session, kst_date, generator_version)`
+   - Item: `item_key(report_uuid, item_kind, symbol, side, intent, watch_condition)`
+   - Decision: `decision:{item_uuid}:{decision}:{actor}` (or caller-supplied)
+   - Watch activation: `watch_activation_key(source_item_uuid)` (one activation per source item)
+   - Watch event: not in this plan — Plan 4 (scanner re-wire)
+
+3. **Status transitions** (decision → item status):
+   - `approve` → `approved`
+   - `deny` → `denied`
+   - `defer` → `deferred`
+   - `skip` → no status change (audit-only)
+   - `partial_approve` → `approved` (the partial scope is recorded in `approved_payload_snapshot`)
+   - `activate` (watch_activation, separate from decisions) → `activated`
+
+4. **Advisory-only invariants** validated app-side at schema construction time AND enforced by DB CHECKs:
+   - `account_scope='kis_live'` requires `execution_mode='advisory_only'`
+   - `market_session='nxt'` requires `execution_mode='advisory_only'`
+
+5. **No broker submission, no order mutation, no scanner write.** Services only persist analyst/operator decisions and watch activation snapshots. Plan 4 owns scanner integration.
+
+6. **Previous-report context** is a query, not a single-link traversal. The `previous_report_uuid` column is a trace hint only. Context returns the recent N reports + unresolved deferred items + active watches + recent watch events + recent decisions, all by filter (market/market_session/account_scope/report_type).
+
+---
+
+## Task 1 — Pydantic schemas
+
+**Files:**
+- Create: `app/schemas/investment_reports.py`
+- Create: `tests/test_investment_reports_schemas.py` (validator tests only — services arrive in subsequent tasks)
+
+**Key types:**
+- `WatchConditionPayload(metric, operator, threshold, threshold_key)` — Literal enums for `metric`/`operator`; threshold as `Decimal`.
+- `IngestReportItem` with `model_validator(mode="after")` enforcing watch_condition + valid_until requirements for `item_kind='watch'`.
+- `IngestReportRequest` with `model_validator(mode="after")` enforcing kis_live → advisory_only and nxt → advisory_only.
+- `RecordDecisionRequest`, `ActivateWatchRequest` with optional `idempotency_key`.
+
+**Tests:** schema-level rejection of (a) watch item without watch_condition, (b) watch item without valid_until, (c) kis_live with non-advisory execution_mode, (d) nxt session with non-advisory execution_mode. ~6-8 tests.
+
+---
+
+## Task 2 — Repository (DAO)
+
+**Files:**
+- Create: `app/services/investment_reports/repository.py`
+- Create: `tests/test_investment_reports_repository.py`
+
+**`InvestmentReportsRepository` methods (all `async`, all take primitives or model objects, return model objects):**
+- Reports: `insert_report`, `get_report_by_id`, `get_report_by_uuid`, `get_report_by_idempotency_key`, `list_reports(filters, limit)`, `latest_report(filters)`
+- Items: `insert_item`, `get_item_by_uuid`, `list_items_for_report`, `update_item_status`
+- Decisions: `insert_decision`, `get_decision_by_idempotency_key`, `list_decisions_for_item`
+- Alerts: `insert_alert`, `get_alert_by_idempotency_key`, `list_active_alerts(market=None, valid_at=None)`, `update_alert_status`
+- Events: `insert_event`, `list_events_for_alert`, `list_recent_events(filters, since, limit)`
+
+**Constraints:**
+- No business logic — repository is just a thin SQLAlchemy wrapper.
+- Filters on list methods support `market`, `market_session`, `account_scope`, `report_type`, `status`.
+- `list_active_alerts` filters by `status='active'` and (if `valid_at` provided) `valid_until > valid_at`.
+
+**Tests:** insert + retrieve round-trips per entity, idempotency-key lookups, list filtering. ~8-10 tests.
+
+---
+
+## Task 3 — Ingestion service
+
+**Files:**
+- Create: `app/services/investment_reports/ingestion.py`
+- Create: `tests/test_investment_reports_ingestion.py`
+
+**`InvestmentReportIngestionService.ingest(request: IngestReportRequest) -> InvestmentReport`:**
+1. Compute report idempotency key via `report_key(...)`.
+2. If `get_report_by_idempotency_key` returns a row, return it unchanged (no items re-inserted).
+3. Otherwise: insert report; for each item in `request.items`, compute `item_key(...)`, and insert via repository.
+4. Flush (do not commit — caller controls transaction).
+5. Return the report.
+
+**Tests:** ~6-8 tests
+- Happy path: report + N items created.
+- Idempotent re-ingest: second call returns same report_uuid, items unchanged (no duplicates).
+- Watch item gets watch_condition stored as JSON.
+- Validator pre-rejection: invalid request raises Pydantic ValidationError before DB hit.
+- Mixed-kind items in one report (action + watch + risk).
+
+---
+
+## Task 4 — Decisions service
+
+**Files:**
+- Create: `app/services/investment_reports/decisions.py`
+- Create: `tests/test_investment_reports_decisions.py`
+
+**`InvestmentReportDecisionService.record(request: RecordDecisionRequest) -> InvestmentReportItemDecision`:**
+1. Resolve item by uuid; raise if not found.
+2. Compose idempotency_key (caller-supplied or auto: `decision:{item_uuid}:{decision}:{actor}`).
+3. Idempotent: if `get_decision_by_idempotency_key` hits, return existing.
+4. Insert decision row.
+5. Transition item status per the mapping in "Locked design decisions" §3. `skip` does not transition.
+6. Flush; return decision.
+
+**Tests:** ~6-8 tests
+- Decision recorded + item status transitions for approve/deny/defer/partial_approve.
+- `skip` leaves item status unchanged.
+- Idempotent re-record returns same decision_uuid, no new row.
+- Multiple decisions per item (e.g., defer → approve) are allowed and both persist.
+- Unknown item_uuid raises ValueError.
+
+---
+
+## Task 5 — Watch activation service
+
+**Files:**
+- Create: `app/services/investment_reports/watch_activation.py`
+- Create: `tests/test_investment_reports_watch_activation.py`
+
+**`WatchActivationService.activate(request: ActivateWatchRequest) -> InvestmentWatchAlert`:**
+1. Resolve item by uuid; reject if missing, not `watch`, not `approved`, or missing `watch_condition`/`valid_until` (latter two enforced by DB but we validate early for clean errors).
+2. Resolve owning report for `market` and `report_uuid`.
+3. Compose idempotency_key as `watch_activation_key(source_item_uuid=item.item_uuid)` (or caller-supplied).
+4. Idempotent: if alert exists by key, return existing.
+5. Insert `InvestmentWatchAlert` copying immutable snapshot fields:
+   - `market` from report
+   - `target_kind`, `symbol`, `intent`, `rationale`, `trigger_checklist`, `max_action`, `valid_until` from item
+   - `metric`, `operator`, `threshold`, `threshold_key` from item.watch_condition
+   - `action_mode` from item.watch_condition (default to `notify_only` if not present)
+6. Transition item status to `activated`.
+7. Flush; return alert.
+
+**Tests:** ~6-8 tests
+- Happy path: alert created with snapshot fields populated from item + report, item status → `activated`.
+- Idempotent re-activate returns same alert_uuid.
+- Reject: item_kind != watch.
+- Reject: item.status != approved.
+- Reject: item not found.
+- Snapshot is immutable: subsequent update to item fields doesn't change the alert.
+
+---
+
+## Task 6 — Query service (list/get/latest/context)
+
+**Files:**
+- Create: `app/services/investment_reports/query_service.py`
+- Create: `tests/test_investment_reports_query_service.py`
+
+**`InvestmentReportQueryService` methods:**
+
+- `list_reports(market=None, market_session=None, account_scope=None, status=None, report_type=None, limit=20) -> list[InvestmentReport]` — ordered by `created_at` DESC.
+
+- `latest_report(**filters) -> InvestmentReport | None` — same filters, returns the most recent matching `created_at`.
+
+- `get_bundle(report_uuid: UUID) -> ReportBundle` — returns a Pydantic response wrapping the report + its items + decisions per item + active alerts derived from the report + recent events linked back to this report. Use a single round-trip where possible via `selectinload`/`joinedload` or explicit `IN` queries.
+
+- `previous_report_context(market, market_session=None, account_scope=None, report_type=None, exclude_report_uuid=None, n_prior=3, since=None) -> PreviousContext` — query-based context per locked refinement #7. Returns:
+  - `prior_reports`: top N matching reports (ordered DESC), excluding `exclude_report_uuid` if given
+  - `unresolved_deferred_items`: items with `status='deferred'` from those prior reports
+  - `active_watches`: active alerts whose `source_report_uuid` is in those prior reports' UUIDs and `status='active'`
+  - `triggered_events`: events linked to those prior reports' UUIDs (`source_report_uuid IN`), most-recent N
+  - `recent_decisions`: decisions on items from those prior reports, most-recent N
+
+**Tests:** ~8-10 tests
+- `list_reports` filters by each filter; default order by created_at DESC.
+- `latest_report` returns most recent matching, or None.
+- `get_bundle` returns nested items + decisions + alerts + events for a known report.
+- `previous_report_context` returns prior reports, deferred items, active alerts, triggered events, and decisions correctly across multiple prior reports.
+- `exclude_report_uuid` skips the named report from the prior set.
+- Empty-state shapes (no prior reports): all collections are empty lists, no crash.
+
+---
+
+## Task 7 — Final wiring, lint, test sweep, PR
+
+- Run `uv run ruff format <changed files>` and `uv run ruff check <changed files>`.
+- Run `uv run ty check app/schemas/investment_reports.py app/services/investment_reports/`.
+- Full Plan 2 test sweep: `uv run pytest tests/test_investment_reports_*.py -v`.
+- Legacy guard: `uv run pytest tests/test_analysis_report_workflow.py tests/test_mcp_watch_order_intent_ledger.py tests/test_watch_order_intent_service.py -v`.
+- Verify no broker/order side-effect imports added by greppping the new modules.
+- Commit per-task with focused messages.
+- Push branch `rob-265-plan-2`, open PR with **base `rob-265`** (stacked on Plan 1's PR).
+
+---
+
+## Self-review notes
+
+- **No MCP/API/scanner/frontend touched.** Confirmed by inspecting the file list — only `app/schemas/`, `app/services/investment_reports/`, and `tests/` change.
+- **Advisory-only invariant** validated app-side (`IngestReportRequest.model_validator`) AND DB-side (CHECK constraints from Plan 1). Defense in depth.
+- **Watch activation** is idempotent per source item (one activation per approved watch). Subsequent activations return the existing alert without copying again — immutable snapshot guarantee.
+- **No broker mutation:** services only INSERT/UPDATE `investment_*` tables. No imports of broker clients, KIS/Upbit/Alpaca/Kiwoom services.
+- **Previous-context** is a query, matching locked refinement #7. `previous_report_uuid` remains a trace hint only.
+- **Transaction boundaries** — services `flush()` but do not `commit()`. Callers (tests / future MCP handlers) own the transaction. Same pattern as `WatchOrderIntentService`.
+
+---
+
+## Out of scope for Plan 2
+
+- MCP/API contract (`investment_report_*`) — Plan 3.
+- OpenClaw notification payload update — Plan 3.
+- Watch scanner re-wire that emits `investment_watch_events` — Plan 4.
+- `/invest/reports` frontend — Plan 5.
+- Legacy clean cut (drop `analysis_*` and `watch_order_intent_ledger`) — Plan 5.

--- a/tests/test_investment_reports_decisions.py
+++ b/tests/test_investment_reports_decisions.py
@@ -5,23 +5,9 @@ from __future__ import annotations
 import uuid
 
 import pytest
-import pytest_asyncio
-import sqlalchemy as sa
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
-from app.models.base import Base
-from app.models.investment_reports import (
-    InvestmentReport,
-    InvestmentReportItem,
-    InvestmentReportItemDecision,
-    InvestmentWatchAlert,
-    InvestmentWatchEvent,
-)
+from app.models.investment_reports import InvestmentReportItem
 from app.schemas.investment_reports import (
     IngestReportItem,
     IngestReportRequest,
@@ -35,43 +21,13 @@ from app.services.investment_reports.ingestion import (
 )
 from app.services.investment_reports.repository import InvestmentReportsRepository
 
-_ALL_TABLES = [
-    InvestmentReport.__table__,
-    InvestmentReportItem.__table__,
-    InvestmentReportItemDecision.__table__,
-    InvestmentWatchAlert.__table__,
-    InvestmentWatchEvent.__table__,
-]
-
-
-@pytest_asyncio.fixture
-async def session() -> AsyncSession:
-    engine = create_async_engine(settings.DATABASE_URL, future=True)
-    async with engine.begin() as conn:
-        await conn.run_sync(
-            Base.metadata.create_all, tables=_ALL_TABLES, checkfirst=True
-        )
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    try:
-        async with factory() as sess:
-            try:
-                yield sess
-            finally:
-                await sess.rollback()
-        async with factory() as cleanup:
-            for table in reversed(_ALL_TABLES):
-                await cleanup.execute(
-                    sa.text(
-                        f'TRUNCATE TABLE review."{table.name}" RESTART IDENTITY CASCADE'
-                    )
-                )
-            await cleanup.commit()
-    finally:
-        await engine.dispose()
-
 
 async def _seed_report_with_one_action_item(
-    session: AsyncSession, *, kst_date: str = "2026-05-18"
+    session: AsyncSession,
+    *,
+    kst_date: str = "2026-05-18",
+    client_item_key: str = "action-1",
+    symbol: str = "005930",
 ) -> InvestmentReportItem:
     ingest = InvestmentReportIngestionService(session)
     report = await ingest.ingest(
@@ -87,8 +43,9 @@ async def _seed_report_with_one_action_item(
             kst_date=kst_date,
             items=[
                 IngestReportItem(
+                    client_item_key=client_item_key,
                     item_kind="action",
-                    symbol="005930",
+                    symbol=symbol,
                     side="buy",
                     intent="buy_review",
                     rationale="r",
@@ -107,7 +64,6 @@ async def test_approve_records_decision_and_transitions_item(
 ) -> None:
     item = await _seed_report_with_one_action_item(session)
     service = InvestmentReportDecisionService(session)
-
     decision = await service.record(
         RecordDecisionRequest(
             item_uuid=item.item_uuid, decision="approve", actor="operator-test"
@@ -123,8 +79,7 @@ async def test_approve_records_decision_and_transitions_item(
 @pytest.mark.asyncio
 async def test_deny_transitions_item_to_denied(session: AsyncSession) -> None:
     item = await _seed_report_with_one_action_item(session)
-    service = InvestmentReportDecisionService(session)
-    await service.record(
+    await InvestmentReportDecisionService(session).record(
         RecordDecisionRequest(
             item_uuid=item.item_uuid, decision="deny", actor="operator-test"
         )
@@ -137,8 +92,7 @@ async def test_deny_transitions_item_to_denied(session: AsyncSession) -> None:
 @pytest.mark.asyncio
 async def test_defer_transitions_item_to_deferred(session: AsyncSession) -> None:
     item = await _seed_report_with_one_action_item(session)
-    service = InvestmentReportDecisionService(session)
-    await service.record(
+    await InvestmentReportDecisionService(session).record(
         RecordDecisionRequest(
             item_uuid=item.item_uuid, decision="defer", actor="operator-test"
         )
@@ -151,15 +105,13 @@ async def test_defer_transitions_item_to_deferred(session: AsyncSession) -> None
 @pytest.mark.asyncio
 async def test_skip_leaves_item_status_unchanged(session: AsyncSession) -> None:
     item = await _seed_report_with_one_action_item(session)
-    service = InvestmentReportDecisionService(session)
-    await service.record(
+    await InvestmentReportDecisionService(session).record(
         RecordDecisionRequest(
             item_uuid=item.item_uuid, decision="skip", actor="operator-test"
         )
     )
     repo = InvestmentReportsRepository(session)
     refreshed = await repo.get_item_by_uuid(item.item_uuid)
-    # skip is audit-only — item stays proposed.
     assert refreshed.status == "proposed"
 
 
@@ -168,8 +120,7 @@ async def test_partial_approve_transitions_to_approved_with_snapshot(
     session: AsyncSession,
 ) -> None:
     item = await _seed_report_with_one_action_item(session)
-    service = InvestmentReportDecisionService(session)
-    await service.record(
+    await InvestmentReportDecisionService(session).record(
         RecordDecisionRequest(
             item_uuid=item.item_uuid,
             decision="partial_approve",
@@ -232,8 +183,44 @@ async def test_unknown_item_uuid_raises(session: AsyncSession) -> None:
     with pytest.raises(ValueError):
         await service.record(
             RecordDecisionRequest(
-                item_uuid=uuid.uuid4(),  # not seeded
+                item_uuid=uuid.uuid4(),
                 decision="approve",
                 actor="operator-test",
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_caller_supplied_idempotency_key_cross_item_collision_rejected(
+    session: AsyncSession,
+) -> None:
+    """Plan 2 hardening #1: a caller-supplied idempotency_key that collides
+    with an existing decision on a DIFFERENT item must raise, not silently
+    return the wrong row.
+    """
+    item_a = await _seed_report_with_one_action_item(
+        session, client_item_key="a-1", symbol="005930"
+    )
+    item_b = await _seed_report_with_one_action_item(
+        session, kst_date="2026-05-19", client_item_key="b-1", symbol="000660"
+    )
+    shared_key = f"shared-key-{uuid.uuid4()}"
+    service = InvestmentReportDecisionService(session)
+
+    await service.record(
+        RecordDecisionRequest(
+            item_uuid=item_a.item_uuid,
+            decision="approve",
+            actor="operator",
+            idempotency_key=shared_key,
+        )
+    )
+    with pytest.raises(ValueError, match="already used for a different item"):
+        await service.record(
+            RecordDecisionRequest(
+                item_uuid=item_b.item_uuid,
+                decision="approve",
+                actor="operator",
+                idempotency_key=shared_key,
             )
         )

--- a/tests/test_investment_reports_decisions.py
+++ b/tests/test_investment_reports_decisions.py
@@ -1,0 +1,239 @@
+"""ROB-265 Plan 2 — Decisions service tests."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.core.config import settings
+from app.models.base import Base
+from app.models.investment_reports import (
+    InvestmentReport,
+    InvestmentReportItem,
+    InvestmentReportItemDecision,
+    InvestmentWatchAlert,
+    InvestmentWatchEvent,
+)
+from app.schemas.investment_reports import (
+    IngestReportItem,
+    IngestReportRequest,
+    RecordDecisionRequest,
+)
+from app.services.investment_reports.decisions import (
+    InvestmentReportDecisionService,
+)
+from app.services.investment_reports.ingestion import (
+    InvestmentReportIngestionService,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+_ALL_TABLES = [
+    InvestmentReport.__table__,
+    InvestmentReportItem.__table__,
+    InvestmentReportItemDecision.__table__,
+    InvestmentWatchAlert.__table__,
+    InvestmentWatchEvent.__table__,
+]
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncSession:
+    engine = create_async_engine(settings.DATABASE_URL, future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            Base.metadata.create_all, tables=_ALL_TABLES, checkfirst=True
+        )
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with factory() as sess:
+            try:
+                yield sess
+            finally:
+                await sess.rollback()
+        async with factory() as cleanup:
+            for table in reversed(_ALL_TABLES):
+                await cleanup.execute(
+                    sa.text(
+                        f'TRUNCATE TABLE review."{table.name}" RESTART IDENTITY CASCADE'
+                    )
+                )
+            await cleanup.commit()
+    finally:
+        await engine.dispose()
+
+
+async def _seed_report_with_one_action_item(
+    session: AsyncSession, *, kst_date: str = "2026-05-18"
+) -> InvestmentReportItem:
+    ingest = InvestmentReportIngestionService(session)
+    report = await ingest.ingest(
+        IngestReportRequest(
+            report_type="kr_morning",
+            market="kr",
+            market_session="regular",
+            account_scope="kis_mock",
+            execution_mode="mock_preview",
+            created_by_profile="test",
+            title="t",
+            summary="s",
+            kst_date=kst_date,
+            items=[
+                IngestReportItem(
+                    item_kind="action",
+                    symbol="005930",
+                    side="buy",
+                    intent="buy_review",
+                    rationale="r",
+                )
+            ],
+        )
+    )
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(report.id)
+    return items[0]
+
+
+@pytest.mark.asyncio
+async def test_approve_records_decision_and_transitions_item(
+    session: AsyncSession,
+) -> None:
+    item = await _seed_report_with_one_action_item(session)
+    service = InvestmentReportDecisionService(session)
+
+    decision = await service.record(
+        RecordDecisionRequest(
+            item_uuid=item.item_uuid, decision="approve", actor="operator-test"
+        )
+    )
+    assert decision.decision == "approve"
+    repo = InvestmentReportsRepository(session)
+    refreshed = await repo.get_item_by_uuid(item.item_uuid)
+    assert refreshed is not None
+    assert refreshed.status == "approved"
+
+
+@pytest.mark.asyncio
+async def test_deny_transitions_item_to_denied(session: AsyncSession) -> None:
+    item = await _seed_report_with_one_action_item(session)
+    service = InvestmentReportDecisionService(session)
+    await service.record(
+        RecordDecisionRequest(
+            item_uuid=item.item_uuid, decision="deny", actor="operator-test"
+        )
+    )
+    repo = InvestmentReportsRepository(session)
+    refreshed = await repo.get_item_by_uuid(item.item_uuid)
+    assert refreshed.status == "denied"
+
+
+@pytest.mark.asyncio
+async def test_defer_transitions_item_to_deferred(session: AsyncSession) -> None:
+    item = await _seed_report_with_one_action_item(session)
+    service = InvestmentReportDecisionService(session)
+    await service.record(
+        RecordDecisionRequest(
+            item_uuid=item.item_uuid, decision="defer", actor="operator-test"
+        )
+    )
+    repo = InvestmentReportsRepository(session)
+    refreshed = await repo.get_item_by_uuid(item.item_uuid)
+    assert refreshed.status == "deferred"
+
+
+@pytest.mark.asyncio
+async def test_skip_leaves_item_status_unchanged(session: AsyncSession) -> None:
+    item = await _seed_report_with_one_action_item(session)
+    service = InvestmentReportDecisionService(session)
+    await service.record(
+        RecordDecisionRequest(
+            item_uuid=item.item_uuid, decision="skip", actor="operator-test"
+        )
+    )
+    repo = InvestmentReportsRepository(session)
+    refreshed = await repo.get_item_by_uuid(item.item_uuid)
+    # skip is audit-only — item stays proposed.
+    assert refreshed.status == "proposed"
+
+
+@pytest.mark.asyncio
+async def test_partial_approve_transitions_to_approved_with_snapshot(
+    session: AsyncSession,
+) -> None:
+    item = await _seed_report_with_one_action_item(session)
+    service = InvestmentReportDecisionService(session)
+    await service.record(
+        RecordDecisionRequest(
+            item_uuid=item.item_uuid,
+            decision="partial_approve",
+            actor="operator-test",
+            approved_payload_snapshot={"max_notional_krw": 100000},
+        )
+    )
+    repo = InvestmentReportsRepository(session)
+    refreshed = await repo.get_item_by_uuid(item.item_uuid)
+    assert refreshed.status == "approved"
+    decisions = await repo.list_decisions_for_item(item.id)
+    assert decisions[0].approved_payload_snapshot == {"max_notional_krw": 100000}
+
+
+@pytest.mark.asyncio
+async def test_record_is_idempotent_per_default_key(session: AsyncSession) -> None:
+    item = await _seed_report_with_one_action_item(session)
+    service = InvestmentReportDecisionService(session)
+    first = await service.record(
+        RecordDecisionRequest(
+            item_uuid=item.item_uuid, decision="approve", actor="operator-test"
+        )
+    )
+    second = await service.record(
+        RecordDecisionRequest(
+            item_uuid=item.item_uuid, decision="approve", actor="operator-test"
+        )
+    )
+    assert first.id == second.id
+    repo = InvestmentReportsRepository(session)
+    decisions = await repo.list_decisions_for_item(item.id)
+    assert len(decisions) == 1
+
+
+@pytest.mark.asyncio
+async def test_multiple_decisions_per_item_persist(session: AsyncSession) -> None:
+    """defer → approve produces two rows; final status reflects latest verb."""
+    item = await _seed_report_with_one_action_item(session)
+    service = InvestmentReportDecisionService(session)
+    await service.record(
+        RecordDecisionRequest(
+            item_uuid=item.item_uuid, decision="defer", actor="operator-test"
+        )
+    )
+    await service.record(
+        RecordDecisionRequest(
+            item_uuid=item.item_uuid, decision="approve", actor="operator-test"
+        )
+    )
+    repo = InvestmentReportsRepository(session)
+    decisions = await repo.list_decisions_for_item(item.id)
+    assert {d.decision for d in decisions} == {"defer", "approve"}
+    refreshed = await repo.get_item_by_uuid(item.item_uuid)
+    assert refreshed.status == "approved"
+
+
+@pytest.mark.asyncio
+async def test_unknown_item_uuid_raises(session: AsyncSession) -> None:
+    service = InvestmentReportDecisionService(session)
+    with pytest.raises(ValueError):
+        await service.record(
+            RecordDecisionRequest(
+                item_uuid=uuid.uuid4(),  # not seeded
+                decision="approve",
+                actor="operator-test",
+            )
+        )

--- a/tests/test_investment_reports_idempotency.py
+++ b/tests/test_investment_reports_idempotency.py
@@ -16,6 +16,8 @@ def test_report_key_is_stable() -> None:
         report_type="kr_morning",
         market="kr",
         market_session="regular",
+        account_scope="kis_mock",
+        execution_mode="mock_preview",
         kst_date="2026-05-18",
         generator_version="v1",
     )
@@ -23,21 +25,48 @@ def test_report_key_is_stable() -> None:
         report_type="kr_morning",
         market="kr",
         market_session="regular",
+        account_scope="kis_mock",
+        execution_mode="mock_preview",
         kst_date="2026-05-18",
         generator_version="v1",
     )
-    assert a == b == "report:kr_morning:kr:regular:2026-05-18:v1"
+    assert a == b == "report:kr_morning:kr:regular:kis_mock:mock_preview:2026-05-18:v1"
 
 
-def test_report_key_none_slot() -> None:
+def test_report_key_none_slot_for_optional_fields() -> None:
     key = report_key(
         report_type="crypto_morning",
         market="crypto",
         market_session=None,
+        account_scope=None,
+        execution_mode="advisory_only",
         kst_date="2026-05-18",
         generator_version="v1",
     )
-    assert key == "report:crypto_morning:crypto:_:2026-05-18:v1"
+    assert key == "report:crypto_morning:crypto:_:_:advisory_only:2026-05-18:v1"
+
+
+def test_report_key_distinguishes_account_scope() -> None:
+    """kis_mock vs kis_live for same date/session/generator must NOT collide."""
+    mock = report_key(
+        report_type="kr_morning",
+        market="kr",
+        market_session="regular",
+        account_scope="kis_mock",
+        execution_mode="mock_preview",
+        kst_date="2026-05-18",
+        generator_version="v1",
+    )
+    live = report_key(
+        report_type="kr_morning",
+        market="kr",
+        market_session="regular",
+        account_scope="kis_live",
+        execution_mode="advisory_only",
+        kst_date="2026-05-18",
+        generator_version="v1",
+    )
+    assert mock != live
 
 
 def test_canonical_hash_is_order_independent() -> None:
@@ -60,6 +89,7 @@ def test_canonical_hash_changes_on_value_change() -> None:
 def test_item_key_with_and_without_condition() -> None:
     with_cond = item_key(
         report_uuid="REPORT-UUID",
+        client_item_key="watch-1",
         item_kind="watch",
         symbol="005930",
         side=None,
@@ -68,6 +98,7 @@ def test_item_key_with_and_without_condition() -> None:
     )
     without_cond = item_key(
         report_uuid="REPORT-UUID",
+        client_item_key="action-1",
         item_kind="action",
         symbol="005930",
         side="buy",
@@ -75,14 +106,39 @@ def test_item_key_with_and_without_condition() -> None:
         watch_condition=None,
     )
     assert with_cond.startswith(
-        "item:report-uuid:watch:005930:_:trend_recovery_review:"
+        "item:report-uuid:watch-1:watch:005930:_:trend_recovery_review:"
     )
-    assert without_cond == "item:report-uuid:action:005930:buy:buy_review:_"
+    assert without_cond == ("item:report-uuid:action-1:action:005930:buy:buy_review:_")
+
+
+def test_item_key_client_item_key_distinguishes_same_natural_fields() -> None:
+    """Two items with identical natural fields but different client keys
+    must NOT collide — fixes the multi-risk / scoped-buy collision case."""
+    a = item_key(
+        report_uuid="R",
+        client_item_key="risk-1",
+        item_kind="risk",
+        symbol=None,
+        side=None,
+        intent="risk_review",
+        watch_condition=None,
+    )
+    b = item_key(
+        report_uuid="R",
+        client_item_key="risk-2",
+        item_kind="risk",
+        symbol=None,
+        side=None,
+        intent="risk_review",
+        watch_condition=None,
+    )
+    assert a != b
 
 
 def test_item_key_condition_change_changes_key() -> None:
     a = item_key(
         report_uuid="R",
+        client_item_key="watch-1",
         item_kind="watch",
         symbol="005930",
         side=None,
@@ -91,6 +147,7 @@ def test_item_key_condition_change_changes_key() -> None:
     )
     b = item_key(
         report_uuid="R",
+        client_item_key="watch-1",
         item_kind="watch",
         symbol="005930",
         side=None,

--- a/tests/test_investment_reports_ingestion.py
+++ b/tests/test_investment_reports_ingestion.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest

--- a/tests/test_investment_reports_ingestion.py
+++ b/tests/test_investment_reports_ingestion.py
@@ -1,0 +1,244 @@
+"""ROB-265 Plan 2 — Ingestion service tests."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.core.config import settings
+from app.models.base import Base
+from app.models.investment_reports import (
+    InvestmentReport,
+    InvestmentReportItem,
+    InvestmentReportItemDecision,
+    InvestmentWatchAlert,
+    InvestmentWatchEvent,
+)
+from app.schemas.investment_reports import (
+    IngestReportItem,
+    IngestReportRequest,
+    WatchConditionPayload,
+)
+from app.services.investment_reports.ingestion import (
+    InvestmentReportIngestionService,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+_ALL_TABLES = [
+    InvestmentReport.__table__,
+    InvestmentReportItem.__table__,
+    InvestmentReportItemDecision.__table__,
+    InvestmentWatchAlert.__table__,
+    InvestmentWatchEvent.__table__,
+]
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncSession:
+    engine = create_async_engine(settings.DATABASE_URL, future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            Base.metadata.create_all, tables=_ALL_TABLES, checkfirst=True
+        )
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with factory() as sess:
+            try:
+                yield sess
+            finally:
+                await sess.rollback()
+        async with factory() as cleanup:
+            for table in reversed(_ALL_TABLES):
+                await cleanup.execute(
+                    sa.text(
+                        f'TRUNCATE TABLE review."{table.name}" RESTART IDENTITY CASCADE'
+                    )
+                )
+            await cleanup.commit()
+    finally:
+        await engine.dispose()
+
+
+def _future(days: int = 7) -> datetime:
+    return datetime.now(UTC) + timedelta(days=days)
+
+
+def _base_request(**overrides) -> IngestReportRequest:
+    payload: dict = {
+        "report_type": "kr_morning",
+        "market": "kr",
+        "market_session": "regular",
+        "account_scope": "kis_mock",
+        "execution_mode": "mock_preview",
+        "created_by_profile": "test",
+        "title": "테스트",
+        "summary": "요약",
+        "kst_date": "2026-05-18",
+        "generator_version": "v1",
+    }
+    payload.update(overrides)
+    return IngestReportRequest(**payload)
+
+
+@pytest.mark.asyncio
+async def test_ingest_creates_report_with_items(session: AsyncSession) -> None:
+    service = InvestmentReportIngestionService(session)
+    request = _base_request(
+        items=[
+            IngestReportItem(
+                item_kind="action",
+                symbol="005930",
+                side="buy",
+                intent="buy_review",
+                rationale="r",
+            ),
+            IngestReportItem(
+                item_kind="watch",
+                symbol="000660",
+                intent="trend_recovery_review",
+                rationale="r",
+                watch_condition=WatchConditionPayload(
+                    metric="rsi", operator="below", threshold=30
+                ),
+                valid_until=_future(),
+            ),
+        ]
+    )
+    report = await service.ingest(request)
+    assert report.id is not None
+    assert report.report_uuid is not None
+
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(report.id)
+    assert len(items) == 2
+    kinds = {it.item_kind for it in items}
+    assert kinds == {"action", "watch"}
+
+
+@pytest.mark.asyncio
+async def test_ingest_is_idempotent_on_same_key(session: AsyncSession) -> None:
+    service = InvestmentReportIngestionService(session)
+    request = _base_request(
+        items=[
+            IngestReportItem(
+                item_kind="action",
+                symbol="005930",
+                side="buy",
+                intent="buy_review",
+                rationale="r",
+            )
+        ]
+    )
+
+    first = await service.ingest(request)
+    second = await service.ingest(request)
+
+    assert first.report_uuid == second.report_uuid
+    assert first.id == second.id
+
+    # No duplicate items.
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(first.id)
+    assert len(items) == 1
+
+
+@pytest.mark.asyncio
+async def test_different_kst_date_creates_distinct_report(
+    session: AsyncSession,
+) -> None:
+    service = InvestmentReportIngestionService(session)
+    a = await service.ingest(_base_request(kst_date="2026-05-18"))
+    b = await service.ingest(_base_request(kst_date="2026-05-19"))
+    assert a.id != b.id
+    assert a.report_uuid != b.report_uuid
+
+
+@pytest.mark.asyncio
+async def test_watch_condition_stored_as_jsonb(session: AsyncSession) -> None:
+    service = InvestmentReportIngestionService(session)
+    request = _base_request(
+        items=[
+            IngestReportItem(
+                item_kind="watch",
+                symbol="005930",
+                intent="trend_recovery_review",
+                rationale="r",
+                watch_condition=WatchConditionPayload(
+                    metric="rsi", operator="below", threshold=30
+                ),
+                valid_until=_future(),
+            )
+        ]
+    )
+    report = await service.ingest(request)
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(report.id)
+    assert items[0].watch_condition is not None
+    assert items[0].watch_condition["metric"] == "rsi"
+    # threshold_key defaulted from threshold via WatchConditionPayload validator
+    assert items[0].watch_condition["threshold_key"] == "30"
+
+
+@pytest.mark.asyncio
+async def test_ingest_advisory_only_invariant_at_schema(
+    session: AsyncSession,
+) -> None:
+    """kis_live + mock_preview is rejected before hitting the DB."""
+    with pytest.raises(Exception) as exc_info:
+        _base_request(account_scope="kis_live", execution_mode="mock_preview")
+    assert "advisory_only" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_ingest_kis_live_advisory_only_succeeds(
+    session: AsyncSession,
+) -> None:
+    service = InvestmentReportIngestionService(session)
+    report = await service.ingest(
+        _base_request(account_scope="kis_live", execution_mode="advisory_only")
+    )
+    assert report.account_scope == "kis_live"
+    assert report.execution_mode == "advisory_only"
+
+
+@pytest.mark.asyncio
+async def test_item_idempotency_key_is_deterministic(
+    session: AsyncSession,
+) -> None:
+    """Re-ingest with the same payload doesn't duplicate items."""
+    service = InvestmentReportIngestionService(session)
+    request = _base_request(
+        items=[
+            IngestReportItem(
+                item_kind="watch",
+                symbol="005930",
+                intent="trend_recovery_review",
+                rationale="r",
+                watch_condition=WatchConditionPayload(
+                    metric="rsi", operator="below", threshold=30
+                ),
+                valid_until=_future(),
+            )
+        ]
+    )
+    first = await service.ingest(request)
+    repo = InvestmentReportsRepository(session)
+    first_items = await repo.list_items_for_report(first.id)
+    assert len(first_items) == 1
+    first_item_idempotency = first_items[0].idempotency_key
+
+    # Re-ingest returns the same report; same idempotency key on items.
+    second = await service.ingest(request)
+    assert second.id == first.id
+    second_items = await repo.list_items_for_report(second.id)
+    assert len(second_items) == 1
+    assert second_items[0].idempotency_key == first_item_idempotency

--- a/tests/test_investment_reports_ingestion.py
+++ b/tests/test_investment_reports_ingestion.py
@@ -2,26 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
-
 import pytest
-import pytest_asyncio
-import sqlalchemy as sa
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
-from app.models.base import Base
-from app.models.investment_reports import (
-    InvestmentReport,
-    InvestmentReportItem,
-    InvestmentReportItemDecision,
-    InvestmentWatchAlert,
-    InvestmentWatchEvent,
-)
 from app.schemas.investment_reports import (
     IngestReportItem,
     IngestReportRequest,
@@ -31,44 +14,7 @@ from app.services.investment_reports.ingestion import (
     InvestmentReportIngestionService,
 )
 from app.services.investment_reports.repository import InvestmentReportsRepository
-
-_ALL_TABLES = [
-    InvestmentReport.__table__,
-    InvestmentReportItem.__table__,
-    InvestmentReportItemDecision.__table__,
-    InvestmentWatchAlert.__table__,
-    InvestmentWatchEvent.__table__,
-]
-
-
-@pytest_asyncio.fixture
-async def session() -> AsyncSession:
-    engine = create_async_engine(settings.DATABASE_URL, future=True)
-    async with engine.begin() as conn:
-        await conn.run_sync(
-            Base.metadata.create_all, tables=_ALL_TABLES, checkfirst=True
-        )
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    try:
-        async with factory() as sess:
-            try:
-                yield sess
-            finally:
-                await sess.rollback()
-        async with factory() as cleanup:
-            for table in reversed(_ALL_TABLES):
-                await cleanup.execute(
-                    sa.text(
-                        f'TRUNCATE TABLE review."{table.name}" RESTART IDENTITY CASCADE'
-                    )
-                )
-            await cleanup.commit()
-    finally:
-        await engine.dispose()
-
-
-def _future(days: int = 7) -> datetime:
-    return datetime.now(UTC) + timedelta(days=days)
+from tests._investment_reports_helpers import future_datetime
 
 
 def _base_request(**overrides) -> IngestReportRequest:
@@ -88,30 +34,39 @@ def _base_request(**overrides) -> IngestReportRequest:
     return IngestReportRequest(**payload)
 
 
+def _action_item(client_item_key: str = "action-1", **overrides) -> IngestReportItem:
+    kwargs: dict = {
+        "client_item_key": client_item_key,
+        "item_kind": "action",
+        "symbol": "005930",
+        "side": "buy",
+        "intent": "buy_review",
+        "rationale": "r",
+    }
+    kwargs.update(overrides)
+    return IngestReportItem(**kwargs)
+
+
+def _watch_item(client_item_key: str = "watch-1", **overrides) -> IngestReportItem:
+    kwargs: dict = {
+        "client_item_key": client_item_key,
+        "item_kind": "watch",
+        "symbol": "000660",
+        "intent": "trend_recovery_review",
+        "rationale": "r",
+        "watch_condition": WatchConditionPayload(
+            metric="rsi", operator="below", threshold=30
+        ),
+        "valid_until": future_datetime(),
+    }
+    kwargs.update(overrides)
+    return IngestReportItem(**kwargs)
+
+
 @pytest.mark.asyncio
 async def test_ingest_creates_report_with_items(session: AsyncSession) -> None:
     service = InvestmentReportIngestionService(session)
-    request = _base_request(
-        items=[
-            IngestReportItem(
-                item_kind="action",
-                symbol="005930",
-                side="buy",
-                intent="buy_review",
-                rationale="r",
-            ),
-            IngestReportItem(
-                item_kind="watch",
-                symbol="000660",
-                intent="trend_recovery_review",
-                rationale="r",
-                watch_condition=WatchConditionPayload(
-                    metric="rsi", operator="below", threshold=30
-                ),
-                valid_until=_future(),
-            ),
-        ]
-    )
+    request = _base_request(items=[_action_item(), _watch_item()])
     report = await service.ingest(request)
     assert report.id is not None
     assert report.report_uuid is not None
@@ -126,25 +81,13 @@ async def test_ingest_creates_report_with_items(session: AsyncSession) -> None:
 @pytest.mark.asyncio
 async def test_ingest_is_idempotent_on_same_key(session: AsyncSession) -> None:
     service = InvestmentReportIngestionService(session)
-    request = _base_request(
-        items=[
-            IngestReportItem(
-                item_kind="action",
-                symbol="005930",
-                side="buy",
-                intent="buy_review",
-                rationale="r",
-            )
-        ]
-    )
-
+    request = _base_request(items=[_action_item()])
     first = await service.ingest(request)
     second = await service.ingest(request)
 
     assert first.report_uuid == second.report_uuid
     assert first.id == second.id
 
-    # No duplicate items.
     repo = InvestmentReportsRepository(session)
     items = await repo.list_items_for_report(first.id)
     assert len(items) == 1
@@ -162,22 +105,25 @@ async def test_different_kst_date_creates_distinct_report(
 
 
 @pytest.mark.asyncio
+async def test_different_account_scope_creates_distinct_report(
+    session: AsyncSession,
+) -> None:
+    """Plan 2 hardening #4: kis_mock vs kis_live for the same date must NOT collide."""
+    service = InvestmentReportIngestionService(session)
+    mock = await service.ingest(
+        _base_request(account_scope="kis_mock", execution_mode="mock_preview")
+    )
+    live = await service.ingest(
+        _base_request(account_scope="kis_live", execution_mode="advisory_only")
+    )
+    assert mock.id != live.id
+    assert mock.report_uuid != live.report_uuid
+
+
+@pytest.mark.asyncio
 async def test_watch_condition_stored_as_jsonb(session: AsyncSession) -> None:
     service = InvestmentReportIngestionService(session)
-    request = _base_request(
-        items=[
-            IngestReportItem(
-                item_kind="watch",
-                symbol="005930",
-                intent="trend_recovery_review",
-                rationale="r",
-                watch_condition=WatchConditionPayload(
-                    metric="rsi", operator="below", threshold=30
-                ),
-                valid_until=_future(),
-            )
-        ]
-    )
+    request = _base_request(items=[_watch_item()])
     report = await service.ingest(request)
     repo = InvestmentReportsRepository(session)
     items = await repo.list_items_for_report(report.id)
@@ -215,29 +161,69 @@ async def test_item_idempotency_key_is_deterministic(
 ) -> None:
     """Re-ingest with the same payload doesn't duplicate items."""
     service = InvestmentReportIngestionService(session)
-    request = _base_request(
-        items=[
-            IngestReportItem(
-                item_kind="watch",
-                symbol="005930",
-                intent="trend_recovery_review",
-                rationale="r",
-                watch_condition=WatchConditionPayload(
-                    metric="rsi", operator="below", threshold=30
-                ),
-                valid_until=_future(),
-            )
-        ]
-    )
+    request = _base_request(items=[_watch_item()])
     first = await service.ingest(request)
     repo = InvestmentReportsRepository(session)
     first_items = await repo.list_items_for_report(first.id)
     assert len(first_items) == 1
     first_item_idempotency = first_items[0].idempotency_key
 
-    # Re-ingest returns the same report; same idempotency key on items.
     second = await service.ingest(request)
     assert second.id == first.id
     second_items = await repo.list_items_for_report(second.id)
     assert len(second_items) == 1
     assert second_items[0].idempotency_key == first_item_idempotency
+
+
+@pytest.mark.asyncio
+async def test_duplicate_natural_key_items_with_distinct_client_keys(
+    session: AsyncSession,
+) -> None:
+    """Plan 2 hardening #2: two items with identical natural fields but
+    distinct client_item_keys must produce two distinct rows.
+    """
+    service = InvestmentReportIngestionService(session)
+    request = _base_request(
+        items=[
+            # Same symbol, side, intent — distinguished only by client_item_key.
+            _action_item(client_item_key="buy-005930-tranche-1"),
+            _action_item(client_item_key="buy-005930-tranche-2"),
+        ]
+    )
+    report = await service.ingest(request)
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(report.id)
+    assert len(items) == 2
+    keys = {it.idempotency_key for it in items}
+    assert len(keys) == 2  # distinct idempotency keys
+
+
+@pytest.mark.asyncio
+async def test_multiple_risk_items_without_symbol_no_longer_collide(
+    session: AsyncSession,
+) -> None:
+    """Plan 2 hardening #2: pre-fix, multiple risk items would collide on
+    (kind=risk, symbol=None, side=None, intent=risk_review) — fixed by
+    client_item_key.
+    """
+    service = InvestmentReportIngestionService(session)
+
+    def _risk(key: str, rationale: str) -> IngestReportItem:
+        return IngestReportItem(
+            client_item_key=key,
+            item_kind="risk",
+            intent="risk_review",
+            rationale=rationale,
+        )
+
+    request = _base_request(
+        items=[
+            _risk("risk-fx", "FX 변동성 확대"),
+            _risk("risk-credit", "신용 스프레드 확대"),
+        ]
+    )
+    report = await service.ingest(request)
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(report.id)
+    assert len(items) == 2
+    assert {it.idempotency_key for it in items} != {None}

--- a/tests/test_investment_reports_query_service.py
+++ b/tests/test_investment_reports_query_service.py
@@ -1,0 +1,351 @@
+"""ROB-265 Plan 2 — Query service tests (list / latest / bundle / context)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.core.config import settings
+from app.models.base import Base
+from app.models.investment_reports import (
+    InvestmentReport,
+    InvestmentReportItem,
+    InvestmentReportItemDecision,
+    InvestmentWatchAlert,
+    InvestmentWatchEvent,
+)
+from app.schemas.investment_reports import (
+    ActivateWatchRequest,
+    IngestReportItem,
+    IngestReportRequest,
+    RecordDecisionRequest,
+    WatchConditionPayload,
+)
+from app.services.investment_reports.decisions import (
+    InvestmentReportDecisionService,
+)
+from app.services.investment_reports.ingestion import (
+    InvestmentReportIngestionService,
+)
+from app.services.investment_reports.query_service import (
+    InvestmentReportQueryService,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from app.services.investment_reports.watch_activation import WatchActivationService
+
+_ALL_TABLES = [
+    InvestmentReport.__table__,
+    InvestmentReportItem.__table__,
+    InvestmentReportItemDecision.__table__,
+    InvestmentWatchAlert.__table__,
+    InvestmentWatchEvent.__table__,
+]
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncSession:
+    engine = create_async_engine(settings.DATABASE_URL, future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            Base.metadata.create_all, tables=_ALL_TABLES, checkfirst=True
+        )
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with factory() as sess:
+            try:
+                yield sess
+            finally:
+                await sess.rollback()
+        async with factory() as cleanup:
+            for table in reversed(_ALL_TABLES):
+                await cleanup.execute(
+                    sa.text(
+                        f'TRUNCATE TABLE review."{table.name}" RESTART IDENTITY CASCADE'
+                    )
+                )
+            await cleanup.commit()
+    finally:
+        await engine.dispose()
+
+
+def _future(days: int = 7) -> datetime:
+    return datetime.now(UTC) + timedelta(days=days)
+
+
+def _request(*, kst_date: str, market: str = "kr", **overrides) -> IngestReportRequest:
+    payload: dict = {
+        "report_type": "kr_morning",
+        "market": market,
+        "market_session": "regular",
+        "account_scope": "kis_mock",
+        "execution_mode": "mock_preview",
+        "created_by_profile": "test",
+        "title": f"t-{kst_date}",
+        "summary": "s",
+        "kst_date": kst_date,
+    }
+    payload.update(overrides)
+    return IngestReportRequest(**payload)
+
+
+@pytest.mark.asyncio
+async def test_list_reports_orders_newest_first(session: AsyncSession) -> None:
+    ingest = InvestmentReportIngestionService(session)
+    await ingest.ingest(_request(kst_date="2026-05-16"))
+    await ingest.ingest(_request(kst_date="2026-05-17"))
+    last = await ingest.ingest(_request(kst_date="2026-05-18"))
+
+    query = InvestmentReportQueryService(session)
+    reports = await query.list_reports(market="kr")
+    assert len(reports) == 3
+    assert reports[0].id == last.id
+
+
+@pytest.mark.asyncio
+async def test_list_reports_filters(session: AsyncSession) -> None:
+    ingest = InvestmentReportIngestionService(session)
+    await ingest.ingest(_request(kst_date="2026-05-18", market="kr"))
+    await ingest.ingest(_request(kst_date="2026-05-18", market="us"))
+
+    query = InvestmentReportQueryService(session)
+    kr_only = await query.list_reports(market="kr")
+    assert len(kr_only) == 1
+    assert kr_only[0].market == "kr"
+
+
+@pytest.mark.asyncio
+async def test_latest_report_returns_none_when_empty(session: AsyncSession) -> None:
+    query = InvestmentReportQueryService(session)
+    assert await query.latest_report(market="kr") is None
+
+
+@pytest.mark.asyncio
+async def test_latest_report_returns_most_recent(session: AsyncSession) -> None:
+    ingest = InvestmentReportIngestionService(session)
+    await ingest.ingest(_request(kst_date="2026-05-16"))
+    expected = await ingest.ingest(_request(kst_date="2026-05-17"))
+    query = InvestmentReportQueryService(session)
+    latest = await query.latest_report(market="kr")
+    assert latest is not None
+    # Most recent insertion wins via (created_at DESC, id DESC).
+    assert latest.id == expected.id
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_returns_nested_shapes(session: AsyncSession) -> None:
+    ingest = InvestmentReportIngestionService(session)
+    report = await ingest.ingest(
+        _request(
+            kst_date="2026-05-18",
+            items=[
+                IngestReportItem(
+                    item_kind="action",
+                    symbol="005930",
+                    side="buy",
+                    intent="buy_review",
+                    rationale="r",
+                ),
+                IngestReportItem(
+                    item_kind="watch",
+                    symbol="000660",
+                    intent="trend_recovery_review",
+                    rationale="r",
+                    watch_condition=WatchConditionPayload(
+                        metric="rsi", operator="below", threshold=30
+                    ),
+                    valid_until=_future(),
+                ),
+            ],
+        )
+    )
+
+    # Drive a decision and a watch activation so the bundle contains both.
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(report.id)
+    watch_item = next(it for it in items if it.item_kind == "watch")
+    action_item = next(it for it in items if it.item_kind == "action")
+
+    decisions_svc = InvestmentReportDecisionService(session)
+    await decisions_svc.record(
+        RecordDecisionRequest(
+            item_uuid=action_item.item_uuid,
+            decision="approve",
+            actor="operator-test",
+        )
+    )
+    await decisions_svc.record(
+        RecordDecisionRequest(
+            item_uuid=watch_item.item_uuid,
+            decision="approve",
+            actor="operator-test",
+        )
+    )
+    await WatchActivationService(session).activate(
+        ActivateWatchRequest(item_uuid=watch_item.item_uuid, actor="operator-test")
+    )
+
+    query = InvestmentReportQueryService(session)
+    bundle = await query.get_bundle(report.report_uuid)
+    assert bundle is not None
+    assert bundle["report"].id == report.id
+    assert len(bundle["items"]) == 2
+    assert len(bundle["alerts"]) == 1
+    # decisions_by_item is keyed by item.id with at least one decision each
+    assert len(bundle["decisions_by_item"][action_item.id]) == 1
+    assert len(bundle["decisions_by_item"][watch_item.id]) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_returns_none_for_missing_report(
+    session: AsyncSession,
+) -> None:
+    query = InvestmentReportQueryService(session)
+    assert await query.get_bundle(uuid.uuid4()) is None
+
+
+@pytest.mark.asyncio
+async def test_previous_context_empty_when_no_prior(session: AsyncSession) -> None:
+    query = InvestmentReportQueryService(session)
+    ctx = await query.previous_report_context(market="kr")
+    assert ctx["prior_reports"] == []
+    assert ctx["unresolved_deferred_items"] == []
+    assert ctx["active_watches"] == []
+    assert ctx["triggered_events"] == []
+    assert ctx["recent_decisions"] == []
+
+
+@pytest.mark.asyncio
+async def test_previous_context_aggregates_across_prior_reports(
+    session: AsyncSession,
+) -> None:
+    ingest = InvestmentReportIngestionService(session)
+    decisions_svc = InvestmentReportDecisionService(session)
+    activation_svc = WatchActivationService(session)
+
+    # Two prior reports.
+    r1 = await ingest.ingest(
+        _request(
+            kst_date="2026-05-16",
+            items=[
+                IngestReportItem(
+                    item_kind="action",
+                    symbol="005930",
+                    side="buy",
+                    intent="buy_review",
+                    rationale="r",
+                ),
+                IngestReportItem(
+                    item_kind="watch",
+                    symbol="000660",
+                    intent="trend_recovery_review",
+                    rationale="r",
+                    watch_condition=WatchConditionPayload(
+                        metric="rsi", operator="below", threshold=30
+                    ),
+                    valid_until=_future(),
+                ),
+            ],
+        )
+    )
+    r2 = await ingest.ingest(
+        _request(
+            kst_date="2026-05-17",
+            items=[
+                IngestReportItem(
+                    item_kind="action",
+                    symbol="035420",
+                    side="buy",
+                    intent="buy_review",
+                    rationale="r",
+                )
+            ],
+        )
+    )
+
+    repo = InvestmentReportsRepository(session)
+    r1_items = await repo.list_items_for_report(r1.id)
+    r2_items = await repo.list_items_for_report(r2.id)
+    action_r1 = next(it for it in r1_items if it.item_kind == "action")
+    watch_r1 = next(it for it in r1_items if it.item_kind == "watch")
+    action_r2 = r2_items[0]
+
+    # action_r1 → deferred. watch_r1 → approve + activate. action_r2 → approve.
+    await decisions_svc.record(
+        RecordDecisionRequest(
+            item_uuid=action_r1.item_uuid, decision="defer", actor="op"
+        )
+    )
+    await decisions_svc.record(
+        RecordDecisionRequest(
+            item_uuid=watch_r1.item_uuid, decision="approve", actor="op"
+        )
+    )
+    await activation_svc.activate(
+        ActivateWatchRequest(item_uuid=watch_r1.item_uuid, actor="op")
+    )
+    await decisions_svc.record(
+        RecordDecisionRequest(
+            item_uuid=action_r2.item_uuid, decision="approve", actor="op"
+        )
+    )
+
+    # A "current" report we want context for.
+    r3 = await ingest.ingest(_request(kst_date="2026-05-18"))
+
+    query = InvestmentReportQueryService(session)
+    ctx = await query.previous_report_context(
+        market="kr",
+        exclude_report_uuid=r3.report_uuid,
+        n_prior=5,
+    )
+
+    prior_ids = {r.id for r in ctx["prior_reports"]}
+    assert prior_ids == {r1.id, r2.id}
+
+    deferred_ids = {it.id for it in ctx["unresolved_deferred_items"]}
+    assert deferred_ids == {action_r1.id}
+
+    assert len(ctx["active_watches"]) == 1
+    assert ctx["active_watches"][0].source_item_uuid == watch_r1.item_uuid
+
+    assert {d.decision for d in ctx["recent_decisions"]} >= {
+        "defer",
+        "approve",
+    }
+
+
+@pytest.mark.asyncio
+async def test_previous_context_excludes_named_report(
+    session: AsyncSession,
+) -> None:
+    ingest = InvestmentReportIngestionService(session)
+    r1 = await ingest.ingest(_request(kst_date="2026-05-17"))
+    r2 = await ingest.ingest(_request(kst_date="2026-05-18"))
+
+    query = InvestmentReportQueryService(session)
+    ctx = await query.previous_report_context(
+        market="kr", exclude_report_uuid=r2.report_uuid, n_prior=5
+    )
+    assert {r.id for r in ctx["prior_reports"]} == {r1.id}
+
+
+@pytest.mark.asyncio
+async def test_previous_context_respects_n_prior_limit(
+    session: AsyncSession,
+) -> None:
+    ingest = InvestmentReportIngestionService(session)
+    for date in ("2026-05-14", "2026-05-15", "2026-05-16", "2026-05-17"):
+        await ingest.ingest(_request(kst_date=date))
+
+    query = InvestmentReportQueryService(session)
+    ctx = await query.previous_report_context(market="kr", n_prior=2)
+    assert len(ctx["prior_reports"]) == 2

--- a/tests/test_investment_reports_query_service.py
+++ b/tests/test_investment_reports_query_service.py
@@ -3,26 +3,10 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime, timedelta
 
 import pytest
-import pytest_asyncio
-import sqlalchemy as sa
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
-from app.models.base import Base
-from app.models.investment_reports import (
-    InvestmentReport,
-    InvestmentReportItem,
-    InvestmentReportItemDecision,
-    InvestmentWatchAlert,
-    InvestmentWatchEvent,
-)
 from app.schemas.investment_reports import (
     ActivateWatchRequest,
     IngestReportItem,
@@ -41,44 +25,7 @@ from app.services.investment_reports.query_service import (
 )
 from app.services.investment_reports.repository import InvestmentReportsRepository
 from app.services.investment_reports.watch_activation import WatchActivationService
-
-_ALL_TABLES = [
-    InvestmentReport.__table__,
-    InvestmentReportItem.__table__,
-    InvestmentReportItemDecision.__table__,
-    InvestmentWatchAlert.__table__,
-    InvestmentWatchEvent.__table__,
-]
-
-
-@pytest_asyncio.fixture
-async def session() -> AsyncSession:
-    engine = create_async_engine(settings.DATABASE_URL, future=True)
-    async with engine.begin() as conn:
-        await conn.run_sync(
-            Base.metadata.create_all, tables=_ALL_TABLES, checkfirst=True
-        )
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    try:
-        async with factory() as sess:
-            try:
-                yield sess
-            finally:
-                await sess.rollback()
-        async with factory() as cleanup:
-            for table in reversed(_ALL_TABLES):
-                await cleanup.execute(
-                    sa.text(
-                        f'TRUNCATE TABLE review."{table.name}" RESTART IDENTITY CASCADE'
-                    )
-                )
-            await cleanup.commit()
-    finally:
-        await engine.dispose()
-
-
-def _future(days: int = 7) -> datetime:
-    return datetime.now(UTC) + timedelta(days=days)
+from tests._investment_reports_helpers import future_datetime
 
 
 def _request(*, kst_date: str, market: str = "kr", **overrides) -> IngestReportRequest:
@@ -95,6 +42,35 @@ def _request(*, kst_date: str, market: str = "kr", **overrides) -> IngestReportR
     }
     payload.update(overrides)
     return IngestReportRequest(**payload)
+
+
+def _action_item(
+    client_item_key: str = "action-1", symbol: str = "005930"
+) -> IngestReportItem:
+    return IngestReportItem(
+        client_item_key=client_item_key,
+        item_kind="action",
+        symbol=symbol,
+        side="buy",
+        intent="buy_review",
+        rationale="r",
+    )
+
+
+def _watch_item(
+    client_item_key: str = "watch-1", symbol: str = "000660"
+) -> IngestReportItem:
+    return IngestReportItem(
+        client_item_key=client_item_key,
+        item_kind="watch",
+        symbol=symbol,
+        intent="trend_recovery_review",
+        rationale="r",
+        watch_condition=WatchConditionPayload(
+            metric="rsi", operator="below", threshold=30
+        ),
+        valid_until=future_datetime(),
+    )
 
 
 @pytest.mark.asyncio
@@ -136,7 +112,6 @@ async def test_latest_report_returns_most_recent(session: AsyncSession) -> None:
     query = InvestmentReportQueryService(session)
     latest = await query.latest_report(market="kr")
     assert latest is not None
-    # Most recent insertion wins via (created_at DESC, id DESC).
     assert latest.id == expected.id
 
 
@@ -144,31 +119,9 @@ async def test_latest_report_returns_most_recent(session: AsyncSession) -> None:
 async def test_get_bundle_returns_nested_shapes(session: AsyncSession) -> None:
     ingest = InvestmentReportIngestionService(session)
     report = await ingest.ingest(
-        _request(
-            kst_date="2026-05-18",
-            items=[
-                IngestReportItem(
-                    item_kind="action",
-                    symbol="005930",
-                    side="buy",
-                    intent="buy_review",
-                    rationale="r",
-                ),
-                IngestReportItem(
-                    item_kind="watch",
-                    symbol="000660",
-                    intent="trend_recovery_review",
-                    rationale="r",
-                    watch_condition=WatchConditionPayload(
-                        metric="rsi", operator="below", threshold=30
-                    ),
-                    valid_until=_future(),
-                ),
-            ],
-        )
+        _request(kst_date="2026-05-18", items=[_action_item(), _watch_item()])
     )
 
-    # Drive a decision and a watch activation so the bundle contains both.
     repo = InvestmentReportsRepository(session)
     items = await repo.list_items_for_report(report.id)
     watch_item = next(it for it in items if it.item_kind == "watch")
@@ -199,7 +152,6 @@ async def test_get_bundle_returns_nested_shapes(session: AsyncSession) -> None:
     assert bundle["report"].id == report.id
     assert len(bundle["items"]) == 2
     assert len(bundle["alerts"]) == 1
-    # decisions_by_item is keyed by item.id with at least one decision each
     assert len(bundle["decisions_by_item"][action_item.id]) == 1
     assert len(bundle["decisions_by_item"][watch_item.id]) == 1
 
@@ -231,43 +183,19 @@ async def test_previous_context_aggregates_across_prior_reports(
     decisions_svc = InvestmentReportDecisionService(session)
     activation_svc = WatchActivationService(session)
 
-    # Two prior reports.
     r1 = await ingest.ingest(
         _request(
             kst_date="2026-05-16",
             items=[
-                IngestReportItem(
-                    item_kind="action",
-                    symbol="005930",
-                    side="buy",
-                    intent="buy_review",
-                    rationale="r",
-                ),
-                IngestReportItem(
-                    item_kind="watch",
-                    symbol="000660",
-                    intent="trend_recovery_review",
-                    rationale="r",
-                    watch_condition=WatchConditionPayload(
-                        metric="rsi", operator="below", threshold=30
-                    ),
-                    valid_until=_future(),
-                ),
+                _action_item(client_item_key="r1-action-1"),
+                _watch_item(client_item_key="r1-watch-1"),
             ],
         )
     )
     r2 = await ingest.ingest(
         _request(
             kst_date="2026-05-17",
-            items=[
-                IngestReportItem(
-                    item_kind="action",
-                    symbol="035420",
-                    side="buy",
-                    intent="buy_review",
-                    rationale="r",
-                )
-            ],
+            items=[_action_item(client_item_key="r2-action-1", symbol="035420")],
         )
     )
 
@@ -278,7 +206,6 @@ async def test_previous_context_aggregates_across_prior_reports(
     watch_r1 = next(it for it in r1_items if it.item_kind == "watch")
     action_r2 = r2_items[0]
 
-    # action_r1 → deferred. watch_r1 → approve + activate. action_r2 → approve.
     await decisions_svc.record(
         RecordDecisionRequest(
             item_uuid=action_r1.item_uuid, decision="defer", actor="op"
@@ -298,14 +225,11 @@ async def test_previous_context_aggregates_across_prior_reports(
         )
     )
 
-    # A "current" report we want context for.
     r3 = await ingest.ingest(_request(kst_date="2026-05-18"))
 
     query = InvestmentReportQueryService(session)
     ctx = await query.previous_report_context(
-        market="kr",
-        exclude_report_uuid=r3.report_uuid,
-        n_prior=5,
+        market="kr", exclude_report_uuid=r3.report_uuid, n_prior=5
     )
 
     prior_ids = {r.id for r in ctx["prior_reports"]}
@@ -317,10 +241,7 @@ async def test_previous_context_aggregates_across_prior_reports(
     assert len(ctx["active_watches"]) == 1
     assert ctx["active_watches"][0].source_item_uuid == watch_r1.item_uuid
 
-    assert {d.decision for d in ctx["recent_decisions"]} >= {
-        "defer",
-        "approve",
-    }
+    assert {d.decision for d in ctx["recent_decisions"]} >= {"defer", "approve"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_investment_reports_repository.py
+++ b/tests/test_investment_reports_repository.py
@@ -3,65 +3,16 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime, timedelta
 
 import pytest
-import pytest_asyncio
-import sqlalchemy as sa
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
-from app.models.base import Base
 from app.models.investment_reports import (
     InvestmentReport,
     InvestmentReportItem,
-    InvestmentReportItemDecision,
-    InvestmentWatchAlert,
-    InvestmentWatchEvent,
 )
 from app.services.investment_reports.repository import InvestmentReportsRepository
-
-_ALL_TABLES = [
-    InvestmentReport.__table__,
-    InvestmentReportItem.__table__,
-    InvestmentReportItemDecision.__table__,
-    InvestmentWatchAlert.__table__,
-    InvestmentWatchEvent.__table__,
-]
-
-
-@pytest_asyncio.fixture
-async def session() -> AsyncSession:
-    engine = create_async_engine(settings.DATABASE_URL, future=True)
-    async with engine.begin() as conn:
-        await conn.run_sync(
-            Base.metadata.create_all, tables=_ALL_TABLES, checkfirst=True
-        )
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    try:
-        async with factory() as sess:
-            try:
-                yield sess
-            finally:
-                await sess.rollback()
-        async with factory() as cleanup:
-            for table in reversed(_ALL_TABLES):
-                await cleanup.execute(
-                    sa.text(
-                        f'TRUNCATE TABLE review."{table.name}" RESTART IDENTITY CASCADE'
-                    )
-                )
-            await cleanup.commit()
-    finally:
-        await engine.dispose()
-
-
-def _future(days: int = 7) -> datetime:
-    return datetime.now(UTC) + timedelta(days=days)
+from tests._investment_reports_helpers import future_datetime
 
 
 async def _insert_report(
@@ -141,12 +92,10 @@ async def test_list_reports_filters_by_market_and_status(
 async def test_latest_report_returns_most_recent(session: AsyncSession) -> None:
     repo = InvestmentReportsRepository(session)
     await _insert_report(repo, market="kr")
-    second = await _insert_report(repo, market="kr")
+    await _insert_report(repo, market="kr")
     third = await _insert_report(repo, market="kr")
     latest = await repo.latest_report(market="kr")
     assert latest is not None
-    assert latest.id in {second.id, third.id}  # most recent two
-    # The very last inserted should be the latest.
     assert latest.id == third.id
 
 
@@ -209,7 +158,7 @@ async def test_alert_insert_and_active_listing(session: AsyncSession) -> None:
         intent="buy_review",
         action_mode="notify_only",
         rationale="r",
-        valid_until=_future(),
+        valid_until=future_datetime(),
     )
     actives = await repo.list_active_alerts(market="kr")
     assert any(a.id == alert.id for a in actives)
@@ -235,7 +184,7 @@ async def test_event_insert_and_list_for_alert(session: AsyncSession) -> None:
         intent="buy_review",
         action_mode="notify_only",
         rationale="r",
-        valid_until=_future(),
+        valid_until=future_datetime(),
     )
     event = await repo.insert_event(
         event_uuid=uuid.uuid4(),
@@ -284,7 +233,7 @@ async def test_list_alerts_for_source_reports(session: AsyncSession) -> None:
         intent="buy_review",
         action_mode="notify_only",
         rationale="r",
-        valid_until=_future(),
+        valid_until=future_datetime(),
     )
     await repo.insert_alert(
         alert_uuid=uuid.uuid4(),
@@ -301,7 +250,7 @@ async def test_list_alerts_for_source_reports(session: AsyncSession) -> None:
         intent="buy_review",
         action_mode="notify_only",
         rationale="r",
-        valid_until=_future(),
+        valid_until=future_datetime(),
     )
     only_report1 = await repo.list_alerts_for_source_reports([report1.report_uuid])
     assert len(only_report1) == 1

--- a/tests/test_investment_reports_repository.py
+++ b/tests/test_investment_reports_repository.py
@@ -1,0 +1,310 @@
+"""ROB-265 Plan 2 — Repository DAO tests."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.core.config import settings
+from app.models.base import Base
+from app.models.investment_reports import (
+    InvestmentReport,
+    InvestmentReportItem,
+    InvestmentReportItemDecision,
+    InvestmentWatchAlert,
+    InvestmentWatchEvent,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+_ALL_TABLES = [
+    InvestmentReport.__table__,
+    InvestmentReportItem.__table__,
+    InvestmentReportItemDecision.__table__,
+    InvestmentWatchAlert.__table__,
+    InvestmentWatchEvent.__table__,
+]
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncSession:
+    engine = create_async_engine(settings.DATABASE_URL, future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            Base.metadata.create_all, tables=_ALL_TABLES, checkfirst=True
+        )
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with factory() as sess:
+            try:
+                yield sess
+            finally:
+                await sess.rollback()
+        async with factory() as cleanup:
+            for table in reversed(_ALL_TABLES):
+                await cleanup.execute(
+                    sa.text(
+                        f'TRUNCATE TABLE review."{table.name}" RESTART IDENTITY CASCADE'
+                    )
+                )
+            await cleanup.commit()
+    finally:
+        await engine.dispose()
+
+
+def _future(days: int = 7) -> datetime:
+    return datetime.now(UTC) + timedelta(days=days)
+
+
+async def _insert_report(
+    repo: InvestmentReportsRepository, **overrides
+) -> InvestmentReport:
+    fields: dict = {
+        "report_uuid": uuid.uuid4(),
+        "idempotency_key": f"rk-{uuid.uuid4()}",
+        "report_type": "kr_morning",
+        "market": "kr",
+        "market_session": "regular",
+        "account_scope": "kis_mock",
+        "execution_mode": "mock_preview",
+        "created_by_profile": "test",
+        "title": "t",
+        "summary": "s",
+        "status": "draft",
+    }
+    fields.update(overrides)
+    return await repo.insert_report(**fields)
+
+
+async def _insert_item(
+    repo: InvestmentReportsRepository, report_id: int, **overrides
+) -> InvestmentReportItem:
+    fields: dict = {
+        "report_id": report_id,
+        "item_uuid": uuid.uuid4(),
+        "idempotency_key": f"ik-{uuid.uuid4()}",
+        "item_kind": "action",
+        "symbol": "005930",
+        "side": "buy",
+        "intent": "buy_review",
+        "target_kind": "asset",
+        "priority": 10,
+        "rationale": "r",
+    }
+    fields.update(overrides)
+    return await repo.insert_item(**fields)
+
+
+@pytest.mark.asyncio
+async def test_report_insert_and_get_by_uuid(session: AsyncSession) -> None:
+    repo = InvestmentReportsRepository(session)
+    row = await _insert_report(repo)
+    fetched = await repo.get_report_by_uuid(row.report_uuid)
+    assert fetched is not None
+    assert fetched.id == row.id
+
+
+@pytest.mark.asyncio
+async def test_report_get_by_idempotency_key(session: AsyncSession) -> None:
+    repo = InvestmentReportsRepository(session)
+    key = f"ik-{uuid.uuid4()}"
+    row = await _insert_report(repo, idempotency_key=key)
+    fetched = await repo.get_report_by_idempotency_key(key)
+    assert fetched is not None
+    assert fetched.id == row.id
+
+
+@pytest.mark.asyncio
+async def test_list_reports_filters_by_market_and_status(
+    session: AsyncSession,
+) -> None:
+    repo = InvestmentReportsRepository(session)
+    await _insert_report(repo, market="kr", status="draft")
+    await _insert_report(repo, market="us", status="draft")
+    await _insert_report(repo, market="kr", status="published")
+
+    kr_drafts = await repo.list_reports(market="kr", status="draft")
+    assert len(kr_drafts) == 1
+    assert kr_drafts[0].market == "kr"
+    assert kr_drafts[0].status == "draft"
+
+
+@pytest.mark.asyncio
+async def test_latest_report_returns_most_recent(session: AsyncSession) -> None:
+    repo = InvestmentReportsRepository(session)
+    await _insert_report(repo, market="kr")
+    second = await _insert_report(repo, market="kr")
+    third = await _insert_report(repo, market="kr")
+    latest = await repo.latest_report(market="kr")
+    assert latest is not None
+    assert latest.id in {second.id, third.id}  # most recent two
+    # The very last inserted should be the latest.
+    assert latest.id == third.id
+
+
+@pytest.mark.asyncio
+async def test_item_insert_and_list_for_report(session: AsyncSession) -> None:
+    repo = InvestmentReportsRepository(session)
+    report = await _insert_report(repo)
+    await _insert_item(repo, report.id)
+    await _insert_item(repo, report.id, symbol="000660")
+    items = await repo.list_items_for_report(report.id)
+    assert len(items) == 2
+    assert {it.symbol for it in items} == {"005930", "000660"}
+
+
+@pytest.mark.asyncio
+async def test_update_item_status(session: AsyncSession) -> None:
+    repo = InvestmentReportsRepository(session)
+    report = await _insert_report(repo)
+    item = await _insert_item(repo, report.id)
+    await repo.update_item_status(item.id, "approved")
+    await session.refresh(item)
+    assert item.status == "approved"
+
+
+@pytest.mark.asyncio
+async def test_decision_insert_and_lookup(session: AsyncSession) -> None:
+    repo = InvestmentReportsRepository(session)
+    report = await _insert_report(repo)
+    item = await _insert_item(repo, report.id)
+    key = f"dec-{uuid.uuid4()}"
+    decision = await repo.insert_decision(
+        item_id=item.id,
+        decision_uuid=uuid.uuid4(),
+        idempotency_key=key,
+        decision="approve",
+        actor="operator",
+    )
+    fetched = await repo.get_decision_by_idempotency_key(key)
+    assert fetched is not None
+    assert fetched.id == decision.id
+
+
+@pytest.mark.asyncio
+async def test_alert_insert_and_active_listing(session: AsyncSession) -> None:
+    repo = InvestmentReportsRepository(session)
+    report = await _insert_report(repo)
+    item = await _insert_item(repo, report.id)
+    alert = await repo.insert_alert(
+        alert_uuid=uuid.uuid4(),
+        idempotency_key=f"a-{uuid.uuid4()}",
+        source_report_uuid=report.report_uuid,
+        source_item_uuid=item.item_uuid,
+        market="kr",
+        target_kind="asset",
+        symbol="005930",
+        metric="price",
+        operator="below",
+        threshold=70000,
+        threshold_key="70000",
+        intent="buy_review",
+        action_mode="notify_only",
+        rationale="r",
+        valid_until=_future(),
+    )
+    actives = await repo.list_active_alerts(market="kr")
+    assert any(a.id == alert.id for a in actives)
+
+
+@pytest.mark.asyncio
+async def test_event_insert_and_list_for_alert(session: AsyncSession) -> None:
+    repo = InvestmentReportsRepository(session)
+    report = await _insert_report(repo)
+    item = await _insert_item(repo, report.id)
+    alert = await repo.insert_alert(
+        alert_uuid=uuid.uuid4(),
+        idempotency_key=f"a-{uuid.uuid4()}",
+        source_report_uuid=report.report_uuid,
+        source_item_uuid=item.item_uuid,
+        market="kr",
+        target_kind="asset",
+        symbol="005930",
+        metric="price",
+        operator="below",
+        threshold=70000,
+        threshold_key="70000",
+        intent="buy_review",
+        action_mode="notify_only",
+        rationale="r",
+        valid_until=_future(),
+    )
+    event = await repo.insert_event(
+        event_uuid=uuid.uuid4(),
+        idempotency_key=f"e-{uuid.uuid4()}",
+        alert_id=alert.id,
+        source_report_uuid=report.report_uuid,
+        source_item_uuid=item.item_uuid,
+        market="kr",
+        target_kind="asset",
+        symbol="005930",
+        metric="price",
+        operator="below",
+        threshold=70000,
+        threshold_key="70000",
+        intent="buy_review",
+        action_mode="notify_only",
+        current_value=69500,
+        outcome="notified",
+        correlation_id=str(uuid.uuid4()),
+        kst_date="2026-05-18",
+    )
+    events = await repo.list_events_for_alert(alert.id)
+    assert len(events) == 1
+    assert events[0].id == event.id
+
+
+@pytest.mark.asyncio
+async def test_list_alerts_for_source_reports(session: AsyncSession) -> None:
+    repo = InvestmentReportsRepository(session)
+    report1 = await _insert_report(repo)
+    report2 = await _insert_report(repo)
+    item1 = await _insert_item(repo, report1.id)
+    item2 = await _insert_item(repo, report2.id)
+    await repo.insert_alert(
+        alert_uuid=uuid.uuid4(),
+        idempotency_key=f"a1-{uuid.uuid4()}",
+        source_report_uuid=report1.report_uuid,
+        source_item_uuid=item1.item_uuid,
+        market="kr",
+        target_kind="asset",
+        symbol="005930",
+        metric="price",
+        operator="below",
+        threshold=70000,
+        threshold_key="70000",
+        intent="buy_review",
+        action_mode="notify_only",
+        rationale="r",
+        valid_until=_future(),
+    )
+    await repo.insert_alert(
+        alert_uuid=uuid.uuid4(),
+        idempotency_key=f"a2-{uuid.uuid4()}",
+        source_report_uuid=report2.report_uuid,
+        source_item_uuid=item2.item_uuid,
+        market="kr",
+        target_kind="asset",
+        symbol="000660",
+        metric="price",
+        operator="below",
+        threshold=60000,
+        threshold_key="60000",
+        intent="buy_review",
+        action_mode="notify_only",
+        rationale="r",
+        valid_until=_future(),
+    )
+    only_report1 = await repo.list_alerts_for_source_reports(
+        [report1.report_uuid]
+    )
+    assert len(only_report1) == 1
+    assert only_report1[0].symbol == "005930"

--- a/tests/test_investment_reports_repository.py
+++ b/tests/test_investment_reports_repository.py
@@ -303,8 +303,6 @@ async def test_list_alerts_for_source_reports(session: AsyncSession) -> None:
         rationale="r",
         valid_until=_future(),
     )
-    only_report1 = await repo.list_alerts_for_source_reports(
-        [report1.report_uuid]
-    )
+    only_report1 = await repo.list_alerts_for_source_reports([report1.report_uuid])
     assert len(only_report1) == 1
     assert only_report1[0].symbol == "005930"

--- a/tests/test_investment_reports_schemas.py
+++ b/tests/test_investment_reports_schemas.py
@@ -1,0 +1,139 @@
+"""ROB-265 Plan 2 — Pydantic schema validator tests.
+
+Schema-level rejection of invariants that the DB also enforces via CHECK.
+We want callers to get a clean ValidationError, not an IntegrityError.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.investment_reports import (
+    ActivateWatchRequest,
+    IngestReportItem,
+    IngestReportRequest,
+    RecordDecisionRequest,
+    WatchConditionPayload,
+)
+
+
+def _future(days: int = 7) -> datetime:
+    return datetime.now(UTC) + timedelta(days=days)
+
+
+def _base_report_kwargs(**overrides) -> dict:
+    kwargs: dict = {
+        "report_type": "kr_morning",
+        "market": "kr",
+        "market_session": "regular",
+        "account_scope": "kis_mock",
+        "execution_mode": "mock_preview",
+        "created_by_profile": "test",
+        "title": "테스트",
+        "summary": "요약",
+        "kst_date": "2026-05-18",
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def test_action_item_round_trip() -> None:
+    item = IngestReportItem(
+        item_kind="action",
+        symbol="005930",
+        side="buy",
+        intent="buy_review",
+        target_kind="asset",
+        rationale="r",
+    )
+    assert item.item_kind == "action"
+    assert item.watch_condition is None
+
+
+def test_watch_item_requires_watch_condition() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        IngestReportItem(
+            item_kind="watch",
+            symbol="005930",
+            intent="trend_recovery_review",
+            rationale="r",
+            valid_until=_future(),
+        )
+    assert "watch_condition" in str(exc_info.value)
+
+
+def test_watch_item_requires_valid_until() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        IngestReportItem(
+            item_kind="watch",
+            symbol="005930",
+            intent="trend_recovery_review",
+            rationale="r",
+            watch_condition=WatchConditionPayload(
+                metric="rsi", operator="below", threshold=30
+            ),
+        )
+    assert "valid_until" in str(exc_info.value)
+
+
+def test_watch_item_full_inserts() -> None:
+    item = IngestReportItem(
+        item_kind="watch",
+        symbol="005930",
+        intent="trend_recovery_review",
+        rationale="r",
+        watch_condition=WatchConditionPayload(
+            metric="rsi", operator="below", threshold=30
+        ),
+        valid_until=_future(),
+    )
+    assert item.watch_condition is not None
+    assert item.watch_condition.metric == "rsi"
+
+
+def test_kis_live_with_mock_preview_rejected() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        IngestReportRequest(
+            **_base_report_kwargs(
+                account_scope="kis_live", execution_mode="mock_preview"
+            )
+        )
+    assert "advisory_only" in str(exc_info.value)
+
+
+def test_nxt_session_with_mock_preview_rejected() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        IngestReportRequest(
+            **_base_report_kwargs(
+                market_session="nxt", execution_mode="mock_preview"
+            )
+        )
+    assert "advisory_only" in str(exc_info.value)
+
+
+def test_kis_live_with_advisory_only_allowed() -> None:
+    req = IngestReportRequest(
+        **_base_report_kwargs(
+            account_scope="kis_live", execution_mode="advisory_only"
+        )
+    )
+    assert req.account_scope == "kis_live"
+
+
+def test_decision_request_minimal() -> None:
+    req = RecordDecisionRequest(
+        item_uuid=uuid.uuid4(),
+        decision="approve",
+        actor="operator-test",
+    )
+    assert req.decision == "approve"
+    assert req.idempotency_key is None
+
+
+def test_activate_watch_request_minimal() -> None:
+    req = ActivateWatchRequest(item_uuid=uuid.uuid4(), actor="operator-test")
+    assert req.idempotency_key is None

--- a/tests/test_investment_reports_schemas.py
+++ b/tests/test_investment_reports_schemas.py
@@ -7,7 +7,6 @@ We want callers to get a clean ValidationError, not an IntegrityError.
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime, timedelta
 
 import pytest
 from pydantic import ValidationError
@@ -19,10 +18,7 @@ from app.schemas.investment_reports import (
     RecordDecisionRequest,
     WatchConditionPayload,
 )
-
-
-def _future(days: int = 7) -> datetime:
-    return datetime.now(UTC) + timedelta(days=days)
+from tests._investment_reports_helpers import future_datetime
 
 
 def _base_report_kwargs(**overrides) -> dict:
@@ -41,27 +37,55 @@ def _base_report_kwargs(**overrides) -> dict:
     return kwargs
 
 
+def _base_item_kwargs(**overrides) -> dict:
+    kwargs: dict = {
+        "client_item_key": "action-1",
+        "item_kind": "action",
+        "symbol": "005930",
+        "side": "buy",
+        "intent": "buy_review",
+        "rationale": "r",
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
 def test_action_item_round_trip() -> None:
-    item = IngestReportItem(
-        item_kind="action",
-        symbol="005930",
-        side="buy",
-        intent="buy_review",
-        target_kind="asset",
-        rationale="r",
-    )
+    item = IngestReportItem(**_base_item_kwargs())
     assert item.item_kind == "action"
+    assert item.client_item_key == "action-1"
     assert item.watch_condition is None
+
+
+def test_item_requires_client_item_key() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        IngestReportItem(
+            item_kind="action",
+            symbol="005930",
+            side="buy",
+            intent="buy_review",
+            rationale="r",
+        )
+    assert "client_item_key" in str(exc_info.value)
+
+
+def test_item_rejects_empty_client_item_key() -> None:
+    with pytest.raises(ValidationError):
+        IngestReportItem(
+            **_base_item_kwargs(client_item_key=""),
+        )
 
 
 def test_watch_item_requires_watch_condition() -> None:
     with pytest.raises(ValidationError) as exc_info:
         IngestReportItem(
-            item_kind="watch",
-            symbol="005930",
-            intent="trend_recovery_review",
-            rationale="r",
-            valid_until=_future(),
+            **_base_item_kwargs(
+                client_item_key="watch-1",
+                item_kind="watch",
+                intent="trend_recovery_review",
+                side=None,
+                valid_until=future_datetime(),
+            )
         )
     assert "watch_condition" in str(exc_info.value)
 
@@ -69,27 +93,31 @@ def test_watch_item_requires_watch_condition() -> None:
 def test_watch_item_requires_valid_until() -> None:
     with pytest.raises(ValidationError) as exc_info:
         IngestReportItem(
-            item_kind="watch",
-            symbol="005930",
-            intent="trend_recovery_review",
-            rationale="r",
-            watch_condition=WatchConditionPayload(
-                metric="rsi", operator="below", threshold=30
-            ),
+            **_base_item_kwargs(
+                client_item_key="watch-1",
+                item_kind="watch",
+                intent="trend_recovery_review",
+                side=None,
+                watch_condition=WatchConditionPayload(
+                    metric="rsi", operator="below", threshold=30
+                ),
+            )
         )
     assert "valid_until" in str(exc_info.value)
 
 
 def test_watch_item_full_inserts() -> None:
     item = IngestReportItem(
-        item_kind="watch",
-        symbol="005930",
-        intent="trend_recovery_review",
-        rationale="r",
-        watch_condition=WatchConditionPayload(
-            metric="rsi", operator="below", threshold=30
-        ),
-        valid_until=_future(),
+        **_base_item_kwargs(
+            client_item_key="watch-1",
+            item_kind="watch",
+            intent="trend_recovery_review",
+            side=None,
+            watch_condition=WatchConditionPayload(
+                metric="rsi", operator="below", threshold=30
+            ),
+            valid_until=future_datetime(),
+        )
     )
     assert item.watch_condition is not None
     assert item.watch_condition.metric == "rsi"
@@ -128,6 +156,38 @@ def test_decision_request_minimal() -> None:
     )
     assert req.decision == "approve"
     assert req.idempotency_key is None
+
+
+def test_partial_approve_requires_non_empty_snapshot() -> None:
+    """partial_approve without scoped payload is indistinguishable from full approve."""
+    with pytest.raises(ValidationError) as exc_info:
+        RecordDecisionRequest(
+            item_uuid=uuid.uuid4(),
+            decision="partial_approve",
+            actor="operator-test",
+        )
+    assert "approved_payload_snapshot" in str(exc_info.value)
+
+
+def test_partial_approve_rejects_empty_snapshot_dict() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        RecordDecisionRequest(
+            item_uuid=uuid.uuid4(),
+            decision="partial_approve",
+            actor="operator-test",
+            approved_payload_snapshot={},
+        )
+    assert "approved_payload_snapshot" in str(exc_info.value)
+
+
+def test_partial_approve_with_snapshot_allowed() -> None:
+    req = RecordDecisionRequest(
+        item_uuid=uuid.uuid4(),
+        decision="partial_approve",
+        actor="operator-test",
+        approved_payload_snapshot={"max_notional_krw": 100000},
+    )
+    assert req.decision == "partial_approve"
 
 
 def test_activate_watch_request_minimal() -> None:

--- a/tests/test_investment_reports_schemas.py
+++ b/tests/test_investment_reports_schemas.py
@@ -108,18 +108,14 @@ def test_kis_live_with_mock_preview_rejected() -> None:
 def test_nxt_session_with_mock_preview_rejected() -> None:
     with pytest.raises(ValidationError) as exc_info:
         IngestReportRequest(
-            **_base_report_kwargs(
-                market_session="nxt", execution_mode="mock_preview"
-            )
+            **_base_report_kwargs(market_session="nxt", execution_mode="mock_preview")
         )
     assert "advisory_only" in str(exc_info.value)
 
 
 def test_kis_live_with_advisory_only_allowed() -> None:
     req = IngestReportRequest(
-        **_base_report_kwargs(
-            account_scope="kis_live", execution_mode="advisory_only"
-        )
+        **_base_report_kwargs(account_scope="kis_live", execution_mode="advisory_only")
     )
     assert req.account_scope == "kis_live"
 

--- a/tests/test_investment_reports_watch_activation.py
+++ b/tests/test_investment_reports_watch_activation.py
@@ -1,0 +1,288 @@
+"""ROB-265 Plan 2 — Watch activation service tests."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+import pytest_asyncio
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.core.config import settings
+from app.models.base import Base
+from app.models.investment_reports import (
+    InvestmentReport,
+    InvestmentReportItem,
+    InvestmentReportItemDecision,
+    InvestmentWatchAlert,
+    InvestmentWatchEvent,
+)
+from app.schemas.investment_reports import (
+    ActivateWatchRequest,
+    IngestReportItem,
+    IngestReportRequest,
+    RecordDecisionRequest,
+    WatchConditionPayload,
+)
+from app.services.investment_reports.decisions import (
+    InvestmentReportDecisionService,
+)
+from app.services.investment_reports.ingestion import (
+    InvestmentReportIngestionService,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from app.services.investment_reports.watch_activation import WatchActivationService
+
+_ALL_TABLES = [
+    InvestmentReport.__table__,
+    InvestmentReportItem.__table__,
+    InvestmentReportItemDecision.__table__,
+    InvestmentWatchAlert.__table__,
+    InvestmentWatchEvent.__table__,
+]
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncSession:
+    engine = create_async_engine(settings.DATABASE_URL, future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            Base.metadata.create_all, tables=_ALL_TABLES, checkfirst=True
+        )
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with factory() as sess:
+            try:
+                yield sess
+            finally:
+                await sess.rollback()
+        async with factory() as cleanup:
+            for table in reversed(_ALL_TABLES):
+                await cleanup.execute(
+                    sa.text(
+                        f'TRUNCATE TABLE review."{table.name}" RESTART IDENTITY CASCADE'
+                    )
+                )
+            await cleanup.commit()
+    finally:
+        await engine.dispose()
+
+
+def _future(days: int = 7) -> datetime:
+    return datetime.now(UTC) + timedelta(days=days)
+
+
+async def _seed_approved_watch_item(
+    session: AsyncSession,
+) -> InvestmentReportItem:
+    ingest = InvestmentReportIngestionService(session)
+    report = await ingest.ingest(
+        IngestReportRequest(
+            report_type="kr_morning",
+            market="kr",
+            market_session="regular",
+            account_scope="kis_mock",
+            execution_mode="mock_preview",
+            created_by_profile="test",
+            title="t",
+            summary="s",
+            kst_date="2026-05-18",
+            items=[
+                IngestReportItem(
+                    item_kind="watch",
+                    symbol="005930",
+                    intent="trend_recovery_review",
+                    rationale="r",
+                    watch_condition=WatchConditionPayload(
+                        metric="rsi", operator="below", threshold=Decimal("30")
+                    ),
+                    valid_until=_future(),
+                )
+            ],
+        )
+    )
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(report.id)
+    watch_item = items[0]
+
+    # Approve it so activation is allowed.
+    decisions = InvestmentReportDecisionService(session)
+    await decisions.record(
+        RecordDecisionRequest(
+            item_uuid=watch_item.item_uuid,
+            decision="approve",
+            actor="operator-test",
+        )
+    )
+    refreshed = await repo.get_item_by_uuid(watch_item.item_uuid)
+    assert refreshed is not None
+    assert refreshed.status == "approved"
+    return refreshed
+
+
+@pytest.mark.asyncio
+async def test_activate_copies_snapshot_and_transitions_item(
+    session: AsyncSession,
+) -> None:
+    item = await _seed_approved_watch_item(session)
+    service = WatchActivationService(session)
+    alert = await service.activate(
+        ActivateWatchRequest(item_uuid=item.item_uuid, actor="operator-test")
+    )
+    assert alert.market == "kr"
+    assert alert.target_kind == "asset"
+    assert alert.symbol == "005930"
+    assert alert.metric == "rsi"
+    assert alert.operator == "below"
+    assert Decimal(alert.threshold) == Decimal("30")
+    assert alert.threshold_key == "30"
+    assert alert.intent == "trend_recovery_review"
+    assert alert.action_mode == "notify_only"
+    assert alert.status == "active"
+    assert alert.source_item_uuid == item.item_uuid
+
+    repo = InvestmentReportsRepository(session)
+    refreshed = await repo.get_item_by_uuid(item.item_uuid)
+    assert refreshed.status == "activated"
+
+
+@pytest.mark.asyncio
+async def test_activate_is_idempotent_per_source_item(
+    session: AsyncSession,
+) -> None:
+    item = await _seed_approved_watch_item(session)
+    service = WatchActivationService(session)
+    first = await service.activate(
+        ActivateWatchRequest(item_uuid=item.item_uuid, actor="operator-test")
+    )
+    second = await service.activate(
+        ActivateWatchRequest(item_uuid=item.item_uuid, actor="operator-test")
+    )
+    assert first.alert_uuid == second.alert_uuid
+    assert first.id == second.id
+
+
+@pytest.mark.asyncio
+async def test_activate_rejects_non_watch_item(session: AsyncSession) -> None:
+    ingest = InvestmentReportIngestionService(session)
+    report = await ingest.ingest(
+        IngestReportRequest(
+            report_type="kr_morning",
+            market="kr",
+            account_scope="kis_mock",
+            execution_mode="mock_preview",
+            created_by_profile="t",
+            title="t",
+            summary="s",
+            kst_date="2026-05-18",
+            items=[
+                IngestReportItem(
+                    item_kind="action",
+                    symbol="005930",
+                    side="buy",
+                    intent="buy_review",
+                    rationale="r",
+                )
+            ],
+        )
+    )
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(report.id)
+    action_item = items[0]
+    # Approve so the only remaining failure is item_kind != watch.
+    await InvestmentReportDecisionService(session).record(
+        RecordDecisionRequest(
+            item_uuid=action_item.item_uuid,
+            decision="approve",
+            actor="operator-test",
+        )
+    )
+    service = WatchActivationService(session)
+    with pytest.raises(ValueError, match="only watch items"):
+        await service.activate(
+            ActivateWatchRequest(
+                item_uuid=action_item.item_uuid, actor="operator-test"
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_activate_rejects_unapproved_watch(session: AsyncSession) -> None:
+    ingest = InvestmentReportIngestionService(session)
+    report = await ingest.ingest(
+        IngestReportRequest(
+            report_type="kr_morning",
+            market="kr",
+            account_scope="kis_mock",
+            execution_mode="mock_preview",
+            created_by_profile="t",
+            title="t",
+            summary="s",
+            kst_date="2026-05-18",
+            items=[
+                IngestReportItem(
+                    item_kind="watch",
+                    symbol="005930",
+                    intent="trend_recovery_review",
+                    rationale="r",
+                    watch_condition=WatchConditionPayload(
+                        metric="rsi", operator="below", threshold=30
+                    ),
+                    valid_until=_future(),
+                )
+            ],
+        )
+    )
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(report.id)
+    watch_item = items[0]
+    # Skip approval — status stays 'proposed'.
+    service = WatchActivationService(session)
+    with pytest.raises(ValueError, match="only approved items"):
+        await service.activate(
+            ActivateWatchRequest(
+                item_uuid=watch_item.item_uuid, actor="operator-test"
+            )
+        )
+
+
+@pytest.mark.asyncio
+async def test_activate_rejects_unknown_item(session: AsyncSession) -> None:
+    service = WatchActivationService(session)
+    with pytest.raises(ValueError, match="item not found"):
+        await service.activate(
+            ActivateWatchRequest(item_uuid=uuid.uuid4(), actor="operator-test")
+        )
+
+
+@pytest.mark.asyncio
+async def test_alert_snapshot_does_not_mutate_when_item_changes(
+    session: AsyncSession,
+) -> None:
+    """Once activated, mutating the source item does not change the alert."""
+    item = await _seed_approved_watch_item(session)
+    service = WatchActivationService(session)
+    alert = await service.activate(
+        ActivateWatchRequest(item_uuid=item.item_uuid, actor="operator-test")
+    )
+    original_rationale = alert.rationale
+    alert_key = alert.idempotency_key
+
+    repo = InvestmentReportsRepository(session)
+    await session.execute(
+        sa.update(InvestmentReportItem)
+        .where(InvestmentReportItem.id == item.id)
+        .values(rationale="something else entirely")
+    )
+    await session.commit()
+
+    refreshed_alert = await repo.get_alert_by_idempotency_key(alert_key)
+    assert refreshed_alert is not None
+    assert refreshed_alert.rationale == original_rationale

--- a/tests/test_investment_reports_watch_activation.py
+++ b/tests/test_investment_reports_watch_activation.py
@@ -207,9 +207,7 @@ async def test_activate_rejects_non_watch_item(session: AsyncSession) -> None:
     service = WatchActivationService(session)
     with pytest.raises(ValueError, match="only watch items"):
         await service.activate(
-            ActivateWatchRequest(
-                item_uuid=action_item.item_uuid, actor="operator-test"
-            )
+            ActivateWatchRequest(item_uuid=action_item.item_uuid, actor="operator-test")
         )
 
 
@@ -247,9 +245,7 @@ async def test_activate_rejects_unapproved_watch(session: AsyncSession) -> None:
     service = WatchActivationService(session)
     with pytest.raises(ValueError, match="only approved items"):
         await service.activate(
-            ActivateWatchRequest(
-                item_uuid=watch_item.item_uuid, actor="operator-test"
-            )
+            ActivateWatchRequest(item_uuid=watch_item.item_uuid, actor="operator-test")
         )
 
 

--- a/tests/test_investment_reports_watch_activation.py
+++ b/tests/test_investment_reports_watch_activation.py
@@ -3,27 +3,13 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import pytest
-import pytest_asyncio
 import sqlalchemy as sa
-from sqlalchemy.ext.asyncio import (
-    AsyncSession,
-    async_sessionmaker,
-    create_async_engine,
-)
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.config import settings
-from app.models.base import Base
-from app.models.investment_reports import (
-    InvestmentReport,
-    InvestmentReportItem,
-    InvestmentReportItemDecision,
-    InvestmentWatchAlert,
-    InvestmentWatchEvent,
-)
+from app.models.investment_reports import InvestmentReportItem
 from app.schemas.investment_reports import (
     ActivateWatchRequest,
     IngestReportItem,
@@ -39,48 +25,15 @@ from app.services.investment_reports.ingestion import (
 )
 from app.services.investment_reports.repository import InvestmentReportsRepository
 from app.services.investment_reports.watch_activation import WatchActivationService
-
-_ALL_TABLES = [
-    InvestmentReport.__table__,
-    InvestmentReportItem.__table__,
-    InvestmentReportItemDecision.__table__,
-    InvestmentWatchAlert.__table__,
-    InvestmentWatchEvent.__table__,
-]
-
-
-@pytest_asyncio.fixture
-async def session() -> AsyncSession:
-    engine = create_async_engine(settings.DATABASE_URL, future=True)
-    async with engine.begin() as conn:
-        await conn.run_sync(
-            Base.metadata.create_all, tables=_ALL_TABLES, checkfirst=True
-        )
-    factory = async_sessionmaker(engine, expire_on_commit=False)
-    try:
-        async with factory() as sess:
-            try:
-                yield sess
-            finally:
-                await sess.rollback()
-        async with factory() as cleanup:
-            for table in reversed(_ALL_TABLES):
-                await cleanup.execute(
-                    sa.text(
-                        f'TRUNCATE TABLE review."{table.name}" RESTART IDENTITY CASCADE'
-                    )
-                )
-            await cleanup.commit()
-    finally:
-        await engine.dispose()
-
-
-def _future(days: int = 7) -> datetime:
-    return datetime.now(UTC) + timedelta(days=days)
+from tests._investment_reports_helpers import future_datetime
 
 
 async def _seed_approved_watch_item(
     session: AsyncSession,
+    *,
+    kst_date: str = "2026-05-18",
+    client_item_key: str = "watch-1",
+    symbol: str = "005930",
 ) -> InvestmentReportItem:
     ingest = InvestmentReportIngestionService(session)
     report = await ingest.ingest(
@@ -93,17 +46,18 @@ async def _seed_approved_watch_item(
             created_by_profile="test",
             title="t",
             summary="s",
-            kst_date="2026-05-18",
+            kst_date=kst_date,
             items=[
                 IngestReportItem(
+                    client_item_key=client_item_key,
                     item_kind="watch",
-                    symbol="005930",
+                    symbol=symbol,
                     intent="trend_recovery_review",
                     rationale="r",
                     watch_condition=WatchConditionPayload(
                         metric="rsi", operator="below", threshold=Decimal("30")
                     ),
-                    valid_until=_future(),
+                    valid_until=future_datetime(),
                 )
             ],
         )
@@ -112,9 +66,7 @@ async def _seed_approved_watch_item(
     items = await repo.list_items_for_report(report.id)
     watch_item = items[0]
 
-    # Approve it so activation is allowed.
-    decisions = InvestmentReportDecisionService(session)
-    await decisions.record(
+    await InvestmentReportDecisionService(session).record(
         RecordDecisionRequest(
             item_uuid=watch_item.item_uuid,
             decision="approve",
@@ -132,8 +84,7 @@ async def test_activate_copies_snapshot_and_transitions_item(
     session: AsyncSession,
 ) -> None:
     item = await _seed_approved_watch_item(session)
-    service = WatchActivationService(session)
-    alert = await service.activate(
+    alert = await WatchActivationService(session).activate(
         ActivateWatchRequest(item_uuid=item.item_uuid, actor="operator-test")
     )
     assert alert.market == "kr"
@@ -184,6 +135,7 @@ async def test_activate_rejects_non_watch_item(session: AsyncSession) -> None:
             kst_date="2026-05-18",
             items=[
                 IngestReportItem(
+                    client_item_key="action-1",
                     item_kind="action",
                     symbol="005930",
                     side="buy",
@@ -196,7 +148,6 @@ async def test_activate_rejects_non_watch_item(session: AsyncSession) -> None:
     repo = InvestmentReportsRepository(session)
     items = await repo.list_items_for_report(report.id)
     action_item = items[0]
-    # Approve so the only remaining failure is item_kind != watch.
     await InvestmentReportDecisionService(session).record(
         RecordDecisionRequest(
             item_uuid=action_item.item_uuid,
@@ -204,9 +155,8 @@ async def test_activate_rejects_non_watch_item(session: AsyncSession) -> None:
             actor="operator-test",
         )
     )
-    service = WatchActivationService(session)
     with pytest.raises(ValueError, match="only watch items"):
-        await service.activate(
+        await WatchActivationService(session).activate(
             ActivateWatchRequest(item_uuid=action_item.item_uuid, actor="operator-test")
         )
 
@@ -226,6 +176,7 @@ async def test_activate_rejects_unapproved_watch(session: AsyncSession) -> None:
             kst_date="2026-05-18",
             items=[
                 IngestReportItem(
+                    client_item_key="watch-1",
                     item_kind="watch",
                     symbol="005930",
                     intent="trend_recovery_review",
@@ -233,7 +184,7 @@ async def test_activate_rejects_unapproved_watch(session: AsyncSession) -> None:
                     watch_condition=WatchConditionPayload(
                         metric="rsi", operator="below", threshold=30
                     ),
-                    valid_until=_future(),
+                    valid_until=future_datetime(),
                 )
             ],
         )
@@ -241,19 +192,16 @@ async def test_activate_rejects_unapproved_watch(session: AsyncSession) -> None:
     repo = InvestmentReportsRepository(session)
     items = await repo.list_items_for_report(report.id)
     watch_item = items[0]
-    # Skip approval — status stays 'proposed'.
-    service = WatchActivationService(session)
     with pytest.raises(ValueError, match="only approved items"):
-        await service.activate(
+        await WatchActivationService(session).activate(
             ActivateWatchRequest(item_uuid=watch_item.item_uuid, actor="operator-test")
         )
 
 
 @pytest.mark.asyncio
 async def test_activate_rejects_unknown_item(session: AsyncSession) -> None:
-    service = WatchActivationService(session)
     with pytest.raises(ValueError, match="item not found"):
-        await service.activate(
+        await WatchActivationService(session).activate(
             ActivateWatchRequest(item_uuid=uuid.uuid4(), actor="operator-test")
         )
 
@@ -264,8 +212,7 @@ async def test_alert_snapshot_does_not_mutate_when_item_changes(
 ) -> None:
     """Once activated, mutating the source item does not change the alert."""
     item = await _seed_approved_watch_item(session)
-    service = WatchActivationService(session)
-    alert = await service.activate(
+    alert = await WatchActivationService(session).activate(
         ActivateWatchRequest(item_uuid=item.item_uuid, actor="operator-test")
     )
     original_rationale = alert.rationale
@@ -282,3 +229,37 @@ async def test_alert_snapshot_does_not_mutate_when_item_changes(
     refreshed_alert = await repo.get_alert_by_idempotency_key(alert_key)
     assert refreshed_alert is not None
     assert refreshed_alert.rationale == original_rationale
+
+
+@pytest.mark.asyncio
+async def test_caller_supplied_idempotency_key_cross_item_collision_rejected(
+    session: AsyncSession,
+) -> None:
+    """Plan 2 hardening #1: a caller-supplied idempotency_key that collides
+    with an existing alert sourced from a DIFFERENT item must raise, not
+    silently return the wrong alert.
+    """
+    item_a = await _seed_approved_watch_item(
+        session, client_item_key="watch-a", symbol="005930"
+    )
+    item_b = await _seed_approved_watch_item(
+        session, kst_date="2026-05-19", client_item_key="watch-b", symbol="000660"
+    )
+    shared_key = f"shared-alert-{uuid.uuid4()}"
+    service = WatchActivationService(session)
+
+    await service.activate(
+        ActivateWatchRequest(
+            item_uuid=item_a.item_uuid,
+            actor="operator",
+            idempotency_key=shared_key,
+        )
+    )
+    with pytest.raises(ValueError, match="already used for a different watch item"):
+        await service.activate(
+            ActivateWatchRequest(
+                item_uuid=item_b.item_uuid,
+                actor="operator",
+                idempotency_key=shared_key,
+            )
+        )


### PR DESCRIPTION
## Summary

Plan 2 of ROB-265. Adds the service layer over the Plan 1 schema. Service-only — no MCP, no API routes, no scanner re-wire, no frontend, no broker mutation. Stacked on PR #862 (Plan 1); base will auto-update to `main` when that PR merges.

**Modules (`app/services/investment_reports/`):**
- `repository.py` — thin SQLAlchemy DAO over all 5 tables, no business logic
- `ingestion.py` — `InvestmentReportIngestionService.ingest(request)` — idempotent report bundle creation, deterministic keys from `(report_type, market, market_session, kst_date, generator_version)`
- `decisions.py` — `InvestmentReportDecisionService.record(request)` — idempotent decision recording, item-status transitions per locked refinement #3 (skip is audit-only)
- `watch_activation.py` — `WatchActivationService.activate(request)` — copy approved watch item → `investment_watch_alerts` as immutable activation snapshot, item → `activated`
- `query_service.py` — list / latest / get_bundle + `previous_report_context` (locked refinement #7: query-based, not single-link traversal)

**Schemas (`app/schemas/investment_reports.py`):**
- `IngestReportRequest`, `IngestReportItem`, `WatchConditionPayload`, `RecordDecisionRequest`, `ActivateWatchRequest`
- `model_validator` rejects `kis_live`+non-advisory and `nxt`+non-advisory pre-DB (defense in depth on top of Plan 1's CHECK constraints)
- `WatchConditionPayload` auto-fills `threshold_key = str(threshold)` when omitted so the canonical dedup form is consistent

## Test plan

- [x] `uv run pytest tests/test_investment_reports_schemas.py tests/test_investment_reports_repository.py tests/test_investment_reports_ingestion.py tests/test_investment_reports_decisions.py tests/test_investment_reports_watch_activation.py tests/test_investment_reports_query_service.py -v` — **50 passed**
- [x] Plan 1 regression: `tests/test_investment_reports_model.py tests/test_investment_reports_idempotency.py` — **32 passed**
- [x] Legacy guard: `tests/test_analysis_report_workflow.py tests/test_mcp_watch_order_intent_ledger.py tests/test_watch_order_intent_service.py` — **16 passed**
- [x] `uv run ruff check` clean, `uv run ruff format` clean
- [x] `uv run ty check app/schemas/investment_reports.py app/services/investment_reports/` clean
- [x] No broker / KIS / Upbit / Alpaca imports in `app/services/investment_reports/` — verified via grep

## Notable test coverage

- Schemas: watch-item shape (condition + valid_until both required), advisory-only invariants pre-DB
- Repository: round-trips per entity, idempotency-key lookups, list filtering, alert listing by source-report-uuid
- Ingestion: idempotent re-ingest, distinct `kst_date` → distinct reports, watch_condition stored as JSONB with threshold_key default, advisory-only at schema layer
- Decisions: approve / deny / defer / partial_approve transitions; skip leaves status unchanged; idempotent per (item, verb, actor); multiple decisions per item persist (defer → approve)
- Watch activation: snapshot copy of immutable fields from item + report, item → `activated`, idempotent per source_item_uuid, rejects non-watch / unapproved / unknown, alert snapshot unaffected by later item mutations
- Query: list filter ordering (created_at DESC, id DESC tiebreaker), get_bundle nested shapes, `previous_report_context` aggregates across N prior reports, `exclude_report_uuid` skip, `n_prior` limit, empty-state shape

## Out of scope (Plans 3-5)

- MCP/API contract — Plan 3
- Watch scanner re-wire onto `investment_watch_alerts`/`investment_watch_events` — Plan 4
- `/invest/reports` frontend + NXT advisory-only pilot + legacy clean cut — Plan 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added investment report service layer supporting ingestion, decision recording, and watch activation workflows.
  * Enabled decision recording on report items with automatic status transitions (approve, deny, defer, skip).
  * Introduced watch activation system to convert approved watch items into active monitoring alerts.
  * Added report querying with context aggregation for tracking related data across reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/865?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->