### PR TITLE
fix(deploy): clear launchd plist before restart bootstrap

### DIFF
--- a/scripts/deploy-native.sh
+++ b/scripts/deploy-native.sh
@@ -145,6 +145,10 @@ restart_single_active_services() {
 
     install -m 0644 "$plist" "$target"
     launchctl bootout "gui/$uid_num/$label" 2>/dev/null || true
+    # macOS launchd can keep a failed/disabled plist-path registration around
+    # after label bootout, causing bootstrap to return EIO even though the label
+    # is no longer visible. Also boot out the installed plist path before retrying.
+    launchctl bootout "gui/$uid_num" "$target" 2>/dev/null || true
 
     for attempt in {1..5}; do
       if launchctl bootstrap "gui/$uid_num" "$target"; then

--- a/tests/scripts/test_native_deploy_rollback_split.py
+++ b/tests/scripts/test_native_deploy_rollback_split.py
@@ -207,6 +207,30 @@ def test_rollback_noop_when_pre_equals_current(tmp_path: Path) -> None:
     assert "mcp-green" not in log
 
 
+def test_restart_single_active_bootouts_installed_plist_path_before_bootstrap() -> None:
+    """Launchd can retain a plist-path registration after label bootout.
+
+    The single-active restart path must clear both the label and installed plist
+    target before bootstrapping again; otherwise production deploy can fail with
+    `Bootstrap failed: 5: Input/output error` while recovering worker/scheduler.
+    """
+    body = DEPLOY.read_text()
+    m = re.search(
+        r"^restart_single_active_services\s*\(\s*\)\s*\{(.*?)^\}",
+        body,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert m, "restart_single_active_services() function not found"
+    fn = m.group(1)
+    label_bootout = 'launchctl bootout "gui/$uid_num/$label"'
+    target_bootout = 'launchctl bootout "gui/$uid_num" "$target"'
+    bootstrap = 'launchctl bootstrap "gui/$uid_num" "$target"'
+    assert label_bootout in fn
+    assert target_bootout in fn
+    assert bootstrap in fn
+    assert fn.index(label_bootout) < fn.index(target_bootout) < fn.index(bootstrap)
+
+
 # ---------------------------------------------------------------------------
 # Static-analysis on deploy-native.sh wiring
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Clear stale launchd plist-path registrations before bootstrapping single-active services.
- Add a regression/static wiring test for `restart_single_active_services()` command order.

## Root cause / evidence
- Production deploy run `26025906181` failed after API/MCP blue-green cutover when `restart_single_active_services()` tried to bootstrap `com.robinco.auto-trader.worker` and later `com.robinco.auto-trader.kis-websocket`.
- Logs showed repeated `Bootstrap failed: 5: Input/output error` after label-only `bootout`.
- The deploy run rolled API/MCP and `current` symlink back; production is healthy but still on the prior release until this fix is deployed.

## Verification
- `git diff --check`
- `uv run pytest tests/scripts/test_native_deploy_rollback_split.py -q` → 10 passed
- `bash -n scripts/deploy-native.sh`
- `uv run ruff check tests/scripts/test_native_deploy_rollback_split.py`
- `uv run ruff format --check tests/scripts/test_native_deploy_rollback_split.py`
- Independent reviewer: passed; no security or logic errors

## Safety
- Deployment script only; no broker/order/watch/DB data mutation path added.
- New `launchctl bootout` is best-effort and scoped to the installed plist path for the known service label.
