### PR TITLE
fix(deploy): skip websocket probe in public stable check

### DIFF
--- a/ops/native/scripts/native_deploy_lib.sh
+++ b/ops/native/scripts/native_deploy_lib.sh
@@ -142,7 +142,11 @@ probe_public_stable() {
   local hc="$AUTO_TRADER_BASE/scripts/healthcheck-native.sh"
   local attempt
   for ((attempt = 1; attempt <= attempts; attempt++)); do
-    if "$hc"; then
+    # Deploy-time stable probing should validate the newly switched API/MCP
+    # routing only. KIS/Upbit websocket monitors are singleton background
+    # services with independent external session state; a transient KIS appkey
+    # lock must not roll back an otherwise healthy API/MCP deployment.
+    if AUTO_TRADER_HEALTHCHECK_SKIP_WS=1 "$hc"; then
       return 0
     fi
     if (( attempt < attempts )); then

--- a/tests/scripts/test_deploy_native_bluegreen.py
+++ b/tests/scripts/test_deploy_native_bluegreen.py
@@ -153,6 +153,27 @@ def test_healthcheck_default_attempts_allow_slow_cold_start() -> None:
     assert "AUTO_TRADER_HEALTHCHECK_ATTEMPTS:-24" in body
 
 
+def test_probe_public_stable_skips_websocket_singletons(tmp_path: Path) -> None:
+    base = _setup_base(tmp_path)
+    healthcheck_log = tmp_path / "healthcheck.log"
+    (base / "scripts" / "healthcheck-native.sh").write_text(
+        "#!/usr/bin/env bash\n"
+        f'echo "skip=${{AUTO_TRADER_HEALTHCHECK_SKIP_WS:-0}} args=$*" >>"{healthcheck_log}"\n'
+        '[[ "${AUTO_TRADER_HEALTHCHECK_SKIP_WS:-0}" == "1" ]]\n'
+    )
+    (base / "scripts" / "healthcheck-native.sh").chmod(0o755)
+
+    proc = _run_bash(
+        "probe_public_stable",
+        base,
+        tmp_path,
+        extra_env={"AUTO_TRADER_HEALTHCHECK_SKIP_WS": "0"},
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert "skip=1 args=" in healthcheck_log.read_text()
+
+
 def test_haproxy_swap_to_color_updates_state(tmp_path: Path) -> None:
     base = _setup_base(tmp_path)
     proc = _run_bash("haproxy_swap_to_color api green", base, tmp_path)


### PR DESCRIPTION
## Summary
- Make `probe_public_stable` call `healthcheck-native.sh` with `AUTO_TRADER_HEALTHCHECK_SKIP_WS=1`.
- Keep API/MCP blue-green public routing checks independent from singleton websocket heartbeat freshness.
- Add a behavior test proving the env override is passed to the healthcheck subprocess.

## Why
The previous production deploy reached API/MCP blue-green routing but failed during the public stable probe because the KIS websocket singleton heartbeat was stale. That singleton health is important, but it should not roll back an otherwise healthy API/MCP release promotion.

## Verification
- `git diff --check`
- `bash -n ops/native/scripts/native_deploy_lib.sh`
- `uv run pytest tests/scripts/test_deploy_native_bluegreen.py -q`
- `uv run ruff check tests/scripts/test_deploy_native_bluegreen.py`
- `uv run ruff format --check tests/scripts/test_deploy_native_bluegreen.py`
- Independent reviewer: passed, no security concerns or logic errors.

## Safety
- No broker/order/watch/DB mutation path changes.
- Websocket healthcheck is not removed globally; only deploy-time public stable probe skips singleton heartbeat checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment stability by refining health check validation during blue-green deployments to prevent unnecessary checks on external dependencies.

* **Tests**
  * Added test coverage for deployment health check behavior validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mgh3326/auto_trader/pull/867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->