### PR TITLE
ROB-265 Plan 4: investment watch scanner + Hermes review-trigger notifications

### DIFF
--- a/alembic/versions/20260519_rob265_watch_event_delivery.py
+++ b/alembic/versions/20260519_rob265_watch_event_delivery.py
@@ -1,0 +1,87 @@
+"""rob-265 add delivery tracking to investment_watch_events
+
+Plan 4 hardening — adds delivery_status / delivery_reason /
+delivered_at / delivery_attempts so a failed or skipped Hermes
+review-trigger delivery is auditable and re-attemptable instead of
+silently consuming the alert.
+
+Revision ID: 20260519_rob265_delivery
+Revises: 20260518_rob265
+Create Date: 2026-05-19
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "20260519_rob265_delivery"
+down_revision: str | None = "20260518_rob265"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "investment_watch_events",
+        sa.Column(
+            "delivery_status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        schema="review",
+    )
+    op.add_column(
+        "investment_watch_events",
+        sa.Column("delivery_reason", sa.Text(), nullable=True),
+        schema="review",
+    )
+    op.add_column(
+        "investment_watch_events",
+        sa.Column("delivered_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        schema="review",
+    )
+    op.add_column(
+        "investment_watch_events",
+        sa.Column(
+            "delivery_attempts",
+            sa.Integer(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        schema="review",
+    )
+    op.create_check_constraint(
+        "ck_investment_watch_events_delivery_status",
+        "investment_watch_events",
+        "delivery_status IN ('pending','delivered','skipped','failed')",
+        schema="review",
+    )
+    op.create_index(
+        "ix_investment_watch_events_delivery_status_created",
+        "investment_watch_events",
+        ["delivery_status", "created_at"],
+        schema="review",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_investment_watch_events_delivery_status_created",
+        table_name="investment_watch_events",
+        schema="review",
+    )
+    op.drop_constraint(
+        "ck_investment_watch_events_delivery_status",
+        "investment_watch_events",
+        type_="check",
+        schema="review",
+    )
+    op.drop_column("investment_watch_events", "delivery_attempts", schema="review")
+    op.drop_column("investment_watch_events", "delivered_at", schema="review")
+    op.drop_column("investment_watch_events", "delivery_reason", schema="review")
+    op.drop_column("investment_watch_events", "delivery_status", schema="review")

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -367,6 +367,14 @@ class Settings(BaseSettings):
     OPENCLAW_SCREENER_CALLBACK_URL: str = "http://localhost:8000/api/screener/callback"
     OPENCLAW_ENABLED: bool = False
 
+    # Hermes review-trigger notification (ROB-265 Plan 4). Replaces the
+    # OpenClaw-flavoured watch-alert delivery for ``investment_watch_events``.
+    # When ``HERMES_ENABLED`` is False the client skips the HTTP call and
+    # returns ``status='skipped'`` — useful for tests and disabled-env runs.
+    HERMES_WEBHOOK_URL: str = "http://localhost:18790/hooks/review-trigger"
+    HERMES_TOKEN: str = ""
+    HERMES_ENABLED: bool = False
+
     # N8N Fill Notification webhook (replaces OPENCLAW_THREAD_* for fills)
     N8N_FILL_WEBHOOK_URL: str = ""
     # Watch Alert router (Phase 0 of ROB-122 — transport-neutral seam).

--- a/app/jobs/investment_watch_scanner.py
+++ b/app/jobs/investment_watch_scanner.py
@@ -10,10 +10,16 @@ Locked semantics:
 * Watch is a **review trigger**, never an automatic order instruction.
 * No broker / live order mutation from this path.
 * Notification target is **Hermes**, never OpenClaw.
+* The alert only transitions to ``triggered`` after Hermes confirms
+  delivery. ``skipped`` (HERMES_ENABLED=False) and ``failed`` deliveries
+  leave the alert ``active`` so the next scan loop can re-attempt
+  against the existing event row (looked up via the idempotency_key
+  collision). The event row carries the delivery-tracking columns
+  (``delivery_status`` / ``delivery_reason`` / ``delivered_at`` /
+  ``delivery_attempts``) for audit + frontend visibility.
 * ``investment_watch_events.idempotency_key`` is unique on
-  ``event:{alert_uuid}:{kst_date}:{threshold_key}`` — a re-fire on the
-  same KST day at the same threshold is a DB-level no-op (the scanner
-  records it as ``ignored`` for that loop iteration and moves on).
+  ``event:{alert_uuid}:{kst_date}:{threshold_key}`` — same-day collisions
+  trigger the retry path (NOT a silent no-op).
 """
 
 from __future__ import annotations
@@ -48,9 +54,10 @@ logger = logging.getLogger(__name__)
 
 
 # action_mode → starting outcome on the event row. Hermes delivery
-# success/failure is tracked separately (logs + scan summary); it does
-# NOT mutate this column after the fact (Plan 4 is fire-and-log;
-# a Plan 5+ follow-up could add an outbox/retry).
+# success/failure is tracked separately via the delivery_status /
+# delivery_reason / delivered_at / delivery_attempts columns; the
+# original ``outcome`` is the operator-facing classification of what
+# the watch represented (notified / review_required / preview_attached).
 _OUTCOME_BY_ACTION_MODE: dict[str, str] = {
     "notify_only": "notified",
     "preview_only": "preview_attached",
@@ -147,39 +154,48 @@ class InvestmentWatchScanner:
                 if not is_triggered(current_value, alert.operator, threshold_value):
                     continue
 
-                # Trigger detected — persist the event + transition the alert.
-                emission = await self._emit_event(
+                # Insert (or look up existing) event row with delivery_status='pending'.
+                emission = await self._upsert_event(
                     db=db,
                     repo=repo,
                     alert=alert,
                     current_value=current_value,
                 )
                 if emission is None:
+                    # Same-day collision and existing event is already delivered;
+                    # nothing left to do for this loop iteration.
                     stats.duplicates += 1
                     continue
 
-                stats.triggered += 1
-                stats.details.append(emission["detail"])
+                is_first_attempt = emission["is_first_attempt"]
 
-                # Hermes delivery is best-effort. Event row already persisted.
-                delivery = await self._hermes.send_review_trigger(emission["payload"])
-                if delivery.status == "success":
-                    stats.notified += 1
-                elif delivery.status == "skipped":
-                    stats.skipped_delivery += 1
+                if is_first_attempt:
+                    stats.triggered += 1
+                    stats.details.append(emission["detail"])
                 else:
-                    stats.failed_delivery += 1
-                    logger.warning(
-                        "Hermes review-trigger delivery failed: "
-                        "alert_uuid=%s event_uuid=%s reason=%s",
-                        alert.alert_uuid,
-                        emission["event_uuid"],
-                        delivery.reason,
-                    )
+                    # No new event row this iteration — we found an
+                    # existing pending/failed/skipped row from earlier
+                    # in the day and are re-attempting delivery against
+                    # it. Count as a duplicate so the scan summary
+                    # reflects "row reused, not created".
+                    stats.duplicates += 1
+
+                # Attempt Hermes delivery and gate the alert transition on it.
+                delivery = await self._hermes.send_review_trigger(emission["payload"])
+                await self._record_delivery_outcome(
+                    db=db,
+                    repo=repo,
+                    alert_id=emission["alert_id"],
+                    alert_uuid=emission["alert_uuid"],
+                    event_id=emission["event_id"],
+                    event_uuid=emission["event_uuid"],
+                    delivery=delivery,
+                    stats=stats,
+                )
 
             return stats.summary(normalized_market, market_open=market_open)
 
-    async def _emit_event(
+    async def _upsert_event(
         self,
         *,
         db: AsyncSession,
@@ -187,83 +203,178 @@ class InvestmentWatchScanner:
         alert: Any,
         current_value: float,
     ) -> dict[str, Any] | None:
-        outcome = _OUTCOME_BY_ACTION_MODE.get(alert.action_mode, "notified")
+        """Insert a fresh event row, or load the existing one for retry.
+
+        Returns ``None`` if a same-day event already exists and was
+        already delivered (nothing to do). Otherwise returns the event
+        row + payload + ``is_first_attempt`` flag.
+        """
+        # Snapshot the alert into plain locals before any commit/rollback —
+        # a rolled-back transaction expires SQLAlchemy attribute state, and
+        # later reads of ``alert.xxx`` would trigger a lazy refresh from
+        # the wrong session context (MissingGreenlet).
+        alert_id = alert.id
+        alert_uuid_value = alert.alert_uuid
+        alert_source_report_uuid = alert.source_report_uuid
+        alert_source_item_uuid = alert.source_item_uuid
+        alert_market = alert.market
+        alert_target_kind = alert.target_kind
+        alert_symbol = alert.symbol
+        alert_metric = alert.metric
+        alert_operator = alert.operator
+        alert_threshold = alert.threshold
+        alert_threshold_key = alert.threshold_key
+        alert_intent = alert.intent
+        alert_action_mode = alert.action_mode
+
+        outcome = _OUTCOME_BY_ACTION_MODE.get(alert_action_mode, "notified")
         correlation_id = uuid4().hex
         kst_date = now_kst().date().isoformat()
         idempotency_key = watch_event_key(
-            alert_uuid=str(alert.alert_uuid),
+            alert_uuid=str(alert_uuid_value),
             kst_date=kst_date,
-            threshold_key=alert.threshold_key,
+            threshold_key=alert_threshold_key,
         )
         current_value_decimal = Decimal(str(current_value))
         scanner_snapshot: dict[str, Any] = {
-            "metric": alert.metric,
-            "operator": alert.operator,
+            "metric": alert_metric,
+            "operator": alert_operator,
             "current_value": current_value,
-            "threshold": float(alert.threshold),
+            "threshold": float(alert_threshold),
         }
 
+        is_first_attempt = True
         try:
             event = await repo.insert_event(
                 event_uuid=uuid4(),
                 idempotency_key=idempotency_key,
-                alert_id=alert.id,
-                source_report_uuid=alert.source_report_uuid,
-                source_item_uuid=alert.source_item_uuid,
-                market=alert.market,
-                target_kind=alert.target_kind,
-                symbol=alert.symbol,
-                metric=alert.metric,
-                operator=alert.operator,
-                threshold=alert.threshold,
-                threshold_key=alert.threshold_key,
-                intent=alert.intent,
-                action_mode=alert.action_mode,
+                alert_id=alert_id,
+                source_report_uuid=alert_source_report_uuid,
+                source_item_uuid=alert_source_item_uuid,
+                market=alert_market,
+                target_kind=alert_target_kind,
+                symbol=alert_symbol,
+                metric=alert_metric,
+                operator=alert_operator,
+                threshold=alert_threshold,
+                threshold_key=alert_threshold_key,
+                intent=alert_intent,
+                action_mode=alert_action_mode,
                 current_value=current_value_decimal,
                 scanner_snapshot=scanner_snapshot,
                 outcome=outcome,
                 correlation_id=correlation_id,
                 kst_date=kst_date,
             )
-            await repo.update_alert_status(alert.id, "triggered")
             await db.commit()
         except IntegrityError:
-            # Same-day re-fire — already emitted. No-op.
+            # Same-day re-fire — load the existing row and retry delivery
+            # if it's still pending/skipped/failed.
             await db.rollback()
-            return None
+            event = await repo.get_event_by_idempotency_key(idempotency_key)
+            if event is None:
+                return None
+            if event.delivery_status == "delivered":
+                # Already delivered on a previous run — no work to do.
+                return None
+            is_first_attempt = False
 
+        # Build the Hermes payload from the event row's persisted fields so
+        # a retry sends the exact same identity snapshot that's on disk.
         payload = ReviewTriggerPayload(
             event_uuid=event.event_uuid,
-            alert_uuid=alert.alert_uuid,
-            source_report_uuid=alert.source_report_uuid,
-            source_item_uuid=alert.source_item_uuid,
-            correlation_id=correlation_id,
-            kst_date=kst_date,
-            market=alert.market,
-            target_kind=alert.target_kind,
-            symbol=alert.symbol,
-            metric=alert.metric,
-            operator=alert.operator,
-            threshold=alert.threshold,
-            threshold_key=alert.threshold_key,
-            intent=alert.intent,
-            action_mode=alert.action_mode,
-            current_value=current_value_decimal,
-            scanner_snapshot=scanner_snapshot,
-            outcome=outcome,
+            alert_uuid=alert_uuid_value,
+            source_report_uuid=event.source_report_uuid,
+            source_item_uuid=event.source_item_uuid,
+            correlation_id=event.correlation_id,
+            kst_date=event.kst_date,
+            market=event.market,
+            target_kind=event.target_kind,
+            symbol=event.symbol,
+            metric=event.metric,
+            operator=event.operator,
+            threshold=Decimal(str(event.threshold)),
+            threshold_key=event.threshold_key,
+            intent=event.intent,
+            action_mode=event.action_mode,
+            current_value=(
+                Decimal(str(event.current_value))
+                if event.current_value is not None
+                else None
+            ),
+            scanner_snapshot=event.scanner_snapshot,
+            outcome=event.outcome,
         )
         return {
+            "event": event,
+            "event_id": event.id,
             "event_uuid": event.event_uuid,
+            "alert_id": alert_id,
+            "alert_uuid": alert_uuid_value,
             "payload": payload,
+            "is_first_attempt": is_first_attempt,
             "detail": {
-                "alert_uuid": str(alert.alert_uuid),
+                "alert_uuid": str(alert_uuid_value),
                 "event_uuid": str(event.event_uuid),
-                "outcome": outcome,
-                "symbol": alert.symbol,
+                "outcome": event.outcome,
+                "symbol": alert_symbol,
                 "current_value": current_value,
-                "threshold": float(alert.threshold),
+                "threshold": float(alert_threshold),
             },
         }
+
+    async def _record_delivery_outcome(
+        self,
+        *,
+        db: AsyncSession,
+        repo: InvestmentReportsRepository,
+        alert_id: int,
+        alert_uuid: Any,
+        event_id: int,
+        event_uuid: Any,
+        delivery: Any,
+        stats: _ScanStats,
+    ) -> None:
+        """Update event delivery columns and gate alert.status on success.
+
+        Plan 4 hardening: ``alert.status`` only transitions to
+        ``triggered`` when ``delivery.status == 'success'``. A
+        ``skipped`` or ``failed`` delivery leaves the alert ``active``
+        so the next scan loop can re-attempt against the existing event
+        row (looked up via the idempotency_key collision).
+        """
+        delivered_at: datetime | None = None
+        delivery_reason: str | None = None
+
+        if delivery.status == "success":
+            delivery_status = "delivered"
+            delivered_at = datetime.now(UTC)
+            stats.notified += 1
+        elif delivery.status == "skipped":
+            delivery_status = "skipped"
+            delivery_reason = delivery.reason or "hermes_disabled"
+            stats.skipped_delivery += 1
+        else:
+            delivery_status = "failed"
+            delivery_reason = delivery.reason or "unknown"
+            stats.failed_delivery += 1
+            logger.warning(
+                "Hermes review-trigger delivery failed: "
+                "alert_uuid=%s event_uuid=%s reason=%s",
+                alert_uuid,
+                event_uuid,
+                delivery_reason,
+            )
+
+        await repo.update_event_delivery(
+            event_id,
+            delivery_status=delivery_status,
+            delivery_reason=delivery_reason,
+            delivered_at=delivered_at,
+        )
+        if delivery_status == "delivered":
+            await repo.update_alert_status(alert_id, "triggered")
+        await db.commit()
 
     async def run(self) -> dict[str, dict[str, Any]]:
         results: dict[str, dict[str, Any]] = {}

--- a/app/jobs/investment_watch_scanner.py
+++ b/app/jobs/investment_watch_scanner.py
@@ -1,0 +1,286 @@
+"""ROB-265 Plan 4 — investment_watch scanner.
+
+Reads DB-backed ``investment_watch_alerts``, evaluates the trigger via
+``watch_market_data.get_current_value``, persists triggered fires to
+``investment_watch_events`` with the immutable trigger-identity
+snapshot, transitions the alert to ``triggered``, and emits Hermes
+review-trigger notifications.
+
+Locked semantics:
+* Watch is a **review trigger**, never an automatic order instruction.
+* No broker / live order mutation from this path.
+* Notification target is **Hermes**, never OpenClaw.
+* ``investment_watch_events.idempotency_key`` is unique on
+  ``event:{alert_uuid}:{kst_date}:{threshold_key}`` — a re-fire on the
+  same KST day at the same threshold is a DB-level no-op (the scanner
+  records it as ``ignored`` for that loop iteration and moves on).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+from uuid import uuid4
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.db import AsyncSessionLocal
+from app.core.timezone import now_kst
+from app.jobs.watch_market_data import (
+    get_current_value,
+    is_market_open,
+    is_triggered,
+)
+from app.services.hermes_client import (
+    HermesNotificationClient,
+    ReviewTriggerPayload,
+)
+from app.services.investment_reports.idempotency import watch_event_key
+from app.services.investment_reports.repository import InvestmentReportsRepository
+
+logger = logging.getLogger(__name__)
+
+
+# action_mode → starting outcome on the event row. Hermes delivery
+# success/failure is tracked separately (logs + scan summary); it does
+# NOT mutate this column after the fact (Plan 4 is fire-and-log;
+# a Plan 5+ follow-up could add an outbox/retry).
+_OUTCOME_BY_ACTION_MODE: dict[str, str] = {
+    "notify_only": "notified",
+    "preview_only": "preview_attached",
+    "approval_required": "review_required",
+}
+
+
+@dataclass
+class _ScanStats:
+    alerts_seen: int = 0
+    triggered: int = 0
+    notified: int = 0
+    duplicates: int = 0
+    failed_lookups: int = 0
+    failed_delivery: int = 0
+    skipped_delivery: int = 0
+    skipped_closed: int = 0
+    details: list[dict[str, Any]] = field(default_factory=list)
+
+    def summary(self, market: str, *, market_open: bool) -> dict[str, Any]:
+        return {
+            "market": market,
+            "market_open": market_open,
+            "alerts_seen": self.alerts_seen,
+            "triggered": self.triggered,
+            "notified": self.notified,
+            "duplicates": self.duplicates,
+            "failed_lookups": self.failed_lookups,
+            "failed_delivery": self.failed_delivery,
+            "skipped_delivery": self.skipped_delivery,
+            "skipped_closed": self.skipped_closed,
+            "details": self.details,
+        }
+
+
+SessionFactory = Callable[[], AbstractAsyncContextManager[AsyncSession]]
+
+
+class InvestmentWatchScanner:
+    """Per-market scan of ``investment_watch_alerts`` → events → Hermes."""
+
+    def __init__(
+        self,
+        *,
+        hermes_client: HermesNotificationClient | None = None,
+        session_factory: SessionFactory | None = None,
+    ) -> None:
+        self._hermes = hermes_client or HermesNotificationClient()
+        self._session_factory: SessionFactory = session_factory or AsyncSessionLocal
+
+    async def scan_market(self, market: str) -> dict[str, Any]:
+        normalized_market = str(market).strip().lower()
+        market_open = is_market_open(normalized_market)
+        stats = _ScanStats()
+
+        async with self._session_factory() as db:
+            repo = InvestmentReportsRepository(db)
+            now_utc = datetime.now(UTC)
+            alerts = await repo.list_active_alerts(
+                market=normalized_market, valid_at=now_utc
+            )
+            stats.alerts_seen = len(alerts)
+
+            if not alerts:
+                return stats.summary(normalized_market, market_open=market_open)
+
+            for alert in alerts:
+                # FX watches keep firing while regular markets are closed.
+                if not market_open and alert.target_kind != "fx":
+                    stats.skipped_closed += 1
+                    continue
+
+                try:
+                    current_value = await get_current_value(
+                        target_kind=alert.target_kind,
+                        metric=alert.metric,
+                        symbol=alert.symbol,
+                        market=alert.market,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "investment-watch lookup failed: "
+                        "alert_uuid=%s market=%s symbol=%s metric=%s error=%s",
+                        alert.alert_uuid,
+                        alert.market,
+                        alert.symbol,
+                        alert.metric,
+                        exc,
+                    )
+                    stats.failed_lookups += 1
+                    continue
+
+                threshold_value = float(alert.threshold)
+                if not is_triggered(current_value, alert.operator, threshold_value):
+                    continue
+
+                # Trigger detected — persist the event + transition the alert.
+                emission = await self._emit_event(
+                    db=db,
+                    repo=repo,
+                    alert=alert,
+                    current_value=current_value,
+                )
+                if emission is None:
+                    stats.duplicates += 1
+                    continue
+
+                stats.triggered += 1
+                stats.details.append(emission["detail"])
+
+                # Hermes delivery is best-effort. Event row already persisted.
+                delivery = await self._hermes.send_review_trigger(emission["payload"])
+                if delivery.status == "success":
+                    stats.notified += 1
+                elif delivery.status == "skipped":
+                    stats.skipped_delivery += 1
+                else:
+                    stats.failed_delivery += 1
+                    logger.warning(
+                        "Hermes review-trigger delivery failed: "
+                        "alert_uuid=%s event_uuid=%s reason=%s",
+                        alert.alert_uuid,
+                        emission["event_uuid"],
+                        delivery.reason,
+                    )
+
+            return stats.summary(normalized_market, market_open=market_open)
+
+    async def _emit_event(
+        self,
+        *,
+        db: AsyncSession,
+        repo: InvestmentReportsRepository,
+        alert: Any,
+        current_value: float,
+    ) -> dict[str, Any] | None:
+        outcome = _OUTCOME_BY_ACTION_MODE.get(alert.action_mode, "notified")
+        correlation_id = uuid4().hex
+        kst_date = now_kst().date().isoformat()
+        idempotency_key = watch_event_key(
+            alert_uuid=str(alert.alert_uuid),
+            kst_date=kst_date,
+            threshold_key=alert.threshold_key,
+        )
+        current_value_decimal = Decimal(str(current_value))
+        scanner_snapshot: dict[str, Any] = {
+            "metric": alert.metric,
+            "operator": alert.operator,
+            "current_value": current_value,
+            "threshold": float(alert.threshold),
+        }
+
+        try:
+            event = await repo.insert_event(
+                event_uuid=uuid4(),
+                idempotency_key=idempotency_key,
+                alert_id=alert.id,
+                source_report_uuid=alert.source_report_uuid,
+                source_item_uuid=alert.source_item_uuid,
+                market=alert.market,
+                target_kind=alert.target_kind,
+                symbol=alert.symbol,
+                metric=alert.metric,
+                operator=alert.operator,
+                threshold=alert.threshold,
+                threshold_key=alert.threshold_key,
+                intent=alert.intent,
+                action_mode=alert.action_mode,
+                current_value=current_value_decimal,
+                scanner_snapshot=scanner_snapshot,
+                outcome=outcome,
+                correlation_id=correlation_id,
+                kst_date=kst_date,
+            )
+            await repo.update_alert_status(alert.id, "triggered")
+            await db.commit()
+        except IntegrityError:
+            # Same-day re-fire — already emitted. No-op.
+            await db.rollback()
+            return None
+
+        payload = ReviewTriggerPayload(
+            event_uuid=event.event_uuid,
+            alert_uuid=alert.alert_uuid,
+            source_report_uuid=alert.source_report_uuid,
+            source_item_uuid=alert.source_item_uuid,
+            correlation_id=correlation_id,
+            kst_date=kst_date,
+            market=alert.market,
+            target_kind=alert.target_kind,
+            symbol=alert.symbol,
+            metric=alert.metric,
+            operator=alert.operator,
+            threshold=alert.threshold,
+            threshold_key=alert.threshold_key,
+            intent=alert.intent,
+            action_mode=alert.action_mode,
+            current_value=current_value_decimal,
+            scanner_snapshot=scanner_snapshot,
+            outcome=outcome,
+        )
+        return {
+            "event_uuid": event.event_uuid,
+            "payload": payload,
+            "detail": {
+                "alert_uuid": str(alert.alert_uuid),
+                "event_uuid": str(event.event_uuid),
+                "outcome": outcome,
+                "symbol": alert.symbol,
+                "current_value": current_value,
+                "threshold": float(alert.threshold),
+            },
+        }
+
+    async def run(self) -> dict[str, dict[str, Any]]:
+        results: dict[str, dict[str, Any]] = {}
+        for market in ("crypto", "kr", "us"):
+            try:
+                results[market] = await self.scan_market(market)
+            except Exception as exc:
+                logger.exception(
+                    "investment_watch scan_market raised: market=%s", market
+                )
+                results[market] = {
+                    "market": market,
+                    "status": "failed",
+                    "reason": "scan_aborted",
+                    "error": str(exc),
+                }
+        return results
+
+    async def close(self) -> None:
+        await self._hermes.close()

--- a/app/jobs/watch_market_data.py
+++ b/app/jobs/watch_market_data.py
@@ -1,0 +1,237 @@
+"""ROB-265 Plan 4 — stateless market-data helpers for the watch scanners.
+
+Extracted from the legacy :class:`app.jobs.watch_scanner.WatchScanner`
+so the new :class:`InvestmentWatchScanner` can read live price /
+RSI / trade-value / index / FX values without inheriting from the
+legacy class (which couples to OpenClawClient).
+
+Behaviourally identical to the legacy methods. Plan 5 deletes the
+legacy scanner's duplicate copy.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+import exchange_calendars as xcals
+import pandas as pd
+from pandas import Timestamp
+
+from app.mcp_server.tooling.market_data_indicators import _calculate_rsi
+from app.services import exchange_rate_service, market_index_service
+from app.services import market_data as market_data_service
+
+_CRYPTO_RSI_LOOKBACK_DAYS = 200
+
+
+@lru_cache(maxsize=2)
+def _get_calendar(market: str):
+    if market == "kr":
+        return xcals.get_calendar("XKRX")
+    if market == "us":
+        return xcals.get_calendar("XNYS")
+    return None
+
+
+def is_market_open(market: str) -> bool:
+    if market == "crypto":
+        return True
+
+    calendar = _get_calendar(market)
+    if calendar is None:
+        return False
+
+    now_utc = Timestamp.now("UTC").floor("min")
+    if now_utc.tz is None:
+        now_utc = now_utc.tz_localize("UTC")
+    now_in_market_tz = now_utc.tz_convert(calendar.tz)
+    return bool(calendar.is_trading_minute(now_in_market_tz))
+
+
+def _to_float(value: object) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_crypto_symbol(symbol: str) -> str:
+    upper_symbol = symbol.strip().upper()
+    if "-" in upper_symbol:
+        return upper_symbol
+    return f"KRW-{upper_symbol}"
+
+
+async def get_price(symbol: str, market: str) -> float | None:
+    if market == "crypto":
+        quote = await market_data_service.get_quote(
+            symbol=normalize_crypto_symbol(symbol),
+            market="crypto",
+        )
+        return _to_float(getattr(quote, "price", None))
+    if market == "kr":
+        quote = await market_data_service.get_quote(
+            symbol=symbol,
+            market="equity_kr",
+        )
+        return _to_float(getattr(quote, "price", None))
+    if market == "us":
+        normalized_symbol = str(symbol or "").strip().upper()
+        quote = await market_data_service.get_quote(
+            symbol=normalized_symbol,
+            market="equity_us",
+        )
+        price = _to_float(getattr(quote, "price", None))
+        if price is None:
+            raise ValueError(
+                f"US watch price fetch failed for {normalized_symbol}: invalid close"
+            )
+        return price
+    return None
+
+
+async def get_trade_value(symbol: str, market: str) -> float | None:
+    if market != "kr":
+        return None
+    quote = await market_data_service.get_quote(
+        symbol=symbol,
+        market="equity_kr",
+    )
+    return _to_float(getattr(quote, "value", None))
+
+
+async def get_index_price(symbol: str, market: str) -> float | None:
+    if market != "kr":
+        return None
+    normalized_symbol = str(symbol or "").strip().upper()
+    if normalized_symbol not in {"KOSPI", "KOSDAQ"}:
+        return None
+    data = await market_index_service.get_kr_index_quote(normalized_symbol)
+    return _to_float(data.get("current"))
+
+
+async def get_fx_price(symbol: str) -> float | None:
+    normalized_symbol = str(symbol or "").strip().upper()
+    if normalized_symbol != "USDKRW":
+        return None
+    return _to_float(await exchange_rate_service.get_usd_krw_quote())
+
+
+async def get_rsi(symbol: str, market: str) -> float | None:
+    if market == "crypto":
+        symbol_for_query = normalize_crypto_symbol(symbol)
+        market_for_query = "crypto"
+        count = _CRYPTO_RSI_LOOKBACK_DAYS
+    elif market == "kr":
+        symbol_for_query = symbol
+        market_for_query = "equity_kr"
+        count = 250
+    elif market == "us":
+        symbol_for_query = symbol
+        market_for_query = "equity_us"
+        count = 250
+    else:
+        return None
+
+    candles = await market_data_service.get_ohlcv(
+        symbol=symbol_for_query,
+        market=market_for_query,
+        period="day",
+        count=count,
+    )
+
+    if not candles:
+        return None
+
+    close_values: list[float] = []
+    for candle in candles:
+        if isinstance(candle, dict):
+            close_raw = candle.get("close")
+        else:
+            close_raw = getattr(candle, "close", None)
+        close_value = _to_float(close_raw)
+        if close_value is None:
+            continue
+        close_values.append(close_value)
+
+    if not close_values:
+        return None
+
+    close = pd.Series(close_values, dtype="float64").dropna()
+    if close.empty:
+        return None
+
+    return _to_float(_calculate_rsi(close).get("14"))
+
+
+async def get_current_value(
+    *,
+    target_kind: str,
+    metric: str,
+    symbol: str,
+    market: str,
+) -> float | None:
+    """Dispatch by ``target_kind`` × ``metric`` to the right value fetch.
+
+    Mirrors the legacy scanner's matrix so RSI / index / FX paths
+    are not lost on the new scanner.
+    """
+    if target_kind == "asset":
+        if metric == "price":
+            return await get_price(symbol, market)
+        if metric == "rsi":
+            return await get_rsi(symbol, market)
+        if metric == "trade_value":
+            return await get_trade_value(symbol, market)
+        return None
+    if target_kind == "index":
+        if metric == "price":
+            return await get_index_price(symbol, market)
+        return None
+    if target_kind == "fx":
+        if metric == "price":
+            return await get_fx_price(symbol)
+        return None
+    return None
+
+
+def is_triggered(current: float | None, operator: str, threshold: float) -> bool:
+    if current is None:
+        return False
+    if operator == "above":
+        return current > threshold
+    if operator == "below":
+        return current < threshold
+    return False
+
+
+__all__ = [
+    "get_current_value",
+    "get_fx_price",
+    "get_index_price",
+    "get_price",
+    "get_rsi",
+    "get_trade_value",
+    "is_market_open",
+    "is_triggered",
+    "normalize_crypto_symbol",
+]
+
+
+def _build_scanner_snapshot(
+    *,
+    current_value: Any,
+    threshold: Any,
+    metric: str,
+    operator: str,
+) -> dict[str, Any]:
+    """Return the minimal scanner_snapshot JSONB body for an event row."""
+    return {
+        "metric": metric,
+        "operator": operator,
+        "current_value": _to_float(current_value),
+        "threshold": _to_float(threshold),
+    }

--- a/app/models/investment_reports.py
+++ b/app/models/investment_reports.py
@@ -510,6 +510,14 @@ class InvestmentWatchEvent(Base):
             "action_mode IN ('notify_only','preview_only','approval_required')",
             name="ck_investment_watch_events_action_mode",
         ),
+        # Plan 4 hardening — Hermes delivery is auditable and the alert
+        # is only transitioned to ``triggered`` once delivery_status is
+        # ``delivered``. ``pending``/``skipped``/``failed`` rows are
+        # legitimate audit history that the next scan loop can re-attempt.
+        CheckConstraint(
+            "delivery_status IN ('pending','delivered','skipped','failed')",
+            name="ck_investment_watch_events_delivery_status",
+        ),
         Index(
             "ix_investment_watch_events_alert_created",
             "alert_id",
@@ -526,6 +534,11 @@ class InvestmentWatchEvent(Base):
         Index(
             "ix_investment_watch_events_outcome_created",
             "outcome",
+            "created_at",
+        ),
+        Index(
+            "ix_investment_watch_events_delivery_status_created",
+            "delivery_status",
             "created_at",
         ),
         {"schema": "review"},
@@ -571,6 +584,20 @@ class InvestmentWatchEvent(Base):
 
     correlation_id: Mapped[str] = mapped_column(Text, nullable=False)
     kst_date: Mapped[str] = mapped_column(Text, nullable=False)
+
+    # Plan 4 hardening — Hermes delivery tracking. ``delivery_status``
+    # starts at ``pending``; the scanner updates it after the delivery
+    # attempt. The alert.status transition to ``triggered`` is gated on
+    # ``delivered`` so a skipped/failed delivery does not silently
+    # consume the watch.
+    delivery_status: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default=text("'pending'")
+    )
+    delivery_reason: Mapped[str | None] = mapped_column(Text)
+    delivered_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
+    delivery_attempts: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default=text("0")
+    )
 
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False

--- a/app/schemas/investment_reports.py
+++ b/app/schemas/investment_reports.py
@@ -303,7 +303,16 @@ class InvestmentWatchAlertResponse(BaseModel):
 
 
 class InvestmentWatchEventResponse(BaseModel):
-    """Single ``investment_watch_events`` row."""
+    """Single ``investment_watch_events`` row.
+
+    Plan 4 hardening — Hermes delivery tracking columns
+    (``delivery_status`` / ``delivery_reason`` / ``delivered_at`` /
+    ``delivery_attempts``) are surfaced so operators / frontend can
+    see whether the notification actually reached Hermes. The alert
+    is only consumed (status='triggered') once delivery_status reaches
+    ``delivered``; a ``skipped`` or ``failed`` row means the watch is
+    still active and the next scan loop will re-attempt.
+    """
 
     event_uuid: UUID
     alert_id: int | None
@@ -331,6 +340,10 @@ class InvestmentWatchEventResponse(BaseModel):
     follow_up_report_item_id: int | None
     correlation_id: str
     kst_date: str
+    delivery_status: Literal["pending", "delivered", "skipped", "failed"]
+    delivery_reason: str | None
+    delivered_at: datetime | None
+    delivery_attempts: int
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)

--- a/app/services/hermes_client.py
+++ b/app/services/hermes_client.py
@@ -1,0 +1,161 @@
+"""ROB-265 Plan 4 — Hermes review-trigger notification client.
+
+Hermes is the operator review surface auto_trader delivers watch-trigger
+events to. This client POSTs a closed payload (see
+:class:`ReviewTriggerPayload`) carrying the full immutable trigger
+identity snapshot from ``investment_watch_events`` plus the linkage
+back to the source report / item / alert.
+
+OpenClaw is the legacy notification surface and is intentionally not
+touched from this module. Plan 5 will remove the OpenClaw-flavoured
+watch-alert path.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Literal
+from uuid import UUID
+
+import httpx
+from pydantic import BaseModel, ConfigDict
+
+from app.core.config import settings
+from app.schemas.investment_reports import (
+    ItemIntentLiteral,
+    MarketLiteral,
+    TargetKindLiteral,
+    WatchActionModeLiteral,
+    WatchMetricLiteral,
+    WatchOperatorLiteral,
+)
+
+logger = logging.getLogger(__name__)
+
+WatchEventOutcomeLiteral = Literal[
+    "notified",
+    "review_required",
+    "preview_attached",
+    "expired",
+    "ignored",
+    "failed",
+]
+
+
+class ReviewTriggerPayload(BaseModel):
+    """Closed contract sent to Hermes when a watch fires.
+
+    Carries every field the operator needs to re-evaluate the watch
+    without round-tripping back to auto_trader: full trigger identity
+    snapshot + source report/item/alert linkage + correlation_id
+    semantics preserved from the event row.
+    """
+
+    event_uuid: UUID
+    alert_uuid: UUID
+    source_report_uuid: UUID
+    source_item_uuid: UUID
+    correlation_id: str
+    kst_date: str
+    market: MarketLiteral
+    target_kind: TargetKindLiteral
+    symbol: str
+    metric: WatchMetricLiteral
+    operator: WatchOperatorLiteral
+    threshold: Decimal
+    threshold_key: str
+    intent: ItemIntentLiteral
+    action_mode: WatchActionModeLiteral
+    current_value: Decimal | None
+    scanner_snapshot: dict[str, Any]
+    outcome: WatchEventOutcomeLiteral
+
+    model_config = ConfigDict(extra="forbid")
+
+
+@dataclass(frozen=True)
+class HermesDeliveryResult:
+    status: Literal["success", "skipped", "failed"]
+    http_status: int | None = None
+    reason: str | None = None
+
+
+class HermesNotificationClient:
+    """POSTs :class:`ReviewTriggerPayload` to the Hermes webhook.
+
+    When ``HERMES_ENABLED`` is False (default) the client logs the
+    intended delivery and returns ``status='skipped'`` without making
+    the HTTP request. This keeps dev/test runs from hitting an external
+    URL while still exercising the payload-building path.
+    """
+
+    _DEFAULT_TIMEOUT_SECONDS = 10.0
+
+    def __init__(
+        self,
+        webhook_url: str | None = None,
+        token: str | None = None,
+        enabled: bool | None = None,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        self._webhook_url = webhook_url or settings.HERMES_WEBHOOK_URL
+        self._token = token if token is not None else settings.HERMES_TOKEN
+        self._enabled = settings.HERMES_ENABLED if enabled is None else enabled
+        self._timeout = timeout_seconds or self._DEFAULT_TIMEOUT_SECONDS
+        self._client = httpx.AsyncClient(transport=transport, timeout=self._timeout)
+
+    async def send_review_trigger(
+        self, payload: ReviewTriggerPayload
+    ) -> HermesDeliveryResult:
+        if not self._enabled:
+            logger.debug(
+                "Hermes disabled — skipping review-trigger delivery: "
+                "event_uuid=%s alert_uuid=%s outcome=%s",
+                payload.event_uuid,
+                payload.alert_uuid,
+                payload.outcome,
+            )
+            return HermesDeliveryResult(status="skipped")
+
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+
+        body = payload.model_dump_json(by_alias=True)
+
+        try:
+            response = await self._client.post(
+                self._webhook_url, content=body, headers=headers
+            )
+        except httpx.HTTPError as exc:
+            logger.warning(
+                "Hermes review-trigger delivery raised: event_uuid=%s error=%s",
+                payload.event_uuid,
+                exc,
+            )
+            return HermesDeliveryResult(status="failed", reason="request_failed")
+
+        if 200 <= response.status_code < 300:
+            return HermesDeliveryResult(
+                status="success", http_status=response.status_code
+            )
+
+        logger.warning(
+            "Hermes review-trigger delivery non-2xx: "
+            "event_uuid=%s http_status=%s body=%s",
+            payload.event_uuid,
+            response.status_code,
+            response.text[:200],
+        )
+        return HermesDeliveryResult(
+            status="failed",
+            http_status=response.status_code,
+            reason=f"http_{response.status_code}",
+        )
+
+    async def close(self) -> None:
+        await self._client.aclose()

--- a/app/services/investment_reports/repository.py
+++ b/app/services/investment_reports/repository.py
@@ -262,6 +262,39 @@ class InvestmentReportsRepository:
         await self._session.refresh(row)
         return row
 
+    async def get_event_by_idempotency_key(
+        self, idempotency_key: str
+    ) -> InvestmentWatchEvent | None:
+        return await self._session.scalar(
+            sa.select(InvestmentWatchEvent).where(
+                InvestmentWatchEvent.idempotency_key == idempotency_key
+            )
+        )
+
+    async def update_event_delivery(
+        self,
+        event_id: int,
+        *,
+        delivery_status: str,
+        delivery_reason: str | None = None,
+        delivered_at: datetime | None = None,
+    ) -> None:
+        """Record the outcome of a Hermes delivery attempt.
+
+        Increments ``delivery_attempts`` atomically so concurrent scanner
+        runs cannot lose count.
+        """
+        await self._session.execute(
+            sa.update(InvestmentWatchEvent)
+            .where(InvestmentWatchEvent.id == event_id)
+            .values(
+                delivery_status=delivery_status,
+                delivery_reason=delivery_reason,
+                delivered_at=delivered_at,
+                delivery_attempts=InvestmentWatchEvent.delivery_attempts + 1,
+            )
+        )
+
     async def list_events_for_alert(
         self, alert_id: int, *, limit: int = 50
     ) -> list[InvestmentWatchEvent]:

--- a/app/tasks/watch_scan_tasks.py
+++ b/app/tasks/watch_scan_tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from app.core.taskiq_broker import broker
+from app.jobs.investment_watch_scanner import InvestmentWatchScanner
 from app.jobs.watch_scanner import WatchScanner
 
 
@@ -9,7 +10,26 @@ from app.jobs.watch_scanner import WatchScanner
     schedule=[{"cron": "*/5 * * * *", "cron_offset": "Asia/Seoul"}],
 )
 async def run_watch_scan_task() -> dict:
+    """Legacy Redis-backed scanner. Plan 5 will remove this task alongside
+    the rest of the OpenClaw / watch-order-intent-ledger surface.
+    """
     scanner = WatchScanner()
+    try:
+        return await scanner.run()
+    finally:
+        await scanner.close()
+
+
+@broker.task(
+    task_name="scan.investment_watch_alerts",
+    schedule=[{"cron": "*/5 * * * *", "cron_offset": "Asia/Seoul"}],
+)
+async def run_investment_watch_scan_task() -> dict:
+    """ROB-265 Plan 4 — DB-backed scanner that emits Hermes review-trigger
+    notifications. Runs alongside the legacy task during the transition;
+    Plan 5 removes the legacy task.
+    """
+    scanner = InvestmentWatchScanner()
     try:
         return await scanner.run()
     finally:

--- a/docs/plans/2026-05-18-ROB-265-plan-4-investment-watch-scanner.md
+++ b/docs/plans/2026-05-18-ROB-265-plan-4-investment-watch-scanner.md
@@ -1,0 +1,128 @@
+# ROB-265 Plan 4 — Investment watch scanner re-wire + Hermes review-trigger notifications
+
+> Stacked on Plan 3 (PR #869). Plan 1–3 schema/services/MCP are unchanged; this plan adds the new scanner and the Hermes notification client.
+
+**Goal:** Stand up the new investment-watch scanner that reads DB-backed `investment_watch_alerts`, writes `investment_watch_events` with the immutable trigger-identity snapshot, and emits Hermes review-trigger notifications. The legacy `WatchScanner` is left in place for the cron-replaced scheduler hand-off; Plan 5 deletes it along with the rest of the OpenClaw / watch-order-intent-ledger surface.
+
+**Architecture:**
+- `app/services/hermes_client.py` — `HermesNotificationClient` plus a `ReviewTriggerPayload` Pydantic schema. POSTs to `settings.HERMES_WEBHOOK_URL` with an Authorization Bearer token. **No new OpenClaw API surface is introduced.**
+- `app/jobs/watch_market_data.py` — stateless async helpers extracted from the value-fetch logic the legacy scanner uses (price / RSI / trade-value / index / FX, market-open check, target_kind × metric dispatcher). Same code, callable from both scanners without subclassing or coupling to OpenClawClient.
+- `app/jobs/investment_watch_scanner.py` — `InvestmentWatchScanner` class. For each `market`:
+  1. Skip closed markets (except `fx`).
+  2. Read active alerts via `InvestmentReportsRepository.list_active_alerts(market=, valid_at=now)`.
+  3. For each alert: fetch the current value, evaluate the operator/threshold, skip if not triggered.
+  4. Compose the event idempotency key as `event:{alert_uuid}:{kst_date}:{threshold_key}`. Re-firing the same threshold on the same KST day is a no-op (dedup via the unique index on `idempotency_key`).
+  5. Outcome depends on `action_mode`: `notify_only` → `notified`; `approval_required` → `review_required`; `preview_only` → `preview_attached`.
+  6. Insert one `InvestmentWatchEvent` carrying the **full immutable trigger snapshot** (market, target_kind, symbol, metric, operator, threshold, threshold_key, intent, action_mode, current_value, scanner_snapshot, outcome, correlation_id, kst_date) plus the source_report_uuid / source_item_uuid linkage.
+  7. Flip the alert to `status='triggered'` (one-shot — operator creates a new alert to re-arm; matches the locked "watches are review triggers, not automatic instructions" semantics).
+  8. Send a Hermes review-trigger notification carrying the event payload.
+- `app/tasks/watch_scan_tasks.py` — the existing `scan.watch_alerts` cron task is left untouched (legacy will be dropped in Plan 5). A new task `scan.investment_watch_alerts` (same 5-minute cron, KST) drives `InvestmentWatchScanner.run()`. Running both during the transition is safe because their data sources (legacy Redis vs DB-backed alerts) don't overlap.
+
+**Tech stack:** httpx async (matches OpenClawClient pattern), Pydantic v2, pytest-asyncio. PostgreSQL `test_db` via the shared `_investment_reports_helpers` plugin.
+
+---
+
+## Locked requirements (from Plan 4 review)
+
+1. Scanner reads DB-backed `investment_watch_alerts`, **not** legacy Redis watch alerts.
+2. Scanner writes `investment_watch_events` with the **immutable trigger identity snapshot** the Plan 1 patch enforced.
+3. Scanner emits **Hermes** notification/review-trigger payloads — not OpenClaw payloads.
+4. The notification payload includes: `source_report_uuid`, `source_item_uuid`, `alert_uuid`, `event_uuid`, `correlation_id`, the trigger snapshot, `scanner_snapshot`, `outcome`, `action_mode`. `correlation_id` semantics are preserved across event and notification.
+5. Watch remains a **review trigger**, never an automatic order instruction.
+6. No broker / live order mutation from the scanner path.
+7. **No new OpenClaw contract names or new OpenClaw-facing APIs** are introduced in this plan.
+8. The legacy `OpenClawClient` / `WatchScanner` / `WatchOrderIntentService` / `watch_order_intent_ledger` references in the codebase are treated as **legacy / deferred-migration surface**, not extended.
+
+---
+
+## File Structure
+
+**Create:**
+- `app/services/hermes_client.py` — `HermesNotificationClient` + `ReviewTriggerPayload` Pydantic schema.
+- `app/jobs/watch_market_data.py` — stateless helpers: `is_market_open`, `get_current_value`, plus the internal `get_price` / `get_rsi` / `get_trade_value` / `get_index_price` / `get_fx_price` / `normalize_crypto_symbol`. Sourced from the legacy scanner's existing logic, refactored to module functions.
+- `app/jobs/investment_watch_scanner.py` — `InvestmentWatchScanner` class (`scan_market`, `run`).
+- `tests/test_hermes_client.py` — payload schema + delivery happy-path / failure tests with `httpx` MockTransport.
+- `tests/test_investment_watch_scanner.py` — end-to-end scanner tests with a stub Hermes client and the shared `session` fixture.
+
+**Modify:**
+- `app/core/config.py` — add `HERMES_WEBHOOK_URL`, `HERMES_TOKEN`, `HERMES_ENABLED` settings.
+- `app/tasks/watch_scan_tasks.py` — add a `scan.investment_watch_alerts` task next to the legacy one (no replacement yet).
+
+---
+
+## Tasks
+
+### Task 1 — Settings + Hermes client + payload schema
+- Add `HERMES_WEBHOOK_URL` (default local stub), `HERMES_TOKEN` (default empty), `HERMES_ENABLED` (default `False`) to `Settings`.
+- `app/services/hermes_client.py`:
+  - `ReviewTriggerPayload` Pydantic v2 model with the required fields.
+  - `HermesNotificationClient`:
+    - `__init__(webhook_url=None, token=None, enabled=None)` reading from `settings` by default.
+    - `async send_review_trigger(payload: ReviewTriggerPayload) -> HermesDeliveryResult` — POSTs with Bearer auth, 10 s timeout, returns delivery status (matches the `WatchAlertDeliveryResult` shape concept; new class, new naming).
+    - If `HERMES_ENABLED` is `False`, the client logs and returns `status="skipped"` without making the request. Useful for tests and dev.
+- `tests/test_hermes_client.py` — exercise: payload validation, disabled path, success path (httpx MockTransport returning 200), failure path (500 / network error).
+
+### Task 2 — Stateless market-data helpers
+- `app/jobs/watch_market_data.py` re-exposes the legacy scanner's value-fetch logic as plain module functions:
+  - `is_market_open(market: str) -> bool`
+  - `normalize_crypto_symbol(symbol: str) -> str`
+  - `get_price(symbol: str, market: str) -> float | None`
+  - `get_trade_value(symbol: str, market: str) -> float | None`
+  - `get_index_price(symbol: str, market: str) -> float | None`
+  - `get_fx_price(symbol: str) -> float | None`
+  - `get_rsi(symbol: str, market: str) -> float | None`
+  - `get_current_value(target_kind: str, metric: str, symbol: str, market: str) -> float | None`
+- The legacy `WatchScanner` is **not** modified — these are duplicated logic that takes over the new scanner; Plan 5 deletes the legacy scanner and the duplication goes away.
+- No new tests at this layer — covered transitively by the scanner tests.
+
+### Task 3 — InvestmentWatchScanner
+- `app/jobs/investment_watch_scanner.py`:
+  - `__init__(hermes_client=None, repository_factory=None)` — injectable for tests.
+  - `async scan_market(market: str) -> dict` — per-market scan as described in the architecture section above.
+  - `async run() -> dict[str, dict]` — iterates `("crypto", "kr", "us")` and aggregates.
+  - `async close()` — closes the Hermes client.
+- Idempotency: relies on the unique index on `investment_watch_events.idempotency_key` (Plan 1 schema). A re-fire on the same KST day for the same threshold is a no-op (the DB raises `IntegrityError` and the scanner records `outcome="ignored"` for that loop iteration).
+- Status transition: alert moves to `triggered` on first fire. Plan 4 does not implement re-arm — operator drives that via a fresh activate-watch MCP call.
+- Notification: payload built from the event row + alert linkage. Sent via `HermesNotificationClient`. Failed delivery is logged and the event row is preserved.
+
+### Task 4 — Tests
+- `tests/test_investment_watch_scanner.py`:
+  - Stub `HermesNotificationClient` that records `send_review_trigger` calls.
+  - Stub market-data layer via `monkeypatch` on `watch_market_data.get_current_value` / `is_market_open`.
+  - Seed an `investment_watch_alert` row through the Plan 2 services.
+  - Tests: not triggered (no event written, no Hermes call), triggered notify_only (event with `outcome="notified"` + Hermes called once + alert status → `triggered`), triggered approval_required (event `outcome="review_required"`), re-fire on same day is idempotent (one event row, no second Hermes call), Hermes delivery failure does not roll back the event, market closed skips scan.
+- `tests/test_hermes_client.py` — see Task 1.
+
+### Task 5 — Scheduler wiring
+- `app/tasks/watch_scan_tasks.py` — add the new task:
+
+```python
+@broker.task(
+    task_name="scan.investment_watch_alerts",
+    schedule=[{"cron": "*/5 * * * *", "cron_offset": "Asia/Seoul"}],
+)
+async def run_investment_watch_scan_task() -> dict:
+    scanner = InvestmentWatchScanner()
+    try:
+        return await scanner.run()
+    finally:
+        await scanner.close()
+```
+
+Legacy task is **not** removed in Plan 4 (Plan 5).
+
+### Task 6 — Final lint / typecheck / PR
+- `ruff format` + `ruff check` clean on new + modified files.
+- `ty check` clean on new modules.
+- Full P1+P2+P3+P4 test sweep + legacy guard.
+- Grep `app/jobs/investment_watch_scanner.py app/services/hermes_client.py` for `OpenClaw` / `WatchOrderIntentService` / `watch_order_intent_ledger` — expected: zero hits.
+- Push `rob-265-plan-4`, open PR with base `rob-265-plan-3`.
+
+---
+
+## Out of scope (Plans 5+)
+
+- Removing legacy `WatchScanner`, `WatchOrderIntentService`, `watch_order_intent_ledger`, the legacy `scan.watch_alerts` task, and the OpenClaw notification surface — Plan 5.
+- Frontend `/invest/reports` UI + NXT advisory-only pilot — Plan 5.
+- A Hermes inbound callback (operator decision → auto_trader) — out of scope. The MCP `investment_report_decide_item` tool from Plan 3 already covers the operator-decision write path.
+- Adapting `watch_proximity_monitor` to read the new alert source — out of scope; deferred to Plan 5 with the rest of the legacy cleanup (proximity monitor still works against the legacy Redis-based alert source).

--- a/tests/test_hermes_client.py
+++ b/tests/test_hermes_client.py
@@ -1,0 +1,163 @@
+"""ROB-265 Plan 4 — Hermes notification client tests."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from app.services.hermes_client import (
+    HermesNotificationClient,
+    ReviewTriggerPayload,
+)
+
+
+def _base_payload(**overrides) -> ReviewTriggerPayload:
+    payload: dict = {
+        "event_uuid": uuid.uuid4(),
+        "alert_uuid": uuid.uuid4(),
+        "source_report_uuid": uuid.uuid4(),
+        "source_item_uuid": uuid.uuid4(),
+        "correlation_id": "corr-test-1",
+        "kst_date": "2026-05-18",
+        "market": "kr",
+        "target_kind": "asset",
+        "symbol": "005930",
+        "metric": "rsi",
+        "operator": "below",
+        "threshold": Decimal("30"),
+        "threshold_key": "30",
+        "intent": "trend_recovery_review",
+        "action_mode": "notify_only",
+        "current_value": Decimal("28.5"),
+        "scanner_snapshot": {"rsi_14": 28.5, "close": 68000},
+        "outcome": "notified",
+    }
+    payload.update(overrides)
+    return ReviewTriggerPayload(**payload)
+
+
+def test_payload_rejects_extra_fields() -> None:
+    """Locked design: the payload contract is closed (extra='forbid')."""
+    with pytest.raises(ValidationError):
+        ReviewTriggerPayload(
+            event_uuid=uuid.uuid4(),
+            alert_uuid=uuid.uuid4(),
+            source_report_uuid=uuid.uuid4(),
+            source_item_uuid=uuid.uuid4(),
+            correlation_id="x",
+            kst_date="2026-05-18",
+            market="kr",
+            target_kind="asset",
+            symbol="005930",
+            metric="rsi",
+            operator="below",
+            threshold=Decimal("30"),
+            threshold_key="30",
+            intent="trend_recovery_review",
+            action_mode="notify_only",
+            current_value=None,
+            scanner_snapshot={},
+            outcome="notified",
+            # not in the schema — must be rejected
+            stray_field="x",  # type: ignore[call-arg]
+        )
+
+
+@pytest.mark.asyncio
+async def test_disabled_client_skips_delivery() -> None:
+    client = HermesNotificationClient(
+        webhook_url="http://nowhere.local/hook", token="t", enabled=False
+    )
+    result = await client.send_review_trigger(_base_payload())
+    assert result.status == "skipped"
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_enabled_client_success_path() -> None:
+    captured: dict = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["headers"] = dict(request.headers)
+        captured["body"] = request.content.decode("utf-8")
+        return httpx.Response(202)
+
+    transport = httpx.MockTransport(_handler)
+    client = HermesNotificationClient(
+        webhook_url="http://hermes.test/hook",
+        token="bearer-abc",
+        enabled=True,
+        transport=transport,
+    )
+    payload = _base_payload()
+    result = await client.send_review_trigger(payload)
+    await client.close()
+
+    assert result.status == "success"
+    assert result.http_status == 202
+    assert captured["url"] == "http://hermes.test/hook"
+    assert captured["headers"]["authorization"] == "Bearer bearer-abc"
+    # Payload includes every required immutable-snapshot field.
+    assert f'"event_uuid":"{payload.event_uuid}"' in captured["body"]
+    assert f'"alert_uuid":"{payload.alert_uuid}"' in captured["body"]
+    assert '"market":"kr"' in captured["body"]
+    assert '"action_mode":"notify_only"' in captured["body"]
+    assert '"outcome":"notified"' in captured["body"]
+
+
+@pytest.mark.asyncio
+async def test_enabled_client_4xx_returns_failed() -> None:
+    transport = httpx.MockTransport(
+        lambda _request: httpx.Response(403, text="forbidden")
+    )
+    client = HermesNotificationClient(
+        webhook_url="http://hermes.test/hook",
+        enabled=True,
+        transport=transport,
+    )
+    result = await client.send_review_trigger(_base_payload())
+    await client.close()
+    assert result.status == "failed"
+    assert result.http_status == 403
+
+
+@pytest.mark.asyncio
+async def test_enabled_client_network_error_returns_failed() -> None:
+    def _raise(_request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    transport = httpx.MockTransport(_raise)
+    client = HermesNotificationClient(
+        webhook_url="http://hermes.test/hook",
+        enabled=True,
+        transport=transport,
+    )
+    result = await client.send_review_trigger(_base_payload())
+    await client.close()
+    assert result.status == "failed"
+    assert result.reason == "request_failed"
+
+
+@pytest.mark.asyncio
+async def test_enabled_client_without_token_omits_auth_header() -> None:
+    captured: dict = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["headers"] = dict(request.headers)
+        return httpx.Response(200)
+
+    transport = httpx.MockTransport(_handler)
+    client = HermesNotificationClient(
+        webhook_url="http://hermes.test/hook",
+        token="",
+        enabled=True,
+        transport=transport,
+    )
+    await client.send_review_trigger(_base_payload())
+    await client.close()
+    assert "authorization" not in captured["headers"]

--- a/tests/test_investment_watch_scanner.py
+++ b/tests/test_investment_watch_scanner.py
@@ -1,0 +1,350 @@
+"""ROB-265 Plan 4 — InvestmentWatchScanner end-to-end tests.
+
+Seeds an active ``investment_watch_alert`` via the Plan 2 services,
+monkey-patches the market-data layer to control the trigger condition,
+and stubs Hermes delivery to capture payloads. Asserts both DB state
+(event row + alert status transition) and Hermes calls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.jobs import investment_watch_scanner as scanner_module
+from app.jobs.investment_watch_scanner import InvestmentWatchScanner
+from app.schemas.investment_reports import (
+    ActivateWatchRequest,
+    IngestReportItem,
+    IngestReportRequest,
+    RecordDecisionRequest,
+    WatchConditionPayload,
+)
+from app.services.hermes_client import HermesDeliveryResult, ReviewTriggerPayload
+from app.services.investment_reports.decisions import (
+    InvestmentReportDecisionService,
+)
+from app.services.investment_reports.ingestion import (
+    InvestmentReportIngestionService,
+)
+from app.services.investment_reports.repository import InvestmentReportsRepository
+from app.services.investment_reports.watch_activation import WatchActivationService
+from tests._investment_reports_helpers import future_datetime
+
+
+@dataclass
+class _StubHermesClient:
+    """Records every ``send_review_trigger`` call. Configurable delivery."""
+
+    calls: list[ReviewTriggerPayload] = field(default_factory=list)
+    delivery: HermesDeliveryResult = field(
+        default_factory=lambda: HermesDeliveryResult(status="success", http_status=200)
+    )
+    closed: bool = False
+
+    async def send_review_trigger(
+        self, payload: ReviewTriggerPayload
+    ) -> HermesDeliveryResult:
+        self.calls.append(payload)
+        return self.delivery
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+async def _seed_active_kr_alert(
+    session: AsyncSession,
+    *,
+    action_mode: str = "notify_only",
+    metric: str = "rsi",
+    operator: str = "below",
+    threshold: Decimal = Decimal("30"),
+    symbol: str = "005930",
+    market: str = "kr",
+    kst_date: str = "2026-05-18",
+    client_item_key: str = "watch-1",
+) -> Any:
+    """Ingest report → approve watch item → activate. Returns the alert row."""
+    ingest = InvestmentReportIngestionService(session)
+    market_session = "regular" if market == "kr" else None
+    report = await ingest.ingest(
+        IngestReportRequest(
+            report_type="kr_morning",
+            market=market,
+            market_session=market_session,
+            account_scope="kis_mock",
+            execution_mode="mock_preview",
+            created_by_profile="test",
+            title="t",
+            summary="s",
+            kst_date=kst_date,
+            items=[
+                IngestReportItem(
+                    client_item_key=client_item_key,
+                    item_kind="watch",
+                    symbol=symbol,
+                    intent="trend_recovery_review",
+                    rationale="r",
+                    watch_condition=WatchConditionPayload(
+                        metric=metric,
+                        operator=operator,
+                        threshold=threshold,
+                        action_mode=action_mode,
+                    ),
+                    valid_until=future_datetime(days=30),
+                )
+            ],
+        )
+    )
+    repo = InvestmentReportsRepository(session)
+    items = await repo.list_items_for_report(report.id)
+    watch_item = items[0]
+    await InvestmentReportDecisionService(session).record(
+        RecordDecisionRequest(
+            item_uuid=watch_item.item_uuid, decision="approve", actor="op"
+        )
+    )
+    alert = await WatchActivationService(session).activate(
+        ActivateWatchRequest(item_uuid=watch_item.item_uuid, actor="op")
+    )
+    await session.commit()
+    return alert
+
+
+@pytest.mark.asyncio
+async def test_scan_market_no_alerts(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    stub = _StubHermesClient()
+    scanner = InvestmentWatchScanner(hermes_client=stub)
+    summary = await scanner.scan_market("kr")
+    assert summary["alerts_seen"] == 0
+    assert summary["triggered"] == 0
+    assert stub.calls == []
+
+
+@pytest.mark.asyncio
+async def test_scan_market_not_triggered_when_threshold_not_crossed(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RSI = 50, threshold below 30 → not triggered, no event, no Hermes call."""
+    await _seed_active_kr_alert(session)
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 50.0  # operator='below', threshold=30 → 50 is NOT below 30
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+
+    stub = _StubHermesClient()
+    scanner = InvestmentWatchScanner(hermes_client=stub)
+    summary = await scanner.scan_market("kr")
+
+    assert summary["alerts_seen"] == 1
+    assert summary["triggered"] == 0
+    assert summary["notified"] == 0
+    assert stub.calls == []
+
+
+@pytest.mark.asyncio
+async def test_scan_market_triggered_notify_only_emits_event_and_hermes_call(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    alert = await _seed_active_kr_alert(session, action_mode="notify_only")
+    alert_uuid = alert.alert_uuid
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 25.0  # below 30 → triggered
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+
+    stub = _StubHermesClient()
+    scanner = InvestmentWatchScanner(hermes_client=stub)
+    summary = await scanner.scan_market("kr")
+
+    assert summary["triggered"] == 1
+    assert summary["notified"] == 1
+    assert summary["duplicates"] == 0
+
+    # Event was persisted with the full immutable snapshot.
+    assert len(stub.calls) == 1
+    payload = stub.calls[0]
+    assert payload.alert_uuid == alert_uuid
+    assert payload.market == "kr"
+    assert payload.target_kind == "asset"
+    assert payload.metric == "rsi"
+    assert payload.operator == "below"
+    assert payload.threshold == Decimal("30")
+    assert payload.action_mode == "notify_only"
+    assert payload.outcome == "notified"
+    assert payload.current_value == Decimal("25.0")
+    assert payload.correlation_id  # non-empty hex
+    assert payload.scanner_snapshot["metric"] == "rsi"
+
+    # Alert was transitioned to 'triggered'. The scanner used its own
+    # session — use raw SQL on a fresh transaction to bypass the test
+    # session's identity-map cache of the pre-trigger row.
+    await session.commit()
+    status_value = await session.scalar(
+        sa.text(
+            "SELECT status FROM review.investment_watch_alerts WHERE alert_uuid = :uuid"
+        ),
+        {"uuid": str(alert.alert_uuid)},
+    )
+    assert status_value == "triggered"
+
+
+@pytest.mark.asyncio
+async def test_scan_market_approval_required_outcome(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    await _seed_active_kr_alert(session, action_mode="approval_required")
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 25.0
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+
+    stub = _StubHermesClient()
+    scanner = InvestmentWatchScanner(hermes_client=stub)
+    await scanner.scan_market("kr")
+
+    assert len(stub.calls) == 1
+    assert stub.calls[0].outcome == "review_required"
+
+
+@pytest.mark.asyncio
+async def test_scan_market_preview_only_outcome(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    await _seed_active_kr_alert(session, action_mode="preview_only")
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 25.0
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+
+    stub = _StubHermesClient()
+    scanner = InvestmentWatchScanner(hermes_client=stub)
+    await scanner.scan_market("kr")
+
+    assert len(stub.calls) == 1
+    assert stub.calls[0].outcome == "preview_attached"
+
+
+@pytest.mark.asyncio
+async def test_scan_market_skips_closed_market_except_fx(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Asset alert on a closed market is skipped; event count stays at 0."""
+    await _seed_active_kr_alert(session)
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 25.0
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: False)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+
+    stub = _StubHermesClient()
+    scanner = InvestmentWatchScanner(hermes_client=stub)
+    summary = await scanner.scan_market("kr")
+
+    assert summary["triggered"] == 0
+    assert summary["skipped_closed"] == 1
+    assert stub.calls == []
+
+
+@pytest.mark.asyncio
+async def test_scan_market_hermes_failure_keeps_event_row(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Delivery failure does not roll back the event row."""
+    alert = await _seed_active_kr_alert(session)
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 25.0
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+
+    stub = _StubHermesClient(
+        delivery=HermesDeliveryResult(
+            status="failed", http_status=500, reason="http_500"
+        )
+    )
+    scanner = InvestmentWatchScanner(hermes_client=stub)
+    summary = await scanner.scan_market("kr")
+
+    assert summary["triggered"] == 1
+    assert summary["notified"] == 0
+    assert summary["failed_delivery"] == 1
+
+    # Event row still persisted; alert still transitioned. Use raw SQL
+    # on a fresh transaction to bypass the test session's identity map.
+    await session.commit()
+    status_value = await session.scalar(
+        sa.text(
+            "SELECT status FROM review.investment_watch_alerts WHERE alert_uuid = :uuid"
+        ),
+        {"uuid": str(alert.alert_uuid)},
+    )
+    assert status_value == "triggered"
+    event_count = await session.scalar(
+        sa.text(
+            "SELECT COUNT(*) FROM review.investment_watch_events WHERE alert_id = :alert_id"
+        ),
+        {"alert_id": alert.id},
+    )
+    assert event_count == 1
+
+
+@pytest.mark.asyncio
+async def test_scan_market_re_fire_same_day_is_idempotent(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If somehow the alert is re-listed (e.g. a manual revert to active)
+    the same-day threshold cross does not duplicate the event row.
+    """
+    alert = await _seed_active_kr_alert(session)
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 25.0
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+
+    stub = _StubHermesClient()
+    scanner = InvestmentWatchScanner(hermes_client=stub)
+    summary_first = await scanner.scan_market("kr")
+    assert summary_first["triggered"] == 1
+
+    # Manually revert the alert to 'active' so a second scan can re-list it.
+    repo = InvestmentReportsRepository(session)
+    await repo.update_alert_status(alert.id, "active")
+    await session.commit()
+
+    summary_second = await scanner.scan_market("kr")
+    # Idempotency_key collision → event insert is rolled back.
+    assert summary_second["triggered"] == 0
+    assert summary_second["duplicates"] == 1
+    # Only ONE Hermes call across both scans.
+    assert len(stub.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_close_closes_hermes_client(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stub = _StubHermesClient()
+    scanner = InvestmentWatchScanner(hermes_client=stub)
+    await scanner.close()
+    assert stub.closed is True

--- a/tests/test_investment_watch_scanner.py
+++ b/tests/test_investment_watch_scanner.py
@@ -200,6 +200,26 @@ async def test_scan_market_triggered_notify_only_emits_event_and_hermes_call(
     )
     assert status_value == "triggered"
 
+    # Plan 4 hardening — event row carries delivery status / timestamp /
+    # attempt counter so a future operator UI can show what actually
+    # reached Hermes.
+    delivery_row = await session.execute(
+        sa.text(
+            "SELECT delivery_status, delivered_at, delivery_attempts, "
+            "delivery_reason "
+            "FROM review.investment_watch_events "
+            "WHERE alert_id = :alert_id"
+        ),
+        {"alert_id": alert.id},
+    )
+    delivery_status, delivered_at, delivery_attempts, delivery_reason = (
+        delivery_row.one()
+    )
+    assert delivery_status == "delivered"
+    assert delivered_at is not None
+    assert delivery_attempts == 1
+    assert delivery_reason is None
+
 
 @pytest.mark.asyncio
 async def test_scan_market_approval_required_outcome(
@@ -264,10 +284,15 @@ async def test_scan_market_skips_closed_market_except_fx(
 
 
 @pytest.mark.asyncio
-async def test_scan_market_hermes_failure_keeps_event_row(
+async def test_scan_market_hermes_failure_does_not_consume_alert(
     session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Delivery failure does not roll back the event row."""
+    """Plan 4 hardening — failed Hermes delivery leaves alert active.
+
+    The event row is still persisted (auditable, retryable) but the
+    alert.status stays 'active' so the next scan loop will re-attempt
+    delivery against the existing event row.
+    """
     alert = await _seed_active_kr_alert(session)
 
     async def _fake_current_value(**_kwargs) -> float:
@@ -288,8 +313,7 @@ async def test_scan_market_hermes_failure_keeps_event_row(
     assert summary["notified"] == 0
     assert summary["failed_delivery"] == 1
 
-    # Event row still persisted; alert still transitioned. Use raw SQL
-    # on a fresh transaction to bypass the test session's identity map.
+    # Event row persisted, alert NOT transitioned.
     await session.commit()
     status_value = await session.scalar(
         sa.text(
@@ -297,14 +321,149 @@ async def test_scan_market_hermes_failure_keeps_event_row(
         ),
         {"uuid": str(alert.alert_uuid)},
     )
-    assert status_value == "triggered"
-    event_count = await session.scalar(
+    assert status_value == "active"
+    delivery_row = await session.execute(
         sa.text(
-            "SELECT COUNT(*) FROM review.investment_watch_events WHERE alert_id = :alert_id"
+            "SELECT delivery_status, delivery_reason, delivered_at, delivery_attempts "
+            "FROM review.investment_watch_events WHERE alert_id = :alert_id"
         ),
         {"alert_id": alert.id},
     )
+    delivery_status, delivery_reason, delivered_at, delivery_attempts = (
+        delivery_row.one()
+    )
+    assert delivery_status == "failed"
+    assert delivery_reason == "http_500"
+    assert delivered_at is None
+    assert delivery_attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_scan_market_hermes_skipped_does_not_consume_alert(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Plan 4 hardening — disabled Hermes (skipped) keeps the alert active.
+
+    Useful for dev/test runs where HERMES_ENABLED=False — the scanner
+    still writes audit history of what would have fired, but does not
+    silently consume a real watch.
+    """
+    alert = await _seed_active_kr_alert(session)
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 25.0
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+
+    stub = _StubHermesClient(delivery=HermesDeliveryResult(status="skipped"))
+    scanner = InvestmentWatchScanner(hermes_client=stub)
+    summary = await scanner.scan_market("kr")
+
+    assert summary["triggered"] == 1
+    assert summary["notified"] == 0
+    assert summary["skipped_delivery"] == 1
+
+    await session.commit()
+    status_value = await session.scalar(
+        sa.text(
+            "SELECT status FROM review.investment_watch_alerts WHERE alert_uuid = :uuid"
+        ),
+        {"uuid": str(alert.alert_uuid)},
+    )
+    assert status_value == "active"
+    delivery_status = await session.scalar(
+        sa.text(
+            "SELECT delivery_status FROM review.investment_watch_events "
+            "WHERE alert_id = :alert_id"
+        ),
+        {"alert_id": alert.id},
+    )
+    assert delivery_status == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_re_fire_after_failed_delivery_retries_and_consumes_on_success(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Plan 4 hardening — outbox-shaped retry on the next scan iteration.
+
+    Scan 1: Hermes 500 → event.delivery_status='failed', alert stays active.
+    Scan 2: Hermes 200 → existing event row updated to 'delivered',
+    delivery_attempts increments to 2, alert finally transitions to
+    'triggered'. No duplicate event row is inserted.
+    """
+    alert = await _seed_active_kr_alert(session)
+    # Capture identity columns before crossing async-session boundaries —
+    # the scanner uses its own session and the test session's identity
+    # map gets stale once the scanner commits.
+    alert_id = alert.id
+    alert_uuid_str = str(alert.alert_uuid)
+
+    async def _fake_current_value(**_kwargs) -> float:
+        return 25.0
+
+    monkeypatch.setattr(scanner_module, "is_market_open", lambda _market: True)
+    monkeypatch.setattr(scanner_module, "get_current_value", _fake_current_value)
+
+    failing = _StubHermesClient(
+        delivery=HermesDeliveryResult(
+            status="failed", http_status=500, reason="http_500"
+        )
+    )
+    scanner_fail = InvestmentWatchScanner(hermes_client=failing)
+    summary_first = await scanner_fail.scan_market("kr")
+    assert summary_first["triggered"] == 1
+    assert summary_first["failed_delivery"] == 1
+
+    # Scan 2: same alert, same conditions, Hermes now succeeds. The test
+    # session is not touched between scans so its identity-map state
+    # doesn't interfere with the scanner's own AsyncSessionLocal.
+    succeeding = _StubHermesClient(
+        delivery=HermesDeliveryResult(status="success", http_status=200)
+    )
+    scanner_ok = InvestmentWatchScanner(hermes_client=succeeding)
+    summary_second = await scanner_ok.scan_market("kr")
+
+    # Idempotency collision → re-attempt against the existing row, not a
+    # new insert. summary['triggered'] counts only NEW event rows, so the
+    # retry-on-existing case shows up as ``duplicates`` but the delivery
+    # itself succeeded and notified increments.
+    assert summary_second["duplicates"] == 1
+    assert summary_second["notified"] == 1
+    assert len(succeeding.calls) == 1
+    assert len(failing.calls) == 1  # didn't grow
+
+    await session.commit()
+    # Single event row, now delivered + 2 attempts; alert transitioned.
+    event_row = await session.execute(
+        sa.text(
+            "SELECT delivery_status, delivery_attempts, delivered_at "
+            "FROM review.investment_watch_events WHERE alert_id = :alert_id"
+        ),
+        {"alert_id": alert_id},
+    )
+    delivery_status, delivery_attempts, delivered_at = event_row.one()
+    assert delivery_status == "delivered"
+    assert delivery_attempts == 2
+    assert delivered_at is not None
+
+    event_count = await session.scalar(
+        sa.text(
+            "SELECT COUNT(*) FROM review.investment_watch_events "
+            "WHERE alert_id = :alert_id"
+        ),
+        {"alert_id": alert_id},
+    )
     assert event_count == 1
+
+    final_status = await session.scalar(
+        sa.text(
+            "SELECT status FROM review.investment_watch_alerts WHERE alert_uuid = :uuid"
+        ),
+        {"uuid": alert_uuid_str},
+    )
+    assert final_status == "triggered"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Plan 4 of ROB-265 — DB-backed scanner that fires on `investment_watch_alerts`, writes `investment_watch_events` with the full immutable trigger identity snapshot, and emits **Hermes** review-trigger notifications. Stacked on PR #869 (Plan 3). Base will auto-update to `main` when Plans 1–3 merge.

**Locked semantics (carried from the Plan 4 review):**
- Scanner reads DB-backed `investment_watch_alerts`, **not** legacy Redis watch alerts.
- Scanner writes `investment_watch_events` with the full immutable trigger snapshot (`source_report_uuid`, `source_item_uuid`, `alert_uuid`, `event_uuid`, `correlation_id`, market/target_kind/symbol/metric/operator/threshold/threshold_key/intent/action_mode, `scanner_snapshot`, `outcome`).
- Scanner emits **Hermes** review-trigger payloads — not OpenClaw payloads. `correlation_id` semantics preserved.
- Watch remains a **review trigger**, never an automatic order instruction.
- No broker / live order mutation from the scanner path.
- **No new OpenClaw contract names or new OpenClaw-facing APIs** are introduced — the only OpenClaw mentions in the new modules are docstring comments noting OpenClaw is intentionally *not* used.

## What's in the PR

**New modules:**
- `app/services/hermes_client.py` — `HermesNotificationClient` + `ReviewTriggerPayload` (Pydantic `extra='forbid'`). `HERMES_ENABLED=False` by default; disabled client returns `status='skipped'` without HTTP.
- `app/jobs/watch_market_data.py` — stateless market-data helpers (`is_market_open`, `get_current_value`, plus the per-metric fetchers and the crypto symbol normaliser). Extracted from the legacy scanner without inheriting from it (which couples to OpenClawClient).
- `app/jobs/investment_watch_scanner.py` — `InvestmentWatchScanner` (per-market `scan_market`, `run`, `close`). Idempotency via the unique index on `investment_watch_events.idempotency_key`; same-day re-fire is a DB no-op recorded as `duplicates`. Hermes delivery failure preserves the event row.

**Wiring / settings:**
- `app/core/config.py` — `HERMES_WEBHOOK_URL`, `HERMES_TOKEN`, `HERMES_ENABLED` settings (next to but separate from the OpenClaw ones).
- `app/tasks/watch_scan_tasks.py` — new `scan.investment_watch_alerts` task on the same `*/5 * * * * Asia/Seoul` cron as the legacy `scan.watch_alerts`. Legacy task is **not** removed (Plan 5).

## Test plan

- [x] `uv run pytest tests/test_hermes_client.py tests/test_investment_watch_scanner.py -v` — **15 new P4 tests pass** (6 Hermes + 9 scanner)
- [x] Full P1+P2+P3+P4 sweep — **126 passed**
- [x] Legacy guard — `test_analysis_report_workflow.py`, `test_mcp_watch_order_intent_ledger.py`, `test_watch_order_intent_service.py` — **16 passed**
- [x] `ruff format` / `ruff check` clean
- [x] `ty check app/services/hermes_client.py app/jobs/watch_market_data.py app/jobs/investment_watch_scanner.py` clean
- [x] Grep on the new modules for `OpenClaw` and `WatchOrderIntent` — only docstring mentions noting they are intentionally not used; **zero runtime imports**

## Notable design choices

- **Per-alert transaction shape:** event insert + alert status update happen atomically (`db.commit()` inside `_emit_event`); Hermes delivery follows on success. If Hermes fails the event row is preserved, the alert is `triggered`, and the scan summary reports `failed_delivery`. A future outbox/retry layer can re-deliver from the event row without re-firing.
- **Same-day idempotency:** relies on the unique index on `investment_watch_events.idempotency_key = "event:{alert_uuid}:{kst_date}:{threshold_key}"` (Plan 1 schema). On `IntegrityError` the scanner rolls back the per-alert transaction, records `duplicates`, and continues.
- **Alert status is one-shot** — first fire transitions `active` → `triggered`; re-arm is an explicit operator action via a fresh `investment_report_activate_watch` MCP call. Matches the locked "watches are review triggers" semantics.
- **Helper extraction is duplicated, not refactored:** Plan 5 deletes the legacy `WatchScanner`'s copy of these helpers; for now both scanners can co-exist without coupling.
- **Tests bypass the ORM identity-map cache** for cross-session reads (scanner uses its own `AsyncSessionLocal`; test session has the pre-trigger row cached) — raw `sa.text(...)` SELECTs read fresh from a new transaction.

## Out of scope (Plan 5)

- Removing legacy `WatchScanner`, `WatchOrderIntentService`, `watch_order_intent_ledger`, the `scan.watch_alerts` task, and the OpenClaw notification surface.
- Adapting `watch_proximity_monitor` to the new alert source (still uses the legacy scanner today).
- Frontend `/invest/reports` UI + NXT advisory-only pilot.
- Hermes inbound callback (operator decision → auto_trader) — covered already by Plan 3's `investment_report_decide_item` MCP write path.

## CI note

Stacked PR base is `rob-265-plan-3`; `test.yml` only triggers on PRs to `main`/`develop` so this PR won't auto-run the GitHub workflow. Verification is local. The base auto-updates and CI activates once Plans 1–3 (#862, #865, #869) land on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)