### PR TITLE
fix(ci): repair main regression after ROB-265 cleanup

### DIFF
--- a/app/mcp_server/tooling/registry.py
+++ b/app/mcp_server/tooling/registry.py
@@ -72,9 +72,6 @@ from app.mcp_server.tooling.trade_profile_registration import (
 from app.mcp_server.tooling.user_settings_registration import (
     register_user_settings_tools,
 )
-from app.mcp_server.tooling.weekend_crypto_paper_cycle import (
-    register_weekend_crypto_paper_cycle_tools,
-)
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
@@ -102,7 +99,6 @@ def register_all_tools(mcp: FastMCP, profile: McpProfile = McpProfile.DEFAULT) -
     register_alpaca_paper_preview_tools(mcp)
     register_alpaca_paper_orders_tools(mcp)
     register_alpaca_paper_ledger_read_tools(mcp)
-    register_weekend_crypto_paper_cycle_tools(mcp)
 
     # Always: read-only with account_mode (mock-safe via ROB-28)
     register_portfolio_tools(mcp)

--- a/tests/_investment_reports_helpers.py
+++ b/tests/_investment_reports_helpers.py
@@ -1,7 +1,7 @@
 """Shared test scaffolding for ROB-265 investment_reports tests.
 
 Centralises the per-test async session fixture, the truncated-table
-list, and a couple of small helpers so the ORM, schema, repository,
+list, the xdist guard lock, and a couple of small helpers so the ORM, schema, repository,
 ingestion, decisions, watch-activation, and query-service test files
 don't each re-declare the same boilerplate (Sonar duplicated-line fix).
 
@@ -40,6 +40,7 @@ INVESTMENT_REPORTS_TABLES = [
     InvestmentWatchAlert.__table__,
     InvestmentWatchEvent.__table__,
 ]
+INVESTMENT_REPORTS_TEST_LOCK_ID = 265_202_605
 
 
 @pytest_asyncio.fixture
@@ -49,29 +50,46 @@ async def session() -> AsyncSession:
     Tables are created idempotently (no-op if the alembic migration
     already owns them). Between tests rows are truncated CASCADE so
     other tests start clean without dropping the schema.
+
+    CI runs pytest-xdist with ``--dist=loadfile``. These tests share the
+    same PostgreSQL schema, and concurrent per-test ``TRUNCATE ... CASCADE``
+    can deadlock with another worker's inserts. A session-level advisory lock
+    serializes only this investment-report fixture while leaving the rest of
+    the suite parallel.
     """
     engine = create_async_engine(settings.DATABASE_URL, future=True)
-    async with engine.begin() as conn:
-        await conn.run_sync(
-            Base.metadata.create_all,
-            tables=INVESTMENT_REPORTS_TABLES,
-            checkfirst=True,
-        )
-    factory = async_sessionmaker(engine, expire_on_commit=False)
     try:
-        async with factory() as sess:
+        async with engine.connect() as guard:
+            await guard.execute(
+                sa.text("SELECT pg_advisory_lock(CAST(:lock_id AS bigint))"),
+                {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
+            )
             try:
-                yield sess
-            finally:
-                await sess.rollback()
-        async with factory() as cleanup:
-            for table in reversed(INVESTMENT_REPORTS_TABLES):
-                await cleanup.execute(
-                    sa.text(
-                        f'TRUNCATE TABLE review."{table.name}" RESTART IDENTITY CASCADE'
+                async with engine.begin() as conn:
+                    await conn.run_sync(
+                        Base.metadata.create_all,
+                        tables=INVESTMENT_REPORTS_TABLES,
+                        checkfirst=True,
                     )
+                factory = async_sessionmaker(engine, expire_on_commit=False)
+                async with factory() as sess:
+                    try:
+                        yield sess
+                    finally:
+                        await sess.rollback()
+                async with factory() as cleanup:
+                    for table in reversed(INVESTMENT_REPORTS_TABLES):
+                        await cleanup.execute(
+                            sa.text(
+                                f'TRUNCATE TABLE review."{table.name}" RESTART IDENTITY CASCADE'
+                            )
+                        )
+                    await cleanup.commit()
+            finally:
+                await guard.execute(
+                    sa.text("SELECT pg_advisory_unlock(CAST(:lock_id AS bigint))"),
+                    {"lock_id": INVESTMENT_REPORTS_TEST_LOCK_ID},
                 )
-            await cleanup.commit()
     finally:
         await engine.dispose()
 

--- a/tests/test_import_contracts.py
+++ b/tests/test_import_contracts.py
@@ -84,6 +84,6 @@ def test_screener_job_no_longer_imports_kis_facade() -> None:
     assert "app.services" in modules
 
 
-def test_watch_scanner_job_no_direct_integration_imports() -> None:
-    watch_scanner_path = ROOT / "app" / "jobs" / "watch_scanner.py"
-    assert _find_integration_imports(watch_scanner_path) == []
+def test_investment_watch_scanner_job_no_direct_integration_imports() -> None:
+    scanner_path = ROOT / "app" / "jobs" / "investment_watch_scanner.py"
+    assert _find_integration_imports(scanner_path) == []

--- a/tests/test_watch_scan_tasks.py
+++ b/tests/test_watch_scan_tasks.py
@@ -19,12 +19,15 @@ class _FakeScanner:
 async def test_run_watch_scan_task_uses_scanner_and_closes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    from app.tasks.watch_scan_tasks import run_watch_scan_task
+    from app.tasks.watch_scan_tasks import run_investment_watch_scan_task
 
-    scanner = _FakeScanner(result={"crypto": {"alerts_sent": 1}})
-    monkeypatch.setattr("app.tasks.watch_scan_tasks.WatchScanner", lambda: scanner)
+    scanner = _FakeScanner(result={"reports": {"alerts_sent": 1}})
+    monkeypatch.setattr(
+        "app.tasks.watch_scan_tasks.InvestmentWatchScanner",
+        lambda: scanner,
+    )
 
-    result = await run_watch_scan_task()
+    result = await run_investment_watch_scan_task()
 
-    assert result == {"crypto": {"alerts_sent": 1}}
+    assert result == {"reports": {"alerts_sent": 1}}
     assert scanner.closed is True


### PR DESCRIPTION
## Summary
- Remove the stale `weekend_crypto_paper_cycle` MCP registration left behind after the retired tool module was deleted.
- Update legacy watch-scan tests/import-contracts to the canonical investment-report watch scanner/task.
- Serialize the shared investment-report PostgreSQL test fixture with an advisory lock so xdist workers do not deadlock on `TRUNCATE ... CASCADE`.

## Test Plan
- `uv run --group test pytest tests/test_mcp_tool_registration.py tests/test_watch_scan_tasks.py tests/test_import_contracts.py tests/test_investment_reports_model.py tests/test_investment_reports_repository.py tests/test_investment_reports_ingestion.py tests/test_investment_reports_decisions.py tests/test_investment_reports_watch_activation.py tests/test_investment_reports_query_service.py tests/test_investment_reports_router.py tests/test_investment_reports_mcp.py -q`
- `uv run --group test pytest tests/test_investment_reports_*.py -n 4 --dist=loadfile -q`
- `uv run --group test --group dev ruff check app/mcp_server/tooling/registry.py tests/test_watch_scan_tasks.py tests/test_import_contracts.py tests/_investment_reports_helpers.py`
- `uv run --group test --group dev ruff format --check app/mcp_server/tooling/registry.py tests/test_watch_scan_tasks.py tests/test_import_contracts.py tests/_investment_reports_helpers.py`
- `uv run --group test python - <<'PY' ... build_tools smoke ... PY`

## Safety
- CI/test-only hotfix plus MCP registry removal of an already-retired tool registration.
- No broker/order/watch execution path invoked.
- No production DB mutation.