### PR TITLE
ROB-265 Plan 3: MCP/API contract for investment_reports

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -33,6 +33,7 @@ from app.routers import (
     invest_app_spa,
     invest_fills,
     invest_web_spa,
+    investment_reports,
     kospi200,
     market_events,
     n8n,
@@ -179,6 +180,7 @@ def create_app() -> FastAPI:
     app.include_router(order_estimation.router)
     app.include_router(order_previews.router)
     app.include_router(analysis_reports.router)
+    app.include_router(investment_reports.router)
     app.include_router(symbol_settings.router)
     app.include_router(portfolio.router)
     app.include_router(ai_markdown.router)

--- a/app/mcp_server/tooling/investment_reports_handlers.py
+++ b/app/mcp_server/tooling/investment_reports_handlers.py
@@ -1,0 +1,381 @@
+"""MCP handlers for ROB-265 investment_reports.
+
+Six tools mirror the Linear issue list. Each opens its own
+``AsyncSessionLocal``, validates the incoming request via the Plan 2
+Pydantic schema, calls the service, commits, and returns the serialised
+response. No broker mutation, no scanner side effects — Plan 4 owns
+that surface.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from app.core.db import AsyncSessionLocal
+from app.schemas.investment_reports import (
+    ActivateWatchRequest,
+    IngestReportItem,
+    IngestReportRequest,
+    InvestmentReportActivateWatchResponse,
+    InvestmentReportBundle,
+    InvestmentReportCreateResponse,
+    InvestmentReportDecideItemResponse,
+    InvestmentReportItemDecisionResponse,
+    InvestmentReportItemResponse,
+    InvestmentReportListResponse,
+    InvestmentReportResponse,
+    InvestmentWatchAlertResponse,
+    InvestmentWatchEventResponse,
+    PreviousReportContextResponse,
+    RecordDecisionRequest,
+)
+from app.services.investment_reports.decisions import (
+    InvestmentReportDecisionService,
+)
+from app.services.investment_reports.ingestion import (
+    InvestmentReportIngestionService,
+)
+from app.services.investment_reports.query_service import (
+    InvestmentReportQueryService,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from app.services.investment_reports.watch_activation import WatchActivationService
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+INVESTMENT_REPORT_TOOL_NAMES: set[str] = {
+    "investment_report_create",
+    "investment_report_list",
+    "investment_report_get",
+    "investment_report_decide_item",
+    "investment_report_activate_watch",
+    "investment_report_context_get",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _serialise_bundle(bundle: dict) -> InvestmentReportBundle:
+    items = bundle["items"]
+    decisions_by_item_uuid: dict[str, list[InvestmentReportItemDecisionResponse]] = {}
+    for item in items:
+        rows = bundle["decisions_by_item"].get(item.id, [])
+        decisions_by_item_uuid[str(item.item_uuid)] = [
+            InvestmentReportItemDecisionResponse.model_validate(d) for d in rows
+        ]
+    return InvestmentReportBundle(
+        report=InvestmentReportResponse.model_validate(bundle["report"]),
+        items=[InvestmentReportItemResponse.model_validate(it) for it in items],
+        decisions_by_item_uuid=decisions_by_item_uuid,
+        alerts=[
+            InvestmentWatchAlertResponse.model_validate(a) for a in bundle["alerts"]
+        ],
+        events=[
+            InvestmentWatchEventResponse.model_validate(e) for e in bundle["events"]
+        ],
+    )
+
+
+def _serialise_context(ctx: dict) -> PreviousReportContextResponse:
+    return PreviousReportContextResponse(
+        prior_reports=[
+            InvestmentReportResponse.model_validate(r) for r in ctx["prior_reports"]
+        ],
+        unresolved_deferred_items=[
+            InvestmentReportItemResponse.model_validate(it)
+            for it in ctx["unresolved_deferred_items"]
+        ],
+        active_watches=[
+            InvestmentWatchAlertResponse.model_validate(a)
+            for a in ctx["active_watches"]
+        ],
+        triggered_events=[
+            InvestmentWatchEventResponse.model_validate(e)
+            for e in ctx["triggered_events"]
+        ],
+        recent_decisions=[
+            InvestmentReportItemDecisionResponse.model_validate(d)
+            for d in ctx["recent_decisions"]
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# investment_report_create
+# ---------------------------------------------------------------------------
+async def investment_report_create_impl(
+    report_type: str,
+    market: str,
+    summary: str,
+    created_by_profile: str,
+    title: str,
+    kst_date: str,
+    items: list[dict[str, Any]] | None = None,
+    market_session: str | None = None,
+    account_scope: str | None = None,
+    execution_mode: str = "advisory_only",
+    risk_summary: str | None = None,
+    thesis_text: str | None = None,
+    no_action_note: str | None = None,
+    market_snapshot: dict[str, Any] | None = None,
+    portfolio_snapshot: dict[str, Any] | None = None,
+    previous_report_uuid: str | None = None,
+    status: str = "draft",
+    metadata: dict[str, Any] | None = None,
+    valid_until: str | None = None,
+    published_at: str | None = None,
+    generator_version: str = "v1",
+) -> dict:
+    payload: dict[str, Any] = {
+        "report_type": report_type,
+        "market": market,
+        "market_session": market_session,
+        "account_scope": account_scope,
+        "execution_mode": execution_mode,
+        "created_by_profile": created_by_profile,
+        "title": title,
+        "summary": summary,
+        "risk_summary": risk_summary,
+        "thesis_text": thesis_text,
+        "no_action_note": no_action_note,
+        "market_snapshot": market_snapshot or {},
+        "portfolio_snapshot": portfolio_snapshot or {},
+        "previous_report_uuid": previous_report_uuid,
+        "status": status,
+        "metadata": metadata or {},
+        "valid_until": valid_until,
+        "published_at": published_at,
+        "items": [IngestReportItem.model_validate(it) for it in (items or [])],
+        "generator_version": generator_version,
+        "kst_date": kst_date,
+    }
+    request = IngestReportRequest.model_validate(payload)
+
+    async with AsyncSessionLocal() as db:
+        repo = InvestmentReportsRepository(db)
+        # Probe for idempotency BEFORE the service call so we can tell the
+        # caller whether the row was newly created or returned as-is.
+        from app.services.investment_reports.idempotency import report_key
+
+        composed_key = report_key(
+            report_type=request.report_type,
+            market=request.market,
+            market_session=request.market_session,
+            account_scope=request.account_scope,
+            execution_mode=request.execution_mode,
+            kst_date=request.kst_date,
+            generator_version=request.generator_version,
+        )
+        pre_existing = await repo.get_report_by_idempotency_key(composed_key)
+        is_new = pre_existing is None
+
+        service = InvestmentReportIngestionService(db, repository=repo)
+        report = await service.ingest(request)
+        await db.commit()
+
+        response = InvestmentReportCreateResponse(
+            idempotent=not is_new,
+            report=InvestmentReportResponse.model_validate(report),
+        )
+    return response.model_dump(mode="json", by_alias=True)
+
+
+# ---------------------------------------------------------------------------
+# investment_report_list
+# ---------------------------------------------------------------------------
+async def investment_report_list_impl(
+    market: str | None = None,
+    market_session: str | None = None,
+    account_scope: str | None = None,
+    status: str | None = None,
+    report_type: str | None = None,
+    limit: int = 20,
+) -> dict:
+    capped = max(1, min(int(limit), 100))
+    async with AsyncSessionLocal() as db:
+        service = InvestmentReportQueryService(db)
+        rows = await service.list_reports(
+            market=market,
+            market_session=market_session,
+            account_scope=account_scope,
+            status=status,
+            report_type=report_type,
+            limit=capped,
+        )
+        response = InvestmentReportListResponse(
+            reports=[InvestmentReportResponse.model_validate(r) for r in rows]
+        )
+    return {"success": True, **response.model_dump(mode="json", by_alias=True)}
+
+
+# ---------------------------------------------------------------------------
+# investment_report_get
+# ---------------------------------------------------------------------------
+async def investment_report_get_impl(report_uuid: str) -> dict:
+    parsed = UUID(report_uuid)
+    async with AsyncSessionLocal() as db:
+        service = InvestmentReportQueryService(db)
+        bundle = await service.get_bundle(parsed)
+        if bundle is None:
+            return {"success": False, "error": "not_found"}
+        serialised = _serialise_bundle(bundle)
+    return {"success": True, **serialised.model_dump(mode="json", by_alias=True)}
+
+
+# ---------------------------------------------------------------------------
+# investment_report_decide_item
+# ---------------------------------------------------------------------------
+async def investment_report_decide_item_impl(
+    item_uuid: str,
+    decision: str,
+    actor: str,
+    decision_note: str | None = None,
+    approved_payload_snapshot: dict[str, Any] | None = None,
+    idempotency_key: str | None = None,
+) -> dict:
+    request = RecordDecisionRequest.model_validate(
+        {
+            "item_uuid": item_uuid,
+            "decision": decision,
+            "actor": actor,
+            "decision_note": decision_note,
+            "approved_payload_snapshot": approved_payload_snapshot,
+            "idempotency_key": idempotency_key,
+        }
+    )
+    async with AsyncSessionLocal() as db:
+        decisions_svc = InvestmentReportDecisionService(db)
+        repo = InvestmentReportsRepository(db)
+        decision_row = await decisions_svc.record(request)
+        item_row = await repo.get_item_by_uuid(request.item_uuid)
+        await db.commit()
+
+        response = InvestmentReportDecideItemResponse(
+            decision=InvestmentReportItemDecisionResponse.model_validate(decision_row),
+            item=InvestmentReportItemResponse.model_validate(item_row),
+        )
+    return response.model_dump(mode="json", by_alias=True)
+
+
+# ---------------------------------------------------------------------------
+# investment_report_activate_watch
+# ---------------------------------------------------------------------------
+async def investment_report_activate_watch_impl(
+    item_uuid: str,
+    actor: str,
+    idempotency_key: str | None = None,
+) -> dict:
+    request = ActivateWatchRequest.model_validate(
+        {
+            "item_uuid": item_uuid,
+            "actor": actor,
+            "idempotency_key": idempotency_key,
+        }
+    )
+    async with AsyncSessionLocal() as db:
+        activation_svc = WatchActivationService(db)
+        repo = InvestmentReportsRepository(db)
+        alert_row = await activation_svc.activate(request)
+        item_row = await repo.get_item_by_uuid(request.item_uuid)
+        await db.commit()
+
+        response = InvestmentReportActivateWatchResponse(
+            alert=InvestmentWatchAlertResponse.model_validate(alert_row),
+            item=InvestmentReportItemResponse.model_validate(item_row),
+        )
+    return response.model_dump(mode="json", by_alias=True)
+
+
+# ---------------------------------------------------------------------------
+# investment_report_context_get
+# ---------------------------------------------------------------------------
+async def investment_report_context_get_impl(
+    market: str,
+    market_session: str | None = None,
+    account_scope: str | None = None,
+    report_type: str | None = None,
+    exclude_report_uuid: str | None = None,
+    n_prior: int = 3,
+) -> dict:
+    capped = max(1, min(int(n_prior), 10))
+    exclude_uuid = UUID(exclude_report_uuid) if exclude_report_uuid else None
+    async with AsyncSessionLocal() as db:
+        service = InvestmentReportQueryService(db)
+        ctx = await service.previous_report_context(
+            market=market,
+            market_session=market_session,
+            account_scope=account_scope,
+            report_type=report_type,
+            exclude_report_uuid=exclude_uuid,
+            n_prior=capped,
+        )
+        serialised = _serialise_context(ctx)
+    return {"success": True, **serialised.model_dump(mode="json", by_alias=True)}
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+def register_investment_report_tools(mcp: FastMCP) -> None:
+    mcp.tool(
+        name="investment_report_create",
+        description=(
+            "Persist one ROB-265 investment_report bundle (report + items). "
+            "Idempotent on (report_type, market, market_session, account_scope, "
+            "execution_mode, kst_date, generator_version). "
+            "No broker / order submission is performed."
+        ),
+    )(investment_report_create_impl)
+    mcp.tool(
+        name="investment_report_list",
+        description=(
+            "List investment_reports filtered by market / market_session / "
+            "account_scope / status / report_type. limit clamped to 1..100."
+        ),
+    )(investment_report_list_impl)
+    mcp.tool(
+        name="investment_report_get",
+        description=(
+            "Return one investment_report bundle by report_uuid — report + "
+            "items + decisions_by_item_uuid + alerts + recent events."
+        ),
+    )(investment_report_get_impl)
+    mcp.tool(
+        name="investment_report_decide_item",
+        description=(
+            "Record an operator decision on one investment_report_item. "
+            "Idempotent per (item_uuid, verb, actor) by default; pass "
+            "idempotency_key to override. partial_approve requires a "
+            "non-empty approved_payload_snapshot."
+        ),
+    )(investment_report_decide_item_impl)
+    mcp.tool(
+        name="investment_report_activate_watch",
+        description=(
+            "Activate an approved watch item into investment_watch_alerts "
+            "as an immutable activation snapshot. Idempotent per source item."
+        ),
+    )(investment_report_activate_watch_impl)
+    mcp.tool(
+        name="investment_report_context_get",
+        description=(
+            "Return previous-report context for the next-report generator: "
+            "prior_reports, unresolved_deferred_items, active_watches, "
+            "triggered_events, recent_decisions. n_prior clamped to 1..10."
+        ),
+    )(investment_report_context_get_impl)
+
+
+__all__ = [
+    "INVESTMENT_REPORT_TOOL_NAMES",
+    "investment_report_activate_watch_impl",
+    "investment_report_context_get_impl",
+    "investment_report_create_impl",
+    "investment_report_decide_item_impl",
+    "investment_report_get_impl",
+    "investment_report_list_impl",
+    "register_investment_report_tools",
+]

--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -40,6 +40,9 @@ from app.mcp_server.tooling.execution_comment_registration import (
     register_execution_comment_tools,
 )
 from app.mcp_server.tooling.fundamentals_registration import register_fundamentals_tools
+from app.mcp_server.tooling.investment_reports_handlers import (
+    register_investment_report_tools,
+)
 from app.mcp_server.tooling.market_brief_registration import (
     register_market_brief_tools,
 )
@@ -96,6 +99,7 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
     register_fundamentals_tools(mcp)
     register_analysis_tools(mcp)
     register_analysis_report_tools(mcp)
+    register_investment_report_tools(mcp)
     register_watch_alert_tools(mcp)
     register_trade_profile_tools(mcp)
     register_market_report_tools(mcp)

--- a/app/routers/investment_reports.py
+++ b/app/routers/investment_reports.py
@@ -1,0 +1,184 @@
+"""ROB-265 — Investment-report read endpoints (Plan 3).
+
+GET-only HTTP surface over the Plan 2 query service. Writes
+(create / decide / activate) go through MCP in Plan 3; HTTP write
+endpoints can be added later if needed.
+
+Auth uses the same ``get_authenticated_user`` dependency as the legacy
+``analysis_reports`` router. The route exists under both
+``/trading/api/...`` and ``/invest/api/...`` so the existing frontend
+proxy patterns keep working.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import get_db
+from app.models.trading import User
+from app.routers.dependencies import get_authenticated_user
+from app.schemas.investment_reports import (
+    AccountScopeLiteral,
+    InvestmentReportBundle,
+    InvestmentReportItemDecisionResponse,
+    InvestmentReportItemResponse,
+    InvestmentReportListResponse,
+    InvestmentReportResponse,
+    InvestmentWatchAlertResponse,
+    InvestmentWatchEventResponse,
+    MarketLiteral,
+    MarketSessionLiteral,
+    PreviousReportContextResponse,
+    ReportStatusLiteral,
+)
+from app.services.investment_reports.query_service import (
+    InvestmentReportQueryService,
+)
+
+router = APIRouter(tags=["investment-reports"])
+
+
+def _build_query_service(
+    db: AsyncSession = Depends(get_db),
+) -> InvestmentReportQueryService:
+    return InvestmentReportQueryService(db)
+
+
+def _serialise_bundle(bundle: dict) -> InvestmentReportBundle:
+    items = bundle["items"]
+    item_responses = [InvestmentReportItemResponse.model_validate(it) for it in items]
+    decisions_by_item_uuid: dict[str, list[InvestmentReportItemDecisionResponse]] = {}
+    for item in items:
+        rows = bundle["decisions_by_item"].get(item.id, [])
+        decisions_by_item_uuid[str(item.item_uuid)] = [
+            InvestmentReportItemDecisionResponse.model_validate(d) for d in rows
+        ]
+    return InvestmentReportBundle(
+        report=InvestmentReportResponse.model_validate(bundle["report"]),
+        items=item_responses,
+        decisions_by_item_uuid=decisions_by_item_uuid,
+        alerts=[
+            InvestmentWatchAlertResponse.model_validate(a) for a in bundle["alerts"]
+        ],
+        events=[
+            InvestmentWatchEventResponse.model_validate(e) for e in bundle["events"]
+        ],
+    )
+
+
+def _serialise_context(ctx: dict) -> PreviousReportContextResponse:
+    return PreviousReportContextResponse(
+        prior_reports=[
+            InvestmentReportResponse.model_validate(r) for r in ctx["prior_reports"]
+        ],
+        unresolved_deferred_items=[
+            InvestmentReportItemResponse.model_validate(it)
+            for it in ctx["unresolved_deferred_items"]
+        ],
+        active_watches=[
+            InvestmentWatchAlertResponse.model_validate(a)
+            for a in ctx["active_watches"]
+        ],
+        triggered_events=[
+            InvestmentWatchEventResponse.model_validate(e)
+            for e in ctx["triggered_events"]
+        ],
+        recent_decisions=[
+            InvestmentReportItemDecisionResponse.model_validate(d)
+            for d in ctx["recent_decisions"]
+        ],
+    )
+
+
+# ---------------------------------------------------------------------------
+# List
+# ---------------------------------------------------------------------------
+@router.get(
+    "/trading/api/investment-reports",
+    response_model=InvestmentReportListResponse,
+    summary="List investment reports (ROB-265)",
+)
+@router.get(
+    "/invest/api/investment-reports",
+    response_model=InvestmentReportListResponse,
+    summary="List investment reports for the /invest dashboard (ROB-265)",
+)
+async def list_investment_reports(
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    service: Annotated[InvestmentReportQueryService, Depends(_build_query_service)],
+    market: MarketLiteral | None = None,
+    market_session: MarketSessionLiteral | None = None,
+    account_scope: AccountScopeLiteral | None = None,
+    status_filter: Annotated[ReportStatusLiteral | None, Query(alias="status")] = None,
+    report_type: str | None = None,
+    limit: int = Query(default=20, ge=1, le=100),
+) -> InvestmentReportListResponse:
+    rows = await service.list_reports(
+        market=market,
+        market_session=market_session,
+        account_scope=account_scope,
+        status=status_filter,
+        report_type=report_type,
+        limit=limit,
+    )
+    return InvestmentReportListResponse(
+        reports=[InvestmentReportResponse.model_validate(r) for r in rows]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Previous-report context (declared BEFORE /{report_uuid} so the literal
+# path "context" doesn't get shadowed by the UUID-parameter route).
+# ---------------------------------------------------------------------------
+@router.get(
+    "/trading/api/investment-reports/context",
+    response_model=PreviousReportContextResponse,
+    summary="Previous-report context for the next-report generator (ROB-265)",
+)
+async def get_previous_report_context(
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    service: Annotated[InvestmentReportQueryService, Depends(_build_query_service)],
+    market: MarketLiteral = Query(..., description="kr | us | crypto"),
+    market_session: MarketSessionLiteral | None = None,
+    account_scope: AccountScopeLiteral | None = None,
+    report_type: str | None = None,
+    exclude_report_uuid: UUID | None = None,
+    n_prior: int = Query(default=3, ge=1, le=10),
+) -> PreviousReportContextResponse:
+    ctx = await service.previous_report_context(
+        market=market,
+        market_session=market_session,
+        account_scope=account_scope,
+        report_type=report_type,
+        exclude_report_uuid=exclude_report_uuid,
+        n_prior=n_prior,
+    )
+    return _serialise_context(ctx)
+
+
+# ---------------------------------------------------------------------------
+# Get one bundle
+# ---------------------------------------------------------------------------
+@router.get(
+    "/trading/api/investment-reports/{report_uuid}",
+    response_model=InvestmentReportBundle,
+    summary="Get one investment report bundle (ROB-265)",
+)
+@router.get(
+    "/invest/api/investment-reports/{report_uuid}",
+    response_model=InvestmentReportBundle,
+    summary="Get one investment report bundle for the /invest dashboard (ROB-265)",
+)
+async def get_investment_report(
+    report_uuid: UUID,
+    _user: Annotated[User, Depends(get_authenticated_user)],
+    service: Annotated[InvestmentReportQueryService, Depends(_build_query_service)],
+) -> InvestmentReportBundle:
+    bundle = await service.get_bundle(report_uuid)
+    if bundle is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not_found")
+    return _serialise_bundle(bundle)

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -189,3 +189,202 @@ class ActivateWatchRequest(BaseModel):
     item_uuid: UUID
     actor: str
     idempotency_key: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Response models (Plan 3 — HTTP / MCP read surface)
+# ---------------------------------------------------------------------------
+#
+# All response models use ``from_attributes=True`` so they can be built
+# directly from an ORM instance via ``Model.model_validate(row)``.
+# ``populate_by_name=True`` is set on response models that need to surface
+# a ``metadata`` JSON field — the ORM attribute is ``report_metadata``
+# but the API contract exposes the plain ``metadata`` key.
+
+
+class InvestmentReportResponse(BaseModel):
+    """Single ``investment_reports`` row, serialised for HTTP / MCP."""
+
+    report_uuid: UUID
+    report_type: str
+    market: MarketLiteral
+    market_session: MarketSessionLiteral | None
+    account_scope: AccountScopeLiteral | None
+    execution_mode: ExecutionModeLiteral
+    created_by_profile: str
+    title: str
+    summary: str
+    risk_summary: str | None
+    thesis_text: str | None
+    no_action_note: str | None
+    market_snapshot: dict[str, Any]
+    portfolio_snapshot: dict[str, Any]
+    previous_report_uuid: UUID | None
+    status: ReportStatusLiteral
+    metadata: dict[str, Any] = Field(
+        validation_alias="report_metadata", serialization_alias="metadata"
+    )
+    created_at: datetime
+    updated_at: datetime
+    published_at: datetime | None
+    valid_until: datetime | None
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+
+class InvestmentReportItemResponse(BaseModel):
+    """Single ``investment_report_items`` row."""
+
+    item_uuid: UUID
+    item_kind: ItemKindLiteral
+    symbol: str | None
+    side: ItemSideLiteral | None
+    intent: ItemIntentLiteral
+    target_kind: TargetKindLiteral
+    priority: int
+    confidence: Decimal | None
+    rationale: str
+    evidence_snapshot: dict[str, Any]
+    watch_condition: dict[str, Any] | None
+    trigger_checklist: list[Any]
+    max_action: dict[str, Any]
+    valid_until: datetime | None
+    status: ItemStatusLiteral
+    metadata: dict[str, Any] = Field(
+        validation_alias="item_metadata", serialization_alias="metadata"
+    )
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+
+class InvestmentReportItemDecisionResponse(BaseModel):
+    """Single ``investment_report_item_decisions`` row."""
+
+    decision_uuid: UUID
+    decision: DecisionVerbLiteral
+    actor: str
+    decision_note: str | None
+    approved_payload_snapshot: dict[str, Any] | None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class InvestmentWatchAlertResponse(BaseModel):
+    """Single ``investment_watch_alerts`` row."""
+
+    alert_uuid: UUID
+    source_report_uuid: UUID
+    source_item_uuid: UUID
+    market: MarketLiteral
+    target_kind: TargetKindLiteral
+    symbol: str
+    metric: WatchMetricLiteral
+    operator: WatchOperatorLiteral
+    threshold: Decimal
+    threshold_key: str
+    intent: ItemIntentLiteral
+    action_mode: WatchActionModeLiteral
+    rationale: str
+    trigger_checklist: list[Any]
+    max_action: dict[str, Any]
+    valid_until: datetime
+    status: Literal["active", "triggered", "expired", "canceled"]
+    metadata: dict[str, Any] = Field(
+        validation_alias="alert_metadata", serialization_alias="metadata"
+    )
+    created_at: datetime
+    activated_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+
+class InvestmentWatchEventResponse(BaseModel):
+    """Single ``investment_watch_events`` row."""
+
+    event_uuid: UUID
+    alert_id: int | None
+    source_report_uuid: UUID
+    source_item_uuid: UUID
+    market: MarketLiteral
+    target_kind: TargetKindLiteral
+    symbol: str
+    metric: WatchMetricLiteral
+    operator: WatchOperatorLiteral
+    threshold: Decimal
+    threshold_key: str
+    intent: ItemIntentLiteral
+    action_mode: WatchActionModeLiteral
+    current_value: Decimal | None
+    scanner_snapshot: dict[str, Any]
+    outcome: Literal[
+        "notified",
+        "review_required",
+        "preview_attached",
+        "expired",
+        "ignored",
+        "failed",
+    ]
+    follow_up_report_item_id: int | None
+    correlation_id: str
+    kst_date: str
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class InvestmentReportBundle(BaseModel):
+    """``investment_report_get`` / ``GET /.../investment-reports/{uuid}``.
+
+    ``decisions_by_item_uuid`` is keyed by string UUID for external
+    consumers (the service-layer dict is keyed by the integer item.id).
+    """
+
+    report: InvestmentReportResponse
+    items: list[InvestmentReportItemResponse]
+    decisions_by_item_uuid: dict[str, list[InvestmentReportItemDecisionResponse]]
+    alerts: list[InvestmentWatchAlertResponse]
+    events: list[InvestmentWatchEventResponse]
+
+
+class InvestmentReportListResponse(BaseModel):
+    """``investment_report_list`` / ``GET /.../investment-reports``."""
+
+    reports: list[InvestmentReportResponse]
+
+
+class PreviousReportContextResponse(BaseModel):
+    """``investment_report_context_get`` / ``GET /.../investment-reports/context``."""
+
+    prior_reports: list[InvestmentReportResponse]
+    unresolved_deferred_items: list[InvestmentReportItemResponse]
+    active_watches: list[InvestmentWatchAlertResponse]
+    triggered_events: list[InvestmentWatchEventResponse]
+    recent_decisions: list[InvestmentReportItemDecisionResponse]
+
+
+class InvestmentReportCreateResponse(BaseModel):
+    """``investment_report_create`` MCP return shape."""
+
+    success: bool = True
+    idempotent: bool
+    report: InvestmentReportResponse
+
+
+class InvestmentReportDecideItemResponse(BaseModel):
+    """``investment_report_decide_item`` MCP return shape."""
+
+    success: bool = True
+    decision: InvestmentReportItemDecisionResponse
+    item: InvestmentReportItemResponse
+
+
+class InvestmentReportActivateWatchResponse(BaseModel):
+    """``investment_report_activate_watch`` MCP return shape."""
+
+    success: bool = True
+    alert: InvestmentWatchAlertResponse
+    item: InvestmentReportItemResponse

--- a/docs/plans/2026-05-18-ROB-265-plan-3-mcp-api-contract.md
+++ b/docs/plans/2026-05-18-ROB-265-plan-3-mcp-api-contract.md
@@ -1,0 +1,104 @@
+# ROB-265 Plan 3 — MCP/API contract for `investment_reports`
+
+> Stacked on Plan 2 (PR #865). Service layer is unchanged; this plan only
+> adds the user-facing read/write surface and the operator MCP tools.
+
+**Goal:** Expose the Plan 2 service layer through (a) HTTP read endpoints for the dashboard/Hermes consumers, and (b) MCP tools for operator workflows. The six tool names follow the Linear issue exactly. No broker mutation; legacy `analysis_*` and `watch_order_intent_ledger_*` registrations stay in place — clean cut is Plan 5.
+
+**Architecture:**
+- HTTP routes: GET-mostly read surface at `/trading/api/investment-reports/...` + `/invest/api/investment-reports/...` (so the `/invest` frontend can call the same data, matching the legacy alias pattern).
+- MCP handlers: 6 tools — `investment_report_create`, `investment_report_list`, `investment_report_get`, `investment_report_decide_item`, `investment_report_activate_watch`, `investment_report_context_get`. Each opens its own `AsyncSessionLocal`.
+- Pydantic response models in `app/schemas/investment_reports.py` use `from_attributes=True` to convert ORM rows. The router & MCP both serialise through these, so the JSON shape is consistent across surfaces.
+- Wiring: `app/main.py` includes the new router; `app/mcp_server/tooling/registry.py` calls a new `register_investment_report_tools`.
+- OpenClaw payload schema work is deferred to Plan 4 (it's scanner-driven and only meaningful once the scanner emits `investment_watch_events`).
+
+**Tech stack:** FastAPI (existing patterns), Pydantic v2 (existing), pytest-asyncio + httpx TestClient.
+
+---
+
+## File Structure
+
+**Create:**
+- `app/routers/investment_reports.py` — APIRouter with 3 GET routes
+- `app/mcp_server/tooling/investment_reports_handlers.py` — 6 tool impls + `register_investment_report_tools`
+- `tests/test_investment_reports_router.py` — TestClient against a minimal FastAPI app
+- `tests/test_investment_reports_mcp.py` — direct calls to the `*_impl` functions
+
+**Modify:**
+- `app/schemas/investment_reports.py` — append response Pydantic models
+- `app/main.py` — `from .routers import investment_reports` + `include_router`
+- `app/mcp_server/tooling/registry.py` — import + call `register_investment_report_tools(mcp)`
+
+---
+
+## HTTP routes (all under `tags=["investment-reports"]`)
+
+| Method | Path | Response model | Calls |
+|---|---|---|---|
+| GET | `/trading/api/investment-reports` | `InvestmentReportListResponse` | `QueryService.list_reports` |
+| GET | `/invest/api/investment-reports` | same | same |
+| GET | `/trading/api/investment-reports/context` | `PreviousReportContextResponse` | `QueryService.previous_report_context` |
+| GET | `/trading/api/investment-reports/{report_uuid}` | `InvestmentReportBundle` | `QueryService.get_bundle` |
+| GET | `/invest/api/investment-reports/{report_uuid}` | same | same |
+
+Routes are auth-required (`get_authenticated_user` Depends) matching the legacy `analysis_reports.py`. Write paths (create/decide/activate) go through MCP only in Plan 3 — HTTP write endpoints can be added later if needed.
+
+## MCP tools (6, all registered together)
+
+| Tool | Wraps | Notes |
+|---|---|---|
+| `investment_report_create` | `IngestionService.ingest` | Idempotent. Accepts an `IngestReportRequest` payload as primitives. |
+| `investment_report_list` | `QueryService.list_reports` | Filters: market, market_session, account_scope, status, report_type, limit. |
+| `investment_report_get` | `QueryService.get_bundle` | Returns the full bundle. |
+| `investment_report_decide_item` | `DecisionService.record` | Idempotent; allows `partial_approve` with required payload snapshot. |
+| `investment_report_activate_watch` | `WatchActivationService.activate` | Idempotent per source item. |
+| `investment_report_context_get` | `QueryService.previous_report_context` | n_prior + filters. |
+
+Each handler:
+1. Validates input via the Plan 2 Pydantic request schema (`IngestReportRequest`, `RecordDecisionRequest`, `ActivateWatchRequest`).
+2. Opens a fresh `AsyncSessionLocal()` per call, calls the service, commits, and returns the serialised response.
+3. Returns `{"success": True, ...}` matching the legacy MCP convention.
+
+---
+
+## Tasks
+
+### Task 1 — Response Pydantic models
+Append to `app/schemas/investment_reports.py`: `InvestmentReportResponse`, `InvestmentReportItemResponse`, `InvestmentReportItemDecisionResponse`, `InvestmentWatchAlertResponse`, `InvestmentWatchEventResponse`, `InvestmentReportBundle`, `InvestmentReportListResponse`, `PreviousReportContextResponse`. Each uses `from_attributes=True` so `model_validate(orm_instance)` works.
+
+### Task 2 — HTTP router
+Create `app/routers/investment_reports.py` with the 3 GET routes from the table above. Service injected via `Depends(get_db)` → `InvestmentReportQueryService`. Auth via `get_authenticated_user`. 404 on missing report.
+
+### Task 3 — MCP handlers
+Create `app/mcp_server/tooling/investment_reports_handlers.py` with 6 `*_impl` functions and the `register_investment_report_tools(mcp)` registrar. Each impl validates the request via the Plan 2 schema, calls the service, commits, and returns a `{"success": True, ...}` dict.
+
+### Task 4 — Wiring
+- `app/main.py`: import the router and `include_router`.
+- `app/mcp_server/tooling/registry.py`: import `register_investment_report_tools` and call it next to `register_analysis_report_tools` (legacy stays — clean cut is Plan 5).
+
+### Task 5 — Router tests
+`tests/test_investment_reports_router.py`:
+- Build a minimal FastAPI app with the investment_reports router + auth override.
+- Tests for list (empty + with filters), bundle (happy path + 404), context (with prior reports).
+- Use the shared `session` fixture from the helpers plugin so DB state is seeded via the real services.
+
+### Task 6 — MCP handler tests
+`tests/test_investment_reports_mcp.py`:
+- Call each `*_impl` directly (no FastMCP runtime needed for unit tests — that's the legacy pattern).
+- Tests for create idempotency, list filter pass-through, get not-found, decide approve + status transition, activate watch, context retrieval.
+
+### Task 7 — Final lint/typecheck/PR
+- `ruff format` + `ruff check` clean on new + modified files.
+- `ty check` clean for schemas + new modules.
+- Full P1+P2+P3 sweep + legacy guard.
+- Push `rob-265-plan-3`, open PR with base `rob-265-plan-2`.
+
+---
+
+## Out of scope (deferred to Plans 4/5)
+
+- OpenClaw notification payload update (Plan 4 — wires the scanner that emits the events).
+- Watch scanner re-wire onto `investment_watch_alerts` / `investment_watch_events` (Plan 4).
+- Frontend `/invest/reports` views (Plan 5).
+- Legacy clean cut — `analysis_*` and `watch_order_intent_ledger_*` removal (Plan 5).
+- Sentry / observability instrumentation on the new tools (follow-up if needed).

--- a/docs/plans/2026-05-18-ROB-265-plan-3-mcp-api-contract.md
+++ b/docs/plans/2026-05-18-ROB-265-plan-3-mcp-api-contract.md
@@ -10,7 +10,7 @@
 - MCP handlers: 6 tools — `investment_report_create`, `investment_report_list`, `investment_report_get`, `investment_report_decide_item`, `investment_report_activate_watch`, `investment_report_context_get`. Each opens its own `AsyncSessionLocal`.
 - Pydantic response models in `app/schemas/investment_reports.py` use `from_attributes=True` to convert ORM rows. The router & MCP both serialise through these, so the JSON shape is consistent across surfaces.
 - Wiring: `app/main.py` includes the new router; `app/mcp_server/tooling/registry.py` calls a new `register_investment_report_tools`.
-- OpenClaw payload schema work is deferred to Plan 4 (it's scanner-driven and only meaningful once the scanner emits `investment_watch_events`).
+- Hermes review-trigger notification payload contract is deferred to Plan 4 (it's scanner-driven and only meaningful once the scanner emits `investment_watch_events`).
 
 **Tech stack:** FastAPI (existing patterns), Pydantic v2 (existing), pytest-asyncio + httpx TestClient.
 
@@ -97,8 +97,8 @@ Create `app/mcp_server/tooling/investment_reports_handlers.py` with 6 `*_impl` f
 
 ## Out of scope (deferred to Plans 4/5)
 
-- OpenClaw notification payload update (Plan 4 — wires the scanner that emits the events).
-- Watch scanner re-wire onto `investment_watch_alerts` / `investment_watch_events` (Plan 4).
+- Hermes review-trigger notification payload update (Plan 4 — wires the scanner that emits the events).
+- Watch scanner re-wire onto `investment_watch_alerts` / `investment_watch_events`, emitting Hermes review-trigger notifications instead of legacy OpenClaw payloads (Plan 4).
 - Frontend `/invest/reports` views (Plan 5).
 - Legacy clean cut — `analysis_*` and `watch_order_intent_ledger_*` removal (Plan 5).
 - Sentry / observability instrumentation on the new tools (follow-up if needed).

--- a/tests/test_investment_reports_mcp.py
+++ b/tests/test_investment_reports_mcp.py
@@ -1,0 +1,256 @@
+"""ROB-265 Plan 3 — MCP handler tests.
+
+Each tool's ``*_impl`` is called directly (matches the legacy
+``test_analysis_report_workflow.py`` style). The handlers open their
+own ``AsyncSessionLocal`` against the same test_db that the ``session``
+fixture manages; the fixture's per-test TRUNCATE keeps state clean.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.mcp_server.tooling.investment_reports_handlers import (
+    INVESTMENT_REPORT_TOOL_NAMES,
+    investment_report_activate_watch_impl,
+    investment_report_context_get_impl,
+    investment_report_create_impl,
+    investment_report_decide_item_impl,
+    investment_report_get_impl,
+    investment_report_list_impl,
+)
+from tests._investment_reports_helpers import future_datetime
+
+
+def _create_kwargs(
+    *, kst_date: str = "2026-05-18", market: str = "kr", **overrides
+) -> dict:
+    kwargs: dict = {
+        "report_type": "kr_morning",
+        "market": market,
+        "market_session": "regular",
+        "account_scope": "kis_mock",
+        "execution_mode": "mock_preview",
+        "created_by_profile": "test",
+        "title": f"t-{kst_date}",
+        "summary": "s",
+        "kst_date": kst_date,
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _action_item_dict(client_item_key: str = "action-1") -> dict:
+    return {
+        "client_item_key": client_item_key,
+        "item_kind": "action",
+        "symbol": "005930",
+        "side": "buy",
+        "intent": "buy_review",
+        "rationale": "r",
+    }
+
+
+def _watch_item_dict(client_item_key: str = "watch-1") -> dict:
+    return {
+        "client_item_key": client_item_key,
+        "item_kind": "watch",
+        "symbol": "000660",
+        "intent": "trend_recovery_review",
+        "rationale": "r",
+        "watch_condition": {
+            "metric": "rsi",
+            "operator": "below",
+            "threshold": 30,
+        },
+        "valid_until": future_datetime().isoformat(),
+    }
+
+
+def test_tool_names_are_exactly_six() -> None:
+    assert INVESTMENT_REPORT_TOOL_NAMES == {
+        "investment_report_create",
+        "investment_report_list",
+        "investment_report_get",
+        "investment_report_decide_item",
+        "investment_report_activate_watch",
+        "investment_report_context_get",
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_returns_idempotent_false_on_first_call(
+    session: AsyncSession,
+) -> None:
+    response = await investment_report_create_impl(
+        items=[_action_item_dict()], **_create_kwargs()
+    )
+    assert response["success"] is True
+    assert response["idempotent"] is False
+    assert response["report"]["report_type"] == "kr_morning"
+    assert response["report"]["market"] == "kr"
+
+
+@pytest.mark.asyncio
+async def test_create_returns_idempotent_true_on_replay(
+    session: AsyncSession,
+) -> None:
+    first = await investment_report_create_impl(
+        items=[_action_item_dict()], **_create_kwargs()
+    )
+    second = await investment_report_create_impl(
+        items=[_action_item_dict()], **_create_kwargs()
+    )
+    assert first["idempotent"] is False
+    assert second["idempotent"] is True
+    assert first["report"]["report_uuid"] == second["report"]["report_uuid"]
+
+
+@pytest.mark.asyncio
+async def test_list_filters_propagate(session: AsyncSession) -> None:
+    await investment_report_create_impl(
+        items=[_action_item_dict()],
+        **_create_kwargs(market="kr", kst_date="2026-05-18"),
+    )
+    await investment_report_create_impl(
+        items=[_action_item_dict()],
+        **_create_kwargs(market="us", kst_date="2026-05-18"),
+    )
+    response = await investment_report_list_impl(market="kr")
+    assert response["success"] is True
+    assert len(response["reports"]) == 1
+    assert response["reports"][0]["market"] == "kr"
+
+
+@pytest.mark.asyncio
+async def test_get_returns_not_found_for_unknown(session: AsyncSession) -> None:
+    response = await investment_report_get_impl(str(uuid.uuid4()))
+    assert response == {"success": False, "error": "not_found"}
+
+
+@pytest.mark.asyncio
+async def test_get_returns_bundle_with_nested_decisions(
+    session: AsyncSession,
+) -> None:
+    created = await investment_report_create_impl(
+        items=[_action_item_dict("act-1"), _watch_item_dict("wt-1")],
+        **_create_kwargs(),
+    )
+    report_uuid = created["report"]["report_uuid"]
+
+    # Look up the items by reading the bundle once.
+    bundle_pre = await investment_report_get_impl(report_uuid)
+    assert bundle_pre["success"] is True
+    item_uuids = {it["item_kind"]: it["item_uuid"] for it in bundle_pre["items"]}
+
+    # Approve the action item via MCP.
+    await investment_report_decide_item_impl(
+        item_uuid=item_uuids["action"], decision="approve", actor="operator-test"
+    )
+
+    bundle_post = await investment_report_get_impl(report_uuid)
+    decisions = bundle_post["decisions_by_item_uuid"][item_uuids["action"]]
+    assert len(decisions) == 1
+    assert decisions[0]["decision"] == "approve"
+
+
+@pytest.mark.asyncio
+async def test_decide_item_idempotent_per_default_key(
+    session: AsyncSession,
+) -> None:
+    created = await investment_report_create_impl(
+        items=[_action_item_dict()], **_create_kwargs()
+    )
+    bundle = await investment_report_get_impl(created["report"]["report_uuid"])
+    item_uuid = bundle["items"][0]["item_uuid"]
+
+    first = await investment_report_decide_item_impl(
+        item_uuid=item_uuid, decision="approve", actor="operator"
+    )
+    second = await investment_report_decide_item_impl(
+        item_uuid=item_uuid, decision="approve", actor="operator"
+    )
+    assert first["decision"]["decision_uuid"] == second["decision"]["decision_uuid"]
+
+
+@pytest.mark.asyncio
+async def test_decide_item_partial_approve_requires_payload(
+    session: AsyncSession,
+) -> None:
+    created = await investment_report_create_impl(
+        items=[_action_item_dict()], **_create_kwargs()
+    )
+    bundle = await investment_report_get_impl(created["report"]["report_uuid"])
+    item_uuid = bundle["items"][0]["item_uuid"]
+
+    with pytest.raises(Exception) as exc_info:
+        await investment_report_decide_item_impl(
+            item_uuid=item_uuid, decision="partial_approve", actor="operator"
+        )
+    assert "approved_payload_snapshot" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_activate_watch_copies_snapshot(session: AsyncSession) -> None:
+    created = await investment_report_create_impl(
+        items=[_watch_item_dict()], **_create_kwargs()
+    )
+    bundle = await investment_report_get_impl(created["report"]["report_uuid"])
+    watch_uuid = bundle["items"][0]["item_uuid"]
+    await investment_report_decide_item_impl(
+        item_uuid=watch_uuid, decision="approve", actor="operator"
+    )
+
+    response = await investment_report_activate_watch_impl(
+        item_uuid=watch_uuid, actor="operator"
+    )
+    assert response["success"] is True
+    assert response["alert"]["source_item_uuid"] == watch_uuid
+    assert response["alert"]["metric"] == "rsi"
+    assert response["alert"]["operator"] == "below"
+    assert response["item"]["status"] == "activated"
+
+
+@pytest.mark.asyncio
+async def test_context_get_aggregates_across_prior_reports(
+    session: AsyncSession,
+) -> None:
+    r1 = await investment_report_create_impl(
+        items=[_action_item_dict()], **_create_kwargs(kst_date="2026-05-16")
+    )
+    r2 = await investment_report_create_impl(
+        items=[_action_item_dict()], **_create_kwargs(kst_date="2026-05-17")
+    )
+    r3 = await investment_report_create_impl(
+        items=[_action_item_dict()], **_create_kwargs(kst_date="2026-05-18")
+    )
+    bundle_r1 = await investment_report_get_impl(r1["report"]["report_uuid"])
+    await investment_report_decide_item_impl(
+        item_uuid=bundle_r1["items"][0]["item_uuid"],
+        decision="defer",
+        actor="operator",
+    )
+
+    ctx = await investment_report_context_get_impl(
+        market="kr", exclude_report_uuid=r3["report"]["report_uuid"], n_prior=5
+    )
+    assert ctx["success"] is True
+    prior_uuids = {r["report_uuid"] for r in ctx["prior_reports"]}
+    assert prior_uuids == {r1["report"]["report_uuid"], r2["report"]["report_uuid"]}
+    deferred_item_uuids = {it["item_uuid"] for it in ctx["unresolved_deferred_items"]}
+    assert deferred_item_uuids == {bundle_r1["items"][0]["item_uuid"]}
+
+
+@pytest.mark.asyncio
+async def test_context_get_n_prior_clamped_to_ten(session: AsyncSession) -> None:
+    # 15 reports, asking for 50 prior — should be clamped to 10.
+    for i in range(15):
+        await investment_report_create_impl(
+            items=[_action_item_dict()],
+            **_create_kwargs(kst_date=f"2026-05-{i + 1:02d}"),
+        )
+    ctx = await investment_report_context_get_impl(market="kr", n_prior=50)
+    assert len(ctx["prior_reports"]) == 10

--- a/tests/test_investment_reports_router.py
+++ b/tests/test_investment_reports_router.py
@@ -1,0 +1,207 @@
+"""ROB-265 Plan 3 — HTTP router tests.
+
+We call the route functions directly with manually-supplied dependencies
+rather than going through TestClient. The route bodies are the part
+under test (serialisation + service wiring); the FastAPI plumbing is
+covered by FastAPI itself.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.routers.investment_reports import (
+    get_investment_report,
+    get_previous_report_context,
+    list_investment_reports,
+)
+from app.schemas.investment_reports import (
+    IngestReportItem,
+    IngestReportRequest,
+    RecordDecisionRequest,
+    WatchConditionPayload,
+)
+from app.services.investment_reports.decisions import (
+    InvestmentReportDecisionService,
+)
+from app.services.investment_reports.ingestion import (
+    InvestmentReportIngestionService,
+)
+from app.services.investment_reports.query_service import (
+    InvestmentReportQueryService,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from tests._investment_reports_helpers import future_datetime
+
+_USER = SimpleNamespace(username="operator-test", id=1)
+
+
+def _request(*, kst_date: str, **overrides) -> IngestReportRequest:
+    payload: dict = {
+        "report_type": "kr_morning",
+        "market": "kr",
+        "market_session": "regular",
+        "account_scope": "kis_mock",
+        "execution_mode": "mock_preview",
+        "created_by_profile": "test",
+        "title": f"t-{kst_date}",
+        "summary": "s",
+        "kst_date": kst_date,
+    }
+    payload.update(overrides)
+    return IngestReportRequest(**payload)
+
+
+def _action_item(client_item_key: str = "action-1") -> IngestReportItem:
+    return IngestReportItem(
+        client_item_key=client_item_key,
+        item_kind="action",
+        symbol="005930",
+        side="buy",
+        intent="buy_review",
+        rationale="r",
+    )
+
+
+def _watch_item(client_item_key: str = "watch-1") -> IngestReportItem:
+    return IngestReportItem(
+        client_item_key=client_item_key,
+        item_kind="watch",
+        symbol="000660",
+        intent="trend_recovery_review",
+        rationale="r",
+        watch_condition=WatchConditionPayload(
+            metric="rsi", operator="below", threshold=30
+        ),
+        valid_until=future_datetime(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_returns_empty_when_no_reports(session: AsyncSession) -> None:
+    service = InvestmentReportQueryService(session)
+    response = await list_investment_reports(
+        _user=_USER,
+        service=service,
+        market="kr",
+        market_session=None,
+        account_scope=None,
+        status_filter=None,
+        report_type=None,
+        limit=20,
+    )
+    assert response.reports == []
+
+
+@pytest.mark.asyncio
+async def test_list_filters_by_market(session: AsyncSession) -> None:
+    ingest = InvestmentReportIngestionService(session)
+    await ingest.ingest(_request(kst_date="2026-05-18", market="kr"))
+    await ingest.ingest(_request(kst_date="2026-05-18", market="us"))
+    await session.commit()
+
+    service = InvestmentReportQueryService(session)
+    kr_response = await list_investment_reports(
+        _user=_USER,
+        service=service,
+        market="kr",
+        market_session=None,
+        account_scope=None,
+        status_filter=None,
+        report_type=None,
+        limit=20,
+    )
+    assert len(kr_response.reports) == 1
+    assert kr_response.reports[0].market == "kr"
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_returns_nested_response(session: AsyncSession) -> None:
+    ingest = InvestmentReportIngestionService(session)
+    report = await ingest.ingest(
+        _request(kst_date="2026-05-18", items=[_action_item(), _watch_item()])
+    )
+
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(report.id)
+    action_item = next(it for it in items if it.item_kind == "action")
+    decisions_svc = InvestmentReportDecisionService(session)
+    await decisions_svc.record(
+        RecordDecisionRequest(
+            item_uuid=action_item.item_uuid,
+            decision="approve",
+            actor="operator-test",
+        )
+    )
+    await session.commit()
+
+    service = InvestmentReportQueryService(session)
+    bundle = await get_investment_report(
+        report_uuid=report.report_uuid, _user=_USER, service=service
+    )
+    assert bundle.report.report_uuid == report.report_uuid
+    assert len(bundle.items) == 2
+    # decision keyed by item_uuid string in the response shape
+    assert str(action_item.item_uuid) in bundle.decisions_by_item_uuid
+    assert len(bundle.decisions_by_item_uuid[str(action_item.item_uuid)]) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_bundle_404_for_missing_report(session: AsyncSession) -> None:
+    service = InvestmentReportQueryService(session)
+    with pytest.raises(HTTPException) as exc_info:
+        await get_investment_report(
+            report_uuid=uuid.uuid4(), _user=_USER, service=service
+        )
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.detail == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_previous_context_empty_for_unknown_market(
+    session: AsyncSession,
+) -> None:
+    service = InvestmentReportQueryService(session)
+    response = await get_previous_report_context(
+        _user=_USER,
+        service=service,
+        market="kr",
+        market_session=None,
+        account_scope=None,
+        report_type=None,
+        exclude_report_uuid=None,
+        n_prior=3,
+    )
+    assert response.prior_reports == []
+    assert response.unresolved_deferred_items == []
+    assert response.active_watches == []
+    assert response.triggered_events == []
+    assert response.recent_decisions == []
+
+
+@pytest.mark.asyncio
+async def test_previous_context_with_prior_reports(session: AsyncSession) -> None:
+    ingest = InvestmentReportIngestionService(session)
+    r1 = await ingest.ingest(_request(kst_date="2026-05-16"))
+    r2 = await ingest.ingest(_request(kst_date="2026-05-17"))
+    r3 = await ingest.ingest(_request(kst_date="2026-05-18"))
+    await session.commit()
+
+    service = InvestmentReportQueryService(session)
+    response = await get_previous_report_context(
+        _user=_USER,
+        service=service,
+        market="kr",
+        market_session=None,
+        account_scope=None,
+        report_type=None,
+        exclude_report_uuid=r3.report_uuid,
+        n_prior=5,
+    )
+    prior_uuids = {r.report_uuid for r in response.prior_reports}
+    assert prior_uuids == {r1.report_uuid, r2.report_uuid}


### PR DESCRIPTION
## Summary

Plan 3 of ROB-265 — read HTTP surface + 6 MCP tools over the Plan 2 service layer. Stacked on PR #865 (Plan 2). Base will auto-update to `main` when both Plan 1 (#862) and Plan 2 (#865) merge.

**HTTP routes (auth-gated, GET-only):**
- `GET /trading/api/investment-reports` + `/invest/api/investment-reports` — list (filters: market, market_session, account_scope, status, report_type, limit)
- `GET /trading/api/investment-reports/context` — previous-report context (n_prior, exclude_report_uuid)
- `GET /trading/api/investment-reports/{report_uuid}` + `/invest/...` — bundle

**MCP tools (all 6 from the Linear issue):**
- `investment_report_create` — idempotent ingestion
- `investment_report_list` — filter pass-through, limit clamped 1..100
- `investment_report_get` — bundle (report + items + decisions + alerts + events)
- `investment_report_decide_item` — record decision, transitions item status; `partial_approve` requires non-empty `approved_payload_snapshot`
- `investment_report_activate_watch` — copy approved watch item → immutable alert snapshot
- `investment_report_context_get` — prior reports + deferred items + active watches + triggered events + recent decisions, n_prior clamped 1..10

**Pydantic response models** with `from_attributes=True` + `serialization_alias` so the ORM's `*_metadata` attribute maps to the cleaner `metadata` JSON key.

## Test plan

- [x] `pytest tests/test_investment_reports_router.py tests/test_investment_reports_mcp.py -v` — **17 new P3 tests pass** (6 router + 11 MCP)
- [x] Full P1+P2+P3 sweep — **111 passed**
- [x] Legacy guard — `test_analysis_report_workflow.py`, `test_mcp_watch_order_intent_ledger.py`, `test_watch_order_intent_service.py` — **16 passed**
- [x] `ruff format` / `ruff check` clean
- [x] `ty check app/schemas/investment_reports.py app/routers/investment_reports.py app/mcp_server/tooling/investment_reports_handlers.py` clean
- [x] No broker / KIS / Upbit / Alpaca imports introduced (grep-verified)

## Notable design notes

- The `/context` route is declared **before** `/{report_uuid}` in the router so FastAPI doesn't try to parse the literal `context` as a UUID parameter.
- `investment_report_create_impl` probes the composed idempotency key before calling the service, so the response can faithfully report `idempotent: True/False`.
- Router tests call route functions directly with manually-supplied dependencies rather than going through `TestClient` — avoids the sync/async cross-loop friction with the shared async session fixture. The MCP `*_impl` tests open their own `AsyncSessionLocal` (matches the legacy MCP test pattern).
- Legacy `analysis_*` and `watch_order_intent_ledger_*` MCP registrations remain in place. Clean cut is Plan 5.

## Out of scope (Plans 4-5)

- OpenClaw notification payload schema update — Plan 4 (the scanner is what calls OpenClaw with event payloads; updating the client without a caller is dead code).
- Watch scanner re-wire onto `investment_watch_alerts` / `investment_watch_events` — Plan 4.
- Frontend `/invest/reports` UI + NXT advisory-only pilot — Plan 5.
- Legacy clean cut (drop `analysis_*` + `watch_order_intent_ledger_*` MCP/API/services/models/tables) — Plan 5.

## CI note

Stacked PR base is `rob-265-plan-2`; `test.yml` only triggers on PRs to `main`/`develop` so the GitHub workflow does not auto-run on this PR. Verification is local. When PR #862 (Plan 1) and PR #865 (Plan 2) merge to main this PR's base will auto-update and CI will activate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)